### PR TITLE
jobs: thread ClockSource into job runtime timestamp reads (#2111)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -167,6 +167,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **jobs:** routed the job runtime's recorded timestamps (enqueued_at/started_at/finished_at, due-at filtering, and the backoff-delay computation) through the injected `ClockSource` seam instead of reading `Utc::now()` directly, so recorded job timestamps are deterministic under the sim harness (production defaults to `SystemClock`, behavior unchanged). The in-memory/sim job path is now fully deterministic; the Postgres durable path still uses server-side SQL `NOW()` (#2111). [no-plugin]
+
 - **admin-plugin:** made the core connection surface backend-agnostic so
   SQLite-backend apps can compile it — flipped every hardcoded
   `diesel_async::AsyncPgConnection` to `autumn_web::RuntimeConnection` across

--- a/autumn/src/job.rs
+++ b/autumn/src/job.rs
@@ -637,6 +637,11 @@ pub struct JobClient {
     /// [`crate::entropy::OsEntropy`]; a simulation seeds it via the app's
     /// [`crate::state::AppState::with_entropy`] so job ids replay deterministically.
     entropy: Arc<dyn crate::entropy::Entropy>,
+    /// Injected clock source for recorded job timestamps (`enqueued_at`, due-at
+    /// filtering, backoff-delay math). Defaults to [`crate::time::SystemClock`];
+    /// a simulation pins it via the app's [`crate::state::AppState::with_clock`]
+    /// so recorded timestamps replay deterministically.
+    clock: Arc<dyn crate::time::ClockSource>,
 }
 
 /// Per-job configuration captured from [`JobInfo`] at runtime start.
@@ -1041,6 +1046,10 @@ struct JobAdminMemoryInner {
 #[derive(Clone)]
 pub struct JobAdminMemoryBackend {
     inner: Arc<RwLock<JobAdminMemoryInner>>,
+    /// Injected clock source for recorded lifecycle timestamps. Defaults to
+    /// [`crate::time::SystemClock`]; the built-in runtime threads the app's
+    /// injected clock in so a simulation records deterministic timestamps.
+    clock: Arc<dyn crate::time::ClockSource>,
 }
 
 impl JobAdminMemoryBackend {
@@ -1060,7 +1069,16 @@ impl JobAdminMemoryBackend {
                 history_limit: history_limit.max(1),
                 delay_cancelers: HashMap::new(),
             })),
+            clock: Arc::new(crate::time::SystemClock),
         }
+    }
+
+    /// Replace the injected clock (builder / simulation helper), sharing the
+    /// same underlying store. Mirrors [`crate::state::AppState::with_clock`].
+    #[must_use]
+    pub fn with_clock(mut self, clock: Arc<dyn crate::time::ClockSource>) -> Self {
+        self.clock = clock;
+        self
     }
 
     /// Record an enqueue that may carry a future due time. When `due_at` is in
