### PR TITLE
ci: preflight the runner PAT and verify registration in the provisioner

### DIFF
--- a/.github/self-hosted-ci-runners.md
+++ b/.github/self-hosted-ci-runners.md
@@ -136,6 +136,35 @@ and the slot would die after a single job.
 6. In the repo: **Settings → Secrets and variables → Actions → Secrets → New
    repository secret**, name `RUNNER_REG_PAT`, paste the token.
 
+#### `RUNNER_REG_PAT` requirements (the common silent-failure cause)
+
+Registration happens **inside the systemd unit on the VM** (`run-ephemeral.sh`
+POSTs `…/actions/runners/registration-token`, then `config.sh`), so a
+mis-scoped or expired PAT makes registration 403/404 and the slots crash-loop —
+without any error in the provision run. The PAT **must** be:
+
+- a **fine-grained** PAT whose **resource owner** is the account/org that owns
+  `madmax983/autumn`;
+- granted **repository access** to `madmax983/autumn`;
+- granted **Repository permissions → Administration: Read and write**;
+- **not expired**.
+
+Decisive manual check (prints `201` for a good PAT, `403`/`404` for a
+bad-scope/expired one):
+
+```sh
+curl -sS -o /dev/null -w '%{http_code}\n' -X POST \
+  -H "Authorization: Bearer <PAT>" \
+  -H "Accept: application/vnd.github+json" \
+  -H "X-GitHub-Api-Version: 2022-11-28" \
+  https://api.github.com/repos/madmax983/autumn/actions/runners/registration-token
+```
+
+The provisioner now runs this exact preflight before creating the VM (failing
+fast if it is not `201`) and, after enabling the units, **verifies at least one
+`hetzner` runner comes Online** before the run succeeds — so a bad PAT surfaces
+in the run itself instead of hours later.
+
 ### Set `AUTUMN_SELF_HOSTED_HEAVY` (do this AFTER provisioning verifies)
 
 - **Settings → Secrets and variables → Actions → Variables → New repository

--- a/.github/self-hosted-ci-runners.md
+++ b/.github/self-hosted-ci-runners.md
@@ -196,6 +196,10 @@ and is filtered out — so nothing can mask a failed new registration.
      to also attach so you can SSH in for debugging. Leave blank if you don't
      need admin access (the provisioner always attaches its own throwaway key
      for setup, then deletes it).
+   - `force_replace` — **migration only**, default `false`. Permits the
+     cleanup-before-create step (§5.1) to delete a same-named server that
+     **lacks** the `managed-by=autumn-ci-provisioner` label. Needed exactly once
+     to replace the pre-label `autumn-ci-runner` VM; leave `false` afterward.
 3. Watch the run: it installs the `hcloud` CLI, creates the VM with
    `bootstrap.sh` as cloud-init user-data, waits for cloud-init to finish,
    delivers the PAT over SSH, and enables the `autumn-runner@1..N` units. The
@@ -205,6 +209,39 @@ and is filtered out — so nothing can mask a failed new registration.
    `self-hosted, hetzner, linux, x64`.
 5. **Flip the switch:** set the repo variable `AUTUMN_SELF_HOSTED_HEAVY = 1`
    (§4). The next CI run routes heavy trusted lanes to the box.
+
+### 5.1 Cleanup-before-create (labeled predecessor deletion)
+
+Hetzner enforces server-name uniqueness, so a **re-provision** of the same
+`server_name` would collide with the prior VM (and, if it somehow succeeded,
+leave the old box running and billing). To make re-provision idempotent, every
+server this workflow creates is stamped with the label
+`managed-by=autumn-ci-provisioner` (via `hcloud server create --label …`), and a
+cleanup step runs **before** "Create server" (after the PAT preflight and the
+hcloud CLI install):
+
+- **No same-named server exists** → nothing to do; proceed to create.
+- **A same-named server carries `managed-by=autumn-ci-provisioner`** → it is our
+  own predecessor, so it is **deleted automatically** before the new one is
+  created. This is the normal recovery/re-provision path.
+- **A same-named server exists but is NOT labeled** → the step **hard-fails**
+  (`exit 1`) and creates nothing, because it cannot prove the workflow created
+  that server — it could be an unrelated VM. Resolve by either deleting it
+  manually after review, or re-dispatching with **`force_replace=true`** (below).
+
+So the provisioner deletes only servers it can prove it created; it never touches
+an unlabeled/unrelated server on its own.
+
+#### One-time `force_replace=true` migration
+
+The **existing** `autumn-ci-runner` VM was created before the label existed, so
+it carries no `managed-by` label and the cleanup step would refuse to delete it.
+To adopt the new behavior, re-dispatch the provision workflow **once** with the
+`force_replace` input set to `true` (§5, step 2). That single run logs a
+`::warning::` and deletes the unlabeled same-named server, then creates a fresh,
+correctly-labeled replacement. Leave `force_replace` at its `false` default for
+every subsequent provision — once the box is labeled, ordinary re-provisions
+delete it automatically without the override.
 
 ## 6. Which lanes route
 
@@ -264,7 +301,12 @@ than failing; flip the variable to drain them onto hosted runners immediately.
 
 - **Delete the VM:** `hcloud server delete autumn-ci-runner` (use whatever
   `server_name` you provisioned with). This destroys all slots at once.
-- **Recreate:** re-run the **"Provision self-hosted runner"** workflow (§5).
+- **Recreate:** re-run the **"Provision self-hosted runner"** workflow (§5). You
+  no longer need to delete the old box by hand first: because provisioned servers
+  carry the `managed-by=autumn-ci-provisioner` label, the cleanup-before-create
+  step (§5.1) deletes the same-named labeled predecessor automatically. (The
+  one-time exception is the pre-label `autumn-ci-runner` VM — use
+  `force_replace=true` for that first migration; see §5.1.)
 - Ephemeral runners **auto-deregister** after each job, so a deleted box leaves
   no live registrations. Any **stale offline** entries left behind (e.g. from a
   hard-killed box) can be removed manually at **Settings → Actions → Runners**.

--- a/.github/self-hosted-ci-runners.md
+++ b/.github/self-hosted-ci-runners.md
@@ -163,7 +163,10 @@ curl -sS -o /dev/null -w '%{http_code}\n' -X POST \
 The provisioner now runs this exact preflight before creating the VM (failing
 fast if it is not `201`) and, after enabling the units, **verifies at least one
 `hetzner` runner comes Online** before the run succeeds — so a bad PAT surfaces
-in the run itself instead of hours later.
+in the run itself instead of hours later. The verify step snapshots the existing
+runner IDs *before* enabling and requires a **newly-registered** runner (an id
+absent from that baseline), so a stale/pre-existing `hetzner` runner from a
+prior provision can never mask a failed new registration.
 
 ### Set `AUTUMN_SELF_HOSTED_HEAVY` (do this AFTER provisioning verifies)
 

--- a/.github/self-hosted-ci-runners.md
+++ b/.github/self-hosted-ci-runners.md
@@ -162,11 +162,20 @@ curl -sS -o /dev/null -w '%{http_code}\n' -X POST \
 
 The provisioner now runs this exact preflight before creating the VM (failing
 fast if it is not `201`) and, after enabling the units, **verifies at least one
-`hetzner` runner comes Online** before the run succeeds — so a bad PAT surfaces
-in the run itself instead of hours later. The verify step snapshots the existing
-runner IDs *before* enabling and requires a **newly-registered** runner (an id
-absent from that baseline), so a stale/pre-existing `hetzner` runner from a
-prior provision can never mask a failed new registration.
+Online runner belonging to THIS provision** before the run succeeds — so a bad
+PAT surfaces in the run itself instead of hours later. Verification is
+**by runner name**: runners are named with the workflow-controlled prefix
+`hetzner-<server_name>-<slot>` (`RUNNER_NAME_PREFIX`, threaded through cloud-init
+into `run-ephemeral.sh`), and the verify step polls for an Online runner whose
+name starts with `hetzner-<server_name>-`. This is correct on both the fresh
+provision path (new Online names) and the **`--replace` reprovision** of the
+same-named server (the normal recovery path — `config.sh --replace` reconnects
+the same stable runner names/ids, still Online). An earlier id-diff against a
+pre-enable baseline false-*failed* that reprovision (the reconnected runner's id
+was already in the baseline, so it was wrongly excluded); name-based matching
+counts it. A stale runner from a *different* prior server has a different
+name-prefix and won't match; a stale same-name runner from a dead VM is Offline
+and is filtered out — so nothing can mask a failed new registration.
 
 ### Set `AUTUMN_SELF_HOSTED_HEAVY` (do this AFTER provisioning verifies)
 

