### PR TITLE
system-tests: add SystemTest::layer() for app-wide middleware

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,6 +111,19 @@ jobs:
           cargo test -p autumn-web --features markdown --test integration_tests rich_text
           cargo test -p autumn-web --features markdown --lib markdown::
           cargo test -p autumn-web --features markdown --doc markdown::
+      - name: Run system-test harness (non-browser) tests
+        # `system-tests` is not a default feature. The `cargo test --workspace`
+        # above happens to compile it today only because `example-e2e` depends
+        # on `autumn-web` with that feature and workspace feature unification
+        # turns it on — accidental coverage that would vanish silently if that
+        # one dependency were ever dev-scoped or dropped. Name it explicitly so
+        # the harness's own tests (browser resolution, transient-CDP retry
+        # loop, `SystemTest::layer`) stay covered on purpose. The `#[ignore]`d
+        # browser tests need Chromium and run in publish-gate.yml's
+        # browser-provisioned job.
+        run: |
+          cargo test -p autumn-web --features system-tests --lib system_test::
+          cargo test -p autumn-web --features system-tests --test integration_tests system_test_api
       - name: Install Postgres client tools (Linux)
         if: runner.os == 'Linux'
         run: |

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -40,6 +40,31 @@ jobs:
         target: [idempotency, routing, headers, session, body]
     steps:
       - uses: actions/checkout@v7
+      - name: Free disk space
+        # cargo-fuzz builds the whole autumn-web dependency graph in release
+        # mode with ASAN instrumentation, which is the most artifact-heavy
+        # build in the repo. Without this, jobs die mid-compile (~3.5 min in,
+        # while the heavy crates codegen) with exit 143 and "The runner has
+        # received a shutdown signal" — the runner agent going down takes the
+        # log with it, so there is no "No space left on device" line to read.
+        # A DIFFERENT arbitrary 2 of the 5 matrix jobs fail per run
+        # (idempotency+headers on trunk-dev dd9e8ae3, body+routing on #2182),
+        # which is the signature of a per-VM resource ceiling rather than
+        # anything target-specific. This is the same reclamation ci.yml's test
+        # and coverage jobs already do for the same class of failure; the fuzz
+        # workflow never got it. `df -h` is left in deliberately so the next
+        # failure has a headroom number to read.
+        run: |
+          sudo rm -rf \
+            /usr/share/dotnet \
+            /usr/local/lib/android \
+            /opt/ghc \
+            /opt/hostedtoolcache \
+            /usr/local/share/boost \
+            /usr/local/lib/node_modules \
+            /usr/share/swift
+          sudo docker image prune --all --force || true
+          df -h
       - name: Install nightly toolchain
         uses: dtolnay/rust-toolchain@nightly
       - name: Install cargo-fuzz

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -40,31 +40,31 @@ jobs:
         target: [idempotency, routing, headers, session, body]
     steps:
       - uses: actions/checkout@v7
-      - name: Free disk space
-        # cargo-fuzz builds the whole autumn-web dependency graph in release
-        # mode with ASAN instrumentation, which is the most artifact-heavy
-        # build in the repo. Without this, jobs die mid-compile (~3.5 min in,
-        # while the heavy crates codegen) with exit 143 and "The runner has
-        # received a shutdown signal" — the runner agent going down takes the
-        # log with it, so there is no "No space left on device" line to read.
-        # A DIFFERENT arbitrary 2 of the 5 matrix jobs fail per run
-        # (idempotency+headers on trunk-dev dd9e8ae3, body+routing on #2182),
-        # which is the signature of a per-VM resource ceiling rather than
-        # anything target-specific. This is the same reclamation ci.yml's test
-        # and coverage jobs already do for the same class of failure; the fuzz
-        # workflow never got it. `df -h` is left in deliberately so the next
-        # failure has a headroom number to read.
+      - name: Report and enlarge headroom for the ASAN build
+        # A COLD cargo-fuzz build of this workspace does not fit on a standard
+        # GitHub runner (4 vCPU / 16 GB). It dies partway into compiling
+        # `autumn-web` itself with exit 143 and "The runner has received a
+        # shutdown signal" — the runner agent is killed, so it takes the log
+        # with it and no OOM line survives to read.
+        #
+        # Warm caches were hiding this. Swatinem/rust-cache keys per matrix
+        # job, so each target has its own cache: whichever targets happened to
+        # restore one passed, and the cold ones died. That is why an arbitrary
+        # 2 of 5 failed per run (idempotency+headers on trunk-dev dd9e8ae3,
+        # body+routing on #2182) and why touching fuzz/Cargo.toml — a
+        # cache-key input — made all 5 fail at once.
+        #
+        # Disk is NOT the constraint: `df -h` on the failing runner reported
+        # 114 GB free (22% used). Memory is. Trade some of that idle disk for
+        # swap so a peak that would otherwise be an OOM kill just gets slower.
         run: |
-          sudo rm -rf \
-            /usr/share/dotnet \
-            /usr/local/lib/android \
-            /opt/ghc \
-            /opt/hostedtoolcache \
-            /usr/local/share/boost \
-            /usr/local/lib/node_modules \
-            /usr/share/swift
-          sudo docker image prune --all --force || true
-          df -h
+          echo "── before ──"; free -h; df -h /
+          sudo swapoff -a || true
+          sudo fallocate -l 16G /swapfile
+          sudo chmod 600 /swapfile
+          sudo mkswap /swapfile
+          sudo swapon /swapfile
+          echo "── after ──"; free -h
       - name: Install nightly toolchain
         uses: dtolnay/rust-toolchain@nightly
       - name: Install cargo-fuzz
@@ -83,6 +83,12 @@ jobs:
         # Force the gnu host target: cargo-fuzz is installed as a musl-static binary
         # (via install-action's cargo-binstall fallback) and would otherwise default to
         # x86_64-unknown-linux-musl, where the ASAN build fails (sanitizer vs static libc).
+        # CARGO_BUILD_JOBS caps concurrent rustc processes. The default (one
+        # per core) stacks several sanitizer-instrumented codegen peaks at
+        # once, which is what tips a cold build over; 2 keeps the build
+        # parallel without racing itself to the ceiling.
+        env:
+          CARGO_BUILD_JOBS: 2
         run: cargo +nightly fuzz run ${{ matrix.target }} --target x86_64-unknown-linux-gnu -- -max_total_time=30 -timeout=10
       - name: Upload crash reproducers
         if: failure()

--- a/.github/workflows/publish-gate.yml
+++ b/.github/workflows/publish-gate.yml
@@ -117,6 +117,22 @@ jobs:
           REQUIRE_FULL_COVERAGE: "1"
         run: ./scripts/check-examples-e2e.sh
 
+      # The harness's own browser tests. They are `#[ignore]`d (they need
+      # Chromium) and live behind the `system-tests` feature, which puts them
+      # outside BOTH always-on sweeps: the `test` job never passes
+      # `--include-ignored`, and ci.yml's Docker `--ignored` sweep uses a
+      # feature list without `system-tests`, so the module does not even
+      # compile into that binary. This job is the only one that provisions a
+      # browser, so it is the only place `SystemTest`'s own end-to-end
+      # coverage (htmx settle, transient-navigation retries, `.layer()`,
+      # console-error capture, `attach()`) can actually run.
+      - name: Run the SystemTest harness browser suite
+        env:
+          AUTUMN_CHROMIUM: ${{ steps.setup-chrome.outputs.chrome-path }}
+        run: |
+          cargo test -p autumn-web --features system-tests \
+            --test integration_tests system_test_api -- --include-ignored
+
   # ---------------------------------------------------------------------------
   # 1. Crate metadata
   # ---------------------------------------------------------------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **system-tests:** `SystemTest::layer(...)` registers app-wide Tower