@@ -1121,7 +1139,7 @@ impl JobAdminMemoryBackend {
         {
             let was_scheduled = record.status == JobAdminStatus::Scheduled;
             record.status = JobAdminStatus::Enqueued;
-            record.enqueued_at = Some(chrono::Utc::now());
+            record.enqueued_at = Some(self.clock.now());
             record.scheduled_for = None;
             record.started_at = None;
             record.finished_at = None;
@@ -1146,7 +1164,7 @@ impl JobAdminMemoryBackend {
             // which point it starts like any other enqueued job.
             JobAdminStatus::Enqueued | JobAdminStatus::Scheduled => {
                 record.status = JobAdminStatus::Running;
-                record.started_at = Some(chrono::Utc::now());
+                record.started_at = Some(self.clock.now());
                 record.scheduled_for = None;
                 record.finished_at = None;
                 record.attempt = attempt;
@@ -1162,7 +1180,7 @@ impl JobAdminMemoryBackend {
             && let Some(record) = inner.records.get_mut(id)
         {
             record.status = JobAdminStatus::Completed;
-            record.finished_at = Some(chrono::Utc::now());
+            record.finished_at = Some(self.clock.now());
             record.last_error = None;
             prune_job_admin_history(&mut inner);
         }
@@ -1173,7 +1191,7 @@ impl JobAdminMemoryBackend {
             && let Some(record) = inner.records.get_mut(id)
         {
             record.status = JobAdminStatus::Retrying;
-            record.finished_at = Some(chrono::Utc::now());
+            record.finished_at = Some(self.clock.now());
             record.last_error = Some(error.to_owned());
         }
     }
@@ -1183,7 +1201,7 @@ impl JobAdminMemoryBackend {
             && let Some(record) = inner.records.get_mut(id)
         {
             record.status = JobAdminStatus::Failed;
-            record.finished_at = Some(chrono::Utc::now());
+            record.finished_at = Some(self.clock.now());
             record.last_error = Some(error);
             prune_job_admin_history(&mut inner);
         }
@@ -1194,7 +1212,7 @@ impl JobAdminMemoryBackend {
             && let Some(record) = inner.records.get_mut(id)
         {
             record.status = JobAdminStatus::Canceled;
-            record.finished_at = Some(chrono::Utc::now());
+            record.finished_at = Some(self.clock.now());
         }
     }
 
@@ -1203,7 +1221,7 @@ impl JobAdminMemoryBackend {
             && let Some(record) = inner.records.get_mut(id)
         {
             record.status = JobAdminStatus::Deduplicated;
-            record.finished_at = Some(chrono::Utc::now());
+            record.finished_at = Some(self.clock.now());
             prune_job_admin_history(&mut inner);
         }
     }
@@ -1224,7 +1242,7 @@ impl JobAdminMemoryBackend {
         }
         let retry = (record.name.clone(), record.payload.clone());
         record.status = JobAdminStatus::Retried;
-        record.finished_at = Some(chrono::Utc::now());
+        record.finished_at = Some(self.clock.now());
         drop(inner);
         Ok(retry)
     }
@@ -1235,7 +1253,7 @@ impl JobAdminMemoryBackend {
             && record.status == JobAdminStatus::Retried
         {
             record.status = JobAdminStatus::Failed;
-            record.finished_at = Some(chrono::Utc::now());
+            record.finished_at = Some(self.clock.now());
         }
     }
 
@@ -1273,7 +1291,7 @@ impl JobAdminMemoryBackend {
             ));
         }
         record.status = JobAdminStatus::Discarded;
-        record.finished_at = Some(chrono::Utc::now());
+        record.finished_at = Some(self.clock.now());
         drop(inner);
         Ok(())
     }
@@ -1297,7 +1315,7 @@ impl JobAdminMemoryBackend {
         }
         record.status = JobAdminStatus::Canceled;
         record.scheduled_for = None;
-        record.finished_at = Some(chrono::Utc::now());
+        record.finished_at = Some(self.clock.now());
         // Pull any pending timer canceler out while we still hold the lock.
         let canceler = inner.delay_cancelers.remove(id);
         drop(inner);
@@ -1340,7 +1358,7 @@ impl JobAdminMemoryBackend {
         let Ok(inner) = self.inner.read() else {
             return JobAdminSnapshot::empty();
         };
-        let now = chrono::Utc::now();
+        let now = self.clock.now();
         let per_page = query.per_page.clamp(1, 100);
         JobAdminSnapshot {
             enqueued: paginate_job_admin_records(
@@ -1405,7 +1423,7 @@ impl JobAdminMemoryBackend {
             attempt,
             max_attempts,
             None,
-            chrono::Utc::now(),
+            self.clock.now(),
         );
         id
     }
@@ -1695,7 +1713,7 @@ fn first_payload_string(payload: &Value, keys: &[&str]) -> Option<String> {
 }
 
 fn default_job_admin_backend_for_state(state: &AppState) -> JobAdminMemoryBackend {
-    let backend = JobAdminMemoryBackend::new();
+    let backend = JobAdminMemoryBackend::new().with_clock(state.clock_arc());
     if job_admin_backend(state).is_none() {
         state.insert_extension(JobAdminBackendEntry(Arc::new(backend.clone())));
     }
@@ -2601,7 +2619,7 @@ impl JobClient {
         // Capture the reference instant once so every downstream decision
         // (filter, admin record status, local-backend sleep) uses a consistent
         // clock reading and near-due jobs cannot be misclassified.
-        let now = chrono::Utc::now();
+        let now = self.clock.now();
         // Only treat a due time strictly in the future as "delayed"; a past or
         // absent due time enqueues for immediate execution exactly as before.
         let due_at = due_at.filter(|due| *due > now);
@@ -2690,7 +2708,7 @@ impl JobClient {
                     // Recompute remaining delay at the moment actual_enqueue
                     // runs (after any interceptor) so the sleep duration stays
                     // accurate even if the interceptor took non-trivial time.
-                    let delay = (due - chrono::Utc::now())
+                    let delay = (due - self.clock.now())
                         .to_std()
                         .unwrap_or(std::time::Duration::ZERO);
                     let sender = sender.clone();
@@ -3192,7 +3210,7 @@ impl JobClient {
         due_at: Option<chrono::DateTime<chrono::Utc>>,
     ) -> AutumnResult<()> {
         crate::job_tracking::reject_reserved_envelope_marker(&payload)?;
-        let due_at = due_at.filter(|due| *due > chrono::Utc::now());
+        let due_at = due_at.filter(|due| *due > self.clock.now());
         let Some(settings) = self.per_job_settings.get(name) else {
             return Err(AutumnError::internal_server_error(std::io::Error::other(
                 format!("job '{name}' is not registered; add it to AppBuilder::jobs()"),
@@ -3641,6 +3659,7 @@ pub(crate) fn start_local_runtime_inner(
             .extension::<Arc<dyn crate::interceptor::JobInterceptor>>()
             .map(|arc| (*arc).clone()),
         entropy: state.entropy_arc(),
+        clock: state.clock_arc(),
         resilience_config: state
             .extension::<crate::config::AutumnConfig>()
             .map(|c| Arc::new(c.resilience.clone())),
@@ -6699,7 +6718,7 @@ fn start_redis_runtime(
     config: &crate::config::JobConfig,
     run_workers: bool,
 ) -> Result<(), AutumnError> {
-    let job_admin = JobAdminMemoryBackend::new();
+    let job_admin = JobAdminMemoryBackend::new().with_clock(state.clock_arc());
     let url = config
         .redis
         .url
@@ -6840,6 +6859,7 @@ fn start_redis_runtime(
                 .extension::<Arc<dyn crate::interceptor::JobInterceptor>>()
                 .map(|arc| (*arc).clone()),
             entropy: state.entropy_arc(),
+            clock: state.clock_arc(),
             resilience_config: state
                 .extension::<crate::config::AutumnConfig>()
                 .map(|c| Arc::new(c.resilience.clone())),
@@ -8091,7 +8111,7 @@ async fn pg_execute_job(
                 // actually claimable. A zero backoff is due-now (`None`).
                 let delay_ms = pg_retry_delay_ms(row.initial_backoff_ms, row.attempt);
                 let ready_at_ms = (delay_ms > 0).then(|| {
-                    let now_ms = u64::try_from(chrono::Utc::now().timestamp_millis()).unwrap_or(0);
+                    let now_ms = u64::try_from(state.clock().now().timestamp_millis()).unwrap_or(0);
                     now_ms.saturating_add(u64::try_from(delay_ms).unwrap_or(0))
                 });
                 PgLifecycleRecord::Retry {
@@ -8299,6 +8319,10 @@ struct PgJobAdminBackend {
     /// Job registry whose per-queue waiting gauges the admin-cancel path must
     /// decrement, mirroring the redis backend.
     registry: crate::actuator::JobRegistry,
+    /// Injected clock source for the snapshot window boundaries and the
+    /// admin-cancel scheduled/ready classification. Defaults to
+    /// [`crate::time::SystemClock`]; a simulation pins it for determinism.
+    clock: Arc<dyn crate::time::ClockSource>,
 }
 
 /// Decide which per-queue waiting mark an admin-cancel of a still-enqueued
@@ -8349,7 +8373,7 @@ impl PgJobAdminBackend {
             AutumnError::internal_server_error_msg(format!("pg admin pool error: {e}"))
         })?;
         let per_page = i64::try_from(query.per_page.clamp(1, 100)).unwrap_or(10);
-        let now = chrono::Utc::now();
+        let now = self.clock.now();
 
         let (enqueued, scheduled) = pg_enqueued_and_scheduled_pages(
             &mut conn,
@@ -8525,7 +8549,7 @@ impl PgJobAdminBackend {
         // process. Category-aware, mirroring the redis admin-cancel path and the
         // enqueue side: a still-future `run_at` was a scheduled mark, a
         // ready/past one a ready mark.
-        if pg_cancel_was_scheduled(row.run_at, chrono::Utc::now()) {
+        if pg_cancel_was_scheduled(row.run_at, self.clock.now()) {
             self.registry.record_cancel_scheduled(&row.name);
         } else {
             self.registry.record_cancel(&row.name);
@@ -8780,7 +8804,7 @@ fn start_postgres_runtime(
         ))
     })?;
 
-    let job_admin = JobAdminMemoryBackend::new();
+    let job_admin = JobAdminMemoryBackend::new().with_clock(state.clock_arc());
     let per_job_settings = build_per_job_settings(&jobs);
     let serialize_claims = any_job_has_concurrency(&jobs);
     let jobs_by_name: Arc<RwLock<HashMap<String, JobInfo>>> = Arc::new(RwLock::new(
@@ -8802,6 +8826,7 @@ fn start_postgres_runtime(
         state.insert_extension(JobAdminBackendEntry(Arc::new(PgJobAdminBackend {
             pool: pool.clone(),
             registry: state.job_registry.clone(),
+            clock: state.clock_arc(),
         })));
     }
 
@@ -8847,6 +8872,7 @@ fn start_postgres_runtime(
                 .extension::<Arc<dyn crate::interceptor::JobInterceptor>>()
                 .map(|arc| (*arc).clone()),
             entropy: state.entropy_arc(),
+            clock: state.clock_arc(),
             resilience_config: state
                 .extension::<crate::config::AutumnConfig>()
                 .map(|c| Arc::new(c.resilience.clone())),
@@ -9206,6 +9232,7 @@ mod tests {
                 per_job_settings,
                 interceptor: None,
                 entropy,
+                clock: std::sync::Arc::new(crate::time::SystemClock),
                 resilience_config: None,
             }
         }
@@ -9262,6 +9289,7 @@ mod tests {
                 per_job_settings: HashMap::new(),
                 interceptor: None,
                 entropy: std::sync::Arc::new(crate::entropy::OsEntropy),
+                clock: std::sync::Arc::new(crate::time::SystemClock),
                 resilience_config: None,
             }
         }
@@ -9323,6 +9351,7 @@ mod tests {
             )]),
             interceptor: None,
             entropy: std::sync::Arc::new(crate::entropy::OsEntropy),
+            clock: std::sync::Arc::new(crate::time::SystemClock),
             resilience_config: None,
         });
 
@@ -9406,6 +9435,7 @@ mod tests {
             )]),
             interceptor: None,
             entropy: std::sync::Arc::new(crate::entropy::OsEntropy),
+            clock: std::sync::Arc::new(crate::time::SystemClock),
             resilience_config: None,
         });
 
@@ -9461,6 +9491,7 @@ mod tests {
             )]),
             interceptor: None,
             entropy: std::sync::Arc::new(crate::entropy::OsEntropy),
+            clock: std::sync::Arc::new(crate::time::SystemClock),
             resilience_config: None,
         });
 
@@ -9519,6 +9550,7 @@ mod tests {
             )]),
             interceptor: None,
             entropy: std::sync::Arc::new(crate::entropy::OsEntropy),
+            clock: std::sync::Arc::new(crate::time::SystemClock),
             resilience_config: None,
         });
 
@@ -9760,6 +9792,7 @@ mod tests {
             )]),
             interceptor: Some(Arc::new(PanickingEnqueueInterceptor)),
             entropy: std::sync::Arc::new(crate::entropy::OsEntropy),
