### PR TITLE
docs: authentication pipeline security audit report (2026-08)

### DIFF
--- a/docs/reports/auth-pipeline-security-audit-2026-08.md
+++ b/docs/reports/auth-pipeline-security-audit-2026-08.md
@@ -70,9 +70,11 @@ Generated `POST /auth/admin/unlock` (`generate/auth.rs`):
 if admin_secret.is_empty() || provided != admin_secret {
 ```
 
-This is the only secret comparison in the whole pipeline that uses `!=`
-instead of a constant-time compare — everywhere else uses `subtle` or the
-`constant_time_eq` helpers. `AUTUMN_ADMIN_SECRET` also has no minimum-length
+This is the only plain `!=` on a long-lived secret in the pipeline — token,
+state, nonce, and cookie comparisons all go through `subtle` or the
+`constant_time_eq` helpers. (The generated TOTP code compare is the other
+non-constant-time comparison, on a short-lived code — see L14.)
+`AUTUMN_ADMIN_SECRET` also has no minimum-length
 validation, unlike the signing secret (32-byte minimum + weak-value denylist).
 
 Recommendation: compare via `autumn_web::auth::constant_time_eq`, and consider
@@ -222,6 +224,48 @@ transactions (optionally sparing the current device's chain, mirroring the
 `token_digest.ne(current)` session carve-out). *(Credit: flagged by automated
 review on the audit PR and verified against the code.)*
 
+### L14. Generated TOTP code comparison is not constant-time
+
+`verify_totp_code` compares `expected == candidate` with a plain string
+equality. Practical exploitability is marginal — the code is 6 digits, rotates
+every 30 s, and a matched step is single-use via the `totp_last_used_step`
+replay guard — but it is inconsistent with the pipeline's own standard
+(constant-time comparison everywhere else, including for values with similar
+threat profiles). Fix: run the candidate through
+`autumn_web::auth::constant_time_eq` against each window's expected code.
+*(Credit: flagged by automated review on the audit PR and verified against the
+code.)*
+
+### L15. Lockout counter collapses concurrent failures right after cool-off
+
+In the generated `login` handler, once a lock's cool-off has expired the local
+state is reset (`current_attempts = 0`) and a failed attempt takes the reset
+branch, which unconditionally writes `failed_attempts = 1`. Every concurrent
+request that read the same expired-lock row takes that same branch and writes
+the same `1` — so a parallel burst of N wrong-password attempts fired at the
+cool-off boundary counts as a single failure instead of N. An attacker can
+thereby stretch each cool-off cycle to (burst size + threshold) attempts
+rather than threshold. The normal path's `failed_attempts + 1` DB-side
+increment *is* atomic; only the reset branch collapses. Fix: make the reset
+branch a guarded atomic transition too, e.g. `UPDATE … SET failed_attempts =
+failed_attempts + 1, locked_at = NULL WHERE id = … AND locked_at <= expiry`
+after first zeroing the counter in the unlock path, or fold reset-and-count
+into one conditional increment. *(Credit: flagged by automated review on the
+audit PR and verified against the code.)*
+
+### L16. Lockout telemetry digest falls back to a public hard-coded salt
+
+The `account_locked` telemetry event salts its `account_id_digest` with
+`SECRET_KEY_BASE` or `AUTUMN_ADMIN_SECRET` — env vars that Autumn's canonical
+config path (`AUTUMN_SECURITY__SIGNING_SECRET` / `autumn.toml`) never sets —
+and otherwise uses the hard-coded literal `"autumn-lockout-fallback-salt"`.
+With a public salt, sequential integer account ids, and only 8 digest bytes
+logged, anyone with log access can enumerate `sha256(salt:id)` and reverse the
+pseudonymization cheaply. Fix: salt from the app's resolved signing key
+(`ResolvedSigningKeys`), which production boot already guarantees exists, and
+drop the static fallback. *(Credit: flagged by automated review on the audit
+PR and verified against the code.)*
+
 ---
 
 ## Notable strengths (verified, not assumed)
@@ -256,10 +300,13 @@ review on the audit PR and verified against the code.)*
   chain, password change/reset revoke remember chains (the TOTP, passkey, and
   email-change flows do not — see L13), `reauth_pw_ok`
   cleared so an email-only login can't shortcut a password reauth.
-- **Lockout**: atomic counters, non-enumerating lock responses, cool-off with
-  clean re-entry, success-path guarded against concurrent locking, salted
-  digest + truncated IP prefix in telemetry.
-- **TOTP**: per-step replay guard (`totp_last_used_step` CAS).
+- **Lockout**: DB-side atomic increment on the normal failure path (the
+  post-cool-off reset branch is not — see L15), non-enumerating lock
+  responses, cool-off with clean re-entry, success-path guarded against
+  concurrent locking, truncated IP prefix in telemetry (the digest salt has a
+  weak fallback — see L16).
+- **TOTP**: per-step replay guard (`totp_last_used_step` CAS); code
+  comparison is not constant-time — see L14.
 - **API tokens**: SHA-256 digest-only at rest (appropriate for 244-bit random
   tokens), scoped default-deny, atomic CTE rotation, blank-seed-token guard,
   scopes carried in request extensions rather than the session (no cookie

--- a/docs/reports/auth-pipeline-security-audit-2026-08.md
+++ b/docs/reports/auth-pipeline-security-audit-2026-08.md
@@ -26,8 +26,8 @@ rest everywhere, constant-time comparison at every secret check but one,
 session-id rotation at every privilege boundary, atomic single-use token
 consumption, JWT algorithm pinning derived from trusted key material, TOTP
 step replay guards, and non-enumerating responses with timing equalization on
-the email-based flows. The findings below are two medium-severity gaps and a
-set of low-severity hardening items.
+the email-based flows. The findings below are three medium-severity gaps and
+a set of low-severity hardening items.
 
 ---
 
@@ -82,6 +82,34 @@ running the value through the same `validate_signing_secret`-style checks at
 startup. (The endpoint is otherwise well-designed: non-enumerating response,
 empty-secret fail-closed, documented CSRF-exemption requirement.)
 
+### M3. The TOTP second-factor endpoint is brute-forceable (no throttle, no attempt limit)
+
+Generated `POST /login/verify` has neither a `#[throttle]` attribute nor any
+failed-attempt counter, and a failed guess returns "Invalid code." while
+leaving `totp_pending_id` in the session — so the pending login survives
+unlimited retries. An attacker who has the password (precisely the scenario
+2FA defends against) can therefore machine-guess the 6-digit code: ~10⁶
+values, with the ±1-step window accepting three codes per attempt, and no
+rate limit in the way. The account-lockout counters do not apply here (they
+are only touched in `login`).
+
+Each miss additionally loads **every** unused recovery code and runs a
+cost-12 bcrypt verify against each, so the same endpoint is a CPU
+amplification vector (~1 s of server CPU per guess with a default code set)
+— painful under load even when the guessing itself fails.
+
+The `reauth` TOTP branch shares the same shape (unlimited tries, full
+recovery-code bcrypt sweep per miss), though it at least demands the password
+on every attempt.
+
+Fix: throttle `/login/verify` like the magic-link routes
+(`#[throttle(limit = 5, per = "1m", key = "ip")]`), add a small
+per-pending-session attempt counter (e.g. 5 tries, then clear
+`totp_pending_id` and force re-login), and only fall through to the
+recovery-code sweep when the submitted value does not look like a 6-digit
+code. Apply the same attempt bound to the `reauth` branch. *(Credit: flagged
+by automated review on the audit PR and verified against the code.)*
+
 ---
 
 ## Low / hardening
@@ -115,7 +143,8 @@ lockout covers per-account brute force, but:
   and re-sends; the 1s timing pad is the only backpressure).
 
 Recommendation: mirror the magic-link posture — `#[throttle]` on both, and a
-per-email cooldown on forgot-password.
+per-email cooldown on forgot-password. The unthrottled TOTP verify endpoint
+is the sharper instance of this gap and is tracked separately as M3.
 
 ### L4. Small enumeration timing channel on login lockout bookkeeping
 
@@ -330,11 +359,13 @@ PR and verified against the code.)*
 
 ## Suggested fix order
 
