### PR TITLE
sim-testing: SQLite sim DB lane substrate (#1797, W4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   deploy but silently ignored at runtime under `AUTUMN_ENV=prod`. The existing
   single-file `from_autumn_toml` / `from_toml_str_with_env` entry points are
   unchanged.
+- **sim-testing:** the deterministic simulation harness (#1797) gained its
+  **SQLite DB lane** — the per-sim database substrate a sim builds its app on.
+  `sim::substrate::SqliteSubstrate` (gated on the `sqlite` feature) builds a
+  fresh, migrated, **in-process in-memory** SQLite pool, unique per simulation,
+  ready to hand to the mounted app. It uses a **named shared-cache** in-memory
+  database anchored by a **kept-alive guard connection** so the migrated schema
+  survives for every pooled checkout — sidestepping the framework's conservative
+  in-memory-migration reject precisely because the guard keeps the database
+  alive — and a distinct database name per substrate guarantees two sims never
+  share state. It also resolves the **feature-unification hazard**: under
+  `--features sqlite` the Postgres advisory-lock scheduler and the durable
+  Postgres job queue are compiled out, so the sim exercises the *representative*
+  local paths — the `InProcessSchedulerCoordinator` (scheduler) and the local
+  `JobAdminMemoryBackend` (jobs). The documented divergence: a green sim proves
+  the orchestration/timing/ordering of those local paths, **not** the Postgres
+  advisory-lock leasing or durable `LISTEN`/`NOTIFY` + `SKIP LOCKED` queue
+  claim/lock semantics (consistent with the RFC §12 scope). The substrate is
+  self-contained and additive: it hands its `RuntimeConnection` pool to a
+  `TestApp` via `TestApp::with_db(...)`, which is exactly the seam W2's
+  `Sim::build(TestApp)` consumes — so W2 wires it into the `Sim` app mount in a
+  follow-up. (0.7.0 work — do not merge until v0.6.0 is cut.)
 ### Fixed
 
 - **migrate:** startup migration auto-apply is now profile-agnostic (#1903).

--- a/autumn/Cargo.toml
+++ b/autumn/Cargo.toml
@@ -601,6 +601,20 @@ path = "tests/sqlite_read_only_tx.rs"
 name = "sqlite_transactional_url_pool"
 path = "tests/sqlite_transactional_url_pool.rs"
 
+# Sim-testing W4 SQLite DB lane (issue #1797): proves the job/scheduler drain
+# runs end-to-end against a fresh, migrated, in-process in-memory SQLite substrate
+# (`sim::substrate::SqliteSubstrate`) over the representative local scheduler
+# (`InProcessSchedulerCoordinator`) + local job runtime paths. Standalone because
+# the consolidated `integration_tests` binary is Postgres-typed and does not
+# compile under `--features sqlite`; needs `test-support` for the public
+# `TestApp` harness, so the file is
+# `#![cfg(all(feature = "sqlite", feature = "test-support"))]` and a default
+# `cargo test` compiles it to an empty (passing) binary. Runs without Docker. Run:
+# `cargo test -p autumn-web --features "sqlite,test-support" --test sim_sqlite_substrate`.
+[[test]]
+name = "sim_sqlite_substrate"
+path = "tests/sim_sqlite_substrate.rs"
+
 # Isolated: sets process-wide proxy env vars (HTTP_PROXY/HTTPS_PROXY/ALL_PROXY)
 # to verify pinned SSRF-safe clients bypass env proxies. Cannot share the
 # consolidated binary — those vars would race the inline network tests.

--- a/autumn/src/sim.rs
+++ b/autumn/src/sim.rs
@@ -55,6 +55,20 @@ use rand_chacha::ChaCha8Rng;
 
 use crate::time::TickingClock;
 
+// The per-sim SQLite DB lane (W4, issue #1797): a fresh, migrated, in-process
+// SQLite substrate the sim builds its app on. Self-contained and additive — W2
+// consumes its pool when it mounts the app on `SimApp`. Only meaningful under the
+// `sqlite` feature (the sim's DB substrate is SQLite by design).
+//
+// Exposed as `#[doc(hidden)] pub` — unstable test/sim plumbing, not the stable
+// surface — mirroring this module's `__seed_from_env` / `__replay_line` hidden
+// hooks. It is `pub` (not `pub(crate)`) purely so the W4 DoD consolidated
+// integration test, which is an external crate, can drive the end-to-end drain;
+// the stable mount API remains W2's `Sim::build`.
+#[cfg(feature = "sqlite")]
+#[doc(hidden)]
+pub mod substrate;
+
 /// The fixed, deterministic epoch the simulation clock starts at:
 /// `2020-01-01T00:00:00Z`.
 ///

--- a/autumn/src/sim/substrate.rs
+++ b/autumn/src/sim/substrate.rs
@@ -1,0 +1,304 @@
+//! Per-sim `SQLite` database substrate (sim-testing W4, issue #1797).
+//!
+//! This is the **DB lane** the sim builds its app on: a fresh, migrated,
+//! in-process `SQLite` database, unique per simulation, ready to be handed to a
+//! [`Sim`](crate::sim::Sim)-mounted app. It is deliberately **self-contained**
+//! and additive — W2 owns `Sim::build(TestApp)` / the `SimApp` mount and will
+//! consume this substrate there in a follow-up; nothing here defines or pre-empts
+//! that public API.
+//!
+//! # Consumption shape (W2 seam)
+//!
+//! W2's `Sim::build` takes a [`crate::test::TestApp`] (not a raw `AppBuilder`),
+//! and the endorsed pattern attaches the DB to the `TestApp` *before* build. So
+//! the substrate hands its pool to a `TestApp` via
+//! [`TestApp::with_db`](crate::test::TestApp::with_db):
+//! `TestApp::new()…with_db(substrate.pool())`, and W2 then calls `sim.build(app)`.
+//! [`SqliteSubstrate::pool`] returns exactly the [`crate::db::RuntimeConnection`]
+//! pool that seam consumes; the substrate value itself must outlive the app,
+//! because it holds the kept-alive guard connection.
+//!
+//! # Why shared-cache in-memory + a kept-alive guard
+//!
+//! A pure `:memory:` / `file::memory:` `SQLite` database is **private per
+//! connection** and is destroyed the moment its *last* connection closes. So the
+//! naive "migrate on a transient connection, then build a pool" sequence loses
+//! the schema before the pool's first checkout, and every DB-backed request then
+//! 500s with "no such table". That is exactly why the framework's startup
+//! migration path *rejects* any in-memory target with registered migrations (see
+//! [`crate::migrate::reject_in_memory_migrations`] /
+//! [`crate::db::sqlite_target_is_any_in_memory`]).
+//!
+//! The substrate honours the literal "in-memory" DoD without hitting that
+//! failure by using a **named shared-cache** in-memory database
+//! (`file:<unique>?mode=memory&cache=shared`) plus a **kept-alive guard
+//! connection** held for the whole sim lifetime:
+//!
+//! 1. Open the guard connection *first*, so the shared in-memory database exists
+//!    and cannot be reclaimed.
+//! 2. Apply the caller's migration set directly through diesel's
+//!    `MigrationHarness` on that same guard connection. This deliberately
+//!    bypasses [`crate::migrate::run_pending_sqlite`]'s in-memory reject — that
+//!    reject is a *conservative* guard for the "no one is keeping the DB alive"
+//!    case, and here the guard connection is precisely what makes applying
+//!    migrations to a shared in-memory DB safe.
+//! 3. Build the async runtime pool ([`crate::db::create_pool`]) over the *same*
+//!    URL. Because the guard connection stays open, the shared in-memory database
+//!    (and the migrated schema) survives for every pooled checkout.
+//!
+//! The unique database name (a fresh UUID per substrate) guarantees two sims
+//! never share state: `SQLite` scopes a shared-cache in-memory database by its
+//! name within the process, so distinct names are fully isolated databases.
+//!
+//! Only the caller-registered migration set is applied — mirroring
+//! [`crate::migrate::auto_migrate_sqlite`], which under the `sqlite` feature also
+//! applies only the app's registered migrations. The Postgres control-plane
+//! [`crate::migrate::FRAMEWORK_MIGRATIONS`] are **not** applied here: they are
+//! Postgres DDL, and the sim's representative scheduler + job paths (below) need
+//! no DB-side control tables.
+//!
+//! # Feature-unification hazard resolution (the representative path)
+//!
+//! Under `--features sqlite` two Postgres-only orchestration backends are
+//! compiled **out**, so the sim exercises their local, in-process substitutes —
+//! which are the real, default-configured paths a single-node `SQLite` app runs:
+//!
+//! * **Scheduler** — the sim runs the **`InProcessSchedulerCoordinator`**
+//!   ([`crate::scheduler::coordinator_from_config`], the
+//!   [`SchedulerBackend::InProcess`](crate::config::SchedulerBackend::InProcess)
+//!   `#[default]`). `coordinator_from_config` *rejects*
+//!   `scheduler.backend = "postgres"` under the `sqlite` feature, because the
+//!   Postgres advisory-lock coordinator leases via `pg_advisory_lock`, which
+//!   `SQLite` has no primitive for.
+//! * **Jobs** — the sim runs the **local `JobAdminMemoryBackend`**
+//!   ([`crate::job::start_runtime`] with the `"local"` backend default);
+//!   `jobs.backend = "postgres"` is a hard-error stub under the `sqlite` feature
+//!   because `SQLite` has no `LISTEN`/`NOTIFY` + `SKIP LOCKED` durable queue.
+//!
+//! **Documented divergence** (consistent with the RFC §12 scope): a green sim
+//! proves the *orchestration, timing, and ordering* of the local scheduler + job
+//! paths. It does **not** validate the Postgres advisory-lock scheduler leasing
+//! or the durable Postgres `LISTEN`/`NOTIFY` + `SKIP LOCKED` job-queue
+//! claim/lock semantics — those are compiled out under `sqlite` and remain the
+//! province of the Postgres-backed integration tests. The sim is a determinism /
+//! orchestration harness, not a Postgres queue-semantics conformance suite.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use diesel_migrations::{EmbeddedMigrations, HarnessWithOutput, MigrationHarness};
+
+use crate::config::DatabaseConfig;
+use crate::db::RuntimeConnection;
+use crate::migrate::EmbeddedMigrationsRef;
+
+use diesel_async::pooled_connection::deadpool::Pool;
+
+/// A monotonic counter folded into each substrate's database name so that, even
+/// within a single process and a single wall-clock instant, two substrates never
+/// collide on a name (belt-and-suspenders alongside the per-substrate UUID).
+static SUBSTRATE_SEQ: AtomicU64 = AtomicU64::new(0);
+
+/// An error building the `SQLite` sim substrate.
+///
+/// Deliberately small and string-backed: the substrate is a test/sim seam, so a
+/// self-describing message is more useful to a sim author than a typed error
+/// tree, and it keeps the type free of a `diesel`/`deadpool` dependency in its
+/// public shape.
+#[derive(Debug)]
+pub enum SubstrateError {
+    /// The guard connection to the in-memory database could not be opened.
+    Connection(String),
+    /// A registered migration failed to apply.
+    Migration(String),
+    /// The async runtime pool could not be built over the substrate database.
+    Pool(String),
+}
+
+impl std::fmt::Display for SubstrateError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Connection(msg) => write!(f, "sim substrate connection error: {msg}"),
+            Self::Migration(msg) => write!(f, "sim substrate migration error: {msg}"),
+            Self::Pool(msg) => write!(f, "sim substrate pool error: {msg}"),
+        }
+    }
+}
+
+impl std::error::Error for SubstrateError {}
+
+/// Holds the kept-alive connection that anchors the shared-cache in-memory
+/// database for the substrate's lifetime.
+///
+/// `SQLite` reclaims a shared-cache in-memory database when its **last** connection
+/// closes; this guard is that last connection. It is never used for queries after
+/// migrations — it exists purely so the async pool's checkouts keep seeing the
+/// migrated schema. Dropping the [`SqliteSubstrate`] drops this guard, releasing
+/// the in-memory database.
+struct SubstrateGuard {
+    _conn: diesel::SqliteConnection,
+}
+
+/// A fresh, migrated, in-process `SQLite` database for one simulation.
+///
+/// Construct one per sim via [`SqliteSubstrate::new`] (no migrations) or
+/// [`SqliteSubstrate::with_migrations`] (apply a caller-supplied set), then hand
+/// [`SqliteSubstrate::pool`] to the app the sim builds. The substrate owns the
+/// kept-alive guard connection, so it must outlive any app that uses its pool.
+pub struct SqliteSubstrate {
+    /// The normalized `file:<unique>?mode=memory&cache=shared` URL both the guard
+    /// connection and the pool were opened against.
+    url: String,
+    /// The async runtime pool over the substrate database. Cloneable and handed
+    /// to the app the sim mounts.
+    pool: Pool<RuntimeConnection>,
+    /// Anchors the shared-cache in-memory database for the substrate's lifetime.
+    _guard: SubstrateGuard,
+}
+
+impl SqliteSubstrate {
+    /// Build a fresh, empty (un-migrated) in-memory `SQLite` substrate.
+    ///
+    /// Equivalent to [`with_migrations`](Self::with_migrations) with no migration
+    /// sets — a legitimate configuration (an app with no registered migrations),
+    /// and the cheapest substrate.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SubstrateError`] if the guard connection cannot be opened or the
+    /// pool cannot be built.
+    pub fn new() -> Result<Self, SubstrateError> {
+        Self::with_migrations(&[])
+    }
+
+    /// Build a fresh in-memory `SQLite` substrate and apply `migrations` (in order)
+    /// against it, so the returned [`pool`](Self::pool) serves a fully-migrated
+    /// schema.
+    ///
+    /// Each entry is applied through diesel's `MigrationHarness`; the kept-alive
+    /// guard connection (opened first) keeps the shared in-memory database — and
+    /// thus the applied schema — alive for every later pooled checkout. See the
+    /// module docs for why this is safe against a shared-cache in-memory target
+    /// even though the framework's own startup path rejects it.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SubstrateError::Connection`] if the guard connection cannot be
+    /// opened, [`SubstrateError::Migration`] if a migration fails, or
+    /// [`SubstrateError::Pool`] if the runtime pool cannot be built.
+    pub fn with_migrations(migrations: &[&EmbeddedMigrations]) -> Result<Self, SubstrateError> {
+        let url = unique_sim_db_url();
+
+        // 1. Open the guard connection FIRST so the shared-cache in-memory
+        //    database exists and cannot be reclaimed while we migrate + build the
+        //    pool. This connection is reused to apply the migrations and then held
+        //    for the substrate's lifetime.
+        let mut guard_conn = crate::db::establish_sqlite_migration_connection(&url)
+            .map_err(|e| SubstrateError::Connection(e.to_string()))?;
+
+        // 2. Apply each registered migration set directly via the harness. We
+        //    bypass `run_pending_sqlite` deliberately: its in-memory reject is a
+        //    conservative guard for the "no one is keeping the DB alive" case,
+        //    which does not hold here — the guard connection above is exactly what
+        //    makes migrating a shared in-memory database safe.
+        for set in migrations {
+            let mut harness = HarnessWithOutput::write_to_stdout(&mut guard_conn);
+            harness
+                .run_pending_migrations(EmbeddedMigrationsRef(set))
+                .map_err(|e| SubstrateError::Migration(e.to_string()))?;
+        }
+
+        // 3. Build the async runtime pool over the SAME shared-cache database. A
+        //    single slot keeps the sim deterministic (`SQLite` is single-writer),
+        //    and every checkout attaches to the guard-anchored in-memory DB and
+        //    sees the migrated schema.
+        let config = DatabaseConfig {
+            url: Some(url.clone()),
+            primary_pool_size: Some(1),
+            ..Default::default()
+        };
+        let pool = crate::db::create_pool(&config)
+            .map_err(|e| SubstrateError::Pool(e.to_string()))?
+            .ok_or_else(|| SubstrateError::Pool("substrate URL yielded no pool".to_owned()))?;
+
+        Ok(Self {
+            url,
+            pool,
+            _guard: SubstrateGuard { _conn: guard_conn },
+        })
+    }
+
+    /// Clone the async runtime pool over the substrate database.
+    ///
+    /// This is what the sim hands to the app it builds (via the
+    /// [`TestApp::with_db`](crate::test::TestApp::with_db) DB seam W2's
+    /// `Sim::build(TestApp)` consumes). The pool is cheap to clone (an `Arc`
+    /// internally); the substrate must outlive every clone, because dropping it
+    /// releases the kept-alive guard connection and the in-memory database with
+    /// it.
+    #[must_use]
+    pub fn pool(&self) -> Pool<RuntimeConnection> {
+        self.pool.clone()
+    }
+
+    /// The `file:<unique>?mode=memory&cache=shared` URL this substrate's database
+    /// lives at.
+    ///
+    /// Useful for wiring the same database into config-driven code paths (e.g. a
+    /// `DatabaseConfig.url`) that resolve the pool themselves rather than taking a
+    /// pre-built one.
+    #[must_use]
+    pub fn url(&self) -> &str {
+        &self.url
+    }
+}
+
+/// Mint a process-unique shared-cache in-memory `SQLite` URL for one substrate.
+///
+/// The name combines a fresh UUID with a monotonic sequence number so two
+/// substrates never collide, and `mode=memory&cache=shared` makes it an in-memory
+/// database shareable across the guard connection and the pool's connections
+/// within this process. A distinct name is a fully isolated database, which is
+/// what keeps two sims from ever sharing state.
+fn unique_sim_db_url() -> String {
+    let seq = SUBSTRATE_SEQ.fetch_add(1, Ordering::Relaxed);
+    let id = uuid::Uuid::new_v4().simple();
+    format!("file:autumn_sim_{id}_{seq}?mode=memory&cache=shared")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{SqliteSubstrate, unique_sim_db_url};
+
+    // Each minted substrate URL is unique (UUID + sequence), so two substrates
+    // are fully isolated databases — the core "two sims never share state"
+    // guarantee, verified at the URL level without opening a database.
+    #[test]
+    fn minted_urls_are_unique_and_shared_cache_in_memory() {
+        let a = unique_sim_db_url();
+        let b = unique_sim_db_url();
+        assert_ne!(a, b, "each substrate must get a distinct database name");
+        for url in [&a, &b] {
+            assert!(url.starts_with("file:autumn_sim_"), "unexpected url: {url}");
+            assert!(url.contains("mode=memory"), "must be in-memory: {url}");
+            assert!(url.contains("cache=shared"), "must be shared-cache: {url}");
+        }
+    }
+
+    // A bare substrate (no migrations) builds and hands out a live pool. This is
+    // the boot-free DB lane the sim consumes; it needs a running tokio runtime
+    // only to check the pool out, so it is a plain async test.
+    #[tokio::test]
+    async fn empty_substrate_builds_and_serves_a_pool() {
+        use diesel_async::RunQueryDsl as _;
+
+        let substrate = SqliteSubstrate::new().expect("empty substrate builds");
+        let pool = substrate.pool();
+        let mut conn = pool.get().await.expect("checkout a substrate connection");
+        // A trivial query proves the pool is live against the guard-anchored
+        // in-memory database.
+        diesel::sql_query("SELECT 1")
+            .execute(&mut *conn)
+            .await
+            .expect("substrate pool serves a query");
+    }
+}