+            clock: std::sync::Arc::new(crate::time::SystemClock),
             resilience_config: None,
         };
 
@@ -9821,6 +9854,7 @@ mod tests {
             )]),
             interceptor: Some(Arc::new(AsyncPanickingEnqueueInterceptor)),
             entropy: std::sync::Arc::new(crate::entropy::OsEntropy),
+            clock: std::sync::Arc::new(crate::time::SystemClock),
             resilience_config: None,
         };
 
@@ -12715,6 +12749,7 @@ mod tests {
             per_job_settings: HashMap::new(),
             interceptor: None,
             entropy: std::sync::Arc::new(crate::entropy::OsEntropy),
+            clock: std::sync::Arc::new(crate::time::SystemClock),
             resilience_config: None,
         });
         assert!(global_job_client().is_some());
@@ -14612,6 +14647,7 @@ mod tests {
                 per_job_settings: settings,
                 interceptor: None,
                 entropy: std::sync::Arc::new(crate::entropy::OsEntropy),
+                clock: std::sync::Arc::new(crate::time::SystemClock),
                 resilience_config: None,
             };
 
@@ -14911,6 +14947,7 @@ mod tests {
             let backend = PgJobAdminBackend {
                 pool: pool.clone(),
                 registry: crate::actuator::JobRegistry::new(),
+                clock: std::sync::Arc::new(crate::time::SystemClock),
             };
             let snapshot = backend.snapshot(JobAdminQuery::default()).await.unwrap();
 
@@ -14941,6 +14978,7 @@ mod tests {
             let backend = PgJobAdminBackend {
                 pool: pool.clone(),
                 registry: crate::actuator::JobRegistry::new(),
+                clock: std::sync::Arc::new(crate::time::SystemClock),
             };
 
             // --- Retry ---
@@ -15035,6 +15073,7 @@ mod tests {
             let backend = PgJobAdminBackend {
                 pool: pool.clone(),
                 registry: crate::actuator::JobRegistry::new(),
+                clock: std::sync::Arc::new(crate::time::SystemClock),
             };
 
             let _guard = global_job_runtime_test_lock().lock().await;
@@ -15094,6 +15133,7 @@ mod tests {
             let backend = PgJobAdminBackend {
                 pool: pool.clone(),
                 registry: crate::actuator::JobRegistry::new(),
+                clock: std::sync::Arc::new(crate::time::SystemClock),
             };
 
             let _guard = global_job_runtime_test_lock().lock().await;
@@ -15638,6 +15678,7 @@ mod tests {
             let backend = PgJobAdminBackend {
                 pool: pool.clone(),
                 registry: crate::actuator::JobRegistry::new(),
+                clock: std::sync::Arc::new(crate::time::SystemClock),
             };
 
             let constraints = unique_constraints("invoice-3", JobUniquenessWindow::Running);
@@ -15752,6 +15793,7 @@ mod tests {
             )]),
             interceptor: None,
             entropy: std::sync::Arc::new(crate::entropy::OsEntropy),
+            clock: std::sync::Arc::new(crate::time::SystemClock),
             resilience_config: None,
         };
         (client, rx)
@@ -16141,6 +16183,7 @@ mod tests {
                 )]),
                 interceptor: None,
                 entropy: std::sync::Arc::new(crate::entropy::OsEntropy),
