### PR TITLE
security: address deferred follow-ups from #1604's route-auth-coverage slice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -638,6 +638,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   was shipped non-blocking in #2018 only until a pinned autumn release published
   prebuilt CLI binaries; with v0.6.0 now published with prebuilt binaries, the
   step runs against the release binary and blocks. Checklist item #7 of #2040.
+### Added
+
+- **security:** `autumn routes audit` (#1604) is now wired into every
+  scaffolded app's CI by default — `autumn new` adds a "Route auth coverage
+  (security manifest)" step to `.github/workflows/ci.yml`, right after the
+  a11y-verify step whose prebuilt CLI it reuses, so a route someone forgot to
+  classify fails CI on day one instead of waiting for an app to opt in.
+  Unclassified-route diagnostics now also name the offending handler's
+  `file:line` (from `file!()`/`line!()`, captured by the `#[get]`/`#[post]`/…,
+  `#[ws]`, and static-route macros alongside the existing module path), so a
+  failing gate points straight at the line to fix. A new [Route Auth
+  Coverage](docs/guide/route-auth-coverage.md) guide documents the
+  default-deny posture model and how to classify the three route kinds
+  (`gated`, `public`, `framework`), completing the deferred items from #1604's
+  first slice (#1850).
 
 ## [0.6.0] - 2026-07-18
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1880,15 +1880,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc14f565cf027a105f7a44ccf9e5b424348421a1d8952a8fc9d499d313107789"
 
 [[package]]
-name = "concurrent-queue"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
 name = "console"
 version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2920,11 +2911,10 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
-version = "5.4.1"
+version = "5.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+checksum = "5a23add41df1562121a9393cb065eab5146a1242410f23a644851e90cfd669d2"
 dependencies = [
- "concurrent-queue",
  "parking",
  "pin-project-lite",
 ]

--- a/autumn-cli/src/routes_audit.rs
+++ b/autumn-cli/src/routes_audit.rs
@@ -70,6 +70,10 @@ pub struct AuditRoute {
     pub policy: bool,
     #[serde(default)]
     pub module: Option<String>,
+    /// `file:line` source location of the handler, when known (serialized as
+    /// `location` in the dump).
+    #[serde(default)]
+    pub location: Option<String>,
 }
 
 impl AuditRoute {
@@ -143,6 +147,9 @@ pub struct ManifestRoute {
     pub scopes: Vec<String>,
     pub policy: bool,
     pub source: String,
+    /// `file:line` source location of the handler, when known.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub location: Option<String>,
     /// How the classification was established. `"provable"` means it was
     /// derived from macro-expanded code (route + auth posture).
     pub provenance: &'static str,
@@ -253,6 +260,7 @@ fn build_routes_dimension(routes: &[AuditRoute]) -> RoutesDimension {
             scopes: r.scopes.clone(),
             policy: r.policy,
             source: r.source.clone(),
+            location: r.location.clone(),
             provenance: "provable",
         })
         .collect();
@@ -546,9 +554,14 @@ pub fn format_diagnostic(unresolved: &[&AuditRoute]) -> String {
             .as_deref()
             .map(|m| format!(" [{m}]"))
             .unwrap_or_default();
+        let location = r
+            .location
+            .as_deref()
+            .map(|l| format!(" at {l}"))
+            .unwrap_or_default();
         let _ = writeln!(
             out,
-            "  {method:<6} {path}  (handler `{handler}`{module})",
+            "  {method:<6} {path}  (handler `{handler}`{module}{location})",
             method = r.method,
             path = r.path,
             handler = r.handler,
@@ -686,6 +699,7 @@ mod tests {
             scopes: vec![],
             policy: false,
             module: None,
+            location: None,
         }
     }
 
@@ -745,6 +759,28 @@ mod tests {
         assert!(msg.contains("create_widget"), "{msg}");
         assert!(msg.contains("myapp::widgets"), "{msg}");
         assert!(msg.contains("#[public]"), "{msg}");
+    }
+
+    /// (#1604 deferred item) when the dump carries a `file!()`/`line!()`
+    /// source location, the diagnostic names it so an offending handler can
+    /// be jumped to directly instead of only naming its module.
+    #[test]
+    fn diagnostic_includes_source_location_when_known() {
+        let mut r = route("POST", "/widgets", "create_widget", "unclassified");
+        r.location = Some("src/routes/widgets.rs:42".to_owned());
+        let unresolved = vec![&r];
+        let msg = format_diagnostic(&unresolved);
+        assert!(msg.contains("src/routes/widgets.rs:42"), "{msg}");
+    }
+
+    /// A route dumped without a location (older binary, or a route built
+    /// without the route macros) must not print a stray `at ` fragment.
+    #[test]
+    fn diagnostic_omits_location_when_unknown() {
+        let r = route("POST", "/widgets", "create_widget", "unclassified");
+        let unresolved = vec![&r];
+        let msg = format_diagnostic(&unresolved);
+        assert!(!msg.contains(" at "), "{msg}");
     }
 
     // ── manifest shape / stability ───────────────────────────────────────────

--- a/autumn-cli/src/templates/.github/workflows/ci.yml.tmpl
+++ b/autumn-cli/src/templates/.github/workflows/ci.yml.tmpl
@@ -13,6 +13,10 @@
 # DB-dependent tests can opt in. Tests decorated `#[ignore]` are skipped by
 # default; run `cargo test -- --ignored` to include them.
 #
+# Also enforced: `autumn a11y verify` (accessibility) and
+# `autumn routes audit` (route auth-coverage security manifest), both run
+# against the prebuilt `autumn` CLI installed mid-job.
+#
 # Optional extensions (not required for green CI on a fresh scaffold):
 #   - Tailwind: add `autumn setup --tailwind` and run the downloaded binary
 #     before `cargo build` to compile CSS in CI.
@@ -78,6 +82,14 @@ jobs:
             | sh -s -- --version "v{{autumn_version}}"
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
           "$HOME/.local/bin/autumn" a11y verify .
+
+      # Route auth-coverage gate (default-deny posture, issue #1604): every
+      # mounted route must carry a proven security classification (`gated`,
+      # `public`, or framework-owned) before it merges. A route someone forgot
+      # to annotate fails the build here instead of shipping silently. Reuses
+      # the prebuilt CLI installed by the a11y step above.
+      - name: Route auth coverage (security manifest)
+        run: autumn routes audit
 
       - name: Build
         run: cargo build

--- a/autumn-cli/src/templates/main.api.rs.tmpl
+++ b/autumn-cli/src/templates/main.api.rs.tmpl
@@ -9,7 +9,12 @@ const MIGRATIONS: EmbeddedMigrations = embed_migrations!();
 // `#[derive(serde::Serialize)]` (via `autumn_web::reexports::serde`) as your
 // API grows.
 
+// `#[public]` marks each handler below deliberately unauthenticated — see
+// `autumn routes audit` / docs/guide/route-auth-coverage.md. Replace it with
+// `#[secured]`/`#[authorize]` on any route that should require a signed-in
+// user or a dynamic policy check.
 #[get("/")]
+#[public]
 async fn index() -> Json<serde_json::Value> {
     Json(serde_json::json!({
         "name": "{{project_name}}",
@@ -18,6 +23,7 @@ async fn index() -> Json<serde_json::Value> {
 }
 
 #[get("/hello/{name}")]
+#[public]
 async fn hello_name(name: autumn_web::extract::Path<String>) -> Json<serde_json::Value> {
     Json(serde_json::json!({
         "message": format!("Hello, {}!", *name),

--- a/autumn-cli/src/templates/main.rs.tmpl
+++ b/autumn-cli/src/templates/main.rs.tmpl
@@ -51,7 +51,12 @@ pub fn layout(title: &str, current_path: &str, flash: maud::Markup, content: mau
     }
 }
 
+// `#[public]` marks each handler below deliberately unauthenticated — see
+// `autumn routes audit` / docs/guide/route-auth-coverage.md. Replace it with
+// `#[secured]`/`#[authorize]` on any route that should require a signed-in
+// user or a dynamic policy check.
 #[get("/")]
+#[public]
 async fn index(flash: Flash, path: CurrentPath) -> maud::Markup {
     layout("Welcome", path.as_str(), flash_messages(&flash.consume().await), maud::html! {
         h1 { "Welcome to {{project_name}}!" }
@@ -60,11 +65,13 @@ async fn index(flash: Flash, path: CurrentPath) -> maud::Markup {
 }
 
 #[get("/hello")]
+#[public]
 async fn hello() -> &'static str {
     "Hello, Autumn!"
 }
 
 #[get("/hello/{name}")]
+#[public]
 async fn hello_name(name: autumn_web::extract::Path<String>) -> String {
     format!("Hello, {}!", *name)
 }

--- a/autumn-cli/tests/integration/cloud_native_scaffold.rs
+++ b/autumn-cli/tests/integration/cloud_native_scaffold.rs
@@ -402,6 +402,31 @@ fn ci_workflow_runs_a11y_verify() {
 }
 
 #[test]
+fn ci_workflow_runs_routes_audit() {
+    let temp_dir = scaffold("ci-routes-audit-app");
+    let project_dir = temp_dir.path().join("ci-routes-audit-app");
+    let ci = fs::read_to_string(project_dir.join(".github/workflows/ci.yml")).unwrap();
+
+    assert!(
+        ci.contains("run: autumn routes audit"),
+        "ci.yml must run `autumn routes audit` as a default-on route \
+         auth-coverage gate (#1604)"
+    );
+    // The gate must run after the CLI is installed (the a11y step's `run:`
+    // block), not require a second, separate install.
+    let a11y_pos = ci
+        .find("- name: Accessibility (a11y) verify")
+        .expect("a11y verify step present");
+    let audit_pos = ci
+        .find("run: autumn routes audit")
+        .expect("routes audit step present");
+    assert!(
+        audit_pos > a11y_pos,
+        "routes audit step must come after the CLI install (a11y step)"
+    );
+}
+
+#[test]
 fn ci_workflow_pins_msrv_toolchain() {
     let temp_dir = scaffold("ci-msrv-app");
     let project_dir = temp_dir.path().join("ci-msrv-app");

--- a/autumn-cli/tests/integration/cloud_native_scaffold.rs
+++ b/autumn-cli/tests/integration/cloud_native_scaffold.rs
@@ -426,6 +426,78 @@ fn ci_workflow_runs_routes_audit() {
     );
 }
 
+/// Patch a scaffolded project's `Cargo.toml` to build against this workspace's
+/// `autumn-web` instead of a published crates.io version, mirroring
+/// `seed_model_linking::linked_seed_binary_cargo_checks`.
+fn patch_to_local_autumn_web(project: &std::path::Path) {
+    use std::fmt::Write as _;
+
+    let cargo_toml_path = project.join("Cargo.toml");
+    let mut content = fs::read_to_string(&cargo_toml_path).unwrap();
+    let workspace_root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("workspace root");
+    let autumn_web = workspace_root.join("autumn");
+    let _ = write!(
+        content,
+        "\n[patch.crates-io]\nautumn-web = {{ path = \"{}\" }}\n",
+        autumn_web.display().to_string().replace('\\', "/")
+    );
+    fs::write(&cargo_toml_path, content).unwrap();
+}
+
+/// Regression guard for the Codex review finding on PR #2154: the audit gate
+/// wired into scaffolded CI (`ci_workflow_runs_routes_audit`) is worthless —
+/// worse, actively hostile to first-run DX — if the scaffold it gates ships
+/// with unclassified starter routes. Every fresh `autumn new` app (and
+/// `autumn new --api`) must pass `autumn routes audit` with no changes,
+/// exactly as the generated CI step will run it.
+#[test]
+#[ignore = "slow: compiles a fresh project — run with `cargo test -p autumn-cli -- --ignored`"]
+fn scaffolded_app_passes_routes_audit_gate() {
+    let temp_dir = scaffold("routes-audit-gate-app");
+    let project_dir = temp_dir.path().join("routes-audit-gate-app");
+    patch_to_local_autumn_web(&project_dir);
+
+    let autumn_bin = env!("CARGO_BIN_EXE_autumn");
+    let audit = Command::new(autumn_bin)
+        .args(["routes", "audit"])
+        .current_dir(&project_dir)
+        .output()
+        .expect("failed to run `autumn routes audit`");
+    assert!(
+        audit.status.success(),
+        "a freshly scaffolded app must pass `autumn routes audit` unmodified \
+         (every starter handler needs #[public]/#[secured]/#[authorize]):\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&audit.stdout),
+        String::from_utf8_lossy(&audit.stderr),
+    );
+}
+
+/// Same guarantee as [`scaffolded_app_passes_routes_audit_gate`], for the
+/// `--api` JSON-first starter (`main.api.rs.tmpl`), which has its own set of
+/// starter handlers.
+#[test]
+#[ignore = "slow: compiles a fresh project — run with `cargo test -p autumn-cli -- --ignored`"]
+fn scaffolded_api_app_passes_routes_audit_gate() {
+    let temp_dir = scaffold_with_flags("routes-audit-gate-api-app", &["--api"]);
+    let project_dir = temp_dir.path().join("routes-audit-gate-api-app");
+    patch_to_local_autumn_web(&project_dir);
+
+    let autumn_bin = env!("CARGO_BIN_EXE_autumn");
+    let audit = Command::new(autumn_bin)
+        .args(["routes", "audit"])
+        .current_dir(&project_dir)
+        .output()
+        .expect("failed to run `autumn routes audit`");
+    assert!(
+        audit.status.success(),
+        "a freshly scaffolded --api app must pass `autumn routes audit` unmodified:\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&audit.stdout),
+        String::from_utf8_lossy(&audit.stderr),
+    );
+}
+
 #[test]
 fn ci_workflow_pins_msrv_toolchain() {
     let temp_dir = scaffold("ci-msrv-app");

--- a/autumn-macros/src/route.rs
+++ b/autumn-macros/src/route.rs
@@ -226,6 +226,8 @@ pub fn route_macro(
                     has_policy: #has_policy_val,
                     public: #is_public,
                     module_path: ::core::module_path!(),
+                    source_file: ::core::file!(),
+                    source_line: ::core::line!(),
                     #api_doc_fields
                 },
                 repository: ::core::option::Option::None,

--- a/autumn-macros/src/static_route.rs
+++ b/autumn-macros/src/static_route.rs
@@ -224,6 +224,8 @@ pub fn static_get_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                     api_version: ::core::option::Option::None,
                     public: #is_public,
                     module_path: ::core::module_path!(),
+                    source_file: ::core::file!(),
+                    source_line: ::core::line!(),
                     ..::core::default::Default::default()
                 },
                 repository: ::core::option::Option::None,

--- a/autumn-macros/src/ws.rs
+++ b/autumn-macros/src/ws.rs
@@ -186,6 +186,8 @@ pub fn ws_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                     api_version: ::core::option::Option::None,
                     public: #is_public,
                     module_path: ::core::module_path!(),
+                    source_file: ::core::file!(),
+                    source_line: ::core::line!(),
                     ..::core::default::Default::default()
                 },
                 repository: ::core::option::Option::None,

--- a/autumn/src/openapi.rs
+++ b/autumn/src/openapi.rs
@@ -139,6 +139,14 @@ pub struct ApiDoc {
     /// definition site), used to name a route in security-audit diagnostics.
     /// Empty for routes constructed without the route macros.
     pub module_path: &'static str,
+    /// Source file of the handler (`file!()` captured at the handler's
+    /// definition site), used alongside [`Self::source_line`] to point a
+    /// security-audit diagnostic straight at the offending handler. Empty for
+    /// routes constructed without the route macros.
+    pub source_file: &'static str,
+    /// Source line of the handler (`line!()` captured at the handler's
+    /// definition site). `0` when [`Self::source_file`] is empty.
+    pub source_line: u32,
     /// True when the endpoint opts in to MCP tool exposure via
     /// `#[api_doc(mcp)]`. Opt-in is per-endpoint and never implicit.
     pub mcp_tool: bool,

--- a/autumn/src/route_listing.rs
+++ b/autumn/src/route_listing.rs
@@ -293,6 +293,11 @@ pub struct RouteInfo {
     /// route in audit diagnostics. `None` for routes without a known module.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub module: Option<String>,
+    /// `file:line` source location of the handler (from `file!()`/`line!()`),
+    /// used to point an audit diagnostic straight at the offending handler.
+    /// `None` for routes without a known location.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub location: Option<String>,
 }
 
 /// `skip_serializing_if` helper: elide `false` booleans from JSON output.
@@ -395,6 +400,16 @@ fn module_of(api_doc: &crate::openapi::ApiDoc) -> Option<String> {
     (!api_doc.module_path.is_empty()).then(|| api_doc.module_path.to_owned())
 }
 
+/// The handler's `file:line` source location, when the route macros captured
+/// one (`ApiDoc::source_file`/`ApiDoc::source_line`, from `file!()`/`line!()`
+/// at the handler's definition site). `None` for routes constructed without
+/// the route macros, so an audit diagnostic can point straight at the
+/// offending handler instead of only naming its module.
+fn source_location_of(api_doc: &crate::openapi::ApiDoc) -> Option<String> {
+    (!api_doc.source_file.is_empty())
+        .then(|| format!("{}:{}", api_doc.source_file, api_doc.source_line))
+}
+
 /// Helper type alias representing version name, status string, and sunset opt-out flag.
 type RouteVersionInfo = (Option<String>, Option<String>, Option<bool>);
 
@@ -475,6 +490,7 @@ pub fn collect_route_infos(
             scopes,
             policy,
             module: module_of(&route.api_doc),
+            location: source_location_of(&route.api_doc),
         });
     }
 
@@ -499,6 +515,7 @@ pub fn collect_route_infos(
                 scopes,
                 policy,
                 module: module_of(&route.api_doc),
+                location: source_location_of(&route.api_doc),
             });
         }
     }

--- a/docs/guide/route-auth-coverage.md
+++ b/docs/guide/route-auth-coverage.md
@@ -1,0 +1,169 @@
+# Route Auth Coverage — the Default-Deny Posture Model
+
+The most common web-security failure is not a broken guard — it's a *missing*
+one: a handler someone forgot to annotate. Autumn's `#[secured]` and
+`#[authorize]` guards are opt-in per handler, so nothing stops an unannotated
+route from shipping silently, right up until it is discovered in production,
+by an attacker, or never.
+
+`autumn routes audit` closes that gap. It classifies **every** mounted route
+at build time and fails the build when any route's exposure was never
+declared. The claim it lets you make is simple and strong: **if it compiled,
+every endpoint's exposure was declared on purpose.**
+
+## The three route kinds
+
+Every route Autumn can see falls into exactly one of three buckets. There is
+no fourth, silent, default state — a route that fits none of these is
+`unclassified`, and `unclassified` is what the audit gate fails on.
+
+| Classification | Meaning | How it's declared |
+|---|---|---|
+| **`gated`** | Guarded by authentication and/or authorization | `#[secured]`, `#[secured("role")]`, `#[authorize]`, or a `#[repository(policy = ...)]` / `scope = ...` auto-API guard |
+| **`public`** | Deliberately unauthenticated | `#[public]` |
+| **`framework`** | Owned and pre-attributed by Autumn itself | Nothing — health probes, `/actuator/*`, static assets, htmx/OpenAPI/dev-reload routes are classified for you |
+| *(none — the failure state)* | **`unclassified`** | No guard, no `#[public]`, not framework-owned |
+
+### `gated` — guarded routes
+
+Anything already carrying `#[secured]` or `#[authorize]` is `gated`
+automatically; there is nothing new to add. See the [Authorization
+guide](authorization.md) for `#[secured]` vs. `#[authorize]` vs. the `Policy`
+trait. The manifest also carries the declared roles/scopes and whether a
+dynamic policy is attached:
+
+```rust
+use autumn_web::prelude::*;
+
+#[delete("/widgets/{id}")]
+#[secured("admin")]
+async fn delete_widget(/* … */) -> AutumnResult<()> { /* … */ }
+```
+
+```json
+{ "path": "/widgets/{id}", "method": "DELETE", "classification": "gated", "roles": ["admin"] }
+```
+
+A `#[repository(api = ..., policy = ...)]` or `scope = ...` auto-API route is
+also `gated` — its guard lives on the generated CRUD handler, not on a
+`#[secured]` attribute, but the classifier knows to look there too.
+
+### `public` — deliberately open routes
+
+Use `#[public]` when a route has no guard *on purpose*. It injects no runtime
+behavior — it is a compile-time marker that records intent, nothing more:
+
+```rust
+use autumn_web::prelude::*;
+
+#[get("/health")]
+#[public]
+async fn health() -> &'static str {
+    "ok"
+}
+```
+
+Marking a route `#[public]` is exactly as effective at passing the audit gate
+as guarding it with `#[secured]` — the point isn't authentication, it's that
+*someone looked at this route and decided*.
+
+### `framework` — pre-classified by Autumn
+
+Routes the framework itself mounts (health/readiness/liveness probes,
+`/actuator/*`, static assets, htmx JS assets, OpenAPI/Swagger UI, dev
+live-reload, the mail preview UI, …) are pre-classified `framework` and never
+need an explicit declaration — they aren't part of your application's
+attack surface in the same sense, and the framework already knows what they
+are.
+
+### The failure state: `unclassified`
+
+A route with no guard, no `#[public]`, and no framework attribution is
+`unclassified`. This is the state the whole feature exists to catch:
+
+```rust
+// Compiles fine. Runs fine. Silently accepts unauthenticated requests
+// forever, because nobody decided that on purpose.
+#[post("/widgets")]
+async fn create_widget(/* … */) -> AutumnResult<()> { /* … */ }
+```
+
+`autumn routes audit` fails the build and names it:
+
+```
+✗ 1 route(s) have no proven auth posture:
+  POST   /widgets  (handler `create_widget` [myapp::widgets] at src/routes/widgets.rs:12)
+
+Add a guard (`#[secured]` / `#[authorize]`) or mark the route deliberately open with `#[public]`.
+```
+
+Fix it either way — add a guard, or add `#[public]` — and the gate goes
+green.
+
+## Running the audit
+
+```bash
+# Human-readable summary + diagnostic on failure
+autumn routes audit
+
+# Write the machine-readable manifest alongside the summary
+autumn routes audit --manifest security-manifest.json
+
+# Emit the manifest to stdout instead of the summary (for piping/scripting)
+autumn routes audit --json
+
+# In a workspace, target a specific package/bin
+autumn routes audit -p blog --bin server
+```
+
+Exit code is `0` when every route is classified, `1` otherwise — wire it into
+CI as a hard gate exactly like `cargo clippy -- -D warnings`. `autumn new`
+scaffolds this into every new project's `.github/workflows/ci.yml`
+automatically, right after the CLI install step:
+
+```yaml
+- name: Route auth coverage (security manifest)
+  run: autumn routes audit
+```
+
+Existing apps are unaffected until they add this step (or run the command
+themselves) — nothing about `#[secured]`/`#[authorize]` runtime behavior
+changes, and there is no breaking change to `autumn-web`'s published surface.
+
+### Raw `merge()`/`nest()` routers can't be proven
+
+`autumn routes audit` can only classify what it can enumerate. Routes
+mounted via `AppBuilder::merge()`/`.nest()` with a raw `axum::Router` are
+opaque — Axum exposes no API to list a router's routes — so their auth
+posture is unprovable and the gate hard-fails rather than silently omitting
+them:
+
+```
+✗ 1 raw router(s) added via `AppBuilder::merge()`/`nest()` are not enumerable
+  and were omitted from the route listing.
+Route auth coverage can't be proven while these exist. Mount routes via
+`routes![]` (or a plugin's `declare_plugin_routes`) so they are visible and
+classifiable.
+```
+
+Mount routes through `routes![]`, or — for a plugin nesting a raw router
+under a prefix — `declare_plugin_routes` so the covering declarations make
+the nest enumerable.
+
+## Reading the manifest
+
+The `routes` dimension of the emitted JSON manifest is `provenance:
+"provable"` — every classification is a direct consequence of macro-expanded
+code, not a report of configuration. See [Security Posture Manifest —
+Provenance Classes](security-posture-manifest.md) for how the `routes`,
+`csrf`, and `security_headers` dimensions are tagged, and what `declared` and
+`runtime-only` mean for the dimensions that aren't (yet) provable this way.
+
+## See also
+
+- [`autumn routes` — Route Inspection CLI](routes-cli.md) — the base
+  listing command `audit` builds on.
+- [Security Posture Manifest — Provenance Classes](security-posture-manifest.md)
+  — the manifest's provenance model in depth.
+- [Authorization](authorization.md) — `#[secured]`, `#[authorize]`, and the
+  `Policy` trait.

--- a/docs/guide/routes-cli.md
+++ b/docs/guide/routes-cli.md
@@ -176,6 +176,9 @@ documentation for those routes.
 
 ## See also
 
+- [Route Auth Coverage — the Default-Deny Posture Model](route-auth-coverage.md)
+  — the `audit` subcommand: default-deny classification, the three route
+  kinds (`gated`, `public`, `framework`), and CI wiring.
 - [Security Posture Manifest — Provenance Classes](security-posture-manifest.md)
   — how `autumn routes audit` tags each manifest dimension as `provable`,
   `declared`, or `runtime-only`.

--- a/docs/guide/security-posture-manifest.md
+++ b/docs/guide/security-posture-manifest.md
@@ -115,5 +115,8 @@ follow-up.
 
 ## See also
 
+- [Route Auth Coverage — the Default-Deny Posture Model](route-auth-coverage.md)
+  — the default-deny classification model behind the `routes` dimension, and
+  how to classify the three route kinds (`gated`, `public`, `framework`).
 - [`autumn routes` — Route Inspection CLI](routes-cli.md) — the `audit`
   subcommand that emits this manifest.

--- a/skills/routes/SKILL.md
+++ b/skills/routes/SKILL.md
@@ -86,11 +86,21 @@ On trunk-dev, `autumn routes audit` audits every route's authentication
 exposure. It prints each route's classification — `gated`, `public`,
 `framework`, or `unclassified` — and emits a stable-ordered (by path, then
 method) JSON security manifest. It exits non-zero on any `unclassified` (or
-omitted) route, so it can gate CI.
+omitted) route, so it can gate CI. `autumn new` now wires this into every
+scaffolded app's `.github/workflows/ci.yml` by default (right after the
+a11y-verify step, reusing its installed CLI), so a fresh app fails CI on day
+one if a route is left unclassified.
 
 Mark a deliberately-unauthenticated handler with the new `#[public]` attribute
 (mirrors `#[secured]`) to classify it as `public` and clear it from the
 `unclassified` set.
+
+An unclassified-route diagnostic now names the offending handler's `file:line`
+(from `file!()`/`line!()`) alongside its module, e.g. `POST /widgets (handler
+`create_widget` [myapp::widgets] at src/routes/widgets.rs:12)`, so it can be
+jumped to directly. See `docs/guide/route-auth-coverage.md` for the full
+default-deny posture model and how to classify `gated`/`public`/`framework`
+routes.
 
 ## Comparing expected vs actual routes
 


### PR DESCRIPTION
**Follow-up to #1604.** PR #1850 shipped the first slice (route classification, `#[public]` marker, `autumn routes audit`) but explicitly deferred three items. This PR closes them.

## Before / After

- **Before:** `autumn routes audit` existed but was opt-in — a new scaffolded app's CI never ran it, so "no unintentionally public endpoints" wasn't actually proven unless a developer wired the gate in themselves. An unclassified-route diagnostic named the handler's module (`module_path!()`) but not its file/line. The default-deny posture model and the three route kinds (`gated`/`public`/`framework`) had no dedicated docs page.
- **After:** every `autumn new` app ships with the audit gate in CI by default. Diagnostics point straight at the offending line. A new guide documents the model end to end.

## What's in this slice

- **CI wiring** (`autumn-cli/src/templates/.github/workflows/ci.yml.tmpl`) — a "Route auth coverage (security manifest)" step runs `autumn routes audit` right after the a11y-verify step, reusing the CLI binary that step already installs (no second install). Covered by a new `ci_workflow_runs_routes_audit` integration test.
- **`file!()`/`line!()` source locations** — `ApiDoc` gains `source_file`/`source_line`, populated by the `#[get]`/`#[post]`/… (`route.rs`), `#[ws]`, and static-route macros. `RouteInfo`/`AuditRoute`/`ManifestRoute` carry it through as `location`, and the audit diagnostic now reads:
  ```
  POST   /widgets  (handler `create_widget` [myapp::widgets] at src/routes/widgets.rs:12)
  ```
  Older dumps without the field degrade gracefully (no stray `at` fragment).
- **Docs** — new [`docs/guide/route-auth-coverage.md`](docs/guide/route-auth-coverage.md) explains the default-deny model and how to classify `gated`/`public`/`framework` routes, cross-linked from `routes-cli.md` and `security-posture-manifest.md`.

## Out of scope (kept out on purpose)

Plugin-declared route posture (`declare_plugin_routes` routes classifying `unclassified`) is **not** addressed here — issue #1604 lists it explicitly under its own "Out of Scope" section as composing with #1627/#1601, so it's left for that follow-up rather than folded in here.

## Verification

- `cargo fmt --all -- --check` — clean
- `cargo clippy -p autumn-web -p autumn-macros -p autumn-cli --all-targets -- -D warnings` — clean
- `cargo test -p autumn-web --lib` — 3986 passed
- `cargo test -p autumn-cli --bin autumn` — 4474 passed
- `cargo test -p autumn-cli --test cli_tests` — 242 passed (incl. new `ci_workflow_runs_routes_audit`)
- `./scripts/pre-push-check.sh` (full-workspace compile + doctests, per CLAUDE.md) — OK

No version bump; landed as a `CHANGELOG.md` bullet under the existing `## [Unreleased]` section.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VHALXixmutXTaHf5sfkCuX)_