-1. M1 (CSRF cookie `Secure` + `__Host-`; session binding as follow-up)
-2. M2 (constant-time admin-secret compare) — one-line fix
-3. L11/L12/L13 (atomic reset-token consumption; confirm-email GET→POST;
+1. M3 (throttle + attempt-bound the TOTP verify endpoint) — the one finding
+   that weakens a security guarantee outright
+2. M1 (CSRF cookie `Secure` + `__Host-`; session binding as follow-up)
+3. M2 (constant-time admin-secret compare) — one-line fix
+4. L11/L12/L13 (atomic reset-token consumption; confirm-email GET→POST;
    remember-chain revocation in the TOTP/passkey/email-change transactions) —
    small, invariant-restoring changes to the generated handlers
-4. L1/L2 (route generated code through the ProxyResolver seams)
-5. L3 (throttle login/forgot-password)
-6. Remaining L-items opportunistically.
+5. L1/L2 (route generated code through the ProxyResolver seams)
+6. L3 (throttle login/forgot-password)
+7. Remaining L-items opportunistically.

--- a/docs/reports/auth-pipeline-security-audit-2026-08.md
+++ b/docs/reports/auth-pipeline-security-audit-2026-08.md
@@ -22,7 +22,8 @@ TOCTOU).
 
 The pipeline is in very good shape. No critical or high-severity issues were
 found. The design repeatedly makes the hard-but-right choice: tokens hashed at
-rest everywhere, constant-time comparison at every secret check but one,
+rest everywhere, constant-time comparison at nearly every secret check (two
+exceptions — the admin secret in M2 and the TOTP code in L14),
 session-id rotation at every privilege boundary, atomic single-use token
 consumption, JWT algorithm pinning derived from trusted key material, TOTP
 step replay guards, and non-enumerating responses with timing equalization on
@@ -195,8 +196,12 @@ requests for one address all observe `count == 0` and each sends:
 - `magic_link_request` — counts recent unconsumed tokens, then inserts + mails.
 - `resend_confirmation` — counts by `confirm_token_expires_at`, then mails and
   *afterwards* updates the expiry (so all but the last link are invalidated).
-- `forgot_password` — re-mints and re-sends with only a 1s timing pad as
-  backpressure.
+- `forgot_password` — note this one is **not** a `count`-race: it does no
+  eligibility `COUNT` at all, and for every known address it *unconditionally*
+  overwrites the reset token and sends another email, with only a 1s timing pad
+  as backpressure. So its fix is a throttle + an actual per-email cooldown
+  (there is none today), not just an atomic issuance claim — the claim only
+  helps once a cooldown exists.
 
 Recommendation: `#[throttle]` **every** unauthenticated auth route
 (`login`, `signup`, `forgot_password`, `reset_password`, `magic_link_request`,
@@ -504,5 +509,8 @@ PR and verified against the code.)*
    remember-chain revocation in the TOTP/passkey/email-change transactions) —
    small, invariant-restoring changes to the generated handlers
 5. L1/L2 (route generated code through the ProxyResolver seams)
-6. L3 (throttle login/forgot-password)
+6. L3 (throttle the **whole** unauthenticated route class — `login`, `signup`,
+   `forgot_password`, `reset_password`, both magic-link POSTs,
+   `resend_confirmation`, `/login/verify` — plus reject-before-bcrypt/HIBP and
+   the atomic issuance claims; not just login + forgot-password)
 7. Remaining L-items opportunistically.

--- a/docs/reports/auth-pipeline-security-audit-2026-08.md
+++ b/docs/reports/auth-pipeline-security-audit-2026-08.md
@@ -168,33 +168,45 @@ record the proxy's IP. This fails safe (unspoofable) but shows users wrong
 "device" IPs and collapses lockout telemetry to one IP. Route it through the
 framework's `ClientAddr`/`ProxyResolver` seam instead.
 
-### L3. `/login`, `/forgot-password`, and `/signup` have no request throttle
+### L3. Unauthenticated routes lack throttling and do expensive work before rejection
 
-The magic-link routes carry `#[throttle(limit = 5, per = "1m", key = "ip")]`
-plus a per-email re-mint cooldown; `login`, `forgot_password`, and `signup`
-have neither (and global rate limiting is off by default). Account
-lockout covers per-account brute force, but:
-- one IP can spray one password across many accounts without friction;
-- `/forgot-password` can be used to email-bomb a victim (each request re-mints
-  and re-sends; the 1s timing pad is the only backpressure);
-- `/signup` runs the configured password policy (including the HIBP
-  k-anonymity lookup when breach-checking is enabled) **and** a cost-12 bcrypt
-  hash *before* the uniqueness-enforcing insert, so an attacker can submit a
-  policy-valid password with any address — even an already-registered one — and
-  burn a blocking bcrypt (plus an outbound HIBP request) on every call. That is
-  a direct CPU/-network amplification path on an unauthenticated route.
+Only the magic-link routes carry `#[throttle(limit = 5, per = "1m", key =
+"ip")]`; the rest of the public auth surface has no per-route throttle, and the
+global limiter is off by default. Two anti-patterns recur across these routes,
+so the fix is a class of routes rather than a single endpoint:
 
