### PR TITLE
docs: rewrite the getting-started guide against the current scaffold

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1732,6 +1732,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **docs:** rewrote the getting-started guide (`docs/guide/getting-started.md`)
+  against the current scaffold and CLI. The guide had drifted: it announced the
+  "0.4 release line" while pinning 0.6 commands, taught Tailwind v3 directives
+  (`@tailwind base;`) against a scaffold that ships v4 (`@import "tailwindcss";`),
+  showed a legacy `{"error": {...}}` body where the framework answers RFC 9457
+  Problem Details, listed a project tree and an `autumn doctor` transcript that
+  no longer matched what `autumn new` and `doctor` actually emit, put
+  `AUTUMN_PROFILE` ahead of `AUTUMN_ENV` in the profile precedence chain, and
+  pinned `diesel-async` 0.8 against the workspace's 0.9. The prerequisites were
+  wrong in a way that broke the first build: the guide said Postgres was needed
+  "only if you want database features", but `db` is a default feature, so a
+  fresh project links `libpq` at compile time whether or not a database is
+  configured — that, the Diesel CLI requirement, and a Docker one-liner for a
+  throwaway Postgres are now stated up front. Model examples moved to the
+  `BIGSERIAL`/`i64` primary-key convention the generators and `#[repository]`
+  assume, replacing `SERIAL`/`i32`.
+
+  Three sections the guide never had were added: `autumn generate scaffold` as
+  the five-command path to working CRUD (previously reachable only from the
+  generators guide), a testing section built on the `tests/integration_test.rs`
+  the scaffold already writes plus `autumn test`, and a prebuilt-binary install
+  path. In exchange, the ~100-line route-collision-diagnostics appendix and the
+  `_method` override's same-origin bullet list were compressed to their
+  first-hour essentials and now link onward, and the production checklist moved
+  from the middle of the walkthrough to the end. The `#configuration`,
+  `#environment-variable-overrides`, and `#route-collision-diagnostics` anchors
+  are preserved, so the inbound links from `deployment.md`, `openapi.md`, and
+  `skills/autumn-web/SKILL.md` still resolve. Version pins remain on the
+  published 0.6.0 line enforced by `first_run_docs_match_current_release_line`.
+  [no-plugin]
+
 - **Router: the whole ingress stack is now applied in ONE `Router::layer`
   call.** #2193 collapsed ~26 sequential applications down to a handful; #2198
   collapses what was left — the inner group, the user layers, the middle group,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1749,11 +1749,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `BIGSERIAL`/`i64` primary-key convention the generators and `#[repository]`
   assume, replacing `SERIAL`/`i32`.
 
-  Three sections the guide never had were added: `autumn generate scaffold` as
-  the five-command path to working CRUD (previously reachable only from the
-  generators guide), a testing section built on the `tests/integration_test.rs`
-  the scaffold already writes plus `autumn test`, and a prebuilt-binary install
-  path. In exchange, the ~100-line route-collision-diagnostics appendix and the
+  Three sections the guide never had were added. First, `autumn generate
+  scaffold`, previously reachable only from the generators guide — and
+  documented for what it actually produces: the read paths serve immediately,
+  while every write stays locked behind both `#[secured]` and the generated
+  policy until `autumn generate auth` is run, and the JSON write handlers are
+  generated but left unregistered. The guide explains that double gate rather
+  than treating it as a caveat, and walks the signup → email-confirmation →
+  login flow that unlocks the write views. Second, a testing section built on
+  the `tests/integration_test.rs` the scaffold already writes, plus `autumn
+  test`. Third, the prebuilt-binary install path. In exchange, the ~100-line
+  route-collision-diagnostics appendix and the
   `_method` override's same-origin bullet list were compressed to their
   first-hour essentials and now link onward, and the production checklist moved
   from the middle of the walkthrough to the end. The `#configuration`,

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -496,8 +496,25 @@ autumn dev
 ```
 
 That writes the `users` migration, the session and remember-token models, the
-handlers, and registers all of them in `src/main.rs`. Sign up, sign in, and the
-create/edit/delete views become reachable.
+handlers, and registers all of them in `src/main.rs`.
+
+Signing up is two steps, not one — the generated flow does not log you in:
+
+1. Sign up at <http://localhost:3000/signup>. The account is created
+   **unconfirmed**, and login rejects unconfirmed accounts.
+2. Open the confirmation link. On the `dev` profile Autumn defaults the mail
+   transport to `log` when `[mail]` is unset, so the confirmation email is
+   printed straight into your `autumn dev` output. Copy the
+   `/auth/confirm/{token}` URL out of the terminal and visit it.
+
+Then log in, and the create/edit/delete views are reachable.
+
+> **On any non-`dev` profile** that smart default does not apply: with `[mail]`
+> unset the transport is `Disabled`, and signup fails fast with a 500 rather
+> than creating an account nobody can confirm. Set `[mail] transport` (use
+> `"log"` locally, `"smtp"` in production) before running the flow there. Same
+> for forgot-password and change-email, which are also mail-gated. See the
+> [mail guide](mail.md).
 
 Read the generated `src/policies/post.rs` before you ship: with no owner column
 detected it authorizes *any* authenticated user and says so in `SECURITY TODO`

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -1,178 +1,308 @@
 # Getting Started with Autumn
 
-This guide takes you from zero to a running Autumn web app with routes, a
-database, HTML templates, interactive UI, and the published `autumn-web` 0.4
-release line. Budget about 30 minutes.
+This guide takes you from an empty directory to a running Autumn application
+with routes, a Postgres-backed model, HTML templates, styling, and
+interactivity. Budget about 30 minutes.
 
 Autumn is a convention-over-configuration web framework for Rust, built on
-[Axum](https://github.com/tokio-rs/axum). It bundles Diesel (database), Maud
-(HTML), Tailwind CSS (styling), htmx (interactivity), actuator endpoints,
-profile-aware configuration, and newer CLI workflows behind a Spring Boot-style
-developer experience.
+[Axum](https://github.com/tokio-rs/axum). It assembles Diesel (database), Maud
+(HTML), Tailwind CSS (styling), htmx (interactivity), health and actuator
+endpoints, profile-aware configuration, and a project CLI behind a Spring
+Boot-style developer experience.
 
-> **Version note:** This is the published-user path for `autumn-web` 0.4.x and
-> `autumn-cli` 0.4.x as of 2026-05-11. If you are contributing from a source
-> checkout, use the local development commands below only after confirming the
-> workspace version still matches this guide.
+> **Version note:** This guide tracks the published `autumn-web` and
+> `autumn-cli` **0.6.x** release line. If you are working from a source
+> checkout of the Autumn repository, the workspace may be ahead of the
+> published crates — see [local development](#local-development) below.
+
+**Where this guide sits.** It is the fast tour. If you want the long-form
+build with checkpoints, work through the
+[tutorial](tutorial/index.md) instead (~2 hours). If you already know your way
+around Rust web frameworks and just want CRUD on screen, jump straight to
+[generate a resource](#the-fast-path-generate-a-crud-resource).
 
 ---
 
 ## Prerequisites
 
-- **Rust 1.88.0+** (edition 2024) -- install via [rustup](https://rustup.rs/)
-- **PostgreSQL** -- only needed if you want database features; Autumn runs
-  fine without one
-- A terminal and a text editor
+- **Rust 1.88.0+** (edition 2024) — install via [rustup](https://rustup.rs/)
+- **The PostgreSQL client library (`libpq`)** — required to *build*, not just
+  to run. The `db` feature is on by default, so a fresh project links `libpq`
+  even before you configure a database. Install `libpq-dev` (Debian/Ubuntu),
+  `libpq` (Homebrew), or `postgresql-devel` (Fedora/RHEL).
+- **A reachable PostgreSQL server** — needed from
+  [Add a database](#add-a-database) onward. The first run works without one;
+  there is a Docker one-liner below when you get there.
+- **The Diesel CLI** — `autumn migrate` shells out to it. Install it once:
+  ```bash
+  cargo install diesel_cli --no-default-features --features postgres
+  ```
 
-Verify your Rust toolchain:
+Verify your toolchain:
 
 ```bash
 rustc --version   # 1.88.0 or later
 cargo --version
 ```
 
+> **Not using a database at all?** Build a JSON API or daemon with
+> `autumn new my-app --api` or `--daemon`. Those flavors drop the view stack
+> or the database respectively; the rest of this guide still applies.
+
 ---
 
 ## Install the CLI
 
-Autumn ships a small CLI for project scaffolding and tooling setup. Install the
-published CLI from crates.io:
+The fastest route is a prebuilt binary — no Rust toolchain needed for the CLI
+itself:
+
+```sh
+# macOS & Linux
+curl -fsSL https://raw.githubusercontent.com/autumn-foundation/autumn/trunk-dev/scripts/install.sh | sh
+```
+
+```powershell
+# Windows
+irm https://raw.githubusercontent.com/autumn-foundation/autumn/trunk-dev/scripts/install.ps1 | iex
+```
+
+Both installers verify a SHA-256 checksum before installing. See the
+[README](../../README.md) for pinning a version or choosing an install
+directory.
+
+To build it from crates.io instead:
 
 ```bash
 cargo install autumn-cli --version 0.6.0
 ```
 
+### Local development
+
 For local development only, from an Autumn source checkout, install the CLI you
-just built instead:
+just built:
 
 ```bash
 cargo install --path autumn-cli
 ```
 
-This gives you the `autumn` binary with the core workflow commands:
+Between releases the workspace can be ahead of the published crates, so a
+source-built CLI may scaffold projects pinning an `autumn-web` version that is
+not on crates.io yet. `autumn doctor`'s `version_compat` check reports the two
+versions side by side; if they disagree, either point the generated
+`Cargo.toml` at your checkout with a `[patch.crates-io]` override or install
+the published CLI instead.
 
-| Command          | What it does                                |
-|------------------|---------------------------------------------|
-| `autumn doctor`  | Diagnose your environment before first run  |
-| `autumn new`     | Scaffold a new project                      |
-| `autumn setup`   | Download Tailwind CSS (with checksum verify) |
-| `autumn dev`     | Run the dev server with file watching        |
-| `autumn build`   | Pre-render `#[static_get]` routes into `dist/` |
-| `autumn migrate` | Run migrations or inspect migration status   |
-| `autumn seed`    | Populate the database with representative data |
-| `autumn console` | Run a pre-wired data playground against your database |
+Either way you get the `autumn` binary. These are the commands you will touch in
+your first hour:
 
----
+| Command                    | What it does                                              |
+|----------------------------|-----------------------------------------------------------|
+| `autumn doctor`            | Diagnose the environment before your first run            |
+| `autumn new`               | Scaffold a new project                                    |
+| `autumn setup`             | Download the Tailwind CSS binary (checksum-verified)      |
+| `autumn dev`               | Run the dev server with file watching and live reload     |
+| `autumn generate`          | Scaffold a model, migration, CRUD routes, and views       |
+| `autumn db`                | Create, drop, or reset the database itself                |
+| `autumn migrate`           | Apply migrations or inspect migration status              |
+| `autumn routes`            | List every mounted route, its handler, and its middleware |
+| `autumn test`              | Provision the test database, migrate it, run `cargo test` |
+| `autumn console`           | Open a pre-wired data playground against your database    |
 
-## Run the Doctor
-
-After installing the CLI, the first command to run from any Autumn project
-root is `autumn doctor`. It checks your environment for common first-run
-problems and tells you exactly what to fix before you waste time chasing
-cryptic errors:
-
-```bash
-autumn doctor
-```
-
-Sample output on a healthy system:
-
-```
-🍂 autumn doctor
-
-✅ rust_toolchain — rustc 1.88.0 ≥ MSRV 1.88.0
-✅ version_compat — autumn-cli 0.6.0 matches autumn-web 0.6.0
-✅ autumn_toml — autumn.toml is valid
-✅ db_connectivity — Postgres reachable at localhost:5432
-✅ pending_migrations — no pending migrations
-✅ port_bindable — port 3000 is available
-✅ tailwind_binary — target/autumn/tailwindcss is present
-✅ stale_artifacts — artifacts look fresh
-
-8 passed, 0 warnings, 0 failed — all clear
-```
-
-If anything is wrong, `autumn doctor` prints a one-line remediation hint
-beneath the failing check.
-
-**Exit codes**: `0` when all checks pass (warnings are allowed); `1` when any
-check fails. Use `--strict` to treat warnings as failures (useful in CI).
-Use `--json` for machine-readable output:
-
-```bash
-# CI pre-flight gate (fail on warnings too)
-autumn doctor --strict
-
-# Machine-readable output for scripts
-autumn doctor --json
-```
+That is a small slice. `autumn --help` lists the full set — deployment
+(`release`, `deploy`), operations (`monitor`, `maintenance`, `canary`,
+`flags`), diagnostics (`replay`, `export`), and more.
 
 ---
 
