### PR TITLE
fix(mail): make DbSuppressionStore backend-agnostic to unblock Coverage CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -229,28 +229,52 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           cargo llvm-cov clean --workspace
-          # `--all-features` is unsafe here: it would enable autumn-web's
-          # backend-flip `sqlite` feature alongside the Postgres-assuming
-          # features, flipping `db::RuntimeConnection` to SQLite and failing
-          # autumn-web's lib to compile (#1614). Cargo has no "all-features
-          # except one crate feature" flag, so cover the rest of the workspace
-          # with `--all-features --exclude autumn-web`, then cover autumn-web
-          # separately with an explicit Postgres feature list (every autumn-web
-          # feature EXCEPT `sqlite`). Both accumulate into the same profile set.
+          # `--all-features` on a `--workspace` run is structurally unsafe here.
+          # Only two workspace members own a `sqlite` feature — autumn-web and
+          # autumn-cli (`sqlite = ["autumn-web/sqlite", ...]`). Under
+          # `--all-features`, autumn-cli's `sqlite` forwards to `autumn-web/sqlite`
+          # and — through GLOBAL cargo feature unification — flips the SHARED
+          # autumn-web dependency's `db::RuntimeConnection` alias to the SQLite
+          # backend for the ENTIRE graph. Every Pg-assuming crate then fails to
+          # compile with E0308 (they pin diesel `postgres` and use
+          # `#[model]`/`Jsonb`/`AsyncPgConnection`): autumn-web's lib itself
+          # (#1614), autumn-admin-plugin, autumn-media-plugin, and the example
+          # apps. Cargo has no "all-features except one crate feature" flag, and
+          # excluding victim crates one-by-one is whack-a-mole. Instead exclude
+          # the two crates that OWN a `sqlite` feature so NO selected package can
+          # turn the flip on, then cover each explicitly:
+          #   - autumn-web: covered below with an explicit Postgres feature list
+          #     (`$PG_FEATURES`, every feature EXCEPT `sqlite`) plus a dedicated
+          #     sqlite+mail lane (see #1614 note below).
+          #   - autumn-cli: its `postgres`/`sqlite` backends are MUTUALLY
+          #     EXCLUSIVE ("NEVER `--all-features`", per autumn-cli/Cargo.toml),
+          #     so it can never be part of an `--all-features` build at all; it is
+          #     covered by its own `-p autumn-cli` test lanes below.
+          # With both feature-owners excluded the catch-all resolves autumn-web
+          # to Postgres, so autumn-admin-plugin / autumn-media-plugin / the
+          # example apps compile again and need NO exclusion.
+          #
+          # `$PG_FEATURES` = every autumn-web feature except `sqlite`. It is the
+          # coverage sibling of `autumn_web_semver_features` in
+          # scripts/check-semver.sh (both deliberately EXCLUDE `sqlite` to avoid
+          # the backend flip); keep the `sqlite`-exclusion invariant in sync.
+          # Coverage is not bound by the crates.io baseline, so this list is a
+          # deliberate superset (adds `offline-sync`, `embed-assets`, `tls`,
+          # `acme`, `managed-pg*`, `system-tests`, `test-support`, …).
           PG_FEATURES="ws,presence,flash,cache-moka,maud,htmx,multipart,tailwind,http-client,oauth2,webauthn,openapi,mcp,markdown,db,offline-sync,test-support,telemetry-otlp,redis,i18n,embed-assets,storage,variants,reporting,mail,inbound-mail,inbound-mailgun,inbound-ses,seed,system-info,csv,system-tests,managed-pg,managed-pg-bundled,tls,acme"
-          # `--all-features` also flips these Pg-only crates to the sqlite
-          # backend they cannot compile against (they pin diesel `postgres` and
-          # use `#[model]`/`Jsonb`/`AsyncPgConnection`). The 8 example apps are
-          # not coverage-critical; autumn-admin-plugin is covered separately via
-          # its own `-p` invocation below (default Pg features). Exclude them so
-          # this workspace catch-all lane compiles under the sqlite flip.
-          cargo llvm-cov --workspace --exclude autumn-web \
-            --exclude autumn-admin-plugin \
-            --exclude blog --exclude bookmarks --exclude bookmarks-distributed \
-            --exclude bookmarks-sharded --exclude reddit-clone --exclude saas \
-            --exclude todo-app --exclude wiki \
+          cargo llvm-cov --workspace --exclude autumn-web --exclude autumn-cli \
             --all-features --no-report
           cargo llvm-cov --no-report -p autumn-web --features "$PG_FEATURES"
