### PR TITLE
ci(real-vps): fail fast on shared Hetzner account server limit

### DIFF
--- a/.github/workflows/deploy-real-vps.yml
+++ b/.github/workflows/deploy-real-vps.yml
@@ -106,6 +106,26 @@ jobs:
           ssh-keygen -t ed25519 -N "" -q -f "${RUNNER_TEMP}/rvps_key"
           echo "SSH_KEY=${RUNNER_TEMP}/rvps_key" >> "${GITHUB_ENV}"
 
+      # Capacity preflight: the Hetzner account's server limit is SHARED with the
+      # nexus CI runner fleet (Hetzner default is 5 servers/account). List current
+      # servers so a "full account" is visible up front rather than as a cryptic
+      # mid-provision failure. Informational only — the authoritative limit check
+      # is the resource_limit_exceeded catch on `hcloud server create` below.
+      - name: Preflight - Hetzner account capacity
+        run: |
+          set -uo pipefail
+          if servers_json=$(hcloud server list -o json 2>/tmp/hcloud_ls_err); then
+            count=$(printf '%s' "$servers_json" | jq 'length')
+            echo "Hetzner account currently has ${count} server(s):"
+            printf '%s' "$servers_json" | jq -r '.[] | "  - \(.name) [\(.status)] \(.server_type.name) @ \(.datacenter.location.name) labels=\(.labels)"'
+            if [ "${count}" -ge 5 ]; then
+              echo "::warning::Account appears to be at the Hetzner default 5-server limit (${count} servers). This limit is shared with the nexus CI runner fleet; provisioning below may fail with resource_limit_exceeded. See docs/runbooks/real-vps.md."
+            fi
+          else
+            echo "::warning::Preflight could not list servers (continuing; provisioning will surface the real error):"
+            cat /tmp/hcloud_ls_err || true
+          fi
+
       # ── Provider-specific provisioning (Hetzner Cloud). Swap this block for a
       # different provider without touching the lifecycle script below. ────────
       #
@@ -173,12 +193,28 @@ jobs:
           fi
 
           echo "Selected server type '$chosen_type' in location '$chosen_loc' (live Hetzner availability)."
-          hcloud server create \
+          set +e
+          create_out=$(hcloud server create \
             --name "${HCLOUD_SERVER_NAME}" \
             --type "$chosen_type" \
             --image "${{ inputs.ubuntu_image || 'ubuntu-24.04' }}" \
             --location "$chosen_loc" \
-            --ssh-key "${HCLOUD_SSH_KEY_NAME}"
+            --ssh-key "${HCLOUD_SSH_KEY_NAME}" \
+            --label managed-by=autumn-rvps 2>&1)
+          create_rc=$?
+          set -e
+          printf '%s\n' "$create_out"
+          if [ "$create_rc" -ne 0 ]; then
+            if printf '%s' "$create_out" | grep -qiE 'resource_limit_exceeded|server limit reached'; then
+              echo "::error::Hetzner account server limit reached - cannot provision the Real-VPS test server."
+              echo "This account's server limit is SHARED with the nexus CI runner fleet (Hetzner default is 5 servers per account)."
+              echo "Operational fix: request a limit increase in the Hetzner Cloud Console (project -> Limits), or free a server slot."
+              echo "Runbook: docs/runbooks/real-vps.md (\"Account server limit\")."
+              exit 1
+            fi
+            echo "::error::hcloud server create failed (see output above)."
+            exit "$create_rc"
+          fi
           ip="$(hcloud server ip "${HCLOUD_SERVER_NAME}")"
           echo "Provisioned ${HCLOUD_SERVER_NAME} (${chosen_type}/${chosen_loc}) at ${ip}"
           echo "TARGET_HOST=${ip}" >> "${GITHUB_ENV}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -206,6 +206,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   follow-up. (0.7.0 work — do not merge until v0.6.0 is cut.)
 ### Fixed
 
+- **ci:** Real-VPS deploy lane fails fast with an actionable message (and a capacity preflight + runbook) when the shared Hetzner account server limit is reached, instead of a cryptic mid-provision `resource_limit_exceeded`. [no-plugin]
 - **migrate:** the two `SQLite` migration entry points — `run_pending_sqlite`
   (up) and `revert_user_migrations_sqlite` (down) — now serialize their whole
   list→plan→apply/revert sequence under a single shared `BEGIN IMMEDIATE` write

