### PR TITLE
feat(consent): scaffold a cookie-consent banner and consent gate in autumn new

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,9 +28,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   reader defends against cookie tossing the same way the session cookie
   reader does, and injecting the banner (which embeds a live per-visitor CSRF
   token) marks the response `Cache-Control: private, no-store` /
-  `Vary: Cookie` so it's never shared across visitors by a cache. Additive;
-  the `--api` JSON-first scaffold is unaffected (no HTML layout to show a
-  banner in).
+  `Vary: Cookie` so it's never shared across visitors by a cache. An oversized
+  HTML response is served intact rather than emptied, conditional-request
+  headers are stripped while a prompt is pending so an `EtagLayer` can't
+  short-circuit to a banner-less cached `304`, the CSRF cookie/form-field
+  names are explicit parameters (`DEFAULT_CSRF_COOKIE_NAME` /
+  `DEFAULT_CSRF_FORM_FIELD`) rather than read off request state, an internal
+  `autumn build` / ISR render is passed through untouched instead of baking
+  the banner into the static file on disk, and the banner uses
+  `position: sticky` so it always reserves its own real, responsive height
+  instead of a fixed CSS estimate. Additive; the `--api` JSON-first scaffold
+  is unaffected (no HTML layout to show a banner in).
 - **search:** a new optional plugin crate, `autumn-search`, turning the in-core
   full-text primitives (#842) into a **search subsystem**: mark a model
   searchable and get an index that stays in sync with the record lifecycle,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **consent:** `autumn new` now scaffolds a cookie-consent banner and a real
+  consent gate, so a fresh app is cookie-compliant by default (#1214). The new
+  `autumn_web::consent` module provides a `Consent` extractor
+  (`consent.allows("analytics", POLICY_VERSION)`) plus `accept_all_cookie` /
+  `reject_non_essential_cookie` builders for a first-party cookie that records
+  the chosen categories, a policy version, and a timestamp; bumping the app's
+  policy version constant invalidates prior consent and re-shows the banner.
+  The scaffolded banner (offering "Accept all" and "Reject non-essential" with
+  equal visual weight) is injected automatically into every HTML page via
+  `inject_consent_banner`, needs no JavaScript, and is wired into the base
+  `autumn new` template alongside `POST /consent/accept` /
+  `POST /consent/reject` routes (redirecting back to the referring page, not
+  always the homepage) and a `GET /consent/manage` withdrawal route linked
+  from the footer (GDPR Art. 7(3): withdrawing consent must be as easy as
+  giving it). Strictly-necessary cookies (session, CSRF) are never routed
+  through the gate — they keep being set unconditionally. The consent cookie
+  reader defends against cookie tossing the same way the session cookie
+  reader does, and injecting the banner (which embeds a live per-visitor CSRF
+  token) marks the response `Cache-Control: private, no-store` /
+  `Vary: Cookie` so it's never shared across visitors by a cache. Additive;
+  the `--api` JSON-first scaffold is unaffected (no HTML layout to show a
+  banner in).
 - **search:** a new optional plugin crate, `autumn-search`, turning the in-core
   full-text primitives (#842) into a **search subsystem**: mark a model
   searchable and get an index that stays in sync with the record lifecycle,

--- a/autumn-cli/src/new.rs
+++ b/autumn-cli/src/new.rs
@@ -1249,9 +1249,9 @@ mod tests {
         );
         assert!(
             main_rs.contains("\"/consent/manage\"")
-                && main_rs.contains("autumn_web::consent::expire_consent_cookie"),
-            "generated main.rs must scaffold a withdrawal route (GDPR Art. 7(3): \
-             withdrawing consent must be as easy as giving it): {main_rs}"
+                && main_rs.contains("autumn_web::consent::consent_banner_markup"),
+            "generated main.rs must scaffold a preferences route reusing the consent-banner \
+             widget (GDPR Art. 7(3): withdrawing consent must be as easy as giving it): {main_rs}"
         );
         assert!(
             main_rs.contains("href=\"/consent/manage\""),
@@ -1261,6 +1261,39 @@ mod tests {
         assert!(
             main_rs.contains("autumn_web::consent::DEFAULT_CSRF_COOKIE_NAME"),
             "the middleware wiring must pass the CSRF cookie name explicitly: {main_rs}"
+        );
+        assert!(
+            main_rs.contains("autumn_web::consent::DEFAULT_CSRF_FORM_FIELD"),
+            "the middleware wiring must pass the CSRF form-field name explicitly: {main_rs}"
+        );
+    }
+
+    // `/consent/manage` must stay a side-effect-free `GET`: it renders the
+    // consent-banner widget so the visitor can make a new choice, but the
+    // actual state change goes through the existing CSRF-protected
+    // `POST /consent/accept` / `POST /consent/reject` handlers. If the GET
+    // handler itself mutated the consent cookie (e.g. by calling
+    // `expire_consent_cookie` directly), a same-origin prefetcher, browser
+    // extension, or cross-site top-level navigation following the footer
+    // link could silently reset a visitor's consent, since `GET` is
+    // CSRF-exempt by definition.
+    #[test]
+    fn consent_manage_route_does_not_mutate_state_on_get() {
+        let tmp = TempDir::new().unwrap();
+        generate("consent-manage-app", tmp.path()).unwrap();
+        let main_rs =
+            fs::read_to_string(tmp.path().join("consent-manage-app/src/main.rs")).unwrap();
+        let start = main_rs
+            .find("async fn consent_manage")
+            .expect("consent_manage handler must exist");
+        let body = &main_rs[start..];
+        let end = body[1..]
+            .find("\n#[")
+            .map_or(body.len(), |offset| offset + 1);
+        let handler_body = &body[..end];
+        assert!(
+            !handler_body.contains("expire_consent_cookie") && !handler_body.contains("SET_COOKIE"),
+            "the GET /consent/manage handler must not itself set or expire any cookie: {handler_body}"
         );
     }
 

--- a/autumn-cli/src/new.rs
+++ b/autumn-cli/src/new.rs
@@ -537,8 +537,8 @@ fn replace_anchor(src: &str, from: &str, to: &str) -> String {
 fn inject_i18n(main_rs: &str) -> String {
     let with_locale = replace_anchor(
         main_rs,
-        "        .routes(routes![index, hello, hello_name])",
-        "        .i18n_auto()\n        .routes(routes![index, hello, hello_name])",
+        "        .routes(routes![index, hello, hello_name, consent_accept, consent_reject, consent_manage])",
+        "        .i18n_auto()\n        .routes(routes![index, hello, hello_name, consent_accept, consent_reject, consent_manage])",
     );
     let with_static = replace_anchor(
         &with_locale,
@@ -1214,6 +1214,100 @@ mod tests {
             p.join("tests/integration_test.rs").is_file(),
             "`autumn new` should generate tests/integration_test.rs"
         );
+    }
+
+    // `autumn new` must scaffold a working cookie-consent banner (issue
+    // #1214): a policy-version constant the app owner can bump to re-prompt,
+    // the auto-injecting middleware wired into the app, and the accept/reject
+    // routes it posts to.
+    #[test]
+    fn generates_consent_banner_wiring_in_main_rs() {
+        let tmp = TempDir::new().unwrap();
+        generate("consent-app", tmp.path()).unwrap();
+        let main_rs = fs::read_to_string(tmp.path().join("consent-app/src/main.rs")).unwrap();
+        assert!(
+            main_rs.contains("CONSENT_POLICY_VERSION"),
+            "generated main.rs must declare a bump-to-reprompt policy version constant: {main_rs}"
+        );
+        assert!(
+            main_rs.contains("autumn_web::consent::inject_consent_banner"),
+            "generated main.rs must wire the consent-banner middleware: {main_rs}"
+        );
+        assert!(
+            main_rs.contains("consent_accept") && main_rs.contains("consent_reject"),
+            "generated main.rs must define consent_accept/consent_reject routes: {main_rs}"
+        );
+        assert!(
+            main_rs.contains("\"/consent/accept\"") && main_rs.contains("\"/consent/reject\""),
+            "generated main.rs must mount the accept/reject routes at their documented paths: {main_rs}"
+        );
+        assert!(
+            main_rs.contains(
+                "routes![index, hello, hello_name, consent_accept, consent_reject, consent_manage]"
+            ),
+            "the new consent routes must be registered alongside the existing routes: {main_rs}"
+        );
+        assert!(
+            main_rs.contains("\"/consent/manage\"")
+                && main_rs.contains("autumn_web::consent::expire_consent_cookie"),
+            "generated main.rs must scaffold a withdrawal route (GDPR Art. 7(3): \
+             withdrawing consent must be as easy as giving it): {main_rs}"
+        );
+        assert!(
+            main_rs.contains("href=\"/consent/manage\""),
+            "the shared layout's footer must link to the withdrawal route so it's \
+             reachable from every page: {main_rs}"
+        );
+        assert!(
+            main_rs.contains("autumn_web::consent::DEFAULT_CSRF_COOKIE_NAME"),
+            "the middleware wiring must pass the CSRF cookie name explicitly: {main_rs}"
+        );
+    }
+
+    // The JSON-first `--api` flavor has no HTML/layout to show a banner in —
+    // it must not scaffold the consent-banner wiring at all.
+    #[test]
+    fn api_flavor_does_not_scaffold_consent_banner() {
+        let tmp = TempDir::new().unwrap();
+        generate_with(
+            "consent-api-app",
+            tmp.path(),
+            GenerateOptions {
+                with_api: true,
+                ..GenerateOptions::default()
+            },
+        )
+        .unwrap();
+        let main_rs = fs::read_to_string(tmp.path().join("consent-api-app/src/main.rs")).unwrap();
+        assert!(
+            !main_rs.contains("inject_consent_banner"),
+            "the --api flavor ships no HTML layout, so it must not scaffold the banner: {main_rs}"
+        );
+    }
+
+    // The generated `--with-i18n` main.rs must still compile-shape correctly:
+    // the i18n injection anchors must stay in sync with the new routes! list
+    // (see `inject_i18n`'s anchor constant).
+    #[test]
+    fn with_i18n_still_wires_consent_routes() {
+        let tmp = TempDir::new().unwrap();
+        generate_with(
+            "consent-i18n-app",
+            tmp.path(),
+            GenerateOptions {
+                with_i18n: true,
+                ..GenerateOptions::default()
+            },
+        )
+        .unwrap();
+        let main_rs = fs::read_to_string(tmp.path().join("consent-i18n-app/src/main.rs")).unwrap();
+        assert!(
+            main_rs.contains(
+                "routes![index, hello, hello_name, consent_accept, consent_reject, consent_manage]"
+            ),
+            "i18n injection must not drop the consent routes from the routes! list: {main_rs}"
+        );
+        assert!(main_rs.contains("i18n_auto"));
     }
 
     // The generated Cargo.toml must have [dev-dependencies] with tokio

--- a/autumn-cli/src/templates/main.rs.tmpl
+++ b/autumn-cli/src/templates/main.rs.tmpl
@@ -129,8 +129,8 @@ async fn consent_manage(
     flash: Flash,
     path: CurrentPath,
     csrf: Option<autumn_web::security::CsrfToken>,
-) -> maud::Markup {
-    layout(
+) -> impl IntoResponse {
+    let markup = layout(
         "Manage cookie preferences",
         path.as_str(),
         flash_messages(&flash.consume().await),
@@ -138,6 +138,22 @@ async fn consent_manage(
             csrf.as_ref().map(autumn_web::security::CsrfToken::token),
             autumn_web::consent::DEFAULT_CSRF_FORM_FIELD,
         ),
+    );
+    // This page embeds the visitor's own live CSRF token, so — like
+    // `inject_consent_banner`'s own injected banner — it must never be
+    // shared across visitors by a cache: a shared/public cache serving this
+    // response to someone else would leak one visitor's token to another
+    // and make every other visitor's own consent forms fail CSRF
+    // validation.
+    (
+        [
+            (
+                autumn_web::reexports::http::header::CACHE_CONTROL,
+                "private, no-store",
+            ),
+            (autumn_web::reexports::http::header::VARY, "Cookie"),
+        ],
+        markup,
     )
 }
 

--- a/autumn-cli/src/templates/main.rs.tmpl
+++ b/autumn-cli/src/templates/main.rs.tmpl
@@ -116,22 +116,28 @@ async fn consent_reject(headers: autumn_web::reexports::http::HeaderMap) -> impl
     )
 }
 
-// A plain `GET` (safe method, no CSRF token required, reachable from a
-// footer link on every page) that withdraws any recorded consent and
-// re-opens the banner so the visitor can choose again.
+// A plain `GET` (reachable from a footer link on every page) that renders a
+// preferences page reusing the consent-banner widget, so withdrawing consent
+// stays as easy as giving it (GDPR Art. 7(3)) without making the withdrawal
+// itself a bare GET: `GET` is CSRF-exempt by definition, so a same-origin
+// prefetcher, browser extension, or cross-site top-level navigation
+// following this link must not be able to silently reset consent on its own.
+// The actual state change happens through the existing CSRF-protected
+// `POST /consent/accept` / `POST /consent/reject` above.
 #[get("/consent/manage")]
-async fn consent_manage(headers: autumn_web::reexports::http::HeaderMap) -> impl IntoResponse {
-    let target = autumn_web::consent::redirect_target_from_referer(
-        headers
-            .get(autumn_web::reexports::http::header::REFERER)
-            .and_then(|v| v.to_str().ok()),
-    );
-    (
-        [(
-            autumn_web::reexports::http::header::SET_COOKIE,
-            autumn_web::consent::expire_consent_cookie(),
-        )],
-        Redirect::to(&target),
+async fn consent_manage(
+    flash: Flash,
+    path: CurrentPath,
+    csrf: Option<autumn_web::security::CsrfToken>,
+) -> maud::Markup {
+    layout(
+        "Manage cookie preferences",
+        path.as_str(),
+        flash_messages(&flash.consume().await),
+        autumn_web::consent::consent_banner_markup(
+            csrf.as_ref().map(autumn_web::security::CsrfToken::token),
+            autumn_web::consent::DEFAULT_CSRF_FORM_FIELD,
+        ),
     )
 }
 

--- a/autumn-cli/src/templates/main.rs.tmpl
+++ b/autumn-cli/src/templates/main.rs.tmpl
@@ -4,6 +4,12 @@ use autumn_web::prelude::*;
 
 const MIGRATIONS: EmbeddedMigrations = embed_migrations!();
 
+// Bump this when the cookie policy changes (e.g. a new analytics vendor is
+// added). A visitor's prior consent recorded under an older version is
+// treated as revoked — see `autumn_web::consent::Consent::needs_prompt` — so
+// the banner reappears and the gate closes until they decide again.
+const CONSENT_POLICY_VERSION: u32 = 1;
+
 // Embed the `static/` tree (and its fingerprint manifest) into the binary for
 // single-binary deploys. Active only when built with the `embed-assets` feature
 // (`autumn build --embed`); in dev the app serves from disk for hot-reload.
@@ -45,6 +51,11 @@ pub fn layout(title: &str, current_path: &str, flash: maud::Markup, content: mau
                 }
                 footer role="contentinfo" {
                     p { "Built with Autumn" }
+                    // Withdrawing consent must be as easy as giving it (GDPR
+                    // Art. 7(3)): a plain GET link (no CSRF token needed, so
+                    // it needs no per-handler wiring) that re-opens the
+                    // banner by expiring the consent cookie.
+                    p { a href="/consent/manage" { "Manage cookie preferences" } }
                 }
             }
         }
@@ -69,11 +80,77 @@ async fn hello_name(name: autumn_web::extract::Path<String>) -> String {
     format!("Hello, {}!", *name)
 }
 
+// Cookie-consent banner (issue #1214): `inject_consent_banner` (wired below)
+// shows the banner on every HTML page until one of these routes is hit. Add
+// more categories to `accept_all_cookie`'s list as the app grows non-essential
+// cookies (e.g. `&["analytics", "marketing"]`), and gate each one at its call
+// site with `consent.allows("analytics", CONSENT_POLICY_VERSION)`. Both
+// routes redirect back to the page the visitor was on (via `Referer`, kept
+// same-origin by `redirect_target_from_referer`) rather than always bouncing
+// to the homepage.
+#[post("/consent/accept")]
+async fn consent_accept(headers: axum::http::HeaderMap) -> impl IntoResponse {
+    let cookie = autumn_web::consent::accept_all_cookie(&["analytics"], CONSENT_POLICY_VERSION);
+    let target = autumn_web::consent::redirect_target_from_referer(
+        headers
+            .get(axum::http::header::REFERER)
+            .and_then(|v| v.to_str().ok()),
+    );
+    (
+        [(axum::http::header::SET_COOKIE, cookie)],
+        Redirect::to(&target),
+    )
+}
+
+#[post("/consent/reject")]
+async fn consent_reject(headers: axum::http::HeaderMap) -> impl IntoResponse {
+    let cookie = autumn_web::consent::reject_non_essential_cookie(CONSENT_POLICY_VERSION);
+    let target = autumn_web::consent::redirect_target_from_referer(
+        headers
+            .get(axum::http::header::REFERER)
+            .and_then(|v| v.to_str().ok()),
+    );
+    (
+        [(axum::http::header::SET_COOKIE, cookie)],
+        Redirect::to(&target),
+    )
+}
+
+// A plain `GET` (safe method, no CSRF token required, reachable from a
+// footer link on every page) that withdraws any recorded consent and
+// re-opens the banner so the visitor can choose again.
+#[get("/consent/manage")]
+async fn consent_manage(headers: axum::http::HeaderMap) -> impl IntoResponse {
+    let target = autumn_web::consent::redirect_target_from_referer(
+        headers
+            .get(axum::http::header::REFERER)
+            .and_then(|v| v.to_str().ok()),
+    );
+    (
+        [(
+            axum::http::header::SET_COOKIE,
+            autumn_web::consent::expire_consent_cookie(),
+        )],
+        Redirect::to(&target),
+    )
+}
+
 #[autumn_web::main]
 async fn main() {
     let app = autumn_web::app()
-        .routes(routes![index, hello, hello_name])
-        .migrations(MIGRATIONS);
+        .routes(routes![index, hello, hello_name, consent_accept, consent_reject, consent_manage])
+        .migrations(MIGRATIONS)
+        // Strictly-necessary cookies (session, CSRF) are never gated — only
+        // this banner/non-essential-category flow depends on consent.
+        .layer(axum::middleware::from_fn(move |req, next| async move {
+            autumn_web::consent::inject_consent_banner(
+                req,
+                next,
+                CONSENT_POLICY_VERSION,
+                autumn_web::consent::DEFAULT_CSRF_COOKIE_NAME,
+            )
+            .await
+        }));
 
     // Single-binary deploys: serve static assets (and i18n locales) from the
     // binary when built with `autumn build --embed`.

--- a/autumn-cli/src/templates/main.rs.tmpl
+++ b/autumn-cli/src/templates/main.rs.tmpl
@@ -89,29 +89,29 @@ async fn hello_name(name: autumn_web::extract::Path<String>) -> String {
 // same-origin by `redirect_target_from_referer`) rather than always bouncing
 // to the homepage.
 #[post("/consent/accept")]
-async fn consent_accept(headers: axum::http::HeaderMap) -> impl IntoResponse {
+async fn consent_accept(headers: autumn_web::reexports::http::HeaderMap) -> impl IntoResponse {
     let cookie = autumn_web::consent::accept_all_cookie(&["analytics"], CONSENT_POLICY_VERSION);
     let target = autumn_web::consent::redirect_target_from_referer(
         headers
-            .get(axum::http::header::REFERER)
+            .get(autumn_web::reexports::http::header::REFERER)
             .and_then(|v| v.to_str().ok()),
     );
     (
-        [(axum::http::header::SET_COOKIE, cookie)],
+        [(autumn_web::reexports::http::header::SET_COOKIE, cookie)],
         Redirect::to(&target),
     )
 }
 
 #[post("/consent/reject")]
-async fn consent_reject(headers: axum::http::HeaderMap) -> impl IntoResponse {
+async fn consent_reject(headers: autumn_web::reexports::http::HeaderMap) -> impl IntoResponse {
     let cookie = autumn_web::consent::reject_non_essential_cookie(CONSENT_POLICY_VERSION);
     let target = autumn_web::consent::redirect_target_from_referer(
         headers
-            .get(axum::http::header::REFERER)
+            .get(autumn_web::reexports::http::header::REFERER)
             .and_then(|v| v.to_str().ok()),
     );
     (
-        [(axum::http::header::SET_COOKIE, cookie)],
+        [(autumn_web::reexports::http::header::SET_COOKIE, cookie)],
         Redirect::to(&target),
     )
 }
@@ -120,15 +120,15 @@ async fn consent_reject(headers: axum::http::HeaderMap) -> impl IntoResponse {
 // footer link on every page) that withdraws any recorded consent and
 // re-opens the banner so the visitor can choose again.
 #[get("/consent/manage")]
-async fn consent_manage(headers: axum::http::HeaderMap) -> impl IntoResponse {
+async fn consent_manage(headers: autumn_web::reexports::http::HeaderMap) -> impl IntoResponse {
     let target = autumn_web::consent::redirect_target_from_referer(
         headers
-            .get(axum::http::header::REFERER)
+            .get(autumn_web::reexports::http::header::REFERER)
             .and_then(|v| v.to_str().ok()),
     );
     (
         [(
-            axum::http::header::SET_COOKIE,
+            autumn_web::reexports::http::header::SET_COOKIE,
             autumn_web::consent::expire_consent_cookie(),
         )],
         Redirect::to(&target),
@@ -142,7 +142,7 @@ async fn main() {
         .migrations(MIGRATIONS)
         // Strictly-necessary cookies (session, CSRF) are never gated — only
         // this banner/non-essential-category flow depends on consent.
-        .layer(axum::middleware::from_fn(move |req, next| async move {
+        .layer(autumn_web::reexports::axum::middleware::from_fn(move |req, next| async move {
             autumn_web::consent::inject_consent_banner(
                 req,
                 next,

--- a/autumn-cli/src/templates/main.rs.tmpl
+++ b/autumn-cli/src/templates/main.rs.tmpl
@@ -148,6 +148,7 @@ async fn main() {
                 next,
                 CONSENT_POLICY_VERSION,
                 autumn_web::consent::DEFAULT_CSRF_COOKIE_NAME,
+                autumn_web::consent::DEFAULT_CSRF_FORM_FIELD,
             )
             .await
         }));

--- a/autumn/src/consent.rs
+++ b/autumn/src/consent.rs
@@ -74,6 +74,19 @@ pub const CONSENT_COOKIE_NAME: &str = "autumn.consent";
 #[cfg(feature = "maud")]
 pub const DEFAULT_CSRF_COOKIE_NAME: &str = "autumn-csrf";
 
+/// Default CSRF form-field name, matching `security::csrf::CsrfConfig`'s own
+/// default.
+///
+/// [`inject_consent_banner`] uses this as the banner forms' hidden CSRF input
+/// name; pass the app's configured name if `security.csrf.form_field` has
+/// been customized. A request-time lookup is not an option here: the
+/// documented layer stack always places user (`AppBuilder::layer`) middleware
+/// like this one outside `CsrfLayer`, so `CsrfLayer`'s `CsrfFormField` request
+/// extension does not exist yet when this middleware's request-side code
+/// runs, and it is config-derived rather than request-derived anyway.
+#[cfg(feature = "maud")]
+pub const DEFAULT_CSRF_FORM_FIELD: &str = "_csrf";
+
 /// Category name that is always allowed by [`Consent::allows`].
 ///
 /// Strictly-necessary cookies (session, CSRF) never actually go through this

--- a/autumn/src/consent.rs
+++ b/autumn/src/consent.rs
@@ -386,19 +386,25 @@ pub fn expire_consent_cookie() -> String {
 /// path — starts with exactly one `/` (not `//`, which browsers treat as
 /// scheme-relative and will happily follow off-site), contains no `://`
 /// (defense in depth against a scheme smuggled in past the leading slash),
-/// carries no `\r`/`\n` (header-injection guard, though
-/// `HeaderValue`/`Redirect` already reject control bytes on their own), and
 /// carries no `\` — browsers using the WHATWG URL parser treat a backslash
 /// exactly like a forward slash when resolving an HTTP(S) URL, so
 /// `/\evil.example` would otherwise slip past the `//` check above and still
-/// resolve to `https://evil.example/` once a browser follows the `Location`.
+/// resolve to `https://evil.example/` once a browser follows the `Location`
+/// — and carries no ASCII control byte (`\0`-`\x1F`, `\x7F`) at all, not
+/// just `\r`/`\n`: the WHATWG URL parser strips ASCII tab and newline bytes
+/// from the whole URL before parsing continues, so `/\t/evil.example`
+/// resolves to `//evil.example` (scheme-relative) once a browser strips the
+/// embedded tab, exactly as if the tab had never been checked for at all.
+/// Rejecting the full control-byte range closes that entire class rather
+/// than reacting to each individually-discovered stripped byte in turn.
 /// Otherwise returns `"/"`.
 #[must_use]
 pub fn safe_redirect_target(path: &str) -> &str {
     let is_safe = path.starts_with('/')
         && !path.starts_with("//")
         && !path.contains("://")
-        && !path.contains(['\r', '\n', '\\']);
+        && !path.contains('\\')
+        && path.bytes().all(|b| !b.is_ascii_control());
     if is_safe { path } else { "/" }
 }
 
@@ -728,6 +734,24 @@ mod tests {
     #[test]
     fn safe_redirect_target_rejects_embedded_crlf() {
         assert_eq!(safe_redirect_target("/x\r\nSet-Cookie: pwned=1"), "/");
+    }
+
+    #[test]
+    fn safe_redirect_target_rejects_tab_based_scheme_relative_bypass() {
+        // The WHATWG URL parser strips ASCII tab/newline bytes from the
+        // whole URL before parsing continues, so `/\t/evil.example` becomes
+        // `//evil.example` (scheme-relative) once a browser strips the tab.
+        assert_eq!(safe_redirect_target("/\t/evil.example"), "/");
+    }
+
+    #[test]
+    fn safe_redirect_target_rejects_any_ascii_control_byte() {
+        // Rejecting the whole control-byte range (not just the specific
+        // bytes browsers are known to strip today) closes this class of
+        // bypass at once rather than reacting to each one individually.
+        assert_eq!(safe_redirect_target("/x\0evil"), "/");
+        assert_eq!(safe_redirect_target("/x\x0Bevil"), "/");
+        assert_eq!(safe_redirect_target("/x\x7Fevil"), "/");
     }
 
     #[test]

--- a/autumn/src/consent.rs
+++ b/autumn/src/consent.rs
@@ -386,15 +386,19 @@ pub fn expire_consent_cookie() -> String {
 /// path — starts with exactly one `/` (not `//`, which browsers treat as
 /// scheme-relative and will happily follow off-site), contains no `://`
 /// (defense in depth against a scheme smuggled in past the leading slash),
-/// and carries no `\r`/`\n` (header-injection guard, though
-/// `HeaderValue`/`Redirect` already reject control bytes on their own).
+/// carries no `\r`/`\n` (header-injection guard, though
+/// `HeaderValue`/`Redirect` already reject control bytes on their own), and
+/// carries no `\` — browsers using the WHATWG URL parser treat a backslash
+/// exactly like a forward slash when resolving an HTTP(S) URL, so
+/// `/\evil.example` would otherwise slip past the `//` check above and still
+/// resolve to `https://evil.example/` once a browser follows the `Location`.
 /// Otherwise returns `"/"`.
 #[must_use]
 pub fn safe_redirect_target(path: &str) -> &str {
     let is_safe = path.starts_with('/')
         && !path.starts_with("//")
         && !path.contains("://")
-        && !path.contains(['\r', '\n']);
+        && !path.contains(['\r', '\n', '\\']);
     if is_safe { path } else { "/" }
 }
 
@@ -724,6 +728,16 @@ mod tests {
     #[test]
     fn safe_redirect_target_rejects_embedded_crlf() {
         assert_eq!(safe_redirect_target("/x\r\nSet-Cookie: pwned=1"), "/");
+    }
+
+    #[test]
+    fn safe_redirect_target_rejects_backslash_based_scheme_relative_bypass() {
+        // Browsers using the WHATWG URL parser treat `\` exactly like `/`
+        // when resolving an HTTP(S) URL, so `/\evil.example` would otherwise
+        // slip past the plain `//` check and still resolve off-site.
+        assert_eq!(safe_redirect_target("/\\evil.example"), "/");
+        assert_eq!(safe_redirect_target("/\\\\evil.example"), "/");
+        assert_eq!(safe_redirect_target("/ok/path\\evil.example"), "/");
     }
 
     #[test]

--- a/autumn/src/consent.rs
+++ b/autumn/src/consent.rs
@@ -423,7 +423,15 @@ pub fn redirect_target_from_referer(referer: Option<&str>) -> String {
     let Some(value) = referer else {
         return "/".to_owned();
     };
-    let after_scheme = value.split("://").nth(1).unwrap_or(value);
+    // `split_once` (not `split(...).nth(1)`): a `split` iterates every
+    // occurrence of the delimiter, so a Referer whose path/query legitimately
+    // contains a second `://` (e.g. `?source=https://vendor.example/x`) would
+    // have `.nth(1)` land on the fragment between the FIRST and SECOND
+    // delimiter instead of everything after the first — truncating the
+    // target partway through an embedded URL. `split_once` only ever
+    // recognizes the first `://`, so the rest of the string (including any
+    // further `://` occurrences) survives intact as ordinary path content.
+    let after_scheme = value.split_once("://").map_or(value, |(_, rest)| rest);
     let path = after_scheme.find('/').map_or("/", |i| &after_scheme[i..]);
     safe_redirect_target(path).to_owned()
 }
@@ -794,5 +802,27 @@ mod tests {
             redirect_target_from_referer(Some("https://example.com")),
             "/"
         );
+    }
+
+    #[test]
+    fn redirect_target_from_referer_does_not_silently_accept_a_scheme_truncated_target() {
+        // A naive `split("://").nth(1)` would stop at the SECOND `://`
+        // occurrence (the one inside the query value) rather than only the
+        // first, silently truncating the target to `/docs?source=https` —
+        // which, having lost its own embedded `://`, would then sail right
+        // past `safe_redirect_target`'s unrelated "no `://` anywhere" guard
+        // and get silently accepted as a corrupted redirect target.
+        // `split_once` preserves the whole thing instead, so the candidate
+        // downstream still legitimately contains `://` and is correctly
+        // rejected by that guard, falling back to the safe "/" rather than
+        // redirecting to a mangled URL.
+        let result = redirect_target_from_referer(Some(
+            "https://app.example.com/docs?source=https://vendor.example.com/x",
+        ));
+        assert_ne!(
+            result, "/docs?source=https",
+            "must not silently truncate to (and accept) a corrupted target: {result}"
+        );
+        assert_eq!(result, "/");
     }
 }

--- a/autumn/src/consent.rs
+++ b/autumn/src/consent.rs
@@ -1,0 +1,747 @@
+//! Cookie-consent tracking and gating (ePrivacy / GDPR Art. 7).
+//!
+//! Provides the [`Consent`] extractor plus a first-party cookie codec, so an
+//! app can read a visitor's cookie-consent choice with a typed helper —
+//! `consent.allows("analytics", CURRENT_POLICY_VERSION)` — instead of hand
+//! rolling cookie parsing and a bespoke "have they agreed" check.
+//!
+//! `autumn new` scaffolds a banner (offering "Accept all" / "Reject
+//! non-essential") wired automatically into every HTML page via
+//! [`inject_consent_banner`], plus `POST /consent/accept` and
+//! `POST /consent/reject` routes that call [`accept_all_cookie`] and
+//! [`reject_non_essential_cookie`] to record the choice.
+//!
+//! ## The gate is the enforcement, not just the banner
+//!
+//! Showing a banner while setting non-essential cookies regardless of the
+//! visitor's choice is non-compliant theater. Application code that sets a
+//! non-essential cookie or injects a third-party script must check the gate
+//! first:
+//!
+//! ```rust,no_run
+//! use autumn_web::consent::Consent;
+//!
+//! const POLICY_VERSION: u32 = 1;
+//!
+//! async fn maybe_track(consent: Consent) {
+//!     if consent.allows("analytics", POLICY_VERSION) {
+//!         // set the analytics cookie / inject the tracking snippet
+//!     }
+//! }
+//! ```
+//!
+//! With no consent recorded (or a stale `policy_version`, see
+//! [`Consent::needs_prompt`]), [`Consent::allows`] returns `false` for every
+//! category except `"necessary"`.
+//!
+//! ## Strictly-necessary cookies are exempt
+//!
+//! The session cookie ([`crate::session`], default name `autumn.sid`) and the
+//! CSRF cookie ([`crate::security::csrf`], default name `autumn-csrf`) are
+//! never routed through this module's gate at all — [`crate::session::SessionLayer`]
+//! and [`crate::security::csrf::CsrfLayer`] set them unconditionally,
+//! regardless of the visitor's consent choice. Consent is not required for
+//! them (ePrivacy's "strictly necessary" exemption), and gating them would
+//! break login. `Consent::allows("necessary", _)` always returns `true` so an
+//! app can express that exemption explicitly at its own necessary-cookie call
+//! sites too, if it wants a single code path either way.
+//!
+//! ## Re-prompting on a policy change
+//!
+//! The consent cookie's payload carries the `policy_version` the visitor
+//! agreed to, alongside the chosen categories and a timestamp. Bump the
+//! app's policy version constant (passed to [`accept_all_cookie`],
+//! [`reject_non_essential_cookie`], [`Consent::allows`], and
+//! [`Consent::needs_prompt`]) when the cookie policy changes; a cookie
+//! recorded under an older version is treated as undecided, so the banner
+//! reappears and the gate closes until the visitor re-decides.
+
+use std::convert::Infallible;
+
+use axum::extract::FromRequestParts;
+use axum::http::HeaderMap;
+use axum::http::header::COOKIE;
+use axum::http::request::Parts;
+
+/// Default name of the first-party cookie recording the visitor's consent choice.
+pub const CONSENT_COOKIE_NAME: &str = "autumn.consent";
+
+/// Default CSRF cookie name, matching `security::csrf::CsrfConfig`'s own default.
+///
+/// [`inject_consent_banner`] echoes this cookie's value as the banner forms'
+/// `_csrf` field; pass the app's configured name if `security.csrf.cookie_name`
+/// has been customized.
+#[cfg(feature = "maud")]
+pub const DEFAULT_CSRF_COOKIE_NAME: &str = "autumn-csrf";
+
+/// Category name that is always allowed by [`Consent::allows`].
+///
+/// Strictly-necessary cookies (session, CSRF) never actually go through this
+/// gate — see the module docs — but an app can use this constant at its own
+/// necessary-cookie call sites for a single, symmetric code path.
+pub const NECESSARY: &str = "necessary";
+
+/// Max age applied to the consent cookie by [`accept_all_cookie`] and
+/// [`reject_non_essential_cookie`]: 180 days, within common regulatory
+/// guidance (no longer than 12 months) for a consent-decision cookie.
+const MAX_AGE_SECS: u64 = 180 * 24 * 60 * 60;
+
+/// The current visitor's recorded (or not-yet-recorded) cookie-consent choice.
+///
+/// Obtained via the [`FromRequestParts`] extractor — take `consent: Consent`
+/// as a handler parameter. Reads directly off the request's `Cookie` header;
+/// no middleware or app state is required to use it.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct Consent {
+    categories: Vec<String>,
+    policy_version: u32,
+    decided_at: Option<String>,
+}
+
+impl Consent {
+    /// A visitor who has not yet recorded any consent choice.
+    #[must_use]
+    pub fn undecided() -> Self {
+        Self::default()
+    }
+
+    /// `true` once the visitor has recorded a choice (accepted or rejected),
+    /// regardless of whether that choice is still current — see
+    /// [`Consent::needs_prompt`] for the version-aware check.
+    #[must_use]
+    pub const fn is_decided(&self) -> bool {
+        self.decided_at.is_some()
+    }
+
+    /// The policy version the visitor's recorded choice was made under.
+    /// `0` when undecided.
+    #[must_use]
+    pub const fn policy_version(&self) -> u32 {
+        self.policy_version
+    }
+
+    /// RFC 3339 timestamp of when the choice was recorded, if any.
+    #[must_use]
+    pub fn decided_at(&self) -> Option<&str> {
+        self.decided_at.as_deref()
+    }
+
+    /// The categories the visitor consented to. Empty for an undecided or
+    /// reject-all visitor.
+    #[must_use]
+    pub fn categories(&self) -> &[String] {
+        &self.categories
+    }
+
+    /// Whether the given category is allowed to run.
+    ///
+    /// `"necessary"` (see [`NECESSARY`]) is always allowed. Every other
+    /// category requires: a recorded decision, matching `current_policy_version`
+    /// (an older-version decision is treated as revoked — see
+    /// [`Consent::needs_prompt`]), and the category being in the visitor's
+    /// accepted list.
+    #[must_use]
+    pub fn allows(&self, category: &str, current_policy_version: u32) -> bool {
+        if category == NECESSARY {
+            return true;
+        }
+        self.is_decided()
+            && self.policy_version == current_policy_version
+            && self.categories.iter().any(|c| c == category)
+    }
+
+    /// Whether the consent banner should be (re-)shown: no decision recorded
+    /// yet, or the recorded decision was made under an older policy version.
+    #[must_use]
+    pub const fn needs_prompt(&self, current_policy_version: u32) -> bool {
+        !self.is_decided() || self.policy_version != current_policy_version
+    }
+
+    /// Parse a raw cookie value (already extracted from the `Cookie` header)
+    /// into a decided [`Consent`]. Returns `None` for a missing, malformed, or
+    /// unparseable value — callers should fall back to [`Consent::undecided`].
+    fn from_cookie_value(raw: &str) -> Option<Self> {
+        let decoded = percent_decode(raw)?;
+        let mut parts = decoded.splitn(3, '|');
+        let version: u32 = parts.next()?.parse().ok()?;
+        let decided_at = parts.next()?;
+        if decided_at.is_empty() || chrono::DateTime::parse_from_rfc3339(decided_at).is_err() {
+            return None;
+        }
+        let categories_field = parts.next().unwrap_or("");
+        let categories = if categories_field.is_empty() {
+            Vec::new()
+        } else {
+            categories_field
+                .split(',')
+                .map(str::to_owned)
+                .collect::<Vec<_>>()
+        };
+        Some(Self {
+            categories,
+            policy_version: version,
+            decided_at: Some(decided_at.to_owned()),
+        })
+    }
+
+    /// Build a [`Consent`] directly from request headers, without requiring
+    /// the [`FromRequestParts`] extractor machinery. Used by the extractor
+    /// impl and by [`inject_consent_banner`] (which needs to inspect consent
+    /// before the response exists).
+    #[must_use]
+    pub fn from_headers(headers: &HeaderMap) -> Self {
+        find_cookie(headers, CONSENT_COOKIE_NAME)
+            .and_then(|raw| Self::from_cookie_value(&raw))
+            .unwrap_or_default()
+    }
+}
+
+impl<S> FromRequestParts<S> for Consent
+where
+    S: Send + Sync,
+{
+    type Rejection = Infallible;
+
+    async fn from_request_parts(parts: &mut Parts, _state: &S) -> Result<Self, Self::Rejection> {
+        Ok(Self::from_headers(&parts.headers))
+    }
+}
+
+/// Find a named cookie's raw value in the `Cookie` request header.
+///
+/// A malformed pair (no `=`) is skipped rather than aborting the whole scan —
+/// a stray valueless cookie sent by some other script on the same site must
+/// not make every other cookie on the request invisible. Mirrors
+/// [`crate::session::get_cookie`]'s cookie-tossing defense: if `name` appears
+/// more than once, that is treated as an attack signal (a legitimate client
+/// only ever sends one), and `None` is returned rather than picking either.
+pub(crate) fn find_cookie(headers: &HeaderMap, name: &str) -> Option<String> {
+    let mut found = None;
+    for cookie_header in headers.get_all(COOKIE) {
+        let Ok(cookie_str) = cookie_header.to_str() else {
+            continue;
+        };
+        for pair in cookie_str.split(';') {
+            let pair = pair.trim();
+            let Some((k, v)) = pair.split_once('=') else {
+                continue;
+            };
+            if k.trim() != name {
+                continue;
+            }
+            if found.is_some() {
+                // Multiple cookies with the same name: possible cookie
+                // tossing. Reject rather than guess which one is genuine.
+                return None;
+            }
+            found = Some(v.trim().to_owned());
+        }
+    }
+    found
+}
+
+// ── Cookie value codec ──────────────────────────────────────────
+//
+// Payload format (before percent-encoding): `{policy_version}|{decided_at}|{categories}`
+// where `categories` is a comma-joined list (empty string when none). The
+// whole payload is percent-encoded so `|`, `,`, and RFC 3339's `:`/`+` never
+// reach the raw cookie value (mirrors `crate::i18n`'s locale cookie encoding).
+
+fn encode_cookie_value(policy_version: u32, decided_at: &str, categories: &[&str]) -> String {
+    let payload = format!("{policy_version}|{decided_at}|{}", categories.join(","));
+    percent_encode(&payload)
+}
+
+fn percent_encode(value: &str) -> String {
+    let mut out = String::with_capacity(value.len());
+    for byte in value.bytes() {
+        if is_unreserved_byte(byte) {
+            out.push(char::from(byte));
+        } else {
+            push_percent_encoded(&mut out, byte);
+        }
+    }
+    out
+}
+
+fn percent_decode(value: &str) -> Option<String> {
+    let bytes = value.as_bytes();
+    let mut out = Vec::with_capacity(bytes.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'%' {
+            let hi = hex_value(*bytes.get(i + 1)?)?;
+            let lo = hex_value(*bytes.get(i + 2)?)?;
+            out.push((hi << 4) | lo);
+            i += 3;
+        } else {
+            out.push(bytes[i]);
+            i += 1;
+        }
+    }
+    String::from_utf8(out).ok()
+}
+
+const fn is_unreserved_byte(byte: u8) -> bool {
+    byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.')
+}
+
+fn push_percent_encoded(output: &mut String, byte: u8) {
+    const HEX: &[u8; 16] = b"0123456789ABCDEF";
+    output.push('%');
+    output.push(char::from(HEX[(byte >> 4) as usize]));
+    output.push(char::from(HEX[(byte & 0x0f) as usize]));
+}
+
+const fn hex_value(byte: u8) -> Option<u8> {
+    match byte {
+        b'0'..=b'9' => Some(byte - b'0'),
+        b'a'..=b'f' => Some(byte - b'a' + 10),
+        b'A'..=b'F' => Some(byte - b'A' + 10),
+        _ => None,
+    }
+}
+
+/// Build a `Set-Cookie` header value recording that the visitor accepted the
+/// given non-essential categories under `policy_version`.
+///
+/// # Examples
+///
+/// ```rust
+/// use autumn_web::consent::accept_all_cookie;
+///
+/// let cookie = accept_all_cookie(&["analytics"], 1);
+/// assert!(cookie.starts_with("autumn.consent="));
+/// assert!(cookie.contains("HttpOnly"));
+/// ```
+#[must_use]
+pub fn accept_all_cookie(categories: &[&str], policy_version: u32) -> String {
+    build_consent_cookie(categories, policy_version)
+}
+
+/// Build a `Set-Cookie` header value recording that the visitor rejected all
+/// non-essential categories under `policy_version`.
+///
+/// # Examples
+///
+/// ```rust
+/// use autumn_web::consent::reject_non_essential_cookie;
+///
+/// let cookie = reject_non_essential_cookie(1);
+/// assert!(cookie.starts_with("autumn.consent="));
+/// ```
+#[must_use]
+pub fn reject_non_essential_cookie(policy_version: u32) -> String {
+    build_consent_cookie(&[], policy_version)
+}
+
+fn build_consent_cookie(categories: &[&str], policy_version: u32) -> String {
+    let decided_at = chrono::Utc::now().to_rfc3339();
+    let value = encode_cookie_value(policy_version, &decided_at, categories);
+    format!(
+        "{CONSENT_COOKIE_NAME}={value}; Path=/; Max-Age={MAX_AGE_SECS}; HttpOnly; Secure; SameSite=Lax"
+    )
+}
+
+/// Build a `Set-Cookie` header value that expires the consent cookie
+/// immediately, returning the visitor to an undecided state so the banner
+/// reappears and they can choose again.
+///
+/// GDPR Art. 7(3) requires withdrawing consent to be as easy as giving it;
+/// wire this to a visible, always-reachable "manage cookie preferences"
+/// link (the scaffold adds one to the shared layout's footer) rather than
+/// only ever showing the choice once.
+///
+/// # Examples
+///
+/// ```rust
+/// use autumn_web::consent::expire_consent_cookie;
+///
+/// let cookie = expire_consent_cookie();
+/// assert!(cookie.starts_with("autumn.consent="));
+/// assert!(cookie.contains("Max-Age=0"));
+/// ```
+#[must_use]
+pub fn expire_consent_cookie() -> String {
+    format!("{CONSENT_COOKIE_NAME}=; Path=/; Max-Age=0; HttpOnly; Secure; SameSite=Lax")
+}
+
+/// Validate a redirect target that came from client-controlled input (a
+/// `Referer` header, a form field), guarding against an open redirect.
+///
+/// Returns `path` unchanged when it looks like a safe same-origin relative
+/// path — starts with exactly one `/` (not `//`, which browsers treat as
+/// scheme-relative and will happily follow off-site), contains no `://`
+/// (defense in depth against a scheme smuggled in past the leading slash),
+/// and carries no `\r`/`\n` (header-injection guard, though
+/// `HeaderValue`/`Redirect` already reject control bytes on their own).
+/// Otherwise returns `"/"`.
+#[must_use]
+pub fn safe_redirect_target(path: &str) -> &str {
+    let is_safe = path.starts_with('/')
+        && !path.starts_with("//")
+        && !path.contains("://")
+        && !path.contains(['\r', '\n']);
+    if is_safe { path } else { "/" }
+}
+
+/// Derive a safe same-origin redirect target from a `Referer` header value,
+/// falling back to `/` when the header is absent, unparseable, or the value
+/// has no path at all.
+///
+/// Used by the scaffolded `/consent/accept` and `/consent/reject` routes so
+/// recording a choice returns the visitor to the page they were on instead of
+/// always bouncing to the homepage. The scheme and host are discarded
+/// entirely (not merely checked) before the result ever reaches
+/// [`safe_redirect_target`], so this can never redirect off-site regardless
+/// of what a forged `Referer` claims.
+#[must_use]
+pub fn redirect_target_from_referer(referer: Option<&str>) -> String {
+    let Some(value) = referer else {
+        return "/".to_owned();
+    };
+    let after_scheme = value.split("://").nth(1).unwrap_or(value);
+    let path = after_scheme.find('/').map_or("/", |i| &after_scheme[i..]);
+    safe_redirect_target(path).to_owned()
+}
+
+#[cfg(feature = "maud")]
+mod banner;
+#[cfg(feature = "maud")]
+pub use banner::{consent_banner_markup, inject_consent_banner};
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::http::HeaderValue;
+
+    fn headers_with_cookie(raw: &str) -> HeaderMap {
+        let mut headers = HeaderMap::new();
+        headers.insert(COOKIE, HeaderValue::from_str(raw).unwrap());
+        headers
+    }
+
+    // ── Consent::undecided / defaults ──────────────────────────────
+
+    #[test]
+    fn undecided_is_not_decided() {
+        let consent = Consent::undecided();
+        assert!(!consent.is_decided());
+        assert_eq!(consent.policy_version(), 0);
+        assert_eq!(consent.decided_at(), None);
+        assert!(consent.categories().is_empty());
+    }
+
+    #[test]
+    fn from_headers_with_no_cookie_header_is_undecided() {
+        let consent = Consent::from_headers(&HeaderMap::new());
+        assert!(!consent.is_decided());
+    }
+
+    #[test]
+    fn from_headers_with_unrelated_cookies_is_undecided() {
+        let headers = headers_with_cookie("autumn.sid=abc123; theme=dark");
+        let consent = Consent::from_headers(&headers);
+        assert!(!consent.is_decided());
+    }
+
+    // A stray valueless cookie pair (no `=`) sent by some other script on the
+    // same site must not blind the parser to every cookie after it.
+    #[test]
+    fn malformed_pair_before_target_cookie_does_not_hide_it() {
+        let headers = headers_with_cookie("junk; autumn.sid=abc123");
+        assert_eq!(find_cookie(&headers, "autumn.sid"), Some("abc123".into()));
+    }
+
+    #[test]
+    fn duplicate_consent_cookie_is_rejected_as_possible_tossing() {
+        let headers = headers_with_cookie("autumn.consent=aaa; autumn.consent=bbb");
+        assert_eq!(find_cookie(&headers, "autumn.consent"), None);
+        let consent = Consent::from_headers(&headers);
+        assert!(
+            !consent.is_decided(),
+            "ambiguous duplicate cookie must not be trusted"
+        );
+    }
+
+    // ── necessary category is always allowed ───────────────────────
+
+    #[test]
+    fn necessary_category_always_allowed_even_when_undecided() {
+        let consent = Consent::undecided();
+        assert!(consent.allows(NECESSARY, 1));
+    }
+
+    #[test]
+    fn non_necessary_category_denied_when_undecided() {
+        let consent = Consent::undecided();
+        assert!(!consent.allows("analytics", 1));
+        assert!(!consent.allows("marketing", 1));
+    }
+
+    // ── accept-all round trip ───────────────────────────────────────
+
+    #[test]
+    fn accept_all_cookie_round_trips_and_allows_category() {
+        let set_cookie = accept_all_cookie(&["analytics", "marketing"], 1);
+        let raw_value = set_cookie
+            .split(';')
+            .next()
+            .unwrap()
+            .strip_prefix("autumn.consent=")
+            .unwrap();
+        let headers = headers_with_cookie(&format!("autumn.consent={raw_value}"));
+        let consent = Consent::from_headers(&headers);
+
+        assert!(consent.is_decided());
+        assert_eq!(consent.policy_version(), 1);
+        assert!(consent.allows("analytics", 1));
+        assert!(consent.allows("marketing", 1));
+        assert!(consent.allows(NECESSARY, 1));
+        assert!(!consent.allows("unrelated-category", 1));
+        assert!(consent.decided_at().is_some());
+    }
+
+    #[test]
+    fn accept_all_cookie_has_expected_attributes() {
+        let cookie = accept_all_cookie(&["analytics"], 1);
+        assert!(cookie.starts_with("autumn.consent="));
+        assert!(cookie.contains("Path=/"));
+        assert!(cookie.contains("HttpOnly"));
+        assert!(cookie.contains("Secure"));
+        assert!(cookie.contains("SameSite=Lax"));
+        assert!(cookie.contains(&format!("Max-Age={MAX_AGE_SECS}")));
+    }
+
+    // ── reject-non-essential round trip ─────────────────────────────
+
+    #[test]
+    fn reject_non_essential_cookie_round_trips_and_denies_categories() {
+        let set_cookie = reject_non_essential_cookie(1);
+        let raw_value = set_cookie
+            .split(';')
+            .next()
+            .unwrap()
+            .strip_prefix("autumn.consent=")
+            .unwrap();
+        let headers = headers_with_cookie(&format!("autumn.consent={raw_value}"));
+        let consent = Consent::from_headers(&headers);
+
+        assert!(
+            consent.is_decided(),
+            "reject is still a recorded decision, not undecided"
+        );
+        assert!(!consent.allows("analytics", 1));
+        assert!(consent.allows(NECESSARY, 1), "necessary always allowed");
+        assert!(consent.categories().is_empty());
+    }
+
+    // ── withdrawal (expire_consent_cookie) ───────────────────────────
+
+    #[test]
+    fn expire_consent_cookie_has_zero_max_age() {
+        let cookie = expire_consent_cookie();
+        assert!(cookie.starts_with("autumn.consent="));
+        assert!(cookie.contains("Max-Age=0"));
+    }
+
+    #[test]
+    fn expiring_a_prior_accept_returns_to_undecided_and_reopens_the_gate() {
+        // A visitor previously accepted analytics...
+        let accept = accept_all_cookie(&["analytics"], 1);
+        let raw_accept = accept
+            .split(';')
+            .next()
+            .unwrap()
+            .strip_prefix("autumn.consent=")
+            .unwrap();
+        let decided = Consent::from_headers(&headers_with_cookie(&format!(
+            "autumn.consent={raw_accept}"
+        )));
+        assert!(decided.allows("analytics", 1));
+
+        // ...then withdraws via "manage cookie preferences": the browser
+        // drops the expired cookie, so the next request carries none at all.
+        let expired = expire_consent_cookie();
+        assert!(
+            expired.contains("Max-Age=0"),
+            "confirms the cookie a browser would discard"
+        );
+        let withdrawn = Consent::from_headers(&HeaderMap::new());
+        assert!(!withdrawn.is_decided());
+        assert!(!withdrawn.allows("analytics", 1));
+        assert!(withdrawn.needs_prompt(1), "banner must reappear");
+    }
+
+    // ── needs_prompt: undecided and version staleness ───────────────
+
+    #[test]
+    fn needs_prompt_true_when_undecided() {
+        assert!(Consent::undecided().needs_prompt(1));
+    }
+
+    #[test]
+    fn needs_prompt_false_when_decided_under_current_version() {
+        let headers = decided_headers(&["analytics"], 1);
+        let consent = Consent::from_headers(&headers);
+        assert!(!consent.needs_prompt(1));
+    }
+
+    #[test]
+    fn needs_prompt_true_after_policy_version_bump() {
+        let headers = decided_headers(&["analytics"], 1);
+        let consent = Consent::from_headers(&headers);
+        // The app bumped its policy version from 1 to 2.
+        assert!(consent.needs_prompt(2));
+    }
+
+    #[test]
+    fn allows_denies_category_after_policy_version_bump_even_if_previously_accepted() {
+        let headers = decided_headers(&["analytics"], 1);
+        let consent = Consent::from_headers(&headers);
+        assert!(consent.allows("analytics", 1));
+        // Re-prompt is not just cosmetic: the gate itself closes under the new version.
+        assert!(!consent.allows("analytics", 2));
+        // ...but necessary is still exempt regardless of version.
+        assert!(consent.allows(NECESSARY, 2));
+    }
+
+    fn decided_headers(categories: &[&str], policy_version: u32) -> HeaderMap {
+        let set_cookie = accept_all_cookie(categories, policy_version);
+        let raw_value = set_cookie
+            .split(';')
+            .next()
+            .unwrap()
+            .strip_prefix("autumn.consent=")
+            .unwrap();
+        headers_with_cookie(&format!("autumn.consent={raw_value}"))
+    }
+
+    // ── malformed cookie values are treated as undecided ────────────
+
+    #[test]
+    fn malformed_cookie_value_is_undecided_not_a_panic() {
+        for bogus in [
+            "not-percent-encoded-but-fine-chars",
+            "1",
+            "1|",
+            "%zz",
+            "",
+            "abc|2024-01-01T00:00:00Z|analytics",
+        ] {
+            let headers = headers_with_cookie(&format!("autumn.consent={bogus}"));
+            let consent = Consent::from_headers(&headers);
+            assert!(
+                !consent.is_decided(),
+                "bogus value {bogus:?} must decode to undecided, not panic"
+            );
+        }
+    }
+
+    #[test]
+    fn cookie_with_invalid_timestamp_is_undecided() {
+        let value = percent_encode("1|not-a-timestamp|analytics");
+        let headers = headers_with_cookie(&format!("autumn.consent={value}"));
+        let consent = Consent::from_headers(&headers);
+        assert!(!consent.is_decided());
+    }
+
+    // ── strictly-necessary cookies are untouched by this module ─────
+
+    #[test]
+    fn session_and_csrf_cookies_survive_alongside_an_undecided_consent() {
+        // Simulates a request that already carries the session + CSRF cookies
+        // (set unconditionally by SessionLayer / CsrfLayer) but has never
+        // recorded a consent choice. This module must not need or touch those
+        // cookies at all — it only ever reads its own cookie name.
+        let headers = headers_with_cookie("autumn.sid=session-value; autumn-csrf=csrf-value");
+        let consent = Consent::from_headers(&headers);
+        assert!(!consent.is_decided());
+        assert!(consent.allows(NECESSARY, 1));
+    }
+
+    // ── percent encode/decode round trip ─────────────────────────────
+
+    #[test]
+    fn percent_encode_decode_round_trips_reserved_characters() {
+        let original = "1|2024-01-01T00:00:00+00:00|analytics,marketing";
+        let encoded = percent_encode(original);
+        assert!(!encoded.contains('|'), "pipe must be encoded: {encoded}");
+        assert!(!encoded.contains(':'), "colon must be encoded: {encoded}");
+        assert_eq!(percent_decode(&encoded).unwrap(), original);
+    }
+
+    #[test]
+    fn percent_decode_rejects_truncated_escape() {
+        assert_eq!(percent_decode("%4"), None);
+        assert_eq!(percent_decode("%"), None);
+    }
+
+    #[test]
+    fn percent_decode_rejects_invalid_hex() {
+        assert_eq!(percent_decode("%zz"), None);
+    }
+
+    // ── safe_redirect_target / redirect_target_from_referer ─────────
+
+    #[test]
+    fn safe_redirect_target_allows_plain_relative_path() {
+        assert_eq!(safe_redirect_target("/blog/post-1"), "/blog/post-1");
+        assert_eq!(safe_redirect_target("/"), "/");
+        assert_eq!(safe_redirect_target("/a?b=c"), "/a?b=c");
+    }
+
+    #[test]
+    fn safe_redirect_target_rejects_scheme_relative_open_redirect() {
+        assert_eq!(safe_redirect_target("//evil.example.com"), "/");
+    }
+
+    #[test]
+    fn safe_redirect_target_rejects_absolute_url() {
+        assert_eq!(safe_redirect_target("https://evil.example.com"), "/");
+        assert_eq!(safe_redirect_target("javascript://alert(1)"), "/");
+    }
+
+    #[test]
+    fn safe_redirect_target_rejects_missing_leading_slash() {
+        assert_eq!(safe_redirect_target("evil.example.com"), "/");
+        assert_eq!(safe_redirect_target(""), "/");
+    }
+
+    #[test]
+    fn safe_redirect_target_rejects_embedded_crlf() {
+        assert_eq!(safe_redirect_target("/x\r\nSet-Cookie: pwned=1"), "/");
+    }
+
+    #[test]
+    fn redirect_target_from_referer_extracts_path_and_query() {
+        assert_eq!(
+            redirect_target_from_referer(Some("https://app.example.com/blog/post-1?x=1")),
+            "/blog/post-1?x=1"
+        );
+    }
+
+    #[test]
+    fn redirect_target_from_referer_falls_back_to_root_when_absent() {
+        assert_eq!(redirect_target_from_referer(None), "/");
+    }
+
+    #[test]
+    fn redirect_target_from_referer_discards_scheme_and_host_entirely() {
+        // Even a maliciously-crafted Referer cannot smuggle an off-site
+        // target through, because the scheme+host are split off and
+        // discarded before any safety check runs.
+        assert_eq!(
+            redirect_target_from_referer(Some("https://good.example.com//evil.example.com")),
+            "/"
+        );
+    }
+
+    #[test]
+    fn redirect_target_from_referer_falls_back_when_no_path_present() {
+        assert_eq!(
+            redirect_target_from_referer(Some("https://example.com")),
+            "/"
+        );
+    }
+}

--- a/autumn/src/consent.rs
+++ b/autumn/src/consent.rs
@@ -37,9 +37,9 @@
 //! ## Strictly-necessary cookies are exempt
 //!
 //! The session cookie ([`crate::session`], default name `autumn.sid`) and the
-//! CSRF cookie ([`crate::security::csrf`], default name `autumn-csrf`) are
+//! CSRF cookie (`security::csrf`, default name `autumn-csrf`) are
 //! never routed through this module's gate at all — [`crate::session::SessionLayer`]
-//! and [`crate::security::csrf::CsrfLayer`] set them unconditionally,
+//! and [`crate::security::CsrfLayer`] set them unconditionally,
 //! regardless of the visitor's consent choice. Consent is not required for
 //! them (ePrivacy's "strictly necessary" exemption), and gating them would
 //! break login. `Consent::allows("necessary", _)` always returns `true` so an

--- a/autumn/src/consent/banner.rs
+++ b/autumn/src/consent/banner.rs
@@ -305,24 +305,60 @@ async fn splice_into_response(response: Response<Body>, snippet: &str) -> Respon
 
 /// Insert `snippet` just before the last `</body>` tag, or append it if the
 /// document has an `<html>`/`</html>` shell but no `</body>`. Leaves `body`
-/// unchanged if neither is present (mirrors
-/// `crate::middleware::dev::inject_snippet`).
+/// unchanged if neither is present.
+///
+/// Operates directly on the raw bytes rather than decoding through
+/// `String::from_utf8_lossy`: an HTML page using a legacy single-byte charset
+/// (e.g. ISO-8859-1) is not valid UTF-8, and lossy-decoding it would silently
+/// replace those bytes with U+FFFD, corrupting page content while its
+/// `<meta charset>` declaration kept claiming the original encoding. Tag
+/// matching is ASCII case-insensitive (`<HTML><BODY>...` is exactly as valid
+/// HTML as lowercase), which a byte-for-byte comparison must do explicitly.
+/// `snippet` is always plain ASCII-safe markup, so splicing it in at an
+/// ASCII tag's byte offset can never straddle a multi-byte UTF-8 sequence.
 fn splice_before_body_close(body: &[u8], snippet: &str) -> Vec<u8> {
-    let html = String::from_utf8_lossy(body);
-
-    if let Some(index) = html.rfind("</body>") {
-        let mut html = html.into_owned();
-        html.insert_str(index, snippet);
-        return html.into_bytes();
+    if let Some(index) = rfind_ascii_case_insensitive(body, b"</body>") {
+        let mut out = Vec::with_capacity(body.len() + snippet.len());
+        out.extend_from_slice(&body[..index]);
+        out.extend_from_slice(snippet.as_bytes());
+        out.extend_from_slice(&body[index..]);
+        return out;
     }
 
-    if html.contains("<html") || html.contains("</html>") {
-        let mut html = html.into_owned();
-        html.push_str(snippet);
-        return html.into_bytes();
+    if contains_ascii_case_insensitive(body, b"<html")
+        || contains_ascii_case_insensitive(body, b"</html>")
+    {
+        let mut out = body.to_vec();
+        out.extend_from_slice(snippet.as_bytes());
+        return out;
     }
 
     body.to_vec()
+}
+
+/// Byte offset of the last case-insensitive (ASCII-only) match of `needle`
+/// in `haystack`. See [`splice_before_body_close`] for why this operates on
+/// raw bytes instead of a decoded `&str`.
+fn rfind_ascii_case_insensitive(haystack: &[u8], needle: &[u8]) -> Option<usize> {
+    if needle.is_empty() || haystack.len() < needle.len() {
+        return None;
+    }
+    (0..=haystack.len() - needle.len())
+        .rev()
+        .find(|&i| haystack[i..i + needle.len()].eq_ignore_ascii_case(needle))
+}
+
+/// Whether `haystack` contains a case-insensitive (ASCII-only) match of
+/// `needle` anywhere.
+fn contains_ascii_case_insensitive(haystack: &[u8], needle: &[u8]) -> bool {
+    if needle.is_empty() {
+        return true;
+    }
+    if haystack.len() < needle.len() {
+        return false;
+    }
+    (0..=haystack.len() - needle.len())
+        .any(|i| haystack[i..i + needle.len()].eq_ignore_ascii_case(needle))
 }
 
 #[cfg(test)]
@@ -404,6 +440,41 @@ mod tests {
     fn splice_leaves_non_html_untouched() {
         let out = splice_before_body_close(b"not html at all", "<snip>");
         assert_eq!(out, b"not html at all");
+    }
+
+    #[test]
+    fn splice_matches_uppercase_and_mixed_case_tags() {
+        let out = splice_before_body_close(b"<HTML><BODY><main>ok</main></BODY></HTML>", "<snip>");
+        let s = String::from_utf8(out).unwrap();
+        assert!(
+            s.contains("<snip></BODY>"),
+            "an uppercase `</BODY>` is exactly as valid HTML as lowercase: {s}"
+        );
+    }
+
+    #[test]
+    fn splice_appends_when_only_uppercase_html_shell_present() {
+        let out = splice_before_body_close(b"<HTML><main>ok</main></HTML>", "<snip>");
+        let s = String::from_utf8(out).unwrap();
+        assert!(s.ends_with("<snip>"), "{s}");
+    }
+
+    #[test]
+    fn splice_preserves_non_utf8_bytes_in_a_legacy_charset_document() {
+        // A byte sequence that is not valid UTF-8 (0xE9 alone is an ISO-8859-1
+        // 'é', but an invalid/incomplete UTF-8 sequence on its own).
+        // `String::from_utf8_lossy` would replace it with U+FFFD; this must
+        // pass it through byte-for-byte instead, since the raw bytes are
+        // spliced around, never decoded.
+        let mut body = b"<html><body>caf\xE9".to_vec();
+        body.extend_from_slice(b"</body></html>");
+        let out = splice_before_body_close(&body, "<snip>");
+        let out_str = String::from_utf8_lossy(&out);
+        assert!(
+            out.windows(4).any(|w| w == b"caf\xE9"),
+            "non-UTF-8 bytes must survive splicing untouched, not become U+FFFD: {out_str}"
+        );
+        assert!(out_str.contains("<snip></body>"));
     }
 
     // ── is_html_response ────────────────────────────────────────────

--- a/autumn/src/consent/banner.rs
+++ b/autumn/src/consent/banner.rs
@@ -14,10 +14,9 @@ use axum::http::header::{
     CACHE_CONTROL, CONTENT_ENCODING, CONTENT_LENGTH, CONTENT_TYPE, IF_MODIFIED_SINCE,
     IF_NONE_MATCH, SET_COOKIE, VARY,
 };
-use axum::http::{HeaderName, HeaderValue, Request, Response};
+use axum::http::{HeaderValue, Request, Response};
 use axum::middleware::Next;
 use futures::StreamExt as _;
-use maud::PreEscaped;
 
 use super::{Consent, find_cookie};
 
@@ -32,17 +31,6 @@ use super::{Consent, find_cookie};
 /// A body over this cap is served **unmodified** (see [`collect_body_prefix`])
 /// rather than dropped — a large page without the banner beats an empty one.
 const MAX_SPLICE_BODY_BYTES: usize = 2 * 1024 * 1024;
-
-/// Bare CSS for [`BANNER_SPACE_RESERVATION_CSS`]'s `<style>` element — reserves
-/// room at the bottom of the viewport so the fixed-position banner never
-/// permanently hides page content (e.g. a `<footer>`) underneath it. Emitted
-/// only alongside the banner itself, so it never affects layout once consent
-/// has been decided. Uses an inline `<style>` tag rather than a JS height
-/// measurement, matching `crate::error_pages::dev_badge`'s own
-/// inline-CSS-only convention; carries the request's CSP nonce (see
-/// [`inject_consent_banner`]) so it isn't dropped under
-/// `security.headers.csp_nonce.enabled = true`.
-const BANNER_SPACE_RESERVATION_CSS: &str = "body{padding-bottom:6.5rem}";
 
 /// Render the consent-banner markup.
 ///
@@ -59,17 +47,10 @@ const BANNER_SPACE_RESERVATION_CSS: &str = "body{padding-bottom:6.5rem}";
 /// it's configured under — see `security.csrf.cookie_name`); pass `None`
 /// only when CSRF protection is disabled entirely. `csrf_field_name` is the
 /// form field the token is submitted under — `"_csrf"` unless the app
-/// customized `security.csrf.form_field`. `nonce` is the request's CSP nonce
-/// (see `security.headers.csp_nonce`) applied to the reservation `<style>`;
-/// pass `None` when CSP nonces are disabled (the default).
+/// customized `security.csrf.form_field`.
 #[must_use]
-pub fn consent_banner_markup(
-    csrf_token: Option<&str>,
-    csrf_field_name: &str,
-    nonce: Option<&str>,
-) -> maud::Markup {
+pub fn consent_banner_markup(csrf_token: Option<&str>, csrf_field_name: &str) -> maud::Markup {
     maud::html! {
-        style nonce=[nonce] { (PreEscaped(BANNER_SPACE_RESERVATION_CSS)) }
         section class="autumn-consent-banner" role="region" aria-label="Cookie consent" {
             p class="autumn-consent-banner__message" {
                 "This site uses cookies. Strictly-necessary cookies (login, security) are always on. "
@@ -115,27 +96,39 @@ pub fn consent_banner_markup(
 ///             next,
 ///             CONSENT_POLICY_VERSION,
 ///             autumn_web::consent::DEFAULT_CSRF_COOKIE_NAME,
+///             autumn_web::consent::DEFAULT_CSRF_FORM_FIELD,
 ///         ).await
 ///     }));
 /// ```
 ///
 /// Reads the visitor's consent cookie and the CSRF cookie directly off the
 /// incoming request's `Cookie` header before calling `next`, so it has no
-/// dependency on where `CsrfLayer` sits in the layer stack. Non-HTML and
+/// dependency on where `CsrfLayer` sits in the layer stack. `csrf_form_field`
+/// is likewise taken as an explicit parameter rather than read from a
+/// `CsrfFormField` request extension: the documented layer stack always
+/// places user (`AppBuilder::layer`) middleware like this one outside
+/// `CsrfLayer`, so that extension does not exist yet on the request side —
+/// pass `security.csrf.form_field`'s configured value (or
+/// [`super::DEFAULT_CSRF_FORM_FIELD`] if unconfigured). Non-HTML and
 /// `Content-Encoding`-bearing responses (compressed bodies) pass through
 /// untouched, exactly like the dev-mode live-reload injector.
+///
+/// An internal `autumn build` / ISR background-regeneration render — tagged
+/// with a [`crate::static_gen::RenderDeadlineExempt`] request extension, per
+/// that type's own docs — is passed through untouched without even
+/// evaluating consent state: these renders have no real visitor and no
+/// consent cookie, so injecting here would bake a banner (and a
+/// build-time-only CSRF token) directly into the static HTML file written to
+/// `dist/`. Every future visitor, including ones who have already consented,
+/// would then receive that frozen-in-time banner forever, since it becomes
+/// literal page content rather than something this middleware could
+/// conditionally show or hide again at request time.
 ///
 /// Also, while a visitor needs (re-)prompting: strips `If-None-Match` /
 /// `If-Modified-Since` from the request before calling `next`, so an inner
 /// `EtagLayer` can't short-circuit to a bodyless `304` — which would replay a
 /// browser-cached, banner-less page and silently skip the required prompt
-/// after a policy bump or a withdrawn consent. And reads the CSRF form-field
-/// name (`security.csrf.form_field`, via `CsrfFormField` in request
-/// extensions) and the CSP nonce (`security.headers.csp_nonce`, via
-/// `CspNonce` in request extensions, or parsed back out of the response's
-/// `Content-Security-Policy` header if `CspNonce` wasn't already in request
-/// extensions when this ran) so the injected banner and its style stay valid
-/// under those configurations too.
+/// after a policy bump or a withdrawn consent.
 ///
 /// Whenever it actually injects the banner (and therefore a live, per-visitor
 /// CSRF token) into the body, it also stamps the response
@@ -143,22 +136,36 @@ pub fn consent_banner_markup(
 /// the app marked publicly cacheable (e.g. via `cache_for(..).public()`)
 /// could have one visitor's CSRF token served to every other visitor (and
 /// any CDN/proxy in between) until the cache entry expires.
+///
+/// # Known limitation: `#[static_get]` pages and CSRF
+///
+/// A first-time visitor whose very first hit lands on a pre-rendered
+/// `#[static_get]` page is served that page by the static-first middleware
+/// before the dynamic router (and therefore `CsrfLayer`) ever runs, so no
+/// CSRF cookie exists yet. This middleware then has no token to embed in the
+/// banner's hidden field, and the resulting `/consent/accept` /
+/// `/consent/reject` submission is rejected by `CsrfLayer` with a `403`. This
+/// does not affect the default `autumn new` scaffold (which has no
+/// `#[static_get]` routes); an app that adds one should exempt its consent
+/// routes' path prefix, or route visitors through a dynamic page at least
+/// once before relying on the static-served banner's buttons.
 pub async fn inject_consent_banner(
     mut request: Request<Body>,
     next: Next,
     policy_version: u32,
     csrf_cookie_name: &str,
+    csrf_form_field: &str,
 ) -> Response<Body> {
+    if request
+        .extensions()
+        .get::<crate::static_gen::RenderDeadlineExempt>()
+        .is_some()
+    {
+        return next.run(request).await;
+    }
+
     let consent = Consent::from_headers(request.headers());
     let request_csrf_cookie = find_cookie(request.headers(), csrf_cookie_name);
-    let csrf_field_name = request
-        .extensions()
-        .get::<crate::security::CsrfFormField>()
-        .map_or_else(|| "_csrf".to_owned(), |field| field.0.clone());
-    let request_nonce = request
-        .extensions()
-        .get::<crate::security::CspNonce>()
-        .map(|nonce| nonce.value().to_owned());
 
     let needs_prompt = consent.needs_prompt(policy_version);
     if needs_prompt {
@@ -174,26 +181,8 @@ pub async fn inject_consent_banner(
 
     let csrf_token =
         extract_response_csrf_cookie(&response, csrf_cookie_name).or(request_csrf_cookie);
-    let nonce = request_nonce.or_else(|| extract_response_csp_nonce(&response));
-    let banner_html =
-        consent_banner_markup(csrf_token.as_deref(), &csrf_field_name, nonce.as_deref())
-            .into_string();
+    let banner_html = consent_banner_markup(csrf_token.as_deref(), csrf_form_field).into_string();
     splice_into_response(response, &banner_html).await
-}
-
-/// Recover the per-request CSP nonce from the response's
-/// `Content-Security-Policy` header, for when `CspNonce` wasn't yet in
-/// request extensions (i.e. `SecurityHeadersLayer` sits inner to this
-/// middleware rather than outer). Mirrors the same `'nonce-...'` extraction
-/// the framework's own tests use.
-fn extract_response_csp_nonce(response: &Response<Body>) -> Option<String> {
-    response
-        .headers()
-        .get(HeaderName::from_static("content-security-policy"))
-        .and_then(|value| value.to_str().ok())
-        .and_then(|csp| csp.split("'nonce-").nth(1))
-        .and_then(|rest| rest.split('\'').next())
-        .map(str::to_owned)
 }
 
 /// Find a fresh CSRF cookie value the wrapped handler's response is about to
@@ -348,14 +337,14 @@ mod tests {
 
     #[test]
     fn banner_has_accessible_region_and_label() {
-        let html = consent_banner_markup(None, "_csrf", None).into_string();
+        let html = consent_banner_markup(None, "_csrf").into_string();
         assert!(html.contains(r#"role="region""#));
         assert!(html.contains(r#"aria-label="Cookie consent""#));
     }
 
     #[test]
     fn banner_reject_and_accept_share_the_same_base_button_class() {
-        let html = consent_banner_markup(None, "_csrf", None).into_string();
+        let html = consent_banner_markup(None, "_csrf").into_string();
         // Reject-as-easy-as-accept: both are `type="submit"` sharing the base
         // `autumn-consent-banner__button` class — neither gets a differently
         // weighted/emphasized class the other lacks.
@@ -371,26 +360,26 @@ mod tests {
 
     #[test]
     fn banner_omits_csrf_field_when_no_token_given() {
-        let html = consent_banner_markup(None, "_csrf", None).into_string();
+        let html = consent_banner_markup(None, "_csrf").into_string();
         assert!(!html.contains("_csrf"));
     }
 
     #[test]
     fn banner_includes_csrf_hidden_field_when_token_given() {
-        let html = consent_banner_markup(Some("tok-123"), "_csrf", None).into_string();
+        let html = consent_banner_markup(Some("tok-123"), "_csrf").into_string();
         assert!(html.contains(r#"name="_csrf""#));
         assert!(html.contains(r#"value="tok-123""#));
     }
 
     #[test]
     fn banner_needs_no_script_tag() {
-        let html = consent_banner_markup(Some("tok"), "_csrf", None).into_string();
+        let html = consent_banner_markup(Some("tok"), "_csrf").into_string();
         assert!(!html.contains("<script"), "banner must need no JS: {html}");
     }
 
     #[test]
     fn banner_buttons_are_keyboard_reachable_native_submit_buttons() {
-        let html = consent_banner_markup(None, "_csrf", None).into_string();
+        let html = consent_banner_markup(None, "_csrf").into_string();
         assert!(html.contains(r#"type="submit""#));
         assert!(!html.contains("tabindex=\"-1\""));
     }
@@ -499,7 +488,7 @@ mod tests {
         Router::new()
             .route("/", get(|| async { html_page() }))
             .layer(axum::middleware::from_fn(move |req, next| async move {
-                inject_consent_banner(req, next, version, "autumn-csrf").await
+                inject_consent_banner(req, next, version, "autumn-csrf", "_csrf").await
             }))
     }
 
@@ -530,7 +519,7 @@ mod tests {
             Router::new()
                 .route("/", get(handler))
                 .layer(axum::middleware::from_fn(move |req, next| async move {
-                    inject_consent_banner(req, next, POLICY_VERSION, "autumn-csrf").await
+                    inject_consent_banner(req, next, POLICY_VERSION, "autumn-csrf", "_csrf").await
                 }))
                 .layer(SessionLayer::new(
                     MemoryStore::new(),
@@ -675,7 +664,7 @@ mod tests {
                 get(|| async { ([(CONTENT_TYPE, "application/json")], r#"{"status":"ok"}"#) }),
             )
             .layer(axum::middleware::from_fn(move |req, next| async move {
-                inject_consent_banner(req, next, 1, "autumn-csrf").await
+                inject_consent_banner(req, next, 1, "autumn-csrf", "_csrf").await
             }));
         let response = app
             .oneshot(Request::builder().uri("/api").body(Body::empty()).unwrap())
@@ -702,7 +691,7 @@ mod tests {
                 }),
             )
             .layer(axum::middleware::from_fn(move |req, next| async move {
-                inject_consent_banner(req, next, 1, "autumn-csrf").await
+                inject_consent_banner(req, next, 1, "autumn-csrf", "_csrf").await
             }));
         let response = app
             .oneshot(Request::builder().uri("/").body(Body::empty()).unwrap())
@@ -807,7 +796,7 @@ mod tests {
                 }),
             )
             .layer(axum::middleware::from_fn(move |req, next| async move {
-                inject_consent_banner(req, next, 1, "autumn-csrf").await
+                inject_consent_banner(req, next, 1, "autumn-csrf", "_csrf").await
             }));
         let response = app
             .oneshot(Request::builder().uri("/").body(Body::empty()).unwrap())
@@ -843,7 +832,7 @@ mod tests {
                 }),
             )
             .layer(axum::middleware::from_fn(move |req, next| async move {
-                inject_consent_banner(req, next, 1, "my-csrf").await
+                inject_consent_banner(req, next, 1, "my-csrf", "_csrf").await
             }));
         let response = app
             .oneshot(Request::builder().uri("/").body(Body::empty()).unwrap())
@@ -859,49 +848,39 @@ mod tests {
         );
     }
 
-    #[test]
-    fn banner_reserves_space_for_fixed_positioning_so_it_cannot_permanently_hide_content() {
-        let html = consent_banner_markup(None, "_csrf", None).into_string();
-        assert!(
-            html.contains("padding-bottom"),
-            "banner must reserve viewport space so a fixed-position banner \
-             doesn't permanently cover page content like a footer: {html}"
-        );
-    }
-
     // ── configured CSRF form-field name ──────────────────────────────
 
     #[test]
     fn banner_uses_default_csrf_field_name() {
-        let html = consent_banner_markup(Some("tok"), "_csrf", None).into_string();
+        let html = consent_banner_markup(Some("tok"), "_csrf").into_string();
         assert!(html.contains(r#"name="_csrf""#));
     }
 
     #[test]
     fn banner_honors_custom_csrf_field_name() {
-        let html = consent_banner_markup(Some("tok"), "authenticity_token", None).into_string();
+        let html = consent_banner_markup(Some("tok"), "authenticity_token").into_string();
         assert!(html.contains(r#"name="authenticity_token""#));
         assert!(!html.contains(r#"name="_csrf""#));
     }
 
     #[tokio::test]
-    async fn banner_honors_configured_csrf_form_field_name_from_request_extensions() {
+    async fn banner_honors_configured_csrf_form_field_name_end_to_end() {
+        // The form-field name is config-derived, not request-derived (see
+        // `inject_consent_banner`'s doc: `CsrfLayer` sits inner to user
+        // layers, so a `CsrfFormField` request extension is never visible
+        // here) -- so it must be threaded in as an explicit parameter, not
+        // read back off the request or response.
         let app = Router::new()
             .route("/", get(|| async { html_page() }))
             .layer(axum::middleware::from_fn(move |req, next| async move {
-                inject_consent_banner(req, next, 1, "autumn-csrf").await
+                inject_consent_banner(req, next, 1, "autumn-csrf", "authenticity_token").await
             }));
 
-        let mut request = Request::builder()
+        let request = Request::builder()
             .uri("/")
             .header("cookie", "autumn-csrf=tok-abc")
             .body(Body::empty())
             .unwrap();
-        request
-            .extensions_mut()
-            .insert(crate::security::CsrfFormField(
-                "authenticity_token".to_owned(),
-            ));
 
         let response = app.oneshot(request).await.unwrap();
         let body = axum::body::to_bytes(response.into_body(), usize::MAX)
@@ -913,138 +892,6 @@ mod tests {
             "{html}"
         );
         assert!(!html.contains(r#"name="_csrf""#), "{html}");
-    }
-
-    // ── CSP nonce ─────────────────────────────────────────────────────
-
-    #[test]
-    fn extract_response_csp_nonce_parses_nonce_from_header() {
-        let response = Response::builder()
-            .header(
-                "content-security-policy",
-                "script-src 'self' 'nonce-abc123'; style-src 'self' 'nonce-abc123'",
-            )
-            .body(Body::empty())
-            .unwrap();
-        assert_eq!(
-            extract_response_csp_nonce(&response),
-            Some("abc123".to_owned())
-        );
-    }
-
-    #[test]
-    fn extract_response_csp_nonce_none_when_header_absent() {
-        let response = Response::builder().body(Body::empty()).unwrap();
-        assert_eq!(extract_response_csp_nonce(&response), None);
-    }
-
-    #[test]
-    fn banner_style_omits_nonce_attribute_when_none() {
-        let html = consent_banner_markup(None, "_csrf", None).into_string();
-        assert!(!html.contains("nonce="), "{html}");
-    }
-
-    #[test]
-    fn banner_style_carries_nonce_when_given() {
-        let html = consent_banner_markup(None, "_csrf", Some("abc123")).into_string();
-        assert!(html.contains(r#"<style nonce="abc123">"#), "{html}");
-    }
-
-    #[tokio::test]
-    async fn banner_nonce_matches_a_real_security_headers_layer_via_request_extensions() {
-        // My middleware runs INNER to `SecurityHeadersLayer` here (it's applied
-        // last, so it wraps outermost), meaning by the time my middleware
-        // reads request extensions, `SecurityHeadersLayer` has already
-        // inserted `CspNonce` on the way in — the primary (request-extension)
-        // resolution path.
-        use crate::security::{CspNonceConfig, HeadersConfig, SecurityHeadersLayer};
-
-        let headers_config = HeadersConfig {
-            csp_nonce: CspNonceConfig { enabled: true },
-            ..HeadersConfig::default()
-        };
-
-        let app = Router::new()
-            .route("/", get(|| async { html_page() }))
-            .layer(axum::middleware::from_fn(move |req, next| async move {
-                inject_consent_banner(req, next, 1, "autumn-csrf").await
-            }))
-            .layer(SecurityHeadersLayer::from_config(&headers_config));
-
-        let response = app
-            .oneshot(Request::builder().uri("/").body(Body::empty()).unwrap())
-            .await
-            .unwrap();
-
-        let csp = response
-            .headers()
-            .get("content-security-policy")
-            .and_then(|v| v.to_str().ok())
-            .expect("CSP header must be set")
-            .to_owned();
-        let nonce = csp
-            .split("'nonce-")
-            .nth(1)
-            .and_then(|rest| rest.split('\'').next())
-            .expect("CSP header must advertise a nonce")
-            .to_owned();
-
-        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
-            .await
-            .unwrap();
-        let html = String::from_utf8(body.to_vec()).unwrap();
-        assert!(
-            html.contains(&format!(r#"nonce="{nonce}""#)),
-            "banner's <style> must carry the same nonce as the response's CSP header: {html}"
-        );
-    }
-
-    #[tokio::test]
-    async fn banner_nonce_falls_back_to_response_header_when_layer_runs_after() {
-        // Here `SecurityHeadersLayer` is applied FIRST (innermost), so my
-        // middleware — outermost — sees no `CspNonce` in request extensions
-        // yet when it runs; it must fall back to parsing the nonce back out
-        // of the response's `Content-Security-Policy` header.
-        use crate::security::{CspNonceConfig, HeadersConfig, SecurityHeadersLayer};
-
-        let headers_config = HeadersConfig {
-            csp_nonce: CspNonceConfig { enabled: true },
-            ..HeadersConfig::default()
-        };
-
-        let app = Router::new()
-            .route("/", get(|| async { html_page() }))
-            .layer(SecurityHeadersLayer::from_config(&headers_config))
-            .layer(axum::middleware::from_fn(move |req, next| async move {
-                inject_consent_banner(req, next, 1, "autumn-csrf").await
-            }));
-
-        let response = app
-            .oneshot(Request::builder().uri("/").body(Body::empty()).unwrap())
-            .await
-            .unwrap();
-
-        let csp = response
-            .headers()
-            .get("content-security-policy")
-            .and_then(|v| v.to_str().ok())
-            .expect("CSP header must be set")
-            .to_owned();
-        let nonce = csp
-            .split("'nonce-")
-            .nth(1)
-            .and_then(|rest| rest.split('\'').next())
-            .expect("CSP header must advertise a nonce")
-            .to_owned();
-
-        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
-            .await
-            .unwrap();
-        let html = String::from_utf8(body.to_vec()).unwrap();
-        assert!(
-            html.contains(&format!(r#"nonce="{nonce}""#)),
-            "banner's <style> must carry the nonce recovered from the CSP header: {html}"
-        );
     }
 
     // ── conditional-request headers stripped while prompting ─────────
@@ -1066,7 +913,7 @@ mod tests {
                 }),
             )
             .layer(axum::middleware::from_fn(move |req, next| async move {
-                inject_consent_banner(req, next, 1, "autumn-csrf").await
+                inject_consent_banner(req, next, 1, "autumn-csrf", "_csrf").await
             }));
 
         let response = app
@@ -1107,7 +954,7 @@ mod tests {
                 }),
             )
             .layer(axum::middleware::from_fn(move |req, next| async move {
-                inject_consent_banner(req, next, 1, "autumn-csrf").await
+                inject_consent_banner(req, next, 1, "autumn-csrf", "_csrf").await
             }));
 
         let cookie = super::super::accept_all_cookie(&["analytics"], 1);
@@ -1135,6 +982,43 @@ mod tests {
         assert!(
             text.contains("inm=true"),
             "no need to force-bust caching when the banner won't show anyway: {text}"
+        );
+    }
+
+    // ── build/ISR internal renders are exempt ─────────────────────────
+
+    #[tokio::test]
+    async fn skips_injection_entirely_for_a_render_deadline_exempt_request() {
+        // `RenderDeadlineExempt` marks an internal `autumn build` / ISR
+        // background-regeneration render, driven directly via `oneshot` with
+        // no real visitor and no consent cookie. Injecting the banner here
+        // would bake it (plus a build-time-only CSRF token) into the static
+        // HTML file written to `dist/`, and every future visitor -- including
+        // ones who have already consented -- would then receive that frozen
+        // banner forever, since it becomes literal page content this
+        // middleware can no longer conditionally hide. A live inbound request
+        // never carries this marker, so this exemption cannot be reached by
+        // an ordinary visitor.
+        let app = Router::new()
+            .route("/", get(|| async { html_page() }))
+            .layer(axum::middleware::from_fn(move |req, next| async move {
+                inject_consent_banner(req, next, 1, "autumn-csrf", "_csrf").await
+            }));
+
+        let request = Request::builder()
+            .uri("/")
+            .extension(crate::static_gen::RenderDeadlineExempt)
+            .body(Body::empty())
+            .unwrap();
+
+        let response = app.oneshot(request).await.unwrap();
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let html = String::from_utf8(body.to_vec()).unwrap();
+        assert!(
+            !html.contains("autumn-consent-banner"),
+            "an internal build/ISR render must never have the banner baked in: {html}"
         );
     }
 }

--- a/autumn/src/consent/banner.rs
+++ b/autumn/src/consent/banner.rs
@@ -32,6 +32,25 @@ use super::{Consent, find_cookie};
 /// rather than dropped — a large page without the banner beats an empty one.
 const MAX_SPLICE_BODY_BYTES: usize = 2 * 1024 * 1024;
 
+/// The literal opening tag [`consent_banner_markup`] always renders for its
+/// outermost `<section>`, used by [`inject_consent_banner`] to detect
+/// whether a handler already rendered the banner itself before splicing in
+/// another copy.
+///
+/// Deliberately the *entire* opening tag rather than just the
+/// `autumn-consent-banner` class name: ordinary page content (documentation
+/// mentioning the class, or user-authored text containing that identifier)
+/// could plausibly contain the bare class name, which would wrongly be
+/// treated as an already-rendered banner and silently skip a required
+/// prompt. Reproducing this whole tag verbatim, byte-for-byte, is not
+/// something incidental prose does.
+///
+/// Must be kept in sync with `consent_banner_markup`'s `section` line — a
+/// test (`rendered_banner_carries_the_detection_marker_verbatim`) asserts
+/// this rather than relying on the two staying in sync by hand.
+const RENDERED_BANNER_MARKER: &str =
+    r#"<section class="autumn-consent-banner" role="region" aria-label="Cookie consent">"#;
+
 /// Render the consent-banner markup.
 ///
 /// Offers "Reject non-essential" and "Accept all" as two `type="submit"`
@@ -286,9 +305,11 @@ async fn splice_into_response(response: Response<Body>, snippet: &str) -> Respon
             // already rendered the banner widget itself to let an
             // already-decided visitor change their choice. Splicing another
             // copy in here would give that response two identical forms —
-            // check for the marker class this middleware's own markup always
-            // carries rather than assuming any particular route.
-            if contains_ascii_case_insensitive(&bytes, b"autumn-consent-banner") {
+            // check for the literal rendered marker (see
+            // `RENDERED_BANNER_MARKER`'s doc for why the whole opening tag,
+            // not just the bare class name) rather than assuming any
+            // particular route.
+            if contains_ascii_case_insensitive(&bytes, RENDERED_BANNER_MARKER.as_bytes()) {
                 return Response::from_parts(parts, Body::from(bytes));
             }
 
@@ -935,11 +956,47 @@ mod tests {
             .route(
                 "/",
                 get(|| async {
+                    let banner = consent_banner_markup(None, "_csrf").into_string();
+                    Response::builder()
+                        .header(CONTENT_TYPE, "text/html; charset=utf-8")
+                        .body(Body::from(format!("<html><body>{banner}</body></html>")))
+                        .unwrap()
+                }),
+            )
+            .layer(axum::middleware::from_fn(move |req, next| async move {
+                inject_consent_banner(req, next, 1, "autumn-csrf", "_csrf").await
+            }));
+        let response = app
+            .oneshot(Request::builder().uri("/").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let html = String::from_utf8(body.to_vec()).unwrap();
+        assert_eq!(
+            html.matches(RENDERED_BANNER_MARKER).count(),
+            1,
+            "must not splice a second banner when the response already contains one: {html}"
+        );
+    }
+
+    #[tokio::test]
+    async fn still_injects_when_page_merely_mentions_the_banner_class_in_prose() {
+        // Documentation or user-authored content mentioning the
+        // `autumn-consent-banner` class name in passing (without actually
+        // rendering the widget's specific opening tag) must NOT be mistaken
+        // for an already-rendered banner — that would silently withhold the
+        // required prompt from an undecided visitor.
+        let app = Router::new()
+            .route(
+                "/",
+                get(|| async {
                     Response::builder()
                         .header(CONTENT_TYPE, "text/html; charset=utf-8")
                         .body(Body::from(
-                            "<html><body><section class=\"autumn-consent-banner\">already \
-                             here</section></body></html>"
+                            "<html><body><p>Style the banner via the \
+                             <code>autumn-consent-banner</code> class.</p></body></html>"
                                 .to_owned(),
                         ))
                         .unwrap()
@@ -956,10 +1013,19 @@ mod tests {
             .await
             .unwrap();
         let html = String::from_utf8(body.to_vec()).unwrap();
-        assert_eq!(
-            html.matches("autumn-consent-banner").count(),
-            1,
-            "must not splice a second banner when the response already contains one: {html}"
+        assert!(
+            html.contains(RENDERED_BANNER_MARKER),
+            "an undecided visitor must still get a real, rendered prompt: {html}"
+        );
+    }
+
+    #[test]
+    fn rendered_banner_carries_the_detection_marker_verbatim() {
+        let html = consent_banner_markup(None, "_csrf").into_string();
+        assert!(
+            html.contains(RENDERED_BANNER_MARKER),
+            "RENDERED_BANNER_MARKER must be kept in sync with consent_banner_markup's \
+             actual rendered output: {html}"
         );
     }
 

--- a/autumn/src/consent/banner.rs
+++ b/autumn/src/consent/banner.rs
@@ -173,6 +173,23 @@ pub fn consent_banner_markup(csrf_token: Option<&str>, csrf_field_name: &str) ->
 /// `#[static_get]` routes); an app that adds one should exempt its consent
 /// routes' path prefix, or route visitors through a dynamic page at least
 /// once before relying on the static-served banner's buttons.
+///
+/// # Known limitation: no true streaming for an undecided visitor
+///
+/// Deliberately mirroring `crate::middleware::dev::inject_live_reload`'s
+/// own buffer-then-splice design (see the module docs), this middleware
+/// waits for the *entire* HTML body (up to `MAX_SPLICE_BODY_BYTES`) before
+/// sending any bytes to the client, rather than forwarding chunks as they
+/// arrive. A page that streams progressively (or simply takes a long time to
+/// fully render) therefore loses that streaming behavior for any visitor who
+/// still needs prompting — the visitor sees nothing until the handler
+/// finishes, even though the eventual response comfortably fits the cap.
+/// True incremental splicing would require scanning the stream chunk-by-chunk
+/// for `</body>` without buffering it whole; that is a meaningfully more
+/// complex streaming transform than this scaffold's cookie-consent banner
+/// warrants, so — like the buffer-then-splice dev-mode injector it mirrors —
+/// it is accepted as a tradeoff for a large majority of ordinary pages rather
+/// than solved here.
 pub async fn inject_consent_banner(
     mut request: Request<Body>,
     next: Next,
@@ -238,7 +255,9 @@ fn is_html_response(response: &Response<Body>) -> bool {
         .headers()
         .get(CONTENT_TYPE)
         .and_then(|value| value.to_str().ok())
-        .is_some_and(|content_type| content_type.contains("text/html"))
+        // HTTP media-type tokens are case-insensitive (RFC 9110 8.3.1) — a
+        // handler returning `Text/HTML` is exactly as valid as `text/html`.
+        .is_some_and(|content_type| content_type.to_ascii_lowercase().contains("text/html"))
 }
 
 /// Outcome of bounding how much of a body [`collect_body_prefix`] buffers.
@@ -540,6 +559,16 @@ mod tests {
     fn html_response_detected_by_content_type() {
         let response = Response::builder()
             .header(CONTENT_TYPE, "text/html; charset=utf-8")
+            .body(Body::empty())
+            .unwrap();
+        assert!(is_html_response(&response));
+    }
+
+    #[test]
+    fn html_response_detected_regardless_of_media_type_case() {
+        // HTTP media-type tokens are case-insensitive (RFC 9110 8.3.1).
+        let response = Response::builder()
+            .header(CONTENT_TYPE, "Text/HTML; charset=utf-8")
             .body(Body::empty())
             .unwrap();
         assert!(is_html_response(&response));

--- a/autumn/src/consent/banner.rs
+++ b/autumn/src/consent/banner.rs
@@ -137,6 +137,11 @@ pub fn consent_banner_markup(csrf_token: Option<&str>, csrf_field_name: &str) ->
 /// could have one visitor's CSRF token served to every other visitor (and
 /// any CDN/proxy in between) until the cache entry expires.
 ///
+/// If the response already contains the banner's own marker class (e.g. a
+/// "manage cookie preferences" handler rendered [`consent_banner_markup`]
+/// itself so an already-decided visitor can change their choice), this
+/// middleware skips injection rather than adding a second, identical copy.
+///
 /// # Known limitation: `#[static_get]` pages and CSRF
 ///
 /// A first-time visitor whose very first hit lands on a pre-rendered
@@ -231,9 +236,12 @@ enum CollectedBody {
     /// body (finding `</body>` would require buffering arbitrarily more), so
     /// unlike the CSRF version there is no separate scan-prefix to return.
     Oversized(Body),
-    /// The body stream errored before EOF. The bytes read so far are
-    /// discarded.
-    Errored,
+    /// The body stream errored before EOF. Carries the bytes read so far and
+    /// the underlying error, so the caller can replay the prefix and then
+    /// end the reconstructed body with the same error — an honest abnormal
+    /// close — rather than silently discarding everything and returning a
+    /// well-formed, misleadingly-complete-looking empty response.
+    Errored { prefix: Bytes, error: axum::Error },
 }
 
 /// Buffer `body` up to `limit` bytes without failing when the body is larger,
@@ -246,7 +254,12 @@ async fn collect_body_prefix(body: Body, limit: usize) -> CollectedBody {
     loop {
         match stream.next().await {
             None => break,
-            Some(Err(_)) => return CollectedBody::Errored,
+            Some(Err(error)) => {
+                return CollectedBody::Errored {
+                    prefix: Bytes::from(buf),
+                    error,
+                };
+            }
             Some(Ok(chunk)) => {
                 let remaining = limit.saturating_sub(buf.len());
                 if chunk.len() > remaining {
@@ -269,6 +282,16 @@ async fn splice_into_response(response: Response<Body>, snippet: &str) -> Respon
     let (mut parts, body) = response.into_parts();
     match collect_body_prefix(body, MAX_SPLICE_BODY_BYTES).await {
         CollectedBody::Full(bytes) => {
+            // A handler (e.g. a "manage cookie preferences" page) may have
+            // already rendered the banner widget itself to let an
+            // already-decided visitor change their choice. Splicing another
+            // copy in here would give that response two identical forms —
+            // check for the marker class this middleware's own markup always
+            // carries rather than assuming any particular route.
+            if contains_ascii_case_insensitive(&bytes, b"autumn-consent-banner") {
+                return Response::from_parts(parts, Body::from(bytes));
+            }
+
             let updated = splice_before_body_close(&bytes, snippet);
             if updated == bytes.as_ref() {
                 return Response::from_parts(parts, Body::from(bytes));
@@ -295,10 +318,23 @@ async fn splice_into_response(response: Response<Body>, snippet: &str) -> Respon
         // Content-Length stays correct and no cache-control change is needed
         // (nothing per-visitor was embedded).
         CollectedBody::Oversized(body) => Response::from_parts(parts, body),
-        // The body stream errored before EOF; nothing to reconstruct.
-        CollectedBody::Errored => {
+        // The body stream errored before EOF. Rather than silently discarding
+        // everything and returning a well-formed, misleadingly-complete
+        // empty `200` — the page did not actually load successfully —
+        // replay whatever bytes were already read and then end the
+        // reconstructed stream with the same error, mirroring
+        // `crate::etag::apply_etag`'s identical handling of a body read
+        // failure: the connection aborts abnormally, an honest signal (to
+        // the client and any caching proxy) that the transfer failed rather
+        // than completed.
+        CollectedBody::Errored { prefix, error } => {
             parts.headers.remove(CONTENT_LENGTH);
-            Response::from_parts(parts, Body::empty())
+            let frames: Vec<Result<Bytes, axum::Error>> = if prefix.is_empty() {
+                vec![Err(error)]
+            } else {
+                vec![Ok(prefix), Err(error)]
+            };
+            Response::from_parts(parts, Body::from_stream(futures::stream::iter(frames)))
         }
     }
 }
@@ -885,6 +921,86 @@ mod tests {
             !String::from_utf8_lossy(&body).contains("autumn-consent-banner"),
             "an oversized body is served as-is without the banner spliced in \
              (splicing would require buffering arbitrarily more)"
+        );
+    }
+
+    #[tokio::test]
+    async fn does_not_splice_a_second_banner_when_the_handler_already_rendered_one() {
+        // A "manage cookie preferences" handler may render the banner widget
+        // itself so an already-decided visitor can change their choice. If
+        // that visitor is undecided (or on a stale policy version),
+        // `needs_prompt` is still true and this middleware must not splice a
+        // second, identical copy into the same response.
+        let app = Router::new()
+            .route(
+                "/",
+                get(|| async {
+                    Response::builder()
+                        .header(CONTENT_TYPE, "text/html; charset=utf-8")
+                        .body(Body::from(
+                            "<html><body><section class=\"autumn-consent-banner\">already \
+                             here</section></body></html>"
+                                .to_owned(),
+                        ))
+                        .unwrap()
+                }),
+            )
+            .layer(axum::middleware::from_fn(move |req, next| async move {
+                inject_consent_banner(req, next, 1, "autumn-csrf", "_csrf").await
+            }));
+        let response = app
+            .oneshot(Request::builder().uri("/").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let html = String::from_utf8(body.to_vec()).unwrap();
+        assert_eq!(
+            html.matches("autumn-consent-banner").count(),
+            1,
+            "must not splice a second banner when the response already contains one: {html}"
+        );
+    }
+
+    #[tokio::test]
+    async fn body_stream_error_replays_buffered_prefix_then_ends_with_the_same_error() {
+        // The bytes read so far must not be silently discarded in favor of a
+        // clean-looking empty `200` — that would misrepresent a genuine
+        // transport/body failure as a successful (if blank) page. Instead
+        // the reconstructed body must replay the prefix and then end
+        // abnormally with the same error, mirroring
+        // `crate::etag::apply_etag`'s identical handling.
+        let prefix = Bytes::from_static(b"<html><body>partial");
+        let error = axum::Error::new(std::io::Error::new(
+            std::io::ErrorKind::UnexpectedEof,
+            "simulated upstream body error",
+        ));
+        let frames: Vec<Result<Bytes, axum::Error>> = vec![Ok(prefix.clone()), Err(error)];
+        let body = Body::from_stream(futures::stream::iter(frames));
+        let response = Response::builder()
+            .header(CONTENT_TYPE, "text/html; charset=utf-8")
+            .body(body)
+            .unwrap();
+
+        let spliced = splice_into_response(response, "<snip>").await;
+        let mut stream = spliced.into_body().into_data_stream();
+        let first = stream
+            .next()
+            .await
+            .expect("the buffered prefix must be replayed")
+            .expect("the prefix chunk must be Ok");
+        assert_eq!(
+            first, prefix,
+            "bytes read before the error must be replayed, not discarded"
+        );
+        let second = stream
+            .next()
+            .await
+            .expect("the reconstructed body must end with an error frame, not silently end");
+        assert!(
+            second.is_err(),
+            "the reconstructed body must end abnormally with the original error"
         );
     }
 

--- a/autumn/src/consent/banner.rs
+++ b/autumn/src/consent/banner.rs
@@ -379,9 +379,20 @@ async fn splice_into_response(response: Response<Body>, snippet: &str) -> Respon
         // Serve the page unmodified — no banner this one time — rather than
         // dropping it: a large report/streamed page without the banner is far
         // better than an empty page. The bytes are unchanged, so any existing
-        // Content-Length stays correct and no cache-control change is needed
-        // (nothing per-visitor was embedded).
-        CollectedBody::Oversized(body) => Response::from_parts(parts, body),
+        // Content-Length stays correct and no Cache-Control change is needed
+        // (nothing per-visitor was embedded). This path is only reached for a
+        // visitor who still needs prompting, and the app's own handler can
+        // still gate markup on the same Consent cookie regardless of whether
+        // the banner itself got spliced in, so — exactly like the
+        // decided-but-not-injected case above — a shared cache must still
+        // vary on it rather than conflate this undecided visitor's oversized
+        // representation with a decided visitor's.
+        CollectedBody::Oversized(body) => {
+            parts
+                .headers
+                .append(VARY, HeaderValue::from_static("Cookie"));
+            Response::from_parts(parts, body)
+        }
         // The body stream errored before EOF. Rather than silently discarding
         // everything and returning a well-formed, misleadingly-complete
         // empty `200` — the page did not actually load successfully —
@@ -1029,6 +1040,43 @@ mod tests {
             !String::from_utf8_lossy(&body).contains("autumn-consent-banner"),
             "an oversized body is served as-is without the banner spliced in \
              (splicing would require buffering arbitrarily more)"
+        );
+    }
+
+    #[tokio::test]
+    async fn oversized_body_still_varies_on_cookie() {
+        // This path is only reached for a visitor who still needs
+        // prompting. Even though the banner itself isn't spliced in (the
+        // body is too large), the app's own handler can still gate markup
+        // on the same Consent cookie, so a shared cache must not conflate
+        // this undecided visitor's oversized representation with a decided
+        // visitor's.
+        let oversized =
+            "<html><body>".to_owned() + &"x".repeat(MAX_SPLICE_BODY_BYTES + 1) + "</body></html>";
+        let app = Router::new()
+            .route(
+                "/",
+                get(move || {
+                    let oversized = oversized.clone();
+                    async move {
+                        Response::builder()
+                            .header(CONTENT_TYPE, "text/html; charset=utf-8")
+                            .body(Body::from(oversized))
+                            .unwrap()
+                    }
+                }),
+            )
+            .layer(axum::middleware::from_fn(move |req, next| async move {
+                inject_consent_banner(req, next, 1, "autumn-csrf", "_csrf").await
+            }));
+        let response = app
+            .oneshot(Request::builder().uri("/").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(
+            response.headers().get(VARY).and_then(|v| v.to_str().ok()),
+            Some("Cookie"),
+            "an oversized undecided-visitor response must still vary on Cookie"
         );
     }
 

--- a/autumn/src/consent/banner.rs
+++ b/autumn/src/consent/banner.rs
@@ -1,0 +1,751 @@
+//! Consent-banner widget and the middleware that auto-injects it.
+//!
+//! [`inject_consent_banner`] is a response-body-splice middleware — it
+//! detects an HTML response and, when the visitor's [`super::Consent`] needs
+//! (re-)prompting, inserts the banner markup right before `</body>`. This
+//! mirrors [`crate::middleware::dev::inject_live_reload`]'s proven
+//! detect-HTML / splice-before-`</body>` / fix-`Content-Length` pattern, so
+//! every HTML page in the app shows the banner automatically — no per-handler
+//! wiring, and no change to the app's shared `layout()` function signature
+//! (which `autumn generate scaffold` depends on staying a stable 4-arg call).
+
+use axum::body::Body;
+use axum::http::header::{
+    CACHE_CONTROL, CONTENT_ENCODING, CONTENT_LENGTH, CONTENT_TYPE, SET_COOKIE, VARY,
+};
+use axum::http::{HeaderValue, Request, Response};
+use axum::middleware::Next;
+use maud::PreEscaped;
+
+use super::{Consent, find_cookie};
+
+/// Upper bound on how much of an HTML response body [`inject_consent_banner`]
+/// will buffer in order to splice the banner in.
+///
+/// Unlike the dev-only `crate::middleware::dev::inject_live_reload` this
+/// mirrors, this middleware runs unconditionally in production for every
+/// undecided visitor — an attacker-triggerable, unauthenticated request path
+/// — so buffering must be bounded rather than `usize::MAX`. Matches the CSRF
+/// body-scan cap precedent (`security.csrf.token_scan_bytes`, 2 MiB default).
+const MAX_SPLICE_BODY_BYTES: usize = 2 * 1024 * 1024;
+
+/// Inline style reserving room at the bottom of the viewport so the
+/// fixed-position banner never permanently hides page content (e.g. a
+/// `<footer>`) underneath it. Emitted only alongside the banner itself, so it
+/// never affects layout once consent has been decided. Uses an inline
+/// `<style>` tag rather than a JS height measurement, matching
+/// `crate::error_pages::dev_badge`'s own inline-CSS-only convention.
+const BANNER_SPACE_RESERVATION_CSS: &str = "<style>body{padding-bottom:6.5rem}</style>";
+
+/// Render the consent-banner markup.
+///
+/// Offers "Reject non-essential" and "Accept all" as two `type="submit"`
+/// buttons sharing one CSS class (`autumn-consent-banner__button`) so neither
+/// is visually more prominent than the other — rejecting must be as easy as
+/// accepting. Both buttons live in a single `<form>` (default action
+/// `/consent/accept`; the reject button overrides via `formaction`) so only
+/// one CSRF hidden field is needed. Needs no JavaScript: plain HTML forms,
+/// native keyboard/tab reachability, `role="region"` + `aria-label` for
+/// screen readers.
+///
+/// `csrf_token` should be the value of the app's CSRF cookie (whatever name
+/// it's configured under — see `security.csrf.cookie_name`); pass `None`
+/// only when CSRF protection is disabled entirely.
+#[must_use]
+pub fn consent_banner_markup(csrf_token: Option<&str>) -> maud::Markup {
+    maud::html! {
+        (PreEscaped(BANNER_SPACE_RESERVATION_CSS))
+        section class="autumn-consent-banner" role="region" aria-label="Cookie consent" {
+            p class="autumn-consent-banner__message" {
+                "This site uses cookies. Strictly-necessary cookies (login, security) are always on. "
+                "Others, like analytics, only run if you accept them."
+            }
+            form method="post" action="/consent/accept" class="autumn-consent-banner__actions" {
+                @if let Some(token) = csrf_token {
+                    input type="hidden" name="_csrf" value=(token);
+                }
+                button
+                    type="submit"
+                    formaction="/consent/reject"
+                    class="autumn-consent-banner__button autumn-consent-banner__button--reject"
+                {
+                    "Reject non-essential"
+                }
+                button
+                    type="submit"
+                    class="autumn-consent-banner__button autumn-consent-banner__button--accept"
+                {
+                    "Accept all"
+                }
+            }
+        }
+    }
+}
+
+/// Middleware: inject the consent banner into every HTML response for a
+/// visitor who needs (re-)prompting (see [`super::Consent::needs_prompt`]).
+///
+/// Register it with the app's configured policy version and CSRF cookie
+/// name (`autumn-csrf` unless `security.csrf.cookie_name` was customized —
+/// see [`super::DEFAULT_CSRF_COOKIE_NAME`]), e.g.:
+///
+/// ```rust,ignore
+/// const CONSENT_POLICY_VERSION: u32 = 1;
+///
+/// let app = autumn_web::app()
+///     .routes(routes![index])
+///     .layer(axum::middleware::from_fn(move |req, next| async move {
+///         autumn_web::consent::inject_consent_banner(
+///             req,
+///             next,
+///             CONSENT_POLICY_VERSION,
+///             autumn_web::consent::DEFAULT_CSRF_COOKIE_NAME,
+///         ).await
+///     }));
+/// ```
+///
+/// Reads the visitor's consent cookie and the CSRF cookie directly off the
+/// incoming request's `Cookie` header before calling `next`, so it has no
+/// dependency on where `CsrfLayer` sits in the layer stack. Non-HTML and
+/// `Content-Encoding`-bearing responses (compressed bodies) pass through
+/// untouched, exactly like the dev-mode live-reload injector.
+///
+/// Whenever it actually injects the banner (and therefore a live, per-visitor
+/// CSRF token) into the body, it also stamps the response
+/// `Cache-Control: private, no-store` and `Vary: Cookie` — otherwise a page
+/// the app marked publicly cacheable (e.g. via `cache_for(..).public()`)
+/// could have one visitor's CSRF token served to every other visitor (and
+/// any CDN/proxy in between) until the cache entry expires.
+pub async fn inject_consent_banner(
+    request: Request<Body>,
+    next: Next,
+    policy_version: u32,
+    csrf_cookie_name: &str,
+) -> Response<Body> {
+    let consent = Consent::from_headers(request.headers());
+    let request_csrf_cookie = find_cookie(request.headers(), csrf_cookie_name);
+
+    let response = next.run(request).await;
+
+    if !consent.needs_prompt(policy_version) || !is_html_response(&response) {
+        return response;
+    }
+
+    let csrf_token =
+        extract_response_csrf_cookie(&response, csrf_cookie_name).or(request_csrf_cookie);
+    let banner_html = consent_banner_markup(csrf_token.as_deref()).into_string();
+    splice_into_response(response, &banner_html).await
+}
+
+/// Find a fresh CSRF cookie value the wrapped handler's response is about to
+/// set (e.g. the very first request from a visitor, before any CSRF cookie
+/// existed on the way in).
+fn extract_response_csrf_cookie(
+    response: &Response<Body>,
+    csrf_cookie_name: &str,
+) -> Option<String> {
+    response
+        .headers()
+        .get_all(SET_COOKIE)
+        .iter()
+        .filter_map(|value| value.to_str().ok())
+        .find_map(|set_cookie| {
+            let rest = set_cookie
+                .strip_prefix(csrf_cookie_name)?
+                .strip_prefix('=')?;
+            let value = rest.split(';').next().unwrap_or(rest);
+            Some(value.to_owned())
+        })
+}
+
+fn is_html_response(response: &Response<Body>) -> bool {
+    if response.headers().contains_key(CONTENT_ENCODING) {
+        return false;
+    }
+    response
+        .headers()
+        .get(CONTENT_TYPE)
+        .and_then(|value| value.to_str().ok())
+        .is_some_and(|content_type| content_type.contains("text/html"))
+}
+
+async fn splice_into_response(response: Response<Body>, snippet: &str) -> Response<Body> {
+    let (mut parts, body) = response.into_parts();
+    let Ok(body) = axum::body::to_bytes(body, MAX_SPLICE_BODY_BYTES).await else {
+        // Body exceeds MAX_SPLICE_BODY_BYTES (or failed to buffer). Bounding
+        // memory use here matters: unlike the dev-only live-reload injector
+        // this mirrors, this middleware runs unconditionally in production
+        // for every undecided visitor, so an unbounded `usize::MAX` buffer
+        // would be a per-request memory-exhaustion vector. The bytes read so
+        // far are already discarded by this point, so the visitor gets an
+        // empty body this one time (an exceedingly rare combination: a
+        // multi-megabyte uncompressed HTML page from a visitor who hasn't
+        // yet decided on consent) rather than an unbounded buffer.
+        parts.headers.remove(CONTENT_LENGTH);
+        return Response::from_parts(parts, Body::empty());
+    };
+    let updated = splice_before_body_close(&body, snippet);
+
+    if updated == body {
+        return Response::from_parts(parts, Body::from(body));
+    }
+
+    parts
+        .headers
+        .insert(CONTENT_LENGTH, HeaderValue::from(updated.len()));
+    // A live, per-visitor CSRF token was just embedded in this body — never
+    // let a CDN/proxy (or the browser) cache and replay it to someone else.
+    parts
+        .headers
+        .insert(CACHE_CONTROL, HeaderValue::from_static("private, no-store"));
+    parts
+        .headers
+        .append(VARY, HeaderValue::from_static("Cookie"));
+    Response::from_parts(parts, Body::from(updated))
+}
+
+/// Insert `snippet` just before the last `</body>` tag, or append it if the
+/// document has an `<html>`/`</html>` shell but no `</body>`. Leaves `body`
+/// unchanged if neither is present (mirrors
+/// `crate::middleware::dev::inject_snippet`).
+fn splice_before_body_close(body: &[u8], snippet: &str) -> Vec<u8> {
+    let html = String::from_utf8_lossy(body);
+
+    if let Some(index) = html.rfind("</body>") {
+        let mut html = html.into_owned();
+        html.insert_str(index, snippet);
+        return html.into_bytes();
+    }
+
+    if html.contains("<html") || html.contains("</html>") {
+        let mut html = html.into_owned();
+        html.push_str(snippet);
+        return html.into_bytes();
+    }
+
+    body.to_vec()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::Router;
+    use axum::http::StatusCode;
+    use axum::routing::get;
+    use tower::ServiceExt;
+
+    // ── consent_banner_markup ────────────────────────────────────────
+
+    #[test]
+    fn banner_has_accessible_region_and_label() {
+        let html = consent_banner_markup(None).into_string();
+        assert!(html.contains(r#"role="region""#));
+        assert!(html.contains(r#"aria-label="Cookie consent""#));
+    }
+
+    #[test]
+    fn banner_reject_and_accept_share_the_same_base_button_class() {
+        let html = consent_banner_markup(None).into_string();
+        // Reject-as-easy-as-accept: both are `type="submit"` sharing the base
+        // `autumn-consent-banner__button` class — neither gets a differently
+        // weighted/emphasized class the other lacks.
+        assert!(html.contains("Reject non-essential"));
+        assert!(html.contains("Accept all"));
+        let button_count = html.matches("autumn-consent-banner__button\"").count()
+            + html.matches("autumn-consent-banner__button ").count();
+        assert!(
+            button_count >= 2,
+            "both buttons must carry the shared base class: {html}"
+        );
+    }
+
+    #[test]
+    fn banner_omits_csrf_field_when_no_token_given() {
+        let html = consent_banner_markup(None).into_string();
+        assert!(!html.contains("_csrf"));
+    }
+
+    #[test]
+    fn banner_includes_csrf_hidden_field_when_token_given() {
+        let html = consent_banner_markup(Some("tok-123")).into_string();
+        assert!(html.contains(r#"name="_csrf""#));
+        assert!(html.contains(r#"value="tok-123""#));
+    }
+
+    #[test]
+    fn banner_needs_no_script_tag() {
+        let html = consent_banner_markup(Some("tok")).into_string();
+        assert!(!html.contains("<script"), "banner must need no JS: {html}");
+    }
+
+    #[test]
+    fn banner_buttons_are_keyboard_reachable_native_submit_buttons() {
+        let html = consent_banner_markup(None).into_string();
+        assert!(html.contains(r#"type="submit""#));
+        assert!(!html.contains("tabindex=\"-1\""));
+    }
+
+    // ── splice_before_body_close ──────────────────────────────────────
+
+    #[test]
+    fn splice_inserts_before_last_body_close_tag() {
+        let out = splice_before_body_close(b"<html><body><main>ok</main></body></html>", "<snip>");
+        let s = String::from_utf8(out).unwrap();
+        assert!(s.contains("<snip></body>"));
+    }
+
+    #[test]
+    fn splice_appends_when_no_body_tag_but_html_shell_present() {
+        let out = splice_before_body_close(b"<html><main>ok</main></html>", "<snip>");
+        let s = String::from_utf8(out).unwrap();
+        assert!(s.ends_with("<snip>"));
+    }
+
+    #[test]
+    fn splice_leaves_non_html_untouched() {
+        let out = splice_before_body_close(b"not html at all", "<snip>");
+        assert_eq!(out, b"not html at all");
+    }
+
+    // ── is_html_response ────────────────────────────────────────────
+
+    #[test]
+    fn html_response_detected_by_content_type() {
+        let response = Response::builder()
+            .header(CONTENT_TYPE, "text/html; charset=utf-8")
+            .body(Body::empty())
+            .unwrap();
+        assert!(is_html_response(&response));
+    }
+
+    #[test]
+    fn json_response_is_not_html() {
+        let response = Response::builder()
+            .header(CONTENT_TYPE, "application/json")
+            .body(Body::empty())
+            .unwrap();
+        assert!(!is_html_response(&response));
+    }
+
+    #[test]
+    fn encoded_html_response_is_skipped() {
+        let response = Response::builder()
+            .header(CONTENT_TYPE, "text/html")
+            .header(CONTENT_ENCODING, "gzip")
+            .body(Body::empty())
+            .unwrap();
+        assert!(!is_html_response(&response));
+    }
+
+    // ── extract_response_csrf_cookie ─────────────────────────────────
+
+    #[test]
+    fn extracts_csrf_value_from_fresh_set_cookie() {
+        let response = Response::builder()
+            .header(SET_COOKIE, "autumn-csrf=fresh-token; Path=/; HttpOnly")
+            .body(Body::empty())
+            .unwrap();
+        assert_eq!(
+            extract_response_csrf_cookie(&response, "autumn-csrf"),
+            Some("fresh-token".to_owned())
+        );
+    }
+
+    #[test]
+    fn no_csrf_set_cookie_yields_none() {
+        let response = Response::builder()
+            .header(SET_COOKIE, "autumn.sid=abc; Path=/")
+            .body(Body::empty())
+            .unwrap();
+        assert_eq!(extract_response_csrf_cookie(&response, "autumn-csrf"), None);
+    }
+
+    #[test]
+    fn extract_response_csrf_cookie_honors_custom_cookie_name() {
+        let response = Response::builder()
+            .header(SET_COOKIE, "my-csrf=custom-token; Path=/")
+            .body(Body::empty())
+            .unwrap();
+        assert_eq!(
+            extract_response_csrf_cookie(&response, "my-csrf"),
+            Some("custom-token".to_owned())
+        );
+        // Must not match under the default name once a custom name is configured.
+        assert_eq!(extract_response_csrf_cookie(&response, "autumn-csrf"), None);
+    }
+
+    // ── inject_consent_banner (full middleware, via a tiny router) ────
+
+    fn html_page() -> Response<Body> {
+        Response::builder()
+            .header(CONTENT_TYPE, "text/html; charset=utf-8")
+            .body(Body::from(
+                "<html><body><main>hello</main></body></html>".to_owned(),
+            ))
+            .unwrap()
+    }
+
+    fn app_with_policy_version(version: u32) -> Router {
+        Router::new()
+            .route("/", get(|| async { html_page() }))
+            .layer(axum::middleware::from_fn(move |req, next| async move {
+                inject_consent_banner(req, next, version, "autumn-csrf").await
+            }))
+    }
+
+    // End-to-end proof for two acceptance criteria at once: (1) the gate is
+    // real enforcement, not just UI — with no consent recorded, a
+    // hypothetical "analytics" cookie a handler would otherwise set is
+    // actually withheld; (2) strictly-necessary cookies (here, the real
+    // session cookie via `SessionLayer`) are completely unaffected by
+    // consent state — they are set on every request regardless.
+    #[tokio::test]
+    async fn gate_withholds_non_essential_cookie_while_session_cookie_is_unaffected() {
+        use crate::session::{MemoryStore, Session, SessionConfig, SessionLayer};
+
+        const POLICY_VERSION: u32 = 1;
+
+        async fn handler(session: Session, consent: Consent) -> Response<Body> {
+            session.insert("visited", "true").await;
+            let mut response = html_page();
+            if consent.allows("analytics", POLICY_VERSION) {
+                response
+                    .headers_mut()
+                    .append(SET_COOKIE, HeaderValue::from_static("analytics=on; Path=/"));
+            }
+            response
+        }
+
+        let app = || {
+            Router::new()
+                .route("/", get(handler))
+                .layer(axum::middleware::from_fn(move |req, next| async move {
+                    inject_consent_banner(req, next, POLICY_VERSION, "autumn-csrf").await
+                }))
+                .layer(SessionLayer::new(
+                    MemoryStore::new(),
+                    SessionConfig::default(),
+                ))
+        };
+
+        // First visit: no consent recorded at all.
+        let response = app()
+            .oneshot(Request::builder().uri("/").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        let set_cookies: Vec<String> = response
+            .headers()
+            .get_all(SET_COOKIE)
+            .iter()
+            .filter_map(|v| v.to_str().ok().map(str::to_owned))
+            .collect();
+        assert!(
+            set_cookies.iter().any(|c| c.starts_with("autumn.sid=")),
+            "strictly-necessary session cookie must still be set: {set_cookies:?}"
+        );
+        assert!(
+            !set_cookies.iter().any(|c| c.starts_with("analytics=")),
+            "non-essential cookie must NOT be set without consent: {set_cookies:?}"
+        );
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let html = String::from_utf8(body.to_vec()).unwrap();
+        assert!(html.contains("autumn-consent-banner"), "{html}");
+
+        // Second visit: consent accepted for "analytics" under the current version.
+        let cookie = super::super::accept_all_cookie(&["analytics"], POLICY_VERSION);
+        let raw_value = cookie
+            .split(';')
+            .next()
+            .unwrap()
+            .strip_prefix("autumn.consent=")
+            .unwrap();
+        let response = app()
+            .oneshot(
+                Request::builder()
+                    .uri("/")
+                    .header("cookie", format!("autumn.consent={raw_value}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let set_cookies: Vec<String> = response
+            .headers()
+            .get_all(SET_COOKIE)
+            .iter()
+            .filter_map(|v| v.to_str().ok().map(str::to_owned))
+            .collect();
+        assert!(
+            set_cookies.iter().any(|c| c.starts_with("analytics=")),
+            "analytics cookie must be set once accepted: {set_cookies:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn injects_banner_when_no_consent_cookie_present() {
+        let app = app_with_policy_version(1);
+        let response = app
+            .oneshot(Request::builder().uri("/").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let html = String::from_utf8(body.to_vec()).unwrap();
+        assert!(html.contains("autumn-consent-banner"), "{html}");
+    }
+
+    #[tokio::test]
+    async fn omits_banner_when_consent_already_decided_under_current_version() {
+        let app = app_with_policy_version(1);
+        let cookie = super::super::accept_all_cookie(&["analytics"], 1);
+        let raw_value = cookie
+            .split(';')
+            .next()
+            .unwrap()
+            .strip_prefix("autumn.consent=")
+            .unwrap();
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/")
+                    .header("cookie", format!("autumn.consent={raw_value}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let html = String::from_utf8(body.to_vec()).unwrap();
+        assert!(!html.contains("autumn-consent-banner"), "{html}");
+    }
+
+    #[tokio::test]
+    async fn reprompts_when_recorded_consent_is_from_an_older_policy_version() {
+        let app = app_with_policy_version(2);
+        let cookie = super::super::accept_all_cookie(&["analytics"], 1);
+        let raw_value = cookie
+            .split(';')
+            .next()
+            .unwrap()
+            .strip_prefix("autumn.consent=")
+            .unwrap();
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/")
+                    .header("cookie", format!("autumn.consent={raw_value}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let html = String::from_utf8(body.to_vec()).unwrap();
+        assert!(
+            html.contains("autumn-consent-banner"),
+            "policy bump must re-show the banner: {html}"
+        );
+    }
+
+    #[tokio::test]
+    async fn non_html_response_is_left_untouched() {
+        let app = Router::new()
+            .route(
+                "/api",
+                get(|| async { ([(CONTENT_TYPE, "application/json")], r#"{"status":"ok"}"#) }),
+            )
+            .layer(axum::middleware::from_fn(move |req, next| async move {
+                inject_consent_banner(req, next, 1, "autumn-csrf").await
+            }));
+        let response = app
+            .oneshot(Request::builder().uri("/api").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        assert_eq!(&body[..], br#"{"status":"ok"}"#);
+    }
+
+    #[tokio::test]
+    async fn banner_carries_csrf_token_freshly_set_by_a_csrf_layer_style_response() {
+        let app = Router::new()
+            .route(
+                "/",
+                get(|| async {
+                    let mut response = html_page();
+                    response.headers_mut().insert(
+                        SET_COOKIE,
+                        HeaderValue::from_static("autumn-csrf=minted-token; Path=/"),
+                    );
+                    response
+                }),
+            )
+            .layer(axum::middleware::from_fn(move |req, next| async move {
+                inject_consent_banner(req, next, 1, "autumn-csrf").await
+            }));
+        let response = app
+            .oneshot(Request::builder().uri("/").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let html = String::from_utf8(body.to_vec()).unwrap();
+        assert!(html.contains(r#"value="minted-token""#), "{html}");
+    }
+
+    #[tokio::test]
+    async fn content_length_updated_after_injection() {
+        let app = app_with_policy_version(1);
+        let response = app
+            .oneshot(Request::builder().uri("/").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        let content_length: usize = response
+            .headers()
+            .get(CONTENT_LENGTH)
+            .and_then(|v| v.to_str().ok())
+            .and_then(|v| v.parse().ok())
+            .expect("content-length must be set after injection");
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        assert_eq!(content_length, body.len());
+    }
+
+    #[tokio::test]
+    async fn injection_marks_response_uncacheable_and_varying_on_cookie() {
+        let app = app_with_policy_version(1);
+        let response = app
+            .oneshot(Request::builder().uri("/").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(
+            response
+                .headers()
+                .get(CACHE_CONTROL)
+                .and_then(|v| v.to_str().ok()),
+            Some("private, no-store"),
+            "a live per-visitor CSRF token was just embedded; this response must never be shared via a cache"
+        );
+        assert_eq!(
+            response.headers().get(VARY).and_then(|v| v.to_str().ok()),
+            Some("Cookie")
+        );
+    }
+
+    #[tokio::test]
+    async fn no_cache_headers_added_when_consent_already_decided() {
+        let app = app_with_policy_version(1);
+        let cookie = super::super::accept_all_cookie(&["analytics"], 1);
+        let raw_value = cookie
+            .split(';')
+            .next()
+            .unwrap()
+            .strip_prefix("autumn.consent=")
+            .unwrap();
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/")
+                    .header("cookie", format!("autumn.consent={raw_value}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert!(
+            response.headers().get(CACHE_CONTROL).is_none(),
+            "no banner injected, so this middleware must not touch caching headers"
+        );
+    }
+
+    #[tokio::test]
+    async fn oversized_body_is_bounded_not_buffered_without_limit() {
+        // A body far larger than MAX_SPLICE_BODY_BYTES must not be fully
+        // buffered into memory; the middleware falls back to an empty body
+        // rather than holding an unbounded allocation.
+        let oversized =
+            "<html><body>".to_owned() + &"x".repeat(MAX_SPLICE_BODY_BYTES + 1) + "</body></html>";
+        let app = Router::new()
+            .route(
+                "/",
+                get(move || {
+                    let oversized = oversized.clone();
+                    async move {
+                        Response::builder()
+                            .header(CONTENT_TYPE, "text/html; charset=utf-8")
+                            .body(Body::from(oversized))
+                            .unwrap()
+                    }
+                }),
+            )
+            .layer(axum::middleware::from_fn(move |req, next| async move {
+                inject_consent_banner(req, next, 1, "autumn-csrf").await
+            }));
+        let response = app
+            .oneshot(Request::builder().uri("/").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        assert!(
+            body.len() < MAX_SPLICE_BODY_BYTES,
+            "oversized body must not pass through fully buffered/spliced: got {} bytes",
+            body.len()
+        );
+    }
+
+    #[tokio::test]
+    async fn honors_custom_csrf_cookie_name_end_to_end() {
+        let app = Router::new()
+            .route(
+                "/",
+                get(|| async {
+                    let mut response = html_page();
+                    response.headers_mut().insert(
+                        SET_COOKIE,
+                        HeaderValue::from_static("my-csrf=minted-under-custom-name; Path=/"),
+                    );
+                    response
+                }),
+            )
+            .layer(axum::middleware::from_fn(move |req, next| async move {
+                inject_consent_banner(req, next, 1, "my-csrf").await
+            }));
+        let response = app
+            .oneshot(Request::builder().uri("/").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let html = String::from_utf8(body.to_vec()).unwrap();
+        assert!(
+            html.contains(r#"value="minted-under-custom-name""#),
+            "{html}"
+        );
+    }
+
+    #[test]
+    fn banner_reserves_space_for_fixed_positioning_so_it_cannot_permanently_hide_content() {
+        let html = consent_banner_markup(None).into_string();
+        assert!(
+            html.contains("padding-bottom"),
+            "banner must reserve viewport space so a fixed-position banner \
+             doesn't permanently cover page content like a footer: {html}"
+        );
+    }
+}

--- a/autumn/src/consent/banner.rs
+++ b/autumn/src/consent/banner.rs
@@ -9,12 +9,14 @@
 //! wiring, and no change to the app's shared `layout()` function signature
 //! (which `autumn generate scaffold` depends on staying a stable 4-arg call).
 
-use axum::body::Body;
+use axum::body::{Body, Bytes};
 use axum::http::header::{
-    CACHE_CONTROL, CONTENT_ENCODING, CONTENT_LENGTH, CONTENT_TYPE, SET_COOKIE, VARY,
+    CACHE_CONTROL, CONTENT_ENCODING, CONTENT_LENGTH, CONTENT_TYPE, IF_MODIFIED_SINCE,
+    IF_NONE_MATCH, SET_COOKIE, VARY,
 };
-use axum::http::{HeaderValue, Request, Response};
+use axum::http::{HeaderName, HeaderValue, Request, Response};
 use axum::middleware::Next;
+use futures::StreamExt as _;
 use maud::PreEscaped;
 
 use super::{Consent, find_cookie};
@@ -27,15 +29,20 @@ use super::{Consent, find_cookie};
 /// undecided visitor — an attacker-triggerable, unauthenticated request path
 /// — so buffering must be bounded rather than `usize::MAX`. Matches the CSRF
 /// body-scan cap precedent (`security.csrf.token_scan_bytes`, 2 MiB default).
+/// A body over this cap is served **unmodified** (see [`collect_body_prefix`])
+/// rather than dropped — a large page without the banner beats an empty one.
 const MAX_SPLICE_BODY_BYTES: usize = 2 * 1024 * 1024;
 
-/// Inline style reserving room at the bottom of the viewport so the
-/// fixed-position banner never permanently hides page content (e.g. a
-/// `<footer>`) underneath it. Emitted only alongside the banner itself, so it
-/// never affects layout once consent has been decided. Uses an inline
-/// `<style>` tag rather than a JS height measurement, matching
-/// `crate::error_pages::dev_badge`'s own inline-CSS-only convention.
-const BANNER_SPACE_RESERVATION_CSS: &str = "<style>body{padding-bottom:6.5rem}</style>";
+/// Bare CSS for [`BANNER_SPACE_RESERVATION_CSS`]'s `<style>` element — reserves
+/// room at the bottom of the viewport so the fixed-position banner never
+/// permanently hides page content (e.g. a `<footer>`) underneath it. Emitted
+/// only alongside the banner itself, so it never affects layout once consent
+/// has been decided. Uses an inline `<style>` tag rather than a JS height
+/// measurement, matching `crate::error_pages::dev_badge`'s own
+/// inline-CSS-only convention; carries the request's CSP nonce (see
+/// [`inject_consent_banner`]) so it isn't dropped under
+/// `security.headers.csp_nonce.enabled = true`.
+const BANNER_SPACE_RESERVATION_CSS: &str = "body{padding-bottom:6.5rem}";
 
 /// Render the consent-banner markup.
 ///
@@ -50,11 +57,19 @@ const BANNER_SPACE_RESERVATION_CSS: &str = "<style>body{padding-bottom:6.5rem}</
 ///
 /// `csrf_token` should be the value of the app's CSRF cookie (whatever name
 /// it's configured under — see `security.csrf.cookie_name`); pass `None`
-/// only when CSRF protection is disabled entirely.
+/// only when CSRF protection is disabled entirely. `csrf_field_name` is the
+/// form field the token is submitted under — `"_csrf"` unless the app
+/// customized `security.csrf.form_field`. `nonce` is the request's CSP nonce
+/// (see `security.headers.csp_nonce`) applied to the reservation `<style>`;
+/// pass `None` when CSP nonces are disabled (the default).
 #[must_use]
-pub fn consent_banner_markup(csrf_token: Option<&str>) -> maud::Markup {
+pub fn consent_banner_markup(
+    csrf_token: Option<&str>,
+    csrf_field_name: &str,
+    nonce: Option<&str>,
+) -> maud::Markup {
     maud::html! {
-        (PreEscaped(BANNER_SPACE_RESERVATION_CSS))
+        style nonce=[nonce] { (PreEscaped(BANNER_SPACE_RESERVATION_CSS)) }
         section class="autumn-consent-banner" role="region" aria-label="Cookie consent" {
             p class="autumn-consent-banner__message" {
                 "This site uses cookies. Strictly-necessary cookies (login, security) are always on. "
@@ -62,7 +77,7 @@ pub fn consent_banner_markup(csrf_token: Option<&str>) -> maud::Markup {
             }
             form method="post" action="/consent/accept" class="autumn-consent-banner__actions" {
                 @if let Some(token) = csrf_token {
-                    input type="hidden" name="_csrf" value=(token);
+                    input type="hidden" name=(csrf_field_name) value=(token);
                 }
                 button
                     type="submit"
@@ -110,6 +125,18 @@ pub fn consent_banner_markup(csrf_token: Option<&str>) -> maud::Markup {
 /// `Content-Encoding`-bearing responses (compressed bodies) pass through
 /// untouched, exactly like the dev-mode live-reload injector.
 ///
+/// Also, while a visitor needs (re-)prompting: strips `If-None-Match` /
+/// `If-Modified-Since` from the request before calling `next`, so an inner
+/// `EtagLayer` can't short-circuit to a bodyless `304` — which would replay a
+/// browser-cached, banner-less page and silently skip the required prompt
+/// after a policy bump or a withdrawn consent. And reads the CSRF form-field
+/// name (`security.csrf.form_field`, via `CsrfFormField` in request
+/// extensions) and the CSP nonce (`security.headers.csp_nonce`, via
+/// `CspNonce` in request extensions, or parsed back out of the response's
+/// `Content-Security-Policy` header if `CspNonce` wasn't already in request
+/// extensions when this ran) so the injected banner and its style stay valid
+/// under those configurations too.
+///
 /// Whenever it actually injects the banner (and therefore a live, per-visitor
 /// CSRF token) into the body, it also stamps the response
 /// `Cache-Control: private, no-store` and `Vary: Cookie` — otherwise a page
@@ -117,24 +144,56 @@ pub fn consent_banner_markup(csrf_token: Option<&str>) -> maud::Markup {
 /// could have one visitor's CSRF token served to every other visitor (and
 /// any CDN/proxy in between) until the cache entry expires.
 pub async fn inject_consent_banner(
-    request: Request<Body>,
+    mut request: Request<Body>,
     next: Next,
     policy_version: u32,
     csrf_cookie_name: &str,
 ) -> Response<Body> {
     let consent = Consent::from_headers(request.headers());
     let request_csrf_cookie = find_cookie(request.headers(), csrf_cookie_name);
+    let csrf_field_name = request
+        .extensions()
+        .get::<crate::security::CsrfFormField>()
+        .map_or_else(|| "_csrf".to_owned(), |field| field.0.clone());
+    let request_nonce = request
+        .extensions()
+        .get::<crate::security::CspNonce>()
+        .map(|nonce| nonce.value().to_owned());
+
+    let needs_prompt = consent.needs_prompt(policy_version);
+    if needs_prompt {
+        request.headers_mut().remove(IF_NONE_MATCH);
+        request.headers_mut().remove(IF_MODIFIED_SINCE);
+    }
 
     let response = next.run(request).await;
 
-    if !consent.needs_prompt(policy_version) || !is_html_response(&response) {
+    if !needs_prompt || !is_html_response(&response) {
         return response;
     }
 
     let csrf_token =
         extract_response_csrf_cookie(&response, csrf_cookie_name).or(request_csrf_cookie);
-    let banner_html = consent_banner_markup(csrf_token.as_deref()).into_string();
+    let nonce = request_nonce.or_else(|| extract_response_csp_nonce(&response));
+    let banner_html =
+        consent_banner_markup(csrf_token.as_deref(), &csrf_field_name, nonce.as_deref())
+            .into_string();
     splice_into_response(response, &banner_html).await
+}
+
+/// Recover the per-request CSP nonce from the response's
+/// `Content-Security-Policy` header, for when `CspNonce` wasn't yet in
+/// request extensions (i.e. `SecurityHeadersLayer` sits inner to this
+/// middleware rather than outer). Mirrors the same `'nonce-...'` extraction
+/// the framework's own tests use.
+fn extract_response_csp_nonce(response: &Response<Body>) -> Option<String> {
+    response
+        .headers()
+        .get(HeaderName::from_static("content-security-policy"))
+        .and_then(|value| value.to_str().ok())
+        .and_then(|csp| csp.split("'nonce-").nth(1))
+        .and_then(|rest| rest.split('\'').next())
+        .map(str::to_owned)
 }
 
 /// Find a fresh CSRF cookie value the wrapped handler's response is about to
@@ -169,39 +228,90 @@ fn is_html_response(response: &Response<Body>) -> bool {
         .is_some_and(|content_type| content_type.contains("text/html"))
 }
 
+/// Outcome of bounding how much of a body [`collect_body_prefix`] buffers.
+/// Mirrors `security::csrf`'s own `CollectedBody` shape (the same problem —
+/// bound memory use without dropping an oversized body — solved once there
+/// for a request body, adapted here for a response body).
+enum CollectedBody {
+    /// The whole body fit within the cap and is fully buffered.
+    Full(Bytes),
+    /// The body exceeded the cap. Replays the complete, unmodified body — the
+    /// buffered prefix plus the over-limit chunk and the remaining stream —
+    /// so the client receives every byte with the tail streamed rather than
+    /// buffered. This middleware does not attempt to splice into an oversized
+    /// body (finding `</body>` would require buffering arbitrarily more), so
+    /// unlike the CSRF version there is no separate scan-prefix to return.
+    Oversized(Body),
+    /// The body stream errored before EOF. The bytes read so far are
+    /// discarded.
+    Errored,
+}
+
+/// Buffer `body` up to `limit` bytes without failing when the body is larger,
+/// reconstructing the full body for pass-through in that case. See
+/// `security::csrf::collect_body_prefix` for the request-body sibling this
+/// mirrors.
+async fn collect_body_prefix(body: Body, limit: usize) -> CollectedBody {
+    let mut buf = Vec::<u8>::new();
+    let mut stream = body.into_data_stream();
+    loop {
+        match stream.next().await {
+            None => break,
+            Some(Err(_)) => return CollectedBody::Errored,
+            Some(Ok(chunk)) => {
+                let remaining = limit.saturating_sub(buf.len());
+                if chunk.len() > remaining {
+                    let mut leading = Vec::with_capacity(2);
+                    if !buf.is_empty() {
+                        leading.push(Ok::<Bytes, axum::Error>(Bytes::from(buf)));
+                    }
+                    leading.push(Ok::<Bytes, axum::Error>(chunk));
+                    let body = Body::from_stream(futures::stream::iter(leading).chain(stream));
+                    return CollectedBody::Oversized(body);
+                }
+                buf.extend_from_slice(&chunk);
+            }
+        }
+    }
+    CollectedBody::Full(Bytes::from(buf))
+}
+
 async fn splice_into_response(response: Response<Body>, snippet: &str) -> Response<Body> {
     let (mut parts, body) = response.into_parts();
-    let Ok(body) = axum::body::to_bytes(body, MAX_SPLICE_BODY_BYTES).await else {
-        // Body exceeds MAX_SPLICE_BODY_BYTES (or failed to buffer). Bounding
-        // memory use here matters: unlike the dev-only live-reload injector
-        // this mirrors, this middleware runs unconditionally in production
-        // for every undecided visitor, so an unbounded `usize::MAX` buffer
-        // would be a per-request memory-exhaustion vector. The bytes read so
-        // far are already discarded by this point, so the visitor gets an
-        // empty body this one time (an exceedingly rare combination: a
-        // multi-megabyte uncompressed HTML page from a visitor who hasn't
-        // yet decided on consent) rather than an unbounded buffer.
-        parts.headers.remove(CONTENT_LENGTH);
-        return Response::from_parts(parts, Body::empty());
-    };
-    let updated = splice_before_body_close(&body, snippet);
+    match collect_body_prefix(body, MAX_SPLICE_BODY_BYTES).await {
+        CollectedBody::Full(bytes) => {
+            let updated = splice_before_body_close(&bytes, snippet);
+            if updated == bytes.as_ref() {
+                return Response::from_parts(parts, Body::from(bytes));
+            }
 
-    if updated == body {
-        return Response::from_parts(parts, Body::from(body));
+            parts
+                .headers
+                .insert(CONTENT_LENGTH, HeaderValue::from(updated.len()));
+            // A live, per-visitor CSRF token was just embedded in this body —
+            // never let a CDN/proxy (or the browser) cache and replay it to
+            // someone else.
+            parts
+                .headers
+                .insert(CACHE_CONTROL, HeaderValue::from_static("private, no-store"));
+            parts
+                .headers
+                .append(VARY, HeaderValue::from_static("Cookie"));
+            Response::from_parts(parts, Body::from(updated))
+        }
+        // Too large to safely buffer and splice into (MAX_SPLICE_BODY_BYTES).
+        // Serve the page unmodified — no banner this one time — rather than
+        // dropping it: a large report/streamed page without the banner is far
+        // better than an empty page. The bytes are unchanged, so any existing
+        // Content-Length stays correct and no cache-control change is needed
+        // (nothing per-visitor was embedded).
+        CollectedBody::Oversized(body) => Response::from_parts(parts, body),
+        // The body stream errored before EOF; nothing to reconstruct.
+        CollectedBody::Errored => {
+            parts.headers.remove(CONTENT_LENGTH);
+            Response::from_parts(parts, Body::empty())
+        }
     }
-
-    parts
-        .headers
-        .insert(CONTENT_LENGTH, HeaderValue::from(updated.len()));
-    // A live, per-visitor CSRF token was just embedded in this body — never
-    // let a CDN/proxy (or the browser) cache and replay it to someone else.
-    parts
-        .headers
-        .insert(CACHE_CONTROL, HeaderValue::from_static("private, no-store"));
-    parts
-        .headers
-        .append(VARY, HeaderValue::from_static("Cookie"));
-    Response::from_parts(parts, Body::from(updated))
 }
 
 /// Insert `snippet` just before the last `</body>` tag, or append it if the
@@ -238,14 +348,14 @@ mod tests {
 
     #[test]
     fn banner_has_accessible_region_and_label() {
-        let html = consent_banner_markup(None).into_string();
+        let html = consent_banner_markup(None, "_csrf", None).into_string();
         assert!(html.contains(r#"role="region""#));
         assert!(html.contains(r#"aria-label="Cookie consent""#));
     }
 
     #[test]
     fn banner_reject_and_accept_share_the_same_base_button_class() {
-        let html = consent_banner_markup(None).into_string();
+        let html = consent_banner_markup(None, "_csrf", None).into_string();
         // Reject-as-easy-as-accept: both are `type="submit"` sharing the base
         // `autumn-consent-banner__button` class — neither gets a differently
         // weighted/emphasized class the other lacks.
@@ -261,26 +371,26 @@ mod tests {
 
     #[test]
     fn banner_omits_csrf_field_when_no_token_given() {
-        let html = consent_banner_markup(None).into_string();
+        let html = consent_banner_markup(None, "_csrf", None).into_string();
         assert!(!html.contains("_csrf"));
     }
 
     #[test]
     fn banner_includes_csrf_hidden_field_when_token_given() {
-        let html = consent_banner_markup(Some("tok-123")).into_string();
+        let html = consent_banner_markup(Some("tok-123"), "_csrf", None).into_string();
         assert!(html.contains(r#"name="_csrf""#));
         assert!(html.contains(r#"value="tok-123""#));
     }
 
     #[test]
     fn banner_needs_no_script_tag() {
-        let html = consent_banner_markup(Some("tok")).into_string();
+        let html = consent_banner_markup(Some("tok"), "_csrf", None).into_string();
         assert!(!html.contains("<script"), "banner must need no JS: {html}");
     }
 
     #[test]
     fn banner_buttons_are_keyboard_reachable_native_submit_buttons() {
-        let html = consent_banner_markup(None).into_string();
+        let html = consent_banner_markup(None, "_csrf", None).into_string();
         assert!(html.contains(r#"type="submit""#));
         assert!(!html.contains("tabindex=\"-1\""));
     }
@@ -672,12 +782,17 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn oversized_body_is_bounded_not_buffered_without_limit() {
-        // A body far larger than MAX_SPLICE_BODY_BYTES must not be fully
-        // buffered into memory; the middleware falls back to an empty body
-        // rather than holding an unbounded allocation.
+    async fn oversized_body_is_bounded_in_memory_but_served_intact_unmodified() {
+        // A body far larger than MAX_SPLICE_BODY_BYTES must never be fully
+        // buffered into memory (bounding the splice buffer matters: this
+        // middleware runs unconditionally in production for every undecided,
+        // unauthenticated visitor). But the visitor must still receive the
+        // real, complete page — a large report/streamed page without the
+        // banner is far better than an empty one — so the response body must
+        // come through byte-for-byte intact, not truncated or dropped.
         let oversized =
             "<html><body>".to_owned() + &"x".repeat(MAX_SPLICE_BODY_BYTES + 1) + "</body></html>";
+        let expected_len = oversized.len();
         let app = Router::new()
             .route(
                 "/",
@@ -701,10 +816,15 @@ mod tests {
         let body = axum::body::to_bytes(response.into_body(), usize::MAX)
             .await
             .unwrap();
+        assert_eq!(
+            body.len(),
+            expected_len,
+            "an oversized body must be served intact, not truncated or emptied"
+        );
         assert!(
-            body.len() < MAX_SPLICE_BODY_BYTES,
-            "oversized body must not pass through fully buffered/spliced: got {} bytes",
-            body.len()
+            !String::from_utf8_lossy(&body).contains("autumn-consent-banner"),
+            "an oversized body is served as-is without the banner spliced in \
+             (splicing would require buffering arbitrarily more)"
         );
     }
 
@@ -741,11 +861,280 @@ mod tests {
 
     #[test]
     fn banner_reserves_space_for_fixed_positioning_so_it_cannot_permanently_hide_content() {
-        let html = consent_banner_markup(None).into_string();
+        let html = consent_banner_markup(None, "_csrf", None).into_string();
         assert!(
             html.contains("padding-bottom"),
             "banner must reserve viewport space so a fixed-position banner \
              doesn't permanently cover page content like a footer: {html}"
+        );
+    }
+
+    // ── configured CSRF form-field name ──────────────────────────────
+
+    #[test]
+    fn banner_uses_default_csrf_field_name() {
+        let html = consent_banner_markup(Some("tok"), "_csrf", None).into_string();
+        assert!(html.contains(r#"name="_csrf""#));
+    }
+
+    #[test]
+    fn banner_honors_custom_csrf_field_name() {
+        let html = consent_banner_markup(Some("tok"), "authenticity_token", None).into_string();
+        assert!(html.contains(r#"name="authenticity_token""#));
+        assert!(!html.contains(r#"name="_csrf""#));
+    }
+
+    #[tokio::test]
+    async fn banner_honors_configured_csrf_form_field_name_from_request_extensions() {
+        let app = Router::new()
+            .route("/", get(|| async { html_page() }))
+            .layer(axum::middleware::from_fn(move |req, next| async move {
+                inject_consent_banner(req, next, 1, "autumn-csrf").await
+            }));
+
+        let mut request = Request::builder()
+            .uri("/")
+            .header("cookie", "autumn-csrf=tok-abc")
+            .body(Body::empty())
+            .unwrap();
+        request
+            .extensions_mut()
+            .insert(crate::security::CsrfFormField(
+                "authenticity_token".to_owned(),
+            ));
+
+        let response = app.oneshot(request).await.unwrap();
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let html = String::from_utf8(body.to_vec()).unwrap();
+        assert!(
+            html.contains(r#"name="authenticity_token" value="tok-abc""#),
+            "{html}"
+        );
+        assert!(!html.contains(r#"name="_csrf""#), "{html}");
+    }
+
+    // ── CSP nonce ─────────────────────────────────────────────────────
+
+    #[test]
+    fn extract_response_csp_nonce_parses_nonce_from_header() {
+        let response = Response::builder()
+            .header(
+                "content-security-policy",
+                "script-src 'self' 'nonce-abc123'; style-src 'self' 'nonce-abc123'",
+            )
+            .body(Body::empty())
+            .unwrap();
+        assert_eq!(
+            extract_response_csp_nonce(&response),
+            Some("abc123".to_owned())
+        );
+    }
+
+    #[test]
+    fn extract_response_csp_nonce_none_when_header_absent() {
+        let response = Response::builder().body(Body::empty()).unwrap();
+        assert_eq!(extract_response_csp_nonce(&response), None);
+    }
+
+    #[test]
+    fn banner_style_omits_nonce_attribute_when_none() {
+        let html = consent_banner_markup(None, "_csrf", None).into_string();
+        assert!(!html.contains("nonce="), "{html}");
+    }
+
+    #[test]
+    fn banner_style_carries_nonce_when_given() {
+        let html = consent_banner_markup(None, "_csrf", Some("abc123")).into_string();
+        assert!(html.contains(r#"<style nonce="abc123">"#), "{html}");
+    }
+
+    #[tokio::test]
+    async fn banner_nonce_matches_a_real_security_headers_layer_via_request_extensions() {
+        // My middleware runs INNER to `SecurityHeadersLayer` here (it's applied
+        // last, so it wraps outermost), meaning by the time my middleware
+        // reads request extensions, `SecurityHeadersLayer` has already
+        // inserted `CspNonce` on the way in — the primary (request-extension)
+        // resolution path.
+        use crate::security::{CspNonceConfig, HeadersConfig, SecurityHeadersLayer};
+
+        let headers_config = HeadersConfig {
+            csp_nonce: CspNonceConfig { enabled: true },
+            ..HeadersConfig::default()
+        };
+
+        let app = Router::new()
+            .route("/", get(|| async { html_page() }))
+            .layer(axum::middleware::from_fn(move |req, next| async move {
+                inject_consent_banner(req, next, 1, "autumn-csrf").await
+            }))
+            .layer(SecurityHeadersLayer::from_config(&headers_config));
+
+        let response = app
+            .oneshot(Request::builder().uri("/").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+
+        let csp = response
+            .headers()
+            .get("content-security-policy")
+            .and_then(|v| v.to_str().ok())
+            .expect("CSP header must be set")
+            .to_owned();
+        let nonce = csp
+            .split("'nonce-")
+            .nth(1)
+            .and_then(|rest| rest.split('\'').next())
+            .expect("CSP header must advertise a nonce")
+            .to_owned();
+
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let html = String::from_utf8(body.to_vec()).unwrap();
+        assert!(
+            html.contains(&format!(r#"nonce="{nonce}""#)),
+            "banner's <style> must carry the same nonce as the response's CSP header: {html}"
+        );
+    }
+
+    #[tokio::test]
+    async fn banner_nonce_falls_back_to_response_header_when_layer_runs_after() {
+        // Here `SecurityHeadersLayer` is applied FIRST (innermost), so my
+        // middleware — outermost — sees no `CspNonce` in request extensions
+        // yet when it runs; it must fall back to parsing the nonce back out
+        // of the response's `Content-Security-Policy` header.
+        use crate::security::{CspNonceConfig, HeadersConfig, SecurityHeadersLayer};
+
+        let headers_config = HeadersConfig {
+            csp_nonce: CspNonceConfig { enabled: true },
+            ..HeadersConfig::default()
+        };
+
+        let app = Router::new()
+            .route("/", get(|| async { html_page() }))
+            .layer(SecurityHeadersLayer::from_config(&headers_config))
+            .layer(axum::middleware::from_fn(move |req, next| async move {
+                inject_consent_banner(req, next, 1, "autumn-csrf").await
+            }));
+
+        let response = app
+            .oneshot(Request::builder().uri("/").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+
+        let csp = response
+            .headers()
+            .get("content-security-policy")
+            .and_then(|v| v.to_str().ok())
+            .expect("CSP header must be set")
+            .to_owned();
+        let nonce = csp
+            .split("'nonce-")
+            .nth(1)
+            .and_then(|rest| rest.split('\'').next())
+            .expect("CSP header must advertise a nonce")
+            .to_owned();
+
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let html = String::from_utf8(body.to_vec()).unwrap();
+        assert!(
+            html.contains(&format!(r#"nonce="{nonce}""#)),
+            "banner's <style> must carry the nonce recovered from the CSP header: {html}"
+        );
+    }
+
+    // ── conditional-request headers stripped while prompting ─────────
+
+    #[tokio::test]
+    async fn strips_conditional_request_headers_while_prompting_so_etag_cannot_shortcut_to_304() {
+        let app = Router::new()
+            .route(
+                "/",
+                get(|headers: axum::http::HeaderMap| async move {
+                    let has_inm = headers.contains_key(axum::http::header::IF_NONE_MATCH);
+                    let has_ims = headers.contains_key(axum::http::header::IF_MODIFIED_SINCE);
+                    Response::builder()
+                        .header(CONTENT_TYPE, "text/html; charset=utf-8")
+                        .body(Body::from(format!(
+                            "<html><body>inm={has_inm} ims={has_ims}</body></html>"
+                        )))
+                        .unwrap()
+                }),
+            )
+            .layer(axum::middleware::from_fn(move |req, next| async move {
+                inject_consent_banner(req, next, 1, "autumn-csrf").await
+            }));
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/")
+                    .header(axum::http::header::IF_NONE_MATCH, "\"abc\"")
+                    .header(
+                        axum::http::header::IF_MODIFIED_SINCE,
+                        "Wed, 21 Oct 2015 07:28:00 GMT",
+                    )
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let text = String::from_utf8(body.to_vec()).unwrap();
+        assert!(text.contains("inm=false"), "{text}");
+        assert!(text.contains("ims=false"), "{text}");
+    }
+
+    #[tokio::test]
+    async fn preserves_conditional_request_headers_when_consent_already_decided() {
+        let app = Router::new()
+            .route(
+                "/",
+                get(|headers: axum::http::HeaderMap| async move {
+                    let has_inm = headers.contains_key(axum::http::header::IF_NONE_MATCH);
+                    Response::builder()
+                        .header(CONTENT_TYPE, "text/html; charset=utf-8")
+                        .body(Body::from(format!(
+                            "<html><body>inm={has_inm}</body></html>"
+                        )))
+                        .unwrap()
+                }),
+            )
+            .layer(axum::middleware::from_fn(move |req, next| async move {
+                inject_consent_banner(req, next, 1, "autumn-csrf").await
+            }));
+
+        let cookie = super::super::accept_all_cookie(&["analytics"], 1);
+        let raw_value = cookie
+            .split(';')
+            .next()
+            .unwrap()
+            .strip_prefix("autumn.consent=")
+            .unwrap();
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/")
+                    .header("cookie", format!("autumn.consent={raw_value}"))
+                    .header(axum::http::header::IF_NONE_MATCH, "\"abc\"")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let text = String::from_utf8(body.to_vec()).unwrap();
+        assert!(
+            text.contains("inm=true"),
+            "no need to force-bust caching when the banner won't show anyway: {text}"
         );
     }
 }

--- a/autumn/src/consent/banner.rs
+++ b/autumn/src/consent/banner.rs
@@ -154,7 +154,14 @@ pub fn consent_banner_markup(csrf_token: Option<&str>, csrf_field_name: &str) ->
 /// `Cache-Control: private, no-store` and `Vary: Cookie` — otherwise a page
 /// the app marked publicly cacheable (e.g. via `cache_for(..).public()`)
 /// could have one visitor's CSRF token served to every other visitor (and
-/// any CDN/proxy in between) until the cache entry expires.
+/// any CDN/proxy in between) until the cache entry expires. For an HTML
+/// response where the visitor has already decided (so nothing is injected),
+/// `Vary: Cookie` is still appended — the app's own handler can render
+/// differently based on the same Consent cookie (e.g.
+/// `consent.allows("analytics", ...)`-gated markup), so a shared cache must
+/// never serve that decided visitor's exact representation to a different
+/// one. `Cache-Control` is left alone in that case, since nothing per-visitor
+/// was freshly embedded and the app's own caching choice should stand.
 ///
 /// If the response already contains the banner's own marker class (e.g. a
 /// "manage cookie preferences" handler rendered [`consent_banner_markup`]
@@ -214,9 +221,26 @@ pub async fn inject_consent_banner(
         request.headers_mut().remove(IF_MODIFIED_SINCE);
     }
 
-    let response = next.run(request).await;
+    let mut response = next.run(request).await;
 
-    if !needs_prompt || !is_html_response(&response) {
+    if !is_html_response(&response) {
+        return response;
+    }
+
+    if !needs_prompt {
+        // A handler can still render differently based on the visitor's
+        // Consent cookie even when this middleware injects nothing (e.g.
+        // `consent.allows("analytics", ...)`-gated markup) — this visitor
+        // simply happens to have already decided. If the app marked the
+        // page publicly cacheable, a shared cache must never serve this
+        // visitor's exact representation to a different visitor (one who's
+        // undecided, or decided under different categories), so it has to
+        // vary on the same header this middleware itself reads consent
+        // from. `append` (not `insert`) preserves any `Vary` the app's own
+        // handler already set (e.g. `Accept-Language`).
+        response
+            .headers_mut()
+            .append(VARY, HeaderValue::from_static("Cookie"));
         return response;
     }
 
@@ -902,7 +926,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn no_cache_headers_added_when_consent_already_decided() {
+    async fn no_cache_control_added_when_consent_already_decided() {
         let app = app_with_policy_version(1);
         let cookie = super::super::accept_all_cookie(&["analytics"], 1);
         let raw_value = cookie
@@ -923,7 +947,41 @@ mod tests {
             .unwrap();
         assert!(
             response.headers().get(CACHE_CONTROL).is_none(),
-            "no banner injected, so this middleware must not touch caching headers"
+            "no banner injected, so this middleware must leave the app's own Cache-Control alone"
+        );
+    }
+
+    #[tokio::test]
+    async fn varies_on_cookie_even_when_consent_already_decided_and_nothing_is_injected() {
+        // The app's own handler can render differently based on the same
+        // Consent cookie (e.g. `consent.allows("analytics", ...)`-gated
+        // markup) even when this middleware itself injects nothing for an
+        // already-decided visitor. A shared cache that stored this
+        // visitor's exact representation must never replay it to a
+        // different visitor (undecided, or decided under different
+        // categories), so the response must still vary on `Cookie`.
+        let app = app_with_policy_version(1);
+        let cookie = super::super::accept_all_cookie(&["analytics"], 1);
+        let raw_value = cookie
+            .split(';')
+            .next()
+            .unwrap()
+            .strip_prefix("autumn.consent=")
+            .unwrap();
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/")
+                    .header("cookie", format!("autumn.consent={raw_value}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            response.headers().get(VARY).and_then(|v| v.to_str().ok()),
+            Some("Cookie"),
+            "a decided-but-not-injected HTML response must still vary on Cookie"
         );
     }
 

--- a/autumn/src/consent/banner.rs
+++ b/autumn/src/consent/banner.rs
@@ -414,9 +414,15 @@ async fn splice_into_response(response: Response<Body>, snippet: &str) -> Respon
     }
 }
 
-/// Insert `snippet` just before the last `</body>` tag, or append it if the
-/// document has an `<html>`/`</html>` shell but no `</body>`. Leaves `body`
-/// unchanged if neither is present.
+/// Insert `snippet` just before the last `</body>` tag, or append it at the
+/// very end otherwise. The caller ([`splice_into_response`], via
+/// [`is_html_response`]) only ever invokes this on a response whose
+/// `Content-Type` is already validated as `text/html`, so a document that
+/// omits its `<html>`/`<body>` wrapper tags entirely — valid HTML5 tag
+/// omission, e.g. `<!doctype html><main>...</main>` — is still a real page a
+/// browser parses and implicitly wraps in `<body>`; appending at the end
+/// still lands the banner where a browser renders it, rather than silently
+/// sending no banner just because no explicit wrapper tag was present.
 ///
 /// Operates directly on the raw bytes rather than decoding through
 /// `String::from_utf8_lossy`: an HTML page using a legacy single-byte charset
@@ -436,15 +442,9 @@ fn splice_before_body_close(body: &[u8], snippet: &str) -> Vec<u8> {
         return out;
     }
 
-    if contains_ascii_case_insensitive(body, b"<html")
-        || contains_ascii_case_insensitive(body, b"</html>")
-    {
-        let mut out = body.to_vec();
-        out.extend_from_slice(snippet.as_bytes());
-        return out;
-    }
-
-    body.to_vec()
+    let mut out = body.to_vec();
+    out.extend_from_slice(snippet.as_bytes());
+    out
 }
 
 /// Byte offset of the last case-insensitive (ASCII-only) match of `needle`
@@ -548,9 +548,16 @@ mod tests {
     }
 
     #[test]
-    fn splice_leaves_non_html_untouched() {
-        let out = splice_before_body_close(b"not html at all", "<snip>");
-        assert_eq!(out, b"not html at all");
+    fn splice_appends_when_no_recognizable_html_wrapper_tag_is_present() {
+        // The caller only ever invokes this on a response whose Content-Type
+        // is already validated as text/html (is_html_response), so a
+        // document that omits its <html>/<body> wrapper tags entirely --
+        // valid HTML5 tag omission, e.g. `<!doctype html><main>...</main>`
+        // -- is still a real page a browser renders; it must still get the
+        // banner appended rather than being silently skipped.
+        let out = splice_before_body_close(b"<!doctype html><main>ok</main>", "<snip>");
+        let s = String::from_utf8(out).unwrap();
+        assert!(s.ends_with("<snip>"), "{s}");
     }
 
     #[test]

--- a/autumn/src/lib.rs
+++ b/autumn/src/lib.rs
@@ -98,6 +98,7 @@ pub use channels::{
 pub mod canary;
 pub mod circuit_breaker;
 pub mod config;
+pub mod consent;
 pub mod credentials;
 pub mod current;
 #[cfg(feature = "db")]

--- a/autumn/src/ui/widgets.css
+++ b/autumn/src/ui/widgets.css
@@ -1270,6 +1270,72 @@
     cursor: not-allowed;
 }
 
+/* ── Cookie-consent banner (issue #1214) ──────────────────────────────────── */
+
+/* Fixed to the bottom of the viewport so it doesn't shift page content, but
+   not a full-screen overlay — a persistent bar, not a blocking modal. Its
+   companion inline `<style>` (emitted alongside this markup, see
+   `consent::banner::BANNER_SPACE_RESERVATION_CSS`) reserves matching
+   `padding-bottom` on `<body>` so it never permanently hides page content
+   (e.g. a `<footer>`) underneath it. `--text-muted` (not `--border`, which is
+   only ~1.2:1 against `--surface`) gives the boundary the ~3:1 contrast
+   WCAG 1.4.11 requires for a UI-component edge; `--shadow` reinforces it. */
+.autumn-consent-banner {
+    position: fixed;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    z-index: 1000;
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    padding: 1rem 1.5rem;
+    background-color: var(--surface);
+    border-top: 1px solid var(--text-muted);
+    box-shadow: var(--shadow);
+    color: var(--text);
+}
+
+.autumn-consent-banner__message {
+    margin: 0;
+    flex: 1 1 20rem;
+    font-size: 0.9rem;
+}
+
+.autumn-consent-banner__actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    margin: 0;
+}
+
+/* Reject and Accept share this one base class — and no other sizing/color
+   rule distinguishes them — so rejecting is exactly as easy (same size,
+   same prominence) as accepting. Do not add a `--reject`/`--accept`-only
+   rule that changes size, weight, or fill; that would recreate the
+   dark-pattern "big Accept button, buried Reject link" this widget exists
+   to avoid. */
+.autumn-consent-banner__button {
+    padding: 0.5rem 1rem;
+    border: 1px solid var(--text-muted);
+    border-radius: var(--radius);
+    background-color: var(--surface);
+    color: var(--text);
+    font: inherit;
+    cursor: pointer;
+}
+
+.autumn-consent-banner__button:hover {
+    border-color: var(--primary);
+}
+
+.autumn-consent-banner__button:focus-visible {
+    outline: 2px solid var(--primary);
+    outline-offset: 2px;
+}
+
 /* Visually hidden but still exposed to assistive technology — the standard
    clip pattern (never `display:none`, which removes it from the a11y tree). */
 .autumn-visually-hidden {

--- a/autumn/src/ui/widgets.css
+++ b/autumn/src/ui/widgets.css
@@ -1272,16 +1272,21 @@
 
 /* ── Cookie-consent banner (issue #1214) ──────────────────────────────────── */
 
-/* Fixed to the bottom of the viewport so it doesn't shift page content, but
-   not a full-screen overlay — a persistent bar, not a blocking modal. Its
-   companion inline `<style>` (emitted alongside this markup, see
-   `consent::banner::BANNER_SPACE_RESERVATION_CSS`) reserves matching
-   `padding-bottom` on `<body>` so it never permanently hides page content
-   (e.g. a `<footer>`) underneath it. `--text-muted` (not `--border`, which is
-   only ~1.2:1 against `--surface`) gives the boundary the ~3:1 contrast
-   WCAG 1.4.11 requires for a UI-component edge; `--shadow` reinforces it. */
+/* `position: sticky` (not `fixed`) deliberately: the banner is spliced right
+   before `</body>`, so as the last element in normal document flow it always
+   reserves exactly its own real, responsive height -- however many lines the
+   message/buttons wrap to on a narrow viewport or at increased text zoom --
+   with no separate CSS reservation hack that could fall out of sync and let
+   a `fixed` banner permanently cover page content (e.g. a `<footer>`)
+   underneath it. It still behaves like a persistent bottom bar (not a
+   full-screen overlay, not a blocking modal) on any page taller than the
+   viewport, which is the common case; on a very short page it simply settles
+   in flow just after the content rather than pinned to the visual bottom of
+   the screen. `--text-muted` (not `--border`, which is only ~1.2:1 against
+   `--surface`) gives the boundary the ~3:1 contrast WCAG 1.4.11 requires for
+   a UI-component edge; `--shadow` reinforces it. */
 .autumn-consent-banner {
-    position: fixed;
+    position: sticky;
     left: 0;
     right: 0;
     bottom: 0;

--- a/skills/autumn-web/SKILL.md
+++ b/skills/autumn-web/SKILL.md
@@ -664,6 +664,23 @@ export AUTUMN_SECURITY__SIGNING_SECRET="$(openssl rand -hex 32)"
 For rotation, set `[security.signing_secret].previous_secrets` until old
 cookies, CSRF tokens, flash state, and signed storage URLs expire.
 
+### Cookie consent (unreleased — trunk-dev, issue #1214)
+
+`autumn new` scaffolds a cookie-consent banner and a real consent gate by
+default — no third-party tracker, no JS. `autumn_web::consent::Consent` is an
+extractor read straight off the request's `Cookie` header (no middleware
+dependency); `consent.allows("analytics", POLICY_VERSION)` is the actual
+enforcement gate (returns `false` for every category except `"necessary"`
+until a decision is recorded under the current policy version).
+`accept_all_cookie` / `reject_non_essential_cookie` / `expire_consent_cookie`
+build the `Set-Cookie` value recording categories + policy version +
+timestamp. `inject_consent_banner` (behind the `maud` feature; mirrors the
+dev-mode live-reload injector) auto-splices the banner into every HTML
+response — no change to the shared `layout()` signature is needed. Bump the
+scaffolded `CONSENT_POLICY_VERSION` constant to invalidate prior consent and
+re-show the banner. Strictly-necessary cookies (session, CSRF) are never
+routed through the gate.
+
 ### Audit actor attribution (unreleased — trunk-dev)
 
 Version/audit writes are auto-attributed to the current actor — no per-call

--- a/skills/autumn-web/SKILL.md
+++ b/skills/autumn-web/SKILL.md
@@ -676,10 +676,16 @@ until a decision is recorded under the current policy version).
 build the `Set-Cookie` value recording categories + policy version +
 timestamp. `inject_consent_banner` (behind the `maud` feature; mirrors the
 dev-mode live-reload injector) auto-splices the banner into every HTML
-response — no change to the shared `layout()` signature is needed. Bump the
-scaffolded `CONSENT_POLICY_VERSION` constant to invalidate prior consent and
-re-show the banner. Strictly-necessary cookies (session, CSRF) are never
-routed through the gate.
+response — no change to the shared `layout()` signature is needed. Takes the
+CSRF cookie name and form-field name as explicit parameters
+(`DEFAULT_CSRF_COOKIE_NAME` / `DEFAULT_CSRF_FORM_FIELD` when unconfigured)
+rather than reading them off request/response state, since `CsrfLayer` always
+sits inner to user layers. Skips injection entirely for an internal `autumn
+build` / ISR render (`static_gen::RenderDeadlineExempt`) rather than baking
+the banner into the static file written to `dist/`. Bump the scaffolded
+`CONSENT_POLICY_VERSION` constant to invalidate prior consent and re-show the
+banner. Strictly-necessary cookies (session, CSRF) are never routed through
+the gate.
 
 ### Audit actor attribution (unreleased — trunk-dev)
 

--- a/skills/autumn-web/references/api-reference.md
+++ b/skills/autumn-web/references/api-reference.md
@@ -424,14 +424,24 @@ Per-primitive setters (in addition to the shared set):
   -> bool`. `accept_all_cookie(&[categories], policy_version)` /
   `reject_non_essential_cookie(policy_version)` / `expire_consent_cookie()`
   build the `Set-Cookie` value (categories + policy version + RFC 3339
-  timestamp). `consent_banner_markup(csrf_token)` (feature `maud`) and
-  `inject_consent_banner(request, next, policy_version, csrf_cookie_name)`
-  (feature `maud`) — a response-body-splice middleware, registered via
+  timestamp). `consent_banner_markup(csrf_token, csrf_field_name)` (feature
+  `maud`) and `inject_consent_banner(request, next, policy_version,
+  csrf_cookie_name, csrf_form_field)` (feature `maud`, `DEFAULT_CSRF_COOKIE_NAME`
+  / `DEFAULT_CSRF_FORM_FIELD` constants for the unconfigured defaults) — a
+  response-body-splice middleware, registered via
   `.layer(axum::middleware::from_fn(...))`, that auto-injects the banner into
   every HTML response without changing the shared `layout()` signature.
-  `safe_redirect_target` / `redirect_target_from_referer` are open-redirect-safe
-  helpers for routing a visitor back to the page they were on after they
-  record a choice. Session and CSRF cookies are never routed through the gate.
+  `csrf_form_field` is a plain parameter (not read from a `CsrfFormField`
+  request extension) because `CsrfLayer` always sits inner to user layers in
+  the documented stack. An internal `autumn build` / ISR render (tagged
+  `static_gen::RenderDeadlineExempt`) is passed through untouched rather than
+  having the banner baked into the static file on disk. `safe_redirect_target`
+  / `redirect_target_from_referer` are open-redirect-safe helpers for routing
+  a visitor back to the page they were on after they record a choice. Session
+  and CSRF cookies are never routed through the gate. Known limitation: a
+  first-time visitor whose first hit lands on a `#[static_get]` page is served
+  before `CsrfLayer` runs, so the banner has no CSRF token to embed and its
+  forms 403 until the visitor reaches a dynamic page at least once.
 
 (Typed accessible primitives — `Img` / `Button` / `Link` / `MenuItem` /
 `TextField` / `TextArea` / `Select` / `Checkbox` / `FileField` — are documented

--- a/skills/autumn-web/references/api-reference.md
+++ b/skills/autumn-web/references/api-reference.md
@@ -416,6 +416,22 @@ Per-primitive setters (in addition to the shared set):
   `cursor_pagination_nav(&CursorPage, &PagerOptions)`, `PagerOptions::new(base)
   .query(qs).hx_target(sel).hx_push_url()` (prelude re-exports).
 - `autumn_web::ui::{WIDGETS_CSS, WIDGETS_CSS_PATH}` widget stylesheet.
+- `autumn_web::consent` (issue #1214, `maud`-gated parts noted below) —
+  cookie-consent banner + gate scaffolded by `autumn new` by default.
+  `Consent` extractor (reads the `Cookie` header directly, no middleware
+  needed) with `consent.allows(category, current_policy_version) -> bool`
+  (always `true` for `"necessary"`) and `consent.needs_prompt(current_policy_version)
+  -> bool`. `accept_all_cookie(&[categories], policy_version)` /
+  `reject_non_essential_cookie(policy_version)` / `expire_consent_cookie()`
+  build the `Set-Cookie` value (categories + policy version + RFC 3339
+  timestamp). `consent_banner_markup(csrf_token)` (feature `maud`) and
+  `inject_consent_banner(request, next, policy_version, csrf_cookie_name)`
+  (feature `maud`) — a response-body-splice middleware, registered via
+  `.layer(axum::middleware::from_fn(...))`, that auto-injects the banner into
+  every HTML response without changing the shared `layout()` signature.
+  `safe_redirect_target` / `redirect_target_from_referer` are open-redirect-safe
+  helpers for routing a visitor back to the page they were on after they
+  record a choice. Session and CSRF cookies are never routed through the gate.
 
 (Typed accessible primitives — `Img` / `Button` / `Link` / `MenuItem` /
 `TextField` / `TextArea` / `Select` / `Checkbox` / `FileField` — are documented


### PR DESCRIPTION
## Summary

Closes #1214. `autumn new` now scaffolds a working cookie-consent banner plus a real consent gate, so a fresh app is cookie-compliant by default — server-rendered, no external JS, no third-party tracker.

- **New `autumn_web::consent` module** (`autumn/src/consent.rs`, `autumn/src/consent/banner.rs`):
  - `Consent` — an Axum extractor read directly off the request's `Cookie` header (no middleware/app-state dependency).
  - `accept_all_cookie` / `reject_non_essential_cookie` / `expire_consent_cookie` — build the `Set-Cookie` value for a first-party cookie recording categories + policy version + timestamp.
  - `Consent::allows(category, current_policy_version)` — the actual gate. Requires a recorded decision **and** a matching policy version; `"necessary"` is always allowed.
  - `inject_consent_banner` (behind the `maud` feature) — a response-body-splice middleware (mirrors the existing dev-mode live-reload injector) that auto-injects the banner into every HTML page. No change to the shared `layout()` function's stable 4-arg signature that `autumn generate scaffold` depends on.
- **Scaffold wiring** (`autumn-cli/src/templates/main.rs.tmpl`): a `CONSENT_POLICY_VERSION` constant, the middleware wired into the app builder, `POST /consent/accept` / `POST /consent/reject` (redirect back to the referring page via `Referer`, not always the homepage), and a `GET /consent/manage` withdrawal link in the footer (GDPR Art. 7(3): withdrawal must be as easy as consent).
- Skipped entirely for `autumn new --api` (no HTML layout to show a banner in).

### Planning approach

Brainstormed four ways to wire the banner into the shared layout (5th layout param, per-handler composition, htmx lazy-fetch, response-body-splice) and reverse-brainstormed failure modes (compliance theater, buried reject, forgeable accept, stale-version leakage, breaking login) before picking the body-splice approach, since `autumn generate scaffold` hard-asserts the shared `layout()` stays an exact 4-argument call.

### Review round

Ran three independent reviews (security, correctness/compliance, accessibility/API-design) against the initial implementation. Confirmed and fixed:
- `find_cookie` aborting the whole cookie scan on one malformed/valueless pair, and only reading the first `Cookie` header (HTTP/2 clients may split cookies across several) — now mirrors `session::get_cookie`'s parsing **and** its cookie-tossing defense (rejects ambiguous duplicate cookie names).
- Unbounded (`usize::MAX`) response-body buffering in an always-on production middleware — now capped (2 MiB, matching the CSRF body-scan precedent), with a documented fallback.
- A live per-visitor CSRF token getting embedded into a response an app might mark publicly cacheable — the middleware now stamps `Cache-Control: private, no-store` / `Vary: Cookie` whenever it actually injects.
- Hardcoded CSRF cookie name — `inject_consent_banner` now takes it as a parameter.
- `Redirect::to("/")` losing the visitor's place — added `redirect_target_from_referer` (host/scheme discarded before any safety check, so it can't redirect off-site) plus `safe_redirect_target` for open-redirect defense in depth.
- No way to withdraw consent once decided — added the `/consent/manage` route + footer link.
- Banner's fixed-bottom positioning permanently hiding page content (e.g. the footer) — a companion inline `<style>` (mirroring the existing dev-error-badge's own inline-CSS precedent) reserves the space.
- `--border` giving only ~1.2:1 contrast against `--surface` on the banner/buttons (WCAG 1.4.11 wants ~3:1) — switched to `--text-muted` + `--shadow`.
- The "gate is enforcement, verified by a test" AC had only an isolated-predicate test — added an end-to-end test that boots a real `SessionLayer` + a handler conditionally setting an "analytics" cookie, proving the session cookie is set unconditionally while the non-essential cookie is withheld until consent.

## Acceptance criteria — evidence

| # | Criterion | Evidence |
|---|---|---|
| 1 | Banner scaffolded into shared layout, shown until a choice is recorded; accessible; no external JS; classes-only styling | `inject_consent_banner` auto-injects into every HTML page (`banner.rs`); `role="region"` + `aria-label="Cookie consent"`, native `type="submit"` buttons; zero JS (`banner_needs_no_script_tag` test). One documented exception: a tiny scoped `<style>` (no `style=` attributes) reserves footer space, mirroring the existing dev-badge's own inline-CSS precedent in this codebase. |
| 2 | Reject as easy/prominent as Accept | Both buttons share `autumn-consent-banner__button` with **no** `--accept`/`--reject` CSS differentiation (`banner_reject_and_accept_share_the_same_base_button_class`) |
| 3 | Cookie captures categories + policy version + timestamp, typed helper | `Consent` extractor, `consent.allows("analytics", POLICY_VERSION)`; round-trip tests in `consent.rs` |
| 4 | Gate is real enforcement, verified by a test | `gate_withholds_non_essential_cookie_while_session_cookie_is_unaffected` (`banner.rs`) — a real handler only sets an "analytics" cookie when `consent.allows(...)`; asserted absent pre-consent, present post-accept |
| 5 | Strictly-necessary cookies exempt + documented, login unaffected | Documented in `consent.rs` module docs; same test above boots a real `SessionLayer` and asserts the session cookie is set regardless of consent state |
| 6 | Re-prompt on policy version bump | `needs_prompt`/`allows` compare `policy_version`; `allows_denies_category_after_policy_version_bump_even_if_previously_accepted`, `reprompts_when_recorded_consent_is_from_an_older_policy_version` (end-to-end through the real middleware) |
| 7 | Granular categories optional; default ships simple accept/reject | `Vec<String>` categories (not a fixed enum); scaffold ships one `"analytics"` category with a comment on adding more |
| 8 | Additive; no breaking change; no version bump | New module + CLI template additions only; `--api` flavor untouched (`api_flavor_does_not_scaffold_consent_banner`); `CHANGELOG.md` bullet under existing `## [Unreleased]`; root `Cargo.toml` version untouched |

**Known, pre-existing gap not introduced by this PR:** the separate `saas` starter's own `layout.rs` (3-arg, predates #1130's flash wiring too) isn't wired up — consistent with that starter already lagging the base scaffold on layout evolution.

## Test plan

- [x] `cargo test -p autumn-web --lib` — 4044 passed (0 failed), including the new `consent`/`consent::banner` modules
- [x] `cargo test -p autumn-cli --bin autumn` — 4475 passed (0 failed), including new scaffold-wiring tests (`--api`, `--with-i18n`, `--daemon`, `--bundled-pg` combinations all still generate correctly)
- [x] `cargo test --doc -p autumn-web` (consent doctests) — all pass
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy -p autumn-web` / `-p autumn-cli` (`--all-targets -- -D warnings`) — clean
- [x] `cargo check --workspace` — clean
- [x] `./scripts/pre-push-check.sh` — passed

---
_Generated by [Claude Code](https://claude.ai/code/session_01UF4pKZbYKaK2EcC9W8StQ6)_