### PR TITLE
fix: rustfmt trunk-dev after #2107 (unblock wave-wide Lint)

### DIFF
--- a/autumn/src/sim.rs
+++ b/autumn/src/sim.rs
@@ -178,7 +178,7 @@ impl Sim {
     pub fn seeded_entropy(&self) -> Arc<dyn Entropy> {
         SeededEntropy::shared(self.seed)
     }
-  
+
     /// Mount `app` on the paused runtime with the simulation's virtual clock
     /// installed, and return the resulting [`crate::test::TestClient`].
     ///

--- a/autumn/tests/integration/mod.rs
+++ b/autumn/tests/integration/mod.rs
@@ -203,8 +203,8 @@ mod sharding_commit_hooks;
 #[cfg(feature = "db")]
 mod sharding_integration;
 mod signed_webhooks;
-mod sim_deterministic_ids;
 mod sim_clock_drain;
+mod sim_deterministic_ids;
 mod sim_test_smoke;
 #[cfg(feature = "ws")]
 mod sse_replay;


### PR DESCRIPTION
Fixes a pre-existing `cargo fmt --all -- --check` failure on trunk-dev that was introduced by the merge of #2107. Reproduced on a clean checkout of current trunk-dev with stable rustfmt.

Two violations:
- autumn/src/sim.rs:178 — trailing whitespace on the blank line after the seeded_entropy method.
- autumn/tests/integration/mod.rs — module declarations out of order (sim_deterministic_ids listed before sim_clock_drain), violating rustfmt reorder_modules.

Impact: the Lint CI check runs `cargo fmt --all -- --check` before clippy, so this baseline red currently fails Lint on every open PR branched from current trunk-dev until this merges. Priority unblock.

This is formatting-only: no behavior change, and no CHANGELOG bullet (pure formatting, so it deliberately avoids the plugin-freshness gate). Verified `cargo fmt --all -- --check` exits 0 after the change and `cargo build -p autumn-web` still builds.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SnvJMDdVamJk9N3rvZZrRm)_