### PR TITLE
Add version requirements to workspace path deps so 0.6.0 crates are publishable

### DIFF
--- a/autumn-cli/Cargo.toml
+++ b/autumn-cli/Cargo.toml
@@ -65,7 +65,7 @@ sqlite = ["autumn-web/sqlite", "diesel_migrations/sqlite"]
 autumn-web = { version = "0.6.0", path = "../autumn", default-features = false, features = [
     "db", "htmx", "maud", "storage", "i18n", "telemetry-otlp", "redis", "cache-moka", "http-client", "reporting"
 ] }
-autumn-schema-core = { path = "../autumn-schema-core" }
+autumn-schema-core = { version = "0.6.0", path = "../autumn-schema-core" }
 base64 = "0.22"
 clap = { version = "4", features = ["derive", "env"] }
 diesel = { workspace = true }


### PR DESCRIPTION
> ⚠️ **MERGE ORDER — release-critical:** Merge this PR and the follow-up trunk-dev→trunk promotion **BEFORE** merging any 0.7.0 wave PRs into trunk-dev. If wave PRs land in trunk-dev first, the promotion merge would drag 0.7.0 wave code into the 0.6.0 release tree that gets published and tagged.

## Before / After

**Before:** `cargo publish` from `autumn-cli` fails:

```
all dependencies must have a version requirement specified when publishing.
dependency `autumn-schema-core` does not specify a version
```

An intra-workspace `{ path = "..." }` dep with no `version = "..."` is not publishable — crates.io requires a version requirement on every normal/build dependency.

**After:** every publishable crate's intra-workspace normal/build path dep carries `version = "0.6.0"`, so `cargo publish` no longer rejects the manifest. The only remaining `cargo publish --dry-run` failure for `autumn-cli` is the expected `no matching package named autumn-schema-core found` — because `autumn-schema-core` is a brand-new crate not yet on crates.io — which clears the moment it is published (it is first in the publish order).

## The How

Audited **every** publishable workspace member (`autumn-web`, `autumn-macros`, `autumn-cli`, `autumn-schema-core`, `autumn-admin-plugin`, `autumn-media-plugin`, `autumn-storage-s3`, `autumn-cache-redis`) for intra-workspace path deps in `[dependencies]` / `[build-dependencies]` (dev-deps don't need a version and none reference workspace crates anyway).

Exactly **one** offender was found and fixed:

| Crate | Path dep | Had version? | Fix |
|---|---|---|---|
| `autumn-cli` | `autumn-schema-core` | **no** | added `version = "0.6.0"` |

Every other intra-workspace path dep already carried `version = "0.6.0"` (verified): `autumn-web → autumn-macros`, `autumn-cli → autumn-web`, and `autumn-{admin,media,storage-s3,cache-redis} → autumn-web`. The pin style matches the repo convention exactly (`{ version = "0.6.0", path = "..." }`, version first).

Manifest-only, one line:

```diff
-autumn-schema-core = { path = "../autumn-schema-core" }
+autumn-schema-core = { version = "0.6.0", path = "../autumn-schema-core" }
```

## crates.io state (checked via the crates.io API)

| Crate | On crates.io? | Latest |
|---|---|---|
| `autumn-web` | yes | 0.5.0 |
| `autumn-macros` | yes | 0.5.0 |
| `autumn-cli` | yes | 0.5.0 |
| `autumn-schema-core` | **NEW (404)** | — |
| `autumn-admin-plugin` | yes | 0.5.0 |
| `autumn-media-plugin` | **NEW (404)** | — |
| `autumn-storage-s3` | yes | 0.5.0 |
| `autumn-cache-redis` | yes | 0.5.0 |

`autumn-schema-core` and `autumn-media-plugin` are new (never published; no conflicting owner).

## Verified deps-first publish order

Derived from the actual dependency edges:

1. `autumn-macros` (no intra-workspace deps)
2. `autumn-schema-core` (no intra-workspace deps — new)
3. `autumn-web` (needs `autumn-macros`)
4. `autumn-cli` (needs `autumn-web` + `autumn-schema-core`)
5. `autumn-admin-plugin` (needs `autumn-web`)
6. `autumn-media-plugin` (needs `autumn-web` — new)
7. `autumn-storage-s3` (needs `autumn-web`)
8. `autumn-cache-redis` (needs `autumn-web`)

(1↔2 interchangeable; 4–8 interchangeable once `autumn-web` is up.)

## Validation (no publish performed)

- `cargo verify-project` on `autumn-cli` → `{"success":"true"}`; `cargo metadata` parses.
- `cargo package -p autumn-cli --no-verify` → the original **"does not specify a version"** error is **GONE**; it now fails only on `no matching package named autumn-schema-core found` (expected until schema-core is published).
- `cargo package -p autumn-schema-core --no-verify` → **succeeds** (`Packaged 6 files`).

No version bump; `[workspace.package] version` stays `0.6.0`. No non-manifest files touched.

## ⚠ Release-tag note

This moves the v0.6.0 tag target: the maintainer should publish from — and tag v0.6.0 at — the **new `trunk-dev` merge commit that includes this fix**, NOT `a062e34`. Publish deps-first per the order above; `autumn-schema-core` must go up before `autumn-cli`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KersdcwZLpx386i7DGiscj)_


**Review convergence:** one-line manifest change (adds `version = "0.6.0"` to autumn-cli's `autumn-schema-core` path dep) validated locally — `cargo package -p autumn-schema-core` succeeds and the `cargo publish` "dependency does not specify a version" error is gone. Automated Codex review is unavailable org-wide post-transfer and the gemini-code-assist bot is quota-limited, so this converges on the empirical validation above plus maintainer review.