### PR TITLE
docs(autumn-cli): fix rustdoc warnings-as-errors failing the publish-gate doc build

### DIFF
--- a/autumn-cli/src/a11y.rs
+++ b/autumn-cli/src/a11y.rs
@@ -1,7 +1,7 @@
 //! `autumn a11y verify` — a build-time accessibility audit of raw `html!`
 //! markup.
 //!
-//! The typed primitives in [`autumn_web::a11y`](autumn_web::a11y) (`Img`,
+//! The typed primitives in [`autumn_web::a11y`] (`Img`,
 //! `Button`, `Link`, `MenuItem`, `TextField`) discharge every accessible-name
 //! obligation **at compile time**: an alt-less image or an unlabeled field
 //! written through them does not compile. Code that uses those primitives is
@@ -26,7 +26,7 @@
 //! therefore *miss* a defect in exotic markup (a miss is acceptable by design),
 //! so its raw-`html!` findings are advisory-grade signal, not a proof of
 //! accessibility. The complete, by-construction guarantee lives in the typed
-//! primitives in [`autumn_web::a11y`](autumn_web::a11y), where an accessible
+//! primitives in [`autumn_web::a11y`], where an accessible
 //! name is a compile-time type obligation proven by `trybuild`; this scanner is
 //! only the escape-hatch net over raw hand-written `html!`.
 //!

--- a/autumn-cli/src/deploy.rs
+++ b/autumn-cli/src/deploy.rs
@@ -240,7 +240,7 @@ impl ResolvedDeployConfig {
     }
 
     /// Persistent per-app dir shared across releases (holds the secret env file
-    /// and, since #1952, the uploaded config manifest[s]). The deployed systemd
+    /// and, since #1952, the uploaded config manifest\[s\]). The deployed systemd
     /// unit sets `AUTUMN_MANIFEST_DIR` to this path so the app's config loader
     /// reads the uploaded `autumn.toml` here at boot.
     #[must_use]

--- a/autumn-cli/src/deploy/exec.rs
+++ b/autumn-cli/src/deploy/exec.rs
@@ -54,7 +54,7 @@
 //! - The **CI end-to-end container harness** that exercises the real `ssh` path
 //!   against a live container — actually driving a rollback over ssh end-to-end —
 //!   is Slice 4; live ssh is not exercised by these unit tests.
-//! - A **Caddy** [`ProxyController`](super::proxy::ProxyController) — kamal-proxy
+//! - A **Caddy** [`ProxyController`] — kamal-proxy
 //!   is the confirmed proxy; Caddy is only the documented swappable alternative.
 //!
 //! The migrate step is fully real: the one-shot runs the uploaded release with
@@ -1182,7 +1182,7 @@ fn loopback_upstream(port: u16) -> String {
 }
 
 /// Per-deploy scratch path holding the pre-refresh kamal-proxy unit's content hash,
-/// so [`ProxyController::refresh_installed_ops`](super::proxy::ProxyController::refresh_installed_ops)
+/// so [`ProxyController::refresh_installed_ops`]
 /// can decide whether the unit ACTUALLY changed on this host (issue #2070). Keyed on
 /// the unique `release_id` so two shared-host deploys never race on a fixed scratch
 /// path; the restart step removes it.