-## Create a Project
+## Create a project
 
 ```bash
 autumn new my-app
 cd my-app
 ```
 
-This generates:
+That writes:
 
 ```
 my-app/
   Cargo.toml
-  autumn.toml          # framework configuration
-  Dockerfile           # production container image
+  README.md                 # project quickstart, generated for this app
+  autumn.toml               # framework configuration
+  Dockerfile                # production container image
   .dockerignore
-  build.rs             # Tailwind CSS build pipeline
-  src/
-    main.rs            # your application entry point
-  static/
-    css/
-      input.css        # Tailwind directives
-  tailwind.config.js
-  migrations/          # Diesel migrations (empty for now)
+  .env.example              # copy to .env for local secrets/overrides
   .gitignore
+  build.rs                  # Tailwind CSS build pipeline + build provenance
+  rust-toolchain.toml
+  rustfmt.toml
+  clippy.toml
+  src/
+    main.rs                 # your application entry point
+  static/
+    css/input.css           # Tailwind entry point
+    js/htmx.min.js          # vendored, integrity-pinned
+    js/htmx-ext-sse.min.js
+    .autumn-assets.json     # vendored-asset manifest with SRI hashes
+  migrations/               # Diesel migrations (empty for now)
+  tests/
+    integration_test.rs     # working smoke tests, no Docker required
+  config/
+    master.key              # encrypts credentials — keep secret, never commit
+    credentials/development.toml.enc
+  .github/workflows/ci.yml  # fmt, clippy, test, and a11y checks
 ```
-
----
-
-## Project Structure
 
 The files that matter right now:
 
-| File                | Purpose                                    |
-|---------------------|--------------------------------------------|
-| `src/main.rs`       | Routes and application bootstrap           |
-| `autumn.toml`       | Server, probes, telemetry, database config |
-| `Dockerfile`        | Multi-stage production image scaffold      |
-| `.dockerignore`     | Keeps local junk out of container builds   |
-| `build.rs`          | Compiles Tailwind CSS on `cargo build`     |
-| `static/`           | Auto-served at `/static/` (CSS, JS, images)|
-| `migrations/`       | Diesel SQL migrations                      |
+| Path                       | Purpose                                          |
+|----------------------------|--------------------------------------------------|
+| `src/main.rs`              | Routes and application bootstrap                 |
+| `autumn.toml`              | Server, database, logging, probes, telemetry     |
+| `.env.example`             | Template for local env overrides (copy to `.env`)|
+| `build.rs`                 | Compiles Tailwind CSS on `cargo build`           |
+| `static/`                  | Auto-served at `/static/`                        |
+| `migrations/`              | Diesel SQL migrations                            |
+| `tests/`                   | Integration tests against the real middleware stack |
+| `config/master.key`        | Decrypts `config/credentials/*.enc` — gitignored |
 
 ---
 
-## Your First Route
+## Preflight with `autumn doctor`
 
-Open `src/main.rs`. The scaffolded app includes a Maud layout, embedded
-migrations, and these starter routes:
+Run this from the project root before anything else. It checks the environment
+and the project config together, and tells you what to fix instead of leaving
+you to decode a runtime error:
+
+```bash
+autumn doctor
+```
+
+On a fresh project, before `autumn setup`, you will see something like:
+
+```
+🍂 autumn doctor
+
+✅ rust_toolchain — rustc 1.88.0 ≥ MSRV 1.88.0
+✅ version_compat — autumn-cli 0.6.0 matches autumn-web 0.6.0
+✅ autumn_toml — autumn.toml and profile configurations are valid
+✅ database_topology — database not configured
+✅ port_bindable — port 3000 is available
+❌ tailwind_binary — target/autumn/tailwindcss not found
+   hint: Run `autumn setup` to download the Tailwind CSS binary
+⚠️  signing_secret — using an ephemeral per-process signing secret (dev/test
+    only; sessions and signed URLs will not survive restarts or be shared
+    across replicas)
+   hint: Set AUTUMN_SECURITY__SIGNING_SECRET before deploying to production
+⚠️  dotenv — `.env.example` is present but no `.env` exists
+   hint: Copy `.env.example` to `.env` and fill in local values
+... (about twenty more checks: TLS, trusted hosts, rate limiting, proxy
+     config, backups, mail, jobs, alerting, model privacy)
+
+23 passed, 3 warnings, 1 failed — problems found
+```
+
+Every failing or warning check prints a one-line remediation hint beneath it.
+Warnings on a fresh project are expected — they are the production checklist,
+not first-run blockers. The exact tally varies with what the machine has
+installed (Chromium for system tests, `pg_dump`/`pg_restore`) and with what you
+have configured, so treat the counts above as illustrative.
+
+**Exit codes:** `0` when every check passes (warnings allowed), `1` when any
+check fails. Two flags matter in automation:
+
+```bash
+autumn doctor --strict   # treat warnings as failures — good CI pre-flight gate
+autumn doctor --json     # machine-readable output
+```
+
+Clear the Tailwind failure now:
+
+```bash
+autumn setup
+```
+
+This downloads the platform-specific Tailwind CSS v4 standalone binary to
+`target/autumn/tailwindcss` and verifies its SHA-256 checksum. Re-run with
+`--force` to re-download.
+
+---
+
+## Run it
+
+```bash
+autumn dev
+```
+
+`autumn dev` watches `src/`, `static/`, `templates/`, `migrations/`, and the
+project's top-level config files, rebuilding and reloading the browser on
+change. To run without watch mode:
+
+```bash
+cargo run
+```
+
+You will see log output like:
+
+```
+  INFO autumn: Database not configured
+  INFO autumn: Listening bound=127.0.0.1:3000
+```
+
+Visit <http://localhost:3000> — you should see "Welcome to my-app!". These
+routes are live immediately:
+
+| Path                  | What it is                                              |
+|-----------------------|---------------------------------------------------------|
+| `/`                   | The scaffolded welcome page                             |
+| `/hello`              | A plain-text handler                                    |
+| `/hello/world`        | A path-parameter handler                                |
+| `/health`             | Health check                                            |
+| `/actuator/health`    | Actuator health, with component detail                  |
+| `/actuator/info`      | Build provenance — git SHA, branch, build timestamp     |
+| `/actuator/metrics`   | Runtime metrics                                         |
+| `/live` `/ready` `/startup` | Kubernetes-style probes                           |
+
+`/health` responds with:
+
+```json
+{ "status": "ok", "version": "0.6.0" }
+```
+
+Press **Ctrl+C** to stop the server. Shutdown is graceful, draining in-flight
+requests up to `server.shutdown_timeout_secs`.
+
+---
+
+## The generated app
+
+Open `src/main.rs`. The scaffold is small but deliberately not a bare
+hello-world — it shows the conventions you will follow as the app grows. Here
+is its skeleton, with the layout helper, the cookie-consent flow, and the
+asset-embedding hooks elided:
 
 ```rust
+use autumn_web::migrate::{EmbeddedMigrations, embed_migrations};
+use autumn_web::prelude::*;
+
+const MIGRATIONS: EmbeddedMigrations = embed_migrations!();
+
 #[get("/")]
-async fn index() -> maud::Markup {
-    layout("Welcome", maud::html! {
+#[public]
+async fn index(flash: Flash, path: CurrentPath) -> maud::Markup {
+    layout("Welcome", path.as_str(), flash_messages(&flash.consume().await), maud::html! {
         h1 { "Welcome to my-app!" }
         p { "Edit " code { "src/main.rs" } " to get started." }
     })
 }
 
 #[get("/hello")]
+#[public]
 async fn hello() -> &'static str {
     "Hello, Autumn!"
 }
 
 #[get("/hello/{name}")]
+#[public]
 async fn hello_name(name: autumn_web::extract::Path<String>) -> String {
     format!("Hello, {}!", *name)
 }
@@ -187,105 +317,65 @@ async fn main() {
 }
 ```
 
-The key pieces:
+The pieces:
 
-- **`#[get("/path")]`** -- annotates a handler for GET requests. Also
-  available: `#[post]`, `#[put]`, `#[delete]`.
-- **`routes![...]`** -- collects annotated handlers into a `Vec<Route>`.
-- **`autumn_web::app().routes(...).run().await`** -- the app builder. Load config,
-  create the database pool, mount routes, start the server.
-- **`.migrations(MIGRATIONS)`** -- embeds and applies the app's Diesel
-  migrations when a database is configured.
-- **`#[autumn_web::main]`** -- sets up the Tokio async runtime. It is a thin
-  wrapper around `#[tokio::main]`.
+- **`#[get("/path")]`** annotates a handler for GET requests. Also available:
+  `#[post]`, `#[put]`, `#[patch]`, `#[delete]`, plus `#[static_get]` for routes
+  pre-rendered to `dist/` by `autumn build`.
+- **`#[public]`** marks a route as deliberately unauthenticated. Autumn can
+  prove authentication coverage at build time — `autumn routes audit` fails on
+  any route that is neither framework-owned, guarded by `#[secured]` /
+  `#[authorize]`, nor explicitly `#[public]`. See
+  [route auth coverage](route-auth-coverage.md).
+- **`routes![...]`** collects annotated handlers into a `Vec<Route>`.
+- **`autumn_web::app().routes(...).run().await`** is the app builder: load
+  config, create the database pool, mount routes, start the server.
+- **`.migrations(MIGRATIONS)`** embeds the app's Diesel migrations in the
+  binary. On the `dev` profile they are applied at startup; every other profile
+  is opt-in via `database.auto_migrate` (see
+  [migrations](migrations.md)).
+- **`#[autumn_web::main]`** sets up the Tokio runtime — a thin wrapper around
+  `#[tokio::main]` that also records the build profile.
 
-Handlers are regular async functions. They can return any type that Axum can
-turn into an HTTP response: `&str`, `String`, `Json<T>`, `Markup` (Maud HTML),
-or your own `impl IntoResponse`.
+Handlers are ordinary async functions. They can return anything Axum can turn
+into a response: `&str`, `String`, `Json<T>`, `Markup` (Maud HTML), or your own
+`impl IntoResponse`.
 
----
+What the excerpt above leaves out is worth opening the file for. The scaffold's
+`layout()` wires in a nav bar with `aria-current` tracking, a skip-to-content
+link, flash messages, and the framework's widget CSS. Alongside it is a working
+cookie-consent flow — a banner injected by a `.layer(...)` on the builder,
+CSRF-protected accept/reject routes, and a preferences page linked from the
+footer so withdrawing consent is as easy as giving it. There is also a
+`#[cfg(feature = "embed-assets")]` block that bakes `static/` into the binary
+for `autumn build --embed`. All of it is ordinary user code: delete what you do
+not need.
 
-## Run It
+To see everything that is actually mounted, including framework routes and
+per-route middleware:
 
 ```bash
-autumn dev
+autumn routes
 ```
