### PR TITLE
fix(sim): force fork/timeout off in the op-driver's embedded proptest runners

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -659,6 +659,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   is W5.a; it stacks on W5.0 and is a sibling of W5.b (item 6). [no-plugin]
 ### Fixed
 
+- **sim-testing:** the op-driver's embedded proptest runners
+  (`Sim::gen_ops_with`, `Sim::run_proptest`, #1797) no longer inherit ambient
+  `PROPTEST_FORK` / `PROPTEST_TIMEOUT` env vars from `Config::default()`.
+  Neither runner has a `test_name` to give proptest's forking machinery, so
+  inheriting fork mode panicked with "Must supply test_name when forking
+  enabled" before a single op could be generated; both configs now force fork
+  mode and the fork timeout off explicitly.
 - **mail:** the prod `deliver_later` durability guard no longer aborts app
   startup for applications that never call `deliver_later`/`deliver_later_eager`
   (#2142). Previously, `install_mailer` hard-failed at boot in `prod` whenever

--- a/autumn/src/sim/op.rs
+++ b/autumn/src/sim/op.rs
@@ -47,11 +47,15 @@
 //! separately, so none of these streams perturb each other). Same seed ⇒ same
 //! generated op sequence ⇒ same shrink path, byte-for-byte.
 //!
-//! [`Sim::run_proptest`] additionally disables proptest's own file-based
-//! failure persistence (`proptest-regressions/*.txt`): the sim harness's
-//! `AUTUMN_SIM_SEED=…` replay line is the single source of truth for
-//! reproducing a failure, so a second, proptest-owned persistence file would
-//! just be a redundant (and potentially stale) source of truth.
+//! Both also disable proptest's own file-based failure persistence
+//! (`proptest-regressions/*.txt`) — the sim harness's `AUTUMN_SIM_SEED=…`
+//! replay line is the single source of truth for reproducing a failure, so a
+//! second, proptest-owned persistence file would just be a redundant (and
+//! potentially stale) source of truth — and force off proptest's fork mode
+//! and fork timeout regardless of any ambient `PROPTEST_FORK` /
+//! `PROPTEST_TIMEOUT` env vars: both runners are owned in-process (there's no
+//! `test_name` to hand proptest's forking machinery), so inheriting fork mode
+//! would panic instead of generating ops.
 //!
 //! # Example
 //!
@@ -106,11 +110,23 @@ fn stream_rng(seed: u64, salt: u64) -> TestRng {
     TestRng::from_seed(RngAlgorithm::ChaCha, &bytes)
 }
 
-/// A [`Config`] with proptest's own file-based failure persistence disabled
-/// (see the module docs' "Determinism" section for why).
-fn config_without_persistence() -> Config {
+/// A [`Config`] for the embedded, in-process runners [`Sim::gen_ops_with`] and
+/// [`Sim::run_proptest`] own directly (as opposed to a runner `#[test]`-owned
+/// proptest picks up via `proptest!`/`#[proptest_derive]`).
+///
+/// Disables proptest's own file-based failure persistence (see the module
+/// docs' "Determinism" section for why) and, since [`Config::default`] also
+/// pulls in whatever `PROPTEST_FORK` / `PROPTEST_TIMEOUT` env vars happen to
+/// be set process-wide, forces fork mode and the fork timeout off — this
+/// runner has no `test_name` to give proptest's forking machinery, so
+/// inheriting fork mode from the environment would panic
+/// (`Must supply test_name when forking enabled`) before a single op could be
+/// generated.
+fn embedded_config() -> Config {
     Config {
         failure_persistence: None,
+        fork: false,
+        timeout: 0,
         ..Config::default()
     }
 }
@@ -146,7 +162,7 @@ impl Sim {
         T: fmt::Debug,
     {
         let mut runner =
-            TestRunner::new_with_rng(Config::default(), stream_rng(self.seed, OP_GEN_STREAM_SALT));
+            TestRunner::new_with_rng(embedded_config(), stream_rng(self.seed, OP_GEN_STREAM_SALT));
         strategy
             .new_tree(&mut runner)
             .expect("op strategy generation should not fail")
@@ -180,10 +196,8 @@ impl Sim {
         S: Strategy<Value = Vec<T>>,
         F: Fn(&mut Self, &[T]),
     {
-        let mut runner = TestRunner::new_with_rng(
-            config_without_persistence(),
-            stream_rng(seed, OP_GEN_STREAM_SALT),
-        );
+        let mut runner =
+            TestRunner::new_with_rng(embedded_config(), stream_rng(seed, OP_GEN_STREAM_SALT));
         let result = runner.run(&strategy, |ops| {
             let mut sim = Self::from_seed(seed);
             body(&mut sim, &ops);
@@ -250,6 +264,26 @@ mod tests {
         let after_rng_use = sim2.gen_ops_with(tiny_op_strategy());
 
         assert_eq!(baseline, after_rng_use);
+    }
+
+    #[test]
+    fn embedded_config_forces_fork_and_timeout_off() {
+        // `Config::default()` folds in whatever `PROPTEST_FORK`/`PROPTEST_TIMEOUT`
+        // env vars happen to be set process-wide (proptest's `contextualize_config`,
+        // cached process-lifetime via a `LazyLock` — not something a per-test env var
+        // override could exercise reliably here). Both embedded runners have no
+        // `test_name` to hand proptest's forking machinery, so inheriting fork mode
+        // would panic with "Must supply test_name when forking enabled" before a
+        // single op could be generated. Assert the override directly instead.
+        let config = embedded_config();
+        assert!(
+            !config.fork,
+            "the embedded op-driver runner must never fork — it has no test_name"
+        );
+        assert_eq!(
+            config.timeout, 0,
+            "the embedded op-driver runner has no fork timeout to honor"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Follow-up to #2158, addressing a post-merge review finding from the `chatgpt-codex-connector` bot on `autumn/src/sim/op.rs` (line 114, in `config_without_persistence`).

`Config::default()` folds in whatever `PROPTEST_FORK` / `PROPTEST_TIMEOUT` env vars happen to be set process-wide (proptest's `contextualize_config`). `Sim::gen_ops_with` and `Sim::run_proptest` each own a `TestRunner` in-process with no `test_name` to give proptest's forking machinery — so with `PROPTEST_FORK=true` set, `TestRunner::run` panicked with `Must supply test_name when forking enabled` before a single op could be generated.

- Replaces `config_without_persistence()` with a shared `embedded_config()` helper used by both `Sim::gen_ops_with` and `Sim::run_proptest` (previously only `run_proptest` disabled failure persistence; `gen_ops_with` used `Config::default()` directly and was equally exposed to the fork/timeout inheritance bug).
- `embedded_config()` explicitly forces `fork: false` and `timeout: 0` after the `..Config::default()` spread, so neither ambient env var can reach the embedded runner regardless of what `Config::default()` resolves to.
- Updates the module's "Determinism" docs to describe both runners' shared config behavior.
- New unit test `embedded_config_forces_fork_and_timeout_off` asserts the override directly — proptest's `DEFAULT_CONFIG` is cached process-lifetime behind a `LazyLock`, so a per-test env var override (`temp_env`) can't reliably exercise the original bug in-process; the fix was manually verified with `PROPTEST_FORK=true cargo test -p autumn-web --features sim-testing --test sim_op_driver` (passes now; panicked before the fix) and again with `PROPTEST_TIMEOUT=1000`.
- `CHANGELOG.md`: new bullet under `## [Unreleased]` → `### Fixed`.

## Test plan

- [x] `cargo build -p autumn-web --features "sqlite,sim-testing" --lib`
- [x] `cargo clippy -p autumn-web --features "sqlite,sim-testing" --lib -- -D warnings`
- [x] `PROPTEST_FORK=true cargo test -p autumn-web --features sim-testing --test sim_op_driver` (2 passed — panicked before the fix)
- [x] `PROPTEST_TIMEOUT=1000 cargo test -p autumn-web --features sim-testing --test sim_op_driver` (2 passed)
- [x] `cargo test -p autumn-web --features "sqlite,sim-testing" --lib sim::op` (6 passed, incl. the new regression test)
- [x] `cargo fmt --all -- --check`
- [x] `./scripts/check-docs.sh`-equivalent (`cargo doc -p autumn-web --no-deps` with the docs.rs feature set and `-D rustdoc::broken_intra_doc_links -D rustdoc::private_intra_doc_links`)