### PR TITLE
feat(notifications): first-class in-app notifications store with read/unread feed (#1148)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **notifications:** first-class in-app notifications store with a read/unread
+  feed (#1148). A new `autumn_web::notifications` module ships a
+  `Notifications` service/extractor (surfaced like `Session`/`Auth`) with
+  `notify(recipient_id, kind, payload)`, `list(...)` returning the shipped
+  `Page`/`ListQuery` pagination (incl. `filter[unread]=true` and
+  `filter[kind]=...`), `unread_count`, and idempotent `mark_read` /
+  `mark_read_for` (recipient-scoped) / `mark_all_read`. Storage is a pluggable
+  `NotificationStore` — `DbNotificationStore` (Postgres or SQLite) by default
+  when a pool is configured, `MemoryNotificationStore` for DB-less dev/tests,
+  or a custom store via `AppBuilder::with_notification_store`. With the `ws`
+  feature, `notify_with_push` additionally publishes the stored notification
+  JSON on the per-recipient `notifications:{id}` channel topic, best-effort (a
+  channel failure never fails the notify). A new `autumn generate
+  notifications` command scaffolds the backend-aware migration, a minimal feed
+  module with registered routes, and an in-process `TestClient` smoke test.
+  Guide: `docs/guide/notifications.md`. All additions are additive — no
+  breaking change to existing surfaces.
 - **cli/generate:** `autumn generate auth` and `autumn generate mailer
   --list-unsubscribe` are now **backend-aware on SQLite** (#1927). On a SQLite
   app they scaffold SQLite-dialect migrations — `INTEGER PRIMARY KEY

--- a/autumn-cli/src/generate/emit.rs
+++ b/autumn-cli/src/generate/emit.rs
@@ -1461,6 +1461,9 @@ const SHARED_MAIN_MODULE_NAMES: &[&str] = &[
     "mailers",
     "inbound_mailers",
     "policies",
+    // A fixed single-file module (`src/notifications.rs`, no directory) —
+    // `shared_module_backing_path_exists` already handles that shape.
+    "notifications",
 ];
 
 /// Whether `name`'s backing module still exists on disk — either as

--- a/autumn-cli/src/generate/mod.rs
+++ b/autumn-cli/src/generate/mod.rs
@@ -24,6 +24,7 @@ pub mod mailer;
 pub mod migration;
 pub mod model;
 pub mod naming;
+pub mod notifications;
 pub mod plugin;
 pub mod policy;
 pub mod pwa;

--- a/autumn-cli/src/generate/notifications.rs
+++ b/autumn-cli/src/generate/notifications.rs
@@ -147,22 +147,28 @@ pub fn plan_notifications(project_root: &Path) -> Result<Plan, GenerateError> {
 
 /// Fully-qualified route entries for `routes![...]` wiring in `main.rs`.
 ///
-/// The demo login is deliberately **absent**: it is a test-only
-/// session-seeding route declared inside the smoke test, never wired into
-/// the production router — shipping it would expose
-/// `POST /notifications/demo_login/{id}` and let an unauthenticated visitor
-/// impersonate any recipient (PR #2144 finding A).
+/// Only the **session-scoped read/mark** routes are wired by default — the
+/// recipient is derived server-side, so these are safe to deploy as-is.
+///
+/// Two handlers are deliberately **absent** from production wiring because
+/// each takes a recipient from the request and would be exploitable if
+/// shipped unguarded (PR #2144 findings A/C):
+/// - `demo_login` — a test-only session seeder, declared only in the smoke
+///   test (never in the production module); shipping it would let an
+///   unauthenticated visitor impersonate any recipient.
+/// - `notify` — a demo write handler present in the production module as an
+///   example, but not registered here: it accepts an arbitrary
+///   `recipient_id`/`kind`/`payload` from the body, so wiring it unguarded
+///   would let anyone create notifications for anyone. Wire it behind your
+///   own auth, or — preferred — delete it and call
+///   `notifications.notify(...)` directly from the domain action that
+///   triggers the notification. The smoke test registers it in its own test
+///   router to exercise the write path.
 fn route_entries() -> Vec<String> {
-    [
-        "notify",
-        "feed",
-        "unread_count",
-        "mark_read",
-        "mark_all_read",
-    ]
-    .iter()
-    .map(|handler| format!("notifications::{handler}"))
-    .collect()
+    ["feed", "unread_count", "mark_read", "mark_all_read"]
+        .iter()
+        .map(|handler| format!("notifications::{handler}"))
+        .collect()
 }
 
 /// The existing `migrations/<ts>_create_notifications/` directory, if the
@@ -299,18 +305,23 @@ pub struct NotifyBody {
     pub payload: serde_json::Value,
 }
 
-/// `POST /notifications` — create a notification from a JSON body and return
-/// the stored record.
+/// `POST /notifications` — DEMO write handler: create a notification from a
+/// JSON body and return the stored record.
 ///
-/// The recipient comes from the body here because server-side notifies are
-/// legitimately cross-recipient (one user's action notifies another) — but
-/// that makes this demo route a spam vector as-is.
+/// This is a worked example, **not wired into the app by default**: it is
+/// deliberately absent from `main.rs`'s `routes![...]` (see `route_entries`
+/// in the generator) because the recipient comes from the request body.
+/// Server-side notifies are legitimately cross-recipient (one user's action
+/// notifies another), which is exactly why the recipient can't be derived
+/// from the caller's session — and why an unguarded `POST /notifications`
+/// would let anyone spam anyone.
 ///
-/// SECURITY / TODO: before shipping, protect or remove this route — e.g.
-/// restrict it to an admin/service caller, or delete it and call
-/// `notifications.notify(...)` from the domain action that triggers the
-/// notification (a new comment, a mention, …). Otherwise anyone can notify
-/// anyone.
+/// SECURITY / TODO: to expose a write endpoint, register this behind your own
+/// authorization (restrict it to an admin/service caller). Preferred: delete
+/// this handler and call `notifications.notify(recipient_id, kind, payload)`
+/// directly from the domain action that triggers the notification (a new
+/// comment, a mention, …). The smoke test registers this handler in its own
+/// test router to exercise the write path.
 #[post("/notifications")]
 pub async fn notify(
     notifications: Notifications,
@@ -1057,7 +1068,6 @@ async fn main() {
         let main = fs::read_to_string(tmp.path().join("src/main.rs")).unwrap();
         assert!(main.contains("mod notifications;"), "{main}");
         for entry in [
-            "notifications::notify",
             "notifications::feed",
             "notifications::unread_count",
             "notifications::mark_read",
@@ -1072,6 +1082,19 @@ async fn main() {
         assert!(
             !main.contains("demo_login"),
             "main.rs must not register the test-only demo login: {main}"
+        );
+        // The demo `notify` write handler (arbitrary body-supplied recipient)
+        // must NOT be wired into the production router either (PR #2144
+        // finding C) — it stays an unregistered example in the module.
+        assert!(
+            !main.contains("notifications::notify"),
+            "main.rs must not register the unguarded demo notify route: {main}"
+        );
+        assert!(
+            fs::read_to_string(tmp.path().join("src/notifications.rs"))
+                .unwrap()
+                .contains("pub async fn notify("),
+            "the notify example handler still lives in the module, just unwired"
         );
     }
 
@@ -1310,7 +1333,7 @@ async fn main() {
             assert!(
                 fs::read_to_string(&main_path)
                     .unwrap()
-                    .contains("notifications::notify")
+                    .contains("notifications::feed")
             );
 
             let destroy_plan = plan_notifications(tmp.path()).unwrap();

--- a/autumn-cli/src/generate/notifications.rs
+++ b/autumn-cli/src/generate/notifications.rs
@@ -510,9 +510,14 @@ async fn main() {
             "_create_notifications/down.sql",
         ] {
             assert!(
-                plan.actions
-                    .iter()
-                    .any(|a| a.path().to_string_lossy().ends_with(suffix)),
+                plan.actions.iter().any(|a| {
+                    // Normalize so the assertion also holds under Windows
+                    // path separators.
+                    a.path()
+                        .to_string_lossy()
+                        .replace('\\', "/")
+                        .ends_with(suffix)
+                }),
                 "plan must include migrations/<ts>{suffix}"
             );
         }

--- a/autumn-cli/src/generate/notifications.rs
+++ b/autumn-cli/src/generate/notifications.rs
@@ -90,11 +90,19 @@ pub fn plan_notifications(project_root: &Path) -> Result<Plan, GenerateError> {
     });
 
     // ── migrations/<ts>_create_notifications/{up,down}.sql ──────────────────
-    // Destroy matches migration directories by their `_create_notifications`
-    // suffix, so the fresh timestamp taken here never blocks a later revert.
-    let migration_dir = project_root
-        .join("migrations")
-        .join(format!("{}_create_{NOTIFICATIONS_TABLE}", timestamp_now()));
+    // Notifications are a singleton scaffold: re-running (especially with
+    // `--force` to refresh it) must not mint a SECOND
+    // `*_create_notifications` directory — two `CREATE TABLE notifications`
+    // migrations would fail the next `autumn migrate` on the duplicate table
+    // and make destroy's suffix match ambiguous (PR #2144 finding B). So
+    // reuse an existing `*_create_notifications` dir when one is present,
+    // minting a fresh timestamped dir only on a clean project. Destroy still
+    // matches by the `_create_notifications` suffix either way.
+    let migration_dir = existing_notifications_migration_dir(project_root).unwrap_or_else(|| {
+        project_root
+            .join("migrations")
+            .join(format!("{}_create_{NOTIFICATIONS_TABLE}", timestamp_now()))
+    });
     plan.create(migration_dir.join("up.sql"), migration_up_sql(backend));
     plan.create(
         migration_dir.join("down.sql"),
@@ -138,9 +146,14 @@ pub fn plan_notifications(project_root: &Path) -> Result<Plan, GenerateError> {
 }
 
 /// Fully-qualified route entries for `routes![...]` wiring in `main.rs`.
+///
+/// The demo login is deliberately **absent**: it is a test-only
+/// session-seeding route declared inside the smoke test, never wired into
+/// the production router — shipping it would expose
+/// `POST /notifications/demo_login/{id}` and let an unauthenticated visitor
+/// impersonate any recipient (PR #2144 finding A).
 fn route_entries() -> Vec<String> {
     [
-        "demo_login",
         "notify",
         "feed",
         "unread_count",
@@ -150,6 +163,33 @@ fn route_entries() -> Vec<String> {
     .iter()
     .map(|handler| format!("notifications::{handler}"))
     .collect()
+}
+
+/// The existing `migrations/<ts>_create_notifications/` directory, if the
+/// project already has one — so a re-run reuses it in place rather than
+/// minting a second singleton migration (PR #2144 finding B). Matched by the
+/// same `_create_notifications` suffix destroy uses (see
+/// `emit::resolve_migration_removal`), so the two stay in agreement.
+///
+/// If more than one somehow exists (a hand-added duplicate), the
+/// lexicographically-smallest is chosen deterministically — the same tie-break
+/// `emit`'s destroy scan applies — rather than depending on `read_dir` order.
+fn existing_notifications_migration_dir(project_root: &Path) -> Option<std::path::PathBuf> {
+    let suffix = format!("_create_{NOTIFICATIONS_TABLE}");
+    let mut matches: Vec<std::path::PathBuf> = std::fs::read_dir(project_root.join("migrations"))
+        .ok()?
+        .filter_map(Result::ok)
+        .map(|entry| entry.path())
+        .filter(|path| {
+            path.is_dir()
+                && path
+                    .file_name()
+                    .and_then(|n| n.to_str())
+                    .is_some_and(|n| n.ends_with(&suffix))
+        })
+        .collect();
+    matches.sort();
+    matches.into_iter().next()
 }
 
 /// The four non-`id` columns of the `notifications` table, expressed in the
@@ -208,57 +248,46 @@ fn migration_up_sql(backend: DatabaseBackend) -> String {
 }
 
 /// The session key, `NotifyBody` type, `current_recipient_id` helper, and
-/// the six route handlers, shared **verbatim** by `src/notifications.rs` and
-/// `tests/notifications_feed.rs` — `tests/*.rs` integration binaries cannot
-/// import the app's own binary crate (there is no `src/lib.rs`), so the
-/// smoke test re-declares the production handlers, and rendering both files
-/// from this one blob keeps them byte-for-byte in sync by construction (the
-/// same contract `generate channel`'s smoke test promises).
+/// the five production route handlers, shared **verbatim** by
+/// `src/notifications.rs` and `tests/notifications_feed.rs` — `tests/*.rs`
+/// integration binaries cannot import the app's own binary crate (there is
+/// no `src/lib.rs`), so the smoke test re-declares the production handlers,
+/// and rendering both files from this one blob keeps them byte-for-byte in
+/// sync by construction (the same contract `generate channel`'s smoke test
+/// promises).
+///
+/// The demo login is **not** here — it is a test-only session-seeding route
+/// ([`render_test_only_demo_login`]) emitted only into the smoke test, never
+/// the production module, so a deployed app never exposes it (PR #2144
+/// finding A).
 ///
 /// Security shape (PR #2144 review): the feed/mark routes never take a
 /// recipient id from the request — the recipient is derived server-side
 /// from the signed session via `current_recipient_id`, so one user can
-/// never read or mark another user's feed. Only the clearly-marked
-/// demo-only login route names a recipient in its URL.
+/// never read or mark another user's feed. Until real auth populates the
+/// session key the feed simply 401s (a safe, dormant default).
 const fn render_handlers() -> &'static str {
-    r#"/// The session key `current_recipient_id` reads. Seeded by the demo login
-/// route below; replace both with your real auth (see the TODOs).
+    r#"/// The session key `current_recipient_id` reads. Populate it from your
+/// auth (see the TODO on `current_recipient_id`); until then the feed is
+/// dormant and every request 401s.
 const RECIPIENT_SESSION_KEY: &str = "notifications.recipient_id";
 
 /// Resolve the signed-in recipient for this request.
 ///
 /// The recipient is derived server-side from the signed session — never
 /// from a path or body parameter — so a caller can only ever see or mark
-/// their own feed. An unauthenticated request gets a 401.
+/// their own feed. An unauthenticated request gets a 401, so these routes
+/// stay dormant until real auth populates the session key.
 ///
 /// TODO: replace this session lookup with your real auth (e.g. an
-/// `Auth<CurrentUser>` extractor returning `user.id`) and delete the demo
-/// login route once sign-in exists.
+/// `Auth<CurrentUser>` extractor returning `user.id`), which is what should
+/// populate `RECIPIENT_SESSION_KEY` on sign-in.
 async fn current_recipient_id(session: &Session) -> AutumnResult<i64> {
     session
         .get(RECIPIENT_SESSION_KEY)
         .await
         .and_then(|value| value.parse().ok())
         .ok_or_else(|| AutumnError::unauthorized_msg("not signed in"))
-}
-
-/// `POST /notifications/demo_login/{recipient_id}` — DEMO ONLY: signs this
-/// client's session in as `recipient_id` so the scaffold (and its smoke
-/// test) runs before any real auth exists.
-///
-/// SECURITY: this route lets anyone become any recipient — it must never
-/// ship. TODO: delete it (and its `routes![...]` entry) once real sign-in
-/// exists, and derive the recipient in `current_recipient_id` from your
-/// auth context instead.
-#[post("/notifications/demo_login/{recipient_id}")]
-pub async fn demo_login(
-    Path(recipient_id): Path<i64>,
-    session: Session,
-) -> AutumnResult<&'static str> {
-    session
-        .insert(RECIPIENT_SESSION_KEY, recipient_id.to_string())
-        .await;
-    Ok("signed in")
 }
 
 /// `POST /notifications` body: who to notify, an application-defined kind
@@ -353,10 +382,37 @@ pub async fn mark_all_read(
 "#
 }
 
+/// The **test-only** session-seeding handler emitted into
+/// `tests/notifications_feed.rs` — and deliberately nowhere else.
+///
+/// It is never part of [`render_handlers`] (so it never reaches the
+/// production `src/notifications.rs`) and never listed in [`route_entries`]
+/// (so it is never wired into the deployed router): a shipped
+/// `POST /notifications/demo_login/{recipient_id}` would let any
+/// unauthenticated visitor sign in as an arbitrary recipient and read or
+/// mark that user's feed (PR #2144 finding A). It exists only so the smoke
+/// test can establish a session the way a real login eventually will.
+const fn render_test_only_demo_login() -> &'static str {
+    r#"/// TEST-ONLY: seed the session with a recipient id so the session-scoped
+/// routes above are reachable from this smoke test. This handler is NOT part
+/// of the generated `src/notifications.rs` and is NOT registered in the real
+/// router — shipping it would be an impersonation endpoint (anyone could POST
+/// `/notifications/demo_login/<victim>`). A real app populates
+/// `RECIPIENT_SESSION_KEY` from its own authentication instead.
+#[post("/notifications/demo_login/{recipient_id}")]
+pub async fn demo_login(Path(recipient_id): Path<i64>, session: Session) -> &'static str {
+    session
+        .insert(RECIPIENT_SESSION_KEY, recipient_id.to_string())
+        .await;
+    "ok"
+}
+"#
+}
+
 /// Render `src/notifications.rs`.
 fn render_app_module() -> String {
     format!(
-        r"//! Generated by `autumn generate notifications`. Edit freely.
+        r#"//! Generated by `autumn generate notifications`. Edit freely.
 //!
 //! A minimal in-app notification feed over the framework's
 //! [`Notifications`] extractor (`autumn_web::notifications`). Storage
@@ -367,9 +423,12 @@ fn render_app_module() -> String {
 //!
 //! The feed/mark routes are session-scoped: the recipient is derived
 //! server-side (`current_recipient_id`), never from the request, so one
-//! user can never read or mark another user's feed. Wire your real auth in
-//! `current_recipient_id` and delete the demo login route — see the
-//! SECURITY/TODO comments below.
+//! user can never read or mark another user's feed. These routes stay
+//! dormant (every request 401s) until your real auth populates the session
+//! key — wire that in `current_recipient_id`; see the TODO there. There is
+//! deliberately no demo-login route in this module: seeding the session is
+//! done only by a test-only route in the generated smoke test, so a
+//! deployed app never exposes a "become any user" endpoint.
 //!
 //! Optional realtime push: with the `ws` feature enabled, swap `notify` for
 //! `notify_with_push` to also broadcast each stored notification on the
@@ -380,7 +439,7 @@ use autumn_web::notifications::{{Notification, Notifications}};
 use autumn_web::prelude::*;
 use serde::Deserialize;
 
-{handlers}",
+{handlers}"#,
         handlers = render_handlers(),
     )
 }
@@ -414,6 +473,7 @@ use autumn_web::test::TestApp;
 use serde::Deserialize;
 
 {handlers}
+{demo_login}
 #[tokio::test]
 async fn notifications_feed_round_trips_over_http() {{
     let client = TestApp::new()
@@ -532,6 +592,7 @@ async fn notifications_feed_round_trips_over_http() {{
 }}
 "#,
         handlers = render_handlers(),
+        demo_login = render_test_only_demo_login(),
     )
 }
 
@@ -751,6 +812,90 @@ async fn main() {
         });
     }
 
+    // ── GREEN: idempotent migration directory (PR #2144 finding B) ─────────
+
+    /// Count the `*_create_notifications` migration directories under `root`.
+    fn count_notification_migration_dirs(root: &Path) -> usize {
+        fs::read_dir(root.join("migrations")).map_or(0, |entries| {
+            entries
+                .filter_map(Result::ok)
+                .filter(|e| {
+                    e.path().is_dir()
+                        && e.file_name()
+                            .to_str()
+                            .is_some_and(|n| n.ends_with("_create_notifications"))
+                })
+                .count()
+        })
+    }
+
+    #[test]
+    fn first_run_mints_exactly_one_migration_dir() {
+        let tmp = project_with_main(default_main());
+        plan_notifications(tmp.path())
+            .unwrap()
+            .execute(Flags::default())
+            .unwrap();
+        assert_eq!(count_notification_migration_dirs(tmp.path()), 1);
+    }
+
+    #[test]
+    fn rerun_reuses_existing_migration_dir_instead_of_minting_a_second() {
+        // PR #2144 finding B: re-running (esp. with --force to refresh this
+        // singleton scaffold) must not create a SECOND
+        // `*_create_notifications` dir — two `CREATE TABLE notifications`
+        // migrations would make `autumn migrate` fail on the duplicate table
+        // and make destroy's suffix match ambiguous.
+        //
+        // Seed a migration dir with an explicit PAST timestamp so the reuse
+        // is genuinely exercised: a fresh `timestamp_now()` would differ from
+        // it, so a plan that reused nothing would mint a second directory.
+        let tmp = project_with_main(default_main());
+        let existing = tmp
+            .path()
+            .join("migrations")
+            .join("20200101000000_create_notifications");
+        fs::create_dir_all(&existing).unwrap();
+        fs::write(existing.join("up.sql"), "-- stale placeholder\n").unwrap();
+        fs::write(existing.join("down.sql"), "-- stale placeholder\n").unwrap();
+
+        // The plan must target the SAME existing directory (its past
+        // timestamp), not a freshly minted current-timestamp one.
+        let plan = plan_notifications(tmp.path()).unwrap();
+        assert!(
+            plan.actions.iter().any(|a| {
+                a.path()
+                    .to_string_lossy()
+                    .replace('\\', "/")
+                    .ends_with("20200101000000_create_notifications/up.sql")
+            }),
+            "re-run must write into the existing migration dir, not a new one: {:?}",
+            plan.actions
+                .iter()
+                .map(|a| a.path().to_owned())
+                .collect::<Vec<_>>()
+        );
+
+        // Applying it with --force overwrites the placeholder in place —
+        // still exactly one `*_create_notifications` dir, and it is the
+        // pre-existing one.
+        plan.execute(Flags {
+            force: true,
+            dry_run: false,
+        })
+        .unwrap();
+        assert_eq!(
+            count_notification_migration_dirs(tmp.path()),
+            1,
+            "a re-run must not mint a second migration directory"
+        );
+        let up = fs::read_to_string(existing.join("up.sql")).unwrap();
+        assert!(
+            up.contains("CREATE TABLE notifications"),
+            "the reused dir's up.sql must be refreshed with the real DDL: {up}"
+        );
+    }
+
     // ── GREEN: app module content ─────────────────────────────────────────
 
     #[test]
@@ -766,11 +911,14 @@ async fn main() {
             src.contains("use autumn_web::notifications::{Notification, Notifications};"),
             "{src}"
         );
-        // The six routes: a clearly-marked demo login, the demo notify, and
-        // the four session-scoped feed routes (no recipient in the URL).
+        // The five production routes: the demo notify plus the four
+        // session-scoped feed routes (no recipient in the URL). The demo
+        // login is TEST-ONLY and must never appear in the production
+        // module or its router (PR #2144 finding A).
         assert!(
-            src.contains(r#"#[post("/notifications/demo_login/{recipient_id}")]"#),
-            "{src}"
+            !src.contains("demo_login"),
+            "the demo login must be test-only — it must not exist in the \
+             production module: {src}"
         );
         assert!(src.contains(r#"#[post("/notifications")]"#), "{src}");
         assert!(src.contains(r#"#[get("/notifications")]"#), "{src}");
@@ -798,14 +946,15 @@ async fn main() {
             "feed, unread_count, mark_read, and mark_all_read must all resolve \
              the recipient from the session: {src}"
         );
-        // An unauthenticated request is rejected, not defaulted.
+        // An unauthenticated request is rejected, not defaulted — the feed is
+        // dormant until real auth populates the session key.
         assert!(src.contains("unauthorized"), "{src}");
         // The mark-read route must additionally use the recipient-scoped
         // (IDOR-safe) store variant, and say why.
         assert!(src.contains(".mark_read_for(recipient_id, id)"), "{src}");
         assert!(src.contains("IDOR"), "{src}");
-        // The demo login and demo notify must carry prominent
-        // SECURITY/TODO markers steering users to real auth.
+        // The demo notify must carry prominent SECURITY/TODO markers steering
+        // users to real auth / protecting the route.
         assert!(src.contains("SECURITY"), "{src}");
         assert!(src.contains("TODO"), "{src}");
         // The feed goes through the shipped pagination extractors.
@@ -815,12 +964,58 @@ async fn main() {
     }
 
     #[test]
-    fn generated_routes_never_take_the_recipient_from_the_url_except_demo_login() {
+    fn demo_login_is_test_only_never_in_production_router() {
+        // PR #2144 finding A (security regression): a production
+        // `demo_login` route lets an unauthenticated visitor POST
+        // `/notifications/demo_login/<victim>` and then read/mark the
+        // victim's feed. The demo login must be test-only — absent from
+        // `route_entries()`, from the emitted production module, and from
+        // `src/main.rs`'s `routes![...]` — while the smoke test seeds the
+        // session with its own local handler.
+        assert!(
+            !route_entries().iter().any(|e| e.contains("demo_login")),
+            "route_entries must not register demo_login: {:?}",
+            route_entries()
+        );
+
+        let tmp = project_with_main(default_main());
+        plan_notifications(tmp.path())
+            .unwrap()
+            .execute(Flags::default())
+            .unwrap();
+
+        let src = fs::read_to_string(tmp.path().join("src/notifications.rs")).unwrap();
+        assert!(
+            !src.contains("fn demo_login"),
+            "production module must not define a demo_login handler: {src}"
+        );
+        let main = fs::read_to_string(tmp.path().join("src/main.rs")).unwrap();
+        assert!(
+            !main.contains("demo_login"),
+            "main.rs must not register a demo_login route: {main}"
+        );
+
+        // The smoke test still seeds the session (its own test-only route),
+        // so the flow stays runnable and honest.
+        let test_src = fs::read_to_string(tmp.path().join("tests/notifications_feed.rs")).unwrap();
+        assert!(
+            test_src.contains("fn demo_login"),
+            "smoke test must declare its own test-only session-seeding \
+             handler: {test_src}"
+        );
+        assert!(
+            test_src.contains("RECIPIENT_SESSION_KEY"),
+            "smoke test's seeding route must write the session key: {test_src}"
+        );
+    }
+
+    #[test]
+    fn production_routes_never_take_the_recipient_from_the_url() {
         // Regression test for the PR #2144 Codex review finding: a
         // `{recipient_id}` path segment on any real route lets any caller
         // read (or mark read) another user's feed — `mark_read_for` scopes
-        // to the *supplied* recipient, not the caller. Only the
-        // clearly-marked demo login may name a recipient in its URL.
+        // to the *supplied* recipient, not the caller. No production route
+        // may name a recipient in its URL (the demo login is test-only now).
         let tmp = project_with_main(default_main());
         plan_notifications(tmp.path())
             .unwrap()
@@ -833,15 +1028,15 @@ async fn main() {
             .map(str::trim)
             .filter(|l| l.starts_with("#[get(") || l.starts_with("#[post("))
             .collect();
-        assert_eq!(route_attrs.len(), 6, "six routes expected: {route_attrs:?}");
-        let recipient_in_url: Vec<&&str> = route_attrs
-            .iter()
-            .filter(|l| l.contains("{recipient_id}"))
-            .collect();
         assert_eq!(
-            recipient_in_url,
-            vec![&r#"#[post("/notifications/demo_login/{recipient_id}")]"#],
-            "only the demo login route may take a recipient id from the URL"
+            route_attrs.len(),
+            5,
+            "five routes expected: {route_attrs:?}"
+        );
+        assert!(
+            !route_attrs.iter().any(|l| l.contains("{recipient_id}")),
+            "no production route may take a recipient id from the URL: \
+             {route_attrs:?}"
         );
         // The demo notify's body-supplied recipient stays (server-side
         // notifies are legitimately cross-recipient), but it must warn that
@@ -862,7 +1057,6 @@ async fn main() {
         let main = fs::read_to_string(tmp.path().join("src/main.rs")).unwrap();
         assert!(main.contains("mod notifications;"), "{main}");
         for entry in [
-            "notifications::demo_login",
             "notifications::notify",
             "notifications::feed",
             "notifications::unread_count",
@@ -874,6 +1068,11 @@ async fn main() {
                 "main.rs must register {entry}: {main}"
             );
         }
+        // The test-only demo login must NOT be wired into the router.
+        assert!(
+            !main.contains("demo_login"),
+            "main.rs must not register the test-only demo login: {main}"
+        );
     }
 
     // ── GREEN: smoke test content ─────────────────────────────────────────
@@ -979,9 +1178,11 @@ async fn main() {
             }
             src[start..=end].to_owned()
         };
+        // `demo_login` is test-only (it lives only in the smoke test), so it
+        // is excluded from the parity contract — only the shared PRODUCTION
+        // handlers must be byte-for-byte identical between the two files.
         for name in [
             "current_recipient_id",
-            "demo_login",
             "notify",
             "feed",
             "unread_count",
@@ -995,6 +1196,17 @@ async fn main() {
                  byte-identical to the production handler"
             );
         }
+        // The shared session-key const must also be re-declared verbatim.
+        assert!(
+            production_src
+                .contains(r#"const RECIPIENT_SESSION_KEY: &str = "notifications.recipient_id";"#),
+            "{production_src}"
+        );
+        assert!(
+            test_src
+                .contains(r#"const RECIPIENT_SESSION_KEY: &str = "notifications.recipient_id";"#),
+            "{test_src}"
+        );
     }
 
     // ── GREEN: Cargo.toml ─────────────────────────────────────────────────

--- a/autumn-cli/src/generate/notifications.rs
+++ b/autumn-cli/src/generate/notifications.rs
@@ -9,13 +9,18 @@
 //!   DDL for the `notifications` table, matching the framework store's
 //!   diesel `table!` mapping byte-for-type (see [`migration_up_sql`]).
 //! - `src/notifications.rs` — notify / feed / unread-count / mark-read /
-//!   mark-all-read route handlers over the `Notifications` extractor.
+//!   mark-all-read route handlers over the `Notifications` extractor. The
+//!   feed/mark routes are **session-scoped**: the recipient is derived
+//!   server-side from the `Session` (seeded by a clearly-marked demo-only
+//!   login route), never from a path or body parameter, so the scaffold
+//!   never teaches an IDOR pattern (PR #2144 review).
 //! - `src/main.rs` — `mod notifications;` declaration and the generated
 //!   routes registered in `routes![...]`.
 //! - `tests/notifications_feed.rs` — a smoke test exercising the full
-//!   notify → list → mark-read → unread-count flow through the in-process
-//!   `TestApp` (no database needed: with no DB configured the extractor
-//!   falls back to its in-process memory store).
+//!   demo-login → notify → list → mark-read → unread-count flow through
+//!   the in-process `TestApp`, including the cross-recipient isolation
+//!   check (no database needed: with no DB configured the extractor falls
+//!   back to its in-process memory store).
 //! - `Cargo.toml` — `serde`/`serde_json` dependencies and the `tokio`
 //!   dev-dependency features the smoke test needs for `#[tokio::test]`.
 
@@ -135,6 +140,7 @@ pub fn plan_notifications(project_root: &Path) -> Result<Plan, GenerateError> {
 /// Fully-qualified route entries for `routes![...]` wiring in `main.rs`.
 fn route_entries() -> Vec<String> {
     [
+        "demo_login",
         "notify",
         "feed",
         "unread_count",
@@ -201,15 +207,61 @@ fn migration_up_sql(backend: DatabaseBackend) -> String {
     }
 }
 
-/// The `NotifyBody` type and the five route handlers, shared **verbatim** by
-/// `src/notifications.rs` and `tests/notifications_feed.rs` — `tests/*.rs`
-/// integration binaries cannot import the app's own binary crate (there is
-/// no `src/lib.rs`), so the smoke test re-declares the production handlers,
-/// and rendering both files from this one blob keeps them byte-for-byte in
-/// sync by construction (the same contract `generate channel`'s smoke test
-/// promises).
+/// The session key, `NotifyBody` type, `current_recipient_id` helper, and
+/// the six route handlers, shared **verbatim** by `src/notifications.rs` and
+/// `tests/notifications_feed.rs` — `tests/*.rs` integration binaries cannot
+/// import the app's own binary crate (there is no `src/lib.rs`), so the
+/// smoke test re-declares the production handlers, and rendering both files
+/// from this one blob keeps them byte-for-byte in sync by construction (the
+/// same contract `generate channel`'s smoke test promises).
+///
+/// Security shape (PR #2144 review): the feed/mark routes never take a
+/// recipient id from the request — the recipient is derived server-side
+/// from the signed session via `current_recipient_id`, so one user can
+/// never read or mark another user's feed. Only the clearly-marked
+/// demo-only login route names a recipient in its URL.
 const fn render_handlers() -> &'static str {
-    r#"/// `POST /notifications` body: who to notify, an application-defined kind
+    r#"/// The session key `current_recipient_id` reads. Seeded by the demo login
+/// route below; replace both with your real auth (see the TODOs).
+const RECIPIENT_SESSION_KEY: &str = "notifications.recipient_id";
+
+/// Resolve the signed-in recipient for this request.
+///
+/// The recipient is derived server-side from the signed session — never
+/// from a path or body parameter — so a caller can only ever see or mark
+/// their own feed. An unauthenticated request gets a 401.
+///
+/// TODO: replace this session lookup with your real auth (e.g. an
+/// `Auth<CurrentUser>` extractor returning `user.id`) and delete the demo
+/// login route once sign-in exists.
+async fn current_recipient_id(session: &Session) -> AutumnResult<i64> {
+    session
+        .get(RECIPIENT_SESSION_KEY)
+        .await
+        .and_then(|value| value.parse().ok())
+        .ok_or_else(|| AutumnError::unauthorized_msg("not signed in"))
+}
+
+/// `POST /notifications/demo_login/{recipient_id}` — DEMO ONLY: signs this
+/// client's session in as `recipient_id` so the scaffold (and its smoke
+/// test) runs before any real auth exists.
+///
+/// SECURITY: this route lets anyone become any recipient — it must never
+/// ship. TODO: delete it (and its `routes![...]` entry) once real sign-in
+/// exists, and derive the recipient in `current_recipient_id` from your
+/// auth context instead.
+#[post("/notifications/demo_login/{recipient_id}")]
+pub async fn demo_login(
+    Path(recipient_id): Path<i64>,
+    session: Session,
+) -> AutumnResult<&'static str> {
+    session
+        .insert(RECIPIENT_SESSION_KEY, recipient_id.to_string())
+        .await;
+    Ok("signed in")
+}
+
+/// `POST /notifications` body: who to notify, an application-defined kind
 /// discriminator (e.g. `"comment.created"`), and a free-form JSON payload.
 #[derive(Deserialize)]
 pub struct NotifyBody {
@@ -221,10 +273,15 @@ pub struct NotifyBody {
 /// `POST /notifications` — create a notification from a JSON body and return
 /// the stored record.
 ///
-/// TODO: replace the body-supplied `recipient_id` with your auth context
-/// (e.g. a session/`Auth` extractor) once real sign-in exists — in
-/// production the *server* decides who a notification belongs to, never the
-/// request body.
+/// The recipient comes from the body here because server-side notifies are
+/// legitimately cross-recipient (one user's action notifies another) — but
+/// that makes this demo route a spam vector as-is.
+///
+/// SECURITY / TODO: before shipping, protect or remove this route — e.g.
+/// restrict it to an admin/service caller, or delete it and call
+/// `notifications.notify(...)` from the domain action that triggers the
+/// notification (a new comment, a mention, …). Otherwise anyone can notify
+/// anyone.
 #[post("/notifications")]
 pub async fn notify(
     notifications: Notifications,
@@ -236,52 +293,61 @@ pub async fn notify(
     Ok(Json(notification))
 }
 
-/// `GET /notifications/{recipient_id}` — one page of the recipient's feed.
+/// `GET /notifications` — one page of the signed-in recipient's feed.
 ///
 /// Supports `?page=`/`?size=` (the `PageRequest` extractor) plus
 /// `?filter[unread]=true`, `?filter[kind]=…`, and `?sort=id|created_at`
 /// (the `ListQuery` extractor); defaults to newest-first.
-#[get("/notifications/{recipient_id}")]
+#[get("/notifications")]
 pub async fn feed(
-    Path(recipient_id): Path<i64>,
+    session: Session,
     query: ListQuery,
     page: PageRequest,
     notifications: Notifications,
 ) -> AutumnResult<Json<Page<Notification>>> {
+    let recipient_id = current_recipient_id(&session).await?;
     Ok(Json(notifications.list(recipient_id, &query, &page).await?))
 }
 
-/// `GET /notifications/{recipient_id}/unread_count` — the bell-badge number.
-#[get("/notifications/{recipient_id}/unread_count")]
+/// `GET /notifications/unread_count` — the signed-in recipient's bell-badge
+/// number.
+#[get("/notifications/unread_count")]
 pub async fn unread_count(
-    Path(recipient_id): Path<i64>,
+    session: Session,
     notifications: Notifications,
 ) -> AutumnResult<Json<u64>> {
+    let recipient_id = current_recipient_id(&session).await?;
     Ok(Json(notifications.unread_count(recipient_id).await?))
 }
 
-/// `POST /notifications/{recipient_id}/read/{id}` — mark one notification read.
+/// `POST /notifications/{id}/read` — mark one of the signed-in recipient's
+/// notifications read.
 ///
-/// Uses the recipient-scoped `mark_read_for` rather than the unscoped
-/// `mark_read`: a notification owned by a different recipient is left
-/// untouched (a no-op, not an error), so one user can never mark another
-/// user's notification read (IDOR-safe). Idempotent on re-marking.
-#[post("/notifications/{recipient_id}/read/{id}")]
+/// Uses the recipient-scoped `mark_read_for` with the session-derived
+/// recipient, rather than the unscoped `mark_read`: a notification owned by
+/// a different recipient is left untouched (a no-op, not an error), so even
+/// a guessed `id` can never mark another user's notification read
+/// (IDOR-safe). Idempotent on re-marking.
+#[post("/notifications/{id}/read")]
 pub async fn mark_read(
-    Path((recipient_id, id)): Path<(i64, i64)>,
+    Path(id): Path<i64>,
+    session: Session,
     notifications: Notifications,
 ) -> AutumnResult<&'static str> {
+    let recipient_id = current_recipient_id(&session).await?;
     notifications.mark_read_for(recipient_id, id).await?;
     Ok("ok")
 }
 
-/// `POST /notifications/{recipient_id}/read_all` — mark the whole feed read;
-/// returns how many notifications transitioned (0 on a repeat call).
-#[post("/notifications/{recipient_id}/read_all")]
+/// `POST /notifications/read_all` — mark the signed-in recipient's whole
+/// feed read; returns how many notifications transitioned (0 on a repeat
+/// call).
+#[post("/notifications/read_all")]
 pub async fn mark_all_read(
-    Path(recipient_id): Path<i64>,
+    session: Session,
     notifications: Notifications,
 ) -> AutumnResult<Json<u64>> {
+    let recipient_id = current_recipient_id(&session).await?;
     Ok(Json(notifications.mark_all_read(recipient_id).await?))
 }
 "#
@@ -299,6 +365,12 @@ fn render_app_module() -> String {
 //! memory store otherwise — so these routes work before `autumn migrate`
 //! has ever run.
 //!
+//! The feed/mark routes are session-scoped: the recipient is derived
+//! server-side (`current_recipient_id`), never from the request, so one
+//! user can never read or mark another user's feed. Wire your real auth in
+//! `current_recipient_id` and delete the demo login route — see the
+//! SECURITY/TODO comments below.
+//!
 //! Optional realtime push: with the `ws` feature enabled, swap `notify` for
 //! `notify_with_push` to also broadcast each stored notification on the
 //! conventional `notifications:{{recipient_id}}` channel topic
@@ -313,19 +385,28 @@ use serde::Deserialize;
     )
 }
 
-/// Render `tests/notifications_feed.rs` — a real notify → list → mark-read →
-/// unread-count round trip over HTTP, no database required.
+/// Render `tests/notifications_feed.rs` — a real demo-login → notify →
+/// list → mark-read → unread-count round trip over HTTP (plus the
+/// cross-recipient isolation check), no database required.
+#[allow(
+    clippy::too_many_lines,
+    reason = "one literal template for the generated smoke test; the length is the \
+              emitted file's, and splitting the flow across helpers would only \
+              obscure what the generated test contains"
+)]
 fn render_smoke_test() -> String {
     format!(
         r#"//! Smoke test generated by `autumn generate notifications`.
 //!
-//! Exercises the full notify → list → mark-read → unread-count flow over
-//! HTTP through the in-process `TestApp` — no database needed: with no DB
-//! configured the `Notifications` extractor falls back to its in-process
-//! memory store. The handlers below are re-declarations of
-//! `src/notifications.rs`'s handlers of the same names, kept byte-for-byte
-//! in sync — `tests/` integration binaries cannot import the app's own
-//! binary crate (there is no `src/lib.rs`).
+//! Exercises the full demo-login → notify → list → mark-read →
+//! unread-count flow over HTTP through the in-process `TestApp` — no
+//! database needed: with no DB configured the `Notifications` extractor
+//! falls back to its in-process memory store. `TestClient` carries a
+//! cookie jar, so the session set by the demo login is replayed on every
+//! later request, exactly like a browser. The handlers below are
+//! re-declarations of `src/notifications.rs`'s handlers of the same names,
+//! kept byte-for-byte in sync — `tests/` integration binaries cannot
+//! import the app's own binary crate (there is no `src/lib.rs`).
 
 use autumn_web::notifications::{{Notification, Notifications}};
 use autumn_web::prelude::*;
@@ -336,8 +417,26 @@ use serde::Deserialize;
 #[tokio::test]
 async fn notifications_feed_round_trips_over_http() {{
     let client = TestApp::new()
-        .routes(routes![notify, feed, unread_count, mark_read, mark_all_read])
+        .routes(routes![
+            demo_login,
+            notify,
+            feed,
+            unread_count,
+            mark_read,
+            mark_all_read
+        ])
         .build();
+
+    // Anonymous requests are rejected: the feed is session-scoped.
+    client.get("/notifications").send().await.assert_status(401);
+
+    // Demo sign-in as recipient 7 — the cookie jar keeps the session for
+    // the rest of the flow.
+    client
+        .post("/notifications/demo_login/7")
+        .send()
+        .await
+        .assert_ok();
 
     // Notify: POST a notification and get the stored record back.
     let created: Notification = client
@@ -354,9 +453,9 @@ async fn notifications_feed_round_trips_over_http() {{
     assert_eq!(created.recipient_id, 7);
     assert_eq!(created.kind, "comment.created");
 
-    // Feed: the new notification shows up.
+    // Feed (session-scoped): the new notification shows up.
     let feed_page: Page<Notification> = client
-        .get("/notifications/7")
+        .get("/notifications")
         .send()
         .await
         .assert_ok()
@@ -366,21 +465,21 @@ async fn notifications_feed_round_trips_over_http() {{
 
     // The unread badge counts it...
     let unread: u64 = client
-        .get("/notifications/7/unread_count")
+        .get("/notifications/unread_count")
         .send()
         .await
         .assert_ok()
         .json();
     assert_eq!(unread, 1);
 
-    // ...until it is marked read (recipient-scoped).
+    // ...until it is marked read (scoped to the session's recipient).
     client
-        .post(&format!("/notifications/7/read/{{}}", created.id))
+        .post(&format!("/notifications/{{}}/read", created.id))
         .send()
         .await
         .assert_ok();
     let unread: u64 = client
-        .get("/notifications/7/unread_count")
+        .get("/notifications/unread_count")
         .send()
         .await
         .assert_ok()
@@ -389,7 +488,7 @@ async fn notifications_feed_round_trips_over_http() {{
 
     // The unread-only feed is now empty.
     let unread_feed: Page<Notification> = client
-        .get("/notifications/7?filter[unread]=true")
+        .get("/notifications?filter[unread]=true")
         .send()
         .await
         .assert_ok()
@@ -408,19 +507,28 @@ async fn notifications_feed_round_trips_over_http() {{
         .await
         .assert_ok();
     let swept: u64 = client
-        .post("/notifications/7/read_all")
+        .post("/notifications/read_all")
         .send()
         .await
         .assert_ok()
         .json();
     assert_eq!(swept, 1);
-    let unread: u64 = client
-        .get("/notifications/7/unread_count")
+
+    // Cross-recipient isolation: signing in as a different recipient shows
+    // an empty feed — the recipient comes from the session, never a URL,
+    // so recipient 7's notifications are unreachable from this session.
+    client
+        .post("/notifications/demo_login/8")
+        .send()
+        .await
+        .assert_ok();
+    let other_feed: Page<Notification> = client
+        .get("/notifications")
         .send()
         .await
         .assert_ok()
         .json();
-    assert_eq!(unread, 0);
+    assert_eq!(other_feed.total_elements, 0);
 }}
 "#,
         handlers = render_handlers(),
@@ -646,7 +754,7 @@ async fn main() {
     // ── GREEN: app module content ─────────────────────────────────────────
 
     #[test]
-    fn execute_writes_app_module_with_five_handlers_over_the_extractor() {
+    fn execute_writes_app_module_with_session_scoped_handlers() {
         let tmp = project_with_main(default_main());
         plan_notifications(tmp.path())
             .unwrap()
@@ -658,34 +766,87 @@ async fn main() {
             src.contains("use autumn_web::notifications::{Notification, Notifications};"),
             "{src}"
         );
+        // The six routes: a clearly-marked demo login, the demo notify, and
+        // the four session-scoped feed routes (no recipient in the URL).
+        assert!(
+            src.contains(r#"#[post("/notifications/demo_login/{recipient_id}")]"#),
+            "{src}"
+        );
         assert!(src.contains(r#"#[post("/notifications")]"#), "{src}");
+        assert!(src.contains(r#"#[get("/notifications")]"#), "{src}");
         assert!(
-            src.contains(r#"#[get("/notifications/{recipient_id}")]"#),
+            src.contains(r#"#[get("/notifications/unread_count")]"#),
             "{src}"
         );
         assert!(
-            src.contains(r#"#[get("/notifications/{recipient_id}/unread_count")]"#),
+            src.contains(r#"#[post("/notifications/{id}/read")]"#),
             "{src}"
         );
         assert!(
-            src.contains(r#"#[post("/notifications/{recipient_id}/read/{id}")]"#),
+            src.contains(r#"#[post("/notifications/read_all")]"#),
             "{src}"
         );
+        // Every read/mark route derives the recipient server-side from the
+        // session through the shared helper — never from the request.
         assert!(
-            src.contains(r#"#[post("/notifications/{recipient_id}/read_all")]"#),
+            src.contains("async fn current_recipient_id(session: &Session)"),
             "{src}"
         );
-        // The mark-read route must use the recipient-scoped (IDOR-safe)
-        // variant, and say why.
+        assert_eq!(
+            src.matches("current_recipient_id(&session).await?").count(),
+            4,
+            "feed, unread_count, mark_read, and mark_all_read must all resolve \
+             the recipient from the session: {src}"
+        );
+        // An unauthenticated request is rejected, not defaulted.
+        assert!(src.contains("unauthorized"), "{src}");
+        // The mark-read route must additionally use the recipient-scoped
+        // (IDOR-safe) store variant, and say why.
         assert!(src.contains(".mark_read_for(recipient_id, id)"), "{src}");
         assert!(src.contains("IDOR"), "{src}");
-        // The demo notify handler must tell the user to swap the
-        // body-supplied recipient for their auth context.
-        assert!(src.contains("TODO:"), "{src}");
+        // The demo login and demo notify must carry prominent
+        // SECURITY/TODO markers steering users to real auth.
+        assert!(src.contains("SECURITY"), "{src}");
+        assert!(src.contains("TODO"), "{src}");
         // The feed goes through the shipped pagination extractors.
         assert!(src.contains("query: ListQuery"), "{src}");
         assert!(src.contains("page: PageRequest"), "{src}");
         assert!(src.contains("Json<Page<Notification>>"), "{src}");
+    }
+
+    #[test]
+    fn generated_routes_never_take_the_recipient_from_the_url_except_demo_login() {
+        // Regression test for the PR #2144 Codex review finding: a
+        // `{recipient_id}` path segment on any real route lets any caller
+        // read (or mark read) another user's feed — `mark_read_for` scopes
+        // to the *supplied* recipient, not the caller. Only the
+        // clearly-marked demo login may name a recipient in its URL.
+        let tmp = project_with_main(default_main());
+        plan_notifications(tmp.path())
+            .unwrap()
+            .execute(Flags::default())
+            .unwrap();
+
+        let src = fs::read_to_string(tmp.path().join("src/notifications.rs")).unwrap();
+        let route_attrs: Vec<&str> = src
+            .lines()
+            .map(str::trim)
+            .filter(|l| l.starts_with("#[get(") || l.starts_with("#[post("))
+            .collect();
+        assert_eq!(route_attrs.len(), 6, "six routes expected: {route_attrs:?}");
+        let recipient_in_url: Vec<&&str> = route_attrs
+            .iter()
+            .filter(|l| l.contains("{recipient_id}"))
+            .collect();
+        assert_eq!(
+            recipient_in_url,
+            vec![&r#"#[post("/notifications/demo_login/{recipient_id}")]"#],
+            "only the demo login route may take a recipient id from the URL"
+        );
+        // The demo notify's body-supplied recipient stays (server-side
+        // notifies are legitimately cross-recipient), but it must warn that
+        // the route needs protection before production.
+        assert!(src.contains("pub recipient_id: i64"), "{src}");
     }
 
     // ── GREEN: main.rs wiring ─────────────────────────────────────────────
@@ -701,6 +862,7 @@ async fn main() {
         let main = fs::read_to_string(tmp.path().join("src/main.rs")).unwrap();
         assert!(main.contains("mod notifications;"), "{main}");
         for entry in [
+            "notifications::demo_login",
             "notifications::notify",
             "notifications::feed",
             "notifications::unread_count",
@@ -727,22 +889,36 @@ async fn main() {
         let test_src = fs::read_to_string(tmp.path().join("tests/notifications_feed.rs")).unwrap();
         assert!(test_src.contains("TestApp"), "{test_src}");
         assert!(test_src.contains("#[tokio::test]"), "{test_src}");
-        // The full HTTP flow: notify → list → mark_read → unread_count →
-        // unread-only feed empty.
+        // The full session-scoped HTTP flow: anonymous 401 → demo login →
+        // notify → list → mark_read → unread_count → unread-only feed empty.
+        // TestClient's cookie jar carries the session across requests.
+        assert!(test_src.contains("assert_status(401)"), "{test_src}");
+        assert!(
+            test_src.contains(r#".post("/notifications/demo_login/7")"#),
+            "{test_src}"
+        );
         assert!(
             test_src.contains(r#".post("/notifications")"#),
             "{test_src}"
         );
+        assert!(test_src.contains(r#".get("/notifications")"#), "{test_src}");
         assert!(
-            test_src.contains(r#".get("/notifications/7")"#),
+            test_src.contains("/notifications/unread_count"),
             "{test_src}"
         );
-        assert!(
-            test_src.contains("/notifications/7/unread_count"),
-            "{test_src}"
-        );
-        assert!(test_src.contains("/notifications/7/read/"), "{test_src}");
+        assert!(test_src.contains("/read"), "{test_src}");
         assert!(test_src.contains("filter[unread]=true"), "{test_src}");
+        // Cross-recipient protection: a different signed-in recipient sees
+        // an empty feed — the recipient comes from the session, not a URL.
+        assert!(
+            test_src.contains(r#".post("/notifications/demo_login/8")"#),
+            "{test_src}"
+        );
+        // No recipient id in any feed/mark URL.
+        assert!(
+            !test_src.contains("/notifications/7/"),
+            "feed/mark URLs must not carry a recipient id: {test_src}"
+        );
         assert!(
             !test_src.contains("todo!"),
             "must not be a stub: {test_src}"
@@ -804,6 +980,8 @@ async fn main() {
             src[start..=end].to_owned()
         };
         for name in [
+            "current_recipient_id",
+            "demo_login",
             "notify",
             "feed",
             "unread_count",

--- a/autumn-cli/src/generate/notifications.rs
+++ b/autumn-cli/src/generate/notifications.rs
@@ -1,0 +1,931 @@
+//! `autumn generate notifications` — scaffold the in-app notification feed
+//! (issue #1148) on top of the framework's `Notifications` extractor.
+//!
+//! Unlike the name-parameterised generators, notifications are a fixed,
+//! single-instance resource (`autumn_web::notifications` reads one
+//! conventional `notifications` table), so the command takes no name. The
+//! generator produces:
+//! - `migrations/<ts>_create_notifications/{up,down}.sql` — backend-aware
+//!   DDL for the `notifications` table, matching the framework store's
+//!   diesel `table!` mapping byte-for-type (see [`migration_up_sql`]).
+//! - `src/notifications.rs` — notify / feed / unread-count / mark-read /
+//!   mark-all-read route handlers over the `Notifications` extractor.
+//! - `src/main.rs` — `mod notifications;` declaration and the generated
+//!   routes registered in `routes![...]`.
+//! - `tests/notifications_feed.rs` — a smoke test exercising the full
+//!   notify → list → mark-read → unread-count flow through the in-process
+//!   `TestApp` (no database needed: with no DB configured the extractor
+//!   falls back to its in-process memory store).
+//! - `Cargo.toml` — `serde`/`serde_json` dependencies and the `tokio`
+//!   dev-dependency features the smoke test needs for `#[tokio::test]`.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::Path;
+
+use autumn_web::config::DatabaseBackend;
+use autumn_web::notifications::NOTIFICATIONS_TABLE;
+
+use super::dsl::{Field, FieldConstraints, FieldKind, IdType};
+use super::emit::Plan;
+use super::model::ensure_cargo_dependencies;
+use super::schema_edit::{
+    create_table_sql_with_metadata_and_id_for, drop_table_sql,
+    ensure_dev_dependency_tokio_test_features, update_main_rs,
+};
+use super::{GenerateError, detect_backend, ensure_project_root, read_or_empty, timestamp_now};
+
+/// Cargo dependencies the generated module and smoke test require: the
+/// notify body derives `Deserialize` and carries a `serde_json::Value`
+/// payload (the same payload type `Notifications::notify` takes).
+const NOTIFICATIONS_DEPS: &[(&str, &str)] = &[
+    ("serde", "{ version = \"1\", features = [\"derive\"] }"),
+    ("serde_json", "\"1\""),
+];
+
+/// Compute the file actions for `autumn generate notifications`.
+///
+/// # Errors
+/// Project layout errors surface here.
+pub fn plan_notifications(project_root: &Path) -> Result<Plan, GenerateError> {
+    ensure_project_root(project_root)?;
+
+    // The emitted DDL is backend-aware, resolved the same way `autumn
+    // migrate` resolves the database URL (env vars, then the profile-merged
+    // `autumn.toml` / `.env`); Postgres is the default when nothing is
+    // configured.
+    let backend = detect_backend(project_root);
+
+    let mut plan = Plan::new(project_root);
+
+    // ── src/notifications.rs ────────────────────────────────────────────────
+    plan.create(
+        project_root.join("src").join("notifications.rs"),
+        render_app_module(),
+    );
+
+    // ── src/main.rs: add mod notifications; and route entries ───────────────
+    let main_path = project_root.join("src").join("main.rs");
+    let main_existing = std::fs::read_to_string(&main_path).map_err(|e| {
+        GenerateError::Io(std::io::Error::new(
+            e.kind(),
+            format!("{}: {e}", main_path.display()),
+        ))
+    })?;
+    let route_entries = route_entries();
+    plan.modify(
+        main_path.clone(),
+        update_main_rs(&main_existing, &["notifications"], &route_entries),
+    );
+    // `mod notifications;` is stripped by `emit::sync_main_rs_mod_declarations`
+    // once `src/notifications.rs` is gone — only the route entries need an
+    // explicit revert here (same split the channel generator uses).
+    plan.push_revert(crate::generate::emit::Revert::RoutesEntries {
+        path: main_path,
+        entries: route_entries,
+    });
+
+    // ── migrations/<ts>_create_notifications/{up,down}.sql ──────────────────
+    // Destroy matches migration directories by their `_create_notifications`
+    // suffix, so the fresh timestamp taken here never blocks a later revert.
+    let migration_dir = project_root
+        .join("migrations")
+        .join(format!("{}_create_{NOTIFICATIONS_TABLE}", timestamp_now()));
+    plan.create(migration_dir.join("up.sql"), migration_up_sql(backend));
+    plan.create(
+        migration_dir.join("down.sql"),
+        drop_table_sql(NOTIFICATIONS_TABLE),
+    );
+
+    // ── tests/notifications_feed.rs ─────────────────────────────────────────
+    plan.create(
+        project_root.join("tests").join("notifications_feed.rs"),
+        render_smoke_test(),
+    );
+
+    // ── Cargo.toml: serde/serde_json deps + tokio dev-dep test features ─────
+    let cargo_path = project_root.join("Cargo.toml");
+    let cargo_existing = read_or_empty(&cargo_path);
+    let mut updated_cargo = ensure_cargo_dependencies(&cargo_existing, NOTIFICATIONS_DEPS);
+    updated_cargo = ensure_dev_dependency_tokio_test_features(&updated_cargo);
+    if updated_cargo != cargo_existing {
+        plan.modify(cargo_path.clone(), updated_cargo);
+    }
+    // Pushed unconditionally — see `plan_cargo_deps`'s matching comment in
+    // model.rs: destroy recomputes this plan against the already-generated
+    // Cargo.toml, where these entries are by definition already present.
+    // Notifications are a fixed, single-instance resource whose only owned
+    // file is `src/notifications.rs` itself, so there is no sibling resource
+    // directory to gate on — passing the module file as `owner_dir` makes
+    // the same-generator sibling check vacuous (`read_dir` on a file never
+    // yields siblings), leaving `Revert::CargoDeps`'s project-wide
+    // crate-reference scan as the real guard against stripping a dependency
+    // some other code still uses.
+    plan.push_revert(crate::generate::emit::Revert::CargoDeps {
+        path: cargo_path,
+        names: NOTIFICATIONS_DEPS
+            .iter()
+            .map(|(name, _)| (*name).to_owned())
+            .collect(),
+        owner_dir: project_root.join("src").join("notifications.rs"),
+    });
+
+    Ok(plan)
+}
+
+/// Fully-qualified route entries for `routes![...]` wiring in `main.rs`.
+fn route_entries() -> Vec<String> {
+    [
+        "notify",
+        "feed",
+        "unread_count",
+        "mark_read",
+        "mark_all_read",
+    ]
+    .iter()
+    .map(|handler| format!("notifications::{handler}"))
+    .collect()
+}
+
+/// The four non-`id` columns of the `notifications` table, expressed in the
+/// migration DSL so the DDL comes out of the same
+/// [`create_table_sql_with_metadata_and_id_for`] helper every other
+/// generator uses (`id` and `created_at` are contributed by the helper
+/// itself).
+fn notification_fields() -> Vec<Field> {
+    let field = |name: &str, kind: FieldKind, nullable: bool| Field {
+        name: name.to_owned(),
+        kind,
+        nullable,
+        variants: Vec::new(),
+        unique: false,
+        constraints: FieldConstraints::default(),
+        state_machine: None,
+    };
+    vec![
+        field("recipient_id", FieldKind::I64, false),
+        field("kind", FieldKind::String, false),
+        field("payload", FieldKind::String, false),
+        field("read_at", FieldKind::DateTime, true),
+    ]
+}
+
+/// Build `up.sql` for the target `backend`.
+///
+/// The column types must match the framework store's diesel `table!` in
+/// `autumn_web::notifications` (`BigInt`/`Text`/`Text`/
+/// `Nullable<Timestamptz>`/`Timestamptz`; `TimestamptzSqlite` — RFC 3339
+/// `TEXT` — on `SQLite`): that store, not any generated model, is what reads
+/// this table. The shared helper's stock `created_at` column is `TIMESTAMP`
+/// (the model generator's convention, paired with a `Timestamp` `schema.rs`
+/// entry), so the Postgres output rewrites that one column to `TIMESTAMPTZ`,
+/// keeping it in lockstep with the framework's `Timestamptz` mapping and the
+/// `CREATE_NOTIFICATIONS_SQL` DDL its integration tests pin. The `SQLite`
+/// output already matches (`TEXT` + `CURRENT_TIMESTAMP` default) and is left
+/// exactly as the helper emits it.
+fn migration_up_sql(backend: DatabaseBackend) -> String {
+    let indexes: BTreeSet<String> = std::iter::once("recipient_id".to_owned()).collect();
+    let sql = create_table_sql_with_metadata_and_id_for(
+        backend,
+        NOTIFICATIONS_TABLE,
+        &notification_fields(),
+        &indexes,
+        &BTreeMap::new(),
+        IdType::BigSerial,
+    );
+    match backend {
+        DatabaseBackend::Postgres => sql.replace(
+            "created_at TIMESTAMP NOT NULL DEFAULT NOW()",
+            "created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()",
+        ),
+        DatabaseBackend::Sqlite => sql,
+    }
+}
+
+/// The `NotifyBody` type and the five route handlers, shared **verbatim** by
+/// `src/notifications.rs` and `tests/notifications_feed.rs` — `tests/*.rs`
+/// integration binaries cannot import the app's own binary crate (there is
+/// no `src/lib.rs`), so the smoke test re-declares the production handlers,
+/// and rendering both files from this one blob keeps them byte-for-byte in
+/// sync by construction (the same contract `generate channel`'s smoke test
+/// promises).
+const fn render_handlers() -> &'static str {
+    r#"/// `POST /notifications` body: who to notify, an application-defined kind
+/// discriminator (e.g. `"comment.created"`), and a free-form JSON payload.
+#[derive(Deserialize)]
+pub struct NotifyBody {
+    pub recipient_id: i64,
+    pub kind: String,
+    pub payload: serde_json::Value,
+}
+
+/// `POST /notifications` — create a notification from a JSON body and return
+/// the stored record.
+///
+/// TODO: replace the body-supplied `recipient_id` with your auth context
+/// (e.g. a session/`Auth` extractor) once real sign-in exists — in
+/// production the *server* decides who a notification belongs to, never the
+/// request body.
+#[post("/notifications")]
+pub async fn notify(
+    notifications: Notifications,
+    Json(body): Json<NotifyBody>,
+) -> AutumnResult<Json<Notification>> {
+    let notification = notifications
+        .notify(body.recipient_id, body.kind, body.payload)
+        .await?;
+    Ok(Json(notification))
+}
+
+/// `GET /notifications/{recipient_id}` — one page of the recipient's feed.
+///
+/// Supports `?page=`/`?size=` (the `PageRequest` extractor) plus
+/// `?filter[unread]=true`, `?filter[kind]=…`, and `?sort=id|created_at`
+/// (the `ListQuery` extractor); defaults to newest-first.
+#[get("/notifications/{recipient_id}")]
+pub async fn feed(
+    Path(recipient_id): Path<i64>,
+    query: ListQuery,
+    page: PageRequest,
+    notifications: Notifications,
+) -> AutumnResult<Json<Page<Notification>>> {
+    Ok(Json(notifications.list(recipient_id, &query, &page).await?))
+}
+
+/// `GET /notifications/{recipient_id}/unread_count` — the bell-badge number.
+#[get("/notifications/{recipient_id}/unread_count")]
+pub async fn unread_count(
+    Path(recipient_id): Path<i64>,
+    notifications: Notifications,
+) -> AutumnResult<Json<u64>> {
+    Ok(Json(notifications.unread_count(recipient_id).await?))
+}
+
+/// `POST /notifications/{recipient_id}/read/{id}` — mark one notification read.
+///
+/// Uses the recipient-scoped `mark_read_for` rather than the unscoped
+/// `mark_read`: a notification owned by a different recipient is left
+/// untouched (a no-op, not an error), so one user can never mark another
+/// user's notification read (IDOR-safe). Idempotent on re-marking.
+#[post("/notifications/{recipient_id}/read/{id}")]
+pub async fn mark_read(
+    Path((recipient_id, id)): Path<(i64, i64)>,
+    notifications: Notifications,
+) -> AutumnResult<&'static str> {
+    notifications.mark_read_for(recipient_id, id).await?;
+    Ok("ok")
+}
+
+/// `POST /notifications/{recipient_id}/read_all` — mark the whole feed read;
+/// returns how many notifications transitioned (0 on a repeat call).
+#[post("/notifications/{recipient_id}/read_all")]
+pub async fn mark_all_read(
+    Path(recipient_id): Path<i64>,
+    notifications: Notifications,
+) -> AutumnResult<Json<u64>> {
+    Ok(Json(notifications.mark_all_read(recipient_id).await?))
+}
+"#
+}
+
+/// Render `src/notifications.rs`.
+fn render_app_module() -> String {
+    format!(
+        r"//! Generated by `autumn generate notifications`. Edit freely.
+//!
+//! A minimal in-app notification feed over the framework's
+//! [`Notifications`] extractor (`autumn_web::notifications`). Storage
+//! resolves automatically: the `notifications` table scaffolded by the
+//! accompanying migration when a database is configured, an in-process
+//! memory store otherwise — so these routes work before `autumn migrate`
+//! has ever run.
+//!
+//! Optional realtime push: with the `ws` feature enabled, swap `notify` for
+//! `notify_with_push` to also broadcast each stored notification on the
+//! conventional `notifications:{{recipient_id}}` channel topic
+//! (`Notifications::topic`).
+
+use autumn_web::notifications::{{Notification, Notifications}};
+use autumn_web::prelude::*;
+use serde::Deserialize;
+
+{handlers}",
+        handlers = render_handlers(),
+    )
+}
+
+/// Render `tests/notifications_feed.rs` — a real notify → list → mark-read →
+/// unread-count round trip over HTTP, no database required.
+fn render_smoke_test() -> String {
+    format!(
+        r#"//! Smoke test generated by `autumn generate notifications`.
+//!
+//! Exercises the full notify → list → mark-read → unread-count flow over
+//! HTTP through the in-process `TestApp` — no database needed: with no DB
+//! configured the `Notifications` extractor falls back to its in-process
+//! memory store. The handlers below are re-declarations of
+//! `src/notifications.rs`'s handlers of the same names, kept byte-for-byte
+//! in sync — `tests/` integration binaries cannot import the app's own
+//! binary crate (there is no `src/lib.rs`).
+
+use autumn_web::notifications::{{Notification, Notifications}};
+use autumn_web::prelude::*;
+use autumn_web::test::TestApp;
+use serde::Deserialize;
+
+{handlers}
+#[tokio::test]
+async fn notifications_feed_round_trips_over_http() {{
+    let client = TestApp::new()
+        .routes(routes![notify, feed, unread_count, mark_read, mark_all_read])
+        .build();
+
+    // Notify: POST a notification and get the stored record back.
+    let created: Notification = client
+        .post("/notifications")
+        .json(&serde_json::json!({{
+            "recipient_id": 7,
+            "kind": "comment.created",
+            "payload": {{"post": 42}}
+        }}))
+        .send()
+        .await
+        .assert_ok()
+        .json();
+    assert_eq!(created.recipient_id, 7);
+    assert_eq!(created.kind, "comment.created");
+
+    // Feed: the new notification shows up.
+    let feed_page: Page<Notification> = client
+        .get("/notifications/7")
+        .send()
+        .await
+        .assert_ok()
+        .json();
+    assert_eq!(feed_page.total_elements, 1);
+    assert_eq!(feed_page.content[0].id, created.id);
+
+    // The unread badge counts it...
+    let unread: u64 = client
+        .get("/notifications/7/unread_count")
+        .send()
+        .await
+        .assert_ok()
+        .json();
+    assert_eq!(unread, 1);
+
+    // ...until it is marked read (recipient-scoped).
+    client
+        .post(&format!("/notifications/7/read/{{}}", created.id))
+        .send()
+        .await
+        .assert_ok();
+    let unread: u64 = client
+        .get("/notifications/7/unread_count")
+        .send()
+        .await
+        .assert_ok()
+        .json();
+    assert_eq!(unread, 0);
+
+    // The unread-only feed is now empty.
+    let unread_feed: Page<Notification> = client
+        .get("/notifications/7?filter[unread]=true")
+        .send()
+        .await
+        .assert_ok()
+        .json();
+    assert_eq!(unread_feed.total_elements, 0);
+
+    // mark-all-read sweeps the rest of the feed in one call.
+    client
+        .post("/notifications")
+        .json(&serde_json::json!({{
+            "recipient_id": 7,
+            "kind": "like",
+            "payload": {{}}
+        }}))
+        .send()
+        .await
+        .assert_ok();
+    let swept: u64 = client
+        .post("/notifications/7/read_all")
+        .send()
+        .await
+        .assert_ok()
+        .json();
+    assert_eq!(swept, 1);
+    let unread: u64 = client
+        .get("/notifications/7/unread_count")
+        .send()
+        .await
+        .assert_ok()
+        .json();
+    assert_eq!(unread, 0);
+}}
+"#,
+        handlers = render_handlers(),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::generate::Flags;
+    use std::fs;
+    use std::path::{Path, PathBuf};
+    use tempfile::TempDir;
+
+    fn project_with_main(main_content: &str) -> TempDir {
+        let tmp = TempDir::new().unwrap();
+        fs::write(
+            tmp.path().join("Cargo.toml"),
+            "[package]\nname=\"x\"\n\n[dependencies]\nautumn-web = \"0.6\"\n",
+        )
+        .unwrap();
+        fs::create_dir_all(tmp.path().join("src")).unwrap();
+        fs::write(tmp.path().join("src/main.rs"), main_content).unwrap();
+        tmp
+    }
+
+    fn default_main() -> &'static str {
+        r#"use autumn_web::prelude::*;
+
+#[get("/")]
+async fn index() -> &'static str { "ok" }
+
+#[autumn_web::main]
+async fn main() {
+    autumn_web::app()
+        .routes(routes![index])
+        .run()
+        .await;
+}
+"#
+    }
+
+    /// Null the database-URL environment variables so backend detection reads
+    /// the temp project's `autumn.toml` deterministically (a stray real
+    /// `DATABASE_URL` in the dev/CI environment would otherwise win) — same
+    /// guard the model generator's `SQLite` tests use.
+    fn with_no_db_env<R>(f: impl FnOnce() -> R) -> R {
+        temp_env::with_vars(
+            [
+                ("AUTUMN_DATABASE__PRIMARY_URL", None::<&str>),
+                ("AUTUMN_DATABASE__URL", None::<&str>),
+                ("DATABASE_URL", None::<&str>),
+            ],
+            f,
+        )
+    }
+
+    /// The generated migration directory carries a fresh timestamp, so tests
+    /// locate it by its stable `_create_notifications` suffix.
+    fn migration_dir(root: &Path) -> PathBuf {
+        let entries: Vec<PathBuf> = fs::read_dir(root.join("migrations"))
+            .expect("migrations dir must exist")
+            .filter_map(Result::ok)
+            .map(|e| e.path())
+            .filter(|p| {
+                p.file_name()
+                    .and_then(|n| n.to_str())
+                    .is_some_and(|n| n.ends_with("_create_notifications"))
+            })
+            .collect();
+        assert_eq!(
+            entries.len(),
+            1,
+            "exactly one notifications migration: {entries:?}"
+        );
+        entries.into_iter().next().unwrap()
+    }
+
+    // ── RED: file plan assertions ─────────────────────────────────────────
+
+    #[test]
+    fn plan_creates_migration_up_and_down() {
+        let tmp = project_with_main(default_main());
+        let plan = plan_notifications(tmp.path()).unwrap();
+        for suffix in [
+            "_create_notifications/up.sql",
+            "_create_notifications/down.sql",
+        ] {
+            assert!(
+                plan.actions
+                    .iter()
+                    .any(|a| a.path().to_string_lossy().ends_with(suffix)),
+                "plan must include migrations/<ts>{suffix}"
+            );
+        }
+    }
+
+    #[test]
+    fn plan_creates_app_module_and_smoke_test() {
+        let tmp = project_with_main(default_main());
+        let plan = plan_notifications(tmp.path()).unwrap();
+        assert!(
+            plan.actions
+                .iter()
+                .any(|a| a.path().ends_with("src/notifications.rs")),
+            "plan must include src/notifications.rs"
+        );
+        assert!(
+            plan.actions
+                .iter()
+                .any(|a| a.path().ends_with("tests/notifications_feed.rs")),
+            "plan must include tests/notifications_feed.rs"
+        );
+    }
+
+    #[test]
+    fn plan_modifies_main_rs() {
+        let tmp = project_with_main(default_main());
+        let plan = plan_notifications(tmp.path()).unwrap();
+        assert!(
+            plan.actions
+                .iter()
+                .any(|a| a.path().ends_with("src/main.rs")),
+            "plan must modify src/main.rs"
+        );
+    }
+
+    #[test]
+    fn plan_errors_when_not_in_project() {
+        let tmp = TempDir::new().unwrap();
+        let err = plan_notifications(tmp.path()).unwrap_err();
+        assert!(matches!(err, GenerateError::NotInProject));
+    }
+
+    #[test]
+    fn plan_errors_when_main_rs_missing() {
+        let tmp = TempDir::new().unwrap();
+        fs::write(tmp.path().join("Cargo.toml"), "[package]\nname=\"x\"\n").unwrap();
+        let err = plan_notifications(tmp.path()).unwrap_err();
+        assert!(matches!(err, GenerateError::Io(_)));
+    }
+
+    // ── GREEN: migration DDL ──────────────────────────────────────────────
+
+    #[test]
+    fn postgres_migration_matches_framework_store_ddl() {
+        with_no_db_env(|| {
+            // No autumn.toml / DB env → Postgres, the detection default.
+            let tmp = project_with_main(default_main());
+            plan_notifications(tmp.path())
+                .unwrap()
+                .execute(Flags::default())
+                .unwrap();
+
+            let dir = migration_dir(tmp.path());
+            let up = fs::read_to_string(dir.join("up.sql")).unwrap();
+            // Column-for-column the diesel `table!` in
+            // `autumn_web::notifications` (BigInt / Text / Text /
+            // Nullable<Timestamptz> / Timestamptz) and the framework
+            // integration test's CREATE_NOTIFICATIONS_SQL constant — plus
+            // the recipient_id index the feed queries want.
+            assert_eq!(
+                up,
+                "CREATE TABLE notifications (\n\
+                 \x20   id BIGSERIAL PRIMARY KEY,\n\
+                 \x20   recipient_id BIGINT NOT NULL,\n\
+                 \x20   kind TEXT NOT NULL,\n\
+                 \x20   payload TEXT NOT NULL,\n\
+                 \x20   read_at TIMESTAMPTZ NULL,\n\
+                 \x20   created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()\n\
+                 );\n\
+                 CREATE INDEX idx_notifications_recipient_id ON notifications (recipient_id);\n"
+            );
+
+            let down = fs::read_to_string(dir.join("down.sql")).unwrap();
+            assert_eq!(down, "DROP TABLE notifications;\n");
+        });
+    }
+
+    #[test]
+    fn sqlite_project_emits_sqlite_ddl() {
+        with_no_db_env(|| {
+            let tmp = project_with_main(default_main());
+            fs::write(
+                tmp.path().join("autumn.toml"),
+                "[database]\nprimary_url = \"sqlite://app.db\"\n",
+            )
+            .unwrap();
+            plan_notifications(tmp.path())
+                .unwrap()
+                .execute(Flags::default())
+                .unwrap();
+
+            let up = fs::read_to_string(migration_dir(tmp.path()).join("up.sql")).unwrap();
+            assert!(up.contains("id INTEGER PRIMARY KEY AUTOINCREMENT"), "{up}");
+            assert!(up.contains("recipient_id INTEGER NOT NULL"), "{up}");
+            assert!(up.contains("kind TEXT NOT NULL"), "{up}");
+            assert!(up.contains("payload TEXT NOT NULL"), "{up}");
+            // Timestamps are RFC 3339 TEXT on SQLite (diesel's
+            // `TimestamptzSqlite`), matching the framework store's SQLite
+            // `table!` mapping.
+            assert!(up.contains("read_at TEXT NULL"), "{up}");
+            assert!(
+                up.contains("created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP"),
+                "{up}"
+            );
+            assert!(
+                up.contains("CREATE INDEX idx_notifications_recipient_id"),
+                "{up}"
+            );
+            // No Postgres-only DDL may leak into a SQLite migration.
+            for leak in ["BIGSERIAL", "TIMESTAMPTZ", "NOW()", "BIGINT"] {
+                assert!(!up.contains(leak), "SQLite up.sql leaked `{leak}`: {up}");
+            }
+        });
+    }
+
+    // ── GREEN: app module content ─────────────────────────────────────────
+
+    #[test]
+    fn execute_writes_app_module_with_five_handlers_over_the_extractor() {
+        let tmp = project_with_main(default_main());
+        plan_notifications(tmp.path())
+            .unwrap()
+            .execute(Flags::default())
+            .unwrap();
+
+        let src = fs::read_to_string(tmp.path().join("src/notifications.rs")).unwrap();
+        assert!(
+            src.contains("use autumn_web::notifications::{Notification, Notifications};"),
+            "{src}"
+        );
+        assert!(src.contains(r#"#[post("/notifications")]"#), "{src}");
+        assert!(
+            src.contains(r#"#[get("/notifications/{recipient_id}")]"#),
+            "{src}"
+        );
+        assert!(
+            src.contains(r#"#[get("/notifications/{recipient_id}/unread_count")]"#),
+            "{src}"
+        );
+        assert!(
+            src.contains(r#"#[post("/notifications/{recipient_id}/read/{id}")]"#),
+            "{src}"
+        );
+        assert!(
+            src.contains(r#"#[post("/notifications/{recipient_id}/read_all")]"#),
+            "{src}"
+        );
+        // The mark-read route must use the recipient-scoped (IDOR-safe)
+        // variant, and say why.
+        assert!(src.contains(".mark_read_for(recipient_id, id)"), "{src}");
+        assert!(src.contains("IDOR"), "{src}");
+        // The demo notify handler must tell the user to swap the
+        // body-supplied recipient for their auth context.
+        assert!(src.contains("TODO:"), "{src}");
+        // The feed goes through the shipped pagination extractors.
+        assert!(src.contains("query: ListQuery"), "{src}");
+        assert!(src.contains("page: PageRequest"), "{src}");
+        assert!(src.contains("Json<Page<Notification>>"), "{src}");
+    }
+
+    // ── GREEN: main.rs wiring ─────────────────────────────────────────────
+
+    #[test]
+    fn execute_updates_main_rs_with_mod_and_route_entries() {
+        let tmp = project_with_main(default_main());
+        plan_notifications(tmp.path())
+            .unwrap()
+            .execute(Flags::default())
+            .unwrap();
+
+        let main = fs::read_to_string(tmp.path().join("src/main.rs")).unwrap();
+        assert!(main.contains("mod notifications;"), "{main}");
+        for entry in [
+            "notifications::notify",
+            "notifications::feed",
+            "notifications::unread_count",
+            "notifications::mark_read",
+            "notifications::mark_all_read",
+        ] {
+            assert!(
+                main.contains(entry),
+                "main.rs must register {entry}: {main}"
+            );
+        }
+    }
+
+    // ── GREEN: smoke test content ─────────────────────────────────────────
+
+    #[test]
+    fn execute_writes_smoke_test_with_testapp_flow() {
+        let tmp = project_with_main(default_main());
+        plan_notifications(tmp.path())
+            .unwrap()
+            .execute(Flags::default())
+            .unwrap();
+
+        let test_src = fs::read_to_string(tmp.path().join("tests/notifications_feed.rs")).unwrap();
+        assert!(test_src.contains("TestApp"), "{test_src}");
+        assert!(test_src.contains("#[tokio::test]"), "{test_src}");
+        // The full HTTP flow: notify → list → mark_read → unread_count →
+        // unread-only feed empty.
+        assert!(
+            test_src.contains(r#".post("/notifications")"#),
+            "{test_src}"
+        );
+        assert!(
+            test_src.contains(r#".get("/notifications/7")"#),
+            "{test_src}"
+        );
+        assert!(
+            test_src.contains("/notifications/7/unread_count"),
+            "{test_src}"
+        );
+        assert!(test_src.contains("/notifications/7/read/"), "{test_src}");
+        assert!(test_src.contains("filter[unread]=true"), "{test_src}");
+        assert!(
+            !test_src.contains("todo!"),
+            "must not be a stub: {test_src}"
+        );
+        assert!(
+            !test_src.contains("#[ignore"),
+            "smoke test must actually run (no DB/Docker needed): {test_src}"
+        );
+    }
+
+    #[test]
+    fn smoke_test_handlers_match_production_handlers_byte_for_byte() {
+        // The smoke test's doc comment promises its handlers are
+        // "re-declarations of src/notifications.rs's handlers of the same
+        // names, kept byte-for-byte in sync" (`tests/` integration binaries
+        // cannot import the app's binary crate), so they must actually be —
+        // the same contract the channel generator's smoke test enforces.
+        let tmp = project_with_main(default_main());
+        plan_notifications(tmp.path())
+            .unwrap()
+            .execute(Flags::default())
+            .unwrap();
+
+        let production_src = fs::read_to_string(tmp.path().join("src/notifications.rs")).unwrap();
+        let test_src = fs::read_to_string(tmp.path().join("tests/notifications_feed.rs")).unwrap();
+
+        // The shared JSON body type must be re-declared too.
+        assert!(
+            production_src.contains("pub struct NotifyBody"),
+            "{production_src}"
+        );
+        assert!(test_src.contains("pub struct NotifyBody"), "{test_src}");
+
+        // Extract each handler (signature + brace-balanced body, so trailing
+        // content like the smoke test's own #[tokio::test] fn is never swept
+        // in) and confirm production and test agree byte-for-byte.
+        let extract_handler = |src: &str, name: &str| -> String {
+            let anchor = format!("async fn {name}(");
+            let start = src
+                .find(&anchor)
+                .unwrap_or_else(|| panic!("`{anchor}` not found in:\n{src}"));
+            let brace_start = src[start..].find('{').unwrap() + start;
+            let bytes = src.as_bytes();
+            let mut depth = 0usize;
+            let mut end = brace_start;
+            for (offset, &b) in bytes[brace_start..].iter().enumerate() {
+                match b {
+                    b'{' => depth += 1,
+                    b'}' => {
+                        depth -= 1;
+                        if depth == 0 {
+                            end = brace_start + offset;
+                            break;
+                        }
+                    }
+                    _ => {}
+                }
+            }
+            src[start..=end].to_owned()
+        };
+        for name in [
+            "notify",
+            "feed",
+            "unread_count",
+            "mark_read",
+            "mark_all_read",
+        ] {
+            assert_eq!(
+                extract_handler(&production_src, name),
+                extract_handler(&test_src, name),
+                "the smoke test's re-declared `{name}` handler must be \
+                 byte-identical to the production handler"
+            );
+        }
+    }
+
+    // ── GREEN: Cargo.toml ─────────────────────────────────────────────────
+
+    #[test]
+    fn execute_adds_serde_serde_json_and_tokio_dev_dependency() {
+        let tmp = project_with_main(default_main());
+        plan_notifications(tmp.path())
+            .unwrap()
+            .execute(Flags::default())
+            .unwrap();
+
+        let cargo = fs::read_to_string(tmp.path().join("Cargo.toml")).unwrap();
+        // The handlers derive `Deserialize` and take a `serde_json::Value`
+        // payload; the smoke test additionally needs `#[tokio::test]`.
+        assert!(cargo.contains("serde"), "{cargo}");
+        assert!(cargo.contains("serde_json"), "{cargo}");
+        assert!(cargo.contains("[dev-dependencies]"), "{cargo}");
+        assert!(cargo.contains("tokio"), "{cargo}");
+    }
+
+    // ── Flag behaviour ────────────────────────────────────────────────────
+
+    #[test]
+    fn dry_run_writes_no_new_files() {
+        let tmp = project_with_main(default_main());
+        let original_main = fs::read_to_string(tmp.path().join("src/main.rs")).unwrap();
+        let original_cargo = fs::read_to_string(tmp.path().join("Cargo.toml")).unwrap();
+        plan_notifications(tmp.path())
+            .unwrap()
+            .execute(Flags {
+                dry_run: true,
+                force: false,
+            })
+            .unwrap();
+
+        assert!(!tmp.path().join("src/notifications.rs").exists());
+        assert!(!tmp.path().join("tests/notifications_feed.rs").exists());
+        assert!(!tmp.path().join("migrations").exists());
+        let main_after = fs::read_to_string(tmp.path().join("src/main.rs")).unwrap();
+        assert_eq!(original_main, main_after, "dry run must not modify main.rs");
+        let cargo_after = fs::read_to_string(tmp.path().join("Cargo.toml")).unwrap();
+        assert_eq!(
+            original_cargo, cargo_after,
+            "dry run must not modify Cargo.toml"
+        );
+    }
+
+    #[test]
+    fn collision_without_force_returns_error() {
+        let tmp = project_with_main(default_main());
+        fs::write(tmp.path().join("src/notifications.rs"), "// existing").unwrap();
+        let err = plan_notifications(tmp.path())
+            .unwrap()
+            .execute(Flags::default())
+            .unwrap_err();
+        assert!(matches!(err, GenerateError::Collisions(_)));
+    }
+
+    #[test]
+    fn force_overwrites_existing_module() {
+        let tmp = project_with_main(default_main());
+        fs::write(tmp.path().join("src/notifications.rs"), "// old").unwrap();
+        plan_notifications(tmp.path())
+            .unwrap()
+            .execute(Flags {
+                force: true,
+                dry_run: false,
+            })
+            .unwrap();
+
+        let src = fs::read_to_string(tmp.path().join("src/notifications.rs")).unwrap();
+        assert!(src.contains("Notifications"), "{src}");
+    }
+
+    // ── Destroy round-trip ────────────────────────────────────────────────
+
+    #[test]
+    fn generate_then_destroy_round_trips_to_original_project_state() {
+        with_no_db_env(|| {
+            let tmp = project_with_main(default_main());
+            // Mirrors a real `autumn new` project's Cargo.toml: a `tokio`
+            // dev-dependency with `rt`/`macros` already present, so
+            // `ensure_dev_dependency_tokio_test_features` (which has no
+            // destroy wiring yet — a documented gap, same as the channel
+            // generator) is a no-op here, matching reality.
+            let cargo_path = tmp.path().join("Cargo.toml");
+            fs::write(
+                &cargo_path,
+                "[package]\nname=\"x\"\n\n[dependencies]\nautumn-web = \"0.6\"\n\n\
+                 [dev-dependencies]\ntokio = { version = \"1\", features = [\"rt\", \"macros\"] }\n",
+            )
+            .unwrap();
+            let main_path = tmp.path().join("src/main.rs");
+            let original_cargo = fs::read_to_string(&cargo_path).unwrap();
+            let original_main = fs::read_to_string(&main_path).unwrap();
+
+            let plan = plan_notifications(tmp.path()).unwrap();
+            plan.execute(Flags::default()).unwrap();
+            assert!(tmp.path().join("src/notifications.rs").exists());
+            assert!(
+                fs::read_to_string(&main_path)
+                    .unwrap()
+                    .contains("notifications::notify")
+            );
+
+            let destroy_plan = plan_notifications(tmp.path()).unwrap();
+            destroy_plan.revert(Flags::default()).unwrap();
+
+            assert!(!tmp.path().join("src/notifications.rs").exists());
+            assert!(!tmp.path().join("tests/notifications_feed.rs").exists());
+            assert!(!tmp.path().join("migrations").exists());
+            assert_eq!(fs::read_to_string(&main_path).unwrap(), original_main);
+            assert_eq!(fs::read_to_string(&cargo_path).unwrap(), original_cargo);
+        });
+    }
+}

--- a/autumn-cli/src/main.rs
+++ b/autumn-cli/src/main.rs
@@ -2154,6 +2154,38 @@ enum GenerateCommands {
         #[arg(long)]
         force: bool,
     },
+    /// Scaffold the in-app notification feed: a `notifications` table
+    /// migration, notify/feed/unread-count/mark-read routes over the built-in
+    /// `Notifications` extractor, `main.rs` route wiring, and an in-process
+    /// smoke test.
+    ///
+    /// Notifications are a fixed, single-instance resource (the framework's
+    /// `Notifications` extractor reads one conventional `notifications`
+    /// table), so this command takes no name argument.
+    ///
+    /// Creates:
+    ///
+    /// - `migrations/<ts>_create_notifications/` — backend-aware table DDL
+    /// - `src/notifications.rs`  — notify / feed / unread-count / mark-read /
+    ///   mark-all-read route handlers
+    /// - `src/main.rs`           — `mod notifications;` + route registration
+    /// - `tests/notifications_feed.rs` — smoke test over the in-process
+    ///   `TestApp` (no database needed: memory-store fallback)
+    /// - `Cargo.toml`            — `serde`/`serde_json` deps and the tokio
+    ///   dev-dependency test features
+    ///
+    /// Example:
+    ///
+    ///   autumn generate notifications
+    #[command(verbatim_doc_comment)]
+    Notifications {
+        /// Print the file plan and exit without writing anything.
+        #[arg(long)]
+        dry_run: bool,
+        /// Overwrite existing files instead of erroring on collision.
+        #[arg(long)]
+        force: bool,
+    },
     /// Generate a complete browser authentication flow: signup, login, logout,
     /// account/profile, forgot-password, and reset-password.
     ///
@@ -3708,6 +3740,10 @@ fn run_generate_command(cmd: GenerateCommands, mode: ApplyMode) {
                 generate::channel::Transport::Sse
             };
             let plan = generate::channel::plan_channel(&resolve_cwd(), &name, transport);
+            apply_plan(plan, generate::Flags { dry_run, force }, mode);
+        }
+        GenerateCommands::Notifications { dry_run, force } => {
+            let plan = generate::notifications::plan_notifications(&resolve_cwd());
             apply_plan(plan, generate::Flags { dry_run, force }, mode);
         }
         GenerateCommands::InboundMail {
@@ -6650,6 +6686,48 @@ mod tests {
     #[test]
     fn parse_generate_channel_without_name_is_error() {
         assert!(Cli::try_parse_from(["autumn", "generate", "channel"]).is_err());
+    }
+
+    // ── autumn generate notifications tests ────────────────────────────────
+
+    #[test]
+    fn parse_generate_notifications_takes_no_name() {
+        let cli = Cli::try_parse_from(["autumn", "generate", "notifications"]).unwrap();
+        let Commands::Generate(GenerateCommands::Notifications { dry_run, force }) = cli.command
+        else {
+            panic!("expected generate notifications");
+        };
+        assert!(!dry_run);
+        assert!(!force);
+        // A fixed resource: a stray name argument must be rejected.
+        assert!(Cli::try_parse_from(["autumn", "generate", "notifications", "Feed"]).is_err());
+    }
+
+    #[test]
+    fn parse_generate_notifications_with_dry_run_and_force() {
+        let cli = Cli::try_parse_from([
+            "autumn",
+            "generate",
+            "notifications",
+            "--dry-run",
+            "--force",
+        ])
+        .unwrap();
+        let Commands::Generate(GenerateCommands::Notifications { dry_run, force }) = cli.command
+        else {
+            panic!("expected generate notifications");
+        };
+        assert!(dry_run);
+        assert!(force);
+    }
+
+    #[test]
+    fn parse_destroy_notifications() {
+        let cli = Cli::try_parse_from(["autumn", "destroy", "notifications"]).unwrap();
+        assert!(matches!(
+            cli.command,
+            Commands::Destroy(GenerateCommands::Notifications { .. })
+        ));
     }
 
     // ── autumn maintenance tests ───────────────────────────────────────────────

--- a/autumn/src/app.rs
+++ b/autumn/src/app.rs
@@ -2118,6 +2118,40 @@ impl AppBuilder {
         })
     }
 
+    /// Register a notification store, overriding the default resolution used
+    /// by the [`Notifications`] extractor.
+    ///
+    /// Without this call the extractor resolves its store automatically: the
+    /// database-backed [`DbNotificationStore`] when a pool is configured (the
+    /// `notifications` table is scaffolded by `autumn generate
+    /// notifications`), the process-local
+    /// [`MemoryNotificationStore`](crate::notifications::MemoryNotificationStore)
+    /// otherwise. Register a store explicitly to plug in a custom backend.
+    ///
+    /// # Example
+    ///
+    /// ```rust,ignore
+    /// use autumn_web::notifications::MemoryNotificationStore;
+    ///
+    /// autumn_web::app()
+    ///     .with_notification_store(MemoryNotificationStore::new())
+    ///     .run()
+    ///     .await;
+    /// ```
+    ///
+    /// [`Notifications`]: crate::notifications::Notifications
+    /// [`DbNotificationStore`]: crate::notifications::DbNotificationStore
+    #[must_use]
+    pub fn with_notification_store<S>(self, store: S) -> Self
+    where
+        S: crate::notifications::NotificationStore,
+    {
+        let service = crate::notifications::Notifications::new(store);
+        self.state_initializer(move |state| {
+            state.insert_extension(service);
+        })
+    }
+
     /// Register an experiment store with a custom [`ExposureSink`].
     ///
     /// Use when you want to forward exposure events to an analytics pipeline

--- a/autumn/src/lib.rs
+++ b/autumn/src/lib.rs
@@ -357,8 +357,6 @@ pub mod middleware;
 /// Content-negotiated success responder (`Negotiate` / `Negotiated` / `Format`).
 #[cfg(feature = "maud")]
 pub mod negotiate;
-/// First-class in-app notifications store with a read/unread feed
-/// ([`notifications::Notifications`]).
 pub mod notifications;
 pub mod openapi;
 pub mod pagination;

--- a/autumn/src/lib.rs
+++ b/autumn/src/lib.rs
@@ -357,6 +357,9 @@ pub mod middleware;
 /// Content-negotiated success responder (`Negotiate` / `Negotiated` / `Format`).
 #[cfg(feature = "maud")]
 pub mod negotiate;
+/// First-class in-app notifications store with a read/unread feed
+/// ([`notifications::Notifications`]).
+pub mod notifications;
 pub mod openapi;
 pub mod pagination;
 pub mod paths;

--- a/autumn/src/notifications.rs
+++ b/autumn/src/notifications.rs
@@ -1,0 +1,977 @@
+//! First-class in-app notification store with a read/unread feed (issue
+//! #1148).
+//!
+//! Nearly every account-based app grows a "notification bell": a persistent,
+//! per-recipient feed with read/unread state and an unread count. This module
+//! ships that composition on top of the primitives Autumn already provides —
+//! the database layer for persistence, [`Page`]/[`ListQuery`] for the feed,
+//! and (optionally) `channels` for realtime push — so an app adds a feed with
+//! one `notify(...)` call instead of a hand-rolled table and four queries.
+//!
+//! # Quick start
+//!
+//! Declare the [`Notifications`] extractor in any handler:
+//!
+//! ```rust,ignore
+//! use autumn_web::notifications::Notifications;
+//! use autumn_web::prelude::*;
+//!
+//! #[post("/comments")]
+//! async fn create_comment(notifications: Notifications) -> AutumnResult<&'static str> {
+//!     // ... create the comment ...
+//!     notifications
+//!         .notify(recipient_id, "comment.created", serde_json::json!({"post": 42}))
+//!         .await?;
+//!     Ok("ok")
+//! }
+//! ```
+//!
+//! Reading the feed reuses the shipped pagination types:
+//!
+//! ```rust,ignore
+//! #[get("/notifications")]
+//! async fn feed(
+//!     Auth(user): Auth<CurrentUser>,
+//!     query: ListQuery,
+//!     page: PageRequest,
+//!     notifications: Notifications,
+//! ) -> AutumnResult<Json<Page<Notification>>> {
+//!     Ok(Json(notifications.list(user.id, &query, &page).await?))
+//! }
+//! ```
+//!
+//! # Storage backends
+//!
+//! [`Notifications`] delegates to a pluggable [`NotificationStore`], resolved
+//! per app in this order:
+//!
+//! 1. A store registered via `AppBuilder::with_notification_store(...)`.
+//! 2. [`DbNotificationStore`] when a database pool is configured (the
+//!    `notifications` table is scaffolded by `autumn generate notifications`).
+//! 3. [`MemoryNotificationStore`] otherwise — a process-local fallback for
+//!    tests and DB-less development.
+//!
+//! This mirrors how `Session` resolves its `SessionStore`.
+//!
+//! # Realtime push over `channels` (optional, best-effort)
+//!
+//! With the `ws` feature enabled, [`Notifications::notify_with_push`] persists
+//! the notification and then publishes its JSON on the conventional
+//! per-recipient topic [`Notifications::topic`] (`notifications:{recipient}`).
+//! The broadcast is **best-effort**: a channel failure (including the common
+//! "no subscribers" case) never fails `notify`. Equivalent manual wiring:
+//!
+//! ```rust,ignore
+//! let n = notifications.notify(user.id, "like", payload).await?;
+//! // Best-effort: ignore the publish result.
+//! let _ = state
+//!     .broadcast()
+//!     .publish(&Notifications::topic(user.id), serde_json::to_string(&n)?);
+//! ```
+//!
+//! # List filters and ordering
+//!
+//! [`Notifications::list`] understands two equality filters from
+//! [`ListQuery`]: `unread` (`filter[unread]=true` keeps only rows whose
+//! `read_at` is unset) and `kind` (`filter[kind]=comment.created`). Sorting
+//! accepts `id` or `created_at`; without an explicit `sort=` the feed returns
+//! newest-first. Unknown filters and sort keys are ignored, matching the
+//! repository `list()` contract.
+
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::error::{AutumnError, AutumnResult};
+use crate::pagination::{ListQuery, Page, PageRequest, SortDir};
+use crate::state::AppState;
+
+/// The `notifications` table name shared by [`DbNotificationStore`] and the
+/// `autumn generate notifications` scaffolding.
+pub const NOTIFICATIONS_TABLE: &str = "notifications";
+
+// ── Record ──────────────────────────────────────────────────────────────────
+
+/// A persisted per-recipient notification.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Notification {
+    /// Primary key.
+    pub id: i64,
+    /// The user this notification belongs to.
+    pub recipient_id: i64,
+    /// Application-defined discriminator, e.g. `"comment.created"`.
+    pub kind: String,
+    /// Application-defined JSON payload.
+    pub payload: Value,
+    /// When the notification was marked read; `None` while unread.
+    pub read_at: Option<DateTime<Utc>>,
+    /// Creation time.
+    pub created_at: DateTime<Utc>,
+}
+
+impl Notification {
+    /// `true` once the notification has been marked read.
+    #[must_use]
+    pub const fn is_read(&self) -> bool {
+        self.read_at.is_some()
+    }
+}
+
+// ── Store error ─────────────────────────────────────────────────────────────
+
+/// Error returned by [`NotificationStore`] implementations.
+#[derive(Debug)]
+pub struct NotificationStoreError {
+    message: String,
+}
+
+impl NotificationStoreError {
+    /// Create a new error with the given message.
+    #[must_use]
+    pub fn new(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+        }
+    }
+}
+
+impl std::fmt::Display for NotificationStoreError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "notification store error: {}", self.message)
+    }
+}
+
+impl std::error::Error for NotificationStoreError {}
+
+// ── Store trait ─────────────────────────────────────────────────────────────
+
+/// Pluggable notification storage backend.
+///
+/// Implement this to store notifications somewhere other than the built-in
+/// backends. All read/unread semantics live in the store so every backend
+/// behaves identically:
+///
+/// - `unread_count` and the `unread` list filter count only rows whose
+///   `read_at` is unset.
+/// - `mark_read`/`mark_all_read` are idempotent: re-marking a read
+///   notification is a no-op (it must not error and must not overwrite the
+///   original `read_at`).
+pub trait NotificationStore: Send + Sync + 'static {
+    /// Persist a new, unread notification and return the stored record.
+    fn notify(
+        &self,
+        recipient_id: i64,
+        kind: String,
+        payload: Value,
+    ) -> impl Future<Output = Result<Notification, NotificationStoreError>> + Send;
+
+    /// One page of the recipient's feed. See the module docs for the
+    /// supported filters (`unread`, `kind`) and sort keys (`id`,
+    /// `created_at`; default newest-first).
+    fn list(
+        &self,
+        recipient_id: i64,
+        query: &ListQuery,
+        page: &PageRequest,
+    ) -> impl Future<Output = Result<Page<Notification>, NotificationStoreError>> + Send;
+
+    /// Number of unread notifications for the recipient.
+    fn unread_count(
+        &self,
+        recipient_id: i64,
+    ) -> impl Future<Output = Result<u64, NotificationStoreError>> + Send;
+
+    /// Mark one notification read, optionally scoped to a recipient. Returns
+    /// the number of rows transitioned (0 when already read, missing, or —
+    /// with a recipient scope — owned by someone else).
+    fn mark_read(
+        &self,
+        id: i64,
+        recipient_id: Option<i64>,
+    ) -> impl Future<Output = Result<u64, NotificationStoreError>> + Send;
+
+    /// Mark all of the recipient's unread notifications read. Returns the
+    /// number of rows transitioned.
+    fn mark_all_read(
+        &self,
+        recipient_id: i64,
+    ) -> impl Future<Output = Result<u64, NotificationStoreError>> + Send;
+}
+
+// ── Erasure bridge (same shape as session::BoxedSessionStore) ───────────────
+//
+// `NotificationStore` uses RPIT futures and is not dyn-compatible, so
+// [`Notifications`] holds a pub(crate) shadow trait with a blanket impl.
+// Users only ever see `NotificationStore`.
+
+type BoxedFuture<'a, T> =
+    Pin<Box<dyn Future<Output = Result<T, NotificationStoreError>> + Send + 'a>>;
+
+pub(crate) trait BoxedNotificationStore: Send + Sync + 'static {
+    fn boxed_notify(
+        &self,
+        recipient_id: i64,
+        kind: String,
+        payload: Value,
+    ) -> BoxedFuture<'_, Notification>;
+    fn boxed_list(
+        &self,
+        recipient_id: i64,
+        query: ListQuery,
+        page: PageRequest,
+    ) -> BoxedFuture<'_, Page<Notification>>;
+    fn boxed_unread_count(&self, recipient_id: i64) -> BoxedFuture<'_, u64>;
+    fn boxed_mark_read(&self, id: i64, recipient_id: Option<i64>) -> BoxedFuture<'_, u64>;
+    fn boxed_mark_all_read(&self, recipient_id: i64) -> BoxedFuture<'_, u64>;
+}
+
+impl<S: NotificationStore> BoxedNotificationStore for S {
+    fn boxed_notify(
+        &self,
+        recipient_id: i64,
+        kind: String,
+        payload: Value,
+    ) -> BoxedFuture<'_, Notification> {
+        Box::pin(NotificationStore::notify(self, recipient_id, kind, payload))
+    }
+
+    fn boxed_list(
+        &self,
+        recipient_id: i64,
+        query: ListQuery,
+        page: PageRequest,
+    ) -> BoxedFuture<'_, Page<Notification>> {
+        Box::pin(async move { NotificationStore::list(self, recipient_id, &query, &page).await })
+    }
+
+    fn boxed_unread_count(&self, recipient_id: i64) -> BoxedFuture<'_, u64> {
+        Box::pin(NotificationStore::unread_count(self, recipient_id))
+    }
+
+    fn boxed_mark_read(&self, id: i64, recipient_id: Option<i64>) -> BoxedFuture<'_, u64> {
+        Box::pin(NotificationStore::mark_read(self, id, recipient_id))
+    }
+
+    fn boxed_mark_all_read(&self, recipient_id: i64) -> BoxedFuture<'_, u64> {
+        Box::pin(NotificationStore::mark_all_read(self, recipient_id))
+    }
+}
+
+// ── Service / extractor ─────────────────────────────────────────────────────
+
+/// The in-app notifications service.
+///
+/// Declare it as a handler parameter (it implements `FromRequestParts`, like
+/// [`Session`](crate::session::Session)) or construct one directly with
+/// [`Notifications::new`] in tests and background jobs. See the module docs
+/// for store resolution and examples.
+#[derive(Clone)]
+pub struct Notifications {
+    store: Arc<dyn BoxedNotificationStore>,
+    #[cfg(feature = "ws")]
+    channels: Option<crate::channels::Channels>,
+}
+
+impl Notifications {
+    /// Build a service over an explicit store.
+    #[must_use]
+    pub fn new(store: impl NotificationStore) -> Self {
+        Self {
+            store: Arc::new(store),
+            #[cfg(feature = "ws")]
+            channels: None,
+        }
+    }
+
+    /// The conventional per-recipient channel topic
+    /// (`notifications:{recipient_id}`) used by
+    /// [`notify_with_push`](Self::notify_with_push) and available to
+    /// subscribers (e.g. a WebSocket feed handler).
+    #[must_use]
+    pub fn topic(recipient_id: i64) -> String {
+        format!("notifications:{recipient_id}")
+    }
+
+    /// Persist a new, unread notification for `recipient_id` and return it.
+    ///
+    /// The write is immediately visible to [`list`](Self::list) and
+    /// [`unread_count`](Self::unread_count).
+    ///
+    /// # Errors
+    ///
+    /// Returns a 500 [`AutumnError`] when the underlying store fails.
+    pub async fn notify(
+        &self,
+        recipient_id: i64,
+        kind: impl Into<String>,
+        payload: Value,
+    ) -> AutumnResult<Notification> {
+        self.store
+            .boxed_notify(recipient_id, kind.into(), payload)
+            .await
+            .map_err(AutumnError::internal_server_error)
+    }
+
+    /// [`notify`](Self::notify), then publish the stored notification as JSON
+    /// on [`Notifications::topic`] over the app's `channels` transport.
+    ///
+    /// The broadcast is **best-effort**: any publish failure (most commonly
+    /// "no subscribers on the topic") is ignored and never fails the notify.
+    /// Outside of a request context (a service built with
+    /// [`Notifications::new`]) there is no channel registry and the push is
+    /// skipped entirely.
+    ///
+    /// # Errors
+    ///
+    /// Returns a 500 [`AutumnError`] when the underlying store fails —
+    /// never because of the channel publish.
+    #[cfg(feature = "ws")]
+    pub async fn notify_with_push(
+        &self,
+        recipient_id: i64,
+        kind: impl Into<String>,
+        payload: Value,
+    ) -> AutumnResult<Notification> {
+        let notification = self.notify(recipient_id, kind, payload).await?;
+        if let Some(channels) = &self.channels
+            && let Ok(json) = serde_json::to_string(&notification)
+        {
+            // Best-effort: a dead or subscriber-less channel never fails
+            // notify.
+            let _ = channels
+                .broadcast()
+                .publish(&Self::topic(recipient_id), json);
+        }
+        Ok(notification)
+    }
+
+    /// One page of the recipient's feed. See the module docs for the
+    /// supported [`ListQuery`] filters and sort keys.
+    ///
+    /// # Errors
+    ///
+    /// Returns a 500 [`AutumnError`] when the underlying store fails.
+    pub async fn list(
+        &self,
+        recipient_id: i64,
+        query: &ListQuery,
+        page: &PageRequest,
+    ) -> AutumnResult<Page<Notification>> {
+        self.store
+            .boxed_list(recipient_id, query.clone(), *page)
+            .await
+            .map_err(AutumnError::internal_server_error)
+    }
+
+    /// Number of unread notifications for the recipient.
+    ///
+    /// # Errors
+    ///
+    /// Returns a 500 [`AutumnError`] when the underlying store fails.
+    pub async fn unread_count(&self, recipient_id: i64) -> AutumnResult<u64> {
+        self.store
+            .boxed_unread_count(recipient_id)
+            .await
+            .map_err(AutumnError::internal_server_error)
+    }
+
+    /// Mark one notification read. Idempotent: re-marking a read notification
+    /// (or a missing id) is a no-op, and the original `read_at` is preserved.
+    ///
+    /// This variant is unscoped — any notification id can be marked. In a
+    /// handler acting on behalf of a signed-in user prefer
+    /// [`mark_read_for`](Self::mark_read_for), which refuses to touch other
+    /// recipients' notifications.
+    ///
+    /// # Errors
+    ///
+    /// Returns a 500 [`AutumnError`] when the underlying store fails.
+    pub async fn mark_read(&self, id: i64) -> AutumnResult<()> {
+        self.store
+            .boxed_mark_read(id, None)
+            .await
+            .map(|_| ())
+            .map_err(AutumnError::internal_server_error)
+    }
+
+    /// Mark one of `recipient_id`'s own notifications read. A notification
+    /// owned by a different recipient is left untouched (a no-op, not an
+    /// error), making this the safe choice for user-facing handlers.
+    ///
+    /// # Errors
+    ///
+    /// Returns a 500 [`AutumnError`] when the underlying store fails.
+    pub async fn mark_read_for(&self, recipient_id: i64, id: i64) -> AutumnResult<()> {
+        self.store
+            .boxed_mark_read(id, Some(recipient_id))
+            .await
+            .map(|_| ())
+            .map_err(AutumnError::internal_server_error)
+    }
+
+    /// Mark all of the recipient's unread notifications read and return how
+    /// many transitioned. Idempotent: a second call returns 0.
+    ///
+    /// # Errors
+    ///
+    /// Returns a 500 [`AutumnError`] when the underlying store fails.
+    pub async fn mark_all_read(&self, recipient_id: i64) -> AutumnResult<u64> {
+        self.store
+            .boxed_mark_all_read(recipient_id)
+            .await
+            .map_err(AutumnError::internal_server_error)
+    }
+
+    /// Default service for an app that never registered a store: the
+    /// database-backed store when a pool is configured, the in-memory store
+    /// otherwise.
+    fn default_for(state: &AppState) -> Self {
+        #[cfg(feature = "db")]
+        if let Some(pool) = crate::db::DbState::pool(state) {
+            return Self::new(DbNotificationStore::new(pool.clone()));
+        }
+        Self::new(MemoryNotificationStore::new())
+    }
+}
+
+impl std::fmt::Debug for Notifications {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Notifications").finish_non_exhaustive()
+    }
+}
+
+impl axum::extract::FromRequestParts<AppState> for Notifications {
+    type Rejection = AutumnError;
+
+    async fn from_request_parts(
+        _parts: &mut axum::http::request::Parts,
+        state: &AppState,
+    ) -> Result<Self, Self::Rejection> {
+        // `extension_or_insert_with` keeps the resolved service (and thus the
+        // memory store's contents) stable across requests, and lets
+        // `AppBuilder::with_notification_store` pre-empt the default.
+        let service = state.extension_or_insert_with::<Self>(|| Self::default_for(state));
+        #[cfg_attr(not(feature = "ws"), allow(unused_mut))]
+        let mut service = (*service).clone();
+        #[cfg(feature = "ws")]
+        {
+            service.channels = Some(state.channels().clone());
+        }
+        Ok(service)
+    }
+}
+
+// ── In-memory store ─────────────────────────────────────────────────────────
+
+/// Process-local [`NotificationStore`] used by default when no database is
+/// configured. Suitable for tests and DB-less development; contents are lost
+/// on restart.
+#[derive(Debug, Default)]
+pub struct MemoryNotificationStore {
+    inner: std::sync::Mutex<MemoryInner>,
+}
+
+#[derive(Debug, Default)]
+struct MemoryInner {
+    next_id: i64,
+    rows: Vec<Notification>,
+}
+
+impl MemoryNotificationStore {
+    /// Create an empty store.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    fn lock(&self) -> Result<std::sync::MutexGuard<'_, MemoryInner>, NotificationStoreError> {
+        self.inner
+            .lock()
+            .map_err(|_| NotificationStoreError::new("memory store mutex poisoned"))
+    }
+}
+
+impl NotificationStore for MemoryNotificationStore {
+    async fn notify(
+        &self,
+        recipient_id: i64,
+        kind: String,
+        payload: Value,
+    ) -> Result<Notification, NotificationStoreError> {
+        let mut inner = self.lock()?;
+        inner.next_id += 1;
+        let notification = Notification {
+            id: inner.next_id,
+            recipient_id,
+            kind,
+            payload,
+            read_at: None,
+            created_at: Utc::now(),
+        };
+        inner.rows.push(notification.clone());
+        drop(inner);
+        Ok(notification)
+    }
+
+    async fn list(
+        &self,
+        recipient_id: i64,
+        query: &ListQuery,
+        page: &PageRequest,
+    ) -> Result<Page<Notification>, NotificationStoreError> {
+        let filter = ListFilter::from_query(query);
+        let inner = self.lock()?;
+        let mut rows: Vec<Notification> = inner
+            .rows
+            .iter()
+            .filter(|n| n.recipient_id == recipient_id)
+            .filter(|n| !filter.unread_only || n.read_at.is_none())
+            .filter(|n| filter.kind.as_deref().is_none_or(|k| n.kind == k))
+            .cloned()
+            .collect();
+        drop(inner);
+
+        // `id` is assigned monotonically, so it doubles as insertion order and
+        // as the tiebreaker for equal `created_at` values.
+        match filter.sort {
+            FeedSort::CreatedAt => rows.sort_by_key(|n| (n.created_at, n.id)),
+            FeedSort::Id => rows.sort_by_key(|n| n.id),
+        }
+        if filter.dir == SortDir::Desc {
+            rows.reverse();
+        }
+
+        let total = i64::try_from(rows.len()).unwrap_or(i64::MAX);
+        let start = usize::try_from(page.offset()).unwrap_or(usize::MAX);
+        let items: Vec<Notification> = rows
+            .into_iter()
+            .skip(start)
+            .take(usize::try_from(page.limit()).unwrap_or(0))
+            .collect();
+        Ok(Page::new(items, total, page))
+    }
+
+    async fn unread_count(&self, recipient_id: i64) -> Result<u64, NotificationStoreError> {
+        let inner = self.lock()?;
+        let count = inner
+            .rows
+            .iter()
+            .filter(|n| n.recipient_id == recipient_id && n.read_at.is_none())
+            .count();
+        drop(inner);
+        Ok(count as u64)
+    }
+
+    async fn mark_read(
+        &self,
+        id: i64,
+        recipient_id: Option<i64>,
+    ) -> Result<u64, NotificationStoreError> {
+        let now = Utc::now();
+        let mut inner = self.lock()?;
+        let marked = inner
+            .rows
+            .iter_mut()
+            .filter(|n| n.id == id)
+            .filter(|n| recipient_id.is_none_or(|rid| n.recipient_id == rid))
+            .filter(|n| n.read_at.is_none())
+            .map(|n| n.read_at = Some(now))
+            .count();
+        drop(inner);
+        Ok(marked as u64)
+    }
+
+    async fn mark_all_read(&self, recipient_id: i64) -> Result<u64, NotificationStoreError> {
+        let now = Utc::now();
+        let mut inner = self.lock()?;
+        let marked = inner
+            .rows
+            .iter_mut()
+            .filter(|n| n.recipient_id == recipient_id && n.read_at.is_none())
+            .map(|n| n.read_at = Some(now))
+            .count();
+        drop(inner);
+        Ok(marked as u64)
+    }
+}
+
+// ── Shared list-parameter interpretation ────────────────────────────────────
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum FeedSort {
+    Id,
+    CreatedAt,
+}
+
+/// The [`ListQuery`] subset both stores understand, so the memory and
+/// database backends interpret feed parameters identically.
+struct ListFilter {
+    unread_only: bool,
+    kind: Option<String>,
+    sort: FeedSort,
+    dir: SortDir,
+}
+
+impl ListFilter {
+    fn from_query(query: &ListQuery) -> Self {
+        let mut unread_only = false;
+        let mut kind = None;
+        for (column, value) in query.filters() {
+            match column {
+                "unread" => unread_only = value == "true" || value == "1",
+                "kind" => kind = Some(value.to_owned()),
+                // Unknown filters are ignored, matching the repository
+                // `list()` allowlist contract.
+                _ => {}
+            }
+        }
+        // Without an explicit sort the feed reads newest-first; an explicit
+        // sort key uses the requested direction (`ListQuery` defaults to
+        // ascending).
+        let (sort, dir) = match query.sort() {
+            Some("created_at") => (FeedSort::CreatedAt, query.direction()),
+            Some("id") => (FeedSort::Id, query.direction()),
+            // No sort requested, or a key outside the allowlist: newest-first.
+            None | Some(_) => (FeedSort::Id, SortDir::Desc),
+        };
+        Self {
+            unread_only,
+            kind,
+            sort,
+            dir,
+        }
+    }
+}
+
+// ── Database-backed store ───────────────────────────────────────────────────
+
+#[cfg(feature = "db")]
+pub use self::db_store::DbNotificationStore;
+
+#[cfg(feature = "db")]
+mod db_store {
+    use super::{
+        FeedSort, ListFilter, Notification, NotificationStore, NotificationStoreError, Value,
+    };
+    use crate::db::RuntimeConnection;
+    use crate::pagination::{ListQuery, Page, PageRequest, SortDir};
+    use chrono::{DateTime, Utc};
+    use diesel::prelude::*;
+    use diesel_async::RunQueryDsl;
+    use diesel_async::pooled_connection::deadpool::Pool;
+
+    // The `notifications` table as scaffolded by `autumn generate
+    // notifications`. Timestamps are TIMESTAMPTZ on Postgres and RFC 3339
+    // TEXT on SQLite (diesel's `TimestamptzSqlite`), matching the DDL the
+    // generator emits per backend.
+    #[cfg(not(feature = "sqlite"))]
+    mod schema {
+        diesel::table! {
+            notifications (id) {
+                id -> BigInt,
+                recipient_id -> BigInt,
+                kind -> Text,
+                payload -> Text,
+                read_at -> Nullable<Timestamptz>,
+                created_at -> Timestamptz,
+            }
+        }
+    }
+    #[cfg(feature = "sqlite")]
+    mod schema {
+        diesel::table! {
+            notifications (id) {
+                id -> BigInt,
+                recipient_id -> BigInt,
+                kind -> Text,
+                payload -> Text,
+                read_at -> Nullable<TimestamptzSqlite>,
+                created_at -> TimestamptzSqlite,
+            }
+        }
+    }
+
+    use schema::notifications;
+
+    #[derive(Queryable, Selectable)]
+    #[diesel(table_name = notifications)]
+    struct NotificationRow {
+        id: i64,
+        recipient_id: i64,
+        kind: String,
+        payload: String,
+        read_at: Option<DateTime<Utc>>,
+        created_at: DateTime<Utc>,
+    }
+
+    impl From<NotificationRow> for Notification {
+        fn from(row: NotificationRow) -> Self {
+            // A payload that no longer parses as JSON (e.g. edited out of
+            // band) degrades to a JSON string of the raw text rather than
+            // failing the whole feed.
+            let payload = match serde_json::from_str(&row.payload) {
+                Ok(parsed) => parsed,
+                Err(_) => Value::String(row.payload),
+            };
+            Self {
+                id: row.id,
+                recipient_id: row.recipient_id,
+                kind: row.kind,
+                payload,
+                read_at: row.read_at,
+                created_at: row.created_at,
+            }
+        }
+    }
+
+    #[derive(Insertable)]
+    #[diesel(table_name = notifications)]
+    struct NewNotificationRow {
+        recipient_id: i64,
+        kind: String,
+        payload: String,
+        created_at: DateTime<Utc>,
+    }
+
+    /// [`NotificationStore`] backed by the app's database pool.
+    ///
+    /// Expects the `notifications` table scaffolded by
+    /// `autumn generate notifications`. This is the default store whenever
+    /// the app has a database configured.
+    #[derive(Clone)]
+    pub struct DbNotificationStore {
+        pool: Pool<RuntimeConnection>,
+    }
+
+    impl DbNotificationStore {
+        /// Build a store over the given pool.
+        #[must_use]
+        pub const fn new(pool: Pool<RuntimeConnection>) -> Self {
+            Self { pool }
+        }
+
+        async fn conn(
+            &self,
+        ) -> Result<
+            diesel_async::pooled_connection::deadpool::Object<RuntimeConnection>,
+            NotificationStoreError,
+        > {
+            self.pool
+                .get()
+                .await
+                .map_err(|e| NotificationStoreError::new(format!("checkout failed: {e}")))
+        }
+    }
+
+    fn store_err(e: &diesel::result::Error) -> NotificationStoreError {
+        NotificationStoreError::new(format!("query failed: {e}"))
+    }
+
+    impl NotificationStore for DbNotificationStore {
+        async fn notify(
+            &self,
+            recipient_id: i64,
+            kind: String,
+            payload: Value,
+        ) -> Result<Notification, NotificationStoreError> {
+            let payload = serde_json::to_string(&payload)
+                .map_err(|e| NotificationStoreError::new(format!("payload serialization: {e}")))?;
+            let mut conn = self.conn().await?;
+            let row: NotificationRow = diesel::insert_into(notifications::table)
+                .values(NewNotificationRow {
+                    recipient_id,
+                    kind,
+                    payload,
+                    created_at: Utc::now(),
+                })
+                .returning(NotificationRow::as_returning())
+                .get_result(&mut conn)
+                .await
+                .map_err(|e| store_err(&e))?;
+            Ok(row.into())
+        }
+
+        async fn list(
+            &self,
+            recipient_id: i64,
+            query: &ListQuery,
+            page: &PageRequest,
+        ) -> Result<Page<Notification>, NotificationStoreError> {
+            use notifications::dsl;
+
+            let filter = ListFilter::from_query(query);
+            let mut conn = self.conn().await?;
+
+            let mut count_query = dsl::notifications
+                .filter(dsl::recipient_id.eq(recipient_id))
+                .into_boxed();
+            let mut select_query = dsl::notifications
+                .filter(dsl::recipient_id.eq(recipient_id))
+                .into_boxed();
+            if filter.unread_only {
+                count_query = count_query.filter(dsl::read_at.is_null());
+                select_query = select_query.filter(dsl::read_at.is_null());
+            }
+            if let Some(kind) = &filter.kind {
+                count_query = count_query.filter(dsl::kind.eq(kind.clone()));
+                select_query = select_query.filter(dsl::kind.eq(kind.clone()));
+            }
+
+            let total: i64 = count_query
+                .count()
+                .get_result(&mut conn)
+                .await
+                .map_err(|e| store_err(&e))?;
+
+            select_query = match (filter.sort, filter.dir) {
+                (FeedSort::Id, SortDir::Asc) => select_query.order(dsl::id.asc()),
+                (FeedSort::Id, SortDir::Desc) => select_query.order(dsl::id.desc()),
+                (FeedSort::CreatedAt, SortDir::Asc) => {
+                    select_query.order((dsl::created_at.asc(), dsl::id.asc()))
+                }
+                (FeedSort::CreatedAt, SortDir::Desc) => {
+                    select_query.order((dsl::created_at.desc(), dsl::id.desc()))
+                }
+            };
+
+            let rows: Vec<NotificationRow> = select_query
+                .select(NotificationRow::as_select())
+                .limit(page.limit())
+                .offset(page.offset())
+                .load(&mut conn)
+                .await
+                .map_err(|e| store_err(&e))?;
+
+            Ok(Page::new(
+                rows.into_iter().map(Notification::from).collect(),
+                total,
+                page,
+            ))
+        }
+
+        async fn unread_count(&self, recipient_id: i64) -> Result<u64, NotificationStoreError> {
+            use notifications::dsl;
+            let mut conn = self.conn().await?;
+            let count: i64 = dsl::notifications
+                .filter(dsl::recipient_id.eq(recipient_id))
+                .filter(dsl::read_at.is_null())
+                .count()
+                .get_result(&mut conn)
+                .await
+                .map_err(|e| store_err(&e))?;
+            Ok(u64::try_from(count).unwrap_or(0))
+        }
+
+        async fn mark_read(
+            &self,
+            id: i64,
+            recipient_id: Option<i64>,
+        ) -> Result<u64, NotificationStoreError> {
+            use notifications::dsl;
+            let mut conn = self.conn().await?;
+            let now = Utc::now();
+            // `read_at IS NULL` in the predicate makes the update idempotent:
+            // an already-read row matches zero rows and keeps its original
+            // timestamp.
+            let affected = match recipient_id {
+                Some(rid) => {
+                    diesel::update(
+                        dsl::notifications
+                            .filter(dsl::id.eq(id))
+                            .filter(dsl::recipient_id.eq(rid))
+                            .filter(dsl::read_at.is_null()),
+                    )
+                    .set(dsl::read_at.eq(Some(now)))
+                    .execute(&mut conn)
+                    .await
+                }
+                None => {
+                    diesel::update(
+                        dsl::notifications
+                            .filter(dsl::id.eq(id))
+                            .filter(dsl::read_at.is_null()),
+                    )
+                    .set(dsl::read_at.eq(Some(now)))
+                    .execute(&mut conn)
+                    .await
+                }
+            }
+            .map_err(|e| store_err(&e))?;
+            Ok(affected as u64)
+        }
+
+        async fn mark_all_read(&self, recipient_id: i64) -> Result<u64, NotificationStoreError> {
+            use notifications::dsl;
+            let mut conn = self.conn().await?;
+            let affected = diesel::update(
+                dsl::notifications
+                    .filter(dsl::recipient_id.eq(recipient_id))
+                    .filter(dsl::read_at.is_null()),
+            )
+            .set(dsl::read_at.eq(Some(Utc::now())))
+            .execute(&mut conn)
+            .await
+            .map_err(|e| store_err(&e))?;
+            Ok(affected as u64)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn list_filter_defaults_to_newest_first() {
+        let filter = ListFilter::from_query(&ListQuery::default());
+        assert!(!filter.unread_only);
+        assert!(filter.kind.is_none());
+        assert_eq!(filter.sort, FeedSort::Id);
+        assert_eq!(filter.dir, SortDir::Desc);
+    }
+
+    #[test]
+    fn list_filter_parses_unread_and_kind() {
+        let query = ListQuery::new(None, SortDir::Asc, &[("unread", "1"), ("kind", "like")]);
+        let filter = ListFilter::from_query(&query);
+        assert!(filter.unread_only);
+        assert_eq!(filter.kind.as_deref(), Some("like"));
+    }
+
+    #[test]
+    fn list_filter_ignores_unknown_sort_and_filters() {
+        let query = ListQuery::new(Some("payload"), SortDir::Asc, &[("recipient_id", "9")]);
+        let filter = ListFilter::from_query(&query);
+        assert!(!filter.unread_only);
+        assert!(filter.kind.is_none());
+        assert_eq!(filter.sort, FeedSort::Id);
+        assert_eq!(
+            filter.dir,
+            SortDir::Desc,
+            "unknown sort falls back to newest-first"
+        );
+    }
+
+    #[test]
+    fn explicit_sort_uses_requested_direction() {
+        let query = ListQuery::new(Some("created_at"), SortDir::Asc, &[]);
+        let filter = ListFilter::from_query(&query);
+        assert_eq!(filter.sort, FeedSort::CreatedAt);
+        assert_eq!(filter.dir, SortDir::Asc);
+    }
+
+    #[tokio::test]
+    async fn memory_store_round_trips_payload() {
+        let notifications = Notifications::new(MemoryNotificationStore::new());
+        let n = notifications
+            .notify(1, "k", json!({"deep": {"value": [1, 2, 3]}}))
+            .await
+            .expect("notify");
+        assert_eq!(n.payload, json!({"deep": {"value": [1, 2, 3]}}));
+    }
+}

--- a/autumn/src/notifications.rs
+++ b/autumn/src/notifications.rs
@@ -976,6 +976,23 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn memory_store_round_trips_null_payload() {
+        // A JSON `null` payload must round-trip as `Value::Null`, not be
+        // confused with "no payload".
+        let notifications = Notifications::new(MemoryNotificationStore::new());
+        let n = notifications
+            .notify(1, "k", Value::Null)
+            .await
+            .expect("notify");
+        assert_eq!(n.payload, Value::Null);
+        let feed = notifications
+            .list(1, &ListQuery::default(), &PageRequest::default())
+            .await
+            .expect("list");
+        assert_eq!(feed.content[0].payload, Value::Null);
+    }
+
+    #[tokio::test]
     async fn memory_store_round_trips_payload() {
         let notifications = Notifications::new(MemoryNotificationStore::new());
         let n = notifications

--- a/autumn/src/notifications.rs
+++ b/autumn/src/notifications.rs
@@ -469,7 +469,8 @@ impl axum::extract::FromRequestParts<AppState> for Notifications {
 
 /// Process-local [`NotificationStore`] used by default when no database is
 /// configured. Suitable for tests and DB-less development; contents are lost
-/// on restart.
+/// on restart and the store grows without bound (no eviction), so it is not
+/// a production store.
 #[derive(Debug, Default)]
 pub struct MemoryNotificationStore {
     inner: std::sync::Mutex<MemoryInner>,

--- a/autumn/src/notifications.rs
+++ b/autumn/src/notifications.rs
@@ -124,7 +124,8 @@ impl Notification {
 // ── Store error ─────────────────────────────────────────────────────────────
 
 /// Error returned by [`NotificationStore`] implementations.
-#[derive(Debug)]
+#[derive(Debug, Clone, thiserror::Error, PartialEq, Eq)]
+#[error("notification store error: {message}")]
 pub struct NotificationStoreError {
     message: String,
 }
@@ -138,14 +139,6 @@ impl NotificationStoreError {
         }
     }
 }
-
-impl std::fmt::Display for NotificationStoreError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "notification store error: {}", self.message)
-    }
-}
-
-impl std::error::Error for NotificationStoreError {}
 
 // ── Store trait ─────────────────────────────────────────────────────────────
 
@@ -445,7 +438,10 @@ impl std::fmt::Debug for Notifications {
 }
 
 impl axum::extract::FromRequestParts<AppState> for Notifications {
-    type Rejection = AutumnError;
+    // Resolution always succeeds (a store fallback always exists); failures
+    // surface from the service methods, not extraction — same contract as
+    // `Session`.
+    type Rejection = std::convert::Infallible;
 
     async fn from_request_parts(
         _parts: &mut axum::http::request::Parts,
@@ -468,9 +464,11 @@ impl axum::extract::FromRequestParts<AppState> for Notifications {
 // ── In-memory store ─────────────────────────────────────────────────────────
 
 /// Process-local [`NotificationStore`] used by default when no database is
-/// configured. Suitable for tests and DB-less development; contents are lost
-/// on restart and the store grows without bound (no eviction), so it is not
-/// a production store.
+/// configured.
+///
+/// Suitable for tests and DB-less development; contents are lost on restart
+/// and the store grows without bound (no eviction), so it is not a
+/// production store.
 #[derive(Debug, Default)]
 pub struct MemoryNotificationStore {
     inner: std::sync::Mutex<MemoryInner>,
@@ -769,6 +767,17 @@ mod db_store {
     }
 
     fn store_err(e: &diesel::result::Error) -> NotificationStoreError {
+        let message = e.to_string();
+        // A missing table means the app has a database but never scaffolded
+        // the notifications feed — turn the bare SQL error into an
+        // actionable one ("relation … does not exist" on Postgres, "no such
+        // table" on SQLite).
+        if message.contains("does not exist") || message.contains("no such table") {
+            return NotificationStoreError::new(format!(
+                "query failed: {e}. The `notifications` table is missing — scaffold it \
+                 with `autumn generate notifications`, then apply it with `autumn migrate`"
+            ));
+        }
         NotificationStoreError::new(format!("query failed: {e}"))
     }
 

--- a/autumn/src/prelude.rs
+++ b/autumn/src/prelude.rs
@@ -258,6 +258,9 @@ pub use crate::auth::RequireApiToken;
 /// actuator log buffer, the access line, any context-aware layer). See
 /// [`crate::log::context`] for the full surface.
 pub use crate::log::context::with_log_field;
+/// In-app notifications service/extractor (persistent per-recipient feed
+/// with read/unread state). See [`crate::notifications`] for the full surface.
+pub use crate::notifications::Notifications;
 /// Session extractor for accessing per-user session data.
 pub use crate::session::Session;
 /// Tenant extractor and context helpers.

--- a/autumn/src/test.rs
+++ b/autumn/src/test.rs
@@ -1186,6 +1186,19 @@ impl TestApp {
         self
     }
 
+    /// Mirrors [`crate::app::AppBuilder::with_notification_store`].
+    #[must_use]
+    pub fn with_notification_store<S>(mut self, store: S) -> Self
+    where
+        S: crate::notifications::NotificationStore,
+    {
+        let service = crate::notifications::Notifications::new(store);
+        self.state_initializers.push(Box::new(move |state| {
+            state.insert_extension(service);
+        }));
+        self
+    }
+
     /// Apply a plugin directly to the test app.
     #[must_use]
     pub fn plugin<P: crate::plugin::Plugin>(mut self, plugin: P) -> Self {

--- a/autumn/tests/integration/mod.rs
+++ b/autumn/tests/integration/mod.rs
@@ -128,6 +128,7 @@ mod negotiate;
 mod nested_form_atomic_save;
 #[cfg(feature = "maud")]
 mod nested_form_order_example;
+mod notifications;
 #[cfg(feature = "offline-sync")]
 mod offline_sync_conformance;
 #[cfg(feature = "offline-sync")]

--- a/autumn/tests/integration/notifications.rs
+++ b/autumn/tests/integration/notifications.rs
@@ -398,6 +398,146 @@ mod push {
     }
 }
 
+// ── Review-pass hardening tests ───────────────────────────────────────────
+
+/// A custom store registered on the builder pre-empts the default
+/// resolution and receives every service call made through the extractor.
+mod custom_store_registration {
+    use super::*;
+    use autumn_web::notifications::{NotificationStore, NotificationStoreError};
+    use autumn_web::prelude::*;
+    use autumn_web::test::TestApp;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    /// Delegates to a memory store while counting notify calls, proving the
+    /// registered instance (not a lazily created default) serves requests.
+    struct CountingStore {
+        inner: MemoryNotificationStore,
+        notifies: Arc<AtomicUsize>,
+    }
+
+    impl NotificationStore for CountingStore {
+        async fn notify(
+            &self,
+            recipient_id: i64,
+            kind: String,
+            payload: serde_json::Value,
+        ) -> Result<Notification, NotificationStoreError> {
+            self.notifies.fetch_add(1, Ordering::SeqCst);
+            self.inner.notify(recipient_id, kind, payload).await
+        }
+        async fn list(
+            &self,
+            recipient_id: i64,
+            query: &ListQuery,
+            page: &PageRequest,
+        ) -> Result<Page<Notification>, NotificationStoreError> {
+            self.inner.list(recipient_id, query, page).await
+        }
+        async fn unread_count(&self, recipient_id: i64) -> Result<u64, NotificationStoreError> {
+            self.inner.unread_count(recipient_id).await
+        }
+        async fn mark_read(
+            &self,
+            id: i64,
+            recipient_id: Option<i64>,
+        ) -> Result<u64, NotificationStoreError> {
+            self.inner.mark_read(id, recipient_id).await
+        }
+        async fn mark_all_read(&self, recipient_id: i64) -> Result<u64, NotificationStoreError> {
+            self.inner.mark_all_read(recipient_id).await
+        }
+    }
+
+    #[post("/custom-notify/{rid}")]
+    async fn notify_route(
+        Path(rid): Path<i64>,
+        notifications: Notifications,
+    ) -> AutumnResult<Json<Notification>> {
+        Ok(Json(notifications.notify(rid, "custom", json!({})).await?))
+    }
+
+    #[tokio::test]
+    async fn with_notification_store_preempts_the_default_resolution() {
+        let notifies = Arc::new(AtomicUsize::new(0));
+        let client = TestApp::new()
+            .routes(routes![notify_route])
+            .with_notification_store(CountingStore {
+                inner: MemoryNotificationStore::new(),
+                notifies: Arc::clone(&notifies),
+            })
+            .build();
+
+        client.post("/custom-notify/1").send().await.assert_ok();
+        client.post("/custom-notify/1").send().await.assert_ok();
+
+        assert_eq!(
+            notifies.load(Ordering::SeqCst),
+            2,
+            "the registered store served the extractor's calls"
+        );
+    }
+}
+
+#[tokio::test]
+async fn explicit_created_at_sort_returns_oldest_first_with_id_tiebreak() {
+    let notifications = service();
+    for i in 0..3 {
+        notifications
+            .notify(6, format!("k{i}"), json!({}))
+            .await
+            .expect("notify");
+    }
+
+    let oldest_first = ListQuery::new(Some("created_at"), SortDir::Asc, &[]);
+    let feed = notifications
+        .list(6, &oldest_first, &PageRequest::default())
+        .await
+        .expect("list");
+    assert_eq!(
+        feed.content
+            .iter()
+            .map(|n| n.kind.as_str())
+            .collect::<Vec<_>>(),
+        vec!["k0", "k1", "k2"],
+        "ascending created_at with monotonic-id tiebreak"
+    );
+}
+
+#[tokio::test]
+async fn concurrent_notify_assigns_unique_ids() {
+    let notifications = service();
+    let handles: Vec<_> = (0..10)
+        .map(|i| {
+            let notifications = notifications.clone();
+            tokio::spawn(async move { notifications.notify(1, format!("k{i}"), json!({})).await })
+        })
+        .collect();
+
+    let mut ids = std::collections::HashSet::new();
+    for handle in handles {
+        let n = handle.await.expect("join").expect("notify");
+        assert!(ids.insert(n.id), "duplicate id {}", n.id);
+    }
+    assert_eq!(ids.len(), 10);
+    assert_eq!(notifications.unread_count(1).await.expect("count"), 10);
+}
+
+/// `notify_with_push` outside a request context (no channel registry) skips
+/// the push entirely and still persists.
+#[cfg(feature = "ws")]
+#[tokio::test]
+async fn notify_with_push_without_channels_still_persists() {
+    let notifications = service();
+    let n = notifications
+        .notify_with_push(2, "quiet", json!({}))
+        .await
+        .expect("notify_with_push without channels");
+    assert_eq!(n.kind, "quiet");
+    assert_eq!(notifications.unread_count(2).await.expect("count"), 1);
+}
+
 // ── Postgres-backed store (testcontainers, requires Docker) ───────────────
 
 // `not(feature = "sqlite")`: under the app-only `sqlite` feature (which
@@ -425,7 +565,11 @@ mod pg {
          read_at TIMESTAMPTZ, \
          created_at TIMESTAMPTZ NOT NULL DEFAULT NOW())";
 
-    async fn setup() -> (Notifications, testcontainers::ContainerAsync<Postgres>) {
+    async fn setup() -> (
+        Notifications,
+        Pool<AsyncPgConnection>,
+        testcontainers::ContainerAsync<Postgres>,
+    ) {
         let container = Postgres::default()
             .start()
             .await
@@ -444,7 +588,8 @@ mod pg {
         drop(conn);
 
         (
-            Notifications::new(DbNotificationStore::new(pool)),
+            Notifications::new(DbNotificationStore::new(pool.clone())),
+            pool,
             container,
         )
     }
@@ -452,7 +597,7 @@ mod pg {
     #[tokio::test]
     #[ignore = "requires Docker (testcontainers)"]
     async fn db_store_supports_the_full_feed_lifecycle() {
-        let (notifications, _container) = setup().await;
+        let (notifications, _pool, _container) = setup().await;
 
         // Write path: notify for a recipient with no prior notifications.
         let a = notifications
@@ -516,7 +661,7 @@ mod pg {
     #[tokio::test]
     #[ignore = "requires Docker (testcontainers)"]
     async fn db_store_mark_read_for_is_recipient_scoped() {
-        let (notifications, _container) = setup().await;
+        let (notifications, _pool, _container) = setup().await;
         let n = notifications
             .notify(1, "a", json!({}))
             .await
@@ -530,5 +675,122 @@ mod pg {
 
         notifications.mark_read_for(1, n.id).await.expect("owner");
         assert_eq!(notifications.unread_count(1).await.expect("count"), 0);
+    }
+
+    /// The `kind` filter, combined `unread`+`kind` filters, and explicit
+    /// `sort=created_at` ordering on the DB store.
+    #[tokio::test]
+    #[ignore = "requires Docker (testcontainers)"]
+    async fn db_store_filters_and_created_at_sort() {
+        let (notifications, _pool, _container) = setup().await;
+        let a = notifications
+            .notify(1, "mention", json!({}))
+            .await
+            .expect("a");
+        let b = notifications.notify(1, "like", json!({})).await.expect("b");
+        let c = notifications
+            .notify(1, "mention", json!({}))
+            .await
+            .expect("c");
+        notifications.mark_read_for(1, a.id).await.expect("read a");
+
+        let page = PageRequest::default();
+        let kind_only = ListQuery::new(None, SortDir::default(), &[("kind", "mention")]);
+        let feed = notifications
+            .list(1, &kind_only, &page)
+            .await
+            .expect("kind");
+        assert_eq!(feed.total_elements, 2);
+        assert!(feed.content.iter().all(|n| n.kind == "mention"));
+
+        let combined = ListQuery::new(
+            None,
+            SortDir::default(),
+            &[("kind", "mention"), ("unread", "true")],
+        );
+        let feed = notifications
+            .list(1, &combined, &page)
+            .await
+            .expect("combined");
+        assert_eq!(feed.total_elements, 1);
+        assert_eq!(feed.content[0].id, c.id);
+
+        let oldest_first = ListQuery::new(Some("created_at"), SortDir::Asc, &[]);
+        let feed = notifications
+            .list(1, &oldest_first, &page)
+            .await
+            .expect("created_at asc");
+        assert_eq!(
+            feed.content.iter().map(|n| n.id).collect::<Vec<_>>(),
+            vec![a.id, b.id, c.id],
+            "oldest first with id tiebreak"
+        );
+    }
+
+    /// A payload corrupted out of band degrades to a JSON string of the raw
+    /// text instead of failing the whole feed.
+    #[tokio::test]
+    #[ignore = "requires Docker (testcontainers)"]
+    async fn db_store_degrades_unparseable_payload_to_string() {
+        let (notifications, pool, _container) = setup().await;
+        let n = notifications
+            .notify(1, "k", json!({"ok": true}))
+            .await
+            .expect("notify");
+
+        let mut conn = pool.get().await.expect("conn");
+        diesel::sql_query("UPDATE notifications SET payload = 'not json' WHERE id = $1")
+            .bind::<diesel::sql_types::BigInt, _>(n.id)
+            .execute(&mut conn)
+            .await
+            .expect("corrupt payload");
+        drop(conn);
+
+        let (query, page) = default_list();
+        let feed = notifications.list(1, &query, &page).await.expect("list");
+        assert_eq!(feed.content[0].payload, json!("not json"));
+    }
+
+    /// With a DB pool configured, the `Notifications` extractor auto-selects
+    /// the database-backed store (not the memory fallback): rows written
+    /// through a route land in the `notifications` table.
+    #[tokio::test]
+    #[ignore = "requires Docker (testcontainers)"]
+    async fn extractor_auto_selects_db_store_when_pool_is_configured() {
+        use autumn_web::prelude::*;
+        use autumn_web::test::TestApp;
+
+        #[post("/pg-notify/{rid}")]
+        async fn notify_route(
+            Path(rid): Path<i64>,
+            notifications: Notifications,
+        ) -> AutumnResult<Json<Notification>> {
+            Ok(Json(notifications.notify(rid, "via-db", json!({})).await?))
+        }
+
+        #[derive(diesel::QueryableByName)]
+        struct CountRow {
+            #[diesel(sql_type = diesel::sql_types::BigInt)]
+            n: i64,
+        }
+
+        let (_notifications, pool, _container) = setup().await;
+        let client = TestApp::new()
+            .routes(routes![notify_route])
+            .with_db(pool.clone())
+            .build();
+
+        client.post("/pg-notify/42").send().await.assert_ok();
+
+        let mut conn = pool.get().await.expect("conn");
+        let row: CountRow =
+            diesel::sql_query("SELECT COUNT(*) AS n FROM notifications WHERE recipient_id = 42")
+                .get_result(&mut conn)
+                .await
+                .expect("count");
+        assert_eq!(
+            row.n, 1,
+            "row persisted in the database, not the memory fallback"
+        );
     }
 }

--- a/autumn/tests/integration/notifications.rs
+++ b/autumn/tests/integration/notifications.rs
@@ -400,7 +400,10 @@ mod push {
 
 // ── Postgres-backed store (testcontainers, requires Docker) ───────────────
 
-#[cfg(feature = "db")]
+// `not(feature = "sqlite")`: under the app-only `sqlite` feature (which
+// implies `db`) the runtime connection is SQLite, so this Postgres pool
+// would no longer type-check against `DbNotificationStore::new`.
+#[cfg(all(feature = "db", not(feature = "sqlite")))]
 mod pg {
     use super::*;
     use autumn_web::notifications::DbNotificationStore;

--- a/autumn/tests/integration/notifications.rs
+++ b/autumn/tests/integration/notifications.rs
@@ -1,0 +1,531 @@
+//! Integration tests for the first-class in-app notifications store
+//! (issue #1148): per-recipient persistent feed with read/unread state,
+//! surfaced through the [`Notifications`] service/extractor.
+//!
+//! Covers, per the acceptance criteria:
+//! - notify → list / `unread_count` visibility (write path and read path),
+//! - `unread_count` and `list` with the `unread` filter ignoring read rows,
+//! - idempotent `mark_read` / `mark_all_read`,
+//! - the `Notifications` extractor working end-to-end through `TestApp`
+//!   (memory store fallback when no database is configured),
+//! - best-effort realtime push over `channels` (a channel failure or absent
+//!   subscriber never fails `notify`),
+//! - the Postgres-backed store (testcontainers, **requires Docker**).
+
+use autumn_web::AutumnResult;
+use autumn_web::notifications::{MemoryNotificationStore, Notification, Notifications};
+use autumn_web::pagination::{ListQuery, Page, PageRequest, SortDir};
+use serde_json::json;
+
+fn service() -> Notifications {
+    Notifications::new(MemoryNotificationStore::new())
+}
+
+fn default_list() -> (ListQuery, PageRequest) {
+    (ListQuery::default(), PageRequest::default())
+}
+
+// ── AC: notify is immediately visible to list / unread_count ──────────────
+
+#[tokio::test]
+async fn notify_creates_row_visible_to_list_and_unread_count() {
+    let notifications = service();
+
+    let created = notifications
+        .notify(7, "comment.created", json!({"post": 42}))
+        .await
+        .expect("notify");
+    assert_eq!(created.recipient_id, 7);
+    assert_eq!(created.kind, "comment.created");
+    assert_eq!(created.payload, json!({"post": 42}));
+    assert!(created.read_at.is_none(), "new notification starts unread");
+
+    let (query, page) = default_list();
+    let feed: Page<Notification> = notifications.list(7, &query, &page).await.expect("list");
+    assert_eq!(feed.total_elements, 1);
+    assert_eq!(feed.content[0].id, created.id);
+
+    assert_eq!(notifications.unread_count(7).await.expect("count"), 1);
+    // Other recipients are unaffected.
+    assert_eq!(notifications.unread_count(8).await.expect("count"), 0);
+}
+
+// ── AC: unread_count / list(unread) ignore read rows ──────────────────────
+
+#[tokio::test]
+async fn unread_count_and_unread_filter_ignore_read_notifications() {
+    let notifications = service();
+
+    let a = notifications
+        .notify(1, "a", json!({}))
+        .await
+        .expect("notify a");
+    let b = notifications
+        .notify(1, "b", json!({}))
+        .await
+        .expect("notify b");
+
+    notifications.mark_read(a.id).await.expect("mark_read");
+
+    assert_eq!(notifications.unread_count(1).await.expect("count"), 1);
+
+    let unread_query = ListQuery::new(None, SortDir::default(), &[("unread", "true")]);
+    let page = PageRequest::default();
+    let unread = notifications
+        .list(1, &unread_query, &page)
+        .await
+        .expect("list unread");
+    assert_eq!(unread.total_elements, 1);
+    assert_eq!(unread.content[0].id, b.id);
+
+    // The unfiltered feed still shows both.
+    let (query, page) = default_list();
+    let all = notifications
+        .list(1, &query, &page)
+        .await
+        .expect("list all");
+    assert_eq!(all.total_elements, 2);
+}
+
+// ── AC: mark_read / mark_all_read are idempotent ──────────────────────────
+
+#[tokio::test]
+async fn mark_read_is_idempotent() {
+    let notifications = service();
+    let n = notifications
+        .notify(3, "x", json!({}))
+        .await
+        .expect("notify");
+
+    notifications
+        .mark_read(n.id)
+        .await
+        .expect("first mark_read");
+    // Re-marking a read notification is a no-op, not an error.
+    notifications
+        .mark_read(n.id)
+        .await
+        .expect("second mark_read");
+    assert_eq!(notifications.unread_count(3).await.expect("count"), 0);
+
+    // A read_at timestamp is preserved, not overwritten, by the re-mark.
+    let (query, page) = default_list();
+    let feed = notifications.list(3, &query, &page).await.expect("list");
+    assert!(feed.content[0].read_at.is_some());
+}
+
+#[tokio::test]
+async fn mark_read_on_missing_id_is_a_noop() {
+    let notifications = service();
+    notifications
+        .mark_read(999)
+        .await
+        .expect("missing id is a no-op");
+}
+
+#[tokio::test]
+async fn mark_all_read_is_idempotent() {
+    let notifications = service();
+    notifications
+        .notify(5, "a", json!({}))
+        .await
+        .expect("notify");
+    notifications
+        .notify(5, "b", json!({}))
+        .await
+        .expect("notify");
+
+    let marked = notifications.mark_all_read(5).await.expect("mark_all_read");
+    assert_eq!(marked, 2);
+    assert_eq!(notifications.unread_count(5).await.expect("count"), 0);
+
+    // Second call marks nothing and does not error.
+    let marked_again = notifications
+        .mark_all_read(5)
+        .await
+        .expect("second mark_all_read");
+    assert_eq!(marked_again, 0);
+}
+
+// ── Recipient-scoped mark_read (IDOR-safe variant for handlers) ───────────
+
+#[tokio::test]
+async fn mark_read_for_only_touches_the_recipients_own_notification() {
+    let notifications = service();
+    let n = notifications
+        .notify(1, "a", json!({}))
+        .await
+        .expect("notify");
+
+    // A different recipient cannot mark someone else's notification read.
+    notifications
+        .mark_read_for(2, n.id)
+        .await
+        .expect("no-op for other recipient");
+    assert_eq!(notifications.unread_count(1).await.expect("count"), 1);
+
+    notifications
+        .mark_read_for(1, n.id)
+        .await
+        .expect("owner marks read");
+    assert_eq!(notifications.unread_count(1).await.expect("count"), 0);
+}
+
+// ── Feed ordering and pagination ──────────────────────────────────────────
+
+#[tokio::test]
+async fn list_returns_newest_first_and_paginates() {
+    let notifications = service();
+    for i in 0..5 {
+        notifications
+            .notify(9, format!("kind{i}"), json!({"i": i}))
+            .await
+            .expect("notify");
+    }
+
+    let query = ListQuery::default();
+    let first = notifications
+        .list(9, &query, &PageRequest::new(1, 2))
+        .await
+        .expect("page 1");
+    assert_eq!(first.total_elements, 5);
+    assert_eq!(first.content.len(), 2);
+    assert!(first.has_next);
+    assert!(!first.has_previous);
+    // Newest first by default.
+    assert_eq!(first.content[0].kind, "kind4");
+    assert_eq!(first.content[1].kind, "kind3");
+
+    let last = notifications
+        .list(9, &query, &PageRequest::new(3, 2))
+        .await
+        .expect("page 3");
+    assert_eq!(last.content.len(), 1);
+    assert_eq!(last.content[0].kind, "kind0");
+    assert!(!last.has_next);
+}
+
+#[tokio::test]
+async fn list_filters_by_kind() {
+    let notifications = service();
+    notifications
+        .notify(4, "mention", json!({}))
+        .await
+        .expect("notify");
+    notifications
+        .notify(4, "like", json!({}))
+        .await
+        .expect("notify");
+
+    let query = ListQuery::new(None, SortDir::default(), &[("kind", "mention")]);
+    let page = PageRequest::default();
+    let feed = notifications.list(4, &query, &page).await.expect("list");
+    assert_eq!(feed.total_elements, 1);
+    assert_eq!(feed.content[0].kind, "mention");
+}
+
+// ── Conventional per-recipient channel topic ──────────────────────────────
+
+#[test]
+fn topic_is_stable_per_recipient() {
+    assert_eq!(Notifications::topic(7), "notifications:7");
+}
+
+// ── Extractor: end-to-end through TestApp (no DB → memory fallback) ───────
+
+mod extractor {
+    use super::*;
+    use autumn_web::prelude::*;
+    use autumn_web::test::TestApp;
+
+    #[post("/boop/{rid}")]
+    async fn notify_route(
+        Path(rid): Path<i64>,
+        notifications: Notifications,
+    ) -> AutumnResult<Json<Notification>> {
+        let n = notifications
+            .notify(rid, "boop", json!({"via": "route"}))
+            .await?;
+        Ok(Json(n))
+    }
+
+    #[get("/feed/{rid}")]
+    async fn feed_route(
+        Path(rid): Path<i64>,
+        query: ListQuery,
+        page: PageRequest,
+        notifications: Notifications,
+    ) -> AutumnResult<Json<Page<Notification>>> {
+        Ok(Json(notifications.list(rid, &query, &page).await?))
+    }
+
+    #[get("/unread/{rid}")]
+    async fn unread_route(
+        Path(rid): Path<i64>,
+        notifications: Notifications,
+    ) -> AutumnResult<Json<u64>> {
+        Ok(Json(notifications.unread_count(rid).await?))
+    }
+
+    #[post("/read/{rid}/{id}")]
+    async fn mark_read_route(
+        Path((rid, id)): Path<(i64, i64)>,
+        notifications: Notifications,
+    ) -> AutumnResult<&'static str> {
+        notifications.mark_read_for(rid, id).await?;
+        Ok("ok")
+    }
+
+    #[tokio::test]
+    async fn notify_list_mark_read_flow_works_through_routes() {
+        let client = TestApp::new()
+            .routes(routes![
+                notify_route,
+                feed_route,
+                unread_route,
+                mark_read_route
+            ])
+            .build();
+
+        // notify
+        let created: Notification = client.post("/boop/7").send().await.assert_ok().json();
+        assert_eq!(created.recipient_id, 7);
+
+        // list
+        let feed: Page<Notification> = client.get("/feed/7").send().await.assert_ok().json();
+        assert_eq!(feed.total_elements, 1);
+
+        // unread count
+        let unread: u64 = client.get("/unread/7").send().await.assert_ok().json();
+        assert_eq!(unread, 1);
+
+        // mark read, then the unread feed is empty
+        client
+            .post(&format!("/read/7/{}", created.id))
+            .send()
+            .await
+            .assert_ok();
+        let unread: u64 = client.get("/unread/7").send().await.assert_ok().json();
+        assert_eq!(unread, 0);
+
+        let unread_feed: Page<Notification> = client
+            .get("/feed/7?filter[unread]=true")
+            .send()
+            .await
+            .assert_ok()
+            .json();
+        assert_eq!(unread_feed.total_elements, 0);
+    }
+
+    #[tokio::test]
+    async fn memory_store_is_shared_across_requests_within_an_app() {
+        let client = TestApp::new()
+            .routes(routes![notify_route, unread_route])
+            .build();
+        client.post("/boop/1").send().await.assert_ok();
+        client.post("/boop/1").send().await.assert_ok();
+        let unread: u64 = client.get("/unread/1").send().await.assert_ok().json();
+        assert_eq!(unread, 2);
+    }
+}
+
+// ── Best-effort realtime push over channels ───────────────────────────────
+
+#[cfg(feature = "ws")]
+mod push {
+    use super::*;
+    use autumn_web::prelude::*;
+    use autumn_web::test::TestApp;
+
+    #[post("/notify-push/{rid}")]
+    async fn notify_push_route(
+        Path(rid): Path<i64>,
+        notifications: Notifications,
+    ) -> AutumnResult<Json<Notification>> {
+        let n = notifications
+            .notify_with_push(rid, "push.test", json!({"hello": true}))
+            .await?;
+        Ok(Json(n))
+    }
+
+    #[get("/unread-push/{rid}")]
+    async fn unread_route(
+        Path(rid): Path<i64>,
+        notifications: Notifications,
+    ) -> AutumnResult<Json<u64>> {
+        Ok(Json(notifications.unread_count(rid).await?))
+    }
+
+    /// AC: the broadcast is best-effort — publishing to a topic with **no
+    /// subscribers** (which errors on the local backend) never fails `notify`.
+    #[tokio::test]
+    async fn channel_failure_never_fails_notify() {
+        let client = TestApp::new()
+            .routes(routes![notify_push_route, unread_route])
+            .build();
+
+        client.post("/notify-push/3").send().await.assert_ok();
+        let unread: u64 = client.get("/unread-push/3").send().await.assert_ok().json();
+        assert_eq!(unread, 1, "notification persisted despite dead channel");
+    }
+
+    /// The push goes out on the conventional per-recipient topic with the
+    /// serialized notification as payload.
+    #[tokio::test]
+    async fn push_publishes_notification_json_on_recipient_topic() {
+        let client = TestApp::new().routes(routes![notify_push_route]).build();
+
+        let mut rx = client
+            .state()
+            .channels()
+            .subscribe(&Notifications::topic(3));
+
+        let created: Notification = client
+            .post("/notify-push/3")
+            .send()
+            .await
+            .assert_ok()
+            .json();
+
+        let msg = tokio::time::timeout(std::time::Duration::from_secs(5), rx.recv())
+            .await
+            .expect("timely broadcast")
+            .expect("broadcast delivered");
+        let pushed: Notification =
+            serde_json::from_str(&msg.into_string()).expect("payload is the notification JSON");
+        assert_eq!(pushed.id, created.id);
+        assert_eq!(pushed.kind, "push.test");
+    }
+}
+
+// ── Postgres-backed store (testcontainers, requires Docker) ───────────────
+
+#[cfg(feature = "db")]
+mod pg {
+    use super::*;
+    use autumn_web::notifications::DbNotificationStore;
+    use diesel_async::AsyncPgConnection;
+    use diesel_async::RunQueryDsl;
+    use diesel_async::pooled_connection::AsyncDieselConnectionManager;
+    use diesel_async::pooled_connection::deadpool::Pool;
+    use testcontainers::runners::AsyncRunner;
+    use testcontainers_modules::postgres::Postgres;
+
+    /// Matches the DDL emitted by `autumn generate notifications` for the
+    /// Postgres backend (autumn-cli `generate/notifications.rs`). Keep the
+    /// two in sync.
+    const CREATE_NOTIFICATIONS_SQL: &str = "CREATE TABLE notifications (\
+         id BIGSERIAL PRIMARY KEY, \
+         recipient_id BIGINT NOT NULL, \
+         kind TEXT NOT NULL, \
+         payload TEXT NOT NULL, \
+         read_at TIMESTAMPTZ, \
+         created_at TIMESTAMPTZ NOT NULL DEFAULT NOW())";
+
+    async fn setup() -> (Notifications, testcontainers::ContainerAsync<Postgres>) {
+        let container = Postgres::default()
+            .start()
+            .await
+            .expect("failed to start postgres container");
+        let host = container.get_host().await.expect("host");
+        let port = container.get_host_port_ipv4(5432).await.expect("port");
+        let url = format!("postgres://postgres:postgres@{host}:{port}/postgres");
+
+        let manager = AsyncDieselConnectionManager::<AsyncPgConnection>::new(&url);
+        let pool = Pool::builder(manager).max_size(4).build().expect("pool");
+        let mut conn = pool.get().await.expect("conn");
+        diesel::sql_query(CREATE_NOTIFICATIONS_SQL)
+            .execute(&mut conn)
+            .await
+            .expect("create notifications table");
+        drop(conn);
+
+        (
+            Notifications::new(DbNotificationStore::new(pool)),
+            container,
+        )
+    }
+
+    #[tokio::test]
+    #[ignore = "requires Docker (testcontainers)"]
+    async fn db_store_supports_the_full_feed_lifecycle() {
+        let (notifications, _container) = setup().await;
+
+        // Write path: notify for a recipient with no prior notifications.
+        let a = notifications
+            .notify(1, "comment.created", json!({"post": 1}))
+            .await
+            .expect("notify a");
+        let b = notifications
+            .notify(1, "like", json!({}))
+            .await
+            .expect("notify b");
+        notifications
+            .notify(2, "other", json!({}))
+            .await
+            .expect("notify other");
+
+        // Read path: immediately visible.
+        let (query, page) = default_list();
+        let feed = notifications.list(1, &query, &page).await.expect("list");
+        assert_eq!(feed.total_elements, 2);
+        assert_eq!(feed.content[0].id, b.id, "newest first");
+        assert_eq!(feed.content[0].payload, json!({}));
+        assert_eq!(feed.content[1].payload, json!({"post": 1}));
+        assert_eq!(notifications.unread_count(1).await.expect("count"), 2);
+
+        // mark_read is idempotent and scoped correctly.
+        notifications.mark_read(a.id).await.expect("mark_read");
+        notifications
+            .mark_read(a.id)
+            .await
+            .expect("mark_read again");
+        assert_eq!(notifications.unread_count(1).await.expect("count"), 1);
+
+        let unread_query = ListQuery::new(None, SortDir::default(), &[("unread", "true")]);
+        let unread = notifications
+            .list(1, &unread_query, &page)
+            .await
+            .expect("unread list");
+        assert_eq!(unread.total_elements, 1);
+        assert_eq!(unread.content[0].id, b.id);
+
+        // mark_all_read is idempotent and per-recipient.
+        assert_eq!(notifications.mark_all_read(1).await.expect("mark_all"), 1);
+        assert_eq!(
+            notifications
+                .mark_all_read(1)
+                .await
+                .expect("mark_all again"),
+            0
+        );
+        assert_eq!(notifications.unread_count(1).await.expect("count"), 0);
+        assert_eq!(
+            notifications
+                .unread_count(2)
+                .await
+                .expect("other recipient count"),
+            1,
+            "other recipients' unread state is untouched"
+        );
+    }
+
+    #[tokio::test]
+    #[ignore = "requires Docker (testcontainers)"]
+    async fn db_store_mark_read_for_is_recipient_scoped() {
+        let (notifications, _container) = setup().await;
+        let n = notifications
+            .notify(1, "a", json!({}))
+            .await
+            .expect("notify");
+
+        notifications
+            .mark_read_for(2, n.id)
+            .await
+            .expect("foreign no-op");
+        assert_eq!(notifications.unread_count(1).await.expect("count"), 1);
+
+        notifications.mark_read_for(1, n.id).await.expect("owner");
+        assert_eq!(notifications.unread_count(1).await.expect("count"), 0);
+    }
+}

--- a/docs/guide/notifications.md
+++ b/docs/guide/notifications.md
@@ -88,12 +88,15 @@ per app:
 2. `DbNotificationStore` when a database pool is configured — the persistent
    default, backed by the `notifications` table the generator scaffolds.
 3. `MemoryNotificationStore` otherwise — a process-local fallback for tests
-   and DB-less development (contents are lost on restart).
+   and DB-less development (contents are lost on restart, and the store grows
+   without bound — do not ship it as the production store).
 
 The `notifications` table stores `id`, `recipient_id`, `kind`, a JSON
 `payload` (TEXT-serialized, so it is identical on Postgres and SQLite), a
 nullable `read_at`, and `created_at`. Timestamps are `TIMESTAMPTZ` on
-Postgres and RFC 3339 `TEXT` on SQLite.
+Postgres and RFC 3339 `TEXT` on SQLite. Keep payloads small and
+reference-shaped (`{"post": 42}`, not the post body): they are stored
+verbatim per recipient and re-sent on every feed page.
 
 To plug in a custom backend, implement `NotificationStore` and register it:
 
@@ -139,6 +142,11 @@ let _ = state
 A WebSocket or SSE handler subscribes to the same topic to stream the feed:
 
 ```rust
+// SECURITY: derive the topic from the *authenticated* user (Auth/session),
+// never from a client-supplied id — topics are guessable and the pushed JSON
+// contains the full notification payload. For channel-level enforcement use
+// the authorized subscription helpers (`subscribe_authorized` /
+// `sse::stream_authorized`, see the realtime guide).
 let mut rx = state.channels().subscribe(&Notifications::topic(user.id));
 while let Ok(msg) = rx.recv().await {
     // forward msg (the notification JSON) to the client

--- a/docs/guide/notifications.md
+++ b/docs/guide/notifications.md
@@ -1,0 +1,154 @@
+# In-app notifications
+
+Every account-based app eventually grows a notification bell: a persistent,
+per-user feed with read/unread state and an unread count. Autumn ships that
+composition as a first-class primitive — the [`Notifications`] service — so you
+add a working feed with one generate command and one `notify(...)` call, with
+zero hand-written SQL.
+
+This is the **in-app/database channel** only: it is not
+[flash](flash.md) (transient, single-request) and not the mailer (email is a
+different delivery channel).
+
+## Quick start
+
+Scaffold the table, a minimal feed API, and a smoke test:
+
+```bash
+autumn generate notifications
+autumn migrate
+```
+
+The generator emits a backend-aware migration (Postgres or SQLite, matching
+your app's configured backend), a `src/notifications.rs` module with feed
+routes, registers those routes in `main.rs`, and writes an in-process smoke
+test (`tests/notifications_feed.rs`) that exercises notify → list → mark-read
+through `TestClient` — run it with `cargo test`.
+
+Then notify from anywhere a handler runs:
+
+```rust
+use autumn_web::notifications::Notifications;
+use autumn_web::prelude::*;
+
+#[post("/comments")]
+async fn create_comment(notifications: Notifications) -> AutumnResult<&'static str> {
+    // ... create the comment ...
+    notifications
+        .notify(recipient_id, "comment.created", serde_json::json!({ "post": 42 }))
+        .await?;
+    Ok("ok")
+}
+```
+
+## The API
+
+`Notifications` is an extractor, surfaced the same way as `Session` and `Db`:
+declare it as a handler parameter. It provides:
+
+| Method | Behavior |
+|--------|----------|
+| `notify(recipient_id, kind, payload)` | Persist a new unread notification; immediately visible to reads |
+| `list(recipient_id, &ListQuery, &PageRequest)` | One `Page` of the feed (shipped pagination) |
+| `unread_count(recipient_id)` | Count of rows with `read_at` unset |
+| `mark_read(id)` / `mark_read_for(recipient_id, id)` | Mark one read — idempotent; the `_for` variant refuses to touch other recipients' rows |
+| `mark_all_read(recipient_id)` | Mark everything read; returns how many transitioned; idempotent |
+
+Reading the feed reuses `Page`/`ListQuery`/`PageRequest`, so the usual query
+parameters work out of the box: `?page=2&size=20`, `?filter[unread]=true`,
+`?filter[kind]=comment.created`, `?sort=created_at&dir=asc`. Without an
+explicit sort the feed returns newest-first. Unknown filters and sort keys are
+ignored, matching the repository `list()` contract.
+
+```rust
+use autumn_web::notifications::{Notification, Notifications};
+use autumn_web::prelude::*;
+
+#[get("/notifications")]
+async fn feed(
+    Auth(user): Auth<CurrentUser>,
+    query: ListQuery,
+    page: PageRequest,
+    notifications: Notifications,
+) -> AutumnResult<Json<Page<Notification>>> {
+    Ok(Json(notifications.list(user.id, &query, &page).await?))
+}
+```
+
+In user-facing handlers prefer `mark_read_for(user.id, id)` over
+`mark_read(id)`: it scopes the update to the signed-in recipient, so a user
+cannot mark someone else's notification read by guessing ids.
+
+## Storage
+
+`Notifications` delegates to a pluggable `NotificationStore`, resolved once
+per app:
+
+1. A store you registered via `AppBuilder::with_notification_store(...)`.
+2. `DbNotificationStore` when a database pool is configured — the persistent
+   default, backed by the `notifications` table the generator scaffolds.
+3. `MemoryNotificationStore` otherwise — a process-local fallback for tests
+   and DB-less development (contents are lost on restart).
+
+The `notifications` table stores `id`, `recipient_id`, `kind`, a JSON
+`payload` (TEXT-serialized, so it is identical on Postgres and SQLite), a
+nullable `read_at`, and `created_at`. Timestamps are `TIMESTAMPTZ` on
+Postgres and RFC 3339 `TEXT` on SQLite.
+
+To plug in a custom backend, implement `NotificationStore` and register it:
+
+```rust
+autumn_web::app()
+    .with_notification_store(MyStore::new())
+    .run()
+    .await;
+```
+
+## Realtime push over channels (optional, best-effort)
+
+With the `ws` feature enabled you can push each new notification to connected
+clients over the existing [channels](realtime.md) transport. The conventional
+per-recipient topic is `Notifications::topic(recipient_id)`
+(`"notifications:{recipient_id}"`).
+
+The built-in helper persists and then publishes the stored notification as
+JSON:
+
+```rust
+#[post("/likes")]
+async fn like(notifications: Notifications) -> AutumnResult<&'static str> {
+    // Persists, then publishes on "notifications:{recipient}". The broadcast
+    // is best-effort: a channel failure never fails the notify.
+    notifications
+        .notify_with_push(recipient_id, "like", serde_json::json!({}))
+        .await?;
+    Ok("ok")
+}
+```
+
+Or wire it manually — the important part is ignoring the publish result, so a
+dead channel (or simply "no subscribers right now") never fails the write:
+
+```rust
+let n = notifications.notify(user.id, "like", payload).await?;
+let _ = state
+    .broadcast()
+    .publish(&Notifications::topic(user.id), serde_json::to_string(&n)?);
+```
+
+A WebSocket or SSE handler subscribes to the same topic to stream the feed:
+
+```rust
+let mut rx = state.channels().subscribe(&Notifications::topic(user.id));
+while let Ok(msg) = rx.recv().await {
+    // forward msg (the notification JSON) to the client
+}
+```
+
+## Out of scope (by design)
+
+The bell/dropdown widget itself, email/SMS delivery, per-user notification
+preferences, digests, and cross-recipient fan-out are deliberately not part of
+this primitive — it ships the data + API layer that those can build on.
+
+[`Notifications`]: https://docs.rs/autumn-web/latest/autumn_web/notifications/struct.Notifications.html

--- a/skills/autumn-web/SKILL.md
+++ b/skills/autumn-web/SKILL.md
@@ -829,6 +829,45 @@ this is *provider-reported* failure.
   recipient fixed their mailbox); `store.suppress(addr, SuppressionReason::Manual)`
   adds one by hand.
 
+## In-app notifications (unreleased — trunk-dev, issue #1148)
+
+A first-class per-recipient notification store with read/unread state — do not
+hand-roll a notifications table, model, and unread-count queries. Scaffold with
+`autumn generate notifications` (backend-aware migration + feed routes + smoke
+test), then use the `Notifications` extractor (in the prelude, surfaced like
+`Session`):
+
+```rust
+use autumn_web::prelude::*;
+
+#[post("/comments")]
+async fn create_comment(notifications: Notifications) -> AutumnResult<&'static str> {
+    notifications
+        .notify(recipient_id, "comment.created", serde_json::json!({"post": 42}))
+        .await?;
+    Ok("ok")
+}
+```
+
+- **API:** `notify(recipient_id, kind, payload)`; `list(recipient_id, &ListQuery,
+  &PageRequest) -> Page<Notification>` (`?filter[unread]=true`,
+  `?filter[kind]=…`, `?sort=created_at|id`, newest-first default);
+  `unread_count(recipient_id)`; idempotent `mark_read(id)` /
+  `mark_read_for(recipient_id, id)` / `mark_all_read(recipient_id)`. In
+  user-facing handlers use `mark_read_for` — it refuses to touch other
+  recipients' rows.
+- **Storage resolution** (mirrors `SessionStore`): a store registered via
+  `AppBuilder::with_notification_store(...)` → `DbNotificationStore` when a DB
+  pool is configured (needs the generated `notifications` table) →
+  `MemoryNotificationStore` (process-local; what `TestApp` without a DB uses,
+  so generated smoke tests need no database).
+- **Realtime push (`ws` feature):** `notify_with_push(...)` persists then
+  publishes the notification JSON on `Notifications::topic(recipient_id)`
+  (`"notifications:{id}"`) — best-effort, a channel failure never fails the
+  notify. Subscribe with `state.channels().subscribe(&Notifications::topic(id))`.
+- Guide: `docs/guide/notifications.md`. Out of scope by design: bell widget,
+  email/SMS channels, preferences/digests, cross-recipient fan-out.
+
 ## Background work
 
 Use built-in jobs and tasks before reaching for a workflow engine:

--- a/skills/autumn-web/SKILL.md
+++ b/skills/autumn-web/SKILL.md
@@ -864,7 +864,10 @@ async fn create_comment(notifications: Notifications) -> AutumnResult<&'static s
 - **Realtime push (`ws` feature):** `notify_with_push(...)` persists then
   publishes the notification JSON on `Notifications::topic(recipient_id)`
   (`"notifications:{id}"`) — best-effort, a channel failure never fails the
-  notify. Subscribe with `state.channels().subscribe(&Notifications::topic(id))`.
+  notify. In the subscribing WS/SSE handler, derive the topic from the
+  **authenticated** user (`Auth`/session), never a client-supplied id — topics
+  are guessable and carry the full payload; use `subscribe_authorized` /
+  `sse::stream_authorized` for channel-level enforcement.
 - Guide: `docs/guide/notifications.md`. Out of scope by design: bell widget,
   email/SMS channels, preferences/digests, cross-recipient fan-out.
 


### PR DESCRIPTION
Implements #1148: a first-class in-app notifications store with a read/unread feed, built TDD (red → green → refactor).

## What ships

**Framework (`autumn-web`, additive only)**
- New `autumn_web::notifications` module:
  - `Notification` record (`id`, `recipient_id`, `kind`, JSON `payload`, nullable `read_at`, `created_at`).
  - `Notifications` service/extractor (surfaced like `Session`/`Auth`, re-exported from the prelude) with `notify(recipient_id, kind, payload)`, `list(recipient_id, &ListQuery, &PageRequest) -> Page<Notification>` (supports `filter[unread]=true`, `filter[kind]=…`, `sort=id|created_at`, newest-first default), `unread_count`, and idempotent `mark_read` / `mark_read_for` (recipient-scoped, IDOR-safe) / `mark_all_read`.
  - Pluggable `NotificationStore` trait; resolution order: `AppBuilder::with_notification_store(...)` → `DbNotificationStore` when a pool is configured → `MemoryNotificationStore` (DB-less dev/tests). Mirrors the `SessionStore` pattern.
  - `DbNotificationStore` works on both Postgres (`TIMESTAMPTZ`) and SQLite (`TimestamptzSqlite`/RFC 3339 TEXT) via the runtime connection aliases.
  - `ws`-gated `notify_with_push`: persists, then publishes the notification JSON on the conventional `notifications:{recipient_id}` topic — **best-effort**, a channel failure never fails the notify.

**CLI (`autumn-cli`)** *(in progress on this branch)*
- `autumn generate notifications`: scaffolds the backend-aware migration (via the existing migration/DSL emitters — no hand-written SQL), a minimal feed module with registered routes, and an in-process `TestClient` smoke test exercising notify → list → mark_read.

**Docs**
- `docs/guide/notifications.md` incl. optional realtime push wiring over `channels`.
- `CHANGELOG.md` entry under `## [Unreleased] → ### Added`.

## Tests
- Memory-store semantics: visibility of `notify` to `list`/`unread_count`, unread filtering, idempotent re-marking, recipient scoping, ordering + pagination.
- Extractor end-to-end through `TestApp` routes (memory fallback, no DB).
- Best-effort push: dead channel never fails notify; push lands on the per-recipient topic.
- Postgres store lifecycle via testcontainers (`#[ignore = "requires Docker (testcontainers)"]`, auto-swept by the CI Docker step).

Closes #1148.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SZf4iLosHrprEiYKAMUzBp

---
_Generated by [Claude Code](https://claude.ai/code/session_01SZf4iLosHrprEiYKAMUzBp)_