### PR TITLE
Harden zero-JS scaffolded attachment uploads (issue #1236)

### DIFF
--- a/autumn-cli/src/generate/scaffold.rs
+++ b/autumn-cli/src/generate/scaffold.rs
@@ -2028,17 +2028,6 @@ fn render_routes_file(
     // binds `AppState` directly via the injected `State(state)`.
     let create_update_state_expr = if has_attachments { "&*state" } else { "&state" };
     let edit_destroy_state_expr = "&state";
-    // The attachment `update` handler loads `current` after parsing the multipart
-    // body (to preserve un-replaced blobs); record-authorize the actor against
-    // that same already-loaded row before writing, instead of a second load.
-    // Spliced into `update_new_block` right after its `current` load.
-    let authz_attachment_update = if authorize && has_attachments {
-        format!(
-            "autumn_web::authorization::authorize::<{pascal_name}>({create_update_state_expr}, &session, \"update\", &current).await?;\n    "
-        )
-    } else {
-        String::new()
-    };
     // Every PRESENT `references` field (its target model — and so its
     // `src/schema.rs` entry — is in the project; `missing_reference_targets`
     // excludes the rest, which the caller already warned about and which fall
@@ -2397,6 +2386,9 @@ fn render_routes_file(
                 match_arms,
                 "            Some(\"{name}\") => {{\n                \
                  if field.file_name().is_some_and(|file_name| !file_name.is_empty()) {{\n                    \
+                 if {name}_blob.is_some() {{\n                        \
+                 return Err(AutumnError::bad_request_msg(\"duplicate attachment field: {name}\"));\n                    \
+                 }}\n                    \
                  let key = format!(\n                        \
                  \"{plural}/{name}/{{}}_{{}}\",\n                        \
                  chrono::Utc::now().timestamp_nanos_opt().unwrap_or_default(),\n                        \
@@ -2525,7 +2517,15 @@ fn render_routes_file(
             let name = &f.name;
             let _ = write!(binds, "\n    new.{name} = {name}_blob.or(current.{name});");
         }
-        format!("{load_current}{authz_attachment_update}{into_new_bind}{binds}")
+        // Authorized attachment updates already loaded `current` in the
+        // up-front authorization preamble, before multipart parsing. Other
+        // attachment variants still load it here for preserve-on-empty.
+        let load_current = if authorize {
+            String::new()
+        } else {
+            load_current
+        };
+        format!("{load_current}{into_new_bind}{binds}")
     } else {
         format!("let new = {into_new_call};")
     };
@@ -2841,11 +2841,10 @@ fn render_routes_file(
             )
         }
     };
