### PR TITLE
fix(deploy): reboot-durability for existing hosts on upgrade (#2070)

### DIFF
--- a/autumn-cli/src/deploy.rs
+++ b/autumn-cli/src/deploy.rs
@@ -1697,6 +1697,56 @@ fn validate_public_port(public_port: u16) -> Result<(), String> {
     Ok(())
 }
 
+/// Refuse a **redeploy** whose new port band collides with the still-live slot's
+/// actual loopback port, BEFORE any op runs — so traffic stays up (#2071).
+///
+/// On a redeploy the operator may have changed `server.port` since the live
+/// release was deployed. The proxy binds `0.0.0.0:{public_port}` (covering
+/// `127.0.0.1:{public_port}`) and the candidate app slot binds
+/// `127.0.0.1:{candidate_port}`, while the still-live release is holding its own
+/// `127.0.0.1:{live_upstream_port}` (the persisted ACTUAL live-slot port). If the
+/// new public port or the new candidate port equals that live loopback port, the
+/// #2070 proxy restart-refresh or the `start-candidate` step fails to bind
+/// (`EADDRINUSE`) mid-cutover — taking public traffic down with no auto-recovery.
+///
+/// This guard runs after `live_upstream_port` is resolved and before any cutover
+/// op executes: on a genuine collision it returns an error so **nothing is run**
+/// and the live release keeps serving. It is intentionally narrow — it refuses
+/// ONLY the two band members that can actually collide (`public_port` and
+/// `candidate_port` vs `live_upstream_port`). A live-slot *port* is never equal
+/// to its own candidate/public on an unchanged-port redeploy (the candidate takes
+/// the OTHER slot, and the public port is never a slot port), so unchanged-port
+/// durability upgrades pass, and a non-colliding `server.port` change (e.g.
+/// 3000→5000) also passes. A fully live-safe colliding-port change is future work
+/// (Option C).
+fn validate_no_live_port_collision(
+    public_port: u16,
+    candidate_port: u16,
+    live_upstream_port: u16,
+) -> Result<(), String> {
+    let offender = if public_port == live_upstream_port {
+        Some(("the proxy's public listener", public_port))
+    } else if candidate_port == live_upstream_port {
+        Some(("the candidate app slot", candidate_port))
+    } else {
+        None
+    };
+    if let Some((which, offending_port)) = offender {
+        return Err(format!(
+            "redeploy public port {public_port} is invalid — {which} (port {offending_port}) \
+             would collide with the currently-live release's loopback port \
+             {live_upstream_port}, so the proxy/candidate restart would fail to bind \
+             (EADDRINUSE) mid-cutover and take public traffic down with no auto-recovery. \
+             Choose a public port whose band {{{public_port}, {p1}, {p2}}} does not include \
+             the currently-live port {live_upstream_port}, or take a maintenance window (a \
+             fully live-safe colliding-port change is future work).",
+            p1 = exec::slot_app_port(public_port, exec::SLOT_BLUE),
+            p2 = exec::slot_app_port(public_port, exec::SLOT_GREEN),
+        ));
+    }
+    Ok(())
+}
+
 // Linear deploy orchestrator; the added MediaMTX host-prep step (#1974 Slice 7)
 // tips it one line over the threshold, and it reads clearest as one sequence.
 #[allow(clippy::too_many_lines)]
@@ -1825,6 +1875,19 @@ fn run_up(
             } else {
                 live_port.unwrap_or(plan.live_port)
             };
+            // Pre-flight guard (#2071): if the operator changed `server.port` such
+            // that the new public port OR the new candidate slot port collides with
+            // the port the still-live release is ACTUALLY holding on loopback, the
+            // #2070 proxy restart-refresh / start-candidate would fail to bind and
+            // take public traffic down with no auto-recovery. Refuse here — BEFORE
+            // any op runs — so the live release keeps serving. Unchanged-port
+            // redeploys and non-colliding port changes are unaffected.
+            validate_no_live_port_collision(
+                plan.public_port,
+                plan.candidate_port,
+                live_upstream_port,
+            )
+            .map_err(DeployError::Config)?;
             let unit = render_app_unit(
                 resolved,
                 &release_dir,
@@ -2000,6 +2063,71 @@ mod tests {
         assert!(validate_public_port(80).is_ok());
         assert!(validate_public_port(3000).is_ok());
         assert!(validate_public_port(8080).is_ok());
+    }
+
+    #[test]
+    fn redeploy_refuses_new_port_band_colliding_with_live_slot() {
+        // #2071 pre-flight guard. Baseline: the live release was deployed at public
+        // 3000 on the blue slot, so it holds `127.0.0.1:3001` (public+1). The
+        // operator now redeploys with a changed `server.port`; the candidate takes
+        // the GREEN slot (public+2).
+
+        // --- Collision variant 1: new public port == the live loopback port. ---
+        // Operator sets server.port = 3001, so the proxy would rebind 0.0.0.0:3001
+        // (covering 127.0.0.1:3001) — the exact port the live app holds.
+        let plan = exec::SlotPlan::redeploy(3001, exec::SLOT_BLUE);
+        let live_upstream_port = 3001; // persisted actual live-slot port (old public+1)
+        let err = validate_no_live_port_collision(
+            plan.public_port,
+            plan.candidate_port,
+            live_upstream_port,
+        )
+        .expect_err("new public port == live loopback port must be refused");
+        assert!(
+            err.contains("3001")
+                && err.contains("public listener")
+                && err.contains("currently-live"),
+            "public-collision message must name the offending/live port + the proxy \
+             listener, got: {err}",
+        );
+
+        // --- Collision variant 2: new candidate slot port == the live loopback. ---
+        // Operator sets server.port = 2999; the green candidate binds public+2 =
+        // 3001, colliding with the still-live blue app's 127.0.0.1:3001.
+        let plan = exec::SlotPlan::redeploy(2999, exec::SLOT_BLUE);
+        assert_eq!(plan.candidate_port, 3001, "green candidate binds public+2");
+        let err = validate_no_live_port_collision(
+            plan.public_port,
+            plan.candidate_port,
+            live_upstream_port,
+        )
+        .expect_err("new candidate port == live loopback port must be refused");
+        assert!(
+            err.contains("3001")
+                && err.contains("candidate app slot")
+                && err.contains("currently-live"),
+            "candidate-collision message must name the offending/live port + the \
+             candidate slot, got: {err}",
+        );
+
+        // --- ALLOWED (a): unchanged-port redeploy (3000, still blue live). ---
+        // The candidate takes the green slot (3002) and the public port (3000) is
+        // never a slot port, so nothing collides with the live 3001.
+        let plan = exec::SlotPlan::redeploy(3000, exec::SLOT_BLUE);
+        assert!(
+            validate_no_live_port_collision(plan.public_port, plan.candidate_port, 3001).is_ok(),
+            "unchanged-port durability redeploy must pass (candidate 3002, public \
+             3000, live 3001)",
+        );
+
+        // --- ALLOWED (b): non-colliding port change 3000 -> 5000. ---
+        // The live app still holds 3001; the new band is {5000, 5001, 5002}, which
+        // does not include 3001.
+        let plan = exec::SlotPlan::redeploy(5000, exec::SLOT_BLUE);
+        assert!(
+            validate_no_live_port_collision(plan.public_port, plan.candidate_port, 3001).is_ok(),
+            "non-colliding server.port change (3000->5000, live 3001) must pass",
+        );
     }
 
     #[test]

--- a/autumn-cli/src/deploy.rs
+++ b/autumn-cli/src/deploy.rs
@@ -1697,95 +1697,63 @@ fn validate_public_port(public_port: u16) -> Result<(), String> {
     Ok(())
 }
 
-/// Refuse a **redeploy** whose new port band collides with the still-live slot's
-/// actual loopback port, BEFORE any op runs — so traffic stays up (#2071).
+/// Refuse a concurrent `server.port` change on the **redeploy** path, BEFORE any op
+/// runs — so the live release keeps serving (#2073).
 ///
-/// On a redeploy the operator may have changed `server.port` since the live
-/// release was deployed. The proxy binds `0.0.0.0:{public_port}` (covering
-/// `127.0.0.1:{public_port}`) and the candidate app slot binds
-/// `127.0.0.1:{candidate_port}`, while the still-live release is holding its own
-/// `127.0.0.1:{live_upstream_port}` (the proxy-OBSERVED ACTUAL live-slot port,
-/// falling back to the persisted marker port then the derived port). If the
-/// new public port or the new candidate port equals that live loopback port, the
-/// #2070 proxy restart-refresh or the `start-candidate` step fails to bind
-/// (`EADDRINUSE`) mid-cutover — taking public traffic down with no auto-recovery.
+/// The reboot-durability upgrade (#2070) makes every redeploy refresh the shared
+/// kamal-proxy unit and, when that unit changed, restart `kamal-proxy run` and
+/// re-register the still-live upstream. Both the restart's public bind and the
+/// re-register's DERIVED loopback target are correct ONLY when the public port is
+/// unchanged: if the operator changed `server.port` since the live release was
+/// deployed, the restart would rebind a different public port and the re-register
+/// would aim at a port nothing listens on, stranding `:80` mid-cutover. Rather than
+/// try to sequence a live-safe port move here (Option C, #2073), refuse the deploy
+/// at pre-flight with an actionable message.
 ///
-/// This guard runs after `live_upstream_port` is resolved and before any cutover
-/// op executes: on a genuine collision it returns an error so **nothing is run**
-/// and the live release keeps serving. It is intentionally narrow — it refuses
-/// ONLY the two band members that can actually collide (`public_port` and
-/// `candidate_port` vs `live_upstream_port`). A live-slot *port* is never equal
-/// to its own candidate/public on an unchanged-port redeploy (the candidate takes
-/// the OTHER slot, and the public port is never a slot port), so unchanged-port
-/// durability upgrades pass, and a non-colliding `server.port` change (e.g.
-/// 3000→5000) also passes. A fully live-safe colliding-port change is future work
-/// (Option C).
-/// Resolve the loopback port the cutover proxy-refresh must re-register the
-/// still-live OLD release at (#2071), authoritative → last resort:
+/// The comparison is sourced from the INSTALLED proxy unit's `--http-port` (captured
+/// by [`exec::probe_deploy_state`]), which is the ground truth of what the running
+/// proxy actually binds:
 ///
-///   1. `observed_live_port` — the PROXY-OBSERVED live target port
-///      ([`exec::proxy_live_target_port`] over the probe's `kamal-proxy list`).
-///      This is the ground truth of what is being served RIGHT NOW — correct for
-///      BOTH modern and legacy/slot-only markers, and correct across a
-///      `server.port` change (the live release still binds its OLD port, which the
-///      derived port would NOT name). On a #1938 drift repair the proxy's actual
-///      routing is likewise the trustworthy signal (the marker is the untrusted
-///      party), so we prefer observed even then.
-///   2. `marker_live_port` — the PERSISTED live-slot marker port (6699b99), the
-///      port the last deploy recorded, used when the proxy reports nothing (down /
-///      no live route) and we kept the marker's slot. Untrusted on a drift repair,
-///      so skipped there.
-///   3. `derived_live_port` — `slot_app_port(NEW public_port, slot)`, the true last
-///      resort. Wrong across a `server.port` change, but if the proxy isn't routing
-///      anything there is no live traffic to preserve.
-///
-/// So an older slot-only marker (`marker_live_port = None`) no longer falls straight
-/// through to the derived port whenever the proxy is routing — it uses the observed
-/// port, closing the legacy-marker live-port hole. This single resolution flows into
-/// BOTH the cutover re-register (#2070) and the collision guard
-/// ([`validate_no_live_port_collision`]).
-fn resolve_live_upstream_port(
-    observed_live_port: Option<u16>,
-    marker_live_port: Option<u16>,
-    derived_live_port: u16,
-    repair: bool,
-) -> u16 {
-    if repair {
-        // Marker untrusted on a drift repair: proxy routing, else derived.
-        observed_live_port.unwrap_or(derived_live_port)
-    } else {
-        observed_live_port
-            .or(marker_live_port)
-            .unwrap_or(derived_live_port)
-    }
-}
-
-fn validate_no_live_port_collision(
-    public_port: u16,
-    candidate_port: u16,
-    live_upstream_port: u16,
+///   - [`exec::InstalledProxyPort::Absent`] → no installed unit, i.e. a first-deploy
+///     shape (the durability refresh writes it fresh). Nothing to conflict with →
+///     allowed. (This branch only runs when `current` is a symlink, so this is the
+///     rare shape where the proxy unit is missing but a release symlink exists.)
+///   - [`exec::InstalledProxyPort::Port`] equal to the requested port → unchanged
+///     redeploy (the common durability-upgrade path) → allowed.
+///   - [`exec::InstalledProxyPort::Port`] DIFFERENT from the requested port → refuse,
+///     naming old vs new port and the two-deploy operator sequence.
+///   - [`exec::InstalledProxyPort::Unreadable`] → the unit is present but its
+///     `--http-port` couldn't be read/parsed, so we can't prove the port is unchanged
+///     → **fail closed** (refuse) rather than risk a mid-cutover bind failure.
+fn refuse_concurrent_public_port_change(
+    installed: &exec::InstalledProxyPort,
+    new_public_port: u16,
 ) -> Result<(), String> {
-    let offender = if public_port == live_upstream_port {
-        Some(("the proxy's public listener", public_port))
-    } else if candidate_port == live_upstream_port {
-        Some(("the candidate app slot", candidate_port))
-    } else {
-        None
-    };
-    if let Some((which, offending_port)) = offender {
-        return Err(format!(
-            "redeploy public port {public_port} is invalid — {which} (port {offending_port}) \
-             would collide with the currently-live release's loopback port \
-             {live_upstream_port}, so the proxy/candidate restart would fail to bind \
-             (EADDRINUSE) mid-cutover and take public traffic down with no auto-recovery. \
-             Choose a public port whose band {{{public_port}, {p1}, {p2}}} does not include \
-             the currently-live port {live_upstream_port}, or take a maintenance window (a \
-             fully live-safe colliding-port change is future work).",
-            p1 = exec::slot_app_port(public_port, exec::SLOT_BLUE),
-            p2 = exec::slot_app_port(public_port, exec::SLOT_GREEN),
-        ));
+    match installed {
+        // No installed proxy unit — first-deploy shape; the durability refresh writes
+        // it fresh at the requested port, so there is nothing to conflict with.
+        exec::InstalledProxyPort::Absent => Ok(()),
+        // Unchanged public port — the common redeploy / durability-upgrade path.
+        exec::InstalledProxyPort::Port(current) if *current == new_public_port => Ok(()),
+        exec::InstalledProxyPort::Port(current) => Err(format!(
+            "Changing server.port on an existing deployment isn't supported here yet \
+             (the installed kamal-proxy is on port {current}, config requests \
+             {new_public_port}): first redeploy with server.port unchanged (adopts the \
+             reboot-durability upgrade), then change the port in a separate deploy. \
+             Tracked in #2073."
+        )),
+        // Fail closed: the unit is present but its --http-port is unreadable, so we
+        // cannot prove the public port is unchanged — refuse rather than risk the
+        // durability restart rebinding a different port and stranding `:80`.
+        exec::InstalledProxyPort::Unreadable => Err(format!(
+            "Cannot verify the installed kamal-proxy's HTTP port before a redeploy \
+             (its systemd unit is present but its `--http-port` could not be read), so \
+             a concurrent server.port change (config requests {new_public_port}) cannot \
+             be ruled out and is refused to avoid stranding public traffic mid-cutover. \
+             Re-provision the host (or repair the kamal-proxy unit) and retry. Live-safe \
+             server.port changes are tracked in #2073."
+        )),
     }
-    Ok(())
 }
 
 // Linear deploy orchestrator; the added MediaMTX host-prep step (#1974 Slice 7)
@@ -1877,10 +1845,20 @@ fn run_up(
             let teardown = exec::first_deploy_teardown_ops(resolved, &release_id, &plan);
             (ops, teardown, "first deploy".to_owned(), true)
         }
-        exec::DeployMode::Redeploy {
-            live_slot,
-            live_port,
-        } => {
+        exec::DeployMode::Redeploy { live_slot } => {
+            // Pre-flight refuse (#2073): the reboot-durability restart-refresh (#2070)
+            // re-execs `kamal-proxy run` on the public port and re-registers the
+            // still-live upstream at its DERIVED loopback port — both correct ONLY
+            // when the public port is unchanged. If the operator changed `server.port`
+            // since the live release was deployed, that restart would rebind a
+            // different public port and the re-register would aim at a dead loopback
+            // port, stranding `:80` mid-cutover with no auto-recovery. Refuse here —
+            // BEFORE any op runs, sourced from the INSTALLED proxy unit's `--http-port`
+            // (captured in the deploy-start probe) — so the live release keeps serving.
+            // A live-safe port change is future work (Option C, #2073). No installed
+            // unit → first-deploy shape (allowed); an unreadable unit → fail closed.
+            refuse_concurrent_public_port_change(&probe.installed_proxy_port, public_port)
+                .map_err(DeployError::Config)?;
             // Reconcile the (possibly stale) live-slot marker against the live
             // proxy before choosing the candidate slot. On an UNAMBIGUOUS
             // proxy-vs-marker disagreement the proxy is authoritative (so the
@@ -1900,32 +1878,6 @@ fn run_up(
                 eprintln!("\u{26A0}\u{FE0F}  {warn}");
             }
             let plan = exec::SlotPlan::redeploy(public_port, reconcile.live_slot);
-            // Port the cutover proxy-refresh re-registers the still-live OLD release
-            // at. The proxy currently fronts that release, so we must target the port
-            // it ACTUALLY binds (#2071) — sourced from the proxy-OBSERVED routing
-            // first, then the persisted marker port, then the derived port. See
-            // `resolve_live_upstream_port` for the full precedence and rationale.
-            let observed_live_port =
-                exec::proxy_live_target_port(&probe.proxy_list, &resolved.service_name);
-            let live_upstream_port = resolve_live_upstream_port(
-                observed_live_port,
-                live_port,
-                plan.live_port,
-                reconcile.repair,
-            );
-            // Pre-flight guard (#2071): if the operator changed `server.port` such
-            // that the new public port OR the new candidate slot port collides with
-            // the port the still-live release is ACTUALLY holding on loopback, the
-            // #2070 proxy restart-refresh / start-candidate would fail to bind and
-            // take public traffic down with no auto-recovery. Refuse here — BEFORE
-            // any op runs — so the live release keeps serving. Unchanged-port
-            // redeploys and non-colliding port changes are unaffected.
-            validate_no_live_port_collision(
-                plan.public_port,
-                plan.candidate_port,
-                live_upstream_port,
-            )
-            .map_err(DeployError::Config)?;
             let unit = render_app_unit(
                 resolved,
                 &release_dir,
@@ -1941,7 +1893,6 @@ fn run_up(
                 &manifests,
                 &release_id,
                 &plan,
-                live_upstream_port,
             );
             // Repair the drifted marker as an early op — before the cutover's
             // record-previous-release reads it — so the on-disk marker matches the
@@ -2104,186 +2055,63 @@ mod tests {
     }
 
     #[test]
-    fn redeploy_refuses_new_port_band_colliding_with_live_slot() {
-        // #2071 pre-flight guard. Baseline: the live release was deployed at public
-        // 3000 on the blue slot, so it holds `127.0.0.1:3001` (public+1). The
-        // operator now redeploys with a changed `server.port`; the candidate takes
-        // the GREEN slot (public+2).
-
-        // --- Collision variant 1: new public port == the live loopback port. ---
-        // Operator sets server.port = 3001, so the proxy would rebind 0.0.0.0:3001
-        // (covering 127.0.0.1:3001) — the exact port the live app holds.
-        let plan = exec::SlotPlan::redeploy(3001, exec::SLOT_BLUE);
-        let live_upstream_port = 3001; // persisted actual live-slot port (old public+1)
-        let err = validate_no_live_port_collision(
-            plan.public_port,
-            plan.candidate_port,
-            live_upstream_port,
-        )
-        .expect_err("new public port == live loopback port must be refused");
+    fn redeploy_refuses_a_concurrent_server_port_change() {
+        // #2073 pre-flight refuse. The installed proxy unit binds port 80; the operator
+        // now redeploys with `server.port = 8080` — a concurrent public-port change the
+        // durability restart-refresh (#2070) can't perform live-safely, so it is refused
+        // BEFORE any op runs, naming old vs new port and the two-deploy sequence.
+        let err = refuse_concurrent_public_port_change(&exec::InstalledProxyPort::Port(80), 8080)
+            .expect_err("a changed server.port must be refused on the redeploy path");
         assert!(
-            err.contains("3001")
-                && err.contains("public listener")
-                && err.contains("currently-live"),
-            "public-collision message must name the offending/live port + the proxy \
-             listener, got: {err}",
+            err.contains("80") && err.contains("8080"),
+            "the refuse message must name the installed (80) and requested (8080) ports: {err}",
         );
-
-        // --- Collision variant 2: new candidate slot port == the live loopback. ---
-        // Operator sets server.port = 2999; the green candidate binds public+2 =
-        // 3001, colliding with the still-live blue app's 127.0.0.1:3001.
-        let plan = exec::SlotPlan::redeploy(2999, exec::SLOT_BLUE);
-        assert_eq!(plan.candidate_port, 3001, "green candidate binds public+2");
-        let err = validate_no_live_port_collision(
-            plan.public_port,
-            plan.candidate_port,
-            live_upstream_port,
-        )
-        .expect_err("new candidate port == live loopback port must be refused");
         assert!(
-            err.contains("3001")
-                && err.contains("candidate app slot")
-                && err.contains("currently-live"),
-            "candidate-collision message must name the offending/live port + the \
-             candidate slot, got: {err}",
-        );
-
-        // --- ALLOWED (a): unchanged-port redeploy (3000, still blue live). ---
-        // The candidate takes the green slot (3002) and the public port (3000) is
-        // never a slot port, so nothing collides with the live 3001.
-        let plan = exec::SlotPlan::redeploy(3000, exec::SLOT_BLUE);
-        assert!(
-            validate_no_live_port_collision(plan.public_port, plan.candidate_port, 3001).is_ok(),
-            "unchanged-port durability redeploy must pass (candidate 3002, public \
-             3000, live 3001)",
-        );
-
-        // --- ALLOWED (b): non-colliding port change 3000 -> 5000. ---
-        // The live app still holds 3001; the new band is {5000, 5001, 5002}, which
-        // does not include 3001.
-        let plan = exec::SlotPlan::redeploy(5000, exec::SLOT_BLUE);
-        assert!(
-            validate_no_live_port_collision(plan.public_port, plan.candidate_port, 3001).is_ok(),
-            "non-colliding server.port change (3000->5000, live 3001) must pass",
-        );
-    }
-
-    // A realistic `kamal-proxy list` stdout serving `service` on 127.0.0.1:`port`.
-    fn proxy_list_serving(service: &str, port: u16) -> String {
-        format!(
-            "Service   Host          Target            State    TLS\n\
-             {service}     example.com   127.0.0.1:{port}   running  no\n"
-        )
-    }
-
-    #[test]
-    fn legacy_marker_sources_live_port_from_proxy_observed_routing() {
-        // #2071 legacy-marker live-port hole (the first-upgrade population). A host
-        // deployed BEFORE the marker gained a port field has a slot-only marker →
-        // `live_port = None`. The operator now redeploys with `server.port` changed
-        // 3000 -> 5000, but the still-live blue release is ACTUALLY bound on
-        // 127.0.0.1:3001. The deploy probe's `kamal-proxy list` observes that 3001.
-        let proxy_list = proxy_list_serving("myapp", 3001);
-        let plan = exec::SlotPlan::redeploy(5000, exec::SLOT_BLUE);
-        assert_eq!(
-            plan.live_port, 5001,
-            "the new-config-DERIVED live port would be the wrong 5001",
-        );
-
-        // The observed port is extracted from the real proxy-list stdout even though
-        // 3001 no longer maps to a slot band under the new public port 5000.
-        let observed = exec::proxy_live_target_port(&proxy_list, "myapp");
-        assert_eq!(
-            observed,
-            Some(3001),
-            "proxy observes the live upstream on 3001"
-        );
-
-        // Legacy slot-only marker → marker port None; this is not a drift repair.
-        let live_upstream_port = resolve_live_upstream_port(observed, None, plan.live_port, false);
-        assert_eq!(
-            live_upstream_port, 3001,
-            "the live port must come from the proxy-OBSERVED routing (3001), NOT the \
-             new-config-derived 5001",
-        );
-
-        // The cutover re-registers the still-live release at exactly this port
-        // (`cutover_ops`'s `live_upstream_port` arg), so the proxy keeps routing to
-        // the real 127.0.0.1:3001 across the restart-refresh — and the collision
-        // guard compares the new band against that same real port.
-        assert!(
-            validate_no_live_port_collision(
-                plan.public_port,
-                plan.candidate_port,
-                live_upstream_port,
-            )
-            .is_ok(),
-            "new band {{5000,5001,5002}} does not collide with the REAL live port 3001",
+            err.contains("server.port unchanged") && err.contains("#2073"),
+            "the refuse message must spell out the operator sequence and reference the \
+             tracking issue: {err}",
         );
     }
 
     #[test]
-    fn resolve_live_upstream_port_precedence_observed_marker_derived() {
-        // 1. Observed present → wins over BOTH marker and derived (non-repair).
-        assert_eq!(
-            resolve_live_upstream_port(Some(3001), Some(9999), 5001, false),
-            3001,
-            "proxy-observed routing is authoritative",
+    fn redeploy_allows_an_unchanged_server_port() {
+        // The common durability-upgrade path: the installed unit's `--http-port` equals
+        // the requested port, so the redeploy proceeds (the restart re-execs on the SAME
+        // port, no collision, derived == actual live port).
+        assert!(
+            refuse_concurrent_public_port_change(&exec::InstalledProxyPort::Port(80), 80).is_ok(),
+            "an unchanged-port redeploy must be allowed",
         );
-        // 2. Observed absent (proxy down / no live route) → persisted marker port.
-        assert_eq!(
-            resolve_live_upstream_port(None, Some(3001), 5001, false),
-            3001,
-            "fall back to the 6699b99 persisted marker port when the proxy is silent",
-        );
-        // 3. Observed AND marker absent (legacy marker, proxy silent) → derived last
-        //    resort (nothing is being routed, so no live traffic to preserve).
-        assert_eq!(
-            resolve_live_upstream_port(None, None, 5001, false),
-            5001,
-            "derived port is the true last resort",
-        );
-        // Modern marker + a routing proxy: both agree on the observed port.
-        assert_eq!(
-            resolve_live_upstream_port(Some(3001), Some(3001), 3001, false),
-            3001,
-        );
-
-        // #1938 drift repair: the marker is the untrusted party, so the OBSERVED
-        // proxy routing wins; with no observed signal it falls to DERIVED, NEVER the
-        // (untrusted) marker port.
-        assert_eq!(
-            resolve_live_upstream_port(Some(3001), Some(9999), 5001, true),
-            3001,
-            "repair prefers observed proxy routing over the untrusted marker",
-        );
-        assert_eq!(
-            resolve_live_upstream_port(None, Some(9999), 5001, true),
-            5001,
-            "repair with no observed signal uses derived, never the untrusted marker",
+        // And with a non-default port that also happens to match.
+        assert!(
+            refuse_concurrent_public_port_change(&exec::InstalledProxyPort::Port(3000), 3000)
+                .is_ok(),
+            "an unchanged non-default port must also be allowed",
         );
     }
 
     #[test]
-    fn legacy_marker_collision_guard_refuses_via_observed_port() {
-        // Legacy marker, operator changes 3000 -> 3001 while the live app really
-        // holds 3001. Observed = 3001; the new public listener 3001 collides with the
-        // live loopback, so the guard refuses using the OBSERVED port — the earlier
-        // hole (comparing against the derived 3002) would have let this through.
-        let proxy_list = proxy_list_serving("myapp", 3001);
-        let observed = exec::proxy_live_target_port(&proxy_list, "myapp");
-        let plan = exec::SlotPlan::redeploy(3001, exec::SLOT_BLUE);
-        let live_upstream_port = resolve_live_upstream_port(observed, None, plan.live_port, false);
-        assert_eq!(live_upstream_port, 3001, "guard sees the REAL live port");
-        let err = validate_no_live_port_collision(
-            plan.public_port,
-            plan.candidate_port,
-            live_upstream_port,
-        )
-        .expect_err("new public port 3001 collides with the real live loopback 3001");
+    fn redeploy_fails_closed_on_an_unreadable_installed_port() {
+        // The installed unit is present but its `--http-port` couldn't be read/parsed,
+        // so we cannot prove the public port is unchanged — refuse (fail closed) rather
+        // than risk the durability restart rebinding a different port and stranding `:80`.
+        let err = refuse_concurrent_public_port_change(&exec::InstalledProxyPort::Unreadable, 80)
+            .expect_err("an unreadable installed proxy port must fail closed");
         assert!(
-            err.contains("3001") && err.contains("currently-live"),
-            "collision message names the real live port, got: {err}",
+            err.contains("could not be read") && err.contains("#2073"),
+            "the fail-closed message must explain the unreadable unit and reference the \
+             tracking issue: {err}",
+        );
+    }
+
+    #[test]
+    fn redeploy_allows_when_no_proxy_unit_is_installed() {
+        // No installed proxy unit at all is a first-deploy shape (the durability refresh
+        // writes it fresh at the requested port) — nothing to conflict with, so the
+        // refuse guard passes regardless of the requested port.
+        assert!(
+            refuse_concurrent_public_port_change(&exec::InstalledProxyPort::Absent, 8080).is_ok(),
+            "an absent installed proxy unit must not trigger the refuse",
         );
     }
 

--- a/autumn-cli/src/deploy.rs
+++ b/autumn-cli/src/deploy.rs
@@ -1786,7 +1786,10 @@ fn run_up(
             let teardown = exec::first_deploy_teardown_ops(resolved, &release_id, &plan);
             (ops, teardown, "first deploy".to_owned(), true)
         }
-        exec::DeployMode::Redeploy { live_slot } => {
+        exec::DeployMode::Redeploy {
+            live_slot,
+            live_port,
+        } => {
             // Reconcile the (possibly stale) live-slot marker against the live
             // proxy before choosing the candidate slot. On an UNAMBIGUOUS
             // proxy-vs-marker disagreement the proxy is authoritative (so the
@@ -1806,6 +1809,22 @@ fn run_up(
                 eprintln!("\u{26A0}\u{FE0F}  {warn}");
             }
             let plan = exec::SlotPlan::redeploy(public_port, reconcile.live_slot);
+            // Port the cutover proxy-refresh re-registers the still-live OLD release
+            // at. The proxy currently fronts that release, so we must target the port
+            // it ACTUALLY binds (#2071): the persisted live-slot marker's port field is
+            // authoritative across a `server.port` change, mirroring how
+            // `resolve_rollback_target` reads the previous-release marker's port. We
+            // trust that marker port ONLY when we kept the marker's slot; on a drift
+            // repair the marker is the untrusted party (#1938), so we fall back to the
+            // derived port for the proxy-authoritative slot (which — since the reconcile
+            // only repairs when the proxy port already mapped to that slot via
+            // `public_port` — equals the port the proxy reported). An older slot-only
+            // marker (no port field) also falls back to the derived port.
+            let live_upstream_port = if reconcile.repair {
+                plan.live_port
+            } else {
+                live_port.unwrap_or(plan.live_port)
+            };
             let unit = render_app_unit(
                 resolved,
                 &release_dir,
@@ -1821,6 +1840,7 @@ fn run_up(
                 &manifests,
                 &release_id,
                 &plan,
+                live_upstream_port,
             );
             // Repair the drifted marker as an early op — before the cutover's
             // record-previous-release reads it — so the on-disk marker matches the

--- a/autumn-cli/src/deploy.rs
+++ b/autumn-cli/src/deploy.rs
@@ -1704,7 +1704,8 @@ fn validate_public_port(public_port: u16) -> Result<(), String> {
 /// release was deployed. The proxy binds `0.0.0.0:{public_port}` (covering
 /// `127.0.0.1:{public_port}`) and the candidate app slot binds
 /// `127.0.0.1:{candidate_port}`, while the still-live release is holding its own
-/// `127.0.0.1:{live_upstream_port}` (the persisted ACTUAL live-slot port). If the
+/// `127.0.0.1:{live_upstream_port}` (the proxy-OBSERVED ACTUAL live-slot port,
+/// falling back to the persisted marker port then the derived port). If the
 /// new public port or the new candidate port equals that live loopback port, the
 /// #2070 proxy restart-refresh or the `start-candidate` step fails to bind
 /// (`EADDRINUSE`) mid-cutover — taking public traffic down with no auto-recovery.
@@ -1719,6 +1720,46 @@ fn validate_public_port(public_port: u16) -> Result<(), String> {
 /// durability upgrades pass, and a non-colliding `server.port` change (e.g.
 /// 3000→5000) also passes. A fully live-safe colliding-port change is future work
 /// (Option C).
+/// Resolve the loopback port the cutover proxy-refresh must re-register the
+/// still-live OLD release at (#2071), authoritative → last resort:
+///
+///   1. `observed_live_port` — the PROXY-OBSERVED live target port
+///      ([`exec::proxy_live_target_port`] over the probe's `kamal-proxy list`).
+///      This is the ground truth of what is being served RIGHT NOW — correct for
+///      BOTH modern and legacy/slot-only markers, and correct across a
+///      `server.port` change (the live release still binds its OLD port, which the
+///      derived port would NOT name). On a #1938 drift repair the proxy's actual
+///      routing is likewise the trustworthy signal (the marker is the untrusted
+///      party), so we prefer observed even then.
+///   2. `marker_live_port` — the PERSISTED live-slot marker port (6699b99), the
+///      port the last deploy recorded, used when the proxy reports nothing (down /
+///      no live route) and we kept the marker's slot. Untrusted on a drift repair,
+///      so skipped there.
+///   3. `derived_live_port` — `slot_app_port(NEW public_port, slot)`, the true last
+///      resort. Wrong across a `server.port` change, but if the proxy isn't routing
+///      anything there is no live traffic to preserve.
+///
+/// So an older slot-only marker (`marker_live_port = None`) no longer falls straight
+/// through to the derived port whenever the proxy is routing — it uses the observed
+/// port, closing the legacy-marker live-port hole. This single resolution flows into
+/// BOTH the cutover re-register (#2070) and the collision guard
+/// ([`validate_no_live_port_collision`]).
+fn resolve_live_upstream_port(
+    observed_live_port: Option<u16>,
+    marker_live_port: Option<u16>,
+    derived_live_port: u16,
+    repair: bool,
+) -> u16 {
+    if repair {
+        // Marker untrusted on a drift repair: proxy routing, else derived.
+        observed_live_port.unwrap_or(derived_live_port)
+    } else {
+        observed_live_port
+            .or(marker_live_port)
+            .unwrap_or(derived_live_port)
+    }
+}
+
 fn validate_no_live_port_collision(
     public_port: u16,
     candidate_port: u16,
@@ -1861,20 +1902,17 @@ fn run_up(
             let plan = exec::SlotPlan::redeploy(public_port, reconcile.live_slot);
             // Port the cutover proxy-refresh re-registers the still-live OLD release
             // at. The proxy currently fronts that release, so we must target the port
-            // it ACTUALLY binds (#2071): the persisted live-slot marker's port field is
-            // authoritative across a `server.port` change, mirroring how
-            // `resolve_rollback_target` reads the previous-release marker's port. We
-            // trust that marker port ONLY when we kept the marker's slot; on a drift
-            // repair the marker is the untrusted party (#1938), so we fall back to the
-            // derived port for the proxy-authoritative slot (which — since the reconcile
-            // only repairs when the proxy port already mapped to that slot via
-            // `public_port` — equals the port the proxy reported). An older slot-only
-            // marker (no port field) also falls back to the derived port.
-            let live_upstream_port = if reconcile.repair {
-                plan.live_port
-            } else {
-                live_port.unwrap_or(plan.live_port)
-            };
+            // it ACTUALLY binds (#2071) — sourced from the proxy-OBSERVED routing
+            // first, then the persisted marker port, then the derived port. See
+            // `resolve_live_upstream_port` for the full precedence and rationale.
+            let observed_live_port =
+                exec::proxy_live_target_port(&probe.proxy_list, &resolved.service_name);
+            let live_upstream_port = resolve_live_upstream_port(
+                observed_live_port,
+                live_port,
+                plan.live_port,
+                reconcile.repair,
+            );
             // Pre-flight guard (#2071): if the operator changed `server.port` such
             // that the new public port OR the new candidate slot port collides with
             // the port the still-live release is ACTUALLY holding on loopback, the
@@ -2127,6 +2165,125 @@ mod tests {
         assert!(
             validate_no_live_port_collision(plan.public_port, plan.candidate_port, 3001).is_ok(),
             "non-colliding server.port change (3000->5000, live 3001) must pass",
+        );
+    }
+
+    // A realistic `kamal-proxy list` stdout serving `service` on 127.0.0.1:`port`.
+    fn proxy_list_serving(service: &str, port: u16) -> String {
+        format!(
+            "Service   Host          Target            State    TLS\n\
+             {service}     example.com   127.0.0.1:{port}   running  no\n"
+        )
+    }
+
+    #[test]
+    fn legacy_marker_sources_live_port_from_proxy_observed_routing() {
+        // #2071 legacy-marker live-port hole (the first-upgrade population). A host
+        // deployed BEFORE the marker gained a port field has a slot-only marker →
+        // `live_port = None`. The operator now redeploys with `server.port` changed
+        // 3000 -> 5000, but the still-live blue release is ACTUALLY bound on
+        // 127.0.0.1:3001. The deploy probe's `kamal-proxy list` observes that 3001.
+        let proxy_list = proxy_list_serving("myapp", 3001);
+        let plan = exec::SlotPlan::redeploy(5000, exec::SLOT_BLUE);
+        assert_eq!(
+            plan.live_port, 5001,
+            "the new-config-DERIVED live port would be the wrong 5001",
+        );
+
+        // The observed port is extracted from the real proxy-list stdout even though
+        // 3001 no longer maps to a slot band under the new public port 5000.
+        let observed = exec::proxy_live_target_port(&proxy_list, "myapp");
+        assert_eq!(
+            observed,
+            Some(3001),
+            "proxy observes the live upstream on 3001"
+        );
+
+        // Legacy slot-only marker → marker port None; this is not a drift repair.
+        let live_upstream_port = resolve_live_upstream_port(observed, None, plan.live_port, false);
+        assert_eq!(
+            live_upstream_port, 3001,
+            "the live port must come from the proxy-OBSERVED routing (3001), NOT the \
+             new-config-derived 5001",
+        );
+
+        // The cutover re-registers the still-live release at exactly this port
+        // (`cutover_ops`'s `live_upstream_port` arg), so the proxy keeps routing to
+        // the real 127.0.0.1:3001 across the restart-refresh — and the collision
+        // guard compares the new band against that same real port.
+        assert!(
+            validate_no_live_port_collision(
+                plan.public_port,
+                plan.candidate_port,
+                live_upstream_port,
+            )
+            .is_ok(),
+            "new band {{5000,5001,5002}} does not collide with the REAL live port 3001",
+        );
+    }
+
+    #[test]
+    fn resolve_live_upstream_port_precedence_observed_marker_derived() {
+        // 1. Observed present → wins over BOTH marker and derived (non-repair).
+        assert_eq!(
+            resolve_live_upstream_port(Some(3001), Some(9999), 5001, false),
+            3001,
+            "proxy-observed routing is authoritative",
+        );
+        // 2. Observed absent (proxy down / no live route) → persisted marker port.
+        assert_eq!(
+            resolve_live_upstream_port(None, Some(3001), 5001, false),
+            3001,
+            "fall back to the 6699b99 persisted marker port when the proxy is silent",
+        );
+        // 3. Observed AND marker absent (legacy marker, proxy silent) → derived last
+        //    resort (nothing is being routed, so no live traffic to preserve).
+        assert_eq!(
+            resolve_live_upstream_port(None, None, 5001, false),
+            5001,
+            "derived port is the true last resort",
+        );
+        // Modern marker + a routing proxy: both agree on the observed port.
+        assert_eq!(
+            resolve_live_upstream_port(Some(3001), Some(3001), 3001, false),
+            3001,
+        );
+
+        // #1938 drift repair: the marker is the untrusted party, so the OBSERVED
+        // proxy routing wins; with no observed signal it falls to DERIVED, NEVER the
+        // (untrusted) marker port.
+        assert_eq!(
+            resolve_live_upstream_port(Some(3001), Some(9999), 5001, true),
+            3001,
+            "repair prefers observed proxy routing over the untrusted marker",
+        );
+        assert_eq!(
+            resolve_live_upstream_port(None, Some(9999), 5001, true),
+            5001,
+            "repair with no observed signal uses derived, never the untrusted marker",
+        );
+    }
+
+    #[test]
+    fn legacy_marker_collision_guard_refuses_via_observed_port() {
+        // Legacy marker, operator changes 3000 -> 3001 while the live app really
+        // holds 3001. Observed = 3001; the new public listener 3001 collides with the
+        // live loopback, so the guard refuses using the OBSERVED port — the earlier
+        // hole (comparing against the derived 3002) would have let this through.
+        let proxy_list = proxy_list_serving("myapp", 3001);
+        let observed = exec::proxy_live_target_port(&proxy_list, "myapp");
+        let plan = exec::SlotPlan::redeploy(3001, exec::SLOT_BLUE);
+        let live_upstream_port = resolve_live_upstream_port(observed, None, plan.live_port, false);
+        assert_eq!(live_upstream_port, 3001, "guard sees the REAL live port");
+        let err = validate_no_live_port_collision(
+            plan.public_port,
+            plan.candidate_port,
+            live_upstream_port,
+        )
+        .expect_err("new public port 3001 collides with the real live loopback 3001");
+        assert!(
+            err.contains("3001") && err.contains("currently-live"),
+            "collision message names the real live port, got: {err}",
         );
     }
 

--- a/autumn-cli/src/deploy/exec.rs
+++ b/autumn-cli/src/deploy/exec.rs
@@ -4036,7 +4036,8 @@ mod tests {
     fn compatible_deploy_help() -> &'static str {
         "Usage:\n  kamal-proxy deploy SERVICE [flags]\n\nFlags:\n  \
          --target host:port\n  --health-check-path string\n  --host strings\n  \
-         --tls\n  --deploy-timeout duration\n  --drain-timeout duration\n"
+         --tls\n  --deploy-timeout duration\n  --drain-timeout duration\n  \
+         --force\n"
     }
 
     #[test]

--- a/autumn-cli/src/deploy/exec.rs
+++ b/autumn-cli/src/deploy/exec.rs
@@ -1562,20 +1562,21 @@ fn loopback_port(field: &str) -> Option<u16> {
     digits.parse().ok()
 }
 
-/// The slot `kamal-proxy list` UNAMBIGUOUSLY reports serving `service_name`, or
-/// `None` when the signal is absent or unclear (→ caller falls back to the marker).
+/// The single loopback target port `kamal-proxy list` UNAMBIGUOUSLY reports
+/// serving `service_name`, or `None` when the signal is absent or unclear.
 ///
-/// A definite slot is returned ONLY when: exactly one output row carries
-/// `service_name` as a standalone whitespace field (the header row never does, and
-/// a service listed twice is ambiguous → `None`), that row carries exactly one
-/// distinct `127.0.0.1:<port>` target, and `port - public_port` maps to a slot
-/// (1=blue, 2=green). Every other shape — service absent, no/garbled target, two
-/// different target ports, a port mapping to neither slot — yields `None`.
-fn proxy_live_slot(
-    list_stdout: &str,
-    service_name: &str,
-    public_port: u16,
-) -> Option<&'static str> {
+/// This is the proxy's OBSERVED current upstream target — the port the live slot
+/// is ACTUALLY routed to right now — and is the ground truth of what is being
+/// served, independent of the public port or any persisted marker (#2071). It is
+/// returned ONLY when exactly one output row carries `service_name` as a standalone
+/// whitespace field (the header row never does, and a service listed twice is
+/// ambiguous → `None`) and that row carries exactly one distinct `127.0.0.1:<port>`
+/// target. Deliberately does NOT require the port to map to a slot band under the
+/// current public port: on a `server.port` change the live release still binds its
+/// OLD port, which no longer maps to a slot relative to the NEW public port, yet is
+/// exactly the port we must preserve.
+#[must_use]
+pub fn proxy_live_target_port(list_stdout: &str, service_name: &str) -> Option<u16> {
     let service = service_name.trim();
     if service.is_empty() {
         return None;
@@ -1600,7 +1601,25 @@ fn proxy_live_slot(
             }
         }
     }
-    slot_for_port(public_port, port?)
+    port
+}
+
+/// The slot `kamal-proxy list` UNAMBIGUOUSLY reports serving `service_name`, or
+/// `None` when the signal is absent or unclear (→ caller falls back to the marker).
+///
+/// A definite slot is returned ONLY when [`proxy_live_target_port`] resolves an
+/// unambiguous single `127.0.0.1:<port>` target AND `port - public_port` maps to a
+/// slot (1=blue, 2=green). Every other shape — service absent, no/garbled target,
+/// two different target ports, a port mapping to neither slot — yields `None`.
+fn proxy_live_slot(
+    list_stdout: &str,
+    service_name: &str,
+    public_port: u16,
+) -> Option<&'static str> {
+    slot_for_port(
+        public_port,
+        proxy_live_target_port(list_stdout, service_name)?,
+    )
 }
 
 /// The decision from reconciling the live-slot marker against the live proxy.
@@ -4073,6 +4092,37 @@ mod tests {
         assert_eq!(decision.live_slot, SLOT_GREEN);
         assert!(!decision.repair);
         assert!(decision.warn.is_none());
+    }
+
+    #[test]
+    fn proxy_live_target_port_extracts_the_observed_upstream_port() {
+        // The observed port is returned even when it does NOT map to a slot band
+        // under the CURRENT public port — the #2071 legacy/port-change case. Here the
+        // live blue release still binds 3001 while the operator's new public port is
+        // 5000, so `slot_for_port(5000, 3001)` is None yet the observed port is 3001.
+        let list = proxy_list_serving("myapp", 3001);
+        assert_eq!(proxy_live_target_port(&list, "myapp"), Some(3001));
+        // And `proxy_live_slot` (slot-mapped) correctly reports None for that same
+        // list under the new public port, proving the observed port is the ONLY
+        // signal that survives a `server.port` change.
+        assert_eq!(proxy_live_slot(&list, "myapp", 5000), None);
+        // Under the matching public port it still maps to the slot as before.
+        assert_eq!(proxy_live_slot(&list, "myapp", 3000), Some(SLOT_BLUE));
+
+        // Unclear signals → None (mirrors proxy_live_slot's fall-back conditions):
+        // service absent, listed twice, no target, two different ports, empty name.
+        assert_eq!(proxy_live_target_port(&list, "other"), None);
+        assert_eq!(proxy_live_target_port(&list, ""), None);
+        let twice = format!(
+            "{}{}",
+            proxy_list_serving("myapp", 3001),
+            "myapp   x   127.0.0.1:3002\n"
+        );
+        assert_eq!(proxy_live_target_port(&twice, "myapp"), None);
+        let two_ports = "Service   Target             Prev\n\
+                         myapp   127.0.0.1:3001   127.0.0.1:3002\n";
+        assert_eq!(proxy_live_target_port(two_ports, "myapp"), None);
+        assert_eq!(proxy_live_target_port("", "myapp"), None);
     }
 
     #[test]

--- a/autumn-cli/src/deploy/exec.rs
+++ b/autumn-cli/src/deploy/exec.rs
@@ -695,6 +695,10 @@ pub fn first_deploy_ops(
 /// migration or readiness timeout aborts here with the old release still serving
 /// (no flip, no drain, no promote). The sequence:
 ///
+/// 0. refresh the shared proxy unit (issue #2070) — rewrite the reboot-durable
+///    unit so an existing host adopts it on upgrade, restarting + re-registering the
+///    live upstream ONLY when the unit actually changed (an unchanged unit does
+///    nothing, preserving steady-state behavior),
 /// 1. prepare remote dirs,
 /// 2. upload the release binary (`0755`),
 /// 3. write the secret env file (`0600`, AC-5),
@@ -737,22 +741,39 @@ pub fn cutover_ops(
     let candidate_unit_path = format!("/etc/systemd/system/{candidate_unit}.service");
     let live_unit = slot_unit_name(&cfg.service_name, plan.live_slot);
 
-    let mut ops = vec![
-        DeployOp::Run(RemoteCommand::new(
-            "prepare-dirs",
-            format!(
-                "mkdir -p {} {}",
-                shell_quote(&release_dir),
-                shell_quote(&shared_dir)
-            ),
-        )),
-        DeployOp::UploadFile {
-            label: "upload-binary",
-            local: binary_local.to_path_buf(),
-            remote_path: remote_binary,
-            mode: Some(0o755),
-        },
-    ];
+    // Refresh the SHARED proxy unit on the redeploy path too (issue #2070).
+    // Previously only `first_deploy_ops` wrote the proxy unit, so a fix landed in
+    // the unit (e.g. the reboot-durable `StateDirectory`/`HOME` of #2069) never
+    // reached an already-provisioned host on upgrade. Prepending the idempotent
+    // install (mirroring how `first_deploy_ops` starts) rewrites it on every
+    // redeploy, and — kamal-proxy only — restarts + re-registers the live upstream
+    // ONLY when the unit actually changed, so an existing host adopts the new unit
+    // with a routeless window bounded to ~the restart (see
+    // `ProxyController::refresh_installed_ops`). Writing the unit is deterministic,
+    // lands at the final path, and causes no restart on its own, so it is safe to do
+    // at the very start of the cutover; the live upstream re-registered on a change
+    // is the slot serving RIGHT NOW (`plan.live_port`), the same target the proxy
+    // already fronts.
+    let mut ops = proxy.refresh_installed_ops(
+        plan.public_port,
+        &cfg.service_name,
+        &loopback_upstream(plan.live_port),
+        &proxy_unit_snapshot_path(release_id),
+    );
+    ops.push(DeployOp::Run(RemoteCommand::new(
+        "prepare-dirs",
+        format!(
+            "mkdir -p {} {}",
+            shell_quote(&release_dir),
+            shell_quote(&shared_dir)
+        ),
+    )));
+    ops.push(DeployOp::UploadFile {
+        label: "upload-binary",
+        local: binary_local.to_path_buf(),
+        remote_path: remote_binary,
+        mode: Some(0o755),
+    });
     // Re-upload the project config manifest(s) into the per-release dir on every
     // redeploy so the config on the server always matches the shipped binary and
     // is coupled to it for rollback (#1952).
@@ -1153,6 +1174,15 @@ pub fn rollback_teardown_ops(cfg: &ResolvedDeployConfig, target: &RollbackTarget
 /// The `host:port` loopback upstream string the proxy routes at.
 fn loopback_upstream(port: u16) -> String {
     format!("127.0.0.1:{port}")
+}
+
+/// Per-deploy scratch path holding the pre-refresh kamal-proxy unit's content hash,
+/// so [`ProxyController::refresh_installed_ops`](super::proxy::ProxyController::refresh_installed_ops)
+/// can decide whether the unit ACTUALLY changed on this host (issue #2070). Keyed on
+/// the unique `release_id` so two shared-host deploys never race on a fixed scratch
+/// path; the restart step removes it.
+fn proxy_unit_snapshot_path(release_id: &str) -> String {
+    format!("/tmp/autumn-kamal-proxy-unit-{release_id}.sha256")
 }
 
 /// Command that records which slot now serves live traffic AND the loopback
@@ -2274,9 +2304,17 @@ mod tests {
         run_ops(&ops, &exec).expect("recording executor never fails");
 
         // The full ordered run sequence (uploads interleave; asserted separately).
+        // The cutover now LEADS with the proxy-unit refresh (issue #2070): the
+        // snapshot of the pre-write unit, the idempotent install, then the
+        // change-gated restart+re-register — before the candidate is prepared.
+        // (`proxy-write-unit` is a WriteFile → uploaded, so excluded from
+        // `run_labels`; asserted separately.)
         assert_eq!(
             exec.run_labels(),
             vec![
+                "proxy-snapshot-unit",
+                "proxy-install",
+                "proxy-restart-if-changed",
                 "prepare-dirs",
                 "daemon-reload",
                 "start-candidate",
@@ -2430,6 +2468,100 @@ mod tests {
             "commit the markers before draining the old release"
         );
         assert!(pos("drain-old") < pos("prune"), "drain before prune");
+    }
+
+    #[test]
+    fn cutover_refreshes_proxy_unit_and_restarts_only_when_changed() {
+        // Issue #2070: the redeploy path must now REFRESH the shared proxy unit so a
+        // reboot-durable unit reaches existing hosts on upgrade — and restart the
+        // running proxy to adopt it ONLY when the unit actually changed, immediately
+        // re-registering the CURRENT live upstream so :80 is routeless for only ~the
+        // restart, not the whole cutover.
+        let ops = sample_cutover_ops(Secret::new("AUTUMN_SECURITY__SIGNING_SECRET=x\n"));
+
+        // (a) The unit is (re)written to its FINAL path on the redeploy path, exactly
+        // like the first deploy — this is what delivers the reboot-durable unit to an
+        // already-provisioned host.
+        assert!(
+            ops.iter().any(|op| matches!(
+                op,
+                DeployOp::WriteFile { label: "proxy-write-unit", remote_path, contents: FileContents::Plain(unit), .. }
+                    if remote_path == "/etc/systemd/system/kamal-proxy.service"
+                        && unit.contains("StateDirectory=kamal-proxy\n")
+                        && unit.contains("Environment=HOME=/var/lib/kamal-proxy\n")
+            )),
+            "cutover must rewrite the reboot-durable proxy unit to its final path"
+        );
+
+        let exec = RecordingExecutor::new();
+        run_ops(&ops, &exec).expect("recording executor never fails");
+        let labels = exec.run_labels();
+        let pos = |l: &str| labels.iter().position(|&x| x == l);
+
+        // (b) The proxy refresh LEADS the cutover (before the candidate is prepared)
+        // and, crucially, the change-gated restart+re-register runs BEFORE the flip —
+        // so on a changed unit the live route is restored up front, keeping :80 served
+        // through the whole candidate-start/migrate/readiness window.
+        assert!(
+            pos("proxy-install").is_some(),
+            "cutover installs the proxy unit"
+        );
+        let restart = pos("proxy-restart-if-changed").expect("restart-if-changed present");
+        assert!(
+            pos("proxy-snapshot-unit").unwrap() < pos("proxy-install").unwrap()
+                && pos("proxy-install").unwrap() < restart,
+            "snapshot → install → restart-if-changed, in order: {labels:?}"
+        );
+        assert!(
+            restart < pos("prepare-dirs").unwrap() && restart < pos("proxy-flip").unwrap(),
+            "the proxy refresh precedes the candidate work and the flip: {labels:?}"
+        );
+
+        // (c) The snapshot captures the CURRENT unit's content hash before the write.
+        let snapshot = exec.shell_for("proxy-snapshot-unit").expect("snapshot ran");
+        assert!(
+            snapshot.contains("sha256sum '/etc/systemd/system/kamal-proxy.service'")
+                && snapshot.contains("/tmp/autumn-kamal-proxy-unit-20260714T120000Z.sha256"),
+            "snapshot hashes the live unit into a per-release scratch path: {snapshot}"
+        );
+
+        // (d) The restart is CHANGE-GATED (unchanged unit → no restart), only fires
+        // while the proxy is active, and — only then — re-registers the CURRENT live
+        // upstream (blue = 127.0.0.1:3001), socket-pinned like every other CLI call.
+        let restart_sh = exec
+            .shell_for("proxy-restart-if-changed")
+            .expect("restart-if-changed ran");
+        assert!(
+            restart_sh.contains("if [ \"$new\" = \"$old\" ]; then exit 0; fi"),
+            "an UNCHANGED unit must short-circuit before any restart: {restart_sh}"
+        );
+        assert!(
+            restart_sh.contains("systemctl is-active --quiet kamal-proxy.service")
+                && restart_sh.contains("systemctl restart kamal-proxy.service"),
+            "on a change it restarts the live proxy: {restart_sh}"
+        );
+        assert!(
+            restart_sh.contains(
+                "env -u XDG_RUNTIME_DIR kamal-proxy deploy 'myapp' --target '127.0.0.1:3001'"
+            ),
+            "on a change it re-registers the CURRENT live upstream, socket-pinned: {restart_sh}"
+        );
+        // The re-register sits AFTER the restart within the one command (so no SSH
+        // round-trip interposes), and the whole restart block is downstream of the
+        // change gate.
+        let gate = restart_sh
+            .find("if [ \"$new\" = \"$old\" ]")
+            .expect("change gate present");
+        let do_restart = restart_sh
+            .find("systemctl restart kamal-proxy.service")
+            .expect("restart present");
+        let reregister = restart_sh
+            .find("kamal-proxy deploy 'myapp' --target '127.0.0.1:3001'")
+            .expect("re-register present");
+        assert!(
+            gate < do_restart && do_restart < reregister,
+            "order must be change-gate → restart → re-register: {restart_sh}"
+        );
     }
 
     /// The candidate-teardown ops for the redeploy sample (candidate on green).

--- a/autumn-cli/src/deploy/exec.rs
+++ b/autumn-cli/src/deploy/exec.rs
@@ -731,6 +731,12 @@ pub fn cutover_ops(
     manifests: &[ManifestUpload],
     release_id: &str,
     plan: &SlotPlan,
+    // The port the currently-live (OLD) release ACTUALLY binds, used only for the
+    // cutover proxy-refresh re-register (below). This is threaded in — rather than
+    // taken from `plan.live_port` — because `plan.live_port` is derived from the NEW
+    // config's `public_port` and is wrong if `server.port` changed since the last
+    // deploy; the caller sources this from the persisted live-slot marker (#2071).
+    live_upstream_port: u16,
 ) -> Vec<DeployOp> {
     let release_dir = format!("{}/{release_id}", cfg.releases_dir());
     let remote_binary = format!("{release_dir}/{}", cfg.app_name);
@@ -752,12 +758,17 @@ pub fn cutover_ops(
     // `ProxyController::refresh_installed_ops`). Writing the unit is deterministic,
     // lands at the final path, and causes no restart on its own, so it is safe to do
     // at the very start of the cutover; the live upstream re-registered on a change
-    // is the slot serving RIGHT NOW (`plan.live_port`), the same target the proxy
-    // already fronts.
+    // is the release serving RIGHT NOW, targeted at its ACTUAL loopback port
+    // (`live_upstream_port`, sourced from the persisted live-slot marker) rather than
+    // the new-config-derived `plan.live_port`. If `server.port` changed since the last
+    // deploy, `plan.live_port` names a port nothing listens on, so the health-gated
+    // re-register would never pass and the cutover would fail with the proxy already
+    // restarted and `:80` routeless (#2071). The candidate/flip below still use the
+    // new derived ports — the new release genuinely binds them.
     let mut ops = proxy.refresh_installed_ops(
         plan.public_port,
         &cfg.service_name,
-        &loopback_upstream(plan.live_port),
+        &loopback_upstream(live_upstream_port),
         &proxy_unit_snapshot_path(release_id),
     );
     ops.push(DeployOp::Run(RemoteCommand::new(
@@ -1380,6 +1391,13 @@ pub enum DeployMode {
     Redeploy {
         /// Slot the currently-live release serves on.
         live_slot: &'static str,
+        /// Loopback port the currently-live release ACTUALLY binds, read from the
+        /// live-slot marker's persisted port field (`{slot}\t{port}`). `None` for an
+        /// older slot-only marker with no port field. This is authoritative across a
+        /// `server.port` change since the last deploy (the derived
+        /// `slot_app_port(current server.port, slot)` is not), mirroring how
+        /// [`resolve_rollback_target`] reads the previous-release marker's port.
+        live_port: Option<u16>,
     },
 }
 
@@ -1439,10 +1457,20 @@ pub fn probe_deploy_state(
     let mode = mode_part
         .trim()
         .strip_prefix("redeploy:")
-        .map_or(DeployMode::First, |marker| DeployMode::Redeploy {
+        .map_or(DeployMode::First, |marker| {
             // The live-slot marker is `{slot}\t{port}` (older markers are slot-only);
             // the slot is the FIRST tab-separated field either way.
-            live_slot: canonical_slot(marker.split('\t').next().unwrap_or(SLOT_BLUE)),
+            let mut fields = marker.split('\t');
+            let live_slot = canonical_slot(fields.next().unwrap_or(SLOT_BLUE));
+            // Parse the persisted port (SECOND field) so the cutover can re-register
+            // the live release at the port it ACTUALLY binds — correct across a
+            // `server.port` change — mirroring how `resolve_rollback_target` reads the
+            // previous-release marker's port. An older slot-only marker → `None`.
+            let live_port = fields.next().and_then(|p| p.trim().parse::<u16>().ok());
+            DeployMode::Redeploy {
+                live_slot,
+                live_port,
+            }
         });
     Ok(DeployProbe {
         mode,
@@ -2194,6 +2222,15 @@ mod tests {
     /// Redeploy cutover ops: the live release is on blue, so the candidate takes
     /// green (loopback 3002).
     fn sample_cutover_ops(env: Secret) -> Vec<DeployOp> {
+        // Default: the live release's actual port matches the config-derived port
+        // (no `server.port` change since the last deploy), so the re-register target
+        // is `plan.live_port` (blue = 3001) — the pre-#2071 behavior every other
+        // cutover test asserts.
+        let plan = SlotPlan::redeploy(3000, SLOT_BLUE);
+        sample_cutover_ops_with_live_port(env, plan.live_port)
+    }
+
+    fn sample_cutover_ops_with_live_port(env: Secret, live_upstream_port: u16) -> Vec<DeployOp> {
         let cfg = resolved();
         let plan = SlotPlan::redeploy(3000, SLOT_BLUE);
         let unit = super::super::render_app_unit(
@@ -2211,6 +2248,7 @@ mod tests {
             &sample_manifests(),
             RELEASE_ID,
             &plan,
+            live_upstream_port,
         )
     }
 
@@ -2561,6 +2599,58 @@ mod tests {
         assert!(
             gate < do_restart && do_restart < reregister,
             "order must be change-gate → restart → re-register: {restart_sh}"
+        );
+    }
+
+    #[test]
+    fn cutover_reregisters_live_release_at_its_actual_persisted_port() {
+        // Issue #2071 P2: if `server.port` changed since the last deploy, the live
+        // (OLD) release still binds the port derived from the PREVIOUS config, not the
+        // new one. The cutover proxy-refresh re-register must target that ACTUAL live
+        // port (sourced from the live-slot marker), NOT the new-config-derived
+        // `plan.live_port` — otherwise the health-gated re-register aims at a dead port
+        // and the deploy fails with the proxy already restarted and `:80` routeless.
+        let plan = SlotPlan::redeploy(3000, SLOT_BLUE);
+        let derived = plan.live_port; // 3001 under the NEW config (public_port 3000)
+        let actual = 4001; // blue's port under the OLD server.port = 4000
+        assert_ne!(
+            derived, actual,
+            "the scenario is meaningful only when server.port changed"
+        );
+
+        let ops = sample_cutover_ops_with_live_port(
+            Secret::new("AUTUMN_SECURITY__SIGNING_SECRET=x\n"),
+            actual,
+        );
+        let exec = RecordingExecutor::new();
+        run_ops(&ops, &exec).expect("recording executor never fails");
+
+        // The change-gated re-register of the still-live OLD release targets its ACTUAL
+        // persisted port (4001), never the new-config-derived port (3001).
+        let restart_sh = exec
+            .shell_for("proxy-restart-if-changed")
+            .expect("restart-if-changed ran");
+        assert!(
+            restart_sh.contains("kamal-proxy deploy 'myapp' --target '127.0.0.1:4001'"),
+            "re-register must target the live release's ACTUAL persisted port (4001): {restart_sh}"
+        );
+        assert!(
+            !restart_sh.contains("127.0.0.1:3001"),
+            "re-register must NOT target the new-config-derived port (3001): {restart_sh}"
+        );
+
+        // The CANDIDATE and the flip are unchanged — the new release genuinely binds
+        // the new derived candidate port (green = 3002); only the OLD-release
+        // re-register uses the persisted live port.
+        let flip = exec.shell_for("proxy-flip").expect("flip ran");
+        assert!(
+            flip.contains("kamal-proxy deploy 'myapp' --target '127.0.0.1:3002'"),
+            "the candidate flip still targets the new derived candidate port (3002): {flip}"
+        );
+        let gate = exec.shell_for("readiness-gate").expect("gate ran");
+        assert!(
+            gate.contains("127.0.0.1:3002/ready"),
+            "readiness gate still probes the candidate's new derived port (3002): {gate}"
         );
     }
 
@@ -3724,23 +3814,27 @@ mod tests {
         assert_eq!(
             probe_deploy_state(&cfg, &redeploy).unwrap().mode,
             DeployMode::Redeploy {
-                live_slot: SLOT_GREEN
+                live_slot: SLOT_GREEN,
+                live_port: Some(3002),
             }
         );
-        // Backward-compat: an older slot-only marker (no port field) still parses.
+        // Backward-compat: an older slot-only marker (no port field) still parses, and
+        // reports `None` for the port (the caller falls back to the derived port).
         let legacy = RecordingExecutor::new().with_stdout("detect-current", "redeploy:green");
         assert_eq!(
             probe_deploy_state(&cfg, &legacy).unwrap().mode,
             DeployMode::Redeploy {
-                live_slot: SLOT_GREEN
+                live_slot: SLOT_GREEN,
+                live_port: None,
             }
         );
-        // A missing/blank marker on a redeploy defaults the live slot to blue.
+        // A missing/blank marker on a redeploy defaults the live slot to blue, no port.
         let default_blue = RecordingExecutor::new().with_stdout("detect-current", "redeploy:");
         assert_eq!(
             probe_deploy_state(&cfg, &default_blue).unwrap().mode,
             DeployMode::Redeploy {
-                live_slot: SLOT_BLUE
+                live_slot: SLOT_BLUE,
+                live_port: None,
             }
         );
     }
@@ -3767,7 +3861,8 @@ mod tests {
         assert_eq!(
             probe.mode,
             DeployMode::Redeploy {
-                live_slot: SLOT_BLUE
+                live_slot: SLOT_BLUE,
+                live_port: Some(3001),
             }
         );
         assert!(
@@ -3788,7 +3883,8 @@ mod tests {
         assert_eq!(
             probe.mode,
             DeployMode::Redeploy {
-                live_slot: SLOT_GREEN
+                live_slot: SLOT_GREEN,
+                live_port: Some(3002),
             }
         );
         assert!(

--- a/autumn-cli/src/deploy/exec.rs
+++ b/autumn-cli/src/deploy/exec.rs
@@ -1425,8 +1425,14 @@ pub struct DeployProbe {
 ///
 /// The probe shell keeps the existing `current`/`live-slot` detection byte-for-
 /// byte (its meaning is unchanged), then appends a delimited section running
-/// `kamal-proxy list` best-effort (`|| true`, stderr suppressed) so a missing
-/// binary, dead control socket, or unlisted service can never fail the probe.
+/// `env -u XDG_RUNTIME_DIR kamal-proxy list` best-effort (`|| true`, stderr
+/// suppressed) so a missing binary, dead control socket, or unlisted service can
+/// never fail the probe. The `env -u XDG_RUNTIME_DIR` control-socket pin mirrors
+/// `deploy_shell` (issue #1948 item 4): without it the SSH session's `pam_systemd`
+/// `XDG_RUNTIME_DIR=/run/user/0` points the CLI at a different socket than the
+/// supervised `kamal-proxy run` service (which has no `XDG_RUNTIME_DIR` → `/tmp`),
+/// so on a real pam host the list would silently come back empty — disabling both
+/// the #1938 drift reconcile and the observed-port path.
 /// The two sections are split on [`PROXY_LIST_DELIM`]; when the delimiter is
 /// absent (older recorded output / a scripted test) the whole stdout is treated
 /// as the mode section and the proxy list is empty — the reconcile then falls
@@ -1443,7 +1449,7 @@ pub fn probe_deploy_state(
         "if [ -L {current} ]; then printf 'redeploy:'; cat {marker} 2>/dev/null || printf '{blue}'; \
          else printf 'first'; fi; \
          printf '\\n{delim}\\n'; \
-         kamal-proxy list 2>/dev/null || true",
+         env -u XDG_RUNTIME_DIR kamal-proxy list 2>/dev/null || true",
         current = shell_quote(&cfg.current_symlink()),
         marker = shell_quote(&live_slot_marker(cfg)),
         blue = SLOT_BLUE,
@@ -3895,6 +3901,16 @@ mod tests {
         assert!(
             shell.contains("kamal-proxy list") && shell.contains("|| true"),
             "probe runs kamal-proxy list best-effort: {shell}"
+        );
+        // The list invocation must be control-socket-pinned exactly like
+        // `deploy_shell` (issue #1948 item 4): without `env -u XDG_RUNTIME_DIR`
+        // the SSH session's pam_systemd `XDG_RUNTIME_DIR` points the CLI at a
+        // different socket than the supervised `kamal-proxy run` service, so on a
+        // real pam host the list comes back silently empty — disabling the #1938
+        // drift reconcile and the observed-port path. Pin it to `kamal-proxy list`.
+        assert!(
+            shell.contains("env -u XDG_RUNTIME_DIR kamal-proxy list"),
+            "probe socket-pins the kamal-proxy list invocation: {shell}"
         );
         // No delimiter in the output (older/scripted) → empty list, mode unchanged.
         let legacy = RecordingExecutor::new().with_stdout("detect-current", "redeploy:green\t3002");

--- a/autumn-cli/src/deploy/exec.rs
+++ b/autumn-cli/src/deploy/exec.rs
@@ -731,12 +731,6 @@ pub fn cutover_ops(
     manifests: &[ManifestUpload],
     release_id: &str,
     plan: &SlotPlan,
-    // The port the currently-live (OLD) release ACTUALLY binds, used only for the
-    // cutover proxy-refresh re-register (below). This is threaded in — rather than
-    // taken from `plan.live_port` — because `plan.live_port` is derived from the NEW
-    // config's `public_port` and is wrong if `server.port` changed since the last
-    // deploy; the caller sources this from the persisted live-slot marker (#2071).
-    live_upstream_port: u16,
 ) -> Vec<DeployOp> {
     let release_dir = format!("{}/{release_id}", cfg.releases_dir());
     let remote_binary = format!("{release_dir}/{}", cfg.app_name);
@@ -758,17 +752,17 @@ pub fn cutover_ops(
     // `ProxyController::refresh_installed_ops`). Writing the unit is deterministic,
     // lands at the final path, and causes no restart on its own, so it is safe to do
     // at the very start of the cutover; the live upstream re-registered on a change
-    // is the release serving RIGHT NOW, targeted at its ACTUAL loopback port
-    // (`live_upstream_port`, sourced from the persisted live-slot marker) rather than
-    // the new-config-derived `plan.live_port`. If `server.port` changed since the last
-    // deploy, `plan.live_port` names a port nothing listens on, so the health-gated
-    // re-register would never pass and the cutover would fail with the proxy already
-    // restarted and `:80` routeless (#2071). The candidate/flip below still use the
-    // new derived ports — the new release genuinely binds them.
+    // is the release serving RIGHT NOW, targeted at the DERIVED live-slot port
+    // (`plan.live_port`). That derived port is CORRECT here because the redeploy path
+    // refuses a concurrent `server.port` change at pre-flight (#2073,
+    // `refuse_concurrent_public_port_change`), so the public port is unchanged and the
+    // derived live port necessarily equals the port the live release actually binds —
+    // a live-safe port change is future work (Option C). The candidate/flip below use
+    // the new derived candidate port, which the new release genuinely binds.
     let mut ops = proxy.refresh_installed_ops(
         plan.public_port,
         &cfg.service_name,
-        &loopback_upstream(live_upstream_port),
+        &loopback_upstream(plan.live_port),
         &proxy_unit_snapshot_path(release_id),
     );
     ops.push(DeployOp::Run(RemoteCommand::new(
@@ -1391,14 +1385,28 @@ pub enum DeployMode {
     Redeploy {
         /// Slot the currently-live release serves on.
         live_slot: &'static str,
-        /// Loopback port the currently-live release ACTUALLY binds, read from the
-        /// live-slot marker's persisted port field (`{slot}\t{port}`). `None` for an
-        /// older slot-only marker with no port field. This is authoritative across a
-        /// `server.port` change since the last deploy (the derived
-        /// `slot_app_port(current server.port, slot)` is not), mirroring how
-        /// [`resolve_rollback_target`] reads the previous-release marker's port.
-        live_port: Option<u16>,
     },
+}
+
+/// The `--http-port` state of the currently-installed kamal-proxy systemd unit,
+/// captured in the same deploy-start probe round-trip (#2073). The redeploy path
+/// uses it to REFUSE a concurrent `server.port` change before touching the proxy:
+/// the reboot-durability restart-refresh (#2070) re-execs `kamal-proxy run` and
+/// re-registers the still-live upstream at its DERIVED port, which is only correct
+/// when the public port is unchanged — so a mismatch must fail the pre-flight
+/// rather than strand `:80` mid-cutover. Supporting a live-safe port change is
+/// tracked separately (Option C).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum InstalledProxyPort {
+    /// No proxy unit file on disk (a first-deploy shape — the durability refresh
+    /// writes it fresh). The refuse guard treats this as "nothing to conflict with".
+    Absent,
+    /// The unit file is present but its `run --http-port {N}` value could not be
+    /// read/parsed (missing flag, non-numeric, out of range, or ambiguous). The
+    /// refuse guard FAILS CLOSED here — derived correctness can't be guaranteed.
+    Unreadable,
+    /// The port the installed unit's `ExecStart … run --http-port {N}` binds.
+    Port(u16),
 }
 
 /// Delimiter appended by the deploy-start probe between the first-vs-redeploy
@@ -1407,10 +1415,23 @@ pub enum DeployMode {
 /// so it can never collide with a marker/slot value.
 const PROXY_LIST_DELIM: &str = "---autumn-kamal-proxy-list---";
 
-/// The outcome of the deploy-start probe: the first-vs-redeploy [`DeployMode`]
-/// PLUS the raw `kamal-proxy list` output captured in the SAME remote round-trip,
-/// so a drifted live-slot marker can be reconciled against the live proxy without
-/// a second probe.
+/// Delimiter appended after the `kamal-proxy list` section, before the installed
+/// proxy unit's `--http-port` grep (#2073), so the three sections ride in ONE
+/// round-trip. Its ABSENCE (older recorded output / a scripted test that stubs
+/// only the mode) is treated as [`InstalledProxyPort::Absent`] — a conservative
+/// "nothing to conflict with" so the refuse guard never fires on synthetic input.
+const PROXY_UNIT_DELIM: &str = "---autumn-kamal-proxy-unit---";
+
+/// Sentinel the probe prints in the unit section when the proxy unit file does
+/// NOT exist on disk — distinguishing [`InstalledProxyPort::Absent`] (no unit) from
+/// [`InstalledProxyPort::Unreadable`] (unit present but no parseable `--http-port`).
+const NO_PROXY_UNIT_SENTINEL: &str = "---autumn-no-proxy-unit---";
+
+/// The outcome of the deploy-start probe: the first-vs-redeploy [`DeployMode`],
+/// the raw `kamal-proxy list` output, AND the installed proxy unit's `--http-port`
+/// state — all captured in the SAME remote round-trip, so a drifted live-slot
+/// marker can be reconciled against the live proxy and a concurrent `server.port`
+/// change refused, both without a second probe.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DeployProbe {
     /// First-vs-redeploy decision (parsed exactly as before from the marker).
@@ -1418,6 +1439,38 @@ pub struct DeployProbe {
     /// Raw `kamal-proxy list` stdout (empty when the proxy could not be listed —
     /// the reconcile then falls back to the marker, fail-safe).
     pub proxy_list: String,
+    /// The installed kamal-proxy unit's `--http-port` (#2073), used by the redeploy
+    /// path to refuse a concurrent `server.port` change before touching the proxy.
+    pub installed_proxy_port: InstalledProxyPort,
+}
+
+/// Parse the probe's unit section into an [`InstalledProxyPort`] (#2073).
+///
+/// The section is the stdout the probe shell prints between [`PROXY_UNIT_DELIM`]
+/// and end-of-output:
+///
+/// - exactly the [`NO_PROXY_UNIT_SENTINEL`] → [`InstalledProxyPort::Absent`] (the
+///   `[ -f … ]` test failed: no unit file);
+/// - a single `--http-port {N}` line with an in-range `u16` → [`InstalledProxyPort::Port`];
+/// - anything else — empty (unit present but `grep` matched nothing), multiple
+///   matches, or a non-`u16` number → [`InstalledProxyPort::Unreadable`] (fail closed).
+fn parse_installed_proxy_port(section: &str) -> InstalledProxyPort {
+    let trimmed = section.trim();
+    if trimmed == NO_PROXY_UNIT_SENTINEL {
+        return InstalledProxyPort::Absent;
+    }
+    // The unit exists (the probe printed no sentinel) but we must find EXACTLY one
+    // `--http-port {N}` match — an empty section (no match) or multiple matches can't
+    // be trusted to name the bound port, so fail closed.
+    let mut lines = trimmed.lines().map(str::trim).filter(|l| !l.is_empty());
+    let (Some(single), None) = (lines.next(), lines.next()) else {
+        return InstalledProxyPort::Unreadable;
+    };
+    // `single` is like `--http-port 80`; take the trailing integer.
+    single
+        .rsplit_once(char::is_whitespace)
+        .and_then(|(_, n)| n.trim().parse::<u16>().ok())
+        .map_or(InstalledProxyPort::Unreadable, InstalledProxyPort::Port)
 }
 
 /// The full deploy-start probe: first-vs-redeploy mode AND the raw `kamal-proxy
@@ -1433,10 +1486,12 @@ pub struct DeployProbe {
 /// supervised `kamal-proxy run` service (which has no `XDG_RUNTIME_DIR` → `/tmp`),
 /// so on a real pam host the list would silently come back empty — disabling both
 /// the #1938 drift reconcile and the observed-port path.
-/// The two sections are split on [`PROXY_LIST_DELIM`]; when the delimiter is
-/// absent (older recorded output / a scripted test) the whole stdout is treated
-/// as the mode section and the proxy list is empty — the reconcile then falls
-/// back to the marker.
+/// The mode section is split off on [`PROXY_LIST_DELIM`]; the remainder is split on
+/// [`PROXY_UNIT_DELIM`] into the proxy list and the installed-unit `--http-port`
+/// grep. When a delimiter is absent (older recorded output / a scripted test) that
+/// trailing section is empty and the probe degrades safely — an empty proxy list
+/// (reconcile falls back to the marker) and [`InstalledProxyPort::Absent`] (the
+/// refuse guard treats it as "nothing to conflict with").
 ///
 /// # Errors
 ///
@@ -1449,38 +1504,46 @@ pub fn probe_deploy_state(
         "if [ -L {current} ]; then printf 'redeploy:'; cat {marker} 2>/dev/null || printf '{blue}'; \
          else printf 'first'; fi; \
          printf '\\n{delim}\\n'; \
-         env -u XDG_RUNTIME_DIR kamal-proxy list 2>/dev/null || true",
+         env -u XDG_RUNTIME_DIR kamal-proxy list 2>/dev/null || true; \
+         printf '\\n{unit_delim}\\n'; \
+         if [ -f {unit} ]; then grep -hoE -e '--http-port[[:space:]]+[0-9]+' {unit} 2>/dev/null || true; \
+         else printf '{no_unit}'; fi",
         current = shell_quote(&cfg.current_symlink()),
         marker = shell_quote(&live_slot_marker(cfg)),
         blue = SLOT_BLUE,
         delim = PROXY_LIST_DELIM,
+        unit_delim = PROXY_UNIT_DELIM,
+        unit = shell_quote(super::proxy::KAMAL_PROXY_UNIT_PATH),
+        no_unit = NO_PROXY_UNIT_SENTINEL,
     );
     let out = exec.run(&RemoteCommand::new("detect-current", shell))?;
-    let (mode_part, proxy_list) = out
+    let (mode_part, rest) = out
         .stdout
         .split_once(PROXY_LIST_DELIM)
         .unwrap_or((out.stdout.as_str(), ""));
+    // Split the proxy list from the installed-unit section. A missing unit delimiter
+    // (older/scripted output) → empty unit section → `Absent` (never a spurious refuse).
+    let (proxy_list, installed_proxy_port) = match rest.split_once(PROXY_UNIT_DELIM) {
+        Some((list, unit_section)) => (list, parse_installed_proxy_port(unit_section)),
+        None => (rest, InstalledProxyPort::Absent),
+    };
     let mode = mode_part
         .trim()
         .strip_prefix("redeploy:")
         .map_or(DeployMode::First, |marker| {
             // The live-slot marker is `{slot}\t{port}` (older markers are slot-only);
-            // the slot is the FIRST tab-separated field either way.
-            let mut fields = marker.split('\t');
-            let live_slot = canonical_slot(fields.next().unwrap_or(SLOT_BLUE));
-            // Parse the persisted port (SECOND field) so the cutover can re-register
-            // the live release at the port it ACTUALLY binds — correct across a
-            // `server.port` change — mirroring how `resolve_rollback_target` reads the
-            // previous-release marker's port. An older slot-only marker → `None`.
-            let live_port = fields.next().and_then(|p| p.trim().parse::<u16>().ok());
-            DeployMode::Redeploy {
-                live_slot,
-                live_port,
-            }
+            // the slot is the FIRST tab-separated field either way. The persisted port
+            // (SECOND field, when present) is not read here — the cutover re-register
+            // uses the DERIVED port, which the pre-flight refuse guard (#2073) proves
+            // equals the actual live port by rejecting any concurrent `server.port`
+            // change. The marker keeps persisting the port for forward-compatibility.
+            let live_slot = canonical_slot(marker.split('\t').next().unwrap_or(SLOT_BLUE));
+            DeployMode::Redeploy { live_slot }
         });
     Ok(DeployProbe {
         mode,
         proxy_list: proxy_list.to_owned(),
+        installed_proxy_port,
     })
 }
 
@@ -2245,17 +2308,11 @@ mod tests {
     }
 
     /// Redeploy cutover ops: the live release is on blue, so the candidate takes
-    /// green (loopback 3002).
+    /// green (loopback 3002). The cutover re-registers the still-live OLD release at
+    /// the DERIVED live-slot port (`plan.live_port`, blue = 3001) — correct because
+    /// the redeploy path refuses a concurrent `server.port` change at pre-flight
+    /// (#2073), so the public port is unchanged and derived == actual.
     fn sample_cutover_ops(env: Secret) -> Vec<DeployOp> {
-        // Default: the live release's actual port matches the config-derived port
-        // (no `server.port` change since the last deploy), so the re-register target
-        // is `plan.live_port` (blue = 3001) — the pre-#2071 behavior every other
-        // cutover test asserts.
-        let plan = SlotPlan::redeploy(3000, SLOT_BLUE);
-        sample_cutover_ops_with_live_port(env, plan.live_port)
-    }
-
-    fn sample_cutover_ops_with_live_port(env: Secret, live_upstream_port: u16) -> Vec<DeployOp> {
         let cfg = resolved();
         let plan = SlotPlan::redeploy(3000, SLOT_BLUE);
         let unit = super::super::render_app_unit(
@@ -2273,7 +2330,6 @@ mod tests {
             &sample_manifests(),
             RELEASE_ID,
             &plan,
-            live_upstream_port,
         )
     }
 
@@ -2624,58 +2680,6 @@ mod tests {
         assert!(
             gate < do_restart && do_restart < reregister,
             "order must be change-gate → restart → re-register: {restart_sh}"
-        );
-    }
-
-    #[test]
-    fn cutover_reregisters_live_release_at_its_actual_persisted_port() {
-        // Issue #2071 P2: if `server.port` changed since the last deploy, the live
-        // (OLD) release still binds the port derived from the PREVIOUS config, not the
-        // new one. The cutover proxy-refresh re-register must target that ACTUAL live
-        // port (sourced from the live-slot marker), NOT the new-config-derived
-        // `plan.live_port` — otherwise the health-gated re-register aims at a dead port
-        // and the deploy fails with the proxy already restarted and `:80` routeless.
-        let plan = SlotPlan::redeploy(3000, SLOT_BLUE);
-        let derived = plan.live_port; // 3001 under the NEW config (public_port 3000)
-        let actual = 4001; // blue's port under the OLD server.port = 4000
-        assert_ne!(
-            derived, actual,
-            "the scenario is meaningful only when server.port changed"
-        );
-
-        let ops = sample_cutover_ops_with_live_port(
-            Secret::new("AUTUMN_SECURITY__SIGNING_SECRET=x\n"),
-            actual,
-        );
-        let exec = RecordingExecutor::new();
-        run_ops(&ops, &exec).expect("recording executor never fails");
-
-        // The change-gated re-register of the still-live OLD release targets its ACTUAL
-        // persisted port (4001), never the new-config-derived port (3001).
-        let restart_sh = exec
-            .shell_for("proxy-restart-if-changed")
-            .expect("restart-if-changed ran");
-        assert!(
-            restart_sh.contains("kamal-proxy deploy 'myapp' --target '127.0.0.1:4001'"),
-            "re-register must target the live release's ACTUAL persisted port (4001): {restart_sh}"
-        );
-        assert!(
-            !restart_sh.contains("127.0.0.1:3001"),
-            "re-register must NOT target the new-config-derived port (3001): {restart_sh}"
-        );
-
-        // The CANDIDATE and the flip are unchanged — the new release genuinely binds
-        // the new derived candidate port (green = 3002); only the OLD-release
-        // re-register uses the persisted live port.
-        let flip = exec.shell_for("proxy-flip").expect("flip ran");
-        assert!(
-            flip.contains("kamal-proxy deploy 'myapp' --target '127.0.0.1:3002'"),
-            "the candidate flip still targets the new derived candidate port (3002): {flip}"
-        );
-        let gate = exec.shell_for("readiness-gate").expect("gate ran");
-        assert!(
-            gate.contains("127.0.0.1:3002/ready"),
-            "readiness gate still probes the candidate's new derived port (3002): {gate}"
         );
     }
 
@@ -3833,33 +3837,31 @@ mod tests {
         );
         // `current` present + marker says green → redeploy onto blue candidate.
         // New-format live-slot marker is `{slot}\t{port}`: the slot is the FIRST
-        // field, the trailing port must not leak into the parsed slot.
+        // field, the trailing port must not leak into the parsed slot (and the port
+        // itself is no longer parsed into the mode — the derived port is used, proven
+        // correct by the #2073 refuse guard).
         let redeploy =
             RecordingExecutor::new().with_stdout("detect-current", "redeploy:green\t3002");
         assert_eq!(
             probe_deploy_state(&cfg, &redeploy).unwrap().mode,
             DeployMode::Redeploy {
                 live_slot: SLOT_GREEN,
-                live_port: Some(3002),
             }
         );
-        // Backward-compat: an older slot-only marker (no port field) still parses, and
-        // reports `None` for the port (the caller falls back to the derived port).
+        // Backward-compat: an older slot-only marker (no port field) still parses.
         let legacy = RecordingExecutor::new().with_stdout("detect-current", "redeploy:green");
         assert_eq!(
             probe_deploy_state(&cfg, &legacy).unwrap().mode,
             DeployMode::Redeploy {
                 live_slot: SLOT_GREEN,
-                live_port: None,
             }
         );
-        // A missing/blank marker on a redeploy defaults the live slot to blue, no port.
+        // A missing/blank marker on a redeploy defaults the live slot to blue.
         let default_blue = RecordingExecutor::new().with_stdout("detect-current", "redeploy:");
         assert_eq!(
             probe_deploy_state(&cfg, &default_blue).unwrap().mode,
             DeployMode::Redeploy {
                 live_slot: SLOT_BLUE,
-                live_port: None,
             }
         );
     }
@@ -3887,7 +3889,6 @@ mod tests {
             probe.mode,
             DeployMode::Redeploy {
                 live_slot: SLOT_BLUE,
-                live_port: Some(3001),
             }
         );
         assert!(
@@ -3912,19 +3913,122 @@ mod tests {
             shell.contains("env -u XDG_RUNTIME_DIR kamal-proxy list"),
             "probe socket-pins the kamal-proxy list invocation: {shell}"
         );
-        // No delimiter in the output (older/scripted) → empty list, mode unchanged.
+        // No delimiter in the output (older/scripted) → empty list, mode unchanged,
+        // and the installed-proxy-port degrades to Absent (never a spurious refuse).
         let legacy = RecordingExecutor::new().with_stdout("detect-current", "redeploy:green\t3002");
         let probe = probe_deploy_state(&cfg, &legacy).unwrap();
         assert_eq!(
             probe.mode,
             DeployMode::Redeploy {
                 live_slot: SLOT_GREEN,
-                live_port: Some(3002),
             }
         );
         assert!(
             probe.proxy_list.is_empty(),
             "no delimiter → empty proxy list"
+        );
+        assert_eq!(
+            probe.installed_proxy_port,
+            InstalledProxyPort::Absent,
+            "a missing unit delimiter degrades to Absent (no spurious refuse)"
+        );
+    }
+
+    #[test]
+    fn probe_deploy_state_captures_the_installed_proxy_port() {
+        let cfg = resolved();
+        // Realistic full probe stdout: mode, the list section, then the unit section
+        // carrying the installed unit's `run --http-port 80` grep result.
+        let stdout = format!(
+            "redeploy:blue\t3001\n---autumn-kamal-proxy-list---\n{}\n\
+             ---autumn-kamal-proxy-unit---\n--http-port 80",
+            proxy_list_serving("myapp", 3001)
+        );
+        let exec = RecordingExecutor::new().with_stdout("detect-current", stdout);
+        let probe = probe_deploy_state(&cfg, &exec).unwrap();
+        assert_eq!(
+            probe.installed_proxy_port,
+            InstalledProxyPort::Port(80),
+            "the installed unit's --http-port is captured"
+        );
+        // The proxy list section is still cleanly split off (the unit delimiter does
+        // not leak into it).
+        assert!(
+            probe.proxy_list.contains("127.0.0.1:3001")
+                && !probe.proxy_list.contains("--http-port"),
+            "the list section is split off from the unit section: {}",
+            probe.proxy_list
+        );
+        // The probe shell reads the installed unit's --http-port, guarded on the unit
+        // file existing, from the shared kamal-proxy unit path.
+        let shell = exec.shell_for("detect-current").expect("probe ran");
+        assert!(
+            shell.contains("--http-port")
+                && shell.contains("/etc/systemd/system/kamal-proxy.service")
+                && shell.contains("[ -f "),
+            "probe greps the installed unit's --http-port guarded on the file: {shell}"
+        );
+
+        // Unit file absent → the probe prints the no-unit sentinel → Absent.
+        let absent = RecordingExecutor::new().with_stdout(
+            "detect-current",
+            "redeploy:blue\t3001\n---autumn-kamal-proxy-list---\n\
+             ---autumn-kamal-proxy-unit---\n---autumn-no-proxy-unit---",
+        );
+        assert_eq!(
+            probe_deploy_state(&cfg, &absent)
+                .unwrap()
+                .installed_proxy_port,
+            InstalledProxyPort::Absent,
+            "the no-unit sentinel parses to Absent"
+        );
+
+        // Unit present but no parseable --http-port (empty unit section) → Unreadable
+        // (fail closed).
+        let unreadable = RecordingExecutor::new().with_stdout(
+            "detect-current",
+            "redeploy:blue\t3001\n---autumn-kamal-proxy-list---\n\
+             ---autumn-kamal-proxy-unit---\n",
+        );
+        assert_eq!(
+            probe_deploy_state(&cfg, &unreadable)
+                .unwrap()
+                .installed_proxy_port,
+            InstalledProxyPort::Unreadable,
+            "a present unit with no readable --http-port fails closed as Unreadable"
+        );
+    }
+
+    #[test]
+    fn parse_installed_proxy_port_classifies_the_unit_section() {
+        // Sentinel → Absent.
+        assert_eq!(
+            parse_installed_proxy_port("---autumn-no-proxy-unit---"),
+            InstalledProxyPort::Absent
+        );
+        // A single `--http-port N` match → Port(N) (whitespace tolerant).
+        assert_eq!(
+            parse_installed_proxy_port("--http-port 80"),
+            InstalledProxyPort::Port(80)
+        );
+        assert_eq!(
+            parse_installed_proxy_port("  --http-port    3000  "),
+            InstalledProxyPort::Port(3000)
+        );
+        // Empty (unit present, no match) → Unreadable (fail closed).
+        assert_eq!(
+            parse_installed_proxy_port("   "),
+            InstalledProxyPort::Unreadable
+        );
+        // Ambiguous (two matches) → Unreadable (fail closed).
+        assert_eq!(
+            parse_installed_proxy_port("--http-port 80\n--http-port 8080"),
+            InstalledProxyPort::Unreadable
+        );
+        // Non-u16 / overflow → Unreadable.
+        assert_eq!(
+            parse_installed_proxy_port("--http-port 99999"),
+            InstalledProxyPort::Unreadable
         );
     }
 

--- a/autumn-cli/src/deploy/proxy.rs
+++ b/autumn-cli/src/deploy/proxy.rs
@@ -74,6 +74,16 @@ const REQUIRED_DEPLOY_FLAGS: &[&str] = &[
 /// matching the `--host <h> --tls` segment `deploy_shell` adds for a TLS app.
 const REQUIRED_TLS_DEPLOY_FLAGS: &[&str] = &["--host", "--tls"];
 
+/// Extra `deploy` flag the post-restart live-route RE-REGISTER emits (issue
+/// #2071). The re-register in [`KamalProxyController::refresh_installed_ops`] runs
+/// `kamal-proxy deploy … --force` (NOT the route/flip), so `--force` is part of
+/// the CLI surface this controller can emit and the compat probe must guard it too
+/// — otherwise a drifted binary lacking `--force` would only surface at
+/// re-register time (post-restart), the worst possible moment. It is kept separate
+/// from [`REQUIRED_DEPLOY_FLAGS`] precisely because it is NOT emitted on every
+/// route/flip, only on the re-register.
+const REQUIRED_REREGISTER_FLAGS: &[&str] = &["--force"];
+
 /// A read-only CLI-surface compatibility probe a [`ProxyController`] can declare,
 /// run ONCE before any cutover (issue #2053).
 ///
@@ -248,10 +258,21 @@ impl KamalProxyController {
         self
     }
 
-    /// The single `kamal-proxy deploy` invocation shared by the initial route and
-    /// the health-gated flip. Centralized so the exact CLI contract lives in one
-    /// place (a Caddy controller would replace THIS with an admin-API call).
-    fn deploy_shell(&self, service: &str, target: &str) -> String {
+    /// The single `kamal-proxy deploy` invocation shared by the initial route, the
+    /// health-gated flip, and the post-restart live-route re-register. Centralized
+    /// so the exact CLI contract lives in one place (a Caddy controller would
+    /// replace THIS with an admin-API call).
+    ///
+    /// `force` appends `--force`, which makes kamal-proxy install+persist the route
+    /// WITHOUT waiting for a fresh `/ready` health check (issue #2071). It is passed
+    /// `true` ONLY by the re-register in [`Self::refresh_installed_ops`] — which is
+    /// re-pinning a route to the release that is ALREADY LIVE and serving, so a
+    /// fresh readiness gate is both unnecessary and dangerous (a transient `/ready`
+    /// blip during the one-time durability restart could otherwise strand `:80` or
+    /// abort the deploy). The initial route ([`Self::route_op`]) and the cutover
+    /// flip ([`Self::flip_op`]) pass `false` and STAY health-gated (unchanged): they
+    /// route to a candidate whose readiness must genuinely be proven first.
+    fn deploy_shell(&self, service: &str, target: &str, force: bool) -> String {
         // Every string parameter is shell-quoted so a service name, upstream, or
         // health-check path carrying query params / special chars can't break out
         // of the command. The numeric timeouts need no quoting.
@@ -274,9 +295,14 @@ impl KamalProxyController {
         let tls = self.tls_host.as_deref().map_or_else(String::new, |host| {
             format!("--host {host} --tls ", host = shell_quote(host))
         });
+        // `--force` (re-register only, issue #2071) trails the stable flag block, so
+        // for the common route/flip (`force = false`) the command is byte-for-byte
+        // the prior health-gated form.
+        let force_flag = if force { " --force" } else { "" };
         format!(
             "env -u XDG_RUNTIME_DIR kamal-proxy deploy {service} --target {target} \
-             --health-check-path {path} {tls}--deploy-timeout {deploy}s --drain-timeout {drain}s",
+             --health-check-path {path} {tls}--deploy-timeout {deploy}s \
+             --drain-timeout {drain}s{force_flag}",
             service = shell_quote(service),
             target = shell_quote(target),
             path = shell_quote(&self.health_check_path),
@@ -305,13 +331,17 @@ impl KamalProxyController {
     }
 
     /// The `deploy` flags this controller requires to be present in the probe
-    /// output — the base set plus the TLS flags when TLS is enabled.
+    /// output — the base set, the TLS flags when TLS is enabled, and the
+    /// re-register `--force` (#2071). The compat probe guards every flag the
+    /// controller can emit on ANY deploy invocation, so `--force` is included even
+    /// though only the post-restart re-register passes it.
     #[must_use]
     pub fn required_deploy_flags(&self) -> Vec<&'static str> {
         let mut flags = REQUIRED_DEPLOY_FLAGS.to_vec();
         if self.tls_host.is_some() {
             flags.extend_from_slice(REQUIRED_TLS_DEPLOY_FLAGS);
         }
+        flags.extend_from_slice(REQUIRED_REREGISTER_FLAGS);
         flags
     }
 
@@ -412,16 +442,20 @@ impl ProxyController for KamalProxyController {
     }
 
     fn route_op(&self, service: &str, upstream: &str) -> DeployOp {
+        // First-deploy route: health-gated (force = false) — the candidate's
+        // readiness must be proven before it receives live traffic.
         DeployOp::Run(RemoteCommand::new(
             "proxy-route",
-            self.deploy_shell(service, upstream),
+            self.deploy_shell(service, upstream, false),
         ))
     }
 
     fn flip_op(&self, service: &str, new_upstream: &str) -> DeployOp {
+        // Cutover flip: health-gated (force = false) — this is THE readiness gate
+        // that keeps an unready candidate from ever taking live traffic.
         DeployOp::Run(RemoteCommand::new(
             "proxy-flip",
-            self.deploy_shell(service, new_upstream),
+            self.deploy_shell(service, new_upstream, false),
         ))
     }
 
@@ -468,15 +502,32 @@ impl ProxyController for KamalProxyController {
         //     readiness window (a zero-downtime violation). Re-registering the CURRENT
         //     live upstream (the slot serving at cutover-start) right after the
         //     restart bounds the routeless window to ~the restart itself.
+        //   * The re-register uses `--force` (#2071). It is re-pinning a route to the
+        //     release that is ALREADY LIVE and serving, so a fresh readiness gate is
+        //     both unnecessary and DANGEROUS: a health-gated re-register would block
+        //     on a fresh `/ready` pass, and a transient `/ready` blip during the
+        //     one-time restart could strand :80 or abort the whole deploy (up to
+        //     30×deploy-timeout). `--force` makes kamal-proxy install+persist the
+        //     route IMMEDIATELY (it skips `WaitUntilHealthy` but still runs
+        //     `saveStateSnapshot`), and the target self-heals via background health
+        //     checks (~1s) — during a real blip it starts serving the instant
+        //     `/ready` recovers, WITHOUT failing the deploy. (A residual ~1s
+        //     `TargetStateAdding` window before the first background `/ready` pass
+        //     remains — kamal-proxy won't route to an unready backend — a documented
+        //     footnote, not a hard failure.)
         //   * The restart and the re-register are ONE remote command, so no SSH
-        //     round-trip can interpose between them, and a bounded retry rides out the
-        //     brief window before the just-restarted proxy's control socket accepts a
-        //     route.
+        //     round-trip can interpose between them. Because `--force` returns
+        //     WITHOUT waiting for readiness, the re-register succeeds on the first
+        //     attempt in the normal case; the long 30×deploy-timeout burn is gone.
+        //     A SMALL bounded retry (5) is kept only to ride out a transient CLI /
+        //     control-socket hiccup in the brief window before the just-restarted
+        //     proxy's socket accepts a connection.
         //   * An UNCHANGED unit (steady-state redeploy) takes NEITHER branch — today's
         //     no-restart behavior is preserved exactly, so a routine redeploy never
         //     churns the shared proxy.
-        // The re-register reuses `deploy_shell`, so it keeps the `env -u
-        // XDG_RUNTIME_DIR` control-socket pin (#2019) and any `--host/--tls` segment.
+        // The re-register reuses `deploy_shell` (with `force = true`), so it keeps the
+        // `env -u XDG_RUNTIME_DIR` control-socket pin (#2019) and any `--host/--tls`
+        // segment. The `|| exit 1` fail-fast on `systemctl restart` is unchanged.
         ops.push(DeployOp::Run(RemoteCommand::new(
             "proxy-restart-if-changed",
             format!(
@@ -489,11 +540,11 @@ impl ProxyController for KamalProxyController {
                  n=0; \
                  until {reregister}; do \
                  n=$((n+1)); \
-                 if [ \"$n\" -ge 30 ]; then \
+                 if [ \"$n\" -ge 5 ]; then \
                  echo 'kamal-proxy did not accept the live route after restart' >&2; exit 1; fi; \
                  sleep 0.5; \
                  done",
-                reregister = self.deploy_shell(service, live_upstream),
+                reregister = self.deploy_shell(service, live_upstream, true),
             ),
         )));
         ops
@@ -671,6 +722,64 @@ mod tests {
             cmd.shell,
             "env -u XDG_RUNTIME_DIR kamal-proxy deploy 'myapp' --target '127.0.0.1:3002' \
              --health-check-path '/ready' --deploy-timeout 60s --drain-timeout 30s",
+        );
+    }
+
+    #[test]
+    fn reregister_is_forced_but_route_and_flip_stay_health_gated() {
+        // #2071: the post-restart re-register re-pins the ALREADY-LIVE upstream, so it
+        // must use `--force` (install+persist immediately, no fresh readiness gate a
+        // transient /ready blip could fail). The first-deploy route and the cutover
+        // flip route to a candidate whose readiness must be PROVEN, so they stay
+        // health-gated (NO --force) — unchanged.
+        let proxy = KamalProxyController::new(60);
+
+        // The re-register (last op of the refresh) is forced, socket-pinned, and
+        // targets the LIVE upstream.
+        let ops = proxy.refresh_installed_ops(8080, "myapp", "127.0.0.1:3001", "/tmp/snap.sha256");
+        let DeployOp::Run(restart) = ops.last().expect("has ops") else {
+            panic!("last op must be the restart/re-register");
+        };
+        assert!(
+            restart.shell.contains(
+                "env -u XDG_RUNTIME_DIR kamal-proxy deploy 'myapp' --target '127.0.0.1:3001' \
+                 --health-check-path '/ready' --deploy-timeout 60s --drain-timeout 30s --force"
+            ),
+            "re-register must be forced + socket-pinned + target the live upstream: {}",
+            restart.shell,
+        );
+        // The `|| exit 1` fail-fast on the restart itself is preserved.
+        assert!(
+            restart
+                .shell
+                .contains("systemctl restart kamal-proxy.service || exit 1"),
+            "restart fail-fast must be preserved: {}",
+            restart.shell,
+        );
+        // With --force the deploy returns without waiting, so the long 30×retry burn
+        // is gone — only a SMALL bounded retry (5) rides out a transient socket hiccup.
+        assert!(
+            restart.shell.contains("if [ \"$n\" -ge 5 ]"),
+            "the retry ceiling is small (5), not the old 30: {}",
+            restart.shell,
+        );
+
+        // The cutover flip and the first-deploy route are health-gated: NO --force.
+        let DeployOp::Run(flip) = proxy.flip_op("myapp", "127.0.0.1:3002") else {
+            panic!("flip_op must be a Run op");
+        };
+        assert!(
+            !flip.shell.contains("--force"),
+            "the cutover flip must STAY health-gated (no --force): {}",
+            flip.shell,
+        );
+        let DeployOp::Run(route) = proxy.route_op("myapp", "127.0.0.1:3002") else {
+            panic!("route_op must be a Run op");
+        };
+        assert!(
+            !route.shell.contains("--force"),
+            "the first-deploy route must STAY health-gated (no --force): {}",
+            route.shell,
         );
     }
 
@@ -951,10 +1060,13 @@ mod tests {
         assert!(
             s.contains(
                 "env -u XDG_RUNTIME_DIR kamal-proxy deploy 'myapp' --target '127.0.0.1:3001' \
-                 --health-check-path '/ready' --deploy-timeout 60s --drain-timeout 30s"
+                 --health-check-path '/ready' --deploy-timeout 60s --drain-timeout 30s --force"
             ),
-            "re-register the current live upstream, socket-pinned: {s}"
+            "re-register the current live upstream, socket-pinned and forced (#2071): {s}"
         );
+        // The re-register is FORCED (#2071): re-pinning the already-live upstream must
+        // not block on a fresh readiness gate that a transient /ready blip could fail.
+        assert!(s.contains("--force"), "re-register must be --force: {s}");
         assert!(
             s.contains("rm -f '/tmp/autumn-kamal-proxy-unit-REL.sha256'"),
             "the scratch snapshot is cleaned up: {s}"
@@ -983,9 +1095,9 @@ mod tests {
             restart.shell.contains(
                 "env -u XDG_RUNTIME_DIR kamal-proxy deploy 'myapp' --target '127.0.0.1:3001' \
                  --health-check-path '/ready' --host 'app.example.com' --tls \
-                 --deploy-timeout 60s --drain-timeout 30s"
+                 --deploy-timeout 60s --drain-timeout 30s --force"
             ),
-            "TLS re-register carries --host/--tls: {}",
+            "TLS re-register carries --host/--tls and --force: {}",
             restart.shell,
         );
     }
@@ -1035,7 +1147,8 @@ mod tests {
          \x20     --host strings                Host(s) to route\n\
          \x20     --tls                         Configure TLS for this service\n\
          \x20     --deploy-timeout duration     How long to wait for the target\n\
-         \x20     --drain-timeout duration      How long to drain the old target\n"
+         \x20     --drain-timeout duration      How long to drain the old target\n\
+         \x20     --force                       Skip health checks and force deployment\n"
     }
 
     #[test]
@@ -1057,6 +1170,9 @@ mod tests {
                 "--health-check-path",
                 "--deploy-timeout",
                 "--drain-timeout",
+                // The post-restart re-register (#2071) emits `--force`, so the probe
+                // guards it too.
+                "--force",
             ],
         );
         let with_tls =
@@ -1070,15 +1186,18 @@ mod tests {
                 "--drain-timeout",
                 "--host",
                 "--tls",
+                "--force",
             ],
         );
-        // Every required flag is one deploy_shell actually emits, so the contract
-        // can never drift from what the controller passes.
-        let flip_shell = with_tls.deploy_shell("svc", "127.0.0.1:3001");
+        // Every required flag is one deploy_shell actually emits (checking the
+        // re-register form, `force = true`, which is the superset that emits every
+        // flag including `--force`), so the contract can never drift from what the
+        // controller passes.
+        let reregister_shell = with_tls.deploy_shell("svc", "127.0.0.1:3001", true);
         for flag in with_tls.required_deploy_flags() {
             assert!(
-                flip_shell.contains(flag),
-                "required flag {flag} must be one deploy_shell emits, got: {flip_shell}",
+                reregister_shell.contains(flag),
+                "required flag {flag} must be one deploy_shell emits, got: {reregister_shell}",
             );
         }
     }
@@ -1094,7 +1213,7 @@ mod tests {
         // Non-TLS controller does not require --host/--tls, so a help capture that
         // lacks them is still compatible for it.
         let no_tls_help = "Flags:\n  --target x\n  --health-check-path p\n  \
-                           --deploy-timeout d\n  --drain-timeout d\n";
+                           --deploy-timeout d\n  --drain-timeout d\n  --force\n";
         assert_eq!(
             KamalProxyController::new(60).assess_deploy_help(no_tls_help),
             Ok(()),
@@ -1104,9 +1223,10 @@ mod tests {
     #[test]
     fn tls_controller_requires_tls_flags() {
         // With TLS enabled, a help capture missing --tls is incompatible for THIS
-        // controller even though a non-TLS controller would accept it.
+        // controller even though a non-TLS controller would accept it. (`--force` is
+        // present so the ONLY missing flag under test is `--tls`.)
         let no_tls_help = "Flags:\n  --target x\n  --health-check-path p\n  \
-                           --deploy-timeout d\n  --drain-timeout d\n  --host h\n";
+                           --deploy-timeout d\n  --drain-timeout d\n  --host h\n  --force\n";
         let with_tls =
             KamalProxyController::new(60).with_tls_host(Some("app.example.com".to_owned()));
         assert_eq!(

--- a/autumn-cli/src/deploy/proxy.rs
+++ b/autumn-cli/src/deploy/proxy.rs
@@ -44,8 +44,10 @@ use super::exec::{DeployOp, FileContents, RemoteCommand, shell_quote};
 /// Absolute path the proxy binary is expected at on the target.
 const KAMAL_PROXY_BIN: &str = "/usr/local/bin/kamal-proxy";
 
-/// Systemd unit path supervising the proxy process.
-const KAMAL_PROXY_UNIT_PATH: &str = "/etc/systemd/system/kamal-proxy.service";
+/// Systemd unit path supervising the proxy process. `pub` (crate-internal in this
+/// binary crate) so the deploy-start probe ([`super::exec::probe_deploy_state`]) can
+/// read the installed unit's `--http-port` in the same round-trip (#2073).
+pub const KAMAL_PROXY_UNIT_PATH: &str = "/etc/systemd/system/kamal-proxy.service";
 
 /// Known-good kamal-proxy version this controller's CLI contract was verified
 /// against — the same version the real-VPS validation harness pins

--- a/autumn-cli/src/deploy/proxy.rs
+++ b/autumn-cli/src/deploy/proxy.rs
@@ -528,6 +528,11 @@ impl ProxyController for KamalProxyController {
         // The re-register reuses `deploy_shell` (with `force = true`), so it keeps the
         // `env -u XDG_RUNTIME_DIR` control-socket pin (#2019) and any `--host/--tls`
         // segment. The `|| exit 1` fail-fast on `systemctl restart` is unchanged.
+        //
+        // Operator advisory: do not combine the one-time proxy reboot-durability
+        // upgrade with a `deploy.tls.host` change in the same deploy — the pre-flip
+        // route refresh re-registers the live release with the current TLS host, so
+        // a failed rollback could strand the previous host. Tracked in #2074.
         ops.push(DeployOp::Run(RemoteCommand::new(
             "proxy-restart-if-changed",
             format!(

--- a/autumn-cli/src/deploy/proxy.rs
+++ b/autumn-cli/src/deploy/proxy.rs
@@ -483,7 +483,7 @@ impl ProxyController for KamalProxyController {
                  rm -f {snap}; \
                  if [ \"$new\" = \"$old\" ]; then exit 0; fi; \
                  if ! systemctl is-active --quiet kamal-proxy.service; then exit 0; fi; \
-                 systemctl restart kamal-proxy.service; \
+                 systemctl restart kamal-proxy.service || exit 1; \
                  n=0; \
                  until {reregister}; do \
                  n=$((n+1)); \

--- a/autumn-cli/src/deploy/proxy.rs
+++ b/autumn-cli/src/deploy/proxy.rs
@@ -144,6 +144,34 @@ pub trait ProxyController {
     /// `public_port` (idempotent — safe to run on every deploy).
     fn ensure_installed_ops(&self, public_port: u16) -> Vec<DeployOp>;
 
+    /// Ordered ops that REFRESH the supervised proxy on a redeploy/upgrade (issue
+    /// #2070): (idempotently) re-write + enable the unit, and — for a controller
+    /// that supervises an unpinned long-running proxy (kamal-proxy) — restart it to
+    /// adopt a CHANGED unit while IMMEDIATELY re-registering the still-live
+    /// `live_upstream` (`host:port`, the slot serving at cutover-start) so the
+    /// public port is routeless for only ~the restart rather than the entire
+    /// candidate-start + migrate + readiness window a naive restart would strand.
+    ///
+    /// `snapshot_path` is a per-deploy scratch path the implementation may use to
+    /// capture the pre-write unit so it can decide whether the unit ACTUALLY changed
+    /// (an unchanged unit must NOT restart — that preserves today's steady-state
+    /// no-restart behavior).
+    ///
+    /// The default is exactly [`Self::ensure_installed_ops`] (write + enable, NO
+    /// restart): a controller that provisions its own pinned binary/config and has
+    /// nothing to "restart to adopt" — e.g. a future `CaddyController` — inherits
+    /// the first-deploy behavior unchanged, so only kamal-proxy overrides this.
+    fn refresh_installed_ops(
+        &self,
+        public_port: u16,
+        service: &str,
+        live_upstream: &str,
+        snapshot_path: &str,
+    ) -> Vec<DeployOp> {
+        let _ = (service, live_upstream, snapshot_path);
+        self.ensure_installed_ops(public_port)
+    }
+
     /// Op that points `service`'s public port at `upstream` (`host:port`) for the
     /// first time (first deploy — there is nothing to swap yet).
     fn route_op(&self, service: &str, upstream: &str) -> DeployOp;
@@ -393,6 +421,80 @@ impl ProxyController for KamalProxyController {
             "proxy-flip",
             self.deploy_shell(service, new_upstream),
         ))
+    }
+
+    fn refresh_installed_ops(
+        &self,
+        public_port: u16,
+        service: &str,
+        live_upstream: &str,
+        snapshot_path: &str,
+    ) -> Vec<DeployOp> {
+        let unit = shell_quote(KAMAL_PROXY_UNIT_PATH);
+        let snap = shell_quote(snapshot_path);
+
+        // (1) Snapshot the CURRENTLY-installed unit's CONTENT hash BEFORE the write
+        // below overwrites it. A rewrite always bumps the file's mtime even when the
+        // bytes are identical, so systemd's own change tracking (`NeedDaemonReload`)
+        // cannot distinguish "actually changed" from "merely rewritten" — a content
+        // hash can. An absent file yields an empty hash, which compares unequal to
+        // the freshly-written one and so counts as "changed" (correct: a brand-new
+        // unit is a change). This is deliberately a HASH, not a copy of the unit
+        // (one of the two mechanisms the design allows), so the scratch file is tiny.
+        let snapshot = DeployOp::Run(RemoteCommand::new(
+            "proxy-snapshot-unit",
+            format!("{{ sha256sum {unit} 2>/dev/null || true; }} | cut -d' ' -f1 > {snap}"),
+        ));
+
+        let mut ops = Vec::with_capacity(4);
+        ops.push(snapshot);
+        // (2)+(3) The idempotent install — write the refreshed unit to its FINAL path
+        // + daemon-reload + `enable --now` — byte-for-byte the first-deploy path
+        // (labels `proxy-write-unit` / `proxy-install`). This is what makes the
+        // reboot-durable `StateDirectory`/`HOME` unit (#2069) reach EXISTING hosts on
+        // every redeploy. On its own it restarts NO running process: `enable --now`
+        // never relaunches an already-active unit, so a live proxy keeps serving with
+        // its old settings until the change-gated restart below (if any).
+        ops.extend(self.ensure_installed_ops(public_port));
+        // (4) Restart ONLY when the unit CONTENT actually changed AND the proxy is
+        // live, then IMMEDIATELY re-register the current live upstream. Rationale:
+        //   * A fresh `kamal-proxy run` restores its LAST-SAVED routing table on
+        //     start; on the first upgrade onto the persistent `StateDirectory` that
+        //     table is empty, so a bare restart would leave the public port routeless
+        //     until the next deploy step re-registered it — and a naive restart at
+        //     cutover-start would strand :80 for the WHOLE candidate-start + migrate +
+        //     readiness window (a zero-downtime violation). Re-registering the CURRENT
+        //     live upstream (the slot serving at cutover-start) right after the
+        //     restart bounds the routeless window to ~the restart itself.
+        //   * The restart and the re-register are ONE remote command, so no SSH
+        //     round-trip can interpose between them, and a bounded retry rides out the
+        //     brief window before the just-restarted proxy's control socket accepts a
+        //     route.
+        //   * An UNCHANGED unit (steady-state redeploy) takes NEITHER branch — today's
+        //     no-restart behavior is preserved exactly, so a routine redeploy never
+        //     churns the shared proxy.
+        // The re-register reuses `deploy_shell`, so it keeps the `env -u
+        // XDG_RUNTIME_DIR` control-socket pin (#2019) and any `--host/--tls` segment.
+        ops.push(DeployOp::Run(RemoteCommand::new(
+            "proxy-restart-if-changed",
+            format!(
+                "new=\"$( {{ sha256sum {unit} 2>/dev/null || true; }} | cut -d' ' -f1 )\"; \
+                 old=\"$(cat {snap} 2>/dev/null || true)\"; \
+                 rm -f {snap}; \
+                 if [ \"$new\" = \"$old\" ]; then exit 0; fi; \
+                 if ! systemctl is-active --quiet kamal-proxy.service; then exit 0; fi; \
+                 systemctl restart kamal-proxy.service; \
+                 n=0; \
+                 until {reregister}; do \
+                 n=$((n+1)); \
+                 if [ \"$n\" -ge 30 ]; then \
+                 echo 'kamal-proxy did not accept the live route after restart' >&2; exit 1; fi; \
+                 sleep 0.5; \
+                 done",
+                reregister = self.deploy_shell(service, live_upstream),
+            ),
+        )));
+        ops
     }
 
     fn compat_probe(&self) -> Option<ProxyCompatProbe> {
@@ -762,6 +864,157 @@ mod tests {
         assert_eq!(
             cmd.shell,
             "systemctl daemon-reload && systemctl enable --now kamal-proxy.service",
+        );
+    }
+
+    #[test]
+    fn refresh_installed_ops_snapshots_installs_then_restarts_only_when_changed() {
+        // Issue #2070: the redeploy refresh wraps the (unchanged) idempotent install
+        // with a pre-write content snapshot and a change-gated restart that
+        // re-registers the current live upstream — WITHOUT altering the shared
+        // `ensure_installed_ops` shape (so the first-deploy path is untouched).
+        let proxy = KamalProxyController::new(60);
+        let ops = proxy.refresh_installed_ops(
+            8080,
+            "myapp",
+            "127.0.0.1:3001",
+            "/tmp/autumn-kamal-proxy-unit-REL.sha256",
+        );
+        assert_eq!(ops.len(), 4, "snapshot + write-unit + install + restart");
+
+        // (1) snapshot the live unit's content hash into the scratch path.
+        let DeployOp::Run(snapshot) = &ops[0] else {
+            panic!("op 0 must be the snapshot Run op");
+        };
+        assert_eq!(snapshot.label, "proxy-snapshot-unit");
+        assert_eq!(
+            snapshot.shell,
+            "{ sha256sum '/etc/systemd/system/kamal-proxy.service' 2>/dev/null || true; } \
+             | cut -d' ' -f1 > '/tmp/autumn-kamal-proxy-unit-REL.sha256'",
+        );
+
+        // (2)+(3) the install ops are byte-for-byte `ensure_installed_ops` (write the
+        // reboot-durable unit to its final path + the unchanged enable --now).
+        let install = proxy.ensure_installed_ops(8080);
+        match (&ops[1], &install[0]) {
+            (
+                DeployOp::WriteFile {
+                    label: l1,
+                    remote_path: p1,
+                    contents: FileContents::Plain(u1),
+                    ..
+                },
+                DeployOp::WriteFile {
+                    contents: FileContents::Plain(u2),
+                    ..
+                },
+            ) => {
+                assert_eq!(*l1, "proxy-write-unit");
+                assert_eq!(p1, KAMAL_PROXY_UNIT_PATH);
+                assert_eq!(u1, u2, "refresh writes the same unit as first deploy");
+                assert!(u1.contains("StateDirectory=kamal-proxy\n"));
+                assert!(u1.contains("Environment=HOME=/var/lib/kamal-proxy\n"));
+            }
+            _ => panic!("op 1 must re-write the proxy unit"),
+        }
+        let DeployOp::Run(inst) = &ops[2] else {
+            panic!("op 2 must be proxy-install");
+        };
+        assert_eq!(inst.label, "proxy-install");
+        assert_eq!(
+            inst.shell,
+            "systemctl daemon-reload && systemctl enable --now kamal-proxy.service",
+        );
+
+        // (4) restart-if-changed: gate on a content change, only restart an ACTIVE
+        // proxy, then re-register the current live upstream (socket-pinned, TLS-aware
+        // via deploy_shell), with a bounded retry for the post-restart socket window.
+        let DeployOp::Run(restart) = &ops[3] else {
+            panic!("op 3 must be proxy-restart-if-changed");
+        };
+        assert_eq!(restart.label, "proxy-restart-if-changed");
+        let s = &restart.shell;
+        assert!(
+            s.contains("if [ \"$new\" = \"$old\" ]; then exit 0; fi"),
+            "unchanged unit → no restart: {s}"
+        );
+        assert!(
+            s.contains("if ! systemctl is-active --quiet kamal-proxy.service; then exit 0; fi"),
+            "restart only an active proxy: {s}"
+        );
+        assert!(
+            s.contains("systemctl restart kamal-proxy.service"),
+            "restart to adopt the changed unit: {s}"
+        );
+        assert!(
+            s.contains(
+                "env -u XDG_RUNTIME_DIR kamal-proxy deploy 'myapp' --target '127.0.0.1:3001' \
+                 --health-check-path '/ready' --deploy-timeout 60s --drain-timeout 30s"
+            ),
+            "re-register the current live upstream, socket-pinned: {s}"
+        );
+        assert!(
+            s.contains("rm -f '/tmp/autumn-kamal-proxy-unit-REL.sha256'"),
+            "the scratch snapshot is cleaned up: {s}"
+        );
+        // Order within the single command: gate → restart → re-register.
+        let gate = s.find("if [ \"$new\" = \"$old\" ]").unwrap();
+        let do_restart = s.find("systemctl restart kamal-proxy.service").unwrap();
+        let reregister = s.find("kamal-proxy deploy 'myapp'").unwrap();
+        assert!(
+            gate < do_restart && do_restart < reregister,
+            "gate→restart→re-register: {s}"
+        );
+    }
+
+    #[test]
+    fn refresh_installed_ops_tls_reregister_carries_host_and_tls() {
+        // With TLS enabled, the change-gated re-register carries the same
+        // `--host <h> --tls` segment as the flip, so a restarted TLS proxy re-adopts
+        // the live route with its cert config intact.
+        let proxy = KamalProxyController::new(60).with_tls_host(Some("app.example.com".to_owned()));
+        let ops = proxy.refresh_installed_ops(8080, "myapp", "127.0.0.1:3001", "/tmp/snap.sha256");
+        let DeployOp::Run(restart) = ops.last().expect("has ops") else {
+            panic!("last op must be the restart");
+        };
+        assert!(
+            restart.shell.contains(
+                "env -u XDG_RUNTIME_DIR kamal-proxy deploy 'myapp' --target '127.0.0.1:3001' \
+                 --health-check-path '/ready' --host 'app.example.com' --tls \
+                 --deploy-timeout 60s --drain-timeout 30s"
+            ),
+            "TLS re-register carries --host/--tls: {}",
+            restart.shell,
+        );
+    }
+
+    #[test]
+    fn refresh_installed_ops_default_is_plain_install_no_restart() {
+        // A controller that provisions its own pinned binary/config (e.g. a future
+        // Caddy controller) inherits the trait default: refresh == ensure_installed,
+        // with NO snapshot and NO restart op.
+        struct PinnedController;
+        impl ProxyController for PinnedController {
+            fn ensure_installed_ops(&self, _public_port: u16) -> Vec<DeployOp> {
+                vec![DeployOp::Run(RemoteCommand::new("install", "true"))]
+            }
+            fn route_op(&self, _service: &str, _upstream: &str) -> DeployOp {
+                DeployOp::Run(RemoteCommand::new("route", "true"))
+            }
+            fn flip_op(&self, _service: &str, _new_upstream: &str) -> DeployOp {
+                DeployOp::Run(RemoteCommand::new("flip", "true"))
+            }
+        }
+        let refreshed =
+            PinnedController.refresh_installed_ops(80, "svc", "127.0.0.1:9001", "/tmp/x");
+        let installed = PinnedController.ensure_installed_ops(80);
+        assert_eq!(refreshed.len(), installed.len());
+        assert!(
+            refreshed
+                .iter()
+                .all(|op| op.label() != "proxy-restart-if-changed"
+                    && op.label() != "proxy-snapshot-unit"),
+            "the default refresh adds neither a snapshot nor a restart op",
         );
     }
 


### PR DESCRIPTION
## Before / After

**Before (#2069 landed, but only reaches *new* hosts):** the reboot-durable proxy unit — `StateDirectory=kamal-proxy` + `Environment=HOME=/var/lib/kamal-proxy` — is written only by `first_deploy_ops` (via `ensure_installed_ops`). The redeploy path (`cutover_ops`) never rewrites the unit, and `proxy-install` is `enable --now`, which does **not** restart an already-running proxy. So an **existing** host that upgrades to #2069 keeps running the old unit (HOME unset → ephemeral `/tmp` state dir) and only becomes reboot-durable if someone manually re-provisions it — the fix silently never lands on the hosts that need it most.

**After:** every redeploy refreshes the shared proxy unit, and — only when the unit **actually changed** and the proxy is live — restarts kamal-proxy to adopt the new unit and **immediately re-registers the current live upstream**, so an existing host becomes reboot-durable on its next deploy with a routeless window bounded to ~the restart.

## How (the two edits + the zero-downtime design)

**1. `cutover_ops` now refreshes the proxy unit (exec.rs).** It leads with `proxy.refresh_installed_ops(plan.public_port, &cfg.service_name, loopback_upstream(plan.live_port), snapshot_path)` — mirroring how `first_deploy_ops` starts with `ensure_installed_ops`. Writing the unit is deterministic, lands at the final path, and causes no restart on its own, so it is safe at the very start of the cutover.

**2. Restart-if-changed + immediate live-route re-register (`ProxyController::refresh_installed_ops`, proxy.rs).** New trait method with a default impl equal to `ensure_installed_ops` (no restart — a future `CaddyController` provisions its own pinned binary and inherits first-deploy behavior). `KamalProxyController` overrides it to emit, around the unchanged `ensure_installed_ops` ops:

- `proxy-snapshot-unit` — captures the **content hash** (`sha256sum`) of the currently-installed unit into a per-release scratch path *before* the write. (mtime always bumps on rewrite, so systemd's own change-tracking can't tell "changed" from "rewritten"; a content hash can. This is the "capture a hash" mechanism from the design.)
- `proxy-write-unit` + `proxy-install` — **byte-for-byte** `ensure_installed_ops` (write the reboot-durable unit to its final path + daemon-reload + `enable --now`). This is what delivers the new unit to an existing host's disk; on its own it restarts nothing.
- `proxy-restart-if-changed` — one shell command: compare new vs old hash; if **equal → exit 0** (steady-state redeploy: no restart, today's behavior preserved). If changed **and** the proxy is active: `systemctl restart kamal-proxy.service`, then a bounded retry loop that re-registers the **current live upstream** (`127.0.0.1:<live_port>` — the slot serving at cutover-start, the same target the proxy already fronts).

**Why not a naive restart:** a fresh `kamal-proxy run` restores its last-saved routing table on start; on the first upgrade onto the persistent `StateDirectory` that table is **empty**, so a bare restart leaves `:80` routeless until the next deploy step re-registers it — and a naive restart at cutover-start would strand `:80` for the **entire** candidate-start + migrate + readiness window (a zero-downtime violation). Re-registering the live upstream **immediately after the restart, in the same remote command** (no SSH round-trip can interpose, bounded retry rides out the brief post-restart socket window) bounds the routeless window to ~the restart itself. The later health-gated `proxy-flip` then swaps to the candidate as usual.

**Preserved invariants:** the `env -u XDG_RUNTIME_DIR` control-socket pin (#2019) is reused via `deploy_shell` for the re-register (and carries any `--host/--tls` segment); `render_app_unit` and the app-slot flow are untouched; the pre-flip failure boundary is unchanged (all refresh ops precede `proxy-flip`, so a failure there still auto-rolls-back with the old release serving).

**ExecStartPre decline:** an alternative was making the unit self-re-register on start via `ExecStartPre`. Declined — an `ExecStartPre` hook has no knowledge of which slot is live (that lives in the deploy plan, not on the host), can't health-gate, and would race/fight the deploy CLI's own route registration. Keeping the restart + re-register in the deploy op sequence (where `live_port` is known) is the honest, testable seam.

## Tests

- `exec::cutover_refreshes_proxy_unit_and_restarts_only_when_changed` — the redeploy path rewrites the reboot-durable unit to its final path; the refresh (snapshot → install → restart-if-changed) leads the cutover and precedes both `prepare-dirs` and `proxy-flip`; the restart is change-gated, only fires on an active proxy, and re-registers the current live upstream (`127.0.0.1:3001`) socket-pinned, in `gate → restart → re-register` order.
- `proxy::refresh_installed_ops_snapshots_installs_then_restarts_only_when_changed` — exact op shape/shell (snapshot + unchanged `ensure_installed_ops` + change-gated restart), scratch-path cleanup.
- `proxy::refresh_installed_ops_tls_reregister_carries_host_and_tls` — the re-register carries `--host/--tls` when TLS is enabled.
- `proxy::refresh_installed_ops_default_is_plain_install_no_restart` — the trait default adds neither snapshot nor restart (Caddy-swappable).
- Updated `redeploy_produces_exact_zero_downtime_sequence` to expect the leading `proxy-snapshot-unit` / `proxy-install` / `proxy-restart-if-changed`. All existing proxy / socket-pin / first-deploy / rollback tests stay green.

Local: `cargo build -p autumn-cli` OK, `cargo test -p autumn-cli` (4309 + 224 + 177 pass, 0 fail) OK, `cargo clippy -p autumn-cli --all-targets -- -D warnings` OK, `cargo fmt -p autumn-cli -- --check` OK.

Closes #2070; follow-up to #2069; Part of #1607.