### PR TITLE
test: de-flake SWR stale-serve test with a Notify happens-before gate (#1809)

### DIFF
--- a/autumn/tests/integration/cache_stampede.rs
+++ b/autumn/tests/integration/cache_stampede.rs
@@ -351,18 +351,36 @@ async fn swr_serves_stale_and_refreshes_in_background() {
     // the grace period).
     tokio::time::sleep(Duration::from_millis(80)).await;
 
+    // A test-controlled gate the background refresh's fill closure blocks on
+    // instead of a fixed `sleep`, so the refresh completes only when the test
+    // explicitly releases it. This is what makes the stale-serve non-blocking
+    // property below provable with ZERO wall-clock dependence (the former
+    // `elapsed < 150ms` ceiling flaked under windows-latest scheduler
+    // starvation — an OS deschedule between `Instant::now()` and the future
+    // resolving was wrongly charged to `elapsed`; see #1809). Because the fill
+    // cannot finish until released, if the foreground stale-serve had waited on
+    // the refresh the call would hang forever — caught by HANG_GUARD as a hard
+    // failure, never a flaky pass — so the mere fact it returns the stale value
+    // while the fill is still gated proves it did not block on the refresh.
+    let refresh_gate = Arc::new(tokio::sync::Notify::new());
+
     // A deterministic signal the background refresh's fill closure fires the
-    // moment it finishes computing the new value. Waiting on this — rather than
-    // a fixed wall-clock timeout — absorbs however long a slow/loaded runner
-    // takes to schedule and run the detached background task.
+    // moment it finishes computing the new value (after the gate opens). Waiting
+    // on this — rather than a fixed wall-clock timeout — absorbs however long a
+    // slow/loaded runner takes to schedule and run the detached background task.
     let refresh_done = Arc::new(tokio::sync::Notify::new());
 
-    let start = std::time::Instant::now();
     let fc = fill_count.clone();
+    let gate = refresh_gate.clone();
     let done = refresh_done.clone();
     let v: String = get_or_compute_with(&cache, &key, opts.clone(), move || async move {
         fc.fetch_add(1, Ordering::SeqCst);
-        tokio::time::sleep(Duration::from_millis(200)).await;
+        // Block until the test releases the gate. Replaces the former
+        // `sleep(200ms)` + `elapsed < 150ms` wall-clock ceiling: the stale-serve
+        // property is now proven structurally by the fact this fill cannot
+        // complete until released, so a starved scheduler can only DELAY the
+        // refresh, never turn the assertion below into a false failure.
+        gate.notified().await;
         let out = Ok::<String, String>("v2".to_string());
         // Publication (`insert_cached`) happens synchronously right after this
         // closure returns; signal now that the compute is done.
@@ -371,20 +389,40 @@ async fn swr_serves_stale_and_refreshes_in_background() {
     })
     .await
     .unwrap();
-    let elapsed = start.elapsed();
     assert_eq!(
         v, "v1",
-        "a stale-but-in-grace value must be served immediately"
-    );
-    assert!(
-        elapsed < Duration::from_millis(150),
-        "serving stale must not wait on the slow background refresh, took {elapsed:?}"
+        "a stale-but-in-grace value must be served immediately without waiting on the \
+         (still-gated) background refresh"
     );
 
-    // Wait deterministically for the background refresh to finish computing —
-    // no wall-clock ceiling on the load-sensitive scheduling + 200ms compute.
-    // (`notify_one` stores a permit if it fires before this await, so there is
-    // no lost-wakeup even when the background task wins the race.)
+    // Strengthen the proof: while the refresh fill is still gated it cannot have
+    // published "v2", so a second read also serves the stale "v1". The in-flight
+    // refresh holds single-flight leadership, so this read neither runs a second
+    // fill (`unexpected-refill` is dropped unrun) nor blocks on it — it is fully
+    // deterministic, with no timing assumption.
+    let fc = fill_count.clone();
+    let still_stale: String = get_or_compute_with(&cache, &key, opts.clone(), move || async move {
+        fc.fetch_add(1, Ordering::SeqCst);
+        Ok::<String, String>("unexpected-refill".to_string())
+    })
+    .await
+    .unwrap();
+    assert_eq!(
+        still_stale, "v1",
+        "the gated background refresh must not have published a new value yet"
+    );
+
+    // Release the gate so the background refresh can finish computing and
+    // publish. `notify_one` stores a permit if the detached refresh task has not
+    // yet parked on `notified()`, so there is no lost-wakeup race regardless of
+    // which task the scheduler runs first.
+    refresh_gate.notify_one();
+
+    // Wait deterministically for the background refresh to finish computing
+    // (now that the gate is open) — no wall-clock ceiling on the load-sensitive
+    // scheduling of the detached task. (`notify_one` stores a permit if it fires
+    // before this await, so there is no lost-wakeup even when the background task
+    // wins the race.)
     //
     // The timeout here is a generous hang-guard, mirroring the bound on the
     // publish loop below: it exists only to convert a genuine never-fires hang


### PR DESCRIPTION
## What

De-flakes `swr_serves_stale_and_refreshes_in_background` in `autumn/tests/integration/cache_stampede.rs` by removing its last absolute wall-clock ceiling. **Test-only — no product code touched.**

## Before / After

- **Before:** the stale-serve non-blocking property was asserted with a wall-clock ceiling — `assert!(elapsed < Duration::from_millis(150))` (cache_stampede.rs:379-382). Bracketing `elapsed = start.elapsed()` around two plain statements on the test task meant an OS deschedule of the tokio worker between `start = Instant::now()` and the future resolving was charged to `elapsed`, producing a **false failure under windows-latest scheduler starvation** on an oversubscribed 2-vCPU runner.
- **After:** the property is proven by a `tokio::sync::Notify` **happens-before gate** with **zero timing dependence**. The background refresh's fill closure now blocks on a test-controlled gate instead of `sleep(200ms)`. Because a gated fill never completes until the test releases it, it cannot be waited on — so the stale-serve call returning `"v1"` while the fill is still gated structurally proves the serve did not block on the refresh. If it *had* blocked, the call would hang forever, converted to a hard failure by the existing 120s `HANG_GUARD` — never a flaky pass. A starved scheduler can only **delay** the refresh, never turn the assertion into a false failure.

## How

- Fill closure records the fill via the existing counter, then `gate.notified().await` (blocks until released), then returns `"v2"` and fires the existing `refresh_done` signal.
- Replaced the `start`/`elapsed`/`assert!(elapsed < 150ms)` block + 200ms sleep with: assert the stale read returns `"v1"`; strengthen with a second read that also returns `"v1"` (single-flight leadership makes this deterministic — the second fill is dropped unrun); then `refresh_gate.notify_one()` and **reuse the existing attempt-capped publish-visibility poll + `HANG_GUARD`** to confirm `"v2"` becomes visible. No new wall-clock deadline is introduced.
- Removed the now-unused `Instant`/`start`/`elapsed` and the 200ms fill sleep. Kept `ttl(50ms)` / `stale_while_revalidate(10s)` and the 80ms stale-inducing sleep (high-resolution boundary, not the flake).

This matches the shape of the prior #1764 / #1809 de-flakes already in this test (a `Notify` for the publish side + an attempt-capped, `HANG_GUARD`-backed poll).

## Verification

Locally green across repeated runs, including under heavy CPU contention (8 busy loops on 4 cores, test pinned to 2 cores to oversubscribe): the specific test passed 12/12 plain and 10/10 under contention, and the full `cache_stampede` module passed repeatedly. `cargo fmt` (changed file) and `cargo clippy -p autumn-web --tests -- -D warnings` both clean.

Refs #1809 (and the #1764/#1809 precedent).

---
_Generated by [Claude Code](https://claude.ai/code/session_01RszvAcKeUfyrEYQoSrZBhs)_