--- a/.github/workflows/provision-self-hosted-runner.yml
+++ b/.github/workflows/provision-self-hosted-runner.yml
@@ -213,23 +213,28 @@ jobs:
         # `systemctl enable --now` (Type=simple) returns instantly and says nothing
         # about whether the on-VM registration actually succeeded, so a crash-looping
         # fleet was previously invisible until the heavy job sat unassigned for hours.
-        # Poll the GitHub runners API and require at least one Online runner whose
-        # NAME is EXACTLY one of THIS provision's slot names (the workflow-controlled
-        # "hetzner-<server_name>-<slot>" for slot in 1..RUNNER_COUNT, see the render
-        # step and run-ephemeral.sh). Exact per-slot names — NOT an unbounded
-        # startswith(prefix) — because a prefix match would also accept a DIFFERENT
-        # server whose name merely EXTENDS this one past a dash (e.g. while
-        # provisioning "autumn-ci-runner", an online "hetzner-autumn-ci-runner-canary-1"
-        # from a separate "-canary" VM startswith("hetzner-autumn-ci-runner-") and
-        # would FALSE-PASS this run's verification). Name-based matching is correct on
-        # BOTH paths: a fresh provision brings new online names, and a --replace
-        # REPROVISION of the same-named server reconnects the SAME stable runner
-        # names/ids — still online, still exactly these slot names — which an id-diff
-        # against a pre-enable baseline would have WRONGLY excluded (config.sh
-        # --replace reuses the existing record), false-failing the recovery path. A
-        # stale runner from a DIFFERENT prior server has a different name and won't
-        # match; a stale SAME-name runner from a dead VM is offline and is filtered
-        # out. Fail the run loudly if none appear. Runs BEFORE the SSH-key teardown so
+        # Poll the GitHub runners API and require ALL runner_count Online runners
+        # whose NAME is EXACTLY one of THIS provision's slot names (the
+        # workflow-controlled "hetzner-<server_name>-<slot>" for slot in
+        # 1..RUNNER_COUNT, see the render step and run-ephemeral.sh). Requiring the
+        # FULL expected slot set — NOT just >= 1 — because a PARTIAL provision (slot 1
+        # registers but another autumn-runner@N unit crash-loops / can't configure)
+        # would otherwise false-pass green while the fleet sits at reduced capacity and
+        # the SSH diagnostics get torn down, leaving heavy CI short of slots with no
+        # way to see why. Exact per-slot names — NOT an unbounded startswith(prefix) —
+        # because a prefix match would also accept a DIFFERENT server whose name merely
+        # EXTENDS this one past a dash (e.g. while provisioning "autumn-ci-runner", an
+        # online "hetzner-autumn-ci-runner-canary-1" from a separate "-canary" VM
+        # startswith("hetzner-autumn-ci-runner-") and would FALSE-PASS this run's
+        # verification). Name-based matching is correct on BOTH paths: a fresh provision
+        # brings new online names, and a --replace REPROVISION of the same-named server
+        # reconnects the SAME stable runner names/ids — still online, still exactly
+        # these slot names — which an id-diff against a pre-enable baseline would have
+        # WRONGLY excluded (config.sh --replace reuses the existing record),
+        # false-failing the recovery path. A stale runner from a DIFFERENT prior server
+        # has a different name and won't match; a stale SAME-name runner from a dead VM
+        # is offline and is filtered out. Fail the run loudly, NAMING the missing
+        # slot(s), if fewer than all N come Online. Runs BEFORE the SSH-key teardown so
         # the on-box diagnostic below can still reach the VM.
         run: |
           set -uo pipefail
@@ -248,21 +253,36 @@ jobs:
           ip="${{ steps.create.outputs.ip }}"
           attempts=0; max=12   # ~4 min at 20s
           online=0
+          online_names='[]'
           until [ "$attempts" -ge "$max" ]; do
-            online=$(curl -sS -H "Authorization: Bearer ${RUNNER_REG_PAT}" -H "Accept: application/vnd.github+json" \
+            # The set of ONLINE runner names that are in this run's expected slot set,
+            # as a JSON array; `online` is its length.
+            online_names=$(curl -sS -H "Authorization: Bearer ${RUNNER_REG_PAT}" -H "Accept: application/vnd.github+json" \
               "https://api.github.com/repos/${gh_owner}/${gh_repo}/actions/runners?per_page=100" \
-              | jq --argjson expected "$expected" '[.runners[] | select(.status=="online") | select(.name as $nm | ($expected | index($nm)) != null)] | length') || online=0
-            echo "online runners in ${expected} : ${online:-0} (attempt $((attempts+1))/$max)"
-            [ "${online:-0}" -ge 1 ] && break
+              | jq -c --argjson expected "$expected" '[.runners[] | select(.status=="online") | .name | select(. as $nm | ($expected | index($nm)) != null)]') || online_names='[]'
+            online=$(printf '%s' "${online_names:-[]}" | jq 'length') || online=0
+            echo "online runners in ${expected} : ${online:-0}/${count} (attempt $((attempts+1))/$max)"
+            [ "${online:-0}" -ge "$count" ] && break
             attempts=$((attempts+1)); sleep 20
           done
-          if [ "${online:-0}" -lt 1 ]; then
-            echo "::error::No Online runner named one of ${expected} from this provision appeared within the timeout; units started but on-VM registration failed."
+          if [ "${online:-0}" -lt "$count" ]; then
+            # Expected slot names that are NOT in the online set (space-joined for the
+            # operator-facing error). "online" (connected) includes a busy runner.
+            missing=$(jq -r -n --argjson expected "$expected" --argjson online "${online_names:-[]}" \
+              '($expected - $online) | join(" ")')
+            echo "::error::Only ${online:-0}/${count} expected runners came Online. Missing: ${missing}. On-VM registration for those slots failed."
+            # Best-effort on-box diagnostic. Map the FIRST missing slot name back to its
+            # slot index (trailing -<N>) so journalctl targets a unit that actually
+            # failed; fall back to slot 1 if the mapping can't be derived.
+            miss1=$(jq -r -n --argjson expected "$expected" --argjson online "${online_names:-[]}" \
+              '(($expected - $online)[0] // "")')
+            slot="${miss1##*-}"
+            case "$slot" in ''|*[!0-9]*) slot=1 ;; esac
             ssh -o StrictHostKeyChecking=no -i "${SSH_KEY}" "root@${ip}" \
-              'systemctl --no-pager status autumn-runner@1 || true; journalctl -u autumn-runner@1 --no-pager -n 60 || true' || true
+              "systemctl --no-pager status autumn-runner@${slot} || true; journalctl -u autumn-runner@${slot} --no-pager -n 60 || true" || true
             exit 1
           fi
-          echo "Registration verified: at least one runner named one of ${expected} is Online."
+          echo "Registration verified: all ${count} expected runners are Online."
 
       - name: Teardown provisioning SSH key
         if: always()

--- a/.github/workflows/provision-self-hosted-runner.yml
+++ b/.github/workflows/provision-self-hosted-runner.yml
@@ -60,6 +60,29 @@ jobs:
           if [ -z "${RUNNER_REG_PAT}" ]; then echo "::error::RUNNER_REG_PAT secret is empty (fine-grained PAT, repo Administration: Read and write)"; missing=1; fi
           [ "$missing" = 0 ]
 
