### PR TITLE
ci: fix retired Hetzner server type in provision-self-hosted-runner

### DIFF
--- a/.github/self-hosted-ci-runners.md
+++ b/.github/self-hosted-ci-runners.md
@@ -145,7 +145,7 @@ and the slot would die after a single job.
 
 1. Confirm both secrets exist (§4).
 2. **Actions → "Provision self-hosted runner" → Run workflow.** Inputs:
-   - `server_type` — `cpx41` (8 vCPU / 16 GB, default) or `cpx31` (4 vCPU / 8 GB).
+   - `server_type` — `cpx42` (8 vCPU / 16 GB, default) or `cpx32` (4 vCPU / 8 GB).
    - `location` — Hetzner location, default `nbg1`.
    - `ubuntu_image` — base image, default `ubuntu-24.04`.
    - `runner_count` — number of ephemeral slots, default `6`.
@@ -234,19 +234,19 @@ than failing; flip the variable to drain them onto hosted runners immediately.
 
 | Type | vCPU | RAM | Disk | Suggested slots |
 |------|------|-----|------|-----------------|
-| `cpx31` | 4 | 8 GB | 160 GB | 3–4 |
-| `cpx41` | 8 | 16 GB | 240 GB | 6 (recommended) |
+| `cpx32` | 4 | 8 GB | 160 GB | 3–4 |
+| `cpx42` | 8 | 16 GB | 240 GB | 6 (recommended) |
 
 Rust + Docker builds are **CPU- and disk-heavy**: a cold-cache workspace build
 plus the wide-feature Postgres-testcontainer test step sits near a runner's disk
 ceiling (ci.yml actively frees disk on hosted runners for exactly this reason),
-and coverage instrumentation roughly doubles `target/` size. `cpx41` with 6
+and coverage instrumentation roughly doubles `target/` size. `cpx42` with 6
 slots gives each concurrent job ~1.3 vCPU / ~2.7 GB / ~40 GB headroom, which
-comfortably runs autumn's heaviest lanes in parallel. `cpx31` works for a
+comfortably runs autumn's heaviest lanes in parallel. `cpx32` works for a
 lighter cadence but expect fewer safe concurrent slots.
 
 **Approximate monthly cost:** on the order of a low-double-digit EUR/month for a
-`cpx31` and roughly double that for a `cpx41`, plus a small IPv4 surcharge and
+`cpx32` and roughly double that for a `cpx42`, plus a small IPv4 surcharge and
 egress. **These are ballpark figures — verify current Hetzner Cloud pricing at
 <https://www.hetzner.com/cloud> before budgeting; do not treat them as exact.**
 Billing is hourly, so deleting the box when idle (§8) genuinely stops the meter.

--- a/.github/workflows/provision-self-hosted-runner.yml
+++ b/.github/workflows/provision-self-hosted-runner.yml
@@ -14,10 +14,10 @@ on:
   workflow_dispatch:
     inputs:
       server_type:
-        description: "Hetzner type (cpx31=4 vCPU/8 GB, cpx41=8 vCPU/16 GB)"
+        description: "Hetzner type (cpx32=4 vCPU/8 GB, cpx42=8 vCPU/16 GB)"
         type: choice
-        options: [cpx41, cpx31]
-        default: cpx41
+        options: [cpx42, cpx32]
+        default: cpx42
       location:
         description: "Hetzner location"
         default: nbg1


### PR DESCRIPTION
## Before / After

**Before:** the "Provision self-hosted runner" workflow only offered the retired Hetzner shared-vCPU AMD plans `cpx41` / `cpx31` (with `cpx41` as the default). Hetzner retired the `cpx11/21/31/41/51` generation for new orders on 2026-01-01, so `hcloud server create --type cpx41` fails at the **Create server** step with `unsupported location for server type`, and provisioning never gets past it.

**After:** the workflow offers the current AMD x86 successors `cpx42` (8 vCPU / 16 GB, default) / `cpx32` (4 vCPU / 8 GB) — from Hetzner's current `cpx12/22/32/42/52/62` generation, which is orderable at `nbg1` (kept as the default location; `cpx22` has provisioned there successfully before, confirming the generation is offered there).

## How

- `.github/workflows/provision-self-hosted-runner.yml`: `server_type` choice `options` `[cpx41, cpx31]` → `[cpx42, cpx32]`, `default` `cpx41` → `cpx42`, and the input description updated to match. Nothing else changed — secrets, the registration flow, cloud-init, and location default are untouched.
- `.github/self-hosted-ci-runners.md`: updated the §5 input hint and the §9 sizing/cost table + prose so the runbook doesn't drift from the workflow (`cpx42` = 8 vCPU / 16 GB AMD; `cpx32` = 4 vCPU / 8 GB AMD).

Verified against docs.hetzner.cloud/changelog: the six current regular-purpose types (`cpx12`…`cpx62`) are available and the old `cpx11/21/31/41/51` line was retired for new orders on 2026-01-01.

Fixes the provision-runner failure (run 29649078524); part of the self-hosted CI runner infra (#2046).