-Recommendation: `#[throttle]` all three, and a per-email cooldown on
-forgot-password. Caveat on "mirror the magic-link posture": the magic-link
-per-email cooldown is itself **not** race-safe — `magic_link_request` does a
-`SELECT count(...)` for a recent unconsumed token and *then* inserts, so
-concurrent requests for one address all observe `recent == 0` and each inserts
-a row and sends a mail (the per-IP `#[throttle]` bounds one IP but not
-distributed callers). Treat the cooldown as best-effort, not a guarantee, and
-close it with an atomic per-account issuance claim (a unique partial index on
-"live unconsumed token per user", or an `INSERT … ON CONFLICT DO NOTHING`
-gate). The unthrottled TOTP verify endpoint is the sharper instance of this
-family and is tracked separately as M3.
+**(a) Expensive work before the cheap rejection.** Several handlers run a
+cost-12 bcrypt hash and/or the HIBP k-anonymity lookup (when
+`[auth.password].breach_check` is on) *before* the check that would reject the
+request, turning each into an unauthenticated CPU/network amplifier:
+- `login` — bcrypt on every attempt (a dummy hash even for unknown emails, by
+  design for timing); one IP can also spray one password across many accounts.
+- `signup` — full password policy (incl. HIBP) **and** bcrypt *before* the
+  uniqueness insert, so a policy-valid password with any address (even a
+  registered one) burns both per call.
+- `reset_password` — `validate_password` (incl. HIBP) runs *before* the reset
+  token is queried, so any bogus token plus an arbitrary password triggers the
+  outbound HIBP request.
+
+**(b) Count-then-issue email races (TOCTOU) + email-bomb.** The per-email
+"cooldown" routes check eligibility with a `SELECT count(...)` and *then*
+send/insert, sending the mail before recording the new token, so concurrent
+requests for one address all observe `count == 0` and each sends:
+- `magic_link_request` — counts recent unconsumed tokens, then inserts + mails.
+- `resend_confirmation` — counts by `confirm_token_expires_at`, then mails and
+  *afterwards* updates the expiry (so all but the last link are invalidated).
+- `forgot_password` — re-mints and re-sends with only a 1s timing pad as
+  backpressure.
+
+Recommendation: `#[throttle]` **every** unauthenticated auth route
+(`login`, `signup`, `forgot_password`, `reset_password`, `magic_link_request`,
+`resend_confirmation`, and the `/login/magic/verify` + `/login/verify` POSTs);
+where feasible, reject cheaply (token/uniqueness lookup) *before* the bcrypt /
+HIBP work; and replace each count-then-issue email cooldown with an atomic
+per-account issuance claim (a unique partial index on "one live unconsumed
+token per user", or `INSERT … ON CONFLICT DO NOTHING`) so the cooldown is a
+guarantee rather than best-effort. The unthrottled TOTP verify endpoint is the
+sharpest instance of anti-pattern (a) and is tracked separately as M3.
 
 ### L4. Small enumeration timing channel on login lockout bookkeeping
 

--- a/docs/reports/auth-pipeline-security-audit-2026-08.md
+++ b/docs/reports/auth-pipeline-security-audit-2026-08.md
@@ -1,0 +1,231 @@
+# Authentication Pipeline Security Audit — 2026-08-14
+
+Scope: the full authentication pipeline in `autumn-web` and the code emitted by
+`autumn generate auth` —
+
+- `autumn/src/auth.rs` (password hashing, `RequireAuth`, `RequireApiToken`,
+  OAuth2/OIDC, API token stores), `auth/password.rs`, `auth/remember.rs`
+- `autumn/src/session.rs`, `session_redis.rs`, `entropy.rs`
+- `autumn/src/security/` (`csrf.rs`, `config.rs` signing keys, `headers.rs`,
+  `trusted_proxies.rs`, `submit_token.rs`, `rate_limit.rs` config surface,
+  `captcha.rs`), `autumn/src/step_up.rs`
+- `autumn-cli/src/generate/auth.rs` (generated login / logout / lockout /
+  forgot- & reset-password / magic-link / TOTP / remember-me / session-tracking
+  handlers), `autumn-cli/src/routes_audit.rs`
+
+Method: manual line-by-line review of the above, checked against OWASP ASVS
+session-management / authentication requirements and known attack classes
+(fixation, enumeration, timing, algorithm confusion, CSRF variants, replay,
+TOCTOU).
+
+## Verdict
+
+The pipeline is in very good shape. No critical or high-severity issues were
+found. The design repeatedly makes the hard-but-right choice: tokens hashed at
+rest everywhere, constant-time comparison at every secret check but one,
+session-id rotation at every privilege boundary, atomic single-use token
+consumption, JWT algorithm pinning derived from trusted key material, TOTP
+step replay guards, and non-enumerating responses with timing equalization on
+the email-based flows. The findings below are two medium-severity gaps and a
+set of low-severity hardening items.
+
+---
+
+## Medium
+
+### M1. CSRF cookie is never set with `Secure` (and the token is not bound to the session)
+
+`security/csrf.rs` builds the cookie as:
+
+```text
+{name}={token}; Path=/; SameSite=Lax; HttpOnly
+```
+
+unconditionally — there is no `Secure` attribute, in any profile. The session
+cookie defaults to `Secure` (and prod smart-defaults force it), the remember
+cookie sets it conditionally, but the CSRF cookie can always be set or
+overwritten over plaintext HTTP by an active network attacker.
+
+Because the scheme is double-submit (cookie value must equal the
+header/form/query value), a planted cookie plus a matching form value passes
+validation. HMAC signing raises the bar but does not close it: tokens are not
+bound to a session, so *any* legitimately-signed token (e.g. one the attacker
+minted by visiting the site) verifies for any victim it can be planted on.
+
+Recommendations, in increasing strength:
+1. Add `Secure` when the deployment is HTTPS (mirror `session.secure` /
+   the prod smart default).
+2. Use the `__Host-` cookie prefix by default so no subdomain or non-secure
+   context can plant it.
+3. Bind the token to the session: sign `{uuid}:{session_id}` rather than the
+   bare uuid, and verify against the current session id. This converts
+   double-submit into a session-bound synchronizer-equivalent and defeats
+   planted-cookie attacks entirely.
+
+### M2. Operator-unlock endpoint compares the admin secret non-constant-time
+
+Generated `POST /auth/admin/unlock` (`generate/auth.rs`):
+
+```rust
+if admin_secret.is_empty() || provided != admin_secret {
+```
+
+This is the only secret comparison in the whole pipeline that uses `!=`
+instead of a constant-time compare — everywhere else uses `subtle` or the
+`constant_time_eq` helpers. `AUTUMN_ADMIN_SECRET` also has no minimum-length
+validation, unlike the signing secret (32-byte minimum + weak-value denylist).
+
+Recommendation: compare via `autumn_web::auth::constant_time_eq`, and consider
+running the value through the same `validate_signing_secret`-style checks at
+startup. (The endpoint is otherwise well-designed: non-enumerating response,
+empty-secret fail-closed, documented CSRF-exemption requirement.)
+
+---
+
+## Low / hardening
+
+### L1. `remember_secure()` reads `X-Forwarded-Proto` directly, bypassing `ProxyResolver`
+
+`generate/auth.rs` decides the remember cookie's `Secure` attribute from a raw
+`x-forwarded-proto` header read. `security/trusted_proxies.rs` explicitly
+forbids this ("Never read X-Forwarded-* directly"), and the consequence is
+concrete: a deployment that terminates TLS in-process (the `acme` feature)
+sends no forwarded headers, so the remember cookie is **never** marked
+`Secure` there. Use `ClientScheme` / the resolver, or key off `session.secure`
+config like the session cookie does.
+
+### L2. Generated handlers use the TCP peer IP, not the resolved client IP
+
+`MaybeClientIp` reads `ConnectInfo` directly. Behind a proxy/LB, the
+active-sessions device list, remember-token rows, and lockout telemetry all
+record the proxy's IP. This fails safe (unspoofable) but shows users wrong
+"device" IPs and collapses lockout telemetry to one IP. Route it through the
+framework's `ClientAddr`/`ProxyResolver` seam instead.
+
+### L3. `/login` and `/forgot-password` have no request throttle
+
+The magic-link routes carry `#[throttle(limit = 5, per = "1m", key = "ip")]`
+plus a per-email re-mint cooldown; the password login and forgot-password
+routes have neither (and global rate limiting is off by default). Account
+lockout covers per-account brute force, but:
+- one IP can spray one password across many accounts without friction;
+- `/forgot-password` can be used to email-bomb a victim (each request re-mints
+  and re-sends; the 1s timing pad is the only backpressure).
+
+Recommendation: mirror the magic-link posture — `#[throttle]` on both, and a
+per-email cooldown on forgot-password.
+
+### L4. Small enumeration timing channel on login lockout bookkeeping
+
+Login equalizes bcrypt timing with a dummy hash (good), but a failed attempt
+on an *existing* account then performs 1–2 `UPDATE`s (failure counter /
+lock stamp) that an unknown-email attempt skips. That re-opens a millisecond-
+scale timing signal after the equalization. Forgot-password pads the whole
+handler to a 1s floor; doing the same on the login failure path (or performing
+a dummy write) would close it.
+
+### L5. `MemoryStore` sessions have no server-side expiry
+
+Cookie `Max-Age` is the only lifetime; the in-memory store never evicts, so a
+leaked session id stays valid until restart and long-lived processes grow
+unboundedly. It is dev-only (prod boot warns), but a periodic sweep with a
+stored expiry would make the default backend safe even when the warning is
+ignored (`allow_memory_in_production = true` exists, after all). The Redis
+backend already applies `SET EX max_age_secs` correctly.
+
+### L6. `trust_forwarded_headers = true` with no ranges/hops trusts every peer
+
+`ProxyResolver`: when forwarding trust is enabled but neither CIDR ranges nor
+`trusted_hops` are configured, every peer is trusted and the rightmost XFF
+entry wins — so a *direct* client can spoof its rate-limit/lockout identity by
+sending its own `X-Forwarded-For`. The dev default (loopback-only) and prod
+default (no trust) are both safe; this is purely the misconfiguration corner.
+A startup warning for "forwarding trusted but no boundary declared" would
+close the footgun.
+
+### L7. Custom profiles silently lose the prod security smart-defaults
+
+`staging`, `qa`, etc. get no smart defaults, so CSRF stays disabled and HSTS
+off unless configured — an operator who believes "staging is prod-like" ships
+without CSRF. Consider a boot note when a non-`dev` profile runs with
+`csrf.enabled = false`.
+
+### L8. bcrypt's 72-byte truncation is silent
+
+`hash_password` passes straight to bcrypt, which truncates input at 72 bytes.
+Two passwords sharing the first 72 bytes verify identically. Standard bcrypt
+behavior, but worth either documenting on `hash_password` or rejecting >72-byte
+passwords in `validate_password` (a max-length knob would also satisfy the
+ASVS "no silent truncation" requirement).
+
+### L9. Generated `read_cookie` accepts duplicate cookie names
+
+The framework's `session::get_cookie` and CSRF extractor reject duplicate
+same-name cookies (cookie-tossing defense); the generated `read_cookie` used
+for the remember cookie takes the first match. Theft-detection limits the
+impact, but the hygiene should match.
+
+### L10. CSRF token accepted from the URL query string
+
+`?_csrf=...` is accepted as a token carrier. Tokens in URLs leak into access
+logs, browser history, and (partially) Referer. The default Referrer-Policy
+mitigates cross-origin leakage; still, consider dropping query-string
+acceptance or gating it behind config.
+
+---
+
+## Notable strengths (verified, not assumed)
+
+- **Password storage**: bcrypt cost 12 via `spawn_blocking`; dummy-hash timing
+  equalization on both invalid-format hashes and unknown users (both dummy
+  hashes are well-formed 60-char `$2b$12$` values, so the equalizing verify
+  really runs).
+- **OIDC**: PKCE S256 always on; state validated constant-time and *not*
+  consumed on mismatch (attacker callbacks can't burn the pending login);
+  nonce required for id_token logins; verification algorithms pinned from the
+  JWK (never the token header) with HS*/`alg=none` rejected — with real
+  algorithm-confusion attack tests.
+- **Sessions**: server-side store, UUIDv4 ids from the OS CSPRNG, optional
+  HMAC-signed cookies with key rotation, duplicate-cookie (tossing) rejection,
+  id rotation at login/reset/magic-link/OAuth completion and logout, old id
+  destroyed in the store on rotation, deadline-cancelled requests never persist
+  partial session state, attacker-chosen cookie ids are never adopted (a miss
+  mints a fresh id).
+- **Signing secrets**: 32-byte production minimum, template-value denylist,
+  fail-fast boot validation, previous-key rotation grace.
+- **Reset/magic-link/confirm tokens**: 256-bit OS-random, digest-only at rest,
+  bounded TTLs, atomic single-use consumption (`UPDATE ... WHERE consumed_at
+  IS NULL RETURNING`), non-enumerating responses with 1s timing floors,
+  link-scanner-safe GET-then-POST consumption, lockout re-checked *after*
+  token consumption to close the TOCTOU race, magic-link deliberately denied
+  step-up freshness (email possession ≠ password knowledge).
+- **Remember-me**: Jaspan series/token scheme, hash-at-rest, constant-time
+  verify, CAS rotation with race re-evaluation, theft detection nukes the
+  chain, credential changes always revoke remember chains, `reauth_pw_ok`
+  cleared so an email-only login can't shortcut a password reauth.
+- **Lockout**: atomic counters, non-enumerating lock responses, cool-off with
+  clean re-entry, success-path guarded against concurrent locking, salted
+  digest + truncated IP prefix in telemetry.
+- **TOTP**: per-step replay guard (`totp_last_used_step` CAS).
+- **API tokens**: SHA-256 digest-only at rest (appropriate for 244-bit random
+  tokens), scoped default-deny, atomic CTE rotation, blank-seed-token guard,
+  scopes carried in request extensions rather than the session (no cookie
+  leakage onto later requests).
+- **CSRF layer mechanics**: normalized-path exemption matching (dot-segment
+  tricks can't reach an exemption), bounded body scan with lossless streaming
+  reconstruction, boundary parsing shared with the real multipart extractor.
+- **Headers**: CSP without `unsafe-eval`, `frame-ancestors 'none'`,
+  `X-Frame-Options: DENY`, nosniff, HSTS prod default.
+- **Verifiability**: `autumn routes audit` emits a fail-closed security
+  manifest — every route must be provably `framework`/`gated`/`public` or the
+  build gate fails — with honest provenance tags (`provable` vs `declared` vs
+  `runtime-only`). Session cookie parsing is additionally fuzzed
+  (`fuzz/fuzz_targets/session.rs`).
+
+## Suggested fix order
+
+1. M1 (CSRF cookie `Secure` + `__Host-`; session binding as follow-up)
+2. M2 (constant-time admin-secret compare) — one-line fix
+3. L1/L2 (route generated code through the ProxyResolver seams)
+4. L3 (throttle login/forgot-password)
+5. Remaining L-items opportunistically.

--- a/docs/reports/auth-pipeline-security-audit-2026-08.md
+++ b/docs/reports/auth-pipeline-security-audit-2026-08.md
@@ -248,10 +248,16 @@ verified against the code.)*
 - **Headers**: CSP without `unsafe-eval`, `frame-ancestors 'none'`,
   `X-Frame-Options: DENY`, nosniff, HSTS prod default.
 - **Verifiability**: `autumn routes audit` emits a fail-closed security
-  manifest — every route must be provably `framework`/`gated`/`public` or the
-  build gate fails — with honest provenance tags (`provable` vs `declared` vs
-  `runtime-only`). Session cookie parsing is additionally fuzzed
-  (`fuzz/fuzz_targets/session.rs`).
+  manifest — every *dump-enumerated* route must be provably
+  `framework`/`gated`/`public` or the build gate fails — with honest
+  provenance tags (`provable` vs `declared` vs `runtime-only`). Coverage
+  caveat: the opt-in serve-path HTTP surfaces (MCP, inbound-mail, storage,
+  SEO) are injected only on the serve path, after the dump early-exit, so the
+  gate cannot classify or fail on them; the manifest discloses this honestly
+  in its `excluded` list (`serve_path_routers`, eventual provenance
+  `provable`) rather than silently omitting it, and closing that gap is the
+  natural next increment of the gate. Session cookie parsing is additionally
+  fuzzed (`fuzz/fuzz_targets/session.rs`).
 
 ## Suggested fix order
 

--- a/docs/reports/auth-pipeline-security-audit-2026-08.md
+++ b/docs/reports/auth-pipeline-security-audit-2026-08.md
@@ -120,6 +120,13 @@ password per attempt: after one successful password check, the
 TOTP/recovery guesses, so second-factor guessing through `/reauth` is
 password-free for the rest of that window.
 
+`two_factor_disable` (`POST /account/2fa/disable`) is a third instance:
+it accepts a current TOTP code *or* the password as re-authentication and has
+no throttle or attempt counter, so an attacker holding an authenticated
+session can machine-guess the 6-digit code until one matches and then turn the
+victim's second factor off. It does correctly consume a matched step via the
+replay guard, but that does not bound *guessing*.
+
 Fix: throttle `/login/verify` like the magic-link routes
 (`#[throttle(limit = 5, per = "1m", key = "ip")]`), add a small
 per-pending-session attempt counter (e.g. 5 tries, then clear
@@ -127,8 +134,8 @@ per-pending-session attempt counter (e.g. 5 tries, then clear
 recovery-code sweep when the submitted value does not look like a 6-digit
 code. Apply the same attempt bound to the `reauth` branch, clearing
 `reauth_pw_ok` after N failed second-factor guesses so the password gate
-re-engages. *(Credit: flagged by automated review on the audit PR and
-verified against the code.)*
+re-engages, and to `two_factor_disable`. *(Credit: flagged by automated review
+on the audit PR and verified against the code.)*
 
 ---
 
@@ -272,6 +279,20 @@ comment. Fix: add the same `{rem_table}` user-scoped delete to those five
 transactions (optionally sparing the current device's chain, mirroring the
 `token_digest.ne(current)` session carve-out). *(Credit: flagged by automated
 review on the audit PR and verified against the code.)*
+
+### L13a. `passkey_revoke` deletes a credential with no fresh-auth check
+
+`POST /passkeys/revoke` is only `#[secured]` — no `#[step_up]`, and no inline
+password/factor check — even though its sibling `passkey_register_begin`
+requires `#[step_up]` and `two_factor_disable` does an inline re-auth. So
+anyone with a live authenticated session (a briefly unattended browser, a
+stolen-but-not-yet-rotated session cookie) can delete every passkey without
+proving fresh possession of any credential, stripping the account's strongest
+factor. This is a credential-management gap distinct from the remember-chain
+omission (L13) on the same handler. Fix: add `#[step_up]` to `passkey_revoke`
+(matching `passkey_register_begin`), or an inline re-auth as
+`two_factor_disable` does. *(Credit: flagged by automated review on the audit
+PR and verified against the code.)*
 
 ### L14. Generated TOTP code comparison is not constant-time
 

--- a/docs/reports/auth-pipeline-security-audit-2026-08.md
+++ b/docs/reports/auth-pipeline-security-audit-2026-08.md
@@ -168,19 +168,33 @@ record the proxy's IP. This fails safe (unspoofable) but shows users wrong
 "device" IPs and collapses lockout telemetry to one IP. Route it through the
 framework's `ClientAddr`/`ProxyResolver` seam instead.
 
-### L3. `/login` and `/forgot-password` have no request throttle
+### L3. `/login`, `/forgot-password`, and `/signup` have no request throttle
 
 The magic-link routes carry `#[throttle(limit = 5, per = "1m", key = "ip")]`
-plus a per-email re-mint cooldown; the password login and forgot-password
-routes have neither (and global rate limiting is off by default). Account
+plus a per-email re-mint cooldown; `login`, `forgot_password`, and `signup`
+have neither (and global rate limiting is off by default). Account
 lockout covers per-account brute force, but:
 - one IP can spray one password across many accounts without friction;
 - `/forgot-password` can be used to email-bomb a victim (each request re-mints
-  and re-sends; the 1s timing pad is the only backpressure).
+  and re-sends; the 1s timing pad is the only backpressure);
+- `/signup` runs the configured password policy (including the HIBP
+  k-anonymity lookup when breach-checking is enabled) **and** a cost-12 bcrypt
+  hash *before* the uniqueness-enforcing insert, so an attacker can submit a
+  policy-valid password with any address — even an already-registered one — and
+  burn a blocking bcrypt (plus an outbound HIBP request) on every call. That is
+  a direct CPU/-network amplification path on an unauthenticated route.
 
-Recommendation: mirror the magic-link posture — `#[throttle]` on both, and a
-per-email cooldown on forgot-password. The unthrottled TOTP verify endpoint
-is the sharper instance of this gap and is tracked separately as M3.
+Recommendation: `#[throttle]` all three, and a per-email cooldown on
+forgot-password. Caveat on "mirror the magic-link posture": the magic-link
+per-email cooldown is itself **not** race-safe — `magic_link_request` does a
+`SELECT count(...)` for a recent unconsumed token and *then* inserts, so
+concurrent requests for one address all observe `recent == 0` and each inserts
+a row and sends a mail (the per-IP `#[throttle]` bounds one IP but not
+distributed callers). Treat the cooldown as best-effort, not a guarantee, and
+close it with an atomic per-account issuance claim (a unique partial index on
+"live unconsumed token per user", or an `INSERT … ON CONFLICT DO NOTHING`
+gate). The unthrottled TOTP verify endpoint is the sharper instance of this
+family and is tracked separately as M3.
 
 ### L4. Small enumeration timing channel on login lockout bookkeeping
 

--- a/docs/reports/auth-pipeline-security-audit-2026-08.md
+++ b/docs/reports/auth-pipeline-security-audit-2026-08.md
@@ -350,6 +350,28 @@ in `delete_account`, delete the `{rem_table}` and `{sess_table}` rows for the
 user and emit the remember-clear cookie, exactly as `logout` does. *(Credit:
 flagged by automated review on the audit PR and verified against the code.)*
 
+### L13c. Pre-2FA pending handoffs survive credential changes and deletion
+
+A TOTP login parks `totp_pending_id` in the session and returns to
+`/login/verify` *before* `record_login_session`, so the pre-second-factor
+state has **no** tracked-session row. Every revocation this report recommends —
+`change_password`/`reset_password` deleting `{sess_table}` rows, the L13b
+deletion fix, `revoke_on_credential_change` — operates on tracked rows, so none
+of them can reach a pending handoff. Meanwhile `login_verify` promotes a
+pending handoff purely on `totp_pending_id` + a valid second factor; it never
+re-checks whether the password changed or the account entered
+`delete_scheduled_at` since the handoff was minted. Chained with M3's unbounded
+guessing, an attacker who already submitted the victim's *old* password can
+keep guessing the second factor **after** the victim changes their password or
+schedules deletion, then complete `login_verify`, mint a fresh tracked session,
+and even cancel the pending deletion — the credential change it was supposed to
+lock them out. Fix: bind the pending handoff to a password/credential version
+(and to non-deletion) and re-verify it in `login_verify`, or give the pending
+state a tracked/revocable row so credential-change revocation covers it too.
+Fixing M3 (bounding the guesses) reduces but does not eliminate this, since the
+promotion still skips the freshness re-check. *(Credit: flagged by automated
+review on the audit PR and verified against the code.)*
+
 ### L14. Generated TOTP code comparison is not constant-time
 
 `verify_totp_code` compares `expected == candidate` with a plain string

--- a/docs/reports/auth-pipeline-security-audit-2026-08.md
+++ b/docs/reports/auth-pipeline-security-audit-2026-08.md
@@ -105,16 +105,21 @@ amplification vector (~1 s of server CPU per guess with a default code set)
 — painful under load even when the guessing itself fails.
 
 The `reauth` TOTP branch shares the same shape (unlimited tries, full
-recovery-code bcrypt sweep per miss), though it at least demands the password
-on every attempt.
+recovery-code bcrypt sweep per miss) — and it does **not** re-demand the
+password per attempt: after one successful password check, the
+`reauth_pw_ok` marker stays valid for 10 minutes and is left intact by failed
+TOTP/recovery guesses, so second-factor guessing through `/reauth` is
+password-free for the rest of that window.
 
 Fix: throttle `/login/verify` like the magic-link routes
 (`#[throttle(limit = 5, per = "1m", key = "ip")]`), add a small
 per-pending-session attempt counter (e.g. 5 tries, then clear
 `totp_pending_id` and force re-login), and only fall through to the
 recovery-code sweep when the submitted value does not look like a 6-digit
-code. Apply the same attempt bound to the `reauth` branch. *(Credit: flagged
-by automated review on the audit PR and verified against the code.)*
+code. Apply the same attempt bound to the `reauth` branch, clearing
+`reauth_pw_ok` after N failed second-factor guesses so the password gate
+re-engages. *(Credit: flagged by automated review on the audit PR and
+verified against the code.)*
 
 ---
 
@@ -273,7 +278,8 @@ code.)*
 
 ### L15. Lockout counter collapses concurrent failures right after cool-off
 
-In the generated `login` handler, once a lock's cool-off has expired the local
+In the generated `login` handler — and identically in `reauth`, which
+duplicates the lockout block — once a lock's cool-off has expired the local
 state is reset (`current_attempts = 0`) and a failed attempt takes the reset
 branch, which unconditionally writes `failed_attempts = 1`. Every concurrent
 request that read the same expired-lock row takes that same branch and writes

--- a/docs/reports/auth-pipeline-security-audit-2026-08.md
+++ b/docs/reports/auth-pipeline-security-audit-2026-08.md
@@ -203,9 +203,17 @@ requests for one address all observe `count == 0` and each sends:
   (there is none today), not just an atomic issuance claim — the claim only
   helps once a cooldown exists.
 
+A third case is the operator-unlock route `POST /auth/admin/unlock`: it has no
+`#[throttle]`, and (per M2) `AUTUMN_ADMIN_SECRET` has no minimum length, so a
+remote caller can make unlimited online guesses against the admin secret. Its
+docstring recommends a VPN/load-balancer allowlist, but that is an operator
+step, not a default — an unrestricted deployment is exposed. Throttle it and/or
+scope the "protect with network controls" advice as mandatory, not optional.
+
 Recommendation: `#[throttle]` **every** unauthenticated auth route
 (`login`, `signup`, `forgot_password`, `reset_password`, `magic_link_request`,
-`resend_confirmation`, and the `/login/magic/verify` + `/login/verify` POSTs);
+`resend_confirmation`, the `/login/magic/verify` + `/login/verify` POSTs, and
+`/auth/admin/unlock`);
 where feasible, reject cheaply (token/uniqueness lookup) *before* the bcrypt /
 HIBP work; and replace each count-then-issue email cooldown with an atomic
 per-account issuance claim (a unique partial index on "one live unconsumed
@@ -386,7 +394,16 @@ lock them out. Fix: bind the pending handoff to a password/credential version
 (and to non-deletion) and re-verify it in `login_verify`, or give the pending
 state a tracked/revocable row so credential-change revocation covers it too.
 Fixing M3 (bounding the guesses) reduces but does not eliminate this, since the
-promotion still skips the freshness re-check. *(Credit: flagged by automated
+promotion still skips the freshness re-check.
+
+Same-shaped omission for lockout specifically: `login_verify` reloads the user
+by `totp_pending_id` and promotes on a valid factor **without** re-checking
+`locked_at` — so a password submitted just before another request crossed the
+lockout threshold lets the attacker keep guessing (M3) and authenticate during
+the active cool-off. `magic_link_verify` already does exactly this guarded
+lock re-check (its #1777 defense-in-depth block); `login_verify` should mirror
+it (a guarded `UPDATE … WHERE locked_at IS NULL OR locked_at <= now - cooloff`,
+rejecting on zero rows) *before* promoting. *(Credit: flagged by automated
 review on the audit PR and verified against the code.)*
 
 ### L14. Generated TOTP code comparison is not constant-time

--- a/docs/reports/auth-pipeline-security-audit-2026-08.md
+++ b/docs/reports/auth-pipeline-security-audit-2026-08.md
@@ -210,10 +210,16 @@ docstring recommends a VPN/load-balancer allowlist, but that is an operator
 step, not a default — an unrestricted deployment is exposed. Throttle it and/or
 scope the "protect with network controls" advice as mandatory, not optional.
 
-Recommendation: `#[throttle]` **every** unauthenticated auth route
-(`login`, `signup`, `forgot_password`, `reset_password`, `magic_link_request`,
-`resend_confirmation`, the `/login/magic/verify` + `/login/verify` POSTs, and
-`/auth/admin/unlock`);
+Recommendation: `#[throttle]` **every generated unauthenticated auth route,
+whether or not enumerated here** — the base set (`login`, `signup`,
+`forgot_password`, `reset_password`, `magic_link_request`,
+`resend_confirmation`, the `/login/magic/verify` + `/login/verify` POSTs,
+`/auth/admin/unlock`) **and the opt-in flows**: under `--oauth` the
+`oauth_redirect` + `oauth_callback` routes (each callback drives an outbound
+token exchange, so it is a network amplifier), and under `--passkeys` the
+`passkey_login_begin` / `passkey_login_finish` POSTs (each runs a WebAuthn
+ceremony, DB loads, and signature verification). Treat "throttle every public
+auth handler" as the invariant rather than a checklist to enumerate;
 where feasible, reject cheaply (token/uniqueness lookup) *before* the bcrypt /
 HIBP work; and replace each count-then-issue email cooldown with an atomic
 per-account issuance claim (a unique partial index on "one live unconsumed
@@ -396,15 +402,25 @@ state a tracked/revocable row so credential-change revocation covers it too.
 Fixing M3 (bounding the guesses) reduces but does not eliminate this, since the
 promotion still skips the freshness re-check.
 
-Same-shaped omission for lockout specifically: `login_verify` reloads the user
-by `totp_pending_id` and promotes on a valid factor **without** re-checking
-`locked_at` — so a password submitted just before another request crossed the
-lockout threshold lets the attacker keep guessing (M3) and authenticate during
-the active cool-off. `magic_link_verify` already does exactly this guarded
-lock re-check (its #1777 defense-in-depth block); `login_verify` should mirror
-it (a guarded `UPDATE … WHERE locked_at IS NULL OR locked_at <= now - cooloff`,
-rejecting on zero rows) *before* promoting. *(Credit: flagged by automated
-review on the audit PR and verified against the code.)*
+Same-shaped omission for lockout specifically, and it generalizes to **every
+login-completion handler**: only `login` (the password path) and
+`magic_link_verify` (its #1777 defense-in-depth block) perform the guarded
+`locked_at` re-check. The other completion paths do not:
+- `login_verify` reloads by `totp_pending_id` and promotes on a valid factor
+  without re-checking `locked_at`, so a password submitted just before another
+  request crossed the threshold lets the attacker keep guessing (M3) and
+  authenticate during the active cool-off.
+- `passkey_login_finish` (under `--passkeys`) selects only `email` and
+  `email_confirmed_at` before writing the session — it never reads `locked_at`
+  at all, so a locked account authenticates via passkey **unconditionally**,
+  fully bypassing lockout (a broader hole than the `login_verify` race).
+
+The rule: every path that creates an authenticated session must run the same
+guarded `UPDATE … WHERE locked_at IS NULL OR locked_at <= now - cooloff`
+(reject on zero rows) that `login`/`magic_link_verify` already do — this
+includes `login_verify`, `passkey_login_finish`, and any future
+login-completion handler. *(Credit: flagged by automated review on the audit
+PR and verified against the code.)*
 
 ### L14. Generated TOTP code comparison is not constant-time
 
@@ -526,8 +542,11 @@ PR and verified against the code.)*
    remember-chain revocation in the TOTP/passkey/email-change transactions) —
    small, invariant-restoring changes to the generated handlers
 5. L1/L2 (route generated code through the ProxyResolver seams)
-6. L3 (throttle the **whole** unauthenticated route class — `login`, `signup`,
-   `forgot_password`, `reset_password`, both magic-link POSTs,
-   `resend_confirmation`, `/login/verify` — plus reject-before-bcrypt/HIBP and
-   the atomic issuance claims; not just login + forgot-password)
+6. L3 (throttle the whole unauthenticated route class — see L3's authoritative
+   inventory, which covers the base routes plus `/auth/admin/unlock` and the
+   opt-in OAuth/passkey handlers — plus reject-before-bcrypt/HIBP and the
+   atomic issuance claims)
+7. The lockout-recheck rule from L13c: every login-completion handler
+   (`login_verify`, `passkey_login_finish`) must re-check `locked_at` before
+   creating a session, matching `login`/`magic_link_verify`
 7. Remaining L-items opportunistically.

--- a/docs/reports/auth-pipeline-security-audit-2026-08.md
+++ b/docs/reports/auth-pipeline-security-audit-2026-08.md
@@ -277,8 +277,18 @@ which frames exactly these events as credential changes, and with
 `change_password`'s own "chains are ALWAYS revoked on a credential change"
 comment. Fix: add the same `{rem_table}` user-scoped delete to those five
 transactions (optionally sparing the current device's chain, mirroring the
-`token_digest.ne(current)` session carve-out). *(Credit: flagged by automated
-review on the audit PR and verified against the code.)*
+`token_digest.ne(current)` session carve-out).
+
+A sixth path has the same gap even though it *is* a password reset: when the
+account has TOTP enabled, `reset_password` parks the new digest and returns
+*before* its own remember-chain delete, and the deferred commit that finishes
+the reset in `login_verify` updates the password and revokes sessions but
+**never** deletes the remember rows. So a TOTP-enabled account's password
+reset — the exact "old password compromised" case — leaves remember chains
+live, contradicting the direct-path guarantee. The same `{rem_table}` delete
+must be added to the deferred `login_verify` reset transaction too.
+*(Credit: flagged by automated review on the audit PR and verified against the
+code.)*
 
 ### L13a. `passkey_revoke` deletes a credential with no fresh-auth check
 
@@ -372,8 +382,9 @@ PR and verified against the code.)*
   knowledge).
 - **Remember-me**: Jaspan series/token scheme, hash-at-rest, constant-time
   verify, CAS rotation with race re-evaluation, theft detection nukes the
-  chain, password change/reset revoke remember chains (the TOTP, passkey, and
-  email-change flows do not — see L13), `reauth_pw_ok`
+  chain, the direct password change/reset paths revoke remember chains (but
+  the TOTP-deferred reset and the TOTP/passkey/email-change flows do not — see
+  L13), `reauth_pw_ok`
   cleared so an email-only login can't shortcut a password reauth.
 - **Lockout**: DB-side atomic increment on the normal failure path (the
   post-cool-off reset branch is not — see L15), non-enumerating lock

--- a/docs/reports/auth-pipeline-security-audit-2026-08.md
+++ b/docs/reports/auth-pipeline-security-audit-2026-08.md
@@ -48,9 +48,18 @@ overwritten over plaintext HTTP by an active network attacker.
 
 Because the scheme is double-submit (cookie value must equal the
 header/form/query value), a planted cookie plus a matching form value passes
-validation. HMAC signing raises the bar but does not close it: tokens are not
-bound to a session, so *any* legitimately-signed token (e.g. one the attacker
-minted by visiting the site) verifies for any victim it can be planted on.
+validation. Prerequisite: the forged request must be *same-site* — on an
+ordinary cross-site form POST, `SameSite=Lax` keeps the cookie at home and
+the check fails on the absent cookie alone. The planted-cookie bypass is
+therefore live for an attacker with a same-site vantage: a controlled or
+compromised sibling subdomain (which can also set parent-domain cookies), or
+an active network attacker injecting into any plaintext-HTTP page of the site
+(enabled by the missing `Secure`). HMAC signing raises the bar but does not
+close it for those attackers: tokens are not bound to a session, so *any*
+legitimately-signed token (e.g. one the attacker minted by visiting the site)
+verifies for any victim it can be planted on. Severity stays medium as a
+defense-in-depth failure — the CSRF layer exists precisely for the contexts
+where SameSite alone doesn't hold, and both gaps are cheap to fix.
 
 Recommendations, in increasing strength:
 1. Add `Secure` when the deployment is HTTPS (mirror `session.secure` /

--- a/docs/reports/auth-pipeline-security-audit-2026-08.md
+++ b/docs/reports/auth-pipeline-security-audit-2026-08.md
@@ -137,8 +137,12 @@ backend already applies `SET EX max_age_secs` correctly.
 
 `ProxyResolver`: when forwarding trust is enabled but neither CIDR ranges nor
 `trusted_hops` are configured, every peer is trusted and the rightmost XFF
-entry wins — so a *direct* client can spoof its rate-limit/lockout identity by
-sending its own `X-Forwarded-For`. The dev default (loopback-only) and prod
+entry wins — so a *direct* client can spoof the identity seen by
+resolver-backed consumers (the global rate limiter's IP keying, `ClientAddr` /
+`ClientHost` / `ClientScheme` extractors, access logs) by sending its own
+`X-Forwarded-For`. Account lockout is unaffected: its counters are
+account-keyed and its IP telemetry reads unspoofable `ConnectInfo` (see L2).
+The dev default (loopback-only) and prod
 default (no trust) are both safe; this is purely the misconfiguration corner.
 A startup warning for "forwarding trusted but no boundary declared" would
 close the footgun.
@@ -201,6 +205,23 @@ variant (`confirm_email_change`) has the same GET-consumption shape and should
 move with it. *(Credit: flagged by automated review on the audit PR and
 verified against the code.)*
 
+### L13. TOTP/passkey/email-change credential flows do not revoke remember chains
+
+`change_password` and `reset_password` delete the user's remember-token rows
+inside their transactions ("the old password is compromised"), but the other
+credential-changing flows do not: `two_factor_confirm`, `two_factor_disable`,
+`passkey_register_finish`, `passkey_revoke`, and `confirm_email_change` all
+revoke tracked *session* rows (under `revoke_on_credential_change`) yet leave
+the remember-token table untouched. A stolen remember cookie therefore
+survives 2FA enrollment/disable and passkey add/remove and can re-establish a
+login afterwards — inconsistent with the `[auth.sessions]` documentation,
+which frames exactly these events as credential changes, and with
+`change_password`'s own "chains are ALWAYS revoked on a credential change"
+comment. Fix: add the same `{rem_table}` user-scoped delete to those five
+transactions (optionally sparing the current device's chain, mirroring the
+`token_digest.ne(current)` session carve-out). *(Credit: flagged by automated
+review on the audit PR and verified against the code.)*
+
 ---
 
 ## Notable strengths (verified, not assumed)
@@ -232,7 +253,8 @@ verified against the code.)*
   knowledge).
 - **Remember-me**: Jaspan series/token scheme, hash-at-rest, constant-time
   verify, CAS rotation with race re-evaluation, theft detection nukes the