+                clock: std::sync::Arc::new(crate::time::SystemClock),
                 resilience_config: None,
             };
             rt.block_on(async {
@@ -16193,6 +16236,7 @@ mod tests {
             per_job_settings: std::collections::HashMap::new(),
             interceptor: None,
             entropy: std::sync::Arc::new(crate::entropy::OsEntropy),
+            clock: std::sync::Arc::new(crate::time::SystemClock),
             resilience_config: None,
         };
 
@@ -16916,6 +16960,7 @@ mod tests {
             )]),
             interceptor: None,
             entropy: std::sync::Arc::new(crate::entropy::OsEntropy),
+            clock: std::sync::Arc::new(crate::time::SystemClock),
             resilience_config: None,
         });
 
@@ -16957,6 +17002,7 @@ mod tests {
             )]),
             interceptor: None,
             entropy: std::sync::Arc::new(crate::entropy::OsEntropy),
+            clock: std::sync::Arc::new(crate::time::SystemClock),
             resilience_config: None,
         });
 
@@ -17108,6 +17154,7 @@ mod tests {
             )]),
             interceptor: None,
             entropy: std::sync::Arc::new(crate::entropy::OsEntropy),
+            clock: std::sync::Arc::new(crate::time::SystemClock),
             resilience_config: None,
         });
 

