### PR TITLE
sim-testing: always! / sometimes! assertion macros + non-vacuity registry (W6, #1797)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **sim-testing:** add the `always!` / `sometimes!` simulation assertion macros
+  (W6 op-driver assertion core, #1797) — hard-invariant + reachability assertions
+  for `#[sim_test]`, with a non-vacuity registry the forthcoming sim-sweep
+  aggregates. `always!(cond[, "fmt", …])` panics on a false invariant with a
+  greppable message (the `#[sim_test]` harness prints the `AUTUMN_SIM_SEED=…`
+  replay line); `sometimes!(cond, "label")` records a reachability target in a
+  thread-local registry (observed vs satisfied) that `Sim::from_seed` resets per
+  seed, exposed via `sometimes_snapshot` / `assert_all_sometimes_satisfied` for
+  the sweep to fail a green-but-vacuous run. [no-plugin]
+
 - **docs/examples:** documented the `autumn-media-plugin` media subsystem
   (broadcast + mesh rooms + MediaMTX). Adds the `docs/guide/media.md` guide
   (install/mount, `MediaConfig` profile loading, the `RoomService`/`RoomStore`

--- a/autumn/Cargo.toml
+++ b/autumn/Cargo.toml
@@ -631,6 +631,17 @@ path = "tests/sim_sqlite_substrate.rs"
 name = "sim_sqlite_integration"
 path = "tests/sim_sqlite_integration.rs"
 
+# W6 semantic core (#1797): the `always!` / `sometimes!` assertion macros and the
+# thread-local non-vacuity registry. Isolated `[[test]]` binary because it drives
+# the process's thread-local reachability registry (and asserts `Sim::from_seed`
+# resets it); the thread-local gives per-test-thread isolation, and keeping it
+# standalone avoids any coupling to the consolidated binary's concurrent tests.
+# Needs no non-default feature, so the `cargo test --workspace` CI step compiles
+# and runs it automatically — no workflow edit required.
+[[test]]
+name = "sim_assert"
+path = "tests/sim_assert.rs"
+
 # Isolated: sets process-wide proxy env vars (HTTP_PROXY/HTTPS_PROXY/ALL_PROXY)
 # to verify pinned SSRF-safe clients bypass env proxies. Cannot share the
 # consolidated binary — those vars would race the inline network tests.

--- a/autumn/src/sim.rs
+++ b/autumn/src/sim.rs
@@ -76,6 +76,18 @@ use crate::time::TickingClock;
 #[doc(hidden)]
 pub mod substrate;
 
+// The W6 semantic core (issue #1797): the `always!` / `sometimes!` assertion
+// macros and the thread-local non-vacuity registry. Public (documented) module —
+// the macros are `#[macro_export]`ed at the crate root (`autumn_web::always` /
+// `autumn_web::sometimes`), and their hidden plumbing plus the sweep-facing
+// registry API live here.
+pub mod assert;
+
+pub use assert::{
+    SometimesRegistry, assert_all_sometimes_satisfied, reset_sometimes_registry,
+    sometimes_snapshot, sometimes_unsatisfied,
+};
+
 /// The fixed, deterministic epoch the simulation clock starts at:
 /// `2020-01-01T00:00:00Z`.
 ///
@@ -129,6 +141,10 @@ impl Sim {
     /// arrives in W2 via [`SimApp`].
     #[must_use]
     pub fn from_seed(seed: u64) -> Self {
+        // Each seed run starts with a clean reachability registry, so the sweep
+        // can attribute observed/satisfied `sometimes!` labels to exactly one
+        // seed before folding them into its cross-seed aggregate (W6, #1797).
+        assert::reset_sometimes_registry();
         let epoch = Utc
             .timestamp_opt(SIM_EPOCH_UNIX_SECS, 0)
             .single()

--- a/autumn/src/sim/assert.rs
+++ b/autumn/src/sim/assert.rs
@@ -1,0 +1,290 @@
+//! Simulation assertion macros — [`always!`](crate::always) /
+//! [`sometimes!`](crate::sometimes) — plus the per-run non-vacuity registry
+//! (sim-testing W6, issue #1797).
+//!
+//! This is the **semantic core** of the op-driver stack: the two assertions a
+//! sim-test author reaches for, and the thread-local reachability registry the
+//! forthcoming `sim-sweep` binary aggregates across seeds to prove a green run
+//! was *non-vacuous* (every reachability target a run claimed to observe was
+//! actually satisfied at least once).
+//!
+//! # The two assertions
+//!
+//! - [`always!`](crate::always) is a **hard invariant**. `always!(cond)` (or
+//!   `always!(cond, "fmt {}", args…)`) panics the instant `cond` is false. Under
+//!   [`#[sim_test]`](crate::sim_test) the panic is caught, the copy-pasteable
+//!   `AUTUMN_SIM_SEED=…` replay line is printed, and the test fails — so an
+//!   `always!` violation reproduces bit-for-bit. The panic message is
+//!   deliberately greppable (`always! invariant violated`) and carries the
+//!   stringified condition plus any caller message.
+//!
+//! - [`sometimes!`](crate::sometimes) is a **reachability target**.
+//!   `sometimes!(cond, "label")` records `"label"` as *observed* in the per-run
+//!   registry, and marks it *satisfied* when `cond` is true. Within a single
+//!   seed run a reachability target may legitimately never fire, so a
+//!   [`#[sim_test]`](crate::sim_test) does **not** auto-fail on an unsatisfied
+//!   label — that would make reachability assertions useless. Instead the
+//!   registry is exposed for the sweep to aggregate across many seeds and fail
+//!   the sweep if some label was seen but never satisfied by *any* seed
+//!   (non-vacuous green). For an explicit single-run check, call
+//!   [`assert_all_sometimes_satisfied`].
+//!
+//! # Registry model (thread-local, deterministic)
+//!
+//! The registry is a thread-local pair of [`BTreeSet`]s (observed / satisfied),
+//! keyed by label string. `BTreeSet` (not `HashSet`) keeps panic-message and
+//! snapshot ordering stable across runs, which the determinism contract
+//! requires.
+//!
+//! Thread-local is the correct isolation boundary under the test harness: libtest
+//! runs each `#[test]` on its own thread, so two tests touching the global
+//! registry concurrently never interfere — each observes its own thread's
+//! registry. [`Sim::from_seed`](crate::sim::Sim::from_seed) resets the current
+//! thread's registry so every seed run starts clean, and the sweep (which runs
+//! seeds sequentially on one thread) reads [`sometimes_snapshot`] after each seed
+//! before resetting for the next.
+
+use std::cell::RefCell;
+use std::collections::BTreeSet;
+
+thread_local! {
+    /// The current thread's reachability registry. One per test thread, so
+    /// concurrent tests never contend (see the module docs).
+    static SOMETIMES_REGISTRY: RefCell<SometimesRegistry> =
+        const { RefCell::new(SometimesRegistry::new()) };
+}
+
+/// The per-run reachability registry backing [`sometimes!`](crate::sometimes).
+///
+/// Tracks two label sets: every label **observed** (a `sometimes!` was reached)
+/// and the subset that was **satisfied** (its condition was true at least once).
+/// A label that is observed but never satisfied is the non-vacuity signal the
+/// sweep fails on.
+#[derive(Debug, Default, Clone)]
+pub struct SometimesRegistry {
+    observed: BTreeSet<String>,
+    satisfied: BTreeSet<String>,
+}
+
+impl SometimesRegistry {
+    /// Construct an empty registry.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            observed: BTreeSet::new(),
+            satisfied: BTreeSet::new(),
+        }
+    }
+
+    /// Record that `label` was observed, marking it satisfied when `satisfied`.
+    fn observe(&mut self, label: &str, satisfied: bool) {
+        self.observed.insert(label.to_owned());
+        if satisfied {
+            self.satisfied.insert(label.to_owned());
+        }
+    }
+
+    /// The labels that were observed but never satisfied (in stable sorted
+    /// order). An empty set means the run was non-vacuous for every target it
+    /// reached.
+    #[must_use]
+    pub fn unsatisfied(&self) -> BTreeSet<String> {
+        self.observed.difference(&self.satisfied).cloned().collect()
+    }
+
+    /// Every label observed this run (in stable sorted order).
+    #[must_use]
+    pub const fn observed(&self) -> &BTreeSet<String> {
+        &self.observed
+    }
+
+    /// Every label satisfied this run (in stable sorted order).
+    #[must_use]
+    pub const fn satisfied(&self) -> &BTreeSet<String> {
+        &self.satisfied
+    }
+
+    /// Clear both label sets.
+    fn reset(&mut self) {
+        self.observed.clear();
+        self.satisfied.clear();
+    }
+}
+
+/// Record a [`sometimes!`](crate::sometimes) observation on the current thread's
+/// registry.
+///
+/// Hidden plumbing the [`sometimes!`](crate::sometimes) macro expands to — not a
+/// stable API. Call the macro, not this function.
+#[doc(hidden)]
+pub fn __sometimes_observe(label: &str, satisfied: bool) {
+    SOMETIMES_REGISTRY.with(|registry| registry.borrow_mut().observe(label, satisfied));
+}
+
+/// Reset the current thread's reachability registry to empty.
+///
+/// Called by [`Sim::from_seed`](crate::sim::Sim::from_seed) so each seed run
+/// starts clean, and exposed for the sweep to reset between seeds after reading
+/// its [`sometimes_snapshot`].
+pub fn reset_sometimes_registry() {
+    SOMETIMES_REGISTRY.with(|registry| registry.borrow_mut().reset());
+}
+
+/// Snapshot the current thread's registry as `(observed, satisfied)` label sets.
+///
+/// The sweep reads this after each seed run to fold the seed's reachability into
+/// its cross-seed aggregate before resetting for the next seed.
+#[must_use]
+pub fn sometimes_snapshot() -> (BTreeSet<String>, BTreeSet<String>) {
+    SOMETIMES_REGISTRY.with(|registry| {
+        let registry = registry.borrow();
+        (registry.observed.clone(), registry.satisfied.clone())
+    })
+}
+
+/// The labels observed but never satisfied on the current thread's registry
+/// (stable sorted order).
+///
+/// Convenience over [`sometimes_snapshot`] for callers that only need the
+/// non-vacuity gap.
+#[must_use]
+pub fn sometimes_unsatisfied() -> BTreeSet<String> {
+    SOMETIMES_REGISTRY.with(|registry| registry.borrow().unsatisfied())
+}
+
+/// Assert that every [`sometimes!`](crate::sometimes) label observed this run was
+/// also satisfied at least once, panicking otherwise.
+///
+/// For explicit single-run non-vacuity checks. The cross-seed aggregation the
+/// sweep performs is the more powerful form (a label may need many seeds to be
+/// satisfied once), so a [`#[sim_test]`](crate::sim_test) body typically does
+/// **not** call this directly.
+///
+/// # Panics
+///
+/// Panics, listing the never-satisfied labels in stable sorted order, if any
+/// observed label was never satisfied.
+pub fn assert_all_sometimes_satisfied() {
+    let unsatisfied = sometimes_unsatisfied();
+    assert!(
+        unsatisfied.is_empty(),
+        "sometimes! reachability never satisfied for label(s): {}",
+        unsatisfied.into_iter().collect::<Vec<_>>().join(", "),
+    );
+}
+
+/// Assert a **hard invariant** that must hold at this point in the simulation.
+///
+/// `always!(cond)` panics the instant `cond` is false; `always!(cond, "fmt {}",
+/// args…)` appends a caller-formatted message. Under
+/// [`#[sim_test]`](crate::sim_test) the panic is caught and the deterministic
+/// `AUTUMN_SIM_SEED=…` replay line is printed, so a violation reproduces exactly.
+/// The message always contains the greppable prefix `always! invariant violated`
+/// and the stringified condition.
+///
+/// ```
+/// use autumn_web::always;
+///
+/// always!(1 + 1 == 2);
+/// let balance = 10;
+/// always!(balance >= 0, "balance must never go negative, was {}", balance);
+/// ```
+#[macro_export]
+macro_rules! always {
+    ($cond:expr $(,)?) => {
+        if !$cond {
+            ::std::panic!(
+                "always! invariant violated: `{}`",
+                ::std::stringify!($cond),
+            );
+        }
+    };
+    ($cond:expr, $($arg:tt)+) => {
+        if !$cond {
+            ::std::panic!(
+                "always! invariant violated: `{}`: {}",
+                ::std::stringify!($cond),
+                ::std::format_args!($($arg)+),
+            );
+        }
+    };
+}
+
+/// Record a **reachability target** — an interesting state the simulation should
+/// sometimes reach across seeds.
+///
+/// `sometimes!(cond, "label")` registers `"label"` as observed and marks it
+/// satisfied when `cond` is true, evaluating `cond` exactly once. It never
+/// panics and never fails the current run on its own — an unsatisfied label
+/// fails the *sweep*, which aggregates reachability across many seeds (see the
+/// [module docs](self)). Use [`assert_all_sometimes_satisfied`] for an explicit
+/// single-run check.
+///
+/// ```
+/// use autumn_web::sometimes;
+///
+/// let queued = 5;
+/// sometimes!(queued > 0, "queue-was-non-empty");
+/// sometimes!(queued > 100, "queue-hit-backpressure");
+/// ```
+#[macro_export]
+macro_rules! sometimes {
+    ($cond:expr, $label:expr $(,)?) => {
+        $crate::sim::assert::__sometimes_observe($label, $cond)
+    };
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{SometimesRegistry, reset_sometimes_registry, sometimes_snapshot};
+
+    // The pure registry: observe records observed; satisfied only when the flag
+    // is set; unsatisfied is exactly observed − satisfied, sorted.
+    #[test]
+    fn registry_tracks_observed_and_satisfied() {
+        let mut reg = SometimesRegistry::new();
+        reg.observe("a", true);
+        reg.observe("b", false);
+        reg.observe("c", false);
+        reg.observe("c", true); // a later satisfaction promotes the label
+
+        assert_eq!(
+            reg.observed().iter().cloned().collect::<Vec<_>>(),
+            vec!["a", "b", "c"]
+        );
+        assert_eq!(
+            reg.satisfied().iter().cloned().collect::<Vec<_>>(),
+            vec!["a", "c"]
+        );
+        // Sorted, stable: only "b" was seen but never satisfied.
+        assert_eq!(
+            reg.unsatisfied().into_iter().collect::<Vec<_>>(),
+            vec!["b".to_owned()]
+        );
+    }
+
+    #[test]
+    fn registry_reset_clears_both_sets() {
+        let mut reg = SometimesRegistry::new();
+        reg.observe("x", true);
+        reg.reset();
+        assert!(reg.observed().is_empty());
+        assert!(reg.satisfied().is_empty());
+        assert!(reg.unsatisfied().is_empty());
+    }
+
+    // The thread-local plumbing: this test owns its thread (libtest runs each
+    // `#[test]` on its own thread), so resetting first keeps it hermetic.
+    #[test]
+    fn thread_local_snapshot_reflects_observations() {
+        reset_sometimes_registry();
+        crate::sometimes!(true, "tl-satisfied");
+        crate::sometimes!(false, "tl-observed-only");
+
+        let (observed, satisfied) = sometimes_snapshot();
+        assert!(observed.contains("tl-satisfied"));
+        assert!(observed.contains("tl-observed-only"));
+        assert!(satisfied.contains("tl-satisfied"));
+        assert!(!satisfied.contains("tl-observed-only"));
+    }
+}

--- a/autumn/tests/sim_assert.rs
+++ b/autumn/tests/sim_assert.rs
@@ -1,0 +1,150 @@
+//! `always!` / `sometimes!` assertion macros + non-vacuity registry (W6, #1797).
+//!
+//! Isolated `[[test]]` binary. The reachability registry is a thread-local:
+//! libtest runs each `#[test]` on its own thread, so tests here never contend on
+//! it — but each test that inspects the registry resets it first (or constructs a
+//! fresh `Sim`, which resets it) to stay hermetic regardless of harness threading.
+
+use autumn_web::sim::{
+    Sim, assert_all_sometimes_satisfied, reset_sometimes_registry, sometimes_snapshot,
+    sometimes_unsatisfied,
+};
+use autumn_web::{always, sometimes};
+
+#[test]
+fn always_true_is_a_noop() {
+    always!(true);
+    always!(1 + 1 == 2);
+    always!(2 > 1, "formatted {} arg", 42);
+}
+
+#[test]
+fn always_false_panics_with_greppable_message() {
+    let payload = std::panic::catch_unwind(|| {
+        always!(false);
+    })
+    .expect_err("always!(false) must panic");
+    let msg = payload
+        .downcast_ref::<String>()
+        .cloned()
+        .or_else(|| payload.downcast_ref::<&str>().map(|s| (*s).to_owned()))
+        .expect("panic payload should be a string");
+    assert!(
+        msg.contains("always! invariant violated"),
+        "message must be greppable: {msg}"
+    );
+    assert!(
+        msg.contains("false"),
+        "message must include the stringified condition: {msg}"
+    );
+}
+
+#[test]
+fn always_false_with_format_args_includes_user_message() {
+    let balance = -3;
+    let payload = std::panic::catch_unwind(|| {
+        always!(balance >= 0, "balance went negative: {}", balance);
+    })
+    .expect_err("always! with a false condition must panic");
+    let msg = payload
+        .downcast_ref::<String>()
+        .cloned()
+        .or_else(|| payload.downcast_ref::<&str>().map(|s| (*s).to_owned()))
+        .expect("panic payload should be a string");
+    assert!(
+        msg.contains("always! invariant violated"),
+        "message must be greppable: {msg}"
+    );
+    assert!(
+        msg.contains("balance went negative: -3"),
+        "message must include the formatted user message: {msg}"
+    );
+}
+
+#[test]
+fn sometimes_records_satisfied_and_observed_only() {
+    reset_sometimes_registry();
+    sometimes!(true, "satisfied-label");
+    sometimes!(false, "observed-only-label");
+
+    let (observed, satisfied) = sometimes_snapshot();
+    assert!(observed.contains("satisfied-label"));
+    assert!(observed.contains("observed-only-label"));
+    assert!(satisfied.contains("satisfied-label"));
+    assert!(!satisfied.contains("observed-only-label"));
+
+    // The non-vacuity gap is exactly the observed-but-never-satisfied label.
+    assert_eq!(
+        sometimes_unsatisfied().into_iter().collect::<Vec<_>>(),
+        vec!["observed-only-label".to_owned()]
+    );
+}
+
+#[test]
+fn sometimes_evaluates_condition_once() {
+    reset_sometimes_registry();
+    let mut calls = 0;
+    sometimes!(
+        {
+            calls += 1;
+            true
+        },
+        "counts-once"
+    );
+    assert_eq!(
+        calls, 1,
+        "sometimes! must evaluate its condition exactly once"
+    );
+}
+
+#[test]
+fn from_seed_resets_registry_between_runs() {
+    // First "seed run": observe a label but leave it unsatisfied.
+    let _first = Sim::from_seed(1);
+    sometimes!(false, "leaked-across-seeds");
+    assert!(sometimes_snapshot().0.contains("leaked-across-seeds"));
+
+    // Constructing the next Sim resets the registry — a fresh seed starts clean,
+    // so the prior seed's labels never leak into this one.
+    let _second = Sim::from_seed(2);
+    let (observed, satisfied) = sometimes_snapshot();
+    assert!(
+        observed.is_empty(),
+        "from_seed must clear observed labels: {observed:?}"
+    );
+    assert!(
+        satisfied.is_empty(),
+        "from_seed must clear satisfied labels: {satisfied:?}"
+    );
+}
+
+#[test]
+fn assert_all_sometimes_satisfied_passes_when_all_satisfied() {
+    reset_sometimes_registry();
+    sometimes!(true, "a");
+    sometimes!(true, "b");
+    assert_all_sometimes_satisfied(); // must not panic
+}
+
+#[test]
+fn assert_all_sometimes_satisfied_panics_on_unsatisfied_label() {
+    reset_sometimes_registry();
+    sometimes!(true, "green-ok");
+    sometimes!(false, "never-fired");
+
+    let payload = std::panic::catch_unwind(assert_all_sometimes_satisfied)
+        .expect_err("an observed-but-unsatisfied label must fail the assertion");
+    let msg = payload
+        .downcast_ref::<String>()
+        .cloned()
+        .or_else(|| payload.downcast_ref::<&str>().map(|s| (*s).to_owned()))
+        .expect("panic payload should be a string");
+    assert!(
+        msg.contains("never-fired"),
+        "panic must name the unsatisfied label: {msg}"
+    );
+    assert!(
+        !msg.contains("green-ok"),
+        "panic must not list satisfied labels: {msg}"
+    );
+}


### PR DESCRIPTION
## Summary

PR **1 of 3** in the **W6 op-driver stack** (sim-testing, #1797): the **semantic core** — the `always!` / `sometimes!` simulation-assertion macros and the per-run non-vacuity registry the forthcoming `sim-sweep` aggregates across seeds.

## Before / After

**Before.** A `#[sim_test]` author could drive seeded time, RNG, and a mounted app, but had no first-class way to state *what must be true* or *what should be reachable* in a simulation. Invariants were ad-hoc `assert!`s (no greppable/replay-framed message), and there was no notion of "this green run was vacuous — the interesting branch never actually happened."

**After.** A sim-test author can write:

```rust
#[sim_test]
async fn transfers_never_overdraw(mut sim: Sim) {
    // HARD invariant: panics on violation; the harness prints the
    // AUTUMN_SIM_SEED=… replay line so it reproduces bit-for-bit.
    always!(balance >= 0, "balance went negative: {}", balance);

    // REACHABILITY target: recorded per-run; the sweep fails if NO seed
    // ever satisfies it (non-vacuous green).
    sometimes!(balance == 0, "balance-hit-exactly-zero");
    sometimes!(retries > 0, "a-retry-happened");
}
```

- `always!(cond)` / `always!(cond, "fmt {}", args…)` — hard invariant; panics with the greppable prefix `always! invariant violated`, the stringified condition, and any caller message. The existing `#[sim_test]` panic path prints the deterministic replay line, so a violation reproduces exactly.
- `sometimes!(cond, "label")` — reachability; records `"label"` as observed and marks it satisfied when `cond` is true (condition evaluated exactly once). It **never** fails the current seed run on its own (a target may legitimately not fire under one seed); the sweep aggregates across many seeds and fails if a label was seen but never satisfied by any of them. `assert_all_sometimes_satisfied()` is provided for an explicit single-run check.

## How

**Files**
- `autumn/src/sim/assert.rs` (new) — the two `#[macro_export]` `macro_rules!` macros (so `use autumn_web::{always, sometimes};` resolves at the crate root), the thread-local `SometimesRegistry` (two `BTreeSet<String>`s: observed / satisfied), the hidden `__sometimes_observe` plumbing the `sometimes!` macro expands to, and the sweep-facing API: `reset_sometimes_registry`, `sometimes_snapshot`, `sometimes_unsatisfied`, `assert_all_sometimes_satisfied`, plus the public `SometimesRegistry`.
- `autumn/src/sim.rs` — `pub mod assert;`, re-exports of the registry API at `autumn_web::sim::*`, and an `assert::reset_sometimes_registry()` call at the top of `Sim::from_seed` so each seed run starts with a clean registry.
- `autumn/tests/sim_assert.rs` (new, isolated `[[test]]`) — the behavioral contract (see Concurrency below).
- `autumn/Cargo.toml` — the `[[test]] name = "sim_assert"` entry.
- `CHANGELOG.md` — one bullet under `## [Unreleased] → Added`.

**Thread-local registry design + concurrency choice.** The registry is a `thread_local!` `RefCell<SometimesRegistry>`. `BTreeSet` (not `HashSet`) keeps panic-message and snapshot ordering stable — the determinism contract requires reproducible output. The concurrency question: two tests in the same binary both touch a *global* registry — do they interfere? **No** — libtest runs each `#[test]` on its own thread, and a thread-local is per-thread, so concurrent tests each observe their own registry and never contend. `Sim::from_seed` resets the current thread's registry (each seed starts clean); the sweep, which runs seeds sequentially on one thread, reads `sometimes_snapshot()` after each seed and resets before the next. This is the correct isolation boundary under CI's concurrent test execution.

I kept the test as an **isolated `[[test]]` binary** rather than folding it into the consolidated `integration_tests` binary: it exercises the process's reachability registry and asserts `Sim::from_seed`'s reset behavior, so keeping it standalone removes any doubt about coupling to the consolidated binary's other concurrent tests. It needs **no non-default feature**, so the existing `cargo test --workspace` CI step compiles and runs it automatically — **no workflow edit required**.

## Stack context

This is **PR 1 of the W6 op-driver stack**:
- **PR 1 (this):** `always!` / `sometimes!` + non-vacuity registry.
- **PR 2:** `enum Op` + a proptest `Strategy` / `Arbitrary` for it + `sim.gen() -> Vec<Op>` + shrinking.
- **PR 3:** a `sim-sweep` `[[bin]]` + a loom-style CI job (`AUTUMN_SIM_SEEDS=N`, stop-on-first-failure, printing the failing seed + the shrunk op-sequence + the replay line). PR 3 wants the W5 chaos work (#2126) merged for full value.

**Base decision:** branched off `trunk-dev`; no compile-dependency on the Chaos wave — this PR is purely additive and self-contained.

## Gates (local)

- `cargo build -p autumn-web --all-targets` — clean.
- `cargo +1.97.0 clippy -p autumn-web --all-targets -- -D warnings` — clean (CI toolchain).
- `cargo test -p autumn-web --test sim_assert` — **8 passed**.
- `cargo test -p autumn-web --doc sim::assert` — **2 passed** (the `always!` / `sometimes!` doc examples).
- `cargo fmt --all -- --check` — clean.