### PR TITLE
sim-testing: strict_wall_clock real-time leak guard (#1797)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,7 +112,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   "no such table" when draining an app mounted on a bare substrate — this test
   therefore registers only its own app migration, with no copied framework-DDL
   fixture to drift. [no-plugin]
-
+- **sim-testing:** `Sim::strict_wall_clock()` (and `Sim::strict_wall_clock_budget(dur)`)
+  add an opt-in **real-time leak guard** (#1797): with it enabled, `Sim::advance`
+  / `Sim::run_to_idle` panic if a paused-sim step burns more than a budget of
+  *real* wall-clock time (default 100 ms; overridable per run via the
+  `AUTUMN_SIM_STRICT_WALL_CLOCK_BUDGET_MS` environment variable), catching a real
+  `std::thread::sleep` / blocking I/O / `spawn_blocking` that escaped tokio's
+  paused virtual timer. The panic flows through the `#[sim_test]` macro's
+  `catch_unwind`, so the `AUTUMN_SIM_SEED=…` replay line still prints. This is a
+  **runtime backstop for the worst off-seam pattern (a real blocking sleep), not
+  off-seam-read detection** — a free-function `Utc::now()` / `Instant::now()` has
+  no runtime interception point in safe Rust, so finding those reads stays the
+  Phase-2 deny-lint's job; the two are complementary. Off by default; the field
+  is a plain read-only `Option<Duration>` (no interior mutability), so the
+  `&self` advance/drain futures stay `Send`. [no-plugin]
 - **dev:** add `scripts/pre-push-check.sh`, a pre-push gate that mirrors CI's
   `lint` + `test` jobs (`cargo fmt --all -- --check`, `cargo clippy --workspace
   --all-targets`, a compile-only `cargo test --workspace --no-run`, and a

--- a/autumn/src/sim.rs
+++ b/autumn/src/sim.rs
@@ -118,6 +118,16 @@ pub struct Sim {
     /// Built [`crate::test::TestClient`] handle, mounted by [`Sim::build`] on
     /// the paused runtime with the virtual clock installed.
     app: SimApp,
+
+    /// Real wall-clock budget for the `strict_wall_clock` real-time leak guard,
+    /// or `None` (the default) when the guard is off. Set once via
+    /// [`strict_wall_clock`](Sim::strict_wall_clock) /
+    /// [`strict_wall_clock_budget`](Sim::strict_wall_clock_budget) *before* the
+    /// run and only **read** by [`advance`](Sim::advance) /
+    /// [`run_to_idle`](Sim::run_to_idle), so it is a plain `Option` with no
+    /// interior mutability — that keeps `Sim: Sync` and the `&self`
+    /// advance/drain futures `Send` (a `Cell`/`RefCell` field would break both).
+    strict_budget: Option<std::time::Duration>,
 }
 
 impl Sim {
@@ -139,6 +149,7 @@ impl Sim {
             clock: SimClock::new(TickingClock::starting_at(epoch)),
             chaos: Chaos::default(),
             app: SimApp::default(),
+            strict_budget: None,
         }
     }
 
@@ -226,6 +237,110 @@ impl Sim {
         self.app.try_client()
     }
 
+    /// Enable the **real-time leak guard** (`strict_wall_clock`) with the
+    /// default budget, panicking if a paused-sim step burns more than that much
+    /// *real* wall-clock time.
+    ///
+    /// # What this guards (and what it deliberately does not)
+    ///
+    /// A paused sim runs on tokio's virtual timer: a
+    /// [`tokio::time::sleep`](https://docs.rs/tokio) / job backoff / delayed
+    /// enqueue consumes **zero** real time and only advances when
+    /// [`advance`](Sim::advance) steps the clock. The one thing that breaks that
+    /// invariant is code that escapes the virtual timer and blocks the real
+    /// thread — a `std::thread::sleep`, a `spawn_blocking`, or a blocking
+    /// syscall. This guard catches the **observable consequence** of that: real
+    /// wall-clock time leaking into a step that should have taken virtually none.
+    ///
+    /// It is **not** off-seam-read detection. It cannot tell you that some code
+    /// read `Utc::now()` / `Instant::now()` directly instead of through the
+    /// injected clock — a free-function `now()` call has no runtime interception
+    /// point in safe Rust, so its *absence* is not observable at runtime. Finding
+    /// those reads is a static-analysis (deny-lint) job; this guard is the
+    /// complementary runtime backstop for the worst pattern (a real blocking
+    /// sleep). Enabling it does not slow a legitimate virtual advance: jumping a
+    /// day of virtual time still costs microseconds of real time, well under
+    /// budget.
+    ///
+    /// # Budget & the `AUTUMN_SIM_STRICT_WALL_CLOCK_BUDGET_MS` override
+    ///
+    /// The default budget is deliberately generous (100 ms) so ordinary CI
+    /// scheduling jitter never trips it — the target is a *real* sleep (seconds),
+    /// not sub-millisecond noise. Set the environment variable
+    /// `AUTUMN_SIM_STRICT_WALL_CLOCK_BUDGET_MS` (whole milliseconds) to override
+    /// the budget globally for a run; a blank or unparseable value is ignored and
+    /// the default (or the value passed to
+    /// [`strict_wall_clock_budget`](Sim::strict_wall_clock_budget)) applies. This
+    /// mirrors the `AUTUMN_SIM_SEED` idiom, so a too-tight budget on a slow
+    /// runner can be loosened without editing test code.
+    ///
+    /// The guard is read-only during the run: enable it (chainably) *before* the
+    /// first [`advance`](Sim::advance) / [`run_to_idle`](Sim::run_to_idle).
+    ///
+    /// ```rust,ignore
+    /// let mut sim = Sim::from_seed(0);
+    /// sim.strict_wall_clock();
+    /// sim.build(TestApp::new());
+    /// sim.advance(std::time::Duration::from_secs(24 * 3600)).await; // virtual, cheap
+    /// sim.run_to_idle().await;
+    /// ```
+    pub fn strict_wall_clock(&mut self) -> &mut Self {
+        self.strict_budget = Some(strict_budget_from_env_or(DEFAULT_STRICT_WALL_CLOCK_BUDGET));
+        self
+    }
+
+    /// Enable the real-time leak guard with an explicit `budget`.
+    ///
+    /// Identical to [`strict_wall_clock`](Sim::strict_wall_clock) but starts from
+    /// `budget` instead of the 100 ms default. The
+    /// `AUTUMN_SIM_STRICT_WALL_CLOCK_BUDGET_MS` environment variable still
+    /// overrides `budget` when it holds a valid whole-millisecond value (so CI
+    /// can loosen the guard globally); a blank/unparseable value leaves `budget`
+    /// in effect. See [`strict_wall_clock`](Sim::strict_wall_clock) for what the
+    /// guard does and does not catch.
+    ///
+    /// ```rust,ignore
+    /// let mut sim = Sim::from_seed(0);
+    /// sim.strict_wall_clock_budget(std::time::Duration::from_millis(5));
+    /// ```
+    pub fn strict_wall_clock_budget(&mut self, budget: std::time::Duration) -> &mut Self {
+        self.strict_budget = Some(strict_budget_from_env_or(budget));
+        self
+    }
+
+    /// Sample a real [`std::time::Instant`] at the start of a guarded step, or
+    /// `None` when the leak guard is off. Held across the step's `.await`s (an
+    /// `Instant` is `Send + Sync`, so the guarded `&self` futures stay `Send`).
+    fn wall_clock_guard_start(&self) -> Option<std::time::Instant> {
+        self.strict_budget.map(|_| std::time::Instant::now())
+    }
+
+    /// Enforce the real-time leak guard at the end of a step: panic if more than
+    /// the configured budget of *real* wall-clock time elapsed since `start`.
+    ///
+    /// A no-op when the guard is off (`start` / `strict_budget` are `None`). The
+    /// panic flows up through the [`#[sim_test]`](crate::sim_test) macro's
+    /// `catch_unwind`, so the `AUTUMN_SIM_SEED=…` replay line still prints.
+    ///
+    /// # Panics
+    ///
+    /// Panics when the leak guard is enabled and real elapsed time exceeds the
+    /// budget (see [`strict_wall_clock`](Sim::strict_wall_clock)).
+    fn enforce_wall_clock_budget(&self, start: Option<std::time::Instant>) {
+        if let (Some(budget), Some(start)) = (self.strict_budget, start) {
+            let elapsed = start.elapsed();
+            assert!(
+                elapsed <= budget,
+                "Sim::strict_wall_clock real-time leak guard tripped: {elapsed:?} of real \
+                 wall-clock time elapsed inside a paused-sim step, exceeding the {budget:?} \
+                 budget. This means real time leaked into the virtual timeline — usually a real \
+                 `std::thread::sleep`, blocking I/O, or `spawn_blocking` that escaped tokio's \
+                 paused timer. If this is CI scheduling jitter rather than a genuine leak, raise \
+                 the budget via the AUTUMN_SIM_STRICT_WALL_CLOCK_BUDGET_MS environment variable."
+            );
+        }
+    }
+
     /// Advance virtual time by `duration`, stepping the injected wall clock and
     /// tokio's paused timer wheel **together**.
     ///
@@ -240,12 +355,18 @@ impl Sim {
     /// Pair with [`run_to_idle`](Sim::run_to_idle) to then drain the work the
     /// fired timers enqueued.
     pub async fn advance(&self, duration: std::time::Duration) {
+        // Real-time leak guard (no-op unless `strict_wall_clock` is enabled):
+        // sample a REAL instant (not tokio's paused time) at entry and check the
+        // real elapsed against the budget before returning. `advance_to` routes
+        // through here, so it inherits the guard for free.
+        let guard_start = self.wall_clock_guard_start();
         // Step the framework clock first so any task woken by the tokio timer
         // that reads the clock observes the already-advanced instant.
         self.clock.advance(duration);
         // Advance tokio's paused timer wheel; this fires due timers and yields
         // so their tasks are polled before returning.
         tokio::time::advance(duration).await;
+        self.enforce_wall_clock_budget(guard_start);
     }
 
     /// Advance virtual time **to** a specific zoned instant, resolving the
@@ -400,6 +521,11 @@ impl Sim {
     /// [`advance`](Sim::advance) to the next interesting instant, then
     /// `run_to_idle` to settle the work it released.
     pub async fn run_to_idle(&self) {
+        // Real-time leak guard (no-op unless `strict_wall_clock` is enabled):
+        // sample a REAL instant at entry and enforce the budget before
+        // returning, catching a real blocking sleep in a drained task.
+        let guard_start = self.wall_clock_guard_start();
+
         // Resolve the mounted app's DB pool once (a cheap, cloned Arc-backed
         // handle). Durable repository commit hooks are rows, so there is
         // nothing to drain when the app was built without a database (e.g. the
@@ -438,6 +564,8 @@ impl Sim {
                     crate::test::drain_ready_repository_commit_hooks(pool, MAX_DRAIN_STEPS).await;
             }
         }
+
+        self.enforce_wall_clock_budget(guard_start);
     }
 }
 
@@ -446,6 +574,45 @@ impl Sim {
 /// Generous relative to the handful of hops a job takes from the queue through
 /// its handler to completion under the single-threaded paused runtime.
 const MAX_DRAIN_STEPS: usize = 1024;
+
+/// Default real wall-clock budget for the `strict_wall_clock` leak guard
+/// ([`Sim::strict_wall_clock`]).
+///
+/// Deliberately generous (100 ms): the guard exists to catch a *real* blocking
+/// sleep escaping the virtual timer (seconds of wall time), so the budget must
+/// sit far above ordinary current-thread scheduling jitter to avoid false
+/// positives on a slow/contended CI runner. A legitimate virtual advance — even
+/// jumping a day of virtual time — costs microseconds of real time, orders of
+/// magnitude under this.
+const DEFAULT_STRICT_WALL_CLOCK_BUDGET: std::time::Duration = std::time::Duration::from_millis(100);
+
+/// Resolve the effective `strict_wall_clock` budget: the
+/// `AUTUMN_SIM_STRICT_WALL_CLOCK_BUDGET_MS` environment override when it holds a
+/// valid whole-millisecond value, otherwise `default`.
+///
+/// Mirrors the [`__seed_from_env`] / [`parse_seed`] idiom so a too-tight budget
+/// on a slow runner can be loosened globally without editing test code; a blank
+/// or unparseable value falls back to `default`.
+fn strict_budget_from_env_or(default: std::time::Duration) -> std::time::Duration {
+    std::env::var("AUTUMN_SIM_STRICT_WALL_CLOCK_BUDGET_MS")
+        .ok()
+        .and_then(|raw| parse_strict_budget_ms(&raw))
+        .unwrap_or(default)
+}
+
+/// Parse a whole-millisecond budget string into a [`std::time::Duration`],
+/// returning `None` for empty/whitespace-only or unparseable input (so the
+/// caller can fall back to the configured default).
+fn parse_strict_budget_ms(raw: &str) -> Option<std::time::Duration> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    trimmed
+        .parse::<u64>()
+        .ok()
+        .map(std::time::Duration::from_millis)
+}
 
 /// The forward-only step [`Sim::advance_to`] resolves a target instant into.
 ///
@@ -718,7 +885,8 @@ pub fn __replay_line(seed: u64, pkg: &str, test: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::{
-        __replay_line, AdvancePlan, Sim, parse_seed, plan_advance_to, resolve_local_to_utc,
+        __replay_line, AdvancePlan, DEFAULT_STRICT_WALL_CLOCK_BUDGET, Sim, parse_seed,
+        parse_strict_budget_ms, plan_advance_to, resolve_local_to_utc, strict_budget_from_env_or,
     };
     use chrono::{NaiveDate, TimeZone, Utc};
     use rand::RngCore;
@@ -792,6 +960,53 @@ mod tests {
         let now = Utc.with_ymd_and_hms(2020, 1, 1, 1, 0, 0).unwrap();
         let target = Utc.with_ymd_and_hms(2020, 1, 1, 0, 0, 0).unwrap();
         let _ = plan_advance_to(now, target);
+    }
+
+    #[test]
+    fn parse_strict_budget_ms_covers_valid_and_garbage() {
+        use std::time::Duration;
+        assert_eq!(
+            parse_strict_budget_ms("100"),
+            Some(Duration::from_millis(100))
+        );
+        assert_eq!(
+            parse_strict_budget_ms("  250  "),
+            Some(Duration::from_millis(250))
+        );
+        assert_eq!(parse_strict_budget_ms("0"), Some(Duration::ZERO));
+        assert_eq!(parse_strict_budget_ms(""), None);
+        assert_eq!(parse_strict_budget_ms("   "), None);
+        assert_eq!(parse_strict_budget_ms("garbage"), None);
+        assert_eq!(parse_strict_budget_ms("-5"), None);
+        assert_eq!(parse_strict_budget_ms("1.5"), None);
+    }
+
+    #[test]
+    fn strict_budget_from_env_falls_back_to_default_when_unset() {
+        // The env var is not set in this unit-test process, so the default is
+        // returned verbatim (the override path is exercised via the public
+        // integration tests, which never set the var).
+        let default = std::time::Duration::from_millis(7);
+        assert_eq!(strict_budget_from_env_or(default), default);
+        assert_eq!(
+            strict_budget_from_env_or(DEFAULT_STRICT_WALL_CLOCK_BUDGET),
+            DEFAULT_STRICT_WALL_CLOCK_BUDGET
+        );
+    }
+
+    #[test]
+    fn strict_wall_clock_builders_set_the_budget() {
+        let mut sim = Sim::from_seed(0);
+        assert!(sim.strict_budget.is_none(), "guard is off by default");
+        sim.strict_wall_clock();
+        assert_eq!(sim.strict_budget, Some(DEFAULT_STRICT_WALL_CLOCK_BUDGET));
+
+        let mut custom = Sim::from_seed(0);
+        custom.strict_wall_clock_budget(std::time::Duration::from_millis(5));
+        assert_eq!(
+            custom.strict_budget,
+            Some(std::time::Duration::from_millis(5))
+        );
     }
 
     #[test]

--- a/autumn/tests/integration/mod.rs
+++ b/autumn/tests/integration/mod.rs
@@ -207,6 +207,7 @@ mod sim_advance_to;
 mod sim_clock_drain;
 mod sim_deterministic_ids;
 mod sim_rate_limit_clock;
+mod sim_strict_wall_clock;
 mod sim_test_smoke;
 #[cfg(feature = "ws")]
 mod sse_replay;

--- a/autumn/tests/integration/sim_strict_wall_clock.rs
+++ b/autumn/tests/integration/sim_strict_wall_clock.rs
@@ -1,0 +1,136 @@
+//! Sim-testing `Sim::strict_wall_clock` **real-time leak guard** (issue #1797,
+//! follow-on to W2's `advance` / `run_to_idle` and the `advance_to` DST work).
+//!
+//! The guard catches the observable consequence of the worst off-seam pattern:
+//! **real wall-clock time leaking into a paused sim** — a real
+//! `std::thread::sleep` / blocking call that escapes tokio's virtual timer. It
+//! is deliberately *not* off-seam-read detection (a free-function `Utc::now()` /
+//! `Instant::now()` has no runtime interception point in safe Rust; catching
+//! those reads is the Phase-2 deny-lint's job). These tests pin the three
+//! behaviours that matter: a clean virtual run passes even when it jumps a full
+//! day of virtual time, a genuine real-time leak trips the guard with an
+//! actionable panic, and the guard is off unless explicitly enabled.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::{Duration, Instant};
+
+use autumn_web::prelude::*;
+use autumn_web::sim::Sim;
+use autumn_web::sim_test;
+use autumn_web::test::TestApp;
+use autumn_web::time::Clock;
+use chrono::{TimeZone, Utc};
+use futures::FutureExt as _;
+use std::panic::AssertUnwindSafe;
+
+/// Reads the injected (virtual) wall clock so the clean-run test can prove the
+/// clock advanced a full day in virtual time.
+#[get("/now")]
+async fn now_route(clock: Clock) -> String {
+    clock.now().to_rfc3339()
+}
+
+/// A clean virtual run with the guard **on** does not trip it: advancing a full
+/// day of virtual time and draining costs microseconds of *real* time, far under
+/// the budget — even though virtual time jumped 24 hours.
+#[sim_test]
+async fn strict_wall_clock_passes_on_clean_virtual_run(mut sim: Sim) {
+    sim.strict_wall_clock();
+    sim.build(TestApp::new().routes(routes![now_route]));
+
+    let wall_start = Instant::now();
+
+    // Jump a full day of virtual time, then drain — no real sleeping anywhere.
+    sim.advance(Duration::from_secs(24 * 3600)).await;
+    sim.run_to_idle().await;
+
+    // The injected clock advanced exactly 24h (epoch + 1 day)...
+    let after = sim.client().get("/now").send().await;
+    after.assert_ok();
+    assert_eq!(
+        after.text(),
+        Utc.with_ymd_and_hms(2020, 1, 2, 0, 0, 0)
+            .unwrap()
+            .to_rfc3339(),
+        "the virtual clock must have advanced a full day"
+    );
+
+    // ...in essentially zero real time, so the leak guard never trips.
+    let wall_elapsed = wall_start.elapsed();
+    assert!(
+        wall_elapsed < Duration::from_millis(100),
+        "a clean virtual advance must stay well under the leak-guard budget, but {wall_elapsed:?} elapsed"
+    );
+}
+
+/// With the guard **on** and a small budget, a real `std::thread::sleep` that
+/// escapes the virtual timer (running inside a drained task) trips the guard:
+/// `run_to_idle` panics, and the message names the elapsed, the budget, and the
+/// `AUTUMN_SIM_STRICT_WALL_CLOCK_BUDGET_MS` override.
+///
+/// Written as a plain paused-runtime test (not `#[sim_test]`) so the panic can be
+/// caught and its message asserted, rather than failing the test.
+#[tokio::test(start_paused = true)]
+async fn strict_wall_clock_fires_on_real_leak() {
+    let mut sim = Sim::from_seed(0);
+    // A tiny budget: the real 120ms sleep below is well over it, while ordinary
+    // scheduling jitter is well under it.
+    sim.strict_wall_clock_budget(Duration::from_millis(10));
+
+    // A real thread sleep escapes tokio's paused virtual timer, burning genuine
+    // wall-clock time when the task is polled during the drain.
+    tokio::spawn(async {
+        std::thread::sleep(Duration::from_millis(120));
+    });
+
+    let outcome = AssertUnwindSafe(sim.run_to_idle()).catch_unwind().await;
+    let payload = outcome.expect_err("run_to_idle must panic when real time leaks into the sim");
+
+    let message = payload
+        .downcast_ref::<String>()
+        .map(String::as_str)
+        .or_else(|| payload.downcast_ref::<&str>().copied())
+        .unwrap_or("");
+
+    assert!(
+        message.contains("strict_wall_clock"),
+        "panic must name the guard: {message}"
+    );
+    assert!(
+        message.contains("budget"),
+        "panic must mention the budget: {message}"
+    );
+    assert!(
+        message.contains("120") || message.contains("ms"),
+        "panic must report the real elapsed time: {message}"
+    );
+    assert!(
+        message.contains("AUTUMN_SIM_STRICT_WALL_CLOCK_BUDGET_MS"),
+        "panic must name the override env var: {message}"
+    );
+}
+
+/// The guard is **off by default**: without a `strict_wall_clock*` call the same
+/// real `std::thread::sleep` inside the drained region does not panic — the drain
+/// completes normally (proving the guard is opt-in, not always-on).
+#[sim_test]
+async fn strict_wall_clock_off_by_default_does_not_panic(sim: Sim) {
+    let ran = Arc::new(AtomicBool::new(false));
+    let ran_task = Arc::clone(&ran);
+
+    // Same real leak as the firing test — but with the guard never enabled, it is
+    // tolerated (the drain just burns the real time and returns).
+    tokio::spawn(async move {
+        std::thread::sleep(Duration::from_millis(120));
+        ran_task.store(true, Ordering::SeqCst);
+    });
+
+    // No panic here despite the real sleep, because the guard is off.
+    sim.run_to_idle().await;
+
+    assert!(
+        ran.load(Ordering::SeqCst),
+        "the real-sleep task should have been drained without tripping any guard"
+    );
+}


### PR DESCRIPTION
## What & why

Adds an **opt-in real-time leak guard** to the sim-testing `Sim` handle (issue #1797).

**Before:** a paused sim runs entirely on tokio's virtual timer. If some code escapes that timer and blocks the real thread — a `std::thread::sleep`, a `spawn_blocking`, a blocking syscall — nothing notices; the test just runs slower than it should, silently, with real wall-clock time leaking into the virtual timeline.

**After:** a test can call `sim.strict_wall_clock()` (or `sim.strict_wall_clock_budget(dur)`) before running. With it enabled, `Sim::advance` / `Sim::run_to_idle` sample a **real** `Instant` at entry and **panic** if the step burned more than a budget of *real* wall-clock time — naming the elapsed, the budget, and the override env var. A clean virtual run (even jumping a full day of virtual time) stays microseconds under budget and passes; a genuine real leak trips loudly. The panic flows through the `#[sim_test]` macro's `catch_unwind`, so the `AUTUMN_SIM_SEED=…` replay line still prints.

## API

```rust
pub fn strict_wall_clock(&mut self) -> &mut Self;                        // default 100ms budget
pub fn strict_wall_clock_budget(&mut self, budget: Duration) -> &mut Self;
```

- **Default budget:** 100 ms — deliberately generous so ordinary current-thread scheduling jitter on a slow/contended CI runner never trips it; the target is a *real* sleep (seconds), not sub-millisecond noise.
- **Env override:** `AUTUMN_SIM_STRICT_WALL_CLOCK_BUDGET_MS` (whole ms) overrides the budget for a run so a too-tight budget can be loosened without editing tests; blank/unparseable falls back to the default (mirrors the `AUTUMN_SIM_SEED` parse idiom).
- **Off by default.** The field is a plain read-only `Option<Duration>` — **no `Cell`/`RefCell`/interior mutability** — set via the builder before the run and only *read* in the guard, so `Sim` stays `Sync` and the `&self` `advance`/`run_to_idle` futures stay `Send` (a `Cell` field would fail the `-D`-enforced `clippy::future_not_send`). One guard home: `advance_to` routes through `advance`, so it inherits the guard for free.

## Delta from the ratified wording (read this)

The originally-ratified line was *"test fails if anything reads `Utc::now()` off-seam."* That is **impossible to enforce at runtime**: a free-function `chrono::Utc::now()` / `std::time::Instant::now()` call has no interception point in safe Rust (there are ~115 `Utc::now()` + ~110 `Instant::now()` off-seam call sites today, and detecting the *absence* of such reads is not observable at runtime). Catching those reads is the **Phase-2 deny-lint's** job (static analysis), not this.

What this PR ships instead is a runtime guard for the **observable consequence of the worst off-seam pattern**: real wall-clock time leaking into a paused sim because a real `thread::sleep` / `spawn_blocking` / blocking I/O escaped the virtual timer. Per the maintainer's riders it is **named for what it does** — `strict_wall_clock`, documented as a *real-time leak guard*, **not** "strict no-real-time mode" and **not** off-seam-read detection. It is **complementary** to the Phase-2 deny-lint (which owns read-detection), not a substitute for it.

Related: this leaves the job.rs off-seam-timestamp gap (#2111) unaddressed by design — that read-detection concern is the deny-lint's, tracked separately.

## Tests

New consolidated module `autumn/tests/integration/sim_strict_wall_clock.rs`:
- **Passes on a clean virtual run** — guard on, `advance(24h)` + `run_to_idle()` with no real sleep → no panic, virtual clock advanced a full day, real time ≪ budget.
- **Fires on a real leak** — guard on with a small budget, a real `std::thread::sleep` inside a drained task → `run_to_idle` panics, and the message mentions the guard/budget/elapsed/`AUTUMN_SIM_STRICT_WALL_CLOCK_BUDGET_MS` (asserted via `futures` `catch_unwind`).
- **Off by default** — no `strict_wall_clock()` call, same real sleep → no panic.

Plus `src/sim.rs` unit tests for the env parse (`parse_strict_budget_ms`), the env-fallback resolver, and the builder wiring. The existing W2 (`backoff_job_fires_in_virtual_time_with_zero_wall_sleep`, `empty_sim_test_runs_at_seed_zero`) and `advance_to` tests stay green.

## Stacking

This **stacks on #2112** (`Sim::advance_to`), which **stacks on #2104**. Base is `sim-clock-advance-to`. Retarget the base down the stack as each merges (→ `sim-clock-advance-to`'s base, then eventually the default branch).

## Gates run locally (all green)

`cargo build -p autumn-web`; targeted `integration_tests` (new + W2 + advance_to) and `src/sim.rs` unit tests; `cargo +stable fmt --all -- --check` (1.97.0 pin lacks rustfmt — pin unchanged); `cargo clippy -p autumn-web --all-targets --features test-support -- -D warnings` **and** without `--features test-support` (both, watching `future_not_send`); the `scripts/check-docs.sh` docs-posture `cargo doc` with `-D rustdoc::broken_intra_doc_links -D rustdoc::private_intra_doc_links` (exit 0). CHANGELOG `[Unreleased] → Added` bullet carries `[no-plugin]`.

## Review notes

Self-reviewed; no external-AI reviewer requested. Coverage (#1614) is the only expected non-gating red.


---
_Generated by [Claude Code](https://claude.ai/code/session_01SnvJMDdVamJk9N3rvZZrRm)_