### PR TITLE
dev: compile-only pre-push gate mirroring CI's cargo test --workspace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,15 +14,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   integration tests — driving the real worker→drain wiring without starting the
   timing-based background commit-hook worker — and returns the number processed.
 
-- **dev:** add `scripts/pre-push-check.sh`, a compile-only (`--no-run`) pre-push
-  gate that mirrors CI's `lint` + `test` jobs (`cargo fmt --all -- --check`,
-  `cargo clippy --workspace --all-targets`, and `cargo test --workspace
-  --no-run`). It compiles every workspace test target — including the autumn-web
-  consolidated `integration_tests` binary that a narrow `cargo test -p
-  autumn-cli` loop never links — so cross-package compile breaks (e.g. the #1614
-  sqlite+mail `E0308`) are caught locally instead of surfacing as CI "flakes".
-  `--no-run` keeps it disk-cheap by skipping the trybuild run that expands
-  scratch by ~17GB. Documented in CONTRIBUTING.md "Before you push". [no-plugin]
+- **dev:** add `scripts/pre-push-check.sh`, a pre-push gate that mirrors CI's
+  `lint` + `test` jobs (`cargo fmt --all -- --check`, `cargo clippy --workspace
+  --all-targets`, a compile-only `cargo test --workspace --no-run`, and a
+  `cargo test --workspace --doc` doctest leg). The compile-only step builds every
+  workspace test target — including the autumn-web consolidated
+  `integration_tests` binary that a narrow `cargo test -p autumn-cli` loop never
+  links — so cross-package compile breaks (e.g. the #1614 sqlite+mail `E0308`)
+  are caught locally instead of surfacing as CI "flakes". `--no-run` keeps it
+  disk-cheap by skipping the trybuild run that expands scratch by ~17GB. Because
+  `--no-run` does **not** build doctests (they compile only in the `--doc`
+  phase) and cargo has no stable compile-only doctest mode, the separate
+  `--workspace --doc` leg runs them to catch doctest breaks like #2107 (an
+  `app.rs` `no_run` example that broke after a struct gained a field); it stays
+  infra-free and disk-cheap because doctests are overwhelmingly `no_run`/`ignore`
+  (still compiled, so the break is caught) and `--doc` never triggers trybuild.
+  Documented in CONTRIBUTING.md "Before you push". [no-plugin]
 
 - **media:** the mesh-room `RoomStore` seam (#1974) is now **async** and gained a
   shared, **multi-process-safe** database-backed implementation. The `RoomStore`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   deterministically claims and runs ready durable repository commit hooks in
   integration tests — driving the real worker→drain wiring without starting the
   timing-based background commit-hook worker — and returns the number processed.
+
+- **dev:** add `scripts/pre-push-check.sh`, a compile-only (`--no-run`) pre-push
+  gate that mirrors CI's `lint` + `test` jobs (`cargo fmt --all -- --check`,
+  `cargo clippy --workspace --all-targets`, and `cargo test --workspace
+  --no-run`). It compiles every workspace test target — including the autumn-web
+  consolidated `integration_tests` binary that a narrow `cargo test -p
+  autumn-cli` loop never links — so cross-package compile breaks (e.g. the #1614
+  sqlite+mail `E0308`) are caught locally instead of surfacing as CI "flakes".
+  `--no-run` keeps it disk-cheap by skipping the trybuild run that expands
+  scratch by ~17GB. Documented in CONTRIBUTING.md "Before you push". [no-plugin]
+
 - **media:** the mesh-room `RoomStore` seam (#1974) is now **async** and gained a
   shared, **multi-process-safe** database-backed implementation. The `RoomStore`
   trait, `RoomService`, and the four room HTTP handlers are now `async` (via

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,11 @@ separate, deliberate step the user asks for by name.
 - **Test all**: `cargo test --workspace`
 - **Test specific package**: `cargo test -p <pkg>`
 - **Test specific target**: `cargo test -p <pkg> --test <target>`
+- **Pre-push gate**: `./scripts/pre-push-check.sh` — compile-only (`--no-run`)
+  mirror of CI's `lint` + `test` jobs. Run it before pushing: a narrow `cargo
+  test -p <pkg>` never links the autumn-web consolidated `integration_tests`
+  binary, so it misses cross-package compile breaks the CI `cargo test
+  --workspace` gate catches. See CONTRIBUTING.md "Before you push".
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,21 +11,35 @@ cross-package break is caught locally instead of on the PR:
 
 It mirrors CI's always-on `lint` + `test` jobs (`.github/workflows/ci.yml`) —
 `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D
-warnings`, and a **compile-only** `cargo test --workspace --no-run`. The
-compile-only step is the important one: CI's blocking gate is `cargo test
---workspace`, which links **every** workspace test target including the
-autumn-web consolidated `integration_tests` binary. A narrower loop like `cargo
-test -p autumn-cli` never compiles that binary, so a cross-package compile break
-(e.g. the #1614 sqlite+mail `E0308`) passes locally and only shows up in CI,
-where it looks like a flake.
+warnings`, a **compile-only** `cargo test --workspace --no-run`, and a
+`cargo test --workspace --doc` doctest leg. The compile-only step is the
+important one: CI's blocking gate is `cargo test --workspace`, which links
+**every** workspace test target including the autumn-web consolidated
+`integration_tests` binary. A narrower loop like `cargo test -p autumn-cli`
+never compiles that binary, so a cross-package compile break (e.g. the #1614
+sqlite+mail `E0308`) passes locally and only shows up in CI, where it looks like
+a flake.
 
 `--no-run` compiles those targets without executing them, deliberately skipping
 the trybuild suite (`autumn/tests/integration/compile_fail.rs`) whose cases each
 spawn a nested `cargo build` at test-**run** time — expanding scratch by ~17GB
-and risking `ENOSPC`. So the gate stays disk-cheap. It does **not** cover the
-Docker/testcontainer, `sqlite`-backend, or Chromium `system-tests` lanes (those
-run in dedicated CI jobs); `cargo test -p <pkg>` remains fine for iterating on a
-single crate — just run `./scripts/pre-push-check.sh` before you push.
+and risking `ENOSPC`. So the gate stays disk-cheap.
+
+The catch: `--no-run` does **not** build doctests — they only compile during the
+`--doc` phase — so a doctest that stops compiling (e.g. #2107, where an `app.rs`
+`no_run` example doctest broke after a struct gained a field) passes `--no-run`
+locally yet fails CI's `cargo test --workspace`, which runs the doc target.
+Cargo has no stable compile-only doctest mode (`cargo test --doc --no-run`
+errors on the current toolchain), so the gate simply **runs** the doctests with
+`cargo test --workspace --doc`. That stays cheap: doctests are overwhelmingly
+`no_run`/`ignore` (which still compile — exactly the #2107 signal), so it needs
+no Postgres/MediaMTX and never hangs, and because `--doc` selects only the doc
+target it never triggers trybuild.
+
+The gate does **not** cover the Docker/testcontainer, `sqlite`-backend, or
+Chromium `system-tests` lanes (those run in dedicated CI jobs); `cargo test -p
+<pkg>` remains fine for iterating on a single crate — just run
+`./scripts/pre-push-check.sh` before you push.
 
 ## Generator conformance gate
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,32 @@
 # Contributing to Autumn
 
+## Before you push
+
+Run the pre-push gate, which compiles the **same targets CI compiles** so a
+cross-package break is caught locally instead of on the PR:
+
+```sh
+./scripts/pre-push-check.sh
+```
+
+It mirrors CI's always-on `lint` + `test` jobs (`.github/workflows/ci.yml`) —
+`cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D
+warnings`, and a **compile-only** `cargo test --workspace --no-run`. The
+compile-only step is the important one: CI's blocking gate is `cargo test
+--workspace`, which links **every** workspace test target including the
+autumn-web consolidated `integration_tests` binary. A narrower loop like `cargo
+test -p autumn-cli` never compiles that binary, so a cross-package compile break
+(e.g. the #1614 sqlite+mail `E0308`) passes locally and only shows up in CI,
+where it looks like a flake.
+
+`--no-run` compiles those targets without executing them, deliberately skipping
+the trybuild suite (`autumn/tests/integration/compile_fail.rs`) whose cases each
+spawn a nested `cargo build` at test-**run** time — expanding scratch by ~17GB
+and risking `ENOSPC`. So the gate stays disk-cheap. It does **not** cover the
+Docker/testcontainer, `sqlite`-backend, or Chromium `system-tests` lanes (those
+run in dedicated CI jobs); `cargo test -p <pkg>` remains fine for iterating on a
+single crate — just run `./scripts/pre-push-check.sh` before you push.
+
 ## Generator conformance gate
 
 Autumn's headline DX promise is that `autumn new` and `autumn generate` emit

--- a/scripts/pre-push-check.sh
+++ b/scripts/pre-push-check.sh
@@ -18,6 +18,20 @@
 # by ~17GB and risking ENOSPC. trybuild compiles at run time, not build time, so
 # `--no-run` never triggers it. This gate stays disk-cheap by construction.
 #
+# Why a SEPARATE doctest leg: `--no-run` compiles every *binary* test target but
+# does NOT build doctests — doctests are only built during the `--doc` phase. So
+# a doctest that stops compiling (e.g. #2107: an app.rs `no_run` example doctest
+# broke after a struct gained a field) sails past `--no-run` locally yet fails
+# CI's `cargo test --workspace`, which DOES run the doc target. Cargo has no
+# stable compile-only doctest mode (`cargo test --doc --no-run` errors "can't
+# skip running doc tests with --no-run" on the current toolchain), so the only
+# way to catch a doctest break is to actually run them. Fortunately that is
+# cheap and infra-free here: almost every doctest is `no_run` or `ignore` (which
+# still COMPILE — exactly the #2107 signal), so `cargo test --workspace --doc`
+# needs no Postgres/MediaMTX, never hangs, and — because `--doc` selects only the
+# doc target — never touches the trybuild integration binaries, so it adds no
+# meaningful disk. It reuses the libs the steps above already built.
+#
 # NOT run here (need Docker / a backend-flip feature / a browser — out of scope
 # for a fast, disk-cheap compile-only gate; CI runs them in dedicated jobs):
 #   - the Docker/testcontainer `#[ignore]`d sweep (ci.yml "Run Docker-dependent tests")
@@ -60,7 +74,20 @@ cargo clippy --workspace --all-targets -- -D warnings
 step "cargo test --workspace --no-run   (compile-only; skips ~17GB trybuild run)"
 cargo test --workspace --no-run
 
+# --- 4. Doctests (workspace, doc target only) --------------------------------
+# `--no-run` above skips doctests (they build only in the `--doc` phase), so a
+# doctest compile break — like #2107's app.rs example — would pass locally but
+# fail CI's `cargo test --workspace`. There's no stable compile-only doctest
+# mode, so run them: it mirrors CI's workspace doctest scope, stays infra-free
+# (doctests are overwhelmingly no_run/ignore, so nothing hits a DB or hangs),
+# and — because `--doc` selects only the doc target — never triggers trybuild,
+# so it adds no meaningful disk.
+step "cargo test --workspace --doc   (doctests; --no-run above does not build them)"
+cargo test --workspace --doc
+
 echo
-echo "pre-push-check: OK — workspace test targets compile clean (compile-only)."
-echo "note: this gate is COMPILE-ONLY. A full \`cargo test --workspace\` (without"
-echo "      --no-run) additionally RUNS trybuild, expanding scratch by ~17GB."
+echo "pre-push-check: OK — workspace test targets compile clean, doctests pass."
+echo "note: steps 1-3 are COMPILE-ONLY; step 4 RUNS doctests (cheap: mostly"
+echo "      no_run/ignore, no DB, and --doc never triggers the ~17GB trybuild run)."
+echo "      A bare \`cargo test --workspace\` (without --no-run / --doc) additionally"
+echo "      RUNS trybuild, expanding scratch by ~17GB — avoid it on a small disk."

--- a/scripts/pre-push-check.sh
+++ b/scripts/pre-push-check.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Pre-push gate: compile the SAME targets CI compiles, COMPILE-ONLY.
+#
+# Why this exists: CI's blocking gate is `cargo test --workspace` (the `test`
+# job in .github/workflows/ci.yml), which compiles every workspace test target
+# — including the autumn-web consolidated `integration_tests` binary. A narrower
+# local loop like `cargo test -p autumn-cli` never links that binary, so a
+# cross-package compile break (e.g. the #1614 sqlite+mail E0308) sails past a
+# green local run and only surfaces in CI, where it looks like a "flake." This
+# script closes that gap: it builds exactly what CI's always-on `lint` + `test`
+# jobs build, so a compile break is caught here instead of on the PR.
+#
+# Why `--no-run`: `cargo test --workspace --no-run` compiles every test binary
+# (catching cross-package breaks in the consolidated integration binary) WITHOUT
+# executing them. That deliberately avoids the trybuild suite
+# (autumn/tests/integration/compile_fail.rs), whose compile-fail / compile-pass
+# cases each spawn a *nested* `cargo build` at test-RUN time — expanding scratch
+# by ~17GB and risking ENOSPC. trybuild compiles at run time, not build time, so
+# `--no-run` never triggers it. This gate stays disk-cheap by construction.
+#
+# NOT run here (need Docker / a backend-flip feature / a browser — out of scope
+# for a fast, disk-cheap compile-only gate; CI runs them in dedicated jobs):
+#   - the Docker/testcontainer `#[ignore]`d sweep (ci.yml "Run Docker-dependent tests")
+#   - the `sqlite-runtime` lane (`--features sqlite`, a backend-flip feature)
+#   - the `system-tests` (Chromium) browser suite
+#
+# Usage (runnable from anywhere in the tree):
+#   ./scripts/pre-push-check.sh
+#
+# WARNING: do NOT run a bare `cargo test --workspace` (without `--no-run`) on a
+# disk-constrained machine — that RUNS trybuild and expands scratch by ~17GB.
+
+set -euo pipefail
+
+root="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$root"
+
+step() {
+  echo
+  echo "==> $*"
+}
+
+# --- 1. Formatting -----------------------------------------------------------
+# Mirrors ci.yml `lint` job: `cargo fmt --all -- --check`.
+step "cargo fmt --all -- --check"
+cargo fmt --all -- --check
+
+# --- 2. Clippy (whole workspace, all targets) --------------------------------
+# Mirrors ci.yml `lint` job: `cargo clippy --workspace --all-targets -- -D warnings`.
+# `--all-targets` also compiles examples/benches, so together with the test
+# compile below this covers the full set of targets CI builds on every PR.
+step "cargo clippy --workspace --all-targets -- -D warnings"
+cargo clippy --workspace --all-targets -- -D warnings
+
+# --- 3. Compile every workspace test target (compile-only) -------------------
+# Mirrors ci.yml `test` job (`cargo test --workspace`), but `--no-run` so it
+# compiles — and never executes — every test binary, including the autumn-web
+# consolidated `integration_tests` binary that a `-p autumn-cli` loop skips.
+# This is the line that catches cross-package compile breaks locally.
+step "cargo test --workspace --no-run   (compile-only; skips ~17GB trybuild run)"
+cargo test --workspace --no-run
+
+echo
+echo "pre-push-check: OK — workspace test targets compile clean (compile-only)."
+echo "note: this gate is COMPILE-ONLY. A full \`cargo test --workspace\` (without"
+echo "      --no-run) additionally RUNS trybuild, expanding scratch by ~17GB."


### PR DESCRIPTION
## Before / After

**Before:** CI&#39;s real blocking gate is `cargo test --workspace` (ci.yml `test` job), which links *every* workspace test target — including the autumn-web consolidated `integration_tests` binary. But the documented local dev loop leaned on a narrower `cargo test -p autumn-cli`, which never compiles that binary. So a cross-package compile break (exactly the kind of #1614 sqlite+mail `E0308`) sailed past a green local run and only surfaced in CI, where it looked like a &#34;flake.&#34;

**After:** a scripted, documented pre-push gate — `scripts/pre-push-check.sh` — that compiles the *same targets CI compiles*, so cross-package breaks are caught locally.

## How

The script mirrors CI&#39;s always-on `lint` + `test` jobs, but **compile-only**:

| Script line | CI source | Command |
|---|---|---|
| `scripts/pre-push-check.sh:46` | `ci.yml:31` (lint) | `cargo fmt --all -- --check` |
| `scripts/pre-push-check.sh:53` | `ci.yml:33` (lint) | `cargo clippy --workspace --all-targets -- -D warnings` |
| `scripts/pre-push-check.sh:61` | `ci.yml:102` (test) | `cargo test --workspace --no-run` |

The fmt and clippy lines are byte-identical to CI. The test line is CI&#39;s `cargo test --workspace` with `--no-run` added: it compiles every test binary (catching cross-package breaks in the consolidated integration binary) **without executing them**. That deliberately avoids the trybuild suite (`autumn/tests/integration/compile_fail.rs`), whose compile-fail / compile-pass cases each spawn a *nested* `cargo build` at test-**run** time — expanding scratch by ~17GB and risking `ENOSPC`. trybuild compiles at run time, not build time, so `--no-run` never triggers it and the gate stays disk-cheap.

Out of scope for this fast compile-only gate (CI runs them in dedicated jobs): the Docker/testcontainer sweep, the `sqlite-runtime` backend-flip lane, and the Chromium `system-tests` suite.

## Docs

- `CONTRIBUTING.md` gains a **&#34;Before you push&#34;** section pointing at the script and explaining why `-p autumn-cli` under-specifies the local gate.
- Workspace `CLAUDE.md` **Commands** section cross-references it.
- `CHANGELOG.md` bullet under `## [Unreleased]`.

## Verification

The full workspace compile-only run was **not** executed to completion locally — deliberately, to avoid burning CI-equivalent compute; the draft PR&#39;s own CI validates the mirrored targets for real. During the partial run, `fmt` passed and the clippy `--workspace --all-targets` compile was underway with **disk holding steady at ~27G** (started 28G), confirming `--no-run` avoids the ~17GB trybuild expansion. `bash -n scripts/pre-push-check.sh` passes and the script is `chmod +x`. Correctness of the mirrored invocation is established by the side-by-side table above.

## Classification

CI / dev-experience change only — no framework/library code touched (one new script + three doc files). **[no-plugin]** exemption applies.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RszvAcKeUfyrEYQoSrZBhs)_

---
**Known CI note:** the Coverage check on this PR is red due to the pre-existing #1614 breakage inherited from `trunk-dev` — this PR touches only `scripts/pre-push-check.sh` and docs (no Rust), so it cannot affect compilation. It is fixed by #2100; merge #2100 first and this Coverage check clears on rebase / the next run.