### PR TITLE
docs/examples: add state-machine transition-effects demo to wiki (#2099)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **docs/examples:** a runnable state-machine / lifecycle demonstration (`#[state_machine]` transition effects) in the `wiki` example — the `Page::status` machine now declares per-edge `on = "..."` effects that append the audit `Revision` inside the transition's transaction, driven from the transitions handler via `transition_status_to_on_conn` under one `Db::tx_with` — cross-linked from the state-machines guide (#2099). [no-plugin]
 - **docs/examples:** documented the `autumn-media-plugin` media subsystem
   (broadcast + mesh rooms + MediaMTX). Adds the `docs/guide/media.md` guide
   (install/mount, `MediaConfig` profile loading, the `RoomService`/`RoomStore`

--- a/docs/guide/state-machines.md
+++ b/docs/guide/state-machines.md
@@ -206,9 +206,14 @@ let next_states: Vec<&str> = Order::__AUTUMN_SM_STATUS_TRANSITIONS
 
 ## Wiki example
 
-The wiki example ships a `Page` model with `draft`, `published`, and `archived`
-states. `#[state_machine]` is added to its `status` field and the
-`PageHooks::before_update` implementation enforces valid transitions, so a
-direct API call or form submission cannot skip `draft → published → archived`
-or jump backward. See `examples/wiki/src/models.rs` and
-`examples/wiki/src/hooks.rs`.
+[`examples/wiki`](../../examples/wiki) ships a `Page` model with `draft`,
+`published`, and `archived` states. `#[state_machine]` is added to its `status`
+field and the `PageHooks::before_update` implementation enforces valid
+transitions, so a direct API call or form submission cannot skip
+`draft → published → archived` or jump backward. Each edge also declares a
+[transition effect](transition-effects.md) (`on = "record_publish_revision"` /
+`on = "record_archive_revision"`) that appends the audit `Revision` inside the
+transition's transaction, and the `transition_status` handler drives the
+effectful `transition_status_to_on_conn` under `Db::tx_with` so the status change
+and its audit row commit atomically. See `examples/wiki/src/models.rs` and
+`examples/wiki/src/routes/pages.rs`.

--- a/docs/guide/transition-effects.md
+++ b/docs/guide/transition-effects.md
@@ -144,6 +144,21 @@ Open that transaction with a helper that hands you the `AsyncPgConnection` the m
 
 ---
 
+## Try it in the wiki example
+
+[`examples/wiki`](../../examples/wiki) wires a synchronous `on` effect onto its
+`Page::status` state machine (`src/models.rs`): the `draft -> published` and
+`published -> archived` edges each declare `on = "record_publish_revision"` /
+`on = "record_archive_revision"`, inherent `async fn(&self, conn)` methods that
+append the audit `Revision` row. The `POST /pages/{slug}/transitions/status`
+handler (`src/routes/pages.rs`) drives `transition_status_to_on_conn` inside a
+`Db::tx_with` transaction and persists the returned status on the same
+connection, so the status change and its audit row commit — or roll back —
+atomically. Publish or archive a page from its show page and check its **History**
+to see the effect-written revision.
+
+---
+
 ## See also
 
 - [Typed lifecycles](lifecycle.md)

--- a/examples/wiki/README.md
+++ b/examples/wiki/README.md
@@ -10,6 +10,12 @@ twice.
 - `#[model]` for `Page` and `Revision`
 - `#[repository(Page, hooks = PageHooks, api = "/api/v1/pages")]`
 - Mutation hooks for slug generation and revision auditing
+- **`#[state_machine]` with transition effects** — `Page::status`
+  (`draft → published → archived`) declares a `can_publish` guard plus per-edge
+  `on = "..."` effects that append the audit `Revision` inside the transition's
+  transaction; the `POST /pages/{slug}/transitions/status` handler drives the
+  effectful `transition_status_to_on_conn` under one `Db::tx_with` (see
+  `docs/guide/state-machines.md` and `docs/guide/transition-effects.md`)
 - Maud templates for a server-rendered editing flow
 - Embedded migrations on startup
 - Framework health and actuator endpoints
@@ -63,6 +69,7 @@ behavior automatically.
 | GET | `/pages/{slug}` | View a page |
 | GET | `/pages/{slug}/edit` | Edit form |
 | POST | `/pages/{slug}` | Update a page |
+| POST | `/pages/{slug}/transitions/status` | Apply a `#[state_machine]` status transition (fires the audit-`Revision` effect) |
 | GET | `/pages/{slug}/history` | Full revision history |
 | GET | `/collections` | List link collections |
 | GET | `/collections/new` | New collection form (nested `has_many`) |

--- a/examples/wiki/src/models.rs
+++ b/examples/wiki/src/models.rs
@@ -1,3 +1,6 @@
+use autumn_web::AutumnResult;
+use diesel_async::{AsyncPgConnection, RunQueryDsl};
+
 use crate::schema::{api_credentials, collection_links, collections, pages, revisions};
 
 /// A stored third-party API token, encrypted at rest (issue #805).
@@ -34,9 +37,16 @@ pub struct Page {
     pub slug: String,
     #[searchable(weight = "B")]
     pub body: String,
+    // A runtime `#[state_machine]` combining a data-dependent guard with
+    // per-edge *transition effects* (docs/guide/transition-effects.md). Each
+    // `on = "method"` names a synchronous, in-transaction effect that fires when
+    // its edge is taken: here it appends the audit `Revision`, so the audit row
+    // and the status change commit — or roll back — together. The `guard` still
+    // blocks publishing an empty page. See `transition_status` in
+    // `src/routes/pages.rs` for the transactional call site.
     #[state_machine(transitions(
-        draft -> published: "can_publish",
-        published -> archived,
+        draft -> published: guard = "can_publish", on = "record_publish_revision",
+        published -> archived: on = "record_archive_revision",
     ))]
     pub status: String,
     #[lock_version]
