### PR TITLE
docs: one-time submit tokens guide + saas example usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **docs:** a `docs/guide/submit-tokens.md` guide for one-time submit tokens
+  (at-most-once form submissions) — the double-submit / duplicate-POST problem,
+  how the default-on `SubmitTokenLayer` + hidden `_submit_token` field +
+  `SubmitToken` extractor close it with no client JS, how it differs from CSRF
+  and `Idempotency-Key`, and the `[security.submit_token]` config knobs. The
+  `saas` example now guards its signup POST with a one-time submit token so a
+  double-clicked signup cannot create a duplicate account. [no-plugin]
 - **test-support:** `autumn_web::test::drain_ready_repository_commit_hooks(pool, max_rows)`
   deterministically claims and runs ready durable repository commit hooks in
   integration tests — driving the real worker→drain wiring without starting the

--- a/autumn-cli/src/starters/saas/README.md
+++ b/autumn-cli/src/starters/saas/README.md
@@ -10,6 +10,7 @@ dashboard that only ever shows your own organisation's data.
 | Piece | Primitive |
 |-------|-----------|
 | Signup / login / logout | `Session` + `hash_password`/`verify_password` (bcrypt) |
+| At-most-once signup | one-time `SubmitToken` in a hidden `_submit_token` field |
 | Tenant per organisation | `tenant_id` stored in the session at signup/login |
 | Row-level isolation | `#[repository(Project, tenant_scoped)]` + `with_tenant` |
 | Server-rendered UI | Maud templates + htmx + Tailwind |

--- a/autumn-cli/src/starters/saas/src/routes/auth.rs
+++ b/autumn-cli/src/starters/saas/src/routes/auth.rs
@@ -9,6 +9,7 @@ use autumn_web::auth::{hash_password, validate_password, verify_password};
 use autumn_web::prelude::*;
 use autumn_web::reexports::axum::http::{HeaderMap, HeaderValue, header::SET_COOKIE};
 use autumn_web::reexports::axum::response::Response;
+use autumn_web::security::SubmitToken;
 use diesel::prelude::*;
 use diesel_async::RunQueryDsl;
 use serde::Deserialize;
@@ -43,7 +44,14 @@ const DUMMY_HASH: &str = "$2b$12$Ro0CUfOqk6cXEKf3dyaM7OhSCvnwM9s1Aw6lfLP2.GvpAfN
 /// Render the signup form, optionally with a validation error. The minimum
 /// length reflects the active `[auth.password]` policy so the `minlength`
 /// attribute always matches what the handler enforces.
