### PR TITLE
ci(cli): make generated-app a11y verify step an enforcing gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **sim-testing:** `#[sim_test]` macro and public `Sim` skeleton for
   deterministic simulation tests (seed-driven, replay-on-panic) (#1797). [no-plugin]
+### Changed
+
+- **cli:** the accessibility (a11y) verify step in the generated-app CI template
+  (`autumn new`) is now an **enforcing gate** — its `continue-on-error: true`
+  escape hatch has been removed, so an a11y violation now fails the job. The step
+  was shipped non-blocking in #2018 only until a pinned autumn release published
+  prebuilt CLI binaries; with v0.6.0 now published with prebuilt binaries, the
+  step runs against the release binary and blocks. Checklist item #7 of #2040.
 
 ## [0.6.0] - 2026-07-18
 

--- a/autumn-cli/src/templates/.github/workflows/ci.yml.tmpl
+++ b/autumn-cli/src/templates/.github/workflows/ci.yml.tmpl
@@ -69,11 +69,10 @@ jobs:
         run: cargo clippy --all-targets -- -D warnings
 
       # Accessibility gate: install the prebuilt `autumn` CLI matching this app's
-      # autumn-web version and scan raw html! markup for a11y violations. Non-blocking
-      # (continue-on-error) until the pinned autumn release publishes its prebuilt
-      # binaries; remove `continue-on-error` to make this an enforcing gate.
+      # autumn-web version and scan raw html! markup for a11y violations. This is an
+      # enforcing gate — it runs against the pinned autumn release's prebuilt binary,
+      # so an a11y violation fails the job.
       - name: Accessibility (a11y) verify
-        continue-on-error: true
         run: |
           curl -fsSL "https://raw.githubusercontent.com/madmax983/autumn/v{{autumn_version}}/scripts/install.sh" \
             | sh -s -- --version "v{{autumn_version}}"


### PR DESCRIPTION
## What

Flip the accessibility (a11y) verify step in the **generated-app CI template** (`autumn new`) from non-blocking to an **enforcing gate**.

**Before:** the a11y step in the generated `ci.yml` carried `continue-on-error: true`, so an a11y violation was reported but never failed the job. Its comment told the reader the step was "Non-blocking (continue-on-error) until the pinned autumn release publishes its prebuilt binaries; remove `continue-on-error` to make this an enforcing gate."

**After:** the `continue-on-error: true` line is removed, so the step now runs against the pinned release's prebuilt `autumn` binary and an a11y violation **fails the job**. The comment is reworded to describe an enforcing gate (no longer calls the step non-blocking, no longer instructs the reader to remove continue-on-error).

The step was shipped non-blocking in #2018 only because prebuilt CLI binaries did not exist before a release ≥ v0.6.0. **v0.6.0 is now published with prebuilt binaries**, so the gate can enforce.

## How

Single template file: `autumn-cli/src/templates/.github/workflows/ci.yml.tmpl`.
- Deleted the `continue-on-error: true` line under `- name: Accessibility (a11y) verify` (was ~line 76).
- Reconciled the preceding comment (~lines 71–74) to describe an enforcing gate.
- **Untouched:** the install-script `curl … raw.githubusercontent.com/.../scripts/install.sh` URL line, the step's `run:` body, and every other job.

The framework's own a11y gate (`.github/workflows/ci.yml`) is already blocking and is **not** touched (#2040 says leave it).

Also adds a `### Changed` bullet to the `CHANGELOG.md` `[Unreleased]` section.

## Testing

- `cargo test -p autumn-cli --test cli_tests ci_workflow` — 6 passed, including `ci_workflow_runs_a11y_verify` (the scaffold test asserts the step exists / installs the CLI / pins the version; it does not assert on `continue-on-error`, so no test assertion needed updating). Grepped the `autumn-cli` tree (incl. `tests/` and fixtures) — no snapshot/golden asserts `continue-on-error` for the generated `ci.yml`.
- `cargo fmt --all` — clean (no Rust source changed).
- `cargo clippy -p autumn-cli --all-targets -- -D warnings` — exit 0.
- `cargo build -p autumn-cli` — exit 0.

## Notes

- Checklist **item #7** of #2040 (0.6.0 release readiness); follow-up to a11y epic #2018.
- **Merge coordination:** this touches the same template file as open **PR #2101**, but a **different, non-overlapping line** — #2101 rewrites the install-script URL; this PR only removes `continue-on-error` on the a11y step and reconciles its comment. No content conflict, but the maintainer may want to coordinate merge order.
- `[no-plugin]` — no plugin directory touched.


---
_Generated by [Claude Code](https://claude.ai/code/session_01YZxPBfkCqLbQiWQtUi9Hps)_