+      - name: Preflight — RUNNER_REG_PAT can mint a registration token
+        # A non-empty PAT is not enough: registration runs INSIDE the systemd
+        # unit on the VM (run-ephemeral.sh POSTs registration-token, then
+        # config.sh) under `set -euo pipefail`, so a mis-scoped/expired PAT makes
+        # a 403/404 abort before config.sh and systemd crash-loops every slot —
+        # silently, since the enable step (Type=simple) returns instantly. Mint a
+        # token here with the SAME call run-ephemeral.sh makes and fail fast if it
+        # is not HTTP 201, BEFORE any VM is created. Never print the PAT or token.
+        run: |
+          set -euo pipefail
+          gh_owner="${GITHUB_REPOSITORY%/*}"
+          gh_repo="${GITHUB_REPOSITORY#*/}"
+          http_code=$(curl -sS -o /tmp/regtok.json -w '%{http_code}' -X POST \
+            -H "Authorization: Bearer ${RUNNER_REG_PAT}" \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "https://api.github.com/repos/${gh_owner}/${gh_repo}/actions/runners/registration-token")
+          if [ "$http_code" != "201" ]; then
+            echo "::error::RUNNER_REG_PAT cannot mint a runner registration token (HTTP $http_code). It must be a fine-grained PAT with resource owner ${gh_owner}, access to ${gh_owner}/${gh_repo}, Administration: Read and write, and not expired."
+            exit 1
+          fi
+          echo "PAT preflight OK: registration-token mint returned 201."
+
       - name: Install hcloud CLI
         run: |
           set -euo pipefail
@@ -135,6 +158,36 @@ jobs:
               'umask 077; cat > /etc/autumn-runner/pat && chown root:root /etc/autumn-runner/pat && chmod 600 /etc/autumn-runner/pat'
           ssh -o StrictHostKeyChecking=no -i "${SSH_KEY}" "root@${ip}" \
             "systemctl daemon-reload && systemctl enable --now \$(seq -f 'autumn-runner@%g' 1 ${n})"
+
+      - name: Verify runner registration
+        # `systemctl enable --now` (Type=simple) returns instantly and says nothing
+        # about whether the on-VM registration actually succeeded, so a crash-looping
+        # fleet was previously invisible until the heavy job sat unassigned for hours.
+        # Poll the GitHub runners API until at least one hetzner runner is Online, and
+        # fail the run loudly if none appear. Runs BEFORE the SSH-key teardown so the
+        # on-box diagnostic below can still reach the VM.
+        run: |
+          set -uo pipefail
+          gh_owner="${GITHUB_REPOSITORY%/*}"
+          gh_repo="${GITHUB_REPOSITORY#*/}"
+          ip="${{ steps.create.outputs.ip }}"
+          attempts=0; max=12   # ~4 min at 20s
+          online=0
+          until [ "$attempts" -ge "$max" ]; do
+            online=$(curl -sS -H "Authorization: Bearer ${RUNNER_REG_PAT}" -H "Accept: application/vnd.github+json" \
+              "https://api.github.com/repos/${gh_owner}/${gh_repo}/actions/runners?per_page=100" \
+              | jq '[.runners[] | select(.status=="online") | select(any(.labels[]; .name=="hetzner"))] | length') || online=0
+            echo "online hetzner runners: ${online:-0} (attempt $((attempts+1))/$max)"
+            [ "${online:-0}" -ge 1 ] && break
+            attempts=$((attempts+1)); sleep 20
+          done
+          if [ "${online:-0}" -lt 1 ]; then
+            echo "::error::No hetzner self-hosted runner came Online within the timeout; units started but on-VM registration failed."
+            ssh -o StrictHostKeyChecking=no -i "${SSH_KEY}" "root@${ip}" \
+              'systemctl --no-pager status autumn-runner@1 || true; journalctl -u autumn-runner@1 --no-pager -n 60 || true' || true
+            exit 1
+          fi
+          echo "Registration verified: at least one hetzner runner is Online."
 
       - name: Teardown provisioning SSH key
         if: always()

--- a/.github/workflows/provision-self-hosted-runner.yml
+++ b/.github/workflows/provision-self-hosted-runner.yml
@@ -251,15 +251,38 @@ jobs:
           expected=$(for i in $(seq 1 "$count"); do printf '%s\n' "${prefix}-${i}"; done \
             | jq -R . | jq -s -c .)
           ip="${{ steps.create.outputs.ip }}"
+          # Fetch ALL runner pages and emit the ONLINE runner names as a compact JSON
+          # array. A single `?per_page=100` fetch (page 1) misses the newly-Online slot
+          # names when the repo has >100 runner records — stale offline entries from
+          # hard-killed / crash-looped boxes accumulate — pushing the fresh names onto
+          # page 2+ and false-failing this guard even though the VM registered fine. So
+          # loop until a short page (the last), accumulating names across pages. Any
+          # transient fetch/parse error returns non-zero so the caller treats the cycle
+          # as not-yet-complete and retries — never a false pass.
+          list_online_runner_names() {
+            local page=1 acc='[]' body names cnt
+            while :; do
+              body=$(curl -sS -H "Authorization: Bearer ${RUNNER_REG_PAT}" -H "Accept: application/vnd.github+json" \
+                "https://api.github.com/repos/${gh_owner}/${gh_repo}/actions/runners?per_page=100&page=${page}") || return 1
+              names=$(printf '%s' "$body" | jq -c '[(.runners // [])[] | select(.status=="online") | .name]') || return 1
+              acc=$(jq -c -n --argjson a "$acc" --argjson b "$names" '$a + $b') || return 1
+              cnt=$(printf '%s' "$body" | jq '(.runners // []) | length') || return 1
+              [ "${cnt:-0}" -lt 100 ] && break   # short page => last page
+              page=$((page+1))
+              [ "$page" -gt 50 ] && break          # safety cap (>=5000 runners)
+            done
+            printf '%s' "$acc"
+          }
           attempts=0; max=12   # ~4 min at 20s
           online=0
           online_names='[]'
           until [ "$attempts" -ge "$max" ]; do
-            # The set of ONLINE runner names that are in this run's expected slot set,
-            # as a JSON array; `online` is its length.
-            online_names=$(curl -sS -H "Authorization: Bearer ${RUNNER_REG_PAT}" -H "Accept: application/vnd.github+json" \
-              "https://api.github.com/repos/${gh_owner}/${gh_repo}/actions/runners?per_page=100" \
-              | jq -c --argjson expected "$expected" '[.runners[] | select(.status=="online") | .name | select(. as $nm | ($expected | index($nm)) != null)]') || online_names='[]'
+            # ALL online runner names across every page (empty on a transient error,
+            # so the cycle just counts as not-yet-complete and retries), then filtered
+            # to this run's expected slot set as a JSON array; `online` is its length.
+            all_online=$(list_online_runner_names) || all_online='[]'
+            online_names=$(printf '%s' "${all_online:-[]}" \
+              | jq -c --argjson expected "$expected" '[.[] | select(. as $nm | ($expected | index($nm)) != null)]') || online_names='[]'
             online=$(printf '%s' "${online_names:-[]}" | jq 'length') || online=0
             echo "online runners in ${expected} : ${online:-0}/${count} (attempt $((attempts+1))/$max)"
             [ "${online:-0}" -ge "$count" ] && break

--- a/.github/workflows/provision-self-hosted-runner.yml
+++ b/.github/workflows/provision-self-hosted-runner.yml
@@ -105,11 +105,20 @@ jobs:
           set -euo pipefail
           gh_owner="${GITHUB_REPOSITORY%/*}"
           gh_repo="${GITHUB_REPOSITORY#*/}"
+          # Runner names are WORKFLOW-CONTROLLED via RUNNER_NAME_PREFIX so "Verify
+          # runner registration" can match THIS provision's runners by name exactly,
+          # without assuming the VM hostname equals the Hetzner server name (a
+          # free-form input; cloud-init may sanitize dots/case/length). The prefix
+          # is exported into the on-VM env and reused by the verify step below;
+          # run-ephemeral.sh falls back to hetzner-$(hostname) if it is ever unset.
+          prefix="hetzner-${{ inputs.server_name }}"
+          echo "RUNNER_NAME_PREFIX=${prefix}" >> "$GITHUB_ENV"
           {
             echo '#!/usr/bin/env bash'
             echo "export GH_OWNER=${gh_owner}"
             echo "export GH_REPO=${gh_repo}"
             echo "export RUNNER_COUNT=${RUNNER_COUNT}"
+            echo "export RUNNER_NAME_PREFIX=${prefix}"
             tail -n +2 scripts/self-hosted-runner/bootstrap.sh
           } > "${RUNNER_TEMP}/user-data.sh"
 
