### PR TITLE
perf: stop deep-cloning AutumnConfig on request paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Performance
 
+- **config reads on the request path:** generated auth handlers, the admin
+  plugin, the `saas` starter, and the `blog`/`saas`/`teams` examples now read
+  configuration through `AppState::config_arc()` instead of
+  `AppState::config()`. `config()` returns an owned `AutumnConfig`, so every
+  call deep-clones **every** config section — 64 allocations and 1,384 bytes
+  against a default config, and more as an app's config grows — even to read a
+  single `bool` or `usize`. On a handler that cost is paid per request, and a
+  handler reading two or three sections paid it two or three times over: a
+  downstream app profiling its request path measured whole-config clones at
+  ~30% of its per-request allocations and ~42% of its per-request bytes.
+  `config_arc()` hands back the shared `Arc<AutumnConfig>` the state already
+  holds, so the same read is a refcount bump and handlers borrow the section
+  they need off the handle (`&config.auth.password`).
+
+  Nothing about the framework's own ingress path changed — that was already
+  allocation-free as of #2199 — and no public signature moved: `config()`
+  remains the per-boot owned-snapshot accessor, and the one generated call site
+  that still uses it is the boot-time `remember_me_startup` hook, which needs an
+  owned `RememberConfig`. Apps calling `state.config()` in their own handlers
+  keep compiling; switching them to `state.config_arc()` is the fix, and
+  `docs/guide/authentication.md` now teaches that as the default. A new
+  generator test pins the emitted handlers to `config_arc()` so the deep clone
+  cannot reappear in scaffolded apps.
+
 - **jobs:** the Postgres job worker's claim query (`SELECT … FOR UPDATE SKIP
   LOCKED`) no longer scans and sorts the entire ready backlog for a queue
   before picking one row, for apps that don't configure `[jobs] queues`

--- a/autumn-admin-plugin/src/routes.rs
+++ b/autumn-admin-plugin/src/routes.rs
@@ -697,7 +697,9 @@ async fn model_create(
     if let Some(Value::String(secret)) = record.get("token") {
         // Mirror the session cookie's Secure flag so the reveal cookie is
         // accepted in both HTTPS and explicit HTTP-only deployments.
-        let secure_attr = if state.config().session.secure {
+        // `config_arc` reads through the shared handle: reading one `bool` must
+        // not deep-clone every config section on a request path.
+        let secure_attr = if state.config_arc().session.secure {
             "; Secure"
         } else {
             ""
@@ -782,7 +784,7 @@ async fn model_detail(
     // Clear the reveal cookie so a page refresh does not show the token again.
     // Mirror the session cookie's Secure flag for consistency.
     if reveal_secret.is_some() {
-        let secure_attr = if state.config().session.secure {
+        let secure_attr = if state.config_arc().session.secure {
             "; Secure"
         } else {
             ""

--- a/autumn-cli/src/generate/auth.rs
+++ b/autumn-cli/src/generate/auth.rs
@@ -3372,7 +3372,10 @@ pub async fn require_tracked_session(
     }};
 
     // Bounded write amplification: skip the UPDATE inside the window.
-    let sessions_cfg = state.config().auth.sessions;
+    // `config_arc` shares the resolved config behind an `Arc`; `config()`
+    // would deep-clone every section to read one field on a request path.
+    let config = state.config_arc();
+    let sessions_cfg = &config.auth.sessions;
     let now = chrono::Utc::now().naive_utc();
     let window =
         chrono::Duration::seconds(i64::try_from(sessions_cfg.last_seen_update_secs).unwrap_or(60));
@@ -3699,7 +3702,7 @@ pub async fn signup_form(
     csrf: Option<CsrfToken>,
     csrf_field: Option<CsrfFormField>,
 ) -> AutumnResult<Markup> {{
-    let min_len = state.config().auth.password.min_length;
+    let min_len = state.config_arc().auth.password.min_length;
     Ok(render_signup_form(min_len, None, csrf.as_ref(), csrf_field.as_ref()))
 }}
 
@@ -3752,7 +3755,10 @@ pub async fn signup(
     // the supplied email, and optional HIBP breach check) instead of a bare
     // length gate. On failure, re-render the form with the specific message at
     // HTTP 200 rather than accepting a weak credential or returning an error page.
-    let password_cfg = state.config().auth.password;
+    // `config_arc` shares the resolved config behind an `Arc`; `config()`
+    // would deep-clone every section to read one field on a request path.
+    let config = state.config_arc();
+    let password_cfg = &config.auth.password;
     let mut policy = password_cfg.policy();
     if password_cfg.breach_check != autumn_web::auth::BreachCheck::Off {{
         // Breach checking needs an HTTP client for the HIBP k-anonymity lookup;
@@ -3936,7 +3942,10 @@ pub async fn login(
 
     // ── Account lockout policy ────────────────────────────────────────────────
     // Read lockout config from the standard Autumn config surface.
-    let lockout_cfg = state.config().auth.lockout;
+    // `config_arc` shares the resolved config behind an `Arc`; `config()`
+    // would deep-clone every section to read one field on a request path.
+    let config = state.config_arc();
+    let lockout_cfg = &config.auth.lockout;
     let lockout_enabled = lockout_cfg.enabled && lockout_cfg.threshold > 0;
 
     if let Some(ref {snake_name}) = found_{snake_name} {{
@@ -4115,12 +4124,16 @@ pub async fn login(
     // Persistent "remember-me" opt-in (issue #1397): when the box is ticked and
     // policy allows it, mint a rotating remember chain and attach its cookie
     // alongside the session cookie. Unticked → behaviour is unchanged.
-    if form.remember.is_some() && state.config().auth.remember.enabled {{
+    // One shared read of the config serves both the opt-in check and the
+    // resolved `[auth.remember]` section — `config()` would deep-clone every
+    // config section twice per login.
+    let config = state.config_arc();
+    if form.remember.is_some() && config.auth.remember.enabled {{
         // Thread the resolved `[auth.remember]` config so cookie_name/duration
         // overrides are honoured (issue #1397.2).
-        let remember_cfg = state.config().auth.remember.clone();
+        let remember_cfg = &config.auth.remember;
         let cookie =
-            issue_remember_cookie(&mut db, &remember_cfg, {snake_name}.id, addr_ip, &headers).await?;
+            issue_remember_cookie(&mut db, remember_cfg, {snake_name}.id, addr_ip, &headers).await?;
         append_set_cookie(&mut response, &cookie);
     }}
     Ok(response)
@@ -4142,13 +4155,15 @@ pub async fn logout(
     flash: Flash,
 ) -> AutumnResult<Response> {{
     // Thread the resolved `[auth.remember]` config so an overridden cookie name
-    // is the one we revoke and clear (issue #1397.2).
-    let remember_cfg = state.config().auth.remember.clone();
+    // is the one we revoke and clear (issue #1397.2). Read through the shared
+    // `Arc` — a logout must not deep-clone every config section.
+    let config = state.config_arc();
+    let remember_cfg = &config.auth.remember;
     // Best-effort: the device must sign out even if the row delete hiccups.
     let _ = untrack_current_session(&mut db, &session).await;
     // Revoke this device's remember chain (issue #1397) so a stolen remember
     // cookie cannot re-establish a login after logout. No-op when absent.
-    revoke_remember_from_cookie(&mut db, &remember_cfg, &headers).await;
+    revoke_remember_from_cookie(&mut db, remember_cfg, &headers).await;
     // Invalidate the session: clear all data (drops the auth keys) and rotate
     // the id so the pre-logout cookie can no longer be replayed — the old id is
     // destroyed in the session store on save. This is equivalent to `destroy()`
@@ -4158,7 +4173,7 @@ pub async fn logout(
     session.rotate_id().await;
     flash.info("You have been logged out.").await;
     let mut response = redirect_to("/login");
-    append_set_cookie(&mut response, &build_remember_clear_cookie(&remember_cfg));
+    append_set_cookie(&mut response, &build_remember_clear_cookie(remember_cfg));
     Ok(response)
 }}
 
@@ -4423,7 +4438,10 @@ pub async fn change_password(
 
     // Enforce the configured password policy, passing the account email as
     // similarity context (matches the signup path).
-    let password_cfg = state.config().auth.password;
+    // `config_arc` shares the resolved config behind an `Arc`; `config()`
+    // would deep-clone every section to read one field on a request path.
+    let config = state.config_arc();
+    let password_cfg = &config.auth.password;
     let mut policy = password_cfg.policy();
     if password_cfg.breach_check != autumn_web::auth::BreachCheck::Off {{
         policy = policy.with_client(autumn_web::http_client::Client::new());
@@ -4467,7 +4485,7 @@ pub async fn change_password(
     // When that flag is false we still rotate + rebind the CURRENT session (so
     // this device stays signed in on a fresh id) and still clear reset/magic-link
     // tokens — only the other-device sign-out is skipped.
-    let revoke_other_sessions_in_txn = state.config().auth.sessions.revoke_on_credential_change;
+    let revoke_other_sessions_in_txn = state.config_arc().auth.sessions.revoke_on_credential_change;
     let pre_rotation_digest = session_token_digest(&session).await;
     session.rotate_id().await;
     let post_rotation_digest = session_token_digest(&session).await;
@@ -4978,7 +4996,10 @@ pub async fn reauth(
         }};
 
         // ── Account lockout policy ──────────────────────────────────────────
-        let lockout_cfg = state.config().auth.lockout;
+        // `config_arc` shares the resolved config behind an `Arc`; `config()`
+        // would deep-clone every section to read one field on a request path.
+        let config = state.config_arc();
+        let lockout_cfg = &config.auth.lockout;
         let lockout_enabled = lockout_cfg.enabled && lockout_cfg.threshold > 0;
 
         if lockout_enabled {{
@@ -5242,7 +5263,7 @@ pub async fn reset_password_form(
     csrf: Option<CsrfToken>,
     csrf_field: Option<CsrfFormField>,
 ) -> AutumnResult<Markup> {{
-    let min_len = state.config().auth.password.min_length;
+    let min_len = state.config_arc().auth.password.min_length;
     Ok(render_reset_password_form(
         &query.token,
         min_len,
@@ -5278,7 +5299,10 @@ pub async fn reset_password(
     // user identifier in scope at this point (the token is validated below), so
     // no similarity context is supplied. On failure, re-render the form with the
     // specific message at HTTP 200 rather than accepting a weak credential.
-    let password_cfg = state.config().auth.password;
+    // `config_arc` shares the resolved config behind an `Arc`; `config()`
+    // would deep-clone every section to read one field on a request path.
+    let config = state.config_arc();
+    let password_cfg = &config.auth.password;
     let mut policy = password_cfg.policy();
     if password_cfg.breach_check != autumn_web::auth::BreachCheck::Off {{
         policy = policy.with_client(autumn_web::http_client::Client::new());
@@ -5344,7 +5368,7 @@ pub async fn reset_password(
     // half-applied. Revoking every existing session is the standard
     // response to credential theft (defaulted on, configurable via
     // [auth.sessions].revoke_on_credential_change).
-    let revoke_existing_sessions = state.config().auth.sessions.revoke_on_credential_change;
+    let revoke_existing_sessions = state.config_arc().auth.sessions.revoke_on_credential_change;
     let {snake_name}_id = {snake_name}.id;
     (*db)
         .transaction::<_, diesel::result::Error, _>(async move |conn| {{
@@ -7938,7 +7962,10 @@ pub async fn oauth_redirect(
         return Redirect::to("/login?error=unknown_provider").into_response();
     }}
 
-    let auth_cfg = state.config().auth;
+    // `config_arc` shares the resolved config behind an `Arc`; `config()`
+    // would deep-clone every section to read one field on a request path.
+    let config = state.config_arc();
+    let auth_cfg = &config.auth;
     let Some(provider) = auth_cfg.oauth2.providers.get(&provider_name) else {{
         warn!(provider = %provider_name, "oauth provider not configured in autumn.toml");
         return Redirect::to("/login?error=provider_not_configured").into_response();
@@ -7972,7 +7999,10 @@ pub async fn oauth_callback(
         return Redirect::to("/login?error=unknown_provider").into_response();
     }}
 
-    let auth_cfg = state.config().auth;
+    // `config_arc` shares the resolved config behind an `Arc`; `config()`
+    // would deep-clone every section to read one field on a request path.
+    let config = state.config_arc();
+    let auth_cfg = &config.auth;
     let Some(provider) = auth_cfg.oauth2.providers.get(&provider_name) else {{
         warn!(provider = %provider_name, "oauth provider not configured in autumn.toml");
         return Redirect::to("/login?error=provider_not_configured").into_response();
@@ -8837,7 +8867,7 @@ pub async fn two_factor_confirm(
     // Capture the revocation policy up front so the delete can run inside
     // the same transaction as the enablement (a post-commit failure here
     // would 500 before the one-time recovery codes are ever shown).
-    let revoke_other_sessions_in_txn = state.config().auth.sessions.revoke_on_credential_change;
+    let revoke_other_sessions_in_txn = state.config_arc().auth.sessions.revoke_on_credential_change;
     let current_token_digest = session_token_digest(&session).await;
     let txn_result = (*db)
         .transaction::<_, diesel::result::Error, _>(async move |conn| {
@@ -8985,7 +9015,7 @@ pub async fn two_factor_disable(
     // 500 after the factor was already removed. Revocation is defaulted on,
     // configurable via [auth.sessions].revoke_on_credential_change.
     let user_id = __SNAKE__.id;
-    let revoke_other_sessions_in_txn = state.config().auth.sessions.revoke_on_credential_change;
+    let revoke_other_sessions_in_txn = state.config_arc().auth.sessions.revoke_on_credential_change;
     let current_token_digest = session_token_digest(&session).await;
     (*db)
         .transaction::<_, diesel::result::Error, _>(async move |conn| {
@@ -9152,7 +9182,7 @@ pub async fn login_verify(
             // atomically; a transaction error rolls both back (token
             // preserved) and is treated as not-committed below.
             let revoke_existing_sessions =
-                state.config().auth.sessions.revoke_on_credential_change;
+                state.config_arc().auth.sessions.revoke_on_credential_change;
             let user_id = __SNAKE__.id;
             (*db)
                 .transaction::<_, diesel::result::Error, _>(async move |conn| {
@@ -9349,7 +9379,7 @@ fn magic_link_routes_section_src(
 //   authenticated session (session-fixation defense).
 
 // Magic-link token TTL and per-email cooldown are sourced from `autumn.toml`
-// via `state.config().auth.magic_link` (see docs/guide/authentication.md):
+// via `state.config_arc().auth.magic_link` (see docs/guide/authentication.md):
 //
 //   [auth.magic_link]
 //   ttl_minutes = 15          # link lifetime; keep ≤ 15 min for a tight window (AC5)
@@ -9415,8 +9445,11 @@ pub async fn magic_link_request(
     let now = chrono::Utc::now().naive_utc();
     // Sourced from `[auth.magic_link]` in autumn.toml (defaults: 15 min TTL, 60s
     // cooldown). Keep `ttl_minutes` ≤ 15 for a tight link-lifetime window.
-    let ttl_minutes = state.config().auth.magic_link.ttl_minutes;
-    let email_cooldown_secs = state.config().auth.magic_link.email_cooldown_secs;
+    // One shared read for both fields; `config()` would deep-clone every
+    // config section twice per request.
+    let config = state.config_arc();
+    let ttl_minutes = config.auth.magic_link.ttl_minutes;
+    let email_cooldown_secs = config.auth.magic_link.email_cooldown_secs;
     // Record start time; the response is padded to a constant minimum below so
     // an attacker cannot infer registration status from response latency.
     let t0 = std::time::Instant::now();
@@ -9605,7 +9638,10 @@ pub async fn magic_link_verify(
     // the SAME generic failure page as an expired/consumed/unknown token — no
     // oracle distinguishes "locked" from "bad link". This sits before the TOTP
     // branch below, so it gates BOTH the 2FA-park and the direct-login paths.
-    let lockout_cfg = state.config().auth.lockout;
+    // `config_arc` shares the resolved config behind an `Arc`; `config()`
+    // would deep-clone every section to read one field on a request path.
+    let config = state.config_arc();
+    let lockout_cfg = &config.auth.lockout;
     let lockout_enabled = lockout_cfg.enabled && lockout_cfg.threshold > 0;
     if lockout_enabled {
         let cooloff = chrono::Duration::seconds(lockout_cfg.cooloff_secs as i64);
@@ -9825,7 +9861,7 @@ with `--oauth`, `--passkeys`, and `--totp` on the same model.
 
 ### Configuration Knobs
 
-The TTL and per-email cooldown are read from `autumn.toml` via `state.config()`,
+The TTL and per-email cooldown are read from `autumn.toml` via `state.config_arc()`,
 so you can tune them without editing the generated handler:
 
 ```toml