--- a/autumn/tests/fixtures/sim_sqlite_substrate/00000000000001_create_sim_job_marks/down.sql
+++ b/autumn/tests/fixtures/sim_sqlite_substrate/00000000000001_create_sim_job_marks/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE sim_job_marks;

--- a/autumn/tests/fixtures/sim_sqlite_substrate/00000000000001_create_sim_job_marks/up.sql
+++ b/autumn/tests/fixtures/sim_sqlite_substrate/00000000000001_create_sim_job_marks/up.sql
@@ -1,0 +1,4 @@
+CREATE TABLE sim_job_marks (
+    id INTEGER PRIMARY KEY,
+    tag TEXT NOT NULL
+);

--- a/autumn/tests/sim_sqlite_substrate.rs
+++ b/autumn/tests/sim_sqlite_substrate.rs
@@ -1,0 +1,231 @@
+//! W4 Definition-of-Done proof (sim-testing, issue #1797): the job/scheduler
+//! drain runs end-to-end against an **in-process, in-memory SQLite** substrate
+//! over the *representative* local scheduler + job paths.
+//!
+//! This is the W4 "SQLite sim DB lane" acceptance test. It:
+//!
+//! 1. Builds a fresh, migrated in-memory SQLite substrate
+//!    ([`autumn_web::sim::substrate::SqliteSubstrate`]) — a shared-cache in-memory
+//!    database anchored by a kept-alive guard connection, with a registered
+//!    migration applied so the schema is live for every pooled checkout.
+//! 2. Mounts an app on it through the existing `TestApp` DB seam (the same seam
+//!    W2 will reuse when it wires the substrate into `Sim::build`).
+//! 3. Resolves the **representative scheduler path** — the in-process
+//!    coordinator — and confirms the Postgres advisory-lock scheduler is refused
+//!    under the `sqlite` feature (the feature-unification hazard resolution).
+//! 4. Enqueues a `#[job]` and drains it through the **local job runtime**
+//!    (`perform_enqueued_jobs`), whose handler writes a row into the migrated
+//!    SQLite schema — proving the drain ran end-to-end against in-process SQLite.
+//!
+//! # Divergence (documented, consistent with RFC §12)
+//!
+//! A green run proves the orchestration/timing/ordering of the **local**
+//! scheduler + job paths. It does **not** validate the Postgres advisory-lock
+//! scheduler leasing or the durable Postgres `LISTEN`/`NOTIFY` + `SKIP LOCKED`
+//! job-queue claim/lock semantics — both are compiled out under `--features
+//! sqlite` and remain the province of the Postgres integration tests. See
+//! `autumn/src/sim/substrate.rs` for the full rationale.
+//!
+//! Needs no Docker: the substrate is in-memory SQLite, so this is a fast,
+//! non-`#[ignore]`d test.
+//!
+//! A **standalone** `[[test]]` binary (not part of the consolidated
+//! `integration_tests` binary, which is Postgres-typed and does not compile under
+//! `--features sqlite`), mirroring every other `sqlite_*` integration test in
+//! this crate. It needs `test-support` for the public [`TestApp`] harness, so the
+//! file is `#![cfg(all(feature = "sqlite", feature = "test-support"))]` — a
+//! default `cargo test` compiles it to an empty (passing) binary. Run it with:
+//! `cargo test -p autumn-web --features "sqlite,test-support" --test sim_sqlite_substrate`.
+
+#![cfg(all(feature = "sqlite", feature = "test-support"))]
+
+use autumn_web::app::AppBuilder;
+use autumn_web::config::{SchedulerBackend, SchedulerConfig};
+use autumn_web::job;
+use autumn_web::migrate::{EmbeddedMigrations, embed_migrations};
+use autumn_web::plugin::Plugin;
+use autumn_web::prelude::*;
+use autumn_web::scheduler::coordinator_from_config;
+use autumn_web::sim::substrate::SqliteSubstrate;
+use autumn_web::task::TaskCoordination;
+use autumn_web::test::TestApp;
+
+use diesel_async::RunQueryDsl as _;
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+
+/// The app-registered migration set for this test: creates `sim_job_marks`.
+const MIGRATIONS: EmbeddedMigrations = embed_migrations!("tests/fixtures/sim_sqlite_substrate");
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+struct MarkArgs {
+    id: i64,
+    tag: String,
+}
+
+/// A background job whose handler writes one row into the migration-created
+/// `sim_job_marks` table on the substrate's SQLite pool. Its side effect is the
+/// row itself, so the drain is observable by querying SQLite afterwards.
+#[job(name = "sim_write_mark", max_attempts = 1, backoff_ms = 1)]
+async fn sim_write_mark(state: AppState, args: MarkArgs) -> AutumnResult<()> {
+    let pool = state
+        .pool()
+        .expect("substrate pool must be wired into AppState")
+        .clone();
+    let mut conn = pool
+        .get()
+        .await
+        .map_err(|e| AutumnError::internal_server_error(std::io::Error::other(e.to_string())))?;
+    diesel::sql_query("INSERT INTO sim_job_marks (id, tag) VALUES (?, ?)")
+        .bind::<diesel::sql_types::BigInt, _>(args.id)
+        .bind::<diesel::sql_types::Text, _>(args.tag)
+        .execute(&mut *conn)
+        .await
+        .map_err(|e| AutumnError::internal_server_error(std::io::Error::other(e.to_string())))?;
+    Ok(())
+}
+
+/// Registers the drain job.
+struct SimJobsPlugin;
+
+impl Plugin for SimJobsPlugin {
+    fn build(self, app: AppBuilder) -> AppBuilder {
+        app.jobs(jobs![sim_write_mark])
+    }
+}
+
+#[derive(diesel::QueryableByName)]
+struct MarkRow {
+    #[diesel(sql_type = diesel::sql_types::Text)]
+    tag: String,
+}
+
+/// The full W4 DoD: migrated in-memory SQLite substrate → mounted app → local
+/// scheduler resolves in-process (and rejects Postgres) → local job drain writes
+/// to the migrated SQLite schema end-to-end.
+#[tokio::test]
+async fn job_and_scheduler_drain_end_to_end_on_sqlite_substrate() {
+    // Serialize on the global-job-runtime lock (the `#[job]::enqueue` path uses
+    // the process-global client) and start from a clean client, mirroring the
+    // other global-runtime tests.
+    let _guard = job::global_job_runtime_test_lock().lock().await;
+    job::clear_global_job_client();
+
+    // (1) Fresh, migrated, in-process in-memory SQLite substrate.
+    let substrate =
+        SqliteSubstrate::with_migrations(&[&MIGRATIONS]).expect("migrated substrate builds");
+
+    // The migrated schema is live on the substrate pool before any app is mounted.
+    {
+        let pool = substrate.pool();
+        let mut conn = pool.get().await.expect("checkout substrate connection");
+        let rows: Vec<MarkRow> = diesel::sql_query("SELECT tag FROM sim_job_marks WHERE 1 = 0")
+            .load(&mut *conn)
+            .await
+            .expect("migrated `sim_job_marks` table is visible to the substrate pool");
+        assert!(rows.is_empty(), "no rows before the drain");
+    }
+
+    // (2) Mount an app on the substrate through the existing TestApp DB seam.
+    let client = TestApp::new()
+        .plugin(SimJobsPlugin)
+        .with_db(substrate.pool())
+        .build();
+
+    // (3) Representative scheduler path (feature-unification hazard resolution):
+    //     the default backend resolves to the in-process coordinator, and it
+    //     grants a fleet tick locally...
+    let coordinator = coordinator_from_config(&SchedulerConfig::default(), client.state())
+        .expect("in-process scheduler resolves under the sqlite feature");
+    assert_eq!(
+        coordinator.backend(),
+        "in_process",
+        "the sim exercises the in-process scheduler, not the Postgres advisory-lock coordinator"
+    );
+    let lease = coordinator
+        .try_acquire("sim_tick", "sim_tick:0", TaskCoordination::Fleet)
+        .await
+        .expect("in-process acquisition does not fail")
+        .expect("in-process coordinator grants the tick locally");
+    assert_eq!(lease.backend(), "in_process");
+
+    //     ...while the Postgres advisory-lock scheduler is refused under sqlite
+    //     (it leases via pg_advisory_lock, which SQLite has no primitive for).
+    let pg_config = SchedulerConfig {
+        backend: SchedulerBackend::Postgres,
+        ..SchedulerConfig::default()
+    };
+    // `Arc<dyn SchedulerCoordinator>` is not `Debug`, so match rather than
+    // `expect_err` (mirroring the scheduler coordination tests).
+    let Err(pg_err) = coordinator_from_config(&pg_config, client.state()) else {
+        panic!("the Postgres advisory-lock scheduler must be refused under the sqlite feature");
+    };
+    assert!(
+        pg_err.to_string().contains("postgres"),
+        "rejection names the postgres backend: {pg_err}"
+    );
+
+    // (4) Enqueue a job and drain it through the local job runtime; the handler
+    //     writes to the migrated SQLite schema.
+    job::enqueue("sim_write_mark", json!({ "id": 1, "tag": "drained" }))
+        .await
+        .expect("enqueue via the local job backend");
+    client.assert_job_enqueued("sim_write_mark");
+
+    let report = client.perform_enqueued_jobs().await;
+    report.assert_all_succeeded();
+    assert_eq!(report.len(), 1, "exactly the one enqueued job drained");
+
+    // The end-to-end effect: the drained job's row is present in the in-memory
+    // SQLite substrate.
+    {
+        let pool = substrate.pool();
+        let mut conn = pool.get().await.expect("checkout substrate connection");
+        let rows: Vec<MarkRow> = diesel::sql_query("SELECT tag FROM sim_job_marks ORDER BY id")
+            .load(&mut *conn)
+            .await
+            .expect("read back the drained row");
+        assert_eq!(
+            rows.iter().map(|r| r.tag.as_str()).collect::<Vec<_>>(),
+            vec!["drained"],
+            "the local job drain wrote exactly one row to the migrated SQLite schema"
+        );
+    }
+
+    job::clear_global_job_client();
+}
+
+/// Two substrates are fully isolated in-memory databases — the "two sims never
+/// share state" guarantee. A row written through one substrate's pool is never
+/// visible through the other's.
+#[tokio::test]
+async fn two_substrates_are_isolated_databases() {
+    let a = SqliteSubstrate::with_migrations(&[&MIGRATIONS]).expect("substrate A builds");
+    let b = SqliteSubstrate::with_migrations(&[&MIGRATIONS]).expect("substrate B builds");
+
+    assert_ne!(
+        a.url(),
+        b.url(),
+        "each substrate gets a distinct database name"
+    );
+
+    {
+        let pool = a.pool();
+        let mut conn = pool.get().await.expect("checkout A");
+        diesel::sql_query("INSERT INTO sim_job_marks (id, tag) VALUES (1, 'only-in-a')")
+            .execute(&mut *conn)
+            .await
+            .expect("write into A");
+    }
+
+    let pool_b = b.pool();
+    let mut conn_b = pool_b.get().await.expect("checkout B");
+    let rows: Vec<MarkRow> = diesel::sql_query("SELECT tag FROM sim_job_marks")
+        .load(&mut *conn_b)
+        .await
+        .expect("read B");
+    assert!(
+        rows.is_empty(),
+        "substrate B must not see substrate A's row — they are isolated databases"
+    );
+}