@@ -50,6 +60,43 @@ pub struct Page {
 impl Page {
     pub fn can_publish(&self) -> bool {
         !self.title.trim().is_empty() && !self.body.trim().is_empty()
+    }
+
+    /// `draft -> published` transition effect. The `on = "record_publish_revision"`
+    /// edge in the state machine calls this inside the transition's transaction
+    /// (through the generated `transition_status_to_on_conn`), so the audit row
+    /// written here is atomic with the status change.
+    async fn record_publish_revision(&self, conn: &mut AsyncPgConnection) -> AutumnResult<()> {
+        self.record_status_revision(conn, "published").await
+    }
+
+    /// `published -> archived` transition effect (see `record_publish_revision`).
+    async fn record_archive_revision(&self, conn: &mut AsyncPgConnection) -> AutumnResult<()> {
+        self.record_status_revision(conn, "archived").await
+    }
+
+    /// Shared effect body: append a `Revision` recording the status change.
+    /// `self` is the pre-transition snapshot, so `self.status` is the *old*
+    /// state and `to` is the state being entered. Returning `Err` here rolls the
+    /// whole transition back.
+    async fn record_status_revision(
+        &self,
+        conn: &mut AsyncPgConnection,
+        to: &str,
+    ) -> AutumnResult<()> {
+        diesel::insert_into(revisions::table)
+            .values(&NewRevision {
+                page_id: self.id,
+                op: "update".into(),
+                title: self.title.clone(),
+                body: self.body.clone(),
+                status: to.to_string(),
+                changed_by: None,
+                summary: Some(format!("Status changed: {} → {to}", self.status)),
+            })
+            .execute(conn)
+            .await?;
+        Ok(())
     }
 }
 
@@ -149,4 +196,49 @@ pub struct NewRevision {
     pub status: String,
     pub changed_by: Option<String>,
     pub summary: Option<String>,
+}
+
+#[cfg(test)]
+mod state_machine_tests {
+    use super::*;
+
+    fn page_with(status: &str, body: &str) -> Page {
+        Page {
+            id: 1,
+            title: "My Page".into(),
+            slug: "my-page".into(),
+            body: body.into(),
+            status: status.into(),
+            lock_version: 0,
+            created_at: chrono::Utc::now().naive_utc(),
+            updated_at: chrono::Utc::now().naive_utc(),
+        }
+    }
+
+    // Adding per-edge transition effects (`on = "..."`) leaves the pure
+    // `#[state_machine]` validators byte-for-byte unchanged: the guarded
+    // `draft -> published` edge and the unguarded `published -> archived` edge
+    // still govern which transitions are legal, and the `can_publish` guard
+    // still blocks publishing an empty page.
+    #[test]
+    fn pure_validators_still_govern_allowed_edges() {
+        assert!(page_with("draft", "Some content").can_transition_status_to("published"));
+        assert!(page_with("published", "Some content").can_transition_status_to("archived"));
+        // Undeclared edge and rejected guard remain denied.
+        assert!(!page_with("published", "Some content").can_transition_status_to("draft"));
+        assert!(!page_with("draft", "").can_transition_status_to("published"));
+    }
+
+    // Compilation contract: declaring an effect makes the model gain the
+    // connection-taking `transition_status_to_on_conn`, which validates the edge,
+    // runs the synchronous `on` effect, and returns the new state string to
+    // persist. Never called (no DB here) — its mere existence type-checks the
+    // effect codegen end to end.
+    #[allow(dead_code)]
+    async fn _assert_on_conn_signature(
+        page: &Page,
+        conn: &mut AsyncPgConnection,
+    ) -> AutumnResult<String> {
+        page.transition_status_to_on_conn(conn, "published").await
+    }
 }

--- a/examples/wiki/src/routes/pages.rs
+++ b/examples/wiki/src/routes/pages.rs
@@ -2,10 +2,11 @@ use autumn_web::extract::Path;
 use autumn_web::prelude::*;
 use diesel::prelude::*;
 use diesel_async::RunQueryDsl;
+use scoped_futures::ScopedFutureExt;
 
 use crate::models::{NewPage, NewRevision, Page, Revision};
 use crate::repositories::{PageRepository, PgPageRepository};
-use crate::schema::revisions;
+use crate::schema::{pages, revisions};
 
 pub fn layout(title: &str, content: Markup) -> Markup {
     html! {
@@ -407,13 +408,21 @@ pub async fn update(
     Ok(Redirect::to(&paths::show(updated.slug)))
 }
 
-/// `POST /pages/{slug}/transitions/status` — apply a state-machine transition.
+/// `POST /pages/{slug}/transitions/status` — apply a state-machine transition
+/// with its **transition effect** (docs/guide/transition-effects.md).
 ///
 /// The `transition_controls` widget on the show page posts the target state
-/// under the field name (`status`). Enforcement is the macro-generated
-/// `Page::transition_status_to`, which returns a 400 for an undefined edge or a
-/// rejected `can_publish` guard — surfaced here by `?`, matching the wiki's
-/// error-propagation convention (no Flash layer is configured).
+/// under the field name (`status`). Rather than the pure `transition_status_to`
+/// validator plus a separate revision insert, this drives the effectful
+/// `transition_status_to_on_conn` inside one transaction: it validates the edge
+/// and `can_publish` guard, fires the edge's synchronous `on` effect (which
+/// writes the audit `Revision`), and we then persist the returned status on the
+/// same connection — so the state change and its audit row commit or roll back
+/// atomically. An illegal edge / rejected guard / effect `Err` becomes a 400 (or
+/// rolls the transaction back), surfaced by `?` per the wiki's convention.
+///
+/// `Db::tx_with` hands the effect the `AsyncPgConnection` its `on` methods
+/// expect (`Db::tx` yields a different pooled connection type).
 #[post("/pages/{slug}/transitions/status")]
 pub async fn transition_status(
     Path(slug): Path<String>,
@@ -422,37 +431,34 @@ pub async fn transition_status(
     form: Form<TransitionForm>,
 ) -> AutumnResult<Redirect> {
     let page = find_page_by_slug(&repo, &slug).await?;
+    let target = form.0.status;
+    let page_id = page.id;
+    let redirect_slug = page.slug.clone();
 
-    // The state machine is the single source of truth: illegal edges and
-    // guard rejections become a 400 here.
-    let new_status = page.transition_status_to(&form.0.status)?;
+    db.tx_with(TxOptions::default(), move |conn| {
+        let page = page.clone();
+        let target = target.clone();
+        async move {
+            // Validates the edge + guard and runs the `on` effect (the audit
+            // Revision write) on `conn`.
+            let new_status = page.transition_status_to_on_conn(conn, &target).await?;
+            // Persist the new state on the same connection so it commits with
+            // the effect's audit row.
+            diesel::update(pages::table.find(page_id))
+                .set((
+                    pages::status.eq(&new_status),
+                    pages::lock_version.eq(pages::lock_version + 1),
+                    pages::updated_at.eq(diesel::dsl::now),
+                ))
+                .execute(conn)
+                .await?;
+            Ok::<(), AutumnError>(())
+        }
+        .scope_boxed()
+    })
+    .await?;
 
-    let update = crate::models::UpdatePage {
-        title: Patch::Unchanged,
-        slug: Patch::Unchanged,
-        body: Patch::Unchanged,
-        status: Patch::Set(new_status),
-        lock_version: page.lock_version,
-    };
-    let updated = repo.update(page.id, &update).await?;
-
-    let summary =
-        generate_update_summary(&page.status, &updated.status, &page.title, &updated.title);
-
-    diesel::insert_into(revisions::table)
-        .values(&NewRevision {
-            page_id: updated.id,
-            op: "update".into(),
-            title: updated.title.clone(),
-            body: updated.body.clone(),
-            status: updated.status.clone(),
-            changed_by: None,
-            summary,
-        })
-        .execute(&mut *db)
-        .await?;
-
-    Ok(Redirect::to(&paths::show(updated.slug)))
+    Ok(Redirect::to(&paths::show(redirect_slug)))
 }
 
 #[get("/pages/{slug}/history")]


### PR DESCRIPTION
## Before

`#[state_machine]` / `#[lifecycle]` transition **effects** (`on` / `on_commit`) had three narrative guides — `docs/guide/state-machines.md`, `docs/guide/lifecycle.md`, `docs/guide/transition-effects.md` — but **no runnable example** exercised a transition effect. The `wiki` example already had a `#[state_machine]` on `Page::status` (`draft → published → archived`) with a `can_publish` guard, but the audit `Revision` was written by the route in a *separate* insert after a pure `transition_status_to` validation — the state change and its audit row were not transactionally coupled.

## After

The `wiki` example now demonstrates **synchronous, in-transaction `on` effects** on its `Page::status` (`draft → published → archived`) machine:

- `Page::status` declares `draft -> published: guard = "can_publish", on = "record_publish_revision"` and `published -> archived: on = "record_archive_revision"`. Each effect is an inherent `async fn(&self, conn) -> AutumnResult<()>` that appends the audit `Revision`.
- `POST /pages/{slug}/transitions/status` drives the effectful `transition_status_to_on_conn` inside one `Db::tx_with` transaction and persists the returned status on the **same** connection, so the state change and its audit `Revision` commit — or roll back — atomically (an illegal edge, rejected guard, or effect `Err` rolls the whole transaction back).

## How

The effect methods live next to the transition table in `src/models.rs`; they insert the `Revision` on the connection the generated `transition_status_to_on_conn` hands them, so the write is part of the transition's transaction. The handler in `src/routes/pages.rs` opens the transaction with `Db::tx_with` (which yields the `AsyncPgConnection` the effect expects, unlike `Db::tx`), calls the effectful method, then does a raw diesel status update on the same connection. No migration — it reuses the existing `revisions` table. A compile-contract unit test in `src/models.rs` type-checks the generated `_on_conn` method and re-asserts the pure validators; all 38 wiki tests pass.

Cross-linked from `docs/guide/state-machines.md` (the existing "Wiki example" section, updated to mention the effects) and `docs/guide/transition-effects.md` (a new "Try it in the wiki example" pointer using the relative `examples/wiki` path), and noted in the wiki README feature list + HTML route table. `CHANGELOG.md` gains one `### Added` bullet under `## [Unreleased]`.

Addresses #2099 (Gap 13 — State machines & lifecycle).

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xpawwz5r7TxagGBq668xr1)_