@@ -148,46 +157,6 @@ jobs:
           done
           [ "$ok" = 1 ] || { echo "::error::cloud-init did not finish in time"; exit 1; }
 
-      - name: Snapshot existing runner IDs (pre-registration baseline)
-        id: runners_before
-        # Capture the set of runner IDs that exist BEFORE this run's units
-        # register, so "Verify runner registration" below can diff against it and
-        # require a NEWLY-registered runner. Without this baseline a stale/
-        # pre-existing `hetzner` runner (from a prior provision) that is already
-        # Online would false-pass the verify poll even if THIS run's VM never
-        # registered — masking a broken box before its diagnostics are captured.
-        # RUNNER_REG_PAT is job-level env (see the job `env:` block).
-        run: |
-          set -uo pipefail
-          gh_owner="${GITHUB_REPOSITORY%/*}"
-          gh_repo="${GITHUB_REPOSITORY#*/}"
-          # Distinguish a SUCCESSFUL read that legitimately returns zero runners
-          # (a first-ever provision → baseline '[]', valid, proceed) from a FAILED
-          # read (curl error / non-200 / jq parse failure). A failed read must NOT
-          # fall back to an empty baseline: an unreadable baseline would make the
-          # id-diff in "Verify runner registration" treat a pre-existing Online
-          # hetzner runner as newly-registered and false-pass. So on a genuine read
-          # failure we retry, then FAIL CLOSED rather than proceed with '[]'.
-          before=""
-          attempts=0; max=5
-          until [ "$attempts" -ge "$max" ]; do
-            http=$(curl -sS -o /tmp/runners_before.json -w '%{http_code}' \
-              -H "Authorization: Bearer ${RUNNER_REG_PAT}" -H "Accept: application/vnd.github+json" \
-              "https://api.github.com/repos/${gh_owner}/${gh_repo}/actions/runners?per_page=100") || http="000"
-            if [ "$http" = "200" ] && before=$(jq -c '[.runners[].id]' /tmp/runners_before.json 2>/dev/null); then
-              break
-            fi
-            before=""
-            echo "runner baseline read failed (http=$http), retrying... ($((attempts+1))/$max)"
-            attempts=$((attempts+1)); sleep 5
-          done
-          if [ -z "$before" ]; then
-            echo "::error::Could not read the runner baseline from the GitHub API after ${max} attempts. Refusing to proceed: an unreadable baseline would let a pre-existing runner false-pass the registration verification."
-            exit 1
-          fi
-          echo "before_ids=$before" >> "$GITHUB_OUTPUT"
-          echo "baseline runner IDs: $before"
-
       - name: Deliver registration PAT and start ephemeral runners
         run: |
           set -euo pipefail
@@ -203,38 +172,44 @@ jobs:
         # `systemctl enable --now` (Type=simple) returns instantly and says nothing
         # about whether the on-VM registration actually succeeded, so a crash-looping
         # fleet was previously invisible until the heavy job sat unassigned for hours.
-        # Poll the GitHub runners API and require at least one hetzner runner that is
-        # Online AND was registered by THIS run — i.e. whose id is NOT in the
-        # pre-registration baseline (steps.runners_before). This id-diff is
-        # naming-agnostic (it does not assume the VM hostname matches the Hetzner
-        # server name), so a stale/pre-existing hetzner runner from a prior
-        # provision can never false-pass while this run's VM silently failed to
-        # register. Fail the run loudly if none appear. Runs BEFORE the SSH-key
-        # teardown so the on-box diagnostic below can still reach the VM.
+        # Poll the GitHub runners API and require at least one Online runner whose
+        # NAME belongs to THIS provision's VM (the workflow-controlled prefix
+        # "hetzner-<server_name>-", see the render step). Name-based matching is
+        # correct on BOTH paths: a fresh provision brings new online names, and a
+        # --replace REPROVISION of the same-named server reconnects the SAME stable
+        # runner names/ids — still online — which an id-diff against a pre-enable
+        # baseline would have WRONGLY excluded (config.sh --replace reuses the
+        # existing record), false-failing the recovery path. A stale runner from a
+        # DIFFERENT prior server has a different name and won't match; a stale
+        # SAME-name runner from a dead VM is offline and is filtered out. Fail the
+        # run loudly if none appear. Runs BEFORE the SSH-key teardown so the on-box
+        # diagnostic below can still reach the VM.
         run: |
           set -uo pipefail
           gh_owner="${GITHUB_REPOSITORY%/*}"
           gh_repo="${GITHUB_REPOSITORY#*/}"
-          before='${{ steps.runners_before.outputs.before_ids }}'
-          [ -n "$before" ] || before='[]'
+          # RUNNER_NAME_PREFIX is exported into $GITHUB_ENV by the render step;
+          # fall back to the same expression defensively so a propagation hiccup
+          # can never leave this unbound under `set -u`.
+          prefix="${RUNNER_NAME_PREFIX:-hetzner-${{ inputs.server_name }}}-"
           ip="${{ steps.create.outputs.ip }}"
           attempts=0; max=12   # ~4 min at 20s
-          new_online=0
+          online=0
           until [ "$attempts" -ge "$max" ]; do
-            new_online=$(curl -sS -H "Authorization: Bearer ${RUNNER_REG_PAT}" -H "Accept: application/vnd.github+json" \
+            online=$(curl -sS -H "Authorization: Bearer ${RUNNER_REG_PAT}" -H "Accept: application/vnd.github+json" \
               "https://api.github.com/repos/${gh_owner}/${gh_repo}/actions/runners?per_page=100" \
-              | jq --argjson before "$before" '[.runners[] | select(.status=="online") | select(any(.labels[]; .name=="hetzner")) | select(.id as $id | ($before | index($id)) | not)] | length') || new_online=0
-            echo "new online hetzner runners (not in baseline): ${new_online:-0} (attempt $((attempts+1))/$max)"
-            [ "${new_online:-0}" -ge 1 ] && break
+              | jq --arg prefix "$prefix" '[.runners[] | select(.status=="online") | select(.name | startswith($prefix))] | length') || online=0
+            echo "online runners named ${prefix}* : ${online:-0} (attempt $((attempts+1))/$max)"
+            [ "${online:-0}" -ge 1 ] && break
             attempts=$((attempts+1)); sleep 20
           done
-          if [ "${new_online:-0}" -lt 1 ]; then
-            echo "::error::No NEWLY-registered hetzner runner from this provision came Online within the timeout; units started but on-VM registration failed."
+          if [ "${online:-0}" -lt 1 ]; then
+            echo "::error::No Online runner named ${prefix}* from this provision appeared within the timeout; units started but on-VM registration failed."
             ssh -o StrictHostKeyChecking=no -i "${SSH_KEY}" "root@${ip}" \
               'systemctl --no-pager status autumn-runner@1 || true; journalctl -u autumn-runner@1 --no-pager -n 60 || true' || true
             exit 1
           fi
-          echo "Registration verified: at least one NEWLY-provisioned hetzner runner is Online."
+          echo "Registration verified: at least one runner named ${prefix}* is Online."
 
       - name: Teardown provisioning SSH key
         if: always()

--- a/.github/workflows/provision-self-hosted-runner.yml
+++ b/.github/workflows/provision-self-hosted-runner.yml
@@ -161,10 +161,30 @@ jobs:
           set -uo pipefail
           gh_owner="${GITHUB_REPOSITORY%/*}"
           gh_repo="${GITHUB_REPOSITORY#*/}"
