### PR TITLE
Fix auto_broadcast update_many dynamic-topic broadcast test (add commit_hooks to NullablePost)

### DIFF
--- a/autumn/tests/integration/auto_broadcast.rs
+++ b/autumn/tests/integration/auto_broadcast.rs
@@ -115,6 +115,7 @@ mod tests {
         NullablePost,
         table = "nullable_posts",
         broadcasts = true,
+        commit_hooks = true,
         topic = "category_posts:{category}",
         container = "category-posts-list"
     )]


### PR DESCRIPTION
## Before

The Docker-sweep test `auto_broadcast::tests::test_auto_broadcast_lifecycle` timed out at `autumn/tests/integration/auto_broadcast.rs:342`, waiting for the bulk-update (`update_many`, category `None → Some`) out-of-band "delete" broadcast on the old `category_posts:none` topic. That broadcast never fired, so the "Test (ubuntu-latest)" check was red. This surfaced after #2080 unblocked the earlier assertions in the same test.

## After

The test's `NullablePostRepository` now opts into the commit-hook path that actually publishes bulk dynamic-topic broadcasts, so the old-topic delete plus the new-topic inserts fire and the test passes.

## How

Added `commit_hooks = true` to the `#[autumn_web::repository(NullablePost, …)]` declaration. `broadcasts = true` already synthesizes the internal hooks type, so no explicit `hooks =` is needed. The inline `update_many` path deliberately skips dynamic-topic broadcasts (a documented performance trade-off), while the commit-hook path captures the previous topic and the worker — which this test already starts — publishes the deletes/inserts.

This is a test-only change: zero product/macro code is touched, and there is no blast radius.

Unblocks PR #2083's "Test (ubuntu-latest)" check.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KersdcwZLpx386i7DGiscj)_