### PR TITLE
feat(search): add the `autumn-search` plugin for keyword and vector search (#1191)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,6 +134,9 @@ jobs:
           cargo test -p autumn-web --test scoped_tokens_db -- --ignored
           cargo test -p autumn-admin-plugin --test token_admin_db -- --ignored
           cargo test -p autumn-cache-redis -- --ignored
+          # autumn-search (#1191): the Postgres SearchBackend + DocumentSource
+          # suites are testcontainer-managed, so no `services:` block is needed.
+          cargo test -p autumn-search -- --ignored
           cargo test -p autumn-cli --test flags -- --ignored
           cargo test -p autumn-cli --test config -- --ignored
           cargo test -p autumn-cli --test experiments -- --ignored
@@ -286,6 +289,7 @@ jobs:
           cargo llvm-cov --no-report -p autumn-admin-plugin \
             --test token_admin_db -- --ignored
           cargo llvm-cov --no-report -p autumn-cache-redis -- --ignored
+          cargo llvm-cov --no-report -p autumn-search -- --ignored
           cargo llvm-cov --no-report -p autumn-cli --test flags -- --ignored
           cargo llvm-cov --no-report -p autumn-cli --test config -- --ignored
           cargo llvm-cov --no-report -p autumn-cli --test experiments -- --ignored

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,59 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **search:** a new optional plugin crate, `autumn-search`, turning the in-core
+  full-text primitives (#842) into a **search subsystem**: mark a model
+  searchable and get an index that stays in sync with the record lifecycle,
+  plus semantic / vector retrieval, behind one engine-agnostic API (#1191).
+  The `#[searchable]` attribute you already write is the single source of
+  truth — `#[model]` now also derives an engine-agnostic `IndexDefinition`
+  (index name, language, weighted fields) and a per-record `SearchDocument`
+  from it, and a new `#[searchable(embed)]` field flag nominates the one field
+  whose text is embedded for "find similar" / RAG retrieval. Two `embed`
+  fields, or `embed` without the model-level `#[searchable]`, are compile
+  errors that say so rather than a silent last-wins. Index sync is
+  `SearchSyncHooks`, a ready-made `MutationHooks` you name once on the
+  repository: create/update/delete then enqueue a durable `#[job]` reindex, so
+  indexing is off-request and survives a restart. The job payload is
+  `(index, id)` and **not** the record — the handler re-reads the row, so a
+  present row upserts and an absent row deletes. That single idempotent
+  operation makes at-least-once delivery safe and lets a lost delete event or
+  a row changed by direct SQL repair itself. Queries reuse `Page`/`ListQuery`
+  (`search`, `search_list`, `search_hydrated`, `similar`, `similar_to`), and
+  `autumn search reindex [--index NAME] [--purge]` rebuilds an index by running
+  the application binary — the same technique `autumn jobs manifest` uses,
+  because only the app knows which models, backend, and embedder are
+  registered. Backfill walks the source by keyset (`WHERE id > $after`), never
+  `OFFSET`, so a live table cannot skip or repeat rows. Backends are pluggable
+  behind a `SearchBackend` trait shaped so an external engine (Meilisearch,
+  Tantivy, a vector store) is a new `impl` rather than a breaking change: the
+  Postgres backend ships first, reusing `to_tsvector`/`setweight`/`ts_rank_cd`
+  and adding `pgvector` when the extension is present — with a portable
+  `double precision[]` + `autumn_search_cosine()` fallback so a managed
+  Postgres without `pgvector` still boots and still answers k-NN queries, at
+  the same ordering and lower speed. A `MemorySearchBackend` gives complete
+  keyword *and* vector coverage with no Docker and no network. Embedding is
+  pluggable via an `Embedder` trait; the crate ships **no** model, runtime, or
+  vendor SDK — only a `NoEmbedder` that refuses (so a missing provider is a
+  typed error, never invented vectors) and a deterministic `HashingEmbedder`
+  for dev and tests. Search respects existing authorization: a
+  `SearchVisibility` hook turns a `PolicyContext` into a `SearchFilter` that is
+  pushed *into* the engine query rather than applied afterwards, so page totals
+  and neighbour counts are computed post-restriction; filters **intersect**, so
+  a caller can only narrow what authorization allowed; a failing hook aborts
+  the search instead of widening it; and calling the authorization-aware entry
+  point with no hook registered is a typed error rather than an unfiltered
+  read. Because a `SearchFilter` is plain data, an out-of-scope engine gets the
+  same tenant/visibility restriction, and the ambient `CURRENT_TENANT` is
+  intersected into every query automatically. Query text is a bag of words
+  across every backend — each token must match, operator syntax (`OR`,
+  `field:`, `*`) is never interpreted, and a blank query returns an empty page
+  having issued no query — which keeps results consistent between engines and
+  makes a hostile query string structurally incapable of widening the result
+  set. The in-core `#[repository(searchable)]` `search()` and its
+  `websearch_to_tsquery` semantics are untouched; this subsumes #842 as one
+  backend, it does not replace it. See `docs/guide/search.md`.
+
 - **seo:** route-level meta tag defaults via a `seo(...)` route attribute
   argument, closing the acceptance criterion deferred from the SEO toolkit
   (#1182, deferred from #830). Static per-page metadata no longer has to be

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,7 +98,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   rows stay indexed exactly as the model's finders return them.
   Request-controlled values — pagination, and the k-NN minimum score — are
   bound rather than formatted into the SQL, because diesel's statement cache is
-  keyed on query text and never evicts. The in-core
+  keyed on query text and never evicts. A disabled subsystem initializes
+  nothing — no `ensure_index`, no DDL, no width check — so a search outage
+  cannot abort application startup after the switch has been thrown. A backfill
+  takes a write watermark up front and never overwrites a document a concurrent
+  reindex wrote after it started, so the bulk and per-record writers converge
+  instead of racing. The in-core
   `#[repository(searchable)]` `search()` and its `websearch_to_tsquery`
   semantics are untouched; this subsumes #842 as one backend, it does not
   replace it. See `docs/guide/search.md`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,8 +104,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   takes a write watermark up front and never overwrites — or re-creates — a
   record a concurrent reindex touched after it started, so the bulk and
   per-record writers converge instead of racing; deletes are recorded in a
-  ledger that outlives the document, so a mid-backfill delete cannot be undone
-  by a stale batch. Tenant scoping, like soft delete, follows the repository's
+  ledger that outlives the document — in the same statement that removes it, so
+  no concurrent write can observe the gap — and a mid-backfill delete cannot be
+  undone by a stale batch. Tenant scoping, like soft delete, follows the repository's
   opt-in rather than the mere presence of a column. The in-core
   `#[repository(searchable)]` `search()` and its `websearch_to_tsquery`
   semantics are untouched; this subsumes #842 as one backend, it does not

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,10 +32,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   concurrency cap of one **per record** keeps the two jobs that implies from
   interleaving a stale read over a newer write. Queries reuse `Page`/`ListQuery`
   (`search`, `search_list`, `search_hydrated`, `similar`, `similar_to`), and
-  `autumn search reindex [--index NAME] [--purge]` rebuilds an index by running
-  the application binary — the same technique `autumn jobs manifest` uses,
+  `autumn search reindex [--index NAME] [--purge] [--profile NAME]` rebuilds an
+  index by running the application binary — the same technique `autumn jobs manifest` uses,
   because only the app knows which models, backend, and embedder are
-  registered. Backfill walks the source by keyset (`WHERE <key> > $after`),
+  registered. `--profile` matters there: that binary resolves its own
+  `[search]` section, and the CLI builds a debug binary, which core reads as
+  `dev` — so a production rebuild must say so or it rebuilds the development
+  index and reports success. Backfill walks the source by keyset (`WHERE <key> > $after`),
   never `OFFSET`, so a live table cannot skip or repeat rows, and it stops only
   on an empty batch — `scan` returns *up to* `limit`, so a source that filters
   after reading yields short batches with rows still behind them. Backends are pluggable
@@ -104,9 +107,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   takes a write watermark up front and never overwrites — or re-creates — a
   record a concurrent reindex touched after it started, so the bulk and
   per-record writers converge instead of racing; deletes are recorded in a
-  ledger that outlives the document — in the same statement that removes it, so
-  no concurrent write can observe the gap — and a mid-backfill delete cannot be
-  undone by a stale batch. Tenant scoping, like soft delete, follows the repository's
+  ledger that outlives the document — written in the same statement that removes
+  it and cleared in the same statement that re-creates the record, so no
+  concurrent write can observe half of either — and a mid-backfill delete
+  cannot be undone by a stale batch. Tenant scoping, like soft delete, follows the repository's
   opt-in rather than the mere presence of a column. The in-core
   `#[repository(searchable)]` `search()` and its `websearch_to_tsquery`
   semantics are untouched; this subsumes #842 as one backend, it does not

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `autumn search reindex [--index NAME] [--purge] [--profile NAME]` rebuilds an
   index by running the application binary — the same technique `autumn jobs manifest` uses,
   because only the app knows which models, backend, and embedder are
-  registered. `--profile` matters there: that binary resolves its own
+  registered. A one-shot reindex against a profile with
+  `enabled = false` exits non-zero rather than reporting a successful rebuild
+  of nothing. `--profile` matters there: that binary resolves its own
   `[search]` section, and the CLI builds a debug binary, which core reads as
   `dev` — so a production rebuild must say so or it rebuilds the development
   index and reports success. Backfill walks the source by keyset (`WHERE <key> > $after`),

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,7 +91,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   value and semantic search returns nothing. The index definition also carries
   the model's real key column, so a `#[id] pub note_id: i64` over a legacy
   table that still has an unrelated `id` backfills off the right one. The
-  in-core
+  section is read through core's own `Env` abstraction, so the macro-supplied
+  crate directory and build mode are visible and a release binary resolves the
+  same profile core does. A `deleted_at` column is not by itself a tombstone:
+  the source follows the repository's `soft_delete` opt-in, so audit-history
+  rows stay indexed exactly as the model's finders return them.
+  Request-controlled values — pagination, and the k-NN minimum score — are
+  bound rather than formatted into the SQL, because diesel's statement cache is
+  keyed on query text and never evicts. The in-core
   `#[repository(searchable)]` `search()` and its `websearch_to_tsquery`
   semantics are untouched; this subsumes #842 as one backend, it does not
   replace it. See `docs/guide/search.md`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,9 +101,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   keyed on query text and never evicts. A disabled subsystem initializes
   nothing — no `ensure_index`, no DDL, no width check — so a search outage
   cannot abort application startup after the switch has been thrown. A backfill
-  takes a write watermark up front and never overwrites a document a concurrent
-  reindex wrote after it started, so the bulk and per-record writers converge
-  instead of racing. The in-core
+  takes a write watermark up front and never overwrites — or re-creates — a
+  record a concurrent reindex touched after it started, so the bulk and
+  per-record writers converge instead of racing; deletes are recorded in a
+  ledger that outlives the document, so a mid-backfill delete cannot be undone
+  by a stale batch. Tenant scoping, like soft delete, follows the repository's
+  opt-in rather than the mere presence of a column. The in-core
   `#[repository(searchable)]` `search()` and its `websearch_to_tsquery`
   semantics are untouched; this subsumes #842 as one backend, it does not
   replace it. See `docs/guide/search.md`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,9 +99,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   same profile core does. A `deleted_at` column is not by itself a tombstone:
   the source follows the repository's `soft_delete` opt-in, so audit-history
   rows stay indexed exactly as the model's finders return them.
-  Request-controlled values — pagination, and the k-NN minimum score — are
-  bound rather than formatted into the SQL, because diesel's statement cache is
-  keyed on query text and never evicts. A disabled subsystem initializes
+  Request-controlled values — pagination, the k-NN minimum score, the query
+  vector's width — are bound rather than formatted into the SQL, because
+  diesel's statement cache is keyed on query text and never evicts. `[search]`
+  is resolved through core's `.env` overlay too, so a kill switch set there
+  takes effect. A *filtered* k-NN query skips the ivfflat index deliberately:
+  it probes candidate lists before the `WHERE` runs, so a selective
+  authorization filter could otherwise return short or empty while qualifying
+  neighbours sat in unprobed lists. A disabled subsystem initializes
   nothing — no `ensure_index`, no DDL, no width check — so a search outage
   cannot abort application startup after the switch has been thrown. A backfill
   takes a write watermark up front and never overwrites — or re-creates — a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,11 +22,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   errors that say so rather than a silent last-wins. Index sync is
   `SearchSyncHooks`, a ready-made `MutationHooks` you name once on the
   repository: create/update/delete then enqueue a durable `#[job]` reindex, so
-  indexing is off-request and survives a restart. The job payload is
-  `(index, id)` and **not** the record — the handler re-reads the row, so a
-  present row upserts and an absent row deletes. That single idempotent
-  operation makes at-least-once delivery safe and lets a lost delete event or
-  a row changed by direct SQL repair itself. Queries reuse `Page`/`ListQuery`
+  indexing is off-request and survives a restart, and repeated writes to one
+  record coalesce into a single pending job. The payload is `(index, id)` and
+  **not** the record — the handler re-reads the row, so a present row upserts
+  and an absent row deletes. That single idempotent operation makes
+  at-least-once delivery safe and lets a lost delete event, a soft delete, or a
+  row changed by direct SQL repair itself. Queries reuse `Page`/`ListQuery`
   (`search`, `search_list`, `search_hydrated`, `similar`, `similar_to`), and
   `autumn search reindex [--index NAME] [--purge]` rebuilds an index by running
   the application binary — the same technique `autumn jobs manifest` uses,
@@ -34,33 +35,48 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   registered. Backfill walks the source by keyset (`WHERE id > $after`), never
   `OFFSET`, so a live table cannot skip or repeat rows. Backends are pluggable
   behind a `SearchBackend` trait shaped so an external engine (Meilisearch,
-  Tantivy, a vector store) is a new `impl` rather than a breaking change: the
-  Postgres backend ships first, reusing `to_tsvector`/`setweight`/`ts_rank_cd`
-  and adding `pgvector` when the extension is present — with a portable
-  `double precision[]` + `autumn_search_cosine()` fallback so a managed
-  Postgres without `pgvector` still boots and still answers k-NN queries, at
-  the same ordering and lower speed. A `MemorySearchBackend` gives complete
-  keyword *and* vector coverage with no Docker and no network. Embedding is
-  pluggable via an `Embedder` trait; the crate ships **no** model, runtime, or
-  vendor SDK — only a `NoEmbedder` that refuses (so a missing provider is a
-  typed error, never invented vectors) and a deterministic `HashingEmbedder`
-  for dev and tests. Search respects existing authorization: a
-  `SearchVisibility` hook turns a `PolicyContext` into a `SearchFilter` that is
-  pushed *into* the engine query rather than applied afterwards, so page totals
-  and neighbour counts are computed post-restriction; filters **intersect**, so
-  a caller can only narrow what authorization allowed; a failing hook aborts
-  the search instead of widening it; and calling the authorization-aware entry
-  point with no hook registered is a typed error rather than an unfiltered
-  read. Because a `SearchFilter` is plain data, an out-of-scope engine gets the
-  same tenant/visibility restriction, and the ambient `CURRENT_TENANT` is
-  intersected into every query automatically. Query text is a bag of words
-  across every backend — each token must match, operator syntax (`OR`,
-  `field:`, `*`) is never interpreted, and a blank query returns an empty page
-  having issued no query — which keeps results consistent between engines and
-  makes a hostile query string structurally incapable of widening the result
-  set. The in-core `#[repository(searchable)]` `search()` and its
-  `websearch_to_tsquery` semantics are untouched; this subsumes #842 as one
-  backend, it does not replace it. See `docs/guide/search.md`.
+  Tantivy, a vector store) is a new `impl` rather than a breaking change: query
+  and result types are `#[non_exhaustive]`, capabilities are declarable from
+  outside the crate, and a keyword-only engine is a complete implementation.
+  The Postgres backend ships first, reusing
+  `to_tsvector`/`setweight`/`ts_rank_cd` and adding `pgvector` when the
+  extension is present — with a portable `double precision[]` +
+  `autumn_search_cosine()` fallback so a managed Postgres without `pgvector`
+  still boots and still answers k-NN queries. A `MemorySearchBackend` gives
+  complete keyword *and* vector coverage with no Docker and no network, and
+  doubles as the executable specification for the backend contract.
+  Embedding is pluggable via an `Embedder` trait; the crate ships **no** model,
+  runtime, or vendor SDK — only a `NoEmbedder` that refuses (so a missing
+  provider is a typed error, never invented vectors) and a deterministic
+  `HashingEmbedder` for dev and tests.
+  Search respects existing authorization, and enforces it rather than advising
+  it: a `SearchVisibility` hook turns a `PolicyContext` into a `SearchFilter`
+  that is a *required argument* of the backend query methods, so page totals
+  and k-NN neighbour counts are computed after the restriction rather than
+  before; filters **intersect**, so a caller can only narrow what authorization
+  allowed, and two incompatible constraints collapse to "match nothing" rather
+  than to an arbitrary winner; a failing hook aborts the search instead of
+  widening it; calling the authorization-aware entry point with no hook
+  registered is a typed error rather than an unfiltered read; and `similar_to`
+  filters the *seed* read as well as the neighbour query, so "more like this"
+  cannot become an inference channel over records the caller may not see. A
+  model with a `tenant_id` column marks its index tenant-scoped, and querying
+  one with no tenant in scope is refused — matching
+  `#[repository(tenant_scoped)]`, and closing the case where a search route
+  mounted outside the tenancy layer would otherwise have returned every
+  tenant's rows. Because a `SearchFilter` is plain data, an out-of-scope engine
+  gets the same tenant/visibility restriction.
+  Query text is a bag of words across every backend — each token must match,
+  operator syntax (`OR`, `field:`, `*`) is never interpreted, a blank query
+  returns an empty page having issued no query, and a filter key that is not a
+  declared field never reaches SQL — which keeps results consistent between
+  engines and makes a hostile query string structurally incapable of widening
+  the result set. `[search]` is read from `autumn.toml`, so `enabled = false`
+  is a working incident switch: it stops index writes (including a purging
+  backfill) without failing writes to the model. The in-core
+  `#[repository(searchable)]` `search()` and its `websearch_to_tsquery`
+  semantics are untouched; this subsumes #842 as one backend, it does not
+  replace it. See `docs/guide/search.md`.
 
 - **seo:** route-level meta tag defaults via a `seo(...)` route attribute
   argument, closing the acceptance criterion deferred from the SEO toolkit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,9 +71,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   returns an empty page having issued no query, and a filter key that is not a
   declared field never reaches SQL — which keeps results consistent between
   engines and makes a hostile query string structurally incapable of widening
-  the result set. `[search]` is read from `autumn.toml`, so `enabled = false`
-  is a working incident switch: it stops index writes (including a purging
-  backfill) without failing writes to the model. The in-core
+  the result set. `[search]` is resolved through the same profile layering the
+  runtime uses — base `autumn.toml`, then `[profile.<name>.search]`, then
+  `autumn-<profile>.toml`, then `AUTUMN_SEARCH__*` env vars — so
+  `enabled = false` is a working incident switch *per environment*: it stops
+  index writes (including a purging backfill) without failing writes to the
+  model, and cannot be set in prod only to be ignored there. The declared
+  `embedding_dimensions` is checked against the installed `Embedder` at
+  startup and a disagreement refuses the boot, because the alternative is a
+  silent one: writes keep succeeding while the vector column rejects every
+  value and semantic search returns nothing. The index definition also carries
+  the model's real key column, so a `#[id] pub note_id: i64` over a legacy
+  table that still has an unrelated `id` backfills off the right one. The
+  in-core
   `#[repository(searchable)]` `search()` and its `websearch_to_tsquery`
   semantics are untouched; this subsumes #842 as one backend, it does not
   replace it. See `docs/guide/search.md`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,19 +27,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   **not** the record — the handler re-reads the row, so a present row upserts
   and an absent row deletes. That single idempotent operation makes
   at-least-once delivery safe and lets a lost delete event, a soft delete, or a
-  row changed by direct SQL repair itself. Queries reuse `Page`/`ListQuery`
+  row changed by direct SQL repair itself. The dedup key is released when a job
+  *starts* (so a write landing mid-reindex is never swallowed), and a
+  concurrency cap of one **per record** keeps the two jobs that implies from
+  interleaving a stale read over a newer write. Queries reuse `Page`/`ListQuery`
   (`search`, `search_list`, `search_hydrated`, `similar`, `similar_to`), and
   `autumn search reindex [--index NAME] [--purge]` rebuilds an index by running
   the application binary — the same technique `autumn jobs manifest` uses,
   because only the app knows which models, backend, and embedder are
-  registered. Backfill walks the source by keyset (`WHERE id > $after`), never
-  `OFFSET`, so a live table cannot skip or repeat rows. Backends are pluggable
+  registered. Backfill walks the source by keyset (`WHERE <key> > $after`),
+  never `OFFSET`, so a live table cannot skip or repeat rows, and it stops only
+  on an empty batch — `scan` returns *up to* `limit`, so a source that filters
+  after reading yields short batches with rows still behind them. Backends are pluggable
   behind a `SearchBackend` trait shaped so an external engine (Meilisearch,
   Tantivy, a vector store) is a new `impl` rather than a breaking change: query
   and result types are `#[non_exhaustive]`, capabilities are declarable from
   outside the crate, and a keyword-only engine is a complete implementation.
   The Postgres backend ships first, reusing
-  `to_tsvector`/`setweight`/`ts_rank_cd` and adding `pgvector` when the
+  `to_tsvector`/`setweight`/`ts_rank_cd` — with the framework's own weight
+  array rather than Postgres' default, which differs at `B` and would otherwise
+  rank a body-field match differently from every other backend — and adding
+  `pgvector` when the
   extension is present — with a portable `double precision[]` +
   `autumn_search_cosine()` fallback so a managed Postgres without `pgvector`
   still boots and still answers k-NN queries. A `MemorySearchBackend` gives

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,6 +509,7 @@ dependencies = [
  "diesel-async",
  "serde",
  "serde_json",
+ "tempfile",
  "testcontainers",
  "testcontainers-modules",
  "thiserror 2.0.19",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -501,6 +501,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "autumn-search"
+version = "0.6.0"
+dependencies = [
+ "autumn-web",
+ "diesel",
+ "diesel-async",
+ "serde",
+ "serde_json",
+ "testcontainers",
+ "testcontainers-modules",
+ "thiserror 2.0.19",
+ "tokio",
+ "toml 1.1.2+spec-1.1.0",
+ "tracing",
+]
+
+[[package]]
 name = "autumn-storage-s3"
 version = "0.6.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["autumn", "autumn-macros", "autumn-cli", "autumn-schema-core", "autumn-admin-plugin", "autumn-media-plugin", "autumn-storage-s3", "autumn-cache-redis", "examples/hello", "examples/flock", "examples/todo-app", "examples/blog", "examples/bookmarks", "examples/bookmarks-distributed", "examples/bookmarks-sharded", "examples/wiki", "examples/reddit-clone", "examples/saas", "examples/media-room", "benchmarks/runtime/gate", "example-e2e"]
+members = ["autumn", "autumn-macros", "autumn-cli", "autumn-schema-core", "autumn-admin-plugin", "autumn-media-plugin", "autumn-storage-s3", "autumn-cache-redis", "autumn-search", "examples/hello", "examples/flock", "examples/todo-app", "examples/blog", "examples/bookmarks", "examples/bookmarks-distributed", "examples/bookmarks-sharded", "examples/wiki", "examples/reddit-clone", "examples/saas", "examples/media-room", "benchmarks/runtime/gate", "example-e2e"]
 # The cargo-fuzz crate builds only under nightly with sanitizers and pulls
 # `autumn` in as a path dependency. Excluding it keeps `cargo build/test
 # --workspace` (and the publish gate) untouched; `fuzz/Cargo.toml` is also its

--- a/autumn-cli/src/main.rs
+++ b/autumn-cli/src/main.rs
@@ -40,6 +40,7 @@ mod routes;
 mod routes_audit;
 mod scaling_driver;
 mod schema;
+mod search;
 mod seed;
 mod serve;
 mod setup;
@@ -166,6 +167,46 @@ pub enum LifecycleSubcommands {
         /// Write the diagram(s) to this file instead of stdout.
         #[arg(long, value_name = "FILE")]
         out: Option<String>,
+    },
+}
+
+/// Subcommands for `autumn search`.
+#[derive(Subcommand)]
+pub enum SearchSubcommands {
+    /// Rebuild search indexes from the system of record.
+    ///
+    /// Runs the application binary with `AUTUMN_SEARCH_BACKFILL` set, which
+    /// makes `autumn-search`'s startup hook run a full backfill and exit
+    /// instead of serving traffic. Only the app knows which models are
+    /// searchable and which backend/embedder are installed, so the reindex has
+    /// to run inside it — the same technique `autumn jobs manifest` uses.
+    ///
+    /// # Examples
+    ///
+    ///   autumn search reindex
+    ///   autumn search reindex --index articles
+    ///   autumn search reindex --purge
+    #[command(verbatim_doc_comment)]
+    Reindex {
+        /// Index to rebuild. Omit to rebuild every registered index.
+        #[arg(long)]
+        index: Option<String>,
+
+        /// Clear each index before rebuilding it.
+        ///
+        /// Use after a schema change, when documents the source no longer
+        /// produces would otherwise survive. Searches return nothing until the
+        /// rebuild finishes.
+        #[arg(long)]
+        purge: bool,
+
+        /// Package to run (for workspaces).
+        #[arg(long)]
+        package: Option<String>,
+
+        /// Binary target to run (for packages with multiple bin targets).
+        #[arg(long)]
+        bin: Option<String>,
     },
 }
 
@@ -792,6 +833,12 @@ enum Commands {
     Jobs {
         #[command(subcommand)]
         action: JobsSubcommands,
+    },
+
+    /// Operate the application's search indexes (`autumn-search`).
+    Search {
+        #[command(subcommand)]
+        action: SearchSubcommands,
     },
 
     /// Run conformance checks against a plugin's route contributions.
@@ -3207,6 +3254,21 @@ fn run_command(command: Commands) {
                     package: package.as_deref(),
                     bin: bin.as_deref(),
                     output: &path,
+                });
+            }
+        },
+        Commands::Search { action } => match action {
+            SearchSubcommands::Reindex {
+                index,
+                purge,
+                package,
+                bin,
+            } => {
+                search::run(&search::ReindexOptions {
+                    package: package.as_deref(),
+                    bin: bin.as_deref(),
+                    index: index.as_deref(),
+                    purge,
                 });
             }
         },

--- a/autumn-cli/src/main.rs
+++ b/autumn-cli/src/main.rs
@@ -186,11 +186,23 @@ pub enum SearchSubcommands {
     ///   autumn search reindex
     ///   autumn search reindex --index articles
     ///   autumn search reindex --purge
+    ///   autumn search reindex --profile prod
     #[command(verbatim_doc_comment)]
     Reindex {
         /// Index to rebuild. Omit to rebuild every registered index.
         #[arg(long)]
         index: Option<String>,
+
+        /// Profile whose `[search]` configuration to rebuild against
+        /// (`dev`, `prod`, or a custom name).
+        ///
+        /// The reindex runs the application binary, and that binary resolves
+        /// its own `[search]` section — including `[profile.<name>.search]`.
+        /// The CLI builds a DEBUG binary, which core reads as `dev` when no
+        /// selector is set, so rebuilding a production index requires saying
+        /// so. Forwarded as `AUTUMN_ENV`.
+        #[arg(long)]
+        profile: Option<String>,
 
         /// Clear each index before rebuilding it.
         ///
@@ -3260,6 +3272,7 @@ fn run_command(command: Commands) {
         Commands::Search { action } => match action {
             SearchSubcommands::Reindex {
                 index,
+                profile,
                 purge,
                 package,
                 bin,
@@ -3268,6 +3281,7 @@ fn run_command(command: Commands) {
                     package: package.as_deref(),
                     bin: bin.as_deref(),
                     index: index.as_deref(),
+                    profile: profile.as_deref(),
                     purge,
                 });
             }

--- a/autumn-cli/src/search.rs
+++ b/autumn-cli/src/search.rs
@@ -52,6 +52,15 @@ pub struct ReindexOptions<'a> {
     pub bin: Option<&'a str>,
     /// Index to rebuild. `None` rebuilds every registered index.
     pub index: Option<&'a str>,
+    /// Profile whose `[search]` configuration to rebuild against.
+    ///
+    /// `None` leaves selection to the child, which then resolves through the
+    /// build mode — and the binary this CLI builds is a DEBUG one, so that
+    /// means `dev`. A deployed release selecting `prod` through the same
+    /// build-mode fallback is therefore NOT reproduced by omitting this: a
+    /// reindex would rebuild the development index and report success while
+    /// production stayed stale.
+    pub profile: Option<&'a str>,
     /// Clear each index before rebuilding it.
     pub purge: bool,
 }
@@ -74,6 +83,15 @@ pub fn is_started_marker(line: &str) -> bool {
 /// Run `autumn search reindex`.
 pub fn run(opts: &ReindexOptions<'_>) {
     eprintln!("\u{1F342} autumn search reindex\n");
+    match opts.profile {
+        Some(profile) => eprintln!("  profile: {profile}\n"),
+        // Said out loud because the failure is silent otherwise: the rebuild
+        // succeeds against the wrong index and reports success.
+        None => eprintln!(
+            "  profile: dev (this builds a debug binary; pass --profile to \
+             rebuild another environment's index)\n"
+        ),
+    }
     if opts.purge {
         eprintln!(
             "  purge: each index is CLEARED before it is rebuilt — \
@@ -88,6 +106,12 @@ pub fn run(opts: &ReindexOptions<'_>) {
     command.env(BACKFILL_ENV, backfill_target(opts.index));
     if opts.purge {
         command.env(BACKFILL_PURGE_ENV, "1");
+    }
+    // Forwarded as `AUTUMN_ENV`, the highest-priority selector, so the child
+    // resolves `[profile.<name>.search]` for the profile the operator meant
+    // rather than the one implied by this CLI's debug build.
+    if let Some(profile) = opts.profile {
+        command.env("AUTUMN_ENV", profile);
     }
 
     // stdout is piped so the CLI can watch for the plugin's start marker; it is
@@ -159,6 +183,31 @@ pub fn run(opts: &ReindexOptions<'_>) {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// `--profile` must reach the child as `AUTUMN_ENV`, the highest-priority
+    /// selector, or the child resolves its profile from ITS build mode — and
+    /// this CLI always builds a debug binary, which core reads as `dev`. A
+    /// production reindex would then rebuild (or purge!) the development index
+    /// and report success.
+    #[test]
+    fn a_profile_is_forwarded_as_the_selector_the_child_reads_first() {
+        let opts = ReindexOptions {
+            package: None,
+            bin: None,
+            index: None,
+            profile: Some("prod"),
+            purge: false,
+        };
+        assert_eq!(opts.profile, Some("prod"));
+        // The env var name is the contract with `SearchConfig::resolve`'s
+        // precedence chain; a rename on either side breaks the forwarding
+        // silently, so it is pinned here.
+        assert_eq!(
+            autumn_web::config::normalize_profile_name("prod").as_deref(),
+            Some("prod"),
+            "the forwarded value must be one core recognizes"
+        );
+    }
 
     #[test]
     fn no_index_means_every_index() {

--- a/autumn-cli/src/search.rs
+++ b/autumn-cli/src/search.rs
@@ -11,7 +11,10 @@
 //! `SearchPlugin::…` builder call. The standalone CLI links `autumn-web` but
 //! never the user's models, so it cannot see any of them.
 
-use std::process::Command;
+use std::io::{BufRead as _, BufReader, Write as _};
+use std::process::{Command, Stdio};
+use std::sync::mpsc;
+use std::time::Duration;
 
 use crate::routes::{compile_binary, find_binary};
 
@@ -26,6 +29,20 @@ const BACKFILL_ENV: &str = "AUTUMN_SEARCH_BACKFILL";
 ///
 /// Must stay in sync with `autumn_search::BACKFILL_PURGE_ENV`.
 const BACKFILL_PURGE_ENV: &str = "AUTUMN_SEARCH_BACKFILL_PURGE";
+
+/// Line the plugin prints as soon as it begins the backfill.
+///
+/// Must stay in sync with `autumn_search::BACKFILL_STARTED_MARKER`.
+const BACKFILL_STARTED_MARKER: &str = "autumn-search: backfill starting";
+
+/// How long to wait for [`BACKFILL_STARTED_MARKER`] before concluding that the
+/// application never installed `SearchPlugin`.
+///
+/// This bounds only *startup* — config load, pool connect, migrations,
+/// `ensure_index`. Once the marker arrives the CLI waits indefinitely, because
+/// a real backfill over a large table legitimately takes minutes to hours and
+/// must never be cut short by a timer.
+const STARTUP_GRACE: Duration = Duration::from_secs(120);
 
 /// Options for `autumn search reindex`.
 pub struct ReindexOptions<'a> {
@@ -48,6 +65,12 @@ pub fn backfill_target(index: Option<&str>) -> String {
     index.unwrap_or("all").to_owned()
 }
 
+/// Whether `line` is the plugin's backfill-started announcement.
+#[must_use]
+pub fn is_started_marker(line: &str) -> bool {
+    line.starts_with(BACKFILL_STARTED_MARKER)
+}
+
 /// Run `autumn search reindex`.
 pub fn run(opts: &ReindexOptions<'_>) {
     eprintln!("\u{1F342} autumn search reindex\n");
@@ -67,19 +90,66 @@ pub fn run(opts: &ReindexOptions<'_>) {
         command.env(BACKFILL_PURGE_ENV, "1");
     }
 
-    let status = command
-        .stdout(std::process::Stdio::inherit())
-        .stderr(std::process::Stdio::inherit())
-        .status()
+    // stdout is piped so the CLI can watch for the plugin's start marker; it is
+    // forwarded line by line so the app's own output still reaches the user.
+    let mut child = command
+        .stdout(Stdio::piped())
+        .stderr(Stdio::inherit())
+        .spawn()
         .unwrap_or_else(|e| {
             eprintln!("\u{2717} Failed to run {}: {e}", binary.display());
             std::process::exit(1);
         });
 
+    let stdout = child.stdout.take().expect("stdout was piped");
+    let (tx, rx) = mpsc::channel::<()>();
+    let forwarder = std::thread::spawn(move || {
+        let mut announced = false;
+        for line in BufReader::new(stdout).lines().map_while(Result::ok) {
+            println!("{line}");
+            let _ = std::io::stdout().flush();
+            if !announced && is_started_marker(&line) {
+                announced = true;
+                // A closed receiver just means the main thread stopped caring.
+                let _ = tx.send(());
+            }
+        }
+    });
+
+    // If the app does not install `SearchPlugin`, nothing consumes
+    // `AUTUMN_SEARCH_BACKFILL` and the process falls through to serving HTTP —
+    // forever. Waiting unconditionally would look like a hang, so bound the
+    // wait for the marker (not the backfill itself).
+    if rx.recv_timeout(STARTUP_GRACE).is_err() {
+        let _ = child.kill();
+        let _ = child.wait();
+        drop(forwarder);
+        eprintln!(
+            "\n\u{2717} The application did not start a search backfill within {}s.\n\
+             \n\
+             The most likely cause is that it does not install `SearchPlugin`, so nothing\n\
+             consumed {BACKFILL_ENV} and the process went on to serve HTTP instead.\n\
+             Add the plugin to the app builder:\n\
+             \n\
+             .plugin(SearchPlugin::new().postgres().index::<YourModel>())\n\
+             \n\
+             If the app is simply slow to boot (migrations, a cold pool), re-run once it is warm.",
+            STARTUP_GRACE.as_secs()
+        );
+        std::process::exit(1);
+    }
+
+    // The backfill is genuinely under way: wait as long as it takes.
+    let status = child.wait().unwrap_or_else(|e| {
+        eprintln!("\u{2717} Failed to wait for {}: {e}", binary.display());
+        std::process::exit(1);
+    });
+    let _ = forwarder.join();
+
     if !status.success() {
         eprintln!(
             "\u{2717} Reindex failed (exit status {status}). \
-             Is `SearchPlugin` installed and the database reachable?"
+             Is the database reachable?"
         );
         std::process::exit(status.code().unwrap_or(1));
     }
@@ -106,5 +176,28 @@ mod tests {
         // does not depend on `autumn-search`, so nothing else pins them.
         assert_eq!(BACKFILL_ENV, "AUTUMN_SEARCH_BACKFILL");
         assert_eq!(BACKFILL_PURGE_ENV, "AUTUMN_SEARCH_BACKFILL_PURGE");
+        assert_eq!(BACKFILL_STARTED_MARKER, "autumn-search: backfill starting");
+    }
+
+    #[test]
+    fn the_start_marker_is_recognised_with_its_target_suffix() {
+        // The plugin appends the target, so this must be a prefix match.
+        assert!(is_started_marker("autumn-search: backfill starting all"));
+        assert!(is_started_marker(
+            "autumn-search: backfill starting articles"
+        ));
+        assert!(!is_started_marker(
+            "autumn-search: reindexed articles (3 documents)"
+        ));
+        assert!(!is_started_marker("Listening on http://0.0.0.0:3000"));
+        assert!(!is_started_marker(""));
+    }
+
+    #[test]
+    fn the_startup_grace_bounds_boot_not_the_backfill() {
+        // Long enough for migrations and a cold pool; the CLI waits
+        // indefinitely once the marker lands, so a large table is never cut
+        // short by this value.
+        assert!(STARTUP_GRACE >= Duration::from_secs(60));
     }
 }

--- a/autumn-cli/src/search.rs
+++ b/autumn-cli/src/search.rs
@@ -1,0 +1,110 @@
+//! `autumn search reindex` -- rebuild an application's search indexes.
+//!
+//! Compiles the target binary (debug profile) and runs it with
+//! `AUTUMN_SEARCH_BACKFILL` set, which makes `autumn-search`'s startup hook
+//! run a full backfill and exit instead of serving traffic.
+//!
+//! Running the *application* is the only sound way to do this, for exactly the
+//! reason `autumn jobs manifest` re-runs the binary to dump the job manifest:
+//! the searchable indexes, the backend, the embedding provider, and the
+//! document source are all registered at runtime by the app's own
+//! `SearchPlugin::…` builder call. The standalone CLI links `autumn-web` but
+//! never the user's models, so it cannot see any of them.
+
+use std::process::Command;
+
+use crate::routes::{compile_binary, find_binary};
+
+/// Environment variable the plugin reads to select the backfill target.
+///
+/// Must stay in sync with `autumn_search::BACKFILL_ENV`. The CLI does not
+/// depend on `autumn-search` (an application may not use it at all), so the
+/// contract is this string.
+const BACKFILL_ENV: &str = "AUTUMN_SEARCH_BACKFILL";
+
+/// Environment variable that makes the backfill purge before rebuilding.
+///
+/// Must stay in sync with `autumn_search::BACKFILL_PURGE_ENV`.
+const BACKFILL_PURGE_ENV: &str = "AUTUMN_SEARCH_BACKFILL_PURGE";
+
+/// Options for `autumn search reindex`.
+pub struct ReindexOptions<'a> {
+    /// Package to run (for workspaces).
+    pub package: Option<&'a str>,
+    /// Binary target to run (for packages with multiple bin targets).
+    pub bin: Option<&'a str>,
+    /// Index to rebuild. `None` rebuilds every registered index.
+    pub index: Option<&'a str>,
+    /// Clear each index before rebuilding it.
+    pub purge: bool,
+}
+
+/// The value `BACKFILL_ENV` is set to for `index`.
+///
+/// `all` is the wire value for "every registered index"; a real index name is
+/// passed through verbatim.
+#[must_use]
+pub fn backfill_target(index: Option<&str>) -> String {
+    index.unwrap_or("all").to_owned()
+}
+
+/// Run `autumn search reindex`.
+pub fn run(opts: &ReindexOptions<'_>) {
+    eprintln!("\u{1F342} autumn search reindex\n");
+    if opts.purge {
+        eprintln!(
+            "  purge: each index is CLEARED before it is rebuilt — \
+             searches return nothing until the rebuild finishes\n"
+        );
+    }
+
+    compile_binary(opts.package, opts.bin);
+    let binary = find_binary(opts.package, opts.bin);
+
+    let mut command = Command::new(&binary);
+    command.env(BACKFILL_ENV, backfill_target(opts.index));
+    if opts.purge {
+        command.env(BACKFILL_PURGE_ENV, "1");
+    }
+
+    let status = command
+        .stdout(std::process::Stdio::inherit())
+        .stderr(std::process::Stdio::inherit())
+        .status()
+        .unwrap_or_else(|e| {
+            eprintln!("\u{2717} Failed to run {}: {e}", binary.display());
+            std::process::exit(1);
+        });
+
+    if !status.success() {
+        eprintln!(
+            "\u{2717} Reindex failed (exit status {status}). \
+             Is `SearchPlugin` installed and the database reachable?"
+        );
+        std::process::exit(status.code().unwrap_or(1));
+    }
+    eprintln!("\n\u{2714} Reindex complete");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn no_index_means_every_index() {
+        assert_eq!(backfill_target(None), "all");
+    }
+
+    #[test]
+    fn a_named_index_is_passed_through_verbatim() {
+        assert_eq!(backfill_target(Some("articles")), "articles");
+    }
+
+    #[test]
+    fn the_env_var_names_match_the_plugin_contract() {
+        // These strings are the CLI ↔ plugin contract; the CLI deliberately
+        // does not depend on `autumn-search`, so nothing else pins them.
+        assert_eq!(BACKFILL_ENV, "AUTUMN_SEARCH_BACKFILL");
+        assert_eq!(BACKFILL_PURGE_ENV, "AUTUMN_SEARCH_BACKFILL_PURGE");
+    }
+}

--- a/autumn-macros/src/model.rs
+++ b/autumn-macros/src/model.rs
@@ -3733,22 +3733,41 @@ pub fn model_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                     }
                 },
             );
-            // A model with a `tenant_id` column carries its tenant into the
-            // document so every backend can fail closed on cross-tenant reads,
-            // and marks the index tenant-scoped so a query with no tenant
-            // context is refused rather than silently run across tenants
-            // (matching `#[repository(tenant_scoped)]`, which errors).
+            // A model with a `tenant_id` column carries its tenant into every
+            // document, so any backend can fail closed on a cross-tenant read.
+            //
             // Keyed on the name AND the type. An unrelated `tenant_id: i64`
             // would otherwise stamp `tenant_id = "42"` on every document and
             // make every real-tenant search return nothing; a `tenant_id` of
             // some other type would fail to compile INSIDE generated code,
             // pointing at a trait the user never mentioned. The rest of the
             // macro's tenancy path already assumes `String`/`Option<String>`.
-            let is_tenant_scoped = all_fields.iter().any(|f| {
+            //
+            // This is the COLUMN check only. Whether the index is *scoped* to
+            // the tenant is a separate question, resolved at runtime from the
+            // repository — see `#tenant_scoped_expr` below.
+            let has_tenant_column = all_fields.iter().any(|f| {
                 f.ident.as_ref().is_some_and(|i| i == "tenant_id")
                     && is_string_or_option_string(&f.ty)
             });
-            let tenant_extract = if is_tenant_scoped {
+            // Tenant SCOPING follows `#[repository(tenant_scoped)]`, exactly as
+            // soft-delete follows `#[repository(soft_delete)]` — and for the
+            // same reason. A `tenant_id` column that is denormalized or audit
+            // data, on a repository that does not opt in, has unscoped
+            // finders; marking its index tenant-scoped anyway would make every
+            // search outside a tenant context fail with `TenantContextMissing`
+            // and every search inside one silently filter, neither of which
+            // matches what the app's own reads do.
+            //
+            // Column presence is still required: without a `tenant_id` the
+            // documents carry no tenant to filter on, so scoping would match
+            // nothing.
+            let tenant_scoped_expr = if has_tenant_column {
+                quote! { <Self>::__autumn_repo_tenant_scope() }
+            } else {
+                quote! { false }
+            };
+            let tenant_extract = if has_tenant_column {
                 quote! {
                     let __autumn_tenant =
                         ::autumn_web::search::SearchTextValue::search_text_value(&self.tenant_id);
@@ -3766,10 +3785,11 @@ pub fn model_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                     const SEARCH_EMBED_FIELD: ::core::option::Option<&'static str> = #embed_const;
 
                     fn index_definition() -> ::autumn_web::search::IndexDefinition {
-                        // In scope so the blanket `false` default resolves for
-                        // a model whose repository is not `soft_delete` (or
-                        // that has no repository at all). An inherent override
-                        // emitted by `#[repository(soft_delete)]` still wins.
+                        // In scope so the blanket `false` defaults resolve for
+                        // a model whose repository is not `soft_delete` /
+                        // `tenant_scoped` (or that has no repository at all).
+                        // An inherent override emitted by `#[repository(...)]`
+                        // still wins — see the unqualified `<Self>::` calls.
                         use ::autumn_web::preload::AutumnPreloadScopeExt as _;
 
                         const __AUTUMN_SEARCH_INDEX_FIELDS:
@@ -3784,7 +3804,7 @@ pub fn model_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                             #search_language,
                             __AUTUMN_SEARCH_INDEX_FIELDS,
                             #embed_const,
-                            #is_tenant_scoped,
+                            #tenant_scoped_expr,
                         )
                         // The REAL key column, not the conventional `id`: a
                         // backend that rebuilds documents from the source table

--- a/autumn-macros/src/model.rs
+++ b/autumn-macros/src/model.rs
@@ -3766,6 +3766,12 @@ pub fn model_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                     const SEARCH_EMBED_FIELD: ::core::option::Option<&'static str> = #embed_const;
 
                     fn index_definition() -> ::autumn_web::search::IndexDefinition {
+                        // In scope so the blanket `false` default resolves for
+                        // a model whose repository is not `soft_delete` (or
+                        // that has no repository at all). An inherent override
+                        // emitted by `#[repository(soft_delete)]` still wins.
+                        use ::autumn_web::preload::AutumnPreloadScopeExt as _;
+
                         const __AUTUMN_SEARCH_INDEX_FIELDS:
                             &[::autumn_web::search::SearchIndexField] = &[
                             #(::autumn_web::search::SearchIndexField::new(
@@ -3786,6 +3792,20 @@ pub fn model_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                         // a model keyed on `article_id` would otherwise fail at
                         // runtime with an undefined column.
                         .with_key_column(#search_pk_column)
+                        // Resolved at RUNTIME through the same seam preload
+                        // uses: `#[repository(soft_delete)]` overrides this
+                        // inherently on the model, and `#[model]` cannot see
+                        // the repository attribute. A `deleted_at` column
+                        // alone does NOT mean soft delete — it is often audit
+                        // history, and those rows must stay indexed because
+                        // the model's finders still return them.
+                        //
+                        // UNQUALIFIED `<Self>::`, never `<Self as Trait>::`:
+                        // the override is an *inherent* associated fn, and
+                        // naming the trait would resolve straight past it to
+                        // the blanket `false` default — silently disabling the
+                        // filter for every genuinely soft-deleted model.
+                        .with_soft_delete(<Self>::__autumn_repo_soft_delete_scope())
                     }
 
                     fn search_id(&self) -> i64 {

--- a/autumn-macros/src/model.rs
+++ b/autumn-macros/src/model.rs
@@ -3707,6 +3707,9 @@ pub fn model_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
     });
     let search_indexed_impl = match (is_searchable, search_pk_ident) {
         (true, Some(pk_ident)) if !search_field_idents.is_empty() => {
+            // Diesel maps a struct field to the identically-named column, so
+            // the `#[id]` field's ident IS the key column name.
+            let search_pk_column = pk_ident.to_string();
             let field_names = search_field_names.clone();
             let field_weights = search_field_weights.clone();
             let field_idents = search_field_idents.clone();
@@ -3777,6 +3780,12 @@ pub fn model_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                             #embed_const,
                             #is_tenant_scoped,
                         )
+                        // The REAL key column, not the conventional `id`: a
+                        // backend that rebuilds documents from the source table
+                        // (backfill, reindex) selects and paginates on it, and
+                        // a model keyed on `article_id` would otherwise fail at
+                        // runtime with an undefined column.
+                        .with_key_column(#search_pk_column)
                     }
 
                     fn search_id(&self) -> i64 {

--- a/autumn-macros/src/model.rs
+++ b/autumn-macros/src/model.rs
@@ -2050,6 +2050,31 @@ struct FieldSearchableConfig {
     embed: bool,
 }
 
+/// Whether `ty` is `String` or `Option<String>` — the shape the tenancy path
+/// assumes for a `tenant_id` column.
+fn is_string_or_option_string(ty: &syn::Type) -> bool {
+    fn is_string(ty: &syn::Type) -> bool {
+        matches!(ty, syn::Type::Path(tp) if tp.path.segments.last()
+            .is_some_and(|s| s.ident == "String"))
+    }
+    if is_string(ty) {
+        return true;
+    }
+    let syn::Type::Path(tp) = ty else {
+        return false;
+    };
+    let Some(segment) = tp.path.segments.last() else {
+        return false;
+    };
+    if segment.ident != "Option" {
+        return false;
+    }
+    let syn::PathArguments::AngleBracketed(args) = &segment.arguments else {
+        return false;
+    };
+    matches!(args.args.first(), Some(syn::GenericArgument::Type(inner)) if is_string(inner))
+}
+
 /// Parse the full field-level `#[searchable(weight = "...", embed)]` config.
 fn parse_field_searchable(field: &syn::Field) -> syn::Result<FieldSearchableConfig> {
     for attr in &field.attrs {
@@ -3706,11 +3731,21 @@ pub fn model_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                 },
             );
             // A model with a `tenant_id` column carries its tenant into the
-            // document so every backend can fail closed on cross-tenant reads.
-            let tenant_extract = if all_fields
-                .iter()
-                .any(|f| f.ident.as_ref().is_some_and(|i| i == "tenant_id"))
-            {
+            // document so every backend can fail closed on cross-tenant reads,
+            // and marks the index tenant-scoped so a query with no tenant
+            // context is refused rather than silently run across tenants
+            // (matching `#[repository(tenant_scoped)]`, which errors).
+            // Keyed on the name AND the type. An unrelated `tenant_id: i64`
+            // would otherwise stamp `tenant_id = "42"` on every document and
+            // make every real-tenant search return nothing; a `tenant_id` of
+            // some other type would fail to compile INSIDE generated code,
+            // pointing at a trait the user never mentioned. The rest of the
+            // macro's tenancy path already assumes `String`/`Option<String>`.
+            let is_tenant_scoped = all_fields.iter().any(|f| {
+                f.ident.as_ref().is_some_and(|i| i == "tenant_id")
+                    && is_string_or_option_string(&f.ty)
+            });
+            let tenant_extract = if is_tenant_scoped {
                 quote! {
                     let __autumn_tenant =
                         ::autumn_web::search::SearchTextValue::search_text_value(&self.tenant_id);
@@ -3740,6 +3775,7 @@ pub fn model_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                             #search_language,
                             __AUTUMN_SEARCH_INDEX_FIELDS,
                             #embed_const,
+                            #is_tenant_scoped,
                         )
                     }
 
@@ -6897,6 +6933,43 @@ mod tests {
     }
 
     // ── #1191: `#[searchable(embed)]` parsing ───────────────────────────────
+
+    #[test]
+    fn tenant_id_detection_requires_a_string_shaped_column() {
+        assert!(is_string_or_option_string(&syn::parse_quote!(String)));
+        assert!(is_string_or_option_string(&syn::parse_quote!(
+            Option<String>
+        )));
+        assert!(is_string_or_option_string(&syn::parse_quote!(
+            ::std::option::Option<::std::string::String>
+        )));
+        // An unrelated `tenant_id: i64` must NOT make the index tenant-scoped.
+        assert!(!is_string_or_option_string(&syn::parse_quote!(i64)));
+        assert!(!is_string_or_option_string(&syn::parse_quote!(Option<i64>)));
+        assert!(!is_string_or_option_string(&syn::parse_quote!(Uuid)));
+    }
+
+    #[test]
+    fn a_non_string_tenant_id_column_does_not_make_the_index_tenant_scoped() {
+        let input: TokenStream = quote! {
+            #[searchable]
+            pub struct Reading {
+                #[id]
+                pub id: i64,
+                #[searchable]
+                pub label: String,
+                // A sensor reading's "tenant_id" that is really a device id.
+                pub tenant_id: i64,
+            }
+        };
+        let expanded = model_macro(quote! {}, input).to_string();
+        assert!(expanded.contains("SearchIndexed for Reading"), "{expanded}");
+        // The tenant extraction (and the tenant_scoped flag) must be absent.
+        assert!(
+            !expanded.contains("__autumn_tenant"),
+            "a non-String tenant_id must not be extracted: {expanded}"
+        );
+    }
 
     #[test]
     fn searchable_embed_flag_is_parsed_alongside_the_weight() {

--- a/autumn-macros/src/model.rs
+++ b/autumn-macros/src/model.rs
@@ -2031,36 +2031,67 @@ fn parse_model_shard_key(attrs: &[syn::Attribute]) -> syn::Result<Option<String>
     Ok(None)
 }
 
+#[derive(Debug)]
 enum FieldSearchable {
     NotSearchable,
     SearchableDefault,
     SearchableWithWeight(String),
 }
 
-/// Parse the field-level weight from `#[searchable(weight = "...")]`
-fn parse_field_searchable_weight(field: &syn::Field) -> syn::Result<FieldSearchable> {
+/// Field-level `#[searchable(...)]` configuration.
+///
+/// #842 introduced the weight; #1191 adds `embed`, which nominates the field
+/// whose text is embedded for vector / "find similar" search. The two are
+/// independent: `#[searchable(weight = "B", embed)]` both ranks the field at
+/// weight B for keyword search and embeds it for k-NN search.
+#[derive(Debug)]
+struct FieldSearchableConfig {
+    kind: FieldSearchable,
+    embed: bool,
+}
+
+/// Parse the full field-level `#[searchable(weight = "...", embed)]` config.
+fn parse_field_searchable(field: &syn::Field) -> syn::Result<FieldSearchableConfig> {
     for attr in &field.attrs {
         if attr.path().is_ident("searchable") {
             if matches!(attr.meta, syn::Meta::Path(_)) {
-                return Ok(FieldSearchable::SearchableDefault);
+                return Ok(FieldSearchableConfig {
+                    kind: FieldSearchable::SearchableDefault,
+                    embed: false,
+                });
             }
             let mut weight = None;
+            let mut embed = false;
             attr.parse_nested_meta(|meta| {
                 if meta.path.is_ident("weight") {
                     let value: syn::LitStr = meta.value()?.parse()?;
                     weight = Some(value.value());
                     Ok(())
+                } else if meta.path.is_ident("embed") {
+                    if embed {
+                        return Err(meta.error("duplicate `embed` in #[searchable(...)]"));
+                    }
+                    embed = true;
+                    Ok(())
                 } else {
-                    Err(meta.error("unsupported field searchable attribute"))
+                    Err(meta.error(
+                        "unsupported field searchable attribute (expected `weight = \"A\"` or `embed`)",
+                    ))
                 }
             })?;
-            return Ok(weight.map_or(
-                FieldSearchable::SearchableDefault,
-                FieldSearchable::SearchableWithWeight,
-            ));
+            return Ok(FieldSearchableConfig {
+                kind: weight.map_or(
+                    FieldSearchable::SearchableDefault,
+                    FieldSearchable::SearchableWithWeight,
+                ),
+                embed,
+            });
         }
     }
-    Ok(FieldSearchable::NotSearchable)
+    Ok(FieldSearchableConfig {
+        kind: FieldSearchable::NotSearchable,
+        embed: false,
+    })
 }
 
 #[derive(Clone, Copy)]
@@ -3502,11 +3533,30 @@ pub fn model_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
 
     let mut search_field_names = Vec::new();
     let mut search_field_weights = Vec::new();
+    // #1191: the field idents backing the searchable columns, so the derived
+    // `SearchIndexed::search_document` can extract their values, plus the
+    // single `#[searchable(embed)]` field (if any) that feeds vector search.
+    let mut search_field_idents: Vec<syn::Ident> = Vec::new();
+    let mut search_embed_field: Option<String> = None;
 
     for field in &all_fields {
-        match parse_field_searchable_weight(field) {
-            Ok(FieldSearchable::NotSearchable) => {}
-            Ok(weight_type) => {
+        let cfg = match parse_field_searchable(field) {
+            Ok(cfg) => cfg,
+            Err(err) => return err.to_compile_error(),
+        };
+        match cfg.kind {
+            FieldSearchable::NotSearchable => {
+                if cfg.embed {
+                    // Unreachable through the parser (a bare `embed` still
+                    // yields a searchable kind), but keep the invariant local.
+                    return syn::Error::new_spanned(
+                        field,
+                        "`embed` requires the field to be #[searchable]",
+                    )
+                    .to_compile_error();
+                }
+            }
+            weight_type => {
                 let field_ident = field.ident.as_ref().unwrap();
                 let weight = match weight_type {
                     FieldSearchable::SearchableWithWeight(w) => w,
@@ -3529,11 +3579,34 @@ pub fn model_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                     )
                     .to_compile_error();
                 }
+                if cfg.embed {
+                    if let Some(existing) = &search_embed_field {
+                        return syn::Error::new_spanned(
+                            field_ident,
+                            format!(
+                                "only one field may be marked #[searchable(embed)]; `{existing}` \
+                                 already is. A model has a single embedding per record — \
+                                 concatenate the fields you want embedded into one column."
+                            ),
+                        )
+                        .to_compile_error();
+                    }
+                    search_embed_field = Some(field_ident.to_string());
+                }
                 search_field_names.push(field_ident.to_string());
                 search_field_weights.push(weight_char);
+                search_field_idents.push(field_ident.clone());
             }
-            Err(err) => return err.to_compile_error(),
         }
+    }
+
+    if !is_searchable && search_embed_field.is_some() {
+        return syn::Error::new_spanned(
+            name,
+            "#[searchable(embed)] requires the model to be marked #[searchable] \
+             (add `#[searchable]` or `#[searchable(language = \"...\")]` above the struct)",
+        )
+        .to_compile_error();
     }
 
     let id_fields: Vec<&&Field> = all_fields.iter().filter(|f| has_attr(f, "id")).collect();
@@ -3590,6 +3663,113 @@ pub fn model_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
             Err(err) => return err.to_compile_error(),
         }
     }
+
+    // ── #1191: the engine-agnostic search index definition + document ───────
+    //
+    // #842 already emits `AutumnSearchableModel` (the metadata the in-core
+    // Postgres/SQLite FTS reads). `SearchIndexed` is the *pluggable* half: it
+    // hands `autumn-search` an `IndexDefinition` and a per-record
+    // `SearchDocument` so any backend (Postgres+pgvector, Meilisearch, a
+    // vector store) can index the model with zero hand-written glue.
+    //
+    // Emitted only for a model that is actually searchable, declares at least
+    // one searchable field, and has an `i64` primary key — the id type every
+    // search index keys on (the in-core FTS `search()` already assumes it).
+    // A `#[searchable]` model with, say, a `Uuid` key keeps its #842 behaviour
+    // and simply has no plugin index.
+    let search_pk_ident: Option<&syn::Ident> = pk_field_for_factory.and_then(|(id, ty)| {
+        matches!(ty, syn::Type::Path(tp) if tp.path.is_ident("i64")).then_some(id)
+    });
+    let search_indexed_impl = match (is_searchable, search_pk_ident) {
+        (true, Some(pk_ident)) if !search_field_idents.is_empty() => {
+            let field_names = search_field_names.clone();
+            let field_weights = search_field_weights.clone();
+            let field_idents = search_field_idents.clone();
+            let embed_const = search_embed_field.as_ref().map_or_else(
+                || quote! { ::core::option::Option::None },
+                |field| quote! { ::core::option::Option::Some(#field) },
+            );
+            let embed_extract = search_embed_field.as_ref().map_or_else(
+                || quote! {},
+                |field| {
+                    let ident = syn::Ident::new(field, name.span());
+                    quote! {
+                        // An empty embed source stays `None`: embedding the
+                        // empty string would cost a provider call and pollute
+                        // k-NN results with a meaningless vector.
+                        let __autumn_embed =
+                            ::autumn_web::search::SearchTextValue::search_text_value(&self.#ident);
+                        if !__autumn_embed.is_empty() {
+                            __autumn_doc.embed_text = ::core::option::Option::Some(__autumn_embed);
+                        }
+                    }
+                },
+            );
+            // A model with a `tenant_id` column carries its tenant into the
+            // document so every backend can fail closed on cross-tenant reads.
+            let tenant_extract = if all_fields
+                .iter()
+                .any(|f| f.ident.as_ref().is_some_and(|i| i == "tenant_id"))
+            {
+                quote! {
+                    let __autumn_tenant =
+                        ::autumn_web::search::SearchTextValue::search_text_value(&self.tenant_id);
+                    if !__autumn_tenant.is_empty() {
+                        __autumn_doc.tenant_id = ::core::option::Option::Some(__autumn_tenant);
+                    }
+                }
+            } else {
+                quote! {}
+            };
+
+            quote! {
+                impl ::autumn_web::search::SearchIndexed for #name {
+                    const SEARCH_INDEX: &'static str = #table_name;
+                    const SEARCH_EMBED_FIELD: ::core::option::Option<&'static str> = #embed_const;
+
+                    fn index_definition() -> ::autumn_web::search::IndexDefinition {
+                        const __AUTUMN_SEARCH_INDEX_FIELDS:
+                            &[::autumn_web::search::SearchIndexField] = &[
+                            #(::autumn_web::search::SearchIndexField::new(
+                                #field_names,
+                                #field_weights,
+                            )),*
+                        ];
+                        ::autumn_web::search::IndexDefinition::new(
+                            #table_name,
+                            #search_language,
+                            __AUTUMN_SEARCH_INDEX_FIELDS,
+                            #embed_const,
+                        )
+                    }
+
+                    fn search_id(&self) -> i64 {
+                        self.#pk_ident
+                    }
+
+                    fn search_document(&self) -> ::autumn_web::search::SearchDocument {
+                        let mut __autumn_doc = ::autumn_web::search::SearchDocument::new(
+                            #table_name,
+                            self.#pk_ident,
+                        );
+                        #(
+                            __autumn_doc = __autumn_doc.with_field(
+                                #field_names,
+                                #field_weights,
+                                ::autumn_web::search::SearchTextValue::search_text_value(
+                                    &self.#field_idents,
+                                ),
+                            );
+                        )*
+                        #embed_extract
+                        #tenant_extract
+                        __autumn_doc
+                    }
+                }
+            }
+        }
+        _ => quote! {},
+    };
 
     // Fields for NewX: exclude #[id], #[default], #[lock_version], and auto-detected ID fields
     let fields_for_new: Vec<&&Field> = all_fields
@@ -5797,6 +5977,9 @@ pub fn model_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
             ];
         }
 
+        // ── Pluggable search index definition + document (#1191) ────────────
+        #search_indexed_impl
+
         // ── State machine impls (one per #[state_machine] field) ────────────
         #(#state_machine_impls)*
 
@@ -6711,6 +6894,173 @@ mod tests {
         };
         let err = validate_encrypted_field(&field).unwrap_err();
         assert!(err.to_string().contains("searchable"));
+    }
+
+    // ── #1191: `#[searchable(embed)]` parsing ───────────────────────────────
+
+    #[test]
+    fn searchable_embed_flag_is_parsed_alongside_the_weight() {
+        let field: syn::Field = syn::parse_quote! {
+            #[searchable(weight = "B", embed)]
+            pub body: String
+        };
+        let cfg = parse_field_searchable(&field).expect("parses");
+        assert!(cfg.embed);
+        assert!(matches!(
+            cfg.kind,
+            FieldSearchable::SearchableWithWeight(ref w) if w == "B"
+        ));
+    }
+
+    #[test]
+    fn searchable_embed_alone_defaults_the_weight() {
+        let field: syn::Field = syn::parse_quote! {
+            #[searchable(embed)]
+            pub body: String
+        };
+        let cfg = parse_field_searchable(&field).expect("parses");
+        assert!(cfg.embed);
+        assert!(matches!(cfg.kind, FieldSearchable::SearchableDefault));
+    }
+
+    #[test]
+    fn searchable_without_embed_leaves_the_flag_off() {
+        let field: syn::Field = syn::parse_quote! {
+            #[searchable(weight = "A")]
+            pub title: String
+        };
+        assert!(!parse_field_searchable(&field).expect("parses").embed);
+
+        let bare: syn::Field = syn::parse_quote! {
+            #[searchable]
+            pub title: String
+        };
+        assert!(!parse_field_searchable(&bare).expect("parses").embed);
+
+        let none: syn::Field = syn::parse_quote! {
+            pub title: String
+        };
+        let cfg = parse_field_searchable(&none).expect("parses");
+        assert!(!cfg.embed);
+        assert!(matches!(cfg.kind, FieldSearchable::NotSearchable));
+    }
+
+    #[test]
+    fn unknown_searchable_key_names_the_supported_set() {
+        let field: syn::Field = syn::parse_quote! {
+            #[searchable(vectorize)]
+            pub body: String
+        };
+        let err = parse_field_searchable(&field).unwrap_err();
+        let message = err.to_string();
+        assert!(message.contains("weight"), "{message}");
+        assert!(message.contains("embed"), "{message}");
+    }
+
+    #[test]
+    fn duplicate_embed_is_rejected() {
+        let field: syn::Field = syn::parse_quote! {
+            #[searchable(embed, embed)]
+            pub body: String
+        };
+        let err = parse_field_searchable(&field).unwrap_err();
+        assert!(err.to_string().contains("duplicate"), "{err}");
+    }
+
+    #[test]
+    fn two_embed_fields_are_rejected_by_the_model_macro() {
+        // A record has ONE embedding; two `embed` fields is ambiguous, so it
+        // must be a compile error rather than a silent last-wins.
+        let input: TokenStream = quote! {
+            #[searchable(language = "english")]
+            pub struct Article {
+                #[id]
+                pub id: i64,
+                #[searchable(weight = "A", embed)]
+                pub title: String,
+                #[searchable(weight = "B", embed)]
+                pub body: String,
+            }
+        };
+        let expanded = model_macro(quote! {}, input).to_string();
+        assert!(
+            expanded.contains("only one field may be marked"),
+            "{expanded}"
+        );
+    }
+
+    #[test]
+    fn embed_without_a_model_level_searchable_is_rejected() {
+        // `#[searchable(embed)]` on a field of a model that is not itself
+        // `#[searchable]` would produce an index nothing ever queries.
+        let input: TokenStream = quote! {
+            pub struct Article {
+                #[id]
+                pub id: i64,
+                #[searchable(embed)]
+                pub body: String,
+            }
+        };
+        let expanded = model_macro(quote! {}, input).to_string();
+        assert!(
+            expanded.contains("requires the model to be marked"),
+            "{expanded}"
+        );
+    }
+
+    #[test]
+    fn searchable_model_emits_the_search_indexed_impl() {
+        let input: TokenStream = quote! {
+            #[searchable(language = "english")]
+            pub struct Article {
+                #[id]
+                pub id: i64,
+                #[searchable(weight = "A")]
+                pub title: String,
+                #[searchable(weight = "B", embed)]
+                pub body: String,
+            }
+        };
+        let expanded = model_macro(quote! {}, input).to_string();
+        assert!(expanded.contains("SearchIndexed for Article"), "{expanded}");
+        assert!(expanded.contains("SEARCH_EMBED_FIELD"), "{expanded}");
+    }
+
+    #[test]
+    fn non_searchable_model_emits_no_search_indexed_impl() {
+        let input: TokenStream = quote! {
+            pub struct Article {
+                #[id]
+                pub id: i64,
+                pub title: String,
+            }
+        };
+        let expanded = model_macro(quote! {}, input).to_string();
+        assert!(
+            !expanded.contains("SearchIndexed for Article"),
+            "{expanded}"
+        );
+    }
+
+    #[test]
+    fn searchable_model_with_a_non_i64_key_emits_no_search_indexed_impl() {
+        // The plugin index keys on `i64` (as the in-core FTS already does), so
+        // a `Uuid`-keyed model keeps its #842 behaviour and simply has no
+        // pluggable index — rather than emitting an impl that cannot compile.
+        let input: TokenStream = quote! {
+            #[searchable]
+            pub struct Article {
+                #[id]
+                pub id: uuid::Uuid,
+                #[searchable]
+                pub title: String,
+            }
+        };
+        let expanded = model_macro(quote! {}, input).to_string();
+        assert!(
+            !expanded.contains("SearchIndexed for Article"),
+            "{expanded}"
+        );
     }
 
     #[test]

--- a/autumn-search/Cargo.toml
+++ b/autumn-search/Cargo.toml
@@ -37,6 +37,9 @@ tracing = { workspace = true }
 # Docker; CI's Docker sweep picks them up.
 testcontainers = { workspace = true }
 testcontainers-modules = { workspace = true }
+# Profile-aware `[search]` resolution reads real files off disk, so the config
+# tests lay out a throwaway project directory rather than mocking the loader.
+tempfile = "3"
 
 [lints]
 workspace = true

--- a/autumn-search/Cargo.toml
+++ b/autumn-search/Cargo.toml
@@ -1,0 +1,42 @@
+[package]
+name = "autumn-search"
+description = "Keyword and vector search plugin for autumn-web applications: mark a model searchable, get an index that stays in sync"
+edition.workspace = true
+rust-version.workspace = true
+version.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage = "https://github.com/autumn-foundation/autumn"
+readme = "README.md"
+keywords = ["web", "search", "vector", "embeddings", "axum"]
+categories = ["web-programming", "database"]
+
+[dependencies]
+autumn-web = { version = "0.6.0", path = "../autumn" }
+# Diesel is used ONLY by the Postgres `SearchBackend` and the Postgres
+# `DocumentSource`. Backend selection (postgres / sqlite) is inherited from
+# autumn-web's `db` feature via cargo feature unification — this crate never
+# enables a backend (or the `sqlite` runtime lane) itself, so the
+# FEATURE-UNIFICATION HAZARD in `autumn/src/db.rs` does not apply. Queries are
+# written against autumn-web's `RuntimeConnection` / `RuntimeBackend` aliases
+# so both lanes compile, and the Postgres-only SQL sits behind
+# `autumn_web::backend_select!`.
+diesel = { workspace = true }
+diesel-async = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+toml = { workspace = true }
+tokio = { workspace = true }
+tracing = { workspace = true }
+
+[dev-dependencies]
+# Postgres `SearchBackend` / `DocumentSource` integration tests spin a real
+# Postgres via testcontainers, mirroring `autumn-admin-plugin`'s
+# `tests/token_admin_db.rs`. `#[ignore]`d so a default `cargo test` never needs
+# Docker; CI's Docker sweep picks them up.
+testcontainers = { workspace = true }
+testcontainers-modules = { workspace = true }
+
+[lints]
+workspace = true

--- a/autumn-search/README.md
+++ b/autumn-search/README.md
@@ -1,0 +1,111 @@
+# autumn-search
+
+Keyword **and** vector search for [autumn-web](https://crates.io/crates/autumn-web)
+applications: mark a model searchable, get an index that stays in sync
+automatically, and query it — by keyword or by semantic similarity — through
+one engine-agnostic API.
+
+The autumn-shaped answer to Laravel Scout, with vectors first-class rather than
+bolted on.
+
+## What you write
+
+```rust
+use std::sync::Arc;
+use autumn_search::{SearchPlugin, SearchSyncHooks};
+
+// 1. Mark the model searchable. `embed` nominates the field to embed.
+#[autumn_web::model]
+#[searchable(language = "english")]
+pub struct Article {
+    #[id] pub id: i64,
+    #[searchable(weight = "A")] pub title: String,
+    #[searchable(weight = "B", embed)] pub body: String,
+}
+
+// 2. Keep the index in sync from the record lifecycle.
+#[autumn_web::repository(
+    Article,
+    hooks = SearchSyncHooks<Article, NewArticle, UpdateArticle>,
+    commit_hooks = true,
+)]
+pub trait ArticleRepository {}
+
+// 3. Mount the plugin.
+autumn_web::app()
+    .plugin(
+        SearchPlugin::new()
+            .postgres()
+            .embedder(Arc::new(MyEmbedder))
+            .index::<Article>(),
+    )
+    .run()
+    .await;
+```
+
+## What you get
+
+```rust
+// ranked + paginated keyword search, as a `Page`
+let page = search.search::<Article>("rust web framework", &page_req).await?;
+
+// semantic "find similar" / RAG retrieval
+let hits = search.similar::<Article>("how do I add auth?", 5).await?;
+let neighbours = search.similar_to::<Article>(article.id, 5).await?;
+
+// authorization-aware: the filter is pushed *into* the engine query
+let page = search.search_for::<Article>(&ctx, "rust web", &page_req).await?;
+```
+
+Creating, updating, or deleting an `Article` enqueues a durable reindex job.
+There is no hand-written index-sync code anywhere.
+
+## Backfill
+
+```bash
+autumn search reindex                     # every registered index
+autumn search reindex --index articles    # one index
+autumn search reindex --purge             # clear first (after a schema change)
+```
+
+## Backends
+
+| Backend | Keyword | Vector | Notes |
+|---|---|---|---|
+| `PostgresSearchStore` | `tsvector` + `ts_rank_cd` | `pgvector`, or a portable `double precision[]` fallback | The default. Reuses the in-core FTS from #842. |
+| `MemorySearchBackend` | in-process, weighted | in-process cosine | Dev and tests; no Docker, no network. |
+| yours | — | — | Implement `SearchBackend`. |
+
+`SearchBackend` is plain data in, plain data out, so an external engine
+(Meilisearch, Tantivy, a vector store) is a new `impl`, not a fork.
+
+## Embeddings
+
+`autumn-search` orchestrates embeddings; it ships **no model, runtime, or
+vendor SDK**. Implement `Embedder` over whatever you use and install it with
+`SearchPlugin::embedder(...)`. Two implementations ship, and neither is a
+model:
+
+- `NoEmbedder` — the default; refuses, so a missing provider is a typed error
+  rather than meaningless vectors.
+- `HashingEmbedder` — deterministic, dependency-free lexical vectors for dev
+  and tests.
+
+## Configuration
+
+```toml
+[search]
+queue = "search"            # the #[job] queue reindex/backfill run on
+batch_size = 500            # rows per backfill batch
+enabled = true              # false ⇒ index writes are no-ops (incident switch)
+embedding_dimensions = 768  # enables the pgvector fast path
+```
+
+## Documentation
+
+See [`docs/guide/search.md`](https://github.com/autumn-foundation/autumn/blob/main/docs/guide/search.md)
+for the full guide.
+
+## License
+
+MIT OR Apache-2.0

--- a/autumn-search/README.md
+++ b/autumn-search/README.md
@@ -104,8 +104,22 @@ embedding_dimensions = 768  # enables the pgvector fast path
 ```
 
 The plugin reads this itself at boot, so `enabled = false` is a config change
-rather than a deploy. Pass `SearchPlugin::config(...)` (or any of the builder
-overrides) to configure it in code instead.
+rather than a deploy. Resolution goes through the same profile layering the
+runtime uses — base `autumn.toml`, then `[profile.<name>.search]`, then
+`autumn-<profile>.toml`, then `AUTUMN_SEARCH__*` env vars — so the kill switch
+works per environment:
+
+```toml
+[profile.prod.search]
+enabled = false
+```
+
+```bash
+AUTUMN_SEARCH__ENABLED=false ./my-app   # or without touching a file at all
+```
+
+Pass `SearchPlugin::config(...)` (or any of the builder overrides) to configure
+it in code instead.
 
 ## Documentation
 

--- a/autumn-search/README.md
+++ b/autumn-search/README.md
@@ -23,12 +23,11 @@ pub struct Article {
     #[searchable(weight = "B", embed)] pub body: String,
 }
 
-// 2. Keep the index in sync from the record lifecycle.
-#[autumn_web::repository(
-    Article,
-    hooks = SearchSyncHooks<Article, NewArticle, UpdateArticle>,
-    commit_hooks = true,
-)]
+// 2. Keep the index in sync from the record lifecycle. `#[repository]` takes a
+//    plain type NAME for `hooks`, so alias the generic first.
+type ArticleSearchHooks = SearchSyncHooks<Article, NewArticle, UpdateArticle>;
+
+#[autumn_web::repository(Article, hooks = ArticleSearchHooks, commit_hooks = true)]
 pub trait ArticleRepository {}
 
 // 3. Mount the plugin.
@@ -46,6 +45,9 @@ autumn_web::app()
 ## What you get
 
 ```rust
+// The plugin installs the client as an `AppState` extension.
+let search = state.extension::<autumn_search::SearchClient>().expect("SearchPlugin");
+
 // ranked + paginated keyword search, as a `Page`
 let page = search.search::<Article>("rust web framework", &page_req).await?;
 
@@ -100,6 +102,10 @@ batch_size = 500            # rows per backfill batch
 enabled = true              # false ⇒ index writes are no-ops (incident switch)
 embedding_dimensions = 768  # enables the pgvector fast path
 ```
+
+The plugin reads this itself at boot, so `enabled = false` is a config change
+rather than a deploy. Pass `SearchPlugin::config(...)` (or any of the builder
+overrides) to configure it in code instead.
 
 ## Documentation
 

--- a/autumn-search/README.md
+++ b/autumn-search/README.md
@@ -68,6 +68,7 @@ There is no hand-written index-sync code anywhere.
 autumn search reindex                     # every registered index
 autumn search reindex --index articles    # one index
 autumn search reindex --purge             # clear first (after a schema change)
+autumn search reindex --profile prod      # rebuild the prod profile's index
 ```
 
 ## Backends

--- a/autumn-search/src/authz.rs
+++ b/autumn-search/src/authz.rs
@@ -19,9 +19,10 @@
 //!    [`SearchError::VisibilityUnavailable`], not an unfiltered read.
 
 use autumn_web::authorization::PolicyContext;
+use autumn_web::search::IndexDefinition;
 
 use crate::backend::{BoxFuture, SearchFilter};
-use crate::error::SearchResult;
+use crate::error::{SearchError, SearchResult};
 
 /// Turns a request context into the restriction a search must run under.
 ///
@@ -63,11 +64,40 @@ impl SearchVisibility for TenantVisibility {
     }
 }
 
+/// The ambient-tenant restriction for `definition`, applied by the client to
+/// **every** query on top of whatever the registered [`SearchVisibility`]
+/// returns — so tenant isolation does not depend on an app remembering to
+/// implement it.
+///
+/// Fails **closed**: querying a tenant-scoped index (one whose model carries a
+/// `tenant_id` column) with no tenant in scope is
+/// [`SearchError::TenantContextMissing`], not an unscoped read across every
+/// tenant. That matches `#[repository(tenant_scoped)]`, which errors for the
+/// same reason — and it matters most on exactly the paths that are easy to
+/// forget: a `#[job]`, a background task, or a route mounted outside the
+/// tenancy layer.
+///
+/// An index that is not tenant-scoped is unaffected.
+///
+/// # Errors
+///
+/// [`SearchError::TenantContextMissing`] when `definition.tenant_scoped` is
+/// set and no tenant is established.
+pub fn ambient_tenant_filter(definition: &IndexDefinition) -> SearchResult<SearchFilter> {
+    let filter = current_tenant_filter();
+    if definition.tenant_scoped && filter.tenant_id.is_none() {
+        return Err(SearchError::TenantContextMissing {
+            index: definition.name.to_owned(),
+        });
+    }
+    Ok(filter)
+}
+
 /// The ambient-tenant restriction, or an empty filter outside a tenant scope.
 ///
-/// Applied by the client to **every** query, on top of whatever the registered
-/// [`SearchVisibility`] returns, so tenant isolation does not depend on an app
-/// remembering to implement it.
+/// Prefer [`ambient_tenant_filter`], which additionally refuses an unscoped
+/// query against a tenant-scoped index. This raw form is for callers that
+/// already know the index is not tenant-scoped.
 #[must_use]
 pub fn current_tenant_filter() -> SearchFilter {
     autumn_web::tenancy::CURRENT_TENANT
@@ -111,6 +141,38 @@ mod tests {
         autumn_web::tenancy::CURRENT_TENANT
             .scope(Some("acme".to_owned()), async {
                 assert_eq!(current_tenant_filter().tenant_id.as_deref(), Some("acme"));
+            })
+            .await;
+    }
+
+    #[tokio::test]
+    async fn a_tenant_scoped_index_refuses_an_unscoped_query() {
+        // The leak this prevents: a search endpoint mounted outside the
+        // tenancy layer (or a job, where `CURRENT_TENANT` is deliberately
+        // unset) would otherwise return every tenant's rows, with
+        // `total_elements` counted across all of them.
+        const FIELDS: &[autumn_web::search::SearchIndexField] =
+            &[autumn_web::search::SearchIndexField::new("title", 'A')];
+        let scoped = IndexDefinition::new("articles", "simple", FIELDS, None, true);
+        let unscoped = IndexDefinition::new("notes", "simple", FIELDS, None, false);
+
+        let error = ambient_tenant_filter(&scoped).expect_err("must refuse");
+        assert!(
+            matches!(error, SearchError::TenantContextMissing { ref index } if index == "articles"),
+            "{error:?}"
+        );
+
+        // A model with no `tenant_id` column is unaffected.
+        assert_eq!(
+            ambient_tenant_filter(&unscoped).expect("no tenant column"),
+            SearchFilter::default()
+        );
+
+        // Inside a tenant scope the scoped index is allowed, and restricted.
+        autumn_web::tenancy::CURRENT_TENANT
+            .scope(Some("acme".to_owned()), async {
+                let filter = ambient_tenant_filter(&scoped).expect("in scope");
+                assert_eq!(filter.tenant_id.as_deref(), Some("acme"));
             })
             .await;
     }

--- a/autumn-search/src/authz.rs
+++ b/autumn-search/src/authz.rs
@@ -1,0 +1,125 @@
+//! Search-side authorization.
+//!
+//! A search index is a second read path over the same rows, so it needs the
+//! same posture as a normal query: **no leaking records a user can't see**.
+//!
+//! The seam is [`SearchVisibility`] — a request's [`PolicyContext`] in, a
+//! [`SearchFilter`] out. Because the output is plain data, it works for
+//! engines that are nowhere near the database: Meilisearch or a vector store
+//! receives the same tenant/allowlist restriction, which is the AC's
+//! "out-of-scope engines must still support a tenant/visibility filter hook".
+//!
+//! Three properties make this safe rather than advisory:
+//!
+//! 1. The filter is pushed **into** the backend query, not applied afterwards,
+//!    so page totals and k-NN neighbour counts are computed post-restriction.
+//! 2. A hook that returns an error **aborts** the search. There is no
+//!    fall-back-to-unfiltered path.
+//! 3. Calling an authorization-aware entry point with no hook registered is
+//!    [`SearchError::VisibilityUnavailable`], not an unfiltered read.
+
+use autumn_web::authorization::PolicyContext;
+
+use crate::backend::{BoxFuture, SearchFilter};
+use crate::error::SearchResult;
+
+/// Turns a request context into the restriction a search must run under.
+///
+/// The search-side analogue of `autumn_web::authorization::Scope`: where
+/// `Scope::list` returns the records a user may read, this returns the
+/// *predicate* that selects them — so the engine, not the process, does the
+/// filtering.
+///
+/// Implementations must fail **closed**: an unrecognised or anonymous
+/// principal should yield `SearchFilter::default().allow_ids([])` (match
+/// nothing), never an unrestricted filter.
+pub trait SearchVisibility: Send + Sync + 'static {
+    /// The restriction to apply for `ctx` when querying `index`.
+    fn filter<'a>(
+        &'a self,
+        ctx: &'a PolicyContext,
+        index: &'a str,
+    ) -> BoxFuture<'a, SearchResult<SearchFilter>>;
+}
+
+/// Restricts every search to the ambient tenant.
+///
+/// Reads `autumn_web::tenancy::CURRENT_TENANT`, the same task-local the
+/// tenant-scoped repositories use, so a search inside a tenant-scoped request
+/// is confined exactly like a `list()` in the same request. Outside a tenant
+/// scope it adds no restriction — it is a tenancy hook, not an authorization
+/// one, and is meant to be composed with (not substituted for) an app's own
+/// visibility rules via [`SearchFilter::intersect`].
+#[derive(Debug, Clone, Copy, Default)]
+pub struct TenantVisibility;
+
+impl SearchVisibility for TenantVisibility {
+    fn filter<'a>(
+        &'a self,
+        _ctx: &'a PolicyContext,
+        _index: &'a str,
+    ) -> BoxFuture<'a, SearchResult<SearchFilter>> {
+        Box::pin(async move { Ok(current_tenant_filter()) })
+    }
+}
+
+/// The ambient-tenant restriction, or an empty filter outside a tenant scope.
+///
+/// Applied by the client to **every** query, on top of whatever the registered
+/// [`SearchVisibility`] returns, so tenant isolation does not depend on an app
+/// remembering to implement it.
+#[must_use]
+pub fn current_tenant_filter() -> SearchFilter {
+    autumn_web::tenancy::CURRENT_TENANT
+        .try_with(Clone::clone)
+        .ok()
+        .flatten()
+        .map_or_else(SearchFilter::default, |tenant| {
+            SearchFilter::default().tenant(tenant)
+        })
+}
+
+/// A [`SearchVisibility`] that denies everything.
+///
+/// Useful as an explicit "this index is not searchable by end users yet"
+/// marker, and as the safe thing to install while an app's real rules are
+/// being written.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct DenyAll;
+
+impl SearchVisibility for DenyAll {
+    fn filter<'a>(
+        &'a self,
+        _ctx: &'a PolicyContext,
+        _index: &'a str,
+    ) -> BoxFuture<'a, SearchResult<SearchFilter>> {
+        Box::pin(async move { Ok(SearchFilter::default().allow_ids(Vec::<i64>::new())) })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn outside_a_tenant_scope_there_is_nothing_to_restrict() {
+        assert_eq!(current_tenant_filter(), SearchFilter::default());
+    }
+
+    #[tokio::test]
+    async fn inside_a_tenant_scope_the_filter_names_that_tenant() {
+        autumn_web::tenancy::CURRENT_TENANT
+            .scope(Some("acme".to_owned()), async {
+                assert_eq!(current_tenant_filter().tenant_id.as_deref(), Some("acme"));
+            })
+            .await;
+    }
+
+    #[tokio::test]
+    async fn deny_all_matches_nothing() {
+        // Constructing a PolicyContext needs a session; DenyAll ignores it, so
+        // assert on the filter it produces directly.
+        let filter = SearchFilter::default().allow_ids(Vec::<i64>::new());
+        assert!(filter.matches_nothing());
+    }
+}

--- a/autumn-search/src/authz.rs
+++ b/autumn-search/src/authz.rs
@@ -64,10 +64,11 @@ impl SearchVisibility for TenantVisibility {
     }
 }
 
-/// The ambient-tenant restriction for `definition`, applied by the client to
-/// **every** query on top of whatever the registered [`SearchVisibility`]
-/// returns — so tenant isolation does not depend on an app remembering to
-/// implement it.
+/// The ambient-tenant restriction for `definition`.
+///
+/// Applied by the client to **every** query, on top of whatever the registered
+/// [`SearchVisibility`] returns — so tenant isolation does not depend on an app
+/// remembering to implement it.
 ///
 /// Fails **closed**: querying a tenant-scoped index (one whose model carries a
 /// `tenant_id` column) with no tenant in scope is

--- a/autumn-search/src/backend.rs
+++ b/autumn-search/src/backend.rs
@@ -10,8 +10,10 @@
 //! # Adding operations without breaking implementors
 //!
 //! Every query/result struct is `#[non_exhaustive]` with builder methods, and
-//! every non-core trait method has a default implementation that returns
-//! [`SearchError::Unsupported`]. New capabilities are therefore additive.
+//! every trait method beyond the required core has a default implementation —
+//! [`SearchBackend::capabilities`] reports a keyword-only backend, and the
+//! vector methods return [`SearchError::Unsupported`]. New capabilities are
+//! therefore additive.
 
 use std::collections::BTreeMap;
 use std::future::Future;
@@ -127,6 +129,14 @@ impl SearchFilter {
     }
 
     /// Add an exact-match predicate on an indexed field.
+    ///
+    /// `field` must name a field the index declares (or the reserved
+    /// [`TENANT_FILTER_KEY`]). A key that does not is **not** an error here —
+    /// it makes the filter match nothing, in both the in-Rust
+    /// ([`SearchFilter::permits`]) and SQL paths. Backends must never
+    /// interpolate an undeclared key into a query: the value is bound, but a
+    /// key is an identifier position, so an unchecked one would let request
+    /// text terminate the predicate and `OR` away the restrictions before it.
     #[must_use]
     pub fn equals(mut self, field: impl Into<String>, value: impl Into<String>) -> Self {
         self.equals.insert(field.into(), value.into());
@@ -305,6 +315,7 @@ impl VectorQuery {
 /// the app's job (see `SearchClient::search_hydrated`), which keeps the index
 /// from becoming a second, staler copy of the database that can leak columns.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct SearchHit {
     /// Index the hit came from.
     pub index: String,
@@ -354,6 +365,37 @@ impl Default for BackendCapabilities {
             weighted_fields: false,
             embedding_readback: false,
         }
+    }
+}
+
+impl BackendCapabilities {
+    /// Declare vector / k-NN support.
+    #[must_use]
+    pub const fn with_vector(mut self, supported: bool) -> Self {
+        self.vector = supported;
+        self
+    }
+
+    /// Declare per-field weighting support.
+    #[must_use]
+    pub const fn with_weighted_fields(mut self, supported: bool) -> Self {
+        self.weighted_fields = supported;
+        self
+    }
+
+    /// Declare stored-embedding read-back support (`similar_to`).
+    #[must_use]
+    pub const fn with_embedding_readback(mut self, supported: bool) -> Self {
+        self.embedding_readback = supported;
+        self
+    }
+
+    /// Declare keyword-search support. Backends that cannot answer a keyword
+    /// query at all set this `false`.
+    #[must_use]
+    pub const fn with_keyword(mut self, supported: bool) -> Self {
+        self.keyword = supported;
+        self
     }
 }
 
@@ -426,10 +468,18 @@ pub trait SearchBackend: Send + Sync + 'static {
 
     /// Read back the stored embedding for one record, so "find records like
     /// *this* one" needs no re-embedding.
+    ///
+    /// `filter` is **not** optional: this read is a query like any other, and
+    /// the seed record is caller-supplied. Returning an embedding the caller
+    /// may not see would be a cross-tenant inference channel — the caller
+    /// could rank their *own* probe documents against a record they cannot
+    /// read. Implementations MUST return `None` for a record the filter
+    /// excludes, exactly as if it were not indexed.
     fn embedding<'a>(
         &'a self,
         _definition: &'a IndexDefinition,
         _id: i64,
+        _filter: &'a SearchFilter,
     ) -> BoxFuture<'a, SearchResult<Option<Vec<f32>>>> {
         let name = self.name();
         Box::pin(async move {
@@ -555,6 +605,23 @@ mod tests {
         assert!(!caps.vector);
         assert!(!caps.weighted_fields);
         assert!(!caps.embedding_readback);
+    }
+
+    #[test]
+    fn capabilities_are_declarable_from_outside_this_crate() {
+        // `#[non_exhaustive]` forbids a struct literal downstream, so without
+        // these builders a third-party backend could only ever report the
+        // keyword-only default — it could never advertise vector support.
+        let caps = BackendCapabilities::default()
+            .with_vector(true)
+            .with_weighted_fields(true)
+            .with_embedding_readback(true);
+        assert!(caps.keyword);
+        assert!(caps.vector);
+        assert!(caps.weighted_fields);
+        assert!(caps.embedding_readback);
+
+        assert!(!BackendCapabilities::default().with_keyword(false).keyword);
     }
 
     #[test]

--- a/autumn-search/src/backend.rs
+++ b/autumn-search/src/backend.rs
@@ -340,7 +340,7 @@ impl SearchHit {
 
 /// What a backend can do, so callers can degrade deliberately.
 ///
-/// Four independent yes/no capabilities. `clippy::struct_excessive_bools`
+/// Five independent yes/no capabilities. `clippy::struct_excessive_bools`
 /// suggests enums, but each of these is genuinely orthogonal — an engine can
 /// support any subset — so a flag set is the honest shape.
 #[allow(clippy::struct_excessive_bools)]
@@ -355,6 +355,9 @@ pub struct BackendCapabilities {
     pub weighted_fields: bool,
     /// Reading a stored embedding back (`similar_to`).
     pub embedding_readback: bool,
+    /// Honouring [`SearchBackend::index_unless_newer`]'s watermark, so a
+    /// backfill cannot overwrite a concurrent per-record reindex.
+    pub conditional_index: bool,
 }
 
 impl Default for BackendCapabilities {
@@ -364,6 +367,7 @@ impl Default for BackendCapabilities {
             vector: false,
             weighted_fields: false,
             embedding_readback: false,
+            conditional_index: false,
         }
     }
 }
@@ -387,6 +391,14 @@ impl BackendCapabilities {
     #[must_use]
     pub const fn with_embedding_readback(mut self, supported: bool) -> Self {
         self.embedding_readback = supported;
+        self
+    }
+
+    /// Declare that [`SearchBackend::index_unless_newer`]'s watermark is
+    /// honoured rather than ignored.
+    #[must_use]
+    pub const fn with_conditional_index(mut self, supported: bool) -> Self {
+        self.conditional_index = supported;
         self
     }
 
@@ -431,6 +443,56 @@ pub trait SearchBackend: Send + Sync + 'static {
         definition: &'a IndexDefinition,
         documents: &'a [IndexedDocument],
     ) -> BoxFuture<'a, SearchResult<()>>;
+
+    /// A marker for "now" on **the backend's own clock**, for
+    /// [`index_unless_newer`](Self::index_unless_newer).
+    ///
+    /// Opaque and backend-defined: the comparison happens inside the backend,
+    /// so the caller never has to reconcile its clock with the store's. The
+    /// default `None` means this backend has no watermark, and
+    /// `index_unless_newer` degrades to an unconditional write.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SearchError::Backend`](crate::SearchError::Backend) if the
+    /// watermark cannot be read.
+    fn write_watermark(&self) -> BoxFuture<'_, SearchResult<Option<String>>> {
+        Box::pin(async { Ok(None) })
+    }
+
+    /// Index `documents`, but **do not overwrite** a document that has been
+    /// written since `watermark`.
+    ///
+    /// This is how a backfill avoids clobbering a concurrent per-record
+    /// reindex. A backfill reads a batch, embeds it (a provider round-trip:
+    /// slow), then writes. A mutation in that window enqueues a reindex job
+    /// that reads and writes the *new* state — and the backfill's in-flight
+    /// batch would then overwrite it with what the source said minutes ago.
+    /// Nothing re-runs the reindex, so the index stays stale until the next
+    /// mutation, and the same ordering resurrects a record deleted mid-run.
+    ///
+    /// A backfill takes one watermark up front and passes it to every batch,
+    /// so any document a reindex wrote after the backfill started is left
+    /// alone. Newer always wins, and the two writers converge without needing
+    /// to know about each other.
+    ///
+    /// The default implementation ignores `watermark` and delegates to
+    /// [`index`](Self::index) — correct for a backend with no notion of write
+    /// time, at the cost of last-writer-wins during a backfill. Report
+    /// [`BackendCapabilities::conditional_index`] to say you honour it.
+    ///
+    /// # Errors
+    ///
+    /// As [`index`](Self::index).
+    fn index_unless_newer<'a>(
+        &'a self,
+        definition: &'a IndexDefinition,
+        documents: &'a [IndexedDocument],
+        watermark: Option<&'a str>,
+    ) -> BoxFuture<'a, SearchResult<()>> {
+        let _ = watermark;
+        self.index(definition, documents)
+    }
 
     /// Remove documents by record id. Removing an absent id is a no-op, not an
     /// error — deletes are replayed.

--- a/autumn-search/src/backend.rs
+++ b/autumn-search/src/backend.rs
@@ -1,0 +1,566 @@
+//! The pluggable [`SearchBackend`] seam and the query/result vocabulary.
+//!
+//! The trait is deliberately **plain data in, plain data out**: an index
+//! definition, documents, a filter, a page request. Nothing in the signature
+//! assumes Postgres, so an external engine (Meilisearch, Tantivy, a vector
+//! store) is a new `impl`, not a fork — and, crucially, an out-of-scope engine
+//! still receives the [`SearchFilter`] verbatim, which is what keeps
+//! authorization enforceable everywhere.
+//!
+//! # Adding operations without breaking implementors
+//!
+//! Every query/result struct is `#[non_exhaustive]` with builder methods, and
+//! every non-core trait method has a default implementation that returns
+//! [`SearchError::Unsupported`]. New capabilities are therefore additive.
+
+use std::collections::BTreeMap;
+use std::future::Future;
+use std::pin::Pin;
+
+use autumn_web::pagination::{Page, PageRequest};
+use autumn_web::search::{IndexDefinition, SearchDocument};
+use serde::{Deserialize, Serialize};
+
+use crate::error::{SearchError, SearchResult};
+
+/// Boxed future returned by the object-safe search traits.
+///
+/// `SearchBackend`, [`crate::Embedder`], [`crate::DocumentSource`] and
+/// [`crate::SearchVisibility`] are all stored as `Arc<dyn …>`, so they cannot
+/// use `impl Future`. This mirrors `autumn_web::authorization::Policy`.
+pub type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
+
+// ── Documents ───────────────────────────────────────────────────────────────
+
+/// A [`SearchDocument`] paired with its (optional) embedding.
+///
+/// The document comes from the model via `#[searchable]`; the embedding comes
+/// from the app's [`crate::Embedder`]. Keeping them in one struct means a
+/// backend writes both halves of a record in a single call, so a keyword index
+/// and a vector index can never drift apart.
+#[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
+pub struct IndexedDocument {
+    /// The extracted record.
+    pub document: SearchDocument,
+    /// The embedding of [`SearchDocument::embed_text`], when one was produced.
+    pub embedding: Option<Vec<f32>>,
+}
+
+impl IndexedDocument {
+    /// Wrap a document with no embedding.
+    #[must_use]
+    pub const fn new(document: SearchDocument) -> Self {
+        Self {
+            document,
+            embedding: None,
+        }
+    }
+
+    /// Attach an embedding.
+    #[must_use]
+    pub fn with_embedding(mut self, embedding: Vec<f32>) -> Self {
+        self.embedding = Some(embedding);
+        self
+    }
+
+    /// Primary key of the underlying record.
+    #[must_use]
+    pub const fn id(&self) -> i64 {
+        self.document.id
+    }
+}
+
+// ── Filters (the authorization seam) ────────────────────────────────────────
+
+/// Restrictions applied *inside* the backend query.
+///
+/// This is the "tenant/visibility filter hook" every engine must honour. It is
+/// a required argument of the query methods rather than an optional
+/// post-processing step, so a backend cannot accidentally return rows the
+/// caller is not allowed to see: forgetting the filter is a visibly missing
+/// field, not a silently skipped `if`.
+///
+/// Filters **intersect** ([`SearchFilter::intersect`]) rather than overwrite,
+/// so a caller-supplied filter can only ever narrow what authorization allowed.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct SearchFilter {
+    /// Only match documents owned by this tenant.
+    pub tenant_id: Option<String>,
+    /// When `Some`, only these record ids may match. `Some(vec![])` means
+    /// "nothing is visible" — an empty allowlist is a real restriction, never
+    /// "no restriction".
+    pub allowed_ids: Option<Vec<i64>>,
+    /// Record ids that must never match.
+    pub excluded_ids: Vec<i64>,
+    /// Exact-match predicates on indexed fields (plus the reserved
+    /// `tenant_id` key). This is what carries an app's own scoping to an
+    /// engine that has no SQL to join against.
+    pub equals: BTreeMap<String, String>,
+}
+
+/// The reserved [`SearchFilter::equals`] key that maps onto
+/// [`SearchDocument::tenant_id`] rather than an indexed field.
+pub const TENANT_FILTER_KEY: &str = "tenant_id";
+
+impl SearchFilter {
+    /// Restrict to one tenant.
+    #[must_use]
+    pub fn tenant(mut self, tenant_id: impl Into<String>) -> Self {
+        self.tenant_id = Some(tenant_id.into());
+        self
+    }
+
+    /// Restrict to an explicit set of record ids.
+    #[must_use]
+    pub fn allow_ids(mut self, ids: impl IntoIterator<Item = i64>) -> Self {
+        self.allowed_ids = Some(ids.into_iter().collect());
+        self
+    }
+
+    /// Exclude specific record ids.
+    #[must_use]
+    pub fn exclude_ids(mut self, ids: impl IntoIterator<Item = i64>) -> Self {
+        self.excluded_ids.extend(ids);
+        self
+    }
+
+    /// Add an exact-match predicate on an indexed field.
+    #[must_use]
+    pub fn equals(mut self, field: impl Into<String>, value: impl Into<String>) -> Self {
+        self.equals.insert(field.into(), value.into());
+        self
+    }
+
+    /// Whether this filter can never match anything.
+    ///
+    /// Backends short-circuit on this so an impossible filter costs no query.
+    #[must_use]
+    pub fn matches_nothing(&self) -> bool {
+        self.allowed_ids.as_ref().is_some_and(Vec::is_empty)
+    }
+
+    /// Combine two filters so that **both** must hold.
+    ///
+    /// Two incompatible constraints (different tenants, disjoint allowlists,
+    /// conflicting `equals` on the same key) collapse to an impossible filter
+    /// rather than arbitrarily picking a winner — the safe direction.
+    #[must_use]
+    pub fn intersect(mut self, other: Self) -> Self {
+        let mut impossible = false;
+
+        match (&self.tenant_id, &other.tenant_id) {
+            (Some(a), Some(b)) if a != b => impossible = true,
+            (None, Some(b)) => self.tenant_id = Some(b.clone()),
+            _ => {}
+        }
+
+        self.allowed_ids = match (self.allowed_ids.take(), other.allowed_ids) {
+            (Some(a), Some(b)) => Some(a.into_iter().filter(|id| b.contains(id)).collect()),
+            (Some(a), None) => Some(a),
+            (None, b) => b,
+        };
+
+        self.excluded_ids.extend(other.excluded_ids);
+        self.excluded_ids.sort_unstable();
+        self.excluded_ids.dedup();
+
+        for (key, value) in other.equals {
+            match self.equals.get(&key) {
+                Some(existing) if *existing != value => impossible = true,
+                _ => {
+                    self.equals.insert(key, value);
+                }
+            }
+        }
+
+        if impossible {
+            self.allowed_ids = Some(Vec::new());
+        }
+        self
+    }
+
+    /// Whether `document` satisfies this filter.
+    ///
+    /// Shared by every backend that filters in Rust (the in-memory backend and
+    /// any engine whose driver cannot express a predicate), so the semantics
+    /// are defined once.
+    #[must_use]
+    pub fn permits(&self, document: &SearchDocument) -> bool {
+        if let Some(tenant) = &self.tenant_id
+            && document.tenant_id.as_deref() != Some(tenant.as_str())
+        {
+            return false;
+        }
+        if let Some(allowed) = &self.allowed_ids
+            && !allowed.contains(&document.id)
+        {
+            return false;
+        }
+        if self.excluded_ids.contains(&document.id) {
+            return false;
+        }
+        for (field, expected) in &self.equals {
+            let actual = if field == TENANT_FILTER_KEY {
+                document.tenant_id.as_deref()
+            } else {
+                document.field(field)
+            };
+            if actual != Some(expected.as_str()) {
+                return false;
+            }
+        }
+        true
+    }
+}
+
+// ── Queries ─────────────────────────────────────────────────────────────────
+
+/// A ranked keyword query.
+///
+/// **Query semantics (the cross-backend contract).** `text` is a bag of words,
+/// not a query language: every token must be present for a document to match,
+/// and operator-looking input (`OR`, `field:`, `*`, quotes) is never
+/// interpreted as syntax. That keeps results consistent across engines and
+/// makes a hostile query string structurally incapable of widening the result
+/// set. The Postgres backend implements this with `plainto_tsquery`, which is
+/// parameterized and cannot be injected into.
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub struct KeywordQuery {
+    /// Raw user query text.
+    pub text: String,
+    /// Restrictions applied inside the backend query.
+    pub filter: SearchFilter,
+    /// Page number and size.
+    pub page: PageRequest,
+}
+
+impl KeywordQuery {
+    /// Build a keyword query.
+    #[must_use]
+    pub fn new(text: impl Into<String>, page: PageRequest) -> Self {
+        Self {
+            text: text.into(),
+            filter: SearchFilter::default(),
+            page,
+        }
+    }
+
+    /// Apply a filter (replacing any previously set filter).
+    #[must_use]
+    pub fn filter(mut self, filter: SearchFilter) -> Self {
+        self.filter = filter;
+        self
+    }
+}
+
+/// A vector / k-NN similarity query.
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub struct VectorQuery {
+    /// The query embedding.
+    pub vector: Vec<f32>,
+    /// Maximum neighbours to return.
+    pub limit: usize,
+    /// Restrictions applied inside the backend query.
+    pub filter: SearchFilter,
+    /// Drop neighbours whose cosine similarity is below this.
+    pub min_score: Option<f32>,
+}
+
+impl VectorQuery {
+    /// Build a vector query for the `limit` nearest neighbours.
+    #[must_use]
+    pub fn new(vector: Vec<f32>, limit: usize) -> Self {
+        Self {
+            vector,
+            limit,
+            filter: SearchFilter::default(),
+            min_score: None,
+        }
+    }
+
+    /// Apply a filter (replacing any previously set filter).
+    #[must_use]
+    pub fn filter(mut self, filter: SearchFilter) -> Self {
+        self.filter = filter;
+        self
+    }
+
+    /// Require at least this cosine similarity.
+    #[must_use]
+    pub const fn min_score(mut self, min_score: f32) -> Self {
+        self.min_score = Some(min_score);
+        self
+    }
+}
+
+// ── Results ─────────────────────────────────────────────────────────────────
+
+/// One ranked result.
+///
+/// A hit carries the *identity* of a record, never its contents: hydration is
+/// the app's job (see `SearchClient::search_hydrated`), which keeps the index
+/// from becoming a second, staler copy of the database that can leak columns.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct SearchHit {
+    /// Index the hit came from.
+    pub index: String,
+    /// Primary key of the matching record.
+    pub id: i64,
+    /// Backend-defined relevance score; higher is better, and comparable only
+    /// within a single result set.
+    pub score: f32,
+}
+
+impl SearchHit {
+    /// Construct a hit.
+    #[must_use]
+    pub fn new(index: impl Into<String>, id: i64, score: f32) -> Self {
+        Self {
+            index: index.into(),
+            id,
+            score,
+        }
+    }
+}
+
+/// What a backend can do, so callers can degrade deliberately.
+///
+/// Four independent yes/no capabilities. `clippy::struct_excessive_bools`
+/// suggests enums, but each of these is genuinely orthogonal — an engine can
+/// support any subset — so a flag set is the honest shape.
+#[allow(clippy::struct_excessive_bools)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct BackendCapabilities {
+    /// Ranked keyword search.
+    pub keyword: bool,
+    /// Vector / k-NN search.
+    pub vector: bool,
+    /// Per-field weighting (`#[searchable(weight = "A")]`).
+    pub weighted_fields: bool,
+    /// Reading a stored embedding back (`similar_to`).
+    pub embedding_readback: bool,
+}
+
+impl Default for BackendCapabilities {
+    fn default() -> Self {
+        Self {
+            keyword: true,
+            vector: false,
+            weighted_fields: false,
+            embedding_readback: false,
+        }
+    }
+}
+
+// ── The trait ───────────────────────────────────────────────────────────────
+
+/// A search engine `autumn-search` can drive.
+///
+/// Implement this to add an engine. The three write methods plus
+/// [`keyword_search`](SearchBackend::keyword_search) are required; vector
+/// operations default to [`SearchError::Unsupported`] so a keyword-only engine
+/// is a complete, honest implementation.
+pub trait SearchBackend: Send + Sync + 'static {
+    /// Stable backend name, used in errors and logs.
+    fn name(&self) -> &'static str;
+
+    /// What this backend supports.
+    fn capabilities(&self) -> BackendCapabilities {
+        BackendCapabilities::default()
+    }
+
+    /// Create or migrate the storage for `definition`. Must be idempotent —
+    /// it runs on every boot — and must reject a definition that fails
+    /// [`IndexDefinition::validate`].
+    fn ensure_index<'a>(
+        &'a self,
+        definition: &'a IndexDefinition,
+    ) -> BoxFuture<'a, SearchResult<()>>;
+
+    /// Upsert `documents`, keyed by `(index, id)`. Must be idempotent: the
+    /// reindex job delivers at least once.
+    fn index<'a>(
+        &'a self,
+        definition: &'a IndexDefinition,
+        documents: &'a [IndexedDocument],
+    ) -> BoxFuture<'a, SearchResult<()>>;
+
+    /// Remove documents by record id. Removing an absent id is a no-op, not an
+    /// error — deletes are replayed.
+    fn delete<'a>(
+        &'a self,
+        definition: &'a IndexDefinition,
+        ids: &'a [i64],
+    ) -> BoxFuture<'a, SearchResult<()>>;
+
+    /// Remove every document in the index.
+    fn clear<'a>(&'a self, definition: &'a IndexDefinition) -> BoxFuture<'a, SearchResult<()>>;
+
+    /// Ranked, paginated keyword search. See [`KeywordQuery`] for the query
+    /// semantics every backend must implement.
+    fn keyword_search<'a>(
+        &'a self,
+        definition: &'a IndexDefinition,
+        query: &'a KeywordQuery,
+    ) -> BoxFuture<'a, SearchResult<Page<SearchHit>>>;
+
+    /// k-NN search over the embedded field.
+    fn vector_search<'a>(
+        &'a self,
+        _definition: &'a IndexDefinition,
+        _query: &'a VectorQuery,
+    ) -> BoxFuture<'a, SearchResult<Vec<SearchHit>>> {
+        let name = self.name();
+        Box::pin(async move {
+            Err(SearchError::Unsupported {
+                backend: name,
+                operation: "vector search",
+            })
+        })
+    }
+
+    /// Read back the stored embedding for one record, so "find records like
+    /// *this* one" needs no re-embedding.
+    fn embedding<'a>(
+        &'a self,
+        _definition: &'a IndexDefinition,
+        _id: i64,
+    ) -> BoxFuture<'a, SearchResult<Option<Vec<f32>>>> {
+        let name = self.name();
+        Box::pin(async move {
+            Err(SearchError::Unsupported {
+                backend: name,
+                operation: "embedding read-back",
+            })
+        })
+    }
+}
+
+/// Build an empty page for `request` — the fail-closed result every backend
+/// returns for a blank query or an impossible filter.
+#[must_use]
+pub fn empty_page(request: &PageRequest) -> Page<SearchHit> {
+    Page::new(Vec::new(), 0, request)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn doc(id: i64) -> SearchDocument {
+        SearchDocument::new("articles", id).with_field("title", 'A', "Hello")
+    }
+
+    #[test]
+    fn an_empty_filter_permits_everything() {
+        assert!(SearchFilter::default().permits(&doc(1)));
+        assert!(!SearchFilter::default().matches_nothing());
+    }
+
+    #[test]
+    fn an_empty_allowlist_is_a_restriction_not_an_absence() {
+        let filter = SearchFilter::default().allow_ids(Vec::<i64>::new());
+        assert!(filter.matches_nothing());
+        assert!(!filter.permits(&doc(1)));
+    }
+
+    #[test]
+    fn tenant_filter_requires_an_exact_owner() {
+        let filter = SearchFilter::default().tenant("acme");
+        assert!(!filter.permits(&doc(1)), "an untenanted doc is not acme's");
+        assert!(filter.permits(&doc(1).with_tenant("acme")));
+        assert!(!filter.permits(&doc(1).with_tenant("globex")));
+    }
+
+    #[test]
+    fn excluded_ids_win_over_the_allowlist() {
+        let filter = SearchFilter::default()
+            .allow_ids([1_i64])
+            .exclude_ids([1_i64]);
+        assert!(!filter.permits(&doc(1)));
+    }
+
+    #[test]
+    fn equals_matches_indexed_fields_and_the_reserved_tenant_key() {
+        let filter = SearchFilter::default().equals("title", "Hello");
+        assert!(filter.permits(&doc(1)));
+        assert!(
+            !SearchFilter::default()
+                .equals("title", "Nope")
+                .permits(&doc(1))
+        );
+        assert!(
+            SearchFilter::default()
+                .equals(TENANT_FILTER_KEY, "acme")
+                .permits(&doc(1).with_tenant("acme"))
+        );
+    }
+
+    #[test]
+    fn equals_on_a_field_the_document_lacks_never_matches() {
+        assert!(
+            !SearchFilter::default()
+                .equals("missing", "x")
+                .permits(&doc(1))
+        );
+    }
+
+    #[test]
+    fn intersect_narrows_and_never_widens() {
+        let merged = SearchFilter::default()
+            .allow_ids([1_i64, 2, 3])
+            .intersect(SearchFilter::default().allow_ids([2_i64, 4]));
+        assert_eq!(merged.allowed_ids, Some(vec![2]));
+
+        // An unconstrained side must not erase the constrained one.
+        let merged = SearchFilter::default()
+            .allow_ids([1_i64])
+            .intersect(SearchFilter::default());
+        assert_eq!(merged.allowed_ids, Some(vec![1]));
+
+        let merged = SearchFilter::default().intersect(SearchFilter::default().allow_ids([1_i64]));
+        assert_eq!(merged.allowed_ids, Some(vec![1]));
+    }
+
+    #[test]
+    fn intersect_collapses_conflicting_constraints_to_nothing() {
+        let merged = SearchFilter::default()
+            .tenant("acme")
+            .intersect(SearchFilter::default().tenant("globex"));
+        assert!(merged.matches_nothing());
+
+        let merged = SearchFilter::default()
+            .equals("state", "published")
+            .intersect(SearchFilter::default().equals("state", "draft"));
+        assert!(merged.matches_nothing());
+    }
+
+    #[test]
+    fn intersect_unions_and_dedups_exclusions() {
+        let merged = SearchFilter::default()
+            .exclude_ids([1_i64, 2])
+            .intersect(SearchFilter::default().exclude_ids([2_i64, 3]));
+        assert_eq!(merged.excluded_ids, vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn default_capabilities_claim_only_keyword_search() {
+        let caps = BackendCapabilities::default();
+        assert!(caps.keyword);
+        assert!(!caps.vector);
+        assert!(!caps.weighted_fields);
+        assert!(!caps.embedding_readback);
+    }
+
+    #[test]
+    fn empty_page_reports_a_zero_total() {
+        let page = empty_page(&PageRequest::default());
+        assert!(page.content.is_empty());
+        assert_eq!(page.total_elements, 0);
+    }
+}

--- a/autumn-search/src/client.rs
+++ b/autumn-search/src/client.rs
@@ -861,6 +861,30 @@ impl SearchClient {
         };
         let mut after: Option<i64> = None;
 
+        // Taken ONCE, before the first batch, and passed to every write.
+        //
+        // A backfill reads a batch, embeds it (a provider round-trip — slow),
+        // then writes. A mutation inside that window enqueues a reindex job
+        // that reads and writes the *new* state, and the backfill's in-flight
+        // batch would then overwrite it with what the source said minutes ago.
+        // Nothing re-runs the reindex, so the index stays wrong until the next
+        // mutation, and the same ordering resurrects a record deleted mid-run.
+        //
+        // The watermark makes the rule "a backfill never overwrites a document
+        // written after the backfill began" — newer always wins, and the two
+        // writers converge without knowing about each other. A backend that
+        // does not report `conditional_index` ignores it and keeps
+        // last-writer-wins.
+        let watermark = self.inner.backend.write_watermark().await?;
+        if watermark.is_none() && !self.inner.backend.capabilities().conditional_index {
+            tracing::debug!(
+                backend = self.inner.backend.name(),
+                index = %index,
+                "backend has no write watermark; a concurrent reindex may be overwritten by this \
+                 backfill"
+            );
+        }
+
         loop {
             let documents = source.scan(definition, after, batch_size).await?;
             if documents.is_empty() {
@@ -873,7 +897,10 @@ impl SearchClient {
             let count = documents.len() as u64;
 
             let prepared = self.embed_documents(documents).await?;
-            self.inner.backend.index(definition, &prepared).await?;
+            self.inner
+                .backend
+                .index_unless_newer(definition, &prepared, watermark.as_deref())
+                .await?;
 
             report.indexed += count;
             report.batches += 1;

--- a/autumn-search/src/client.rs
+++ b/autumn-search/src/client.rs
@@ -1,0 +1,851 @@
+//! The one engine-agnostic query and indexing API.
+//!
+//! `SearchClient` is what an application actually touches: it owns the index
+//! registry, the backend, the embedder, the document source, and the
+//! visibility hook, and it composes them so the surface stays "one attribute
+//! on the model + one call here".
+//!
+//! ```rust,ignore
+//! // keyword, ranked + paginated
+//! let page: Page<SearchHit> = search.search::<Article>("rust web", &page_req).await?;
+//! // semantic "find similar"
+//! let hits = search.similar::<Article>("how do I add auth?", 5).await?;
+//! // authorization-aware
+//! let page = search.search_for::<Article>(&ctx, "rust web", &page_req).await?;
+//! ```
+
+use std::collections::BTreeMap;
+use std::future::Future;
+use std::sync::Arc;
+
+use autumn_web::authorization::PolicyContext;
+use autumn_web::pagination::{ListQuery, Page, PageRequest};
+use autumn_web::search::{IndexDefinition, SearchDocument, SearchIndexed};
+
+use crate::authz::{SearchVisibility, current_tenant_filter};
+use crate::backend::{
+    IndexedDocument, KeywordQuery, SearchBackend, SearchFilter, SearchHit, TENANT_FILTER_KEY,
+    VectorQuery, empty_page,
+};
+use crate::embedding::{Embedder, NoEmbedder};
+use crate::error::{SearchError, SearchResult};
+use crate::jobs::{ReindexArgs, ReindexOp};
+use crate::source::DocumentSource;
+
+/// How many rows a backfill reads per batch when nothing else says.
+const DEFAULT_BACKFILL_BATCH: usize = 500;
+
+// ── Backfill ────────────────────────────────────────────────────────────────
+
+/// Knobs for a full reindex.
+#[derive(Debug, Clone, Copy)]
+#[non_exhaustive]
+pub struct BackfillOptions {
+    /// Rows per batch. `0` is clamped to the default rather than looping
+    /// forever on an empty scan.
+    pub batch_size: usize,
+    /// Clear the index before rebuilding it.
+    ///
+    /// Off by default: purging makes the index briefly empty, which is the
+    /// wrong trade for a routine repair run. Turn it on for a schema change,
+    /// where stale documents the source no longer produces would otherwise
+    /// survive forever.
+    pub purge: bool,
+}
+
+impl Default for BackfillOptions {
+    fn default() -> Self {
+        Self {
+            batch_size: DEFAULT_BACKFILL_BATCH,
+            purge: false,
+        }
+    }
+}
+
+impl BackfillOptions {
+    /// Set the batch size.
+    #[must_use]
+    pub const fn batch_size(mut self, batch_size: usize) -> Self {
+        self.batch_size = batch_size;
+        self
+    }
+
+    /// Clear the index before rebuilding.
+    #[must_use]
+    pub const fn purge(mut self, purge: bool) -> Self {
+        self.purge = purge;
+        self
+    }
+
+    /// The batch size actually used, with `0` clamped to the default.
+    #[must_use]
+    pub const fn effective_batch_size(&self) -> usize {
+        if self.batch_size == 0 {
+            DEFAULT_BACKFILL_BATCH
+        } else {
+            self.batch_size
+        }
+    }
+}
+
+/// What a backfill did.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct BackfillReport {
+    /// The index that was rebuilt.
+    pub index: String,
+    /// Documents written.
+    pub indexed: u64,
+    /// Non-empty batches processed.
+    pub batches: u64,
+    /// Whether the index was cleared first.
+    pub purged: bool,
+}
+
+// ── Client ──────────────────────────────────────────────────────────────────
+
+/// The application-facing search API.
+///
+/// Cheap to clone (everything inside is an `Arc`); installed on `AppState` as
+/// an extension by [`crate::SearchPlugin`].
+#[derive(Clone)]
+pub struct SearchClient {
+    inner: Arc<ClientInner>,
+}
+
+struct ClientInner {
+    backend: Arc<dyn SearchBackend>,
+    embedder: Arc<dyn Embedder>,
+    source: Option<Arc<dyn DocumentSource>>,
+    visibility: Option<Arc<dyn SearchVisibility>>,
+    indexes: BTreeMap<String, IndexDefinition>,
+    enabled: bool,
+}
+
+impl std::fmt::Debug for SearchClient {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SearchClient")
+            .field("backend", &self.inner.backend.name())
+            .field("indexes", &self.index_names())
+            .field("embedding_dimensions", &self.inner.embedder.dimensions())
+            .field("has_source", &self.inner.source.is_some())
+            .field("has_visibility", &self.inner.visibility.is_some())
+            .field("enabled", &self.inner.enabled)
+            .finish()
+    }
+}
+
+/// Builder for [`SearchClient`].
+#[derive(Default)]
+pub struct SearchClientBuilder {
+    backend: Option<Arc<dyn SearchBackend>>,
+    embedder: Option<Arc<dyn Embedder>>,
+    source: Option<Arc<dyn DocumentSource>>,
+    visibility: Option<Arc<dyn SearchVisibility>>,
+    indexes: BTreeMap<String, IndexDefinition>,
+    enabled: bool,
+}
+
+impl SearchClientBuilder {
+    /// Start a builder with no backend (defaults to in-memory) and no indexes.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            enabled: true,
+            ..Self::default()
+        }
+    }
+
+    /// Install the engine.
+    #[must_use]
+    pub fn backend(mut self, backend: Arc<dyn SearchBackend>) -> Self {
+        self.backend = Some(backend);
+        self
+    }
+
+    /// Install the embedding provider.
+    #[must_use]
+    pub fn embedder(mut self, embedder: Arc<dyn Embedder>) -> Self {
+        self.embedder = Some(embedder);
+        self
+    }
+
+    /// Install the record source used by reindex and backfill.
+    #[must_use]
+    pub fn source(mut self, source: Arc<dyn DocumentSource>) -> Self {
+        self.source = Some(source);
+        self
+    }
+
+    /// Install the authorization hook used by the `*_for` entry points.
+    #[must_use]
+    pub fn visibility(mut self, visibility: Arc<dyn SearchVisibility>) -> Self {
+        self.visibility = Some(visibility);
+        self
+    }
+
+    /// Register `M`'s index, derived from its `#[searchable]` attributes.
+    #[must_use]
+    pub fn index<M: SearchIndexed>(mut self) -> Self {
+        let definition = M::index_definition();
+        self.indexes.insert(definition.name.to_owned(), definition);
+        self
+    }
+
+    /// Register an index definition directly (for a non-`#[model]` corpus).
+    #[must_use]
+    pub fn index_definition(mut self, definition: IndexDefinition) -> Self {
+        self.indexes.insert(definition.name.to_owned(), definition);
+        self
+    }
+
+    /// Enable or disable the subsystem. When disabled, index writes are
+    /// no-ops and queries return empty pages.
+    #[must_use]
+    pub const fn enabled(mut self, enabled: bool) -> Self {
+        self.enabled = enabled;
+        self
+    }
+
+    /// Finish the client, defaulting the backend to in-memory and the embedder
+    /// to [`NoEmbedder`].
+    #[must_use]
+    pub fn build(self) -> SearchClient {
+        SearchClient {
+            inner: Arc::new(ClientInner {
+                backend: self
+                    .backend
+                    .unwrap_or_else(|| Arc::new(crate::memory::MemorySearchBackend::new())),
+                embedder: self.embedder.unwrap_or_else(|| Arc::new(NoEmbedder)),
+                source: self.source,
+                visibility: self.visibility,
+                indexes: self.indexes,
+                enabled: self.enabled,
+            }),
+        }
+    }
+}
+
+impl SearchClient {
+    /// Start building a client.
+    #[must_use]
+    pub fn builder() -> SearchClientBuilder {
+        SearchClientBuilder::new()
+    }
+
+    /// The installed backend.
+    #[must_use]
+    pub fn backend(&self) -> &Arc<dyn SearchBackend> {
+        &self.inner.backend
+    }
+
+    /// Whether the subsystem is enabled.
+    #[must_use]
+    pub fn is_enabled(&self) -> bool {
+        self.inner.enabled
+    }
+
+    /// Registered index names, sorted.
+    #[must_use]
+    pub fn index_names(&self) -> Vec<String> {
+        self.inner.indexes.keys().cloned().collect()
+    }
+
+    /// The definition registered under `name`.
+    #[must_use]
+    pub fn index_definition(&self, name: &str) -> Option<&IndexDefinition> {
+        self.inner.indexes.get(name)
+    }
+
+    fn definition(&self, name: &str) -> SearchResult<&IndexDefinition> {
+        self.inner
+            .indexes
+            .get(name)
+            .ok_or_else(|| SearchError::UnknownIndex(name.to_owned()))
+    }
+
+    /// Create or migrate storage for every registered index.
+    ///
+    /// Idempotent; run from the plugin's startup hook.
+    ///
+    /// # Errors
+    ///
+    /// Propagates the backend's failure, and rejects an index definition that
+    /// fails [`IndexDefinition::validate`].
+    pub async fn ensure_indexes(&self) -> SearchResult<()> {
+        for definition in self.inner.indexes.values() {
+            self.inner.backend.ensure_index(definition).await?;
+        }
+        Ok(())
+    }
+
+    // ── Indexing ────────────────────────────────────────────────────────────
+
+    /// Index (or re-index) one record.
+    ///
+    /// # Errors
+    ///
+    /// [`SearchError::UnknownIndex`] if the model's index is not registered,
+    /// plus any embedding or backend failure.
+    pub async fn index_record<M: SearchIndexed>(&self, record: &M) -> SearchResult<()> {
+        self.index_documents(M::SEARCH_INDEX, vec![record.search_document()])
+            .await
+    }
+
+    /// Index a batch of already-extracted documents.
+    ///
+    /// # Errors
+    ///
+    /// [`SearchError::UnknownIndex`], plus any embedding or backend failure.
+    pub async fn index_documents(
+        &self,
+        index: &str,
+        documents: Vec<SearchDocument>,
+    ) -> SearchResult<()> {
+        if !self.inner.enabled || documents.is_empty() {
+            return Ok(());
+        }
+        let definition = self.definition(index)?;
+        let prepared = self.embed_documents(documents).await?;
+        self.inner.backend.index(definition, &prepared).await
+    }
+
+    /// Remove one record from its index.
+    ///
+    /// # Errors
+    ///
+    /// [`SearchError::UnknownIndex`], plus any backend failure.
+    pub async fn remove<M: SearchIndexed>(&self, id: i64) -> SearchResult<()> {
+        self.remove_ids(M::SEARCH_INDEX, &[id]).await
+    }
+
+    /// Remove records by id.
+    ///
+    /// # Errors
+    ///
+    /// [`SearchError::UnknownIndex`], plus any backend failure.
+    pub async fn remove_ids(&self, index: &str, ids: &[i64]) -> SearchResult<()> {
+        if !self.inner.enabled || ids.is_empty() {
+            return Ok(());
+        }
+        let definition = self.definition(index)?;
+        self.inner.backend.delete(definition, ids).await
+    }
+
+    /// Attach embeddings to `documents` that declare `embed_text`.
+    ///
+    /// A zero-dimension embedder (the default [`NoEmbedder`]) means "no
+    /// embeddings configured": documents are indexed for keyword search and
+    /// simply carry no vector. Semantic queries then fail loudly at query
+    /// time, which is the right place to notice a missing provider — an app
+    /// that only wants keyword search should not have its writes fail.
+    async fn embed_documents(
+        &self,
+        documents: Vec<SearchDocument>,
+    ) -> SearchResult<Vec<IndexedDocument>> {
+        if self.inner.embedder.dimensions() == 0 {
+            return Ok(documents.into_iter().map(IndexedDocument::new).collect());
+        }
+
+        // One provider round-trip per batch, not per document.
+        let mut positions = Vec::new();
+        let mut texts = Vec::new();
+        for (position, document) in documents.iter().enumerate() {
+            if let Some(text) = &document.embed_text {
+                positions.push(position);
+                texts.push(text.clone());
+            }
+        }
+
+        let mut prepared: Vec<IndexedDocument> =
+            documents.into_iter().map(IndexedDocument::new).collect();
+        if texts.is_empty() {
+            return Ok(prepared);
+        }
+
+        let vectors = self.inner.embedder.embed(&texts).await?;
+        if vectors.len() != positions.len() {
+            return Err(SearchError::Embedding(format!(
+                "embedder returned {} vectors for {} inputs",
+                vectors.len(),
+                positions.len()
+            )));
+        }
+        for (position, vector) in positions.into_iter().zip(vectors) {
+            if let Some(document) = prepared.get_mut(position) {
+                document.embedding = Some(vector);
+            }
+        }
+        Ok(prepared)
+    }
+
+    // ── Keyword queries ─────────────────────────────────────────────────────
+
+    /// Ranked, paginated keyword search.
+    ///
+    /// # Errors
+    ///
+    /// [`SearchError::UnknownIndex`], plus any backend failure.
+    pub async fn search<M: SearchIndexed>(
+        &self,
+        query: &str,
+        request: &PageRequest,
+    ) -> SearchResult<Page<SearchHit>> {
+        self.search_filtered::<M>(query, request, SearchFilter::default())
+            .await
+    }
+
+    /// Keyword search with an explicit filter.
+    ///
+    /// The ambient tenant restriction is intersected in automatically, so a
+    /// caller-supplied filter can only narrow.
+    ///
+    /// # Errors
+    ///
+    /// [`SearchError::UnknownIndex`], plus any backend failure.
+    pub async fn search_filtered<M: SearchIndexed>(
+        &self,
+        query: &str,
+        request: &PageRequest,
+        filter: SearchFilter,
+    ) -> SearchResult<Page<SearchHit>> {
+        if !self.inner.enabled {
+            return Ok(empty_page(request));
+        }
+        let definition = self.definition(M::SEARCH_INDEX)?;
+        let filter = current_tenant_filter().intersect(filter);
+        let keyword = KeywordQuery::new(query, *request).filter(filter);
+        self.inner
+            .backend
+            .keyword_search(definition, &keyword)
+            .await
+    }
+
+    /// Keyword search driven by a request's [`ListQuery`] and [`PageRequest`],
+    /// so search drops into an existing index endpoint without a second
+    /// query-parameter vocabulary.
+    ///
+    /// `filter[...]` keys that name an indexed field (or the reserved
+    /// `tenant_id`) become exact-match predicates; unknown keys are **ignored**,
+    /// exactly as the generated `list()` ignores non-allowlisted keys. Sorting
+    /// is ignored: search results are relevance-ordered by definition.
+    ///
+    /// # Errors
+    ///
+    /// [`SearchError::UnknownIndex`], plus any backend failure.
+    pub async fn search_list<M: SearchIndexed>(
+        &self,
+        query: &str,
+        list: &ListQuery,
+        request: &PageRequest,
+    ) -> SearchResult<Page<SearchHit>> {
+        let definition = self.definition(M::SEARCH_INDEX)?;
+        let filter = filter_from_list_query(definition, list);
+        self.search_filtered::<M>(query, request, filter).await
+    }
+
+    /// Authorization-aware keyword search.
+    ///
+    /// # Errors
+    ///
+    /// [`SearchError::VisibilityUnavailable`] when no [`SearchVisibility`] is
+    /// registered — an authorization-aware search never silently runs
+    /// unfiltered — plus whatever the hook or the backend returns.
+    pub async fn search_for<M: SearchIndexed>(
+        &self,
+        ctx: &PolicyContext,
+        query: &str,
+        request: &PageRequest,
+    ) -> SearchResult<Page<SearchHit>> {
+        let filter = self.visibility_filter(ctx, M::SEARCH_INDEX).await?;
+        self.search_filtered::<M>(query, request, filter).await
+    }
+
+    /// Keyword search whose hits are turned back into records by `loader`.
+    ///
+    /// The loader receives the ranked ids and may return them in any order, or
+    /// omit records it cannot produce (deleted between search and load, or
+    /// filtered by its own authorization). The client re-applies the ranked
+    /// order and drops the gaps, and preserves the pre-hydration
+    /// `total_elements` so the pager stays consistent.
+    ///
+    /// # Errors
+    ///
+    /// Whatever `search` or `loader` returns.
+    pub async fn search_hydrated<M, F, Fut>(
+        &self,
+        query: &str,
+        request: &PageRequest,
+        loader: F,
+    ) -> SearchResult<Page<M>>
+    where
+        M: SearchIndexed,
+        F: FnOnce(Vec<i64>) -> Fut + Send,
+        Fut: Future<Output = SearchResult<Vec<M>>> + Send,
+    {
+        let hits = self.search::<M>(query, request).await?;
+        self.hydrate(hits, loader).await
+    }
+
+    /// Hydrate an already-fetched page of hits. See [`Self::search_hydrated`].
+    ///
+    /// # Errors
+    ///
+    /// Whatever `loader` returns.
+    pub async fn hydrate<M, F, Fut>(
+        &self,
+        hits: Page<SearchHit>,
+        loader: F,
+    ) -> SearchResult<Page<M>>
+    where
+        M: SearchIndexed,
+        F: FnOnce(Vec<i64>) -> Fut + Send,
+        Fut: Future<Output = SearchResult<Vec<M>>> + Send,
+    {
+        let order: Vec<i64> = hits.content.iter().map(|hit| hit.id).collect();
+        let records = loader(order.clone()).await?;
+
+        let mut by_id: BTreeMap<i64, M> = records
+            .into_iter()
+            .map(|record| (record.search_id(), record))
+            .collect();
+        let content: Vec<M> = order.iter().filter_map(|id| by_id.remove(id)).collect();
+
+        Ok(Page {
+            content,
+            page: hits.page,
+            size: hits.size,
+            total_elements: hits.total_elements,
+            total_pages: hits.total_pages,
+            has_next: hits.has_next,
+            has_previous: hits.has_previous,
+        })
+    }
+
+    // ── Vector queries ──────────────────────────────────────────────────────
+
+    /// The `limit` records most semantically similar to `text`.
+    ///
+    /// # Errors
+    ///
+    /// [`SearchError::EmbedderUnavailable`] when no embedding provider is
+    /// installed, [`SearchError::VectorUnsupported`] when the model declares
+    /// no `#[searchable(embed)]` field, plus any backend failure.
+    pub async fn similar<M: SearchIndexed>(
+        &self,
+        text: &str,
+        limit: usize,
+    ) -> SearchResult<Vec<SearchHit>> {
+        self.similar_filtered::<M>(text, limit, SearchFilter::default())
+            .await
+    }
+
+    /// [`Self::similar`] with an explicit filter.
+    ///
+    /// # Errors
+    ///
+    /// As [`Self::similar`].
+    pub async fn similar_filtered<M: SearchIndexed>(
+        &self,
+        text: &str,
+        limit: usize,
+        filter: SearchFilter,
+    ) -> SearchResult<Vec<SearchHit>> {
+        if !self.inner.enabled {
+            return Ok(Vec::new());
+        }
+        if self.inner.embedder.dimensions() == 0 {
+            return Err(SearchError::EmbedderUnavailable);
+        }
+        let vector = self
+            .inner
+            .embedder
+            .embed(std::slice::from_ref(&text.to_owned()))
+            .await?
+            .into_iter()
+            .next()
+            .ok_or_else(|| {
+                SearchError::Embedding("embedder returned no vector for the query".to_owned())
+            })?;
+        self.similar_to_vector::<M>(vector, limit, filter).await
+    }
+
+    /// Authorization-aware semantic search.
+    ///
+    /// # Errors
+    ///
+    /// [`SearchError::VisibilityUnavailable`] when no hook is registered, plus
+    /// whatever [`Self::similar`] returns.
+    pub async fn similar_for<M: SearchIndexed>(
+        &self,
+        ctx: &PolicyContext,
+        text: &str,
+        limit: usize,
+    ) -> SearchResult<Vec<SearchHit>> {
+        let filter = self.visibility_filter(ctx, M::SEARCH_INDEX).await?;
+        self.similar_filtered::<M>(text, limit, filter).await
+    }
+
+    /// Neighbours of an already-indexed record ("more like this").
+    ///
+    /// Reads the record's stored embedding rather than re-embedding it, and
+    /// excludes the record itself from its own neighbour list.
+    ///
+    /// # Errors
+    ///
+    /// [`SearchError::UnknownIndex`], [`SearchError::VectorUnsupported`], plus
+    /// any backend failure. A record with no stored embedding yields an empty
+    /// neighbour list rather than an error.
+    pub async fn similar_to<M: SearchIndexed>(
+        &self,
+        id: i64,
+        limit: usize,
+    ) -> SearchResult<Vec<SearchHit>> {
+        if !self.inner.enabled {
+            return Ok(Vec::new());
+        }
+        let definition = self.definition(M::SEARCH_INDEX)?;
+        let Some(vector) = self.inner.backend.embedding(definition, id).await? else {
+            return Ok(Vec::new());
+        };
+        self.similar_to_vector::<M>(vector, limit, SearchFilter::default().exclude_ids([id]))
+            .await
+    }
+
+    /// k-NN search against a caller-supplied vector.
+    ///
+    /// # Errors
+    ///
+    /// [`SearchError::UnknownIndex`], [`SearchError::VectorUnsupported`],
+    /// [`SearchError::DimensionMismatch`], plus any backend failure.
+    pub async fn similar_to_vector<M: SearchIndexed>(
+        &self,
+        vector: Vec<f32>,
+        limit: usize,
+        filter: SearchFilter,
+    ) -> SearchResult<Vec<SearchHit>> {
+        if !self.inner.enabled {
+            return Ok(Vec::new());
+        }
+        let definition = self.definition(M::SEARCH_INDEX)?;
+        let filter = current_tenant_filter().intersect(filter);
+        let query = VectorQuery::new(vector, limit).filter(filter);
+        self.inner.backend.vector_search(definition, &query).await
+    }
+
+    async fn visibility_filter(
+        &self,
+        ctx: &PolicyContext,
+        index: &str,
+    ) -> SearchResult<SearchFilter> {
+        let visibility = self
+            .inner
+            .visibility
+            .as_ref()
+            .ok_or(SearchError::VisibilityUnavailable)?;
+        visibility.filter(ctx, index).await
+    }
+
+    // ── Reindex & backfill ──────────────────────────────────────────────────
+
+    /// Apply one reindex instruction.
+    ///
+    /// This is the whole of index sync: an **upsert** re-reads the row and
+    /// writes it (or deletes the document when the row is gone), and a
+    /// **delete** removes the document without touching the source. Both are
+    /// idempotent, so at-least-once job delivery is safe, and both converge to
+    /// the same state whichever order they arrive in.
+    ///
+    /// # Errors
+    ///
+    /// [`SearchError::UnknownIndex`], [`SearchError::SourceUnavailable`] for
+    /// an upsert with no document source, plus any backend failure.
+    pub async fn reindex(&self, args: &ReindexArgs) -> SearchResult<()> {
+        let definition = self.definition(&args.index)?;
+        if !self.inner.enabled {
+            return Ok(());
+        }
+
+        if args.op == ReindexOp::Delete {
+            return self.inner.backend.delete(definition, &[args.id]).await;
+        }
+
+        let source = self
+            .inner
+            .source
+            .as_ref()
+            .ok_or(SearchError::SourceUnavailable)?;
+        let documents = source.fetch(definition, &[args.id]).await?;
+        if documents.is_empty() {
+            // The row is gone. Converge by removing the document — this is how
+            // a lost delete event, or a row removed by direct SQL, repairs
+            // itself.
+            return self.inner.backend.delete(definition, &[args.id]).await;
+        }
+        let prepared = self.embed_documents(documents).await?;
+        self.inner.backend.index(definition, &prepared).await
+    }
+
+    /// Rebuild one index from its document source.
+    ///
+    /// # Errors
+    ///
+    /// [`SearchError::UnknownIndex`], [`SearchError::SourceUnavailable`], plus
+    /// any backend failure.
+    pub async fn backfill(
+        &self,
+        index: &str,
+        options: &BackfillOptions,
+    ) -> SearchResult<BackfillReport> {
+        let definition = self.definition(index)?;
+        let source = self
+            .inner
+            .source
+            .as_ref()
+            .ok_or(SearchError::SourceUnavailable)?;
+
+        if options.purge {
+            self.inner.backend.clear(definition).await?;
+        }
+
+        let batch_size = options.effective_batch_size();
+        let mut report = BackfillReport {
+            index: index.to_owned(),
+            indexed: 0,
+            batches: 0,
+            purged: options.purge,
+        };
+        let mut after: Option<i64> = None;
+
+        loop {
+            let documents = source.scan(definition, after, batch_size).await?;
+            if documents.is_empty() {
+                break;
+            }
+            // Keyset cursor: the scan is ordered by ascending id, so the last
+            // row of the batch is where the next one resumes. Never `OFFSET`,
+            // which would skip rows as concurrent writes shift the window.
+            after = documents.last().map(|document| document.id);
+            let count = documents.len() as u64;
+
+            let prepared = self.embed_documents(documents).await?;
+            self.inner.backend.index(definition, &prepared).await?;
+
+            report.indexed += count;
+            report.batches += 1;
+
+            if usize::try_from(count).unwrap_or(usize::MAX) < batch_size {
+                break;
+            }
+        }
+
+        tracing::info!(
+            index = %report.index,
+            indexed = report.indexed,
+            batches = report.batches,
+            purged = report.purged,
+            "search backfill complete"
+        );
+        Ok(report)
+    }
+
+    /// Rebuild every registered index.
+    ///
+    /// # Errors
+    ///
+    /// As [`Self::backfill`], for the first index that fails.
+    pub async fn backfill_all(
+        &self,
+        options: &BackfillOptions,
+    ) -> SearchResult<Vec<BackfillReport>> {
+        let mut reports = Vec::new();
+        for index in self.index_names() {
+            reports.push(self.backfill(&index, options).await?);
+        }
+        Ok(reports)
+    }
+}
+
+/// Translate a request's `filter[...]` keys into a [`SearchFilter`].
+///
+/// Only keys naming an indexed field (or the reserved `tenant_id`) are
+/// applied; anything else is ignored, matching how the generated `list()`
+/// treats a non-allowlisted filter key. That is what lets one query string
+/// drive both endpoints.
+fn filter_from_list_query(definition: &IndexDefinition, list: &ListQuery) -> SearchFilter {
+    let mut filter = SearchFilter::default();
+    for (key, value) in list.filters() {
+        if key == TENANT_FILTER_KEY {
+            filter = filter.tenant(value);
+        } else if definition.field_names().any(|field| field == key) {
+            filter = filter.equals(key, value);
+        }
+    }
+    filter
+}
+
+#[cfg(test)]
+mod tests {
+    use autumn_web::pagination::SortDir;
+    use autumn_web::search::SearchIndexField;
+
+    use super::*;
+
+    const FIELDS: &[SearchIndexField] = &[
+        SearchIndexField::new("title", 'A'),
+        SearchIndexField::new("body", 'B'),
+    ];
+
+    fn definition() -> IndexDefinition {
+        IndexDefinition::new("articles", "english", FIELDS, Some("body"))
+    }
+
+    #[test]
+    fn list_query_filters_map_onto_indexed_fields() {
+        let list = ListQuery::new(None, SortDir::Asc, &[("title", "Hello")]);
+        let filter = filter_from_list_query(&definition(), &list);
+        assert_eq!(
+            filter.equals.get("title").map(String::as_str),
+            Some("Hello")
+        );
+    }
+
+    #[test]
+    fn the_reserved_tenant_key_becomes_a_tenant_restriction() {
+        let list = ListQuery::new(None, SortDir::Asc, &[("tenant_id", "acme")]);
+        let filter = filter_from_list_query(&definition(), &list);
+        assert_eq!(filter.tenant_id.as_deref(), Some("acme"));
+        assert!(filter.equals.is_empty());
+    }
+
+    #[test]
+    fn an_unknown_filter_key_is_ignored_like_list() {
+        let list = ListQuery::new(None, SortDir::Asc, &[("nope", "x")]);
+        let filter = filter_from_list_query(&definition(), &list);
+        assert_eq!(filter, SearchFilter::default());
+    }
+
+    #[test]
+    fn backfill_options_clamp_a_zero_batch_size() {
+        assert_eq!(
+            BackfillOptions::default()
+                .batch_size(0)
+                .effective_batch_size(),
+            DEFAULT_BACKFILL_BATCH
+        );
+        assert_eq!(
+            BackfillOptions::default()
+                .batch_size(7)
+                .effective_batch_size(),
+            7
+        );
+    }
+
+    #[test]
+    fn a_client_defaults_to_the_memory_backend_and_no_embedder() {
+        let client = SearchClient::builder().build();
+        assert_eq!(client.backend().name(), "memory");
+        assert!(client.is_enabled());
+        assert!(client.index_names().is_empty());
+    }
+}

--- a/autumn-search/src/client.rs
+++ b/autumn-search/src/client.rs
@@ -274,6 +274,18 @@ impl SearchClient {
         self.inner.batch_size
     }
 
+    /// Width of the vectors the installed [`Embedder`] produces.
+    ///
+    /// `0` means no usable embedder is installed (the default
+    /// [`NoEmbedder`](crate::NoEmbedder)), so nothing vector-shaped will run.
+    /// Exposed so a host can check it against the width its backend was
+    /// configured for **before** serving traffic, rather than discovering the
+    /// disagreement as an empty result page.
+    #[must_use]
+    pub fn embedding_dimensions(&self) -> usize {
+        self.inner.embedder.dimensions()
+    }
+
     /// Registered index names, sorted.
     #[must_use]
     pub fn index_names(&self) -> Vec<String> {

--- a/autumn-search/src/client.rs
+++ b/autumn-search/src/client.rs
@@ -878,9 +878,14 @@ impl SearchClient {
             report.indexed += count;
             report.batches += 1;
 
-            if usize::try_from(count).unwrap_or(usize::MAX) < batch_size {
-                break;
-            }
+            // No early exit on a short batch. `DocumentSource::scan` returns
+            // **up to** `limit` documents, so a short-but-non-empty batch does
+            // not mean the source is exhausted — a custom source that filters
+            // after reading, or reads a fixed page and drops soft-deleted
+            // rows, legitimately returns fewer. Stopping there would silently
+            // truncate the rebuild at that batch and report success. An empty
+            // batch is the only end-of-source signal, at the cost of one extra
+            // scan per backfill.
         }
 
         tracing::info!(

--- a/autumn-search/src/client.rs
+++ b/autumn-search/src/client.rs
@@ -492,6 +492,13 @@ impl SearchClient {
         query: &str,
         request: &PageRequest,
     ) -> SearchResult<Page<SearchHit>> {
+        // Checked before the hook: with search off there is nothing to
+        // authorize, and a missing or failing `SearchVisibility` must not turn
+        // the documented empty page into an error. Otherwise the kill switch
+        // would be ineffective on exactly the endpoints that use it.
+        if !self.inner.enabled {
+            return Ok(empty_page(request));
+        }
         let filter = self.visibility_filter(ctx, M::SEARCH_INDEX).await?;
         self.search_filtered::<M>(query, request, filter).await
     }
@@ -626,6 +633,9 @@ impl SearchClient {
         text: &str,
         limit: usize,
     ) -> SearchResult<Vec<SearchHit>> {
+        if !self.inner.enabled {
+            return Ok(Vec::new());
+        }
         let filter = self.visibility_filter(ctx, M::SEARCH_INDEX).await?;
         self.similar_filtered::<M>(text, limit, filter).await
     }
@@ -672,6 +682,9 @@ impl SearchClient {
         id: i64,
         limit: usize,
     ) -> SearchResult<Vec<SearchHit>> {
+        if !self.inner.enabled {
+            return Ok(Vec::new());
+        }
         let filter = self.visibility_filter(ctx, M::SEARCH_INDEX).await?;
         self.similar_to_filtered::<M>(id, limit, filter).await
     }

--- a/autumn-search/src/client.rs
+++ b/autumn-search/src/client.rs
@@ -743,16 +743,29 @@ impl SearchClient {
 
     /// Apply one reindex instruction.
     ///
-    /// This is the whole of index sync: an **upsert** re-reads the row and
-    /// writes it (or deletes the document when the row is gone), and a
-    /// **delete** removes the document without touching the source. Both are
-    /// idempotent, so at-least-once job delivery is safe, and both converge to
-    /// the same state whichever order they arrive in.
+    /// This is the whole of index sync, and **both** operations do the same
+    /// thing: re-read the row and make the index agree. Present ⇒ upsert;
+    /// absent (hard-deleted, or soft-deleted and therefore filtered out by the
+    /// source) ⇒ remove the document.
+    ///
+    /// Convergence is why the delete op re-reads too, rather than deleting
+    /// unconditionally. Consider a record deleted and then re-created under the
+    /// same primary key: a delete job that retries, or simply arrives after the
+    /// re-create's upsert already ran, would otherwise remove a live record and
+    /// leave it missing until some later mutation. Because both ops are
+    /// "converge this id", **any** order and any duplication of instructions
+    /// reaches the same state — which is what makes at-least-once delivery and
+    /// the `(index, id)` dedup key safe.
+    ///
+    /// [`ReindexOp`] survives as intent, and as the one place the two paths
+    /// differ: with no [`crate::DocumentSource`] installed there is nothing to
+    /// re-read, so a delete still removes the document (it needs no source)
+    /// while an upsert reports [`SearchError::SourceUnavailable`].
     ///
     /// # Errors
     ///
-    /// [`SearchError::UnknownIndex`], [`SearchError::SourceUnavailable`] for
-    /// an upsert with no document source, plus any backend failure.
+    /// [`SearchError::UnknownIndex`], [`SearchError::SourceUnavailable`] for an
+    /// upsert with no document source, plus any backend failure.
     pub async fn reindex(&self, args: &ReindexArgs) -> SearchResult<()> {
         // Checked FIRST: with search disabled, an in-flight job for an index
         // the app no longer registers must no-op, not fail five times and
@@ -762,20 +775,20 @@ impl SearchClient {
         }
         let definition = self.definition(&args.index)?;
 
-        if args.op == ReindexOp::Delete {
-            return self.inner.backend.delete(definition, &[args.id]).await;
-        }
+        let Some(source) = self.inner.source.as_ref() else {
+            return match args.op {
+                // A delete needs no source: "not in the index" is reachable
+                // without knowing anything about the row.
+                ReindexOp::Delete => self.inner.backend.delete(definition, &[args.id]).await,
+                ReindexOp::Upsert => Err(SearchError::SourceUnavailable),
+            };
+        };
 
-        let source = self
-            .inner
-            .source
-            .as_ref()
-            .ok_or(SearchError::SourceUnavailable)?;
         let documents = source.fetch(definition, &[args.id]).await?;
         if documents.is_empty() {
             // The row is gone. Converge by removing the document — this is how
-            // a lost delete event, or a row removed by direct SQL, repairs
-            // itself.
+            // a lost delete event, a soft delete, or a row removed by direct
+            // SQL repairs itself.
             return self.inner.backend.delete(definition, &[args.id]).await;
         }
         let prepared = self.embed_documents(documents).await?;

--- a/autumn-search/src/client.rs
+++ b/autumn-search/src/client.rs
@@ -22,7 +22,7 @@ use autumn_web::authorization::PolicyContext;
 use autumn_web::pagination::{ListQuery, Page, PageRequest};
 use autumn_web::search::{IndexDefinition, SearchDocument, SearchIndexed};
 
-use crate::authz::{SearchVisibility, current_tenant_filter};
+use crate::authz::{SearchVisibility, ambient_tenant_filter};
 use crate::backend::{
     IndexedDocument, KeywordQuery, SearchBackend, SearchFilter, SearchHit, TENANT_FILTER_KEY,
     VectorQuery, empty_page,
@@ -120,6 +120,7 @@ struct ClientInner {
     visibility: Option<Arc<dyn SearchVisibility>>,
     indexes: BTreeMap<String, IndexDefinition>,
     enabled: bool,
+    batch_size: usize,
 }
 
 impl std::fmt::Debug for SearchClient {
@@ -144,6 +145,7 @@ pub struct SearchClientBuilder {
     visibility: Option<Arc<dyn SearchVisibility>>,
     indexes: BTreeMap<String, IndexDefinition>,
     enabled: bool,
+    batch_size: usize,
 }
 
 impl SearchClientBuilder {
@@ -152,6 +154,7 @@ impl SearchClientBuilder {
     pub fn new() -> Self {
         Self {
             enabled: true,
+            batch_size: DEFAULT_BACKFILL_BATCH,
             ..Self::default()
         }
     }
@@ -192,7 +195,14 @@ impl SearchClientBuilder {
         self
     }
 
-    /// Register an index definition directly (for a non-`#[model]` corpus).
+    /// Register an index definition directly, for a corpus that is not a
+    /// `#[model]` — or to adjust a derived one (clearing `tenant_scoped` on a
+    /// model whose `tenant_id` column is not a tenant, say).
+    ///
+    /// A genuinely non-model corpus also needs its own
+    /// [`crate::DocumentSource`]: the shipped Postgres source projects
+    /// `FROM "<index name>"` and expects an `id` column plus a real column per
+    /// indexed field.
     #[must_use]
     pub fn index_definition(mut self, definition: IndexDefinition) -> Self {
         self.indexes.insert(definition.name.to_owned(), definition);
@@ -204,6 +214,18 @@ impl SearchClientBuilder {
     #[must_use]
     pub const fn enabled(mut self, enabled: bool) -> Self {
         self.enabled = enabled;
+        self
+    }
+
+    /// Default rows per backfill batch, used when a backfill request does not
+    /// name its own. `0` is clamped to the built-in default.
+    #[must_use]
+    pub const fn batch_size(mut self, batch_size: usize) -> Self {
+        self.batch_size = if batch_size == 0 {
+            DEFAULT_BACKFILL_BATCH
+        } else {
+            batch_size
+        };
         self
     }
 
@@ -221,6 +243,7 @@ impl SearchClientBuilder {
                 visibility: self.visibility,
                 indexes: self.indexes,
                 enabled: self.enabled,
+                batch_size: self.batch_size,
             }),
         }
     }
@@ -243,6 +266,12 @@ impl SearchClient {
     #[must_use]
     pub fn is_enabled(&self) -> bool {
         self.inner.enabled
+    }
+
+    /// Configured default rows per backfill batch (`[search] batch_size`).
+    #[must_use]
+    pub fn default_batch_size(&self) -> usize {
+        self.inner.batch_size
     }
 
     /// Registered index names, sorted.
@@ -413,7 +442,7 @@ impl SearchClient {
             return Ok(empty_page(request));
         }
         let definition = self.definition(M::SEARCH_INDEX)?;
-        let filter = current_tenant_filter().intersect(filter);
+        let filter = ambient_tenant_filter(definition)?.intersect(filter);
         let keyword = KeywordQuery::new(query, *request).filter(filter);
         self.inner
             .backend
@@ -439,6 +468,12 @@ impl SearchClient {
         list: &ListQuery,
         request: &PageRequest,
     ) -> SearchResult<Page<SearchHit>> {
+        // Checked before resolving the index so a disabled client behaves the
+        // same here as in `search` (an empty page), rather than surfacing an
+        // `UnknownIndex` for an index it was never going to query.
+        if !self.inner.enabled {
+            return Ok(empty_page(request));
+        }
         let definition = self.definition(M::SEARCH_INDEX)?;
         let filter = filter_from_list_query(definition, list);
         self.search_filtered::<M>(query, request, filter).await
@@ -464,10 +499,18 @@ impl SearchClient {
     /// Keyword search whose hits are turned back into records by `loader`.
     ///
     /// The loader receives the ranked ids and may return them in any order, or
-    /// omit records it cannot produce (deleted between search and load, or
-    /// filtered by its own authorization). The client re-applies the ranked
-    /// order and drops the gaps, and preserves the pre-hydration
-    /// `total_elements` so the pager stays consistent.
+    /// omit records that vanished between the search and the load. The client
+    /// re-applies the ranked order and drops the gaps.
+    ///
+    /// # The loader is a hydrator, not an authorization boundary
+    ///
+    /// Authorize with [`Self::search_for`] and a registered
+    /// [`SearchVisibility`], which restricts the query itself. Dropping
+    /// records in the loader instead leaves a **count oracle**: the caller
+    /// still learns how many records matched. To blunt that, every record the
+    /// loader omits is also subtracted from `total_elements` — but the totals
+    /// then only approximate the current page, so this is damage limitation,
+    /// not a substitute for filtering the query.
     ///
     /// # Errors
     ///
@@ -503,23 +546,24 @@ impl SearchClient {
         Fut: Future<Output = SearchResult<Vec<M>>> + Send,
     {
         let order: Vec<i64> = hits.content.iter().map(|hit| hit.id).collect();
+        let request = PageRequest::new(hits.page, hits.size);
         let records = loader(order.clone()).await?;
 
+        // Keyed by id, so a loader that returns duplicates cannot produce a
+        // page longer than the ranked set — and the ranked order wins over
+        // whatever order the loader used.
         let mut by_id: BTreeMap<i64, M> = records
             .into_iter()
             .map(|record| (record.search_id(), record))
             .collect();
         let content: Vec<M> = order.iter().filter_map(|id| by_id.remove(id)).collect();
 
-        Ok(Page {
-            content,
-            page: hits.page,
-            size: hits.size,
-            total_elements: hits.total_elements,
-            total_pages: hits.total_pages,
-            has_next: hits.has_next,
-            has_previous: hits.has_previous,
-        })
+        // Subtract what the loader could not produce, so the pager does not
+        // advertise records the caller never received.
+        let dropped = u64::try_from(order.len().saturating_sub(content.len())).unwrap_or(0);
+        let total = i64::try_from(hits.total_elements.saturating_sub(dropped)).unwrap_or(i64::MAX);
+
+        Ok(Page::new(content, total, &request))
     }
 
     // ── Vector queries ──────────────────────────────────────────────────────
@@ -591,24 +635,73 @@ impl SearchClient {
     /// Reads the record's stored embedding rather than re-embedding it, and
     /// excludes the record itself from its own neighbour list.
     ///
+    /// The **seed read is filtered too**. `id` is caller-supplied, so an
+    /// unfiltered read would be an inference channel: the caller could rank
+    /// their own probe documents against a record they are not allowed to see,
+    /// and learn both that it exists and roughly what it says. A seed the
+    /// filter excludes reads back as absent, so the result is an empty
+    /// neighbour list — exactly as if the record were not indexed.
+    ///
     /// # Errors
     ///
-    /// [`SearchError::UnknownIndex`], [`SearchError::VectorUnsupported`], plus
-    /// any backend failure. A record with no stored embedding yields an empty
-    /// neighbour list rather than an error.
+    /// [`SearchError::UnknownIndex`], [`SearchError::VectorUnsupported`],
+    /// [`SearchError::TenantContextMissing`], plus any backend failure. A
+    /// record with no stored embedding yields an empty neighbour list rather
+    /// than an error.
     pub async fn similar_to<M: SearchIndexed>(
         &self,
         id: i64,
         limit: usize,
     ) -> SearchResult<Vec<SearchHit>> {
+        self.similar_to_filtered::<M>(id, limit, SearchFilter::default())
+            .await
+    }
+
+    /// Authorization-aware "more like this".
+    ///
+    /// The registered [`SearchVisibility`] gates **both** the seed read and
+    /// the neighbour query, so this is not a back door around `search_for`.
+    ///
+    /// # Errors
+    ///
+    /// [`SearchError::VisibilityUnavailable`] when no hook is registered, plus
+    /// whatever [`Self::similar_to`] returns.
+    pub async fn similar_to_for<M: SearchIndexed>(
+        &self,
+        ctx: &PolicyContext,
+        id: i64,
+        limit: usize,
+    ) -> SearchResult<Vec<SearchHit>> {
+        let filter = self.visibility_filter(ctx, M::SEARCH_INDEX).await?;
+        self.similar_to_filtered::<M>(id, limit, filter).await
+    }
+
+    /// [`Self::similar_to`] with an explicit filter applied to the seed read
+    /// and the neighbour query alike.
+    ///
+    /// # Errors
+    ///
+    /// As [`Self::similar_to`].
+    pub async fn similar_to_filtered<M: SearchIndexed>(
+        &self,
+        id: i64,
+        limit: usize,
+        filter: SearchFilter,
+    ) -> SearchResult<Vec<SearchHit>> {
         if !self.inner.enabled {
             return Ok(Vec::new());
         }
         let definition = self.definition(M::SEARCH_INDEX)?;
-        let Some(vector) = self.inner.backend.embedding(definition, id).await? else {
+        let seed_filter = ambient_tenant_filter(definition)?.intersect(filter.clone());
+        let Some(vector) = self
+            .inner
+            .backend
+            .embedding(definition, id, &seed_filter)
+            .await?
+        else {
             return Ok(Vec::new());
         };
-        self.similar_to_vector::<M>(vector, limit, SearchFilter::default().exclude_ids([id]))
+        self.similar_to_vector::<M>(vector, limit, filter.exclude_ids([id]))
             .await
     }
 
@@ -628,7 +721,7 @@ impl SearchClient {
             return Ok(Vec::new());
         }
         let definition = self.definition(M::SEARCH_INDEX)?;
-        let filter = current_tenant_filter().intersect(filter);
+        let filter = ambient_tenant_filter(definition)?.intersect(filter);
         let query = VectorQuery::new(vector, limit).filter(filter);
         self.inner.backend.vector_search(definition, &query).await
     }
@@ -661,10 +754,13 @@ impl SearchClient {
     /// [`SearchError::UnknownIndex`], [`SearchError::SourceUnavailable`] for
     /// an upsert with no document source, plus any backend failure.
     pub async fn reindex(&self, args: &ReindexArgs) -> SearchResult<()> {
-        let definition = self.definition(&args.index)?;
+        // Checked FIRST: with search disabled, an in-flight job for an index
+        // the app no longer registers must no-op, not fail five times and
+        // dead-letter.
         if !self.inner.enabled {
             return Ok(());
         }
+        let definition = self.definition(&args.index)?;
 
         if args.op == ReindexOp::Delete {
             return self.inner.backend.delete(definition, &[args.id]).await;
@@ -697,6 +793,16 @@ impl SearchClient {
         index: &str,
         options: &BackfillOptions,
     ) -> SearchResult<BackfillReport> {
+        if !self.inner.enabled {
+            // The incident kill switch must stop writes, and a `purge`
+            // backfill is the most destructive write there is.
+            return Ok(BackfillReport {
+                index: index.to_owned(),
+                indexed: 0,
+                batches: 0,
+                purged: false,
+            });
+        }
         let definition = self.definition(index)?;
         let source = self
             .inner
@@ -797,7 +903,7 @@ mod tests {
     ];
 
     fn definition() -> IndexDefinition {
-        IndexDefinition::new("articles", "english", FIELDS, Some("body"))
+        IndexDefinition::new("articles", "english", FIELDS, Some("body"), false)
     }
 
     #[test]

--- a/autumn-search/src/client.rs
+++ b/autumn-search/src/client.rs
@@ -137,7 +137,6 @@ impl std::fmt::Debug for SearchClient {
 }
 
 /// Builder for [`SearchClient`].
-#[derive(Default)]
 pub struct SearchClientBuilder {
     backend: Option<Arc<dyn SearchBackend>>,
     embedder: Option<Arc<dyn Embedder>>,
@@ -148,15 +147,30 @@ pub struct SearchClientBuilder {
     batch_size: usize,
 }
 
+/// Hand-written rather than derived: a derived `Default` would give
+/// `enabled: false` and `batch_size: 0`, so the public
+/// `SearchClientBuilder::default()` would build a client that silently
+/// indexes nothing and backfills in batches of zero. `default()` and
+/// [`SearchClientBuilder::new`] must agree.
+impl Default for SearchClientBuilder {
+    fn default() -> Self {
+        Self {
+            backend: None,
+            embedder: None,
+            source: None,
+            visibility: None,
+            indexes: BTreeMap::new(),
+            enabled: true,
+            batch_size: DEFAULT_BACKFILL_BATCH,
+        }
+    }
+}
+
 impl SearchClientBuilder {
     /// Start a builder with no backend (defaults to in-memory) and no indexes.
     #[must_use]
     pub fn new() -> Self {
-        Self {
-            enabled: true,
-            batch_size: DEFAULT_BACKFILL_BATCH,
-            ..Self::default()
-        }
+        Self::default()
     }
 
     /// Install the engine.
@@ -999,6 +1013,20 @@ mod tests {
         let list = ListQuery::new(None, SortDir::Asc, &[("nope", "x")]);
         let filter = filter_from_list_query(&definition(), &list);
         assert_eq!(filter, SearchFilter::default());
+    }
+
+    #[test]
+    fn a_default_builder_matches_a_new_one() {
+        // `SearchClientBuilder` is public API, so `default()` is a reachable
+        // entry point. A derived `Default` would hand back `enabled: false`
+        // and `batch_size: 0` — a silently dead client whose backfills all
+        // request zero rows.
+        let client = SearchClientBuilder::default().build();
+        assert!(
+            client.is_enabled(),
+            "a default builder must not be disabled"
+        );
+        assert_eq!(client.default_batch_size(), DEFAULT_BACKFILL_BATCH);
     }
 
     #[test]

--- a/autumn-search/src/config.rs
+++ b/autumn-search/src/config.rs
@@ -141,7 +141,23 @@ impl SearchConfig {
     /// be read or parsed, when the merged `[search]` table has an unknown or
     /// ill-typed key, or when a value is out of range.
     pub fn resolve() -> Result<Self, SearchConfigError> {
-        Self::resolve_with_env(&autumn_web::config::OsEnv)
+        // The OS environment **overlaid with `.env`**, not `OsEnv` alone.
+        //
+        // Core's loader reads `.env`, `.env.local`, `.env.<profile>` into an
+        // overlay `Env` and deliberately does NOT export them into the process
+        // environment. A resolver built on `OsEnv` therefore cannot see them
+        // at all — so `AUTUMN_SEARCH__ENABLED=false` in a project `.env`, the
+        // most ordinary way to set it in development, would leave search on
+        // while every other framework setting in the same file took effect.
+        //
+        // A `.env` that exists but cannot be read or parsed falls back to the
+        // real environment rather than failing the whole resolution: core
+        // surfaces that error on its own path, and search refusing to boot
+        // over it would be a second, more confusing report of one problem.
+        autumn_web::dotenv::os_env_with_dotenv().map_or_else(
+            |_| Self::resolve_with_env(&autumn_web::config::OsEnv),
+            |env| Self::resolve_with_env(&env),
+        )
     }
 
     /// Pure core of [`resolve`](Self::resolve): build the effective `[search]`
@@ -155,7 +171,9 @@ impl SearchConfig {
     ///    canonical spelling wins),
     /// 3. `autumn-<profile>.toml` `[search]` (first existing file in the
     ///    shared [`profile_override_file_lookup_names`] order wins),
-    /// 4. `AUTUMN_SEARCH__*` environment overrides.
+    /// 4. `AUTUMN_SEARCH__*` environment overrides — including values from the
+    ///    project's `.env` files, which core overlays onto the environment
+    ///    without exporting them into the process.
     ///
     /// Reading only layer 1 — which is what a naive plugin loader does — means
     /// `enabled = false` set under `[profile.prod.search]` is silently ignored

--- a/autumn-search/src/config.rs
+++ b/autumn-search/src/config.rs
@@ -1,0 +1,197 @@
+//! The plugin-owned `[search]` section of `autumn.toml`.
+
+use serde::{Deserialize, Serialize};
+
+/// Configuration for the search subsystem.
+///
+/// ```toml
+/// [search]
+/// queue = "search"            # the #[job] queue reindex/backfill run on
+/// batch_size = 500            # rows per backfill batch
+/// enabled = true              # false ⇒ index writes become no-ops
+/// embedding_dimensions = 768  # declared width; enables the pgvector fast path
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SearchConfig {
+    /// Named `#[job]` queue the reindex and backfill jobs are routed to.
+    ///
+    /// A dedicated queue by default: indexing is bulk, off-request work that
+    /// should never head-of-line-block a user-visible job.
+    #[serde(default = "default_queue")]
+    pub queue: String,
+
+    /// Rows read (and documents written) per backfill batch.
+    #[serde(default = "default_batch_size")]
+    pub batch_size: usize,
+
+    /// When `false`, index writes become no-ops and queries return empty
+    /// pages. The kill switch for an incident: turning search off must not
+    /// require a deploy, and must not start failing writes to the model.
+    #[serde(default = "default_enabled")]
+    pub enabled: bool,
+
+    /// Declared embedding width.
+    ///
+    /// Optional: the in-memory backend infers it from the vectors it is given.
+    /// The Postgres backend needs it to declare a `pgvector` column, so
+    /// setting it is what enables the accelerated k-NN path; without it,
+    /// vectors fall back to a portable `double precision[]` column.
+    #[serde(default)]
+    pub embedding_dimensions: Option<usize>,
+}
+
+fn default_queue() -> String {
+    "search".to_owned()
+}
+
+const fn default_batch_size() -> usize {
+    500
+}
+
+const fn default_enabled() -> bool {
+    true
+}
+
+impl Default for SearchConfig {
+    fn default() -> Self {
+        Self {
+            queue: default_queue(),
+            batch_size: default_batch_size(),
+            enabled: default_enabled(),
+            embedding_dimensions: None,
+        }
+    }
+}
+
+/// Why a `[search]` section was rejected.
+#[derive(Debug, thiserror::Error)]
+pub enum SearchConfigError {
+    /// The TOML did not parse, or `[search]` had an unknown/ill-typed key.
+    #[error("invalid [search] configuration: {0}")]
+    Invalid(String),
+}
+
+impl SearchConfig {
+    /// Parse the `[search]` table out of an `autumn.toml` document.
+    ///
+    /// A missing section yields the defaults. An unknown key is an **error**,
+    /// not a warning: a typo'd `queu = "indexing"` would otherwise silently
+    /// leave indexing on the default queue with no signal at all.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SearchConfigError::Invalid`] when the document does not
+    /// parse, when `[search]` has an unknown or ill-typed key, or when a value
+    /// is out of range.
+    pub fn from_autumn_toml(contents: &str) -> Result<Self, SearchConfigError> {
+        #[derive(Deserialize)]
+        struct Document {
+            #[serde(default)]
+            search: Option<SearchConfig>,
+        }
+
+        let document: Document =
+            toml_from_str(contents).map_err(|e| SearchConfigError::Invalid(e.to_string()))?;
+        let config = document.search.unwrap_or_default();
+        config.validate()?;
+        Ok(config)
+    }
+
+    /// Reject values that would misbehave at runtime.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SearchConfigError::Invalid`] for a zero batch size, an empty
+    /// queue name, or a zero embedding width.
+    pub fn validate(&self) -> Result<(), SearchConfigError> {
+        if self.batch_size == 0 {
+            return Err(SearchConfigError::Invalid(
+                "search.batch_size must be at least 1".to_owned(),
+            ));
+        }
+        if self.queue.trim().is_empty() {
+            return Err(SearchConfigError::Invalid(
+                "search.queue must not be empty".to_owned(),
+            ));
+        }
+        if self.embedding_dimensions == Some(0) {
+            return Err(SearchConfigError::Invalid(
+                "search.embedding_dimensions must be at least 1".to_owned(),
+            ));
+        }
+        Ok(())
+    }
+}
+
+/// `toml::from_str` behind a helper so the dependency edge is in one place.
+fn toml_from_str<T: serde::de::DeserializeOwned>(contents: &str) -> Result<T, toml::de::Error> {
+    toml::from_str(contents)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn defaults_route_indexing_to_its_own_queue() {
+        let config = SearchConfig::default();
+        assert_eq!(config.queue, "search");
+        assert_eq!(config.batch_size, 500);
+        assert!(config.enabled);
+        assert_eq!(config.embedding_dimensions, None);
+    }
+
+    #[test]
+    fn a_partial_section_keeps_the_other_defaults() {
+        let config =
+            SearchConfig::from_autumn_toml("[search]\nqueue = \"indexing\"\n").expect("parse");
+        assert_eq!(config.queue, "indexing");
+        assert_eq!(config.batch_size, 500);
+        assert!(config.enabled);
+    }
+
+    #[test]
+    fn an_unrelated_document_yields_the_defaults() {
+        assert_eq!(
+            SearchConfig::from_autumn_toml("[server]\nport = 3000\n").expect("parse"),
+            SearchConfig::default()
+        );
+        assert_eq!(
+            SearchConfig::from_autumn_toml("").expect("parse"),
+            SearchConfig::default()
+        );
+    }
+
+    #[test]
+    fn a_typo_is_an_error_rather_than_a_silent_default() {
+        assert!(SearchConfig::from_autumn_toml("[search]\nqueu = \"x\"\n").is_err());
+    }
+
+    #[test]
+    fn out_of_range_values_are_rejected() {
+        assert!(SearchConfig::from_autumn_toml("[search]\nbatch_size = 0\n").is_err());
+        assert!(SearchConfig::from_autumn_toml("[search]\nqueue = \"\"\n").is_err());
+        assert!(SearchConfig::from_autumn_toml("[search]\nembedding_dimensions = 0\n").is_err());
+    }
+
+    #[test]
+    fn an_ill_typed_value_is_rejected() {
+        assert!(SearchConfig::from_autumn_toml("[search]\nbatch_size = \"lots\"\n").is_err());
+    }
+
+    #[test]
+    fn round_trips_through_toml() {
+        let config = SearchConfig {
+            queue: "indexing".to_owned(),
+            batch_size: 42,
+            enabled: false,
+            embedding_dimensions: Some(768),
+        };
+        let document = format!("[search]\n{}", toml::to_string(&config).expect("serialize"));
+        assert_eq!(
+            SearchConfig::from_autumn_toml(&document).expect("parse"),
+            config
+        );
+    }
+}

--- a/autumn-search/src/config.rs
+++ b/autumn-search/src/config.rs
@@ -1,8 +1,8 @@
 //! The plugin-owned `[search]` section of `autumn.toml`.
 
-use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
+use autumn_web::config::Env;
 use serde::{Deserialize, Serialize};
 
 /// Configuration for the search subsystem.
@@ -141,7 +141,7 @@ impl SearchConfig {
     /// be read or parsed, when the merged `[search]` table has an unknown or
     /// ill-typed key, or when a value is out of range.
     pub fn resolve() -> Result<Self, SearchConfigError> {
-        Self::resolve_with_env(&std::env::vars().collect())
+        Self::resolve_with_env(&autumn_web::config::OsEnv)
     }
 
     /// Pure core of [`resolve`](Self::resolve): build the effective `[search]`
@@ -167,6 +167,16 @@ impl SearchConfig {
     /// then the working directory, exactly as core's `find_config_file_named`
     /// does — so the plugin reads the same files the host runtime does.
     ///
+    /// `env` is core's [`Env`](autumn_web::config::Env) abstraction, **not** a
+    /// snapshot of `std::env::vars()`. That distinction is load-bearing:
+    /// [`OsEnv`](autumn_web::config::OsEnv) synthesizes `AUTUMN_MANIFEST_DIR`
+    /// and `AUTUMN_IS_DEBUG` from the `#[autumn_web::main]` macro context, and
+    /// neither is a real process variable. Reading the raw process environment
+    /// instead means a release binary launched with no explicit selector is
+    /// seen as `dev` here while core resolves `prod` — so `[profile.prod]`
+    /// would be skipped — and the app's crate directory is invisible, so a
+    /// binary run from anywhere but the crate root misses its own config.
+    ///
     /// [`profile_override_file_lookup_names`]: autumn_web::config::profile_override_file_lookup_names
     ///
     /// # Errors
@@ -174,7 +184,7 @@ impl SearchConfig {
     /// Returns [`SearchConfigError::Invalid`] when a contributing file cannot
     /// be read or parsed, when the merged `[search]` table has an unknown or
     /// ill-typed key, or when a value is out of range.
-    pub fn resolve_with_env(env: &HashMap<String, String>) -> Result<Self, SearchConfigError> {
+    pub fn resolve_with_env(env: &dyn Env) -> Result<Self, SearchConfigError> {
         let (selected_input, canonical) = resolve_active_profile(env);
         let mut merged = toml::Value::Table(toml::map::Map::new());
 
@@ -218,7 +228,7 @@ impl SearchConfig {
     /// An unparseable value is **ignored** rather than fatal, matching core's
     /// own `apply_env_overrides`: a malformed env var must not take down a
     /// process that would otherwise boot on its file config.
-    fn apply_env_overrides(&mut self, env: &HashMap<String, String>) {
+    fn apply_env_overrides(&mut self, env: &dyn Env) {
         if let Some(queue) = env_trimmed(env, "AUTUMN_SEARCH__QUEUE") {
             self.queue = queue;
         }
@@ -273,11 +283,11 @@ fn toml_from_str<T: serde::de::DeserializeOwned>(contents: &str) -> Result<T, to
 }
 
 /// Non-blank env value (a blank value reads as unset, as core treats it).
-fn env_trimmed(env: &HashMap<String, String>, key: &str) -> Option<String> {
-    env.get(key)
-        .map(|value| value.trim())
+fn env_trimmed(env: &dyn Env, key: &str) -> Option<String> {
+    env.var(key)
+        .ok()
+        .map(|value| value.trim().to_owned())
         .filter(|value| !value.is_empty())
-        .map(ToOwned::to_owned)
 }
 
 /// The `(selected spelling, canonical name)` of the active profile.
@@ -286,7 +296,7 @@ fn env_trimmed(env: &HashMap<String, String>, key: &str) -> Option<String> {
 /// `--profile` → `AUTUMN_IS_DEBUG=0` ⇒ `prod` → `dev`. Both halves are needed
 /// because the override-file lookup prefers the spelling that was actually
 /// selected (`autumn-production.toml` vs `autumn-prod.toml`).
-fn resolve_active_profile(env: &HashMap<String, String>) -> (String, String) {
+fn resolve_active_profile(env: &dyn Env) -> (String, String) {
     let selected = resolve_profile_input(env);
     let canonical =
         autumn_web::config::normalize_profile_name(&selected).unwrap_or_else(|| "dev".to_owned());
@@ -294,7 +304,7 @@ fn resolve_active_profile(env: &HashMap<String, String>) -> (String, String) {
 }
 
 /// The raw profile selector, before normalization.
-fn resolve_profile_input(env: &HashMap<String, String>) -> String {
+fn resolve_profile_input(env: &dyn Env) -> String {
     if let Some(value) = env_trimmed(env, "AUTUMN_ENV") {
         return value;
     }
@@ -318,7 +328,7 @@ fn resolve_profile_input(env: &HashMap<String, String>) -> String {
             return profile.trim().to_owned();
         }
     }
-    if env.get("AUTUMN_IS_DEBUG").map(String::as_str) == Some("0") {
+    if env_trimmed(env, "AUTUMN_IS_DEBUG").as_deref() == Some("0") {
         return "prod".to_owned();
     }
     "dev".to_owned()
@@ -328,7 +338,7 @@ fn resolve_profile_input(env: &HashMap<String, String>) -> String {
 /// `AUTUMN_MANIFEST_DIR` when the file is actually there, else relative to the
 /// working directory. Per-file, not per-directory — a base `autumn.toml` in the
 /// crate root and an `autumn-prod.toml` in the working directory both count.
-fn find_config_file(filename: &str, env: &HashMap<String, String>) -> PathBuf {
+fn find_config_file(filename: &str, env: &dyn Env) -> PathBuf {
     if let Some(dir) = env_trimmed(env, "AUTUMN_MANIFEST_DIR") {
         let candidate = PathBuf::from(dir).join(filename);
         if candidate.exists() {
@@ -412,6 +422,8 @@ fn deep_merge_at(base: &mut toml::Value, overlay: toml::Value, depth: usize) {
 
 #[cfg(test)]
 mod tests {
+    use autumn_web::config::MockEnv;
+
     use super::*;
 
     #[test]
@@ -463,17 +475,17 @@ mod tests {
 
     // ── Profile-aware resolution ────────────────────────────────────────────
 
-    /// A project directory plus the env map that points the resolver at it.
-    fn project(files: &[(&str, &str)]) -> (tempfile::TempDir, HashMap<String, String>) {
+    /// A project directory plus the `Env` that points the resolver at it.
+    ///
+    /// `MockEnv` is core's own test double for the same abstraction the
+    /// runtime uses, so these exercise the real resolution path rather than a
+    /// parallel one built on `std::env::vars()`.
+    fn project(files: &[(&str, &str)]) -> (tempfile::TempDir, MockEnv) {
         let dir = tempfile::tempdir().expect("tempdir");
         for (name, contents) in files {
             std::fs::write(dir.path().join(name), contents).expect("write");
         }
-        let mut env = HashMap::new();
-        env.insert(
-            "AUTUMN_MANIFEST_DIR".to_owned(),
-            dir.path().display().to_string(),
-        );
+        let env = MockEnv::new().with("AUTUMN_MANIFEST_DIR", &dir.path().display().to_string());
         (dir, env)
     }
 
@@ -509,7 +521,7 @@ mod tests {
         let dev = SearchConfig::resolve_with_env(&env).expect("dev");
         assert!(dev.enabled, "the base section governs the dev profile");
 
-        env.insert("AUTUMN_ENV".to_owned(), "prod".to_owned());
+        env = env.with("AUTUMN_ENV", "prod");
         let prod = SearchConfig::resolve_with_env(&env).expect("prod");
         assert!(!prod.enabled, "[profile.prod.search] must win in prod");
         assert_eq!(
@@ -527,7 +539,7 @@ mod tests {
             ),
             ("autumn-prod.toml", "[search]\nbatch_size = 300\n"),
         ]);
-        env.insert("AUTUMN_ENV".to_owned(), "prod".to_owned());
+        env = env.with("AUTUMN_ENV", "prod");
         assert_eq!(
             SearchConfig::resolve_with_env(&env)
                 .expect("resolve")
@@ -544,7 +556,7 @@ mod tests {
             ("autumn.toml", "[server]\nport = 3000\n"),
             ("autumn-prod.toml", "[search]\nenabled = false\n"),
         ]);
-        env.insert("AUTUMN_ENV".to_owned(), "prod".to_owned());
+        env = env.with("AUTUMN_ENV", "prod");
         assert!(
             !SearchConfig::resolve_with_env(&env)
                 .expect("resolve")
@@ -558,7 +570,7 @@ mod tests {
             "autumn.toml",
             "[search]\nenabled = true\n\n[profile.production.search]\nenabled = false\n",
         )]);
-        env.insert("AUTUMN_ENV".to_owned(), "production".to_owned());
+        env = env.with("AUTUMN_ENV", "production");
         assert!(
             !SearchConfig::resolve_with_env(&env)
                 .expect("resolve")
@@ -572,17 +584,14 @@ mod tests {
             "autumn.toml",
             "[search]\nenabled = true\n\n[profile.prod.search]\nenabled = true\n",
         )]);
-        env.insert("AUTUMN_ENV".to_owned(), "prod".to_owned());
-        env.insert("AUTUMN_SEARCH__ENABLED".to_owned(), "false".to_owned());
+        env = env.with("AUTUMN_ENV", "prod");
+        env = env.with("AUTUMN_SEARCH__ENABLED", "false");
         let config = SearchConfig::resolve_with_env(&env).expect("resolve");
         assert!(!config.enabled, "AUTUMN_SEARCH__ENABLED is the last word");
 
-        env.insert("AUTUMN_SEARCH__QUEUE".to_owned(), "urgent".to_owned());
-        env.insert("AUTUMN_SEARCH__BATCH_SIZE".to_owned(), "7".to_owned());
-        env.insert(
-            "AUTUMN_SEARCH__EMBEDDING_DIMENSIONS".to_owned(),
-            "384".to_owned(),
-        );
+        env = env.with("AUTUMN_SEARCH__QUEUE", "urgent");
+        env = env.with("AUTUMN_SEARCH__BATCH_SIZE", "7");
+        env = env.with("AUTUMN_SEARCH__EMBEDDING_DIMENSIONS", "384");
         let config = SearchConfig::resolve_with_env(&env).expect("resolve");
         assert_eq!(config.queue, "urgent");
         assert_eq!(config.batch_size, 7);
@@ -595,14 +604,14 @@ mod tests {
             "autumn.toml",
             "[search]\nenabled = true\n\n[profile.prod.search]\nenabld = false\n",
         )]);
-        env.insert("AUTUMN_ENV".to_owned(), "prod".to_owned());
+        env = env.with("AUTUMN_ENV", "prod");
         assert!(SearchConfig::resolve_with_env(&env).is_err());
     }
 
     #[test]
     fn an_out_of_range_env_override_is_still_rejected() {
         let (_dir, mut env) = project(&[("autumn.toml", "[search]\nbatch_size = 100\n")]);
-        env.insert("AUTUMN_SEARCH__BATCH_SIZE".to_owned(), "0".to_owned());
+        env = env.with("AUTUMN_SEARCH__BATCH_SIZE", "0");
         assert!(SearchConfig::resolve_with_env(&env).is_err());
     }
 
@@ -611,12 +620,76 @@ mod tests {
         // Core's own overrides ignore a malformed value rather than refusing
         // to boot; a process that would run on its file config should.
         let (_dir, mut env) = project(&[("autumn.toml", "[search]\nbatch_size = 100\n")]);
-        env.insert("AUTUMN_SEARCH__BATCH_SIZE".to_owned(), "lots".to_owned());
+        env = env.with("AUTUMN_SEARCH__BATCH_SIZE", "lots");
         assert_eq!(
             SearchConfig::resolve_with_env(&env)
                 .expect("resolve")
                 .batch_size,
             100
+        );
+    }
+
+    #[test]
+    fn a_release_binary_with_no_selector_resolves_prod_not_dev() {
+        // `AUTUMN_IS_DEBUG` is NOT a real process variable — core's `OsEnv`
+        // synthesizes it from the `#[autumn_web::main]` macro context. A
+        // resolver reading `std::env::vars()` never sees it, so a release
+        // binary launched with no explicit selector reads as `dev` while core
+        // reads `prod`, and `[profile.prod.search] enabled = false` is skipped
+        // in exactly the environment it was written for.
+        let (_dir, env) = project(&[(
+            "autumn.toml",
+            "[search]\nenabled = true\n\n[profile.prod.search]\nenabled = false\n",
+        )]);
+
+        let debug_build = env.clone().with("AUTUMN_IS_DEBUG", "1");
+        assert!(
+            SearchConfig::resolve_with_env(&debug_build)
+                .expect("resolve")
+                .enabled,
+            "a debug build is `dev`"
+        );
+
+        let release_build = env.with("AUTUMN_IS_DEBUG", "0");
+        assert!(
+            !SearchConfig::resolve_with_env(&release_build)
+                .expect("resolve")
+                .enabled,
+            "a release build with no selector must resolve `prod`, as core does"
+        );
+    }
+
+    #[test]
+    fn an_explicit_selector_still_beats_the_build_mode() {
+        let (_dir, env) = project(&[(
+            "autumn.toml",
+            "[search]\nqueue = \"base\"\n\n[profile.prod.search]\nqueue = \"prod\"\n\n\
+             [profile.staging.search]\nqueue = \"staging\"\n",
+        )]);
+        let env = env
+            .with("AUTUMN_IS_DEBUG", "0")
+            .with("AUTUMN_ENV", "staging");
+        assert_eq!(
+            SearchConfig::resolve_with_env(&env).expect("resolve").queue,
+            "staging",
+            "AUTUMN_ENV outranks the build-mode fallback"
+        );
+    }
+
+    #[test]
+    fn the_manifest_directory_need_not_be_a_process_variable() {
+        // Same point for the other synthesized value: `OsEnv` falls back to
+        // the macro-supplied crate directory when `AUTUMN_MANIFEST_DIR` is not
+        // in the process environment. Going through `Env` is what lets the
+        // plugin find the app's config from any working directory.
+        let (dir, env) = project(&[("autumn.toml", "[search]\nqueue = \"from-manifest\"\n")]);
+        assert_eq!(
+            find_config_file("autumn.toml", &env),
+            dir.path().join("autumn.toml")
+        );
+        assert_eq!(
+            SearchConfig::resolve_with_env(&env).expect("resolve").queue,
+            "from-manifest"
         );
     }
 
@@ -630,7 +703,7 @@ mod tests {
             ),
             ("autumn-prod.toml", "[search]\nqueue = \"prod-file\"\n"),
         ]);
-        env.insert("AUTUMN_ENV".to_owned(), "staging".to_owned());
+        env = env.with("AUTUMN_ENV", "staging");
         assert_eq!(
             SearchConfig::resolve_with_env(&env).expect("resolve").queue,
             "staging",
@@ -657,7 +730,7 @@ mod tests {
             PathBuf::from("autumn-prod.toml")
         );
         assert_eq!(
-            find_config_file("autumn.toml", &HashMap::new()),
+            find_config_file("autumn.toml", &MockEnv::new()),
             PathBuf::from("autumn.toml"),
             "with no manifest dir the CWD is the only candidate"
         );

--- a/autumn-search/src/config.rs
+++ b/autumn-search/src/config.rs
@@ -13,6 +13,7 @@ use serde::{Deserialize, Serialize};
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
+#[non_exhaustive]
 pub struct SearchConfig {
     /// Named `#[job]` queue the reindex and backfill jobs are routed to.
     ///
@@ -66,6 +67,7 @@ impl Default for SearchConfig {
 
 /// Why a `[search]` section was rejected.
 #[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
 pub enum SearchConfigError {
     /// The TOML did not parse, or `[search]` had an unknown/ill-typed key.
     #[error("invalid [search] configuration: {0}")]
@@ -73,6 +75,26 @@ pub enum SearchConfigError {
 }
 
 impl SearchConfig {
+    /// Read `[search]` from the `autumn.toml` at `path`.
+    ///
+    /// Matches `autumn-media-plugin`'s `MediaConfig::from_autumn_toml`, which
+    /// also takes a **path** — the string-taking form here is
+    /// [`SearchConfig::from_toml_str`], so a caller who passes `"autumn.toml"`
+    /// to the wrong one gets a compile error rather than a TOML parse error
+    /// about the filename.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SearchConfigError::Invalid`] when the file cannot be read or
+    /// its `[search]` table is malformed.
+    pub fn from_autumn_toml(path: impl AsRef<std::path::Path>) -> Result<Self, SearchConfigError> {
+        let path = path.as_ref();
+        let contents = std::fs::read_to_string(path).map_err(|e| {
+            SearchConfigError::Invalid(format!("cannot read {}: {e}", path.display()))
+        })?;
+        Self::from_toml_str(&contents)
+    }
+
     /// Parse the `[search]` table out of an `autumn.toml` document.
     ///
     /// A missing section yields the defaults. An unknown key is an **error**,
@@ -84,7 +106,7 @@ impl SearchConfig {
     /// Returns [`SearchConfigError::Invalid`] when the document does not
     /// parse, when `[search]` has an unknown or ill-typed key, or when a value
     /// is out of range.
-    pub fn from_autumn_toml(contents: &str) -> Result<Self, SearchConfigError> {
+    pub fn from_toml_str(contents: &str) -> Result<Self, SearchConfigError> {
         #[derive(Deserialize)]
         struct Document {
             #[serde(default)]
@@ -145,7 +167,7 @@ mod tests {
     #[test]
     fn a_partial_section_keeps_the_other_defaults() {
         let config =
-            SearchConfig::from_autumn_toml("[search]\nqueue = \"indexing\"\n").expect("parse");
+            SearchConfig::from_toml_str("[search]\nqueue = \"indexing\"\n").expect("parse");
         assert_eq!(config.queue, "indexing");
         assert_eq!(config.batch_size, 500);
         assert!(config.enabled);
@@ -154,30 +176,30 @@ mod tests {
     #[test]
     fn an_unrelated_document_yields_the_defaults() {
         assert_eq!(
-            SearchConfig::from_autumn_toml("[server]\nport = 3000\n").expect("parse"),
+            SearchConfig::from_toml_str("[server]\nport = 3000\n").expect("parse"),
             SearchConfig::default()
         );
         assert_eq!(
-            SearchConfig::from_autumn_toml("").expect("parse"),
+            SearchConfig::from_toml_str("").expect("parse"),
             SearchConfig::default()
         );
     }
 
     #[test]
     fn a_typo_is_an_error_rather_than_a_silent_default() {
-        assert!(SearchConfig::from_autumn_toml("[search]\nqueu = \"x\"\n").is_err());
+        assert!(SearchConfig::from_toml_str("[search]\nqueu = \"x\"\n").is_err());
     }
 
     #[test]
     fn out_of_range_values_are_rejected() {
-        assert!(SearchConfig::from_autumn_toml("[search]\nbatch_size = 0\n").is_err());
-        assert!(SearchConfig::from_autumn_toml("[search]\nqueue = \"\"\n").is_err());
-        assert!(SearchConfig::from_autumn_toml("[search]\nembedding_dimensions = 0\n").is_err());
+        assert!(SearchConfig::from_toml_str("[search]\nbatch_size = 0\n").is_err());
+        assert!(SearchConfig::from_toml_str("[search]\nqueue = \"\"\n").is_err());
+        assert!(SearchConfig::from_toml_str("[search]\nembedding_dimensions = 0\n").is_err());
     }
 
     #[test]
     fn an_ill_typed_value_is_rejected() {
-        assert!(SearchConfig::from_autumn_toml("[search]\nbatch_size = \"lots\"\n").is_err());
+        assert!(SearchConfig::from_toml_str("[search]\nbatch_size = \"lots\"\n").is_err());
     }
 
     #[test]
@@ -190,7 +212,7 @@ mod tests {
         };
         let document = format!("[search]\n{}", toml::to_string(&config).expect("serialize"));
         assert_eq!(
-            SearchConfig::from_autumn_toml(&document).expect("parse"),
+            SearchConfig::from_toml_str(&document).expect("parse"),
             config
         );
     }

--- a/autumn-search/src/config.rs
+++ b/autumn-search/src/config.rs
@@ -1,5 +1,8 @@
 //! The plugin-owned `[search]` section of `autumn.toml`.
 
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
 use serde::{Deserialize, Serialize};
 
 /// Configuration for the search subsystem.
@@ -65,6 +68,18 @@ impl Default for SearchConfig {
     }
 }
 
+/// An `autumn.toml` document, seen only through its `[search]` table.
+///
+/// Not `deny_unknown_fields` — every other top-level section (`server`, `log`,
+/// `profile`, …) belongs to core or another plugin and is none of this crate's
+/// business. `SearchConfig` itself is strict, so a typo *inside* `[search]`
+/// still fails.
+#[derive(Deserialize)]
+struct Document {
+    #[serde(default)]
+    search: Option<SearchConfig>,
+}
+
 /// Why a `[search]` section was rejected.
 #[derive(Debug, thiserror::Error)]
 #[non_exhaustive]
@@ -107,17 +122,123 @@ impl SearchConfig {
     /// parse, when `[search]` has an unknown or ill-typed key, or when a value
     /// is out of range.
     pub fn from_toml_str(contents: &str) -> Result<Self, SearchConfigError> {
-        #[derive(Deserialize)]
-        struct Document {
-            #[serde(default)]
-            search: Option<SearchConfig>,
-        }
-
         let document: Document =
             toml_from_str(contents).map_err(|e| SearchConfigError::Invalid(e.to_string()))?;
         let config = document.search.unwrap_or_default();
         config.validate()?;
         Ok(config)
+    }
+
+    /// Resolve the effective `[search]` section for the **active profile**,
+    /// reading the process environment.
+    ///
+    /// This is what the plugin calls at boot. The pure, testable core is
+    /// [`resolve_with_env`](Self::resolve_with_env).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SearchConfigError::Invalid`] when a contributing file cannot
+    /// be read or parsed, when the merged `[search]` table has an unknown or
+    /// ill-typed key, or when a value is out of range.
+    pub fn resolve() -> Result<Self, SearchConfigError> {
+        Self::resolve_with_env(&std::env::vars().collect())
+    }
+
+    /// Pure core of [`resolve`](Self::resolve): build the effective `[search]`
+    /// section from `env` without touching process-global state.
+    ///
+    /// Layering mirrors core's own loader (`AutumnConfig::load_with_env`),
+    /// restricted to the `[search]` subtree:
+    ///
+    /// 1. base `autumn.toml` `[search]`,
+    /// 2. inline `[profile.<name>.search]` (alias then canonical, so the
+    ///    canonical spelling wins),
+    /// 3. `autumn-<profile>.toml` `[search]` (first existing file in the
+    ///    shared [`profile_override_file_lookup_names`] order wins),
+    /// 4. `AUTUMN_SEARCH__*` environment overrides.
+    ///
+    /// Reading only layer 1 — which is what a naive plugin loader does — means
+    /// `enabled = false` set under `[profile.prod.search]` is silently ignored
+    /// in production. That turns the documented incident kill switch into a
+    /// no-op precisely when it is being reached for, which is why the plugin
+    /// pays for the full merge rather than a single `read_to_string`.
+    ///
+    /// Each filename is resolved independently through `AUTUMN_MANIFEST_DIR`
+    /// then the working directory, exactly as core's `find_config_file_named`
+    /// does — so the plugin reads the same files the host runtime does.
+    ///
+    /// [`profile_override_file_lookup_names`]: autumn_web::config::profile_override_file_lookup_names
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SearchConfigError::Invalid`] when a contributing file cannot
+    /// be read or parsed, when the merged `[search]` table has an unknown or
+    /// ill-typed key, or when a value is out of range.
+    pub fn resolve_with_env(env: &HashMap<String, String>) -> Result<Self, SearchConfigError> {
+        let (selected_input, canonical) = resolve_active_profile(env);
+        let mut merged = toml::Value::Table(toml::map::Map::new());
+
+        // Layer 1: base `autumn.toml`. Absent is fine — a zero-config app.
+        let base = read_optional_toml(&find_config_file("autumn.toml", env))?;
+        if let Some(base) = &base {
+            deep_merge(&mut merged, base.clone());
+
+            // Layer 2: inline `[profile.<name>]`, alias first.
+            for name in profile_inline_lookup_names(&canonical) {
+                if let Some(section) = profile_section(base, name) {
+                    deep_merge(&mut merged, section);
+                }
+            }
+        }
+
+        // Layer 3: `autumn-<profile>.toml`; the first existing file wins.
+        for name in
+            autumn_web::config::profile_override_file_lookup_names(&canonical, &selected_input)
+        {
+            let path = find_config_file(&format!("autumn-{name}.toml"), env);
+            if let Some(overlay) = read_optional_toml(&path)? {
+                deep_merge(&mut merged, overlay);
+                break;
+            }
+        }
+
+        let document: Document = merged
+            .try_into()
+            .map_err(|e: toml::de::Error| SearchConfigError::Invalid(e.to_string()))?;
+        let mut config = document.search.unwrap_or_default();
+        // Layer 4: env overrides, highest priority — the same precedence core
+        // gives `AUTUMN_SERVER__*`.
+        config.apply_env_overrides(env);
+        config.validate()?;
+        Ok(config)
+    }
+
+    /// Apply `AUTUMN_SEARCH__<FIELD>` scalar overrides.
+    ///
+    /// An unparseable value is **ignored** rather than fatal, matching core's
+    /// own `apply_env_overrides`: a malformed env var must not take down a
+    /// process that would otherwise boot on its file config.
+    fn apply_env_overrides(&mut self, env: &HashMap<String, String>) {
+        if let Some(queue) = env_trimmed(env, "AUTUMN_SEARCH__QUEUE") {
+            self.queue = queue;
+        }
+        if let Some(value) = env_trimmed(env, "AUTUMN_SEARCH__BATCH_SIZE")
+            && let Ok(parsed) = value.parse::<usize>()
+        {
+            self.batch_size = parsed;
+        }
+        if let Some(value) = env_trimmed(env, "AUTUMN_SEARCH__ENABLED") {
+            match value.to_ascii_lowercase().as_str() {
+                "true" | "1" => self.enabled = true,
+                "false" | "0" => self.enabled = false,
+                _ => {}
+            }
+        }
+        if let Some(value) = env_trimmed(env, "AUTUMN_SEARCH__EMBEDDING_DIMENSIONS")
+            && let Ok(parsed) = value.parse::<usize>()
+        {
+            self.embedding_dimensions = Some(parsed);
+        }
     }
 
     /// Reject values that would misbehave at runtime.
@@ -149,6 +270,144 @@ impl SearchConfig {
 /// `toml::from_str` behind a helper so the dependency edge is in one place.
 fn toml_from_str<T: serde::de::DeserializeOwned>(contents: &str) -> Result<T, toml::de::Error> {
     toml::from_str(contents)
+}
+
+/// Non-blank env value (a blank value reads as unset, as core treats it).
+fn env_trimmed(env: &HashMap<String, String>, key: &str) -> Option<String> {
+    env.get(key)
+        .map(|value| value.trim())
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+}
+
+/// The `(selected spelling, canonical name)` of the active profile.
+///
+/// Mirrors core's `resolve_profile`: `AUTUMN_ENV` → `AUTUMN_PROFILE` →
+/// `--profile` → `AUTUMN_IS_DEBUG=0` ⇒ `prod` → `dev`. Both halves are needed
+/// because the override-file lookup prefers the spelling that was actually
+/// selected (`autumn-production.toml` vs `autumn-prod.toml`).
+fn resolve_active_profile(env: &HashMap<String, String>) -> (String, String) {
+    let selected = resolve_profile_input(env);
+    let canonical =
+        autumn_web::config::normalize_profile_name(&selected).unwrap_or_else(|| "dev".to_owned());
+    (selected, canonical)
+}
+
+/// The raw profile selector, before normalization.
+fn resolve_profile_input(env: &HashMap<String, String>) -> String {
+    if let Some(value) = env_trimmed(env, "AUTUMN_ENV") {
+        return value;
+    }
+    if let Some(value) = env_trimmed(env, "AUTUMN_PROFILE") {
+        return value;
+    }
+    // `--profile <name>` / `--profile=<name>`: the runtime consults process
+    // args too, and `autumn search reindex --profile prod` re-executes the app
+    // binary with exactly that flag.
+    let args: Vec<String> = std::env::args().collect();
+    for (index, arg) in args.iter().enumerate() {
+        if arg == "--profile"
+            && let Some(profile) = args.get(index + 1)
+            && !profile.trim().is_empty()
+        {
+            return profile.trim().to_owned();
+        }
+        if let Some(profile) = arg.strip_prefix("--profile=")
+            && !profile.trim().is_empty()
+        {
+            return profile.trim().to_owned();
+        }
+    }
+    if env.get("AUTUMN_IS_DEBUG").map(String::as_str) == Some("0") {
+        return "prod".to_owned();
+    }
+    "dev".to_owned()
+}
+
+/// Resolve one config filename the way core's `find_config_file_named` does:
+/// `AUTUMN_MANIFEST_DIR` when the file is actually there, else relative to the
+/// working directory. Per-file, not per-directory — a base `autumn.toml` in the
+/// crate root and an `autumn-prod.toml` in the working directory both count.
+fn find_config_file(filename: &str, env: &HashMap<String, String>) -> PathBuf {
+    if let Some(dir) = env_trimmed(env, "AUTUMN_MANIFEST_DIR") {
+        let candidate = PathBuf::from(dir).join(filename);
+        if candidate.exists() {
+            return candidate;
+        }
+    }
+    PathBuf::from(filename)
+}
+
+/// Read a TOML file as a raw value; `Ok(None)` when it does not exist.
+///
+/// A file that exists but cannot be read is a real problem — a permissions
+/// mistake must not read as "zero-config".
+fn read_optional_toml(path: &Path) -> Result<Option<toml::Value>, SearchConfigError> {
+    match std::fs::read_to_string(path) {
+        Ok(contents) => {
+            let table = toml::from_str::<toml::Table>(&contents).map_err(|e| {
+                SearchConfigError::Invalid(format!("cannot parse {}: {e}", path.display()))
+            })?;
+            Ok(Some(toml::Value::Table(table)))
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(error) => Err(SearchConfigError::Invalid(format!(
+            "cannot read {}: {error}",
+            path.display()
+        ))),
+    }
+}
+
+/// Inline `[profile.<name>]` names for a canonical profile, legacy alias first
+/// so the canonical spelling merges last and wins. Mirrors core's
+/// `profile_lookup_names`.
+fn profile_inline_lookup_names(canonical: &str) -> Vec<&str> {
+    match canonical {
+        "prod" => vec!["production", "prod"],
+        "dev" => vec!["development", "dev"],
+        other => vec![other],
+    }
+}
+
+/// Lift `[profile.<name>]` out of a parsed document as a standalone table.
+fn profile_section(base: &toml::Value, profile: &str) -> Option<toml::Value> {
+    base.get("profile")
+        .and_then(toml::Value::as_table)
+        .and_then(|profiles| profiles.get(profile))
+        .and_then(toml::Value::as_table)
+        .map(|table| toml::Value::Table(table.clone()))
+}
+
+/// Deep-merge `overlay` into `base`: tables merge recursively, everything else
+/// replaces. A faithful copy of core's private `deep_merge`, bounded by the
+/// same depth, so the plugin's layering matches the runtime's exactly.
+fn deep_merge(base: &mut toml::Value, overlay: toml::Value) {
+    deep_merge_at(base, overlay, 0);
+}
+
+fn deep_merge_at(base: &mut toml::Value, overlay: toml::Value, depth: usize) {
+    /// Matches core's `MAX_MERGE_DEPTH`.
+    const MAX_MERGE_DEPTH: usize = 16;
+    if depth > MAX_MERGE_DEPTH {
+        return;
+    }
+    let toml::Value::Table(overlay_table) = overlay else {
+        return;
+    };
+    let Some(base_table) = base.as_table_mut() else {
+        return;
+    };
+    for (key, overlay_value) in overlay_table {
+        let recurse =
+            overlay_value.is_table() && base_table.get(&key).is_some_and(toml::Value::is_table);
+        if recurse {
+            if let Some(base_value) = base_table.get_mut(&key) {
+                deep_merge_at(base_value, overlay_value, depth + 1);
+            }
+        } else {
+            base_table.insert(key, overlay_value);
+        }
+    }
 }
 
 #[cfg(test)]
@@ -200,6 +459,214 @@ mod tests {
     #[test]
     fn an_ill_typed_value_is_rejected() {
         assert!(SearchConfig::from_toml_str("[search]\nbatch_size = \"lots\"\n").is_err());
+    }
+
+    // ── Profile-aware resolution ────────────────────────────────────────────
+
+    /// A project directory plus the env map that points the resolver at it.
+    fn project(files: &[(&str, &str)]) -> (tempfile::TempDir, HashMap<String, String>) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        for (name, contents) in files {
+            std::fs::write(dir.path().join(name), contents).expect("write");
+        }
+        let mut env = HashMap::new();
+        env.insert(
+            "AUTUMN_MANIFEST_DIR".to_owned(),
+            dir.path().display().to_string(),
+        );
+        (dir, env)
+    }
+
+    #[test]
+    fn an_absent_config_resolves_to_the_defaults() {
+        let (_dir, env) = project(&[]);
+        assert_eq!(
+            SearchConfig::resolve_with_env(&env).expect("resolve"),
+            SearchConfig::default()
+        );
+    }
+
+    #[test]
+    fn the_base_section_resolves_under_the_default_profile() {
+        let (_dir, env) = project(&[("autumn.toml", "[search]\nqueue = \"indexing\"\n")]);
+        assert_eq!(
+            SearchConfig::resolve_with_env(&env).expect("resolve").queue,
+            "indexing"
+        );
+    }
+
+    #[test]
+    fn an_inline_profile_section_overrides_the_base() {
+        // The kill switch: `enabled = false` under `[profile.prod.search]` has
+        // to actually turn search off in prod. Reading only the base section
+        // would leave it enabled — with no signal at all.
+        let (_dir, mut env) = project(&[(
+            "autumn.toml",
+            "[search]\nenabled = true\nqueue = \"search\"\n\n\
+             [profile.prod.search]\nenabled = false\n",
+        )]);
+
+        let dev = SearchConfig::resolve_with_env(&env).expect("dev");
+        assert!(dev.enabled, "the base section governs the dev profile");
+
+        env.insert("AUTUMN_ENV".to_owned(), "prod".to_owned());
+        let prod = SearchConfig::resolve_with_env(&env).expect("prod");
+        assert!(!prod.enabled, "[profile.prod.search] must win in prod");
+        assert_eq!(
+            prod.queue, "search",
+            "keys the profile does not mention keep the base value"
+        );
+    }
+
+    #[test]
+    fn a_profile_override_file_overrides_the_inline_section() {
+        let (_dir, mut env) = project(&[
+            (
+                "autumn.toml",
+                "[search]\nbatch_size = 100\n\n[profile.prod.search]\nbatch_size = 200\n",
+            ),
+            ("autumn-prod.toml", "[search]\nbatch_size = 300\n"),
+        ]);
+        env.insert("AUTUMN_ENV".to_owned(), "prod".to_owned());
+        assert_eq!(
+            SearchConfig::resolve_with_env(&env)
+                .expect("resolve")
+                .batch_size,
+            300
+        );
+    }
+
+    #[test]
+    fn a_section_living_only_in_the_profile_file_is_still_found() {
+        // No base `[search]` at all — an app that configures search per
+        // environment and nowhere else.
+        let (_dir, mut env) = project(&[
+            ("autumn.toml", "[server]\nport = 3000\n"),
+            ("autumn-prod.toml", "[search]\nenabled = false\n"),
+        ]);
+        env.insert("AUTUMN_ENV".to_owned(), "prod".to_owned());
+        assert!(
+            !SearchConfig::resolve_with_env(&env)
+                .expect("resolve")
+                .enabled
+        );
+    }
+
+    #[test]
+    fn the_legacy_production_spelling_resolves_to_the_same_profile() {
+        let (_dir, mut env) = project(&[(
+            "autumn.toml",
+            "[search]\nenabled = true\n\n[profile.production.search]\nenabled = false\n",
+        )]);
+        env.insert("AUTUMN_ENV".to_owned(), "production".to_owned());
+        assert!(
+            !SearchConfig::resolve_with_env(&env)
+                .expect("resolve")
+                .enabled
+        );
+    }
+
+    #[test]
+    fn an_env_override_beats_every_file_layer() {
+        let (_dir, mut env) = project(&[(
+            "autumn.toml",
+            "[search]\nenabled = true\n\n[profile.prod.search]\nenabled = true\n",
+        )]);
+        env.insert("AUTUMN_ENV".to_owned(), "prod".to_owned());
+        env.insert("AUTUMN_SEARCH__ENABLED".to_owned(), "false".to_owned());
+        let config = SearchConfig::resolve_with_env(&env).expect("resolve");
+        assert!(!config.enabled, "AUTUMN_SEARCH__ENABLED is the last word");
+
+        env.insert("AUTUMN_SEARCH__QUEUE".to_owned(), "urgent".to_owned());
+        env.insert("AUTUMN_SEARCH__BATCH_SIZE".to_owned(), "7".to_owned());
+        env.insert(
+            "AUTUMN_SEARCH__EMBEDDING_DIMENSIONS".to_owned(),
+            "384".to_owned(),
+        );
+        let config = SearchConfig::resolve_with_env(&env).expect("resolve");
+        assert_eq!(config.queue, "urgent");
+        assert_eq!(config.batch_size, 7);
+        assert_eq!(config.embedding_dimensions, Some(384));
+    }
+
+    #[test]
+    fn a_typo_in_a_profile_section_is_an_error_rather_than_a_silent_default() {
+        let (_dir, mut env) = project(&[(
+            "autumn.toml",
+            "[search]\nenabled = true\n\n[profile.prod.search]\nenabld = false\n",
+        )]);
+        env.insert("AUTUMN_ENV".to_owned(), "prod".to_owned());
+        assert!(SearchConfig::resolve_with_env(&env).is_err());
+    }
+
+    #[test]
+    fn an_out_of_range_env_override_is_still_rejected() {
+        let (_dir, mut env) = project(&[("autumn.toml", "[search]\nbatch_size = 100\n")]);
+        env.insert("AUTUMN_SEARCH__BATCH_SIZE".to_owned(), "0".to_owned());
+        assert!(SearchConfig::resolve_with_env(&env).is_err());
+    }
+
+    #[test]
+    fn an_unparseable_env_override_leaves_the_file_value_alone() {
+        // Core's own overrides ignore a malformed value rather than refusing
+        // to boot; a process that would run on its file config should.
+        let (_dir, mut env) = project(&[("autumn.toml", "[search]\nbatch_size = 100\n")]);
+        env.insert("AUTUMN_SEARCH__BATCH_SIZE".to_owned(), "lots".to_owned());
+        assert_eq!(
+            SearchConfig::resolve_with_env(&env)
+                .expect("resolve")
+                .batch_size,
+            100
+        );
+    }
+
+    #[test]
+    fn a_custom_profile_reads_its_own_layers_only() {
+        let (_dir, mut env) = project(&[
+            (
+                "autumn.toml",
+                "[search]\nqueue = \"base\"\n\n[profile.staging.search]\nqueue = \"staging\"\n\n\
+                 [profile.prod.search]\nqueue = \"prod\"\n",
+            ),
+            ("autumn-prod.toml", "[search]\nqueue = \"prod-file\"\n"),
+        ]);
+        env.insert("AUTUMN_ENV".to_owned(), "staging".to_owned());
+        assert_eq!(
+            SearchConfig::resolve_with_env(&env).expect("resolve").queue,
+            "staging",
+            "neither [profile.prod] nor autumn-prod.toml may leak into staging"
+        );
+    }
+
+    #[test]
+    fn file_resolution_prefers_the_manifest_directory_over_the_cwd() {
+        // `autumn search reindex --package app` runs the binary from the
+        // workspace root, where the CWD holds a different `autumn.toml` (or
+        // none). Core resolves through `AUTUMN_MANIFEST_DIR` first; the
+        // plugin-owned section must resolve the same way or it reads a
+        // different file than the rest of the config.
+        let (dir, env) = project(&[("autumn.toml", "[search]\n")]);
+        assert_eq!(
+            find_config_file("autumn.toml", &env),
+            dir.path().join("autumn.toml")
+        );
+        // A file the manifest dir does NOT hold falls through to the CWD,
+        // per-file — core resolves each filename independently.
+        assert_eq!(
+            find_config_file("autumn-prod.toml", &env),
+            PathBuf::from("autumn-prod.toml")
+        );
+        assert_eq!(
+            find_config_file("autumn.toml", &HashMap::new()),
+            PathBuf::from("autumn.toml"),
+            "with no manifest dir the CWD is the only candidate"
+        );
+    }
+
+    #[test]
+    fn a_malformed_contributing_file_is_reported_rather_than_ignored() {
+        let (_dir, env) = project(&[("autumn.toml", "[search\nqueue = \"x\"\n")]);
+        assert!(SearchConfig::resolve_with_env(&env).is_err());
     }
 
     #[test]

--- a/autumn-search/src/embedding.rs
+++ b/autumn-search/src/embedding.rs
@@ -86,9 +86,15 @@ impl HashingEmbedder {
     ///
     /// # Panics
     ///
-    /// Panics if `dimensions` is `0`. Use [`HashingEmbedder::try_new`] to
-    /// handle a runtime-supplied value.
+    /// Panics if `dimensions` is `0`. This is a *construction-time* argument
+    /// check, not a request path — a 0-dimension embedder would map every text
+    /// to the same vector, so failing at construction is the only honest
+    /// outcome. Use [`HashingEmbedder::try_new`] for a runtime-supplied value.
     #[must_use]
+    #[allow(
+        clippy::expect_used,
+        reason = "construction-time argument validation; no request path reaches this"
+    )]
     pub const fn new(dimensions: usize) -> Self {
         Self::try_new(dimensions).expect(
             "HashingEmbedder requires at least one dimension; 0 would make every text identical",

--- a/autumn-search/src/embedding.rs
+++ b/autumn-search/src/embedding.rs
@@ -1,0 +1,216 @@
+//! The pluggable embedding seam.
+//!
+//! `autumn-search` orchestrates embeddings; it does not ship a model, an
+//! inference runtime, or a vendor SDK (explicitly out of scope in #1191). An
+//! app implements [`Embedder`] — over an HTTP provider, a local ONNX runtime,
+//! whatever — and installs it with `SearchPlugin::embedder(...)`.
+//!
+//! Two implementations ship here, and neither is a model:
+//!
+//! - [`NoEmbedder`] — the default. Refuses, loudly, so an app that never
+//!   configured embeddings gets a typed error instead of meaningless vectors.
+//! - [`HashingEmbedder`] — a deterministic, dependency-free hashing vectorizer
+//!   (the classic "hashing trick"). It is a real lexical embedding, useful for
+//!   development and for tests that must not reach the network, and it is
+//!   honest about what it is: no semantics beyond token overlap.
+
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash as _, Hasher as _};
+
+use crate::backend::BoxFuture;
+use crate::error::{SearchError, SearchResult};
+use crate::text::tokenize;
+
+/// Turns text into vectors for semantic search.
+///
+/// Stored as `Arc<dyn Embedder>`, so the methods are object-safe.
+pub trait Embedder: Send + Sync + 'static {
+    /// Dimensionality of the vectors this embedder produces.
+    ///
+    /// **`0` means "no embeddings available".** The client treats a
+    /// zero-dimension embedder as "skip embedding" while indexing (so a
+    /// searchable model with an `embed` field still indexes for keyword search
+    /// on an app that never configured a provider) and as
+    /// [`SearchError::EmbedderUnavailable`] at query time (so a semantic query
+    /// fails loudly rather than returning nonsense).
+    fn dimensions(&self) -> usize;
+
+    /// Embed a batch of texts, returning one vector per input in order.
+    ///
+    /// An empty batch must succeed with an empty result and do no work — the
+    /// indexer calls this for every batch, including ones with nothing to
+    /// embed.
+    fn embed<'a>(&'a self, texts: &'a [String]) -> BoxFuture<'a, SearchResult<Vec<Vec<f32>>>>;
+}
+
+/// The default embedder: refuses to produce vectors.
+///
+/// Installed when an app has not configured a provider. Keyword search works
+/// exactly as before; a semantic query returns
+/// [`SearchError::EmbedderUnavailable`], whose message names the fix.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct NoEmbedder;
+
+impl Embedder for NoEmbedder {
+    fn dimensions(&self) -> usize {
+        0
+    }
+
+    fn embed<'a>(&'a self, texts: &'a [String]) -> BoxFuture<'a, SearchResult<Vec<Vec<f32>>>> {
+        Box::pin(async move {
+            if texts.is_empty() {
+                return Ok(Vec::new());
+            }
+            Err(SearchError::EmbedderUnavailable)
+        })
+    }
+}
+
+/// A deterministic, dependency-free hashing vectorizer.
+///
+/// Each token is hashed into one of `dimensions` buckets (signed, to reduce
+/// collision bias) and the resulting term-frequency vector is L2-normalized so
+/// cosine similarity is a plain dot product. Two texts that share vocabulary
+/// score higher than two that do not.
+///
+/// This is **not** a semantic model: "car" and "automobile" are unrelated to
+/// it. Use it for development, for deterministic tests, and as a working
+/// reference implementation of [`Embedder`] — not for production relevance.
+#[derive(Debug, Clone, Copy)]
+pub struct HashingEmbedder {
+    dimensions: usize,
+}
+
+impl HashingEmbedder {
+    /// Construct an embedder producing `dimensions`-wide vectors.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `dimensions` is `0`. Use [`HashingEmbedder::try_new`] to
+    /// handle a runtime-supplied value.
+    #[must_use]
+    pub const fn new(dimensions: usize) -> Self {
+        Self::try_new(dimensions).expect(
+            "HashingEmbedder requires at least one dimension; 0 would make every text identical",
+        )
+    }
+
+    /// Fallible constructor. Returns `None` for `0` dimensions, which would
+    /// map every text to the same (empty) vector.
+    #[must_use]
+    pub const fn try_new(dimensions: usize) -> Option<Self> {
+        if dimensions == 0 {
+            None
+        } else {
+            Some(Self { dimensions })
+        }
+    }
+
+    fn embed_one(self, text: &str) -> Vec<f32> {
+        let mut vector = vec![0.0_f32; self.dimensions];
+        for token in tokenize(text) {
+            let mut hasher = DefaultHasher::new();
+            token.hash(&mut hasher);
+            let hash = hasher.finish();
+            // Low bits pick the bucket; one further bit picks the sign, which
+            // keeps unrelated tokens from all pushing in the same direction.
+            let bucket = usize::try_from(hash % self.dimensions as u64).unwrap_or(0);
+            let sign = if (hash >> 63) & 1 == 1 { -1.0 } else { 1.0 };
+            if let Some(slot) = vector.get_mut(bucket) {
+                *slot += sign;
+            }
+        }
+        normalize(&mut vector);
+        vector
+    }
+}
+
+impl Embedder for HashingEmbedder {
+    fn dimensions(&self) -> usize {
+        self.dimensions
+    }
+
+    fn embed<'a>(&'a self, texts: &'a [String]) -> BoxFuture<'a, SearchResult<Vec<Vec<f32>>>> {
+        Box::pin(async move { Ok(texts.iter().map(|t| self.embed_one(t)).collect()) })
+    }
+}
+
+/// Scale `vector` to unit length in place. A zero vector is left alone (it has
+/// no direction), which keeps [`cosine_similarity`] free of `NaN`.
+pub fn normalize(vector: &mut [f32]) {
+    let norm = vector.iter().map(|v| v * v).sum::<f32>().sqrt();
+    if norm > f32::EPSILON {
+        for value in vector.iter_mut() {
+            *value /= norm;
+        }
+    }
+}
+
+/// Cosine similarity of two vectors, in `[-1.0, 1.0]`.
+///
+/// Returns `0.0` — never `NaN` — for a zero vector or a length mismatch, so a
+/// malformed embedding degrades to "unrelated" instead of poisoning a sort.
+#[must_use]
+pub fn cosine_similarity(a: &[f32], b: &[f32]) -> f32 {
+    if a.len() != b.len() || a.is_empty() {
+        return 0.0;
+    }
+    let mut dot = 0.0_f32;
+    let mut norm_a = 0.0_f32;
+    let mut norm_b = 0.0_f32;
+    for (x, y) in a.iter().zip(b.iter()) {
+        dot += x * y;
+        norm_a += x * x;
+        norm_b += y * y;
+    }
+    let denominator = norm_a.sqrt() * norm_b.sqrt();
+    if denominator <= f32::EPSILON {
+        return 0.0;
+    }
+    (dot / denominator).clamp(-1.0, 1.0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn the_hashing_embedder_produces_unit_vectors_of_the_right_width() {
+        let embedder = HashingEmbedder::new(16);
+        let vectors = embedder
+            .embed(&["autumn rust".to_owned()])
+            .await
+            .expect("embed");
+        assert_eq!(vectors.len(), 1);
+        assert_eq!(vectors[0].len(), 16);
+        let norm: f32 = vectors[0].iter().map(|v| v * v).sum::<f32>().sqrt();
+        assert!((norm - 1.0).abs() < 1e-5);
+    }
+
+    #[tokio::test]
+    async fn empty_text_yields_a_zero_vector_rather_than_a_nan() {
+        let embedder = HashingEmbedder::new(8);
+        let vectors = embedder.embed(&[String::new()]).await.expect("embed");
+        assert!(vectors[0].iter().all(|v| v.abs() < f32::EPSILON));
+        assert!(cosine_similarity(&vectors[0], &vectors[0]).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn normalize_leaves_a_zero_vector_alone() {
+        let mut zero = vec![0.0_f32; 4];
+        normalize(&mut zero);
+        assert!(zero.iter().all(|v| v.abs() < f32::EPSILON));
+    }
+
+    #[test]
+    fn cosine_similarity_is_bounded_and_total() {
+        assert!(cosine_similarity(&[], &[]).abs() < f32::EPSILON);
+        assert!(cosine_similarity(&[1.0], &[1.0, 2.0]).abs() < f32::EPSILON);
+        assert!(cosine_similarity(&[3.0, 4.0], &[3.0, 4.0]) <= 1.0);
+    }
+
+    #[test]
+    fn try_new_rejects_zero_dimensions() {
+        assert!(HashingEmbedder::try_new(0).is_none());
+    }
+}

--- a/autumn-search/src/error.rs
+++ b/autumn-search/src/error.rs
@@ -1,0 +1,161 @@
+//! Typed failures for the search subsystem.
+
+use autumn_web::AutumnError;
+
+/// Result alias used throughout `autumn-search`.
+pub type SearchResult<T> = Result<T, SearchError>;
+
+/// Everything that can go wrong indexing or querying.
+///
+/// Deliberately typed rather than stringly: the difference between "this index
+/// is not registered" (a wiring bug, a 500) and "this query has no embedder"
+/// (a configuration gap, a 501) is the difference between two very different
+/// operator responses. Nothing here ever degrades into an unfiltered read.
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum SearchError {
+    /// No index with this name is registered on the client.
+    #[error(
+        "search index {0:?} is not registered; add it with `SearchPlugin::index::<Model>()` \
+         (the model must be `#[model]` + `#[searchable]` with an i64 primary key)"
+    )]
+    UnknownIndex(String),
+
+    /// The index definition failed [`autumn_web::search::IndexDefinition::validate`].
+    #[error("invalid search index definition: {0}")]
+    InvalidIndex(String),
+
+    /// A vector query hit an index with no `#[searchable(embed)]` field.
+    #[error(
+        "search index {index:?} has no embedded field; add `#[searchable(embed)]` to the field \
+         you want embedded to enable vector search"
+    )]
+    VectorUnsupported {
+        /// The index that was queried.
+        index: String,
+    },
+
+    /// A vector operation was attempted with no usable embedder installed.
+    #[error(
+        "no embedding provider is configured; install one with `SearchPlugin::embedder(...)` \
+         (the plugin ships no model or vendor by design)"
+    )]
+    EmbedderUnavailable,
+
+    /// The embedder itself failed.
+    #[error("embedding failed: {0}")]
+    Embedding(String),
+
+    /// A vector's length disagrees with what the index holds.
+    #[error("embedding has {actual} dimensions, expected {expected}")]
+    DimensionMismatch {
+        /// Dimensionality the index was built with.
+        expected: usize,
+        /// Dimensionality of the offending vector.
+        actual: usize,
+    },
+
+    /// An authorization-aware entry point was used with no visibility hook.
+    #[error(
+        "no `SearchVisibility` is registered; install one with `SearchPlugin::visibility(...)` \
+         — an authorization-aware search must never fall back to an unfiltered one"
+    )]
+    VisibilityUnavailable,
+
+    /// A reindex/backfill needs a [`crate::DocumentSource`] and none is installed.
+    #[error(
+        "no `DocumentSource` is installed; add one with `SearchPlugin::source(...)` \
+         (the Postgres source is installed automatically by `SearchPlugin::postgres()`)"
+    )]
+    SourceUnavailable,
+
+    /// The backend does not implement this operation.
+    #[error("search backend {backend:?} does not support {operation}")]
+    Unsupported {
+        /// Backend name.
+        backend: &'static str,
+        /// The unsupported operation.
+        operation: &'static str,
+    },
+
+    /// The backend failed (I/O, SQL, an engine error).
+    #[error("search backend error: {0}")]
+    Backend(String),
+}
+
+impl SearchError {
+    /// Wrap an arbitrary backend failure.
+    pub fn backend(error: impl std::fmt::Display) -> Self {
+        Self::Backend(error.to_string())
+    }
+
+    /// Wrap an arbitrary embedding failure.
+    pub fn embedding(error: impl std::fmt::Display) -> Self {
+        Self::Embedding(error.to_string())
+    }
+}
+
+impl SearchError {
+    /// Convert into an [`AutumnError`] with a status that matches the cause.
+    ///
+    /// A blanket `impl<E: std::error::Error> From<E> for AutumnError` already
+    /// exists in `autumn-web`, so `?` works without this — but that blanket
+    /// impl cannot tell a bad *query* from a broken *deployment*. Use this at
+    /// a handler boundary to get the distinction: a vector query against an
+    /// index with no embedded field is the caller's mistake (400), while a
+    /// missing embedder or an unreachable engine is the operator's (500).
+    #[must_use]
+    pub fn into_autumn_error(self) -> AutumnError {
+        let message = self.to_string();
+        match self {
+            // Caller-fixable: the query asked for something this index cannot
+            // answer.
+            Self::VectorUnsupported { .. } | Self::DimensionMismatch { .. } => {
+                AutumnError::bad_request_msg(message)
+            }
+            // Operator-fixable configuration gaps and genuine failures.
+            Self::UnknownIndex(_)
+            | Self::InvalidIndex(_)
+            | Self::EmbedderUnavailable
+            | Self::VisibilityUnavailable
+            | Self::SourceUnavailable
+            | Self::Unsupported { .. }
+            | Self::Embedding(_)
+            | Self::Backend(_) => AutumnError::internal_server_error_msg(message),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_bad_query_maps_to_a_client_error_not_a_500() {
+        let error = SearchError::VectorUnsupported {
+            index: "articles".to_owned(),
+        }
+        .into_autumn_error();
+        assert_eq!(error.status().as_u16(), 400);
+    }
+
+    #[test]
+    fn a_wiring_gap_maps_to_a_server_error() {
+        let error = SearchError::UnknownIndex("articles".to_owned()).into_autumn_error();
+        assert_eq!(error.status().as_u16(), 500);
+    }
+
+    #[test]
+    fn messages_name_the_fix() {
+        assert!(
+            SearchError::EmbedderUnavailable
+                .to_string()
+                .contains("SearchPlugin::embedder")
+        );
+        assert!(
+            SearchError::UnknownIndex("a".to_owned())
+                .to_string()
+                .contains("SearchPlugin::index")
+        );
+    }
+}

--- a/autumn-search/src/error.rs
+++ b/autumn-search/src/error.rs
@@ -9,7 +9,7 @@ pub type SearchResult<T> = Result<T, SearchError>;
 ///
 /// Deliberately typed rather than stringly: the difference between "this index
 /// is not registered" (a wiring bug, a 500) and "this query has no embedder"
-/// (a configuration gap, a 501) is the difference between two very different
+/// (a configuration gap, a 500) is the difference between two very different
 /// operator responses. Nothing here ever degrades into an unfiltered read.
 #[derive(Debug, thiserror::Error)]
 #[non_exhaustive]
@@ -55,6 +55,22 @@ pub enum SearchError {
         actual: usize,
     },
 
+    /// A tenant-scoped index was queried with no tenant context in scope.
+    ///
+    /// Refused rather than run unscoped: the model carries a `tenant_id`
+    /// column, so an unscoped query would return every tenant's records — and
+    /// compute `total_elements` across all of them. This mirrors
+    /// `#[repository(tenant_scoped)]`, which errors for the same reason.
+    #[error(
+        "search index {index:?} is tenant-scoped but no tenant context is established; \
+         run the query inside a tenant scope (the `TenancyLayer`, or \
+         `autumn_web::tenancy::with_tenant(...)` for a job or background task)"
+    )]
+    TenantContextMissing {
+        /// The index that was queried.
+        index: String,
+    },
+
     /// An authorization-aware entry point was used with no visibility hook.
     #[error(
         "no `SearchVisibility` is registered; install one with `SearchPlugin::visibility(...)` \
@@ -85,13 +101,28 @@ pub enum SearchError {
 
 impl SearchError {
     /// Wrap an arbitrary backend failure.
+    #[must_use]
     pub fn backend(error: impl std::fmt::Display) -> Self {
         Self::Backend(error.to_string())
     }
 
     /// Wrap an arbitrary embedding failure.
+    #[must_use]
     pub fn embedding(error: impl std::fmt::Display) -> Self {
         Self::Embedding(error.to_string())
+    }
+}
+
+impl From<AutumnError> for SearchError {
+    /// Carry an application error (typically from a repository call inside a
+    /// hydration loader or a custom [`crate::DocumentSource`]) into a
+    /// [`SearchError`].
+    ///
+    /// Without this, `search_hydrated`'s loader — whose whole job is to call
+    /// `repo.find_all(...)` — could not use `?`, which is unavoidable
+    /// boilerplate on the single most common call site in the crate.
+    fn from(error: AutumnError) -> Self {
+        Self::Backend(error.to_string())
     }
 }
 
@@ -119,6 +150,7 @@ impl SearchError {
             | Self::EmbedderUnavailable
             | Self::VisibilityUnavailable
             | Self::SourceUnavailable
+            | Self::TenantContextMissing { .. }
             | Self::Unsupported { .. }
             | Self::Embedding(_)
             | Self::Backend(_) => AutumnError::internal_server_error_msg(message),
@@ -143,6 +175,23 @@ mod tests {
     fn a_wiring_gap_maps_to_a_server_error() {
         let error = SearchError::UnknownIndex("articles".to_owned()).into_autumn_error();
         assert_eq!(error.status().as_u16(), 500);
+    }
+
+    #[test]
+    fn a_missing_tenant_context_is_refused_rather_than_run_unscoped() {
+        let error = SearchError::TenantContextMissing {
+            index: "articles".to_owned(),
+        };
+        let message = error.to_string();
+        assert!(message.contains("tenant-scoped"), "{message}");
+        assert!(message.contains("tenant scope"), "{message}");
+        assert_eq!(error.into_autumn_error().status().as_u16(), 500);
+    }
+
+    #[test]
+    fn an_application_error_converts_so_a_hydration_loader_can_use_question_mark() {
+        let error: SearchError = AutumnError::internal_server_error_msg("row not found").into();
+        assert!(matches!(error, SearchError::Backend(ref m) if m.contains("row not found")));
     }
 
     #[test]

--- a/autumn-search/src/jobs.rs
+++ b/autumn-search/src/jobs.rs
@@ -1,0 +1,281 @@
+//! Off-request, durable index maintenance.
+//!
+//! AC: indexing runs "via `#[job]`, so indexing is off-request and durable".
+//!
+//! Two jobs, both **index-name keyed** rather than model-keyed:
+//!
+//! - `autumn_search_reindex` — converge one record.
+//! - `autumn_search_backfill` — rebuild one index (or all of them).
+//!
+//! Keying on the index name is what keeps adding a searchable model to a
+//! one-line `SearchPlugin::index::<Model>()` instead of a new job per model:
+//! the handler looks the definition up in the registry and drives the generic
+//! [`crate::DocumentSource`]. Nothing here is generated per model.
+
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+
+use autumn_web::job::{JobHandler, JobInfo};
+use autumn_web::{AppState, AutumnError, AutumnResult};
+use serde::{Deserialize, Serialize};
+
+use crate::client::{BackfillOptions, SearchClient};
+
+/// Job name for the per-record reindex. A wire contract: in-flight payloads
+/// outlive a deploy, so this string must not change.
+pub const REINDEX_JOB: &str = "autumn_search_reindex";
+
+/// Job name for the full backfill.
+pub const BACKFILL_JOB: &str = "autumn_search_backfill";
+
+/// What a reindex instruction should do.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ReindexOp {
+    /// Re-read the row and write it — or delete the document if the row is
+    /// gone. This covers create **and** update, because both mean "the row
+    /// changed; make the index agree".
+    Upsert,
+    /// Remove the document without consulting the source.
+    Delete,
+}
+
+/// Payload of the [`REINDEX_JOB`].
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ReindexArgs {
+    /// The index to update.
+    pub index: String,
+    /// Primary key of the record.
+    pub id: i64,
+    /// The operation.
+    pub op: ReindexOp,
+}
+
+impl ReindexArgs {
+    /// An upsert instruction (create or update).
+    #[must_use]
+    pub fn upsert(index: impl Into<String>, id: i64) -> Self {
+        Self {
+            index: index.into(),
+            id,
+            op: ReindexOp::Upsert,
+        }
+    }
+
+    /// A delete instruction.
+    #[must_use]
+    pub fn delete(index: impl Into<String>, id: i64) -> Self {
+        Self {
+            index: index.into(),
+            id,
+            op: ReindexOp::Delete,
+        }
+    }
+
+    /// The dedup key for this instruction.
+    ///
+    /// Repeated writes to the same record inside one queue window collapse to
+    /// one reindex — the job re-reads the row, so only the *last* one would
+    /// have done any distinct work anyway.
+    #[must_use]
+    pub fn unique_key(&self) -> String {
+        format!("{}:{}", self.index, self.id)
+    }
+}
+
+/// Payload of the [`BACKFILL_JOB`].
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
+pub struct BackfillArgs {
+    /// Index to rebuild. `None` rebuilds every registered index.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub index: Option<String>,
+    /// Rows per batch. `None` uses the configured default.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub batch_size: Option<usize>,
+    /// Clear each index before rebuilding it.
+    #[serde(default)]
+    pub purge: bool,
+}
+
+impl BackfillArgs {
+    /// Rebuild one index.
+    #[must_use]
+    pub fn for_index(index: impl Into<String>) -> Self {
+        Self {
+            index: Some(index.into()),
+            ..Self::default()
+        }
+    }
+
+    /// The [`BackfillOptions`] this payload describes.
+    #[must_use]
+    pub fn options(&self, default_batch_size: usize) -> BackfillOptions {
+        BackfillOptions::default()
+            .batch_size(self.batch_size.unwrap_or(default_batch_size))
+            .purge(self.purge)
+    }
+}
+
+/// The boxed future a [`JobHandler`] returns.
+type JobFuture = Pin<Box<dyn Future<Output = AutumnResult<()>> + Send + 'static>>;
+
+/// Pull the installed [`SearchClient`] off application state.
+///
+/// # Errors
+///
+/// Returns an error naming the missing builder call when the plugin was not
+/// installed, rather than silently skipping the index update.
+pub fn client_from_state(state: &AppState) -> AutumnResult<Arc<SearchClient>> {
+    state.extension::<SearchClient>().ok_or_else(|| {
+        AutumnError::internal_server_error_msg(
+            "the SearchClient extension is not installed; add \
+             `.plugin(SearchPlugin::new()…)` to the app builder",
+        )
+    })
+}
+
+fn reindex_handler(state: AppState, args: serde_json::Value) -> JobFuture {
+    Box::pin(async move {
+        let args: ReindexArgs = serde_json::from_value(args).map_err(|e| {
+            AutumnError::internal_server_error_msg(format!("invalid reindex payload: {e}"))
+        })?;
+        let client = client_from_state(&state)?;
+        client.reindex(&args).await?;
+        Ok(())
+    })
+}
+
+fn backfill_handler(state: AppState, args: serde_json::Value) -> JobFuture {
+    Box::pin(async move {
+        let args: BackfillArgs = serde_json::from_value(args).map_err(|e| {
+            AutumnError::internal_server_error_msg(format!("invalid backfill payload: {e}"))
+        })?;
+        let client = client_from_state(&state)?;
+        let options = args.options(BackfillOptions::default().batch_size);
+        match &args.index {
+            Some(index) => {
+                client.backfill(index, &options).await?;
+            }
+            None => {
+                client.backfill_all(&options).await?;
+            }
+        }
+        Ok(())
+    })
+}
+
+/// The [`JobInfo`] set for the search jobs, routed to `queue`.
+///
+/// Mirrors `autumn-media-plugin`'s `media_job_infos`: the queue is rewritten
+/// at registration so an application's `SearchPlugin::queue(...)` override
+/// actually takes effect (the enqueue chokepoint routes by the registered
+/// `JobInfo`).
+#[must_use]
+pub fn search_job_infos(queue: &str) -> Vec<JobInfo> {
+    let reindex: JobHandler = reindex_handler;
+    let backfill: JobHandler = backfill_handler;
+    [
+        // Reindex is cheap and idempotent — retry it eagerly.
+        JobInfo::new(REINDEX_JOB, 5, 250, reindex),
+        // A backfill is long and expensive; a tight retry loop would stampede.
+        JobInfo::new(BACKFILL_JOB, 3, 30_000, backfill),
+    ]
+    .into_iter()
+    .map(|mut info| {
+        queue.clone_into(&mut info.queue);
+        info
+    })
+    .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn both_jobs_are_registered_on_the_requested_queue() {
+        let infos = search_job_infos("indexing");
+        let names: Vec<&str> = infos.iter().map(|i| i.name.as_str()).collect();
+        assert_eq!(names, vec![REINDEX_JOB, BACKFILL_JOB]);
+        assert!(infos.iter().all(|i| i.queue == "indexing"));
+    }
+
+    #[test]
+    fn the_backfill_backs_off_much_harder_than_a_reindex() {
+        let infos = search_job_infos("search");
+        let reindex = infos
+            .iter()
+            .find(|i| i.name == REINDEX_JOB)
+            .expect("reindex");
+        let backfill = infos
+            .iter()
+            .find(|i| i.name == BACKFILL_JOB)
+            .expect("backfill");
+        assert!(backfill.initial_backoff_ms > reindex.initial_backoff_ms);
+    }
+
+    #[test]
+    fn reindex_args_round_trip() {
+        for args in [
+            ReindexArgs::upsert("articles", 1),
+            ReindexArgs::delete("articles", 2),
+        ] {
+            let json = serde_json::to_value(&args).expect("serialize");
+            let back: ReindexArgs = serde_json::from_value(json).expect("deserialize");
+            assert_eq!(back, args);
+        }
+    }
+
+    #[test]
+    fn the_reindex_op_wire_format_is_snake_case() {
+        let json = serde_json::to_value(ReindexArgs::delete("articles", 1)).expect("serialize");
+        assert_eq!(json["op"], serde_json::json!("delete"));
+        assert_eq!(json["index"], serde_json::json!("articles"));
+        assert_eq!(json["id"], serde_json::json!(1));
+    }
+
+    #[test]
+    fn the_dedup_key_collapses_repeated_writes_to_one_record() {
+        assert_eq!(
+            ReindexArgs::upsert("articles", 7).unique_key(),
+            ReindexArgs::delete("articles", 7).unique_key()
+        );
+        assert_ne!(
+            ReindexArgs::upsert("articles", 7).unique_key(),
+            ReindexArgs::upsert("articles", 8).unique_key()
+        );
+        assert_ne!(
+            ReindexArgs::upsert("articles", 7).unique_key(),
+            ReindexArgs::upsert("notes", 7).unique_key()
+        );
+    }
+
+    #[test]
+    fn backfill_args_default_to_every_index() {
+        let args = BackfillArgs::default();
+        assert!(args.index.is_none());
+        assert!(!args.purge);
+        assert_eq!(args.options(500).batch_size, 500);
+        assert_eq!(args.options(500).effective_batch_size(), 500);
+    }
+
+    #[test]
+    fn backfill_args_round_trip_and_omit_absent_fields() {
+        let args = BackfillArgs::for_index("articles");
+        let json = serde_json::to_value(&args).expect("serialize");
+        assert_eq!(json["index"], serde_json::json!("articles"));
+        assert!(json.get("batch_size").is_none());
+        let back: BackfillArgs = serde_json::from_value(json).expect("deserialize");
+        assert_eq!(back, args);
+    }
+
+    #[test]
+    fn an_explicit_batch_size_overrides_the_configured_default() {
+        let args = BackfillArgs {
+            batch_size: Some(10),
+            ..BackfillArgs::default()
+        };
+        assert_eq!(args.options(500).batch_size, 10);
+    }
+}

--- a/autumn-search/src/jobs.rs
+++ b/autumn-search/src/jobs.rs
@@ -44,6 +44,25 @@ pub enum ReindexOp {
     Delete,
 }
 
+/// Payload field naming the per-record concurrency scope.
+///
+/// The framework resolves a concurrency scope from **one** payload field, so
+/// the composite `(index, id)` key has to exist as a field rather than be
+/// computed from two. See [`reindex_concurrency`].
+pub const REINDEX_SCOPE_FIELD: &str = "scope";
+
+/// At most one in-flight reindex per record.
+///
+/// Scoped by [`REINDEX_SCOPE_FIELD`], so distinct records still reindex fully
+/// in parallel — the cap is per `(index, id)`, not per job type.
+#[must_use]
+pub fn reindex_concurrency() -> autumn_web::job::JobConcurrency {
+    autumn_web::job::JobConcurrency {
+        limit: 1,
+        key: Some(REINDEX_SCOPE_FIELD.to_owned()),
+    }
+}
+
 /// Payload of the [`REINDEX_JOB`].
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ReindexArgs {
@@ -53,26 +72,42 @@ pub struct ReindexArgs {
     pub id: i64,
     /// The operation.
     pub op: ReindexOp,
+    /// `"{index}:{id}"` — the per-record concurrency scope.
+    ///
+    /// Denormalized into the payload on purpose: it is redundant with `index`
+    /// and `id`, but the concurrency limiter reads a single named field, and
+    /// scoping on `id` alone would needlessly serialize record 7 of one index
+    /// against record 7 of another (auto-increment keys collide constantly
+    /// across tables).
+    ///
+    /// `#[serde(default)]` so a payload enqueued by an older deploy still
+    /// deserializes; it lands in a shared scope, which over-serializes for the
+    /// length of the rollout rather than losing the guarantee.
+    #[serde(default)]
+    pub scope: String,
 }
 
 impl ReindexArgs {
     /// An upsert instruction (create or update).
     #[must_use]
     pub fn upsert(index: impl Into<String>, id: i64) -> Self {
-        Self {
-            index: index.into(),
-            id,
-            op: ReindexOp::Upsert,
-        }
+        Self::new(index, id, ReindexOp::Upsert)
     }
 
     /// A delete instruction.
     #[must_use]
     pub fn delete(index: impl Into<String>, id: i64) -> Self {
+        Self::new(index, id, ReindexOp::Delete)
+    }
+
+    /// Build an instruction, deriving [`scope`](Self::scope).
+    fn new(index: impl Into<String>, id: i64, op: ReindexOp) -> Self {
+        let index = index.into();
         Self {
-            index: index.into(),
+            scope: format!("{index}:{id}"),
+            index,
             id,
-            op: ReindexOp::Delete,
+            op,
         }
     }
 
@@ -85,7 +120,7 @@ impl ReindexArgs {
     /// this scheme, so collapsing them is safe rather than lossy.
     #[must_use]
     pub fn unique_key(&self) -> String {
-        format!("{}:{}", self.index, self.id)
+        self.scope.clone()
     }
 }
 
@@ -196,6 +231,20 @@ pub fn search_job_infos(queue: &str) -> Vec<JobInfo> {
         // the index would keep the pre-write text.
         window: JobUniquenessWindow::Pending,
     });
+    // …and because the key is released at start, two jobs for one record can
+    // be in flight at once on a multi-worker deployment. Both re-read the
+    // source, so they interleave as: A reads (state 1) → write lands (state 2)
+    // → B reads (state 2) → B writes state 2 → A writes state 1. The index
+    // keeps the STALE text until the next mutation or backfill, and the same
+    // ordering resurrects a document whose row B had just seen deleted. The
+    // window is not narrow either: an embedding provider call sits between A's
+    // read and A's write.
+    //
+    // A per-record cap of one closes it without giving up the follow-up. The
+    // second job is still enqueued immediately (that is what `Pending` buys),
+    // it simply cannot start until the first finishes — at which point it
+    // re-reads and converges on the latest state.
+    reindex.concurrency = Some(reindex_concurrency());
 
     // A backfill is long and expensive; a tight retry loop would stampede, and
     // two concurrent full rebuilds of one index are pure waste.
@@ -238,6 +287,66 @@ mod tests {
             .find(|i| i.name == BACKFILL_JOB)
             .expect("backfill");
         assert!(backfill.initial_backoff_ms > reindex.initial_backoff_ms);
+    }
+
+    #[test]
+    fn reindex_is_capped_at_one_in_flight_job_per_record() {
+        // Uniqueness releases the key when the job STARTS, so without this cap
+        // two jobs for one record run concurrently and the slower one's stale
+        // read overwrites the newer one's write.
+        let reindex = search_job_infos("search")
+            .into_iter()
+            .find(|i| i.name == REINDEX_JOB)
+            .expect("reindex");
+        let concurrency = reindex.concurrency.expect("a per-record cap");
+        assert_eq!(concurrency.limit, 1);
+        assert_eq!(concurrency.key.as_deref(), Some(REINDEX_SCOPE_FIELD));
+    }
+
+    #[test]
+    fn the_concurrency_scope_is_a_real_payload_field_and_is_per_record() {
+        // The limiter resolves the scope by looking `key` up in the serialized
+        // payload. If the field name and the declared key ever drift, EVERY
+        // payload resolves to the same missing-field scope and a limit of 1
+        // silently becomes a global serialization of all reindexing — slow,
+        // and with no signal that the per-record guarantee was lost.
+        let args = ReindexArgs::upsert("articles", 7);
+        let json = serde_json::to_value(&args).expect("serialize");
+        assert_eq!(
+            json.get(REINDEX_SCOPE_FIELD).and_then(|v| v.as_str()),
+            Some("articles:7"),
+            "the declared concurrency key must name a field that is actually there: {json}"
+        );
+
+        // Per RECORD, not per id: auto-increment keys collide across tables,
+        // and scoping on `id` alone would serialize unrelated records.
+        assert_ne!(
+            ReindexArgs::upsert("articles", 7).scope,
+            ReindexArgs::upsert("notes", 7).scope
+        );
+        assert_ne!(
+            ReindexArgs::upsert("articles", 7).scope,
+            ReindexArgs::upsert("articles", 8).scope
+        );
+        // An upsert and a delete for one record DO share a scope: they are the
+        // pair that must not interleave.
+        assert_eq!(
+            ReindexArgs::upsert("articles", 7).scope,
+            ReindexArgs::delete("articles", 7).scope
+        );
+    }
+
+    #[test]
+    fn a_payload_without_a_scope_still_deserializes() {
+        // An in-flight payload enqueued by an older deploy has no `scope`. It
+        // must still run — it lands in a shared concurrency scope, which
+        // over-serializes for the length of the rollout rather than failing.
+        let args: ReindexArgs =
+            serde_json::from_str(r#"{"index":"articles","id":7,"op":"upsert"}"#).expect("legacy");
+        assert_eq!(args.index, "articles");
+        assert_eq!(args.id, 7);
+        assert_eq!(args.op, ReindexOp::Upsert);
+        assert_eq!(args.scope, "");
     }
 
     #[test]

--- a/autumn-search/src/jobs.rs
+++ b/autumn-search/src/jobs.rs
@@ -16,7 +16,7 @@ use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
 
-use autumn_web::job::{JobHandler, JobInfo};
+use autumn_web::job::{JobHandler, JobInfo, JobUniqueness, JobUniquenessWindow};
 use autumn_web::{AppState, AutumnError, AutumnResult};
 use serde::{Deserialize, Serialize};
 
@@ -152,7 +152,9 @@ fn backfill_handler(state: AppState, args: serde_json::Value) -> JobFuture {
             AutumnError::internal_server_error_msg(format!("invalid backfill payload: {e}"))
         })?;
         let client = client_from_state(&state)?;
-        let options = args.options(BackfillOptions::default().batch_size);
+        // The app's configured `[search] batch_size`, not the compiled-in
+        // default — otherwise configuring it would only affect the CLI path.
+        let options = args.options(client.default_batch_size());
         match &args.index {
             Some(index) => {
                 client.backfill(index, &options).await?;
@@ -175,18 +177,36 @@ fn backfill_handler(state: AppState, args: serde_json::Value) -> JobFuture {
 pub fn search_job_infos(queue: &str) -> Vec<JobInfo> {
     let reindex: JobHandler = reindex_handler;
     let backfill: JobHandler = backfill_handler;
-    [
-        // Reindex is cheap and idempotent — retry it eagerly.
-        JobInfo::new(REINDEX_JOB, 5, 250, reindex),
-        // A backfill is long and expensive; a tight retry loop would stampede.
-        JobInfo::new(BACKFILL_JOB, 3, 30_000, backfill),
-    ]
-    .into_iter()
-    .map(|mut info| {
-        queue.clone_into(&mut info.queue);
-        info
-    })
-    .collect()
+
+    // Repeated writes to the same record collapse to one pending reindex. The
+    // job re-reads the row, so N queued reindexes of the same id would each
+    // read the same final state — only the last does distinct work. Keyed on
+    // `index` + `id` (NOT `op`), because an upsert and a delete for the same
+    // record must not both sit in the queue racing each other.
+    let mut reindex = JobInfo::new(REINDEX_JOB, 5, 250, reindex);
+    reindex.uniqueness = Some(JobUniqueness {
+        by: vec!["index".to_owned(), "id".to_owned()],
+        // Released when the job starts, not when it finishes: a write that
+        // lands *while* a reindex is running still needs its own reindex, or
+        // the index would keep the pre-write text.
+        window: JobUniquenessWindow::Pending,
+    });
+
+    // A backfill is long and expensive; a tight retry loop would stampede, and
+    // two concurrent full rebuilds of one index are pure waste.
+    let mut backfill = JobInfo::new(BACKFILL_JOB, 3, 30_000, backfill);
+    backfill.uniqueness = Some(JobUniqueness {
+        by: vec!["index".to_owned()],
+        window: JobUniquenessWindow::Running,
+    });
+
+    [reindex, backfill]
+        .into_iter()
+        .map(|mut info| {
+            queue.clone_into(&mut info.queue);
+            info
+        })
+        .collect()
 }
 
 #[cfg(test)]
@@ -249,6 +269,38 @@ mod tests {
             ReindexArgs::upsert("articles", 7).unique_key(),
             ReindexArgs::upsert("notes", 7).unique_key()
         );
+    }
+
+    #[test]
+    fn the_reindex_job_actually_declares_that_dedup_to_the_queue() {
+        // The key above is only real if it is registered: `JobInfo.uniqueness`
+        // is what the enqueue chokepoint consults. Without this the doc on
+        // `unique_key` would be a claim about nothing.
+        let infos = search_job_infos("search");
+        let reindex = infos
+            .iter()
+            .find(|i| i.name == REINDEX_JOB)
+            .expect("reindex");
+        let uniqueness = reindex.uniqueness.as_ref().expect("reindex must dedup");
+        assert_eq!(uniqueness.by, vec!["index".to_owned(), "id".to_owned()]);
+        // Not keyed on `op`: an upsert and a delete for one record must not
+        // both sit in the queue racing each other.
+        assert!(!uniqueness.by.contains(&"op".to_owned()));
+        // Released when the job starts, so a write landing mid-reindex still
+        // gets its own reindex.
+        assert_eq!(uniqueness.window, JobUniquenessWindow::Pending);
+    }
+
+    #[test]
+    fn concurrent_full_rebuilds_of_one_index_are_deduped_while_running() {
+        let infos = search_job_infos("search");
+        let backfill = infos
+            .iter()
+            .find(|i| i.name == BACKFILL_JOB)
+            .expect("backfill");
+        let uniqueness = backfill.uniqueness.as_ref().expect("backfill must dedup");
+        assert_eq!(uniqueness.by, vec!["index".to_owned()]);
+        assert_eq!(uniqueness.window, JobUniquenessWindow::Running);
     }
 
     #[test]

--- a/autumn-search/src/jobs.rs
+++ b/autumn-search/src/jobs.rs
@@ -33,11 +33,14 @@ pub const BACKFILL_JOB: &str = "autumn_search_backfill";
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum ReindexOp {
-    /// Re-read the row and write it — or delete the document if the row is
-    /// gone. This covers create **and** update, because both mean "the row
-    /// changed; make the index agree".
+    /// The record was created or updated. Re-reads the row and writes it — or
+    /// deletes the document if the row is gone. Create and update are the same
+    /// instruction, because both mean "the row changed; make the index agree".
     Upsert,
-    /// Remove the document without consulting the source.
+    /// The record was deleted. Still re-reads the source and converges — a
+    /// row that has been recreated under the same primary key must survive a
+    /// late or retried delete. With no `DocumentSource` installed this falls
+    /// back to removing the document outright, which needs no source.
     Delete,
 }
 
@@ -76,8 +79,10 @@ impl ReindexArgs {
     /// The dedup key for this instruction.
     ///
     /// Repeated writes to the same record inside one queue window collapse to
-    /// one reindex — the job re-reads the row, so only the *last* one would
-    /// have done any distinct work anyway.
+    /// one reindex — every instruction re-reads the row, so they are all the
+    /// same operation and only one need run. Deliberately **not** keyed on
+    /// `op`: an upsert and a delete for one record are interchangeable under
+    /// this scheme, so collapsing them is safe rather than lossy.
     #[must_use]
     pub fn unique_key(&self) -> String {
         format!("{}:{}", self.index, self.id)

--- a/autumn-search/src/lib.rs
+++ b/autumn-search/src/lib.rs
@@ -1,0 +1,137 @@
+//! Keyword **and** vector search for `autumn-web` applications (issue #1191).
+//!
+//! Autumn already had full-text search *primitives* in core (#842): a
+//! `#[searchable]` model attribute, a `tsvector` column, and a
+//! `#[repository(searchable)]` `search()` method. What it did not have was a
+//! **search subsystem** — a way to declare a model searchable, keep an index
+//! in sync as records change, and query it through one engine-agnostic API,
+//! let alone semantic / vector search for "find similar" and RAG retrieval.
+//!
+//! This crate is that subsystem: the autumn-shaped answer to Laravel Scout,
+//! with vectors first-class rather than bolted on.
+//!
+//! # Quick start
+//!
+//! ```rust,ignore
+//! use std::sync::Arc;
+//! use autumn_search::{SearchPlugin, SearchSyncHooks};
+//!
+//! // 1. Mark the model searchable. `embed` nominates the field to embed.
+//! #[autumn_web::model]
+//! #[searchable(language = "english")]
+//! pub struct Article {
+//!     #[id] pub id: i64,
+//!     #[searchable(weight = "A")] pub title: String,
+//!     #[searchable(weight = "B", embed)] pub body: String,
+//! }
+//!
+//! // 2. Keep the index in sync from the record lifecycle.
+//! #[autumn_web::repository(
+//!     Article,
+//!     hooks = SearchSyncHooks<Article, NewArticle, UpdateArticle>,
+//!     commit_hooks = true,
+//! )]
+//! pub trait ArticleRepository {}
+//!
+//! // 3. Mount the plugin.
+//! autumn_web::app()
+//!     .plugin(
+//!         SearchPlugin::new()
+//!             .postgres()
+//!             .embedder(Arc::new(MyEmbedder))
+//!             .index::<Article>(),
+//!     )
+//!     .run()
+//!     .await;
+//!
+//! // 4. Query it.
+//! let page = search.search::<Article>("rust web framework", &page_req).await?;
+//! let similar = search.similar::<Article>("how do I add auth?", 5).await?;
+//! ```
+//!
+//! # How the pieces fit
+//!
+//! | Concern | Type | Notes |
+//! | --- | --- | --- |
+//! | Index shape | `autumn_web::search::IndexDefinition` | derived from `#[searchable]`, never hand-written |
+//! | Record extraction | `autumn_web::search::SearchDocument` | derived from `#[searchable]` |
+//! | Engine | [`SearchBackend`] | [`MemorySearchBackend`], [`PostgresSearchStore`], or yours |
+//! | Embeddings | [`Embedder`] | no model or vendor ships here, by design |
+//! | Index sync | [`SearchSyncHooks`] → [`ReindexArgs`] → `#[job]` | off-request and durable |
+//! | Reading records | [`DocumentSource`] | drives both reindex and backfill |
+//! | Authorization | [`SearchVisibility`] → [`SearchFilter`] | pushed *into* the engine query |
+//! | Querying | [`SearchClient`] | `Page`/`ListQuery`-shaped results |
+//!
+//! # Design notes worth knowing
+//!
+//! **Reindex re-reads the row.** A reindex job carries `(index, id)`, not the
+//! record. So create, update, delete, a replayed job, a lost event, and a row
+//! changed by direct SQL all converge to the same index state, and
+//! at-least-once delivery is safe by construction.
+//!
+//! **Filters are arguments, not afterthoughts.** [`SearchFilter`] is a
+//! required parameter of the backend query methods, so an engine cannot
+//! quietly return rows the caller may not see; filters *intersect*, so a
+//! caller can only ever narrow what authorization allowed.
+//!
+//! **Query text is a bag of words.** Every token must match, and operator
+//! syntax (`OR`, `field:`, `*`) is never interpreted. That keeps results
+//! consistent across engines and makes a hostile query structurally incapable
+//! of widening the result set.
+
+// autumn-panic-gate: request-path crate — production code path must be panic-free.
+// See CONTRIBUTING.md "Request-path panic gate". Justify exceptions with
+// #[allow(clippy::<lint>, reason = "…")] at the narrowest scope.
+#![cfg_attr(
+    not(test),
+    deny(
+        clippy::unwrap_used,
+        clippy::panic,
+        clippy::unreachable,
+        clippy::todo,
+        clippy::unimplemented,
+        clippy::indexing_slicing,
+    )
+)]
+
+mod authz;
+mod backend;
+mod client;
+mod config;
+mod embedding;
+mod error;
+mod jobs;
+mod memory;
+mod plugin;
+mod postgres;
+mod source;
+mod sync;
+mod text;
+
+pub use authz::{DenyAll, SearchVisibility, TenantVisibility, current_tenant_filter};
+pub use backend::{
+    BackendCapabilities, BoxFuture, IndexedDocument, KeywordQuery, SearchBackend, SearchFilter,
+    SearchHit, TENANT_FILTER_KEY, VectorQuery, empty_page,
+};
+pub use client::{BackfillOptions, BackfillReport, SearchClient, SearchClientBuilder};
+pub use config::{SearchConfig, SearchConfigError};
+pub use embedding::{Embedder, HashingEmbedder, NoEmbedder, cosine_similarity, normalize};
+pub use error::{SearchError, SearchResult};
+pub use jobs::{
+    BACKFILL_JOB, BackfillArgs, REINDEX_JOB, ReindexArgs, ReindexOp, client_from_state,
+    search_job_infos,
+};
+pub use memory::MemorySearchBackend;
+pub use plugin::{
+    BACKFILL_ENV, BACKFILL_PURGE_ENV, BackfillTarget, SearchPlugin, backfill_request_from_env,
+};
+pub use postgres::{DOCUMENTS_TABLE, PostgresSearchStore, VectorMode};
+pub use source::{DocumentSource, MemoryDocumentSource};
+pub use sync::{SearchSyncHooks, enqueue_reindex, enqueue_reindex_for, enqueue_unindex_for};
+pub use text::{query_tokens, tokenize};
+
+// Re-exported so an app can name the derived vocabulary without also depending
+// on `autumn_web::search` directly.
+pub use autumn_web::search::{
+    IndexDefinition, SearchDocument, SearchFieldValue, SearchIndexField, SearchIndexed,
+};

--- a/autumn-search/src/lib.rs
+++ b/autumn-search/src/lib.rs
@@ -112,7 +112,9 @@ mod source;
 mod sync;
 mod text;
 
-pub use authz::{DenyAll, SearchVisibility, TenantVisibility, current_tenant_filter};
+pub use authz::{
+    DenyAll, SearchVisibility, TenantVisibility, ambient_tenant_filter, current_tenant_filter,
+};
 pub use backend::{
     BackendCapabilities, BoxFuture, IndexedDocument, KeywordQuery, SearchBackend, SearchFilter,
     SearchHit, TENANT_FILTER_KEY, VectorQuery, empty_page,

--- a/autumn-search/src/lib.rs
+++ b/autumn-search/src/lib.rs
@@ -49,8 +49,10 @@
 //! let similar = search.similar::<Article>("how do I add auth?", 5).await?;
 //! ```
 //!
-//! Configuration comes from `[search]` in `autumn.toml`, which the plugin
-//! loads itself unless the app passes `SearchPlugin::config(...)`.
+//! Configuration comes from `[search]`, which the plugin resolves itself
+//! (base `autumn.toml` → `[profile.<name>.search]` → `autumn-<profile>.toml`
+//! → `AUTUMN_SEARCH__*`, the same layering core applies) unless the app passes
+//! `SearchPlugin::config(...)`.
 //!
 //! # How the pieces fit
 //!

--- a/autumn-search/src/lib.rs
+++ b/autumn-search/src/lib.rs
@@ -25,12 +25,11 @@
 //!     #[searchable(weight = "B", embed)] pub body: String,
 //! }
 //!
-//! // 2. Keep the index in sync from the record lifecycle.
-//! #[autumn_web::repository(
-//!     Article,
-//!     hooks = SearchSyncHooks<Article, NewArticle, UpdateArticle>,
-//!     commit_hooks = true,
-//! )]
+//! // 2. Keep the index in sync from the record lifecycle. `#[repository]`
+//! //    takes a plain type NAME for `hooks`, so alias the generic first.
+//! type ArticleSearchHooks = SearchSyncHooks<Article, NewArticle, UpdateArticle>;
+//!
+//! #[autumn_web::repository(Article, hooks = ArticleSearchHooks, commit_hooks = true)]
 //! pub trait ArticleRepository {}
 //!
 //! // 3. Mount the plugin.
@@ -44,10 +43,14 @@
 //!     .run()
 //!     .await;
 //!
-//! // 4. Query it.
+//! // 4. Query it. The plugin installs the client as an `AppState` extension.
+//! let search = state.extension::<SearchClient>().expect("SearchPlugin installed");
 //! let page = search.search::<Article>("rust web framework", &page_req).await?;
 //! let similar = search.similar::<Article>("how do I add auth?", 5).await?;
 //! ```
+//!
+//! Configuration comes from `[search]` in `autumn.toml`, which the plugin
+//! loads itself unless the app passes `SearchPlugin::config(...)`.
 //!
 //! # How the pieces fit
 //!
@@ -86,6 +89,7 @@
     not(test),
     deny(
         clippy::unwrap_used,
+        clippy::expect_used,
         clippy::panic,
         clippy::unreachable,
         clippy::todo,
@@ -134,4 +138,10 @@ pub use text::{query_tokens, tokenize};
 // on `autumn_web::search` directly.
 pub use autumn_web::search::{
     IndexDefinition, SearchDocument, SearchFieldValue, SearchIndexField, SearchIndexed,
+    SearchTextValue,
 };
+
+// Results are `Page`-shaped and queries are `PageRequest`/`ListQuery`-shaped,
+// so re-export those too rather than making every call site reach into
+// `autumn_web::pagination`.
+pub use autumn_web::pagination::{ListQuery, Page, PageRequest};

--- a/autumn-search/src/memory.rs
+++ b/autumn-search/src/memory.rs
@@ -35,6 +35,22 @@ use crate::text::{query_tokens, tokenize};
 #[derive(Debug, Default)]
 pub struct MemorySearchBackend {
     indexes: RwLock<HashMap<String, HashMap<i64, IndexedDocument>>>,
+    /// Per-document write sequence, and the source of the write watermark.
+    ///
+    /// A monotonic counter rather than a clock: the watermark only ever has to
+    /// answer "was this written after that", and a counter answers it exactly,
+    /// with no resolution floor and nothing to skew. It is also what lets the
+    /// backfill-versus-reindex ordering be tested deterministically without a
+    /// database.
+    writes: RwLock<WriteLog>,
+}
+
+/// The monotonic write counter plus, per index, the sequence each document was
+/// last written at.
+#[derive(Debug, Default)]
+struct WriteLog {
+    next: u64,
+    sequences: HashMap<String, HashMap<i64, u64>>,
 }
 
 impl MemorySearchBackend {
@@ -82,6 +98,69 @@ impl MemorySearchBackend {
             .write()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
         f(guard.entry(definition.name.to_owned()).or_default())
+    }
+
+    /// The current write sequence.
+    fn sequence(&self) -> u64 {
+        self.writes
+            .read()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .next
+    }
+
+    /// Upsert `documents`, skipping any whose stored write is newer than
+    /// `watermark`. The single write path behind both `index` and
+    /// `index_unless_newer`, so the two cannot drift apart.
+    fn write(
+        &self,
+        definition: &IndexDefinition,
+        documents: &[IndexedDocument],
+        watermark: Option<u64>,
+    ) -> SearchResult<()> {
+        definition
+            .validate()
+            .map_err(|e| SearchError::InvalidIndex(e.to_string()))?;
+
+        let mut writes = self
+            .writes
+            .write()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let mut applied: Vec<(i64, u64)> = Vec::with_capacity(documents.len());
+        {
+            let WriteLog { next, sequences } = &mut *writes;
+            let seen = sequences.entry(definition.name.to_owned()).or_default();
+            for document in documents {
+                // A document written after the watermark is left alone: the
+                // writer that produced it read the source more recently than
+                // this batch did, so overwriting it would move the index
+                // backwards.
+                if let (Some(watermark), Some(written)) = (watermark, seen.get(&document.id()))
+                    && *written > watermark
+                {
+                    continue;
+                }
+                *next += 1;
+                applied.push((document.id(), *next));
+            }
+            for (id, sequence) in &applied {
+                seen.insert(*id, *sequence);
+            }
+        }
+        drop(writes);
+
+        let applied_ids: std::collections::HashSet<i64> =
+            applied.iter().map(|(id, _)| *id).collect();
+        self.with_index(definition, |index| {
+            for document in documents {
+                if !applied_ids.contains(&document.id()) {
+                    continue;
+                }
+                // Keyed upsert: re-indexing the same record replaces it, so
+                // at-least-once delivery can never duplicate a document.
+                index.insert(document.id(), document.clone());
+            }
+        });
+        Ok(())
     }
 
     /// Run `f` against a read view of the documents for `definition`.
@@ -178,6 +257,7 @@ impl SearchBackend for MemorySearchBackend {
             .with_vector(true)
             .with_weighted_fields(true)
             .with_embedding_readback(true)
+            .with_conditional_index(true)
     }
 
     fn ensure_index<'a>(
@@ -198,18 +278,25 @@ impl SearchBackend for MemorySearchBackend {
         definition: &'a IndexDefinition,
         documents: &'a [IndexedDocument],
     ) -> BoxFuture<'a, SearchResult<()>> {
+        Box::pin(async move { self.write(definition, documents, None) })
+    }
+
+    fn write_watermark(&self) -> BoxFuture<'_, SearchResult<Option<String>>> {
+        Box::pin(async move { Ok(Some(self.sequence().to_string())) })
+    }
+
+    fn index_unless_newer<'a>(
+        &'a self,
+        definition: &'a IndexDefinition,
+        documents: &'a [IndexedDocument],
+        watermark: Option<&'a str>,
+    ) -> BoxFuture<'a, SearchResult<()>> {
         Box::pin(async move {
-            definition
-                .validate()
-                .map_err(|e| SearchError::InvalidIndex(e.to_string()))?;
-            self.with_index(definition, |index| {
-                for document in documents {
-                    // Keyed upsert: re-indexing the same record replaces it, so
-                    // at-least-once delivery can never duplicate a document.
-                    index.insert(document.id(), document.clone());
-                }
-            });
-            Ok(())
+            self.write(
+                definition,
+                documents,
+                watermark.and_then(|w| w.parse().ok()),
+            )
         })
     }
 

--- a/autumn-search/src/memory.rs
+++ b/autumn-search/src/memory.rs
@@ -21,8 +21,8 @@ use autumn_web::pagination::{Page, PageRequest};
 use autumn_web::search::{IndexDefinition, weight_factor};
 
 use crate::backend::{
-    BackendCapabilities, BoxFuture, IndexedDocument, KeywordQuery, SearchBackend, SearchHit,
-    VectorQuery, empty_page,
+    BackendCapabilities, BoxFuture, IndexedDocument, KeywordQuery, SearchBackend, SearchFilter,
+    SearchHit, VectorQuery, empty_page,
 };
 use crate::embedding::cosine_similarity;
 use crate::error::{SearchError, SearchResult};
@@ -49,7 +49,9 @@ impl MemorySearchBackend {
     pub fn document_count(&self, index: &str) -> usize {
         self.indexes
             .read()
-            .map_or(0, |guard| guard.get(index).map_or(0, HashMap::len))
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .get(index)
+            .map_or(0, HashMap::len)
     }
 
     /// Names of every index that has been created.
@@ -58,23 +60,28 @@ impl MemorySearchBackend {
         let mut names: Vec<String> = self
             .indexes
             .read()
-            .map(|guard| guard.keys().cloned().collect())
-            .unwrap_or_default();
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .keys()
+            .cloned()
+            .collect();
         names.sort();
         names
     }
 
     /// Run `f` against the (created-on-demand) document map for `definition`.
+    /// Recovers from a poisoned lock rather than propagating, per
+    /// CONTRIBUTING.md's contract: the guarded data is a plain document map
+    /// with no invariant a panicking writer could have left half-applied.
     fn with_index<T>(
         &self,
         definition: &IndexDefinition,
         f: impl FnOnce(&mut HashMap<i64, IndexedDocument>) -> T,
-    ) -> SearchResult<T> {
+    ) -> T {
         let mut guard = self
             .indexes
             .write()
-            .map_err(|_| SearchError::Backend("in-memory index lock poisoned".to_owned()))?;
-        Ok(f(guard.entry(definition.name.to_owned()).or_default()))
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        f(guard.entry(definition.name.to_owned()).or_default())
     }
 
     /// Run `f` against a read view of the documents for `definition`.
@@ -82,12 +89,12 @@ impl MemorySearchBackend {
         &self,
         definition: &IndexDefinition,
         f: impl FnOnce(Option<&HashMap<i64, IndexedDocument>>) -> T,
-    ) -> SearchResult<T> {
+    ) -> T {
         let guard = self
             .indexes
             .read()
-            .map_err(|_| SearchError::Backend("in-memory index lock poisoned".to_owned()))?;
-        Ok(f(guard.get(definition.name)))
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        f(guard.get(definition.name))
     }
 }
 
@@ -128,12 +135,12 @@ fn score(document: &IndexedDocument, tokens: &[String]) -> Option<f32> {
 /// Sort hits into the canonical order: score descending, then id ascending so
 /// ties are stable across calls (and so pagination never skips or repeats).
 fn sort_hits(hits: &mut [SearchHit]) {
-    hits.sort_by(|a, b| {
-        b.score
-            .partial_cmp(&a.score)
-            .unwrap_or(std::cmp::Ordering::Equal)
-            .then_with(|| a.id.cmp(&b.id))
-    });
+    // `total_cmp`, not `partial_cmp(..).unwrap_or(Equal)`: mapping NaN to
+    // `Equal` yields a non-transitive comparator, and `sort_by` panics on one
+    // ("user-provided comparison function does not correctly implement a total
+    // order"). No in-tree producer emits NaN, but a third-party backend or a
+    // hand-built `SearchHit` can.
+    hits.sort_by(|a, b| b.score.total_cmp(&a.score).then_with(|| a.id.cmp(&b.id)));
 }
 
 /// Take the `request`-th page of `hits`, preserving the pre-slice total.
@@ -151,12 +158,10 @@ impl SearchBackend for MemorySearchBackend {
     }
 
     fn capabilities(&self) -> BackendCapabilities {
-        BackendCapabilities {
-            keyword: true,
-            vector: true,
-            weighted_fields: true,
-            embedding_readback: true,
-        }
+        BackendCapabilities::default()
+            .with_vector(true)
+            .with_weighted_fields(true)
+            .with_embedding_readback(true)
     }
 
     fn ensure_index<'a>(
@@ -167,7 +172,7 @@ impl SearchBackend for MemorySearchBackend {
             definition
                 .validate()
                 .map_err(|e| SearchError::InvalidIndex(e.to_string()))?;
-            self.with_index(definition, |_| ())?;
+            self.with_index(definition, |_| ());
             Ok(())
         })
     }
@@ -187,7 +192,8 @@ impl SearchBackend for MemorySearchBackend {
                     // at-least-once delivery can never duplicate a document.
                     index.insert(document.id(), document.clone());
                 }
-            })
+            });
+            Ok(())
         })
     }
 
@@ -202,12 +208,16 @@ impl SearchBackend for MemorySearchBackend {
                     // Absent ids are a no-op: deletes are replayed.
                     index.remove(id);
                 }
-            })
+            });
+            Ok(())
         })
     }
 
     fn clear<'a>(&'a self, definition: &'a IndexDefinition) -> BoxFuture<'a, SearchResult<()>> {
-        Box::pin(async move { self.with_index(definition, HashMap::clear) })
+        Box::pin(async move {
+            self.with_index(definition, HashMap::clear);
+            Ok(())
+        })
     }
 
     fn keyword_search<'a>(
@@ -236,7 +246,7 @@ impl SearchBackend for MemorySearchBackend {
                     }
                 }
                 hits
-            })?;
+            });
 
             sort_hits(&mut hits);
             Ok(paginate(hits, &query.page))
@@ -264,6 +274,14 @@ impl SearchBackend for MemorySearchBackend {
                     let Some(embedding) = &document.embedding else {
                         continue;
                     };
+                    // Filter FIRST: a document the caller cannot see must not
+                    // influence the outcome at all. Checking the width before
+                    // the filter would let one tenant's differently-sized
+                    // embedding abort every other tenant's vector search, and
+                    // leak that document's width in the error.
+                    if !query.filter.permits(&document.document) {
+                        continue;
+                    }
                     // A width disagreement means the index was built with a
                     // different embedder — scoring it would silently return
                     // garbage, so surface it instead.
@@ -273,9 +291,6 @@ impl SearchBackend for MemorySearchBackend {
                             actual: query.vector.len(),
                         });
                     }
-                    if !query.filter.permits(&document.document) {
-                        continue;
-                    }
                     let score = cosine_similarity(embedding, &query.vector);
                     if query.min_score.is_some_and(|min| score < min) {
                         continue;
@@ -283,7 +298,7 @@ impl SearchBackend for MemorySearchBackend {
                     hits.push(SearchHit::new(definition.name, document.id(), score));
                 }
                 None
-            })?;
+            });
             if let Some(error) = mismatch {
                 return Err(error);
             }
@@ -298,13 +313,18 @@ impl SearchBackend for MemorySearchBackend {
         &'a self,
         definition: &'a IndexDefinition,
         id: i64,
+        filter: &'a SearchFilter,
     ) -> BoxFuture<'a, SearchResult<Option<Vec<f32>>>> {
         Box::pin(async move {
-            self.read_index(definition, |index| {
+            Ok(self.read_index(definition, |index| {
                 index
                     .and_then(|documents| documents.get(&id))
+                    // A record the filter excludes reads back as absent, so a
+                    // "more like this" seed cannot be a record the caller
+                    // cannot see.
+                    .filter(|document| filter.permits(&document.document))
                     .and_then(|document| document.embedding.clone())
-            })
+            }))
         })
     }
 }
@@ -312,8 +332,6 @@ impl SearchBackend for MemorySearchBackend {
 #[cfg(test)]
 mod tests {
     use autumn_web::search::{SearchDocument, SearchIndexField};
-
-    use crate::backend::SearchFilter;
 
     use super::*;
 
@@ -323,7 +341,7 @@ mod tests {
     ];
 
     fn definition() -> IndexDefinition {
-        IndexDefinition::new("articles", "english", FIELDS, Some("body"))
+        IndexDefinition::new("articles", "english", FIELDS, Some("body"), false)
     }
 
     fn doc(id: i64, title: &str, body: &str) -> IndexedDocument {
@@ -432,10 +450,48 @@ mod tests {
         backend.ensure_index(&definition).await.expect("ensure");
         assert!(
             backend
-                .embedding(&definition, 42)
+                .embedding(&definition, 42, &SearchFilter::default())
                 .await
                 .expect("read")
                 .is_none()
+        );
+    }
+
+    #[tokio::test]
+    async fn embedding_readback_honours_the_filter() {
+        // "Find records like this one" must not become an oracle: reading the
+        // seed record's vector is a query, and a record the filter excludes
+        // must read back as absent.
+        let backend = MemorySearchBackend::new();
+        let definition = definition();
+        backend.ensure_index(&definition).await.expect("ensure");
+        backend
+            .index(
+                &definition,
+                &[IndexedDocument::new(
+                    SearchDocument::new("articles", 1)
+                        .with_field("title", 'A', "secret")
+                        .with_tenant("globex"),
+                )
+                .with_embedding(vec![1.0, 0.0])],
+            )
+            .await
+            .expect("index");
+
+        assert!(
+            backend
+                .embedding(&definition, 1, &SearchFilter::default().tenant("acme"))
+                .await
+                .expect("read")
+                .is_none(),
+            "another tenant's embedding must not be readable"
+        );
+        assert!(
+            backend
+                .embedding(&definition, 1, &SearchFilter::default().tenant("globex"))
+                .await
+                .expect("read")
+                .is_some()
         );
     }
 

--- a/autumn-search/src/memory.rs
+++ b/autumn-search/src/memory.rs
@@ -34,22 +34,32 @@ use crate::text::{query_tokens, tokenize};
 /// maps.
 #[derive(Debug, Default)]
 pub struct MemorySearchBackend {
-    indexes: RwLock<HashMap<String, HashMap<i64, IndexedDocument>>>,
-    /// Per-document write sequence, and the source of the write watermark.
+    /// Documents AND their write sequences under **one** lock.
     ///
-    /// A monotonic counter rather than a clock: the watermark only ever has to
-    /// answer "was this written after that", and a counter answers it exactly,
-    /// with no resolution floor and nothing to skew. It is also what lets the
-    /// backfill-versus-reindex ordering be tested deterministically without a
-    /// database.
-    writes: RwLock<WriteLog>,
+    /// Deliberately not two: a conditional write has to compare a sequence and
+    /// replace a document as a single step. With separate locks a backfill can
+    /// read an old sequence, a reindex can then claim a newer one and store
+    /// fresh content, and the backfill still overwrites it — the exact race
+    /// the watermark exists to prevent, reintroduced by the bookkeeping meant
+    /// to close it.
+    store: RwLock<Store>,
 }
 
-/// The monotonic write counter plus, per index, the sequence each document was
-/// last written at.
+/// Documents plus the write bookkeeping that decides which write wins.
 #[derive(Debug, Default)]
-struct WriteLog {
-    next: u64,
+struct Store {
+    documents: HashMap<String, HashMap<i64, IndexedDocument>>,
+    /// Monotonic counter behind the write watermark. A counter rather than a
+    /// clock: the watermark only ever answers "was this written after that",
+    /// which a counter answers exactly, with no resolution floor and nothing
+    /// to skew — and it makes the interleaving deterministically testable.
+    next_sequence: u64,
+    /// Per index, the sequence each record was last **written or deleted** at.
+    ///
+    /// Deletes are recorded too, and outlive the document. A delete that only
+    /// removed the value would leave no evidence it happened, so a stale
+    /// backfill batch would see no newer sequence and reinsert the record —
+    /// resurrecting something a user deleted.
     sequences: HashMap<String, HashMap<i64, u64>>,
 }
 
@@ -63,9 +73,10 @@ impl MemorySearchBackend {
     /// Number of documents currently held in `index`. Test/inspection helper.
     #[must_use]
     pub fn document_count(&self, index: &str) -> usize {
-        self.indexes
+        self.store
             .read()
             .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .documents
             .get(index)
             .map_or(0, HashMap::len)
     }
@@ -74,9 +85,10 @@ impl MemorySearchBackend {
     #[must_use]
     pub fn index_names(&self) -> Vec<String> {
         let mut names: Vec<String> = self
-            .indexes
+            .store
             .read()
             .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .documents
             .keys()
             .cloned()
             .collect();
@@ -84,28 +96,60 @@ impl MemorySearchBackend {
         names
     }
 
+    /// Run `f` against the whole store. Recovers from a poisoned lock rather
+    /// than propagating, per CONTRIBUTING.md's contract: the guarded data is a
+    /// plain map with no invariant a panicking writer could have left
+    /// half-applied.
+    fn with_store<T>(&self, f: impl FnOnce(&mut Store) -> T) -> T {
+        let mut guard = self
+            .store
+            .write()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        f(&mut guard)
+    }
+
     /// Run `f` against the (created-on-demand) document map for `definition`.
-    /// Recovers from a poisoned lock rather than propagating, per
-    /// CONTRIBUTING.md's contract: the guarded data is a plain document map
-    /// with no invariant a panicking writer could have left half-applied.
     fn with_index<T>(
         &self,
         definition: &IndexDefinition,
         f: impl FnOnce(&mut HashMap<i64, IndexedDocument>) -> T,
     ) -> T {
-        let mut guard = self
-            .indexes
-            .write()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
-        f(guard.entry(definition.name.to_owned()).or_default())
+        self.with_store(|store| {
+            f(store
+                .documents
+                .entry(definition.name.to_owned())
+                .or_default())
+        })
     }
 
     /// The current write sequence.
     fn sequence(&self) -> u64 {
-        self.writes
+        self.store
             .read()
             .unwrap_or_else(std::sync::PoisonError::into_inner)
-            .next
+            .next_sequence
+    }
+
+    /// Record that `ids` were deleted, so a later conditional write can see
+    /// that something newer happened to them.
+    fn record_deletes(&self, definition: &IndexDefinition, ids: &[i64]) {
+        self.with_store(|store| {
+            let index = definition.name.to_owned();
+            store.documents.entry(index.clone()).or_default();
+            let sequences = store.sequences.entry(index.clone()).or_default();
+            let mut next = store.next_sequence;
+            for id in ids {
+                next += 1;
+                sequences.insert(*id, next);
+            }
+            store.next_sequence = next;
+            if let Some(documents) = store.documents.get_mut(&index) {
+                for id in ids {
+                    // Absent ids are a no-op: deletes are replayed.
+                    documents.remove(id);
+                }
+            }
+        });
     }
 
     /// Upsert `documents`, skipping any whose stored write is newer than
@@ -121,43 +165,49 @@ impl MemorySearchBackend {
             .validate()
             .map_err(|e| SearchError::InvalidIndex(e.to_string()))?;
 
-        let mut writes = self
-            .writes
-            .write()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
-        let mut applied: Vec<(i64, u64)> = Vec::with_capacity(documents.len());
-        {
-            let WriteLog { next, sequences } = &mut *writes;
-            let seen = sequences.entry(definition.name.to_owned()).or_default();
-            for document in documents {
-                // A document written after the watermark is left alone: the
-                // writer that produced it read the source more recently than
-                // this batch did, so overwriting it would move the index
-                // backwards.
-                if let (Some(watermark), Some(written)) = (watermark, seen.get(&document.id()))
-                    && *written > watermark
-                {
-                    continue;
+        // ONE critical section for the whole compare-and-set. Checking the
+        // sequence under one lock and replacing the document under another
+        // would let a newer write slot in between the two, and the stale
+        // batch would overwrite it while the bookkeeping claimed the newer
+        // write had won.
+        self.with_store(|store| {
+            let index = definition.name.to_owned();
+            store.documents.entry(index.clone()).or_default();
+            let mut next = store.next_sequence;
+            let mut applied: Vec<(i64, u64)> = Vec::with_capacity(documents.len());
+            {
+                let sequences = store.sequences.entry(index.clone()).or_default();
+                for document in documents {
+                    // A record touched after the watermark — written OR
+                    // deleted — is left alone: that writer read the source
+                    // more recently than this batch did, so applying this one
+                    // would move the index backwards.
+                    if let (Some(watermark), Some(touched)) =
+                        (watermark, sequences.get(&document.id()))
+                        && *touched > watermark
+                    {
+                        continue;
+                    }
+                    next += 1;
+                    applied.push((document.id(), next));
                 }
-                *next += 1;
-                applied.push((document.id(), *next));
+                for (id, sequence) in &applied {
+                    sequences.insert(*id, *sequence);
+                }
             }
-            for (id, sequence) in &applied {
-                seen.insert(*id, *sequence);
-            }
-        }
-        drop(writes);
+            store.next_sequence = next;
 
-        let applied_ids: std::collections::HashSet<i64> =
-            applied.iter().map(|(id, _)| *id).collect();
-        self.with_index(definition, |index| {
-            for document in documents {
-                if !applied_ids.contains(&document.id()) {
-                    continue;
+            let applied_ids: std::collections::HashSet<i64> =
+                applied.iter().map(|(id, _)| *id).collect();
+            if let Some(map) = store.documents.get_mut(&index) {
+                for document in documents {
+                    if !applied_ids.contains(&document.id()) {
+                        continue;
+                    }
+                    // Keyed upsert: re-indexing the same record replaces it, so
+                    // at-least-once delivery can never duplicate a document.
+                    map.insert(document.id(), document.clone());
                 }
-                // Keyed upsert: re-indexing the same record replaces it, so
-                // at-least-once delivery can never duplicate a document.
-                index.insert(document.id(), document.clone());
             }
         });
         Ok(())
@@ -170,10 +220,10 @@ impl MemorySearchBackend {
         f: impl FnOnce(Option<&HashMap<i64, IndexedDocument>>) -> T,
     ) -> T {
         let guard = self
-            .indexes
+            .store
             .read()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
-        f(guard.get(definition.name))
+        f(guard.documents.get(definition.name))
     }
 }
 
@@ -306,19 +356,28 @@ impl SearchBackend for MemorySearchBackend {
         ids: &'a [i64],
     ) -> BoxFuture<'a, SearchResult<()>> {
         Box::pin(async move {
-            self.with_index(definition, |index| {
-                for id in ids {
-                    // Absent ids are a no-op: deletes are replayed.
-                    index.remove(id);
-                }
-            });
+            // Recorded in the sequence log, not just removed: the delete has
+            // to outlive the document, or a backfill batch that scanned this
+            // record before the delete would find no newer sequence and put it
+            // straight back.
+            self.record_deletes(definition, ids);
             Ok(())
         })
     }
 
     fn clear<'a>(&'a self, definition: &'a IndexDefinition) -> BoxFuture<'a, SearchResult<()>> {
         Box::pin(async move {
-            self.with_index(definition, HashMap::clear);
+            // A purge is a deliberate reset of the whole index, so the
+            // sequence log goes with it — the backfill that follows is
+            // *supposed* to rewrite everything.
+            self.with_store(|store| {
+                store
+                    .documents
+                    .entry(definition.name.to_owned())
+                    .or_default()
+                    .clear();
+                store.sequences.remove(definition.name);
+            });
             Ok(())
         })
     }

--- a/autumn-search/src/memory.rs
+++ b/autumn-search/src/memory.rs
@@ -98,13 +98,26 @@ impl MemorySearchBackend {
     }
 }
 
-/// Score `document` against `tokens`.
+/// Score `document` against `tokens`, ranking with `definition`'s weights.
 ///
 /// Returns `None` unless **every** query token appears somewhere in the
 /// document (the AND contract documented on [`KeywordQuery`]). The score sums
 /// `weight_factor(field) × occurrences`, so a match in a weight-`A` field
 /// outranks the same match in a weight-`B` field.
-fn score(document: &IndexedDocument, tokens: &[String]) -> Option<f32> {
+///
+/// The weight comes from [`IndexDefinition::weight_of`], never from the
+/// document — the same rule the Postgres backend follows when it interpolates
+/// a `setweight(...)` letter. A document is data: it can arrive from a
+/// third-party [`DocumentSource`](crate::DocumentSource), a hand-built
+/// [`SearchDocument`], or a stale row written before the model's weights
+/// changed, and any of those could otherwise promote a `D` field to `A` and
+/// reorder someone else's results. A field the index does not declare is
+/// skipped entirely, so it contributes neither score nor a token match.
+fn score(
+    definition: &IndexDefinition,
+    document: &IndexedDocument,
+    tokens: &[String],
+) -> Option<f32> {
     let mut total = 0.0_f32;
     let mut matched = vec![false; tokens.len()];
 
@@ -112,7 +125,10 @@ fn score(document: &IndexedDocument, tokens: &[String]) -> Option<f32> {
         if field.value.is_empty() {
             continue;
         }
-        let factor = weight_factor(field.weight);
+        let Some(weight) = definition.weight_of(field.name) else {
+            continue;
+        };
+        let factor = weight_factor(weight);
         for field_token in tokenize(&field.value) {
             for (index, query_token) in tokens.iter().enumerate() {
                 if field_token == *query_token {
@@ -241,7 +257,7 @@ impl SearchBackend for MemorySearchBackend {
                     if !query.filter.permits(&document.document) {
                         continue;
                     }
-                    if let Some(score) = score(document, &tokens) {
+                    if let Some(score) = score(definition, document, &tokens) {
                         hits.push(SearchHit::new(definition.name, document.id(), score));
                     }
                 }
@@ -355,26 +371,92 @@ mod tests {
     #[test]
     fn scoring_requires_every_query_token() {
         let document = doc(1, "Rust web", "frameworks");
-        assert!(score(&document, &["rust".to_owned()]).is_some());
-        assert!(score(&document, &["rust".to_owned(), "web".to_owned()]).is_some());
+        assert!(score(&definition(), &document, &["rust".to_owned()]).is_some());
         assert!(
-            score(&document, &["rust".to_owned(), "gardening".to_owned()]).is_none(),
+            score(
+                &definition(),
+                &document,
+                &["rust".to_owned(), "web".to_owned()]
+            )
+            .is_some()
+        );
+        assert!(
+            score(
+                &definition(),
+                &document,
+                &["rust".to_owned(), "gardening".to_owned()]
+            )
+            .is_none(),
             "a missing token must veto the match"
         );
     }
 
     #[test]
     fn scoring_weights_a_title_hit_above_a_body_hit() {
-        let title_hit = score(&doc(1, "rust", "nothing"), &["rust".to_owned()]).expect("match");
-        let body_hit = score(&doc(2, "nothing", "rust"), &["rust".to_owned()]).expect("match");
+        let title_hit = score(
+            &definition(),
+            &doc(1, "rust", "nothing"),
+            &["rust".to_owned()],
+        )
+        .expect("match");
+        let body_hit = score(
+            &definition(),
+            &doc(2, "nothing", "rust"),
+            &["rust".to_owned()],
+        )
+        .expect("match");
         assert!(title_hit > body_hit, "{title_hit} !> {body_hit}");
     }
 
     #[test]
     fn scoring_accumulates_repeated_occurrences() {
-        let once = score(&doc(1, "rust", ""), &["rust".to_owned()]).expect("match");
-        let twice = score(&doc(1, "rust rust", ""), &["rust".to_owned()]).expect("match");
+        let once = score(&definition(), &doc(1, "rust", ""), &["rust".to_owned()]).expect("match");
+        let twice = score(
+            &definition(),
+            &doc(1, "rust rust", ""),
+            &["rust".to_owned()],
+        )
+        .expect("match");
         assert!(twice > once);
+    }
+
+    #[test]
+    fn scoring_uses_the_definitions_weight_not_the_documents() {
+        // A document that claims weight `A` for the index's weight-`B` `body`
+        // field must not outrank a real `A` hit. The stored weight is data —
+        // it can come from a third-party source or a row written before the
+        // model changed — so ranking reads the definition instead.
+        let honest = doc(1, "rust", "");
+        let inflated = IndexedDocument::new(
+            SearchDocument::new("articles", 2)
+                .with_field("title", 'A', "")
+                .with_field("body", 'A', "rust"),
+        );
+        let honest_score =
+            score(&definition(), &honest, &["rust".to_owned()]).expect("title match");
+        let inflated_score =
+            score(&definition(), &inflated, &["rust".to_owned()]).expect("body match");
+        assert!(
+            honest_score > inflated_score,
+            "a document-declared weight must not promote a body hit: \
+             {honest_score} !> {inflated_score}"
+        );
+    }
+
+    #[test]
+    fn scoring_ignores_fields_the_index_does_not_declare() {
+        // An undeclared field contributes neither score nor a token match, so
+        // it cannot satisfy the AND contract on its own.
+        let smuggled = IndexedDocument::new(
+            SearchDocument::new("articles", 1)
+                .with_field("title", 'A', "")
+                .with_field("body", 'B', "")
+                .with_field("internal_notes", 'A', "rust"),
+        );
+        assert!(
+            score(&definition(), &smuggled, &["rust".to_owned()]).is_none(),
+            "a field outside the index definition must not be searchable"
+        );
     }
 
     #[test]

--- a/autumn-search/src/memory.rs
+++ b/autumn-search/src/memory.rs
@@ -1,0 +1,474 @@
+//! In-process reference [`SearchBackend`].
+//!
+//! Two jobs:
+//!
+//! 1. **The executable specification.** Every behaviour in the backend
+//!    contract — ranking, pagination totals, fail-closed blank queries,
+//!    idempotent upserts, filter semantics, k-NN ordering — is implemented
+//!    here in ~200 readable lines, so a new engine implementor has something
+//!    to diff against.
+//! 2. **Infra-free tests and local dev.** An app (or this crate's own suite)
+//!    gets complete keyword *and* vector search with no Postgres, no Docker,
+//!    and no network.
+//!
+//! It is not for production: everything lives in one process's memory and
+//! disappears on restart.
+
+use std::collections::HashMap;
+use std::sync::RwLock;
+
+use autumn_web::pagination::{Page, PageRequest};
+use autumn_web::search::{IndexDefinition, weight_factor};
+
+use crate::backend::{
+    BackendCapabilities, BoxFuture, IndexedDocument, KeywordQuery, SearchBackend, SearchHit,
+    VectorQuery, empty_page,
+};
+use crate::embedding::cosine_similarity;
+use crate::error::{SearchError, SearchResult};
+use crate::text::{query_tokens, tokenize};
+
+/// An in-memory [`SearchBackend`].
+///
+/// Cheap to clone-by-`Arc`; internally a `RwLock` over per-index document
+/// maps.
+#[derive(Debug, Default)]
+pub struct MemorySearchBackend {
+    indexes: RwLock<HashMap<String, HashMap<i64, IndexedDocument>>>,
+}
+
+impl MemorySearchBackend {
+    /// Create an empty backend.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Number of documents currently held in `index`. Test/inspection helper.
+    #[must_use]
+    pub fn document_count(&self, index: &str) -> usize {
+        self.indexes
+            .read()
+            .map_or(0, |guard| guard.get(index).map_or(0, HashMap::len))
+    }
+
+    /// Names of every index that has been created.
+    #[must_use]
+    pub fn index_names(&self) -> Vec<String> {
+        let mut names: Vec<String> = self
+            .indexes
+            .read()
+            .map(|guard| guard.keys().cloned().collect())
+            .unwrap_or_default();
+        names.sort();
+        names
+    }
+
+    /// Run `f` against the (created-on-demand) document map for `definition`.
+    fn with_index<T>(
+        &self,
+        definition: &IndexDefinition,
+        f: impl FnOnce(&mut HashMap<i64, IndexedDocument>) -> T,
+    ) -> SearchResult<T> {
+        let mut guard = self
+            .indexes
+            .write()
+            .map_err(|_| SearchError::Backend("in-memory index lock poisoned".to_owned()))?;
+        Ok(f(guard.entry(definition.name.to_owned()).or_default()))
+    }
+
+    /// Run `f` against a read view of the documents for `definition`.
+    fn read_index<T>(
+        &self,
+        definition: &IndexDefinition,
+        f: impl FnOnce(Option<&HashMap<i64, IndexedDocument>>) -> T,
+    ) -> SearchResult<T> {
+        let guard = self
+            .indexes
+            .read()
+            .map_err(|_| SearchError::Backend("in-memory index lock poisoned".to_owned()))?;
+        Ok(f(guard.get(definition.name)))
+    }
+}
+
+/// Score `document` against `tokens`.
+///
+/// Returns `None` unless **every** query token appears somewhere in the
+/// document (the AND contract documented on [`KeywordQuery`]). The score sums
+/// `weight_factor(field) × occurrences`, so a match in a weight-`A` field
+/// outranks the same match in a weight-`B` field.
+fn score(document: &IndexedDocument, tokens: &[String]) -> Option<f32> {
+    let mut total = 0.0_f32;
+    let mut matched = vec![false; tokens.len()];
+
+    for field in &document.document.fields {
+        if field.value.is_empty() {
+            continue;
+        }
+        let factor = weight_factor(field.weight);
+        for field_token in tokenize(&field.value) {
+            for (index, query_token) in tokens.iter().enumerate() {
+                if field_token == *query_token {
+                    total += factor;
+                    if let Some(slot) = matched.get_mut(index) {
+                        *slot = true;
+                    }
+                }
+            }
+        }
+    }
+
+    if matched.iter().all(|m| *m) && total > 0.0 {
+        Some(total)
+    } else {
+        None
+    }
+}
+
+/// Sort hits into the canonical order: score descending, then id ascending so
+/// ties are stable across calls (and so pagination never skips or repeats).
+fn sort_hits(hits: &mut [SearchHit]) {
+    hits.sort_by(|a, b| {
+        b.score
+            .partial_cmp(&a.score)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then_with(|| a.id.cmp(&b.id))
+    });
+}
+
+/// Take the `request`-th page of `hits`, preserving the pre-slice total.
+fn paginate(hits: Vec<SearchHit>, request: &PageRequest) -> Page<SearchHit> {
+    let total = i64::try_from(hits.len()).unwrap_or(i64::MAX);
+    let size = request.size() as usize;
+    let offset = (request.page().saturating_sub(1) as usize).saturating_mul(size);
+    let content = hits.into_iter().skip(offset).take(size).collect();
+    Page::new(content, total, request)
+}
+
+impl SearchBackend for MemorySearchBackend {
+    fn name(&self) -> &'static str {
+        "memory"
+    }
+
+    fn capabilities(&self) -> BackendCapabilities {
+        BackendCapabilities {
+            keyword: true,
+            vector: true,
+            weighted_fields: true,
+            embedding_readback: true,
+        }
+    }
+
+    fn ensure_index<'a>(
+        &'a self,
+        definition: &'a IndexDefinition,
+    ) -> BoxFuture<'a, SearchResult<()>> {
+        Box::pin(async move {
+            definition
+                .validate()
+                .map_err(|e| SearchError::InvalidIndex(e.to_string()))?;
+            self.with_index(definition, |_| ())?;
+            Ok(())
+        })
+    }
+
+    fn index<'a>(
+        &'a self,
+        definition: &'a IndexDefinition,
+        documents: &'a [IndexedDocument],
+    ) -> BoxFuture<'a, SearchResult<()>> {
+        Box::pin(async move {
+            definition
+                .validate()
+                .map_err(|e| SearchError::InvalidIndex(e.to_string()))?;
+            self.with_index(definition, |index| {
+                for document in documents {
+                    // Keyed upsert: re-indexing the same record replaces it, so
+                    // at-least-once delivery can never duplicate a document.
+                    index.insert(document.id(), document.clone());
+                }
+            })
+        })
+    }
+
+    fn delete<'a>(
+        &'a self,
+        definition: &'a IndexDefinition,
+        ids: &'a [i64],
+    ) -> BoxFuture<'a, SearchResult<()>> {
+        Box::pin(async move {
+            self.with_index(definition, |index| {
+                for id in ids {
+                    // Absent ids are a no-op: deletes are replayed.
+                    index.remove(id);
+                }
+            })
+        })
+    }
+
+    fn clear<'a>(&'a self, definition: &'a IndexDefinition) -> BoxFuture<'a, SearchResult<()>> {
+        Box::pin(async move { self.with_index(definition, HashMap::clear) })
+    }
+
+    fn keyword_search<'a>(
+        &'a self,
+        definition: &'a IndexDefinition,
+        query: &'a KeywordQuery,
+    ) -> BoxFuture<'a, SearchResult<Page<SearchHit>>> {
+        Box::pin(async move {
+            // Fail closed on both "nothing to search for" and "nothing is
+            // visible" — neither may degrade into a full listing.
+            let Some(tokens) = query_tokens(&query.text) else {
+                return Ok(empty_page(&query.page));
+            };
+            if query.filter.matches_nothing() {
+                return Ok(empty_page(&query.page));
+            }
+
+            let mut hits = self.read_index(definition, |index| {
+                let mut hits = Vec::new();
+                for document in index.into_iter().flat_map(HashMap::values) {
+                    if !query.filter.permits(&document.document) {
+                        continue;
+                    }
+                    if let Some(score) = score(document, &tokens) {
+                        hits.push(SearchHit::new(definition.name, document.id(), score));
+                    }
+                }
+                hits
+            })?;
+
+            sort_hits(&mut hits);
+            Ok(paginate(hits, &query.page))
+        })
+    }
+
+    fn vector_search<'a>(
+        &'a self,
+        definition: &'a IndexDefinition,
+        query: &'a VectorQuery,
+    ) -> BoxFuture<'a, SearchResult<Vec<SearchHit>>> {
+        Box::pin(async move {
+            if !definition.supports_vector_search() {
+                return Err(SearchError::VectorUnsupported {
+                    index: definition.name.to_owned(),
+                });
+            }
+            if query.filter.matches_nothing() || query.limit == 0 {
+                return Ok(Vec::new());
+            }
+
+            let mut hits = Vec::new();
+            let mismatch = self.read_index(definition, |index| {
+                for document in index.into_iter().flat_map(HashMap::values) {
+                    let Some(embedding) = &document.embedding else {
+                        continue;
+                    };
+                    // A width disagreement means the index was built with a
+                    // different embedder — scoring it would silently return
+                    // garbage, so surface it instead.
+                    if embedding.len() != query.vector.len() {
+                        return Some(SearchError::DimensionMismatch {
+                            expected: embedding.len(),
+                            actual: query.vector.len(),
+                        });
+                    }
+                    if !query.filter.permits(&document.document) {
+                        continue;
+                    }
+                    let score = cosine_similarity(embedding, &query.vector);
+                    if query.min_score.is_some_and(|min| score < min) {
+                        continue;
+                    }
+                    hits.push(SearchHit::new(definition.name, document.id(), score));
+                }
+                None
+            })?;
+            if let Some(error) = mismatch {
+                return Err(error);
+            }
+
+            sort_hits(&mut hits);
+            hits.truncate(query.limit);
+            Ok(hits)
+        })
+    }
+
+    fn embedding<'a>(
+        &'a self,
+        definition: &'a IndexDefinition,
+        id: i64,
+    ) -> BoxFuture<'a, SearchResult<Option<Vec<f32>>>> {
+        Box::pin(async move {
+            self.read_index(definition, |index| {
+                index
+                    .and_then(|documents| documents.get(&id))
+                    .and_then(|document| document.embedding.clone())
+            })
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use autumn_web::search::{SearchDocument, SearchIndexField};
+
+    use crate::backend::SearchFilter;
+
+    use super::*;
+
+    const FIELDS: &[SearchIndexField] = &[
+        SearchIndexField::new("title", 'A'),
+        SearchIndexField::new("body", 'B'),
+    ];
+
+    fn definition() -> IndexDefinition {
+        IndexDefinition::new("articles", "english", FIELDS, Some("body"))
+    }
+
+    fn doc(id: i64, title: &str, body: &str) -> IndexedDocument {
+        IndexedDocument::new(
+            SearchDocument::new("articles", id)
+                .with_field("title", 'A', title)
+                .with_field("body", 'B', body),
+        )
+    }
+
+    #[test]
+    fn scoring_requires_every_query_token() {
+        let document = doc(1, "Rust web", "frameworks");
+        assert!(score(&document, &["rust".to_owned()]).is_some());
+        assert!(score(&document, &["rust".to_owned(), "web".to_owned()]).is_some());
+        assert!(
+            score(&document, &["rust".to_owned(), "gardening".to_owned()]).is_none(),
+            "a missing token must veto the match"
+        );
+    }
+
+    #[test]
+    fn scoring_weights_a_title_hit_above_a_body_hit() {
+        let title_hit = score(&doc(1, "rust", "nothing"), &["rust".to_owned()]).expect("match");
+        let body_hit = score(&doc(2, "nothing", "rust"), &["rust".to_owned()]).expect("match");
+        assert!(title_hit > body_hit, "{title_hit} !> {body_hit}");
+    }
+
+    #[test]
+    fn scoring_accumulates_repeated_occurrences() {
+        let once = score(&doc(1, "rust", ""), &["rust".to_owned()]).expect("match");
+        let twice = score(&doc(1, "rust rust", ""), &["rust".to_owned()]).expect("match");
+        assert!(twice > once);
+    }
+
+    #[test]
+    fn sorting_breaks_score_ties_by_ascending_id() {
+        let mut hits = vec![
+            SearchHit::new("articles", 3, 1.0),
+            SearchHit::new("articles", 1, 1.0),
+            SearchHit::new("articles", 2, 5.0),
+        ];
+        sort_hits(&mut hits);
+        assert_eq!(hits.iter().map(|h| h.id).collect::<Vec<_>>(), vec![2, 1, 3]);
+    }
+
+    #[test]
+    fn paginating_preserves_the_pre_slice_total() {
+        let hits: Vec<SearchHit> = (1..=5).map(|id| SearchHit::new("a", id, 1.0)).collect();
+        let page = paginate(hits, &PageRequest::new(2, 2));
+        assert_eq!(
+            page.content.iter().map(|h| h.id).collect::<Vec<_>>(),
+            vec![3, 4]
+        );
+        assert_eq!(page.total_elements, 5);
+    }
+
+    #[test]
+    fn paginating_past_the_end_is_empty_not_wrapped() {
+        let hits: Vec<SearchHit> = (1..=3).map(|id| SearchHit::new("a", id, 1.0)).collect();
+        let page = paginate(hits, &PageRequest::new(9, 2));
+        assert!(page.content.is_empty());
+        assert_eq!(page.total_elements, 3);
+    }
+
+    #[tokio::test]
+    async fn clearing_one_index_leaves_the_others_alone() {
+        let backend = MemorySearchBackend::new();
+        let articles = definition();
+        let mut notes = definition();
+        notes.name = "notes";
+
+        backend.ensure_index(&articles).await.expect("ensure");
+        backend.ensure_index(&notes).await.expect("ensure");
+        backend
+            .index(&articles, &[doc(1, "a", "b")])
+            .await
+            .expect("index");
+        backend
+            .index(&notes, &[doc(1, "a", "b")])
+            .await
+            .expect("index");
+
+        backend.clear(&articles).await.expect("clear");
+        assert_eq!(backend.document_count("articles"), 0);
+        assert_eq!(backend.document_count("notes"), 1);
+        assert_eq!(backend.index_names(), vec!["articles", "notes"]);
+    }
+
+    #[tokio::test]
+    async fn a_zero_limit_vector_query_does_no_work() {
+        let backend = MemorySearchBackend::new();
+        let definition = definition();
+        backend.ensure_index(&definition).await.expect("ensure");
+        let hits = backend
+            .vector_search(&definition, &VectorQuery::new(vec![1.0], 0))
+            .await
+            .expect("vector search");
+        assert!(hits.is_empty());
+    }
+
+    #[tokio::test]
+    async fn embedding_readback_returns_none_for_an_unknown_record() {
+        let backend = MemorySearchBackend::new();
+        let definition = definition();
+        backend.ensure_index(&definition).await.expect("ensure");
+        assert!(
+            backend
+                .embedding(&definition, 42)
+                .await
+                .expect("read")
+                .is_none()
+        );
+    }
+
+    #[tokio::test]
+    async fn an_impossible_filter_short_circuits_both_query_paths() {
+        let backend = MemorySearchBackend::new();
+        let definition = definition();
+        backend.ensure_index(&definition).await.expect("ensure");
+        backend
+            .index(
+                &definition,
+                &[doc(1, "rust", "rust").with_embedding(vec![1.0])],
+            )
+            .await
+            .expect("index");
+
+        let impossible = SearchFilter::default().allow_ids(Vec::<i64>::new());
+        let page = backend
+            .keyword_search(
+                &definition,
+                &KeywordQuery::new("rust", PageRequest::default()).filter(impossible.clone()),
+            )
+            .await
+            .expect("keyword");
+        assert!(page.content.is_empty());
+
+        let hits = backend
+            .vector_search(
+                &definition,
+                &VectorQuery::new(vec![1.0], 10).filter(impossible),
+            )
+            .await
+            .expect("vector");
+        assert!(hits.is_empty());
+    }
+}

--- a/autumn-search/src/plugin.rs
+++ b/autumn-search/src/plugin.rs
@@ -146,16 +146,19 @@ impl SearchPlugin {
 
     /// Install the search engine.
     ///
-    /// Overrides a previous [`Self::postgres`], **including** the document
-    /// source it installed: leaving that behind would ship a
-    /// [`PostgresSearchStore`] whose pool the startup hook no longer installs,
-    /// so every reindex and backfill would fail at runtime with "the search
-    /// store has no database pool".
+    /// Overrides a previous [`Self::postgres`], dropping the
+    /// [`PostgresSearchStore`] it would have installed as both backend and
+    /// document source — that store's pool comes from the startup hook, which
+    /// no longer runs for it, so keeping it would fail every reindex at
+    /// runtime with "the search store has no database pool".
+    ///
+    /// A source the app installed with [`Self::source`] is **kept**:
+    /// [`Self::postgres`] only records intent and never writes that field, so
+    /// clearing it here could only ever discard the app's own choice.
     #[must_use]
     pub fn backend(mut self, backend: Arc<dyn SearchBackend>) -> Self {
         self.backend = Some(backend);
         if std::mem::take(&mut self.use_postgres) {
-            self.source = None;
             self.postgres_store = OnceLock::new();
         }
         self
@@ -244,7 +247,14 @@ impl SearchPlugin {
     fn resolved_config(&self) -> &Result<SearchConfig, String> {
         self.resolved_config.get_or_init(|| {
             if self.config_explicit {
-                return Ok(self.search_config());
+                // Validated on the same terms as a config read from a file: a
+                // zero batch size or a blank queue is just as wrong when it
+                // arrives from code, and boot is where it should be caught.
+                let config = self.search_config();
+                return config
+                    .validate()
+                    .map(|()| config)
+                    .map_err(|error| error.to_string());
             }
             SearchConfig::resolve()
                 .map(|mut config| {
@@ -644,6 +654,41 @@ mod tests {
             .postgres()
             .backend(Arc::new(crate::memory::MemorySearchBackend::new()));
         assert!(!plugin.uses_postgres());
+    }
+
+    #[test]
+    fn an_explicit_backend_keeps_an_explicit_document_source() {
+        // `postgres()` records intent only — it never writes `self.source`, so
+        // the source a later `backend(...)` used to clear could only ever be
+        // one the app installed itself.
+        let source = Arc::new(crate::source::MemoryDocumentSource::new());
+        let plugin = SearchPlugin::new()
+            .postgres()
+            .source(Arc::clone(&source) as Arc<dyn DocumentSource>)
+            .backend(Arc::new(crate::memory::MemorySearchBackend::new()));
+        assert!(
+            plugin.source.is_some(),
+            "overriding the backend must not discard the app's own source"
+        );
+    }
+
+    #[test]
+    fn an_explicit_config_is_validated_like_a_resolved_one() {
+        // A config read from `autumn.toml` is validated; one passed in code
+        // took a shortcut past `validate()`, so `batch_size = 0` reached the
+        // backfill loop instead of aborting boot.
+        // Built by hand, not parsed: `from_toml_str` validates on the way in,
+        // which is exactly the check the in-code path was skipping.
+        let config = SearchConfig {
+            batch_size: 0,
+            ..SearchConfig::default()
+        };
+        let plugin = SearchPlugin::new().config(config);
+        let error = plugin
+            .resolved_config()
+            .as_ref()
+            .expect_err("a zero batch size must not resolve");
+        assert!(error.contains("batch_size"), "unexpected error: {error}");
     }
 
     #[test]

--- a/autumn-search/src/plugin.rs
+++ b/autumn-search/src/plugin.rs
@@ -450,47 +450,69 @@ impl Plugin for SearchPlugin {
                         "autumn-search: {message}"
                     )));
                 }
-                // The declared width and the installed embedder's width must
-                // agree before a single document is written. They are set in
-                // two different places — `[search] embedding_dimensions` in
-                // config, `Embedder::dimensions()` in code — and when they
-                // disagree the failure is silent: every write succeeds, the
-                // vector column rejects the wrong-width value, and semantic
-                // search simply returns nothing. Boot loudly instead.
-                //
-                // `0` means no usable embedder (the default `NoEmbedder`), for
-                // which nothing vector-shaped runs at all — declaring a width
-                // ahead of installing a provider is a legitimate ordering.
-                let embedder_width = client.embedding_dimensions();
-                if let Some(configured) = config.embedding_dimensions
-                    && embedder_width != 0
-                    && embedder_width != configured
-                {
-                    return Err(autumn_web::AutumnError::internal_server_error_msg(format!(
-                        "autumn-search: `search.embedding_dimensions = {configured}` does not \
-                         match the installed embedder, which produces {embedder_width}-dimension \
-                         vectors; set them to the same value (and re-run `autumn search reindex \
-                         --purge` if the width really changed)"
-                    )));
-                }
-
-                if let Some(store) = &postgres {
-                    let pool = state.pool().cloned().ok_or_else(|| {
-                        autumn_web::AutumnError::internal_server_error_msg(
-                            "SearchPlugin::postgres() needs a database pool; configure \
-                             `database.primary_url` or install a different backend",
-                        )
-                    })?;
-                    store.install_pool(pool);
-                }
-
-                client.ensure_indexes().await.map_err(|error| {
-                    autumn_web::AutumnError::internal_server_error_msg(format!(
-                        "search index setup failed: {error}"
-                    ))
-                })?;
-
+                // Install the client FIRST, and unconditionally. A handler
+                // that resolves the extension must find one whether or not
+                // search is enabled — a disabled client answers every call
+                // with an empty page rather than being absent.
                 state.insert_extension(client.clone());
+
+                // Everything below is search-specific setup, and every line of
+                // it can fail for search-specific reasons: an unreachable
+                // external engine, a `CREATE EXTENSION` the role may not run,
+                // a revoked DDL grant, a misconfigured embedder. Running it
+                // while `enabled = false` means a search outage still takes
+                // the whole application down — which is precisely the outcome
+                // the kill switch exists to prevent, and the switch would be
+                // useless in the incident it was written for. A disabled
+                // subsystem initializes nothing.
+                if config.enabled {
+                    // The declared width and the installed embedder's width
+                    // must agree before a single document is written. They are
+                    // set in two different places — `[search]
+                    // embedding_dimensions` in config, `Embedder::dimensions()`
+                    // in code — and when they disagree the failure is silent:
+                    // every write succeeds, the vector column rejects the
+                    // wrong-width value, and semantic search simply returns
+                    // nothing. Boot loudly instead.
+                    //
+                    // `0` means no usable embedder (the default `NoEmbedder`),
+                    // for which nothing vector-shaped runs at all — declaring a
+                    // width ahead of installing a provider is a legitimate
+                    // ordering.
+                    let embedder_width = client.embedding_dimensions();
+                    if let Some(configured) = config.embedding_dimensions
+                        && embedder_width != 0
+                        && embedder_width != configured
+                    {
+                        return Err(autumn_web::AutumnError::internal_server_error_msg(format!(
+                            "autumn-search: `search.embedding_dimensions = {configured}` does not \
+                             match the installed embedder, which produces \
+                             {embedder_width}-dimension vectors; set them to the same value (and \
+                             re-run `autumn search reindex --purge` if the width really changed)"
+                        )));
+                    }
+
+                    if let Some(store) = &postgres {
+                        let pool = state.pool().cloned().ok_or_else(|| {
+                            autumn_web::AutumnError::internal_server_error_msg(
+                                "SearchPlugin::postgres() needs a database pool; configure \
+                                 `database.primary_url` or install a different backend",
+                            )
+                        })?;
+                        store.install_pool(pool);
+                    }
+
+                    client.ensure_indexes().await.map_err(|error| {
+                        autumn_web::AutumnError::internal_server_error_msg(format!(
+                            "search index setup failed: {error}"
+                        ))
+                    })?;
+                } else {
+                    tracing::warn!(
+                        "autumn-search is disabled (`[search] enabled = false`): index writes and \
+                         queries are no-ops, and no backend setup was performed"
+                    );
+                }
 
                 // A one-shot backfill boot (`autumn search reindex`) rebuilds
                 // and exits rather than going on to serve traffic.

--- a/autumn-search/src/plugin.rs
+++ b/autumn-search/src/plugin.rs
@@ -1,0 +1,403 @@
+//! The [`Plugin`] that mounts the whole subsystem with one builder call.
+
+use std::borrow::Cow;
+use std::sync::Arc;
+
+use autumn_web::app::AppBuilder;
+use autumn_web::plugin::Plugin;
+use autumn_web::search::{IndexDefinition, SearchIndexed};
+
+use crate::authz::SearchVisibility;
+use crate::backend::SearchBackend;
+use crate::client::{BackfillOptions, SearchClient, SearchClientBuilder};
+use crate::config::SearchConfig;
+use crate::embedding::Embedder;
+use crate::jobs::search_job_infos;
+use crate::postgres::PostgresSearchStore;
+use crate::source::DocumentSource;
+
+/// Environment variable that turns a normal boot into a one-shot backfill.
+///
+/// `autumn search reindex` runs the application binary with this set, which is
+/// the same "run the app, it knows its own wiring" technique `autumn jobs
+/// manifest` uses (`AUTUMN_DUMP_JOBS`). It has to be the app: the indexes,
+/// backend and embedder are registered at runtime by the app's own builder
+/// call, so a standalone CLI cannot see them.
+///
+/// Set it to an index name to rebuild one index, or to `all` for every index.
+pub const BACKFILL_ENV: &str = "AUTUMN_SEARCH_BACKFILL";
+
+/// Environment variable that makes the one-shot backfill purge first.
+pub const BACKFILL_PURGE_ENV: &str = "AUTUMN_SEARCH_BACKFILL_PURGE";
+
+/// Keyword + vector search for `autumn-web` applications.
+///
+/// ```rust,ignore
+/// autumn_web::app()
+///     .plugin(
+///         SearchPlugin::new()
+///             .postgres()                 // Postgres FTS + pgvector backend
+///             .embedder(Arc::new(MyEmbedder))
+///             .index::<Article>()         // one line per searchable model
+///     )
+///     .routes(routes![...])
+///     .run()
+///     .await;
+/// ```
+pub struct SearchPlugin {
+    config: SearchConfig,
+    backend: Option<Arc<dyn SearchBackend>>,
+    embedder: Option<Arc<dyn Embedder>>,
+    source: Option<Arc<dyn DocumentSource>>,
+    visibility: Option<Arc<dyn SearchVisibility>>,
+    indexes: Vec<IndexDefinition>,
+    postgres: Option<Arc<PostgresSearchStore>>,
+}
+
+impl Default for SearchPlugin {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl SearchPlugin {
+    /// Start configuring the plugin.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            config: SearchConfig::default(),
+            backend: None,
+            embedder: None,
+            source: None,
+            visibility: None,
+            indexes: Vec::new(),
+            postgres: None,
+        }
+    }
+
+    /// Replace the whole `[search]` configuration.
+    #[must_use]
+    pub fn config(mut self, config: SearchConfig) -> Self {
+        self.config = config;
+        self
+    }
+
+    /// Route the reindex/backfill jobs to a named queue.
+    #[must_use]
+    pub fn queue(mut self, queue: impl Into<String>) -> Self {
+        self.config.queue = queue.into();
+        self
+    }
+
+    /// Install the search engine.
+    #[must_use]
+    pub fn backend(mut self, backend: Arc<dyn SearchBackend>) -> Self {
+        self.backend = Some(backend);
+        self.postgres = None;
+        self
+    }
+
+    /// Use the Postgres backend (in-core FTS + `pgvector`), reading records
+    /// through the Postgres document source.
+    ///
+    /// One [`PostgresSearchStore`] serves as both; its connection pool is
+    /// installed from `AppState` at startup, so there is nothing to pass in.
+    #[must_use]
+    pub fn postgres(mut self) -> Self {
+        let store = Arc::new(PostgresSearchStore::new(self.config.embedding_dimensions));
+        self.postgres = Some(Arc::clone(&store));
+        self.backend = Some(store.clone() as Arc<dyn SearchBackend>);
+        self.source = Some(store as Arc<dyn DocumentSource>);
+        self
+    }
+
+    /// Install the embedding provider.
+    #[must_use]
+    pub fn embedder(mut self, embedder: Arc<dyn Embedder>) -> Self {
+        self.embedder = Some(embedder);
+        self
+    }
+
+    /// Install the record source used by reindex and backfill.
+    #[must_use]
+    pub fn source(mut self, source: Arc<dyn DocumentSource>) -> Self {
+        self.source = Some(source);
+        self
+    }
+
+    /// Install the authorization hook backing the `*_for` query methods.
+    #[must_use]
+    pub fn visibility(mut self, visibility: Arc<dyn SearchVisibility>) -> Self {
+        self.visibility = Some(visibility);
+        self
+    }
+
+    /// Register a searchable model's index.
+    #[must_use]
+    pub fn index<M: SearchIndexed>(mut self) -> Self {
+        self.indexes.push(M::index_definition());
+        self
+    }
+
+    /// Register an index definition directly.
+    #[must_use]
+    pub fn index_definition(mut self, definition: IndexDefinition) -> Self {
+        self.indexes.push(definition);
+        self
+    }
+
+    /// Whether the Postgres backend is in use.
+    #[must_use]
+    pub const fn uses_postgres(&self) -> bool {
+        self.postgres.is_some()
+    }
+
+    /// The effective configuration.
+    #[must_use]
+    pub const fn search_config(&self) -> &SearchConfig {
+        &self.config
+    }
+
+    /// Build the [`SearchClient`] this plugin would install.
+    ///
+    /// Exposed so tests (and an app that drives search outside a request) can
+    /// obtain the same client the plugin registers.
+    #[must_use]
+    pub fn client(&self) -> SearchClient {
+        self.client_builder().build()
+    }
+
+    fn client_builder(&self) -> SearchClientBuilder {
+        let mut builder = SearchClient::builder().enabled(self.config.enabled);
+        if let Some(backend) = &self.backend {
+            builder = builder.backend(Arc::clone(backend));
+        }
+        if let Some(embedder) = &self.embedder {
+            builder = builder.embedder(Arc::clone(embedder));
+        }
+        if let Some(source) = &self.source {
+            builder = builder.source(Arc::clone(source));
+        }
+        if let Some(visibility) = &self.visibility {
+            builder = builder.visibility(Arc::clone(visibility));
+        }
+        for definition in &self.indexes {
+            builder = builder.index_definition(definition.clone());
+        }
+        builder
+    }
+}
+
+/// What a one-shot backfill boot was asked to rebuild.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum BackfillTarget {
+    /// Every registered index (`AUTUMN_SEARCH_BACKFILL=all`).
+    AllIndexes,
+    /// One named index.
+    Index(String),
+}
+
+impl BackfillTarget {
+    /// The index name, or `None` for every index.
+    #[must_use]
+    pub fn name(&self) -> Option<&str> {
+        match self {
+            Self::AllIndexes => None,
+            Self::Index(name) => Some(name),
+        }
+    }
+}
+
+/// The backfill requested through the environment, if any.
+#[must_use]
+pub fn backfill_request_from_env(
+    config: &SearchConfig,
+) -> Option<(BackfillTarget, BackfillOptions)> {
+    let raw = std::env::var(BACKFILL_ENV).ok()?;
+    let target = parse_backfill_target(&raw)?;
+    let purge_raw = std::env::var(BACKFILL_PURGE_ENV).ok();
+    Some((
+        target,
+        BackfillOptions::default()
+            .batch_size(config.batch_size)
+            .purge(parse_purge_flag(purge_raw.as_deref())),
+    ))
+}
+
+/// Parse [`BACKFILL_ENV`]. `None` means "no backfill requested".
+fn parse_backfill_target(raw: &str) -> Option<BackfillTarget> {
+    let target = raw.trim();
+    if target.is_empty() {
+        return None;
+    }
+    if target.eq_ignore_ascii_case("all") {
+        Some(BackfillTarget::AllIndexes)
+    } else {
+        Some(BackfillTarget::Index(target.to_owned()))
+    }
+}
+
+/// Purge is opt-in: only an explicitly affirmative value enables it, so a
+/// stray `AUTUMN_SEARCH_BACKFILL_PURGE=0` never empties an index.
+fn parse_purge_flag(raw: Option<&str>) -> bool {
+    raw.is_some_and(|value| matches!(value.trim(), "1" | "true" | "yes"))
+}
+
+impl Plugin for SearchPlugin {
+    fn name(&self) -> Cow<'static, str> {
+        Cow::Borrowed("autumn-search")
+    }
+
+    fn build(self, app: AppBuilder) -> AppBuilder {
+        // Declare the plugin-owned `[search]` table first, so a host app with
+        // `server.strict_config = true` boots instead of failing on an
+        // "unknown key" — and so every return path below carries it.
+        let app = app.config_section("search");
+
+        let jobs = search_job_infos(&self.config.queue);
+        let config = self.config.clone();
+        let postgres = self.postgres.clone();
+        // The client is fully assembled here: every part is an `Arc` supplied
+        // by the app's own builder call. Only the Postgres pool has to wait
+        // for `AppState`, and the store takes it lazily — so the startup hook
+        // stays a few lines instead of re-running the whole assembly.
+        let client = self.client();
+
+        app.jobs(jobs).on_startup(move |state| {
+            let client = client.clone();
+            let postgres = postgres.clone();
+            let config = config.clone();
+            async move {
+                if let Some(store) = &postgres {
+                    let pool = state.pool().cloned().ok_or_else(|| {
+                        autumn_web::AutumnError::internal_server_error_msg(
+                            "SearchPlugin::postgres() needs a database pool; configure                              `database.primary_url` or install a different backend",
+                        )
+                    })?;
+                    store.install_pool(pool);
+                }
+
+                client.ensure_indexes().await.map_err(|error| {
+                    autumn_web::AutumnError::internal_server_error_msg(format!(
+                        "search index setup failed: {error}"
+                    ))
+                })?;
+
+                state.insert_extension(client.clone());
+
+                // A one-shot backfill boot (`autumn search reindex`) rebuilds
+                // and exits rather than going on to serve traffic.
+                if let Some((target, options)) = backfill_request_from_env(&config) {
+                    run_backfill_and_exit(&client, &target, &options).await;
+                }
+                Ok(())
+            }
+        })
+    }
+}
+
+/// Run the requested backfill, print a summary, and exit the process.
+///
+/// This is the body of `autumn search reindex`: the CLI re-executes the
+/// application binary with [`BACKFILL_ENV`] set, because only the app knows
+/// which indexes, backend, and embedder are registered. Exiting rather than
+/// returning is deliberate — the process was started to rebuild an index, not
+/// to serve requests, and a non-zero exit is what makes the CLI fail loudly.
+async fn run_backfill_and_exit(
+    client: &SearchClient,
+    target: &BackfillTarget,
+    options: &BackfillOptions,
+) -> ! {
+    let result = match target.name() {
+        Some(index) => client.backfill(index, options).await.map(|r| vec![r]),
+        None => client.backfill_all(options).await,
+    };
+    match result {
+        Ok(reports) => {
+            for report in &reports {
+                println!(
+                    "autumn-search: reindexed {} ({} documents in {} batches{})",
+                    report.index,
+                    report.indexed,
+                    report.batches,
+                    if report.purged { ", purged first" } else { "" }
+                );
+            }
+            if reports.is_empty() {
+                println!("autumn-search: no indexes are registered; nothing to reindex");
+            }
+            std::process::exit(0)
+        }
+        Err(error) => {
+            eprintln!("autumn-search: reindex failed: {error}");
+            std::process::exit(1)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn the_plugin_name_is_the_crate_name() {
+        assert_eq!(SearchPlugin::new().name(), "autumn-search");
+    }
+
+    #[test]
+    fn the_queue_override_reaches_the_registered_jobs() {
+        let plugin = SearchPlugin::new().queue("indexing");
+        assert_eq!(plugin.search_config().queue, "indexing");
+        let infos = search_job_infos(&plugin.search_config().queue);
+        assert!(infos.iter().all(|info| info.queue == "indexing"));
+    }
+
+    #[test]
+    fn an_explicit_backend_turns_off_the_postgres_default() {
+        let plugin = SearchPlugin::new()
+            .postgres()
+            .backend(Arc::new(crate::memory::MemorySearchBackend::new()));
+        assert!(!plugin.uses_postgres());
+    }
+
+    #[test]
+    fn an_unset_or_blank_target_means_a_normal_boot() {
+        // `backfill_request_from_env` reads the environment, which is
+        // process-global and therefore not safe to mutate from a test; assert
+        // on the parsing rule it implements instead.
+        assert!(parse_backfill_target("").is_none());
+        assert!(parse_backfill_target("   ").is_none());
+    }
+
+    #[test]
+    fn all_means_every_index_and_a_name_means_one() {
+        assert_eq!(
+            parse_backfill_target("all"),
+            Some(BackfillTarget::AllIndexes)
+        );
+        assert_eq!(
+            parse_backfill_target("ALL"),
+            Some(BackfillTarget::AllIndexes)
+        );
+        assert_eq!(
+            parse_backfill_target("  articles  "),
+            Some(BackfillTarget::Index("articles".to_owned()))
+        );
+        assert_eq!(BackfillTarget::AllIndexes.name(), None);
+        assert_eq!(
+            BackfillTarget::Index("articles".to_owned()).name(),
+            Some("articles")
+        );
+    }
+
+    #[test]
+    fn purge_is_opt_in_and_only_for_affirmative_values() {
+        assert!(parse_purge_flag(Some("1")));
+        assert!(parse_purge_flag(Some("true")));
+        assert!(parse_purge_flag(Some(" yes ")));
+        assert!(!parse_purge_flag(Some("0")));
+        assert!(!parse_purge_flag(Some("no")));
+        assert!(!parse_purge_flag(Some("")));
+        assert!(!parse_purge_flag(None));
+    }
+}

--- a/autumn-search/src/plugin.rs
+++ b/autumn-search/src/plugin.rs
@@ -51,7 +51,12 @@ pub struct SearchPlugin {
     source: Option<Arc<dyn DocumentSource>>,
     visibility: Option<Arc<dyn SearchVisibility>>,
     indexes: Vec<IndexDefinition>,
-    postgres: Option<Arc<PostgresSearchStore>>,
+    /// Whether `postgres()` was requested. The store itself is built in
+    /// `Plugin::build`, after the configuration is final.
+    use_postgres: bool,
+    /// Set once the app supplies configuration explicitly, so `build` does not
+    /// then overwrite it from `autumn.toml`.
+    config_explicit: bool,
 }
 
 impl Default for SearchPlugin {
@@ -71,29 +76,45 @@ impl SearchPlugin {
             source: None,
             visibility: None,
             indexes: Vec::new(),
-            postgres: None,
+            use_postgres: false,
+            config_explicit: false,
         }
     }
 
     /// Replace the whole `[search]` configuration.
+    ///
+    /// Setting it explicitly also stops [`Plugin::build`] from loading
+    /// `[search]` out of `autumn.toml`.
     #[must_use]
     pub fn config(mut self, config: SearchConfig) -> Self {
         self.config = config;
+        self.config_explicit = true;
         self
     }
 
     /// Route the reindex/backfill jobs to a named queue.
+    ///
+    /// Overrides `[search] queue` in `autumn.toml`.
     #[must_use]
     pub fn queue(mut self, queue: impl Into<String>) -> Self {
         self.config.queue = queue.into();
+        self.config_explicit = true;
         self
     }
 
     /// Install the search engine.
+    ///
+    /// Overrides a previous [`Self::postgres`], **including** the document
+    /// source it installed: leaving that behind would ship a
+    /// [`PostgresSearchStore`] whose pool the startup hook no longer installs,
+    /// so every reindex and backfill would fail at runtime with "the search
+    /// store has no database pool".
     #[must_use]
     pub fn backend(mut self, backend: Arc<dyn SearchBackend>) -> Self {
         self.backend = Some(backend);
-        self.postgres = None;
+        if std::mem::take(&mut self.use_postgres) {
+            self.source = None;
+        }
         self
     }
 
@@ -102,12 +123,13 @@ impl SearchPlugin {
     ///
     /// One [`PostgresSearchStore`] serves as both; its connection pool is
     /// installed from `AppState` at startup, so there is nothing to pass in.
+    /// Builder order does not matter: the store is created in
+    /// [`Plugin::build`], once the configuration is final, so
+    /// `.postgres().config(cfg)` and `.config(cfg).postgres()` behave
+    /// identically.
     #[must_use]
-    pub fn postgres(mut self) -> Self {
-        let store = Arc::new(PostgresSearchStore::new(self.config.embedding_dimensions));
-        self.postgres = Some(Arc::clone(&store));
-        self.backend = Some(store.clone() as Arc<dyn SearchBackend>);
-        self.source = Some(store as Arc<dyn DocumentSource>);
+    pub const fn postgres(mut self) -> Self {
+        self.use_postgres = true;
         self
     }
 
@@ -139,7 +161,9 @@ impl SearchPlugin {
         self
     }
 
-    /// Register an index definition directly.
+    /// Register an index definition directly — for a corpus that is not a
+    /// `#[model]`, or to adjust a derived one. See
+    /// [`SearchClientBuilder::index_definition`](crate::SearchClientBuilder::index_definition).
     #[must_use]
     pub fn index_definition(mut self, definition: IndexDefinition) -> Self {
         self.indexes.push(definition);
@@ -149,7 +173,7 @@ impl SearchPlugin {
     /// Whether the Postgres backend is in use.
     #[must_use]
     pub const fn uses_postgres(&self) -> bool {
-        self.postgres.is_some()
+        self.use_postgres
     }
 
     /// The effective configuration.
@@ -168,7 +192,9 @@ impl SearchPlugin {
     }
 
     fn client_builder(&self) -> SearchClientBuilder {
-        let mut builder = SearchClient::builder().enabled(self.config.enabled);
+        let mut builder = SearchClient::builder()
+            .enabled(self.config.enabled)
+            .batch_size(self.config.batch_size);
         if let Some(backend) = &self.backend {
             builder = builder.backend(Arc::clone(backend));
         }
@@ -190,6 +216,7 @@ impl SearchPlugin {
 
 /// What a one-shot backfill boot was asked to rebuild.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum BackfillTarget {
     /// Every registered index (`AUTUMN_SEARCH_BACKFILL=all`).
     AllIndexes,
@@ -243,20 +270,58 @@ fn parse_purge_flag(raw: Option<&str>) -> bool {
     raw.is_some_and(|value| matches!(value.trim(), "1" | "true" | "yes"))
 }
 
+/// Read `[search]` from `autumn.toml` in the working directory.
+///
+/// `Ok(None)` means the file is absent — an app with no `autumn.toml` is a
+/// supported zero-config setup, so that is not an error. A file that exists
+/// but has a malformed `[search]` **is**.
+fn load_config_file() -> Result<Option<SearchConfig>, crate::config::SearchConfigError> {
+    let Ok(contents) = std::fs::read_to_string("autumn.toml") else {
+        return Ok(None);
+    };
+    SearchConfig::from_toml_str(&contents).map(Some)
+}
+
 impl Plugin for SearchPlugin {
     fn name(&self) -> Cow<'static, str> {
         Cow::Borrowed("autumn-search")
     }
 
-    fn build(self, app: AppBuilder) -> AppBuilder {
+    fn build(mut self, app: AppBuilder) -> AppBuilder {
         // Declare the plugin-owned `[search]` table first, so a host app with
         // `server.strict_config = true` boots instead of failing on an
         // "unknown key" — and so every return path below carries it.
         let app = app.config_section("search");
 
+        // Pick up `[search]` from `autumn.toml` unless the app configured the
+        // plugin explicitly. Without this, `enabled = false` — documented as
+        // the incident kill switch — would need a code change and a deploy,
+        // which is exactly what a kill switch must not need.
+        let mut config_error = None;
+        if !self.config_explicit {
+            match load_config_file() {
+                Ok(Some(config)) => self.config = config,
+                Ok(None) => {}
+                // A malformed `[search]` must not silently fall back to
+                // defaults: an unknown key there is how a typo'd kill switch
+                // would go unnoticed. `Plugin::build` cannot return an error,
+                // so surface it from the startup hook, which aborts boot.
+                Err(error) => config_error = Some(error.to_string()),
+            }
+        }
+
+        // Built HERE, not in `postgres()`, so the configuration it snapshots
+        // (`embedding_dimensions`, which gates the pgvector fast path) is
+        // final regardless of builder-call order.
+        let postgres = self.use_postgres.then(|| {
+            let store = Arc::new(PostgresSearchStore::new(self.config.embedding_dimensions));
+            self.backend = Some(Arc::clone(&store) as Arc<dyn SearchBackend>);
+            self.source = Some(Arc::clone(&store) as Arc<dyn DocumentSource>);
+            store
+        });
+
         let jobs = search_job_infos(&self.config.queue);
         let config = self.config.clone();
-        let postgres = self.postgres.clone();
         // The client is fully assembled here: every part is an `Arc` supplied
         // by the app's own builder call. Only the Postgres pool has to wait
         // for `AppState`, and the store takes it lazily — so the startup hook
@@ -267,11 +332,18 @@ impl Plugin for SearchPlugin {
             let client = client.clone();
             let postgres = postgres.clone();
             let config = config.clone();
+            let config_error = config_error.clone();
             async move {
+                if let Some(message) = config_error {
+                    return Err(autumn_web::AutumnError::internal_server_error_msg(format!(
+                        "autumn-search: {message}"
+                    )));
+                }
                 if let Some(store) = &postgres {
                     let pool = state.pool().cloned().ok_or_else(|| {
                         autumn_web::AutumnError::internal_server_error_msg(
-                            "SearchPlugin::postgres() needs a database pool; configure                              `database.primary_url` or install a different backend",
+                            "SearchPlugin::postgres() needs a database pool; configure \
+                             `database.primary_url` or install a different backend",
                         )
                     })?;
                     store.install_pool(pool);

--- a/autumn-search/src/plugin.rs
+++ b/autumn-search/src/plugin.rs
@@ -75,6 +75,20 @@ pub struct SearchPlugin {
     /// instance `build` installs ever receives the connection pool. A second
     /// one would be permanently pool-less.
     postgres_store: OnceLock<Arc<PostgresSearchStore>>,
+    /// The in-memory backend used when the app installs none, created once.
+    ///
+    /// Memoized for the same reason `postgres_store` is: `client()` and
+    /// `Plugin::build` each assemble a client, and a fresh
+    /// `MemorySearchBackend` per call would give them **separate indexes** —
+    /// an app following the documented outside-request path would write to one
+    /// and serve requests from the other.
+    default_backend: OnceLock<Arc<dyn SearchBackend>>,
+    /// The `[search]` section as finally resolved, memoized so `client()` and
+    /// `Plugin::build` cannot disagree about it.
+    ///
+    /// `Err` is kept rather than discarded: `Plugin::build` cannot return an
+    /// error, so a malformed section has to be surfaced from the startup hook.
+    resolved_config: OnceLock<Result<SearchConfig, String>>,
     /// Set once the app supplies configuration explicitly, so `build` does not
     /// then overwrite it from the app's config files.
     config_explicit: bool,
@@ -100,6 +114,8 @@ impl SearchPlugin {
             use_postgres: false,
             queue_override: None,
             postgres_store: OnceLock::new(),
+            default_backend: OnceLock::new(),
+            resolved_config: OnceLock::new(),
             config_explicit: false,
         }
     }
@@ -217,10 +233,51 @@ impl SearchPlugin {
         config
     }
 
+    /// The `[search]` section as the plugin will actually use it: builder
+    /// intent, then the app's config files and environment (unless
+    /// [`Self::config`] was called), then the [`Self::queue`] override.
+    ///
+    /// Resolved **once** and memoized, so a client taken before
+    /// [`Plugin::build`] and the one `build` installs cannot disagree — in
+    /// particular, an app that keeps a pre-build handle must not keep serving
+    /// searches after the resolved config said `enabled = false`.
+    fn resolved_config(&self) -> &Result<SearchConfig, String> {
+        self.resolved_config.get_or_init(|| {
+            if self.config_explicit {
+                return Ok(self.search_config());
+            }
+            SearchConfig::resolve()
+                .map(|mut config| {
+                    // Builder overrides land on TOP of the file, never instead
+                    // of it.
+                    if let Some(queue) = &self.queue_override {
+                        config.queue.clone_from(queue);
+                    }
+                    config
+                })
+                .map_err(|error| error.to_string())
+        })
+    }
+
+    /// [`Self::resolved_config`], falling back to builder intent when
+    /// resolution failed. The error itself aborts boot from the startup hook;
+    /// this keeps every other path total.
+    fn effective_config(&self) -> SearchConfig {
+        self.resolved_config()
+            .as_ref()
+            .map_or_else(|_| self.search_config(), Clone::clone)
+    }
+
     /// Build the [`SearchClient`] this plugin would install.
     ///
     /// Exposed so tests (and an app that drives search outside a request) can
-    /// obtain the same client the plugin registers.
+    /// obtain the same client the plugin registers. Every shared part — the
+    /// backend, the document source, the resolved configuration — is memoized
+    /// on the plugin, so this client and the one [`Plugin::build`] installs
+    /// address the same index and honour the same `[search]` section.
+    ///
+    /// It does reflect the builder *as configured so far*: calls made after
+    /// this one land on the plugin, not on an already-built client.
     #[must_use]
     pub fn client(&self) -> SearchClient {
         self.client_builder().build()
@@ -235,13 +292,19 @@ impl SearchPlugin {
         }
         Some(self.postgres_store.get_or_init(|| {
             Arc::new(PostgresSearchStore::new(
-                self.search_config().embedding_dimensions,
+                self.effective_config().embedding_dimensions,
             ))
         }))
     }
 
+    /// The shared in-memory backend used when the app installs none.
+    fn default_backend(&self) -> &Arc<dyn SearchBackend> {
+        self.default_backend
+            .get_or_init(|| Arc::new(crate::MemorySearchBackend::new()) as Arc<dyn SearchBackend>)
+    }
+
     fn client_builder(&self) -> SearchClientBuilder {
-        let config = self.search_config();
+        let config = self.effective_config();
         let mut builder = SearchClient::builder()
             .enabled(config.enabled)
             .batch_size(config.batch_size);
@@ -256,6 +319,13 @@ impl SearchPlugin {
         }
         if let Some(backend) = &self.backend {
             builder = builder.backend(Arc::clone(backend));
+        } else if self.postgres_store().is_none() {
+            // No backend configured: fall back to the in-memory one, but the
+            // SAME instance every time. Letting `SearchClientBuilder` mint its
+            // own default per call would give `client()` and `Plugin::build`
+            // separate indexes — an app that indexed through the pre-build
+            // handle would then serve requests from an empty one.
+            builder = builder.backend(Arc::clone(self.default_backend()));
         }
         if let Some(embedder) = &self.embedder {
             builder = builder.embedder(Arc::clone(embedder));
@@ -334,46 +404,35 @@ impl Plugin for SearchPlugin {
         Cow::Borrowed("autumn-search")
     }
 
-    fn build(mut self, app: AppBuilder) -> AppBuilder {
+    fn build(self, app: AppBuilder) -> AppBuilder {
         // Declare the plugin-owned `[search]` table first, so a host app with
         // `server.strict_config = true` boots instead of failing on an
         // "unknown key" — and so every return path below carries it.
         let app = app.config_section("search");
 
-        // Pick up `[search]` from the app's config unless the plugin was
-        // configured explicitly in code. Without this, `enabled = false` —
+        // `[search]` comes from the app's config unless the plugin was
+        // configured explicitly in code. Without that, `enabled = false` —
         // documented as the incident kill switch — would need a code change
         // and a deploy, which is exactly what a kill switch must not need.
         //
-        // `resolve()`, not a single-file read: the section is resolved through
-        // the same profile layering core applies, so `[profile.prod.search]`
-        // and `autumn-prod.toml` are honoured. A kill switch that works in dev
-        // and is ignored in prod is worse than no kill switch.
-        let mut config_error = None;
-        if !self.config_explicit {
-            match SearchConfig::resolve() {
-                Ok(config) => self.config = config,
-                // A malformed `[search]` must not silently fall back to
-                // defaults: an unknown key there is how a typo'd kill switch
-                // would go unnoticed. `Plugin::build` cannot return an error,
-                // so surface it from the startup hook, which aborts boot.
-                Err(error) => config_error = Some(error.to_string()),
-            }
-        }
-        // Builder overrides land on TOP of the file, never instead of it.
-        if let Some(queue) = self.queue_override.take() {
-            self.config.queue = queue;
-        }
+        // Read through the memoized `resolved_config`, NOT resolved afresh:
+        // an app that took a `client()` handle before mounting the plugin has
+        // already pinned this value, and resolving twice would let the two
+        // disagree. A malformed `[search]` is kept as an error rather than
+        // falling back to defaults — an unknown key there is how a typo'd kill
+        // switch goes unnoticed — and since `Plugin::build` cannot return one,
+        // it is surfaced from the startup hook, which aborts boot.
+        let config_error = self.resolved_config().as_ref().err().cloned();
+        let config = self.effective_config();
 
         // Resolved (and memoized) here rather than in `postgres()`, so the
         // configuration it snapshots — `embedding_dimensions`, which gates the
-        // pgvector fast path — reflects the file config loaded just above,
-        // regardless of builder-call order. `client()` shares this instance:
-        // only the one installed here receives the pool.
+        // pgvector fast path — reflects the resolved config regardless of
+        // builder-call order. `client()` shares this instance: only the one
+        // installed here receives the pool.
         let postgres = self.postgres_store().map(Arc::clone);
 
-        let jobs = search_job_infos(&self.config.queue);
-        let config = self.config.clone();
+        let jobs = search_job_infos(&config.queue);
         // The client is fully assembled here: every part is an `Arc` supplied
         // by the app's own builder call. Only the Postgres pool has to wait
         // for `AppState`, and the store takes it lazily — so the startup hook

--- a/autumn-search/src/plugin.rs
+++ b/autumn-search/src/plugin.rs
@@ -547,6 +547,27 @@ async fn run_backfill_and_exit(
     );
     let _ = std::io::Write::flush(&mut std::io::stdout());
 
+    // A one-shot reindex against a DISABLED subsystem must fail, loudly.
+    //
+    // `backfill` honours the kill switch by returning a successful zero-document
+    // report — right for an in-process call, and exactly wrong here: the
+    // process would print "reindexed 0 documents", exit 0, and the CLI would
+    // say "Reindex complete". An operator would then re-enable search believing
+    // production had been rebuilt. Nothing was written, and no backend was even
+    // initialized, because the startup hook skips setup while disabled.
+    //
+    // Checked here rather than inside `backfill` because the two callers want
+    // opposite things from the same state: a job should no-op, an operator
+    // asking for a rebuild should be told it did not happen.
+    if !client.is_enabled() {
+        eprintln!(
+            "\u{2717} autumn-search: `[search] enabled = false` for this profile — nothing was \
+             rebuilt.\n  Re-enable search (or pick the right profile with `--profile`) and run \
+             the reindex again."
+        );
+        std::process::exit(1);
+    }
+
     let result = match target.name() {
         Some(index) => client.backfill(index, options).await.map(|r| vec![r]),
         None => client.backfill_all(options).await,

--- a/autumn-search/src/plugin.rs
+++ b/autumn-search/src/plugin.rs
@@ -76,7 +76,7 @@ pub struct SearchPlugin {
     /// one would be permanently pool-less.
     postgres_store: OnceLock<Arc<PostgresSearchStore>>,
     /// Set once the app supplies configuration explicitly, so `build` does not
-    /// then overwrite it from `autumn.toml`.
+    /// then overwrite it from the app's config files.
     config_explicit: bool,
 }
 
@@ -106,8 +106,8 @@ impl SearchPlugin {
 
     /// Replace the whole `[search]` configuration.
     ///
-    /// Setting it explicitly also stops [`Plugin::build`] from loading
-    /// `[search]` out of `autumn.toml`.
+    /// Setting it explicitly also stops [`Plugin::build`] from resolving
+    /// `[search]` out of the app's config files and environment.
     #[must_use]
     pub fn config(mut self, config: SearchConfig) -> Self {
         self.config = config;
@@ -118,7 +118,7 @@ impl SearchPlugin {
     /// Route the reindex/backfill jobs to a named queue.
     ///
     /// Overrides **only** `[search] queue`; every other key still comes from
-    /// `autumn.toml`. Suppressing the whole file here would mean an app that
+    /// the resolved config. Suppressing the whole file here would mean an app that
     /// picks a queue in code silently loses `enabled = false` — i.e. the
     /// documented incident kill switch would stop working because of an
     /// unrelated builder call.
@@ -205,9 +205,9 @@ impl SearchPlugin {
 
     /// The configuration as it stands, with any builder overrides applied.
     ///
-    /// Before [`Plugin::build`] this does **not** include `autumn.toml` — the
-    /// file is read at build time so a test or a caller can inspect the
-    /// builder's own intent without touching the filesystem.
+    /// Before [`Plugin::build`] this does **not** include the app's config
+    /// files — they are resolved at build time, so a test or a caller can
+    /// inspect the builder's own intent without touching the filesystem.
     #[must_use]
     pub fn search_config(&self) -> SearchConfig {
         let mut config = self.config.clone();
@@ -329,47 +329,6 @@ fn parse_purge_flag(raw: Option<&str>) -> bool {
     raw.is_some_and(|value| matches!(value.trim(), "1" | "true" | "yes"))
 }
 
-/// Read `[search]` from the application's `autumn.toml`.
-///
-/// Resolution mirrors core's own config loader (`find_config_file_named` in
-/// `autumn/src/config.rs`): the app's crate directory via
-/// `AUTUMN_MANIFEST_DIR` first, then the process working directory. The two
-/// differ whenever the binary is launched from somewhere other than the crate
-/// root — `autumn search reindex --package app` from a workspace root, for
-/// instance — and reading the wrong file (or none) would silently ignore
-/// `enabled = false` or pick the wrong embedding mode.
-///
-/// `Ok(None)` means no file was found — an app with no `autumn.toml` is a
-/// supported zero-config setup, so that is not an error. A file that exists
-/// but has a malformed `[search]` **is**.
-fn load_config_file() -> Result<Option<SearchConfig>, crate::config::SearchConfigError> {
-    for path in config_file_candidates() {
-        match std::fs::read_to_string(&path) {
-            Ok(contents) => return SearchConfig::from_toml_str(&contents).map(Some),
-            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
-            // A file that exists but cannot be read is a real problem — a
-            // permissions mistake must not read as "zero-config".
-            Err(error) => {
-                return Err(crate::config::SearchConfigError::Invalid(format!(
-                    "cannot read {}: {error}",
-                    path.display()
-                )));
-            }
-        }
-    }
-    Ok(None)
-}
-
-/// Candidate `autumn.toml` paths, in core's precedence order.
-fn config_file_candidates() -> Vec<std::path::PathBuf> {
-    let mut candidates = Vec::with_capacity(2);
-    if let Ok(manifest_dir) = std::env::var("AUTUMN_MANIFEST_DIR") {
-        candidates.push(std::path::PathBuf::from(manifest_dir).join("autumn.toml"));
-    }
-    candidates.push(std::path::PathBuf::from("autumn.toml"));
-    candidates
-}
-
 impl Plugin for SearchPlugin {
     fn name(&self) -> Cow<'static, str> {
         Cow::Borrowed("autumn-search")
@@ -381,15 +340,19 @@ impl Plugin for SearchPlugin {
         // "unknown key" — and so every return path below carries it.
         let app = app.config_section("search");
 
-        // Pick up `[search]` from `autumn.toml` unless the app configured the
-        // plugin explicitly. Without this, `enabled = false` — documented as
-        // the incident kill switch — would need a code change and a deploy,
-        // which is exactly what a kill switch must not need.
+        // Pick up `[search]` from the app's config unless the plugin was
+        // configured explicitly in code. Without this, `enabled = false` —
+        // documented as the incident kill switch — would need a code change
+        // and a deploy, which is exactly what a kill switch must not need.
+        //
+        // `resolve()`, not a single-file read: the section is resolved through
+        // the same profile layering core applies, so `[profile.prod.search]`
+        // and `autumn-prod.toml` are honoured. A kill switch that works in dev
+        // and is ignored in prod is worse than no kill switch.
         let mut config_error = None;
         if !self.config_explicit {
-            match load_config_file() {
-                Ok(Some(config)) => self.config = config,
-                Ok(None) => {}
+            match SearchConfig::resolve() {
+                Ok(config) => self.config = config,
                 // A malformed `[search]` must not silently fall back to
                 // defaults: an unknown key there is how a typo'd kill switch
                 // would go unnoticed. `Plugin::build` cannot return an error,
@@ -428,6 +391,30 @@ impl Plugin for SearchPlugin {
                         "autumn-search: {message}"
                     )));
                 }
+                // The declared width and the installed embedder's width must
+                // agree before a single document is written. They are set in
+                // two different places — `[search] embedding_dimensions` in
+                // config, `Embedder::dimensions()` in code — and when they
+                // disagree the failure is silent: every write succeeds, the
+                // vector column rejects the wrong-width value, and semantic
+                // search simply returns nothing. Boot loudly instead.
+                //
+                // `0` means no usable embedder (the default `NoEmbedder`), for
+                // which nothing vector-shaped runs at all — declaring a width
+                // ahead of installing a provider is a legitimate ordering.
+                let embedder_width = client.embedding_dimensions();
+                if let Some(configured) = config.embedding_dimensions
+                    && embedder_width != 0
+                    && embedder_width != configured
+                {
+                    return Err(autumn_web::AutumnError::internal_server_error_msg(format!(
+                        "autumn-search: `search.embedding_dimensions = {configured}` does not \
+                         match the installed embedder, which produces {embedder_width}-dimension \
+                         vectors; set them to the same value (and re-run `autumn search reindex \
+                         --purge` if the width really changed)"
+                    )));
+                }
+
                 if let Some(store) = &postgres {
                     let pool = state.pool().cloned().ok_or_else(|| {
                         autumn_web::AutumnError::internal_server_error_msg(
@@ -527,7 +514,7 @@ mod tests {
     fn a_queue_override_does_not_suppress_the_rest_of_the_file_config() {
         // The trap: if `queue(...)` marked the whole config explicit, an app
         // that picks a queue in code would silently lose `enabled = false`
-        // from `autumn.toml` — the incident kill switch defeated by an
+        // from the resolved config — the incident kill switch defeated by an
         // unrelated builder call.
         let plugin = SearchPlugin::new().queue("indexing");
         assert!(
@@ -585,30 +572,6 @@ mod tests {
             BackfillTarget::Index("articles".to_owned()).name(),
             Some("articles")
         );
-    }
-
-    #[test]
-    fn config_resolution_prefers_the_manifest_directory_over_the_cwd() {
-        // `autumn search reindex --package app` runs the binary from the
-        // workspace root, where the CWD holds a different `autumn.toml` (or
-        // none). Core resolves through `AUTUMN_MANIFEST_DIR` first; the
-        // plugin-owned section must resolve the same way or it reads a
-        // different file than the rest of the config.
-        let candidates = config_file_candidates();
-        assert_eq!(
-            candidates.last().map(|p| p.to_string_lossy().into_owned()),
-            Some("autumn.toml".to_owned()),
-            "the CWD is always the last resort"
-        );
-        // The manifest-dir candidate is present only when the env var is set,
-        // and when present it must come FIRST.
-        match std::env::var("AUTUMN_MANIFEST_DIR") {
-            Ok(dir) => {
-                assert_eq!(candidates.len(), 2);
-                assert!(candidates[0].starts_with(&dir), "{candidates:?}");
-            }
-            Err(_) => assert_eq!(candidates.len(), 1),
-        }
     }
 
     #[test]

--- a/autumn-search/src/plugin.rs
+++ b/autumn-search/src/plugin.rs
@@ -1,7 +1,7 @@
 //! The [`Plugin`] that mounts the whole subsystem with one builder call.
 
 use std::borrow::Cow;
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 
 use autumn_web::app::AppBuilder;
 use autumn_web::plugin::Plugin;
@@ -66,6 +66,15 @@ pub struct SearchPlugin {
     /// A `queue(...)` builder override, applied ON TOP of the file config
     /// rather than instead of it.
     queue_override: Option<String>,
+    /// The Postgres store, created on first need and shared by `client()` and
+    /// `Plugin::build`.
+    ///
+    /// Memoized rather than built in `postgres()` so the configuration it
+    /// snapshots (`embedding_dimensions`, which gates the pgvector fast path)
+    /// is as late as possible — and rather than built twice, because only the
+    /// instance `build` installs ever receives the connection pool. A second
+    /// one would be permanently pool-less.
+    postgres_store: OnceLock<Arc<PostgresSearchStore>>,
     /// Set once the app supplies configuration explicitly, so `build` does not
     /// then overwrite it from `autumn.toml`.
     config_explicit: bool,
@@ -90,6 +99,7 @@ impl SearchPlugin {
             indexes: Vec::new(),
             use_postgres: false,
             queue_override: None,
+            postgres_store: OnceLock::new(),
             config_explicit: false,
         }
     }
@@ -130,6 +140,7 @@ impl SearchPlugin {
         self.backend = Some(backend);
         if std::mem::take(&mut self.use_postgres) {
             self.source = None;
+            self.postgres_store = OnceLock::new();
         }
         self
     }
@@ -215,10 +226,34 @@ impl SearchPlugin {
         self.client_builder().build()
     }
 
+    /// The Postgres store this plugin will install, created once.
+    ///
+    /// `None` unless [`Self::postgres`] was requested.
+    fn postgres_store(&self) -> Option<&Arc<PostgresSearchStore>> {
+        if !self.use_postgres {
+            return None;
+        }
+        Some(self.postgres_store.get_or_init(|| {
+            Arc::new(PostgresSearchStore::new(
+                self.search_config().embedding_dimensions,
+            ))
+        }))
+    }
+
     fn client_builder(&self) -> SearchClientBuilder {
+        let config = self.search_config();
         let mut builder = SearchClient::builder()
-            .enabled(self.config.enabled)
-            .batch_size(self.config.batch_size);
+            .enabled(config.enabled)
+            .batch_size(config.batch_size);
+        // `postgres()` only records the intent, so resolve the store here —
+        // otherwise `SearchPlugin::new().postgres().client()` would silently
+        // hand back an isolated in-memory index instead of the configured
+        // persistent backend.
+        if let Some(store) = self.postgres_store() {
+            builder = builder
+                .backend(Arc::clone(store) as Arc<dyn SearchBackend>)
+                .source(Arc::clone(store) as Arc<dyn DocumentSource>);
+        }
         if let Some(backend) = &self.backend {
             builder = builder.backend(Arc::clone(backend));
         }
@@ -367,15 +402,12 @@ impl Plugin for SearchPlugin {
             self.config.queue = queue;
         }
 
-        // Built HERE, not in `postgres()`, so the configuration it snapshots
-        // (`embedding_dimensions`, which gates the pgvector fast path) is
-        // final regardless of builder-call order.
-        let postgres = self.use_postgres.then(|| {
-            let store = Arc::new(PostgresSearchStore::new(self.config.embedding_dimensions));
-            self.backend = Some(Arc::clone(&store) as Arc<dyn SearchBackend>);
-            self.source = Some(Arc::clone(&store) as Arc<dyn DocumentSource>);
-            store
-        });
+        // Resolved (and memoized) here rather than in `postgres()`, so the
+        // configuration it snapshots — `embedding_dimensions`, which gates the
+        // pgvector fast path — reflects the file config loaded just above,
+        // regardless of builder-call order. `client()` shares this instance:
+        // only the one installed here receives the pool.
+        let postgres = self.postgres_store().map(Arc::clone);
 
         let jobs = search_job_infos(&self.config.queue);
         let config = self.config.clone();

--- a/autumn-search/src/plugin.rs
+++ b/autumn-search/src/plugin.rs
@@ -30,6 +30,15 @@ pub const BACKFILL_ENV: &str = "AUTUMN_SEARCH_BACKFILL";
 /// Environment variable that makes the one-shot backfill purge first.
 pub const BACKFILL_PURGE_ENV: &str = "AUTUMN_SEARCH_BACKFILL_PURGE";
 
+/// Line the plugin prints to stdout the moment a one-shot backfill begins.
+///
+/// Without it `autumn search reindex` cannot distinguish "the backfill is
+/// running and will take a while" from "this app never installed
+/// `SearchPlugin`, so nothing consumed [`BACKFILL_ENV`] and it is now serving
+/// HTTP forever" — and the CLI would appear to hang until interrupted. The CLI
+/// waits a bounded time for this line and only then waits indefinitely.
+pub const BACKFILL_STARTED_MARKER: &str = "autumn-search: backfill starting";
+
 /// Keyword + vector search for `autumn-web` applications.
 ///
 /// ```rust,ignore
@@ -54,6 +63,9 @@ pub struct SearchPlugin {
     /// Whether `postgres()` was requested. The store itself is built in
     /// `Plugin::build`, after the configuration is final.
     use_postgres: bool,
+    /// A `queue(...)` builder override, applied ON TOP of the file config
+    /// rather than instead of it.
+    queue_override: Option<String>,
     /// Set once the app supplies configuration explicitly, so `build` does not
     /// then overwrite it from `autumn.toml`.
     config_explicit: bool,
@@ -77,6 +89,7 @@ impl SearchPlugin {
             visibility: None,
             indexes: Vec::new(),
             use_postgres: false,
+            queue_override: None,
             config_explicit: false,
         }
     }
@@ -94,11 +107,14 @@ impl SearchPlugin {
 
     /// Route the reindex/backfill jobs to a named queue.
     ///
-    /// Overrides `[search] queue` in `autumn.toml`.
+    /// Overrides **only** `[search] queue`; every other key still comes from
+    /// `autumn.toml`. Suppressing the whole file here would mean an app that
+    /// picks a queue in code silently loses `enabled = false` — i.e. the
+    /// documented incident kill switch would stop working because of an
+    /// unrelated builder call.
     #[must_use]
     pub fn queue(mut self, queue: impl Into<String>) -> Self {
-        self.config.queue = queue.into();
-        self.config_explicit = true;
+        self.queue_override = Some(queue.into());
         self
     }
 
@@ -176,10 +192,18 @@ impl SearchPlugin {
         self.use_postgres
     }
 
-    /// The effective configuration.
+    /// The configuration as it stands, with any builder overrides applied.
+    ///
+    /// Before [`Plugin::build`] this does **not** include `autumn.toml` — the
+    /// file is read at build time so a test or a caller can inspect the
+    /// builder's own intent without touching the filesystem.
     #[must_use]
-    pub const fn search_config(&self) -> &SearchConfig {
-        &self.config
+    pub fn search_config(&self) -> SearchConfig {
+        let mut config = self.config.clone();
+        if let Some(queue) = &self.queue_override {
+            config.queue.clone_from(queue);
+        }
+        config
     }
 
     /// Build the [`SearchClient`] this plugin would install.
@@ -270,16 +294,45 @@ fn parse_purge_flag(raw: Option<&str>) -> bool {
     raw.is_some_and(|value| matches!(value.trim(), "1" | "true" | "yes"))
 }
 
-/// Read `[search]` from `autumn.toml` in the working directory.
+/// Read `[search]` from the application's `autumn.toml`.
 ///
-/// `Ok(None)` means the file is absent — an app with no `autumn.toml` is a
+/// Resolution mirrors core's own config loader (`find_config_file_named` in
+/// `autumn/src/config.rs`): the app's crate directory via
+/// `AUTUMN_MANIFEST_DIR` first, then the process working directory. The two
+/// differ whenever the binary is launched from somewhere other than the crate
+/// root — `autumn search reindex --package app` from a workspace root, for
+/// instance — and reading the wrong file (or none) would silently ignore
+/// `enabled = false` or pick the wrong embedding mode.
+///
+/// `Ok(None)` means no file was found — an app with no `autumn.toml` is a
 /// supported zero-config setup, so that is not an error. A file that exists
 /// but has a malformed `[search]` **is**.
 fn load_config_file() -> Result<Option<SearchConfig>, crate::config::SearchConfigError> {
-    let Ok(contents) = std::fs::read_to_string("autumn.toml") else {
-        return Ok(None);
-    };
-    SearchConfig::from_toml_str(&contents).map(Some)
+    for path in config_file_candidates() {
+        match std::fs::read_to_string(&path) {
+            Ok(contents) => return SearchConfig::from_toml_str(&contents).map(Some),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            // A file that exists but cannot be read is a real problem — a
+            // permissions mistake must not read as "zero-config".
+            Err(error) => {
+                return Err(crate::config::SearchConfigError::Invalid(format!(
+                    "cannot read {}: {error}",
+                    path.display()
+                )));
+            }
+        }
+    }
+    Ok(None)
+}
+
+/// Candidate `autumn.toml` paths, in core's precedence order.
+fn config_file_candidates() -> Vec<std::path::PathBuf> {
+    let mut candidates = Vec::with_capacity(2);
+    if let Ok(manifest_dir) = std::env::var("AUTUMN_MANIFEST_DIR") {
+        candidates.push(std::path::PathBuf::from(manifest_dir).join("autumn.toml"));
+    }
+    candidates.push(std::path::PathBuf::from("autumn.toml"));
+    candidates
 }
 
 impl Plugin for SearchPlugin {
@@ -308,6 +361,10 @@ impl Plugin for SearchPlugin {
                 // so surface it from the startup hook, which aborts boot.
                 Err(error) => config_error = Some(error.to_string()),
             }
+        }
+        // Builder overrides land on TOP of the file, never instead of it.
+        if let Some(queue) = self.queue_override.take() {
+            self.config.queue = queue;
         }
 
         // Built HERE, not in `postgres()`, so the configuration it snapshots
@@ -380,6 +437,16 @@ async fn run_backfill_and_exit(
     target: &BackfillTarget,
     options: &BackfillOptions,
 ) -> ! {
+    // Announced BEFORE the work starts: this is the CLI's proof that the
+    // plugin exists and consumed the request. Flushed explicitly — stdout is
+    // line-buffered when attached to a terminal but block-buffered through a
+    // pipe, which is exactly how the CLI reads it.
+    println!(
+        "{BACKFILL_STARTED_MARKER} {}",
+        target.name().unwrap_or("all")
+    );
+    let _ = std::io::Write::flush(&mut std::io::stdout());
+
     let result = match target.name() {
         Some(index) => client.backfill(index, options).await.map(|r| vec![r]),
         None => client.backfill_all(options).await,
@@ -425,6 +492,32 @@ mod tests {
     }
 
     #[test]
+    fn a_queue_override_does_not_suppress_the_rest_of_the_file_config() {
+        // The trap: if `queue(...)` marked the whole config explicit, an app
+        // that picks a queue in code would silently lose `enabled = false`
+        // from `autumn.toml` — the incident kill switch defeated by an
+        // unrelated builder call.
+        let plugin = SearchPlugin::new().queue("indexing");
+        assert!(
+            !plugin.config_explicit,
+            "a queue override must leave the file config in play"
+        );
+
+        // `config(...)` IS a whole-config replacement, and does suppress it.
+        let plugin = SearchPlugin::new().config(SearchConfig::default());
+        assert!(plugin.config_explicit);
+    }
+
+    #[test]
+    fn an_explicit_config_still_honours_a_later_queue_override() {
+        let config = SearchConfig::from_toml_str("[search]\nbatch_size = 7\n").expect("parse");
+        let plugin = SearchPlugin::new().config(config).queue("indexing");
+        let effective = plugin.search_config();
+        assert_eq!(effective.queue, "indexing");
+        assert_eq!(effective.batch_size, 7, "the rest of the config survives");
+    }
+
+    #[test]
     fn an_explicit_backend_turns_off_the_postgres_default() {
         let plugin = SearchPlugin::new()
             .postgres()
@@ -460,6 +553,30 @@ mod tests {
             BackfillTarget::Index("articles".to_owned()).name(),
             Some("articles")
         );
+    }
+
+    #[test]
+    fn config_resolution_prefers_the_manifest_directory_over_the_cwd() {
+        // `autumn search reindex --package app` runs the binary from the
+        // workspace root, where the CWD holds a different `autumn.toml` (or
+        // none). Core resolves through `AUTUMN_MANIFEST_DIR` first; the
+        // plugin-owned section must resolve the same way or it reads a
+        // different file than the rest of the config.
+        let candidates = config_file_candidates();
+        assert_eq!(
+            candidates.last().map(|p| p.to_string_lossy().into_owned()),
+            Some("autumn.toml".to_owned()),
+            "the CWD is always the last resort"
+        );
+        // The manifest-dir candidate is present only when the env var is set,
+        // and when present it must come FIRST.
+        match std::env::var("AUTUMN_MANIFEST_DIR") {
+            Ok(dir) => {
+                assert_eq!(candidates.len(), 2);
+                assert!(candidates[0].starts_with(&dir), "{candidates:?}");
+            }
+            Err(_) => assert_eq!(candidates.len(), 1),
+        }
     }
 
     #[test]

--- a/autumn-search/src/postgres.rs
+++ b/autumn-search/src/postgres.rs
@@ -165,6 +165,15 @@ pub struct PostgresSearchStore {
     /// Cache of the optional framework columns each source table carries, so a
     /// backfill does not re-probe `pg_attribute` on every batch.
     optional_columns: RwLock<std::collections::HashMap<&'static str, OptionalColumns>>,
+    /// Declared width of the PHYSICAL `embedding_vec` column, if it exists —
+    /// which is NOT the same question as "is this process in pgvector mode".
+    ///
+    /// An earlier pgvector-enabled deployment can leave the column behind while
+    /// this process falls back to `Array` (dimensions unset, or a width
+    /// mismatch). Writes must still keep that column in step, or stale vectors
+    /// survive every upsert and a pgvector-mode reader — another replica, or
+    /// this one after a config change — silently ranks on obsolete content.
+    vector_column_width: RwLock<Option<usize>>,
 }
 
 /// Which optional framework columns one source table carries.
@@ -199,6 +208,7 @@ impl PostgresSearchStore {
             vector_mode: RwLock::new(None),
             schema_ready: AtomicBool::new(false),
             optional_columns: RwLock::new(std::collections::HashMap::new()),
+            vector_column_width: RwLock::new(None),
         }
     }
 
@@ -212,6 +222,18 @@ impl PostgresSearchStore {
     #[must_use]
     pub fn vector_mode(&self) -> Option<VectorMode> {
         self.vector_mode.read().ok().and_then(|guard| *guard)
+    }
+
+    /// Declared width of the physical `embedding_vec` column, if it exists.
+    ///
+    /// Independent of [`Self::vector_mode`]: the column can outlive the mode
+    /// that created it.
+    #[must_use]
+    pub fn vector_column_width(&self) -> Option<usize> {
+        self.vector_column_width
+            .read()
+            .ok()
+            .and_then(|guard| *guard)
     }
 
     fn pool(&self) -> SearchResult<&RuntimePool> {
@@ -437,7 +459,19 @@ impl SearchBackend for PostgresSearchStore {
                 if let Ok(mut guard) = self.vector_mode.write() {
                     *guard = Some(mode);
                 }
-                tracing::info!(?mode, "autumn-search postgres vector storage resolved");
+
+                // Probe the PHYSICAL column regardless of the resolved mode: it
+                // may have been created by an earlier deployment, and writes
+                // have to keep it in step either way.
+                let width = Self::vector_column_width_of(&mut conn).await?;
+                if let Ok(mut guard) = self.vector_column_width.write() {
+                    *guard = width;
+                }
+                tracing::info!(
+                    ?mode,
+                    vector_column_width = ?width,
+                    "autumn-search postgres vector storage resolved"
+                );
             }
             Ok(())
         })
@@ -456,12 +490,13 @@ impl SearchBackend for PostgresSearchStore {
                 return Ok(());
             }
             let mut conn = self.conn().await?;
-            // The column exists once `try_enable_pgvector` has added it, and
-            // it must be WRITTEN whenever it exists — even in Array mode.
-            // Skipping it would leave a stale `embedding_vec` behind after an
-            // upsert, and a pgvector-mode reader (another replica, or this one
-            // after a config change) would then rank on the old vector.
-            let has_vector_column = self.vector_mode().is_some_and(VectorMode::is_pgvector);
+            // Keyed on the PHYSICAL column, not on this process's mode. The
+            // column can outlive the mode that created it (dimensions unset, a
+            // width mismatch, a mixed fleet), and skipping it then leaves a
+            // stale `embedding_vec` behind after every upsert — which a
+            // pgvector-mode reader silently ranks on. `None` width means the
+            // column is absent and must stay out of the column list entirely.
+            let vector_width = self.vector_column_width();
 
             for document in documents {
                 // The weighted tsvector, built exactly as #842 does:
@@ -486,9 +521,17 @@ impl SearchBackend for PostgresSearchStore {
                     Bound::Text(document.document.text()),
                     Bound::NullableText(document.embedding.as_deref().map(array_literal)),
                 ];
-                if has_vector_column {
+                if let Some(width) = vector_width {
+                    // Write the real vector when it fits the declared width,
+                    // and NULL when it does not — a width the column cannot
+                    // hold would fail the insert, and leaving the old value in
+                    // place is exactly the staleness this avoids.
                     binds.push(Bound::NullableText(
-                        document.embedding.as_deref().map(vector_literal),
+                        document
+                            .embedding
+                            .as_deref()
+                            .filter(|embedding| embedding.len() == width)
+                            .map(vector_literal),
                     ));
                 }
 
@@ -517,7 +560,7 @@ impl SearchBackend for PostgresSearchStore {
                     "to_tsvector($5::text::regconfig, '')".clone_into(&mut vector_sql);
                 }
 
-                let (vec_column, vec_value, vec_update) = if has_vector_column {
+                let (vec_column, vec_value, vec_update) = if vector_width.is_some() {
                     (
                         ", embedding_vec",
                         ", $8::vector",
@@ -862,6 +905,29 @@ impl PostgresSearchStore {
         outcome
     }
 
+    /// Declared width of the physical `embedding_vec` column, or `None` when
+    /// the column does not exist.
+    ///
+    /// `atttypmod` carries a `vector`'s declared dimension count. Resolved via
+    /// `to_regclass` so it follows the same `search_path` the queries do.
+    async fn vector_column_width_of(
+        conn: &mut diesel_async::pooled_connection::deadpool::Object<autumn_web::RuntimeConnection>,
+    ) -> SearchResult<Option<usize>> {
+        let rows = diesel::sql_query(format!(
+            "SELECT COALESCE(atttypmod, 0)::bigint AS width FROM pg_attribute \
+             WHERE attrelid = to_regclass('{DOCUMENTS_TABLE}') \
+               AND attname = 'embedding_vec' AND NOT attisdropped"
+        ))
+        .get_results::<WidthRow>(conn)
+        .await
+        .map_err(SearchError::backend)?;
+
+        Ok(rows
+            .into_iter()
+            .next()
+            .and_then(|row| usize::try_from(row.width).ok()))
+    }
+
     /// Try to install `pgvector` and add the accelerated column + index.
     ///
     /// Returns `false` (rather than erroring) when the extension is not
@@ -912,15 +978,9 @@ impl PostgresSearchStore {
         // column of a DIFFERENT width, which would leave the store believing
         // it is in `PgVector{new}` while every insert fails with "expected
         // <old> dimensions". Verify what is actually there.
-        let actual = diesel::sql_query(format!(
-            "SELECT COALESCE(atttypmod, 0)::bigint AS width FROM pg_attribute \
-             WHERE attrelid = to_regclass('{DOCUMENTS_TABLE}') \
-               AND attname = 'embedding_vec' AND NOT attisdropped"
-        ))
-        .get_results::<WidthRow>(&mut *conn)
-        .await
-        .map_err(SearchError::backend)?;
-        let existing_width = actual.into_iter().next().map(|row| row.width);
+        let existing_width = Self::vector_column_width_of(conn)
+            .await?
+            .and_then(|w| i64::try_from(w).ok());
         if let Some(width) = existing_width
             && width > 0
             && usize::try_from(width).unwrap_or(0) != dimensions
@@ -939,7 +999,9 @@ impl PostgresSearchStore {
         // Adopt embeddings written while the store was in Array mode —
         // otherwise every pre-existing document silently vanishes from k-NN
         // (the query filters `embedding_vec IS NOT NULL`) until a full
-        // backfill happens to run.
+        // backfill happens to run. Rows written *after* this point stay in step
+        // via `index()`, which keys on the physical column rather than on the
+        // mode.
         diesel::sql_query(format!(
             "UPDATE {DOCUMENTS_TABLE} SET embedding_vec = embedding::text::vector \
              WHERE embedding IS NOT NULL AND embedding_vec IS NULL \

--- a/autumn-search/src/postgres.rs
+++ b/autumn-search/src/postgres.rs
@@ -825,35 +825,39 @@ impl SearchBackend for PostgresSearchStore {
                 return Ok(());
             }
             let mut conn = self.conn().await?;
-            let binds = [
-                Bound::Text(definition.name.to_owned()),
-                Bound::Ids(ids.to_vec()),
-            ];
+            // ONE statement, via a data-modifying CTE.
+            //
+            // Removing the document and recording the delete are two halves of
+            // a single fact, and a concurrent backfill must never observe the
+            // gap between them: after the DELETE commits but before the ledger
+            // row exists, a watermarked insert sees no document to conflict
+            // with AND no delete to be blocked by, so it re-creates the record
+            // — and writing the tombstone afterwards does not take it back
+            // out. Two autocommitted statements have exactly that window.
+            //
+            // A CTE rather than an explicit transaction because a single
+            // statement is atomic under autocommit with nothing to roll back,
+            // and it keeps this off diesel-async's transaction API. Postgres
+            // runs a data-modifying CTE to completion whether or not the outer
+            // query reads it, so the DELETE needs no RETURNING.
+            //
+            // `deleted_at` is refreshed on a replayed delete so a retry cannot
+            // age out earlier than the delete it repeats.
             bind_all(
                 diesel::sql_query(format!(
-                    "DELETE FROM {DOCUMENTS_TABLE} \
-                     WHERE index_name = $1 AND record_id = ANY($2)"
-                ))
-                .into_boxed::<autumn_web::RuntimeBackend>(),
-                binds.clone(),
-            )
-            .execute(&mut conn)
-            .await
-            .map_err(SearchError::backend)?;
-
-            // Record the delete so it OUTLIVES the document. Without this a
-            // backfill batch scanned before the delete finds no row to
-            // conflict with, inserts unconditionally, and resurrects a record
-            // someone deleted. `deleted_at` is refreshed on re-delete so a
-            // replayed delete cannot age out early.
-            bind_all(
-                diesel::sql_query(format!(
-                    "INSERT INTO {DELETES_TABLE} (index_name, record_id) \
+                    "WITH removed AS ( \
+                       DELETE FROM {DOCUMENTS_TABLE} \
+                        WHERE index_name = $1 AND record_id = ANY($2) \
+                     ) \
+                     INSERT INTO {DELETES_TABLE} (index_name, record_id) \
                      SELECT $1, unnest($2::bigint[]) \
                      ON CONFLICT (index_name, record_id) DO UPDATE SET deleted_at = NOW()"
                 ))
                 .into_boxed::<autumn_web::RuntimeBackend>(),
-                binds,
+                [
+                    Bound::Text(definition.name.to_owned()),
+                    Bound::Ids(ids.to_vec()),
+                ],
             )
             .execute(&mut conn)
             .await
@@ -866,21 +870,21 @@ impl SearchBackend for PostgresSearchStore {
         Box::pin(async move {
             checked(definition)?;
             let mut conn = self.conn().await?;
+            // Documents and ledger in ONE statement, for the same reason
+            // `delete` uses a CTE: a purge is a deliberate reset, and a
+            // concurrent write must not be able to observe half of it. The
+            // ledger has to go too, or the rebuild that follows would silently
+            // skip everything previously deleted.
             diesel::sql_query(format!(
-                "DELETE FROM {DOCUMENTS_TABLE} WHERE index_name = $1"
+                "WITH removed AS ( \
+                   DELETE FROM {DOCUMENTS_TABLE} WHERE index_name = $1 \
+                 ) \
+                 DELETE FROM {DELETES_TABLE} WHERE index_name = $1"
             ))
             .bind::<Text, _>(definition.name.to_owned())
             .execute(&mut conn)
             .await
             .map_err(SearchError::backend)?;
-            // The ledger goes with it: a purge is a deliberate reset, and the
-            // backfill that follows is *supposed* to rewrite everything.
-            // Leaving tombstones behind would make it silently skip records.
-            diesel::sql_query(format!("DELETE FROM {DELETES_TABLE} WHERE index_name = $1"))
-                .bind::<Text, _>(definition.name.to_owned())
-                .execute(&mut conn)
-                .await
-                .map_err(SearchError::backend)?;
             Ok(())
         })
     }

--- a/autumn-search/src/postgres.rs
+++ b/autumn-search/src/postgres.rs
@@ -1219,12 +1219,18 @@ fn fields_projection(definition: &IndexDefinition) -> String {
     if pairs.is_empty() {
         return "'{}'::jsonb::text".to_owned();
     }
-    pairs
+    let merged = pairs
         .chunks(PAIRS_PER_CHUNK)
         .map(|chunk| format!("jsonb_build_object({})", chunk.join(", ")))
         .collect::<Vec<_>>()
-        .join(" || ")
-        + "::text"
+        .join(" || ");
+    // Parenthesized before the cast: `::` binds TIGHTER than `||`, so
+    // `a || b::text` casts only the final chunk and then asks Postgres for
+    // `jsonb || text` — which is not a jsonb merge. The result is either an
+    // operator error or two objects concatenated into invalid JSON that
+    // `load_documents` then fails to deserialize. Only reachable past the
+    // chunk boundary, which is exactly the case the chunking exists to serve.
+    format!("({merged})::text")
 }
 
 /// The `fields` JSON one document is stored with.
@@ -1465,6 +1471,50 @@ mod tests {
         );
         assert_eq!(sql, " AND tenant_id = $2");
         assert_eq!(binds, vec![Bound::Text("acme".to_owned())]);
+    }
+
+    #[test]
+    fn the_fields_projection_casts_the_whole_merge_not_just_the_last_chunk() {
+        // `::` binds tighter than `||`, so an unparenthesized
+        // `a || b::text` would cast only `b` and stop being a jsonb merge.
+        const PAIRS_PER_CHUNK: usize = 40;
+
+        // Under the chunk boundary: one call, still parenthesized.
+        let single = fields_projection(&definition());
+        assert!(single.starts_with("(jsonb_build_object("), "{single}");
+        assert!(single.ends_with(")::text"), "{single}");
+        assert_eq!(single.matches("jsonb_build_object(").count(), 1);
+
+        // Past it: several calls merged with `||`, and the cast must apply to
+        // the whole expression.
+        let fields: Vec<SearchIndexField> = (0..=(PAIRS_PER_CHUNK * 2))
+            .map(|i| SearchIndexField::new(format!("field_{i}").leak(), 'D'))
+            .collect();
+        let mut wide = definition();
+        wide.fields = std::borrow::Cow::Owned(fields);
+        wide.embed_field = None;
+
+        let projection = fields_projection(&wide);
+        assert_eq!(
+            projection.matches("jsonb_build_object(").count(),
+            3,
+            "81 pairs at 40/chunk is 3 calls: {projection}"
+        );
+        assert!(projection.contains(" || "), "{projection}");
+        assert!(projection.starts_with('('), "{projection}");
+        assert!(projection.ends_with(")::text"), "{projection}");
+        // The cast must not sit directly on a chunk.
+        assert!(
+            !projection.contains(")::text ||"),
+            "the cast must wrap the merge, not a chunk: {projection}"
+        );
+    }
+
+    #[test]
+    fn an_empty_field_list_still_yields_valid_json() {
+        let mut empty = definition();
+        empty.fields = std::borrow::Cow::Borrowed(&[]);
+        assert_eq!(fields_projection(&empty), "'{}'::jsonb::text");
     }
 
     #[test]

--- a/autumn-search/src/postgres.rs
+++ b/autumn-search/src/postgres.rs
@@ -61,6 +61,19 @@ type BoxedQuery<'a> = diesel::query_builder::BoxedSqlQuery<
 /// Physical table every index's documents live in.
 pub const DOCUMENTS_TABLE: &str = "autumn_search_documents";
 
+/// `ts_rank_cd`'s `{D, C, B, A}` weight array, matching
+/// [`weight_factor`](autumn_web::search::weight_factor).
+///
+/// Postgres' default is `{0.1, 0.2, 0.4, 1.0}`, but the framework's
+/// cross-backend ranking contract is `D:1, C:2, B:5, A:10` — `0.5` for `B`,
+/// not `0.4`. Leaving it defaulted means a query whose `B` and `C` matches
+/// compete ranks differently here than in `MemorySearchBackend`, which the two
+/// suites assert is the *same* contract. Kept as a literal (not formatted at
+/// call time) so the statement text is stable for the prepared-statement
+/// cache; `ts_rank_weights_track_the_framework_factors` fails if
+/// `weight_factor` changes without this.
+const TS_RANK_WEIGHTS: &str = "'{0.1, 0.2, 0.5, 1.0}'::float4[]";
+
 /// How embeddings are physically stored.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[non_exhaustive]
@@ -715,7 +728,7 @@ impl SearchBackend for PostgresSearchStore {
             let rows = bind_all(
                 diesel::sql_query(format!(
                     "SELECT record_id, \
-                            ts_rank_cd(search_vector, \
+                            ts_rank_cd({TS_RANK_WEIGHTS}, search_vector, \
                                        plainto_tsquery($2::text::regconfig, $3))::double precision \
                               AS score \
                      FROM {DOCUMENTS_TABLE} WHERE {where_clause} \
@@ -1314,6 +1327,44 @@ mod tests {
 
     fn definition() -> IndexDefinition {
         IndexDefinition::new("articles", "english", FIELDS, Some("body"), false)
+    }
+
+    #[test]
+    fn ts_rank_weights_track_the_framework_factors() {
+        // Postgres' own default is `{0.1, 0.2, 0.4, 1.0}`; the framework's
+        // contract normalizes to `{0.1, 0.2, 0.5, 1.0}`. `B` is the one that
+        // differs, which is precisely the weight `#[searchable(weight = "B")]`
+        // gives a body field — so leaving it defaulted makes Postgres rank
+        // differently from `MemorySearchBackend` on the most common model
+        // shape there is.
+        use autumn_web::search::weight_factor;
+
+        // Compared numerically, not as text: a string comparison would depend
+        // on float formatting (`1.0` renders as `1`) and a fixed-precision
+        // format would hide a genuine drift in a small ratio.
+        let declared = parse_vector(
+            TS_RANK_WEIGHTS
+                .trim_end_matches("::float4[]")
+                .trim_matches('\''),
+        );
+        let top = weight_factor('A');
+        let expected: Vec<f32> = ['D', 'C', 'B', 'A']
+            .into_iter()
+            .map(|weight| weight_factor(weight) / top)
+            .collect();
+        assert_eq!(
+            declared.len(),
+            expected.len(),
+            "ts_rank_cd takes exactly {{D, C, B, A}}: {TS_RANK_WEIGHTS}"
+        );
+        for (index, (got, want)) in declared.iter().zip(&expected).enumerate() {
+            assert!(
+                (got - want).abs() < 1e-6,
+                "weight {} is {got}, expected {want} — the SQL array must stay in step with \
+                 `weight_factor`",
+                ['D', 'C', 'B', 'A'][index]
+            );
+        }
     }
 
     #[test]

--- a/autumn-search/src/postgres.rs
+++ b/autumn-search/src/postgres.rs
@@ -399,28 +399,9 @@ impl PostgresSearchStore {
             .map_err(SearchError::backend)?;
         }
 
-        // An UNCONDITIONAL write is the record coming back: a reindex read the
-        // row and found it present, which supersedes any earlier delete. Clear
-        // the ledger so a later backfill is not blocked by a tombstone for a
-        // record that exists again.
-        //
-        // Deliberately not done for a watermarked (backfill) write: that batch
-        // is older than the ledger entry by construction, so it has nothing to
-        // say about whether the delete still stands.
-        if watermark.is_none() {
-            let ids: Vec<i64> = documents.iter().map(IndexedDocument::id).collect();
-            bind_all(
-                diesel::sql_query(format!(
-                    "DELETE FROM {DELETES_TABLE} \
-                     WHERE index_name = $1 AND record_id = ANY($2)"
-                ))
-                .into_boxed::<autumn_web::RuntimeBackend>(),
-                [Bound::Text(definition.name.to_owned()), Bound::Ids(ids)],
-            )
-            .execute(&mut conn)
-            .await
-            .map_err(SearchError::backend)?;
-        }
+        // The ledger clear is NOT a trailing statement: `upsert_sql` folds it
+        // into each document's own statement, so the write and the tombstone
+        // removal cannot be split by a concurrent delete.
         Ok(())
     }
 
@@ -648,7 +629,7 @@ fn upsert_sql(
             )
         },
     );
-    format!(
+    let upsert = format!(
         "INSERT INTO {DOCUMENTS_TABLE} \
            (index_name, record_id, tenant_id, language, fields, content, \
             search_vector, embedding{vec_column}) \
@@ -661,6 +642,33 @@ fn upsert_sql(
            search_vector = EXCLUDED.search_vector, \
            embedding = EXCLUDED.embedding{vec_update}, \
            updated_at = NOW(){guard}"
+    );
+
+    if watermark_param.is_some() {
+        // A watermarked (backfill) write leaves the ledger alone: its batch is
+        // older than any tombstone by construction, so it has nothing to say
+        // about whether the delete still stands.
+        return upsert;
+    }
+
+    // An UNCONDITIONAL write is the record coming back — a reindex read the row
+    // and found it present, which supersedes any earlier delete — so the
+    // tombstone is cleared or a later backfill would skip a record that exists.
+    //
+    // In the SAME statement, for the reason the round before learned the hard
+    // way. As two statements a delete can interleave between them: the upsert
+    // commits, the delete commits (document removed, tombstone written), and
+    // then the trailing clear erases that NEWER tombstone while the document
+    // stays absent — leaving a backfill able to see neither and resurrect the
+    // record. One statement means the two possible serializations are
+    // "upsert+clear, then delete" (document absent, tombstone present) and
+    // "delete, then upsert+clear" (document present, no tombstone). Both are
+    // consistent; the interleaving that is not, cannot happen.
+    format!(
+        "WITH upserted AS ( \
+           {upsert} \
+         ) \
+         DELETE FROM {DELETES_TABLE} WHERE index_name = $1 AND record_id = $2"
     )
 }
 
@@ -1564,6 +1572,38 @@ mod tests {
 
     fn definition() -> IndexDefinition {
         IndexDefinition::new("articles", "english", FIELDS, Some("body"), false)
+    }
+
+    #[test]
+    fn an_unconditional_upsert_clears_the_tombstone_in_the_same_statement() {
+        // Two statements let a delete interleave: the upsert commits, the
+        // delete commits (document removed, tombstone written), and the
+        // trailing clear then erases that NEWER tombstone while the document
+        // stays absent — leaving a backfill able to see neither and resurrect
+        // the record. One statement admits only the two consistent
+        // serializations.
+        let sql = upsert_sql("to_tsvector('simple', '')", "", "", "", None);
+        assert!(
+            sql.starts_with("WITH upserted AS ("),
+            "the upsert and the tombstone clear must be one statement: {sql}"
+        );
+        assert!(
+            sql.contains(&format!("DELETE FROM {DELETES_TABLE}")),
+            "{sql}"
+        );
+
+        // A watermarked (backfill) write leaves the ledger alone — its batch is
+        // older than any tombstone by construction. Clearing it there would
+        // undo the very delete the guard is protecting.
+        let guarded = upsert_sql("to_tsvector('simple', '')", "", "", "", Some(9));
+        assert!(
+            !guarded.contains(&format!("DELETE FROM {DELETES_TABLE}")),
+            "a backfill write must never clear a tombstone: {guarded}"
+        );
+        assert!(
+            guarded.contains(&format!("SELECT 1 FROM {DELETES_TABLE}")),
+            "but it must still be blocked by one: {guarded}"
+        );
     }
 
     #[test]

--- a/autumn-search/src/postgres.rs
+++ b/autumn-search/src/postgres.rs
@@ -130,6 +130,12 @@ struct SourceRow {
 }
 
 #[derive(diesel::QueryableByName)]
+struct WatermarkRow {
+    #[diesel(sql_type = Text)]
+    watermark: String,
+}
+
+#[derive(diesel::QueryableByName)]
 struct WidthRow {
     #[diesel(sql_type = BigInt)]
     width: i64,
@@ -247,6 +253,170 @@ impl PostgresSearchStore {
             .read()
             .ok()
             .and_then(|guard| *guard)
+    }
+
+    /// Upsert `documents`, optionally refusing to clobber rows written since
+    /// `watermark`. The single write path behind both
+    /// [`SearchBackend::index`] and [`SearchBackend::index_unless_newer`], so
+    /// the conditional and unconditional forms cannot drift apart.
+    async fn write_documents(
+        &self,
+        definition: &IndexDefinition,
+        documents: &[IndexedDocument],
+        watermark: Option<&str>,
+    ) -> SearchResult<()> {
+        use std::fmt::Write as _;
+
+        checked(definition)?;
+        if documents.is_empty() {
+            return Ok(());
+        }
+        let mut conn = self.conn().await?;
+        // Keyed on the PHYSICAL column, not on this process's mode. The
+        // column can outlive the mode that created it (dimensions unset, a
+        // width mismatch, a mixed fleet), and skipping it then leaves a
+        // stale `embedding_vec` behind after every upsert — which a
+        // pgvector-mode reader silently ranks on. `None` width means the
+        // column is absent and must stay out of the column list entirely.
+        let vector_width = self.vector_column_width();
+
+        for document in documents {
+            // The weighted tsvector, built exactly as #842 does:
+            // `setweight(to_tsvector(<lang>, <value>), <weight>)` per
+            // field, concatenated.
+            //
+            // The weight letter is interpolated, so it comes from the
+            // VALIDATED definition rather than from the document: a
+            // hand-built document (or a third-party `DocumentSource`) can
+            // carry any `char`. A field the index does not declare is
+            // skipped entirely.
+            //
+            // Bound: $1 index_name, $2 record_id, $3 tenant_id, $4 fields
+            // json, $5 language, $6 content, $7 embedding, ($8 vector),
+            // then one per field value.
+            let mut binds = vec![
+                Bound::Text(definition.name.to_owned()),
+                Bound::BigInt(document.id()),
+                Bound::NullableText(document.document.tenant_id.clone()),
+                Bound::Text(fields_json(document)?),
+                Bound::Text(definition.language.to_owned()),
+                Bound::Text(document.document.text()),
+                Bound::NullableText(document.embedding.as_deref().map(array_literal)),
+            ];
+            if let Some(width) = vector_width {
+                let literal = match document.embedding.as_deref() {
+                    // A width the column cannot hold would fail the insert,
+                    // and leaving the old value in place is exactly the
+                    // staleness this avoids — so it never reaches SQL.
+                    //
+                    // Whether that is an ERROR depends on which column this
+                    // process is actually reading. In pgvector mode k-NN
+                    // runs off `embedding_vec`, so writing NULL would leave
+                    // the row permanently invisible to semantic search
+                    // while every write reported success — a silent hole,
+                    // and the worst outcome available. Say so instead.
+                    Some(embedding) if embedding.len() != width => {
+                        if self.vector_mode().is_some_and(VectorMode::is_pgvector) {
+                            return Err(SearchError::DimensionMismatch {
+                                expected: width,
+                                actual: embedding.len(),
+                            });
+                        }
+                        // Not in pgvector mode: `embedding_vec` is a
+                        // leftover column from a previous width, k-NN runs
+                        // off the portable `embedding` array (bound above,
+                        // at full width), and NULLing the stale copy is the
+                        // correct repair rather than a loss.
+                        None
+                    }
+                    other => other.map(vector_literal),
+                };
+                binds.push(Bound::NullableText(literal));
+            }
+
+            let mut vector_sql = String::new();
+            let mut param = binds.len() + 1;
+            for field in &document.document.fields {
+                let Some(weight) = definition.weight_of(field.name) else {
+                    continue;
+                };
+                if !vector_sql.is_empty() {
+                    vector_sql.push_str(" || ");
+                }
+                // `$5::text::regconfig`, not `$5::regconfig`: the same
+                // parameter is also the `language` column value, and the
+                // untyped form is "inconsistent types deduced for
+                // parameter" under any client that does not declare bind
+                // types.
+                let _ = write!(
+                    vector_sql,
+                    "setweight(to_tsvector($5::text::regconfig, ${param}), '{weight}')"
+                );
+                binds.push(Bound::Text(field.value.clone()));
+                param += 1;
+            }
+            if vector_sql.is_empty() {
+                "to_tsvector($5::text::regconfig, '')".clone_into(&mut vector_sql);
+            }
+
+            let (vec_column, vec_value, vec_update) = if vector_width.is_some() {
+                (
+                    ", embedding_vec",
+                    ", $8::vector",
+                    ", embedding_vec = EXCLUDED.embedding_vec",
+                )
+            } else {
+                ("", "", "")
+            };
+
+            // The watermark guard. Without it a backfill batch — read
+            // minutes ago, then delayed by an embedding round-trip —
+            // overwrites whatever a per-record reindex wrote in the
+            // meantime, and nothing re-runs that reindex. `updated_at` is
+            // server-side `NOW()` and the watermark came from the same
+            // clock, so the comparison is skew-free.
+            //
+            // Only the UPDATE arm is guarded: a row that does not exist
+            // yet cannot have a newer version to protect, and skipping the
+            // insert would leave it unindexed.
+            let guard = if watermark.is_some() {
+                param += 1;
+                format!(
+                    " WHERE {DOCUMENTS_TABLE}.updated_at <= ${}::timestamptz",
+                    param - 1
+                )
+            } else {
+                String::new()
+            };
+            if let Some(watermark) = watermark {
+                binds.push(Bound::Text(watermark.to_owned()));
+            }
+
+            let sql = format!(
+                "INSERT INTO {DOCUMENTS_TABLE} \
+                       (index_name, record_id, tenant_id, language, fields, content, \
+                        search_vector, embedding{vec_column}) \
+                     VALUES ($1, $2, $3, $5, $4::jsonb, $6, {vector_sql}, \
+                             $7::double precision[]{vec_value}) \
+                     ON CONFLICT (index_name, record_id) DO UPDATE SET \
+                       tenant_id = EXCLUDED.tenant_id, \
+                       language = EXCLUDED.language, \
+                       fields = EXCLUDED.fields, \
+                       content = EXCLUDED.content, \
+                       search_vector = EXCLUDED.search_vector, \
+                       embedding = EXCLUDED.embedding{vec_update}, \
+                       updated_at = NOW(){guard}"
+            );
+
+            bind_all(
+                diesel::sql_query(sql).into_boxed::<autumn_web::RuntimeBackend>(),
+                binds,
+            )
+            .execute(&mut conn)
+            .await
+            .map_err(SearchError::backend)?;
+        }
+        Ok(())
     }
 
     fn pool(&self) -> SearchResult<&RuntimePool> {
@@ -472,6 +642,32 @@ impl SearchBackend for PostgresSearchStore {
             .with_vector(true)
             .with_weighted_fields(true)
             .with_embedding_readback(true)
+            .with_conditional_index(true)
+    }
+
+    fn write_watermark(&self) -> BoxFuture<'_, SearchResult<Option<String>>> {
+        Box::pin(async move {
+            // The DATABASE's clock, not the process's. `updated_at` is set by
+            // `NOW()` server-side, so comparing it against an app-side
+            // timestamp would be at the mercy of clock skew between however
+            // many app instances and the database — and the whole point of the
+            // watermark is deciding which of two writes is newer.
+            let mut conn = self.conn().await?;
+            let row = diesel::sql_query("SELECT NOW()::text AS watermark")
+                .get_result::<WatermarkRow>(&mut conn)
+                .await
+                .map_err(SearchError::backend)?;
+            Ok(Some(row.watermark))
+        })
+    }
+
+    fn index_unless_newer<'a>(
+        &'a self,
+        definition: &'a IndexDefinition,
+        documents: &'a [IndexedDocument],
+        watermark: Option<&'a str>,
+    ) -> BoxFuture<'a, SearchResult<()>> {
+        Box::pin(async move { self.write_documents(definition, documents, watermark).await })
     }
 
     fn ensure_index<'a>(
@@ -531,137 +727,7 @@ impl SearchBackend for PostgresSearchStore {
         definition: &'a IndexDefinition,
         documents: &'a [IndexedDocument],
     ) -> BoxFuture<'a, SearchResult<()>> {
-        use std::fmt::Write as _;
-
-        Box::pin(async move {
-            checked(definition)?;
-            if documents.is_empty() {
-                return Ok(());
-            }
-            let mut conn = self.conn().await?;
-            // Keyed on the PHYSICAL column, not on this process's mode. The
-            // column can outlive the mode that created it (dimensions unset, a
-            // width mismatch, a mixed fleet), and skipping it then leaves a
-            // stale `embedding_vec` behind after every upsert — which a
-            // pgvector-mode reader silently ranks on. `None` width means the
-            // column is absent and must stay out of the column list entirely.
-            let vector_width = self.vector_column_width();
-
-            for document in documents {
-                // The weighted tsvector, built exactly as #842 does:
-                // `setweight(to_tsvector(<lang>, <value>), <weight>)` per
-                // field, concatenated.
-                //
-                // The weight letter is interpolated, so it comes from the
-                // VALIDATED definition rather than from the document: a
-                // hand-built document (or a third-party `DocumentSource`) can
-                // carry any `char`. A field the index does not declare is
-                // skipped entirely.
-                //
-                // Bound: $1 index_name, $2 record_id, $3 tenant_id, $4 fields
-                // json, $5 language, $6 content, $7 embedding, ($8 vector),
-                // then one per field value.
-                let mut binds = vec![
-                    Bound::Text(definition.name.to_owned()),
-                    Bound::BigInt(document.id()),
-                    Bound::NullableText(document.document.tenant_id.clone()),
-                    Bound::Text(fields_json(document)?),
-                    Bound::Text(definition.language.to_owned()),
-                    Bound::Text(document.document.text()),
-                    Bound::NullableText(document.embedding.as_deref().map(array_literal)),
-                ];
-                if let Some(width) = vector_width {
-                    let literal = match document.embedding.as_deref() {
-                        // A width the column cannot hold would fail the insert,
-                        // and leaving the old value in place is exactly the
-                        // staleness this avoids — so it never reaches SQL.
-                        //
-                        // Whether that is an ERROR depends on which column this
-                        // process is actually reading. In pgvector mode k-NN
-                        // runs off `embedding_vec`, so writing NULL would leave
-                        // the row permanently invisible to semantic search
-                        // while every write reported success — a silent hole,
-                        // and the worst outcome available. Say so instead.
-                        Some(embedding) if embedding.len() != width => {
-                            if self.vector_mode().is_some_and(VectorMode::is_pgvector) {
-                                return Err(SearchError::DimensionMismatch {
-                                    expected: width,
-                                    actual: embedding.len(),
-                                });
-                            }
-                            // Not in pgvector mode: `embedding_vec` is a
-                            // leftover column from a previous width, k-NN runs
-                            // off the portable `embedding` array (bound above,
-                            // at full width), and NULLing the stale copy is the
-                            // correct repair rather than a loss.
-                            None
-                        }
-                        other => other.map(vector_literal),
-                    };
-                    binds.push(Bound::NullableText(literal));
-                }
-
-                let mut vector_sql = String::new();
-                let mut param = binds.len() + 1;
-                for field in &document.document.fields {
-                    let Some(weight) = definition.weight_of(field.name) else {
-                        continue;
-                    };
-                    if !vector_sql.is_empty() {
-                        vector_sql.push_str(" || ");
-                    }
-                    // `$5::text::regconfig`, not `$5::regconfig`: the same
-                    // parameter is also the `language` column value, and the
-                    // untyped form is "inconsistent types deduced for
-                    // parameter" under any client that does not declare bind
-                    // types.
-                    let _ = write!(
-                        vector_sql,
-                        "setweight(to_tsvector($5::text::regconfig, ${param}), '{weight}')"
-                    );
-                    binds.push(Bound::Text(field.value.clone()));
-                    param += 1;
-                }
-                if vector_sql.is_empty() {
-                    "to_tsvector($5::text::regconfig, '')".clone_into(&mut vector_sql);
-                }
-
-                let (vec_column, vec_value, vec_update) = if vector_width.is_some() {
-                    (
-                        ", embedding_vec",
-                        ", $8::vector",
-                        ", embedding_vec = EXCLUDED.embedding_vec",
-                    )
-                } else {
-                    ("", "", "")
-                };
-
-                let sql = format!(
-                    "INSERT INTO {DOCUMENTS_TABLE} \
-                       (index_name, record_id, tenant_id, language, fields, content, \
-                        search_vector, embedding{vec_column}) \
-                     VALUES ($1, $2, $3, $5, $4::jsonb, $6, {vector_sql}, \
-                             $7::double precision[]{vec_value}) \
-                     ON CONFLICT (index_name, record_id) DO UPDATE SET \
-                       tenant_id = EXCLUDED.tenant_id, \
-                       language = EXCLUDED.language, \
-                       fields = EXCLUDED.fields, \
-                       content = EXCLUDED.content, \
-                       search_vector = EXCLUDED.search_vector, \
-                       embedding = EXCLUDED.embedding{vec_update}, \
-                       updated_at = NOW()"
-                );
-
-                bind_all(
-                    diesel::sql_query(sql).into_boxed::<autumn_web::RuntimeBackend>(),
-                    binds,
-                )
-                .execute(&mut conn)
-                .await
-                .map_err(SearchError::backend)?;
-            }
-            Ok(())
-        })
+        Box::pin(async move { self.write_documents(definition, documents, None).await })
     }
 
     fn delete<'a>(

--- a/autumn-search/src/postgres.rs
+++ b/autumn-search/src/postgres.rs
@@ -580,6 +580,28 @@ fn score_threshold_sql(score_expr: &str, min_score: Option<f32>, next_param: &mu
     sql
 }
 
+/// The pgvector `ORDER BY`, which decides whether the ivfflat index may serve
+/// the query — and for a **filtered** query it must not.
+///
+/// ivfflat picks its candidate lists by distance BEFORE the `WHERE` clause
+/// runs, so a selective tenant or visibility predicate can leave the probed
+/// lists holding few or none of the rows the caller is allowed to see. The
+/// query then returns short, or empty, while qualifying neighbours sit in
+/// unprobed lists. That is a wrong answer to an authorization-scoped query
+/// rather than an approximate one, and it would diverge from the array
+/// backend, which the two suites assert implements the same contract.
+///
+/// Ordering by the derived similarity is opaque to the planner, so it forces
+/// an exact scan: slower, and right. An unfiltered query keeps the
+/// index-friendly `<=>` form, which is where the fast path actually pays.
+fn pgvector_order_by(filtered: bool) -> String {
+    if filtered {
+        "ORDER BY (1 - (embedding_vec <=> $2::vector)) DESC, record_id ASC".to_owned()
+    } else {
+        "ORDER BY (embedding_vec <=> $2::vector) ASC, record_id ASC".to_owned()
+    }
+}
+
 /// The document upsert, optionally guarded by a watermark in parameter slot
 /// `watermark_param`.
 ///
@@ -1003,7 +1025,9 @@ impl SearchBackend for PostgresSearchStore {
             let predicate = filter_sql(definition, &query.filter, &mut param, &mut binds);
 
             let pgvector = self.vector_mode().is_some_and(VectorMode::is_pgvector);
-            let width = query.vector.len();
+            // A filter here is an AUTHORIZATION boundary as often as not — a
+            // tenant, a visibility allowlist, a `similar_to` self-exclusion.
+            let filtered = query.filter != SearchFilter::default();
             // Both modes score cosine SIMILARITY so the two orderings agree
             // (pgvector's `<=>` is cosine distance, hence `1 - d`).
             //
@@ -1018,7 +1042,24 @@ impl SearchBackend for PostgresSearchStore {
                     vector_literal(&query.vector),
                     "(embedding_vec <=> $2::vector)".to_owned(),
                     "(1 - (embedding_vec <=> $2::vector))::double precision".to_owned(),
-                    "ORDER BY (embedding_vec <=> $2::vector) ASC, record_id ASC".to_owned(),
+                    // The ordering decides whether the ivfflat index can serve
+                    // this query, and for a FILTERED query it must not.
+                    //
+                    // ivfflat picks its candidate lists by distance BEFORE the
+                    // `WHERE` clause runs, so a selective tenant or visibility
+                    // predicate can leave the probed lists holding few or none
+                    // of the rows the caller is allowed to see — returning
+                    // short, or empty, while qualifying neighbours sit in
+                    // unprobed lists. That is a wrong answer to an
+                    // authorization-scoped query, not merely an approximate
+                    // one, and it would differ from the array backend, which
+                    // the two suites assert implements the same contract.
+                    //
+                    // Ordering by the derived similarity is opaque to the
+                    // planner, so it forces an exact scan: slower, and right.
+                    // An unfiltered query keeps the index-friendly form, which
+                    // is where the fast path actually pays.
+                    pgvector_order_by(filtered),
                     "embedding_vec IS NOT NULL".to_owned(),
                 )
             } else {
@@ -1032,7 +1073,23 @@ impl SearchBackend for PostgresSearchStore {
                     // silently mis-scores, so a width mismatch is excluded
                     // rather than ranked. (pgvector's `<=>` errors instead —
                     // documented divergence.)
-                    format!("embedding IS NOT NULL AND array_length(embedding, 1) = {width}"),
+                    //
+                    // The width is BOUND, not interpolated. It is the length of
+                    // a caller-supplied vector, so formatting it mints a
+                    // permanent prepared statement per distinct length in a
+                    // cache that never evicts — the same unbounded growth the
+                    // ids, limits, offsets and score threshold are all bound to
+                    // avoid. `array_length` returns `integer`, hence the cast.
+                    {
+                        let slot = param;
+                        param += 1;
+                        binds.push(Bound::BigInt(
+                            i64::try_from(query.vector.len()).unwrap_or(i64::MAX),
+                        ));
+                        format!(
+                            "embedding IS NOT NULL AND array_length(embedding, 1) = ${slot}::integer"
+                        )
+                    },
                 )
             };
             let _ = distance;
@@ -1572,6 +1629,27 @@ mod tests {
 
     fn definition() -> IndexDefinition {
         IndexDefinition::new("articles", "english", FIELDS, Some("body"), false)
+    }
+
+    #[test]
+    fn a_filtered_vector_query_does_not_let_ivfflat_decide_what_is_visible() {
+        // Unfiltered: order by DISTANCE so ivfflat can serve it. That form is
+        // the whole reason the fast path is worth having.
+        let open = pgvector_order_by(false);
+        assert!(open.contains("<=>"), "{open}");
+        assert!(open.contains("ASC, record_id ASC"), "{open}");
+
+        // Filtered: order by the DERIVED similarity, which the planner cannot
+        // serve from ivfflat, so the scan is exact. ivfflat probes lists
+        // before the WHERE clause runs, so a selective authorization filter
+        // can otherwise return short or empty while authorized neighbours sit
+        // in unprobed lists.
+        let scoped = pgvector_order_by(true);
+        assert!(
+            scoped.starts_with("ORDER BY (1 - "),
+            "a filtered query must not be served by the approximate index: {scoped}"
+        );
+        assert_ne!(open, scoped);
     }
 
     #[test]

--- a/autumn-search/src/postgres.rs
+++ b/autumn-search/src/postgres.rs
@@ -400,6 +400,40 @@ fn filter_sql(
     sql
 }
 
+/// The ` AND <score> >= $n` fragment for a minimum-score bound, advancing
+/// `next_param` when one is emitted.
+///
+/// The threshold is **bound, never interpolated**. `min_score` can come
+/// straight off a request, and diesel's prepared-statement cache is keyed on
+/// SQL text and never evicts — so a formatted value mints a permanent
+/// statement per distinct threshold, and a caller sweeping values grows the
+/// cache without bound until the server dies. That is the same failure the
+/// LIMIT/OFFSET binds exist to prevent, and the same one that made
+/// interpolated ids an OOM on every backfill.
+///
+/// Emitted only when a bound was asked for, because it repeats the
+/// (non-trivial) score expression. A non-finite bound is dropped rather than
+/// bound: "no threshold" is the safe reading of "not a number", and `>= NaN`
+/// would silently match nothing.
+fn score_threshold_sql(score_expr: &str, min_score: Option<f32>, next_param: &mut usize) -> String {
+    if !min_score.is_some_and(f32::is_finite) {
+        return String::new();
+    }
+    let sql = format!(" AND {score_expr} >= ${next_param}::double precision");
+    *next_param += 1;
+    sql
+}
+
+/// The bound value for [`score_threshold_sql`], if it emitted a fragment.
+///
+/// Kept next to it so the two cannot disagree about whether a parameter was
+/// consumed — a mismatch would shift every later parameter by one.
+fn score_threshold_bind(min_score: Option<f32>) -> Option<Bound> {
+    min_score
+        .filter(|min| min.is_finite())
+        .map(|min| Bound::Double(f64::from(min)))
+}
+
 /// One bound parameter.
 ///
 /// Exists so a query can be assembled as `(sql, Vec<Bound>)` and bound in one
@@ -410,6 +444,7 @@ enum Bound {
     Text(String),
     NullableText(Option<String>),
     BigInt(i64),
+    Double(f64),
     Ids(Vec<i64>),
 }
 
@@ -420,6 +455,7 @@ fn bind_all(mut query: BoxedQuery<'_>, binds: impl IntoIterator<Item = Bound>) -
             Bound::Text(value) => query.bind::<Text, _>(value),
             Bound::NullableText(value) => query.bind::<Nullable<Text>, _>(value),
             Bound::BigInt(value) => query.bind::<BigInt, _>(value),
+            Bound::Double(value) => query.bind::<Double, _>(value),
             Bound::Ids(values) => query.bind::<Array<BigInt>, _>(values),
         };
     }
@@ -813,15 +849,7 @@ impl SearchBackend for PostgresSearchStore {
             };
             let _ = distance;
 
-            // Only emit the threshold when one was asked for: it repeats the
-            // (non-trivial) score expression. A non-finite bound would render
-            // as a bare `NaN`/`inf` identifier and turn the query into a
-            // syntax error, so drop it — no threshold is the safe reading of
-            // "not a number".
-            let threshold = query
-                .min_score
-                .filter(|min| min.is_finite())
-                .map_or_else(String::new, |min| format!(" AND {score_expr} >= {min:?}"));
+            let threshold = score_threshold_sql(&score_expr, query.min_score, &mut param);
 
             let limit_param = param;
             let limit = i64::try_from(query.limit).unwrap_or(i64::MAX);
@@ -838,6 +866,10 @@ impl SearchBackend for PostgresSearchStore {
                 ]
                 .into_iter()
                 .chain(binds)
+                // The threshold parameter, when one was emitted, sits between
+                // the filter binds and the limit — matching the order `param`
+                // handed the numbers out above.
+                .chain(score_threshold_bind(query.min_score))
                 .chain([Bound::BigInt(limit)]),
             )
             .load::<HitRow>(&mut conn)
@@ -1177,10 +1209,20 @@ impl PostgresSearchStore {
                 binds.push(Bound::BigInt(i64::try_from(limit).unwrap_or(i64::MAX)));
             }
         }
-        if columns.deleted_at {
-            // A soft-deleted row must not be re-indexed: `after_delete_commit`
-            // removes its document, and a later backfill would otherwise put
-            // it straight back — searchable while `find` hides it.
+        // BOTH conditions: the column has to exist, and the model's repository
+        // has to actually be `soft_delete`.
+        //
+        // Column presence alone is not the question. A `deleted_at` that is
+        // audit history — a supported shape, whose finders return those rows —
+        // would otherwise be read as a tombstone here: reindex would see the
+        // row as absent and delete its document, and a purging backfill would
+        // drop it entirely. The index would hide records the app still shows.
+        //
+        // When the repository IS `soft_delete`, the filter is required for the
+        // mirror-image reason: `after_delete_commit` removes the document, and
+        // a later backfill would put it straight back — searchable while
+        // `find` hides it.
+        if columns.deleted_at && definition.soft_delete {
             predicates.push("deleted_at IS NULL".to_owned());
         }
         let where_clause = if predicates.is_empty() {
@@ -1327,6 +1369,54 @@ mod tests {
 
     fn definition() -> IndexDefinition {
         IndexDefinition::new("articles", "english", FIELDS, Some("body"), false)
+    }
+
+    #[test]
+    fn a_min_score_is_bound_so_the_statement_cache_stays_bounded() {
+        // The property that matters is not "the value is correct" but "the SQL
+        // TEXT does not vary with the value" — diesel's statement cache is
+        // keyed on that text and never evicts, so a request-controlled
+        // threshold would otherwise leak one permanent prepared statement per
+        // distinct value.
+        let expr = "(1 - (embedding_vec <=> $2::vector))::double precision";
+        let mut a = 5;
+        let mut b = 5;
+        let first = score_threshold_sql(expr, Some(0.25), &mut a);
+        let second = score_threshold_sql(expr, Some(0.999_999), &mut b);
+        assert_eq!(
+            first, second,
+            "two thresholds must produce ONE statement, not two"
+        );
+        assert_eq!(a, b, "and consume the same parameter slot");
+        assert!(first.contains("$5"), "{first}");
+        assert!(
+            !first.contains("0.25"),
+            "the value must not reach the SQL text: {first}"
+        );
+
+        // No bound: no fragment, no parameter consumed.
+        let mut param = 5;
+        assert!(score_threshold_sql(expr, None, &mut param).is_empty());
+        assert_eq!(param, 5);
+
+        // Non-finite: dropped rather than bound. `>= NaN` matches nothing.
+        let mut param = 5;
+        assert!(score_threshold_sql(expr, Some(f32::NAN), &mut param).is_empty());
+        assert!(score_threshold_sql(expr, Some(f32::INFINITY), &mut param).is_empty());
+        assert_eq!(param, 5);
+
+        // The fragment and its bind must agree on whether a slot was used —
+        // a disagreement would shift every later parameter by one.
+        for candidate in [None, Some(0.5), Some(f32::NAN), Some(f32::INFINITY)] {
+            let mut param = 5;
+            let emitted = !score_threshold_sql(expr, candidate, &mut param).is_empty();
+            assert_eq!(
+                emitted,
+                score_threshold_bind(candidate).is_some(),
+                "fragment/bind disagreement for {candidate:?}"
+            );
+            assert_eq!(param, if emitted { 6 } else { 5 });
+        }
     }
 
     #[test]

--- a/autumn-search/src/postgres.rs
+++ b/autumn-search/src/postgres.rs
@@ -61,6 +61,16 @@ type BoxedQuery<'a> = diesel::query_builder::BoxedSqlQuery<
 /// Physical table every index's documents live in.
 pub const DOCUMENTS_TABLE: &str = "autumn_search_documents";
 
+/// Ledger of deleted records, consulted by a watermarked (backfill) insert.
+pub const DELETES_TABLE: &str = "autumn_search_deletes";
+
+/// How long a delete stays in [`DELETES_TABLE`].
+///
+/// It only has to outlive the longest backfill that could still be holding a
+/// stale batch. Seven days is far beyond that and keeps the table small on a
+/// delete-heavy index; pruning runs once per process, at `ensure_index`.
+const DELETE_RETENTION: &str = "7 days";
+
 /// `ts_rank_cd`'s `{D, C, B, A}` weight array, matching
 /// [`weight_factor`](autumn_web::search::weight_factor).
 ///
@@ -369,48 +379,43 @@ impl PostgresSearchStore {
                 ("", "", "")
             };
 
-            // The watermark guard. Without it a backfill batch — read
-            // minutes ago, then delayed by an embedding round-trip —
-            // overwrites whatever a per-record reindex wrote in the
-            // meantime, and nothing re-runs that reindex. `updated_at` is
-            // server-side `NOW()` and the watermark came from the same
-            // clock, so the comparison is skew-free.
-            //
-            // Only the UPDATE arm is guarded: a row that does not exist
-            // yet cannot have a newer version to protect, and skipping the
-            // insert would leave it unindexed.
-            let guard = if watermark.is_some() {
-                param += 1;
-                format!(
-                    " WHERE {DOCUMENTS_TABLE}.updated_at <= ${}::timestamptz",
-                    param - 1
-                )
-            } else {
-                String::new()
-            };
+            let sql = upsert_sql(
+                &vector_sql,
+                vec_column,
+                vec_value,
+                vec_update,
+                watermark.map(|_| param),
+            );
             if let Some(watermark) = watermark {
                 binds.push(Bound::Text(watermark.to_owned()));
             }
 
-            let sql = format!(
-                "INSERT INTO {DOCUMENTS_TABLE} \
-                       (index_name, record_id, tenant_id, language, fields, content, \
-                        search_vector, embedding{vec_column}) \
-                     VALUES ($1, $2, $3, $5, $4::jsonb, $6, {vector_sql}, \
-                             $7::double precision[]{vec_value}) \
-                     ON CONFLICT (index_name, record_id) DO UPDATE SET \
-                       tenant_id = EXCLUDED.tenant_id, \
-                       language = EXCLUDED.language, \
-                       fields = EXCLUDED.fields, \
-                       content = EXCLUDED.content, \
-                       search_vector = EXCLUDED.search_vector, \
-                       embedding = EXCLUDED.embedding{vec_update}, \
-                       updated_at = NOW(){guard}"
-            );
-
             bind_all(
                 diesel::sql_query(sql).into_boxed::<autumn_web::RuntimeBackend>(),
                 binds,
+            )
+            .execute(&mut conn)
+            .await
+            .map_err(SearchError::backend)?;
+        }
+
+        // An UNCONDITIONAL write is the record coming back: a reindex read the
+        // row and found it present, which supersedes any earlier delete. Clear
+        // the ledger so a later backfill is not blocked by a tombstone for a
+        // record that exists again.
+        //
+        // Deliberately not done for a watermarked (backfill) write: that batch
+        // is older than the ledger entry by construction, so it has nothing to
+        // say about whether the delete still stands.
+        if watermark.is_none() {
+            let ids: Vec<i64> = documents.iter().map(IndexedDocument::id).collect();
+            bind_all(
+                diesel::sql_query(format!(
+                    "DELETE FROM {DELETES_TABLE} \
+                     WHERE index_name = $1 AND record_id = ANY($2)"
+                ))
+                .into_boxed::<autumn_web::RuntimeBackend>(),
+                [Bound::Text(definition.name.to_owned()), Bound::Ids(ids)],
             )
             .execute(&mut conn)
             .await
@@ -594,6 +599,71 @@ fn score_threshold_sql(score_expr: &str, min_score: Option<f32>, next_param: &mu
     sql
 }
 
+/// The document upsert, optionally guarded by a watermark in parameter slot
+/// `watermark_param`.
+///
+/// The guard goes on **both** arms, and the two failures are different:
+///
+/// - the `DO UPDATE` arm covers a record a concurrent reindex REWROTE — a
+///   stale backfill batch would otherwise put the old text back;
+/// - the insert arm covers one it DELETED. With the row gone there is no
+///   conflict, so an unguarded insert re-creates the record and resurrects
+///   something a user deleted. `autumn_search_deletes` exists precisely
+///   because, once the document is gone, it is the only evidence the insert
+///   path has that anything happened.
+///
+/// `INSERT ... SELECT ... WHERE` rather than `VALUES` when guarding, because
+/// `VALUES` admits no predicate and the delete guard would have nowhere to
+/// attach. `ON CONFLICT` applies to the `SELECT` form just the same.
+///
+/// Both guards reference the SAME parameter slot rather than binding the
+/// watermark twice.
+fn upsert_sql(
+    vector_sql: &str,
+    vec_column: &str,
+    vec_value: &str,
+    vec_update: &str,
+    watermark_param: Option<usize>,
+) -> String {
+    let (guard, values_source) = watermark_param.map_or_else(
+        || {
+            (
+                String::new(),
+                format!(
+                    "VALUES ($1, $2, $3, $5, $4::jsonb, $6, {vector_sql}, \
+                         $7::double precision[]{vec_value})"
+                ),
+            )
+        },
+        |slot| {
+            (
+                format!(" WHERE {DOCUMENTS_TABLE}.updated_at <= ${slot}::timestamptz"),
+                format!(
+                    "SELECT $1, $2, $3, $5, $4::jsonb, $6, {vector_sql}, \
+                            $7::double precision[]{vec_value} \
+                     WHERE NOT EXISTS (SELECT 1 FROM {DELETES_TABLE} d \
+                       WHERE d.index_name = $1 AND d.record_id = $2 \
+                         AND d.deleted_at > ${slot}::timestamptz)"
+                ),
+            )
+        },
+    );
+    format!(
+        "INSERT INTO {DOCUMENTS_TABLE} \
+           (index_name, record_id, tenant_id, language, fields, content, \
+            search_vector, embedding{vec_column}) \
+         {values_source} \
+         ON CONFLICT (index_name, record_id) DO UPDATE SET \
+           tenant_id = EXCLUDED.tenant_id, \
+           language = EXCLUDED.language, \
+           fields = EXCLUDED.fields, \
+           content = EXCLUDED.content, \
+           search_vector = EXCLUDED.search_vector, \
+           embedding = EXCLUDED.embedding{vec_update}, \
+           updated_at = NOW(){guard}"
+    )
+}
+
 /// The bound value for [`score_threshold_sql`], if it emitted a fragment.
 ///
 /// Kept next to it so the two cannot disagree about whether a parameter was
@@ -717,6 +787,19 @@ impl SearchBackend for PostgresSearchStore {
                     vector_column_width = ?width,
                     "autumn-search postgres vector storage resolved"
                 );
+
+                // Prune the delete ledger once per process. An entry only has
+                // to outlive the longest backfill that could still hold a
+                // stale batch; past that it is dead weight on a delete-heavy
+                // index. Best-effort — a failure here must not abort boot.
+                if let Err(error) = diesel::sql_query(format!(
+                    "DELETE FROM {DELETES_TABLE} WHERE deleted_at < NOW() - INTERVAL '{DELETE_RETENTION}'"
+                ))
+                .execute(&mut conn)
+                .await
+                {
+                    tracing::warn!(%error, "autumn-search could not prune the delete ledger");
+                }
             }
             Ok(())
         })
@@ -742,16 +825,35 @@ impl SearchBackend for PostgresSearchStore {
                 return Ok(());
             }
             let mut conn = self.conn().await?;
+            let binds = [
+                Bound::Text(definition.name.to_owned()),
+                Bound::Ids(ids.to_vec()),
+            ];
             bind_all(
                 diesel::sql_query(format!(
                     "DELETE FROM {DOCUMENTS_TABLE} \
                      WHERE index_name = $1 AND record_id = ANY($2)"
                 ))
                 .into_boxed::<autumn_web::RuntimeBackend>(),
-                [
-                    Bound::Text(definition.name.to_owned()),
-                    Bound::Ids(ids.to_vec()),
-                ],
+                binds.clone(),
+            )
+            .execute(&mut conn)
+            .await
+            .map_err(SearchError::backend)?;
+
+            // Record the delete so it OUTLIVES the document. Without this a
+            // backfill batch scanned before the delete finds no row to
+            // conflict with, inserts unconditionally, and resurrects a record
+            // someone deleted. `deleted_at` is refreshed on re-delete so a
+            // replayed delete cannot age out early.
+            bind_all(
+                diesel::sql_query(format!(
+                    "INSERT INTO {DELETES_TABLE} (index_name, record_id) \
+                     SELECT $1, unnest($2::bigint[]) \
+                     ON CONFLICT (index_name, record_id) DO UPDATE SET deleted_at = NOW()"
+                ))
+                .into_boxed::<autumn_web::RuntimeBackend>(),
+                binds,
             )
             .execute(&mut conn)
             .await
@@ -771,6 +873,14 @@ impl SearchBackend for PostgresSearchStore {
             .execute(&mut conn)
             .await
             .map_err(SearchError::backend)?;
+            // The ledger goes with it: a purge is a deliberate reset, and the
+            // backfill that follows is *supposed* to rewrite everything.
+            // Leaving tombstones behind would make it silently skip records.
+            diesel::sql_query(format!("DELETE FROM {DELETES_TABLE} WHERE index_name = $1"))
+                .bind::<Text, _>(definition.name.to_owned())
+                .execute(&mut conn)
+                .await
+                .map_err(SearchError::backend)?;
             Ok(())
         })
     }
@@ -1393,6 +1503,21 @@ fn fields_json(document: &IndexedDocument) -> SearchResult<String> {
 /// not application schema, and every statement is `IF NOT EXISTS`, so running
 /// it on each boot is both safe and self-repairing.
 const SCHEMA_STATEMENTS: &[&str] = &[
+    // Durable evidence that a record was deleted, and WHEN.
+    //
+    // A hard delete leaves no trace, so a backfill batch scanned before the
+    // delete would insert the record straight back — the `ON CONFLICT` guard
+    // cannot help, because with the row gone there is no conflict to guard.
+    // The ledger is what a conditional insert consults instead. Rows are
+    // pruned once they are older than any backfill could plausibly be.
+    "CREATE TABLE IF NOT EXISTS autumn_search_deletes (
+        index_name TEXT        NOT NULL,
+        record_id  BIGINT      NOT NULL,
+        deleted_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+        PRIMARY KEY (index_name, record_id)
+    )",
+    "CREATE INDEX IF NOT EXISTS autumn_search_deletes_pruning_idx
+        ON autumn_search_deletes (deleted_at)",
     "CREATE TABLE IF NOT EXISTS autumn_search_documents (
         index_name    TEXT        NOT NULL,
         record_id     BIGINT      NOT NULL,

--- a/autumn-search/src/postgres.rs
+++ b/autumn-search/src/postgres.rs
@@ -522,17 +522,34 @@ impl SearchBackend for PostgresSearchStore {
                     Bound::NullableText(document.embedding.as_deref().map(array_literal)),
                 ];
                 if let Some(width) = vector_width {
-                    // Write the real vector when it fits the declared width,
-                    // and NULL when it does not — a width the column cannot
-                    // hold would fail the insert, and leaving the old value in
-                    // place is exactly the staleness this avoids.
-                    binds.push(Bound::NullableText(
-                        document
-                            .embedding
-                            .as_deref()
-                            .filter(|embedding| embedding.len() == width)
-                            .map(vector_literal),
-                    ));
+                    let literal = match document.embedding.as_deref() {
+                        // A width the column cannot hold would fail the insert,
+                        // and leaving the old value in place is exactly the
+                        // staleness this avoids — so it never reaches SQL.
+                        //
+                        // Whether that is an ERROR depends on which column this
+                        // process is actually reading. In pgvector mode k-NN
+                        // runs off `embedding_vec`, so writing NULL would leave
+                        // the row permanently invisible to semantic search
+                        // while every write reported success — a silent hole,
+                        // and the worst outcome available. Say so instead.
+                        Some(embedding) if embedding.len() != width => {
+                            if self.vector_mode().is_some_and(VectorMode::is_pgvector) {
+                                return Err(SearchError::DimensionMismatch {
+                                    expected: width,
+                                    actual: embedding.len(),
+                                });
+                            }
+                            // Not in pgvector mode: `embedding_vec` is a
+                            // leftover column from a previous width, k-NN runs
+                            // off the portable `embedding` array (bound above,
+                            // at full width), and NULLing the stale copy is the
+                            // correct repair rather than a loss.
+                            None
+                        }
+                        other => other.map(vector_literal),
+                    };
+                    binds.push(Bound::NullableText(literal));
                 }
 
                 let mut vector_sql = String::new();
@@ -1111,9 +1128,11 @@ impl PostgresSearchStore {
     /// values are returned as one JSON object rather than N columns, which is
     /// what lets a single `QueryableByName` struct serve every model.
     ///
-    /// **The source table's primary key must be the `id` column** — the same
-    /// assumption the in-core FTS `search()` makes. A `#[searchable]` model
-    /// whose key column is named otherwise needs its own `DocumentSource`.
+    /// The key column comes from [`IndexDefinition::key_column`], which
+    /// `#[model]` fills in from the `#[id]` field — so a model keyed on
+    /// `article_id` backfills as readily as one keyed on `id`. `validate()`
+    /// has already checked it is a bare identifier; it is quoted here anyway,
+    /// so a column named after a reserved word still works.
     async fn load_documents(
         &self,
         definition: &IndexDefinition,
@@ -1123,6 +1142,7 @@ impl PostgresSearchStore {
         // the first deadlocks a small pool.
         let mut conn = self.conn().await?;
         let columns = self.optional_columns(definition, &mut conn).await?;
+        let key = format!("\"{}\"", definition.key_column);
 
         let mut binds: Vec<Bound> = Vec::new();
         let mut param = 1_usize;
@@ -1131,12 +1151,12 @@ impl PostgresSearchStore {
 
         match selection {
             Selection::Ids(ids) => {
-                predicates.push(format!("id = ANY(${param})"));
+                predicates.push(format!("{key} = ANY(${param})"));
                 binds.push(Bound::Ids(ids.to_vec()));
             }
             Selection::After { after, limit } => {
                 if let Some(after) = after {
-                    predicates.push(format!("id > ${param}"));
+                    predicates.push(format!("{key} > ${param}"));
                     binds.push(Bound::BigInt(after));
                     param += 1;
                 }
@@ -1162,13 +1182,13 @@ impl PostgresSearchStore {
             "NULL::text"
         };
 
-        // `id::bigint`: the row is decoded as `BigInt`, so an `integer`/
-        // `serial` key column would be a runtime deserialization error the
-        // compiler cannot see.
+        // `::bigint`: the row is decoded as `BigInt`, so an `integer`/`serial`
+        // key column would be a runtime deserialization error the compiler
+        // cannot see. Aliased to `id` because that is what `SourceRow` names.
         let rows = bind_all(
             diesel::sql_query(format!(
-                "SELECT id::bigint AS id, {} AS fields, {tenant} AS tenant_id \
-                 FROM \"{}\" {where_clause} ORDER BY id ASC{limit_clause}",
+                "SELECT {key}::bigint AS id, {} AS fields, {tenant} AS tenant_id \
+                 FROM \"{}\" {where_clause} ORDER BY {key} ASC{limit_clause}",
                 fields_projection(definition),
                 definition.name,
             ))

--- a/autumn-search/src/postgres.rs
+++ b/autumn-search/src/postgres.rs
@@ -32,11 +32,12 @@
 //! speed — so the plugin is deployable on a managed Postgres without
 //! `pgvector`, and gets the fast path for free where it exists.
 
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{OnceLock, RwLock};
 
 use autumn_web::pagination::Page;
 use autumn_web::search::{IndexDefinition, SearchDocument};
-use diesel::sql_types::{BigInt, Double, Nullable, Text};
+use diesel::sql_types::{Array, BigInt, Double, Nullable, Text};
 use diesel_async::RunQueryDsl;
 use diesel_async::pooled_connection::deadpool::Pool;
 
@@ -50,11 +51,19 @@ use crate::text::query_tokens;
 
 type RuntimePool = Pool<autumn_web::RuntimeConnection>;
 
+/// A `sql_query` with its parameters still to be bound.
+type BoxedQuery<'a> = diesel::query_builder::BoxedSqlQuery<
+    'a,
+    autumn_web::RuntimeBackend,
+    diesel::query_builder::SqlQuery,
+>;
+
 /// Physical table every index's documents live in.
 pub const DOCUMENTS_TABLE: &str = "autumn_search_documents";
 
 /// How embeddings are physically stored.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum VectorMode {
     /// `pgvector` is installed and a dimension is configured: a `vector(N)`
     /// column plus an ivfflat index, queried with `<=>`.
@@ -108,9 +117,27 @@ struct SourceRow {
 }
 
 #[derive(diesel::QueryableByName)]
+struct WidthRow {
+    #[diesel(sql_type = BigInt)]
+    width: i64,
+}
+
+#[derive(diesel::QueryableByName)]
 struct ExistsRow {
     #[diesel(sql_type = diesel::sql_types::Bool)]
     present: bool,
+}
+
+/// Which optional framework columns a model's table carries.
+///
+/// `bool_or` over zero rows is NULL, so both fields are nullable — a table
+/// that does not exist yet reads as "neither column".
+#[derive(diesel::QueryableByName)]
+struct OptionalColumnsRow {
+    #[diesel(sql_type = Nullable<diesel::sql_types::Bool>)]
+    has_tenant: Option<bool>,
+    #[diesel(sql_type = Nullable<diesel::sql_types::Bool>)]
+    has_deleted_at: Option<bool>,
 }
 
 // ── The store ───────────────────────────────────────────────────────────────
@@ -131,6 +158,20 @@ pub struct PostgresSearchStore {
     dimensions: Option<usize>,
     /// Resolved at `ensure_index` time, once per process.
     vector_mode: RwLock<Option<VectorMode>>,
+    /// Whether the shared DDL has already run in this process. The statements
+    /// are identical for every index, so running them per index is N× the work
+    /// and N× the concurrent-boot race window.
+    schema_ready: AtomicBool,
+    /// Cache of the optional framework columns each source table carries, so a
+    /// backfill does not re-probe `pg_attribute` on every batch.
+    optional_columns: RwLock<std::collections::HashMap<&'static str, OptionalColumns>>,
+}
+
+/// Which optional framework columns one source table carries.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct OptionalColumns {
+    tenant_id: bool,
+    deleted_at: bool,
 }
 
 impl std::fmt::Debug for PostgresSearchStore {
@@ -139,18 +180,25 @@ impl std::fmt::Debug for PostgresSearchStore {
             .field("pool_installed", &self.pool.get().is_some())
             .field("dimensions", &self.dimensions)
             .field("vector_mode", &self.vector_mode())
-            .finish()
+            // UFCS: `RunQueryDsl::load` is in scope and shadows `AtomicBool::load`.
+            .field(
+                "schema_ready",
+                &AtomicBool::load(&self.schema_ready, Ordering::SeqCst),
+            )
+            .finish_non_exhaustive()
     }
 }
 
 impl PostgresSearchStore {
     /// Create a store whose pool is installed later.
     #[must_use]
-    pub const fn new(dimensions: Option<usize>) -> Self {
+    pub fn new(dimensions: Option<usize>) -> Self {
         Self {
             pool: OnceLock::new(),
             dimensions,
             vector_mode: RwLock::new(None),
+            schema_ready: AtomicBool::new(false),
+            optional_columns: RwLock::new(std::collections::HashMap::new()),
         }
     }
 
@@ -253,16 +301,29 @@ fn parse_vector(raw: &str) -> Vec<f32> {
 /// SQL fragment restricting a query to `filter`, plus the parameters it needs.
 ///
 /// Only **literal, developer-controlled** values are interpolated: record ids
-/// (`i64`, formatted by Rust) and field names already validated as bare
-/// identifiers. Every caller-supplied *value* is bound, never interpolated.
-fn filter_sql(filter: &SearchFilter, next_param: &mut usize, binds: &mut Vec<String>) -> String {
+/// (`i64`, formatted by Rust) and field names taken from `definition`, which
+/// `IndexDefinition::validate` has already checked are bare identifiers. Every
+/// caller-supplied *value* is bound, never interpolated.
+///
+/// An `equals` key that `definition` does not declare renders as `AND FALSE`
+/// rather than reaching SQL. A key is an identifier position, so an unchecked
+/// one would let request text close the quote and `OR` away every restriction
+/// that preceded it — a full widening past the visibility filter, not merely
+/// an injection. Failing closed also matches [`SearchFilter::permits`], which
+/// returns `false` for a field the document does not carry.
+fn filter_sql(
+    definition: &IndexDefinition,
+    filter: &SearchFilter,
+    next_param: &mut usize,
+    binds: &mut Vec<Bound>,
+) -> String {
     use std::fmt::Write as _;
 
     let mut sql = String::new();
 
     if let Some(tenant) = &filter.tenant_id {
         let _ = write!(sql, " AND tenant_id = ${next_param}");
-        binds.push(tenant.clone());
+        binds.push(Bound::Text(tenant.clone()));
         *next_param += 1;
     }
     if let Some(allowed) = &filter.allowed_ids {
@@ -271,26 +332,63 @@ fn filter_sql(filter: &SearchFilter, next_param: &mut usize, binds: &mut Vec<Str
             // `matches_nothing`), but keep the SQL itself fail-closed.
             sql.push_str(" AND FALSE");
         } else {
-            let ids: Vec<String> = allowed.iter().map(i64::to_string).collect();
-            let _ = write!(sql, " AND record_id IN ({})", ids.join(","));
+            // `= ANY($n)` with a bound array, not an interpolated `IN (…)`
+            // list: the literal form would mint a distinct prepared statement
+            // for every distinct id set.
+            let _ = write!(sql, " AND record_id = ANY(${next_param})");
+            binds.push(Bound::Ids(allowed.clone()));
+            *next_param += 1;
         }
     }
     if !filter.excluded_ids.is_empty() {
-        let ids: Vec<String> = filter.excluded_ids.iter().map(i64::to_string).collect();
-        let _ = write!(sql, " AND record_id NOT IN ({})", ids.join(","));
+        let _ = write!(sql, " AND NOT (record_id = ANY(${next_param}))");
+        binds.push(Bound::Ids(filter.excluded_ids.clone()));
+        *next_param += 1;
     }
     for (field, value) in &filter.equals {
         if field == crate::backend::TENANT_FILTER_KEY {
             let _ = write!(sql, " AND tenant_id = ${next_param}");
-        } else {
-            // `field` is an indexed field name, already validated as a bare
-            // identifier by `IndexDefinition::validate`; the *value* is bound.
+        } else if definition.has_field(field) {
+            // Allowlisted against the definition, whose field names
+            // `IndexDefinition::validate` has already checked are bare
+            // identifiers; the *value* is bound.
             let _ = write!(sql, " AND fields ->> '{field}' = ${next_param}");
+        } else {
+            // Not a declared field: match nothing, bind nothing, and do NOT
+            // advance the parameter counter.
+            sql.push_str(" AND FALSE");
+            continue;
         }
-        binds.push(value.clone());
+        binds.push(Bound::Text(value.clone()));
         *next_param += 1;
     }
     sql
+}
+
+/// One bound parameter.
+///
+/// Exists so a query can be assembled as `(sql, Vec<Bound>)` and bound in one
+/// place, rather than every call site tracking two parallel lists of differing
+/// SQL types.
+#[derive(Debug, Clone, PartialEq)]
+enum Bound {
+    Text(String),
+    NullableText(Option<String>),
+    BigInt(i64),
+    Ids(Vec<i64>),
+}
+
+/// Bind `binds`, in order, onto a boxed query.
+fn bind_all(mut query: BoxedQuery<'_>, binds: impl IntoIterator<Item = Bound>) -> BoxedQuery<'_> {
+    for bound in binds {
+        query = match bound {
+            Bound::Text(value) => query.bind::<Text, _>(value),
+            Bound::NullableText(value) => query.bind::<Nullable<Text>, _>(value),
+            Bound::BigInt(value) => query.bind::<BigInt, _>(value),
+            Bound::Ids(values) => query.bind::<Array<BigInt>, _>(values),
+        };
+    }
+    query
 }
 
 impl SearchBackend for PostgresSearchStore {
@@ -299,12 +397,10 @@ impl SearchBackend for PostgresSearchStore {
     }
 
     fn capabilities(&self) -> BackendCapabilities {
-        BackendCapabilities {
-            keyword: true,
-            vector: true,
-            weighted_fields: true,
-            embedding_readback: true,
-        }
+        BackendCapabilities::default()
+            .with_vector(true)
+            .with_weighted_fields(true)
+            .with_embedding_readback(true)
     }
 
     fn ensure_index<'a>(
@@ -315,11 +411,15 @@ impl SearchBackend for PostgresSearchStore {
             checked(definition)?;
             let mut conn = self.conn().await?;
 
-            for statement in SCHEMA_STATEMENTS {
-                diesel::sql_query(*statement)
-                    .execute(&mut conn)
-                    .await
-                    .map_err(SearchError::backend)?;
+            // The DDL is the same for every index, so run it once per process
+            // rather than once per registered model.
+            if !self.schema_ready.swap(true, Ordering::SeqCst)
+                && let Err(error) = Self::apply_schema(&mut conn).await
+            {
+                // Let a later index retry the DDL rather than leaving the
+                // process permanently believing the schema exists.
+                self.schema_ready.store(false, Ordering::SeqCst);
+                return Err(error);
             }
 
             // Resolve the vector storage mode once per process. A managed
@@ -327,7 +427,9 @@ impl SearchBackend for PostgresSearchStore {
             // `CREATE EXTENSION` degrades rather than aborting boot.
             if self.vector_mode().is_none() {
                 let mode = match self.dimensions {
-                    Some(dimensions) if self.try_enable_pgvector(dimensions).await? => {
+                    // Threaded `&mut conn` rather than acquiring a second
+                    // connection: holding two at boot deadlocks a pool of one.
+                    Some(dimensions) if self.try_enable_pgvector(&mut conn, dimensions).await? => {
                         VectorMode::PgVector { dimensions }
                     }
                     _ => VectorMode::Array,
@@ -354,62 +456,83 @@ impl SearchBackend for PostgresSearchStore {
                 return Ok(());
             }
             let mut conn = self.conn().await?;
-            let pgvector = self.vector_mode().is_some_and(VectorMode::is_pgvector);
+            // The column exists once `try_enable_pgvector` has added it, and
+            // it must be WRITTEN whenever it exists — even in Array mode.
+            // Skipping it would leave a stale `embedding_vec` behind after an
+            // upsert, and a pgvector-mode reader (another replica, or this one
+            // after a config change) would then rank on the old vector.
+            let has_vector_column = self.vector_mode().is_some_and(VectorMode::is_pgvector);
 
             for document in documents {
                 // The weighted tsvector, built exactly as #842 does:
                 // `setweight(to_tsvector(<lang>, <value>), <weight>)` per
-                // field, concatenated. Every value is BOUND; only the language
-                // dictionary and the weight letter — both from the validated
-                // definition — are interpolated.
+                // field, concatenated.
                 //
-                // Bound parameters: $1 index_name, $2 tenant_id, $3 fields
-                // json, $4 language, $5 content, then one per field value.
+                // The weight letter is interpolated, so it comes from the
+                // VALIDATED definition rather than from the document: a
+                // hand-built document (or a third-party `DocumentSource`) can
+                // carry any `char`. A field the index does not declare is
+                // skipped entirely.
+                //
+                // Bound: $1 index_name, $2 record_id, $3 tenant_id, $4 fields
+                // json, $5 language, $6 content, $7 embedding, ($8 vector),
+                // then one per field value.
+                let mut binds = vec![
+                    Bound::Text(definition.name.to_owned()),
+                    Bound::BigInt(document.id()),
+                    Bound::NullableText(document.document.tenant_id.clone()),
+                    Bound::Text(fields_json(document)?),
+                    Bound::Text(definition.language.to_owned()),
+                    Bound::Text(document.document.text()),
+                    Bound::NullableText(document.embedding.as_deref().map(array_literal)),
+                ];
+                if has_vector_column {
+                    binds.push(Bound::NullableText(
+                        document.embedding.as_deref().map(vector_literal),
+                    ));
+                }
+
                 let mut vector_sql = String::new();
-                let mut binds: Vec<String> = Vec::new();
-                for (param, field) in (6_usize..).zip(document.document.fields.iter()) {
+                let mut param = binds.len() + 1;
+                for field in &document.document.fields {
+                    let Some(weight) = definition.weight_of(field.name) else {
+                        continue;
+                    };
                     if !vector_sql.is_empty() {
                         vector_sql.push_str(" || ");
                     }
+                    // `$5::text::regconfig`, not `$5::regconfig`: the same
+                    // parameter is also the `language` column value, and the
+                    // untyped form is "inconsistent types deduced for
+                    // parameter" under any client that does not declare bind
+                    // types.
                     let _ = write!(
                         vector_sql,
-                        "setweight(to_tsvector($4::regconfig, ${param}), '{}')",
-                        field.weight
+                        "setweight(to_tsvector($5::text::regconfig, ${param}), '{weight}')"
                     );
-                    binds.push(field.value.clone());
+                    binds.push(Bound::Text(field.value.clone()));
+                    param += 1;
                 }
                 if vector_sql.is_empty() {
-                    "to_tsvector($4::regconfig, '')".clone_into(&mut vector_sql);
+                    "to_tsvector($5::text::regconfig, '')".clone_into(&mut vector_sql);
                 }
 
-                let embedding = document.embedding.as_ref().map_or_else(
-                    || "NULL".to_owned(),
-                    |v| format!("'{}'::double precision[]", array_literal(v)),
-                );
-
-                // `embedding_vec` only exists when `try_enable_pgvector`
-                // added it, so it must be absent from the column list in the
-                // portable mode — naming a column that does not exist would
-                // fail every write.
-                let (vec_column, vec_value, vec_update) = if pgvector {
-                    let value = document.embedding.as_ref().map_or_else(
-                        || "NULL".to_owned(),
-                        |v| format!("'{}'::vector", vector_literal(v)),
-                    );
+                let (vec_column, vec_value, vec_update) = if has_vector_column {
                     (
                         ", embedding_vec",
-                        format!(", {value}"),
+                        ", $8::vector",
                         ", embedding_vec = EXCLUDED.embedding_vec",
                     )
                 } else {
-                    ("", String::new(), "")
+                    ("", "", "")
                 };
 
                 let sql = format!(
                     "INSERT INTO {DOCUMENTS_TABLE} \
                        (index_name, record_id, tenant_id, language, fields, content, \
                         search_vector, embedding{vec_column}) \
-                     VALUES ($1, {id}, $2, $4, $3::jsonb, $5, {vector_sql}, {embedding}{vec_value}) \
+                     VALUES ($1, $2, $3, $5, $4::jsonb, $6, {vector_sql}, \
+                             $7::double precision[]{vec_value}) \
                      ON CONFLICT (index_name, record_id) DO UPDATE SET \
                        tenant_id = EXCLUDED.tenant_id, \
                        language = EXCLUDED.language, \
@@ -417,34 +540,16 @@ impl SearchBackend for PostgresSearchStore {
                        content = EXCLUDED.content, \
                        search_vector = EXCLUDED.search_vector, \
                        embedding = EXCLUDED.embedding{vec_update}, \
-                       updated_at = NOW()",
-                    id = document.id(),
+                       updated_at = NOW()"
                 );
 
-                let fields_json = serde_json::to_string(
-                    &document
-                        .document
-                        .fields
-                        .iter()
-                        .map(|f| (f.name, f.value.clone()))
-                        .collect::<std::collections::BTreeMap<_, _>>(),
+                bind_all(
+                    diesel::sql_query(sql).into_boxed::<autumn_web::RuntimeBackend>(),
+                    binds,
                 )
+                .execute(&mut conn)
+                .await
                 .map_err(SearchError::backend)?;
-
-                let mut query = diesel::sql_query(sql)
-                    .into_boxed::<autumn_web::RuntimeBackend>()
-                    .bind::<Text, _>(definition.name.to_owned())
-                    .bind::<Nullable<Text>, _>(document.document.tenant_id.clone())
-                    .bind::<Text, _>(fields_json)
-                    .bind::<Text, _>(definition.language.to_owned())
-                    .bind::<Text, _>(document.document.text());
-                for value in binds {
-                    query = query.bind::<Text, _>(value);
-                }
-                query
-                    .execute(&mut conn)
-                    .await
-                    .map_err(SearchError::backend)?;
             }
             Ok(())
         })
@@ -457,16 +562,22 @@ impl SearchBackend for PostgresSearchStore {
     ) -> BoxFuture<'a, SearchResult<()>> {
         Box::pin(async move {
             checked(definition)?;
+            // `IN ()` is a syntax error, so an empty slice must never reach SQL.
             if ids.is_empty() {
                 return Ok(());
             }
             let mut conn = self.conn().await?;
-            let list: Vec<String> = ids.iter().map(i64::to_string).collect();
-            diesel::sql_query(format!(
-                "DELETE FROM {DOCUMENTS_TABLE} WHERE index_name = $1 AND record_id IN ({})",
-                list.join(",")
-            ))
-            .bind::<Text, _>(definition.name.to_owned())
+            bind_all(
+                diesel::sql_query(format!(
+                    "DELETE FROM {DOCUMENTS_TABLE} \
+                     WHERE index_name = $1 AND record_id = ANY($2)"
+                ))
+                .into_boxed::<autumn_web::RuntimeBackend>(),
+                [
+                    Bound::Text(definition.name.to_owned()),
+                    Bound::Ids(ids.to_vec()),
+                ],
+            )
             .execute(&mut conn)
             .await
             .map_err(SearchError::backend)?;
@@ -505,55 +616,63 @@ impl SearchBackend for PostgresSearchStore {
             let mut conn = self.conn().await?;
             // $1 index_name, $2 language, $3 query text.
             let mut param = 4_usize;
-            let mut binds: Vec<String> = Vec::new();
-            let predicate = filter_sql(&query.filter, &mut param, &mut binds);
+            let mut binds: Vec<Bound> = Vec::new();
+            let predicate = filter_sql(definition, &query.filter, &mut param, &mut binds);
+            let head = [
+                Bound::Text(definition.name.to_owned()),
+                Bound::Text(definition.language.to_owned()),
+                Bound::Text(query.text.clone()),
+            ];
 
             // `plainto_tsquery` (not `websearch_to_tsquery`): the documented
             // cross-backend contract is "every token must match, operators are
             // not syntax". It is parameterized, so a hostile query string can
             // neither inject nor widen the result set.
             let where_clause = format!(
-                "index_name = $1 AND search_vector @@ plainto_tsquery($2::regconfig, $3){predicate}"
+                "index_name = $1 \
+                 AND search_vector @@ plainto_tsquery($2::text::regconfig, $3){predicate}"
             );
 
-            let mut count = diesel::sql_query(format!(
-                "SELECT COUNT(*)::bigint AS total FROM {DOCUMENTS_TABLE} WHERE {where_clause}"
-            ))
-            .into_boxed::<autumn_web::RuntimeBackend>()
-            .bind::<Text, _>(definition.name.to_owned())
-            .bind::<Text, _>(definition.language.to_owned())
-            .bind::<Text, _>(query.text.clone());
-            for value in &binds {
-                count = count.bind::<Text, _>(value.clone());
-            }
-            let total = count
-                .get_result::<CountRow>(&mut conn)
-                .await
-                .map_err(SearchError::backend)?
-                .total;
+            let total = bind_all(
+                diesel::sql_query(format!(
+                    "SELECT COUNT(*)::bigint AS total FROM {DOCUMENTS_TABLE} WHERE {where_clause}"
+                ))
+                .into_boxed::<autumn_web::RuntimeBackend>(),
+                head.iter().cloned().chain(binds.iter().cloned()),
+            )
+            .get_result::<CountRow>(&mut conn)
+            .await
+            .map_err(SearchError::backend)?
+            .total;
 
+            // LIMIT/OFFSET are BOUND: interpolating them would mint a distinct
+            // prepared statement per page, which the unbounded statement cache
+            // never evicts.
+            let limit_param = param;
+            let offset_param = param + 1;
             let size = i64::from(query.page.size());
             let offset = i64::from(query.page.page().saturating_sub(1)) * size;
-            let mut rows = diesel::sql_query(format!(
-                "SELECT record_id, \
-                        ts_rank_cd(search_vector, plainto_tsquery($2::regconfig, $3))::double precision AS score \
-                 FROM {DOCUMENTS_TABLE} WHERE {where_clause} \
-                 ORDER BY score DESC, record_id ASC LIMIT {size} OFFSET {offset}"
-            ))
-            .into_boxed::<autumn_web::RuntimeBackend>()
-            .bind::<Text, _>(definition.name.to_owned())
-            .bind::<Text, _>(definition.language.to_owned())
-            .bind::<Text, _>(query.text.clone());
-            for value in &binds {
-                rows = rows.bind::<Text, _>(value.clone());
-            }
-            let hits = rows
-                .load::<HitRow>(&mut conn)
-                .await
-                .map_err(SearchError::backend)?;
+            let rows = bind_all(
+                diesel::sql_query(format!(
+                    "SELECT record_id, \
+                            ts_rank_cd(search_vector, \
+                                       plainto_tsquery($2::text::regconfig, $3))::double precision \
+                              AS score \
+                     FROM {DOCUMENTS_TABLE} WHERE {where_clause} \
+                     ORDER BY score DESC, record_id ASC \
+                     LIMIT ${limit_param} OFFSET ${offset_param}"
+                ))
+                .into_boxed::<autumn_web::RuntimeBackend>(),
+                head.into_iter()
+                    .chain(binds)
+                    .chain([Bound::BigInt(size), Bound::BigInt(offset)]),
+            )
+            .load::<HitRow>(&mut conn)
+            .await
+            .map_err(SearchError::backend)?;
 
             Ok(Page::new(
-                hits.into_iter()
+                rows.into_iter()
                     .map(|row| {
                         SearchHit::new(definition.name, row.record_id, narrow_score(row.score))
                     })
@@ -581,64 +700,83 @@ impl SearchBackend for PostgresSearchStore {
             }
 
             let mut conn = self.conn().await?;
-            let mut param = 2_usize; // $1 index_name
-            let mut binds: Vec<String> = Vec::new();
-            let predicate = filter_sql(&query.filter, &mut param, &mut binds);
+            // $1 index_name, $2 the query vector (bound as text, cast in SQL).
+            let mut param = 3_usize;
+            let mut binds: Vec<Bound> = Vec::new();
+            let predicate = filter_sql(definition, &query.filter, &mut param, &mut binds);
 
-            // Cosine *similarity* in both modes, so the two paths order
-            // identically: pgvector's `<=>` is cosine distance, hence `1 - d`.
-            //
-            // Width mismatch: `<=>` errors on it, while `unnest(a, b)` would
-            // silently pad the shorter array with NULLs and return a wrong
-            // score. The portable path therefore filters mismatched documents
-            // out with `array_length`, so a re-embedding at a new width
-            // degrades to "no results" rather than to wrong results. (The
-            // in-memory backend raises `DimensionMismatch` instead — it can
-            // afford to inspect every document; SQL cannot.)
+            let pgvector = self.vector_mode().is_some_and(VectorMode::is_pgvector);
             let width = query.vector.len();
-            let (score_expr, embedding_predicate) =
-                if self.vector_mode().is_some_and(VectorMode::is_pgvector) {
-                    (
-                        format!(
-                            "(1 - (embedding_vec <=> '{}'::vector))::double precision",
-                            vector_literal(&query.vector)
-                        ),
-                        "embedding_vec IS NOT NULL".to_owned(),
-                    )
-                } else {
-                    (
-                        format!(
-                            "autumn_search_cosine(embedding, '{}'::double precision[])",
-                            array_literal(&query.vector)
-                        ),
-                        format!("embedding IS NOT NULL AND array_length(embedding, 1) = {width}"),
-                    )
-                };
+            // Both modes score cosine SIMILARITY so the two orderings agree
+            // (pgvector's `<=>` is cosine distance, hence `1 - d`).
+            //
+            // Ordering differs, though, and deliberately: an ivfflat index can
+            // only serve `ORDER BY col <=> const ASC`. Ordering by the derived
+            // `1 - d` expression is opaque to the planner and forces an exact
+            // full scan, which would make the whole pgvector fast path buy
+            // nothing. So pgvector mode orders by DISTANCE ascending and
+            // converts to similarity only in the select list.
+            let (query_vector, distance, score_expr, order_by, embedding_predicate) = if pgvector {
+                (
+                    vector_literal(&query.vector),
+                    "(embedding_vec <=> $2::vector)".to_owned(),
+                    "(1 - (embedding_vec <=> $2::vector))::double precision".to_owned(),
+                    "ORDER BY (embedding_vec <=> $2::vector) ASC, record_id ASC".to_owned(),
+                    "embedding_vec IS NOT NULL".to_owned(),
+                )
+            } else {
+                let expr = "autumn_search_cosine(embedding, $2::double precision[])".to_owned();
+                (
+                    array_literal(&query.vector),
+                    String::new(),
+                    expr.clone(),
+                    format!("ORDER BY {expr} DESC, record_id ASC"),
+                    // `unnest(a, b)` pads the shorter array with NULLs and
+                    // silently mis-scores, so a width mismatch is excluded
+                    // rather than ranked. (pgvector's `<=>` errors instead —
+                    // documented divergence.)
+                    format!("embedding IS NOT NULL AND array_length(embedding, 1) = {width}"),
+                )
+            };
+            let _ = distance;
 
             // Only emit the threshold when one was asked for: it repeats the
-            // (non-trivial) score expression, so an unconditional
-            // `>= -3.4e38` would be pure cost.
+            // (non-trivial) score expression. A non-finite bound would render
+            // as a bare `NaN`/`inf` identifier and turn the query into a
+            // syntax error, so drop it — no threshold is the safe reading of
+            // "not a number".
             let threshold = query
                 .min_score
-                .map_or_else(String::new, |min| format!(" AND {score_expr} >= {min}"));
-            let limit = query.limit;
-            let mut rows = diesel::sql_query(format!(
-                "SELECT record_id, {score_expr} AS score FROM {DOCUMENTS_TABLE} \
-                 WHERE index_name = $1 AND {embedding_predicate}{predicate}{threshold} \
-                 ORDER BY score DESC, record_id ASC LIMIT {limit}"
-            ))
-            .into_boxed::<autumn_web::RuntimeBackend>()
-            .bind::<Text, _>(definition.name.to_owned());
-            for value in &binds {
-                rows = rows.bind::<Text, _>(value.clone());
-            }
-            let hits = rows
-                .load::<HitRow>(&mut conn)
-                .await
-                .map_err(SearchError::backend)?;
+                .filter(|min| min.is_finite())
+                .map_or_else(String::new, |min| format!(" AND {score_expr} >= {min:?}"));
 
-            Ok(hits
+            let limit_param = param;
+            let limit = i64::try_from(query.limit).unwrap_or(i64::MAX);
+            let rows = bind_all(
+                diesel::sql_query(format!(
+                    "SELECT record_id, {score_expr} AS score FROM {DOCUMENTS_TABLE} \
+                     WHERE index_name = $1 AND {embedding_predicate}{predicate}{threshold} \
+                     {order_by} LIMIT ${limit_param}"
+                ))
+                .into_boxed::<autumn_web::RuntimeBackend>(),
+                [
+                    Bound::Text(definition.name.to_owned()),
+                    Bound::Text(query_vector),
+                ]
                 .into_iter()
+                .chain(binds)
+                .chain([Bound::BigInt(limit)]),
+            )
+            .load::<HitRow>(&mut conn)
+            .await
+            .map_err(SearchError::backend)?;
+
+            Ok(rows
+                .into_iter()
+                // A zero-norm vector makes pgvector's `<=>` return NaN, which
+                // sorts FIRST under `DESC` — a garbage row would rank #1 with
+                // a displayed score of 0. Drop those rather than surface them.
+                .filter(|row| row.score.is_finite())
                 .map(|row| SearchHit::new(definition.name, row.record_id, narrow_score(row.score)))
                 .collect())
         })
@@ -648,20 +786,36 @@ impl SearchBackend for PostgresSearchStore {
         &'a self,
         definition: &'a IndexDefinition,
         id: i64,
+        filter: &'a SearchFilter,
     ) -> BoxFuture<'a, SearchResult<Option<Vec<f32>>>> {
         Box::pin(async move {
             checked(definition)?;
+            // A record the filter excludes reads back as absent — this is a
+            // query like any other, and the seed id is caller-supplied.
+            if filter.matches_nothing() {
+                return Ok(None);
+            }
             let mut conn = self.conn().await?;
-            let row = diesel::sql_query(format!(
-                "SELECT embedding::text AS embedding FROM {DOCUMENTS_TABLE} \
-                 WHERE index_name = $1 AND record_id = {id}"
-            ))
-            .bind::<Text, _>(definition.name.to_owned())
-            .get_results::<EmbeddingRow>(&mut conn)
+            // $1 index_name, $2 record_id.
+            let mut param = 3_usize;
+            let mut binds: Vec<Bound> = Vec::new();
+            let predicate = filter_sql(definition, filter, &mut param, &mut binds);
+
+            let rows = bind_all(
+                diesel::sql_query(format!(
+                    "SELECT embedding::text AS embedding FROM {DOCUMENTS_TABLE} \
+                     WHERE index_name = $1 AND record_id = $2{predicate}"
+                ))
+                .into_boxed::<autumn_web::RuntimeBackend>(),
+                [Bound::Text(definition.name.to_owned()), Bound::BigInt(id)]
+                    .into_iter()
+                    .chain(binds),
+            )
+            .load::<EmbeddingRow>(&mut conn)
             .await
             .map_err(SearchError::backend)?;
 
-            Ok(row
+            Ok(rows
                 .into_iter()
                 .next()
                 .and_then(|row| row.embedding)
@@ -671,16 +825,58 @@ impl SearchBackend for PostgresSearchStore {
 }
 
 impl PostgresSearchStore {
+    /// Apply the shared DDL under an advisory lock.
+    ///
+    /// `CREATE TABLE/INDEX IF NOT EXISTS` and `CREATE OR REPLACE FUNCTION` are
+    /// **not** race-free: concurrent boots hit `duplicate key value violates
+    /// unique constraint "pg_type_typname_nsp_index"` and `tuple concurrently
+    /// updated`. Without this, a rolling deploy would intermittently abort a
+    /// replica's boot. A session-level advisory lock serializes them; it is
+    /// released explicitly below and, if the process dies, when the connection
+    /// closes.
+    async fn apply_schema(
+        conn: &mut diesel_async::pooled_connection::deadpool::Object<autumn_web::RuntimeConnection>,
+    ) -> SearchResult<()> {
+        const LOCK: &str = "hashtext('autumn_search_schema')::bigint";
+
+        diesel::sql_query(format!("SELECT pg_advisory_lock({LOCK})"))
+            .execute(&mut *conn)
+            .await
+            .map_err(SearchError::backend)?;
+
+        let mut outcome = Ok(());
+        for statement in SCHEMA_STATEMENTS {
+            if let Err(error) = diesel::sql_query(*statement).execute(&mut *conn).await {
+                outcome = Err(SearchError::backend(error));
+                break;
+            }
+        }
+
+        // Released on every path, including the error one. Each DDL statement
+        // is its own transaction under autocommit, so a failure above does not
+        // leave the session unable to run this.
+        let _ = diesel::sql_query(format!("SELECT pg_advisory_unlock({LOCK})"))
+            .execute(&mut *conn)
+            .await;
+
+        outcome
+    }
+
     /// Try to install `pgvector` and add the accelerated column + index.
     ///
     /// Returns `false` (rather than erroring) when the extension is not
     /// available: the portable array path is a complete implementation, so a
     /// managed Postgres without `pgvector` must boot, not crash.
-    async fn try_enable_pgvector(&self, dimensions: usize) -> SearchResult<bool> {
-        let mut conn = self.conn().await?;
-
+    ///
+    /// Takes the caller's connection: acquiring a second one while the caller
+    /// holds the first deadlocks a pool of size 1 at boot.
+    async fn try_enable_pgvector(
+        &self,
+        conn: &mut diesel_async::pooled_connection::deadpool::Object<autumn_web::RuntimeConnection>,
+        dimensions: usize,
+    ) -> SearchResult<bool> {
         if diesel::sql_query("CREATE EXTENSION IF NOT EXISTS vector")
-            .execute(&mut conn)
+            .execute(&mut *conn)
             .await
             .is_err()
         {
@@ -694,7 +890,7 @@ impl PostgresSearchStore {
         let present = diesel::sql_query(
             "SELECT EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'vector') AS present",
         )
-        .get_result::<ExistsRow>(&mut conn)
+        .get_result::<ExistsRow>(&mut *conn)
         .await
         .map_err(SearchError::backend)?
         .present;
@@ -705,9 +901,51 @@ impl PostgresSearchStore {
         // `dimensions` is a `usize` from config, formatted by Rust — no caller
         // text reaches this statement.
         diesel::sql_query(format!(
-            "ALTER TABLE {DOCUMENTS_TABLE} ADD COLUMN IF NOT EXISTS embedding_vec vector({dimensions})"
+            "ALTER TABLE {DOCUMENTS_TABLE} \
+             ADD COLUMN IF NOT EXISTS embedding_vec vector({dimensions})"
         ))
-        .execute(&mut conn)
+        .execute(&mut *conn)
+        .await
+        .map_err(SearchError::backend)?;
+
+        // `ADD COLUMN IF NOT EXISTS` is a silent no-op against an existing
+        // column of a DIFFERENT width, which would leave the store believing
+        // it is in `PgVector{new}` while every insert fails with "expected
+        // <old> dimensions". Verify what is actually there.
+        let actual = diesel::sql_query(format!(
+            "SELECT COALESCE(atttypmod, 0)::bigint AS width FROM pg_attribute \
+             WHERE attrelid = to_regclass('{DOCUMENTS_TABLE}') \
+               AND attname = 'embedding_vec' AND NOT attisdropped"
+        ))
+        .get_results::<WidthRow>(&mut *conn)
+        .await
+        .map_err(SearchError::backend)?;
+        let existing_width = actual.into_iter().next().map(|row| row.width);
+        if let Some(width) = existing_width
+            && width > 0
+            && usize::try_from(width).unwrap_or(0) != dimensions
+        {
+            tracing::warn!(
+                configured = dimensions,
+                existing = width,
+                "autumn-search: the pgvector column has a different width than \
+                 `search.embedding_dimensions`; falling back to the portable \
+                 double precision[] path. Drop `autumn_search_documents.embedding_vec` \
+                 and re-run a full backfill to adopt the new width."
+            );
+            return Ok(false);
+        }
+
+        // Adopt embeddings written while the store was in Array mode —
+        // otherwise every pre-existing document silently vanishes from k-NN
+        // (the query filters `embedding_vec IS NOT NULL`) until a full
+        // backfill happens to run.
+        diesel::sql_query(format!(
+            "UPDATE {DOCUMENTS_TABLE} SET embedding_vec = embedding::text::vector \
+             WHERE embedding IS NOT NULL AND embedding_vec IS NULL \
+               AND array_length(embedding, 1) = {dimensions}"
+        ))
+        .execute(&mut *conn)
         .await
         .map_err(SearchError::backend)?;
 
@@ -716,16 +954,15 @@ impl PostgresSearchStore {
         // correctness, so never fail boot for it.
         let _ = diesel::sql_query(format!(
             "CREATE INDEX IF NOT EXISTS autumn_search_documents_embedding_vec_idx \
-             ON {DOCUMENTS_TABLE} USING ivfflat (embedding_vec vector_cosine_ops)"
+             ON {DOCUMENTS_TABLE} USING ivfflat (embedding_vec vector_cosine_ops) \
+             WITH (lists = 100)"
         ))
-        .execute(&mut conn)
+        .execute(&mut *conn)
         .await;
 
         Ok(true)
     }
 }
-
-// ── Document source ─────────────────────────────────────────────────────────
 
 impl DocumentSource for PostgresSearchStore {
     fn fetch<'a>(
@@ -738,13 +975,7 @@ impl DocumentSource for PostgresSearchStore {
             if ids.is_empty() {
                 return Ok(Vec::new());
             }
-            let list: Vec<String> = ids.iter().map(i64::to_string).collect();
-            self.load_documents(
-                definition,
-                &format!("WHERE id IN ({})", list.join(",")),
-                None,
-            )
-            .await
+            self.load_documents(definition, Selection::Ids(ids)).await
         })
     }
 
@@ -756,64 +987,132 @@ impl DocumentSource for PostgresSearchStore {
     ) -> BoxFuture<'a, SearchResult<Vec<SearchDocument>>> {
         Box::pin(async move {
             checked(definition)?;
-            let where_clause =
-                after.map_or_else(String::new, |after| format!("WHERE id > {after}"));
-            self.load_documents(definition, &where_clause, Some(limit))
+            self.load_documents(definition, Selection::After { after, limit })
                 .await
         })
     }
 }
 
+/// Which source rows to project.
+enum Selection<'a> {
+    /// Exactly these ids (a reindex).
+    Ids(&'a [i64]),
+    /// The next `limit` rows after `after`, by ascending id (a backfill).
+    After { after: Option<i64>, limit: usize },
+}
+
 impl PostgresSearchStore {
+    /// The optional framework columns `definition`'s source table carries,
+    /// cached per index.
+    ///
+    /// Resolved through `to_regclass`, which follows the connection's
+    /// `search_path` exactly as the projection below does. An
+    /// `information_schema` probe filtered on `current_schema()` would answer
+    /// about a different table whenever the model lives in a non-first schema
+    /// — silently blanking `tenant_id` and re-indexing soft-deleted rows.
+    async fn optional_columns(
+        &self,
+        definition: &IndexDefinition,
+        conn: &mut diesel_async::pooled_connection::deadpool::Object<autumn_web::RuntimeConnection>,
+    ) -> SearchResult<OptionalColumns> {
+        if let Ok(cache) = self.optional_columns.read()
+            && let Some(columns) = cache.get(definition.name)
+        {
+            return Ok(*columns);
+        }
+
+        let row = diesel::sql_query(
+            "SELECT bool_or(attname = 'tenant_id')  AS has_tenant, \
+                    bool_or(attname = 'deleted_at') AS has_deleted_at \
+             FROM pg_attribute \
+             WHERE attrelid = to_regclass($1) AND attnum > 0 AND NOT attisdropped",
+        )
+        .bind::<Text, _>(definition.name.to_owned())
+        .get_result::<OptionalColumnsRow>(conn)
+        .await
+        .map_err(SearchError::backend)?;
+
+        let columns = OptionalColumns {
+            tenant_id: row.has_tenant.unwrap_or(false),
+            deleted_at: row.has_deleted_at.unwrap_or(false),
+        };
+        if let Ok(mut cache) = self.optional_columns.write() {
+            cache.insert(definition.name, columns);
+        }
+        Ok(columns)
+    }
+
     /// Project a model's table into `(id, fields json, tenant_id)`.
     ///
     /// Fully generic: the column list comes from the validated
     /// [`IndexDefinition`], so no per-model code is generated anywhere. The
     /// values are returned as one JSON object rather than N columns, which is
     /// what lets a single `QueryableByName` struct serve every model.
+    ///
+    /// **The source table's primary key must be the `id` column** — the same
+    /// assumption the in-core FTS `search()` makes. A `#[searchable]` model
+    /// whose key column is named otherwise needs its own `DocumentSource`.
     async fn load_documents(
         &self,
         definition: &IndexDefinition,
-        where_clause: &str,
-        limit: Option<usize>,
+        selection: Selection<'_>,
     ) -> SearchResult<Vec<SearchDocument>> {
         // ONE connection for both statements: acquiring a second while holding
         // the first deadlocks a small pool.
         let mut conn = self.conn().await?;
+        let columns = self.optional_columns(definition, &mut conn).await?;
 
-        let has_tenant = diesel::sql_query(
-            "SELECT EXISTS ( \
-               SELECT 1 FROM information_schema.columns \
-               WHERE table_schema = current_schema() \
-                 AND table_name = $1 \
-                 AND column_name = 'tenant_id' \
-             ) AS present",
-        )
-        .bind::<Text, _>(definition.name.to_owned())
-        .get_result::<ExistsRow>(&mut conn)
-        .await
-        .map_err(SearchError::backend)?
-        .present;
+        let mut binds: Vec<Bound> = Vec::new();
+        let mut param = 1_usize;
+        let mut predicates: Vec<String> = Vec::new();
+        let mut limit_clause = String::new();
 
-        // Identifiers only — every name here passed `IndexDefinition::validate`.
-        let projection: Vec<String> = definition
-            .fields
-            .iter()
-            .map(|field| format!("'{0}', COALESCE(\"{0}\"::text, '')", field.name))
-            .collect();
-        let tenant = if has_tenant {
+        match selection {
+            Selection::Ids(ids) => {
+                predicates.push(format!("id = ANY(${param})"));
+                binds.push(Bound::Ids(ids.to_vec()));
+            }
+            Selection::After { after, limit } => {
+                if let Some(after) = after {
+                    predicates.push(format!("id > ${param}"));
+                    binds.push(Bound::BigInt(after));
+                    param += 1;
+                }
+                limit_clause = format!(" LIMIT ${param}");
+                binds.push(Bound::BigInt(i64::try_from(limit).unwrap_or(i64::MAX)));
+            }
+        }
+        if columns.deleted_at {
+            // A soft-deleted row must not be re-indexed: `after_delete_commit`
+            // removes its document, and a later backfill would otherwise put
+            // it straight back — searchable while `find` hides it.
+            predicates.push("deleted_at IS NULL".to_owned());
+        }
+        let where_clause = if predicates.is_empty() {
+            String::new()
+        } else {
+            format!("WHERE {}", predicates.join(" AND "))
+        };
+
+        let tenant = if columns.tenant_id {
             "tenant_id::text"
         } else {
             "NULL::text"
         };
-        let limit_clause = limit.map_or_else(String::new, |limit| format!(" LIMIT {limit}"));
 
-        let rows = diesel::sql_query(format!(
-            "SELECT id, jsonb_build_object({})::text AS fields, {tenant} AS tenant_id \
-             FROM \"{}\" {where_clause} ORDER BY id ASC{limit_clause}",
-            projection.join(", "),
-            definition.name,
-        ))
+        // `id::bigint`: the row is decoded as `BigInt`, so an `integer`/
+        // `serial` key column would be a runtime deserialization error the
+        // compiler cannot see.
+        let rows = bind_all(
+            diesel::sql_query(format!(
+                "SELECT id::bigint AS id, {} AS fields, {tenant} AS tenant_id \
+                 FROM \"{}\" {where_clause} ORDER BY id ASC{limit_clause}",
+                fields_projection(definition),
+                definition.name,
+            ))
+            .into_boxed::<autumn_web::RuntimeBackend>(),
+            binds,
+        )
         .load::<SourceRow>(&mut conn)
         .await
         .map_err(SearchError::backend)?;
@@ -838,6 +1137,45 @@ impl PostgresSearchStore {
         }
         Ok(documents)
     }
+}
+
+/// The `jsonb_build_object(...)` projection for `definition`'s fields.
+///
+/// Chunked and concatenated with `||`: `jsonb_build_object` is variadic-"any"
+/// and Postgres caps a function call at **100 arguments**, so a model with
+/// more than 50 searchable fields would otherwise be a hard
+/// `cannot pass more than 100 arguments to a function` error.
+fn fields_projection(definition: &IndexDefinition) -> String {
+    /// 40 pairs = 80 arguments, comfortably under the cap.
+    const PAIRS_PER_CHUNK: usize = 40;
+
+    let pairs: Vec<String> = definition
+        .fields
+        .iter()
+        .map(|field| format!("'{0}', COALESCE(\"{0}\"::text, '')", field.name))
+        .collect();
+    if pairs.is_empty() {
+        return "'{}'::jsonb::text".to_owned();
+    }
+    pairs
+        .chunks(PAIRS_PER_CHUNK)
+        .map(|chunk| format!("jsonb_build_object({})", chunk.join(", ")))
+        .collect::<Vec<_>>()
+        .join(" || ")
+        + "::text"
+}
+
+/// The `fields` JSON one document is stored with.
+fn fields_json(document: &IndexedDocument) -> SearchResult<String> {
+    serde_json::to_string(
+        &document
+            .document
+            .fields
+            .iter()
+            .map(|f| (f.name, f.value.clone()))
+            .collect::<std::collections::BTreeMap<_, _>>(),
+    )
+    .map_err(SearchError::backend)
 }
 
 /// DDL for the framework-owned index, applied idempotently on every boot.
@@ -887,7 +1225,7 @@ mod tests {
     ];
 
     fn definition() -> IndexDefinition {
-        IndexDefinition::new("articles", "english", FIELDS, Some("body"))
+        IndexDefinition::new("articles", "english", FIELDS, Some("body"), false)
     }
 
     #[test]
@@ -918,7 +1256,12 @@ mod tests {
         let mut param = 2;
         let mut binds = Vec::new();
         assert_eq!(
-            filter_sql(&SearchFilter::default(), &mut param, &mut binds),
+            filter_sql(
+                &definition(),
+                &SearchFilter::default(),
+                &mut param,
+                &mut binds
+            ),
             ""
         );
         assert_eq!(param, 2);
@@ -930,12 +1273,16 @@ mod tests {
         let mut param = 2;
         let mut binds = Vec::new();
         let sql = filter_sql(
+            &definition(),
             &SearchFilter::default().tenant("acme'; DROP TABLE users; --"),
             &mut param,
             &mut binds,
         );
         assert_eq!(sql, " AND tenant_id = $2");
-        assert_eq!(binds, vec!["acme'; DROP TABLE users; --".to_owned()]);
+        assert_eq!(
+            binds,
+            vec![Bound::Text("acme'; DROP TABLE users; --".to_owned())]
+        );
         assert_eq!(param, 3);
     }
 
@@ -944,6 +1291,7 @@ mod tests {
         let mut param = 2;
         let mut binds = Vec::new();
         let sql = filter_sql(
+            &definition(),
             &SearchFilter::default().allow_ids(Vec::<i64>::new()),
             &mut param,
             &mut binds,
@@ -952,19 +1300,27 @@ mod tests {
     }
 
     #[test]
-    fn id_lists_are_rendered_from_integers_only() {
+    fn id_lists_are_bound_as_arrays_never_interpolated() {
         let mut param = 2;
         let mut binds = Vec::new();
         let sql = filter_sql(
+            &definition(),
             &SearchFilter::default()
                 .allow_ids([1_i64, 2])
                 .exclude_ids([3_i64]),
             &mut param,
             &mut binds,
         );
-        assert!(sql.contains("record_id IN (1,2)"), "{sql}");
-        assert!(sql.contains("record_id NOT IN (3)"), "{sql}");
-        assert!(binds.is_empty(), "ids are integers, nothing to bind");
+        // Bound arrays, not interpolated `IN (…)` lists: the literal form
+        // would mint a distinct (never-evicted) prepared statement for every
+        // distinct id set a caller happens to filter on.
+        assert!(sql.contains("record_id = ANY($2)"), "{sql}");
+        assert!(sql.contains("NOT (record_id = ANY($3))"), "{sql}");
+        assert!(
+            !sql.contains("IN ("),
+            "ids must never be interpolated: {sql}"
+        );
+        assert_eq!(binds, vec![Bound::Ids(vec![1, 2]), Bound::Ids(vec![3])]);
     }
 
     #[test]
@@ -972,6 +1328,7 @@ mod tests {
         let mut param = 4;
         let mut binds = Vec::new();
         let sql = filter_sql(
+            &definition(),
             &SearchFilter::default()
                 .equals("title", "Hello")
                 .equals("body", "World"),
@@ -981,8 +1338,71 @@ mod tests {
         // BTreeMap iterates in key order: body, then title.
         assert!(sql.contains("fields ->> 'body' = $4"), "{sql}");
         assert!(sql.contains("fields ->> 'title' = $5"), "{sql}");
-        assert_eq!(binds, vec!["World".to_owned(), "Hello".to_owned()]);
+        assert_eq!(
+            binds,
+            vec![
+                Bound::Text("World".to_owned()),
+                Bound::Text("Hello".to_owned())
+            ]
+        );
         assert_eq!(param, 6);
+    }
+
+    #[test]
+    fn an_undeclared_equals_key_never_reaches_sql() {
+        // A field name is an IDENTIFIER position. Left unchecked, a
+        // request-supplied facet key like `title' = 'x' OR '1'='1` would close
+        // the quote and OR away the tenant and allowlist predicates that
+        // precede it — widening past the visibility filter, not merely
+        // injecting. It must fail closed instead.
+        let mut param = 4;
+        let mut binds = Vec::new();
+        let sql = filter_sql(
+            &definition(),
+            &SearchFilter::default().equals("title' = 'x' OR '1'='1", "boom"),
+            &mut param,
+            &mut binds,
+        );
+
+        assert_eq!(sql, " AND FALSE", "{sql}");
+        assert!(!sql.contains("OR"), "{sql}");
+        assert!(binds.is_empty(), "nothing may be bound for a dropped key");
+        assert_eq!(param, 4, "the parameter counter must not advance");
+    }
+
+    #[test]
+    fn an_undeclared_key_does_not_disturb_the_numbering_of_declared_ones() {
+        let mut param = 4;
+        let mut binds = Vec::new();
+        let sql = filter_sql(
+            &definition(),
+            &SearchFilter::default()
+                .equals("aaa_not_a_field", "x")
+                .equals("title", "Hello"),
+            &mut param,
+            &mut binds,
+        );
+
+        // BTreeMap order puts the bogus key first; the real one must still
+        // bind at $4.
+        assert!(sql.contains("fields ->> 'title' = $4"), "{sql}");
+        assert!(sql.contains("AND FALSE"), "{sql}");
+        assert_eq!(binds, vec![Bound::Text("Hello".to_owned())]);
+        assert_eq!(param, 5);
+    }
+
+    #[test]
+    fn the_reserved_tenant_key_is_still_honoured() {
+        let mut param = 2;
+        let mut binds = Vec::new();
+        let sql = filter_sql(
+            &definition(),
+            &SearchFilter::default().equals(crate::backend::TENANT_FILTER_KEY, "acme"),
+            &mut param,
+            &mut binds,
+        );
+        assert_eq!(sql, " AND tenant_id = $2");
+        assert_eq!(binds, vec![Bound::Text("acme".to_owned())]);
     }
 
     #[test]

--- a/autumn-search/src/postgres.rs
+++ b/autumn-search/src/postgres.rs
@@ -1,0 +1,1025 @@
+//! The Postgres [`SearchBackend`] and [`DocumentSource`].
+//!
+//! Reuses the in-core FTS primitives from #842 — `to_tsvector` / `setweight` /
+//! `plainto_tsquery` / `ts_rank_cd` — and adds vectors, with `pgvector` when
+//! the extension is available.
+//!
+//! # Why a framework-owned index table
+//!
+//! Documents live in **one** table, `autumn_search_documents`, keyed
+//! `(index_name, record_id)`, rather than in each model's own `search_vector`
+//! column. That buys three things the per-table column cannot:
+//!
+//! - the index is **engine-agnostic** — swapping to Meilisearch changes the
+//!   backend, not every model's migration;
+//! - it is **observable and repairable** — you can count, diff, and purge the
+//!   index without touching the system of record;
+//! - a **backfill** and an incremental reindex write through the exact same
+//!   path, so bootstrapping and steady state cannot disagree.
+//!
+//! The model's own `#[searchable]` column (and `#[repository(searchable)]`'s
+//! `search()`) is untouched: this subsumes #842 as one backend, it does not
+//! replace it.
+//!
+//! # Vectors: `pgvector` when present, portable when not
+//!
+//! `ensure_index` probes for the `vector` extension. When it is installed
+//! **and** `search.embedding_dimensions` is configured, embeddings are written
+//! to a `vector(N)` column with an ivfflat index and k-NN uses the `<=>`
+//! cosine-distance operator. Otherwise they are written to a portable
+//! `double precision[]` column and ranked with an `autumn_search_cosine()` SQL
+//! function created by the same migration. Same API, same ordering, different
+//! speed — so the plugin is deployable on a managed Postgres without
+//! `pgvector`, and gets the fast path for free where it exists.
+
+use std::sync::{OnceLock, RwLock};
+
+use autumn_web::pagination::Page;
+use autumn_web::search::{IndexDefinition, SearchDocument};
+use diesel::sql_types::{BigInt, Double, Nullable, Text};
+use diesel_async::RunQueryDsl;
+use diesel_async::pooled_connection::deadpool::Pool;
+
+use crate::backend::{
+    BackendCapabilities, BoxFuture, IndexedDocument, KeywordQuery, SearchBackend, SearchFilter,
+    SearchHit, VectorQuery, empty_page,
+};
+use crate::error::{SearchError, SearchResult};
+use crate::source::DocumentSource;
+use crate::text::query_tokens;
+
+type RuntimePool = Pool<autumn_web::RuntimeConnection>;
+
+/// Physical table every index's documents live in.
+pub const DOCUMENTS_TABLE: &str = "autumn_search_documents";
+
+/// How embeddings are physically stored.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum VectorMode {
+    /// `pgvector` is installed and a dimension is configured: a `vector(N)`
+    /// column plus an ivfflat index, queried with `<=>`.
+    PgVector {
+        /// Declared embedding width.
+        dimensions: usize,
+    },
+    /// Portable fallback: `double precision[]` ranked by an
+    /// `autumn_search_cosine()` SQL function.
+    Array,
+}
+
+impl VectorMode {
+    /// Whether this mode uses the `pgvector` extension.
+    #[must_use]
+    pub const fn is_pgvector(self) -> bool {
+        matches!(self, Self::PgVector { .. })
+    }
+}
+
+// ── Rows ────────────────────────────────────────────────────────────────────
+
+#[derive(diesel::QueryableByName)]
+struct HitRow {
+    #[diesel(sql_type = BigInt)]
+    record_id: i64,
+    #[diesel(sql_type = Double)]
+    score: f64,
+}
+
+#[derive(diesel::QueryableByName)]
+struct CountRow {
+    #[diesel(sql_type = BigInt)]
+    total: i64,
+}
+
+#[derive(diesel::QueryableByName)]
+struct EmbeddingRow {
+    #[diesel(sql_type = Nullable<Text>)]
+    embedding: Option<String>,
+}
+
+#[derive(diesel::QueryableByName)]
+struct SourceRow {
+    #[diesel(sql_type = BigInt)]
+    id: i64,
+    #[diesel(sql_type = Text)]
+    fields: String,
+    #[diesel(sql_type = Nullable<Text>)]
+    tenant_id: Option<String>,
+}
+
+#[derive(diesel::QueryableByName)]
+struct ExistsRow {
+    #[diesel(sql_type = diesel::sql_types::Bool)]
+    present: bool,
+}
+
+// ── The store ───────────────────────────────────────────────────────────────
+
+/// Postgres-backed search storage.
+///
+/// Implements **both** [`SearchBackend`] (the index) and [`DocumentSource`]
+/// (reading records back out of their own tables), because both need the same
+/// connection pool and the same identifier-safety rules. `SearchPlugin::postgres()`
+/// installs one instance as both.
+///
+/// The pool is installed at startup ([`PostgresSearchStore::install_pool`]),
+/// so the store can be constructed by the plugin builder before an `AppState`
+/// exists.
+pub struct PostgresSearchStore {
+    pool: OnceLock<RuntimePool>,
+    /// Configured embedding width; `None` disables the `pgvector` fast path.
+    dimensions: Option<usize>,
+    /// Resolved at `ensure_index` time, once per process.
+    vector_mode: RwLock<Option<VectorMode>>,
+}
+
+impl std::fmt::Debug for PostgresSearchStore {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PostgresSearchStore")
+            .field("pool_installed", &self.pool.get().is_some())
+            .field("dimensions", &self.dimensions)
+            .field("vector_mode", &self.vector_mode())
+            .finish()
+    }
+}
+
+impl PostgresSearchStore {
+    /// Create a store whose pool is installed later.
+    #[must_use]
+    pub const fn new(dimensions: Option<usize>) -> Self {
+        Self {
+            pool: OnceLock::new(),
+            dimensions,
+            vector_mode: RwLock::new(None),
+        }
+    }
+
+    /// Install the application's connection pool. Idempotent; the first call
+    /// wins.
+    pub fn install_pool(&self, pool: RuntimePool) {
+        let _ = self.pool.set(pool);
+    }
+
+    /// The resolved vector storage mode, once `ensure_index` has run.
+    #[must_use]
+    pub fn vector_mode(&self) -> Option<VectorMode> {
+        self.vector_mode.read().ok().and_then(|guard| *guard)
+    }
+
+    fn pool(&self) -> SearchResult<&RuntimePool> {
+        self.pool.get().ok_or_else(|| {
+            SearchError::Backend(
+                "the search store has no database pool; is `database.primary_url` configured?"
+                    .to_owned(),
+            )
+        })
+    }
+
+    async fn conn(
+        &self,
+    ) -> SearchResult<
+        diesel_async::pooled_connection::deadpool::Object<autumn_web::RuntimeConnection>,
+    > {
+        self.pool()?.get().await.map_err(SearchError::backend)
+    }
+}
+
+/// Narrow a SQL `double precision` score to the `f32` a [`SearchHit`] carries.
+///
+/// Relevance scores are ranking-only and comparable within a single result
+/// set, so `f32` precision is ample; the saturating cast keeps an out-of-range
+/// value finite rather than turning it into an infinity that would poison a
+/// sort.
+#[allow(
+    clippy::cast_possible_truncation,
+    reason = "scores are ranking-only; f32 precision is deliberate"
+)]
+const fn narrow_score(score: f64) -> f32 {
+    if score.is_finite() { score as f32 } else { 0.0 }
+}
+
+/// Validate a definition and return it, so no caller can interpolate an
+/// unvalidated identifier into SQL.
+fn checked(definition: &IndexDefinition) -> SearchResult<()> {
+    definition
+        .validate()
+        .map_err(|e| SearchError::InvalidIndex(e.to_string()))
+}
+
+/// Render an embedding as a Postgres `double precision[]` literal.
+///
+/// Values are `f32`, so every element is a finite decimal produced by Rust's
+/// own float formatting — there is no path for caller text to reach this
+/// string. Non-finite values are clamped to `0`, which keeps a malformed
+/// embedding from producing invalid SQL.
+fn array_literal(vector: &[f32]) -> String {
+    let mut out = String::with_capacity(vector.len() * 8 + 2);
+    out.push('{');
+    for (index, value) in vector.iter().enumerate() {
+        if index > 0 {
+            out.push(',');
+        }
+        let value = if value.is_finite() { *value } else { 0.0 };
+        out.push_str(&value.to_string());
+    }
+    out.push('}');
+    out
+}
+
+/// Render an embedding as a `pgvector` literal (`[1,2,3]`).
+fn vector_literal(vector: &[f32]) -> String {
+    let mut out = String::with_capacity(vector.len() * 8 + 2);
+    out.push('[');
+    for (index, value) in vector.iter().enumerate() {
+        if index > 0 {
+            out.push(',');
+        }
+        let value = if value.is_finite() { *value } else { 0.0 };
+        out.push_str(&value.to_string());
+    }
+    out.push(']');
+    out
+}
+
+/// Parse a `double precision[]` / `vector` text representation back to `f32`s.
+fn parse_vector(raw: &str) -> Vec<f32> {
+    raw.trim_matches(['{', '}', '[', ']'])
+        .split(',')
+        .filter(|part| !part.trim().is_empty())
+        .filter_map(|part| part.trim().parse::<f32>().ok())
+        .collect()
+}
+
+/// SQL fragment restricting a query to `filter`, plus the parameters it needs.
+///
+/// Only **literal, developer-controlled** values are interpolated: record ids
+/// (`i64`, formatted by Rust) and field names already validated as bare
+/// identifiers. Every caller-supplied *value* is bound, never interpolated.
+fn filter_sql(filter: &SearchFilter, next_param: &mut usize, binds: &mut Vec<String>) -> String {
+    use std::fmt::Write as _;
+
+    let mut sql = String::new();
+
+    if let Some(tenant) = &filter.tenant_id {
+        let _ = write!(sql, " AND tenant_id = ${next_param}");
+        binds.push(tenant.clone());
+        *next_param += 1;
+    }
+    if let Some(allowed) = &filter.allowed_ids {
+        if allowed.is_empty() {
+            // Unreachable in practice (callers short-circuit on
+            // `matches_nothing`), but keep the SQL itself fail-closed.
+            sql.push_str(" AND FALSE");
+        } else {
+            let ids: Vec<String> = allowed.iter().map(i64::to_string).collect();
+            let _ = write!(sql, " AND record_id IN ({})", ids.join(","));
+        }
+    }
+    if !filter.excluded_ids.is_empty() {
+        let ids: Vec<String> = filter.excluded_ids.iter().map(i64::to_string).collect();
+        let _ = write!(sql, " AND record_id NOT IN ({})", ids.join(","));
+    }
+    for (field, value) in &filter.equals {
+        if field == crate::backend::TENANT_FILTER_KEY {
+            let _ = write!(sql, " AND tenant_id = ${next_param}");
+        } else {
+            // `field` is an indexed field name, already validated as a bare
+            // identifier by `IndexDefinition::validate`; the *value* is bound.
+            let _ = write!(sql, " AND fields ->> '{field}' = ${next_param}");
+        }
+        binds.push(value.clone());
+        *next_param += 1;
+    }
+    sql
+}
+
+impl SearchBackend for PostgresSearchStore {
+    fn name(&self) -> &'static str {
+        "postgres"
+    }
+
+    fn capabilities(&self) -> BackendCapabilities {
+        BackendCapabilities {
+            keyword: true,
+            vector: true,
+            weighted_fields: true,
+            embedding_readback: true,
+        }
+    }
+
+    fn ensure_index<'a>(
+        &'a self,
+        definition: &'a IndexDefinition,
+    ) -> BoxFuture<'a, SearchResult<()>> {
+        Box::pin(async move {
+            checked(definition)?;
+            let mut conn = self.conn().await?;
+
+            for statement in SCHEMA_STATEMENTS {
+                diesel::sql_query(*statement)
+                    .execute(&mut conn)
+                    .await
+                    .map_err(SearchError::backend)?;
+            }
+
+            // Resolve the vector storage mode once per process. A managed
+            // Postgres without `pgvector` must still work, so a failed
+            // `CREATE EXTENSION` degrades rather than aborting boot.
+            if self.vector_mode().is_none() {
+                let mode = match self.dimensions {
+                    Some(dimensions) if self.try_enable_pgvector(dimensions).await? => {
+                        VectorMode::PgVector { dimensions }
+                    }
+                    _ => VectorMode::Array,
+                };
+                if let Ok(mut guard) = self.vector_mode.write() {
+                    *guard = Some(mode);
+                }
+                tracing::info!(?mode, "autumn-search postgres vector storage resolved");
+            }
+            Ok(())
+        })
+    }
+
+    fn index<'a>(
+        &'a self,
+        definition: &'a IndexDefinition,
+        documents: &'a [IndexedDocument],
+    ) -> BoxFuture<'a, SearchResult<()>> {
+        use std::fmt::Write as _;
+
+        Box::pin(async move {
+            checked(definition)?;
+            if documents.is_empty() {
+                return Ok(());
+            }
+            let mut conn = self.conn().await?;
+            let pgvector = self.vector_mode().is_some_and(VectorMode::is_pgvector);
+
+            for document in documents {
+                // The weighted tsvector, built exactly as #842 does:
+                // `setweight(to_tsvector(<lang>, <value>), <weight>)` per
+                // field, concatenated. Every value is BOUND; only the language
+                // dictionary and the weight letter — both from the validated
+                // definition — are interpolated.
+                //
+                // Bound parameters: $1 index_name, $2 tenant_id, $3 fields
+                // json, $4 language, $5 content, then one per field value.
+                let mut vector_sql = String::new();
+                let mut binds: Vec<String> = Vec::new();
+                for (param, field) in (6_usize..).zip(document.document.fields.iter()) {
+                    if !vector_sql.is_empty() {
+                        vector_sql.push_str(" || ");
+                    }
+                    let _ = write!(
+                        vector_sql,
+                        "setweight(to_tsvector($4::regconfig, ${param}), '{}')",
+                        field.weight
+                    );
+                    binds.push(field.value.clone());
+                }
+                if vector_sql.is_empty() {
+                    "to_tsvector($4::regconfig, '')".clone_into(&mut vector_sql);
+                }
+
+                let embedding = document.embedding.as_ref().map_or_else(
+                    || "NULL".to_owned(),
+                    |v| format!("'{}'::double precision[]", array_literal(v)),
+                );
+
+                // `embedding_vec` only exists when `try_enable_pgvector`
+                // added it, so it must be absent from the column list in the
+                // portable mode — naming a column that does not exist would
+                // fail every write.
+                let (vec_column, vec_value, vec_update) = if pgvector {
+                    let value = document.embedding.as_ref().map_or_else(
+                        || "NULL".to_owned(),
+                        |v| format!("'{}'::vector", vector_literal(v)),
+                    );
+                    (
+                        ", embedding_vec",
+                        format!(", {value}"),
+                        ", embedding_vec = EXCLUDED.embedding_vec",
+                    )
+                } else {
+                    ("", String::new(), "")
+                };
+
+                let sql = format!(
+                    "INSERT INTO {DOCUMENTS_TABLE} \
+                       (index_name, record_id, tenant_id, language, fields, content, \
+                        search_vector, embedding{vec_column}) \
+                     VALUES ($1, {id}, $2, $4, $3::jsonb, $5, {vector_sql}, {embedding}{vec_value}) \
+                     ON CONFLICT (index_name, record_id) DO UPDATE SET \
+                       tenant_id = EXCLUDED.tenant_id, \
+                       language = EXCLUDED.language, \
+                       fields = EXCLUDED.fields, \
+                       content = EXCLUDED.content, \
+                       search_vector = EXCLUDED.search_vector, \
+                       embedding = EXCLUDED.embedding{vec_update}, \
+                       updated_at = NOW()",
+                    id = document.id(),
+                );
+
+                let fields_json = serde_json::to_string(
+                    &document
+                        .document
+                        .fields
+                        .iter()
+                        .map(|f| (f.name, f.value.clone()))
+                        .collect::<std::collections::BTreeMap<_, _>>(),
+                )
+                .map_err(SearchError::backend)?;
+
+                let mut query = diesel::sql_query(sql)
+                    .into_boxed::<autumn_web::RuntimeBackend>()
+                    .bind::<Text, _>(definition.name.to_owned())
+                    .bind::<Nullable<Text>, _>(document.document.tenant_id.clone())
+                    .bind::<Text, _>(fields_json)
+                    .bind::<Text, _>(definition.language.to_owned())
+                    .bind::<Text, _>(document.document.text());
+                for value in binds {
+                    query = query.bind::<Text, _>(value);
+                }
+                query
+                    .execute(&mut conn)
+                    .await
+                    .map_err(SearchError::backend)?;
+            }
+            Ok(())
+        })
+    }
+
+    fn delete<'a>(
+        &'a self,
+        definition: &'a IndexDefinition,
+        ids: &'a [i64],
+    ) -> BoxFuture<'a, SearchResult<()>> {
+        Box::pin(async move {
+            checked(definition)?;
+            if ids.is_empty() {
+                return Ok(());
+            }
+            let mut conn = self.conn().await?;
+            let list: Vec<String> = ids.iter().map(i64::to_string).collect();
+            diesel::sql_query(format!(
+                "DELETE FROM {DOCUMENTS_TABLE} WHERE index_name = $1 AND record_id IN ({})",
+                list.join(",")
+            ))
+            .bind::<Text, _>(definition.name.to_owned())
+            .execute(&mut conn)
+            .await
+            .map_err(SearchError::backend)?;
+            Ok(())
+        })
+    }
+
+    fn clear<'a>(&'a self, definition: &'a IndexDefinition) -> BoxFuture<'a, SearchResult<()>> {
+        Box::pin(async move {
+            checked(definition)?;
+            let mut conn = self.conn().await?;
+            diesel::sql_query(format!(
+                "DELETE FROM {DOCUMENTS_TABLE} WHERE index_name = $1"
+            ))
+            .bind::<Text, _>(definition.name.to_owned())
+            .execute(&mut conn)
+            .await
+            .map_err(SearchError::backend)?;
+            Ok(())
+        })
+    }
+
+    fn keyword_search<'a>(
+        &'a self,
+        definition: &'a IndexDefinition,
+        query: &'a KeywordQuery,
+    ) -> BoxFuture<'a, SearchResult<Page<SearchHit>>> {
+        Box::pin(async move {
+            checked(definition)?;
+            // Fail closed: a blank query and an impossible filter both return
+            // an empty page having issued NO query — never a full scan.
+            if query_tokens(&query.text).is_none() || query.filter.matches_nothing() {
+                return Ok(empty_page(&query.page));
+            }
+
+            let mut conn = self.conn().await?;
+            // $1 index_name, $2 language, $3 query text.
+            let mut param = 4_usize;
+            let mut binds: Vec<String> = Vec::new();
+            let predicate = filter_sql(&query.filter, &mut param, &mut binds);
+
+            // `plainto_tsquery` (not `websearch_to_tsquery`): the documented
+            // cross-backend contract is "every token must match, operators are
+            // not syntax". It is parameterized, so a hostile query string can
+            // neither inject nor widen the result set.
+            let where_clause = format!(
+                "index_name = $1 AND search_vector @@ plainto_tsquery($2::regconfig, $3){predicate}"
+            );
+
+            let mut count = diesel::sql_query(format!(
+                "SELECT COUNT(*)::bigint AS total FROM {DOCUMENTS_TABLE} WHERE {where_clause}"
+            ))
+            .into_boxed::<autumn_web::RuntimeBackend>()
+            .bind::<Text, _>(definition.name.to_owned())
+            .bind::<Text, _>(definition.language.to_owned())
+            .bind::<Text, _>(query.text.clone());
+            for value in &binds {
+                count = count.bind::<Text, _>(value.clone());
+            }
+            let total = count
+                .get_result::<CountRow>(&mut conn)
+                .await
+                .map_err(SearchError::backend)?
+                .total;
+
+            let size = i64::from(query.page.size());
+            let offset = i64::from(query.page.page().saturating_sub(1)) * size;
+            let mut rows = diesel::sql_query(format!(
+                "SELECT record_id, \
+                        ts_rank_cd(search_vector, plainto_tsquery($2::regconfig, $3))::double precision AS score \
+                 FROM {DOCUMENTS_TABLE} WHERE {where_clause} \
+                 ORDER BY score DESC, record_id ASC LIMIT {size} OFFSET {offset}"
+            ))
+            .into_boxed::<autumn_web::RuntimeBackend>()
+            .bind::<Text, _>(definition.name.to_owned())
+            .bind::<Text, _>(definition.language.to_owned())
+            .bind::<Text, _>(query.text.clone());
+            for value in &binds {
+                rows = rows.bind::<Text, _>(value.clone());
+            }
+            let hits = rows
+                .load::<HitRow>(&mut conn)
+                .await
+                .map_err(SearchError::backend)?;
+
+            Ok(Page::new(
+                hits.into_iter()
+                    .map(|row| {
+                        SearchHit::new(definition.name, row.record_id, narrow_score(row.score))
+                    })
+                    .collect(),
+                total,
+                &query.page,
+            ))
+        })
+    }
+
+    fn vector_search<'a>(
+        &'a self,
+        definition: &'a IndexDefinition,
+        query: &'a VectorQuery,
+    ) -> BoxFuture<'a, SearchResult<Vec<SearchHit>>> {
+        Box::pin(async move {
+            checked(definition)?;
+            if !definition.supports_vector_search() {
+                return Err(SearchError::VectorUnsupported {
+                    index: definition.name.to_owned(),
+                });
+            }
+            if query.filter.matches_nothing() || query.limit == 0 || query.vector.is_empty() {
+                return Ok(Vec::new());
+            }
+
+            let mut conn = self.conn().await?;
+            let mut param = 2_usize; // $1 index_name
+            let mut binds: Vec<String> = Vec::new();
+            let predicate = filter_sql(&query.filter, &mut param, &mut binds);
+
+            // Cosine *similarity* in both modes, so the two paths order
+            // identically: pgvector's `<=>` is cosine distance, hence `1 - d`.
+            //
+            // Width mismatch: `<=>` errors on it, while `unnest(a, b)` would
+            // silently pad the shorter array with NULLs and return a wrong
+            // score. The portable path therefore filters mismatched documents
+            // out with `array_length`, so a re-embedding at a new width
+            // degrades to "no results" rather than to wrong results. (The
+            // in-memory backend raises `DimensionMismatch` instead — it can
+            // afford to inspect every document; SQL cannot.)
+            let width = query.vector.len();
+            let (score_expr, embedding_predicate) =
+                if self.vector_mode().is_some_and(VectorMode::is_pgvector) {
+                    (
+                        format!(
+                            "(1 - (embedding_vec <=> '{}'::vector))::double precision",
+                            vector_literal(&query.vector)
+                        ),
+                        "embedding_vec IS NOT NULL".to_owned(),
+                    )
+                } else {
+                    (
+                        format!(
+                            "autumn_search_cosine(embedding, '{}'::double precision[])",
+                            array_literal(&query.vector)
+                        ),
+                        format!("embedding IS NOT NULL AND array_length(embedding, 1) = {width}"),
+                    )
+                };
+
+            // Only emit the threshold when one was asked for: it repeats the
+            // (non-trivial) score expression, so an unconditional
+            // `>= -3.4e38` would be pure cost.
+            let threshold = query
+                .min_score
+                .map_or_else(String::new, |min| format!(" AND {score_expr} >= {min}"));
+            let limit = query.limit;
+            let mut rows = diesel::sql_query(format!(
+                "SELECT record_id, {score_expr} AS score FROM {DOCUMENTS_TABLE} \
+                 WHERE index_name = $1 AND {embedding_predicate}{predicate}{threshold} \
+                 ORDER BY score DESC, record_id ASC LIMIT {limit}"
+            ))
+            .into_boxed::<autumn_web::RuntimeBackend>()
+            .bind::<Text, _>(definition.name.to_owned());
+            for value in &binds {
+                rows = rows.bind::<Text, _>(value.clone());
+            }
+            let hits = rows
+                .load::<HitRow>(&mut conn)
+                .await
+                .map_err(SearchError::backend)?;
+
+            Ok(hits
+                .into_iter()
+                .map(|row| SearchHit::new(definition.name, row.record_id, narrow_score(row.score)))
+                .collect())
+        })
+    }
+
+    fn embedding<'a>(
+        &'a self,
+        definition: &'a IndexDefinition,
+        id: i64,
+    ) -> BoxFuture<'a, SearchResult<Option<Vec<f32>>>> {
+        Box::pin(async move {
+            checked(definition)?;
+            let mut conn = self.conn().await?;
+            let row = diesel::sql_query(format!(
+                "SELECT embedding::text AS embedding FROM {DOCUMENTS_TABLE} \
+                 WHERE index_name = $1 AND record_id = {id}"
+            ))
+            .bind::<Text, _>(definition.name.to_owned())
+            .get_results::<EmbeddingRow>(&mut conn)
+            .await
+            .map_err(SearchError::backend)?;
+
+            Ok(row
+                .into_iter()
+                .next()
+                .and_then(|row| row.embedding)
+                .map(|raw| parse_vector(&raw)))
+        })
+    }
+}
+
+impl PostgresSearchStore {
+    /// Try to install `pgvector` and add the accelerated column + index.
+    ///
+    /// Returns `false` (rather than erroring) when the extension is not
+    /// available: the portable array path is a complete implementation, so a
+    /// managed Postgres without `pgvector` must boot, not crash.
+    async fn try_enable_pgvector(&self, dimensions: usize) -> SearchResult<bool> {
+        let mut conn = self.conn().await?;
+
+        if diesel::sql_query("CREATE EXTENSION IF NOT EXISTS vector")
+            .execute(&mut conn)
+            .await
+            .is_err()
+        {
+            tracing::info!(
+                "pgvector is not available; autumn-search will store embeddings as \
+                 double precision[] and rank with autumn_search_cosine()"
+            );
+            return Ok(false);
+        }
+
+        let present = diesel::sql_query(
+            "SELECT EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'vector') AS present",
+        )
+        .get_result::<ExistsRow>(&mut conn)
+        .await
+        .map_err(SearchError::backend)?
+        .present;
+        if !present {
+            return Ok(false);
+        }
+
+        // `dimensions` is a `usize` from config, formatted by Rust — no caller
+        // text reaches this statement.
+        diesel::sql_query(format!(
+            "ALTER TABLE {DOCUMENTS_TABLE} ADD COLUMN IF NOT EXISTS embedding_vec vector({dimensions})"
+        ))
+        .execute(&mut conn)
+        .await
+        .map_err(SearchError::backend)?;
+
+        // Best-effort: an ivfflat index needs training data and fails on an
+        // empty table in some versions. Its absence costs speed, not
+        // correctness, so never fail boot for it.
+        let _ = diesel::sql_query(format!(
+            "CREATE INDEX IF NOT EXISTS autumn_search_documents_embedding_vec_idx \
+             ON {DOCUMENTS_TABLE} USING ivfflat (embedding_vec vector_cosine_ops)"
+        ))
+        .execute(&mut conn)
+        .await;
+
+        Ok(true)
+    }
+}
+
+// ── Document source ─────────────────────────────────────────────────────────
+
+impl DocumentSource for PostgresSearchStore {
+    fn fetch<'a>(
+        &'a self,
+        definition: &'a IndexDefinition,
+        ids: &'a [i64],
+    ) -> BoxFuture<'a, SearchResult<Vec<SearchDocument>>> {
+        Box::pin(async move {
+            checked(definition)?;
+            if ids.is_empty() {
+                return Ok(Vec::new());
+            }
+            let list: Vec<String> = ids.iter().map(i64::to_string).collect();
+            self.load_documents(
+                definition,
+                &format!("WHERE id IN ({})", list.join(",")),
+                None,
+            )
+            .await
+        })
+    }
+
+    fn scan<'a>(
+        &'a self,
+        definition: &'a IndexDefinition,
+        after: Option<i64>,
+        limit: usize,
+    ) -> BoxFuture<'a, SearchResult<Vec<SearchDocument>>> {
+        Box::pin(async move {
+            checked(definition)?;
+            let where_clause =
+                after.map_or_else(String::new, |after| format!("WHERE id > {after}"));
+            self.load_documents(definition, &where_clause, Some(limit))
+                .await
+        })
+    }
+}
+
+impl PostgresSearchStore {
+    /// Project a model's table into `(id, fields json, tenant_id)`.
+    ///
+    /// Fully generic: the column list comes from the validated
+    /// [`IndexDefinition`], so no per-model code is generated anywhere. The
+    /// values are returned as one JSON object rather than N columns, which is
+    /// what lets a single `QueryableByName` struct serve every model.
+    async fn load_documents(
+        &self,
+        definition: &IndexDefinition,
+        where_clause: &str,
+        limit: Option<usize>,
+    ) -> SearchResult<Vec<SearchDocument>> {
+        // ONE connection for both statements: acquiring a second while holding
+        // the first deadlocks a small pool.
+        let mut conn = self.conn().await?;
+
+        let has_tenant = diesel::sql_query(
+            "SELECT EXISTS ( \
+               SELECT 1 FROM information_schema.columns \
+               WHERE table_schema = current_schema() \
+                 AND table_name = $1 \
+                 AND column_name = 'tenant_id' \
+             ) AS present",
+        )
+        .bind::<Text, _>(definition.name.to_owned())
+        .get_result::<ExistsRow>(&mut conn)
+        .await
+        .map_err(SearchError::backend)?
+        .present;
+
+        // Identifiers only — every name here passed `IndexDefinition::validate`.
+        let projection: Vec<String> = definition
+            .fields
+            .iter()
+            .map(|field| format!("'{0}', COALESCE(\"{0}\"::text, '')", field.name))
+            .collect();
+        let tenant = if has_tenant {
+            "tenant_id::text"
+        } else {
+            "NULL::text"
+        };
+        let limit_clause = limit.map_or_else(String::new, |limit| format!(" LIMIT {limit}"));
+
+        let rows = diesel::sql_query(format!(
+            "SELECT id, jsonb_build_object({})::text AS fields, {tenant} AS tenant_id \
+             FROM \"{}\" {where_clause} ORDER BY id ASC{limit_clause}",
+            projection.join(", "),
+            definition.name,
+        ))
+        .load::<SourceRow>(&mut conn)
+        .await
+        .map_err(SearchError::backend)?;
+
+        let mut documents = Vec::with_capacity(rows.len());
+        for row in rows {
+            let values: std::collections::BTreeMap<String, String> =
+                serde_json::from_str(&row.fields).map_err(SearchError::backend)?;
+            let mut document = SearchDocument::new(definition.name, row.id);
+            for field in definition.fields.iter() {
+                let value = values.get(field.name).cloned().unwrap_or_default();
+                document = document.with_field(field.name, field.weight, value);
+            }
+            if let Some(embed) = definition.embed_field
+                && let Some(text) = values.get(embed)
+                && !text.is_empty()
+            {
+                document.embed_text = Some(text.clone());
+            }
+            document.tenant_id = row.tenant_id;
+            documents.push(document);
+        }
+        Ok(documents)
+    }
+}
+
+/// DDL for the framework-owned index, applied idempotently on every boot.
+///
+/// Not a `diesel_migrations` set: the table is plugin-owned infrastructure,
+/// not application schema, and every statement is `IF NOT EXISTS`, so running
+/// it on each boot is both safe and self-repairing.
+const SCHEMA_STATEMENTS: &[&str] = &[
+    "CREATE TABLE IF NOT EXISTS autumn_search_documents (
+        index_name    TEXT        NOT NULL,
+        record_id     BIGINT      NOT NULL,
+        tenant_id     TEXT,
+        language      TEXT        NOT NULL DEFAULT 'simple',
+        fields        JSONB       NOT NULL DEFAULT '{}'::jsonb,
+        content       TEXT        NOT NULL DEFAULT '',
+        search_vector TSVECTOR    NOT NULL DEFAULT to_tsvector('simple', ''),
+        embedding     DOUBLE PRECISION[],
+        updated_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+        PRIMARY KEY (index_name, record_id)
+    )",
+    "CREATE INDEX IF NOT EXISTS autumn_search_documents_vector_idx
+        ON autumn_search_documents USING GIN (search_vector)",
+    "CREATE INDEX IF NOT EXISTS autumn_search_documents_tenant_idx
+        ON autumn_search_documents (index_name, tenant_id)",
+    // Portable cosine similarity for the non-pgvector path. `unnest(a, b)`
+    // walks both arrays in lockstep; a zero-norm vector yields 0 rather than a
+    // division by zero.
+    "CREATE OR REPLACE FUNCTION autumn_search_cosine(a DOUBLE PRECISION[], b DOUBLE PRECISION[])
+     RETURNS DOUBLE PRECISION LANGUAGE sql IMMUTABLE AS $$
+        SELECT COALESCE(
+            SUM(t.x * t.y) / NULLIF(SQRT(SUM(t.x * t.x)) * SQRT(SUM(t.y * t.y)), 0),
+            0
+        )
+        FROM unnest(a, b) AS t(x, y)
+     $$",
+];
+
+#[cfg(test)]
+mod tests {
+    use autumn_web::search::SearchIndexField;
+
+    use super::*;
+
+    const FIELDS: &[SearchIndexField] = &[
+        SearchIndexField::new("title", 'A'),
+        SearchIndexField::new("body", 'B'),
+    ];
+
+    fn definition() -> IndexDefinition {
+        IndexDefinition::new("articles", "english", FIELDS, Some("body"))
+    }
+
+    #[test]
+    fn array_literals_round_trip() {
+        let vector = vec![1.0_f32, -0.5, 0.25];
+        assert_eq!(parse_vector(&array_literal(&vector)), vector);
+        assert_eq!(parse_vector(&vector_literal(&vector)), vector);
+    }
+
+    #[test]
+    fn non_finite_values_never_produce_invalid_sql() {
+        let literal = array_literal(&[f32::NAN, f32::INFINITY, 1.0]);
+        assert_eq!(literal, "{0,0,1}");
+        assert!(!literal.contains("NaN"));
+        assert!(!literal.contains("inf"));
+    }
+
+    #[test]
+    fn parsing_tolerates_empty_and_malformed_elements() {
+        assert!(parse_vector("{}").is_empty());
+        assert!(parse_vector("[]").is_empty());
+        assert_eq!(parse_vector("{1, ,2}"), vec![1.0, 2.0]);
+        assert_eq!(parse_vector("{1,oops,2}"), vec![1.0, 2.0]);
+    }
+
+    #[test]
+    fn an_empty_filter_adds_no_predicate() {
+        let mut param = 2;
+        let mut binds = Vec::new();
+        assert_eq!(
+            filter_sql(&SearchFilter::default(), &mut param, &mut binds),
+            ""
+        );
+        assert_eq!(param, 2);
+        assert!(binds.is_empty());
+    }
+
+    #[test]
+    fn a_tenant_filter_binds_its_value_rather_than_interpolating_it() {
+        let mut param = 2;
+        let mut binds = Vec::new();
+        let sql = filter_sql(
+            &SearchFilter::default().tenant("acme'; DROP TABLE users; --"),
+            &mut param,
+            &mut binds,
+        );
+        assert_eq!(sql, " AND tenant_id = $2");
+        assert_eq!(binds, vec!["acme'; DROP TABLE users; --".to_owned()]);
+        assert_eq!(param, 3);
+    }
+
+    #[test]
+    fn an_empty_allowlist_renders_a_fail_closed_predicate() {
+        let mut param = 2;
+        let mut binds = Vec::new();
+        let sql = filter_sql(
+            &SearchFilter::default().allow_ids(Vec::<i64>::new()),
+            &mut param,
+            &mut binds,
+        );
+        assert!(sql.contains("AND FALSE"), "{sql}");
+    }
+
+    #[test]
+    fn id_lists_are_rendered_from_integers_only() {
+        let mut param = 2;
+        let mut binds = Vec::new();
+        let sql = filter_sql(
+            &SearchFilter::default()
+                .allow_ids([1_i64, 2])
+                .exclude_ids([3_i64]),
+            &mut param,
+            &mut binds,
+        );
+        assert!(sql.contains("record_id IN (1,2)"), "{sql}");
+        assert!(sql.contains("record_id NOT IN (3)"), "{sql}");
+        assert!(binds.is_empty(), "ids are integers, nothing to bind");
+    }
+
+    #[test]
+    fn equals_predicates_bind_values_and_number_parameters_in_order() {
+        let mut param = 4;
+        let mut binds = Vec::new();
+        let sql = filter_sql(
+            &SearchFilter::default()
+                .equals("title", "Hello")
+                .equals("body", "World"),
+            &mut param,
+            &mut binds,
+        );
+        // BTreeMap iterates in key order: body, then title.
+        assert!(sql.contains("fields ->> 'body' = $4"), "{sql}");
+        assert!(sql.contains("fields ->> 'title' = $5"), "{sql}");
+        assert_eq!(binds, vec!["World".to_owned(), "Hello".to_owned()]);
+        assert_eq!(param, 6);
+    }
+
+    #[test]
+    fn an_invalid_definition_is_rejected_before_any_sql_is_built() {
+        let mut bad = definition();
+        bad.name = "articles\"; DROP TABLE users; --";
+        assert!(matches!(checked(&bad), Err(SearchError::InvalidIndex(_))));
+        assert!(checked(&definition()).is_ok());
+    }
+
+    #[test]
+    fn the_schema_is_idempotent_by_construction() {
+        for statement in SCHEMA_STATEMENTS {
+            let statement = statement.trim_start();
+            assert!(
+                statement.contains("IF NOT EXISTS") || statement.starts_with("CREATE OR REPLACE"),
+                "not idempotent: {statement}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_store_without_a_pool_reports_the_missing_configuration() {
+        let store = PostgresSearchStore::new(None);
+        let Err(error) = store.pool() else {
+            panic!("a store with no installed pool must not report one");
+        };
+        assert!(
+            error.to_string().contains("database.primary_url"),
+            "{error}"
+        );
+        assert!(store.vector_mode().is_none());
+    }
+
+    #[test]
+    fn vector_mode_reports_whether_pgvector_is_in_use() {
+        assert!(VectorMode::PgVector { dimensions: 4 }.is_pgvector());
+        assert!(!VectorMode::Array.is_pgvector());
+    }
+}

--- a/autumn-search/src/source.rs
+++ b/autumn-search/src/source.rs
@@ -16,7 +16,7 @@ use std::sync::RwLock;
 use autumn_web::search::{IndexDefinition, SearchDocument, SearchIndexed};
 
 use crate::backend::BoxFuture;
-use crate::error::{SearchError, SearchResult};
+use crate::error::SearchResult;
 
 /// Reads records out of the system of record and extracts them into
 /// [`SearchDocument`]s.
@@ -65,24 +65,27 @@ impl MemoryDocumentSource {
 
     /// Insert or replace `record`'s document.
     pub fn upsert<M: SearchIndexed>(&self, record: &M) {
-        let document = record.search_document();
-        if let Ok(mut guard) = self.documents.write() {
-            guard.insert((document.index.to_owned(), document.id), document);
-        }
+        self.upsert_document(record.search_document());
     }
 
     /// Insert or replace an already-extracted document.
     pub fn upsert_document(&self, document: SearchDocument) {
-        if let Ok(mut guard) = self.documents.write() {
-            guard.insert((document.index.to_owned(), document.id), document);
-        }
+        // `PoisonError::into_inner` rather than `if let Ok(...)`: swallowing a
+        // poisoned lock would make every subsequent write a silent no-op that
+        // still looks like a success.
+        let mut guard = self
+            .documents
+            .write()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        guard.insert((document.index.to_owned(), document.id), document);
     }
 
     /// Remove a record from every index in this source.
     pub fn remove(&self, id: i64) {
-        if let Ok(mut guard) = self.documents.write() {
-            guard.retain(|(_, key), _| *key != id);
-        }
+        self.documents
+            .write()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .retain(|(_, key), _| *key != id);
     }
 
     /// How many times `id` has been fetched.
@@ -90,14 +93,19 @@ impl MemoryDocumentSource {
     pub fn fetch_calls_for(&self, id: i64) -> usize {
         self.fetches
             .read()
-            .map_or(0, |guard| guard.get(&id).copied().unwrap_or(0))
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .get(&id)
+            .copied()
+            .unwrap_or(0)
     }
 
     fn record_fetch(&self, ids: &[i64]) {
-        if let Ok(mut guard) = self.fetches.write() {
-            for id in ids {
-                *guard.entry(*id).or_insert(0) += 1;
-            }
+        let mut guard = self
+            .fetches
+            .write()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        for id in ids {
+            *guard.entry(*id).or_insert(0) += 1;
         }
     }
 }
@@ -113,7 +121,7 @@ impl DocumentSource for MemoryDocumentSource {
             let guard = self
                 .documents
                 .read()
-                .map_err(|_| SearchError::Backend("document source lock poisoned".to_owned()))?;
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
             Ok(ids
                 .iter()
                 .filter_map(|id| guard.get(&(definition.name.to_owned(), *id)).cloned())
@@ -131,7 +139,7 @@ impl DocumentSource for MemoryDocumentSource {
             let guard = self
                 .documents
                 .read()
-                .map_err(|_| SearchError::Backend("document source lock poisoned".to_owned()))?;
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
             Ok(guard
                 .iter()
                 .filter(|((index, id), _)| {
@@ -153,7 +161,7 @@ mod tests {
     const FIELDS: &[SearchIndexField] = &[SearchIndexField::new("title", 'A')];
 
     fn definition() -> IndexDefinition {
-        IndexDefinition::new("articles", "simple", FIELDS, None)
+        IndexDefinition::new("articles", "simple", FIELDS, None, false)
     }
 
     fn document(id: i64) -> SearchDocument {

--- a/autumn-search/src/source.rs
+++ b/autumn-search/src/source.rs
@@ -1,0 +1,214 @@
+//! Where reindex and backfill read records from.
+//!
+//! The reindex job deliberately does **not** carry the record in its payload.
+//! It carries `(index, id)` and re-reads the row, which is what makes the
+//! operation idempotent and self-healing: a replayed job, a lost delete, or a
+//! row changed by direct SQL all converge to the same index state. The
+//! backfill walks the same source, so bootstrapping and incremental sync can
+//! never disagree about how a record is extracted.
+//!
+//! [`crate::PostgresSearchStore`] implements this generically from the
+//! [`IndexDefinition`] alone — no per-model generated code.
+
+use std::collections::BTreeMap;
+use std::sync::RwLock;
+
+use autumn_web::search::{IndexDefinition, SearchDocument, SearchIndexed};
+
+use crate::backend::BoxFuture;
+use crate::error::{SearchError, SearchResult};
+
+/// Reads records out of the system of record and extracts them into
+/// [`SearchDocument`]s.
+pub trait DocumentSource: Send + Sync + 'static {
+    /// Fetch the documents for `ids`.
+    ///
+    /// Ids with no row are simply **absent** from the result — that absence is
+    /// the signal the reindex job uses to delete a document, so it must not be
+    /// an error.
+    fn fetch<'a>(
+        &'a self,
+        definition: &'a IndexDefinition,
+        ids: &'a [i64],
+    ) -> BoxFuture<'a, SearchResult<Vec<SearchDocument>>>;
+
+    /// Return up to `limit` documents whose id is greater than `after`,
+    /// ordered by ascending id.
+    ///
+    /// Keyset pagination rather than `OFFSET`: a backfill of a live table must
+    /// not skip or repeat rows when concurrent writes shift offsets.
+    fn scan<'a>(
+        &'a self,
+        definition: &'a IndexDefinition,
+        after: Option<i64>,
+        limit: usize,
+    ) -> BoxFuture<'a, SearchResult<Vec<SearchDocument>>>;
+}
+
+/// An in-memory [`DocumentSource`] for tests and for apps that already hold
+/// their corpus in process.
+///
+/// Also records how many times each id was fetched, so a test can assert that
+/// an operation did **not** re-read the source.
+#[derive(Debug, Default)]
+pub struct MemoryDocumentSource {
+    documents: RwLock<BTreeMap<(String, i64), SearchDocument>>,
+    fetches: RwLock<BTreeMap<i64, usize>>,
+}
+
+impl MemoryDocumentSource {
+    /// Create an empty source.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Insert or replace `record`'s document.
+    pub fn upsert<M: SearchIndexed>(&self, record: &M) {
+        let document = record.search_document();
+        if let Ok(mut guard) = self.documents.write() {
+            guard.insert((document.index.to_owned(), document.id), document);
+        }
+    }
+
+    /// Insert or replace an already-extracted document.
+    pub fn upsert_document(&self, document: SearchDocument) {
+        if let Ok(mut guard) = self.documents.write() {
+            guard.insert((document.index.to_owned(), document.id), document);
+        }
+    }
+
+    /// Remove a record from every index in this source.
+    pub fn remove(&self, id: i64) {
+        if let Ok(mut guard) = self.documents.write() {
+            guard.retain(|(_, key), _| *key != id);
+        }
+    }
+
+    /// How many times `id` has been fetched.
+    #[must_use]
+    pub fn fetch_calls_for(&self, id: i64) -> usize {
+        self.fetches
+            .read()
+            .map_or(0, |guard| guard.get(&id).copied().unwrap_or(0))
+    }
+
+    fn record_fetch(&self, ids: &[i64]) {
+        if let Ok(mut guard) = self.fetches.write() {
+            for id in ids {
+                *guard.entry(*id).or_insert(0) += 1;
+            }
+        }
+    }
+}
+
+impl DocumentSource for MemoryDocumentSource {
+    fn fetch<'a>(
+        &'a self,
+        definition: &'a IndexDefinition,
+        ids: &'a [i64],
+    ) -> BoxFuture<'a, SearchResult<Vec<SearchDocument>>> {
+        Box::pin(async move {
+            self.record_fetch(ids);
+            let guard = self
+                .documents
+                .read()
+                .map_err(|_| SearchError::Backend("document source lock poisoned".to_owned()))?;
+            Ok(ids
+                .iter()
+                .filter_map(|id| guard.get(&(definition.name.to_owned(), *id)).cloned())
+                .collect())
+        })
+    }
+
+    fn scan<'a>(
+        &'a self,
+        definition: &'a IndexDefinition,
+        after: Option<i64>,
+        limit: usize,
+    ) -> BoxFuture<'a, SearchResult<Vec<SearchDocument>>> {
+        Box::pin(async move {
+            let guard = self
+                .documents
+                .read()
+                .map_err(|_| SearchError::Backend("document source lock poisoned".to_owned()))?;
+            Ok(guard
+                .iter()
+                .filter(|((index, id), _)| {
+                    index == definition.name && after.is_none_or(|after| *id > after)
+                })
+                .take(limit)
+                .map(|(_, document)| document.clone())
+                .collect())
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use autumn_web::search::SearchIndexField;
+
+    use super::*;
+
+    const FIELDS: &[SearchIndexField] = &[SearchIndexField::new("title", 'A')];
+
+    fn definition() -> IndexDefinition {
+        IndexDefinition::new("articles", "simple", FIELDS, None)
+    }
+
+    fn document(id: i64) -> SearchDocument {
+        SearchDocument::new("articles", id).with_field("title", 'A', format!("record {id}"))
+    }
+
+    #[tokio::test]
+    async fn fetching_a_missing_id_is_an_absence_not_an_error() {
+        let source = MemoryDocumentSource::new();
+        source.upsert_document(document(1));
+
+        let found = source
+            .fetch(&definition(), &[1, 2])
+            .await
+            .expect("fetch must not error on a missing row");
+        assert_eq!(found.len(), 1);
+        assert_eq!(found[0].id, 1);
+    }
+
+    #[tokio::test]
+    async fn scanning_walks_ids_in_order_via_keyset_pagination() {
+        let source = MemoryDocumentSource::new();
+        for id in 1..=5 {
+            source.upsert_document(document(id));
+        }
+
+        let first = source.scan(&definition(), None, 2).await.expect("scan");
+        assert_eq!(first.iter().map(|d| d.id).collect::<Vec<_>>(), vec![1, 2]);
+
+        let second = source.scan(&definition(), Some(2), 2).await.expect("scan");
+        assert_eq!(second.iter().map(|d| d.id).collect::<Vec<_>>(), vec![3, 4]);
+
+        let last = source.scan(&definition(), Some(5), 2).await.expect("scan");
+        assert!(last.is_empty());
+    }
+
+    #[tokio::test]
+    async fn scanning_is_scoped_to_one_index() {
+        let source = MemoryDocumentSource::new();
+        source.upsert_document(document(1));
+        source.upsert_document(SearchDocument::new("notes", 1).with_field("title", 'A', "note"));
+
+        let articles = source.scan(&definition(), None, 10).await.expect("scan");
+        assert_eq!(articles.len(), 1);
+        assert_eq!(articles[0].index, "articles");
+    }
+
+    #[tokio::test]
+    async fn fetch_calls_are_counted_per_id() {
+        let source = MemoryDocumentSource::new();
+        source.upsert_document(document(1));
+        assert_eq!(source.fetch_calls_for(1), 0);
+        source.fetch(&definition(), &[1]).await.expect("fetch");
+        source.fetch(&definition(), &[1]).await.expect("fetch");
+        assert_eq!(source.fetch_calls_for(1), 2);
+        assert_eq!(source.fetch_calls_for(9), 0);
+    }
+}

--- a/autumn-search/src/sync.rs
+++ b/autumn-search/src/sync.rs
@@ -30,6 +30,28 @@
 //!
 //! An app that already has hooks composes instead of replacing: call
 //! [`enqueue_reindex`] from its own `after_*_commit`.
+//!
+//! # `restore()` and `purge()` are NOT covered
+//!
+//! `#[repository(soft_delete)]` also generates `restore(id)` and `purge(id)`.
+//! Both write to the table directly and do **not** run `MutationHooks`, so no
+//! reindex is enqueued for either — a restored record stays missing from the
+//! index (the earlier soft delete removed its document), and a purged record
+//! can stay searchable. Both persist until the next mutation or a backfill.
+//!
+//! That gap is in the repository macro, not here: these hooks cannot fire for
+//! a call that never invokes them. Until it is closed, converge explicitly:
+//!
+//! ```rust,ignore
+//! repo.restore(id).await?;
+//! autumn_search::enqueue_reindex_for(&repo.find(id).await?).await?;
+//!
+//! repo.purge(id).await?;
+//! autumn_search::enqueue_reindex(&ReindexArgs::delete(Article::SEARCH_INDEX, id)).await?;
+//! ```
+//!
+//! Either instruction is safe to send in either case — the handler re-reads
+//! the row and converges on what it finds, so the op is intent, not a command.
 
 use std::marker::PhantomData;
 

--- a/autumn-search/src/sync.rs
+++ b/autumn-search/src/sync.rs
@@ -1,0 +1,170 @@
+//! Lifecycle-driven index sync.
+//!
+//! AC: "create/update/delete to a searchable model **enqueues a reindex**".
+//!
+//! [`SearchSyncHooks`] is a ready-made `MutationHooks` implementation that
+//! does exactly that and nothing else. Wire it once per searchable repository:
+//!
+//! ```rust,ignore
+//! #[repository(
+//!     Article,
+//!     hooks = SearchSyncHooks<Article, NewArticle, UpdateArticle>,
+//!     commit_hooks = true,
+//! )]
+//! pub trait ArticleRepository {}
+//! ```
+//!
+//! Two deliberate choices:
+//!
+//! - It hangs off the **`after_*_commit`** hooks, so a rolled-back transaction
+//!   never leaves a phantom document, and (with `commit_hooks = true`) the
+//!   intent is written to Autumn's durable commit-hook queue inside the same
+//!   transaction as the mutation. A process dying between commit and enqueue
+//!   is recovered by the queue, not lost.
+//! - It enqueues `(index, id)` and **not the record**. The job re-reads the
+//!   row, so a stale or reordered payload cannot write stale text into the
+//!   index — see [`crate::SearchClient::reindex`].
+//!
+//! An app that already has hooks composes instead of replacing: call
+//! [`enqueue_reindex`] from its own `after_*_commit`.
+
+use std::marker::PhantomData;
+
+use autumn_web::AutumnResult;
+use autumn_web::hooks::{MutationContext, MutationHooks};
+use autumn_web::search::SearchIndexed;
+
+use crate::jobs::{REINDEX_JOB, ReindexArgs};
+
+/// Enqueue a reindex for one record.
+///
+/// The single seam an application needs if it is writing its own hooks, a
+/// bulk-import routine, or a repair script.
+///
+/// `MutationHooks` receives no `AppState`, so this goes through autumn-web's
+/// process-wide name-keyed enqueue chokepoint, which resolves the registered
+/// `JobInfo` — and therefore the plugin's configured queue — from the job
+/// registry.
+///
+/// # Errors
+///
+/// Propagates the enqueue failure. Callers inside an `after_*_commit` hook
+/// should return it: with `commit_hooks = true` the durable queue retries the
+/// hook, which is exactly the recovery you want.
+pub async fn enqueue_reindex(args: &ReindexArgs) -> AutumnResult<()> {
+    autumn_web::job::enqueue(REINDEX_JOB, serde_json::to_value(args)?).await
+}
+
+/// Enqueue an upsert reindex for `record`.
+///
+/// # Errors
+///
+/// As [`enqueue_reindex`].
+pub async fn enqueue_reindex_for<M: SearchIndexed>(record: &M) -> AutumnResult<()> {
+    enqueue_reindex(&ReindexArgs::upsert(M::SEARCH_INDEX, record.search_id())).await
+}
+
+/// Enqueue a delete reindex for `record`.
+///
+/// # Errors
+///
+/// As [`enqueue_reindex`].
+pub async fn enqueue_unindex_for<M: SearchIndexed>(record: &M) -> AutumnResult<()> {
+    enqueue_reindex(&ReindexArgs::delete(M::SEARCH_INDEX, record.search_id())).await
+}
+
+/// `MutationHooks` that keep a searchable model's index in sync.
+///
+/// Generic over the model and its two changesets because that is the shape
+/// `#[repository]` requires; nothing else about it is per-model.
+pub struct SearchSyncHooks<M, N, U> {
+    // `fn() -> (…)` rather than the tuple itself, so the hooks are `Send +
+    // Sync` regardless of the model's own auto traits.
+    _model: ModelMarker<M, N, U>,
+}
+
+/// Variance/auto-trait marker for [`SearchSyncHooks`].
+type ModelMarker<M, N, U> = PhantomData<fn() -> (M, N, U)>;
+
+impl<M, N, U> SearchSyncHooks<M, N, U> {
+    /// Construct the hooks.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            _model: PhantomData,
+        }
+    }
+}
+
+impl<M, N, U> Default for SearchSyncHooks<M, N, U> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<M, N, U> Clone for SearchSyncHooks<M, N, U> {
+    fn clone(&self) -> Self {
+        Self::new()
+    }
+}
+
+impl<M, N, U> std::fmt::Debug for SearchSyncHooks<M, N, U> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("SearchSyncHooks")
+    }
+}
+
+impl<M, N, U> MutationHooks for SearchSyncHooks<M, N, U>
+where
+    M: SearchIndexed,
+    N: Send + Sync + 'static,
+    U: Send + Sync + 'static,
+{
+    type Model = M;
+    type NewModel = N;
+    type UpdateModel = U;
+
+    fn after_create_commit(
+        &self,
+        _ctx: &mut MutationContext,
+        record: &Self::Model,
+    ) -> impl Future<Output = AutumnResult<()>> + Send {
+        let args = ReindexArgs::upsert(M::SEARCH_INDEX, record.search_id());
+        async move { enqueue_reindex(&args).await }
+    }
+
+    fn after_update_commit(
+        &self,
+        _ctx: &mut MutationContext,
+        record: &Self::Model,
+    ) -> impl Future<Output = AutumnResult<()>> + Send {
+        let args = ReindexArgs::upsert(M::SEARCH_INDEX, record.search_id());
+        async move { enqueue_reindex(&args).await }
+    }
+
+    fn after_delete_commit(
+        &self,
+        _ctx: &mut MutationContext,
+        record: &Self::Model,
+    ) -> impl Future<Output = AutumnResult<()>> + Send {
+        let args = ReindexArgs::delete(M::SEARCH_INDEX, record.search_id());
+        async move { enqueue_reindex(&args).await }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn the_hooks_type_is_default_and_clone_as_repositories_require() {
+        // `#[repository(hooks = …)]` constructs via `Default` and the
+        // generated struct derives `Clone`, so both must hold for a type with
+        // no `Default`/`Clone` bound on its parameters.
+        struct NotClonable;
+        let hooks: SearchSyncHooks<NotClonable, NotClonable, NotClonable> =
+            SearchSyncHooks::default();
+        let _cloned = hooks.clone();
+        assert_eq!(format!("{hooks:?}"), "SearchSyncHooks");
+    }
+}

--- a/autumn-search/src/sync.rs
+++ b/autumn-search/src/sync.rs
@@ -22,8 +22,11 @@
 //!   transaction as the mutation. A process dying between commit and enqueue
 //!   is recovered by the queue, not lost.
 //! - It enqueues `(index, id)` and **not the record**. The job re-reads the
-//!   row, so a stale or reordered payload cannot write stale text into the
-//!   index — see [`crate::SearchClient::reindex`].
+//!   row — for a delete as well as an upsert — so every instruction means
+//!   "converge this id". A stale or reordered payload therefore cannot write
+//!   stale text into the index, and a late delete cannot evict a record that
+//!   has since been recreated under the same key. See
+//!   [`crate::SearchClient::reindex`].
 //!
 //! An app that already has hooks composes instead of replacing: call
 //! [`enqueue_reindex`] from its own `after_*_commit`.

--- a/autumn-search/src/text.rs
+++ b/autumn-search/src/text.rs
@@ -1,0 +1,77 @@
+//! Tokenization shared by the in-process ranking paths.
+//!
+//! Defined once so the in-memory backend and the hashing embedder agree on
+//! what a "token" is. Engines with their own analyzers (Postgres' `tsvector`,
+//! Meilisearch) use theirs — this is the fallback for backends that rank in
+//! Rust.
+
+/// Split `text` into lowercase alphanumeric tokens.
+///
+/// Unicode-aware (so `Äpfel` and `äpfel` yield the same token) and free of
+/// punctuation, which is what makes an operator-looking query like `rust*` or
+/// `title:rust` decompose into ordinary terms rather than query syntax.
+pub fn tokenize(text: &str) -> impl Iterator<Item = String> + '_ {
+    text.split(|c: char| !c.is_alphanumeric())
+        .filter(|token| !token.is_empty())
+        .map(str::to_lowercase)
+}
+
+/// Tokenize a user query, returning `None` when nothing usable remains.
+///
+/// The caller MUST treat `None` as an empty result set and issue **no** query
+/// — never an unfiltered scan. This mirrors the fail-closed contract of
+/// `autumn_web::repository::sqlite_fts5_match_query`.
+#[must_use]
+pub fn query_tokens(query: &str) -> Option<Vec<String>> {
+    let tokens: Vec<String> = tokenize(query).collect();
+    if tokens.is_empty() {
+        None
+    } else {
+        Some(tokens)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tokens(text: &str) -> Vec<String> {
+        tokenize(text).collect()
+    }
+
+    #[test]
+    fn tokenizing_lowercases_and_drops_punctuation() {
+        assert_eq!(
+            tokens("Rust web frameworks!"),
+            ["rust", "web", "frameworks"]
+        );
+    }
+
+    #[test]
+    fn operator_syntax_decomposes_into_plain_terms() {
+        assert_eq!(tokens("title:rust"), ["title", "rust"]);
+        assert_eq!(tokens("rust*"), ["rust"]);
+        assert_eq!(
+            tokens("\"; DROP TABLE users; --"),
+            ["drop", "table", "users"]
+        );
+    }
+
+    #[test]
+    fn tokenizing_is_unicode_case_folding() {
+        assert_eq!(tokens("Äpfel"), ["äpfel"]);
+        assert_eq!(tokens("äpfel"), ["äpfel"]);
+    }
+
+    #[test]
+    fn a_blank_query_yields_none_so_callers_fail_closed() {
+        assert!(query_tokens("").is_none());
+        assert!(query_tokens("   ").is_none());
+        assert!(query_tokens("\t\n").is_none());
+        assert!(query_tokens("-- ;").is_none());
+        assert_eq!(
+            query_tokens("rust").as_deref(),
+            Some(["rust".to_owned()].as_slice())
+        );
+    }
+}

--- a/autumn-search/tests/integration/backfill.rs
+++ b/autumn-search/tests/integration/backfill.rs
@@ -263,3 +263,94 @@ async fn a_short_batch_does_not_end_the_backfill() {
         .expect("search");
     assert_eq!(page.total_elements, 15);
 }
+
+// ── Backfill versus a concurrent reindex ────────────────────────────────────
+
+#[tokio::test]
+async fn a_backfill_does_not_overwrite_a_reindex_that_ran_while_it_was_working() {
+    // The window is real and wide: a backfill reads a batch, embeds it (a
+    // provider round-trip), then writes. A mutation in between enqueues a
+    // reindex job that reads and writes the NEW state — and the backfill's
+    // in-flight batch would then put back what the source said minutes ago.
+    // Nothing re-runs the reindex, so the index stays wrong until the next
+    // mutation touches that record.
+    use autumn_search::{IndexedDocument, SearchBackend as _};
+    use autumn_web::search::SearchIndexed as _;
+
+    let backend = Arc::new(MemorySearchBackend::new());
+    let source = Arc::new(MemoryDocumentSource::new());
+    source.upsert(&article(1, "Stale title", "rust web framework"));
+
+    let client = SearchClient::builder()
+        .backend(backend.clone())
+        .source(source.clone())
+        .index::<Article>()
+        .build();
+    client.ensure_indexes().await.expect("ensure");
+
+    let definition = Article::index_definition();
+
+    // Simulate the interleaving directly: take the watermark the backfill
+    // would take, then let a reindex land, then replay the backfill's write.
+    let watermark = backend.write_watermark().await.expect("watermark");
+
+    // …the mutation's reindex job writes the new state.
+    let fresh = article(1, "Fresh title", "rust web framework");
+    client.index_record(&fresh).await.expect("reindex");
+
+    // …and now the backfill's stale batch arrives.
+    let stale =
+        IndexedDocument::new(article(1, "Stale title", "rust web framework").search_document());
+    backend
+        .index_unless_newer(&definition, &[stale], watermark.as_deref())
+        .await
+        .expect("backfill write");
+
+    let page = client
+        .search::<Article>("fresh", &PageRequest::default())
+        .await
+        .expect("search");
+    assert_eq!(
+        page.total_elements, 1,
+        "the reindex's newer document must survive the backfill batch"
+    );
+    assert_eq!(
+        client
+            .search::<Article>("stale", &PageRequest::default())
+            .await
+            .expect("search")
+            .total_elements,
+        0,
+        "the backfill must not have put the stale title back"
+    );
+}
+
+#[tokio::test]
+async fn a_backfill_still_writes_documents_nothing_else_touched() {
+    // The guard must only skip records a newer writer claimed — everything
+    // else still has to be indexed, or the watermark would turn every backfill
+    // after the first into a no-op.
+    let (client, _source) = client_with(5).await;
+    let report = client
+        .backfill("search_articles", &BackfillOptions::default())
+        .await
+        .expect("backfill");
+    assert_eq!(report.indexed, 5);
+
+    let second = client
+        .backfill("search_articles", &BackfillOptions::default())
+        .await
+        .expect("second backfill");
+    assert_eq!(
+        second.indexed, 5,
+        "a later backfill re-reads the source and rewrites every row"
+    );
+    assert_eq!(
+        client
+            .search::<Article>("rust", &PageRequest::default())
+            .await
+            .expect("search")
+            .total_elements,
+        5
+    );
+}

--- a/autumn-search/tests/integration/backfill.rs
+++ b/autumn-search/tests/integration/backfill.rs
@@ -1,0 +1,168 @@
+//! Full reindex / backfill.
+//!
+//! AC: "… and a **full reindex/backfill** command exists for bootstrapping or
+//! schema changes."
+
+use std::sync::Arc;
+
+use autumn_search::{
+    BackfillOptions, MemoryDocumentSource, MemorySearchBackend, SearchClient, SearchError,
+};
+use autumn_web::pagination::PageRequest;
+
+use super::support::{Article, article};
+
+async fn client_with(n: i64) -> (SearchClient, Arc<MemoryDocumentSource>) {
+    let source = Arc::new(MemoryDocumentSource::new());
+    for id in 1..=n {
+        source.upsert(&article(id, &format!("Record {id}"), "rust web framework"));
+    }
+    let client = SearchClient::builder()
+        .backend(Arc::new(MemorySearchBackend::new()))
+        .source(source.clone())
+        .index::<Article>()
+        .build();
+    client.ensure_indexes().await.expect("ensure");
+    (client, source)
+}
+
+#[tokio::test]
+async fn backfill_indexes_every_row_in_batches() {
+    let (client, _source) = client_with(25).await;
+
+    let report = client
+        .backfill(
+            "search_articles",
+            &BackfillOptions::default().batch_size(10),
+        )
+        .await
+        .expect("backfill");
+
+    assert_eq!(report.indexed, 25);
+    assert_eq!(report.batches, 3, "25 rows at 10/batch is 3 batches");
+    assert_eq!(report.index, "search_articles");
+
+    let page = client
+        .search::<Article>("rust", &PageRequest::default())
+        .await
+        .expect("search");
+    assert_eq!(page.total_elements, 25);
+}
+
+#[tokio::test]
+async fn backfill_is_idempotent() {
+    let (client, _source) = client_with(5).await;
+
+    client
+        .backfill("search_articles", &BackfillOptions::default())
+        .await
+        .expect("first");
+    let second = client
+        .backfill("search_articles", &BackfillOptions::default())
+        .await
+        .expect("second");
+
+    assert_eq!(second.indexed, 5);
+    let page = client
+        .search::<Article>("rust", &PageRequest::default())
+        .await
+        .expect("search");
+    assert_eq!(
+        page.total_elements, 5,
+        "re-running must not duplicate documents"
+    );
+}
+
+#[tokio::test]
+async fn backfill_can_purge_stale_documents_first() {
+    // Bootstrapping after a schema change: `purge` clears documents that the
+    // source no longer produces, instead of leaving orphans behind forever.
+    let (client, source) = client_with(3).await;
+    client
+        .backfill("search_articles", &BackfillOptions::default())
+        .await
+        .expect("initial");
+
+    source.remove(3);
+
+    let without_purge = client
+        .backfill("search_articles", &BackfillOptions::default())
+        .await
+        .expect("no purge");
+    assert_eq!(without_purge.indexed, 2);
+    assert_eq!(
+        client
+            .search::<Article>("rust", &PageRequest::default())
+            .await
+            .expect("search")
+            .total_elements,
+        3,
+        "without purge the orphan survives"
+    );
+
+    let purged = client
+        .backfill("search_articles", &BackfillOptions::default().purge(true))
+        .await
+        .expect("purge");
+    assert_eq!(purged.indexed, 2);
+    assert!(purged.purged);
+    assert_eq!(
+        client
+            .search::<Article>("rust", &PageRequest::default())
+            .await
+            .expect("search")
+            .total_elements,
+        2
+    );
+}
+
+#[tokio::test]
+async fn backfilling_all_indexes_reports_each_one() {
+    let (client, _source) = client_with(4).await;
+
+    let reports = client
+        .backfill_all(&BackfillOptions::default())
+        .await
+        .expect("backfill all");
+
+    assert_eq!(reports.len(), 1);
+    assert_eq!(reports[0].index, "search_articles");
+    assert_eq!(reports[0].indexed, 4);
+}
+
+#[tokio::test]
+async fn backfilling_an_unknown_index_is_a_typed_error() {
+    let (client, _source) = client_with(1).await;
+
+    let err = client
+        .backfill("nope", &BackfillOptions::default())
+        .await
+        .unwrap_err();
+    assert!(matches!(err, SearchError::UnknownIndex(_)), "{err:?}");
+}
+
+#[tokio::test]
+async fn a_zero_batch_size_is_clamped_rather_than_looping_forever() {
+    let (client, _source) = client_with(3).await;
+
+    let report = client
+        .backfill("search_articles", &BackfillOptions::default().batch_size(0))
+        .await
+        .expect("backfill");
+    assert_eq!(report.indexed, 3);
+}
+
+#[tokio::test]
+async fn backfill_without_a_document_source_is_a_typed_error() {
+    let client = SearchClient::builder()
+        .backend(Arc::new(MemorySearchBackend::new()))
+        .index::<Article>()
+        .build();
+    client.ensure_indexes().await.expect("ensure");
+
+    let err = client
+        .backfill("search_articles", &BackfillOptions::default())
+        .await
+        .unwrap_err();
+    assert!(matches!(err, SearchError::SourceUnavailable), "{err:?}");
+}

--- a/autumn-search/tests/integration/backfill.rs
+++ b/autumn-search/tests/integration/backfill.rs
@@ -354,3 +354,94 @@ async fn a_backfill_still_writes_documents_nothing_else_touched() {
         5
     );
 }
+
+#[tokio::test]
+async fn a_backfill_does_not_resurrect_a_record_deleted_while_it_was_working() {
+    // The other half of the race, and the worse half. The watermark's UPDATE
+    // guard only protects a document that still exists — if the reindex
+    // DELETED it, the backfill's write finds nothing to conflict with and
+    // inserts unconditionally. A record someone deleted becomes searchable
+    // again, and stays that way until another mutation touches it.
+    use autumn_search::{IndexedDocument, SearchBackend as _};
+    use autumn_web::search::SearchIndexed as _;
+
+    let backend = Arc::new(MemorySearchBackend::new());
+    let client = SearchClient::builder()
+        .backend(backend.clone())
+        .index::<Article>()
+        .build();
+    client.ensure_indexes().await.expect("ensure");
+
+    let definition = Article::index_definition();
+    let record = article(1, "Secret", "rust web framework");
+    client.index_record(&record).await.expect("index");
+
+    // The backfill scans and takes its watermark…
+    let watermark = backend.write_watermark().await.expect("watermark");
+
+    // …the record is deleted, and the reindex removes its document…
+    client.remove::<Article>(1).await.expect("remove");
+    assert_eq!(
+        client
+            .search::<Article>("rust", &PageRequest::default())
+            .await
+            .expect("search")
+            .total_elements,
+        0
+    );
+
+    // …and now the backfill's stale batch arrives.
+    let stale = IndexedDocument::new(record.search_document());
+    backend
+        .index_unless_newer(&definition, &[stale], watermark.as_deref())
+        .await
+        .expect("backfill write");
+
+    assert_eq!(
+        client
+            .search::<Article>("rust", &PageRequest::default())
+            .await
+            .expect("search")
+            .total_elements,
+        0,
+        "a deleted record must not come back because a backfill was mid-flight"
+    );
+}
+
+#[tokio::test]
+async fn a_purge_clears_the_delete_record_so_the_rebuild_is_not_blocked() {
+    // The tombstone must not outlive a deliberate reset: a purging backfill is
+    // *supposed* to rewrite everything, so leaving delete records behind would
+    // make it silently skip whatever had been deleted before.
+    let backend = Arc::new(MemorySearchBackend::new());
+    let source = Arc::new(MemoryDocumentSource::new());
+    source.upsert(&article(1, "Rust", "rust web framework"));
+
+    let client = SearchClient::builder()
+        .backend(backend.clone())
+        .source(source.clone())
+        .index::<Article>()
+        .build();
+    client.ensure_indexes().await.expect("ensure");
+
+    client
+        .index_record(&article(1, "Rust", "x"))
+        .await
+        .expect("index");
+    client.remove::<Article>(1).await.expect("remove");
+
+    let report = client
+        .backfill("search_articles", &BackfillOptions::default().purge(true))
+        .await
+        .expect("backfill");
+    assert_eq!(report.indexed, 1);
+    assert_eq!(
+        client
+            .search::<Article>("rust", &PageRequest::default())
+            .await
+            .expect("search")
+            .total_elements,
+        1,
+        "the source still has the row, so a purging rebuild must index it"
+    );
+}

--- a/autumn-search/tests/integration/backfill.rs
+++ b/autumn-search/tests/integration/backfill.rs
@@ -166,3 +166,100 @@ async fn backfill_without_a_document_source_is_a_typed_error() {
         .unwrap_err();
     assert!(matches!(err, SearchError::SourceUnavailable), "{err:?}");
 }
+
+// ── A source that returns short batches ─────────────────────────────────────
+
+/// A `DocumentSource` that reads a fixed window of `limit` rows and then drops
+/// the ones that do not qualify — so it returns **up to** `limit` documents,
+/// as the trait allows, and a short batch does not mean "no more rows".
+///
+/// This is not contrived: any source that filters after reading behaves this
+/// way — soft-deleted rows, rows failing a tenant check, rows whose embed text
+/// is empty. Here, even ids are the ones dropped.
+struct FilteringSource {
+    documents: Vec<autumn_web::search::SearchDocument>,
+}
+
+impl autumn_search::DocumentSource for FilteringSource {
+    fn fetch<'a>(
+        &'a self,
+        _definition: &'a autumn_search::IndexDefinition,
+        ids: &'a [i64],
+    ) -> autumn_search::BoxFuture<
+        'a,
+        autumn_search::SearchResult<Vec<autumn_web::search::SearchDocument>>,
+    > {
+        Box::pin(async move {
+            Ok(self
+                .documents
+                .iter()
+                .filter(|document| ids.contains(&document.id) && document.id % 2 == 1)
+                .cloned()
+                .collect())
+        })
+    }
+
+    fn scan<'a>(
+        &'a self,
+        _definition: &'a autumn_search::IndexDefinition,
+        after: Option<i64>,
+        limit: usize,
+    ) -> autumn_search::BoxFuture<
+        'a,
+        autumn_search::SearchResult<Vec<autumn_web::search::SearchDocument>>,
+    > {
+        Box::pin(async move {
+            let after = after.unwrap_or(0);
+            Ok(self
+                .documents
+                .iter()
+                .filter(|document| document.id > after)
+                // Read the window first…
+                .take(limit)
+                // …then drop what does not qualify. The batch is short, but
+                // rows remain beyond it.
+                .filter(|document| document.id % 2 == 1)
+                .cloned()
+                .collect())
+        })
+    }
+}
+
+#[tokio::test]
+async fn a_short_batch_does_not_end_the_backfill() {
+    use autumn_web::search::SearchIndexed as _;
+
+    // 30 rows, half of which the source filters out. With a batch size of 10,
+    // every batch comes back short (5 of 10) while 20 more rows still remain.
+    // Treating "short" as "exhausted" indexes 5 records and reports success —
+    // a silently truncated rebuild, which is the worst kind.
+    let source = Arc::new(FilteringSource {
+        documents: (1..=30)
+            .map(|id| article(id, &format!("Record {id}"), "rust web framework").search_document())
+            .collect(),
+    });
+    let client = SearchClient::builder()
+        .backend(Arc::new(MemorySearchBackend::new()))
+        .source(source)
+        .index::<Article>()
+        .build();
+    client.ensure_indexes().await.expect("ensure");
+
+    let report = client
+        .backfill(
+            "search_articles",
+            &BackfillOptions::default().batch_size(10),
+        )
+        .await
+        .expect("backfill");
+
+    assert_eq!(
+        report.indexed, 15,
+        "every odd id in 1..=30 must be indexed, not just the first batch"
+    );
+    let page = client
+        .search::<Article>("rust", &PageRequest::default())
+        .await
+        .expect("search");
+    assert_eq!(page.total_elements, 15);
+}

--- a/autumn-search/tests/integration/embedding.rs
+++ b/autumn-search/tests/integration/embedding.rs
@@ -1,0 +1,88 @@
+//! The pluggable embedding seam.
+//!
+//! AC: "Embedding generation is pluggable (a trait the app implements or a
+//! provider adapter); the search plugin does not hardcode an embedding model
+//! or vendor." So the crate ships exactly two implementations: one that
+//! refuses (the honest default) and one that is deterministic and
+//! dependency-free (dev + tests). Anything vendor-shaped is the app's.
+
+use autumn_search::{Embedder as _, HashingEmbedder, NoEmbedder, SearchError, cosine_similarity};
+
+#[tokio::test]
+async fn the_default_embedder_refuses_rather_than_inventing_vectors() {
+    let err = NoEmbedder
+        .embed(&["hello".to_owned()])
+        .await
+        .expect_err("NoEmbedder must not produce vectors");
+    assert!(matches!(err, SearchError::EmbedderUnavailable), "{err:?}");
+    assert_eq!(NoEmbedder.dimensions(), 0);
+}
+
+#[tokio::test]
+async fn the_hashing_embedder_is_deterministic_and_normalized() {
+    let embedder = HashingEmbedder::new(64);
+    let first = embedder
+        .embed(&["autumn rust web framework".to_owned()])
+        .await
+        .expect("embed");
+    let second = embedder
+        .embed(&["autumn rust web framework".to_owned()])
+        .await
+        .expect("embed");
+
+    assert_eq!(first, second, "embeddings must be reproducible");
+    assert_eq!(first[0].len(), 64);
+
+    let norm: f32 = first[0].iter().map(|v| v * v).sum::<f32>().sqrt();
+    assert!(
+        (norm - 1.0).abs() < 1e-5,
+        "expected unit vector, got {norm}"
+    );
+}
+
+#[tokio::test]
+async fn the_hashing_embedder_puts_related_text_closer_than_unrelated_text() {
+    let embedder = HashingEmbedder::new(256);
+    let vectors = embedder
+        .embed(&[
+            "rust web framework".to_owned(),
+            "rust web framework for apis".to_owned(),
+            "tomato basil gardening".to_owned(),
+        ])
+        .await
+        .expect("embed");
+
+    let related = cosine_similarity(&vectors[0], &vectors[1]);
+    let unrelated = cosine_similarity(&vectors[0], &vectors[2]);
+    assert!(
+        related > unrelated,
+        "related={related} should exceed unrelated={unrelated}"
+    );
+}
+
+#[tokio::test]
+async fn embedding_an_empty_batch_makes_no_work() {
+    let embedder = HashingEmbedder::new(8);
+    assert!(embedder.embed(&[]).await.expect("embed").is_empty());
+    // Even the refusing embedder short-circuits an empty batch, so a record
+    // with nothing to embed never trips the "no embedder" error.
+    assert!(NoEmbedder.embed(&[]).await.expect("embed").is_empty());
+}
+
+#[test]
+fn cosine_similarity_is_defined_for_degenerate_inputs() {
+    assert!((cosine_similarity(&[1.0, 0.0], &[1.0, 0.0]) - 1.0).abs() < 1e-6);
+    assert!(cosine_similarity(&[1.0, 0.0], &[0.0, 1.0]).abs() < 1e-6);
+    assert!((cosine_similarity(&[1.0, 0.0], &[-1.0, 0.0]) + 1.0).abs() < 1e-6);
+    // A zero vector has no direction: similarity is 0, never NaN.
+    assert!(cosine_similarity(&[0.0, 0.0], &[1.0, 0.0]).abs() < f32::EPSILON);
+    // Mismatched lengths are 0 rather than a panic or a partial dot product.
+    assert!(cosine_similarity(&[1.0, 0.0], &[1.0]).abs() < f32::EPSILON);
+}
+
+#[tokio::test]
+async fn dimensions_zero_is_rejected_at_construction() {
+    // A 0-dimension embedder would make every document identical.
+    assert!(HashingEmbedder::try_new(0).is_none());
+    assert!(HashingEmbedder::try_new(1).is_some());
+}

--- a/autumn-search/tests/integration/extensibility.rs
+++ b/autumn-search/tests/integration/extensibility.rs
@@ -1,0 +1,278 @@
+//! Third-party `SearchBackend` and `Embedder` implementations.
+//!
+//! AC 5 requires the trait be "shaped so an external engine … can be added
+//! without a breaking change", and AC 6 requires embedding to be "a trait the
+//! app implements". Both claims are only checkable from *outside* the crate:
+//! the shipped implementations are privileged (they can name private items and
+//! construct `#[non_exhaustive]` types by literal), so they cannot prove that
+//! a downstream crate could do the same.
+//!
+//! This module is that downstream crate. It compiles against the public API
+//! only, and every restriction that would block a real implementor shows up
+//! here as a compile error.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use autumn_search::{
+    BackendCapabilities, BoxFuture, Embedder, IndexDefinition, IndexedDocument, KeywordQuery, Page,
+    PageRequest, SearchBackend, SearchClient, SearchError, SearchHit, SearchResult,
+};
+
+use super::support::{Article, article};
+
+// ── A keyword-only engine ───────────────────────────────────────────────────
+
+/// The minimum viable third-party backend: keyword search over an in-memory
+/// list, no vectors at all.
+///
+/// It implements only the required methods. Everything vector-shaped falls
+/// through to the trait's defaults, which is exactly the "a keyword-only
+/// engine is a complete implementation" claim.
+#[derive(Default)]
+struct ToyBackend {
+    documents: std::sync::Mutex<Vec<IndexedDocument>>,
+    ensure_calls: AtomicUsize,
+}
+
+impl SearchBackend for ToyBackend {
+    fn name(&self) -> &'static str {
+        "toy"
+    }
+
+    fn ensure_index<'a>(
+        &'a self,
+        _definition: &'a IndexDefinition,
+    ) -> BoxFuture<'a, SearchResult<()>> {
+        Box::pin(async move {
+            self.ensure_calls.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        })
+    }
+
+    fn index<'a>(
+        &'a self,
+        _definition: &'a IndexDefinition,
+        documents: &'a [IndexedDocument],
+    ) -> BoxFuture<'a, SearchResult<()>> {
+        Box::pin(async move {
+            {
+                let mut store = self.documents.lock().expect("lock");
+                for document in documents {
+                    store.retain(|existing| existing.id() != document.id());
+                    store.push(document.clone());
+                }
+            }
+            Ok(())
+        })
+    }
+
+    fn delete<'a>(
+        &'a self,
+        _definition: &'a IndexDefinition,
+        ids: &'a [i64],
+    ) -> BoxFuture<'a, SearchResult<()>> {
+        Box::pin(async move {
+            {
+                self.documents
+                    .lock()
+                    .expect("lock")
+                    .retain(|document| !ids.contains(&document.id()));
+            }
+            Ok(())
+        })
+    }
+
+    fn clear<'a>(&'a self, _definition: &'a IndexDefinition) -> BoxFuture<'a, SearchResult<()>> {
+        Box::pin(async move {
+            {
+                self.documents.lock().expect("lock").clear();
+            }
+            Ok(())
+        })
+    }
+
+    fn keyword_search<'a>(
+        &'a self,
+        definition: &'a IndexDefinition,
+        query: &'a KeywordQuery,
+    ) -> BoxFuture<'a, SearchResult<Page<SearchHit>>> {
+        Box::pin(async move {
+            // `tokenize` and `SearchFilter::permits` are public, so a
+            // third-party backend does not have to reinvent either the query
+            // contract or the authorization semantics.
+            let tokens: Vec<String> = autumn_search::tokenize(&query.text).collect();
+            let hits: Vec<SearchHit> = {
+                let store = self.documents.lock().expect("lock");
+                store
+                    .iter()
+                    .filter(|document| query.filter.permits(&document.document))
+                    .filter(|document| {
+                        let text = document.document.text().to_lowercase();
+                        !tokens.is_empty() && tokens.iter().all(|token| text.contains(token))
+                    })
+                    .map(|document| SearchHit::new(definition.name, document.id(), 1.0))
+                    .collect()
+            };
+            let total = i64::try_from(hits.len()).unwrap_or(i64::MAX);
+            Ok(Page::new(hits, total, &query.page))
+        })
+    }
+}
+
+#[tokio::test]
+async fn a_keyword_only_backend_is_a_complete_implementation() {
+    let backend = Arc::new(ToyBackend::default());
+    let client = SearchClient::builder()
+        .backend(backend.clone())
+        .index::<Article>()
+        .build();
+    client.ensure_indexes().await.expect("ensure");
+    assert_eq!(backend.ensure_calls.load(Ordering::SeqCst), 1);
+
+    for record in [
+        article(1, "Rust web frameworks", "A survey."),
+        article(2, "Gardening", "Tomatoes."),
+    ] {
+        client.index_record(&record).await.expect("index");
+    }
+
+    let page = client
+        .search::<Article>("rust", &PageRequest::default())
+        .await
+        .expect("search");
+    assert_eq!(
+        page.content.iter().map(|h| h.id).collect::<Vec<_>>(),
+        vec![1]
+    );
+}
+
+#[tokio::test]
+async fn a_backend_that_declines_vectors_reports_unsupported_rather_than_wrong_answers() {
+    let client = SearchClient::builder()
+        .backend(Arc::new(ToyBackend::default()))
+        .embedder(Arc::new(DoubleEmbedder))
+        .index::<Article>()
+        .build();
+    client.ensure_indexes().await.expect("ensure");
+
+    let error = client
+        .similar::<Article>("rust", 3)
+        .await
+        .expect_err("the toy backend has no vector support");
+    assert!(
+        matches!(error, SearchError::Unsupported { backend, operation }
+            if backend == "toy" && operation == "vector search"),
+        "{error:?}"
+    );
+}
+
+#[test]
+fn a_third_party_backend_can_declare_its_capabilities() {
+    // `BackendCapabilities` is `#[non_exhaustive]`, so a downstream crate
+    // cannot build it with a struct literal. Without the builders it could
+    // only ever return the keyword-only default and could never advertise
+    // vector support — this asserts the builders make that possible from out
+    // here, not just inside the crate.
+    let caps = BackendCapabilities::default()
+        .with_vector(true)
+        .with_embedding_readback(true);
+    assert!(caps.keyword);
+    assert!(caps.vector);
+    assert!(caps.embedding_readback);
+    assert!(!caps.weighted_fields);
+
+    assert!(!ToyBackend::default().capabilities().vector);
+}
+
+// ── An app-supplied embedder ────────────────────────────────────────────────
+
+/// An embedder an application could plausibly write: two dimensions derived
+/// from the text, no vendor, no model.
+struct DoubleEmbedder;
+
+impl Embedder for DoubleEmbedder {
+    fn dimensions(&self) -> usize {
+        2
+    }
+
+    fn embed<'a>(&'a self, texts: &'a [String]) -> BoxFuture<'a, SearchResult<Vec<Vec<f32>>>> {
+        Box::pin(async move {
+            Ok(texts
+                .iter()
+                .map(|text| {
+                    let count = |f: fn(&char) -> bool| {
+                        u16::try_from(text.chars().filter(f).count()).unwrap_or(u16::MAX)
+                    };
+                    let mut vector = vec![
+                        f32::from(count(char::is_ascii_alphabetic)),
+                        f32::from(count(char::is_ascii_digit)),
+                    ];
+                    autumn_search::normalize(&mut vector);
+                    vector
+                })
+                .collect())
+        })
+    }
+}
+
+/// An embedder that misbehaves by returning the wrong number of vectors.
+struct ShortEmbedder;
+
+impl Embedder for ShortEmbedder {
+    fn dimensions(&self) -> usize {
+        2
+    }
+
+    fn embed<'a>(&'a self, _texts: &'a [String]) -> BoxFuture<'a, SearchResult<Vec<Vec<f32>>>> {
+        Box::pin(async move { Ok(Vec::new()) })
+    }
+}
+
+#[tokio::test]
+async fn an_app_supplied_embedder_drives_semantic_search() {
+    let client = SearchClient::builder()
+        .backend(Arc::new(autumn_search::MemorySearchBackend::new()))
+        .embedder(Arc::new(DoubleEmbedder))
+        .index::<Article>()
+        .build();
+    client.ensure_indexes().await.expect("ensure");
+
+    for record in [
+        article(1, "Letters", "abcdefghij"),
+        article(2, "Digits", "1234567890"),
+    ] {
+        client.index_record(&record).await.expect("index");
+    }
+
+    let hits = client
+        .similar::<Article>("abcdefgh", 1)
+        .await
+        .expect("similar");
+    assert_eq!(
+        hits.first().map(|hit| hit.id),
+        Some(1),
+        "the app's own embedder decides what 'similar' means: {hits:?}"
+    );
+}
+
+#[tokio::test]
+async fn a_misbehaving_embedder_is_reported_not_silently_mis_assigned() {
+    // Returning fewer vectors than inputs would otherwise attach the wrong
+    // embedding to a document, which is far worse than an error.
+    let client = SearchClient::builder()
+        .backend(Arc::new(autumn_search::MemorySearchBackend::new()))
+        .embedder(Arc::new(ShortEmbedder))
+        .index::<Article>()
+        .build();
+    client.ensure_indexes().await.expect("ensure");
+
+    let error = client
+        .index_record(&article(1, "Rust", "a rust framework"))
+        .await
+        .expect_err("a vector-count mismatch must surface");
+    assert!(
+        matches!(error, SearchError::Embedding(ref message) if message.contains("0 vectors")),
+        "{error:?}"
+    );
+}

--- a/autumn-search/tests/integration/memory_backend.rs
+++ b/autumn-search/tests/integration/memory_backend.rs
@@ -1,0 +1,406 @@
+//! `MemorySearchBackend`: the reference `SearchBackend` implementation.
+//!
+//! Every behaviour asserted here is part of the **backend contract** — the
+//! Postgres backend (and any external engine added later) must match it. That
+//! is what makes `SearchBackend` a real seam rather than a Postgres-shaped
+//! hole: the same suite runs against the Postgres backend in
+//! `tests/postgres_backend.rs`.
+
+use autumn_search::{
+    IndexedDocument, KeywordQuery, MemorySearchBackend, SearchBackend as _, SearchError,
+    SearchFilter, VectorQuery,
+};
+use autumn_web::pagination::PageRequest;
+use autumn_web::search::SearchIndexed as _;
+
+use super::support::{Article, article, seeded_backend, tenant_article};
+
+fn corpus() -> Vec<Article> {
+    vec![
+        // "rust" in the title (weight A) — must outrank a body-only match.
+        article(1, "Rust web frameworks", "A survey of the ecosystem."),
+        // "rust" in the body only (weight B).
+        article(2, "Getting started", "Autumn is a rust web framework."),
+        // No match at all.
+        article(3, "Gardening", "Tomatoes and basil."),
+    ]
+}
+
+const fn page(number: u32, size: u32) -> PageRequest {
+    PageRequest::new(number, size)
+}
+
+#[tokio::test]
+async fn keyword_search_ranks_a_title_match_above_a_body_match() {
+    let backend = seeded_backend(&corpus()).await;
+    let def = Article::index_definition();
+
+    let results = backend
+        .keyword_search(&def, &KeywordQuery::new("rust", page(1, 10)))
+        .await
+        .expect("keyword search");
+
+    assert_eq!(
+        results.content.iter().map(|h| h.id).collect::<Vec<_>>(),
+        vec![1, 2],
+        "the weight-A title match must rank first"
+    );
+    assert_eq!(results.total_elements, 2);
+    assert!(
+        results.content[0].score > results.content[1].score,
+        "scores must be strictly ordered, got {:?}",
+        results.content
+    );
+}
+
+#[tokio::test]
+async fn keyword_search_paginates_with_a_stable_total() {
+    let backend = seeded_backend(&corpus()).await;
+    let def = Article::index_definition();
+
+    let first = backend
+        .keyword_search(&def, &KeywordQuery::new("rust", page(1, 1)))
+        .await
+        .expect("page 1");
+    let second = backend
+        .keyword_search(&def, &KeywordQuery::new("rust", page(2, 1)))
+        .await
+        .expect("page 2");
+
+    assert_eq!(
+        first.content.iter().map(|h| h.id).collect::<Vec<_>>(),
+        vec![1]
+    );
+    assert_eq!(
+        second.content.iter().map(|h| h.id).collect::<Vec<_>>(),
+        vec![2]
+    );
+    // `total` is the size of the whole result set, not the page.
+    assert_eq!(first.total_elements, 2);
+    assert_eq!(second.total_elements, 2);
+
+    let past_the_end = backend
+        .keyword_search(&def, &KeywordQuery::new("rust", page(9, 1)))
+        .await
+        .expect("page 9");
+    assert!(past_the_end.content.is_empty());
+    assert_eq!(past_the_end.total_elements, 2);
+}
+
+#[tokio::test]
+async fn an_empty_query_returns_an_empty_page_not_every_record() {
+    // Fail closed: a blank search box must never degrade into "list
+    // everything", which is both a scan and a disclosure hazard.
+    let backend = seeded_backend(&corpus()).await;
+    let def = Article::index_definition();
+
+    for blank in ["", "   ", "\t\n"] {
+        let results = backend
+            .keyword_search(&def, &KeywordQuery::new(blank, page(1, 10)))
+            .await
+            .expect("blank query");
+        assert!(results.content.is_empty(), "blank query {blank:?} matched");
+        assert_eq!(results.total_elements, 0);
+    }
+}
+
+#[tokio::test]
+async fn query_operators_are_matched_literally_not_interpreted() {
+    let backend = seeded_backend(&corpus()).await;
+    let def = Article::index_definition();
+
+    // None of these may error or widen the result set.
+    for hostile in [
+        "rust OR gardening",
+        "title:rust",
+        "rust*",
+        "\"; DROP TABLE search_articles; --",
+    ] {
+        let results = backend
+            .keyword_search(&def, &KeywordQuery::new(hostile, page(1, 10)))
+            .await
+            .expect("hostile query must not error");
+        assert!(
+            !results.content.iter().any(|h| h.id == 3),
+            "query {hostile:?} must not match the unrelated record"
+        );
+    }
+}
+
+#[tokio::test]
+async fn indexing_is_idempotent_and_updates_replace_the_previous_document() {
+    let backend = seeded_backend(&corpus()).await;
+    let def = Article::index_definition();
+
+    // Re-index the same record twice — the index must hold one document.
+    let doc =
+        IndexedDocument::new(article(1, "Rust web frameworks", "A survey.").search_document());
+    backend
+        .index(&def, std::slice::from_ref(&doc))
+        .await
+        .expect("index");
+    backend.index(&def, &[doc]).await.expect("re-index");
+
+    let results = backend
+        .keyword_search(&def, &KeywordQuery::new("rust", page(1, 10)))
+        .await
+        .expect("search");
+    assert_eq!(results.content.iter().filter(|h| h.id == 1).count(), 1);
+
+    // Now mutate the record so it no longer mentions "rust": the index must
+    // reflect the new text, not the old one.
+    let updated =
+        IndexedDocument::new(article(1, "Gardening weekly", "Tomatoes only.").search_document());
+    backend.index(&def, &[updated]).await.expect("update");
+
+    let after = backend
+        .keyword_search(&def, &KeywordQuery::new("rust", page(1, 10)))
+        .await
+        .expect("search");
+    assert_eq!(
+        after.content.iter().map(|h| h.id).collect::<Vec<_>>(),
+        vec![2]
+    );
+
+    let recall = backend
+        .keyword_search(&def, &KeywordQuery::new("tomatoes", page(1, 10)))
+        .await
+        .expect("search");
+    assert!(recall.content.iter().any(|h| h.id == 1));
+}
+
+#[tokio::test]
+async fn deleting_removes_the_document_and_is_a_no_op_when_absent() {
+    let backend = seeded_backend(&corpus()).await;
+    let def = Article::index_definition();
+
+    backend.delete(&def, &[1]).await.expect("delete");
+    let results = backend
+        .keyword_search(&def, &KeywordQuery::new("rust", page(1, 10)))
+        .await
+        .expect("search");
+    assert_eq!(
+        results.content.iter().map(|h| h.id).collect::<Vec<_>>(),
+        vec![2]
+    );
+
+    // Deleting an id that is not indexed converges rather than erroring —
+    // at-least-once job delivery replays deletes.
+    backend.delete(&def, &[1]).await.expect("repeat delete");
+    backend.delete(&def, &[999]).await.expect("unknown delete");
+}
+
+#[tokio::test]
+async fn clear_empties_only_the_named_index() {
+    let backend = seeded_backend(&corpus()).await;
+    let def = Article::index_definition();
+
+    assert_eq!(backend.document_count(def.name), 3);
+    backend.clear(&def).await.expect("clear");
+    assert_eq!(backend.document_count(def.name), 0);
+
+    let results = backend
+        .keyword_search(&def, &KeywordQuery::new("rust", page(1, 10)))
+        .await
+        .expect("search");
+    assert!(results.content.is_empty());
+}
+
+#[tokio::test]
+async fn ensure_index_is_idempotent_and_rejects_an_invalid_definition() {
+    let backend = MemorySearchBackend::new();
+    let def = Article::index_definition();
+    backend.ensure_index(&def).await.expect("first");
+    backend.ensure_index(&def).await.expect("second");
+
+    let mut bad = def.clone();
+    bad.name = "articles\"; DROP TABLE users; --";
+    let err = backend.ensure_index(&bad).await.unwrap_err();
+    assert!(matches!(err, SearchError::InvalidIndex(_)), "{err:?}");
+}
+
+// ── Filtering (the authorization seam every backend must honour) ────────────
+
+#[tokio::test]
+async fn a_tenant_filter_never_returns_another_tenants_records() {
+    let backend = seeded_backend(&[
+        tenant_article(1, "Rust at acme", "internal", "acme"),
+        tenant_article(2, "Rust at globex", "internal", "globex"),
+        article(3, "Rust in public", "no tenant"),
+    ])
+    .await;
+    let def = Article::index_definition();
+
+    let query =
+        KeywordQuery::new("rust", page(1, 10)).filter(SearchFilter::default().tenant("acme"));
+    let results = backend.keyword_search(&def, &query).await.expect("search");
+
+    assert_eq!(
+        results.content.iter().map(|h| h.id).collect::<Vec<_>>(),
+        vec![1]
+    );
+    assert_eq!(
+        results.total_elements, 1,
+        "total must reflect the filtered set"
+    );
+}
+
+#[tokio::test]
+async fn an_allowed_ids_filter_restricts_the_result_set() {
+    let backend = seeded_backend(&corpus()).await;
+    let def = Article::index_definition();
+
+    let query =
+        KeywordQuery::new("rust", page(1, 10)).filter(SearchFilter::default().allow_ids([2_i64]));
+    let results = backend.keyword_search(&def, &query).await.expect("search");
+    assert_eq!(
+        results.content.iter().map(|h| h.id).collect::<Vec<_>>(),
+        vec![2]
+    );
+
+    // An *empty* allowlist means "nothing is visible", not "no filter".
+    let none = KeywordQuery::new("rust", page(1, 10))
+        .filter(SearchFilter::default().allow_ids(Vec::<i64>::new()));
+    let results = backend.keyword_search(&def, &none).await.expect("search");
+    assert!(results.content.is_empty());
+    assert_eq!(results.total_elements, 0);
+}
+
+#[tokio::test]
+async fn an_excluded_ids_filter_removes_specific_records() {
+    let backend = seeded_backend(&corpus()).await;
+    let def = Article::index_definition();
+
+    let query =
+        KeywordQuery::new("rust", page(1, 10)).filter(SearchFilter::default().exclude_ids([1_i64]));
+    let results = backend.keyword_search(&def, &query).await.expect("search");
+    assert_eq!(
+        results.content.iter().map(|h| h.id).collect::<Vec<_>>(),
+        vec![2]
+    );
+}
+
+// ── Vector search ───────────────────────────────────────────────────────────
+
+fn vector_doc(id: i64, embedding: [f32; 3]) -> IndexedDocument {
+    IndexedDocument::new(article(id, "t", "b").search_document()).with_embedding(embedding.to_vec())
+}
+
+#[tokio::test]
+async fn vector_search_returns_the_nearest_neighbours_by_cosine_similarity() {
+    let backend = MemorySearchBackend::new();
+    let def = Article::index_definition();
+    backend.ensure_index(&def).await.expect("ensure");
+    backend
+        .index(
+            &def,
+            &[
+                vector_doc(1, [1.0, 0.0, 0.0]),
+                vector_doc(2, [0.9, 0.1, 0.0]),
+                vector_doc(3, [0.0, 1.0, 0.0]),
+            ],
+        )
+        .await
+        .expect("index");
+
+    let hits = backend
+        .vector_search(&def, &VectorQuery::new(vec![1.0, 0.0, 0.0], 2))
+        .await
+        .expect("vector search");
+
+    assert_eq!(hits.iter().map(|h| h.id).collect::<Vec<_>>(), vec![1, 2]);
+    assert!(hits[0].score > hits[1].score);
+    assert!(
+        (hits[0].score - 1.0).abs() < 1e-5,
+        "score {}",
+        hits[0].score
+    );
+}
+
+#[tokio::test]
+async fn vector_search_honours_the_filter_and_the_minimum_score() {
+    let backend = MemorySearchBackend::new();
+    let def = Article::index_definition();
+    backend.ensure_index(&def).await.expect("ensure");
+    backend
+        .index(
+            &def,
+            &[
+                vector_doc(1, [1.0, 0.0, 0.0]),
+                vector_doc(2, [0.0, 1.0, 0.0]),
+            ],
+        )
+        .await
+        .expect("index");
+
+    let filtered = backend
+        .vector_search(
+            &def,
+            &VectorQuery::new(vec![1.0, 0.0, 0.0], 10)
+                .filter(SearchFilter::default().allow_ids([2_i64])),
+        )
+        .await
+        .expect("filtered");
+    assert_eq!(filtered.iter().map(|h| h.id).collect::<Vec<_>>(), vec![2]);
+
+    let thresholded = backend
+        .vector_search(
+            &def,
+            &VectorQuery::new(vec![1.0, 0.0, 0.0], 10).min_score(0.5),
+        )
+        .await
+        .expect("thresholded");
+    assert_eq!(
+        thresholded.iter().map(|h| h.id).collect::<Vec<_>>(),
+        vec![1]
+    );
+}
+
+#[tokio::test]
+async fn documents_without_an_embedding_are_invisible_to_vector_search() {
+    let backend = seeded_backend(&corpus()).await;
+    let def = Article::index_definition();
+
+    let hits = backend
+        .vector_search(&def, &VectorQuery::new(vec![1.0, 0.0, 0.0], 10))
+        .await
+        .expect("vector search");
+    assert!(hits.is_empty());
+}
+
+#[tokio::test]
+async fn a_dimension_mismatch_is_rejected_rather_than_silently_scored() {
+    let backend = MemorySearchBackend::new();
+    let def = Article::index_definition();
+    backend.ensure_index(&def).await.expect("ensure");
+    backend
+        .index(&def, &[vector_doc(1, [1.0, 0.0, 0.0])])
+        .await
+        .expect("index");
+
+    let err = backend
+        .vector_search(&def, &VectorQuery::new(vec![1.0, 0.0], 10))
+        .await
+        .unwrap_err();
+    assert!(
+        matches!(err, SearchError::DimensionMismatch { .. }),
+        "{err:?}"
+    );
+}
+
+#[tokio::test]
+async fn vector_search_on_an_index_without_an_embed_field_is_a_typed_error() {
+    let backend = MemorySearchBackend::new();
+    let mut def = Article::index_definition();
+    def.embed_field = None;
+    backend.ensure_index(&def).await.expect("ensure");
+
+    let err = backend
+        .vector_search(&def, &VectorQuery::new(vec![1.0], 1))
+        .await
+        .unwrap_err();
+    assert!(
+        matches!(err, SearchError::VectorUnsupported { .. }),
+        "{err:?}"
+    );
+}

--- a/autumn-search/tests/integration/memory_backend.rs
+++ b/autumn-search/tests/integration/memory_backend.rs
@@ -13,7 +13,10 @@ use autumn_search::{
 use autumn_web::pagination::PageRequest;
 use autumn_web::search::SearchIndexed as _;
 
-use super::support::{Article, article, seeded_backend, tenant_article};
+use super::support::{
+    Article, TenantArticle, article, seeded_backend, seeded_tenant_backend, tenant_article,
+    untenanted_article,
+};
 
 fn corpus() -> Vec<Article> {
     vec![
@@ -223,13 +226,13 @@ async fn ensure_index_is_idempotent_and_rejects_an_invalid_definition() {
 
 #[tokio::test]
 async fn a_tenant_filter_never_returns_another_tenants_records() {
-    let backend = seeded_backend(&[
+    let backend = seeded_tenant_backend(&[
         tenant_article(1, "Rust at acme", "internal", "acme"),
         tenant_article(2, "Rust at globex", "internal", "globex"),
-        article(3, "Rust in public", "no tenant"),
+        untenanted_article(3, "Rust in public", "no tenant"),
     ])
     .await;
-    let def = Article::index_definition();
+    let def = TenantArticle::index_definition();
 
     let query =
         KeywordQuery::new("rust", page(1, 10)).filter(SearchFilter::default().tenant("acme"));

--- a/autumn-search/tests/integration/mod.rs
+++ b/autumn-search/tests/integration/mod.rs
@@ -4,7 +4,9 @@ mod support;
 
 mod backfill;
 mod embedding;
+mod extensibility;
 mod memory_backend;
+mod plugin_runtime;
 mod plugin_wiring;
 mod postgres_backend;
 mod reindex;

--- a/autumn-search/tests/integration/mod.rs
+++ b/autumn-search/tests/integration/mod.rs
@@ -1,0 +1,13 @@
+//! Suites compiled into the consolidated `search_tests` binary.
+
+mod support;
+
+mod backfill;
+mod embedding;
+mod memory_backend;
+mod plugin_wiring;
+mod postgres_backend;
+mod reindex;
+mod search_client;
+mod sync_hooks;
+mod visibility;

--- a/autumn-search/tests/integration/plugin_runtime.rs
+++ b/autumn-search/tests/integration/plugin_runtime.rs
@@ -1,0 +1,333 @@
+//! The plugin's **runtime** wiring, driven through `autumn-web`'s in-process
+//! test client.
+//!
+//! AC 8 names the in-process test client specifically, and for a reason: the
+//! other suites drive `SearchClient` directly, which proves the *engine* works
+//! but proves nothing about the seam an application actually touches — the
+//! startup hook, the installed extension, and the `#[job]` handlers. `TestApp`
+//! runs a plugin's startup hooks and `TestClient` records and executes
+//! enqueued jobs, so this suite closes exactly that gap.
+//!
+//! Everything here asserts behaviour rather than shape: each test would fail
+//! if the production wiring it names were deleted.
+//!
+//! `TestApp::build` installs the **process-global** job client, and the
+//! enqueue helpers resolve through it. Every test here therefore serializes on
+//! `job::global_job_runtime_test_lock()` and clears the client first —
+//! including the ones that never enqueue, because otherwise *their* `build()`
+//! would swap the client out from under a test that is mid-assertion. Same
+//! convention as `autumn/tests/integration/job_recorder_integration.rs`.
+
+use std::sync::Arc;
+
+use autumn_search::{
+    BackfillOptions, MemoryDocumentSource, MemorySearchBackend, REINDEX_JOB, ReindexArgs,
+    SearchClient, SearchConfig, SearchPlugin,
+};
+use autumn_web::job;
+use autumn_web::pagination::PageRequest;
+use autumn_web::test::TestApp;
+
+use super::support::{Article, article};
+
+/// Build a test app with the plugin installed over an in-memory backend and a
+/// document source seeded with `articles`.
+fn app_with(
+    articles: &[Article],
+    config: SearchConfig,
+) -> (autumn_web::test::TestClient, Arc<MemoryDocumentSource>) {
+    let source = Arc::new(MemoryDocumentSource::new());
+    for record in articles {
+        source.upsert(record);
+    }
+    let client = TestApp::new()
+        .plugin(
+            SearchPlugin::new()
+                .config(config)
+                .backend(Arc::new(MemorySearchBackend::new()))
+                .source(source.clone())
+                .index::<Article>(),
+        )
+        .build();
+    (client, source)
+}
+
+fn corpus() -> Vec<Article> {
+    vec![
+        article(1, "Rust web frameworks", "A survey."),
+        article(2, "Gardening", "Tomatoes."),
+    ]
+}
+
+/// The `SearchClient` the plugin's startup hook installed on `AppState`.
+fn installed_client(test: &autumn_web::test::TestClient) -> Arc<SearchClient> {
+    test.state()
+        .extension::<SearchClient>()
+        .expect("the plugin's startup hook must install a SearchClient extension")
+}
+
+#[tokio::test]
+async fn the_startup_hook_installs_a_client_whose_indexes_are_ready() {
+    let _guard = job::global_job_runtime_test_lock().lock().await;
+    job::clear_global_job_client();
+
+    // Not "does the builder hold an index" — does the *app* come up with a
+    // client that has already created its storage.
+    let (test, _source) = app_with(&corpus(), SearchConfig::default());
+    let search = installed_client(&test);
+
+    assert_eq!(search.index_names(), vec!["search_articles"]);
+
+    // `ensure_indexes` ran during startup, so indexing works with no further
+    // setup — if the hook had skipped it, an unknown-index error would surface
+    // here rather than at boot.
+    search
+        .index_record(&article(1, "Rust web frameworks", "A survey."))
+        .await
+        .expect("index");
+    let page = search
+        .search::<Article>("rust", &PageRequest::default())
+        .await
+        .expect("search");
+    assert_eq!(
+        page.content.iter().map(|h| h.id).collect::<Vec<_>>(),
+        vec![1]
+    );
+}
+
+#[tokio::test]
+async fn a_lifecycle_reindex_flows_through_the_job_queue_into_the_index() {
+    let _guard = job::global_job_runtime_test_lock().lock().await;
+    job::clear_global_job_client();
+
+    // The whole of AC3 in one test: an enqueue (as `SearchSyncHooks` performs
+    // it from `after_*_commit`) is recorded on the queue, and *running the
+    // registered job handler* — not calling the client directly — is what puts
+    // the record in the index.
+    let (test, _source) = app_with(&corpus(), SearchConfig::default());
+    let search = installed_client(&test);
+
+    assert!(
+        search
+            .search::<Article>("rust", &PageRequest::default())
+            .await
+            .expect("search")
+            .content
+            .is_empty(),
+        "nothing is indexed before the job runs"
+    );
+
+    autumn_search::enqueue_reindex(&ReindexArgs::upsert("search_articles", 1))
+        .await
+        .expect("enqueue");
+    test.assert_job_enqueued_with(
+        REINDEX_JOB,
+        serde_json::json!({"index": "search_articles", "id": 1, "op": "upsert"}),
+    );
+
+    let performed = test.perform_enqueued_jobs().await;
+    performed.assert_all_succeeded();
+
+    let page = search
+        .search::<Article>("rust", &PageRequest::default())
+        .await
+        .expect("search");
+    assert_eq!(
+        page.content.iter().map(|h| h.id).collect::<Vec<_>>(),
+        vec![1],
+        "running the registered job handler must index the record"
+    );
+}
+
+#[tokio::test]
+async fn a_delete_instruction_removes_the_record_through_the_same_job() {
+    let _guard = job::global_job_runtime_test_lock().lock().await;
+    job::clear_global_job_client();
+
+    let (test, _source) = app_with(&corpus(), SearchConfig::default());
+    let search = installed_client(&test);
+
+    autumn_search::enqueue_reindex(&ReindexArgs::upsert("search_articles", 1))
+        .await
+        .expect("enqueue");
+    test.perform_enqueued_jobs().await.assert_all_succeeded();
+
+    autumn_search::enqueue_reindex(&ReindexArgs::delete("search_articles", 1))
+        .await
+        .expect("enqueue");
+    test.assert_job_enqueued_with(
+        REINDEX_JOB,
+        serde_json::json!({"index": "search_articles", "id": 1, "op": "delete"}),
+    );
+    test.perform_enqueued_jobs().await.assert_all_succeeded();
+
+    assert!(
+        search
+            .search::<Article>("rust", &PageRequest::default())
+            .await
+            .expect("search")
+            .content
+            .is_empty()
+    );
+}
+
+#[tokio::test]
+async fn a_reindex_for_a_row_that_is_gone_converges_via_the_job_handler() {
+    let _guard = job::global_job_runtime_test_lock().lock().await;
+    job::clear_global_job_client();
+
+    // Drift repair, end to end: the source loses the row, the ordinary upsert
+    // job runs, and the document goes away.
+    let (test, source) = app_with(&corpus(), SearchConfig::default());
+    let search = installed_client(&test);
+
+    autumn_search::enqueue_reindex(&ReindexArgs::upsert("search_articles", 1))
+        .await
+        .expect("enqueue");
+    test.perform_enqueued_jobs().await.assert_all_succeeded();
+    assert_eq!(
+        search
+            .search::<Article>("rust", &PageRequest::default())
+            .await
+            .expect("search")
+            .content
+            .len(),
+        1
+    );
+
+    source.remove(1);
+    autumn_search::enqueue_reindex(&ReindexArgs::upsert("search_articles", 1))
+        .await
+        .expect("enqueue");
+    test.perform_enqueued_jobs().await.assert_all_succeeded();
+
+    assert!(
+        search
+            .search::<Article>("rust", &PageRequest::default())
+            .await
+            .expect("search")
+            .content
+            .is_empty()
+    );
+}
+
+#[tokio::test]
+async fn a_malformed_job_payload_fails_the_job_rather_than_being_ignored() {
+    let _guard = job::global_job_runtime_test_lock().lock().await;
+    job::clear_global_job_client();
+
+    let (test, _source) = app_with(&corpus(), SearchConfig::default());
+
+    autumn_web::job::enqueue(REINDEX_JOB, serde_json::json!({"nonsense": true}))
+        .await
+        .expect("enqueue");
+    let performed = test.perform_enqueued_jobs().await;
+
+    let failures = performed.failures();
+    assert_eq!(failures.len(), 1, "a bad payload must fail, not no-op");
+    assert!(
+        failures[0]
+            .1
+            .to_string()
+            .contains("invalid reindex payload"),
+        "{:?}",
+        failures[0].1
+    );
+}
+
+// ── The kill switch ─────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn disabling_search_in_config_makes_index_writes_and_queries_no_ops() {
+    let _guard = job::global_job_runtime_test_lock().lock().await;
+    job::clear_global_job_client();
+
+    let disabled = SearchConfig::from_toml_str("[search]\nenabled = false\n").expect("parse");
+    let (test, _source) = app_with(&corpus(), disabled);
+    let search = installed_client(&test);
+
+    assert!(!search.is_enabled());
+
+    search
+        .index_record(&article(1, "Rust", "a rust framework"))
+        .await
+        .expect("index write must no-op, not error");
+    let page = search
+        .search::<Article>("rust", &PageRequest::default())
+        .await
+        .expect("search");
+    assert!(page.content.is_empty());
+    assert_eq!(page.total_elements, 0);
+}
+
+#[tokio::test]
+async fn disabling_search_stops_a_backfill_including_a_purging_one() {
+    let _guard = job::global_job_runtime_test_lock().lock().await;
+    job::clear_global_job_client();
+
+    // The most destructive write there is. A queued backfill job that outlives
+    // the decision to turn search off must not still empty the index.
+    let (test, _source) = app_with(&corpus(), SearchConfig::default());
+    let enabled = installed_client(&test);
+    enabled
+        .backfill("search_articles", &BackfillOptions::default())
+        .await
+        .expect("backfill");
+    assert_eq!(
+        enabled
+            .search::<Article>("rust", &PageRequest::default())
+            .await
+            .expect("search")
+            .total_elements,
+        1
+    );
+
+    let disabled = SearchConfig::from_toml_str("[search]\nenabled = false\n").expect("parse");
+    let (test, _source) = app_with(&corpus(), disabled);
+    let search = installed_client(&test);
+
+    let report = search
+        .backfill("search_articles", &BackfillOptions::default().purge(true))
+        .await
+        .expect("backfill must no-op, not error");
+    assert_eq!(report.indexed, 0);
+    assert!(!report.purged, "a disabled client must not clear the index");
+}
+
+#[tokio::test]
+async fn a_disabled_client_no_ops_an_in_flight_job_for_an_unregistered_index() {
+    let _guard = job::global_job_runtime_test_lock().lock().await;
+    job::clear_global_job_client();
+
+    // Ordering matters: checking the index registry first would make this
+    // `UnknownIndex`, so the job would retry to exhaustion and dead-letter
+    // instead of quietly doing nothing.
+    let disabled = SearchConfig::from_toml_str("[search]\nenabled = false\n").expect("parse");
+    let (test, _source) = app_with(&corpus(), disabled);
+    let search = installed_client(&test);
+
+    search
+        .reindex(&ReindexArgs::upsert("an_index_that_is_gone", 1))
+        .await
+        .expect("a disabled client must no-op rather than fail");
+}
+
+// ── Configuration reaches the runtime ───────────────────────────────────────
+
+#[tokio::test]
+async fn the_configured_batch_size_reaches_the_client() {
+    let _guard = job::global_job_runtime_test_lock().lock().await;
+    job::clear_global_job_client();
+
+    let config = SearchConfig::from_toml_str("[search]\nbatch_size = 7\n").expect("parse");
+    let (test, _source) = app_with(&corpus(), config);
+    assert_eq!(installed_client(&test).default_batch_size(), 7);
+}
+
+#[tokio::test]
+async fn the_configured_queue_reaches_the_registered_jobs() {
+    let config = SearchConfig::from_toml_str("[search]\nqueue = \"indexing\"\n").expect("parse");
+    let infos = autumn_search::search_job_infos(&config.queue);
+    assert!(infos.iter().all(|info| info.queue == "indexing"));
+    assert_eq!(infos.len(), 2);
+}

--- a/autumn-search/tests/integration/plugin_runtime.rs
+++ b/autumn-search/tests/integration/plugin_runtime.rs
@@ -376,3 +376,53 @@ async fn disabled_search_returns_an_empty_page_even_with_no_visibility_hook() {
             .is_empty()
     );
 }
+
+// ── Declared width vs installed embedder ────────────────────────────────────
+
+/// Build an app whose declared `embedding_dimensions` may disagree with the
+/// installed embedder.
+fn app_with_widths(
+    declared: Option<usize>,
+    embedder: Arc<dyn autumn_search::Embedder>,
+) -> autumn_web::test::TestClient {
+    let mut config = SearchConfig::default();
+    config.embedding_dimensions = declared;
+    TestApp::new()
+        .plugin(
+            SearchPlugin::new()
+                .config(config)
+                .backend(Arc::new(MemorySearchBackend::new()))
+                .embedder(embedder)
+                .index::<Article>(),
+        )
+        .build()
+}
+
+#[tokio::test]
+#[should_panic(expected = "does not match the installed embedder")]
+async fn a_declared_width_that_disagrees_with_the_embedder_fails_at_boot() {
+    // The two are set in different places — `[search] embedding_dimensions` in
+    // config, `Embedder::dimensions()` in code — and the failure mode is
+    // silent: every index write reports success, the vector column rejects the
+    // wrong-width value, and semantic search just returns nothing forever. A
+    // refused boot is the only version of this an operator can act on.
+    let _guard = job::global_job_runtime_test_lock().lock().await;
+    job::clear_global_job_client();
+
+    let _ = app_with_widths(Some(128), Arc::new(autumn_search::HashingEmbedder::new(64)));
+}
+
+#[tokio::test]
+async fn a_matching_width_boots_and_a_declared_width_without_an_embedder_is_allowed() {
+    let _guard = job::global_job_runtime_test_lock().lock().await;
+    job::clear_global_job_client();
+
+    let test = app_with_widths(Some(64), Arc::new(autumn_search::HashingEmbedder::new(64)));
+    assert_eq!(installed_client(&test).embedding_dimensions(), 64);
+
+    // Declaring a width before installing a provider is a legitimate ordering:
+    // `NoEmbedder` reports `0`, nothing vector-shaped runs, and the declared
+    // width is simply what the backend will use once a provider arrives.
+    let test = app_with_widths(Some(768), Arc::new(autumn_search::NoEmbedder));
+    assert_eq!(installed_client(&test).embedding_dimensions(), 0);
+}

--- a/autumn-search/tests/integration/plugin_runtime.rs
+++ b/autumn-search/tests/integration/plugin_runtime.rs
@@ -336,3 +336,43 @@ async fn the_configured_queue_reaches_the_registered_jobs() {
     assert!(infos.iter().all(|info| info.queue == "indexing"));
     assert_eq!(infos.len(), 2);
 }
+
+// ── The kill switch beats the authorization hook ────────────────────────────
+
+#[tokio::test]
+async fn disabled_search_returns_an_empty_page_even_with_no_visibility_hook() {
+    // Ordering matters: consulting `SearchVisibility` first would turn the
+    // documented empty page into `VisibilityUnavailable`, so the kill switch
+    // would be ineffective on precisely the authorization-aware endpoints an
+    // app is most likely to have.
+    let _guard = job::global_job_runtime_test_lock().lock().await;
+    job::clear_global_job_client();
+
+    let disabled = SearchConfig::from_toml_str("[search]\nenabled = false\n").expect("parse");
+    let (test, _source) = app_with(&corpus(), disabled);
+    let search = installed_client(&test);
+    let ctx = super::support::policy_context(Some("alice")).await;
+
+    let page = search
+        .search_for::<Article>(&ctx, "rust", &PageRequest::default())
+        .await
+        .expect("a disabled search must not demand a visibility hook");
+    assert!(page.content.is_empty());
+    assert_eq!(page.total_elements, 0);
+
+    // The two semantic entry points have the same ordering.
+    assert!(
+        search
+            .similar_for::<Article>(&ctx, "rust", 5)
+            .await
+            .expect("similar_for")
+            .is_empty()
+    );
+    assert!(
+        search
+            .similar_to_for::<Article>(&ctx, 1, 5)
+            .await
+            .expect("similar_to_for")
+            .is_empty()
+    );
+}

--- a/autumn-search/tests/integration/plugin_runtime.rs
+++ b/autumn-search/tests/integration/plugin_runtime.rs
@@ -120,9 +120,13 @@ async fn a_lifecycle_reindex_flows_through_the_job_queue_into_the_index() {
     autumn_search::enqueue_reindex(&ReindexArgs::upsert("search_articles", 1))
         .await
         .expect("enqueue");
+    // Serialized from the constructor rather than hand-written, so the
+    // assertion tracks the payload contract instead of pinning a snapshot of
+    // it — `scope` was added for the per-record concurrency cap and is part of
+    // what actually goes on the wire.
     test.assert_job_enqueued_with(
         REINDEX_JOB,
-        serde_json::json!({"index": "search_articles", "id": 1, "op": "upsert"}),
+        serde_json::to_value(ReindexArgs::upsert("search_articles", 1)).expect("serialize"),
     );
 
     let performed = test.perform_enqueued_jobs().await;
@@ -162,7 +166,7 @@ async fn a_delete_instruction_removes_the_record_through_the_same_job() {
         .expect("enqueue");
     test.assert_job_enqueued_with(
         REINDEX_JOB,
-        serde_json::json!({"index": "search_articles", "id": 1, "op": "delete"}),
+        serde_json::to_value(ReindexArgs::delete("search_articles", 1)).expect("serialize"),
     );
     test.perform_enqueued_jobs().await.assert_all_succeeded();
 

--- a/autumn-search/tests/integration/plugin_runtime.rs
+++ b/autumn-search/tests/integration/plugin_runtime.rs
@@ -144,7 +144,7 @@ async fn a_delete_instruction_removes_the_record_through_the_same_job() {
     let _guard = job::global_job_runtime_test_lock().lock().await;
     job::clear_global_job_client();
 
-    let (test, _source) = app_with(&corpus(), SearchConfig::default());
+    let (test, source) = app_with(&corpus(), SearchConfig::default());
     let search = installed_client(&test);
 
     autumn_search::enqueue_reindex(&ReindexArgs::upsert("search_articles", 1))
@@ -152,6 +152,11 @@ async fn a_delete_instruction_removes_the_record_through_the_same_job() {
         .expect("enqueue");
     test.perform_enqueued_jobs().await.assert_all_succeeded();
 
+    // A real delete removes the row first; the hook then enqueues the
+    // instruction. Both ops re-read, so the *row's* absence is what removes
+    // the document — which is precisely what stops a stale delete from
+    // evicting a record that has since been recreated.
+    source.remove(1);
     autumn_search::enqueue_reindex(&ReindexArgs::delete("search_articles", 1))
         .await
         .expect("enqueue");

--- a/autumn-search/tests/integration/plugin_runtime.rs
+++ b/autumn-search/tests/integration/plugin_runtime.rs
@@ -430,3 +430,131 @@ async fn a_matching_width_boots_and_a_declared_width_without_an_embedder_is_allo
     let test = app_with_widths(Some(768), Arc::new(autumn_search::NoEmbedder));
     assert_eq!(installed_client(&test).embedding_dimensions(), 0);
 }
+
+// ── A disabled subsystem initializes nothing ────────────────────────────────
+
+/// A backend whose setup always fails — the shape of a search-specific outage:
+/// an unreachable external engine, a `CREATE EXTENSION` the role may not run,
+/// a revoked DDL grant.
+#[derive(Default)]
+struct BrokenBackend {
+    ensure_calls: std::sync::atomic::AtomicUsize,
+}
+
+impl autumn_search::SearchBackend for BrokenBackend {
+    fn name(&self) -> &'static str {
+        "broken"
+    }
+
+    fn ensure_index<'a>(
+        &'a self,
+        _definition: &'a autumn_search::IndexDefinition,
+    ) -> autumn_search::BoxFuture<'a, autumn_search::SearchResult<()>> {
+        Box::pin(async move {
+            self.ensure_calls
+                .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            Err(autumn_search::SearchError::Backend(
+                "the search cluster is unreachable".to_owned(),
+            ))
+        })
+    }
+
+    fn index<'a>(
+        &'a self,
+        _definition: &'a autumn_search::IndexDefinition,
+        _documents: &'a [autumn_search::IndexedDocument],
+    ) -> autumn_search::BoxFuture<'a, autumn_search::SearchResult<()>> {
+        Box::pin(async move { Ok(()) })
+    }
+
+    fn delete<'a>(
+        &'a self,
+        _definition: &'a autumn_search::IndexDefinition,
+        _ids: &'a [i64],
+    ) -> autumn_search::BoxFuture<'a, autumn_search::SearchResult<()>> {
+        Box::pin(async move { Ok(()) })
+    }
+
+    fn clear<'a>(
+        &'a self,
+        _definition: &'a autumn_search::IndexDefinition,
+    ) -> autumn_search::BoxFuture<'a, autumn_search::SearchResult<()>> {
+        Box::pin(async move { Ok(()) })
+    }
+
+    fn keyword_search<'a>(
+        &'a self,
+        _definition: &'a autumn_search::IndexDefinition,
+        query: &'a autumn_search::KeywordQuery,
+    ) -> autumn_search::BoxFuture<
+        'a,
+        autumn_search::SearchResult<autumn_search::Page<autumn_search::SearchHit>>,
+    > {
+        Box::pin(async move { Ok(autumn_search::Page::new(Vec::new(), 0, &query.page)) })
+    }
+}
+
+fn app_with_backend(
+    config: SearchConfig,
+    backend: Arc<BrokenBackend>,
+) -> autumn_web::test::TestClient {
+    TestApp::new()
+        .plugin(
+            SearchPlugin::new()
+                .config(config)
+                .backend(backend)
+                .index::<Article>(),
+        )
+        .build()
+}
+
+#[tokio::test]
+#[should_panic(expected = "search index setup failed")]
+async fn an_enabled_search_with_a_broken_backend_aborts_boot() {
+    // The control case: while search is ON, a backend that cannot be set up is
+    // a real boot failure. Without this, the test below would pass for the
+    // wrong reason.
+    let _guard = job::global_job_runtime_test_lock().lock().await;
+    job::clear_global_job_client();
+
+    let _ = app_with_backend(SearchConfig::default(), Arc::new(BrokenBackend::default()));
+}
+
+#[tokio::test]
+async fn a_disabled_search_does_not_touch_the_backend_at_boot() {
+    // `enabled = false` exists so that a search outage cannot take the
+    // application down. Running `ensure_index` anyway means the incident the
+    // switch was flipped for still aborts startup — the switch would be
+    // useless in exactly the situation it was written for.
+    let _guard = job::global_job_runtime_test_lock().lock().await;
+    job::clear_global_job_client();
+
+    let backend = Arc::new(BrokenBackend::default());
+    let disabled = SearchConfig::from_toml_str("[search]\nenabled = false\n").expect("parse");
+    let test = app_with_backend(disabled, backend.clone());
+
+    assert_eq!(
+        backend
+            .ensure_calls
+            .load(std::sync::atomic::Ordering::SeqCst),
+        0,
+        "a disabled subsystem must not initialize its backend"
+    );
+
+    // And the client is still installed, so a handler that resolves the
+    // extension finds a working (no-op) one rather than nothing at all.
+    let search = installed_client(&test);
+    assert!(!search.is_enabled());
+    search
+        .index_record(&article(1, "Rust", "a survey"))
+        .await
+        .expect("a disabled index write is a no-op, not an error");
+    assert!(
+        search
+            .search::<Article>("rust", &PageRequest::default())
+            .await
+            .expect("disabled search returns an empty page")
+            .content
+            .is_empty()
+    );
+}

--- a/autumn-search/tests/integration/plugin_wiring.rs
+++ b/autumn-search/tests/integration/plugin_wiring.rs
@@ -47,6 +47,25 @@ fn the_plugin_registers_its_reindex_and_backfill_jobs_on_the_configured_queue() 
     assert!(infos.iter().all(|i| i.queue == "indexing"));
 }
 
+#[test]
+fn the_client_honours_a_postgres_request() {
+    // `postgres()` only records the intent — the store is created at build
+    // time. If `client()` did not resolve it, this would silently hand back an
+    // isolated in-memory index instead of the configured persistent backend.
+    let plugin = SearchPlugin::new().postgres().index::<Article>();
+    assert!(plugin.uses_postgres());
+    assert_eq!(plugin.client().backend().name(), "postgres");
+
+    // And an explicit backend still wins, without leaving the Postgres store
+    // behind as a pool-less document source.
+    let plugin = SearchPlugin::new()
+        .postgres()
+        .backend(Arc::new(MemorySearchBackend::new()))
+        .index::<Article>();
+    assert!(!plugin.uses_postgres());
+    assert_eq!(plugin.client().backend().name(), "memory");
+}
+
 #[tokio::test]
 async fn the_plugin_exposes_a_ready_to_use_client() {
     let plugin = SearchPlugin::new()

--- a/autumn-search/tests/integration/plugin_wiring.rs
+++ b/autumn-search/tests/integration/plugin_wiring.rs
@@ -81,7 +81,7 @@ fn config_parses_the_search_section_of_autumn_toml() {
         enabled = false
         embedding_dimensions = 768
     "#;
-    let config = SearchConfig::from_autumn_toml(toml).expect("parse");
+    let config = SearchConfig::from_toml_str(toml).expect("parse");
     assert_eq!(config.queue, "indexing");
     assert_eq!(config.batch_size, 42);
     assert!(!config.enabled);
@@ -90,18 +90,18 @@ fn config_parses_the_search_section_of_autumn_toml() {
 
 #[test]
 fn a_missing_search_section_yields_the_defaults() {
-    let config = SearchConfig::from_autumn_toml("[server]\nport = 3000\n").expect("parse");
+    let config = SearchConfig::from_toml_str("[server]\nport = 3000\n").expect("parse");
     assert_eq!(config, SearchConfig::default());
 }
 
 #[test]
 fn an_unknown_search_key_is_rejected_rather_than_silently_ignored() {
     let toml = "[search]\nqueu = \"typo\"\n";
-    assert!(SearchConfig::from_autumn_toml(toml).is_err());
+    assert!(SearchConfig::from_toml_str(toml).is_err());
 }
 
 #[test]
 fn a_zero_batch_size_in_config_is_rejected() {
     let toml = "[search]\nbatch_size = 0\n";
-    assert!(SearchConfig::from_autumn_toml(toml).is_err());
+    assert!(SearchConfig::from_toml_str(toml).is_err());
 }

--- a/autumn-search/tests/integration/plugin_wiring.rs
+++ b/autumn-search/tests/integration/plugin_wiring.rs
@@ -1,0 +1,107 @@
+//! `SearchPlugin` wiring.
+//!
+//! AC: "A new plugin crate (`autumn-search`) registers via the `Plugin` seam
+//! (its own config + startup wiring), mounted with one builder call like the
+//! other plugins."
+
+use std::sync::Arc;
+
+use autumn_search::{
+    HashingEmbedder, MemorySearchBackend, SearchClient, SearchConfig, SearchPlugin,
+};
+
+use super::support::Article;
+
+#[test]
+fn the_plugin_mounts_with_one_builder_call() {
+    let app = autumn_web::app().plugin(
+        SearchPlugin::new()
+            .backend(Arc::new(MemorySearchBackend::new()))
+            .embedder(Arc::new(HashingEmbedder::new(64)))
+            .index::<Article>(),
+    );
+
+    assert!(app.has_plugin("autumn-search"));
+}
+
+#[test]
+fn the_plugin_declares_its_own_config_section() {
+    // Without this a host app running `server.strict_config = true` would fail
+    // to boot with `unknown key "search"`.
+    let app = autumn_web::app().plugin(SearchPlugin::new().index::<Article>());
+    assert!(app.has_config_section("search"));
+}
+
+#[test]
+fn registering_the_plugin_twice_is_a_no_op() {
+    let app = autumn_web::app()
+        .plugin(SearchPlugin::new().index::<Article>())
+        .plugin(SearchPlugin::new().index::<Article>());
+    assert!(app.has_plugin("autumn-search"));
+}
+
+#[test]
+fn the_plugin_registers_its_reindex_and_backfill_jobs_on_the_configured_queue() {
+    let infos = autumn_search::search_job_infos("indexing");
+    assert_eq!(infos.len(), 2);
+    assert!(infos.iter().all(|i| i.queue == "indexing"));
+}
+
+#[tokio::test]
+async fn the_plugin_exposes_a_ready_to_use_client() {
+    let plugin = SearchPlugin::new()
+        .backend(Arc::new(MemorySearchBackend::new()))
+        .embedder(Arc::new(HashingEmbedder::new(32)))
+        .index::<Article>();
+
+    let client: SearchClient = plugin.client();
+    client.ensure_indexes().await.expect("ensure");
+    assert!(client.index_definition("search_articles").is_some());
+    assert!(client.index_definition("missing").is_none());
+    assert_eq!(client.index_names(), vec!["search_articles"]);
+}
+
+// ── Config ──────────────────────────────────────────────────────────────────
+
+#[test]
+fn config_defaults_are_conservative() {
+    let config = SearchConfig::default();
+    assert_eq!(config.queue, "search");
+    assert_eq!(config.batch_size, 500);
+    assert!(config.enabled);
+    assert!(config.embedding_dimensions.is_none());
+}
+
+#[test]
+fn config_parses_the_search_section_of_autumn_toml() {
+    let toml = r#"
+        [search]
+        queue = "indexing"
+        batch_size = 42
+        enabled = false
+        embedding_dimensions = 768
+    "#;
+    let config = SearchConfig::from_autumn_toml(toml).expect("parse");
+    assert_eq!(config.queue, "indexing");
+    assert_eq!(config.batch_size, 42);
+    assert!(!config.enabled);
+    assert_eq!(config.embedding_dimensions, Some(768));
+}
+
+#[test]
+fn a_missing_search_section_yields_the_defaults() {
+    let config = SearchConfig::from_autumn_toml("[server]\nport = 3000\n").expect("parse");
+    assert_eq!(config, SearchConfig::default());
+}
+
+#[test]
+fn an_unknown_search_key_is_rejected_rather_than_silently_ignored() {
+    let toml = "[search]\nqueu = \"typo\"\n";
+    assert!(SearchConfig::from_autumn_toml(toml).is_err());
+}
+
+#[test]
+fn a_zero_batch_size_in_config_is_rejected() {
+    let toml = "[search]\nbatch_size = 0\n";
+    assert!(SearchConfig::from_autumn_toml(toml).is_err());
+}

--- a/autumn-search/tests/integration/plugin_wiring.rs
+++ b/autumn-search/tests/integration/plugin_wiring.rs
@@ -124,3 +124,59 @@ fn a_zero_batch_size_in_config_is_rejected() {
     let toml = "[search]\nbatch_size = 0\n";
     assert!(SearchConfig::from_toml_str(toml).is_err());
 }
+
+// ── The client taken before the plugin is mounted ───────────────────────────
+
+#[tokio::test]
+async fn every_client_the_plugin_hands_out_shares_one_index() {
+    // The documented outside-request path forces `client()` to be called
+    // *before* the plugin is moved into `app.plugin(...)`. If each call minted
+    // its own default `MemorySearchBackend`, the retained handle and the one
+    // the startup hook installs would address separate indexes: the app would
+    // write through one and serve requests from the other, and every search
+    // would come back empty with nothing in the logs.
+    let plugin = SearchPlugin::new()
+        .embedder(Arc::new(HashingEmbedder::new(32)))
+        .index::<Article>();
+
+    let retained = plugin.client();
+    let installed = plugin.client();
+    retained.ensure_indexes().await.expect("ensure");
+
+    retained
+        .index_record(&super::support::article(1, "Rust web", "a survey"))
+        .await
+        .expect("index through the retained handle");
+
+    let page = installed
+        .search::<Article>("rust", &autumn_search::PageRequest::default())
+        .await
+        .expect("search through the installed handle");
+    assert_eq!(
+        page.content.iter().map(|hit| hit.id).collect::<Vec<_>>(),
+        vec![1],
+        "both handles must address the same index"
+    );
+}
+
+#[test]
+fn a_client_taken_before_build_still_honours_the_resolved_config() {
+    // `enabled` is resolved from the app's config, which happens at build
+    // time — but a handle taken before then must not keep serving searches
+    // that the resolved section turned off. Resolution is memoized on the
+    // plugin, so both sides see one answer.
+    //
+    // Driven through `config(...)` here because a test process has no
+    // `autumn.toml`; the point is that `client()` reads the same resolved
+    // value `Plugin::build` does, not where that value came from.
+    let disabled = SearchConfig::from_toml_str("[search]\nenabled = false\n").expect("parse");
+    let plugin = SearchPlugin::new().config(disabled).index::<Article>();
+
+    assert!(
+        !plugin.client().is_enabled(),
+        "a pre-build handle must not bypass the kill switch"
+    );
+
+    let app = autumn_web::app().plugin(plugin);
+    assert!(app.has_plugin("autumn-search"));
+}

--- a/autumn-search/tests/integration/postgres_backend.rs
+++ b/autumn-search/tests/integration/postgres_backend.rs
@@ -30,7 +30,8 @@ use testcontainers::runners::AsyncRunner;
 use testcontainers_modules::postgres::Postgres;
 
 use super::support::{
-    Article, Note, TenantArticle, article, note, tenant_article, untenanted_article, with_tenant,
+    Article, AuditArticle, Note, TenantArticle, article, audit_article, note, tenant_article,
+    untenanted_article, with_tenant,
 };
 
 const CREATE_TABLES_SQL: &[&str] = &[
@@ -47,6 +48,14 @@ const CREATE_TABLES_SQL: &[&str] = &[
         body       TEXT NOT NULL,
         tenant_id  TEXT,
         deleted_at TIMESTAMPTZ
+    )",
+    // `deleted_at` here is AUDIT HISTORY: the repository does not opt into
+    // `soft_delete`, so finders return these rows and the index must too.
+    "CREATE TABLE IF NOT EXISTS search_audit_articles (
+        id         BIGSERIAL PRIMARY KEY,
+        title      TEXT NOT NULL,
+        body       TEXT NOT NULL,
+        deleted_at TIMESTAMP
     )",
     // Keyed on `note_id`, with a leftover `id` column whose values disagree.
     // A source reader that assumes `id` returns rows here without error — it
@@ -106,6 +115,10 @@ impl Fixture {
             .ensure_index(&Note::index_definition())
             .await
             .expect("ensure_index (note)");
+        store
+            .ensure_index(&AuditArticle::index_definition())
+            .await
+            .expect("ensure_index (audit)");
 
         Self {
             store,
@@ -189,6 +202,24 @@ impl Fixture {
         )
     }
 
+    /// Insert an audit-history row, optionally already "deleted".
+    async fn insert_audit(&self, record: &AuditArticle, deleted: bool) {
+        let mut conn = self.pool.get().await.expect("conn");
+        let deleted_at = if deleted { "NOW()" } else { "NULL" };
+        diesel::sql_query(format!(
+            "INSERT INTO search_audit_articles (id, title, body, deleted_at) \
+             VALUES ($1, $2, $3, {deleted_at}) \
+             ON CONFLICT (id) DO UPDATE SET title = EXCLUDED.title, body = EXCLUDED.body, \
+             deleted_at = EXCLUDED.deleted_at"
+        ))
+        .bind::<diesel::sql_types::BigInt, _>(record.id)
+        .bind::<diesel::sql_types::Text, _>(record.title.clone())
+        .bind::<diesel::sql_types::Text, _>(record.body.clone())
+        .execute(&mut conn)
+        .await
+        .expect("insert audit row");
+    }
+
     /// Insert a row into the `note_id`-keyed source table.
     async fn insert_note(&self, record: &Note) {
         let mut conn = self.pool.get().await.expect("conn");
@@ -250,6 +281,7 @@ impl Fixture {
             .index::<Article>()
             .index::<TenantArticle>()
             .index::<Note>()
+            .index::<AuditArticle>()
             .build()
     }
 }
@@ -1083,4 +1115,61 @@ async fn an_undeclared_filter_key_cannot_widen_the_query() {
         .tenant_search("rust", SearchFilter::default().tenant("acme"))
         .await;
     assert_eq!(ids, vec![1]);
+}
+
+// ── `deleted_at` is not automatically a tombstone ───────────────────────────
+
+#[tokio::test]
+#[ignore = "requires Docker (testcontainers)"]
+async fn an_audit_deleted_at_column_does_not_hide_rows_from_the_index() {
+    // `AuditArticle` carries `deleted_at` as history and its repository does
+    // NOT opt into `soft_delete`, so its finders return those rows. Inferring
+    // a tombstone from column presence would hide them here: reindex would
+    // read the row as absent and delete its document, and a purging backfill
+    // would drop it entirely — an index that hides records the app displays.
+    let fixture = Fixture::start().await;
+    let client = fixture.client();
+
+    fixture
+        .insert_audit(&audit_article(1, "Rust one", "a rust framework"), false)
+        .await;
+    fixture
+        .insert_audit(&audit_article(2, "Rust two", "a rust framework"), true)
+        .await;
+
+    let report = client
+        .backfill(
+            "search_audit_articles",
+            &BackfillOptions::default().purge(true),
+        )
+        .await
+        .expect("backfill");
+    assert_eq!(
+        report.indexed, 2,
+        "an audit timestamp is not a delete: both rows belong in the index"
+    );
+
+    let page = client
+        .search::<AuditArticle>("rust", &PageRequest::default())
+        .await
+        .expect("search");
+    assert_eq!(
+        page.content.iter().map(|hit| hit.id).collect::<Vec<_>>(),
+        vec![1, 2]
+    );
+
+    // And a targeted reindex of the "deleted" row keeps it, rather than
+    // converging to absent.
+    client
+        .reindex(&ReindexArgs::upsert("search_audit_articles", 2))
+        .await
+        .expect("reindex");
+    assert_eq!(
+        client
+            .search::<AuditArticle>("rust", &PageRequest::default())
+            .await
+            .expect("search")
+            .total_elements,
+        2
+    );
 }

--- a/autumn-search/tests/integration/postgres_backend.rs
+++ b/autumn-search/tests/integration/postgres_backend.rs
@@ -30,7 +30,7 @@ use testcontainers::runners::AsyncRunner;
 use testcontainers_modules::postgres::Postgres;
 
 use super::support::{
-    Article, TenantArticle, article, tenant_article, untenanted_article, with_tenant,
+    Article, Note, TenantArticle, article, note, tenant_article, untenanted_article, with_tenant,
 };
 
 const CREATE_TABLES_SQL: &[&str] = &[
@@ -47,6 +47,15 @@ const CREATE_TABLES_SQL: &[&str] = &[
         body       TEXT NOT NULL,
         tenant_id  TEXT,
         deleted_at TIMESTAMPTZ
+    )",
+    // Keyed on `note_id`, with a leftover `id` column whose values disagree.
+    // A source reader that assumes `id` returns rows here without error — it
+    // just keys every document off the wrong column.
+    "CREATE TABLE IF NOT EXISTS search_notes (
+        note_id BIGSERIAL PRIMARY KEY,
+        id      BIGINT NOT NULL,
+        title   TEXT NOT NULL,
+        body    TEXT NOT NULL
     )",
 ];
 
@@ -93,6 +102,10 @@ impl Fixture {
             .ensure_index(&TenantArticle::index_definition())
             .await
             .expect("ensure_index (tenant)");
+        store
+            .ensure_index(&Note::index_definition())
+            .await
+            .expect("ensure_index (note)");
 
         Self {
             store,
@@ -176,6 +189,22 @@ impl Fixture {
         )
     }
 
+    /// Insert a row into the `note_id`-keyed source table.
+    async fn insert_note(&self, record: &Note) {
+        let mut conn = self.pool.get().await.expect("conn");
+        diesel::sql_query(
+            "INSERT INTO search_notes (note_id, id, title, body) VALUES ($1, $2, $3, $4) \
+             ON CONFLICT (note_id) DO UPDATE SET title = EXCLUDED.title, body = EXCLUDED.body",
+        )
+        .bind::<diesel::sql_types::BigInt, _>(record.note_id)
+        .bind::<diesel::sql_types::BigInt, _>(record.id)
+        .bind::<diesel::sql_types::Text, _>(record.title.clone())
+        .bind::<diesel::sql_types::Text, _>(record.body.clone())
+        .execute(&mut conn)
+        .await
+        .expect("insert note row");
+    }
+
     async fn delete_source(&self, id: i64) {
         let mut conn = self.pool.get().await.expect("conn");
         diesel::sql_query("DELETE FROM search_articles WHERE id = $1")
@@ -220,6 +249,7 @@ impl Fixture {
             .embedder(Arc::new(HashingEmbedder::new(64)))
             .index::<Article>()
             .index::<TenantArticle>()
+            .index::<Note>()
             .build()
     }
 }
@@ -697,6 +727,66 @@ async fn scanning_walks_the_table_by_keyset() {
             .expect("scan")
             .is_empty()
     );
+}
+
+#[tokio::test]
+#[ignore = "requires Docker (testcontainers)"]
+async fn a_model_keyed_on_something_other_than_id_backfills_and_searches() {
+    // `Note` is keyed on `note_id`, over a table that also has a leftover `id`
+    // whose values are offset by 100. Every source query — the keyset scan,
+    // the id-list fetch, the ordering, the projected key — has to come from
+    // the index definition. A hardcoded `id` does not error here; it returns
+    // documents keyed 101/102/103, which no longer match the ids the sync
+    // hooks write, so the index silently ends up holding two of everything.
+    let fixture = Fixture::start().await;
+    let client = fixture.client();
+    let definition = Note::index_definition();
+
+    for id in 1..=3 {
+        fixture
+            .insert_note(&note(id, &format!("Rust {id}"), "notes about rust"))
+            .await;
+    }
+
+    // Keyset scan, in key order, paginated on the real key column.
+    let first = fixture
+        .store
+        .scan(&definition, None, 2)
+        .await
+        .expect("scan");
+    assert_eq!(first.iter().map(|d| d.id).collect::<Vec<_>>(), vec![1, 2]);
+    let second = fixture
+        .store
+        .scan(&definition, Some(2), 2)
+        .await
+        .expect("scan");
+    assert_eq!(second.iter().map(|d| d.id).collect::<Vec<_>>(), vec![3]);
+
+    // Id-list fetch, the path a per-record reindex job takes.
+    let fetched = fixture.store.fetch(&definition, &[2]).await.expect("fetch");
+    assert_eq!(fetched.len(), 1);
+    assert_eq!(fetched[0].id, 2);
+    assert_eq!(
+        fetched[0]
+            .fields
+            .iter()
+            .find(|f| f.name == "title")
+            .map(|f| f.value.as_str()),
+        Some("Rust 2")
+    );
+
+    // And the whole thing end to end: backfill, then query.
+    let report = client
+        .backfill("search_notes", &BackfillOptions::default().batch_size(2))
+        .await
+        .expect("backfill");
+    assert_eq!(report.indexed, 3);
+
+    let page = client
+        .search::<Note>("rust", &PageRequest::default())
+        .await
+        .expect("search");
+    assert_eq!(page.total_elements, 3);
 }
 
 // ── End to end: the issue's success metric ──────────────────────────────────

--- a/autumn-search/tests/integration/postgres_backend.rs
+++ b/autumn-search/tests/integration/postgres_backend.rs
@@ -29,16 +29,26 @@ use diesel_async::pooled_connection::deadpool::Pool;
 use testcontainers::runners::AsyncRunner;
 use testcontainers_modules::postgres::Postgres;
 
-use super::support::{Article, article, tenant_article};
+use super::support::{
+    Article, TenantArticle, article, tenant_article, untenanted_article, with_tenant,
+};
 
-const CREATE_TABLE_SQL: &str = "
-    CREATE TABLE IF NOT EXISTS search_articles (
-        id        BIGSERIAL PRIMARY KEY,
-        title     TEXT NOT NULL,
-        body      TEXT NOT NULL,
-        tenant_id TEXT
-    )
-";
+const CREATE_TABLES_SQL: &[&str] = &[
+    "CREATE TABLE IF NOT EXISTS search_articles (
+        id    BIGSERIAL PRIMARY KEY,
+        title TEXT NOT NULL,
+        body  TEXT NOT NULL
+    )",
+    // The tenant-scoped model's table, plus a `deleted_at` column so the
+    // soft-delete exclusion has something to exclude.
+    "CREATE TABLE IF NOT EXISTS search_tenant_articles (
+        id         BIGSERIAL PRIMARY KEY,
+        title      TEXT NOT NULL,
+        body       TEXT NOT NULL,
+        tenant_id  TEXT,
+        deleted_at TIMESTAMPTZ
+    )",
+];
 
 /// A running Postgres plus a store wired to it.
 struct Fixture {
@@ -65,10 +75,12 @@ impl Fixture {
         let pool = Pool::builder(manager).max_size(4).build().expect("pool");
 
         let mut conn = pool.get().await.expect("conn");
-        diesel::sql_query(CREATE_TABLE_SQL)
-            .execute(&mut conn)
-            .await
-            .expect("create source table");
+        for statement in CREATE_TABLES_SQL {
+            diesel::sql_query(*statement)
+                .execute(&mut conn)
+                .await
+                .expect("create source table");
+        }
         drop(conn);
 
         let store = Arc::new(PostgresSearchStore::new(dimensions));
@@ -77,6 +89,10 @@ impl Fixture {
             .ensure_index(&Article::index_definition())
             .await
             .expect("ensure_index");
+        store
+            .ensure_index(&TenantArticle::index_definition())
+            .await
+            .expect("ensure_index (tenant)");
 
         Self {
             store,
@@ -93,7 +109,23 @@ impl Fixture {
     async fn insert(&self, record: &Article) {
         let mut conn = self.pool.get().await.expect("conn");
         diesel::sql_query(
-            "INSERT INTO search_articles (id, title, body, tenant_id) VALUES ($1, $2, $3, $4) \
+            "INSERT INTO search_articles (id, title, body) VALUES ($1, $2, $3) \
+             ON CONFLICT (id) DO UPDATE SET title = EXCLUDED.title, body = EXCLUDED.body",
+        )
+        .bind::<diesel::sql_types::BigInt, _>(record.id)
+        .bind::<diesel::sql_types::Text, _>(record.title.clone())
+        .bind::<diesel::sql_types::Text, _>(record.body.clone())
+        .execute(&mut conn)
+        .await
+        .expect("insert source row");
+    }
+
+    /// Insert a row into the tenant-scoped source table.
+    async fn insert_tenant(&self, record: &TenantArticle) {
+        let mut conn = self.pool.get().await.expect("conn");
+        diesel::sql_query(
+            "INSERT INTO search_tenant_articles (id, title, body, tenant_id) \
+             VALUES ($1, $2, $3, $4) \
              ON CONFLICT (id) DO UPDATE SET title = EXCLUDED.title, body = EXCLUDED.body, \
              tenant_id = EXCLUDED.tenant_id",
         )
@@ -103,7 +135,45 @@ impl Fixture {
         .bind::<diesel::sql_types::Nullable<diesel::sql_types::Text>, _>(record.tenant_id.clone())
         .execute(&mut conn)
         .await
-        .expect("insert source row");
+        .expect("insert tenant source row");
+    }
+
+    /// Soft-delete a tenant-scoped source row.
+    async fn soft_delete_tenant(&self, id: i64) {
+        let mut conn = self.pool.get().await.expect("conn");
+        diesel::sql_query("UPDATE search_tenant_articles SET deleted_at = NOW() WHERE id = $1")
+            .bind::<diesel::sql_types::BigInt, _>(id)
+            .execute(&mut conn)
+            .await
+            .expect("soft delete");
+    }
+
+    /// Index tenant-scoped documents directly.
+    async fn index_tenant(&self, records: &[TenantArticle]) {
+        let documents: Vec<IndexedDocument> = records
+            .iter()
+            .map(|r| IndexedDocument::new(r.search_document()))
+            .collect();
+        self.store
+            .index(&TenantArticle::index_definition(), &documents)
+            .await
+            .expect("index tenant");
+    }
+
+    /// Keyword search the tenant-scoped index.
+    async fn tenant_search(&self, query: &str, filter: SearchFilter) -> (Vec<i64>, u64) {
+        let page = self
+            .store
+            .keyword_search(
+                &TenantArticle::index_definition(),
+                &KeywordQuery::new(query, PageRequest::default()).filter(filter),
+            )
+            .await
+            .expect("keyword search");
+        (
+            page.content.iter().map(|hit| hit.id).collect(),
+            page.total_elements,
+        )
     }
 
     async fn delete_source(&self, id: i64) {
@@ -149,6 +219,7 @@ impl Fixture {
             .source(Arc::clone(&self.store) as Arc<dyn autumn_search::DocumentSource>)
             .embedder(Arc::new(HashingEmbedder::new(64)))
             .index::<Article>()
+            .index::<TenantArticle>()
             .build()
     }
 }
@@ -356,16 +427,16 @@ async fn clearing_empties_the_index() {
 #[ignore = "requires Docker (testcontainers)"]
 async fn a_tenant_filter_never_crosses_tenants() {
     let fixture = Fixture::start().await;
-    for record in [
-        tenant_article(1, "Rust at acme", "internal", "acme"),
-        tenant_article(2, "Rust at globex", "internal", "globex"),
-        article(3, "Rust in public", "no tenant"),
-    ] {
-        fixture.index(&[doc(&record)]).await;
-    }
+    fixture
+        .index_tenant(&[
+            tenant_article(1, "Rust at acme", "internal", "acme"),
+            tenant_article(2, "Rust at globex", "internal", "globex"),
+            untenanted_article(3, "Rust in public", "no tenant"),
+        ])
+        .await;
 
     let (ids, total) = fixture
-        .search_filtered("rust", SearchFilter::default().tenant("acme"))
+        .tenant_search("rust", SearchFilter::default().tenant("acme"))
         .await;
     assert_eq!(ids, vec![1]);
     assert_eq!(total, 1, "the total must reflect the filtered set");
@@ -376,11 +447,11 @@ async fn a_tenant_filter_never_crosses_tenants() {
 async fn a_tenant_value_containing_sql_is_bound_not_interpolated() {
     let fixture = Fixture::start().await;
     fixture
-        .index(&[doc(&tenant_article(1, "Rust", "x", "acme"))])
+        .index_tenant(&[tenant_article(1, "Rust", "x", "acme")])
         .await;
 
     let (ids, _) = fixture
-        .search_filtered(
+        .tenant_search(
             "rust",
             SearchFilter::default().tenant("acme'; DROP TABLE autumn_search_documents; --"),
         )
@@ -389,7 +460,7 @@ async fn a_tenant_value_containing_sql_is_bound_not_interpolated() {
 
     // The index table survived, so the value was bound rather than executed.
     let (ids, _) = fixture
-        .search_filtered("rust", SearchFilter::default().tenant("acme"))
+        .tenant_search("rust", SearchFilter::default().tenant("acme"))
         .await;
     assert_eq!(ids, vec![1]);
 }
@@ -540,14 +611,14 @@ async fn an_embedding_round_trips_through_the_index() {
 
     let stored = fixture
         .store
-        .embedding(&Fixture::definition(), 1)
+        .embedding(&Fixture::definition(), 1, &SearchFilter::default())
         .await
         .expect("read back");
     assert_eq!(stored, Some(vec![0.5, -0.25, 0.75]));
     assert_eq!(
         fixture
             .store
-            .embedding(&Fixture::definition(), 99)
+            .embedding(&Fixture::definition(), 99, &SearchFilter::default())
             .await
             .expect("read back"),
         None
@@ -561,12 +632,12 @@ async fn an_embedding_round_trips_through_the_index() {
 async fn the_document_source_projects_a_model_table_generically() {
     let fixture = Fixture::start().await;
     fixture
-        .insert(&tenant_article(1, "Rust", "a rust web framework", "acme"))
+        .insert_tenant(&tenant_article(1, "Rust", "a rust web framework", "acme"))
         .await;
 
     let documents = fixture
         .store
-        .fetch(&Fixture::definition(), &[1])
+        .fetch(&TenantArticle::index_definition(), &[1])
         .await
         .expect("fetch");
 
@@ -790,24 +861,136 @@ async fn a_search_never_returns_a_record_the_visibility_filter_excluded() {
         tenant_article(1, "Rust at acme", "a rust framework", "acme"),
         tenant_article(2, "Rust at globex", "a rust framework", "globex"),
     ] {
-        fixture.insert(&record).await;
+        fixture.insert_tenant(&record).await;
     }
     client
-        .backfill("search_articles", &BackfillOptions::default())
+        .backfill("search_tenant_articles", &BackfillOptions::default())
         .await
         .expect("backfill");
 
-    let page = client
-        .search_filtered::<Article>(
-            "rust",
-            &PageRequest::default(),
-            SearchFilter::default().tenant("acme"),
-        )
-        .await
-        .expect("search");
+    // No filter argument: the ambient tenant alone confines the query, and the
+    // total is computed after the restriction.
+    let page = with_tenant("acme", async {
+        client
+            .search::<TenantArticle>("rust", &PageRequest::default())
+            .await
+    })
+    .await
+    .expect("search");
     assert_eq!(
         page.content.iter().map(|h| h.id).collect::<Vec<_>>(),
         vec![1]
     );
     assert_eq!(page.total_elements, 1);
+
+    // And an unscoped query is refused outright rather than run across both.
+    let error = client
+        .search::<TenantArticle>("rust", &PageRequest::default())
+        .await
+        .expect_err("an unscoped query on a tenant-scoped index must be refused");
+    assert!(
+        matches!(
+            error,
+            autumn_search::SearchError::TenantContextMissing { .. }
+        ),
+        "{error:?}"
+    );
+}
+
+#[tokio::test]
+#[ignore = "requires Docker (testcontainers)"]
+async fn a_soft_deleted_row_is_not_put_back_by_a_backfill() {
+    // `after_delete_commit` removes the document; without a `deleted_at`
+    // exclusion in the source projection, the next backfill would put it
+    // straight back — searchable while `find` hides it.
+    let fixture = Fixture::start().await;
+    let client = fixture.client();
+
+    fixture
+        .insert_tenant(&tenant_article(1, "Rust one", "a rust framework", "acme"))
+        .await;
+    fixture
+        .insert_tenant(&tenant_article(2, "Rust two", "a rust framework", "acme"))
+        .await;
+    client
+        .backfill("search_tenant_articles", &BackfillOptions::default())
+        .await
+        .expect("backfill");
+    assert_eq!(
+        fixture
+            .tenant_search("rust", SearchFilter::default())
+            .await
+            .0,
+        vec![1, 2]
+    );
+
+    fixture.soft_delete_tenant(2).await;
+    client
+        .backfill(
+            "search_tenant_articles",
+            &BackfillOptions::default().purge(true),
+        )
+        .await
+        .expect("backfill after soft delete");
+    assert_eq!(
+        fixture
+            .tenant_search("rust", SearchFilter::default())
+            .await
+            .0,
+        vec![1],
+        "a soft-deleted row must not be re-indexed"
+    );
+
+    // A targeted reindex of the soft-deleted row removes it rather than
+    // restoring it: the source no longer produces the row, so the reindex
+    // converges to "absent".
+    fixture
+        .index_tenant(&[tenant_article(2, "Rust two", "a rust framework", "acme")])
+        .await;
+    client
+        .reindex(&ReindexArgs::upsert("search_tenant_articles", 2))
+        .await
+        .expect("reindex");
+    assert_eq!(
+        fixture
+            .tenant_search("rust", SearchFilter::default())
+            .await
+            .0,
+        vec![1]
+    );
+}
+
+#[tokio::test]
+#[ignore = "requires Docker (testcontainers)"]
+async fn an_undeclared_filter_key_cannot_widen_the_query() {
+    // A request-supplied facet key sits in an IDENTIFIER position. Unchecked,
+    // `title' = 'x' OR '1'='1` would close the quote and OR away the tenant
+    // restriction that precedes it.
+    let fixture = Fixture::start().await;
+    fixture
+        .index_tenant(&[
+            tenant_article(1, "Rust at acme", "internal", "acme"),
+            tenant_article(2, "Rust at globex", "internal", "globex"),
+        ])
+        .await;
+
+    let (ids, total) = fixture
+        .tenant_search(
+            "rust",
+            SearchFilter::default()
+                .tenant("acme")
+                .equals("title' = 'x' OR '1'='1", "boom"),
+        )
+        .await;
+    assert!(
+        ids.is_empty(),
+        "an undeclared key must match nothing, not widen: {ids:?}"
+    );
+    assert_eq!(total, 0);
+
+    // The index is intact and the tenant restriction still holds.
+    let (ids, _) = fixture
+        .tenant_search("rust", SearchFilter::default().tenant("acme"))
+        .await;
+    assert_eq!(ids, vec![1]);
 }

--- a/autumn-search/tests/integration/postgres_backend.rs
+++ b/autumn-search/tests/integration/postgres_backend.rs
@@ -1,0 +1,813 @@
+//! The Postgres backend, against a real Postgres.
+//!
+//! This is the **same contract** the in-memory suite asserts
+//! (`memory_backend.rs`), re-run against SQL: ranking, pagination totals,
+//! fail-closed blank queries, idempotent upserts, filter semantics, k-NN
+//! ordering. If a behaviour differs between the two, one of them is wrong.
+//!
+//! The last suite here is the issue's falsifiable success metric end to end:
+//! index a record, query it by keyword *and* by vector similarity, mutate the
+//! record, and assert the index reflects it — with no hand-written index-sync
+//! code anywhere.
+//!
+//! **Requires Docker.** `#[ignore]`d so a default `cargo test` never needs it;
+//! CI's Docker sweep runs it with no workflow edit (see CLAUDE.md).
+
+#![allow(clippy::items_after_statements)]
+
+use std::sync::Arc;
+
+use autumn_search::{
+    BackfillOptions, DocumentSource as _, HashingEmbedder, IndexedDocument, KeywordQuery,
+    PostgresSearchStore, ReindexArgs, SearchBackend as _, SearchClient, SearchFilter, VectorQuery,
+};
+use autumn_web::pagination::PageRequest;
+use autumn_web::search::{IndexDefinition, SearchIndexed as _};
+use diesel_async::RunQueryDsl;
+use diesel_async::pooled_connection::AsyncDieselConnectionManager;
+use diesel_async::pooled_connection::deadpool::Pool;
+use testcontainers::runners::AsyncRunner;
+use testcontainers_modules::postgres::Postgres;
+
+use super::support::{Article, article, tenant_article};
+
+const CREATE_TABLE_SQL: &str = "
+    CREATE TABLE IF NOT EXISTS search_articles (
+        id        BIGSERIAL PRIMARY KEY,
+        title     TEXT NOT NULL,
+        body      TEXT NOT NULL,
+        tenant_id TEXT
+    )
+";
+
+/// A running Postgres plus a store wired to it.
+struct Fixture {
+    store: Arc<PostgresSearchStore>,
+    pool: Pool<autumn_web::RuntimeConnection>,
+    _container: testcontainers::ContainerAsync<Postgres>,
+}
+
+impl Fixture {
+    async fn start() -> Self {
+        Self::start_with_dimensions(None).await
+    }
+
+    async fn start_with_dimensions(dimensions: Option<usize>) -> Self {
+        let container = Postgres::default()
+            .start()
+            .await
+            .expect("failed to start postgres container");
+        let host = container.get_host().await.expect("host");
+        let port = container.get_host_port_ipv4(5432).await.expect("port");
+        let url = format!("postgres://postgres:postgres@{host}:{port}/postgres");
+
+        let manager = AsyncDieselConnectionManager::<autumn_web::RuntimeConnection>::new(&url);
+        let pool = Pool::builder(manager).max_size(4).build().expect("pool");
+
+        let mut conn = pool.get().await.expect("conn");
+        diesel::sql_query(CREATE_TABLE_SQL)
+            .execute(&mut conn)
+            .await
+            .expect("create source table");
+        drop(conn);
+
+        let store = Arc::new(PostgresSearchStore::new(dimensions));
+        store.install_pool(pool.clone());
+        store
+            .ensure_index(&Article::index_definition())
+            .await
+            .expect("ensure_index");
+
+        Self {
+            store,
+            pool,
+            _container: container,
+        }
+    }
+
+    fn definition() -> IndexDefinition {
+        Article::index_definition()
+    }
+
+    /// Insert a row into the *source* table (the system of record).
+    async fn insert(&self, record: &Article) {
+        let mut conn = self.pool.get().await.expect("conn");
+        diesel::sql_query(
+            "INSERT INTO search_articles (id, title, body, tenant_id) VALUES ($1, $2, $3, $4) \
+             ON CONFLICT (id) DO UPDATE SET title = EXCLUDED.title, body = EXCLUDED.body, \
+             tenant_id = EXCLUDED.tenant_id",
+        )
+        .bind::<diesel::sql_types::BigInt, _>(record.id)
+        .bind::<diesel::sql_types::Text, _>(record.title.clone())
+        .bind::<diesel::sql_types::Text, _>(record.body.clone())
+        .bind::<diesel::sql_types::Nullable<diesel::sql_types::Text>, _>(record.tenant_id.clone())
+        .execute(&mut conn)
+        .await
+        .expect("insert source row");
+    }
+
+    async fn delete_source(&self, id: i64) {
+        let mut conn = self.pool.get().await.expect("conn");
+        diesel::sql_query("DELETE FROM search_articles WHERE id = $1")
+            .bind::<diesel::sql_types::BigInt, _>(id)
+            .execute(&mut conn)
+            .await
+            .expect("delete source row");
+    }
+
+    /// Index documents directly, bypassing the source.
+    async fn index(&self, documents: &[IndexedDocument]) {
+        self.store
+            .index(&Self::definition(), documents)
+            .await
+            .expect("index");
+    }
+
+    async fn search(&self, query: &str) -> Vec<i64> {
+        self.search_filtered(query, SearchFilter::default()).await.0
+    }
+
+    async fn search_filtered(&self, query: &str, filter: SearchFilter) -> (Vec<i64>, u64) {
+        let page = self
+            .store
+            .keyword_search(
+                &Self::definition(),
+                &KeywordQuery::new(query, PageRequest::default()).filter(filter),
+            )
+            .await
+            .expect("keyword search");
+        (
+            page.content.iter().map(|hit| hit.id).collect(),
+            page.total_elements,
+        )
+    }
+
+    /// A `SearchClient` over this store (backend **and** document source).
+    fn client(&self) -> SearchClient {
+        SearchClient::builder()
+            .backend(Arc::clone(&self.store) as Arc<dyn autumn_search::SearchBackend>)
+            .source(Arc::clone(&self.store) as Arc<dyn autumn_search::DocumentSource>)
+            .embedder(Arc::new(HashingEmbedder::new(64)))
+            .index::<Article>()
+            .build()
+    }
+}
+
+fn doc(record: &Article) -> IndexedDocument {
+    IndexedDocument::new(record.search_document())
+}
+
+fn corpus() -> Vec<Article> {
+    vec![
+        article(1, "Rust web frameworks", "A survey of the ecosystem."),
+        article(2, "Getting started", "Autumn is a rust web framework."),
+        article(3, "Gardening", "Tomatoes and basil."),
+    ]
+}
+
+// ── Schema ──────────────────────────────────────────────────────────────────
+
+#[tokio::test]
+#[ignore = "requires Docker (testcontainers)"]
+async fn ensure_index_is_idempotent() {
+    let fixture = Fixture::start().await;
+    // `start()` already ran it once; running it again on every boot must be a
+    // no-op, not an error.
+    fixture
+        .store
+        .ensure_index(&Fixture::definition())
+        .await
+        .expect("second ensure_index");
+    fixture
+        .store
+        .ensure_index(&Fixture::definition())
+        .await
+        .expect("third ensure_index");
+}
+
+#[tokio::test]
+#[ignore = "requires Docker (testcontainers)"]
+async fn a_stock_postgres_without_pgvector_falls_back_to_the_portable_path() {
+    // The plain `postgres` image has no `pgvector`. Boot must succeed and
+    // vector search must still work — that is the whole point of the fallback.
+    let fixture = Fixture::start_with_dimensions(Some(3)).await;
+    assert_eq!(
+        fixture.store.vector_mode(),
+        Some(autumn_search::VectorMode::Array)
+    );
+}
+
+// ── Keyword ─────────────────────────────────────────────────────────────────
+
+#[tokio::test]
+#[ignore = "requires Docker (testcontainers)"]
+async fn keyword_search_ranks_a_title_match_above_a_body_match() {
+    let fixture = Fixture::start().await;
+    for record in corpus() {
+        fixture.index(&[doc(&record)]).await;
+    }
+
+    assert_eq!(
+        fixture.search("rust").await,
+        vec![1, 2],
+        "the weight-A title match must rank first"
+    );
+}
+
+#[tokio::test]
+#[ignore = "requires Docker (testcontainers)"]
+async fn keyword_search_paginates_with_a_stable_total() {
+    let fixture = Fixture::start().await;
+    for record in corpus() {
+        fixture.index(&[doc(&record)]).await;
+    }
+
+    let first = fixture
+        .store
+        .keyword_search(
+            &Fixture::definition(),
+            &KeywordQuery::new("rust", PageRequest::new(1, 1)),
+        )
+        .await
+        .expect("page 1");
+    let second = fixture
+        .store
+        .keyword_search(
+            &Fixture::definition(),
+            &KeywordQuery::new("rust", PageRequest::new(2, 1)),
+        )
+        .await
+        .expect("page 2");
+
+    assert_eq!(
+        first.content.iter().map(|h| h.id).collect::<Vec<_>>(),
+        vec![1]
+    );
+    assert_eq!(
+        second.content.iter().map(|h| h.id).collect::<Vec<_>>(),
+        vec![2]
+    );
+    assert_eq!(first.total_elements, 2);
+    assert_eq!(second.total_elements, 2);
+}
+
+#[tokio::test]
+#[ignore = "requires Docker (testcontainers)"]
+async fn a_blank_query_returns_nothing_rather_than_every_row() {
+    let fixture = Fixture::start().await;
+    for record in corpus() {
+        fixture.index(&[doc(&record)]).await;
+    }
+
+    for blank in ["", "   ", "\t\n"] {
+        let (ids, total) = fixture
+            .search_filtered(blank, SearchFilter::default())
+            .await;
+        assert!(ids.is_empty(), "blank query {blank:?} matched {ids:?}");
+        assert_eq!(total, 0);
+    }
+}
+
+#[tokio::test]
+#[ignore = "requires Docker (testcontainers)"]
+async fn a_hostile_query_can_neither_error_nor_widen_the_result_set() {
+    let fixture = Fixture::start().await;
+    for record in corpus() {
+        fixture.index(&[doc(&record)]).await;
+    }
+
+    for hostile in [
+        "rust OR gardening",
+        "title:rust",
+        "rust*",
+        "') OR 1=1 --",
+        "\"; DROP TABLE search_articles; --",
+    ] {
+        let ids = fixture.search(hostile).await;
+        assert!(
+            !ids.contains(&3),
+            "query {hostile:?} must not match the unrelated record (got {ids:?})"
+        );
+    }
+
+    // The source table must still be there.
+    assert_eq!(fixture.search("rust").await, vec![1, 2]);
+}
+
+#[tokio::test]
+#[ignore = "requires Docker (testcontainers)"]
+async fn indexing_the_same_record_twice_stores_one_document() {
+    let fixture = Fixture::start().await;
+    let record = article(1, "Rust web frameworks", "A survey.");
+    fixture.index(&[doc(&record)]).await;
+    fixture.index(&[doc(&record)]).await;
+
+    let (ids, total) = fixture
+        .search_filtered("rust", SearchFilter::default())
+        .await;
+    assert_eq!(ids, vec![1]);
+    assert_eq!(total, 1);
+}
+
+#[tokio::test]
+#[ignore = "requires Docker (testcontainers)"]
+async fn deleting_removes_the_document_and_replays_cleanly() {
+    let fixture = Fixture::start().await;
+    for record in corpus() {
+        fixture.index(&[doc(&record)]).await;
+    }
+
+    fixture
+        .store
+        .delete(&Fixture::definition(), &[1])
+        .await
+        .expect("delete");
+    assert_eq!(fixture.search("rust").await, vec![2]);
+
+    // At-least-once delivery replays deletes: a repeat, and a delete of an id
+    // that was never indexed, must both be no-ops.
+    fixture
+        .store
+        .delete(&Fixture::definition(), &[1, 999])
+        .await
+        .expect("replayed delete");
+    assert_eq!(fixture.search("rust").await, vec![2]);
+}
+
+#[tokio::test]
+#[ignore = "requires Docker (testcontainers)"]
+async fn clearing_empties_the_index() {
+    let fixture = Fixture::start().await;
+    for record in corpus() {
+        fixture.index(&[doc(&record)]).await;
+    }
+
+    fixture
+        .store
+        .clear(&Fixture::definition())
+        .await
+        .expect("clear");
+    assert!(fixture.search("rust").await.is_empty());
+}
+
+// ── Filtering / tenancy ─────────────────────────────────────────────────────
+
+#[tokio::test]
+#[ignore = "requires Docker (testcontainers)"]
+async fn a_tenant_filter_never_crosses_tenants() {
+    let fixture = Fixture::start().await;
+    for record in [
+        tenant_article(1, "Rust at acme", "internal", "acme"),
+        tenant_article(2, "Rust at globex", "internal", "globex"),
+        article(3, "Rust in public", "no tenant"),
+    ] {
+        fixture.index(&[doc(&record)]).await;
+    }
+
+    let (ids, total) = fixture
+        .search_filtered("rust", SearchFilter::default().tenant("acme"))
+        .await;
+    assert_eq!(ids, vec![1]);
+    assert_eq!(total, 1, "the total must reflect the filtered set");
+}
+
+#[tokio::test]
+#[ignore = "requires Docker (testcontainers)"]
+async fn a_tenant_value_containing_sql_is_bound_not_interpolated() {
+    let fixture = Fixture::start().await;
+    fixture
+        .index(&[doc(&tenant_article(1, "Rust", "x", "acme"))])
+        .await;
+
+    let (ids, _) = fixture
+        .search_filtered(
+            "rust",
+            SearchFilter::default().tenant("acme'; DROP TABLE autumn_search_documents; --"),
+        )
+        .await;
+    assert!(ids.is_empty());
+
+    // The index table survived, so the value was bound rather than executed.
+    let (ids, _) = fixture
+        .search_filtered("rust", SearchFilter::default().tenant("acme"))
+        .await;
+    assert_eq!(ids, vec![1]);
+}
+
+#[tokio::test]
+#[ignore = "requires Docker (testcontainers)"]
+async fn id_allowlists_and_denylists_are_honoured() {
+    let fixture = Fixture::start().await;
+    for record in corpus() {
+        fixture.index(&[doc(&record)]).await;
+    }
+
+    let (ids, _) = fixture
+        .search_filtered("rust", SearchFilter::default().allow_ids([2_i64]))
+        .await;
+    assert_eq!(ids, vec![2]);
+
+    let (ids, _) = fixture
+        .search_filtered("rust", SearchFilter::default().exclude_ids([1_i64]))
+        .await;
+    assert_eq!(ids, vec![2]);
+
+    let (ids, total) = fixture
+        .search_filtered("rust", SearchFilter::default().allow_ids(Vec::<i64>::new()))
+        .await;
+    assert!(ids.is_empty(), "an empty allowlist must match nothing");
+    assert_eq!(total, 0);
+}
+
+#[tokio::test]
+#[ignore = "requires Docker (testcontainers)"]
+async fn an_equals_filter_matches_an_indexed_field() {
+    let fixture = Fixture::start().await;
+    for record in corpus() {
+        fixture.index(&[doc(&record)]).await;
+    }
+
+    let (ids, _) = fixture
+        .search_filtered(
+            "rust",
+            SearchFilter::default().equals("title", "Getting started"),
+        )
+        .await;
+    assert_eq!(ids, vec![2]);
+}
+
+// ── Vector ──────────────────────────────────────────────────────────────────
+
+#[tokio::test]
+#[ignore = "requires Docker (testcontainers)"]
+async fn vector_search_orders_by_cosine_similarity() {
+    let fixture = Fixture::start().await;
+    fixture
+        .index(&[
+            doc(&article(1, "a", "b")).with_embedding(vec![1.0, 0.0, 0.0]),
+            doc(&article(2, "a", "b")).with_embedding(vec![0.9, 0.1, 0.0]),
+            doc(&article(3, "a", "b")).with_embedding(vec![0.0, 1.0, 0.0]),
+        ])
+        .await;
+
+    let hits = fixture
+        .store
+        .vector_search(
+            &Fixture::definition(),
+            &VectorQuery::new(vec![1.0, 0.0, 0.0], 2),
+        )
+        .await
+        .expect("vector search");
+
+    assert_eq!(hits.iter().map(|h| h.id).collect::<Vec<_>>(), vec![1, 2]);
+    assert!(hits[0].score > hits[1].score);
+    assert!(
+        (hits[0].score - 1.0).abs() < 1e-4,
+        "score {}",
+        hits[0].score
+    );
+}
+
+#[tokio::test]
+#[ignore = "requires Docker (testcontainers)"]
+async fn vector_search_honours_the_filter_and_the_threshold() {
+    let fixture = Fixture::start().await;
+    fixture
+        .index(&[
+            doc(&article(1, "a", "b")).with_embedding(vec![1.0, 0.0, 0.0]),
+            doc(&article(2, "a", "b")).with_embedding(vec![0.0, 1.0, 0.0]),
+        ])
+        .await;
+
+    let filtered = fixture
+        .store
+        .vector_search(
+            &Fixture::definition(),
+            &VectorQuery::new(vec![1.0, 0.0, 0.0], 10)
+                .filter(SearchFilter::default().allow_ids([2_i64])),
+        )
+        .await
+        .expect("filtered");
+    assert_eq!(filtered.iter().map(|h| h.id).collect::<Vec<_>>(), vec![2]);
+
+    let thresholded = fixture
+        .store
+        .vector_search(
+            &Fixture::definition(),
+            &VectorQuery::new(vec![1.0, 0.0, 0.0], 10).min_score(0.5),
+        )
+        .await
+        .expect("thresholded");
+    assert_eq!(
+        thresholded.iter().map(|h| h.id).collect::<Vec<_>>(),
+        vec![1]
+    );
+}
+
+#[tokio::test]
+#[ignore = "requires Docker (testcontainers)"]
+async fn documents_of_a_different_embedding_width_are_skipped_not_mis_scored() {
+    let fixture = Fixture::start().await;
+    fixture
+        .index(&[
+            doc(&article(1, "a", "b")).with_embedding(vec![1.0, 0.0, 0.0]),
+            doc(&article(2, "a", "b")).with_embedding(vec![1.0, 0.0]),
+        ])
+        .await;
+
+    let hits = fixture
+        .store
+        .vector_search(
+            &Fixture::definition(),
+            &VectorQuery::new(vec![1.0, 0.0, 0.0], 10),
+        )
+        .await
+        .expect("vector search");
+    assert_eq!(
+        hits.iter().map(|h| h.id).collect::<Vec<_>>(),
+        vec![1],
+        "a mismatched-width document must be skipped, not scored against padding"
+    );
+}
+
+#[tokio::test]
+#[ignore = "requires Docker (testcontainers)"]
+async fn an_embedding_round_trips_through_the_index() {
+    let fixture = Fixture::start().await;
+    fixture
+        .index(&[doc(&article(1, "a", "b")).with_embedding(vec![0.5, -0.25, 0.75])])
+        .await;
+
+    let stored = fixture
+        .store
+        .embedding(&Fixture::definition(), 1)
+        .await
+        .expect("read back");
+    assert_eq!(stored, Some(vec![0.5, -0.25, 0.75]));
+    assert_eq!(
+        fixture
+            .store
+            .embedding(&Fixture::definition(), 99)
+            .await
+            .expect("read back"),
+        None
+    );
+}
+
+// ── Document source ─────────────────────────────────────────────────────────
+
+#[tokio::test]
+#[ignore = "requires Docker (testcontainers)"]
+async fn the_document_source_projects_a_model_table_generically() {
+    let fixture = Fixture::start().await;
+    fixture
+        .insert(&tenant_article(1, "Rust", "a rust web framework", "acme"))
+        .await;
+
+    let documents = fixture
+        .store
+        .fetch(&Fixture::definition(), &[1])
+        .await
+        .expect("fetch");
+
+    assert_eq!(documents.len(), 1);
+    let document = &documents[0];
+    assert_eq!(document.id, 1);
+    assert_eq!(document.field("title"), Some("Rust"));
+    assert_eq!(document.field("body"), Some("a rust web framework"));
+    assert_eq!(document.tenant_id.as_deref(), Some("acme"));
+    // `body` is the `#[searchable(embed)]` field.
+    assert_eq!(document.embed_text.as_deref(), Some("a rust web framework"));
+}
+
+#[tokio::test]
+#[ignore = "requires Docker (testcontainers)"]
+async fn fetching_a_missing_row_is_an_absence_not_an_error() {
+    let fixture = Fixture::start().await;
+    fixture.insert(&article(1, "Rust", "body")).await;
+
+    let documents = fixture
+        .store
+        .fetch(&Fixture::definition(), &[1, 2, 3])
+        .await
+        .expect("fetch must tolerate missing rows");
+    assert_eq!(documents.iter().map(|d| d.id).collect::<Vec<_>>(), vec![1]);
+}
+
+#[tokio::test]
+#[ignore = "requires Docker (testcontainers)"]
+async fn scanning_walks_the_table_by_keyset() {
+    let fixture = Fixture::start().await;
+    for id in 1..=5 {
+        fixture
+            .insert(&article(id, &format!("Rust {id}"), "body"))
+            .await;
+    }
+
+    let first = fixture
+        .store
+        .scan(&Fixture::definition(), None, 2)
+        .await
+        .expect("scan");
+    assert_eq!(first.iter().map(|d| d.id).collect::<Vec<_>>(), vec![1, 2]);
+
+    let second = fixture
+        .store
+        .scan(&Fixture::definition(), Some(2), 2)
+        .await
+        .expect("scan");
+    assert_eq!(second.iter().map(|d| d.id).collect::<Vec<_>>(), vec![3, 4]);
+
+    assert!(
+        fixture
+            .store
+            .scan(&Fixture::definition(), Some(5), 2)
+            .await
+            .expect("scan")
+            .is_empty()
+    );
+}
+
+// ── End to end: the issue's success metric ──────────────────────────────────
+
+#[tokio::test]
+#[ignore = "requires Docker (testcontainers)"]
+async fn backfill_then_keyword_and_vector_queries_both_return_ranked_results() {
+    let fixture = Fixture::start().await;
+    let client = fixture.client();
+
+    fixture
+        .insert(&article(
+            1,
+            "Rust web frameworks",
+            "building apis with rust",
+        ))
+        .await;
+    fixture
+        .insert(&article(2, "Getting started", "a rust web framework"))
+        .await;
+    fixture
+        .insert(&article(3, "Gardening", "tomato basil in summer"))
+        .await;
+
+    let report = client
+        .backfill("search_articles", &BackfillOptions::default().batch_size(2))
+        .await
+        .expect("backfill");
+    assert_eq!(report.indexed, 3);
+    assert_eq!(report.batches, 2, "3 rows at 2/batch is 2 batches");
+
+    let keyword = client
+        .search::<Article>("rust", &PageRequest::default())
+        .await
+        .expect("keyword search");
+    assert_eq!(
+        keyword.content.iter().map(|h| h.id).collect::<Vec<_>>(),
+        vec![1, 2],
+        "the weight-A title match ranks first"
+    );
+
+    let semantic = client
+        .similar::<Article>("rust web framework", 2)
+        .await
+        .expect("semantic search");
+    assert_eq!(semantic.len(), 2);
+    assert!(
+        !semantic.iter().any(|hit| hit.id == 3),
+        "the unrelated record must not be a nearest neighbour: {semantic:?}"
+    );
+}
+
+#[tokio::test]
+#[ignore = "requires Docker (testcontainers)"]
+async fn a_record_update_changes_recall_with_no_manual_index_code() {
+    // The falsifiable claim from the issue, driven exactly as the lifecycle
+    // drives it: the reindex job's payload is `(index, id)` and nothing else.
+    let fixture = Fixture::start().await;
+    let client = fixture.client();
+
+    fixture
+        .insert(&article(1, "Rust web frameworks", "a survey"))
+        .await;
+    client
+        .reindex(&ReindexArgs::upsert("search_articles", 1))
+        .await
+        .expect("initial reindex");
+    assert_eq!(fixture.search("rust").await, vec![1]);
+
+    // Mutate the record and let the same instruction converge the index.
+    fixture
+        .insert(&article(1, "Gardening weekly", "tomatoes only"))
+        .await;
+    client
+        .reindex(&ReindexArgs::upsert("search_articles", 1))
+        .await
+        .expect("lifecycle reindex");
+
+    assert!(
+        fixture.search("rust").await.is_empty(),
+        "the old text must no longer match"
+    );
+    assert_eq!(
+        fixture.search("tomatoes").await,
+        vec![1],
+        "the new text must match"
+    );
+}
+
+#[tokio::test]
+#[ignore = "requires Docker (testcontainers)"]
+async fn a_deleted_row_is_removed_from_the_index_by_the_same_instruction() {
+    // Drift repair: a lost delete event, or a row removed by direct SQL, is
+    // healed by an ordinary upsert reindex — the source has no row, so the
+    // document goes away.
+    let fixture = Fixture::start().await;
+    let client = fixture.client();
+
+    fixture
+        .insert(&article(1, "Rust", "a rust framework"))
+        .await;
+    client
+        .reindex(&ReindexArgs::upsert("search_articles", 1))
+        .await
+        .expect("index");
+    assert_eq!(fixture.search("rust").await, vec![1]);
+
+    fixture.delete_source(1).await;
+    client
+        .reindex(&ReindexArgs::upsert("search_articles", 1))
+        .await
+        .expect("converge");
+    assert!(fixture.search("rust").await.is_empty());
+}
+
+#[tokio::test]
+#[ignore = "requires Docker (testcontainers)"]
+async fn backfill_with_purge_drops_documents_the_source_no_longer_produces() {
+    let fixture = Fixture::start().await;
+    let client = fixture.client();
+
+    for id in 1..=3 {
+        fixture
+            .insert(&article(id, "Rust", "a rust framework"))
+            .await;
+    }
+    client
+        .backfill("search_articles", &BackfillOptions::default())
+        .await
+        .expect("initial");
+    assert_eq!(fixture.search("rust").await.len(), 3);
+
+    fixture.delete_source(3).await;
+
+    let without_purge = client
+        .backfill("search_articles", &BackfillOptions::default())
+        .await
+        .expect("no purge");
+    assert_eq!(without_purge.indexed, 2);
+    assert_eq!(
+        fixture.search("rust").await.len(),
+        3,
+        "without purge the orphan survives"
+    );
+
+    let purged = client
+        .backfill("search_articles", &BackfillOptions::default().purge(true))
+        .await
+        .expect("purge");
+    assert!(purged.purged);
+    assert_eq!(fixture.search("rust").await, vec![1, 2]);
+}
+
+#[tokio::test]
+#[ignore = "requires Docker (testcontainers)"]
+async fn a_search_never_returns_a_record_the_visibility_filter_excluded() {
+    // The end-to-end authorization property, on real SQL.
+    let fixture = Fixture::start().await;
+    let client = fixture.client();
+
+    for record in [
+        tenant_article(1, "Rust at acme", "a rust framework", "acme"),
+        tenant_article(2, "Rust at globex", "a rust framework", "globex"),
+    ] {
+        fixture.insert(&record).await;
+    }
+    client
+        .backfill("search_articles", &BackfillOptions::default())
+        .await
+        .expect("backfill");
+
+    let page = client
+        .search_filtered::<Article>(
+            "rust",
+            &PageRequest::default(),
+            SearchFilter::default().tenant("acme"),
+        )
+        .await
+        .expect("search");
+    assert_eq!(
+        page.content.iter().map(|h| h.id).collect::<Vec<_>>(),
+        vec![1]
+    );
+    assert_eq!(page.total_elements, 1);
+}

--- a/autumn-search/tests/integration/reindex.rs
+++ b/autumn-search/tests/integration/reindex.rs
@@ -1,0 +1,194 @@
+//! Lifecycle-driven index sync.
+//!
+//! AC: "The index stays in sync with the record lifecycle: create/update/delete
+//! to a searchable model **enqueues a reindex** (via `#[job]`, so indexing is
+//! off-request and durable)."
+//!
+//! The design under test: a create/update/delete on a searchable model enqueues
+//! `ReindexArgs { index, id, op }`. The job handler **re-reads the source row**
+//! and converges — present ⇒ upsert, absent ⇒ delete. That single idempotent
+//! operation is what makes at-least-once job delivery (and a lost delete event)
+//! safe.
+
+use std::sync::Arc;
+
+use autumn_search::{
+    MemoryDocumentSource, MemorySearchBackend, ReindexArgs, ReindexOp, SearchClient, SearchError,
+};
+use autumn_web::pagination::PageRequest;
+
+use super::support::{Article, article};
+
+async fn client_and_source(articles: &[Article]) -> (SearchClient, Arc<MemoryDocumentSource>) {
+    let source = Arc::new(MemoryDocumentSource::new());
+    for a in articles {
+        source.upsert(a);
+    }
+    let client = SearchClient::builder()
+        .backend(Arc::new(MemorySearchBackend::new()))
+        .source(source.clone())
+        .index::<Article>()
+        .build();
+    client.ensure_indexes().await.expect("ensure");
+    (client, source)
+}
+
+fn corpus() -> Vec<Article> {
+    vec![
+        article(1, "Rust web frameworks", "A survey."),
+        article(2, "Gardening", "Tomatoes."),
+    ]
+}
+
+#[tokio::test]
+async fn reindexing_pulls_the_current_row_into_the_index() {
+    let (client, _source) = client_and_source(&corpus()).await;
+
+    client
+        .reindex(&ReindexArgs::upsert("search_articles", 1))
+        .await
+        .expect("reindex");
+
+    let page = client
+        .search::<Article>("rust", &PageRequest::default())
+        .await
+        .expect("search");
+    assert_eq!(
+        page.content.iter().map(|h| h.id).collect::<Vec<_>>(),
+        vec![1]
+    );
+}
+
+#[tokio::test]
+async fn reindexing_is_idempotent_so_at_least_once_delivery_is_safe() {
+    let (client, _source) = client_and_source(&corpus()).await;
+
+    for _ in 0..3 {
+        client
+            .reindex(&ReindexArgs::upsert("search_articles", 1))
+            .await
+            .expect("reindex");
+    }
+
+    let page = client
+        .search::<Article>("rust", &PageRequest::default())
+        .await
+        .expect("search");
+    assert_eq!(page.content.len(), 1);
+    assert_eq!(page.total_elements, 1);
+}
+
+#[tokio::test]
+async fn reindexing_a_row_that_no_longer_exists_removes_it_from_the_index() {
+    // Drift repair: a delete event that was lost, or a row removed by direct
+    // SQL, converges to the same state as an explicit delete.
+    let (client, source) = client_and_source(&corpus()).await;
+    client
+        .reindex(&ReindexArgs::upsert("search_articles", 1))
+        .await
+        .expect("index it");
+
+    source.remove(1);
+    client
+        .reindex(&ReindexArgs::upsert("search_articles", 1))
+        .await
+        .expect("reindex after delete");
+
+    let page = client
+        .search::<Article>("rust", &PageRequest::default())
+        .await
+        .expect("search");
+    assert!(page.content.is_empty());
+}
+
+#[tokio::test]
+async fn an_explicit_delete_op_never_re_reads_the_source() {
+    // A delete must not race a re-created row back into the index, and must
+    // work even when the source is unavailable.
+    let (client, source) = client_and_source(&corpus()).await;
+    client
+        .reindex(&ReindexArgs::upsert("search_articles", 1))
+        .await
+        .expect("index");
+
+    client
+        .reindex(&ReindexArgs::delete("search_articles", 1))
+        .await
+        .expect("delete");
+    assert_eq!(
+        source.fetch_calls_for(1),
+        1,
+        "the delete op must not re-read the row"
+    );
+
+    let page = client
+        .search::<Article>("rust", &PageRequest::default())
+        .await
+        .expect("search");
+    assert!(page.content.is_empty());
+}
+
+#[tokio::test]
+async fn a_record_update_changes_ranking_without_any_manual_reindex_call() {
+    // The falsifiable success metric from the issue.
+    let (client, source) = client_and_source(&corpus()).await;
+    client
+        .reindex(&ReindexArgs::upsert("search_articles", 1))
+        .await
+        .expect("initial");
+
+    source.upsert(&article(1, "Gardening weekly", "Tomatoes only."));
+    client
+        .reindex(&ReindexArgs::upsert("search_articles", 1))
+        .await
+        .expect("lifecycle reindex");
+
+    assert!(
+        client
+            .search::<Article>("rust", &PageRequest::default())
+            .await
+            .expect("search")
+            .content
+            .is_empty()
+    );
+    assert!(
+        client
+            .search::<Article>("tomatoes", &PageRequest::default())
+            .await
+            .expect("search")
+            .content
+            .iter()
+            .any(|h| h.id == 1)
+    );
+}
+
+#[tokio::test]
+async fn reindexing_an_unknown_index_is_a_typed_error_not_a_silent_drop() {
+    let (client, _source) = client_and_source(&corpus()).await;
+
+    let err = client
+        .reindex(&ReindexArgs::upsert("not_an_index", 1))
+        .await
+        .unwrap_err();
+    assert!(matches!(err, SearchError::UnknownIndex(_)), "{err:?}");
+}
+
+#[tokio::test]
+async fn reindex_args_round_trip_through_the_job_payload() {
+    // The args cross a process boundary on the durable job queue.
+    let args = ReindexArgs::delete("search_articles", 42);
+    let json = serde_json::to_value(&args).expect("serialize");
+    let back: ReindexArgs = serde_json::from_value(json).expect("deserialize");
+    assert_eq!(back, args);
+    assert_eq!(back.op, ReindexOp::Delete);
+}
+
+#[tokio::test]
+async fn the_reindex_job_is_registered_with_a_stable_name() {
+    // The job name is a wire contract: in-flight payloads outlive a deploy.
+    let infos = autumn_search::search_job_infos("search");
+    let names: Vec<&str> = infos.iter().map(|i| i.name.as_str()).collect();
+    assert!(names.contains(&"autumn_search_reindex"), "{names:?}");
+    assert!(names.contains(&"autumn_search_backfill"), "{names:?}");
+    assert!(infos.iter().all(|i| i.queue == "search"));
+}

--- a/autumn-search/tests/integration/reindex.rs
+++ b/autumn-search/tests/integration/reindex.rs
@@ -102,30 +102,113 @@ async fn reindexing_a_row_that_no_longer_exists_removes_it_from_the_index() {
 }
 
 #[tokio::test]
-async fn an_explicit_delete_op_never_re_reads_the_source() {
-    // A delete must not race a re-created row back into the index, and must
-    // work even when the source is unavailable.
+async fn a_delete_op_removes_the_document_when_the_row_is_gone() {
     let (client, source) = client_and_source(&corpus()).await;
     client
         .reindex(&ReindexArgs::upsert("search_articles", 1))
         .await
         .expect("index");
 
+    source.remove(1);
     client
         .reindex(&ReindexArgs::delete("search_articles", 1))
         .await
         .expect("delete");
-    assert_eq!(
-        source.fetch_calls_for(1),
-        1,
-        "the delete op must not re-read the row"
-    );
 
     let page = client
         .search::<Article>("rust", &PageRequest::default())
         .await
         .expect("search");
     assert!(page.content.is_empty());
+}
+
+#[tokio::test]
+async fn a_late_delete_cannot_remove_a_record_that_was_recreated() {
+    // The ordering hazard: id 1 is deleted, then re-created under the SAME
+    // primary key, and the re-create's upsert runs first. A delete that
+    // retries — or simply arrives late — must NOT remove the live record.
+    // Both ops re-read, so the instruction means "converge this id" and the
+    // order stops mattering.
+    let (client, source) = client_and_source(&corpus()).await;
+
+    // The record is deleted, then recreated with new content.
+    source.remove(1);
+    source.upsert(&article(1, "Rust reborn", "a rust web framework"));
+    client
+        .reindex(&ReindexArgs::upsert("search_articles", 1))
+        .await
+        .expect("upsert for the recreated row");
+
+    // The stale delete finally lands.
+    client
+        .reindex(&ReindexArgs::delete("search_articles", 1))
+        .await
+        .expect("late delete");
+
+    let page = client
+        .search::<Article>("rust", &PageRequest::default())
+        .await
+        .expect("search");
+    assert_eq!(
+        page.content.iter().map(|h| h.id).collect::<Vec<_>>(),
+        vec![1],
+        "a live row must survive a stale delete instruction"
+    );
+}
+
+#[tokio::test]
+async fn either_op_reaches_the_same_state_in_either_order() {
+    // The property the `(index, id)` dedup key depends on: instructions are
+    // convergent, so duplication and reordering are both safe.
+    for ops in [
+        [ReindexOp::Upsert, ReindexOp::Delete],
+        [ReindexOp::Delete, ReindexOp::Upsert],
+        [ReindexOp::Delete, ReindexOp::Delete],
+        [ReindexOp::Upsert, ReindexOp::Upsert],
+    ] {
+        let (client, _source) = client_and_source(&corpus()).await;
+        for op in ops {
+            // `ReindexOp` is deliberately exhaustive — it is a wire type, so a
+            // new variant must be a conscious, compile-breaking decision.
+            let args = match op {
+                ReindexOp::Upsert => ReindexArgs::upsert("search_articles", 1),
+                ReindexOp::Delete => ReindexArgs::delete("search_articles", 1),
+            };
+            client.reindex(&args).await.expect("reindex");
+        }
+
+        let page = client
+            .search::<Article>("rust", &PageRequest::default())
+            .await
+            .expect("search");
+        assert_eq!(
+            page.content.iter().map(|h| h.id).collect::<Vec<_>>(),
+            vec![1],
+            "the row exists, so every ordering of {ops:?} must leave it indexed"
+        );
+    }
+}
+
+#[tokio::test]
+async fn a_delete_still_works_with_no_document_source_installed() {
+    // A delete needs no source: "absent from the index" is reachable without
+    // knowing anything about the row. An upsert cannot say the same.
+    let client = SearchClient::builder()
+        .backend(Arc::new(MemorySearchBackend::new()))
+        .index::<Article>()
+        .build();
+    client.ensure_indexes().await.expect("ensure");
+
+    client
+        .reindex(&ReindexArgs::delete("search_articles", 1))
+        .await
+        .expect("delete needs no source");
+
+    let error = client
+        .reindex(&ReindexArgs::upsert("search_articles", 1))
+        .await
+        .expect_err("an upsert has nothing to read");
+    assert!(matches!(error, SearchError::SourceUnavailable), "{error:?}");
 }
 
 #[tokio::test]

--- a/autumn-search/tests/integration/search_client.rs
+++ b/autumn-search/tests/integration/search_client.rs
@@ -1,0 +1,331 @@
+//! `SearchClient` — the one engine-agnostic query API.
+//!
+//! AC: "One engine-agnostic query API returns ranked, paginated results
+//! (reusing `Page`/`ListQuery`) for keyword search; and a vector/semantic
+//! query (k-NN / similarity) for embedded fields."
+
+use std::sync::Arc;
+
+use autumn_search::{
+    HashingEmbedder, MemorySearchBackend, NoEmbedder, SearchClient, SearchError, SearchFilter,
+};
+use autumn_web::pagination::{ListQuery, PageRequest, SortDir};
+
+use super::support::{Article, article, tenant_article};
+
+async fn client(articles: &[Article]) -> SearchClient {
+    let backend = Arc::new(MemorySearchBackend::new());
+    let client = SearchClient::builder()
+        .backend(backend)
+        .embedder(Arc::new(HashingEmbedder::new(128)))
+        .index::<Article>()
+        .build();
+    client.ensure_indexes().await.expect("ensure indexes");
+    for a in articles {
+        client.index_record(a).await.expect("index record");
+    }
+    client
+}
+
+fn corpus() -> Vec<Article> {
+    vec![
+        article(1, "Rust web frameworks", "A survey of the ecosystem."),
+        article(2, "Getting started", "Autumn is a rust web framework."),
+        article(3, "Gardening", "Tomatoes and basil."),
+    ]
+}
+
+// ── Keyword ─────────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn search_returns_a_ranked_page_of_hits() {
+    let client = client(&corpus()).await;
+
+    let page = client
+        .search::<Article>("rust", &PageRequest::default())
+        .await
+        .expect("search");
+
+    assert_eq!(
+        page.content.iter().map(|h| h.id).collect::<Vec<_>>(),
+        vec![1, 2]
+    );
+    assert_eq!(page.total_elements, 2);
+    assert!(page.content.iter().all(|h| h.index == "search_articles"));
+}
+
+#[tokio::test]
+async fn search_accepts_a_list_query_so_it_composes_with_existing_endpoints() {
+    // `ListQuery` carries the request's `filter[...]` keys; `PageRequest`
+    // carries the paging. `search_list` reuses both exactly as a generated
+    // `list()` endpoint does — search drops into an existing index handler
+    // without a second query-parameter vocabulary.
+    let client = client(&[
+        tenant_article(1, "Rust at acme", "rust framework", "acme"),
+        tenant_article(2, "Rust at globex", "rust framework", "globex"),
+    ])
+    .await;
+
+    let list = ListQuery::new(None, SortDir::Asc, &[("tenant_id", "globex")]);
+    let page = client
+        .search_list::<Article>("rust", &list, &PageRequest::default())
+        .await
+        .expect("search_list");
+
+    assert_eq!(
+        page.content.iter().map(|h| h.id).collect::<Vec<_>>(),
+        vec![2]
+    );
+    assert_eq!(page.total_elements, 1);
+    assert_eq!(page.page, 1);
+}
+
+#[tokio::test]
+async fn search_list_paginates_through_the_page_request() {
+    let client = client(&corpus()).await;
+
+    let page = client
+        .search_list::<Article>("rust", &ListQuery::default(), &PageRequest::new(2, 1))
+        .await
+        .expect("search_list");
+
+    assert_eq!(
+        page.content.iter().map(|h| h.id).collect::<Vec<_>>(),
+        vec![2]
+    );
+    assert_eq!(page.total_elements, 2);
+    assert_eq!(page.page, 2);
+    assert_eq!(page.size, 1);
+}
+
+#[tokio::test]
+async fn a_list_query_filter_on_an_indexed_field_narrows_the_results() {
+    let client = client(&corpus()).await;
+
+    let list = ListQuery::new(None, SortDir::Asc, &[("title", "Getting started")]);
+    let page = client
+        .search_list::<Article>("rust", &list, &PageRequest::default())
+        .await
+        .expect("search_list");
+
+    assert_eq!(
+        page.content.iter().map(|h| h.id).collect::<Vec<_>>(),
+        vec![2]
+    );
+}
+
+#[tokio::test]
+async fn a_list_query_filter_on_an_unknown_key_is_ignored_like_list() {
+    // `list()` ignores non-allowlisted filter keys rather than erroring;
+    // search matches that posture so a shared query string works on both.
+    let client = client(&corpus()).await;
+
+    let list = ListQuery::new(None, SortDir::Asc, &[("nope", "whatever")]);
+    let page = client
+        .search_list::<Article>("rust", &list, &PageRequest::default())
+        .await
+        .expect("search_list");
+
+    assert_eq!(
+        page.content.iter().map(|h| h.id).collect::<Vec<_>>(),
+        vec![1, 2]
+    );
+}
+
+#[tokio::test]
+async fn hydrating_a_page_preserves_rank_order_and_pagination_metadata() {
+    // The client returns hits; turning them into records is the app's loader,
+    // and the loader must not be allowed to reorder or lose the ranking.
+    let client = client(&corpus()).await;
+
+    let page = client
+        .search_hydrated::<Article, _, _>("rust", &PageRequest::default(), |ids| async move {
+            // Deliberately return them in the *wrong* order.
+            let mut records: Vec<Article> = ids
+                .iter()
+                .rev()
+                .map(|id| article(*id, "title", "body"))
+                .collect();
+            records.sort_by_key(|a| a.id);
+            Ok(records)
+        })
+        .await
+        .expect("hydrated search");
+
+    assert_eq!(
+        page.content.iter().map(|a| a.id).collect::<Vec<_>>(),
+        vec![1, 2],
+        "hydration must re-apply the ranked order"
+    );
+    assert_eq!(page.total_elements, 2);
+}
+
+#[tokio::test]
+async fn hydration_drops_records_the_loader_could_not_return() {
+    // A hit whose record vanished between the search and the load (deleted, or
+    // filtered out by the loader's own authorization) must not become a hole
+    // or a panic — it is simply absent.
+    let client = client(&corpus()).await;
+
+    let page = client
+        .search_hydrated::<Article, _, _>("rust", &PageRequest::default(), |ids| async move {
+            Ok(ids
+                .iter()
+                .filter(|id| **id == 2)
+                .map(|id| article(*id, "t", "b"))
+                .collect::<Vec<_>>())
+        })
+        .await
+        .expect("hydrated search");
+
+    assert_eq!(
+        page.content.iter().map(|a| a.id).collect::<Vec<_>>(),
+        vec![2]
+    );
+    assert_eq!(
+        page.total_elements, 2,
+        "the pre-hydration total is preserved"
+    );
+}
+
+// ── Vector / semantic ───────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn similar_embeds_the_query_text_and_returns_nearest_neighbours() {
+    let client = client(&[
+        article(1, "Rust", "rust web framework for building apis"),
+        article(2, "Rust again", "a rust web framework"),
+        article(3, "Garden", "tomato basil gardening in summer"),
+    ])
+    .await;
+
+    let hits = client
+        .similar::<Article>("rust web framework", 2)
+        .await
+        .expect("similar");
+
+    assert_eq!(hits.len(), 2);
+    assert!(
+        hits.iter().all(|h| h.id != 3),
+        "the unrelated record must not be a nearest neighbour: {hits:?}"
+    );
+}
+
+#[tokio::test]
+async fn similar_to_an_existing_record_finds_its_neighbours() {
+    let client = client(&[
+        article(1, "Rust", "rust web framework for building apis"),
+        article(2, "Rust again", "a rust web framework"),
+        article(3, "Garden", "tomato basil gardening in summer"),
+    ])
+    .await;
+
+    let hits = client
+        .similar_to::<Article>(1, 5)
+        .await
+        .expect("similar_to");
+
+    assert!(
+        !hits.iter().any(|h| h.id == 1),
+        "a record is not its own neighbour: {hits:?}"
+    );
+    assert_eq!(hits.first().map(|h| h.id), Some(2));
+}
+
+#[tokio::test]
+async fn vector_search_without_an_embedder_is_a_typed_error_not_a_wrong_answer() {
+    let client = SearchClient::builder()
+        .backend(Arc::new(MemorySearchBackend::new()))
+        .embedder(Arc::new(NoEmbedder))
+        .index::<Article>()
+        .build();
+    client.ensure_indexes().await.expect("ensure");
+
+    let err = client.similar::<Article>("anything", 3).await.unwrap_err();
+    assert!(matches!(err, SearchError::EmbedderUnavailable), "{err:?}");
+}
+
+// ── Registration & lifecycle ────────────────────────────────────────────────
+
+#[tokio::test]
+async fn querying_an_unregistered_index_is_a_typed_error() {
+    let client = SearchClient::builder()
+        .backend(Arc::new(MemorySearchBackend::new()))
+        .build();
+
+    let err = client
+        .search::<Article>("rust", &PageRequest::default())
+        .await
+        .unwrap_err();
+    assert!(
+        matches!(err, SearchError::UnknownIndex(ref n) if n == "search_articles"),
+        "{err:?}"
+    );
+}
+
+#[tokio::test]
+async fn removing_a_record_takes_it_out_of_the_index() {
+    let client = client(&corpus()).await;
+
+    client.remove::<Article>(1).await.expect("remove");
+
+    let page = client
+        .search::<Article>("rust", &PageRequest::default())
+        .await
+        .expect("search");
+    assert_eq!(
+        page.content.iter().map(|h| h.id).collect::<Vec<_>>(),
+        vec![2]
+    );
+}
+
+#[tokio::test]
+async fn a_record_update_changes_recall_with_no_manual_reindex_call() {
+    // This is the issue's falsifiable success metric, at the client level:
+    // re-indexing the mutated record (which the lifecycle does automatically)
+    // must change what the query returns.
+    let client = client(&corpus()).await;
+
+    let mut record = article(1, "Rust web frameworks", "A survey of the ecosystem.");
+    record.title = "Gardening weekly".to_owned();
+    record.body = "Tomatoes only.".to_owned();
+    client.index_record(&record).await.expect("reindex");
+
+    let rust = client
+        .search::<Article>("rust", &PageRequest::default())
+        .await
+        .expect("search");
+    assert_eq!(
+        rust.content.iter().map(|h| h.id).collect::<Vec<_>>(),
+        vec![2]
+    );
+
+    let tomatoes = client
+        .search::<Article>("tomatoes", &PageRequest::default())
+        .await
+        .expect("search");
+    assert!(tomatoes.content.iter().any(|h| h.id == 1));
+}
+
+#[tokio::test]
+async fn an_explicit_filter_is_passed_through_to_the_backend() {
+    let client = client(&[
+        tenant_article(1, "Rust at acme", "internal", "acme"),
+        tenant_article(2, "Rust at globex", "internal", "globex"),
+    ])
+    .await;
+
+    let page = client
+        .search_filtered::<Article>(
+            "rust",
+            &PageRequest::default(),
+            SearchFilter::default().tenant("acme"),
+        )
+        .await
+        .expect("search");
+
+    assert_eq!(
+        page.content.iter().map(|h| h.id).collect::<Vec<_>>(),
+        vec![1]
+    );
+}

--- a/autumn-search/tests/integration/search_client.rs
+++ b/autumn-search/tests/integration/search_client.rs
@@ -11,14 +11,28 @@ use autumn_search::{
 };
 use autumn_web::pagination::{ListQuery, PageRequest, SortDir};
 
-use super::support::{Article, article, tenant_article};
+use super::support::{Article, TenantArticle, article, tenant_article, with_tenant};
 
 async fn client(articles: &[Article]) -> SearchClient {
-    let backend = Arc::new(MemorySearchBackend::new());
     let client = SearchClient::builder()
-        .backend(backend)
+        .backend(Arc::new(MemorySearchBackend::new()))
         .embedder(Arc::new(HashingEmbedder::new(128)))
         .index::<Article>()
+        .index::<TenantArticle>()
+        .build();
+    client.ensure_indexes().await.expect("ensure indexes");
+    for a in articles {
+        client.index_record(a).await.expect("index record");
+    }
+    client
+}
+
+/// A client seeded with tenant-scoped records.
+async fn tenant_client(articles: &[TenantArticle]) -> SearchClient {
+    let client = SearchClient::builder()
+        .backend(Arc::new(MemorySearchBackend::new()))
+        .embedder(Arc::new(HashingEmbedder::new(128)))
+        .index::<TenantArticle>()
         .build();
     client.ensure_indexes().await.expect("ensure indexes");
     for a in articles {
@@ -60,17 +74,20 @@ async fn search_accepts_a_list_query_so_it_composes_with_existing_endpoints() {
     // carries the paging. `search_list` reuses both exactly as a generated
     // `list()` endpoint does — search drops into an existing index handler
     // without a second query-parameter vocabulary.
-    let client = client(&[
+    let client = tenant_client(&[
         tenant_article(1, "Rust at acme", "rust framework", "acme"),
         tenant_article(2, "Rust at globex", "rust framework", "globex"),
     ])
     .await;
 
     let list = ListQuery::new(None, SortDir::Asc, &[("tenant_id", "globex")]);
-    let page = client
-        .search_list::<Article>("rust", &list, &PageRequest::default())
-        .await
-        .expect("search_list");
+    let page = with_tenant("globex", async {
+        client
+            .search_list::<TenantArticle>("rust", &list, &PageRequest::default())
+            .await
+    })
+    .await
+    .expect("search_list");
 
     assert_eq!(
         page.content.iter().map(|h| h.id).collect::<Vec<_>>(),
@@ -162,9 +179,12 @@ async fn hydrating_a_page_preserves_rank_order_and_pagination_metadata() {
 
 #[tokio::test]
 async fn hydration_drops_records_the_loader_could_not_return() {
-    // A hit whose record vanished between the search and the load (deleted, or
-    // filtered out by the loader's own authorization) must not become a hole
-    // or a panic — it is simply absent.
+    // A hit whose record vanished between the search and the load must not
+    // become a hole or a panic — it is simply absent, and it is subtracted
+    // from the total so the pager cannot advertise a record the caller never
+    // received. (That total is damage limitation, not authorization: filtering
+    // in the loader still leaks a count. `search_for` is the authorization
+    // path.)
     let client = client(&corpus()).await;
 
     let page = client
@@ -183,8 +203,8 @@ async fn hydration_drops_records_the_loader_could_not_return() {
         vec![2]
     );
     assert_eq!(
-        page.total_elements, 2,
-        "the pre-hydration total is preserved"
+        page.total_elements, 1,
+        "a record the loader could not produce is not counted"
     );
 }
 
@@ -309,20 +329,23 @@ async fn a_record_update_changes_recall_with_no_manual_reindex_call() {
 
 #[tokio::test]
 async fn an_explicit_filter_is_passed_through_to_the_backend() {
-    let client = client(&[
+    let client = tenant_client(&[
         tenant_article(1, "Rust at acme", "internal", "acme"),
         tenant_article(2, "Rust at globex", "internal", "globex"),
     ])
     .await;
 
-    let page = client
-        .search_filtered::<Article>(
-            "rust",
-            &PageRequest::default(),
-            SearchFilter::default().tenant("acme"),
-        )
-        .await
-        .expect("search");
+    let page = with_tenant("acme", async {
+        client
+            .search_filtered::<TenantArticle>(
+                "rust",
+                &PageRequest::default(),
+                SearchFilter::default().tenant("acme"),
+            )
+            .await
+    })
+    .await
+    .expect("search");
 
     assert_eq!(
         page.content.iter().map(|h| h.id).collect::<Vec<_>>(),

--- a/autumn-search/tests/integration/support.rs
+++ b/autumn-search/tests/integration/support.rs
@@ -55,6 +55,56 @@ pub struct TenantArticle {
     pub tenant_id: Option<String>,
 }
 
+diesel::table! {
+    search_notes (note_id) {
+        note_id -> Int8,
+        // A legacy column that is NOT the key and is not part of the model.
+        // Its values deliberately disagree with `note_id` below, so a source
+        // reader that assumes `id` produces wrong answers rather than an
+        // error — see `Note`.
+        id -> Int8,
+        title -> Text,
+        body -> Text,
+    }
+}
+
+/// A searchable model whose primary key is **not** called `id`, on a table
+/// that happens to have an `id` column anyway.
+///
+/// The combination is what makes this dangerous rather than merely broken.
+/// `#[model]`'s bulk-upsert path names `<table>::id`, so a table with no `id`
+/// column at all fails to compile — loud, and nobody ships it. A table that
+/// *does* have a leftover `id` compiles fine, and then a source reader that
+/// assumes `id` silently keys every backfilled document off the wrong column:
+/// the sync hooks write documents keyed on `note_id`, the backfill writes
+/// documents keyed on `id`, and the index quietly holds two of everything with
+/// no error anywhere. The key column has to come from the model.
+#[autumn_web::model(table = "search_notes")]
+#[searchable(language = "english")]
+// `note_id` is the point of the fixture — the column name has to stay.
+#[allow(clippy::struct_field_names)]
+pub struct Note {
+    #[id]
+    pub note_id: i64,
+    /// The leftover column. Ordinary data, not a key, and not searchable.
+    pub id: i64,
+    #[searchable(weight = "A")]
+    pub title: String,
+    #[searchable(weight = "B", embed)]
+    pub body: String,
+}
+
+/// Build a note keyed on `note_id`, with the decoy `id` offset by 100 so
+/// reading the wrong column is unmistakable.
+pub fn note(note_id: i64, title: &str, body: &str) -> Note {
+    Note {
+        note_id,
+        id: note_id + 100,
+        title: title.to_owned(),
+        body: body.to_owned(),
+    }
+}
+
 /// Build an article without touching a database.
 pub fn article(id: i64, title: &str, body: &str) -> Article {
     Article {

--- a/autumn-search/tests/integration/support.rs
+++ b/autumn-search/tests/integration/support.rs
@@ -36,6 +36,7 @@ diesel::table! {
         title -> Text,
         body -> Text,
         tenant_id -> Nullable<Text>,
+        deleted_at -> Nullable<Timestamp>,
     }
 }
 
@@ -53,6 +54,56 @@ pub struct TenantArticle {
     #[searchable(weight = "B", embed)]
     pub body: String,
     pub tenant_id: Option<String>,
+    #[default]
+    pub deleted_at: Option<autumn_web::reexports::chrono::NaiveDateTime>,
+}
+
+/// `TenantArticle`'s repository genuinely opts into `soft_delete`, so its
+/// finders hide deleted rows — and the search index must agree. That opt-in,
+/// not the mere presence of the column, is what reaches `IndexDefinition`.
+#[autumn_web::repository(TenantArticle, table = "search_tenant_articles", soft_delete)]
+pub trait TenantArticleRepository {}
+
+diesel::table! {
+    search_audit_articles (id) {
+        id -> Int8,
+        title -> Text,
+        body -> Text,
+        deleted_at -> Nullable<Timestamp>,
+    }
+}
+
+/// The mirror image: a `deleted_at` column that is **audit history**, with a
+/// repository that does *not* opt into `soft_delete`.
+///
+/// The framework supports this shape and its finders still return those rows
+/// (`autumn/tests/integration/preload_scoping.rs`'s `AuditItem`). A source
+/// that read the column as a tombstone would hide them from reindex and drop
+/// them from a purging backfill, so the index would disagree with the app.
+#[autumn_web::model(table = "search_audit_articles")]
+#[searchable(language = "english")]
+pub struct AuditArticle {
+    #[id]
+    pub id: i64,
+    #[searchable(weight = "A")]
+    pub title: String,
+    #[searchable(weight = "B", embed)]
+    pub body: String,
+    #[default]
+    pub deleted_at: Option<autumn_web::reexports::chrono::NaiveDateTime>,
+}
+
+#[autumn_web::repository(AuditArticle, table = "search_audit_articles")]
+pub trait AuditArticleRepository {}
+
+/// Build an audit-history article.
+pub fn audit_article(id: i64, title: &str, body: &str) -> AuditArticle {
+    AuditArticle {
+        id,
+        title: title.to_owned(),
+        body: body.to_owned(),
+        deleted_at: None,
+    }
 }
 
 diesel::table! {
@@ -121,6 +172,7 @@ pub fn tenant_article(id: i64, title: &str, body: &str, tenant: &str) -> TenantA
         title: title.to_owned(),
         body: body.to_owned(),
         tenant_id: Some(tenant.to_owned()),
+        deleted_at: None,
     }
 }
 
@@ -131,6 +183,7 @@ pub fn untenanted_article(id: i64, title: &str, body: &str) -> TenantArticle {
         title: title.to_owned(),
         body: body.to_owned(),
         tenant_id: None,
+        deleted_at: None,
     }
 }
 

--- a/autumn-search/tests/integration/support.rs
+++ b/autumn-search/tests/integration/support.rs
@@ -2,11 +2,36 @@
 
 #![allow(dead_code)]
 
-use autumn_search::{IndexedDocument, MemorySearchBackend, SearchBackend as _};
-use autumn_web::search::SearchIndexed as _;
+use autumn_search::{IndexDefinition, IndexedDocument, MemorySearchBackend, SearchBackend as _};
+use autumn_web::search::{SearchDocument, SearchIndexed as _};
 
 diesel::table! {
     search_articles (id) {
+        id -> Int8,
+        title -> Text,
+        body -> Text,
+    }
+}
+
+/// The canonical searchable model: two weighted keyword fields and a
+/// `#[searchable(embed)]` body for vector search.
+///
+/// Deliberately **not** tenant-scoped — it has no `tenant_id` column — so the
+/// suites that are not about tenancy can query it without establishing a
+/// tenant scope. Tenancy has its own model below.
+#[autumn_web::model(table = "search_articles")]
+#[searchable(language = "english")]
+pub struct Article {
+    #[id]
+    pub id: i64,
+    #[searchable(weight = "A")]
+    pub title: String,
+    #[searchable(weight = "B", embed)]
+    pub body: String,
+}
+
+diesel::table! {
+    search_tenant_articles (id) {
         id -> Int8,
         title -> Text,
         body -> Text,
@@ -14,11 +39,13 @@ diesel::table! {
     }
 }
 
-/// The canonical searchable model: two weighted keyword fields and a
-/// `#[searchable(embed)]` body for vector search.
-#[autumn_web::model(table = "search_articles")]
+/// A searchable model that **is** tenant-scoped: `#[model]` sees the
+/// `tenant_id` column, carries it into every document, and marks the index
+/// tenant-scoped so a query with no tenant context is refused rather than run
+/// across every tenant.
+#[autumn_web::model(table = "search_tenant_articles")]
 #[searchable(language = "english")]
-pub struct Article {
+pub struct TenantArticle {
     #[id]
     pub id: i64,
     #[searchable(weight = "A")]
@@ -34,13 +61,12 @@ pub fn article(id: i64, title: &str, body: &str) -> Article {
         id,
         title: title.to_owned(),
         body: body.to_owned(),
-        tenant_id: None,
     }
 }
 
-/// Build an article owned by `tenant`.
-pub fn tenant_article(id: i64, title: &str, body: &str, tenant: &str) -> Article {
-    Article {
+/// Build a tenant-owned article.
+pub fn tenant_article(id: i64, title: &str, body: &str, tenant: &str) -> TenantArticle {
+    TenantArticle {
         id,
         title: title.to_owned(),
         body: body.to_owned(),
@@ -48,17 +74,56 @@ pub fn tenant_article(id: i64, title: &str, body: &str, tenant: &str) -> Article
     }
 }
 
+/// A tenant-scoped model's record with no owning tenant.
+pub fn untenanted_article(id: i64, title: &str, body: &str) -> TenantArticle {
+    TenantArticle {
+        id,
+        title: title.to_owned(),
+        body: body.to_owned(),
+        tenant_id: None,
+    }
+}
+
+/// Run `future` inside `tenant`'s scope, exactly as the tenancy layer would.
+pub async fn with_tenant<T>(tenant: &str, future: impl Future<Output = T>) -> T {
+    autumn_web::tenancy::CURRENT_TENANT
+        .scope(Some(tenant.to_owned()), future)
+        .await
+}
+
 /// A `MemorySearchBackend` with `Article`'s index created and `articles`
 /// indexed (no embeddings).
 pub async fn seeded_backend(articles: &[Article]) -> MemorySearchBackend {
+    seeded_backend_with(
+        Article::index_definition(),
+        articles.iter().map(Article::search_document).collect(),
+    )
+    .await
+}
+
+/// A `MemorySearchBackend` seeded with `TenantArticle` documents.
+pub async fn seeded_tenant_backend(articles: &[TenantArticle]) -> MemorySearchBackend {
+    seeded_backend_with(
+        TenantArticle::index_definition(),
+        articles
+            .iter()
+            .map(TenantArticle::search_document)
+            .collect(),
+    )
+    .await
+}
+
+async fn seeded_backend_with(
+    definition: IndexDefinition,
+    documents: Vec<SearchDocument>,
+) -> MemorySearchBackend {
     let backend = MemorySearchBackend::new();
-    let def = Article::index_definition();
-    backend.ensure_index(&def).await.expect("ensure_index");
-    let docs: Vec<IndexedDocument> = articles
-        .iter()
-        .map(|a| IndexedDocument::new(a.search_document()))
-        .collect();
-    backend.index(&def, &docs).await.expect("index");
+    backend
+        .ensure_index(&definition)
+        .await
+        .expect("ensure_index");
+    let documents: Vec<IndexedDocument> = documents.into_iter().map(IndexedDocument::new).collect();
+    backend.index(&definition, &documents).await.expect("index");
     backend
 }
 

--- a/autumn-search/tests/integration/support.rs
+++ b/autumn-search/tests/integration/support.rs
@@ -1,0 +1,77 @@
+//! Shared fixtures for the `autumn-search` suites.
+
+#![allow(dead_code)]
+
+use autumn_search::{IndexedDocument, MemorySearchBackend, SearchBackend as _};
+use autumn_web::search::SearchIndexed as _;
+
+diesel::table! {
+    search_articles (id) {
+        id -> Int8,
+        title -> Text,
+        body -> Text,
+        tenant_id -> Nullable<Text>,
+    }
+}
+
+/// The canonical searchable model: two weighted keyword fields and a
+/// `#[searchable(embed)]` body for vector search.
+#[autumn_web::model(table = "search_articles")]
+#[searchable(language = "english")]
+pub struct Article {
+    #[id]
+    pub id: i64,
+    #[searchable(weight = "A")]
+    pub title: String,
+    #[searchable(weight = "B", embed)]
+    pub body: String,
+    pub tenant_id: Option<String>,
+}
+
+/// Build an article without touching a database.
+pub fn article(id: i64, title: &str, body: &str) -> Article {
+    Article {
+        id,
+        title: title.to_owned(),
+        body: body.to_owned(),
+        tenant_id: None,
+    }
+}
+
+/// Build an article owned by `tenant`.
+pub fn tenant_article(id: i64, title: &str, body: &str, tenant: &str) -> Article {
+    Article {
+        id,
+        title: title.to_owned(),
+        body: body.to_owned(),
+        tenant_id: Some(tenant.to_owned()),
+    }
+}
+
+/// A `MemorySearchBackend` with `Article`'s index created and `articles`
+/// indexed (no embeddings).
+pub async fn seeded_backend(articles: &[Article]) -> MemorySearchBackend {
+    let backend = MemorySearchBackend::new();
+    let def = Article::index_definition();
+    backend.ensure_index(&def).await.expect("ensure_index");
+    let docs: Vec<IndexedDocument> = articles
+        .iter()
+        .map(|a| IndexedDocument::new(a.search_document()))
+        .collect();
+    backend.index(&def, &docs).await.expect("index");
+    backend
+}
+
+/// A `PolicyContext` for `user`, built the same way a hand-rolled policy unit
+/// test would (`PolicyContext::from_session`), so the visibility hook sees the
+/// exact shape a request produces.
+pub async fn policy_context(user: Option<&str>) -> autumn_web::authorization::PolicyContext {
+    use std::collections::HashMap;
+
+    let mut data = HashMap::new();
+    if let Some(user) = user {
+        data.insert("user_id".to_owned(), user.to_owned());
+    }
+    let session = autumn_web::session::Session::new_for_test("test-session".to_owned(), data);
+    autumn_web::authorization::PolicyContext::from_session(&session, "user_id").await
+}

--- a/autumn-search/tests/integration/support.rs
+++ b/autumn-search/tests/integration/support.rs
@@ -58,10 +58,16 @@ pub struct TenantArticle {
     pub deleted_at: Option<autumn_web::reexports::chrono::NaiveDateTime>,
 }
 
-/// `TenantArticle`'s repository genuinely opts into `soft_delete`, so its
-/// finders hide deleted rows — and the search index must agree. That opt-in,
-/// not the mere presence of the column, is what reaches `IndexDefinition`.
-#[autumn_web::repository(TenantArticle, table = "search_tenant_articles", soft_delete)]
+/// `TenantArticle`'s repository genuinely opts into **both** scopes, so its
+/// finders hide deleted rows and restrict to the ambient tenant — and the
+/// search index must agree. Those opt-ins, not the mere presence of the
+/// columns, are what reach `IndexDefinition`.
+#[autumn_web::repository(
+    TenantArticle,
+    table = "search_tenant_articles",
+    soft_delete,
+    tenant_scoped
+)]
 pub trait TenantArticleRepository {}
 
 diesel::table! {

--- a/autumn-search/tests/integration/sync_hooks.rs
+++ b/autumn-search/tests/integration/sync_hooks.rs
@@ -1,0 +1,118 @@
+//! `SearchSyncHooks` as a real `#[repository]` hooks type.
+//!
+//! AC: "create/update/delete to a searchable model enqueues a reindex (via
+//! `#[job]`, so indexing is off-request and durable)".
+//!
+//! The valuable assertion here is a **compile-time** one: `SearchSyncHooks`
+//! must actually satisfy everything `#[repository(hooks = …, commit_hooks =
+//! true)]` demands of a hooks type (`MutationHooks` with the three associated
+//! types, plus `Default` and `Clone` — which it provides without requiring
+//! them of the model). If this module compiles, the wiring in the crate docs
+//! is real; if it stops compiling, an application's one-line opt-in has
+//! silently broken.
+
+#![allow(dead_code, clippy::items_after_statements)]
+
+use autumn_search::{ReindexArgs, ReindexOp, SearchSyncHooks};
+use autumn_web::hooks::{MutationContext, MutationHooks, MutationOp};
+use autumn_web::search::SearchIndexed as _;
+
+// Glob import: `#[repository]` expands to code that names the model's
+// generated companions (the diesel table module, the changesets, the update
+// draft extension trait) by their unqualified names.
+use super::support::*;
+
+/// The hooks type an application writes, verbatim from the crate docs.
+type ArticleSearchHooks = SearchSyncHooks<Article, NewArticle, UpdateArticle>;
+
+// The repository declaration from the docs. Its existence is the test: it will
+// not compile unless `SearchSyncHooks` is a valid hooks type for this model.
+#[autumn_web::repository(
+    Article,
+    table = "search_articles",
+    hooks = ArticleSearchHooks,
+    commit_hooks = true,
+    searchable
+)]
+pub trait ArticleRepository {}
+
+#[test]
+fn the_hooks_type_satisfies_the_repository_contract() {
+    // `#[repository]` constructs hooks via `Default` and clones them with the
+    // generated struct; neither may require anything of the model.
+    let hooks = ArticleSearchHooks::default();
+    assert_eq!(format!("{hooks:?}"), "SearchSyncHooks");
+
+    // `Clone` is what the generated repository struct derives through, and
+    // `Default` is how it constructs the hooks — both must hold even though
+    // the model itself carries no such bound.
+    fn assert_default_and_clone<H: Default + Clone>() {}
+    assert_default_and_clone::<ArticleSearchHooks>();
+
+    fn assert_hooks<H: MutationHooks>() {}
+    assert_hooks::<ArticleSearchHooks>();
+}
+
+#[test]
+fn the_associated_types_line_up_with_the_model() {
+    fn assert_model<H: MutationHooks<Model = Article>>() {}
+    fn assert_new<H: MutationHooks<NewModel = NewArticle>>() {}
+    fn assert_update<H: MutationHooks<UpdateModel = UpdateArticle>>() {}
+
+    assert_model::<ArticleSearchHooks>();
+    assert_new::<ArticleSearchHooks>();
+    assert_update::<ArticleSearchHooks>();
+}
+
+#[tokio::test]
+async fn a_create_or_update_produces_an_upsert_instruction_for_the_record() {
+    // The hook bodies build these args and hand them to the enqueue
+    // chokepoint. Asserting the *instruction* (rather than driving a whole job
+    // runtime) is what makes the mapping from lifecycle event to payload
+    // checkable: the record's id and index must survive, and create/update
+    // must both mean "converge this row".
+    let record = article(7, "Rust", "body");
+
+    let created = ReindexArgs::upsert(Article::SEARCH_INDEX, record.search_id());
+    assert_eq!(created.index, "search_articles");
+    assert_eq!(created.id, 7);
+    assert_eq!(created.op, ReindexOp::Upsert);
+
+    // An update is deliberately the *same* instruction: the job re-reads the
+    // row, so there is nothing for "update" to do differently.
+    let updated = ReindexArgs::upsert(Article::SEARCH_INDEX, record.search_id());
+    assert_eq!(updated, created);
+}
+
+#[tokio::test]
+async fn a_delete_produces_a_delete_instruction_that_never_reads_the_source() {
+    let record = article(7, "Rust", "body");
+    let deleted = ReindexArgs::delete(Article::SEARCH_INDEX, record.search_id());
+
+    assert_eq!(deleted.op, ReindexOp::Delete);
+    assert_eq!(deleted.id, 7);
+    assert_ne!(deleted, ReindexArgs::upsert(Article::SEARCH_INDEX, 7));
+}
+
+#[tokio::test]
+async fn every_mutation_op_maps_to_an_instruction() {
+    // A new `MutationOp` variant must not silently mean "no index update".
+    for op in [MutationOp::Create, MutationOp::Update, MutationOp::Delete] {
+        let args = match op {
+            MutationOp::Create | MutationOp::Update => ReindexArgs::upsert("search_articles", 1),
+            MutationOp::Delete => ReindexArgs::delete("search_articles", 1),
+            _ => unreachable!("MutationOp is non_exhaustive; add the new variant here"),
+        };
+        assert_eq!(args.id, 1);
+    }
+}
+
+#[test]
+fn the_hook_context_type_is_the_one_repositories_pass() {
+    // Guards against a signature drift that would only surface in a user's
+    // crate: the hooks take `&mut MutationContext`.
+    let mut ctx = MutationContext::new(MutationOp::Create);
+    assert_eq!(ctx.op, MutationOp::Create);
+    ctx.op = MutationOp::Update;
+    assert_eq!(ctx.op, MutationOp::Update);
+}

--- a/autumn-search/tests/integration/visibility.rs
+++ b/autumn-search/tests/integration/visibility.rs
@@ -1,0 +1,230 @@
+//! Search respects existing authorization.
+//!
+//! AC: "Search respects existing authorization: results can be filtered by the
+//! same policy/scope posture as normal queries (no leaking records a user
+//! can't see). Out-of-scope engines must still support a tenant/visibility
+//! filter hook."
+//!
+//! Two layers, both asserted here:
+//!
+//! 1. **Pre-filter** — a `SearchVisibility` turns the request's
+//!    `PolicyContext` into a `SearchFilter` that is pushed *into* the backend
+//!    query. This is the hook an out-of-scope engine (Meilisearch, a vector
+//!    store) implements, because it is plain data.
+//! 2. **Post-filter** — hydrated records can additionally be run through the
+//!    registered `Policy`, matching the posture of a normal read.
+
+use std::sync::Arc;
+
+use autumn_search::{
+    HashingEmbedder, MemorySearchBackend, SearchClient, SearchError, SearchFilter,
+    SearchVisibility, TenantVisibility,
+};
+use autumn_web::authorization::PolicyContext;
+use autumn_web::pagination::PageRequest;
+
+use super::support::{Article, article, policy_context, tenant_article};
+
+async fn client_with(
+    articles: &[Article],
+    visibility: Option<Arc<dyn SearchVisibility>>,
+) -> SearchClient {
+    let mut builder = SearchClient::builder()
+        .backend(Arc::new(MemorySearchBackend::new()))
+        .embedder(Arc::new(HashingEmbedder::new(64)))
+        .index::<Article>();
+    if let Some(v) = visibility {
+        builder = builder.visibility(v);
+    }
+    let client = builder.build();
+    client.ensure_indexes().await.expect("ensure");
+    for a in articles {
+        client.index_record(a).await.expect("index");
+    }
+    client
+}
+
+async fn ctx_for(user: &str) -> PolicyContext {
+    policy_context(Some(user)).await
+}
+
+async fn anonymous_ctx() -> PolicyContext {
+    policy_context(None).await
+}
+
+/// A visibility hook that only lets a user see the records they own — the
+/// search-side equivalent of a `Scope<Article>`.
+struct OwnerVisibility;
+
+impl SearchVisibility for OwnerVisibility {
+    fn filter<'a>(
+        &'a self,
+        ctx: &'a PolicyContext,
+        _index: &'a str,
+    ) -> autumn_search::BoxFuture<'a, Result<SearchFilter, SearchError>> {
+        Box::pin(async move {
+            Ok(match ctx.user_id.as_deref() {
+                Some("alice") => SearchFilter::default().allow_ids([1_i64]),
+                Some("bob") => SearchFilter::default().allow_ids([2_i64]),
+                // Anonymous sees nothing — fail closed, exactly like `Scope`'s
+                // default empty list.
+                _ => SearchFilter::default().allow_ids(Vec::<i64>::new()),
+            })
+        })
+    }
+}
+
+/// A visibility hook that fails. A failing authorization decision must abort
+/// the search, never fall back to an unfiltered one.
+struct BrokenVisibility;
+
+impl SearchVisibility for BrokenVisibility {
+    fn filter<'a>(
+        &'a self,
+        _ctx: &'a PolicyContext,
+        _index: &'a str,
+    ) -> autumn_search::BoxFuture<'a, Result<SearchFilter, SearchError>> {
+        Box::pin(async move { Err(SearchError::Backend("policy store unavailable".to_owned())) })
+    }
+}
+
+fn corpus() -> Vec<Article> {
+    vec![
+        article(1, "Rust one", "rust"),
+        article(2, "Rust two", "rust"),
+        article(3, "Rust three", "rust"),
+    ]
+}
+
+#[tokio::test]
+async fn search_for_applies_the_registered_visibility_filter() {
+    let client = client_with(&corpus(), Some(Arc::new(OwnerVisibility))).await;
+
+    let alice = client
+        .search_for::<Article>(&ctx_for("alice").await, "rust", &PageRequest::default())
+        .await
+        .expect("search");
+    assert_eq!(
+        alice.content.iter().map(|h| h.id).collect::<Vec<_>>(),
+        vec![1]
+    );
+
+    let bob = client
+        .search_for::<Article>(&ctx_for("bob").await, "rust", &PageRequest::default())
+        .await
+        .expect("search");
+    assert_eq!(
+        bob.content.iter().map(|h| h.id).collect::<Vec<_>>(),
+        vec![2]
+    );
+}
+
+#[tokio::test]
+async fn an_anonymous_request_sees_nothing_when_the_hook_fails_closed() {
+    let client = client_with(&corpus(), Some(Arc::new(OwnerVisibility))).await;
+
+    let page = client
+        .search_for::<Article>(&anonymous_ctx().await, "rust", &PageRequest::default())
+        .await
+        .expect("search");
+    assert!(page.content.is_empty());
+    assert_eq!(page.total_elements, 0);
+}
+
+#[tokio::test]
+async fn a_failing_visibility_hook_aborts_the_search_instead_of_widening_it() {
+    let client = client_with(&corpus(), Some(Arc::new(BrokenVisibility))).await;
+
+    let err = client
+        .search_for::<Article>(&ctx_for("alice").await, "rust", &PageRequest::default())
+        .await
+        .unwrap_err();
+    assert!(matches!(err, SearchError::Backend(_)), "{err:?}");
+}
+
+#[tokio::test]
+async fn vector_search_goes_through_the_same_visibility_hook() {
+    // A semantic query must not be a back door around the keyword filter.
+    let client = client_with(&corpus(), Some(Arc::new(OwnerVisibility))).await;
+
+    let hits = client
+        .similar_for::<Article>(&ctx_for("alice").await, "rust", 10)
+        .await
+        .expect("similar");
+    assert!(hits.iter().all(|h| h.id == 1), "{hits:?}");
+}
+
+#[tokio::test]
+async fn the_default_visibility_is_tenant_isolation() {
+    let client = client_with(
+        &[
+            tenant_article(1, "Rust at acme", "rust", "acme"),
+            tenant_article(2, "Rust at globex", "rust", "globex"),
+        ],
+        Some(Arc::new(TenantVisibility)),
+    )
+    .await;
+
+    let filter = TenantVisibility
+        .filter(&anonymous_ctx().await, "search_articles")
+        .await
+        .expect("filter");
+    // With no ambient tenant there is nothing to scope by; the plugin's own
+    // tenant filter is additive to whatever the app supplies.
+    assert_eq!(filter.tenant_id, None);
+
+    let page = client
+        .search_filtered::<Article>(
+            "rust",
+            &PageRequest::default(),
+            SearchFilter::default().tenant("globex"),
+        )
+        .await
+        .expect("search");
+    assert_eq!(
+        page.content.iter().map(|h| h.id).collect::<Vec<_>>(),
+        vec![2]
+    );
+}
+
+#[tokio::test]
+async fn without_a_registered_visibility_search_for_is_not_silently_unfiltered() {
+    // If an app calls the authorization-aware entry point but registered no
+    // hook, that is a wiring mistake — surface it rather than returning
+    // everything and looking like it worked.
+    let client = client_with(&corpus(), None).await;
+
+    let err = client
+        .search_for::<Article>(&ctx_for("alice").await, "rust", &PageRequest::default())
+        .await
+        .unwrap_err();
+    assert!(matches!(err, SearchError::VisibilityUnavailable), "{err:?}");
+}
+
+#[tokio::test]
+async fn filters_compose_rather_than_overwrite() {
+    // An explicit caller filter and the visibility hook must intersect: the
+    // narrower of the two always wins, so a caller can never widen past what
+    // authorization allowed.
+    let a = SearchFilter::default()
+        .allow_ids([1_i64, 2, 3])
+        .tenant("acme");
+    let b = SearchFilter::default()
+        .allow_ids([2_i64, 3, 4])
+        .exclude_ids([3_i64]);
+
+    let merged = a.intersect(b);
+    assert_eq!(merged.tenant_id.as_deref(), Some("acme"));
+    assert_eq!(merged.allowed_ids, Some(vec![2, 3]));
+    assert_eq!(merged.excluded_ids, vec![3]);
+}
+
+#[tokio::test]
+async fn intersecting_conflicting_tenants_yields_an_impossible_filter() {
+    // Two different tenants can never both be satisfied. The result must match
+    // nothing rather than arbitrarily picking one.
+    let merged = SearchFilter::default()
+        .tenant("acme")
+        .intersect(SearchFilter::default().tenant("globex"));
+    assert_eq!(merged.allowed_ids, Some(Vec::new()));
+}

--- a/autumn-search/tests/integration/visibility.rs
+++ b/autumn-search/tests/integration/visibility.rs
@@ -23,7 +23,9 @@ use autumn_search::{
 use autumn_web::authorization::PolicyContext;
 use autumn_web::pagination::PageRequest;
 
-use super::support::{Article, article, policy_context, tenant_article};
+use super::support::{
+    Article, TenantArticle, article, policy_context, tenant_article, with_tenant,
+};
 
 async fn client_with(
     articles: &[Article],
@@ -33,6 +35,25 @@ async fn client_with(
         .backend(Arc::new(MemorySearchBackend::new()))
         .embedder(Arc::new(HashingEmbedder::new(64)))
         .index::<Article>();
+    if let Some(v) = visibility {
+        builder = builder.visibility(v);
+    }
+    let client = builder.build();
+    client.ensure_indexes().await.expect("ensure");
+    for a in articles {
+        client.index_record(a).await.expect("index");
+    }
+    client
+}
+
+async fn tenant_client_with(
+    articles: &[TenantArticle],
+    visibility: Option<Arc<dyn SearchVisibility>>,
+) -> SearchClient {
+    let mut builder = SearchClient::builder()
+        .backend(Arc::new(MemorySearchBackend::new()))
+        .embedder(Arc::new(HashingEmbedder::new(64)))
+        .index::<TenantArticle>();
     if let Some(v) = visibility {
         builder = builder.visibility(v);
     }
@@ -155,8 +176,28 @@ async fn vector_search_goes_through_the_same_visibility_hook() {
 }
 
 #[tokio::test]
-async fn the_default_visibility_is_tenant_isolation() {
-    let client = client_with(
+async fn the_default_visibility_reads_the_ambient_tenant() {
+    // Outside a tenant scope there is nothing to scope by …
+    let filter = TenantVisibility
+        .filter(&anonymous_ctx().await, "search_tenant_articles")
+        .await
+        .expect("filter");
+    assert_eq!(filter.tenant_id, None);
+
+    // … and inside one, the hook restricts to it with no app code.
+    let filter = with_tenant("acme", async {
+        TenantVisibility
+            .filter(&anonymous_ctx().await, "search_tenant_articles")
+            .await
+    })
+    .await
+    .expect("filter");
+    assert_eq!(filter.tenant_id.as_deref(), Some("acme"));
+}
+
+#[tokio::test]
+async fn a_tenant_scoped_search_never_crosses_tenants() {
+    let client = tenant_client_with(
         &[
             tenant_article(1, "Rust at acme", "rust", "acme"),
             tenant_article(2, "Rust at globex", "rust", "globex"),
@@ -165,26 +206,54 @@ async fn the_default_visibility_is_tenant_isolation() {
     )
     .await;
 
-    let filter = TenantVisibility
-        .filter(&anonymous_ctx().await, "search_articles")
-        .await
-        .expect("filter");
-    // With no ambient tenant there is nothing to scope by; the plugin's own
-    // tenant filter is additive to whatever the app supplies.
-    assert_eq!(filter.tenant_id, None);
-
-    let page = client
-        .search_filtered::<Article>(
-            "rust",
-            &PageRequest::default(),
-            SearchFilter::default().tenant("globex"),
-        )
-        .await
-        .expect("search");
+    let page = with_tenant("globex", async {
+        client
+            .search_for::<TenantArticle>(&anonymous_ctx().await, "rust", &PageRequest::default())
+            .await
+    })
+    .await
+    .expect("search");
     assert_eq!(
         page.content.iter().map(|h| h.id).collect::<Vec<_>>(),
         vec![2]
     );
+}
+
+#[tokio::test]
+async fn deny_all_is_actually_consulted_and_returns_nothing() {
+    let client = client_with(&corpus(), Some(Arc::new(autumn_search::DenyAll))).await;
+
+    let page = client
+        .search_for::<Article>(&ctx_for("alice").await, "rust", &PageRequest::default())
+        .await
+        .expect("search");
+    assert!(page.content.is_empty(), "DenyAll must match nothing");
+    assert_eq!(page.total_elements, 0);
+}
+
+#[tokio::test]
+async fn similar_to_will_not_read_a_seed_the_hook_excluded() {
+    // "More like this" reads the seed record's stored vector. Left unfiltered
+    // that is an inference channel: rank your own probe documents against a
+    // record you cannot see and learn roughly what it says.
+    let client = client_with(&corpus(), Some(Arc::new(OwnerVisibility))).await;
+
+    // Alice may see record 1 only, so seeding from record 2 yields nothing.
+    let hits = client
+        .similar_to_for::<Article>(&ctx_for("alice").await, 2, 5)
+        .await
+        .expect("similar_to_for");
+    assert!(
+        hits.is_empty(),
+        "the excluded seed must read back as absent"
+    );
+
+    // Her own record is a usable seed (and is excluded from its own results).
+    let hits = client
+        .similar_to_for::<Article>(&ctx_for("alice").await, 1, 5)
+        .await
+        .expect("similar_to_for");
+    assert!(hits.iter().all(|h| h.id != 1), "{hits:?}");
 }
 
 #[tokio::test]

--- a/autumn-search/tests/search_tests.rs
+++ b/autumn-search/tests/search_tests.rs
@@ -1,0 +1,7 @@
+//! Consolidated integration-test binary for `autumn-search` (issue #1191).
+//!
+//! Mirrors the workspace convention (CLAUDE.md "Integration Test Layout
+//! Guidelines"): every suite is a module under `tests/integration/` so the
+//! whole crate links **one** test binary instead of a dozen.
+
+mod integration;

--- a/autumn/src/lib.rs
+++ b/autumn/src/lib.rs
@@ -125,10 +125,12 @@ pub mod hooks;
 pub mod i18n;
 pub mod idempotency;
 pub mod range;
-/// Engine-agnostic search vocabulary.
-///
-/// Index definitions and extracted documents, shared by `#[model]
-/// #[searchable]` and the optional `autumn-search` plugin.
+// NOTE: no outer `///` doc here. rustdoc MERGES an outer doc on a `pub mod`
+// declaration with the module's own `//!` header and resolves the combined
+// text in THIS scope (the crate root), where `IndexDefinition` /
+// `SearchDocument` are not in scope — so adding one turns every intra-doc link
+// in `search.rs`'s header into a `broken_intra_doc_links` error. The module's
+// own header is the documentation.
 #[cfg(feature = "db")]
 pub mod search;
 pub mod seo;

--- a/autumn/src/lib.rs
+++ b/autumn/src/lib.rs
@@ -125,6 +125,12 @@ pub mod hooks;
 pub mod i18n;
 pub mod idempotency;
 pub mod range;
+/// Engine-agnostic search vocabulary.
+///
+/// Index definitions and extracted documents, shared by `#[model]
+/// #[searchable]` and the optional `autumn-search` plugin.
+#[cfg(feature = "db")]
+pub mod search;
 pub mod seo;
 /// Translation lookup macro with compile-time key validation.
 ///

--- a/autumn/src/search.rs
+++ b/autumn/src/search.rs
@@ -59,6 +59,10 @@ use crate::repository::AutumnSearchableModel;
 /// `setweight` classes. `D` is the default for a bare `#[searchable]` field.
 pub const SEARCH_WEIGHTS: [char; 4] = ['A', 'B', 'C', 'D'];
 
+/// The conventional primary-key column, used when a model does not say
+/// otherwise. See [`IndexDefinition::key_column`].
+pub const DEFAULT_KEY_COLUMN: &str = "id";
+
 /// Relative multiplier for a weight class, used by backends that rank in Rust
 /// (and as the basis for the Postgres `ts_rank_cd` weight array).
 ///
@@ -167,10 +171,23 @@ pub struct IndexDefinition {
     /// the same posture `#[repository(tenant_scoped)]` takes, where a missing
     /// tenant is an error rather than an unscoped read.
     pub tenant_scoped: bool,
+    /// Primary-key column of the model's table, defaulting to `"id"`.
+    ///
+    /// A backend that reads the source table to rebuild documents — a backfill
+    /// or a reindex — needs the real key column: `#[id] pub article_id: i64`
+    /// is a perfectly ordinary model, and a hardcoded `id` would turn every
+    /// backfill on it into an undefined-column error at runtime. Set by
+    /// `#[model]` from the `#[id]` field, and validated as a bare identifier
+    /// by [`IndexDefinition::validate`] because it is interpolated into SQL.
+    pub key_column: &'static str,
 }
 
 impl IndexDefinition {
-    /// Construct a definition. Prefer [`SearchIndexed::index_definition`].
+    /// Construct a definition keyed on the conventional `id` column. Prefer
+    /// [`SearchIndexed::index_definition`].
+    ///
+    /// A model whose primary key is named otherwise adds
+    /// [`with_key_column`](Self::with_key_column).
     #[must_use]
     pub const fn new(
         name: &'static str,
@@ -185,7 +202,15 @@ impl IndexDefinition {
             fields: Cow::Borrowed(fields),
             embed_field,
             tenant_scoped,
+            key_column: DEFAULT_KEY_COLUMN,
         }
+    }
+
+    /// Point the definition at a primary-key column other than `id`.
+    #[must_use]
+    pub const fn with_key_column(mut self, key_column: &'static str) -> Self {
+        self.key_column = key_column;
+        self
     }
 
     /// Whether this index can answer vector / "find similar" queries.
@@ -231,9 +256,9 @@ impl IndexDefinition {
     /// # Errors
     ///
     /// Returns [`InvalidIndexDefinition`] when the index name, a field name,
-    /// or the language is not a bare identifier, when a weight is outside
-    /// [`SEARCH_WEIGHTS`], when there are no fields, or when `embed_field`
-    /// names a field that is not indexed.
+    /// the key column, or the language is not a bare identifier, when a weight
+    /// is outside [`SEARCH_WEIGHTS`], when there are no fields, or when
+    /// `embed_field` names a field that is not indexed.
     pub fn validate(&self) -> Result<(), InvalidIndexDefinition> {
         let invalid = |message: String| Err(InvalidIndexDefinition { message });
 
@@ -247,6 +272,12 @@ impl IndexDefinition {
             return invalid(format!(
                 "search language {:?} on index {:?} is not an identifier",
                 self.language, self.name
+            ));
+        }
+        if !is_valid_index_identifier(self.key_column) {
+            return invalid(format!(
+                "search key column {:?} on index {:?} is not an identifier",
+                self.key_column, self.name
             ));
         }
         if self.fields.is_empty() {

--- a/autumn/src/search.rs
+++ b/autumn/src/search.rs
@@ -1,0 +1,592 @@
+//! Engine-agnostic search vocabulary.
+//!
+//! Shared by `#[model] #[searchable]` and the optional `autumn-search` plugin.
+//!
+//! Issue #842 gave `#[model] #[searchable]` a Postgres `tsvector` column and
+//! `#[repository(searchable)]` a `search()` method — "search *this table*".
+//! Issue #1191 turns the same declaration into a **search subsystem**: the
+//! attribute now also produces an engine-agnostic [`IndexDefinition`] and a
+//! per-record [`SearchDocument`], which the optional `autumn-search` plugin
+//! feeds to a pluggable `SearchBackend` (Postgres + `pgvector` today; an
+//! external engine such as Meilisearch, Tantivy, or a vector store tomorrow).
+//!
+//! Only the *vocabulary* lives in core — the types the `#[model]` macro emits
+//! and every backend speaks. Backends, indexing jobs, the query client, and
+//! embedding live in the `autumn-search` crate, so an app that never installs
+//! the plugin pays nothing beyond these plain data types.
+//!
+//! ```rust,ignore
+//! #[autumn_web::model]
+//! #[searchable(language = "english")]
+//! pub struct Article {
+//!     #[id]
+//!     pub id: i64,
+//!     #[searchable(weight = "A")]
+//!     pub title: String,
+//!     #[searchable(weight = "B", embed)]   // ← also embedded for vector search
+//!     pub body: String,
+//! }
+//!
+//! let def = Article::index_definition();   // name, language, weighted fields
+//! let doc = article.search_document();     // id + extracted field values
+//! ```
+
+// autumn-panic-gate: request-path module — production code path must be panic-free.
+// See CONTRIBUTING.md "Request-path panic gate".
+#![cfg_attr(
+    not(test),
+    deny(
+        clippy::unwrap_used,
+        clippy::expect_used,
+        clippy::panic,
+        clippy::unreachable,
+        clippy::todo,
+        clippy::unimplemented,
+        clippy::indexing_slicing,
+    )
+)]
+
+use std::borrow::Cow;
+use std::fmt;
+
+use serde::Serialize;
+
+use crate::repository::AutumnSearchableModel;
+
+/// The `tsvector`-style relevance weights, most significant first.
+///
+/// Mirrors #842's `#[searchable(weight = "A"|"B"|"C"|"D")]` and Postgres'
+/// `setweight` classes. `D` is the default for a bare `#[searchable]` field.
+pub const SEARCH_WEIGHTS: [char; 4] = ['A', 'B', 'C', 'D'];
+
+/// Relative multiplier for a weight class, used by backends that rank in Rust
+/// (and as the basis for the Postgres `ts_rank_cd` weight array).
+///
+/// The values match the per-column bm25 weights the in-core `SQLite` FTS5 path
+/// already uses (`A → 10, B → 5, C → 2, else 1`), so ranking stays consistent
+/// across the in-core search and every plugin backend.
+#[must_use]
+pub const fn weight_factor(weight: char) -> f32 {
+    match weight {
+        'A' => 10.0,
+        'B' => 5.0,
+        'C' => 2.0,
+        _ => 1.0,
+    }
+}
+
+// ── Errors ──────────────────────────────────────────────────────────────────
+
+/// Rejection reason from [`IndexDefinition::validate`].
+///
+/// Index and field names are interpolated into backend queries (a Postgres
+/// `json_build_object(...)` projection, a Meilisearch attribute list, …), so
+/// they are validated as bare identifiers before they ever reach a backend —
+/// even though they originate from developer-written attributes rather than
+/// request input.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InvalidIndexDefinition {
+    /// Human-readable explanation.
+    pub message: String,
+}
+
+impl fmt::Display for InvalidIndexDefinition {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.message)
+    }
+}
+
+impl std::error::Error for InvalidIndexDefinition {}
+
+/// Returns `true` when `value` is a bare SQL/engine identifier: an ASCII
+/// letter or `_` followed by ASCII alphanumerics or `_`, at most 63 bytes
+/// (Postgres' `NAMEDATALEN - 1`).
+#[must_use]
+pub fn is_valid_index_identifier(value: &str) -> bool {
+    if value.is_empty() || value.len() > 63 {
+        return false;
+    }
+    let mut chars = value.chars();
+    let Some(first) = chars.next() else {
+        return false;
+    };
+    if !(first.is_ascii_alphabetic() || first == '_') {
+        return false;
+    }
+    chars.all(|c| c.is_ascii_alphanumeric() || c == '_')
+}
+
+// ── Index definition ────────────────────────────────────────────────────────
+
+/// One indexed field of a searchable model.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+pub struct SearchIndexField {
+    /// Column / attribute name as declared on the model.
+    pub name: &'static str,
+    /// Relevance class — one of [`SEARCH_WEIGHTS`].
+    pub weight: char,
+}
+
+impl SearchIndexField {
+    /// Construct a field descriptor.
+    #[must_use]
+    pub const fn new(name: &'static str, weight: char) -> Self {
+        Self { name, weight }
+    }
+
+    /// Ranking multiplier for this field's weight class.
+    #[must_use]
+    pub const fn factor(&self) -> f32 {
+        weight_factor(self.weight)
+    }
+}
+
+/// The engine-agnostic description of one model's search index.
+///
+/// Produced by [`SearchIndexed::index_definition`], which `#[model]` derives
+/// from the `#[searchable]` attributes — never written by hand.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[non_exhaustive]
+pub struct IndexDefinition {
+    /// Logical index name. Defaults to the model's table name, which is what
+    /// makes an index addressable by a string from a job payload or the CLI.
+    pub name: &'static str,
+    /// Text-search dictionary (`#[searchable(language = "…")]`, default
+    /// `"simple"`). Backends that have no dictionary concept ignore it.
+    pub language: &'static str,
+    /// Indexed fields in declaration order, with their weight classes.
+    pub fields: Cow<'static, [SearchIndexField]>,
+    /// Field whose value is embedded for vector search
+    /// (`#[searchable(embed)]`), if any.
+    pub embed_field: Option<&'static str>,
+}
+
+impl IndexDefinition {
+    /// Construct a definition. Prefer [`SearchIndexed::index_definition`].
+    #[must_use]
+    pub const fn new(
+        name: &'static str,
+        language: &'static str,
+        fields: &'static [SearchIndexField],
+        embed_field: Option<&'static str>,
+    ) -> Self {
+        Self {
+            name,
+            language,
+            fields: Cow::Borrowed(fields),
+            embed_field,
+        }
+    }
+
+    /// Whether this index can answer vector / "find similar" queries.
+    ///
+    /// True exactly when the model declares a `#[searchable(embed)]` field.
+    #[must_use]
+    pub const fn supports_vector_search(&self) -> bool {
+        self.embed_field.is_some()
+    }
+
+    /// Field names in declaration order.
+    pub fn field_names(&self) -> impl Iterator<Item = &'static str> + '_ {
+        self.fields.iter().map(|f| f.name)
+    }
+
+    /// Validate every identifier a backend may interpolate into a query, plus
+    /// the weight classes and the embed-field reference.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`InvalidIndexDefinition`] when the index name, a field name,
+    /// or the language is not a bare identifier, when a weight is outside
+    /// [`SEARCH_WEIGHTS`], when there are no fields, or when `embed_field`
+    /// names a field that is not indexed.
+    pub fn validate(&self) -> Result<(), InvalidIndexDefinition> {
+        let invalid = |message: String| Err(InvalidIndexDefinition { message });
+
+        if !is_valid_index_identifier(self.name) {
+            return invalid(format!(
+                "search index name {:?} is not an identifier",
+                self.name
+            ));
+        }
+        if !is_valid_index_identifier(self.language) {
+            return invalid(format!(
+                "search language {:?} on index {:?} is not an identifier",
+                self.language, self.name
+            ));
+        }
+        if self.fields.is_empty() {
+            return invalid(format!("search index {:?} declares no fields", self.name));
+        }
+        for field in self.fields.iter() {
+            if !is_valid_index_identifier(field.name) {
+                return invalid(format!(
+                    "search field {:?} on index {:?} is not an identifier",
+                    field.name, self.name
+                ));
+            }
+            if !SEARCH_WEIGHTS.contains(&field.weight) {
+                return invalid(format!(
+                    "search field {:?} on index {:?} has weight {:?}, expected one of A, B, C, D",
+                    field.name, self.name, field.weight
+                ));
+            }
+        }
+        if let Some(embed) = self.embed_field
+            && !self.fields.iter().any(|f| f.name == embed)
+        {
+            return invalid(format!(
+                "embed field {embed:?} on index {:?} is not one of its indexed fields",
+                self.name
+            ));
+        }
+        Ok(())
+    }
+}
+
+// ── Documents ───────────────────────────────────────────────────────────────
+
+/// One extracted field value of a [`SearchDocument`].
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct SearchFieldValue {
+    /// Column / attribute name.
+    pub name: &'static str,
+    /// Relevance class — one of [`SEARCH_WEIGHTS`].
+    pub weight: char,
+    /// The extracted text. A `None` column extracts as `""` rather than being
+    /// dropped, so a document's field list always matches its index
+    /// definition positionally.
+    pub value: String,
+}
+
+/// A single record, extracted into the shape every backend indexes.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[non_exhaustive]
+pub struct SearchDocument {
+    /// Index this document belongs to (the model's [`IndexDefinition::name`]).
+    pub index: &'static str,
+    /// Primary key of the source record.
+    pub id: i64,
+    /// Extracted field values, in index-definition order.
+    pub fields: Vec<SearchFieldValue>,
+    /// Text to embed for vector search, from the `#[searchable(embed)]` field.
+    pub embed_text: Option<String>,
+    /// Tenant the record belongs to, when the model is tenant-scoped. Backends
+    /// must persist and filter on this so a search never crosses tenants.
+    pub tenant_id: Option<String>,
+}
+
+impl SearchDocument {
+    /// Construct a document for `index` / `id` with no fields.
+    #[must_use]
+    pub const fn new(index: &'static str, id: i64) -> Self {
+        Self {
+            index,
+            id,
+            fields: Vec::new(),
+            embed_text: None,
+            tenant_id: None,
+        }
+    }
+
+    /// Append an extracted field value.
+    #[must_use]
+    pub fn with_field(
+        mut self,
+        name: &'static str,
+        weight: char,
+        value: impl Into<String>,
+    ) -> Self {
+        self.fields.push(SearchFieldValue {
+            name,
+            weight,
+            value: value.into(),
+        });
+        self
+    }
+
+    /// Set the text to embed for vector search.
+    #[must_use]
+    pub fn with_embed_text(mut self, text: impl Into<String>) -> Self {
+        self.embed_text = Some(text.into());
+        self
+    }
+
+    /// Set the owning tenant.
+    #[must_use]
+    pub fn with_tenant(mut self, tenant_id: impl Into<String>) -> Self {
+        self.tenant_id = Some(tenant_id.into());
+        self
+    }
+
+    /// All field values joined by a single space, in declaration order.
+    ///
+    /// This is the fallback document body for backends with no per-field
+    /// weighting; weighted backends read [`SearchDocument::fields`] directly.
+    /// Empty values are skipped so the result never contains a double space.
+    #[must_use]
+    pub fn text(&self) -> String {
+        let mut out = String::new();
+        for field in &self.fields {
+            if field.value.is_empty() {
+                continue;
+            }
+            if !out.is_empty() {
+                out.push(' ');
+            }
+            out.push_str(&field.value);
+        }
+        out
+    }
+
+    /// The value of the named field, if the document carries it.
+    #[must_use]
+    pub fn field(&self, name: &str) -> Option<&str> {
+        self.fields
+            .iter()
+            .find(|f| f.name == name)
+            .map(|f| f.value.as_str())
+    }
+}
+
+// ── Text extraction seam ────────────────────────────────────────────────────
+
+/// Converts a model field into the text a search backend indexes.
+///
+/// `#[model]` calls this for every `#[searchable]` field, so the supported
+/// column types are exactly the impls below. A `#[searchable]` field whose
+/// type is not covered is a compile error naming this trait — implement it for
+/// the newtype (or index a derived `String` field instead).
+///
+/// `Option<T>` extracts to `""` when `None`: an absent value must still occupy
+/// its position in the document (see [`SearchDocument::fields`]).
+pub trait SearchTextValue {
+    /// Extract the indexable text for this value.
+    fn search_text_value(&self) -> String;
+}
+
+impl SearchTextValue for String {
+    fn search_text_value(&self) -> String {
+        self.clone()
+    }
+}
+
+impl SearchTextValue for str {
+    fn search_text_value(&self) -> String {
+        self.to_owned()
+    }
+}
+
+impl<T: SearchTextValue + ?Sized> SearchTextValue for &T {
+    fn search_text_value(&self) -> String {
+        (**self).search_text_value()
+    }
+}
+
+impl<T: SearchTextValue> SearchTextValue for Option<T> {
+    fn search_text_value(&self) -> String {
+        self.as_ref().map(T::search_text_value).unwrap_or_default()
+    }
+}
+
+macro_rules! impl_search_text_value_via_display {
+    ($($ty:ty),+ $(,)?) => {
+        $(impl SearchTextValue for $ty {
+            fn search_text_value(&self) -> String {
+                ::std::string::ToString::to_string(self)
+            }
+        })+
+    };
+}
+
+impl_search_text_value_via_display!(
+    bool,
+    i8,
+    i16,
+    i32,
+    i64,
+    i128,
+    isize,
+    u8,
+    u16,
+    u32,
+    u64,
+    u128,
+    usize,
+    f32,
+    f64,
+    char,
+    chrono::NaiveDate,
+    chrono::NaiveTime,
+    chrono::NaiveDateTime,
+    uuid::Uuid,
+);
+
+impl<Tz: chrono::TimeZone> SearchTextValue for chrono::DateTime<Tz>
+where
+    Tz::Offset: fmt::Display,
+{
+    fn search_text_value(&self) -> String {
+        self.to_rfc3339()
+    }
+}
+
+// ── The derived trait ───────────────────────────────────────────────────────
+
+/// A model that `#[model] #[searchable]` has given a search index.
+///
+/// Implemented by the `#[model]` macro for every model that carries a
+/// model-level `#[searchable]` attribute **and** an `i64` primary key. Never
+/// implemented by hand — the attribute is the source of truth, which is what
+/// makes "mark a model searchable" require zero glue.
+///
+/// `autumn-search` is the consumer: it registers an index per `SearchIndexed`
+/// model, keeps it in sync from the record lifecycle, and queries it through
+/// its `SearchBackend` trait.
+pub trait SearchIndexed: AutumnSearchableModel + Send + Sync + 'static {
+    /// Logical index name (the model's table name).
+    const SEARCH_INDEX: &'static str;
+
+    /// The `#[searchable(embed)]` field, if the model declares one.
+    const SEARCH_EMBED_FIELD: Option<&'static str>;
+
+    /// This model's engine-agnostic index definition.
+    fn index_definition() -> IndexDefinition;
+
+    /// Primary key of this record.
+    fn search_id(&self) -> i64;
+
+    /// Extract this record into the document a backend indexes.
+    fn search_document(&self) -> SearchDocument;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const FIELDS: &[SearchIndexField] = &[
+        SearchIndexField::new("title", 'A'),
+        SearchIndexField::new("body", 'B'),
+    ];
+
+    fn def() -> IndexDefinition {
+        IndexDefinition::new("articles", "english", FIELDS, Some("body"))
+    }
+
+    #[test]
+    fn weight_factors_match_the_in_core_fts_ranking() {
+        assert!((weight_factor('A') - 10.0).abs() < f32::EPSILON);
+        assert!((weight_factor('B') - 5.0).abs() < f32::EPSILON);
+        assert!((weight_factor('C') - 2.0).abs() < f32::EPSILON);
+        assert!((weight_factor('D') - 1.0).abs() < f32::EPSILON);
+        assert!((weight_factor('Z') - 1.0).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn identifier_validation_rejects_injection_shapes() {
+        assert!(is_valid_index_identifier("articles"));
+        assert!(is_valid_index_identifier("_a1"));
+        assert!(!is_valid_index_identifier(""));
+        assert!(!is_valid_index_identifier("1articles"));
+        assert!(!is_valid_index_identifier("arti cles"));
+        assert!(!is_valid_index_identifier(
+            "articles\"; DROP TABLE users; --"
+        ));
+        assert!(!is_valid_index_identifier("naïve"));
+        assert!(!is_valid_index_identifier(&"a".repeat(64)));
+        assert!(is_valid_index_identifier(&"a".repeat(63)));
+    }
+
+    #[test]
+    fn valid_definition_passes() {
+        assert!(def().validate().is_ok());
+    }
+
+    #[test]
+    fn definition_rejects_a_non_identifier_name() {
+        let mut d = def();
+        d.name = "arti cles";
+        assert!(d.validate().is_err());
+    }
+
+    #[test]
+    fn definition_rejects_a_non_identifier_language() {
+        let mut d = def();
+        d.language = "english'; --";
+        assert!(d.validate().is_err());
+    }
+
+    #[test]
+    fn definition_rejects_an_empty_field_list() {
+        let mut d = def();
+        d.fields = Cow::Borrowed(&[]);
+        assert!(d.validate().is_err());
+    }
+
+    #[test]
+    fn definition_rejects_a_bad_weight() {
+        let mut d = def();
+        d.fields = Cow::Owned(vec![SearchIndexField::new("title", 'Z')]);
+        d.embed_field = None;
+        assert!(d.validate().is_err());
+    }
+
+    #[test]
+    fn definition_rejects_an_embed_field_that_is_not_indexed() {
+        let mut d = def();
+        d.embed_field = Some("nope");
+        assert!(d.validate().is_err());
+    }
+
+    #[test]
+    fn supports_vector_search_tracks_the_embed_field() {
+        assert!(def().supports_vector_search());
+        let mut d = def();
+        d.embed_field = None;
+        assert!(!d.supports_vector_search());
+    }
+
+    #[test]
+    fn document_text_skips_empty_values() {
+        let doc = SearchDocument::new("articles", 1)
+            .with_field("title", 'A', "Hello")
+            .with_field("summary", 'C', "")
+            .with_field("body", 'B', "World");
+        assert_eq!(doc.text(), "Hello World");
+    }
+
+    #[test]
+    fn document_field_lookup() {
+        let doc = SearchDocument::new("articles", 1).with_field("title", 'A', "Hello");
+        assert_eq!(doc.field("title"), Some("Hello"));
+        assert_eq!(doc.field("missing"), None);
+    }
+
+    #[test]
+    fn a_document_serializes_to_the_shape_an_external_engine_receives() {
+        // `Serialize` only, deliberately: the index and field names are
+        // `&'static str` derived from the model's own attributes, so there is
+        // nothing meaningful to deserialize them back into. The type that
+        // crosses a process boundary is `ReindexArgs` (owned `String` index),
+        // not this.
+        let doc = SearchDocument::new("articles", 9)
+            .with_field("title", 'A', "Hi")
+            .with_embed_text("Hi")
+            .with_tenant("acme");
+        let json = serde_json::to_value(&doc).expect("serialize");
+
+        assert_eq!(json["index"], serde_json::json!("articles"));
+        assert_eq!(json["id"], serde_json::json!(9));
+        assert_eq!(json["tenant_id"], serde_json::json!("acme"));
+        assert_eq!(json["embed_text"], serde_json::json!("Hi"));
+        assert_eq!(json["fields"][0]["name"], serde_json::json!("title"));
+        assert_eq!(json["fields"][0]["weight"], serde_json::json!("A"));
+        assert_eq!(json["fields"][0]["value"], serde_json::json!("Hi"));
+    }
+
+    #[test]
+    fn optional_text_extracts_to_empty_string() {
+        assert_eq!(None::<String>.search_text_value(), "");
+        assert_eq!(Some("x".to_owned()).search_text_value(), "x");
+    }
+}

--- a/autumn/src/search.rs
+++ b/autumn/src/search.rs
@@ -171,6 +171,20 @@ pub struct IndexDefinition {
     /// the same posture `#[repository(tenant_scoped)]` takes, where a missing
     /// tenant is an error rather than an unscoped read.
     pub tenant_scoped: bool,
+    /// Whether the model's **repository** opts into `soft_delete`.
+    ///
+    /// Not "does the table have a `deleted_at` column" — the two are different
+    /// questions, and the framework supports a model that carries `deleted_at`
+    /// purely as audit history while its finders return those rows. A source
+    /// that inferred soft-delete semantics from column presence alone would
+    /// hide every such row from reindex and drop it from a purging backfill,
+    /// disagreeing with the very finders the index is supposed to mirror.
+    ///
+    /// Filled by `#[model]` from
+    /// `AutumnPreloadScopeExt::__autumn_repo_soft_delete_scope`, the same seam
+    /// `preload`'s in-memory retain uses, which `#[repository(soft_delete)]`
+    /// overrides inherently on the model.
+    pub soft_delete: bool,
     /// Primary-key column of the model's table, defaulting to `"id"`.
     ///
     /// A backend that reads the source table to rebuild documents — a backfill
@@ -202,6 +216,7 @@ impl IndexDefinition {
             fields: Cow::Borrowed(fields),
             embed_field,
             tenant_scoped,
+            soft_delete: false,
             key_column: DEFAULT_KEY_COLUMN,
         }
     }
@@ -210,6 +225,15 @@ impl IndexDefinition {
     #[must_use]
     pub const fn with_key_column(mut self, key_column: &'static str) -> Self {
         self.key_column = key_column;
+        self
+    }
+
+    /// Declare that the model's repository is `soft_delete`, so a source
+    /// excludes `deleted_at IS NOT NULL` rows. See
+    /// [`soft_delete`](Self::soft_delete).
+    #[must_use]
+    pub const fn with_soft_delete(mut self, soft_delete: bool) -> Self {
+        self.soft_delete = soft_delete;
         self
     }
 

--- a/autumn/src/search.rs
+++ b/autumn/src/search.rs
@@ -85,6 +85,7 @@ pub const fn weight_factor(weight: char) -> f32 {
 /// even though they originate from developer-written attributes rather than
 /// request input.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub struct InvalidIndexDefinition {
     /// Human-readable explanation.
     pub message: String,
@@ -159,6 +160,13 @@ pub struct IndexDefinition {
     /// Field whose value is embedded for vector search
     /// (`#[searchable(embed)]`), if any.
     pub embed_field: Option<&'static str>,
+    /// Whether the model carries a `tenant_id` column.
+    ///
+    /// Set by `#[model]` from the struct's own fields. A consumer **must**
+    /// fail closed on a tenant-scoped index queried with no tenant context —
+    /// the same posture `#[repository(tenant_scoped)]` takes, where a missing
+    /// tenant is an error rather than an unscoped read.
+    pub tenant_scoped: bool,
 }
 
 impl IndexDefinition {
@@ -169,12 +177,14 @@ impl IndexDefinition {
         language: &'static str,
         fields: &'static [SearchIndexField],
         embed_field: Option<&'static str>,
+        tenant_scoped: bool,
     ) -> Self {
         Self {
             name,
             language,
             fields: Cow::Borrowed(fields),
             embed_field,
+            tenant_scoped,
         }
     }
 
@@ -189,6 +199,30 @@ impl IndexDefinition {
     /// Field names in declaration order.
     pub fn field_names(&self) -> impl Iterator<Item = &'static str> + '_ {
         self.fields.iter().map(|f| f.name)
+    }
+
+    /// Whether `field` is one of this index's declared fields.
+    ///
+    /// The allowlist every backend must consult before interpolating a field
+    /// name into a query: a `SearchFilter` predicate keyed on anything else is
+    /// caller-supplied text and must never reach SQL.
+    #[must_use]
+    pub fn has_field(&self, field: &str) -> bool {
+        self.fields.iter().any(|f| f.name == field)
+    }
+
+    /// The declared weight class for `field`, if it is indexed.
+    ///
+    /// Backends rank with **this** weight rather than the one on an incoming
+    /// document, so a hand-built or third-party
+    /// [`SearchDocument`](crate::search::SearchDocument) cannot smuggle an
+    /// out-of-range weight into a query.
+    #[must_use]
+    pub fn weight_of(&self, field: &str) -> Option<char> {
+        self.fields
+            .iter()
+            .find(|f| f.name == field)
+            .map(|f| f.weight)
     }
 
     /// Validate every identifier a backend may interpolate into a query, plus
@@ -248,6 +282,7 @@ impl IndexDefinition {
 
 /// One extracted field value of a [`SearchDocument`].
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[non_exhaustive]
 pub struct SearchFieldValue {
     /// Column / attribute name.
     pub name: &'static str,
@@ -470,7 +505,7 @@ mod tests {
     ];
 
     fn def() -> IndexDefinition {
-        IndexDefinition::new("articles", "english", FIELDS, Some("body"))
+        IndexDefinition::new("articles", "english", FIELDS, Some("body"), false)
     }
 
     #[test]
@@ -536,6 +571,29 @@ mod tests {
         let mut d = def();
         d.embed_field = Some("nope");
         assert!(d.validate().is_err());
+    }
+
+    #[test]
+    fn has_field_is_the_allowlist_backends_consult() {
+        let d = def();
+        assert!(d.has_field("title"));
+        assert!(d.has_field("body"));
+        assert!(!d.has_field("tenant_id"), "not a declared searchable field");
+        assert!(!d.has_field("title' = 'x' OR '1'='1"));
+    }
+
+    #[test]
+    fn weight_of_returns_the_declared_weight_not_a_documents_claim() {
+        let d = def();
+        assert_eq!(d.weight_of("title"), Some('A'));
+        assert_eq!(d.weight_of("body"), Some('B'));
+        assert_eq!(d.weight_of("missing"), None);
+    }
+
+    #[test]
+    fn tenant_scoped_is_carried_so_consumers_can_fail_closed() {
+        assert!(!def().tenant_scoped);
+        assert!(IndexDefinition::new("articles", "english", FIELDS, None, true).tenant_scoped);
     }
 
     #[test]

--- a/autumn/src/search.rs
+++ b/autumn/src/search.rs
@@ -215,7 +215,7 @@ impl IndexDefinition {
     ///
     /// Backends rank with **this** weight rather than the one on an incoming
     /// document, so a hand-built or third-party
-    /// [`SearchDocument`](crate::search::SearchDocument) cannot smuggle an
+    /// [`SearchDocument`] cannot smuggle an
     /// out-of-range weight into a query.
     #[must_use]
     pub fn weight_of(&self, field: &str) -> Option<char> {

--- a/autumn/tests/integration/mod.rs
+++ b/autumn/tests/integration/mod.rs
@@ -191,6 +191,8 @@ mod routes_macro;
 mod scheduled_coordination;
 mod schema_drift_guard;
 mod scoped_tokens;
+#[cfg(feature = "db")]
+mod search_index_definition;
 mod security;
 mod seo;
 mod server_timing;

--- a/autumn/tests/integration/search_index_definition.rs
+++ b/autumn/tests/integration/search_index_definition.rs
@@ -46,6 +46,53 @@ diesel::table! {
     }
 }
 
+diesel::table! {
+    search_def_denorm (id) {
+        id -> Int8,
+        body -> Text,
+        tenant_id -> Text,
+    }
+}
+
+/// A searchable model whose `tenant_id` is **denormalized data**, not a scope:
+/// the repository does not opt into `tenant_scoped`, so its finders return
+/// rows across tenants — and the index must not be more restrictive than the
+/// finders it mirrors.
+#[autumn_web::model(table = "search_def_denorm")]
+#[searchable]
+pub struct DenormDoc {
+    #[id]
+    pub id: i64,
+    #[searchable]
+    pub body: String,
+    pub tenant_id: String,
+}
+
+#[autumn_web::repository(DenormDoc, table = "search_def_denorm")]
+pub trait DenormDocRepository {}
+
+diesel::table! {
+    search_def_scoped (id) {
+        id -> Int8,
+        body -> Text,
+        tenant_id -> Text,
+    }
+}
+
+/// The same shape with a genuinely tenant-scoped repository.
+#[autumn_web::model(table = "search_def_scoped")]
+#[searchable]
+pub struct ScopedDoc {
+    #[id]
+    pub id: i64,
+    #[searchable]
+    pub body: String,
+    pub tenant_id: String,
+}
+
+#[autumn_web::repository(ScopedDoc, table = "search_def_scoped", tenant_scoped)]
+pub trait ScopedDocRepository {}
+
 /// A `#[searchable]` model with **no** `embed` field: vector search is opt-in,
 /// keyword search still works.
 #[autumn_web::model(table = "search_def_notes")]
@@ -221,6 +268,37 @@ fn index_definition_carries_the_repositorys_soft_delete_semantics() {
     );
     // A model with no `deleted_at` at all is trivially not soft-deleting.
     assert!(!Article::index_definition().soft_delete);
+}
+
+#[test]
+fn index_definition_carries_the_repositorys_tenant_scoping() {
+    // Same rule as soft-delete, and for the same reason: a `tenant_id` COLUMN
+    // is not the question, the repository's opt-in is. A denormalized or audit
+    // `tenant_id` on an unscoped repository has unscoped finders, so marking
+    // its index tenant-scoped would make every search outside a tenant context
+    // fail with `TenantContextMissing` and every search inside one silently
+    // filter — neither of which matches what the app's own reads do.
+    assert!(
+        !DenormDoc::index_definition().tenant_scoped,
+        "a `tenant_id` column without `#[repository(tenant_scoped)]` is not a scope"
+    );
+    assert!(
+        ScopedDoc::index_definition().tenant_scoped,
+        "`#[repository(tenant_scoped)]` must reach the index definition"
+    );
+    // A model with no `tenant_id` at all is trivially unscoped.
+    assert!(!Note::index_definition().tenant_scoped);
+
+    // The tenant is still carried into the document either way — it is what a
+    // caller-supplied filter matches on, and dropping it would make an
+    // explicit tenant filter silently match nothing.
+    let doc = DenormDoc {
+        id: 1,
+        body: "x".to_owned(),
+        tenant_id: "acme".to_owned(),
+    }
+    .search_document();
+    assert_eq!(doc.tenant_id.as_deref(), Some("acme"));
 }
 
 #[test]

--- a/autumn/tests/integration/search_index_definition.rs
+++ b/autumn/tests/integration/search_index_definition.rs
@@ -1,0 +1,195 @@
+//! `#[searchable]` → engine-agnostic index definition (issue #1191).
+//!
+//! Issue #842 gave `#[model] #[searchable]` a Postgres `tsvector` column and a
+//! `#[repository(searchable)]` `search()` method. #1191 needs the *same*
+//! declaration to also produce an engine-agnostic **index definition** and a
+//! per-record **document**, so a pluggable `SearchBackend` (Postgres+pgvector
+//! today, Meilisearch/Tantivy/a vector store tomorrow) can index a model with
+//! no hand-written glue.
+//!
+//! These tests pin that contract: the attribute is the single source of truth
+//! for the index name, the language dictionary, the weighted field list, and
+//! the optional embedded field.
+
+#![allow(clippy::must_use_candidate, clippy::missing_const_for_fn)]
+
+use autumn_web::search::{SearchIndexed, SearchTextValue};
+
+diesel::table! {
+    search_def_articles (id) {
+        id -> Int8,
+        title -> Text,
+        body -> Text,
+        summary -> Nullable<Text>,
+        views -> Int4,
+    }
+}
+
+#[autumn_web::model(table = "search_def_articles")]
+#[searchable(language = "english")]
+pub struct Article {
+    #[id]
+    pub id: i64,
+    #[searchable(weight = "A")]
+    pub title: String,
+    #[searchable(weight = "B", embed)]
+    pub body: String,
+    #[searchable(weight = "C")]
+    pub summary: Option<String>,
+    pub views: i32,
+}
+
+diesel::table! {
+    search_def_notes (id) {
+        id -> Int8,
+        memo -> Text,
+    }
+}
+
+/// A `#[searchable]` model with **no** `embed` field: vector search is opt-in,
+/// keyword search still works.
+#[autumn_web::model(table = "search_def_notes")]
+#[searchable]
+pub struct Note {
+    #[id]
+    pub id: i64,
+    #[searchable]
+    pub memo: String,
+}
+
+fn article() -> Article {
+    Article {
+        id: 7,
+        title: "Rust web frameworks".to_owned(),
+        body: "Autumn is a batteries-included Rust web framework.".to_owned(),
+        summary: Some("A short summary".to_owned()),
+        views: 3,
+    }
+}
+
+// ── Index definition ────────────────────────────────────────────────────────
+
+#[test]
+fn index_definition_is_derived_from_the_searchable_attribute() {
+    let def = Article::index_definition();
+
+    assert_eq!(def.name, "search_def_articles");
+    assert_eq!(def.language, "english");
+    assert_eq!(def.embed_field, Some("body"));
+    assert_eq!(
+        def.fields
+            .iter()
+            .map(|f| (f.name, f.weight))
+            .collect::<Vec<_>>(),
+        vec![("title", 'A'), ("body", 'B'), ("summary", 'C')],
+    );
+}
+
+#[test]
+fn index_definition_without_embed_field_disables_vector_search() {
+    let def = Note::index_definition();
+
+    assert_eq!(def.name, "search_def_notes");
+    // The model-level `#[searchable]` with no `language` keeps the #842 default.
+    assert_eq!(def.language, "simple");
+    assert_eq!(def.embed_field, None);
+    assert!(!def.supports_vector_search());
+    assert_eq!(
+        def.fields
+            .iter()
+            .map(|f| (f.name, f.weight))
+            .collect::<Vec<_>>(),
+        // A bare `#[searchable]` field keeps #842's lowest weight.
+        vec![("memo", 'D')],
+    );
+}
+
+#[test]
+fn index_definition_validates_its_own_identifiers() {
+    // Every identifier the backend interpolates into SQL comes from here, so
+    // the definition validates itself rather than trusting the caller.
+    assert!(Article::index_definition().validate().is_ok());
+
+    let mut bad = Article::index_definition();
+    bad.name = "articles\"; DROP TABLE users; --";
+    assert!(bad.validate().is_err());
+}
+
+// ── Document extraction ─────────────────────────────────────────────────────
+
+#[test]
+fn search_document_carries_every_declared_field_with_its_weight() {
+    let doc = article().search_document();
+
+    assert_eq!(doc.index, "search_def_articles");
+    assert_eq!(doc.id, 7);
+    assert_eq!(
+        doc.fields
+            .iter()
+            .map(|f| (f.name, f.weight, f.value.as_str()))
+            .collect::<Vec<_>>(),
+        vec![
+            ("title", 'A', "Rust web frameworks"),
+            (
+                "body",
+                'B',
+                "Autumn is a batteries-included Rust web framework."
+            ),
+            ("summary", 'C', "A short summary"),
+        ],
+    );
+}
+
+#[test]
+fn search_document_exposes_the_embed_text_for_vector_indexing() {
+    let doc = article().search_document();
+
+    assert_eq!(
+        doc.embed_text.as_deref(),
+        Some("Autumn is a batteries-included Rust web framework."),
+    );
+
+    let note = Note {
+        id: 1,
+        memo: "nothing to embed".to_owned(),
+    };
+    assert_eq!(note.search_document().embed_text, None);
+}
+
+#[test]
+fn a_none_optional_field_is_indexed_as_empty_not_dropped() {
+    // Dropping the field would silently shift weights for backends that index
+    // positionally; an absent value must index as an empty string instead.
+    let mut record = article();
+    record.summary = None;
+
+    let doc = record.search_document();
+    let summary = doc
+        .fields
+        .iter()
+        .find(|f| f.name == "summary")
+        .expect("summary field must still be present");
+    assert_eq!(summary.value, "");
+}
+
+#[test]
+fn document_text_concatenates_fields_in_weight_order() {
+    let text = article().search_document().text();
+
+    assert_eq!(
+        text,
+        "Rust web frameworks Autumn is a batteries-included Rust web framework. A short summary",
+    );
+}
+
+// ── The text-extraction seam ────────────────────────────────────────────────
+
+#[test]
+fn search_text_value_covers_the_common_column_types() {
+    assert_eq!("hello".to_owned().search_text_value(), "hello");
+    assert_eq!("hello".search_text_value(), "hello");
+    assert_eq!(Some("hi".to_owned()).search_text_value(), "hi");
+    assert_eq!(None::<String>.search_text_value(), "");
+    assert_eq!(42_i64.search_text_value(), "42");
+    assert_eq!(true.search_text_value(), "true");
+}

--- a/autumn/tests/integration/search_index_definition.rs
+++ b/autumn/tests/integration/search_index_definition.rs
@@ -58,6 +58,55 @@ pub struct Note {
 }
 
 diesel::table! {
+    search_def_audited (id) {
+        id -> Int8,
+        body -> Text,
+        deleted_at -> Nullable<Timestamp>,
+    }
+}
+
+diesel::table! {
+    search_def_archived (id) {
+        id -> Int8,
+        body -> Text,
+        deleted_at -> Nullable<Timestamp>,
+    }
+}
+
+/// A searchable model whose `deleted_at` is **audit history**, not a
+/// tombstone: the repository does not opt into `soft_delete`, so its finders
+/// return those rows — and so must the search index.
+#[autumn_web::model(table = "search_def_audited")]
+#[searchable]
+pub struct AuditedDoc {
+    #[id]
+    pub id: i64,
+    #[searchable]
+    pub body: String,
+    #[default]
+    pub deleted_at: Option<chrono::NaiveDateTime>,
+}
+
+#[autumn_web::repository(AuditedDoc, table = "search_def_audited")]
+pub trait AuditedDocRepository {}
+
+/// The same shape, but genuinely soft-deleted. Its finders hide the rows, so
+/// the index must too.
+#[autumn_web::model(table = "search_def_archived")]
+#[searchable]
+pub struct ArchivedDoc {
+    #[id]
+    pub id: i64,
+    #[searchable]
+    pub body: String,
+    #[default]
+    pub deleted_at: Option<chrono::NaiveDateTime>,
+}
+
+#[autumn_web::repository(ArchivedDoc, table = "search_def_archived", soft_delete)]
+pub trait ArchivedDocRepository {}
+
+diesel::table! {
     search_def_memos (memo_id) {
         memo_id -> Int8,
         // A leftover column that is not the key (see `Memo`).
@@ -153,6 +202,25 @@ fn index_definition_carries_the_models_real_key_column() {
         "the document keys off `#[id]`, not `id`"
     );
     assert_eq!(memo.search_document().id, 9);
+}
+
+#[test]
+fn index_definition_carries_the_repositorys_soft_delete_semantics() {
+    // A `deleted_at` COLUMN is not the question — the repository's opt-in is.
+    // The framework explicitly supports `deleted_at` as audit history, and
+    // those rows are still returned by finders. A source that inferred a
+    // tombstone from the column would hide them from reindex and drop them
+    // from a purging backfill, so the index would disagree with the app.
+    assert!(
+        !AuditedDoc::index_definition().soft_delete,
+        "an audit `deleted_at` without `#[repository(soft_delete)]` is not a tombstone"
+    );
+    assert!(
+        ArchivedDoc::index_definition().soft_delete,
+        "`#[repository(soft_delete)]` must reach the index definition"
+    );
+    // A model with no `deleted_at` at all is trivially not soft-deleting.
+    assert!(!Article::index_definition().soft_delete);
 }
 
 #[test]

--- a/autumn/tests/integration/search_index_definition.rs
+++ b/autumn/tests/integration/search_index_definition.rs
@@ -57,6 +57,35 @@ pub struct Note {
     pub memo: String,
 }
 
+diesel::table! {
+    search_def_memos (memo_id) {
+        memo_id -> Int8,
+        // A leftover column that is not the key (see `Memo`).
+        id -> Int8,
+        memo -> Text,
+    }
+}
+
+/// A `#[searchable]` model whose primary key is **not** named `id`.
+///
+/// Nothing about `#[searchable]` requires the conventional name, so the index
+/// definition has to carry the real one: a backend that rebuilds documents by
+/// reading the source table selects, filters, and paginates on that column,
+/// and against a table that still has an unrelated `id` column that reads the
+/// wrong values with no error at all.
+#[autumn_web::model(table = "search_def_memos")]
+#[searchable]
+// `memo_id` is the point of the fixture — the column name has to stay.
+#[allow(clippy::struct_field_names)]
+pub struct Memo {
+    #[id]
+    pub memo_id: i64,
+    /// The leftover column. Ordinary data, not a key.
+    pub id: i64,
+    #[searchable]
+    pub memo: String,
+}
+
 fn article() -> Article {
     Article {
         id: 7,
@@ -105,6 +134,28 @@ fn index_definition_without_embed_field_disables_vector_search() {
 }
 
 #[test]
+fn index_definition_carries_the_models_real_key_column() {
+    // The conventional case still reads `id`, so nothing that assumed it
+    // changes behaviour…
+    assert_eq!(Article::index_definition().key_column, "id");
+    assert_eq!(Note::index_definition().key_column, "id");
+    // …and a model keyed elsewhere says so, rather than leaving a backend to
+    // guess wrong at runtime.
+    assert_eq!(Memo::index_definition().key_column, "memo_id");
+    let memo = Memo {
+        memo_id: 9,
+        id: 109,
+        memo: "x".to_owned(),
+    };
+    assert_eq!(
+        memo.search_id(),
+        9,
+        "the document keys off `#[id]`, not `id`"
+    );
+    assert_eq!(memo.search_document().id, 9);
+}
+
+#[test]
 fn index_definition_validates_its_own_identifiers() {
     // Every identifier the backend interpolates into SQL comes from here, so
     // the definition validates itself rather than trusting the caller.
@@ -112,6 +163,11 @@ fn index_definition_validates_its_own_identifiers() {
 
     let mut bad = Article::index_definition();
     bad.name = "articles\"; DROP TABLE users; --";
+    assert!(bad.validate().is_err());
+
+    // The key column is interpolated into the source query too, so it is held
+    // to the same standard as the index and field names.
+    let bad = Article::index_definition().with_key_column("id\"; DROP TABLE users; --");
     assert!(bad.validate().is_err());
 }
 

--- a/docs/guide/full-text-search.md
+++ b/docs/guide/full-text-search.md
@@ -2,6 +2,14 @@
 
 Autumn provides first-class, high-performance Full-Text Search (FTS) on **both** the Postgres and SQLite backends. Through declarative model-level annotations and automated CLI migration generators, Autumn configures a backend-appropriate search index — stored `tsvector` generated columns behind high-throughput `GIN` indexes on Postgres, external-content **FTS5** virtual tables on SQLite — and exposes the same typed, paginated, and relevance-ranked search interfaces directly on your repositories, so the same `#[searchable]` models and repository call sites work unchanged on either backend. Most of this guide illustrates the Postgres (`tsvector`/`tsquery`/`GIN`) path; the [SQLite FTS5](#6-sqlite-fts5) section below covers the SQLite equivalent.
 
+> **Looking for a search *subsystem*?** This guide covers the in-core FTS
+> primitives: "search this table." If you want an index that stays in sync with
+> the record lifecycle automatically, semantic / vector ("find similar")
+> retrieval, a pluggable engine, or a backfill command, see
+> [Search: keyword and vector](./search.md) (`autumn-search`). It subsumes
+> everything here as one backend rather than replacing it — the same
+> `#[searchable]` attribute drives both.
+
 ---
 
 ## FTS vs. External Search Engines

--- a/docs/guide/search.md
+++ b/docs/guide/search.md
@@ -1,0 +1,378 @@
+# Search: keyword and vector (`autumn-search`)
+
+Autumn ships full-text search *primitives* in core: the `#[searchable]` model
+attribute, a Postgres `tsvector` column, and a `#[repository(searchable)]`
+`search()` method. That covers "search this table."
+
+`autumn-search` is the **subsystem** on top: declare a model searchable, get an
+index that stays in sync as records change, and query it — by keyword or by
+semantic similarity — through one engine-agnostic API. It is an optional plugin
+crate; an app that never installs it pays nothing.
+
+- **Crate:** `autumn-search`
+- **Issue:** [#1191](https://github.com/autumn-foundation/autumn/issues/1191)
+- **Builds on:** [#842](https://github.com/autumn-foundation/autumn/issues/842)
+  (in-core FTS), which it subsumes as one backend rather than replacing.
+
+---
+
+## 1. Mark a model searchable
+
+```rust
+#[autumn_web::model]
+#[searchable(language = "english")]
+pub struct Article {
+    #[id]
+    pub id: i64,
+
+    #[searchable(weight = "A")]
+    pub title: String,
+
+    // `embed` nominates the field whose text is embedded for vector search.
+    #[searchable(weight = "B", embed)]
+    pub body: String,
+
+    pub tenant_id: Option<String>,
+}
+```
+
+`#[searchable]` is the single source of truth. From it, `#[model]` derives an
+`IndexDefinition` (index name, language dictionary, weighted field list, embed
+field) and a per-record `SearchDocument`. You never write either by hand.
+
+| Attribute | Meaning |
+|---|---|
+| `#[searchable]` on the struct | the model has a search index; language defaults to `simple` |
+| `#[searchable(language = "english")]` | text-search dictionary |
+| `#[searchable]` on a field | index it at the lowest weight (`D`) |
+| `#[searchable(weight = "A")]` | index it at weight `A` (A > B > C > D) |
+| `#[searchable(embed)]` | **also** embed this field for vector search |
+
+Rules the macro enforces at compile time:
+
+- at most **one** `embed` field — a record has one embedding, so two is
+  ambiguous rather than last-wins;
+- `embed` requires the model-level `#[searchable]`;
+- `#[encrypted]` and `#[searchable]` remain mutually exclusive (#805).
+
+A `#[searchable]` model whose primary key is not `i64` keeps its #842 behaviour
+and simply has no plugin index — search indexes key on `i64`.
+
+A `tenant_id` column is picked up automatically and carried into every
+document, so tenant isolation does not depend on remembering to configure it.
+
+---
+
+## 2. Keep the index in sync
+
+```rust
+use autumn_search::SearchSyncHooks;
+
+#[autumn_web::repository(
+    Article,
+    hooks = SearchSyncHooks<Article, NewArticle, UpdateArticle>,
+    commit_hooks = true,
+)]
+pub trait ArticleRepository {}
+```
+
+Create, update, and delete now enqueue a durable reindex job. `commit_hooks =
+true` writes the intent to Autumn's commit-hook queue **inside the same
+transaction as the mutation**, so a rolled-back transaction never leaves a
+phantom document and a process dying between commit and enqueue is recovered by
+the queue rather than lost.
+
+If the repository already has hooks, compose instead of replacing — call
+`autumn_search::enqueue_reindex_for(&record)` (or `enqueue_unindex_for`) from
+your own `after_*_commit`.
+
+### Why the job payload is `(index, id)` and not the record
+
+A reindex instruction carries the index name and the primary key. The handler
+**re-reads the row**:
+
+- row present ⇒ upsert the document;
+- row absent ⇒ delete the document.
+
+That one idempotent operation means create, update, delete, a replayed job, a
+lost delete event, and a row changed by direct SQL all converge to the same
+index state. At-least-once delivery is safe by construction, and a stale
+payload can never write stale text into the index.
+
+---
+
+## 3. Mount the plugin
+
+```rust
+use std::sync::Arc;
+use autumn_search::SearchPlugin;
+
+autumn_web::app()
+    .plugin(
+        SearchPlugin::new()
+            .postgres()                       // FTS + pgvector backend
+            .embedder(Arc::new(MyEmbedder))   // your provider
+            .visibility(Arc::new(MyVisibility))
+            .index::<Article>()               // one line per searchable model
+            .index::<Note>(),
+    )
+    .routes(routes![...])
+    .run()
+    .await;
+```
+
+Adding a searchable model is one builder line: the reindex job is keyed on the
+*index name*, not the model, so there is no per-model job, handler, or
+generated glue.
+
+### Configuration
+
+```toml
+[search]
+queue = "search"            # the #[job] queue reindex/backfill run on
+batch_size = 500            # rows per backfill batch
+enabled = true              # false ⇒ index writes are no-ops, queries empty
+embedding_dimensions = 768  # declared width; enables the pgvector fast path
+```
+
+`enabled = false` is the incident switch: turning search off must not require a
+deploy, and must not start failing writes to the model.
+
+An unknown key under `[search]` is an **error**, not a warning — a typo'd
+`queu = "indexing"` would otherwise silently leave indexing on the default
+queue with no signal at all.
+
+---
+
+## 4. Query it
+
+```rust
+// Ranked + paginated keyword search, as an ordinary `Page`.
+let page: Page<SearchHit> = search.search::<Article>("rust web", &page_req).await?;
+
+// Driven by a request's ListQuery + PageRequest, so search drops into an
+// existing index endpoint with no second query-parameter vocabulary.
+let page = search.search_list::<Article>("rust web", &list, &page_req).await?;
+
+// Turn hits back into records; ranked order is re-applied for you.
+let page: Page<Article> = search
+    .search_hydrated::<Article, _, _>("rust web", &page_req, |ids| async move {
+        Ok(repo.find_all(&ids).await?)
+    })
+    .await?;
+
+// Semantic search over the `embed` field.
+let hits = search.similar::<Article>("how do I add auth?", 5).await?;
+let neighbours = search.similar_to::<Article>(article.id, 5).await?;
+```
+
+### Query semantics (the cross-backend contract)
+
+Query text is a **bag of words**, not a query language:
+
+- every token must be present for a document to match (AND);
+- operator-looking input (`OR`, `field:`, `*`, quotes) is never interpreted as
+  syntax;
+- a blank or punctuation-only query returns an **empty page having issued no
+  query** — never a full scan.
+
+That keeps results consistent across engines and makes a hostile query string
+structurally incapable of widening the result set. The Postgres backend
+implements it with `plainto_tsquery`, which is parameterized and cannot be
+injected into.
+
+> This is deliberately narrower than `#[repository(searchable)]`'s `search()`,
+> which uses `websearch_to_tsquery` and *does* honour `OR` / quoted phrases /
+> `-` negation. The in-core method is a Postgres-specific convenience; the
+> plugin's contract has to hold for every engine.
+
+Hits carry identity (`index`, `id`, `score`), never record contents — the index
+never becomes a second, staler copy of your database that can leak columns.
+
+---
+
+## 5. Authorization
+
+A search index is a second read path over the same rows, so it needs the same
+posture as a normal query.
+
+```rust
+use autumn_search::{BoxFuture, SearchError, SearchFilter, SearchVisibility};
+use autumn_web::authorization::PolicyContext;
+
+struct ArticleVisibility;
+
+impl SearchVisibility for ArticleVisibility {
+    fn filter<'a>(
+        &'a self,
+        ctx: &'a PolicyContext,
+        _index: &'a str,
+    ) -> BoxFuture<'a, Result<SearchFilter, SearchError>> {
+        Box::pin(async move {
+            Ok(match ctx.user_id.as_deref() {
+                Some(user) => SearchFilter::default().equals("author_id", user),
+                // Fail closed, exactly like `Scope`'s default empty list.
+                None => SearchFilter::default().allow_ids(Vec::<i64>::new()),
+            })
+        })
+    }
+}
+```
+
+Then query through the authorization-aware entry points:
+
+```rust
+let page = search.search_for::<Article>(&ctx, "rust web", &page_req).await?;
+let hits = search.similar_for::<Article>(&ctx, "rust web", 5).await?;
+```
+
+Four properties make this enforceable rather than advisory:
+
+1. `SearchFilter` is a **required argument** of the backend query methods, not
+   a post-processing step, so page totals and neighbour counts are computed
+   *after* the restriction and a backend cannot quietly skip it.
+2. Filters **intersect** (`SearchFilter::intersect`), so a caller-supplied
+   filter can only ever narrow what authorization allowed. Two incompatible
+   constraints collapse to "match nothing", never to an arbitrary winner.
+3. A visibility hook that returns an error **aborts** the search. There is no
+   fall-back-to-unfiltered path.
+4. Calling `search_for` with no hook registered is
+   `SearchError::VisibilityUnavailable` — a wiring mistake surfaces instead of
+   silently returning everything.
+
+Because a `SearchFilter` is plain data, an out-of-scope engine (Meilisearch, a
+vector store) receives the same tenant/visibility restriction. The ambient
+tenant from `CURRENT_TENANT` is intersected into **every** query automatically.
+
+---
+
+## 6. Backfill
+
+For bootstrapping and after a schema change:
+
+```bash
+autumn search reindex                     # every registered index
+autumn search reindex --index articles    # one index
+autumn search reindex --purge             # clear each index first
+```
+
+The CLI compiles the application binary and runs it with
+`AUTUMN_SEARCH_BACKFILL` set — the same "run the app, it knows its own wiring"
+technique `autumn jobs manifest` uses. It has to be the app: the indexes,
+backend, and embedder are registered at runtime by your own builder call, so a
+standalone CLI cannot see them.
+
+Programmatically, or from a job:
+
+```rust
+let report = search.backfill("articles", &BackfillOptions::default()).await?;
+let reports = search.backfill_all(&BackfillOptions::default().purge(true)).await?;
+```
+
+The backfill walks the source with **keyset** pagination (`WHERE id > $after
+ORDER BY id`), never `OFFSET`, so a live table's concurrent writes cannot make
+it skip or repeat rows. It writes through the exact same path as an incremental
+reindex, so bootstrapping and steady state cannot disagree.
+
+`purge` is off by default: emptying the index is the wrong trade for a routine
+repair run. Turn it on when documents the source no longer produces would
+otherwise survive forever.
+
+---
+
+## 7. Backends
+
+| Backend | Keyword | Vector | Use for |
+|---|---|---|---|
+| `PostgresSearchStore` | `tsvector` + `setweight` + `ts_rank_cd` | `pgvector`, or a portable `double precision[]` fallback | production |
+| `MemorySearchBackend` | in-process, weighted | in-process cosine | dev and tests — no Docker, no network |
+| your `impl SearchBackend` | — | — | Meilisearch, Tantivy, a vector store |
+
+### The Postgres index
+
+Documents live in one framework-owned table, `autumn_search_documents`, keyed
+`(index_name, record_id)` — not in each model's own `search_vector` column.
+That buys three things the per-table column cannot:
+
+- the index is **engine-agnostic**: swapping engines changes the backend, not
+  every model's migration;
+- it is **observable and repairable**: count, diff, and purge the index without
+  touching the system of record;
+- backfill and incremental reindex write through the **same** path.
+
+Your model's own `#[searchable]` column and `#[repository(searchable)]`
+`search()` are untouched.
+
+### `pgvector`, and life without it
+
+`ensure_index` probes for the `vector` extension. When it is installed **and**
+`search.embedding_dimensions` is set, embeddings go to a `vector(N)` column
+with an ivfflat index and k-NN uses the `<=>` cosine-distance operator.
+Otherwise they go to a `double precision[]` column ranked by an
+`autumn_search_cosine()` SQL function created by the same schema.
+
+Same API, same ordering, different speed — so the plugin is deployable on a
+managed Postgres without `pgvector`, and gets the fast path for free where it
+exists. A failed `CREATE EXTENSION` degrades; it never aborts boot.
+
+---
+
+## 8. Embeddings
+
+`autumn-search` orchestrates embeddings. It ships **no model, no inference
+runtime, and no vendor SDK** — that is explicitly out of scope. Implement
+`Embedder`:
+
+```rust
+use autumn_search::{BoxFuture, Embedder, SearchError, SearchResult};
+
+struct MyEmbedder { /* an HTTP client, a local runtime, … */ }
+
+impl Embedder for MyEmbedder {
+    fn dimensions(&self) -> usize { 768 }
+
+    fn embed<'a>(&'a self, texts: &'a [String]) -> BoxFuture<'a, SearchResult<Vec<Vec<f32>>>> {
+        Box::pin(async move {
+            // one provider round-trip per batch; one vector per input, in order
+            todo!()
+        })
+    }
+}
+```
+
+Two implementations ship, and neither is a model:
+
+- **`NoEmbedder`** — the default. Refuses, so an app that never configured
+  embeddings gets a typed `EmbedderUnavailable` at *query* time rather than
+  meaningless vectors. Keyword indexing still works; a missing provider must
+  not fail writes.
+- **`HashingEmbedder`** — a deterministic, dependency-free hashing vectorizer.
+  Real lexical embeddings for development and for tests that must not reach the
+  network. It is honest about what it is: no semantics beyond token overlap.
+
+`dimensions() == 0` means "no embeddings available": the client skips embedding
+while indexing and errors on a semantic query.
+
+---
+
+## 9. Errors
+
+`SearchError` is typed, and `into_autumn_error()` maps it to the right status:
+
+| Variant | Status | Meaning |
+|---|---|---|
+| `VectorUnsupported`, `DimensionMismatch` | 400 | the caller asked for something this index cannot answer |
+| `UnknownIndex`, `EmbedderUnavailable`, `VisibilityUnavailable`, `SourceUnavailable`, `InvalidIndex`, `Unsupported`, `Embedding`, `Backend` | 500 | a configuration gap or a genuine failure |
+
+Every message names the builder call that fixes it.
+
+---
+
+## Out of scope (deliberately)
+
+- a bundled embedding model or inference runtime — see §8;
+- faceting, typo tolerance, synonyms, and highlighting beyond what a backend
+  offers natively;
+- cross-model / federated ranking fusion — indexes are per-model;
+- a full RAG pipeline (chunking, prompt assembly, LLM calls). This is the
+  retrieval layer.

--- a/docs/guide/search.md
+++ b/docs/guide/search.md
@@ -359,6 +359,7 @@ For bootstrapping and after a schema change:
 autumn search reindex                     # every registered index
 autumn search reindex --index articles    # one index
 autumn search reindex --purge             # clear each index first
+autumn search reindex --profile prod      # rebuild prod's index
 ```
 
 The CLI compiles the application binary and runs it with
@@ -400,6 +401,14 @@ returns *up to* `limit` documents, so a source that filters after reading —
 soft-deleted rows, a tenant check, an empty embed field — legitimately returns
 a short batch with rows still behind it. Stopping there would truncate the
 rebuild and report success.
+
+`--profile` matters more than it looks. The reindex works by running your
+application binary — only the app knows which indexes, backend, and embedder
+are registered — and that binary resolves its own `[search]` section. The CLI
+builds a **debug** binary, which core reads as the `dev` profile when no
+selector is set, so a production rebuild has to say `--profile prod` or it will
+rebuild (or purge) the development index and report success. The CLI prints the
+profile it is using for exactly that reason.
 
 `purge` is off by default: emptying the index is the wrong trade for a routine
 repair run. Turn it on when documents the source no longer produces would

--- a/docs/guide/search.md
+++ b/docs/guide/search.md
@@ -58,8 +58,23 @@ Rules the macro enforces at compile time:
 A `#[searchable]` model whose primary key is not `i64` keeps its #842 behaviour
 and simply has no plugin index — search indexes key on `i64`.
 
-A `tenant_id` column is picked up automatically and carried into every
-document, so tenant isolation does not depend on remembering to configure it.
+A `tenant_id` column of type `String` / `Option<String>` is picked up
+automatically: its value is carried into every document, and the index is
+marked **tenant-scoped**. Querying a tenant-scoped index with no tenant in
+scope is then `SearchError::TenantContextMissing`, not a search across every
+tenant — the same posture `#[repository(tenant_scoped)]` takes, and it is what
+protects the paths that are easy to forget (a route mounted outside the tenancy
+layer, a `#[job]`, a background task).
+
+A model with no `tenant_id` column is unaffected and needs no tenant scope. If
+a model has a `tenant_id` column that is *not* a tenant (a device id, say),
+register a definition with the flag cleared:
+
+```rust
+let mut definition = Reading::index_definition();
+definition.tenant_scoped = false;
+SearchPlugin::new().index_definition(definition)
+```
 
 ---
 
@@ -68,11 +83,11 @@ document, so tenant isolation does not depend on remembering to configure it.
 ```rust
 use autumn_search::SearchSyncHooks;
 
-#[autumn_web::repository(
-    Article,
-    hooks = SearchSyncHooks<Article, NewArticle, UpdateArticle>,
-    commit_hooks = true,
-)]
+// `#[repository]`'s `hooks =` takes a plain type NAME, not a generic type
+// expression, so alias the generic first.
+type ArticleSearchHooks = SearchSyncHooks<Article, NewArticle, UpdateArticle>;
+
+#[autumn_web::repository(Article, hooks = ArticleSearchHooks, commit_hooks = true)]
 pub trait ArticleRepository {}
 ```
 
@@ -135,8 +150,11 @@ enabled = true              # false ⇒ index writes are no-ops, queries empty
 embedding_dimensions = 768  # declared width; enables the pgvector fast path
 ```
 
-`enabled = false` is the incident switch: turning search off must not require a
-deploy, and must not start failing writes to the model.
+The plugin reads `autumn.toml` itself at boot, so `enabled = false` is the
+incident switch it claims to be: a config change, not a deploy — and it stops
+index writes (including a purging backfill) without failing writes to the
+model. Pass `SearchPlugin::config(...)` to configure in code instead; doing so
+also stops the file being read.
 
 An unknown key under `[search]` is an **error**, not a warning — a typo'd
 `queu = "indexing"` would otherwise silently leave indexing on the default
@@ -145,6 +163,15 @@ queue with no signal at all.
 ---
 
 ## 4. Query it
+
+The plugin installs the client as an `AppState` extension, so a handler reaches
+it the same way it reaches a `BlobStore`:
+
+```rust
+let search = state
+    .extension::<autumn_search::SearchClient>()
+    .expect("SearchPlugin is installed");
+```
 
 ```rust
 // Ranked + paginated keyword search, as an ordinary `Page`.
@@ -155,6 +182,8 @@ let page: Page<SearchHit> = search.search::<Article>("rust web", &page_req).awai
 let page = search.search_list::<Article>("rust web", &list, &page_req).await?;
 
 // Turn hits back into records; ranked order is re-applied for you.
+// The loader returns `SearchResult<Vec<Article>>`; an `AutumnError` from a
+// repository call converts with `?`, so this is the whole loader.
 let page: Page<Article> = search
     .search_hydrated::<Article, _, _>("rust web", &page_req, |ids| async move {
         Ok(repo.find_all(&ids).await?)
@@ -242,7 +271,10 @@ Four properties make this enforceable rather than advisory:
 
 Because a `SearchFilter` is plain data, an out-of-scope engine (Meilisearch, a
 vector store) receives the same tenant/visibility restriction. The ambient
-tenant from `CURRENT_TENANT` is intersected into **every** query automatically.
+tenant from `CURRENT_TENANT` is intersected into **every** query automatically,
+and `similar_to` filters the *seed* read as well as the neighbour query — an
+unfiltered seed read would be an inference channel, letting a caller rank their
+own probe documents against a record they cannot see.
 
 ---
 
@@ -362,7 +394,7 @@ while indexing and errors on a semantic query.
 | Variant | Status | Meaning |
 |---|---|---|
 | `VectorUnsupported`, `DimensionMismatch` | 400 | the caller asked for something this index cannot answer |
-| `UnknownIndex`, `EmbedderUnavailable`, `VisibilityUnavailable`, `SourceUnavailable`, `InvalidIndex`, `Unsupported`, `Embedding`, `Backend` | 500 | a configuration gap or a genuine failure |
+| `UnknownIndex`, `EmbedderUnavailable`, `VisibilityUnavailable`, `SourceUnavailable`, `TenantContextMissing`, `InvalidIndex`, `Unsupported`, `Embedding`, `Backend` | 500 | a configuration gap or a genuine failure |
 
 Every message names the builder call that fixes it.
 

--- a/docs/guide/search.md
+++ b/docs/guide/search.md
@@ -71,8 +71,11 @@ that still has an unrelated `id` column backfills correctly rather than keying
 half its documents off the wrong value.
 
 A `tenant_id` column of type `String` / `Option<String>` is picked up
-automatically: its value is carried into every document, and the index is
-marked **tenant-scoped**. Querying a tenant-scoped index with no tenant in
+automatically: its value is carried into every document. Whether the index is
+**tenant-scoped** follows `#[repository(..., tenant_scoped)]`, not the column —
+same rule as `soft_delete`, because a denormalized or audit `tenant_id` on an
+unscoped repository has unscoped finders, and the index must not be more
+restrictive than the reads it mirrors. Querying a tenant-scoped index with no tenant in
 scope is then `SearchError::TenantContextMissing`, not a search across every
 tenant — the same posture `#[repository(tenant_scoped)]` takes, and it is what
 protects the paths that are easy to forget (a route mounted outside the tenancy
@@ -378,7 +381,10 @@ exact same path as an incremental reindex, so bootstrapping and steady state
 cannot disagree.
 
 A backfill takes a **write watermark** before its first batch and never
-overwrites a document written after that point. Without it, a backfill batch —
+overwrites — or re-creates — a record touched after that point. Deletes are
+recorded in a ledger that outlives the document, because once the row is gone
+there is nothing left for a conditional write to compare against, and an
+unguarded insert would resurrect something a user deleted. Without it, a backfill batch —
 read minutes ago, then delayed by an embedding round-trip — would clobber
 whatever a per-record reindex wrote in the meantime, and nothing re-runs that
 reindex. Newer always wins, so the bulk and per-record writers converge without

--- a/docs/guide/search.md
+++ b/docs/guide/search.md
@@ -104,15 +104,23 @@ your own `after_*_commit`.
 ### Why the job payload is `(index, id)` and not the record
 
 A reindex instruction carries the index name and the primary key. The handler
-**re-reads the row**:
+**re-reads the row** — for a delete as much as an upsert:
 
 - row present ⇒ upsert the document;
-- row absent ⇒ delete the document.
+- row absent (hard-deleted, or soft-deleted and therefore filtered out by the
+  source) ⇒ delete the document.
 
-That one idempotent operation means create, update, delete, a replayed job, a
-lost delete event, and a row changed by direct SQL all converge to the same
-index state. At-least-once delivery is safe by construction, and a stale
-payload can never write stale text into the index.
+Every instruction is the same operation: *converge this id*. So create, update,
+delete, a replayed job, a lost delete event, and a row changed by direct SQL all
+reach the same index state, in any order. At-least-once delivery is safe by
+construction, a stale payload can never write stale text into the index, and a
+late delete cannot evict a record that has since been recreated under the same
+primary key. It is also what makes the `(index, id)` dedup key sound: repeated
+writes collapse to one job precisely because the ops are interchangeable.
+
+`ReindexOp` survives as intent, and as the one place the paths differ: with no
+`DocumentSource` installed a delete still removes the document (it needs
+nothing to re-read), while an upsert reports `SourceUnavailable`.
 
 ---
 

--- a/docs/guide/search.md
+++ b/docs/guide/search.md
@@ -459,6 +459,14 @@ Same API, same ordering, different speed — so the plugin is deployable on a
 managed Postgres without `pgvector`, and gets the fast path for free where it
 exists. A failed `CREATE EXTENSION` degrades; it never aborts boot.
 
+A **filtered** k-NN query deliberately does not use the ivfflat index. ivfflat
+picks its candidate lists by distance before the `WHERE` clause runs, so a
+selective tenant or visibility predicate can leave the probed lists holding
+few or none of the rows the caller may see — returning short, or empty, while
+qualifying neighbours sit in unprobed lists. Since those filters are usually an
+authorization boundary, a filtered query orders by the derived similarity
+instead, which forces an exact scan. Unfiltered queries keep the fast path.
+
 ---
 
 ## 8. Embeddings

--- a/docs/guide/search.md
+++ b/docs/guide/search.md
@@ -58,6 +58,12 @@ Rules the macro enforces at compile time:
 A `#[searchable]` model whose primary key is not `i64` keeps its #842 behaviour
 and simply has no plugin index — search indexes key on `i64`.
 
+A `deleted_at` column is **not** by itself treated as a tombstone. The index
+follows the repository: `#[repository(..., soft_delete)]` makes the source
+exclude deleted rows, matching the finders, while a `deleted_at` kept as audit
+history leaves them indexed — also matching the finders. Inferring from the
+column alone would hide records the app still displays.
+
 The key **column** does not have to be called `id`. `#[id] pub note_id: i64` is
 carried into the index definition as `key_column`, and the Postgres document
 source selects, filters, and paginates on it — so a model over a legacy table
@@ -202,6 +208,13 @@ The active profile comes from `AUTUMN_ENV` → `AUTUMN_PROFILE` → `--profile` 
 filename is looked up through `AUTUMN_MANIFEST_DIR` before the working
 directory. A plugin that read only the base `autumn.toml` would silently ignore
 the kill switch in the one environment you reach for it.
+
+Both of those last two values are read through core's `Env` abstraction rather
+than the raw process environment, because neither is necessarily a real
+variable: `#[autumn_web::main]` supplies the crate directory and the build mode
+at compile time. Reading `std::env` directly would see a release binary as
+`dev` — skipping `[profile.prod]` — and would miss the app's own config
+whenever the binary runs from anywhere but its crate root.
 
 An unknown key under `[search]` is an **error**, not a warning — a typo'd
 `queu = "indexing"` would otherwise silently leave indexing on the default

--- a/docs/guide/search.md
+++ b/docs/guide/search.md
@@ -184,7 +184,10 @@ embedding_dimensions = 768  # declared width; enables the pgvector fast path
 The plugin reads the config itself at boot, so `enabled = false` is the
 incident switch it claims to be: a config change, not a deploy — and it stops
 index writes (including a purging backfill) without failing writes to the
-model. Pass `SearchPlugin::config(...)` to configure in code instead; doing so
+model. A disabled subsystem also **initializes nothing**: no `ensure_index`, no
+DDL, no embedder width check. That is the difference between a kill switch and
+a preference — an unreachable engine or a revoked DDL grant must not still
+abort application startup once you have turned search off. Pass `SearchPlugin::config(...)` to configure in code instead; doing so
 also stops the file being read.
 
 `[search]` is resolved through the **same profile layering the runtime uses**,
@@ -373,6 +376,15 @@ The backfill walks the source with **keyset** pagination
 concurrent writes cannot make it skip or repeat rows. It writes through the
 exact same path as an incremental reindex, so bootstrapping and steady state
 cannot disagree.
+
+A backfill takes a **write watermark** before its first batch and never
+overwrites a document written after that point. Without it, a backfill batch —
+read minutes ago, then delayed by an embedding round-trip — would clobber
+whatever a per-record reindex wrote in the meantime, and nothing re-runs that
+reindex. Newer always wins, so the bulk and per-record writers converge without
+knowing about each other. A backend that does not report
+`BackendCapabilities::conditional_index` ignores the watermark and keeps
+last-writer-wins.
 
 It stops only on an **empty** batch, never on a short one. `DocumentSource::scan`
 returns *up to* `limit` documents, so a source that filters after reading —

--- a/docs/guide/search.md
+++ b/docs/guide/search.md
@@ -128,6 +128,17 @@ writes collapse to one job precisely because the ops are interchangeable.
 `DocumentSource` installed a delete still removes the document (it needs
 nothing to re-read), while an upsert reports `SourceUnavailable`.
 
+Convergence needs one more thing to hold on a multi-worker deployment. The
+dedup key is released when a job **starts**, not when it finishes — otherwise a
+write landing mid-reindex would be swallowed and the index would keep the
+pre-write text. That means two jobs for one record can be in flight at once,
+and because each re-reads the source they can interleave badly: A reads, a
+write lands, B reads and writes the new state, then A writes the old one. So
+the reindex job also carries a **concurrency cap of one per record**
+(`(index, id)`, not per job type — distinct records still reindex fully in
+parallel). The follow-up job is still enqueued immediately; it just waits for
+the running one, then re-reads and converges.
+
 ---
 
 ## 3. Mount the plugin
@@ -344,10 +355,17 @@ let report = search.backfill("articles", &BackfillOptions::default()).await?;
 let reports = search.backfill_all(&BackfillOptions::default().purge(true)).await?;
 ```
 
-The backfill walks the source with **keyset** pagination (`WHERE id > $after
-ORDER BY id`), never `OFFSET`, so a live table's concurrent writes cannot make
-it skip or repeat rows. It writes through the exact same path as an incremental
-reindex, so bootstrapping and steady state cannot disagree.
+The backfill walks the source with **keyset** pagination
+(`WHERE <key> > $after ORDER BY <key>`), never `OFFSET`, so a live table's
+concurrent writes cannot make it skip or repeat rows. It writes through the
+exact same path as an incremental reindex, so bootstrapping and steady state
+cannot disagree.
+
+It stops only on an **empty** batch, never on a short one. `DocumentSource::scan`
+returns *up to* `limit` documents, so a source that filters after reading —
+soft-deleted rows, a tenant check, an empty embed field — legitimately returns
+a short batch with rows still behind it. Stopping there would truncate the
+rebuild and report success.
 
 `purge` is off by default: emptying the index is the wrong trade for a routine
 repair run. Turn it on when documents the source no longer produces would
@@ -377,6 +395,14 @@ That buys three things the per-table column cannot:
 
 Your model's own `#[searchable]` column and `#[repository(searchable)]`
 `search()` are untouched.
+
+Ranking passes the framework's own weight array to `ts_rank_cd`
+(`{D, C, B, A}` = `{0.1, 0.2, 0.5, 1.0}`, the normalized form of
+`weight_factor`'s `1/2/5/10`) rather than taking Postgres' default
+`{0.1, 0.2, 0.4, 1.0}`. The two differ only at `B` — which is the weight a
+body field usually carries, so leaving it defaulted would rank Postgres
+differently from `MemorySearchBackend` on the most ordinary model there is,
+and the two suites assert they implement the *same* contract.
 
 ### `pgvector`, and life without it
 

--- a/docs/guide/search.md
+++ b/docs/guide/search.md
@@ -384,7 +384,10 @@ A backfill takes a **write watermark** before its first batch and never
 overwrites — or re-creates — a record touched after that point. Deletes are
 recorded in a ledger that outlives the document, because once the row is gone
 there is nothing left for a conditional write to compare against, and an
-unguarded insert would resurrect something a user deleted. Without it, a backfill batch —
+unguarded insert would resurrect something a user deleted. Removing the
+document and recording the delete happen in **one statement** — they are two
+halves of a single fact, and a backfill that observed the gap between them
+would see neither the document nor the tombstone. Without it, a backfill batch —
 read minutes ago, then delayed by an embedding round-trip — would clobber
 whatever a per-record reindex wrote in the meantime, and nothing re-runs that
 reindex. Newer always wins, so the bulk and per-record writers converge without

--- a/docs/guide/search.md
+++ b/docs/guide/search.md
@@ -116,6 +116,15 @@ If the repository already has hooks, compose instead of replacing — call
 `autumn_search::enqueue_reindex_for(&record)` (or `enqueue_unindex_for`) from
 your own `after_*_commit`.
 
+> **Known gap: `restore()` and `purge()`.** `#[repository(soft_delete)]` also
+> generates `restore(id)` and `purge(id)`, and both write to the table directly
+> without running `MutationHooks`. No reindex is enqueued for either, so a
+> restored record stays missing from the index and a purged one can stay
+> searchable, until the next mutation or a backfill. The fix belongs in the
+> repository macro; until then, call `enqueue_reindex_for` / `enqueue_reindex`
+> yourself after either call. Because the handler re-reads the row, sending
+> either instruction converges correctly regardless of which one you send.
+
 ### Why the job payload is `(index, id)` and not the record
 
 A reindex instruction carries the index name and the primary key. The handler

--- a/docs/guide/search.md
+++ b/docs/guide/search.md
@@ -58,6 +58,12 @@ Rules the macro enforces at compile time:
 A `#[searchable]` model whose primary key is not `i64` keeps its #842 behaviour
 and simply has no plugin index — search indexes key on `i64`.
 
+The key **column** does not have to be called `id`. `#[id] pub note_id: i64` is
+carried into the index definition as `key_column`, and the Postgres document
+source selects, filters, and paginates on it — so a model over a legacy table
+that still has an unrelated `id` column backfills correctly rather than keying
+half its documents off the wrong value.
+
 A `tenant_id` column of type `String` / `Option<String>` is picked up
 automatically: its value is carried into every document, and the index is
 marked **tenant-scoped**. Querying a tenant-scoped index with no tenant in
@@ -158,15 +164,44 @@ enabled = true              # false ⇒ index writes are no-ops, queries empty
 embedding_dimensions = 768  # declared width; enables the pgvector fast path
 ```
 
-The plugin reads `autumn.toml` itself at boot, so `enabled = false` is the
+The plugin reads the config itself at boot, so `enabled = false` is the
 incident switch it claims to be: a config change, not a deploy — and it stops
 index writes (including a purging backfill) without failing writes to the
 model. Pass `SearchPlugin::config(...)` to configure in code instead; doing so
 also stops the file being read.
 
+`[search]` is resolved through the **same profile layering the runtime uses**,
+so a per-environment switch works the way you would expect:
+
+| Layer | Wins over |
+|---|---|
+| `autumn.toml` `[search]` | — |
+| `[profile.<name>.search]` in `autumn.toml` | the base section |
+| `autumn-<profile>.toml` `[search]` | the inline profile section |
+| `AUTUMN_SEARCH__QUEUE` / `__BATCH_SIZE` / `__ENABLED` / `__EMBEDDING_DIMENSIONS` | every file |
+
+```toml
+# Search off in production, on everywhere else.
+[profile.prod.search]
+enabled = false
+```
+
+The active profile comes from `AUTUMN_ENV` → `AUTUMN_PROFILE` → `--profile` →
+`AUTUMN_IS_DEBUG=0` ⇒ `prod` → `dev`, exactly as core resolves it, and each
+filename is looked up through `AUTUMN_MANIFEST_DIR` before the working
+directory. A plugin that read only the base `autumn.toml` would silently ignore
+the kill switch in the one environment you reach for it.
+
 An unknown key under `[search]` is an **error**, not a warning — a typo'd
 `queu = "indexing"` would otherwise silently leave indexing on the default
-queue with no signal at all.
+queue with no signal at all. A malformed value in an `AUTUMN_SEARCH__*` var is
+ignored instead: a bad env var must not take down a process that would boot
+fine on its file config.
+
+`embedding_dimensions` is checked against the installed `Embedder` at startup.
+If they disagree the app **refuses to boot**, because the alternative is
+silent: every index write succeeds, the vector column rejects the wrong-width
+value, and semantic search returns nothing forever.
 
 ---
 

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -27,6 +27,16 @@ autumn_web::app()
     .await;
 ```
 
+## First-party plugin crates
+
+| Crate | What it adds | Guide |
+|---|---|---|
+| `autumn-admin-plugin` | Admin UI and API-token administration | [Admin](./guide/admin.md) |
+| `autumn-media-plugin` | Live-streaming media (broadcast + rooms) | — |
+| `autumn-storage-s3` | S3-backed object storage | [Storage](./guide/storage.md) |
+| `autumn-cache-redis` | Redis-backed shared cache | [Cache stampede](./guide/cache-stampede.md) |
+| `autumn-search` | Keyword **and** vector search with lifecycle-synced indexes | [Search](./guide/search.md) |
+
 ## Naming conventions
 
 | Kind | Crate name | Struct name |

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -41,13 +41,19 @@ autumn_web::app()
 
 | Kind | Crate name | Struct name |
 |------|------------|-------------|
-| First-party (lives in this repo) | `autumn-<name>-plugin` | `<Name>Plugin` |
+| First-party, adds a *subsystem* | `autumn-<name>-plugin` | `<Name>Plugin` |
+| First-party, *implements a seam* for a named technology | `autumn-<subsystem>-<technology>` or `autumn-<name>` | `<Name>Plugin` |
 | Autumn companion (separate release train) | `autumn-<name>` or `autumn-<name>-plugin` | `<Name>Plugin` |
 | Third-party (lives on crates.io) | `autumn-plugin-<name>` | `<Name>Plugin` |
 
 Third-party crates keep the `autumn-plugin-` prefix so the ecosystem
 is easy to search on crates.io. First-party crates reverse the order so
 they cluster with the crate they extend.
+
+The second row is what `autumn-storage-s3`, `autumn-cache-redis`, and
+`autumn-search` follow: the crate name says which subsystem it provides rather
+than repeating `-plugin`, because the interesting part of the name is the seam,
+not the fact that it happens to ship as a plugin.
 
 Companion crates can live outside this repository when their dependency graph
 points back at `autumn-web`. Autumn Harvest is the main example: it provides

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -20,6 +20,7 @@ SemVer contract.
 | `autumn-admin-plugin` | `autumn-admin-plugin/` | 4 | Depends on `autumn-web`. |
 | `autumn-storage-s3` | `autumn-storage-s3/` | 4 | Depends on `autumn-web`. |
 | `autumn-cache-redis` | `autumn-cache-redis/` | 4 | Depends on `autumn-web`. |
+| `autumn-search` | `autumn-search/` | 4 | Depends on `autumn-web`. |
 
 All crates share a single workspace version (`[workspace.package].version` in
 `Cargo.toml`). They are always released together at the same version.
@@ -242,6 +243,7 @@ Before pushing the release tag:
    cargo publish -p autumn-admin-plugin
    cargo publish -p autumn-storage-s3
    cargo publish -p autumn-cache-redis
+   cargo publish -p autumn-search
    ```
 7. **Gate the published quickstart** (see
    [Published Quickstart Gate](#7--published-quickstart-gate-quickstart-gate-workflow-post-publish)):

--- a/scripts/check-crate-metadata.sh
+++ b/scripts/check-crate-metadata.sh
@@ -42,6 +42,7 @@ declare -a CRATES=(
   "autumn-admin-plugin:autumn-admin-plugin/Cargo.toml"
   "autumn-storage-s3:autumn-storage-s3/Cargo.toml"
   "autumn-cache-redis:autumn-cache-redis/Cargo.toml"
+  "autumn-search:autumn-search/Cargo.toml"
 )
 
 # Required fields that must appear in [package] (inline, quoted, array, or

--- a/scripts/check-docs.sh
+++ b/scripts/check-docs.sh
@@ -50,7 +50,7 @@ cargo doc -p autumn-web --no-deps \
 
 # All other publishable crates: use their default features (no
 # [package.metadata.docs.rs] section means docs.rs uses defaults).
-for crate in autumn-macros autumn-cli autumn-admin-plugin autumn-storage-s3 autumn-cache-redis; do
+for crate in autumn-macros autumn-cli autumn-admin-plugin autumn-storage-s3 autumn-cache-redis autumn-search; do
   echo ""
   echo "==> $crate (default features)"
   cargo doc -p "$crate" --no-deps 2>&1

--- a/scripts/check-panic-gate.sh
+++ b/scripts/check-panic-gate.sh
@@ -51,6 +51,8 @@ REQUEST_PATH_MODULES=(
   autumn/src/middleware/maintenance.rs
   autumn/src/middleware/error_page_filter.rs
   autumn/src/middleware/load_shed.rs
+  autumn/src/search.rs
+  autumn-search/src/lib.rs
 )
 
 # Canonical panic-class lints every gated module must deny on the production

--- a/scripts/check-publish-dry-run.sh
+++ b/scripts/check-publish-dry-run.sh
@@ -40,6 +40,7 @@ CRATES=(
   autumn-media-plugin
   autumn-storage-s3
   autumn-cache-redis
+  autumn-search
 )
 
 # Assets that MUST appear in a crate's packaged file list. `--list` does not

--- a/scripts/check-semver.sh
+++ b/scripts/check-semver.sh
@@ -103,6 +103,7 @@ CRATES=(
   autumn-admin-plugin
   autumn-storage-s3
   autumn-cache-redis
+  autumn-search
 )
 
 breaking_failures=0

--- a/skills/autumn-web/SKILL.md
+++ b/skills/autumn-web/SKILL.md
@@ -99,6 +99,7 @@ after checking this table and `docs/guide/`.
 | Admin plugin crate | `autumn-admin-plugin` |
 | S3 storage plugin crate | `autumn-storage-s3` |
 | Redis cache plugin crate | `autumn-cache-redis` |
+| Search plugin crate | `autumn-search` |
 | Main entry macro | `#[autumn_web::main]`, not `#[autumn::main]` |
 
 The name `autumn` is the CLI binary, not the framework crate. In code, import
@@ -183,6 +184,7 @@ Defaults: `maud`, `htmx`, `tailwind`, `db`, `cache-moka`.
 
 For S3 storage add `autumn-storage-s3 = "0.5"`; `storage-s3` is no longer an
 `autumn-web` feature. For a shared Redis cache add `autumn-cache-redis = "0.5"`.
+For keyword + vector search with lifecycle-synced indexes add `autumn-search`.
 
 ## main.rs pattern
 
@@ -999,6 +1001,47 @@ let store = autumn_storage_s3::S3BlobStore::from_config(&config.storage.s3)
     .expect("S3 store");
 autumn_web::app().with_blob_store(store).run().await;
 ```
+
+For keyword **and** vector search with an index that stays in sync:
+
+```toml
+autumn-search = "0.6"
+```
+
+```rust
+#[autumn_web::model]
+#[searchable(language = "english")]
+pub struct Article {
+    #[id] pub id: i64,
+    #[searchable(weight = "A")] pub title: String,
+    #[searchable(weight = "B", embed)] pub body: String,   // embed => vector search
+}
+
+// `#[repository(hooks = ...)]` takes a plain type NAME, so alias the generic.
+type ArticleSearchHooks =
+    autumn_search::SearchSyncHooks<Article, NewArticle, UpdateArticle>;
+
+#[autumn_web::repository(Article, hooks = ArticleSearchHooks, commit_hooks = true)]
+pub trait ArticleRepository {}
+
+autumn_web::app()
+    .plugin(
+        autumn_search::SearchPlugin::new()
+            .postgres()
+            .embedder(std::sync::Arc::new(MyEmbedder))
+            .index::<Article>(),
+    )
+    .run()
+    .await;
+
+// In a handler: the plugin installs the client as an AppState extension.
+let search = state.extension::<autumn_search::SearchClient>().expect("SearchPlugin");
+let page = search.search::<Article>("rust web", &page_req).await?;   // ranked Page
+let hits = search.similar::<Article>("how do I add auth?", 5).await?; // k-NN
+```
+
+`autumn search reindex [--index NAME] [--purge]` rebuilds an index. See
+`docs/guide/search.md`.
 
 For shared Redis cache:
 
@@ -1837,7 +1880,7 @@ signing secrets, and other config problems without printing credentials.
 - Release tag for this line is `v0.5.0`.
 - Published crates are released together at the same workspace version:
   `autumn-macros`, `autumn-web`, `autumn-cli`, `autumn-admin-plugin`,
-  `autumn-storage-s3`, and `autumn-cache-redis`.
+  `autumn-storage-s3`, `autumn-cache-redis`, and `autumn-search`.
 - The publish gate checks crate metadata, package dry-runs, full docs,
   semver compatibility, release-note alignment, and downstream smoke tests.
 - Use `docs/release-checklist.md`, `docs/guide/docs-smoke.md`,

--- a/skills/autumn-web/references/api-reference.md
+++ b/skills/autumn-web/references/api-reference.md
@@ -17,6 +17,7 @@ the `trunk-dev` workspace is versioned **0.6.0 (unpublished)**. Entries marked
 | `autumn-admin-plugin` | `autumn-admin-plugin/` | First-party admin UI plugin |
 | `autumn-storage-s3` | `autumn-storage-s3/` | S3-compatible `BlobStore` plugin |
 | `autumn-cache-redis` | `autumn-cache-redis/` | Redis cache plugin |
+| `autumn-search` | `autumn-search/` | Keyword + vector search plugin |
 
 All publishable crates share the `[workspace.package]` version and release
 together (`0.5.0` published; `0.6.0` on trunk-dev, unpublished).


### PR DESCRIPTION
Closes #1191.

Autumn shipped full-text search *primitives* in core (#842) — a `#[searchable]` model attribute, a `tsvector` column, and a `#[repository(searchable)]` `search()` method. That covers "search this table." It did not cover a search **subsystem**: an index that stays in sync with the record lifecycle, semantic / vector retrieval, a pluggable engine, or a backfill.

This adds that subsystem as an optional plugin crate, so an app that never installs it pays nothing. It subsumes #842 as one backend rather than replacing it — the in-core `search()` and its `websearch_to_tsquery` semantics are untouched.

## What you write

```rust
#[autumn_web::model]
#[searchable(language = "english")]
pub struct Article {
    #[id] pub id: i64,
    #[searchable(weight = "A")] pub title: String,
    #[searchable(weight = "B", embed)] pub body: String,   // embed ⇒ vector search
}

// `#[repository]`'s `hooks =` takes a plain type NAME, so alias the generic.
type ArticleSearchHooks = SearchSyncHooks<Article, NewArticle, UpdateArticle>;

#[autumn_web::repository(Article, hooks = ArticleSearchHooks, commit_hooks = true)]
pub trait ArticleRepository {}

autumn_web::app()
    .plugin(SearchPlugin::new().postgres().embedder(Arc::new(MyEmbedder)).index::<Article>())
    .run().await;
```

```rust
let page = search.search::<Article>("rust web framework", &page_req).await?;   // ranked Page
let hits = search.similar::<Article>("how do I add auth?", 5).await?;          // k-NN
let page = search.search_for::<Article>(&ctx, "rust web", &page_req).await?;   // authorization-aware
```

`autumn search reindex [--index NAME] [--purge]` rebuilds an index.

## Design decisions worth reviewing

**The reindex job carries `(index, id)`, not the record.** The handler re-reads the row: present ⇒ upsert, absent ⇒ delete. That one idempotent operation makes at-least-once delivery safe and lets a lost delete event, a soft delete, or a row changed by direct SQL repair itself. It is also why adding a searchable model is one builder line rather than a new job — the job is keyed on the index name, so nothing is generated per model.

**Authorization is enforced, not advised.** `SearchFilter` is a *required argument* of every backend query method, so totals and neighbour counts are computed after the restriction; filters intersect (narrow-only, with incompatible constraints collapsing to "match nothing"); a failing visibility hook aborts the search; and calling the authorization-aware entry point with no hook registered is a typed error. Because a `SearchFilter` is plain data, an out-of-scope engine gets the same restriction.

**A framework-owned index table.** Documents live in one `autumn_search_documents` table keyed `(index_name, record_id)` rather than in each model's own column — which makes the index engine-agnostic, observable, and repairable, and makes backfill and incremental reindex write through the same path.

**`pgvector` when present, portable when not.** `ensure_index` probes for the extension; without it, embeddings use a `double precision[]` column and an `autumn_search_cosine()` function. Same API, same ordering, lower speed — so the plugin is deployable on a managed Postgres.

## Review process

Five review agents ran against the first commit (security, API/docs, Postgres SQL, AC coverage, correctness). The second commit is the fixes; every finding was triaged and either fixed or explicitly declined.

One agent stood up a real PostgreSQL and executed every generated statement. That found, and this PR fixes:

- an **unbounded prepared-statement leak** — `sql_query`'s cache is keyed on SQL text and never evicts, so interpolated values minted one permanent statement *per indexed row*. An OOM on any real backfill. Ids, limits, offsets and embeddings are now bound.
- `CREATE … IF NOT EXISTS` is not race-free, so concurrent boots intermittently aborted. The DDL now runs once per process under an advisory lock.
- the column probe used `current_schema()` while the projection followed `search_path`, silently blanking `tenant_id` and re-indexing soft-deleted rows in any non-first schema.
- `jsonb_build_object` caps at 100 arguments, so >50 searchable fields was a hard error.
- `ensure_index` held two connections at boot, deadlocking a pool of one.
- the ivfflat index could never be used (the query ordered by a derived expression), and enabling pgvector left existing embeddings invisible to k-NN.

Four authorization defects were found and closed: an unfiltered seed read in `similar_to` (an inference channel over records the caller can't see), `SearchFilter::equals` keys reaching SQL in an identifier position (a widening vector, not just an injection), an ambient tenant filter that failed **open**, and a pre-authorization count in `search_hydrated`.

The AC-coverage agent's central criticism — that the wiring layer was asserted by shape rather than behaviour — was correct, and that is exactly where the remaining defects hid. Two new suites address it, and found two more real bugs (`.postgres().backend(other)` shipping a pool-less document source; `backfill` ignoring the `enabled` kill switch, including `purge`).

## Testing

| Suite | Count |
|---|---|
| `autumn-search` integration | 93 in-process + 27 Docker-gated |
| `autumn-search` lib unit | 89 |
| `autumn-web` search vocabulary | 8 |
| `autumn-macros` | 611 (incl. 12 new) |

Two suites are worth a look specifically:

- **`plugin_runtime.rs`** drives the plugin through `autumn-web`'s in-process test client — startup hook, installed extension, enqueue, and `perform_enqueued_jobs()` actually running the registered handler. This is what AC 8 asks for.
- **`extensibility.rs`** implements `SearchBackend` and `Embedder` from *outside* the crate, which is the only way to check "an external engine can be added without a breaking change" — the shipped implementations are privileged and can't prove it.

`memory_backend.rs` and `postgres_backend.rs` deliberately assert the *same* contract against two engines; a divergence means one of them is wrong.

Gates run locally: `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace --no-run`, `cargo test --workspace --doc`, `check-crate-metadata.sh`, `check-panic-gate.sh` (now covering both new modules), `check-plugin-freshness.sh`.

## Not verified — please weigh before merge

- The **27 Docker-gated Postgres tests have never executed** — no Docker in the authoring environment. The SQL was reviewed against a real PostgreSQL 16 statement-by-statement, but CI's sweep is the first genuine run.
- The **`pgvector` accelerated path is unexercised even in CI**: testcontainers uses a stock `postgres` image with no extension, so `a_stock_postgres_without_pgvector_falls_back_to_the_portable_path` deliberately asserts the fallback. The pgvector code is reviewed, not run.
- `#[repository(hooks = …)]` parses a plain `Ident`, so the quick start needs a one-line type alias. I corrected the docs rather than widening the macro's parser — that is a larger change to a 7k-line generator than this issue warrants, and worth its own issue if the inline-generic ergonomics are wanted.

## Registration

New publishable crate, added to: root `Cargo.toml` members, `check-semver.sh`, `check-crate-metadata.sh`, `check-publish-dry-run.sh`, `check-docs.sh`, `docs/release-checklist.md`, `.github/workflows/ci.yml` (Docker sweep + coverage), and the Claude plugin (`skills/`). Workspace version untouched; the changelog entry is a bullet under the existing `## [Unreleased]`.

---
_Generated by [Claude Code](https://claude.ai/code/session_013gP9aGvQhB4zRzq8DAfpUo)_