-  chain, credential changes always revoke remember chains, `reauth_pw_ok`
+  chain, password change/reset revoke remember chains (the TOTP, passkey, and
+  email-change flows do not — see L13), `reauth_pw_ok`
   cleared so an email-only login can't shortcut a password reauth.
 - **Lockout**: atomic counters, non-enumerating lock responses, cool-off with
   clean re-entry, success-path guarded against concurrent locking, salted
@@ -263,8 +285,9 @@ verified against the code.)*
 
 1. M1 (CSRF cookie `Secure` + `__Host-`; session binding as follow-up)
 2. M2 (constant-time admin-secret compare) — one-line fix
-3. L11/L12 (atomic reset-token consumption; confirm-email GET→POST) — small,
-   invariant-restoring changes to the generated handlers
+3. L11/L12/L13 (atomic reset-token consumption; confirm-email GET→POST;
+   remember-chain revocation in the TOTP/passkey/email-change transactions) —
+   small, invariant-restoring changes to the generated handlers
 4. L1/L2 (route generated code through the ProxyResolver seams)
 5. L3 (throttle login/forgot-password)
 6. Remaining L-items opportunistically.

--- a/docs/reports/auth-pipeline-security-audit-2026-08.md
+++ b/docs/reports/auth-pipeline-security-audit-2026-08.md
@@ -127,6 +127,13 @@ session can machine-guess the 6-digit code until one matches and then turn the
 victim's second factor off. It does correctly consume a matched step via the
 replay guard, but that does not bound *guessing*.
 