-          before=$(curl -sS -H "Authorization: Bearer ${RUNNER_REG_PAT}" -H "Accept: application/vnd.github+json" \
-            "https://api.github.com/repos/${gh_owner}/${gh_repo}/actions/runners?per_page=100" \
-            | jq -c '[.runners[].id]') || before='[]'
-          [ -n "$before" ] || before='[]'
+          # Distinguish a SUCCESSFUL read that legitimately returns zero runners
+          # (a first-ever provision → baseline '[]', valid, proceed) from a FAILED
+          # read (curl error / non-200 / jq parse failure). A failed read must NOT
+          # fall back to an empty baseline: an unreadable baseline would make the
+          # id-diff in "Verify runner registration" treat a pre-existing Online
+          # hetzner runner as newly-registered and false-pass. So on a genuine read
+          # failure we retry, then FAIL CLOSED rather than proceed with '[]'.
+          before=""
+          attempts=0; max=5
+          until [ "$attempts" -ge "$max" ]; do
+            http=$(curl -sS -o /tmp/runners_before.json -w '%{http_code}' \
+              -H "Authorization: Bearer ${RUNNER_REG_PAT}" -H "Accept: application/vnd.github+json" \
+              "https://api.github.com/repos/${gh_owner}/${gh_repo}/actions/runners?per_page=100") || http="000"
+            if [ "$http" = "200" ] && before=$(jq -c '[.runners[].id]' /tmp/runners_before.json 2>/dev/null); then
+              break
+            fi
+            before=""
+            echo "runner baseline read failed (http=$http), retrying... ($((attempts+1))/$max)"
+            attempts=$((attempts+1)); sleep 5
+          done
+          if [ -z "$before" ]; then
+            echo "::error::Could not read the runner baseline from the GitHub API after ${max} attempts. Refusing to proceed: an unreadable baseline would let a pre-existing runner false-pass the registration verification."
+            exit 1
+          fi
           echo "before_ids=$before" >> "$GITHUB_OUTPUT"
           echo "baseline runner IDs: $before"
 

--- a/.github/workflows/provision-self-hosted-runner.yml
+++ b/.github/workflows/provision-self-hosted-runner.yml
@@ -148,6 +148,26 @@ jobs:
           done
           [ "$ok" = 1 ] || { echo "::error::cloud-init did not finish in time"; exit 1; }
 
+      - name: Snapshot existing runner IDs (pre-registration baseline)
+        id: runners_before
+        # Capture the set of runner IDs that exist BEFORE this run's units
+        # register, so "Verify runner registration" below can diff against it and
+        # require a NEWLY-registered runner. Without this baseline a stale/
+        # pre-existing `hetzner` runner (from a prior provision) that is already
+        # Online would false-pass the verify poll even if THIS run's VM never
+        # registered — masking a broken box before its diagnostics are captured.
+        # RUNNER_REG_PAT is job-level env (see the job `env:` block).
+        run: |
+          set -uo pipefail
+          gh_owner="${GITHUB_REPOSITORY%/*}"
+          gh_repo="${GITHUB_REPOSITORY#*/}"
+          before=$(curl -sS -H "Authorization: Bearer ${RUNNER_REG_PAT}" -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/repos/${gh_owner}/${gh_repo}/actions/runners?per_page=100" \
+            | jq -c '[.runners[].id]') || before='[]'
+          [ -n "$before" ] || before='[]'
+          echo "before_ids=$before" >> "$GITHUB_OUTPUT"
+          echo "baseline runner IDs: $before"
+
       - name: Deliver registration PAT and start ephemeral runners
         run: |
           set -euo pipefail
@@ -163,31 +183,38 @@ jobs:
         # `systemctl enable --now` (Type=simple) returns instantly and says nothing
         # about whether the on-VM registration actually succeeded, so a crash-looping
         # fleet was previously invisible until the heavy job sat unassigned for hours.
-        # Poll the GitHub runners API until at least one hetzner runner is Online, and
-        # fail the run loudly if none appear. Runs BEFORE the SSH-key teardown so the
-        # on-box diagnostic below can still reach the VM.
+        # Poll the GitHub runners API and require at least one hetzner runner that is
+        # Online AND was registered by THIS run — i.e. whose id is NOT in the
+        # pre-registration baseline (steps.runners_before). This id-diff is
+        # naming-agnostic (it does not assume the VM hostname matches the Hetzner
+        # server name), so a stale/pre-existing hetzner runner from a prior
+        # provision can never false-pass while this run's VM silently failed to
+        # register. Fail the run loudly if none appear. Runs BEFORE the SSH-key
+        # teardown so the on-box diagnostic below can still reach the VM.
         run: |
           set -uo pipefail
           gh_owner="${GITHUB_REPOSITORY%/*}"
           gh_repo="${GITHUB_REPOSITORY#*/}"
+          before='${{ steps.runners_before.outputs.before_ids }}'
+          [ -n "$before" ] || before='[]'
           ip="${{ steps.create.outputs.ip }}"
           attempts=0; max=12   # ~4 min at 20s
-          online=0
+          new_online=0
           until [ "$attempts" -ge "$max" ]; do
-            online=$(curl -sS -H "Authorization: Bearer ${RUNNER_REG_PAT}" -H "Accept: application/vnd.github+json" \
+            new_online=$(curl -sS -H "Authorization: Bearer ${RUNNER_REG_PAT}" -H "Accept: application/vnd.github+json" \
               "https://api.github.com/repos/${gh_owner}/${gh_repo}/actions/runners?per_page=100" \
-              | jq '[.runners[] | select(.status=="online") | select(any(.labels[]; .name=="hetzner"))] | length') || online=0
-            echo "online hetzner runners: ${online:-0} (attempt $((attempts+1))/$max)"
-            [ "${online:-0}" -ge 1 ] && break
+              | jq --argjson before "$before" '[.runners[] | select(.status=="online") | select(any(.labels[]; .name=="hetzner")) | select(.id as $id | ($before | index($id)) | not)] | length') || new_online=0
+            echo "new online hetzner runners (not in baseline): ${new_online:-0} (attempt $((attempts+1))/$max)"
+            [ "${new_online:-0}" -ge 1 ] && break
             attempts=$((attempts+1)); sleep 20
           done
-          if [ "${online:-0}" -lt 1 ]; then
-            echo "::error::No hetzner self-hosted runner came Online within the timeout; units started but on-VM registration failed."
+          if [ "${new_online:-0}" -lt 1 ]; then
+            echo "::error::No NEWLY-registered hetzner runner from this provision came Online within the timeout; units started but on-VM registration failed."
             ssh -o StrictHostKeyChecking=no -i "${SSH_KEY}" "root@${ip}" \
               'systemctl --no-pager status autumn-runner@1 || true; journalctl -u autumn-runner@1 --no-pager -n 60 || true' || true
             exit 1
           fi
-          echo "Registration verified: at least one hetzner runner is Online."
+          echo "Registration verified: at least one NEWLY-provisioned hetzner runner is Online."
 
       - name: Teardown provisioning SSH key
         if: always()

--- a/.github/workflows/provision-self-hosted-runner.yml
+++ b/.github/workflows/provision-self-hosted-runner.yml
@@ -33,6 +33,11 @@ on:
       admin_ssh_key_name:
         description: "Optional existing hcloud ssh-key name to also attach for your own admin access"
         default: ""
+      force_replace:
+        description: "Migration only: permit deleting a same-named server that LACKS the managed-by=autumn-ci-provisioner label (needed once to replace a pre-label VM)."
+        required: false
+        default: "false"
+        type: boolean
 
 concurrency:
   group: provision-self-hosted-runner
@@ -122,6 +127,41 @@ jobs:
             tail -n +2 scripts/self-hosted-runner/bootstrap.sh
           } > "${RUNNER_TEMP}/user-data.sh"
 
