### PR TITLE
feat: safe rich-text field with Markdown editor and sanitized render (#1255)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
         # is unusable here: `managed-pg-bundled` pulls in `postgresql_embedded`, whose
         # build script downloads Postgres binaries; this explicit list covers exactly
         # the gated modules with no new services.)
-        run: cargo clippy -p autumn-web --features "ws,mail,offline-sync,redis" --all-targets -- -D warnings
+        run: cargo clippy -p autumn-web --features "ws,mail,offline-sync,redis,markdown" --all-targets -- -D warnings
       - name: Panic-free request-path gate
         run: ./scripts/check-panic-gate.sh
       - name: Accessibility gate (raw html! escape hatches across the repo)
@@ -100,6 +100,17 @@ jobs:
         continue-on-error: true
       - name: Run tests
         run: cargo test --workspace
+      - name: Run markdown-gated tests (user-content sanitizer)
+        # `markdown` is not a default feature, so the `cargo test --workspace`
+        # above compiles neither the stored-XSS regression corpus
+        # (`autumn/tests/integration/rich_text.rs`, gated on
+        # `markdown` + `maud`) nor the `markdown::user_content` doctests. That
+        # corpus IS the safety guarantee for user-submitted rich text
+        # (issue #1255), so it has to run in a lane that blocks merge.
+        run: |
+          cargo test -p autumn-web --features markdown --test integration_tests rich_text
+          cargo test -p autumn-web --features markdown --lib markdown::
+          cargo test -p autumn-web --features markdown --doc markdown::
       - name: Install Postgres client tools (Linux)
         if: runner.os == 'Linux'
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,8 +75,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   field it renders, via the new `form::field_from_urlencoded` — the editor
   `hx-include`s the whole form, so decoding the form struct would fail on the
   first strictly-typed empty column of a freshly-opened `new` page and leave the
-  preview blank until every unrelated field was filled in. See the [rich text
-  guide](docs/guide/rich-text.md). `form::rich_text_area` renders a labeled
+  preview blank until every unrelated field was filled in. A non-nullable
+  `richtext` column renders through `required_rich_text_area*`, matching every
+  other non-nullable generated control — `String` and `TEXT NOT NULL` both
+  accept `""`, so without that signal an empty editor persisted a blank body.
+  See the [rich text guide](docs/guide/rich-text.md). `form::rich_text_area` renders a labeled
   textarea, a minimal Markdown formatting toolbar, and the current value; the
   toolbar shows each construct's syntax rather than inserting it on click,
   because inserting into a `<textarea>` needs JavaScript and a control that

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **rich text:** a safe first-class path for **user-submitted** formatted text,
+  so a content app built on Autumn cannot ship stored XSS by using the shipped
+  helpers (#1255). `autumn generate scaffold post title:String body:richtext`
+  is the whole setup: a `TEXT` column holding the Markdown **source**, a form
+  with a Markdown editor and an htmx live preview, and a show view that renders
+  through a sanitizer — no JavaScript of your own and no sanitizer to
+  configure. The renderer is `autumn_web::markdown::render_user_content`, and
+  it applies two independent controls: raw-HTML passthrough is disabled at the
+  parser (raw markup becomes escaped text, and link/image destinations are
+  checked against a URL-scheme allowlist before the HTML writer runs), and the
+  resulting HTML is then run through an `ammonia` allowlist built from the
+  curated `RICH_TEXT_ALLOWED_TAGS` / `RICH_TEXT_ALLOWED_URL_SCHEMES` public
+  constants. Either control alone blocks the canonical payloads; both are
+  applied so a bypass of one is not a bypass of the feature. The allowlist is
+  deliberately tight — no `<img>` (a Markdown image degrades to its alt text,
+  so a post cannot beacon a reader's IP to a third-party host), no `id`/`name`
+  (DOM clobbering), `style` narrowed to table alignment, `class` narrowed to
+  the code-fence language hint, and `rel="noopener noreferrer nofollow"` forced
+  onto every surviving link. This is the counterpart to the existing
+  `markdown::render`, which stays what it always was — a *trusted*,
+  build-time renderer that injects heading anchors and applies no allowlist;
+  its docs now say so and point here. `form::rich_text_area` renders the
+  editor, `form::rich_text_area_htmx` adds the preview pane (filtering the
+  one-time submit token out of the preview POST), and `sanitize_user_html`
+  applies the same allowlist when the untrusted rich text arrives as HTML
+  rather than Markdown. A 40-payload adversarial corpus locks the guarantee
+  down structurally — it parses the rendered output and asserts that no
+  non-allowlisted element, no event-handler attribute, and no URL outside the
+  scheme allowlist survives. See the [rich text
+  guide](docs/guide/rich-text.md).
 - **search:** a new optional plugin crate, `autumn-search`, turning the in-core
   full-text primitives (#842) into a **search subsystem**: mark a model
   searchable and get an index that stays in sync with the record lifecycle,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,7 +71,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   rather than Markdown. A 40-payload adversarial corpus locks the guarantee
   down structurally — it parses the rendered output and asserts that no
   non-allowlisted element, no event-handler attribute, and no URL outside the
-  scheme allowlist survives. See the [rich text
+  scheme allowlist survives. The generated preview endpoint reads only the
+  field it renders, via the new `form::field_from_urlencoded` — the editor
+  `hx-include`s the whole form, so decoding the form struct would fail on the
+  first strictly-typed empty column of a freshly-opened `new` page and leave the
+  preview blank until every unrelated field was filled in. See the [rich text
   guide](docs/guide/rich-text.md). `form::rich_text_area` renders a labeled
   textarea, a minimal Markdown formatting toolbar, and the current value; the
   toolbar shows each construct's syntax rather than inserting it on click,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   so a post cannot beacon a reader's IP to a third-party host), no `id`/`name`
   (DOM clobbering), `style` narrowed to table alignment, `class` narrowed to
   the code-fence language hint, and `rel="noopener noreferrer nofollow"` forced
-  onto every surviving link. This is the counterpart to the existing
+  onto every surviving link. Block nesting is capped at 100 levels: the HTML
+  sanitizer walks its open-elements stack once per block start tag, so
+  uncapped nesting would be quadratic — and `"> "` is two source bytes per
+  level, which would let one request body (or one stored post, re-rendered on
+  every view) burn minutes of CPU. This is the counterpart to the existing
   `markdown::render`, which stays what it always was — a *trusted*,
   build-time renderer that injects heading anchors and applies no allowlist;
   its docs now say so and point here. `form::rich_text_area` renders the
@@ -38,7 +42,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   down structurally — it parses the rendered output and asserts that no
   non-allowlisted element, no event-handler attribute, and no URL outside the
   scheme allowlist survives. See the [rich text
-  guide](docs/guide/rich-text.md).
+  guide](docs/guide/rich-text.md). `form::rich_text_area` renders a labeled
+  textarea, a minimal Markdown formatting toolbar, and the current value; the
+  toolbar shows each construct's syntax rather than inserting it on click,
+  because inserting into a `<textarea>` needs JavaScript and a control that
+  silently does nothing without scripting is worse than none — the editor's
+  contract is that it works with no JavaScript at all.
 - **search:** a new optional plugin crate, `autumn-search`, turning the in-core
   full-text primitives (#842) into a **search subsystem**: mark a model
   searchable and get an index that stays in sync with the record lifecycle,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -85,6 +85,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "ammonia"
+version = "4.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc6d763210e2eb7670d1a5183a08bebefa3f97db2a738a684f2ce00bd49f681d"
+dependencies = [
+ "cssparser",
+ "html5ever",
+ "maplit",
+ "url",
+]
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -544,6 +556,7 @@ name = "autumn-web"
 version = "0.6.0"
 dependencies = [
  "aes-gcm",
+ "ammonia",
  "autumn-macros",
  "axum",
  "base64 0.22.1",
@@ -4355,6 +4368,12 @@ dependencies = [
  "nix 0.29.0",
  "winapi",
 ]
+
+[[package]]
+name = "maplit"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
 
 [[package]]
 name = "markup5ever"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,6 +100,9 @@ time = { version = ">=0.3, <0.3.55" }
 csv = "1.3"
 rust_decimal = "1"
 pulldown-cmark = { version = "0.13", default-features = false, features = ["html"] }
+# HTML allowlist sanitizer for user-submitted rich text (issue #1255). Pulled in
+# by autumn-web's `markdown` feature; see `autumn/src/markdown/user_content.rs`.
+ammonia = "4.1"
 chromiumoxide = { version = "0.9", default-features = false }
 image = { version = "0.25", default-features = false, features = ["jpeg", "png", "webp"] }
 

--- a/autumn-cli/src/generate/admin.rs
+++ b/autumn-cli/src/generate/admin.rs
@@ -424,7 +424,12 @@ const fn is_default_optional(field: &Field) -> bool {
 
 fn is_default_hide_from_list(field: &Field) -> bool {
     // TextArea bodies and binary blobs clutter the table; updated_at is redundant noise.
-    matches!(field.kind, FieldKind::Text | FieldKind::Bytea) || field.name == "updated_at"
+    // `RichText` renders as a TextArea too (see `admin_field_kind`), and a
+    // Markdown body is the single worst column to inline in a list view.
+    matches!(
+        field.kind,
+        FieldKind::Text | FieldKind::RichText | FieldKind::Bytea
+    ) || field.name == "updated_at"
 }
 
 fn is_lock_version_field(field: &Field, lock_version_field: Option<&str>) -> bool {
@@ -1168,6 +1173,35 @@ mod tests {
     /// Create a minimal project root: Cargo.toml + src/models/<snake>.rs.
     fn project_with_model(snake: &str) -> TempDir {
         project_with_model_source(snake, "// stub\n")
+    }
+
+    #[test]
+    fn richtext_column_is_a_textarea_hidden_from_the_list() {
+        // A `richtext` column edits as a plain textarea in the admin's
+        // raw-value editor (issue #1255) — and a Markdown body is the single
+        // worst column to inline in a list table, exactly like a `Text` body.
+        let field = |kind: crate::generate::dsl::FieldKind| Field {
+            name: "body".to_owned(),
+            kind,
+            nullable: false,
+            variants: Vec::new(),
+            unique: false,
+            constraints: crate::generate::dsl::FieldConstraints::default(),
+            state_machine: None,
+        };
+        let rich = field(FieldKind::RichText);
+        let text = field(FieldKind::Text);
+        assert_eq!(admin_field_kind(&rich), "AdminFieldKind::TextArea");
+        assert!(
+            is_default_hide_from_list(&rich),
+            "a Markdown body must not clutter the admin list table"
+        );
+        // It behaves identically to the `Text` column it mirrors.
+        assert_eq!(admin_field_kind(&rich), admin_field_kind(&text));
+        assert_eq!(
+            is_default_hide_from_list(&rich),
+            is_default_hide_from_list(&text)
+        );
     }
 
     fn project_with_model_source(snake: &str, model_source: &str) -> TempDir {

--- a/autumn-cli/src/generate/admin.rs
+++ b/autumn-cli/src/generate/admin.rs
@@ -380,7 +380,11 @@ const fn admin_field_kind(field: &Field) -> &'static str {
         FieldKind::String | FieldKind::Uuid | FieldKind::Enum | FieldKind::Decimal { .. } => {
             "AdminFieldKind::Text"
         }
-        FieldKind::Text => "AdminFieldKind::TextArea",
+        // `RichText` (issue #1255) edits as a plain multi-line textarea in the
+        // admin panel: the column holds Markdown source, and the admin's
+        // record editor is a raw-value editor, not the app-facing form that
+        // renders `rich_text_area`'s hint and preview.
+        FieldKind::Text | FieldKind::RichText => "AdminFieldKind::TextArea",
         // A foreign-key id renders the same as any other integer column.
         FieldKind::I32 | FieldKind::I64 | FieldKind::References => "AdminFieldKind::Integer",
         FieldKind::Bool => "AdminFieldKind::Boolean",
@@ -400,7 +404,10 @@ fn admin_field_is_encrypted(options: &AdminOptions, name: &str) -> bool {
 }
 
 const fn is_default_searchable(field: &Field) -> bool {
-    matches!(field.kind, FieldKind::String | FieldKind::Text)
+    matches!(
+        field.kind,
+        FieldKind::String | FieldKind::Text | FieldKind::RichText
+    )
 }
 
 const fn is_default_filterable(field: &Field) -> bool {

--- a/autumn-cli/src/generate/dsl.rs
+++ b/autumn-cli/src/generate/dsl.rs
@@ -278,9 +278,9 @@ pub enum FieldKind {
     /// diesel token is `Text`, and the SQL column type is `TEXT` on both
     /// backends. The distinction is entirely in the generated UI:
     ///
-    /// - the form renders `autumn_web::form::rich_text_area` — a Markdown
-    ///   editor with a hint and (with `--live-validation`) an htmx live preview
-    ///   — instead of a bare `<textarea>`;
+    /// - the form renders `autumn_web::form::rich_text_area_htmx_with_token_field`
+    ///   — a Markdown editor with a no-JavaScript syntax toolbar and an htmx
+    ///   live preview — instead of a bare `<textarea>`;
     /// - the `show` view renders the value through
     ///   `autumn_web::markdown::render_user_content`, which disables raw-HTML
     ///   passthrough and applies an allowlist sanitizer, instead of emitting
@@ -289,8 +289,11 @@ pub enum FieldKind {
     ///   those resolve.
     ///
     /// The `{email}`/`{url}` format constraints are rejected on this kind
-    /// (a Markdown body cannot satisfy a single-line format validator), but the
-    /// `{min}`/`{max}` length bounds apply exactly as they do for `Text`.
+    /// (a Markdown body cannot satisfy a single-line format validator). The
+    /// `{min}`/`{max}` length bounds are accepted and emit the same server-side
+    /// `#[validate(length(…))]` rule as `Text`; unlike `Text` they emit no
+    /// client-side `minlength`/`maxlength`, because the editor is rendered by
+    /// `rich_text_area`, which takes no HTML5 constraint attributes.
     RichText,
     /// `i32` — `INTEGER`.
     I32,
@@ -1372,8 +1375,12 @@ fn set_label_constraint(
 fn unknown_constraint_message(token: &str, kind: FieldKind) -> String {
     let accepted = match kind {
         FieldKind::String | FieldKind::Text => "min=N, max=N, email, url",
-        FieldKind::RichText => "min=N, max=N",
-        FieldKind::I32 | FieldKind::I64 | FieldKind::F32 | FieldKind::F64 => "min=N, max=N",
+        // `RichText` shares the numeric arm's accepted set, not `String`'s: it
+        // takes the `min`/`max` length bounds but NOT the `email`/`url` format
+        // validators, which a Markdown body could never satisfy (issue #1255).
+        FieldKind::RichText | FieldKind::I32 | FieldKind::I64 | FieldKind::F32 | FieldKind::F64 => {
+            "min=N, max=N"
+        }
         FieldKind::References => "label:col",
         _ => "(none — this field type takes no constraint modifiers)",
     };

--- a/autumn-cli/src/generate/dsl.rs
+++ b/autumn-cli/src/generate/dsl.rs
@@ -217,7 +217,10 @@ impl Field {
         let c = &self.constraints;
         let mut out = Vec::new();
         match self.kind {
-            FieldKind::String | FieldKind::Text => {
+            // `RichText` shares `Text`'s length rules; its `email`/`url`
+            // constraints are rejected at parse time, so the flags below are
+            // always false for it.
+            FieldKind::String | FieldKind::Text | FieldKind::RichText => {
                 if c.min.is_some() || c.max.is_some() {
                     out.push(format!(
                         "length({})",
@@ -268,6 +271,27 @@ pub enum FieldKind {
     String,
     /// `Text` (alias for `String`) — `TEXT`.
     Text,
+    /// `richtext` — user-submitted Markdown, stored as `TEXT` (issue #1255).
+    ///
+    /// Storage-identical to [`FieldKind::Text`]: the column holds the Markdown
+    /// **source**, never rendered HTML, so the Rust type is `String`, the
+    /// diesel token is `Text`, and the SQL column type is `TEXT` on both
+    /// backends. The distinction is entirely in the generated UI:
+    ///
+    /// - the form renders `autumn_web::form::rich_text_area` — a Markdown
+    ///   editor with a hint and (with `--live-validation`) an htmx live preview
+    ///   — instead of a bare `<textarea>`;
+    /// - the `show` view renders the value through
+    ///   `autumn_web::markdown::render_user_content`, which disables raw-HTML
+    ///   passthrough and applies an allowlist sanitizer, instead of emitting
+    ///   the source as escaped text;
+    /// - the scaffold enables `autumn-web`'s `markdown` feature so both of
+    ///   those resolve.
+    ///
+    /// The `{email}`/`{url}` format constraints are rejected on this kind
+    /// (a Markdown body cannot satisfy a single-line format validator), but the
+    /// `{min}`/`{max}` length bounds apply exactly as they do for `Text`.
+    RichText,
     /// `i32` — `INTEGER`.
     I32,
     /// `i64` — `BIGINT`.
@@ -337,7 +361,7 @@ impl FieldKind {
             // `Enum`'s "String" here is a storage-representation fallback
             // only — `Field::rust_type()` overrides it with the generated
             // enum's real type name.
-            Self::String | Self::Text | Self::Enum => "String",
+            Self::String | Self::Text | Self::RichText | Self::Enum => "String",
             Self::I32 => "i32",
             // `References` is always `i64`, matching the default `i64` PK convention.
             Self::I64 | Self::References => "i64",
@@ -357,7 +381,7 @@ impl FieldKind {
     #[must_use]
     pub const fn schema_type(self) -> &'static str {
         match self {
-            Self::String | Self::Text | Self::Enum => "Text",
+            Self::String | Self::Text | Self::RichText | Self::Enum => "Text",
             Self::I32 => "Int4",
             Self::I64 | Self::References => "Int8",
             Self::Bool => "Bool",
@@ -376,7 +400,7 @@ impl FieldKind {
     #[must_use]
     pub const fn sql_type(self) -> &'static str {
         match self {
-            Self::String | Self::Text | Self::Enum => "TEXT",
+            Self::String | Self::Text | Self::RichText | Self::Enum => "TEXT",
             Self::I32 => "INTEGER",
             Self::I64 | Self::References => "BIGINT",
             Self::Bool => "BOOLEAN",
@@ -417,7 +441,7 @@ impl FieldKind {
     )]
     pub const fn sqlite_sql_type(self) -> &'static str {
         match self {
-            Self::String | Self::Text | Self::Enum => "TEXT",
+            Self::String | Self::Text | Self::RichText | Self::Enum => "TEXT",
             Self::I32 | Self::I64 | Self::References | Self::Bool => "INTEGER",
             Self::F32 | Self::F64 => "REAL",
             Self::Uuid => "TEXT",
@@ -481,7 +505,7 @@ impl FieldKind {
     )]
     pub const fn sqlite_schema_type(self) -> &'static str {
         match self {
-            Self::String | Self::Text | Self::Enum => "Text",
+            Self::String | Self::Text | Self::RichText | Self::Enum => "Text",
             Self::I32 => "Int4",
             Self::I64 | Self::References => "Int8",
             Self::Bool => "Bool",
@@ -562,6 +586,17 @@ impl FieldKind {
     #[must_use]
     pub const fn is_enum(self) -> bool {
         matches!(self, Self::Enum)
+    }
+
+    /// Returns `true` for a `richtext` field (issue #1255).
+    ///
+    /// Used by the scaffold generator to pick the Markdown editor control and
+    /// the sanitizing `show`-view render, and to enable `autumn-web`'s
+    /// `markdown` feature on the project. Storage-wise the column is
+    /// indistinguishable from [`FieldKind::Text`].
+    #[must_use]
+    pub const fn is_rich_text(self) -> bool {
+        matches!(self, Self::RichText)
     }
 
     /// Returns `true` for an exact-precision `decimal` field.
@@ -693,7 +728,7 @@ impl IdType {
 }
 
 /// Comma-separated list of supported types, for error messages and `--help`.
-pub const SUPPORTED_TYPES: &str = "String, Text, i32, i64, bool, f32, f64, \
+pub const SUPPORTED_TYPES: &str = "String, Text, richtext, i32, i64, bool, f32, f64, \
     Uuid, NaiveDateTime, DateTime, Vec<u8>, Bytea, Attachment, references, \
     enum{a,b,…}, decimal{precision,scale}, Option<…>, :unique";
 
@@ -702,7 +737,7 @@ pub const SUPPORTED_TYPES: &str = "String, Text, i32, i64, bool, f32, f64, \
 /// [`FieldKind::sqlite_has_diesel_conversion`] rejects (`Uuid`, `Decimal`,
 /// `Enum`). Used in the generate-time rejection message so the user knows which
 /// field kinds a `SQLite` app supports today.
-pub const SQLITE_SUPPORTED_KINDS: &str = "String, Text, i32, i64, bool, f32, f64, \
+pub const SQLITE_SUPPORTED_KINDS: &str = "String, Text, richtext, i32, i64, bool, f32, f64, \
     NaiveDateTime, DateTime, Vec<u8>, Bytea, Attachment, references, Option<…>, :unique";
 
 /// Comma-separated list of supported Postgres column types (`udt_name`), for
@@ -1115,6 +1150,14 @@ fn parse_field_constraints(body: &str, kind: FieldKind) -> Result<FieldConstrain
         );
     }
 
+    // `min`/`max` length bounds apply to every text-shaped column, `richtext`
+    // included. The `email`/`url` *format* validators do not: a Markdown body
+    // can never satisfy a single-line format rule, so accepting them would emit
+    // a field no submission could ever fill (issue #1255).
+    let length_bounded = matches!(
+        kind,
+        FieldKind::String | FieldKind::Text | FieldKind::RichText
+    );
     let string_like = matches!(kind, FieldKind::String | FieldKind::Text);
     let numeric = matches!(
         kind,
@@ -1171,7 +1214,7 @@ fn parse_field_constraints(body: &str, kind: FieldKind) -> Result<FieldConstrain
 
     // Cross-check the combination against the kind: length/range bounds need a
     // string or numeric field, and require min <= max when both are present.
-    if (c.min.is_some() || c.max.is_some()) && !string_like && !numeric {
+    if (c.min.is_some() || c.max.is_some()) && !length_bounded && !numeric {
         return Err(format!(
             "min/max constraints are not supported for {} fields",
             kind.rust_type()
@@ -1185,7 +1228,7 @@ fn parse_field_constraints(body: &str, kind: FieldKind) -> Result<FieldConstrain
         // instead of failing generation here. Each bound already passed
         // `parse_bound` for `kind`, so these re-parses succeed exactly.
         let inverted = match kind {
-            FieldKind::String | FieldKind::Text => {
+            FieldKind::String | FieldKind::Text | FieldKind::RichText => {
                 matches!((min.parse::<u64>(), max.parse::<u64>()), (Ok(lo), Ok(hi)) if lo > hi)
             }
             FieldKind::I32 | FieldKind::I64 => {
@@ -1237,7 +1280,7 @@ fn parse_bound(value: &str, kind: FieldKind) -> Result<String, String> {
     // concrete type and re-`to_string()`-ing yields a literal that is always
     // valid and value-preserving (issue #1388 follow-up).
     match kind {
-        FieldKind::String | FieldKind::Text => {
+        FieldKind::String | FieldKind::Text | FieldKind::RichText => {
             let n = value
                 .parse::<u64>()
                 .map_err(|_| format!("length bound '{value}' must be a non-negative integer"))?;
@@ -1329,6 +1372,7 @@ fn set_label_constraint(
 fn unknown_constraint_message(token: &str, kind: FieldKind) -> String {
     let accepted = match kind {
         FieldKind::String | FieldKind::Text => "min=N, max=N, email, url",
+        FieldKind::RichText => "min=N, max=N",
         FieldKind::I32 | FieldKind::I64 | FieldKind::F32 | FieldKind::F64 => "min=N, max=N",
         FieldKind::References => "label:col",
         _ => "(none — this field type takes no constraint modifiers)",
@@ -1601,6 +1645,11 @@ fn atomic_type(ty: &str) -> Option<FieldKind> {
         // References / references: foreign-key column, resolved to `_id` and
         // `BIGINT REFERENCES <table>(id)` by the callers that emit SQL.
         "References" | "references" => Some(FieldKind::References),
+        // richtext (issue #1255): a TEXT column holding user-submitted Markdown
+        // that the generated views render through the sanitizing
+        // `markdown::render_user_content`. All three spellings are accepted so
+        // the token reads naturally however the author types it.
+        "richtext" | "RichText" | "rich_text" => Some(FieldKind::RichText),
         _ => {
             // Allow `Vec<u8>` as a synonym for `Bytea`.
             strip_wrapper(ty, "Vec").and_then(|inner| {
@@ -2025,6 +2074,106 @@ mod tests {
     fn parse_attachment_lowercase() {
         let f = parse_field("cover_image:attachment").unwrap();
         assert_eq!(f.kind, FieldKind::Attachment);
+    }
+
+    // ── richtext (issue #1255) ─────────────────────────────────────────────
+
+    #[test]
+    fn parse_richtext_token() {
+        let f = parse_field("body:richtext").unwrap();
+        assert_eq!(f.kind, FieldKind::RichText);
+        assert!(!f.nullable);
+        assert_eq!(f.name, "body");
+    }
+
+    #[test]
+    fn parse_richtext_accepts_documented_spellings() {
+        for token in ["body:richtext", "body:RichText", "body:rich_text"] {
+            assert_eq!(
+                parse_field(token).unwrap().kind,
+                FieldKind::RichText,
+                "{token} should parse as RichText"
+            );
+        }
+    }
+
+    #[test]
+    fn richtext_stores_markdown_source_in_a_text_column() {
+        // The column holds the Markdown *source*, not rendered HTML — so it is
+        // an ordinary TEXT/String column everywhere in the storage stack.
+        let f = parse_field("body:richtext").unwrap();
+        assert_eq!(f.rust_type(), "String");
+        assert_eq!(f.sql_type(), "TEXT");
+        assert_eq!(f.schema_type(), "Text");
+        assert_eq!(
+            f.sql_column_type_for(DatabaseBackend::Sqlite),
+            "TEXT",
+            "richtext must work on the SQLite backend too"
+        );
+        assert_eq!(f.schema_type_for(DatabaseBackend::Sqlite), "Text");
+        assert!(FieldKind::RichText.sqlite_has_diesel_conversion());
+    }
+
+    #[test]
+    fn optional_richtext_parses() {
+        let f = parse_field("body:Option<richtext>").unwrap();
+        assert_eq!(f.kind, FieldKind::RichText);
+        assert!(f.nullable);
+        assert_eq!(f.rust_type(), "Option<String>");
+        assert_eq!(f.schema_type(), "Nullable<Text>");
+    }
+
+    #[test]
+    fn richtext_is_rich_text_predicate() {
+        assert!(FieldKind::RichText.is_rich_text());
+        assert!(!FieldKind::Text.is_rich_text());
+        assert!(!FieldKind::String.is_rich_text());
+    }
+
+    #[test]
+    fn richtext_accepts_length_constraints() {
+        let f = parse_field("body:richtext{min=10,max=50000}").unwrap();
+        assert_eq!(f.validation_attrs(), vec!["length(min = 10, max = 50000)"]);
+    }
+
+    #[test]
+    fn richtext_rejects_format_constraints() {
+        // `email`/`url` are single-line format validators; a Markdown body can
+        // never satisfy them, so accepting them would emit an unwritable field.
+        for token in ["body:richtext{email}", "body:richtext{url}"] {
+            let err = parse_field(token).unwrap_err().to_string();
+            assert!(
+                err.contains("email") || err.contains("url"),
+                "{token} should be rejected, got: {err}"
+            );
+        }
+    }
+
+    #[test]
+    fn richtext_rejects_state_machine_modifier() {
+        let err = parse_field("body:richtext:states(draft -> live)")
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("state machine"), "{err}");
+    }
+
+    #[test]
+    fn richtext_supports_unique_modifier_like_other_text_columns() {
+        let f = parse_field("body:richtext:unique").unwrap();
+        assert_eq!(f.kind, FieldKind::RichText);
+        assert!(f.unique);
+    }
+
+    #[test]
+    fn richtext_appears_in_supported_types_constants() {
+        assert!(
+            SUPPORTED_TYPES.contains("richtext"),
+            "SUPPORTED_TYPES must list richtext"
+        );
+        assert!(
+            SQLITE_SUPPORTED_KINDS.contains("richtext"),
+            "SQLITE_SUPPORTED_KINDS must list richtext — it is a plain TEXT column"
+        );
     }
 
     #[test]
@@ -3206,6 +3355,9 @@ mod schema_core_parity {
         let cases: Vec<(FieldKind, ColumnType, Vec<String>)> = vec![
             (FieldKind::String, ColumnType::Text, vec![]),
             (FieldKind::Text, ColumnType::Text, vec![]),
+            // `RichText` is a presentation/UX distinction only — it stores the
+            // Markdown *source*, so every storage mapping is `Text`'s.
+            (FieldKind::RichText, ColumnType::Text, vec![]),
             (FieldKind::I32, ColumnType::Int32, vec![]),
             (FieldKind::I64, ColumnType::Int64, vec![]),
             (FieldKind::References, ColumnType::Int64, vec![]),

--- a/autumn-cli/src/generate/emit.rs
+++ b/autumn-cli/src/generate/emit.rs
@@ -153,11 +153,20 @@ pub enum Revert {
     /// Remove the `[auth.webauthn]` stub block `autumn generate auth
     /// --passkeys` appended to `path` (`autumn.toml`).
     AuthWebauthnStub { path: PathBuf },
-    /// Remove `/{plural}/validate` from `[security.submit_token] exempt_paths`
-    /// in `path` (`autumn.toml`) — the submit-token exemption `autumn generate
-    /// scaffold --live-validation` appended for issue #1360 — dropping the
-    /// block if that empties a freshly-generated `exempt_paths` key.
-    SubmitTokenValidateExempt { path: PathBuf, plural: String },
+    /// Remove `/{plural}/{segment}` from `[security.submit_token]
+    /// exempt_paths` in `path` (`autumn.toml`) — a submit-token exemption
+    /// `autumn generate scaffold` appended — dropping the block if that empties
+    /// a freshly-generated `exempt_paths` key.
+    ///
+    /// `segment` is `"validate"` for the `--live-validation` inline-validation
+    /// routes (issue #1360) or `"preview"` for a `richtext` column's live
+    /// Markdown preview routes (issue #1255). Both hx-include the whole form,
+    /// so both must be exempt from the one-time submit-token guard.
+    SubmitTokenValidateExempt {
+        path: PathBuf,
+        plural: String,
+        segment: String,
+    },
     /// Remove the remember-me middleware layer + startup-hook calls
     /// `autumn generate auth` injected into the `AppBuilder` chain in `path`
     /// (`src/main.rs`) (issue #1397).
@@ -340,9 +349,9 @@ impl Revert {
                 super::auth::remove_oauth_provider_stubs(content, providers)
             }
             Self::AuthWebauthnStub { .. } => super::auth::remove_webauthn_stub(content),
-            Self::SubmitTokenValidateExempt { plural, .. } => {
-                super::scaffold::remove_submit_token_validate_exempt_from_toml(content, plural)
-            }
+            Self::SubmitTokenValidateExempt {
+                plural, segment, ..
+            } => super::scaffold::remove_submit_token_exempt_from_toml(content, plural, segment),
             Self::SeedBinLinks { .. } => super::schema_edit::unlink_models_from_seed_bin(content),
         }
     }
@@ -1091,6 +1100,14 @@ fn autumn_web_feature_markers(feature: &str) -> &'static [&'static str] {
         // import line — both of which this marker already catches. There is no
         // prelude-unqualified spelling to miss, so no extra marker is needed.
         "storage" => &["autumn_web::storage::"],
+        // A `richtext` scaffold (issue #1255) enables `markdown` for the
+        // sanitizing `render_user_content` its show/preview paths call, but a
+        // hand-written route can render trusted Markdown through the same
+        // feature's `render`/`MarkdownRegistry`. `autumn_web::markdown::`
+        // catches every spelling: the prelude re-exports none of these types,
+        // so any user must reach them through that path — fully qualified or
+        // via a `use autumn_web::markdown::{…};` import line.
+        "markdown" => &["autumn_web::markdown::"],
         _ => &[],
     }
 }

--- a/autumn-cli/src/generate/model.rs
+++ b/autumn-cli/src/generate/model.rs
@@ -1771,7 +1771,10 @@ fn render_validation_attr(field: &Field, rule: &str) -> Result<String, String> {
 }
 
 const fn is_string_like(field: &Field) -> bool {
-    matches!(field.kind, FieldKind::String | FieldKind::Text)
+    matches!(
+        field.kind,
+        FieldKind::String | FieldKind::Text | FieldKind::RichText
+    )
 }
 
 /// Strip a single layer of matching double or single quotes from a
@@ -1832,7 +1835,7 @@ fn sql_default_literal(field: &Field, value: &str) -> Result<String, String> {
             "false" => Ok("FALSE".to_owned()),
             _ => Err("bool defaults must be true or false".to_owned()),
         },
-        FieldKind::String | FieldKind::Text => {
+        FieldKind::String | FieldKind::Text | FieldKind::RichText => {
             let unquoted = unquote_default_value(value);
             Ok(format!("'{}'", unquoted.replace('\'', "''")))
         }

--- a/autumn-cli/src/generate/model.rs
+++ b/autumn-cli/src/generate/model.rs
@@ -516,6 +516,38 @@ fn type_is_uuid(ty: &syn::Type) -> bool {
 /// Parses with `syn` (like [`model_struct_has_uuid_pk`]) so grouped
 /// attributes, doc comments, and a multi-model `src/models.rs` layout don't
 /// defeat it.
+/// The doc comment the model generator puts on a `richtext` column (issue
+/// #1255), and the marker [`model_string_columns`] matches to exclude it from
+/// `references` display-label candidates.
+///
+/// A `richtext` column's Rust type is a bare `String`, identical to
+/// `String`/`Text`, so the rendered source carries no other signal. Editing or
+/// removing this line only downgrades label selection to the pre-#1255
+/// behaviour (a Markdown body may be chosen as a `<select>` label) — nothing
+/// breaks.
+pub(super) const RICH_TEXT_MARKER_DOC: &str =
+    "Markdown source (rich text) — render with `autumn_web::markdown::render_user_content`.";
+
+/// Whether `field`'s attributes carry the [`RICH_TEXT_MARKER_DOC`] marker.
+fn has_rich_text_marker(field: &syn::Field) -> bool {
+    field.attrs.iter().any(|attr| {
+        let syn::Meta::NameValue(nv) = &attr.meta else {
+            return false;
+        };
+        if !nv.path.is_ident("doc") {
+            return false;
+        }
+        let syn::Expr::Lit(syn::ExprLit {
+            lit: syn::Lit::Str(s),
+            ..
+        }) = &nv.value
+        else {
+            return false;
+        };
+        s.value().trim() == RICH_TEXT_MARKER_DOC
+    })
+}
+
 pub(super) fn model_string_columns(project_root: &Path, base: &str) -> Vec<(String, bool)> {
     let pascal_name = pascal(base);
     let per_resource = project_root
@@ -550,6 +582,14 @@ pub(super) fn model_string_columns(project_root: &Path, base: &str) -> Vec<(Stri
         let Some(ident) = field.ident.as_ref() else {
             continue;
         };
+        // A `richtext` column is a `String` in Rust but must not be offered as
+        // a `references` display label (issue #1255) — see
+        // [`RICH_TEXT_MARKER_DOC`]. This mirrors the self-reference path in
+        // `scaffold::target_string_columns`, which filters on the `FieldKind`
+        // directly because the in-flight columns are still typed there.
+        if has_rich_text_marker(field) {
+            continue;
+        }
         if let Some(nullable) = string_like_nullability(&field.ty) {
             out.push((ident.to_string(), nullable));
         }
@@ -1717,7 +1757,13 @@ fn validate_known_field(
 
 fn render_validation_attr(field: &Field, rule: &str) -> Result<String, String> {
     if rule == "url" || rule == "email" {
-        if !is_string_like(field) {
+        // `richtext` is deliberately excluded even though `is_string_like`
+        // accepts it for LENGTH rules: a Markdown body can never satisfy a
+        // single-line format validator, so `#[validate(email)]` on one makes the
+        // field unwritable. The DSL rejects `body:richtext{email}` for the same
+        // reason (issue #1255) — this is the `--validate` flag's matching guard,
+        // so the two spellings agree.
+        if !is_string_like(field) || field.kind.is_rich_text() {
             return Err(format!("{rule} validation requires String or Text fields"));
         }
         return Ok(rule.to_owned());
@@ -2129,6 +2175,17 @@ fn render_model_file(
                 }
             }
             let _ = writeln!(out, "    #[state_machine(transitions({inner}))]");
+        }
+        // Issue #1255: a `richtext` column renders as a bare `String`, exactly
+        // like `String`/`Text`, so nothing in the emitted source would otherwise
+        // distinguish it. Emit a marker doc comment that (a) tells a human
+        // reading the model that the column holds Markdown source to be rendered
+        // through `render_user_content`, and (b) lets
+        // [`model_string_columns`] skip it when picking a `references` display
+        // label — a whole Markdown body is the worst possible `<select>` option
+        // text. See [`RICH_TEXT_MARKER_DOC`].
+        if f.kind.is_rich_text() {
+            let _ = writeln!(out, "    /// {RICH_TEXT_MARKER_DOC}");
         }
         let _ = writeln!(out, "    pub {}: {},", f.name, f.rust_type());
     }

--- a/autumn-cli/src/generate/scaffold.rs
+++ b/autumn-cli/src/generate/scaffold.rs
@@ -795,6 +795,17 @@ fn plan_scaffold_with_options_impl(
             .map(|f| f.name.clone())
             .collect()
     };
+    // Issue #1255: the `POST /{plural}/preview/{field}` fragment handlers the
+    // routes module emits for each `richtext` column. HTML surface only — an
+    // `--api` scaffold renders no form, so it emits no preview endpoint.
+    let rich_text_field_names: Vec<String> = if options_with_key.api {
+        Vec::new()
+    } else {
+        rich_text_fields(&fields)
+            .iter()
+            .map(|f| f.name.clone())
+            .collect()
+    };
     let route_entries = main_route_entries(
         &plural,
         &snake_name,
@@ -803,6 +814,7 @@ fn plan_scaffold_with_options_impl(
         search_enabled && !options_with_key.api,
         &validated_field_names,
         &sm_field_names,
+        &rich_text_field_names,
     );
     let mut mods = vec!["models", "schema", "repositories"];
     if !options_with_key.api {
@@ -988,6 +1000,41 @@ fn plan_scaffold_with_options_impl(
         }
     }
 
+    // Issue #1255: a scaffold with `richtext` columns needs autumn-web's
+    // `markdown` feature. The generated show view, preview route, and form
+    // control all call into `autumn_web::markdown::render_user_content` (via
+    // `form::rich_text_area_htmx`'s pre-rendered preview pane), which is gated
+    // on that feature — without it the scaffold would not compile.
+    // `--api` renders no form and no show view, so it needs neither the
+    // feature nor the preview route — the column is just TEXT carrying Markdown
+    // source out over JSON, and the client renders it.
+    let rich_text_views = has_rich_text_fields(&fields) && !options_with_key.api;
+    if rich_text_views {
+        let cargo_path = project_root.join("Cargo.toml");
+        let base = plan
+            .actions
+            .iter()
+            .rev()
+            .find_map(|a| match a {
+                Action::Modify { path, contents } if path == &cargo_path => Some(contents.clone()),
+                _ => None,
+            })
+            .unwrap_or_else(|| read_or_empty(&cargo_path));
+        let updated = ensure_autumn_web_feature(&base, "markdown");
+        if updated != base {
+            plan.actions.retain(|a| a.path() != cargo_path);
+            plan.modify(cargo_path.clone(), updated);
+        }
+        // Pushed unconditionally for the same reason as the attachment block
+        // above: at `destroy` time the plan is recomputed against the already-
+        // generated Cargo.toml, where the feature is by definition present.
+        plan.push_revert(Revert::CargoAutumnWebFeature {
+            path: cargo_path,
+            feature: "markdown".to_owned(),
+            owner_dir: Some(project_root.join("src").join("routes")),
+        });
+    }
+
     // --live requires `ws` (sse::stream), `maud` (LiveFragment/Markup), and `htmx`.
     // --live-validation alone also emits Markup-returning validate handlers and
     // references HTMX_JS_PATH, so it requires `htmx` + `maud` even without `ws`.
@@ -1083,35 +1130,65 @@ fn plan_scaffold_with_options_impl(
         }
     }
 
-    // ── autumn.toml: exempt the live-validation routes from the submit-token
-    // guard (issue #1360). The generated `POST /{plural}/validate/{field}`
-    // inline-validation routes `hx-include` the whole form, so without this the
-    // one-time `_submit_token` is consumed by a validation POST and the real
-    // create/update submit replays a validation fragment instead of mutating.
+    // ── autumn.toml: exempt this resource's form-echoing POST routes from the
+    // submit-token guard.
+    //
+    // Both families `hx-include` the whole form, so without an exemption the
+    // one-time `_submit_token` is consumed by a helper request and the real
+    // create/update submit replays a fragment instead of mutating:
+    //
+    // - `POST /{plural}/validate/{field}` — `--live-validation` inline
+    //   validation (issue #1360).
+    // - `POST /{plural}/preview/{field}` — a `richtext` column's live Markdown
+    //   preview (issue #1255).
+    //
     // The `hx-params="not _submit_token"` markup filter mitigates this only for
     // the DEFAULT field name; exempting the route by prefix makes it robust for
-    // ANY configured `security.submit_token.field_name`. Only meaningful for
-    // `--live-validation`, and only when the project actually has an
-    // `autumn.toml` to edit (a bare/hand-rolled project keeps the markup
-    // filter as its sole, still-effective default-field-name guard).
+    // ANY configured `security.submit_token.field_name`. Only applied when the
+    // project actually has an `autumn.toml` to edit (a bare/hand-rolled project
+    // keeps the markup filter as its sole, still-effective default-field-name
+    // guard).
+    let mut exempt_segments: Vec<&str> = Vec::new();
     if options_with_key.live_validation {
+        exempt_segments.push("validate");
+    }
+    if rich_text_views {
+        exempt_segments.push("preview");
+    }
+    if !exempt_segments.is_empty() {
         let autumn_toml_path = project_root.join("autumn.toml");
         if autumn_toml_path.exists() {
-            let toml_existing = read_or_empty(&autumn_toml_path);
-            // Only record the modify *and* the destroy-time revert when this
-            // scaffold actually inserts the exemption. If `/{plural}/validate`
-            // is already present (a preexisting, user-owned entry), the append
-            // is a no-op and returns `None`; recording a revert then would let a
-            // later `autumn destroy` delete an exemption we never added,
-            // re-enabling submit-token guarding on live-validation routes.
-            if let Some(updated_toml) =
-                append_submit_token_validate_exempt_to_toml(&toml_existing, &plural)
-            {
-                plan.modify(autumn_toml_path.clone(), updated_toml);
-                plan.push_revert(Revert::SubmitTokenValidateExempt {
-                    path: autumn_toml_path,
-                    plural,
-                });
+            for segment in exempt_segments {
+                // Re-read the *planned* content each round so a second segment
+                // merges into the first's edit instead of overwriting it.
+                let toml_existing = plan
+                    .actions
+                    .iter()
+                    .rev()
+                    .find_map(|a| match a {
+                        Action::Modify { path, contents } if path == &autumn_toml_path => {
+                            Some(contents.clone())
+                        }
+                        _ => None,
+                    })
+                    .unwrap_or_else(|| read_or_empty(&autumn_toml_path));
+                // Only record the modify *and* the destroy-time revert when this
+                // scaffold actually inserts the exemption. If the prefix is
+                // already present (a preexisting, user-owned entry), the append
+                // is a no-op and returns `None`; recording a revert then would
+                // let a later `autumn destroy` delete an exemption we never
+                // added, re-enabling submit-token guarding on those routes.
+                if let Some(updated_toml) =
+                    append_submit_token_exempt_to_toml(&toml_existing, &plural, segment)
+                {
+                    plan.actions.retain(|a| a.path() != autumn_toml_path);
+                    plan.modify(autumn_toml_path.clone(), updated_toml);
+                    plan.push_revert(Revert::SubmitTokenValidateExempt {
+                        path: autumn_toml_path.clone(),
+                        plural: plural.clone(),
+                        segment: segment.to_owned(),
+                    });
+                }
             }
         }
     }
@@ -3281,6 +3358,54 @@ pub async fn index(
         String::new()
     };
 
+    // Issue #1255: one `POST /{plural}/preview/{field}` fragment endpoint per
+    // `richtext` column, driving that column's htmx live preview.
+    //
+    // The handler decodes the same submitted form the create/update handlers
+    // do (so the endpoint needs no bespoke request type) and returns the
+    // field's Markdown rendered through `markdown::render_user_content` — the
+    // sanitizing helper, identical to the show view. That equality is the whole
+    // point: what the author sees in the preview is byte-for-byte what a reader
+    // will see, including anything the allowlist strips.
+    let preview_handlers = {
+        let mut ph = String::new();
+        for f in rich_text_fields(fields) {
+            let field_name = &f.name;
+            let value_expr = if f.nullable {
+                format!("changeset.field_value(\"{field_name}\").unwrap_or_default()")
+            } else {
+                format!("changeset.field_value(\"{field_name}\").unwrap_or_default()")
+            };
+            let _ = write!(
+                ph,
+                "\n\n/// `POST /{plural}/preview/{field_name}` — sanitized Markdown preview fragment.\n"
+            );
+            let _ = writeln!(
+                ph,
+                "///\n/// Decodes the submitted form and returns `{field_name}` rendered through\n\
+                 /// `autumn_web::markdown::render_user_content`, which disables raw-HTML\n\
+                 /// passthrough and runs the output through an allowlist sanitizer. htmx swaps\n\
+                 /// the fragment into `#{field_name}-preview` (`hx-swap=\"innerHTML\"`), so the\n\
+                 /// author previews exactly the markup a reader will get."
+            );
+            let _ = writeln!(ph, "#[post(\"/{plural}/preview/{field_name}\")]");
+            let _ = writeln!(
+                ph,
+                "pub async fn preview_{field_name}(body: autumn_web::reexports::axum::body::Bytes) -> autumn_web::Markup {{"
+            );
+            ph.push_str("    let Ok(form) = decode_form(body) else {\n");
+            ph.push_str("        return autumn_web::html! {};\n");
+            ph.push_str("    };\n");
+            ph.push_str("    let changeset = form.into_changeset();\n");
+            let _ = writeln!(
+                ph,
+                "    autumn_web::markdown::render_user_content(&{value_expr})"
+            );
+            ph.push_str("}\n");
+        }
+        ph
+    };
+
     // Issue #1133: emit an `autumn_web::paths![…]` invocation so the routes
     // module gains a `pub mod paths` re-exporting each handler's typed
     // `__autumn_path_*` companion under a clean short name. Every view href,
@@ -3308,6 +3433,11 @@ pub async fn index(
             for field_name in validations.keys() {
                 names.push(format!("validate_{field_name}"));
             }
+        }
+        // Issue #1255: one preview endpoint per `richtext` column, linked from
+        // the form's `rich_text_area_htmx(&…, paths::preview_{field}())`.
+        for f in rich_text_fields(fields) {
+            names.push(format!("preview_{}", f.name));
         }
         // Issue #1326: one transition endpoint per state-machine field, linked
         // from the show page's `transition_controls` form actions
@@ -3878,6 +4008,7 @@ pub async fn events(
     } else {
         String::new()
     } + &validate_handlers
+        + &preview_handlers
         + &paths_macro
         + &search_handler
 }
@@ -3924,6 +4055,20 @@ fn render_update_changeset_expr(pascal_name: &str, fields: &[Field]) -> String {
 /// Whether any field in `fields` is a file attachment.
 fn has_attachment_fields(fields: &[Field]) -> bool {
     fields.iter().any(|f| f.kind.is_attachment())
+}
+
+/// Whether the scaffold declares any `richtext` column (issue #1255).
+///
+/// Gates the `markdown` feature on the project's `autumn-web` dependency, the
+/// generated `POST /{plural}/preview/{field}` routes, and their submit-token
+/// exemption.
+fn has_rich_text_fields(fields: &[Field]) -> bool {
+    fields.iter().any(|f| f.kind.is_rich_text())
+}
+
+/// The `richtext` columns of a scaffold, in declaration order (issue #1255).
+fn rich_text_fields(fields: &[Field]) -> Vec<&Field> {
+    fields.iter().filter(|f| f.kind.is_rich_text()).collect()
 }
 
 /// Emit the `FormModel` delegation impl for the generated `{Pascal}Form`
@@ -4025,6 +4170,30 @@ fn render_form_for_helper(
                 let _ = write!(
                     builder_calls,
                     "\n        .override_field(\"{name}\", autumn_web::form::FieldControl::Select {{ options: vec![{options}] }})"
+                );
+            }
+            FieldKind::RichText => {
+                // Issue #1255: the derive sees a plain `String` column and
+                // emits a single-line text input. A rich-text column instead
+                // renders `form::rich_text_area_htmx` — a Markdown editor with
+                // a syntax hint and an htmx live-preview pane wired to the
+                // generated `POST /{plural}/preview/{field}` endpoint. That is
+                // a whole labeled control, not a `FieldControl` variant, so it
+                // takes the same `.exclude()` + `.append()` escape hatch the
+                // constrained-field arm below uses.
+                //
+                // The token-field-aware variant is used so the preview POST's
+                // `hx-params` filter names the app's ACTUAL configured
+                // `[security.submit_token].field_name` (issue #1843), not just
+                // the default — the helper already has the `SubmitFormField`
+                // extractor in scope for `submit_token_input`.
+                let label = humanize_label(name);
+                let _ = write!(builder_calls, "\n        .exclude(\"{name}\")");
+                let _ = write!(
+                    appends,
+                    "\n        .append(autumn_web::form::rich_text_area_htmx_with_token_field(\
+                     changeset, \"{name}\", \"{label}\", &paths::preview_{name}(), \
+                     submit_field.map_or(\"_submit_token\", |f| f.0.as_str())))"
                 );
             }
             FieldKind::Decimal { scale, .. } => {
@@ -4452,7 +4621,22 @@ fn render_changeset_form_inputs(
         // shipped `autumn_web::form` helpers can't express; render it as raw
         // markup instead so the live path matches the standard path (#1750).
         let constraint = html5_constraint_spec(f);
-        let line = if f.kind.is_reference() && reference_select_names.contains(name.as_str()) {
+        let line = if f.kind.is_rich_text() {
+            // Issue #1255: identical control to the standard `form_for` path —
+            // the Markdown editor with its htmx live preview. A rich-text
+            // column never takes the inline-*validation* htmx path: its wrapper
+            // already owns an `hx-post` (the preview), and a second one would
+            // fight it for the same element.
+            //
+            // `.as_ref()` because the handler owns an `Option<SubmitFormField>`
+            // here (the `form_for` helper takes an `Option<&…>` instead) — two
+            // rich-text columns in one form would otherwise use a moved value.
+            format!(
+                "(autumn_web::form::rich_text_area_htmx_with_token_field(&{cv}, \"{name}\", \
+                 \"{label}\", &paths::preview_{name}(), \
+                 submit_field.as_ref().map_or(\"_submit_token\", |f| f.0.as_str())))"
+            )
+        } else if f.kind.is_reference() && reference_select_names.contains(name.as_str()) {
             // belongs_to parent dropdown (issue #1146), restored in the
             // `--live-validation` per-field path (issue #1750).
             render_live_reference_select(f, cv)
@@ -4941,15 +5125,22 @@ fn cell_value_expr(field: &Field) -> String {
             )
         }
         // Nullable String/Text: use as_deref to avoid heap allocation.
-        (true, FieldKind::String | FieldKind::Text) => {
+        // `RichText` joins them: an index cell renders the Markdown SOURCE as
+        // escaped text (maud's `Render` impl escapes it), never rendered
+        // markup — a table cell has no business carrying block-level HTML, and
+        // escaped source is inherently safe. The rendered form lives on the
+        // show page (see `render_show_property_rows`).
+        (true, FieldKind::String | FieldKind::Text | FieldKind::RichText) => {
             format!("row.{name}.as_deref().unwrap_or_default()")
         }
         // Nullable: Option<T> — no Render impl; unwrap to String.
         (true, _) => format!("row.{name}.as_ref().map(ToString::to_string).unwrap_or_default()"),
         // Non-nullable Bytea: Cow<str> does implement Render.
         (false, FieldKind::Bytea) => format!("String::from_utf8_lossy(&row.{name})"),
-        // String/Text: &String implements Render via deref coercion.
-        (false, FieldKind::String | FieldKind::Text) => format!("&row.{name}"),
+        // String/Text/RichText: &String implements Render via deref coercion.
+        (false, FieldKind::String | FieldKind::Text | FieldKind::RichText) => {
+            format!("&row.{name}")
+        }
         // Numerics (i32, i64, f32, f64): implement Render directly.
         (false, FieldKind::I32 | FieldKind::I64 | FieldKind::F32 | FieldKind::F64) => {
             format!("row.{name}")
@@ -5059,6 +5250,20 @@ fn render_show_property_rows(
         let label = humanize(&f.name);
         let cell_expr = if f.kind.is_reference() && reference_displays.contains_key(&f.name) {
             format!("{}_label", f.name)
+        } else if f.kind.is_rich_text() {
+            // Issue #1255: the column stores user-submitted Markdown SOURCE, so
+            // the show page renders it through `render_user_content` — raw-HTML
+            // passthrough disabled, output run through an allowlist sanitizer.
+            // This is the one place the scaffold emits pre-escaped markup from a
+            // user-controlled column, and it is exactly why that helper exists.
+            let name = &f.name;
+            if f.nullable {
+                format!(
+                    "autumn_web::markdown::render_user_content(row.{name}.as_deref().unwrap_or_default())"
+                )
+            } else {
+                format!("autumn_web::markdown::render_user_content(&row.{name})")
+            }
         } else {
             cell_value_expr(f)
         };
@@ -6310,7 +6515,9 @@ fn sql_sample_literal(kind: FieldKind) -> String {
         // special-cases every enum column (the field under test gets the
         // deliberately out-of-set literal; any *other* required enum column
         // gets one of its own real variants instead — see that function).
-        FieldKind::String | FieldKind::Text | FieldKind::Enum => "'sample'".to_owned(),
+        FieldKind::String | FieldKind::Text | FieldKind::RichText | FieldKind::Enum => {
+            "'sample'".to_owned()
+        }
         FieldKind::I32 | FieldKind::I64 | FieldKind::References => "1".to_owned(),
         FieldKind::Bool => "TRUE".to_owned(),
         FieldKind::F32 | FieldKind::F64 => "1.0".to_owned(),
@@ -6349,7 +6556,7 @@ const API_SMOKE_TEST_SEED_ROWS: usize = 25;
 /// per row.
 fn sql_seed_value_expr(f: &Field) -> String {
     match f.kind {
-        FieldKind::String | FieldKind::Text => "'sample-' || g".to_owned(),
+        FieldKind::String | FieldKind::Text | FieldKind::RichText => "'sample-' || g".to_owned(),
         FieldKind::I32 | FieldKind::I64 => "g".to_owned(),
         FieldKind::F32 | FieldKind::F64 => "g::double precision".to_owned(),
         FieldKind::NaiveDateTime | FieldKind::DateTime => {
@@ -6562,7 +6769,9 @@ fn render_enum_rejection_smoke_test(
 /// the duplicate-insert assertion would never trip.
 fn unique_sample_literal(kind: FieldKind) -> String {
     match kind {
-        FieldKind::String | FieldKind::Text | FieldKind::Enum => "'dup_value'".to_owned(),
+        FieldKind::String | FieldKind::Text | FieldKind::RichText | FieldKind::Enum => {
+            "'dup_value'".to_owned()
+        }
         FieldKind::I32 | FieldKind::I64 => "424242".to_owned(),
         // Must be a real seeded row's id, not an arbitrary literal — a
         // `references` target column is FK-constrained against the stub
@@ -6595,7 +6804,9 @@ fn unique_sample_literal(kind: FieldKind) -> String {
 /// to decide which violation Postgres actually reports.
 fn unique_sample_literal_variant(kind: FieldKind) -> String {
     match kind {
-        FieldKind::String | FieldKind::Text | FieldKind::Enum => "'dup_value_2'".to_owned(),
+        FieldKind::String | FieldKind::Text | FieldKind::RichText | FieldKind::Enum => {
+            "'dup_value_2'".to_owned()
+        }
         FieldKind::I32 | FieldKind::I64 => "424243".to_owned(),
         // The second stub row `render_reference_stub_tables_sql` seeds —
         // distinct from `unique_sample_literal`'s "1" for the same reason
@@ -6824,6 +7035,7 @@ fn main_route_entries(
     search: bool,
     validated_field_names: &[String],
     sm_field_names: &[String],
+    rich_text_field_names: &[String],
 ) -> Vec<String> {
     if api {
         let mut entries = vec![
@@ -6866,22 +7078,33 @@ fn main_route_entries(
         for field_name in sm_field_names {
             entries.push(format!("routes::{plural}::transition_{field_name}"));
         }
+        // Issue #1255: mount the `POST /{plural}/preview/{field}` fragment
+        // handler emitted for each `richtext` column, so the editor's htmx live
+        // preview resolves to a real route rather than 404ing. A scaffold with
+        // no rich-text column pushes nothing here and keeps the mounted route
+        // set byte-identical.
+        for field_name in rich_text_field_names {
+            entries.push(format!("routes::{plural}::preview_{field_name}"));
+        }
         entries.push(format!("repositories::{snake_name}::{snake_name}_api_list"));
         entries.push(format!("repositories::{snake_name}::{snake_name}_api_get"));
         entries
     }
 }
 
-/// The submit-token exempt-path prefix for a `--live-validation` resource.
+/// The submit-token exempt-path prefix for one family of a resource's
+/// form-echoing POST routes.
 ///
-/// The generated inline-validation routes are `POST /{plural}/validate/{field}`;
-/// this prefix exempts every one of them from the submit-token guard at once
-/// (the guard matches `exempt_paths` by prefix — an exact match, a prefix ending
-/// in `/`, or a prefix whose remainder begins with `/`, so `/{plural}/validate`
+/// `segment` is `"validate"` for the `--live-validation` inline-validation
+/// routes (`POST /{plural}/validate/{field}`, issue #1360) or `"preview"` for a
+/// `richtext` column's live Markdown preview (`POST /{plural}/preview/{field}`,
+/// issue #1255). Either prefix exempts every route in its family at once (the
+/// guard matches `exempt_paths` by prefix — an exact match, a prefix ending in
+/// `/`, or a prefix whose remainder begins with `/`, so `/{plural}/validate`
 /// covers `/{plural}/validate/title`, `/{plural}/validate/body`, … without
 /// touching the guarded `POST /{plural}` create route).
-fn submit_token_validate_exempt_prefix(plural: &str) -> String {
-    format!("/{plural}/validate")
+fn submit_token_exempt_prefix(plural: &str, segment: &str) -> String {
+    format!("/{plural}/{segment}")
 }
 
 /// The `(start, end)` line span of a top-level `[header]` TOML table — the
@@ -6898,9 +7121,10 @@ fn toml_table_block_range(lines: &[&str], header: &str) -> Option<(usize, usize)
     Some((start, end))
 }
 
-/// Ensure `/{plural}/validate` is listed under `[security.submit_token]
-/// exempt_paths` so a `--live-validation` scaffold's inline-validation POSTs
-/// never consume the one-time submit token (issue #1360).
+/// Ensure `/{plural}/{segment}` is listed under `[security.submit_token]
+/// exempt_paths` so a scaffold's form-echoing POSTs (inline validation,
+/// issue #1360; richtext preview, issue #1255) never consume the one-time
+/// submit token.
 ///
 /// This is the route-based, field-name-agnostic half of the fix: the
 /// `hx-params="not _submit_token"` markup filter only strips the DEFAULT field
@@ -6919,10 +7143,14 @@ fn toml_table_block_range(lines: &[&str], header: &str) -> Option<(usize, usize)
 /// Handles three shapes — no `[security.submit_token]` table (append a fresh
 /// one), a table without an `exempt_paths` key (insert the key after the
 /// header), and a table whose `exempt_paths` array is merged in place.
-fn append_submit_token_validate_exempt_to_toml(existing: &str, plural: &str) -> Option<String> {
+fn append_submit_token_exempt_to_toml(
+    existing: &str,
+    plural: &str,
+    segment: &str,
+) -> Option<String> {
     use toml_edit::{Array, DocumentMut, Item, Table, Value};
 
-    let exempt = submit_token_validate_exempt_prefix(plural);
+    let exempt = submit_token_exempt_prefix(plural, segment);
 
     // Parse format-preservingly so comments, ordering, and hand-crafted array
     // layout survive the edit. A config we can't parse is left untouched (and we
@@ -6965,19 +7193,20 @@ fn append_submit_token_validate_exempt_to_toml(existing: &str, plural: &str) -> 
     Some(doc.to_string())
 }
 
-/// Inverse of [`append_submit_token_validate_exempt_to_toml`] (`autumn
-/// destroy`, issue #1048): remove `/{plural}/validate` from
+/// Inverse of [`append_submit_token_exempt_to_toml`] (`autumn
+/// destroy`, issue #1048): remove `/{plural}/{segment}` from
 /// `[security.submit_token] exempt_paths`, dropping the whole block if that
 /// leaves an empty freshly-generated `exempt_paths = [...]` as its only key.
 ///
 /// Conservative: only touches an `exempt_paths` array that still contains the
 /// exact prefix this generator inserts, never a hand-edited value.
-pub(super) fn remove_submit_token_validate_exempt_from_toml(
+pub(super) fn remove_submit_token_exempt_from_toml(
     existing: &str,
     plural: &str,
+    segment: &str,
 ) -> String {
     const HEADER: &str = "[security.submit_token]";
-    let exempt = submit_token_validate_exempt_prefix(plural);
+    let exempt = submit_token_exempt_prefix(plural, segment);
     let quoted = format!("\"{exempt}\"");
 
     let lines: Vec<&str> = existing.lines().collect();
@@ -12682,7 +12911,7 @@ async fn main() {
     #[test]
     fn submit_token_exempt_appends_fresh_block_when_absent() {
         let existing = "[server]\nport = 3000\n";
-        let out = append_submit_token_validate_exempt_to_toml(existing, "posts")
+        let out = append_submit_token_exempt_to_toml(existing, "posts", "validate")
             .expect("absent exemption must be inserted");
         assert!(out.contains("[security.submit_token]"), "{out}");
         assert!(
@@ -12696,7 +12925,7 @@ async fn main() {
     #[test]
     fn submit_token_exempt_is_idempotent() {
         let existing = "[security.submit_token]\nexempt_paths = [\"/posts/validate\"]\n";
-        let out = append_submit_token_validate_exempt_to_toml(existing, "posts");
+        let out = append_submit_token_exempt_to_toml(existing, "posts", "validate");
         assert_eq!(
             out, None,
             "re-adding the same prefix must be a no-op returning None"
@@ -12707,7 +12936,7 @@ async fn main() {
     fn submit_token_exempt_merges_into_existing_array() {
         let existing =
             "[security.submit_token]\nttl_secs = 900\nexempt_paths = [\"/webhooks/x\"]\n";
-        let out = append_submit_token_validate_exempt_to_toml(existing, "posts")
+        let out = append_submit_token_exempt_to_toml(existing, "posts", "validate")
             .expect("a new prefix must be merged into the existing array");
         assert!(out.contains("\"/webhooks/x\""), "{out}");
         assert!(out.contains("\"/posts/validate\""), "{out}");
@@ -12731,7 +12960,7 @@ exempt_paths = [
     \"/webhooks/x\",
 ]
 ";
-        let out = append_submit_token_validate_exempt_to_toml(existing, "posts")
+        let out = append_submit_token_exempt_to_toml(existing, "posts", "validate")
             .expect("a new prefix must be merged into the commented array");
         // The merged output is valid TOML.
         let parsed: toml::Value =
@@ -12753,7 +12982,7 @@ exempt_paths = [
     #[test]
     fn submit_token_exempt_inserts_key_when_block_lacks_it() {
         let existing = "[security.submit_token]\nttl_secs = 900\n";
-        let out = append_submit_token_validate_exempt_to_toml(existing, "posts")
+        let out = append_submit_token_exempt_to_toml(existing, "posts", "validate")
             .expect("a block lacking the key must gain one");
         assert!(
             out.contains("exempt_paths = [\"/posts/validate\"]"),
@@ -12768,7 +12997,7 @@ exempt_paths = [
         // `security.submit_token.field_name`. It must cover the per-field
         // validation routes but never the guarded create route.
         assert_eq!(
-            submit_token_validate_exempt_prefix("posts"),
+            submit_token_exempt_prefix("posts", "validate"),
             "/posts/validate"
         );
     }
@@ -12776,9 +13005,9 @@ exempt_paths = [
     #[test]
     fn remove_submit_token_exempt_drops_fresh_block() {
         let existing = "[server]\nport = 3000\n";
-        let added = append_submit_token_validate_exempt_to_toml(existing, "posts")
+        let added = append_submit_token_exempt_to_toml(existing, "posts", "validate")
             .expect("fresh block must be added");
-        let removed = remove_submit_token_validate_exempt_from_toml(&added, "posts");
+        let removed = remove_submit_token_exempt_from_toml(&added, "posts", "validate");
         assert!(!removed.contains("/posts/validate"), "{removed}");
         assert!(!removed.contains("[security.submit_token]"), "{removed}");
         assert!(removed.contains("[server]"), "{removed}");
@@ -12788,7 +13017,7 @@ exempt_paths = [
     fn remove_submit_token_exempt_keeps_other_entries() {
         let existing =
             "[security.submit_token]\nexempt_paths = [\"/webhooks/x\", \"/posts/validate\"]\n";
-        let removed = remove_submit_token_validate_exempt_from_toml(existing, "posts");
+        let removed = remove_submit_token_exempt_from_toml(existing, "posts", "validate");
         assert!(removed.contains("\"/webhooks/x\""), "{removed}");
         assert!(!removed.contains("/posts/validate"), "{removed}");
         assert!(removed.contains("[security.submit_token]"), "{removed}");
@@ -12798,7 +13027,7 @@ exempt_paths = [
     fn remove_submit_token_exempt_ignores_hand_edited_value() {
         // Never touch an array that no longer carries our exact prefix.
         let existing = "[security.submit_token]\nexempt_paths = [\"/custom/only\"]\n";
-        let removed = remove_submit_token_validate_exempt_from_toml(existing, "posts");
+        let removed = remove_submit_token_exempt_from_toml(existing, "posts", "validate");
         assert_eq!(removed, existing);
     }
 
@@ -12869,6 +13098,208 @@ exempt_paths = [
         assert!(
             !touches_toml,
             "a plain scaffold (no --live-validation) must not add submit-token exemptions"
+        );
+    }
+
+    // ── richtext scaffolding (issue #1255) ─────────────────────────────────
+
+    /// Plan `autumn generate scaffold Post title:String body:richtext` against
+    /// a fresh project — the exact command the issue's success metric names.
+    fn richtext_scaffold_plan(tmp: &TempDir) -> Plan {
+        plan_scaffold(
+            tmp.path(),
+            "Post",
+            &["title:String".into(), "body:richtext".into()],
+            "20260731000000",
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn richtext_scaffold_form_uses_the_markdown_editor_widget() {
+        let tmp = project_with_main(default_main());
+        let plan = richtext_scaffold_plan(&tmp);
+        let routes = action_contents(&plan, "src/routes/posts.rs");
+        assert!(
+            routes.contains("rich_text_area"),
+            "the form must render the Markdown editor, not a bare textarea:\n{routes}"
+        );
+        // The non-richtext column keeps its ordinary control.
+        assert!(routes.contains("\"title\""), "{routes}");
+    }
+
+    #[test]
+    fn richtext_scaffold_show_view_renders_through_the_sanitizer() {
+        let tmp = project_with_main(default_main());
+        let plan = richtext_scaffold_plan(&tmp);
+        let routes = action_contents(&plan, "src/routes/posts.rs");
+        assert!(
+            routes.contains("autumn_web::markdown::render_user_content(&row.body)"),
+            "the show view must render the stored Markdown through the sanitizing \
+             helper:\n{routes}"
+        );
+        // …and never through the trusted-content renderer or a raw passthrough.
+        assert!(
+            !routes.contains("markdown::render(&row.body)"),
+            "the trusted-content renderer must never see user input:\n{routes}"
+        );
+        assert!(
+            !routes.contains("PreEscaped(&row.body)"),
+            "the raw source must never be emitted pre-escaped:\n{routes}"
+        );
+    }
+
+    #[test]
+    fn richtext_scaffold_index_view_shows_escaped_source_not_markup() {
+        let tmp = project_with_main(default_main());
+        let plan = richtext_scaffold_plan(&tmp);
+        let routes = action_contents(&plan, "src/routes/posts.rs");
+        // The index column renders the raw source through maud's escaping
+        // `Render` impl — a table cell must not carry block-level markup, and
+        // escaped text is inherently safe.
+        let columns = routes
+            .split_once("let columns:")
+            .expect("index columns block")
+            .1;
+        let columns = columns.split_once("];").unwrap().0;
+        assert!(
+            !columns.contains("render_user_content"),
+            "index cells render the source as escaped text, not HTML:\n{columns}"
+        );
+    }
+
+    #[test]
+    fn richtext_scaffold_generates_a_preview_route() {
+        let tmp = project_with_main(default_main());
+        let plan = richtext_scaffold_plan(&tmp);
+        let routes = action_contents(&plan, "src/routes/posts.rs");
+        assert!(
+            routes.contains("#[post(\"/posts/preview/body\")]"),
+            "a richtext column needs a preview endpoint for the htmx live \
+             preview:\n{routes}"
+        );
+        assert!(routes.contains("pub async fn preview_body("), "{routes}");
+        // The preview handler renders through the same sanitizer.
+        let handler = routes
+            .split_once("pub async fn preview_body(")
+            .unwrap()
+            .1
+            .split_once("\n}\n")
+            .unwrap()
+            .0;
+        assert!(
+            handler.contains("render_user_content"),
+            "the preview must be sanitized exactly like the show view:\n{handler}"
+        );
+        // The typed path helper is exported so the form can link to it.
+        assert!(routes.contains("preview_body"), "{routes}");
+    }
+
+    #[test]
+    fn richtext_scaffold_enables_the_markdown_feature() {
+        let tmp = project_with_main(default_main());
+        fs::write(
+            tmp.path().join("Cargo.toml"),
+            "[package]\nname = \"x\"\n\n[dependencies]\nautumn-web = \"0.6.0\"\n",
+        )
+        .unwrap();
+        let plan = richtext_scaffold_plan(&tmp);
+        let cargo = action_contents(&plan, "Cargo.toml");
+        assert!(
+            cargo.contains("markdown"),
+            "a richtext scaffold must enable autumn-web's `markdown` feature so \
+             `render_user_content` resolves:\n{cargo}"
+        );
+    }
+
+    #[test]
+    fn richtext_scaffold_exempts_the_preview_route_from_the_submit_token() {
+        let tmp = project_with_main(default_main());
+        fs::write(
+            tmp.path().join("autumn.toml"),
+            "[security.submit_token]\nfield_name = \"_confirm\"\n",
+        )
+        .unwrap();
+        let plan = richtext_scaffold_plan(&tmp);
+        let toml = action_contents(&plan, "autumn.toml");
+        assert!(
+            toml.contains("/posts/preview"),
+            "the preview POST hx-includes the whole form, so it must not spend \
+             the one-time submit token under a custom field name:\n{toml}"
+        );
+        assert!(
+            plan.reverts.iter().any(|r| matches!(
+                r,
+                Revert::SubmitTokenValidateExempt { segment, .. } if segment == "preview"
+            )),
+            "the inserted preview exemption must be reverted on destroy"
+        );
+    }
+
+    #[test]
+    fn api_richtext_scaffold_skips_the_html_only_wiring() {
+        // `--api` renders no form and no show view, so a richtext column is
+        // just a TEXT column carrying Markdown source out over JSON. Pulling in
+        // the `markdown` feature (and exempting a preview route that is never
+        // generated) would be dead weight.
+        let tmp = project_with_main(default_main());
+        fs::write(
+            tmp.path().join("Cargo.toml"),
+            "[package]\nname = \"x\"\n\n[dependencies]\nautumn-web = \"0.6.0\"\n",
+        )
+        .unwrap();
+        fs::write(
+            tmp.path().join("autumn.toml"),
+            "[security.submit_token]\nfield_name = \"_confirm\"\n",
+        )
+        .unwrap();
+        let plan = plan_scaffold_with_options(
+            tmp.path(),
+            "Post",
+            &["title:String".into(), "body:richtext".into()],
+            "20260731000000",
+            &ScaffoldOptions {
+                api: true,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        let cargo = action_contents(&plan, "Cargo.toml");
+        assert!(
+            !cargo.contains("\"markdown\""),
+            "--api has no view that renders Markdown:\n{cargo}"
+        );
+        let toml = action_contents(&plan, "autumn.toml");
+        assert!(
+            !toml.contains("/posts/preview"),
+            "--api generates no preview route to exempt:\n{toml}"
+        );
+    }
+
+    #[test]
+    fn non_richtext_scaffold_stays_untouched_by_the_richtext_wiring() {
+        let tmp = project_with_main(default_main());
+        fs::write(
+            tmp.path().join("Cargo.toml"),
+            "[package]\nname = \"x\"\n\n[dependencies]\nautumn-web = \"0.6.0\"\n",
+        )
+        .unwrap();
+        let plan = plan_scaffold(
+            tmp.path(),
+            "Post",
+            &["title:String".into(), "body:Text".into()],
+            "20260731000000",
+        )
+        .unwrap();
+        let routes = action_contents(&plan, "src/routes/posts.rs");
+        assert!(!routes.contains("rich_text_area"), "{routes}");
+        assert!(!routes.contains("render_user_content"), "{routes}");
+        assert!(!routes.contains("/posts/preview"), "{routes}");
+        let cargo = action_contents(&plan, "Cargo.toml");
+        assert!(
+            !cargo.contains("markdown"),
+            "a scaffold with no richtext column must not pull in the markdown \
+             feature:\n{cargo}"
         );
     }
 

--- a/autumn-cli/src/generate/scaffold.rs
+++ b/autumn-cli/src/generate/scaffold.rs
@@ -773,8 +773,23 @@ fn plan_scaffold_with_options_impl(
             format!("missing {}", main_path.display()),
         ))
     })?;
+    // Issue #1255: a `richtext` column never takes the htmx inline-validation
+    // path — its wrapper already owns an `hx-post` for the live preview, so
+    // `render_changeset_form_inputs` renders the editor instead of
+    // `text_input_htmx`. Emitting (and mounting, and submit-token-exempting) a
+    // `validate_{field}` route nothing links to would be dead surface, so filter
+    // those columns out here and at the emission site in `render_routes_file`.
     let validated_field_names: Vec<String> = if options_with_key.live_validation {
-        metadata.validations().keys().cloned().collect()
+        metadata
+            .validations()
+            .keys()
+            .filter(|name| {
+                !fields
+                    .iter()
+                    .any(|f| &&f.name == name && f.kind.is_rich_text())
+            })
+            .cloned()
+            .collect()
     } else {
         Vec::new()
     };
@@ -798,10 +813,15 @@ fn plan_scaffold_with_options_impl(
     // Issue #1255: the `POST /{plural}/preview/{field}` fragment handlers the
     // routes module emits for each `richtext` column. HTML surface only — an
     // `--api` scaffold renders no form, so it emits no preview endpoint.
+    //
+    // Derived from `form_fields`, NOT `fields`: a `--default`ed column is
+    // dropped from the form (and therefore from the rendered routes module), so
+    // deriving from `fields` would mount a `preview_{field}` handler the module
+    // never emitted and fail the generated app to compile.
     let rich_text_field_names: Vec<String> = if options_with_key.api {
         Vec::new()
     } else {
-        rich_text_fields(&fields)
+        rich_text_fields(&form_fields)
             .iter()
             .map(|f| f.name.clone())
             .collect()
@@ -1008,6 +1028,10 @@ fn plan_scaffold_with_options_impl(
     // `--api` renders no form and no show view, so it needs neither the
     // feature nor the preview route — the column is just TEXT carrying Markdown
     // source out over JSON, and the client renders it.
+    // The show view renders EVERY richtext column (including a `--default`ed
+    // one, which the form drops but the detail page still displays), so the
+    // feature gate reads `fields`. The preview *routes* below are emitted only
+    // for form columns, so their exemption reads `rich_text_field_names`.
     let rich_text_views = has_rich_text_fields(&fields) && !options_with_key.api;
     if rich_text_views {
         let cargo_path = project_root.join("Cargo.toml");
@@ -1152,7 +1176,7 @@ fn plan_scaffold_with_options_impl(
     if options_with_key.live_validation {
         exempt_segments.push("validate");
     }
-    if rich_text_views {
+    if !rich_text_field_names.is_empty() {
         exempt_segments.push("preview");
     }
     if !exempt_segments.is_empty() {
@@ -3290,12 +3314,23 @@ pub async fn index(
     // one place the validation rules live, and the returned markup matches
     // `text_input_htmx`'s `hx-swap="outerHTML"` contract — swapping in a bare
     // `<span>` would delete the input it's supposed to replace.
+    // Issue #1255: rich-text columns are excluded — see the matching filter on
+    // `validated_field_names` in `plan_scaffold`. Both sides must agree or the
+    // mounted route set and the emitted handler set drift apart.
+    let htmx_validated: Vec<(&String, &Vec<String>)> = validations
+        .iter()
+        .filter(|(name, _)| {
+            !fields
+                .iter()
+                .any(|f| &&f.name == name && f.kind.is_rich_text())
+        })
+        .collect();
     let validate_handlers = if live_validation {
         let mut vh = String::new();
-        for (field_name, rules) in validations {
+        for (field_name, rules) in &htmx_validated {
             let rule_comment = rules.join(", ");
             let label = humanize_label(field_name);
-            let field = fields.iter().find(|f| f.name == *field_name);
+            let field = fields.iter().find(|f| f.name == **field_name);
             // Issue #1750: a DSL-constrained `String`/`Text` field renders in
             // the form through the raw-markup constrained control (carrying the
             // #1388 HTML5 attributes `minlength`/`maxlength`/`type="email"`), so
@@ -3371,11 +3406,10 @@ pub async fn index(
         let mut ph = String::new();
         for f in rich_text_fields(fields) {
             let field_name = &f.name;
-            let value_expr = if f.nullable {
-                format!("changeset.field_value(\"{field_name}\").unwrap_or_default()")
-            } else {
-                format!("changeset.field_value(\"{field_name}\").unwrap_or_default()")
-            };
+            // `field_value` already flattens a nullable column to `None`, and the
+            // preview of an empty body is legitimately empty markup — so the
+            // nullable and non-nullable cases read identically here.
+            let value_expr = format!("changeset.field_value(\"{field_name}\").unwrap_or_default()");
             let _ = write!(
                 ph,
                 "\n\n/// `POST /{plural}/preview/{field_name}` — sanitized Markdown preview fragment.\n"
@@ -3430,7 +3464,7 @@ pub async fn index(
         // One inline-validation endpoint per validated field (live-validation
         // only), each linked from the form's `.hx("post", paths::validate_{f}())`.
         if live_validation {
-            for field_name in validations.keys() {
+            for (field_name, _) in &htmx_validated {
                 names.push(format!("validate_{field_name}"));
             }
         }
@@ -7027,6 +7061,13 @@ fn render_unique_violation_smoke_test(
     out
 }
 
+#[allow(
+    clippy::too_many_arguments,
+    reason = "one parameter per optional route family the scaffold can emit \
+              (live SSE, search, inline validation, state transitions, rich-text \
+              preview); grouping them into a struct would only move the same \
+              list one level out"
+)]
 fn main_route_entries(
     plural: &str,
     snake_name: &str,
@@ -13233,6 +13274,42 @@ exempt_paths = [
                 Revert::SubmitTokenValidateExempt { segment, .. } if segment == "preview"
             )),
             "the inserted preview exemption must be reverted on destroy"
+        );
+    }
+
+    #[test]
+    fn defaulted_richtext_column_mounts_no_preview_route() {
+        // A `--default`ed column is dropped from the form, so the routes module
+        // emits no `preview_{field}` handler for it. Mounting one anyway in
+        // `main.rs` fails the generated app to compile with `cannot find value
+        // preview_body in module routes::posts`.
+        let tmp = project_with_main(default_main());
+        let plan = plan_scaffold_with_options(
+            tmp.path(),
+            "Post",
+            &["title:String".into(), "body:richtext".into()],
+            "20260731000000",
+            &ScaffoldOptions {
+                model: ModelOptions {
+                    defaults: vec!["body=hi".to_owned()],
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        let routes = action_contents(&plan, "src/routes/posts.rs");
+        let main_rs = action_contents(&plan, "src/main.rs");
+        assert_eq!(
+            routes.contains("pub async fn preview_body("),
+            main_rs.contains("routes::posts::preview_body"),
+            "the mounted route set must match the handlers actually emitted\n\
+             routes:\n{routes}\nmain:\n{main_rs}"
+        );
+        // The show view still displays the column, so the feature is still needed.
+        assert!(
+            routes.contains("render_user_content(&row.body)"),
+            "a defaulted richtext column still renders on the detail page:\n{routes}"
         );
     }
 

--- a/autumn-cli/src/generate/scaffold.rs
+++ b/autumn-cli/src/generate/scaffold.rs
@@ -4225,10 +4225,19 @@ fn render_form_for_helper(
                 // the default — the helper already has the `SubmitFormField`
                 // extractor in scope for `submit_token_input`.
                 let label = humanize_label(name);
+                // A non-nullable column takes the `required_*` variant, exactly
+                // like every other generated control — `String` and `TEXT NOT
+                // NULL` both accept `""`, so without it an empty editor would
+                // silently persist a blank body (PR #2157 review).
+                let helper = if f.nullable {
+                    "rich_text_area_htmx_with_token_field"
+                } else {
+                    "required_rich_text_area_htmx_with_token_field"
+                };
                 let _ = write!(builder_calls, "\n        .exclude(\"{name}\")");
                 let _ = write!(
                     appends,
-                    "\n        .append(autumn_web::form::rich_text_area_htmx_with_token_field(\
+                    "\n        .append(autumn_web::form::{helper}(\
                      changeset, \"{name}\", \"{label}\", &paths::preview_{name}(), \
                      submit_field.map_or(\"_submit_token\", |f| f.0.as_str())))"
                 );
@@ -4668,8 +4677,13 @@ fn render_changeset_form_inputs(
             // `.as_ref()` because the handler owns an `Option<SubmitFormField>`
             // here (the `form_for` helper takes an `Option<&…>` instead) — two
             // rich-text columns in one form would otherwise use a moved value.
+            let helper = if f.nullable {
+                "rich_text_area_htmx_with_token_field"
+            } else {
+                "required_rich_text_area_htmx_with_token_field"
+            };
             format!(
-                "(autumn_web::form::rich_text_area_htmx_with_token_field(&{cv}, \"{name}\", \
+                "(autumn_web::form::{helper}(&{cv}, \"{name}\", \
                  \"{label}\", &paths::preview_{name}(), \
                  submit_field.as_ref().map_or(\"_submit_token\", |f| f.0.as_str())))"
             )
@@ -13237,6 +13251,35 @@ exempt_paths = [
         );
         // The typed path helper is exported so the form can link to it.
         assert!(routes.contains("preview_body"), "{routes}");
+    }
+
+    #[test]
+    fn non_nullable_richtext_gets_a_required_signal() {
+        // PR #2157 review: every other non-nullable generated control carries
+        // `required`/`aria-required`. A `body:richtext` column had neither, and
+        // since `String` and `TEXT NOT NULL` both accept `""`, an empty editor
+        // persisted a blank body.
+        let tmp = project_with_main(default_main());
+        let plan = plan_scaffold(
+            tmp.path(),
+            "Post",
+            &["body:richtext".into(), "note:Option<richtext>".into()],
+            "20260731000000",
+        )
+        .unwrap();
+        let routes = action_contents(&plan, "src/routes/posts.rs");
+        assert!(
+            routes.contains("required_rich_text_area_htmx_with_token_field(changeset, \"body\""),
+            "a non-nullable richtext column needs the required variant:\n{routes}"
+        );
+        assert!(
+            routes.contains("rich_text_area_htmx_with_token_field(changeset, \"note\""),
+            "a nullable richtext column keeps the optional variant:\n{routes}"
+        );
+        assert!(
+            !routes.contains("required_rich_text_area_htmx_with_token_field(changeset, \"note\""),
+            "leaving a nullable column blank is valid — no required signal:\n{routes}"
+        );
     }
 
     #[test]

--- a/autumn-cli/src/generate/scaffold.rs
+++ b/autumn-cli/src/generate/scaffold.rs
@@ -3406,10 +3406,6 @@ pub async fn index(
         let mut ph = String::new();
         for f in rich_text_fields(fields) {
             let field_name = &f.name;
-            // `field_value` already flattens a nullable column to `None`, and the
-            // preview of an empty body is legitimately empty markup — so the
-            // nullable and non-nullable cases read identically here.
-            let value_expr = format!("changeset.field_value(\"{field_name}\").unwrap_or_default()");
             let _ = write!(
                 ph,
                 "\n\n/// `POST /{plural}/preview/{field_name}` — sanitized Markdown preview fragment.\n"
@@ -3427,14 +3423,21 @@ pub async fn index(
                 ph,
                 "pub async fn preview_{field_name}(body: autumn_web::reexports::axum::body::Bytes) -> autumn_web::Markup {{"
             );
-            ph.push_str("    let Ok(form) = decode_form(body) else {\n");
-            ph.push_str("        return autumn_web::html! {};\n");
-            ph.push_str("    };\n");
-            ph.push_str("    let changeset = form.into_changeset();\n");
+            // Read ONLY the previewed field, leniently — never `decode_form`.
+            // The editor `hx-include`s the whole form, so on a fresh `new` page
+            // every other column arrives blank; deserializing the form struct
+            // would fail on the first strictly-typed empty field (`count=` into
+            // an `i64`) and blank the preview until the author had filled in
+            // every unrelated column (PR #2157 review). A preview performs no
+            // validation, so it has no reason to need the rest of the form —
+            // unlike the inline-validation fragments above, which decode the
+            // whole form precisely because checking `#[validate]` rules is
+            // their job.
             let _ = writeln!(
                 ph,
-                "    autumn_web::markdown::render_user_content(&{value_expr})"
+                "    let source = autumn_web::form::field_from_urlencoded(&body, \"{field_name}\")\n        .unwrap_or_default();"
             );
+            let _ = writeln!(ph, "    autumn_web::markdown::render_user_content(&source)");
             ph.push_str("}\n");
         }
         ph
@@ -13234,6 +13237,44 @@ exempt_paths = [
         );
         // The typed path helper is exported so the form can link to it.
         assert!(routes.contains("preview_body"), "{routes}");
+    }
+
+    #[test]
+    fn richtext_preview_does_not_depend_on_the_rest_of_the_form_decoding() {
+        // PR #2157 review: the preview `hx-include`s the whole form, so on a
+        // fresh "new" page every other field is still blank. Decoding the whole
+        // form struct to reach the one previewed field would fail on the first
+        // strictly-typed empty column (`count=` into an `i64`) and blank the
+        // preview until every unrelated field was filled in.
+        let tmp = project_with_main(default_main());
+        let plan = plan_scaffold(
+            tmp.path(),
+            "Post",
+            &["body:richtext".into(), "count:i64".into()],
+            "20260731000000",
+        )
+        .unwrap();
+        let routes = action_contents(&plan, "src/routes/posts.rs");
+        let handler = routes
+            .split_once("pub async fn preview_body(")
+            .expect("preview handler")
+            .1
+            .split_once("\n}\n")
+            .unwrap()
+            .0;
+        assert!(
+            handler.contains("field_from_urlencoded"),
+            "the preview must read its one field leniently:\n{handler}"
+        );
+        assert!(
+            !handler.contains("decode_form"),
+            "whole-form decode couples the preview to every other field's \
+             validity:\n{handler}"
+        );
+        assert!(
+            handler.contains("render_user_content"),
+            "the preview must still be sanitized:\n{handler}"
+        );
     }
 
     #[test]

--- a/autumn-cli/tests/integration/mod.rs
+++ b/autumn-cli/tests/integration/mod.rs
@@ -18,6 +18,7 @@ mod offsite_backup;
 mod repo_hygiene;
 mod scaffold_belongs_to;
 mod scaffold_form_for;
+mod scaffold_rich_text;
 mod scaffold_search;
 mod scaffold_sort_filter;
 mod scaffold_validation;

--- a/autumn-cli/tests/integration/scaffold_rich_text.rs
+++ b/autumn-cli/tests/integration/scaffold_rich_text.rs
@@ -1,0 +1,168 @@
+//! End-to-end scaffolding of a `richtext` column (issue #1255).
+//!
+//! `autumn generate scaffold Post title:String body:richtext` must produce an
+//! app that is **safe by default**: the form edits Markdown source through the
+//! shipped editor widget, the show view renders it through the sanitizing
+//! `markdown::render_user_content`, and the project's `autumn-web` dependency
+//! carries the `markdown` feature so all of that resolves.
+//!
+//! The string assertions run everywhere; the `#[ignore]`d compile check proves
+//! the emitted code actually builds against this workspace's `autumn-web`.
+
+use std::fmt::Write as _;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Run the production `autumn` binary in `dir`, asserting success.
+fn run_autumn(dir: &Path, args: &[&str]) {
+    let autumn_bin = env!("CARGO_BIN_EXE_autumn");
+    let output = Command::new(autumn_bin)
+        .args(args)
+        .current_dir(dir)
+        .output()
+        .expect("failed to run autumn");
+    assert!(
+        output.status.success(),
+        "autumn {args:?} failed (exit={:?})\nstdout: {}\nstderr: {}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+}
+
+/// `autumn new` + `autumn generate scaffold … body:richtext` in a fresh
+/// tempdir, returning the tempdir guard and the project root.
+fn rich_text_project(project_name: &str, extra: &[&str]) -> (tempfile::TempDir, PathBuf) {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    run_autumn(tmp.path(), &["new", project_name]);
+    let project = tmp.path().join(project_name);
+    let mut args = vec![
+        "generate",
+        "scaffold",
+        "Post",
+        "title:String",
+        "body:richtext",
+    ];
+    args.extend_from_slice(extra);
+    run_autumn(&project, &args);
+    (tmp, project)
+}
+
+#[test]
+fn richtext_scaffold_emits_the_editor_preview_and_sanitized_render() {
+    let (_tmp, project) = rich_text_project("richtext-app", &[]);
+    let routes = fs::read_to_string(project.join("src/routes/posts.rs")).unwrap();
+
+    // The form control is the Markdown editor, wired to the preview endpoint.
+    assert!(
+        routes.contains("rich_text_area_htmx_with_token_field"),
+        "form must render the Markdown editor:\n{routes}"
+    );
+    assert!(
+        routes.contains("paths::preview_body()"),
+        "the editor must link to the typed preview path helper:\n{routes}"
+    );
+
+    // The preview endpoint exists and sanitizes.
+    assert!(
+        routes.contains("#[post(\"/posts/preview/body\")]"),
+        "{routes}"
+    );
+    assert!(routes.contains("pub async fn preview_body("), "{routes}");
+
+    // The show view renders through the sanitizer, never raw.
+    assert!(
+        routes.contains("autumn_web::markdown::render_user_content(&row.body)"),
+        "show view must sanitize:\n{routes}"
+    );
+    assert!(
+        !routes.contains("maud::PreEscaped(&row.body)"),
+        "the raw source must never be emitted pre-escaped:\n{routes}"
+    );
+
+    // The preview route is mounted in main.rs.
+    let main_rs = fs::read_to_string(project.join("src/main.rs")).unwrap();
+    assert!(
+        main_rs.contains("routes::posts::preview_body"),
+        "the preview handler must be mounted or the editor 404s:\n{main_rs}"
+    );
+
+    // The `markdown` feature is enabled so the helper resolves.
+    let cargo = fs::read_to_string(project.join("Cargo.toml")).unwrap();
+    assert!(cargo.contains("markdown"), "{cargo}");
+
+    // The preview POST hx-includes the whole form, so it must not spend the
+    // one-time submit token.
+    let autumn_toml = fs::read_to_string(project.join("autumn.toml")).unwrap();
+    assert!(
+        autumn_toml.contains("/posts/preview"),
+        "the preview route must be submit-token exempt:\n{autumn_toml}"
+    );
+}
+
+#[test]
+fn richtext_scaffold_migration_uses_a_plain_text_column() {
+    // The column stores Markdown SOURCE, never rendered HTML — so it is an
+    // ordinary TEXT column with no special storage handling.
+    let (_tmp, project) = rich_text_project("richtext-migration-app", &[]);
+    let migrations = fs::read_dir(project.join("migrations")).unwrap();
+    let up = migrations
+        .filter_map(Result::ok)
+        .map(|e| e.path().join("up.sql"))
+        .find(|p| p.exists() && fs::read_to_string(p).is_ok_and(|s| s.contains("posts")))
+        .expect("create_posts migration");
+    let sql = fs::read_to_string(up).unwrap();
+    assert!(sql.contains("body TEXT NOT NULL"), "{sql}");
+
+    let schema = fs::read_to_string(project.join("src/schema.rs")).unwrap();
+    assert!(schema.contains("body -> Text,"), "{schema}");
+
+    let model = fs::read_to_string(project.join("src/models/post.rs")).unwrap();
+    assert!(model.contains("pub body: String,"), "{model}");
+}
+
+/// Slow end-to-end check: the generated `richtext` project type-checks against
+/// this workspace's `autumn-web`, proving the emitted editor call, preview
+/// handler, and sanitized show render all resolve with the auto-enabled
+/// `markdown` feature.
+///
+/// Ignored by default; run with
+/// `cargo test -p autumn-cli --test cli_tests -- --ignored richtext`.
+#[test]
+#[ignore = "slow: cargo-checks a fresh project — run with `cargo test -p autumn-cli -- --ignored`"]
+fn richtext_scaffold_cargo_checks() {
+    let (_tmp, project) = rich_text_project("richtext-check-app", &[]);
+    let cargo_toml_path = project.join("Cargo.toml");
+    let mut content = fs::read_to_string(&cargo_toml_path).unwrap();
+    let workspace_root = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("workspace root");
+    let _ = write!(
+        content,
+        "\n[patch.crates-io]\nautumn-web = {{ path = \"{}\" }}\nautumn-macros = {{ path = \"{}\" }}\n",
+        workspace_root
+            .join("autumn")
+            .display()
+            .to_string()
+            .replace('\\', "/"),
+        workspace_root
+            .join("autumn-macros")
+            .display()
+            .to_string()
+            .replace('\\', "/"),
+    );
+    fs::write(&cargo_toml_path, content).unwrap();
+
+    let check = Command::new("cargo")
+        .args(["check", "--tests"])
+        .current_dir(&project)
+        .output()
+        .unwrap();
+    assert!(
+        check.status.success(),
+        "cargo check on the richtext scaffold failed:\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&check.stdout),
+        String::from_utf8_lossy(&check.stderr),
+    );
+}

--- a/autumn/Cargo.toml
+++ b/autumn/Cargo.toml
@@ -33,8 +33,11 @@ openapi = ["dep:serde_yaml"]
 # agents can call the real, authenticated handler pipeline. Builds on the
 # same `ApiDoc` registry that drives `openapi`, so it implies that feature.
 mcp = ["openapi"]
-# Optional Markdown rendering with frontmatter parsing and SSG integration.
-markdown = ["dep:pulldown-cmark"]
+# Optional Markdown rendering with frontmatter parsing and SSG integration,
+# plus the safe *user-submitted* rich-text path (issue #1255): `ammonia` is the
+# allowlist HTML sanitizer `markdown::render_user_content` runs its output
+# through, so a content app can accept user Markdown without stored XSS.
+markdown = ["dep:pulldown-cmark", "dep:ammonia"]
 db = [
     "dep:deadpool",
     "dep:diesel",
@@ -292,6 +295,7 @@ serde_urlencoded = "0.7"
 serde_path_to_error = "0.1"
 serde_yaml = { version = "0.9", optional = true }
 pulldown-cmark = { workspace = true, optional = true }
+ammonia = { workspace = true, optional = true }
 subtle = "2.6.1"
 base64 = "0.22"
 url = "2.5.8"

--- a/autumn/src/form.rs
+++ b/autumn/src/form.rs
@@ -1378,7 +1378,7 @@ pub fn rich_text_area<T: Serialize>(
     field: &str,
     label: &str,
 ) -> maud::Markup {
-    rich_text_area_inner(changeset, field, label, None)
+    rich_text_area_inner(changeset, field, label, None, false)
 }
 
 /// Render a [`rich_text_area`] with an htmx-driven live preview pane.
@@ -1402,21 +1402,23 @@ pub fn rich_text_area<T: Serialize>(
 /// ```rust,ignore
 /// #[post("/posts/preview/body")]
 /// pub async fn preview_body(body: Bytes) -> Markup {
-///     let Ok(form) = decode_form(body) else {
-///         return html! {};
-///     };
-///     let changeset = form.into_changeset();
-///     autumn_web::markdown::render_user_content(
-///         &changeset.field_value("body").unwrap_or_default(),
-///     )
+///     let source = autumn_web::form::field_from_urlencoded(&body, "body")
+///         .unwrap_or_default();
+///     autumn_web::markdown::render_user_content(&source)
 /// }
 /// ```
 ///
-/// Do **not** use the [`ChangesetForm<T>`] extractor here. It rejects a body it
-/// cannot deserialize with a 4xx response, and a half-filled form legitimately
-/// posts an empty string for a numeric column — htmx does not swap a 4xx, so
-/// the preview would silently stop updating mid-edit. Failing closed to empty
-/// markup keeps the editor usable.
+/// Note it reads the one field it needs with [`field_from_urlencoded`] rather
+/// than deserializing the whole form: `hx-include` posts **every** field, so on
+/// a freshly-opened "new" page an unrelated required `i64` column arrives as
+/// `count=`, and a whole-form decode would fail on that empty string and blank
+/// the preview until the author had filled in every other column.
+///
+/// For the same reason, do **not** use the [`ChangesetForm<T>`] extractor here:
+/// it rejects a body it cannot deserialize with a 4xx, htmx does not swap a
+/// 4xx, and the preview would silently stop updating mid-edit. Reading the one
+/// field has no failure mode — an absent or empty field previews as empty,
+/// which is exactly right for a cleared editor.
 #[cfg(feature = "maud")]
 #[must_use]
 pub fn rich_text_area_htmx<T: Serialize>(
@@ -1451,7 +1453,81 @@ pub fn rich_text_area_htmx_with_token_field<T: Serialize>(
     preview_url: &str,
     token_field: &str,
 ) -> maud::Markup {
-    rich_text_area_inner(changeset, field, label, Some((preview_url, token_field)))
+    rich_text_area_inner(
+        changeset,
+        field,
+        label,
+        Some((preview_url, token_field)),
+        false,
+    )
+}
+
+/// Render a labeled Markdown editor for a **required** rich-text field.
+///
+/// Identical to [`rich_text_area`] but adds the HTML `required` attribute and
+/// `aria-required="true"`, giving both AT users and browser-native validation
+/// the required-field signal — matching the `required_*` siblings for every
+/// other control.
+///
+/// This matters more here than it looks: both `String` deserialization and a
+/// `TEXT NOT NULL` column accept the empty string, so without a client-side
+/// signal a non-nullable rich-text column would silently persist a blank body
+/// unless the field also declared a `{min=N}` length constraint (PR #2157
+/// review). The generator picks this variant for a non-nullable `richtext`
+/// column and [`rich_text_area`] for an `Option<richtext>` one.
+#[cfg(feature = "maud")]
+#[must_use]
+pub fn required_rich_text_area<T: Serialize>(
+    changeset: &Changeset<T>,
+    field: &str,
+    label: &str,
+) -> maud::Markup {
+    rich_text_area_inner(changeset, field, label, None, true)
+}
+
+/// Render a **required** Markdown editor with an htmx-driven live preview.
+///
+/// The required-field counterpart of [`rich_text_area_htmx`]; see
+/// [`required_rich_text_area`] for why the signal matters and
+/// [`rich_text_area_htmx`] for the preview wiring.
+#[cfg(feature = "maud")]
+#[must_use]
+pub fn required_rich_text_area_htmx<T: Serialize>(
+    changeset: &Changeset<T>,
+    field: &str,
+    label: &str,
+    preview_url: &str,
+) -> maud::Markup {
+    required_rich_text_area_htmx_with_token_field(
+        changeset,
+        field,
+        label,
+        preview_url,
+        DEFAULT_SUBMIT_TOKEN_FIELD,
+    )
+}
+
+/// Like [`required_rich_text_area_htmx`] but excludes the caller-supplied
+/// submit-token field name from the preview POST instead of the hardcoded
+/// default `_submit_token`.
+///
+/// The required-field counterpart of [`rich_text_area_htmx_with_token_field`].
+#[cfg(feature = "maud")]
+#[must_use]
+pub fn required_rich_text_area_htmx_with_token_field<T: Serialize>(
+    changeset: &Changeset<T>,
+    field: &str,
+    label: &str,
+    preview_url: &str,
+    token_field: &str,
+) -> maud::Markup {
+    rich_text_area_inner(
+        changeset,
+        field,
+        label,
+        Some((preview_url, token_field)),
+        true,
+    )
 }
 
 /// Shared body of [`rich_text_area`] and its htmx variant. `preview` is
@@ -1462,6 +1538,7 @@ fn rich_text_area_inner<T: Serialize>(
     field: &str,
     label: &str,
     preview: Option<(&str, &str)>,
+    required: bool,
 ) -> maud::Markup {
     let errors = changeset.errors_for(field);
     let has_errors = !errors.is_empty();
@@ -1498,6 +1575,8 @@ fn rich_text_area_inner<T: Serialize>(
                 class=(if has_errors { "autumn-field__input autumn-rich-text__editor autumn-field__input--invalid" } else { "autumn-field__input autumn-rich-text__editor" })
                 aria-invalid=(if has_errors { "true" } else { "false" })
                 aria-describedby=(described_by)
+                required[required]
+                aria-required=[required.then_some("true")]
                 hx-post=[preview.map(|(url, _)| url)]
                 hx-trigger=[preview.map(|_| "keyup changed delay:400ms, change")]
                 hx-target=[preview.map(|_| preview_target.as_str())]
@@ -3745,6 +3824,50 @@ mod tests {
         assert_eq!(field_from_urlencoded(b"", "body"), None);
         // A key that merely *contains* the name must not match.
         assert_eq!(field_from_urlencoded(b"body_extra=no", "body"), None);
+    }
+
+    #[cfg(feature = "maud")]
+    #[test]
+    fn required_rich_text_area_signals_a_required_field() {
+        // PR #2157 review: a non-nullable `body:richtext` column had no
+        // required signal at all, unlike every other non-nullable generated
+        // control. Both `String` deserialization and a `TEXT NOT NULL` column
+        // accept `""`, so an empty editor persisted a blank body silently.
+        #[derive(serde::Serialize)]
+        struct F {
+            body: String,
+        }
+        let cs = Changeset::new(F {
+            body: String::new(),
+        });
+        let html = required_rich_text_area(&cs, "body", "Body").into_string();
+        assert!(html.contains("required"), "{html}");
+        assert!(html.contains(r#"aria-required="true""#), "{html}");
+        // Still the same editor otherwise.
+        assert!(html.contains("<textarea"), "{html}");
+        assert!(html.contains("autumn-rich-text"), "{html}");
+
+        // The optional variant keeps its previous behaviour: leaving a nullable
+        // column blank is valid, so no browser-native "please fill this out".
+        let optional = rich_text_area(&cs, "body", "Body").into_string();
+        assert!(!optional.contains(r#"aria-required="true""#), "{optional}");
+    }
+
+    #[cfg(feature = "maud")]
+    #[test]
+    fn required_rich_text_area_htmx_keeps_both_the_preview_and_the_signal() {
+        #[derive(serde::Serialize)]
+        struct F {
+            body: String,
+        }
+        let cs = Changeset::new(F {
+            body: String::new(),
+        });
+        let html =
+            required_rich_text_area_htmx(&cs, "body", "Body", "/posts/preview/body").into_string();
+        assert!(html.contains(r#"aria-required="true""#), "{html}");
+        assert!(html.contains(r#"hx-post="/posts/preview/body""#), "{html}");
+        assert!(html.contains(r##"hx-target="#body-preview""##), "{html}");
     }
 
     #[cfg(feature = "maud")]

--- a/autumn/src/form.rs
+++ b/autumn/src/form.rs
@@ -1280,12 +1280,36 @@ pub fn textarea_input<T: Serialize>(
     }
 }
 
-/// The hint shown under a [`rich_text_area`] editor, telling the author which
-/// Markdown the field accepts. Kept in one place so the widget, its htmx
-/// variant, and the generated scaffold all say the same thing.
+/// The hint shown under a [`rich_text_area`] editor. Deliberately short: the
+/// syntax itself lives in the toolbar ([`RICH_TEXT_TOOLBAR`]), so this sentence
+/// only carries the part the toolbar can't — that HTML is *not* accepted.
 #[cfg(feature = "maud")]
-const RICH_TEXT_HINT: &str = "Markdown supported: **bold**, _italic_, [links](https://example.com), \
-     lists, `code`, and tables. HTML is not allowed and is shown as plain text.";
+const RICH_TEXT_HINT: &str = "Markdown supported. HTML is not allowed and is shown as plain text.";
+
+/// The minimal Markdown toolbar rendered above a [`rich_text_area`] editor, as
+/// `(label, syntax)` pairs.
+///
+/// This is a **no-JavaScript** toolbar: it shows the syntax for each supported
+/// construct at the point of use rather than inserting it on click. That is a
+/// deliberate trade-off. Inserting text into a `<textarea>` is impossible in
+/// HTML alone, so a click-to-insert toolbar would mean shipping a script — and a
+/// scripted control that silently does nothing when scripting is off is worse
+/// than no control at all. The editor's contract is that it works with no
+/// JavaScript (issue #1255), so the toolbar holds to the same bar.
+///
+/// Every entry corresponds to something the renderer actually emits (see
+/// [`RICH_TEXT_ALLOWED_TAGS`](crate::markdown::RICH_TEXT_ALLOWED_TAGS)) — there
+/// is no affordance here for syntax the sanitizer would strip.
+#[cfg(feature = "maud")]
+const RICH_TEXT_TOOLBAR: &[(&str, &str)] = &[
+    ("Bold", "**bold**"),
+    ("Italic", "_italic_"),
+    ("Link", "[text](url)"),
+    ("Code", "`code`"),
+    ("List", "- item"),
+    ("Heading", "# Heading"),
+    ("Quote", "> quote"),
+];
 
 /// Render a labeled Markdown editor for a rich-text field (issue #1255).
 ///
@@ -1329,18 +1353,29 @@ pub fn rich_text_area<T: Serialize>(
 /// submit needs; use [`rich_text_area_htmx_with_token_field`] when the app
 /// customizes `[security.submit_token].field_name`.
 ///
-/// The preview handler should extract [`ChangesetForm<T>`] and return
+/// The preview handler should decode the body **leniently** and return
 /// [`markdown::render_user_content`](crate::markdown::render_user_content) of
-/// the submitted field:
+/// the submitted field — this is exactly what `autumn generate scaffold
+/// … body:richtext` emits:
 ///
 /// ```rust,ignore
 /// #[post("/posts/preview/body")]
-/// async fn preview_body(form: ChangesetForm<PostForm>) -> Markup {
+/// pub async fn preview_body(body: Bytes) -> Markup {
+///     let Ok(form) = decode_form(body) else {
+///         return html! {};
+///     };
+///     let changeset = form.into_changeset();
 ///     autumn_web::markdown::render_user_content(
-///         &form.field_value("body").unwrap_or_default(),
+///         &changeset.field_value("body").unwrap_or_default(),
 ///     )
 /// }
 /// ```
+///
+/// Do **not** use the [`ChangesetForm<T>`] extractor here. It rejects a body it
+/// cannot deserialize with a 4xx response, and a half-filled form legitimately
+/// posts an empty string for a numeric column — htmx does not swap a 4xx, so
+/// the preview would silently stop updating mid-edit. Failing closed to empty
+/// markup keeps the editor usable.
 #[cfg(feature = "maud")]
 #[must_use]
 pub fn rich_text_area_htmx<T: Serialize>(
@@ -1407,6 +1442,14 @@ fn rich_text_area_inner<T: Serialize>(
     maud::html! {
         div id=(wrapper_id) class="autumn-field autumn-rich-text" data-autumn-field-wrapper=(field) {
             label for=(field) class="autumn-field__label" { (label) }
+            div class="autumn-rich-text__toolbar" role="group" aria-label="Markdown formatting" {
+                @for (control, syntax) in RICH_TEXT_TOOLBAR {
+                    span class="autumn-rich-text__toolbar-item" {
+                        span class="autumn-rich-text__toolbar-label" { (control) }
+                        code class="autumn-rich-text__toolbar-syntax" { (syntax) }
+                    }
+                }
+            }
             textarea
                 id=(field)
                 name=(field)
@@ -1432,11 +1475,17 @@ fn rich_text_area_inner<T: Serialize>(
             @if preview.is_some() {
                 div class="autumn-rich-text__preview-wrapper" {
                     span class="autumn-rich-text__preview-label" id=(format!("{field}-preview-label")) { "Preview" }
+                    // Deliberately NOT an `aria-live` region: this element is
+                    // the htmx swap target and re-renders on every pause in
+                    // typing, so announcing it would read the entire post back
+                    // to the author mid-sentence. `docs/guide/accessibility.md`
+                    // reserves live regions for short, deliberate status
+                    // messages delivered out-of-band. It stays a labeled
+                    // landmark the author can navigate to on demand.
                     div
                         id=(preview_id)
                         class="autumn-rich-text__preview"
                         role="region"
-                        aria-live="polite"
                         aria-labelledby=(format!("{field}-preview-label"))
                         { (rich_text_preview(&value)) }
                 }
@@ -3627,6 +3676,50 @@ mod tests {
 
     #[cfg(feature = "maud")]
     #[test]
+    fn rich_text_area_renders_a_minimal_markdown_toolbar() {
+        #[derive(serde::Serialize)]
+        struct F {
+            body: String,
+        }
+        let cs = Changeset::new(F {
+            body: String::new(),
+        });
+        let html = rich_text_area(&cs, "body", "Body").into_string();
+
+        // A grouped, labeled toolbar — announced as one unit rather than as
+        // loose text between the label and the editor.
+        assert!(html.contains(r#"role="group""#), "{html}");
+        assert!(html.contains("autumn-rich-text__toolbar"), "{html}");
+        assert!(
+            html.to_lowercase()
+                .contains(r#"aria-label="markdown formatting"#),
+            "{html}"
+        );
+
+        // Every syntax the allowlist actually renders is represented.
+        for token in [
+            "**bold**",
+            "_italic_",
+            "[text](url)",
+            "- item",
+            "# Heading",
+            "> quote",
+        ] {
+            assert!(
+                html.contains(&maud::html! { (token) }.into_string()),
+                "toolbar is missing the {token:?} affordance:\n{html}"
+            );
+        }
+
+        // The graceful base case: the toolbar must not depend on JavaScript,
+        // and must not render a control that silently does nothing without it.
+        assert!(!html.contains("<script"), "{html}");
+        assert!(!html.contains("<button"), "{html}");
+        assert!(!html.contains("onclick"), "{html}");
+    }
+
+    #[cfg(feature = "maud")]
+    #[test]
     fn rich_text_area_escapes_the_editor_value() {
         #[derive(serde::Serialize)]
         struct F {
@@ -3688,9 +3781,13 @@ mod tests {
         assert!(html.contains("hx-trigger="), "{html}");
         // The one-time submit token must not be spent by preview requests.
         assert!(html.contains(r#"hx-params="not _submit_token""#), "{html}");
-        // The pane htmx swaps into, announced politely for AT users.
+        // The pane htmx swaps into. Deliberately not an `aria-live` region —
+        // it re-renders on every pause in typing, and announcing the whole
+        // rendered body back to its author is noise, not help.
         assert!(html.contains(r#"id="body-preview""#), "{html}");
-        assert!(html.contains(r#"aria-live="polite""#), "{html}");
+        assert!(!html.contains("aria-live"), "{html}");
+        assert!(html.contains(r#"role="region""#), "{html}");
+        assert!(html.contains("aria-labelledby="), "{html}");
         // No inline JavaScript anywhere — htmx attributes only.
         assert!(!html.contains("<script"), "{html}");
         assert!(!html.contains("onkeyup"), "{html}");

--- a/autumn/src/form.rs
+++ b/autumn/src/form.rs
@@ -475,6 +475,42 @@ impl<T: Serialize> ChangesetForm<T> {
         text_input_htmx_with_token_field(&self.changeset, field, label, validate_url, token_field)
     }
 
+    /// Render a labeled Markdown editor for a rich-text `field` (issue #1255).
+    ///
+    /// Delegates to [`rich_text_area`]; see that function for the full contract,
+    /// including how to render the stored value back out safely.
+    pub fn rich_text_area(&self, field: &str, label: &str) -> maud::Markup {
+        rich_text_area(&self.changeset, field, label)
+    }
+
+    /// Render a Markdown editor with an htmx-driven live preview pane.
+    ///
+    /// Delegates to [`rich_text_area_htmx`]; see that function for full docs.
+    pub fn rich_text_area_htmx(&self, field: &str, label: &str, preview_url: &str) -> maud::Markup {
+        rich_text_area_htmx(&self.changeset, field, label, preview_url)
+    }
+
+    /// Render a Markdown editor with an htmx live preview, excluding the
+    /// configured submit-token field `token_field` from the preview POST.
+    ///
+    /// Delegates to [`rich_text_area_htmx_with_token_field`]; use this when the
+    /// app customizes `[security.submit_token].field_name` (issue #1843).
+    pub fn rich_text_area_htmx_with_token_field(
+        &self,
+        field: &str,
+        label: &str,
+        preview_url: &str,
+        token_field: &str,
+    ) -> maud::Markup {
+        rich_text_area_htmx_with_token_field(
+            &self.changeset,
+            field,
+            label,
+            preview_url,
+            token_field,
+        )
+    }
+
     /// Render a `<button type="submit">` with `label`.
     pub fn submit_button(&self, label: &str) -> maud::Markup {
         submit_button(label)
@@ -1242,6 +1278,189 @@ pub fn textarea_input<T: Serialize>(
             }
         }
     }
+}
+
+/// The hint shown under a [`rich_text_area`] editor, telling the author which
+/// Markdown the field accepts. Kept in one place so the widget, its htmx
+/// variant, and the generated scaffold all say the same thing.
+#[cfg(feature = "maud")]
+const RICH_TEXT_HINT: &str = "Markdown supported: **bold**, _italic_, [links](https://example.com), \
+     lists, `code`, and tables. HTML is not allowed and is shown as plain text.";
+
+/// Render a labeled Markdown editor for a rich-text field (issue #1255).
+///
+/// The control is a plain `<textarea>` carrying the Markdown **source** — the
+/// column stores the source, never rendered HTML — plus a hint naming the
+/// supported syntax. It needs no JavaScript and degrades to an ordinary
+/// textarea everywhere.
+///
+/// Render the stored value back out with
+/// [`markdown::render_user_content`](crate::markdown::render_user_content),
+/// which disables raw-HTML passthrough and applies an allowlist sanitizer.
+/// Rendering it any other way — `PreEscaped(&post.body)`, or the trusted-content
+/// [`markdown::render`](crate::markdown::render) — reintroduces stored XSS.
+///
+/// Use [`rich_text_area_htmx`] to add a live preview pane.
+///
+/// - Sets `name` and `id` to `field`
+/// - Wraps in a `<div id="{field}-field">` for stable htmx targeting
+/// - Populates the textarea body from the changeset's serialized data
+/// - Points `aria-describedby` at the hint, plus the error region when errors exist
+#[cfg(feature = "maud")]
+#[must_use]
+pub fn rich_text_area<T: Serialize>(
+    changeset: &Changeset<T>,
+    field: &str,
+    label: &str,
+) -> maud::Markup {
+    rich_text_area_inner(changeset, field, label, None)
+}
+
+/// Render a [`rich_text_area`] with an htmx-driven live preview pane.
+///
+/// The textarea POSTs the form to `preview_url` a short moment after typing
+/// stops and swaps the response into `#{field}-preview` — **no JavaScript of
+/// your own**, just htmx attributes. Without htmx (or with scripting off) the
+/// control still works: it is the same textarea, and the pane simply shows the
+/// server-rendered preview of the value the page was rendered with.
+///
+/// As with [`text_input_htmx`], `hx-params` excludes the default one-time
+/// submit-token field so a preview request cannot spend the token the real
+/// submit needs; use [`rich_text_area_htmx_with_token_field`] when the app
+/// customizes `[security.submit_token].field_name`.
+///
+/// The preview handler should extract [`ChangesetForm<T>`] and return
+/// [`markdown::render_user_content`](crate::markdown::render_user_content) of
+/// the submitted field:
+///
+/// ```rust,ignore
+/// #[post("/posts/preview/body")]
+/// async fn preview_body(form: ChangesetForm<PostForm>) -> Markup {
+///     autumn_web::markdown::render_user_content(
+///         &form.field_value("body").unwrap_or_default(),
+///     )
+/// }
+/// ```
+#[cfg(feature = "maud")]
+#[must_use]
+pub fn rich_text_area_htmx<T: Serialize>(
+    changeset: &Changeset<T>,
+    field: &str,
+    label: &str,
+    preview_url: &str,
+) -> maud::Markup {
+    rich_text_area_htmx_with_token_field(
+        changeset,
+        field,
+        label,
+        preview_url,
+        DEFAULT_SUBMIT_TOKEN_FIELD,
+    )
+}
+
+/// Like [`rich_text_area_htmx`] but excludes the caller-supplied submit-token
+/// field name from the preview POST instead of the hardcoded default
+/// `_submit_token`.
+///
+/// Use this when the app customizes `[security.submit_token].field_name`
+/// (issue #1843) — source the configured name at request time from the
+/// [`SubmitFormField`](crate::security::SubmitFormField) extractor. Passing
+/// `"_submit_token"` here is equivalent to calling [`rich_text_area_htmx`].
+#[cfg(feature = "maud")]
+#[must_use]
+pub fn rich_text_area_htmx_with_token_field<T: Serialize>(
+    changeset: &Changeset<T>,
+    field: &str,
+    label: &str,
+    preview_url: &str,
+    token_field: &str,
+) -> maud::Markup {
+    rich_text_area_inner(changeset, field, label, Some((preview_url, token_field)))
+}
+
+/// Shared body of [`rich_text_area`] and its htmx variant. `preview` is
+/// `Some((preview_url, token_field))` for the live-preview flavour.
+#[cfg(feature = "maud")]
+fn rich_text_area_inner<T: Serialize>(
+    changeset: &Changeset<T>,
+    field: &str,
+    label: &str,
+    preview: Option<(&str, &str)>,
+) -> maud::Markup {
+    let errors = changeset.errors_for(field);
+    let has_errors = !errors.is_empty();
+    let value = changeset.field_value(field).unwrap_or_default();
+    let error_id = format!("{field}-error");
+    let hint_id = format!("{field}-hint");
+    let wrapper_id = format!("{field}-field");
+    let preview_id = format!("{field}-preview");
+    // The hint is always present, so `aria-describedby` is never empty and
+    // never names an element that isn't in the DOM.
+    let described_by = if has_errors {
+        format!("{hint_id} {error_id}")
+    } else {
+        hint_id.clone()
+    };
+    let preview_target = format!("#{preview_id}");
+    let hx_params = preview.map(|(_, token_field)| format!("not {token_field}"));
+
+    maud::html! {
+        div id=(wrapper_id) class="autumn-field autumn-rich-text" data-autumn-field-wrapper=(field) {
+            label for=(field) class="autumn-field__label" { (label) }
+            textarea
+                id=(field)
+                name=(field)
+                rows="12"
+                class=(if has_errors { "autumn-field__input autumn-rich-text__editor autumn-field__input--invalid" } else { "autumn-field__input autumn-rich-text__editor" })
+                aria-invalid=(if has_errors { "true" } else { "false" })
+                aria-describedby=(described_by)
+                hx-post=[preview.map(|(url, _)| url)]
+                hx-trigger=[preview.map(|_| "keyup changed delay:400ms, change")]
+                hx-target=[preview.map(|_| preview_target.as_str())]
+                hx-swap=[preview.map(|_| "innerHTML")]
+                hx-include=[preview.map(|_| "closest form")]
+                hx-params=[hx_params.as_deref()]
+                { (value) }
+            p id=(hint_id) class="autumn-rich-text__hint" { (RICH_TEXT_HINT) }
+            @if has_errors {
+                div id=(error_id) role="alert" class="autumn-field__errors" {
+                    @for error in errors {
+                        p class="autumn-field__error" { (error) }
+                    }
+                }
+            }
+            @if preview.is_some() {
+                div class="autumn-rich-text__preview-wrapper" {
+                    span class="autumn-rich-text__preview-label" id=(format!("{field}-preview-label")) { "Preview" }
+                    div
+                        id=(preview_id)
+                        class="autumn-rich-text__preview"
+                        role="region"
+                        aria-live="polite"
+                        aria-labelledby=(format!("{field}-preview-label"))
+                        { (rich_text_preview(&value)) }
+                }
+            }
+        }
+    }
+}
+
+/// Server-side pre-render of the preview pane's initial contents.
+///
+/// With the `markdown` feature on, the current value is rendered through the
+/// same sanitizer the live preview and the show page use, so a 422 re-render
+/// displays the preview immediately instead of waiting for the first keystroke.
+/// Without it, the pane starts empty and fills in on the first htmx response.
+#[cfg(all(feature = "maud", feature = "markdown"))]
+fn rich_text_preview(value: &str) -> maud::Markup {
+    crate::markdown::render_user_content(value)
+}
+
+/// Fallback for builds without the `markdown` feature — see the documented
+/// sibling above.
+#[cfg(all(feature = "maud", not(feature = "markdown")))]
+fn rich_text_preview(_value: &str) -> maud::Markup {
+    maud::html! {}
 }
 
 /// Render a labeled `<input type="text">` for a required field.
@@ -3378,6 +3597,178 @@ mod tests {
         assert!(html.contains(r#"aria-invalid="true""#), "{html}");
         assert!(html.contains(r#"role="alert""#), "{html}");
         assert!(html.contains("required"), "{html}");
+    }
+
+    // ── Rich text (issue #1255) ────────────────────────────────────────────
+
+    #[cfg(feature = "maud")]
+    #[test]
+    fn rich_text_area_renders_a_labeled_markdown_editor() {
+        #[derive(serde::Serialize)]
+        struct F {
+            body: String,
+        }
+        let cs = Changeset::new(F {
+            body: "Hello **world**".into(),
+        });
+        let html = rich_text_area(&cs, "body", "Body").into_string();
+        assert!(html.contains("<textarea"), "{html}");
+        assert!(html.contains(r#"name="body""#), "{html}");
+        assert!(html.contains(r#"id="body""#), "{html}");
+        assert!(html.contains(r#"<label for="body""#), "{html}");
+        assert!(html.contains("Body"), "{html}");
+        // The submitted Markdown source round-trips into the editor.
+        assert!(html.contains("Hello **world**"), "{html}");
+        // A hint tells the author the field takes Markdown — the whole point of
+        // the control over a bare textarea.
+        assert!(html.to_lowercase().contains("markdown"), "{html}");
+        assert!(html.contains("autumn-rich-text"), "{html}");
+    }
+
+    #[cfg(feature = "maud")]
+    #[test]
+    fn rich_text_area_escapes_the_editor_value() {
+        #[derive(serde::Serialize)]
+        struct F {
+            body: String,
+        }
+        let cs = Changeset::new(F {
+            body: "</textarea><script>alert(1)</script>".into(),
+        });
+        let html = rich_text_area(&cs, "body", "Body").into_string();
+        assert!(!html.contains("<script"), "{html}");
+        assert!(!html.contains("</textarea><script"), "{html}");
+    }
+
+    #[cfg(feature = "maud")]
+    #[test]
+    fn rich_text_area_describes_itself_with_hint_and_errors() {
+        #[derive(serde::Serialize)]
+        struct F {
+            body: String,
+        }
+        let cs = Changeset::new(F {
+            body: String::new(),
+        });
+        let ok = rich_text_area(&cs, "body", "Body").into_string();
+        // Error-free: described by the hint alone, never a dangling error id.
+        assert!(ok.contains(r#"aria-describedby="body-hint""#), "{ok}");
+        assert!(ok.contains(r#"aria-invalid="false""#), "{ok}");
+
+        let mut errors = HashMap::new();
+        errors.insert("body".to_string(), vec!["must not be blank".to_string()]);
+        let cs = Changeset::from_errors(
+            F {
+                body: String::new(),
+            },
+            errors,
+        );
+        let bad = rich_text_area(&cs, "body", "Body").into_string();
+        assert!(
+            bad.contains(r#"aria-describedby="body-hint body-error""#),
+            "{bad}"
+        );
+        assert!(bad.contains(r#"aria-invalid="true""#), "{bad}");
+        assert!(bad.contains(r#"role="alert""#), "{bad}");
+        assert!(bad.contains("must not be blank"), "{bad}");
+    }
+
+    #[cfg(feature = "maud")]
+    #[test]
+    fn rich_text_area_htmx_wires_a_live_preview_with_no_javascript() {
+        #[derive(serde::Serialize)]
+        struct F {
+            body: String,
+        }
+        let cs = Changeset::new(F { body: "hi".into() });
+        let html = rich_text_area_htmx(&cs, "body", "Body", "/posts/preview/body").into_string();
+        assert!(html.contains(r#"hx-post="/posts/preview/body""#), "{html}");
+        assert!(html.contains(r##"hx-target="#body-preview""##), "{html}");
+        assert!(html.contains(r#"hx-swap="innerHTML""#), "{html}");
+        assert!(html.contains("hx-trigger="), "{html}");
+        // The one-time submit token must not be spent by preview requests.
+        assert!(html.contains(r#"hx-params="not _submit_token""#), "{html}");
+        // The pane htmx swaps into, announced politely for AT users.
+        assert!(html.contains(r#"id="body-preview""#), "{html}");
+        assert!(html.contains(r#"aria-live="polite""#), "{html}");
+        // No inline JavaScript anywhere — htmx attributes only.
+        assert!(!html.contains("<script"), "{html}");
+        assert!(!html.contains("onkeyup"), "{html}");
+    }
+
+    #[cfg(feature = "maud")]
+    #[test]
+    fn rich_text_area_htmx_with_token_field_filters_the_configured_field() {
+        #[derive(serde::Serialize)]
+        struct F {
+            body: String,
+        }
+        let cs = Changeset::new(F {
+            body: String::new(),
+        });
+        let html = rich_text_area_htmx_with_token_field(
+            &cs,
+            "body",
+            "Body",
+            "/posts/preview/body",
+            "_one_time",
+        )
+        .into_string();
+        assert!(html.contains(r#"hx-params="not _one_time""#), "{html}");
+        assert!(!html.contains("_submit_token"), "{html}");
+    }
+
+    #[cfg(all(feature = "maud", feature = "markdown"))]
+    #[test]
+    fn rich_text_area_htmx_preview_pane_is_prerendered_and_sanitized() {
+        #[derive(serde::Serialize)]
+        struct F {
+            body: String,
+        }
+        let cs = Changeset::new(F {
+            body: "**bold** [x](javascript:alert(1))".into(),
+        });
+        let html = rich_text_area_htmx(&cs, "body", "Body", "/posts/preview/body").into_string();
+        // A 422 re-render shows the preview immediately, without waiting for
+        // the first keystroke to fire the htmx request…
+        assert!(html.contains("<strong>bold</strong>"), "{html}");
+        // …and that server-side pre-render goes through the same sanitizer.
+        // Scoped to the preview pane: the textarea legitimately still holds the
+        // raw Markdown source, escaped as text content, because the column
+        // stores the source and the author must be able to edit it back.
+        let pane = html
+            .split_once(r#"id="body-preview""#)
+            .expect("preview pane present")
+            .1;
+        assert!(!pane.to_ascii_lowercase().contains("javascript:"), "{pane}");
+        assert!(!pane.contains("href="), "{pane}");
+        // The editor keeps the source verbatim (escaped), not the render.
+        assert!(
+            html.contains("[x](javascript:alert(1))</textarea>"),
+            "{html}"
+        );
+    }
+
+    #[cfg(feature = "maud")]
+    #[test]
+    fn changeset_form_exposes_the_rich_text_helpers() {
+        #[derive(serde::Serialize)]
+        struct F {
+            body: String,
+        }
+        let form = ChangesetForm {
+            changeset: Changeset::new(F { body: "hi".into() }),
+            csrf_token: None,
+            csrf_field: "_csrf".to_owned(),
+        };
+        assert_eq!(
+            form.rich_text_area("body", "Body").into_string(),
+            rich_text_area(&form.changeset, "body", "Body").into_string()
+        );
+        assert_eq!(
+            form.rich_text_area_htmx("body", "Body", "/p").into_string(),
+            rich_text_area_htmx(&form.changeset, "body", "Body", "/p").into_string()
+        );
     }
 
     #[cfg(feature = "maud")]

--- a/autumn/src/form.rs
+++ b/autumn/src/form.rs
@@ -1280,6 +1280,47 @@ pub fn textarea_input<T: Serialize>(
     }
 }
 
+/// Extract one field's value from a URL-encoded form body, without
+/// deserializing the whole form.
+///
+/// # Why this exists
+///
+/// A fragment endpoint that only needs *one* field — a rich-text live preview,
+/// say — is usually reached from an htmx `hx-include="closest form"`, which
+/// posts **every** field on the page. Deserializing that into the form struct
+/// to read one value couples the fragment to the validity of every *other*
+/// field: on a freshly-opened "new" form, a required `i64` column arrives as
+/// `count=`, `serde_urlencoded` fails on the empty string, and the fragment
+/// renders nothing. The author would have to fill in every unrelated column
+/// before the preview started working (PR #2157 review).
+///
+/// Reading the one field leniently avoids that entirely. It is the right tool
+/// *only* when the endpoint genuinely needs a single raw value and performs no
+/// validation — inline **validation** fragments still decode the whole form,
+/// because checking a field against its `#[validate]` rules is exactly what
+/// they are for.
+///
+/// Percent-escapes and `+`-as-space are decoded. The first occurrence of a
+/// repeated key wins, matching `serde_urlencoded`. A present-but-empty field
+/// returns `Some("")`, not `None`, so a cleared editor previews as empty
+/// rather than falling back to a stale value.
+///
+/// # Example
+///
+/// ```
+/// use autumn_web::form::field_from_urlencoded;
+///
+/// let body = b"title=Hi&body=a+%2B+b&count=";
+/// assert_eq!(field_from_urlencoded(body, "body").as_deref(), Some("a + b"));
+/// assert_eq!(field_from_urlencoded(body, "missing"), None);
+/// ```
+#[must_use]
+pub fn field_from_urlencoded(body: &[u8], field: &str) -> Option<String> {
+    url::form_urlencoded::parse(body)
+        .find(|(key, _)| key.as_ref() == field)
+        .map(|(_, value)| value.into_owned())
+}
+
 /// The hint shown under a [`rich_text_area`] editor. Deliberately short: the
 /// syntax itself lives in the toolbar ([`RICH_TEXT_TOOLBAR`]), so this sentence
 /// only carries the part the toolbar can't — that HTML is *not* accepted.
@@ -3649,6 +3690,62 @@ mod tests {
     }
 
     // ── Rich text (issue #1255) ────────────────────────────────────────────
+
+    #[test]
+    fn strict_form_decode_fails_on_a_partially_filled_form() {
+        // The premise of `field_from_urlencoded` (PR #2157 review): a live
+        // preview `hx-include`s the WHOLE form, so on a fresh "new" page every
+        // other field is still empty. Deserializing the whole form struct to
+        // reach one field therefore fails on the first strictly-typed empty
+        // field — and the preview would go blank until the author filled in
+        // every unrelated required column.
+        #[derive(serde::Deserialize)]
+        struct PostForm {
+            #[allow(dead_code)]
+            body: String,
+            #[allow(dead_code)]
+            count: i64,
+        }
+        let partial = b"body=hello+%2A%2Aworld%2A%2A&count=";
+        assert!(
+            serde_urlencoded::from_bytes::<PostForm>(partial).is_err(),
+            "whole-form decode must fail here — that is the bug being fixed"
+        );
+        // The lenient single-field extractor reaches the field regardless.
+        assert_eq!(
+            field_from_urlencoded(partial, "body").as_deref(),
+            Some("hello **world**")
+        );
+    }
+
+    #[test]
+    fn field_from_urlencoded_decodes_percent_and_plus_escapes() {
+        let body = b"title=hi&body=a+%2B+b+%26+%3Cc%3E&other=x";
+        assert_eq!(
+            field_from_urlencoded(body, "body").as_deref(),
+            Some("a + b & <c>")
+        );
+        assert_eq!(field_from_urlencoded(body, "title").as_deref(), Some("hi"));
+        assert_eq!(field_from_urlencoded(body, "absent"), None);
+    }
+
+    #[test]
+    fn field_from_urlencoded_handles_empty_and_repeated_keys() {
+        // An empty value is present-but-blank, not absent — a cleared editor
+        // must preview as empty, not fall back to a stale value.
+        assert_eq!(
+            field_from_urlencoded(b"body=&x=1", "body").as_deref(),
+            Some("")
+        );
+        // First occurrence wins, matching serde_urlencoded's own behaviour.
+        assert_eq!(
+            field_from_urlencoded(b"body=first&body=second", "body").as_deref(),
+            Some("first")
+        );
+        assert_eq!(field_from_urlencoded(b"", "body"), None);
+        // A key that merely *contains* the name must not match.
+        assert_eq!(field_from_urlencoded(b"body_extra=no", "body"), None);
+    }
 
     #[cfg(feature = "maud")]
     #[test]

--- a/autumn/src/markdown/mod.rs
+++ b/autumn/src/markdown/mod.rs
@@ -9,13 +9,13 @@
 //!
 //! | Source of the Markdown | Use |
 //! |---|---|
-//! | Files you authored and committed (docs, marketing pages, a `content/` tree) | [`render`] / [`MarkdownRegistry`] |
+//! | Files you authored and committed (docs, marketing pages, a `content/` tree) | [`render`](crate::markdown::render) / [`MarkdownRegistry`](crate::markdown::MarkdownRegistry) |
 //! | Anything a request body carried in (posts, comments, wiki bodies, bios) | `render_user_content` |
 //!
-//! [`render`] is built for *trusted, build-time* content: it injects heading
+//! [`render`](crate::markdown::render) is built for *trusted, build-time* content: it injects heading
 //! anchors and applies no allowlist. `render_user_content` disables raw-HTML
 //! passthrough, restricts link schemes, and runs the output through an
-//! allowlist sanitizer — see [`render_user_content_html`] and
+//! allowlist sanitizer — see [`render_user_content_html`](crate::markdown::render_user_content_html) and
 //! [`docs/guide/rich-text.md`] for the exact guarantee.
 //!
 //! [`docs/guide/rich-text.md`]: https://github.com/autumn-foundation/autumn/blob/main/docs/guide/rich-text.md

--- a/autumn/src/markdown/mod.rs
+++ b/autumn/src/markdown/mod.rs
@@ -2,6 +2,24 @@
 //!
 //! Enable with the Cargo feature `markdown`.
 //!
+//! ## Trusted content vs. user content
+//!
+//! This module has two entry points, and picking the wrong one is a security
+//! bug:
+//!
+//! | Source of the Markdown | Use |
+//! |---|---|
+//! | Files you authored and committed (docs, marketing pages, a `content/` tree) | [`render`] / [`MarkdownRegistry`] |
+//! | Anything a request body carried in (posts, comments, wiki bodies, bios) | `render_user_content` |
+//!
+//! [`render`] is built for *trusted, build-time* content: it injects heading
+//! anchors and applies no allowlist. `render_user_content` disables raw-HTML
+//! passthrough, restricts link schemes, and runs the output through an
+//! allowlist sanitizer — see [`render_user_content_html`] and
+//! [`docs/guide/rich-text.md`] for the exact guarantee.
+//!
+//! [`docs/guide/rich-text.md`]: https://github.com/autumn-foundation/autumn/blob/main/docs/guide/rich-text.md
+//!
 //! ## Quick start
 //!
 //! ### 1. Embed Markdown files at compile time
@@ -78,10 +96,17 @@
 mod registry;
 mod renderer;
 mod types;
+mod user_content;
 
 pub use registry::MarkdownRegistry;
 pub use renderer::{heading_id, render};
 pub use types::{
     MarkdownError, MarkdownFrontmatter, MarkdownPage, MarkdownSource, RenderOptions,
     RenderedMarkdown, TocItem,
+};
+#[cfg(feature = "maud")]
+pub use user_content::render_user_content;
+pub use user_content::{
+    RICH_TEXT_ALLOWED_TAGS, RICH_TEXT_ALLOWED_URL_SCHEMES, render_user_content_html,
+    sanitize_user_html,
 };

--- a/autumn/src/markdown/renderer.rs
+++ b/autumn/src/markdown/renderer.rs
@@ -8,8 +8,12 @@ use crate::markdown::types::{RenderOptions, RenderedMarkdown, TocItem};
 /// every heading and returning an ordered table of contents.
 ///
 /// Fenced code blocks preserve their language hint as a `language-{lang}`
-/// CSS class. The output HTML is safe: it is produced by pulldown-cmark's
-/// built-in HTML writer, which escapes raw HTML by default.
+/// CSS class. Raw HTML in the source is escaped rather than emitted — this
+/// function rewrites pulldown-cmark's `Html`/`InlineHtml` events to text before
+/// the writer runs (pulldown's own writer would pass them through verbatim).
+///
+/// That is **not** the same as sanitizing, and this renderer is not a
+/// sanitizer — see below.
 ///
 /// # Not for user-submitted text
 ///

--- a/autumn/src/markdown/renderer.rs
+++ b/autumn/src/markdown/renderer.rs
@@ -11,6 +11,18 @@ use crate::markdown::types::{RenderOptions, RenderedMarkdown, TocItem};
 /// CSS class. The output HTML is safe: it is produced by pulldown-cmark's
 /// built-in HTML writer, which escapes raw HTML by default.
 ///
+/// # Not for user-submitted text
+///
+/// This helper targets *trusted, build-time* content — pages you authored and
+/// committed. It applies **no** URL-scheme allowlist (a `[x](javascript:…)`
+/// link renders as written) and injects heading `id` anchors from the document
+/// text, which user-controlled headings could use for DOM clobbering.
+///
+/// For anything a request body carried in — posts, comments, wiki bodies —
+/// use [`render_user_content_html`](crate::markdown::render_user_content_html)
+/// (or `render_user_content` for `maud::Markup`) instead, which disables
+/// raw-HTML passthrough and runs the output through an allowlist sanitizer.
+///
 /// # Example
 ///
 /// ```

--- a/autumn/src/markdown/user_content.rs
+++ b/autumn/src/markdown/user_content.rs
@@ -12,10 +12,11 @@
 //!
 //! 1. **Raw-HTML passthrough is disabled.** Every `Html`/`InlineHtml` event
 //!    pulldown-cmark produces is rewritten to a `Text` event, so raw markup in
-//!    the source is HTML-escaped rather than emitted. Link and image
-//!    destinations are additionally checked against
-//!    [`RICH_TEXT_ALLOWED_URL_SCHEMES`] *before* the HTML writer sees them, and
-//!    a link with a rejected scheme is degraded to its own text.
+//!    the source is HTML-escaped rather than emitted. Link destinations are
+//!    additionally checked against [`RICH_TEXT_ALLOWED_URL_SCHEMES`] *before*
+//!    the HTML writer sees them, and a link with a rejected scheme is degraded
+//!    to its own text. Image destinations are never rendered at all (see
+//!    below), so they are dropped rather than scheme-checked.
 //! 2. **The result is run through an allowlist sanitizer.** The HTML string is
 //!    then passed through [`ammonia`], configured with the curated
 //!    [`RICH_TEXT_ALLOWED_TAGS`] tag set, a per-tag attribute allowlist, and the
@@ -42,7 +43,7 @@
 
 use std::sync::LazyLock;
 
-use pulldown_cmark::{Event, LinkType, Options, Parser, Tag, TagEnd};
+use pulldown_cmark::{Event, Options, Parser, Tag, TagEnd};
 
 /// The HTML tags [`render_user_content`] may emit — formatting, links, lists,
 /// code, and tables, per issue #1255. Anything else in the rendered output is
@@ -57,7 +58,9 @@ pub const RICH_TEXT_ALLOWED_TAGS: &[&str] = &[
     "p", "br", "hr", "blockquote",
     // Headings
     "h1", "h2", "h3", "h4", "h5", "h6",
-    // Inline formatting
+    // Inline formatting. `sub`/`sup` have no CommonMark syntax and so are
+    // unreachable from `render_user_content_html`; they are allowlisted for
+    // `sanitize_user_html` callers whose source is already HTML.
     "em", "strong", "del", "sub", "sup",
     // Links
     "a",
@@ -90,7 +93,8 @@ const ALLOWED_TEXT_ALIGN: &[&str] = &["left", "right", "center"];
 /// Render user-submitted Markdown to sanitized HTML.
 ///
 /// See the [module documentation](self) for the exact guarantee and allowlist.
-/// Prefer [`render_user_content`] when you are emitting into a Maud template.
+/// Prefer `render_user_content` (the `maud` feature) when you are emitting into
+/// a Maud template.
 ///
 /// # Example
 ///
@@ -141,11 +145,12 @@ pub fn render_user_content(source: &str) -> maud::Markup {
     maud::PreEscaped(render_user_content_html(source))
 }
 
-/// Run an HTML string through the same allowlist [`render_user_content`] uses.
+/// Run an HTML string through the same allowlist [`render_user_content_html`]
+/// uses.
 ///
 /// Use this when the untrusted rich text reaches you as HTML rather than
 /// Markdown (a legacy column, an imported feed). Markdown input should go
-/// through [`render_user_content`] instead, which additionally disables
+/// through [`render_user_content_html`] instead, which additionally disables
 /// raw-HTML passthrough at the parser.
 ///
 /// # Example
@@ -227,6 +232,18 @@ fn build_sanitizer() -> ammonia::Builder<'static> {
     builder
 }
 
+/// The deepest block nesting (blockquotes, lists, tables) [`render_user_content`]
+/// will emit. Anything past this is flattened: the container tags are dropped
+/// and their content kept.
+///
+/// This is a **denial-of-service bound**, not a style rule. The HTML sanitizer
+/// walks its open-elements stack once per block start tag, so emitting `n`
+/// nested containers costs O(n²) — and `"> "` is two source bytes per level, so
+/// a single request body can ask for millions of levels. Capping the depth makes
+/// the whole render linear in input size. Real prose never approaches 100 levels
+/// of nesting; documents below the cap render byte-identically.
+const MAX_BLOCK_NESTING_DEPTH: usize = 100;
+
 /// Streaming adapter over pulldown-cmark events that removes every avenue for
 /// attacker-controlled markup *before* the HTML writer runs:
 ///
@@ -235,6 +252,8 @@ fn build_sanitizer() -> ammonia::Builder<'static> {
 ///   has its anchor dropped; the link text survives as plain text.
 /// - Images are always dropped in favour of their alt text (image embedding is
 ///   out of scope for this field).
+/// - Block nesting past [`MAX_BLOCK_NESTING_DEPTH`] is flattened, bounding the
+///   sanitizer's per-start-tag stack walk (see that constant).
 struct SafeEvents<'a, I: Iterator<Item = Event<'a>>> {
     inner: I,
     /// Depth of image tags currently open. Non-zero means we are inside an
@@ -243,6 +262,9 @@ struct SafeEvents<'a, I: Iterator<Item = Event<'a>>> {
     /// Stack of open links, `true` when that link's anchor was dropped and its
     /// matching `End` must be dropped too.
     dropped_links: Vec<bool>,
+    /// Stack of open block containers, `true` when that container was dropped
+    /// for exceeding the depth cap and its matching `End` must be dropped too.
+    dropped_blocks: Vec<bool>,
 }
 
 impl<'a, I: Iterator<Item = Event<'a>>> SafeEvents<'a, I> {
@@ -251,8 +273,42 @@ impl<'a, I: Iterator<Item = Event<'a>>> SafeEvents<'a, I> {
             inner,
             image_depth: 0,
             dropped_links: Vec::new(),
+            dropped_blocks: Vec::new(),
         }
     }
+}
+
+/// Whether `tag` opens a block container that nests — i.e. one that grows the
+/// HTML sanitizer's open-elements stack and so counts against
+/// [`MAX_BLOCK_NESTING_DEPTH`].
+const fn is_nesting_block(tag: &Tag<'_>) -> bool {
+    matches!(
+        tag,
+        Tag::BlockQuote(_)
+            | Tag::List(_)
+            | Tag::Item
+            | Tag::Table(_)
+            | Tag::TableHead
+            | Tag::TableRow
+            | Tag::TableCell
+            | Tag::FootnoteDefinition(_)
+    )
+}
+
+/// The [`TagEnd`] counterpart of [`is_nesting_block`]. Kept adjacent so the two
+/// can never drift — a mismatch would desynchronize the `dropped_blocks` stack.
+const fn is_nesting_block_end(tag: TagEnd) -> bool {
+    matches!(
+        tag,
+        TagEnd::BlockQuote(_)
+            | TagEnd::List(_)
+            | TagEnd::Item
+            | TagEnd::Table
+            | TagEnd::TableHead
+            | TagEnd::TableRow
+            | TagEnd::TableCell
+            | TagEnd::FootnoteDefinition
+    )
 }
 
 impl<'a, I: Iterator<Item = Event<'a>>> Iterator for SafeEvents<'a, I> {
@@ -285,13 +341,12 @@ impl<'a, I: Iterator<Item = Event<'a>>> Iterator for SafeEvents<'a, I> {
                             id,
                         }));
                     }
-                    // Rejected scheme: drop the anchor, keep the text. An
-                    // autolink carries no separate text event, so re-emit the
-                    // destination as inert text instead of losing it silently.
+                    // Rejected scheme: drop the anchor and keep the text. The
+                    // parser emits the link's visible text as its own `Text`
+                    // event — including for an autolink, whose text is the
+                    // destination — so suppressing just the `Start`/`End` pair
+                    // preserves it exactly once.
                     self.dropped_links.push(true);
-                    if matches!(link_type, LinkType::Autolink | LinkType::Email) {
-                        return Some(Event::Text(dest_url));
-                    }
                 }
                 Event::End(TagEnd::Link) => {
                     if !self.dropped_links.pop().unwrap_or(false) {
@@ -301,6 +356,20 @@ impl<'a, I: Iterator<Item = Event<'a>>> Iterator for SafeEvents<'a, I> {
                 // Inside an image, code spans are alt text — flatten to text so
                 // the alt survives without markup.
                 Event::Code(s) if self.image_depth > 0 => return Some(Event::Text(s)),
+                Event::Start(tag) if is_nesting_block(&tag) => {
+                    // Past the cap, drop the container but keep descending —
+                    // the content inside it still renders, just unwrapped.
+                    let over_cap = self.dropped_blocks.len() >= MAX_BLOCK_NESTING_DEPTH;
+                    self.dropped_blocks.push(over_cap);
+                    if !over_cap {
+                        return Some(Event::Start(tag));
+                    }
+                }
+                Event::End(tag) if is_nesting_block_end(tag) => {
+                    if !self.dropped_blocks.pop().unwrap_or(false) {
+                        return Some(Event::End(tag));
+                    }
+                }
                 other => return Some(other),
             }
         }

--- a/autumn/src/markdown/user_content.rs
+++ b/autumn/src/markdown/user_content.rs
@@ -92,7 +92,8 @@ const ALLOWED_TEXT_ALIGN: &[&str] = &["left", "right", "center"];
 
 /// Render user-submitted Markdown to sanitized HTML.
 ///
-/// See the [module documentation](self) for the exact guarantee and allowlist.
+/// See the [`markdown` module documentation](crate::markdown) for the exact
+/// guarantee and allowlist.
 /// Prefer `render_user_content` (the `maud` feature) when you are emitting into
 /// a Maud template.
 ///

--- a/autumn/src/markdown/user_content.rs
+++ b/autumn/src/markdown/user_content.rs
@@ -1,0 +1,422 @@
+//! Safe rendering of **user-submitted** Markdown (issue #1255).
+//!
+//! The rest of this module ([`render`](super::render), [`MarkdownRegistry`](super::MarkdownRegistry))
+//! is built for *trusted, build-time, file-based* content: pages you authored
+//! and committed to the repository. This file is the other half — the path for
+//! text a request body carried in, where the author is an attacker until proven
+//! otherwise.
+//!
+//! # The guarantee
+//!
+//! [`render_user_content`] renders Markdown under two independent controls:
+//!
+//! 1. **Raw-HTML passthrough is disabled.** Every `Html`/`InlineHtml` event
+//!    pulldown-cmark produces is rewritten to a `Text` event, so raw markup in
+//!    the source is HTML-escaped rather than emitted. Link and image
+//!    destinations are additionally checked against
+//!    [`RICH_TEXT_ALLOWED_URL_SCHEMES`] *before* the HTML writer sees them, and
+//!    a link with a rejected scheme is degraded to its own text.
+//! 2. **The result is run through an allowlist sanitizer.** The HTML string is
+//!    then passed through [`ammonia`], configured with the curated
+//!    [`RICH_TEXT_ALLOWED_TAGS`] tag set, a per-tag attribute allowlist, and the
+//!    same URL-scheme allowlist.
+//!
+//! Either control alone blocks the canonical payloads; both are applied so a
+//! bypass of one is not a bypass of the feature. The regression corpus that
+//! locks this down lives in `tests/integration/rich_text.rs`.
+//!
+//! # What the allowlist deliberately excludes
+//!
+//! - **`<img>`** — image embedding is out of scope for this field. A Markdown
+//!   image degrades to its alt text, so a post cannot beacon a reader's IP to a
+//!   third-party host.
+//! - **`id`/`name` attributes** — user-controlled ids enable DOM clobbering
+//!   (a heading called `Login` shadowing `document.getElementById("login")`), so
+//!   unlike [`render`](super::render) this path injects no heading anchors.
+//! - **`style` attributes**, except the `text-align` rule pulldown-cmark itself
+//!   emits for aligned table cells.
+//! - **`class` attributes**, except the `language-*` hint on fenced code blocks.
+//! - **`<script>`, `<style>`, `<iframe>`, `<object>`, `<embed>`, `<form>`,
+//!   `<input>`, `<svg>`, `<math>`, `<base>`, `<link>`, `<meta>`** and every
+//!   event-handler (`on*`) attribute.
+
+use std::sync::LazyLock;
+
+use pulldown_cmark::{Event, LinkType, Options, Parser, Tag, TagEnd};
+
+/// The HTML tags [`render_user_content`] may emit — formatting, links, lists,
+/// code, and tables, per issue #1255. Anything else in the rendered output is
+/// removed by the sanitizer.
+///
+/// This is a fixed, curated set: per-field allowlist configuration is
+/// deliberately out of scope, so the guarantee is the same everywhere in every
+/// app and can be reasoned about once.
+#[rustfmt::skip]
+pub const RICH_TEXT_ALLOWED_TAGS: &[&str] = &[
+    // Block structure
+    "p", "br", "hr", "blockquote",
+    // Headings
+    "h1", "h2", "h3", "h4", "h5", "h6",
+    // Inline formatting
+    "em", "strong", "del", "sub", "sup",
+    // Links
+    "a",
+    // Lists
+    "ul", "ol", "li",
+    // Code
+    "code", "pre",
+    // Tables
+    "table", "thead", "tbody", "tr", "th", "td",
+];
+
+/// The URL schemes a link in user-submitted Markdown may use.
+///
+/// A destination whose scheme is absent from this list is rejected: the anchor
+/// is dropped and its text kept. Relative (`/about`), fragment (`#anchor`), and
+/// protocol-relative (`//host/path`) destinations carry no scheme and are
+/// allowed.
+pub const RICH_TEXT_ALLOWED_URL_SCHEMES: &[&str] = &["http", "https", "mailto", "tel"];
+
+/// `rel` value forced onto every surviving link. `noopener`/`noreferrer` close
+/// reverse-tabnabbing and referrer leakage; `nofollow` stops user-submitted
+/// content from conferring search-engine reputation (comment-spam hardening).
+const LINK_REL: &str = "noopener noreferrer nofollow";
+
+/// The `text-align` values pulldown-cmark emits on aligned table cells. Any
+/// other `style` declaration is dropped — this is the whole of the CSS surface
+/// user content can reach.
+const ALLOWED_TEXT_ALIGN: &[&str] = &["left", "right", "center"];
+
+/// Render user-submitted Markdown to sanitized HTML.
+///
+/// See the [module documentation](self) for the exact guarantee and allowlist.
+/// Prefer [`render_user_content`] when you are emitting into a Maud template.
+///
+/// # Example
+///
+/// ```
+/// use autumn_web::markdown::render_user_content_html;
+///
+/// let html = render_user_content_html("Hello **world** [x](javascript:alert(1))");
+/// assert!(html.contains("<strong>world</strong>"));
+/// assert!(!html.contains("javascript:"));
+/// ```
+#[must_use]
+pub fn render_user_content_html(source: &str) -> String {
+    let mut opts = Options::empty();
+    opts.insert(Options::ENABLE_TABLES);
+    opts.insert(Options::ENABLE_STRIKETHROUGH);
+
+    let events = Parser::new_ext(source, opts);
+    let safe = SafeEvents::new(events);
+
+    let mut html = String::with_capacity(source.len() + source.len() / 2);
+    pulldown_cmark::html::push_html(&mut html, safe);
+
+    sanitize_user_html(&html)
+}
+
+/// Render user-submitted Markdown to sanitized [`maud::Markup`].
+///
+/// This is the helper a handler or template calls; the returned `Markup` is
+/// already escaped-safe, so it can be interpolated directly:
+///
+/// ```rust,ignore
+/// html! {
+///     article class="post-body" { (render_user_content(&post.body)) }
+/// }
+/// ```
+///
+/// # Example
+///
+/// ```
+/// use autumn_web::markdown::render_user_content;
+///
+/// let markup = render_user_content("[x](javascript:alert(1))");
+/// assert!(!markup.into_string().contains("javascript:"));
+/// ```
+#[cfg(feature = "maud")]
+#[must_use]
+pub fn render_user_content(source: &str) -> maud::Markup {
+    maud::PreEscaped(render_user_content_html(source))
+}
+
+/// Run an HTML string through the same allowlist [`render_user_content`] uses.
+///
+/// Use this when the untrusted rich text reaches you as HTML rather than
+/// Markdown (a legacy column, an imported feed). Markdown input should go
+/// through [`render_user_content`] instead, which additionally disables
+/// raw-HTML passthrough at the parser.
+///
+/// # Example
+///
+/// ```
+/// use autumn_web::markdown::sanitize_user_html;
+///
+/// let clean = sanitize_user_html("<p onclick=\"alert(1)\">hi</p><script>alert(1)</script>");
+/// assert_eq!(clean, "<p>hi</p>");
+/// ```
+#[must_use]
+pub fn sanitize_user_html(html: &str) -> String {
+    SANITIZER.clean(html).to_string()
+}
+
+/// The configured [`ammonia`] cleaner. Built once — `ammonia::Builder` compiles
+/// its allowlists into hash sets, so rebuilding per render would dominate the
+/// cost of rendering a short comment.
+static SANITIZER: LazyLock<ammonia::Builder<'static>> = LazyLock::new(build_sanitizer);
+
+fn build_sanitizer() -> ammonia::Builder<'static> {
+    use std::collections::{HashMap, HashSet};
+
+    let mut builder = ammonia::Builder::empty();
+
+    builder
+        .tags(RICH_TEXT_ALLOWED_TAGS.iter().copied().collect())
+        .url_schemes(RICH_TEXT_ALLOWED_URL_SCHEMES.iter().copied().collect())
+        // `link_rel` applies to every `<a>` ammonia keeps, including ones whose
+        // `rel` the input tried to set itself.
+        .link_rel(Some(LINK_REL));
+
+    // Per-tag attribute allowlist. Everything not named here — every `on*`
+    // handler, `id`, `name`, `srcdoc`, `formaction`, … — is dropped.
+    let attrs: HashMap<&str, HashSet<&str>> = HashMap::from([
+        // `rel` is deliberately absent from `a`: `link_rel` above makes ammonia
+        // *set* it on every surviving `<a>`, and ammonia asserts the two are
+        // not both configured (an input-supplied `rel` would otherwise win over
+        // the forced hardening).
+        ("a", HashSet::from(["href", "title"])),
+        ("code", HashSet::from(["class"])),
+        ("pre", HashSet::from(["class"])),
+        ("th", HashSet::from(["style"])),
+        ("td", HashSet::from(["style"])),
+        ("ol", HashSet::from(["start"])),
+    ]);
+    builder.tag_attributes(attrs);
+    builder.generic_attributes(HashSet::new());
+
+    // The three attributes above that carry a *value* space wide enough to be
+    // abused (`class` selectors, `style` declarations) are narrowed to exactly
+    // the shapes the Markdown renderer itself produces.
+    builder.attribute_filter(|element, attribute, value| match (element, attribute) {
+        ("code" | "pre", "class") => {
+            // Only the `language-{lang}` hint from a fenced code block, and only
+            // when `{lang}` is a plain identifier — never an arbitrary class an
+            // attacker could use to hook the host page's CSS or JS selectors.
+            let is_language_hint = value.strip_prefix("language-").is_some_and(|lang| {
+                !lang.is_empty()
+                    && lang
+                        .chars()
+                        .all(|c| c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | '+' | '.'))
+            });
+            is_language_hint.then(|| value.to_owned().into())
+        }
+        ("th" | "td", "style") => {
+            // Only the `text-align` rule pulldown-cmark emits for an aligned
+            // table column.
+            let normalized = value.trim().trim_end_matches(';');
+            let aligned = normalized.split_once(':').is_some_and(|(prop, val)| {
+                prop.trim().eq_ignore_ascii_case("text-align")
+                    && ALLOWED_TEXT_ALIGN.contains(&val.trim().to_ascii_lowercase().as_str())
+            });
+            aligned.then(|| value.to_owned().into())
+        }
+        _ => Some(value.into()),
+    });
+
+    builder
+}
+
+/// Streaming adapter over pulldown-cmark events that removes every avenue for
+/// attacker-controlled markup *before* the HTML writer runs:
+///
+/// - `Html` / `InlineHtml` events become `Text`, so raw markup is escaped.
+/// - A link whose destination scheme is not in [`RICH_TEXT_ALLOWED_URL_SCHEMES`]
+///   has its anchor dropped; the link text survives as plain text.
+/// - Images are always dropped in favour of their alt text (image embedding is
+///   out of scope for this field).
+struct SafeEvents<'a, I: Iterator<Item = Event<'a>>> {
+    inner: I,
+    /// Depth of image tags currently open. Non-zero means we are inside an
+    /// image's alt-text events, which we keep as plain text.
+    image_depth: usize,
+    /// Stack of open links, `true` when that link's anchor was dropped and its
+    /// matching `End` must be dropped too.
+    dropped_links: Vec<bool>,
+}
+
+impl<'a, I: Iterator<Item = Event<'a>>> SafeEvents<'a, I> {
+    const fn new(inner: I) -> Self {
+        Self {
+            inner,
+            image_depth: 0,
+            dropped_links: Vec::new(),
+        }
+    }
+}
+
+impl<'a, I: Iterator<Item = Event<'a>>> Iterator for SafeEvents<'a, I> {
+    type Item = Event<'a>;
+
+    fn next(&mut self) -> Option<Event<'a>> {
+        loop {
+            let event = self.inner.next()?;
+            match event {
+                // Raw HTML never reaches the writer as markup.
+                Event::Html(s) | Event::InlineHtml(s) => return Some(Event::Text(s)),
+                Event::Start(Tag::Image { .. }) => {
+                    self.image_depth += 1;
+                }
+                Event::End(TagEnd::Image) => {
+                    self.image_depth = self.image_depth.saturating_sub(1);
+                }
+                Event::Start(Tag::Link {
+                    link_type,
+                    dest_url,
+                    title,
+                    id,
+                }) => {
+                    if url_scheme_allowed(&dest_url) {
+                        self.dropped_links.push(false);
+                        return Some(Event::Start(Tag::Link {
+                            link_type,
+                            dest_url,
+                            title,
+                            id,
+                        }));
+                    }
+                    // Rejected scheme: drop the anchor, keep the text. An
+                    // autolink carries no separate text event, so re-emit the
+                    // destination as inert text instead of losing it silently.
+                    self.dropped_links.push(true);
+                    if matches!(link_type, LinkType::Autolink | LinkType::Email) {
+                        return Some(Event::Text(dest_url));
+                    }
+                }
+                Event::End(TagEnd::Link) => {
+                    if !self.dropped_links.pop().unwrap_or(false) {
+                        return Some(Event::End(TagEnd::Link));
+                    }
+                }
+                // Inside an image, code spans are alt text — flatten to text so
+                // the alt survives without markup.
+                Event::Code(s) if self.image_depth > 0 => return Some(Event::Text(s)),
+                other => return Some(other),
+            }
+        }
+    }
+}
+
+/// Whether a link destination's scheme is in [`RICH_TEXT_ALLOWED_URL_SCHEMES`].
+///
+/// A destination with no scheme (relative, fragment, or protocol-relative) is
+/// allowed. The scheme is read with the same tolerances a browser applies:
+/// leading whitespace and embedded control characters (TAB/LF/CR/NUL) are
+/// ignored, and the comparison is ASCII-case-insensitive — so `java\tscript:`
+/// and `JaVaScRiPt:` are recognised as `javascript:` and rejected.
+fn url_scheme_allowed(dest: &str) -> bool {
+    url_scheme(dest).is_none_or(|scheme| RICH_TEXT_ALLOWED_URL_SCHEMES.contains(&scheme.as_str()))
+}
+
+/// Extract a URL's lowercased scheme, or `None` when it has none.
+///
+/// Mirrors the two normalisations the WHATWG URL parser applies before it reads
+/// a scheme, and no more:
+///
+/// - leading (and trailing) C0 control characters and spaces are removed —
+///   so `"\0javascript:…"` and `"  javascript:…"` are `javascript`;
+/// - TAB, LF, and CR are removed from *anywhere* in the URL — so
+///   `"java\tscript:…"` is `javascript`.
+///
+/// An interior *space* is deliberately **not** removed: a browser
+/// percent-encodes it rather than closing up the string, so `"foo bar:baz"` is
+/// a relative URL, not a `foo bar` scheme.
+fn url_scheme(dest: &str) -> Option<String> {
+    let trimmed = dest.trim_matches(|c: char| (c as u32) <= 0x20);
+    let mut scheme = String::new();
+    for c in trimmed.chars() {
+        match c {
+            '\t' | '\n' | '\r' => {}
+            ':' => {
+                return (!scheme.is_empty() && is_valid_scheme(&scheme)).then_some(scheme);
+            }
+            // A path/query/fragment separator ends any possible scheme: the
+            // colon in `/a:b` or `#a:b` is data, not a scheme delimiter.
+            '/' | '?' | '#' => return None,
+            c => scheme.push(c.to_ascii_lowercase()),
+        }
+    }
+    None
+}
+
+/// Whether `candidate` is syntactically a URL scheme (RFC 3986: an ASCII letter
+/// followed by letters, digits, `+`, `-`, or `.`). A colon in `foo bar:baz`
+/// does not introduce a scheme, so such a destination stays relative.
+fn is_valid_scheme(candidate: &str) -> bool {
+    let mut chars = candidate.chars();
+    chars.next().is_some_and(|c| c.is_ascii_alphabetic())
+        && chars.all(|c| c.is_ascii_alphanumeric() || matches!(c, '+' | '-' | '.'))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn scheme_extraction_handles_obfuscation() {
+        assert_eq!(url_scheme("https://a"), Some("https".to_owned()));
+        assert_eq!(url_scheme("JaVaScRiPt:x"), Some("javascript".to_owned()));
+        assert_eq!(url_scheme("java\tscript:x"), Some("javascript".to_owned()));
+        assert_eq!(url_scheme("  javascript:x"), Some("javascript".to_owned()));
+        assert_eq!(
+            url_scheme("\u{0}javascript:x"),
+            Some("javascript".to_owned())
+        );
+        // Relative, fragment, and protocol-relative destinations have no scheme.
+        assert_eq!(url_scheme("/a/b"), None);
+        assert_eq!(url_scheme("#anchor"), None);
+        assert_eq!(url_scheme("//host/path"), None);
+        assert_eq!(url_scheme("a/b:c"), None);
+        // A colon after a non-scheme-shaped prefix is data, not a delimiter.
+        assert_eq!(url_scheme("foo bar:baz"), None);
+        assert_eq!(url_scheme("1abc:x"), None);
+    }
+
+    #[test]
+    fn scheme_allowlist_accepts_only_curated_schemes() {
+        assert!(url_scheme_allowed("https://example.com"));
+        assert!(url_scheme_allowed("http://example.com"));
+        assert!(url_scheme_allowed("mailto:a@b.example"));
+        assert!(url_scheme_allowed("tel:+15551234"));
+        assert!(url_scheme_allowed("/relative"));
+        assert!(!url_scheme_allowed("javascript:alert(1)"));
+        assert!(!url_scheme_allowed("vbscript:x"));
+        assert!(!url_scheme_allowed("data:text/html,x"));
+        assert!(!url_scheme_allowed("file:///etc/passwd"));
+    }
+
+    #[test]
+    fn table_alignment_style_survives_but_other_css_does_not() {
+        let aligned =
+            sanitize_user_html("<table><tr><td style=\"text-align: right\">1</td></tr></table>");
+        assert!(aligned.contains("style=\"text-align: right\""), "{aligned}");
+        let injected =
+            sanitize_user_html("<table><tr><td style=\"position:fixed;top:0\">1</td></tr></table>");
+        assert!(!injected.contains("position"), "{injected}");
+        // A `text-align` declaration smuggling a second rule alongside it is
+        // rejected wholesale rather than partially kept.
+        let smuggled = sanitize_user_html(
+            "<table><tr><td style=\"text-align:left;position:fixed\">1</td></tr></table>",
+        );
+        assert!(!smuggled.contains("position"), "{smuggled}");
+    }
+
+    #[test]
+    fn allowed_tag_and_scheme_lists_have_no_duplicates() {
+        let mut tags = RICH_TEXT_ALLOWED_TAGS.to_vec();
+        tags.sort_unstable();
+        let len = tags.len();
+        tags.dedup();
+        assert_eq!(tags.len(), len, "duplicate entry in RICH_TEXT_ALLOWED_TAGS");
+    }
+}

--- a/autumn/src/ui/widgets.css
+++ b/autumn/src/ui/widgets.css
@@ -163,6 +163,39 @@
     gap: 0.375rem;
 }
 
+.autumn-rich-text__toolbar {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    padding: 0.375rem 0.5rem;
+    border: 1px solid var(--border);
+    border-bottom: none;
+    border-radius: var(--radius) var(--radius) 0 0;
+    background-color: var(--surface);
+}
+
+.autumn-rich-text__toolbar-item {
+    display: inline-flex;
+    align-items: baseline;
+    gap: 0.25rem;
+    font-size: 0.75rem;
+}
+
+.autumn-rich-text__toolbar-label {
+    color: var(--text-muted);
+}
+
+.autumn-rich-text__toolbar-syntax {
+    font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+    color: var(--text);
+}
+
+/* The toolbar sits directly on top of the editor, so they read as one control. */
+.autumn-rich-text__toolbar + .autumn-rich-text__editor {
+    border-top-left-radius: 0;
+    border-top-right-radius: 0;
+}
+
 .autumn-rich-text__editor {
     min-height: 12rem;
     font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;

--- a/autumn/src/ui/widgets.css
+++ b/autumn/src/ui/widgets.css
@@ -157,6 +157,70 @@
     margin: 0;
 }
 
+/* ── Rich text (autumn-rich-text) — issue #1255 ───────────────────────────── */
+
+.autumn-rich-text {
+    gap: 0.375rem;
+}
+
+.autumn-rich-text__editor {
+    min-height: 12rem;
+    font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+    resize: vertical;
+}
+
+.autumn-rich-text__hint {
+    font-size: 0.8125rem;
+    color: var(--text-muted);
+    margin: 0;
+}
+
+.autumn-rich-text__preview-wrapper {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    margin-top: 0.5rem;
+}
+
+.autumn-rich-text__preview-label {
+    font-size: 0.875rem;
+    font-weight: 500;
+    color: var(--text);
+}
+
+.autumn-rich-text__preview {
+    padding: 0.75rem;
+    border: 1px dashed var(--border);
+    border-radius: var(--radius);
+    background-color: var(--surface);
+    color: var(--text);
+    font-size: 0.875rem;
+    line-height: 1.6;
+    overflow-wrap: anywhere;
+}
+
+.autumn-rich-text__preview > :first-child {
+    margin-top: 0;
+}
+
+.autumn-rich-text__preview > :last-child {
+    margin-bottom: 0;
+}
+
+.autumn-rich-text__preview pre {
+    overflow-x: auto;
+}
+
+.autumn-rich-text__preview table {
+    border-collapse: collapse;
+}
+
+.autumn-rich-text__preview th,
+.autumn-rich-text__preview td {
+    border: 1px solid var(--border);
+    padding: 0.25rem 0.5rem;
+}
+
 /* ── Submit button (autumn-submit) ────────────────────────────────────────── */
 
 .autumn-submit {

--- a/autumn/tests/integration/mod.rs
+++ b/autumn/tests/integration/mod.rs
@@ -186,6 +186,8 @@ mod repository_scope_meta;
 #[cfg(feature = "db")]
 mod repository_search;
 mod request_timeout;
+#[cfg(all(feature = "markdown", feature = "maud"))]
+mod rich_text;
 mod route_macro;
 mod routes_macro;
 mod scheduled_coordination;

--- a/autumn/tests/integration/rich_text.rs
+++ b/autumn/tests/integration/rich_text.rs
@@ -1,0 +1,419 @@
+//! Safe rich-text rendering for **user-submitted** Markdown (issue #1255).
+//!
+//! These tests are the regression lock on the sanitization guarantee documented
+//! in `docs/guide/rich-text.md`: `markdown::render_user_content` must render
+//! user Markdown with raw-HTML passthrough disabled and the result run through
+//! the curated allowlist, so a content app built on autumn cannot ship stored
+//! XSS by using the shipped helper.
+//!
+//! The payload corpus below is deliberately adversarial. Widening
+//! `RICH_TEXT_ALLOWED_TAGS` / `RICH_TEXT_ALLOWED_URL_SCHEMES` without also
+//! re-deriving these expectations should fail loudly here.
+
+use autumn_web::markdown::{
+    RICH_TEXT_ALLOWED_TAGS, RICH_TEXT_ALLOWED_URL_SCHEMES, render_user_content,
+    render_user_content_html, sanitize_user_html,
+};
+
+/// Tag-open markers that must never appear *as live markup* in the rendered
+/// output. A payload that survives as escaped text (`&lt;script&gt;`) is inert
+/// and does not match these, which is exactly the distinction we want.
+const FORBIDDEN_TAGS: &[&str] = &[
+    "<script",
+    "</script",
+    "<iframe",
+    "<object",
+    "<embed",
+    "<style",
+    "<form",
+    "<input",
+    "<svg",
+    "<math",
+    "<base",
+    "<link",
+    "<meta",
+    "<img",
+    "<noscript",
+    "<template",
+    "<textarea",
+];
+
+/// Attribute names that must never survive on any element. Checked against
+/// parsed attribute *names* (see [`parse_tag`]), never raw substrings, so an
+/// escaped `&quot; onmouseover=&quot;` sitting inertly inside a `title` value
+/// is correctly treated as harmless text.
+const FORBIDDEN_ATTRS: &[&str] = &[
+    "srcdoc",
+    "formaction",
+    // User-controlled ids/names enable DOM clobbering.
+    "id",
+    "name",
+    "http-equiv",
+];
+
+/// Adversarial Markdown/HTML payloads a hostile user could submit.
+const XSS_CORPUS: &[&str] = &[
+    // The AC's named payload.
+    "[x](javascript:alert(1))",
+    // Case obfuscation.
+    "[x](JaVaScRiPt:alert(1))",
+    // Entity obfuscation — CommonMark decodes entity refs in link destinations.
+    "[x](&#106;avascript:alert(1))",
+    "[x](javascript&colon;alert(1))",
+    // Control-character obfuscation (browsers strip TAB/LF/CR inside URLs).
+    "[x](java\tscript:alert(1))",
+    "[x](java\nscript:alert(1))",
+    // Leading whitespace / NUL padding.
+    "[x](   javascript:alert(1))",
+    "[x](\u{0}javascript:alert(1))",
+    // Other executable schemes.
+    "[x](vbscript:msgbox(1))",
+    "[x](data:text/html;base64,PHNjcmlwdD5hbGVydCgxKTwvc2NyaXB0Pg==)",
+    // Image destinations take the same path as links.
+    "![x](javascript:alert(1))",
+    "![x](data:text/html;base64,PHNjcmlwdD4=)",
+    // Reference-style links resolve to the same destination.
+    "[x][ref]\n\n[ref]: javascript:alert(1)",
+    // Autolinks.
+    "<javascript:alert(1)>",
+    // Raw HTML blocks and inline raw HTML.
+    "<script>alert(1)</script>",
+    "<SCRIPT>alert(1)</SCRIPT>",
+    "<img src=x onerror=alert(1)>",
+    "<div onclick=\"alert(1)\">hi</div>",
+    "<a href=\"#\" onmouseover=\"alert(1)\">x</a>",
+    "<style>body{background:url(javascript:alert(1))}</style>",
+    "<iframe src=\"https://evil.example\"></iframe>",
+    "<iframe srcdoc=\"&lt;script&gt;alert(1)&lt;/script&gt;\"></iframe>",
+    "<object data=\"evil.swf\"></object>",
+    "<embed src=\"evil.swf\">",
+    "<form action=\"https://evil.example\"><input type=\"submit\" formaction=\"javascript:alert(1)\"></form>",
+    "<base href=\"https://evil.example/\">",
+    "<link rel=\"stylesheet\" href=\"https://evil.example/x.css\">",
+    "<meta http-equiv=\"refresh\" content=\"0;url=https://evil.example\">",
+    "<svg onload=\"alert(1)\"></svg>",
+    "<svg><animate onbegin=alert(1) attributeName=x dur=1s></svg>",
+    // mXSS-shaped namespace confusion.
+    "<math><mtext><table><mglyph><style><!--</style><img src=x onerror=alert(1)>",
+    "<noscript><p title=\"</noscript><img src=x onerror=alert(1)>\">",
+    // Comment-smuggled markup.
+    "<!--<img src=x onerror=alert(1)>-->",
+    // Backslash-escaped scheme.
+    "[x](\\6a avascript:alert(1))",
+    // Inside a fenced code block the payload must stay inert text.
+    "```html\n<script>alert(1)</script>\n```",
+    // Inside inline code.
+    "`<img src=x onerror=alert(1)>`",
+    // Inside a blockquote / list, where a naive filter might not descend.
+    "> [x](javascript:alert(1))",
+    "- [x](javascript:alert(1))",
+    // Inside a table cell.
+    "| a |\n|---|\n| [x](javascript:alert(1)) |",
+    // Title attribute injection attempt.
+    "[x](https://ok.example \"a\\\" onmouseover=\\\"alert(1)\")",
+];
+
+/// Split `html` into its live tag regions (`<…>`).
+///
+/// The rendered output never contains a raw `<` in text — the HTML writer
+/// escapes it to `&lt;` — so every `<…>` span really is a tag. Restricting the
+/// attribute assertions to these spans is what lets the corpus distinguish a
+/// *neutralised* payload (`&lt;img src=x onerror=…&gt;`, inert text that happens
+/// to spell `onerror`) from a live one.
+fn tag_regions(html: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    let mut rest = html;
+    while let Some(start) = rest.find('<') {
+        rest = &rest[start..];
+        let end = rest.find('>').map_or(rest.len(), |i| i + 1);
+        out.push(rest[..end].to_owned());
+        rest = &rest[end..];
+    }
+    out
+}
+
+/// Split one lowercased tag region into its element name and `(name, value)`
+/// attribute pairs.
+///
+/// Deliberately a *strict* reader rather than a permissive one: ammonia always
+/// emits `name="value"` with `"`/`&`/`<`/`>` escaped inside the value, so
+/// respecting the quotes is enough to tell a real attribute from characters
+/// that merely look like one inside a value.
+fn parse_tag(region: &str) -> (String, Vec<(String, String)>) {
+    let body = region
+        .trim_start_matches('<')
+        .trim_end_matches('>')
+        .trim_end_matches('/');
+    let body = body.trim_start_matches('/');
+    let mut chars = body.chars().peekable();
+
+    let mut name = String::new();
+    while let Some(&c) = chars.peek() {
+        if c.is_ascii_alphanumeric() {
+            name.push(c);
+            chars.next();
+        } else {
+            break;
+        }
+    }
+
+    let mut attrs = Vec::new();
+    loop {
+        while chars.peek().is_some_and(|c| c.is_whitespace()) {
+            chars.next();
+        }
+        let mut attr = String::new();
+        while let Some(&c) = chars.peek() {
+            if c == '=' || c.is_whitespace() {
+                break;
+            }
+            attr.push(c);
+            chars.next();
+        }
+        if attr.is_empty() {
+            break;
+        }
+        let mut value = String::new();
+        if chars.peek() == Some(&'=') {
+            chars.next();
+            match chars.peek().copied() {
+                Some(quote @ ('"' | '\'')) => {
+                    chars.next();
+                    for c in chars.by_ref() {
+                        if c == quote {
+                            break;
+                        }
+                        value.push(c);
+                    }
+                }
+                _ => {
+                    while let Some(&c) = chars.peek() {
+                        if c.is_whitespace() {
+                            break;
+                        }
+                        value.push(c);
+                        chars.next();
+                    }
+                }
+            }
+        }
+        attrs.push((attr, value));
+    }
+    (name, attrs)
+}
+
+/// Assert that `html` — the render of `payload` — contains no executable
+/// markup: no live dangerous tag, no non-allowlisted element, no event-handler
+/// or clobbering attribute, and no URL attribute outside
+/// `RICH_TEXT_ALLOWED_URL_SCHEMES`.
+fn assert_inert(payload: &str, html: &str) {
+    let lowered = html.to_ascii_lowercase();
+    for tag in FORBIDDEN_TAGS {
+        assert!(
+            !lowered.contains(tag),
+            "payload {payload:?} emitted live {tag:?}:\n{html}"
+        );
+    }
+    for region in tag_regions(&lowered) {
+        let (name, attrs) = parse_tag(&region);
+        // Nothing outside the curated tag set may survive as live markup.
+        assert!(
+            name.is_empty() || RICH_TEXT_ALLOWED_TAGS.contains(&name.as_str()),
+            "payload {payload:?} emitted non-allowlisted tag {name:?}:\n{html}"
+        );
+        for (attr, value) in attrs {
+            assert!(
+                !attr.starts_with("on"),
+                "payload {payload:?} kept event handler {attr:?} on <{name}>:\n{html}"
+            );
+            assert!(
+                !FORBIDDEN_ATTRS.contains(&attr.as_str()),
+                "payload {payload:?} kept attribute {attr:?} on <{name}>:\n{html}"
+            );
+            if !matches!(attr.as_str(), "href" | "src") {
+                continue;
+            }
+            // Strip the characters a browser ignores inside a URL before
+            // reading the scheme, so an obfuscated `java\tscript:` can't slip
+            // past this check either.
+            let squeezed: String = value
+                .chars()
+                .filter(|c| (*c as u32) > 0x20 && *c as u32 != 0x7F)
+                .collect();
+            let Some((scheme, _)) = squeezed.split_once(':') else {
+                continue;
+            };
+            let looks_like_scheme = scheme
+                .chars()
+                .next()
+                .is_some_and(|c| c.is_ascii_alphabetic())
+                && scheme
+                    .chars()
+                    .all(|c| c.is_ascii_alphanumeric() || matches!(c, '+' | '-' | '.'));
+            assert!(
+                !looks_like_scheme || RICH_TEXT_ALLOWED_URL_SCHEMES.contains(&scheme),
+                "payload {payload:?} kept a {scheme:?} URL ({value:?}):\n{html}"
+            );
+        }
+    }
+}
+
+#[test]
+fn xss_corpus_never_emits_executable_markup() {
+    for payload in XSS_CORPUS {
+        assert_inert(payload, &render_user_content_html(payload));
+    }
+}
+
+#[test]
+fn xss_corpus_is_inert_through_the_html_sanitizer_too() {
+    // The second control on its own: feeding each payload straight to the
+    // allowlist sanitizer (as `sanitize_user_html` callers with an HTML source
+    // do) must also produce inert output.
+    for payload in XSS_CORPUS {
+        assert_inert(payload, &sanitize_user_html(payload));
+    }
+}
+
+#[test]
+fn ac_named_javascript_link_payload_emits_no_href() {
+    // The acceptance criterion names this payload explicitly: the rendered
+    // output must carry no `javascript:` URL at all.
+    let html = render_user_content_html("[x](javascript:alert(1))");
+    assert!(!html.to_ascii_lowercase().contains("javascript:"), "{html}");
+    // The link text survives as plain text — we drop the anchor, not the words.
+    assert!(html.contains('x'), "{html}");
+}
+
+#[test]
+fn script_tag_is_escaped_not_executed() {
+    let html = render_user_content_html("<script>alert('xss')</script>");
+    assert!(!html.contains("<script"), "{html}");
+    assert!(html.contains("&lt;script&gt;"), "{html}");
+}
+
+#[test]
+fn safe_markdown_still_renders() {
+    let html = render_user_content_html(
+        "# Title\n\nSome **bold** and _italic_ and `code`.\n\n- one\n- two\n\n\
+         1. first\n2. second\n\n> quoted\n\n```rust\nfn main() {}\n```\n\n\
+         [link](https://example.com) and [rel](/local/path) and [mail](mailto:a@b.example)\n\n\
+         | a | b |\n|---|---|\n| 1 | 2 |\n",
+    );
+    assert!(html.contains("<h1>"), "{html}");
+    assert!(html.contains("<strong>bold</strong>"), "{html}");
+    assert!(html.contains("<em>italic</em>"), "{html}");
+    assert!(html.contains("<code>code</code>"), "{html}");
+    assert!(html.contains("<ul>"), "{html}");
+    assert!(html.contains("<ol>"), "{html}");
+    assert!(html.contains("<blockquote>"), "{html}");
+    assert!(html.contains("<pre>"), "{html}");
+    assert!(html.contains("<table>"), "{html}");
+    assert!(html.contains("https://example.com"), "{html}");
+    assert!(html.contains("/local/path"), "{html}");
+    assert!(html.contains("mailto:a@b.example"), "{html}");
+}
+
+#[test]
+fn headings_carry_no_id_attribute() {
+    // User-controlled `id` attributes enable DOM clobbering (a user heading
+    // named "Login" shadowing `document.getElementById("login")`), so the
+    // user-content renderer must not inject the heading anchors the
+    // trusted-content `render()` emits.
+    let html = render_user_content_html("# Login\n\n## csrf-token\n");
+    assert!(!html.contains("id="), "{html}");
+}
+
+#[test]
+fn external_links_are_rel_hardened() {
+    let html = render_user_content_html("[x](https://example.com)");
+    let lowered = html.to_ascii_lowercase();
+    assert!(lowered.contains("rel="), "{html}");
+    assert!(lowered.contains("noopener"), "{html}");
+    assert!(lowered.contains("noreferrer"), "{html}");
+}
+
+#[test]
+fn images_are_not_embedded_but_alt_text_survives() {
+    // Image embedding is out of scope for this field (issue #1255): a Markdown
+    // image degrades to its alt text rather than emitting a remote `<img>`.
+    let html = render_user_content_html("![a cat](https://example.com/cat.png)");
+    assert!(!html.contains("<img"), "{html}");
+    assert!(html.contains("a cat"), "{html}");
+}
+
+#[test]
+fn fenced_code_language_class_survives() {
+    let html = render_user_content_html("```rust\nfn main() {}\n```");
+    assert!(html.contains("language-rust"), "{html}");
+}
+
+#[test]
+fn code_class_allowlist_rejects_non_language_classes() {
+    // `class` is only tolerated on code/pre and only in the `language-*` shape
+    // the Markdown renderer itself emits — never an arbitrary attacker class
+    // that could hook a page's own CSS/JS selectors.
+    let html = sanitize_user_html("<pre><code class=\"evil-hook\">x</code></pre>");
+    assert!(!html.contains("evil-hook"), "{html}");
+}
+
+#[test]
+fn sanitize_user_html_strips_disallowed_tags_and_attributes() {
+    let html = sanitize_user_html(
+        "<p onclick=\"alert(1)\">ok</p><script>alert(1)</script><iframe></iframe>",
+    );
+    assert!(html.contains("ok"), "{html}");
+    assert!(!html.contains("onclick"), "{html}");
+    assert!(!html.contains("<script"), "{html}");
+    assert!(!html.contains("<iframe"), "{html}");
+}
+
+#[test]
+fn sanitize_user_html_drops_javascript_href() {
+    let html = sanitize_user_html("<a href=\"javascript:alert(1)\">x</a>");
+    assert!(!html.to_ascii_lowercase().contains("javascript:"), "{html}");
+}
+
+#[test]
+fn allowlists_are_published_and_curated() {
+    // The guarantee is inspectable, not folklore: the tag and scheme allowlists
+    // are public constants the guide documents.
+    for tag in [
+        "p", "a", "ul", "ol", "li", "code", "pre", "table", "strong", "em",
+    ] {
+        assert!(
+            RICH_TEXT_ALLOWED_TAGS.contains(&tag),
+            "expected {tag} in the allowlist"
+        );
+    }
+    for tag in [
+        "script", "style", "iframe", "img", "form", "input", "object",
+    ] {
+        assert!(
+            !RICH_TEXT_ALLOWED_TAGS.contains(&tag),
+            "{tag} must never be allowlisted"
+        );
+    }
+    assert!(RICH_TEXT_ALLOWED_URL_SCHEMES.contains(&"https"));
+    assert!(!RICH_TEXT_ALLOWED_URL_SCHEMES.contains(&"javascript"));
+    assert!(!RICH_TEXT_ALLOWED_URL_SCHEMES.contains(&"data"));
+}
+
+#[test]
+fn markup_helper_matches_string_helper() {
+    let source = "Hello **world** [x](javascript:alert(1))";
+    let markup: maud::Markup = render_user_content(source);
+    assert_eq!(markup.into_string(), render_user_content_html(source));
+}
+
+#[test]
+fn empty_input_renders_empty_output() {
+    assert_eq!(render_user_content_html("").trim(), "");
+}
+
+#[test]
+fn very_long_input_does_not_panic() {
+    let source = "a **b** [c](https://d.example)\n\n".repeat(5_000);
+    let html = render_user_content_html(&source);
+    assert!(html.contains("<strong>b</strong>"));
+}

--- a/autumn/tests/integration/rich_text.rs
+++ b/autumn/tests/integration/rich_text.rs
@@ -38,18 +38,35 @@ const FORBIDDEN_TAGS: &[&str] = &[
     "<textarea",
 ];
 
-/// Attribute names that must never survive on any element. Checked against
-/// parsed attribute *names* (see [`parse_tag`]), never raw substrings, so an
-/// escaped `&quot; onmouseover=&quot;` sitting inertly inside a `title` value
-/// is correctly treated as harmless text.
-const FORBIDDEN_ATTRS: &[&str] = &[
-    "srcdoc",
-    "formaction",
-    // User-controlled ids/names enable DOM clobbering.
-    "id",
-    "name",
-    "http-equiv",
+/// The complete per-tag attribute allowlist, mirroring `build_sanitizer`'s
+/// `tag_attributes` map in `autumn/src/markdown/user_content.rs`.
+///
+/// This is an **allowlist**, not a denylist, and that distinction is the whole
+/// point: a denylist of scary-looking names (`onerror`, `srcdoc`, …) silently
+/// tolerates anything nobody thought to enumerate — `style` (a full-viewport
+/// clickjacking overlay), `ping` and `target` (which together defeat the forced
+/// `rel` hardening), `data-*` hooks into the host page's own scripts. Asserting
+/// the exact surviving set means widening the sanitizer without widening this
+/// table fails the corpus.
+///
+/// `rel` appears on `a` because ammonia *adds* it (`link_rel`); it is not
+/// accepted from input.
+const ALLOWED_TAG_ATTRIBUTES: &[(&str, &[&str])] = &[
+    ("a", &["href", "title", "rel"]),
+    ("code", &["class"]),
+    ("pre", &["class"]),
+    ("th", &["style"]),
+    ("td", &["style"]),
+    ("ol", &["start"]),
 ];
+
+/// The attributes permitted on `tag`, or an empty slice when the tag takes none.
+fn allowed_attributes_for(tag: &str) -> &'static [&'static str] {
+    ALLOWED_TAG_ATTRIBUTES
+        .iter()
+        .find(|(name, _)| *name == tag)
+        .map_or(&[], |(_, attrs)| *attrs)
+}
 
 /// Adversarial Markdown/HTML payloads a hostile user could submit.
 const XSS_CORPUS: &[&str] = &[
@@ -111,6 +128,20 @@ const XSS_CORPUS: &[&str] = &[
     "| a |\n|---|\n| [x](javascript:alert(1)) |",
     // Title attribute injection attempt.
     "[x](https://ok.example \"a\\\" onmouseover=\\\"alert(1)\")",
+    // Non-scripting attributes that are just as dangerous as an `on*` handler:
+    // a full-viewport `style` overlay is clickjacking/UI-redress, a remote
+    // `background: url(…)` is the same reader-IP beacon the `<img>` exclusion
+    // exists to prevent, and `ping`/`target` together defeat the forced
+    // `rel="noopener noreferrer"` hardening.
+    "<p style=\"position:fixed;top:0;left:0;width:100vw;height:100vh;z-index:9999\">x</p>",
+    "<p style=\"background:url(https://evil.example/beacon.png)\">x</p>",
+    "<a href=\"https://ok.example\" ping=\"https://evil.example/track\" target=\"_blank\">x</a>",
+    "<a href=\"https://ok.example\" rel=\"\">x</a>",
+    // A `data-*` hook into the host page's own scripts.
+    "<p data-controller=\"admin\" data-action=\"delete\">x</p>",
+    // Attribute smuggling through the two value-narrowed attributes.
+    "<pre><code class=\"language-rust evil-hook\">x</code></pre>",
+    "<table><tr><td style=\"text-align:left;position:fixed\">x</td></tr></table>",
 ];
 
 /// Split `html` into its live tag regions (`<…>`).
@@ -222,13 +253,15 @@ fn assert_inert(payload: &str, html: &str) {
             "payload {payload:?} emitted non-allowlisted tag {name:?}:\n{html}"
         );
         for (attr, value) in attrs {
+            // The allowlist assertion subsumes every denylist we could write —
+            // event handlers, `id`/`name`, `srcdoc`, `formaction`, `style`,
+            // `ping`, `target`, `data-*` — because anything not named for this
+            // tag fails here.
             assert!(
-                !attr.starts_with("on"),
-                "payload {payload:?} kept event handler {attr:?} on <{name}>:\n{html}"
-            );
-            assert!(
-                !FORBIDDEN_ATTRS.contains(&attr.as_str()),
-                "payload {payload:?} kept attribute {attr:?} on <{name}>:\n{html}"
+                allowed_attributes_for(&name).contains(&attr.as_str()),
+                "payload {payload:?} kept non-allowlisted attribute {attr:?} on \
+                 <{name}> (allowed: {:?}):\n{html}",
+                allowed_attributes_for(&name)
             );
             if !matches!(attr.as_str(), "href" | "src") {
                 continue;
@@ -409,6 +442,66 @@ fn markup_helper_matches_string_helper() {
 #[test]
 fn empty_input_renders_empty_output() {
     assert_eq!(render_user_content_html("").trim(), "");
+}
+
+#[test]
+fn deeply_nested_blocks_render_in_linear_time() {
+    // A rich-text column is rendered on every show-page view and on every
+    // keystroke-debounced preview POST, so the renderer must not be
+    // super-linear in any attacker-controlled dimension. `"> "` is the maximal
+    // amplifier: two source bytes per nesting level.
+    //
+    // Before the nesting cap this was O(depth²) inside the HTML sanitizer's
+    // open-elements scope walk — 80 KB of input took ~111s. The assertion is a
+    // generous ceiling (a linear render of this input is milliseconds); it is
+    // sized to catch a return of quadratic behaviour, not to benchmark.
+    use std::time::Instant;
+
+    let source = "> ".repeat(40_000);
+    let started = Instant::now();
+    let html = render_user_content_html(&source);
+    let elapsed = started.elapsed();
+
+    assert!(
+        elapsed.as_secs() < 5,
+        "rendering {} bytes of nested blockquotes took {elapsed:?} — the renderer \
+         has regressed to super-linear behaviour",
+        source.len()
+    );
+    // Output stays bounded too: past the cap the nesting is flattened rather
+    // than emitted, so a 80 KB input cannot inflate into megabytes of markup.
+    assert!(
+        html.len() < 10_000,
+        "output inflated to {} bytes from a capped-depth input",
+        html.len()
+    );
+}
+
+#[test]
+fn nesting_below_the_cap_is_preserved_exactly() {
+    // The cap must not disturb documents anyone would actually write.
+    let source = "> ".repeat(20) + "quoted";
+    let html = render_user_content_html(&source);
+    assert_eq!(
+        html.matches("<blockquote>").count(),
+        20,
+        "ordinary nesting must survive untouched:\n{html}"
+    );
+    assert!(html.contains("quoted"), "{html}");
+}
+
+#[test]
+fn rejected_autolink_keeps_its_text_exactly_once() {
+    // Dropping the anchor must not duplicate the destination: the parser
+    // already emits the autolink's text as its own event.
+    let html = render_user_content_html("<javascript:alert(1)>");
+    assert_eq!(html.trim(), "<p>javascript:alert(1)</p>", "{html}");
+    let html = render_user_content_html("<ftp://example.com/f>");
+    assert_eq!(html.trim(), "<p>ftp://example.com/f</p>", "{html}");
+    // An allowed autolink still becomes a real link, exactly once.
+    let html = render_user_content_html("<https://example.com/>");
+    assert_eq!(html.matches("<a ").count(), 1, "{html}");
+    assert_eq!(html.matches("https://example.com/").count(), 2, "{html}");
 }
 
 #[test]

--- a/autumn/tests/integration/rich_text.rs
+++ b/autumn/tests/integration/rich_text.rs
@@ -309,6 +309,43 @@ fn xss_corpus_is_inert_through_the_html_sanitizer_too() {
 }
 
 #[test]
+fn ac_named_combined_payload_emits_no_script_and_no_javascript_href() {
+    // The acceptance criterion names this exact input: the rendered output must
+    // contain no `<script>` and no `javascript:` href.
+    let payload = "<script>alert(1)</script>[x](javascript:alert(1))";
+    let html = render_user_content_html(payload);
+    let lowered = html.to_ascii_lowercase();
+
+    // No script element.
+    assert!(!lowered.contains("<script"), "{html}");
+    assert!(!lowered.contains("</script"), "{html}");
+    // No `javascript:` href — the criterion is about the *href*, and
+    // `assert_inert` proves it structurally by parsing every surviving tag.
+    assert!(
+        !lowered.contains("href="),
+        "no anchor survives here:\n{html}"
+    );
+    assert_inert(payload, &html);
+
+    // Everything survives only as inert, escaped text. Note the link is not
+    // even parsed as a link here: `<script>` opens a CommonMark *HTML block*,
+    // which swallows the rest of the line — so `javascript:` appears in the
+    // output as literal characters. That is why this asserts on `href` rather
+    // than on the bare substring.
+    assert!(html.contains("&lt;script&gt;"), "{html}");
+
+    // Split across lines the link IS parsed as a link — and is still defused.
+    let split = render_user_content_html("<script>alert(1)</script>\n\n[x](javascript:alert(1))");
+    let split_lower = split.to_ascii_lowercase();
+    assert!(!split_lower.contains("<script"), "{split}");
+    assert!(
+        !split_lower.contains("javascript:"),
+        "a genuinely parsed javascript: link must leave no trace:\n{split}"
+    );
+    assert!(split.contains('x'), "the link text survives:\n{split}");
+}
+
+#[test]
 fn ac_named_javascript_link_payload_emits_no_href() {
     // The acceptance criterion names this payload explicitly: the rendered
     // output must carry no `javascript:` URL at all.

--- a/docs/guide/generators.md
+++ b/docs/guide/generators.md
@@ -67,6 +67,7 @@ set.
 | ----------------- | ------------------------------- | ------------------ | ------------------- |
 | `title:String`    | `String`                        | `Text`             | `TEXT`              |
 | `body:Text`       | `String` (alias for `String`)   | `Text`             | `TEXT`              |
+| `body:richtext`   | `String` (Markdown source)      | `Text`             | `TEXT`              |
 | `count:i32`       | `i32`                           | `Int4`             | `INTEGER`           |
 | `count:i64`       | `i64`                           | `Int8`             | `BIGINT`            |
 | `score:f32`       | `f32`                           | `Float4`           | `REAL`              |
@@ -81,6 +82,36 @@ set.
 Wrap any of the above in `Option<…>` to make the column nullable
 (`Option<String>`, `Option<i64>`, `Option<NaiveDateTime>`, …). The generator
 emits both `NULL` in the migration SQL and `Nullable<T>` in `schema.rs`.
+
+### `richtext` — safe user-submitted Markdown
+
+`body:richtext` is storage-identical to `body:Text` (a plain `TEXT` column
+holding the Markdown **source**, never rendered HTML). What it changes is the
+generated UI:
+
+- the form renders a Markdown editor with a syntax hint and an htmx live
+  preview instead of a bare `<textarea>`;
+- a `POST /{plural}/preview/{field}` endpoint drives that preview;
+- the show view renders the column through
+  `autumn_web::markdown::render_user_content`, which disables raw-HTML
+  passthrough and runs the output through an allowlist sanitizer;
+- `autumn-web`'s `markdown` feature is enabled on your project.
+
+```bash
+autumn generate scaffold Post title:String body:richtext
+```
+
+That is the whole setup — the resulting app accepts formatted user content
+without stored XSS. See the [rich text guide](rich-text.md) for the exact
+sanitization guarantee, the tag/URL-scheme allowlist, and what it deliberately
+excludes.
+
+`{min=N,max=N}` length bounds work on a `richtext` column exactly as they do on
+`Text`. `{email}` and `{url}` are rejected: a Markdown body cannot satisfy a
+single-line format validator, so accepting them would emit a field no
+submission could fill. `--api` scaffolds ignore the rich-text wiring entirely —
+they render no form or show view, so the column is just `TEXT` carried out over
+JSON.
 
 ### Validation and HTML5 constraints (`{…}` modifiers)
 
@@ -98,7 +129,7 @@ autumn generate scaffold Post \
 
 | Modifier                        | Applies to        | `#[validate(…)]`        | HTML5 attribute(s)        |
 | ------------------------------- | ----------------- | ----------------------- | ------------------------- |
-| `{min=N,max=N}` (String/Text)   | `String`/`Text`   | `length(min, max)`      | `minlength` / `maxlength` |
+| `{min=N,max=N}` (String/Text)   | `String`/`Text`/`richtext` | `length(min, max)` | `minlength` / `maxlength` |
 | `{min=N,max=N}` (numeric)       | `i32`/`i64`/`f32`/`f64` | `range(min, max)` | `min` / `max` (`type="number"`) |
 | `{email}`                       | `String`/`Text`   | `email`                 | `type="email"`            |
 | `{url}`                         | `String`/`Text`   | `url`                   | `type="url"`              |

--- a/docs/guide/generators.md
+++ b/docs/guide/generators.md
@@ -89,8 +89,8 @@ emits both `NULL` in the migration SQL and `Nullable<T>` in `schema.rs`.
 holding the Markdown **source**, never rendered HTML). What it changes is the
 generated UI:
 
-- the form renders a Markdown editor with a syntax hint and an htmx live
-  preview instead of a bare `<textarea>`;
+- the form renders a Markdown editor with a no-JavaScript syntax toolbar and an
+  htmx live preview instead of a bare `<textarea>`;
 - a `POST /{plural}/preview/{field}` endpoint drives that preview;
 - the show view renders the column through
   `autumn_web::markdown::render_user_content`, which disables raw-HTML
@@ -106,10 +106,12 @@ without stored XSS. See the [rich text guide](rich-text.md) for the exact
 sanitization guarantee, the tag/URL-scheme allowlist, and what it deliberately
 excludes.
 
-`{min=N,max=N}` length bounds work on a `richtext` column exactly as they do on
-`Text`. `{email}` and `{url}` are rejected: a Markdown body cannot satisfy a
-single-line format validator, so accepting them would emit a field no
-submission could fill. `--api` scaffolds ignore the rich-text wiring entirely —
+`{min=N,max=N}` length bounds are accepted on a `richtext` column and emit the
+same server-side `#[validate(length(…))]` rule as `Text` — but no client-side
+`minlength`/`maxlength`, since the editor is rendered by `rich_text_area`, which
+takes no HTML5 constraint attributes. `{email}` and `{url}` are rejected: a
+Markdown body cannot satisfy a single-line format validator, so accepting them
+would emit a field no submission could fill. `--api` scaffolds ignore the rich-text wiring entirely —
 they render no form or show view, so the column is just `TEXT` carried out over
 JSON.
 
@@ -129,7 +131,8 @@ autumn generate scaffold Post \
 
 | Modifier                        | Applies to        | `#[validate(…)]`        | HTML5 attribute(s)        |
 | ------------------------------- | ----------------- | ----------------------- | ------------------------- |
-| `{min=N,max=N}` (String/Text)   | `String`/`Text`/`richtext` | `length(min, max)` | `minlength` / `maxlength` |
+| `{min=N,max=N}` (String/Text)   | `String`/`Text`   | `length(min, max)`      | `minlength` / `maxlength` |
+| `{min=N,max=N}` (richtext)      | `richtext`        | `length(min, max)`      | *(none — server-side only)* |
 | `{min=N,max=N}` (numeric)       | `i32`/`i64`/`f32`/`f64` | `range(min, max)` | `min` / `max` (`type="number"`) |
 | `{email}`                       | `String`/`Text`   | `email`                 | `type="email"`            |
 | `{url}`                         | `String`/`Text`   | `url`                   | `type="url"`              |

--- a/docs/guide/rich-text.md
+++ b/docs/guide/rich-text.md
@@ -1,0 +1,190 @@
+# Rich Text
+
+Blogs, forums, comment threads, and wikis all need the same thing: let a user
+write formatted text, then show it to other users. Doing that by hand means
+picking an editor, picking a Markdown renderer, and — the part everyone
+forgets — picking and correctly configuring an HTML sanitizer. Skip the last
+step and you have shipped stored XSS.
+
+Autumn gives you the whole path in one scaffold token:
+
+```bash
+autumn generate scaffold Post title:String body:richtext
+```
+
+That produces a `TEXT` column holding the Markdown source, a form with a
+Markdown editor and a live preview, and a show view that renders the stored
+text through a sanitizer. No JavaScript of your own, no sanitizer to configure.
+
+## The sanitization guarantee
+
+`autumn_web::markdown::render_user_content` is the only function you should
+use to render text a request body carried in. It applies **two independent
+controls**:
+
+1. **Raw-HTML passthrough is disabled.** Every raw-HTML event the Markdown
+   parser produces is rewritten into a text event, so `<script>alert(1)</script>`
+   in the source renders as the visible characters `<script>alert(1)</script>`,
+   not as a script tag. Link and image destinations are checked against the URL
+   scheme allowlist *before* the HTML writer runs; a link with a rejected scheme
+   is degraded to its own text.
+2. **The output is run through an allowlist sanitizer.** The resulting HTML
+   string is passed through [`ammonia`](https://crates.io/crates/ammonia),
+   configured with the curated tag set, a per-tag attribute allowlist, and the
+   same URL-scheme allowlist.
+
+Either control alone blocks the canonical payloads. Both are applied so that a
+bypass of one is not a bypass of the feature.
+
+```rust
+use autumn_web::markdown::render_user_content;
+
+// In a handler or template:
+html! {
+    article class="post-body" { (render_user_content(&post.body)) }
+}
+```
+
+The guarantee is locked down by an adversarial payload corpus in
+`autumn/tests/integration/rich_text.rs`, which parses the rendered output and
+asserts that no non-allowlisted element, no event-handler attribute, and no URL
+outside the scheme allowlist survives.
+
+## The allowlist
+
+Both lists are public constants, so the guarantee is inspectable rather than
+folklore:
+
+| Constant | Contents |
+| --- | --- |
+| `markdown::RICH_TEXT_ALLOWED_TAGS` | `p` `br` `hr` `blockquote` `h1`–`h6` `em` `strong` `del` `sub` `sup` `a` `ul` `ol` `li` `code` `pre` `table` `thead` `tbody` `tr` `th` `td` |
+| `markdown::RICH_TEXT_ALLOWED_URL_SCHEMES` | `http` `https` `mailto` `tel` |
+
+Attributes are allowlisted per tag and narrowed further by value:
+
+| Tag | Allowed attributes |
+| --- | --- |
+| `a` | `href`, `title` (`rel` is *forced* to `noopener noreferrer nofollow`) |
+| `code`, `pre` | `class`, and only in the `language-{lang}` shape a fenced code block produces |
+| `th`, `td` | `style`, and only a `text-align: left\|right\|center` rule |
+| `ol` | `start` |
+
+A URL destination with **no** scheme — relative (`/about`), fragment
+(`#section`), or protocol-relative (`//host/path`) — is allowed. The scheme is
+read with the same tolerances a browser applies, so `JaVaScRiPt:`,
+`java<TAB>script:`, and a leading-NUL-padded `javascript:` are all recognised
+and rejected.
+
+### What is deliberately excluded
+
+- **`<img>`.** Image embedding is out of scope for this field. A Markdown image
+  degrades to its alt text, so a post cannot beacon a reader's IP address to a
+  third-party host.
+- **`id` and `name` attributes.** User-controlled ids enable DOM clobbering —
+  a heading called "Login" shadowing `document.getElementById("login")`. Unlike
+  the trusted-content renderer, this path injects no heading anchors.
+- **`style` attributes**, except the table-alignment rule above.
+- **`class` attributes**, except the code-fence language hint.
+- **`<script>`, `<style>`, `<iframe>`, `<object>`, `<embed>`, `<form>`,
+  `<input>`, `<svg>`, `<math>`, `<base>`, `<link>`, `<meta>`** and every
+  event-handler (`on*`) attribute.
+- **Per-field allowlist configuration.** The allowlist is fixed on purpose: one
+  guarantee, reasoned about once, identical in every app.
+
+## Trusted content is a different function
+
+The `markdown` module has two entry points, and picking the wrong one is a
+security bug:
+
+| Source of the Markdown | Use |
+| --- | --- |
+| Files you authored and committed (docs, marketing pages, a `content/` tree) | `markdown::render` / `MarkdownRegistry` |
+| Anything a request body carried in (posts, comments, wiki bodies, bios) | `markdown::render_user_content` |
+
+`markdown::render` is built for build-time content: it injects heading anchors
+and applies **no** URL-scheme allowlist, so `[x](javascript:alert(1))` renders
+as written. Never point it at user input.
+
+If your untrusted rich text arrives as HTML rather than Markdown — a legacy
+column, an imported feed — use `markdown::sanitize_user_html`, which applies
+the same allowlist to an HTML string.
+
+## The editor widget
+
+`autumn_web::form::rich_text_area` renders a labeled `<textarea>` carrying the
+Markdown source, plus a hint naming the supported syntax. It needs no
+JavaScript and degrades to an ordinary textarea everywhere.
+
+```rust
+form.rich_text_area("body", "Body")
+```
+
+`rich_text_area_htmx` adds a live preview pane:
+
+```rust
+form.rich_text_area_htmx("body", "Body", &paths::preview_body())
+```
+
+The textarea POSTs the form to the preview URL a short moment after typing
+stops and swaps the response into `#body-preview` — htmx attributes only, no
+script of your own. The preview handler renders through the *same* sanitizer as
+the show view, so what the author previews is byte-for-byte what a reader gets,
+including anything the allowlist strips:
+
+```rust
+#[post("/posts/preview/body")]
+pub async fn preview_body(body: Bytes) -> Markup {
+    let Ok(form) = decode_form(body) else {
+        return html! {};
+    };
+    let changeset = form.into_changeset();
+    autumn_web::markdown::render_user_content(
+        &changeset.field_value("body").unwrap_or_default(),
+    )
+}
+```
+
+The scaffold generates exactly this handler for you.
+
+### Submit tokens
+
+The preview POST `hx-include`s the whole form, which would otherwise spend the
+one-time `_submit_token` that the real create/update submit needs. Two guards
+cover this:
+
+- the widget emits `hx-params="not _submit_token"`, filtering the token out
+  client-side. If your app customizes `[security.submit_token].field_name`, use
+  `rich_text_area_htmx_with_token_field` and pass the configured name from the
+  `SubmitFormField` extractor;
+- the scaffold adds `/{plural}/preview` to `[security.submit_token]
+  exempt_paths` in `autumn.toml`, which is field-name-agnostic.
+
+## Storing and rendering
+
+The column stores the Markdown **source**, never rendered HTML. That means:
+
+- an author can edit what they wrote, exactly as they wrote it;
+- tightening the allowlist takes effect on the next page render, with no
+  migration and no re-sanitization pass over historical rows;
+- a bug in the sanitizer is fixed by upgrading, not by rewriting your data.
+
+The index view renders the source as escaped text — a table cell has no
+business carrying block-level markup, and escaped source is inherently safe.
+The rendered form appears on the show page.
+
+## Feature flag
+
+All of this lives behind `autumn-web`'s `markdown` feature:
+
+```toml
+autumn-web = { version = "0.6.0", features = ["markdown"] }
+```
+
+A `richtext` scaffold enables it on your project automatically.
+
+## Not in scope
+
+Block/WYSIWYG editors, collaborative editing, image upload and embedding,
+@-mentions, slash commands, emoji pickers, storing pre-rendered HTML, and
+per-field allowlist configuration are all deliberately out of scope. The goal
+is one token to safe formatted text — not an editor product.

--- a/docs/guide/rich-text.md
+++ b/docs/guide/rich-text.md
@@ -132,6 +132,14 @@ bar.
 form.rich_text_area("body", "Body")
 ```
 
+For a **non-nullable** column use `required_rich_text_area` (and
+`required_rich_text_area_htmx` for the preview variant), which adds the HTML
+`required` attribute and `aria-required="true"`. This matters more than it
+looks: both `String` deserialization and a `TEXT NOT NULL` column accept the
+empty string, so without that signal an empty editor would silently persist a
+blank body unless the field also declared a `{min=N}` constraint. The scaffold
+picks the right variant from the column's nullability.
+
 `rich_text_area_htmx` adds a live preview pane:
 
 ```rust

--- a/docs/guide/rich-text.md
+++ b/docs/guide/rich-text.md
@@ -147,17 +147,23 @@ including anything the allowlist strips:
 ```rust
 #[post("/posts/preview/body")]
 pub async fn preview_body(body: Bytes) -> Markup {
-    let Ok(form) = decode_form(body) else {
-        return html! {};
-    };
-    let changeset = form.into_changeset();
-    autumn_web::markdown::render_user_content(
-        &changeset.field_value("body").unwrap_or_default(),
-    )
+    let source = autumn_web::form::field_from_urlencoded(&body, "body")
+        .unwrap_or_default();
+    autumn_web::markdown::render_user_content(&source)
 }
 ```
 
 The scaffold generates exactly this handler for you.
+
+Note that it reads the one field it needs with
+`form::field_from_urlencoded` rather than deserializing the whole form.
+`hx-include="closest form"` posts **every** field, so on a freshly-opened "new"
+page a required `i64` column arrives as `count=`. Decoding the form struct would
+fail on that empty string and the preview would stay blank until the author had
+filled in every unrelated column. A preview validates nothing, so it has no
+reason to depend on the rest of the form being valid — unlike an inline
+*validation* fragment, which decodes the whole form precisely because checking
+`#[validate]` rules is its job.
 
 ### Submit tokens
 

--- a/docs/guide/rich-text.md
+++ b/docs/guide/rich-text.md
@@ -25,9 +25,10 @@ controls**:
 1. **Raw-HTML passthrough is disabled.** Every raw-HTML event the Markdown
    parser produces is rewritten into a text event, so `<script>alert(1)</script>`
    in the source renders as the visible characters `<script>alert(1)</script>`,
-   not as a script tag. Link and image destinations are checked against the URL
-   scheme allowlist *before* the HTML writer runs; a link with a rejected scheme
-   is degraded to its own text.
+   not as a script tag. Link destinations are checked against the URL scheme
+   allowlist *before* the HTML writer runs; a link with a rejected scheme is
+   degraded to its own text. Image destinations are never rendered at all, so
+   they are dropped rather than scheme-checked.
 2. **The output is run through an allowlist sanitizer.** The resulting HTML
    string is passed through [`ammonia`](https://crates.io/crates/ammonia),
    configured with the curated tag set, a per-tag attribute allowlist, and the
@@ -59,6 +60,10 @@ folklore:
 | --- | --- |
 | `markdown::RICH_TEXT_ALLOWED_TAGS` | `p` `br` `hr` `blockquote` `h1`–`h6` `em` `strong` `del` `sub` `sup` `a` `ul` `ol` `li` `code` `pre` `table` `thead` `tbody` `tr` `th` `td` |
 | `markdown::RICH_TEXT_ALLOWED_URL_SCHEMES` | `http` `https` `mailto` `tel` |
+
+`sub` and `sup` have no CommonMark syntax, so they are unreachable from
+`render_user_content` — they are allowlisted for `sanitize_user_html` callers
+whose source is already HTML.
 
 Attributes are allowlisted per tag and narrowed further by value:
 
@@ -112,8 +117,16 @@ the same allowlist to an HTML string.
 ## The editor widget
 
 `autumn_web::form::rich_text_area` renders a labeled `<textarea>` carrying the
-Markdown source, plus a hint naming the supported syntax. It needs no
+Markdown source, a minimal formatting toolbar, and a hint. It needs no
 JavaScript and degrades to an ordinary textarea everywhere.
+
+The toolbar shows the syntax for each supported construct (`**bold**`,
+`[text](url)`, `- item`, …) rather than inserting it on click. That is
+deliberate: inserting text into a `<textarea>` is impossible in HTML alone, so a
+click-to-insert toolbar would require a script — and a control that silently
+does nothing when scripting is off is worse than no control. The editor's
+contract is that it works with no JavaScript, so the toolbar holds to the same
+bar.
 
 ```rust
 form.rich_text_area("body", "Body")
@@ -188,3 +201,17 @@ Block/WYSIWYG editors, collaborative editing, image upload and embedding,
 @-mentions, slash commands, emoji pickers, storing pre-rendered HTML, and
 per-field allowlist configuration are all deliberately out of scope. The goal
 is one token to safe formatted text — not an editor product.
+
+A **click-to-insert** toolbar is also out of scope for the same reason: it
+cannot be built without JavaScript, and the widget's contract is that it works
+without any. If you want one, `rich_text_area`'s markup is stable enough to
+enhance from your own script — the editor is `#{field}` and the toolbar is
+`.autumn-rich-text__toolbar`.
+
+### Known limitation: field order
+
+A `richtext` column is rendered through `form_for`'s `.exclude()` + `.append()`
+escape hatch, and appended markup lands just before the submit button. So in a
+generated form a rich-text column always appears **last**, regardless of where
+it sits in the field list. The attachment and DSL-constrained columns share this
+limitation. Reorder by editing the generated `{resource}_form_for` helper.

--- a/skills/autumn-web/SKILL.md
+++ b/skills/autumn-web/SKILL.md
@@ -173,7 +173,7 @@ Defaults: `maud`, `htmx`, `tailwind`, `db`, `cache-moka`.
 | `oauth2` | OAuth2/OIDC helpers and `autumn generate auth --oauth` scaffolding |
 | `openapi` | OpenAPI route metadata and spec generation |
 | `mcp` | Project typed JSON endpoints as MCP tools; implies `openapi` |
-| `markdown` | Markdown rendering with frontmatter and static-site support |
+| `markdown` | Markdown rendering with frontmatter and static-site support, plus the safe user-submitted rich-text path (`render_user_content`, `rich_text_area`) — see [rich text](../../docs/guide/rich-text.md) |
 | `telemetry-otlp` | OpenTelemetry OTLP export |
 | `test-support` | Testcontainers-backed `TestApp`, `TestClient`, and `TestDb` |
 | `i18n` | Locale extractor and compile-time checked translations |


### PR DESCRIPTION
Closes #1255.

`autumn generate scaffold post title:String body:richtext` now produces a content app that accepts user-authored formatted text without stored XSS — no editor to pick, no sanitizer to configure, no JavaScript to write.

## The problem

The `markdown` module was built for *trusted, build-time* content: `render()` injects heading anchors and applies no URL allowlist, so `[x](javascript:alert(1))` renders as written. There was no HTML sanitizer anywhere in the workspace, `form.rs` shipped no editor control, and `FieldKind` had no rich-text variant — so every content app built on autumn hand-rolled both halves, and the ones that skipped the sanitizer shipped stored XSS.

## The guarantee

`markdown::render_user_content` applies **two independent controls**, so a bypass of one is not a bypass of the feature:

1. **Raw-HTML passthrough is disabled at the parser.** `Html`/`InlineHtml` events become escaped `Text`, and link destinations are scheme-checked *before* the HTML writer runs. Images are dropped in favour of their alt text.
2. **The output goes through an `ammonia` allowlist** built from the public `RICH_TEXT_ALLOWED_TAGS` / `RICH_TEXT_ALLOWED_URL_SCHEMES` constants, with a per-tag attribute allowlist narrowed further by value.

The allowlist is deliberately tight, and each exclusion closes a specific vector:

| Excluded | Why |
| --- | --- |
| `<img>` | A remote image is a reader-IP beacon. Markdown images degrade to alt text. |
| `id` / `name` | DOM clobbering — a heading called "Login" shadowing `getElementById("login")`. This path injects no heading anchors, unlike `render()`. |
| `style` (except `text-align` on cells) | Full-viewport overlays are clickjacking; `background: url(…)` is a beacon. |
| `class` (except the `language-*` code hint) | Hooks into the host page's own CSS/JS selectors. |
| `ping`, `target` | Together they defeat the forced `rel="noopener noreferrer nofollow"`. |

## What's included

- **`autumn-web`** — `markdown::{render_user_content, render_user_content_html, sanitize_user_html}` plus the two allowlist constants; `form::rich_text_area{,_htmx,_htmx_with_token_field}` and matching `ChangesetForm` methods; widget CSS.
- **`autumn-cli`** — `FieldKind::RichText`. Storage-identical to `Text` (plain `TEXT`, both backends, schema-core parity test extended); the difference is entirely in the generated views — Markdown editor in the form, `POST /{plural}/preview/{field}` driving the htmx preview, sanitized render in `show`, escaped source in `index`, `markdown` feature auto-enabled, preview routes added to the submit-token `exempt_paths`.
- **Docs** — `docs/guide/rich-text.md`, the `richtext` DSL token in `generators.md`, a trusted-vs-user-content warning on `render()`, CHANGELOG under `[Unreleased]`.

## Design notes worth reviewing

- **The toolbar shows syntax rather than inserting it.** Inserting into a `<textarea>` is impossible in HTML alone, and AC #3 requires the widget work with no JavaScript. A button that silently does nothing when scripting is off is worse than no button.
- **The column stores the Markdown source, never rendered HTML.** Tightening the allowlist then takes effect on the next render — no migration, no re-sanitization pass over historical rows.
- **The preview renders through the same function as the show view**, so what an author previews is byte-for-byte what a reader gets, including anything the allowlist strips.

## Testing

A 47-payload adversarial corpus asserts **structurally**, not by substring: it parses every surviving tag and checks the element against the allowlist, every attribute against the per-tag allowlist, and every URL against the scheme allowlist. That distinction matters — a payload neutralised into escaped text (`&lt;img … onerror=…&gt;`) must not be confused with a live one.

The corpus was mutation-tested: widening the sanitizer to permit `style`/`ping`/`target` makes it fail.

Also covered: `--live-validation`, `--default`, and plain richtext scaffolds each generate an app that `cargo check`s against this workspace's `autumn-web` (captured as an `#[ignore]`d CI test); a DoS regression capping block nesting; and a new CI lane so the markdown-gated tests actually run on a PR — `markdown` is not a default feature, so `cargo test --workspace` previously compiled neither the corpus nor its doctests.

## Follow-up (not in this PR)

`examples/wiki` still hand-rolls `body.split("\n\n")` for rendering. Converting it to `richtext` would be the natural demonstration of the success metric, but it's outside this issue's scope.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N82mAfQ7UihUC9asMUAHx7

---
_Generated by [Claude Code](https://claude.ai/code/session_01N82mAfQ7UihUC9asMUAHx7)_