### PR TITLE
mail: enforce the prod deliver_later durability guard lazily, not at boot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -298,6 +298,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   richer per-fault surfaces build additively on it. [no-plugin]
 ### Fixed
 
+- **mail:** the prod `deliver_later` durability guard no longer aborts app
+  startup for applications that never call `deliver_later`/`deliver_later_eager`
+  (#2142). Previously, `install_mailer` hard-failed at boot in `prod` whenever
+  no durable `MailDeliveryQueue` was registered and
+  `mail.allow_in_process_deliver_later_in_production` was unset — even for
+  apps that only ever call `Mailer::send`. The check is now enforced lazily:
+  startup logs a warning and continues, and `try_deliver_later`/
+  `try_deliver_later_eager` return the new `MailError::NoDurableQueueInProduction`
+  the first time deferred delivery is actually attempted without a durable
+  backend or explicit ack.
 - **ci:** wire the `sim_sqlite_substrate` (W4) integration test into the
   `sqlite-runtime` job's `cargo test --features "sqlite,test-support"`
   invocation (alongside `sim_chaos`) so it actually runs in CI, and fix a

--- a/autumn/src/mail.rs
+++ b/autumn/src/mail.rs
@@ -6394,9 +6394,11 @@ mod tests {
         let error = installed
             .try_deliver_later_eager(sample_mail())
             .expect_err("deliver_later_eager must fail the same way");
-        assert!(error
-            .to_string()
-            .contains("allow_in_process_deliver_later_in_production"));
+        assert!(
+            error
+                .to_string()
+                .contains("allow_in_process_deliver_later_in_production")
+        );
     }
 
     #[test]

--- a/autumn/src/mail.rs
+++ b/autumn/src/mail.rs
@@ -1031,6 +1031,16 @@ pub enum MailError {
     /// stable if those loaders are ever enabled.
     #[error("failed to inline CSS into HTML mail body: {0}")]
     CssInline(String),
+    /// `deliver_later`/`deliver_later_eager` was called in `prod` with a
+    /// non-disabled transport, no durable [`MailDeliveryQueue`] registered, and
+    /// no explicit [`MailConfig::allow_in_process_deliver_later_in_production`]
+    /// opt-in (issue #2142). Enforced lazily at the first deferred send rather
+    /// than at boot, so applications that never call `deliver_later` are
+    /// unaffected.
+    #[error(
+        "mail.deliver_later has no durable backend in prod: register a MailDeliveryQueueHandle on AppState or set mail.allow_in_process_deliver_later_in_production = true to opt into the in-process Tokio fallback"
+    )]
+    NoDurableQueueInProduction,
 }
 
 /// Escape hatch for custom transports.
@@ -1545,6 +1555,12 @@ pub struct Mailer {
     /// Default for CSS inlining of HTML bodies when a message does not set its
     /// own [`Mail::inline_css`] override. Sourced from [`MailConfig::inline_css`].
     inline_css_default: bool,
+    /// Set by `install_mailer` when running in `prod` with a non-disabled
+    /// transport but no durable [`MailDeliveryQueue`] and no explicit
+    /// [`MailConfig::allow_in_process_deliver_later_in_production`] ack
+    /// (issue #2142). Rather than failing app startup for apps that never call
+    /// `deliver_later`, the check is deferred to the first actual call.
+    block_deliver_later_without_durable_queue: bool,
 }
 
 impl Mailer {
@@ -1596,6 +1612,7 @@ impl Mailer {
             unsubscribe: None,
             suppression: None,
             inline_css_default: false,
+            block_deliver_later_without_durable_queue: false,
         }
     }
 