+          # Explicit sqlite+mail lane (#1614). Excluding autumn-cli above removed
+          # the only place the `--all-features` catch-all compiled autumn-web
+          # under the `sqlite` + `mail` union — which is exactly the
+          # `DbSuppressionStore` backend-flip this PR fixes, so coverage must
+          # keep compiling it. Restore it here, isolated to `-p autumn-web` so the
+          # sqlite flip can never leak onto the Pg-assuming workspace crates. A
+          # named sqlite `[[test]]` target keeps it off the pg-URL lib unit tests
+          # (which assume Postgres) — same rule the `sqlite-runtime` job follows.
+          cargo llvm-cov --no-report -p autumn-web --features "sqlite,mail" \
+            --test sqlite_boot_serve
           cargo llvm-cov --no-report -p autumn-web --features "$PG_FEATURES" \
             --test db_hooks_lifecycle -- --ignored
           cargo llvm-cov --no-report -p autumn-web --features "$PG_FEATURES" \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -238,7 +238,18 @@ jobs:
           # separately with an explicit Postgres feature list (every autumn-web
           # feature EXCEPT `sqlite`). Both accumulate into the same profile set.
           PG_FEATURES="ws,presence,flash,cache-moka,maud,htmx,multipart,tailwind,http-client,oauth2,webauthn,openapi,mcp,markdown,db,offline-sync,test-support,telemetry-otlp,redis,i18n,embed-assets,storage,variants,reporting,mail,inbound-mail,inbound-mailgun,inbound-ses,seed,system-info,csv,system-tests,managed-pg,managed-pg-bundled,tls,acme"
-          cargo llvm-cov --workspace --exclude autumn-web --all-features --no-report
+          # `--all-features` also flips these Pg-only crates to the sqlite
+          # backend they cannot compile against (they pin diesel `postgres` and
+          # use `#[model]`/`Jsonb`/`AsyncPgConnection`). The 8 example apps are
+          # not coverage-critical; autumn-admin-plugin is covered separately via
+          # its own `-p` invocation below (default Pg features). Exclude them so
+          # this workspace catch-all lane compiles under the sqlite flip.
+          cargo llvm-cov --workspace --exclude autumn-web \
+            --exclude autumn-admin-plugin \
+            --exclude blog --exclude bookmarks --exclude bookmarks-distributed \
+            --exclude bookmarks-sharded --exclude reddit-clone --exclude saas \
+            --exclude todo-app --exclude wiki \
+            --all-features --no-report
           cargo llvm-cov --no-report -p autumn-web --features "$PG_FEATURES"
           cargo llvm-cov --no-report -p autumn-web --features "$PG_FEATURES" \
             --test db_hooks_lifecycle -- --ignored

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `COPY --from=builder /app/i18n /app/i18n` lines are injected for
   `--with-i18n` and the anchors stripped otherwise (a non-i18n build context
   has no `i18n/` dir), leaving no stray anchor markers.