--- a/autumn/src/state.rs
+++ b/autumn/src/state.rs
@@ -507,6 +507,15 @@ impl AppState {
         self
     }
 
+    /// Clone the shared clock handle, e.g. to thread into a subsystem that needs
+    /// the injected clock without going through Axum's extractor machinery.
+    ///
+    /// Mirrors [`Self::entropy_arc`].
+    #[must_use]
+    pub(crate) fn clock_arc(&self) -> Arc<dyn ClockSource> {
+        Arc::clone(&self.clock)
+    }
+
     /// Returns the active entropy source wired into this state.
     ///
     /// Handlers should prefer the [`crate::entropy::Rng`] extractor; this

--- a/autumn/tests/integration/mod.rs
+++ b/autumn/tests/integration/mod.rs
@@ -206,6 +206,7 @@ mod signed_webhooks;
 mod sim_advance_to;
 mod sim_clock_drain;
 mod sim_deterministic_ids;
+mod sim_job_clock;
 mod sim_rate_limit_clock;
 mod sim_test_smoke;
 #[cfg(feature = "ws")]

--- a/autumn/tests/integration/sim_job_clock.rs
+++ b/autumn/tests/integration/sim_job_clock.rs
@@ -1,0 +1,147 @@
+//! Sim-testing (issue #2111): the job runtime's recorded wall-clock timestamps
+//! (`enqueued_at` / `finished_at`) are read through the injected [`ClockSource`]
+//! seam, so under the [`Sim`] harness they are the **virtual** clock's time, not
+//! real wall time. This is the clock twin of the seeded-entropy job-id work
+//! (`sim_deterministic_ids`) and mirrors `sim_clock_drain`'s wiring.
+//!
+//! The probe jobs succeed immediately; the test reads the recorded timestamps
+//! back through the public job-admin snapshot and asserts they equal the sim's
+//! pinned virtual epoch (and epoch + an advance), proving the timestamp is
+//! virtual rather than wall-clock.
+
+use std::time::Duration;
+
+use autumn_web::app::AppBuilder;
+use autumn_web::job;
+use autumn_web::job::{JobAdminQuery, job_admin_backend};
+use autumn_web::plugin::Plugin;
+use autumn_web::prelude::*;
+use autumn_web::sim::Sim;
+use autumn_web::sim_test;
+use autumn_web::test::TestApp;
+use autumn_web::time::Clock;
+use serde::{Deserialize, Serialize};
+
+/// One hour — the virtual advance applied between the two probes.
+const ONE_HOUR: Duration = Duration::from_secs(3600);
+
+/// Empty payload for the probe jobs.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct ProbeArgs;
+
+// Two immediately-succeeding probes so each recorded lifecycle carries a
+// distinct, addressable name in the admin snapshot.
+#[job(name = "sim_clock_probe_a")]
+async fn sim_clock_probe_a(_state: AppState, _args: ProbeArgs) -> AutumnResult<()> {
+    Ok(())
+}
+
+#[job(name = "sim_clock_probe_b")]
+async fn sim_clock_probe_b(_state: AppState, _args: ProbeArgs) -> AutumnResult<()> {
+    Ok(())
+}
+
+/// Registers both probe jobs on the mounted app.
+struct ClockProbeJobPlugin;
+
+impl Plugin for ClockProbeJobPlugin {
+    fn build(self, app: AppBuilder) -> AppBuilder {
+        app.jobs(jobs![sim_clock_probe_a, sim_clock_probe_b])
+    }
+}
+
+/// Reads the injected (virtual) wall clock, so the test can prove it advanced.
+#[get("/now")]
+async fn now_route(clock: Clock) -> String {
+    clock.now().to_rfc3339()
+}
+
+/// Returns `(enqueued_at, finished_at)` (RFC3339, seconds, `Z`) for the newest
+/// admin record whose job name matches, read through the public job-admin
+/// backend that the built-in runtime shares with the injected clock.
+async fn recorded_times(state: &AppState, name: &str) -> (String, String) {
+    let backend = job_admin_backend(state).expect("job admin backend is installed");
+    let snap = backend
+        .snapshot(JobAdminQuery::default())
+        .await
+        .expect("admin snapshot");
+    let record = snap
+        .enqueued
+        .records
+        .iter()
+        .chain(snap.scheduled.records.iter())
+        .chain(snap.running.records.iter())
+        .chain(snap.completed.records.iter())
+        .chain(snap.failed.records.iter())
+        .find(|r| r.name == name)
+        .unwrap_or_else(|| panic!("no admin record found for job '{name}'"));
+    (
+        record.enqueued_at.clone().unwrap_or_default(),
+        record.finished_at.clone().unwrap_or_default(),
+    )
+}
+
+#[sim_test]
+async fn recorded_job_timestamps_are_virtual_under_the_sim(mut sim: Sim) {
+    // This job path uses the process-global job client, so serialize on the
+    // shared runtime lock and start from a clean client, exactly like the other
+    // global-runtime integration tests.
+    let _guard = job::global_job_runtime_test_lock().lock().await;
+    job::clear_global_job_client();
+
+    // Mount the app on the paused runtime with the sim's virtual clock (pinned at
+    // the fixed sim epoch) and the in-process job runtime.
+    sim.build(
+        TestApp::new()
+            .plugin(ClockProbeJobPlugin)
+            .routes(routes![now_route]),
+    );
+
+    // Seed stability, as the other sim tests assert.
+    assert_eq!(sim.seed, 0, "the default sim seed is 0");
+
+    // The injected clock starts pinned at the fixed sim epoch.
+    let before = sim.client().get("/now").send().await;
+    before.assert_ok();
+    assert_eq!(before.text(), "2020-01-01T00:00:00+00:00");
+
+    // Enqueue the first probe at the epoch and drain: it runs and succeeds, so
+    // both `enqueued_at` and `finished_at` are recorded through the injected
+    // clock at the virtual epoch — NOT real wall time.
+    SimClockProbeAJob::enqueue(ProbeArgs).await.unwrap();
+    sim.run_to_idle().await;
+
+    let (a_enqueued, a_finished) = recorded_times(sim.client().state(), "sim_clock_probe_a").await;
+    assert_eq!(
+        a_enqueued, "2020-01-01T00:00:00Z",
+        "enqueued_at is the virtual epoch, not wall-clock time",
+    );
+    assert_eq!(
+        a_finished, "2020-01-01T00:00:00Z",
+        "finished_at is the virtual epoch, not wall-clock time",
+    );
+
+    // Advance virtual time one hour, then enqueue + drain the second probe. Its
+    // recorded timestamps must be the advanced virtual time (epoch + 1h),
+    // proving a later lifecycle write also reads the injected clock.
+    sim.advance(ONE_HOUR).await;
+
+    let after = sim.client().get("/now").send().await;
+    after.assert_ok();
+    assert_eq!(after.text(), "2020-01-01T01:00:00+00:00");
+
+    SimClockProbeBJob::enqueue(ProbeArgs).await.unwrap();
+    sim.run_to_idle().await;
+
+    let (b_enqueued, b_finished) = recorded_times(sim.client().state(), "sim_clock_probe_b").await;
+    assert_eq!(
+        b_enqueued, "2020-01-01T01:00:00Z",
+        "the later record's enqueued_at is epoch + the 1h virtual advance",
+    );
+    assert_eq!(
+        b_finished, "2020-01-01T01:00:00Z",
+        "the later record's finished_at is epoch + the 1h virtual advance",
+    );
+
+    job::clear_global_job_client();
+}