-    // Update: on the attachment path the handler already loads `current` (after
-    // parsing multipart, to preserve un-replaced blobs) and authorizes there via
-    // `authz_attachment_update`, so no up-front preamble is emitted. Every other
-    // variant loads + authorizes here.
-    let authz_update_preamble = if authorize && !has_attachments {
+    // Load and authorize before parsing the request body on every authorized
+    // update. For attachments this ensures a denied actor cannot stream bytes
+    // into storage and an authorization `?` cannot bypass staged-blob cleanup.
+    let authz_update_preamble = if authorize {
         format!(
             "{load}autumn_web::authorization::authorize::<{pascal_name}>({state}, &session, \"update\", &current).await?;\n    ",
             load = load_current_stmt("current"),
@@ -3663,13 +3662,9 @@ use crate::schema::{schema_import};",
              //! resulting `Blob` on the record. An edit that doesn't re-upload preserves\n\
              //! the existing attachment.\n\
              //!\n\
-             //! SIZE CEILING with CSRF on (the prod-profile default): the CSRF middleware\n\
-             //! buffers the request body only up to ~2 MiB while scanning for the form\n\
-             //! token, so a zero-JS multipart upload larger than ~2 MiB is rejected with\n\
-             //! 403 (token not found in the truncated body) BEFORE the handler's\n\
-             //! `max_file_size_bytes`/413 check can run. For files above that ceiling, use\n\
-             //! the advanced presigned direct-upload path below (it doesn't route the file\n\
-             //! bytes through the CSRF-scanned form body).\n\
+             //! CSRF scans only a bounded prefix and then streams the complete body onward;\n\
+             //! this generated form places its token first, so the upload limit remains the\n\
+             //! configured `max_file_size_bytes` and oversized files retain their 413.\n\
              //!\n\
              //! The `storage` + `multipart` features are enabled on `autumn-web`\n\
              //! automatically; configure `[storage]` in `autumn.toml` (local disk for dev,\n\
@@ -5166,9 +5161,14 @@ fn render_live_reference_select(field: &Field, changeset_var: &str) -> String {
 fn cell_value_expr(field: &Field) -> String {
     let name = &field.name;
     match (field.nullable, field.kind) {
-        // Attachment: always Option<Blob>; show presence only, no Blob internals.
+        // Attachment: always Option<Blob>. Render non-sensitive stored metadata
+        // so a reloaded index/show view distinguishes the bound upload without
+        // exposing the backend's internal object key. Keep the value escaped
+        // through maud's ordinary `Render` path.
         (_, FieldKind::Attachment) => {
-            format!("if row.{name}.is_some() {{ \"attachment\" }} else {{ \"—\" }}")
+            format!(
+                "row.{name}.as_ref().map_or_else(|| \"—\".to_owned(), |blob| format!(\"{{}} ({{}} bytes)\", blob.content_type, blob.byte_size))"
+            )
         }
         (true, FieldKind::Bytea) => {
             format!(

--- a/autumn-cli/tests/integration/scaffold_form_for.rs
+++ b/autumn-cli/tests/integration/scaffold_form_for.rs
@@ -398,6 +398,10 @@ fn scaffold_attachment_emits_zero_js_multipart_handlers() {
         routes.contains(".save_to_blob_store(&*store, key).await?;"),
         "{routes}"
     );
+    assert!(
+        routes.contains("duplicate attachment field: image"),
+        "duplicate file parts must be rejected before a staged blob is overwritten: {routes}"
+    );
     assert!(routes.contains("multipart.next_field().await?"), "{routes}");
     // The parse span is wrapped in a single fallible block funneling every `?`
     // (next_field, save, bytes_limited, utf8, decode_form) to one cleanup path.
@@ -415,6 +419,19 @@ fn scaffold_attachment_emits_zero_js_multipart_handlers() {
         "{routes}"
     );
     assert!(routes.contains("new.image = image_blob;"), "{routes}");
+
+    // Reloaded index/show views render non-sensitive stored metadata rather
+    // than reducing every persisted attachment to the same generic label or
+    // exposing the backend object key (AC3).
+    assert!(
+        routes.contains("blob.content_type, blob.byte_size"),
+        "{routes}"
+    );
+    assert!(
+        routes.contains("CSRF scans only a bounded prefix")
+            && routes.contains("oversized files retain their 413"),
+        "the generated note must describe the streaming CSRF/upload-limit behavior: {routes}"
+    );
 
     // storage + multipart auto-enabled on autumn-web (AC7).
     let cargo = fs::read_to_string(project.join("Cargo.toml")).unwrap();
@@ -635,6 +652,16 @@ fn scaffold_attachment_cleans_up_saved_blob_on_early_return() {
     );
 
     let update = handler_body(&routes, "pub async fn update(", "pub async fn destroy(");
+    let authorize_at = update
+        .find("autumn_web::authorization::authorize::<Photo>")
+        .unwrap_or_else(|| panic!("missing update authorization:\n{update}"));
+    let save_at = update
+        .find("save_to_blob_store")
+        .unwrap_or_else(|| panic!("missing multipart save:\n{update}"));
+    assert!(
+        authorize_at < save_at,
+        "record authorization must run before an attachment update stores attacker-controlled bytes:\n{update}"
+    );
     let update_success_at = update
         .find("flash.success(\"Photo updated\")")
         .unwrap_or_else(|| panic!("missing update success in:\n{update}"));
@@ -642,17 +669,18 @@ fn scaffold_attachment_cleans_up_saved_blob_on_early_return() {
     // Cleanup guards every update early return that can occur after the first
     // blob is saved. Codex P2 centralized the parse span: the mid-loop save
     // failure, `next_field`, `bytes_limited`, the UTF-8 conversion, and
-    // `decode_form` collapse to ONE cleanup inside the parse block. The six
-    // post-parse returns keep their own cleanup: validation 422, the current-row
-    // load, `into_new`, the unique-violation 422, the generic DB `Err`, and the
-    // not-found (`updated == 0`) guard.
+    // `decode_form` collapse to ONE cleanup inside the parse block. The five
+    // post-parse returns keep their own cleanup: validation 422,
+    // `into_new`, the unique-violation 422, the generic DB `Err`, and the
+    // not-found (`updated == 0`) guard. Current-row load and authorization now
+    // happen before parsing, when there is no staged blob to clean up.
     assert_eq!(
         update_early
             .matches("let _ = store.delete(key).await;")
             .count(),
-        7,
-        "update must clean up the saved blob on all seven early-return sites \
-         (one central parse-span cleanup, plus validation, current-row load, into_new, \
+        6,
+        "update must clean up the saved blob on all six early-return sites \
+         (one central parse-span cleanup, plus validation, into_new, \
          unique-violation, DB error, not-found):\n{update}"
     );
     assert!(

--- a/docs/brainstorming-scaffolded-attachment-uploads-2026-08-02.md
+++ b/docs/brainstorming-scaffolded-attachment-uploads-2026-08-02.md
@@ -1,0 +1,115 @@
+# Scaffolded attachment uploads — issue #1236 plan
+
+## Boundary and specification
+
+The change is generator-only: newly generated HTML scaffolds with one or more
+`Attachment` fields must accept a browser multipart submission, stream file
+parts through `MultipartField::save_to_blob_store`, and bind the returned
+`Blob`. Non-attachment scaffolds and the public storage/extractor APIs remain
+unchanged.
+
+Observable invariants:
+
+1. Create binds each uploaded attachment, while an omitted optional file binds
+   `NULL`.
+2. Update binds a replacement or preserves the current blob when the file part
+   is empty/absent.
+3. Every saved blob is either committed with the row or best-effort deleted on
+   a later parse, validation, authorization, or database failure.
+4. Upload size failures retain the extractor's `413 Payload Too Large` mapping.
+5. Generated forms need only multipart encoding and a named file input; no
+   hidden storage key, presign endpoint, or JavaScript is part of the default.
+6. Reloaded views visibly identify the bound blob through non-sensitive metadata.
+
+This is generated Rust and does not introduce a new critical runtime algorithm
+or state representation, so a separate Verus model would duplicate template
+string tests without proving the generated integration boundary. Executable
+code-generation, generated-project compilation, and real local-blob-store tests
+are the appropriate proof boundary.
+
+## Brainstorming
+
+Candidate approaches considered:
+
+- Generate a presign endpoint and JavaScript uploader.
+- Buffer uploaded bytes in the route before writing storage.
+- Stream `MultipartField` directly into the configured `BlobStore` and rebuild
+  only the text fields for the existing form decoder.
+- Add a new public framework abstraction around attachment forms.
+
+The streaming approach reuses the shipped primitive, enforces configured size
+limits, works for local and S3 stores, and keeps the public API unchanged. The
+existing form decoder remains the single source of text-field semantics.
+
+## Reverse brainstorming
+
+Ways to make the scaffold fail or lose data deliberately:
+
+- Keep emitting a file input but decode the body as URL-encoded bytes.
+- Expect a hidden blob key that no generated JavaScript populates.
+- Replace an existing attachment with `NULL` on an empty edit submission.
+- Save the first of several files, then leak it when a later part is invalid.
+- Swallow the extractor's size error and return a generic `500`.
+- Generate code requiring undeclared `storage` or `multipart` features.
+- Persist a blob but render only an indistinguishable generic marker after
+  reload.
+
+Each failure mode maps to a generator assertion, cleanup-path test, real-store
+write-path test, or fresh-project compilation check.
+
+## Six hats review
+
+- **White (facts):** `save_to_blob_store` already streams and enforces the
+  configured cap; attachment columns are nullable `Option<Blob>`; browsers do
+  not repopulate file inputs.
+- **Red (user experience):** the plain generated form must work immediately and
+  an edit without a new upload must feel safe rather than destructive.
+- **Black (risks):** multipart parsing can fail after an earlier blob was saved;
+  authorization/validation/DB failures can orphan objects; extractor ordering
+  can make generated axum handlers fail to compile.
+- **Yellow (benefits):** zero handwritten upload code, backend-independent
+  storage, progressive enhancement, and a clear opt-in path for large direct
+  uploads.
+- **Green (alternatives):** rebuild URL-encoded text pairs to reuse validation,
+  generate unique per-field keys, and centralize cleanup around the whole
+  fallible parse span.
+- **Blue (process):** RED generator tests first; GREEN minimal template changes;
+  REFACTOR shared rendering/cleanup helpers; then format, lint, focused tests,
+  fresh-scaffold compilation, acceptance-criteria audit, and multi-angle review.
+
+## TDD execution
+
+### Red
+
+Extend the attachment scaffold integration test to require index/show output to
+identify the persisted blob. Confirm it fails against the generic
+`"attachment"` marker.
+
+### Green
+
+Render the stored content type and byte size for present attachment cells and
+an em dash for `NULL`, using maud's escaped value rendering.
+
+### Refactor and verification
+
+Keep the behavior in the shared `cell_value_expr` helper so index and show views
+cannot drift. Run formatting, focused generator tests, the ignored fresh-project
+compile test, clippy, and an affected-area stub scan. Review the final diff from
+correctness, security/data-integrity, testing, and generated-code/DX angles.
+
+## Review outcomes
+
+Independent correctness, security/data-integrity, and testing/DX reviews found
+that authorized updates previously stored multipart bytes before checking the
+record policy. The refactor now loads and authorizes the record before parsing,
+so a denied actor cannot consume blob storage and no authorization error can
+orphan a staged upload. Duplicate file parts for one field are rejected inside
+the centralized cleanup span, preventing overwrite-orphans. The generated note
+was also corrected to match the current bounded-prefix CSRF scanner, and views
+render non-sensitive blob metadata rather than internal storage keys.
+
+Successful replacement does not automatically delete the prior blob: `Blob`
+values can be intentionally shared and the framework has no ownership/refcount
+contract that makes deletion safe. Cleanup remains limited to newly staged,
+uncommitted objects; lifecycle reclamation requires an explicit ownership
+policy and is outside this generator-only issue.


### PR DESCRIPTION
### Motivation

- Make the scaffolded Attachment happy-path work end-to-end with zero JavaScript by emitting multipart handlers that stream files to the configured `BlobStore` and bind the returned `Blob` instead of requiring presign JS.
- Prevent data-loss and DoS/abuse vectors by ensuring staged blobs are cleaned up on early returns and that unauthorized actors cannot stream bytes into storage.

### Description

- Generator changes: `autumn-cli/src/generate/scaffold.rs` now emits `create`/`update` handlers that accept `mut multipart: autumn_web::extract::Multipart`, stream file parts via `MultipartField::save_to_blob_store`, record `saved_blob_keys` for best-effort cleanup, and bind the returned `Blob` into the model (`new.field = blob.or(current.field)` for updates).
- Safety hardening: duplicate file parts for the same attachment field are rejected during the centralized parse span, and record load + authorization are moved to run before multipart parsing on authorized update paths so a denied actor cannot persist staged uploads.
- Views and DX: generated index/show cell rendering for Attachment fields now shows non-sensitive stored metadata (content type + byte size) rather than a generic "attachment" marker or raw internal keys, and the generator note was corrected to explain the bounded-prefix CSRF scan and that oversized uploads still map to `413` (presigned direct uploads remain documented as the advanced opt-in path).
- Tests and docs: extended `autumn-cli/tests/integration/scaffold_form_for.rs` with focused assertions covering multipart emission, duplicate-field rejection, preserve-on-update, stored-metadata rendering, CSRF/413 guidance, authorization ordering, and cleanup coverage; added a durable planning document `docs/brainstorming-scaffolded-attachment-uploads-2026-08-02.md` recording the SPEC/RED/GREEN/REFACTOR plan, brainstorming, reverse-brainstorm, and six-hats review.

### Testing

- Ran `cargo fmt --all` successfully.
- Ran the focused integration suite: `cargo test -p autumn-cli --test cli_tests attachment -- --nocapture` and `cargo test -p autumn-cli --test cli_tests generated_attachment_scaffold_cargo_checks -- --ignored --nocapture`, which passed the new & updated tests (3 passed; the slow fresh-project check passed when invoked with `--ignored`).
- Verified multipart streaming and storage-limit behavior via existing `autumn-web` extractor tests (the `save_to_blob_store` 413 behavior is exercised by unit tests and retained).
- Performed `git diff --check` and inspected diffs; no new TODO/FIXME stubs were introduced in the affected area.
- Ran `cargo clippy -p autumn-cli --all-targets -- -D warnings`, which would pass for the changed files but is blocked by pre-existing `autumn-macros` lints (`similar_names` and `cognitive_complexity`) unrelated to this generator change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6eb8685d70832ab469bdc72b28c90f)