### PR TITLE
Add bulk-select + delete-selected flow to HTML scaffolds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **cli,web:** `autumn generate scaffold` now ships a **no-JavaScript
+  bulk-select + delete-selected flow** on every standard HTML index list
+  (#1312). The `data_table` gains a leading
+  `bulk_select_checkbox` column, the list (and, with `--searchable`, the whole
+  htmx-swapped results container) is wrapped in a `bulk_actions_form` posting
+  to a new `#[secured] POST /{plural}/bulk_delete` handler, and `src/main.rs`
+  mounts that route immediately after `destroy`. The handler parses the
+  repeated checkboxes with a generated `parse_bulk_ids` helper, per-row
+  authorizes with the same `"delete"` action `destroy` uses when policy wiring
+  is on (an unauthorized row is dropped from the batch, not 403'd, so the
+  endpoint is no existence oracle), routes the delete through
+  `repo.delete_many` so soft-delete/hooks/`dependent(...)` cascades all apply,
+  flashes the deleted count, and 303s back to the index. An empty or malformed
+  selection redirects without error — a list-write endpoint never 400s on bad
+  params. The checkbox field is deliberately `name="ids"` (not `ids[]`),
+  matching `autumn-admin-plugin`'s existing bulk-action contract; the parser
+  accepts the `ids[]` spelling too, for clients that send it. Three reusable
+  widgets back it for hand-written views: `autumn_web::widgets::{
+  bulk_select_checkbox, bulk_actions_toolbar, bulk_actions_form}` plus a
+  `BulkActionsConfig` builder (opt-in `confirm(...)` prompt; off by default so
+  the control keeps working with scripting disabled). Gated off for
+  `--live`/`--live-validation`/`--sharded`/`--api`, whose output stays
+  byte-identical.
 - **sim-testing:** fix a genuine **job-backoff thundering herd** the
   deterministic simulation harness caught (W7, #1797): the local job
   runtime's retry backoff (`execute_local_job`, `job.rs`) computed a pure

--- a/autumn-cli/src/generate/scaffold.rs
+++ b/autumn-cli/src/generate/scaffold.rs
@@ -15004,4 +15004,323 @@ exempt_paths = [
             "a preexisting, user-owned exemption must not be claimed via a revert"
         );
     }
+
+    // ── bulk-select + delete-selected (issue #1312) ────────────────────────
+
+    /// The default `Post` field set used by the bulk-delete tests.
+    fn bulk_fields() -> Vec<String> {
+        vec![
+            "title:String".to_owned(),
+            "body:Text".to_owned(),
+            "published:bool".to_owned(),
+        ]
+    }
+
+    /// Plan a `Post` scaffold with `options` and return its routes file source.
+    fn bulk_routes(options: &ScaffoldOptions) -> String {
+        let tmp = project_with_main(default_main());
+        let plan = plan_scaffold_with_options(
+            tmp.path(),
+            "Post",
+            &bulk_fields(),
+            "20260427000000",
+            options,
+        )
+        .unwrap();
+        action_contents(&plan, "src/routes/posts.rs")
+    }
+
+    /// The default (non-live, non-sharded) `Post` scaffold's routes source.
+    fn bulk_routes_default() -> String {
+        bulk_routes(&ScaffoldOptions::default())
+    }
+
+    /// Slice out the body of a named `pub async fn` handler in a routes file:
+    /// everything from its signature up to the next top-level `pub async fn`.
+    fn handler_slice<'a>(routes: &'a str, name: &str) -> &'a str {
+        let needle = format!("pub async fn {name}(");
+        let start = routes.find(&needle).unwrap_or_else(|| {
+            panic!("routes file must emit `{needle}`:\n{routes}");
+        });
+        let rest = &routes[start + needle.len()..];
+        rest.split("pub async fn ").next().unwrap_or(rest)
+    }
+
+    #[test]
+    fn index_wraps_list_in_bulk_delete_form() {
+        let routes = bulk_routes_default();
+        assert!(routes.contains("bulk_actions_form("), "{routes}");
+        assert!(routes.contains("paths::bulk_delete()"), "{routes}");
+        let index = handler_slice(&routes, "index");
+        let form_at = index
+            .find("bulk_actions_form(")
+            .unwrap_or_else(|| panic!("index must wrap its list in the bulk form:\n{index}"));
+        let table_at = index
+            .find("data_table(")
+            .unwrap_or_else(|| panic!("index must still render the data_table:\n{index}"));
+        assert!(
+            form_at < table_at,
+            "the bulk form must wrap the data_table, not follow it:\n{index}"
+        );
+    }
+
+    #[test]
+    fn index_prepends_bulk_select_checkbox_column() {
+        let routes = bulk_routes_default();
+        let index = handler_slice(&routes, "index");
+        assert!(index.contains("columns.insert(0,"), "{index}");
+        assert!(index.contains("bulk_select_checkbox("), "{index}");
+    }
+
+    #[test]
+    fn index_handler_takes_csrf_for_bulk_form() {
+        let routes = bulk_routes_default();
+        let index = handler_slice(&routes, "index");
+        assert!(index.contains("csrf: Option<CsrfToken>"), "{index}");
+        assert!(
+            index.contains("csrf_field: Option<CsrfFormField>"),
+            "{index}"
+        );
+    }
+
+    #[test]
+    fn bulk_delete_handler_is_secured_and_routed() {
+        let routes = bulk_routes_default();
+        assert!(
+            routes.contains("#[secured]\n#[post(\"/posts/bulk_delete\")]"),
+            "the bulk delete route must be #[secured]: {routes}"
+        );
+        assert!(routes.contains("pub async fn bulk_delete("), "{routes}");
+    }
+
+    #[test]
+    fn bulk_delete_body_extractor_is_last() {
+        let routes = bulk_routes_default();
+        let bulk = handler_slice(&routes, "bulk_delete");
+        // Parameter list: everything up to the closing `)` of the signature.
+        let Some((params, _)) = bulk.split_once("\n)") else {
+            panic!("bulk_delete must have a parameter list:\n{bulk}");
+        };
+        assert!(params.contains("flash: Flash,"), "{params}");
+        let last = params
+            .lines()
+            .map(str::trim)
+            .rfind(|l| !l.is_empty())
+            .unwrap_or_else(|| panic!("bulk_delete must take parameters:\n{params}"));
+        // axum requires the body-consuming extractor to be the final argument.
+        assert!(
+            last.starts_with("body:") && last.contains("Bytes"),
+            "the Bytes body extractor must be the last parameter, got `{last}`:\n{params}"
+        );
+    }
+
+    #[test]
+    fn bulk_delete_calls_delete_many() {
+        let routes = bulk_routes_default();
+        let bulk = handler_slice(&routes, "bulk_delete");
+        assert!(bulk.contains(".delete_many(&"), "{bulk}");
+        assert!(
+            !bulk.contains("diesel::delete"),
+            "bulk delete must route through the repository, not a raw diesel::delete: {bulk}"
+        );
+        assert!(
+            !bulk.contains("deleted_at.eq("),
+            "bulk delete must not hand-roll the soft-delete update: {bulk}"
+        );
+    }
+
+    #[test]
+    fn bulk_delete_never_returns_bad_request() {
+        let routes = bulk_routes_default();
+        let bulk = handler_slice(&routes, "bulk_delete");
+        assert!(
+            !bulk.contains("bad_request"),
+            "an empty or malformed selection must never 400: {bulk}"
+        );
+        assert!(
+            !bulk.contains("StatusCode::BAD_REQUEST"),
+            "an empty or malformed selection must never 400: {bulk}"
+        );
+    }
+
+    #[test]
+    fn bulk_delete_empty_selection_redirects_without_deleting() {
+        let routes = bulk_routes_default();
+        let bulk = handler_slice(&routes, "bulk_delete");
+        assert!(bulk.contains("is_empty()"), "{bulk}");
+        let redirect_at = bulk
+            .find("Redirect::to(&paths::index())")
+            .unwrap_or_else(|| panic!("empty selection must redirect to the index:\n{bulk}"));
+        let delete_at = bulk
+            .find(".delete_many(&")
+            .unwrap_or_else(|| panic!("bulk delete must call delete_many:\n{bulk}"));
+        assert!(
+            redirect_at < delete_at,
+            "the empty-selection early return must precede the delete:\n{bulk}"
+        );
+    }
+
+    #[test]
+    fn bulk_ids_parser_accepts_bracket_form() {
+        let routes = bulk_routes_default();
+        assert!(routes.contains("fn parse_bulk_ids("), "{routes}");
+        let Some((_, rest)) = routes.split_once("fn parse_bulk_ids(") else {
+            panic!("routes must emit a parse_bulk_ids helper:\n{routes}");
+        };
+        let parser = rest.split("\npub ").next().unwrap_or(rest);
+        assert!(parser.contains("url::form_urlencoded::parse"), "{parser}");
+        assert!(parser.contains("\"ids\""), "{parser}");
+        assert!(parser.contains("\"ids[]\""), "{parser}");
+        assert!(
+            parser.contains(".contains(&"),
+            "the parser must dedupe selected ids: {parser}"
+        );
+    }
+
+    #[test]
+    fn bulk_delete_authorizes_each_selected_row() {
+        // An owner column (`user_id`) turns on the policy/authorize wiring.
+        let tmp = project_with_main(default_main());
+        let plan = plan_scaffold(
+            tmp.path(),
+            "Post",
+            &["title:String".into(), "user_id:i64".into()],
+            "20260427000000",
+        )
+        .unwrap();
+        let routes = action_contents(&plan, "src/routes/posts.rs");
+        let bulk = handler_slice(&routes, "bulk_delete");
+        assert!(
+            bulk.contains("for "),
+            "authorization must run per row: {bulk}"
+        );
+        assert!(bulk.contains("authorize::<Post>("), "{bulk}");
+        assert!(bulk.contains("\"delete\""), "{bulk}");
+    }
+
+    #[test]
+    fn bulk_delete_soft_delete_filters_already_deleted() {
+        let routes = bulk_routes(&ScaffoldOptions {
+            model: ModelOptions {
+                soft_delete: true,
+                ..Default::default()
+            },
+            ..Default::default()
+        });
+        let bulk = handler_slice(&routes, "bulk_delete");
+        assert!(
+            bulk.contains("deleted_at.is_null()"),
+            "the soft-delete SELECT must skip already-deleted rows: {bulk}"
+        );
+    }
+
+    #[test]
+    fn bulk_delete_omitted_for_live_variant() {
+        let routes = bulk_routes(&ScaffoldOptions {
+            live: true,
+            ..Default::default()
+        });
+        assert!(!routes.contains("bulk_delete"), "{routes}");
+        assert!(!routes.contains("bulk_actions_form"), "{routes}");
+    }
+
+    #[test]
+    fn bulk_delete_omitted_for_live_validation_variant() {
+        let routes = bulk_routes(&ScaffoldOptions {
+            live_validation: true,
+            ..Default::default()
+        });
+        assert!(!routes.contains("bulk_delete"), "{routes}");
+        assert!(!routes.contains("bulk_actions_form"), "{routes}");
+    }
+
+    #[test]
+    fn bulk_delete_omitted_for_sharded_variant() {
+        let routes = bulk_routes(&ScaffoldOptions {
+            model: ModelOptions {
+                sharded: true,
+                shard_key: Some("title".to_owned()),
+                ..Default::default()
+            },
+            ..Default::default()
+        });
+        assert!(!routes.contains("bulk_delete"), "{routes}");
+        assert!(!routes.contains("bulk_actions_form"), "{routes}");
+    }
+
+    #[test]
+    fn paths_macro_includes_bulk_delete() {
+        let routes = bulk_routes_default();
+        let Some((paths_block, _)) = routes
+            .split_once("autumn_web::paths![")
+            .and_then(|(_, rest)| rest.split_once("];"))
+        else {
+            panic!("routes must emit an autumn_web::paths! block:\n{routes}");
+        };
+        assert!(
+            paths_block.contains("bulk_delete"),
+            "paths! must export bulk_delete so paths::bulk_delete() resolves: {paths_block}"
+        );
+    }
+
+    #[test]
+    fn main_rs_registers_bulk_delete_after_destroy() {
+        let tmp = project_with_main(default_main());
+        let plan = plan_scaffold(tmp.path(), "Post", &bulk_fields(), "20260427000000").unwrap();
+        let main = action_contents(&plan, "src/main.rs");
+        assert!(main.contains("routes::posts::bulk_delete"), "{main}");
+        let destroy_at = main
+            .find("routes::posts::destroy")
+            .unwrap_or_else(|| panic!("main.rs must mount destroy:\n{main}"));
+        let bulk_at = main
+            .find("routes::posts::bulk_delete")
+            .unwrap_or_else(|| panic!("main.rs must mount bulk_delete:\n{main}"));
+        assert!(
+            destroy_at < bulk_at,
+            "bulk_delete must be registered immediately after destroy:\n{main}"
+        );
+    }
+
+    #[test]
+    fn write_path_test_covers_bulk_delete() {
+        let tmp = project_with_main(default_main());
+        let plan = plan_scaffold(tmp.path(), "Post", &bulk_fields(), "20260427000000").unwrap();
+        let test_file = action_contents(&plan, "tests/post.rs");
+        assert!(test_file.contains("/posts/bulk_delete"), "{test_file}");
+        assert!(test_file.contains("ids=1&ids=2"), "{test_file}");
+        assert!(
+            test_file.contains("0 row(s)"),
+            "the bulk delete must be observed to remove both rows: {test_file}"
+        );
+        // The empty-selection case is a 303 no-op, not a 400.
+        let Some((_, bulk_section)) = test_file.split_once("/posts/bulk_delete") else {
+            panic!("write-path test must exercise bulk_delete:\n{test_file}");
+        };
+        assert!(
+            bulk_section.contains(".form(\"\")") || bulk_section.contains("ids="),
+            "an empty-ids POST must be exercised: {bulk_section}"
+        );
+        assert!(
+            bulk_section.contains("assert_status(303)"),
+            "the empty-ids POST must still redirect with 303: {bulk_section}"
+        );
+        assert!(
+            !bulk_section.contains("assert_status(400)"),
+            "an empty selection must never 400: {bulk_section}"
+        );
+    }
+
+    #[test]
+    fn live_scaffold_output_contains_no_bulk_artifacts() {
+        let routes = bulk_routes(&ScaffoldOptions {
+            live: true,
+            ..Default::default()
+        });
+        for needle in ["bulk", "bulk_actions", "ids[]"] {
+            assert!(
+                !routes.contains(needle),
+                "the --live scaffold must carry no `{needle}` artifact: {routes}"
+            );
+        }
+    }
 }

