### PR TITLE
Fix detect-current: printf mis-parses the no-proxy sentinel as an option (deploy E2E exit 2)

### DIFF
--- a/autumn-cli/src/deploy/exec.rs
+++ b/autumn-cli/src/deploy/exec.rs
@@ -1507,7 +1507,7 @@ pub fn probe_deploy_state(
          env -u XDG_RUNTIME_DIR kamal-proxy list 2>/dev/null || true; \
          printf '\\n{unit_delim}\\n'; \
          if [ -f {unit} ]; then grep -hoE -e '--http-port[[:space:]]+[0-9]+' {unit} 2>/dev/null || true; \
-         else printf '{no_unit}'; fi",
+         else printf '%s' '{no_unit}'; fi",
         current = shell_quote(&cfg.current_symlink()),
         marker = shell_quote(&live_slot_marker(cfg)),
         blue = SLOT_BLUE,
@@ -2331,6 +2331,32 @@ mod tests {
             RELEASE_ID,
             &plan,
         )
+    }
+
+    #[test]
+    fn detect_current_prints_no_proxy_sentinel_literally() {
+        // The `detect-current` probe emits the "no proxy unit" sentinel, whose
+        // value begins with `--`. It MUST be printed as a literal string argument
+        // (`printf '%s' '<sentinel>'`), never as printf's format string
+        // (`printf '<sentinel>'`) — otherwise POSIX printf parses the leading `--`
+        // as an invalid option and exits non-zero, breaking deploy on any fresh
+        // target that has no kamal-proxy unit (the `else` branch always runs).
+        let cfg = resolved();
+        let exec = RecordingExecutor::new();
+        // Scripted-empty stdout; we only care about the emitted shell command.
+        let _ = probe_deploy_state(&cfg, &exec);
+        let shell = exec.shell_for("detect-current").expect("detect-current ran");
+        let safe = format!("printf '%s' '{NO_PROXY_UNIT_SENTINEL}'");
+        let unsafe_form = format!("printf '{NO_PROXY_UNIT_SENTINEL}'");
+        assert!(
+            shell.contains(&safe),
+            "the no-proxy sentinel must be printed via `printf '%s'`: {shell}"
+        );
+        assert!(
+            !shell.contains(&unsafe_form),
+            "the no-proxy sentinel must not be printed as a bare printf format \
+             string (its `--` prefix would be parsed as an invalid option): {shell}"
+        );
     }
 
     #[test]

--- a/autumn-cli/src/deploy/exec.rs
+++ b/autumn-cli/src/deploy/exec.rs
@@ -2345,7 +2345,9 @@ mod tests {
         let exec = RecordingExecutor::new();
         // Scripted-empty stdout; we only care about the emitted shell command.
         let _ = probe_deploy_state(&cfg, &exec);
-        let shell = exec.shell_for("detect-current").expect("detect-current ran");
+        let shell = exec
+            .shell_for("detect-current")
+            .expect("detect-current ran");
         let safe = format!("printf '%s' '{NO_PROXY_UNIT_SENTINEL}'");
         let unsafe_form = format!("printf '{NO_PROXY_UNIT_SENTINEL}'");
         assert!(


### PR DESCRIPTION
## Before

On a fresh deploy target with no kamal-proxy unit, `autumn deploy` (the `detect-current` probe) failed with:

```
remote command detect-current failed: exit status 2
```

The remote shell ran `printf '---autumn-no-proxy-unit---'` and POSIX printf parsed the leading `--` as an invalid option (`printf: --: invalid option`), so the command exited non-zero. On a fresh container there is no kamal-proxy unit, so the `else` branch always runs — making this deterministic. This surfaced the deploy-E2E tests `deploy_e2e_full_lifecycle` / `deploy_e2e_pam_systemd_control_socket` (autumn-cli) as red on #2083's "Test (ubuntu-latest)".

## After

The sentinel is printed literally via `printf '%s' '---autumn-no-proxy-unit---'`, so `detect-current` returns the sentinel (exit 0) and the deploy proceeds. Behavior is otherwise unchanged — the parsed stdout contract (`exec.rs:~1459`) is identical.

## How

- One-line change at `exec.rs:~1510`: `printf '{no_unit}'` → `printf '%s' '{no_unit}'`. The sentinel value and the parse logic are untouched; the other printfs in the command (those starting with `\n`) were already safe.
- Added a focused unit test (`detect_current_prints_no_proxy_sentinel_literally`) pinning that the `detect-current` command emits the sentinel via `printf '%s'` and never as a bare `printf ''` — the missing coverage that let this slip.

## Reproduction

```
bash -c "printf '---autumn-no-proxy-unit---'"
# printf: --: invalid option   (exit 2)
```

## Why it surfaced now

These deploy-E2E tests were un-gated in wave 18 (#2032). Earlier the whole "Test" job aborted on the auto_broadcast failure (fixed by #2080/#2091) before reaching `deploy_e2e`, which masked this until now.

Unblocks PR #2083's "Test (ubuntu-latest)" (ubuntu axis; the windows-Test red is being tracked separately as a suspected flake).

---
_Generated by [Claude Code](https://claude.ai/code/session_01KersdcwZLpx386i7DGiscj)_

## Review convergence

- **Empirical proof:** The deploy-E2E `Test (ubuntu-latest)` check passes on this branch — the exact tests (`deploy_e2e_full_lifecycle`, `deploy_e2e_pam_systemd_control_socket`) that were red on #2083 now pass with this fix — and the root cause was reproduced locally: `bash -c "printf '---autumn-no-proxy-unit---'"` → `printf: --: invalid option` (exit 2).
- **Automated review:** Automated Codex review is unavailable org-wide following the repository transfer (no responses to `@codex review`).
- **Convergence:** Converged on the empirical proof above; pending maintainer review.
- **Coverage check red is pre-existing and unrelated** — the `Coverage` job fails at *compile* (not a coverage-threshold regression): `cargo llvm-cov --workspace --exclude autumn-web --all-features` unifies autumn-web's `sqlite` feature, flipping `db::RuntimeConnection` and breaking `autumn/src/mail.rs` (E0308). This is red on the trunk-dev baseline itself (documented in ci.yml), tracked as issue #1614, and is non-gating; it is queued as a scoped infra fix for 0.7.0.
