### PR TITLE
test-support: expose deterministic drain for durable repository commit hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **test-support:** `autumn_web::test::drain_ready_repository_commit_hooks(pool, max_rows)`
+  deterministically claims and runs ready durable repository commit hooks in
+  integration tests — driving the real worker→drain wiring without starting the
+  timing-based background commit-hook worker — and returns the number processed.
 - **media:** the mesh-room `RoomStore` seam (#1974) is now **async** and gained a
   shared, **multi-process-safe** database-backed implementation. The `RoomStore`
   trait, `RoomService`, and the four room HTTP handlers are now `async` (via

--- a/autumn/src/repository_commit_hooks.rs
+++ b/autumn/src/repository_commit_hooks.rs
@@ -1377,7 +1377,7 @@ fn spawn_repository_commit_hook_kick_worker(
 }
 
 #[cfg(not(feature = "sqlite"))]
-async fn drain_ready_repository_commit_hooks(pool: &PgPool, worker_id: &str, max_rows: usize) {
+pub async fn drain_ready_repository_commit_hooks(pool: &PgPool, worker_id: &str, max_rows: usize) {
     for _ in 0..max_rows {
         let Some(row) = pg_claim_next_repository_commit_hook(pool, worker_id).await else {
             break;
@@ -1909,7 +1909,7 @@ async fn sqlite_claim_next_repository_commit_hook(
 /// scope) → ack/nack, one row at a time. Mirrors the Postgres
 /// `drain_ready_repository_commit_hooks` shape.
 #[cfg(feature = "sqlite")]
-async fn sqlite_drain_ready_repository_commit_hooks(
+pub async fn sqlite_drain_ready_repository_commit_hooks(
     pool: &RtPool,
     worker_id: &str,
     max_rows: usize,
@@ -2131,7 +2131,7 @@ fn hex_lower(bytes: impl AsRef<[u8]>) -> String {
     )
 }
 
-fn repository_commit_hook_worker_id() -> String {
+pub fn repository_commit_hook_worker_id() -> String {
     format!("repository-hook-{}", uuid::Uuid::new_v4())
 }
 

--- a/autumn/src/test.rs
+++ b/autumn/src/test.rs
@@ -3997,6 +3997,92 @@ impl TestDb {
     }
 }
 
+/// Deterministically claims and runs up to `max_rows` ready durable repository
+/// commit hooks, returning the number processed.
+///
+/// Intended for integration tests that need to drive the real worker→drain
+/// wiring (claim → run the registered runner → ack/nack) **without** the
+/// timing-based background commit-hook worker that a served app starts. It
+/// generates its own worker id and delegates to the same backend-appropriate
+/// drain the production worker uses, so a test can enqueue a durable hook,
+/// assert its side effect has not happened, drain once, and assert the side
+/// effect deterministically — no `sleep`, no polling.
+///
+/// Pass a `max_rows` >= the number of enqueued hooks to fully drain in one
+/// call. Hooks whose `run_at` is still in the future, or whose handler runner
+/// is not registered in this process, are left untouched.
+///
+/// The returned count is the number of ready hooks claimed and run this pass
+/// (`min(ready_hooks, max_rows)`); it does not include hooks that failed and
+/// were re-queued with a future backoff.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// use autumn_web::test::TestDb;
+///
+/// let db = TestDb::shared().await;
+/// // ... enqueue a durable repository commit hook and register its runner ...
+///
+/// let processed = autumn_web::test::drain_ready_repository_commit_hooks(&db.pool(), 16).await;
+/// assert_eq!(processed, 1);
+/// // ... assert the hook's side effect now exists ...
+/// ```
+///
+/// # Panics
+///
+/// Panics if a pooled database connection cannot be acquired or the ready-hook
+/// count query fails — this helper is for tests, where surfacing such a
+/// database failure loudly is the desired behavior.
+#[cfg(feature = "db")]
+pub async fn drain_ready_repository_commit_hooks(
+    pool: &Pool<crate::db::RuntimeConnection>,
+    max_rows: usize,
+) -> usize {
+    use diesel_async::RunQueryDsl as _;
+
+    #[derive(diesel::QueryableByName)]
+    struct ReadyCount {
+        #[diesel(sql_type = diesel::sql_types::BigInt)]
+        ready: i64,
+    }
+
+    // The private drains return `()`, so measure the ready set up-front and
+    // report how many this pass will claim-and-run. In a single-threaded test
+    // (no competing worker) this equals the number processed, capped at
+    // `max_rows`. Predicate mirrors the claim query's readiness gate
+    // (`status = 'enqueued' AND run_at <= now`); `CURRENT_TIMESTAMP` is standard
+    // SQL on both the Postgres and SQLite backends.
+    let ready_before: usize = {
+        let mut conn = pool
+            .get()
+            .await
+            .expect("drain_ready_repository_commit_hooks: acquire pooled connection");
+        let row = diesel::sql_query(
+            "SELECT COUNT(*) AS ready \
+             FROM autumn_repository_commit_hooks \
+             WHERE status = 'enqueued' AND run_at <= CURRENT_TIMESTAMP",
+        )
+        .get_result::<ReadyCount>(&mut *conn)
+        .await
+        .expect("drain_ready_repository_commit_hooks: count ready hooks");
+        usize::try_from(row.ready).unwrap_or(0)
+    };
+
+    let worker_id = crate::repository_commit_hooks::repository_commit_hook_worker_id();
+
+    #[cfg(not(feature = "sqlite"))]
+    crate::repository_commit_hooks::drain_ready_repository_commit_hooks(pool, &worker_id, max_rows)
+        .await;
+    #[cfg(feature = "sqlite")]
+    crate::repository_commit_hooks::sqlite_drain_ready_repository_commit_hooks(
+        pool, &worker_id, max_rows,
+    )
+    .await;
+
+    ready_before.min(max_rows)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/autumn/src/test.rs
+++ b/autumn/src/test.rs
@@ -3998,7 +3998,8 @@ impl TestDb {
 }
 
 /// Deterministically claims and runs up to `max_rows` ready durable repository
-/// commit hooks, returning the number processed.
+/// commit hooks, returning the number of ready hooks selected for this drain
+/// pass.
 ///
 /// Intended for integration tests that need to drive the real worker→drain
 /// wiring (claim → run the registered runner → ack/nack) **without** the
@@ -4012,9 +4013,14 @@ impl TestDb {
 /// call. Hooks whose `run_at` is still in the future, or whose handler runner
 /// is not registered in this process, are left untouched.
 ///
-/// The returned count is the number of ready hooks claimed and run this pass
-/// (`min(ready_hooks, max_rows)`); it does not include hooks that failed and
-/// were re-queued with a future backoff.
+/// The returned count is the size of the ready set measured *before* the pass
+/// (`status = 'enqueued'` and due), capped at `max_rows`
+/// (`min(ready_hooks, max_rows)`). Because it is measured up front — the
+/// underlying private drains return `()` and expose no per-hook success tally —
+/// it reflects the rows *selected* for draining, not a success count. In the
+/// intended single-threaded / private-pool test (no competing worker) every
+/// selected hook runs, so this equals the number processed; a hook that fails
+/// and is re-queued with a future backoff during the pass is still counted here.
 ///
 /// # Example
 ///

--- a/autumn/tests/integration/commit_hook_drain.rs
+++ b/autumn/tests/integration/commit_hook_drain.rs
@@ -1,0 +1,165 @@
+//! Integration coverage for the test-harness export
+//! [`autumn_web::test::drain_ready_repository_commit_hooks`].
+//!
+//! Exercises the export exactly as a downstream integration test would: a
+//! durable repository commit hook is staged into the real
+//! `autumn_repository_commit_hooks` queue, its registered runner has a
+//! persisted, observable side effect (a row in a second table), and the drain
+//! export drives the real claim → run-registered-runner → ack wiring **without**
+//! starting the timing-based background commit-hook worker. The whole flow is
+//! deterministic: no `sleep`, no timeout-poll.
+//!
+//! The enqueue + runner registration go through the same low-level durable
+//! surface the framework's own `tests/sqlite_commit_hook_worker.rs` uses, rather
+//! than a macro `#[repository(commit_hooks = true)]` `save()`. A macro `save()`
+//! auto-kicks the dispatcher, which spawns a background drain worker — exactly
+//! the timing-based worker this export exists to avoid — so driving the enqueue
+//! directly is what keeps the "not fired yet → drain → fired" assertions
+//! deterministic. A private [`TestDb::new`] pool (not the shared one) further
+//! guarantees no other test's background worker can touch this queue.
+//!
+//! Run with:
+//!
+//!     cargo test -p autumn-web --features "db,test-support" \
+//!         --test integration_tests commit_hook_drain -- --ignored
+
+#[cfg(all(feature = "db", feature = "test-support"))]
+mod tests {
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    use autumn_web::AutumnError;
+    use autumn_web::test::TestDb;
+    use diesel_async::{RunQueryDsl, SimpleAsyncConnection};
+    use serde_json::json;
+
+    const COMMIT_HOOK_UP: &str = include_str!(
+        "../../repository_commit_hook_migrations/20260515000000_create_repository_commit_hook_queue/up.sql"
+    );
+
+    // Process-unique so the globally-registered runner registry never collides
+    // with another test's handler key in the same test binary.
+    static KEY_SEQ: AtomicU64 = AtomicU64::new(0);
+
+    fn unique_handler_key() -> &'static str {
+        let n = KEY_SEQ.fetch_add(1, Ordering::Relaxed);
+        Box::leak(format!("test::commit_hook_drain::handler::{n}").into_boxed_str())
+    }
+
+    #[derive(diesel::QueryableByName)]
+    struct CountRow {
+        #[diesel(sql_type = diesel::sql_types::BigInt)]
+        n: i64,
+    }
+
+    async fn count_marks(db: &TestDb) -> i64 {
+        let mut conn = db.pool().get().await.expect("checkout");
+        diesel::sql_query("SELECT COUNT(*) AS n FROM hook_marks")
+            .get_result::<CountRow>(&mut *conn)
+            .await
+            .expect("count hook_marks")
+            .n
+    }
+
+    #[tokio::test]
+    #[ignore = "requires Docker (testcontainers)"]
+    async fn drain_export_runs_ready_repository_commit_hook_end_to_end() {
+        let db = TestDb::new().await;
+
+        // Real durable queue schema + a second table the hook writes into as its
+        // deterministically observable side effect.
+        {
+            let mut conn = db.pool().get().await.expect("setup connection");
+            conn.batch_execute(COMMIT_HOOK_UP)
+                .await
+                .expect("apply commit-hook queue migration");
+            conn.batch_execute(
+                "CREATE TABLE IF NOT EXISTS hook_marks (\
+                     id BIGSERIAL PRIMARY KEY, \
+                     note TEXT NOT NULL\
+                 )",
+            )
+            .await
+            .expect("create hook_marks table");
+        }
+
+        // Register the durable runner. Its create branch writes a persisted row
+        // into the second table, so a fired hook is observable across a fresh
+        // connection — the strongest end-to-end assertion.
+        let handler_key = unique_handler_key();
+        let runner_pool = db.pool();
+        autumn_web::__private::register_repository_commit_hook_runner(
+            handler_key,
+            move |_ctx, _record| {
+                let pool = runner_pool.clone();
+                async move {
+                    let mut conn = pool.get().await.map_err(|error| {
+                        AutumnError::internal_server_error_msg(format!("hook pool error: {error}"))
+                    })?;
+                    diesel::sql_query("INSERT INTO hook_marks (note) VALUES ('fired')")
+                        .execute(&mut *conn)
+                        .await
+                        .map_err(|error| {
+                            AutumnError::internal_server_error_msg(format!(
+                                "hook insert failed: {error}"
+                            ))
+                        })?;
+                    Ok(())
+                }
+            },
+            |_ctx, _record| async { Ok(()) },
+            |_ctx, _record| async { Ok(()) },
+        );
+
+        // Stage one durable hook into the real queue (no dispatcher kick, so no
+        // background worker is ever spawned on this pool).
+        {
+            let mut conn = db.pool().get().await.expect("enqueue connection");
+            autumn_web::__private::enqueue_repository_commit_hook_on_conn(
+                &mut conn,
+                handler_key,
+                "create",
+                None,
+                None,
+                &json!({ "op": "create" }),
+                &json!({ "note": "fired" }),
+            )
+            .await
+            .expect("enqueue durable hook");
+        }
+
+        // Precondition: the hook is queued but has NOT run — no worker exists.
+        assert_eq!(
+            count_marks(&db).await,
+            0,
+            "the commit hook must not have fired before the drain"
+        );
+
+        // Drive the real drain wiring through the export. A cap above the number
+        // of enqueued hooks drains everything in one pass.
+        let processed = autumn_web::test::drain_ready_repository_commit_hooks(&db.pool(), 16).await;
+        assert_eq!(
+            processed, 1,
+            "the drain must report exactly one ready hook claimed-and-run"
+        );
+
+        // The registered runner fired end-to-end through the real claim/ack path.
+        assert_eq!(
+            count_marks(&db).await,
+            1,
+            "the commit hook's persisted side effect must exist after the drain"
+        );
+
+        // A second drain has nothing ready and is a no-op.
+        let processed_again =
+            autumn_web::test::drain_ready_repository_commit_hooks(&db.pool(), 16).await;
+        assert_eq!(
+            processed_again, 0,
+            "a drained queue reports zero on re-drain"
+        );
+        assert_eq!(
+            count_marks(&db).await,
+            1,
+            "re-draining must not run the already-processed hook again"
+        );
+    }
+}

--- a/autumn/tests/integration/mod.rs
+++ b/autumn/tests/integration/mod.rs
@@ -38,6 +38,7 @@ mod chaos_session_loom;
 mod chaos_state_loom;
 mod circuit_breaker_integration;
 mod clock_integration;
+mod commit_hook_drain;
 mod compile_fail;
 mod compression_middleware;
 mod config_deprecation;


### PR DESCRIPTION
**Before/After (plain language):** Before, a downstream integration test could only start autumn's timing-based background commit-hook worker and poll with timeouts (e.g. `tests/integration/auto_broadcast.rs` waits on 3s `tokio::time::timeout` loops) — the real worker→drain wiring was trusted-but-untested from downstream. After, a downstream test can call `autumn_web::test::drain_ready_repository_commit_hooks(pool, max_rows)` to deterministically claim-and-run ready durable repository commit hooks with no background worker, and assert the hook fired end-to-end.

**How:** New documented `#[cfg(feature = "db")]` test-harness fn in `src/test.rs` that self-generates a worker_id (via the existing `repository_commit_hook_worker_id()`), feature-forks to the crate's own private pg/sqlite drain, and returns the number of ready hooks selected for draining (capped at `max_rows`). Additive-only: the two private drains + the worker_id helper are widened from module-private to plain `pub` within the already-`pub(crate)` `repository_commit_hooks` module — NO body/signature/behavior change, so nothing is refactored and no public API is widened. New consolidated Postgres integration test (`tests/integration/commit_hook_drain.rs`) enqueues a durable commit hook, asserts its observable side effect is absent, calls the export, and asserts the side effect is now present — driving the real registered-runner wiring deterministically (no sleeps/timeouts).

**Downstream context:** Requested by the Nexus project — Nexus #653 (sync-leaf rework) wants a true end-to-end commit-hook test; the private worker→drain symbols in 0.5.0/0.6.0 left downstream unable to drive the real wiring. This is the framework-side export enabling that.

**Coordination note:** The concurrent sim-testing lane's `sim.run_to_idle()` will reuse the SAME now-`pub` drain seam; this change only widens visibility of those fns (no behavior change) so that lane builds on it without a shared-seam refactor.

**Versioning:** No workspace version bump. Whether this ships as 0.6.1 or 0.7.0 is the maintainer's call at release time.

**Testing:** `cargo fmt --all -- --check`, `cargo clippy -p autumn-web --all-targets --features "db,test-support" -- -D warnings`, `cargo build -p autumn-web --features "db,test-support"`, and `cargo test -p autumn-web --features "db,test-support" --test integration_tests --no-run` all pass locally. The new integration test is `#[ignore = "requires Docker (testcontainers)"]`; Docker was unavailable in the dev sandbox so it compiled/linked but was not executed locally — it runs automatically in CI's Docker sweep. No external AI reviewer was used (Codex retired, Gemini sunset); review is the documented self-review below.

**Self-review notes:** Confirmed the 3 widened fns are visibility-only (`pub` keyword added, no body/param/return-type change) and that `repository_commit_hooks` is `pub(crate)` in `lib.rs`, so this widens no public API. One prose-only rustdoc tightening was applied: the export returns `min(ready_before, max_rows)` measured *before* draining, so the doc no longer claims it "excludes failed-and-requeued hooks" (an up-front measurement structurally cannot) — it now states it reports the ready set selected for the pass, which equals the number processed in the intended single-threaded/private-pool test. The integration test uses no `sleep`/timeout-poll and is gated `#[cfg(all(feature = "db", feature = "test-support"))]` + `#[ignore = "requires Docker (testcontainers)"]`.

**[no-plugin] exemption:** No plugin directory is touched by this change (only `autumn/src`, `autumn/tests`, and `CHANGELOG.md`), so the plugin-doc requirement does not apply.

---
_Generated by [Claude Code](https://claude.ai/code/session_01A75RQ2uVaihdTeFVERZ7dg)_

---
**Known CI note — Coverage check (non-gating):** The `Coverage` check is red due to the pre-existing, tracked issue **#1614**, not this PR. It fails at a compile error unrelated to this diff — `E0308` in `autumn/src/mail.rs:3435` (`DbSuppressionStore::new` expects `Pool<AsyncPgConnection>` but the coverage lane's `--all-features` build unifies to a `SyncConnectionWrapper` pool). Coverage is never measured, and this PR touches none of `mail.rs`. In this repo `Coverage` is informational (it `needs: [test, meta]` and is not a required merge gate), so this does not block the merge sweep.
---

---
_Generated by [Claude Code](https://claude.ai/code)_