### PR TITLE
docs: downloads guide + range-capable export route in bookmarks example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **docs:** a `docs/guide/downloads.md` guide covering the typed `Download`
+  response — the `from_bytes` / `from_stream` / `from_async_read` / `from_blob`
+  constructors, the `.filename` / `.content_type` / `.inline` / `.etag` /
+  `.last_modified` builders, and `into_response_ranged` for RFC 7233 `Range`
+  requests / `206 Partial Content` — plus a range-capable CSV export route
+  (`GET /bookmarks/export.csv`) added to the `bookmarks` example. `[no-plugin]`
 - **test-support:** `autumn_web::test::drain_ready_repository_commit_hooks(pool, max_rows)`
   deterministically claims and runs ready durable repository commit hooks in
   integration tests — driving the real worker→drain wiring without starting the

--- a/docs/guide/downloads.md
+++ b/docs/guide/downloads.md
@@ -1,0 +1,269 @@
+# File Downloads and Range Requests
+
+Autumn ships a typed [`Download`] response so a handler can serve a file — owned
+bytes, a byte stream, an [`AsyncRead`], or a stored blob — with the right
+`Content-Type`, `Content-Disposition`, and `Content-Length` headers without
+hand-rolling header strings. When you serve it through
+[`into_response_ranged`][ranged] it also honours the request's `Range` header and
+answers with `206 Partial Content`, so a browser `<video>` element can seek and a
+resumed download can pick up where it left off.
+
+`Download` is a plain `IntoResponse`, so returning it from a `#[get]` handler is a
+single expression. The RFC 7233 range machinery lives in the reusable
+[`autumn_web::range`] module and is driven for you by `into_response_ranged`.
+
+## Why it matters
+
+Serving a file "by hand" means building `Content-Disposition` strings (and
+getting the quoting and non-ASCII `filename*` encoding right), inferring a MIME
+type, streaming large objects without buffering them in memory, and — if you want
+seekable media or resumable downloads — parsing `Range`/`If-Range` and emitting
+`206`/`416`/`Content-Range`. `Download` does all of that, and keeps the bytes
+flowing through your own authorized handler rather than a public presigned URL.
+
+## Quick start
+
+Serve owned bytes as a downloadable file:
+
+```rust
+use autumn_web::download::Download;
+use autumn_web::prelude::*;
+
+#[get("/export.csv")]
+async fn export_csv() -> Download {
+    let csv = b"id,name\n1,ada\n".to_vec();
+    Download::from_bytes(csv).filename("export.csv")
+}
+```
+
+Naming the file with `.filename("export.csv")` sets three things at once:
+
+- `Content-Disposition: attachment; filename="export.csv"` — the browser offers a
+  save dialog with that name.
+- `Content-Type: text/csv; charset=utf-8` — inferred from the `.csv` extension
+  (override it with [`content_type`]).
+- `Content-Length` — taken from the byte length.
+
+The filename is sanitized: control characters (including CR/LF) are stripped, a
+path-like name is reduced to its basename (`.filename("../../etc/passwd")` emits
+`filename="passwd"`), and a non-ASCII name additionally gets an RFC 5987
+`filename*=UTF-8''…` parameter — so a caller-supplied name can never inject an
+extra header directive.
+
+## Constructing a download
+
+Pick the constructor that matches where the bytes come from:
+
+| Constructor | Source | Range-capable? |
+|---|---|---|
+| [`Download::from_bytes`] | owned, in-memory bytes (`Vec<u8>`, `Bytes`, …) | **yes** — a slice is served from memory |
+| [`Download::from_stream`] | any `Stream<Item = Result<Bytes, io::Error>>` | no — an opaque stream cannot be re-seeked |
+| [`Download::from_async_read`] | any [`AsyncRead`] (wrapped incrementally, not buffered) | no |
+| [`Download::from_blob`] | a stored [`Blob`] (needs the `storage` feature) | **yes** — a ranged request fetches only the slice |
+
+`from_stream` and `from_async_read` transfer the body incrementally with chunked
+encoding and emit no `Content-Length` (the length is unknown). Because their
+source cannot be re-seeked, they are always served in full and never advertise
+`Accept-Ranges`, even through `into_response_ranged`.
+
+## Builder options
+
+Chain setters on the constructed download before returning it:
+
+```rust
+use autumn_web::download::Download;
+use autumn_web::prelude::*;
+
+# fn demo(bytes: Vec<u8>) -> Download {
+Download::from_bytes(bytes)
+    .filename("report.pdf")            // Content-Disposition + inferred type
+    .content_type("application/pdf")   // override the inferred type
+    .etag(ETag::strong("v42"))         // strong validator (see Range, below)
+    .last_modified("Wed, 21 Oct 2015 07:28:00 GMT")
+# }
+```
+
+- [`filename`] — sets the `Content-Disposition` filename (and MIME inference).
+- [`content_type`] — sets `Content-Type` explicitly, overriding the type inferred
+  from the filename extension or blob metadata.
+- [`inline`] — serves the file inline (`Content-Disposition: inline`) instead of
+  forcing a save dialog. Use it for media you want rendered in place.
+- [`etag`] — attaches a strong `ETag`. It is emitted on the response and used as
+  the `If-Range` validator for ranged requests.
+- [`last_modified`] — attaches a `Last-Modified` HTTP-date, likewise emitted and
+  usable as an `If-Range` validator (the value must already be a formatted
+  HTTP-date, e.g. `Wed, 21 Oct 2015 07:28:00 GMT`).
+
+The effective content type is resolved in order: explicit `.content_type()` →
+inferred from the filename extension → blob-metadata default →
+`application/octet-stream`.
+
+## Serving a private stored file behind auth
+
+Because `Download` is a plain `IntoResponse`, a policy-protected handler can
+stream a stored blob as a download in one expression. `from_blob` reads only the
+object's metadata up front and opens the byte stream lazily, so the full object
+is never buffered in memory — it works for large files behind authorization
+without issuing a public presigned URL:
+
+```rust
+use autumn_web::download::Download;
+use autumn_web::storage::SharedBlobStore;
+use autumn_web::{secured, AutumnError};
+
+#[secured(policy = "reports.read")]
+async fn download_report(
+    store: SharedBlobStore,
+    report_key: String,
+) -> Result<Download, AutumnError> {
+    Ok(Download::from_blob(&store, report_key).await?.filename("report.pdf"))
+}
+```
+
+`from_blob` returns a [`BlobStoreError`] if the blob does not exist or its
+metadata cannot be read.
+
+## Range requests and `206 Partial Content`
+
+The plain `IntoResponse` conversion cannot see the request, so it always serves
+the full body. To honour a `Range` header, call
+[`into_response_ranged(&req_headers)`][ranged] instead — an `async` method that
+reads `Range` / `If-Range` from the request headers and can answer with `206`:
+
+```rust
+use autumn_web::download::Download;
+use autumn_web::prelude::*;
+use autumn_web::reexports::axum::response::Response;
+use autumn_web::reexports::http::HeaderMap;
+
+#[get("/reports/{id}/download")]
+async fn download(id: Path<i64>, headers: HeaderMap) -> AutumnResult<Response> {
+    let bytes = load_report_bytes(*id).await?;
+    Ok(Download::from_bytes(bytes)
+        .filename("report.pdf")
+        .etag(ETag::strong(format!("report-{}", *id)))
+        .into_response_ranged(&headers)
+        .await)
+}
+# async fn load_report_bytes(_id: i64) -> AutumnResult<Vec<u8>> { Ok(Vec::new()) }
+```
+
+What `into_response_ranged` does for a **range-capable** body
+(`from_bytes` / `from_blob`):
+
+- **No `Range` header** (or an invalid/unparseable one) → the full `200` with
+  `Accept-Ranges: bytes`. An invalid range is ignored, never rejected (RFC 7233
+  §3.1).
+- **A satisfiable range** (`bytes=0-1023`, `bytes=1024-`, or the suffix form
+  `bytes=-1024`) → `206 Partial Content` with `Content-Range: bytes start-end/total`
+  and just the requested slice. For a blob, only that slice is fetched from the
+  store ([`BlobStore::get_range`]) — the whole object is never read for a seek.
+- **An unsatisfiable range** (start past the end of the file) → `416 Range Not
+  Satisfiable` with `Content-Range: bytes */total`.
+
+For an **opaque stream** (`from_stream` / `from_async_read`) it always serves the
+full `200` and does not advertise `Accept-Ranges`, because the source cannot be
+re-seeked.
+
+### `If-Range` and validators
+
+When a client caches a partial response and later asks to continue, it sends the
+range plus an `If-Range` header carrying the validator it saw. If that validator
+no longer matches the current representation — the file changed underneath it —
+serving the stale bytes as a `206` would corrupt the client's copy. So the range
+is honoured only when the `If-Range` validator still matches; otherwise the whole
+representation is served as a fresh `200`.
+
+Attach a validator with `.etag(…)` and/or `.last_modified(…)`. Note that
+`If-Range` requires a **strong** entity-tag (a weak `ETag` never matches), so use
+[`ETag::strong`] for a download you expect to serve ranged. Without any validator,
+an `If-Range` request simply falls back to the full `200`.
+
+### Seekable media
+
+A browser `<video>` element seeks by issuing `Range` requests, so returning a
+media download through `into_response_ranged` is all it takes to make it
+scrubbable — combine `.inline()` (render in place) with `.content_type("video/mp4")`:
+
+```rust
+use autumn_web::download::Download;
+use autumn_web::storage::SharedBlobStore;
+use autumn_web::{secured, AutumnError};
+use http::HeaderMap;
+
+#[secured(policy = "media.watch")]
+async fn watch(
+    store: SharedBlobStore,
+    key: String,
+    headers: HeaderMap,
+) -> Result<axum::response::Response, AutumnError> {
+    Ok(Download::from_blob(&store, key)
+        .await?
+        .content_type("video/mp4")
+        .inline()
+        .into_response_ranged(&headers)
+        .await)
+}
+```
+
+## Working example
+
+The [`bookmarks`](../../examples/bookmarks) example serves
+`GET /bookmarks/export.csv`: it builds an RFC 4180 CSV of every bookmark, wraps it
+in `Download::from_bytes(...).filename("bookmarks.csv")`, attaches a strong
+content-derived `ETag`, and returns it through `into_response_ranged(&headers)`.
+A plain fetch downloads the whole file; a ranged fetch gets a `206`:
+
+```bash
+# Full download (200, Content-Disposition: attachment; filename="bookmarks.csv")
+curl -OJ http://localhost:3000/bookmarks/export.csv
+
+# A byte range (206 Partial Content, Content-Range: bytes 0-99/<total>)
+curl -H 'Range: bytes=0-99' -i http://localhost:3000/bookmarks/export.csv
+```
+
+## The `range` module
+
+The `Range` handling above is powered by [`autumn_web::range`], the reusable
+RFC 7233 core. `into_response_ranged` drives it for you, but you can call it
+directly to add ranged responses to a hand-built response:
+
+- [`range::resolve(headers, total, validator)`][resolve] parses the request's
+  `Range`/`If-Range` against a known `total` size and returns a
+  [`RangeResolution`] — `Full`, `Partial { start, end, total }`, or
+  `Unsatisfiable { total }`.
+- [`Validator`] carries the current strong `ETag` and/or `Last-Modified` for the
+  `If-Range` check (`Validator::new().with_etag(&tag).with_last_modified(lm)`).
+- [`range::partial_bytes_response(&resolution, bytes)`][pbr] builds the matching
+  `200`/`206`/`416` response over in-memory bytes.
+- [`content_range_value(start, end, total)`][crv] and
+  [`set_accept_ranges(&mut headers)`][sar] are the small header helpers.
+
+Ranges are inclusive byte offsets, matching the `Content-Range` convention. A
+multi-range request (`bytes=0-50,100-150`) is collapsed deterministically to the
+first satisfiable sub-range and served as a single-range `206` — a
+`multipart/byteranges` body is intentionally not produced.
+
+[`Download`]: https://docs.rs/autumn-web/latest/autumn_web/download/struct.Download.html
+[`Download::from_bytes`]: https://docs.rs/autumn-web/latest/autumn_web/download/struct.Download.html#method.from_bytes
+[`Download::from_stream`]: https://docs.rs/autumn-web/latest/autumn_web/download/struct.Download.html#method.from_stream
+[`Download::from_async_read`]: https://docs.rs/autumn-web/latest/autumn_web/download/struct.Download.html#method.from_async_read
+[`Download::from_blob`]: https://docs.rs/autumn-web/latest/autumn_web/download/struct.Download.html#method.from_blob
+[`filename`]: https://docs.rs/autumn-web/latest/autumn_web/download/struct.Download.html#method.filename
+[`content_type`]: https://docs.rs/autumn-web/latest/autumn_web/download/struct.Download.html#method.content_type
+[`inline`]: https://docs.rs/autumn-web/latest/autumn_web/download/struct.Download.html#method.inline
+[`etag`]: https://docs.rs/autumn-web/latest/autumn_web/download/struct.Download.html#method.etag
+[`last_modified`]: https://docs.rs/autumn-web/latest/autumn_web/download/struct.Download.html#method.last_modified
+[ranged]: https://docs.rs/autumn-web/latest/autumn_web/download/struct.Download.html#method.into_response_ranged
+[`autumn_web::range`]: https://docs.rs/autumn-web/latest/autumn_web/range/index.html
+[resolve]: https://docs.rs/autumn-web/latest/autumn_web/range/fn.resolve.html
+[`RangeResolution`]: https://docs.rs/autumn-web/latest/autumn_web/range/enum.RangeResolution.html
+[`Validator`]: https://docs.rs/autumn-web/latest/autumn_web/range/struct.Validator.html
+[pbr]: https://docs.rs/autumn-web/latest/autumn_web/range/fn.partial_bytes_response.html
+[crv]: https://docs.rs/autumn-web/latest/autumn_web/range/fn.content_range_value.html
+[sar]: https://docs.rs/autumn-web/latest/autumn_web/range/fn.set_accept_ranges.html
+[`ETag::strong`]: https://docs.rs/autumn-web/latest/autumn_web/etag/struct.ETag.html#method.strong
+[`BlobStore::get_range`]: https://docs.rs/autumn-web/latest/autumn_web/storage/trait.BlobStore.html#method.get_range
+[`BlobStoreError`]: https://docs.rs/autumn-web/latest/autumn_web/storage/enum.BlobStoreError.html
+[`Blob`]: https://docs.rs/autumn-web/latest/autumn_web/storage/struct.Blob.html
+[`AsyncRead`]: https://docs.rs/tokio/latest/tokio/io/trait.AsyncRead.html