### PR DESCRIPTION
## Before / After

**Before:** the job runtime read wall-clock time by calling `chrono::Utc::now()` directly at every recorded-timestamp site — `enqueued_at` / `started_at` / `finished_at` lifecycle writes, the future-due filter, and the local backoff-delay computation. Under the seeded sim harness these sites recorded **real wall-clock time**, so a run that pinned the virtual clock still stamped job records with the machine's actual clock — non-deterministic and un-replayable.

**After:** those reads go through the app's injected `ClockSource` seam. In production the seam defaults to `SystemClock`, so behavior is byte-identical to before. Under the sim harness the seam is the pinned virtual clock, so recorded job timestamps are virtual and deterministic — a job enqueued at the sim epoch records the epoch, and after `sim.advance(1h)` the next record stamps epoch + 1h.

## How

- Added a `clock: Arc` field to `JobClient`, `JobAdminMemoryBackend`, and `PgJobAdminBackend`, mirroring the existing `entropy: Arc` threading (this is the clock twin of #2107's entropy work and #2114's rate-limiter clock injection).
- New `AppState::clock_arc()` accessor (mirrors the existing `entropy_arc()`); production build sites thread `state.clock_arc()` in, and the two admin backends share `JobClient`'s injected clock via `.with_clock(state.clock_arc())`.
- Every lifecycle `Utc::now()` in the in-memory admin backend, the `enqueue_with_outcome_due` reference instant, the backoff-delay math (zero-clamp preserved), the future-due filter, the Pg snapshot window boundaries, and the Pg admin-cancel scheduled/ready classification now read `self.clock.now()` (or `state.clock().now()` where only `state` is in scope).
- Test/other literal constructors default the field to `SystemClock`.

## New sim test

`autumn/tests/integration/sim_job_clock.rs` (`recorded_job_timestamps_are_virtual_under_the_sim`): under the sim clock pinned at `2020-01-01T00:00:00Z`, enqueues a probe job and drains — asserting the recorded `enqueued_at`/`finished_at` equal the virtual epoch (not wall time). It then `sim.advance(1h)`, enqueues a second probe, and asserts its recorded timestamps equal epoch + 1h. `sim.seed == 0` is asserted for seed stability. Timestamps are read back through the public `job_admin_backend(...)` snapshot.

## Residual (out of scope, spec'd on #2111)

The in-memory/sim job path is now fully deterministic. The **Postgres durable enqueue path keeps server-side SQL `NOW()`** (`COALESCE($run_at, NOW())`) — that is the documented residual boundary and is intentionally not touched here. Monotonic `std::time::Instant::now()` throttle timers are also out of scope.