### PR TITLE
fix: restore trunk-dev compile (auth.rs backend binding) + fmt

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -360,7 +360,7 @@ jobs:
             --test sqlite_upsert_isolation \
             --test sqlite_dependent_destroy \
             --test sqlite_commit_hook_worker \
-            --test sqlite_jobs_scheduler_e2e
+            --test sqlite_jobs_scheduler_e2e \
             --test sim_sqlite_substrate \
             --test sim_sqlite_integration
 

--- a/autumn-cli/src/generate/auth.rs
+++ b/autumn-cli/src/generate/auth.rs
@@ -1892,13 +1892,13 @@ scope = "openid profile email"
 /// (issue #1927).
 ///
 /// The auth generator scaffolds several tables (users, sessions, remember
-/// tokens, recovery codes, magic-link tokens, OAuth identities, WebAuthn
+/// tokens, recovery codes, magic-link tokens, OAuth identities, `WebAuthn`
 /// credentials) via hand-written `CREATE TABLE` strings. This carries the small
 /// set of column-type fragments that differ between backends so the Postgres
 /// output stays byte-for-byte identical while a `SQLite` app gets valid DDL:
-/// `INTEGER PRIMARY KEY AUTOINCREMENT` for auto-increment ids (SQLite has no
+/// `INTEGER PRIMARY KEY AUTOINCREMENT` for auto-increment ids (`SQLite` has no
 /// `BIGSERIAL`), plain `INTEGER` for `BIGINT`/`INT`, and ISO-8601 `TEXT`
-/// timestamps defaulted to `CURRENT_TIMESTAMP` (SQLite has no dedicated
+/// timestamps defaulted to `CURRENT_TIMESTAMP` (`SQLite` has no dedicated
 /// timestamp type nor `NOW()`). Portable pieces (`TEXT`, `REFERENCES`, `UNIQUE`,
 /// `CREATE INDEX`) are shared and unchanged. Mirrors the dialect mapping the
 /// backend-aware model/migration generators use
