### PR TITLE
feat(sim): property-based op-driver — Sim::gen_ops / Sim::run_proptest (W6 PR2, #1797)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -340,6 +340,11 @@ jobs:
         run: cargo build -p autumn-web --features sqlite
       - name: Clippy (autumn-web lib, sqlite backend)
         run: cargo clippy -p autumn-web --features sqlite --lib -- -D warnings
+      - name: Clippy (autumn-web lib, sim-testing op-driver)
+        # `sim-testing` (W6 PR2, issue #1797) promotes `proptest` to a library
+        # dependency for `sim::op` — lint it here (alongside the sqlite lib
+        # lint above) since it's not part of any other feature combo above.
+        run: cargo clippy -p autumn-web --features "sqlite,sim-testing" --lib -- -D warnings
       - name: Run the sqlite integration suite
         # Named sqlite `[[test]]` targets only. `test-support` is required by the
         # TestApp/Db-extractor-based tests (sqlite_db_extractor, sqlite_read_only_tx,
@@ -376,6 +381,16 @@ jobs:
         run: |
           cargo test -p autumn-web --features "sqlite,test-support,mail" \
             --test sim_chaos_mail
+      - name: Run the sim op-driver DoD suite (W6 PR2, issue #1797)
+        # `sim_op_driver` needs the `sim-testing` feature (`proptest` as a
+        # library dependency) — runs as its own invocation to avoid widening
+        # the feature set of the other sqlite tests above. It doesn't actually
+        # need `sqlite`/`test-support` (it never calls `Sim::build`), but lives
+        # in this job to keep sim-testing CI coverage co-located with the rest
+        # of the sim DoD suites.
+        run: |
+          cargo test -p autumn-web --features sim-testing \
+            --test sim_op_driver
 
   # Genuine loom model checks: the loom_models test binary uses loom::sync::*
   # unconditionally, so loom::model() exhaustively explores thread interleavings

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -304,6 +304,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   guides (#2099). Also corrects stale rustdoc that advertised a `/v3/api-docs`
   default (the served default is `/openapi.json`) and an "OpenAPI 3.0" document
   (the generator emits 3.1.0). [no-plugin]
+- **sim-testing:** add a property-based **op-driver** (`sim::op`, W6 PR2,
+  #1797) behind the new `sim-testing` feature: `Sim::gen_ops::<T>()` /
+  `Sim::gen_ops_with(strategy)` deterministically draw an arbitrary `Vec<T>`
+  of app-defined operations from a seed, and `Sim::run_proptest(seed,
+  strategy, body)` is the shrink-capable entrypoint — it owns a proptest
+  `TestRunner` and rebuilds a fresh `Sim::from_seed(seed)` for every case
+  (including every shrink attempt), so an `always!` violation shrinks to a
+  minimal, byte-for-byte-reproducible counterexample. The op-generation RNG
+  stream is salted independently of the app-facing entropy, chaos, and crash
+  streams, and proptest's own file-based failure persistence is disabled in
+  favor of the `AUTUMN_SIM_SEED=…` replay line. `proptest` is now also an
+  optional **library** dependency (not just dev-only), so this can live in
+  `src/` and the forthcoming `sim-sweep` binary (W6 PR3) can depend on it
+  too. [no-plugin]
 - **sim-testing:** add the `always!` / `sometimes!` simulation assertion macros
   (W6 op-driver assertion core, #1797) — hard-invariant + reachability assertions
   for `#[sim_test]`, with a non-vacuity registry the forthcoming sim-sweep

--- a/autumn/Cargo.toml
+++ b/autumn/Cargo.toml
@@ -112,6 +112,12 @@ telemetry-otlp = [
     "dep:opentelemetry-otlp",
     "dep:tracing-opentelemetry",
 ]
+# W6 PR2 op-driver (issue #1797): promotes `proptest` from a dev-only dependency
+# to an optional **library** dependency so `sim::Op`-style generation/shrinking
+# code can live in `src/` (not just `tests/`), and so the forthcoming `sim-sweep`
+# `[[bin]]` (W6 PR3), which is a binary and therefore cannot use dev-deps, can
+# depend on it too. `proptest` itself stays out of default builds.
+sim-testing = ["dep:proptest"]
 redis = ["dep:redis"]
 i18n = []
 # Embed the app's `static/` tree (incl. the fingerprint manifest) and i18n
@@ -288,6 +294,7 @@ rust_decimal.workspace = true
 croner = "3.0.1"
 testcontainers = { workspace = true, optional = true }
 testcontainers-modules = { workspace = true, optional = true }
+proptest = { version = "1.4", optional = true }
 serde_urlencoded = "0.7"
 serde_path_to_error = "0.1"
 serde_yaml = { version = "0.9", optional = true }
@@ -705,6 +712,21 @@ path = "tests/sim_sqlite_integration.rs"
 [[test]]
 name = "sim_assert"
 path = "tests/sim_assert.rs"
+
+# W6 PR2 op-driver DoD (issue #1797): `Sim::gen_ops`/`Sim::gen_ops_with`
+# (deterministic generation) and `Sim::run_proptest` (the shrink-capable
+# runner-owning entrypoint) against a small, self-contained, deliberately buggy
+# account model — proves an injected invariant break is found, shrunk to a
+# minimal counterexample, and replays deterministically. Isolated `[[test]]`
+# binary because it needs `proptest` as a library dependency behind the new
+# `sim-testing` feature, which the default-feature consolidated
+# `integration_tests` binary does not enable, so the file is
+# `#![cfg(feature = "sim-testing")]` and a default `cargo test` compiles it to
+# an empty (passing) binary. Runs without Docker. Run:
+# `cargo test -p autumn-web --features sim-testing --test sim_op_driver`.
+[[test]]
+name = "sim_op_driver"
+path = "tests/sim_op_driver.rs"
 
 # Isolated: sets process-wide proxy env vars (HTTP_PROXY/HTTPS_PROXY/ALL_PROXY)
 # to verify pinned SSRF-safe clients bypass env proxies. Cannot share the

--- a/autumn/src/sim.rs
+++ b/autumn/src/sim.rs
@@ -44,6 +44,10 @@
 //! - **W5** turns [`Chaos`] into a public, seed-driven fault-injection builder
 //!   ([`Sim::chaos`]), installed at [`Sim::build`] and recorded into the
 //!   schedule read by [`Sim::__chaos_events`].
+//! - **W6** adds the [`always!`](crate::always) / [`sometimes!`](crate::sometimes)
+//!   assertion macros ([`assert`]) and, behind the `sim-testing` feature, a
+//!   property-based op-driver (`sim::op`) — `Sim::gen_ops`/`Sim::gen_ops_with` for
+//!   deterministic generation and `Sim::run_proptest` for shrink-capable runs.
 //!
 //! Everything here is designed to grow additively (builder-style) without
 //! breaking the frozen surface — hence the `#[non_exhaustive]` markers.
@@ -113,6 +117,13 @@ pub use assert::{
     sometimes_snapshot, sometimes_unsatisfied,
 };
 pub use crash::{CrashPoint, CrashSchedule};
+
+// The W6 op-driver (PR2, issue #1797): `Sim::gen_ops`/`Sim::gen_ops_with` (deterministic,
+// non-shrinking generation) and `Sim::run_proptest` (the shrink-capable
+// runner-owning entrypoint). Behind the `sim-testing` feature because it needs
+// `proptest` as a library (not just dev) dependency — see `autumn/Cargo.toml`.
+#[cfg(feature = "sim-testing")]
+pub mod op;
 
 /// The fixed, deterministic epoch the simulation clock starts at:
 /// `2020-01-01T00:00:00Z`.

--- a/autumn/src/sim.rs
+++ b/autumn/src/sim.rs
@@ -45,7 +45,7 @@
 //!   ([`Sim::chaos`]), installed at [`Sim::build`] and recorded into the
 //!   schedule read by [`Sim::__chaos_events`].
 //! - **W6** adds the [`always!`](crate::always) / [`sometimes!`](crate::sometimes)
-//!   assertion macros ([`assert`]) and, behind the `sim-testing` feature, a
+//!   assertion macros ([`mod@assert`]) and, behind the `sim-testing` feature, a
 //!   property-based op-driver (`sim::op`) — `Sim::gen_ops`/`Sim::gen_ops_with` for
 //!   deterministic generation and `Sim::run_proptest` for shrink-capable runs.
 //!

--- a/autumn/src/sim/op.rs
+++ b/autumn/src/sim/op.rs
@@ -1,0 +1,293 @@
+//! Property-based `Op` generation and shrinking (sim-testing W6 PR2, issue
+//! #1797).
+//!
+//! This is the **op-driver** lane of the sim harness: turning a seeded [`Sim`]
+//! into a source of arbitrary, reproducible operation sequences, and — when a
+//! sequence uncovers an [`always!`](crate::always) violation — shrinking that
+//! sequence down to a minimal reproduction.
+//!
+//! # Design (rulings taken 2026-08-01, issue #1797 comment thread)
+//!
+//! Three shape questions were open before this could be written faithfully.
+//! This module answers all three; see the issue thread for the full reasoning,
+//! summarized here:
+//!
+//! 1. **Generic, not a shipped concrete `Op`.** [`Sim::gen_ops`] is
+//!    `fn gen_ops<T: Arbitrary>(&mut self) -> Vec<T>` — the app supplies its own
+//!    operation enum and `Arbitrary`/`Strategy` impl. A frozen, domain-agnostic
+//!    [`Sim`] cannot ship a fixed operation vocabulary (the RFC's own worked
+//!    examples, `Deposit`/`Transfer`, are app-domain, not framework-domain).
+//!    (Named `gen_ops`, not the ruling's proposed `gen` — `gen` became a
+//!    reserved keyword under the 2024 edition this workspace builds on, so it
+//!    is not available as a method identifier without an ugly `r#gen` raw-ident
+//!    call site.)
+//! 2. **A runner-owning shrink entrypoint, `gen_ops()` redefined as
+//!    generation-only.** [`Sim::gen_ops`] / [`Sim::gen_ops_with`] draw exactly one
+//!    `Vec<T>` — they cannot shrink, because shrinking requires proptest to
+//!    observe a case's pass/fail and rebuild state before the next try.
+//!    [`Sim::run_proptest`] is the shrink-capable entrypoint: it owns a
+//!    proptest `TestRunner`, and for every case (including every shrink
+//!    attempt) rebuilds a **fresh** `Sim` from the same base seed before
+//!    invoking the case closure — mirroring [`#[sim_test]`](crate::sim_test)'s
+//!    "exactly one `Sim` per run" contract at the per-case level instead of the
+//!    per-test level. This is additive: `#[sim_test]` and `Sim::build` are
+//!    untouched.
+//! 3. **`proptest` promoted to an optional *library* dependency** behind the
+//!    new `sim-testing` feature (see `autumn/Cargo.toml`), since this module
+//!    lives in `src/`, not `tests/`, and the forthcoming `sim-sweep` `[[bin]]`
+//!    (W6 PR3) needs it as a lib dep too — a `[[bin]]` cannot use dev-deps.
+//!
+//! # Determinism
+//!
+//! Both [`Sim::gen_ops`]/[`Sim::gen_ops_with`] and [`Sim::run_proptest`] seed proptest's
+//! own case-generation RNG from a **dedicated stream**, `seed ^
+//! OP_GEN_STREAM_SALT` — independent of the app-facing entropy source
+//! ([`Sim::seeded_entropy`]), the [`chaos`](crate::sim::chaos) decision stream,
+//! and the [`crash`](crate::sim::crash) decision stream (each salted
+//! separately, so none of these streams perturb each other). Same seed ⇒ same
+//! generated op sequence ⇒ same shrink path, byte-for-byte.
+//!
+//! [`Sim::run_proptest`] additionally disables proptest's own file-based
+//! failure persistence (`proptest-regressions/*.txt`): the sim harness's
+//! `AUTUMN_SIM_SEED=…` replay line is the single source of truth for
+//! reproducing a failure, so a second, proptest-owned persistence file would
+//! just be a redundant (and potentially stale) source of truth.
+//!
+//! # Example
+//!
+//! ```rust,ignore
+//! use autumn_web::sim::Sim;
+//! use proptest::prelude::*;
+//!
+//! #[derive(Debug, Clone, proptest_derive::Arbitrary)]
+//! enum Op {
+//!     Deposit(u32),
+//!     Transfer { to: u8, amount: u32 },
+//! }
+//!
+//! let result = Sim::run_proptest(0, proptest::collection::vec(any::<Op>(), 1..32), |sim, ops| {
+//!     sim.build(app());
+//!     for op in ops {
+//!         apply(sim, op);
+//!     }
+//!     always!(invariant_holds(sim));
+//! });
+//! assert!(result.is_ok(), "{}", result.unwrap_err());
+//! ```
+
+use std::fmt;
+
+use proptest::arbitrary::{Arbitrary, any};
+use proptest::strategy::{Strategy, ValueTree};
+use proptest::test_runner::{Config, RngAlgorithm, TestError, TestRng, TestRunner};
+use rand::{RngCore, SeedableRng};
+use rand_chacha::ChaCha8Rng;
+
+use super::Sim;
+
+/// Salt `XOR`ed into the sim seed to derive the op-generation RNG stream,
+/// keeping it independent of the app-facing entropy, chaos-decision, and
+/// crash-decision streams (each salted with their own distinct constant). An
+/// arbitrary fixed non-zero constant.
+const OP_GEN_STREAM_SALT: u64 = 0x0B_D1_2E_4A_0B_D1_2E_4A;
+
+/// The default op-sequence length range [`Sim::gen_ops`] draws from. Callers who
+/// need a different range (or a non-uniform shape) should use
+/// [`Sim::gen_ops_with`] / [`Sim::run_proptest`] with an explicit strategy instead.
+const DEFAULT_OP_COUNT: std::ops::Range<usize> = 1..64;
+
+/// Derive a proptest [`TestRng`] deterministically from `seed ^ salt`, via the
+/// same `ChaCha8Rng`-expansion pattern [`crash::CrashSchedule`](crate::sim::crash::CrashSchedule)
+/// uses for its own seed-derived stream.
+fn stream_rng(seed: u64, salt: u64) -> TestRng {
+    let mut seeder = ChaCha8Rng::seed_from_u64(seed ^ salt);
+    let mut bytes = [0u8; 32];
+    seeder.fill_bytes(&mut bytes);
+    TestRng::from_seed(RngAlgorithm::ChaCha, &bytes)
+}
+
+/// A [`Config`] with proptest's own file-based failure persistence disabled
+/// (see the module docs' "Determinism" section for why).
+fn config_without_persistence() -> Config {
+    Config {
+        failure_persistence: None,
+        ..Config::default()
+    }
+}
+
+impl Sim {
+    /// Draw a single deterministic `Vec<T>` from `T`'s [`Arbitrary`] strategy,
+    /// seeded from this simulation's seed.
+    ///
+    /// This is **generation-only** — it does not shrink. Reach for
+    /// [`Sim::run_proptest`] when a generated sequence needs to shrink toward a
+    /// minimal counterexample on failure. Use [`Sim::gen_ops_with`] for a custom
+    /// strategy (length range, weighting, `prop_filter`, …) instead of `T`'s
+    /// default `Arbitrary` impl.
+    pub fn gen_ops<T>(&mut self) -> Vec<T>
+    where
+        T: fmt::Debug + Arbitrary,
+    {
+        self.gen_ops_with(proptest::collection::vec(any::<T>(), DEFAULT_OP_COUNT))
+    }
+
+    /// Draw a single deterministic value from an explicit `strategy`, seeded
+    /// from this simulation's seed. See [`Sim::gen_ops`] for the default-strategy
+    /// convenience form.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `strategy` itself fails to produce a value (a `prop_filter`
+    /// or similar strategy combinator rejecting every draw) — this mirrors
+    /// proptest's own `Strategy::new_tree` failure mode and should not happen
+    /// for a well-formed op strategy.
+    pub fn gen_ops_with<T>(&mut self, strategy: impl Strategy<Value = Vec<T>>) -> Vec<T>
+    where
+        T: fmt::Debug,
+    {
+        let mut runner =
+            TestRunner::new_with_rng(Config::default(), stream_rng(self.seed, OP_GEN_STREAM_SALT));
+        strategy
+            .new_tree(&mut runner)
+            .expect("op strategy generation should not fail")
+            .current()
+    }
+
+    /// Run a shrink-capable property test: for every case `strategy` produces
+    /// (including every shrink attempt after a failure), build a **fresh**
+    /// `Sim::from_seed(seed)` and invoke `body(&mut sim, &ops)`.
+    ///
+    /// A panic inside `body` (e.g. an [`always!`](crate::always) violation) is
+    /// caught by proptest and treated as a case failure, so an invariant break
+    /// shrinks exactly like any other proptest failure. On failure, prints the
+    /// `AUTUMN_SIM_SEED=…` replay line alongside the shrunk minimal op
+    /// sequence, mirroring [`#[sim_test]`](crate::sim_test)'s panic report.
+    ///
+    /// `seed` is the **base** seed: it seeds both proptest's own case-
+    /// generation stream (via a salted derivation, see the module docs) and
+    /// every per-case `Sim`, so the whole run — generation, shrink path, and
+    /// each case's simulated behavior — reproduces byte-for-byte from `seed`
+    /// alone.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`TestError::Fail`] with the shrunk minimal op sequence if any
+    /// case (including a shrink attempt) panics or fails; [`TestError::Abort`]
+    /// if the run itself could not proceed (e.g. too many rejected cases).
+    pub fn run_proptest<T, S, F>(seed: u64, strategy: S, body: F) -> Result<(), TestError<Vec<T>>>
+    where
+        T: fmt::Debug,
+        S: Strategy<Value = Vec<T>>,
+        F: Fn(&mut Self, &[T]),
+    {
+        let mut runner = TestRunner::new_with_rng(
+            config_without_persistence(),
+            stream_rng(seed, OP_GEN_STREAM_SALT),
+        );
+        let result = runner.run(&strategy, |ops| {
+            let mut sim = Self::from_seed(seed);
+            body(&mut sim, &ops);
+            Ok(())
+        });
+        if let Err(ref err) = result
+            && let TestError::Fail(ref reason, ref shrunk_ops) = *err
+        {
+            eprintln!(
+                "AUTUMN_SIM_SEED=0x{seed:x} — shrunk to {} op(s): {shrunk_ops:?} ({reason})",
+                shrunk_ops.len()
+            );
+        }
+        result
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use proptest::prelude::*;
+
+    use super::*;
+
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    enum TinyOp {
+        Inc,
+        Dec,
+    }
+
+    fn tiny_op_strategy() -> impl Strategy<Value = Vec<TinyOp>> {
+        proptest::collection::vec(prop_oneof![Just(TinyOp::Inc), Just(TinyOp::Dec)], 0..16)
+    }
+
+    #[test]
+    fn gen_ops_with_is_deterministic_for_the_same_seed() {
+        let mut a = Sim::from_seed(42);
+        let mut b = Sim::from_seed(42);
+        let ops_a = a.gen_ops_with(tiny_op_strategy());
+        let ops_b = b.gen_ops_with(tiny_op_strategy());
+        assert_eq!(ops_a, ops_b);
+    }
+
+    #[test]
+    fn gen_ops_with_diverges_across_seeds() {
+        let mut a = Sim::from_seed(1);
+        let mut b = Sim::from_seed(2);
+        let ops_a = a.gen_ops_with(tiny_op_strategy());
+        let ops_b = b.gen_ops_with(tiny_op_strategy());
+        assert_ne!(
+            ops_a, ops_b,
+            "different seeds should overwhelmingly diverge"
+        );
+    }
+
+    #[test]
+    fn gen_ops_with_is_independent_of_seeded_entropy_stream() {
+        // Drawing from the app-facing RNG before `gen_ops_with` must not perturb
+        // the op-generation stream — they're salted independently.
+        let mut sim = Sim::from_seed(7);
+        let baseline = sim.gen_ops_with(tiny_op_strategy());
+
+        let mut sim2 = Sim::from_seed(7);
+        let _ = sim2.rng().next_u64();
+        let after_rng_use = sim2.gen_ops_with(tiny_op_strategy());
+
+        assert_eq!(baseline, after_rng_use);
+    }
+
+    #[test]
+    fn run_proptest_rebuilds_a_fresh_sim_per_case() {
+        let seeds_seen = std::sync::Mutex::new(Vec::new());
+        let result = Sim::run_proptest(0, tiny_op_strategy(), |sim, _ops| {
+            seeds_seen.lock().unwrap().push(sim.seed);
+        });
+        assert!(result.is_ok());
+        let seen = seeds_seen.into_inner().unwrap();
+        assert!(!seen.is_empty());
+        assert!(
+            seen.iter().all(|&s| s == 0),
+            "every case must see the same base seed"
+        );
+    }
+
+    #[test]
+    fn run_proptest_shrinks_a_failing_sequence_to_a_minimal_reproduction() {
+        // Fails whenever three or more `Inc`s appear back to back — proptest
+        // should shrink an arbitrary failing sequence down to exactly that.
+        let result = Sim::run_proptest(123, tiny_op_strategy(), |_sim, ops| {
+            let mut run = 0;
+            for op in ops {
+                run = if *op == TinyOp::Inc { run + 1 } else { 0 };
+                assert!(run < 3, "three Incs in a row");
+            }
+        });
+        let err = result.expect_err("the seeded sweep must find a failing sequence");
+        match err {
+            TestError::Fail(_, shrunk_ops) => {
+                assert_eq!(
+                    shrunk_ops,
+                    vec![TinyOp::Inc, TinyOp::Inc, TinyOp::Inc],
+                    "shrinking should reduce to the minimal 3-Inc counterexample, got {shrunk_ops:?}"
+                );
+            }
+            TestError::Abort(reason) => panic!("expected a shrunk failure, got an abort: {reason}"),
+        }
+    }
+}

--- a/autumn/tests/sim_op_driver.rs
+++ b/autumn/tests/sim_op_driver.rs
@@ -1,0 +1,112 @@
+//! W6 PR2 Definition-of-Done proof (sim-testing, issue #1797): the op-driver
+//! finds an injected invariant break, shrinks it to a minimal counterexample,
+//! and the shrunk counterexample replays deterministically.
+//!
+//! Deliberately does **not** touch `Sim::build`/`TestApp` — that's proven
+//! end-to-end by the other `sim_*` `DoD` tests (`sim_chaos_crash`,
+//! `sim_sqlite_integration`, …); this file's only job is the op-driver
+//! mechanism itself: `Sim::gen_ops_with`/`Sim::run_proptest` against a small,
+//! self-contained domain model (an account balance, mirroring the RFC's own
+//! `Deposit`/`Transfer` worked example) with a real, intentional bug.
+//!
+//! Isolated `[[test]]` binary because it needs the `sim-testing` feature
+//! (`proptest` as a library dependency, not just a dev-dependency — see
+//! `autumn/Cargo.toml`), which the default-feature consolidated
+//! `integration_tests` binary does not enable. The file is
+//! `#![cfg(feature = "sim-testing")]`, so a default `cargo test` compiles it to
+//! an empty (passing) binary. Run it with:
+//! `cargo test -p autumn-web --features sim-testing --test sim_op_driver`.
+
+#![cfg(feature = "sim-testing")]
+
+use autumn_web::always;
+use autumn_web::sim::Sim;
+use proptest::prelude::*;
+use proptest::test_runner::TestError;
+
+/// A toy account op, mirroring the RFC's own `Deposit`/`Transfer` example
+/// closely enough to be representative without needing a real app.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Op {
+    Deposit(u32),
+    Withdraw(u32),
+}
+
+impl Arbitrary for Op {
+    type Parameters = ();
+    type Strategy = BoxedStrategy<Op>;
+
+    fn arbitrary_with((): ()) -> Self::Strategy {
+        prop_oneof![
+            (1u32..100).prop_map(Op::Deposit),
+            (1u32..100).prop_map(Op::Withdraw),
+        ]
+        .boxed()
+    }
+}
+
+/// Applies `ops` to a starting-from-zero balance and asserts the invariant
+/// "balance never goes negative" via `always!`.
+///
+/// **Deliberately buggy**: `Withdraw` subtracts unconditionally, with no floor
+/// check against the current balance — exactly the class of bug an op-driver
+/// sweep exists to catch. A single `Withdraw` from a zero balance already
+/// violates the invariant, so this is the smallest possible counterexample the
+/// shrinker can converge on.
+fn apply_ops(ops: &[Op]) {
+    let mut balance: i64 = 0;
+    for op in ops {
+        match *op {
+            Op::Deposit(amount) => balance += i64::from(amount),
+            Op::Withdraw(amount) => balance -= i64::from(amount),
+        }
+        always!(balance >= 0, "balance went negative: {balance}");
+    }
+}
+
+#[test]
+fn run_proptest_finds_and_shrinks_the_injected_invariant_break() {
+    let result = Sim::run_proptest(
+        0,
+        proptest::collection::vec(any::<Op>(), 1..32),
+        |_sim, ops| {
+            apply_ops(ops);
+        },
+    );
+
+    let err = result.expect_err("a Withdraw from a zero balance must violate the invariant");
+    let TestError::Fail(_, shrunk_ops) = err else {
+        panic!("expected a shrunk failure, got an abort");
+    };
+    assert_eq!(
+        shrunk_ops,
+        vec![Op::Withdraw(1)],
+        "should shrink to the minimal single-withdraw counterexample, got {shrunk_ops:?}"
+    );
+}
+
+#[test]
+fn the_shrunk_counterexample_replays_deterministically() {
+    // Same base seed twice: the op-driver's own determinism contract (proptest's
+    // case-generation stream is seeded from `seed`, see `sim::op`'s module docs)
+    // means both runs must find and shrink to the identical minimal failure.
+    let run = || {
+        let result = Sim::run_proptest(
+            0,
+            proptest::collection::vec(any::<Op>(), 1..32),
+            |_sim, ops| {
+                apply_ops(ops);
+            },
+        );
+        match result.expect_err("must fail") {
+            TestError::Fail(_, shrunk_ops) => shrunk_ops,
+            TestError::Abort(reason) => panic!("expected a shrunk failure, got an abort: {reason}"),
+        }
+    };
+
+    assert_eq!(
+        run(),
+        run(),
+        "the same base seed must replay the same shrunk counterexample"
+    );
+}


### PR DESCRIPTION
## Summary

Adds the **op-driver** lane of the sim harness (W6 PR2, part of the #1797 sim-testing epic): turning a seeded `Sim` into a source of arbitrary, reproducible operation sequences, with shrinking on failure.

- New `sim::op` module (behind a new `sim-testing` feature):
  - `Sim::gen_ops::<T>()` / `Sim::gen_ops_with(strategy)` — deterministic, non-shrinking generation of an arbitrary `Vec<T>` from a seed.
  - `Sim::run_proptest(seed, strategy, body)` — the shrink-capable entrypoint. Owns a proptest `TestRunner` and rebuilds a **fresh** `Sim::from_seed(seed)` for every case (including every shrink attempt), mirroring `#[sim_test]`'s "exactly one `Sim` per run" contract at the per-case level.
  - The op-generation RNG stream is salted independently of the app-facing entropy, chaos-decision, and crash-decision streams, so none perturb each other. Same seed ⇒ same generated sequence ⇒ same shrink path, byte-for-byte.
  - Proptest's own file-based failure persistence is disabled — the harness's `AUTUMN_SIM_SEED=…` replay line is the single source of truth for reproducing a failure.
- `proptest` promoted from a dev-only dependency to an optional **library** dependency (`sim-testing` feature), since this code lives in `src/`, not `tests/`, and the forthcoming `sim-sweep` binary (W6 PR3) needs it as a lib dep too (a `[[bin]]` can't use dev-deps). `proptest` stays out of default builds.
- `autumn/tests/sim_op_driver.rs` — the DoD proof: a small, self-contained, deliberately buggy account model (`Deposit`/`Withdraw`, mirroring the RFC's own worked example) with an injected invariant break (`Withdraw` has no floor check), proving the op-driver finds the break, shrinks it to the minimal `[Withdraw(1)]` counterexample, and replays deterministically.
- CI: a new clippy step (`sqlite,sim-testing` lib lint) and a new test step (`cargo test -p autumn-web --features sim-testing --test sim_op_driver`) in the `sqlite-runtime` job.
- `CHANGELOG.md`: new bullet under `## [Unreleased]`.

## Test plan

- [x] `cargo build -p autumn-web --features "sqlite,sim-testing" --lib`
- [x] `cargo clippy -p autumn-web --features "sqlite,sim-testing" --lib -- -D warnings`
- [x] `cargo test -p autumn-web --features sim-testing --test sim_op_driver` (2 passed)
- [x] `cargo test -p autumn-web --features "sqlite,sim-testing" --lib sim::op` (5 passed)
- [x] `cargo test -p autumn-web --test sim_op_driver` (default features — compiles to an empty, passing binary as documented)
- [x] `cargo fmt --all -- --check`

---
_Generated by [Claude Code](https://claude.ai/code/session_018zxeAKoTCyoF8PTN7K5cpN)_