--- a/autumn-cli/src/generate/scaffold.rs
+++ b/autumn-cli/src/generate/scaffold.rs
@@ -800,6 +800,14 @@ fn plan_scaffold_with_options_impl(
         );
     }
 
+    // Issue #1312: bulk-select + `POST /{plural}/bulk_delete`. Must agree exactly
+    // with the `bulk_delete_enabled` gate in `render_routes_file` (plus `--api`,
+    // which emits no HTML routes module at all), or main.rs would mount a route
+    // the module never emitted.
+    let bulk_delete_enabled = !options_with_key.api
+        && !options_with_key.live
+        && !options_with_key.live_validation
+        && !options_with_key.model.sharded;
     // Smoke test under `tests/<snake>.rs`. Uses the same soft-delete-augmented
     // field list as the real migration (see `augment_fields_for_soft_delete`)
     // so the smoke test's throwaway table matches the real schema exactly.
@@ -817,6 +825,7 @@ fn plan_scaffold_with_options_impl(
             metadata.defaults(),
             metadata.validations(),
             authorize_wiring,
+            bulk_delete_enabled,
         ),
     );
 
@@ -887,6 +896,7 @@ fn plan_scaffold_with_options_impl(
         options_with_key.api,
         options_with_key.live,
         search_enabled && !options_with_key.api,
+        bulk_delete_enabled,
         &validated_field_names,
         &sm_field_names,
         &rich_text_field_names,
@@ -2106,6 +2116,14 @@ fn render_routes_file(
     // model/repository/migration still get `searchable`). Precedent: the label
     // -map gating for the live index.
     let search_enabled = !searchable.is_empty() && !live && !live_validation;
+    // Issue #1312: bulk-select + `POST /{plural}/bulk_delete`. Emitted only for
+    // the standard HTML list. `--live`/`--live-validation` own their list DOM
+    // through an SSE/htmx out-of-band swap contract that a wrapping `<form>` and
+    // an extra checkbox column would break, and the `--sharded` repository has no
+    // cross-shard `delete_many` to route a mixed selection through — so those
+    // three variants stay byte-identical to their pre-#1312 output. (`--api`
+    // emits no HTML routes file at all, so it needs no gate here.)
+    let bulk_delete_enabled = !live && !live_validation && !sharded;
     let validated_fields: Vec<&str> = validations.keys().map(String::as_str).collect();
     let unique_fields: Vec<&Field> = fields.iter().filter(|f| f.unique).collect();
     // Issue #1326: fields carrying a `:states(…)` state machine. Only these
@@ -3551,6 +3569,112 @@ mod attachment_read_back_tests {
          }}\n"
     );
 
+    // ── issue #1312: bulk-select + delete-selected ─────────────────────────
+    //
+    // The repeated-checkbox body parser. Emitted next to `csrf_input` /
+    // `submit_token_input` (the routes module's other private form helpers) and
+    // only when the bulk gate is on, so the `--live`/`--sharded` output is
+    // byte-identical.
+    let bulk_ids_parser = if bulk_delete_enabled {
+        "\n/// Parse the bulk-select checkboxes out of a URL-encoded form body.\n\
+         ///\n\
+         /// Accepts both the plain `ids=1&ids=2` spelling the generated checkboxes\n\
+         /// submit and the `ids[]=1&ids[]=2` spelling some clients send. A value\n\
+         /// that isn't an integer is dropped rather than rejected — a list-write\n\
+         /// endpoint never 400s on a hand-edited form — and repeats are collapsed\n\
+         /// so the same row is never queued for deletion twice.\n\
+         fn parse_bulk_ids(body: &Bytes) -> Vec<i64> {\n    \
+         let mut ids: Vec<i64> = Vec::new();\n    \
+         for (key, value) in url::form_urlencoded::parse(body.as_ref()) {\n        \
+         if key == \"ids\" || key == \"ids[]\" {\n            \
+         if let Ok(id) = value.parse::<i64>() {\n                \
+         if !ids.contains(&id) {\n                    \
+         ids.push(id);\n                \
+         }\n            \
+         }\n        \
+         }\n    \
+         }\n    \
+         ids\n\
+         }\n"
+    } else {
+        ""
+    };
+    // `POST /{plural}/bulk_delete`. Emitted straight after the `index` handler
+    // it serves (and before `show`), so the list view and its bulk action read
+    // together.
+    let bulk_delete_fn = if bulk_delete_enabled {
+        // Same `State` + `Session` pair `destroy` takes when policy wiring is on.
+        let authz_params = if authorize {
+            format!("{edit_destroy_authz_params},")
+        } else {
+            String::new()
+        };
+        // Soft-delete: an already-deleted row is invisible to the list, so it must
+        // stay out of the selection too (matching `destroy`'s `deleted_at IS NULL`
+        // filter). The actual delete still routes through `delete_many`, which
+        // applies the repository's soft-delete + `dependent(...)` cascade rules.
+        let soft_delete_filter = if soft_delete {
+            format!(".filter({plural}::deleted_at.is_null())\n        ")
+        } else {
+            String::new()
+        };
+        let allowed_block = if authorize {
+            format!(
+                "    let mut allowed: Vec<i64> = Vec::with_capacity(rows.len());\n    \
+                 for row in &rows {{\n        \
+                 // A row the actor may not delete is dropped from the batch instead of\n        \
+                 // failing the request: answering differently for \"not yours\" than for\n        \
+                 // \"not selected\" would turn this endpoint into an existence oracle.\n        \
+                 if autumn_web::authorization::authorize::<{pascal_name}>({edit_destroy_state_expr}, &session, \"delete\", row)\n            \
+                 .await\n            \
+                 .is_ok()\n        \
+                 {{\n            \
+                 allowed.push(row.id);\n        \
+                 }}\n    \
+                 }}\n"
+            )
+        } else {
+            "    let allowed: Vec<i64> = rows.iter().map(|row| row.id).collect();\n".to_owned()
+        };
+        format!(
+            "\n\n/// `POST /{plural}/bulk_delete` — delete every selected row in one submit.\n\
+             ///\n\
+             /// Reads the index list's repeated `ids` checkboxes (see `parse_bulk_ids`,\n\
+             /// which also accepts the `ids[]` spelling). Malformed ids are dropped and an\n\
+             /// empty selection just redirects back with an informational flash — a\n\
+             /// list-write endpoint never 400s on bad params. The delete itself routes\n\
+             /// through the repository's `delete_many`, so soft-delete, model hooks, and\n\
+             /// `dependent(...)` cascades all apply exactly as they do for the single-row\n\
+             /// `destroy`; a `dependent(restrict)` violation aborts the whole batch with a\n\
+             /// 409 and rolls back.\n\
+             #[secured]\n\
+             #[post(\"/{plural}/bulk_delete\")]\n\
+             pub async fn bulk_delete(\n    \
+             flash: Flash,{authz_params}\n    \
+             repo: Pg{pascal_name}Repository,\n    \
+             mut db: {db_ty},\n    \
+             body: Bytes,\n\
+             ) -> AutumnResult<autumn_web::Redirect> {{\n    \
+             let ids = parse_bulk_ids(&body);\n    \
+             if ids.is_empty() {{\n        \
+             flash.info(\"No {plural} selected\").await;\n        \
+             return Ok(autumn_web::Redirect::to(&paths::index()));\n    \
+             }}\n    \
+             let rows: Vec<{pascal_name}> = {plural}::table\n        \
+             .filter({plural}::id.eq_any(&ids))\n        \
+             {soft_delete_filter}.select({pascal_name}::as_select())\n        \
+             .load(&mut *db)\n        \
+             .await?;\n\
+             {allowed_block}    \
+             repo.delete_many(&allowed).await?;\n    \
+             flash.success(format!(\"Deleted {{}} {plural}\", allowed.len())).await;\n    \
+             Ok(autumn_web::Redirect::to(&paths::index()))\n\
+             }}"
+        )
+    } else {
+        String::new()
+    };
+
     // Template splice bindings for the generated form struct, its conversion,
     // the edit-form seed, and (when present) the datetime parse helper.
     let form_struct = &model_form.form_struct;