+- **mail:** make `DbSuppressionStore` backend-agnostic
+  (`Pool<RuntimeConnection>`) so the `sqlite` + `mail` feature union compiles,
+  unblocking the Coverage CI job (#1614).
 ### Added
 
 - **router:** new `health.enabled` config knob (default `true`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,12 +76,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **mail:** make `DbSuppressionStore` backend-agnostic
   (`Pool<RuntimeConnection>`) so the `sqlite` + `mail` feature union compiles,
   unblocking the Coverage CI job (#1614). The Coverage lane's
-  `--workspace --all-features` catch-all now also `--exclude`s the Pg-only
-  example crates (`blog`, `bookmarks`, `bookmarks-distributed`,
-  `bookmarks-sharded`, `reddit-clone`, `saas`, `todo-app`, `wiki`) and
-  `autumn-admin-plugin`, which cannot compile under the global `sqlite`
-  backend-flip; the examples are not coverage-critical and `autumn-admin-plugin`
-  keeps its coverage via its dedicated `-p` invocation. [no-plugin]
+  `--workspace --all-features` catch-all now excludes the two workspace members
+  that OWN a `sqlite` feature — `autumn-web` and `autumn-cli` — instead of the
+  earlier per-crate exclusion of victim crates. Under `--all-features`,
+  autumn-cli's `sqlite` forwarded to `autumn-web/sqlite` and (via global cargo
+  feature unification) flipped the shared autumn-web dependency to the SQLite
+  backend for the whole graph, breaking every Pg-assuming crate
+  (`autumn-admin-plugin`, `autumn-media-plugin`, the example apps) with E0308.
+  Excluding the two feature-owners resolves autumn-web to Postgres in the
+  catch-all, so those crates compile again and their earlier `--exclude`s are
+  dropped; autumn-cli's `postgres`/`sqlite` backends are mutually exclusive and
+  it can never be `--all-features`'d anyway (it keeps its dedicated `-p` test
+  lanes). A dedicated `-p autumn-web --features "sqlite,mail"` lane preserves the
+  `sqlite` + `mail` union compile in the coverage job. [no-plugin]
 ### Added
 
 - **router:** new `health.enabled` config knob (default `true`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,7 +75,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   has no `i18n/` dir), leaving no stray anchor markers.
 - **mail:** make `DbSuppressionStore` backend-agnostic
   (`Pool<RuntimeConnection>`) so the `sqlite` + `mail` feature union compiles,
-  unblocking the Coverage CI job (#1614).
+  unblocking the Coverage CI job (#1614). The Coverage lane's
+  `--workspace --all-features` catch-all now also `--exclude`s the Pg-only
+  example crates (`blog`, `bookmarks`, `bookmarks-distributed`,
+  `bookmarks-sharded`, `reddit-clone`, `saas`, `todo-app`, `wiki`) and
+  `autumn-admin-plugin`, which cannot compile under the global `sqlite`
+  backend-flip; the examples are not coverage-critical and `autumn-admin-plugin`
+  keeps its coverage via its dedicated `-p` invocation. [no-plugin]
 ### Added
 
 - **router:** new `health.enabled` config knob (default `true`,

--- a/autumn/src/mail.rs
+++ b/autumn/src/mail.rs
@@ -4179,7 +4179,6 @@ pub mod db_suppression {
     use std::pin::Pin;
 
     use diesel::prelude::*;
-    use diesel_async::AsyncPgConnection;
     use diesel_async::RunQueryDsl;
     use diesel_async::pooled_connection::deadpool::Pool;
 
@@ -4207,13 +4206,13 @@ pub mod db_suppression {
     /// `autumn generate mailer --list-unsubscribe` writes into the app.
     #[derive(Clone)]
     pub struct DbSuppressionStore {
-        pool: Pool<AsyncPgConnection>,
+        pool: Pool<crate::db::RuntimeConnection>,
     }
 
     impl DbSuppressionStore {
         /// Create a store backed by `pool`.
         #[must_use]
-        pub const fn new(pool: Pool<AsyncPgConnection>) -> Self {
+        pub const fn new(pool: Pool<crate::db::RuntimeConnection>) -> Self {
             Self { pool }
         }
     }


### PR DESCRIPTION
## Before / After

**Before:** The Coverage CI job (`ci.yml:241`, `cargo llvm-cov --workspace --exclude autumn-web --all-features --no-report`) fails to compile with `E0308` at `autumn/src/mail.rs`. `--exclude autumn-web` skips only coverage instrumentation, not compilation, and `--all-features` co-enables autumn-cli's `sqlite` (which forwards `autumn-web/sqlite`) together with `mail`. That flips `crate::db::RuntimeConnection` to the SQLite connection wrapper, while `DbSuppressionStore` stayed hardcoded to `Pool<AsyncPgConnection>` — a type mismatch that fails the build.

**After:** `autumn-web` compiles on both backend lanes with `mail` enabled, so the Coverage job builds again.

## How

`DbSuppressionStore` in `mod db_suppression` now stores `Pool<crate::db::RuntimeConnection>` (the backend-agnostic alias) instead of `Pool<AsyncPgConnection>`, on both the struct field and `new()`. The now-unused `use diesel_async::AsyncPgConnection;` import is removed. This mirrors the existing pattern in `autumn-media-plugin/src/rooms_db.rs` and the local precedent in `repository_commit_hooks.rs`. The `is_suppressed` / `suppress` query bodies are already portable across the diesel pg and sqlite lanes, so no query logic changes — the diff is just the two type annotations plus the dropped import.

## Reproduction

The failing repro (now succeeds):

```
cargo check -p autumn-web --no-default-features --features sqlite,mail
```

The pg lane still compiles:

```
cargo check -p autumn-web --no-default-features --features db,mail
```

## Notes

This is a CI/infra compile fix — `[no-plugin]` exemption applies (no product/plugin behavior changes).

Refs #1614.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RszvAcKeUfyrEYQoSrZBhs)_

**Follow-up:** #2108 — make `autumn-admin-plugin` backend-agnostic so SQLite apps can use it (re-scoped; the original coverage-lane motivation is resolved in this PR by excluding the sqlite feature-owner `autumn-cli`, not per-crate).