--- a/examples/bookmarks/README.md
+++ b/examples/bookmarks/README.md
@@ -57,6 +57,7 @@ The server starts at <http://localhost:3000>.
 |--------|--------------|------------------------------|
 | GET    | `/`          | Redirect to `/bookmarks`     |
 | GET    | `/bookmarks` | List all bookmarks           |
+| GET    | `/bookmarks/export.csv` | Download all bookmarks as CSV (typed `Download`, Range/206) |
 | GET    | `/bookmarks/{id}` | Show one bookmark        |
 | GET    | `/bookmarks/tag/{tag}` | Filter bookmarks by tag |
 | GET    | `/bookmarks/new` | Add bookmark form        |

--- a/examples/bookmarks/src/main.rs
+++ b/examples/bookmarks/src/main.rs
@@ -23,6 +23,7 @@ async fn main() {
         .routes(routes![
             home,
             routes::bookmarks::index,
+            routes::bookmarks::export_csv,
             routes::bookmarks::search,
             routes::bookmarks::tags_autocomplete,
             routes::bookmarks::show,

--- a/examples/bookmarks/src/routes/bookmarks.rs
+++ b/examples/bookmarks/src/routes/bookmarks.rs
@@ -17,9 +17,15 @@
 //! All four compose without special wiring, demonstrating the widget lane
 //! (data_table, active_search, autocomplete_input, property_list).
 
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
+
+use autumn_web::download::Download;
 use autumn_web::extract::{Form, Path};
 use autumn_web::form::Changeset;
 use autumn_web::prelude::*;
+use autumn_web::reexports::axum::response::Response;
+use autumn_web::reexports::http::HeaderMap;
 use autumn_web::widgets::{Column, DataTableConfig, data_table, property_list};
 use diesel::prelude::*;
 use diesel_async::RunQueryDsl;
@@ -153,6 +159,10 @@ pub async fn index(repo: PgBookmarkRepository) -> AutumnResult<Markup> {
                       class="border border-indigo-600 text-indigo-600 px-4 py-2 rounded hover:bg-indigo-50" {
                         "+ Add (wizard)"
                     }
+                    a href="/bookmarks/export.csv"
+                      class="border border-gray-300 text-gray-600 px-4 py-2 rounded hover:bg-gray-100" {
+                        "Export CSV"
+                    }
                 }
             }
             // ── Active search widget ──────────────────────────────────────
@@ -169,6 +179,64 @@ pub async fn index(repo: PgBookmarkRepository) -> AutumnResult<Markup> {
             }
         },
     ))