@@ -11083,11 +11083,11 @@ mod tests {
     // base scaffold plus each optional feature flag.
 
     /// Backend-aware DDL (issue #1927): `generate auth` on a `SQLite` app now
-    /// scaffolds its migrations in SQLite dialect (`INTEGER PRIMARY KEY
+    /// scaffolds its migrations in `SQLite` dialect (`INTEGER PRIMARY KEY
     /// AUTOINCREMENT`, `DEFAULT CURRENT_TIMESTAMP`) instead of being rejected —
     /// covering the users table AND the DB-backed sessions table (issue #1908) —
     /// and no Postgres-only `BIGSERIAL` / `BIGINT` / `NOW()` leaks into the
-    /// SQLite migration.
+    /// `SQLite` migration.
     #[test]
     fn plan_auth_emits_sqlite_ddl_including_sessions() {
         let tmp = project_with_main();
@@ -11187,10 +11187,10 @@ mod tests {
         );
     }
 
-    /// DB-backed sessions store on SQLite (issue #1908): the generated
+    /// DB-backed sessions store on `SQLite` (issue #1908): the generated
     /// `routes/auth.rs` types its connection pools against the backend-agnostic
     /// `::autumn_web::RuntimeConnection` alias (which resolves to `AsyncPgConnection`
-    /// on Postgres and the SQLite connection under the `sqlite` feature), never a
+    /// on Postgres and the `SQLite` connection under the `sqlite` feature), never a
     /// hard-coded `diesel_async::AsyncPgConnection`, so the generated app compiles
     /// on whichever backend it selected.
     #[test]
@@ -11211,7 +11211,7 @@ mod tests {
 
     /// The `--oauth` (`oauth_identities`) and `--passkeys`
     /// (`webauthn_credentials`) migrations are backend-aware too (issue #1927):
-    /// SQLite dialect on a SQLite app, historical Postgres DDL otherwise.
+    /// `SQLite` dialect on a `SQLite` app, historical Postgres DDL otherwise.
     #[test]
     fn oauth_and_passkey_migrations_are_backend_aware() {
         use autumn_web::config::DatabaseBackend;

--- a/autumn-cli/src/generate/auth.rs
+++ b/autumn-cli/src/generate/auth.rs
@@ -1159,6 +1159,10 @@ fn plan_auth_options_impl(
         for_revert,
     )?;
 
+    // Determine the target app's database backend so the scaffolded migrations
+    // emit backend-aware DDL (issue #1927), matching the base auth plan above.
+    let backend = super::detect_backend(project_root);
+
     let pascal_name = pascal(name);
     let snake_name = snake(name);
     let user_table = pluralize(&snake_name);
@@ -11195,9 +11199,7 @@ mod tests {
         for magic_link in [false, true] {
             let routes = render_routes_file("User", "user", "users", &[], false, magic_link);
             assert!(
-                routes.contains(
-                    "deadpool::Pool<::autumn_web::RuntimeConnection>"
-                ),
+                routes.contains("deadpool::Pool<::autumn_web::RuntimeConnection>"),
                 "session pool must be typed against RuntimeConnection (magic_link={magic_link}): {routes}"
             );
             assert!(

--- a/autumn-cli/src/generate/mailer.rs
+++ b/autumn-cli/src/generate/mailer.rs
@@ -277,7 +277,7 @@ fn plan_unsubscribe_migration(
 /// `TIMESTAMPTZ NOT NULL DEFAULT NOW()`). `SQLite` — which has neither
 /// `BIGSERIAL` nor `NOW()` nor a dedicated timestamp type — gets the portable
 /// form (`INTEGER PRIMARY KEY AUTOINCREMENT`, ISO-8601 `TEXT ... DEFAULT
-/// CURRENT_TIMESTAMP`), matching the SQLite dialect the backend-aware
+/// CURRENT_TIMESTAMP`), matching the `SQLite` dialect the backend-aware
 /// model/migration generators emit.
 const fn unsubscribe_migration_up(backend: autumn_web::config::DatabaseBackend) -> &'static str {
     match backend {
@@ -313,7 +313,7 @@ CREATE TABLE mail_unsubscribes (
 
 /// SQLite-dialect companion to [`UNSUBSCRIBE_MIGRATION_UP`] (issue #1927):
 /// `INTEGER PRIMARY KEY AUTOINCREMENT` for the id and an ISO-8601 `TEXT` column
-/// defaulted to `CURRENT_TIMESTAMP` (SQLite has no `BIGSERIAL`, `TIMESTAMPTZ`,
+/// defaulted to `CURRENT_TIMESTAMP` (`SQLite` has no `BIGSERIAL`, `TIMESTAMPTZ`,
 /// or `NOW()`). The `UNIQUE` constraint and column names are portable and
 /// unchanged.
 const UNSUBSCRIBE_MIGRATION_UP_SQLITE: &str = "\
@@ -614,9 +614,9 @@ async fn main() {
 
     /// Backend-aware DDL (issue #1927): `generate mailer --list-unsubscribe` on a
     /// `SQLite` app now scaffolds the `mail_unsubscribes` suppression migration in
-    /// SQLite dialect (`INTEGER PRIMARY KEY AUTOINCREMENT`, `DEFAULT
+    /// `SQLite` dialect (`INTEGER PRIMARY KEY AUTOINCREMENT`, `DEFAULT
     /// CURRENT_TIMESTAMP`) instead of being rejected — and no Postgres-only
-    /// `BIGSERIAL` / `TIMESTAMPTZ` / `NOW()` leaks into the SQLite migration.
+    /// `BIGSERIAL` / `TIMESTAMPTZ` / `NOW()` leaks into the `SQLite` migration.
     #[test]
     fn plan_mailer_with_list_unsubscribe_emits_sqlite_ddl() {
         let tmp = project_with_main(default_main());

--- a/autumn-cli/src/generate/mailer.rs
+++ b/autumn-cli/src/generate/mailer.rs
@@ -264,7 +264,10 @@ fn plan_unsubscribe_migration(
     let dir = existing_mail_unsubscribes_dir(&migrations_dir).unwrap_or_else(|| {
         migrations_dir.join(format!("{}_create_mail_unsubscribes", timestamp_now()))
     });
-    plan.create_if_absent(dir.join("up.sql"), unsubscribe_migration_up(backend).to_owned());
+    plan.create_if_absent(
+        dir.join("up.sql"),
+        unsubscribe_migration_up(backend).to_owned(),
+    );
     plan.create_if_absent(dir.join("down.sql"), UNSUBSCRIBE_MIGRATION_DOWN.to_owned());
 }
 

--- a/autumn/tests/sqlite_field_conversions.rs
+++ b/autumn/tests/sqlite_field_conversions.rs
@@ -83,9 +83,7 @@ async fn boot_pool(db_name: &str) -> SqlitePool {
     // test passes a DISTINCT name so the two `#[tokio::test]`s — which run in
     // parallel — never share rows through the process-wide shared cache.
     let config = DatabaseConfig {
-        url: Some(format!(
-            "sqlite://file:{db_name}?mode=memory&cache=shared"
-        )),
+        url: Some(format!("sqlite://file:{db_name}?mode=memory&cache=shared")),
         primary_pool_size: Some(1),
         ..Default::default()
     };
@@ -190,7 +188,11 @@ async fn datetime_column_orders_chronologically_on_sqlite() {
     let latest = DateTime::<Utc>::from_timestamp(1_800_000_000, 0).unwrap();
     let naive = earliest.naive_utc();
 
-    for (label, ts) in [("b-middle", middle), ("c-latest", latest), ("a-earliest", earliest)] {
+    for (label, ts) in [
+        ("b-middle", middle),
+        ("c-latest", latest),
+        ("a-earliest", earliest),
+    ] {
         repo.save(&NewConversionRow {
             label: label.to_string(),
             happened_at: ts,


### PR DESCRIPTION
Restores the `trunk-dev` compile and drives the resulting CI checks green. Three clearly-scoped commits.

## 1 — Restore compile (`error[E0425]`)

`trunk-dev` did not compile. `cargo build -p autumn-cli` failed with:

```
error[E0425]: cannot find value `backend` in this scope
  --> autumn-cli/src/generate/auth.rs:1178
  --> autumn-cli/src/generate/auth.rs:1327
```

`plan_auth_options_impl` (auth.rs:1139) called `render_oauth_migration_up(backend, …)` / `render_passkey_migration_up(backend, …)` with a `backend` it never bound. This was captured mid-edit by the recovery-checkpoint commit that landed the backend-aware auth/mailer DDL work (draft #2138, issues #1927/#1908) before those call sites were finished. The break cascaded red across every branch cut from trunk-dev.

**Fix** — smallest correct restoration, one binding matching the sibling `plan_auth_with_providers_ex_impl` (auth.rs:476) and `mailer.rs:216`:

```rust
    let backend = super::detect_backend(project_root);
```

The same commit runs `cargo fmt --all`, clearing pre-existing rustfmt drift in `autumn/tests/sqlite_field_conversions.rs`, `autumn-cli/src/generate/auth.rs`, and `autumn-cli/src/generate/mailer.rs`.

## 2 — Lint green (`clippy::doc_markdown`)

Once compile was restored, CI Lint surfaced 13 pre-existing `doc_markdown` "missing backticks" warnings in the #1927 docstrings (auth.rs / mailer.rs) — bare `SQLite` (×12) and `WebAuthn` (×1). Backticked exactly the flagged terms, doc-comments only, no code or prose reworded. `cargo clippy -p autumn-cli --all-targets -- -D warnings` is clean afterward.

## 3 — SQLite runtime green (pre-existing CI workflow bug)

The `SQLite runtime (feature=sqlite)` check was red on a **workflow** bug, not code: in the `sqlite-runtime` job's test step, `--test sqlite_jobs_scheduler_e2e` was missing its trailing `\`, so the shell ran the next line `--test sim_sqlite_substrate …` as a command → `--test: command not found`, exit 127 — **after all sqlite test binaries passed**. Adding the one missing backslash restores the line-continuation.

Two consequences worth noting:
- This bug also meant `sim_sqlite_substrate` and `sim_sqlite_integration` were **never actually executed** by CI; this commit is what truly enforces them.
- The missing backslash was introduced by `66eb1b7` (PR #2129, "test(sqlite): confirm in-process jobs + scheduler run end-to-end on SQLite"). Present identically on trunk-dev.

## Verification (local, pre-push)

- `cargo build -p autumn-cli` → exit 0
- `cargo build -p autumn-cli --no-default-features --features sqlite` (sqlite backend-flip lane) → exit 0
- `cargo fmt --all --check` → exit 0
- `cargo clippy -p autumn-cli --all-targets -- -D warnings` → clean
- `cargo test -p autumn-cli generate` → `165 passed; 0 failed`

## Notes

- CHANGELOG: no new bullet — pure build/CI fix to unreleased code, no user-facing surface.
- [no-plugin]
- No force-pushes.