+  middleware on the router a browser test serves (#1456). Applications whose
+  routes depend on a global layer — tenant scoping bound to a database pool,
+  an auth shim, request enrichment — previously had no way to install it on
+  the runner, and the workaround (cloning the layer onto each handler before
+  passing them to `.routes()`) exercises a stack the real app never serves.
+  The method takes the same `IntoAppLayer` values as `AppBuilder::layer` (any
+  `tower::Layer` whose service is `Infallible` — `from_fn` middleware and
+  off-the-shelf tower-http layers alike) and routes them through the *same*
+  router-assembly path, so the layer lands in the identical position — inside
+  `RequestId` and the session layer, outside CSRF/CORS — and middleware that
+  reads the request ID or session finds them under test exactly as in
+  production. Multiple calls compose with `AppBuilder`'s ordering contract:
+  the first registration is the outermost layer on ingress. Layers apply on
+  both the default-state path and the `.state(...)` override path. See
+  `docs/guide/system-tests.md`.
+
 - **model:** declarative votable/reaction association via `#[votable(by =
   ..., aggregate = sum|count)]` (#1362). Votes, likes and favourites are the
   same shape every time — a `(reactor, target)`-unique edge table, a
@@ -1346,6 +1363,58 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   schedule / zero rate installs nothing, so a default `Chaos` is unchanged. This
   is W5.a; it stacks on W5.0 and is a sibling of W5.b (item 6). [no-plugin]
 ### Fixed
+
+- **system-tests:** `SystemTest` and `autumn doctor` no longer report
+  "no browser" on a Windows host that has Chrome installed (#1456), for three
+  separate reasons that all had to go. (1) The candidate list contained no
+  Windows locations at all — only Unix paths, plus a `PATH` scan that looked
+  for a bare `chrome` (`Path::is_file` does not apply `PATHEXT`, so it could
+  never match `chrome.exe`) — so unless `AUTUMN_CHROMIUM` or
+  `PLAYWRIGHT_BROWSERS_PATH` was set, nothing was ever probed. Chrome's real
+  install locations under `%ProgramFiles%`, `%ProgramFiles(x86)%` and
+  `%LOCALAPPDATA%` are now searched, and the `PATH` scan asks for `.exe`.
+  (2) The `--version` probe is no longer executed on Windows: `chrome.exe` is
+  a GUI-subsystem binary that writes nothing to the parent console, and
+  `--version` is not an early-exit switch there, so running it proceeds into
+  real browser startup — which is how the report saw exit code 21 (the
+  already-running instance being notified) instead of a version string.
+  Handing it a private profile would only have replaced that abort with a
+  visible browser window and a `Command::output()` call blocking until every
+  child closed its stdout. An existing `.exe` is now accepted on file
+  evidence — the issue's own suggested fix — and reported as `version
+  unavailable`. The extension check is what keeps a mistyped
+  `AUTUMN_CHROMIUM` from shadowing a browser that would have worked. (3) On
+  Linux/macOS the probe now runs against its own throwaway `--user-data-dir`,
+  so it can never rendezvous with a Chrome holding the real profile, and a
+  binary that exits 0 without printing (a launcher shim) is still accepted,
+  while a spawn failure or non-zero exit still rejects the candidate. The
+  platform-dependent decisions live in pure functions taking the platform as
+  an argument, so both branches are unit-tested on every host rather than
+  being dead code behind `#[cfg(windows)]` on the Linux CI runner.
+- **system-tests:** `autumn doctor`'s browser check and the `SystemTest`
+  harness now share one implementation (`autumn_web::browser_detect`, not
+  behind the `system-tests` feature) instead of keeping separate copies of the
+  candidate list and version probe (#1456). The duplicates had already
+  drifted, so the CLI could report no browser on a host where the harness
+  found one.
+- **system-tests:** assertion polling survives more of the CDP errors a page
+  transition produces (#1456). `expect_text` / `expect_url` /
+  `expect_attribute` / the implicit htmx-settle wait already retried "cannot
+  find context with specified id" when a redirect destroyed the JS execution
+  context mid-poll; they now also retry `"Inspected target navigated or
+  closed"` — the same navigation race, under a name that never contained the
+  word "context" — recognise these in chromiumoxide's untyped `ChromeMessage`
+  variant as well as the typed one, and match case-insensitively. The match
+  is an explicit phrase list, not a bare `contains("context")` and not "any
+  Chrome error is transient": a real failure such as `"No node with given id
+  found"` (or a JS `"ReferenceError: context is not defined"`) still aborts
+  immediately instead of decaying into a five-second timeout with a worse
+  message, and `"Target closed"` / `"Session with given id not found"` are
+  deliberately excluded because Chrome emits them for a dead renderer too —
+  swallowing those would let a crashed page pass the settle fence. The retry
+  loop itself is now one shared function with unit tests covering retry,
+  fail-fast, and deadline behaviour, so the fix is no longer provable only by
+  a browser test.
 
 - **sim-testing:** the op-driver's embedded proptest runners
   (`Sim::gen_ops_with`, `Sim::run_proptest`, #1797) no longer inherit ambient

--- a/autumn-cli/src/doctor.rs
+++ b/autumn-cli/src/doctor.rs
@@ -7450,64 +7450,23 @@ pub fn check_maintenance_mode() -> CheckResult {
 // ── System-test browser check ─────────────────────────────────────────────
 
 /// Candidate paths probed for a Chromium binary, in resolution order.
+///
+/// Delegates to `autumn_web::browser_detect` so `autumn doctor` and the
+/// `SystemTest` harness can never disagree about whether this host can run
+/// system tests — they used to keep separate copies of this list and did
+/// (#1456).
 pub fn browser_candidate_paths() -> Vec<std::path::PathBuf> {
-    let mut candidates: Vec<std::path::PathBuf> = Vec::new();
-
-    if let Ok(p) = std::env::var("AUTUMN_CHROMIUM") {
-        candidates.push(std::path::PathBuf::from(p));
-    }
-
-    if let Ok(base) = std::env::var("PLAYWRIGHT_BROWSERS_PATH") {
-        let base = std::path::PathBuf::from(base);
-        if let Ok(entries) = std::fs::read_dir(&base) {
-            let mut pw_paths: Vec<_> = entries
-                .flatten()
-                .filter(|e| e.file_name().to_string_lossy().starts_with("chromium-"))
-                .map(|e| {
-                    if cfg!(target_os = "macos") {
-                        e.path()
-                            .join("chrome-mac")
-                            .join("Chromium.app")
-                            .join("Contents")
-                            .join("MacOS")
-                            .join("Chromium")
-                    } else if cfg!(target_os = "windows") {
-                        e.path().join("chrome-win").join("chrome.exe")
-                    } else {
-                        e.path().join("chrome-linux").join("chrome")
-                    }
-                })
-                .collect();
-            pw_paths.sort();
-            pw_paths.reverse();
-            candidates.extend(pw_paths);
-        }
-    }
-
-    candidates.extend(
-        [
-            "/usr/bin/chromium-browser",
-            "/usr/bin/chromium",
-            "/usr/bin/google-chrome",
-            "/usr/bin/google-chrome-stable",
-            "/snap/bin/chromium",
-            "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
-            "/Applications/Chromium.app/Contents/MacOS/Chromium",
-        ]
-        .map(std::path::PathBuf::from),
-    );
-
-    candidates
+    autumn_web::browser_detect::browser_candidates()
 }
 
-/// Run `<path> --version` and return the trimmed output on success.
+/// Probe `path` for a browser version, using the same rules as the harness.
+///
+/// Returns `None` when the candidate is not usable, and
+/// `autumn_web::browser_detect::UNKNOWN_VERSION` when it is usable but cannot
+/// report a version (Windows `chrome.exe` is a GUI-subsystem binary that
+/// prints nothing to the parent console).
 fn probe_browser_version(path: &std::path::Path) -> Option<String> {
-    std::process::Command::new(path)
-        .arg("--version")
-        .output()
-        .ok()
-        .filter(|o| o.status.success())
-        .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_owned())
+    autumn_web::browser_detect::probe_version(path)
 }
 
 /// Check whether a Chromium binary is available for system tests.
@@ -7556,9 +7515,11 @@ fn cargo_toml_features_has_key(cargo_toml: &str, key: &str) -> bool {
 pub fn check_system_test_browser() -> CheckResult {
     let candidates = browser_candidate_paths();
     for path in &candidates {
-        if path.is_file()
-            && let Some(version) = probe_browser_version(path)
-        {
+        // No `is_file()` pre-check: `probe_browser_version` owns that
+        // decision, and on Windows "the file exists" *is* the answer — a
+        // GUI-subsystem `chrome.exe` can never report a version, so gating on
+        // one here is what produced the false "no browser installed" (#1456).
+        if let Some(version) = probe_browser_version(path) {
             return CheckResult {
                 name: "system_test_browser",
                 status: CheckStatus::Pass,

--- a/autumn/src/browser_detect.rs
+++ b/autumn/src/browser_detect.rs
@@ -1,0 +1,579 @@
+//! Locating a usable Chromium/Chrome binary on the host.
+//!
+//! Shared by the [`system_test`](crate::system_test) harness (which launches
+//! the browser it finds) and `autumn doctor` (which only reports on it).
+//! Both used to carry their own copy of this logic and drifted — a fix in one
+//! left the other reporting the opposite answer on the same machine — so the
+//! resolution order, the version probe, and its platform quirks live here
+//! once.
+//!
+//! Deliberately **not** behind the `system-tests` feature: `autumn doctor`
+//! must be able to tell you whether system tests would work without pulling
+//! `chromiumoxide` (and a headless browser stack) into the CLI.
+//!
+//! # Resolution order
+//!
+//! 1. `AUTUMN_CHROMIUM` environment variable (full binary path)
+//! 2. `PLAYWRIGHT_BROWSERS_PATH` — scans `<path>/chromium-*/…`
+//! 3. `PATH`-based lookup (`chrome`, `google-chrome`, `chromium`, …)
+//! 4. Well-known per-platform install locations
+
+use std::fmt;
+use std::path::{Path, PathBuf};
+
+/// Version string reported for a browser binary that exists and is usable but
+/// cannot tell us its version — see [`probe_version`].
+pub const UNKNOWN_VERSION: &str = "version unavailable";
+
+// ── BrowserCheck ───────────────────────────────────────────────────────────
+
+/// Result of probing the host for a usable Chromium binary.
+///
+/// Returned by [`BrowserCheck::run`] and shown by `autumn doctor`.
+#[derive(Debug, Clone)]
+pub enum BrowserCheck {
+    /// A usable binary was found at `path` with the reported `version` string.
+    Found {
+        /// Absolute path to the Chromium binary.
+        path: PathBuf,
+        /// Version string reported by `--version` (e.g. `"Chromium 122.0.6261.111"`),
+        /// or [`UNKNOWN_VERSION`] when the platform cannot report one.
+        version: String,
+    },
+    /// No usable binary could be found; `searched_paths` lists every path that
+    /// was probed so the user knows what to add.
+    NotFound {
+        /// Every path that was checked and did not yield a working binary.
+        searched_paths: Vec<PathBuf>,
+    },
+}
+
+impl BrowserCheck {
+    /// Probe the host for a Chromium binary using the documented resolution
+    /// order and return the result.
+    #[must_use]
+    pub fn run() -> Self {
+        let candidates = browser_candidates();
+        let mut searched = Vec::new();
+        for path in &candidates {
+            if let Some(version) = probe_version(path) {
+                return Self::Found {
+                    path: path.clone(),
+                    version,
+                };
+            }
+            searched.push(path.clone());
+        }
+        Self::NotFound {
+            searched_paths: searched,
+        }
+    }
+
+    /// `true` when a browser was found.
+    #[must_use]
+    pub const fn is_found(&self) -> bool {
+        matches!(self, Self::Found { .. })
+    }
+}
+
+impl fmt::Display for BrowserCheck {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Found { path, version } => {
+                write!(f, "Chromium found: {} ({})", path.display(), version)
+            }
+            Self::NotFound { searched_paths } => {
+                write!(
+                    f,
+                    "Chromium not found. Searched:\n{}",
+                    searched_paths
+                        .iter()
+                        .map(|p| format!("  {}", p.display()))
+                        .collect::<Vec<_>>()
+                        .join("\n")
+                )?;
+                write!(
+                    f,
+                    "\n\nTo install on Ubuntu/Debian: apt-get install chromium-browser\n\
+                     Or set the AUTUMN_CHROMIUM environment variable to the full binary path."
+                )
+            }
+        }
+    }
+}
+
+// ── Candidate discovery ────────────────────────────────────────────────────
+
+/// Binary names to look for on `PATH`, in preference order.
+const PATH_BINARY_NAMES: &[&str] = &[
+    "chrome",
+    "google-chrome",
+    "google-chrome-stable",
+    "chromium",
+    "chromium-browser",
+];
+
+/// All paths to probe for a Chromium binary, in resolution order.
+#[must_use]
+pub fn browser_candidates() -> Vec<PathBuf> {
+    let mut candidates: Vec<PathBuf> = Vec::new();
+
+    // 1. Explicit override.
+    if let Ok(p) = std::env::var("AUTUMN_CHROMIUM") {
+        candidates.push(PathBuf::from(p));
+    }
+
+    // 2. Playwright browsers directory.
+    if let Ok(base) = std::env::var("PLAYWRIGHT_BROWSERS_PATH") {
+        let base = PathBuf::from(base);
+        if let Ok(entries) = std::fs::read_dir(&base) {
+            let mut pw_paths: Vec<PathBuf> = entries
+                .flatten()
+                .filter(|e| e.file_name().to_string_lossy().starts_with("chromium-"))
+                .map(|e| {
+                    if cfg!(target_os = "macos") {
+                        e.path()
+                            .join("chrome-mac")
+                            .join("Chromium.app")
+                            .join("Contents")
+                            .join("MacOS")
+                            .join("Chromium")
+                    } else if cfg!(target_os = "windows") {
+                        e.path().join("chrome-win").join("chrome.exe")
+                    } else {
+                        e.path().join("chrome-linux").join("chrome")
+                    }
+                })
+                .collect();
+            pw_paths.sort();
+            pw_paths.reverse(); // highest revision first
+            candidates.extend(pw_paths);
+        }
+    }
+
+    // 3. PATH-based lookup — covers CI setups like browser-actions/setup-chrome
+    //    that install a `chrome` or `google-chrome` binary on PATH rather than
+    //    at a well-known fixed location.
+    for name in PATH_BINARY_NAMES {
+        // `Path::is_file` stats the literal path and does *not* apply
+        // Windows' PATHEXT resolution, so a bare `chrome` never matches
+        // `chrome.exe`. Ask for the name Windows actually stores on disk.
+        let file_name = if cfg!(target_os = "windows") {
+            format!("{name}.exe")
+        } else {
+            (*name).to_owned()
+        };
+        if let Some(p) = std::env::var_os("PATH").and_then(|path_var| {
+            std::env::split_paths(&path_var)
+                .map(|dir| dir.join(&file_name))
+                .find(|p| p.is_file())
+        }) {
+            candidates.push(p);
+        }
+    }
+
+    // 4. Well-known system paths.
+    candidates.extend(well_known_paths());
+
+    candidates
+}
+
+/// Per-platform install locations, checked after `PATH`.
+fn well_known_paths() -> Vec<PathBuf> {
+    if cfg!(target_os = "windows") {
+        // Chrome installs under `%ProgramFiles%` / `%ProgramFiles(x86)%` for a
+        // machine-wide install and `%LOCALAPPDATA%` for the (very common)
+        // per-user one. Read the variables rather than hard-coding `C:\` —
+        // the system drive is not always `C:`, and the 32-bit variable name
+        // contains parentheses, so it must be fetched by name.
+        ["ProgramFiles", "ProgramFiles(x86)", "LOCALAPPDATA"]
+            .iter()
+            .filter_map(std::env::var_os)
+            .flat_map(|base| {
+                let base = PathBuf::from(base);
+                ["Google\\Chrome", "Google\\Chrome Beta", "Chromium"]
+                    .iter()
+                    .map(move |vendor| base.join(vendor).join("Application").join("chrome.exe"))
+            })
+            .collect()
+    } else {
+        [
+            "/usr/bin/chromium-browser",
+            "/usr/bin/chromium",
+            "/usr/bin/google-chrome",
+            "/usr/bin/google-chrome-stable",
+            "/snap/bin/chromium",
+            "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+            "/Applications/Chromium.app/Contents/MacOS/Chromium",
+        ]
+        .iter()
+        .map(PathBuf::from)
+        .collect()
+    }
+}
+
+/// Return the first candidate that exists and probes successfully.
+#[must_use]
+pub fn find_chromium() -> Option<PathBuf> {
+    browser_candidates()
+        .into_iter()
+        .find(|path| probe_version(path).is_some())
+}
+
+// ── Version probe ──────────────────────────────────────────────────────────
+
+/// Outcome of asking a candidate binary for its version.
+#[derive(Debug, PartialEq, Eq)]
+enum VersionProbe {
+    /// The process ran and exited successfully; payload is its raw stdout
+    /// (which may legitimately be empty for a launcher shim that prints
+    /// elsewhere).
+    Ran(String),
+    /// The process could not be spawned, or exited non-zero. The candidate is
+    /// not usable.
+    Failed,
+    /// The probe was deliberately not executed, but the file is a plausible
+    /// browser binary. See [`run_version_probe`] for why Windows takes this
+    /// path.
+    Skipped,
+}
+
+/// Arguments for the `--version` probe.
+///
+/// The private `--user-data-dir` keeps the probe from touching the user's real
+/// profile: launching Chrome against a profile another instance already holds
+/// makes the new process rendezvous with the running one instead of answering
+/// us (#1456). `--version` exits before profile setup on POSIX, so this is
+/// belt-and-braces there rather than load-bearing — but it costs nothing and
+/// covers wrapper scripts that do reach profile startup.
+fn version_probe_args(user_data_dir: &Path) -> Vec<String> {
+    vec![
+        "--version".to_owned(),
+        format!("--user-data-dir={}", user_data_dir.display()),
+    ]
+}
+
+/// A throwaway profile directory for a single probe.
+fn unique_probe_dir() -> PathBuf {
+    static COUNTER: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    let n = COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    std::env::temp_dir().join(format!("autumn-browser-probe-{}-{n}", std::process::id()))
+}
+
+/// `true` when `path` carries a Windows executable extension.
+///
+/// The Windows path accepts a candidate on file evidence alone, so this is the
+/// only filter standing between a mistyped `AUTUMN_CHROMIUM` (a README, a
+/// `.lnk` shortcut) and it shadowing a browser that would actually have
+/// worked.
+fn has_windows_executable_extension(path: &Path) -> bool {
+    path.extension()
+        .is_some_and(|ext| ext.eq_ignore_ascii_case("exe"))
+}
+
+/// Ask `path` for its version, or decide not to ask.
+///
+/// **Windows never executes the candidate.** `chrome.exe` is a GUI-subsystem
+/// binary: it writes nothing to the parent console, and `--version` is not an
+/// early-exit switch there, so running it proceeds into real browser startup —
+/// which is how the original report saw exit code 21 (the running instance
+/// being notified) rather than a version string. Handing it a private profile
+/// would remove that abort only to replace it with something worse: a real
+/// browser window, and a [`std::process::Command::output`] call that blocks
+/// until every child process closes its stdout handle. File existence is the
+/// strongest signal available on Windows, and it is the one the issue's own
+/// suggested fix names.
+fn run_version_probe(path: &Path) -> VersionProbe {
+    if !path.is_file() {
+        return VersionProbe::Failed;
+    }
+
+    if cfg!(target_os = "windows") {
+        return if has_windows_executable_extension(path) {
+            VersionProbe::Skipped
+        } else {
+            VersionProbe::Failed
+        };
+    }
+
+    let probe_profile = unique_probe_dir();
+    let output = std::process::Command::new(path)
+        .args(version_probe_args(&probe_profile))
+        .output();
+    // `--version` should not create the directory, but Chrome variants differ;
+    // clean up unconditionally and ignore failure.
+    let _ = std::fs::remove_dir_all(&probe_profile);
+
+    match output {
+        Ok(o) if o.status.success() => {
+            VersionProbe::Ran(String::from_utf8_lossy(&o.stdout).into_owned())
+        }
+        _ => VersionProbe::Failed,
+    }
+}
+
+/// Turn a probe outcome into the reported version.
+///
+/// Split from [`run_version_probe`] so the platform-dependent decisions are
+/// unit-testable on every host — a `#[cfg(windows)]` branch would be dead,
+/// unexercised code on the Linux CI runner.
+fn version_from_probe(probe: &VersionProbe) -> Option<String> {
+    match probe {
+        VersionProbe::Ran(stdout) => {
+            let trimmed = stdout.trim();
+            // Exiting 0 is the usability signal; the text is a bonus. A
+            // launcher shim that prints its version to stderr (or nothing at
+            // all) is still a browser we can drive.
+            Some(if trimmed.is_empty() {
+                UNKNOWN_VERSION.to_owned()
+            } else {
+                trimmed.to_owned()
+            })
+        }
+        VersionProbe::Skipped => Some(UNKNOWN_VERSION.to_owned()),
+        VersionProbe::Failed => None,
+    }
+}
+
+/// Probe `path` for a browser version.
+///
+/// Returns `None` when the candidate is not a usable browser binary, and
+/// [`UNKNOWN_VERSION`] when it is usable but cannot report a version (see
+/// [`run_version_probe`]).
+#[must_use]
+pub fn probe_version(path: &Path) -> Option<String> {
+    version_from_probe(&run_version_probe(path))
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn browser_check_not_found_message_has_hints() {
+        let check = BrowserCheck::NotFound {
+            searched_paths: vec![PathBuf::from("/no/such/path")],
+        };
+        let msg = check.to_string();
+        assert!(msg.contains("apt-get") || msg.contains("AUTUMN_CHROMIUM"));
+    }
+
+    #[test]
+    fn browser_candidates_includes_common_paths() {
+        let candidates = browser_candidates();
+        let as_strings: Vec<_> = candidates
+            .iter()
+            .map(|p| p.to_string_lossy().into_owned())
+            .collect();
+        assert!(
+            as_strings
+                .iter()
+                .any(|s| s.contains("chromium") || s.contains("chrome")),
+            "should have at least one chrome path; got {as_strings:?}"
+        );
+    }
+
+    #[test]
+    fn well_known_paths_target_the_host_platform() {
+        // #1456: the well-known list was Linux + macOS only, so a Windows host
+        // with a stock Chrome install reached no candidate at all and the
+        // version-probe fix downstream of it could never help.
+        let paths: Vec<String> = well_known_paths()
+            .iter()
+            .map(|p| p.to_string_lossy().into_owned())
+            .collect();
+        assert!(!paths.is_empty(), "every platform needs candidates");
+        if cfg!(target_os = "windows") {
+            assert!(
+                paths.iter().all(|p| p.ends_with("chrome.exe")),
+                "Windows candidates must name the real on-disk binary; got {paths:?}"
+            );
+            assert!(
+                paths.iter().any(|p| p.contains("Application")),
+                "Windows Chrome lives in <base>\\...\\Application\\chrome.exe; got {paths:?}"
+            );
+        } else {
+            assert!(
+                paths.iter().any(|p| p.starts_with('/')),
+                "POSIX candidates must be absolute; got {paths:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn version_probe_isolates_the_profile_directory() {
+        let dir = PathBuf::from("/tmp/probe-profile");
+        let args = version_probe_args(&dir);
+
+        assert!(
+            args.iter().any(|a| a == "--version"),
+            "the probe must still ask for the version; got {args:?}"
+        );
+        let user_data_dir: Vec<_> = args
+            .iter()
+            .filter(|a| a.starts_with("--user-data-dir="))
+            .collect();
+        assert_eq!(
+            user_data_dir.len(),
+            1,
+            "the probe must pass exactly one --user-data-dir so it never \
+             rendezvouses with a Chrome already holding the real profile; \
+             got {args:?}"
+        );
+        assert!(
+            user_data_dir[0].contains("probe-profile"),
+            "--user-data-dir must point at the supplied private directory; got {args:?}"
+        );
+    }
+
+    #[test]
+    fn probe_dirs_are_never_reused() {
+        assert_ne!(
+            unique_probe_dir(),
+            unique_probe_dir(),
+            "two probes must not share a directory, or one's cleanup deletes \
+             the other's profile mid-probe"
+        );
+    }
+
+    #[test]
+    fn version_from_probe_prefers_reported_version() {
+        assert_eq!(
+            version_from_probe(&VersionProbe::Ran("Chromium 122.0.6261.111\n".to_owned())),
+            Some("Chromium 122.0.6261.111".to_owned()),
+            "reported version must be used verbatim (trimmed)"
+        );
+    }
+
+    #[test]
+    fn version_from_probe_accepts_a_binary_that_exits_zero_without_output() {
+        // A launcher shim may print its version to stderr or not at all.
+        // Exiting 0 is the usability signal, and rejecting these would have
+        // regressed hosts that worked before #1456.
+        for stdout in ["", "   \r\n"] {
+            assert_eq!(
+                version_from_probe(&VersionProbe::Ran(stdout.to_owned())),
+                Some(UNKNOWN_VERSION.to_owned()),
+                "stdout {stdout:?} exited 0, so the binary is usable"
+            );
+        }
+    }
+
+    #[test]
+    fn version_from_probe_skipped_resolves_without_running_anything() {
+        // The Windows path: chrome.exe exists but must not be executed.
+        assert_eq!(
+            version_from_probe(&VersionProbe::Skipped),
+            Some(UNKNOWN_VERSION.to_owned()),
+            "an existing Windows chrome.exe must resolve as found, not as \
+             BrowserNotFound"
+        );
+    }
+
+    #[test]
+    fn version_from_probe_rejects_a_failed_probe() {
+        // Spawn failure or a non-zero exit means the candidate is unusable.
+        // It must keep failing so the search falls through to the next
+        // candidate and, if none work, the caller still gets the
+        // searched-paths error with its remediation hint.
+        assert_eq!(
+            version_from_probe(&VersionProbe::Failed),
+            None,
+            "a broken binary must not be papered over"
+        );
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    #[test]
+    fn the_probe_actually_passes_its_arguments_to_the_process() {
+        // The pure functions above cover the decisions; this covers the
+        // wiring. `echo` prints back whatever argv it received, so a
+        // successful probe whose "version" is our own flags proves both
+        // `--version` and the isolating `--user-data-dir` reached the child.
+        let echo = ["/bin/echo", "/usr/bin/echo"]
+            .into_iter()
+            .map(Path::new)
+            .find(|p| p.is_file());
+        let Some(echo) = echo else {
+            return; // no `echo` on this host; nothing to assert against
+        };
+
+        let reported = probe_version(echo).expect("echo exits 0, so it is 'usable'");
+        assert!(
+            reported.contains("--version"),
+            "the probe must ask for the version; echo saw {reported:?}"
+        );
+        assert!(
+            reported.contains("--user-data-dir="),
+            "the probe must isolate the profile so a running Chrome cannot \
+             abort it; echo saw {reported:?}"
+        );
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    #[test]
+    fn a_non_zero_exit_is_not_a_browser() {
+        // `false` exists on every POSIX host and exits 1.
+        let Some(falsy) = ["/bin/false", "/usr/bin/false"]
+            .into_iter()
+            .map(Path::new)
+            .find(|p| p.is_file())
+        else {
+            return;
+        };
+        assert_eq!(
+            probe_version(falsy),
+            None,
+            "a binary that exits non-zero must not be accepted as a browser"
+        );
+    }
+
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn windows_accepts_an_existing_exe_without_running_it() {
+        // The running test binary is a real, existing `.exe` that is
+        // emphatically not Chrome — and must still resolve, because on
+        // Windows file existence is the only signal available and executing
+        // the candidate is exactly what #1456 says not to do.
+        let me = std::env::current_exe().expect("test binary path");
+        assert_eq!(probe_version(&me), Some(UNKNOWN_VERSION.to_owned()));
+
+        assert_eq!(
+            probe_version(Path::new(r"C:\definitely\not\here\chrome.exe")),
+            None,
+            "a path that does not exist is still not a browser"
+        );
+    }
+
+    #[test]
+    fn missing_files_never_probe() {
+        assert_eq!(
+            run_version_probe(Path::new("/definitely/not/a/browser/chrome")),
+            VersionProbe::Failed
+        );
+        assert_eq!(
+            probe_version(Path::new("/definitely/not/a/browser/chrome")),
+            None
+        );
+    }
+
+    #[test]
+    fn windows_candidates_must_look_like_executables() {
+        assert!(has_windows_executable_extension(Path::new(
+            r"C:\Program Files\Google\Chrome\Application\chrome.exe"
+        )));
+        assert!(
+            has_windows_executable_extension(Path::new("chrome.EXE")),
+            "the extension check must be case-insensitive"
+        );
+        for not_a_binary in ["chrome.lnk", "README.md", "chrome"] {
+            assert!(
+                !has_windows_executable_extension(Path::new(not_a_binary)),
+                "{not_a_binary:?} must not be accepted as a browser binary, or a \
+                 mistyped AUTUMN_CHROMIUM would shadow one that works"
+            );
+        }
+    }
+}

--- a/autumn/src/browser_detect.rs
+++ b/autumn/src/browser_detect.rs
@@ -1,7 +1,8 @@
 //! Locating a usable Chromium/Chrome binary on the host.
 //!
-//! Shared by the [`system_test`](crate::system_test) harness (which launches
-//! the browser it finds) and `autumn doctor` (which only reports on it).
+//! Shared by the `system_test` harness (which launches the browser it finds;
+//! feature `system-tests`, so this always-compiled module cannot link to it)
+//! and `autumn doctor` (which only reports on it).
 //! Both used to carry their own copy of this logic and drifted — a fix in one
 //! left the other reporting the opposite answer on the same machine — so the
 //! resolution order, the version probe, and its platform quirks live here
@@ -338,8 +339,18 @@ fn version_from_probe(probe: &VersionProbe) -> Option<String> {
 /// Probe `path` for a browser version.
 ///
 /// Returns `None` when the candidate is not a usable browser binary, and
-/// [`UNKNOWN_VERSION`] when it is usable but cannot report a version (see
-/// [`run_version_probe`]).
+/// [`UNKNOWN_VERSION`] when it is usable but cannot report a version.
+///
+/// On Linux and macOS "usable" means `<path> --version` ran and exited 0
+/// (against a throwaway `--user-data-dir`, so it can never rendezvous with a
+/// Chrome holding the real profile); empty output is still accepted, since a
+/// launcher shim may print elsewhere.
+///
+/// On **Windows** the candidate is never executed: `chrome.exe` is a
+/// GUI-subsystem binary that writes nothing to the parent console, and
+/// `--version` is not an early-exit switch there, so running it starts a real
+/// browser instead of answering (#1456). An existing file with an `.exe`
+/// extension is accepted on that evidence alone.
 #[must_use]
 pub fn probe_version(path: &Path) -> Option<String> {
     version_from_probe(&run_version_probe(path))

--- a/autumn/src/browser_detect.rs
+++ b/autumn/src/browser_detect.rs
@@ -155,6 +155,36 @@ pub fn browser_candidates() -> Vec<PathBuf> {
     // 3. PATH-based lookup — covers CI setups like browser-actions/setup-chrome
     //    that install a `chrome` or `google-chrome` binary on PATH rather than
     //    at a well-known fixed location.
+    candidates.extend(path_candidates(std::env::var_os("PATH").as_deref()));
+
+    // 4. Well-known system paths.
+    candidates.extend(well_known_paths());
+
+    // A duplicate can only waste a probe and clutter the searched-paths list
+    // in the not-found error (duplicate PATH entries are common).
+    let mut seen = std::collections::HashSet::new();
+    candidates.retain(|p| seen.insert(p.clone()));
+
+    candidates
+}
+
+/// Every `PATH` directory holding one of [`PATH_BINARY_NAMES`], in `PATH`
+/// order, for each name in preference order.
+///
+/// Returns **all** matches rather than the first per name. Existence is not
+/// usability — [`probe_version`] is what decides — so a stale or
+/// non-executable `chrome` early in `PATH` must not mask a working one a CI
+/// setup action installed later. The extra entries cost one stat each.
+///
+/// Takes `PATH` as an argument rather than reading the environment so it is
+/// testable without mutating process-wide state (which this crate forbids:
+/// `unsafe_code = "forbid"`).
+fn path_candidates(path_var: Option<&std::ffi::OsStr>) -> Vec<PathBuf> {
+    let Some(path_var) = path_var else {
+        return Vec::new();
+    };
+
+    let mut found = Vec::new();
     for name in PATH_BINARY_NAMES {
         // `Path::is_file` stats the literal path and does *not* apply
         // Windows' PATHEXT resolution, so a bare `chrome` never matches
@@ -164,19 +194,13 @@ pub fn browser_candidates() -> Vec<PathBuf> {
         } else {
             (*name).to_owned()
         };
-        if let Some(p) = std::env::var_os("PATH").and_then(|path_var| {
-            std::env::split_paths(&path_var)
+        found.extend(
+            std::env::split_paths(path_var)
                 .map(|dir| dir.join(&file_name))
-                .find(|p| p.is_file())
-        }) {
-            candidates.push(p);
-        }
+                .filter(|p| p.is_file()),
+        );
     }
-
-    // 4. Well-known system paths.
-    candidates.extend(well_known_paths());
-
-    candidates
+    found
 }
 
 /// Per-platform install locations, checked after `PATH`.
@@ -261,15 +285,34 @@ fn unique_probe_dir() -> PathBuf {
     std::env::temp_dir().join(format!("autumn-browser-probe-{}-{n}", std::process::id()))
 }
 
-/// `true` when `path` carries a Windows executable extension.
+/// `true` when `path` names something that plausibly *is* a Chrome/Chromium
+/// binary, judged from the filename alone.
 ///
-/// The Windows path accepts a candidate on file evidence alone, so this is the
-/// only filter standing between a mistyped `AUTUMN_CHROMIUM` (a README, a
-/// `.lnk` shortcut) and it shadowing a browser that would actually have
-/// worked.
-fn has_windows_executable_extension(path: &Path) -> bool {
-    path.extension()
-        .is_some_and(|ext| ext.eq_ignore_ascii_case("exe"))
+/// The Windows branch accepts a candidate without running it, so this is the
+/// only filter standing between a stale or mistyped `AUTUMN_CHROMIUM` and it
+/// **ending discovery**: it is the first candidate, so accepting it stops
+/// `find_chromium` from ever reaching a real Chrome further down the list, and
+/// turns a clear `BrowserNotFound` (which prints every searched path and the
+/// remediation hint) into an opaque failure later, inside `Browser::launch`.
+///
+/// Requiring `.exe` alone is not enough — every discovery source *except* the
+/// env override already constrains the filename (`chrome.exe` under the
+/// well-known install roots and the Playwright layout, the `PATH_BINARY_NAMES`
+/// on `PATH`), so the override is the one place an arbitrary path can enter.
+/// Matching on `chrom` keeps the real-world variants that people legitimately
+/// point at — `chrome.exe`, `chromium.exe`, `chrome-headless-shell.exe`,
+/// `google-chrome.exe` — while rejecting a wrong turn like `notepad.exe`.
+fn looks_like_a_browser_binary(path: &Path) -> bool {
+    let has_exe_extension = path
+        .extension()
+        .is_some_and(|ext| ext.eq_ignore_ascii_case("exe"));
+
+    let named_like_chrome = path
+        .file_stem()
+        .and_then(|stem| stem.to_str())
+        .is_some_and(|stem| stem.to_ascii_lowercase().contains("chrom"));
+
+    has_exe_extension && named_like_chrome
 }
 
 /// Ask `path` for its version, or decide not to ask.
@@ -290,7 +333,7 @@ fn run_version_probe(path: &Path) -> VersionProbe {
     }
 
     if cfg!(target_os = "windows") {
-        return if has_windows_executable_extension(path) {
+        return if looks_like_a_browser_binary(path) {
             VersionProbe::Skipped
         } else {
             VersionProbe::Failed
@@ -384,6 +427,59 @@ mod tests {
                 .any(|s| s.contains("chromium") || s.contains("chrome")),
             "should have at least one chrome path; got {as_strings:?}"
         );
+    }
+
+    #[test]
+    fn path_scan_keeps_every_match_not_just_the_first() {
+        // A stale, non-executable `chrome` early in PATH must not mask a
+        // working one installed later (e.g. by a CI setup action): existence
+        // is not usability, and `probe_version` — not this scan — is what
+        // decides. Both must survive into the candidate list, in PATH order.
+        let base = std::env::temp_dir().join(format!(
+            "autumn-path-scan-{}-{}",
+            std::process::id(),
+            line!()
+        ));
+        let stale = base.join("stale");
+        let good = base.join("good");
+        std::fs::create_dir_all(&stale).unwrap();
+        std::fs::create_dir_all(&good).unwrap();
+        let binary = if cfg!(target_os = "windows") {
+            "chrome.exe"
+        } else {
+            "chrome"
+        };
+        std::fs::write(stale.join(binary), b"stale").unwrap();
+        std::fs::write(good.join(binary), b"good").unwrap();
+
+        let joined = std::env::join_paths([&stale, &good]).unwrap();
+        let found = path_candidates(Some(joined.as_os_str()));
+
+        assert_eq!(
+            found,
+            vec![stale.join(binary), good.join(binary)],
+            "both PATH hits must be candidates, in PATH order"
+        );
+
+        let _ = std::fs::remove_dir_all(&base);
+    }
+
+    #[test]
+    fn path_scan_without_a_path_variable_is_empty() {
+        assert!(path_candidates(None).is_empty());
+    }
+
+    #[test]
+    fn candidates_are_deduplicated() {
+        let candidates = browser_candidates();
+        let mut seen = std::collections::HashSet::new();
+        for path in &candidates {
+            assert!(
+                seen.insert(path.clone()),
+                "duplicate candidate {path:?} wastes a probe and clutters the \
+                 searched-paths list in the not-found error"
+            );
+        }
     }
 
     #[test]
@@ -544,18 +640,34 @@ mod tests {
     #[cfg(target_os = "windows")]
     #[test]
     fn windows_accepts_an_existing_exe_without_running_it() {
-        // The running test binary is a real, existing `.exe` that is
-        // emphatically not Chrome — and must still resolve, because on
-        // Windows file existence is the only signal available and executing
-        // the candidate is exactly what #1456 says not to do.
-        let me = std::env::current_exe().expect("test binary path");
-        assert_eq!(probe_version(&me), Some(UNKNOWN_VERSION.to_owned()));
+        // A file that exists and is named like Chrome must resolve without
+        // being executed — running the candidate is exactly what #1456 says
+        // not to do on Windows. The file's *contents* are irrelevant here,
+        // which is the point: we never launch it.
+        let dir = std::env::temp_dir().join("autumn-browser-detect-test");
+        std::fs::create_dir_all(&dir).expect("create temp dir");
+        let fake_chrome = dir.join("chrome.exe");
+        std::fs::write(&fake_chrome, b"not really chrome").expect("write fake binary");
+
+        assert_eq!(
+            probe_version(&fake_chrome),
+            Some(UNKNOWN_VERSION.to_owned()),
+            "an existing chrome.exe must resolve as found, not BrowserNotFound"
+        );
+
+        // Same directory, same existence, wrong program: must NOT end
+        // discovery (see `looks_like_a_browser_binary`).
+        let not_chrome = dir.join("notepad.exe");
+        std::fs::write(&not_chrome, b"not a browser").expect("write decoy");
+        assert_eq!(probe_version(&not_chrome), None);
 
         assert_eq!(
             probe_version(Path::new(r"C:\definitely\not\here\chrome.exe")),
             None,
             "a path that does not exist is still not a browser"
         );
+
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[test]
@@ -571,19 +683,37 @@ mod tests {
     }
 
     #[test]
-    fn windows_candidates_must_look_like_executables() {
-        assert!(has_windows_executable_extension(Path::new(
-            r"C:\Program Files\Google\Chrome\Application\chrome.exe"
-        )));
-        assert!(
-            has_windows_executable_extension(Path::new("chrome.EXE")),
-            "the extension check must be case-insensitive"
-        );
-        for not_a_binary in ["chrome.lnk", "README.md", "chrome"] {
+    fn windows_candidates_must_look_like_a_browser() {
+        for real in [
+            r"C:\Program Files\Google\Chrome\Application\chrome.exe",
+            r"C:\Users\me\AppData\Local\Chromium\Application\chrome.exe",
+            "chrome.EXE",   // case-insensitive extension
+            "CHROMIUM.exe", // case-insensitive name
+            "chrome-headless-shell.exe",
+            "google-chrome.exe",
+        ] {
             assert!(
-                !has_windows_executable_extension(Path::new(not_a_binary)),
-                "{not_a_binary:?} must not be accepted as a browser binary, or a \
-                 mistyped AUTUMN_CHROMIUM would shadow one that works"
+                looks_like_a_browser_binary(Path::new(real)),
+                "{real:?} is a browser people legitimately point AUTUMN_CHROMIUM at"
+            );
+        }
+
+        for not_a_browser in [
+            // Right extension, wrong program. Accepting this would end
+            // discovery at a stale/mistyped override and hide an installed
+            // Chrome further down the candidate list.
+            "notepad.exe",
+            r"C:\Windows\System32\cmd.exe",
+            // Right name, not an executable.
+            "chrome.lnk",
+            "chrome",
+            "README.md",
+        ] {
+            assert!(
+                !looks_like_a_browser_binary(Path::new(not_a_browser)),
+                "{not_a_browser:?} must not end discovery — a wrong override has \
+                 to fall through to the real candidates, and failing that yield \
+                 BrowserNotFound with its searched-paths list"
             );
         }
     }

--- a/autumn/src/lib.rs
+++ b/autumn/src/lib.rs
@@ -90,8 +90,9 @@ pub mod authorization;
 pub mod batches;
 /// Locating a usable Chromium/Chrome binary on the host.
 ///
-/// Shared by the [`system_test`] harness and `autumn doctor`; deliberately not
-/// behind the `system-tests` feature so the CLI can report on browser
+/// Shared by the `system_test` harness (feature `system-tests`, hence no
+/// intra-doc link from this always-compiled item) and `autumn doctor`;
+/// deliberately not behind that feature so the CLI can report on browser
 /// availability without depending on a headless-browser stack.
 pub mod browser_detect;
 pub mod build_info;

--- a/autumn/src/lib.rs
+++ b/autumn/src/lib.rs
@@ -88,6 +88,12 @@ pub mod audit;
 pub mod auth;
 pub mod authorization;
 pub mod batches;
+/// Locating a usable Chromium/Chrome binary on the host.
+///
+/// Shared by the [`system_test`] harness and `autumn doctor`; deliberately not
+/// behind the `system-tests` feature so the CLI can report on browser
+/// availability without depending on a headless-browser stack.
+pub mod browser_detect;
 pub mod build_info;
 pub mod cache;
 #[cfg(feature = "ws")]

--- a/autumn/src/router.rs
+++ b/autumn/src/router.rs
@@ -292,6 +292,32 @@ pub fn try_build_router(
     config: &AutumnConfig,
     state: AppState,
 ) -> Result<axum::Router, RouterBuildError> {
+    try_build_router_with_layers(route_list, config, state, Vec::new())
+}
+
+/// [`try_build_router`] plus caller-supplied app-wide Tower layers.
+///
+/// The layers are handed to the same [`RouterContext::custom_layers`] slot
+/// that [`AppBuilder::layer`](crate::app::AppBuilder::layer) uses, so they
+/// land in the identical stack position (inside `RequestId` and the session
+/// layer, outside CSRF/CORS) and compose with the identical ordering
+/// contract — the first registration is the outermost layer on ingress.
+///
+/// Exists for `SystemTest::layer` (feature `system-tests`, hence no intra-doc
+/// link from this always-compiled module): a browser test that registers its
+/// app's middleware must observe exactly the stack the real app serves,
+/// otherwise the harness lies about what production does.
+///
+/// # Errors
+///
+/// Returns [`RouterBuildError`] when router assembly encounters invalid
+/// framework configuration, such as an unusable session backend.
+pub fn try_build_router_with_layers(
+    route_list: Vec<Route>,
+    config: &AutumnConfig,
+    state: AppState,
+    custom_layers: Vec<crate::app::CustomLayerRegistration>,
+) -> Result<axum::Router, RouterBuildError> {
     let startup_barrier_state = state.clone();
     let router = try_build_router_inner(
         route_list,
@@ -302,7 +328,7 @@ pub fn try_build_router(
             scoped_groups: Vec::new(),
             merge_routers: Vec::new(),
             nest_routers: Vec::new(),
-            custom_layers: Vec::new(),
+            custom_layers,
             static_gate_layers: Vec::new(),
             #[cfg(feature = "maud")]
             error_page_renderer: None,

--- a/autumn/src/system_test.rs
+++ b/autumn/src/system_test.rs
@@ -40,14 +40,50 @@
 //! }
 //! ```
 //!
+//! # Custom middleware
+//!
+//! Routes that depend on app-wide middleware (tenant scoping, an auth shim,
+//! request enrichment) can register it with [`SystemTest::layer`], which
+//! takes the same layers as
+//! [`AppBuilder::layer`](crate::app::AppBuilder::layer) and puts them in the
+//! same position in the stack:
+//!
+//! ```rust,no_run
+//! # use autumn_web::system_test::SystemTest;
+//! # use autumn_web::prelude::*;
+//! # #[get("/")] async fn index() -> &'static str { "" }
+//! # async fn scope_to_tenant(
+//! #     req: axum::extract::Request,
+//! #     next: axum::middleware::Next,
+//! # ) -> axum::response::Response { next.run(req).await }
+//! # async fn example() {
+//! let runner = SystemTest::new()
+//!     .routes(routes![index])
+//!     .layer(axum::middleware::from_fn(scope_to_tenant))
+//!     .build()
+//!     .await
+//!     .expect("start runner");
+//! # }
+//! ```
+//!
 //! # Browser resolution order
 //!
 //! 1. `AUTUMN_CHROMIUM` environment variable (full binary path)
 //! 2. `PLAYWRIGHT_BROWSERS_PATH` — scans `<path>/chromium-*/chrome-linux/chrome`
-//! 3. Common system paths: `/usr/bin/chromium-browser`, `/usr/bin/chromium`,
-//!    `/usr/bin/google-chrome`, `/usr/bin/google-chrome-stable`,
-//!    `/Applications/Google Chrome.app/Contents/MacOS/Google Chrome`,
-//!    `/Applications/Chromium.app/Contents/MacOS/Chromium`
+//! 3. `PATH`-based lookup (`chrome`, `google-chrome`, `chromium`, …)
+//! 4. Well-known per-platform install locations — `/usr/bin/chromium-browser`,
+//!    `/usr/bin/google-chrome`, … on Linux; `/Applications/Google
+//!    Chrome.app/…` on macOS; `%ProgramFiles%` / `%LOCALAPPDATA%`
+//!    `…\Application\chrome.exe` on Windows
+//!
+//! Resolution lives in [`crate::browser_detect`], shared with `autumn doctor`
+//! so the two can never disagree about whether this host can run system
+//! tests. On POSIX each candidate is confirmed with a `--version` probe run
+//! against its own throwaway `--user-data-dir`; on Windows the candidate is
+//! accepted on file evidence alone, because `chrome.exe` is a GUI-subsystem
+//! binary that cannot answer over the parent console and executing it would
+//! start a real browser (#1456). `autumn doctor` then reports `version
+//! unavailable` rather than claiming no browser is installed.
 //!
 //! When the browser cannot be found the error message prints all searched
 //! paths and the `apt-get install chromium-browser` remediation hint.
@@ -68,8 +104,7 @@
 
 #![cfg(feature = "system-tests")]
 
-use std::fmt;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
@@ -94,6 +129,10 @@ const DEFAULT_HX_SETTLE_TIMEOUT: Duration = Duration::from_secs(2);
 /// Default assertion polling interval.
 const POLL_INTERVAL: Duration = Duration::from_millis(100);
 
+/// How long auto-waiting assertions (`expect_text`, `expect_url`,
+/// `expect_attribute`) poll before giving up.
+const ASSERTION_TIMEOUT: Duration = Duration::from_secs(5);
+
 /// Grace period `expect_no_console_errors` polls for any in-flight CDP
 /// console/exception events to be delivered before declaring the page
 /// clean. Generous relative to typical sub-10ms local CDP round-trips so it
@@ -102,83 +141,14 @@ const POLL_INTERVAL: Duration = Duration::from_millis(100);
 /// rather than waiting out the rest of it.
 const CONSOLE_ERROR_GRACE: Duration = Duration::from_millis(500);
 
-// ── BrowserCheck ───────────────────────────────────────────────────────────
+// ── Browser detection ──────────────────────────────────────────────────────
 
-/// Result of probing the host for a usable Chromium binary.
-///
-/// Returned by [`BrowserCheck::run`] and shown by `autumn doctor`.
-#[derive(Debug, Clone)]
-pub enum BrowserCheck {
-    /// A usable binary was found at `path` with the reported `version` string.
-    Found {
-        /// Absolute path to the Chromium binary.
-        path: PathBuf,
-        /// Version string reported by `--version` (e.g. `"Chromium 122.0.6261.111"`).
-        version: String,
-    },
-    /// No usable binary could be found; `searched_paths` lists every path that
-    /// was probed so the user knows what to add.
-    NotFound {
-        /// Every path that was checked and did not yield a working binary.
-        searched_paths: Vec<PathBuf>,
-    },
-}
-
-impl BrowserCheck {
-    /// Probe the host for a Chromium binary using the documented resolution
-    /// order and return the result.
-    #[must_use]
-    pub fn run() -> Self {
-        let candidates = browser_candidates();
-        let mut searched = Vec::new();
-        for path in &candidates {
-            if path.is_file()
-                && let Some(version) = probe_version(path)
-            {
-                return Self::Found {
-                    path: path.clone(),
-                    version,
-                };
-            }
-            searched.push(path.clone());
-        }
-        Self::NotFound {
-            searched_paths: searched,
-        }
-    }
-
-    /// `true` when a browser was found.
-    #[must_use]
-    pub const fn is_found(&self) -> bool {
-        matches!(self, Self::Found { .. })
-    }
-}
-
-impl fmt::Display for BrowserCheck {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::Found { path, version } => {
-                write!(f, "Chromium found: {} ({})", path.display(), version)
-            }
-            Self::NotFound { searched_paths } => {
-                write!(
-                    f,
-                    "Chromium not found. Searched:\n{}",
-                    searched_paths
-                        .iter()
-                        .map(|p| format!("  {}", p.display()))
-                        .collect::<Vec<_>>()
-                        .join("\n")
-                )?;
-                write!(
-                    f,
-                    "\n\nTo install on Ubuntu/Debian: apt-get install chromium-browser\n\
-                     Or set the AUTUMN_CHROMIUM environment variable to the full binary path."
-                )
-            }
-        }
-    }
-}
+// Browser discovery and the `--version` probe live in `crate::browser_detect`
+// so `autumn doctor` (which must not depend on chromiumoxide) runs exactly
+// the same resolution logic. Re-exported here because
+// `autumn_web::system_test::BrowserCheck` is the documented path.
+pub use crate::browser_detect::BrowserCheck;
+use crate::browser_detect::{browser_candidates, find_chromium};
 
 // ── SystemTestError ────────────────────────────────────────────────────────
 
@@ -225,6 +195,34 @@ pub enum SystemTestError {
     Browser(#[from] chromiumoxide::error::CdpError),
 }
 
+/// Substrings Chrome uses to report "whatever you were evaluating against no
+/// longer exists because the page moved".
+///
+/// Deliberately an explicit list rather than a blanket "any `Chrome` error is
+/// transient": treating a genuine failure (`"No node with given id found"`)
+/// as transient would replace a fast, precise error with a silent five-second
+/// timeout and a worse message.
+/// Compared case-insensitively against the CDP error message.
+///
+/// Notably **absent**: `"Target closed"` and `"Session with given id not
+/// found"`. Chrome emits those for a renderer that died (a sad tab under CI
+/// memory pressure) just as readily as for a navigation, and
+/// [`Page::wait_for_hx_settle`] maps a transient error to *settled* — so
+/// swallowing them would turn a crashed page into a five-second
+/// `expect_text` timeout with no screenshot, which is exactly the failure
+/// mode this list exists to avoid.
+///
+/// [`Page::wait_for_hx_settle`]: Page::wait_for_hx_settle
+const TRANSIENT_NAVIGATION_MARKERS: &[&str] = &[
+    // The error reported in #1456.
+    "cannot find context with specified id",
+    // Same race, reported against the context rather than the lookup.
+    "execution context was destroyed",
+    // A navigation that swapped the inspected target out from under the
+    // in-flight command — no "context" in the text at all.
+    "inspected target navigated or closed",
+];
+
 /// True for CDP errors that just mean "the page navigated away mid-poll" —
 /// e.g. a plain (non-htmx) form submit's full-page redirect racing an
 /// in-flight `evaluate()` call, which briefly leaves no valid JS execution
@@ -232,10 +230,67 @@ pub enum SystemTestError {
 /// failure: assertion polling loops treat these as "not ready yet" and keep
 /// polling rather than aborting on the first unlucky tick.
 fn is_transient_navigation_error(err: &chromiumoxide::error::CdpError) -> bool {
-    matches!(
-        err,
-        chromiumoxide::error::CdpError::Chrome(inner) if inner.message.contains("context")
-    )
+    // `Chrome` carries a typed CDP error object; `ChromeMessage` is the same
+    // class of failure for responses that did not deserialise into one, so
+    // both must be inspected or the error leaks through under the other name.
+    let message = match err {
+        chromiumoxide::error::CdpError::Chrome(inner) => inner.message.as_str(),
+        chromiumoxide::error::CdpError::ChromeMessage(message) => message.as_str(),
+        _ => return false,
+    };
+    let message = message.to_ascii_lowercase();
+    TRANSIENT_NAVIGATION_MARKERS
+        .iter()
+        .any(|marker| message.contains(marker))
+}
+
+/// Poll `probe` every [`POLL_INTERVAL`] until it reports success or
+/// `deadline` passes.
+///
+/// This is the retry loop every auto-waiting assertion shares, and the reason
+/// it exists as a named function: a transient CDP error (see
+/// [`is_transient_navigation_error`]) must be indistinguishable from "not
+/// true yet" — the page merely navigated out from under an in-flight
+/// `evaluate()` — while a genuine CDP error must abort immediately rather
+/// than decay into a timeout with a worse message.
+///
+/// `transient_means` is what a transient error should be read as. Assertions
+/// pass `false` ("not true yet — keep polling on the page we land on");
+/// [`Page::wait_for_hx_settle`] passes `true`, because a page that navigated
+/// away has no htmx activity left to wait for.
+///
+/// Returns `Ok(true)` on success, `Ok(false)` if the deadline passed without
+/// one (the caller owns the failure message and artifacts), and `Err` for a
+/// non-transient CDP error.
+///
+/// [`Page::wait_for_hx_settle`]: Page::wait_for_hx_settle
+async fn poll_until_deadline<F, Fut>(
+    deadline: tokio::time::Instant,
+    transient_means: bool,
+    mut probe: F,
+) -> Result<bool, SystemTestError>
+where
+    F: FnMut() -> Fut,
+    Fut: Future<Output = Result<bool, chromiumoxide::error::CdpError>>,
+{
+    loop {
+        match probe().await {
+            Ok(true) => return Ok(true),
+            Ok(false) => {}
+            Err(e) if is_transient_navigation_error(&e) => {
+                if transient_means {
+                    return Ok(true);
+                }
+            }
+            Err(e) => return Err(e.into()),
+        }
+
+        if tokio::time::Instant::now() >= deadline {
+            return Ok(false);
+        }
+
+        tokio::time::sleep(POLL_INTERVAL).await;
+    }
 }
 
 // ── Artifact directory ─────────────────────────────────────────────────────
@@ -275,13 +330,18 @@ pub fn artifact_dir(test_name: &str) -> PathBuf {
 #[must_use]
 pub struct SystemTest {
     routes: Vec<Route>,
-    #[allow(dead_code)]
+    /// Config for the default-state path; ignored when the caller supplies
+    /// their own `AppState` via [`SystemTest::state`], whose embedded config
+    /// wins so handlers and middleware agree on one set of settings.
     config: AutumnConfig,
     artifact_dir_override: Option<PathBuf>,
     browser_timeout: Duration,
     hx_settle_timeout: Duration,
     /// Optional pre-configured state; overrides the default `AppState::for_test()`.
     state_override: Option<crate::state::AppState>,
+    /// App-wide Tower layers registered via [`SystemTest::layer`], applied in
+    /// the same router position as [`crate::app::AppBuilder::layer`].
+    custom_layers: Vec<crate::app::CustomLayerRegistration>,
 }
 
 impl Default for SystemTest {
@@ -308,6 +368,7 @@ impl SystemTest {
             browser_timeout: DEFAULT_BROWSER_TIMEOUT,
             hx_settle_timeout: DEFAULT_HX_SETTLE_TIMEOUT,
             state_override: None,
+            custom_layers: Vec::new(),
         }
     }
 
@@ -329,6 +390,66 @@ impl SystemTest {
     /// [`AppState`]: crate::state::AppState
     pub fn state(mut self, state: crate::state::AppState) -> Self {
         self.state_override = Some(state);
+        self
+    }
+
+    /// Register an app-wide [`tower::Layer`] on the router the system test
+    /// serves — the harness equivalent of
+    /// [`AppBuilder::layer`](crate::app::AppBuilder::layer).
+    ///
+    /// Without this, routes that depend on global middleware (tenant
+    /// scoping, an auth shim, request enrichment) cannot be exercised
+    /// end-to-end: the only workaround is hand-mapping each layer onto
+    /// individual handlers before passing them to [`routes`](Self::routes),
+    /// which tests a stack the real app never serves.
+    ///
+    /// The layer is applied in the **same router position** as
+    /// `AppBuilder::layer` — inside Autumn's request-ID and session layers,
+    /// outside CSRF/CORS — so middleware that reads the request ID or session
+    /// finds them here exactly as it does in production. (The CSRF layer is
+    /// only present when you supply a config via [`state`](Self::state) that
+    /// enables it; [`SystemTest::new`] disables CSRF by default.)
+    ///
+    /// # Ordering
+    ///
+    /// Also matching `AppBuilder::layer`: when called multiple times the
+    /// **first** call is the outermost layer on ingress (it sees the request
+    /// first and the response last).
+    ///
+    /// # Bounds
+    ///
+    /// [`IntoAppLayer`](crate::app::IntoAppLayer) is the same sealed trait
+    /// `AppBuilder::layer` uses: any `tower::Layer` whose service satisfies
+    /// axum's requirements (`Error = Infallible`). Layers with real errors
+    /// (e.g. `TimeoutLayer`'s `BoxError`) must be wrapped with
+    /// [`axum::error_handling::HandleErrorLayer`] first.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,no_run
+    /// # use autumn_web::system_test::SystemTest;
+    /// # use autumn_web::prelude::*;
+    /// # #[get("/")] async fn index() -> &'static str { "" }
+    /// # async fn scope_to_tenant(
+    /// #     req: axum::extract::Request,
+    /// #     next: axum::middleware::Next,
+    /// # ) -> axum::response::Response { next.run(req).await }
+    /// # async fn example() {
+    /// let runner = SystemTest::new()
+    ///     .routes(routes![index])
+    ///     .layer(axum::middleware::from_fn(scope_to_tenant))
+    ///     .build()
+    ///     .await
+    ///     .expect("start runner");
+    /// # }
+    /// ```
+    pub fn layer<L: crate::app::IntoAppLayer>(mut self, layer: L) -> Self {
+        self.custom_layers
+            .push(crate::app::CustomLayerRegistration {
+                type_id: std::any::TypeId::of::<L>(),
+                type_name: std::any::type_name::<L>(),
+                apply: Box::new(move |router| layer.apply_to(router)),
+            });
         self
     }
 
@@ -365,8 +486,17 @@ impl SystemTest {
         let addr = listener.local_addr().map_err(SystemTestError::ArtifactIo)?;
         let base_url = format!("http://127.0.0.1:{}", addr.port());
 
+        // Read the settings the runner (not the router) needs before
+        // `into_router` consumes the builder.
+        let browser_timeout = self.browser_timeout;
+        let hx_settle_timeout = self.hx_settle_timeout;
+        let artifact_dir = self
+            .artifact_dir_override
+            .clone()
+            .unwrap_or_else(default_artifact_dir);
+
         // 2. Build the axum router from the registered routes.
-        let router = build_router_for_system_test(self.routes, self.state_override);
+        let router = self.into_router();
         let service = tower::Layer::layer(&crate::middleware::MethodOverrideLayer::new(), router);
         let make_service = axum::ServiceExt::<axum::extract::Request>::into_make_service(service);
 
@@ -381,21 +511,51 @@ impl SystemTest {
         });
 
         // 4. Launch Chromium.
-        let (browser, user_data_dir) = launch_browser(self.browser_timeout).await?;
-
-        let artifact_dir = self
-            .artifact_dir_override
-            .unwrap_or_else(default_artifact_dir);
+        let (browser, user_data_dir) = launch_browser(browser_timeout).await?;
 
         Ok(SystemTestRunner {
             base_url,
             browser: Some(browser),
             artifact_dir,
             user_data_dir,
-            hx_settle_timeout: self.hx_settle_timeout,
+            hx_settle_timeout,
             _shutdown: Some(shutdown_tx),
             _server_handle: Some(server_handle),
         })
+    }
+
+    /// Assemble the axum router this builder will serve, without binding a
+    /// port or launching a browser.
+    ///
+    /// Split out of [`build`](Self::build) so router assembly — route
+    /// registration, state selection, and custom-layer application — is
+    /// exercisable without a Chromium binary.
+    fn into_router(self) -> axum::Router {
+        // Both arms only decide *which* (config, state) pair to build from;
+        // the single build call below is deliberately shared so a future edit
+        // cannot wire `custom_layers` into one path and forget the other.
+        let (config, state) = if let Some(state) = self.state_override {
+            // Use the config already embedded in the caller-supplied state so
+            // that middleware (tenancy, auth, rate-limiting, CSRF) is built
+            // from the same settings handlers observe via AppState::config().
+            // Headless Chromium handles cookies normally, so CSRF works
+            // end-to-end: the browser receives the CSRF cookie on first visit
+            // and replays it on form submissions, exactly as a real user does.
+            let config = state
+                .extension::<AutumnConfig>()
+                .map(|arc| (*arc).clone())
+                .unwrap_or_default();
+            (config, state)
+        } else {
+            // The builder's own config: `test` profile with CSRF disabled, so
+            // a fixture form does not have to thread a token through its HTML.
+            let state = crate::state::AppState::for_test().with_profile("test");
+            state.insert_extension(self.config.clone());
+            (self.config, state)
+        };
+
+        crate::router::try_build_router_with_layers(self.routes, &config, state, self.custom_layers)
+            .unwrap_or_else(|error| panic!("invalid router configuration: {error}"))
     }
 
     /// Launch a managed headless Chromium and attach it to an **already
@@ -829,37 +989,21 @@ impl Page {
     /// # Errors
     /// [`SystemTestError::Timeout`] or [`SystemTestError::AssertionFailed`].
     pub async fn expect_text(&self, text: &str) -> Result<&Self, SystemTestError> {
-        let timeout = Duration::from_secs(5);
-        let deadline = tokio::time::Instant::now() + timeout;
+        let deadline = tokio::time::Instant::now() + ASSERTION_TIMEOUT;
+        let js = format!(
+            "document.body && document.body.innerText.includes({})",
+            js_string_literal(text)
+        );
 
-        loop {
-            let evaluated = self
-                .inner
-                .evaluate(format!(
-                    "document.body && document.body.innerText.includes({})",
-                    js_string_literal(text)
-                ))
-                .await;
-
-            let found = match evaluated {
-                Ok(result) => result.into_value().unwrap_or(false),
-                Err(e) if is_transient_navigation_error(&e) => false,
-                Err(e) => return Err(e.into()),
-            };
-            if found {
-                return Ok(self);
-            }
-
-            if tokio::time::Instant::now() >= deadline {
-                let artifact = self.write_failure_artifacts("expect_text").await.ok();
-                return Err(SystemTestError::AssertionFailed {
-                    message: format!("expected text {text:?} in page body"),
-                    artifact_path: artifact,
-                });
-            }
-
-            tokio::time::sleep(POLL_INTERVAL).await;
+        if poll_until_deadline(deadline, false, || self.evaluate_bool(js.clone(), false)).await? {
+            return Ok(self);
         }
+
+        let artifact = self.write_failure_artifacts("expect_text").await.ok();
+        Err(SystemTestError::AssertionFailed {
+            message: format!("expected text {text:?} in page body"),
+            artifact_path: artifact,
+        })
     }
 
     /// Assert that the current page URL ends with or contains `pattern`.
@@ -867,44 +1011,28 @@ impl Page {
     /// # Errors
     /// [`SystemTestError::Timeout`] or [`SystemTestError::AssertionFailed`].
     pub async fn expect_url(&self, pattern: &str) -> Result<&Self, SystemTestError> {
-        let timeout = Duration::from_secs(5);
-        let deadline = tokio::time::Instant::now() + timeout;
+        let deadline = tokio::time::Instant::now() + ASSERTION_TIMEOUT;
+        let js = format!(
+            "window.location.href.includes({})",
+            js_string_literal(pattern)
+        );
 
-        loop {
-            let evaluated = self
-                .inner
-                .evaluate(format!(
-                    "window.location.href.includes({})",
-                    js_string_literal(pattern)
-                ))
-                .await;
-
-            let found = match evaluated {
-                Ok(result) => result.into_value().unwrap_or(false),
-                Err(e) if is_transient_navigation_error(&e) => false,
-                Err(e) => return Err(e.into()),
-            };
-            if found {
-                return Ok(self);
-            }
-
-            if tokio::time::Instant::now() >= deadline {
-                let current_url: String = self
-                    .inner
-                    .evaluate("window.location.href")
-                    .await
-                    .ok()
-                    .and_then(|v| v.into_value::<String>().ok())
-                    .unwrap_or_else(|| "<unknown>".into());
-                let artifact = self.write_failure_artifacts("expect_url").await.ok();
-                return Err(SystemTestError::AssertionFailed {
-                    message: format!("expected URL to contain {pattern:?}, got {current_url:?}"),
-                    artifact_path: artifact,
-                });
-            }
-
-            tokio::time::sleep(POLL_INTERVAL).await;
+        if poll_until_deadline(deadline, false, || self.evaluate_bool(js.clone(), false)).await? {
+            return Ok(self);
         }
+
+        let current_url: String = self
+            .inner
+            .evaluate("window.location.href")
+            .await
+            .ok()
+            .and_then(|v| v.into_value::<String>().ok())
+            .unwrap_or_else(|| "<unknown>".into());
+        let artifact = self.write_failure_artifacts("expect_url").await.ok();
+        Err(SystemTestError::AssertionFailed {
+            message: format!("expected URL to contain {pattern:?}, got {current_url:?}"),
+            artifact_path: artifact,
+        })
     }
 
     /// Assert that an element matching `selector` has attribute `attr` equal
@@ -918,38 +1046,26 @@ impl Page {
         attr: &str,
         value: &str,
     ) -> Result<&Self, SystemTestError> {
-        let timeout = Duration::from_secs(5);
-        let deadline = tokio::time::Instant::now() + timeout;
+        let deadline = tokio::time::Instant::now() + ASSERTION_TIMEOUT;
+        let js = format!(
+            "(function() {{ \
+               var el = document.querySelector({sel}); \
+               return el && el.getAttribute({attr}) === {val}; \
+             }})()",
+            sel = js_string_literal(selector),
+            attr = js_string_literal(attr),
+            val = js_string_literal(value),
+        );
 
-        loop {
-            let js = format!(
-                "(function() {{ \
-                   var el = document.querySelector({sel}); \
-                   return el && el.getAttribute({attr}) === {val}; \
-                 }})()",
-                sel = js_string_literal(selector),
-                attr = js_string_literal(attr),
-                val = js_string_literal(value),
-            );
-            let found = match self.inner.evaluate(js).await {
-                Ok(result) => result.into_value().unwrap_or(false),
-                Err(e) if is_transient_navigation_error(&e) => false,
-                Err(e) => return Err(e.into()),
-            };
-            if found {
-                return Ok(self);
-            }
-
-            if tokio::time::Instant::now() >= deadline {
-                let artifact = self.write_failure_artifacts("expect_attribute").await.ok();
-                return Err(SystemTestError::AssertionFailed {
-                    message: format!("expected [{attr}={value:?}] on {selector:?}"),
-                    artifact_path: artifact,
-                });
-            }
-
-            tokio::time::sleep(POLL_INTERVAL).await;
+        if poll_until_deadline(deadline, false, || self.evaluate_bool(js.clone(), false)).await? {
+            return Ok(self);
         }
+
+        let artifact = self.write_failure_artifacts("expect_attribute").await.ok();
+        Err(SystemTestError::AssertionFailed {
+            message: format!("expected [{attr}={value:?}] on {selector:?}"),
+            artifact_path: artifact,
+        })
     }
 
     // ── htmx helpers ──────────────────────────────────────────────────────
@@ -1106,8 +1222,15 @@ impl Page {
 
     /// Evaluate a JavaScript expression on the page and return the result.
     ///
+    /// Unlike the `expect_*` assertions this is a **single, raw** evaluation:
+    /// it does not poll and does not absorb the transient CDP errors a
+    /// concurrent navigation produces. If you are using it to wait for
+    /// something (see the [`expect_hx_settle`](Self::expect_hx_settle)
+    /// delayed-trigger note), retry it yourself rather than assuming one call
+    /// lands on a live execution context.
+    ///
     /// # Errors
-    /// Propagates CDP errors.
+    /// Propagates CDP errors, including transient navigation ones.
     pub async fn evaluate(
         &self,
         js: impl Into<String>,
@@ -1121,31 +1244,44 @@ impl Page {
 
     async fn wait_for_hx_settle(&self) -> Result<(), SystemTestError> {
         let deadline = tokio::time::Instant::now() + self.hx_settle_timeout;
-        loop {
-            let evaluated = self
-                .inner
-                .evaluate("document.querySelectorAll('.htmx-request,.htmx-settling,.htmx-swapping').length === 0")
-                .await;
-            // A destroyed execution context (the page navigated away, e.g. a
-            // plain form submit's full-page redirect) means there is no more
-            // htmx activity on that page to wait for — that counts as settled,
-            // not "keep polling a page that no longer exists".
-            let settled = match evaluated {
-                Ok(result) => result.into_value().unwrap_or(true),
-                Err(e) if is_transient_navigation_error(&e) => true,
-                Err(e) => return Err(e.into()),
-            };
-            if settled {
-                return Ok(());
-            }
-            if tokio::time::Instant::now() >= deadline {
-                return Err(SystemTestError::Timeout {
-                    message: "htmx did not settle".into(),
-                    timeout: self.hx_settle_timeout,
-                });
-            }
-            tokio::time::sleep(POLL_INTERVAL).await;
+        // A destroyed execution context (the page navigated away, e.g. a plain
+        // form submit's full-page redirect) means there is no more htmx
+        // activity on that page to wait for — that counts as settled, not
+        // "keep polling a page that no longer exists". Hence
+        // `transient_means: true`. An undecodable result reads as settled for
+        // the same reason: a page with no htmx at all must not stall here.
+        let settled = poll_until_deadline(deadline, true, || {
+            self.evaluate_bool(
+                "document.querySelectorAll('.htmx-request,.htmx-settling,.htmx-swapping').length === 0"
+                    .to_owned(),
+                true,
+            )
+        })
+        .await?;
+
+        if settled {
+            return Ok(());
         }
+        Err(SystemTestError::Timeout {
+            message: "htmx did not settle".into(),
+            timeout: self.hx_settle_timeout,
+        })
+    }
+
+    /// Evaluate `js` and read the result as a bool, using `default` when the
+    /// page returns something that is not one (e.g. `undefined` on a page
+    /// that has not finished loading).
+    async fn evaluate_bool(
+        &self,
+        js: String,
+        default: bool,
+    ) -> Result<bool, chromiumoxide::error::CdpError> {
+        Ok(self
+            .inner
+            .evaluate(js)
+            .await?
+            .into_value()
+            .unwrap_or(default))
     }
 
     /// Write screenshot + HTML artifacts and return the base path (without
@@ -1214,131 +1350,6 @@ macro_rules! system_test {
 
 // ── Internal utilities ─────────────────────────────────────────────────────
 
-/// All paths to probe for a Chromium binary, in resolution order.
-fn browser_candidates() -> Vec<PathBuf> {
-    let mut candidates: Vec<PathBuf> = Vec::new();
-
-    // 1. Explicit override.
-    if let Ok(p) = std::env::var("AUTUMN_CHROMIUM") {
-        candidates.push(PathBuf::from(p));
-    }
-
-    // 2. Playwright browsers directory.
-    if let Ok(base) = std::env::var("PLAYWRIGHT_BROWSERS_PATH") {
-        let base = PathBuf::from(base);
-        if let Ok(entries) = std::fs::read_dir(&base) {
-            let mut pw_paths: Vec<PathBuf> = entries
-                .flatten()
-                .filter(|e| e.file_name().to_string_lossy().starts_with("chromium-"))
-                .map(|e| {
-                    if cfg!(target_os = "macos") {
-                        e.path()
-                            .join("chrome-mac")
-                            .join("Chromium.app")
-                            .join("Contents")
-                            .join("MacOS")
-                            .join("Chromium")
-                    } else if cfg!(target_os = "windows") {
-                        e.path().join("chrome-win").join("chrome.exe")
-                    } else {
-                        e.path().join("chrome-linux").join("chrome")
-                    }
-                })
-                .collect();
-            pw_paths.sort();
-            pw_paths.reverse(); // highest revision first
-            candidates.extend(pw_paths);
-        }
-    }
-
-    // 3. PATH-based lookup — covers CI setups like browser-actions/setup-chrome
-    //    that install a `chrome` or `google-chrome` binary on PATH rather than
-    //    at a well-known fixed location.
-    for name in &[
-        "chrome",
-        "google-chrome",
-        "google-chrome-stable",
-        "chromium",
-        "chromium-browser",
-    ] {
-        if let Some(p) = std::env::var_os("PATH").and_then(|path_var| {
-            std::env::split_paths(&path_var)
-                .map(|dir| dir.join(name))
-                .find(|p| p.is_file())
-        }) {
-            candidates.push(p);
-        }
-    }
-
-    // 4. Well-known system paths.
-    candidates.extend(
-        [
-            "/usr/bin/chromium-browser",
-            "/usr/bin/chromium",
-            "/usr/bin/google-chrome",
-            "/usr/bin/google-chrome-stable",
-            "/snap/bin/chromium",
-            "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
-            "/Applications/Chromium.app/Contents/MacOS/Chromium",
-        ]
-        .map(PathBuf::from),
-    );
-
-    candidates
-}
-
-/// Return the first candidate that exists and reports a version.
-fn find_chromium() -> Option<PathBuf> {
-    browser_candidates()
-        .into_iter()
-        .find(|path| path.is_file() && probe_version(path).is_some())
-}
-
-/// Run `<path> --version` and return the output if successful.
-fn probe_version(path: &Path) -> Option<String> {
-    std::process::Command::new(path)
-        .arg("--version")
-        .output()
-        .ok()
-        .filter(|o| o.status.success())
-        .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_owned())
-}
-
-/// Build a minimal axum `Router` from a list of registered `Route`s.
-///
-/// If `state_override` is `Some`, it is used as-is (caller is responsible for
-/// all required registrations such as DB pool, API versions, policies).
-/// Otherwise a default test state is constructed.
-fn build_router_for_system_test(
-    routes: Vec<Route>,
-    state_override: Option<crate::state::AppState>,
-) -> axum::Router {
-    if let Some(state) = state_override {
-        // Use the config already embedded in the caller-supplied state so
-        // that middleware (tenancy, auth, rate-limiting, CSRF) is built
-        // from the same settings that handlers observe via AppState::config().
-        // Headless Chromium handles cookies normally, so CSRF works end-to-end:
-        // the browser receives the CSRF cookie on first visit and replays it
-        // on form submissions, exactly as a real user would.
-        let config = state
-            .extension::<AutumnConfig>()
-            .map(|arc| (*arc).clone())
-            .unwrap_or_default();
-        crate::router::build_router(routes, &config, state)
-    } else {
-        let mut security = crate::security::SecurityConfig::default();
-        security.csrf.enabled = false;
-        let config = AutumnConfig {
-            profile: Some("test".into()),
-            security,
-            ..Default::default()
-        };
-        let state = crate::state::AppState::for_test().with_profile("test");
-        state.insert_extension(config.clone());
-        crate::router::build_router(routes, &config, state)
-    }
-}
-
 /// Escape a string as a JSON-safe JavaScript string literal.
 fn js_string_literal(s: &str) -> String {
     let escaped = s
@@ -1372,39 +1383,434 @@ mod tests {
         assert!(d.to_string_lossy().contains("system-tests"));
     }
 
-    #[test]
-    fn browser_check_not_found_message_has_hints() {
-        let check = BrowserCheck::NotFound {
-            searched_paths: vec![PathBuf::from("/no/such/path")],
-        };
-        let msg = check.to_string();
-        assert!(msg.contains("apt-get") || msg.contains("AUTUMN_CHROMIUM"));
+    // ── Issue #1456 (2): transient CDP errors during page transitions ────
+    //
+    // When a user action navigates the page (a submit button that redirects),
+    // Chrome tears down the JS execution context. An `evaluate()` already in
+    // flight from an assertion poll then fails with a CDP error that means
+    // "the page moved" — not "the assertion is false". Those must be
+    // swallowed by the polling loops and retried until the deadline, while
+    // genuine CDP errors still surface immediately.
+
+    /// Build the `CdpError` shape Chrome actually returns for these.
+    fn chrome_err(message: &str) -> chromiumoxide::error::CdpError {
+        chromiumoxide::error::CdpError::Chrome(chromiumoxide::types::Error {
+            // The predicate matches on the message, never the code: -32000 is
+            // Chrome's catch-all server error and covers genuine failures too.
+            code: -32000,
+            message: message.to_owned(),
+        })
     }
 
     #[test]
-    fn browser_candidates_includes_common_paths() {
-        let candidates = browser_candidates();
-        let as_strings: Vec<_> = candidates
-            .iter()
-            .map(|p| p.to_string_lossy().into_owned())
-            .collect();
+    fn transient_navigation_errors_are_recognised() {
+        for message in [
+            // The exact error reported in #1456.
+            "Cannot find context with specified id",
+            "Execution context was destroyed.",
+            // Same race, reported against the target — note it contains no
+            // "context" at all, which is why the pre-#1456 substring match
+            // let it through.
+            "Inspected target navigated or closed",
+            // Casing must not matter.
+            "cannot find CONTEXT with specified id",
+        ] {
+            assert!(
+                is_transient_navigation_error(&chrome_err(message)),
+                "{message:?} means the page navigated mid-poll and must be \
+                 retried, not propagated"
+            );
+        }
+    }
+
+    #[test]
+    fn transient_detection_covers_untyped_chrome_messages() {
+        // chromiumoxide reports a CDP response error that does not
+        // deserialise into its typed `Error` as `ChromeMessage` instead —
+        // same failure, different variant, must not leak through.
         assert!(
-            as_strings
-                .iter()
-                .any(|s| s.contains("chromium") || s.contains("chrome")),
-            "should have at least one chrome path; got {as_strings:?}"
+            is_transient_navigation_error(&chromiumoxide::error::CdpError::msg(
+                "Cannot find context with specified id"
+            )),
+            "the untyped ChromeMessage variant carries the same transient errors"
+        );
+    }
+
+    #[test]
+    fn genuine_cdp_errors_are_not_swallowed() {
+        // Treating these as transient would convert a fast, precise failure
+        // into a silent five-second timeout with a worse message.
+        for message in [
+            "No node with given id found",
+            "Could not compute content quads.",
+            "Node is not a HTMLElement",
+            // A JS error that merely mentions the word — the pre-#1456 bare
+            // `contains("context")` match would have swallowed this.
+            "ReferenceError: context is not defined",
+        ] {
+            assert!(
+                !is_transient_navigation_error(&chrome_err(message)),
+                "{message:?} is a real failure and must propagate immediately"
+            );
+        }
+        assert!(
+            !is_transient_navigation_error(&chromiumoxide::error::CdpError::Timeout),
+            "a CDP timeout is not a navigation race"
+        );
+        assert!(
+            !is_transient_navigation_error(&chromiumoxide::error::CdpError::NoResponse),
+            "a dead connection is not a navigation race"
+        );
+    }
+
+    #[test]
+    fn a_dead_target_is_not_treated_as_a_navigation() {
+        // Chrome emits these when the renderer died (a sad tab under CI
+        // memory pressure), not only when the page moved. `wait_for_hx_settle`
+        // reads a transient error as *settled*, so swallowing these would let
+        // a crashed page sail through `click()` and fail five seconds later in
+        // `expect_text` with no screenshot — the exact decay this predicate
+        // exists to prevent.
+        for message in ["Target closed", "Session with given id not found."] {
+            assert!(
+                !is_transient_navigation_error(&chrome_err(message)),
+                "{message:?} is indistinguishable from a dead renderer and must \
+                 surface immediately"
+            );
+        }
+    }
+
+    // ── The retry loop itself (AC2's actual behaviour) ───────────────────
+    //
+    // The predicate above only classifies an error. What #1456 asks for is
+    // that assertion helpers *keep polling* past one — these drive the shared
+    // loop with a scripted probe so the behaviour is covered without a
+    // browser.
+
+    /// A probe that replays `script`, one entry per call, then repeats the
+    /// last entry forever. Also records how many times it was called.
+    fn scripted_probe(
+        script: Vec<Result<bool, chromiumoxide::error::CdpError>>,
+    ) -> (
+        impl FnMut() -> std::future::Ready<Result<bool, chromiumoxide::error::CdpError>>,
+        Arc<std::sync::atomic::AtomicUsize>,
+    ) {
+        let calls = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let counter = Arc::clone(&calls);
+        let script = Arc::new(script);
+        let probe = move || {
+            let n = counter.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            let step = script.get(n).unwrap_or_else(|| script.last().unwrap());
+            let replay = match step {
+                Ok(v) => Ok(*v),
+                Err(e) => Err(chromiumoxide::error::CdpError::msg(e.to_string())),
+            };
+            std::future::ready(replay)
+        };
+        (probe, calls)
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn polling_retries_past_transient_errors_and_succeeds() {
+        // The #1456 scenario: a redirect destroys the execution context under
+        // two in-flight evaluations, then the post-navigation page answers.
+        let (probe, calls) = scripted_probe(vec![
+            Err(chrome_err("Cannot find context with specified id")),
+            Err(chrome_err("Cannot find context with specified id")),
+            Ok(true),
+        ]);
+        let deadline = tokio::time::Instant::now() + ASSERTION_TIMEOUT;
+
+        let outcome = poll_until_deadline(deadline, false, probe).await;
+
+        assert!(
+            matches!(outcome, Ok(true)),
+            "a transient error must not abort the poll; got {outcome:?}"
+        );
+        assert_eq!(
+            calls.load(std::sync::atomic::Ordering::Relaxed),
+            3,
+            "the loop must have polled past both transient errors"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn polling_aborts_immediately_on_a_genuine_error() {
+        let (probe, calls) = scripted_probe(vec![Err(chrome_err("No node with given id found"))]);
+        let deadline = tokio::time::Instant::now() + ASSERTION_TIMEOUT;
+
+        let outcome = poll_until_deadline(deadline, false, probe).await;
+
+        assert!(
+            matches!(outcome, Err(SystemTestError::Browser(_))),
+            "a genuine CDP error must propagate rather than decay into a \
+             timeout; got {outcome:?}"
+        );
+        assert_eq!(
+            calls.load(std::sync::atomic::Ordering::Relaxed),
+            1,
+            "it must fail fast, not keep polling"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn polling_gives_up_at_the_deadline() {
+        // Unrelenting transient errors must still terminate — otherwise a
+        // permanently broken page hangs the test instead of failing it.
+        let (probe, _) = scripted_probe(vec![Err(chrome_err(
+            "Cannot find context with specified id",
+        ))]);
+        let deadline = tokio::time::Instant::now() + ASSERTION_TIMEOUT;
+
+        let outcome = poll_until_deadline(deadline, false, probe).await;
+
+        assert!(
+            matches!(outcome, Ok(false)),
+            "the caller must get the deadline signal so it can write artifacts \
+             and report a real assertion failure; got {outcome:?}"
+        );
+        assert!(
+            tokio::time::Instant::now() >= deadline,
+            "it must actually have waited out the assertion timeout"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn settle_treats_a_navigated_page_as_settled() {
+        // `wait_for_hx_settle` passes `transient_means: true`: a page that
+        // navigated away has no htmx activity left to wait for, so the fence
+        // must return at once rather than poll a page that no longer exists.
+        let (probe, calls) =
+            scripted_probe(vec![Err(chrome_err("Execution context was destroyed."))]);
+        let deadline = tokio::time::Instant::now() + DEFAULT_HX_SETTLE_TIMEOUT;
+
+        let outcome = poll_until_deadline(deadline, true, probe).await;
+
+        assert!(matches!(outcome, Ok(true)), "got {outcome:?}");
+        assert_eq!(
+            calls.load(std::sync::atomic::Ordering::Relaxed),
+            1,
+            "settle must not keep polling a destroyed context"
+        );
+    }
+
+    // ── Issue #1456 (3): custom middleware layers on the test router ──────
+    //
+    // Apps whose routes depend on global middleware (tenant scoping, auth
+    // shims, request enrichment) had no way to register it on `SystemTest`,
+    // forcing callers to hand-map layers onto individual handlers before
+    // passing them to `.routes()`. `SystemTest::layer` must register a
+    // Tower layer that the served router actually runs — on *both* the
+    // default-state and `state()`-override paths — and must compose
+    // multiple registrations with the same ordering contract as
+    // `AppBuilder::layer` (first call = outermost on ingress).
+
+    /// Records the ingress order of every middleware that ran.
+    type IngressLog = Arc<Mutex<Vec<&'static str>>>;
+
+    /// A tenant identifier a middleware inserts and a handler reads back —
+    /// the shape of the tenant-scoping middleware from the original report.
+    #[derive(Clone)]
+    struct TenantId(&'static str);
+
+    /// A `from_fn` layer that appends `name` to `log` on the way *in* and
+    /// again (as `"<name>:out"`) on the way *out*, so both halves of the
+    /// documented ordering contract are observable.
+    fn recording_layer(
+        log: &IngressLog,
+        name: &'static str,
+        out: &'static str,
+    ) -> impl crate::app::IntoAppLayer + Clone {
+        let log = Arc::clone(log);
+        axum::middleware::from_fn(
+            move |req: axum::extract::Request, next: axum::middleware::Next| {
+                let log = Arc::clone(&log);
+                async move {
+                    log.lock().unwrap().push(name);
+                    let response = next.run(req).await;
+                    log.lock().unwrap().push(out);
+                    response
+                }
+            },
+        )
+    }
+
+    /// A route that echoes the [`TenantId`] a layer inserted, or says it saw
+    /// none. Proves the layer wraps *registered routes*, not just the
+    /// fallback, and that its request extensions reach handlers.
+    fn tenant_echo_route() -> Route {
+        Route {
+            method: http::Method::GET,
+            path: "/",
+            handler: axum::routing::get(|tenant: Option<axum::Extension<TenantId>>| async move {
+                tenant.map_or_else(
+                    || "no-tenant".to_owned(),
+                    |axum::Extension(t)| format!("tenant={}", t.0),
+                )
+            }),
+            name: "tenant_echo",
+            api_doc: crate::openapi::ApiDoc {
+                method: "GET",
+                path: "/",
+                operation_id: "tenant_echo",
+                success_status: 200,
+                ..Default::default()
+            },
+            repository: None,
+            idempotency: crate::route::RouteIdempotency::Direct,
+            timeout: crate::route::RouteTimeout::Inherit,
+            seo: crate::seo::SeoRouteDefaults::EMPTY,
+            api_version: None,
+            sunset_opt_out: false,
+        }
+    }
+
+    /// Drive one `GET /` through `router` and return its status and body.
+    async fn probe_router(router: axum::Router) -> (axum::http::StatusCode, String) {
+        use tower::ServiceExt as _;
+        let request = axum::http::Request::builder()
+            .uri("/")
+            .body(axum::body::Body::empty())
+            .unwrap();
+        let response = router.oneshot(request).await.unwrap();
+        let status = response.status();
+        let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        (status, String::from_utf8_lossy(&bytes).into_owned())
+    }
+
+    /// A layer that inserts a [`TenantId`] for the handler to read.
+    fn tenant_layer() -> impl crate::app::IntoAppLayer + Clone {
+        axum::middleware::from_fn(
+            |mut req: axum::extract::Request, next: axum::middleware::Next| async move {
+                req.extensions_mut().insert(TenantId("acme-corp"));
+                next.run(req).await
+            },
+        )
+    }
+
+    #[tokio::test]
+    async fn registered_layer_reaches_registered_route_handlers() {
+        // The whole point of the feature: middleware must wrap the routes
+        // under test, and what it puts on the request must reach the handler.
+        let builder = SystemTest::new()
+            .routes(vec![tenant_echo_route()])
+            .layer(tenant_layer());
+        let (status, body) = probe_router(builder.into_router()).await;
+
+        assert_eq!(status, axum::http::StatusCode::OK);
+        assert_eq!(
+            body, "tenant=acme-corp",
+            "the handler must observe the extension inserted by the layer \
+             registered via SystemTest::layer"
+        );
+    }
+
+    #[tokio::test]
+    async fn without_a_layer_the_same_route_sees_nothing() {
+        // Guards the test above against passing for the wrong reason.
+        let builder = SystemTest::new().routes(vec![tenant_echo_route()]);
+        let (_, body) = probe_router(builder.into_router()).await;
+        assert_eq!(body, "no-tenant");
+    }
+
+    #[tokio::test]
+    async fn registered_layer_runs_on_the_state_override_path() {
+        // Layers must not silently vanish because the caller supplied their
+        // own AppState — the branch a future edit is most likely to forget.
+        let state = crate::state::AppState::for_test();
+        state.insert_extension(AutumnConfig::default());
+        let builder = SystemTest::new()
+            .routes(vec![tenant_echo_route()])
+            .state(state)
+            .layer(tenant_layer());
+        let (_, body) = probe_router(builder.into_router()).await;
+        assert_eq!(body, "tenant=acme-corp");
+    }
+
+    #[tokio::test]
+    async fn a_layer_can_short_circuit_the_handler() {
+        // Proves the layer genuinely *wraps* the handler rather than merely
+        // running alongside it.
+        let builder =
+            SystemTest::new()
+                .routes(vec![tenant_echo_route()])
+                .layer(axum::middleware::from_fn(
+                    |_req: axum::extract::Request, _next: axum::middleware::Next| async move {
+                        axum::http::StatusCode::IM_A_TEAPOT
+                    },
+                ));
+        let (status, body) = probe_router(builder.into_router()).await;
+
+        assert_eq!(status, axum::http::StatusCode::IM_A_TEAPOT);
+        assert!(
+            !body.contains("tenant"),
+            "the handler must not have run; got body {body:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn layers_compose_first_registered_outermost() {
+        let log: IngressLog = Arc::new(Mutex::new(Vec::new()));
+        let builder = SystemTest::new()
+            .routes(vec![tenant_echo_route()])
+            .layer(recording_layer(&log, "first", "first:out"))
+            .layer(recording_layer(&log, "second", "second:out"));
+        probe_router(builder.into_router()).await;
+
+        assert_eq!(
+            *log.lock().unwrap(),
+            vec!["first", "second", "second:out", "first:out"],
+            "ordering must match AppBuilder::layer: the first registration is \
+             the outermost layer, so it sees the request first and the \
+             response last"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_registered_layer_observes_the_framework_request_id() {
+        // The stack-position claim in the docs — layers sit *inside*
+        // Autumn's RequestId layer — is what makes a system test faithful to
+        // production for middleware that reads it. Mirrors
+        // `custom_layer_sees_request_id` in tests/integration/custom_layer.rs.
+        let seen: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(None));
+        let sink = Arc::clone(&seen);
+        let builder =
+            SystemTest::new()
+                .routes(vec![tenant_echo_route()])
+                .layer(axum::middleware::from_fn(
+                    move |req: axum::extract::Request, next: axum::middleware::Next| {
+                        let sink = Arc::clone(&sink);
+                        async move {
+                            let id = req
+                                .extensions()
+                                .get::<crate::middleware::RequestId>()
+                                .map(ToString::to_string);
+                            *sink.lock().unwrap() = id;
+                            next.run(req).await
+                        }
+                    },
+                ));
+        probe_router(builder.into_router()).await;
+
+        let observed = seen.lock().unwrap().clone();
+        assert!(
+            observed.is_some_and(|id| !id.is_empty()),
+            "a layer registered on SystemTest must see the request ID, as it \
+             does under AppBuilder::layer"
         );
     }
 
     #[test]
     fn build_router_default_state_does_not_panic() {
-        // Exercises the None branch of build_router_for_system_test.
-        let _router = build_router_for_system_test(vec![], None);
+        // Exercises the None arm of `into_router`.
+        let _router = SystemTest::new().into_router();
     }
 
     #[test]
     fn build_router_with_state_override_uses_embedded_config() {
-        // Exercises the Some(state) branch: config is read from the supplied
+        // Exercises the Some(state) arm: config is read from the supplied
         // state rather than constructed from scratch.
         let config = AutumnConfig {
             profile: Some("custom".into()),
@@ -1412,13 +1818,13 @@ mod tests {
         };
         let state = crate::state::AppState::for_test();
         state.insert_extension(config);
-        let _router = build_router_for_system_test(vec![], Some(state));
+        let _router = SystemTest::new().state(state).into_router();
     }
 
     #[test]
     fn build_router_with_state_override_no_embedded_config_uses_default() {
         // When the supplied state has no AutumnConfig extension, a default is used.
         let state = crate::state::AppState::for_test();
-        let _router = build_router_for_system_test(vec![], Some(state));
+        let _router = SystemTest::new().state(state).into_router();
     }
 }

--- a/autumn/tests/integration/system_test_api.rs
+++ b/autumn/tests/integration/system_test_api.rs
@@ -16,7 +16,6 @@ use autumn_web::system_test::{BrowserCheck, SystemTest, SystemTestError};
 #[test]
 fn browser_check_reports_result() {
     let result = BrowserCheck::run();
-    // Always returns a result; variant depends on whether Chrome is installed.
     match result {
         BrowserCheck::Found { path, version } => {
             assert!(!path.as_os_str().is_empty());
@@ -29,6 +28,28 @@ fn browser_check_reports_result() {
             );
         }
     }
+}
+
+/// #1456: a host that *has* a browser at one of the searched paths must never
+/// report `NotFound`. Without this the whole check passes in both directions,
+/// so the reported bug — a false `BrowserNotFound` on a Windows box with
+/// Chrome installed — would stay green on the very runner that reproduces it.
+#[test]
+fn an_installed_browser_is_never_reported_as_missing() {
+    let installed: Vec<_> = autumn_web::browser_detect::browser_candidates()
+        .into_iter()
+        .filter(|p| p.is_file())
+        .collect();
+    if installed.is_empty() {
+        return; // genuinely no browser on this host; nothing to assert
+    }
+
+    let check = BrowserCheck::run();
+    assert!(
+        check.is_found(),
+        "these browser binaries exist on this host but the check reported \
+         them missing: {installed:?}\n{check}"
+    );
 }
 
 #[test]
@@ -74,6 +95,39 @@ fn system_test_builder_has_expected_methods() {
             .hx_settle_timeout(std::time::Duration::from_millis(500));
         // We don't call .build().await here to avoid needing a browser.
     }
+}
+
+// ── Custom middleware layers (#1456, issue 3) ──────────────────────────────
+//
+// Apps whose routes depend on global middleware (e.g. a database
+// tenant-scoping layer) previously had no way to register it on the runner,
+// forcing callers to clone and map layers onto individual handlers before
+// passing them to `.routes()`. `SystemTest::layer` must accept any Tower
+// layer that `AppBuilder::layer` accepts, and be chainable with the rest of
+// the builder in any order.
+
+// Compile-only: this asserts the public `.layer()` surface exists, takes the
+// same `IntoAppLayer` values as `AppBuilder::layer`, is chainable with the
+// other builder methods, and can be called more than once. It is deliberately
+// *not* a `#[test]` — rustc type-checks the body whether or not it ever runs,
+// so wrapping it would only inflate the passing count with an assertion-free
+// test that reads like behavioural coverage.
+#[expect(dead_code, reason = "compile-time API-shape assertion; never called")]
+fn assert_layer_api_shape() {
+    async fn passthrough(
+        req: axum::extract::Request,
+        next: axum::middleware::Next,
+    ) -> axum::response::Response {
+        next.run(req).await
+    }
+
+    let _builder = SystemTest::new()
+        .layer(axum::middleware::from_fn(passthrough))
+        .artifact_dir("/tmp/artifacts")
+        // Not just `from_fn`: an off-the-shelf tower-http layer must satisfy
+        // the same bound, as it does on `AppBuilder::layer`.
+        .layer(tower_http::cors::CorsLayer::permissive())
+        .hx_settle_timeout(std::time::Duration::from_millis(500));
 }
 
 // ── SystemTestError formatting ─────────────────────────────────────────────
@@ -251,6 +305,47 @@ async fn click_triggering_full_page_navigation_does_not_break_polling() {
     page.expect_text("Navigated successfully").await.expect(
         "text on the post-redirect page must be visible without the poll \
          aborting on a transient destroyed-execution-context error",
+    );
+}
+
+/// End-to-end proof for #1456 issue 3: a layer registered with
+/// `SystemTest::layer` runs inside the served stack and its request
+/// extensions reach the route handlers, so a real browser sees middleware
+/// output rendered in the page — the exact shape of the reporter's
+/// tenant-scoping middleware.
+#[tokio::test]
+#[ignore = "requires Chromium"]
+async fn custom_layer_is_visible_to_route_handlers_in_the_browser() {
+    use autumn_web::prelude::*;
+
+    #[derive(Clone)]
+    struct TenantId(&'static str);
+
+    async fn scope_to_tenant(
+        mut req: axum::extract::Request,
+        next: axum::middleware::Next,
+    ) -> axum::response::Response {
+        req.extensions_mut().insert(TenantId("acme-corp"));
+        next.run(req).await
+    }
+
+    #[get("/")]
+    async fn index(axum::Extension(tenant): axum::Extension<TenantId>) -> String {
+        format!("<html><body><h1>Tenant: {}</h1></body></html>", tenant.0)
+    }
+
+    let runner = SystemTest::new()
+        .routes(routes![index])
+        .layer(axum::middleware::from_fn(scope_to_tenant))
+        .build()
+        .await
+        .expect("start runner");
+
+    let page = runner.page().await.expect("open page");
+    page.visit("/").await.expect("visit");
+    page.expect_text("Tenant: acme-corp").await.expect(
+        "the handler must observe the extension inserted by the layer \
+         registered via SystemTest::layer",
     );
 }
 

--- a/autumn/tests/integration/system_test_api.rs
+++ b/autumn/tests/integration/system_test_api.rs
@@ -30,25 +30,33 @@ fn browser_check_reports_result() {
     }
 }
 
-/// #1456: a host that *has* a browser at one of the searched paths must never
+/// #1456: a host where a candidate path holds a *usable* browser must never
 /// report `NotFound`. Without this the whole check passes in both directions,
-/// so the reported bug — a false `BrowserNotFound` on a Windows box with
-/// Chrome installed — would stay green on the very runner that reproduces it.
+/// so the reported bug — a false `BrowserNotFound` on a box with Chrome
+/// installed — would stay green on the very runner that reproduces it.
+///
+/// Usability is decided by `probe_version`, not by `is_file()`: on POSIX an
+/// existing candidate may be non-executable, a stale wrapper, or exit
+/// non-zero, all of which the probe rejects on purpose, so `NotFound` is the
+/// correct answer there. (On Windows the probe *is* file existence plus an
+/// `.exe` extension, which is exactly the #1456 behaviour this pins.) What is
+/// asserted is the invariant that binds the two together: if any candidate
+/// probes successfully, the check that walks those candidates must find it.
 #[test]
-fn an_installed_browser_is_never_reported_as_missing() {
-    let installed: Vec<_> = autumn_web::browser_detect::browser_candidates()
+fn a_usable_browser_is_never_reported_as_missing() {
+    let usable: Vec<_> = autumn_web::browser_detect::browser_candidates()
         .into_iter()
-        .filter(|p| p.is_file())
+        .filter(|p| autumn_web::browser_detect::probe_version(p).is_some())
         .collect();
-    if installed.is_empty() {
-        return; // genuinely no browser on this host; nothing to assert
+    if usable.is_empty() {
+        return; // genuinely no usable browser on this host; nothing to assert
     }
 
     let check = BrowserCheck::run();
     assert!(
         check.is_found(),
-        "these browser binaries exist on this host but the check reported \
-         them missing: {installed:?}\n{check}"
+        "these browser binaries probe successfully on this host but the check \
+         reported them missing: {usable:?}\n{check}"
     );
 }
 

--- a/docs/guide/system-tests.md
+++ b/docs/guide/system-tests.md
@@ -115,7 +115,62 @@ All `Page` methods return `Result<&Self, SystemTestError>` and can be chained.
 | `page.expect_hx_settle()` | Explicitly wait for htmx to finish |
 | `page.expect_sse_event(id, predicate)` | Wait for SSE content in DOM |
 
-### htmx auto-waiting
+### Transient navigation errors
+
+Assertion helpers (`expect_text`, `expect_url`, `expect_attribute`,
+`expect_sse_event`) poll by evaluating JavaScript on the page. When an action
+triggers a full-page navigation — a submit button that redirects, say — Chrome
+destroys the JS execution context that an in-flight evaluation was targeting,
+and CDP reports errors such as `Cannot find context with specified id` or
+`Inspected target navigated or closed`.
+
+These are treated as "not ready yet": the helper keeps polling until its
+deadline instead of failing the test on the first unlucky tick. Genuine CDP
+errors (`No node with given id found`, for example) still surface immediately,
+so a real failure is never converted into a silent timeout.
+
+---
+
+## Custom middleware
+
+Use `.layer(...)` to register app-wide middleware on the router the test
+serves. It accepts the same Tower layers as
+[`AppBuilder::layer`](middleware.md) and applies them in the same position:
+
+```rust
+async fn scope_to_tenant(
+    mut req: axum::extract::Request,
+    next: axum::middleware::Next,
+) -> axum::response::Response {
+    req.extensions_mut().insert(TenantId("acme-corp"));
+    next.run(req).await
+}
+
+let runner = SystemTest::new()
+    .routes(routes![index, create_todo])
+    .layer(axum::middleware::from_fn(scope_to_tenant))
+    .build()
+    .await
+    .unwrap();
+```
+
+When `.layer()` is called more than once the **first** call is the outermost
+layer on ingress — it sees the request first and the response last, matching
+`AppBuilder::layer`.
+
+The layer sits inside Autumn's request-ID and session layers and outside
+CSRF/CORS, so middleware that reads the request ID or session finds them under
+test exactly as in production. (The CSRF layer is off by default in the
+harness, so "outside CSRF" only matters when you supply a config via
+`.state(...)` that re-enables it.) Layers apply on both the default-state path
+and the `.state(...)` override path.
+
+Without this you would have to map each layer onto individual handlers before
+passing them to `.routes()`, which tests a stack the real app never serves.
+
+---
+
+## htmx auto-waiting
 
 `click()` automatically waits for htmx to finish settling before returning.
 This is implemented by polling `document.querySelectorAll('.htmx-request').length === 0`
@@ -181,8 +236,10 @@ SystemTest::new()
 The harness looks for Chromium in this order:
 
 1. `AUTUMN_CHROMIUM` environment variable (full path)
-2. `PLAYWRIGHT_BROWSERS_PATH` directory (scans `chromium-*/chrome-linux/chrome`)
-3. Common system paths:
+2. `PLAYWRIGHT_BROWSERS_PATH` directory (scans `chromium-*/`)
+3. `PATH` lookup for `chrome`, `google-chrome`, `google-chrome-stable`,
+   `chromium`, `chromium-browser` (`.exe` on Windows)
+4. Well-known install locations:
    - `/usr/bin/chromium-browser` (Ubuntu/Debian)
    - `/usr/bin/chromium`
    - `/usr/bin/google-chrome`
@@ -190,6 +247,26 @@ The harness looks for Chromium in this order:
    - `/snap/bin/chromium`
    - `/Applications/Google Chrome.app/Contents/MacOS/Google Chrome` (macOS)
    - `/Applications/Chromium.app/Contents/MacOS/Chromium` (macOS)
+   - `%ProgramFiles%`, `%ProgramFiles(x86)%` and `%LOCALAPPDATA%` under
+     `Google\Chrome\Application\chrome.exe` (and the `Chrome Beta` /
+     `Chromium` variants) on Windows
+
+On Linux and macOS each candidate is confirmed with a `--version` probe run
+against its own throwaway `--user-data-dir`, so a Chrome already running on
+the host cannot abort the probe on a locked profile directory. A binary that
+exits 0 without printing anything (a launcher shim, say) is still accepted.
+
+**Windows:** `chrome.exe` is a GUI-subsystem binary — it writes nothing to the
+parent console, and `--version` is not an early-exit switch there, so running
+it starts a real browser rather than answering. The harness therefore does not
+execute the candidate on Windows at all: an existing `.exe` at a known
+location is accepted, and `autumn doctor` reports `version unavailable`
+instead of falsely claiming no browser is installed. Windows install
+locations (`%ProgramFiles%`, `%ProgramFiles(x86)%`, `%LOCALAPPDATA%` under
+`…\Application\chrome.exe`) are searched alongside the Unix ones.
+
+`autumn doctor` and the `SystemTest` runner share this resolution code, so the
+two can never disagree about whether this host can run system tests.
 
 Run `autumn doctor` to check whether a browser is detected:
 

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -28,8 +28,20 @@ package = "autumn-web"
 # `router::extract_path_params`, the path-parameter extraction seam).
 features = ["inbound-mail", "multipart", "openapi"]
 
+# cargo-fuzz builds in release mode with ASAN instrumentation, which is the
+# repo's heaviest build; debug info is a large share of that footprint and is
+# what pushes the runner over its ceiling (see the "Free disk space" step in
+# .github/workflows/fuzz.yml). `line-tables-only` keeps stack traces
+# symbolicated — all a crash reproducer needs, since the input is replayed
+# locally with full debug info — while dropping the type/variable DWARF nobody
+# reads from a CI log. Build scripts and proc macros never appear in a fuzz
+# backtrace, so they need none at all. Mirrors the root workspace's
+# `[profile.test]` / `[profile.test.build-override]` pairing.
 [profile.release]
-debug = 1
+debug = "line-tables-only"
+
+[profile.release.build-override]
+debug = 0
 
 # Keep fuzz-target builds from tripping the "unused `main`" style lints and to
 # match cargo-fuzz conventions.

--- a/skills/autumn-web/SKILL.md
+++ b/skills/autumn-web/SKILL.md
@@ -1952,6 +1952,42 @@ touches a database — it only reverses generated files/migrations.
 production defaults, missing primaries, stale replica migrations, missing
 signing secrets, and other config problems without printing credentials.
 
+## System tests (browser, feature `system-tests`)
+
+`SystemTest` boots the app on an ephemeral port, launches managed headless
+Chromium, and hands back a `Page` with htmx-aware auto-waiting assertions. Add
+`autumn-web = { features = ["system-tests"] }` as a **dev-dependency** only.
+
+```rust
+let runner = SystemTest::new()
+    .routes(routes![index, create_todo])
+    .state(state)                                       // real pool/policies
+    .layer(axum::middleware::from_fn(scope_to_tenant))  // unreleased
+    .build().await.unwrap();
+
+let page = runner.page().await.unwrap();
+page.visit("/").await?;
+page.click("Add").await?;          // auto-waits for htmx settle
+page.expect_text("Saved").await?;
+page.expect_no_console_errors().await?;
+```
+
+- `.layer(...)` (**unreleased**) takes the same layers as `AppBuilder::layer`
+  and puts them in the same stack position, so middleware that reads the
+  request ID or session behaves as in production. Use it whenever the routes
+  under test need global middleware — mapping layers onto individual handlers
+  instead tests a stack the real app never serves.
+- `expect_*` assertions poll to a deadline and ignore the transient CDP errors
+  a mid-poll navigation (e.g. a redirecting form submit) produces; `evaluate`
+  is a single raw call that does not.
+- Generated tests are `#[ignore]`d — run with `-- --include-ignored`. Failures
+  write a `.png` + `.html` to `target/system-tests/<test>/`.
+- `autumn doctor` reports whether a usable browser was found, using the same
+  resolution as the harness (`AUTUMN_CHROMIUM` overrides it).
+
+Full API: `skills/autumn-web/references/api-reference.md`; guide:
+`docs/guide/system-tests.md`.
+
 ## 0.5.0 release traps
 
 - `AUTUMN_SECURITY__SIGNING_SECRET` is required in `prod` / `production`.

--- a/skills/autumn-web/references/api-reference.md
+++ b/skills/autumn-web/references/api-reference.md
@@ -754,6 +754,38 @@ double-submits and replays.
 | `with_shard_router(router)` | Sharding router (**unreleased**) |
 | `run()` | Start server |
 
+## SystemTest builder (`autumn_web::system_test`, feature `system-tests`)
+
+Browser-driven tests: boots the app on an ephemeral port, launches managed
+headless Chromium, returns a `Page` with htmx-aware auto-waiting assertions.
+Dev-dependency only.
+
+| Method | Notes |
+|---|---|
+| `SystemTest::new()` | Builder; `test` profile with CSRF disabled |
+| `.routes(routes![...])` | Routes to serve; additive across calls |
+| `.state(AppState)` | Supply a pre-built state (real DB pool, policies); its embedded config wins |
+| `.layer(layer)` | App-wide Tower middleware, same `IntoAppLayer` bound and stack position as `AppBuilder::layer` — first call is outermost on ingress (**unreleased**) |
+| `.artifact_dir(path)` | Where failure screenshots/HTML go (default `target/system-tests/<test>/`) |
+| `.browser_timeout(d)` / `.hx_settle_timeout(d)` | Launch and htmx-settle deadlines |
+| `.build()` | Boot server + browser → `SystemTestRunner` |
+| `SystemTest::attach(base_url)` | Browser only, against an already-running app (`attach_with_timeout` for a custom deadline) |
+| `runner.page()` / `runner.base_url()` | Open a `Page`; the app's base URL |
+| `BrowserCheck::run()` | Probe the host for Chromium; also what `autumn doctor` reports |
+
+Reach for `.layer(...)` whenever the routes under test depend on global
+middleware (tenant scoping, an auth shim, request enrichment) — mapping the
+layer onto individual handlers instead tests a stack the real app never
+serves.
+
+`Page`: `visit`, `fill`, `click`, `expect_text`, `expect_url`,
+`expect_attribute`, `expect_hx_settle`, `expect_sse_event`,
+`expect_no_console_errors`, `console_errors`, `snapshot`, `evaluate`. The
+`expect_*` assertions poll to a deadline and ignore the transient CDP errors a
+mid-poll navigation produces; `evaluate` is a single raw call that does not.
+
+See `docs/guide/system-tests.md`.
+
 ## Cargo features
 
 ```toml


### PR DESCRIPTION
## Summary

Adds `SystemTest::layer()` to register app-wide Tower middleware on the router a browser test serves, enabling end-to-end testing of routes that depend on global middleware like tenant scoping, auth shims, or request enrichment.

## Key Changes

- **New `SystemTest::layer()` method**: Accepts the same `IntoAppLayer` values as `AppBuilder::layer` and applies them in the identical router position (inside `RequestId` and session layers, outside CSRF/CORS). Multiple calls compose with `AppBuilder`'s ordering contract: the first registration is the outermost layer on ingress.

- **Browser detection refactored to shared module**: Moved `BrowserCheck`, `browser_candidates()`, and `probe_version()` from `system_test.rs` into a new `browser_detect.rs` module (not behind `system-tests` feature) so `autumn doctor` and the test harness can never disagree about whether a host can run system tests. Both now delegate to the same resolution logic.

- **Improved transient navigation error handling**: Extracted `poll_until_deadline()` helper that powers all auto-waiting assertions (`expect_text`, `expect_url`, `expect_attribute`). Transient CDP errors (context destroyed mid-navigation) are now distinguished from genuine failures via an explicit `TRANSIENT_NAVIGATION_MARKERS` list, preventing false timeouts while still surfacing real errors immediately.

- **Router assembly refactored**: Split `SystemTest::build()` to extract `into_router()` so router assembly (route registration, state selection, custom-layer application) is exercisable without a Chromium binary. Both the default-state path and `.state(...)` override path now apply custom layers identically.

- **Documentation expanded**: Added "Custom middleware" section to system-tests guide with examples. Updated browser resolution order documentation to clarify PATH-based lookup and per-platform install locations, plus Windows-specific version probe behavior.

- **Test coverage**: Added `an_installed_browser_is_never_reported_as_missing()` regression test for #1456 (false `BrowserNotFound` on Windows with Chrome installed).

## Implementation Details

- The `layer()` method stores registrations in `custom_layers: Vec<CustomLayerRegistration>` and passes them to `try_build_router_with_layers()`, a new variant of `try_build_router()` that applies layers in the same position as `AppBuilder::layer`.

- Windows version probe deliberately skips execution (checks file extension only) to avoid spawning a real browser window; POSIX probes with `--version --user-data-dir=<throwaway>` to confirm usability without touching the user's profile.

- Transient navigation markers are compared case-insensitively and deliberately exclude `"Target closed"` and `"Session with given id not found"` (which indicate renderer crashes, not navigation) to avoid converting genuine failures into silent timeouts.

- `ASSERTION_TIMEOUT` constant (5 seconds) centralizes the deadline for all auto-waiting assertions, replacing inline hardcoded values.

https://claude.ai/code/session_011sAsq5hZPFgfipJeuh6XxY