### PR TITLE
Render stored attachments in scaffolded show/edit views (#1236)

### DIFF
--- a/.github/workflows/generator-conformance.yml
+++ b/.github/workflows/generator-conformance.yml
@@ -202,6 +202,28 @@ jobs:
             integration::console::console_run_surfaces_a_compile_error_in_the_playground \
             -- --ignored --exact
 
+      # ── zero-JS attachment uploads (#1236) ──────────────────────────────
+      #
+      # The machine proof that a scaffolded `Attachment` column actually
+      # works: the first compiles a fresh attachment scaffold with only the
+      # auto-enabled `storage` + `multipart` features (AC7), the second
+      # COMPILES AND RUNS that project's generated test binary, so the
+      # emitted multipart create / 413 / NULL-column tests (AC4, AC6) are
+      # proven to pass rather than only string-matched. Same `cli_tests`
+      # caveat as the console block above — named explicitly or they never
+      # execute anywhere.
+      - name: generated_attachment_scaffold_cargo_checks
+        run: |
+          cargo test -p autumn-cli --test cli_tests \
+            integration::scaffold_form_for::generated_attachment_scaffold_cargo_checks \
+            -- --ignored --exact
+
+      - name: generated_attachment_scaffold_multipart_test_passes
+        run: |
+          cargo test -p autumn-cli --test cli_tests \
+            integration::scaffold_form_for::generated_attachment_scaffold_multipart_test_passes \
+            -- --ignored --exact
+
   # ── Generated-app variant conformance matrix ────────────────────────────────
   #
   # One matrixed job that scaffolds a fresh project in a specific "variant"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -592,7 +592,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   inside `security.csrf.token_scan_bytes` however large the upload is. The note
   now names the real limits (`max_file_size_bytes` → 413,
   `max_request_size_bytes` → global body cap). The index list stays a cheap
-  presence marker (its `data_table` column closure is sync and per row).
+  presence marker (`widgets::Column`'s cell closure is synchronous and
+  `presigned_url` is async, so there is nowhere to await it).
+
+  Follow-ups from the review of that work, in the same slice: the `show` handler
+  now runs the record policy before it renders — the link it emits is a signed
+  bearer capability for the bytes, and the blob-serving route validates that
+  signature alone, so disclosing one from a handler that never consults
+  `can_show` would have made the generated policy's "tighten this if shows
+  should be gated" comment untrue (a no-op under the default policy, which
+  allows reads); the minted blob key now carries a sanitized extension derived
+  from the uploaded filename, so a download opens in the right application
+  instead of landing as an extensionless `1785…_5cf1a2be-…`; a failure to sign
+  logs a warning instead of silently degrading to a link-less name; and
+  generating an `Attachment` column now warns when `autumn.toml` has no
+  `[storage]` section, since `backend` defaults to `disabled` and the first
+  upload would otherwise answer `500 storage not configured`. The two
+  `#[ignore]`d gates that compile — and run — a freshly scaffolded project are
+  wired into `generator-conformance.yml`; the consolidated `cli_tests` binary's
+  only other CI `--ignored` sweep filters on `offsite`, so without that they
+  never executed anywhere. `autumn-field__current` / `autumn-attachment__meta`
+  are now real classes in `widgets.css` rather than invented ones, and
+  `docs/guide/storage.md` documents the scaffolded no-JS path and frames
+  presigned direct upload as the opt-in advanced alternative.
+
   Generator-only; no `autumn-web` API change.
 
 - **jobs:** routed the job runtime's recorded timestamps (enqueued_at/started_at/finished_at, due-at filtering, and the backoff-delay computation) through the injected `ClockSource` seam instead of reading `Utc::now()` directly, so recorded job timestamps are deterministic under the sim harness (production defaults to `SystemClock`, behavior unchanged). The in-memory/sim job path is now fully deterministic; the Postgres durable path still uses server-side SQL `NOW()` (#2111). [no-plugin]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -616,6 +616,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `docs/guide/storage.md` documents the scaffolded no-JS path and frames
   presigned direct upload as the opt-in advanced alternative.
 
+  From the PR review: `attachment_url` refuses to issue a URL at all for content
+  a browser would execute as same-origin script. The local backend serves blobs
+  from the app's own origin, replaying the content type they were uploaded under
+  with no `Content-Disposition`, and the default CSP allows `script-src 'self'`
+  — so a stored `text/html` or `image/svg+xml` reached by direct *navigation*
+  would run with the visitor's cookies, and an anchor's `download` attribute
+  governs clicks on that anchor rather than navigation to the URL. The generated
+  `LINKABLE_CONTENT_TYPES` is fail-closed and covers the types a scaffold is
+  actually used for (images, PDF, plain text, media, archives, office
+  documents); anything else still renders on the page, just without a link. It
+  also compares `blob.provider_id` against the configured store before signing,
+  so a blob left over from a previous backend degrades to the no-link path
+  instead of linking to a nonexistent object — or to unrelated bytes that happen
+  to share its key.
+
   Generator-only; no `autumn-web` API change.
 
 - **jobs:** routed the job runtime's recorded timestamps (enqueued_at/started_at/finished_at, due-at filtering, and the backoff-delay computation) through the injected `ClockSource` seam instead of reading `Utc::now()` directly, so recorded job timestamps are deterministic under the sim harness (production defaults to `SystemClock`, behavior unchanged). The in-memory/sim job path is now fully deterministic; the Postgres durable path still uses server-side SQL `NOW()` (#2111). [no-plugin]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -568,6 +568,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **generate:** finished the zero-JS file-upload slice (#1236) on the read-back
+  side. A scaffold with an `Attachment` column now *shows* what it stored: the
+  generated `show` and edit views resolve a signed, time-bounded URL through the
+  configured `BlobStore` (`attachment_url`) and render a download link
+  (`attachment_link`) instead of the literal word "attachment", degrading to the
+  stored file's name when no `[storage]` backend is configured. The edit form
+  additionally labels the currently stored file above the file input — a file
+  `<input>` can't be repopulated, so without it there was no way to tell an
+  empty column from one holding a blob you simply didn't replace — and it
+  renders identically on the 422 re-render, which is why `update` now loads the
+  current row *before* validating (that also runs the record policy before the
+  form is handed back, and the policy denial joins the #1872 blob-cleanup paths
+  so a forbidden update no longer orphans the just-uploaded file). The generated
+  write-path test grew the two AC4 cases — an upload over
+  `security.upload.max_file_size_bytes` is rejected with `413`, and a submit
+  with no file leaves the optional column `NULL` — and a new (`#[ignore]`d)
+  gate compiles *and runs* a freshly scaffolded project's test binary, so the
+  emitted tests are proven to pass rather than only string-matched. Finally, the
+  generated handler note dropped a false "~2 MiB CSRF size ceiling" warning that
+  pushed authors back onto the JavaScript presign path: `form_for` renders the
+  CSRF and submit-token hidden inputs as the form's *first* fields, so both land
+  inside `security.csrf.token_scan_bytes` however large the upload is. The note
+  now names the real limits (`max_file_size_bytes` → 413,
+  `max_request_size_bytes` → global body cap). The index list stays a cheap
+  presence marker (its `data_table` column closure is sync and per row).
+  Generator-only; no `autumn-web` API change.
+
 - **jobs:** routed the job runtime's recorded timestamps (enqueued_at/started_at/finished_at, due-at filtering, and the backoff-delay computation) through the injected `ClockSource` seam instead of reading `Utc::now()` directly, so recorded job timestamps are deterministic under the sim harness (production defaults to `SystemClock`, behavior unchanged). The in-memory/sim job path is now fully deterministic; the Postgres durable path still uses server-side SQL `NOW()` (#2111). [no-plugin]
 
 - **admin-plugin:** made the core connection surface backend-agnostic so

