### PR TITLE
migrate: serialize SQLite migrate up/down under a shared write lock (#2065)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,6 +119,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   follow-up. (0.7.0 work — do not merge until v0.6.0 is cut.)
 ### Fixed
 
+- **migrate:** the two `SQLite` migration entry points — `run_pending_sqlite`
+  (up) and `revert_user_migrations_sqlite` (down) — now serialize their whole
+  list→plan→apply/revert sequence under a single shared `BEGIN IMMEDIATE` write
+  lock (#2065, the deferred follow-up from #2062). Previously the read→plan→apply
+  window was unlocked, so two concurrent `autumn migrate` / `autumn schema
+  migrate` processes against the same file could each read the same pending (or
+  applied) set before either wrote, and the loser then re-ran an already-applied
+  `up.sql` (or already-reverted `down.sql`) and reported a **false** migration
+  failure. The lock is taken through diesel's `AnsiTransactionManager` so diesel's
+  own per-migration transactions nest as savepoints (no "cannot start a
+  transaction within a transaction"), and a concurrent migrator now queues on the
+  connection's `busy_timeout`, re-reads an already-drained set, and cleanly
+  no-ops. There is still **no Postgres advisory lock** on the `SQLite` path —
+  `SQLite` has no such primitive; the on-disk write lock is the entire
+  serialization mechanism. Single-process migrate/revert behaviour is unchanged.
+  [no-plugin]
 - Docs and crate metadata: updated repository/homepage URLs, README badges, install scripts, and the CI workflow template from the old `madmax983/autumn` owner to `autumn-foundation/autumn` after the GitHub org transfer. Old links still redirect; this makes the canonical URLs correct.
 - **migrate:** startup migration auto-apply is now profile-agnostic (#1903).
   Previously the opt-in was name-gated to `prod`/`production`, so a custom

--- a/autumn/src/migrate.rs
+++ b/autumn/src/migrate.rs
@@ -325,12 +325,16 @@ where
 
 /// Run all pending migrations against a `SQLite` database URL (issue #1614, PR3).
 ///
-/// The `SQLite` counterpart to [`run_pending`]. `SQLite` is a single-writer local
-/// database, so — unlike the Postgres path — there is **no advisory lock**: no
-/// cross-process serialization is needed and `SQLite` has no `pg_advisory_lock`
-/// primitive. Establishes a synchronous `SqliteConnection` (via
-/// [`crate::db::establish_sqlite_migration_connection`]) and applies pending
-/// migrations through diesel's `MigrationHarness`.
+/// The `SQLite` counterpart to [`run_pending`]. Establishes a synchronous
+/// `SqliteConnection` (via [`crate::db::establish_sqlite_migration_connection`])
+/// and applies pending migrations through diesel's `MigrationHarness`, wrapping
+/// the whole list→apply sequence in the shared [`with_sqlite_migration_lock`]
+/// write lock (issue #2065, deferred from PR #2062) so two concurrent `autumn
+/// migrate` / `autumn schema migrate` processes against the same file cannot
+/// interleave their read-then-write windows and re-run an already-applied
+/// migration. There is still **no Postgres advisory lock** on this path —
+/// `SQLite` has no `pg_advisory_lock` primitive; the on-disk write lock held
+/// across the sequence is the entire cross-process serialization mechanism.
 ///
 /// The migration set is taken as a [`MigrationSource<Sqlite>`](diesel::migration::MigrationSource);
 /// the framework's [`EmbeddedMigrations`] (and [`EmbeddedMigrationsRef`]) satisfy
@@ -358,13 +362,87 @@ pub fn run_pending_sqlite(
     }
     let mut conn = crate::db::establish_sqlite_migration_connection(database_url)
         .map_err(|e| MigrationError::Connection(e.to_string()))?;
-    let mut harness = HarnessWithOutput::write_to_stdout(&mut conn);
-    let applied = harness
-        .run_pending_migrations(migrations)
+    let applied = with_sqlite_migration_lock(&mut conn, |conn| {
+        let mut harness = HarnessWithOutput::write_to_stdout(conn);
+        harness
+            .run_pending_migrations(migrations)
+            .map(|applied| applied.iter().map(|m| format!("{m}")).collect::<Vec<_>>())
+            .map_err(|e| MigrationError::Migration(e.to_string()))
+    })?;
+    Ok(MigrationResult { applied })
+}
+
+/// Serialize a `SQLite` migration sequence under the database's write lock.
+///
+/// The single intra-run serialization primitive shared by BOTH `SQLite`
+/// migration directions — [`run_pending_sqlite`] (up) and
+/// [`revert_user_migrations_sqlite`] (down) — and therefore by both the `autumn
+/// migrate` and `autumn schema migrate` verbs, which each route through those two
+/// functions. It takes the `SQLite` write lock up front with `BEGIN IMMEDIATE`
+/// and holds it across the whole list→plan→apply/revert sequence in `f`, then
+/// commits. Two concurrent migrators against the same file therefore cannot
+/// interleave their read-then-write windows: the second `BEGIN IMMEDIATE` queues
+/// on the connection's `busy_timeout` (set by
+/// [`crate::db::establish_sqlite_migration_connection`]) until the first commits,
+/// then re-reads an already-drained pending/applied set and cleanly no-ops
+/// instead of re-running an already-applied `up.sql` (or already-reverted
+/// `down.sql`) and reporting a false failure (issue #2065, deferred from
+/// PR #2062).
+///
+/// There is deliberately **no Postgres advisory lock** on the `SQLite` path
+/// (issue #1999 / #2036 precedent) — `SQLite` has no `pg_advisory_lock`
+/// primitive; this on-disk write lock is the whole serialization mechanism.
+///
+/// # Cooperation with diesel's per-migration transactions
+///
+/// The `BEGIN IMMEDIATE` is issued **through** diesel's `AnsiTransactionManager`
+/// (`begin_transaction_sql`), so the manager's depth counter advances 0 → 1 (the
+/// same technique as [`crate::db::scoped_immediate_transaction`]). Each migration
+/// diesel then applies/reverts inside its own `self.transaction(...)` becomes a
+/// nested `SAVEPOINT` (depth 1 → 2) rather than a raw nested `BEGIN`, which would
+/// fail with "cannot start a transaction within a transaction".
+///
+/// On any error the outer transaction is rolled back, so a mid-sequence failure
+/// leaves the applied set unchanged (the sequence is atomic) rather than
+/// partially advanced. On the success path — the only path the concurrency fix
+/// exercises, since a loser drains an already-empty set — the end state is
+/// identical to the pre-lock harness.
+///
+/// # Errors
+///
+/// Returns [`MigrationError::Migration`] if the write lock cannot be taken or the
+/// transaction cannot be committed, or the error returned by `f`.
+#[cfg(feature = "sqlite")]
+fn with_sqlite_migration_lock<T>(
+    conn: &mut diesel::SqliteConnection,
+    f: impl FnOnce(&mut diesel::SqliteConnection) -> Result<T, MigrationError>,
+) -> Result<T, MigrationError> {
+    use diesel::connection::{AnsiTransactionManager, TransactionManager};
+
+    // Take the write lock up front THROUGH the transaction manager so its depth
+    // counter is synced (0 → 1); diesel's per-migration `self.transaction(...)`
+    // then nests as a SAVEPOINT instead of colliding with a raw nested BEGIN.
+    AnsiTransactionManager::begin_transaction_sql(conn, "BEGIN IMMEDIATE")
         .map_err(|e| MigrationError::Migration(e.to_string()))?;
-    Ok(MigrationResult {
-        applied: applied.iter().map(|m| format!("{m}")).collect(),
-    })
+
+    match f(conn) {
+        Ok(value) => {
+            <AnsiTransactionManager as TransactionManager<diesel::SqliteConnection>>::commit_transaction(conn)
+                .map_err(|e| MigrationError::Migration(e.to_string()))?;
+            Ok(value)
+        }
+        Err(err) => {
+            if let Err(rollback_err) = <AnsiTransactionManager as TransactionManager<
+                diesel::SqliteConnection,
+            >>::rollback_transaction(conn)
+            {
+                tracing::warn!(
+                    "failed to roll back SQLite migration write-lock transaction after error: {rollback_err}"
+                );
+            }
+            Err(err)
+        }
+    }
 }
 
 /// Return names of pending (not yet applied) migrations on a `SQLite` target.
@@ -1776,10 +1854,15 @@ pub fn applied_user_migrations_sqlite(
 /// `SQLite` counterpart to [`revert_user_migrations_locked`]: plan and execute a
 /// user-migration rollback against a `SQLite` database.
 ///
-/// `SQLite` is a single-writer local database, so there is **no advisory lock**
-/// (issue #1999 / #2036 precedent): the applied set is listed, `plan` chooses the
-/// newest-first versions to revert, and each is reverted through diesel's
-/// `MigrationHarness`. There is likewise **no content-checksum bookkeeping** — the
+/// The applied set is listed, `plan` chooses the newest-first versions to revert,
+/// and each is reverted through diesel's `MigrationHarness` — the whole
+/// list→plan→revert sequence held under the shared [`with_sqlite_migration_lock`]
+/// write lock (issue #2065, deferred from PR #2062) so a concurrent migrator
+/// cannot interleave and re-revert an already-reverted `down.sql`. There is
+/// deliberately **no Postgres advisory lock** on this path (issue #1999 / #2036
+/// precedent) — `SQLite` has no `pg_advisory_lock` primitive; the on-disk write
+/// lock is the whole cross-process serialization mechanism. There is likewise
+/// **no content-checksum bookkeeping** — the
 /// `SQLite` `autumn migrate up` path applies through the unlocked harness and
 /// records no `autumn_migration_checksums` rows (that table's DDL is
 /// Postgres-specific), so there is nothing to delete on revert.
@@ -1812,37 +1895,39 @@ where
         .migrations()
         .map_err(|e| MigrationError::Migration(e.to_string()))?;
 
-    let applied_user =
-        resolve_applied_user_migrations_sqlite(&mut conn, &all_migrations, migrations_dir)?;
-    let versions = plan(&applied_user)?;
+    with_sqlite_migration_lock(&mut conn, |conn| {
+        let applied_user =
+            resolve_applied_user_migrations_sqlite(conn, &all_migrations, migrations_dir)?;
+        let versions = plan(&applied_user)?;
 
-    let mut count = 0;
-    for version in &versions {
-        let target = diesel::migration::MigrationVersion::from(version.as_str());
-        let migration = all_migrations
-            .iter()
-            .find(|m| m.name().version() == target)
-            .ok_or_else(|| {
-                MigrationError::Migration(format!(
-                    "migration version {version} is applied but not present in {} — \
-                     cannot revert (its down.sql is unavailable)",
-                    migrations_dir.display()
-                ))
-            })?;
+        let mut count = 0;
+        for version in &versions {
+            let target = diesel::migration::MigrationVersion::from(version.as_str());
+            let migration = all_migrations
+                .iter()
+                .find(|m| m.name().version() == target)
+                .ok_or_else(|| {
+                    MigrationError::Migration(format!(
+                        "migration version {version} is applied but not present in {} — \
+                         cannot revert (its down.sql is unavailable)",
+                        migrations_dir.display()
+                    ))
+                })?;
 
-        let started = std::time::Instant::now();
-        conn.revert_migration(migration.as_ref())
-            .map_err(|e| MigrationError::Migration(e.to_string()))?;
-        let duration = started.elapsed();
+            let started = std::time::Instant::now();
+            conn.revert_migration(migration.as_ref())
+                .map_err(|e| MigrationError::Migration(e.to_string()))?;
+            let duration = started.elapsed();
 
-        on_reverted(&RevertedMigration {
-            version: version.clone(),
-            name: migration.name().to_string(),
-            duration,
-        });
-        count += 1;
-    }
-    Ok(count)
+            on_reverted(&RevertedMigration {
+                version: version.clone(),
+                name: migration.name().to_string(),
+                duration,
+            });
+            count += 1;
+        }
+        Ok(count)
+    })
 }
 
 // ── Startup wait-for-database ─────────────────────────────────────────────────

--- a/autumn/src/sim.rs
+++ b/autumn/src/sim.rs
@@ -178,7 +178,7 @@ impl Sim {
     pub fn seeded_entropy(&self) -> Arc<dyn Entropy> {
         SeededEntropy::shared(self.seed)
     }
-  
+
     /// Mount `app` on the paused runtime with the simulation's virtual clock
     /// installed, and return the resulting [`crate::test::TestClient`].
     ///

--- a/autumn/tests/fixtures/sqlite_migrations_concurrent/00000000000001_create_t1/down.sql
+++ b/autumn/tests/fixtures/sqlite_migrations_concurrent/00000000000001_create_t1/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE t1;

--- a/autumn/tests/fixtures/sqlite_migrations_concurrent/00000000000001_create_t1/up.sql
+++ b/autumn/tests/fixtures/sqlite_migrations_concurrent/00000000000001_create_t1/up.sql
@@ -1,0 +1,4 @@
+CREATE TABLE t1 (
+    id INTEGER PRIMARY KEY,
+    name TEXT NOT NULL
+);

--- a/autumn/tests/fixtures/sqlite_migrations_concurrent/00000000000002_create_t2/down.sql
+++ b/autumn/tests/fixtures/sqlite_migrations_concurrent/00000000000002_create_t2/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE t2;

--- a/autumn/tests/fixtures/sqlite_migrations_concurrent/00000000000002_create_t2/up.sql
+++ b/autumn/tests/fixtures/sqlite_migrations_concurrent/00000000000002_create_t2/up.sql
@@ -1,0 +1,4 @@
+CREATE TABLE t2 (
+    id INTEGER PRIMARY KEY,
+    name TEXT NOT NULL
+);

--- a/autumn/tests/fixtures/sqlite_migrations_concurrent/00000000000003_create_t3/down.sql
+++ b/autumn/tests/fixtures/sqlite_migrations_concurrent/00000000000003_create_t3/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE t3;

--- a/autumn/tests/fixtures/sqlite_migrations_concurrent/00000000000003_create_t3/up.sql
+++ b/autumn/tests/fixtures/sqlite_migrations_concurrent/00000000000003_create_t3/up.sql
@@ -1,0 +1,4 @@
+CREATE TABLE t3 (
+    id INTEGER PRIMARY KEY,
+    name TEXT NOT NULL
+);

--- a/autumn/tests/fixtures/sqlite_migrations_concurrent/00000000000004_create_t4/down.sql
+++ b/autumn/tests/fixtures/sqlite_migrations_concurrent/00000000000004_create_t4/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE t4;

--- a/autumn/tests/fixtures/sqlite_migrations_concurrent/00000000000004_create_t4/up.sql
+++ b/autumn/tests/fixtures/sqlite_migrations_concurrent/00000000000004_create_t4/up.sql
@@ -1,0 +1,4 @@
+CREATE TABLE t4 (
+    id INTEGER PRIMARY KEY,
+    name TEXT NOT NULL
+);

--- a/autumn/tests/fixtures/sqlite_migrations_concurrent/00000000000005_create_t5/down.sql
+++ b/autumn/tests/fixtures/sqlite_migrations_concurrent/00000000000005_create_t5/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE t5;

--- a/autumn/tests/fixtures/sqlite_migrations_concurrent/00000000000005_create_t5/up.sql
+++ b/autumn/tests/fixtures/sqlite_migrations_concurrent/00000000000005_create_t5/up.sql
@@ -1,0 +1,4 @@
+CREATE TABLE t5 (
+    id INTEGER PRIMARY KEY,
+    name TEXT NOT NULL
+);

--- a/autumn/tests/fixtures/sqlite_migrations_concurrent/00000000000006_create_t6/down.sql
+++ b/autumn/tests/fixtures/sqlite_migrations_concurrent/00000000000006_create_t6/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE t6;

--- a/autumn/tests/fixtures/sqlite_migrations_concurrent/00000000000006_create_t6/up.sql
+++ b/autumn/tests/fixtures/sqlite_migrations_concurrent/00000000000006_create_t6/up.sql
@@ -1,0 +1,4 @@
+CREATE TABLE t6 (
+    id INTEGER PRIMARY KEY,
+    name TEXT NOT NULL
+);

--- a/autumn/tests/integration/mod.rs
+++ b/autumn/tests/integration/mod.rs
@@ -203,8 +203,8 @@ mod sharding_commit_hooks;
 #[cfg(feature = "db")]
 mod sharding_integration;
 mod signed_webhooks;
-mod sim_deterministic_ids;
 mod sim_clock_drain;
+mod sim_deterministic_ids;
 mod sim_test_smoke;
 #[cfg(feature = "ws")]
 mod sse_replay;

--- a/autumn/tests/sqlite_migrations.rs
+++ b/autumn/tests/sqlite_migrations.rs
@@ -49,6 +49,15 @@ use tower::ServiceExt as _; // for `oneshot`
 /// `.migrations(MIGRATIONS)` stores. It creates the `widgets` table.
 const MIGRATIONS: EmbeddedMigrations = embed_migrations!("tests/fixtures/sqlite_migrations");
 
+/// A multi-migration set (six `CREATE TABLE` steps, each without `IF NOT
+/// EXISTS`) used by the concurrency test. Several migrations widen the
+/// read→plan→apply window so racing migrators genuinely overlap, and a
+/// double-applied step errors hard ("table already exists") — so an unserialized
+/// path reliably surfaces a false failure, while the write-locked path drains the
+/// set exactly once.
+const CONCURRENT_MIGRATIONS: EmbeddedMigrations =
+    embed_migrations!("tests/fixtures/sqlite_migrations_concurrent");
+
 /// The runtime pool type. Under `--features sqlite` `RuntimeConnection` resolves
 /// to `SyncConnectionWrapper<SqliteConnection>`.
 type SqlitePool = Pool<RuntimeConnection>;
@@ -220,5 +229,91 @@ fn shared_cache_in_memory_target_with_registered_migrations_is_rejected() {
         !msg.contains("`file::memory:?cache=shared`"),
         "the corrected message no longer recommends a shared-cache in-memory URL as a remedy \
          (got {msg:?})"
+    );
+}
+
+/// Many concurrent `run_pending_sqlite` calls against the SAME file-backed
+/// database must ALL succeed — the winner applies the pending set once, every
+/// loser queues on the write lock, re-reads an already-drained pending set, and
+/// cleanly no-ops — instead of a loser re-running an already-applied migration
+/// and reporting a false failure (issue #2065, deferred from PR #2062).
+///
+/// Before the shared `BEGIN IMMEDIATE` serialization primitive, the
+/// list→plan→apply window was unlocked, so racing migrators read the same empty
+/// applied set and double-applied the same `up.sql`, and the loser surfaced a
+/// failed migration. The single-file write lock now serializes the whole
+/// sequence, so a racer that waits and then finds nothing pending is a clean
+/// no-op, never an error.
+#[test]
+fn concurrent_run_pending_sqlite_serializes_without_false_failure() {
+    use std::sync::{Arc, Barrier};
+
+    // Enough racers to reliably force the wait-on-lock path.
+    const THREADS: usize = 8;
+    // The six-step set widens the race window; a double-applied step errors.
+    const EXPECTED_APPLIED: usize = 6;
+
+    // A file target so every migration connection contends on the same on-disk
+    // write lock (a `:memory:` target is private per connection — no contention).
+    let tmp = tempfile::TempDir::new().expect("temp dir");
+    let db_path = tmp.path().join("concurrent.db");
+    let url: Arc<str> = Arc::from(format!("sqlite://{}", db_path.display()));
+
+    // A `Barrier` releases every racer together so their read→apply windows
+    // genuinely overlap.
+    let barrier = Arc::new(Barrier::new(THREADS));
+
+    // Spawn ALL threads before joining ANY: collecting the handles first is
+    // load-bearing (fusing the spawn+join iterators would join each thread
+    // before spawning the next, serialising the racers and defeating the test).
+    #[allow(clippy::needless_collect)]
+    let handles: Vec<_> = (0..THREADS)
+        .map(|_| {
+            let url = Arc::clone(&url);
+            let barrier = Arc::clone(&barrier);
+            std::thread::spawn(move || {
+                barrier.wait();
+                run_pending_sqlite(&url, CONCURRENT_MIGRATIONS)
+            })
+        })
+        .collect();
+
+    let results: Vec<Result<_, _>> = handles
+        .into_iter()
+        .map(|h| h.join().expect("migration thread did not panic"))
+        .collect();
+
+    // (1) No racer reports a false failure.
+    for (i, result) in results.iter().enumerate() {
+        assert!(
+            result.is_ok(),
+            "concurrent migrator {i} reported a failure instead of a clean no-op: {:?}",
+            result.as_ref().err()
+        );
+    }
+
+    // (2) Every registered migration is applied EXACTLY once across all racers:
+    //     the winner (holding the write lock) drains the whole set, and every
+    //     loser then reads an already-empty pending set. A double-applied step
+    //     under an unserialized path would instead error above.
+    let per_thread_applied: Vec<usize> = results
+        .iter()
+        .map(|r| r.as_ref().expect("ok checked above").applied.len())
+        .collect();
+    let total_applied: usize = per_thread_applied.iter().sum();
+    assert_eq!(
+        total_applied, EXPECTED_APPLIED,
+        "each registered migration must apply exactly once across all racers \
+         (per-thread applied counts = {per_thread_applied:?})"
+    );
+
+    // (3) The schema converged and the migrations are recorded: a fresh
+    //     `run_pending_sqlite` now finds nothing pending (idempotent no-op).
+    let after = run_pending_sqlite(&url, CONCURRENT_MIGRATIONS)
+        .expect("a post-convergence run is a clean no-op, not a failure");
+    assert!(
+        after.applied.is_empty(),
+        "after the concurrent batch converged, re-running applies nothing (got {:?})",
+        after.applied
     );
 }


### PR DESCRIPTION
Closes #2065. Deferred follow-up from #2062 (the legacy `autumn migrate` → SQLite backend-flip), where this cross-cutting serialization change was declined as out-of-scope for the port.

## Problem

The two SQLite migration entry points ran **unlocked**:
- `autumn/src/migrate.rs` — `run_pending_sqlite(...)` (up)
- `autumn/src/migrate.rs` — `revert_user_migrations_sqlite(...)` (down)

Each reads its pending/applied set, plans, and applies/reverts without serializing that read→plan→apply/revert window. Under two concurrent `autumn migrate` (or `autumn schema migrate`) processes against the same SQLite file, both can read the same set before either writes, so the loser re-runs an already-applied `up.sql` (or an already-reverted `down.sql`) and **reports a false migration/rollback failure**. Diesel's per-migration transaction prevents *corruption* (the loser fails and rolls back atomically), so this was a reported-failure/robustness gap, not data corruption.

## Fix

One shared serialization primitive, `with_sqlite_migration_lock`, wrapping **both** directions — and therefore both the `migrate` and `schema migrate` verbs and the boot auto-migrate, which all route through these two functions. It takes the SQLite write lock up front with `BEGIN IMMEDIATE` and holds it across the whole list→plan→apply/revert sequence, then commits.

The critical constraint (a naive outer `BEGIN IMMEDIATE` collides with diesel's per-migration `BEGIN` → "cannot start a transaction within a transaction") is handled by issuing the lock **through** diesel's `AnsiTransactionManager` (`begin_transaction_sql`), so the manager's depth counter advances 0 → 1 and each per-migration `self.transaction(...)` nests as a `SAVEPOINT` instead of a raw nested `BEGIN`. This is the same technique already used by `db::scoped_immediate_transaction`. A concurrent migrator queues on the connection's existing `busy_timeout`, re-reads an already-drained set, and cleanly no-ops.

There is still **no Postgres advisory lock** on the SQLite path (issues #1999 / #2036 precedent) — SQLite has no such primitive; the on-disk write lock is the entire cross-process serialization mechanism. The now-inaccurate "no cross-process serialization is needed" doc comments on both functions are updated to describe the intra-run write lock while keeping the accurate "no pg advisory lock" note.

## Behaviour

- **Single-process** migrate/revert is unchanged: the same migrations apply/revert to the same end state.
- On a **mid-sequence failure** the outer transaction rolls back, so a batch is atomic (identical on the success path; a partial-failure now leaves the applied set unchanged rather than partially advanced — see the doc comment).

## Test

`concurrent_run_pending_sqlite_serializes_without_false_failure` (in the existing `sqlite`-gated `tests/sqlite_migrations.rs` isolated binary — the natural home; the consolidated pg-only `integration_tests` binary cannot compile SQLite code, and the `sqlite-runtime` CI job already runs this `[[test]]` target) spawns 8 barrier-released threads all running `run_pending_sqlite` against one temp file with a new six-step fixture (`tests/fixtures/sqlite_migrations_concurrent/`, each step a bare `CREATE TABLE` so a double-apply errors). It asserts no racer reports a failure, that the set applies exactly once across all racers, and that a follow-up run is a clean no-op. Verified it **fails without the lock** and passes with it.

## Gates (local)

- `cargo build -p autumn-web --features sqlite --lib` — pass
- `cargo test -p autumn-web --features sqlite --test sqlite_migrations` — pass (4/4)
- `cargo +1.97.0 clippy -p autumn-web --features sqlite --lib -- -D warnings` — pass (the CI sqlite-runtime lib-clippy gate)
- `cargo fmt --all -- --check` — clean (this branch also carries the trivial fmt-only fix for the pre-existing #2107 baseline red at `sim.rs` / `mod.rs`)
- `cargo test --doc -p autumn-web` — pass (default/pg features)

## Note

The second commit is a trivial fmt-only carry of the pre-existing `cargo fmt --all --check` baseline red introduced by #2107 (trailing whitespace + a mod-ordering slip), so this PR's CI Lint can pass; no behaviour change.

`[no-plugin]`