+`two_factor_confirm` (`POST /account/2fa/confirm`) is a fourth: an
+authenticated session holding an abandoned `totp_pending_secret` can guess the
+current 6-digit value with no throttle or attempt counter (the pending secret
+survives every failed guess), then enable 2FA and receive the freshly minted
+recovery codes — effectively taking over the account's second factor from a
+merely-authenticated session.
+
 Fix: throttle `/login/verify` like the magic-link routes
 (`#[throttle(limit = 5, per = "1m", key = "ip")]`), add a small
 per-pending-session attempt counter (e.g. 5 tries, then clear
@@ -134,8 +141,10 @@ per-pending-session attempt counter (e.g. 5 tries, then clear
 recovery-code sweep when the submitted value does not look like a 6-digit
 code. Apply the same attempt bound to the `reauth` branch, clearing
 `reauth_pw_ok` after N failed second-factor guesses so the password gate
-re-engages, and to `two_factor_disable`. *(Credit: flagged by automated review
-on the audit PR and verified against the code.)*
+re-engages, and to `two_factor_disable` and `two_factor_confirm` (for the
+latter, drop `totp_pending_secret` after N failed guesses so enrollment must
+restart). *(Credit: flagged by automated review on the audit PR and verified
+against the code.)*
 
 ---
 
@@ -303,6 +312,21 @@ omission (L13) on the same handler. Fix: add `#[step_up]` to `passkey_revoke`
 (matching `passkey_register_begin`), or an inline re-auth as
 `two_factor_disable` does. *(Credit: flagged by automated review on the audit
 PR and verified against the code.)*
+
+### L13b. Scheduled account deletion doesn't revoke sessions or remember chains
+
+Generated `delete_account` (`POST /account/delete`, the 30-day-grace GDPR
+path) stamps `delete_scheduled_at` and calls `session.destroy()` — but nothing
+else. It does not delete the user's remember-token rows, clear the remember
+cookie, or revoke other tracked sessions. Because the account row survives the
+grace window, the global `remember_me` middleware silently re-authenticates
+the user from their remember cookie on the very next request, and any other
+logged-in devices stay live. So "delete my account" neither logs the user out
+everywhere nor stops a stolen remember cookie. (The immediate
+`account_destroy` path is fine — its row delete cascades to sessions.) Fix:
+in `delete_account`, delete the `{rem_table}` and `{sess_table}` rows for the
+user and emit the remember-clear cookie, exactly as `logout` does. *(Credit:
+flagged by automated review on the audit PR and verified against the code.)*
 
 ### L14. Generated TOTP code comparison is not constant-time
 

--- a/docs/reports/auth-pipeline-security-audit-2026-08.md
+++ b/docs/reports/auth-pipeline-security-audit-2026-08.md
@@ -172,6 +172,35 @@ logs, browser history, and (partially) Referer. The default Referrer-Policy
 mitigates cross-origin leakage; still, consider dropping query-string
 acceptance or gating it behind config.
 
+### L11. Reset tokens are not atomically consumed
+
+Generated `reset_password` SELECTs the user by `reset_token_digest`, but the
+subsequent transaction UPDATEs the row by `find(user_id)` only — it never
+re-checks the digest. Two concurrent POSTs presenting the same valid token can
+both pass the SELECT and both commit, with the second password overwriting the
+first (each also rotating/revoking sessions). Exploitability is low — both
+requests must already hold the secret token — but it breaks the single-use
+invariant the magic-link and confirm-email flows enforce. Fix: add
+`.filter(reset_token_digest.eq(&token_digest))` to the in-transaction UPDATE
+(or consume via the same `UPDATE … RETURNING` pattern) and treat zero affected
+rows as an invalid link. *(Credit: flagged by automated review on the audit PR
+and verified against the code.)*
+
+### L12. `confirm_email` consumes its token — and grants a session — on a bare GET
+
+`GET /auth/confirm/{token}` atomically consumes the token (good) but does so
+directly on the GET, unlike magic-link's scanner-safe non-consuming GET →
+confirming POST. Consequences: (a) an email link-scanner or preview bot that
+follows the URL burns the single-use token before the human clicks, leaving
+them at the "invalid or expired" page and forcing a resend; (b) a
+session-granting, CSRF-exempt-by-method GET is login-CSRF-shaped — a victim
+who top-level-navigates an attacker's own confirm link is silently logged into
+the attacker's account. Recommendation: adopt the magic-link pattern (GET
+renders a confirm form, POST consumes), which fixes both. The email-change
+variant (`confirm_email_change`) has the same GET-consumption shape and should
+move with it. *(Credit: flagged by automated review on the audit PR and
+verified against the code.)*
+
 ---
 
 ## Notable strengths (verified, not assumed)
@@ -194,11 +223,13 @@ acceptance or gating it behind config.
 - **Signing secrets**: 32-byte production minimum, template-value denylist,
   fail-fast boot validation, previous-key rotation grace.
 - **Reset/magic-link/confirm tokens**: 256-bit OS-random, digest-only at rest,
-  bounded TTLs, atomic single-use consumption (`UPDATE ... WHERE consumed_at
-  IS NULL RETURNING`), non-enumerating responses with 1s timing floors,
-  link-scanner-safe GET-then-POST consumption, lockout re-checked *after*
-  token consumption to close the TOCTOU race, magic-link deliberately denied
-  step-up freshness (email possession ≠ password knowledge).
+  bounded TTLs, non-enumerating responses with 1s timing floors. Magic-link
+  and confirm-email consume atomically (`UPDATE … RETURNING` on the digest);
+  reset does not — see L11. Magic-link additionally uses the link-scanner-safe
+  non-consuming GET → confirming POST pattern (confirm-email does not — see
+  L12), re-checks lockout *after* token consumption to close the TOCTOU race,
+  and is deliberately denied step-up freshness (email possession ≠ password
+  knowledge).
 - **Remember-me**: Jaspan series/token scheme, hash-at-rest, constant-time
   verify, CAS rotation with race re-evaluation, theft detection nukes the
   chain, credential changes always revoke remember chains, `reauth_pw_ok`
@@ -226,6 +257,8 @@ acceptance or gating it behind config.
 
 1. M1 (CSRF cookie `Secure` + `__Host-`; session binding as follow-up)
 2. M2 (constant-time admin-secret compare) — one-line fix
-3. L1/L2 (route generated code through the ProxyResolver seams)
-4. L3 (throttle login/forgot-password)
-5. Remaining L-items opportunistically.
+3. L11/L12 (atomic reset-token consumption; confirm-email GET→POST) — small,
+   invariant-restoring changes to the generated handlers
+4. L1/L2 (route generated code through the ProxyResolver seams)
+5. L3 (throttle login/forgot-password)
+6. Remaining L-items opportunistically.

--- a/docs/reports/auth-pipeline-security-audit-2026-08.md
+++ b/docs/reports/auth-pipeline-security-audit-2026-08.md
@@ -276,17 +276,25 @@ verified against the code.)*
 
 `change_password` and `reset_password` delete the user's remember-token rows
 inside their transactions ("the old password is compromised"), but the other