--- a/autumn/tests/sim_sqlite_substrate.rs
+++ b/autumn/tests/sim_sqlite_substrate.rs
@@ -1,10 +1,10 @@
 //! W4 Definition-of-Done proof (sim-testing, issue #1797): the job/scheduler
-//! drain runs end-to-end against an **in-process, in-memory SQLite** substrate
+//! drain runs end-to-end against an **in-process, in-memory `SQLite`** substrate
 //! over the *representative* local scheduler + job paths.
 //!
-//! This is the W4 "SQLite sim DB lane" acceptance test. It:
+//! This is the W4 "`SQLite` sim DB lane" acceptance test. It:
 //!
-//! 1. Builds a fresh, migrated in-memory SQLite substrate
+//! 1. Builds a fresh, migrated in-memory `SQLite` substrate
 //!    ([`autumn_web::sim::substrate::SqliteSubstrate`]) — a shared-cache in-memory
 //!    database anchored by a kept-alive guard connection, with a registered
 //!    migration applied so the schema is live for every pooled checkout.
@@ -15,7 +15,7 @@
 //!    under the `sqlite` feature (the feature-unification hazard resolution).
 //! 4. Enqueues a `#[job]` and drains it through the **local job runtime**
 //!    (`perform_enqueued_jobs`), whose handler writes a row into the migrated
