### PR TITLE
sim-testing W1: #[sim_test] macro + public Sim skeleton (#1797)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **sim-testing:** `#[sim_test]` macro and public `Sim` skeleton for
+  deterministic simulation tests (seed-driven, replay-on-panic) (#1797).
+
 ## [0.6.0] - 2026-07-18
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **sim-testing:** `#[sim_test]` macro and public `Sim` skeleton for
-  deterministic simulation tests (seed-driven, replay-on-panic) (#1797).
+  deterministic simulation tests (seed-driven, replay-on-panic) (#1797). [no-plugin]
 
 ## [0.6.0] - 2026-07-18
 

--- a/autumn-macros/src/lib.rs
+++ b/autumn-macros/src/lib.rs
@@ -45,6 +45,7 @@ mod routes_macro;
 mod scheduled;
 mod secured;
 mod service;
+mod sim_test;
 mod static_route;
 mod static_routes_macro;
 mod step_up;
@@ -242,6 +243,33 @@ pub fn paths(input: TokenStream) -> TokenStream {
 #[proc_macro_attribute]
 pub fn main(_attr: TokenStream, item: TokenStream) -> TokenStream {
     main_macro::main_macro(item.into()).into()
+}
+
+/// Annotate an async function as a deterministic simulation test (S-1797, W1).
+///
+/// Expands into a synchronous `#[test]` function that reads a seed from the
+/// `AUTUMN_SIM_SEED` environment variable (hex `0x..` or decimal, default `0`),
+/// builds a paused current-thread tokio runtime, constructs a
+/// `autumn_web::sim::Sim` from the seed, runs the async body, and prints a
+/// copy-pasteable replay line on panic before re-propagating the failure.
+///
+/// The annotated function must be `async` and take exactly one argument — the
+/// [`Sim`](../autumn_web/sim/struct.Sim.html) handle.
+///
+/// # Example
+///
+/// ```ignore
+/// use autumn_web::sim::Sim;
+/// use autumn_web::sim_test;
+///
+/// #[sim_test]
+/// async fn deterministic(mut sim: Sim) {
+///     assert_eq!(sim.seed, 0);
+/// }
+/// ```
+#[proc_macro_attribute]
+pub fn sim_test(attr: TokenStream, item: TokenStream) -> TokenStream {
+    sim_test::sim_test_macro(attr.into(), item.into()).into()
 }
 
 /// Annotate an async inbound mail handler function.

--- a/autumn-macros/src/sim_test.rs
+++ b/autumn-macros/src/sim_test.rs
@@ -1,0 +1,240 @@
+//! `#[sim_test]` macro implementation (sim-testing W1, issue #1797).
+//!
+//! Mirrors the [`crate::main_macro`] pattern: we emit a *synchronous*
+//! `#[test]` function that builds a tokio runtime by hand (rather than
+//! delegating to `#[tokio::test]`), because the generated code uses
+//! `::autumn_web::` paths so it resolves for a user who only depends on
+//! `autumn-web`.
+//!
+//! The user writes:
+//!
+//! ```ignore
+//! #[sim_test]
+//! async fn my_test(mut sim: Sim) { /* ... */ }
+//! ```
+//!
+//! and it expands (in spirit) to:
+//!
+//! ```ignore
+//! #[test]
+//! fn my_test() {
+//!     let seed = ::autumn_web::sim::__seed_from_env();
+//!     let runtime = ::autumn_web::reexports::tokio::runtime::Builder::new_current_thread()
+//!         .enable_all()
+//!         .start_paused(true)
+//!         .build()
+//!         .expect("failed to build paused sim runtime");
+//!     let result = ::std::panic::catch_unwind(::std::panic::AssertUnwindSafe(|| {
+//!         let mut sim = ::autumn_web::sim::Sim::from_seed(seed);
+//!         runtime.block_on(async move { /* body */ })
+//!     }));
+//!     if let ::std::result::Result::Err(payload) = result {
+//!         ::std::eprintln!(
+//!             "{}",
+//!             ::autumn_web::sim::__replay_line(seed, env!("CARGO_PKG_NAME"), "my_test")
+//!         );
+//!         ::std::panic::resume_unwind(payload);
+//!     }
+//! }
+//! ```
+//!
+//! The paused runtime (`start_paused(true)`) freezes the tokio virtual clock at
+//! start so W1 tests run deterministically; W2 will drive that clock through
+//! [`Sim`](../../autumn_web/sim/struct.Sim.html)'s `SimClock` handle.
+
+use proc_macro2::TokenStream;
+use quote::quote;
+use syn::{FnArg, ItemFn};
+
+/// Expand `#[sim_test] async fn t(sim: Sim) { .. }` into a deterministic,
+/// seed-driven `#[test]` function.
+pub fn sim_test_macro(_attr: TokenStream, item: TokenStream) -> TokenStream {
+    let input_fn: ItemFn = match syn::parse2(item) {
+        Ok(f) => f,
+        Err(err) => return err.to_compile_error(),
+    };
+
+    let sig = &input_fn.sig;
+
+    if sig.asyncness.is_none() {
+        return syn::Error::new_spanned(sig.fn_token, "sim_test functions must be async")
+            .to_compile_error();
+    }
+
+    // Exactly one argument, and it must be a plain typed argument (not `self`).
+    let mut typed_args = sig.inputs.iter().filter_map(|arg| match arg {
+        FnArg::Typed(pat_type) => Some(pat_type),
+        FnArg::Receiver(_) => None,
+    });
+    let Some(sim_arg) = typed_args.next() else {
+        return syn::Error::new_spanned(
+            &sig.inputs,
+            "sim_test functions must take exactly one argument, the `Sim` handle \
+             (e.g. `async fn my_test(sim: Sim)`)",
+        )
+        .to_compile_error();
+    };
+    if typed_args.next().is_some() {
+        return syn::Error::new_spanned(
+            &sig.inputs,
+            "sim_test functions must take exactly one argument, the `Sim` handle \
+             (e.g. `async fn my_test(sim: Sim)`)",
+        )
+        .to_compile_error();
+    }
+
+    let sim_pat = &sim_arg.pat;
+    // Bind the constructed Sim with the user's declared type annotation, so the
+    // type they name (e.g. an imported `Sim`) is actually used — otherwise the
+    // import warns as unused — and the constructed value is checked against it.
+    let sim_ty = &sim_arg.ty;
+    let fn_name = &sig.ident;
+    let fn_name_str = fn_name.to_string();
+    let attrs = &input_fn.attrs;
+    let vis = &input_fn.vis;
+    let body = &input_fn.block;
+
+    quote! {
+        #(#attrs)*
+        #[test]
+        #vis fn #fn_name() {
+            // Deterministic seed: `AUTUMN_SIM_SEED` (hex `0x..` or decimal),
+            // defaulting to 0. Parsing lives in autumn-web so it is unit-tested
+            // and the macro stays tiny.
+            let __autumn_sim_seed: u64 = ::autumn_web::sim::__seed_from_env();
+
+            // A current-thread runtime with the virtual clock paused at start,
+            // so time never advances on its own — the executor is deterministic.
+            // `start_paused(true)` requires tokio's `test-util` feature.
+            let __autumn_sim_runtime =
+                ::autumn_web::reexports::tokio::runtime::Builder::new_current_thread()
+                    .enable_all()
+                    .start_paused(true)
+                    .build()
+                    .expect("failed to build paused sim runtime");
+
+            // Run the user body with the fn argument bound to the constructed
+            // Sim, catching a panic so we can print the deterministic replay
+            // line before re-propagating (the test must still FAIL).
+            let __autumn_sim_result = ::std::panic::catch_unwind(
+                ::std::panic::AssertUnwindSafe(|| {
+                    let #sim_pat: #sim_ty = ::autumn_web::sim::Sim::from_seed(__autumn_sim_seed);
+                    __autumn_sim_runtime.block_on(async move #body)
+                }),
+            );
+
+            if let ::std::result::Result::Err(__autumn_sim_payload) = __autumn_sim_result {
+                ::std::eprintln!(
+                    "{}",
+                    ::autumn_web::sim::__replay_line(
+                        __autumn_sim_seed,
+                        env!("CARGO_PKG_NAME"),
+                        #fn_name_str,
+                    )
+                );
+                ::std::panic::resume_unwind(__autumn_sim_payload);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::sim_test_macro;
+    use quote::quote;
+
+    // The expansion is a synchronous `#[test]` fn that builds a paused
+    // current-thread runtime, constructs a Sim from the seed, and wires the
+    // replay-on-panic path.
+    #[test]
+    fn expands_to_paused_test_runtime_with_replay() {
+        let out = sim_test_macro(quote! {}, quote! { async fn t(sim: Sim) {} });
+        let rendered = out.to_string();
+        assert!(
+            rendered.contains("# [test]"),
+            "expansion must be a #[test] fn: {rendered}"
+        );
+        assert!(
+            rendered.contains("new_current_thread"),
+            "expansion must build a current-thread runtime: {rendered}"
+        );
+        assert!(
+            rendered.contains("start_paused"),
+            "expansion must pause the runtime clock: {rendered}"
+        );
+        assert!(
+            rendered.contains("from_seed"),
+            "expansion must construct the Sim from the seed: {rendered}"
+        );
+        assert!(
+            rendered.contains("__replay_line"),
+            "expansion must wire the replay line: {rendered}"
+        );
+        assert!(
+            rendered.contains("catch_unwind"),
+            "expansion must catch the panic to print the replay line: {rendered}"
+        );
+        assert!(
+            rendered.contains("__seed_from_env"),
+            "expansion must read the seed from the environment: {rendered}"
+        );
+    }
+
+    // The user's argument pattern (e.g. `mut sim`) is preserved as the binding
+    // for the constructed Sim.
+    #[test]
+    fn preserves_the_argument_binding_pattern() {
+        let out = sim_test_macro(quote! {}, quote! { async fn t(mut sim: Sim) {} });
+        let rendered = out.to_string();
+        assert!(
+            rendered.contains("let mut sim :"),
+            "expansion must bind the Sim to the user's `mut sim` pattern with its \
+             declared type: {rendered}"
+        );
+    }
+
+    // Non-async input is a targeted compile error mentioning `async`.
+    #[test]
+    fn rejects_non_async() {
+        let out = sim_test_macro(quote! {}, quote! { fn t(sim: Sim) {} });
+        let rendered = out.to_string();
+        assert!(
+            rendered.contains("compile_error"),
+            "non-async input must produce a compile error: {rendered}"
+        );
+        assert!(
+            rendered.contains("async"),
+            "the compile error must mention async: {rendered}"
+        );
+    }
+
+    // Zero arguments is a targeted compile error about the argument count.
+    #[test]
+    fn rejects_zero_args() {
+        let out = sim_test_macro(quote! {}, quote! { async fn t() {} });
+        let rendered = out.to_string();
+        assert!(
+            rendered.contains("compile_error"),
+            "zero-arg input must produce a compile error: {rendered}"
+        );
+        assert!(
+            rendered.contains("exactly one argument"),
+            "the compile error must mention the argument count: {rendered}"
+        );
+    }
+
+    // Two arguments is a targeted compile error about the argument count.
+    #[test]
+    fn rejects_two_args() {
+        let out = sim_test_macro(quote! {}, quote! { async fn t(sim: Sim, extra: u8) {} });
+        let rendered = out.to_string();
+        assert!(
+            rendered.contains("compile_error"),
+            "two-arg input must produce a compile error: {rendered}"
+        );
+        assert!(
+            rendered.contains("exactly one argument"),
+            "the compile error must mention the argument count: {rendered}"
+        );
+    }
+}

--- a/autumn/Cargo.toml
+++ b/autumn/Cargo.toml
@@ -260,7 +260,11 @@ pin-project-lite = "0.2"
 serde.workspace = true
 serde_json = "1"
 thiserror.workspace = true
-tokio.workspace = true
+# `test-util` is required at runtime by the `#[sim_test]` macro (S-1797): its
+# generated code builds a `start_paused(true)` current-thread runtime so
+# simulation tests run against a paused virtual clock. Enabled here (not just as
+# a dev-dependency) so a downstream crate's `#[sim_test]` compiles out of the box.
+tokio = { workspace = true, features = ["test-util"] }
 tokio-stream = { workspace = true, optional = true }
 tokio-util = { workspace = true, features = ["io"] }
 toml.workspace = true

--- a/autumn/src/lib.rs
+++ b/autumn/src/lib.rs
@@ -776,6 +776,16 @@ pub use autumn_macros::mailer_preview;
 /// }
 /// ```
 pub use autumn_macros::main;
+/// Annotate an async function as a deterministic simulation test (S-1797).
+///
+/// Expands into a synchronous `#[test]` that reads a seed from
+/// `AUTUMN_SIM_SEED` (hex `0x..` or decimal, default `0`), builds a paused
+/// current-thread runtime, constructs a [`sim::Sim`] from the seed, runs the
+/// body, and prints a copy-pasteable replay line on panic. The function must be
+/// `async` and take exactly one argument — the [`sim::Sim`] handle.
+///
+/// See the [`sim`] module for the full quick-start.
+pub use autumn_macros::sim_test;
 /// Author a widget story for the `/_stories` gallery:
 /// `story!{ "Group", "Name", { ... } }`.
 ///
@@ -1570,6 +1580,7 @@ pub mod reexports {
     pub use validator;
 }
 
+pub mod sim;
 /// Shared application state passed to route handlers.
 pub(crate) mod state;
 #[cfg(feature = "system-tests")]

--- a/autumn/src/sim.rs
+++ b/autumn/src/sim.rs
@@ -1,0 +1,295 @@
+//! Deterministic simulation testing (sim-testing, issue #1797).
+//!
+//! This module is the public 0.7.0 developer-experience surface for writing
+//! **deterministic** simulation tests: a single [`#[sim_test]`](crate::sim_test)
+//! attribute gives you a seeded [`Sim`] handle and a paused runtime, so a test
+//! runs identically on every machine and every run, and a failure prints a
+//! copy-pasteable line that reproduces it exactly.
+//!
+//! # Quick start
+//!
+//! ```rust,ignore
+//! use autumn_web::sim::Sim;
+//! use autumn_web::sim_test;
+//!
+//! #[sim_test]
+//! async fn deterministic(mut sim: Sim) {
+//!     // The seed comes from `AUTUMN_SIM_SEED` (hex `0x..` or decimal,
+//!     // default 0). Everything derived from `sim` is seed-driven and
+//!     // reproducible.
+//!     assert_eq!(sim.seed, 0);
+//!     let _rng = sim.rng();
+//! }
+//! ```
+//!
+//! Reproduce a failing run by copying the replay line printed on panic, e.g.:
+//!
+//! ```text
+//! AUTUMN_SIM_SEED=0x9f3a cargo test -p my-crate deterministic
+//! ```
+//!
+//! # Scope (Wave 1)
+//!
+//! W1 ships the **deterministic executor, the seed / replay / injection
+//! plumbing, and the public [`Sim`] skeleton** only. The handles hung off
+//! [`Sim`] ([`SimRng`], [`SimClock`], [`Chaos`], [`SimApp`]) are frozen,
+//! stability-minded placeholders whose behavior lands in later waves:
+//!
+//! - **W2** wires virtual-clock advancing / draining onto [`SimClock`] against
+//!   [`crate::time::ClockSource`], and mounts an app on [`SimApp`].
+//! - **W3** exposes deterministic id / `Uuid` generation through [`SimRng`].
+//! - **W5** turns [`Chaos`] into a public fault-injection builder.
+//!
+//! Everything here is designed to grow additively (builder-style) without
+//! breaking the frozen surface — hence the `#[non_exhaustive]` markers.
+
+// The placeholder handles are intentionally thin in W1; their methods and
+// docs fill in over later waves. These narrowly-scoped allows keep the
+// skeleton clean under the workspace's pedantic lint set without masking real
+// issues in the behavioral code that lands later.
+#![allow(clippy::missing_const_for_fn)]
+
+use chrono::{TimeZone, Utc};
+use rand::SeedableRng;
+use rand_chacha::ChaCha8Rng;
+
+use crate::time::TickingClock;
+
+/// The fixed, deterministic epoch the simulation clock starts at:
+/// `2020-01-01T00:00:00Z`.
+///
+/// Every sim run starts its virtual clock here so wall-clock-derived values are
+/// reproducible across machines and runs. W2 drives this clock forward via
+/// [`SimClock`].
+const SIM_EPOCH_UNIX_SECS: i64 = 1_577_836_800; // 2020-01-01T00:00:00Z
+
+/// A deterministic simulation handle, constructed from a single `u64` seed.
+///
+/// `Sim` is the day-one **public, stability-frozen** entry point handed to a
+/// [`#[sim_test]`](crate::sim_test) body. Its [`seed`](Sim::seed) is public so a
+/// test can assert on or thread it; the injection handles it owns
+/// ([`SimRng`] / [`SimClock`] / [`Chaos`] / [`SimApp`]) are private and reached
+/// through accessors, so their internals can evolve wave-over-wave without a
+/// breaking change.
+///
+/// Marked `#[non_exhaustive]` so future waves can add handles without breaking
+/// construction — always build one via [`Sim::from_seed`].
+#[non_exhaustive]
+pub struct Sim {
+    /// The seed this simulation was constructed from.
+    ///
+    /// Reproduce a run by exporting `AUTUMN_SIM_SEED=0x<seed>` (the replay line
+    /// printed on panic does this for you).
+    pub seed: u64,
+
+    /// Seeded deterministic RNG. Generation helpers land in W3.
+    rng: SimRng,
+
+    /// Virtual clock, started at the fixed sim epoch
+    /// (`2020-01-01T00:00:00Z`). Advancing / draining lands in W2.
+    #[allow(dead_code)] // wired up (advance/run_to_idle) in W2
+    clock: SimClock,
+
+    /// Fault-injection configuration. Becomes a public builder in W5.
+    #[allow(dead_code)] // fault-injection behavior lands in W5
+    chaos: Chaos,
+
+    /// Built router + `AppState` handle. Mounted on the paused runtime in W2.
+    #[allow(dead_code)] // app mounting lands in W2
+    app: SimApp,
+}
+
+impl Sim {
+    /// Construct a simulation from `seed`.
+    ///
+    /// Infallible and cheap: it seeds the RNG and starts the virtual clock but
+    /// does **not** boot a database or an app, so an empty
+    /// [`#[sim_test]`](crate::sim_test) runs with zero setup. App mounting
+    /// arrives in W2 via [`SimApp`].
+    #[must_use]
+    pub fn from_seed(seed: u64) -> Self {
+        let epoch = Utc
+            .timestamp_opt(SIM_EPOCH_UNIX_SECS, 0)
+            .single()
+            .unwrap_or_else(|| Utc.timestamp_nanos(0));
+        Self {
+            seed,
+            rng: SimRng::new(seed),
+            clock: SimClock::new(TickingClock::starting_at(epoch)),
+            chaos: Chaos::default(),
+            app: SimApp::default(),
+        }
+    }
+
+    /// The seed this simulation was constructed from.
+    ///
+    /// Provided for API symmetry alongside the public [`seed`](Sim::seed)
+    /// field.
+    #[must_use]
+    pub const fn seed(&self) -> u64 {
+        self.seed
+    }
+
+    /// Borrow the seeded deterministic RNG handle.
+    ///
+    /// W1 exposes only the handle; the deterministic id / `Uuid` generation
+    /// helpers built on top of it land in W3.
+    #[must_use]
+    pub fn rng(&mut self) -> &mut SimRng {
+        &mut self.rng
+    }
+}
+
+/// A seeded, deterministic random number generator handle.
+///
+/// Wraps a `ChaCha8Rng` seeded from the simulation seed, so the same seed
+/// always yields the same draw sequence. W3 will expose deterministic id and
+/// `Uuid` generation through this handle; W1 only constructs and threads it.
+pub struct SimRng {
+    #[allow(dead_code)] // read by the deterministic generation helpers in W3
+    inner: ChaCha8Rng,
+}
+
+impl SimRng {
+    /// Seed a fresh deterministic RNG from `seed`.
+    pub(crate) fn new(seed: u64) -> Self {
+        Self {
+            inner: ChaCha8Rng::seed_from_u64(seed),
+        }
+    }
+
+    /// Borrow the underlying `ChaCha8Rng`.
+    ///
+    /// Internal for W1 (used by the determinism smoke test); the public
+    /// generation surface lands in W3.
+    #[cfg(test)]
+    pub(crate) fn inner_mut(&mut self) -> &mut ChaCha8Rng {
+        &mut self.inner
+    }
+}
+
+/// A virtual clock handle for the simulation.
+///
+/// Wraps a [`TickingClock`] started at the fixed sim
+/// epoch. W2 wires `advance` / `run_to_idle` here against
+/// [`crate::time::ClockSource`], driving the paused tokio runtime's virtual
+/// clock in lockstep. W1 only constructs it.
+pub struct SimClock {
+    #[allow(dead_code)] // advance/run_to_idle wiring lands in W2
+    inner: TickingClock,
+}
+
+impl SimClock {
+    /// Wrap a ticking clock as the simulation's virtual clock.
+    pub(crate) fn new(inner: TickingClock) -> Self {
+        Self { inner }
+    }
+}
+
+/// Fault-injection configuration for a simulation.
+///
+/// An empty placeholder in W1. W5 makes this a public, `#[non_exhaustive]`
+/// builder (e.g. `db_transient_errors`, `clock_skew`, …) that the executor
+/// consults to deterministically inject faults.
+#[non_exhaustive]
+#[derive(Default, Debug, Clone)]
+pub struct Chaos {}
+
+/// The built application handle for a simulation.
+///
+/// A placeholder for the mounted router + `AppState` in W1. W2 mounts an
+/// `AppBuilder` app on the paused runtime here so sim tests can drive real
+/// requests deterministically.
+#[non_exhaustive]
+#[derive(Default)]
+pub struct SimApp {}
+
+/// Read and parse the simulation seed from the `AUTUMN_SIM_SEED` environment
+/// variable.
+///
+/// Accepts a hex (`0x`-prefixed) or decimal `u64`; an absent or unparseable
+/// value falls back to `0`. Called by the [`#[sim_test]`](crate::sim_test)
+/// macro so the parsing is unit-tested in one place and the macro stays tiny.
+#[doc(hidden)]
+#[must_use]
+pub fn __seed_from_env() -> u64 {
+    std::env::var("AUTUMN_SIM_SEED").map_or(0, |raw| parse_seed(&raw))
+}
+
+/// Parse a seed string: hex (`0x`/`0X` prefixed) or decimal, defaulting to `0`
+/// on any parse failure or empty input.
+fn parse_seed(raw: &str) -> u64 {
+    let trimmed = raw.trim();
+    trimmed
+        .strip_prefix("0x")
+        .or_else(|| trimmed.strip_prefix("0X"))
+        .map_or_else(
+            || trimmed.parse::<u64>().unwrap_or(0),
+            |hex| u64::from_str_radix(hex, 16).unwrap_or(0),
+        )
+}
+
+/// Build the deterministic replay line printed on a sim-test panic.
+///
+/// Returns exactly
+/// `AUTUMN_SIM_SEED=0x<seed-hex> cargo test -p <pkg> <test>` — copy-paste it to
+/// reproduce the failing run bit-for-bit. Called by the
+/// [`#[sim_test]`](crate::sim_test) macro.
+#[doc(hidden)]
+#[must_use]
+pub fn __replay_line(seed: u64, pkg: &str, test: &str) -> String {
+    format!("AUTUMN_SIM_SEED=0x{seed:x} cargo test -p {pkg} {test}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{__replay_line, Sim, parse_seed};
+    use rand::RngCore;
+
+    #[test]
+    fn replay_line_zero_seed_is_exact() {
+        assert_eq!(
+            __replay_line(0, "autumn-web", "my_test"),
+            "AUTUMN_SIM_SEED=0x0 cargo test -p autumn-web my_test"
+        );
+    }
+
+    #[test]
+    fn replay_line_formats_seed_as_hex() {
+        let line = __replay_line(0x9f3a, "autumn-web", "my_test");
+        assert!(
+            line.contains("0x9f3a"),
+            "seed must be rendered in hex: {line}"
+        );
+        assert_eq!(
+            line,
+            "AUTUMN_SIM_SEED=0x9f3a cargo test -p autumn-web my_test"
+        );
+    }
+
+    #[test]
+    fn parse_seed_covers_hex_decimal_and_garbage() {
+        assert_eq!(parse_seed("0"), 0);
+        assert_eq!(parse_seed("0x9f3a"), 0x9f3a);
+        assert_eq!(parse_seed("0X9F3A"), 0x9f3a);
+        assert_eq!(parse_seed("42"), 42);
+        assert_eq!(parse_seed("garbage"), 0);
+        assert_eq!(parse_seed(""), 0);
+        assert_eq!(parse_seed("  0x10  "), 0x10);
+    }
+
+    #[test]
+    fn from_seed_exposes_the_seed() {
+        assert_eq!(Sim::from_seed(0).seed, 0);
+        assert_eq!(Sim::from_seed(7).seed(), 7);
+    }
+
+    #[test]
+    fn same_seed_produces_identical_first_draw() {
+        let mut a = Sim::from_seed(7);
+        let mut b = Sim::from_seed(7);
+        let da = a.rng().inner_mut().next_u64();
+        let db = b.rng().inner_mut().next_u64();
+        assert_eq!(da, db, "same seed must yield the same first RNG draw");
+    }
+}

--- a/autumn/tests/integration/mod.rs
+++ b/autumn/tests/integration/mod.rs
@@ -202,6 +202,7 @@ mod sharding_commit_hooks;
 #[cfg(feature = "db")]
 mod sharding_integration;
 mod signed_webhooks;
+mod sim_test_smoke;
 #[cfg(feature = "ws")]
 mod sse_replay;
 mod static_serving;

--- a/autumn/tests/integration/sim_test_smoke.rs
+++ b/autumn/tests/integration/sim_test_smoke.rs
@@ -1,0 +1,15 @@
+//! Smoke test proving the sim-testing W1 Definition of Done (issue #1797):
+//! an empty `#[sim_test]` compiles and runs deterministically at seed 0.
+//!
+//! The replay-line-on-panic path is covered by the `__replay_line` unit test in
+//! `autumn/src/sim.rs` and the macro-expansion assertions in
+//! `autumn-macros/src/sim_test.rs`; this test deliberately does **not** panic
+//! (that would fail CI).
+
+use autumn_web::sim::Sim;
+use autumn_web::sim_test;
+
+#[sim_test]
+async fn empty_sim_test_runs_at_seed_zero(sim: Sim) {
+    assert_eq!(sim.seed, 0);
+}


### PR DESCRIPTION
> **0.7.0 work (Wave 1 of #1797).** Rebased on post-promotion trunk-dev — the v0.6.0 promotion (#2083) has merged, so the merge freeze no longer applies. Merge on the maintainer's normal schedule.

Wave 1 of the 0.7.0 deterministic sim-testing feature (issue #1797). W1 only: the executor + `Sim` core skeleton + the `#[sim_test]` macro. Clock advancing/draining, the entropy seam, the SQLite lane, `Chaos` fault injection, and the proptest/sweep tooling are later waves (W2–W7) and deliberately out of scope here.

## Before / After
- **Before:** there's no way to write a deterministic, replayable async test in autumn.
- **After:** a developer writes `#[sim_test] async fn my_test(sim: Sim) { ... }` and it runs on a single-threaded, paused-clock Tokio runtime seeded from `AUTUMN_SIM_SEED` (default `0`). The same seed reproduces the same run. When a sim test panics, it prints a copy-paste replay line:
  `AUTUMN_SIM_SEED=0x… cargo test -p autumn-web `

## How
- **`autumn-macros`:** new `#[sim_test]` proc-macro (`sim_test_macro`, proc-macro2 in/out for unit-testability, registered alongside `#[main]`). Expands an `async fn t(sim: Sim)` into a sync `#[test]` that reads the seed from `AUTUMN_SIM_SEED` (hex `0x..` or decimal, defaulting to 0), builds `Builder::new_current_thread().enable_all().start_paused(true)`, binds the test's argument to `Sim::from_seed(seed)`, runs the body under `catch_unwind`, and on panic prints the replay line before re-propagating (the test still fails). Guards: the fn must be `async` and take exactly one argument.
- **`autumn-web`:** new public `sim` module. `#[non_exhaustive] pub struct Sim { pub seed, rng, clock, chaos, app }` — the day-one public app-developer surface, shape-frozen for stability. `Sim::from_seed` is infallible and boot-free (seeds a ChaCha8 rng, starts a `TickingClock` at a fixed epoch; no DB/app spin-up) so an empty sim test runs with zero setup. `SimRng` / `SimClock` / `Chaos` / `SimApp` are documented placeholders with clearly-labelled W2/W3/W5 extension points. Re-exported as `pub use autumn_macros::sim_test;`.
- Enabled tokio's `test-util` feature on autumn-web's main dependency so `start_paused` compiles for downstream users.

## Tests
- Macro-expansion unit tests (async guard, arg-count guard, and that the expansion wires `new_current_thread`/`start_paused`/`from_seed`/`__replay_line`/`catch_unwind`).
- `Sim` unit tests: replay-line formatting, seed parsing (`0`/`0x9f3a`/`42`/garbage→0), determinism (same seed → identical first rng draw).
- Integration smoke test: an empty `#[sim_test]` runs deterministically and observes `sim.seed == 0`.

## Definition of done (met)
Empty `#[sim_test]` compiles and runs deterministically at seed 0; a panicking test prints the replay line; all public items documented (rustdoc-clean under the doc-gate deny flags); unit tests for macro expansion and replay-line formatting.

## Local gate
Scoped to `-p autumn-macros -p autumn-web` (full-workspace test risks trybuild ENOSPC): build ✓, tests ✓ (macros 577 passed incl. 5 sim_test; sim 5 passed; smoke test passed), `cargo fmt --check` ✓, clippy on toolchain 1.97.0 `-D warnings` ✓, doc gate ✓ (new `sim` module doc-clean).

---
_Generated by [Claude Code](https://claude.ai/code/session_01AM2CjWTytBwJy6qzHM97ge)_

---
`[no-plugin]` — public API addition; the autumn-web skill/docs update is deferred to the 0.7.0 docs batch (`skills/` is maintainer-owned and left untouched by feature lanes per project convention). This exemption is reversible in review.

## Reviews
- **Codex:** unresponsive org-wide since the org transfer (requested; no reply — known and not expected to change).
- **Gemini Code Assist:** not configured in this repo (`/gemini review` posted for the record; no response expected).
- **Convergence evidence:** documented self-review (see PR comment) + green CI.

## Known CI reds (pre-existing, not this PR)
- **Coverage (red) — pre-existing trunk-dev break #1614, not this PR.** The Coverage job runs `cargo llvm-cov --all-features`, which unifies the `sqlite` feature and fails to compile `autumn/src/mail.rs:3435` with `error[E0308]` (`DbSuppressionStore::new` expects `Pool<AsyncPgConnection>` but gets a sqlite `SyncConnectionWrapper`). This is red on baseline trunk-dev independently of this branch; this PR touches no `mail.rs`, pool, or feature wiring. Non-gating.