### PR TITLE
feat(sim): seed-sweep runner + sim-sweep CI job (W6 PR3, #1797)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -417,14 +417,14 @@ jobs:
           cargo test -p autumn-web --features sim-testing \
             --test sim_sweep_driver
 
-  # Sim seed sweep (W6 PR3, issue #1797): sweeps `AUTUMN_SIM_SEEDS` seeds
-  # sequentially (see `sim::sweep`'s module docs for why sequential, not
-  # parallel) through the `sim-sweep` `[[bin]]`'s built-in, deliberately
-  # CORRECT account demo scenario — this job proves the seed-sweep mechanism
-  # itself scales to many seeds without a false positive. A genuine invariant
-  # break IS caught and shrunk: that's the `sim_sweep_driver` DoD suite in the
-  # sqlite-runtime job above, not this job (which must always stay green).
-  # Structured like the `loom` job below: its own bounded, standalone step.
+  # Sim seed sweep (W6 PR3, issue #1797): sweeps `AUTUMN_SIM_SEEDS` seeds in
+  # parallel (see `sim::sweep`'s module docs) through the `sim-sweep` `[[bin]]`'s
+  # built-in, deliberately CORRECT account demo scenario — this job proves the
+  # seed-sweep mechanism itself scales to many seeds without a false positive.
+  # A genuine invariant break IS caught and shrunk: that's the
+  # `sim_sweep_driver` DoD suite in the sqlite-runtime job above, not this job
+  # (which must always stay green). Structured like the `loom` job below: its
+  # own bounded, standalone step.
   sim-sweep:
     name: Sim sweep (sim-testing)
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -417,14 +417,14 @@ jobs:
           cargo test -p autumn-web --features sim-testing \
             --test sim_sweep_driver
 
-  # Sim seed sweep (W6 PR3, issue #1797): sweeps `AUTUMN_SIM_SEEDS` seeds in
-  # parallel (see `sim::sweep`'s module docs) through the `sim-sweep` `[[bin]]`'s
-  # built-in, deliberately CORRECT account demo scenario — this job proves the
-  # seed-sweep mechanism itself scales to many seeds without a false positive.
-  # A genuine invariant break IS caught and shrunk: that's the
-  # `sim_sweep_driver` DoD suite in the sqlite-runtime job above, not this job
-  # (which must always stay green). Structured like the `loom` job below: its
-  # own bounded, standalone step.
+  # Sim seed sweep (W6 PR3, issue #1797): sweeps `AUTUMN_SIM_SEEDS` seeds
+  # sequentially (see `sim::sweep`'s module docs for why sequential, not
+  # parallel) through the `sim-sweep` `[[bin]]`'s built-in, deliberately
+  # CORRECT account demo scenario — this job proves the seed-sweep mechanism
+  # itself scales to many seeds without a false positive. A genuine invariant
+  # break IS caught and shrunk: that's the `sim_sweep_driver` DoD suite in the
+  # sqlite-runtime job above, not this job (which must always stay green).
+  # Structured like the `loom` job below: its own bounded, standalone step.
   sim-sweep:
     name: Sim sweep (sim-testing)
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -356,6 +356,10 @@ jobs:
         # dependency for `sim::op` — lint it here (alongside the sqlite lib
         # lint above) since it's not part of any other feature combo above.
         run: cargo clippy -p autumn-web --features "sqlite,sim-testing" --lib -- -D warnings
+      - name: Clippy (autumn-web bin, sim-sweep)
+        # `sim-sweep` (W6 PR3, issue #1797) is a `[[bin]]`, not part of `--lib`
+        # above, so it needs its own explicit clippy invocation.
+        run: cargo clippy -p autumn-web --features "sqlite,sim-testing" --bin sim-sweep -- -D warnings
       - name: Run the sqlite integration suite
         # Named sqlite `[[test]]` targets only. `test-support` is required by the
         # TestApp/Db-extractor-based tests (sqlite_db_extractor, sqlite_read_only_tx,
@@ -402,6 +406,36 @@ jobs:
         run: |
           cargo test -p autumn-web --features sim-testing \
             --test sim_op_driver
+      - name: Run the sim seed-sweep DoD suite (W6 PR3, issue #1797)
+        # `sim_sweep_driver` proves `sim::sweep::sweep_proptest` itself — finds
+        # and shrinks an injected invariant break across a batch of seeds,
+        # deterministic replay of the failing seed, and the cross-seed
+        # `sometimes!` non-vacuity aggregate. Same `sim-testing` feature gate
+        # and rationale as the op-driver DoD suite above; kept as its own step
+        # for the same reason (isolated `[[test]]` binary, no `sqlite` need).
+        run: |
+          cargo test -p autumn-web --features sim-testing \
+            --test sim_sweep_driver
+
+  # Sim seed sweep (W6 PR3, issue #1797): sweeps `AUTUMN_SIM_SEEDS` seeds
+  # sequentially (see `sim::sweep`'s module docs for why sequential, not
+  # parallel) through the `sim-sweep` `[[bin]]`'s built-in, deliberately
+  # CORRECT account demo scenario — this job proves the seed-sweep mechanism
+  # itself scales to many seeds without a false positive. A genuine invariant
+  # break IS caught and shrunk: that's the `sim_sweep_driver` DoD suite in the
+  # sqlite-runtime job above, not this job (which must always stay green).
+  # Structured like the `loom` job below: its own bounded, standalone step.
+  sim-sweep:
+    name: Sim sweep (sim-testing)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2.7.8
+      - name: Run the sim-sweep seed sweep
+        run: cargo run -p autumn-web --release --features sim-testing --bin sim-sweep
+        env:
+          AUTUMN_SIM_SEEDS: "512"
 
   # Genuine loom model checks: the loom_models test binary uses loom::sync::*
   # unconditionally, so loom::model() exhaustively explores thread interleavings

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -353,8 +353,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **sim-testing:** add the **seed-sweep runner** (`sim::sweep`, W6 PR3,
   #1797) and the CI-facing `sim-sweep` `[[bin]]`: `sweep_proptest(seeds,
   &strategy, body)` runs `Sim::run_proptest` across a batch of seeds on a
-  `std::thread::available_parallelism`-sized worker pool and reports the
-  lowest-index failing seed (if any), with its shrunk op-sequence — the
+  `std::thread::available_parallelism`-sized worker pool — each worker builds
+  and enters its own paused current-thread Tokio runtime (the same
+  construction `#[sim_test]` uses), so a `body` that mounts a real app via
+  `sim.build` (which starts the job runtime through `tokio::spawn`) doesn't
+  panic with "there is no reactor running" on a raw, contextless worker
+  thread — and reports the lowest-index failing seed (if any), with its
+  shrunk op-sequence. The
   library's own `SweepFailure` is caller-agnostic (it doesn't prescribe a
   replay command, since `sweep_proptest` has no idea what test or binary is
   calling it); the `sim-sweep` bin appends its own replay suggestion when it

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -379,10 +379,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   reports the new `SweepOutcome::Empty` rather than silently falling through
   to `Passed { seeds_run: 0 }` — the bin treats it as a failure (exit `1`) so
   a misconfigured seed count can't quietly green the CI job without testing
-  anything. `AUTUMN_SIM_SEEDS=1000 cargo run -p autumn-web --release
-  --features sim-testing --bin sim-sweep` sweeps seeds `0..1000` against a
-  built-in account demo scenario; a new standalone CI job runs it at seed
-  count 512 on every push/PR, structured like the `loom` job. [no-plugin]
+  anything. `embedded_config()` (the op-driver's internal proptest `Config`,
+  already forcing fork/timeout off regardless of ambient `PROPTEST_FORK`/
+  `PROPTEST_TIMEOUT`) now also pins the case count to a fixed 256, ignoring
+  `PROPTEST_CASES` entirely: `PROPTEST_CASES=0` would otherwise make a case
+  closure never run at all while still reporting success, and even a bare
+  "clamp to at least 1" would still collapse proptest's automatic shrink
+  budget (`cases × 4`) to 4 iterations, aborting shrinking early with a
+  far-from-minimal counterexample. `AUTUMN_SIM_SEEDS=1000 cargo run -p
+  autumn-web --release --features sim-testing --bin sim-sweep` sweeps seeds
+  `0..1000` against a built-in account demo scenario; a new standalone CI job
+  runs it at seed count 512 on every push/PR, structured like the `loom`
+  job. [no-plugin]
 - **sim-testing:** add a property-based **op-driver** (`sim::op`, W6 PR2,
   #1797) behind the new `sim-testing` feature: `Sim::gen_ops::<T>()` /
   `Sim::gen_ops_with(strategy)` deterministically draw an arbitrary `Vec<T>`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -352,25 +352,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (the generator emits 3.1.0). [no-plugin]
 - **sim-testing:** add the **seed-sweep runner** (`sim::sweep`, W6 PR3,
   #1797) and the CI-facing `sim-sweep` `[[bin]]`: `sweep_proptest(seeds,
-  &strategy, body)` runs `Sim::run_proptest` across a batch of seeds on a
-  `std::thread::available_parallelism`-sized worker pool — each worker builds
-  and enters its own paused current-thread Tokio runtime (the same
-  construction `#[sim_test]` uses), so a `body` that mounts a real app via
-  `sim.build` (which starts the job runtime through `tokio::spawn`) doesn't
-  panic with "there is no reactor running" on a raw, contextless worker
-  thread — and reports the lowest-index failing seed (if any), with its
-  shrunk op-sequence. The
-  library's own `SweepFailure` is caller-agnostic (it doesn't prescribe a
-  replay command, since `sweep_proptest` has no idea what test or binary is
-  calling it); the `sim-sweep` bin appends its own replay suggestion when it
-  prints a failure, since it knows its own invocation. Deterministic
-  regardless of thread scheduling, since every seed in the batch always runs
-  to completion before the lowest-index failure is selected. Folds every
-  proptest case's `sometimes!` observations (not just the last of up to 256
-  cases per seed — `Sim::run_proptest_with_case_hook` is a new `pub(crate)`
-  hook for this) into a cross-seed aggregate, so a fully-green sweep is only
-  reported as `Passed` when it is also non-vacuous (`Vacuous` otherwise, if
-  some label was observed but never satisfied anywhere in the range).
+  &strategy, body)` runs `Sim::run_proptest` sequentially across a batch of
+  seeds, stopping at the first failing seed and reporting its shrunk
+  op-sequence. `SweepFailure`'s `Display` is caller-agnostic (it doesn't
+  prescribe a replay command, since `sweep_proptest` has no idea what test or
+  binary is calling it); the `sim-sweep` bin appends its own replay
+  suggestion when it prints a failure, since it knows its own invocation.
+  Folds every proptest case's `sometimes!` observations (not just the last of
+  up to 256 cases per seed — `Sim::run_proptest_with_case_hook` is a new
+  `pub(crate)` hook for this) into a cross-seed aggregate, so a fully-green
+  sweep is only reported as `Passed` when it is also non-vacuous (`Vacuous`
+  otherwise, if some label was observed but never satisfied anywhere in the
+  range). Deliberately sequential rather than parallel across a worker pool:
+  review of an earlier revision surfaced that `TestApp::build` (what a
+  `body` mounting a real app calls) unconditionally touches process-global
+  state (the cache, the event bus, and — when jobs are configured — a global
+  job client), which concurrent workers would race on, and that
+  `Sim::run_proptest`'s sync-only `body` signature can't `.await`
+  `Sim::run_to_idle` to drain spawned background work even with a runtime
+  entered — both architectural, not patchable within this sweep. Sequential
+  execution sidesteps both; sweep-level threading was orthogonal to the
+  harness's actual concurrency-bug-finding power anyway (that comes from
+  exploring seeds against W1's single-threaded deterministic executor, not
+  from how many OS threads process the outer seed range).
   `AUTUMN_SIM_SEEDS=1000 cargo run -p autumn-web --release --features
   sim-testing --bin sim-sweep` sweeps seeds `0..1000` against a built-in
   account demo scenario; a new standalone CI job runs it at seed count 512 on

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -350,6 +350,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   guides (#2099). Also corrects stale rustdoc that advertised a `/v3/api-docs`
   default (the served default is `/openapi.json`) and an "OpenAPI 3.0" document
   (the generator emits 3.1.0). [no-plugin]
+- **sim-testing:** add the **seed-sweep runner** (`sim::sweep`, W6 PR3,
+  #1797) and the CI-facing `sim-sweep` `[[bin]]`: `sweep_proptest(seeds,
+  &strategy, body)` runs `Sim::run_proptest` sequentially across a batch of
+  seeds, stopping at the first failing seed and reporting its shrunk
+  op-sequence plus a replay command, and folds each seed's `sometimes!`
+  reachability into a cross-seed aggregate so a fully-green sweep is only
+  reported as `Passed` when it is also non-vacuous (`Vacuous` otherwise, if
+  some label was observed but never satisfied anywhere in the range). Runs
+  sequentially on one thread rather than in parallel — the `sometimes!`
+  non-vacuity registry is thread-local, and the sweep is documented as its
+  aggregator, so spreading seeds across OS threads would fragment it.
+  `AUTUMN_SIM_SEEDS=1000 cargo run -p autumn-web --release --features
+  sim-testing --bin sim-sweep` sweeps seeds `0..1000` against a built-in
+  account demo scenario; a new standalone CI job runs it at seed count 512 on
+  every push/PR, structured like the `loom` job. [no-plugin]
 - **sim-testing:** add a property-based **op-driver** (`sim::op`, W6 PR2,
   #1797) behind the new `sim-testing` feature: `Sim::gen_ops::<T>()` /
   `Sim::gen_ops_with(strategy)` deterministically draw an arbitrary `Vec<T>`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -352,19 +352,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (the generator emits 3.1.0). [no-plugin]
 - **sim-testing:** add the **seed-sweep runner** (`sim::sweep`, W6 PR3,
   #1797) and the CI-facing `sim-sweep` `[[bin]]`: `sweep_proptest(seeds,
-  &strategy, body)` runs `Sim::run_proptest` sequentially across a batch of
-  seeds, stopping at the first failing seed and reporting its shrunk
-  op-sequence plus a replay command, and folds each seed's `sometimes!`
-  reachability into a cross-seed aggregate so a fully-green sweep is only
-  reported as `Passed` when it is also non-vacuous (`Vacuous` otherwise, if
-  some label was observed but never satisfied anywhere in the range). Runs
-  sequentially on one thread rather than in parallel — the `sometimes!`
-  non-vacuity registry is thread-local, and the sweep is documented as its
-  aggregator, so spreading seeds across OS threads would fragment it.
-  `AUTUMN_SIM_SEEDS=1000 cargo run -p autumn-web --release --features
-  sim-testing --bin sim-sweep` sweeps seeds `0..1000` against a built-in
-  account demo scenario; a new standalone CI job runs it at seed count 512 on
-  every push/PR, structured like the `loom` job. [no-plugin]
+  &strategy, body)` runs `Sim::run_proptest` across a batch of seeds on a
+  `std::thread::available_parallelism`-sized worker pool and reports the
+  lowest-index failing seed (if any), with its shrunk op-sequence plus a
+  replay command — deterministic regardless of thread scheduling, since every
+  seed in the batch always runs to completion before the lowest-index failure
+  is selected. Folds every proptest case's `sometimes!` observations (not
+  just the last of up to 256 cases per seed — `Sim::run_proptest_with_case_hook`
+  is a new `pub(crate)` hook for this) into a cross-seed aggregate, so a
+  fully-green sweep is only reported as `Passed` when it is also non-vacuous
+  (`Vacuous` otherwise, if some label was observed but never satisfied
+  anywhere in the range). `AUTUMN_SIM_SEEDS=1000 cargo run -p autumn-web
+  --release --features sim-testing --bin sim-sweep` sweeps seeds `0..1000`
+  against a built-in account demo scenario; a new standalone CI job runs it
+  at seed count 512 on every push/PR, structured like the `loom` job.
+  [no-plugin]
 - **sim-testing:** add a property-based **op-driver** (`sim::op`, W6 PR2,
   #1797) behind the new `sim-testing` feature: `Sim::gen_ops::<T>()` /
   `Sim::gen_ops_with(strategy)` deterministically draw an arbitrary `Vec<T>`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -374,11 +374,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   execution sidesteps both; sweep-level threading was orthogonal to the
   harness's actual concurrency-bug-finding power anyway (that comes from
   exploring seeds against W1's single-threaded deterministic executor, not
-  from how many OS threads process the outer seed range).
-  `AUTUMN_SIM_SEEDS=1000 cargo run -p autumn-web --release --features
-  sim-testing --bin sim-sweep` sweeps seeds `0..1000` against a built-in
-  account demo scenario; a new standalone CI job runs it at seed count 512 on
-  every push/PR, structured like the `loom` job. [no-plugin]
+  from how many OS threads process the outer seed range). An empty seed range
+  (`AUTUMN_SIM_SEEDS=0`, or any empty iterator passed to `sweep_proptest`)
+  reports the new `SweepOutcome::Empty` rather than silently falling through
+  to `Passed { seeds_run: 0 }` — the bin treats it as a failure (exit `1`) so
+  a misconfigured seed count can't quietly green the CI job without testing
+  anything. `AUTUMN_SIM_SEEDS=1000 cargo run -p autumn-web --release
+  --features sim-testing --bin sim-sweep` sweeps seeds `0..1000` against a
+  built-in account demo scenario; a new standalone CI job runs it at seed
+  count 512 on every push/PR, structured like the `loom` job. [no-plugin]
 - **sim-testing:** add a property-based **op-driver** (`sim::op`, W6 PR2,
   #1797) behind the new `sim-testing` feature: `Sim::gen_ops::<T>()` /
   `Sim::gen_ops_with(strategy)` deterministically draw an arbitrary `Vec<T>`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -354,19 +354,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   #1797) and the CI-facing `sim-sweep` `[[bin]]`: `sweep_proptest(seeds,
   &strategy, body)` runs `Sim::run_proptest` across a batch of seeds on a
   `std::thread::available_parallelism`-sized worker pool and reports the
-  lowest-index failing seed (if any), with its shrunk op-sequence plus a
-  replay command — deterministic regardless of thread scheduling, since every
-  seed in the batch always runs to completion before the lowest-index failure
-  is selected. Folds every proptest case's `sometimes!` observations (not
-  just the last of up to 256 cases per seed — `Sim::run_proptest_with_case_hook`
-  is a new `pub(crate)` hook for this) into a cross-seed aggregate, so a
-  fully-green sweep is only reported as `Passed` when it is also non-vacuous
-  (`Vacuous` otherwise, if some label was observed but never satisfied
-  anywhere in the range). `AUTUMN_SIM_SEEDS=1000 cargo run -p autumn-web
-  --release --features sim-testing --bin sim-sweep` sweeps seeds `0..1000`
-  against a built-in account demo scenario; a new standalone CI job runs it
-  at seed count 512 on every push/PR, structured like the `loom` job.
-  [no-plugin]
+  lowest-index failing seed (if any), with its shrunk op-sequence — the
+  library's own `SweepFailure` is caller-agnostic (it doesn't prescribe a
+  replay command, since `sweep_proptest` has no idea what test or binary is
+  calling it); the `sim-sweep` bin appends its own replay suggestion when it
+  prints a failure, since it knows its own invocation. Deterministic
+  regardless of thread scheduling, since every seed in the batch always runs
+  to completion before the lowest-index failure is selected. Folds every
+  proptest case's `sometimes!` observations (not just the last of up to 256
+  cases per seed — `Sim::run_proptest_with_case_hook` is a new `pub(crate)`
+  hook for this) into a cross-seed aggregate, so a fully-green sweep is only
+  reported as `Passed` when it is also non-vacuous (`Vacuous` otherwise, if
+  some label was observed but never satisfied anywhere in the range).
+  `AUTUMN_SIM_SEEDS=1000 cargo run -p autumn-web --release --features
+  sim-testing --bin sim-sweep` sweeps seeds `0..1000` against a built-in
+  account demo scenario; a new standalone CI job runs it at seed count 512 on
+  every push/PR, structured like the `loom` job. [no-plugin]
 - **sim-testing:** add a property-based **op-driver** (`sim::op`, W6 PR2,
   #1797) behind the new `sim-testing` feature: `Sim::gen_ops::<T>()` /
   `Sim::gen_ops_with(strategy)` deterministically draw an arbitrary `Vec<T>`

--- a/autumn/Cargo.toml
+++ b/autumn/Cargo.toml
@@ -387,6 +387,18 @@ harness = false
 name = "inspector"
 harness = false
 
+# W6 PR3 seed-sweep runner (issue #1797): CI-facing driver for
+# `sim::sweep::sweep_proptest`. `required-features` (not a `#![cfg(...)]` file
+# guard, since a `[[bin]]` target — unlike a `[[test]]` — is simply skipped by
+# Cargo when its required feature is off, rather than needing to compile to an
+# empty stub) keeps it out of default builds: `cargo build`/`cargo run`
+# without `--features sim-testing` doesn't see this binary at all. Run:
+# `AUTUMN_SIM_SEEDS=1000 cargo run -p autumn-web --release --features sim-testing --bin sim-sweep`.
+[[bin]]
+name = "sim-sweep"
+path = "src/bin/sim_sweep.rs"
+required-features = ["sim-testing"]
+
 [[test]]
 name = "integration_tests"
 path = "tests/integration_tests.rs"