@@ -1887,6 +1904,9 @@ impl Mailer {
         if self.transport.is_disabled() {
             return Ok(());
         }
+        if self.block_deliver_later_without_durable_queue && self.delivery_queue.is_none() {
+            return Err(MailError::NoDurableQueueInProduction);
+        }
         let mut mail = mail.with_defaults(&self.defaults);
         // Resolve the CSS-inlining default onto the message once, at the top of
         // the deferred path, so BOTH the durable-queue branch (persisted for a
@@ -1956,6 +1976,9 @@ impl Mailer {
     pub fn try_deliver_later_eager(&self, mail: Mail) -> Result<(), MailError> {
         if self.transport.is_disabled() {
             return Ok(());
+        }
+        if self.block_deliver_later_without_durable_queue && self.delivery_queue.is_none() {
+            return Err(MailError::NoDurableQueueInProduction);
         }
         let mut mail = mail.with_defaults(&self.defaults);
         self.freeze_inline_css_default(&mut mail);
@@ -2138,6 +2161,7 @@ impl MailerBuilder {
             unsubscribe: None,
             suppression: None,
             inline_css_default: self.inline_css,
+            block_deliver_later_without_durable_queue: false,
         })
     }
 }
@@ -3354,15 +3378,20 @@ impl MailTransport for InterceptedMailTransport {
 /// Picks up a runtime-installed [`MailDeliveryQueueHandle`] from
 /// [`AppState`] extensions when present, so plugins (Harvest, Redis-backed,
 /// etc.) can register durable delivery before this runs. In `prod` with a
-/// non-`Disabled` transport, startup fails when neither a durable queue nor
-/// [`MailConfig::allow_in_process_deliver_later_in_production`] is set, unless
-/// `enforce_durable_guard` is `false` (used by short-lived contexts like
-/// static-site builds where `deliver_later` semantics don't apply).
+/// non-`Disabled` transport, when neither a durable queue nor
+/// [`MailConfig::allow_in_process_deliver_later_in_production`] is set, startup
+/// still succeeds — apps that never call `deliver_later` should not be crashed
+/// for a code path they don't use (issue #2142). Instead, a startup warning is
+/// logged and the installed [`Mailer`] is marked so that
+/// [`Mailer::try_deliver_later`]/[`Mailer::try_deliver_later_eager`] fail with
+/// [`MailError::NoDurableQueueInProduction`] the first time deferred delivery
+/// is actually attempted. `enforce_durable_guard` set to `false` (used by
+/// short-lived contexts like static-site builds where `deliver_later`
+/// semantics don't apply) skips this check entirely.
 ///
 /// # Errors
 ///
-/// Returns an Autumn error when the configured transport cannot be created or
-/// when the production `deliver_later` guard is not satisfied.
+/// Returns an Autumn error when the configured transport cannot be created.
 #[allow(clippy::too_many_lines)]
 pub(crate) fn install_mailer(
     state: &AppState,
@@ -3398,11 +3427,17 @@ pub(crate) fn install_mailer(
     if enforce_durable_guard && in_production && transport_sends_mail {
         let has_durable_queue = mailer.delivery_queue.is_some();
         if !has_durable_queue && !config.allow_in_process_deliver_later_in_production {
-            return Err(AutumnError::service_unavailable_msg(
-                "mail.deliver_later has no durable backend in prod: register a MailDeliveryQueueHandle on AppState or set mail.allow_in_process_deliver_later_in_production = true to opt into the in-process Tokio fallback",
-            ));
-        }
-        if !has_durable_queue {
+            // Issue #2142: don't hard-fail app boot over an unused code path.
+            // Apps that only call `send()` are never affected; apps that do
+            // call `deliver_later` in this state find out at the call site
+            // (see `Mailer::try_deliver_later`), not by crashing at startup.
+            tracing::warn!(
+                "mail.deliver_later has no durable backend in prod: deliver_later/deliver_later_eager will fail if called; \
+                 register a MailDeliveryQueueHandle on AppState, or set mail.allow_in_process_deliver_later_in_production = true \
+                 to opt into the non-durable in-process Tokio fallback. Apps that only use mail.send() are unaffected."
+            );
+            mailer.block_deliver_later_without_durable_queue = true;
+        } else if !has_durable_queue {
             tracing::warn!(
                 "mail.deliver_later is using the in-process Tokio fallback in prod; this is acknowledged via mail.allow_in_process_deliver_later_in_production but is not durable across restarts or replicas"
             );
@@ -6333,18 +6368,35 @@ mod tests {
     }
 
     #[test]
-    fn install_mailer_rejects_in_process_fallback_in_prod_without_ack() {
+    fn install_mailer_boots_in_prod_without_ack_but_blocks_deliver_later() {
+        // Issue #2142: a missing durable queue + ack must not crash app
+        // startup — only the `deliver_later` call path should fail, and only
+        // if the app actually reaches it.
         let state = crate::AppState::for_test().with_profile("prod");
         let config = sample_smtp_config();
 
-        let error = install_mailer(&state, &config, true)
-            .expect_err("prod must reject in-process deliver_later fallback without ack");
+        install_mailer(&state, &config, true)
+            .expect("missing durable queue/ack must not fail app boot");
 
+        let installed = state
+            .extension::<Mailer>()
+            .expect("install_mailer should store a Mailer extension");
+
+        let error = installed
+            .try_deliver_later(sample_mail())
+            .expect_err("deliver_later without a durable queue or ack must fail lazily in prod");
         let message = error.to_string();
         assert!(
             message.contains("allow_in_process_deliver_later_in_production"),
             "error should explain how to opt in: {message}"
         );
+
+        let error = installed
+            .try_deliver_later_eager(sample_mail())
+            .expect_err("deliver_later_eager must fail the same way");
+        assert!(error
+            .to_string()
+            .contains("allow_in_process_deliver_later_in_production"));
     }
 
     #[test]

--- a/autumn/src/mail.rs
+++ b/autumn/src/mail.rs
@@ -1894,8 +1894,11 @@ impl Mailer {
     ///
     /// # Errors
     ///
-    /// Returns an error when no active Tokio runtime is available to host the
-    /// background task.
+    /// Returns [`MailError::NoDurableQueueInProduction`] when this `Mailer` was
+    /// installed in `prod` with no durable [`MailDeliveryQueue`] and no
+    /// [`MailConfig::allow_in_process_deliver_later_in_production`] opt-in (issue
+    /// #2142). Otherwise returns an error when no active Tokio runtime is
+    /// available to host the background task.
     ///
     /// # Panics
     ///
@@ -1972,7 +1975,11 @@ impl Mailer {
     ///
     /// # Errors
     ///
-    /// Returns an error when no active Tokio runtime is available.
+    /// Returns [`MailError::NoDurableQueueInProduction`] when this `Mailer` was
+    /// installed in `prod` with no durable [`MailDeliveryQueue`] and no
+    /// [`MailConfig::allow_in_process_deliver_later_in_production`] opt-in (issue
+    /// #2142). Otherwise returns an error when no active Tokio runtime is
+    /// available.
     pub fn try_deliver_later_eager(&self, mail: Mail) -> Result<(), MailError> {
         if self.transport.is_disabled() {
             return Ok(());

--- a/docs/guide/cloud-native.md
+++ b/docs/guide/cloud-native.md
@@ -225,12 +225,13 @@ tls = "starttls"
 For durable retries across replicas, register a durable
 [`MailDeliveryQueue`](mail.md#deferred-delivery-deliver_later) via
 `AppBuilder::with_mail_delivery_queue` before `.run()` (see the Mail Guide
-for the trait definition and an outbox example). Without one, `prod` startup
-fails unless you explicitly set
+for the trait definition and an outbox example). Without one, calling
+`deliver_later` in `prod` fails at the call site unless you explicitly set
 `mail.allow_in_process_deliver_later_in_production = true`, which
 acknowledges the in-process Tokio fallback. The fallback is fine for local
 development and small single-process deployments but is not durable across
-restarts or replicas.
+restarts or replicas. Apps that only call `mailer.send(...)` never reach this
+guard and need neither a queue nor the flag.
 
 When email dispatch is coordinated with DB writes, use
 [`Db::tx`](transactions.md) for the database side so the write set commits or

--- a/docs/guide/cloud-native.md
+++ b/docs/guide/cloud-native.md
@@ -225,13 +225,16 @@ tls = "starttls"
 For durable retries across replicas, register a durable
 [`MailDeliveryQueue`](mail.md#deferred-delivery-deliver_later) via
 `AppBuilder::with_mail_delivery_queue` before `.run()` (see the Mail Guide
-for the trait definition and an outbox example). Without one, calling
-`deliver_later` in `prod` fails at the call site unless you explicitly set
+for the trait definition and an outbox example). Without one,
+`try_deliver_later`/`try_deliver_later_eager` return
+`MailError::NoDurableQueueInProduction` in `prod` unless you explicitly set
 `mail.allow_in_process_deliver_later_in_production = true`, which
-acknowledges the in-process Tokio fallback. The fallback is fine for local
-development and small single-process deployments but is not durable across
-restarts or replicas. Apps that only call `mailer.send(...)` never reach this
-guard and need neither a queue nor the flag.
+acknowledges the in-process Tokio fallback (the plain `deliver_later`/
+`deliver_later_eager` methods only log that error, so a caller using them
+can't observe it). The fallback is fine for local development and small
+single-process deployments but is not durable across restarts or replicas.
+Apps that only call `mailer.send(...)` never reach this guard and need
+neither a queue nor the flag.
 
 When email dispatch is coordinated with DB writes, use
 [`Db::tx`](transactions.md) for the database side so the write set commits or

--- a/docs/guide/mail.md
+++ b/docs/guide/mail.md
@@ -343,8 +343,13 @@ imply durable delivery on their own. The framework provides two paths:
 
 ### Production Guard
 
-In `prod`/`production`, Autumn refuses to start with an active mail transport
-and no durable backend unless you explicitly opt in:
+In `prod`/`production`, with an active mail transport and no durable backend
+registered, Autumn does **not** fail to start — apps that never call
+`deliver_later`/`deliver_later_eager` (e.g. only `mailer.send(...)`) are
+unaffected either way. Startup logs a warning, and the guard is enforced lazily
+at the call site instead: the first `deliver_later`/`deliver_later_eager` call
+returns `MailError::NoDurableQueueInProduction` until you either register a
+`MailDeliveryQueueHandle` or explicitly opt in:
 
 ```toml
 [mail]
@@ -352,9 +357,10 @@ transport = "smtp"
 allow_in_process_deliver_later_in_production = true
 ```
 
-Without that flag, startup fails with a clear message asking you to either
-install a `MailDeliveryQueueHandle` or set the flag. The flag is intended as an
-acknowledged single-replica escape hatch, not a recommended production setup.
+The flag is intended as an acknowledged single-replica escape hatch, not a
+recommended production setup — with it set, `deliver_later` falls back to an
+in-process Tokio task instead of failing, but delivery is not durable across
+restarts or replicas.
 
 ### DB-Write + Mail Patterns (Outbox)
 
@@ -393,9 +399,11 @@ build a `Mailer::with_transport(...)`.
 - Add a plain-text fallback for every HTML email.
 - Assert file-transport `.eml` contents in integration tests.
 - Register a `MailDeliveryQueueHandle` (Harvest, DB outbox, Redis, etc.) for
-  durable `deliver_later` retries. Without one, `prod` startup fails unless
+  durable `deliver_later` retries. Without one, calling `deliver_later` in
+  `prod` fails at the call site unless
   `mail.allow_in_process_deliver_later_in_production = true` is set, in which
-  case Autumn falls back to an in-process Tokio task and logs failures.
+  case Autumn falls back to an in-process Tokio task and logs failures. Apps
+  that only use `mailer.send(...)` are unaffected and need neither.
 - For DB-write + mail-orchestration flows, use the [Transactions
   Guide](transactions.md) for the canonical atomic write pattern.
 - Shipping newsletters, digests, or other bulk mail? See

--- a/docs/guide/mail.md
+++ b/docs/guide/mail.md
@@ -347,9 +347,13 @@ In `prod`/`production`, with an active mail transport and no durable backend
 registered, Autumn does **not** fail to start — apps that never call
 `deliver_later`/`deliver_later_eager` (e.g. only `mailer.send(...)`) are
 unaffected either way. Startup logs a warning, and the guard is enforced lazily
-at the call site instead: the first `deliver_later`/`deliver_later_eager` call
-returns `MailError::NoDurableQueueInProduction` until you either register a
-`MailDeliveryQueueHandle` or explicitly opt in:
+at the call site instead: `try_deliver_later`/`try_deliver_later_eager` return
+`MailError::NoDurableQueueInProduction` on the first deferred send, until you
+either register a `MailDeliveryQueueHandle` or explicitly opt in. The plain
+`deliver_later`/`deliver_later_eager` convenience methods call these
+fallible `try_*` variants but only log the error — they still return `()`, so
+a caller using them cannot observe or match on the typed error and should not
+assume the mail was scheduled just because the call returned.
 
 ```toml
 [mail]
@@ -399,11 +403,13 @@ build a `Mailer::with_transport(...)`.
 - Add a plain-text fallback for every HTML email.
 - Assert file-transport `.eml` contents in integration tests.
 - Register a `MailDeliveryQueueHandle` (Harvest, DB outbox, Redis, etc.) for
-  durable `deliver_later` retries. Without one, calling `deliver_later` in
-  `prod` fails at the call site unless
-  `mail.allow_in_process_deliver_later_in_production = true` is set, in which
-  case Autumn falls back to an in-process Tokio task and logs failures. Apps
-  that only use `mailer.send(...)` are unaffected and need neither.
+  durable `deliver_later` retries. Without one, `try_deliver_later`/
+  `try_deliver_later_eager` return `MailError::NoDurableQueueInProduction` in
+  `prod` unless `mail.allow_in_process_deliver_later_in_production = true` is
+  set, in which case Autumn falls back to an in-process Tokio task. The plain
+  `deliver_later`/`deliver_later_eager` methods only log that error — they
+  don't propagate it to the caller. Apps that only use `mailer.send(...)` are
+  unaffected and need neither.
 - For DB-write + mail-orchestration flows, use the [Transactions
   Guide](transactions.md) for the canonical atomic write pattern.
 - Shipping newsletters, digests, or other bulk mail? See


### PR DESCRIPTION
## Summary

Fixes #2142.

`install_mailer`'s production durability guard previously hard-failed app startup in `prod` whenever the transport was active, no durable `MailDeliveryQueue` was registered, and `mail.allow_in_process_deliver_later_in_production` was unset — even for applications that never call `deliver_later`/`deliver_later_eager` (e.g. apps that only use `mailer.send(...)`, or that route bulk mail through their own durable rails).

- `install_mailer` no longer returns an error for this case. Startup logs a `tracing::warn!` explaining the situation and continues; the installed `Mailer` is marked internally.
- `Mailer::try_deliver_later` / `try_deliver_later_eager` now check that marker and return the new `MailError::NoDurableQueueInProduction` the first time a deferred send is actually attempted without a durable queue or explicit ack — instead of silently falling back to the non-durable in-process Tokio path.
- `deliver_later` (the non-`try_` variant) already logs-and-swallows errors from `try_deliver_later`, so this degrades gracefully per-call rather than crashing the process.
- Apps that register a `MailDeliveryQueueHandle`, or set `mail.allow_in_process_deliver_later_in_production = true`, or never call `deliver_later` at all, are unaffected.

Updated `docs/guide/mail.md` and `docs/guide/cloud-native.md` to describe the new lazy-enforcement behavior, and added a `CHANGELOG.md` entry under `[Unreleased]`.

## Test plan

- [x] `cargo test --lib --features "test-support,mail"` in `autumn/` — 4101 passed, 0 failed
- [x] Rewrote `install_mailer_rejects_in_process_fallback_in_prod_without_ack` as `install_mailer_boots_in_prod_without_ack_but_blocks_deliver_later`, asserting boot succeeds and `try_deliver_later`/`try_deliver_later_eager` fail lazily with the expected message
- [x] `./scripts/pre-push-check.sh` compile-only gate (fmt/clippy steps were skipped — `rustfmt`/`clippy` components are not installed for this toolchain in this sandbox; `cargo check`/`cargo test --workspace --no-run` portions passed)

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01DoyZRDE5ht5J4NB9YmRPN8


---
_Generated by [Claude Code](https://claude.ai/code/session_01DoyZRDE5ht5J4NB9YmRPN8)_