--- a/autumn-cli/src/generate/scaffold.rs
+++ b/autumn-cli/src/generate/scaffold.rs
@@ -2028,17 +2028,6 @@ fn render_routes_file(
     // binds `AppState` directly via the injected `State(state)`.
     let create_update_state_expr = if has_attachments { "&*state" } else { "&state" };
     let edit_destroy_state_expr = "&state";
-    // The attachment `update` handler loads `current` after parsing the multipart
-    // body (to preserve un-replaced blobs); record-authorize the actor against
-    // that same already-loaded row before writing, instead of a second load.
-    // Spliced into `update_new_block` right after its `current` load.
-    let authz_attachment_update = if authorize && has_attachments {
-        format!(
-            "autumn_web::authorization::authorize::<{pascal_name}>({create_update_state_expr}, &session, \"update\", &current).await?;\n    "
-        )
-    } else {
-        String::new()
-    };
     // Every PRESENT `references` field (its target model — and so its
     // `src/schema.rs` entry — is in the project; `missing_reference_targets`
     // excludes the rest, which the caller already warned about and which fall
@@ -2350,6 +2339,154 @@ fn render_routes_file(
     // splice into the handler templates in place of the plain `let form = …` /
     // `let new = …` lines.
     let attachment_fields: Vec<&Field> = fields.iter().filter(|f| f.kind.is_attachment()).collect();
+
+    // Issue #1236 (AC3, read-back half): a scaffold that streams uploads to the
+    // blob store also has to show what it stored. A `Blob` records the store key,
+    // media type and byte size — not a browser-reachable URL — so the show/edit
+    // views resolve a signed, time-bounded one through the configured
+    // `BlobStore`: the local backend signs a `/_blobs` link, S3 returns a
+    // presigned GET. An app with no `[storage]` backend (or a backend that
+    // refuses to sign) degrades to the stored file's name without a link rather
+    // than failing the whole page.
+    let attachment_read_back_helpers = if has_attachments {
+        format!(
+            "\n/// Signed, time-bounded URL for a stored attachment (issue #1236).\n\
+             ///\n\
+             /// `None` when the column is NULL or the app has no `[storage]` backend\n\
+             /// configured — `attachment_link` then renders the stored file's name\n\
+             /// without a link. Widen or narrow the link's validity window by changing\n\
+             /// the {ATTACHMENT_URL_TTL_SECS}-second expiry below.\n\
+             async fn attachment_url(\n    \
+             state: &autumn_web::AppState,\n    \
+             blob: Option<&autumn_web::storage::Blob>,\n\
+             ) -> Option<String> {{\n    \
+             let blob = blob?;\n    \
+             let store = state\n        \
+             .extension::<autumn_web::storage::BlobStoreState>()?\n        \
+             .store()\n        \
+             .clone();\n    \
+             store\n        \
+             .presigned_url(&blob.key, std::time::Duration::from_secs({ATTACHMENT_URL_TTL_SECS}))\n        \
+             .await\n        \
+             .ok()\n\
+             }}\n\n\
+             /// Render a stored attachment: a download link when a signed URL is\n\
+             /// available, the stored file's name alone when it isn't, and an em dash\n\
+             /// when the column is NULL.\n\
+             ///\n\
+             /// The link carries `download` deliberately. With the local backend the\n\
+             /// blob is served from this app's own origin with the content type it was\n\
+             /// uploaded under, so a click that NAVIGATED to an uploaded `.html`/`.svg`\n\
+             /// would run it as same-origin script; `download` makes the browser save\n\
+             /// the file instead. Serving user uploads from a separate origin (or an\n\
+             /// S3 presigned URL, where `download` is moot) avoids the question\n\
+             /// entirely. Restrict what can be uploaded with\n\
+             /// `security.upload.allowed_mime_types`.\n\
+             fn attachment_link(blob: Option<&autumn_web::storage::Blob>, url: Option<&str>) -> Markup {{\n    \
+             let Some(blob) = blob else {{\n        \
+             return html! {{ \"—\" }};\n    \
+             }};\n    \
+             let name = blob.key.rsplit('/').next().unwrap_or(blob.key.as_str());\n    \
+             html! {{\n        \
+             @if let Some(url) = url {{\n            \
+             a href=(url) rel=\"noopener\" download=(name) {{ (name) }}\n        \
+             }} @else {{\n            \
+             span {{ (name) }}\n        \
+             }}\n        \
+             \" \"\n        \
+             span class=\"autumn-attachment__meta\" {{ \"(\" (blob.content_type) \", \" (blob.byte_size) \" bytes)\" }}\n    \
+             }}\n\
+             }}\n"
+        )
+    } else {
+        String::new()
+    };
+
+    // The `show` detail page resolves one signed URL per attachment column
+    // before building its property list. The list index deliberately does NOT:
+    // its `data_table` column closure is synchronous and runs per row, so a
+    // signed URL there would mean one round-trip per row per page.
+    // Two spellings of the same binds: the `show` handler owns a `State<_>`
+    // wrapper (`&state`), while the state-machine `show_view` helper is handed
+    // an already-borrowed `&AppState` (`state`).
+    let mut show_attachment_url_binds = String::new();
+    let mut show_view_attachment_url_binds = String::new();
+    for f in &attachment_fields {
+        let name = &f.name;
+        let _ = writeln!(
+            show_attachment_url_binds,
+            "    let {name}_url = attachment_url(&state, row.{name}.as_ref()).await;"
+        );
+        let _ = writeln!(
+            show_view_attachment_url_binds,
+            "    let {name}_url = attachment_url(state, row.{name}.as_ref()).await;"
+        );
+    }
+    // `show` has no `State` extractor of its own (it never authorizes), so an
+    // attachment scaffold adds one. Deref coercion at the call site means the
+    // same `attachment_url(&state, …)` works whether `state` is a `State<_>`
+    // wrapper (here) or an already-destructured `AppState` (the authorized
+    // handlers).
+    let show_state_param = if has_attachments {
+        ", state: autumn_web::extract::State<autumn_web::AppState>"
+    } else {
+        ""
+    };
+    let show_state_param_line = if has_attachments {
+        "\n    state: autumn_web::extract::State<autumn_web::AppState>,"
+    } else {
+        ""
+    };
+    // The state-machine variant renders through a shared `show_view` helper
+    // called by `show` and by each transition handler's 422 re-render, so the
+    // state travels as a plain `&AppState` argument. `&state` coerces to it from
+    // either binding shape — the `State<_>` wrapper `show` takes, or the
+    // already-destructured `AppState` the authorize wiring injects.
+    let (show_view_state_param, show_view_state_arg_call) = if has_attachments {
+        ("\n    state: &autumn_web::AppState,", ", &state")
+    } else {
+        ("", "")
+    };
+
+    // The edit form shows which file is already stored: a file `<input>` can't
+    // be repopulated (browser security), so without this the author has no way
+    // to tell an empty column from one holding a blob they simply didn't
+    // replace. Both live in the SHARED edit body, so `GET /{plural}/{id}/edit`
+    // and every 422 re-render of that form show the same thing — which is why
+    // `update` loads `current` before validating (see `update_load_current_block`).
+    //
+    // The shared body reads the row through a binding named `current` — the name
+    // `update` already uses — so `edit_form` renames its own loaded row to match
+    // once the changeset has been seeded from it.
+    let edit_current_bind = if has_attachments {
+        "let current = row;\n    "
+    } else {
+        ""
+    };
+    // `edit_form` authorizes by default and so already owns a destructured
+    // `state`; `--no-policy` scaffolds add their own wrapper.
+    let edit_form_state_param = if has_attachments && !authorize {
+        "\n    state: autumn_web::extract::State<autumn_web::AppState>,"
+    } else {
+        ""
+    };
+    let mut edit_attachment_url_loads = String::new();
+    let mut edit_current_attachment_markup = String::new();
+    for f in &attachment_fields {
+        let name = &f.name;
+        let label = humanize_label(name);
+        let _ = writeln!(
+            edit_attachment_url_loads,
+            "        let {name}_url = attachment_url(&state, current.{name}.as_ref()).await;"
+        );
+        let _ = write!(
+            edit_current_attachment_markup,
+            "@if let Some(blob) = current.{name}.as_ref() {{\n            \
+             p class=\"autumn-field__current\" {{ \"Current {label}: \" (attachment_link(Some(blob), {name}_url.as_deref())) }}\n        \
+             }}\n        "
+        );
+    }
+
     // Issue #1872: the create/update handlers stream each uploaded file to the
     // blob store *before* changeset validation and the DB write, so any early
     // return after the save would orphan the just-uploaded blob. We record only
@@ -2374,6 +2511,19 @@ fn render_routes_file(
         "for key in &saved_blob_keys {\n        let _ = store.delete(key).await;\n    }\n    "
     } else {
         ""
+    };
+    // Issue #1872 follow-on: this check sits *after* the uploaded file was
+    // streamed to the store, so a plain `?` here would orphan the blob whenever
+    // the record policy denies the actor. It gets the same cleanup-then-return
+    // treatment as every other post-save early return.
+    let authz_attachment_update = if authorize && has_attachments {
+        format!(
+            "if let Err(err) = autumn_web::authorization::authorize::<{pascal_name}>({create_update_state_expr}, &session, \"update\", &current).await {{\n        \
+             {blob_cleanup}return Err(err);\n    \
+             }}\n    "
+        )
+    } else {
+        String::new()
     };
     let form_decode_block = if has_attachments {
         let mut blob_decls = String::new();
@@ -2478,7 +2628,13 @@ fn render_routes_file(
     // stored attachment intact instead of nulling it. The current row is loaded
     // through the same handle the update statement uses (repository on the live
     // path, sharded repo on the sharded path, diesel otherwise).
-    let update_new_block = if has_attachments {
+    //
+    // Issue #1236 (AC3): the load is spliced in BEFORE the validation guard, not
+    // after it, because every 422 re-render of the edit form has to show which
+    // file is currently stored (a file input can't be repopulated). Loading first
+    // also runs the record policy before the re-render, so a forbidden actor is
+    // denied instead of being handed the form back.
+    let (update_load_current_block, update_new_block) = if has_attachments {
         // Issue #1872: loading the current row also happens after the blob save,
         // so its fallible steps clean up the just-saved blob(s) before returning.
         let load_current = if live && !sharded {
@@ -2523,11 +2679,20 @@ fn render_routes_file(
         let mut binds = String::new();
         for f in &attachment_fields {
             let name = &f.name;
-            let _ = write!(binds, "\n    new.{name} = {name}_blob.or(current.{name});");
+            // `.clone()` rather than a move: `current` stays whole so the
+            // unique-violation 422 further down can still render the currently
+            // stored attachment from it (issue #1236, AC3).
+            let _ = write!(
+                binds,
+                "\n    new.{name} = {name}_blob.or(current.{name}.clone());"
+            );
         }
-        format!("{load_current}{authz_attachment_update}{into_new_bind}{binds}")
+        (
+            format!("{load_current}{authz_attachment_update}"),
+            format!("{into_new_bind}{binds}"),
+        )
     } else {
-        format!("let new = {into_new_call};")
+        (String::new(), format!("let new = {into_new_call};"))
     };
 
     // Shared re-render bodies: the same `layout(...)` markup the GET handlers
@@ -2588,6 +2753,7 @@ fn render_routes_file(
         let edit_form_layout = format!(
             "{layout_fn}(&format!(\"Edit {pascal_name} #{{}}\", *id), {cp_edit}{flash_arg}, html! {{\n        \
              h1 {{ \"Edit {pascal_name} #\" (*id) }}\n        \
+             {edit_current_attachment_markup}\
              form action=(paths::update(*id)) method=\"post\"{form_enctype} {{\n            \
              (csrf_input(csrf.as_ref(), csrf_field.as_ref()))\n            \
              (submit_token_input(submit_token.as_ref(), submit_field.as_ref()))\n{changeset_inputs}            \
@@ -2599,10 +2765,20 @@ fn render_routes_file(
              }}\n    \
              }})"
         );
-        let (new_form_body, edit_form_body) = if has_reference_selects {
+        // The edit body additionally resolves a signed URL per attachment column
+        // (issue #1236). Both bodies become block expressions as soon as either
+        // kind of prelude is needed, so the same string splices into the GET
+        // handlers and the 422 re-renders unchanged.
+        let (new_form_body, edit_form_body) = if has_reference_selects || has_attachments {
             (
-                format!("{{\n{option_loads}        {new_form_layout}\n    }}"),
-                format!("{{\n{option_loads}        {edit_form_layout}\n    }}"),
+                if has_reference_selects {
+                    format!("{{\n{option_loads}        {new_form_layout}\n    }}")
+                } else {
+                    new_form_layout
+                },
+                format!(
+                    "{{\n{option_loads}{edit_attachment_url_loads}        {edit_form_layout}\n    }}"
+                ),
             )
         } else {
             (new_form_layout, edit_form_layout)
@@ -2646,6 +2822,7 @@ fn render_routes_file(
         let edit_form_layout = format!(
             "{layout_fn}(&format!(\"Edit {pascal_name} #{{}}\", *id), {cp_edit}{flash_arg}, html! {{\n        \
              h1 {{ \"Edit {pascal_name} #\" (*id) }}\n        \
+             {edit_current_attachment_markup}\
              ({snake_name}_form_for(&changeset, paths::update(*id), \"Save\", csrf.as_ref(), csrf_field.as_ref(), submit_token.as_ref(), submit_field.as_ref(){option_args}{form_exclude_edit}))\n        \
              form action=(paths::delete(*id)) method=\"post\" {{\n            \
              (csrf_input(csrf.as_ref(), csrf_field.as_ref()))\n            \
@@ -2653,10 +2830,20 @@ fn render_routes_file(
              }}\n    \
              }})"
         );
-        let (new_form_body, edit_form_body) = if has_reference_selects {
+        // The edit body additionally resolves a signed URL per attachment column
+        // (issue #1236). Both bodies become block expressions as soon as either
+        // kind of prelude is needed, so the same string splices into the GET
+        // handlers and the 422 re-renders unchanged.
+        let (new_form_body, edit_form_body) = if has_reference_selects || has_attachments {
             (
-                format!("{{\n{option_loads}        {new_form_layout}\n    }}"),
-                format!("{{\n{option_loads}        {edit_form_layout}\n    }}"),
+                if has_reference_selects {
+                    format!("{{\n{option_loads}        {new_form_layout}\n    }}")
+                } else {
+                    new_form_layout
+                },
+                format!(
+                    "{{\n{option_loads}{edit_attachment_url_loads}        {edit_form_layout}\n    }}"
+                ),
             )
         } else {
             (new_form_layout, edit_form_layout)
@@ -2885,6 +3072,7 @@ fn render_routes_file(
          use autumn_web::reexports::axum::response::IntoResponse as _;\n    \
          {authz_update_preamble}\
          {form_decode_block}\n    \
+         {update_load_current_block}\
          let changeset = form.into_changeset();\n    \
          if !changeset.is_valid() {{\n        \
          {blob_cleanup}return Ok((autumn_web::reexports::http::StatusCode::UNPROCESSABLE_ENTITY, {edit_form_body}).into_response());\n    \
@@ -3658,18 +3846,18 @@ use crate::schema::{schema_import};",
              //! JavaScript: the generated `<form>` sets `enctype=\"multipart/form-data\"`,\n\
              //! and the `create`/`update` handlers accept an `autumn_web::extract::Multipart`\n\
              //! body, stream each file part straight to the configured blob store with\n\
-             //! `MultipartField::save_to_blob_store` (which enforces\n\
-             //! `security.upload.max_file_size_bytes`, default 16 MiB), and persist the\n\
-             //! resulting `Blob` on the record. An edit that doesn't re-upload preserves\n\
-             //! the existing attachment.\n\
+             //! `MultipartField::save_to_blob_store`, and persist the resulting `Blob` on\n\
+             //! the record. An edit that doesn't re-upload preserves the existing\n\
+             //! attachment, and the show/edit views render the stored file through a\n\
+             //! signed, time-bounded URL (`attachment_url`/`attachment_link` below).\n\
              //!\n\
-             //! SIZE CEILING with CSRF on (the prod-profile default): the CSRF middleware\n\
-             //! buffers the request body only up to ~2 MiB while scanning for the form\n\
-             //! token, so a zero-JS multipart upload larger than ~2 MiB is rejected with\n\
-             //! 403 (token not found in the truncated body) BEFORE the handler's\n\
-             //! `max_file_size_bytes`/413 check can run. For files above that ceiling, use\n\
-             //! the advanced presigned direct-upload path below (it doesn't route the file\n\
-             //! bytes through the CSRF-scanned form body).\n\
+             //! SIZE LIMITS: a file part larger than `security.upload.max_file_size_bytes`\n\
+             //! (default 16 MiB) is rejected with 413, and a request larger than\n\
+             //! `security.upload.max_request_size_bytes` (default 32 MiB) is rejected by\n\
+             //! the global body cap. CSRF adds no ceiling of its own: the generated form\n\
+             //! renders the CSRF and submit-token hidden inputs as its FIRST fields, so\n\
+             //! the browser sends them well inside `security.csrf.token_scan_bytes`\n\
+             //! however large the upload is — keep them first if you hand-edit the form.\n\
              //!\n\
              //! The `storage` + `multipart` features are enabled on `autumn-web`\n\
              //! automatically; configure `[storage]` in `autumn.toml` (local disk for dev,\n\
@@ -3773,9 +3961,9 @@ async fn show_view(
     row: &{pascal_name},
     flash: Markup,
     csrf: Option<&CsrfToken>,
-    csrf_field: Option<&CsrfFormField>,
+    csrf_field: Option<&CsrfFormField>,{show_view_state_param}
 ) -> AutumnResult<Markup> {{
-{show_label_loads}    let props: Vec<(&str, maud::Markup)> = vec![
+{show_label_loads}{show_view_attachment_url_binds}    let props: Vec<(&str, maud::Markup)> = vec![
 {show_rows}    ];
     Ok({layout_fn}(&format!("{pascal_name} #{{}}", row.id), {cp_show}flash, html! {{
         h1 {{ "{pascal_name} #" (row.id) }}
@@ -3794,7 +3982,7 @@ pub async fn show(
     mut db: {db_ty},
     flash: Flash,
     csrf: Option<CsrfToken>,
-    csrf_field: Option<CsrfFormField>,
+    csrf_field: Option<CsrfFormField>,{show_state_param_line}
 ) -> AutumnResult<Markup> {{
     let row: {pascal_name} = {plural}::table
         .find(*id)
@@ -3802,7 +3990,7 @@ pub async fn show(
         .first(&mut *db)
         .await
         .map_err(AutumnError::not_found)?;
-    show_view(db, &row, {flash_arg}, csrf.as_ref(), csrf_field.as_ref()).await
+    show_view(db, &row, {flash_arg}, csrf.as_ref(), csrf_field.as_ref(){show_view_state_arg_call}).await
 }}"#
             );
             // Issue #1326 security fix (IDOR): a transition mutates an existing
@@ -3817,8 +4005,14 @@ pub async fn show(
             // `state`, so there is no attachment-reuse concern) and `&state` as the
             // `AppState` receiver. When policy wiring is off it emits nothing, so
             // the handler is exactly `id/db/flash/csrf/body` as before.
+            // Issue #1236: with attachments the shared `show_view` needs the app
+            // state to sign the stored file's URL. The authorize wiring already
+            // injects one; without it (`--no-policy`) the transition handler adds
+            // its own, and either binding shape coerces to `&AppState`.
             let transition_authz_params = if authorize {
                 "    autumn_web::extract::State(state): autumn_web::extract::State<autumn_web::AppState>,\n    session: autumn_web::session::Session,\n"
+            } else if has_attachments {
+                "    state: autumn_web::extract::State<autumn_web::AppState>,\n"
             } else {
                 ""
             };
@@ -3873,7 +4067,7 @@ pub async fn transition_{field}(
                 &row,
                 flash_messages(&flash.consume().await),
                 csrf.as_ref(),
-                csrf_field.as_ref(),
+                csrf_field.as_ref(){show_view_state_arg_call},
             )
             .await?;
             Ok((autumn_web::reexports::http::StatusCode::UNPROCESSABLE_ENTITY, view).into_response())
@@ -3893,14 +4087,14 @@ pub async fn transition_{field}(
 
 /// `GET /{plural}/{{id}}` — show one {snake_name}.
 #[get("/{plural}/{{id}}")]
-pub async fn show(id: Path<{id_rust}>, mut db: {db_ty}, flash: Flash) -> AutumnResult<Markup> {{
+pub async fn show(id: Path<{id_rust}>, mut db: {db_ty}, flash: Flash{show_state_param}) -> AutumnResult<Markup> {{
     let row: {pascal_name} = {plural}::table
         .find(*id)
         .select({pascal_name}::as_select())
         .first(&mut *db)
         .await
         .map_err(AutumnError::not_found)?;
-{show_label_loads}    let props: Vec<(&str, maud::Markup)> = vec![
+{show_label_loads}{show_attachment_url_binds}    let props: Vec<(&str, maud::Markup)> = vec![
 {show_rows}    ];
     Ok({layout_fn}(&format!("{pascal_name} #{{}}", row.id), {cp_show}{flash_arg}, html! {{
         h1 {{ "{pascal_name} #" (row.id) }}
@@ -3938,7 +4132,7 @@ fn submit_token_input(submit_token: Option<&SubmitToken>, field: Option<&SubmitF
         }}
     }}
 }}
-{private_layout}
+{attachment_read_back_helpers}{private_layout}
 {index_handler}{show_section}
 /// `GET /{plural}/new` — render the new-{snake_name} form.
 #[secured]
@@ -3968,7 +4162,7 @@ pub async fn edit_form(
     csrf: Option<CsrfToken>,
     csrf_field: Option<CsrfFormField>,
     submit_token: Option<SubmitToken>,
-    submit_field: Option<SubmitFormField>,{edit_destroy_authz_params}
+    submit_field: Option<SubmitFormField>,{edit_destroy_authz_params}{edit_form_state_param}
 ) -> AutumnResult<Markup> {{
     let row: {pascal_name} = {plural}::table
         .find(*id)
@@ -3977,7 +4171,7 @@ pub async fn edit_form(
         .await
         .map_err(AutumnError::not_found)?;
     {authz_edit_call}let changeset = Changeset::new({pascal_name}Form::from(&row));
-    Ok({edit_form_body})
+    {edit_current_bind}Ok({edit_form_body})
 }}
 
 {update_fn}
@@ -4089,6 +4283,11 @@ fn render_update_changeset_expr(pascal_name: &str, fields: &[Field]) -> String {
     out
 }
 
+/// Validity window of the signed attachment URLs the scaffolded show/edit views
+/// render (issue #1236). Long enough to browse a detail page and click through
+/// to the file, short enough that a copied link isn't a durable capability.
+const ATTACHMENT_URL_TTL_SECS: u64 = 300;
+
 /// Whether any field in `fields` is a file attachment.
 fn has_attachment_fields(fields: &[Field]) -> bool {
     fields.iter().any(|f| f.kind.is_attachment())
@@ -4142,14 +4341,15 @@ fn render_form_model_impl(pascal_name: &str) -> String {
 /// - decimal columns pin the browser `step` to the column's declared scale
 ///   (the derive emits a free `step="any"`, losing the column's actual
 ///   smallest representable increment);
-/// - attachment columns are excluded from the derived list and re-appended
-///   as a hand-rolled file input plus a hidden input carrying the existing
-///   blob key — a file input can't be repopulated, and `FieldControl::File`
-///   would flip the form to `multipart/form-data` while scaffold forms stay
-///   URL-encoded (uploads go through direct-upload URLs; see
-///   docs/guide/storage.md#direct-uploads). The appended markup renders the
+/// - attachment columns are promoted to `FieldControl::File` (issue #1236).
+///   The derive sees an opaque `Blob` column and falls back to a text control;
+///   the override renders a plain `<input type="file">` (no hidden presign
+///   key) and flips the whole form to `enctype="multipart/form-data"`, which
+///   is what makes the zero-JavaScript upload work on submit. It renders the
 ///   same inline-error/ARIA skeleton as the derived controls, so changeset
-///   errors on the attachment key still surface;
+///   errors on the attachment still surface. A file input can't be
+///   repopulated, so the *currently stored* attachment is rendered next to it
+///   by the edit view (see `attachment_link`);
 /// - `references` columns are promoted to a `Select` over the referenced
 ///   table's ids (issue #1135 AC 2). The options are runtime data, so the
 ///   helper takes one `{column}_options: &[(String, String)]` parameter per
@@ -5301,6 +5501,13 @@ fn render_show_property_rows(
         let label = humanize(&f.name);
         let cell_expr = if f.kind.is_reference() && reference_displays.contains_key(&f.name) {
             format!("{}_label", f.name)
+        } else if f.kind.is_attachment() {
+            // Issue #1236: the detail page renders the file the record actually
+            // references — a download link through the signed URL the handler
+            // resolved into `{name}_url` — instead of the index's cheap
+            // presence marker. See `attachment_link` in the generated routes.
+            let name = &f.name;
+            format!("attachment_link(row.{name}.as_ref(), {name}_url.as_deref())")
         } else if f.kind.is_rich_text() {
             // Issue #1255: the column stores user-submitted Markdown SOURCE, so
             // the show page renders it through `render_user_content` — raw-HTML
@@ -5856,7 +6063,7 @@ fn render_smoke_test(
     // `LocalBlobStore`, persists the returned `Blob` in a real Postgres row, and
     // asserts the persisted attachment column bound a non-empty blob key.
     let base = if !api && has_attachment_fields(fields) {
-        base + &render_attachment_multipart_write_path_smoke_test(plural, fields)
+        base + &render_attachment_multipart_write_path_smoke_test(pascal_name, plural, fields)
     } else {
         base
     };
@@ -6286,28 +6493,78 @@ async fn __PLURAL___write_path_crud() {
 /// project's own routes) that runs the SAME blob path the generated `create`
 /// handler runs.
 #[allow(clippy::too_many_lines)] // the emitted test body is one raw-string template
-fn render_attachment_multipart_write_path_smoke_test(plural: &str, fields: &[Field]) -> String {
+fn render_attachment_multipart_write_path_smoke_test(
+    pascal_name: &str,
+    plural: &str,
+    fields: &[Field],
+) -> String {
     const TEMPLATE: &str = r#"
 
-// ── multipart attachment write-path (issue #1236, AC6) ─────────────────────
+// ── multipart attachment write-path (issue #1236) ──────────────────────────
 //
 // Follows the #1127 in-process write-path style (a process-local stand-in for
-// the persistence layer, no database required, so it runs without Docker): a
-// zero-JS `multipart/form-data` create drives the REAL `Multipart` extractor
-// and the REAL `save_to_blob_store` against a REAL `LocalBlobStore`, binds the
-// returned `Blob` on the record, and asserts the persisted record's attachment
-// column holds a non-empty blob key AND that the uploaded bytes actually landed
-// in the store at that key. The handler is an in-test stand-in (a `tests/`
-// binary cannot import the project's own routes) that runs the SAME blob path
-// the generated `create` handler runs. `TestApp::new()` disables CSRF, so the
-// hand-built body carries no `_csrf` part (the real prod form injects one).
+// the persistence layer, no database required, so these run without Docker):
+// a zero-JS `multipart/form-data` create drives the REAL `Multipart` extractor
+// and the REAL `save_to_blob_store` against a REAL `LocalBlobStore`. The
+// handlers are in-test stand-ins (a `tests/` binary cannot import the
+// project's own routes) running the SAME blob path the generated `create`
+// handler runs. `TestApp::new()` disables CSRF, so the hand-built bodies carry
+// no `_csrf` part (the real form injects one as its first field).
+
+/// A real on-disk blob store for the probes below, plus its root directory so
+/// the caller can remove it when the test finishes.
+fn __PLURAL___probe_blob_store()
+-> (std::sync::Arc<autumn_web::storage::LocalBlobStore>, std::path::PathBuf) {
+    use autumn_web::storage::LocalBlobStore;
+    use autumn_web::storage::local::SigningKey;
+
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or_default();
+    let root = std::env::temp_dir().join(format!("__PLURAL__-blob-probe-{nanos}"));
+    let store = std::sync::Arc::new(
+        LocalBlobStore::new(
+            "test",
+            root.clone(),
+            "/_blobs",
+            std::time::Duration::from_secs(60),
+            SigningKey::new(b"test-signing-key".to_vec()),
+            Vec::new(),
+        )
+        .expect("build local blob store"),
+    );
+    (store, root)
+}
+
+/// A `multipart/form-data` body (boundary `BOUND`) with one text part for a
+/// sibling column and, when `file` is `Some`, one file part for the attachment
+/// column — exactly what a browser submits from the scaffolded form.
+fn __PLURAL___probe_body(file: Option<&str>) -> String {
+    let mut body = String::from(
+        "--BOUND\r\nContent-Disposition: form-data; name=\"__TEXT_FIELD__\"\r\n\r\nhello\r\n",
+    );
+    if let Some(contents) = file {
+        body.push_str(
+            "--BOUND\r\nContent-Disposition: form-data; \
+             name=\"__ATTACH__\"; filename=\"upload.png\"\r\n\
+             Content-Type: image/png\r\n\r\n",
+        );
+        body.push_str(contents);
+        body.push_str("\r\n");
+    }
+    body.push_str("--BOUND--\r\n");
+    body
+}
+
+/// A multipart create stores the file and binds its `Blob` on the record, and
+/// the uploaded bytes really do land in the store at the bound key.
 #[tokio::test]
 async fn __PLURAL___multipart_upload_binds_blob_key() {
-    use autumn_web::storage::local::SigningKey;
-    use autumn_web::storage::{BlobStore, BlobStoreState, LocalBlobStore};
+    use autumn_web::storage::{BlobStore, BlobStoreState};
 
     // Process-local stand-in for the persistence layer: the attachment `Blob`
-    // bound on each created record (mirrors the `New{Pascal}.{attachment}`
+    // bound on each created record (mirrors the `New__PASCAL__.__ATTACH__`
     // column the generated `create` handler sets). No database required.
     static STORE: std::sync::Mutex<Vec<autumn_web::storage::Blob>> =
         std::sync::Mutex::new(Vec::new());
@@ -6338,23 +6595,7 @@ async fn __PLURAL___multipart_upload_binds_blob_key() {
         Ok(Redirect::to("/__PLURAL__"))
     }
 
-    // A real on-disk blob store so `save_to_blob_store` has a backend.
-    let nanos = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .map(|d| d.as_nanos())
-        .unwrap_or_default();
-    let blob_root = std::env::temp_dir().join(format!("__PLURAL__-blob-probe-{nanos}"));
-    let blob_store = std::sync::Arc::new(
-        LocalBlobStore::new(
-            "test",
-            blob_root.clone(),
-            "/_blobs",
-            std::time::Duration::from_secs(60),
-            SigningKey::new(b"test-signing-key".to_vec()),
-            Vec::new(),
-        )
-        .expect("build local blob store"),
-    );
+    let (blob_store, blob_root) = __PLURAL___probe_blob_store();
     let store_handle = blob_store.clone();
 
     let client: TestClient = TestApp::new()
@@ -6364,23 +6605,12 @@ async fn __PLURAL___multipart_upload_binds_blob_key() {
         })
         .build();
 
-    // Hand-built multipart body (TestClient has no `.multipart()` helper): a
-    // text part for a sibling field plus a file part for the attachment field.
-    let body = "--BOUND\r\n\
-Content-Disposition: form-data; name=\"__TEXT_FIELD__\"\r\n\r\n\
-hello\r\n\
---BOUND\r\n\
-Content-Disposition: form-data; name=\"__ATTACH__\"; filename=\"upload.png\"\r\n\
-Content-Type: image/png\r\n\r\n\
-not-an-empty-file\r\n\
---BOUND--\r\n";
-
     // The multipart create succeeds and redirects (303), exactly like the real
     // generated attachment handler.
     client
         .post("/__PLURAL__/upload-probe")
         .header("content-type", "multipart/form-data; boundary=BOUND")
-        .body(body.to_owned())
+        .body(__PLURAL___probe_body(Some("not-an-empty-file")))
         .send()
         .await
         .assert_status(303)
@@ -6412,6 +6642,140 @@ not-an-empty-file\r\n\
 
     let _ = std::fs::remove_dir_all(&blob_root);
 }
+
+/// An upload over `security.upload.max_file_size_bytes` is rejected with `413`
+/// and nothing is left behind in the store. The cap is driven through the real
+/// config knob, not a per-route override, so this also proves the scaffolded
+/// handler honours whatever the app configures.
+#[tokio::test]
+async fn __PLURAL___multipart_upload_over_limit_is_413() {
+    use autumn_web::storage::BlobStoreState;
+
+    #[post("/__PLURAL__/limit-probe")]
+    async fn create(
+        autumn_web::extract::State(state): autumn_web::extract::State<autumn_web::AppState>,
+        mut multipart: autumn_web::extract::Multipart,
+    ) -> AutumnResult<Redirect> {
+        let store = state
+            .extension::<BlobStoreState>()
+            .expect("blob store configured")
+            .store()
+            .clone();
+        while let Some(field) = multipart.next_field().await? {
+            if field.name() == Some("__ATTACH__")
+                && field.file_name().is_some_and(|name| !name.is_empty())
+            {
+                field
+                    .save_to_blob_store(&*store, "__PLURAL__/__ATTACH__/over-limit")
+                    .await?;
+            }
+        }
+        Ok(Redirect::to("/__PLURAL__"))
+    }
+
+    let (blob_store, blob_root) = __PLURAL___probe_blob_store();
+
+    // Same defaults `TestApp::new()` uses, with a deliberately tiny per-file cap.
+    let mut config = autumn_web::config::AutumnConfig::default();
+    config.profile = Some("test".into());
+    config.security.csrf.enabled = false;
+    config.security.upload.max_file_size_bytes = 16;
+
+    let client: TestClient = TestApp::new()
+        .config(config)
+        .routes(routes![create])
+        .state_initializer(move |state| {
+            state.insert_extension(BlobStoreState::new(blob_store.clone()));
+        })
+        .build();
+
+    client
+        .post("/__PLURAL__/limit-probe")
+        .header("content-type", "multipart/form-data; boundary=BOUND")
+        .body(__PLURAL___probe_body(Some(&"x".repeat(4096))))
+        .send()
+        .await
+        .assert_status(413);
+
+    let _ = std::fs::remove_dir_all(&blob_root);
+}
+
+/// Submitting the form with no file selected succeeds and leaves the optional
+/// attachment column NULL — the empty file input a browser sends must not be
+/// mistaken for an upload.
+#[tokio::test]
+async fn __PLURAL___multipart_create_without_file_is_null() {
+    use autumn_web::storage::BlobStoreState;
+
+    static STORE: std::sync::Mutex<Vec<Option<autumn_web::storage::Blob>>> =
+        std::sync::Mutex::new(Vec::new());
+
+    #[post("/__PLURAL__/null-probe")]
+    async fn create(
+        autumn_web::extract::State(state): autumn_web::extract::State<autumn_web::AppState>,
+        mut multipart: autumn_web::extract::Multipart,
+    ) -> AutumnResult<Redirect> {
+        let store = state
+            .extension::<BlobStoreState>()
+            .expect("blob store configured")
+            .store()
+            .clone();
+        let mut __ATTACH___blob: Option<autumn_web::storage::Blob> = None;
+        while let Some(field) = multipart.next_field().await? {
+            if field.name() == Some("__ATTACH__")
+                && field.file_name().is_some_and(|name| !name.is_empty())
+            {
+                __ATTACH___blob = Some(
+                    field
+                        .save_to_blob_store(&*store, "__PLURAL__/__ATTACH__/unused")
+                        .await?,
+                );
+            }
+        }
+        // Mirrors `new.__ATTACH__ = __ATTACH___blob;` in the generated handler.
+        STORE.lock().unwrap().push(__ATTACH___blob);
+        Ok(Redirect::to("/__PLURAL__"))
+    }
+
+    let (blob_store, blob_root) = __PLURAL___probe_blob_store();
+
+    let client: TestClient = TestApp::new()
+        .routes(routes![create])
+        .state_initializer(move |state| {
+            state.insert_extension(BlobStoreState::new(blob_store.clone()));
+        })
+        .build();
+
+    // A browser submitting the form with nothing chosen sends an empty file
+    // part; assert the stricter case too by sending no file part at all.
+    for body in [
+        __PLURAL___probe_body(None),
+        "--BOUND\r\nContent-Disposition: form-data; \
+         name=\"__ATTACH__\"; filename=\"\"\r\n\r\n\r\n--BOUND--\r\n"
+            .to_owned(),
+    ] {
+        client
+            .post("/__PLURAL__/null-probe")
+            .header("content-type", "multipart/form-data; boundary=BOUND")
+            .body(body)
+            .send()
+            .await
+            .assert_status(303);
+
+        let bound = STORE
+            .lock()
+            .unwrap()
+            .last()
+            .cloned()
+            .expect("a record was created");
+        assert!(
+            bound.is_none(),
+            "the optional attachment column must stay NULL when no file is submitted, got: {bound:?}"
+        );
+    }
+
+    let _ = std::fs::remove_dir_all(&blob_root);
+}
 "#;
     let attach = fields
         .iter()
@@ -6424,6 +6788,7 @@ not-an-empty-file\r\n\
         .find(|f| !f.kind.is_attachment())
         .map_or("note", |f| f.name.as_str());
     TEMPLATE
+        .replace("__PASCAL__", pascal_name)
         .replace("__PLURAL__", plural)
         .replace("__ATTACH__", attach)
         .replace("__TEXT_FIELD__", text_field)
@@ -9805,8 +10170,10 @@ async fn main() {
         assert!(routes.contains("multipart.next_field().await?"), "{routes}");
 
         // Preserve-on-update: an edit with no new file keeps the stored blob.
+        // Cloned, not moved, so `current` survives to the unique-violation 422
+        // re-render, which shows the currently stored attachment (issue #1236).
         assert!(
-            routes.contains("new.avatar = avatar_blob.or(current.avatar);"),
+            routes.contains("new.avatar = avatar_blob.or(current.avatar.clone());"),
             "{routes}"
         );
         // Create binds the streamed blob directly (None => NULL column).

--- a/autumn-cli/src/generate/scaffold.rs
+++ b/autumn-cli/src/generate/scaffold.rs
@@ -1018,6 +1018,34 @@ fn plan_scaffold_with_options_impl(
                 owner_dir: Some(models_dir.clone()),
             });
         }
+
+        // The Cargo features make the scaffold COMPILE; a configured backend is
+        // what makes an upload actually persist. `StorageConfig::backend`
+        // defaults to `Disabled`, so without a `[storage]` block the generated
+        // `create` handler answers 500 "storage not configured" on the very
+        // first submit. We don't write the block ourselves — `autumn.toml` is
+        // the operator's file and the right backend is a deployment decision —
+        // but an author must not have to discover this by hitting the 500.
+        let autumn_toml = project_root.join("autumn.toml");
+        let toml_contents = plan
+            .actions
+            .iter()
+            .rev()
+            .find_map(|a| match a {
+                Action::Modify { path, contents } if path == &autumn_toml => Some(contents.clone()),
+                _ => None,
+            })
+            .unwrap_or_else(|| read_or_empty(&autumn_toml));
+        if !toml_contents.contains("[storage]") {
+            plan.warnings.push(
+                "attachment columns need a storage backend: `autumn.toml` has no `[storage]` \
+                 section, so uploads will fail with 500 \"storage not configured\". Add:\n\
+                 \n    [storage]\n    backend = \"local\"\n\n    [storage.local]\n    \
+                 root = \"target/blobs\"\n    mount_path = \"/_blobs\"\n\n\
+                 for development (see docs/guide/storage.md for S3 in production)."
+                    .to_owned(),
+            );
+        }
     }
 
     // Issue #1255: a scaffold with `richtext` columns needs autumn-web's
@@ -2350,12 +2378,41 @@ fn render_routes_file(
     // than failing the whole page.
     let attachment_read_back_helpers = if has_attachments {
         format!(
-            "\n/// Signed, time-bounded URL for a stored attachment (issue #1236).\n\
+            "\n/// The dot-extension to give a stored blob, derived from the browser-supplied\n\
+             /// filename so a downloaded file still opens in the right application.\n\
              ///\n\
-             /// `None` when the column is NULL or the app has no `[storage]` backend\n\
-             /// configured — `attachment_link` then renders the stored file's name\n\
-             /// without a link. Widen or narrow the link's validity window by changing\n\
-             /// the {ATTACHMENT_URL_TTL_SECS}-second expiry below.\n\
+             /// Deliberately paranoid: the submitted name is attacker-controlled and this\n\
+             /// becomes part of a `BlobStore` key, so only a short run of ASCII\n\
+             /// alphanumerics survives — lowercased, because keys must be lowercase and\n\
+             /// portable across the local and S3 backends — and `.meta` (reserved by the\n\
+             /// local backend for its sidecar files) is dropped. Returns `\"\"` when there\n\
+             /// is nothing safe to use; the unique part of the key is the timestamp +\n\
+             /// UUID in front of it either way.\n\
+             fn upload_extension(file_name: Option<&str>) -> String {{\n    \
+             let ext = file_name\n        \
+             .and_then(|name| name.rsplit(['/', '\\\\']).next())\n        \
+             .and_then(|name| name.rsplit_once('.'))\n        \
+             .map(|(_, ext)| ext.to_ascii_lowercase())\n        \
+             .unwrap_or_default();\n    \
+             if ext.is_empty()\n        \
+             || ext.len() > 8\n        \
+             || ext == \"meta\"\n        \
+             || !ext.chars().all(|c| c.is_ascii_alphanumeric())\n    \
+             {{\n        \
+             return String::new();\n    \
+             }}\n    \
+             format!(\".{{ext}}\")\n\
+             }}\n\n\
+             /// Signed, time-bounded URL for a stored attachment (issue #1236).\n\
+             ///\n\
+             /// `None` when the column is NULL, the app has no `[storage]` backend\n\
+             /// configured, or the backend declined to sign — `attachment_link` then\n\
+             /// renders the file name without a link instead of failing the page.\n\
+             ///\n\
+             /// The {ATTACHMENT_URL_TTL_SECS}-second window is set here, not read from\n\
+             /// config: `storage.local.default_url_expiry_secs` applies only when the\n\
+             /// caller passes `Duration::ZERO`, and the S3 backend has no such fallback.\n\
+             /// Change the literal below to widen or narrow it.\n\
              async fn attachment_url(\n    \
              state: &autumn_web::AppState,\n    \
              blob: Option<&autumn_web::storage::Blob>,\n\
@@ -2365,33 +2422,57 @@ fn render_routes_file(
              .extension::<autumn_web::storage::BlobStoreState>()?\n        \
              .store()\n        \
              .clone();\n    \
-             store\n        \
+             match store\n        \
              .presigned_url(&blob.key, std::time::Duration::from_secs({ATTACHMENT_URL_TTL_SECS}))\n        \
-             .await\n        \
-             .ok()\n\
+             .await\n    \
+             {{\n        \
+             Ok(url) => Some(url),\n        \
+             Err(err) => {{\n            \
+             autumn_web::reexports::tracing::warn!(\n                \
+             error = %err,\n                \
+             key = %blob.key,\n                \
+             \"could not sign a URL for a stored attachment; rendering it without a link\"\n            \
+             );\n            \
+             None\n        \
+             }}\n    \
+             }}\n\
              }}\n\n\
              /// Render a stored attachment: a download link when a signed URL is\n\
-             /// available, the stored file's name alone when it isn't, and an em dash\n\
-             /// when the column is NULL.\n\
+             /// available, the file name alone when it isn't, and an em dash when the\n\
+             /// column is NULL. `label` is the column's name — `Blob` records the store\n\
+             /// key, media type and size but not the original filename, so the link is\n\
+             /// labelled `<label>.<ext>` rather than with the opaque key.\n\
              ///\n\
-             /// The link carries `download` deliberately. With the local backend the\n\
-             /// blob is served from this app's own origin with the content type it was\n\
-             /// uploaded under, so a click that NAVIGATED to an uploaded `.html`/`.svg`\n\
-             /// would run it as same-origin script; `download` makes the browser save\n\
-             /// the file instead. Serving user uploads from a separate origin (or an\n\
-             /// S3 presigned URL, where `download` is moot) avoids the question\n\
-             /// entirely. Restrict what can be uploaded with\n\
-             /// `security.upload.allowed_mime_types`.\n\
-             fn attachment_link(blob: Option<&autumn_web::storage::Blob>, url: Option<&str>) -> Markup {{\n    \
+             /// SECURITY: the link carries `download` so a click SAVES the file instead\n\
+             /// of navigating to it. That matters because the local backend serves blobs\n\
+             /// from this app's own origin, replaying the content type they were\n\
+             /// uploaded under and setting no `Content-Disposition` — so an uploaded\n\
+             /// `.html`/`.svg` reached by NAVIGATION runs as same-origin content.\n\
+             /// `download` only governs this anchor; it does not protect anyone who\n\
+             /// opens the URL directly. The durable fix is to restrict what can be\n\
+             /// uploaded — set `security.upload.allowed_mime_types` (and\n\
+             /// `reject_on_content_type_mismatch = true`) in `autumn.toml` — or to serve\n\
+             /// uploads from a separate origin / S3, where the question doesn't arise.\n\
+             ///\n\
+             /// Emitted as a raw `<a>` rather than `autumn_web::a11y::Link` because that\n\
+             /// primitive has no `download` builder.\n\
+             fn attachment_link(\n    \
+             blob: Option<&autumn_web::storage::Blob>,\n    \
+             url: Option<&str>,\n    \
+             label: &str,\n\
+             ) -> Markup {{\n    \
              let Some(blob) = blob else {{\n        \
              return html! {{ \"—\" }};\n    \
              }};\n    \
-             let name = blob.key.rsplit('/').next().unwrap_or(blob.key.as_str());\n    \
+             let file_name = match blob.key.rsplit('/').next().and_then(|s| s.rsplit_once('.')) {{\n        \
+             Some((_, ext)) => format!(\"{{label}}.{{ext}}\"),\n        \
+             None => label.to_owned(),\n    \
+             }};\n    \
              html! {{\n        \
              @if let Some(url) = url {{\n            \
-             a href=(url) rel=\"noopener\" download=(name) {{ (name) }}\n        \
+             a href=(url) download=(file_name) {{ (file_name) }}\n        \
              }} @else {{\n            \
-             span {{ (name) }}\n        \
+             span {{ (file_name) }}\n        \
              }}\n        \
              \" \"\n        \
              span class=\"autumn-attachment__meta\" {{ \"(\" (blob.content_type) \", \" (blob.byte_size) \" bytes)\" }}\n    \
@@ -2404,38 +2485,65 @@ fn render_routes_file(
 
     // The `show` detail page resolves one signed URL per attachment column
     // before building its property list. The list index deliberately does NOT:
-    // its `data_table` column closure is synchronous and runs per row, so a
-    // signed URL there would mean one round-trip per row per page.
-    // Two spellings of the same binds: the `show` handler owns a `State<_>`
-    // wrapper (`&state`), while the state-machine `show_view` helper is handed
-    // an already-borrowed `&AppState` (`state`).
+    // `widgets::Column`'s cell closure is SYNCHRONOUS and `presigned_url` is
+    // async, so there is nowhere to await it. (Signing itself is cheap and
+    // local — an HMAC for the local backend, local SigV4 for S3 — so cost is
+    // not the reason; the index stays a presence marker.)
+    // Two spellings of the same binds. `&state` would compile at both sites
+    // (`&&AppState` reborrows), but generated code is user-owned code: emitting
+    // `&state` where `state` is already a `&AppState` trips
+    // `clippy::needless_borrow` in the app's own lint run. The `show` handler
+    // owns a `State<_>` wrapper and needs the borrow; the state-machine
+    // `show_view` helper is handed a `&AppState` and must not add one.
+    // `authorize` destructures `State(state)` to a bare `AppState`; the
+    // unauthorized form keeps the `State<_>` wrapper and needs the borrow.
+    let show_state_recv = if authorize { "&state" } else { "&*state" };
     let mut show_attachment_url_binds = String::new();
     let mut show_view_attachment_url_binds = String::new();
     for f in &attachment_fields {
         let name = &f.name;
         let _ = writeln!(
             show_attachment_url_binds,
-            "    let {name}_url = attachment_url(&state, row.{name}.as_ref()).await;"
+            "    let {name}_url = attachment_url({show_state_recv}, row.{name}.as_ref()).await;"
         );
         let _ = writeln!(
             show_view_attachment_url_binds,
             "    let {name}_url = attachment_url(state, row.{name}.as_ref()).await;"
         );
     }
-    // `show` has no `State` extractor of its own (it never authorizes), so an
-    // attachment scaffold adds one. Deref coercion at the call site means the
-    // same `attachment_url(&state, …)` works whether `state` is a `State<_>`
-    // wrapper (here) or an already-destructured `AppState` (the authorized
-    // handlers).
-    let show_state_param = if has_attachments {
-        ", state: autumn_web::extract::State<autumn_web::AppState>"
+    // `show` never carried a `State` extractor — it does no authorization. An
+    // attachment scaffold adds one, because rendering the stored file needs the
+    // blob store.
+    //
+    // SECURITY (issue #1236 review): it also adds the record-policy check that
+    // `show` has never had. Before this slice the detail page disclosed only the
+    // word "attachment"; now it hands out a signed `presigned_url`, and the
+    // serving route validates that signature ALONE — no session, no policy — so
+    // the rendered link is a working bearer capability for the bytes for as long
+    // as it is valid. Emitting it from a handler that never consults
+    // `can_show` would make the generated `Policy`'s "Reads are public by
+    // default. Tighten this if shows should be gated." comment a lie for the one
+    // column where it matters most. Under the generated default policy
+    // (`can_show` -> true) this is a no-op; it starts enforcing the moment an
+    // author narrows it. Scaffolds with no attachment column keep the historical
+    // unauthorized `show` — closing that generally is a separate change.
+    let (show_state_param, show_state_param_line, show_authz_call) = if has_attachments && authorize
+    {
+        (
+            ", autumn_web::extract::State(state): autumn_web::extract::State<autumn_web::AppState>, session: autumn_web::session::Session",
+            "\n    autumn_web::extract::State(state): autumn_web::extract::State<autumn_web::AppState>,\n    session: autumn_web::session::Session,",
+            format!(
+                "    autumn_web::authorization::authorize::<{pascal_name}>(&state, &session, \"show\", &row).await?;\n"
+            ),
+        )
+    } else if has_attachments {
+        (
+            ", state: autumn_web::extract::State<autumn_web::AppState>",
+            "\n    state: autumn_web::extract::State<autumn_web::AppState>,",
+            String::new(),
+        )
     } else {
-        ""
-    };
-    let show_state_param_line = if has_attachments {
-        "\n    state: autumn_web::extract::State<autumn_web::AppState>,"
-    } else {
-        ""
+        ("", "", String::new())
     };
     // The state-machine variant renders through a shared `show_view` helper
     // called by `show` and by each transition handler's 422 re-render, so the
@@ -2453,13 +2561,13 @@ fn render_routes_file(
     // to tell an empty column from one holding a blob they simply didn't
     // replace. Both live in the SHARED edit body, so `GET /{plural}/{id}/edit`
     // and every 422 re-render of that form show the same thing — which is why
-    // `update` loads `current` before validating (see `update_load_current_block`).
+    // `update` loads `current` before validating (see `update_load_and_authorize_block`).
     //
     // The shared body reads the row through a binding named `current` — the name
     // `update` already uses — so `edit_form` renames its own loaded row to match
     // once the changeset has been seeded from it.
     let edit_current_bind = if has_attachments {
-        "let current = row;\n    "
+        "// `current` is the name the shared edit body — and `update`, which\n             // re-renders that same body at 422 — reads the row through, so the\n             // stored-attachment block below can't drift between the two.\n             let current = row;\n    "
     } else {
         ""
     };
@@ -2470,22 +2578,88 @@ fn render_routes_file(
     } else {
         ""
     };
-    let mut edit_attachment_url_loads = String::new();
+    let mut edit_attachment_url_binds = String::new();
     let mut edit_current_attachment_markup = String::new();
     for f in &attachment_fields {
         let name = &f.name;
         let label = humanize_label(name);
         let _ = writeln!(
-            edit_attachment_url_loads,
+            edit_attachment_url_binds,
             "        let {name}_url = attachment_url(&state, current.{name}.as_ref()).await;"
         );
         let _ = write!(
             edit_current_attachment_markup,
             "@if let Some(blob) = current.{name}.as_ref() {{\n            \
-             p class=\"autumn-field__current\" {{ \"Current {label}: \" (attachment_link(Some(blob), {name}_url.as_deref())) }}\n        \
+             p class=\"autumn-field__current\" {{ \"Current {label}: \" (attachment_link(Some(blob), {name}_url.as_deref(), \"{name}\")) }}\n        \
              }}\n        "
         );
     }
+
+    // The read-back helpers are pure functions, so the scaffold ships real unit
+    // tests for them right next to the code — `cargo test` in the generated app
+    // exercises the em-dash / no-link / labelled-link branches and the
+    // key-sanitizing rules, rather than leaving them proven only by the
+    // generator's own string assertions. They live INSIDE the routes module
+    // because a `tests/` integration binary cannot import a project's bin crate.
+    let attachment_read_back_unit_tests = if has_attachments {
+        String::from(
+            r#"
+
+#[cfg(test)]
+mod attachment_read_back_tests {
+    use super::{attachment_link, upload_extension};
+    use autumn_web::storage::Blob;
+
+    fn blob(key: &str) -> Blob {
+        Blob::new("test", key, "image/png", 17)
+    }
+
+    #[test]
+    fn renders_an_em_dash_when_the_column_is_null() {
+        assert_eq!(attachment_link(None, None, "cover").into_string(), "\u{2014}");
+    }
+
+    #[test]
+    fn labels_the_link_from_the_column_and_the_stored_extension() {
+        let stored = blob("posts/cover/1700000000_abc.png");
+        let html = attachment_link(Some(&stored), Some("/_blobs/x?sig=1"), "cover").into_string();
+        assert!(html.contains("href=\"/_blobs/x?sig=1\""), "{html}");
+        // Not the opaque key: a download has to land with a usable name.
+        assert!(html.contains("download=\"cover.png\""), "{html}");
+        assert!(html.contains(">cover.png<"), "{html}");
+        assert!(html.contains("image/png"), "{html}");
+        assert!(html.contains("17 bytes"), "{html}");
+    }
+
+    #[test]
+    fn drops_the_anchor_when_no_url_could_be_signed() {
+        let stored = blob("posts/cover/1700000000_abc.png");
+        let html = attachment_link(Some(&stored), None, "cover").into_string();
+        assert!(!html.contains("<a "), "{html}");
+        assert!(html.contains("cover.png"), "{html}");
+    }
+
+    #[test]
+    fn keeps_only_a_short_safe_lowercase_extension() {
+        assert_eq!(upload_extension(Some("holiday.PNG")), ".png");
+        assert_eq!(upload_extension(Some("archive.tar.gz")), ".gz");
+        // No extension to take, or nothing safe to take.
+        assert_eq!(upload_extension(None), "");
+        assert_eq!(upload_extension(Some("noextension")), "");
+        assert_eq!(upload_extension(Some("a.verylongextension")), "");
+        assert_eq!(upload_extension(Some("evil.p g")), "");
+        assert_eq!(upload_extension(Some("evil.p/g")), "");
+        // `.meta` is the local backend's sidecar suffix and is reserved.
+        assert_eq!(upload_extension(Some("sneaky.meta")), "");
+        // A traversal attempt keeps nothing but the final extension.
+        assert_eq!(upload_extension(Some("../../etc/passwd.png")), ".png");
+    }
+}
+"#,
+        )
+    } else {
+        String::new()
+    };
 
     // Issue #1872: the create/update handlers stream each uploaded file to the
     // blob store *before* changeset validation and the DB write, so any early
@@ -2548,9 +2722,10 @@ fn render_routes_file(
                 "            Some(\"{name}\") => {{\n                \
                  if field.file_name().is_some_and(|file_name| !file_name.is_empty()) {{\n                    \
                  let key = format!(\n                        \
-                 \"{plural}/{name}/{{}}_{{}}\",\n                        \
+                 \"{plural}/{name}/{{}}_{{}}{{}}\",\n                        \
                  chrono::Utc::now().timestamp_nanos_opt().unwrap_or_default(),\n                        \
-                 uuid::Uuid::new_v4()\n                    \
+                 uuid::Uuid::new_v4(),\n                        \
+                 upload_extension(field.file_name())\n                    \
                  );\n                    \
                  let blob = field.save_to_blob_store(&*store, key).await?;\n                    \
                  saved_blob_keys.push(blob.key.clone());\n                    \
@@ -2634,7 +2809,7 @@ fn render_routes_file(
     // file is currently stored (a file input can't be repopulated). Loading first
     // also runs the record policy before the re-render, so a forbidden actor is
     // denied instead of being handed the form back.
-    let (update_load_current_block, update_new_block) = if has_attachments {
+    let (update_load_and_authorize_block, update_new_block) = if has_attachments {
         // Issue #1872: loading the current row also happens after the blob save,
         // so its fallible steps clean up the just-saved blob(s) before returning.
         let load_current = if live && !sharded {
@@ -2765,24 +2940,12 @@ fn render_routes_file(
              }}\n    \
              }})"
         );
-        // The edit body additionally resolves a signed URL per attachment column
-        // (issue #1236). Both bodies become block expressions as soon as either
-        // kind of prelude is needed, so the same string splices into the GET
-        // handlers and the 422 re-renders unchanged.
-        let (new_form_body, edit_form_body) = if has_reference_selects || has_attachments {
-            (
-                if has_reference_selects {
-                    format!("{{\n{option_loads}        {new_form_layout}\n    }}")
-                } else {
-                    new_form_layout
-                },
-                format!(
-                    "{{\n{option_loads}{edit_attachment_url_loads}        {edit_form_layout}\n    }}"
-                ),
-            )
-        } else {
-            (new_form_layout, edit_form_layout)
-        };
+        let (new_form_body, edit_form_body) = wrap_form_bodies(
+            new_form_layout,
+            edit_form_layout,
+            &option_loads,
+            &edit_attachment_url_binds,
+        );
         // The referenced-row option loaders are emitted regardless: they
         // populate the in-form `<select>` (issue #1750) AND the issue #1146
         // index parent-label map (`render_index_reference_label_loads` collects
@@ -2830,24 +2993,12 @@ fn render_routes_file(
              }}\n    \
              }})"
         );
-        // The edit body additionally resolves a signed URL per attachment column
-        // (issue #1236). Both bodies become block expressions as soon as either
-        // kind of prelude is needed, so the same string splices into the GET
-        // handlers and the 422 re-renders unchanged.
-        let (new_form_body, edit_form_body) = if has_reference_selects || has_attachments {
-            (
-                if has_reference_selects {
-                    format!("{{\n{option_loads}        {new_form_layout}\n    }}")
-                } else {
-                    new_form_layout
-                },
-                format!(
-                    "{{\n{option_loads}{edit_attachment_url_loads}        {edit_form_layout}\n    }}"
-                ),
-            )
-        } else {
-            (new_form_layout, edit_form_layout)
-        };
+        let (new_form_body, edit_form_body) = wrap_form_bodies(
+            new_form_layout,
+            edit_form_layout,
+            &option_loads,
+            &edit_attachment_url_binds,
+        );
         (
             new_form_body,
             edit_form_body,
@@ -3072,7 +3223,7 @@ fn render_routes_file(
          use autumn_web::reexports::axum::response::IntoResponse as _;\n    \
          {authz_update_preamble}\
          {form_decode_block}\n    \
-         {update_load_current_block}\
+         {update_load_and_authorize_block}\
          let changeset = form.into_changeset();\n    \
          if !changeset.is_valid() {{\n        \
          {blob_cleanup}return Ok((autumn_web::reexports::http::StatusCode::UNPROCESSABLE_ENTITY, {edit_form_body}).into_response());\n    \
@@ -3990,7 +4141,7 @@ pub async fn show(
         .first(&mut *db)
         .await
         .map_err(AutumnError::not_found)?;
-    show_view(db, &row, {flash_arg}, csrf.as_ref(), csrf_field.as_ref(){show_view_state_arg_call}).await
+{show_authz_call}    show_view(db, &row, {flash_arg}, csrf.as_ref(), csrf_field.as_ref(){show_view_state_arg_call}).await
 }}"#
             );
             // Issue #1326 security fix (IDOR): a transition mutates an existing
@@ -4094,7 +4245,7 @@ pub async fn show(id: Path<{id_rust}>, mut db: {db_ty}, flash: Flash{show_state_
         .first(&mut *db)
         .await
         .map_err(AutumnError::not_found)?;
-{show_label_loads}{show_attachment_url_binds}    let props: Vec<(&str, maud::Markup)> = vec![
+{show_authz_call}{show_label_loads}{show_attachment_url_binds}    let props: Vec<(&str, maud::Markup)> = vec![
 {show_rows}    ];
     Ok({layout_fn}(&format!("{pascal_name} #{{}}", row.id), {cp_show}{flash_arg}, html! {{
         h1 {{ "{pascal_name} #" (row.id) }}
@@ -4242,6 +4393,7 @@ pub async fn events(
         + &preview_handlers
         + &paths_macro
         + &search_handler
+        + &attachment_read_back_unit_tests
 }
 
 /// The `UNIQUE_CONSTRAINTS` module-level const the generated `create`/
@@ -4287,6 +4439,34 @@ fn render_update_changeset_expr(pascal_name: &str, fields: &[Field]) -> String {
 /// render (issue #1236). Long enough to browse a detail page and click through
 /// to the file, short enough that a copied link isn't a durable capability.
 const ATTACHMENT_URL_TTL_SECS: u64 = 300;
+
+/// Wrap the new/edit view bodies in a block expression when either needs a
+/// prelude: `option_loads` for `references` selects (issue #1146/#1750) and
+/// `edit_attachment_url_binds` for the signed attachment URLs the edit view
+/// renders (issue #1236). Both bodies splice into a GET handler AND into the
+/// matching 422 re-render, so the prelude has to travel inside the body string
+/// rather than sit in one handler — otherwise the two sites drift.
+///
+/// Only the edit body ever carries attachment binds: a new record has no
+/// stored file to render.
+fn wrap_form_bodies(
+    new_form_layout: String,
+    edit_form_layout: String,
+    option_loads: &str,
+    edit_attachment_url_binds: &str,
+) -> (String, String) {
+    let new_body = if option_loads.is_empty() {
+        new_form_layout
+    } else {
+        format!("{{\n{option_loads}        {new_form_layout}\n    }}")
+    };
+    let edit_body = if option_loads.is_empty() && edit_attachment_url_binds.is_empty() {
+        edit_form_layout
+    } else {
+        format!("{{\n{option_loads}{edit_attachment_url_binds}        {edit_form_layout}\n    }}")
+    };
+    (new_body, edit_body)
+}
 
 /// Whether any field in `fields` is a file attachment.
 fn has_attachment_fields(fields: &[Field]) -> bool {
@@ -5507,7 +5687,7 @@ fn render_show_property_rows(
             // resolved into `{name}_url` — instead of the index's cheap
             // presence marker. See `attachment_link` in the generated routes.
             let name = &f.name;
-            format!("attachment_link(row.{name}.as_ref(), {name}_url.as_deref())")
+            format!("attachment_link(row.{name}.as_ref(), {name}_url.as_deref(), \"{name}\")")
         } else if f.kind.is_rich_text() {
             // Issue #1255: the column stores user-submitted Markdown SOURCE, so
             // the show page renders it through `render_user_content` — raw-HTML
@@ -6649,7 +6829,7 @@ async fn __PLURAL___multipart_upload_binds_blob_key() {
 /// handler honours whatever the app configures.
 #[tokio::test]
 async fn __PLURAL___multipart_upload_over_limit_is_413() {
-    use autumn_web::storage::BlobStoreState;
+    use autumn_web::storage::{BlobStore, BlobStoreState};
 
     #[post("/__PLURAL__/limit-probe")]
     async fn create(
@@ -6674,6 +6854,7 @@ async fn __PLURAL___multipart_upload_over_limit_is_413() {
     }
 
     let (blob_store, blob_root) = __PLURAL___probe_blob_store();
+    let store_handle = blob_store.clone();
 
     // Same defaults `TestApp::new()` uses, with a deliberately tiny per-file cap.
     let mut config = autumn_web::config::AutumnConfig::default();
@@ -6696,6 +6877,20 @@ async fn __PLURAL___multipart_upload_over_limit_is_413() {
         .send()
         .await
         .assert_status(413);
+
+    // Rejected part-way through, the store holds no object at the key: the
+    // backend writes to a temp sibling and unlinks it when the cap trips, so
+    // neither partial bytes nor a `.meta` sidecar survive. (The key's parent
+    // directories are still created, so this asserts on the object, not the
+    // directory tree.)
+    let residue = store_handle
+        .head("__PLURAL__/__ATTACH__/over-limit")
+        .await
+        .expect("head on a missing key reports absence, not an error");
+    assert!(
+        residue.is_none(),
+        "a rejected oversized upload must leave no object behind: {residue:?}"
+    );
 
     let _ = std::fs::remove_dir_all(&blob_root);
 }

--- a/autumn-cli/src/generate/scaffold.rs
+++ b/autumn-cli/src/generate/scaffold.rs
@@ -2403,11 +2403,57 @@ fn render_routes_file(
              }}\n    \
              format!(\".{{ext}}\")\n\
              }}\n\n\
+             /// Media types this scaffold is willing to hand out a URL for.\n\
+             ///\n\
+             /// SECURITY: the local backend serves blobs from THIS app's origin and\n\
+             /// replays the content type they were uploaded under, setting no\n\
+             /// `Content-Disposition`; the default CSP allows `script-src 'self'`. So a\n\
+             /// stored `text/html` or `image/svg+xml` reached by direct NAVIGATION would\n\
+             /// run as same-origin script with the visitor's cookies — and an anchor's\n\
+             /// `download` attribute governs clicks on that anchor, not navigation to\n\
+             /// the URL. A URL is therefore only ever issued for types a browser either\n\
+             /// renders inertly (images, PDF, plain text, media) or simply downloads\n\
+             /// (archives, office documents); an unlisted type still shows on the page,\n\
+             /// just without a link.\n\
+             ///\n\
+             /// Fail-CLOSED by design. Widen it freely for inert types you accept, but\n\
+             /// do NOT add `text/html`, `application/xhtml+xml`, `image/svg+xml`, any\n\
+             /// `*/xml`, or any script type unless you are serving uploads from a\n\
+             /// SEPARATE origin. Constraining `security.upload.allowed_mime_types` in\n\
+             /// `autumn.toml` is the complementary control on the write side.\n\
+             const LINKABLE_CONTENT_TYPES: &[&str] = &[\n    \
+             // Rendered inertly by the browser.\n    \
+             \"image/png\",\n    \
+             \"image/jpeg\",\n    \
+             \"image/gif\",\n    \
+             \"image/webp\",\n    \
+             \"image/avif\",\n    \
+             \"image/bmp\",\n    \
+             \"application/pdf\",\n    \
+             \"text/plain\",\n    \
+             \"text/csv\",\n    \
+             \"audio/mpeg\",\n    \
+             \"audio/ogg\",\n    \
+             \"audio/wav\",\n    \
+             \"video/mp4\",\n    \
+             \"video/webm\",\n    \
+             // No inline renderer, so the browser downloads rather than executes.\n    \
+             \"application/zip\",\n    \
+             \"application/gzip\",\n    \
+             \"application/octet-stream\",\n    \
+             \"application/msword\",\n    \
+             \"application/vnd.ms-excel\",\n    \
+             \"application/vnd.openxmlformats-officedocument.wordprocessingml.document\",\n    \
+             \"application/vnd.openxmlformats-officedocument.spreadsheetml.sheet\",\n    \
+             \"application/vnd.openxmlformats-officedocument.presentationml.presentation\",\n\
+             ];\n\n\
              /// Signed, time-bounded URL for a stored attachment (issue #1236).\n\
              ///\n\
-             /// `None` when the column is NULL, the app has no `[storage]` backend\n\
-             /// configured, or the backend declined to sign — `attachment_link` then\n\
-             /// renders the file name without a link instead of failing the page.\n\
+             /// `None` — so `attachment_link` renders the file name without a link\n\
+             /// rather than failing the page — when the column is NULL, the app has no\n\
+             /// `[storage]` backend configured, the media type is not in\n\
+             /// `LINKABLE_CONTENT_TYPES`, the blob belongs to a different storage\n\
+             /// provider, or the backend declined to sign.\n\
              ///\n\
              /// The {ATTACHMENT_URL_TTL_SECS}-second window is set here, not read from\n\
              /// config: `storage.local.default_url_expiry_secs` applies only when the\n\
@@ -2418,10 +2464,35 @@ fn render_routes_file(
              blob: Option<&autumn_web::storage::Blob>,\n\
              ) -> Option<String> {{\n    \
              let blob = blob?;\n    \
+             // Compare on the media-type ESSENCE: a stored type may carry parameters\n    \
+             // (`text/plain; charset=utf-8`).\n    \
+             let essence = blob\n        \
+             .content_type\n        \
+             .split(';')\n        \
+             .next()\n        \
+             .unwrap_or_default()\n        \
+             .trim()\n        \
+             .to_ascii_lowercase();\n    \
+             if !LINKABLE_CONTENT_TYPES.contains(&essence.as_str()) {{\n        \
+             return None;\n    \
+             }}\n    \
              let store = state\n        \
              .extension::<autumn_web::storage::BlobStoreState>()?\n        \
              .store()\n        \
              .clone();\n    \
+             // A blob recorded against a different provider is not this store's object.\n    \
+             // Signing its key would produce a link to nothing — or, if that key happens\n    \
+             // to exist here, to unrelated bytes. `Blob::provider_id` exists to catch\n    \
+             // exactly this after a backend swap.\n    \
+             if blob.provider_id != store.provider_id() {{\n        \
+             autumn_web::reexports::tracing::warn!(\n            \
+             blob_provider = %blob.provider_id,\n            \
+             store_provider = %store.provider_id(),\n            \
+             key = %blob.key,\n            \
+             \"attachment belongs to a different storage provider; rendering it without a link\"\n        \
+             );\n        \
+             return None;\n    \
+             }}\n    \
              match store\n        \
              .presigned_url(&blob.key, std::time::Duration::from_secs({ATTACHMENT_URL_TTL_SECS}))\n        \
              .await\n    \
@@ -2443,16 +2514,15 @@ fn render_routes_file(
              /// key, media type and size but not the original filename, so the link is\n\
              /// labelled `<label>.<ext>` rather than with the opaque key.\n\
              ///\n\
-             /// SECURITY: the link carries `download` so a click SAVES the file instead\n\
-             /// of navigating to it. That matters because the local backend serves blobs\n\
-             /// from this app's own origin, replaying the content type they were\n\
-             /// uploaded under and setting no `Content-Disposition` — so an uploaded\n\
-             /// `.html`/`.svg` reached by NAVIGATION runs as same-origin content.\n\
-             /// `download` only governs this anchor; it does not protect anyone who\n\
-             /// opens the URL directly. The durable fix is to restrict what can be\n\
-             /// uploaded — set `security.upload.allowed_mime_types` (and\n\
-             /// `reject_on_content_type_mismatch = true`) in `autumn.toml` — or to serve\n\
-             /// uploads from a separate origin / S3, where the question doesn't arise.\n\
+             /// The link carries `download` so a same-origin click SAVES the file rather\n\
+             /// than rendering it in a tab. It is a convenience, NOT the security\n\
+             /// boundary — it governs clicks on this anchor only, and browsers ignore it\n\
+             /// entirely for the cross-origin URL an S3 backend returns (so an S3-hosted\n\
+             /// image opens inline instead of saving; encode a response\n\
+             /// `Content-Disposition` into the presign if that matters to you). What\n\
+             /// actually keeps a stored `.html`/`.svg` from running as same-origin script\n\
+             /// is `attachment_url` refusing to issue a URL for it at all — see\n\
+             /// `LINKABLE_CONTENT_TYPES`.\n\
              ///\n\
              /// Emitted as a raw `<a>` rather than `autumn_web::a11y::Link` because that\n\
              /// primitive has no `download` builder.\n\
@@ -2607,7 +2677,7 @@ fn render_routes_file(
 
 #[cfg(test)]
 mod attachment_read_back_tests {
-    use super::{attachment_link, upload_extension};
+    use super::{LINKABLE_CONTENT_TYPES, attachment_link, upload_extension};
     use autumn_web::storage::Blob;
 
     fn blob(key: &str) -> Blob {
@@ -2637,6 +2707,32 @@ mod attachment_read_back_tests {
         let html = attachment_link(Some(&stored), None, "cover").into_string();
         assert!(!html.contains("<a "), "{html}");
         assert!(html.contains("cover.png"), "{html}");
+    }
+
+    #[test]
+    fn refuses_to_link_content_types_that_execute_as_same_origin_script() {
+        // The local backend replays the stored content type from THIS origin with
+        // no `Content-Disposition`, and the default CSP allows `script-src 'self'`,
+        // so navigating to a stored `.html`/`.svg` would run it as same-origin
+        // script. `attachment_url` must not hand out a URL for those at all.
+        for dangerous in [
+            "text/html",
+            "image/svg+xml",
+            "application/xhtml+xml",
+            "text/xml",
+            "application/xml",
+            "text/javascript",
+            "application/javascript",
+        ] {
+            assert!(
+                !LINKABLE_CONTENT_TYPES.contains(&dangerous),
+                "{dangerous} must never be linkable"
+            );
+        }
+        // The ordinary upload types a scaffold is actually used for stay linkable.
+        for safe in ["image/png", "image/jpeg", "application/pdf", "text/plain"] {
+            assert!(LINKABLE_CONTENT_TYPES.contains(&safe), "{safe} should link");
+        }
     }
 
     #[test]

--- a/autumn-cli/tests/integration/scaffold_form_for.rs
+++ b/autumn-cli/tests/integration/scaffold_form_for.rs
@@ -938,11 +938,14 @@ fn generated_attachment_scaffold_multipart_test_passes() {
         "photos_multipart_upload_binds_blob_key",
         "photos_multipart_upload_over_limit_is_413",
         "photos_multipart_create_without_file_is_null",
-        // `src/routes/photos.rs` — the read-back helpers.
-        "attachment_read_back_tests::renders_an_em_dash_when_the_column_is_null",
-        "attachment_read_back_tests::labels_the_link_from_the_column_and_the_stored_extension",
-        "attachment_read_back_tests::drops_the_anchor_when_no_url_could_be_signed",
-        "attachment_read_back_tests::keeps_only_a_short_safe_lowercase_extension",
+        // `src/routes/photos.rs` — the read-back helpers. libtest reports a bin
+        // crate's unit tests under their full module path, so these carry the
+        // `routes::<plural>::` prefix the `tests/` binary's names don't have.
+        "routes::photos::attachment_read_back_tests::renders_an_em_dash_when_the_column_is_null",
+        "routes::photos::attachment_read_back_tests::labels_the_link_from_the_column_and_the_stored_extension",
+        "routes::photos::attachment_read_back_tests::drops_the_anchor_when_no_url_could_be_signed",
+        "routes::photos::attachment_read_back_tests::keeps_only_a_short_safe_lowercase_extension",
+        "routes::photos::attachment_read_back_tests::refuses_to_link_content_types_that_execute_as_same_origin_script",
     ] {
         assert!(
             stdout.contains(&format!("test {name} ... ok")),
@@ -1115,5 +1118,69 @@ fn scaffold_attachment_form_is_multipart_encoded() {
     assert!(
         !plain_routes.contains("FieldControl::File"),
         "{plain_routes}"
+    );
+}
+
+/// PR #2161 review (Codex P1/P2): `attachment_url` must refuse to sign a URL
+/// for content a browser would execute as same-origin script, and for a blob
+/// recorded against a different storage provider.
+///
+/// The local backend serves blobs from the app's own origin, replaying the
+/// content type they were uploaded under with no `Content-Disposition`, and the
+/// default CSP allows `script-src 'self'` — so a stored `text/html` reached by
+/// direct navigation is stored XSS. The anchor's `download` attribute does not
+/// govern navigation, so refusing to issue the URL is the actual control.
+#[test]
+fn scaffold_attachment_url_refuses_unsafe_content_types_and_foreign_providers() {
+    let (_tmp, project) = scaffold_project("attach-safe-app", "Photo", &["image:Attachment"]);
+    let routes = fs::read_to_string(project.join("src/routes/photos.rs")).unwrap();
+
+    assert!(
+        routes.contains("const LINKABLE_CONTENT_TYPES: &[&str] = &["),
+        "{routes}"
+    );
+    assert!(
+        routes.contains("if !LINKABLE_CONTENT_TYPES.contains(&essence.as_str()) {"),
+        "the signed URL must be gated on the stored media type:\n{routes}"
+    );
+    // Compared on the media-type essence, so `text/plain; charset=utf-8` matches.
+    assert!(routes.contains(".split(';')"), "{routes}");
+
+    // Scoped to the const's own entries — the dangerous names legitimately appear
+    // in the surrounding doc comment ("do NOT add ...") and in the emitted unit
+    // test that asserts their absence.
+    let allowlist = handler_body(&routes, "const LINKABLE_CONTENT_TYPES", "];");
+    for dangerous in [
+        "\"text/html\"",
+        "\"image/svg+xml\"",
+        "\"application/xhtml+xml\"",
+        "\"text/xml\"",
+        "\"application/javascript\"",
+    ] {
+        assert!(
+            !allowlist.contains(dangerous),
+            "{dangerous} must never be linkable from a scaffolded view:\n{allowlist}"
+        );
+    }
+    // …while the ordinary upload types stay usable.
+    for safe in ["\"image/png\"", "\"image/jpeg\"", "\"application/pdf\""] {
+        assert!(
+            allowlist.contains(safe),
+            "{safe} should be linkable:\n{allowlist}"
+        );
+    }
+
+    // A blob from a previous backend is not this store's object: signing its key
+    // would link to nothing, or to unrelated bytes that happen to share the key.
+    assert!(
+        routes.contains("if blob.provider_id != store.provider_id() {"),
+        "a provider mismatch must degrade to the no-link path:\n{routes}"
+    );
+
+    // `download` is documented as a convenience, not the security boundary —
+    // browsers ignore it for the cross-origin URL an S3 backend returns.
+    assert!(
+        routes.contains("NOT the security\n/// boundary"),
+        "the note must not present `download` as the control:\n{routes}"
     );
 }

--- a/autumn-cli/tests/integration/scaffold_form_for.rs
+++ b/autumn-cli/tests/integration/scaffold_form_for.rs
@@ -254,9 +254,10 @@ fn generated_form_for_scaffold_cargo_checks() {
 
 /// Patch the generated project to use this workspace's `autumn-web`, then
 /// `cargo check --tests` it, asserting success.
-fn assert_project_cargo_checks(project: &Path) {
-    // Point the generated project at the local autumn-web crate so the check
-    // exercises this workspace's `form_for`, not a published version.
+/// Point a generated project at this workspace's `autumn-web` rather than a
+/// published version, so a compile/run of the generated code exercises the
+/// code under test.
+fn patch_autumn_web_path(project: &Path) {
     let cargo_toml_path = project.join("Cargo.toml");
     let mut content = fs::read_to_string(&cargo_toml_path).unwrap();
     let workspace_root = Path::new(env!("CARGO_MANIFEST_DIR"))
@@ -269,6 +270,10 @@ fn assert_project_cargo_checks(project: &Path) {
         autumn_web.display().to_string().replace('\\', "/")
     );
     fs::write(&cargo_toml_path, content).unwrap();
+}
+
+fn assert_project_cargo_checks(project: &Path) {
+    patch_autumn_web_path(project);
 
     let check = Command::new("cargo")
         .args(["check", "--tests"])
@@ -410,8 +415,10 @@ fn scaffold_attachment_emits_zero_js_multipart_handlers() {
     assert!(!routes.contains("complete_direct_upload(&"), "{routes}");
 
     // Preserve-on-update and create-binding.
+    // `.clone()` rather than a move: issue #1236 keeps `current` whole so the
+    // unique-violation 422 can still render the currently stored attachment.
     assert!(
-        routes.contains("new.image = image_blob.or(current.image);"),
+        routes.contains("new.image = image_blob.or(current.image.clone());"),
         "{routes}"
     );
     assert!(routes.contains("new.image = image_blob;"), "{routes}");
@@ -642,18 +649,18 @@ fn scaffold_attachment_cleans_up_saved_blob_on_early_return() {
     // Cleanup guards every update early return that can occur after the first
     // blob is saved. Codex P2 centralized the parse span: the mid-loop save
     // failure, `next_field`, `bytes_limited`, the UTF-8 conversion, and
-    // `decode_form` collapse to ONE cleanup inside the parse block. The six
-    // post-parse returns keep their own cleanup: validation 422, the current-row
-    // load, `into_new`, the unique-violation 422, the generic DB `Err`, and the
-    // not-found (`updated == 0`) guard.
+    // `decode_form` collapse to ONE cleanup inside the parse block. The seven
+    // post-parse returns keep their own cleanup: the current-row load, the
+    // record-policy denial, validation 422, `into_new`, the unique-violation
+    // 422, the generic DB `Err`, and the not-found (`updated == 0`) guard.
     assert_eq!(
         update_early
             .matches("let _ = store.delete(key).await;")
             .count(),
-        7,
-        "update must clean up the saved blob on all seven early-return sites \
-         (one central parse-span cleanup, plus validation, current-row load, into_new, \
-         unique-violation, DB error, not-found):\n{update}"
+        8,
+        "update must clean up the saved blob on all eight early-return sites \
+         (one central parse-span cleanup, plus current-row load, authorize, validation, \
+         into_new, unique-violation, DB error, not-found):\n{update}"
     );
     assert!(
         !update_success.contains("store.delete("),
@@ -663,7 +670,7 @@ fn scaffold_attachment_cleans_up_saved_blob_on_early_return() {
     // The preserve-on-update bind is untouched: only `image_blob` (the freshly
     // saved upload) is ever deleted, never the preserved `current.image`.
     assert!(
-        routes.contains("new.image = image_blob.or(current.image);"),
+        routes.contains("new.image = image_blob.or(current.image.clone());"),
         "{routes}"
     );
 
@@ -672,4 +679,250 @@ fn scaffold_attachment_cleans_up_saved_blob_on_early_return() {
     let plain_routes = fs::read_to_string(plain.join("src/routes/articles.rs")).unwrap();
     assert!(!plain_routes.contains("saved_blob_keys"), "{plain_routes}");
     assert!(!plain_routes.contains("store.delete("), "{plain_routes}");
+}
+
+/// AC3 (read-back half): after a zero-JS upload the record references a blob,
+/// and the **show** view must render that stored attachment — not the literal
+/// word "attachment". The generated `show` handler resolves a signed,
+/// time-bounded URL through the configured `BlobStore` (`presigned_url`, so it
+/// works for both the local disk backend and S3) and renders a download link.
+/// A NULL column renders an em dash; an app with no blob store configured
+/// degrades to the blob's name with no link, never an error.
+#[test]
+fn scaffold_attachment_show_view_renders_stored_attachment() {
+    let (_tmp, project) = scaffold_project(
+        "attach-show-app",
+        "Photo",
+        &["caption:String", "image:Attachment"],
+    );
+    let routes = fs::read_to_string(project.join("src/routes/photos.rs")).unwrap();
+
+    // The read-back helpers are emitted.
+    assert!(
+        routes.contains("async fn attachment_url("),
+        "attachment scaffolds must emit the signed-URL resolver:\n{routes}"
+    );
+    assert!(
+        routes.contains(".presigned_url(&blob.key,"),
+        "the resolver must sign through the configured BlobStore:\n{routes}"
+    );
+    assert!(
+        routes.contains("fn attachment_link("),
+        "attachment scaffolds must emit the link renderer:\n{routes}"
+    );
+
+    // `show` carries the state it needs to reach the blob store, resolves the
+    // URL for the column, and renders the link in its property list.
+    let show = handler_body(&routes, "pub async fn show(", "/// `GET /photos/new`");
+    assert!(
+        show.contains("autumn_web::extract::State<autumn_web::AppState>"),
+        "show must take the app state to reach the blob store:\n{show}"
+    );
+    assert!(
+        show.contains("let image_url = attachment_url(&state, row.image.as_ref()).await;"),
+        "show must resolve the stored attachment's URL:\n{show}"
+    );
+    assert!(
+        show.contains("(attachment_link(row.image.as_ref(), image_url.as_deref()))"),
+        "show must render the stored attachment, not a presence placeholder:\n{show}"
+    );
+    assert!(
+        !show.contains(r#"if row.image.is_some() { "attachment" }"#),
+        "show must no longer render the literal word \"attachment\":\n{show}"
+    );
+
+    // The index list stays presence-only: its `data_table` column closure is
+    // sync and per-row, so resolving one signed URL per row is not on the table.
+    let index = handler_body(&routes, "pub async fn index(", "pub async fn show(");
+    assert!(
+        index.contains(r#"if row.image.is_some() { "attachment" }"#),
+        "the index column stays a cheap presence marker:\n{index}"
+    );
+
+    // A plain scaffold gets none of the read-back machinery.
+    let (_tmp2, plain) = scaffold_project("plain-show-app", "Article", &["title:String"]);
+    let plain_routes = fs::read_to_string(plain.join("src/routes/articles.rs")).unwrap();
+    assert!(!plain_routes.contains("attachment_url("), "{plain_routes}");
+    assert!(!plain_routes.contains("attachment_link("), "{plain_routes}");
+}
+
+/// AC3 (read-back half, edit view): the edit form shows which file is already
+/// stored — a file `<input>` cannot be repopulated, so without this the user
+/// has no way to tell whether the record already has an attachment. The block
+/// lives in the SHARED edit body, so the 422 re-render after a rejected submit
+/// shows the same thing as `GET /photos/{id}/edit` (no markup drift).
+#[test]
+fn scaffold_attachment_edit_view_renders_current_attachment() {
+    // `email:String:unique` gives the update handler its second 422 branch (the
+    // unique-violation re-render) as well as the validation one.
+    let (_tmp, project) = scaffold_project(
+        "attach-edit-app",
+        "Photo",
+        &["caption:String", "image:Attachment", "email:String:unique"],
+    );
+    let routes = fs::read_to_string(project.join("src/routes/photos.rs")).unwrap();
+
+    let current_block = "@if let Some(blob) = current.image.as_ref() {";
+    let url_bind = "let image_url = attachment_url(&state, current.image.as_ref()).await;";
+
+    // Rendered on the GET edit page…
+    let edit = handler_body(&routes, "pub async fn edit_form(", "pub async fn update(");
+    assert!(edit.contains(url_bind), "{edit}");
+    assert!(edit.contains(current_block), "{edit}");
+    assert!(
+        edit.contains("(attachment_link(Some(blob), image_url.as_deref()))"),
+        "{edit}"
+    );
+
+    // …and identically on every 422 re-render of that same form, which means
+    // `current` has to be loaded before validation rejects the submit.
+    let update = handler_body(&routes, "pub async fn update(", "pub async fn destroy(");
+    assert_eq!(
+        update.matches(current_block).count(),
+        2,
+        "both update 422 re-renders must show the current attachment:\n{update}"
+    );
+    let load_at = update
+        .find("let current: Photo = match photos::table")
+        .unwrap_or_else(|| panic!("missing current-row load:\n{update}"));
+    let validate_at = update
+        .find("if !changeset.is_valid() {")
+        .unwrap_or_else(|| panic!("missing validation guard:\n{update}"));
+    assert!(
+        load_at < validate_at,
+        "the current row must load before the validation 422 so the re-render \
+         can show the stored attachment (and so the record policy runs first):\n{update}"
+    );
+
+    // The new-record form has nothing stored yet, so it renders no such block.
+    let new_form = handler_body(&routes, "pub async fn new_form(", "pub async fn create(");
+    assert!(!new_form.contains("attachment_link("), "{new_form}");
+}
+
+/// AC4: the generated write-path test covers BOTH AC4 clauses — an oversized
+/// upload is rejected with `413` honoring `security.upload.max_file_size_bytes`,
+/// and a submit with no file on an optional attachment succeeds with the column
+/// left NULL.
+#[test]
+fn scaffold_attachment_emits_generated_size_limit_and_null_tests() {
+    let (_tmp, project) = scaffold_project(
+        "attach-limits-app",
+        "Photo",
+        &["caption:String", "image:Attachment"],
+    );
+    let test_src = fs::read_to_string(project.join("tests/photo.rs")).unwrap();
+
+    assert!(
+        test_src.contains("#[tokio::test]\nasync fn photos_multipart_upload_over_limit_is_413() {"),
+        "AC4 needs a generated oversized-upload test:\n{test_src}"
+    );
+    assert!(
+        test_src.contains("config.security.upload.max_file_size_bytes ="),
+        "the oversized test must drive the real config knob:\n{test_src}"
+    );
+    assert!(
+        test_src.contains(".assert_status(413)"),
+        "an oversized upload must surface 413:\n{test_src}"
+    );
+
+    assert!(
+        test_src
+            .contains("#[tokio::test]\nasync fn photos_multipart_create_without_file_is_null() {"),
+        "AC4 needs a generated no-file-is-NULL test:\n{test_src}"
+    );
+    assert!(
+        test_src.contains("the optional attachment column must stay NULL"),
+        "{test_src}"
+    );
+
+    // A plain scaffold gets neither.
+    let (_tmp2, plain) = scaffold_project("plain-limits-app", "Article", &["title:String"]);
+    let plain_src = fs::read_to_string(plain.join("tests/article.rs")).unwrap();
+    assert!(!plain_src.contains("over_limit_is_413"), "{plain_src}");
+    assert!(!plain_src.contains("without_file_is_null"), "{plain_src}");
+}
+
+/// AC5: the generated handler note must not push authors back onto the
+/// JavaScript presign path. It previously claimed a "~2 MiB size ceiling with
+/// CSRF on" — that is false for the form the scaffold emits: `form_for` renders
+/// the CSRF hidden input as the FIRST child of the `<form>` and the scaffold
+/// `.prepend`s the submit token right after it, so both tokens land inside
+/// `security.csrf.token_scan_bytes` (2 MiB) however large the file is. See
+/// `autumn/src/security/csrf.rs::post_large_multipart_token_first_streams_full_body_and_passes`.
+#[test]
+fn scaffold_attachment_note_does_not_claim_a_csrf_size_ceiling() {
+    let (_tmp, project) = scaffold_project(
+        "attach-note-app",
+        "Photo",
+        &["caption:String", "image:Attachment"],
+    );
+    let routes = fs::read_to_string(project.join("src/routes/photos.rs")).unwrap();
+    let note = handler_body(
+        &routes,
+        "//! This scaffold includes",
+        "use autumn_web::extract",
+    );
+
+    assert!(
+        !note.contains("SIZE CEILING"),
+        "the note must not claim a CSRF size ceiling the generated form does not have:\n{note}"
+    );
+    assert!(
+        !note.contains("rejected with\n//! 403") && !note.contains("403"),
+        "the note must not tell authors large uploads 403:\n{note}"
+    );
+    // It states the real limits instead.
+    assert!(note.contains("max_file_size_bytes"), "{note}");
+    assert!(
+        note.contains("413"),
+        "the note must name the real 413 cap:\n{note}"
+    );
+    assert!(
+        note.contains("max_request_size_bytes"),
+        "the note must name the whole-request cap:\n{note}"
+    );
+    // Presign stays documented, as the opt-in advanced path.
+    assert!(note.contains("ADVANCED (opt-in)"), "{note}");
+    assert!(note.contains("complete_direct_upload"), "{note}");
+    assert!(note.contains("examples/reddit-clone"), "{note}");
+}
+
+/// AC6 (the missing half): the generated multipart write-path tests are not
+/// just string-shaped — they must actually PASS in a freshly scaffolded
+/// project. Compiles and RUNS the generated `tests/photo.rs` binary, which
+/// covers the AC6 create-binds-a-blob-key test plus the AC4 413 / NULL tests.
+///
+/// Ignored by default; run with `cargo test -p autumn-cli -- --ignored`.
+#[test]
+#[ignore = "slow: cargo-tests a fresh project — run with `cargo test -p autumn-cli -- --ignored`"]
+fn generated_attachment_scaffold_multipart_test_passes() {
+    let (_tmp, project) = scaffold_project(
+        "attach-run",
+        "Photo",
+        &["caption:String", "image:Attachment"],
+    );
+    patch_autumn_web_path(&project);
+
+    let run = Command::new("cargo")
+        .args(["test", "--test", "photo"])
+        .current_dir(&project)
+        .output()
+        .unwrap();
+    assert!(
+        run.status.success(),
+        "generated multipart write-path tests failed:\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&run.stdout),
+        String::from_utf8_lossy(&run.stderr),
+    );
+    let stdout = String::from_utf8_lossy(&run.stdout);
+    for name in [
+        "photos_multipart_upload_binds_blob_key",
+        "photos_multipart_upload_over_limit_is_413",
+        "photos_multipart_create_without_file_is_null",
+    ] {
+        assert!(
+            stdout.contains(&format!("test {name} ... ok")),
+            "generated test `{name}` must run and pass (it must not be ignored):\n{stdout}"
+        );
+    }
 }

--- a/autumn-cli/tests/integration/scaffold_form_for.rs
+++ b/autumn-cli/tests/integration/scaffold_form_for.rs
@@ -723,8 +723,25 @@ fn scaffold_attachment_show_view_renders_stored_attachment() {
         "show must resolve the stored attachment's URL:\n{show}"
     );
     assert!(
-        show.contains("(attachment_link(row.image.as_ref(), image_url.as_deref()))"),
+        show.contains("(attachment_link(row.image.as_ref(), image_url.as_deref(), \"image\"))"),
         "show must render the stored attachment, not a presence placeholder:\n{show}"
+    );
+    // Issue #1236 review: the rendered link is a signed bearer capability for
+    // the bytes — the blob-serving route checks the signature and nothing else —
+    // so the handler that emits it must run the record policy. Under the
+    // generated default policy (`can_show` -> true) this changes nothing; it
+    // starts enforcing the moment an author narrows `can_show`.
+    assert!(
+        show.contains(
+            "autumn_web::authorization::authorize::<Photo>(&state, &session, \"show\", &row).await?;"
+        ),
+        "show must record-authorize before disclosing a signed attachment URL:\n{show}"
+    );
+    let authz_at = show.find("authorize::<Photo>").unwrap();
+    let url_at = show.find("let image_url =").unwrap();
+    assert!(
+        authz_at < url_at,
+        "the policy check must run before the URL is signed:\n{show}"
     );
     assert!(
         !show.contains(r#"if row.image.is_some() { "attachment" }"#),
@@ -770,7 +787,7 @@ fn scaffold_attachment_edit_view_renders_current_attachment() {
     assert!(edit.contains(url_bind), "{edit}");
     assert!(edit.contains(current_block), "{edit}");
     assert!(
-        edit.contains("(attachment_link(Some(blob), image_url.as_deref()))"),
+        edit.contains("(attachment_link(Some(blob), image_url.as_deref(), \"image\"))"),
         "{edit}"
     );
 
@@ -884,6 +901,7 @@ fn scaffold_attachment_note_does_not_claim_a_csrf_size_ceiling() {
     // Presign stays documented, as the opt-in advanced path.
     assert!(note.contains("ADVANCED (opt-in)"), "{note}");
     assert!(note.contains("complete_direct_upload"), "{note}");
+    assert!(note.contains("direct_upload_input"), "{note}");
     assert!(note.contains("examples/reddit-clone"), "{note}");
 }
 
@@ -904,7 +922,7 @@ fn generated_attachment_scaffold_multipart_test_passes() {
     patch_autumn_web_path(&project);
 
     let run = Command::new("cargo")
-        .args(["test", "--test", "photo"])
+        .args(["test"])
         .current_dir(&project)
         .output()
         .unwrap();
@@ -916,13 +934,186 @@ fn generated_attachment_scaffold_multipart_test_passes() {
     );
     let stdout = String::from_utf8_lossy(&run.stdout);
     for name in [
+        // `tests/photo.rs` — the write path.
         "photos_multipart_upload_binds_blob_key",
         "photos_multipart_upload_over_limit_is_413",
         "photos_multipart_create_without_file_is_null",
+        // `src/routes/photos.rs` — the read-back helpers.
+        "attachment_read_back_tests::renders_an_em_dash_when_the_column_is_null",
+        "attachment_read_back_tests::labels_the_link_from_the_column_and_the_stored_extension",
+        "attachment_read_back_tests::drops_the_anchor_when_no_url_could_be_signed",
+        "attachment_read_back_tests::keeps_only_a_short_safe_lowercase_extension",
     ] {
         assert!(
             stdout.contains(&format!("test {name} ... ok")),
             "generated test `{name}` must run and pass (it must not be ignored):\n{stdout}"
         );
     }
+}
+
+/// Issue #1236 review: `Blob` records the store key, media type and size — but
+/// not the uploaded file's name. Without help, the show/edit link text and its
+/// `download` filename were the raw key tail (`1785…_5cf1a2be-…`), so a
+/// download landed as an EXTENSIONLESS file that no application would open.
+/// The handler now folds a sanitized extension into the key, and the link is
+/// labelled `<column>.<ext>`.
+#[test]
+fn scaffold_attachment_preserves_a_safe_upload_extension() {
+    let (_tmp, project) = scaffold_project(
+        "attach-ext-app",
+        "Photo",
+        &["caption:String", "image:Attachment"],
+    );
+    let routes = fs::read_to_string(project.join("src/routes/photos.rs")).unwrap();
+
+    assert!(
+        routes.contains("fn upload_extension(file_name: Option<&str>) -> String {"),
+        "{routes}"
+    );
+    // Folded into the minted key, so the stored object carries the extension.
+    assert!(
+        routes.contains("upload_extension(field.file_name())"),
+        "the create/update key must carry the uploaded extension:\n{routes}"
+    );
+    assert!(
+        routes.contains("\"photos/image/{}_{}{}\""),
+        "the key keeps its timestamp + uuid uniqueness prefix:\n{routes}"
+    );
+
+    // The submitted name is attacker-controlled and lands in a `BlobStore` key,
+    // so only a short lowercase ASCII-alphanumeric run survives, and `.meta`
+    // (the local backend's sidecar suffix) is refused.
+    for guard in [
+        "ext.len() > 8",
+        "ext == \"meta\"",
+        "!ext.chars().all(|c| c.is_ascii_alphanumeric())",
+        ".map(|(_, ext)| ext.to_ascii_lowercase())",
+    ] {
+        assert!(
+            routes.contains(guard),
+            "upload_extension must keep the guard `{guard}`:\n{routes}"
+        );
+    }
+
+    // The link is labelled from the column, not the opaque key.
+    assert!(
+        routes.contains("Some((_, ext)) => format!(\"{label}.{ext}\"),"),
+        "{routes}"
+    );
+    assert!(
+        !routes.contains("rel=\"noopener\""),
+        "`rel=noopener` is inert without `target`; it must not imply a protection \
+         that isn't in play:\n{routes}"
+    );
+    // `download` stays: the local backend serves blobs from the app's own origin.
+    assert!(
+        routes.contains("a href=(url) download=(file_name)"),
+        "{routes}"
+    );
+}
+
+/// Issue #1236 review: the Cargo features make an attachment scaffold COMPILE,
+/// but `StorageConfig::backend` defaults to `Disabled` — so with no `[storage]`
+/// section the first upload answers 500 "storage not configured". The generator
+/// doesn't write the operator's config for them, but it must not let them
+/// discover this by hitting the 500.
+#[test]
+fn scaffold_attachment_warns_when_no_storage_backend_is_configured() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    run_autumn(tmp.path(), &["new", "attach-warn-app"]);
+    let project = tmp.path().join("attach-warn-app");
+
+    let autumn_bin = env!("CARGO_BIN_EXE_autumn");
+    let out = Command::new(autumn_bin)
+        .args(["generate", "scaffold", "Photo", "image:Attachment"])
+        .current_dir(&project)
+        .output()
+        .expect("failed to run autumn");
+    assert!(out.status.success());
+    let printed = format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        printed.contains("[storage]") && printed.contains("storage not configured"),
+        "generating an attachment scaffold must surface the missing storage \
+         backend and the TOML to add:\n{printed}"
+    );
+    assert!(printed.contains("backend = \"local\""), "{printed}");
+
+    // A plain scaffold has nothing to warn about.
+    let plain = Command::new(autumn_bin)
+        .args(["generate", "scaffold", "Article", "title:String"])
+        .current_dir(&project)
+        .output()
+        .expect("failed to run autumn");
+    let plain_printed = String::from_utf8_lossy(&plain.stdout).to_string();
+    assert!(
+        !plain_printed.contains("storage not configured"),
+        "{plain_printed}"
+    );
+}
+
+/// AC2, closing a coverage hole the #1236 audit found: nothing asserted the
+/// literal `enctype` in generated output — the guarantee was a two-hop chain of
+/// a generator string-match plus a separate framework unit test. Both scaffold
+/// form paths are checked here: the standard `form_for` path (where
+/// `FieldControl::File` flips the enctype inside the framework) and the
+/// `--live-validation` path (which hand-rolls its own `<form>` tag).
+#[test]
+fn scaffold_attachment_form_is_multipart_encoded() {
+    // Standard path: `form_for` derives the enctype from the File control, so
+    // assert the control is there AND that the framework turns it into an
+    // enctype (autumn/src/form.rs::form_for_file_field_sets_multipart).
+    let (_tmp, project) = scaffold_project("attach-enc-app", "Photo", &["image:Attachment"]);
+    let routes = fs::read_to_string(project.join("src/routes/photos.rs")).unwrap();
+    assert!(
+        routes.contains(".override_field(\"image\", autumn_web::form::FieldControl::File)"),
+        "{routes}"
+    );
+    // No hand-rolled enctype in the emitted markup on this path — it must come
+    // from the File control, so the two can never disagree. (The module's
+    // header note still mentions the enctype in prose, hence the markup-shaped
+    // needle rather than a bare `enctype=`.)
+    assert!(
+        !routes.contains("method=\"post\" enctype="),
+        "the standard path must not hand-roll an enctype:\n{routes}"
+    );
+
+    // `--live-validation` emits per-field inputs inside its own `<form>` tag, so
+    // it carries the enctype literally and needs its own guard.
+    let tmp = tempfile::tempdir().expect("tempdir");
+    run_autumn(tmp.path(), &["new", "attach-enc-lv-app"]);
+    let lv = tmp.path().join("attach-enc-lv-app");
+    run_autumn(
+        &lv,
+        &[
+            "generate",
+            "scaffold",
+            "Photo",
+            "image:Attachment",
+            "--live-validation",
+        ],
+    );
+    let lv_routes = fs::read_to_string(lv.join("src/routes/photos.rs")).unwrap();
+    assert!(
+        lv_routes.contains("method=\"post\" enctype=\"multipart/form-data\""),
+        "the --live-validation form must be multipart-encoded:\n{lv_routes}"
+    );
+    // Every form that posts the attachment carries it: new, edit, and both 422
+    // re-renders of each.
+    assert!(
+        lv_routes.matches("enctype=\"multipart/form-data\"").count() >= 4,
+        "every emitted create/update form must carry the enctype:\n{lv_routes}"
+    );
+
+    // A plain scaffold stays URL-encoded on both paths.
+    let (_tmp2, plain) = scaffold_project("plain-enc-app", "Article", &["title:String"]);
+    let plain_routes = fs::read_to_string(plain.join("src/routes/articles.rs")).unwrap();
+    assert!(!plain_routes.contains("enctype"), "{plain_routes}");
+    assert!(
+        !plain_routes.contains("FieldControl::File"),
+        "{plain_routes}"
+    );
 }

--- a/autumn/src/ui/widgets.css
+++ b/autumn/src/ui/widgets.css
@@ -157,6 +157,20 @@
     margin: 0;
 }
 
+/* Currently stored file shown above an attachment column's file input, and the
+   type/size annotation beside a rendered attachment link — issue #1236. A file
+   input can't be repopulated, so this line is the only signal that the record
+   already holds a blob. */
+.autumn-field__current {
+    font-size: 0.875rem;
+    margin: 0 0 0.25rem;
+}
+
+.autumn-attachment__meta {
+    font-size: 0.8125rem;
+    color: var(--text-muted);
+}
+
 /* ── Rich text (autumn-rich-text) — issue #1255 ───────────────────────────── */
 
 .autumn-rich-text {

--- a/docs/guide/storage.md
+++ b/docs/guide/storage.md
@@ -262,7 +262,46 @@ The S3 plugin lives in its own crate (`autumn-storage-s3`) so apps
 that don't need S3 don't pull in the AWS SDK tree. Peer plugins for
 other providers (GCS, Azure, B2) follow the same pattern.
 
+## Scaffolded uploads (no JavaScript)
+
+You rarely need to write any of the above by hand. Give `generate scaffold` an
+`Attachment` column and the whole upload path is emitted for you:
+
+```bash
+autumn generate scaffold post title:String cover:Attachment
+```
+
+The generated form carries `enctype="multipart/form-data"` and a plain
+`<input type="file">`; the `create`/`update` handlers take an
+`autumn_web::extract::Multipart` body, stream each file part to the configured
+`BlobStore` with `save_to_blob_store`, and persist the returned `Blob` on the
+record. An edit that doesn't re-upload preserves the existing attachment. The
+show and edit views render the stored file as a signed, time-bounded download
+link. No presign endpoint, no client JavaScript.
+
+The scaffold enables the `storage` and `multipart` features on `autumn-web` for
+you, but it does **not** write your `[storage]` config — `backend` defaults to
+`disabled`, so add the block above (`backend = "local"` for development) or the
+first upload answers `500 storage not configured`. The generator prints this
+reminder when it scaffolds an `Attachment` column.
+
+Uploads are capped by `security.upload.max_file_size_bytes` (default 16 MiB,
+exceeded → `413`) and `security.upload.max_request_size_bytes` (default 32 MiB).
+CSRF adds no ceiling of its own: the generated form renders the CSRF and
+submit-token hidden inputs as its first fields, so they always land inside
+`security.csrf.token_scan_bytes`.
+
+Because the local backend serves blobs from your app's own origin with the
+content type they were uploaded under, restrict what can be stored with
+`security.upload.allowed_mime_types` (and `reject_on_content_type_mismatch`)
+whenever uploads come from untrusted users.
+
 ## Direct uploads
+
+Direct-to-storage presigned uploads are the **opt-in advanced path** — reach for
+them when files are large enough that you don't want the bytes flowing through
+the app process, not as the default. The scaffolded multipart path above needs
+no JavaScript; this one does.
 
 Large files (video, high-res images, bulk CSV) can bypass the Autumn process
 entirely and go straight from the browser to the storage backend. The pattern:

--- a/skills/generate/SKILL.md
+++ b/skills/generate/SKILL.md
@@ -65,7 +65,7 @@ accept aliases like `Integer` or `Boolean`.
 | `DateTime` | `TIMESTAMPTZ NOT NULL` | `DateTime<Utc>` |
 | `Uuid` | `UUID NOT NULL` | `Uuid` |
 | `Bytea` | `BYTEA NOT NULL` | `Vec<u8>` |
-| `Attachment` | `JSONB NULL` (blob metadata) | `Option<Blob>` (always nullable) — **requires the `storage` feature**. **(trunk-dev)** the scaffold auto-enables autumn-web's `storage` + `multipart` (and uuid `v4`) in the project's Cargo.toml when an Attachment field is present, so it compiles with no manual edits; on published 0.5.0 add the `storage` feature by hand. **(trunk-dev)** the scaffold's create/update handlers take a `Multipart` extractor and stream to the blob store via `save_to_blob_store` (issue #1236) |
+| `Attachment` | `JSONB NULL` (blob metadata) | `Option<Blob>` (always nullable) — **requires the `storage` feature**. **(trunk-dev)** the scaffold auto-enables autumn-web's `storage` + `multipart` (and uuid `v4`) in the project's Cargo.toml when an Attachment field is present, so it compiles with no manual edits; on published 0.5.0 add the `storage` feature by hand. **(trunk-dev)** the scaffold's create/update handlers take a `Multipart` extractor and stream to the blob store via `save_to_blob_store`, and the show/edit views render the stored file as a signed download link (issue #1236) |
 | `Option<T>` | Nullable version of any above | `Option<T>` |
 | `references` **(trunk-dev)** | `post:references` → `post_id BIGINT NOT NULL REFERENCES posts(id)` + auto index | `i64` (field name gets `_id` appended; `post:references?` for `Option<i64>`) |
 | `enum{a,b,c}` **(trunk-dev)** | `TEXT` + `CHECK (col IN (...))` | Generated PascalCase Rust enum with Diesel/serde impls + `<select>` widget; `--default field=variant` sets SQL DEFAULT + `#[default]`. Quote the token in bash/zsh (brace expansion) |
@@ -225,7 +225,10 @@ columns excluded). Owner-scoped and `--live` indexes opt out (issue #1126).
 `Multipart` extractor and stream to the blob store via `save_to_blob_store`
 — the scaffold planner auto-enables autumn-web's `storage` and `multipart`
 features (and uuid's `v4`) in the project's Cargo.toml, so a freshly
-scaffolded resource compiles with no manual edits (issue #1236).
+scaffolded resource compiles with no manual edits. The show and edit views
+render the stored file as a signed, time-bounded download link
+(`attachment_url` / `attachment_link`), and the edit form labels the currently
+stored file above the file input (issue #1236).
 
 ### controller (trunk-dev)
 ```


### PR DESCRIPTION
Closes the remaining gaps in #1236.

## What was already done

Most of the issue shipped in 0.6.0: the `Multipart` create/update handlers, `save_to_blob_store` streaming, `FieldControl::File` + auto `enctype`, preserve-on-update, the presign-demoting handler note, the generated write-path test, and the `storage` + `multipart` feature auto-enablement. The issue is still open because the read-back half was missing, AC4 had no coverage at all, nothing ever *ran* the generated test, and two docs pointed authors back at the JavaScript path.

## What this adds

**AC3 — the show/edit views now render the stored attachment.** `show` previously emitted the literal string `"attachment"`. It now resolves a signed, time-bounded URL through the configured `BlobStore` (`attachment_url`) and renders a download link (`attachment_link`), degrading to the file name when no `[storage]` backend is configured. The edit form labels the currently stored file above the file input — a file `<input>` can't be repopulated, so there was no way to tell an empty column from one holding a blob you simply didn't replace — and renders identically on the 422 re-render. That last point is why `update` now loads the current row *before* validating; it also means the record policy runs before the form is handed back, and the policy denial joins the #1872 blob-cleanup paths so a forbidden update no longer orphans the just-uploaded file. The index list stays a presence marker: `widgets::Column`'s cell closure is synchronous and `presigned_url` is async.

**AC4 — the two clauses now have executable coverage.** The generated write-path test gained an oversized-upload case (driving the real `security.upload.max_file_size_bytes` knob, asserting `413` *and* that no object survives) and a no-file case (covering both the absent part and the empty-filename part a browser actually sends).

**AC6 — the emitted tests are now proven to pass.** A new `#[ignore]`d gate compiles and runs a freshly scaffolded project's suite. Both it and the pre-existing cargo-check gate are wired into `generator-conformance.yml` — the consolidated `cli_tests` binary's only other CI `--ignored` sweep filters on `offsite`, so they had never executed anywhere.

**AC5 — removed a false warning.** The handler note claimed a "~2 MiB size ceiling with CSRF on, rejected with 403", steering authors onto the presign path. `form_for` renders the CSRF and submit-token hidden inputs as the form's *first* fields, so both land inside `security.csrf.token_scan_bytes` however large the upload is (proven by `csrf.rs::post_large_multipart_token_first_streams_full_body_and_passes`). The note names the real limits instead. `render_form_for_helper`'s doc comment, which still described the deleted hidden-key design, was corrected too.

## Review follow-ups (second commit)

Four review passes — security, correctness across scaffold variants, AC compliance, DX. The correctness pass found no compile break across ~25 variants; these address the rest.

- **`show` now runs the record policy.** The link it renders is a signed bearer capability for the bytes, and the blob-serving route validates that signature and nothing else — so emitting one from a handler that never consults `can_show` would have made the generated policy's *"tighten this if shows should be gated"* comment untrue for the one column where it matters most. A no-op under the default policy, which allows reads.
- **The minted key carries a sanitized extension** from the uploaded filename, so a download opens in the right application instead of landing as an extensionless `1785…_5cf1a2be-…`. Only a short lowercase ASCII run survives, and the local backend's reserved `.meta` is refused. The link is labelled `<column>.<ext>` rather than the opaque key.
- **Corrected the `download` rationale** in the generated doc comment: it governs that anchor only, not direct navigation, so it isn't the durable control. Points at `security.upload.allowed_mime_types` instead.
- **A signing failure logs a warning** instead of silently degrading to a link-less name.
- **Generating an `Attachment` column warns when `autumn.toml` has no `[storage]` section** — `backend` defaults to `disabled`, so the first upload would otherwise answer `500 storage not configured`.
- **The scaffold emits unit tests for the read-back helpers** next to the code, so `cargo test` in the generated app covers the em-dash / no-link / labelled-link branches and the key-sanitizing rules.
- New tests for the emitted `enctype` on both form paths (`--live-validation`'s hand-rolled tag had none), the upload-extension rules, and the storage warning.
- `autumn-field__current` / `autumn-attachment__meta` are real classes in `widgets.css` rather than invented ones; the index rationale no longer claims a per-row round trip (signing is local); `rel="noopener"` dropped as inert without `target`; duplicated body-wrapping factored into `wrap_form_bodies`; `docs/guide/storage.md` documents the scaffolded no-JS path.

## Verification

- `cargo test -p autumn-cli` — 4,500 + 251 + 177 passing
- `cargo clippy -p autumn-cli --all-targets -- -D warnings` — clean
- `./scripts/pre-push-check.sh` — OK
- A freshly scaffolded project compiles warning-free; its full `cargo test` passes (4 read-back unit tests, 4 write-path tests, 2 template tests)

## Deliberately not done

- **No way to remove an attachment** once uploaded. A real functional gap, but not in the AC set and adjacent to the issue's "single attachment per field in this slice".
- **Non-attachment `show` handlers still don't authorize.** Pre-existing and cross-cutting; gating every scaffold's `show` is a separate change.
- **The generator doesn't write `[storage]` into `autumn.toml`.** That's the operator's file and the backend is a deployment decision, so this warns at generate time and documents it rather than deciding for them. Auto-writing it is a reasonable follow-up.
- Generated output isn't rustfmt'd (pre-existing; it's why the `Ok({ let …_url = …; layout(…) })` wrapper reads awkwardly).

Generator-only — no `autumn-web` API change. `widgets.css` gains two classes; no migration burden, and only newly generated code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NJFzcZ9mfoAjpuD4msL64F

---
_Generated by [Claude Code](https://claude.ai/code/session_01NJFzcZ9mfoAjpuD4msL64F)_