@@ -731,6 +743,21 @@ path = "tests/sim_assert.rs"
 [[test]]
 name = "sim_op_driver"
 path = "tests/sim_op_driver.rs"
+
+# W6 PR3 seed-sweep DoD (issue #1797): `sim::sweep::sweep_proptest` against the
+# same small, self-contained, deliberately buggy account model `sim_op_driver`
+# uses — proves the sweep finds and shrinks an injected invariant break across
+# a batch of seeds, that the failing seed reported is deterministic across
+# repeated sweeps, and that the cross-seed `sometimes!` non-vacuity aggregate
+# (`SweepOutcome::Vacuous`) fires when a reachability label is observed but
+# never satisfied anywhere in the swept range. Isolated `[[test]]` binary for
+# the same reason as `sim_op_driver`: needs the `sim-testing` feature, so the
+# file is `#![cfg(feature = "sim-testing")]` and a default `cargo test`
+# compiles it to an empty (passing) binary. Runs without Docker. Run:
+# `cargo test -p autumn-web --features sim-testing --test sim_sweep_driver`.
+[[test]]
+name = "sim_sweep_driver"
+path = "tests/sim_sweep_driver.rs"
 
 # Isolated: sets process-wide proxy env vars (HTTP_PROXY/HTTPS_PROXY/ALL_PROXY)
 # to verify pinned SSRF-safe clients bypass env proxies. Cannot share the

--- a/autumn/src/bin/sim_sweep.rs
+++ b/autumn/src/bin/sim_sweep.rs
@@ -1,7 +1,7 @@
 //! `sim-sweep`: the CI-facing driver for [`autumn_web::sim::sweep::sweep_proptest`]
 //! (sim-testing W6 PR3, issue #1797).
 //!
-//! Sweeps a batch of seeds, sequentially, against a small, self-contained,
+//! Sweeps a batch of seeds, in parallel, against a small, self-contained,
 //! deliberately **correct** account demo scenario (mirroring
 //! `tests/sim_op_driver.rs`'s worked example, but with the `Withdraw`
 //! floor-check bug fixed) — proving the seed-sweep mechanism itself scales to
@@ -42,14 +42,17 @@ enum Op {
 
 impl Arbitrary for Op {
     type Parameters = ();
-    type Strategy = BoxedStrategy<Self>;
+    // `SBoxedStrategy` (not `BoxedStrategy`), same reason as
+    // `sim_sweep_driver.rs`: `sweep_proptest` shares the strategy across a
+    // worker-thread pool via `&S`, which needs `S: Send + Sync`.
+    type Strategy = SBoxedStrategy<Self>;
 
     fn arbitrary_with((): ()) -> Self::Strategy {
         prop_oneof![
             (1u32..100).prop_map(Op::Deposit),
             (1u32..100).prop_map(Op::Withdraw),
         ]
-        .boxed()
+        .sboxed()
     }
 }
 

--- a/autumn/src/bin/sim_sweep.rs
+++ b/autumn/src/bin/sim_sweep.rs
@@ -1,7 +1,7 @@
 //! `sim-sweep`: the CI-facing driver for [`autumn_web::sim::sweep::sweep_proptest`]
 //! (sim-testing W6 PR3, issue #1797).
 //!
-//! Sweeps a batch of seeds, in parallel, against a small, self-contained,
+//! Sweeps a batch of seeds, sequentially, against a small, self-contained,
 //! deliberately **correct** account demo scenario (mirroring
 //! `tests/sim_op_driver.rs`'s worked example, but with the `Withdraw`
 //! floor-check bug fixed) — proving the seed-sweep mechanism itself scales to
@@ -42,17 +42,14 @@ enum Op {
 
 impl Arbitrary for Op {
     type Parameters = ();
-    // `SBoxedStrategy` (not `BoxedStrategy`), same reason as
-    // `sim_sweep_driver.rs`: `sweep_proptest` shares the strategy across a
-    // worker-thread pool via `&S`, which needs `S: Send + Sync`.
-    type Strategy = SBoxedStrategy<Self>;
+    type Strategy = BoxedStrategy<Self>;
 
     fn arbitrary_with((): ()) -> Self::Strategy {
         prop_oneof![
             (1u32..100).prop_map(Op::Deposit),
             (1u32..100).prop_map(Op::Withdraw),
         ]
-        .sboxed()
+        .boxed()
     }
 }
 

--- a/autumn/src/bin/sim_sweep.rs
+++ b/autumn/src/bin/sim_sweep.rs
@@ -1,0 +1,107 @@
+//! `sim-sweep`: the CI-facing driver for [`autumn_web::sim::sweep::sweep_proptest`]
+//! (sim-testing W6 PR3, issue #1797).
+//!
+//! Sweeps a batch of seeds, sequentially, against a small, self-contained,
+//! deliberately **correct** account demo scenario (mirroring
+//! `tests/sim_op_driver.rs`'s worked example, but with the `Withdraw`
+//! floor-check bug fixed) — proving the seed-sweep mechanism itself scales to
+//! many seeds without false positives. It is a smoke check for the harness,
+//! not a real app-level property; the `sim_sweep_driver` `DoD` test proves the
+//! mechanism catches a *genuine* invariant break, using the intentionally
+//! buggy variant of this same model.
+//!
+//! Structured like the `loom` CI job: its own bounded CI step
+//! (`.github/workflows/ci.yml`), not part of the normal `cargo test` run.
+//!
+//! # Usage
+//!
+//! ```text
+//! AUTUMN_SIM_SEEDS=1000 cargo run -p autumn-web --release --features sim-testing --bin sim-sweep
+//! ```
+//!
+//! `AUTUMN_SIM_SEEDS` is the number of seeds to sweep, starting at `0`
+//! (`0..AUTUMN_SIM_SEEDS`); defaults to 256 if unset or unparseable. Exits `0`
+//! if every seed passes and the sweep is non-vacuous (see
+//! [`autumn_web::sim::sweep`]'s module docs); exits `1` and prints either the
+//! first failing seed's shrunk op-sequence plus a replay command, or the
+//! unsatisfied `sometimes!` labels, on a failing or vacuous sweep.
+
+use autumn_web::sim::sweep::{SweepOutcome, sweep_proptest};
+use autumn_web::{always, sometimes};
+use proptest::prelude::*;
+
+const DEFAULT_SEED_COUNT: u64 = 256;
+
+/// The demo scenario this binary sweeps: a toy account op, mirroring
+/// `tests/sim_op_driver.rs`'s `Deposit`/`Withdraw` worked example.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Op {
+    Deposit(u32),
+    Withdraw(u32),
+}
+
+impl Arbitrary for Op {
+    type Parameters = ();
+    type Strategy = BoxedStrategy<Self>;
+
+    fn arbitrary_with((): ()) -> Self::Strategy {
+        prop_oneof![
+            (1u32..100).prop_map(Op::Deposit),
+            (1u32..100).prop_map(Op::Withdraw),
+        ]
+        .boxed()
+    }
+}
+
+/// Applies `ops` to a starting-from-zero balance and asserts the invariant
+/// "balance never goes negative" via `always!`.
+///
+/// Unlike `tests/sim_op_driver.rs`'s deliberately buggy twin, `Withdraw` here
+/// floors at zero (`amount.min(balance)`) instead of subtracting
+/// unconditionally — this binary's own sweep is expected to stay green.
+fn apply_ops(ops: &[Op]) {
+    let mut balance: i64 = 0;
+    for op in ops {
+        match *op {
+            Op::Deposit(amount) => balance += i64::from(amount),
+            Op::Withdraw(amount) => balance -= i64::from(amount).min(balance),
+        }
+        always!(balance >= 0, "balance went negative: {balance}");
+        sometimes!(balance == 0, "balance-returned-to-zero");
+    }
+}
+
+fn seed_count() -> u64 {
+    std::env::var("AUTUMN_SIM_SEEDS")
+        .ok()
+        .and_then(|value| value.parse().ok())
+        .unwrap_or(DEFAULT_SEED_COUNT)
+}
+
+fn main() {
+    let count = seed_count();
+    let strategy = proptest::collection::vec(any::<Op>(), 1..32);
+    println!("sim-sweep: sweeping {count} seed(s) (0..{count}) against the account demo scenario");
+
+    match sweep_proptest(0..count, &strategy, |_sim, ops| apply_ops(ops)) {
+        SweepOutcome::Passed { seeds_run } => {
+            println!("sim-sweep: PASSED — {seeds_run} seed(s), non-vacuous");
+        }
+        SweepOutcome::Failed { seeds_run, failure } => {
+            eprintln!("sim-sweep: FAILED after {seeds_run} seed(s)");
+            eprintln!("{failure}");
+            std::process::exit(1);
+        }
+        SweepOutcome::Vacuous {
+            seeds_run,
+            unsatisfied,
+        } => {
+            eprintln!(
+                "sim-sweep: VACUOUS — {seeds_run} seed(s) all passed, but sometimes! label(s) \
+                 were observed and never satisfied across the whole sweep: {}",
+                unsatisfied.into_iter().collect::<Vec<_>>().join(", ")
+            );
+            std::process::exit(1);
+        }
+    }
+}

--- a/autumn/src/bin/sim_sweep.rs
+++ b/autumn/src/bin/sim_sweep.rs
@@ -117,6 +117,15 @@ fn main() {
             );
             std::process::exit(1);
         }
+        SweepOutcome::Empty => {
+            // `count` was 0 (or somehow otherwise produced an empty range) —
+            // fail loudly rather than let a misconfigured AUTUMN_SIM_SEEDS
+            // silently green this CI job without testing anything.
+            eprintln!(
+                "sim-sweep: EMPTY — AUTUMN_SIM_SEEDS={count} swept zero seeds; nothing was tested"
+            );
+            std::process::exit(1);
+        }
     }
 }
 

--- a/autumn/src/bin/sim_sweep.rs
+++ b/autumn/src/bin/sim_sweep.rs
@@ -81,6 +81,19 @@ fn seed_count() -> u64 {
         .unwrap_or(DEFAULT_SEED_COUNT)
 }
 
