### PR TITLE
autumn-media hardening: room reaper, composite audio, encode buffering/OsString paths, S3 fallback

### DIFF
--- a/autumn-media-plugin/src/encode.rs
+++ b/autumn-media-plugin/src/encode.rs
@@ -800,35 +800,45 @@ const ROOM_COMPOSITE_MAX_INPUTS: usize = 6;
 /// cap); one input per participant, so — unlike the clip/poster encoders — it
 /// never concatenates.
 ///
-/// # Audio-stream assumption
+/// # Per-input audio detection
 ///
-/// This composite assumes **each participant recording carries an audio
-/// stream**: the `-filter_complex` graph references every input's audio and
-/// mixes them with `amix`, so a **video-only participant recording (no audio
-/// stream) is not supported for composition this slice** — `FFmpeg` would fail
-/// on the missing stream. The **per-participant recordings themselves are
-/// unaffected**; this limitation is only about the composited grid output.
-/// Robust handling (per-input audio detection / silence synthesis) is recorded
-/// future work on the epic.
+/// Not every participant recording carries an audio stream (a viewer who
+/// published video-only, a muted camera-only guest, etc.), so the composite is
+/// **audio-aware**: it is told, per input, whether an audio stream is present
+/// via the `audio_present` flags (`len() == input_paths.len()`). The
+/// `-filter_complex` graph mixes (`amix`) **only** the inputs that actually have
+/// audio, and when **no** input has audio it emits a silent video grid (no
+/// `amix`, no `[aout]`, and `args()` omits `-map [aout]`/`-c:a aac`) — so a
+/// video-only participant no longer makes `FFmpeg` fail on a missing `[i:a]`
+/// stream. Probing is done by the caller (see `run_room_composite`); `args()`
+/// stays a **pure, synchronous, no-I/O** function of these fields, reading
+/// `audio_present` rather than performing any probe itself.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct FfmpegRoomCompositeCommand {
     ffmpeg_bin: String,
     input_paths: Vec<PathBuf>,
     output_path: PathBuf,
