### PR TITLE
Guard health-indicator run_all tests against global breaker leakage

### DIFF
--- a/autumn/tests/integration/health_indicator_integration.rs
+++ b/autumn/tests/integration/health_indicator_integration.rs
@@ -123,7 +123,17 @@ fn registry_duplicate_name_is_rejected() {
 // ── run_all ──────────────────────────────────────────────────────
 
 #[tokio::test]
+#[allow(clippy::await_holding_lock)]
 async fn registry_run_all_returns_all_results() {
+    // `run_all()` folds in the process-global circuit-breaker registry, which a
+    // concurrently-running circuit_breaker_integration test may have populated.
+    // Take the same guard that module uses so a leaked breaker can't inflate our
+    // count.
+    let _lock = autumn_web::circuit_breaker::TEST_LOCK
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    autumn_web::circuit_breaker::global_registry().clear();
+
     let registry = HealthIndicatorRegistry::new();
     registry
         .register("a", IndicatorGroup::Readiness, Arc::new(AlwaysUp))
@@ -134,6 +144,8 @@ async fn registry_run_all_returns_all_results() {
 
     let results = registry.run_all().await;
     assert_eq!(results.len(), 2);
+
+    autumn_web::circuit_breaker::global_registry().clear();
 }
 
 #[tokio::test]
@@ -161,7 +173,17 @@ async fn registry_run_readiness_skips_health_only_indicators() {
 }
 
 #[tokio::test]
+#[allow(clippy::await_holding_lock)]
 async fn hung_indicator_times_out_and_reports_unknown_with_timed_out_detail() {
+    // `run_all()` folds in the process-global circuit-breaker registry, which a
+    // concurrently-running circuit_breaker_integration test may have populated.
+    // Take the same guard that module uses so a leaked breaker can't inflate our
+    // count.
+    let _lock = autumn_web::circuit_breaker::TEST_LOCK
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    autumn_web::circuit_breaker::global_registry().clear();
+
     let registry = HealthIndicatorRegistry::new();
     registry
         .register("hung", IndicatorGroup::Readiness, Arc::new(HungIndicator))
@@ -174,6 +196,8 @@ async fn hung_indicator_times_out_and_reports_unknown_with_timed_out_detail() {
         results[0].output.details.get("timed_out"),
         Some(&serde_json::Value::Bool(true))
     );
+
+    autumn_web::circuit_breaker::global_registry().clear();
 }
 
 // ── aggregate_status ─────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Test-isolation-only fix for an intermittent, order-dependent flake in the consolidated `autumn-web` `integration_tests` binary.

## Before / After (plain language)

- **Before:** the heavy `autumn-web` `integration_tests` suite intermittently fails two health-indicator `run_all` assertions (e.g. `got 3 expected 2`, `got 2 expected 1`) when a `circuit_breaker_integration` test runs concurrently in the same binary.
- **After:** those two tests take the existing `TEST_LOCK` + `global_registry().clear()` guard, so the process-global circuit-breaker registry can't leak into their counts. The flake is removed; assertions and expected counts are unchanged.

## How

`HealthIndicatorRegistry::run_all()` (`autumn/src/actuator.rs`) appends the process-global circuit-breaker registry (`circuit_breaker::global_registry().all_breakers()`, a static `OnceLock`) to its results. The sibling module `circuit_breaker_integration.rs` registers breakers into that same global registry and guards itself with `autumn_web::circuit_breaker::TEST_LOCK` + `global_registry().clear()`. The two health `run_all` tests previously took neither guard, so under the concurrently-run `integration_tests` binary an overlapping circuit-breaker test could leak +1 into the health test's count.

This mirrors `circuit_breaker_integration`'s exact idiom in the two affected tests (`registry_run_all_returns_all_results` and `hung_indicator_times_out_and_reports_unknown_with_timed_out_detail`): acquire `TEST_LOCK` (`unwrap_or_else(PoisonError::into_inner)`), `clear()` at entry, `clear()` at exit, with `#[allow(clippy::await_holding_lock)]` for the std-Mutex-guard-across-`.await` on the current-thread `#[tokio::test]` runtime. `run_readiness`-only tests are left untouched (they don't consult the global breaker registry). No runtime source (`actuator.rs`, `circuit_breaker.rs`) is touched.

## Verification

- `cargo test -p autumn-web --test integration_tests --features "test-support,offline-sync,ws,mail,redis" --no-run` — compiles clean.
- `cargo test ... health_indicator` — all 20 pass, including both `run_all` tests. (They pass in isolation even without the fix; the fix's value is anti-flake under concurrency, which the heavy fleet CI job exercises.)
- `cargo fmt -p autumn-web` — clean.

## Freeze-fit note

Test-isolation-only; stabilizes release CI signal; no runtime code touched.