+/// This binary's own replay suggestion for a failing `seed` — appended after
+/// `SweepFailure`'s (caller-agnostic) `Display` output, since only this
+/// binary knows it's the one being invoked. The count is decimal, matching
+/// `seed_count`'s decimal-only parser: printing it as hex here would
+/// silently fail to parse there and fall back to the default seed count
+/// instead of covering the failing seed.
+fn replay_command(seed: u64) -> String {
+    format!(
+        "  replay: AUTUMN_SIM_SEEDS={} cargo run -p autumn-web --release --features sim-testing --bin sim-sweep",
+        seed.wrapping_add(1),
+    )
+}
+
 fn main() {
     let count = seed_count();
     let strategy = proptest::collection::vec(any::<Op>(), 1..32);
@@ -93,6 +106,7 @@ fn main() {
         SweepOutcome::Failed { seeds_run, failure } => {
             eprintln!("sim-sweep: FAILED after {seeds_run} seed(s)");
             eprintln!("{failure}");
+            eprintln!("{}", replay_command(failure.seed));
             std::process::exit(1);
         }
         SweepOutcome::Vacuous {
@@ -106,5 +120,31 @@ fn main() {
             );
             std::process::exit(1);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn replay_command_emits_a_seed_count_that_covers_the_failing_seed_and_parses_as_plain_decimal()
+    {
+        let command = replay_command(300);
+        let count_str = command
+            .split("AUTUMN_SIM_SEEDS=")
+            .nth(1)
+            .and_then(|rest| rest.split_whitespace().next())
+            .expect("replay command must carry a seed count");
+        // Mirrors `seed_count`'s own decimal-only parser — this is the exact
+        // failure mode the P2 review comment caught: a hex count here would
+        // silently fail this same parse and fall back to `DEFAULT_SEED_COUNT`.
+        let count: u64 = count_str.parse().unwrap_or_else(|err| {
+            panic!("replay count {count_str:?} must parse as plain decimal u64: {err}")
+        });
+        assert!(
+            count > 300,
+            "replay count {count} must exceed the failing seed 300 so re-sweeping 0..{count} reaches it"
+        );
     }
 }

--- a/autumn/src/sim.rs
+++ b/autumn/src/sim.rs
@@ -49,9 +49,8 @@
 //!   property-based op-driver (`sim::op`) — `Sim::gen_ops`/`Sim::gen_ops_with` for
 //!   deterministic generation and `Sim::run_proptest` for shrink-capable runs —
 //!   plus a seed-sweep runner (`sim::sweep`): `sweep_proptest` runs
-//!   `Sim::run_proptest` across a batch of seeds on a worker-thread pool,
-//!   reporting the lowest-index failing seed, driven in CI by the
-//!   `sim-sweep` `[[bin]]`.
+//!   `Sim::run_proptest` sequentially across a batch of seeds, reporting the
+//!   first failing seed, driven in CI by the `sim-sweep` `[[bin]]`.
 //!
 //! Everything here is designed to grow additively (builder-style) without
 //! breaking the frozen surface — hence the `#[non_exhaustive]` markers.
@@ -130,11 +129,13 @@ pub use crash::{CrashPoint, CrashSchedule};
 pub mod op;
 
 // The W6 seed-sweep runner (PR3, issue #1797): `sweep_proptest` runs
-// `Sim::run_proptest` across a batch of seeds on a worker-thread pool,
-// reporting the lowest-index failing seed (if any), and folds `sometimes!`
-// reachability — across every proptest case in every seed — across the whole
-// swept range so a green sweep is provably non-vacuous. The `sim-sweep`
-// `[[bin]]` (`autumn/src/bin/sim_sweep.rs`) is its CI-facing driver. Same
+// `Sim::run_proptest` sequentially across a batch of seeds, reporting the
+// first failing seed (if any), and folds `sometimes!` reachability — across
+// every proptest case in every seed — across the whole swept range so a
+// green sweep is provably non-vacuous. Sequential, not parallel: see
+// `sim::sweep`'s module docs for why a `body` that mounts a real app makes
+// OS-thread parallelism unsafe here. The `sim-sweep` `[[bin]]`
+// (`autumn/src/bin/sim_sweep.rs`) is its CI-facing driver. Same
 // `sim-testing` feature gate as `op` — it builds directly on
 // `Sim::run_proptest_with_case_hook`.
 #[cfg(feature = "sim-testing")]

--- a/autumn/src/sim.rs
+++ b/autumn/src/sim.rs
@@ -49,8 +49,9 @@
 //!   property-based op-driver (`sim::op`) — `Sim::gen_ops`/`Sim::gen_ops_with` for
 //!   deterministic generation and `Sim::run_proptest` for shrink-capable runs —
 //!   plus a seed-sweep runner (`sim::sweep`): `sweep_proptest` runs
-//!   `Sim::run_proptest` across a batch of seeds, stopping and reporting at the
-//!   first failure, driven in CI by the `sim-sweep` `[[bin]]`.
+//!   `Sim::run_proptest` across a batch of seeds on a worker-thread pool,
+//!   reporting the lowest-index failing seed, driven in CI by the
+//!   `sim-sweep` `[[bin]]`.
 //!
 //! Everything here is designed to grow additively (builder-style) without
 //! breaking the frozen surface — hence the `#[non_exhaustive]` markers.
@@ -129,12 +130,13 @@ pub use crash::{CrashPoint, CrashSchedule};
 pub mod op;
 
 // The W6 seed-sweep runner (PR3, issue #1797): `sweep_proptest` runs
-// `Sim::run_proptest` sequentially across a batch of seeds, stopping (and
-// reporting) at the first failing seed, and folds `sometimes!` reachability
-// across the whole swept range so a green sweep is provably non-vacuous. The
-// `sim-sweep` `[[bin]]` (`autumn/src/bin/sim_sweep.rs`) is its CI-facing
-// driver. Same `sim-testing` feature gate as `op` — it builds directly on
-// `Sim::run_proptest_with_ref`.
+// `Sim::run_proptest` across a batch of seeds on a worker-thread pool,
+// reporting the lowest-index failing seed (if any), and folds `sometimes!`
+// reachability — across every proptest case in every seed — across the whole
+// swept range so a green sweep is provably non-vacuous. The `sim-sweep`
+// `[[bin]]` (`autumn/src/bin/sim_sweep.rs`) is its CI-facing driver. Same
+// `sim-testing` feature gate as `op` — it builds directly on
+// `Sim::run_proptest_with_case_hook`.
 #[cfg(feature = "sim-testing")]
 pub mod sweep;
 

--- a/autumn/src/sim.rs
+++ b/autumn/src/sim.rs
@@ -47,7 +47,10 @@
 //! - **W6** adds the [`always!`](crate::always) / [`sometimes!`](crate::sometimes)
 //!   assertion macros ([`mod@assert`]) and, behind the `sim-testing` feature, a
 //!   property-based op-driver (`sim::op`) — `Sim::gen_ops`/`Sim::gen_ops_with` for
-//!   deterministic generation and `Sim::run_proptest` for shrink-capable runs.
+//!   deterministic generation and `Sim::run_proptest` for shrink-capable runs —
+//!   plus a seed-sweep runner (`sim::sweep`): `sweep_proptest` runs
+//!   `Sim::run_proptest` across a batch of seeds, stopping and reporting at the
+//!   first failure, driven in CI by the `sim-sweep` `[[bin]]`.
 //!
 //! Everything here is designed to grow additively (builder-style) without
 //! breaking the frozen surface — hence the `#[non_exhaustive]` markers.
@@ -124,6 +127,19 @@ pub use crash::{CrashPoint, CrashSchedule};
 // `proptest` as a library (not just dev) dependency — see `autumn/Cargo.toml`.
 #[cfg(feature = "sim-testing")]
 pub mod op;
+
+// The W6 seed-sweep runner (PR3, issue #1797): `sweep_proptest` runs
+// `Sim::run_proptest` sequentially across a batch of seeds, stopping (and
+// reporting) at the first failing seed, and folds `sometimes!` reachability
+// across the whole swept range so a green sweep is provably non-vacuous. The
+// `sim-sweep` `[[bin]]` (`autumn/src/bin/sim_sweep.rs`) is its CI-facing
+// driver. Same `sim-testing` feature gate as `op` — it builds directly on
+// `Sim::run_proptest_with_ref`.
+#[cfg(feature = "sim-testing")]
+pub mod sweep;
+
+#[cfg(feature = "sim-testing")]
+pub use sweep::{SweepFailure, SweepOutcome, sweep_proptest};
 
 /// The fixed, deterministic epoch the simulation clock starts at:
 /// `2020-01-01T00:00:00Z`.

--- a/autumn/src/sim/op.rs
+++ b/autumn/src/sim/op.rs
@@ -229,11 +229,49 @@ impl Sim {
         S: Strategy<Value = Vec<T>>,
         F: Fn(&mut Self, &[T]),
     {
+        Self::run_proptest_with_case_hook(seed, strategy, body, || {})
+    }
+
+    /// As [`Sim::run_proptest_with_ref`], but additionally invokes `on_case`
+    /// immediately after every case's `body` returns *successfully* — before
+    /// proptest's runner tries the next case, which calls [`Sim::from_seed`]
+    /// again and so resets the [`sometimes!`](crate::sometimes) registry.
+    ///
+    /// [`sim::sweep`](super::sweep) is the only caller: a single seed's
+    /// `run_proptest` drives up to [`Config::default`]'s `cases` (256)
+    /// candidate op-sequences internally, each starting with a fresh registry
+    /// — reading [`sometimes_snapshot`](super::assert::sometimes_snapshot)
+    /// only once, *after* the whole seed finishes, would see just the last
+    /// case tried and silently drop every earlier case's observations. The
+    /// hook lets the sweep fold each case's snapshot before it's overwritten.
+    ///
+    /// Not invoked for a case whose `body` panics — the panic unwinds past
+    /// the hook call. That's fine here: a failing case stops the whole seed
+    /// (and the sweep reports the failure itself), so that case's
+    /// `sometimes!` observations never needed to feed into the non-vacuity
+    /// aggregate in the first place.
+    pub(crate) fn run_proptest_with_case_hook<T, S, F, H>(
+        seed: u64,
+        strategy: &S,
+        body: F,
+        on_case: H,
+    ) -> Result<(), TestError<Vec<T>>>
+    where
+        T: fmt::Debug,
+        S: Strategy<Value = Vec<T>>,
+        F: Fn(&mut Self, &[T]),
+        H: FnMut(),
+    {
+        // `TestRunner::run` requires the test closure to be `Fn`, but the hook
+        // is `FnMut` (it accumulates into a caller-owned set across calls) —
+        // a `RefCell` lets a single `Fn` closure call it repeatedly.
+        let on_case = std::cell::RefCell::new(on_case);
         let mut runner =
             TestRunner::new_with_rng(embedded_config(), stream_rng(seed, OP_GEN_STREAM_SALT));
         runner.run(strategy, |ops| {
             let mut sim = Self::from_seed(seed);
             body(&mut sim, &ops);
+            (on_case.borrow_mut())();
             Ok(())
         })
     }

--- a/autumn/src/sim/op.rs
+++ b/autumn/src/sim/op.rs
@@ -136,23 +136,43 @@ fn stream_rng(seed: u64, salt: u64) -> TestRng {
     TestRng::from_seed(RngAlgorithm::ChaCha, &bytes)
 }
 
+/// The case count [`embedded_config`] pins regardless of any ambient
+/// `PROPTEST_CASES` — matches proptest's own documented default
+/// (`Config::default().cases` absent any env override), so callers who never
+/// set `PROPTEST_CASES` see no behavior change.
+const EMBEDDED_CASES: u32 = 256;
+
 /// A [`Config`] for the embedded, in-process runners [`Sim::gen_ops_with`] and
 /// [`Sim::run_proptest`] own directly (as opposed to a runner `#[test]`-owned
 /// proptest picks up via `proptest!`/`#[proptest_derive]`).
 ///
 /// Disables proptest's own file-based failure persistence (see the module
 /// docs' "Determinism" section for why) and, since [`Config::default`] also
-/// pulls in whatever `PROPTEST_FORK` / `PROPTEST_TIMEOUT` env vars happen to
-/// be set process-wide, forces fork mode and the fork timeout off — this
-/// runner has no `test_name` to give proptest's forking machinery, so
-/// inheriting fork mode from the environment would panic
-/// (`Must supply test_name when forking enabled`) before a single op could be
-/// generated.
+/// pulls in whatever `PROPTEST_FORK` / `PROPTEST_TIMEOUT` / `PROPTEST_CASES`
+/// env vars happen to be set process-wide:
+///
+/// - forces fork mode and the fork timeout off — this runner has no
+///   `test_name` to give proptest's forking machinery, so inheriting fork
+///   mode from the environment would panic (`Must supply test_name when
+///   forking enabled`) before a single op could be generated;
+/// - pins the case count to [`EMBEDDED_CASES`], entirely ignoring
+///   `PROPTEST_CASES` — `PROPTEST_CASES=0` would otherwise make
+///   [`TestRunner::run`] return `Ok(())` without ever invoking the case
+///   closure, so `body` (and any `always!`/`sometimes!` inside it) never
+///   runs at all while [`Sim::run_proptest`] still reports success, silently
+///   defeating the whole point of the sweep this backs
+///   ([`sim::sweep`](super::sweep)). A bare `.max(1)` clamp would avoid that
+///   specific failure but still shrinks worse: proptest's automatic
+///   `max_shrink_iters` is `cases.saturating_mul(4)`, so clamping to the
+///   bare minimum of 1 case also collapses the shrink budget to 4
+///   iterations, aborting shrinking early with a far-from-minimal
+///   counterexample — pinning the whole case count sidesteps that too.
 fn embedded_config() -> Config {
     Config {
         failure_persistence: None,
         fork: false,
         timeout: 0,
+        cases: EMBEDDED_CASES,
         ..Config::default()
     }
 }
@@ -371,6 +391,25 @@ mod tests {
         assert_eq!(
             config.timeout, 0,
             "the embedded op-driver runner has no fork timeout to honor"
+        );
+    }
+
+    #[test]
+    fn embedded_config_pins_the_case_count_ignoring_proptest_cases() {
+        // `PROPTEST_CASES=0` in the environment would otherwise make
+        // `Config::default().cases` zero, so `TestRunner::run` returns
+        // `Ok(())` without ever invoking the case closure — `body` (and any
+        // `always!`/`sometimes!` inside it) never runs, yet `run_proptest`
+        // still reports success. A bare `.max(1)` clamp would avoid that but
+        // also collapse proptest's automatic shrink budget
+        // (`cases.saturating_mul(4)`) to 4 iterations — assert the exact
+        // pinned value instead, same reasoning as
+        // `embedded_config_forces_fork_and_timeout_off` above (the env var
+        // is read once, process-lifetime, via a `LazyLock`).
+        assert_eq!(
+            embedded_config().cases,
+            EMBEDDED_CASES,
+            "the embedded op-driver runner must always run exactly EMBEDDED_CASES cases"
         );
     }
 

--- a/autumn/src/sim/op.rs
+++ b/autumn/src/sim/op.rs
@@ -57,6 +57,29 @@
 //! `test_name` to hand proptest's forking machinery), so inheriting fork mode
 //! would panic instead of generating ops.
 //!
+//! # Calling `body` closures that mount an app
+//!
+//! [`Sim::run_proptest`] itself neither builds nor enters a Tokio runtime — it
+//! calls `body` directly, on whatever thread and in whatever ambient context
+//! the caller invoked it from (this predates the op-driver; it was already
+//! true of every earlier `Sim` entrypoint). A `body` that mounts a real app
+//! via [`Sim::build`] therefore needs the **caller** to already have an
+//! entered Tokio runtime — [`Sim::build`] starts the local job runtime
+//! through a bare `tokio::spawn` (`job.rs`) when the app configures jobs,
+//! which panics with `"there is no reactor running"` outside one. Call
+//! [`Sim::run_proptest`] synchronously from inside an already-running async
+//! context (e.g. a `#[tokio::test]` function, or code already inside
+//! `Runtime::block_on`) rather than from a bare `fn main()` or a plain,
+//! non-async `#[test]`.
+//!
+//! Even with a runtime entered, `body: Fn(&mut Sim, &[T])` is plain
+//! synchronous — it can never itself `.await` [`Sim::advance`] /
+//! [`Sim::run_to_idle`] to drain a mounted app's background job workers
+//! mid-body, so job-backed invariants are better proven with
+//! [`#[sim_test]`](crate::sim_test) (whose body is `async` and can drive
+//! `run_to_idle` directly) than with the op-driver until a future async-body
+//! variant of `run_proptest` exists.
+//!
 //! # Example
 //!
 //! ```rust,ignore
@@ -69,6 +92,9 @@
 //!     Transfer { to: u8, amount: u32 },
 //! }
 //!
+//! // Called from inside a `#[tokio::test]` (or otherwise already inside a
+//! // running Tokio runtime) — see "Calling `body` closures that mount an
+//! // app" above for why that's required here.
 //! let result = Sim::run_proptest(0, proptest::collection::vec(any::<Op>(), 1..32), |sim, ops| {
 //!     sim.build(app());
 //!     for op in ops {

--- a/autumn/src/sim/op.rs
+++ b/autumn/src/sim/op.rs
@@ -34,8 +34,8 @@
 //!    untouched.
 //! 3. **`proptest` promoted to an optional *library* dependency** behind the
 //!    new `sim-testing` feature (see `autumn/Cargo.toml`), since this module
-//!    lives in `src/`, not `tests/`, and the forthcoming `sim-sweep` `[[bin]]`
-//!    (W6 PR3) needs it as a lib dep too — a `[[bin]]` cannot use dev-deps.
+//!    lives in `src/`, not `tests/`, and the `sim-sweep` `[[bin]]` ([`sim::sweep`](super::sweep),
+//!    W6 PR3) needs it as a lib dep too — a `[[bin]]` cannot use dev-deps.
 //!
 //! # Determinism
 //!
@@ -196,13 +196,7 @@ impl Sim {
         S: Strategy<Value = Vec<T>>,
         F: Fn(&mut Self, &[T]),
     {
-        let mut runner =
-            TestRunner::new_with_rng(embedded_config(), stream_rng(seed, OP_GEN_STREAM_SALT));
-        let result = runner.run(&strategy, |ops| {
-            let mut sim = Self::from_seed(seed);
-            body(&mut sim, &ops);
-            Ok(())
-        });
+        let result = Self::run_proptest_with_ref(seed, &strategy, body);
         if let Err(ref err) = result
             && let TestError::Fail(ref reason, ref shrunk_ops) = *err
         {
@@ -212,6 +206,36 @@ impl Sim {
             );
         }
         result
+    }
+
+    /// The shared core [`Sim::run_proptest`] delegates to, taking `strategy`
+    /// by reference instead of by value.
+    ///
+    /// `pub(crate)` rather than a second public entrypoint: [`sim::sweep`](super::sweep)
+    /// is the only other caller, and it needs to run the **same** strategy and
+    /// body across many seeds without requiring either to be `Clone` — a
+    /// reference is enough because [`TestRunner::run`] itself only ever
+    /// borrows the strategy. Does not print the replay line; callers own their
+    /// own failure reporting ([`Sim::run_proptest`] prints its single-seed
+    /// line, [`sim::sweep`](super::sweep) reports the seed that stopped the
+    /// sweep).
+    pub(crate) fn run_proptest_with_ref<T, S, F>(
+        seed: u64,
+        strategy: &S,
+        body: F,
+    ) -> Result<(), TestError<Vec<T>>>
+    where
+        T: fmt::Debug,
+        S: Strategy<Value = Vec<T>>,
+        F: Fn(&mut Self, &[T]),
+    {
+        let mut runner =
+            TestRunner::new_with_rng(embedded_config(), stream_rng(seed, OP_GEN_STREAM_SALT));
+        runner.run(strategy, |ops| {
+            let mut sim = Self::from_seed(seed);
+            body(&mut sim, &ops);
+            Ok(())
+        })
     }
 }
 

--- a/autumn/src/sim/sweep.rs
+++ b/autumn/src/sim/sweep.rs
@@ -2,12 +2,14 @@
 //!
 //! This is the **sweep** lane of the sim harness: running
 //! [`Sim::run_proptest`] across a batch of seeds, in parallel, and reporting
-//! the lowest-index failing seed (if any) — its shrunk minimal op-sequence
-//! (proptest's own shrink loop, run per-seed by [`Sim::run_proptest`]) plus a
-//! deterministic replay command. The `sim-sweep` `[[bin]]`
-//! (`autumn/src/bin/sim_sweep.rs`) is the CI-facing driver; [`sweep_proptest`]
-//! is the reusable library function it (and the `sim_sweep_driver` `DoD`
-//! test) calls.
+//! the lowest-index failing seed (if any) and its shrunk minimal op-sequence
+//! (proptest's own shrink loop, run per-seed by [`Sim::run_proptest`]).
+//! [`sweep_proptest`] is a caller-agnostic public library function — it does
+//! not prescribe a replay command, since it has no idea what test or binary
+//! is calling it with what strategy; a caller that knows its own invocation
+//! context appends its own replay suggestion when it reports the failure
+//! (see `autumn/src/bin/sim_sweep.rs`, the CI-facing driver, for a worked
+//! example).
 //!
 //! # Design: parallel across available cores, full batch, deterministic result
 //!
@@ -79,20 +81,22 @@ pub struct SweepFailure<T> {
 
 impl<T: fmt::Debug> fmt::Display for SweepFailure<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        // The replay count is decimal, matching `AUTUMN_SIM_SEEDS`'s own
-        // decimal parser (`sim_sweep.rs`'s `seed_count`) — printing it as hex
-        // here would silently fail to parse and fall back to the default
-        // seed count, producing a replay command that doesn't actually
-        // replay the reported failure.
+        // Caller-agnostic — [`sweep_proptest`] is a public library function
+        // any application can call with its own strategy/body, so this must
+        // not prescribe a specific command (that was a real bug: it used to
+        // hard-code the `sim-sweep` bin's own invocation, which runs an
+        // unrelated built-in demo and can pass even when the reported seed
+        // reliably fails the *caller's* property). Mirrors
+        // [`Sim::run_proptest`]'s own replay line for the same reason — a
+        // caller that knows its own invocation context (like the `sim-sweep`
+        // bin) appends its own replay suggestion when it prints this.
         write!(
             f,
-            "AUTUMN_SIM_SEED=0x{:x} — shrunk to {} op(s): {:?} ({})\n  \
-             replay: AUTUMN_SIM_SEEDS={} cargo run -p autumn-web --release --features sim-testing --bin sim-sweep",
+            "AUTUMN_SIM_SEED=0x{:x} — shrunk to {} op(s): {:?} ({})",
             self.seed,
             self.shrunk_ops.len(),
             self.shrunk_ops,
             self.reason,
-            self.seed.wrapping_add(1),
         )
     }
 }
@@ -244,34 +248,27 @@ mod tests {
     }
 
     #[test]
-    fn failure_display_prints_a_decimal_replay_count_that_covers_the_failing_seed() {
-        // `AUTUMN_SIM_SEEDS` (`sim_sweep.rs`'s `seed_count`) parses with plain
-        // `str::parse::<u64>()`, i.e. decimal only — printing the replay count
-        // as `0x…` here would silently fail to parse there and fall back to
-        // the default seed count, producing a replay command that doesn't
-        // actually cover (and so can't reproduce) the reported failure.
+    fn failure_display_is_caller_agnostic_and_does_not_prescribe_a_replay_command() {
+        // `sweep_proptest` is a public library function any application can
+        // call with its own strategy/body — `Display` used to hard-code a
+        // `cargo run ... --bin sim-sweep` suggestion, which is wrong for
+        // every caller except that one specific demo binary (that command
+        // runs sim-sweep's *own* built-in scenario, not the caller's). A
+        // caller that knows its own invocation context appends its own
+        // suggestion instead (see `sim_sweep.rs`'s `main`).
         let failure = SweepFailure {
             seed: 300u64,
             shrunk_ops: vec![TinyOp::Inc],
             reason: "example".to_owned(),
         };
         let rendered = failure.to_string();
-        let replay_line = rendered
-            .lines()
-            .find(|line| line.contains("AUTUMN_SIM_SEEDS="))
-            .expect("Display must print a replay line");
-        let count_str = replay_line
-            .split("AUTUMN_SIM_SEEDS=")
-            .nth(1)
-            .and_then(|rest| rest.split_whitespace().next())
-            .expect("replay line must carry a seed count");
-        let count: u64 = count_str.parse().unwrap_or_else(|err| {
-            panic!("replay count {count_str:?} must parse as plain decimal u64: {err}")
-        });
         assert!(
-            count > failure.seed,
-            "replay count {count} must exceed the failing seed {} so re-sweeping 0..{count} reaches it",
-            failure.seed
+            !rendered.contains("cargo run") && !rendered.contains("sim-sweep"),
+            "Display must not prescribe a specific replay command, got: {rendered:?}"
+        );
+        assert!(
+            rendered.contains("0x12c"),
+            "Display must still report the failing seed, got: {rendered:?}"
         );
     }
 

--- a/autumn/src/sim/sweep.rs
+++ b/autumn/src/sim/sweep.rs
@@ -1,8 +1,8 @@
 //! Seed sweep runner (sim-testing W6 PR3, issue #1797).
 //!
 //! This is the **sweep** lane of the sim harness: running
-//! [`Sim::run_proptest`] across a batch of seeds, in parallel, and reporting
-//! the lowest-index failing seed (if any) and its shrunk minimal op-sequence
+//! [`Sim::run_proptest`] across a batch of seeds, sequentially, and reporting
+//! the first failing seed (if any) and its shrunk minimal op-sequence
 //! (proptest's own shrink loop, run per-seed by [`Sim::run_proptest`]).
 //! [`sweep_proptest`] is a caller-agnostic public library function — it does
 //! not prescribe a replay command, since it has no idea what test or binary
@@ -11,39 +11,61 @@
 //! (see `autumn/src/bin/sim_sweep.rs`, the CI-facing driver, for a worked
 //! example).
 //!
-//! # Design: parallel across available cores, full batch, deterministic result
+//! # Design: sequential, not parallel — and why that's not a regression
 //!
-//! [`sweep_proptest`] dispatches the swept seeds across a
-//! [`std::thread::available_parallelism`]-sized worker pool
-//! ([`std::thread::scope`], no new dependency) rather than one seed at a
-//! time. Two things make that safe and still fully deterministic:
+//! An earlier revision of this module parallelized the sweep across a
+//! `std::thread`-per-core worker pool. Review caught four escalating,
+//! genuinely real bugs in that design, and the last two are not
+//! patch-level fixes — they're a hard architectural wall:
 //!
-//! - The only shared mutable state a `Sim` run touches is the
-//!   [`sometimes!`](crate::sometimes) reachability registry
-//!   ([`sim::assert`](super::assert)), and it's **thread-local** — every
-//!   other seam (`SimRng`, the clock, chaos/crash schedules) is a pure
-//!   function of the seed, owned by that seed's own `Sim` value. Each worker
-//!   folds *its own* thread's registry into a seed-local accumulator (see
-//!   below) before handing that off to a shared aggregate — never reading or
-//!   resetting another thread's registry.
-//! - Every seed in the requested range is run to completion (no worker
-//!   aborts early just because a peer found a failure elsewhere in the
-//!   batch). After every worker finishes, the **lowest-index** failing seed
-//!   among everything collected is reported — deterministic regardless of
-//!   which worker happened to reach a failure first. This trades "stop the
-//!   instant any failure is found" for a simpler, race-free result; for a
-//!   *bounded* batch (`AUTUMN_SIM_SEEDS=N`, not an open-ended search) the
-//!   worst-case total work is the same either way (≤ N seed-runs), so the
-//!   only real cost is CI wall-clock in the failing case, not correctness.
+//! - **Process-global state.** `TestApp::build` (what `Sim::build`/`body`
+//!   calls to mount a real app) unconditionally clears process-global state
+//!   at the top of the function — the cache (`crate::cache::clear_global_cache`)
+//!   and the event bus (`crate::events::clear_global_event_bus`) — and, when
+//!   the app configures jobs, installs a process-global `GLOBAL_JOB_CLIENT`
+//!   (`job.rs`). None of this is per-`Sim`-instance or thread-local. Two
+//!   `body` closures calling `sim.build(...)` **concurrently** on different
+//!   worker threads race on all of it — one seed's app can clear or
+//!   redirect another seed's cache, event bus, or job routing mid-run. This
+//!   isn't something a worker-local fix (like the paused-runtime-per-worker
+//!   fix an intermediate revision added) can solve; it needs either a global
+//!   lock serializing every `sim.build`-calling case (which defeats the
+//!   point of parallelizing exactly the scenarios that matter most) or
+//!   process-per-worker isolation (far outside this PR's scope).
+//! - **The sync-only `body` signature can't drive spawned work.**
+//!   `Sim::run_proptest`'s `body: Fn(&mut Sim, &[T])` is plain synchronous —
+//!   it cannot `.await` anything, so it can never call [`Sim::advance`] or
+//!   [`Sim::run_to_idle`] (both `async fn`) to actually drain a mounted
+//!   app's background job workers. Merely `.enter()`ing a Tokio runtime on
+//!   each worker (as the intermediate revision did) stops `tokio::spawn`
+//!   from panicking, but never *polls* the runtime, so any spawned
+//!   background tasks stay permanently inert — a job-backed property would
+//!   silently test against an app whose workers never run. Fixing this for
+//!   real needs `Sim::run_proptest`'s body to become async — a breaking
+//!   change to the already-shipped W6 PR2 signature, out of scope here.
 //!
-//! Each worker also builds and [`enter`](tokio::runtime::Runtime::enter)s its
-//! **own** paused current-thread Tokio runtime — the exact construction
-//! [`#[sim_test]`](crate::sim_test) uses — for its whole lifetime, reused
-//! across every seed it processes. A raw `std::thread::scope` thread
-//! otherwise inherits no ambient Tokio context, so a `body` that mounts a
-//! real app (`sim.build`, which starts the job runtime via `tokio::spawn`)
-//! would panic with "there is no reactor running" — a real bug an earlier
-//! revision of this parallelization had, caught in review.
+//! Both are specific to `body` closures that call `sim.build`/mount a real
+//! app — every scenario this PR actually ships (the `sim-sweep` bin's demo,
+//! `sim_sweep_driver`'s `DoD` tests, this module's own unit tests) is a
+//! self-contained op-application model with no app-mounting at all, so
+//! neither bug is reachable from anything merged here. But `sweep_proptest`
+//! is a *public* function; a future caller mounting a real app is exactly
+//! the scenario the whole sim-testing effort exists for, and it must not
+//! silently corrupt itself. Sequential execution sidesteps both bugs
+//! entirely — there is never more than one `body` invocation in flight, so
+//! there is nothing to race regardless of what `body` does — while costing
+//! only sweep wall-clock, not correctness or coverage: **sweep-level
+//! threading is orthogonal to the harness's actual concurrency-bug-finding
+//! power**, which comes from exploring different seeds (each driving a
+//! *single-threaded, deterministic* `Sim` executor internally, per W1's
+//! design), not from how many OS threads process the outer seed range.
+//!
+//! This also matches the already-shipped W6 PR1 [`sometimes!`](crate::sometimes)
+//! non-vacuity registry ([`sim::assert`](super::assert)), whose own module
+//! docs already named this exact sweep as "the sweep (which runs seeds
+//! sequentially on one thread)" — sequential was the original, reviewed
+//! design; the parallel revision was a detour that review correctly walked
+//! back.
 //!
 //! # Non-vacuity
 //!
@@ -65,8 +87,6 @@
 
 use std::collections::BTreeSet;
 use std::fmt;
-use std::sync::Mutex;
-use std::sync::atomic::{AtomicUsize, Ordering};
 
 use proptest::strategy::Strategy;
 use proptest::test_runner::TestError;
@@ -77,8 +97,8 @@ use super::assert::{reset_sometimes_registry, sometimes_snapshot};
 /// The seed a sweep reports as failing, and why.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SweepFailure<T> {
-    /// The lowest-index seed (in sweep order) whose [`Sim::run_proptest`] run
-    /// failed among every seed in the swept batch.
+    /// The first seed (in sweep order) whose [`Sim::run_proptest`] run
+    /// failed; the sweep stopped there without running any later seed.
     pub seed: u64,
     /// The minimal op-sequence proptest shrunk this seed's failure down to.
     /// Empty for a [`TestError::Abort`] (the run itself could not proceed —
@@ -116,13 +136,14 @@ pub enum SweepOutcome<T> {
     /// Every swept seed passed, and every [`sometimes!`](crate::sometimes)
     /// label observed across the whole sweep was satisfied at least once.
     Passed {
-        /// How many seeds were run.
+        /// How many seeds were run before the sweep concluded.
         seeds_run: u64,
     },
-    /// `failure` is the lowest-index seed (in sweep order) that failed.
+    /// `failure.seed` was the first seed (in sweep order) to fail; the sweep
+    /// stopped there without running any later seed.
     Failed {
-        /// How many seeds were run (always the full requested batch — see
-        /// the module docs for why the sweep doesn't abort early).
+        /// How many seeds were run before the sweep stopped (includes the
+        /// failing seed itself).
         seeds_run: u64,
         /// The failing seed and its shrunk reproduction.
         failure: SweepFailure<T>,
@@ -138,115 +159,60 @@ pub enum SweepOutcome<T> {
     },
 }
 
-/// Sweep `seeds` across a worker pool through [`Sim::run_proptest`].
+/// Sweep `seeds` sequentially through [`Sim::run_proptest`].
 ///
-/// Reports the lowest-index failing seed (if any), folding every case's
+/// Stops at the first failing seed (fail-fast) and folds every case's
 /// [`sometimes!`](crate::sometimes) observations (not just the last case per
-/// seed) into a cross-seed non-vacuity aggregate. See the module docs for the
-/// parallelism and non-vacuity design.
+/// seed) into a cross-seed non-vacuity aggregate. See the module docs for why
+/// this runs sequentially rather than in parallel.
 ///
-/// `strategy` and `body` are each shared by reference across every seed and
-/// every worker — neither needs to be `Clone`.
-///
-/// # Panics
-///
-/// Panics if a worker thread panics while holding the internal aggregation
-/// lock — this does not happen in ordinary use: a panic inside `body` (e.g.
-/// an [`always!`](crate::always) violation) is caught by proptest's
-/// `TestRunner` itself and turned into a case failure, never propagating to
-/// the worker thread.
+/// `strategy` and `body` are each shared by reference across every seed —
+/// neither needs to be `Clone`.
 pub fn sweep_proptest<T, S, F>(
     seeds: impl IntoIterator<Item = u64>,
     strategy: &S,
     body: F,
 ) -> SweepOutcome<T>
 where
-    T: fmt::Debug + Send,
-    S: Strategy<Value = Vec<T>> + Sync,
-    F: Fn(&mut Sim, &[T]) + Sync,
+    T: fmt::Debug,
+    S: Strategy<Value = Vec<T>>,
+    F: Fn(&mut Sim, &[T]),
 {
-    let seeds: Vec<u64> = seeds.into_iter().collect();
-    let seeds_run = seeds.len() as u64;
-    let worker_count = std::thread::available_parallelism()
-        .map_or(1, std::num::NonZero::get)
-        .min(seeds.len().max(1));
+    let mut seeds_run = 0u64;
+    let mut all_observed = BTreeSet::new();
+    let mut all_satisfied = BTreeSet::new();
 
-    let next_index = AtomicUsize::new(0);
-    let aggregate: Mutex<(BTreeSet<String>, BTreeSet<String>)> =
-        Mutex::new((BTreeSet::new(), BTreeSet::new()));
-    // (seed index, failure) for every seed in the batch that failed —
-    // reduced to the lowest-index entry after every worker has finished the
-    // whole batch, so the reported seed never depends on thread scheduling.
-    let failures: Mutex<Vec<(usize, SweepFailure<T>)>> = Mutex::new(Vec::new());
+    for seed in seeds {
+        seeds_run += 1;
 
-    std::thread::scope(|scope| {
-        for _ in 0..worker_count {
-            scope.spawn(|| {
-                // A raw `std::thread::scope` worker inherits no ambient Tokio
-                // context — unlike `#[sim_test]`'s single `block_on`-driven
-                // thread, which every case in the (formerly sequential) sweep
-                // used to share. A `body` that mounts a real app (`sim.build`,
-                // which starts the job runtime via `tokio::spawn` —
-                // `job.rs`'s worker-loop spawn) would panic with "there is no
-                // reactor running" without this. One paused current-thread
-                // runtime per worker, entered for its whole lifetime — mirrors
-                // `#[sim_test]`'s own runtime exactly (`sim_test.rs`), reused
-                // across every seed this worker processes rather than rebuilt
-                // per seed.
-                let __sweep_worker_runtime = tokio::runtime::Builder::new_current_thread()
-                    .enable_all()
-                    .start_paused(true)
-                    .build()
-                    .expect("failed to build a paused sim runtime for this sweep worker");
-                let _sweep_worker_runtime_guard = __sweep_worker_runtime.enter();
+        let mut seed_observed = BTreeSet::new();
+        let mut seed_satisfied = BTreeSet::new();
+        let result = Sim::run_proptest_with_case_hook(seed, strategy, &body, || {
+            let (observed, satisfied) = sometimes_snapshot();
+            seed_observed.extend(observed);
+            seed_satisfied.extend(satisfied);
+            reset_sometimes_registry();
+        });
 
-                loop {
-                    let index = next_index.fetch_add(1, Ordering::Relaxed);
-                    let Some(&seed) = seeds.get(index) else {
-                        break;
-                    };
+        all_observed.extend(seed_observed);
+        all_satisfied.extend(seed_satisfied);
 
-                    let mut seed_observed = BTreeSet::new();
-                    let mut seed_satisfied = BTreeSet::new();
-                    let result = Sim::run_proptest_with_case_hook(seed, strategy, &body, || {
-                        let (observed, satisfied) = sometimes_snapshot();
-                        seed_observed.extend(observed);
-                        seed_satisfied.extend(satisfied);
-                        reset_sometimes_registry();
-                    });
-
-                    {
-                        let mut agg = aggregate.lock().unwrap();
-                        agg.0.extend(seed_observed);
-                        agg.1.extend(seed_satisfied);
-                    }
-
-                    if let Err(err) = result {
-                        let (reason, shrunk_ops) = match err {
-                            TestError::Fail(reason, shrunk_ops) => (reason.to_string(), shrunk_ops),
-                            TestError::Abort(reason) => (format!("aborted: {reason}"), Vec::new()),
-                        };
-                        failures.lock().unwrap().push((
-                            index,
-                            SweepFailure {
-                                seed,
-                                shrunk_ops,
-                                reason,
-                            },
-                        ));
-                    }
-                }
-            });
+        if let Err(err) = result {
+            let (reason, shrunk_ops) = match err {
+                TestError::Fail(reason, shrunk_ops) => (reason.to_string(), shrunk_ops),
+                TestError::Abort(reason) => (format!("aborted: {reason}"), Vec::new()),
+            };
+            return SweepOutcome::Failed {
+                seeds_run,
+                failure: SweepFailure {
+                    seed,
+                    shrunk_ops,
+                    reason,
+                },
+            };
         }
-    });
-
-    let mut failures = failures.into_inner().unwrap();
-    failures.sort_by_key(|(index, _)| *index);
-    if let Some((_, failure)) = failures.into_iter().next() {
-        return SweepOutcome::Failed { seeds_run, failure };
     }
 
-    let (all_observed, all_satisfied) = aggregate.into_inner().unwrap();
     let unsatisfied: BTreeSet<String> = all_observed.difference(&all_satisfied).cloned().collect();
     if unsatisfied.is_empty() {
         SweepOutcome::Passed { seeds_run }
@@ -272,29 +238,6 @@ mod tests {
 
     fn tiny_op_strategy() -> impl Strategy<Value = Vec<TinyOp>> {
         proptest::collection::vec(prop_oneof![Just(TinyOp::Inc), Just(TinyOp::Dec)], 0..16)
-    }
-
-    #[test]
-    fn sweep_workers_have_a_reactor_so_body_can_spawn_tokio_tasks() {
-        // A raw `std::thread::scope` worker inherits no ambient Tokio
-        // context. A `body` that mounts a real app (`sim.build`) starts the
-        // job runtime via a bare `tokio::spawn` (`job.rs`) — reproduce that
-        // exact failure mode directly (no need for the full `TestApp`/job
-        // machinery) with `tokio::spawn` in `body`: it would panic with
-        // "there is no reactor running" on a worker with no runtime entered.
-        // `worker_count` in `sweep_proptest` is
-        // `available_parallelism().min(seeds.len())`, so a range with more
-        // seeds than one guarantees more than one worker thread is exercised
-        // whenever this test runs on a multi-core machine.
-        let strategy = tiny_op_strategy();
-        let outcome = sweep_proptest(0..16, &strategy, |_sim, _ops| {
-            let _ = tokio::spawn(async {});
-        });
-        assert!(
-            matches!(outcome, SweepOutcome::Passed { seeds_run: 16 }),
-            "every worker must have an entered Tokio runtime so `tokio::spawn` \
-             in `body` doesn't panic, got {outcome:?}"
-        );
     }
 
     #[test]
@@ -377,7 +320,7 @@ mod tests {
     }
 
     #[test]
-    fn sweep_finds_the_lowest_index_failing_seed_in_the_batch() {
+    fn sweep_stops_at_the_first_failing_seed_and_shrinks_it() {
         // Fails whenever three or more `Inc`s appear back to back.
         let strategy = tiny_op_strategy();
         let outcome = sweep_proptest(0..16, &strategy, |_sim, ops| {
@@ -389,10 +332,7 @@ mod tests {
         });
         match outcome {
             SweepOutcome::Failed { seeds_run, failure } => {
-                assert_eq!(
-                    seeds_run, 16,
-                    "the full batch runs regardless of where the failure is"
-                );
+                assert!(seeds_run >= 1);
                 assert_eq!(
                     failure.shrunk_ops,
                     vec![TinyOp::Inc, TinyOp::Inc, TinyOp::Inc]

--- a/autumn/src/sim/sweep.rs
+++ b/autumn/src/sim/sweep.rs
@@ -1,43 +1,61 @@
 //! Seed sweep runner (sim-testing W6 PR3, issue #1797).
 //!
 //! This is the **sweep** lane of the sim harness: running
-//! [`Sim::run_proptest`] across a batch of seeds, stopping at the first
-//! failing seed and reporting it — its shrunk minimal op-sequence (proptest's
-//! own shrink loop, run per-seed by [`Sim::run_proptest`]) plus a
-//! deterministic replay seed. The `sim-sweep` `[[bin]]` (`autumn/src/bin/sim_sweep.rs`)
-//! is the CI-facing driver; [`sweep_proptest`] is the reusable library
-//! function it (and the `sim_sweep_driver` `DoD` test) calls.
+//! [`Sim::run_proptest`] across a batch of seeds, in parallel, and reporting
+//! the lowest-index failing seed (if any) — its shrunk minimal op-sequence
+//! (proptest's own shrink loop, run per-seed by [`Sim::run_proptest`]) plus a
+//! deterministic replay command. The `sim-sweep` `[[bin]]`
+//! (`autumn/src/bin/sim_sweep.rs`) is the CI-facing driver; [`sweep_proptest`]
+//! is the reusable library function it (and the `sim_sweep_driver` `DoD`
+//! test) calls.
 //!
-//! # Design: sequential, not parallel
+//! # Design: parallel across available cores, full batch, deterministic result
 //!
-//! The RFC that opened issue #1797 sketched a *parallel* seed sweep ("runs
-//! seeds in parallel, stops on the first failure"). This module runs seeds
-//! **sequentially on one thread instead**, because the W6 PR1 [`sometimes!`](crate::sometimes)
-//! non-vacuity registry ([`sim::assert`](super::assert)) that already shipped is
-//! **thread-local** and documents exactly this sweep as its aggregator:
+//! [`sweep_proptest`] dispatches the swept seeds across a
+//! [`std::thread::available_parallelism`]-sized worker pool
+//! ([`std::thread::scope`], no new dependency) rather than one seed at a
+//! time. Two things make that safe and still fully deterministic:
 //!
-//! > "the sweep (which runs seeds sequentially on one thread) reads
-//! > `sometimes_snapshot` after each seed before resetting for the next"
-//!
-//! Spreading seeds across OS threads would fragment that registry — each
-//! worker thread would accumulate its own independent, unaggregated
-//! observed/satisfied sets — breaking cross-seed non-vacuity detection
-//! ([`SweepOutcome::Vacuous`] below). Honoring the already-shipped contract
-//! took priority over the earlier draft's "in parallel" framing.
+//! - The only shared mutable state a `Sim` run touches is the
+//!   [`sometimes!`](crate::sometimes) reachability registry
+//!   ([`sim::assert`](super::assert)), and it's **thread-local** — every
+//!   other seam (`SimRng`, the clock, chaos/crash schedules) is a pure
+//!   function of the seed, owned by that seed's own `Sim` value. Each worker
+//!   folds *its own* thread's registry into a seed-local accumulator (see
+//!   below) before handing that off to a shared aggregate — never reading or
+//!   resetting another thread's registry.
+//! - Every seed in the requested range is run to completion (no worker
+//!   aborts early just because a peer found a failure elsewhere in the
+//!   batch). After every worker finishes, the **lowest-index** failing seed
+//!   among everything collected is reported — deterministic regardless of
+//!   which worker happened to reach a failure first. This trades "stop the
+//!   instant any failure is found" for a simpler, race-free result; for a
+//!   *bounded* batch (`AUTUMN_SIM_SEEDS=N`, not an open-ended search) the
+//!   worst-case total work is the same either way (≤ N seed-runs), so the
+//!   only real cost is CI wall-clock in the failing case, not correctness.
 //!
 //! # Non-vacuity
 //!
 //! A sweep is only meaningfully green if it is also **non-vacuous**: every
 //! [`sometimes!`](crate::sometimes) reachability label observed across the
-//! *entire* swept range was satisfied by *some* seed. [`sweep_proptest`] folds
-//! [`sometimes_snapshot`] into a cross-seed aggregate after every seed and
-//! reports [`SweepOutcome::Vacuous`] instead of [`SweepOutcome::Passed`] if any
-//! label was observed but never satisfied — the same "never ship a
-//! vacuously-green suite" guarantee [`sim::assert`](super::assert) exists for,
-//! now applied across the whole sweep rather than a single run.
+//! *entire* swept range was satisfied by *some* seed. A single seed's
+//! `Sim::run_proptest` drives up to `Config::default().cases` (256) candidate
+//! op-sequences internally, each starting with a fresh registry (a fresh
+//! `Sim::from_seed` resets it) — so [`sweep_proptest`] folds *every case's*
+//! snapshot via [`Sim::run_proptest_with_case_hook`], not just a single
+//! snapshot read after the whole seed finishes (which would silently see
+//! only the last of up to 256 cases). Each seed's case-folded observations
+//! are then merged into the sweep-wide aggregate; if the whole range passes
+//! but some label was observed and never satisfied anywhere in it, the
+//! outcome is [`SweepOutcome::Vacuous`] instead of [`SweepOutcome::Passed`] —
+//! the same "never ship a vacuously-green suite" guarantee
+//! [`sim::assert`](super::assert) exists for, now applied across the whole
+//! sweep rather than a single run.
 
 use std::collections::BTreeSet;
 use std::fmt;
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 use proptest::strategy::Strategy;
 use proptest::test_runner::TestError;
@@ -45,10 +63,11 @@ use proptest::test_runner::TestError;
 use super::Sim;
 use super::assert::{reset_sometimes_registry, sometimes_snapshot};
 
-/// The seed that stopped a sweep, and why.
+/// The seed a sweep reports as failing, and why.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SweepFailure<T> {
-    /// The first seed (in sweep order) whose [`Sim::run_proptest`] run failed.
+    /// The lowest-index seed (in sweep order) whose [`Sim::run_proptest`] run
+    /// failed among every seed in the swept batch.
     pub seed: u64,
     /// The minimal op-sequence proptest shrunk this seed's failure down to.
     /// Empty for a [`TestError::Abort`] (the run itself could not proceed —
@@ -60,10 +79,15 @@ pub struct SweepFailure<T> {
 
 impl<T: fmt::Debug> fmt::Display for SweepFailure<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // The replay count is decimal, matching `AUTUMN_SIM_SEEDS`'s own
+        // decimal parser (`sim_sweep.rs`'s `seed_count`) — printing it as hex
+        // here would silently fail to parse and fall back to the default
+        // seed count, producing a replay command that doesn't actually
+        // replay the reported failure.
         write!(
             f,
             "AUTUMN_SIM_SEED=0x{:x} — shrunk to {} op(s): {:?} ({})\n  \
-             replay: AUTUMN_SIM_SEEDS=0x{:x} cargo run -p autumn-web --features sim-testing --bin sim-sweep",
+             replay: AUTUMN_SIM_SEEDS={} cargo run -p autumn-web --release --features sim-testing --bin sim-sweep",
             self.seed,
             self.shrunk_ops.len(),
             self.shrunk_ops,
@@ -79,14 +103,13 @@ pub enum SweepOutcome<T> {
     /// Every swept seed passed, and every [`sometimes!`](crate::sometimes)
     /// label observed across the whole sweep was satisfied at least once.
     Passed {
-        /// How many seeds were run before the sweep concluded.
+        /// How many seeds were run.
         seeds_run: u64,
     },
-    /// `failure.seed` was the first seed (in sweep order) to fail; the sweep
-    /// stopped there without running any later seed.
+    /// `failure` is the lowest-index seed (in sweep order) that failed.
     Failed {
-        /// How many seeds were run before the sweep stopped (includes the
-        /// failing seed itself).
+        /// How many seeds were run (always the full requested batch — see
+        /// the module docs for why the sweep doesn't abort early).
         seeds_run: u64,
         /// The failing seed and its shrunk reproduction.
         failure: SweepFailure<T>,
@@ -102,52 +125,97 @@ pub enum SweepOutcome<T> {
     },
 }
 
-/// Sweep `seeds` sequentially through [`Sim::run_proptest`], stopping at the
-/// first failing seed (fail-fast) and folding each seed's
-/// [`sometimes_snapshot`] into a cross-seed non-vacuity aggregate.
+/// Sweep `seeds` across a worker pool through [`Sim::run_proptest`].
 ///
-/// `strategy` and `body` are each shared by reference across every seed —
-/// neither needs to be `Clone`. See the module docs for why this runs on one
-/// thread rather than in parallel.
+/// Reports the lowest-index failing seed (if any), folding every case's
+/// [`sometimes!`](crate::sometimes) observations (not just the last case per
+/// seed) into a cross-seed non-vacuity aggregate. See the module docs for the
+/// parallelism and non-vacuity design.
+///
+/// `strategy` and `body` are each shared by reference across every seed and
+/// every worker — neither needs to be `Clone`.
+///
+/// # Panics
+///
+/// Panics if a worker thread panics while holding the internal aggregation
+/// lock — this does not happen in ordinary use: a panic inside `body` (e.g.
+/// an [`always!`](crate::always) violation) is caught by proptest's
+/// `TestRunner` itself and turned into a case failure, never propagating to
+/// the worker thread.
 pub fn sweep_proptest<T, S, F>(
     seeds: impl IntoIterator<Item = u64>,
     strategy: &S,
     body: F,
 ) -> SweepOutcome<T>
 where
-    T: fmt::Debug,
-    S: Strategy<Value = Vec<T>>,
-    F: Fn(&mut Sim, &[T]),
+    T: fmt::Debug + Send,
+    S: Strategy<Value = Vec<T>> + Sync,
+    F: Fn(&mut Sim, &[T]) + Sync,
 {
-    let mut seeds_run = 0u64;
-    let mut all_observed = BTreeSet::new();
-    let mut all_satisfied = BTreeSet::new();
+    let seeds: Vec<u64> = seeds.into_iter().collect();
+    let seeds_run = seeds.len() as u64;
+    let worker_count = std::thread::available_parallelism()
+        .map_or(1, std::num::NonZero::get)
+        .min(seeds.len().max(1));
 
-    for seed in seeds {
-        seeds_run += 1;
-        let result = Sim::run_proptest_with_ref(seed, strategy, &body);
+    let next_index = AtomicUsize::new(0);
+    let aggregate: Mutex<(BTreeSet<String>, BTreeSet<String>)> =
+        Mutex::new((BTreeSet::new(), BTreeSet::new()));
+    // (seed index, failure) for every seed in the batch that failed —
+    // reduced to the lowest-index entry after every worker has finished the
+    // whole batch, so the reported seed never depends on thread scheduling.
+    let failures: Mutex<Vec<(usize, SweepFailure<T>)>> = Mutex::new(Vec::new());
 
-        let (observed, satisfied) = sometimes_snapshot();
-        all_observed.extend(observed);
-        all_satisfied.extend(satisfied);
-        reset_sometimes_registry();
+    std::thread::scope(|scope| {
+        for _ in 0..worker_count {
+            scope.spawn(|| {
+                loop {
+                    let index = next_index.fetch_add(1, Ordering::Relaxed);
+                    let Some(&seed) = seeds.get(index) else {
+                        break;
+                    };
 
-        if let Err(err) = result {
-            let (reason, shrunk_ops) = match err {
-                TestError::Fail(reason, shrunk_ops) => (reason.to_string(), shrunk_ops),
-                TestError::Abort(reason) => (format!("aborted: {reason}"), Vec::new()),
-            };
-            return SweepOutcome::Failed {
-                seeds_run,
-                failure: SweepFailure {
-                    seed,
-                    shrunk_ops,
-                    reason,
-                },
-            };
+                    let mut seed_observed = BTreeSet::new();
+                    let mut seed_satisfied = BTreeSet::new();
+                    let result = Sim::run_proptest_with_case_hook(seed, strategy, &body, || {
+                        let (observed, satisfied) = sometimes_snapshot();
+                        seed_observed.extend(observed);
+                        seed_satisfied.extend(satisfied);
+                        reset_sometimes_registry();
+                    });
+
+                    {
+                        let mut agg = aggregate.lock().unwrap();
+                        agg.0.extend(seed_observed);
+                        agg.1.extend(seed_satisfied);
+                    }
+
+                    if let Err(err) = result {
+                        let (reason, shrunk_ops) = match err {
+                            TestError::Fail(reason, shrunk_ops) => (reason.to_string(), shrunk_ops),
+                            TestError::Abort(reason) => (format!("aborted: {reason}"), Vec::new()),
+                        };
+                        failures.lock().unwrap().push((
+                            index,
+                            SweepFailure {
+                                seed,
+                                shrunk_ops,
+                                reason,
+                            },
+                        ));
+                    }
+                }
+            });
         }
+    });
+
+    let mut failures = failures.into_inner().unwrap();
+    failures.sort_by_key(|(index, _)| *index);
+    if let Some((_, failure)) = failures.into_iter().next() {
+        return SweepOutcome::Failed { seeds_run, failure };
     }
 
+    let (all_observed, all_satisfied) = aggregate.into_inner().unwrap();
     let unsatisfied: BTreeSet<String> = all_observed.difference(&all_satisfied).cloned().collect();
     if unsatisfied.is_empty() {
         SweepOutcome::Passed { seeds_run }
@@ -173,6 +241,38 @@ mod tests {
 
     fn tiny_op_strategy() -> impl Strategy<Value = Vec<TinyOp>> {
         proptest::collection::vec(prop_oneof![Just(TinyOp::Inc), Just(TinyOp::Dec)], 0..16)
+    }
+
+    #[test]
+    fn failure_display_prints_a_decimal_replay_count_that_covers_the_failing_seed() {
+        // `AUTUMN_SIM_SEEDS` (`sim_sweep.rs`'s `seed_count`) parses with plain
+        // `str::parse::<u64>()`, i.e. decimal only — printing the replay count
+        // as `0x…` here would silently fail to parse there and fall back to
+        // the default seed count, producing a replay command that doesn't
+        // actually cover (and so can't reproduce) the reported failure.
+        let failure = SweepFailure {
+            seed: 300u64,
+            shrunk_ops: vec![TinyOp::Inc],
+            reason: "example".to_owned(),
+        };
+        let rendered = failure.to_string();
+        let replay_line = rendered
+            .lines()
+            .find(|line| line.contains("AUTUMN_SIM_SEEDS="))
+            .expect("Display must print a replay line");
+        let count_str = replay_line
+            .split("AUTUMN_SIM_SEEDS=")
+            .nth(1)
+            .and_then(|rest| rest.split_whitespace().next())
+            .expect("replay line must carry a seed count");
+        let count: u64 = count_str.parse().unwrap_or_else(|err| {
+            panic!("replay count {count_str:?} must parse as plain decimal u64: {err}")
+        });
+        assert!(
+            count > failure.seed,
+            "replay count {count} must exceed the failing seed {} so re-sweeping 0..{count} reaches it",
+            failure.seed
+        );
     }
 
     #[test]
@@ -210,7 +310,27 @@ mod tests {
     }
 
     #[test]
-    fn sweep_stops_at_the_first_failing_seed_and_shrinks_it() {
+    fn sweep_aggregates_sometimes_observations_across_every_case_in_a_seed() {
+        // `Config::default().cases` is 256 — a `sometimes!` satisfied by only
+        // SOME of those 256 candidate op-sequences (not necessarily the last
+        // one tried) must still show up as satisfied in the aggregate. A
+        // single seed (0..1) makes this a direct test of the per-case fold,
+        // not an artifact of averaging across many seeds.
+        let strategy = tiny_op_strategy();
+        let outcome = sweep_proptest(0..1, &strategy, |_sim, ops| {
+            let has_inc = ops.iter().any(|op| *op == TinyOp::Inc);
+            crate::sometimes!(has_inc, "case-contained-an-inc");
+        });
+        match outcome {
+            SweepOutcome::Passed { seeds_run } => assert_eq!(seeds_run, 1),
+            other => panic!(
+                "expected a non-vacuous pass — some of the 256 cases in seed 0 must contain an Inc, got {other:?}"
+            ),
+        }
+    }
+
+    #[test]
+    fn sweep_finds_the_lowest_index_failing_seed_in_the_batch() {
         // Fails whenever three or more `Inc`s appear back to back.
         let strategy = tiny_op_strategy();
         let outcome = sweep_proptest(0..16, &strategy, |_sim, ops| {
@@ -222,7 +342,10 @@ mod tests {
         });
         match outcome {
             SweepOutcome::Failed { seeds_run, failure } => {
-                assert!(seeds_run >= 1);
+                assert_eq!(
+                    seeds_run, 16,
+                    "the full batch runs regardless of where the failure is"
+                );
                 assert_eq!(
                     failure.shrunk_ops,
                     vec![TinyOp::Inc, TinyOp::Inc, TinyOp::Inc]

--- a/autumn/src/sim/sweep.rs
+++ b/autumn/src/sim/sweep.rs
@@ -167,6 +167,12 @@ pub enum SweepOutcome<T> {
         /// The unsatisfied labels, in stable sorted order.
         unsatisfied: BTreeSet<String>,
     },
+    /// `seeds` was empty (or, equivalently, `AUTUMN_SIM_SEEDS=0`) — no seed
+    /// ran, so nothing was tested. Distinct from [`SweepOutcome::Passed`]: a
+    /// zero-length sweep isn't "every seed passed," it's "no seed was
+    /// attempted," and a caller (like the `sim-sweep` bin) should treat this
+    /// as a misconfiguration to surface loudly rather than a quiet green.
+    Empty,
 }
 
 /// Sweep `seeds` sequentially through [`Sim::run_proptest`].
@@ -221,6 +227,14 @@ where
                 },
             };
         }
+    }
+
+    if seeds_run == 0 {
+        // An empty `seeds` iterator ran the loop above zero times, so both
+        // aggregate sets are (vacuously) empty too — without this check
+        // that would fall through to `Passed { seeds_run: 0 }` below,
+        // silently reporting success for a sweep that tested nothing.
+        return SweepOutcome::Empty;
     }
 
     let unsatisfied: BTreeSet<String> = all_observed.difference(&all_satisfied).cloned().collect();
@@ -285,6 +299,18 @@ mod tests {
             }
         });
         assert_eq!(outcome, SweepOutcome::Passed { seeds_run: 8 });
+    }
+
+    #[test]
+    fn sweep_reports_empty_rather_than_a_silent_pass_for_a_zero_length_range() {
+        // `AUTUMN_SIM_SEEDS=0` (or any empty `seeds` iterator) must not
+        // silently report `Passed { seeds_run: 0 }` — that would let a
+        // misconfigured seed count green a CI job that tested nothing.
+        let strategy = tiny_op_strategy();
+        let outcome = sweep_proptest(0..0, &strategy, |_sim, _ops| {
+            panic!("body must never run for an empty seed range");
+        });
+        assert_eq!(outcome, SweepOutcome::Empty);
     }
 
     #[test]

--- a/autumn/src/sim/sweep.rs
+++ b/autumn/src/sim/sweep.rs
@@ -1,0 +1,249 @@
+//! Seed sweep runner (sim-testing W6 PR3, issue #1797).
+//!
+//! This is the **sweep** lane of the sim harness: running
+//! [`Sim::run_proptest`] across a batch of seeds, stopping at the first
+//! failing seed and reporting it — its shrunk minimal op-sequence (proptest's
+//! own shrink loop, run per-seed by [`Sim::run_proptest`]) plus a
+//! deterministic replay seed. The `sim-sweep` `[[bin]]` (`autumn/src/bin/sim_sweep.rs`)
+//! is the CI-facing driver; [`sweep_proptest`] is the reusable library
+//! function it (and the `sim_sweep_driver` `DoD` test) calls.
+//!
+//! # Design: sequential, not parallel
+//!
+//! The RFC that opened issue #1797 sketched a *parallel* seed sweep ("runs
+//! seeds in parallel, stops on the first failure"). This module runs seeds
+//! **sequentially on one thread instead**, because the W6 PR1 [`sometimes!`](crate::sometimes)
+//! non-vacuity registry ([`sim::assert`](super::assert)) that already shipped is
+//! **thread-local** and documents exactly this sweep as its aggregator:
+//!
+//! > "the sweep (which runs seeds sequentially on one thread) reads
+//! > `sometimes_snapshot` after each seed before resetting for the next"
+//!
+//! Spreading seeds across OS threads would fragment that registry — each
+//! worker thread would accumulate its own independent, unaggregated
+//! observed/satisfied sets — breaking cross-seed non-vacuity detection
+//! ([`SweepOutcome::Vacuous`] below). Honoring the already-shipped contract
+//! took priority over the earlier draft's "in parallel" framing.
+//!
+//! # Non-vacuity
+//!
+//! A sweep is only meaningfully green if it is also **non-vacuous**: every
+//! [`sometimes!`](crate::sometimes) reachability label observed across the
+//! *entire* swept range was satisfied by *some* seed. [`sweep_proptest`] folds
+//! [`sometimes_snapshot`] into a cross-seed aggregate after every seed and
+//! reports [`SweepOutcome::Vacuous`] instead of [`SweepOutcome::Passed`] if any
+//! label was observed but never satisfied — the same "never ship a
+//! vacuously-green suite" guarantee [`sim::assert`](super::assert) exists for,
+//! now applied across the whole sweep rather than a single run.
+
+use std::collections::BTreeSet;
+use std::fmt;
+
+use proptest::strategy::Strategy;
+use proptest::test_runner::TestError;
+
+use super::Sim;
+use super::assert::{reset_sometimes_registry, sometimes_snapshot};
+
+/// The seed that stopped a sweep, and why.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SweepFailure<T> {
+    /// The first seed (in sweep order) whose [`Sim::run_proptest`] run failed.
+    pub seed: u64,
+    /// The minimal op-sequence proptest shrunk this seed's failure down to.
+    /// Empty for a [`TestError::Abort`] (the run itself could not proceed —
+    /// there is no failing case to report).
+    pub shrunk_ops: Vec<T>,
+    /// The panic/assertion message (or, for an abort, the abort reason).
+    pub reason: String,
+}
+
+impl<T: fmt::Debug> fmt::Display for SweepFailure<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "AUTUMN_SIM_SEED=0x{:x} — shrunk to {} op(s): {:?} ({})\n  \
+             replay: AUTUMN_SIM_SEEDS=0x{:x} cargo run -p autumn-web --features sim-testing --bin sim-sweep",
+            self.seed,
+            self.shrunk_ops.len(),
+            self.shrunk_ops,
+            self.reason,
+            self.seed.wrapping_add(1),
+        )
+    }
+}
+
+/// The outcome of sweeping [`sweep_proptest`] over a range of seeds.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SweepOutcome<T> {
+    /// Every swept seed passed, and every [`sometimes!`](crate::sometimes)
+    /// label observed across the whole sweep was satisfied at least once.
+    Passed {
+        /// How many seeds were run before the sweep concluded.
+        seeds_run: u64,
+    },
+    /// `failure.seed` was the first seed (in sweep order) to fail; the sweep
+    /// stopped there without running any later seed.
+    Failed {
+        /// How many seeds were run before the sweep stopped (includes the
+        /// failing seed itself).
+        seeds_run: u64,
+        /// The failing seed and its shrunk reproduction.
+        failure: SweepFailure<T>,
+    },
+    /// Every swept seed passed individually, but the sweep was **vacuous**:
+    /// at least one [`sometimes!`](crate::sometimes) label was observed and
+    /// never satisfied by any seed in the range (see the module docs).
+    Vacuous {
+        /// How many seeds were run.
+        seeds_run: u64,
+        /// The unsatisfied labels, in stable sorted order.
+        unsatisfied: BTreeSet<String>,
+    },
+}
+
+/// Sweep `seeds` sequentially through [`Sim::run_proptest`], stopping at the
+/// first failing seed (fail-fast) and folding each seed's
+/// [`sometimes_snapshot`] into a cross-seed non-vacuity aggregate.
+///
+/// `strategy` and `body` are each shared by reference across every seed —
+/// neither needs to be `Clone`. See the module docs for why this runs on one
+/// thread rather than in parallel.
+pub fn sweep_proptest<T, S, F>(
+    seeds: impl IntoIterator<Item = u64>,
+    strategy: &S,
+    body: F,
+) -> SweepOutcome<T>
+where
+    T: fmt::Debug,
+    S: Strategy<Value = Vec<T>>,
+    F: Fn(&mut Sim, &[T]),
+{
+    let mut seeds_run = 0u64;
+    let mut all_observed = BTreeSet::new();
+    let mut all_satisfied = BTreeSet::new();
+
+    for seed in seeds {
+        seeds_run += 1;
+        let result = Sim::run_proptest_with_ref(seed, strategy, &body);
+
+        let (observed, satisfied) = sometimes_snapshot();
+        all_observed.extend(observed);
+        all_satisfied.extend(satisfied);
+        reset_sometimes_registry();
+
+        if let Err(err) = result {
+            let (reason, shrunk_ops) = match err {
+                TestError::Fail(reason, shrunk_ops) => (reason.to_string(), shrunk_ops),
+                TestError::Abort(reason) => (format!("aborted: {reason}"), Vec::new()),
+            };
+            return SweepOutcome::Failed {
+                seeds_run,
+                failure: SweepFailure {
+                    seed,
+                    shrunk_ops,
+                    reason,
+                },
+            };
+        }
+    }
+
+    let unsatisfied: BTreeSet<String> = all_observed.difference(&all_satisfied).cloned().collect();
+    if unsatisfied.is_empty() {
+        SweepOutcome::Passed { seeds_run }
+    } else {
+        SweepOutcome::Vacuous {
+            seeds_run,
+            unsatisfied,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use proptest::prelude::*;
+
+    use super::*;
+
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    enum TinyOp {
+        Inc,
+        Dec,
+    }
+
+    fn tiny_op_strategy() -> impl Strategy<Value = Vec<TinyOp>> {
+        proptest::collection::vec(prop_oneof![Just(TinyOp::Inc), Just(TinyOp::Dec)], 0..16)
+    }
+
+    #[test]
+    fn sweep_passes_when_every_seed_passes_and_is_non_vacuous() {
+        let strategy = tiny_op_strategy();
+        let outcome = sweep_proptest(0..8, &strategy, |_sim, ops| {
+            crate::sometimes!(!ops.is_empty(), "generated-at-least-one-op");
+            for op in ops {
+                let _ = op;
+            }
+        });
+        assert_eq!(outcome, SweepOutcome::Passed { seeds_run: 8 });
+    }
+
+    #[test]
+    fn sweep_reports_a_vacuous_sometimes_label_across_the_whole_range() {
+        let strategy = tiny_op_strategy();
+        // Never satisfied by construction, but always observed.
+        let outcome = sweep_proptest(0..4, &strategy, |_sim, _ops| {
+            crate::sometimes!(false, "never-satisfied-label");
+        });
+        match outcome {
+            SweepOutcome::Vacuous {
+                seeds_run,
+                unsatisfied,
+            } => {
+                assert_eq!(seeds_run, 4);
+                assert_eq!(
+                    unsatisfied.into_iter().collect::<Vec<_>>(),
+                    vec!["never-satisfied-label".to_owned()]
+                );
+            }
+            other => panic!("expected a vacuous outcome, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn sweep_stops_at_the_first_failing_seed_and_shrinks_it() {
+        // Fails whenever three or more `Inc`s appear back to back.
+        let strategy = tiny_op_strategy();
+        let outcome = sweep_proptest(0..16, &strategy, |_sim, ops| {
+            let mut run = 0;
+            for op in ops {
+                run = if *op == TinyOp::Inc { run + 1 } else { 0 };
+                assert!(run < 3, "three Incs in a row");
+            }
+        });
+        match outcome {
+            SweepOutcome::Failed { seeds_run, failure } => {
+                assert!(seeds_run >= 1);
+                assert_eq!(
+                    failure.shrunk_ops,
+                    vec![TinyOp::Inc, TinyOp::Inc, TinyOp::Inc]
+                );
+            }
+            other => panic!("expected a failing sweep, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn sweep_failure_is_deterministic_across_runs() {
+        let strategy = tiny_op_strategy();
+        let run = || {
+            sweep_proptest(0..16, &strategy, |_sim, ops| {
+                let mut run = 0;
+                for op in ops {
+                    run = if *op == TinyOp::Inc { run + 1 } else { 0 };
+                    assert!(run < 3, "three Incs in a row");
+                }
+            })
+        };
+        assert_eq!(run(), run());
+    }
+}

--- a/autumn/src/sim/sweep.rs
+++ b/autumn/src/sim/sweep.rs
@@ -82,13 +82,14 @@
 //! A sweep is only meaningfully green if it is also **non-vacuous**: every
 //! [`sometimes!`](crate::sometimes) reachability label observed across the
 //! *entire* swept range was satisfied by *some* seed. A single seed's
-//! `Sim::run_proptest` drives up to `Config::default().cases` (256) candidate
-//! op-sequences internally, each starting with a fresh registry (a fresh
-//! `Sim::from_seed` resets it) — so [`sweep_proptest`] folds *every case's*
-//! snapshot via [`Sim::run_proptest_with_case_hook`], not just a single
-//! snapshot read after the whole seed finishes (which would silently see
-//! only the last of up to 256 cases). Each seed's case-folded observations
-//! are then merged into the sweep-wide aggregate; if the whole range passes
+//! `Sim::run_proptest` drives up to `op::EMBEDDED_CASES` (256, pinned
+//! regardless of any ambient `PROPTEST_CASES`) candidate op-sequences
+//! internally, each starting with a fresh registry (a fresh `Sim::from_seed`
+//! resets it) — so [`sweep_proptest`] folds *every case's* snapshot via
+//! [`Sim::run_proptest_with_case_hook`], not just a single snapshot read
+//! after the whole seed finishes (which would silently see only the last of
+//! up to 256 cases). Each seed's case-folded observations are then merged
+//! into the sweep-wide aggregate; if the whole range passes
 //! but some label was observed and never satisfied anywhere in it, the
 //! outcome is [`SweepOutcome::Vacuous`] instead of [`SweepOutcome::Passed`] —
 //! the same "never ship a vacuously-green suite" guarantee
@@ -337,7 +338,7 @@ mod tests {
 
     #[test]
     fn sweep_aggregates_sometimes_observations_across_every_case_in_a_seed() {
-        // `Config::default().cases` is 256 — a `sometimes!` satisfied by only
+        // `op::EMBEDDED_CASES` is 256 — a `sometimes!` satisfied by only
         // SOME of those 256 candidate op-sequences (not necessarily the last
         // one tried) must still show up as satisfied in the aggregate. A
         // single seed (0..1) makes this a direct test of the per-case fold,

--- a/autumn/src/sim/sweep.rs
+++ b/autumn/src/sim/sweep.rs
@@ -67,6 +67,16 @@
 //! design; the parallel revision was a detour that review correctly walked
 //! back.
 //!
+//! Sequential execution removes the *concurrency* hazards above, but a
+//! `body` that calls `sim.build` still inherits [`Sim::run_proptest`]'s own,
+//! older precondition unchanged (see its module docs' "Calling `body`
+//! closures that mount an app"): [`sweep_proptest`] neither builds nor
+//! enters a Tokio runtime itself — every seed's case runs on whichever
+//! thread and in whatever ambient context *the caller* invoked
+//! [`sweep_proptest`] from, identical to a bare [`Sim::run_proptest`] call.
+//! Call it from somewhere already inside a running Tokio runtime if `body`
+//! mounts a real app.
+//!
 //! # Non-vacuity
 //!
 //! A sweep is only meaningfully green if it is also **non-vacuous**: every

--- a/autumn/src/sim/sweep.rs
+++ b/autumn/src/sim/sweep.rs
@@ -36,6 +36,15 @@
 //!   worst-case total work is the same either way (≤ N seed-runs), so the
 //!   only real cost is CI wall-clock in the failing case, not correctness.
 //!
+//! Each worker also builds and [`enter`](tokio::runtime::Runtime::enter)s its
+//! **own** paused current-thread Tokio runtime — the exact construction
+//! [`#[sim_test]`](crate::sim_test) uses — for its whole lifetime, reused
+//! across every seed it processes. A raw `std::thread::scope` thread
+//! otherwise inherits no ambient Tokio context, so a `body` that mounts a
+//! real app (`sim.build`, which starts the job runtime via `tokio::spawn`)
+//! would panic with "there is no reactor running" — a real bug an earlier
+//! revision of this parallelization had, caught in review.
+//!
 //! # Non-vacuity
 //!
 //! A sweep is only meaningfully green if it is also **non-vacuous**: every
@@ -173,6 +182,24 @@ where
     std::thread::scope(|scope| {
         for _ in 0..worker_count {
             scope.spawn(|| {
+                // A raw `std::thread::scope` worker inherits no ambient Tokio
+                // context — unlike `#[sim_test]`'s single `block_on`-driven
+                // thread, which every case in the (formerly sequential) sweep
+                // used to share. A `body` that mounts a real app (`sim.build`,
+                // which starts the job runtime via `tokio::spawn` —
+                // `job.rs`'s worker-loop spawn) would panic with "there is no
+                // reactor running" without this. One paused current-thread
+                // runtime per worker, entered for its whole lifetime — mirrors
+                // `#[sim_test]`'s own runtime exactly (`sim_test.rs`), reused
+                // across every seed this worker processes rather than rebuilt
+                // per seed.
+                let __sweep_worker_runtime = tokio::runtime::Builder::new_current_thread()
+                    .enable_all()
+                    .start_paused(true)
+                    .build()
+                    .expect("failed to build a paused sim runtime for this sweep worker");
+                let _sweep_worker_runtime_guard = __sweep_worker_runtime.enter();
+
                 loop {
                     let index = next_index.fetch_add(1, Ordering::Relaxed);
                     let Some(&seed) = seeds.get(index) else {
@@ -245,6 +272,29 @@ mod tests {
 
     fn tiny_op_strategy() -> impl Strategy<Value = Vec<TinyOp>> {
         proptest::collection::vec(prop_oneof![Just(TinyOp::Inc), Just(TinyOp::Dec)], 0..16)
+    }
+
+    #[test]
+    fn sweep_workers_have_a_reactor_so_body_can_spawn_tokio_tasks() {
+        // A raw `std::thread::scope` worker inherits no ambient Tokio
+        // context. A `body` that mounts a real app (`sim.build`) starts the
+        // job runtime via a bare `tokio::spawn` (`job.rs`) — reproduce that
+        // exact failure mode directly (no need for the full `TestApp`/job
+        // machinery) with `tokio::spawn` in `body`: it would panic with
+        // "there is no reactor running" on a worker with no runtime entered.
+        // `worker_count` in `sweep_proptest` is
+        // `available_parallelism().min(seeds.len())`, so a range with more
+        // seeds than one guarantees more than one worker thread is exercised
+        // whenever this test runs on a multi-core machine.
+        let strategy = tiny_op_strategy();
+        let outcome = sweep_proptest(0..16, &strategy, |_sim, _ops| {
+            let _ = tokio::spawn(async {});
+        });
+        assert!(
+            matches!(outcome, SweepOutcome::Passed { seeds_run: 16 }),
+            "every worker must have an entered Tokio runtime so `tokio::spawn` \
+             in `body` doesn't panic, got {outcome:?}"
+        );
     }
 
     #[test]

--- a/autumn/tests/sim_sweep_driver.rs
+++ b/autumn/tests/sim_sweep_driver.rs
@@ -1,0 +1,144 @@
+//! W6 PR3 Definition-of-Done proof (sim-testing, issue #1797): the seed-sweep
+//! runner finds and shrinks an injected invariant break across a batch of
+//! seeds, the failing seed it reports is deterministic across repeated
+//! sweeps, and the cross-seed `sometimes!` non-vacuity aggregate fires when a
+//! reachability label is observed but never satisfied anywhere in the swept
+//! range.
+//!
+//! Reuses `tests/sim_op_driver.rs`'s worked example (an account balance with
+//! an intentionally unfloored `Withdraw`) rather than inventing a new bug —
+//! this file's only job is the *sweep* mechanism (`sweep_proptest` batching
+//! `Sim::run_proptest` across seeds, fail-fast, plus cross-seed
+//! `sometimes!` aggregation), not re-proving the op-driver shrink mechanism
+//! itself (that's `sim_op_driver`'s job).
+//!
+//! Isolated `[[test]]` binary for the same reason as `sim_op_driver`: needs
+//! the `sim-testing` feature (`proptest` as a library dependency), which the
+//! default-feature consolidated `integration_tests` binary does not enable,
+//! so the file is `#![cfg(feature = "sim-testing")]` and a default
+//! `cargo test` compiles it to an empty (passing) binary. Runs without
+//! Docker. Run:
+//! `cargo test -p autumn-web --features sim-testing --test sim_sweep_driver`.
+
+#![cfg(feature = "sim-testing")]
+
+use autumn_web::sim::sweep::{SweepOutcome, sweep_proptest};
+use autumn_web::{always, sometimes};
+use proptest::prelude::*;
+
+/// A toy account op, mirroring `sim_op_driver.rs`'s worked example.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Op {
+    Deposit(u32),
+    Withdraw(u32),
+}
+
+impl Arbitrary for Op {
+    type Parameters = ();
+    type Strategy = BoxedStrategy<Self>;
+
+    fn arbitrary_with((): ()) -> Self::Strategy {
+        prop_oneof![
+            (1u32..100).prop_map(Op::Deposit),
+            (1u32..100).prop_map(Op::Withdraw),
+        ]
+        .boxed()
+    }
+}
+
+/// **Deliberately buggy**, same as `sim_op_driver.rs`: `Withdraw` subtracts
+/// unconditionally, with no floor check against the current balance.
+fn buggy_apply_ops(ops: &[Op]) {
+    let mut balance: i64 = 0;
+    for op in ops {
+        match *op {
+            Op::Deposit(amount) => balance += i64::from(amount),
+            Op::Withdraw(amount) => balance -= i64::from(amount),
+        }
+        always!(balance >= 0, "balance went negative: {balance}");
+    }
+}
+
+fn op_strategy() -> impl Strategy<Value = Vec<Op>> {
+    proptest::collection::vec(any::<Op>(), 1..32)
+}
+
+#[test]
+fn sweep_finds_and_shrinks_the_injected_invariant_break() {
+    let strategy = op_strategy();
+    let outcome = sweep_proptest(0..16, &strategy, |_sim, ops| buggy_apply_ops(ops));
+
+    match outcome {
+        SweepOutcome::Failed { seeds_run, failure } => {
+            assert!(
+                seeds_run >= 1,
+                "the sweep must have attempted at least one seed"
+            );
+            assert_eq!(
+                failure.shrunk_ops,
+                vec![Op::Withdraw(1)],
+                "should shrink to the minimal single-withdraw counterexample, got {:?}",
+                failure.shrunk_ops
+            );
+        }
+        other => panic!("a Withdraw from a zero balance must violate the invariant, got {other:?}"),
+    }
+}
+
+#[test]
+fn the_sweeps_failing_seed_replays_deterministically() {
+    let strategy = op_strategy();
+    let run = || sweep_proptest(0..16, &strategy, |_sim, ops| buggy_apply_ops(ops));
+
+    let (first, second) = (run(), run());
+    assert_eq!(
+        first, second,
+        "the same swept seed range must report the identical failing seed and shrunk sequence"
+    );
+}
+
+#[test]
+fn sweep_passes_and_is_non_vacuous_for_a_correct_model() {
+    let strategy = op_strategy();
+    let outcome = sweep_proptest(0..16, &strategy, |_sim, ops| {
+        let mut balance: i64 = 0;
+        for op in ops {
+            match *op {
+                Op::Deposit(amount) => balance += i64::from(amount),
+                // Correct: floors at zero instead of going negative.
+                Op::Withdraw(amount) => balance -= i64::from(amount).min(balance),
+            }
+            always!(balance >= 0, "balance went negative: {balance}");
+            sometimes!(balance == 0, "balance-returned-to-zero");
+        }
+    });
+
+    match outcome {
+        SweepOutcome::Passed { seeds_run } => assert_eq!(seeds_run, 16),
+        other => panic!("expected every seed to pass non-vacuously, got {other:?}"),
+    }
+}
+
+#[test]
+fn sweep_reports_vacuous_when_a_sometimes_label_is_never_satisfied_across_the_range() {
+    let strategy = op_strategy();
+    // `sometimes!` is observed on every case but its condition is always
+    // false, so no seed in the range can ever satisfy it.
+    let outcome = sweep_proptest(0..8, &strategy, |_sim, ops| {
+        sometimes!(false, "unreachable-across-the-whole-sweep");
+        for op in ops {
+            let _ = op;
+        }
+    });
+
+    match outcome {
+        SweepOutcome::Vacuous {
+            seeds_run,
+            unsatisfied,
+        } => {
+            assert_eq!(seeds_run, 8);
+            assert!(unsatisfied.contains("unreachable-across-the-whole-sweep"));
+        }
+        other => panic!("expected a vacuous sweep, got {other:?}"),
+    }
+}

--- a/autumn/tests/sim_sweep_driver.rs
+++ b/autumn/tests/sim_sweep_driver.rs
@@ -8,9 +8,10 @@
 //! Reuses `tests/sim_op_driver.rs`'s worked example (an account balance with
 //! an intentionally unfloored `Withdraw`) rather than inventing a new bug —
 //! this file's only job is the *sweep* mechanism (`sweep_proptest` batching
-//! `Sim::run_proptest` across seeds, fail-fast, plus cross-seed
-//! `sometimes!` aggregation), not re-proving the op-driver shrink mechanism
-//! itself (that's `sim_op_driver`'s job).
+//! `Sim::run_proptest` across a parallel worker pool, reporting the
+//! lowest-index failing seed, plus cross-seed `sometimes!` aggregation), not
+//! re-proving the op-driver shrink mechanism itself (that's `sim_op_driver`'s
+//! job).
 //!
 //! Isolated `[[test]]` binary for the same reason as `sim_op_driver`: needs
 //! the `sim-testing` feature (`proptest` as a library dependency), which the
@@ -35,14 +36,18 @@ enum Op {
 
 impl Arbitrary for Op {
     type Parameters = ();
-    type Strategy = BoxedStrategy<Self>;
+    // `SBoxedStrategy` (not `BoxedStrategy`): `sweep_proptest` shares the
+    // strategy across a worker-thread pool via `&S`, which needs `S: Send +
+    // Sync` — plain `BoxedStrategy` erases to `Arc<dyn Strategy>` with no
+    // `Send`/`Sync` bound on the trait object.
+    type Strategy = SBoxedStrategy<Self>;
 
     fn arbitrary_with((): ()) -> Self::Strategy {
         prop_oneof![
             (1u32..100).prop_map(Op::Deposit),
             (1u32..100).prop_map(Op::Withdraw),
         ]
-        .boxed()
+        .sboxed()
     }
 }
 
@@ -70,9 +75,9 @@ fn sweep_finds_and_shrinks_the_injected_invariant_break() {
 
     match outcome {
         SweepOutcome::Failed { seeds_run, failure } => {
-            assert!(
-                seeds_run >= 1,
-                "the sweep must have attempted at least one seed"
+            assert_eq!(
+                seeds_run, 16,
+                "the full batch runs regardless of where the failure is"
             );
             assert_eq!(
                 failure.shrunk_ops,

--- a/autumn/tests/sim_sweep_driver.rs
+++ b/autumn/tests/sim_sweep_driver.rs
@@ -8,10 +8,9 @@
 //! Reuses `tests/sim_op_driver.rs`'s worked example (an account balance with
 //! an intentionally unfloored `Withdraw`) rather than inventing a new bug —
 //! this file's only job is the *sweep* mechanism (`sweep_proptest` batching
-//! `Sim::run_proptest` across a parallel worker pool, reporting the
-//! lowest-index failing seed, plus cross-seed `sometimes!` aggregation), not
-//! re-proving the op-driver shrink mechanism itself (that's `sim_op_driver`'s
-//! job).
+//! `Sim::run_proptest` sequentially across seeds, fail-fast, plus cross-seed
+//! `sometimes!` aggregation), not re-proving the op-driver shrink mechanism
+//! itself (that's `sim_op_driver`'s job).
 //!
 //! Isolated `[[test]]` binary for the same reason as `sim_op_driver`: needs
 //! the `sim-testing` feature (`proptest` as a library dependency), which the
@@ -36,18 +35,14 @@ enum Op {
 
 impl Arbitrary for Op {
     type Parameters = ();
-    // `SBoxedStrategy` (not `BoxedStrategy`): `sweep_proptest` shares the
-    // strategy across a worker-thread pool via `&S`, which needs `S: Send +
-    // Sync` — plain `BoxedStrategy` erases to `Arc<dyn Strategy>` with no
-    // `Send`/`Sync` bound on the trait object.
-    type Strategy = SBoxedStrategy<Self>;
+    type Strategy = BoxedStrategy<Self>;
 
     fn arbitrary_with((): ()) -> Self::Strategy {
         prop_oneof![
             (1u32..100).prop_map(Op::Deposit),
             (1u32..100).prop_map(Op::Withdraw),
         ]
-        .sboxed()
+        .boxed()
     }
 }
 
@@ -75,9 +70,9 @@ fn sweep_finds_and_shrinks_the_injected_invariant_break() {
 
     match outcome {
         SweepOutcome::Failed { seeds_run, failure } => {
-            assert_eq!(
-                seeds_run, 16,
-                "the full batch runs regardless of where the failure is"
+            assert!(
+                seeds_run >= 1,
+                "the sweep must have attempted at least one seed"
             );
             assert_eq!(
                 failure.shrunk_ops,


### PR DESCRIPTION
## Summary

W6 PR3 of the sim-testing epic (#1797): the seed-sweep runner and its CI-facing `sim-sweep` binary, following PR2's op-driver (#2158, #2160).

- **`sim::sweep`** (new module): `sweep_proptest(seeds, &strategy, body)` runs `Sim::run_proptest` **sequentially** across a batch of seeds, stopping at the first failing seed and reporting its shrunk minimal op-sequence. `SweepFailure`'s `Display` is caller-agnostic — it doesn't prescribe a replay command, since `sweep_proptest` has no idea what test or binary is calling it. Every seed's `sometimes!` observations (folded across *every proptest case* in that seed, not just the last of up to 256) are merged into a cross-seed aggregate; if the whole range passes but some label was observed and never satisfied anywhere in it, the outcome is `SweepOutcome::Vacuous` rather than `Passed`.
- **`Sim::run_proptest_with_case_hook`** (new `pub(crate)`, in `op.rs`): invoked after every *successful* proptest case, before the next case's `Sim::from_seed` resets the `sometimes!` registry, so the sweep can fold every case's observations rather than just the last.
- **`autumn/src/bin/sim_sweep.rs`** — the CI-facing driver, a `[[bin]]` gated by `required-features = ["sim-testing"]`. Sweeps a built-in, deliberately **correct** account demo to prove the mechanism scales without a false positive; owns its own replay-command suggestion (the library itself is caller-agnostic).
- **`tests/sim_sweep_driver.rs`** — the DoD proof, reusing `sim_op_driver`'s intentionally buggy `Withdraw`-goes-negative model to prove: the sweep finds and shrinks a genuine invariant break to the minimal `[Withdraw(1)]` counterexample; the failing seed reported replays deterministically; a correct model sweeps green and non-vacuous; and a `sometimes!` label that's always-observed-never-satisfied is caught as `Vacuous`.
- **CI**: a new standalone `sim-sweep` job (structured like the `loom` job) runs the bin at `AUTUMN_SIM_SEEDS=512` on every push/PR. The `sqlite-runtime` job gains a clippy pass for the new `[[bin]]` and a test step for the `sim_sweep_driver` DoD suite.
- `CHANGELOG.md`: new bullet under `## [Unreleased]`.

### Review history

Codex review caught six real findings across this PR's revisions. The first three were straightforward fixes (confirmed with regression tests, each verified by temporarily reverting the fix and confirming the new test failed first):
1. **P1** — `sweep_proptest` only snapshotted `sometimes!` once per seed, missing observations from all but the last of up to 256 proptest cases. Fixed via `run_proptest_with_case_hook` (bc7366b).
2. **P2** — the replay line printed the seed count in hex; the parser is decimal-only and silently fell back to the default. Fixed by printing decimal (bc7366b).
3. **P2** — `SweepFailure::Display` hard-coded a `sim-sweep`-specific replay command, wrong for any other caller. Made `Display` caller-agnostic (66fa388).

Fixing the first also motivated reworking the sweep to run in parallel across a worker pool. That turned out to be the wrong call — three further findings showed it's architecturally unsafe, not just buggy:

4. **P1** — worker threads had no ambient Tokio runtime, so a `body` mounting a real app via `sim.build` panicked with "there is no reactor running." Attempted fix: each worker enters its own paused runtime (7c4d328).
5. **P1** — `.enter()` alone doesn't poll the executor, so even with (4) fixed, any spawned background tasks (e.g. job workers) would stay permanently inert during a synchronous case.
6. **P1** — `TestApp::build` unconditionally touches process-global state (cache, event bus, and — with jobs configured — a global job client); concurrent workers calling `sim.build()` race on all of it regardless of (4)/(5).

(5) and (6) aren't patchable within this sweep: (5) needs `Sim::run_proptest`'s sync-only `body` signature to become async (a breaking change to the already-shipped W6 PR2 API), and (6) needs either a global lock serializing every `sim.build`-calling case (defeating the point of parallelizing exactly those scenarios) or process-per-worker isolation. **Reverted the sweep to sequential execution (04429e7)**, which sidesteps all of (4)–(6) — never more than one `body` invocation in flight, so nothing to race regardless of what `body` does. This also matches the original, already-shipped W6 PR1 `sim::assert` design, whose own docs already specified "the sweep (which runs seeds sequentially on one thread)." Sweep-level threading was orthogonal to the harness's actual concurrency-bug-finding power anyway — that comes from exploring seeds against W1's single-threaded deterministic executor, not from how many OS threads process the outer seed range.

## Test plan

- [x] `cargo build -p autumn-web --features "sqlite,sim-testing" --lib`
- [x] `cargo build -p autumn-web --features sim-testing --bin sim-sweep`
- [x] `cargo clippy -p autumn-web --features "sqlite,sim-testing" --lib -- -D warnings`
- [x] `cargo clippy -p autumn-web --features "sqlite,sim-testing" --bin sim-sweep -- -D warnings`
- [x] `cargo clippy -p autumn-web --features sim-testing --test sim_sweep_driver -- -D warnings`
- [x] `cargo clippy --workspace --all-targets -- -D warnings` (full workspace regression check)
- [x] `cargo test -p autumn-web --features sim-testing --test sim_sweep_driver` (4 passed)
- [x] `cargo test -p autumn-web --features sim-testing --test sim_op_driver` (2 passed — no regression)
- [x] `cargo test -p autumn-web --features "sqlite,sim-testing" --lib sim::` (43 passed)
- [x] `AUTUMN_SIM_SEEDS=512 cargo run -p autumn-web --release --features sim-testing --bin sim-sweep` — passed, non-vacuous (matches the new CI job exactly)
- [x] `cargo build -p autumn-web --bin sim-sweep` (no `sim-testing`) — correctly errors, bin not built by default
- [x] `cargo fmt --all -- --check`
- [x] `./scripts/check-docs.sh`