@@ -1193,7 +1193,7 @@ fn proxy_unit_snapshot_path(release_id: &str) -> String {
 /// Command that records which slot now serves live traffic AND the loopback
 /// `port` its unit was rendered with, as `{slot}\t{port}` (read by the next
 /// redeploy's [`probe_deploy_state`], and copied into the previous-release marker
-/// by [`record_previous_release`] so a later rollback targets the real listener).
+/// by `record_previous_release` so a later rollback targets the real listener).
 ///
 /// The port is persisted because it is `slot_app_port(current server.port, slot)`
 /// computed AT THIS deploy — correct at deploy time even if a later deploy changes

--- a/autumn-cli/src/deploy/media.rs
+++ b/autumn-cli/src/deploy/media.rs
@@ -23,7 +23,7 @@
 //! - [`MediaMtxController::ensure_installed_ops`] emits the ordered
 //!   [`DeployOp`]s (mkdir the config dir, write the yml, write the unit,
 //!   `daemon-reload && enable --now && restart`) driven over the injectable
-//!   [`DeployExecutor`](super::exec::DeployExecutor), so the remote command
+//!   [`DeployExecutor`], so the remote command
 //!   sequence is assertable against a recording fake with no live host. It
 //!   no-ops (empty op vector) when the section is not `enabled`.
 //! - Five fail-closed doctor checks — [`mediamtx_ports_distinct`],
@@ -1135,7 +1135,7 @@ fn join_ports(ports: &[u16]) -> String {
 /// provisioned by this module, exactly as autumn treats kamal-proxy. This check
 /// verifies it is present before cutover.
 ///
-/// **Why this must run in the pre-cutover preflight:** [`provision_media_host`]
+/// **Why this must run in the pre-cutover preflight:** `provision_media_host`
 /// (which writes the unit and runs `systemctl … restart`) is deliberately
 /// deferred until AFTER the app deploy commits. Without this check a host missing
 /// the binary passes the other three checks, the app cuts over, and only THEN

--- a/autumn-cli/src/doctor.rs
+++ b/autumn-cli/src/doctor.rs
@@ -4302,9 +4302,9 @@ fn resolve_optional_signing_secret() -> Option<String> {
 
 /// Resolve the signing secret the deploy preflight should grade, from the SAME
 /// merged active-profile runtime table used for the deploy config and DB URL
-/// (base autumn.toml + `[profile.<env>]` + autumn-<env>.toml), env first. A
+/// (base autumn.toml + `[profile.<env>]` + `autumn-<env>.toml`), env first. A
 /// secret supplied only in an active profile
-/// (`[profile.<env>].security.signing_secret` / autumn-<env>.toml) is invisible
+/// (`[profile.<env>].security.signing_secret` / `autumn-<env>.toml`) is invisible
 /// to the raw top-level `autumn.toml` that [`resolve_optional_signing_secret`]
 /// reads, so a raw-table lookup would report it MISSING even though
 /// `AutumnConfig::load()` and `autumn deploy check` see it. Never returns/prints

--- a/autumn-cli/src/main.rs
+++ b/autumn-cli/src/main.rs
@@ -1917,7 +1917,7 @@ enum GenerateCommands {
     /// Generate a `#[model]` struct, Diesel migration, and schema entry.
     ///
     /// Field types: String, Text, i32, i64, bool, f32, f64, Uuid, `NaiveDateTime`,
-    /// `DateTime`, `Vec<u8>`/Bytea, Attachment, references, `enum{a,b,...}`, Option<...>.
+    /// `DateTime`, `Vec<u8>`/Bytea, Attachment, references, `enum{a,b,...}`, `Option<...>`.
     ///
     /// `field:references` scaffolds a foreign key: a `field_id BIGINT` column
     /// with a `REFERENCES <table>(id)` constraint and an index, where `<table>`
@@ -2476,7 +2476,7 @@ enum GenerateCommands {
     /// register the new routes in `src/main.rs`.
     ///
     /// Field types: String, Text, i32, i64, bool, f32, f64, Uuid, `NaiveDateTime`,
-    /// `DateTime`, `Vec<u8>`/Bytea, Attachment, references, `enum{a,b,...}`, Option<...>.
+    /// `DateTime`, `Vec<u8>`/Bytea, Attachment, references, `enum{a,b,...}`, `Option<...>`.
     ///
     /// `field:references` scaffolds a foreign key (`field_id BIGINT
     /// REFERENCES <table>(id)` plus an index), e.g.

--- a/autumn-cli/src/main.rs
+++ b/autumn-cli/src/main.rs
@@ -376,7 +376,7 @@ enum Commands {
     /// It always runs under the test profile and exports these for the suite:
     ///
     ///   AUTUMN_ENV=test
-    ///   DATABASE_URL / AUTUMN_DATABASE__PRIMARY_URL = <resolved test URL>
+    ///   DATABASE_URL / AUTUMN_DATABASE__PRIMARY_URL = `<resolved test URL>`
     ///
     /// Lifecycle (create → migrate → run):
     ///
@@ -1917,7 +1917,7 @@ enum GenerateCommands {
     /// Generate a `#[model]` struct, Diesel migration, and schema entry.
     ///
     /// Field types: String, Text, i32, i64, bool, f32, f64, Uuid, `NaiveDateTime`,
-    /// `DateTime`, Vec<u8>/Bytea, Attachment, references, `enum{a,b,...}`, Option<...>.
+    /// `DateTime`, `Vec<u8>`/Bytea, Attachment, references, `enum{a,b,...}`, Option<...>.
     ///
     /// `field:references` scaffolds a foreign key: a `field_id BIGINT` column
     /// with a `REFERENCES <table>(id)` constraint and an index, where `<table>`
@@ -2354,7 +2354,7 @@ enum GenerateCommands {
     ///
     ///   autumn generate tauri
     ///   autumn generate tauri --dry-run
-    ///   autumn generate tauri --remote-url https://app.example.com
+    ///   autumn generate tauri --remote-url <https://app.example.com>
     #[allow(clippy::doc_markdown)]
     #[command(verbatim_doc_comment)]
     Tauri {
@@ -2476,7 +2476,7 @@ enum GenerateCommands {
     /// register the new routes in `src/main.rs`.
     ///
     /// Field types: String, Text, i32, i64, bool, f32, f64, Uuid, `NaiveDateTime`,
-    /// `DateTime`, Vec<u8>/Bytea, Attachment, references, `enum{a,b,...}`, Option<...>.
+    /// `DateTime`, `Vec<u8>`/Bytea, Attachment, references, `enum{a,b,...}`, Option<...>.
     ///
     /// `field:references` scaffolds a foreign key (`field_id BIGINT
     /// REFERENCES <table>(id)` plus an index), e.g.

--- a/autumn-cli/src/schema/doctor.rs
+++ b/autumn-cli/src/schema/doctor.rs
@@ -23,7 +23,7 @@
 //! skipped WARN rather than failing. The database-schema-drift check introspects
 //! the live database: on a default (Postgres-only) build a `SQLite` backend is
 //! skipped, while a `--features sqlite` build additionally references
-//! [`introspect_sqlite`](super::introspect::introspect_sqlite) so it can diff a live
+//! `introspect_sqlite` so it can diff a live
 //! `SQLite` database too.
 
 use std::path::Path;

--- a/autumn-cli/src/schema/mod.rs
+++ b/autumn-cli/src/schema/mod.rs
@@ -390,7 +390,7 @@ fn run_snapshot(
 /// three commands can never derive the backend inconsistently for one profile.
 ///
 /// Both backends are supported: a resolved `SQLite` backend introspects via
-/// [`introspect::introspect_sqlite`] on the `sqlite` build (and is refused loudly on
+/// `introspect::introspect_sqlite` on the `sqlite` build (and is refused loudly on
 /// a default Postgres-only build). Before writing, a **provider-lock** guard refuses
 /// to clobber an existing snapshot tagged for another backend.
 fn run_pull(

--- a/autumn-cli/src/schema/parse.rs
+++ b/autumn-cli/src/schema/parse.rs
@@ -176,7 +176,7 @@ impl ParsedSchema {
     /// diffed against a snapshot baseline without inventing a fake model source.
     /// There are no parser diagnostics for an introspected schema (every column
     /// is resolved — an unmappable type becomes
-    /// [`ColumnType::Opaque`](autumn_schema_core::ColumnType::Opaque) rather than
+    /// [`ColumnType::Opaque`] rather than
     /// being skipped), so the `diagnostics` vec is empty.
     #[must_use]
     pub const fn from_tables(tables: Vec<Table>) -> Self {


### PR DESCRIPTION
## What / why

The publish-gate **"Documentation build"** job (`./scripts/check-docs.sh`, which builds each publishable crate with `RUSTDOCFLAGS="-D rustdoc::broken_intra_doc_links -D rustdoc::private_intra_doc_links"`) fails on pre-existing `autumn-cli` rustdoc problems: broken intra-doc links (hard errors under the `-D` flags) plus a batch of unclosed-HTML-tag / redundant-link / bare-URL warnings. Because publish-gate also runs on the `v[0-9]+.*` **tag push**, this reds the **v0.6.0** tag unless fixed on trunk first.

This PR fixes only the offending doc comments so the doc build passes. Part of the 0.6.0 pre-tag fix set (alongside #2076).

Reference failing run: publish-gate dispatch `29671158457`, "Documentation build" job — `error: could not document autumn-cli` (exit 101).

## Changes (doc-comment-only — no code, signatures, or logic touched)

**Broken intra-doc links → rendered as code / escaped** (the actual gate-failing errors):
- `autumn-cli/src/deploy/exec.rs:1196` — `` [`record_previous_release`] `` (no such item in scope) → `` `record_previous_release` ``
- `autumn-cli/src/deploy/media.rs:1138` — `` [`provision_media_host`] `` (private `fn` in the parent module; a link would also trip `-D private_intra_doc_links`) → `` `provision_media_host` ``
- `autumn-cli/src/deploy.rs:243` — `manifest[s]` parsed as a link → escaped to `manifest\[s\]`
- `autumn-cli/src/schema/doctor.rs:26` & `autumn-cli/src/schema/mod.rs:393` — `` [`introspect_sqlite`] `` (a `#[cfg(feature = "sqlite")]`-gated item absent from the default-features docs build) → backticked as code

**Redundant explicit link targets → deduped** (label already resolves to the same destination):
- `autumn-cli/src/a11y.rs:4` and `:29` — `` [`autumn_web::a11y`](autumn_web::a11y) `` → `` [`autumn_web::a11y`] ``
- `autumn-cli/src/deploy/exec.rs:57` — `` [`ProxyController`](super::proxy::ProxyController) `` → `` [`ProxyController`] ``
- `autumn-cli/src/deploy/exec.rs:1185` — `` [`ProxyController::refresh_installed_ops`](…) `` → `` [`ProxyController::refresh_installed_ops`] ``
- `autumn-cli/src/deploy/media.rs:26` — `` [`DeployExecutor`](super::exec::DeployExecutor) `` → `` [`DeployExecutor`] ``
- `autumn-cli/src/schema/parse.rs:179` — `` [`ColumnType::Opaque`](autumn_schema_core::ColumnType::Opaque) `` → `` [`ColumnType::Opaque`] ``

**Unclosed HTML tags → backticked generics/placeholders:**
- `autumn-cli/src/doctor.rs:4305` & `:4307` — `autumn-<env>.toml` → `` `autumn-<env>.toml` ``
- `autumn-cli/src/main.rs:379` — `<resolved test URL>` → `` `<resolved test URL>` ``
- `autumn-cli/src/main.rs:1920` & `:2479` — `Vec<u8>` → `` `Vec<u8>` ``

**Bare URL → autolink:**
- `autumn-cli/src/main.rs:2357` — `https://app.example.com` → `<https://app.example.com>`

## Verification

Command reproduced (the crate the gate fails on, using check-docs.sh's exact flags):

```
RUSTDOCFLAGS="-D rustdoc::broken_intra_doc_links -D rustdoc::private_intra_doc_links" \
CARGO_PROFILE_DEV_DEBUG=line-tables-only CARGO_PROFILE_DEV_INCREMENTAL=false \
cargo doc -p autumn-cli --no-deps
```

- Before: `error: could not document autumn-cli` (exit 101) — 5 broken-link errors + 12 warnings.
- After: **`Finished dev profile … EXIT_STATUS=0`** — zero autumn-cli rustdoc errors/warnings. (The only remaining line is an upstream `proc-macro-error2` future-incompat note from a dependency, which check-docs.sh deliberately does not gate on.)
- `cargo fmt --all -- --check` passes (doc-only change).

The full `./scripts/check-docs.sh` was also run locally — it confirmed `autumn-web` / `autumn-macros` are unaffected and the failure was isolated to `autumn-cli`.

> Note: the local toolchain here is `1.94.1` while CI's `docs` job uses newer `stable`; the broken-link **errors** reproduced identically, and the HTML-tag / redundant-link / bare-URL **warnings** are fixed per the authoritative CI job log. This PR's own publish-gate run confirms the final result on CI's toolchain.

Relates to #2040.

---
_Generated by [Claude Code](https://claude.ai/code/session_01E23QWeW5uP6BX8uQgfizFT)_