-fn signup_page(min_len: usize, error: Option<&str>) -> Markup {
+///
+/// `submit_token` is a fresh one-time token embedded as a hidden
+/// `_submit_token` field. The framework's `SubmitTokenLayer` consumes it on the
+/// POST so a double-clicked or browser-retried signup runs exactly once and
+/// cannot create a duplicate account — no client-side JavaScript involved. A
+/// new token is minted on every render (including this error re-render), so the
+/// corrected resubmit carries a fresh token rather than a spent one.
+fn signup_page(min_len: usize, submit_token: &str, error: Option<&str>) -> Markup {
     layout(
         "Sign up",
         false,
@@ -53,6 +61,7 @@ fn signup_page(min_len: usize, error: Option<&str>) -> Markup {
                 p class="mb-4 text-sm text-red-600" role="alert" { (error) }
             }
             form action="/signup" method="post" class="space-y-4 bg-white rounded-lg shadow p-6 max-w-md" {
+                input type="hidden" name="_submit_token" value=(submit_token);
                 div {
                     label for="email" class="block text-sm font-medium mb-1" { "Email" }
                     input #email type="email" name="email" required autocomplete="email"
@@ -76,14 +85,22 @@ fn signup_page(min_len: usize, error: Option<&str>) -> Markup {
 }
 
 #[get("/signup")]
-pub async fn signup_form(State(state): State<AppState>) -> Markup {
-    signup_page(state.config().auth.password.min_length, None)
+pub async fn signup_form(State(state): State<AppState>, submit_token: SubmitToken) -> Markup {
+    signup_page(
+        state.config().auth.password.min_length,
+        submit_token.token(),
+        None,
+    )
 }
 
 #[post("/signup")]
 pub async fn signup(
     State(state): State<AppState>,
     session: Session,
+    // A fresh token for the error re-render below; the token that guarded THIS
+    // request has already been consumed by `SubmitTokenLayer` before the handler
+    // ran, so the re-rendered form must carry a new one.
+    submit_token: SubmitToken,
     mut db: Db,
     Form(form): Form<SignupForm>,
 ) -> AutumnResult<Response> {
@@ -121,7 +138,12 @@ pub async fn signup(
         } else {
             messages.join("\n")
         };
-        return Ok(signup_page(password_cfg.min_length, Some(&message)).into_response());
+        return Ok(signup_page(
+            password_cfg.min_length,
+            submit_token.token(),
+            Some(&message),
+        )
+        .into_response());
     }
 
     // Each account gets its own isolated tenant; email is the unique identifier

--- a/docs/guide/submit-tokens.md
+++ b/docs/guide/submit-tokens.md
@@ -1,0 +1,159 @@
+# One-Time Submit Tokens
+
+A one-time submit token gives a plain HTML form an **at-most-once** guarantee:
+the mutating request behind it runs exactly once, no matter how many times the
+browser sends it. A user who double-clicks **Submit**, hits Back and resubmits,
+or whose browser silently retries a flaky POST cannot create a duplicate record.
+It is server-side, default-on, and needs **no client-side JavaScript**.
+
+The whole feature is one hidden form field plus a Tower layer that the framework
+applies for you.
+
+---
+
+## The problem
+
+The classic double-submit hole is not closed by the two primitives that sit next
+to it:
+
+- **CSRF tokens** mint a *stable, per-session* value. A valid `_csrf` token
+  submitted twice passes both times — CSRF stops a forged request, not a
+  duplicate one.
+- **Idempotency keys** ([`idempotency.md`](idempotency.md)) are *header-driven*
+  on `Idempotency-Key`. API clients send that header; a browser submitting a
+  bare `<form>` never does.
+
+So a create form with only CSRF protection still lets a double-click insert two
+rows. A `UNIQUE` constraint may catch some of those, but many mutations (post a
+comment, charge a card, send an invite) have no natural uniqueness key.
+
+Submit tokens close the gap: a fresh, single-use token is minted per render,
+embedded in the form, and consumed against a shared idempotency store on the
+POST. The first use runs the handler and records its response; a replayed token
+short-circuits and replays that first response instead of re-running anything.
+
+---
+
+## Quick start
+
+Submit-token protection is **on by default** — the framework installs
+[`SubmitTokenLayer`] whenever `security.submit_token.enabled = true` (the
+default). You do not construct the layer yourself. Two steps opt an individual
+form in:
+
+1. Take the [`SubmitToken`] extractor in the handler that renders the form and
+   emit its value in a hidden `_submit_token` field.
+2. Do nothing else — the layer consumes that field on the matching POST.
+
+```rust,ignore
+use autumn_web::prelude::*;
+use autumn_web::security::SubmitToken;
+
+#[get("/form")]
+async fn form(submit_token: SubmitToken) -> Markup {
+    html! {
+        form method="POST" action="/submit" {
+            input type="hidden" name="_submit_token" value=(submit_token.token());
+            input type="text" name="title";
+            button { "Submit" }
+        }
+    }
+}
+
+#[post("/submit")]
+async fn submit(Form(form): Form<CreateForm>) -> AutumnResult<Redirect> {
+    // Runs exactly once per rendered token. A double-click replays the redirect
+    // below instead of inserting a second row.
+    create_record(form).await?;
+    Ok(Redirect::to("/thanks"))
+}
+```
+
+The POST handler needs no submit-token parameter and no special return type: the
+layer guards the request *before* it reaches the handler, so the handler stays a
+plain create action. Because serde ignores unknown fields by default, the extra
+`_submit_token` value on the form body is simply not part of your `CreateForm`
+struct.
+
+---
+
+## How it works
+
+`SubmitTokenLayer` wraps every request:
+
+1. **Mint.** On *every* request (the GET that renders the form and the re-render
+   after a rejected POST alike) the layer generates a fresh random token and
+   places it in request extensions. The [`SubmitToken`] extractor reads it back.
+2. **Scan.** On a mutating request (`POST`/`PUT`/`PATCH`/`DELETE`) the layer
+   scans the form body for the configured field (`_submit_token`). A request
+   with no such field passes straight through unchanged, so only forms that
+   embed the field are guarded.
+3. **Consume.** The token is looked up in the shared idempotency store:
+   - **First use** — the layer takes an in-flight lock, runs the handler, and
+     records the response (2xx/3xx) under the token before releasing the lock.
+   - **Replayed token** — the stored first response is returned verbatim, tagged
+     with an `x-submit-token-replayed` header. The handler never runs again.
+   - **Concurrent duplicate** — a second request racing the first loses the lock
+     and gets a `409 Conflict` rather than re-running the mutation.
+
+Because the token is a per-render random UUID it is globally unique and needs no
+method, path, or principal scoping — the token *is* the identity of the single
+logical submission.
+
+### Where the state lives
+
+Consumed tokens are stored in the same backend as
+[idempotency keys](idempotency.md). By default the submit-token store **inherits
+`[idempotency].backend`**: in-memory in development, Redis in production. That
+inheritance matters for horizontal scaling — with a shared Redis store a
+double-click that load-balances to a *different* replica still sees the token as
+consumed and replays the first response, so the mutation cannot run twice across
+your fleet.
+
+---
+
+## Configuration
+
+All keys live under `[security.submit_token]` and have working defaults:
+
+```toml
+[security.submit_token]
+enabled = true          # default; installs the layer
+field_name = "_submit_token"
+ttl_secs = 600          # replay window for a consumed token's response (10 min)
+in_flight_ttl_secs = 86400  # safety expiry for an in-flight lock (24 h)
+# backend inherits [idempotency].backend when unset
+# backend = "redis"     # override for submit tokens only
+exempt_paths = []       # path prefixes skipped by the guard
+```
+
+| Key | Default | Meaning |
+|-----|---------|---------|
+| `enabled` | `true` | Install the layer at all. |
+| `field_name` | `"_submit_token"` | Hidden field the guard reads. |
+| `ttl_secs` | `600` | How long a consumed token replays its first response. |
+| `in_flight_ttl_secs` | `86400` | Safety expiry for the in-flight lock; independent of `ttl_secs` so lowering the replay window can never shorten how long an active submission is excluded from re-entry. |
+| `backend` | inherits `[idempotency].backend` | Store for consumed tokens. |
+| `exempt_paths` | `[]` | Path prefixes the guard skips. |
+
+If you customise `field_name`, read the resolved name from the
+[`SubmitFormField`] extractor rather than hard-coding it, so the hidden input's
+`name` always matches what the guard scans for.
+
+> **Production note.** An explicit `[security.submit_token].backend = "memory"`
+> in production fails startup fast — an in-memory store is per-process and cannot
+> protect a multi-replica deployment. Leave `backend` unset (to inherit Redis) or
+> set it explicitly to `"redis"`.
+
+---
+
+## Related
+
+- [Idempotency keys](idempotency.md) — the header-driven sibling for API
+  clients, and the store submit tokens reuse.
+- Nested `has_many` forms (`nested_form`) already integrate submit tokens via
+  `NestedChangesetForm::with_submit_token`, so a master-detail form inherits the
+  same at-most-once guarantee.
+
+See the **saas** example (`examples/saas/src/routes/auth.rs`) for a real
+signup form guarded by a one-time submit token.

--- a/examples/saas/README.md
+++ b/examples/saas/README.md
@@ -10,6 +10,7 @@ dashboard that only ever shows your own organisation's data.
 | Piece | Primitive |
 |-------|-----------|
 | Signup / login / logout | `Session` + `hash_password`/`verify_password` (bcrypt) |
+| At-most-once signup | one-time `SubmitToken` in a hidden `_submit_token` field |
 | Tenant per organisation | `tenant_id` stored in the session at signup/login |
 | Row-level isolation | `#[repository(Project, tenant_scoped)]` + `with_tenant` |
 | Server-rendered UI | Maud templates + htmx + Tailwind |

--- a/examples/saas/src/routes/auth.rs
+++ b/examples/saas/src/routes/auth.rs
@@ -9,6 +9,7 @@ use autumn_web::auth::{hash_password, validate_password, verify_password};
 use autumn_web::prelude::*;
 use autumn_web::reexports::axum::http::{HeaderMap, HeaderValue, header::SET_COOKIE};
 use autumn_web::reexports::axum::response::Response;
+use autumn_web::security::SubmitToken;
 use diesel::prelude::*;
 use diesel_async::RunQueryDsl;
 use serde::Deserialize;
@@ -43,7 +44,14 @@ const DUMMY_HASH: &str = "$2b$12$Ro0CUfOqk6cXEKf3dyaM7OhSCvnwM9s1Aw6lfLP2.GvpAfN
 /// Render the signup form, optionally with a validation error. The minimum
 /// length reflects the active `[auth.password]` policy so the `minlength`
 /// attribute always matches what the handler enforces.
-fn signup_page(min_len: usize, error: Option<&str>) -> Markup {
+///
+/// `submit_token` is a fresh one-time token embedded as a hidden
+/// `_submit_token` field. The framework's `SubmitTokenLayer` consumes it on the
+/// POST so a double-clicked or browser-retried signup runs exactly once and
+/// cannot create a duplicate account — no client-side JavaScript involved. A
+/// new token is minted on every render (including this error re-render), so the
+/// corrected resubmit carries a fresh token rather than a spent one.
+fn signup_page(min_len: usize, submit_token: &str, error: Option<&str>) -> Markup {
     layout(
         "Sign up",
         false,
@@ -53,6 +61,7 @@ fn signup_page(min_len: usize, error: Option<&str>) -> Markup {
                 p class="mb-4 text-sm text-red-600" role="alert" { (error) }
             }
             form action="/signup" method="post" class="space-y-4 bg-white rounded-lg shadow p-6 max-w-md" {
+                input type="hidden" name="_submit_token" value=(submit_token);
                 div {
                     label for="email" class="block text-sm font-medium mb-1" { "Email" }
                     input #email type="email" name="email" required autocomplete="email"
@@ -76,14 +85,22 @@ fn signup_page(min_len: usize, error: Option<&str>) -> Markup {
 }
 
 #[get("/signup")]
-pub async fn signup_form(State(state): State<AppState>) -> Markup {
-    signup_page(state.config().auth.password.min_length, None)
+pub async fn signup_form(State(state): State<AppState>, submit_token: SubmitToken) -> Markup {
+    signup_page(
+        state.config().auth.password.min_length,
+        submit_token.token(),
+        None,
+    )
 }
 
 #[post("/signup")]
 pub async fn signup(
     State(state): State<AppState>,
     session: Session,
+    // A fresh token for the error re-render below; the token that guarded THIS
+    // request has already been consumed by `SubmitTokenLayer` before the handler
+    // ran, so the re-rendered form must carry a new one.
+    submit_token: SubmitToken,
     mut db: Db,
     Form(form): Form<SignupForm>,
 ) -> AutumnResult<Response> {
@@ -121,7 +138,12 @@ pub async fn signup(
         } else {
             messages.join("\n")
         };
-        return Ok(signup_page(password_cfg.min_length, Some(&message)).into_response());
+        return Ok(signup_page(
+            password_cfg.min_length,
+            submit_token.token(),
+            Some(&message),
+        )
+        .into_response());
     }
 
     // Each account gets its own isolated tenant; email is the unique identifier


### PR DESCRIPTION
Closes Gap 4 of #2099 (one-time submit tokens / at-most-once form submission).

## Before / After

**Before:** one-time submit tokens had no guide and no example usage — the feature (`autumn/src/security/submit_token.rs`) was rustdoc-only.

**After:** `docs/guide/submit-tokens.md` explains the feature end to end, and the `saas` example's signup POST is guarded by a one-time submit token so a double-clicked signup cannot create a duplicate account.

## How

- **Guide** (`docs/guide/submit-tokens.md`): standalone `docs/guide/<name>.md` (H1 title, no frontmatter). Covers the double-submit / duplicate-POST problem; how the default-on `SubmitTokenLayer` + hidden `_submit_token` field + `SubmitToken` extractor close it with **no client JS**; how it differs from CSRF (stable per-session) and `Idempotency-Key` (header-driven); the replay / in-flight-lock semantics; and the `[security.submit_token]` config knobs (including the inherited idempotency backend and the production in-memory guard). Snippets follow the module's own rustdoc example.
- **Example** (`examples/saas/src/routes/auth.rs`): the signup GET renders the token via the `SubmitToken` extractor in a hidden `_submit_token` field; the framework's default-on layer consumes it on the POST. The POST handler also takes a fresh `SubmitToken` so the validation-error re-render carries a new token rather than the spent one. Added a README feature row.
- **CHANGELOG**: one bullet under `## [Unreleased]` → `### Added`, carrying `[no-plugin]`.

`[no-plugin]`

## Self-review checklist

- [x] Guide is a standalone `docs/guide/*.md` (H1 title, no frontmatter, plain markdown).
- [x] Guide snippets match current APIs — `autumn_web::security::SubmitToken`, `.token()`, hidden `_submit_token` field, `[security.submit_token]` config keys — cross-checked against `autumn/src/security/submit_token.rs` and `config.rs`.
- [x] Example change compiles: `cargo build -p saas` (clean) and `cargo clippy -p saas --all-targets -- -D warnings` (clean; only the unrelated Tailwind-CLI build-script note).
- [x] `cargo fmt --all` applied; reverted two unrelated pre-existing fmt drifts it surfaced so the diff stays scoped to this change.
- [x] Only files I changed are staged (guide, CHANGELOG, saas README + auth.rs).
- [x] No version bump; no new dated CHANGELOG section.
- [x] Existing saas signup integration test remains valid — a POST without a `_submit_token` field passes through the guard unchanged, so no test needed updating.

## AI-reviewer note

No external AI reviewer ran on this change. The verification above is a documented self-review only.


---
_Generated by [Claude Code](https://claude.ai/code/session_01ErYU5Xz7Z2Cr7DjDPnddZE)_