-credential-changing flows do not: `two_factor_confirm`, `two_factor_disable`,
-`passkey_register_finish`, `passkey_revoke`, and `confirm_email_change` all
-revoke tracked *session* rows (under `revoke_on_credential_change`) yet leave
-the remember-token table untouched. A stolen remember cookie therefore
-survives 2FA enrollment/disable and passkey add/remove and can re-establish a
-login afterwards — inconsistent with the `[auth.sessions]` documentation,
-which frames exactly these events as credential changes, and with
-`change_password`'s own "chains are ALWAYS revoked on a credential change"
-comment. Fix: add the same `{rem_table}` user-scoped delete to those five
-transactions (optionally sparing the current device's chain, mirroring the
-`token_digest.ne(current)` session carve-out).
+credential-changing flows do not. Two sub-cases:
+
+- `two_factor_confirm`, `two_factor_disable`, `passkey_register_finish`, and
+  `passkey_revoke` revoke tracked *session* rows (under
+  `revoke_on_credential_change`) yet leave the remember-token table untouched.
+  A stolen remember cookie therefore survives 2FA enrollment/disable and
+  passkey add/remove and can re-establish a login afterwards.
+- `confirm_email_change` is worse: it takes only `Db` and `Path`, never reads
+  `revoke_on_credential_change`, and its transaction touches **neither** the
+  session table nor the remember table. So an email-address change revokes
+  *nothing* — every existing session and every remember chain survives it.
+
+Both are inconsistent with the `[auth.sessions]` documentation, which frames
+exactly these events as credential changes, and with `change_password`'s own
+"chains are ALWAYS revoked on a credential change" comment. Fix: add the same
+`{rem_table}` user-scoped delete to the first four transactions (optionally
+sparing the current device's chain, mirroring the `token_digest.ne(current)`
+session carve-out); for `confirm_email_change`, add **both** the session and
+remember-chain revocation.
 
 A sixth path has the same gap even though it *is* a password reset: when the
 account has TOTP enabled, `reset_password` parks the new digest and returns