-
-If you prefer not to use watch mode:
-
-```bash
-cargo run
-```
-
-You will see log output like:
-
-```
-  INFO autumn: Database not configured
-  INFO autumn: Listening addr=127.0.0.1:3000
-```
-
-Visit [http://localhost:3000](http://localhost:3000) -- you should see
-"Welcome to my-app!". Try
-[http://localhost:3000/hello/world](http://localhost:3000/hello/world) for the
-path parameter route.
-
-A health check is automatically mounted at
-[http://localhost:3000/health](http://localhost:3000/health). Actuator
-endpoints are also auto-mounted at
-[http://localhost:3000/actuator/health](http://localhost:3000/actuator/health),
-[http://localhost:3000/actuator/info](http://localhost:3000/actuator/info), and
-[http://localhost:3000/actuator/metrics](http://localhost:3000/actuator/metrics).
-Probe endpoints are also available at `/live`, `/ready`, and `/startup`.
-
-The `/health` response looks like:
-
-```json
-{ "status": "ok", "version": "0.6.0" }
-```
-
-Press **Ctrl+C** to stop the server (graceful shutdown with a configurable
-drain timeout).
 
 ---
 
-## Production Notes
+## Routing essentials
 
-The generated app starts with local-safe defaults:
-
-- sessions are in-memory unless you switch to Redis
-- `#[scheduled]` tasks run in-process
-- the generated Dockerfile is generic container scaffolding, not a full Kubernetes deployment
-
-Before deploying multiple replicas, you should usually:
-
-1. Set `AUTUMN_PROFILE=prod`
-2. Configure `/live`, `/ready`, and `/startup` in your platform probes
-3. Enable OTLP telemetry and point it at your collector
-4. Move sessions to Redis
-5. Run migrations as a one-shot job before starting web replicas
-
-The scaffolded `Dockerfile` and `autumn.toml` include commented examples for
-probes, telemetry, and Redis sessions. For the full deployment story, read the
-[Cloud-Native Guide](cloud-native.md).
-
----
-
-## Path Parameters
-
-Axum-style path parameters use curly braces in the route pattern and the
-`Path<T>` extractor in the handler signature:
+Path parameters use curly braces in the pattern and the `Path<T>` extractor in
+the signature:
 
 ```rust
 use autumn_web::extract::Path;
 use autumn_web::get;
 
 #[get("/users/{id}")]
-async fn get_user(id: Path<i32>) -> String {
+async fn get_user(id: Path<i64>) -> String {
     format!("User #{}", *id)
 }
 ```
 
-Multiple parameters work by destructuring a tuple:
+Multiple parameters destructure a tuple:
 
 ```rust
 #[get("/orgs/{org}/repos/{repo}")]
@@ -294,7 +384,7 @@ async fn get_repo(Path((org, repo)): Path<(String, String)>) -> String {
 }
 ```
 
-You can also use `Query<T>` for query string parameters:
+Query strings use `Query<T>` over any `Deserialize` type:
 
 ```rust
 use autumn_web::extract::Query;
@@ -314,32 +404,86 @@ async fn list_items(Query(params): Query<Pagination>) -> String {
 }
 ```
 
+Compose route groups by calling `.routes()` more than once — one call per
+module keeps `main.rs` readable as the app grows:
+
+```rust
+autumn_web::app()
+    .routes(routes![index, hello, hello_name])
+    .routes(routes![list_items, get_user, get_repo])
+    .run()
+    .await;
+```
+
+To mount a group under a path prefix *and* wrap it in a Tower layer — the usual
+shape for a guarded API surface — use `.scoped(prefix, layer, routes)`. Unlike
+a raw merged router, scoped routes stay in the route registry, so
+`autumn routes`, the auth audit, and OpenAPI still see them:
+
+```rust
+use autumn_web::middleware::RequestIdLayer; // any Tower Layer
+
+autumn_web::app()
+    .routes(routes![index])
+    .scoped("/api/v1", RequestIdLayer::default(), routes![list_items])
+    .run()
+    .await;
+```
+
 ---
 
-## Set Up the Database
+## The fast path: generate a CRUD resource
+
+Before writing CRUD by hand, know that you usually do not have to.
+`autumn generate scaffold` emits the model, the migration, the `schema.rs`
+entry, a `#[repository]`, HTML routes and views, a JSON API, and a smoke test —
+then registers everything in `src/main.rs`:
+
+```bash
+autumn new my-app
+cd my-app
+autumn generate scaffold Post title:String body:Text published:bool
+# configure [database] in autumn.toml (next section), then:
+autumn db create
+autumn migrate
+autumn dev
+```
+
+Visit <http://localhost:3000/posts> for the generated index page, or
+<http://localhost:3000/api/posts> for the JSON endpoint.
+
+The field DSL carries validation and relationships too — `title:String{min=3,max=120}`
+emits both a server-side `#[validate(length(...))]` rule and the matching HTML5
+constraint; `body:richtext` swaps the textarea for a sanitizing Markdown editor;
+`post:references` with `--belongs-to Post` scaffolds the parent's show page with
+its children listed and an inline create form.
+
+Generated code uses only macros and conventions Autumn already ships, so once a
+generator has run the files are ordinary user code you should edit freely.
+`autumn destroy` cleanly reverses a matching `generate` invocation. See the
+[code generators guide](generators.md) for the full field DSL, every
+subcommand, and the flags.
+
+The rest of this guide builds that same shape by hand — a `Todo` resource,
+step by step — because knowing what the generator emits is what makes the
+generated code safe to edit.
+
+---
+
+## Add a database
 
 Autumn uses [Diesel](https://diesel.rs/) with
 [diesel-async](https://github.com/weiznich/diesel_async) and
-[deadpool](https://docs.rs/deadpool) for async Postgres connections. Autumn
-drives Diesel for you — the steps below stand up and migrate the database using
-`autumn` commands end to end.
+[deadpool](https://docs.rs/deadpool) for async Postgres connections.
 
-### 1. Install the Diesel CLI
+### 1. Configure the connection
 
-`autumn migrate` shells out to the Diesel CLI to apply migrations, so install it
-once:
-
-```bash
-cargo install diesel_cli --no-default-features --features postgres
-```
-
-### 2. Configure the connection
-
-Edit `autumn.toml` and uncomment the `[database]` section:
+`autumn.toml` ships with the `[database]` block commented out. Uncomment it and
+point it at a reachable Postgres:
 
 ```toml
 [database]
-url = "postgres://localhost/my_app"
+url = "postgres://postgres:postgres@localhost:5432/my_app"
 pool_size = 10
 connect_timeout_secs = 5
 ```
@@ -354,21 +498,36 @@ primary_url = "postgres://localhost/my_app"
 primary_pool_size = 10
 replica_pool_size = 5
 replica_fallback = "fail_readiness"
-auto_migrate_in_production = false
+auto_migrate = false
 ```
 
-`Db`, transactions, advisory locks, and `autumn migrate` use the primary role.
-The optional replica role is for read paths that can tolerate replica replay
-lag according to `replica_fallback`.
+`Db`, transactions, advisory locks, and `autumn migrate` always use the primary
+role. The optional replica role serves read paths that tolerate replay lag,
+governed by `replica_fallback`.
 
-You can also set the primary URL via environment variable, which takes
-precedence over the TOML file:
+Prefer environment variables? Copy `.env.example` to `.env` (already
+gitignored) and set the URL there instead:
 
 ```bash
-export AUTUMN_DATABASE__PRIMARY_URL="postgres://localhost/my_app"
+AUTUMN_DATABASE__PRIMARY_URL="postgres://localhost/my_app"
 ```
 
-(Note the double underscore `__` separating section from field.)
+`autumn dev` auto-loads `.env` on the dev and test profiles, and real shell
+environment variables always win over `.env` values. Note the double
+underscore `__` separating section from field.
+
+### 2. Get a Postgres
+
+Already have one? Skip ahead. Otherwise start a throwaway instance matching the
+URL above:
+
+```bash
+docker run -d --rm --name my-app-pg -e POSTGRES_PASSWORD=postgres \
+  -e POSTGRES_DB=my_app -p 5432:5432 postgres:16
+
+# The container reports "started" before it accepts connections — wait for it.
+until docker exec my-app-pg pg_isready -U postgres >/dev/null 2>&1; do sleep 1; done
+```
 
 ### 3. Create the database
 
@@ -376,36 +535,38 @@ export AUTUMN_DATABASE__PRIMARY_URL="postgres://localhost/my_app"
 autumn db create
 ```
 
-`autumn db create` reads the connection you just configured and creates the
-database on its server. It is idempotent — run it again and it simply reports
-that the database already exists. (Need a clean slate while iterating on your
-schema? See `autumn db reset` below.)
+This reads the connection you configured and creates the database on its
+server. It is idempotent — run it again and it reports that the database
+already exists.
 
-### 4. Create a migration
+### 4. Write a migration
 
 ```bash
 autumn generate migration CreateTodos
 ```
 
-This emits a timestamped migration directory under `migrations/` with `up.sql`
-and `down.sql` files. Edit the generated `up.sql`:
+That emits a timestamped directory under `migrations/` with `up.sql` and
+`down.sql`. Edit `up.sql`:
 
 ```sql
 CREATE TABLE todos (
-    id SERIAL PRIMARY KEY,
+    id BIGSERIAL PRIMARY KEY,
     title TEXT NOT NULL,
     completed BOOLEAN NOT NULL DEFAULT FALSE,
     created_at TIMESTAMP NOT NULL DEFAULT NOW()
 );
 ```
 
-And the `down.sql`:
+And `down.sql`:
 
 ```sql
 DROP TABLE todos;
 ```
 
-Run it:
+`BIGSERIAL` / `i64` is the Autumn primary-key convention — the generators, the
+`#[repository]` macro, and the admin plugin all assume it.
+
+Apply it:
 
 ```bash
 autumn migrate
@@ -414,14 +575,14 @@ autumn migrate
 `autumn migrate` applies every pending migration to the primary database and
 regenerates `src/schema.rs` with Diesel's table macro.
 
-> **Tip — reset the dev database.** While iterating on your schema, run
-> `autumn db reset` to drop, recreate, migrate, and (when a `src/bin/seed.rs`
-> exists) seed the database in a single step. It refuses to run against a
-> production profile unless you pass `--force`.
+> **Tip — reset the dev database.** While iterating on a schema, `autumn db
+> reset` drops, recreates, migrates, and (when `src/bin/seed.rs` exists) seeds
+> in one step. It refuses to run against a production profile without
+> `--force`.
 
 ---
 
-## Define a Model
+## Define a model
 
 Create `src/models.rs`:
 
@@ -435,7 +596,7 @@ use crate::schema::todos;
 #[diesel(table_name = todos)]
 #[diesel(check_for_backend(diesel::pg::Pg))]
 pub struct Todo {
-    pub id: i32,
+    pub id: i64,
     pub title: String,
     pub completed: bool,
     pub created_at: chrono::NaiveDateTime,
@@ -448,38 +609,48 @@ pub struct NewTodo {
 }
 ```
 
-Autumn also provides a `#[model]` attribute macro that auto-derives the
-Diesel and Serde traits for you:
+Autumn's `#[model]` attribute macro derives the Diesel and Serde traits for
+you:
 
 ```rust
 use crate::schema::todos;
 
-// Equivalent to the manual derives above (Queryable, Selectable,
-// Insertable, Serialize, Deserialize) plus #[diesel(table_name = todos)]
+// Equivalent to the manual derives above (Queryable, Selectable, Insertable,
+// Serialize, Deserialize) plus #[diesel(table_name = todos)].
 #[autumn_web::model(table = "todos")]
 pub struct Todo {
-    pub id: i32,
+    pub id: i64,
     pub title: String,
     pub completed: bool,
     pub created_at: chrono::NaiveDateTime,
 }
 ```
 
-If you omit the `table = "..."` argument, the table name is inferred from the
-struct name: `BlogPost` becomes `blog_posts`, `User` becomes `users`.
+Omit `table = "..."` and the table name is inferred from the struct name:
+`BlogPost` becomes `blog_posts`, `User` becomes `users`.
 
-Add the required dependencies to `Cargo.toml`:
+For a full data-access layer — typed finders, pagination, bulk CRUD, hooks,
+soft delete, counter caches — annotate a trait with `#[repository]` instead of
+hand-writing queries. See the [repositories guide](repositories.md).
+
+Writing Diesel code by hand means naming Diesel directly. Add these alongside
+the dependencies `autumn new` already wrote — the scaffold depends only on
+`autumn-web`, `maud`, and `diesel_migrations`, because until now nothing in
+your code referred to Diesel's traits:
 
 ```toml
 [dependencies]
 autumn-web = "0.6"
 chrono = { version = "0.4", features = ["serde"] }
 diesel = { version = "2", features = ["postgres", "chrono"] }
-diesel-async = { version = "0.8", features = ["postgres"] }
+diesel-async = { version = "0.9", features = ["postgres"] }
 serde = { version = "1", features = ["derive"] }
 ```
 
-Don't forget to declare the modules in `main.rs`:
+(`autumn generate scaffold` adds these for you — another reason to let the
+generator lay down the first resource.)
+
+Declare the modules in `main.rs`:
 
 ```rust
 mod models;
@@ -488,11 +659,11 @@ mod schema;
 
 ---
 
-## Query the Database
+## Query the database
 
-Use the `Db` extractor to get an async Postgres connection from the pool.
-It implements `Deref<Target = AsyncPgConnection>`, so you can pass `&mut *db`
-directly to Diesel queries:
+Use the `Db` extractor to take an async connection from the pool. It
+dereferences to the runtime connection type, so `&mut *db` goes straight into
+Diesel queries:
 
 ```rust
 use autumn_web::prelude::*;
@@ -527,43 +698,34 @@ async fn create_todo(mut db: Db, body: Json<NewTodo>) -> AutumnResult<Json<Todo>
 
 Key points:
 
-- **`Db`** is an extractor, not a global. Declare it in your handler signature
-  and Autumn hands you a pooled connection. The connection returns to the pool
-  when the handler completes.
-- **`AutumnResult<T>`** is `Result<T, AutumnError>`. The `?` operator
-  converts any `std::error::Error` into an `AutumnError` with status 500.
-  Diesel errors, I/O errors, serde errors -- they all "just work" with `?`.
-- **`mut db: Db`** -- you need `mut` because Diesel queries take `&mut` on
-  the connection.
+- **`Db` is an extractor, not a global.** Declare it in the handler signature
+  and Autumn hands you a pooled connection, returned to the pool when the
+  handler completes.
+- **`AutumnResult<T>` is `Result<T, AutumnError>`.** The `?` operator converts
+  any `std::error::Error` into an `AutumnError` with status 500 — Diesel
+  errors, I/O errors, serde errors all work.
+- **`mut db: Db`** — Diesel queries take `&mut` on the connection.
 
-Register the new handlers in your `main()`:
+Register the handlers and try it:
 
 ```rust
-mod models;
-mod schema;
-
-use autumn_web::routes;
-
-#[autumn_web::main]
-async fn main() {
-    autumn_web::app()
-        .routes(routes![list_todos, create_todo])
-        .run()
-        .await;
-}
+autumn_web::app()
+    .routes(routes![list_todos, create_todo])
+    .migrations(MIGRATIONS)
+    .run()
+    .await;
 ```
 
-Test it:
-
 ```bash
-# Create a todo
 curl -X POST http://localhost:3000/api/todos \
   -H "Content-Type: application/json" \
   -d '{"title": "Write Autumn guide"}'
 
-# List todos
 curl http://localhost:3000/todos
 ```
+
+Need a transaction across several statements? Use `Db::tx` / `Db::tx_with` —
+see [transactions](transactions.md).
 
 ---
 
@@ -578,12 +740,12 @@ use autumn_web::prelude::*;
 #[get("/")]
 async fn index() -> Markup {
     html! {
-        (autumn_web::PreEscaped("<!DOCTYPE html>"))
+        (maud::DOCTYPE)
         html lang="en" {
             head {
                 meta charset="utf-8";
                 title { "My App" }
-                link rel="stylesheet" href="/static/css/autumn.css";
+                link rel="stylesheet" href=(asset_url("css/autumn.css"));
             }
             body {
                 h1 { "Welcome to my app" }
@@ -596,29 +758,29 @@ async fn index() -> Markup {
 
 Maud syntax in brief:
 
-| Maud                                  | HTML output                              |
-|---------------------------------------|------------------------------------------|
-| `h1 { "Hello" }`                     | `<h1>Hello</h1>`                         |
-| `div class="box" { "content" }`      | `<div class="box">content</div>`         |
-| `input type="text" name="q";`        | `<input type="text" name="q">`           |
-| `(variable)`                          | Escaped interpolation                    |
-| `(PreEscaped(raw_html))`             | Unescaped interpolation                  |
-| `@if cond { ... } @else { ... }`     | Conditional rendering                   |
-| `@for item in &items { ... }`        | Loop rendering                           |
+| Maud                              | HTML output                      |
+|-----------------------------------|----------------------------------|
+| `h1 { "Hello" }`                  | `<h1>Hello</h1>`                 |
+| `div class="box" { "content" }`   | `<div class="box">content</div>` |
+| `input type="text" name="q";`     | `<input type="text" name="q">`   |
+| `(variable)`                      | Escaped interpolation            |
+| `(PreEscaped(raw_html))`          | Unescaped interpolation          |
+| `@if cond { ... } @else { ... }`  | Conditional rendering            |
+| `@for item in &items { ... }`     | Loop rendering                   |
 
 Extract reusable layouts into functions:
 
 ```rust
 fn layout(title: &str, content: Markup) -> Markup {
     html! {
-        (autumn_web::PreEscaped("<!DOCTYPE html>"))
+        (maud::DOCTYPE)
         html lang="en" {
             head {
                 meta charset="utf-8";
                 meta name="viewport" content="width=device-width, initial-scale=1";
                 title { (title) }
-                link rel="stylesheet" href="/static/css/autumn.css";
-                script src="/static/js/htmx.min.js" {}
+                link rel="stylesheet" href=(asset_url("css/autumn.css"));
+                (javascript_include_tag("htmx"))
             }
             body class="bg-gray-100 min-h-screen" {
                 div class="max-w-2xl mx-auto py-10 px-4" {
@@ -628,11 +790,7 @@ fn layout(title: &str, content: Markup) -> Markup {
         }
     }
 }
-```
 
-Then use it in handlers:
-
-```rust
 #[get("/about")]
 async fn about() -> Markup {
     layout("About", html! {
@@ -642,27 +800,20 @@ async fn about() -> Markup {
 }
 ```
 
+`asset_url` and `javascript_include_tag` resolve to plain paths in dev and to
+fingerprinted, integrity-pinned URLs after `autumn build` — so you get cache
+busting without hardcoding hashes.
+
 ---
 
 ## Style with Tailwind CSS
 
-Autumn integrates [Tailwind CSS](https://tailwindcss.com/) via a `build.rs`
-that runs the Tailwind standalone CLI at compile time.
+Autumn integrates [Tailwind CSS](https://tailwindcss.com/) v4 through the
+generated `build.rs`, which runs the Tailwind standalone CLI at compile time.
 
-### 1. Download Tailwind
-
-```bash
-autumn setup
-```
-
-This downloads the platform-specific Tailwind CSS binary to
-`target/autumn/tailwindcss` with SHA-256 checksum verification. Use
-`autumn setup --force` to re-download.
-
-### 2. Write Tailwind classes in your templates
-
-The `build.rs` scans `src/**/*.rs` for class names, so Tailwind utility
-classes inside Maud templates are automatically picked up:
+You already downloaded the binary with `autumn setup`. Write Tailwind utility
+classes directly in your Maud templates — `build.rs` scans `src/**/*.rs` for
+class names:
 
 ```rust
 html! {
@@ -673,38 +824,45 @@ html! {
 }
 ```
 
-### 3. Build
+Then build:
 
 ```bash
 cargo build
 ```
 
-The build script compiles `static/css/input.css` (which contains Tailwind
-directives) into `static/css/autumn.css`. This file is auto-served at
-`/static/css/autumn.css`.
+The build script compiles `static/css/input.css` into `static/css/autumn.css`,
+served at `/static/css/autumn.css` (reference it with
+`asset_url("css/autumn.css")`). The compiled file is a build artifact and is
+gitignored.
 
-Your `input.css` starts with:
+Your `input.css` starts with the Tailwind v4 import:
 
 ```css
-@tailwind base;
-@tailwind components;
-@tailwind utilities;
+@import "tailwindcss";
 ```
 
-Add custom CSS below the directives as needed.
+Add custom CSS below it. Component CSS for Autumn's built-in widgets ships from
+the framework itself at `autumn_web::ui::WIDGETS_CSS_PATH`, so `input.css` only
+needs your app's own styles.
 
-> **Skipping Tailwind:** If you do not need CSS, delete `build.rs` and the
-> Tailwind-related files. Autumn runs fine without them.
+> **Skipping Tailwind:** the build script treats the Tailwind binary as
+> optional — without it, `cargo build` simply skips the CSS step and the app
+> runs unstyled. To drop Tailwind for good, delete `tailwind.config.js` and
+> `static/css/input.css` and remove the Tailwind branch from `build.rs`. Keep
+> the rest of `build.rs`: it also bakes the git SHA, branch, and build
+> timestamp into the binary for `/actuator/info`.
 
 ---
 
-## Add Interactivity with htmx
+## Add interactivity with htmx
 
-Autumn bundles [htmx](https://htmx.org/) and auto-serves it at
-`/static/js/htmx.min.js`. Include the script tag in your layout, then use
-htmx attributes in your Maud templates.
+Autumn vendors [htmx](https://htmx.org/) into `static/js/` with a pinned
+subresource-integrity hash and serves it through
+`javascript_include_tag("htmx")`. Include that in your layout, then use htmx
+attributes in your templates.
 
-Here is a toggle button that updates a todo without a full page reload:
+Here is a toggle-and-delete pair that updates a todo without a full page
+reload:
 
 ```rust
 use autumn_web::prelude::*;
@@ -726,14 +884,14 @@ fn todo_item(todo: &Todo) -> Markup {
     html! {
         li id=(format!("todo-{}", todo.id))
            class="flex items-center gap-3 p-3 bg-white rounded shadow" {
-            // Toggle button -- POST via htmx, swap this <li> with the response
+            // Toggle — POST via htmx, swap this <li> with the response.
             button hx-post=(format!("/todos/{}/toggle", todo.id))
                    hx-target=(format!("#todo-{}", todo.id))
                    hx-swap="outerHTML" {
                 @if todo.completed { "\u{2713}" } @else { "\u{25CB}" }
             }
             span class=(title_class) { (todo.title) }
-            // Delete button -- returns empty string, htmx removes the element
+            // Delete — returns an empty body, htmx removes the element.
             button hx-delete=(format!("/todos/{}", todo.id))
                    hx-target=(format!("#todo-{}", todo.id))
                    hx-swap="outerHTML" {
@@ -743,34 +901,22 @@ fn todo_item(todo: &Todo) -> Markup {
     }
 }
 
-/// Toggle completion status -- returns the updated HTML fragment.
+/// Toggle completion — returns the updated HTML fragment.
 #[post("/todos/{id}/toggle")]
-async fn toggle(id: Path<i32>, mut db: Db) -> AutumnResult<Markup> {
-    let todo: Todo = todos::table
-        .find(*id)
-        .select(Todo::as_select())
-        .first(&mut *db)
-        .await
-        .map_err(AutumnError::not_found)?;
-
-    diesel::update(todos::table.find(*id))
-        .set(todos::completed.eq(!todo.completed))
-        .execute(&mut *db)
-        .await?;
-
-    let updated: Todo = todos::table
-        .find(*id)
-        .select(Todo::as_select())
-        .first(&mut *db)
+async fn toggle(id: Path<i64>, mut db: Db) -> AutumnResult<Markup> {
+    let updated: Todo = diesel::update(todos::table.find(*id))
+        .set(todos::completed.eq(diesel::dsl::not(todos::completed)))
+        .returning(Todo::as_returning())
+        .get_result(&mut *db)
         .await
         .map_err(AutumnError::not_found)?;
 
     Ok(todo_item(&updated))
 }
 
-/// Delete a todo -- returns empty string so htmx removes the element.
+/// Delete a todo — empty response body, so htmx removes the element.
 #[delete("/todos/{id}")]
-async fn delete_todo(id: Path<i32>, mut db: Db) -> AutumnResult<String> {
+async fn delete_todo(id: Path<i64>, mut db: Db) -> AutumnResult<String> {
     diesel::delete(todos::table.find(*id))
         .execute(&mut *db)
         .await?;
@@ -779,104 +925,58 @@ async fn delete_todo(id: Path<i32>, mut db: Db) -> AutumnResult<String> {
 }
 ```
 
-The htmx attributes you will use most often:
+The attributes you will reach for most:
 
-| Attribute     | Purpose                                              |
-|---------------|------------------------------------------------------|
-| `hx-get`      | Issue a GET request to the URL                       |
-| `hx-post`     | Issue a POST request to the URL                      |
-| `hx-delete`   | Issue a DELETE request to the URL                    |
-| `hx-target`   | CSS selector for the element to update               |
-| `hx-swap`     | How to insert the response (`outerHTML`, `innerHTML`, `beforeend`, etc.) |
-| `hx-trigger`  | Event that triggers the request (default: natural event) |
+| Attribute    | Purpose                                                    |
+|--------------|------------------------------------------------------------|
+| `hx-get`     | Issue a GET request to the URL                             |
+| `hx-post`    | Issue a POST request to the URL                            |
+| `hx-delete`  | Issue a DELETE request to the URL                          |
+| `hx-target`  | CSS selector for the element to update                     |
+| `hx-swap`    | How to insert the response (`outerHTML`, `innerHTML`, `beforeend`, …) |
+| `hx-trigger` | Event that fires the request (default: the natural event)  |
 
-The pattern: your handler returns an HTML fragment (not a full page), htmx
-swaps it into the DOM. No JavaScript required.
+The pattern: your handler returns an HTML fragment, htmx swaps it into the DOM.
+No JavaScript required.
 
-### Plain HTML forms targeting PUT/PATCH/DELETE
+### Forms without JavaScript
 
-When you want the same edit and delete flows to work with JavaScript
-disabled (or before htmx loads), submit a plain `<form>` and include a
-hidden `_method` field. Autumn rewrites the request to the declared
-HTTP method **before route matching**, so your `#[put]`, `#[patch]`, and
-`#[delete]` handlers stay semantically honest:
+The same flows should work with JavaScript disabled. Submit a plain `<form>`
+with a hidden `_method` field and Autumn rewrites the request to the declared
+method **before route matching**, so your `#[put]`, `#[patch]`, and `#[delete]`
+handlers stay semantically honest:
 
 ```rust,no_run
 use autumn_web::form::method_input;
 use autumn_web::prelude::*;
-use autumn_web::security::CsrfToken;
 
 #[get("/todos/{id}/edit")]
-async fn edit_form(id: Path<i32>, csrf: Option<CsrfToken>) -> Markup {
+async fn edit_form(id: Path<i64>) -> Markup {
     html! {
         form method="post" action=(format!("/todos/{}", *id)) {
-            // Hidden field. Autumn rewrites this POST to DELETE.
-            (method_input("DELETE"))
-            @if let Some(token) = csrf.as_ref() {
-                input type="hidden" name="_csrf" value=(token.token());
-            }
+            (method_input("DELETE"))   // Autumn rewrites this POST to DELETE
             button type="submit" { "Delete" }
         }
     }
 }
 ```
 
-A few notes:
-
-- The override is honoured only for `POST` requests with
-  `Content-Type: application/x-www-form-urlencoded`. Headers like
-  `X-HTTP-Method-Override` are intentionally not enabled by default.
-- It is also enforced as **same-origin**: the request must carry
-  `Sec-Fetch-Site: same-origin` or `none` (sent by every browser
-  since ~2020), or — for `same-site` or when `Sec-Fetch-Site` is
-  absent — its `Origin` header must match the request's scheme,
-  host, and port. This is stricter than `same-site` alone, because
-  `same-site` accepts sibling subdomains under the same registrable
-  domain (e.g. `evil.example.com` -> `app.example.com`). When
-  running behind a TLS-terminating reverse proxy, the scheme is
-  read from `X-Forwarded-Proto` (leftmost client-facing value);
-  the host is read from `X-Forwarded-Host` if surfaced, otherwise
-  from `Host`. Requests that don't meet these conditions are
-  forwarded as the original `POST` so a cross-origin form can
-  never reach a route declared only as `#[delete]`. The
-  `autumn_web::test::TestApp` `form()` helper sets
-  `Sec-Fetch-Site: same-origin` automatically.
-- Unknown override values (anything other than `PUT`, `PATCH`, `DELETE`,
-  case-insensitive) reject with `400 Bad Request` before your handler runs.
-- Form-urlencoded bodies larger than 2 MiB are rejected with
-  `413 Payload Too Large` so an oversized form with `_method=DELETE`
-  isn't silently demoted to a `POST` (body-size-driven semantics).
-  Use `multipart/form-data` for large submissions.
-- CSRF still treats the transport `POST` as unsafe — an overridden
-  `DELETE` without a valid token returns `403 Forbidden` just like any
-  other mutating POST.
-- `autumn routes` and `/actuator/routes` keep reporting the declared
-  method (`DELETE`, `PUT`, `PATCH`) so route listings, OpenAPI docs, and
-  log filters stay accurate.
-
-If you build the form through `ChangesetForm::form_tag`, just pass the
-declared method and the helper handles the override and CSRF inputs
-for you:
-
-```rust,ignore
-form.form_tag("/todos/42", "delete", html! { button { "Delete" } })
-// Renders: <form method="post" action="/todos/42">
-//            <input type="hidden" name="_method" value="DELETE">
-//            <input type="hidden" name="_csrf" value="...">
-//            <button>Delete</button>
-//          </form>
-```
+The override is accepted only for same-origin, form-urlencoded `POST` requests,
+CSRF still applies, and `autumn routes` keeps reporting the declared method. If
+you build forms with `ChangesetForm::form_tag`, the method and CSRF inputs are
+emitted for you. See [nested forms](nested-forms.md) and
+[submit tokens](submit-tokens.md) for the full form story.
 
 ---
 
-## Error Handling
+## Error handling
 
-`AutumnResult<T>` is `Result<T, AutumnError>`. Every handler that can fail
-should return this type.
+`AutumnResult<T>` is `Result<T, AutumnError>`. Any handler that can fail should
+return it.
 
 ### The `?` operator
 
-Any `std::error::Error` converts to `AutumnError` with HTTP 500 automatically:
+Any `std::error::Error` converts to an `AutumnError` with HTTP 500:
 
 ```rust
 #[get("/users")]
@@ -888,11 +988,11 @@ async fn list_users(mut db: Db) -> AutumnResult<Json<Vec<User>>> {
 
 ### Status refinement
 
-For expected errors, use the status constructors:
+For expected failures, use a status constructor:
 
 ```rust
 #[get("/users/{id}")]
-async fn get_user(id: Path<i32>, mut db: Db) -> AutumnResult<Json<User>> {
+async fn get_user(id: Path<i64>, mut db: Db) -> AutumnResult<Json<User>> {
     let user = users::table
         .find(*id)
         .first(&mut *db)
@@ -903,126 +1003,158 @@ async fn get_user(id: Path<i32>, mut db: Db) -> AutumnResult<Json<User>> {
 }
 ```
 
-Available constructors:
+Each constructor has an `_msg` twin that takes a string instead of a source
+error — `AutumnError::not_found_msg("no such todo")`.
 
-| Method                      | HTTP Status                |
-|-----------------------------|----------------------------|
-| `AutumnError::not_found(e)` | 404 Not Found              |
-| `AutumnError::bad_request(e)` | 400 Bad Request          |
-| `AutumnError::unprocessable(e)` | 422 Unprocessable Entity |
-| `err.with_status(StatusCode::FORBIDDEN)` | Any status code |
+| Constructor                              | HTTP status               |
+|------------------------------------------|---------------------------|
+| `AutumnError::bad_request(e)`            | 400 Bad Request           |
+| `AutumnError::unauthorized(e)`           | 401 Unauthorized          |
+| `AutumnError::forbidden(e)`              | 403 Forbidden             |
+| `AutumnError::not_found(e)`              | 404 Not Found             |
+| `AutumnError::conflict(e)`               | 409 Conflict              |
+| `AutumnError::unprocessable(e)`          | 422 Unprocessable Entity  |
+| `AutumnError::internal_server_error(e)`  | 500 Internal Server Error |
+| `err.with_status(StatusCode::…)`         | Any status code           |
 
-Error responses are JSON:
+### The response shape
+
+Autumn answers API clients with
+[Problem Details](https://www.rfc-editor.org/rfc/rfc9457) (RFC 7807, obsoleted
+by RFC 9457) bodies, served as `application/problem+json`:
 
 ```json
 {
-  "error": {
-    "status": 404,
-    "message": "Record not found"
-  }
+  "type": "https://autumn.dev/problems/not-found",
+  "title": "Not Found",
+  "status": 404,
+  "detail": "Record not found",
+  "instance": "/users/42",
+  "code": "autumn.not_found",
+  "request_id": "0f1c2d3e-4a5b-6c7d-8e9f-0a1b2c3d4e5f",
+  "errors": []
 }
 ```
+
+`code` is a stable machine-readable identifier, `request_id` correlates with
+your logs, and `errors` carries field-level validation failures when the error
+came from a `Validate` rejection. Browsers negotiating `text/html` get the
+error page instead of JSON. Server-error detail is never echoed to clients in
+production.
+
+When a 5xx does reach a user, you can record it as a replayable
+[failure capsule](failure-capsules.md) — the request, the database traffic it
+produced, and the outcome, in one file that `autumn replay` re-runs offline.
 
 ---
 
 ## Configuration
 
-Autumn uses a five-layer configuration system:
+Autumn resolves configuration in five layers, each overriding the last:
 
-1. **Framework defaults** -- compiled into the binary, zero-config start
-2. **Profile smart defaults** -- built-in `dev` / `prod` behavior
-3. **`autumn.toml`** -- project-level overrides
-4. **`autumn-{profile}.toml`** -- profile-specific overrides
-5. **`AUTUMN_*` environment variables** -- deployment overrides (highest priority)
+1. **Framework defaults** — compiled in, zero-config start
+2. **Profile smart defaults** — built-in `dev` / `prod` behavior
+3. **`autumn.toml`** — project-level overrides
+4. **`autumn-{profile}.toml`** — profile-specific overrides
+5. **`AUTUMN_*` environment variables** — deployment overrides, highest priority
 
 ### `autumn.toml` reference
 
 ```toml
 [server]
-host = "127.0.0.1"          # default
+host = "127.0.0.1"           # default
 port = 3000                  # default
 shutdown_timeout_secs = 30   # default, seconds to drain in-flight requests
-# max_concurrent_requests = 256 # unset by default (unlimited); caps in-flight
-                               # requests, shedding the excess with a 503
+# max_concurrent_requests = 256 # unset by default; sheds excess with a 503
+
+[server.timeouts]
+# Per-request wall-clock deadline. The prod profile enables 30s automatically.
+# Streaming responses are never interrupted; any route can override with
+# `#[get("/slow", timeout_ms = 120000)]` or `timeout = "off"`.
+# request_timeout_ms = 30000
 
 [database]
 primary_url = "postgres://user:pass@localhost:5432/my_app"
-# url = "postgres://user:pass@localhost:5432/my_app" # legacy single-primary alias
+# url = "postgres://…"       # single-primary alias for primary_url
 # replica_url = "postgres://user:pass@localhost:5433/my_app"
 pool_size = 10               # default, max connections per role
 # primary_pool_size = 10
 # replica_pool_size = 5
-replica_fallback = "fail_readiness" # or "primary"
+replica_fallback = "fail_readiness"  # or "primary"
 connect_timeout_secs = 5     # default
-auto_migrate_in_production = false
+# auto_migrate = false       # dev auto-applies; other profiles opt in
 
 [log]
-level = "info"               # default, supports tracing filter syntax
+level = "info"               # supports tracing filter syntax
 format = "Auto"              # Auto | Pretty | Json
 
 [health]
 path = "/health"             # default
+# enabled = true
 
 [actuator]
-sensitive = false            # prod default; dev smart defaults enable sensitive endpoints
+sensitive = false            # prod default; dev smart defaults expose more
 ```
+
+The generated `autumn.toml` carries commented blocks for telemetry, mail, and
+Redis sessions too. The [cloud-native guide](cloud-native.md) covers the full
+production surface.
 
 ### Environment variable overrides
 
-Every config field can be overridden via environment variables. The pattern is
-`AUTUMN_SECTION__FIELD` (double underscore separates section from field):
+Every config field can be overridden with an environment variable. The pattern
+is `AUTUMN_SECTION__FIELD` — a double underscore separates section from field:
 
-| Variable                             | Overrides              |
-|--------------------------------------|------------------------|
-| `AUTUMN_SERVER__PORT`                | `server.port`          |
-| `AUTUMN_SERVER__HOST`                | `server.host`          |
-| `AUTUMN_SERVER__SHUTDOWN_TIMEOUT_SECS` | `server.shutdown_timeout_secs` |
-| `AUTUMN_SERVER__MAX_CONCURRENT_REQUESTS` | `server.max_concurrent_requests` |
-| `AUTUMN_DATABASE__URL`               | `database.url`         |
-| `AUTUMN_DATABASE__PRIMARY_URL`       | `database.primary_url` |
-| `AUTUMN_DATABASE__REPLICA_URL`       | `database.replica_url` |
-| `AUTUMN_DATABASE__POOL_SIZE`         | `database.pool_size`   |
-| `AUTUMN_DATABASE__PRIMARY_POOL_SIZE` | `database.primary_pool_size` |
-| `AUTUMN_DATABASE__REPLICA_POOL_SIZE` | `database.replica_pool_size` |
-| `AUTUMN_DATABASE__REPLICA_FALLBACK`  | `database.replica_fallback` |
-| `AUTUMN_DATABASE__CONNECT_TIMEOUT_SECS` | `database.connect_timeout_secs` |
-| `AUTUMN_LOG__LEVEL`                  | `log.level`            |
-| `AUTUMN_LOG__FORMAT`                 | `log.format`           |
-| `AUTUMN_HEALTH__PATH`               | `health.path`          |
-| `AUTUMN_PROFILE`                     | active profile         |
+| Variable                                 | Overrides                       |
+|------------------------------------------|---------------------------------|
+| `AUTUMN_SERVER__PORT`                    | `server.port`                   |
+| `AUTUMN_SERVER__HOST`                    | `server.host`                   |
+| `AUTUMN_SERVER__SHUTDOWN_TIMEOUT_SECS`   | `server.shutdown_timeout_secs`  |
+| `AUTUMN_SERVER__MAX_CONCURRENT_REQUESTS` | `server.max_concurrent_requests`|
+| `AUTUMN_DATABASE__URL`                   | `database.url`                  |
+| `AUTUMN_DATABASE__PRIMARY_URL`           | `database.primary_url`          |
+| `AUTUMN_DATABASE__REPLICA_URL`           | `database.replica_url`          |
+| `AUTUMN_DATABASE__POOL_SIZE`             | `database.pool_size`            |
+| `AUTUMN_DATABASE__REPLICA_FALLBACK`      | `database.replica_fallback`     |
+| `AUTUMN_DATABASE__AUTO_MIGRATE`          | `database.auto_migrate`         |
+| `AUTUMN_LOG__LEVEL`                      | `log.level`                     |
+| `AUTUMN_LOG__FORMAT`                     | `log.format`                    |
+| `AUTUMN_HEALTH__PATH`                    | `health.path`                   |
+| `AUTUMN_SECURITY__SIGNING_SECRET`        | `security.signing_secret`       |
+| `AUTUMN_ENV`                             | active profile                  |
 
 Profiles resolve in this order:
 
-1. `AUTUMN_PROFILE`
-2. `--profile <name>`
-3. debug/release auto-detection (`dev` for debug, `prod` for release)
+1. `AUTUMN_ENV`
+2. `AUTUMN_PROFILE` (legacy alias)
+3. `--profile <name>`
+4. Build-mode auto-detection — `dev` for debug builds, `prod` for release
 
-That means you can keep shared defaults in `autumn.toml`, put local dev
-settings in `autumn-dev.toml`, and override the final few things in CI or
-deployment with env vars.
+So you can keep shared defaults in `autumn.toml`, local settings in
+`autumn-dev.toml`, and override the last few things in CI or deployment with
+environment variables. Profile selectors are deliberately excluded from `.env`,
+so a `.env` file can never switch the active profile.
 
 ### Log format behavior
 
-| Format    | Behavior                                              |
-|-----------|-------------------------------------------------------|
-| `Auto`    | Pretty in development, JSON when `AUTUMN_ENV=production` |
-| `Pretty`  | Always human-readable, colorized                     |
-| `Json`    | Always structured JSON                                |
+| Format   | Behavior                                                 |
+|----------|----------------------------------------------------------|
+| `Auto`   | Pretty in development, JSON when the profile is production |
+| `Pretty` | Always human-readable, colorized                         |
+| `Json`   | Always structured JSON                                   |
 
 ### Running without a database
 
-If you omit the `[database]` section (or leave both `primary_url` and `url`
-unset), Autumn starts without a database pool. Handlers that use `Db` will return 503 Service
-Unavailable. This is useful for static sites, APIs that do not need a
-database, or during early development.
+Omit the `[database]` section (or leave both `primary_url` and `url` unset) and
+Autumn starts with no pool. Handlers that use `Db` return 503 Service
+Unavailable. That is useful for static sites, database-free APIs, and early
+development.
 
 ### Escape hatch: mounting raw Axum routers
 
-When route macros are enough, prefer them -- you keep Autumn's discovery
-conventions and the codebase stays more uniform.
-
-When you need Axum-native composition (for example, mounting a third-party
-router like GraphQL), use `.merge()` or `.nest()`:
+Prefer the route macros — you keep Autumn's discovery conventions and the
+codebase stays uniform. When you need Axum-native composition (mounting a
+third-party router such as GraphQL), use `.merge()` or `.nest()`:
 
 ```rust,no_run
 use autumn_web::prelude::*;
@@ -1037,125 +1169,152 @@ async fn main() {
         .route("/graphql", axum::routing::get(|| async { "graphql endpoint" }));
 
     autumn_web::app()
-        .routes(routes![index]) // Autumn-managed routes
-        .merge(graphql) // Raw Axum routes on the same app
+        .routes(routes![index])   // Autumn-managed routes
+        .merge(graphql)           // raw Axum routes on the same app
         .run()
         .await;
 }
 ```
 
-Use `.merge()` for direct mounting and `.nest("/prefix", router)` when you want
-all routes under a prefix (for example `/api/v2`).
-
-Merged/nested routers share the same `AppState` and still pass through Autumn's
-global middleware (including `X-Request-Id` response headers). Avoid defining
-the same method+path in both managed and raw routers -- Axum treats overlaps as
-an error during router construction.
+Use `.merge()` for direct mounting and `.nest("/prefix", router)` to put every
+route under a prefix. Merged and nested routers share the same `AppState` and
+still pass through Autumn's global middleware, including `X-Request-Id`
+response headers.
 
 ### Route collision diagnostics
 
-Autumn preflights route registration and refuses to start when it can already
-prove a collision. Instead of an Axum panic mid-mount, the framework returns a
-structured `RouterBuildError` **before any router is mounted**, so the failure
-mode is a clean error message that names the offending handlers rather than a
-half-configured process crashing at startup:
+Autumn preflights route registration and refuses to start when it can prove a
+collision — a structured `RouterBuildError` naming the offending handlers
+**before any router is mounted**, rather than an Axum panic mid-boot:
 
-- **`FrameworkRouteOverlap`** -- a user route lands on a path a framework route
-  already owns (probes, actuator, `X-Request-Id`, dev live-reload).
-- **`OpenApiPathCollision`** (feature `openapi`) -- an `openapi_json_path` or
-  `swagger_ui_path` collides with a `GET` route Autumn already owns; each side
-  is named so you can fix the config or the route.
-- **`DuplicateUserRoute`** (issue #1012) -- two user- or plugin-registered
-  routes resolve to the same `(method, path)` after `.scoped(prefix, …)` prefix
-  resolution (including `#[repository]`-generated API routes). The error names
-  **both** handlers, the HTTP method, and the path:
+- **`FrameworkRouteOverlap`** — a user route lands on a path a framework route
+  already owns (probes, actuator, dev live-reload).
+- **`OpenApiPathCollision`** (feature `openapi`) — an `openapi_json_path` or
+  `swagger_ui_path` collides with a `GET` route Autumn already owns.
+- **`DuplicateUserRoute`** — two registered routes resolve to the same
+  `(method, path)` after `.scoped()` prefix resolution. Distinct methods on the
+  same exact path (`GET /admin` + `POST /admin`) are fine — Axum merges those
+  into one `MethodRouter`.
+- **`ConflictingRouteShape`** — two *different* path templates that Axum's
+  matcher cannot tell apart, such as `/users/{id}` and `/users/{slug}`.
+  Detection is delegated to **matchit**, the exact routing engine Axum 0.8
+  uses, so the preflight mirrors Axum's real accept/reject behavior. Because
+  matchit rejects these before method merging, they conflict regardless of HTTP
+  method.
 
-  ```text
-  duplicate user route: "list_posts_v1" and "list_posts_v2" both resolve to
-  GET "/api/posts"; choose a different path for one of them or remove the
-  duplicate registration
-  ```
+Each error names both handlers and both templates:
 
-  Distinct methods on the *same exact path* (`GET /admin` + `POST /admin`, or
-  `GET /users/{id}` + `POST /users/{id}`) are NOT flagged -- Axum merges them
-  into a single `MethodRouter` cleanly.
-- **`ConflictingRouteShape`** (issue #1012) -- two routes whose **different**
-  path templates resolve to overlapping shapes that Axum's matcher cannot tell
-  apart. Path-shape conflict detection is delegated to **matchit**, the exact
-  routing engine Axum 0.8 uses, so the preflight mirrors Axum's real accept/
-  reject behavior precisely -- including every edge case: capture-name
-  differences (`/users/{id}` vs `/users/{slug}`), a normal capture versus a
-  catch-all at the same position (`/u/{id}` vs `/u/{*rest}`), a catch-all
-  versus a dynamic *descendant* (`/cmd/{tool}/{sub}` vs `/cmd/{*path}`), and
-  mixed literal+capture segments (`/file.{ext}` vs `/file.{kind}`). Axum's
-  matchit router rejects the second template as a conflict *before* method
-  merging, so unlike an exact-duplicate path these can never coexist **regardless
-  of HTTP method** -- `GET /users/{id}` + `POST /users/{slug}` is still a
-  conflict. The error names **both** handlers and **both** original templates:
+```text
+conflicting route shapes: "show_user" ("/users/{id}") and "create_user"
+("/users/{slug}") resolve to the same Axum path shape but use different path
+templates; axum's matchit router rejects this as a route conflict regardless
+of HTTP method — rename the captures so both use the same template, or make
+their static paths distinct
+```
 
-  ```text
-  conflicting route shapes: "show_user" ("/users/{id}") and "create_user"
-  ("/users/{slug}") resolve to the same Axum path shape but use different path
-  templates; axum's matchit router rejects this as a route conflict regardless
-  of HTTP method — rename the captures so both use the same template, or make
-  their static paths distinct
-  ```
-
-  Because the check *is* matchit, it never over-flags what Axum would accept: a
-  static segment and a capture at the same position (`/users/me` +
-  `/users/{id}`) coexist, and escaped literal braces (`{{`/`}}`, e.g. the static
-  path `/{{foo}}`) are *not* captures, so `/{{foo}}` and `/{{bar}}` remain
-  distinct static routes and build cleanly.
-
-Opaque routers registered via `.merge(router)` or `.nest(prefix, router)`
-cannot be introspected through Axum's public API, so a collision that lives
-inside one of those routers still surfaces as an Axum startup panic. The
-duplicate-route preflight emits a `tracing::warn!` in that case ("check
-skipped") so operators know the check didn't cover that code path -- keep
-merged/nested raw routers on paths disjoint from your Autumn-managed routes.
+Routers registered through `.merge()` or `.nest()` cannot be introspected
+through Axum's public API, so a collision inside one still surfaces as a
+startup panic. The preflight emits a `tracing::warn!` ("check skipped") in that
+case — keep raw merged routers on paths disjoint from your managed routes.
 
 ---
 
-## What's Next?
+## Test what you built
 
-You now have a working Autumn application with routes, database access,
-HTML rendering, Tailwind styling, htmx interactivity, health checks, and
-actuator endpoints.
+The scaffold ships working tests in `tests/integration_test.rs`. They boot the
+full Autumn middleware pipeline in-process — security headers, routing,
+tracing, request IDs — without binding a TCP listener, and need no Docker:
 
-Here are some things to explore:
+```rust
+use autumn_web::prelude::*;
+use autumn_web::test::TestApp;
 
-- **Organize routes into modules** -- call `.routes()` multiple times on the
-  app builder to compose route groups:
-  ```rust
-  autumn_web::app()
-      .routes(routes![index])
-      .routes(routes![list_todos, create_todo, toggle, delete_todo])
-      .run()
-      .await;
-  ```
-- **Use `Form<T>`** for HTML form submissions instead of JSON:
-  ```rust
-  use autumn_web::extract::Form;
+#[tokio::test]
+async fn get_index_returns_200() {
+    let client = TestApp::new().routes(routes![index]).build();
 
-  #[post("/todos")]
-  async fn create(mut db: Db, form: Form<NewTodo>) -> AutumnResult<Markup> {
-      // form.0 is the deserialized NewTodo
-      // ...
-  }
-  ```
-- **Check `/health` and `/actuator/*`** -- `/health` gives a small health
-  response, while actuator adds info, metrics, env/configprops, loggers, and
-  scheduled task visibility depending on the active profile.
-- **Localize your UI** -- enable the opt-in `i18n` feature flag on `autumn-web`
-  and drop translation files at `i18n/<locale>.ftl`. See
-  [the i18n guide](./i18n.md) for the convention, the `Locale` extractor, and
-  the `t!()` macro.
-- **Inspect request IDs** -- every response includes an `X-Request-Id` header
-  (UUID v4) for log correlation.
-- **Look at the example apps** -- [`examples/todo-app`](../../examples/todo-app),
-  [`examples/blog`](../../examples/blog), [`examples/bookmarks`](../../examples/bookmarks),
-  and [`examples/wiki`](../../examples/wiki) each exercise different parts of
-  the current framework.
+    client
+        .get("/")
+        .send()
+        .await
+        .assert_ok()
+        .assert_body_contains("Welcome");
+}
+```
 
-Autumn is still pre-1.0 and evolving quickly. File issues, break glass when you
-need Axum escape hatches, and ship something.
+```bash
+cargo test
+```
+
+For database-backed tests, `autumn test` resolves a `*_test` database URL,
+creates it, migrates it, and then shells out to `cargo test` with
+`AUTUMN_ENV=test` exported — refusing to run against a non-test database name:
+
+```bash
+autumn test
+autumn test --reset   # drop and recreate first, for schema drift
+```
+
+See the [testing guide](testing.md) for `TestDb`, fixtures, and
+[system tests](system-tests.md) for browser-driven coverage.
+
+---
+
+## Before you deploy
+
+The generated app starts with local-safe defaults: in-memory sessions,
+in-process `#[scheduled]` tasks, an ephemeral signing secret, and a generic
+container Dockerfile. Before running multiple replicas you usually want to:
+
+1. Set `AUTUMN_ENV=prod`
+2. Set a durable `AUTUMN_SECURITY__SIGNING_SECRET` and a trusted-hosts list
+3. Wire `/live`, `/ready`, and `/startup` into your platform's probes
+4. Enable OTLP telemetry and point it at your collector
+5. Move sessions to Redis
+6. Run migrations as a one-shot job before starting web replicas
+
+`autumn doctor --strict` checks most of that for you, and
+`autumn release init --target <platform>` scaffolds deployment assets for
+Docker Compose, Fly, AWS, GCP, and Azure. The
+[cloud-native guide](cloud-native.md) and [deployment guide](deployment.md)
+carry the full story.
+
+---
+
+## What's next
+
+You now have an Autumn application with routes, database access, HTML
+rendering, styling, interactivity, tests, health checks, and actuator
+endpoints. Where to go from here:
+
+**Go deeper on the basics**
+- [Tutorial](tutorial/index.md) — the same ground at book length, with checkpoints
+- [Code generators](generators.md) — the full `autumn generate` surface
+- [Repositories](repositories.md) — typed data access, bulk CRUD, hooks
+- [Migrations](migrations.md) and [declarative schema](declarative-schema.md)
+- [Testing](testing.md) — `TestApp`, `TestDb`, fixtures
+
+**Add capabilities**
+- [Authentication](authentication.md) and [authorization](authorization.md)
+- [Background jobs](jobs.md) and [scheduled tasks](tasks.md)
+- [Real-time](realtime.md) — SSE, WebSockets, presence
+- [Mail](mail.md), [storage](storage.md), [search](search.md), [i18n](i18n.md)
+- [OpenAPI](openapi.md) — generated docs and a Swagger UI
+
+**Operate it**
+- [Cloud-native](cloud-native.md) and [deployment](deployment.md)
+- [Metrics](metrics.md), [operator alerts](operator-alerts.md), [audit logging](audit-logging.md)
+- [Failure capsules](failure-capsules.md) — record and replay production 500s
+
+**Reference**
+- [What happens when](what-happens-when.md) — edge cases and failure modes
+- [Macro transparency](macro-transparency.md) — exactly what each macro expands to
+- [Coming from other frameworks](coming-from-other-frameworks.md) — Rails, Spring Boot, Django, Laravel mappings
+- Example apps: [`examples/todo-app`](../../examples/todo-app),
+  [`examples/blog`](../../examples/blog),
+  [`examples/bookmarks`](../../examples/bookmarks),
+  [`examples/wiki`](../../examples/wiki),
+  [`examples/reddit-clone`](../../examples/reddit-clone)
+
+Autumn is pre-1.0 and moving quickly. File issues, reach for the Axum escape
+hatches when you need them, and ship something.

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -436,8 +436,8 @@ autumn_web::app()
 
 Before writing CRUD by hand, know that you usually do not have to.
 `autumn generate scaffold` emits the model, the migration, the `schema.rs`
-entry, a `#[repository]`, HTML routes and views, a JSON API, and a smoke test —
-then registers everything in `src/main.rs`:
+entry, a `#[repository]`, HTML routes and views, a policy stub, a JSON API, and
+a smoke test — then wires the routes into `src/main.rs` for you:
 
 ```bash
 autumn new my-app
@@ -450,7 +450,48 @@ autumn dev
 ```
 
 Visit <http://localhost:3000/posts> for the generated index page, or
-<http://localhost:3000/api/posts> for the JSON endpoint.
+<http://localhost:3000/api/posts> for the JSON read endpoint.
+
+### The writes are locked, on purpose
+
+Those five commands do **not** hand you an open CRUD app, and it is worth
+understanding why before you go looking for the bug:
+
+- The read paths — `GET /posts`, `GET /posts/{id}`, the CSV export, and the
+  JSON `GET /api/posts` — work immediately.
+- The write paths — `new_form`, `create`, `edit_form`, `update`, `destroy`,
+  `bulk_delete` — are emitted with `#[secured]`. A fresh `autumn new` app has
+  no login flow, so with no authenticated session those routes answer
+  `401 Unauthorized`.
+- The JSON *write* handlers are generated but deliberately **not** registered
+  in `routes![]`. Mount them once you have written a real repository policy.
+
+That is the scaffold being secure by default rather than open by default: it
+would rather hand you a locked door than an unauthenticated `DELETE` endpoint
+you forgot about. `autumn routes audit` enforces the same posture in CI.
+
+To get writes working, generate the missing half — a full signup, login,
+logout, account, and password-reset flow, named after the model it creates:
+
+```bash
+autumn generate auth User
+autumn migrate
+autumn dev
+```
+
+That writes the `users` migration, the session and remember-token models, the
+handlers, and registers all of them in `src/main.rs`. Sign up, sign in, and the
+create/edit/delete views become reachable. The
+generated `src/policies/post.rs` authorizes any authenticated user and marks
+itself with `SECURITY TODO` comments; replace those with a real per-record
+ownership rule before production. See [authentication](authentication.md) and
+[authorization](authorization.md).
+
+If you only want to click around a demo, removing the `#[secured]` attributes
+from `src/routes/posts.rs` opens the write routes — it is your code to edit.
+Do that knowingly, and not on anything reachable from the internet.
+
+### More of the DSL
 
 The field DSL carries validation and relationships too — `title:String{min=3,max=120}`
 emits both a server-side `#[validate(length(...))]` rule and the matching HTML5

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -367,18 +367,28 @@ the signature:
 
 ```rust
 use autumn_web::extract::Path;
-use autumn_web::get;
+use autumn_web::{get, public};
 
 #[get("/users/{id}")]
+#[public]
 async fn get_user(id: Path<i64>) -> String {
     format!("User #{}", *id)
 }
 ```
 
+> **Why `#[public]` on every example from here on.** The scaffold's generated
+> `.github/workflows/ci.yml` runs `autumn routes audit`, which fails the build
+> on any mounted route carrying no security classification. A handler with no
+> `#[public]`, `#[secured]`, or `#[authorize]` is *unclassified*, not
+> *public* — it works locally and goes red on your first CI push. Saying
+> `#[public]` out loud is the whole point of the gate: an unauthenticated route
+> should be a decision, not an oversight.
+
 Multiple parameters destructure a tuple:
 
 ```rust
 #[get("/orgs/{org}/repos/{repo}")]
+#[public]
 async fn get_repo(Path((org, repo)): Path<(String, String)>) -> String {
     format!("{org}/{repo}")
 }
@@ -397,6 +407,7 @@ struct Pagination {
 }
 
 #[get("/items")]
+#[public]
 async fn list_items(Query(params): Query<Pagination>) -> String {
     let page = params.page.unwrap_or(1);
     let per_page = params.per_page.unwrap_or(20);
@@ -723,6 +734,7 @@ use crate::models::{NewTodo, Todo};
 use crate::schema::todos;
 
 #[get("/todos")]
+#[public]
 async fn list_todos(mut db: Db) -> AutumnResult<Json<Vec<Todo>>> {
     let all_todos = todos::table
         .order(todos::created_at.desc())
@@ -734,6 +746,7 @@ async fn list_todos(mut db: Db) -> AutumnResult<Json<Vec<Todo>>> {
 }
 
 #[post("/api/todos")]
+#[public]
 async fn create_todo(mut db: Db, body: Json<NewTodo>) -> AutumnResult<Json<Todo>> {
     let created: Todo = diesel::insert_into(todos::table)
         .values(&body.0)
@@ -787,6 +800,7 @@ templating library. Return `Markup` from a handler to send HTML:
 use autumn_web::prelude::*;
 
 #[get("/")]
+#[public]
 async fn index() -> Markup {
     html! {
         (maud::DOCTYPE)
@@ -820,7 +834,11 @@ Maud syntax in brief:
 Extract reusable layouts into functions:
 
 ```rust
-fn layout(title: &str, content: Markup) -> Markup {
+use autumn_web::HTMX_CSRF_JS_PATH;
+use autumn_web::prelude::*;
+use autumn_web::security::CsrfToken;
+
+fn layout(title: &str, csrf_token: Option<&str>, content: Markup) -> Markup {
     html! {
         (maud::DOCTYPE)
         html lang="en" {
@@ -828,8 +846,14 @@ fn layout(title: &str, content: Markup) -> Markup {
                 meta charset="utf-8";
                 meta name="viewport" content="width=device-width, initial-scale=1";
                 title { (title) }
+                // htmx reads the token from here. The CSRF cookie is HttpOnly,
+                // so JavaScript cannot get at it any other way.
+                @if let Some(token) = csrf_token {
+                    meta name="csrf-token" content=(token);
+                }
                 link rel="stylesheet" href=(asset_url("css/autumn.css"));
                 (javascript_include_tag("htmx"))
+                script src=(HTMX_CSRF_JS_PATH) {}
             }
             body class="bg-gray-100 min-h-screen" {
                 div class="max-w-2xl mx-auto py-10 px-4" {
@@ -841,13 +865,21 @@ fn layout(title: &str, content: Markup) -> Markup {
 }
 
 #[get("/about")]
-async fn about() -> Markup {
-    layout("About", html! {
+#[public]
+async fn about(csrf: Option<CsrfToken>) -> Markup {
+    layout("About", csrf.as_ref().map(CsrfToken::token), html! {
         h1 { "About this app" }
         p { "Built with Autumn, Maud, and Tailwind." }
     })
 }
 ```
+
+Those three CSRF lines are load-bearing the moment you add htmx. `HTMX_CSRF_JS_PATH`
+is a helper Autumn serves that copies the `csrf-token` meta tag into an
+`X-CSRF-Token` header on every htmx request. Without it, the `hx-post` and
+`hx-delete` calls in the next section sail through in `dev` and return
+`403 Forbidden` under `prod`, where CSRF protection is on by default. The
+`examples/reddit-clone` layout is the reference implementation.
 
 `asset_url` and `javascript_include_tag` resolve to plain paths in dev and to
 fingerprinted, integrity-pinned URLs after `autumn build` — so you get cache
@@ -910,6 +942,11 @@ subresource-integrity hash and serves it through
 `javascript_include_tag("htmx")`. Include that in your layout, then use htmx
 attributes in your templates.
 
+The handlers below mutate data, so they need the `csrf-token` meta tag and the
+`HTMX_CSRF_JS_PATH` helper from the [layout above](#render-html-with-maud). If
+you skipped that, add it now — otherwise these buttons will work on your
+machine and return `403` in production.
+
 Here is a toggle-and-delete pair that updates a todo without a full page
 reload:
 
@@ -952,6 +989,7 @@ fn todo_item(todo: &Todo) -> Markup {
 
 /// Toggle completion — returns the updated HTML fragment.
 #[post("/todos/{id}/toggle")]
+#[public]
 async fn toggle(id: Path<i64>, mut db: Db) -> AutumnResult<Markup> {
     let updated: Todo = diesel::update(todos::table.find(*id))
         .set(todos::completed.eq(diesel::dsl::not(todos::completed)))
@@ -965,6 +1003,7 @@ async fn toggle(id: Path<i64>, mut db: Db) -> AutumnResult<Markup> {
 
 /// Delete a todo — empty response body, so htmx removes the element.
 #[delete("/todos/{id}")]
+#[public]
 async fn delete_todo(id: Path<i64>, mut db: Db) -> AutumnResult<String> {
     diesel::delete(todos::table.find(*id))
         .execute(&mut *db)
@@ -1001,6 +1040,7 @@ use autumn_web::prelude::*;
 use autumn_web::security::CsrfToken;
 
 #[get("/todos/{id}/edit")]
+#[public]
 async fn edit_form(id: Path<i64>, csrf: Option<CsrfToken>) -> Markup {
     html! {
         form method="post" action=(format!("/todos/{}", *id)) {
@@ -1039,6 +1079,7 @@ Any `std::error::Error` converts to an `AutumnError` with HTTP 500:
 
 ```rust
 #[get("/users")]
+#[public]
 async fn list_users(mut db: Db) -> AutumnResult<Json<Vec<User>>> {
     let users = users::table.load(&mut *db).await?; // 500 on failure
     Ok(Json(users))
@@ -1051,6 +1092,7 @@ For expected failures, use a status constructor:
 
 ```rust
 #[get("/users/{id}")]
+#[public]
 async fn get_user(id: Path<i64>, mut db: Db) -> AutumnResult<Json<User>> {
     let user = users::table
         .find(*id)
@@ -1220,6 +1262,7 @@ use autumn_web::prelude::*;
 use autumn_web::AppState;
 
 #[get("/")]
+#[public]
 async fn index() -> &'static str { "ok" }
 
 #[autumn_web::main]

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -460,15 +460,20 @@ understanding why before you go looking for the bug:
 - The read paths — `GET /posts`, `GET /posts/{id}`, the CSV export, and the
   JSON `GET /api/posts` — work immediately.
 - The write paths — `new_form`, `create`, `edit_form`, `update`, `destroy`,
-  `bulk_delete` — are emitted with `#[secured]`. A fresh `autumn new` app has
-  no login flow, so with no authenticated session those routes answer
-  `401 Unauthorized`.
+  `bulk_delete` — are locked twice over. Each is emitted with `#[secured]`, so
+  a request with no authenticated session is rejected at the route; and each
+  handler body *also* calls `authorize::<Post>(&state, &session, "update", &row)`
+  (or `authorize_create::<Post>`) against the `PostPolicy` registered in
+  `src/main.rs`. A fresh `autumn new` app has no login flow, so you get a
+  `401` at the route and, if you strip the attribute, a `403` from the policy.
 - The JSON *write* handlers are generated but deliberately **not** registered
   in `routes![]`. Mount them once you have written a real repository policy.
 
-That is the scaffold being secure by default rather than open by default: it
-would rather hand you a locked door than an unauthenticated `DELETE` endpoint
-you forgot about. `autumn routes audit` enforces the same posture in CI.
+That double gate is deliberate. `#[secured]` answers "is anyone signed in?" and
+the policy answers "may *this* user touch *this* row?" — deleting one attribute
+cannot silently open a mutation path, and `autumn routes audit` enforces the
+same posture in CI. It is the scaffold preferring to hand you a locked door
+over an unauthenticated `DELETE` endpoint you forgot about.
 
 To get writes working, generate the missing half — a full signup, login,
 logout, account, and password-reset flow, named after the model it creates:
@@ -481,15 +486,18 @@ autumn dev
 
 That writes the `users` migration, the session and remember-token models, the
 handlers, and registers all of them in `src/main.rs`. Sign up, sign in, and the
-create/edit/delete views become reachable. The
-generated `src/policies/post.rs` authorizes any authenticated user and marks
-itself with `SECURITY TODO` comments; replace those with a real per-record
-ownership rule before production. See [authentication](authentication.md) and
-[authorization](authorization.md).
+create/edit/delete views become reachable.
 
-If you only want to click around a demo, removing the `#[secured]` attributes
-from `src/routes/posts.rs` opens the write routes — it is your code to edit.
-Do that knowingly, and not on anything reachable from the internet.
+Read the generated `src/policies/post.rs` before you ship: with no owner column
+detected it authorizes *any* authenticated user and says so in `SECURITY TODO`
+comments. Replace those with a real per-record ownership rule. See
+[authentication](authentication.md) and [authorization](authorization.md).
+
+Generating the auth flow really is the short path here. Opening the writes to
+anonymous visitors instead means editing both layers — dropping every
+`#[secured]` attribute *and* rewriting `PostPolicy` to return `true` — which is
+more work than `autumn generate auth User`, and leaves you with a scaffold that
+no longer resembles the one the rest of the docs describe.
 
 ### More of the DSL
 

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -949,23 +949,33 @@ handlers stay semantically honest:
 ```rust,no_run
 use autumn_web::form::method_input;
 use autumn_web::prelude::*;
+use autumn_web::security::CsrfToken;
 
 #[get("/todos/{id}/edit")]
-async fn edit_form(id: Path<i64>) -> Markup {
+async fn edit_form(id: Path<i64>, csrf: Option<CsrfToken>) -> Markup {
     html! {
         form method="post" action=(format!("/todos/{}", *id)) {
             (method_input("DELETE"))   // Autumn rewrites this POST to DELETE
+            @if let Some(token) = csrf.as_ref() {
+                input type="hidden" name="_csrf" value=(token.token());
+            }
             button type="submit" { "Delete" }
         }
     }
 }
 ```
 
-The override is accepted only for same-origin, form-urlencoded `POST` requests,
-CSRF still applies, and `autumn routes` keeps reporting the declared method. If
-you build forms with `ChangesetForm::form_tag`, the method and CSRF inputs are
-emitted for you. See [nested forms](nested-forms.md) and
-[submit tokens](submit-tokens.md) for the full form story.
+The `_csrf` field is not optional dressing. CSRF still treats the transport
+`POST` as unsafe, and the `prod` profile turns CSRF protection on by default —
+so a form that omits the token gets a `403 Forbidden` before your `#[delete]`
+handler ever runs, even though it works fine in `dev`.
+
+Beyond that, the override is accepted only for same-origin, form-urlencoded
+`POST` requests, and `autumn routes` keeps reporting the declared method so
+route listings and OpenAPI stay accurate. If you build forms with
+`ChangesetForm::form_tag`, the method and CSRF inputs are emitted for you. See
+[nested forms](nested-forms.md) and [submit tokens](submit-tokens.md) for the
+full form story.
 
 ---
 

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -45,9 +45,21 @@ rustc --version   # 1.88.0 or later
 cargo --version
 ```
 
-> **Not using a database at all?** Build a JSON API or daemon with
-> `autumn new my-app --api` or `--daemon`. Those flavors drop the view stack
-> or the database respectively; the rest of this guide still applies.
+Two scaffold flavors change that list, and they change it in different
+directions — pick by what you want to *drop*, not by what you want to build:
+
+> **No database at all?** `autumn new my-app --daemon` scaffolds a model-free
+> app with `autumn-web`'s `db` feature switched off, so it needs neither
+> Postgres nor `libpq` nor the Diesel CLI. It keeps the view stack, so
+> everything below except the database sections applies. (`--bundled-pg` is
+> the opposite trade: a daemon that *keeps* the database and manages a local
+> Postgres for you.)
+>
+> **Building a JSON API?** `autumn new my-app --api` drops the view stack —
+> Maud, Tailwind, htmx, the whole `static/` tree — but **keeps** the database
+> and migrations. The `libpq` prerequisite above still applies to it; the HTML,
+> Tailwind, and htmx sections of this guide do not. The two flags are not
+> combinable.
 
 ---
 


### PR DESCRIPTION
Rewrites `docs/guide/getting-started.md`. Every claim in the new guide was checked against the real toolchain: the CLI was built from this checkout, `autumn new` / `generate scaffold` / `generate auth` were actually run, and the resulting trees, `autumn doctor` transcript, and generated handlers were read back rather than recalled.

## What was wrong

The guide had drifted from the framework it documents:

| Claim in the old guide | Reality |
|---|---|
| &#34;the published `autumn-web` 0.4 release line&#34;, &#34;0.4.x … as of 2026-05-11&#34; | Every command in the same file pinned 0.6 |
| `@tailwind base; @tailwind components; @tailwind utilities;` | `autumn setup` fetches Tailwind **v4.1.0**; the scaffold&#39;s `input.css` is `@import &#34;tailwindcss&#34;;` |
| Errors are `{&#34;error&#34;: {&#34;status&#34;: 404, &#34;message&#34;: &#34;…&#34;}}` | `application/problem+json` with `type`/`title`/`status`/`detail`/`instance`/`code`/`request_id`/`errors` |
| Profiles resolve `AUTUMN_PROFILE` → `--profile` → build mode | `AUTUMN_ENV` first; `AUTUMN_PROFILE` is the legacy alias |
| `diesel-async = { version = &#34;0.8&#34; }` | Workspace is on 0.9 |
| `id SERIAL PRIMARY KEY` / `id: i32` | `BIGSERIAL`/`i64` is the convention the generators and `#[repository]` assume |
| An 8-line `autumn doctor` sample with checks named `db_connectivity`, `pending_migrations` | Real output is ~27 checks with different names; those two don&#39;t appear when no database is configured |
| A 12-entry project tree | `autumn new` also writes `README.md`, `tests/`, `config/credentials/`, `.github/workflows/ci.yml`, `.env.example`, `rust-toolchain.toml`, `rustfmt.toml`, `clippy.toml`, vendored htmx |
| The scaffolded `main.rs`, shown with a 2-arg `layout()` and no attributes | 4-arg `layout()`, `#[public]` on every handler, a cookie-consent flow, an `embed-assets` block |

The prerequisites were wrong in a way that breaks the very first build: the guide said Postgres was needed &#34;only if you want database features; Autumn runs fine without one&#34;. `db` is a default feature, so a fresh project links `libpq` at compile time whether or not a database is configured. `libpq`, the Diesel CLI requirement, and a Docker one-liner for a throwaway Postgres are now stated up front.

## What changed

**Added** — three things the guide never covered:
- `autumn generate scaffold`, previously reachable only from the generators guide — documented for what it actually produces (see below), not as a one-liner to CRUD.
- A testing section built on the `tests/integration_test.rs` the scaffold already writes, plus `autumn test`.
- The prebuilt-binary install path (`install.sh` / `install.ps1`), already in the README.

**Trimmed** — the ~100-line route-collision-diagnostics appendix and the `_method` override&#39;s same-origin bullet list are compressed to their first-hour essentials and link onward. Reference depth belongs in the reference docs; this guide is the 30-minute tour that sits between the README quickstart and the 12-chapter tutorial, and it now says so in the opening.

**Reordered** — &#34;Production Notes&#34; no longer interrupts the walkthrough between &#34;Run it&#34; and &#34;Path Parameters&#34;; it is a &#34;Before you deploy&#34; section at the end. `autumn doctor` moved up to where a new user actually needs it, immediately after `autumn new`.

## The scaffold is locked, and the guide says so

The generated CRUD resource is **not** an open CRUD app, and pretending otherwise is what makes readers think they hit a bug:

- Reads (`GET /posts`, `GET /posts/{id}`, the CSV export, `GET /api/posts`) serve immediately.
- Writes are gated twice: `#[secured]` on the route, and an `authorize::<Post>` / `authorize_create::<Post>` call in the handler body against the registered `PostPolicy`. Deleting the attribute alone gets you to the form and a 403 on submit.
- The JSON write handlers are generated but deliberately unregistered.

The guide explains that double gate as a design decision rather than a caveat, then walks the flow that unlocks it: `autumn generate auth User` → sign up → **open the `/auth/confirm/{token}` link** (printed into the `autumn dev` log, since the `dev` profile defaults the mail transport to `log`) → log in.

## Compatibility

The `#configuration`, `#environment-variable-overrides`, and `#route-collision-diagnostics` anchors are preserved, so the inbound links from `docs/guide/deployment.md`, `docs/guide/openapi.md`, and `skills/autumn-web/SKILL.md` still resolve.

Version pins stay on the published 0.6.0 line, per the `[Unreleased]` convention in `CLAUDE.md` — bumping install instructions is part of cutting a release, not of this change.

## Verification

- `cargo test -p autumn-cli --test cli_tests first_run_docs_match_current_release_line` — passes (the gate holding every first-run doc to the README&#39;s published CLI pin, the MSRV string, the `autumn-web` release line, and the exact `/health` JSON).
- `scripts/check-examples.sh` — passes; every `examples/*` path referenced is in the catalog.
- All 36 relative links in the file resolve to existing paths.
- Every example handler carries a `#[public]` classification, so copying them into a scaffolded app does not fail its generated `autumn routes audit` CI step.

## Review history

Seven findings from automated review, all fixed on this branch. Six were the same failure mode on my part — plausible generalizations in newly-written prose that the code contradicts, most of them dev/prod divergences that would have worked on a reader&#39;s machine and failed on deploy: a `_method` form missing its `_csrf` field, htmx mutations with no `csrf-token` meta tag or `HTMX_CSRF_JS_PATH` helper, unclassified routes, the two-layer authorization gate, the skipped email-confirmation step, and `--api` described as database-free when it keeps `db` (only `--daemon` drops it). The seventh was this PR&#39;s own changelog entry repeating the &#34;working CRUD&#34; claim the change exists to remove. Details are in the individual review threads.

The sections rewritten most (&#34;The writes are locked, on purpose&#34;, the prerequisites notes) would benefit from a human read — churn tends to leave seams.

## Found while verifying, not fixed here

`autumn-cli/src/templates/main.rs.tmpl:39` links `/static/css/app.css`, but `build.rs.tmpl` compiles Tailwind to `static/css/autumn.css` — and the dev watcher (`dev.rs`), the fingerprint manifest (`build.rs`), and the scaffold&#39;s `.gitignore` all key on `autumn.css`. A fresh `autumn new` app therefore 404s its own stylesheet. `app.css` is correct for the `saas` starter, which has its own `build.rs` emitting that name; it looks like it was copied into the base template. No test pins it. The guide documents the real pipeline (`input.css` → `static/css/autumn.css`, referenced via `asset_url(&#34;css/autumn.css&#34;)`) rather than the broken link, but the one-line template fix belongs in its own change.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011r2h7ouHJuArhAgBLADiQB