-//!    SQLite schema — proving the drain ran end-to-end against in-process SQLite.
+//!    `SQLite` schema — proving the drain ran end-to-end against in-process `SQLite`.
 //!
 //! # Divergence (documented, consistent with RFC §12)
 //!
@@ -26,7 +26,7 @@
 //! sqlite` and remain the province of the Postgres integration tests. See
 //! `autumn/src/sim/substrate.rs` for the full rationale.
 //!
-//! Needs no Docker: the substrate is in-memory SQLite, so this is a fast,
+//! Needs no Docker: the substrate is in-memory `SQLite`, so this is a fast,
 //! non-`#[ignore]`d test.
 //!
 //! A **standalone** `[[test]]` binary (not part of the consolidated
@@ -64,8 +64,8 @@ struct MarkArgs {
 }
 
 /// A background job whose handler writes one row into the migration-created
-/// `sim_job_marks` table on the substrate's SQLite pool. Its side effect is the
-/// row itself, so the drain is observable by querying SQLite afterwards.
+/// `sim_job_marks` table on the substrate's `SQLite` pool. Its side effect is the
+/// row itself, so the drain is observable by querying `SQLite` afterwards.
 #[job(name = "sim_write_mark", max_attempts = 1, backoff_ms = 1)]
 async fn sim_write_mark(state: AppState, args: MarkArgs) -> AutumnResult<()> {
     let pool = state
@@ -100,9 +100,9 @@ struct MarkRow {
     tag: String,
 }
 
-/// The full W4 DoD: migrated in-memory SQLite substrate → mounted app → local
+/// The full W4 `DoD`: migrated in-memory `SQLite` substrate → mounted app → local
 /// scheduler resolves in-process (and rejects Postgres) → local job drain writes
-/// to the migrated SQLite schema end-to-end.
+/// to the migrated `SQLite` schema end-to-end.
 #[tokio::test]
 async fn job_and_scheduler_drain_end_to_end_on_sqlite_substrate() {
     // Serialize on the global-job-runtime lock (the `#[job]::enqueue` path uses


### PR DESCRIPTION
Wave **W4** of the sim-testing harness (issue #1797): the **SQLite sim DB lane**.

`[no-plugin]` — this change touches no plugin directory.

## Before / After

**Before.** The merged W1 skeleton gives `Sim::from_seed` a seed, RNG, virtual clock, and placeholder handles, but a sim has **no database to build an app on**. There was no per-sim substrate, and the "in-memory SQLite" path was a trap: a pure `:memory:`/`file::memory:` DB is destroyed when its last connection closes, so migrations run on a transient connection and vanish before the runtime pool anchors them ("no such table"). The framework's startup migration path *rejects* in-memory targets for exactly this reason.

**After.** A self-contained `sim::substrate::SqliteSubstrate` (gated on the `sqlite` feature) builds a **fresh, migrated, in-process in-memory SQLite pool, unique per simulation**, ready to hand to the app the sim builds. Two sims never share state, and the (W2) job/scheduler drain runs end-to-end against it over a real representative scheduler path.

## How

- **Named shared-cache in-memory + kept-alive guard.** The substrate mints a unique `file:autumn_sim__?mode=memory&cache=shared` URL, opens a **guard connection first** (so the shared in-memory DB exists and can't be reclaimed), applies the caller's migration set directly via diesel's `MigrationHarness` on that guard, then builds the async runtime pool (`db::create_pool`) over the *same* URL. Because the guard stays open for the substrate's lifetime, the migrated schema survives every pooled checkout. This deliberately bypasses `run_pending_sqlite`'s in-memory reject — that reject is a *conservative* guard for the "nobody keeps the DB alive" case, which the guard connection makes moot. A distinct database name per substrate = fully isolated databases.
- **Consumption shape (W2 seam).** The substrate hands its `RuntimeConnection` pool to a `TestApp` via `TestApp::with_db(substrate.pool())` — exactly the seam W2's `Sim::build(TestApp)` consumes. The substrate value must outlive the app (it owns the guard). It does **not** build against `AppBuilder` and adds no `AppBuilder`→`TestApp` bridge.
- **Only the caller's migrations** are applied, mirroring `auto_migrate_sqlite` (which under `sqlite` also applies only the app's registered set; the Postgres control-plane `FRAMEWORK_MIGRATIONS` are Postgres DDL and unneeded — the local scheduler/job paths need no DB-side control tables).

## Feature-unification hazard resolution

Under `--features sqlite`, two Postgres-only orchestration backends are compiled out, so the sim exercises their **real, default-configured local substitutes**:

- **Scheduler → `InProcessSchedulerCoordinator`** (`coordinator_from_config`, the `SchedulerBackend::InProcess` `#[default]`). `scheduler.backend = "postgres"` is refused under `sqlite` (the advisory-lock coordinator leases via `pg_advisory_lock`, which SQLite lacks).
- **Jobs → local `JobAdminMemoryBackend`** (`start_runtime` with the `"local"` backend default). `jobs.backend = "postgres"` is a hard-error stub under `sqlite` (no `LISTEN`/`NOTIFY` + `SKIP LOCKED` durable queue).

**Documented divergence (RFC §12 scope):** a green sim proves the *orchestration, timing, and ordering* of the local scheduler + job paths. It does **not** validate the Postgres advisory-lock scheduler leasing or the durable Postgres `LISTEN`/`NOTIFY` + `SKIP LOCKED` job-queue claim/lock semantics — those are compiled out under `sqlite` and remain the province of the Postgres integration tests. The sim is a determinism/orchestration harness, not a Postgres queue-semantics conformance suite.

## W4 DoD test

`autumn/tests/sim_sqlite_substrate.rs` (a **standalone** `[[test]]` binary, `#[cfg(all(feature = "sqlite", feature = "test-support"))]`): builds the migrated in-memory substrate → mounts an app via `TestApp::with_db(...)` → resolves the in-process scheduler and confirms the Postgres backend is refused under sqlite → enqueues a `#[job]` and drains it through the local job runtime → asserts the drained row is present in the in-memory SQLite schema. A second test asserts two substrates are isolated databases. Needs **no Docker**.

It is a standalone binary because the consolidated `integration_tests` binary is Postgres-typed and does not compile under `--features sqlite` (129 compile errors when scoped) — matching the established convention that *every* `sqlite_*` test in this crate is its own `[[test]]` binary.

## Pending W2 seam wiring

The SQLite substrate is **self-contained**. W2 published its signature mid-flight: `Sim::build` takes a `crate::test::TestApp` (not a raw `AppBuilder`), and the endorsed pattern attaches the DB to the `TestApp` *before* build. This substrate is already shaped for that: `substrate.pool()` → `TestApp::with_db(...)` → `sim.build(app)`. The actual `sim.build(app)` call will land in a **follow-up integration commit once W2 merges**; nothing here defines or pre-empts `Sim::build`. (This is a divergence from the original `AppBuilder` mount plan, now corrected to W2's real `TestApp` seam.)

## Self-review

- **Scope.** Additive only. `sim.rs` gains one feature-gated `#[doc(hidden)] pub mod substrate;` line; `tests/integration/mod.rs` is net-unchanged. No Postgres semantics modeled; no fault injection (W5), entropy/IDs (W3), clock drain (W2), or proptest sweeps (W6).
- **Visibility.** `SqliteSubstrate` is `#[doc(hidden)] pub` — unstable test/sim plumbing (mirroring this module's existing `__seed_from_env`/`__replay_line` hidden hooks), `pub` only so the standalone integration test (an external crate) can drive the DoD; the stable mount API stays W2's.
- **DB lifetime correctness.** Guard-open-before-migrate ordering is load-bearing; verified by the passing test (a table read on a *pooled* connection after the guard-applied migration) and the isolation test (a write through one substrate is invisible through another).
- **Determinism.** The pool is forced single-slot (SQLite is single-writer) for deterministic ordering; the DB name folds a UUID + a monotonic sequence so collisions are impossible even at one wall-clock instant.
- **No model identifiers** anywhere in code/comments/commit/PR.

## Verification (verbatim results)

- `cargo fmt --all -- --check` → clean (exit 0).
- `cargo build -p autumn-web --features sqlite` → `Finished` (exit 0); `cargo build -p autumn-web` (no sqlite) → `Finished` (exit 0).
- `cargo clippy -p autumn-web --features sqlite --lib -- -D warnings` → clean (exit 0) — covers the new `substrate` module.
- `cargo test -p autumn-web --features "sqlite,test-support" --test sim_sqlite_substrate` → **2 passed; 0 failed**. Lib unit tests (`--lib "sim::substrate"`) → **2 passed**.

**Pre-existing, not introduced here:** the full `--all-targets` clippy under `--features sqlite` is red on files I did not touch — `src/test.rs:280` has an `unused import: diesel_async::RunQueryDsl` that fires only in the `sqlite+test-support` combo, and `sqlite_migrations.rs` / `sqlite_searchable_repository.rs` / `sqlite_commit_hook_worker.rs` have `doc_markdown` findings. Scoped clippy on my test target reports **zero** findings referencing my files (only the pre-existing `test.rs:280`). Left untouched per scope ("don't fix unrelated issues") — flagging as a follow-up.

**Toolchain note:** the repo pins `1.97.0` via a directory override, but this environment shipped it without the `clippy`/`rustfmt` components; I installed them for `1.97.0` (`rustup component add`) and ran all gates on the pinned toolchain.

## Reviewer note

No external AI reviewer is available (Codex is dead org-wide; Gemini code-review has been sunset). This PR relies on the self-review above plus the human reviewer.

Refs #1797 (wave W4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013jifLiH8HAXm9e2C9koDcL

---
_Generated by [Claude Code](https://claude.ai/code/session_013jifLiH8HAXm9e2C9koDcL)_

---

**Known non-gating CI red:** the `Coverage` check fails on the pre-existing #1614 `mail.rs` all-features break — `DbSuppressionStore::new` hardcodes a Postgres-only pool type (`Pool` of `AsyncPgConnection`) instead of the backend-agnostic `RuntimeConnection` alias, so under the coverage lane's `--all-features` sqlite+mail unification it fails to compile with E0308. It is red on the `trunk-dev` baseline and unrelated to this PR — W4 touches nothing in `mail.rs`. `Coverage` is not a required merge gate here, so this is left as-is per the known-red list.