@@ -3657,6 +3781,35 @@ mod attachment_read_back_tests {
             route_key_field,
         )
     };
+    // Issue #1312: the shared columns prelude the index AND the search-results
+    // fragment both splice, so a searched list keeps its row checkboxes. The
+    // config is bound BEFORE the columns vec (and the action `String` before
+    // it): the inserted column's cell closure borrows `bulk_cfg`, so `columns`
+    // must be dropped first — declaring it after keeps the borrow well-ordered.
+    let index_columns_labeled = if bulk_delete_enabled {
+        let with_mut =
+            index_columns_labeled.replacen("    let columns:", "    let mut columns:", 1);
+        format!(
+            "    let bulk_action = paths::bulk_delete();\n    \
+             let bulk_cfg = autumn_web::widgets::BulkActionsConfig::new(&bulk_action);\n\
+             {with_mut}    \
+             columns.insert(0, autumn_web::widgets::Column::new(\"\", |row: &{pascal_name}| maud::html! {{ (autumn_web::widgets::bulk_select_checkbox(row.id, &bulk_cfg)) }}));\n"
+        )
+    } else {
+        index_columns_labeled
+    };
+    // Issue #1312: the CSRF pair the index/search handlers thread into
+    // `bulk_actions_form`'s hidden field. Injected after `flash: Flash,` in the
+    // signatures that render the bulk form; empty (so byte-identical) otherwise.
+    let bulk_csrf_params = if bulk_delete_enabled {
+        "\n    csrf: Option<CsrfToken>,\n    csrf_field: Option<CsrfFormField>,"
+    } else {
+        ""
+    };
+    // The `Option<&str>` conversions `bulk_actions_form` takes for its hidden
+    // CSRF input, matching the `csrf_input` helper's field-name default.
+    let bulk_csrf_args =
+        "csrf.as_ref().map(|t| t.token()), csrf_field.as_ref().map(|f| f.0.as_str())";
     // #1126: the data_table config is wired symmetrically with what the server
     // applies — `.query(..)` preserves the current filters on sort links,
     // `.active_sort`/`.active_dir` mark the column the repository ordered by, and
@@ -3703,13 +3856,40 @@ mod attachment_read_back_tests {
         r"(pagination_nav(&page_data, &PagerOptions::new(&paths::index()).query(pager_query)))"
             .to_string()
     };