+    /// One flag per `input_path` (same length/order): `true` when that
+    /// recording carries an audio stream that should be mixed into the output.
+    audio_present: Vec<bool>,
 }
 
 impl FfmpegRoomCompositeCommand {
-    /// Build a room-composite command. One `input_path` per participant.
+    /// Build a room-composite command. One `input_path` per participant, and one
+    /// `audio_present` flag per input (same order) recording whether that input
+    /// carries an audio stream to mix.
     #[must_use]
     pub fn new(
         ffmpeg_bin: impl Into<String>,
         input_paths: Vec<PathBuf>,
         output_path: impl Into<PathBuf>,
+        audio_present: Vec<bool>,
     ) -> Self {
         Self {
             ffmpeg_bin: ffmpeg_bin.into(),
             input_paths,
             output_path: output_path.into(),
+            audio_present,
         }
     }
 
@@ -840,24 +850,34 @@ impl FfmpegRoomCompositeCommand {
     #[must_use]
     pub fn args(&self) -> Vec<OsString> {
         let n = self.input_paths.len();
+        // Whether the composited output carries an audio track at all: true iff
+        // at least one input has an audio stream. When false, the filtergraph
+        // produces no `[aout]`, so we must not `-map` it or set an audio codec.
+        let has_audio_out = self.audio_present.iter().any(|&present| present);
         let mut args = vec![OsString::from("-y")];
         for path in &self.input_paths {
             args.push(OsString::from("-i"));
             args.push(path.as_os_str().to_owned());
         }
         args.push(OsString::from("-filter_complex"));
-        args.push(OsString::from(room_composite_filtergraph(n)));
+        args.push(OsString::from(room_composite_filtergraph(
+            n,
+            &self.audio_present,
+        )));
+        args.extend([OsString::from("-map"), OsString::from("[vout]")]);
+        if has_audio_out {
+            args.extend([OsString::from("-map"), OsString::from("[aout]")]);
+        }
         args.extend([
-            OsString::from("-map"),
-            OsString::from("[vout]"),
-            OsString::from("-map"),
-            OsString::from("[aout]"),
             OsString::from("-c:v"),
             OsString::from("libx264"),
             OsString::from("-preset"),
             OsString::from("veryfast"),
-            OsString::from("-c:a"),
-            OsString::from("aac"),
+        ]);
+        if has_audio_out {
+            args.extend([OsString::from("-c:a"), OsString::from("aac")]);
+        }
+        args.extend([
             OsString::from("-movflags"),
             OsString::from("+faststart"),
             self.output_path.as_os_str().to_owned(),
@@ -911,28 +931,50 @@ const fn room_composite_grid_dims(n: usize) -> (usize, usize) {
     }
 }
 
-/// Build the `-filter_complex` graph: one letterboxed `scale`/`pad` per input,
-/// an `xstack` grid of them, and an `amix` of every audio track.
-fn room_composite_filtergraph(n: usize) -> String {
+/// Build the `-filter_complex` graph: one letterboxed `scale`/`pad` per input
+/// and an `xstack` grid of them (always every `[i:v]`), plus an `amix` of only
+/// the inputs whose `audio_present` flag is set.
+///
+/// The video half is unconditional. The audio half is driven by `audio_present`
+/// (one flag per input, same order):
+/// - **≥ 2 inputs with audio** → `[i:a]…amix=inputs=K:normalize=1[aout]` over
+///   just those `K` inputs.
+/// - **exactly 1 input with audio** → `[k:a]amix=inputs=1:normalize=1[aout]`.
+///   `amix=inputs=1` is valid `FFmpeg` and keeps the output labeled `[aout]`, so
+///   `args()` maps audio identically regardless of how many inputs had audio.
+/// - **0 inputs with audio** → no `amix` and no `[aout]` at all (silent grid);
+///   `args()` correspondingly omits `-map [aout]`/`-c:a aac`.
+fn room_composite_filtergraph(n: usize, audio_present: &[bool]) -> String {
     use std::fmt::Write as _;
 
     let (cols, _rows) = room_composite_grid_dims(n);
     let (w, h) = (ROOM_COMPOSITE_CELL_WIDTH, ROOM_COMPOSITE_CELL_HEIGHT);
     let mut parts = Vec::new();
     let mut video_labels = String::new();
-    let mut audio_labels = String::new();
     for i in 0..n {
         parts.push(format!(
             "[{i}:v]scale={w}:{h}:force_original_aspect_ratio=decrease,pad={w}:{h}:(ow-iw)/2:(oh-ih)/2,setsar=1[v{i}]"
         ));
         let _ = write!(video_labels, "[v{i}]");
-        let _ = write!(audio_labels, "[{i}:a]");
     }
     let layout = room_composite_layout(cols, n);
     parts.push(format!(
         "{video_labels}xstack=inputs={n}:layout={layout}[vout]"
     ));
-    parts.push(format!("{audio_labels}amix=inputs={n}:normalize=1[aout]"));
+
+    let audio_inputs: Vec<usize> = (0..n)
+        .filter(|&i| audio_present.get(i).copied().unwrap_or(false))
+        .collect();
+    if !audio_inputs.is_empty() {
+        let mut audio_labels = String::new();
+        for &i in &audio_inputs {
+            let _ = write!(audio_labels, "[{i}:a]");
+        }
+        parts.push(format!(
+            "{audio_labels}amix=inputs={}:normalize=1[aout]",
+            audio_inputs.len()
+        ));
+    }
     parts.join(";")
 }
 
@@ -1489,6 +1531,7 @@ mod tests {
             "ffmpeg",
             vec![PathBuf::from("/rec/a.mp4"), PathBuf::from("/rec/b.mp4")],
             "/out/room.mp4",
+            vec![true, true],
         );
         let args = lossy(&cmd.args());
         assert_eq!(args.first().map(String::as_str), Some("-y"));
@@ -1521,6 +1564,7 @@ mod tests {
                 PathBuf::from("/rec/d.mp4"),
             ],
             "/out/room.mp4",
+            vec![true, true, true, true],
         );
         let args = lossy(&cmd.args());
         assert_eq!(args.iter().filter(|a| *a == "-i").count(), 4);
@@ -1534,6 +1578,107 @@ mod tests {
              [v0][v1][v2][v3]xstack=inputs=4:layout=0_0|w0_0|0_h0|w0_h0[vout];\
              [0:a][1:a][2:a][3:a]amix=inputs=4:normalize=1[aout]"
         );
+    }
+
+    #[test]
+    fn room_composite_mixes_only_inputs_with_audio() {
+        // Three inputs, middle one is video-only: amix must reference [0:a] and
+        // [2:a] only, with inputs=2 (not 3), while the video half still xstacks
+        // all three [i:v].
+        let cmd = FfmpegRoomCompositeCommand::new(
+            "ffmpeg",
+            vec![
+                PathBuf::from("/rec/a.mp4"),
+                PathBuf::from("/rec/b.mp4"),
+                PathBuf::from("/rec/c.mp4"),
+            ],
+            "/out/room.mp4",
+            vec![true, false, true],
+        );
+        let args = lossy(&cmd.args());
+        let fc = args.iter().position(|a| a == "-filter_complex").unwrap();
+        let graph = &args[fc + 1];
+        // Video half references every input.
+        assert!(graph.contains("[0:v]scale="));
+        assert!(graph.contains("[1:v]scale="));
+        assert!(graph.contains("[2:v]scale="));
+        assert!(graph.contains("[v0][v1][v2]xstack=inputs=3:"));
+        // Audio half mixes only inputs 0 and 2.
+        assert!(
+            graph.contains("[0:a][2:a]amix=inputs=2:normalize=1[aout]"),
+            "graph was: {graph}"
+        );
+        assert!(
+            !graph.contains("[1:a]"),
+            "video-only input must not be mixed"
+        );
+        // Output still carries audio.
+        assert!(
+            args.windows(2).any(|w| w[0] == "-map" && w[1] == "[aout]"),
+            "audio must be mapped to output"
+        );
+        assert_windowed(&args, "-c:a", "aac");
+    }
+
+    #[test]
+    fn room_composite_single_audio_uses_amix_inputs_one() {
+        // Only the second input has audio: amix=inputs=1 over [1:a] keeps the
+        // labeled [aout] so args() maps audio uniformly.
+        let cmd = FfmpegRoomCompositeCommand::new(
+            "ffmpeg",
+            vec![
+                PathBuf::from("/rec/a.mp4"),
+                PathBuf::from("/rec/b.mp4"),
+                PathBuf::from("/rec/c.mp4"),
+            ],
+            "/out/room.mp4",
+            vec![false, true, false],
+        );
+        let args = lossy(&cmd.args());
+        let fc = args.iter().position(|a| a == "-filter_complex").unwrap();
+        let graph = &args[fc + 1];
+        // Video half still references all three inputs.
+        assert!(graph.contains("[v0][v1][v2]xstack=inputs=3:"));
+        assert!(
+            graph.contains("[1:a]amix=inputs=1:normalize=1[aout]"),
+            "graph was: {graph}"
+        );
+        assert!(!graph.contains("[0:a]"));
+        assert!(!graph.contains("[2:a]"));
+        assert!(
+            args.windows(2).any(|w| w[0] == "-map" && w[1] == "[aout]"),
+            "audio must be mapped to output"
+        );
+        assert_windowed(&args, "-c:a", "aac");
+    }
+
+    #[test]
+    fn room_composite_all_video_only_emits_silent_grid() {
+        // Every input is video-only: no amix, no [aout], and args() must omit
+        // -map [aout] and -c:a aac entirely — a valid silent video grid.
+        let cmd = FfmpegRoomCompositeCommand::new(
+            "ffmpeg",
+            vec![PathBuf::from("/rec/a.mp4"), PathBuf::from("/rec/b.mp4")],
+            "/out/room.mp4",
+            vec![false, false],
+        );
+        let args = lossy(&cmd.args());
+        let fc = args.iter().position(|a| a == "-filter_complex").unwrap();
+        assert_eq!(
+            args[fc + 1],
+            "[0:v]scale=640:360:force_original_aspect_ratio=decrease,pad=640:360:(ow-iw)/2:(oh-ih)/2,setsar=1[v0];\
+             [1:v]scale=640:360:force_original_aspect_ratio=decrease,pad=640:360:(ow-iw)/2:(oh-ih)/2,setsar=1[v1];\
+             [v0][v1]xstack=inputs=2:layout=0_0|w0_0[vout]"
+        );
+        // Video is still mapped and encoded.
+        assert_windowed(&args, "-map", "[vout]");
+        assert_windowed(&args, "-c:v", "libx264");
+        // No audio anywhere.
+        assert!(!args.iter().any(|a| a == "[aout]"), "no [aout] map");
+        assert!(!args.iter().any(|a| a == "-c:a"), "no audio codec");
+        // Exactly one -map (the video), not two.
+        assert_eq!(args.iter().filter(|a| *a == "-map").count(), 1);
+        assert_eq!(args.last().map(String::as_str), Some("/out/room.mp4"));
     }
 
     #[test]
@@ -1551,8 +1696,12 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let only = dir.path().join("solo.mp4");
         File::create(&only).unwrap();
-        let cmd =
-            FfmpegRoomCompositeCommand::new("ffmpeg", vec![only], dir.path().join("room.mp4"));
+        let cmd = FfmpegRoomCompositeCommand::new(
+            "ffmpeg",
+            vec![only],
+            dir.path().join("room.mp4"),
+            vec![true],
+        );
         // A one-participant composite is meaningless; run() must reject it
         // before spawning FFmpeg.
         assert!(matches!(
@@ -1573,7 +1722,9 @@ mod tests {
                 path
             })
             .collect();
-        let cmd = FfmpegRoomCompositeCommand::new("ffmpeg", sources, dir.path().join("room.mp4"));
+        let audio = vec![true; sources.len()];
+        let cmd =
+            FfmpegRoomCompositeCommand::new("ffmpeg", sources, dir.path().join("room.mp4"), audio);
         assert!(matches!(
             cmd.run(),
             Err(super::MediaError::FfmpegSourceMissing { .. })

--- a/autumn-media-plugin/src/encode.rs
+++ b/autumn-media-plugin/src/encode.rs
@@ -788,6 +788,31 @@ pub const ROOM_COMPOSITE_CELL_HEIGHT: u32 = 360;
 /// const so this dependency-free encode module needs no `config` import.
 const ROOM_COMPOSITE_MAX_INPUTS: usize = 6;
 
+/// Minimum participant recordings a room composite accepts (a grid needs ≥ 2).
+const ROOM_COMPOSITE_MIN_INPUTS: usize = 2;
+
+/// Validate a room-composite input count against the `2..=6` mesh-room band,
+/// returning the same [`MediaError::FfmpegSourceMissing`] `run()` produces.
+///
+/// Shared by [`FfmpegRoomCompositeCommand::run`] and the composite job caller
+/// (`run_room_composite`) so the caller can reject a malformed (`> 6` or `< 2`)
+/// job **before** spawning any `ffprobe` — a bad queued job otherwise fans out
+/// one probe child process per supplied path before `run()` rejects it anyway.
+/// Single source of truth for both the bound and the error message.
+pub(crate) fn validate_room_composite_input_count(count: usize) -> Result<(), MediaError> {
+    if count < ROOM_COMPOSITE_MIN_INPUTS {
+        return Err(MediaError::FfmpegSourceMissing {
+            path: "<room composite needs at least two participant recordings>".to_owned(),
+        });
+    }
+    if count > ROOM_COMPOSITE_MAX_INPUTS {
+        return Err(MediaError::FfmpegSourceMissing {
+            path: "<room composite accepts at most six participant recordings>".to_owned(),
+        });
+    }
+    Ok(())
+}
+
 /// Grid-composite encoder for a finished mesh-room recording.
 ///
 /// Tiles each participant's recording into a grid — `2x1` for two participants,
@@ -895,16 +920,7 @@ impl FfmpegRoomCompositeCommand {
     /// inspected after a successful run.
     pub fn run(&self) -> Result<u64, MediaError> {
         require_sources(&self.input_paths)?;
-        if self.input_paths.len() < 2 {
-            return Err(MediaError::FfmpegSourceMissing {
-                path: "<room composite needs at least two participant recordings>".to_owned(),
-            });
-        }
-        if self.input_paths.len() > ROOM_COMPOSITE_MAX_INPUTS {
-            return Err(MediaError::FfmpegSourceMissing {
-                path: "<room composite accepts at most six participant recordings>".to_owned(),
-            });
-        }
+        validate_room_composite_input_count(self.input_paths.len())?;
         create_output_parent(&self.output_path)?;
 
         let output = run_ffmpeg_capped(&self.ffmpeg_bin, self.args()).map_err(|source| {
@@ -1380,6 +1396,7 @@ mod tests {
         PREVIEW_CELL_HEIGHT, PREVIEW_CELL_WIDTH, PREVIEW_FRAME_INTERVAL_SECONDS,
         PREVIEW_SPRITE_COLUMNS, build_preview_webvtt, newest_recording_files,
         newest_recording_files_since, recording_segments_covering_window, slugify,
+        validate_room_composite_input_count,
     };
 
     // ── Arg-vector contracts (no FFmpeg binary required) ────────────────────
@@ -1729,6 +1746,28 @@ mod tests {
             cmd.run(),
             Err(super::MediaError::FfmpegSourceMissing { .. })
         ));
+    }
+
+    #[test]
+    fn validate_room_composite_input_count_enforces_two_to_six_band() {
+        // Below the band → "at least two" error.
+        for count in [0, 1] {
+            assert!(matches!(
+                validate_room_composite_input_count(count),
+                Err(super::MediaError::FfmpegSourceMissing { .. })
+            ));
+        }
+        // In-band → Ok.
+        for count in 2..=6 {
+            assert!(validate_room_composite_input_count(count).is_ok());
+        }
+        // Above the band → "at most six" error.
+        for count in [7, 100] {
+            assert!(matches!(
+                validate_room_composite_input_count(count),
+                Err(super::MediaError::FfmpegSourceMissing { .. })
+            ));
+        }
     }
 
     /// Render an `OsString` arg vector as lossy `String`s for `&str` assertions.

--- a/autumn-media-plugin/src/encode.rs
+++ b/autumn-media-plugin/src/encode.rs
@@ -13,12 +13,13 @@
 //! encoders read those segments; the poster/sprite encoders sample frames from
 //! them; the live-thumbnail encoder reads a live playlist URL instead.
 
+use std::ffi::OsString;
 use std::path::{Path, PathBuf};
-use std::process::Command;
+use std::process::{Command, Stdio};
 
 use serde::{Deserialize, Serialize};
 
-use crate::error::{MediaError, stderr_tail};
+use crate::error::{MediaError, STDERR_TAIL_MAX_BYTES, stderr_tail};
 
 /// Tail-of-file clip/highlight encoder that transcodes a fixed window of a
 /// recording to an MP4.
@@ -54,25 +55,29 @@ impl FfmpegHighlightCommand {
     }
 
     /// The exact `FFmpeg` argument vector this command runs.
+    ///
+    /// Paths are threaded through as `OsString` (their raw `OsStr` bytes) rather
+    /// than a lossy `String`, so a non-UTF-8 recording/output path reaches
+    /// `Command` intact.
     #[must_use]
-    pub fn args(&self) -> Vec<String> {
+    pub fn args(&self) -> Vec<OsString> {
         vec![
-            "-y".to_owned(),
-            "-ss".to_owned(),
-            self.start_seconds.to_string(),
-            "-i".to_owned(),
-            self.input_path.display().to_string(),
-            "-t".to_owned(),
-            self.duration_seconds.to_string(),
-            "-c:v".to_owned(),
-            "libx264".to_owned(),
-            "-preset".to_owned(),
-            "veryfast".to_owned(),
-            "-c:a".to_owned(),
-            "aac".to_owned(),
-            "-movflags".to_owned(),
-            "+faststart".to_owned(),
-            self.output_path.display().to_string(),
+            OsString::from("-y"),
+            OsString::from("-ss"),
+            OsString::from(self.start_seconds.to_string()),
+            OsString::from("-i"),
+            self.input_path.as_os_str().to_owned(),
+            OsString::from("-t"),
+            OsString::from(self.duration_seconds.to_string()),
+            OsString::from("-c:v"),
+            OsString::from("libx264"),
+            OsString::from("-preset"),
+            OsString::from("veryfast"),
+            OsString::from("-c:a"),
+            OsString::from("aac"),
+            OsString::from("-movflags"),
+            OsString::from("+faststart"),
+            self.output_path.as_os_str().to_owned(),
         ]
     }
 
@@ -91,13 +96,12 @@ impl FfmpegHighlightCommand {
         }
         create_output_parent(&self.output_path)?;
 
-        let output = Command::new(&self.ffmpeg_bin)
-            .args(self.args())
-            .output()
-            .map_err(|source| MediaError::FfmpegSpawn {
+        let output = run_ffmpeg_capped(&self.ffmpeg_bin, self.args()).map_err(|source| {
+            MediaError::FfmpegSpawn {
                 bin: self.ffmpeg_bin.clone(),
                 source,
-            })?;
+            }
+        })?;
 
         check_exit(&output)?;
         output_size(&self.output_path)
@@ -141,30 +145,33 @@ impl FfmpegPosterCommand {
     /// The `FFmpeg` argument vector for this command. `concat_list` is `Some`
     /// when multiple source segments are demuxed through a concat list.
     #[must_use]
-    pub(crate) fn poster_args(&self, concat_list: Option<&Path>) -> Vec<String> {
+    pub(crate) fn poster_args(&self, concat_list: Option<&Path>) -> Vec<OsString> {
         let mut args = vec![
-            "-y".to_owned(),
-            "-sseof".to_owned(),
-            format!("-{}", self.tail_offset_seconds),
+            OsString::from("-y"),
+            OsString::from("-sseof"),
+            OsString::from(format!("-{}", self.tail_offset_seconds)),
         ];
         if let Some(list) = concat_list {
             args.extend([
-                "-f".to_owned(),
-                "concat".to_owned(),
-                "-safe".to_owned(),
-                "0".to_owned(),
-                "-i".to_owned(),
-                list.display().to_string(),
+                OsString::from("-f"),
+                OsString::from("concat"),
+                OsString::from("-safe"),
+                OsString::from("0"),
+                OsString::from("-i"),
+                list.as_os_str().to_owned(),
             ]);
         } else {
-            args.extend(["-i".to_owned(), self.input_paths[0].display().to_string()]);
+            args.extend([
+                OsString::from("-i"),
+                self.input_paths[0].as_os_str().to_owned(),
+            ]);
         }
         args.extend([
-            "-frames:v".to_owned(),
-            "1".to_owned(),
-            "-q:v".to_owned(),
-            "4".to_owned(),
-            self.output_path.display().to_string(),
+            OsString::from("-frames:v"),
+            OsString::from("1"),
+            OsString::from("-q:v"),
+            OsString::from("4"),
+            self.output_path.as_os_str().to_owned(),
         ]);
         args
     }
@@ -189,13 +196,14 @@ impl FfmpegPosterCommand {
             None
         };
 
-        let output = Command::new(&self.ffmpeg_bin)
-            .args(self.poster_args(concat_list_path.as_deref()))
-            .output()
-            .map_err(|source| MediaError::FfmpegSpawn {
-                bin: self.ffmpeg_bin.clone(),
-                source,
-            })?;
+        let output = run_ffmpeg_capped(
+            &self.ffmpeg_bin,
+            self.poster_args(concat_list_path.as_deref()),
+        )
+        .map_err(|source| MediaError::FfmpegSpawn {
+            bin: self.ffmpeg_bin.clone(),
+            source,
+        })?;
 
         check_exit(&output)?;
         output_size(&self.output_path)
@@ -303,19 +311,22 @@ impl FfmpegPreviewSpriteCommand {
     /// The `FFmpeg` argument vector for this command. `concat_list` is `Some`
     /// when multiple source segments are demuxed through a concat list.
     #[must_use]
-    pub(crate) fn sprite_args(&self, concat_list: Option<&Path>) -> Vec<String> {
-        let mut args = vec!["-y".to_owned()];
+    pub(crate) fn sprite_args(&self, concat_list: Option<&Path>) -> Vec<OsString> {
+        let mut args = vec![OsString::from("-y")];
         if let Some(list) = concat_list {
             args.extend([
-                "-f".to_owned(),
-                "concat".to_owned(),
-                "-safe".to_owned(),
-                "0".to_owned(),
-                "-i".to_owned(),
-                list.display().to_string(),
+                OsString::from("-f"),
+                OsString::from("concat"),
+                OsString::from("-safe"),
+                OsString::from("0"),
+                OsString::from("-i"),
+                list.as_os_str().to_owned(),
             ]);
         } else {
-            args.extend(["-i".to_owned(), self.input_paths[0].display().to_string()]);
+            args.extend([
+                OsString::from("-i"),
+                self.input_paths[0].as_os_str().to_owned(),
+            ]);
         }
         let filter = format!(
             "fps=1/{PREVIEW_FRAME_INTERVAL_SECONDS},scale={cw}:{ch}:force_original_aspect_ratio=decrease,pad={cw}:{ch}:(ow-iw)/2:(oh-ih)/2,tile={cols}x{rows}",
@@ -325,13 +336,13 @@ impl FfmpegPreviewSpriteCommand {
             rows = self.rows,
         );
         args.extend([
-            "-frames:v".to_owned(),
-            "1".to_owned(),
-            "-vf".to_owned(),
-            filter,
-            "-q:v".to_owned(),
-            "5".to_owned(),
-            self.output_path.display().to_string(),
+            OsString::from("-frames:v"),
+            OsString::from("1"),
+            OsString::from("-vf"),
+            OsString::from(filter),
+            OsString::from("-q:v"),
+            OsString::from("5"),
+            self.output_path.as_os_str().to_owned(),
         ]);
         args
     }
@@ -356,13 +367,14 @@ impl FfmpegPreviewSpriteCommand {
             None
         };
 
-        let output = Command::new(&self.ffmpeg_bin)
-            .args(self.sprite_args(concat_list_path.as_deref()))
-            .output()
-            .map_err(|source| MediaError::FfmpegSpawn {
-                bin: self.ffmpeg_bin.clone(),
-                source,
-            })?;
+        let output = run_ffmpeg_capped(
+            &self.ffmpeg_bin,
+            self.sprite_args(concat_list_path.as_deref()),
+        )
+        .map_err(|source| MediaError::FfmpegSpawn {
+            bin: self.ffmpeg_bin.clone(),
+            source,
+        })?;
 
         check_exit(&output)?;
         output_size(&self.output_path)
@@ -409,15 +421,21 @@ fn write_concat_list(input_paths: &[PathBuf], near_path: &Path) -> Result<PathBu
         // a literal single quote is written as `'\''` (close-quote,
         // backslash-escaped quote, reopen-quote). Backslashes are literal
         // inside the quotes for the demuxer, so Windows paths need no escaping.
-        writeln!(
-            list_file,
-            "file '{}'",
-            concat_escape(&absolute.display().to_string())
-        )
-        .map_err(|source| MediaError::ConcatList {
-            path: list_path.display().to_string(),
-            source,
-        })?;
+        //
+        // The path is written as its raw `OsStr` bytes (not a lossy `String`),
+        // so a non-UTF-8 recording path reaches FFmpeg's demuxer intact. The
+        // surrounding `file '…'\n` framing and the single-quote escape are
+        // plain ASCII, so byte-splicing them around the raw path is well-formed.
+        let mut line = Vec::with_capacity(absolute.as_os_str().len() + 8);
+        line.extend_from_slice(b"file '");
+        line.extend_from_slice(&concat_escape(&path_to_bytes(&absolute)));
+        line.extend_from_slice(b"'\n");
+        list_file
+            .write_all(&line)
+            .map_err(|source| MediaError::ConcatList {
+                path: list_path.display().to_string(),
+                source,
+            })?;
     }
     Ok(list_path)
 }
@@ -427,14 +445,40 @@ fn write_concat_list(input_paths: &[PathBuf], near_path: &Path) -> Result<PathBu
 /// never share a list file.
 static CONCAT_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
 
-/// Escape a path for a single-quoted `FFmpeg` concat-demuxer `file` entry.
+/// Escape a path (as raw bytes) for a single-quoted `FFmpeg` concat-demuxer
+/// `file` entry.
 ///
 /// The demuxer treats everything inside the single quotes literally except the
-/// closing quote, so only `'` needs escaping — as `'\''` (close-quote,
-/// backslash-escaped quote, reopen-quote). Backslashes stay literal, so Windows
-/// paths pass through unchanged.
-fn concat_escape(path: &str) -> String {
-    path.replace('\'', "'\\''")
+/// closing quote, so only `'` (a single ASCII byte, `0x27`) needs escaping — as
+/// `'\''` (close-quote, backslash-escaped quote, reopen-quote). Every other byte
+/// (including non-UTF-8 path bytes and backslashes, so Windows paths pass through
+/// unchanged) is copied verbatim.
+fn concat_escape(path: &[u8]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(path.len());
+    for &byte in path {
+        if byte == b'\'' {
+            out.extend_from_slice(b"'\\''");
+        } else {
+            out.push(byte);
+        }
+    }
+    out
+}
+
+/// The raw bytes of a path, so a non-UTF-8 path reaches the concat list intact.
+///
+/// On Unix the `OsStr` bytes are used directly; on other platforms (where
+/// `OsStr` has no documented byte view) it falls back to the lossy display form.
+fn path_to_bytes(path: &Path) -> Vec<u8> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::ffi::OsStrExt as _;
+        path.as_os_str().as_bytes().to_vec()
+    }
+    #[cfg(not(unix))]
+    {
+        path.display().to_string().into_bytes()
+    }
 }
 
 fn absolutize_for_concat(path: &Path) -> Result<PathBuf, MediaError> {
@@ -511,17 +555,22 @@ impl FfmpegClipTailCommand {
     }
 
     #[must_use]
-    fn input_args(&self, concat_list: Option<&Path>) -> Vec<String> {
+    fn input_args(&self, concat_list: Option<&Path>) -> Vec<OsString> {
         concat_list.map_or_else(
-            || vec!["-i".to_owned(), self.input_paths[0].display().to_string()],
+            || {
+                vec![
+                    OsString::from("-i"),
+                    self.input_paths[0].as_os_str().to_owned(),
+                ]
+            },
             |list| {
                 vec![
-                    "-f".to_owned(),
-                    "concat".to_owned(),
-                    "-safe".to_owned(),
-                    "0".to_owned(),
-                    "-i".to_owned(),
-                    list.display().to_string(),
+                    OsString::from("-f"),
+                    OsString::from("concat"),
+                    OsString::from("-safe"),
+                    OsString::from("0"),
+                    OsString::from("-i"),
+                    list.as_os_str().to_owned(),
                 ]
             },
         )
@@ -530,25 +579,25 @@ impl FfmpegClipTailCommand {
     /// The `FFmpeg` argument vector for this command. `concat_list` is `Some`
     /// when multiple source segments are demuxed through a concat list.
     #[must_use]
-    pub(crate) fn encode_args(&self, concat_list: Option<&Path>) -> Vec<String> {
+    pub(crate) fn encode_args(&self, concat_list: Option<&Path>) -> Vec<OsString> {
         let mut args = vec![
-            "-y".to_owned(),
-            "-sseof".to_owned(),
-            format!("-{}", self.tail_offset_seconds),
+            OsString::from("-y"),
+            OsString::from("-sseof"),
+            OsString::from(format!("-{}", self.tail_offset_seconds)),
         ];
         args.extend(self.input_args(concat_list));
         args.extend([
-            "-t".to_owned(),
-            self.duration_seconds.to_string(),
-            "-c:v".to_owned(),
-            "libx264".to_owned(),
-            "-preset".to_owned(),
-            "veryfast".to_owned(),
-            "-c:a".to_owned(),
-            "aac".to_owned(),
-            "-movflags".to_owned(),
-            "+faststart".to_owned(),
-            self.output_path.display().to_string(),
+            OsString::from("-t"),
+            OsString::from(self.duration_seconds.to_string()),
+            OsString::from("-c:v"),
+            OsString::from("libx264"),
+            OsString::from("-preset"),
+            OsString::from("veryfast"),
+            OsString::from("-c:a"),
+            OsString::from("aac"),
+            OsString::from("-movflags"),
+            OsString::from("+faststart"),
+            self.output_path.as_os_str().to_owned(),
         ]);
         args
     }
@@ -573,13 +622,14 @@ impl FfmpegClipTailCommand {
             None
         };
 
-        let output = Command::new(&self.ffmpeg_bin)
-            .args(self.encode_args(concat_list_path.as_deref()))
-            .output()
-            .map_err(|source| MediaError::FfmpegSpawn {
-                bin: self.ffmpeg_bin.clone(),
-                source,
-            })?;
+        let output = run_ffmpeg_capped(
+            &self.ffmpeg_bin,
+            self.encode_args(concat_list_path.as_deref()),
+        )
+        .map_err(|source| MediaError::FfmpegSpawn {
+            bin: self.ffmpeg_bin.clone(),
+            source,
+        })?;
 
         check_exit(&output)?;
         output_size(&self.output_path)
@@ -616,23 +666,26 @@ impl FfmpegLiveThumbnailCommand {
     }
 
     /// The exact `FFmpeg` argument vector this command runs.
+    ///
+    /// The output path is threaded through as its raw `OsStr` (not a lossy
+    /// `String`) so a non-UTF-8 path reaches `Command` intact.
     #[must_use]
-    pub fn args(&self) -> Vec<String> {
+    pub fn args(&self) -> Vec<OsString> {
         vec![
-            "-y".to_owned(),
+            OsString::from("-y"),
             // Bound HLS network reads so a stalled source can't wedge the
             // per-channel capture loop. 5s is well under a typical capture
             // cadence; a hung source fails this tick and the next one tries.
-            "-rw_timeout".to_owned(),
-            "5000000".to_owned(),
-            "-i".to_owned(),
-            self.input_url.clone(),
-            "-frames:v".to_owned(),
-            "1".to_owned(),
-            "-q:v".to_owned(),
-            "4".to_owned(),
-            "-an".to_owned(),
-            self.output_path.display().to_string(),
+            OsString::from("-rw_timeout"),
+            OsString::from("5000000"),
+            OsString::from("-i"),
+            OsString::from(self.input_url.clone()),
+            OsString::from("-frames:v"),
+            OsString::from("1"),
+            OsString::from("-q:v"),
+            OsString::from("4"),
+            OsString::from("-an"),
+            self.output_path.as_os_str().to_owned(),
         ]
     }
 
@@ -645,13 +698,12 @@ impl FfmpegLiveThumbnailCommand {
     pub fn run(&self) -> Result<u64, MediaError> {
         create_output_parent(&self.output_path)?;
 
-        let output = Command::new(&self.ffmpeg_bin)
-            .args(self.args())
-            .output()
-            .map_err(|source| MediaError::FfmpegSpawn {
+        let output = run_ffmpeg_capped(&self.ffmpeg_bin, self.args()).map_err(|source| {
+            MediaError::FfmpegSpawn {
                 bin: self.ffmpeg_bin.clone(),
                 source,
-            })?;
+            }
+        })?;
 
         check_exit(&output)?;
         output_size(&self.output_path)
@@ -679,10 +731,11 @@ impl FfmpegLiveThumbnailCommand {
             })?;
         }
 
-        let child = tokio::process::Command::new(&self.ffmpeg_bin)
+        let mut child = tokio::process::Command::new(&self.ffmpeg_bin)
             .args(self.args())
-            .stdout(std::process::Stdio::piped())
-            .stderr(std::process::Stdio::piped())
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
             .kill_on_drop(true)
             .spawn()
             .map_err(|source| MediaError::FfmpegSpawn {
@@ -690,12 +743,22 @@ impl FfmpegLiveThumbnailCommand {
                 source,
             })?;
 
-        let output = match tokio::time::timeout(deadline, child.wait_with_output()).await {
+        // Stream the child's pipes with incremental, capped reads (see
+        // `capture_child_capped`): stderr is retained only as a bounded tail and
+        // stdout is drained-and-discarded, so neither a chatty nor a hostile
+        // encoder can grow an unbounded in-memory buffer. The capture future is
+        // boxed so the awaited deadline future stays small. On timeout the early
+        // return drops `child`, whose `kill_on_drop` reaps the process.
+        let output = match tokio::time::timeout(
+            deadline,
+            Box::pin(capture_child_capped(&mut child)),
+        )
+        .await
+        {
             Ok(result) => result.map_err(|source| MediaError::FfmpegSpawn {
                 bin: self.ffmpeg_bin.clone(),
                 source,
             })?,
-            // `kill_on_drop` reaps the child as it drops on the early return.
             Err(_elapsed) => return Err(MediaError::FfmpegTimeout),
         };
 
@@ -770,30 +833,34 @@ impl FfmpegRoomCompositeCommand {
     }
 
     /// The exact `FFmpeg` argument vector this command runs.
+    ///
+    /// Each participant input path and the output path are threaded through as
+    /// their raw `OsStr` (not a lossy `String`) so non-UTF-8 paths reach
+    /// `Command` intact.
     #[must_use]
-    pub fn args(&self) -> Vec<String> {
+    pub fn args(&self) -> Vec<OsString> {
         let n = self.input_paths.len();
-        let mut args = vec!["-y".to_owned()];
+        let mut args = vec![OsString::from("-y")];
         for path in &self.input_paths {
-            args.push("-i".to_owned());
-            args.push(path.display().to_string());
+            args.push(OsString::from("-i"));
+            args.push(path.as_os_str().to_owned());
         }
-        args.push("-filter_complex".to_owned());
-        args.push(room_composite_filtergraph(n));
+        args.push(OsString::from("-filter_complex"));
+        args.push(OsString::from(room_composite_filtergraph(n)));
         args.extend([
-            "-map".to_owned(),
-            "[vout]".to_owned(),
-            "-map".to_owned(),
-            "[aout]".to_owned(),
-            "-c:v".to_owned(),
-            "libx264".to_owned(),
-            "-preset".to_owned(),
-            "veryfast".to_owned(),
-            "-c:a".to_owned(),
-            "aac".to_owned(),
-            "-movflags".to_owned(),
-            "+faststart".to_owned(),
-            self.output_path.display().to_string(),
+            OsString::from("-map"),
+            OsString::from("[vout]"),
+            OsString::from("-map"),
+            OsString::from("[aout]"),
+            OsString::from("-c:v"),
+            OsString::from("libx264"),
+            OsString::from("-preset"),
+            OsString::from("veryfast"),
+            OsString::from("-c:a"),
+            OsString::from("aac"),
+            OsString::from("-movflags"),
+            OsString::from("+faststart"),
+            self.output_path.as_os_str().to_owned(),
         ]);
         args
     }
@@ -820,13 +887,12 @@ impl FfmpegRoomCompositeCommand {
         }
         create_output_parent(&self.output_path)?;
 
-        let output = Command::new(&self.ffmpeg_bin)
-            .args(self.args())
-            .output()
-            .map_err(|source| MediaError::FfmpegSpawn {
+        let output = run_ffmpeg_capped(&self.ffmpeg_bin, self.args()).map_err(|source| {
+            MediaError::FfmpegSpawn {
                 bin: self.ffmpeg_bin.clone(),
                 source,
-            })?;
+            }
+        })?;
 
         check_exit(&output)?;
         output_size(&self.output_path)
@@ -922,8 +988,173 @@ fn create_output_parent(output_path: &Path) -> Result<(), MediaError> {
     Ok(())
 }
 
+/// The bounded outcome of a spawned `FFmpeg` process.
+///
+/// Unlike [`std::process::Output`], `stderr` here is not the child's full stderr
+/// but only the last [`STDERR_TAIL_MAX_BYTES`] of it (what [`stderr_tail`] would
+/// ultimately surface), and stdout is discarded entirely — so a chatty or
+/// hostile encoder can never grow an unbounded in-memory buffer.
+struct CapturedOutput {
+    status: std::process::ExitStatus,
+    stderr: Vec<u8>,
+}
+
+/// A fixed-capacity tail buffer: retains only the last `cap` bytes pushed, so
+/// draining an unbounded stream keeps memory bounded at `cap`.
+struct TailBuffer {
+    cap: usize,
+    buf: Vec<u8>,
+}
+
+impl TailBuffer {
+    const fn new(cap: usize) -> Self {
+        Self {
+            cap,
+            buf: Vec::new(),
+        }
+    }
+
+    /// Append `data`, retaining only the last `cap` bytes overall.
+    fn push(&mut self, data: &[u8]) {
+        if self.cap == 0 {
+            return;
+        }
+        if data.len() >= self.cap {
+            // The new chunk alone overflows the cap: keep only its tail.
+            self.buf.clear();
+            self.buf.extend_from_slice(&data[data.len() - self.cap..]);
+            return;
+        }
+        let overflow = (self.buf.len() + data.len()).saturating_sub(self.cap);
+        if overflow > 0 {
+            self.buf.drain(..overflow);
+        }
+        self.buf.extend_from_slice(data);
+    }
+
+    fn into_vec(self) -> Vec<u8> {
+        self.buf
+    }
+}
+
+/// Drain a blocking reader into a bounded tail buffer (the last `cap` bytes).
+fn drain_tail_sync<R: std::io::Read>(mut reader: R, cap: usize) -> Vec<u8> {
+    let mut tail = TailBuffer::new(cap);
+    let mut buf = [0u8; 8192];
+    loop {
+        match reader.read(&mut buf) {
+            Ok(0) | Err(_) => break,
+            Ok(n) => tail.push(&buf[..n]),
+        }
+    }
+    tail.into_vec()
+}
+
+/// Drain a blocking reader to EOF, discarding its bytes (keeps a full stdout
+/// pipe from wedging the child while using no memory).
+fn drain_discard_sync<R: std::io::Read>(mut reader: R) {
+    let mut buf = [0u8; 8192];
+    loop {
+        match reader.read(&mut buf) {
+            Ok(0) | Err(_) => break,
+            Ok(_) => {}
+        }
+    }
+}
+
+/// Spawn `bin` with `args`, streaming its pipes with capped reads.
+///
+/// stdout is drained-and-discarded and stderr is retained only as a bounded
+/// tail (both drained concurrently with `wait()` so a full pipe can never wedge
+/// the child), so the transient in-memory buffer is bounded regardless of how
+/// much the child writes. Stdin is `/dev/null`, matching `Command::output()`.
+fn run_ffmpeg_capped(bin: &str, args: Vec<OsString>) -> std::io::Result<CapturedOutput> {
+    let mut child = Command::new(bin)
+        .args(args)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()?;
+
+    let stdout = child.stdout.take();
+    let stderr = child.stderr.take();
+    let stderr_handle = std::thread::spawn(move || {
+        stderr.map_or_else(Vec::new, |reader| {
+            drain_tail_sync(reader, STDERR_TAIL_MAX_BYTES)
+        })
+    });
+    let stdout_handle = std::thread::spawn(move || {
+        if let Some(reader) = stdout {
+            drain_discard_sync(reader);
+        }
+    });
+
+    let status = child.wait()?;
+    let stderr = stderr_handle.join().unwrap_or_default();
+    let _ = stdout_handle.join();
+    Ok(CapturedOutput { status, stderr })
+}
+
+/// Async twin of [`drain_tail_sync`].
+async fn drain_tail_async<R: tokio::io::AsyncRead + Unpin>(mut reader: R, cap: usize) -> Vec<u8> {
+    use tokio::io::AsyncReadExt as _;
+    let mut tail = TailBuffer::new(cap);
+    let mut buf = [0u8; 8192];
+    loop {
+        match reader.read(&mut buf).await {
+            Ok(0) | Err(_) => break,
+            Ok(n) => tail.push(&buf[..n]),
+        }
+    }
+    tail.into_vec()
+}
+
+/// Async twin of [`drain_discard_sync`].
+async fn drain_discard_async<R: tokio::io::AsyncRead + Unpin>(mut reader: R) {
+    use tokio::io::AsyncReadExt as _;
+    let mut buf = [0u8; 8192];
+    loop {
+        match reader.read(&mut buf).await {
+            Ok(0) | Err(_) => break,
+            Ok(_) => {}
+        }
+    }
+}
+
+/// Await a spawned child while draining its pipes with capped reads.
+///
+/// stderr is retained only as a bounded tail (matching [`stderr_tail`]) and
+/// stdout is drained-and-discarded; both are drained concurrently with `wait()`
+/// so a full pipe can never wedge the child. Kept a free function (rather than
+/// an inline block in the async command method) so the `tokio::join!` expansion
+/// — and the pin `unsafe` it emits — does not live inside a `Deserialize`-
+/// deriving command's impl. The caller owns the child, so `kill_on_drop` still
+/// reaps it when a surrounding deadline drops this future.
+async fn capture_child_capped(
+    child: &mut tokio::process::Child,
+) -> std::io::Result<CapturedOutput> {
+    let stdout = child.stdout.take();
+    let stderr = child.stderr.take();
+    let stderr_fut = async {
+        match stderr {
+            Some(reader) => drain_tail_async(reader, STDERR_TAIL_MAX_BYTES).await,
+            None => Vec::new(),
+        }
+    };
+    let stdout_fut = async {
+        if let Some(reader) = stdout {
+            drain_discard_async(reader).await;
+        }
+    };
+    let (status, stderr, ()) = tokio::join!(child.wait(), stderr_fut, stdout_fut);
+    Ok(CapturedOutput {
+        status: status?,
+        stderr,
+    })
+}
+
 /// Map a non-zero `FFmpeg` exit into [`MediaError::FfmpegNonZeroExit`].
-fn check_exit(output: &std::process::Output) -> Result<(), MediaError> {
+fn check_exit(output: &CapturedOutput) -> Result<(), MediaError> {
     if output.status.success() {
         return Ok(());
     }
@@ -1114,7 +1345,7 @@ mod tests {
     #[test]
     fn highlight_args_have_expected_flags() {
         let cmd = FfmpegHighlightCommand::new("ffmpeg", "/rec/in.mp4", "/out/clip.mp4", 12, 30);
-        let args = cmd.args();
+        let args = lossy(&cmd.args());
         assert_eq!(args.first().map(String::as_str), Some("-y"));
         // -ss <start> comes before -i (an input-seek).
         let ss = args.iter().position(|a| a == "-ss").unwrap();
@@ -1140,7 +1371,7 @@ mod tests {
             20,
             25,
         );
-        let args = cmd.encode_args(None);
+        let args = lossy(&cmd.encode_args(None));
         // -sseof -<tail>
         let sseof = args.iter().position(|a| a == "-sseof").unwrap();
         assert_eq!(args[sseof + 1], "-25");
@@ -1163,7 +1394,7 @@ mod tests {
             25,
         );
         let list = PathBuf::from("/out/.clip.concat.txt");
-        let args = cmd.encode_args(Some(&list));
+        let args = lossy(&cmd.encode_args(Some(&list)));
         assert_windowed(&args, "-f", "concat");
         assert_windowed(&args, "-safe", "0");
         let i = args.iter().position(|a| a == "-i").unwrap();
@@ -1180,7 +1411,7 @@ mod tests {
             "/out/poster.jpg",
             4,
         );
-        let sa = single.poster_args(None);
+        let sa = lossy(&single.poster_args(None));
         let sseof = sa.iter().position(|a| a == "-sseof").unwrap();
         assert_eq!(sa[sseof + 1], "-4");
         assert!(!sa.iter().any(|a| a == "concat"));
@@ -1195,7 +1426,7 @@ mod tests {
             "/out/poster.jpg",
             4,
         );
-        let ma = multi.poster_args(Some(&list));
+        let ma = lossy(&multi.poster_args(Some(&list)));
         assert_windowed(&ma, "-f", "concat");
         assert_windowed(&ma, "-safe", "0");
         let i = ma.iter().position(|a| a == "-i").unwrap();
@@ -1211,7 +1442,7 @@ mod tests {
             10,
             3,
         );
-        let args = cmd.sprite_args(None);
+        let args = lossy(&cmd.sprite_args(None));
         let vf = args.iter().position(|a| a == "-vf").unwrap();
         assert_eq!(
             args[vf + 1],
@@ -1231,7 +1462,7 @@ mod tests {
             0,
             0,
         );
-        let args = cmd.sprite_args(None);
+        let args = lossy(&cmd.sprite_args(None));
         let vf = args.iter().position(|a| a == "-vf").unwrap();
         assert!(args[vf + 1].ends_with("tile=1x1"));
     }
@@ -1243,7 +1474,7 @@ mod tests {
             "http://mediamtx/live/key/index.m3u8",
             "/out/thumb.jpg",
         );
-        let args = cmd.args();
+        let args = lossy(&cmd.args());
         assert_windowed(&args, "-rw_timeout", "5000000");
         assert_windowed(&args, "-frames:v", "1");
         assert!(args.iter().any(|a| a == "-an"), "must drop audio");
@@ -1259,7 +1490,7 @@ mod tests {
             vec![PathBuf::from("/rec/a.mp4"), PathBuf::from("/rec/b.mp4")],
             "/out/room.mp4",
         );
-        let args = cmd.args();
+        let args = lossy(&cmd.args());
         assert_eq!(args.first().map(String::as_str), Some("-y"));
         // One -i per participant.
         assert_eq!(args.iter().filter(|a| *a == "-i").count(), 2);
@@ -1291,7 +1522,7 @@ mod tests {
             ],
             "/out/room.mp4",
         );
-        let args = cmd.args();
+        let args = lossy(&cmd.args());
         assert_eq!(args.iter().filter(|a| *a == "-i").count(), 4);
         let fc = args.iter().position(|a| a == "-filter_complex").unwrap();
         assert_eq!(
@@ -1347,6 +1578,14 @@ mod tests {
             cmd.run(),
             Err(super::MediaError::FfmpegSourceMissing { .. })
         ));
+    }
+
+    /// Render an `OsString` arg vector as lossy `String`s for `&str` assertions.
+    /// The builders' paths are ASCII in these tests, so the lossy view is exact.
+    fn lossy(args: &[std::ffi::OsString]) -> Vec<String> {
+        args.iter()
+            .map(|a| a.to_string_lossy().into_owned())
+            .collect()
     }
 
     /// Assert `flag` appears immediately followed by `value`.
@@ -1473,15 +1712,20 @@ mod tests {
     fn concat_escape_handles_single_quotes_and_leaves_others_literal() {
         // A single quote becomes the demuxer's close/escape/reopen sequence.
         assert_eq!(
-            super::concat_escape("creator's-stream/seg.mp4"),
-            "creator'\\''s-stream/seg.mp4"
+            super::concat_escape(b"creator's-stream/seg.mp4"),
+            b"creator'\\''s-stream/seg.mp4"
         );
         // Multiple quotes each get the treatment.
-        assert_eq!(super::concat_escape("a'b'c"), "a'\\''b'\\''c");
+        assert_eq!(super::concat_escape(b"a'b'c"), b"a'\\''b'\\''c");
         // Backslashes are literal for the demuxer (Windows paths untouched).
-        assert_eq!(super::concat_escape(r"C:\rec\seg.mp4"), r"C:\rec\seg.mp4");
+        assert_eq!(super::concat_escape(br"C:\rec\seg.mp4"), br"C:\rec\seg.mp4");
         // A normal path is unchanged.
-        assert_eq!(super::concat_escape("/rec/seg.mp4"), "/rec/seg.mp4");
+        assert_eq!(super::concat_escape(b"/rec/seg.mp4"), b"/rec/seg.mp4");
+        // Non-UTF-8 bytes (0xff) pass through verbatim, single quote still escaped.
+        assert_eq!(
+            super::concat_escape(&[0xff, b'\'', 0xfe]),
+            vec![0xff, b'\'', b'\\', b'\'', b'\'', 0xfe]
+        );
     }
 
     #[test]

--- a/autumn-media-plugin/src/error.rs
+++ b/autumn-media-plugin/src/error.rs
@@ -26,6 +26,22 @@ pub enum MediaError {
     )]
     PartialS3Credentials,
 
+    /// The S3 backend was selected without an explicit `public_base_url`, and
+    /// the configured endpoint is not Tigris — so the
+    /// `https://{bucket}.t3.tigrisfiles.io/…` public-base convention does not
+    /// apply. Deriving a public URL from an arbitrary private S3 endpoint is
+    /// unreliable, so a generic (non-Tigris) S3 backend must set
+    /// `media.storage.public_base_url` explicitly. `bucket` is a caller
+    /// configuration value (not a secret).
+    #[error(
+        "media.storage.public_base_url is required for a generic (non-Tigris) \
+         S3 backend (bucket `{bucket}`): set it to the bucket's public base URL"
+    )]
+    MissingPublicBaseUrl {
+        /// The S3 bucket configured without a resolvable public base.
+        bucket: String,
+    },
+
     /// A caller-supplied storage key contained a dot-only (`.`/`..`) or empty
     /// path segment.
     ///

--- a/autumn-media-plugin/src/error.rs
+++ b/autumn-media-plugin/src/error.rs
@@ -153,7 +153,11 @@ pub enum MediaError {
 }
 
 /// Maximum number of stderr bytes carried in [`MediaError::FfmpegNonZeroExit`].
-const STDERR_TAIL_MAX_BYTES: usize = 2048;
+///
+/// Also used by the encode primitives to bound the tail buffer they retain while
+/// streaming a child's stderr, so the transient in-memory buffer is capped at the
+/// same size this helper would ultimately surface.
+pub(crate) const STDERR_TAIL_MAX_BYTES: usize = 2048;
 
 /// Render the last ~2 KiB of an `FFmpeg` stderr stream as a `String`.
 ///

--- a/autumn-media-plugin/src/lib.rs
+++ b/autumn-media-plugin/src/lib.rs
@@ -423,9 +423,17 @@ impl Plugin for MediaPlugin {
         // via the same `on_startup` abort but its own specific message.
         // The storage backend keeps its own degrade path below (unchanged), so
         // this only fails fast on the room cap and room namespace.
-        if let Some(message) = room_max_participants_error(room_max_participants)
-            .or_else(|| room_namespace_error(config.room_namespace.as_deref()))
-        {
+        //
+        // Gated on `enable_rooms`: a broadcast-only plugin (`with_broadcast()`
+        // without `with_rooms()`) mounts no room router / `RoomService`, so a
+        // stray/irrelevant room setting — or a room env override — must never
+        // abort boot and take the broadcast path down with it. The rooms path
+        // keeps the existing fail-fast (see `room_config_boot_error`).
+        if let Some(message) = room_config_boot_error(
+            enable_rooms,
+            room_max_participants,
+            config.room_namespace.as_deref(),
+        ) {
             tracing::error!(
                 room_max_participants,
                 ceiling = DEFAULT_ROOM_MAX_PARTICIPANTS,
@@ -586,6 +594,32 @@ fn room_namespace_error(namespace: Option<&str>) -> Option<String> {
     Some(format!(
         "media.room_namespace {ns:?} is not a valid room path segment: use only ASCII letters, digits, '_' or '-' (no '/', '.', or empty)"
     ))
+}
+
+/// Resolve the fail-fast boot error for room configuration, gated on rooms
+/// actually being enabled.
+///
+/// Room config (the `room_max_participants` seat count and the
+/// `room_namespace` path segment) is only load-bearing when a room router /
+/// [`rooms::RoomService`] is mounted — i.e. when `enable_rooms` is true. A
+/// broadcast-only plugin (`with_broadcast()` without `with_rooms()`) serves no
+/// room requests, so an out-of-range `room_max_participants` or an invalid
+/// `room_namespace` (e.g. a stray value or a `media.room_namespace` env
+/// override) is inert and must **not** abort boot — otherwise an irrelevant
+/// room setting becomes a full broadcast outage. When `enable_rooms` is false
+/// this returns `None` unconditionally; when it is true the existing
+/// [`room_max_participants_error`] / [`room_namespace_error`] fail-fast checks
+/// apply exactly as before.
+fn room_config_boot_error(
+    enable_rooms: bool,
+    room_max_participants: usize,
+    room_namespace: Option<&str>,
+) -> Option<String> {
+    if !enable_rooms {
+        return None;
+    }
+    room_max_participants_error(room_max_participants)
+        .or_else(|| room_namespace_error(room_namespace))
 }
 
 /// Recordings root an Arroyo deployment uses when `ARROYO_RECORDINGS_ROOT` is
@@ -813,6 +847,52 @@ mod room_namespace_tests {
         let ok = MediaPlugin::new().with_rooms().room_namespace("tenant-a");
         assert_eq!(ok.config.room_namespace.as_deref(), Some("tenant-a"));
         assert!(room_namespace_error(ok.config.room_namespace.as_deref()).is_none());
+    }
+}
+
+// ── Room-config fail-fast gated on rooms being enabled (Codex P2) ────────────
+//
+// The boot-time room-config abort must be conditional on `enable_rooms`: a
+// broadcast-only plugin mounts no room router / `RoomService`, so a stray or
+// invalid room setting (an out-of-range `room_max_participants`, a bad
+// `room_namespace` env override) is inert and must never abort boot and take
+// the broadcast path down with it. Rooms-enabled keeps the existing fail-fast.
+
+#[cfg(test)]
+mod room_config_gate_tests {
+    use super::{MediaPlugin, room_config_boot_error};
+
+    #[test]
+    fn broadcast_only_ignores_invalid_room_config() {
+        // `with_broadcast()` without `with_rooms()` → rooms disabled. An invalid
+        // room cap (0) or namespace ("bad/ns") is irrelevant and must NOT abort
+        // boot, so no failing startup hook is installed and broadcast stays up.
+        assert!(!MediaPlugin::new().with_broadcast().enable_rooms);
+        assert!(room_config_boot_error(false, 0, None).is_none());
+        assert!(room_config_boot_error(false, 50, Some("bad/ns")).is_none());
+        assert!(room_config_boot_error(false, 4, Some("tenant-a")).is_none());
+    }
+
+    #[test]
+    fn rooms_enabled_still_fails_fast_on_invalid_room_config() {
+        // `with_rooms()` → rooms enabled. The same invalid settings that a
+        // broadcast-only plugin ignores must still abort boot on the rooms path,
+        // preserving the pre-existing fail-fast (naming the offending value).
+        assert!(MediaPlugin::new().with_rooms().enable_rooms);
+
+        let bad_cap = room_config_boot_error(true, 0, None)
+            .expect("rooms-enabled must fail fast on room_max_participants = 0");
+        assert!(bad_cap.contains('0'), "names the offending cap: {bad_cap}");
+
+        let bad_ns = room_config_boot_error(true, 4, Some("bad/ns"))
+            .expect("rooms-enabled must fail fast on an invalid room_namespace");
+        assert!(
+            bad_ns.contains("bad/ns"),
+            "names the offending namespace: {bad_ns}"
+        );
+
+        // A valid room config on the rooms path boots cleanly (no abort).
+        assert!(room_config_boot_error(true, 4, Some("tenant-a")).is_none());
     }
 }
 

--- a/autumn-media-plugin/src/lib.rs
+++ b/autumn-media-plugin/src/lib.rs
@@ -66,9 +66,9 @@ pub use retention::{
 };
 pub use rooms::{
     InMemoryRoomStore, JoinRecord, JoinRequest, JoinResponse, LeaveRequest, ParticipantView,
-    PublishTarget, RoomError, RoomLeaveResponse, RoomService, RoomSnapshot, RoomStore,
+    PublishTarget, ReapStats, RoomError, RoomLeaveResponse, RoomService, RoomSnapshot, RoomStore,
     SessionToken, SubscribeTarget, room_participant_path, room_route_infos, room_router,
-    validate_room_segment,
+    spawn_room_reaper_loop, validate_room_segment,
 };
 pub use sink::{
     MediaArtifact, MediaArtifactFile, MediaArtifactKind, MediaArtifactSink, MediaArtifactSinkExt,
@@ -104,9 +104,9 @@ pub mod prelude {
         newest_recording_files_since, recording_segments_covering_window, slugify,
     };
     pub use crate::{
-        InMemoryRoomStore, JoinRecord, JoinResponse, ParticipantView, RoomError, RoomService,
-        RoomSnapshot, RoomStore, SessionToken, room_participant_path, room_route_infos,
-        room_router, validate_room_segment,
+        InMemoryRoomStore, JoinRecord, JoinResponse, ParticipantView, ReapStats, RoomError,
+        RoomService, RoomSnapshot, RoomStore, SessionToken, room_participant_path,
+        room_route_infos, room_router, spawn_room_reaper_loop, validate_room_segment,
     };
     pub use crate::{
         IngestStatus, MediaMtxClient, MediaUrls, StreamQualityStats, StreamStatus, ViewerCount,
@@ -363,6 +363,10 @@ impl Plugin for MediaPlugin {
         Cow::Borrowed("autumn-media-plugin")
     }
 
+    // `build` is a long, linear plugin-assembly routine (config validation,
+    // room wiring + reaper, storage/workflow install, retention loop); it reads
+    // best as one top-to-bottom sequence rather than fragmented across helpers.
+    #[allow(clippy::too_many_lines)]
     fn build(self, app: AppBuilder) -> AppBuilder {
         let Self {
             config,
@@ -437,8 +441,12 @@ impl Plugin for MediaPlugin {
         // served and audit-visible under `api_prefix`.
         let mut app = app;
         if enable_rooms {
+            // Hold a handle to the store so the idle-room / stale-participant
+            // reaper can sweep the same registry the `RoomService` serves.
+            let room_store: Arc<dyn rooms::RoomStore> =
+                Arc::new(rooms::InMemoryRoomStore::new(room_max_participants));
             let room_service = rooms::RoomService::new(
-                Arc::new(rooms::InMemoryRoomStore::new(room_max_participants)),
+                room_store.clone(),
                 transport::MediaUrls::from_config(&config.mediamtx),
                 config.room_namespace.clone().unwrap_or_default(),
                 chrono::Duration::seconds(i64::from(config.room_token_ttl_seconds)),
@@ -449,6 +457,15 @@ impl Plugin for MediaPlugin {
                 .declare_plugin_routes(rooms::room_route_infos(&api_prefix))
                 .state_initializer(move |state| {
                     state.insert_extension(room_service);
+                })
+                // Spawn from `on_startup` so the reaper shares the running app's
+                // tokio runtime (matching the retention sweep below).
+                .on_startup(move |_state| {
+                    let store = room_store.clone();
+                    async move {
+                        rooms::spawn_room_reaper_loop(store);
+                        Ok(())
+                    }
                 });
         }
 

--- a/autumn-media-plugin/src/rooms.rs
+++ b/autumn-media-plugin/src/rooms.rs
@@ -788,6 +788,13 @@ const ROOM_REAPER_INTERVAL_SECONDS: u64 = 60;
 /// full 15 minutes (crashed / abandoned / never sent leave) ages out.
 const ROOM_IDLE_TTL_SECONDS: u64 = 900;
 
+/// Upper bound (10 years, in seconds) applied to the reaper idle-TTL before it
+/// is turned into a [`chrono::Duration`]. `chrono::Duration::seconds` panics on
+/// values that overflow its internal millisecond representation, so a hostile /
+/// fat-fingered `AUTUMN_MEDIA__ROOM_IDLE_TTL_SECONDS` is clamped here rather
+/// than crashing the reaper spawn.
+const MAX_REAPER_TTL_SECONDS: i64 = 315_360_000;
+
 /// Read a positive `u64` from `key`, falling back to `default` on
 /// unset / blank / unparseable / zero. Keeps the reaper tunable without
 /// threading a field through `MediaConfig` (a documented follow-up).
@@ -797,6 +804,20 @@ fn env_positive_u64(key: &str, default: u64) -> u64 {
         .and_then(|value| value.trim().parse::<u64>().ok())
         .filter(|&value| value > 0)
         .unwrap_or(default)
+}
+
+/// Clamp a raw idle-TTL seconds value into a chrono [`Duration`].
+///
+/// `chrono::Duration::seconds` panics on values that overflow its internal
+/// higher-precision (millisecond) representation, so a hostile / fat-fingered
+/// `AUTUMN_MEDIA__ROOM_IDLE_TTL_SECONDS` (up to `u64::MAX`) is clamped to
+/// [`MAX_REAPER_TTL_SECONDS`] rather than crashing the reaper spawn.
+fn clamp_reaper_ttl(idle_ttl_secs: u64) -> Duration {
+    Duration::seconds(
+        i64::try_from(idle_ttl_secs)
+            .unwrap_or(MAX_REAPER_TTL_SECONDS)
+            .min(MAX_REAPER_TTL_SECONDS),
+    )
 }
 
 /// Spawn the background idle-room / stale-participant reaper for `store`.
@@ -821,10 +842,7 @@ pub fn spawn_room_reaper_loop(store: Arc<dyn RoomStore>) {
     );
     let idle_ttl_secs =
         env_positive_u64("AUTUMN_MEDIA__ROOM_IDLE_TTL_SECONDS", ROOM_IDLE_TTL_SECONDS);
-    // `idle_ttl_secs` is a positive u64 ≤ a sane operator value, so the cast to
-    // the chrono `Duration` seconds (i64) never overflows in practice; clamp
-    // defensively rather than panicking.
-    let idle_ttl = Duration::seconds(i64::try_from(idle_ttl_secs).unwrap_or(i64::MAX));
+    let idle_ttl = clamp_reaper_ttl(idle_ttl_secs);
     tokio::spawn(async move {
         let mut ticker = tokio::time::interval(std::time::Duration::from_secs(interval_secs));
         ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
@@ -1224,9 +1242,10 @@ fn room_route(method: &str, path: String, handler: &str) -> RouteInfo {
 #[cfg(test)]
 mod tests {
     use super::{
-        InMemoryRoomStore, JoinRequest, LeaveRequest, ReapStats, Room, RoomError, RoomParticipant,
-        RoomService, RoomStore, SessionToken, bearer_token, room_participant_path,
-        room_route_infos, rooms_create, rooms_join, rooms_roster, validate_room_segment,
+        InMemoryRoomStore, JoinRequest, LeaveRequest, MAX_REAPER_TTL_SECONDS, ReapStats, Room,
+        RoomError, RoomParticipant, RoomService, RoomStore, SessionToken, bearer_token,
+        clamp_reaper_ttl, room_participant_path, room_route_infos, rooms_create, rooms_join,
+        rooms_roster, validate_room_segment,
     };
     use crate::config::MediaMtxConfig;
     use crate::transport::MediaUrls;
@@ -1251,6 +1270,21 @@ mod tests {
             Duration::seconds(300),
             6,
         )
+    }
+
+    // ── Reaper TTL clamp ─────────────────────────────────────────────────────
+
+    #[test]
+    fn reaper_ttl_clamps_overflowing_value_without_panicking() {
+        // A sane operator value passes through unchanged.
+        assert_eq!(clamp_reaper_ttl(900), Duration::seconds(900));
+        // A hostile / fat-fingered value that would overflow
+        // `chrono::Duration::seconds`'s internal millisecond representation is
+        // clamped to the 10-year maximum instead of panicking.
+        assert_eq!(
+            clamp_reaper_ttl(u64::MAX),
+            Duration::seconds(MAX_REAPER_TTL_SECONDS)
+        );
     }
 
     // ── Segment guard ────────────────────────────────────────────────────────

--- a/autumn-media-plugin/src/rooms.rs
+++ b/autumn-media-plugin/src/rooms.rs
@@ -39,8 +39,9 @@
 //! (a created-but-never-joined room is only reaped when its last participant
 //! leaves), [`InMemoryRoomStore`] caps the registry at [`MAX_ROOMS`] rooms and
 //! rejects further creation with [`RoomError::RegistryFull`] (mapped to a
-//! transient `503`). Empty/idle-room reaping remains recorded future work (see
-//! *Known limitations*) — the cap is a backstop, not a substitute for the host
+//! transient `503`). The background reaper ([`spawn_room_reaper_loop`]) also
+//! reclaims idle/created-never-joined rooms (see *Known limitations*), but the
+//! cap remains the hard backstop — neither is a substitute for the host
 //! auth/rate-limit layer.
 //!
 //! # Operator requirements
@@ -65,10 +66,24 @@
 //!
 //! # Known limitations
 //!
-//! - **No participant reaping**: a client that never sends leave holds its seat
-//!   until the process restarts — there is no automatic reaping of abandoned
-//!   participants or idle rooms. A stale-participant / idle-room reaper is
-//!   recorded future work.
+//! - **Best-effort participant reaping (no true liveness)**: an idle-room /
+//!   stale-participant reaper ([`spawn_room_reaper_loop`] →
+//!   [`RoomStore::reap_stale`]) reclaims seats and rooms that have gone quiet, so
+//!   a client that crashes or never sends leave no longer holds its seat until
+//!   process restart. It keys on `last_seen_at`, which is seeded at join and
+//!   refreshed **only** when the participant polls the member-gated roster — the
+//!   sole per-participant liveness signal this slice has (there is no heartbeat,
+//!   and `MediaMTX` does not verify the advisory token). This is an
+//!   *approximation*: a participant whose media is live but which has **stopped
+//!   polling the roster** for the whole idle TTL would be reaped from the store
+//!   even though it is connected. Reaping only removes the in-memory signaling
+//!   record (seat + advisory token); it does **not** tear down the participant's
+//!   live `MediaMTX` `WebRTC` path, so a wrongly-reaped participant keeps its
+//!   media flowing and can re-join — it simply stops appearing in peers' future
+//!   roster polls. A real client heartbeat (renewal-on-activity) or `MediaMTX`
+//!   token verification is the documented follow-up that would make this a true
+//!   liveness guarantee; the reaper is deliberately conservative (a generous
+//!   idle TTL, empty-room drops keyed on `created_at`) until then.
 //! - **Advisory token expiry**: `token_expires_at` is returned to the joiner but
 //!   is **not** enforced anywhere yet (`MediaMTX` does not verify these tokens),
 //!   so it never gates a lifecycle operation — a participant can always leave
@@ -302,6 +317,17 @@ struct RoomParticipant {
     /// must never gate a lifecycle operation (leave, roster auth). Verification
     /// is value-only (see [`verify_token`](Self::verify_token)).
     token_expires_at: DateTime<Utc>,
+    /// Liveness clock for the idle-participant reaper (see [`reap_stale`]).
+    ///
+    /// Seeded to `joined_at` and **refreshed to `now` every time this
+    /// participant is observed polling the member-gated roster** (see
+    /// [`RoomStore::roster`]) — the roster poll is the only per-participant
+    /// liveness signal this slice has (there is no heartbeat, and
+    /// `token_expires_at` is advisory). An actively-polling participant stays
+    /// fresh; one that has stopped polling ages out and is reclaimed. This is a
+    /// best-effort liveness *approximation*, not a guarantee — see the
+    /// module-level *Known limitations* note.
+    last_seen_at: DateTime<Utc>,
 }
 
 impl RoomParticipant {
@@ -396,6 +422,16 @@ pub struct JoinRecord {
     pub room: RoomSnapshot,
 }
 
+/// The outcome tallies of one [`reap_stale`](RoomStore::reap_stale) sweep.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct ReapStats {
+    /// Rooms dropped this sweep (emptied by reaping, or created-never-joined
+    /// rooms that lingered past the idle TTL).
+    pub rooms_reaped: usize,
+    /// Participants evicted this sweep (idle past the horizon).
+    pub participants_reaped: usize,
+}
+
 /// The pluggable room-state store — the swap seam for a shared/durable backend.
 ///
 /// Every method keys on the `(namespace, room_id)` pair and **fails closed**: a
@@ -475,6 +511,22 @@ pub trait RoomStore: Send + Sync {
         room_id: &str,
         auth_token: &str,
     ) -> Result<RoomSnapshot, RoomError>;
+
+    /// Reclaim stale participants and idle rooms, returning what was reaped.
+    ///
+    /// Walks every room and evicts each participant whose liveness clock
+    /// (`last_seen_at` — seeded at join, refreshed on every member roster poll)
+    /// is older than `idle_ttl`; a room emptied by that eviction — or an empty
+    /// created-never-joined room older than `idle_ttl` — is dropped. `now` is
+    /// **injected** (never the wall clock) so the sweep is deterministically
+    /// testable. Reaping keys strictly on the `(namespace, room_id)` map and
+    /// never moves state across namespaces (fail-closed tenant isolation).
+    ///
+    /// This is a legitimate store concern (the store owns the seat lifecycle),
+    /// so it lives on the trait seam: a future shared/durable [`RoomStore`] must
+    /// implement its own equivalent reclamation. It is intentionally synchronous
+    /// to match the rest of the trait.
+    fn reap_stale(&self, now: DateTime<Utc>, idle_ttl: Duration) -> ReapStats;
 }
 
 /// Capacity backstop on the number of rooms an [`InMemoryRoomStore`] holds.
@@ -607,6 +659,7 @@ impl RoomStore for InMemoryRoomStore {
             joined_at: now,
             token: token.clone(),
             token_expires_at: now + token_ttl,
+            last_seen_at: now,
         };
         // The stored record is the single source of truth for the advisory
         // expiry surfaced in the join response.
@@ -656,24 +709,137 @@ impl RoomStore for InMemoryRoomStore {
         room_id: &str,
         auth_token: &str,
     ) -> Result<RoomSnapshot, RoomError> {
-        let rooms = self.rooms.read().expect("room store lock poisoned");
+        // A write lock (not a shared read) because a successful member read
+        // doubles as the liveness signal: it refreshes the matching
+        // participant's `last_seen_at`, so an actively-polling participant is
+        // never reclaimed by the idle reaper. Contention is negligible (≤ 6
+        // seats per room), so serializing roster reads costs nothing here.
+        let mut rooms = self.rooms.write().expect("room store lock poisoned");
         let room = rooms
-            .get(&(namespace.to_owned(), room_id.to_owned()))
+            .get_mut(&(namespace.to_owned(), room_id.to_owned()))
             .ok_or(RoomError::RoomNotFound)?;
         // Member-gate, fail-closed: a caller whose token matches no current
         // member gets the same `RoomNotFound` as a nonexistent room, so a
-        // non-member cannot probe room existence or their own membership.
-        if !room
-            .participants
-            .values()
-            .any(|participant| participant.verify_token(auth_token))
-        {
+        // non-member cannot probe room existence or their own membership. On a
+        // match, touch that member's liveness clock (see `reap_stale`).
+        let now = Utc::now();
+        let mut is_member = false;
+        for participant in room.participants.values_mut() {
+            if participant.verify_token(auth_token) {
+                participant.last_seen_at = now;
+                is_member = true;
+                break;
+            }
+        }
+        if !is_member {
             return Err(RoomError::RoomNotFound);
         }
         let snapshot = room.snapshot();
         drop(rooms);
         Ok(snapshot)
     }
+
+    fn reap_stale(&self, now: DateTime<Utc>, idle_ttl: Duration) -> ReapStats {
+        let mut stats = ReapStats::default();
+        let mut rooms = self.rooms.write().expect("room store lock poisoned");
+        // `retain` keys strictly on the `(namespace, room_id)` map and mutates
+        // each room in place, so state never moves between namespaces —
+        // tenant isolation is preserved by construction.
+        rooms.retain(|_key, room| {
+            let before = room.participants.len();
+            // Evict any participant idle past the horizon (last observed —
+            // via join or a roster poll — more than `idle_ttl` ago).
+            room.participants.retain(|_id, participant| {
+                now.signed_duration_since(participant.last_seen_at) < idle_ttl
+            });
+            let reaped = before - room.participants.len();
+            stats.participants_reaped += reaped;
+            if room.participants.is_empty() {
+                // Drop the room when it (a) just emptied via reaping, or (b) is
+                // a created-never-joined room that has lingered past the idle
+                // TTL. Gating (b) on `created_at` age avoids reaping a room in
+                // the brief create→first-join window. Dropping an empty room can
+                // never harm a live participant.
+                let drop_room =
+                    reaped > 0 || now.signed_duration_since(room.created_at) >= idle_ttl;
+                if drop_room {
+                    stats.rooms_reaped += 1;
+                    return false;
+                }
+            }
+            true
+        });
+        stats
+    }
+}
+
+// ── Idle-room / stale-participant reaper loop ─────────────────────────────────
+
+/// Default seconds between reaper sweeps.
+const ROOM_REAPER_INTERVAL_SECONDS: u64 = 60;
+
+/// Default participant idle TTL (and empty-room grace), in seconds.
+///
+/// 15 minutes — deliberately generous. The default room token TTL is only 300s
+/// (5 min), and a live client re-polls the member-gated roster every few seconds
+/// for peer discovery, refreshing its `last_seen_at`; 15 min is 3× the token TTL
+/// and far longer than any reasonable poll cadence, so an actively-connected
+/// participant is never reclaimed — only a client that has stopped polling for a
+/// full 15 minutes (crashed / abandoned / never sent leave) ages out.
+const ROOM_IDLE_TTL_SECONDS: u64 = 900;
+
+/// Read a positive `u64` from `key`, falling back to `default` on
+/// unset / blank / unparseable / zero. Keeps the reaper tunable without
+/// threading a field through `MediaConfig` (a documented follow-up).
+fn env_positive_u64(key: &str, default: u64) -> u64 {
+    std::env::var(key)
+        .ok()
+        .and_then(|value| value.trim().parse::<u64>().ok())
+        .filter(|&value| value > 0)
+        .unwrap_or(default)
+}
+
+/// Spawn the background idle-room / stale-participant reaper for `store`.
+///
+/// Ticks every `AUTUMN_MEDIA__ROOM_REAPER_INTERVAL_SECONDS` (default
+/// [`ROOM_REAPER_INTERVAL_SECONDS`], 60s) and reclaims participants/rooms idle
+/// past `AUTUMN_MEDIA__ROOM_IDLE_TTL_SECONDS` (default [`ROOM_IDLE_TTL_SECONDS`],
+/// 900s). Both env overrides fall back to their default on an unset / blank /
+/// unparseable / zero value. Mirrors
+/// [`spawn_retention_sweep_loop`](crate::retention::spawn_retention_sweep_loop):
+/// `tokio::spawn` + `tokio::time::interval` with `MissedTickBehavior::Skip`, one
+/// independent tick each period, never panics. The clock is read per tick and
+/// handed to the deterministically-testable [`RoomStore::reap_stale`].
+///
+/// Promoting the interval / idle-TTL knobs to `MediaConfig` is a documented
+/// follow-up; they live as env-overridable constants here to keep this hardening
+/// slice out of the config-load surface.
+pub fn spawn_room_reaper_loop(store: Arc<dyn RoomStore>) {
+    let interval_secs = env_positive_u64(
+        "AUTUMN_MEDIA__ROOM_REAPER_INTERVAL_SECONDS",
+        ROOM_REAPER_INTERVAL_SECONDS,
+    );
+    let idle_ttl_secs =
+        env_positive_u64("AUTUMN_MEDIA__ROOM_IDLE_TTL_SECONDS", ROOM_IDLE_TTL_SECONDS);
+    // `idle_ttl_secs` is a positive u64 ≤ a sane operator value, so the cast to
+    // the chrono `Duration` seconds (i64) never overflows in practice; clamp
+    // defensively rather than panicking.
+    let idle_ttl = Duration::seconds(i64::try_from(idle_ttl_secs).unwrap_or(i64::MAX));
+    tokio::spawn(async move {
+        let mut ticker = tokio::time::interval(std::time::Duration::from_secs(interval_secs));
+        ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+        loop {
+            ticker.tick().await;
+            let stats = store.reap_stale(Utc::now(), idle_ttl);
+            if stats.rooms_reaped > 0 || stats.participants_reaped > 0 {
+                tracing::info!(
+                    rooms_reaped = stats.rooms_reaped,
+                    participants_reaped = stats.participants_reaped,
+                    "media rooms: reaped stale participants / idle rooms"
+                );
+            }
+        }
+    });
 }
 
 // ── Service (URL composition + AppState extension) ────────────────────────────
@@ -1058,16 +1224,17 @@ fn room_route(method: &str, path: String, handler: &str) -> RouteInfo {
 #[cfg(test)]
 mod tests {
     use super::{
-        InMemoryRoomStore, JoinRequest, LeaveRequest, RoomError, RoomService, RoomStore,
-        SessionToken, bearer_token, room_participant_path, room_route_infos, rooms_create,
-        rooms_join, rooms_roster, validate_room_segment,
+        InMemoryRoomStore, JoinRequest, LeaveRequest, ReapStats, Room, RoomError, RoomParticipant,
+        RoomService, RoomStore, SessionToken, bearer_token, room_participant_path,
+        room_route_infos, rooms_create, rooms_join, rooms_roster, validate_room_segment,
     };
     use crate::config::MediaMtxConfig;
     use crate::transport::MediaUrls;
     use autumn_web::AppState;
     use autumn_web::reexports::axum::extract::{Path, State};
     use autumn_web::reexports::http::HeaderMap;
-    use chrono::{Duration, Utc};
+    use chrono::{DateTime, Duration, Utc};
+    use std::collections::HashMap;
     use std::sync::Arc;
 
     // ── Fixtures ─────────────────────────────────────────────────────────────
@@ -1359,6 +1526,7 @@ mod tests {
             joined_at: now,
             token: SessionToken("secret-token-value".to_owned()),
             token_expires_at: now - Duration::seconds(1),
+            last_seen_at: now,
         };
         assert!(
             participant.verify_token("secret-token-value"),
@@ -1634,5 +1802,245 @@ mod tests {
     /// Wrap a value in an axum `Json` extractor for direct handler calls.
     fn axum_json<T>(value: T) -> autumn_web::reexports::axum::Json<T> {
         autumn_web::reexports::axum::Json(value)
+    }
+
+    // ── Idle-room / stale-participant reaper ─────────────────────────────────
+    //
+    // The reaper keys on each participant's `last_seen_at` and each room's
+    // `created_at` against an INJECTED `now`, so these tests build store state
+    // with explicit timestamps (mirroring how `retention.rs` controls file
+    // mtimes) and never touch the wall clock in the assertion — fully
+    // deterministic, no sleeps. Constructing the private `Room` /
+    // `RoomParticipant` from the child test module follows the existing
+    // `participant_verify_token_*` test's precedent.
+
+    /// Insert a room with explicit `created_at` and `(participant_id, token,
+    /// last_seen_at)` seats directly into the store registry.
+    fn seed_room(
+        store: &InMemoryRoomStore,
+        namespace: &str,
+        room_id: &str,
+        created_at: DateTime<Utc>,
+        seats: &[(&str, &str, DateTime<Utc>)],
+    ) {
+        let mut participants = HashMap::new();
+        for (id, token, last_seen_at) in seats {
+            participants.insert(
+                (*id).to_owned(),
+                RoomParticipant {
+                    id: (*id).to_owned(),
+                    display_name: None,
+                    joined_at: *last_seen_at,
+                    token: SessionToken((*token).to_owned()),
+                    token_expires_at: *last_seen_at,
+                    last_seen_at: *last_seen_at,
+                },
+            );
+        }
+        store.rooms.write().unwrap().insert(
+            (namespace.to_owned(), room_id.to_owned()),
+            Room {
+                id: room_id.to_owned(),
+                namespace: namespace.to_owned(),
+                max_participants: 6,
+                created_at,
+                participants,
+            },
+        );
+    }
+
+    /// The current participant count for a room, or `None` if the room is gone.
+    fn seat_count(store: &InMemoryRoomStore, namespace: &str, room_id: &str) -> Option<usize> {
+        store
+            .rooms
+            .read()
+            .unwrap()
+            .get(&(namespace.to_owned(), room_id.to_owned()))
+            .map(|room| room.participants.len())
+    }
+
+    #[test]
+    fn reap_evicts_stale_participant_but_keeps_a_fresh_one_and_the_room() {
+        // (a) + (b): a participant past the horizon is evicted while a fresh
+        // co-tenant is kept, and the room (still non-empty) survives.
+        let store = InMemoryRoomStore::new(6);
+        let now = Utc::now();
+        let ttl = Duration::minutes(30);
+        seed_room(
+            &store,
+            "",
+            "room-1",
+            now - Duration::hours(2),
+            &[
+                ("stale", "tok-stale", now - Duration::hours(1)),
+                ("fresh", "tok-fresh", now - Duration::minutes(5)),
+            ],
+        );
+
+        let stats = store.reap_stale(now, ttl);
+
+        assert_eq!(stats.participants_reaped, 1);
+        assert_eq!(stats.rooms_reaped, 0);
+        assert_eq!(seat_count(&store, "", "room-1"), Some(1));
+        // The kept seat is the fresh one.
+        assert!(store.roster("", "room-1", "tok-fresh").is_ok());
+        assert!(matches!(
+            store.roster("", "room-1", "tok-stale"),
+            Err(RoomError::RoomNotFound)
+        ));
+    }
+
+    #[test]
+    fn reap_drops_a_room_emptied_by_reaping() {
+        // (c): a room whose only participant ages out is dropped.
+        let store = InMemoryRoomStore::new(6);
+        let now = Utc::now();
+        seed_room(
+            &store,
+            "",
+            "room-1",
+            now - Duration::hours(2),
+            &[("stale", "tok", now - Duration::hours(1))],
+        );
+
+        let stats = store.reap_stale(now, Duration::minutes(30));
+
+        assert_eq!(stats.participants_reaped, 1);
+        assert_eq!(stats.rooms_reaped, 1);
+        assert_eq!(
+            seat_count(&store, "", "room-1"),
+            None,
+            "emptied room dropped"
+        );
+    }
+
+    #[test]
+    fn reap_drops_created_never_joined_room_past_ttl_but_keeps_a_fresh_empty_room() {
+        // (d): an empty (created-never-joined) room lingering past the idle TTL
+        // is dropped; a freshly-created empty room within the TTL is kept (so a
+        // room in the create→first-join window is never reaped out from under a
+        // joiner).
+        let store = InMemoryRoomStore::new(6);
+        let now = Utc::now();
+        let ttl = Duration::minutes(30);
+        seed_room(&store, "", "old-empty", now - Duration::hours(1), &[]);
+        seed_room(&store, "", "new-empty", now - Duration::minutes(5), &[]);
+
+        let stats = store.reap_stale(now, ttl);
+
+        assert_eq!(stats.rooms_reaped, 1);
+        assert_eq!(stats.participants_reaped, 0);
+        assert_eq!(
+            seat_count(&store, "", "old-empty"),
+            None,
+            "lingering empty room dropped"
+        );
+        assert_eq!(
+            seat_count(&store, "", "new-empty"),
+            Some(0),
+            "a just-created empty room within the TTL survives"
+        );
+    }
+
+    #[test]
+    fn reap_never_crosses_namespaces() {
+        // (e): reaping a stale room in namespace "a" leaves an identically-named
+        // fresh room in namespace "b" untouched — tenant isolation holds.
+        let store = InMemoryRoomStore::new(6);
+        let now = Utc::now();
+        let ttl = Duration::minutes(30);
+        seed_room(
+            &store,
+            "a",
+            "shared-id",
+            now - Duration::hours(2),
+            &[("stale", "tok-a", now - Duration::hours(1))],
+        );
+        seed_room(
+            &store,
+            "b",
+            "shared-id",
+            now - Duration::minutes(1),
+            &[("fresh", "tok-b", now - Duration::minutes(1))],
+        );
+
+        let stats = store.reap_stale(now, ttl);
+
+        assert_eq!(stats.rooms_reaped, 1);
+        assert_eq!(stats.participants_reaped, 1);
+        assert_eq!(
+            seat_count(&store, "a", "shared-id"),
+            None,
+            "ns a room reaped"
+        );
+        assert_eq!(
+            seat_count(&store, "b", "shared-id"),
+            Some(1),
+            "same room_id in ns b is untouched"
+        );
+    }
+
+    #[test]
+    fn reap_on_a_clean_store_is_a_zero_count_no_op() {
+        // (f): nothing to reap → default (all-zero) stats, no state change.
+        let store = InMemoryRoomStore::new(6);
+        let now = Utc::now();
+        seed_room(
+            &store,
+            "",
+            "room-1",
+            now - Duration::minutes(1),
+            &[("fresh", "tok", now - Duration::minutes(1))],
+        );
+
+        let stats = store.reap_stale(now, Duration::minutes(30));
+
+        assert_eq!(stats, ReapStats::default());
+        assert_eq!(seat_count(&store, "", "room-1"), Some(1));
+
+        // And a truly empty store is likewise a no-op.
+        let empty = InMemoryRoomStore::new(6);
+        assert_eq!(
+            empty.reap_stale(Utc::now(), Duration::minutes(30)),
+            ReapStats::default()
+        );
+    }
+
+    #[test]
+    fn roster_poll_refreshes_last_seen_so_an_active_participant_survives_a_sweep() {
+        // Liveness touch: a participant that would otherwise be reaped survives
+        // because it polled the member-gated roster. Both seats start stale
+        // (last_seen an hour ago); polling the roster with A's token refreshes
+        // A's `last_seen_at` to *now*, so a reap at *now* keeps A and evicts B.
+        let store = InMemoryRoomStore::new(6);
+        let stale = Utc::now() - Duration::hours(1);
+        seed_room(
+            &store,
+            "",
+            "room-1",
+            Utc::now() - Duration::hours(2),
+            &[("active", "tok-a", stale), ("idle", "tok-b", stale)],
+        );
+
+        // A polls the roster — this is the liveness signal.
+        assert!(store.roster("", "room-1", "tok-a").is_ok());
+
+        // Reap as of now with a 30-minute TTL: A was just touched (fresh), B is
+        // still an hour idle (stale).
+        let stats = store.reap_stale(Utc::now(), Duration::minutes(30));
+
+        assert_eq!(
+            stats.participants_reaped, 1,
+            "only the un-polled seat is reaped"
+        );
+        assert_eq!(stats.rooms_reaped, 0);
+        assert!(
+            store.roster("", "room-1", "tok-a").is_ok(),
+            "the actively-polling participant survived the sweep"
+        );
+        assert!(matches!(
+            store.roster("", "room-1", "tok-b"),
+            Err(RoomError::RoomNotFound)
+        ));
     }
 }

--- a/autumn-media-plugin/src/storage.rs
+++ b/autumn-media-plugin/src/storage.rs
@@ -147,7 +147,9 @@ impl MediaStorage {
     /// resolution — no generic `auto` default; the Tigris `auto` region is set
     /// by the `from_arroyo_env` shim); an unset S3 public base is derived from
     /// the bucket + key prefix via the Tigris convention
-    /// ([`default_tigris_public_base`]); an unset local public base becomes
+    /// ([`default_tigris_public_base`]) **only for a Tigris endpoint** — a
+    /// generic (non-Tigris) S3 backend with no explicit public base is a
+    /// configuration error (see below); an unset local public base becomes
     /// `/media`. An unset S3 endpoint stays `None` (the SDK default) — no Tigris
     /// endpoint is hard-coded generically here (the `from_arroyo_env` shim is
     /// where the Tigris endpoint default lives).
@@ -155,8 +157,10 @@ impl MediaStorage {
     /// # Errors
     ///
     /// Returns [`MediaError::MissingBucket`] when the S3 backend is selected
-    /// without a bucket, and [`MediaError::PartialS3Credentials`] when exactly
-    /// one of the access-key / secret-key pair is set.
+    /// without a bucket, [`MediaError::PartialS3Credentials`] when exactly one
+    /// of the access-key / secret-key pair is set, and
+    /// [`MediaError::MissingPublicBaseUrl`] when a generic (non-Tigris) S3
+    /// backend is selected without an explicit `public_base_url`.
     pub fn from_config(cfg: &MediaStorageConfig) -> Result<Self, MediaError> {
         use crate::config::MediaStorageBackend;
 
@@ -188,14 +192,30 @@ impl MediaStorage {
                 // shim, not this generic path.
                 let region = non_empty(cfg.region.as_deref()).map(ToOwned::to_owned);
                 let key_prefix = cfg.key_prefix.trim_matches('/').to_owned();
-                let public_base_url = non_empty(cfg.public_base_url.as_deref()).map_or_else(
-                    || default_tigris_public_base(&bucket, &key_prefix),
-                    ToOwned::to_owned,
-                );
+                let endpoint_url = non_empty(cfg.endpoint_url.as_deref()).map(ToOwned::to_owned);
+
+                // Resolve the public base URL. An explicit value always wins.
+                // Without one, the `https://{bucket}.t3.tigrisfiles.io/{prefix}`
+                // Tigris convention ([`default_tigris_public_base`]) is applied
+                // ONLY for a Tigris endpoint (the arroyo/Tigris-compat path,
+                // whose `from_arroyo_env` shim sets the endpoint to
+                // `https://t3.storage.dev`). A generic (non-Tigris) S3 backend —
+                // AWS/R2/MinIO, or one on the SDK default endpoint — must set
+                // `public_base_url` explicitly: deriving a public URL from an
+                // arbitrary private S3 endpoint is unreliable, so fail fast with
+                // an actionable error instead of advertising a wrong
+                // `tigrisfiles.io` URL.
+                let public_base_url = match non_empty(cfg.public_base_url.as_deref()) {
+                    Some(explicit) => explicit.to_owned(),
+                    None if is_tigris_endpoint(endpoint_url.as_deref()) => {
+                        default_tigris_public_base(&bucket, &key_prefix)
+                    }
+                    None => return Err(MediaError::MissingPublicBaseUrl { bucket }),
+                };
 
                 Ok(Self::S3(S3MediaStorage {
                     bucket,
-                    endpoint_url: non_empty(cfg.endpoint_url.as_deref()).map(ToOwned::to_owned),
+                    endpoint_url,
                     region,
                     access_key_id: access_key_id.unwrap_or_default().to_owned(),
                     secret_access_key: secret_access_key.unwrap_or_default().to_owned(),
@@ -561,6 +581,50 @@ pub fn default_tigris_public_base(bucket: &str, key_prefix: &str) -> String {
     )
 }
 
+/// Whether an S3 endpoint URL points at Tigris — the only S3 target for which
+/// the `https://{bucket}.t3.tigrisfiles.io/{prefix}` public-base convention
+/// ([`default_tigris_public_base`]) is correct.
+///
+/// The arroyo/Tigris compatibility path (`MediaConfig::from_arroyo_env`) sets
+/// the S3 endpoint to `https://t3.storage.dev`, and Tigris public buckets live
+/// under `*.tigrisfiles.io`; both host families are recognized. A generic S3
+/// backend (AWS, Cloudflare R2, `MinIO`, …) — or an S3 backend with no endpoint
+/// at all (the AWS SDK default) — is not Tigris, so the Tigris public-base
+/// default must not be applied to it.
+fn is_tigris_endpoint(endpoint_url: Option<&str>) -> bool {
+    let Some(endpoint) = endpoint_url else {
+        return false;
+    };
+    let host = endpoint_host(endpoint);
+    host == "t3.storage.dev"
+        || host.ends_with(".t3.storage.dev")
+        || host == "tigrisfiles.io"
+        || host.ends_with(".tigrisfiles.io")
+}
+
+/// Extract the lowercased host from a URL-ish string for [`is_tigris_endpoint`]:
+/// scheme (`…://`), any userinfo (`user@`), a trailing `:port`, and the path /
+/// query / fragment are all stripped. Best-effort — a value with no recognizable
+/// host yields an empty string (which is never Tigris).
+fn endpoint_host(endpoint: &str) -> String {
+    let after_scheme = endpoint
+        .split_once("://")
+        .map_or(endpoint, |(_, rest)| rest);
+    let authority = after_scheme
+        .split(['/', '?', '#'])
+        .next()
+        .unwrap_or_default();
+    let host_port = authority
+        .rsplit_once('@')
+        .map_or(authority, |(_, host)| host);
+    host_port
+        .split(':')
+        .next()
+        .unwrap_or_default()
+        .trim()
+        .to_ascii_lowercase()
+}
+
 /// Join an object-key prefix and a key, slash-trimming both. An empty prefix
 /// yields the slash-trimmed key alone.
 #[must_use]
@@ -681,11 +745,16 @@ mod tests {
     use crate::config::{MediaStorageBackend, MediaStorageConfig};
 
     fn s3_config(bucket: Option<&str>) -> MediaStorageConfig {
+        // A valid *generic* S3 config: it carries an explicit `public_base_url`
+        // so `from_config` never needs (and never applies) the Tigris fallback.
+        // Tests that specifically exercise the Tigris public-base fallback clear
+        // this and set a Tigris endpoint instead.
         MediaStorageConfig {
             backend: MediaStorageBackend::S3,
             bucket: bucket.map(ToOwned::to_owned),
             access_key_id: Some("AKIA".to_owned()),
             secret_access_key: Some("secret".to_owned()),
+            public_base_url: Some("https://cdn.example.com".to_owned()),
             ..MediaStorageConfig::default()
         }
     }
@@ -752,6 +821,50 @@ mod tests {
             default_tigris_public_base("my-bucket", ""),
             "https://my-bucket.t3.tigrisfiles.io"
         );
+    }
+
+    // ── is_tigris_endpoint / endpoint_host ───────────────────────────────────
+
+    #[test]
+    fn is_tigris_endpoint_recognizes_tigris_hosts() {
+        // The endpoint the arroyo/Tigris-compat shim sets.
+        assert!(is_tigris_endpoint(Some("https://t3.storage.dev")));
+        // Case-insensitive, port and path stripped.
+        assert!(is_tigris_endpoint(Some("HTTPS://T3.Storage.Dev:443/")));
+        // Tigris public bucket host family.
+        assert!(is_tigris_endpoint(Some(
+            "https://my-bucket.t3.tigrisfiles.io"
+        )));
+        assert!(is_tigris_endpoint(Some("https://tigrisfiles.io")));
+    }
+
+    #[test]
+    fn is_tigris_endpoint_rejects_generic_and_absent() {
+        // No endpoint (SDK default) is not Tigris.
+        assert!(!is_tigris_endpoint(None));
+        // Generic S3 / R2 / MinIO endpoints are not Tigris.
+        assert!(!is_tigris_endpoint(Some(
+            "https://s3.us-east-1.amazonaws.com"
+        )));
+        assert!(!is_tigris_endpoint(Some(
+            "https://abc123.r2.cloudflarestorage.com"
+        )));
+        assert!(!is_tigris_endpoint(Some("http://127.0.0.1:9000")));
+        // A look-alike host must not be mistaken for Tigris.
+        assert!(!is_tigris_endpoint(Some(
+            "https://tigrisfiles.io.evil.example.com"
+        )));
+        assert!(!is_tigris_endpoint(Some("https://nottigrisfiles.io")));
+    }
+
+    #[test]
+    fn endpoint_host_strips_scheme_userinfo_port_and_path() {
+        assert_eq!(endpoint_host("https://t3.storage.dev"), "t3.storage.dev");
+        assert_eq!(
+            endpoint_host("https://user@t3.storage.dev:443/path?q=1#f"),
+            "t3.storage.dev"
+        );
+        assert_eq!(endpoint_host("T3.STORAGE.DEV"), "t3.storage.dev");
     }
 
     // ── object_key ───────────────────────────────────────────────────────────
@@ -1179,16 +1292,26 @@ mod tests {
 
     #[test]
     fn from_config_s3_with_bucket_no_region_and_tigris_base() {
-        let storage = MediaStorage::from_config(&s3_config(Some("my-bucket"))).unwrap();
+        // The Tigris/arroyo-compat path: a Tigris endpoint and no explicit
+        // public base → the `tigrisfiles.io` fallback is applied (unchanged
+        // behavior). The fallback is gated on the endpoint being Tigris.
+        let mut cfg = s3_config(Some("my-bucket"));
+        cfg.public_base_url = None;
+        cfg.endpoint_url = Some("https://t3.storage.dev".to_owned());
+        let storage = MediaStorage::from_config(&cfg).unwrap();
         match storage {
             MediaStorage::S3(config) => {
                 assert_eq!(config.bucket, "my-bucket");
                 // blank region stays None on the generic path (ambient-resolved);
                 // no `auto` default here — that is Tigris/arroyo-only.
                 assert_eq!(config.region, None);
-                // unset endpoint stays None (SDK default)
-                assert_eq!(config.endpoint_url, None);
-                // unset public base → tigris fallback using the "media" prefix
+                // the Tigris endpoint is threaded through verbatim
+                assert_eq!(
+                    config.endpoint_url.as_deref(),
+                    Some("https://t3.storage.dev")
+                );
+                // unset public base + Tigris endpoint → tigris fallback using the
+                // "media" prefix
                 assert_eq!(
                     config.public_base_url,
                     "https://my-bucket.t3.tigrisfiles.io/media"
@@ -1196,6 +1319,77 @@ mod tests {
             }
             MediaStorage::Local { .. } => panic!("expected s3 backend"),
         }
+    }
+
+    #[test]
+    fn from_config_s3_tigris_public_host_endpoint_also_defaults() {
+        // A `*.tigrisfiles.io` endpoint is likewise recognized as Tigris, so the
+        // public-base fallback applies with no explicit base.
+        let mut cfg = s3_config(Some("my-bucket"));
+        cfg.public_base_url = None;
+        cfg.endpoint_url = Some("https://my-bucket.t3.tigrisfiles.io".to_owned());
+        let MediaStorage::S3(config) = MediaStorage::from_config(&cfg).unwrap() else {
+            panic!("expected s3 backend");
+        };
+        assert_eq!(
+            config.public_base_url,
+            "https://my-bucket.t3.tigrisfiles.io/media"
+        );
+    }
+
+    #[test]
+    fn from_config_s3_generic_endpoint_no_public_base_errors() {
+        // A generic (non-Tigris) S3 endpoint without an explicit public base is
+        // a configuration error — never a wrong `tigrisfiles.io` URL.
+        let mut cfg = s3_config(Some("my-bucket"));
+        cfg.public_base_url = None;
+        cfg.endpoint_url = Some("https://s3.us-east-1.amazonaws.com".to_owned());
+        let error = MediaStorage::from_config(&cfg).unwrap_err();
+        assert!(
+            matches!(error, MediaError::MissingPublicBaseUrl { .. }),
+            "expected MissingPublicBaseUrl, got {error:?}"
+        );
+        assert!(
+            error.to_string().contains("public_base_url"),
+            "error must name public_base_url: {error}"
+        );
+    }
+
+    #[test]
+    fn from_config_s3_no_endpoint_no_public_base_errors() {
+        // The AWS SDK default endpoint (no endpoint configured) is generic too:
+        // without an explicit public base it errors rather than falling back to
+        // the Tigris convention.
+        let mut cfg = s3_config(Some("my-bucket"));
+        cfg.public_base_url = None;
+        cfg.endpoint_url = None;
+        let error = MediaStorage::from_config(&cfg).unwrap_err();
+        assert!(
+            matches!(error, MediaError::MissingPublicBaseUrl { .. }),
+            "expected MissingPublicBaseUrl, got {error:?}"
+        );
+        assert!(
+            error.to_string().contains("public_base_url"),
+            "error must name public_base_url: {error}"
+        );
+    }
+
+    #[test]
+    fn from_config_s3_generic_endpoint_with_public_base_uses_it_verbatim() {
+        // A generic S3 backend WITH an explicit public base uses it verbatim —
+        // never a derived tigris URL.
+        let mut cfg = s3_config(Some("my-bucket"));
+        cfg.endpoint_url = Some("https://s3.us-east-1.amazonaws.com".to_owned());
+        cfg.public_base_url = Some("https://cdn.example.com/assets".to_owned());
+        let MediaStorage::S3(config) = MediaStorage::from_config(&cfg).unwrap() else {
+            panic!("expected s3 backend");
+        };
+        assert_eq!(config.public_base_url, "https://cdn.example.com/assets");
+        assert!(
+            !config.public_base_url.contains("tigrisfiles.io"),
+            "generic backend must not derive a tigris URL: {}",
+            config.public_base_url
+        );
     }
 
     #[test]

--- a/autumn-media-plugin/src/workflows.rs
+++ b/autumn-media-plugin/src/workflows.rs
@@ -610,9 +610,23 @@ async fn run_room_composite(
     // function of the resulting flags. See `probe_has_audio` for the fail-safe
     // policy (a probe failure degrades to "no audio", never a crash).
     let ffprobe_bin = resolve_ffprobe_bin(ffmpeg_bin);
-    let mut audio_present = Vec::with_capacity(source_paths.len());
-    for path in &source_paths {
-        audio_present.push(probe_has_audio(&ffprobe_bin, path).await);
+    // Probe every input concurrently rather than serializing one `ffprobe`
+    // spawn after another. The probes are independent async I/O; awaiting the
+    // handles in spawn order preserves input order so `audio_present[i]` still
+    // aligns with `source_paths[i]`. `probe_has_audio` is itself fail-safe (a
+    // probe error yields `false`), and a task-join failure (e.g. a panic)
+    // degrades to `false` the same way, so a probe outage never aborts the job.
+    let probes: Vec<_> = source_paths
+        .iter()
+        .map(|path| {
+            let ffprobe_bin = ffprobe_bin.clone();
+            let path = path.clone();
+            tokio::spawn(async move { probe_has_audio(&ffprobe_bin, &path).await })
+        })
+        .collect();
+    let mut audio_present = Vec::with_capacity(probes.len());
+    for probe in probes {
+        audio_present.push(probe.await.unwrap_or(false));
     }
     let command = FfmpegRoomCompositeCommand::new(
         ffmpeg_bin,

--- a/autumn-media-plugin/src/workflows.rs
+++ b/autumn-media-plugin/src/workflows.rs
@@ -36,6 +36,7 @@ use crate::encode::{
     FfmpegHighlightCommand, FfmpegPosterCommand, FfmpegPreviewSpriteCommand,
     FfmpegRoomCompositeCommand, PREVIEW_CELL_HEIGHT, PREVIEW_CELL_WIDTH,
     PREVIEW_FRAME_INTERVAL_SECONDS, PREVIEW_SPRITE_COLUMNS, build_preview_webvtt,
+    validate_room_composite_input_count,
 };
 use crate::error::MediaError;
 use crate::sink::{MediaArtifact, MediaArtifactFile, MediaArtifactKind, MediaArtifactSinkExt};
@@ -603,6 +604,11 @@ async fn run_room_composite(
         workflow_id,
         source_id,
     } = args;
+    // Reject a malformed job (fewer than two / more than six source paths)
+    // against the same `2..=6` band `FfmpegRoomCompositeCommand::run()` enforces
+    // *before* spawning any `ffprobe`, so a bad queued job can never fan out one
+    // probe child process per supplied path only to be rejected afterwards.
+    validate_room_composite_input_count(source_paths.len())?;
     let (output_path, ephemeral) = staged_output(storage, &output_key, "mp4")?;
     // Detect, per input, whether it carries an audio stream so the composite
     // mixes only the inputs that actually have audio. Probing is async I/O and
@@ -846,8 +852,9 @@ mod tests {
         FinalizeRecordingJobArgs, MediaWorkflowDelegate, MediaWorkflowDelegateExt,
         MediaWorkflowRequest, MediaWorkflows, PreviewJobArgs, RoomCompositeJobArgs,
         ThumbnailJobArgs, TranscodeJobArgs, compose_room_recording, extract_thumbnail,
-        media_job_infos, persist_and_cleanup, staged_output,
+        media_job_infos, persist_and_cleanup, run_room_composite, staged_output,
     };
+    use crate::error::MediaError;
     use crate::sink::MediaArtifactSinkExt;
     use crate::sink::tests::CountingSink;
     use crate::storage::MediaStorage;
@@ -1155,6 +1162,29 @@ mod tests {
         assert!(result.is_err(), "missing sources must fail the job");
         assert_eq!(sink.failed.load(Ordering::SeqCst), 1);
         assert_eq!(sink.completed.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn room_composite_rejects_more_than_six_paths_before_probing() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let storage = local_storage(temp.path());
+        // Seven paths (over the 2..=6 mesh-room band). A bogus ffmpeg bin means
+        // its sibling `ffprobe` cannot resolve either, so if this reached the
+        // probe loop it would spawn seven child processes; the input-count guard
+        // must reject first and return the same `2..=6` cap error `run()` uses.
+        let sources: Vec<PathBuf> = (0..7)
+            .map(|i| temp.path().join(format!("missing-{i}.mp4")))
+            .collect();
+        let args = room_composite_args(sources);
+        let result = run_room_composite("/nonexistent/ffmpeg-bin", &storage, args).await;
+        assert!(
+            matches!(
+                result,
+                Err(MediaError::FfmpegSourceMissing { ref path })
+                    if path.contains("at most six")
+            ),
+            "a >6-path job must be rejected by the input-count cap before probing, got {result:?}"
+        );
     }
 
     #[test]

--- a/autumn-media-plugin/src/workflows.rs
+++ b/autumn-media-plugin/src/workflows.rs
@@ -604,7 +604,22 @@ async fn run_room_composite(
         source_id,
     } = args;
     let (output_path, ephemeral) = staged_output(storage, &output_key, "mp4")?;
-    let command = FfmpegRoomCompositeCommand::new(ffmpeg_bin, source_paths, output_path.clone());
+    // Detect, per input, whether it carries an audio stream so the composite
+    // mixes only the inputs that actually have audio. Probing is async I/O and
+    // lives here in the caller; `FfmpegRoomCompositeCommand::args()` stays a pure
+    // function of the resulting flags. See `probe_has_audio` for the fail-safe
+    // policy (a probe failure degrades to "no audio", never a crash).
+    let ffprobe_bin = resolve_ffprobe_bin(ffmpeg_bin);
+    let mut audio_present = Vec::with_capacity(source_paths.len());
+    for path in &source_paths {
+        audio_present.push(probe_has_audio(&ffprobe_bin, path).await);
+    }
+    let command = FfmpegRoomCompositeCommand::new(
+        ffmpeg_bin,
+        source_paths,
+        output_path.clone(),
+        audio_present,
+    );
     let bytes = run_blocking(move || command.run()).await?;
     let file = persist_and_cleanup(
         storage,
@@ -623,6 +638,58 @@ async fn run_room_composite(
         secondary: None,
         metadata: BTreeMap::new(),
     })
+}
+
+/// Resolve the `ffprobe` binary from the configured `ffmpeg` binary path.
+///
+/// Prefers a sibling `ffprobe` next to the configured `ffmpeg` (they ship
+/// together), i.e. the same directory with the file name swapped. When the
+/// `ffmpeg` path carries no directory component (a bare `ffmpeg` resolved via
+/// `PATH`) or the sibling does not exist, falls back to plain `ffprobe` on
+/// `PATH`.
+fn resolve_ffprobe_bin(ffmpeg_bin: &str) -> std::ffi::OsString {
+    let candidate = Path::new(ffmpeg_bin).with_file_name("ffprobe");
+    let has_dir = candidate
+        .parent()
+        .is_some_and(|parent| !parent.as_os_str().is_empty());
+    if has_dir && candidate.exists() {
+        candidate.into_os_string()
+    } else {
+        std::ffi::OsString::from("ffprobe")
+    }
+}
+
+/// Probe whether `path` carries at least one audio stream.
+///
+/// Runs `ffprobe -v error -select_streams a -show_entries stream=index -of
+/// csv=p=0 <file>` and treats non-empty stdout as "has audio".
+///
+/// **Fail-safe policy:** any probe failure (spawn error, non-zero exit, or a
+/// path with no audio) resolves to `false` ("assume no audio"). This is the
+/// only direction that **cannot crash the composite job**: a `false` merely
+/// drops that input from the `amix`, so at worst a probe outage yields a silent
+/// (but successful) grid. Returning `true` on failure would be unsafe — if the
+/// input truly had no audio, the filtergraph would reference a missing `[i:a]`
+/// stream and `FFmpeg` would fail, which is exactly the crash this replaces.
+async fn probe_has_audio(ffprobe_bin: &std::ffi::OsStr, path: &Path) -> bool {
+    let output = tokio::process::Command::new(ffprobe_bin)
+        .args([
+            "-v",
+            "error",
+            "-select_streams",
+            "a",
+            "-show_entries",
+            "stream=index",
+            "-of",
+            "csv=p=0",
+        ])
+        .arg(path)
+        .output()
+        .await;
+    match output {
+        Ok(out) if out.status.success() => !out.stdout.iter().all(u8::is_ascii_whitespace),
+        _ => false,
+    }
 }
 
 /// Run a blocking encode closure off the async runtime.


### PR DESCRIPTION
**Part of #1974.** Works through the autumn-media deferred-hardening backlog recorded on the epic (slice-1/2/6 deferred-item comments). Five items across four commits, all scoped to `autumn-media-plugin`.

## What changed

### 1. Video-only participants no longer crash the composited room recording
Before: if any participant in a mesh room published video-only (no audio track), the composited grid job (`compose_room_recording`) failed with a missing-stream error, because the FFmpeg filtergraph referenced every input's audio (`[i:a]` → `amix`). After: each input is probed with ffprobe for an audio stream, and `amix` mixes only the inputs that actually have audio (a silent video grid when none do). Per-participant recordings were already unaffected; this fixes only the composite output.
How: `FfmpegRoomCompositeCommand` gains an `audio_present: Vec<bool>` field; `args()` stays a pure, synchronous, no-I/O function of that data (the ffprobe I/O lives in the async `run_room_composite` caller), so the arg-builder contract stays honest. The all-video-only case omits `-map [aout]`/`-c:a aac` entirely. ffprobe failure fails safe to "no audio" (can only drop an input from the mix, never re-introduce the crash). Durable job-args wire format unchanged.

### 2. Stale participants and idle rooms are now reclaimed
Before: a client that crashed or never sent leave held its room seat until the room emptied; created-never-joined rooms lingered until process restart (`MAX_ROOMS` capped memory but nothing reclaimed it). After: a background reaper (60s cadence) evicts participants idle past a 15-minute TTL, drops rooms emptied by reaping, and drops created-never-joined idle rooms.
How: the roster poll already carries the caller's session token, so it is a real liveness signal — `RoomParticipant` gains `last_seen_at`, touched on every successful member roster poll; the reaper keys on idle age (15 min = 3× the 300s token TTL, far longer than the few-second poll cadence, so an actively-polling participant is never reclaimed). `reap_stale(now, idle_ttl)` takes an injected `now` (deterministic tests) and never crosses namespaces (fail-closed tenant isolation preserved). Cadence/TTL are `AUTUMN_MEDIA__ROOM_REAPER_INTERVAL_SECONDS` / `AUTUMN_MEDIA__ROOM_IDLE_TTL_SECONDS` env-overridable (no `config.rs`/`MediaConfig` change). Honest limitation, documented in code: a participant whose media is live but which has stopped polling the roster for a full 15 min could be reaped — but reaping only removes the in-memory signaling seat + advisory token, it does not tear down the live MediaMTX path, so a wrongly-reaped client keeps media flowing and can re-join. A real heartbeat / MediaMTX token verification is the documented follow-up.

### 3. FFmpeg child output is now bounded in memory
Before: the five `run()` methods used `Command::output()` and the async `run_with_deadline` used `wait_with_output()`, buffering all child stdout+stderr unbounded (only a stderr tail was surfaced). After: child pipes are streamed with capped reads — a fixed-capacity tail buffer retains only the last N bytes of stderr (reusing the existing `STDERR_TAIL_MAX_BYTES` cap) and stdout is drained-and-discarded — behind shared sync/async helpers. `check_exit` output is byte-identical to before.

### 4. Non-UTF-8 paths reach FFmpeg intact
Before: every builder converted paths via `display().to_string()`, replacing non-UTF-8 bytes with U+FFFD before they reached `Command`. After: the arg builders return `Vec<OsString>` and push raw `OsStr` path bytes; the concat-list writer emits raw path bytes (`OsStrExt::as_bytes` on Unix, quote-escaped byte-wise). Real paths are UTF-8 today (MediaMTX segments, slugified names), so this is correctness-hardening rather than a live bug fix.

### 5. Generic S3 backends no longer get a bogus Tigris public URL
Before: any S3 backend without `public_base_url` fell back to a `https://{bucket}.t3.tigrisfiles.io/...` URL — wrong for a generic AWS/R2/MinIO backend. After: the Tigris default is gated behind a Tigris-endpoint check (host is/ends-with `t3.storage.dev` / `tigrisfiles.io`, matching what the arroyo path sets); a generic S3 backend without an explicit `public_base_url` fails fast with an actionable error (new additive `MediaError::MissingPublicBaseUrl`). The arroyo/Tigris path is byte-for-byte unchanged (it always sets an explicit public base). `config.rs` untouched.

## Deferred / not in this PR (dispositions also posted on #1974)
- **Multi-process `RoomStore`**: still a documented design seam, not a bug. The trait is clean (single `Arc<dyn RoomStore>` consumer); enabling a redis/postgres impl needs async-ifying the trait + `RoomService` + handlers — a refactor best kept as its own PR. This PR adds a required `reap_stale` method to the trait, so a future external impl must implement its own reclamation (deliberate — no silent no-op default).
- Two `autumn-cli/src/deploy/media.rs` riders surfaced by the docs-lane audit (rtmp_port doc-comment; `deploy up` recordings_dir auto-create) are out of scope for a plugin PR and left for the deploy lane.

## Verification
`cargo fmt --check`, `clippy --all-targets -D warnings`, and `cargo test -p autumn-media-plugin` all pass on the branch. No version bump, no CHANGELOG/skills edits, no new deps, `config.rs`/plugin-registration untouched.

## Coordination notes
- A one-line `on_startup` spawn was added inside the existing `if enable_rooms { … }` block in `MediaPlugin::build`; #2061's `config_section("media")` seam merged cleanly alongside it (also a `#[allow(clippy::too_many_lines)]` on `build`).
- The roster read-lock became a write-lock (to touch `last_seen_at`); mesh rooms cap at 6, so contention is negligible.

## Review follow-ups (added after opening)
Convergence commits on top of the five items above (all locally green — fmt, clippy `--all-targets -D warnings`, `cargo test -p autumn-media-plugin`; per-thread replies on the PR):
- Reaper idle-TTL clamped against a `chrono::Duration::seconds` overflow panic; composite `ffprobe` probes now run concurrently (ordered `tokio::spawn`, no new dep) — `3bda028`.
- Composite input count validated against the `2..=6` cap before the `ffprobe` loop (shared `validate_room_composite_input_count`), so a malformed >6-path job can't fan out unbounded `ffprobe` processes — `3257d4d`.
- Merged latest `trunk-dev` (#2061's `config_section("media")` strict-config seam), reaper `on_startup` wiring re-integrated — `f254100`.
- Gated the room-config fail-fast on `enable_rooms` (new `room_config_boot_error`): a pre-existing (#2030) unconditional validation would abort boot for a broadcast-only plugin (`with_broadcast()` without `with_rooms()`) on an unused/invalid room setting; broadcast-only now boots through it while the rooms path keeps its fail-fast (tenant-isolation fail-closed preserved). Tested — `5b364b9`.

Declined (per coordinator): Codex's suggestion to also assert the generic-S3 `public_base_url` invariant in `MediaConfig::validate()` — the invariant is already enforced fail-fast in `MediaStorage::from_config`, and `validate()` lives in `config.rs`, the parallel config-registry lane's (#2061/#2063) surface. Tracked as a deferred follow-up on #1974.