### PR TITLE
docs: add aggregate queries guide and bookmarks /stats roll-up route (#2099)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **docs:** an **aggregate queries** guide (`docs/guide/aggregates.md`) documenting GROUP BY roll-ups, paired with a runnable `GET /stats` roll-up route in the `bookmarks` example (#2099). [no-plugin]
 - **docs/examples:** documented the `autumn-media-plugin` media subsystem
   (broadcast + mesh rooms + MediaMTX). Adds the `docs/guide/media.md` guide
   (install/mount, `MediaConfig` profile loading, the `RoomService`/`RoomStore`

--- a/docs/guide/aggregates.md
+++ b/docs/guide/aggregates.md
@@ -1,0 +1,228 @@
+# Aggregate Queries
+
+Dashboards and stats pages rarely want individual rows — they want *roll-ups*:
+how many bookmarks per tag, the total score per post, the average order value per
+customer, a count of sign-ups per day. Autumn expresses these `GROUP BY`
+aggregates **declaratively on a `#[repository]` trait**: you name a method like
+`count_grouped_by_tag`, and the macro generates a typed, lazy query builder that
+runs the `COUNT`/`SUM`/`AVG`/`MIN`/`MAX` in the database and hands you back a
+`Vec<(key, value)>`.
+
+No hand-written SQL, no loading every row and folding in memory, and no untyped
+`sql_query` — the group key and aggregate value are real Rust types the compiler
+checks. The generated query also composes the repository's soft-delete filter,
+tenant scoping, and read-replica routing exactly like a plain `count`, so a
+roll-up inherits all of that for free.
+
+The full API lives in [`autumn_web::aggregate`]; this guide builds it up against
+the [`bookmarks`](../../examples/bookmarks) example, whose `GET /stats` route runs
+two real roll-ups.
+
+## Prerequisites
+
+Grouped aggregates ride on `#[autumn_web::repository]`, so you need the default
+Postgres/Diesel repository stack — the same setup any Autumn app with a
+`#[model]` and a `#[repository]` already has. Nothing extra to enable: the
+`aggregate` module is part of the core `autumn-web` crate.
+
+```toml
+[dependencies]
+autumn-web = { version = "0.6", features = ["openapi"] }
+```
+
+The `DateBucket` type used for time-series roll-ups is at
+`autumn_web::aggregate::DateBucket`; the builder types are re-exported from the
+same module.
+
+## Declaring a roll-up
+
+Aggregates are declared as extra methods on your existing `#[repository]` trait.
+The **method name is the query** — the macro parses it into a grouped aggregate:
+
+- `count_grouped_by_<col>` → `COUNT(*) GROUP BY <col>`
+- `sum_<col>_grouped_by_<group_col>` → `SUM(<col>) GROUP BY <group_col>`
+- `avg_<col>_` / `min_<col>_` / `max_<col>_grouped_by_<group_col>` likewise
+
+The return type `Vec<(K, V)>` names the group-key type `K` and the aggregate
+value type `V`. In the bookmarks example (`src/repositories/bookmark.rs`) we add
+two:
+
+```rust,ignore
+#[autumn_web::repository(Bookmark, api = "/api/bookmarks")]
+pub trait BookmarkRepository {
+    fn find_by_tag(tag: String) -> Vec<Bookmark>;
+    fn find_by_alive(alive: bool) -> Vec<Bookmark>;
+
+    /// `COUNT(*) GROUP BY tag` → one `(tag, count)` pair per distinct tag.
+    fn count_grouped_by_tag() -> Vec<(String, i64)>;
+    /// `COUNT(*) GROUP BY created_at` → raw per-timestamp counts, later
+    /// rolled into a daily series with `.bucket(DateBucket::Day)`.
+    fn count_grouped_by_created_at() -> Vec<(chrono::NaiveDateTime, i64)>;
+}
+```
+
+Each declared method becomes an **inherent method** on the generated
+`PgBookmarkRepository` struct that returns a lazy
+[`GroupedAggregate`](autumn_web::aggregate::GroupedAggregate) builder (mirroring
+`find_in_batches`). Nothing touches the database until you call the terminal
+`.load()`.
+
+## Running the query
+
+Call the generated method, then `.load().await` to execute:
+
+```rust,ignore
+// COUNT(*) GROUP BY tag → Vec<(tag, count)>, one pair per distinct tag.
+let by_tag: Vec<(String, i64)> = repo.count_grouped_by_tag().load().await?;
+```
+
+The result is one `(key, value)` pair per group. An empty table yields an empty
+`Vec`; the database decides the group order unless you ask for one (next
+section).
+
+`COUNT` values are a plain `i64`. `SUM`/`AVG`/`MIN`/`MAX` are **null-safe** and
+so wrap their value in `Option`: a group whose aggregated column is entirely
+`NULL` comes back as `(key, None)`, never a fabricated `Some(0)`. See
+[Value and key types](#value-and-key-types) for the full table.
+
+## Top-N: order and limit
+
+To rank groups — the classic "top 10 tags" — order by the aggregated value and
+cap the result. Both are chainable builder methods, and the ordering/limit run in
+the database (you get exactly N rows back, not the whole set sorted in Rust):
+
+```rust,ignore
+// Top 10 tags by bookmark count, largest first.
+let top_tags: Vec<(String, i64)> = repo
+    .count_grouped_by_tag()
+    .order_by_aggregate_desc()
+    .limit(10)
+    .load()
+    .await?;
+```
+
+Use [`order_by_aggregate_asc`](autumn_web::aggregate::GroupedAggregate::order_by_aggregate_asc)
+for smallest-first. The ordering is on the *aggregate value*, not the group key —
+that is what makes it a leaderboard rather than an alphabetical list.
+
+## Filtering before the group
+
+[`filter_eq`](autumn_web::aggregate::GroupedAggregate::filter_eq) and
+[`filter_range`](autumn_web::aggregate::GroupedAggregate::filter_range) scope
+which rows feed the aggregate — they apply **before** grouping, and both bounds
+are bound as query parameters (never string-interpolated):
+
+```rust,ignore
+// Only bookmarks created in a window feed the counts.
+let recent: Vec<(chrono::NaiveDateTime, i64)> = repo
+    .count_grouped_by_created_at()
+    .filter_range(window_start, window_end)
+    .load()
+    .await?;
+```
+
+The predicate is always on the **raw** group column, so a range over timestamps
+windows the input to a time-series roll-up.
+
+## Time series with `DateBucket`
+
+Grouping on a raw `created_at` timestamp gives one bucket per distinct instant —
+almost never what you want. [`bucket`](autumn_web::aggregate::GroupedAggregate::bucket)
+groups by `date_trunc('<unit>', <col>)` instead, collapsing the timestamps into
+`Day`, `Week`, or `Month` buckets keyed by each bucket's start:
+
+```rust,ignore
+use autumn_web::aggregate::DateBucket;
+
+let window_end = chrono::Utc::now().naive_utc();
+let window_start = window_end - chrono::Duration::days(30);
+
+// Bookmarks added per day over the trailing 30 days.
+let mut per_day: Vec<(chrono::NaiveDateTime, i64)> = repo
+    .count_grouped_by_created_at()
+    .bucket(DateBucket::Day)
+    .filter_range(window_start, window_end)
+    .load()
+    .await?;
+
+// The database groups in no defined order; sort into a chronological series.
+per_day.sort_by_key(|(day, _)| *day);
+```
+
+`.bucket()` is **type-gated**: it exists only when the group key is a timestamp
+type (`NaiveDateTime` for `timestamp`, `DateTime<Utc>` for `timestamptz`). A
+non-temporal key — like the `String` tag from `count_grouped_by_tag` — has no
+`.bucket()` method at all, so an invalid `date_trunc` on a non-timestamp column is
+a compile error rather than a runtime failure. As shown above, `filter_range`
+still windows the **raw** timestamps, which is exactly what bounds a bucketed
+series.
+
+## Value and key types
+
+The macro reads `K` and `V` straight from the declared `Vec<(K, V)>` and bakes in
+the matching Postgres types:
+
+| method                 | `V`                              |
+|------------------------|----------------------------------|
+| `count_grouped_by_`    | `i64`                            |
+| `sum_*_grouped_by_`    | `Option<T>` (`T` = column type)  |
+| `min_*` / `max_*`      | `Option<T>`                      |
+| `avg_*_grouped_by_`    | `Option<f64>`                    |
+
+`K` is the group column's Rust type (or, under `.bucket()`, the bucket-start
+timestamp). A nullable group-key **type** (`K = Option<T>`) is rejected at
+compile time; a nullable group **column** is fine — rows with a `NULL` key are
+simply excluded (the generated SQL guards with `IS NOT NULL`). Nullable *value*
+columns are fine and drive the `→ None` behaviour above.
+
+## Scoping comes for free
+
+A grouped aggregate acquires its connection through the same read-route helper as
+`count`, and composes the same predicates:
+
+- **Soft delete** — a `soft_delete` repository excludes trashed rows from the
+  aggregate (`deleted_at IS NULL`), matching every other finder.
+- **Multi-tenancy** — a `tenant_scoped` repository only aggregates the active
+  tenant's rows. (Because `SUM`/`AVG`/`MIN`/`MAX` cannot be merged across shards,
+  a sharded tenant repository used via `across_tenants()` rejects grouped
+  aggregates rather than returning a per-shard-partial answer.)
+- **Read replicas** — the query routes to the read role, so a replica-routed
+  repository rolls up off the replica.
+
+## Encrypted columns
+
+Grouped aggregates are **not** available on an `#[encrypted(...)]` column, as
+either the group key or the aggregated value: the column stores ciphertext, so
+grouping would bucket by ciphertext and an equality filter would compare
+plaintext against ciphertext and match nothing. Such a method returns an error at
+call time — group on (or aggregate over) a non-encrypted column, or drop to a raw
+query.
+
+## Try it in the bookmarks example
+
+The [`bookmarks`](../../examples/bookmarks) example wires both roll-ups into a
+single `GET /bookmarks/stats` route (in `src/routes/bookmarks.rs`) that renders a
+**Top tags** table (`count_grouped_by_tag` +
+`.order_by_aggregate_desc().limit(...)`) and an **Added per day** series
+(`count_grouped_by_created_at` + `.bucket(DateBucket::Day).filter_range(...)`).
+With the app running and some seeded data:
+
+```bash
+# Populate faked bookmarks, then open the stats page.
+autumn seed --count 200 --model Bookmark
+curl -fsS http://localhost:3000/bookmarks/stats
+```
+
+## When *not* to reach for a grouped aggregate
+
+- **A single scalar** — a plain total or one average across the whole table is a
+  `count`/`sum` on the repository, not a `GROUP BY`.
+- **Per-row data you then group in the template** — if you need the individual
+  rows anyway, load them once and group in Rust rather than issuing a second
+  aggregate query.
+- **Multi-column composite keys or `HAVING`** — the declarative form groups on a
+  single column; a genuinely multi-dimensional cube wants a raw query.
+
+Grouped aggregates earn their keep exactly when you want *one typed roll-up per
+group*, computed in the database, with soft-delete/tenant/replica scoping applied
+automatically.

--- a/examples/bookmarks/README.md
+++ b/examples/bookmarks/README.md
@@ -58,6 +58,7 @@ The server starts at <http://localhost:3000>.
 | GET    | `/`          | Redirect to `/bookmarks`     |
 | GET    | `/bookmarks` | List all bookmarks           |
 | GET    | `/bookmarks/export.csv` | Download all bookmarks as CSV (typed `Download`, Range/206) |
+| GET    | `/bookmarks/stats` | Grouped-aggregate roll-ups: top tags + added-per-day series |
 | GET    | `/bookmarks/{id}` | Show one bookmark        |
 | GET    | `/bookmarks/tag/{tag}` | Filter bookmarks by tag |
 | GET    | `/bookmarks/new` | Add bookmark form        |

--- a/examples/bookmarks/src/main.rs
+++ b/examples/bookmarks/src/main.rs
@@ -24,6 +24,9 @@ async fn main() {
             home,
             routes::bookmarks::index,
             routes::bookmarks::export_csv,
+            // Grouped-aggregate roll-up page (#1364): per-tag counts and a
+            // day-bucketed activity series, both via the aggregate API.
+            routes::bookmarks::stats,
             routes::bookmarks::search,
             routes::bookmarks::tags_autocomplete,
             routes::bookmarks::show,

--- a/examples/bookmarks/src/repositories/bookmark.rs
+++ b/examples/bookmarks/src/repositories/bookmark.rs
@@ -11,4 +11,16 @@ use crate::schema::bookmarks;
 pub trait BookmarkRepository {
     fn find_by_tag(tag: String) -> Vec<Bookmark>;
     fn find_by_alive(alive: bool) -> Vec<Bookmark>;
+
+    // ── Grouped aggregate roll-ups (issue #1364), powering `GET /stats` ──────
+    //
+    // Each `*_grouped_by_*` method becomes an inherent method on the generated
+    // `PgBookmarkRepository` returning a lazy `GroupedAggregate` builder; nothing
+    // runs until `.load()`. See `docs/guide/aggregates.md`.
+
+    /// `COUNT(*) GROUP BY tag` → one `(tag, count)` pair per distinct tag.
+    fn count_grouped_by_tag() -> Vec<(String, i64)>;
+    /// `COUNT(*) GROUP BY created_at` → the raw per-timestamp counts, bucketed
+    /// into a daily time series by the `/stats` route via `.bucket(DateBucket::Day)`.
+    fn count_grouped_by_created_at() -> Vec<(chrono::NaiveDateTime, i64)>;
 }

--- a/examples/bookmarks/src/routes/bookmarks.rs
+++ b/examples/bookmarks/src/routes/bookmarks.rs
@@ -20,6 +20,7 @@
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
 
+use autumn_web::aggregate::DateBucket;
 use autumn_web::download::Download;
 use autumn_web::extract::{Form, Path};
 use autumn_web::form::Changeset;
@@ -163,6 +164,10 @@ pub async fn index(repo: PgBookmarkRepository) -> AutumnResult<Markup> {
                       class="border border-gray-300 text-gray-600 px-4 py-2 rounded hover:bg-gray-100" {
                         "Export CSV"
                     }
+                    a href="/bookmarks/stats"
+                      class="border border-gray-300 text-gray-600 px-4 py-2 rounded hover:bg-gray-100" {
+                        "Stats"
+                    }
                 }
             }
             // ── Active search widget ──────────────────────────────────────
@@ -237,6 +242,113 @@ pub async fn export_csv(repo: PgBookmarkRepository, headers: HeaderMap) -> Autum
         .etag(etag)
         .into_response_ranged(&headers)
         .await)