+    // Issue #1312: the list itself (data_table + pager) is wrapped in the
+    // bulk-actions `<form>` so each row's checkbox submits with the
+    // delete-selected button. The "New {pascal_name}" link, the htmx `<script>`,
+    // and the search box deliberately stay OUTSIDE: they are page furniture, not
+    // part of the selection.
+    //
+    // When searchable, the form sits INSIDE the `#{plural}-search-results`
+    // container htmx swaps — not around it. The `/search` fragment is itself a
+    // whole `bulk_actions_form`, so swapping it into a container that already
+    // lived inside a form would nest one `<form>` in another (invalid HTML the
+    // parser silently drops). Form-inside-container means every swap replaces
+    // the form wholesale and the checkboxes always have their submit button.
     let index_list_block = if search_enabled {
+        let inner = if bulk_delete_enabled {
+            format!(
+                "div id=\"{plural}-search-results\" {{\n            \
+                 (autumn_web::widgets::bulk_actions_form(&bulk_cfg, {bulk_csrf_args}, html! {{\n                \
+                 {list_render}\n                {pager_line}\n            }}))\n        }}"
+            )
+        } else {
+            format!(
+                "div id=\"{plural}-search-results\" {{\n            {list_render}\n            {pager_line}\n        }}"
+            )
+        };
         format!(
             "script src=(autumn_web::htmx::HTMX_JS_PATH) {{}}\n        \
              (autumn_web::widgets::active_search_input(\"{snake_name}-search\", \"Search {pascal_name}s\", \
              &autumn_web::widgets::ActiveSearchConfig::new(\"/{plural}/search\", \"#{plural}-search-results\")\
              .placeholder(\"Search {pascal_name}s…\")))\n        \
-             div id=\"{plural}-search-results\" {{\n            {list_render}\n            {pager_line}\n        }}"
+             {inner}"
+        )
+    } else if bulk_delete_enabled {
+        format!(
+            "(autumn_web::widgets::bulk_actions_form(&bulk_cfg, {bulk_csrf_args}, html! {{\n            {list_render}\n            {pager_line}\n        }}))"
         )
     } else {
         format!("{list_render}\n        {pager_line}")
@@ -3758,7 +3938,7 @@ pub async fn index(
     autumn_web::extract::State(state): autumn_web::extract::State<autumn_web::AppState>,
     session: autumn_web::session::Session,
     repo: Pg{pascal_name}Repository,
-    {index_db_param}flash: Flash,
+    {index_db_param}flash: Flash,{bulk_csrf_params}
 ) -> AutumnResult<Markup> {{
     let ctx = autumn_web::authorization::PolicyContext::from_request(&state, &session).await;
     let owner_id = ctx.user_id_i64().unwrap_or(-1);
@@ -3906,7 +4086,7 @@ pub async fn index(
     RawQuery(raw_query): RawQuery,
     page_req: PageRequest,
     repo: Pg{pascal_name}Repository,
-    {index_db_param}flash: Flash,
+    {index_db_param}flash: Flash,{bulk_csrf_params}
 ) -> AutumnResult<Markup> {{
     let page_data: Page<{pascal_name}> = repo.list(&list_query, &page_req).await?;
     let pager_query = raw_query.as_deref().unwrap_or("");
@@ -4130,6 +4310,12 @@ pub async fn index(
             "update".to_owned(),
             "delete".to_owned(),
         ];
+        // Issue #1312: `paths::bulk_delete()` backs the index list's bulk form
+        // action. Gated with the handler, so the `--live`/`--sharded` paths!
+        // block stays byte-identical.
+        if bulk_delete_enabled {
+            names.push("bulk_delete".to_owned());
+        }
         if live {
             names.push("events".to_owned());
         }
@@ -4170,6 +4356,25 @@ pub async fn index(
     // The pager preserves the request's raw query string (stripping `page`/
     // `size`) via `PagerOptions::query`, so `q` survives pagination without any
     // hand-rolled percent-encoding.
+    //
+    // Issue #1312: the fragment htmx swaps into `#{plural}-search-results` is the
+    // WHOLE bulk form, not just the table — otherwise the first search would
+    // replace the form's innards with checkboxes that have no `<form>` (and no
+    // submit button) around them, silently breaking bulk delete after a search.
+    let search_results_table = format!(
+        r#"(autumn_web::widgets::data_table(&page_data.content, &columns, &autumn_web::widgets::DataTableConfig::new("No {plural} found.").base_path("/{plural}/search")))"#
+    );
+    let search_results_pager = format!(
+        r#"(pagination_nav(&page_data, &PagerOptions::new("/{plural}/search").query(pager_query)))"#
+    );
+    let search_results_body = if bulk_delete_enabled {
+        format!(
+            "(autumn_web::widgets::bulk_actions_form(&bulk_cfg, {bulk_csrf_args}, html! {{\n            \
+             {search_results_table}\n            {search_results_pager}\n        }}))"
+        )
+    } else {
+        format!("{search_results_table}\n        {search_results_pager}")
+    };
     let search_handler = if search_enabled && owner_scoped_standard {
         // Issue #1841: owner-scoped FTS handler for the standard Db path. The
         // SECURITY INVARIANT is that this branch calls ONLY the owner-filtered
@@ -4209,7 +4414,7 @@ pub async fn search(
     autumn_web::extract::State(state): autumn_web::extract::State<autumn_web::AppState>,
     session: autumn_web::session::Session,
     repo: Pg{pascal_name}Repository,
-    {index_db_param}flash: Flash,
+    {index_db_param}flash: Flash,{bulk_csrf_params}
 ) -> AutumnResult<Markup> {{
     let ctx = autumn_web::authorization::PolicyContext::from_request(&state, &session).await;
     let owner_id = ctx.user_id_i64().unwrap_or(-1);
@@ -4224,8 +4429,7 @@ pub async fn search(
         repo.search_page_scoped(owner_id, q, &page_req).await?
     }};
 {index_label_loads}{index_columns_labeled}    let results = html! {{
-        (autumn_web::widgets::data_table(&page_data.content, &columns, &autumn_web::widgets::DataTableConfig::new("No {plural} found.").base_path("/{plural}/search")))
-        (pagination_nav(&page_data, &PagerOptions::new("/{plural}/search").query(pager_query)))
+        {search_results_body}
     }};
     if hx.is_htmx {{
         return Ok(results);
@@ -4272,7 +4476,7 @@ pub async fn search(
     autumn_web::reexports::axum::extract::RawQuery(raw_query): autumn_web::reexports::axum::extract::RawQuery,
     page_req: PageRequest,
     hx: autumn_web::htmx::HxRequest,
-{repo_extractor}    flash: Flash,
+{repo_extractor}    flash: Flash,{bulk_csrf_params}
 ) -> AutumnResult<Markup> {{
 {repo_bind}    let q = query.q.trim();
     // Preserve the request's raw query string (already percent-encoded) on pager
@@ -4285,8 +4489,7 @@ pub async fn search(
         repo.search_page(q, &page_req).await?
     }};
 {index_label_loads}{index_columns_labeled}    let results = html! {{
-        (autumn_web::widgets::data_table(&page_data.content, &columns, &autumn_web::widgets::DataTableConfig::new("No {plural} found.").base_path("/{plural}/search")))
-        (pagination_nav(&page_data, &PagerOptions::new("/{plural}/search").query(pager_query)))
+        {search_results_body}
     }};
     if hx.is_htmx {{
         return Ok(results);
@@ -4613,8 +4816,8 @@ fn submit_token_input(submit_token: Option<&SubmitToken>, field: Option<&SubmitF
         }}
     }}
 }}
-{attachment_read_back_helpers}{private_layout}
-{index_handler}{show_section}
+{bulk_ids_parser}{attachment_read_back_helpers}{private_layout}
+{index_handler}{bulk_delete_fn}{show_section}
 /// `GET /{plural}/new` — render the new-{snake_name} form.
 #[secured]
 #[get("/{plural}/new", name = "new")]
@@ -6551,6 +6754,7 @@ fn render_smoke_test(
     defaults: &BTreeMap<String, String>,
     validations: &BTreeMap<String, Vec<String>>,
     authorize: bool,
+    bulk_delete: bool,
 ) -> String {
     let stub_tables_sql = render_reference_stub_tables_sql(fields, plural);
     let create_table_sql =
@@ -6604,7 +6808,7 @@ fn render_smoke_test(
     let base = if api {
         base
     } else {
-        base + &render_write_path_smoke_test(pascal_name, plural)
+        base + &render_write_path_smoke_test(pascal_name, plural, bulk_delete)
     };
 
     // Issue #1236 (AC6): attachment scaffolds additionally get a multipart
@@ -6875,7 +7079,7 @@ fn render_validation_rejection_smoke_test(
 /// browser; the in-process harness does not require it, and this comment
 /// records that so the absent token reads as intentional, not a gap.
 #[allow(clippy::too_many_lines)] // the emitted test body is one raw-string template
-fn render_write_path_smoke_test(pascal_name: &str, plural: &str) -> String {
+fn render_write_path_smoke_test(pascal_name: &str, plural: &str, bulk_delete: bool) -> String {
     const TEMPLATE: &str = r#"
 // ── write-path CRUD (issue #1127) ─────────────────────────────────────────
 //
@@ -6949,10 +7153,10 @@ async fn __PLURAL___write_path_crud() {
     async fn destroy(id: Path<i64>) -> impl IntoResponse {
         STORE.lock().unwrap().retain(|(i, _)| *i != *id);
         Redirect::to("/__PLURAL__")
-    }
+    }__BULK_HANDLER__
 
     let client: TestClient = TestApp::new()
-        .routes(routes![index, create, update, destroy])
+        .routes(routes![index, create, update, destroy__BULK_ROUTE__])
         .build();
 
     // Create (happy path): a valid POST redirects (303 See Other) to the index
@@ -7018,10 +7222,88 @@ async fn __PLURAL___write_path_crud() {
         .get("/__PLURAL__")
         .send()
         .await
-        .assert_body_contains("0 row(s)");
+        .assert_body_contains("0 row(s)");__BULK_STEPS__
 }
 "#;
+    // Issue #1312: the bulk delete-selected stand-in. Mirrors the generated
+    // handler's contract — repeated `ids` checkboxes, 303 back to the index, and
+    // an empty selection that is a no-op rather than a 400.
+    const BULK_HANDLER: &str = r#"
+
+    // Issue #1312: the index list's bulk form posts the checked rows here as
+    // repeated `ids` pairs. Malformed values are dropped and an empty selection
+    // is a no-op — a list-write endpoint never 400s on bad params.
+    #[post("/__PLURAL__/bulk_delete")]
+    async fn bulk_delete(
+        body: autumn_web::reexports::axum::body::Bytes,
+    ) -> impl IntoResponse {
+        let mut ids: Vec<i64> = Vec::new();
+        for (key, value) in url::form_urlencoded::parse(body.as_ref()) {
+            if (key == "ids" || key == "ids[]")
+                && let Ok(id) = value.parse::<i64>()
+                && !ids.contains(&id)
+            {
+                ids.push(id);
+            }
+        }
+        STORE.lock().unwrap().retain(|(i, _)| !ids.contains(i));
+        Redirect::to("/__PLURAL__")
+    }"#;
+    const BULK_STEPS: &str = r#"
+
+    // Bulk delete (issue #1312): re-seed two rows, then submit both ids the way
+    // the generated list's checkboxes do (`ids=1&ids=2`). One POST removes both
+    // and redirects (303) to the index.
+    for name in ["bulk-one", "bulk-two"] {
+        client
+            .post("/__PLURAL__")
+            .form(&format!("name={name}&witness=w"))
+            .send()
+            .await
+            .assert_status(303);
+    }
+    client
+        .get("/__PLURAL__")
+        .send()
+        .await
+        .assert_body_contains("2 row(s)");
+    client
+        .post("/__PLURAL__/bulk_delete")
+        .form("ids=1&ids=2")
+        .send()
+        .await
+        .assert_status(303)
+        .assert_header("location", "/__PLURAL__");
+    client
+        .get("/__PLURAL__")
+        .send()
+        .await
+        .assert_body_contains("0 row(s)");
+
+    // An empty selection is a 303 no-op, NOT a 400: nothing was checked, so
+    // nothing is deleted and the visitor lands back on the list.
+    client
+        .post("/__PLURAL__/bulk_delete")
+        .form("")
+        .send()
+        .await
+        .assert_status(303)
+        .assert_header("location", "/__PLURAL__");
+    client
+        .get("/__PLURAL__")
+        .send()
+        .await
+        .assert_body_contains("0 row(s)");"#;
     TEMPLATE
+        .replace(
+            "__BULK_HANDLER__",
+            if bulk_delete { BULK_HANDLER } else { "" },
+        )
+        .replace(
+            "__BULK_ROUTE__",
+            if bulk_delete { ", bulk_delete" } else { "" },
+        )
+        .replace("__BULK_STEPS__", if bulk_delete { BULK_STEPS } else { "" })
         .replace("__PASCAL__", pascal_name)
         .replace("__PLURAL__", plural)
 }
@@ -8023,10 +8305,11 @@ fn render_unique_violation_smoke_test(
 
 #[allow(
     clippy::too_many_arguments,
+    clippy::fn_params_excessive_bools,
     reason = "one parameter per optional route family the scaffold can emit \
-              (live SSE, search, inline validation, state transitions, rich-text \
-              preview); grouping them into a struct would only move the same \
-              list one level out"
+              (live SSE, search, bulk delete, inline validation, state \
+              transitions, rich-text preview); grouping them into a struct would \
+              only move the same list one level out"
 )]
 fn main_route_entries(
     plural: &str,
@@ -8034,6 +8317,7 @@ fn main_route_entries(
     api: bool,
     live: bool,
     search: bool,
+    bulk_delete: bool,
     validated_field_names: &[String],
     sm_field_names: &[String],
     rich_text_field_names: &[String],
@@ -8060,6 +8344,13 @@ fn main_route_entries(
             format!("routes::{plural}::update"),
             format!("routes::{plural}::destroy"),
         ];
+        // Issue #1312: mount the bulk delete-selected route immediately after the
+        // per-row `destroy` it generalises. Gated with the handler emission in
+        // `render_routes_file` — mounting a route the module never emitted would
+        // fail the generated app to compile.
+        if bulk_delete {
+            entries.push(format!("routes::{plural}::bulk_delete"));
+        }
         if live {
             entries.push(format!("routes::{plural}::events"));
         }
@@ -14052,13 +14343,14 @@ async fn main() {
         )
         .unwrap();
         let routes = action_contents(&plan, "src/routes/posts.rs");
-        // edit / update / destroy carry an inline authorize call.
+        // edit / update / destroy carry an inline authorize call, and (issue
+        // #1312) bulk_delete authorizes each selected row before deleting it.
         assert_eq!(
             routes
                 .matches("autumn_web::authorization::authorize::<Post>")
                 .count(),
-            3,
-            "edit/update/destroy must each authorize: {routes}"
+            4,
+            "edit/update/destroy/bulk_delete must each authorize: {routes}"
         );
         assert!(routes.contains("\"edit\", &row"), "{routes}");
         assert!(routes.contains("\"update\", &current"), "{routes}");
@@ -14343,8 +14635,8 @@ async fn main() {
             routes
                 .matches("autumn_web::authorization::authorize::<Post>")
                 .count(),
-            3,
-            "no-owner edit/update/destroy must each authorize: {routes}"
+            4,
+            "no-owner edit/update/destroy/bulk_delete must each authorize: {routes}"
         );
         assert!(
             routes
@@ -14670,8 +14962,9 @@ exempt_paths = [
         // The index column renders the raw source through maud's escaping
         // `Render` impl — a table cell must not carry block-level markup, and
         // escaped text is inherently safe.
+        // `let mut columns:` since issue #1312 prepends the bulk-select column.
         let columns = routes
-            .split_once("let columns:")
+            .split_once("columns: Vec<")
             .expect("index columns block")
             .1;
         let columns = columns.split_once("];").unwrap().0;

--- a/autumn-cli/tests/generate.rs
+++ b/autumn-cli/tests/generate.rs
@@ -4402,9 +4402,17 @@ fn generate_scaffold_index_uses_paginated_repo_method() {
         routes.contains(".page(") || routes.contains(".list("),
         "scaffold index must call a paginated repository method (page()/list()): {routes}"
     );
+    // Scoped to the `index` handler body: since issue #1312 the module also
+    // emits a `bulk_delete` handler whose SELECT is bounded by the submitted id
+    // list (`WHERE id = ANY($1)`), which is not an unpaginated index load.
+    let index = routes
+        .split_once("pub async fn index(")
+        .expect("scaffold must emit an index handler")
+        .1;
+    let index = index.split("pub async fn ").next().unwrap_or(index);
     assert!(
-        !routes.contains(".load(&mut *db)"),
-        "scaffold index must not load every row without pagination: {routes}"
+        !index.contains(".load(&mut *db)"),
+        "scaffold index must not load every row without pagination: {index}"
     );
     // The repository trait must be imported so `repo.list()`/`repo.page()` (trait
     // methods) resolve at compile time — without it the generated code fails with E0599.

--- a/autumn-cli/tests/generate.rs
+++ b/autumn-cli/tests/generate.rs
@@ -816,6 +816,9 @@ fn generate_scaffold_full_e2e_post() {
         "routes::posts::create",
         "routes::posts::edit_form",
         "routes::posts::update",
+        // Issue #1312: the bulk delete-selected route is mounted alongside the
+        // per-row destroy for every non-live, non-sharded HTML scaffold.
+        "routes::posts::bulk_delete",
         "repositories::post::post_api_list",
         "repositories::post::post_api_get",
     ] {

--- a/autumn-cli/tests/integration/mod.rs
+++ b/autumn-cli/tests/integration/mod.rs
@@ -17,6 +17,7 @@ mod migrate_sqlite;
 mod offsite_backup;
 mod repo_hygiene;
 mod scaffold_belongs_to;
+mod scaffold_bulk_delete;
 mod scaffold_form_for;
 mod scaffold_rich_text;
 mod scaffold_search;

--- a/autumn-cli/tests/integration/scaffold_bulk_delete.rs
+++ b/autumn-cli/tests/integration/scaffold_bulk_delete.rs
@@ -1,0 +1,285 @@
+//! Bulk-select + delete-selected wiring in scaffolded list views (issue #1312).
+//!
+//! The generated non-live, non-sharded HTML scaffold wraps its index list in an
+//! `autumn_web::widgets::bulk_actions_form(...)` posting to a new
+//! `POST /{plural}/bulk_delete` handler, prepends a per-row
+//! `bulk_select_checkbox(...)` column, and routes the delete through the
+//! repository's `delete_many`. Empty selections are a 303 no-op, never a 400.
+//! The `--live`, `--live-validation`, `--sharded` and `--api` variants are
+//! deliberately gated off and stay byte-identical to their pre-#1312 output.
+
+use std::fmt::Write as _;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+const fn autumn_bin() -> &'static str {
+    env!("CARGO_BIN_EXE_autumn")
+}
+
+fn run_autumn_ok(dir: &Path, args: &[&str]) {
+    let output = Command::new(autumn_bin())
+        .args(args)
+        .current_dir(dir)
+        .output()
+        .expect("failed to run autumn");
+    assert!(
+        output.status.success(),
+        "autumn {args:?} failed (exit={:?})\nstdout: {}\nstderr: {}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+}
+
+/// `autumn new` + `generate scaffold Post <cols> [extra_flags]`, returning the
+/// tempdir guard and the generated project root.
+fn scaffold_project(name: &str, extra_flags: &[&str]) -> (tempfile::TempDir, PathBuf) {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    run_autumn_ok(tmp.path(), &["new", name]);
+    let project = tmp.path().join(name);
+    let mut args = vec![
+        "generate",
+        "scaffold",
+        "Post",
+        "title:String",
+        "body:Text",
+        "published:bool",
+    ];
+    args.extend_from_slice(extra_flags);
+    run_autumn_ok(&project, &args);
+    (tmp, project)
+}
+
+/// `scaffold_project`, returning the generated `src/routes/posts.rs` source.
+fn scaffold_routes(name: &str, extra_flags: &[&str]) -> (tempfile::TempDir, String) {
+    let (tmp, project) = scaffold_project(name, extra_flags);
+    let routes = fs::read_to_string(project.join("src/routes/posts.rs")).unwrap();
+    (tmp, routes)
+}
+
+/// Slice out a named `pub async fn` handler: its signature through the line
+/// before the next top-level handler.
+fn handler_slice<'a>(routes: &'a str, name: &str) -> &'a str {
+    let needle = format!("pub async fn {name}(");
+    let start = routes
+        .find(&needle)
+        .unwrap_or_else(|| panic!("routes file must emit `{needle}`:\n{routes}"));
+    let rest = &routes[start + needle.len()..];
+    rest.split("pub async fn ").next().unwrap_or(rest)
+}
+
+#[test]
+fn plain_scaffold_emits_bulk_form_checkbox_and_handler() {
+    let (_tmp, routes) = scaffold_routes("bulk-plain", &[]);
+    assert!(
+        routes.contains("#[post(\"/posts/bulk_delete\")]"),
+        "a bulk delete route must be emitted:\n{routes}"
+    );
+    assert!(
+        routes.contains("pub async fn bulk_delete("),
+        "a bulk delete handler must be emitted:\n{routes}"
+    );
+    assert!(
+        routes.contains("autumn_web::widgets::bulk_actions_form("),
+        "the index list must be wrapped in the bulk actions form:\n{routes}"
+    );
+    assert!(
+        routes.contains("bulk_select_checkbox("),
+        "each row must render a bulk-select checkbox:\n{routes}"
+    );
+    assert!(
+        routes.contains("paths::bulk_delete()"),
+        "the form action must resolve through paths::bulk_delete():\n{routes}"
+    );
+    // The "New Post" link stays outside the bulk form.
+    let index = handler_slice(&routes, "index");
+    let new_link_at = index
+        .find("New Post")
+        .unwrap_or_else(|| panic!("index must keep the New Post link:\n{index}"));
+    let form_at = index
+        .find("bulk_actions_form(")
+        .unwrap_or_else(|| panic!("index must render the bulk form:\n{index}"));
+    assert!(
+        new_link_at < form_at,
+        "the New Post link must stay outside the bulk form:\n{index}"
+    );
+}
+
+#[test]
+fn soft_delete_scaffold_routes_bulk_through_delete_many() {
+    let (_tmp, routes) = scaffold_routes("bulk-soft", &["--soft-delete"]);
+    let bulk = handler_slice(&routes, "bulk_delete");
+    assert!(
+        bulk.contains(".delete_many(&"),
+        "the soft-delete bulk path must go through the repository:\n{bulk}"
+    );
+    assert!(
+        bulk.contains("deleted_at.is_null()"),
+        "the SELECT must skip already soft-deleted rows:\n{bulk}"
+    );
+    assert!(
+        !bulk.contains("deleted_at.eq("),
+        "the handler must not hand-roll the soft-delete update:\n{bulk}"
+    );
+    assert!(
+        !bulk.contains("diesel::delete"),
+        "the soft-delete variant must never physically delete:\n{bulk}"
+    );
+}
+
+#[test]
+fn owner_scoped_scaffold_authorizes_each_row_before_bulk_delete() {
+    // A `user_id` column turns on the record-level policy + authorize wiring.
+    let tmp = tempfile::tempdir().expect("tempdir");
+    run_autumn_ok(tmp.path(), &["new", "bulk-owner"]);
+    let project = tmp.path().join("bulk-owner");
+    run_autumn_ok(
+        &project,
+        &[
+            "generate",
+            "scaffold",
+            "Post",
+            "title:String",
+            "user_id:i64",
+        ],
+    );
+    let routes = fs::read_to_string(project.join("src/routes/posts.rs")).unwrap();
+    let bulk = handler_slice(&routes, "bulk_delete");
+    assert!(
+        bulk.contains("autumn_web::authorization::authorize::<Post>("),
+        "each selected row must be authorized:\n{bulk}"
+    );
+    assert!(bulk.contains("\"delete\""), "{bulk}");
+    assert!(
+        bulk.contains("for "),
+        "authorization must run per row in a loop:\n{bulk}"
+    );
+    // Unauthorized rows are dropped from the selection, not 403'd.
+    assert!(
+        !bulk.contains("forbidden") && !bulk.contains("StatusCode::FORBIDDEN"),
+        "an unauthorized row must be skipped, not fail the whole request:\n{bulk}"
+    );
+}
+
+#[test]
+fn live_scaffold_omits_bulk_delete() {
+    let (_tmp, routes) = scaffold_routes("bulk-live", &["--live"]);
+    assert!(!routes.contains("bulk_delete"), "{routes}");
+    assert!(!routes.contains("bulk_actions_form"), "{routes}");
+    assert!(!routes.contains("bulk_select_checkbox"), "{routes}");
+}
+
+#[test]
+fn sharded_scaffold_omits_bulk_delete() {
+    let (_tmp, routes) = scaffold_routes("bulk-sharded", &["--sharded", "--shard-key", "title"]);
+    assert!(!routes.contains("bulk_delete"), "{routes}");
+    assert!(!routes.contains("bulk_actions_form"), "{routes}");
+    assert!(!routes.contains("bulk_select_checkbox"), "{routes}");
+}
+
+#[test]
+fn api_scaffold_omits_bulk_delete() {
+    // `--api` scaffolds have no HTML routes file at all.
+    let (_tmp, project) = scaffold_project("bulk-api", &["--api"]);
+    assert!(
+        !project.join("src/routes/posts.rs").exists(),
+        "an --api scaffold must not emit an HTML routes file"
+    );
+    let main = fs::read_to_string(project.join("src/main.rs")).unwrap();
+    assert!(!main.contains("bulk_delete"), "{main}");
+}
+
+#[test]
+fn main_rs_mounts_bulk_delete_route() {
+    let (_tmp, project) = scaffold_project("bulk-main", &[]);
+    let main = fs::read_to_string(project.join("src/main.rs")).unwrap();
+    assert!(
+        main.contains("routes::posts::bulk_delete"),
+        "main.rs must mount the bulk delete route:\n{main}"
+    );
+    let destroy_at = main
+        .find("routes::posts::destroy")
+        .unwrap_or_else(|| panic!("main.rs must mount destroy:\n{main}"));
+    let bulk_at = main
+        .find("routes::posts::bulk_delete")
+        .unwrap_or_else(|| panic!("main.rs must mount bulk_delete:\n{main}"));
+    assert!(
+        destroy_at < bulk_at,
+        "bulk_delete must be registered immediately after destroy:\n{main}"
+    );
+}
+
+#[test]
+fn searchable_scaffold_keeps_checkboxes_in_search_fragment() {
+    let (_tmp, routes) = scaffold_routes("bulk-search", &["--searchable", "title,body"]);
+    let search = handler_slice(&routes, "search");
+    assert!(
+        search.contains("bulk_select_checkbox("),
+        "the search results fragment must keep the row checkboxes:\n{search}"
+    );
+    assert!(
+        search.contains("bulk_actions_form("),
+        "the search results fragment must stay inside the bulk form:\n{search}"
+    );
+    // The search input itself stays outside the bulk form.
+    let index = handler_slice(&routes, "index");
+    let input_at = index
+        .find("active_search_input(")
+        .unwrap_or_else(|| panic!("index must render the search box:\n{index}"));
+    let form_at = index
+        .find("bulk_actions_form(")
+        .unwrap_or_else(|| panic!("index must render the bulk form:\n{index}"));
+    assert!(
+        input_at < form_at,
+        "the search input must stay outside the bulk form:\n{index}"
+    );
+}
+
+/// Point a generated project at this workspace's `autumn-web` rather than a
+/// published version, so a compile of the generated code exercises the code
+/// under test.
+fn patch_autumn_web_path(project: &Path) {
+    let cargo_toml_path = project.join("Cargo.toml");
+    let mut content = fs::read_to_string(&cargo_toml_path).unwrap();
+    let workspace_root = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("workspace root");
+    let autumn_web = workspace_root.join("autumn");
+    let _ = write!(
+        content,
+        "\n[patch.crates-io]\nautumn-web = {{ path = \"{}\" }}\n",
+        autumn_web.display().to_string().replace('\\', "/")
+    );
+    fs::write(&cargo_toml_path, content).unwrap();
+}
+
+fn assert_project_cargo_checks(project: &Path) {
+    patch_autumn_web_path(project);
+
+    let check = Command::new("cargo")
+        .args(["check", "--tests"])
+        .current_dir(project)
+        .output()
+        .unwrap();
+    assert!(
+        check.status.success(),
+        "cargo check on generated scaffold failed:\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&check.stdout),
+        String::from_utf8_lossy(&check.stderr),
+    );
+}
+
+/// The emitted bulk-delete handler, parser helper, and index/search views must
+/// actually compile — both on the physical-delete and soft-delete paths.
+///
+/// Ignored by default; run with `cargo test -p autumn-cli -- --ignored`.
+#[test]
+#[ignore = "slow: cargo-checks a fresh project — run with `cargo test -p autumn-cli -- --ignored`"]
+fn bulk_delete_generated_project_cargo_checks() {
+    let (_tmp, project) = scaffold_project("bulk-check-plain", &[]);
+    assert_project_cargo_checks(&project);
+
+    let (_tmp_soft, project_soft) = scaffold_project("bulk-check-soft", &["--soft-delete"]);
+    assert_project_cargo_checks(&project_soft);
+}

--- a/autumn/src/widgets.rs
+++ b/autumn/src/widgets.rs
@@ -1127,6 +1127,106 @@ pub fn data_table<T>(
     }
 }
 
+// ── bulk actions (#1312) ──────────────────────────────────────────────────
+
+/// Configuration for the bulk-select / bulk-actions widgets.
+///
+/// Build with [`BulkActionsConfig::new`] (the form `action` URL) and chain the
+/// builder methods for optional overrides.
+#[cfg(feature = "maud")]
+#[derive(Debug, Clone)]
+pub struct BulkActionsConfig<'a> {
+    /// Form `action` URL the bulk submit posts to (e.g. `/posts/bulk_delete`).
+    pub action: &'a str,
+    /// Name of the per-row checkbox field (default `"ids"`).
+    pub field_name: &'a str,
+    /// Label on the bulk submit button (default `"Delete selected"`).
+    pub submit_label: &'a str,
+    /// Prefix of each checkbox's `aria-label` (default `"Select row"`).
+    pub select_label: &'a str,
+    /// Optional confirmation prompt. `None` (the default) emits no `onclick`,
+    /// so the control keeps working with JavaScript disabled.
+    pub confirm: Option<&'a str>,
+}
+
+#[cfg(feature = "maud")]
+impl<'a> BulkActionsConfig<'a> {
+    /// Create a new config posting to `action`, with sensible defaults.
+    #[must_use]
+    pub const fn new(action: &'a str) -> Self {
+        Self {
+            action,
+            field_name: "ids",
+            submit_label: "Delete selected",
+            select_label: "Select row",
+            confirm: None,
+        }
+    }
+
+    /// Override the per-row checkbox field name (default `"ids"`).
+    #[must_use]
+    pub const fn field_name(mut self, field_name: &'a str) -> Self {
+        self.field_name = field_name;
+        self
+    }
+
+    /// Override the bulk submit button label (default `"Delete selected"`).
+    #[must_use]
+    pub const fn submit_label(mut self, submit_label: &'a str) -> Self {
+        self.submit_label = submit_label;
+        self
+    }
+
+    /// Override the checkbox `aria-label` prefix (default `"Select row"`).
+    #[must_use]
+    pub const fn select_label(mut self, select_label: &'a str) -> Self {
+        self.select_label = select_label;
+        self
+    }
+
+    /// Opt into a JavaScript confirmation prompt on the submit button.
+    #[must_use]
+    pub const fn confirm(mut self, confirm: &'a str) -> Self {
+        self.confirm = Some(confirm);
+        self
+    }
+}
+
+/// Render one row's bulk-select checkbox.
+#[cfg(feature = "maud")]
+#[must_use]
+pub fn bulk_select_checkbox(
+    value: impl std::fmt::Display,
+    config: &BulkActionsConfig<'_>,
+) -> maud::Markup {
+    // TODO(#1312): green phase
+    let _ = (value.to_string(), config);
+    maud::html! {}
+}
+
+/// Render the bulk-actions toolbar (the submit button).
+#[cfg(feature = "maud")]
+#[must_use]
+pub fn bulk_actions_toolbar(config: &BulkActionsConfig<'_>) -> maud::Markup {
+    // TODO(#1312): green phase
+    let _ = config;
+    maud::html! {}
+}
+
+/// Wrap `content` in the bulk-actions `<form>`, with a csrf field and toolbar.
+#[cfg(feature = "maud")]
+#[must_use]
+pub fn bulk_actions_form(
+    config: &BulkActionsConfig<'_>,
+    csrf_token: Option<&str>,
+    csrf_field: Option<&str>,
+    content: maud::Markup,
+) -> maud::Markup {
+    // TODO(#1312): green phase
+    let _ = (config, csrf_token, csrf_field, content);
+    maud::html! {}
+}
+
 // ── breadcrumb ────────────────────────────────────────────────────────────
 
 /// A single crumb in a [`breadcrumb`] navigation trail.
@@ -6223,6 +6323,123 @@ mod tests {
         assert!(html.contains("q=foo"), "{html}");
         // no duplicate old sort
         assert!(!html.contains("sort=old"), "{html}");
+    }
+
+    // ── bulk actions (#1312) ───────────────────────────────────────────
+
+    #[test]
+    fn bulk_actions_config_defaults() {
+        let cfg = BulkActionsConfig::new("/posts/bulk_delete");
+        assert_eq!(cfg.action, "/posts/bulk_delete");
+        assert_eq!(cfg.field_name, "ids");
+        assert_eq!(cfg.submit_label, "Delete selected");
+        assert_eq!(cfg.select_label, "Select row");
+        assert!(cfg.confirm.is_none());
+    }
+
+    #[test]
+    fn bulk_actions_config_builders() {
+        let cfg = BulkActionsConfig::new("/posts/bulk_delete")
+            .field_name("post_ids")
+            .submit_label("Archive selected")
+            .select_label("Select post")
+            .confirm("Archive these posts?");
+        assert_eq!(cfg.action, "/posts/bulk_delete");
+        assert_eq!(cfg.field_name, "post_ids");
+        assert_eq!(cfg.submit_label, "Archive selected");
+        assert_eq!(cfg.select_label, "Select post");
+        assert_eq!(cfg.confirm, Some("Archive these posts?"));
+    }
+
+    #[test]
+    fn bulk_select_checkbox_emits_name_value_and_aria_label() {
+        let cfg = BulkActionsConfig::new("/posts/bulk_delete");
+        let html = bulk_select_checkbox(42, &cfg).into_string();
+        assert!(html.contains(r#"type="checkbox""#), "{html}");
+        assert!(html.contains(r#"name="ids""#), "{html}");
+        assert!(html.contains(r#"value="42""#), "{html}");
+        assert!(html.contains("autumn-bulk-select"), "{html}");
+        assert!(html.contains(r#"aria-label="Select row 42""#), "{html}");
+    }
+
+    #[test]
+    fn bulk_select_checkbox_honours_custom_field_name() {
+        let cfg = BulkActionsConfig::new("/posts/bulk_delete")
+            .field_name("post_ids")
+            .select_label("Select post");
+        let html = bulk_select_checkbox(7, &cfg).into_string();
+        assert!(html.contains(r#"name="post_ids""#), "{html}");
+        assert!(!html.contains(r#"name="ids""#), "{html}");
+        assert!(html.contains(r#"aria-label="Select post 7""#), "{html}");
+    }
+
+    #[test]
+    fn bulk_actions_form_renders_csrf_hidden_input() {
+        let cfg = BulkActionsConfig::new("/posts/bulk_delete");
+        let html = bulk_actions_form(&cfg, Some("tok-123"), None, maud::html! {}).into_string();
+        assert!(html.contains(r#"type="hidden""#), "{html}");
+        // The csrf field name defaults to `_csrf` when none is supplied.
+        assert!(html.contains(r#"name="_csrf""#), "{html}");
+        assert!(html.contains(r#"value="tok-123""#), "{html}");
+        // A configured field name wins over the default.
+        let named = bulk_actions_form(&cfg, Some("tok-123"), Some("authenticity"), maud::html! {})
+            .into_string();
+        assert!(named.contains(r#"name="authenticity""#), "{named}");
+        assert!(!named.contains(r#"name="_csrf""#), "{named}");
+    }
+
+    #[test]
+    fn bulk_actions_form_omits_csrf_input_when_none() {
+        let cfg = BulkActionsConfig::new("/posts/bulk_delete");
+        let html = bulk_actions_form(&cfg, None, None, maud::html! {}).into_string();
+        assert!(!html.contains(r#"type="hidden""#), "{html}");
+        assert!(!html.contains("_csrf"), "{html}");
+        // The form itself is still rendered.
+        assert!(html.contains("<form"), "{html}");
+    }
+
+    #[test]
+    fn bulk_actions_form_posts_to_action_and_wraps_content() {
+        let cfg = BulkActionsConfig::new("/posts/bulk_delete");
+        let content = maud::html! { p { "row-marker" } };
+        let html = bulk_actions_form(&cfg, None, None, content).into_string();
+        assert!(html.contains(r#"method="post""#), "{html}");
+        assert!(html.contains(r#"action="/posts/bulk_delete""#), "{html}");
+        assert!(html.contains("autumn-bulk-form"), "{html}");
+        assert!(html.contains("row-marker"), "{html}");
+        // The toolbar is rendered inside the form, after the content.
+        let content_at = html.find("row-marker").expect("content rendered");
+        let toolbar_at = html
+            .find("autumn-bulk-actions")
+            .expect("toolbar rendered inside the form");
+        assert!(
+            content_at < toolbar_at,
+            "toolbar must follow content: {html}"
+        );
+        assert!(html.trim_end().ends_with("</form>"), "{html}");
+    }
+
+    #[test]
+    fn bulk_actions_toolbar_button_is_submit_and_labelled() {
+        let cfg = BulkActionsConfig::new("/posts/bulk_delete");
+        let html = bulk_actions_toolbar(&cfg).into_string();
+        assert!(html.contains("autumn-bulk-actions"), "{html}");
+        assert!(html.contains(r#"role="group""#), "{html}");
+        assert!(html.contains(r#"type="submit""#), "{html}");
+        assert!(html.contains("Delete selected"), "{html}");
+    }
+
+    #[test]
+    fn bulk_actions_toolbar_confirm_is_opt_in() {
+        // No-JS guarantee: the default toolbar carries no `onclick` handler.
+        let cfg = BulkActionsConfig::new("/posts/bulk_delete");
+        let plain = bulk_actions_toolbar(&cfg).into_string();
+        assert!(!plain.contains("onclick"), "{plain}");
+        // Opting in emits the confirmation prompt.
+        let confirmed =
+            bulk_actions_toolbar(&cfg.clone().confirm("Delete these rows?")).into_string();
+        assert!(confirmed.contains("onclick"), "{confirmed}");
+        assert!(confirmed.contains("Delete these rows?"), "{confirmed}");
     }
 
     // ── CardConfig builder ─────────────────────────────────────────────

--- a/autumn/src/widgets.rs
+++ b/autumn/src/widgets.rs
@@ -35,6 +35,14 @@
 //! | Plain `GET` form is sufficient | `axum::extract::Query` |
 //! | You need unusual htmx wiring | Hand-write `hx-*` attributes |
 //!
+//! # Bulk actions
+//!
+//! | Widget | Use |
+//! |--------|-----|
+//! | `bulk_select_checkbox` | One row's `name="ids"` select checkbox (issue #1312) |
+//! | `bulk_actions_toolbar` | `role="group"` submit button applying the selection |
+//! | `bulk_actions_form` | `POST` form wrapping a list + toolbar, with the CSRF field |
+//!
 //! # Modals & confirmation
 //!
 //! | Situation | Use |
@@ -1192,39 +1200,208 @@ impl<'a> BulkActionsConfig<'a> {
     }
 }
 
-/// Render one row's bulk-select checkbox.
+/// Render one row's bulk-select checkbox (issue #1312).
+///
+/// One of these goes in the first cell of every row inside a
+/// [`bulk_actions_form`]. Every checkbox shares the same `name`
+/// ([`BulkActionsConfig::field_name`], default `"ids"`), so a browser submits
+/// the checked rows as repeated `ids=<value>` pairs — no JavaScript, no
+/// per-row form. The server side reads them back with any repeated-key form
+/// parser (the scaffold's generated `parse_bulk_ids` accepts both `ids` and
+/// the `ids[]` spelling some clients emit).
+///
+/// `value` is anything [`Display`](std::fmt::Display) — typically the row's
+/// primary key. It is HTML-escaped by Maud, both in `value` and in the
+/// `aria-label` (`"{select_label} {value}"`), so a screen reader announces
+/// which row each checkbox selects rather than a wall of unlabelled controls.
+///
+/// # CSS hooks
+///
+/// | Selector | Element |
+/// |----------|---------|
+/// | `.autumn-bulk-select` | The per-row `<input type="checkbox">` |
+///
+/// # Example
+///
+/// ```rust,ignore
+/// use autumn_web::widgets::{BulkActionsConfig, Column, bulk_select_checkbox};
+///
+/// let action = paths::bulk_delete();
+/// let cfg = BulkActionsConfig::new(&action);
+/// let mut columns: Vec<Column<Post>> = post_columns();
+/// columns.insert(
+///     0,
+///     Column::new("", |row: &Post| maud::html! { (bulk_select_checkbox(row.id, &cfg)) }),
+/// );
+/// ```
+///
+/// ```rust
+/// use autumn_web::widgets::{BulkActionsConfig, bulk_select_checkbox};
+///
+/// let cfg = BulkActionsConfig::new("/posts/bulk_delete");
+/// let html = bulk_select_checkbox(42, &cfg).into_string();
+/// assert!(html.contains(r#"type="checkbox""#));
+/// assert!(html.contains(r#"name="ids""#));
+/// assert!(html.contains(r#"value="42""#));
+/// assert!(html.contains(r#"aria-label="Select row 42""#));
+/// ```
 #[cfg(feature = "maud")]
 #[must_use]
 pub fn bulk_select_checkbox(
     value: impl std::fmt::Display,
     config: &BulkActionsConfig<'_>,
 ) -> maud::Markup {
-    // TODO(#1312): green phase
-    let _ = (value.to_string(), config);
-    maud::html! {}
+    let value = value.to_string();
+    let aria_label = format!("{} {value}", config.select_label);
+    maud::html! {
+        input type="checkbox" name=(config.field_name) value=(value)
+            class="autumn-bulk-select" aria-label=(aria_label);
+    }
 }
 
-/// Render the bulk-actions toolbar (the submit button).
+/// Render the bulk-actions toolbar — the submit button that applies the
+/// selection (issue #1312).
+///
+/// Rendered automatically at the end of a [`bulk_actions_form`]; call it
+/// directly only when hand-building the surrounding `<form>`.
+///
+/// # No-JavaScript guarantee
+///
+/// The button is a plain `<button type="submit">`. An `onclick="return
+/// confirm(...)"` handler is emitted **only** when
+/// [`BulkActionsConfig::confirm`] opted in — so the default control still
+/// works with scripting disabled, and even with a confirmation configured the
+/// server remains the enforcement point.
+///
+/// # CSS hooks
+///
+/// | Selector | Element |
+/// |----------|---------|
+/// | `.autumn-bulk-actions` | Grouping `<div role="group">` around the submit button |
+///
+/// # Example
+///
+/// ```rust,ignore
+/// use autumn_web::widgets::{BulkActionsConfig, bulk_actions_toolbar};
+///
+/// let cfg = BulkActionsConfig::new("/posts/bulk_delete")
+///     .submit_label("Delete selected")
+///     .confirm("Delete the selected posts?");
+/// let toolbar = bulk_actions_toolbar(&cfg);
+/// ```
+///
+/// ```rust
+/// use autumn_web::widgets::{BulkActionsConfig, bulk_actions_toolbar};
+///
+/// let cfg = BulkActionsConfig::new("/posts/bulk_delete");
+/// let html = bulk_actions_toolbar(&cfg).into_string();
+/// assert!(html.contains(r#"class="autumn-bulk-actions""#));
+/// assert!(html.contains(r#"type="submit""#));
+/// assert!(html.contains("Delete selected"));
+/// // No confirmation was configured, so no inline handler is emitted.
+/// assert!(!html.contains("onclick"));
+/// ```
 #[cfg(feature = "maud")]
 #[must_use]
 pub fn bulk_actions_toolbar(config: &BulkActionsConfig<'_>) -> maud::Markup {
-    // TODO(#1312): green phase
-    let _ = config;
-    maud::html! {}
+    // Built as an owned string so Maud's attribute escaping applies to the
+    // caller-supplied prompt (a `'` in the message can't break out of the
+    // handler, and `<`/`&` can't break out of the attribute).
+    let onclick = config
+        .confirm
+        .map(|message| format!("return confirm('{message}')"));
+    maud::html! {
+        div class="autumn-bulk-actions" role="group" {
+            button type="submit" onclick=[onclick.as_deref()] { (config.submit_label) }
+        }
+    }
 }
 
-/// Wrap `content` in the bulk-actions `<form>`, with a csrf field and toolbar.
+/// Wrap a rendered list in the bulk-actions `<form>` (issue #1312).
+///
+/// This is the outer half of the no-JavaScript bulk-select flow: a plain
+/// `POST` form whose `action` is [`BulkActionsConfig::action`], containing (in
+/// order) the hidden CSRF field, the caller's `content` — a table, list, or
+/// anything else carrying one [`bulk_select_checkbox`] per row — and the
+/// [`bulk_actions_toolbar`] submit button.
+///
+/// Keep page furniture that is *not* part of the selection (a "New record"
+/// link, a search box) outside the form: anything inside is submitted with the
+/// selection.
+///
+/// # CSRF
+///
+/// Pass the handler's token as `csrf_token` and the configured field name as
+/// `csrf_field` (both `Option<&str>`, e.g.
+/// `csrf.as_ref().map(|t| t.token())` and
+/// `csrf_field.as_ref().map(|f| f.0.as_str())`). When `csrf_token` is `None`
+/// no hidden input is rendered at all; when it is `Some`, the field name
+/// defaults to `"_csrf"`.
+///
+/// # CSS hooks
+///
+/// | Selector | Element |
+/// |----------|---------|
+/// | `.autumn-bulk-form` | The wrapping `<form method="post">` |
+/// | `.autumn-bulk-actions` | Grouping `<div role="group">` around the submit button |
+/// | `.autumn-bulk-select` | Each row's `<input type="checkbox">` |
+///
+/// # Example
+///
+/// ```rust,ignore
+/// use autumn_web::widgets::{BulkActionsConfig, bulk_actions_form, data_table, DataTableConfig};
+///
+/// let action = paths::bulk_delete();
+/// let cfg = BulkActionsConfig::new(&action);
+/// Ok(layout("Posts", html! {
+///     a href=(paths::new()) { "New Post" } // outside the form
+///     (bulk_actions_form(
+///         &cfg,
+///         csrf.as_ref().map(|t| t.token()),
+///         csrf_field.as_ref().map(|f| f.0.as_str()),
+///         html! {
+///             (data_table(&page.content, &columns, &DataTableConfig::new("No posts yet.")))
+///         },
+///     ))
+/// }))
+/// ```
+///
+/// ```rust
+/// use autumn_web::widgets::{BulkActionsConfig, bulk_actions_form};
+///
+/// let cfg = BulkActionsConfig::new("/posts/bulk_delete");
+/// let html = bulk_actions_form(&cfg, Some("tok-123"), None, maud::html! { p { "rows" } })
+///     .into_string();
+/// assert!(html.contains(r#"method="post""#));
+/// assert!(html.contains(r#"action="/posts/bulk_delete""#));
+/// assert!(html.contains(r#"name="_csrf""#));
+/// assert!(html.contains(r#"value="tok-123""#));
+/// // Content first, toolbar last, all inside the form.
+/// assert!(html.find("rows") < html.find("autumn-bulk-actions"));
+/// assert!(html.trim_end().ends_with("</form>"));
+/// ```
+// `content` is taken by value so `bulk_actions_form(&cfg, .., html! { .. })`
+// reads without a `&` at the call site (matching `alert_with`); Maud renders it
+// by reference, hence the allow.
 #[cfg(feature = "maud")]
 #[must_use]
+#[allow(clippy::needless_pass_by_value)]
 pub fn bulk_actions_form(
     config: &BulkActionsConfig<'_>,
     csrf_token: Option<&str>,
     csrf_field: Option<&str>,
     content: maud::Markup,
 ) -> maud::Markup {
-    // TODO(#1312): green phase
-    let _ = (config, csrf_token, csrf_field, content);
-    maud::html! {}
+    let csrf_field_name = csrf_field.unwrap_or("_csrf");
+    maud::html! {
+        form method="post" action=(config.action) class="autumn-bulk-form" {
+            @if let Some(token) = csrf_token {
+                input type="hidden" name=(csrf_field_name) value=(token);
+            }
+            (content)
+            (bulk_actions_toolbar(config))
+        }
+    }
 }
 
 // ── breadcrumb ────────────────────────────────────────────────────────────

--- a/docs/guide/generators.md
+++ b/docs/guide/generators.md
@@ -711,6 +711,63 @@ concession, not a routing one. CSRF protection still treats the
 overridden mutation as unsafe and rejects submissions without a valid
 token with `403 Forbidden`.
 
+### Bulk select and delete selected
+
+Every standard HTML scaffold's index list ships a no-JavaScript
+bulk-delete flow (issue #1312):
+
+- The `data_table` gains a leading checkbox column. Each row renders
+  `autumn_web::widgets::bulk_select_checkbox(row.id, &bulk_cfg)` —
+  `<input type="checkbox" name="ids" value="…">` with an
+  `aria-label="Select row <id>"`, so a screen reader announces which row
+  each control selects.
+- The list (and, with `--searchable`, the whole
+  `#<plural>-search-results` container htmx swaps) is wrapped in
+  `autumn_web::widgets::bulk_actions_form(...)`: a plain
+  `POST /<plural>/bulk_delete` form carrying the CSRF hidden field and a
+  **Delete selected** submit button. The "New …" link and the search box
+  stay outside the form — they are page furniture, not part of the
+  selection.
+- A `#[secured] #[post("/<plural>/bulk_delete")]` handler is emitted and
+  mounted in `src/main.rs` right after `destroy`.
+
+Contract of the generated handler:
+
+| Situation | Behaviour |
+| --------- | --------- |
+| Checked rows | Deleted through the repository's `delete_many`, then a `Deleted N <plural>` flash and a 303 back to the index. |
+| Field name | `name="ids"` (matching `autumn-admin-plugin`); the parser also accepts the `ids[]` spelling some clients send. |
+| Empty selection | Info flash + 303 redirect. **Never** a 400 — a list-write endpoint doesn't fail on missing params. |
+| Malformed id (`ids=abc`) | Silently dropped, same as above. Duplicates are collapsed. |
+| `--soft-delete` | The pre-flight `SELECT` filters `deleted_at IS NULL`, and `delete_many` applies the soft-delete update — no hand-rolled `deleted_at` write. |
+| Record policy wiring on (an owner column, the default) | Each selected row is authorized with the same `"delete"` action `destroy` uses. A row the actor may not delete is dropped from the batch rather than 403'ing the request, so the endpoint is not an existence oracle. |
+| `dependent(restrict)` child rows | `delete_many` probes first and aborts the **whole** batch with a 409, rolling back — no partial delete. |
+
+Not emitted for `--live`, `--live-validation`, or `--sharded` (their list
+DOM is owned by an SSE/htmx swap contract, or has no cross-shard
+`delete_many`), and `--api` scaffolds render no HTML at all. Those
+variants' output is byte-identical to their pre-#1312 shape.
+
+The three widgets are ordinary public helpers — use them in hand-written
+list views too:
+
+```rust,ignore
+use autumn_web::widgets::{BulkActionsConfig, bulk_actions_form, bulk_select_checkbox};
+
+let action = paths::bulk_delete();
+let cfg = BulkActionsConfig::new(&action)
+    .submit_label("Archive selected")
+    .confirm("Archive these posts?"); // opt-in; omit to stay 100% no-JS
+html! {
+    (bulk_actions_form(
+        &cfg,
+        csrf.as_ref().map(|t| t.token()),
+        csrf_field.as_ref().map(|f| f.0.as_str()),
+        html! { (my_list(&rows, &cfg)) },
+    ))
+}
+```
+
 Metadata flags let you keep common model and repository polish in the
 generation step:
 


### PR DESCRIPTION
Implements issue #1312: a no-JavaScript bulk-delete flow for standard HTML scaffold index lists.

## Summary

Every non-live, non-sharded, non-API HTML scaffold now ships with:
- A leading checkbox column on the index list (and search results when `--searchable`)
- A `POST /{plural}/bulk_delete` handler that deletes multiple selected rows in one request
- A bulk-actions form wrapping the list with a "Delete selected" submit button
- Full support for soft-delete, record-level authorization, and search integration

The feature is gated off for `--live`, `--live-validation`, `--sharded`, and `--api` variants to keep their output byte-identical to pre-#1312 versions.

## Key Changes

**autumn-cli/src/generate/scaffold.rs:**
- Added `bulk_delete_enabled` gate computed identically in both `plan_scaffold_with_options_impl` and `render_routes_file` to ensure consistency
- Generated `parse_bulk_ids` helper to parse repeated `ids` checkboxes from form bodies (accepts both `ids=1&ids=2` and `ids[]=1&ids[]=2` spellings)
- Generated `bulk_delete` handler that:
  - Parses selected row IDs from the form body
  - Returns 303 + info flash for empty selections (never 400s)
  - Filters soft-deleted rows before authorization/deletion
  - Per-row authorizes with the same `"delete"` action as `destroy` when policy wiring is on
  - Routes through `delete_many` so soft-delete, hooks, and `dependent(...)` cascades apply
- Prepended a `bulk_select_checkbox` column to index and search results
- Wrapped index list (and search results container when searchable) in `bulk_actions_form`
- Added CSRF parameters to index/search handler signatures
- Updated `paths!` block to include `bulk_delete` route name
- Extended smoke tests to exercise the bulk delete flow (empty selection, repeated ids, duplicates)

**autumn/src/widgets.rs:**
- Added `BulkActionsConfig` builder for configuring bulk-select behavior (action URL, field name, labels, optional confirmation)
- Added `bulk_select_checkbox` widget: renders `<input type="checkbox" name="ids">` with `aria-label` for accessibility
- Added `bulk_actions_toolbar` widget: renders the submit button with optional `onclick` confirmation
- Added `bulk_actions_form` widget: wraps content in a `POST` form with CSRF hidden field and toolbar
- All three widgets are gated behind the `maud` feature and include comprehensive doc comments with examples

**autumn-cli/tests/integration/scaffold_bulk_delete.rs (new):**
- Integration tests covering:
  - Plain scaffold emits bulk form, checkboxes, and handler
  - Soft-delete routes through `delete_many` with `deleted_at IS NULL` filter
  - Owner-scoped scaffolds authorize each row before deletion
  - `--live`, `--sharded`, `--api` variants omit bulk delete entirely
  - `main.rs` mounts the route immediately after `destroy`
  - Searchable scaffolds keep checkboxes in search fragments
  - Generated code compiles against the workspace's `autumn-web`

**docs/guide/generators.md:**
- Added "Bulk select and delete selected" section documenting the feature, contract, and behavior matrix

**CHANGELOG.md:**
- Added entry under "Added" describing the feature and its scope

## Implementation Details

- **Gating logic:** The `bulk_delete_enabled` gate is computed identically in two places (`plan_scaffold_with_options_impl` and `render_routes_file`) to ensure the smoke test, routes file, and main.rs all agree on whether to emit the feature. This prevents main.rs from mounting a route the module never emitted.
- **Search integration:** When `--searchable`, the search results fragment is itself a whole `bulk_actions_form`, so htmx swaps replace the form wholesale and checkboxes always have their submit button (avoiding nested `<form>` HTML).
- **No-JavaScript guarantee:** All widgets work without JavaScript

https://claude.ai/code/session_01S27uRmiQ67t7HL2ykBSHCw