+      - name: Delete labeled predecessor server (own same-named VM)
+        # Each provision creates a fresh server named `${{ inputs.server_name }}`,
+        # which collides on Hetzner's server-name uniqueness with a prior one and
+        # would otherwise leave the old VM running (and billing). Delete our OWN
+        # same-named predecessor before creating the new one — but SAFELY: only a
+        # server carrying the managed-by=autumn-ci-provisioner label this workflow
+        # stamps on every server it creates (see "Create server" below) is deleted
+        # automatically. An unlabeled same-named server (e.g. an unrelated VM, or the
+        # one pre-label `autumn-ci-runner` box) is refused with a HARD FAIL unless the
+        # one-time `force_replace=true` migration input is set — so this step can never
+        # delete a server this provisioner did not create. Runs after the PAT preflight
+        # (Guard A) and after the hcloud CLI is installed, before "Create server".
+        # HCLOUD_TOKEN is in scope from the job-level env, like the other hcloud steps.
+        run: |
+          set -uo pipefail
+          name="${{ inputs.server_name }}"
+          force_replace="${{ inputs.force_replace }}"
+          # Exact-name existence + label lookup in one describe (describe by name;
+          # non-zero exit if absent). jq is available on the hosted runner.
+          if server_json=$(hcloud server describe "$name" -o json 2>/dev/null); then
+            label=$(printf '%s' "$server_json" | jq -r '.labels["managed-by"] // ""')
+            if [ "$label" = "autumn-ci-provisioner" ]; then
+              echo "Deleting managed predecessor server '$name' (labeled managed-by=autumn-ci-provisioner)."
+              hcloud server delete "$name"
+            elif [ "$force_replace" = "true" ]; then
+              echo "::warning::force_replace=true: deleting UNLABELED same-named server '$name' (one-time migration)."
+              hcloud server delete "$name"
+            else
+              echo "::error::A server named '$name' exists but is NOT labeled managed-by=autumn-ci-provisioner. Refusing to delete it (could be unrelated). Manual review required, or re-dispatch with force_replace=true for a one-time migration."
+              exit 1
+            fi
+          else
+            echo "No existing server named '$name'; nothing to clean up."
+          fi
+
       - name: Create server
         id: create
         run: |
@@ -135,6 +175,7 @@ jobs:
             --image "${{ inputs.ubuntu_image }}"
             --location "${{ inputs.location }}"
             --ssh-key "${key_name}"
+            --label managed-by=autumn-ci-provisioner
             --user-data-from-file "${RUNNER_TEMP}/user-data.sh")
           if [ -n "${{ inputs.admin_ssh_key_name }}" ]; then
             create_args+=(--ssh-key "${{ inputs.admin_ssh_key_name }}")

--- a/.github/workflows/provision-self-hosted-runner.yml
+++ b/.github/workflows/provision-self-hosted-runner.yml
@@ -173,17 +173,23 @@ jobs:
         # about whether the on-VM registration actually succeeded, so a crash-looping
         # fleet was previously invisible until the heavy job sat unassigned for hours.
         # Poll the GitHub runners API and require at least one Online runner whose
-        # NAME belongs to THIS provision's VM (the workflow-controlled prefix
-        # "hetzner-<server_name>-", see the render step). Name-based matching is
-        # correct on BOTH paths: a fresh provision brings new online names, and a
-        # --replace REPROVISION of the same-named server reconnects the SAME stable
-        # runner names/ids — still online — which an id-diff against a pre-enable
-        # baseline would have WRONGLY excluded (config.sh --replace reuses the
-        # existing record), false-failing the recovery path. A stale runner from a
-        # DIFFERENT prior server has a different name and won't match; a stale
-        # SAME-name runner from a dead VM is offline and is filtered out. Fail the
-        # run loudly if none appear. Runs BEFORE the SSH-key teardown so the on-box
-        # diagnostic below can still reach the VM.
+        # NAME is EXACTLY one of THIS provision's slot names (the workflow-controlled
+        # "hetzner-<server_name>-<slot>" for slot in 1..RUNNER_COUNT, see the render
+        # step and run-ephemeral.sh). Exact per-slot names — NOT an unbounded
+        # startswith(prefix) — because a prefix match would also accept a DIFFERENT
+        # server whose name merely EXTENDS this one past a dash (e.g. while
+        # provisioning "autumn-ci-runner", an online "hetzner-autumn-ci-runner-canary-1"
+        # from a separate "-canary" VM startswith("hetzner-autumn-ci-runner-") and
+        # would FALSE-PASS this run's verification). Name-based matching is correct on
+        # BOTH paths: a fresh provision brings new online names, and a --replace
+        # REPROVISION of the same-named server reconnects the SAME stable runner
+        # names/ids — still online, still exactly these slot names — which an id-diff
+        # against a pre-enable baseline would have WRONGLY excluded (config.sh
+        # --replace reuses the existing record), false-failing the recovery path. A
+        # stale runner from a DIFFERENT prior server has a different name and won't
+        # match; a stale SAME-name runner from a dead VM is offline and is filtered
+        # out. Fail the run loudly if none appear. Runs BEFORE the SSH-key teardown so
+        # the on-box diagnostic below can still reach the VM.
         run: |
           set -uo pipefail
           gh_owner="${GITHUB_REPOSITORY%/*}"
@@ -191,25 +197,31 @@ jobs:
           # RUNNER_NAME_PREFIX is exported into $GITHUB_ENV by the render step;
           # fall back to the same expression defensively so a propagation hiccup
           # can never leave this unbound under `set -u`.
-          prefix="${RUNNER_NAME_PREFIX:-hetzner-${{ inputs.server_name }}}-"
+          prefix="${RUNNER_NAME_PREFIX:-hetzner-${{ inputs.server_name }}}"
+          count="${{ inputs.runner_count }}"
+          # Exact expected slot names for THIS run as a JSON array. Built with
+          # printf + `jq -R` (never sed) so a server_name containing shell/sed/regex
+          # metacharacters is matched literally — no escaping hazard.
+          expected=$(for i in $(seq 1 "$count"); do printf '%s\n' "${prefix}-${i}"; done \
+            | jq -R . | jq -s -c .)
           ip="${{ steps.create.outputs.ip }}"
           attempts=0; max=12   # ~4 min at 20s
           online=0
           until [ "$attempts" -ge "$max" ]; do
             online=$(curl -sS -H "Authorization: Bearer ${RUNNER_REG_PAT}" -H "Accept: application/vnd.github+json" \
               "https://api.github.com/repos/${gh_owner}/${gh_repo}/actions/runners?per_page=100" \
-              | jq --arg prefix "$prefix" '[.runners[] | select(.status=="online") | select(.name | startswith($prefix))] | length') || online=0
-            echo "online runners named ${prefix}* : ${online:-0} (attempt $((attempts+1))/$max)"
+              | jq --argjson expected "$expected" '[.runners[] | select(.status=="online") | select(.name as $nm | ($expected | index($nm)) != null)] | length') || online=0
+            echo "online runners in ${expected} : ${online:-0} (attempt $((attempts+1))/$max)"
             [ "${online:-0}" -ge 1 ] && break
             attempts=$((attempts+1)); sleep 20
           done
           if [ "${online:-0}" -lt 1 ]; then
-            echo "::error::No Online runner named ${prefix}* from this provision appeared within the timeout; units started but on-VM registration failed."
+            echo "::error::No Online runner named one of ${expected} from this provision appeared within the timeout; units started but on-VM registration failed."
             ssh -o StrictHostKeyChecking=no -i "${SSH_KEY}" "root@${ip}" \
               'systemctl --no-pager status autumn-runner@1 || true; journalctl -u autumn-runner@1 --no-pager -n 60 || true' || true
             exit 1
           fi
-          echo "Registration verified: at least one runner named ${prefix}* is Online."
+          echo "Registration verified: at least one runner named one of ${expected} is Online."
 
       - name: Teardown provisioning SSH key
         if: always()

--- a/scripts/self-hosted-runner/bootstrap.sh
+++ b/scripts/self-hosted-runner/bootstrap.sh
@@ -65,10 +65,12 @@ RUSTUP_HOME=/opt/rust/rustup CARGO_HOME=/opt/rust/cargo /opt/rust/cargo/bin/rust
 for b in cargo rustc rustup; do
   ln -sf /opt/rust/cargo/bin/"${b}" /usr/local/bin/"${b}"
 done