--- a/docs/reports/auth-pipeline-security-audit-2026-08.md
+++ b/docs/reports/auth-pipeline-security-audit-2026-08.md
@@ -60,7 +60,13 @@ Recommendations, in increasing strength:
 3. Bind the token to the session: sign `{uuid}:{session_id}` rather than the
    bare uuid, and verify against the current session id. This converts
    double-submit into a session-bound synchronizer-equivalent and defeats
-   planted-cookie attacks entirely.
+   planted-cookie attacks entirely. Design constraint: the session id rotates
+   at login/reset/OAuth completion, and `CsrfService` currently keeps an
+   existing valid cookie without re-minting — a naive binding would therefore
+   break every post-login form. The binding design must re-mint the CSRF
+   cookie whenever the session rotates (the session layer knows when it does),
+   or bind to a stable per-browser secret that survives rotation instead of
+   the raw session id.
 
 ### M2. Operator-unlock endpoint compares the admin secret non-constant-time
 
@@ -317,7 +323,11 @@ PR and verified against the code.)*
 - **Signing secrets**: 32-byte production minimum, template-value denylist,
   fail-fast boot validation, previous-key rotation grace.
 - **Reset/magic-link/confirm tokens**: 256-bit OS-random, digest-only at rest,
-  bounded TTLs, non-enumerating responses with 1s timing floors. Magic-link
+  bounded TTLs, non-enumerating responses — with 1s timing floors on the
+  *issuance* handlers (forgot-password, magic-link request, resend-
+  confirmation); the verification handlers have no floor, which is acceptable
+  because a submitted token's validity is already disclosed by the response
+  itself. Magic-link
   and confirm-email consume atomically (`UPDATE … RETURNING` on the digest);
   reset does not — see L11. Magic-link additionally uses the link-scanner-safe
   non-consuming GET → confirming POST pattern (confirm-email does not — see


### PR DESCRIPTION
Adds a full manual security audit of the authentication pipeline to `docs/reports/`.

**Scope reviewed line-by-line:**
- `autumn/src/auth.rs` (+ `auth/password.rs`, `auth/remember.rs`) — hashing, `RequireAuth`/`RequireApiToken`, OAuth2/OIDC, API token stores
- `autumn/src/session.rs`, `session_redis.rs`, `entropy.rs`
- `autumn/src/security/` — `csrf`, `config` (signing keys), `headers`, `trusted_proxies`, `submit_token`, `captcha`; `step_up.rs`
- `autumn-cli/src/generate/auth.rs` — generated login/lockout/reset/magic-link/TOTP/remember-me/session-tracking handlers
- `autumn-cli/src/routes_audit.rs`

**Verdict:** no critical or high findings. The report documents:
- **2 medium** — (M1) CSRF cookie is never set `Secure` and the double-submit token isn't session-bound; (M2) generated `/auth/admin/unlock` compares `X-Admin-Secret` with a non-constant-time `!=`
- **10 low/hardening** — e.g. `remember_secure()` reads `X-Forwarded-Proto` directly instead of via `ProxyResolver`, generated handlers use raw `ConnectInfo` IPs, no throttle on `/login`/`/forgot-password` (magic-link has one), `MemoryStore` sessions never expire server-side, bcrypt 72-byte truncation undocumented
- Verified strengths and a suggested fix order

Docs-only change; no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016jpdy26KCEeAyvh1JXfzvx

---
_Generated by [Claude Code](https://claude.ai/code/session_016jpdy26KCEeAyvh1JXfzvx)_