### PR TITLE
Fix live_broadcast/auto_broadcast Docker-sweep test assertions

### DIFF
--- a/autumn/tests/integration/auto_broadcast.rs
+++ b/autumn/tests/integration/auto_broadcast.rs
@@ -273,7 +273,12 @@ mod tests {
             .expect("timeout waiting for custom update broadcast")
             .expect("recv error");
         let html_content = msg.into_string();
-        assert!(html_content.contains("hx-swap-oob=\"beforeend:#custom-posts-list\""));
+        // A topic-change re-insert publishes with the model's `insert_swap()`
+        // (not the create-path container), so the OOB selector comes from
+        // `BroadcastPost::insert_swap()` = Target(BeforeEnd, "#broadcast_posts-list").
+        // `OobSwap::Target::format_value` uses that selector verbatim and ignores
+        // the target id, so the SSE envelope is `beforeend:#broadcast_posts-list`.
+        assert!(html_content.contains("hx-swap-oob=\"beforeend:#broadcast_posts-list\""));
         assert!(html_content.contains(&format!("id=\"custom-post-{}", custom_post.id)));
         assert!(html_content.contains("world"));
 

--- a/autumn/tests/integration/auto_broadcast.rs
+++ b/autumn/tests/integration/auto_broadcast.rs
@@ -264,10 +264,8 @@ mod tests {
             .expect("timeout waiting for delete on old topic broadcast")
             .expect("recv error");
         let html_content_old = msg_old.into_string();
-        assert!(html_content_old.contains(&format!(
-            "hx-swap-oob=\"delete:#custom-post-{}\"",
-            custom_post.id
-        )));
+        assert!(html_content_old.contains("hx-swap-oob=\"delete\""));
+        assert!(html_content_old.contains(&format!("id=\"custom-post-{}\"", custom_post.id)));
 
         // Wait for the background worker to drain and publish update on custom topic
         let msg = tokio::time::timeout(std::time::Duration::from_secs(3), custom_update_sub.recv())
@@ -291,10 +289,8 @@ mod tests {
             .expect("timeout waiting for custom delete broadcast")
             .expect("recv error");
         let html_content = msg.into_string();
-        assert!(html_content.contains(&format!(
-            "hx-swap-oob=\"delete:#custom-post-{}\"",
-            custom_post.id
-        )));
+        assert!(html_content.contains("hx-swap-oob=\"delete\""));
+        assert!(html_content.contains(&format!("id=\"custom-post-{}\"", custom_post.id)));
 
         // 5. Test bulk update (update_many) and nullable topic placeholders
         let nullable_repo = PgNullablePostRepository::with_pool_untracked(db.pool());
@@ -340,20 +336,18 @@ mod tests {
             .await
             .expect("timeout waiting for delete on none topic")
             .expect("recv error");
-        assert!(msg_none.into_string().contains(&format!(
-            "hx-swap-oob=\"delete:#nullable_post-{}\"",
-            post_none.id
-        )));
+        let msg_none_str = msg_none.into_string();
+        assert!(msg_none_str.contains("hx-swap-oob=\"delete\""));
+        assert!(msg_none_str.contains(&format!("id=\"nullable_post-{}\"", post_none.id)));
 
         // - category_posts:rust should receive a delete for post_some.id
         let msg_rust = tokio::time::timeout(std::time::Duration::from_secs(3), rust_sub.recv())
             .await
             .expect("timeout waiting for delete on rust topic")
             .expect("recv error");
-        assert!(msg_rust.into_string().contains(&format!(
-            "hx-swap-oob=\"delete:#nullable_post-{}\"",
-            post_some.id
-        )));
+        let msg_rust_str = msg_rust.into_string();
+        assert!(msg_rust_str.contains("hx-swap-oob=\"delete\""));
+        assert!(msg_rust_str.contains(&format!("id=\"nullable_post-{}\"", post_some.id)));
 
         // - category_posts:go should receive updates for both
         let msg_go1 = tokio::time::timeout(std::time::Duration::from_secs(3), go_sub.recv())

--- a/autumn/tests/integration/live_broadcast.rs
+++ b/autumn/tests/integration/live_broadcast.rs
@@ -190,7 +190,7 @@ async fn update_broadcasts_true_swap() {
     );
     // Update uses OobSwap::True (outerHTML) — fragment carries the attribute directly
     assert!(
-        html.contains("live_item"),
+        html.contains("live-item"),
         "update fragment must reference item element, got: {html}"
     );
 }
@@ -228,10 +228,10 @@ async fn delete_broadcasts_oob_delete() {
 
     let html = msg.as_str();
     assert!(html.contains("delete"), "must contain delete swap: {html}");
-    // Trunk-dev delete tombstone: <div id="live_item-{id}" hx-swap-oob="delete">
+    // Trunk-dev delete tombstone: <div id="live-item-{id}" hx-swap-oob="delete">
     assert!(
-        html.contains(&format!("live_item-{}", saved.id)),
-        "must contain element id live_item-{}, got: {html}",
+        html.contains(&format!("live-item-{}", saved.id)),
+        "must contain element id live-item-{}, got: {html}",
         saved.id
     );
 }
@@ -247,9 +247,11 @@ async fn no_broadcasts_attr_emits_nothing() {
     let new_item = NewSilentItem {
         name: "quiet".to_owned(),
     };
-    // Even inside a CURRENT_CHANNELS scope, SilentItemRepository has no broadcasts attr
+    // Even inside a CURRENT_CHANNELS scope, SilentItemRepository has no broadcasts attr.
+    // Clone the handle so the sender stays alive across the recv below — otherwise the
+    // only Channels handle is moved into the scope and dropped, closing rx immediately.
     CURRENT_CHANNELS
-        .scope(channels, async {
+        .scope(channels.clone(), async {
             repo.save(&new_item).await.expect("save");
         })
         .await;


### PR DESCRIPTION
## Before / After

**Before:** the consolidated `integration_tests` "Run Docker-dependent tests" sweep deterministically fails four `live_broadcast`/`auto_broadcast` tests (newly reachable since `ws` was folded into the sweep). The failures are all test-only bugs:
- dom-id assertions used the underscore form `live_item` / `live_item-{id}` while the test's own `LiveItem::dom_id_for` and the product emit the hyphenated `live-item-{id}`;
- `no_broadcasts_attr_emits_nothing` moved the only `Channels` handle into `.scope(channels, …)`, dropping the sender so `rx.recv()` returned `Err(Closed)` immediately and tripped the negative assertion instead of pending → `Elapsed`;
- the `auto_broadcast` delete assertions matched the HTTP `format_value` delete-form shape `hx-swap-oob="delete:#{id}"`, but the SSE broadcast path emits the tombstone `<div id="{id}" hx-swap-oob="delete"></div>`.

**After:** the assertions match the product's actual behavior — the `live-item-{id}` dom-ids, the SSE `delete` tombstone envelope (attribute value `delete`, id as a separate attribute), and a cloned `channels` handle keeps the negative-assertion `recv` pending.

## How

- `live_broadcast.rs`: swap the underscore dom-id substrings to hyphenated form in `update_broadcasts_true_swap` and `delete_broadcasts_oob_delete` (matching `LiveFragment::dom_id_for`, mirroring the hyphen form asserted in `inline_broadcast_prefetch.rs`); clone the `Channels` handle into the `CURRENT_CHANNELS.scope` in `no_broadcasts_attr_emits_nothing` so the broadcast sender outlives `rx.recv()`.
- `auto_broadcast.rs`: replace each of the four delete-form assertions with a pair asserting `hx-swap-oob="delete"` and the `id="…-{id}"` attribute separately — the tombstone shape pinned by the product unit test `oob_envelope_delete_emits_tombstone`.

## Freeze-fit note

Test-only assertion corrections; product untouched; fixes a standing trunk-dev Docker-sweep breakage; OUTSIDE the pre-tag release set.

## Verification

Docker was unavailable in this environment, so CI is the runtime proof. The consolidated test binary compiles cleanly with the exact CI feature set: `cargo test -p autumn-web --test integration_tests --features "test-support,offline-sync,ws,mail,redis" --no-run`. `git diff --name-only` is exactly the two test files.