@@ -9839,8 +9875,8 @@ documented defaults below.
 
 | Knob | Location | Default | Purpose |
 |------|----------|---------|---------|
-| `auth.magic_link.ttl_minutes` | `[auth.magic_link]` in `autumn.toml` (via `state.config()`) | `15` | Link lifetime (TTL) in minutes. Keep ≤ 15 min for a tight window — a magic link is a bearer credential, so a short expiry bounds the blast radius of a leaked link. |
-| `auth.magic_link.email_cooldown_secs` | `[auth.magic_link]` in `autumn.toml` (via `state.config()`) | `60` | Per-email cooldown in seconds: suppresses re-minting a token for the same address within the window (email-bomb throttle). |
+| `auth.magic_link.ttl_minutes` | `[auth.magic_link]` in `autumn.toml` (via `state.config_arc()`) | `15` | Link lifetime (TTL) in minutes. Keep ≤ 15 min for a tight window — a magic link is a bearer credential, so a short expiry bounds the blast radius of a leaked link. |
+| `auth.magic_link.email_cooldown_secs` | `[auth.magic_link]` in `autumn.toml` (via `state.config_arc()`) | `60` | Per-email cooldown in seconds: suppresses re-minting a token for the same address within the window (email-bomb throttle). |
 | `#[throttle(limit = 5, per = "1m", key = "ip")]` | attribute on `POST /login/magic` and `POST /login/magic/verify` | 5/min/IP | Per-IP rate limit via autumn's existing rate-limit middleware (request minting + token brute-force bound). |
 
 ### Security Guarantees
