### PR TITLE
Close #743 gaps: document-unique Markdown heading anchors + keyed SSG params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **duplicate Markdown heading anchors:** `markdown::render` now hands out
+  document-unique heading `id`s. A page that repeated a heading — and real docs
+  repeat "Example", "Usage", and "Notes" constantly — emitted the same `id`
+  twice, which is invalid HTML and made every table-of-contents entry for the
+  repeated heading jump to the first occurrence. The first use of a slug is
+  still handed back unchanged, so anchors already published in URLs keep
+  resolving; later collisions get a `-1`, `-2`, … suffix, the convention
+  GitHub, mdBook, and Hugo share. The suffix search skips ids already claimed by
+  an unrelated heading, so `## Example` / `## Example 1` / `## Example` yields
+  `example`, `example-1`, `example-2` instead of colliding again on
+  `example-1`. Headings with no alphanumeric characters still emit no `id` at
+  all and stay out of the anchor namespace.
+
+### Added
+
+- **`MarkdownRegistry::static_params_for(param)`:** derive SSG params for a
+  `#[static_get]` route whose path parameter is not named `slug` — e.g.
+  `#[static_get("/docs/{page}", params = …)]` needs
+  `static_params_for("page")`, because a `StaticParams` entry keyed `"slug"`
+  leaves `{page}` unsubstituted. `static_params()` is unchanged and now
+  delegates to it with `"slug"`.
+
 ### Performance
 
 - **config reads on the request path:** generated auth handlers, the admin

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,13 +13,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   document-unique heading `id`s. A page that repeated a heading — and real docs
   repeat "Example", "Usage", and "Notes" constantly — emitted the same `id`
   twice, which is invalid HTML and made every table-of-contents entry for the
-  repeated heading jump to the first occurrence. The first use of a slug is
-  still handed back unchanged, so anchors already published in URLs keep
-  resolving; later collisions get a `-1`, `-2`, … suffix, the convention
-  GitHub, mdBook, and Hugo share. The suffix search skips ids already claimed by
-  an unrelated heading, so `## Example` / `## Example 1` / `## Example` yields
-  `example`, `example-1`, `example-2` instead of colliding again on
-  `example-1`. Headings with no alphanumeric characters still emit no `id` at
+  repeated heading jump to the first occurrence. Every heading still keeps the
+  slug its own text produces, so anchors already published in URLs keep
+  resolving; only *repeats* of an already-claimed slug get a `-1`, `-2`, …
+  suffix, the convention GitHub, mdBook, and Hugo share. Because the renderer
+  reserves every heading's natural slug before handing out any suffix, a repeat
+  can never steal a slug another heading owns by name regardless of the order
+  the two appear in: `## Example` / `## Example` / `## Example 1` renders
+  `example`, `example-2`, `example-1`, leaving `#example-1` pointing at
+  "Example 1". Headings with no alphanumeric characters still emit no `id` at
   all and stay out of the anchor namespace.
 
 ### Added

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -130,15 +130,15 @@ The island crate that produces the wasm lives in `examples/island-flock`
 
 ---
 
-### `examples/wiki` — Mutation Hooks and Revision History
+### `examples/wiki` — Mutation Hooks, Revision History, and Markdown Docs
 
 <!-- catalog:example name=wiki tier=supported -->
 
 | Field | Value |
 |-------|-------|
-| **Persona** | Developer adding audit trails and lifecycle hooks to a content model |
-| **Journey** | Hooks/revisions: slug lifecycle, before/after-save hooks, full revision history, REST API |
-| **Key capabilities** | `#[model]` hooks, revision tracking, slug generation, generated REST API |
+| **Persona** | Developer adding audit trails and lifecycle hooks to a content model, or serving Markdown-backed docs pages |
+| **Journey** | Hooks/revisions: slug lifecycle, before/after-save hooks, full revision history, REST API. Docs: embedded `content/*.md` rendered live at `/docs/{slug}` and pre-rendered to `dist/` by the same handler |
+| **Key capabilities** | `#[model]` hooks, revision tracking, slug generation, generated REST API, `markdown` feature (`MarkdownRegistry` + frontmatter + TOC) composed with `#[static_get]` SSG |
 | **Prerequisites** | Rust 1.88.0+, PostgreSQL |
 | **Run command** | `cargo run -p wiki` |
 | **Success proof** | `curl http://localhost:3000/api/v1/pages` returns `[]` |
@@ -269,6 +269,7 @@ can pick the closest starting point without overlap.
 | Distributed deployment | `bookmarks-distributed` | Primary + replica Postgres, multi-replica web tier, Docker Compose |
 | Horizontal sharding | `bookmarks-sharded` | Tenant → slot → shard routing, control DB, cross-shard fan-out, Docker Compose |
 | Hooks / revisions | `wiki` | Before/after-save hooks, slug lifecycle, full revision trail |
+| Markdown docs + SSG | `wiki` | `markdown` feature: embedded `.md` with frontmatter, TOC, heading anchors, rendered live at `/docs/{slug}` and pre-rendered via `#[static_get]` |
 | Full-stack showcase | `reddit-clone` | Auth, sessions, jobs, channels, email, A/B experiments, signed webhooks, outbound HTTP, error reporting — the complete feature showcase |
 | Multi-tenant SaaS starter | `saas` | Session auth + row-level tenancy + tenant-scoped dashboard — the flagship `autumn new --starter saas` archetype |
 | Live mesh rooms | `media-room` | Installs `autumn-media-plugin` with rooms and creates/lists mesh-call rooms through the mounted `RoomService` |

--- a/autumn/src/markdown/mod.rs
+++ b/autumn/src/markdown/mod.rs
@@ -56,8 +56,9 @@
 //!
 //! Heading anchors are unique per document: a heading repeated within a page
 //! keeps the plain slug on its first occurrence (`#example`) and later ones are