+}
+
+// ── CSV export (typed Download + Range) ───────────────────────────────────────
+
+/// Escape one CSV field per RFC 4180: wrap it in double quotes when it contains
+/// a comma, quote, CR, or LF, doubling any embedded quote.
+fn csv_field(value: &str) -> String {
+    if value.contains([',', '"', '\n', '\r']) {
+        format!("\"{}\"", value.replace('"', "\"\""))
+    } else {
+        value.to_owned()
+    }
+}
+
+/// Render every bookmark as one RFC 4180 CSV document (header row + one row per
+/// bookmark).
+fn bookmarks_csv(rows: &[Bookmark]) -> String {
+    let mut out = String::from("id,url,title,tag,alive,created_at\n");
+    for row in rows {
+        out.push_str(&format!(
+            "{},{},{},{},{},{}\n",
+            row.id,
+            csv_field(&row.url),
+            csv_field(&row.title),
+            csv_field(&row.tag),
+            row.alive,
+            row.created_at,
+        ));
+    }
+    out
+}
+
+/// Export all bookmarks as a downloadable CSV file.
+///
+/// Builds a typed [`Download`] from in-memory bytes, names the file (which also
+/// sets `Content-Type: text/csv` from the `.csv` extension and
+/// `Content-Disposition: attachment`), and attaches a strong `ETag` derived
+/// from the content. Serving it through [`Download::into_response_ranged`] lets
+/// the response honour a request `Range` header: a byte range yields `206
+/// Partial Content` with `Content-Range` (a stale `If-Range` validator falls
+/// back to the full body), while a plain request gets the full `200` with
+/// `Accept-Ranges: bytes`.
+#[get("/bookmarks/export.csv")]
+pub async fn export_csv(repo: PgBookmarkRepository, headers: HeaderMap) -> AutumnResult<Response> {
+    let rows = repo.find_all().await?;
+    let csv = bookmarks_csv(&rows);
+
+    // A strong validator so a client's `If-Range` can be honoured across a
+    // resumed/ranged transfer; it changes whenever the exported rows change.
+    let mut hasher = DefaultHasher::new();
+    csv.hash(&mut hasher);
+    let etag = ETag::strong(format!("{:016x}", hasher.finish()));
+
+    Ok(Download::from_bytes(csv)
+        .filename("bookmarks.csv")
+        .etag(etag)
+        .into_response_ranged(&headers)
+        .await)
 }
 
 #[get("/bookmarks/{id}")]