@@ -9860,7 +9896,7 @@ documented defaults below.
   malformed tokens all render the same generic failure page; the GET confirm page
   is likewise rendered identically regardless of token validity.
 - **Configurable TTL**: tokens expire after `auth.magic_link.ttl_minutes`
-  (default 15), sourced from `autumn.toml` via `state.config()`.
+  (default 15), sourced from `autumn.toml` via `state.config_arc()`.
 - **Rate-limited**: per-IP (`#[throttle]`) and per-email (DB cooldown).
 - **Session-fixation defense**: the session id is rotated before the
   authenticated session is established.
@@ -10060,7 +10096,10 @@ fn redirect_to(url: &str) -> axum::response::Redirect {
 // ── Config helper ──────────────────────────────────────────────────────────────
 
 fn build_webauthn(state: &AppState) -> AutumnResult<Webauthn> {
-    let cfg = &state.config().auth.webauthn;
+    // `config_arc` shares the resolved config behind an `Arc`; `config()`
+    // would deep-clone every section to read one field on a request path.
+    let config = state.config_arc();
+    let cfg = &config.auth.webauthn;
     if cfg.rp_id.is_empty() || cfg.rp_origin.is_empty() {
         return Err(AutumnError::internal_server_error_msg(
             "WebAuthn is not configured. Set [auth.webauthn] rp_id, rp_name, and rp_origin \
@@ -10277,7 +10316,7 @@ pub async fn passkey_register_finish(
     // [auth.sessions].revoke_on_credential_change) can never be silently
     // skipped, and a failure rolls the credential back so the client can
     // retry without storing a duplicate.
-    let revoke_other_sessions_in_txn = state.config().auth.sessions.revoke_on_credential_change;
+    let revoke_other_sessions_in_txn = state.config_arc().auth.sessions.revoke_on_credential_change;
     let current_token_digest = crate::routes::auth::session_token_digest(&session).await;
     (*db)
         .transaction::<_, diesel::result::Error, _>(async move |conn| {
@@ -10582,7 +10621,7 @@ pub async fn passkey_revoke(
     // after it.
     let user_id = current.id;
     let credential_id = form.id;
-    let revoke_other_sessions_in_txn = state.config().auth.sessions.revoke_on_credential_change;
+    let revoke_other_sessions_in_txn = state.config_arc().auth.sessions.revoke_on_credential_change;
     let current_token_digest = crate::routes::auth::session_token_digest(&session).await;
     (*db)
         .transaction::<_, diesel::result::Error, _>(async move |conn| {
@@ -11019,6 +11058,74 @@ mod tests {
     use super::*;
     use std::fs;
     use tempfile::TempDir;
+
+    /// Generated request handlers must read config through `state.config_arc()`,
+    /// never `state.config()`.
+    ///
+    /// `config()` hands back an owned snapshot, which deep-clones every section
+    /// of `AutumnConfig` (~65 allocations) to read one field. In a handler that
+    /// is paid per request, and a handler reading two sections pays it twice —
+    /// which is how a downstream app measured whole-config clones at ~30% of its
+    /// per-request allocations. `config_arc()` clones the `Arc` instead, so the
+    /// same read is a refcount bump.
+    ///
+    /// The one legitimate `config()` in the emitted file is the boot-time
+    /// `remember_me_startup` hook: it runs once and hands `init_remember_pool` an
+    /// owned `RememberConfig`. This pins that exception to exactly one site, so a
+    /// `config()` re-introduced into any handler fails here rather than in a
+    /// downstream profile.
+    #[test]
+    fn generated_handlers_read_config_through_the_shared_arc() {
+        const STARTUP_HOOK: &str = "pub async fn remember_me_startup";
+
+        for (label, routes) in [
+            (
+                "plain",
+                render_routes_file("User", "user", "users", &[], false, false),
+            ),
+            (
+                "totp",
+                render_routes_file("User", "user", "users", &[], true, false),
+            ),
+            (
+                "magic-link",
+                render_routes_file("User", "user", "users", &[], false, true),
+            ),
+            (
+                "oauth",
+                render_routes_file(
+                    "User",
+                    "user",
+                    "users",
+                    &["github".to_owned()],
+                    false,
+                    false,
+                ),
+            ),
+        ] {
+            let hook_at = routes
+                .find(STARTUP_HOOK)
+                .unwrap_or_else(|| panic!("{label}: expected a {STARTUP_HOOK} definition"));
+            // The hook's own `config()` sits a few lines into its body; anything
+            // further out is a handler paying a deep clone per request.
+            let hook_body_end = hook_at + 600;
+
+            for (offset, _) in routes.match_indices("state.config()") {
+                assert!(
+                    (hook_at..hook_body_end).contains(&offset),
+                    "{label}: generated code calls state.config() outside the boot-time \
+                     {STARTUP_HOOK} hook (byte {offset}), which deep-clones every config \
+                     section on a request path — use state.config_arc() instead:\n{}",
+                    &routes[offset.saturating_sub(300)..(offset + 200).min(routes.len())]
+                );
+            }
+
+            assert!(
+                routes.contains("state.config_arc()"),
+                "{label}: generated handlers must read config through state.config_arc()"
+            );
+        }
+    }
 
     fn project_with_main() -> TempDir {
         let tmp = TempDir::new().unwrap();
@@ -11878,8 +11985,9 @@ mod tests {
         let body = magic_link_verify_body(&routes);
         // Reads the same [auth.lockout] config the password-login path uses.
         assert!(
-            body.contains("let lockout_cfg = state.config().auth.lockout;"),
-            "verify must read [auth.lockout] config for the lock recheck: {body}"
+            body.contains("let lockout_cfg = &config.auth.lockout;")
+                && body.contains("let config = state.config_arc();"),
+            "verify must read [auth.lockout] through the shared config handle: {body}"
         );
         // TOCTOU-safe: the recheck must NOT trust the stale in-memory `user` row
         // SELECTed earlier — it must re-read `locked_at` at the DB. The stale
@@ -11926,8 +12034,9 @@ mod tests {
         let routes = render_routes_file("User", "user", "users", &[], true, true);
         let body = magic_link_verify_body(&routes);
         assert!(
-            body.contains("let lockout_cfg = state.config().auth.lockout;"),
-            "totp variant must read [auth.lockout] config for the lock recheck: {body}"
+            body.contains("let lockout_cfg = &config.auth.lockout;")
+                && body.contains("let config = state.config_arc();"),
+            "totp variant must read [auth.lockout] through the shared config handle: {body}"
         );
         assert!(
             !body.contains("if let Some(locked_at) = user.locked_at {"),
@@ -12186,10 +12295,11 @@ mod tests {
     fn magic_link_ttl_is_config_sourced_with_15_minute_default() {
         let tmp = project_with_main();
         let routes = magic_link_routes(tmp.path());
-        // TTL is now sourced from autumn.toml via state.config(), not a const.
+        // TTL is sourced from autumn.toml via the shared config handle, not a const.
         assert!(
-            routes.contains("state.config().auth.magic_link.ttl_minutes"),
-            "TTL must be sourced from state.config().auth.magic_link: {routes}"
+            routes.contains("let ttl_minutes = config.auth.magic_link.ttl_minutes;")
+                && routes.contains("let config = state.config_arc();"),
+            "TTL must be sourced from auth.magic_link via config_arc: {routes}"
         );
         // The documented default (15) and the ≤ 15-minute guidance must survive
         // the move to config so operators keep the tight-window recommendation.
@@ -12199,8 +12309,9 @@ mod tests {
         );
         // The per-email cooldown is likewise config-sourced.
         assert!(
-            routes.contains("state.config().auth.magic_link.email_cooldown_secs"),
-            "per-email cooldown must be sourced from state.config().auth.magic_link: {routes}"
+            routes
+                .contains("let email_cooldown_secs = config.auth.magic_link.email_cooldown_secs;"),
+            "per-email cooldown must be sourced from auth.magic_link: {routes}"
         );
     }
 
@@ -13480,7 +13591,7 @@ mod tests {
         let routes = render_routes_file("User", "user", "users", &[], false, false);
         let body = handler_body(&routes, "change_password");
         assert!(
-            body.contains("state.config().auth.sessions.revoke_on_credential_change"),
+            body.contains("state.config_arc().auth.sessions.revoke_on_credential_change"),
             "change_password must read the revoke_on_credential_change opt-out"
         );
         // The OTHER-session delete is gated on the captured flag.

--- a/autumn-cli/src/starters/saas/src/routes/auth.rs
+++ b/autumn-cli/src/starters/saas/src/routes/auth.rs
@@ -87,7 +87,7 @@ fn signup_page(min_len: usize, submit_token: &str, error: Option<&str>) -> Marku
 #[get("/signup")]
 pub async fn signup_form(State(state): State<AppState>, submit_token: SubmitToken) -> Markup {
     signup_page(
-        state.config().auth.password.min_length,
+        state.config_arc().auth.password.min_length,
         submit_token.token(),
         None,
     )
@@ -121,7 +121,10 @@ pub async fn signup(
     // the email, and optional HIBP breach check). On failure, re-render the form
     // with the specific message at HTTP 200 rather than accepting a weak
     // credential.
-    let password_cfg = state.config().auth.password;
+    // `config_arc` shares the resolved config behind an `Arc`; `config()` would
+    // deep-clone every section just to read `[auth.password]` on a request path.
+    let config = state.config_arc();
+    let password_cfg = &config.auth.password;
     let mut policy = password_cfg.policy();
     if password_cfg.breach_check != autumn_web::auth::BreachCheck::Off {
         // Breach checking needs an HTTP client for the HIBP k-anonymity lookup;
@@ -249,14 +252,18 @@ pub async fn login(
     // Persistent "remember-me" opt-in (issue #1397): when the box is ticked and
     // the policy allows it, mint a rotating remember chain and attach its cookie
     // alongside the session cookie. Unticked → behaviour is unchanged.
-    if form.remember.is_some() && state.config().auth.remember.enabled {
+    // One shared read of the config for both the opt-in check and the resolved
+    // `[auth.remember]` section below — `config()` would deep-clone the whole
+    // config twice per login.
+    let config = state.config_arc();
+    if form.remember.is_some() && config.auth.remember.enabled {
         // Thread the resolved `[auth.remember]` config so cookie_name/duration
         // overrides are honoured (issue #1397.2).
-        let remember_cfg = state.config().auth.remember.clone();
+        let remember_cfg = &config.auth.remember;
         // `Db` derefs to the underlying connection; `&mut *db` reborrows it.
         let cookie = crate::remember::issue_remember_cookie(
             &mut db,
-            &remember_cfg,
+            remember_cfg,
             user.id,
             &user.tenant_id,
             &headers,
@@ -280,13 +287,15 @@ pub async fn logout(
     headers: HeaderMap,
 ) -> AutumnResult<Response> {
     // Thread the resolved `[auth.remember]` config so an overridden cookie name
-    // is the one we revoke and clear (issue #1397.2).
-    let remember_cfg = state.config().auth.remember.clone();
+    // is the one we revoke and clear (issue #1397.2). Read through the shared
+    // `Arc` — a logout must not deep-clone every config section.
+    let config = state.config_arc();
+    let remember_cfg = &config.auth.remember;
 
     // Revoke this device's remember chain (issue #1397) before tearing the
     // session down, so a stolen remember cookie cannot re-establish a login
     // after logout. No-op when no remember cookie is present.
-    crate::remember::revoke_current_chain(&mut db, &remember_cfg, &headers).await;
+    crate::remember::revoke_current_chain(&mut db, remember_cfg, &headers).await;
 
     // Clear the session contents and rotate the id so the old cookie cannot be
     // replayed.
@@ -295,7 +304,7 @@ pub async fn logout(
 
     let mut response = Redirect::to("/").into_response();
     if let Ok(header_value) =
-        HeaderValue::from_str(&crate::remember::clear_remember_cookie(&remember_cfg))
+        HeaderValue::from_str(&crate::remember::clear_remember_cookie(remember_cfg))
     {
         response.headers_mut().append(SET_COOKIE, header_value);
     }

--- a/autumn/src/auth.rs
+++ b/autumn/src/auth.rs
@@ -748,7 +748,7 @@ impl Default for SessionTrackingConfig {
 /// Passwordless magic-link login configuration (issue #1737).
 ///
 /// Read from the `[auth.magic_link]` section of `autumn.toml`. Consumed by the
-/// routes emitted by `autumn generate auth --magic-link` via `state.config()`.
+/// routes emitted by `autumn generate auth --magic-link` via `state.config_arc()`.
 /// All fields have safe production defaults.
 ///
 /// ```toml

--- a/autumn/src/state.rs
+++ b/autumn/src/state.rs
@@ -1541,11 +1541,17 @@ mod tests {
         );
     }
 
-    /// `config`'s signature is load-bearing beyond this crate: autumn-cli's
-    /// auth generator emits `state.config()` move-out patterns as strings that
-    /// CI never compiles, so a change here surfaces only in generated apps.
+    /// Both accessors' signatures are load-bearing beyond this crate: autumn-cli's
+    /// auth generator emits reads against them as strings that CI never compiles,
+    /// so a change here surfaces only in generated apps.
+    ///
+    /// `config_arc` is the one generated request handlers call — they bind the
+    /// handle and borrow sections off it (`&config.auth.password`), so it has to
+    /// keep returning an owned `Arc` that outlives the borrow. `config` stays
+    /// pinned too: it remains the per-boot owned-snapshot accessor.
     #[test]
     fn config_signature_is_unchanged() {
         let _: fn(&AppState) -> crate::config::AutumnConfig = AppState::config;
+        let _: fn(&AppState) -> Arc<crate::config::AutumnConfig> = AppState::config_arc;
     }
 }

--- a/autumn/tests/integration/pagination_cursor_proptest.rs
+++ b/autumn/tests/integration/pagination_cursor_proptest.rs
@@ -22,6 +22,47 @@ prop_compose! {
     }
 }
 
+/// The identity of an HMAC key, for "are these two keys actually different?".
+///
+/// HMAC-SHA256 zero-pads any key shorter than its 64-byte block size, so `[]`,
+/// `[0]` and `[0, 0]` are all the *same* key and mint byte-identical
+/// signatures. Raw slice inequality therefore does not mean two keys differ as
+/// HMAC keys, and a forgery test that assumes it does is asking for a token
+/// signed with key A to be rejected under a key B that is, in fact, key A.
+/// Stripping trailing zero bytes collapses each key to the padded form HMAC
+/// actually uses, so `!=` on the result means what the test needs it to mean.
+///
+/// Scoped to keys at or under the block size, which is all this file draws
+/// (0..48 bytes); a longer key is hashed rather than padded, so it would need
+/// the hash, not this.
+fn hmac_key_identity(key: &[u8]) -> &[u8] {
+    let significant = key.iter().rposition(|&b| b != 0).map_or(0, |i| i + 1);
+    &key[..significant]
+}
+
+/// Pins the padding property the assumption above encodes, so the reason that
+/// assumption is not simply `key_a != key_b` cannot be lost: two keys that
+/// differ only in trailing zero bytes verify each other's tokens, because they
+/// are one key as far as HMAC is concerned.
+#[test]
+fn keys_differing_only_in_zero_padding_are_one_hmac_key() {
+    let key = Key {
+        id: 7,
+        ts: 11,
+        tenant: "acme".to_owned(),
+    };
+    let token = Cursor::encode_signed(&key, &[0]).expect("encode_signed never fails");
+
+    let decoded: Option<Key> = Cursor::decode_signed(&token, &[]);
+
+    assert_eq!(
+        decoded,
+        Some(key),
+        "`[0]` and `[]` are the same HMAC key once zero-padded to the block \
+         size, so a token signed with one must verify under the other"
+    );
+}
+
 proptest! {
     #![proptest_config(ProptestConfig::with_cases(256))]
 
@@ -51,14 +92,18 @@ proptest! {
     }
 
     /// Forgery rejection: a token signed with key A must NOT verify under a
-    /// different key B (when the keys actually differ).
+    /// key B that is genuinely a different key — see `hmac_key_identity` for
+    /// why "genuinely" is doing work there.
     #[test]
     fn signed_token_rejects_wrong_key(
         key in arb_key(),
         key_a in prop::collection::vec(any::<u8>(), 0..48),
         key_b in prop::collection::vec(any::<u8>(), 0..48),
     ) {
-        prop_assume!(key_a != key_b);
+        // Not `key_a != key_b`: keys differing only in trailing zero bytes are
+        // the same HMAC key (see `hmac_key_identity`), so that weaker
+        // assumption lets through pairs where rejection is impossible.
+        prop_assume!(hmac_key_identity(&key_a) != hmac_key_identity(&key_b));
         let token = Cursor::encode_signed(&key, &key_a).expect("encode_signed never fails");
         let decoded: Option<Key> = Cursor::decode_signed(&token, &key_b);
         prop_assert_eq!(decoded, None);

--- a/docs/guide/authentication.md
+++ b/docs/guide/authentication.md
@@ -225,7 +225,10 @@ all of them at once, rather than making the user fix one problem per round-trip:
 ```rust,ignore
 use autumn_web::auth::{BreachCheck, validate_password};
 
-let cfg = state.config().auth.password;
+// `config_arc` clones the `Arc`, not the config behind it, so reading policy
+// on a per-request path costs a refcount bump rather than a deep clone.
+let config = state.config_arc();
+let cfg = &config.auth.password;
 let mut policy = cfg.policy();
 if cfg.breach_check != BreachCheck::Off {
     // The HIBP lookup needs an HTTP client; the default-off path never builds one.
@@ -239,11 +242,18 @@ if !validation.is_valid() {
 }
 ```
 
-`state.config()` hands back an owned, independently mutable snapshot, which
-costs a deep clone of every config section. On a path that runs per request
-rather than per boot, read through `state.config_arc()` instead — it clones the
-`Arc`, not the config behind it — and clone only the section you need:
-`state.config_arc().auth.password.clone()`.
+Read config through `state.config_arc()` on anything that runs per request. It
+hands back a shared `Arc<AutumnConfig>`, so the read is a refcount bump: borrow
+the section you need off the handle (`&config.auth.password`), or clone just
+that section if you need it owned.
+
+`state.config()` is the per-boot accessor. It hands back an owned, independently
+mutable snapshot, and paying for one means deep-cloning **every** config section
+— 64 allocations and 1,384 bytes per call against a default config, more as your
+config grows — to read a single field. On a request path that cost is repeated
+on every request, and a handler that reads two or three sections pays it two or
+three times over. Reach for it in `on_startup` hooks and one-shot setup, not in
+handlers.
 
 ```toml
 [auth.password]
@@ -263,7 +273,7 @@ differ only in what happens when HIBP is unreachable — `fail_open` allows the
 password, `fail_closed` rejects it. Start with `fail_open`: a transient HIBP
 outage should not block legitimate sign-ups.
 
-Render the policy into the form (`minlength = state.config().auth.password
+Render the policy into the form (`minlength = state.config_arc().auth.password
 .min_length`) so the client-side hint always matches what the handler enforces.
 
 ---
@@ -350,20 +360,21 @@ pub async fn logout(
     mut db: Db,
     headers: HeaderMap,
 ) -> AutumnResult<Response> {
-    let remember_cfg = state.config().auth.remember.clone();
+    let config = state.config_arc();
+    let remember_cfg = &config.auth.remember;
 
     // Drop this device's tracking row, then revoke its remember chain — before
     // the session teardown, and only a no-op when neither is in play. Skipping
     // this is the classic bug: the session dies, the remember cookie survives,
     // and the next request logs the browser straight back in.
     let _ = untrack_current_session(&mut db, &session).await;
-    revoke_remember_from_cookie(&mut db, &remember_cfg, &headers).await;
+    revoke_remember_from_cookie(&mut db, remember_cfg, &headers).await;
 
     session.clear().await;
     session.rotate_id().await;   // old cookie can no longer be replayed
 
     let mut response = Redirect::to("/").into_response();
-    append_set_cookie(&mut response, &build_remember_clear_cookie(&remember_cfg));
+    append_set_cookie(&mut response, &build_remember_clear_cookie(remember_cfg));
     Ok(response)
 }
 ```

--- a/examples/blog/src/routes/oauth.rs
+++ b/examples/blog/src/routes/oauth.rs
@@ -33,7 +33,10 @@ pub async fn oauth_redirect(
         )));
     }
 
-    let auth_cfg = state.config().auth;
+    // `config_arc` shares the resolved config behind an `Arc`; `config()` would
+    // deep-clone every section (including the OAuth provider map) per request.
+    let config = state.config_arc();
+    let auth_cfg = &config.auth;
     let provider = auth_cfg
         .oauth2
         .providers
@@ -66,7 +69,10 @@ pub async fn oauth_callback(
         )));
     }
 
-    let auth_cfg = state.config().auth;
+    // `config_arc` shares the resolved config behind an `Arc`; `config()` would
+    // deep-clone every section (including the OAuth provider map) per request.
+    let config = state.config_arc();
+    let auth_cfg = &config.auth;
     let provider = auth_cfg
         .oauth2
         .providers

--- a/examples/saas/src/routes/auth.rs
+++ b/examples/saas/src/routes/auth.rs
@@ -87,7 +87,7 @@ fn signup_page(min_len: usize, submit_token: &str, error: Option<&str>) -> Marku
 #[get("/signup")]
 pub async fn signup_form(State(state): State<AppState>, submit_token: SubmitToken) -> Markup {
     signup_page(
-        state.config().auth.password.min_length,
+        state.config_arc().auth.password.min_length,
         submit_token.token(),
         None,
     )
@@ -121,7 +121,10 @@ pub async fn signup(
     // the email, and optional HIBP breach check). On failure, re-render the form
     // with the specific message at HTTP 200 rather than accepting a weak
     // credential.
-    let password_cfg = state.config().auth.password;
+    // `config_arc` shares the resolved config behind an `Arc`; `config()` would
+    // deep-clone every section just to read `[auth.password]` on a request path.
+    let config = state.config_arc();
+    let password_cfg = &config.auth.password;
     let mut policy = password_cfg.policy();
     if password_cfg.breach_check != autumn_web::auth::BreachCheck::Off {
         // Breach checking needs an HTTP client for the HIBP k-anonymity lookup;
@@ -249,14 +252,18 @@ pub async fn login(
     // Persistent "remember-me" opt-in (issue #1397): when the box is ticked and
     // the policy allows it, mint a rotating remember chain and attach its cookie
     // alongside the session cookie. Unticked → behaviour is unchanged.
-    if form.remember.is_some() && state.config().auth.remember.enabled {
+    // One shared read of the config for both the opt-in check and the resolved
+    // `[auth.remember]` section below — `config()` would deep-clone the whole
+    // config twice per login.
+    let config = state.config_arc();
+    if form.remember.is_some() && config.auth.remember.enabled {
         // Thread the resolved `[auth.remember]` config so cookie_name/duration
         // overrides are honoured (issue #1397.2).
-        let remember_cfg = state.config().auth.remember.clone();
+        let remember_cfg = &config.auth.remember;
         // `Db` derefs to the underlying connection; `&mut *db` reborrows it.
         let cookie = crate::remember::issue_remember_cookie(
             &mut db,
-            &remember_cfg,
+            remember_cfg,
             user.id,
             &user.tenant_id,
             &headers,
@@ -280,13 +287,15 @@ pub async fn logout(
     headers: HeaderMap,
 ) -> AutumnResult<Response> {
     // Thread the resolved `[auth.remember]` config so an overridden cookie name
-    // is the one we revoke and clear (issue #1397.2).
-    let remember_cfg = state.config().auth.remember.clone();
+    // is the one we revoke and clear (issue #1397.2). Read through the shared
+    // `Arc` — a logout must not deep-clone every config section.
+    let config = state.config_arc();
+    let remember_cfg = &config.auth.remember;
 
     // Revoke this device's remember chain (issue #1397) before tearing the
     // session down, so a stolen remember cookie cannot re-establish a login
     // after logout. No-op when no remember cookie is present.
-    crate::remember::revoke_current_chain(&mut db, &remember_cfg, &headers).await;
+    crate::remember::revoke_current_chain(&mut db, remember_cfg, &headers).await;
 
     // Clear the session contents and rotate the id so the old cookie cannot be
     // replayed.
@@ -295,7 +304,7 @@ pub async fn logout(
 
     let mut response = Redirect::to("/").into_response();
     if let Ok(header_value) =
-        HeaderValue::from_str(&crate::remember::clear_remember_cookie(&remember_cfg))
+        HeaderValue::from_str(&crate::remember::clear_remember_cookie(remember_cfg))
     {
         response.headers_mut().append(SET_COOKIE, header_value);
     }

--- a/examples/teams/src/routes/auth.rs
+++ b/examples/teams/src/routes/auth.rs
@@ -70,7 +70,7 @@ fn signup_page(min_len: usize, csrf_token: &str, error: Option<&str>) -> Markup 
 #[get("/signup")]
 pub async fn signup_form(State(state): State<AppState>, csrf: Option<CsrfToken>) -> Markup {
     signup_page(
-        state.config().auth.password.min_length,
+        state.config_arc().auth.password.min_length,
         csrf_value(&csrf),
         None,
     )
@@ -95,8 +95,10 @@ pub async fn signup(
             "Password must be at most 128 characters",
         ));
     }
-    let password_cfg = state.config().auth.password;
-    let policy = password_cfg.policy();
+    // `config_arc` shares the resolved config behind an `Arc`; `config()` would
+    // deep-clone every section just to read `[auth.password]` on a request path.
+    let config = state.config_arc();
+    let policy = config.auth.password.policy();
     let validation =
         autumn_web::auth::validate_password(&form.password, &policy, &[email.as_str()]).await;
     if !validation.is_valid() {
@@ -106,9 +108,12 @@ pub async fn signup(
         } else {
             messages.join("\n")
         };
-        return Ok(
-            signup_page(password_cfg.min_length, csrf_value(&csrf), Some(&message)).into_response(),
-        );
+        return Ok(signup_page(
+            config.auth.password.min_length,
+            csrf_value(&csrf),
+            Some(&message),
+        )
+        .into_response());
     }
 
     let password_hash = hash_password(&form.password).await?;

--- a/examples/teams/src/routes/invitations.rs
+++ b/examples/teams/src/routes/invitations.rs
@@ -502,8 +502,10 @@ pub async fn accept_invitation(
                         "Password must be at most 128 characters",
                     ));
                 }
-                let password_cfg = state.config().auth.password;
-                let policy = password_cfg.policy();
+                // Read through the shared `Arc`: `config()` would deep-clone
+                // every config section to reach `[auth.password]`.
+                let config = state.config_arc();
+                let policy = config.auth.password.policy();
                 let validation =
                     autumn_web::auth::validate_password(password, &policy, &[email.as_str()]).await;
                 if !validation.is_valid() {


### PR DESCRIPTION
## The report

A downstream app (Nexus CRM, built on autumn-web) profiled its request path and found whole-`AutumnConfig` deep clones at **~650 allocations and ~101 KB per request — 30% of the request's allocations and 42% of its bytes**, with the suggested fix being "an `Arc<AutumnConfig>` inside `AppState`".

## What was actually happening

`AppState` does not deep-clone config when it is cloned — config lives in the extension map behind an `Arc`, so `AppState::clone()` is already a refcount bump, and #2199 made the framework's own ingress path allocation-free (`config_alloc_gate` pins a request at ≤ 288 blocks).

The clones come from explicit `AppState::config()` calls. `config()` returns an *owned* `AutumnConfig`, so each call deep-clones every section — measured at **64 allocations / 1,384 bytes** against a default config, more as an app's config grows — even to read a single `bool` or `usize`. Handlers pay that per request, and a handler reading two or three sections pays it two or three times over. ~10 such reads per request against a fatter config is exactly the reported shape.

`AppState::config_arc()` already exists and hands back the shared `Arc<AutumnConfig>`. What was missing was the code an app actually runs using it.

## Changes

Converted every request-path `config()` read to `config_arc()`, binding the handle once and borrowing sections off it (`&config.auth.password`) instead of moving an owned section out of a fresh deep clone:

- **generated auth handlers** (`autumn generate auth`, incl. the `--totp`, `--passkeys`, `--magic-link` and `--oauth` variants) — the largest surface, since every scaffolded app inherits it. Login and logout each dropped two whole-config clones; signup, reset-password, change-password, reauth, session tracking, magic-link and the OAuth redirect/callback each dropped one or more.
- **admin plugin** — the two `session.secure` reads.
- **`saas` starter** and the **`blog` / `saas` / `teams` examples**.
- **`docs/guide/authentication.md`** — now teaches `config_arc()` as the default for handlers, with `config()` framed as the per-boot accessor.

## Not changed

- No public signature moved. `config()` remains the per-boot owned-snapshot accessor, and apps calling it in their own handlers keep compiling — switching them to `config_arc()` is the fix.
- The framework ingress path, which was already clean.
- The one generated call site still on `config()`: the boot-time `remember_me_startup` hook, which runs once and needs an owned `RememberConfig`.
- `AppState` keeps config in the extension map rather than gaining a plain `Arc` field. That is deliberate: `app::build` re-inserts a mutated config after `build_state`, and plugins can install one later, so already-cloned states must read through the map to observe it. The map read is allocation-free and already delivers the refcount-bump property the report asked for.

## Regression guards

- New generator test `generated_handlers_read_config_through_the_shared_arc` renders each auth variant and fails if `state.config()` appears anywhere outside the startup hook. Verified it has teeth by reintroducing one call site and watching it fail.
- `config_signature_is_unchanged` now pins `config_arc`'s signature too, since generated code depends on it returning an owned `Arc` that outlives the borrows taken off it.

## Verification

- `./scripts/pre-push-check.sh` green — fmt, `clippy --workspace --all-targets -- -D warnings`, workspace test-target compile, doctests.
- Generator conformance (these actually compile a scaffolded app): `generated_auth_totp_cargo_checks`, `generated_auth_passkeys_cargo_checks`, `generated_auth_magic_link_cargo_checks`, `generated_auth_magic_link_with_totp_cargo_checks` — all pass. The `--oauth` borrow pattern is covered by `examples/blog`, which compiles in the workspace gate.
- `cargo test -p autumn-cli --bin autumn generate::auth` — 212 pass.
- `config_alloc_gate` (4) and `state::tests` (21) pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ReHEDzSmxgayGqsb9fWQgY)_