-//! suffixed (`#example-1`), so every entry in [`RenderedMarkdown::toc`] links to
-//! its own heading.
+//! suffixed (`#example-1`), so every entry in the
+//! [`RenderedMarkdown`](crate::markdown::RenderedMarkdown) table of contents
+//! links to its own heading.
 //!
 //! ### 3. Wire up static pre-rendering
 //!

--- a/autumn/src/markdown/mod.rs
+++ b/autumn/src/markdown/mod.rs
@@ -54,6 +54,11 @@
 //! }
 //! ```
 //!
+//! Heading anchors are unique per document: a heading repeated within a page
+//! keeps the plain slug on its first occurrence (`#example`) and later ones are
+//! suffixed (`#example-1`), so every entry in [`RenderedMarkdown::toc`] links to
+//! its own heading.
+//!
 //! ### 3. Wire up static pre-rendering
 //!
 //! ```rust,ignore

--- a/autumn/src/markdown/registry.rs
+++ b/autumn/src/markdown/registry.rs
@@ -126,11 +126,36 @@ impl MarkdownRegistry {
     /// ```
     #[must_use]
     pub fn static_params(&self) -> Vec<StaticParams> {
-        self.all_sorted()
-            .into_iter()
+        self.static_params_for("slug")
+    }
+
+    /// Derive one [`StaticParams`] per page, binding each page's slug to the
+    /// route parameter named `param`.
+    ///
+    /// Use this when the `#[static_get]` route names its parameter something
+    /// other than `slug` — e.g. `#[static_get("/docs/{page}", …)]` needs
+    /// `static_params_for("page")`, because a `StaticParams` entry keyed
+    /// `"slug"` would leave `{page}` unsubstituted.
+    ///
+    /// Pages are returned in sorted order (same as [`MarkdownRegistry::all_sorted`]).
+    ///
+    /// # Example
+    ///
+    /// ```rust,ignore
+    /// async fn doc_params(_router: axum::Router) -> Vec<StaticParams> {
+    ///     docs_registry().static_params_for("page")
+    /// }
+    ///
+    /// #[static_get("/docs/{page}", params = doc_params)]
+    /// async fn show_doc(Path(page): Path<String>) -> AutumnResult<Markup> { ... }
+    /// ```
+    #[must_use]
+    pub fn static_params_for(&self, param: &str) -> Vec<StaticParams> {
+        self.pages
+            .values()
             .map(|p| {
                 let mut params = StaticParams::new();
-                params.insert("slug".to_owned(), p.slug.clone());
+                params.insert(param.to_owned(), p.slug.clone());
                 params
             })
             .collect()
@@ -381,6 +406,25 @@ mod tests {
         let params = registry.static_params();
         assert_eq!(params[0].get("slug").unwrap(), "getting-started");
         assert_eq!(params[1].get("slug").unwrap(), "api-reference");
+    }
+
+    #[test]
+    fn static_params_for_uses_custom_param_name() {
+        // `#[static_get("/docs/{page}")]` binds a param named `page`, not
+        // `slug`. Without a keyed helper, SSG for such a route gets params it
+        // cannot substitute.
+        let registry = MarkdownRegistry::from_embedded(&[GETTING_STARTED, API_REFERENCE]).unwrap();
+        let params = registry.static_params_for("page");
+        assert_eq!(params.len(), 2);
+        assert_eq!(params[0].get("page").unwrap(), "getting-started");
+        assert_eq!(params[1].get("page").unwrap(), "api-reference");
+        assert!(!params[0].contains_key("slug"));
+    }
+
+    #[test]
+    fn static_params_delegates_to_static_params_for_slug() {
+        let registry = MarkdownRegistry::from_embedded(&[GETTING_STARTED, API_REFERENCE]).unwrap();
+        assert_eq!(registry.static_params(), registry.static_params_for("slug"));
     }
 
     #[test]

--- a/autumn/src/markdown/registry.rs
+++ b/autumn/src/markdown/registry.rs
@@ -422,12 +422,6 @@ mod tests {
     }
 
     #[test]
-    fn static_params_delegates_to_static_params_for_slug() {
-        let registry = MarkdownRegistry::from_embedded(&[GETTING_STARTED, API_REFERENCE]).unwrap();
-        assert_eq!(registry.static_params(), registry.static_params_for("slug"));
-    }
-
-    #[test]
     fn empty_registry_is_empty() {
         let registry = MarkdownRegistry::from_embedded(&[]).unwrap();
         assert!(registry.is_empty());

--- a/autumn/src/markdown/renderer.rs
+++ b/autumn/src/markdown/renderer.rs
@@ -153,6 +153,11 @@ fn heading_text(events: &[Event<'_>], start: usize) -> String {
 /// `## Example` would take `example-1`, and a `#example-1` link already
 /// published against `## Example 1` would silently resolve to a different
 /// heading — worse for a docs site than a dead link.
+///
+/// A heading whose *own* slug already ends in `-N`, repeated, can only be
+/// disambiguated by suffixing the whole slug — `# x-1` twice yields `x-1` and
+/// `x-1-1`, as it does on GitHub. Reallocating the repeat from the `x` root
+/// would hand it `x-2`, which reads as belonging to a heading titled "x 2".
 struct AnchorAllocator {
     /// Slugs handed out so far.
     used: std::collections::HashSet<String>,
@@ -503,20 +508,33 @@ mod tests {
     }
 
     #[test]
-    fn suffixes_never_nest() {
-        // A base slug that is itself a suffixed form must not produce `x-1-1`.
+    fn every_heading_keeps_its_own_natural_slug() {
+        // With three `# x` competing for suffixes, the headings whose own text
+        // yields "x-1"/"x-2" must still get those exact ids — the repeats are
+        // pushed past them rather than squatting on them.
         let md = "# x\n# x\n# x\n# x-1\n# x-2\n# x\n";
         let result = render(md, RenderOptions::default());
         let ids: Vec<&str> = result.toc.iter().map(|t| t.id.as_str()).collect();
-        for id in &ids {
-            assert!(
-                !id.contains("-1-"),
-                "nested suffix in {id:?} (all: {ids:?})"
-            );
-        }
-        // Headings whose own text yields "x-1"/"x-2" keep those ids.
         assert_eq!(ids[3], "x-1");
         assert_eq!(ids[4], "x-2");
+        assert_eq!(ids[0], "x");
+        // Repeats of "x" skip the reserved x-1/x-2 entirely.
+        assert_eq!(ids[1], "x-3");
+        assert_eq!(ids[2], "x-4");
+        assert_eq!(ids[5], "x-5");
+    }
+
+    #[test]
+    fn repeat_of_a_numeric_looking_slug_nests_its_suffix() {
+        // A heading whose *own* slug already ends in `-N`, repeated, can only
+        // be disambiguated by suffixing the whole slug: `x-1` then `x-1-1`.
+        // This is what GitHub does too. Reallocating the second one from the
+        // "x" root would hand it `x-2`, which reads as belonging to a heading
+        // titled "x 2" — so nesting is the honest outcome, not a defect.
+        let md = "# x-1\n# x-1\n";
+        let result = render(md, RenderOptions::default());
+        let ids: Vec<&str> = result.toc.iter().map(|t| t.id.as_str()).collect();
+        assert_eq!(ids, vec!["x-1", "x-1-1"]);
     }
 
     #[test]

--- a/autumn/src/markdown/renderer.rs
+++ b/autumn/src/markdown/renderer.rs
@@ -7,9 +7,12 @@ use crate::markdown::types::{RenderOptions, RenderedMarkdown, TocItem};
 /// Render Markdown body text to HTML, injecting stable `id` attributes on
 /// every heading and returning an ordered table of contents.
 ///
-/// Anchors are unique within a document: a repeated heading keeps the plain
-/// slug on its first occurrence and gets a `-1`, `-2`, … suffix on later ones,
-/// so the HTML stays valid and every TOC entry links to its own heading.
+/// Anchors are unique within a document, so the HTML stays valid and every TOC
+/// entry links to its own heading. Each heading keeps the slug its own text
+/// produces; only *repeats* of an already-claimed slug are suffixed with `-1`,
+/// `-2`, … A suffix never takes a slug that another heading owns by name, so
+/// `## Example` / `## Example` / `## Example 1` renders `example`, `example-2`,
+/// `example-1` — `#example-1` still points at "Example 1" either way round.
 ///
 /// Fenced code blocks preserve their language hint as a `language-{lang}`
 /// CSS class. Raw HTML in the source is escaped rather than emitted — this
@@ -58,26 +61,14 @@ pub fn render(body: &str, options: RenderOptions) -> RenderedMarkdown {
 
     let mut toc: Vec<TocItem> = Vec::new();
     let mut output: Vec<Event<'_>> = Vec::with_capacity(raw.len());
-    let mut anchors = AnchorAllocator::default();
+    let mut anchors = AnchorAllocator::with_reserved(&raw);
 
     let mut i = 0;
     while i < raw.len() {
         match &raw[i] {
             Event::Start(Tag::Heading { level, .. }) => {
                 let level_u8 = heading_level_to_u8(*level);
-                // Look ahead to collect the heading's plain-text content.
-                let mut text = String::with_capacity(128);
-                let mut j = i + 1;
-                while j < raw.len() {
-                    match &raw[j] {
-                        Event::Text(t) | Event::Code(t) => text.push_str(t),
-                        // Preserve word boundaries across soft/hard line breaks.
-                        Event::SoftBreak | Event::HardBreak => text.push(' '),
-                        Event::End(TagEnd::Heading(_)) => break,
-                        _ => {}
-                    }
-                    j += 1;
-                }
+                let text = heading_text(&raw, i);
                 let id = anchors.allocate(&heading_id(&text));
                 // Only inject an id and add a TOC entry when the heading has
                 // at least one alphanumeric character.  An empty id (e.g. a
@@ -125,6 +116,22 @@ pub fn render(body: &str, options: RenderOptions) -> RenderedMarkdown {
     RenderedMarkdown { html, toc }
 }
 
+/// Collect a heading's plain-text content, given the index of its
+/// `Event::Start(Tag::Heading { .. })` in `events`.
+fn heading_text(events: &[Event<'_>], start: usize) -> String {
+    let mut text = String::with_capacity(128);
+    for event in &events[start + 1..] {
+        match event {
+            Event::Text(t) | Event::Code(t) => text.push_str(t),
+            // Preserve word boundaries across soft/hard line breaks.
+            Event::SoftBreak | Event::HardBreak => text.push(' '),
+            Event::End(TagEnd::Heading(_)) => break,
+            _ => {}
+        }
+    }
+    text
+}
+
 /// Hands out document-unique heading anchors.
 ///
 /// A document may legitimately repeat a heading ("Example", "Usage", "Notes"),
@@ -133,25 +140,53 @@ pub fn render(body: &str, options: RenderOptions) -> RenderedMarkdown {
 /// produces duplicate `id` attributes — invalid HTML — and makes every TOC
 /// link for the repeated heading jump to the first occurrence.
 ///
-/// The first use of a slug is handed back unchanged, so anchors already
-/// published in URLs keep resolving; later collisions get a `-1`, `-2`, …
-/// suffix (the convention GitHub, mdBook, and Hugo all use). The suffix search
-/// skips candidates already claimed by an unrelated heading, so a document
-/// containing `## Example`, `## Example 1`, `## Example` yields `example`,
-/// `example-1`, `example-2` rather than colliding on `example-1`.
-#[derive(Default)]
+/// Every heading keeps the slug its own text produces; only *repeats* of an
+/// already-claimed slug are suffixed with `-1`, `-2`, … (the convention
+/// GitHub, mdBook, and Hugo all use). To make that hold regardless of heading
+/// order, the allocator is seeded with every heading's natural slug up front
+/// and never hands one out as a suffix. A document containing `## Example`,
+/// `## Example`, `## Example 1` therefore yields `example`, `example-2`,
+/// `example-1` — the second `## Example` skips past `example-1` because
+/// `## Example 1` owns it by name, whether it appears before or after.
+///
+/// Without that reservation the suffix search would be first-come: the second
+/// `## Example` would take `example-1`, and a `#example-1` link already
+/// published against `## Example 1` would silently resolve to a different
+/// heading — worse for a docs site than a dead link.
 struct AnchorAllocator {
+    /// Slugs handed out so far.
     used: std::collections::HashSet<String>,
+    /// Every slug some heading in the document produces from its own text.
+    /// Never used as a collision suffix, so each such heading can claim it.
+    reserved: std::collections::HashSet<String>,
     /// Highest suffix tried per base slug, so a heading repeated `n` times
     /// costs O(n) probes in total rather than O(n²).
     next_suffix: std::collections::HashMap<String, usize>,
 }
 
 impl AnchorAllocator {
-    /// Reserve and return a unique anchor derived from `base`.
+    /// Seed the allocator with the natural slug of every heading in `events`.
+    fn with_reserved(events: &[Event<'_>]) -> Self {
+        let mut reserved = std::collections::HashSet::new();
+        for (i, event) in events.iter().enumerate() {
+            if matches!(event, Event::Start(Tag::Heading { .. })) {
+                let slug = heading_id(&heading_text(events, i));
+                if !slug.is_empty() {
+                    reserved.insert(slug);
+                }
+            }
+        }
+        Self {
+            used: std::collections::HashSet::new(),
+            reserved,
+            next_suffix: std::collections::HashMap::new(),
+        }
+    }
+
+    /// Claim and return a unique anchor derived from `base`.
     ///
     /// An empty `base` (a heading with no alphanumeric characters) is returned
-    /// as-is and never reserved — the caller emits no `id` at all for it, so
+    /// as-is and never claimed — the caller emits no `id` at all for it, so
     /// such headings must not consume or collide in the anchor namespace.
     fn allocate(&mut self, base: &str) -> String {
         if base.is_empty() {
@@ -160,14 +195,21 @@ impl AnchorAllocator {
         if self.used.insert(base.to_owned()) {
             return base.to_owned();
         }
-        let counter = self.next_suffix.entry(base.to_owned()).or_insert(0);
-        loop {
-            *counter += 1;
+        // Resume from the highest suffix already tried for this base rather
+        // than rescanning from 1, then write it back below. Taken by value so
+        // the loop can borrow `self.used` mutably.
+        let mut counter = self.next_suffix.get(base).copied().unwrap_or(0);
+        let id = loop {
+            counter += 1;
             let candidate = format!("{base}-{counter}");
-            if self.used.insert(candidate.clone()) {
-                return candidate;
+            // Skip slugs some other heading owns by name, then skip anything
+            // already handed out.
+            if !self.reserved.contains(&candidate) && self.used.insert(candidate.clone()) {
+                break candidate;
             }
-        }
+        };
+        self.next_suffix.insert(base.to_owned(), counter);
+        id
     }
 }
 
@@ -441,6 +483,37 @@ mod tests {
         sorted.sort_unstable();
         sorted.dedup();
         assert_eq!(sorted.len(), ids.len(), "ids must be unique: {ids:?}");
+    }
+
+    #[test]
+    fn duplicate_never_steals_another_headings_natural_slug() {
+        // "Example 1" slugifies naturally to "example-1". A second "Example"
+        // must not take that id just because it appears first — a published
+        // `#example-1` link would then silently resolve to the wrong heading,
+        // which is worse for a docs site than a dead link.
+        let md = "## Example\n\n## Example\n\n## Example 1\n";
+        let result = render(md, RenderOptions::default());
+        let ids: Vec<&str> = result.toc.iter().map(|t| t.id.as_str()).collect();
+        assert_eq!(ids, vec!["example", "example-2", "example-1"]);
+        // The heading that owns "example-1" by its own text keeps it.
+        assert_eq!(result.toc[2].text, "Example 1");
+    }
+
+    #[test]
+    fn suffixes_never_nest() {
+        // A base slug that is itself a suffixed form must not produce `x-1-1`.
+        let md = "# x\n# x\n# x\n# x-1\n# x-2\n# x\n";
+        let result = render(md, RenderOptions::default());
+        let ids: Vec<&str> = result.toc.iter().map(|t| t.id.as_str()).collect();
+        for id in &ids {
+            assert!(
+                !id.contains("-1-"),
+                "nested suffix in {id:?} (all: {ids:?})"
+            );
+        }
+        // Headings whose own text yields "x-1"/"x-2" keep those ids.
+        assert_eq!(ids[3], "x-1");
+        assert_eq!(ids[4], "x-2");
     }
 
     #[test]

--- a/autumn/src/markdown/renderer.rs
+++ b/autumn/src/markdown/renderer.rs
@@ -439,15 +439,31 @@ mod tests {
     #[test]
     fn duplicate_headings_get_unique_ids() {
         // Real docs repeat headings ("Example", "Usage", "Notes"). Emitting the
-        // same `id` twice is invalid HTML and makes both TOC links jump to the
-        // first occurrence.
-        let md = "## Example\n\nFirst.\n\n## Example\n\nSecond.\n";
+        // same `id` twice is invalid HTML and makes every TOC link for the
+        // repeated heading jump to the first occurrence.
+        let md = "## Example\n\nFirst.\n\n## Example\n\nSecond.\n\n## Example\n\nThird.\n";
         let result = render(md, RenderOptions::default());
-        assert_eq!(result.toc.len(), 2);
-        assert_eq!(result.toc[0].id, "example");
-        assert_eq!(result.toc[1].id, "example-1");
+        let ids: Vec<&str> = result.toc.iter().map(|t| t.id.as_str()).collect();
+        assert_eq!(ids, vec!["example", "example-1", "example-2"]);
         assert!(result.html.contains(r#"<h2 id="example">"#));
         assert!(result.html.contains(r#"<h2 id="example-1">"#));
+        assert!(result.html.contains(r#"<h2 id="example-2">"#));
+    }
+
+    #[test]
+    fn anchors_do_not_leak_between_documents() {
+        // The allocator must be per-`render` call. If its state were ever
+        // shared (a `static`/`thread_local`, or a future caching refactor),
+        // the same document would render different anchors depending on what
+        // was rendered before it — silently breaking every published deep link
+        // on a multi-page docs build.
+        let md = "## Example\n\n## Example\n";
+        let first = render(md, RenderOptions::default());
+        let second = render(md, RenderOptions::default());
+        let ids_a: Vec<&str> = first.toc.iter().map(|t| t.id.as_str()).collect();
+        let ids_b: Vec<&str> = second.toc.iter().map(|t| t.id.as_str()).collect();
+        assert_eq!(ids_a, ids_b, "anchor state leaked across render() calls");
+        assert_eq!(ids_a, vec!["example", "example-1"]);
     }
 
     #[test]
@@ -462,14 +478,6 @@ mod tests {
     }
 
     #[test]
-    fn three_duplicate_headings_count_up() {
-        let md = "## Notes\n## Notes\n## Notes\n";
-        let result = render(md, RenderOptions::default());
-        let ids: Vec<&str> = result.toc.iter().map(|t| t.id.as_str()).collect();
-        assert_eq!(ids, vec!["notes", "notes-1", "notes-2"]);
-    }
-
-    #[test]
     fn dedup_suffix_skips_ids_already_taken_by_another_heading() {
         // "Example 1" naturally slugifies to "example-1", which is also the
         // suffix a second "Example" would want. The dedup counter must skip
@@ -478,11 +486,6 @@ mod tests {
         let result = render(md, RenderOptions::default());
         let ids: Vec<&str> = result.toc.iter().map(|t| t.id.as_str()).collect();
         assert_eq!(ids, vec!["example", "example-1", "example-2"]);
-        // Every emitted id must be distinct.
-        let mut sorted = ids.clone();
-        sorted.sort_unstable();
-        sorted.dedup();
-        assert_eq!(sorted.len(), ids.len(), "ids must be unique: {ids:?}");
     }
 
     #[test]
@@ -537,18 +540,34 @@ mod tests {
 
     #[test]
     fn toc_ids_match_emitted_heading_ids() {
-        // The TOC is only useful if every entry's id actually exists in the
-        // rendered HTML.
+        // The TOC is only useful if every entry's id resolves to exactly one
+        // heading. A bare `contains` check would pass vacuously when several
+        // headings share an id, so assert each id appears *once* and that the
+        // document emits no ids beyond the ones the TOC lists.
         let md = "# Guide\n## Example\n### Example\n## Example\n";
         let result = render(md, RenderOptions::default());
-        for item in &result.toc {
-            assert!(
-                result.html.contains(&format!(r#" id="{}">"#, item.id)),
-                "TOC id {:?} has no matching heading in HTML:\n{}",
-                item.id,
+
+        let ids: Vec<&str> = result.toc.iter().map(|t| t.id.as_str()).collect();
+        let mut unique = ids.clone();
+        unique.sort_unstable();
+        unique.dedup();
+        assert_eq!(unique.len(), ids.len(), "TOC ids must be distinct: {ids:?}");
+
+        for id in &ids {
+            let needle = format!(r#" id="{id}">"#);
+            assert_eq!(
+                result.html.matches(&needle).count(),
+                1,
+                "TOC id {id:?} must match exactly one heading in:\n{}",
                 result.html
             );
         }
+        assert_eq!(
+            result.html.matches(r#" id=""#).count(),
+            ids.len(),
+            "every emitted id must be represented in the TOC:\n{}",
+            result.html
+        );
     }
 
     #[test]

--- a/autumn/src/markdown/renderer.rs
+++ b/autumn/src/markdown/renderer.rs
@@ -7,6 +7,10 @@ use crate::markdown::types::{RenderOptions, RenderedMarkdown, TocItem};
 /// Render Markdown body text to HTML, injecting stable `id` attributes on
 /// every heading and returning an ordered table of contents.
 ///
+/// Anchors are unique within a document: a repeated heading keeps the plain
+/// slug on its first occurrence and gets a `-1`, `-2`, … suffix on later ones,
+/// so the HTML stays valid and every TOC entry links to its own heading.
+///
 /// Fenced code blocks preserve their language hint as a `language-{lang}`
 /// CSS class. Raw HTML in the source is escaped rather than emitted — this
 /// function rewrites pulldown-cmark's `Html`/`InlineHtml` events to text before
@@ -54,6 +58,7 @@ pub fn render(body: &str, options: RenderOptions) -> RenderedMarkdown {
 
     let mut toc: Vec<TocItem> = Vec::new();
     let mut output: Vec<Event<'_>> = Vec::with_capacity(raw.len());
+    let mut anchors = AnchorAllocator::default();
 
     let mut i = 0;
     while i < raw.len() {
@@ -73,7 +78,7 @@ pub fn render(body: &str, options: RenderOptions) -> RenderedMarkdown {
                     }
                     j += 1;
                 }
-                let id = heading_id(&text);
+                let id = anchors.allocate(&heading_id(&text));
                 // Only inject an id and add a TOC entry when the heading has
                 // at least one alphanumeric character.  An empty id (e.g. a
                 // punctuation-only heading like `# !!!`) would produce invalid
@@ -120,6 +125,52 @@ pub fn render(body: &str, options: RenderOptions) -> RenderedMarkdown {
     RenderedMarkdown { html, toc }
 }
 
+/// Hands out document-unique heading anchors.
+///
+/// A document may legitimately repeat a heading ("Example", "Usage", "Notes"),
+/// but [`heading_id`] is a pure function of the heading text, so every
+/// repetition slugifies to the same string. Emitting that string twice
+/// produces duplicate `id` attributes — invalid HTML — and makes every TOC
+/// link for the repeated heading jump to the first occurrence.
+///
+/// The first use of a slug is handed back unchanged, so anchors already
+/// published in URLs keep resolving; later collisions get a `-1`, `-2`, …
+/// suffix (the convention GitHub, mdBook, and Hugo all use). The suffix search
+/// skips candidates already claimed by an unrelated heading, so a document
+/// containing `## Example`, `## Example 1`, `## Example` yields `example`,
+/// `example-1`, `example-2` rather than colliding on `example-1`.
+#[derive(Default)]
+struct AnchorAllocator {
+    used: std::collections::HashSet<String>,
+    /// Highest suffix tried per base slug, so a heading repeated `n` times
+    /// costs O(n) probes in total rather than O(n²).
+    next_suffix: std::collections::HashMap<String, usize>,
+}
+
+impl AnchorAllocator {
+    /// Reserve and return a unique anchor derived from `base`.
+    ///
+    /// An empty `base` (a heading with no alphanumeric characters) is returned
+    /// as-is and never reserved — the caller emits no `id` at all for it, so
+    /// such headings must not consume or collide in the anchor namespace.
+    fn allocate(&mut self, base: &str) -> String {
+        if base.is_empty() {
+            return String::new();
+        }
+        if self.used.insert(base.to_owned()) {
+            return base.to_owned();
+        }
+        let counter = self.next_suffix.entry(base.to_owned()).or_insert(0);
+        loop {
+            *counter += 1;
+            let candidate = format!("{base}-{counter}");
+            if self.used.insert(candidate.clone()) {
+                return candidate;
+            }
+        }
+    }
+}
+
 const fn heading_level_to_u8(level: HeadingLevel) -> u8 {
     match level {
         HeadingLevel::H1 => 1,
@@ -137,6 +188,15 @@ const fn heading_level_to_u8(level: HeadingLevel) -> u8 {
 /// remaining parts, filters empty parts, and joins with `-`.  Non-ASCII
 /// scripts (e.g. German umlauts, CJK characters) are preserved so that
 /// anchors remain meaningful for non-English content.
+///
+/// This is a pure function of the heading text, so two headings that read the
+/// same produce the same ID. [`render`] deduplicates within a document by
+/// suffixing later collisions; call this directly only when you need the raw
+/// slug for one piece of text.
+///
+/// Text with no alphanumeric characters (e.g. `"!!!"`) yields an empty string.
+/// [`render`] emits no `id` attribute at all in that case rather than an
+/// invalid `id=""`.
 ///
 /// # Examples
 ///
@@ -332,6 +392,90 @@ mod tests {
         assert!(result.toc.is_empty());
         // The heading tag itself must still be present.
         assert!(result.html.contains("<h1>"));
+    }
+
+    #[test]
+    fn duplicate_headings_get_unique_ids() {
+        // Real docs repeat headings ("Example", "Usage", "Notes"). Emitting the
+        // same `id` twice is invalid HTML and makes both TOC links jump to the
+        // first occurrence.
+        let md = "## Example\n\nFirst.\n\n## Example\n\nSecond.\n";
+        let result = render(md, RenderOptions::default());
+        assert_eq!(result.toc.len(), 2);
+        assert_eq!(result.toc[0].id, "example");
+        assert_eq!(result.toc[1].id, "example-1");
+        assert!(result.html.contains(r#"<h2 id="example">"#));
+        assert!(result.html.contains(r#"<h2 id="example-1">"#));
+    }
+
+    #[test]
+    fn first_occurrence_keeps_unsuffixed_id() {
+        // Heading IDs are URL-visible. Deduplication must only ever *add* a
+        // suffix to later duplicates so existing deep links keep resolving.
+        let md = "# Intro\n\n## Setup\n\n## Setup\n";
+        let result = render(md, RenderOptions::default());
+        assert_eq!(result.toc[0].id, "intro");
+        assert_eq!(result.toc[1].id, "setup");
+        assert_eq!(result.toc[2].id, "setup-1");
+    }
+
+    #[test]
+    fn three_duplicate_headings_count_up() {
+        let md = "## Notes\n## Notes\n## Notes\n";
+        let result = render(md, RenderOptions::default());
+        let ids: Vec<&str> = result.toc.iter().map(|t| t.id.as_str()).collect();
+        assert_eq!(ids, vec!["notes", "notes-1", "notes-2"]);
+    }
+
+    #[test]
+    fn dedup_suffix_skips_ids_already_taken_by_another_heading() {
+        // "Example 1" naturally slugifies to "example-1", which is also the
+        // suffix a second "Example" would want. The dedup counter must skip
+        // past ids that are already in use rather than collide again.
+        let md = "## Example\n\n## Example 1\n\n## Example\n";
+        let result = render(md, RenderOptions::default());
+        let ids: Vec<&str> = result.toc.iter().map(|t| t.id.as_str()).collect();
+        assert_eq!(ids, vec!["example", "example-1", "example-2"]);
+        // Every emitted id must be distinct.
+        let mut sorted = ids.clone();
+        sorted.sort_unstable();
+        sorted.dedup();
+        assert_eq!(sorted.len(), ids.len(), "ids must be unique: {ids:?}");
+    }
+
+    #[test]
+    fn dedup_is_case_insensitive_via_slug() {
+        // "Setup" and "SETUP" slugify to the same id, so the second must be
+        // suffixed.
+        let md = "## Setup\n\n## SETUP\n";
+        let result = render(md, RenderOptions::default());
+        assert_eq!(result.toc[0].id, "setup");
+        assert_eq!(result.toc[1].id, "setup-1");
+    }
+
+    #[test]
+    fn duplicate_punctuation_only_headings_stay_id_free() {
+        // Empty slugs are not ids at all, so they must not participate in
+        // dedup (no `id="-1"` nonsense) and must stay out of the TOC.
+        let result = render("# !!!\n\n# ???\n", RenderOptions::default());
+        assert!(!result.html.contains("id="));
+        assert!(result.toc.is_empty());
+    }
+
+    #[test]
+    fn toc_ids_match_emitted_heading_ids() {
+        // The TOC is only useful if every entry's id actually exists in the
+        // rendered HTML.
+        let md = "# Guide\n## Example\n### Example\n## Example\n";
+        let result = render(md, RenderOptions::default());
+        for item in &result.toc {
+            assert!(
+                result.html.contains(&format!(r#" id="{}">"#, item.id)),
+                "TOC id {:?} has no matching heading in HTML:\n{}",
+                item.id,
+                result.html
+            );
+        }
     }
 
     #[test]

--- a/autumn/src/markdown/types.rs
+++ b/autumn/src/markdown/types.rs
@@ -72,7 +72,13 @@ impl Default for RenderOptions {
 /// The output from rendering a [`MarkdownPage`].
 #[derive(Debug, Clone)]
 pub struct RenderedMarkdown {
-    /// Safe HTML produced from the Markdown body.
+    /// HTML produced from the Markdown body.
+    ///
+    /// Raw HTML in the source is escaped rather than emitted, but this is
+    /// **not** sanitized output — see
+    /// [`render`](crate::markdown::render), which is for trusted build-time
+    /// content only. For user-submitted Markdown use
+    /// [`render_user_content_html`](crate::markdown::render_user_content_html).
     pub html: String,
     /// Table of contents extracted from headings, in document order.
     pub toc: Vec<TocItem>,

--- a/skills/autumn-web/SKILL.md
+++ b/skills/autumn-web/SKILL.md
@@ -346,6 +346,46 @@ introspected — a non-empty opaque table emits a `tracing::warn!`
 ("check skipped") rather than a false pass. See
 `docs/guide/getting-started.md` "Route collision diagnostics".
 
+### Markdown-backed pages + SSG (feature `markdown`)
+
+`MarkdownRegistry` parses `.md` files with `+++` TOML frontmatter (`title`
+required; `description`/`order` default to `""`/`0`) and pairs with
+`#[static_get]` so one handler serves live requests in dev and pre-renders in
+`autumn build`. Build it once in a `OnceLock` from `from_embedded(&[MarkdownSource
+{ slug, content: include_str!(...) }])` or `from_dir(path)` (non-recursive);
+pages sort by `(order, slug)`.
+
+```rust
+async fn doc_params(_router: axum::Router) -> Vec<StaticParams> {
+    docs().static_params()            // one entry per page, keyed "slug"
+}
+
+#[static_get("/docs/{slug}", params = doc_params)]
+async fn show(Path(slug): Path<String>) -> AutumnResult<Markup> {
+    let page = docs().get(&slug).ok_or_else(AutumnError::not_found)?;
+    let out = render(&page.body, RenderOptions::default());
+    Ok(layout(&page.frontmatter.title, html! { (PreEscaped(&out.html)) }))
+}
+```
+
+`static_params()` keys every entry `"slug"`. If the route names its parameter
+anything else — `#[static_get("/docs/{page}", …)]` — use
+`static_params_for("page")` (unreleased — trunk-dev, issue #743); a mismatched
+key leaves `{page}` unsubstituted and the SSG build panics on the invalid URI.
+
+`render` returns `{ html, toc }` and injects heading anchors. Anchors are
+document-unique: each heading keeps the slug its own text produces, and only
+*repeats* are suffixed `-1`, `-2`, … A suffix never takes a slug another heading
+owns by name, so `## Example` / `## Example` / `## Example 1` yields `example`,
+`example-2`, `example-1` — deep links stay put. Headings with no alphanumeric
+characters get no `id` at all.
+
+`render` is for **trusted, build-time content only** — it applies no URL-scheme
+allowlist. For anything a request body carried in, use `render_user_content`
+(see [rich text](../../docs/guide/rich-text.md)). The framework ships no docs
+theme; compose `out.html`/`out.toc` into your own Maud layout. Worked example:
+`examples/wiki` (`src/routes/docs.rs` + `content/*.md`).
+
 ## Models and repositories
 
 Autumn uses Diesel + diesel-async for Postgres. Primary keys are `i64` /


### PR DESCRIPTION
## Context

Issue #743 ("Add first-class Markdown rendering with SSG integration") was already closed, and every acceptance criterion had an implementation. This PR is the result of re-auditing those ACs against what the code actually promises, and closing the places where it fell short.

Two real gaps surfaced, both under ACs that were nominally met.

## 1. Duplicate heading anchors (AC3 — "generates stable heading IDs")

`heading_id` is a pure function of the heading text and `render` kept no per-document state, so a page that repeated a heading emitted the same `id` twice. Real docs repeat "Example", "Usage", and "Notes" constantly, so this fires immediately:

```markdown
## Example
## Example
```

produced two `<h2 id="example">` — invalid HTML, and both table-of-contents links jump to the first section.

`render` now allocates document-unique anchors. Every heading keeps the slug its own text produces, so anchors already published in URLs keep resolving; only *repeats* of an already-claimed slug get a `-1`, `-2`, … suffix, matching GitHub, mdBook, and Hugo.

The first cut of this got the stability guarantee subtly wrong, and code review caught it. A first-come suffix search lets a repeated heading steal a slug that a *later* heading owns by name:

```markdown
## Example
## Example
## Example 1
```

rendered `example`, `example-1`, `example-1-1` — so `#example-1`, previously pointing at the heading literally titled "Example 1", silently retargeted to the second "Example". A deep link resolving to the *wrong* heading is worse for a docs site than a dead one. The renderer now reserves every heading's natural slug in a pre-pass over the already-materialized event vector and never hands a reserved slug out as a suffix, so the guarantee holds regardless of the order the colliding headings appear in (`example`, `example-2`, `example-1`).

Headings with no alphanumeric characters still emit no `id` at all and stay out of the anchor namespace.

Nesting is a deliberate non-guarantee: a heading whose *own* slug already ends in `-N`, repeated, can only be disambiguated by suffixing the whole slug, so `# x-1` twice yields `x-1` and `x-1-1` — as it does on GitHub. Reallocating the repeat from the `x` root would hand it an anchor with no visible relationship to its own text. `repeat_of_a_numeric_looking_slug_nests_its_suffix` pins this.

## 2. `MarkdownRegistry::static_params_for(param)` (AC4 — "helpers to derive `StaticParams`")

`static_params()` hardcoded the `"slug"` key, so a route declaring `#[static_get("/docs/{page}", …)]` got params it could not substitute — `{page}` stayed literal and SSG panicked on the resulting invalid URI. `static_params_for("page")` covers that; `static_params()` is unchanged and delegates to it.

## 3. Catalog discoverability (AC9) and plugin coverage

`examples/wiki` is the AC9 example — embedded `.md` rendered live at `/docs/{slug}` and pre-rendered by the same handler — but its `EXAMPLES.md` entry described only hooks and revisions, leaving the Markdown/SSG story invisible from the catalog. Added to the entry and the capability table.

The `skills/autumn-web` skill likewise mentioned the `markdown` feature only as a one-line feature-table row pointing at the user-content rich-text guide, with nothing on the registry, frontmatter, or SSG composition. Added a section covering all of it.

## Approach

Red/green/refactor throughout. Each behavior change landed as a failing test first — the RED for the anchor collision reproduced as `left: ["example", "example-1", "example-1-1"]` against the expected `["example", "example-2", "example-1"]`.

## Testing

- `cargo test -p autumn-web --features markdown --lib markdown::` — 59 passed (baseline was 48)
- `cargo test -p autumn-web --features markdown --doc markdown` — 5 passed, 6 ignored
- `cargo test -p wiki --bins` — 34 passed
- `cargo clippy -p autumn-web --features markdown --all-targets -- -D warnings` — clean
- `./scripts/pre-push-check.sh` — passed
- `./scripts/check-docs.sh` — passed
- `BASE_REF=origin/trunk-dev ./scripts/check-plugin-freshness.sh` — passed

Reviewed from four angles by separate agents (correctness, security/public-API, AC compliance, test quality). Findings that were acted on:

- **Correctness:** the order-dependent stability bug described above, found by fuzzing a standalone copy of the allocator over 20,000 randomized heading sequences.
- **Security:** no findings. All 1,114,112 Unicode codepoints were brute-forced against `heading_id`; no alphanumeric codepoint lowercases to `"`, `<`, `>`, or whitespace, so the unescaped `id="{id}"` attribute cannot be broken out of. The allocator was measured at `probes/n == 1.00` up to n=128,000 on four adversarial constructions, so the suffix search is not a DoS vector. The `render_user_content` path does not share this renderer, so the trusted/untrusted split is untouched.
- **Test quality (mutation testing):** `toc_ids_match_emitted_heading_ids` was vacuous — `html.contains(id)` is an existence check that survived all eight allocator mutations, including removing dedup entirely. It now asserts each TOC id matches exactly one heading. A second gap: nothing pinned the allocator being per-`render`-call, so swapping the local for a `thread_local!` left the suite green; `anchors_do_not_leak_between_documents` closes that. Two tests that killed no unique mutation were dropped.
- **Docs accuracy:** the `render` doc comment and CHANGELOG claimed order-independent stability the first-come version did not provide, and `RenderedMarkdown.html` was described as "Safe HTML" while the renderer documents itself as explicitly not a sanitizer. Both corrected.
- **Codex review:** caught that the `suffixes_never_nest` test overclaimed — its fixture contained `x-1` only once, so it never exercised the nesting path. Resolved by dropping the guarantee rather than changing the behavior (see above); the test was rewritten as `every_heading_keeps_its_own_natural_slug` to pin what the reservation pass actually provides.

## Compatibility

Additive and non-breaking. `static_params_for` is a new inherent method; `static_params()` keeps its signature. The only observable change is heading ids on documents that repeat a heading — which is the fix. Changelog entries are under `## [Unreleased]`; no version bump.

## Not done

Recursive `from_dir` (nested `content/docs/guide/*.md` silently yields an empty registry) is a real ergonomic limit but is outside every AC here, so I left it alone rather than widen the scope. Worth its own issue if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RjfhecZxd7FHmGk92Zfm96