+}
+
+// ── Stats roll-ups (grouped aggregate queries) ────────────────────────────────
+
+/// Number of most-popular tags shown on the stats page.
+const TOP_TAGS: i64 = 10;
+/// Trailing window (days) for the "added per day" time series.
+const ACTIVITY_WINDOW_DAYS: i64 = 30;
+
+/// Bookmark statistics driven entirely by grouped aggregate roll-ups.
+///
+/// Runs two `GROUP BY` queries through the generated aggregate builders on
+/// [`PgBookmarkRepository`] (no hand-written SQL, no in-memory folding):
+///
+/// - **Per tag** — `count_grouped_by_tag()` with
+///   [`order_by_aggregate_desc`](autumn_web::aggregate::GroupedAggregate::order_by_aggregate_desc)
+///   + [`limit`](autumn_web::aggregate::GroupedAggregate::limit) for the top-N
+///   tags by bookmark count.
+/// - **Added per day** — `count_grouped_by_created_at()` with
+///   [`bucket(DateBucket::Day)`](autumn_web::aggregate::GroupedAggregate::bucket)
+///   to roll the raw `created_at` timestamps into a daily time series, scoped to
+///   the trailing window with
+///   [`filter_range`](autumn_web::aggregate::GroupedAggregate::filter_range).
+///
+/// See `docs/guide/aggregates.md` for the walkthrough behind this route.
+#[get("/bookmarks/stats")]
+pub async fn stats(repo: PgBookmarkRepository) -> AutumnResult<Markup> {
+    // Top tags by bookmark count, largest first: `COUNT(*) GROUP BY tag`
+    // ordered on the aggregate and capped — the whole top-N runs in the DB.
+    let by_tag: Vec<(String, i64)> = repo
+        .count_grouped_by_tag()
+        .order_by_aggregate_desc()
+        .limit(TOP_TAGS)
+        .load()
+        .await?;
+
+    // Daily activity over the trailing window: bucket the raw `created_at`
+    // timestamps into days, keyed by each day's midnight.
+    let window_end = chrono::Utc::now().naive_utc();
+    let window_start = window_end - chrono::Duration::days(ACTIVITY_WINDOW_DAYS);
+    let mut per_day: Vec<(chrono::NaiveDateTime, i64)> = repo
+        .count_grouped_by_created_at()
+        .bucket(DateBucket::Day)
+        .filter_range(window_start, window_end)
+        .load()
+        .await?;
+    // The database groups in no defined order; sort into a chronological series.
+    per_day.sort_by_key(|(day, _)| *day);
+
+    Ok(layout(
+        "Stats",
+        html! {
+            div class="mb-6" {
+                a href="/bookmarks" class="text-sm text-indigo-600 hover:underline" { "Back to list" }
+                h1 class="text-2xl font-bold mt-2" { "Bookmark stats" }
+            }
+
+            section class="mb-8" {
+                h2 class="text-lg font-semibold mb-3" { "Top tags" }
+                @if by_tag.is_empty() {
+                    p class="text-gray-500" { "No bookmarks yet." }
+                } @else {
+                    table class="w-full text-left border border-gray-200 rounded overflow-hidden" {
+                        thead class="bg-gray-100 text-xs uppercase text-gray-600" {
+                            tr { th class="px-4 py-2" { "Tag" } th class="px-4 py-2 text-right" { "Bookmarks" } }
+                        }
+                        tbody {
+                            @for (tag, count) in &by_tag {
+                                tr class="border-t border-gray-100" {
+                                    td class="px-4 py-2" {
+                                        a href=(format!("/bookmarks/tag/{tag}"))
+                                          class="text-indigo-600 hover:underline" { (tag) }
+                                    }
+                                    td class="px-4 py-2 text-right tabular-nums" { (count) }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            section {
+                h2 class="text-lg font-semibold mb-3" {
+                    "Added per day " span class="text-sm text-gray-500 font-normal" {
+                        "(last " (ACTIVITY_WINDOW_DAYS) " days)"
+                    }
+                }
+                @if per_day.is_empty() {
+                    p class="text-gray-500" { "No bookmarks added in this window." }
+                } @else {
+                    table class="w-full text-left border border-gray-200 rounded overflow-hidden" {
+                        thead class="bg-gray-100 text-xs uppercase text-gray-600" {
+                            tr { th class="px-4 py-2" { "Day" } th class="px-4 py-2 text-right" { "Added" } }
+                        }
+                        tbody {
+                            @for (day, count) in &per_day {
+                                tr class="border-t border-gray-100" {
+                                    td class="px-4 py-2 tabular-nums" { (day.format("%Y-%m-%d")) }
+                                    td class="px-4 py-2 text-right tabular-nums" { (count) }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+    ))
 }
 
 #[get("/bookmarks/{id}")]


### PR DESCRIPTION
## Before

Aggregate queries (GROUP BY roll-ups) — `count`/`sum`/`avg`/`min`/`max` grouped by a column, declared on a `#[repository]` trait — were new in 0.6.0 but documented only as rustdoc in `autumn/src/aggregate.rs`. There was no guide and no runnable example a reader could copy from.

## After

- A new **`docs/guide/aggregates.md`** guide covering the whole surface: declaring a roll-up by method name (`count_grouped_by_<col>`, `sum_<col>_grouped_by_<group_col>`, …), the lazy `GroupedAggregate` builder and its terminal `.load()`, top-N via `order_by_aggregate_desc().limit(n)`, pre-group `filter_eq`/`filter_range`, `DateBucket` day/week/month time series, the value/key type rules, and the automatic soft-delete / tenant / read-replica scoping.
- A runnable **`GET /bookmarks/stats`** route in the `bookmarks` example that runs two real roll-ups and renders them as Maud tables. The guide cross-links the example.

## How

The example declares two aggregate methods on the existing `BookmarkRepository` trait — `count_grouped_by_tag()` and `count_grouped_by_created_at()` — which the `#[repository]` macro turns into inherent aggregate-builder methods on `PgBookmarkRepository`. The `stats` handler renders a **Top tags** table (`count_grouped_by_tag().order_by_aggregate_desc().limit(10)`) and an **Added per day** activity series (`count_grouped_by_created_at().bucket(DateBucket::Day).filter_range(start, end)`) — no hand-written SQL. The route is registered in `main.rs`, gets a discoverable "Stats" link on the index page, and a row in the README route table. The guide's code samples are lifted from this route.

Addresses #2099 (Gap 6).

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xpawwz5r7TxagGBq668xr1)_