--- a/docs/runbooks/real-vps.md
+++ b/docs/runbooks/real-vps.md
@@ -1,0 +1,48 @@
+# Runbook: Real-VPS deploy test lane
+
+The `Deploy (Real VPS)` workflow (`.github/workflows/deploy-real-vps.yml`) runs
+nightly (and on demand) and provisions a throwaway Hetzner Cloud server to
+exercise a real end-to-end deploy, then destroys it in an `always()` teardown.
+
+## Account server limit (shared with nexus CI)
+
+**Symptom:** the workflow fails during provisioning with
+`hcloud: server limit reached (resource_limit_exceeded)` right after the SSH key
+is created and a server type/location is selected.
+
+**Cause — not a leak.** The Hetzner Cloud account has a default limit of **5
+servers per account**, and that account is **shared with the nexus CI runner
+fleet**. When all 5 slots are occupied by (legitimate, long-lived) nexus runner
+servers, there is no free slot for the Real-VPS run's ephemeral server, so
+`hcloud server create` is rejected.
+
+The Real-VPS lane's own resources are ephemeral and cleaned up every run:
+- Server name: `autumn-rvps-<run_id>-<attempt>`, labelled `managed-by=autumn-rvps`.
+- SSH key name: `autumn-rvps-key-<run_id>-<attempt>`.
+- Both are deleted by the workflow's `if: always()` teardown step, so a normal
+  run (success or failure) strands neither.
+
+The capacity preflight step lists the current servers before provisioning, so a
+full account is visible up front; the server-create step now maps the raw
+`resource_limit_exceeded` error to this runbook instead of dying cryptically.
+
+## Operational fix
+
+Pick one:
+
+1. **Request a server-limit increase** (preferred if both Real-VPS and nexus CI
+   need to run): Hetzner Cloud Console -> the project -> **Limits** -> request an
+   increase above 5. Once granted, re-run the workflow.
+2. **Free a slot**: if a nexus CI runner server is stale/unneeded, remove it (via
+   the nexus provisioning tooling) to free a slot, then re-run.
+
+## Note on a hard-cancelled run
+
+The teardown runs as an `if: always()` step, which covers step failures. If a run
+is hard-cancelled or the runner dies before that step executes, its
+`autumn-rvps-<run_id>-<attempt>` server/key could be stranded. Because every
+Real-VPS server is labelled `managed-by=autumn-rvps`, a stranded one is
+identifiable with `hcloud server list -l managed-by=autumn-rvps` and can be
+deleted manually. (A dedicated automated sweep was intentionally left out: at the
+default 5-server shared limit there is no backlog to clean, and the labelled
+identity above makes a rare manual cleanup trivial.)


### PR DESCRIPTION
## Before / After

**Before:** the nightly `Deploy (Real VPS)` workflow dies mid-provision with a cryptic `hcloud: server limit reached (resource_limit_exceeded)` right after the SSH key is created and a server type/location is selected. Nothing tells the operator what happened or what to do.

**After:** the lane lists the account's current servers up front, and if `hcloud server create` is rejected for the limit it fails with an actionable message pointing at a new runbook. The operator immediately sees the account is full and the fix (limit increase or free a slot).

## Diagnosis — this is NOT a leak

Per the maintainer: the Hetzner Cloud account is at its **default 5-servers-per-account limit**, and those slots are legitimately occupied by **nexus CI runner** servers that share the same account. The Real-VPS lane's own resources are ephemeral and already cleaned up every run: the existing `if: always()` teardown deletes both the run's server (`autumn-rvps-{run_id}-{attempt}`) and its SSH key (`autumn-rvps-key-{run_id}-{attempt}`). So there is no orphan backlog to sweep — the earlier "orphaned servers leaking the limit" hypothesis was ruled out, and this PR deliberately does **not** add any bulk orphan-sweep / cleanup machinery.

A live `hcloud` inventory could not be attached as raw evidence: this environment's permission classifier blocks any access to `HCLOUD_TOKEN`. The evidence here is the maintainer's account-state diagnosis plus the workflow reading (per-run naming, no reclaim label, single `always()` teardown, no pre-run sweep).

## What changed

- **Capacity preflight** (new step before Provision): `hcloud server list -o json`, prints each server, and emits a `::warning::` when the account is already at the 5-server default limit. Informational only — never hard-fails on the count, since the limit can be raised later.
- **Fail-fast on the real error**: `hcloud server create` output is captured; a `resource_limit_exceeded` / `server limit reached` failure maps to an `::error::` naming the shared nexus limit and the runbook, then `exit 1`. Any other create failure re-exits with its original code. Success path is unchanged.
- **Diagnostic label**: Real-VPS servers are now created with `--label managed-by=autumn-rvps`, so the preflight listing (and any rare manual cleanup) can tell our ephemeral servers apart from the nexus fleet.
- **Runbook**: new `docs/runbooks/real-vps.md` documenting the shared-account limit, the two operational fixes, and the ephemeral naming/teardown.
- The existing `always()` teardown (server + SSH key) is unchanged.

## Operational fix for the maintainer

Pick one, then re-run the workflow:
1. **Request a limit increase** (preferred): Hetzner Cloud Console then the project then **Limits**, raise above 5.
2. **Free a slot**: retire a stale nexus CI runner server via the nexus tooling.

## Verification note (honest)

YAML validates (`yaml.safe_load` OK). `actionlint` is not installed in this environment, so it was not run. There are no Rust changes, so fmt/clippy are N/A. The behavioral fix can only be exercised end-to-end by a real workflow run against the Hetzner account — the preflight/error-mapping paths run inside GitHub Actions with the CI `HCLOUD_TOKEN`, which is not reachable from here. So the runtime behavior is unverified until the lane runs post-merge (against a full account for the error path, or a freed/raised limit for the success path).

`[no-plugin]` — infra/CI only, no Claude-plugin or agent-facing surface.

@codex review

---
_Generated by [Claude Code](https://claude.ai/code/session_01ModqAqj2GAZSrwP8Jcch7G)_