-# Login shells (and anything sourcing /etc/profile) also get the toolchain.
+# Login shells (and anything sourcing /etc/profile) also get the toolchain BIN
+# dir on PATH. Deliberately do NOT export RUSTUP_HOME/CARGO_HOME here: pointing
+# them at the read-only /opt/rust would break job-time toolchain/tool installs
+# (dtolnay/rust-toolchain, `cargo install cargo-fuzz`) for login-shell jobs too.
+# Left unset, they default to the runner user's writable ~/.rustup / ~/.cargo.
 cat > /etc/profile.d/rust.sh <<'PROFILE'
-export RUSTUP_HOME=/opt/rust/rustup
-export CARGO_HOME=/opt/rust/cargo
 export PATH="/opt/rust/cargo/bin:${PATH}"
 PROFILE
 chmod 0644 /etc/profile.d/rust.sh
@@ -152,14 +154,20 @@ sudo -u runner ./config.sh --unattended --replace \
   --labels "self-hosted,hetzner,linux,x64" \
   --ephemeral
 # The runner worker (Runner.Worker) is started via `sudo -u runner ./run.sh`,
-# and sudo's default env_reset STRIPS the systemd unit's RUSTUP_HOME/CARGO_HOME
-# and resets PATH to secure_path — so the Environment= vars above never reach the
-# worker or the cargo/rustc it spawns. Set them explicitly with `env` at the sudo
-# boundary (hardcoding the absolute /opt/rust paths) so run.sh, Runner.Worker, and
-# every `cargo test` / `rustc` subprocess inherit the system toolchain by design.
+# and sudo's default env_reset resets PATH to secure_path — so the unit's
+# Environment=PATH never reaches the worker or the cargo/rustc it spawns. Set
+# PATH explicitly with `env` at the sudo boundary so run.sh, Runner.Worker, and
+# every spawned `cargo`/`rustc` subprocess resolve the system toolchain binaries
+# via /opt/rust/cargo/bin + the /usr/local/bin symlinks.
+#
+# Deliberately do NOT set RUSTUP_HOME/CARGO_HOME here: /opt/rust is root-owned
+# and read-only (a+rX), so pointing them there would make job-time installs
+# (dtolnay/rust-toolchain@nightly, `cargo install cargo-fuzz`) fail with
+# permission errors. Left unset, they default to the runner user's WRITABLE
+# ~/.rustup / ~/.cargo, where the job's own toolchain step installs; the rustup
+# proxy (found on PATH) then resolves that per-user toolchain. This mirrors
+# GitHub-hosted runners: system-discoverable binaries + a per-user writable home.
 exec sudo -u runner env \
-  RUSTUP_HOME=/opt/rust/rustup \
-  CARGO_HOME=/opt/rust/cargo \
   PATH="/opt/rust/cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" \
   ./run.sh
 WRAP
@@ -176,15 +184,16 @@ StartLimitIntervalSec=0
 
 [Service]
 Type=simple
-# Put the system-wide Rust toolchain (installed by bootstrap.sh at /opt/rust) on
-# the service PATH and pin the absolute RUSTUP_HOME/CARGO_HOME, so the runner
-# service, the Runner.Worker it forks, `cargo test`, AND every subprocess the
-# tests spawn (autumn-cli's `cargo metadata` / `rustc`) inherit them and can
-# resolve cargo/rustc without depending on $GITHUB_PATH or the runner user's
-# $HOME (fixes the `Os NotFound` spawn failures on the self-hosted runner).
+# Put the system-wide Rust toolchain BIN dir (installed by bootstrap.sh at
+# /opt/rust) on the service PATH so the runner service, the Runner.Worker it
+# forks, `cargo`, AND every subprocess the tests spawn (autumn-cli's
+# `cargo metadata` / `rustc`) resolve cargo/rustc/rustup without depending on
+# $GITHUB_PATH or the runner user's $HOME (fixes the `Os NotFound` spawn
+# failures on the self-hosted runner). Deliberately do NOT set
+# RUSTUP_HOME/CARGO_HOME: /opt/rust is read-only, so pointing them there would
+# break job-time installs (dtolnay/rust-toolchain, cargo-fuzz). Left unset they
+# default to the runner user's writable ~/.rustup / ~/.cargo.
 Environment=PATH=/opt/rust/cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-Environment=RUSTUP_HOME=/opt/rust/rustup
-Environment=CARGO_HOME=/opt/rust/cargo
 ExecStart=/opt/autumn-runner/run-ephemeral.sh %i
 Restart=always
 RestartSec=5

--- a/scripts/self-hosted-runner/bootstrap.sh
+++ b/scripts/self-hosted-runner/bootstrap.sh
@@ -16,6 +16,10 @@ RUNNER_COUNT="${RUNNER_COUNT:-6}"
 GH_OWNER="${GH_OWNER:-madmax983}"
 GH_REPO="${GH_REPO:-autumn}"
 RUNNER_VERSION="${RUNNER_VERSION:-}"   # empty => resolve the latest release at boot
+# Workflow-controlled runner-name prefix so the provisioner can verify THIS run's
+# runners by name (see provision-self-hosted-runner.yml). Empty => run-ephemeral.sh
+# falls back to hetzner-$(hostname).
+RUNNER_NAME_PREFIX="${RUNNER_NAME_PREFIX:-}"
 
 export DEBIAN_FRONTEND=noninteractive
 apt-get update
@@ -76,6 +80,7 @@ cat > /etc/autumn-runner/env <<EOF
 GH_OWNER=${GH_OWNER}
 GH_REPO=${GH_REPO}
 RUNNER_HOME=${RUNNER_HOME}
+RUNNER_NAME_PREFIX=${RUNNER_NAME_PREFIX}
 EOF
 chmod 0644 /etc/autumn-runner/env
 
@@ -104,7 +109,7 @@ sudo -u runner rm -f .runner .credentials .credentials_rsaparams 2>/dev/null || 
 sudo -u runner ./config.sh --unattended --replace \
   --url "https://github.com/${GH_OWNER}/${GH_REPO}" \
   --token "${reg_token}" \
-  --name "hetzner-$(hostname)-${slot}" \
+  --name "${RUNNER_NAME_PREFIX:-hetzner-$(hostname)}-${slot}" \
   --labels "self-hosted,hetzner,linux,x64" \
   --ephemeral
 exec sudo -u runner ./run.sh

--- a/scripts/self-hosted-runner/bootstrap.sh
+++ b/scripts/self-hosted-runner/bootstrap.sh
@@ -58,12 +58,19 @@ curl -fsSL https://sh.rustup.rs \
 # Record a system default toolchain under the absolute RUSTUP_HOME so a rustup
 # proxy invoked with a cleared/reset environment still resolves a toolchain.
 RUSTUP_HOME=/opt/rust/rustup CARGO_HOME=/opt/rust/cargo /opt/rust/cargo/bin/rustup default stable
-# Belt-and-suspenders: symlink the proxies into /usr/local/bin, which is on the
-# default execvp search path even when PATH is unset (env_clear) — so a test
-# that spawns `cargo`/`rustc`/`rustup` with a minimal or cleared environment
-# still finds them (`env -i /usr/local/bin/cargo --version` succeeds).
+# Belt-and-suspenders: symlink the proxies onto the exec search path. The
+# load-bearing target is /usr/bin: when a process spawns a command by name with
+# PATH unset/cleared (Command::env_clear()), glibc's execvp falls back to the
+# confstr _CS_PATH default of `/bin:/usr/bin` (verify: `getconf PATH`), which
+# does NOT include /usr/local/bin — so a link there alone would still NotFound
+# an env_clear'd `cargo`/`rustc` spawn. Linking into /usr/bin puts the proxies
+# on that default path (`env -i /usr/bin/cargo --version` succeeds). We also
+# link into /usr/local/bin, which is earlier in a normal PATH. /usr/bin/{cargo,
+# rustc,rustup} are free on this image (Rust is installed via rustup at /opt/rust,
+# not apt), so `ln -sf` clobbers no distro package.
 for b in cargo rustc rustup; do
   ln -sf /opt/rust/cargo/bin/"${b}" /usr/local/bin/"${b}"