### PR DESCRIPTION
Closes Gap 5 of the docs/examples coverage audit (#2099): typed `Download` responses with `Range`/`206` had no guide and no example. `[no-plugin]`

## Before / After

**Before:** the typed `Download` response and its `Range`/`206 Partial Content` path (`autumn/src/download.rs` + `autumn/src/range.rs`) were documented only in rustdoc — no `docs/guide/` page and no runnable example serving a real file download.

**After:**
- `docs/guide/downloads.md` — a standalone guide for serving file downloads: the `from_bytes` / `from_stream` / `from_async_read` / `from_blob` constructors, the `.filename` / `.content_type` / `.inline` / `.etag` / `.last_modified` builders, filename sanitization, MIME inference, serving a private stored blob behind auth, and `into_response_ranged` for RFC 7233 `Range` requests (`206`/`416`/`If-Range` semantics + seekable media), with a short section on the reusable `autumn_web::range` core.
- A range-capable download route in the **`bookmarks`** example: `GET /bookmarks/export.csv` builds an RFC 4180 CSV of every bookmark, wraps it in `Download::from_bytes(...).filename("bookmarks.csv")` with a strong content-derived `ETag`, and returns it through `into_response_ranged(&headers)` so a `Range` request yields `206 Partial Content`. Registered in `main.rs`, surfaced as a discoverable "Export CSV" link on the index page, and documented in the example README's routes table.

## How

The guide is written against the real APIs in `autumn/src/download.rs` and `autumn/src/range.rs` (both read in full), reusing the shapes from the crate's doctested `//!` examples. The example route matches the bookmarks crate's existing style (repository extractor, `AutumnResult<Response>`, `HeaderMap` extractor as used elsewhere in the repo) and needs no new dependency or feature — the `from_bytes` path works without the `storage` feature.

## Self-review checklist

- [x] `cargo fmt --all -- --check` — clean.
- [x] `cargo build -p bookmarks` — succeeds.
- [x] `cargo clippy -p bookmarks --all-targets -- -D warnings` — no warnings.
- [x] Guide is a standalone `docs/guide/<name>.md`: H1 title, no frontmatter, plain markdown.
- [x] Snippets use current APIs; the illustrative CSV export change was compiled.
- [x] Only intended files staged; workspace-wide `cargo fmt` reformats of unrelated base-branch files were reverted.
- [x] One CHANGELOG bullet under `## [Unreleased]` → `### Added`, carrying `[no-plugin]`; no version bump, no dated section.
- [x] No `TODO`/`unimplemented!` markers in the changed files.

## Note on review

No external AI reviewer ran on this change; the checklist above is a manual self-review only.

Refs #2099.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ErYU5Xz7Z2Cr7DjDPnddZE)_