+  ln -sf /opt/rust/cargo/bin/"${b}" /usr/bin/"${b}"
 done
 # Login shells (and anything sourcing /etc/profile) also get the toolchain BIN
 # dir on PATH. Deliberately do NOT export RUSTUP_HOME/CARGO_HOME here: pointing

--- a/scripts/self-hosted-runner/bootstrap.sh
+++ b/scripts/self-hosted-runner/bootstrap.sh
@@ -151,7 +151,17 @@ sudo -u runner ./config.sh --unattended --replace \
   --name "${RUNNER_NAME_PREFIX:-hetzner-$(hostname)}-${slot}" \
   --labels "self-hosted,hetzner,linux,x64" \
   --ephemeral
-exec sudo -u runner ./run.sh
+# The runner worker (Runner.Worker) is started via `sudo -u runner ./run.sh`,
+# and sudo's default env_reset STRIPS the systemd unit's RUSTUP_HOME/CARGO_HOME
+# and resets PATH to secure_path — so the Environment= vars above never reach the
+# worker or the cargo/rustc it spawns. Set them explicitly with `env` at the sudo
+# boundary (hardcoding the absolute /opt/rust paths) so run.sh, Runner.Worker, and
+# every `cargo test` / `rustc` subprocess inherit the system toolchain by design.
+exec sudo -u runner env \
+  RUSTUP_HOME=/opt/rust/rustup \
+  CARGO_HOME=/opt/rust/cargo \
+  PATH="/opt/rust/cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" \
+  ./run.sh
 WRAP
 chmod 0755 "${RUNNER_HOME}/run-ephemeral.sh"
 

--- a/scripts/self-hosted-runner/bootstrap.sh
+++ b/scripts/self-hosted-runner/bootstrap.sh
@@ -38,6 +38,45 @@ apt-get update
 apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
 systemctl enable --now docker
 
+# --- system-wide Rust toolchain -------------------------------------------
+# ci.yml's Test job sets Rust up with dtolnay/rust-toolchain, which installs
+# cargo/rustc into the RUNNER user's ~/.cargo/bin and only exports that dir via
+# $GITHUB_PATH for workflow *steps*. Subprocesses SPAWNED BY THE TESTS — e.g.
+# autumn-cli's `Command::new("cargo").args(["metadata", ...])` (src/dev.rs) and
+# `Command::new(rustc)` (src/new.rs) — resolve the binary via a plain PATH
+# lookup and do not reliably inherit that step-only PATH, and a test that
+# env_clear()s or overrides $HOME loses the $HOME/.cargo resolution entirely, so
+# those spawns fail with `Os { code: 2, kind: NotFound }`. Install the toolchain
+# system-wide in an absolute, HOME-independent location so every process (and
+# every child it spawns) can resolve cargo/rustc/rustup regardless of $HOME or a
+# reset environment.
+export RUSTUP_HOME=/opt/rust/rustup
+export CARGO_HOME=/opt/rust/cargo
+curl -fsSL https://sh.rustup.rs \
+  | sh -s -- -y --no-modify-path --profile minimal --default-toolchain stable \
+      --component rustfmt --component clippy
+# Record a system default toolchain under the absolute RUSTUP_HOME so a rustup
+# proxy invoked with a cleared/reset environment still resolves a toolchain.
+RUSTUP_HOME=/opt/rust/rustup CARGO_HOME=/opt/rust/cargo /opt/rust/cargo/bin/rustup default stable
+# Belt-and-suspenders: symlink the proxies into /usr/local/bin, which is on the
+# default execvp search path even when PATH is unset (env_clear) — so a test
+# that spawns `cargo`/`rustc`/`rustup` with a minimal or cleared environment
+# still finds them (`env -i /usr/local/bin/cargo --version` succeeds).
+for b in cargo rustc rustup; do
+  ln -sf /opt/rust/cargo/bin/"${b}" /usr/local/bin/"${b}"
+done
+# Login shells (and anything sourcing /etc/profile) also get the toolchain.
+cat > /etc/profile.d/rust.sh <<'PROFILE'
+export RUSTUP_HOME=/opt/rust/rustup
+export CARGO_HOME=/opt/rust/cargo
+export PATH="/opt/rust/cargo/bin:${PATH}"
+PROFILE
+chmod 0644 /etc/profile.d/rust.sh
+# Make the whole toolchain world-readable/traversable (done LAST so every file
+# rustup wrote is covered) so the unprivileged `runner` user — and the CI test
+# subprocesses running as it — can execute it.
+chmod -R a+rX /opt/rust
+
 # --- unprivileged runner user (needs sudo: ci.yml runs sudo apt-get / sudo rm) ---
 if ! id -u "${RUNNER_USER}" >/dev/null 2>&1; then
   useradd -m -s /bin/bash "${RUNNER_USER}"
@@ -127,6 +166,15 @@ StartLimitIntervalSec=0
 
 [Service]
 Type=simple
+# Put the system-wide Rust toolchain (installed by bootstrap.sh at /opt/rust) on
+# the service PATH and pin the absolute RUSTUP_HOME/CARGO_HOME, so the runner
+# service, the Runner.Worker it forks, `cargo test`, AND every subprocess the
+# tests spawn (autumn-cli's `cargo metadata` / `rustc`) inherit them and can
+# resolve cargo/rustc without depending on $GITHUB_PATH or the runner user's
+# $HOME (fixes the `Os NotFound` spawn failures on the self-hosted runner).
+Environment=PATH=/opt/rust/cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+Environment=RUSTUP_HOME=/opt/rust/rustup
+Environment=CARGO_HOME=/opt/rust/cargo
 ExecStart=/opt/autumn-runner/run-ephemeral.sh %i
 Restart=always
 RestartSec=5


### PR DESCRIPTION
## Problem

The self-hosted runner provisioner could pass **every** workflow step while the runner fleet silently never came up. On the last provision, 6 ephemeral runner units started but none registered Online, and the heavy trunk-dev Test job (labels `self-hosted, hetzner, linux, x64`) sat unassigned for ~2.5h.

Root cause: registration runs **inside the systemd unit on the VM** — `run-ephemeral.sh` does `POST /repos/{owner}/{repo}/actions/runners/registration-token` with `curl -f` under `set -euo pipefail`, then `config.sh`. A mis-scoped or expired `RUNNER_REG_PAT` makes that POST return 403/404 and abort **before** `config.sh`, so systemd `Restart=always` crash-loops all slots. None of it was visible in the run: the "start runners" step is pure `systemctl enable --now` (Type=simple returns instantly), and the Preflight only checked the PAT was **non-empty**, never its scope. So a bad PAT passed every step yet the fleet never registered.

## Fix — two guards that fail loudly in the run

- **Guard A — Preflight PAT-scope check** (before the VM is created): mint a registration token with the *exact* call `run-ephemeral.sh` makes and fail fast unless it returns **HTTP 201**. Catches a mis-scoped/expired PAT before a VM is even spent. Never prints the PAT or token.
- **Guard B — Post-enable registration verification** (after `enable --now`, **before** the SSH-key teardown): poll the GitHub runners API until at least one `hetzner` runner is **Online**; if none appear within ~4 min, dump on-box `systemctl status` / `journalctl` (best-effort, while the throwaway SSH key still exists) and fail the run.

Both derive `gh_owner`/`gh_repo` from `${GITHUB_REPOSITORY}` (matching the existing render step), use the job-level `RUNNER_REG_PAT` secret, and mirror the enable step's exact `ssh` form for the diagnostic.

Also documents the `RUNNER_REG_PAT` requirements (fine-grained; resource owner = repo owner; repo access to `madmax983/autumn`; Administration: Read+write; not expired) and the decisive manual `201` check in the runbook.

## Scope / validation

- Edits only `.github/workflows/provision-self-hosted-runner.yml` and `.github/self-hosted-ci-runners.md`. No `CHANGELOG.md`, no version bump.
- YAML parses (`python3 -c "import yaml; yaml.safe_load(...)"` → OK).
- No workflow was dispatched or re-run.