### PR TITLE
⚡ Replace ingress `from_fn` layers with named-future services (#2214)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -179,10 +179,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   recursive `clone_box` down the rest of the stack, so each conversion took a
   whole deep-clone cascade with it too.
 
-  Measured end-to-end on a `TestApp` round trip (debug profile, deterministic
-  across runs): **172 → 140 allocation blocks** and **37,819 → 26,030 bytes**
-  per request under the default feature set — 18.6% fewer allocations and 31.2%
-  fewer bytes. The ingress clone-on-call traversal count drops from 13 to 9 in
+  Re-run of the issue's own DHAT recipe on `benches/request_pipeline.rs`
+  (release, 200 iterations = 650 requests), before and after on the same
+  machine — filtering allocation sites whose second stack frame is
+  `FromFn<..>::call` exactly, as the issue specifies:
+
+  | | `FromFn::call` `Box::pin` | share of run bytes | marginal blocks/req | marginal bytes/req |
+  | --- | ---: | ---: | ---: | ---: |
+  | before | 3,250 blocks / 5,215,600 bytes | 19.80% | 168.8 | 36,826 |
+  | after | **0 / 0** (0 sites) | **0%** | 139.2 | 25,943 |
+
+  The before column reproduces the issue's measurement exactly on block count
+  (3,250) and to within 1% on bytes. Overall: **−17.5% allocations** and
+  **−29.6% bytes** per request.
+
+  The same movement is pinned as a regression gate in the debug profile, where
+  it is deterministic run to run: **172 → 140 allocation blocks** and
+  **37,819 → 26,030 bytes** per request under the default feature set. The ingress clone-on-call traversal count drops from 13 to 9 in
   the same move, on the default set and on a 13-feature build alike. One layer
   also sheds an allocation of its own: the asset cache-control layer no longer
   clones the request path into a `String` on every request in the app.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -157,6 +157,60 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Performance
 
+- **ingress middleware no longer boxes a future per layer per request:** every
+  `axum::middleware::from_fn` on the framework's always-on request path is now a
+  hand-rolled `tower::Service` with a **named** future. `from_fn` cannot avoid
+  the cost it was paying: the async block it generates has no nameable type, so
+  `FromFn::call` returns it as `Box::pin(..)` — one heap allocation per call
+  site per request, sized by everything that block captures across its single
+  `.await`, which for an outer layer is the whole downstream continuation. DHAT
+  measured those boxes at **19.57% of every byte** the `request_pipeline`
+  benchmark allocated (5,267,600 of 26,918,238 bytes over 650 requests) while
+  being only 2.14% of the blocks — the largest single allocation cost in the
+  profile (issue #2214).
+
+  Converted: the asset cache-control layer, the event-bus app context, the
+  webhook replay-key cleanup, the method-override rejection filter, the
+  trusted-host gate, the startup barrier, the per-request timeout, the
+  read-your-own-writes pin, and (under `oauth2`) the HTTP-interceptor scope.
+  Each keeps its behaviour and its position in the stack exactly; what goes away
+  is the box and, with it, the `self.inner.clone()` `from_fn` needed to move the
+  inner service into that box — which for an erased `BoxCloneSyncService` was a
+  recursive `clone_box` down the rest of the stack, so each conversion took a
+  whole deep-clone cascade with it too.
+
+  Measured end-to-end on a `TestApp` round trip (debug profile, deterministic
+  across runs): **172 → 140 allocation blocks** and **37,819 → 26,030 bytes**
+  per request under the default feature set — 18.6% fewer allocations and 31.2%
+  fewer bytes. The ingress clone-on-call traversal count drops from 13 to 9 in
+  the same move, on the default set and on a 13-feature build alike. One layer
+  also sheds an allocation of its own: the asset cache-control layer no longer
+  clones the request path into a `String` on every request in the app.
+
+  Two middlewares are deliberately **not** converted, because they `.await`
+  before calling the inner service and their futures therefore cannot be named
+  without `type_alias_impl_trait`: the tenancy middleware (async tenant
+  extraction) and the rate-limit principal shim (async session read). Both are
+  off by default. `webhook_replay_cleanup` keeps one box, taken only on a `5xx`
+  that actually registered replay keys; on every other request its future is
+  unboxed (it still mints the per-request replay cell it always did).
+
+  One public behaviour change: `read_your_writes::middleware` used to
+  `unreachable!()` when handed `ReadYourWrites::Off`. It now debug-asserts and
+  falls back to an inert `Off` pin instead of panicking on the request path.
+  Both call sites gate on `mode != Off`, so the arm stays unreachable in
+  practice. Otherwise nothing public moved: `asset_cache_control`,
+  `method_override_rejection_filter` and `webhook_replay_cleanup_middleware`
+  remain exported `async fn`s with identical behaviour, now sharing their
+  decision logic with the layers so the two forms cannot drift.
+
+  Four gates keep the win from eroding: a per-request allocation **blocks**
+  ceiling tight enough that restoring a single `from_fn` fails it, a companion
+  **bytes** ceiling derived under the wider feature set CI actually gates with,
+  the ingress traversal count pinned to its exact measurement, and a
+  `type_name`-based assertion that none of the converted services ever returns a
+  `Pin<Box<dyn Future>>` again.
+
 - **config reads on the request path:** generated auth handlers, the admin
   plugin, the `saas` starter, and the `blog`/`saas`/`teams` examples now read
   configuration through `AppState::config_arc()` instead of

--- a/autumn/src/assets.rs
+++ b/autumn/src/assets.rs
@@ -394,21 +394,125 @@ pub async fn asset_cache_control(
     req: axum::extract::Request,
     next: axum::middleware::Next,
 ) -> axum::response::Response {
-    let path = req.uri().path().to_owned();
+    let header = cache_control_for_request(&req);
     let mut resp = next.run(req).await;
-    if path.starts_with("/static/") && resp.status().is_success() {
-        let is_immutable = path.strip_prefix("/static/").is_some_and(is_manifest_asset);
-        let header = if is_immutable {
+    apply_cache_control(&mut resp, header);
+    resp
+}
+
+/// `Cache-Control` value a `/static/...` request's successful response should
+/// carry, or `None` for any request that is not a static-asset request.
+///
+/// Resolved from the request *before* the response exists so the decision costs
+/// no allocation: the old form owned the path in a `String` for the whole
+/// downstream call, purely to re-read it afterwards.
+///
+/// One consequence of resolving up front: [`is_manifest_asset`] now runs for
+/// every `/static/...` request rather than only for successful ones, so a `404`
+/// for a missing asset can be the call that populates the process-lifetime
+/// manifest `OnceLock`. The manifest is written by `autumn build` before the
+/// server starts and never changes while it runs, so *which* request warms it
+/// is not observable; non-asset requests are unaffected either way, since
+/// `strip_prefix` returns `None` before any manifest lookup happens.
+fn cache_control_for_request<B>(req: &axum::http::Request<B>) -> Option<&'static str> {
+    req.uri().path().strip_prefix("/static/").map(|rel| {
+        if is_manifest_asset(rel) {
             "public, max-age=31536000, immutable"
         } else {
             "public, max-age=0, must-revalidate"
-        };
+        }
+    })
+}
+
+/// Stamp `header` onto `resp` when the request was for a static asset and the
+/// response succeeded. Shared by [`asset_cache_control`] and
+/// [`AssetCacheControlFuture`] so the two forms cannot drift.
+fn apply_cache_control<B>(resp: &mut axum::http::Response<B>, header: Option<&'static str>) {
+    if let Some(header) = header
+        && resp.status().is_success()
+    {
         resp.headers_mut().insert(
             http::header::CACHE_CONTROL,
             http::HeaderValue::from_static(header),
         );
     }
-    resp
+}
+
+/// Tower [`Layer`](tower::Layer) form of [`asset_cache_control`], used by the
+/// framework's ingress stack.
+///
+/// The `axum::middleware::from_fn` this replaces cost a `Box::pin` of the
+/// wrapped async block on every request — every request in the app, not just
+/// requests for `/static/...`, because this layer is applied globally — plus a
+/// deep clone of the erased service beneath it and a `String` clone of the
+/// request path (issue #2214). None of that survives here: the header is a
+/// `&'static str` decided up front and the future is the inner service's own.
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct AssetCacheControlLayer;
+
+impl<S> tower::Layer<S> for AssetCacheControlLayer {
+    type Service = AssetCacheControlService<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        AssetCacheControlService { inner }
+    }
+}
+
+/// Tower [`Service`](tower::Service) produced by [`AssetCacheControlLayer`].
+#[derive(Clone, Debug)]
+pub(crate) struct AssetCacheControlService<S> {
+    inner: S,
+}
+
+impl<S, ReqBody, ResBody> tower::Service<axum::http::Request<ReqBody>>
+    for AssetCacheControlService<S>
+where
+    S: tower::Service<axum::http::Request<ReqBody>, Response = axum::http::Response<ResBody>>,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = AssetCacheControlFuture<S::Future>;
+
+    fn poll_ready(
+        &mut self,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, req: axum::http::Request<ReqBody>) -> Self::Future {
+        AssetCacheControlFuture {
+            header: cache_control_for_request(&req),
+            inner: self.inner.call(req),
+        }
+    }
+}
+
+pin_project_lite::pin_project! {
+    /// Future returned by [`AssetCacheControlService`]: the inner service's own
+    /// future plus the `&'static str` header to stamp on its response.
+    pub(crate) struct AssetCacheControlFuture<F> {
+        #[pin]
+        inner: F,
+        header: Option<&'static str>,
+    }
+}
+
+impl<F, ResBody, E> std::future::Future for AssetCacheControlFuture<F>
+where
+    F: std::future::Future<Output = Result<axum::http::Response<ResBody>, E>>,
+{
+    type Output = Result<axum::http::Response<ResBody>, E>;
+
+    fn poll(
+        self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Self::Output> {
+        let this = self.project();
+        let mut response = std::task::ready!(this.inner.poll(cx))?;
+        apply_cache_control(&mut response, *this.header);
+        std::task::Poll::Ready(Ok(response))
+    }
 }
 
 /// Best-effort `Content-Type` for a static/embedded asset, derived from its
@@ -596,7 +700,7 @@ pub(crate) async fn serve_embedded(
 pub fn embedded_static_router() -> axum::Router {
     axum::Router::new()
         .route("/static/{*path}", axum::routing::get(serve_embedded))
-        .layer(axum::middleware::from_fn(asset_cache_control))
+        .layer(AssetCacheControlLayer)
 }
 
 #[cfg(test)]
@@ -711,5 +815,114 @@ mod tests {
         // Unknown / extensionless fall back to octet-stream.
         assert_eq!(content_type_for("data.bin"), "application/octet-stream");
         assert_eq!(content_type_for("LICENSE"), "application/octet-stream");
+    }
+}
+
+/// Direct coverage for [`AssetCacheControlService`] (issue #2214).
+///
+/// The framework's ingress installs the *layer*; the retained
+/// [`asset_cache_control`] `async fn` is what every pre-existing test exercises.
+/// An end-to-end test cannot cover the layer under default features either: the
+/// `/static` route is a `ServeDir` over a `static/` directory this crate does
+/// not ship, so every `/static/...` request in the test suite 404s and the
+/// success branch — the entire point of this middleware — is never reached.
+/// Driving the service directly over a stub inner service closes that.
+#[cfg(test)]
+mod cache_control_service_tests {
+    use super::{AssetCacheControlLayer, cache_control_for_request};
+    use axum::body::Body;
+    use axum::http::{Request, Response, StatusCode};
+    use tower::{Layer, Service, ServiceExt};
+
+    const REVALIDATE: &str = "public, max-age=0, must-revalidate";
+
+    /// Inner service that answers every request with `status` and no
+    /// `Cache-Control`, so any header on the way out came from the layer.
+    fn responder(
+        status: StatusCode,
+    ) -> impl Service<Request<Body>, Response = Response<Body>, Error = std::convert::Infallible> + Clone
+    {
+        tower::service_fn(move |_req: Request<Body>| async move {
+            Ok::<_, std::convert::Infallible>(
+                Response::builder()
+                    .status(status)
+                    .body(Body::empty())
+                    .expect("response builds"),
+            )
+        })
+    }
+
+    /// `#[allow(future_not_send)]`: `tower::service_fn`'s closure is not
+    /// `Sync`, so this helper's future is `!Send`. It only ever runs on a
+    /// `#[tokio::test]` current-thread runtime, which never moves it.
+    #[allow(clippy::future_not_send)]
+    async fn cache_control_for(path: &str, status: StatusCode) -> Option<String> {
+        let service = AssetCacheControlLayer.layer(responder(status));
+        let response = service
+            .oneshot(
+                Request::builder()
+                    .uri(path)
+                    .body(Body::empty())
+                    .expect("request builds"),
+            )
+            .await
+            .expect("infallible");
+        response
+            .headers()
+            .get(http::header::CACHE_CONTROL)
+            .map(|v| v.to_str().expect("ascii header").to_owned())
+    }
+
+    #[tokio::test]
+    async fn stamps_successful_static_responses() {
+        // Debug builds have no fingerprint manifest, so every asset is the
+        // revalidate (non-immutable) case.
+        assert_eq!(
+            cache_control_for("/static/css/app.css", StatusCode::OK).await,
+            Some(REVALIDATE.to_owned()),
+        );
+    }
+
+    #[tokio::test]
+    async fn leaves_non_static_routes_alone() {
+        assert_eq!(cache_control_for("/ping", StatusCode::OK).await, None);
+        // `/static` without the trailing slash is NOT an asset path — the
+        // predicate is a `/static/` prefix, matching the original `starts_with`.
+        assert_eq!(cache_control_for("/static", StatusCode::OK).await, None);
+        assert_eq!(cache_control_for("/staticky/x", StatusCode::OK).await, None);
+    }
+
+    #[tokio::test]
+    async fn leaves_unsuccessful_static_responses_alone() {
+        for status in [
+            StatusCode::NOT_FOUND,
+            StatusCode::FOUND,
+            StatusCode::INTERNAL_SERVER_ERROR,
+        ] {
+            assert_eq!(
+                cache_control_for("/static/css/app.css", status).await,
+                None,
+                "only a successful response may be given a Cache-Control"
+            );
+        }
+    }
+
+    /// The request-side half of the decision, isolated: `/static/` exactly
+    /// yields an empty relative path and still counts as an asset request,
+    /// matching the original `starts_with(..) && strip_prefix(..)` pair.
+    #[test]
+    fn the_predicate_matches_the_original_starts_with_form() {
+        let req = |path: &str| {
+            Request::builder()
+                .uri(path)
+                .body(Body::empty())
+                .expect("request builds")
+        };
+        assert!(cache_control_for_request(&req("/static/")).is_some());
+        assert!(cache_control_for_request(&req("/static/a.css")).is_some());
+        // Query strings are not part of `Uri::path()`, so they cannot affect it.
+        assert!(cache_control_for_request(&req("/static/a.css?v=1")).is_some());
+        assert!(cache_control_for_request(&req("/static")).is_none());
+        assert!(cache_control_for_request(&req("/")).is_none());
     }
 }

--- a/autumn/src/events.rs
+++ b/autumn/src/events.rs
@@ -457,6 +457,75 @@ fn current_event_app() -> Option<AppState> {
     CURRENT_EVENT_APP.try_with(AppState::clone).ok()
 }
 
+/// Tower [`Layer`](tower::Layer) installing the request's app as the ambient
+/// event-bus context for the whole downstream stack.
+///
+/// This was an `axum::middleware::from_fn_with_state` until #2214. `from_fn`
+/// has to `Box::pin` the async block it generates, because that block's type
+/// cannot be named — one heap allocation on every request, and this layer sits
+/// near the outside of the ingress stack, so the block captured the entire
+/// downstream continuation. [`scope_event_app`] already returns a *named*
+/// future ([`tokio::task::futures::TaskLocalFuture`]), so a hand-rolled service
+/// can hand it straight back and allocate nothing.
+///
+/// The inner future is built inside a `sync_scope` and then polled inside a
+/// `scope`, rather than simply being passed to `scope` as an argument.
+/// Arguments are evaluated first, so the plain form would run the whole
+/// synchronous `Service::call` chain beneath this layer — which includes
+/// `TrustedProxiesService` and every operator- or plugin-registered Tower layer
+/// — with the task-local unset, where the `from_fn` form it replaces ran it
+/// inside the scope. `crate::capsule::capture` documents the same hazard and
+/// guards it with a dedicated test.
+#[derive(Clone)]
+pub(crate) struct EventAppContextLayer {
+    state: AppState,
+}
+
+impl EventAppContextLayer {
+    pub(crate) const fn new(state: AppState) -> Self {
+        Self { state }
+    }
+}
+
+impl<S> tower::Layer<S> for EventAppContextLayer {
+    type Service = EventAppContextService<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        EventAppContextService {
+            inner,
+            state: self.state.clone(),
+        }
+    }
+}
+
+/// Tower [`Service`](tower::Service) produced by [`EventAppContextLayer`].
+#[derive(Clone)]
+pub(crate) struct EventAppContextService<S> {
+    inner: S,
+    state: AppState,
+}
+
+impl<S, ReqBody> tower::Service<axum::http::Request<ReqBody>> for EventAppContextService<S>
+where
+    S: tower::Service<axum::http::Request<ReqBody>>,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = tokio::task::futures::TaskLocalFuture<AppState, S::Future>;
+
+    fn poll_ready(
+        &mut self,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, req: axum::http::Request<ReqBody>) -> Self::Future {
+        let inner = CURRENT_EVENT_APP.sync_scope(self.state.clone(), || self.inner.call(req));
+        scope_event_app(self.state.clone(), inner)
+    }
+}
+
 /// Publish an event without a request context (services, jobs, scheduled tasks).
 ///
 /// Resolves the **current app** from the ambient request/job context when one is

--- a/autumn/src/mcp.rs
+++ b/autumn/src/mcp.rs
@@ -1113,14 +1113,14 @@ struct ReplayContext<'a> {
 /// before the request body is buffered.
 ///
 /// The `/mcp` envelope is merged after `apply_middleware`, so it does not pass
-/// through the global [`trusted_host_middleware`](crate::router) every direct
+/// through the global `TrustedHostLayer` in [`crate::router`] that every direct
 /// route runs; this layer restores that gate for the endpoint. Running as a
 /// layer (rather than inside `serve_mcp`) means a bad-`Host` request is rejected
 /// before the handler's `Bytes` extractor reads up to the configured
 /// `max_request_size_bytes`, exactly as a direct route rejects in middleware
 /// before handler extraction.
 ///
-/// Host resolution mirrors `trusted_host_middleware`: the proxy-resolved
+/// Host resolution mirrors `TrustedHostService`: the proxy-resolved
 /// identity first (honouring `X-Forwarded-Host` from trusted upstreams), then
 /// the HTTP/2 `:authority` carried in the request URI, then the `Host` header —
 /// so an HTTP/2 client that sends `:authority` without a `Host` header is not
@@ -1201,7 +1201,7 @@ async fn serve_mcp(
     // `mcp_host_origin_guard` layer (applied in `build_mcp_router`) rather than
     // here, so an untrusted Host or disallowed Origin is rejected *before* this
     // handler buffers `body` up to the configured `max_request_size_bytes` —
-    // mirroring how direct routes reject in `trusted_host_middleware` before
+    // mirroring how direct routes reject in `TrustedHostService` before
     // handler extraction.
     let parsed: Value = match serde_json::from_slice(&body) {
         Ok(v) => v,

--- a/autumn/src/middleware/method_override.rs
+++ b/autumn/src/middleware/method_override.rs
@@ -141,6 +141,7 @@ use std::task::{Context, Poll};
 use axum::http::{Request, Response, StatusCode};
 use tower::{Layer, Service};
 
+use crate::middleware::short_circuit::ShortCircuitFuture;
 use crate::security::trusted_proxies::ResolvedClientIdentity;
 
 /// Default form field name for the method override.
@@ -210,48 +211,105 @@ pub async fn method_override_rejection_filter(
     request: axum::extract::Request,
     next: axum::middleware::Next,
 ) -> axum::response::Response {
-    use crate::middleware::exception_filter::AutumnErrorInfo;
-    use axum::response::IntoResponse;
-
-    if let Some(rejection) = request
-        .extensions()
-        .get::<MethodOverrideRejection>()
-        .copied()
-    {
-        let (status, message) = match rejection {
-            MethodOverrideRejection::InvalidValue => (
-                StatusCode::BAD_REQUEST,
-                "Invalid method override value: must be PUT, PATCH, or DELETE.",
-            ),
-            MethodOverrideRejection::BodyTooLarge => (
-                StatusCode::PAYLOAD_TOO_LARGE,
-                "Form body too large for method-override scanning.",
-            ),
-        };
-        let mut response = (
-            status,
-            [(
-                http::header::CONTENT_TYPE,
-                http::HeaderValue::from_static("text/plain; charset=utf-8"),
-            )],
-            message,
-        )
-            .into_response();
-        // Surface this as a framework error so the exception filter
-        // chain (problem-details normalization, custom HTML error-page
-        // rendering) processes it the same as any handler-generated
-        // error response. Without this extension, `ExceptionFilterFuture`
-        // treats the response as pre-formed and skips renegotiation.
-        response.extensions_mut().insert(AutumnErrorInfo {
-            status,
-            message: message.to_owned(),
-            details: None,
-            problem_type: None,
-            backtrace_string: None,
-        });
+    if let Some(response) = rejection_response(&request) {
         return response;
     }
     next.run(request).await
+}
+
+/// The rejection response for a request carrying a [`MethodOverrideRejection`]
+/// extension, or `None` when it carries none (the overwhelmingly common case).
+///
+/// Shared by [`method_override_rejection_filter`] and
+/// [`MethodOverrideRejectionService`] so the two forms of the same middleware
+/// cannot drift.
+fn rejection_response<B>(request: &Request<B>) -> Option<Response<axum::body::Body>> {
+    use crate::middleware::exception_filter::AutumnErrorInfo;
+    use axum::response::IntoResponse;
+
+    let rejection = request
+        .extensions()
+        .get::<MethodOverrideRejection>()
+        .copied()?;
+    let (status, message) = match rejection {
+        MethodOverrideRejection::InvalidValue => (
+            StatusCode::BAD_REQUEST,
+            "Invalid method override value: must be PUT, PATCH, or DELETE.",
+        ),
+        MethodOverrideRejection::BodyTooLarge => (
+            StatusCode::PAYLOAD_TOO_LARGE,
+            "Form body too large for method-override scanning.",
+        ),
+    };
+    let mut response = (
+        status,
+        [(
+            http::header::CONTENT_TYPE,
+            http::HeaderValue::from_static("text/plain; charset=utf-8"),
+        )],
+        message,
+    )
+        .into_response();
+    // Surface this as a framework error so the exception filter
+    // chain (problem-details normalization, custom HTML error-page
+    // rendering) processes it the same as any handler-generated
+    // error response. Without this extension, `ExceptionFilterFuture`
+    // treats the response as pre-formed and skips renegotiation.
+    response.extensions_mut().insert(AutumnErrorInfo {
+        status,
+        message: message.to_owned(),
+        details: None,
+        problem_type: None,
+        backtrace_string: None,
+    });
+    Some(response)
+}
+
+/// Tower [`Layer`](tower::Layer) form of [`method_override_rejection_filter`],
+/// used by the framework's ingress stack.
+///
+/// Behaviourally identical to the `async fn` above; it exists because
+/// `axum::middleware::from_fn` has to `Box::pin` the future of whatever it
+/// wraps, paying a heap allocation on every request whether or not a rejection
+/// is present — and this layer sits on the always-on path, so that was one
+/// allocation per request for a check that is a no-op almost every time
+/// (issue #2214). [`ShortCircuitFuture`] holds the inner service's future in
+/// place instead.
+#[derive(Clone, Copy, Debug)]
+pub struct MethodOverrideRejectionLayer;
+
+impl<S> Layer<S> for MethodOverrideRejectionLayer {
+    type Service = MethodOverrideRejectionService<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        MethodOverrideRejectionService { inner }
+    }
+}
+
+/// Tower [`Service`] produced by [`MethodOverrideRejectionLayer`].
+#[derive(Clone, Debug)]
+pub struct MethodOverrideRejectionService<S> {
+    inner: S,
+}
+
+impl<S, ReqBody> Service<Request<ReqBody>> for MethodOverrideRejectionService<S>
+where
+    S: Service<Request<ReqBody>, Response = Response<axum::body::Body>>,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = ShortCircuitFuture<S::Future>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, req: Request<ReqBody>) -> Self::Future {
+        rejection_response(&req).map_or_else(
+            || ShortCircuitFuture::forward(self.inner.call(req)),
+            ShortCircuitFuture::short_circuit,
+        )
+    }
 }
 
 /// Tower [`Layer`] that applies the HTML form method override convention.

--- a/autumn/src/middleware/mod.rs
+++ b/autumn/src/middleware/mod.rs
@@ -29,6 +29,7 @@ pub(crate) mod method_override;
 pub(crate) mod metrics;
 pub(crate) mod request_id;
 pub(crate) mod server_timing;
+pub(crate) mod short_circuit;
 #[cfg(feature = "telemetry-otlp")]
 pub(crate) mod trace_context;
 

--- a/autumn/src/middleware/short_circuit.rs
+++ b/autumn/src/middleware/short_circuit.rs
@@ -1,0 +1,155 @@
+//! The future shape every "inspect, then reject or forward" ingress gate
+//! returns (issue #2214).
+//!
+//! A gate middleware looks at a request synchronously and either produces a
+//! response of its own — a `400` for an untrusted `Host`, a `503` while the app
+//! is still starting up — or hands the request to the service beneath it
+//! untouched. Written as an `axum::middleware::from_fn` that shape costs a heap
+//! allocation on *every* request: `FromFn::call` wraps the async block it
+//! generates in a `Box::pin`, because the block's type cannot be named, and it
+//! clones its inner service to move it in there — which for an erased
+//! `BoxCloneSyncService` is a recursive `clone_box` down the rest of the stack.
+//! Neither cost depends on whether the gate actually rejects anything.
+//!
+//! [`ShortCircuitFuture`] is the named alternative. It holds the inner
+//! service's own future in place (no box, no clone) on the forwarding path and
+//! a ready-made response on the rejecting one, so a gate written against it
+//! allocates nothing per request. DHAT measured the `from_fn` boxes it replaces
+//! at 19.57% of every byte the `request_pipeline` benchmark allocated.
+//!
+//! `MaintenanceFuture` and `LoadShedFuture` are the same shape and predate this
+//! type; they are deliberately left alone because both are exported from the
+//! crate root, so collapsing them into this one would be a breaking change for
+//! a purely internal tidy.
+
+// autumn-panic-gate: request-path module — production code path must be panic-free.
+// See CONTRIBUTING.md "Request-path panic gate". Justify exceptions with
+// #[allow(clippy::<lint>, reason = "…")] at the narrowest scope.
+#![cfg_attr(
+    not(test),
+    deny(
+        clippy::unwrap_used,
+        clippy::expect_used,
+        clippy::panic,
+        clippy::unreachable,
+        clippy::todo,
+        clippy::unimplemented,
+        clippy::indexing_slicing,
+        clippy::string_slice,
+        clippy::arithmetic_side_effects,
+    )
+)]
+
+use std::future::Future;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+use axum::body::Body;
+use axum::http::Response;
+use pin_project_lite::pin_project;
+
+pin_project! {
+    /// Future returned by an ingress gate: either a response the gate produced
+    /// itself, ready on the first poll, or the inner service's future polled
+    /// through unchanged.
+    ///
+    /// The `Forward` variant stores `F` **by value** rather than boxing it, so
+    /// the whole chain of framework middleware collapses into the single
+    /// `Box::pin` `axum::routing::Route` already takes at the top of the stack
+    /// instead of taking one of its own per layer.
+    #[project = ShortCircuitFutureProj]
+    pub enum ShortCircuitFuture<F> {
+        /// The gate rejected the request; `response` is handed back on the
+        /// first poll and the inner service is never called.
+        ShortCircuit { response: Option<Response<Body>> },
+        /// The gate passed the request through; this is the inner service's
+        /// own future.
+        Forward {
+            #[pin]
+            inner: F,
+        },
+    }
+}
+
+impl<F> ShortCircuitFuture<F> {
+    /// Reject the request with `response`, without calling the inner service.
+    pub(crate) const fn short_circuit(response: Response<Body>) -> Self {
+        Self::ShortCircuit {
+            response: Some(response),
+        }
+    }
+
+    /// Forward to the inner service's future.
+    pub(crate) const fn forward(inner: F) -> Self {
+        Self::Forward { inner }
+    }
+}
+
+impl<F, E> Future for ShortCircuitFuture<F>
+where
+    F: Future<Output = Result<Response<Body>, E>>,
+{
+    type Output = Result<Response<Body>, E>;
+
+    #[allow(
+        clippy::expect_used,
+        reason = "unreachable: future not polled after Ready"
+    )]
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        match self.project() {
+            ShortCircuitFutureProj::ShortCircuit { response } => Poll::Ready(Ok(response
+                .take()
+                .expect("ShortCircuitFuture polled after completion"))),
+            ShortCircuitFutureProj::Forward { inner } => inner.poll(cx),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::http::StatusCode;
+
+    /// The whole point of this type: no `Box` anywhere in the future a gate
+    /// hands back, so nothing is heap-allocated per request (issue #2214).
+    #[test]
+    fn the_future_is_named_not_boxed() {
+        let name = std::any::type_name::<ShortCircuitFuture<std::future::Ready<()>>>();
+        assert!(
+            !name.contains("Box"),
+            "ShortCircuitFuture must stay a named, unboxed future; got {name}"
+        );
+    }
+
+    /// A `Forward` future that would hang forever: resolving a `ShortCircuit`
+    /// built over it proves the inner future is never polled.
+    type Never = std::future::Pending<Result<Response<Body>, std::convert::Infallible>>;
+
+    #[tokio::test]
+    async fn short_circuit_resolves_with_the_gate_response_without_the_inner_future() {
+        let response = Response::builder()
+            .status(StatusCode::BAD_REQUEST)
+            .body(Body::empty())
+            .expect("response builds");
+
+        let got = ShortCircuitFuture::<Never>::short_circuit(response)
+            .await
+            .expect("infallible");
+        assert_eq!(got.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn forward_resolves_with_the_inner_futures_output() {
+        let inner = std::future::ready(Ok::<_, std::convert::Infallible>(
+            Response::builder()
+                .status(StatusCode::IM_A_TEAPOT)
+                .body(Body::empty())
+                .expect("response builds"),
+        ));
+
+        let got = ShortCircuitFuture::forward(inner)
+            .await
+            .expect("infallible");
+        assert_eq!(got.status(), StatusCode::IM_A_TEAPOT);
+    }
+}

--- a/autumn/src/read_your_writes.rs
+++ b/autumn/src/read_your_writes.rs
@@ -276,10 +276,11 @@ pub const RYW_COOKIE_NAME: &str = "autumn.ryw";
 /// Axum middleware function that installs the RYWW task-local for every
 /// request and, in `session` mode, handles the signed cookie lifecycle.
 ///
-/// The framework itself installs [`ReadYourWritesLayer`] (the same logic as a
-/// `tower::Service` with a named future — see issue #2214) rather than this
-/// function; it is retained as public API for callers wiring the middleware
-/// into an `axum::middleware::from_fn` of their own.
+/// The framework itself installs `ReadYourWritesLayer` — the same logic as a
+/// `tower::Service` with a named future, so the ingress path pays no `Box::pin`
+/// per request (issue #2214) — rather than this function, which is retained as
+/// public API for callers wiring the middleware into an
+/// `axum::middleware::from_fn` of their own.
 pub async fn middleware(
     req: axum::http::Request<axum::body::Body>,
     next: axum::middleware::Next,

--- a/autumn/src/read_your_writes.rs
+++ b/autumn/src/read_your_writes.rs
@@ -203,7 +203,19 @@ tokio::task_local! {
 ///
 /// Called by the RYW middleware for every request when mode is not `off`.
 pub async fn scope<F: std::future::Future>(pin: RequestPin, fut: F) -> F::Output {
-    PIN.scope(pin, fut).await
+    scope_future(pin, fut).await
+}
+
+/// [`scope`] as a **named** future rather than an `async fn`.
+///
+/// [`ReadYourWritesService`] needs the concrete type so its own `Service::Future`
+/// can be named and therefore need no `Box::pin` (issue #2214); `scope` above is
+/// the ergonomic `async fn` wrapper every other caller uses.
+pub(crate) fn scope_future<F: std::future::Future>(
+    pin: RequestPin,
+    fut: F,
+) -> tokio::task::futures::TaskLocalFuture<RequestPin, F> {
+    PIN.scope(pin, fut)
 }
 
 /// Mark that the current request has performed a primary write.
@@ -264,8 +276,10 @@ pub const RYW_COOKIE_NAME: &str = "autumn.ryw";
 /// Axum middleware function that installs the RYWW task-local for every
 /// request and, in `session` mode, handles the signed cookie lifecycle.
 ///
-/// Installed by `apply_middleware` in `router.rs` when
-/// `database.read_your_writes != "off"`.
+/// The framework itself installs [`ReadYourWritesLayer`] (the same logic as a
+/// `tower::Service` with a named future — see issue #2214) rather than this
+/// function; it is retained as public API for callers wiring the middleware
+/// into an `axum::middleware::from_fn` of their own.
 pub async fn middleware(
     req: axum::http::Request<axum::body::Body>,
     next: axum::middleware::Next,
@@ -274,30 +288,188 @@ pub async fn middleware(
     keys: Option<std::sync::Arc<crate::security::config::ResolvedSigningKeys>>,
     metrics: crate::middleware::MetricsCollector,
 ) -> axum::http::Response<axum::body::Body> {
-    let pin = match mode {
-        crate::config::ReadYourWrites::Session => {
-            let cookie_val = extract_ryw_cookie_value(&req);
-            match (cookie_val, &keys) {
-                (Some(cv), Some(k)) => {
-                    RequestPin::with_session_cookie_and_metrics(&cv, k, window_secs, metrics)
-                }
-                _ => RequestPin::new_with_metrics(mode, metrics),
-            }
-        }
-        crate::config::ReadYourWrites::Request => RequestPin::new_with_metrics(mode, metrics),
-        crate::config::ReadYourWrites::Off => unreachable!("RYW middleware installed in off mode"),
+    let settings = ReadYourWritesSettings {
+        mode,
+        window_secs,
+        keys,
+        metrics,
     };
-
+    let pin = request_pin_for(&req, &settings);
     let pin_for_response = pin.clone();
 
     let mut response = scope(pin, next.run(req)).await;
 
     // Session mode: stamp a Set-Cookie if a write occurred so subsequent
     // requests within the freshness window also route to primary.
-    if mode == crate::config::ReadYourWrites::Session
-        && let Some(k) = &keys
-        && let Some(cv) = session_cookie_value(&pin_for_response, k)
+    stamp_ryw_cookie(&mut response, &settings, &pin_for_response);
+
+    response
+}
+
+/// Extract the `autumn.ryw` cookie value from raw `Cookie` headers.
+///
+/// Delegates to `session::get_cookie` so that duplicate-name rejection
+/// (cookie-tossing mitigation) and exact-name matching are handled uniformly
+/// with the session layer.
+fn extract_ryw_cookie_value<B>(req: &axum::http::Request<B>) -> Option<String> {
+    crate::session::get_cookie(req.headers(), RYW_COOKIE_NAME)
+}
+
+/// Everything the read-your-own-writes middleware resolves once at
+/// router-assembly time.
+///
+/// Behind an `Arc` in the layer because the produced service is cloned on every
+/// traversal of the ingress stack above it.
+struct ReadYourWritesSettings {
+    mode: crate::config::ReadYourWrites,
+    window_secs: u64,
+    keys: Option<Arc<crate::security::config::ResolvedSigningKeys>>,
+    metrics: crate::middleware::MetricsCollector,
+}
+
+/// Tower [`Layer`](tower::Layer) form of [`middleware`], used by the framework's
+/// ingress stack.
+///
+/// The `axum::middleware::from_fn` closure it replaces `Box::pin`ned its async
+/// block on every request and cloned the erased service beneath it to move it in
+/// (issue #2214). `PIN.scope(..)` already yields a named
+/// [`tokio::task::futures::TaskLocalFuture`], so the pin can be installed with
+/// no allocation at all.
+#[derive(Clone)]
+pub(crate) struct ReadYourWritesLayer {
+    settings: Arc<ReadYourWritesSettings>,
+}
+
+impl ReadYourWritesLayer {
+    /// Build the layer. `mode` must not be [`ReadYourWrites::Off`] — the
+    /// framework only installs this layer when read-your-own-writes is on.
+    pub(crate) fn new(
+        mode: crate::config::ReadYourWrites,
+        window_secs: u64,
+        keys: Option<Arc<crate::security::config::ResolvedSigningKeys>>,
+        metrics: crate::middleware::MetricsCollector,
+    ) -> Self {
+        Self {
+            settings: Arc::new(ReadYourWritesSettings {
+                mode,
+                window_secs,
+                keys,
+                metrics,
+            }),
+        }
+    }
+}
+
+impl<S> tower::Layer<S> for ReadYourWritesLayer {
+    type Service = ReadYourWritesService<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        ReadYourWritesService {
+            inner,
+            settings: Arc::clone(&self.settings),
+        }
+    }
+}
+
+/// Tower [`Service`](tower::Service) produced by [`ReadYourWritesLayer`].
+#[derive(Clone)]
+pub(crate) struct ReadYourWritesService<S> {
+    inner: S,
+    settings: Arc<ReadYourWritesSettings>,
+}
+
+impl<S, ReqBody> tower::Service<axum::http::Request<ReqBody>> for ReadYourWritesService<S>
+where
+    S: tower::Service<axum::http::Request<ReqBody>, Response = axum::response::Response>,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = ReadYourWritesFuture<S::Future>;
+
+    fn poll_ready(
+        &mut self,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, req: axum::http::Request<ReqBody>) -> Self::Future {
+        let pin = request_pin_for(&req, &self.settings);
+        let pin_for_response = pin.clone();
+        // Built inside the scope, not merely polled inside it: arguments are
+        // evaluated first, so passing `self.inner.call(req)` straight to
+        // `scope_future` would run the synchronous `Service::call` chain beneath
+        // this layer with `PIN` unset. `is_pinned()`/`mark_write()` are public
+        // and synchronous, so an operator's own Tower layer is entitled to call
+        // them from `call`. See `crate::capsule::capture` for the same hazard.
+        let inner = PIN.sync_scope(pin.clone(), || self.inner.call(req));
+        ReadYourWritesFuture {
+            inner: scope_future(pin, inner),
+            settings: Arc::clone(&self.settings),
+            pin: pin_for_response,
+        }
+    }
+}
+
+/// Mint the per-request pin, reading the signed `autumn.ryw` cookie in session
+/// mode. Shared by [`middleware`] and [`ReadYourWritesService`].
+fn request_pin_for<B>(
+    req: &axum::http::Request<B>,
+    settings: &ReadYourWritesSettings,
+) -> RequestPin {
+    match settings.mode {
+        crate::config::ReadYourWrites::Session => {
+            match (extract_ryw_cookie_value(req), &settings.keys) {
+                (Some(cv), Some(k)) => RequestPin::with_session_cookie_and_metrics(
+                    &cv,
+                    k,
+                    settings.window_secs,
+                    settings.metrics.clone(),
+                ),
+                _ => RequestPin::new_with_metrics(settings.mode, settings.metrics.clone()),
+            }
+        }
+        crate::config::ReadYourWrites::Request => {
+            RequestPin::new_with_metrics(settings.mode, settings.metrics.clone())
+        }
+        crate::config::ReadYourWrites::Off => {
+            // Unreachable: both call sites gate on `mode != Off`
+            // (`apply_middleware` only builds the layer inside that check, and
+            // `middleware` documents the same precondition). This used to be an
+            // `unreachable!()`; it is a `debug_assert!` plus an INERT pin now,
+            // because turning a caller's misconfiguration into a panic on the
+            // request path is the wrong trade for a middleware whose whole job
+            // is optional. The fallback is `Off`, not `Request`: `Request` is
+            // the *active* mode, so it would silently start pinning reads to
+            // the primary for an app that configured read-your-own-writes off —
+            // contradicting `is_pinned_off_mode_never_pins` below. `Off` is
+            // inert (`is_pinned` is false, no cookie is minted), which is what
+            // the configuration asked for.
+            debug_assert!(
+                false,
+                "read-your-own-writes middleware built in `off` mode; \
+                 both call sites are supposed to gate on `mode != Off`"
+            );
+            RequestPin::new_with_metrics(
+                crate::config::ReadYourWrites::Off,
+                settings.metrics.clone(),
+            )
+        }
+    }
+}
+
+/// Stamp the `autumn.ryw` `Set-Cookie` on `response` when session mode recorded
+/// a primary write. Shared by [`middleware`] and [`ReadYourWritesFuture`].
+fn stamp_ryw_cookie(
+    response: &mut axum::response::Response,
+    settings: &ReadYourWritesSettings,
+    pin: &RequestPin,
+) {
+    if settings.mode == crate::config::ReadYourWrites::Session
+        && let Some(k) = &settings.keys
+        && let Some(cv) = session_cookie_value(pin, k)
     {
+        let window_secs = settings.window_secs;
         let cookie_str = format!(
             "{RYW_COOKIE_NAME}={cv}; Max-Age={window_secs}; HttpOnly; \
              Secure; SameSite=Lax; Path=/"
@@ -308,17 +480,35 @@ pub async fn middleware(
                 .append(axum::http::header::SET_COOKIE, hv);
         }
     }
-
-    response
 }
 
-/// Extract the `autumn.ryw` cookie value from raw `Cookie` headers.
-///
-/// Delegates to `session::get_cookie` so that duplicate-name rejection
-/// (cookie-tossing mitigation) and exact-name matching are handled uniformly
-/// with the session layer.
-fn extract_ryw_cookie_value(req: &axum::http::Request<axum::body::Body>) -> Option<String> {
-    crate::session::get_cookie(req.headers(), RYW_COOKIE_NAME)
+pin_project_lite::pin_project! {
+    /// Future returned by [`ReadYourWritesService`]: the inner service's future
+    /// polled inside the task-local pin scope, then the session-mode
+    /// `Set-Cookie` stamp on the way out.
+    pub(crate) struct ReadYourWritesFuture<F> {
+        #[pin]
+        inner: tokio::task::futures::TaskLocalFuture<RequestPin, F>,
+        settings: Arc<ReadYourWritesSettings>,
+        pin: RequestPin,
+    }
+}
+
+impl<F, E> std::future::Future for ReadYourWritesFuture<F>
+where
+    F: std::future::Future<Output = Result<axum::response::Response, E>>,
+{
+    type Output = Result<axum::response::Response, E>;
+
+    fn poll(
+        self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Self::Output> {
+        let this = self.project();
+        let mut response = std::task::ready!(this.inner.poll(cx))?;
+        stamp_ryw_cookie(&mut response, this.settings, this.pin);
+        std::task::Poll::Ready(Ok(response))
+    }
 }
 
 #[cfg(test)]
@@ -689,5 +879,146 @@ mod tests {
             saw_pin.load(Ordering::Relaxed),
             "a valid incoming autumn.ryw cookie must activate the pin inside the handler"
         );
+    }
+}
+
+/// Direct coverage for [`ReadYourWritesService`] (issue #2214).
+///
+/// The framework's ingress installs the *layer*; the retained [`middleware`]
+/// `async fn` is what the pre-existing `middleware() integration tests` in this
+/// file exercise, through an `axum::middleware::from_fn`. Nothing drove the
+/// service form, so the two properties that live in the wiring rather than in
+/// the shared helpers — the task-local pin being installed, and the response-side
+/// cookie stamp — were untested on the path production actually takes.
+#[cfg(test)]
+mod service_tests {
+    use super::{ReadYourWritesLayer, is_pinned, mark_write};
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    use axum::body::Body;
+    use axum::http::{Request, Response, StatusCode};
+    use tower::{Layer, Service, ServiceExt};
+
+    use crate::config::ReadYourWrites;
+
+    fn test_keys() -> Arc<crate::security::config::ResolvedSigningKeys> {
+        Arc::new(crate::security::config::ResolvedSigningKeys::new(
+            b"test-key-for-ryw-service".to_vec(),
+            vec![],
+        ))
+    }
+
+    /// Inner service that marks a primary write (the way a generated mutating
+    /// repository method does) and reports whether the pin was visible.
+    fn writing_handler(
+        saw_scope: Arc<AtomicBool>,
+        write: bool,
+    ) -> impl Service<Request<Body>, Response = Response<Body>, Error = std::convert::Infallible> + Clone
+    {
+        tower::service_fn(move |_req: Request<Body>| {
+            let saw_scope = Arc::clone(&saw_scope);
+            async move {
+                if write {
+                    mark_write();
+                }
+                saw_scope.store(is_pinned(), Ordering::SeqCst);
+                Ok::<_, std::convert::Infallible>(
+                    Response::builder()
+                        .status(StatusCode::OK)
+                        .body(Body::empty())
+                        .expect("response builds"),
+                )
+            }
+        })
+    }
+
+    /// `#[allow(future_not_send)]`: `tower::service_fn`'s closure is not
+    /// `Sync`, so this helper's future is `!Send`. It only ever runs on a
+    /// `#[tokio::test]` current-thread runtime, which never moves it.
+    #[allow(clippy::future_not_send)]
+    async fn run(
+        mode: ReadYourWrites,
+        keys: Option<Arc<crate::security::config::ResolvedSigningKeys>>,
+        write: bool,
+    ) -> (bool, Option<String>) {
+        let saw_scope = Arc::new(AtomicBool::new(false));
+        let layer = ReadYourWritesLayer::new(
+            mode,
+            60,
+            keys,
+            crate::middleware::MetricsCollector::default(),
+        );
+        let response = layer
+            .layer(writing_handler(Arc::clone(&saw_scope), write))
+            .oneshot(Request::builder().body(Body::empty()).expect("request"))
+            .await
+            .expect("infallible");
+        let cookie = response
+            .headers()
+            .get(axum::http::header::SET_COOKIE)
+            .map(|v| v.to_str().expect("ascii cookie").to_owned());
+        (saw_scope.load(Ordering::SeqCst), cookie)
+    }
+
+    /// The whole reason this layer exists: the request-scoped pin must be
+    /// visible to everything beneath it. Without the task-local scope,
+    /// `is_pinned()` reads `false` after a write and every replica-eligible read
+    /// silently goes to the replica.
+    #[tokio::test]
+    async fn the_request_pin_scope_is_installed_for_the_inner_service() {
+        let (saw_scope, _) = run(ReadYourWrites::Request, None, true).await;
+        assert!(
+            saw_scope,
+            "a write inside the handler must leave `is_pinned()` true — the \
+             task-local pin scope is not reaching the inner service"
+        );
+    }
+
+    /// Control: no write, no pin. Proves the assertion above tracks the write
+    /// rather than being true for every request.
+    #[tokio::test]
+    async fn no_write_means_no_pin() {
+        let (saw_scope, _) = run(ReadYourWrites::Request, None, false).await;
+        assert!(!saw_scope);
+    }
+
+    /// Session mode stamps the signed `autumn.ryw` cookie after a write, with
+    /// the documented attributes, so the *next* request also routes to primary.
+    #[tokio::test]
+    async fn session_mode_stamps_the_ryw_cookie_after_a_write() {
+        let (_, cookie) = run(ReadYourWrites::Session, Some(test_keys()), true).await;
+        let cookie = cookie.expect("session mode must stamp autumn.ryw after a write");
+        assert!(cookie.starts_with("autumn.ryw="), "got {cookie}");
+        assert!(cookie.contains("Max-Age=60"), "got {cookie}");
+        assert!(cookie.contains("HttpOnly"), "got {cookie}");
+        assert!(cookie.contains("Secure"), "got {cookie}");
+        assert!(cookie.contains("SameSite=Lax"), "got {cookie}");
+        assert!(cookie.contains("Path=/"), "got {cookie}");
+    }
+
+    /// No write, no cookie — the freshness window is only opened by an actual
+    /// primary write.
+    #[tokio::test]
+    async fn session_mode_stamps_no_cookie_without_a_write() {
+        let (_, cookie) = run(ReadYourWrites::Session, Some(test_keys()), false).await;
+        assert_eq!(cookie, None);
+    }
+
+    /// Request mode is per-request only: it never mints a cross-request cookie,
+    /// even after a write.
+    #[tokio::test]
+    async fn request_mode_never_stamps_a_cookie() {
+        let (_, cookie) = run(ReadYourWrites::Request, Some(test_keys()), true).await;
+        assert_eq!(cookie, None);
+    }
+
+    /// Session mode with no signing key configured cannot sign the cookie, so
+    /// it stamps none — the warn-and-degrade path `apply_middleware` documents.
+    #[tokio::test]
+    async fn session_mode_without_keys_stamps_no_cookie() {
+        let (saw_scope, cookie) = run(ReadYourWrites::Session, None, true).await;
+        assert_eq!(cookie, None);
+        assert!(saw_scope, "in-request pinning still works without a key");
     }
 }

--- a/autumn/src/router.rs
+++ b/autumn/src/router.rs
@@ -12,7 +12,6 @@ use crate::app::ScopedGroup;
 use crate::config::AutumnConfig;
 #[cfg(feature = "maud")]
 use crate::error_pages::{self, SharedRenderer};
-use crate::extract::State;
 use crate::idempotency::{IdempotencyLayer, IdempotencyStore, MemoryIdempotencyStore};
 use crate::middleware::RequestIdLayer;
 use crate::middleware::dev;
@@ -21,7 +20,6 @@ use crate::middleware::exception_filter::{
 };
 use crate::route::Route;
 use crate::state::AppState;
-use axum::middleware::Next;
 use axum::response::IntoResponse;
 use http::{Request, StatusCode};
 use thiserror::Error;
@@ -669,9 +667,7 @@ fn build_router_pre_state(
         let static_dir = crate::app::project_dir("static", &env);
         router = router.nest_service("/static", tower_http::services::ServeDir::new(&static_dir));
     }
-    router = router.layer(axum::middleware::from_fn(
-        crate::assets::asset_cache_control,
-    ));
+    router = router.layer(crate::assets::AssetCacheControlLayer);
 
     router = mount_scoped_groups(
         router,
@@ -760,8 +756,7 @@ fn build_router_pre_state(
     }
 
     #[cfg(feature = "oauth2")]
-    let http_interceptor =
-        axum::middleware::from_fn_with_state(state.clone(), http_interceptor_middleware);
+    let http_interceptor = HttpInterceptorLayer::new(state.clone());
     #[cfg(not(feature = "oauth2"))]
     let http_interceptor = tower::layer::util::Identity::new();
 
@@ -774,7 +769,7 @@ fn build_router_pre_state(
     // event-bus context stays outer to the oauth2 interceptor exactly as the two
     // separate `.layer()` calls used to leave it (issue #2193).
     let router = router.layer((
-        axum::middleware::from_fn_with_state(state.clone(), event_app_context_middleware),
+        crate::events::EventAppContextLayer::new(state.clone()),
         http_interceptor,
     ));
 
@@ -3461,7 +3456,7 @@ fn build_route_timeout_table(
         // Key by (path, *effective request method*) so an override on one handler
         // never bleeds onto sibling methods that share the template, while still
         // resolving when the request reaches the handler through a method alias.
-        // `request_timeout_handler` looks up `req.method()`, which differs from
+        // `RequestTimeoutService` looks up `req.method()`, which differs from
         // the declared method in two cases:
         //   - axum serves `HEAD` through a `#[get]` handler, so a GET override
         //     must also cover HEAD.
@@ -3587,33 +3582,26 @@ fn apply_request_timeout_middleware(
     route_timeouts: RouteTimeoutTable,
     mirror_cors: bool,
 ) -> axum::Router<AppState> {
-    let Some(s) = build_request_timeout_settings(config, metrics, route_timeouts, mirror_cors)
+    let Some(settings) =
+        build_request_timeout_settings(config, metrics, route_timeouts, mirror_cors)
     else {
         return router;
     };
-    // The closure is built here rather than in a shared helper because its type
-    // (and the opaque future it returns) cannot be named across a function
-    // boundary; `apply_middleware` builds an identical one for the main ingress
-    // stack. Keep the two in sync.
-    router.layer(axum::middleware::from_fn(move |req, next| {
-        request_timeout_handler(
-            req,
-            next,
-            s.global,
-            s.route_timeouts.clone(),
-            s.metrics.clone(),
-            s.cors.clone(),
-        )
-    }))
+    // Both this envelope and `apply_middleware` install the SAME layer type now,
+    // so there is nothing left to keep in sync: before #2214 each site had to
+    // build its own `axum::middleware::from_fn` closure, because the closure's
+    // type (and the opaque future it returned) could not be named across a
+    // function boundary, and the two copies could silently drift.
+    router.layer(RequestTimeoutLayer::new(settings))
 }
 
-/// Everything [`request_timeout_handler`] needs, resolved once at
+/// Everything [`RequestTimeoutService`] needs, resolved once at
 /// router-assembly time.
 ///
-/// `Clone` is load-bearing: both call sites move this into an
-/// `axum::middleware::from_fn` closure, and `Router::layer` requires the layer
-/// (hence the closure, hence its captures) to be `Clone`.
-#[derive(Clone)]
+/// Held behind an `Arc` by [`RequestTimeoutLayer`] because the produced service
+/// is cloned on the request path: every field is individually cheap to clone
+/// (`RouteTimeoutTable` and the CORS snapshot are already `Arc`s), but one
+/// refcount bump for the whole struct beats four.
 struct RequestTimeoutSettings {
     global: Option<Duration>,
     route_timeouts: RouteTimeoutTable,
@@ -3669,99 +3657,288 @@ fn build_request_timeout_settings(
     })
 }
 
-async fn request_timeout_handler(
-    req: axum::extract::Request,
-    next: axum::middleware::Next,
-    global: Option<std::time::Duration>,
-    route_timeouts: RouteTimeoutTable,
-    metrics: crate::middleware::MetricsCollector,
-    cors: Option<std::sync::Arc<crate::config::CorsConfig>>,
-) -> axum::response::Response {
-    // Internal `autumn build` / ISR regeneration renders drive a `#[static_get]`
-    // route directly via `oneshot` and tag the request with `RenderDeadlineExempt`
-    // (there is no client connection whose deadline should apply). Skip the
-    // deadline for these; live inbound requests to the same route do not carry
-    // the marker and are bounded normally below.
-    if req
-        .extensions()
-        .get::<crate::static_gen::RenderDeadlineExempt>()
-        .is_some()
-    {
-        return next.run(req).await;
-    }
+/// Tower [`Layer`](tower::Layer) applying the framework's per-request deadline.
+///
+/// Replaces the `axum::middleware::from_fn` closure both call sites used to
+/// build. `from_fn` had to `Box::pin` the async block it wrapped — one heap
+/// allocation per request, sized by the whole downstream continuation the block
+/// captured across its `.await` — and clone its inner service to move it in
+/// there. [`RequestTimeoutFuture`] holds `tokio::time::Timeout<S::Future>`
+/// (itself a named type) in place instead, so a deadline costs no allocation
+/// and an exempt route costs not even a timer (issue #2214).
+#[derive(Clone)]
+pub struct RequestTimeoutLayer {
+    settings: Arc<RequestTimeoutSettings>,
+}
 
-    // Resolve the effective deadline from the matched route template + method,
-    // using borrowed lookups so exempt/disabled routes allocate nothing.
-    let matched_path_ref = req
-        .extensions()
-        .get::<axum::extract::MatchedPath>()
-        .map(axum::extract::MatchedPath::as_str);
-    let route_timeout = matched_path_ref
-        .and_then(|p| route_timeouts.get(p))
-        .and_then(|by_method| by_method.get(req.method()))
-        .copied()
-        .unwrap_or(crate::route::RouteTimeout::Inherit);
-    let deadline = match route_timeout {
-        crate::route::RouteTimeout::Disabled => None,
-        crate::route::RouteTimeout::Override(d) => Some(d),
-        crate::route::RouteTimeout::Inherit => global,
-    };
-    let Some(duration) = deadline else {
-        // Exempt (disabled route, or global off with a non-Override route) —
-        // no allocation on this hot path.
-        return next.run(req).await;
-    };
-
-    // A deadline is active: now it's worth owning the path for the warn log.
-    let matched_path = matched_path_ref.map(ToOwned::to_owned);
-    let request_id = req
-        .extensions()
-        .get::<crate::middleware::RequestId>()
-        .cloned();
-    // Capture the request Origin before `req` is consumed so a timeout 503 can
-    // mirror the CORS headers `CorsLayer` would have added (only when mirroring
-    // is enabled — see `apply_request_timeout_middleware`).
-    let cors_origin = cors
-        .as_ref()
-        .and_then(|_| req.headers().get(http::header::ORIGIN).cloned());
-    let start = std::time::Instant::now();
-    match tokio::time::timeout(duration, next.run(req)).await {
-        Ok(response) => response,
-        Err(_elapsed) => {
-            let elapsed_ms = u64::try_from(start.elapsed().as_millis()).unwrap_or(u64::MAX);
-            let route = matched_path.as_deref().unwrap_or("<unmatched>");
-            // Structured telemetry: route template + elapsed time so operators
-            // can alert on the (already-counted) timeout event.
-            tracing::warn!(
-                target: "autumn::timeout",
-                route = route,
-                elapsed_ms = elapsed_ms,
-                timeout_ms = u64::try_from(duration.as_millis()).unwrap_or(u64::MAX),
-                request_id = request_id.as_ref().map(ToString::to_string),
-                "inbound request exceeded deadline"
-            );
-            metrics.record_request_timeout();
-            // Return a 503 via the standard error type so the exception-filter
-            // and error-page stack negotiate JSON vs HTML and enrich with the
-            // request id — no manual Problem Details assembly, no raw BoxError.
-            let mut response =
-                crate::error::AutumnError::service_unavailable(RequestDeadlineExceeded {
-                    timeout_ms: u64::try_from(duration.as_millis()).unwrap_or(u64::MAX),
-                })
-                .into_response();
-            // Tag the 503 so the outer session layer skips persisting any partial
-            // session mutation the cancelled handler made before the deadline.
-            response.extensions_mut().insert(RequestDeadlineCancelled);
-            // This layer is outside `CorsLayer` in the main stack, so the 503
-            // never passes back through it; mirror the CORS headers ourselves so
-            // cross-origin browser clients can read the Problem Details body
-            // instead of seeing an opaque CORS failure.
-            if let Some(cors) = cors.as_deref() {
-                mirror_cors_headers(cors, cors_origin.as_ref(), &mut response);
-            }
-            response
+impl RequestTimeoutLayer {
+    fn new(settings: RequestTimeoutSettings) -> Self {
+        Self {
+            settings: Arc::new(settings),
         }
     }
+}
+
+impl<S> tower::Layer<S> for RequestTimeoutLayer {
+    type Service = RequestTimeoutService<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        RequestTimeoutService {
+            inner,
+            settings: Arc::clone(&self.settings),
+        }
+    }
+}
+
+/// Tower [`Service`](tower::Service) produced by [`RequestTimeoutLayer`].
+#[derive(Clone)]
+pub struct RequestTimeoutService<S> {
+    inner: S,
+    settings: Arc<RequestTimeoutSettings>,
+}
+
+impl<S> RequestTimeoutService<S> {
+    /// The deadline that applies to `req`, or `None` when it is exempt.
+    ///
+    /// Uses borrowed lookups throughout so an exempt or deadline-free route
+    /// allocates nothing.
+    fn deadline_for<B>(&self, req: &Request<B>) -> Option<Duration> {
+        // Internal `autumn build` / ISR regeneration renders drive a
+        // `#[static_get]` route directly via `oneshot` and tag the request with
+        // `RenderDeadlineExempt` (there is no client connection whose deadline
+        // should apply). Skip the deadline for these; live inbound requests to
+        // the same route do not carry the marker and are bounded normally.
+        if req
+            .extensions()
+            .get::<crate::static_gen::RenderDeadlineExempt>()
+            .is_some()
+        {
+            return None;
+        }
+
+        // Resolve the effective deadline from the matched route template +
+        // method.
+        let route_timeout = req
+            .extensions()
+            .get::<axum::extract::MatchedPath>()
+            .map(axum::extract::MatchedPath::as_str)
+            .and_then(|p| self.settings.route_timeouts.get(p))
+            .and_then(|by_method| by_method.get(req.method()))
+            .copied()
+            .unwrap_or(crate::route::RouteTimeout::Inherit);
+        match route_timeout {
+            crate::route::RouteTimeout::Disabled => None,
+            crate::route::RouteTimeout::Override(d) => Some(d),
+            crate::route::RouteTimeout::Inherit => self.settings.global,
+        }
+    }
+}
+
+impl<S> tower::Service<Request<axum::body::Body>> for RequestTimeoutService<S>
+where
+    S: tower::Service<Request<axum::body::Body>, Response = axum::response::Response>,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = RequestTimeoutFuture<S::Future>;
+
+    fn poll_ready(
+        &mut self,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, req: Request<axum::body::Body>) -> Self::Future {
+        let Some(duration) = self.deadline_for(&req) else {
+            // Exempt (disabled route, or global off with a non-Override route)
+            // — no timer and no allocation on this hot path.
+            return RequestTimeoutFuture::Unbounded {
+                inner: self.inner.call(req),
+            };
+        };
+
+        // A deadline is active: now it's worth owning the path for the warn log.
+        let matched_path = req
+            .extensions()
+            .get::<axum::extract::MatchedPath>()
+            .map(|p| p.as_str().to_owned());
+        let request_id = req
+            .extensions()
+            .get::<crate::middleware::RequestId>()
+            .cloned();
+        // Capture the request Origin before `req` is consumed so a timeout 503
+        // can mirror the CORS headers `CorsLayer` would have added (only when
+        // mirroring is enabled — see `apply_request_timeout_middleware`).
+        let cors_origin = self
+            .settings
+            .cors
+            .as_ref()
+            .and_then(|_| req.headers().get(http::header::ORIGIN).cloned());
+
+        // Build the inner future FIRST, then start the clock, then arm the
+        // timer, so `start` and the deadline measure the same interval. The
+        // `from_fn` form armed both inside an async block, where the downstream
+        // `call` chain had not run yet; here that chain runs during
+        // `self.inner.call(req)`, so capturing `start` before it would leave
+        // `elapsed_ms` measuring a strictly longer span than `timeout_ms`.
+        //
+        // `tokio::time::timeout` needs a runtime handle, so this service's
+        // `call` must run inside a Tokio runtime. That is the same requirement
+        // `tower::timeout::Timeout::call` imposes (it builds its `Sleep` in
+        // `call` too), and every driver in this crate reaches it through
+        // `ServiceExt::oneshot`, which only calls `call` from inside a poll.
+        let inner = self.inner.call(req);
+        let start = std::time::Instant::now();
+
+        RequestTimeoutFuture::Bounded {
+            inner: tokio::time::timeout(duration, inner),
+            settings: Arc::clone(&self.settings),
+            duration,
+            matched_path,
+            request_id,
+            cors_origin,
+            start,
+        }
+    }
+}
+
+pin_project_lite::pin_project! {
+    /// Future returned by [`RequestTimeoutService`].
+    ///
+    /// `Unbounded` is the exempt path and is literally the inner service's own
+    /// future; `Bounded` wraps it in `tokio::time::Timeout`, which is a named
+    /// type, so neither variant is heap-allocated.
+    ///
+    /// `Elapsed` exists to make the deadline actually *cancel*.
+    /// `tokio::time::Timeout::poll` does not drop the future it wraps when the
+    /// timer fires — it just reports `Err(Elapsed)` — so a `Bounded` variant
+    /// that returned the `503` in place would keep the whole cancelled handler
+    /// tree (its database connection guards, its load-shed slot, its webhook
+    /// [`ReplayKeyGuard`](crate::webhook)) alive until whatever owns *this*
+    /// future is itself dropped, several response layers later. The `from_fn`
+    /// form dropped it at the deadline, because its `tokio::time::timeout(..)`
+    /// was a `match` scrutinee temporary. Transitioning to `Elapsed` restores
+    /// that: `Pin::set` drops the old variant in place, so the handler tree is
+    /// released before the `503` starts travelling back out.
+    #[project = RequestTimeoutFutureProj]
+    pub enum RequestTimeoutFuture<F> {
+        Unbounded {
+            #[pin]
+            inner: F,
+        },
+        Bounded {
+            #[pin]
+            inner: tokio::time::Timeout<F>,
+            settings: Arc<RequestTimeoutSettings>,
+            duration: Duration,
+            matched_path: Option<String>,
+            request_id: Option<crate::middleware::RequestId>,
+            cors_origin: Option<http::HeaderValue>,
+            start: std::time::Instant,
+        },
+        Elapsed {
+            response: Option<axum::response::Response>,
+        },
+    }
+}
+
+impl<F, E> std::future::Future for RequestTimeoutFuture<F>
+where
+    F: std::future::Future<Output = Result<axum::response::Response, E>>,
+{
+    type Output = Result<axum::response::Response, E>;
+
+    #[allow(
+        clippy::expect_used,
+        reason = "unreachable: future not polled after Ready"
+    )]
+    fn poll(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Self::Output> {
+        loop {
+            let elapsed = match self.as_mut().project() {
+                RequestTimeoutFutureProj::Unbounded { inner } => return inner.poll(cx),
+                RequestTimeoutFutureProj::Bounded {
+                    inner,
+                    settings,
+                    duration,
+                    matched_path,
+                    request_id,
+                    cors_origin,
+                    start,
+                } => match std::task::ready!(inner.poll(cx)) {
+                    Ok(response) => return std::task::Poll::Ready(response),
+                    Err(_elapsed) => Self::Elapsed {
+                        response: Some(deadline_exceeded_response(
+                            settings,
+                            *duration,
+                            matched_path.as_deref(),
+                            request_id.as_ref(),
+                            cors_origin.as_ref(),
+                            *start,
+                        )),
+                    },
+                },
+                RequestTimeoutFutureProj::Elapsed { response } => {
+                    return std::task::Poll::Ready(Ok(response
+                        .take()
+                        .expect("RequestTimeoutFuture polled after completion")));
+                }
+            };
+            // Drops the `Bounded` variant — and with it the cancelled handler
+            // future the elapsed `Timeout` is still holding — before the `503`
+            // leaves this layer.
+            self.as_mut().set(elapsed);
+        }
+    }
+}
+
+/// Build the `503` a request that blew its deadline receives, recording the
+/// timeout metric and emitting the structured `autumn::timeout` warn on the way.
+///
+/// Split out of [`RequestTimeoutFuture::poll`] so that hot method stays a
+/// dispatch and nothing else.
+fn deadline_exceeded_response(
+    settings: &RequestTimeoutSettings,
+    duration: Duration,
+    matched_path: Option<&str>,
+    request_id: Option<&crate::middleware::RequestId>,
+    cors_origin: Option<&http::HeaderValue>,
+    start: std::time::Instant,
+) -> axum::response::Response {
+    let elapsed_ms = u64::try_from(start.elapsed().as_millis()).unwrap_or(u64::MAX);
+    let route = matched_path.unwrap_or("<unmatched>");
+    // Structured telemetry: route template + elapsed time so operators
+    // can alert on the (already-counted) timeout event.
+    tracing::warn!(
+        target: "autumn::timeout",
+        route = route,
+        elapsed_ms = elapsed_ms,
+        timeout_ms = u64::try_from(duration.as_millis()).unwrap_or(u64::MAX),
+        request_id = request_id.map(ToString::to_string),
+        "inbound request exceeded deadline"
+    );
+    settings.metrics.record_request_timeout();
+    // Return a 503 via the standard error type so the exception-filter
+    // and error-page stack negotiate JSON vs HTML and enrich with the
+    // request id — no manual Problem Details assembly, no raw BoxError.
+    let mut response = crate::error::AutumnError::service_unavailable(RequestDeadlineExceeded {
+        timeout_ms: u64::try_from(duration.as_millis()).unwrap_or(u64::MAX),
+    })
+    .into_response();
+    // Tag the 503 so the outer session layer skips persisting any partial
+    // session mutation the cancelled handler made before the deadline.
+    response.extensions_mut().insert(RequestDeadlineCancelled);
+    // This layer is outside `CorsLayer` in the main stack, so the 503
+    // never passes back through it; mirror the CORS headers ourselves so
+    // cross-origin browser clients can read the Problem Details body
+    // instead of seeing an opaque CORS failure.
+    if let Some(cors) = settings.cors.as_deref() {
+        mirror_cors_headers(cors, cors_origin, &mut response);
+    }
+    response
 }
 
 struct BuiltIdempotencyLayers {
@@ -4079,7 +4256,7 @@ fn apply_middleware(
         axum::Extension(upload_config),
         // Global body-size cap covering JSON, form, raw bytes, and multipart.
         body_limit,
-        axum::middleware::from_fn(crate::webhook::webhook_replay_cleanup_middleware),
+        crate::webhook::WebhookReplayCleanupLayer,
         // Admission control / load shedding (#1006). Outer to MaintenanceLayer so
         // the cheap in-flight-count check runs before maintenance mode's
         // bypass-header/IP-allowlist evaluation. `None` (the default — no
@@ -4108,16 +4285,14 @@ fn apply_middleware(
         // them. Placed outside CSRF so a `BodyTooLarge` (empty body)
         // doesn't get masked by a `403` from CSRF's missing-token branch,
         // and a clear `400 invalid _method` outranks "missing CSRF".
-        axum::middleware::from_fn(crate::middleware::method_override_rejection_filter),
+        crate::middleware::method_override::MethodOverrideRejectionLayer,
         tower::util::option_layer(build_bot_protection_layer(config)),
         tower::util::option_layer(build_csrf_layer(config, signing_keys_opt.clone())),
         // Inner to the CSRF layer so CSRF is validated first on the request
         // path; a replayed `_submit_token` is still short-circuited even when
         // the request carries a valid `_csrf` (issue #1360, AC #4).
         tower::util::option_layer(submit_token_layer),
-        axum::middleware::from_fn(move |req, next| {
-            trusted_host_middleware(req, next, trusted_host_policy.clone())
-        }),
+        TrustedHostLayer::new(trusted_host_policy),
         tower::util::option_layer(build_ingress_cors_layer(config)),
     );
 
@@ -4142,7 +4317,7 @@ fn apply_middleware(
     // ── Middle group: outer to the user layers, inner to the session ────────
     //
     // Per-request timeout (inner to RequestId so the request ID set by that
-    // layer is available when the timeout fires — see request_timeout_handler).
+    // layer is available when the timeout fires — see RequestTimeoutService).
     //
     // Full ingress layer order (outermost → innermost):
     //   TraceContext → AccessLog-fallback (applied in apply_startup_barrier) →
@@ -4175,25 +4350,14 @@ fn apply_middleware(
     // `request_timeout_ms`. Moving the timer out there would again lose the
     // `X-Request-Id` correlation; bound this with a server/proxy read timeout
     // instead.
-    // The closure is built here rather than in a shared helper because its type
-    // (and the opaque future it returns) cannot be named across a function
-    // boundary; `apply_request_timeout_middleware` builds an identical one for
-    // the `/mcp` envelope. Keep the two in sync.
+    // `apply_request_timeout_middleware` installs the SAME layer type for the
+    // `/mcp` envelope, so the two cannot drift; before #2214 each site had to
+    // build its own `axum::middleware::from_fn` closure (whose type, and whose
+    // opaque future, could not be named across a function boundary) and a
+    // comment here asked future readers to keep the copies in sync by hand.
     let timeout_layer =
-        build_request_timeout_settings(config, state.metrics.clone(), route_timeouts, true).map(
-            |s| {
-                axum::middleware::from_fn(move |req, next| {
-                    request_timeout_handler(
-                        req,
-                        next,
-                        s.global,
-                        s.route_timeouts.clone(),
-                        s.metrics.clone(),
-                        s.cors.clone(),
-                    )
-                })
-            },
-        );
+        build_request_timeout_settings(config, state.metrics.clone(), route_timeouts, true)
+            .map(RequestTimeoutLayer::new);
 
     // Failure-capsule capture (#1598). Outer to the reporting layer, because a
     // request's capture scope has to exist before that layer snapshots its
@@ -4365,16 +4529,7 @@ fn apply_middleware(
                 );
             }
             let metrics = state.metrics().clone();
-            axum::middleware::from_fn(move |req, next| {
-                crate::read_your_writes::middleware(
-                    req,
-                    next,
-                    ryw_mode,
-                    window_secs,
-                    keys.clone(),
-                    metrics.clone(),
-                )
-            })
+            crate::read_your_writes::ReadYourWritesLayer::new(ryw_mode, window_secs, keys, metrics)
         }),
     );
     #[cfg(not(feature = "db"))]
@@ -4538,16 +4693,22 @@ fn apply_layers_in_registration_order(
     router.layer(ComposedRegisteredLayers::new(layers))
 }
 
-async fn trusted_host_middleware(
-    req: Request<axum::body::Body>,
-    next: Next,
-    policy: TrustedHostPolicy,
-) -> axum::response::Response {
+/// Decide whether `req` clears the trusted-host policy, returning the rejection
+/// response when it does not.
+///
+/// Shared by [`TrustedHostService`] and — through it — every ingress path, so
+/// the decision lives in exactly one place. Returns `None` for "let it
+/// through", which is the overwhelmingly common answer and costs no allocation
+/// at all: the host string is only owned on the branch that has to compare it.
+fn trusted_host_rejection<B>(
+    req: &Request<B>,
+    policy: &TrustedHostPolicy,
+) -> Option<axum::response::Response> {
     let path = req.uri().path();
     if (req.method() == http::Method::GET || req.method() == http::Method::HEAD)
         && policy.probe_bypass_paths.contains(path)
     {
-        return next.run(req).await;
+        return None;
     }
     let authority = req.uri().authority().map(http::uri::Authority::as_str);
     let host_header = req
@@ -4562,27 +4723,91 @@ async fn trusted_host_middleware(
         .filter(|h| !h.is_empty());
     let host_source_present = raw_host.is_some();
     if host.is_none() && !host_source_present && policy.allow_missing_host {
-        return next.run(req).await;
+        return None;
     }
     if host.as_deref().is_some_and(|host| policy.allows_host(host)) {
-        next.run(req).await
-    } else {
-        tracing::warn!(host = ?host, "trusted host rejected request");
-        let body = crate::error::problem_details_json_string(
-            StatusCode::BAD_REQUEST,
-            "Invalid Host header",
-            None,
-            None,
-            None,
-            None,
-            true,
-        );
+        return None;
+    }
+    tracing::warn!(host = ?host, "trusted host rejected request");
+    let body = crate::error::problem_details_json_string(
+        StatusCode::BAD_REQUEST,
+        "Invalid Host header",
+        None,
+        None,
+        None,
+        None,
+        true,
+    );
+    Some(
         (
             StatusCode::BAD_REQUEST,
             [(http::header::CONTENT_TYPE, "application/problem+json")],
             body,
         )
-            .into_response()
+            .into_response(),
+    )
+}
+
+/// Tower [`Layer`](tower::Layer) enforcing [`TrustedHostPolicy`] on the ingress
+/// path.
+///
+/// This used to be an `axum::middleware::from_fn` closure. It is a hand-rolled
+/// service now because `from_fn` `Box::pin`s the future of whatever it wraps —
+/// one heap allocation per request, sized by everything the wrapped async block
+/// captures across its `.await`, which for a layer this far out is the whole
+/// downstream continuation — plus a `self.inner.clone()` that deep-clones the
+/// erased stack beneath it. Neither cost depended on whether a request was
+/// actually rejected (issue #2214).
+#[derive(Clone, Debug)]
+pub struct TrustedHostLayer {
+    policy: TrustedHostPolicy,
+}
+
+impl TrustedHostLayer {
+    pub(crate) const fn new(policy: TrustedHostPolicy) -> Self {
+        Self { policy }
+    }
+}
+
+impl<S> tower::Layer<S> for TrustedHostLayer {
+    type Service = TrustedHostService<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        TrustedHostService {
+            inner,
+            policy: self.policy.clone(),
+        }
+    }
+}
+
+/// Tower [`Service`](tower::Service) produced by [`TrustedHostLayer`].
+#[derive(Clone, Debug)]
+pub struct TrustedHostService<S> {
+    inner: S,
+    policy: TrustedHostPolicy,
+}
+
+impl<S, ReqBody> tower::Service<Request<ReqBody>> for TrustedHostService<S>
+where
+    S: tower::Service<Request<ReqBody>, Response = axum::response::Response>,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = crate::middleware::short_circuit::ShortCircuitFuture<S::Future>;
+
+    fn poll_ready(
+        &mut self,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, req: Request<ReqBody>) -> Self::Future {
+        use crate::middleware::short_circuit::ShortCircuitFuture;
+        trusted_host_rejection(&req, &self.policy).map_or_else(
+            || ShortCircuitFuture::forward(self.inner.call(req)),
+            ShortCircuitFuture::short_circuit,
+        )
     }
 }
 
@@ -4964,7 +5189,7 @@ pub fn try_build_router_with_static_inner(
 }
 
 #[derive(Clone)]
-struct StartupBarrierState {
+pub struct StartupBarrierState {
     app_state: AppState,
     // Canonical exact-match probe/health paths (`probe_bypass_paths`), the
     // single source of truth shared with `TrustedHostPolicy` and the
@@ -5065,26 +5290,88 @@ fn apply_startup_barrier(
         trace_context,
         tower::util::option_layer(server_timing_fallback),
         tower::util::option_layer(access_log_fallback),
-        axum::middleware::from_fn_with_state(barrier_state, startup_barrier),
+        StartupBarrierLayer::new(barrier_state),
     ))
 }
 
-async fn startup_barrier(
-    State(state): State<StartupBarrierState>,
-    request: axum::extract::Request,
-    next: Next,
-) -> axum::response::Response {
-    if crate::app::is_static_build_mode()
-        || state.app_state.probes().is_startup_complete()
-        || state.allows_path(request.uri().path())
-    {
-        next.run(request).await
-    } else {
-        (
-            StatusCode::SERVICE_UNAVAILABLE,
-            "Service is still starting up",
-        )
-            .into_response()
+/// Tower [`Layer`](tower::Layer) for the startup readiness barrier: requests are refused with
+/// `503 Service is still starting up` until the app reports startup complete,
+/// except on the paths the barrier lets through (probes, actuator).
+///
+/// A hand-rolled service rather than an `axum::middleware::from_fn`: this is the
+/// outermost layer inside the `Router`, so `from_fn`'s per-request `Box::pin`
+/// captured the entire downstream continuation and its `self.inner.clone()`
+/// deep-cloned the whole erased stack — on every request, for a check that
+/// passes on every request after the first few seconds of process life
+/// (issue #2214).
+///
+/// The state is held behind an `Arc` because the produced service is cloned on
+/// the request path — once per traversal of the stack above it — and
+/// `StartupBarrierState` owns an `AppState` plus three `Vec<String>` path lists.
+/// Holding it by value would deep-copy all three on every one of those clones,
+/// which is the cost #2193 removed elsewhere in this stack.
+#[derive(Clone)]
+pub struct StartupBarrierLayer {
+    state: Arc<StartupBarrierState>,
+}
+
+impl StartupBarrierLayer {
+    pub(crate) fn new(state: StartupBarrierState) -> Self {
+        Self {
+            state: Arc::new(state),
+        }
+    }
+}
+
+impl<S> tower::Layer<S> for StartupBarrierLayer {
+    type Service = StartupBarrierService<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        StartupBarrierService {
+            inner,
+            state: Arc::clone(&self.state),
+        }
+    }
+}
+
+/// Tower [`Service`](tower::Service) produced by [`StartupBarrierLayer`].
+#[derive(Clone)]
+pub struct StartupBarrierService<S> {
+    inner: S,
+    state: Arc<StartupBarrierState>,
+}
+
+impl<S, ReqBody> tower::Service<Request<ReqBody>> for StartupBarrierService<S>
+where
+    S: tower::Service<Request<ReqBody>, Response = axum::response::Response>,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = crate::middleware::short_circuit::ShortCircuitFuture<S::Future>;
+
+    fn poll_ready(
+        &mut self,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, req: Request<ReqBody>) -> Self::Future {
+        use crate::middleware::short_circuit::ShortCircuitFuture;
+        if crate::app::is_static_build_mode()
+            || self.state.app_state.probes().is_startup_complete()
+            || self.state.allows_path(req.uri().path())
+        {
+            ShortCircuitFuture::forward(self.inner.call(req))
+        } else {
+            ShortCircuitFuture::short_circuit(
+                (
+                    StatusCode::SERVICE_UNAVAILABLE,
+                    "Service is still starting up",
+                )
+                    .into_response(),
+            )
+        }
     }
 }
 
@@ -5603,31 +5890,118 @@ fn mount_swagger_ui_routes(
     router
 }
 
-/// Scope the request's [`AppState`] as the ambient event-bus app for the
-/// duration of the request, so the free `events::publish` resolves this app.
-async fn event_app_context_middleware(
-    state: axum::extract::State<AppState>,
-    req: axum::extract::Request,
-    next: axum::middleware::Next,
-) -> axum::response::Response {
-    crate::events::scope_event_app(state.0.clone(), async move { next.run(req).await }).await
+/// Tower [`Layer`](tower::Layer) installing the app's registered
+/// [`HttpInterceptor`](crate::interceptor::HttpInterceptor) as the ambient
+/// interceptor chain for outbound `reqwest` calls made during this request.
+///
+/// Hand-rolled rather than an `axum::middleware::from_fn_with_state` for the
+/// reason #2214 documents: `from_fn` `Box::pin`s the async block it generates
+/// on every request. `tokio::task_local!`'s `scope` returns a named
+/// `TaskLocalFuture`, so the scoped branch needs no box either — and an app
+/// with no interceptor registered (the common case) forwards the inner
+/// service's future completely untouched.
+///
+/// Like [`crate::events::EventAppContextLayer`], the inner future is built
+/// inside a `sync_scope` as well as polled inside a `scope`, so the synchronous
+/// `Service::call` chain beneath this layer also sees the interceptors.
+#[cfg(feature = "oauth2")]
+#[derive(Clone)]
+pub struct HttpInterceptorLayer {
+    state: AppState,
 }
 
 #[cfg(feature = "oauth2")]
-async fn http_interceptor_middleware(
-    state: axum::extract::State<AppState>,
-    req: axum::extract::Request,
-    next: axum::middleware::Next,
-) -> axum::response::Response {
-    use crate::interceptor::{ACTIVE_HTTP_INTERCEPTORS, HttpInterceptor};
-    if let Some(interceptor_arc) = state.extension::<Arc<dyn HttpInterceptor>>() {
-        let interceptor = (*interceptor_arc).clone();
-        let interceptors = vec![interceptor];
-        ACTIVE_HTTP_INTERCEPTORS
-            .scope(interceptors, async move { next.run(req).await })
-            .await
-    } else {
-        next.run(req).await
+impl HttpInterceptorLayer {
+    pub(crate) const fn new(state: AppState) -> Self {
+        Self { state }
+    }
+}
+
+#[cfg(feature = "oauth2")]
+impl<S> tower::Layer<S> for HttpInterceptorLayer {
+    type Service = HttpInterceptorService<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        HttpInterceptorService {
+            inner,
+            state: self.state.clone(),
+        }
+    }
+}
+
+/// Tower [`Service`](tower::Service) produced by [`HttpInterceptorLayer`].
+#[cfg(feature = "oauth2")]
+#[derive(Clone)]
+pub struct HttpInterceptorService<S> {
+    inner: S,
+    state: AppState,
+}
+
+#[cfg(feature = "oauth2")]
+pin_project_lite::pin_project! {
+    /// Future returned by [`HttpInterceptorService`].
+    #[project = HttpInterceptorFutureProj]
+    pub enum HttpInterceptorScopeFuture<F> {
+        /// No interceptor registered: the inner service's own future.
+        Plain {
+            #[pin]
+            inner: F,
+        },
+        /// The inner future, polled inside the interceptor task-local scope.
+        Scoped {
+            #[pin]
+            inner: tokio::task::futures::TaskLocalFuture<
+                Vec<Arc<dyn crate::interceptor::HttpInterceptor>>,
+                F,
+            >,
+        },
+    }
+}
+
+#[cfg(feature = "oauth2")]
+impl<F: std::future::Future> std::future::Future for HttpInterceptorScopeFuture<F> {
+    type Output = F::Output;
+
+    fn poll(
+        self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Self::Output> {
+        match self.project() {
+            HttpInterceptorFutureProj::Plain { inner } => inner.poll(cx),
+            HttpInterceptorFutureProj::Scoped { inner } => inner.poll(cx),
+        }
+    }
+}
+
+#[cfg(feature = "oauth2")]
+impl<S, ReqBody> tower::Service<Request<ReqBody>> for HttpInterceptorService<S>
+where
+    S: tower::Service<Request<ReqBody>>,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = HttpInterceptorScopeFuture<S::Future>;
+
+    fn poll_ready(
+        &mut self,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, req: Request<ReqBody>) -> Self::Future {
+        use crate::interceptor::{ACTIVE_HTTP_INTERCEPTORS, HttpInterceptor};
+        let Some(interceptor_arc) = self.state.extension::<Arc<dyn HttpInterceptor>>() else {
+            return HttpInterceptorScopeFuture::Plain {
+                inner: self.inner.call(req),
+            };
+        };
+        let interceptors = vec![(*interceptor_arc).clone()];
+        let inner =
+            ACTIVE_HTTP_INTERCEPTORS.sync_scope(interceptors.clone(), || self.inner.call(req));
+        HttpInterceptorScopeFuture::Scoped {
+            inner: ACTIVE_HTTP_INTERCEPTORS.scope(interceptors, inner),
+        }
     }
 }
 
@@ -11192,7 +11566,8 @@ mod trusted_host_tests {
             }),
         );
 
-        // No RequestIdLayer — exercises the else branch in request_timeout_handler.
+        // No RequestIdLayer — exercises the `request_id: None` branch in
+        // `RequestTimeoutService`.
         let router = apply_request_timeout_middleware(
             router,
             &config,
@@ -11802,6 +12177,179 @@ mod trusted_host_tests {
         // An empty set requires no fail-closed behaviour.
         assert!(!super::custom_layers_require_fail_closed_idempotency(&[]));
     }
+
+    // ----------------------------------------------------------------------
+    // #2214: the ingress stack's middleware futures must stay unboxed
+    // ----------------------------------------------------------------------
+
+    /// The structural half of issue #2214's fix, in one assertion per converted
+    /// middleware.
+    ///
+    /// Each of these layers used to be an `axum::middleware::from_fn`, whose
+    /// `FromFn::call` must `Box::pin` the async block it generates — the block's
+    /// type cannot be named, so there is nowhere else for it to live. That was
+    /// one heap allocation per request per call site, 19.57% of every byte the
+    /// `request_pipeline` benchmark allocated.
+    ///
+    /// A hand-rolled `tower::Service` fixes it only if its `Future` associated
+    /// type is genuinely named all the way down. Writing one that still returns
+    /// `Pin<Box<dyn Future>>` — the shape `SessionService`, `LogContextService`
+    /// and `TrustedProxiesService` use — would satisfy every behavioural test in
+    /// the suite while allocating exactly as much as before. This test is what
+    /// makes that impossible to do by accident: the sibling allocation gate in
+    /// `tests/config_alloc_gate.rs` pins the *total*, and this pins *where* the
+    /// total comes from.
+    ///
+    /// What this pins precisely: that the associated `Future` type is not
+    /// literally a `Pin<Box<dyn Future>>`. `std::any::type_name` prints a type's
+    /// path and generic arguments, never its fields, so it cannot see a box
+    /// hidden inside a variant of an otherwise-named future — which is exactly
+    /// what `WebhookReplayCleanupFuture`'s rare `Releasing` branch is, and why
+    /// that one is pinned by the sibling test below (on size) instead of here.
+    #[test]
+    fn converted_ingress_middleware_futures_are_never_boxed() {
+        /// The inner service every layer under test is stacked on: its own
+        /// future is a named `Ready`, so any `Box` in the resulting type name
+        /// was contributed by the layer.
+        type Inner = tower::util::ServiceFn<
+            fn(
+                axum::extract::Request,
+            )
+                -> std::future::Ready<Result<axum::response::Response, std::convert::Infallible>>,
+        >;
+        type Fut<Svc> = <Svc as tower::Service<axum::extract::Request>>::Future;
+
+        fn assert_unboxed<Svc: tower::Service<axum::extract::Request>>(what: &str) {
+            let name = std::any::type_name::<Fut<Svc>>();
+            assert!(
+                !name.contains("Box"),
+                "{what} must return a named, unboxed future — an \
+                 `axum::middleware::from_fn`-shaped `Box::pin` here is one heap \
+                 allocation on every request (issue #2214). Got: {name}"
+            );
+        }
+
+        assert_unboxed::<super::TrustedHostService<Inner>>("TrustedHostService");
+        assert_unboxed::<super::StartupBarrierService<Inner>>("StartupBarrierService");
+        assert_unboxed::<super::RequestTimeoutService<Inner>>("RequestTimeoutService");
+        assert_unboxed::<crate::assets::AssetCacheControlService<Inner>>(
+            "AssetCacheControlService",
+        );
+        assert_unboxed::<crate::events::EventAppContextService<Inner>>("EventAppContextService");
+        assert_unboxed::<crate::read_your_writes::ReadYourWritesService<Inner>>(
+            "ReadYourWritesService",
+        );
+        assert_unboxed::<crate::middleware::method_override::MethodOverrideRejectionService<Inner>>(
+            "MethodOverrideRejectionService",
+        );
+        #[cfg(feature = "oauth2")]
+        assert_unboxed::<super::HttpInterceptorService<Inner>>("HttpInterceptorService");
+    }
+
+    /// `WebhookReplayCleanupFuture` is the one converted middleware that still
+    /// boxes, and that is deliberate: releasing the replay keys a failed webhook
+    /// delivery registered is genuinely async work that has to run *after* the
+    /// inner future resolves, so it cannot be folded into the inner service's
+    /// own future.
+    ///
+    /// The box lives in the `Releasing` variant, which is only ever constructed
+    /// for a `5xx` response that actually registered keys — so the happy path
+    /// (and every request that is not a webhook delivery at all) never takes it.
+    /// The sibling test above cannot pin that, because `type_name` does not
+    /// print field types; this one does, by size. `Serving` stores the scoped
+    /// inner future, the replay cell and the drop guard **inline**, so the enum
+    /// must be at least as large as all three together. Move the box to
+    /// `Serving` and the enum collapses to roughly a pointer plus the response,
+    /// and this fails.
+    #[test]
+    fn webhook_replay_cleanup_boxes_only_its_rare_release_branch() {
+        use std::mem::size_of;
+
+        type Ready = std::future::Ready<Result<axum::response::Response, std::convert::Infallible>>;
+        type Scoped = tokio::task::futures::TaskLocalFuture<crate::webhook::ReplayStoreCell, Ready>;
+
+        let serving_inline = size_of::<Scoped>()
+            + size_of::<crate::webhook::ReplayStoreCell>()
+            + size_of::<crate::webhook::ReplayKeyGuard>();
+        let whole = size_of::<crate::webhook::WebhookReplayCleanupFuture<Ready>>();
+        assert!(
+            whole >= serving_inline,
+            "WebhookReplayCleanupFuture must hold the scoped inner future, the \
+             replay cell and the drop guard inline in its `Serving` variant \
+             ({serving_inline} bytes together), but the whole future is only \
+             {whole} bytes — the inner future has been boxed, which costs an \
+             allocation on every request rather than only on a failed webhook \
+             delivery (issue #2214)"
+        );
+    }
+
+    /// The startup barrier's short-circuit branch: until the app reports startup
+    /// complete, a request to a non-exempt path is refused with `503`.
+    ///
+    /// Driven directly over a stub inner service because `apply_startup_barrier`
+    /// is production-only — `TestApp::build` deliberately mirrors just its two
+    /// response-side fallbacks (see `crate::test`), so no end-to-end test in the
+    /// suite can reach this branch.
+    #[tokio::test]
+    async fn startup_barrier_refuses_requests_until_startup_completes() {
+        use tower::{Layer, ServiceExt};
+
+        fn ok_service() -> impl tower::Service<
+            axum::extract::Request,
+            Response = axum::response::Response,
+            Error = std::convert::Infallible,
+        > + Clone {
+            tower::service_fn(|_req: axum::extract::Request| async move {
+                Ok::<_, std::convert::Infallible>("handler ran".into_response())
+            })
+        }
+
+        // `#[allow(future_not_send)]`: `tower::service_fn`'s closure is not
+        // `Sync`, so this helper's future is `!Send`. It only ever runs on a
+        // `#[tokio::test]` current-thread runtime, which never moves it.
+        #[allow(clippy::future_not_send)]
+        async fn status_for(startup_complete: bool, path: &str) -> (StatusCode, String) {
+            let state = AppState::for_test().with_startup_complete(startup_complete);
+            let config = AutumnConfig::default();
+            let layer = super::StartupBarrierLayer::new(super::StartupBarrierState::from_config(
+                &config, &state,
+            ));
+            let response = layer
+                .layer(ok_service())
+                .oneshot(
+                    axum::extract::Request::builder()
+                        .uri(path)
+                        .body(Body::empty())
+                        .expect("request builds"),
+                )
+                .await
+                .expect("infallible");
+            let status = response.status();
+            let body = axum::body::to_bytes(response.into_body(), 64 * 1024)
+                .await
+                .expect("body collects");
+            (status, String::from_utf8_lossy(&body).into_owned())
+        }
+
+        let (status, body) = status_for(false, "/anything").await;
+        assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
+        assert_eq!(body, "Service is still starting up");
+
+        // Control: the same request once startup has completed reaches the
+        // handler, so the 503 above is the barrier and not a broken stub.
+        let (status, body) = status_for(true, "/anything").await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body, "handler ran");
+
+        // Probe/actuator paths are exempt even before startup completes, so a
+        // platform readiness check can still reach them.
+        let (status, _) = status_for(false, "/actuator/health").await;
+        assert_ne!(
+            status,
+            StatusCode::SERVICE_UNAVAILABLE,
+            "probe paths must bypass the startup barrier"
+        );
+    }
 }
 #[derive(Clone, Debug)]
 pub struct TrustedHostPolicy {
@@ -11841,8 +12389,8 @@ impl TrustedHostPolicy {
     }
 
     /// Whether a request carrying no usable `Host` is allowed through. Mirrors
-    /// `trusted_host_middleware`'s missing-host branch for callers (e.g. the MCP
-    /// envelope) that enforce the policy outside that middleware.
+    /// `trusted_host_rejection`'s missing-host branch for callers (e.g. the MCP
+    /// envelope) that enforce the policy outside [`TrustedHostService`].
     ///
     /// Only the `mcp` feature consumes this today; gated so default-feature
     /// builds don't flag it as dead code.

--- a/autumn/src/webhook.rs
+++ b/autumn/src/webhook.rs
@@ -1019,7 +1019,7 @@ impl WebhookVerifyError {
     }
 }
 
-type ReplayStoreCell =
+pub(crate) type ReplayStoreCell =
     std::sync::Arc<std::sync::Mutex<Option<(std::sync::Arc<dyn WebhookReplayStore>, Vec<String>)>>>;
 
 tokio::task_local! {
@@ -1039,7 +1039,7 @@ tokio::task_local! {
 /// mean a handler that committed its side effect *before* failing can be invoked
 /// again on retry, which is the standard at-least-once contract handlers must
 /// tolerate.
-struct ReplayKeyGuard {
+pub(crate) struct ReplayKeyGuard {
     cell: ReplayStoreCell,
     completed: bool,
 }
@@ -1068,7 +1068,7 @@ pub async fn webhook_replay_cleanup_middleware(
     req: axum::extract::Request,
     next: axum::middleware::Next,
 ) -> axum::response::Response {
-    let cell = std::sync::Arc::new(std::sync::Mutex::new(None));
+    let cell: ReplayStoreCell = std::sync::Arc::new(std::sync::Mutex::new(None));
     let cell_cloned = cell.clone();
 
     let mut guard = ReplayKeyGuard {
@@ -1082,20 +1082,173 @@ pub async fn webhook_replay_cleanup_middleware(
 
     guard.completed = true;
 
-    if response.status().is_server_error() {
-        let to_remove = match cell_cloned.lock() {
-            Ok(mut guard) => guard.take(),
-            Err(poisoned) => poisoned.into_inner().take(),
-        };
-        if let Some((store, keys)) = to_remove {
-            for key in keys {
-                tracing::debug!(key = %key, "Releasing webhook replay key due to 5xx server error");
-                let _ = store.remove(&key).await;
-            }
-        }
+    if let Some(cleanup) = release_keys_on_server_error(&cell_cloned, response.status()) {
+        cleanup.await;
     }
 
     response
+}
+
+/// Take the request's inserted replay keys back out of `cell` and return the
+/// work that removes them, when `status` says the request failed with a `5xx`.
+///
+/// Returns `None` on every other status, and on a `5xx` that inserted no keys —
+/// so the common path allocates nothing and awaits nothing. Shared by
+/// [`webhook_replay_cleanup_middleware`] and [`WebhookReplayCleanupFuture`].
+fn release_keys_on_server_error(
+    cell: &ReplayStoreCell,
+    status: axum::http::StatusCode,
+) -> Option<impl std::future::Future<Output = ()> + Send + 'static> {
+    if !status.is_server_error() {
+        return None;
+    }
+    let (store, keys) = match cell.lock() {
+        Ok(mut guard) => guard.take(),
+        Err(poisoned) => poisoned.into_inner().take(),
+    }?;
+    Some(async move {
+        for key in keys {
+            tracing::debug!(key = %key, "Releasing webhook replay key due to 5xx server error");
+            let _ = store.remove(&key).await;
+        }
+    })
+}
+
+/// Tower [`Layer`](tower::Layer) form of [`webhook_replay_cleanup_middleware`],
+/// used by the framework's ingress stack.
+///
+/// The `axum::middleware::from_fn` it replaces `Box::pin`ned its wrapped async
+/// block on every request, and cloned the erased service beneath it to get it in
+/// there (issue #2214). Here the happy path — a request that is not a webhook
+/// delivery, or one that succeeds — is a `TaskLocalFuture` holding the inner
+/// service's own future: no boxed future, no clone of the stack below. (It
+/// still mints the per-request [`ReplayStoreCell`] it always did; that
+/// allocation is the middleware's own state, not `from_fn`'s wrapper.) Only the
+/// rare `5xx` *that actually registered replay keys* takes a box, for the
+/// removal work.
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct WebhookReplayCleanupLayer;
+
+impl<S> tower::Layer<S> for WebhookReplayCleanupLayer {
+    type Service = WebhookReplayCleanupService<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        WebhookReplayCleanupService { inner }
+    }
+}
+
+/// Tower [`Service`](tower::Service) produced by [`WebhookReplayCleanupLayer`].
+#[derive(Clone, Debug)]
+pub(crate) struct WebhookReplayCleanupService<S> {
+    inner: S,
+}
+
+impl<S, ReqBody> tower::Service<axum::http::Request<ReqBody>> for WebhookReplayCleanupService<S>
+where
+    S: tower::Service<axum::http::Request<ReqBody>, Response = axum::response::Response>,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = WebhookReplayCleanupFuture<S::Future>;
+
+    fn poll_ready(
+        &mut self,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, req: axum::http::Request<ReqBody>) -> Self::Future {
+        let cell: ReplayStoreCell = std::sync::Arc::new(std::sync::Mutex::new(None));
+        // Built inside the scope, not merely polled inside it — see
+        // `crate::capsule::capture` for why the argument form would run the
+        // synchronous `Service::call` chain beneath this layer with the
+        // task-local unset.
+        let inner = WEBHOOK_REPLAY_KEY.sync_scope(cell.clone(), || self.inner.call(req));
+        WebhookReplayCleanupFuture::Serving {
+            inner: WEBHOOK_REPLAY_KEY.scope(cell.clone(), inner),
+            guard: ReplayKeyGuard {
+                cell: cell.clone(),
+                completed: false,
+            },
+            cell,
+        }
+    }
+}
+
+pin_project_lite::pin_project! {
+    /// Future returned by [`WebhookReplayCleanupService`].
+    ///
+    /// `Serving` holds the [`ReplayKeyGuard`] alongside the scoped inner
+    /// future, so dropping this future before it resolves — a handler panic, or
+    /// the request-timeout layer above cancelling it — still runs the guard's
+    /// `Drop` and releases the inserted keys, exactly as the `from_fn` form's
+    /// dropped async block did.
+    #[project = WebhookReplayCleanupFutureProj]
+    pub(crate) enum WebhookReplayCleanupFuture<F> {
+        Serving {
+            #[pin]
+            inner: tokio::task::futures::TaskLocalFuture<ReplayStoreCell, F>,
+            cell: ReplayStoreCell,
+            guard: ReplayKeyGuard,
+        },
+        /// A `5xx` that inserted replay keys: release them before handing the
+        /// response back. This is the only branch that allocates.
+        Releasing {
+            #[pin]
+            cleanup: std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send>>,
+            response: Option<axum::response::Response>,
+        },
+    }
+}
+
+impl<F, E> std::future::Future for WebhookReplayCleanupFuture<F>
+where
+    F: std::future::Future<Output = Result<axum::response::Response, E>>,
+{
+    type Output = Result<axum::response::Response, E>;
+
+    #[allow(
+        clippy::expect_used,
+        reason = "unreachable: future not polled after Ready"
+    )]
+    fn poll(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Self::Output> {
+        loop {
+            let next = match self.as_mut().project() {
+                WebhookReplayCleanupFutureProj::Serving { inner, cell, guard } => {
+                    let response = match std::task::ready!(inner.poll(cx)) {
+                        Ok(response) => response,
+                        Err(error) => {
+                            // The inner service failed rather than responding.
+                            // Leave `completed` false so the guard's `Drop`
+                            // releases the keys, matching the panic/cancel path.
+                            return std::task::Poll::Ready(Err(error));
+                        }
+                    };
+                    // The handler ran to completion: the guard's drop-time
+                    // release must not fire, whatever the status was.
+                    guard.completed = true;
+                    match release_keys_on_server_error(cell, response.status()) {
+                        None => return std::task::Poll::Ready(Ok(response)),
+                        Some(cleanup) => Self::Releasing {
+                            cleanup: Box::pin(cleanup),
+                            response: Some(response),
+                        },
+                    }
+                }
+                WebhookReplayCleanupFutureProj::Releasing { cleanup, response } => {
+                    std::task::ready!(cleanup.poll(cx));
+                    return std::task::Poll::Ready(Ok(response
+                        .take()
+                        .expect("WebhookReplayCleanupFuture polled after completion")));
+                }
+            };
+            self.as_mut().set(next);
+        }
+    }
 }
 
 async fn verify_request(
@@ -1507,4 +1660,209 @@ pub(crate) fn install_registry_from_config(
     let registry = WebhookRegistry::from_config(config)?;
     state.insert_extension(registry);
     Ok(())
+}
+
+/// Direct coverage for [`WebhookReplayCleanupService`] and its future's state
+/// machine (issue #2214).
+///
+/// The framework's ingress installs the *layer*; the retained
+/// [`webhook_replay_cleanup_middleware`] `async fn` is the form the pre-existing
+/// suite exercises. The `Releasing` branch — the one piece of genuinely new
+/// async state-machine code here, and the only branch that still allocates — is
+/// reachable end-to-end only from a signed webhook delivery that registers a
+/// replay key and then fails, so it is driven directly here instead.
+#[cfg(test)]
+mod replay_cleanup_service_tests {
+    use super::{
+        ReplayStoreCell, WEBHOOK_REPLAY_KEY, WebhookReplayCleanupLayer, WebhookReplayFuture,
+        WebhookReplayStore,
+    };
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::{Arc, Mutex};
+    use std::time::{Duration, SystemTime};
+
+    use axum::body::Body;
+    use axum::http::{Request, Response, StatusCode};
+    use tower::{Layer, Service, ServiceExt};
+
+    /// Replay store that records every key it is asked to remove.
+    #[derive(Debug, Default)]
+    struct RecordingStore {
+        removed: Mutex<Vec<String>>,
+        remove_calls: AtomicUsize,
+    }
+
+    impl WebhookReplayStore for RecordingStore {
+        fn check_and_insert<'a>(
+            &'a self,
+            _key: &'a str,
+            _received_at: SystemTime,
+            _window: Duration,
+        ) -> WebhookReplayFuture<'a> {
+            Box::pin(async { Ok(true) })
+        }
+
+        fn remove<'a>(&'a self, key: &'a str) -> WebhookReplayFuture<'a> {
+            self.remove_calls.fetch_add(1, Ordering::SeqCst);
+            let key = key.to_owned();
+            Box::pin(async move {
+                self.removed.lock().expect("lock").push(key);
+                Ok(true)
+            })
+        }
+    }
+
+    /// Inner service that registers `keys` into the ambient replay cell — the
+    /// way `SignedWebhook`'s extractor does — and then answers with `status`.
+    fn delivery_handler(
+        store: Arc<RecordingStore>,
+        keys: Vec<String>,
+        status: StatusCode,
+    ) -> impl Service<Request<Body>, Response = Response<Body>, Error = std::convert::Infallible> + Clone
+    {
+        tower::service_fn(move |_req: Request<Body>| {
+            let store = Arc::clone(&store);
+            let keys = keys.clone();
+            async move {
+                WEBHOOK_REPLAY_KEY.with(|cell: &ReplayStoreCell| {
+                    *cell.lock().expect("lock") =
+                        Some((store as Arc<dyn WebhookReplayStore>, keys.clone()));
+                });
+                Ok::<_, std::convert::Infallible>(
+                    Response::builder()
+                        .status(status)
+                        .body(Body::empty())
+                        .expect("response builds"),
+                )
+            }
+        })
+    }
+
+    /// `#[allow(future_not_send)]`: `tower::service_fn`'s closure is not
+    /// `Sync`, so this helper's future is `!Send`. It only ever runs on a
+    /// `#[tokio::test]` current-thread runtime, which never moves it.
+    #[allow(clippy::future_not_send)]
+    async fn drive(store: &Arc<RecordingStore>, status: StatusCode) -> StatusCode {
+        let service = WebhookReplayCleanupLayer.layer(delivery_handler(
+            Arc::clone(store),
+            vec!["evt_1".to_owned(), "evt_2".to_owned()],
+            status,
+        ));
+        service
+            .oneshot(Request::builder().body(Body::empty()).expect("request"))
+            .await
+            .expect("infallible")
+            .status()
+    }
+
+    /// The task-local really is installed for the inner service — without it
+    /// `WEBHOOK_REPLAY_KEY.with(..)` in the handler panics.
+    #[tokio::test]
+    async fn the_replay_key_scope_is_installed_for_the_inner_service() {
+        let store = Arc::new(RecordingStore::default());
+        assert_eq!(drive(&store, StatusCode::OK).await, StatusCode::OK);
+    }
+
+    /// A successful delivery keeps its replay keys — releasing them would let
+    /// an attacker replay the signed payload inside the window.
+    #[tokio::test]
+    async fn a_2xx_never_releases_replay_keys() {
+        let store = Arc::new(RecordingStore::default());
+        drive(&store, StatusCode::OK).await;
+        assert_eq!(store.remove_calls.load(Ordering::SeqCst), 0);
+        assert!(store.removed.lock().expect("lock").is_empty());
+    }
+
+    /// The `Releasing` branch: a `5xx` that registered keys releases every one
+    /// of them, and the client still receives the original response.
+    #[tokio::test]
+    async fn a_5xx_releases_every_registered_replay_key_and_still_returns_the_response() {
+        let store = Arc::new(RecordingStore::default());
+        let status = drive(&store, StatusCode::INTERNAL_SERVER_ERROR).await;
+        assert_eq!(
+            status,
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "the release branch must not swallow or rewrite the response"
+        );
+        let mut removed = store.removed.lock().expect("lock").clone();
+        removed.sort();
+        assert_eq!(removed, vec!["evt_1".to_owned(), "evt_2".to_owned()]);
+    }
+
+    /// A `4xx` is the client's fault, not a delivery failure: keys stay
+    /// consumed, exactly as before the conversion.
+    #[tokio::test]
+    async fn a_4xx_does_not_release_replay_keys() {
+        let store = Arc::new(RecordingStore::default());
+        drive(&store, StatusCode::BAD_REQUEST).await;
+        assert_eq!(store.remove_calls.load(Ordering::SeqCst), 0);
+    }
+
+    /// A `5xx` from a request that registered no keys must not take the
+    /// allocating `Releasing` branch at all — it short-circuits to `None`.
+    #[tokio::test]
+    async fn a_5xx_with_no_registered_keys_releases_nothing() {
+        let store = Arc::new(RecordingStore::default());
+        let service =
+            WebhookReplayCleanupLayer.layer(tower::service_fn(|_req: Request<Body>| async move {
+                Ok::<_, std::convert::Infallible>(
+                    Response::builder()
+                        .status(StatusCode::BAD_GATEWAY)
+                        .body(Body::empty())
+                        .expect("response builds"),
+                )
+            }));
+        let response = service
+            .oneshot(Request::builder().body(Body::empty()).expect("request"))
+            .await
+            .expect("infallible");
+        assert_eq!(response.status(), StatusCode::BAD_GATEWAY);
+        assert_eq!(store.remove_calls.load(Ordering::SeqCst), 0);
+    }
+
+    /// Cancellation: dropping the future before the inner service resolves must
+    /// still release the keys, via `ReplayKeyGuard`'s `Drop`. This is the path
+    /// the request-timeout layer above takes when a webhook handler blows its
+    /// deadline, and the one the `from_fn` form got for free by dropping its
+    /// boxed async block.
+    #[tokio::test]
+    async fn dropping_the_future_mid_flight_still_releases_the_keys() {
+        let store = Arc::new(RecordingStore::default());
+        let store_for_handler = Arc::clone(&store);
+        let service =
+            WebhookReplayCleanupLayer.layer(tower::service_fn(move |_req: Request<Body>| {
+                let store = Arc::clone(&store_for_handler);
+                async move {
+                    WEBHOOK_REPLAY_KEY.with(|cell: &ReplayStoreCell| {
+                        *cell.lock().expect("lock") = Some((
+                            store as Arc<dyn WebhookReplayStore>,
+                            vec!["evt_cancelled".to_owned()],
+                        ));
+                    });
+                    // Never resolves: the only way out is cancellation.
+                    std::future::pending::<Result<Response<Body>, std::convert::Infallible>>().await
+                }
+            }));
+
+        let handle = tokio::spawn(async move {
+            let _ = service
+                .oneshot(Request::builder().body(Body::empty()).expect("request"))
+                .await;
+        });
+        // Let the handler run far enough to register its key, then cancel.
+        tokio::task::yield_now().await;
+        handle.abort();
+        let _ = handle.await;
+        // The guard's Drop spawns the removals; give them a turn.
+        for _ in 0..8 {
+            tokio::task::yield_now().await;
+        }
+
+        assert_eq!(
+            store.removed.lock().expect("lock").as_slice(),
+            ["evt_cancelled".to_owned()],
+            "a cancelled webhook delivery must release the replay keys it \
+             registered, so the provider's redelivery is accepted"
+        );
+    }
 }

--- a/autumn/tests/config_alloc_gate.rs
+++ b/autumn/tests/config_alloc_gate.rs
@@ -1,5 +1,13 @@
-//! Isolated integration test: allocation gate for `AppState`'s config
-//! accessors (issue #2198).
+//! Isolated integration test: the framework's per-request allocation gates —
+//! `AppState`'s config accessors (issue #2198) and the ingress stack's
+//! allocation blocks and bytes (issues #2198, #2205, #2214).
+//!
+//! Everything that has to be judged on *allocations* rather than on a
+//! structural count lives here, in one binary, for the reason the next
+//! paragraph gives. Its sibling gate
+//! `tests/integration/middleware_stack_depth.rs` counts clone-on-call
+//! traversals of the same stack; that count is a proxy, this file is the
+//! measurement.
 //!
 //! `AppState::config` deep-clones every section of `AutumnConfig` on each call,
 //! which is paid per request on the paths that read config. `config_arc` exists
@@ -148,52 +156,46 @@ fn config_allocates_because_it_deep_clones() {
     );
 }
 
-/// Trivial handler: the ceiling below is about the framework's per-request
+/// Trivial handler: the ceilings below are about the framework's per-request
 /// work, so the handler itself must contribute as close to nothing as possible.
 #[autumn_web::get("/ping")]
 async fn ping() -> &'static str {
     "pong"
 }
 
-/// Per-request allocation ceiling for a `TestClient` round trip.
+/// What one `TestClient` round trip through the production ingress costs.
+#[derive(Clone, Copy, Debug)]
+struct PerRequest {
+    /// Allocation blocks (`malloc` calls), averaged over the measured run.
+    blocks: u64,
+    /// Allocated bytes, averaged over the measured run.
+    bytes: u64,
+}
+
+/// Drive `MEASURED` requests through a `TestApp`-built production router and
+/// return the per-request allocation cost.
 ///
-/// The framework reads the whole config once per request and takes an owned
-/// deep clone to do it. That clone is worth about a fifth of everything a
-/// request allocates, which is what makes this ceiling meaningful rather than
-/// decorative.
+/// `customize` runs on the `TestApp` before it is built, so a caller can
+/// register extra layers and measure their marginal cost.
 ///
-/// Numbers behind the constant, all from the debug profile with default
-/// features, identical across three runs (the whole path is deterministic, so
-/// there is no noise budget to reserve): 320 blocks on the tree before #2198's
-/// `config_arc` work, 220 after it landed, and 172 after `AppState::profile`
-/// and `AppState::auth_session_key` moved from owned `String`/`Option<String>`
-/// to `Arc<str>` (`appstate_clone_allocates_nothing_for_profile_and_auth_session_key`
-/// above pins that clone at zero) — a 48-block drop, since `AppState` is
-/// cloned on every hop of the ingress tower stack and each of those two
-/// fields used to be deep-copied on every one of those clones. The ceiling
-/// sits above the current 172 with about a tenth of headroom to spare.
-///
-/// A ceiling this close to the measured value is a deliberate trade: it can
-/// only stay honest while the number stays deterministic. If this ever fails
-/// with a count just over the line rather than a regression-sized jump,
-/// re-measure and re-derive it rather than nudging it upwards.
-#[test]
-fn per_request_allocations_stay_under_the_ceiling() {
+/// The runtime has to be current-thread: `allocation-counter` counts
+/// thread-locally, so anything a worker thread allocated would go uncounted and
+/// every ceiling here would flatter whatever moved off this thread.
+fn measure_per_request(
+    customize: impl FnOnce(autumn_web::test::TestApp) -> autumn_web::test::TestApp,
+) -> PerRequest {
     use autumn_web::routes;
     use autumn_web::test::TestApp;
 
-    const CEILING: u64 = 190;
     const WARMUP: usize = 3;
     const MEASURED: u64 = 10;
 
-    // Counting is thread-local, so the runtime has to be current-thread:
-    // anything a worker thread allocated would go uncounted and the ceiling
-    // would flatter whatever moved off this thread.
     let runtime = tokio::runtime::Builder::new_current_thread()
         .enable_all()
         .build()
         .expect("current-thread runtime should build");
-    let client = runtime.block_on(async { TestApp::new().routes(routes![ping]).build() });
+    let client =
+        runtime.block_on(async { customize(TestApp::new().routes(routes![ping])).build() });
 
     // First requests pay one-time setup (lazily built middleware state, caches)
     // that steady-state requests do not.
@@ -211,13 +213,245 @@ fn per_request_allocations_stay_under_the_ceiling() {
             }
         });
     });
-    let per_request = info.count_total / MEASURED;
+
+    PerRequest {
+        blocks: info.count_total / MEASURED,
+        bytes: info.bytes_total / MEASURED,
+    }
+}
+
+/// Per-request allocation-BLOCK ceiling for a `TestClient` round trip.
+///
+/// What makes it meaningful rather than decorative is that it has caught real
+/// movement three times: it is the number #2198, #2205 and #2214 each drove
+/// down, and each of those wins is one a purely structural gate could not see.
+/// (An earlier version of this comment justified the ceiling by the whole-config
+/// deep clone `AppState::config()` used to take per request — that clone left
+/// the request path in #2198, when every framework read moved to `config_arc`.)
+///
+/// Numbers behind the constant, all from the debug profile with default
+/// features, identical across three runs (the whole path is deterministic, so
+/// there is no noise budget to reserve): 320 blocks on the tree before #2198's
+/// `config_arc` work, 220 after it landed, 172 after `AppState::profile`
+/// and `AppState::auth_session_key` moved from owned `String`/`Option<String>`
+/// to `Arc<str>` (`appstate_clone_allocates_nothing_for_profile_and_auth_session_key`
+/// above pins that clone at zero) — a 48-block drop, since `AppState` is
+/// cloned on every hop of the ingress tower stack and each of those two
+/// fields used to be deep-copied on every one of those clones — and **140**
+/// after #2214 replaced the always-on ingress `axum::middleware::from_fn`
+/// layers with hand-rolled services carrying named futures. That 32-block drop
+/// is more than the one `Box::pin` per converted layer the issue title names:
+/// `FromFn::call` also opens with `self.inner.clone()`, and cloning an erased
+/// `BoxCloneSyncService` is a recursive `clone_box` down the rest of the stack,
+/// so each conversion took a whole deep-clone cascade with it (plus the
+/// `String` `asset_cache_control` used to own its path in). The ceiling sits
+/// above the current measurement with about a tenth of headroom to spare.
+///
+/// **Feature sensitivity.** CI gates with `cargo test --workspace`, which
+/// unifies far more features than the 8 defaults a local `cargo test -p
+/// autumn-web` builds — so a ceiling derived under defaults alone would be a
+/// guess. This one is not: 140 was measured under the default set AND under a
+/// 13-feature build adding `oauth2`, `mail`, `storage`, `ws` and `openapi`.
+/// Blocks did not move at all between the two (bytes did — see the sibling
+/// gate). The remaining 6 blocks of headroom are for a feature neither build
+/// covers.
+///
+/// A ceiling this close to the measured value is a deliberate trade, and here
+/// it buys something specific: at 146 a single restored `axum::middleware::from_fn`
+/// on the ingress path (7 blocks, per the control test below) fails this gate.
+/// A looser ceiling would only catch a wholesale revert. It can only stay
+/// honest while the number stays deterministic — if this ever fails with a
+/// count just over the line rather than a regression-sized jump, re-measure
+/// under both feature sets and re-derive it rather than nudging it upwards.
+#[test]
+fn per_request_allocations_stay_under_the_ceiling() {
+    const CEILING: u64 = 146;
+
+    let measured = measure_per_request(|app| app);
+    println!(
+        "per-request ingress cost: {} blocks / {} bytes",
+        measured.blocks, measured.bytes
+    );
 
     assert!(
-        per_request <= CEILING,
-        "a request allocated {per_request} blocks, over the {CEILING} ceiling \
-         ({} blocks and {} bytes across {MEASURED} requests)",
-        info.count_total,
-        info.bytes_total
+        measured.blocks <= CEILING,
+        "a request allocated {} blocks, over the {CEILING} ceiling ({} bytes \
+         per request). 172 was the pre-#2214 measurement: check whether an \
+         `axum::middleware::from_fn` is back on the always-on ingress path — \
+         each one costs a `Box::pin` per request.",
+        measured.blocks,
+        measured.bytes,
+    );
+}
+
+/// Per-request allocated-BYTES ceiling for a `TestClient` round trip.
+///
+/// Bytes, not blocks, are the quantity issue #2214 is denominated in: the
+/// `Box::pin` `axum::middleware::from_fn` wraps its future in is *one* block
+/// but a large one — DHAT measured 1088-2224 bytes at each of the seven call
+/// sites the `request_pipeline` bench traverses, because an outer layer's async
+/// block captures the whole downstream continuation across its single `.await`.
+/// Summed, that was 19.57% of every byte the benchmark allocated while being
+/// only 2.14% of the blocks. A block-count ceiling alone would barely move for
+/// the largest allocation cost in the profile, which is exactly why this
+/// sibling gate exists.
+///
+/// Derivation, debug profile, stable across three runs: **37,819 bytes** per
+/// request before #2214 and **26,030** after under the 8 default features — a
+/// 31.2% reduction, against the 19.57% DHAT attributed to the `from_fn` boxes
+/// alone, the balance being the deep clones those boxes' `self.inner.clone()`
+/// used to drag along with them.
+///
+/// Unlike the block count, bytes ARE feature-sensitive: the same measurement
+/// under a 13-feature build (defaults plus `oauth2`, `mail`, `storage`, `ws`,
+/// `openapi`) is **27,622** — 6.1% higher, because a wider `AutumnConfig` and a
+/// wider `UploadConfig` ride along in request extensions without adding a
+/// single allocation *block*. The ceiling is therefore derived from the WIDER
+/// measurement plus about a tenth, not from the default-feature one; a ceiling
+/// derived from 26,030 would have left barely 3% of room under the feature set
+/// CI actually gates with.
+///
+/// That makes this a *bulk* gate: it catches a wholesale reintroduction of the
+/// `from_fn` layers (which would put the number back near 38k), not a single
+/// one (worth ~1.9 KB). Single-layer regressions are the block ceiling's job
+/// above, and the `type_name` assertions in `src/router.rs`'s test module.
+///
+/// The same honesty rule as the block ceiling applies: a failure a hair over
+/// the line means re-measure under both feature sets and re-derive, not nudge.
+#[test]
+fn per_request_allocated_bytes_stay_under_the_ceiling() {
+    const CEILING: u64 = 30_500;
+
+    let measured = measure_per_request(|app| app);
+    println!(
+        "per-request ingress cost: {} blocks / {} bytes",
+        measured.blocks, measured.bytes
+    );
+
+    assert!(
+        measured.bytes <= CEILING,
+        "a request allocated {} bytes, over the {CEILING} ceiling ({} blocks \
+         per request). ~37.8k was the pre-#2214 measurement: check whether an \
+         `axum::middleware::from_fn` is back on the always-on ingress path — \
+         its `Box::pin` is sized by everything the wrapped async block captures \
+         across `.await`, which for an outer layer is the whole downstream \
+         continuation.",
+        measured.bytes,
+        measured.blocks,
+    );
+}
+
+/// App-wide operator layer that neither clones its inner service on call nor
+/// boxes its future, so registering it costs only the type erasure every
+/// registration pays. The control below subtracts that erasure out.
+#[derive(Clone)]
+struct PassthroughLayer;
+
+impl<S> tower::Layer<S> for PassthroughLayer {
+    type Service = PassthroughService<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        PassthroughService { inner }
+    }
+}
+
+#[derive(Clone)]
+struct PassthroughService<S> {
+    inner: S,
+}
+
+impl<S> tower::Service<axum::extract::Request> for PassthroughService<S>
+where
+    S: tower::Service<axum::extract::Request>,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = S::Future;
+
+    fn poll_ready(
+        &mut self,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, req: axum::extract::Request) -> Self::Future {
+        self.inner.call(req)
+    }
+}
+
+/// The sensitivity control for the two ceilings above, and the executable
+/// statement of what issue #2214 is about.
+///
+/// Both registrations below wrap the same no-op behaviour around the same app
+/// and are erased identically (`AppBuilder::layer` boxes every registration
+/// through `BoxCloneSyncServiceLayer` — one `Box::pin` per request, common to
+/// both). The ONLY difference is that one is written as a `tower::Service`
+/// whose future is its inner service's future, and the other is written as an
+/// `axum::middleware::from_fn`, whose generated `FromFn::call` must
+/// `Box::pin` the async block it wraps because that block's type cannot be
+/// named. The difference between the two measurements is therefore exactly one
+/// `from_fn` box.
+///
+/// The measured difference is bigger than the single box, and deliberately so:
+/// `FromFn::call` opens with `self.inner.clone()` so it can move the inner
+/// service into the async block, and cloning an erased `BoxCloneSyncService`
+/// is a recursive `clone_box` down every remaining level of the stack — the
+/// same cascade #2193/#2198 measured. So a `from_fn` costs its own box PLUS a
+/// deep clone of everything beneath it, which is why converting one is worth
+/// more than the one allocation the issue title names. At the operator-layer
+/// position measured here (debug profile, default features) the difference is
+/// **7 blocks / ~1.9 KB** per request; a `from_fn` further out costs more,
+/// because more of the stack sits below it.
+///
+/// This test is green both before and after #2214 — that is the point. It
+/// proves the ceilings above are measured on an instrument that can see the
+/// thing they are gating, rather than being two numbers that happen to hold.
+/// The no-op the control below wraps in an `axum::middleware::from_fn`.
+async fn noop_middleware(
+    req: axum::extract::Request,
+    next: axum::middleware::Next,
+) -> axum::response::Response {
+    next.run(req).await
+}
+
+/// A floor rather than `> 0`: the ceilings above were derived against a
+/// `from_fn` that costs 7 blocks at the position measured here, so an
+/// instrument that could only still see 1 of those 7 would leave them
+/// unmeetable while this control stayed green.
+const MIN_FROM_FN_BLOCKS: u64 = 5;
+
+#[test]
+fn a_from_fn_layer_costs_more_heap_blocks_per_request_than_a_named_future() {
+    let named = measure_per_request(|app| app.layer(PassthroughLayer));
+    let boxed = measure_per_request(|app| app.layer(axum::middleware::from_fn(noop_middleware)));
+    println!(
+        "named-future layer: {} blocks / {} bytes; from_fn layer: {} blocks / {} bytes \
+         (delta {} blocks / {} bytes)",
+        named.blocks,
+        named.bytes,
+        boxed.blocks,
+        boxed.bytes,
+        boxed.blocks.saturating_sub(named.blocks),
+        boxed.bytes.saturating_sub(named.bytes),
+    );
+
+    assert!(
+        boxed.blocks >= named.blocks + MIN_FROM_FN_BLOCKS,
+        "an `axum::middleware::from_fn` must cost at least {MIN_FROM_FN_BLOCKS} \
+         heap blocks per request more than the same no-op written as a \
+         `tower::Service` with a named future (named = {} blocks, from_fn = {} \
+         blocks; 7 was the measurement the ceilings above were derived against). \
+         If the gap has shrunk, `from_fn` changed and those ceilings need \
+         re-deriving, not this assertion loosening.",
+        named.blocks,
+        boxed.blocks,
+    );
+    assert!(
+        boxed.bytes > named.bytes,
+        "the `from_fn` box has to be visible in bytes too, but the named-future \
+         layer measured {} bytes and the `from_fn` one {} bytes",
+        named.bytes,
+        boxed.bytes,
     );
 }

--- a/autumn/tests/integration/ingress_named_futures.rs
+++ b/autumn/tests/integration/ingress_named_futures.rs
@@ -1,0 +1,282 @@
+//! Behavioural characterization for the ingress middlewares issue #2214
+//! rewrote from `axum::middleware::from_fn` closures into hand-rolled
+//! `tower::Service`s with named futures.
+//!
+//! # What this file is for
+//!
+//! #2214 is a pure allocation change: every layer here is supposed to do
+//! *exactly* what it did before, just without the `Box::pin` `from_fn` wraps
+//! its otherwise-unnameable future in. The two gates that measure the win —
+//! `tests/config_alloc_gate.rs` (blocks and bytes per request) and
+//! `middleware_stack_depth.rs` (clone-on-call traversals) — say nothing at all
+//! about whether the rewritten middleware still *works*. That is this file's
+//! job, and it is deliberately written so that every assertion is green both
+//! before and after the conversion.
+//!
+//! The failure modes it is aimed at are the ones a mechanical rewrite actually
+//! produces:
+//!
+//! 1. **A gate's short-circuit stops flowing through the outer response
+//!    layers.** A `from_fn` returns its rejection from inside the stack, so
+//!    security headers and the request id are still applied on the way out. A
+//!    hand-rolled service that resolved its short-circuit anywhere else would
+//!    lose them silently — the status code would still be right.
+//! 2. **A task-local scope is dropped.** `EventAppContextLayer`,
+//!    `WebhookReplayCleanupLayer` and `ReadYourWritesLayer` exist only to
+//!    install a `tokio::task_local!` around the rest of the request. A
+//!    conversion that forgot the scope would leave every functional test green
+//!    while silently re-routing published events to the process-global bus.
+//! 3. **Response-side work stops happening.** `AssetCacheControlLayer` is the
+//!    only converted layer whose whole job is on the way *out*.
+//!
+//! Ordering between these layers is pinned by `middleware_stack_order.rs` and
+//! `middleware_stack_depth::merged_stack_preserves_ingress_order`, and is
+//! deliberately not re-asserted here.
+//!
+//! Conversions this file does NOT cover, and where they are covered instead —
+//! each of these is driven directly over a stub inner service, because the
+//! assembled `TestApp` router cannot reach the branch that matters:
+//!
+//! | conversion | covered by |
+//! | --- | --- |
+//! | `AssetCacheControlService` (success branch) | `assets::cache_control_service_tests` |
+//! | `WebhookReplayCleanupService` (release + cancel branches) | `webhook::replay_cleanup_service_tests` |
+//! | `ReadYourWritesService` | `read_your_writes::service_tests` |
+//! | `StartupBarrierService` (503 branch) | `router::trusted_host_tests::startup_barrier_refuses_requests_until_startup_completes` |
+//! | `RequestTimeoutService` | `tests/integration/request_timeout.rs` |
+//! | `MethodOverrideRejectionService` | `middleware_stack_depth::merged_stack_preserves_ingress_order` |
+//! | `HttpInterceptorService` | `boundary_hooks_integration.rs` (`oauth2`) |
+
+use autumn_web::config::AutumnConfig;
+use autumn_web::test::TestApp;
+use autumn_web::{event, get, routes};
+
+#[get("/ping")]
+async fn ping() -> &'static str {
+    "pong"
+}
+
+// ── TrustedHostLayer ────────────────────────────────────────────────────────
+
+fn config_with_trusted_host() -> AutumnConfig {
+    let mut config = AutumnConfig {
+        profile: Some("prod".to_owned()),
+        ..AutumnConfig::default()
+    };
+    config.security.trusted_hosts.hosts = vec!["example.com".to_owned()];
+    config
+}
+
+/// An allowed `Host` is forwarded to the handler unchanged — the control that
+/// makes the rejection below evidence about the policy rather than about a
+/// layer that rejects everything.
+#[tokio::test]
+async fn trusted_host_forwards_an_allowed_host() {
+    let client = TestApp::new()
+        .config(config_with_trusted_host())
+        .routes(routes![ping])
+        .build();
+
+    let response = client
+        .get("/ping")
+        .header("host", "example.com")
+        .send()
+        .await;
+    response.assert_status(200);
+    assert_eq!(response.text(), "pong");
+}
+
+/// An untrusted `Host` is refused with the documented Problem Details `400` —
+/// and that `400`, produced by a layer deep inside the ingress stack, still
+/// carries the response headers the layers *outside* it stamp. That second
+/// assertion is the one that catches a short-circuit resolved in the wrong
+/// place: the status alone would look identical.
+#[tokio::test]
+async fn trusted_host_rejects_an_untrusted_host_through_the_outer_response_layers() {
+    let client = TestApp::new()
+        .config(config_with_trusted_host())
+        .routes(routes![ping])
+        .build();
+
+    let response = client
+        .get("/ping")
+        .header("host", "evil.example.net")
+        .send()
+        .await;
+
+    response.assert_status(400);
+    assert_eq!(
+        response.header("content-type"),
+        Some("application/problem+json"),
+        "the trusted-host rejection must stay a Problem Details response; \
+         headers = {:?}",
+        response.headers
+    );
+    assert!(
+        response.header("x-request-id").is_some(),
+        "the rejection is produced INSIDE the ingress stack, so it can only \
+         carry x-request-id while `RequestIdLayer` is still outside it; \
+         headers = {:?}",
+        response.headers
+    );
+    assert!(
+        response.header("x-content-type-options").is_some(),
+        "the rejection must still travel out through the security headers; \
+         headers = {:?}",
+        response.headers
+    );
+}
+
+/// The health/probe bypass: a `GET` to a probe path is exempt from the policy
+/// even with a `Host` the policy would otherwise refuse, so a platform load
+/// balancer that dials the pod by IP keeps every replica in rotation.
+#[tokio::test]
+async fn trusted_host_bypasses_probe_paths() {
+    let client = TestApp::new()
+        .config(config_with_trusted_host())
+        .routes(routes![ping])
+        .build();
+
+    let response = client
+        .get("/actuator/health")
+        .header("host", "10.0.0.7:8080")
+        .send()
+        .await;
+
+    assert_ne!(
+        response.status.as_u16(),
+        400,
+        "probe paths bypass the trusted-host policy; body = {}",
+        response.text()
+    );
+}
+
+// ── AssetCacheControlLayer ──────────────────────────────────────────────────
+
+/// A `/static/...` request that does not resolve to a file must NOT be given a
+/// `Cache-Control` — the header is stamped only on success.
+///
+/// This is deliberately the *only* asset assertion made end-to-end. The
+/// success case cannot be reached from here: `/static` is a `ServeDir` over a
+/// `static/` directory this crate does not ship, so every `/static/...` request
+/// in this suite 404s. Writing an `if response.is_success() { … } else { … }`
+/// test would therefore assert the else-branch forever and pass identically
+/// with `AssetCacheControlLayer` deleted from the router. The stamping itself
+/// is pinned where it can actually be exercised — over a stub inner service, in
+/// `assets::cache_control_service_tests`.
+#[tokio::test]
+async fn asset_cache_control_leaves_unresolved_static_requests_unstamped() {
+    let client = TestApp::new().routes(routes![ping]).build();
+
+    let response = client.get("/static/does-not-exist.css").send().await;
+    assert!(
+        !response.status.is_success(),
+        "this suite ships no `static/` directory, so the premise of this test \
+         is that the request 404s; if that ever changes, assert the \
+         revalidate Cache-Control here instead of removing the test"
+    );
+    assert!(
+        response.header("cache-control").is_none(),
+        "an unsuccessful /static response must NOT be given a Cache-Control \
+         header; headers = {:?}",
+        response.headers
+    );
+}
+
+/// Non-asset routes are untouched — the layer is applied globally, so "does
+/// nothing off `/static/`" is a real property and not an accident of routing.
+#[tokio::test]
+async fn asset_cache_control_leaves_ordinary_routes_alone() {
+    let client = TestApp::new().routes(routes![ping]).build();
+
+    let response = client.get("/ping").send().await;
+    response.assert_status(200);
+    assert!(
+        response.header("cache-control").is_none(),
+        "the asset cache-control layer must not stamp non-/static routes; \
+         headers = {:?}",
+        response.headers
+    );
+}
+
+// ── EventAppContextLayer ────────────────────────────────────────────────────
+
+#[event]
+struct ScopedPing {
+    marker: i64,
+}
+
+/// A handler that publishes through the FREE `events::publish`, which resolves
+/// its target from the ambient task-local this layer installs (rather than
+/// through the `Events` extractor, which carries the app explicitly and would
+/// therefore prove nothing).
+#[get("/publish")]
+async fn publish_ambiently() -> &'static str {
+    autumn_web::events::publish(ScopedPing { marker: 7 })
+        .await
+        .expect("publish should succeed");
+    "published"
+}
+
+/// The scope this layer exists for, pinned by isolation rather than by
+/// presence.
+///
+/// `TestApp::build` re-installs the app it builds as the process-global event
+/// bus, so a *single* app cannot tell "the scope worked" from "the scope was
+/// lost and the global fallback happened to point at me". Two apps can: the
+/// second one built owns the global bus, so a request to the FIRST app can only
+/// reach the first app's recorder through the task-local `EventAppContextLayer`
+/// installs. If the conversion dropped the scope, this event would land in
+/// `second`'s recorder instead.
+#[tokio::test]
+async fn event_app_context_scope_keeps_parallel_apps_isolated() {
+    let first = TestApp::new().routes(routes![publish_ambiently]).build();
+    let second = TestApp::new().routes(routes![ping]).build();
+
+    first.get("/publish").send().await.assert_status(200);
+
+    first.assert_event_published::<ScopedPing>();
+    assert_eq!(
+        second.published_events::<ScopedPing>().len(),
+        0,
+        "the ambient publish must resolve the app whose request is running, \
+         not the process-global bus the later-built app installed — the \
+         task-local scope is what makes that true"
+    );
+}
+
+// ── WebhookReplayCleanupLayer ───────────────────────────────────────────────
+
+/// The webhook replay-key task-local must be installed for every request, so
+/// `SignedWebhook`'s extractor can register the keys it inserts and the layer
+/// can release them if the handler fails.
+///
+/// Asserted through the layer's observable effect rather than by reading the
+/// task-local directly: a handler that succeeds must leave the request's
+/// response untouched, and a `5xx` must still be delivered to the client after
+/// the release work runs (the branch that is the only remaining allocation in
+/// this middleware).
+#[get("/boom")]
+async fn boom() -> Result<&'static str, autumn_web::AutumnError> {
+    Err(autumn_web::AutumnError::internal_server_error_msg(
+        "deliberate failure",
+    ))
+}
+
+#[tokio::test]
+async fn webhook_replay_cleanup_passes_both_success_and_server_error_through() {
+    let client = TestApp::new().routes(routes![ping, boom]).build();
+
+    client.get("/ping").send().await.assert_status(200);
+
+    // The 5xx path is the one that takes the release branch. Whatever it does
+    // with replay keys, the client must still receive the response.
+    let response = client.get("/boom").send().await;
+    response.assert_status(500);
+    assert!(
+        response.header("x-request-id").is_some(),
+        "the 500 must still carry the framework's response headers after the \
+         replay-key release branch runs; headers = {:?}",
+        response.headers
+    );
+}

--- a/autumn/tests/integration/mcp_endpoint.rs
+++ b/autumn/tests/integration/mcp_endpoint.rs
@@ -1254,7 +1254,7 @@ async fn proxy_resolved_same_origin_is_allowed() {
 
 #[tokio::test]
 async fn untrusted_host_is_rejected_even_without_origin() {
-    // Parity with normal routes' `trusted_host_middleware`: a request whose Host
+    // Parity with normal routes' `TrustedHostService`: a request whose Host
     // isn't trusted is refused (400) even when it carries no `Origin` (so the
     // DNS-rebinding Origin check is skipped). Without this gate a no-`Origin`
     // agent could call `initialize`/`tools/list` with an arbitrary Host and
@@ -1280,7 +1280,7 @@ async fn untrusted_host_is_rejected_even_without_origin() {
 async fn http2_authority_without_host_header_is_honored() {
     // An HTTP/2 client carries the target host in the request URI `:authority`
     // and may omit the `Host` header. The endpoint must resolve the host from
-    // the URI authority — exactly as `trusted_host_middleware` does for direct
+    // the URI authority — exactly as `TrustedHostService` does for direct
     // routes — instead of treating it as a missing host and 400'ing a trusted
     // authority. (`resolve_client_host` only consults the `Host` header, so
     // `ResolvedClientIdentity.host` is `None` here and the authority fallback is

--- a/autumn/tests/integration/middleware_stack_depth.rs
+++ b/autumn/tests/integration/middleware_stack_depth.rs
@@ -32,9 +32,17 @@
 //! What that integer counts is **every service above the probe that clones on
 //! call**, which is the `Route` box levels *plus* each
 //! `axum::middleware::from_fn` (its generated `Service::call` starts with
-//! `self.inner.clone()`). Collapsing `Router::layer` calls removes box levels;
-//! it does not remove `from_fn` traversals. So the number moves with both, and
-//! a new `from_fn` inside an existing tuple raises it without adding a box.
+//! `self.inner.clone()`) *plus* every hand-rolled service that has to clone its
+//! inner to move it into a boxed future. Collapsing `Router::layer` calls
+//! removes box levels; it does not remove clone-on-call traversals. So the
+//! number moves with both, and a new `from_fn` inside an existing tuple raises
+//! it without adding a box.
+//!
+//! Since #2214 that second half is also a proxy for a *heap allocation*: a
+//! service clones its inner precisely when it needs to own it inside a
+//! `Box::pin`ned future, which is the per-request allocation #2214 measured at
+//! 19.6% of all bytes. A service with a named `pin_project!` future neither
+//! clones nor boxes, so both costs leave together and this gate sees it.
 //!
 //! The probe is attached to a `MethodRouter` in a merged raw router, which
 //! `mount_raw_routers` mounts *after* `build_router_pre_state` has already
@@ -48,17 +56,22 @@
 //! The measured integer decomposes as **D + C**. *D* counts `Route` box levels
 //! above the probe: one per `Router::layer` call applied above it, plus one for
 //! the base `Route` box the leaf `MethodRouter` is stored in. *C* counts the
-//! clone-on-call services above the probe (each `from_fn`). Only *D* moves when
-//! `Router::layer` calls are collapsed; only *C* moves with the enabled Cargo
-//! features. `cargo test -p autumn-web` builds the 8 default features and
-//! measures **16** (D = 8, C = 8), while CI's `cargo test --workspace` unifies
-//! ~29 features across the workspace — `oauth2` (enabled by `examples/blog`)
-//! adds its HTTP-interceptor `from_fn` for **17** (D = 8, C = 9).
+//! clone-on-call services above the probe. Only *D* moves when `Router::layer`
+//! calls are collapsed; *C* moves with the enabled Cargo features and with how
+//! each middleware is written.
 //!
-//! Because *C* is feature-dependent, the assertion has to be a window rather
-//! than an equality; its ceiling is derived from the widest *predicted*
-//! configuration, not the widest current one, so the gate fails on the way back
-//! up. See [`INGRESS_TRAVERSAL_WINDOW`] for the arithmetic.
+//! Before #2214, `cargo test -p autumn-web` (the 8 default features) measured
+//! **13** (D = 5, C = 8) and CI's `cargo test --workspace` — which unifies ~29
+//! features across the workspace — measured **14**, because `oauth2` (enabled
+//! by `examples/blog`) contributed an extra HTTP-interceptor `from_fn`. #2214
+//! converted that interceptor along with the always-on `from_fn`s, so both
+//! configurations now measure **9** (D = 5, C = 4).
+//!
+//! The assertion is still a window rather than an equality: a feature not
+//! enabled anywhere in this workspace could reintroduce the spread, and the
+//! ceiling is derived from the widest *predicted* configuration rather than the
+//! widest current one, so the gate fails on the way back up. See
+//! [`INGRESS_TRAVERSAL_WINDOW`] for the arithmetic.
 //!
 //! The lower bound matters too. Without it, a refactor that mounted merged raw
 //! routers *after* the middleware — which is exactly how `/mcp` is treated —
@@ -146,22 +159,53 @@ async fn unused() -> &'static str {
 /// | CI workspace-unified features, before #2198 | 8 | 9 | **17** |
 /// | default features, after #2198 | 5 | 8 | **13** |
 /// | CI workspace-unified features, after #2198 | 5 | 9 | **14** |
+/// | default features, after #2214 | 5 | 4 | **9** |
+/// | CI workspace-unified features, after #2214 | 5 | 4 | **9** |
 ///
 /// #2198 removes three box levels by folding `apply_middleware`'s four
 /// remaining `Router::layer` calls — the inner group, the middle group, the
 /// session layer, and the outer group — into a single nested-tuple call.
 ///
-/// **Upper bound 15** = the widest predicted configuration (14) plus one, so
-/// restoring even ONE of the collapsed `.layer()` calls — which puts the
-/// measurement straight back to 16-17 — fails this gate.
+/// #2214 then removes four of the eight clone-on-call services by converting
+/// every `axum::middleware::from_fn` on the always-on ingress path into a
+/// hand-rolled `tower::Service` with a NAMED future. Four of those conversions
+/// are visible to this probe — `EventAppContextLayer`,
+/// `WebhookReplayCleanupLayer`, `MethodOverrideRejectionLayer`, and
+/// `TrustedHostLayer`. `StartupBarrierLayer` is a fifth, but `apply_startup_barrier`
+/// is production-only (`TestApp::build` mirrors just its two response-side
+/// fallbacks), so it never entered this count in the first place;
+/// `AssetCacheControlLayer` is a sixth, applied *before* the probe's mount
+/// point and therefore also outside it. Each conversion removes both a
+/// clone-on-call traversal (`FromFn::call` opens with `self.inner.clone()`) and
+/// the `Box::pin` `from_fn` wraps its otherwise-unnameable future in — the
+/// allocation #2214 is actually about. The *feature*-dependence of *C*
+/// disappears with them: `oauth2`'s HTTP-interceptor `from_fn` is converted
+/// too, so the default and workspace-unified measurements now agree.
 ///
-/// **Lower bound 6** is a sentinel, not a budget. It sits well under the
-/// `from_fn` floor (C alone is 8-9, so no legitimate composition of the current
-/// stack can reach it) and well above the 1-3 a probe measures once it has
-/// fallen out of the framework stack entirely — the failure mode described in
-/// the module header. It is deliberately slack: tightening it toward the real
-/// measurement would make every feature-set difference a failure without
-/// catching anything the ceiling does not already catch.
+/// **Upper bound 9** is the measurement itself, not the measurement plus slack.
+/// Before #2214 this bound carried a `+1` of headroom to absorb the feature
+/// spread — and that headroom is exactly what made the gate blind to the
+/// regression it is named for, since restoring one `from_fn` inside an existing
+/// tuple, or one collapsed `Router::layer` call, moves the number by exactly
+/// one. With `oauth2`'s interceptor converted there is no spread left to
+/// absorb: 9 was measured under the 8 default features AND under a
+/// 13-feature build adding `oauth2`, `mail`, `storage`, `ws` and `openapi`.
+/// So the bound is set to the measurement, and either regression fails it.
+///
+/// If a feature this workspace does not currently enable ever contributes a
+/// tenth traversal, this gate will fail on it. That is the intended outcome:
+/// identify the clone-on-call service the feature adds, convert it the way
+/// #2214 converted the rest, or widen the window deliberately with the
+/// measurement written down here — do not nudge the bound to make a red run
+/// green.
+///
+/// **Lower bound 6** is a sentinel, not a budget. It sits under the current
+/// floor (five box levels plus the four remaining clone-on-call services) and
+/// well above the 1-3 a probe measures once it has fallen out of the framework
+/// stack entirely — the failure mode described in the module header. It is
+/// deliberately slack: tightening it toward the real measurement would make
+/// every feature-set difference a failure without catching anything the ceiling
+/// does not already catch.
 ///
 /// # What this gate is blind to
 ///
@@ -178,8 +222,13 @@ async fn unused() -> &'static str {
 /// That is why the fix for #2198 collapses `Router::layer` calls — which
 /// deletes whole box levels — rather than erasing layer types, and why a future
 /// change that lowers this number by erasure must be judged on allocation
-/// counts instead of on this gate.
-const INGRESS_TRAVERSAL_WINDOW: std::ops::RangeInclusive<usize> = 6..=15;
+/// counts instead of on this gate. #2214's conversions are judged that way too:
+/// `per_request_allocations_stay_under_the_ceiling` and
+/// `per_request_allocated_bytes_stay_under_the_ceiling` in
+/// `tests/config_alloc_gate.rs` pin the blocks and bytes a request actually
+/// allocates, which is what a `from_fn` box costs and what this count can only
+/// stand proxy for.
+const INGRESS_TRAVERSAL_WINDOW: std::ops::RangeInclusive<usize> = 6..=9;
 
 /// Build the production router with a clone-counting probe at the innermost
 /// position, drive one request through it, and return the traversal count.
@@ -262,10 +311,17 @@ async fn ingress_stack_depth_stays_within_budget() {
     assert!(
         traversals <= *INGRESS_TRAVERSAL_WINDOW.end(),
         "a single request deep-cloned the ingress stack {traversals} times \
-         (max {}). Expected 13 on the default feature set and 14 under CI's \
-         workspace-unified features; 16-17 is the pre-#2198 measurement, i.e. \
-         one of the four collapsed `Router::layer` calls in `apply_middleware` \
-         is back. Every `Router::layer` call boxes the whole downstream stack in \
+         (max {}). Expected exactly 9 on every feature set. 10 means one more \
+         clone-on-call service or one more `Router::layer` call than the \
+         stack is supposed to have; 13-14 is the pre-#2214 \
+         measurement, i.e. an `axum::middleware::from_fn` is back on the \
+         always-on ingress path — each one clones the whole stack beneath it \
+         AND heap-allocates a `Box::pin` for its own future on every request \
+         (issue #2214); write a `tower::Service` with a named future instead, \
+         the way `TrustedHostLayer` and `StartupBarrierLayer` do. 16-17 is the \
+         pre-#2198 measurement, i.e. one of the four collapsed `Router::layer` \
+         calls in `apply_middleware` is back. Every `Router::layer` call boxes \
+         the whole downstream stack in \
          a `BoxCloneSyncService`, and axum clones that box on each call — so the \
          per-request cost is quadratic in the number of `.layer()` calls (issues \
          #2193, #2198). Compose the layers into one \
@@ -283,8 +339,8 @@ async fn ingress_stack_depth_stays_within_budget() {
     assert!(
         traversals >= *INGRESS_TRAVERSAL_WINDOW.start(),
         "the probe saw only {traversals} traversals (min {}), which is below the \
-         `from_fn` floor of the current stack (the clone-on-call services alone \
-         account for 8-9) and means the probe is no longer inside the \
+         floor of the current stack (five box levels alone account for it) and \
+         means the probe is no longer inside the \
          framework's ingress stack — so this gate is measuring nothing. Check \
          that `mount_raw_routers` still runs BEFORE `apply_middleware`; if \
          merged routers moved after it (the way `/mcp` is mounted), this test \

--- a/autumn/tests/integration/mod.rs
+++ b/autumn/tests/integration/mod.rs
@@ -108,6 +108,7 @@ mod i18n_integration;
 mod idempotency_middleware;
 #[cfg(feature = "inbound-mail")]
 mod inbound_mail_integration;
+mod ingress_named_futures;
 mod inline_broadcast_prefetch;
 mod inspector_integration;
 mod isr_coordination;

--- a/scripts/check-panic-gate.sh
+++ b/scripts/check-panic-gate.sh
@@ -134,8 +134,10 @@ REQUEST_PATH_MODULES=(
 
 # The manifest may grow, never shrink. Deleting a gated module is a deliberate
 # act that has to move this number too, so a silent `git revert` of an entry
-# cannot quietly shrink the gate's surface.
-MODULE_COUNT_FLOOR=43
+# cannot quietly shrink the gate's surface. It tracks the manifest's length, so
+# it moves with every addition too — otherwise a one-entry revert would shrink
+# the manifest back under the floor while the gate still passed.
+MODULE_COUNT_FLOOR=44
 
 # Gated modules whose feature is KNOWINGLY not enabled by any enforcing CI clippy
 # lane, as `<path>:<feature>`. Their headers are real but unenforced: the deny

--- a/scripts/check-panic-gate.sh
+++ b/scripts/check-panic-gate.sh
@@ -114,6 +114,7 @@ REQUEST_PATH_MODULES=(
   autumn/src/middleware/maintenance.rs:default
   autumn/src/middleware/error_page_filter.rs:default
   autumn/src/middleware/load_shed.rs:default
+  autumn/src/middleware/short_circuit.rs:default
   autumn/src/capsule/capture.rs:reporting
   autumn/src/capsule/wire.rs:db
   autumn/src/capsule/record_db.rs:db


### PR DESCRIPTION
Closes #2214.

## The cost

`axum::middleware::from_fn` cannot avoid a heap allocation per request. The async block it generates has no nameable type, so `FromFn::call` returns it as `Box::pin(..)` — and it clones its inner service to move it in there, which for an erased `BoxCloneSyncService` is a recursive `clone_box` down the rest of the stack.

DHAT measured those boxes at **19.57% of every byte** the `request_pipeline` benchmark allocated (5,267,600 of 26,918,238 over 650 requests) while being only 2.14% of the blocks — the largest unaddressed allocation cost in the profile, and bigger by bytes than the already-fixed `AppState::clone` finding.

## The change

Every `from_fn` on the framework's always-on ingress path is now a hand-rolled `tower::Service` with a **named** future:

| layer | future |
| --- | --- |
| `AssetCacheControlLayer` | `pin_project!` struct (also drops a per-request `String`) |
| `EventAppContextLayer` | `TaskLocalFuture<AppState, S::Future>` |
| `WebhookReplayCleanupLayer` | `TaskLocalFuture` + a boxed tail only on a failed delivery |
| `MethodOverrideRejectionLayer` | `ShortCircuitFuture` |
| `TrustedHostLayer` | `ShortCircuitFuture` |
| `StartupBarrierLayer` | `ShortCircuitFuture` |
| `RequestTimeoutLayer` | `tokio::time::Timeout<S::Future>` |
| `ReadYourWritesLayer` | `TaskLocalFuture<RequestPin, S::Future>` |
| `HttpInterceptorLayer` (`oauth2`) | `TaskLocalFuture` / passthrough |

Each keeps its behaviour and its exact position in the stack. Three "inspect, then reject or forward" gates share a new `ShortCircuitFuture` in `src/middleware/short_circuit.rs`. `RequestTimeoutLayer` also collapses the duplication `router.rs` used to ask readers to "keep in sync" by hand — both call sites now install the same layer type.

## Measured

The issue's own DHAT recipe, re-run on `benches/request_pipeline.rs` (release, 200 iterations = 650 requests) against this branch **and its base commit on the same machine**, filtering allocation sites whose second stack frame is `FromFn<..>::call` exactly, as the issue specifies:

| | `FromFn::call` `Box::pin` | share of run bytes | marginal blocks/req | marginal bytes/req |
| --- | ---: | ---: | ---: | ---: |
| before | 3,250 blocks / 5,215,600 bytes | 19.80% | 168.8 | 36,826 |
| after | **0 / 0** (0 matching sites) | **0%** | **139.2** | **25,943** |

The before column reproduces the issue's measurement exactly on block count (3,250) and to within 1% on bytes, which is the check that the filter is measuring the same thing the issue did. Overall **−17.5% allocations** and **−29.6% bytes** per request.

The same movement, pinned as a regression gate in the debug profile where it is deterministic run to run:

| metric | before | after | |
| --- | ---: | ---: | --- |
| allocation blocks / request | 172 | **140** | −18.6% |
| allocated bytes / request | 37,819 | **26,030** | −31.2% |
| ingress clone-on-call traversals | 13 | **9** | |

The byte reduction exceeds the 19.57% DHAT attributed to the boxes alone because each `from_fn` also dragged along a deep clone of the stack beneath it via `self.inner.clone()`.

## Deliberately not converted

The tenancy middleware and the rate-limit principal shim both `.await` *before* calling the inner service, so their futures cannot be named without `type_alias_impl_trait`. Both are off by default. `webhook_replay_cleanup` keeps one box, taken only on a `5xx` that actually registered replay keys.

## Gates

Four, so the win cannot erode quietly:

1. **Blocks ceiling** (`tests/config_alloc_gate.rs`) — 146, tight enough that restoring a *single* `from_fn` (7 blocks) fails it. 140 measured under the default 8 features and under a 13-feature build.
2. **Bytes ceiling** — 30,500, derived from the **wider** feature set (27,622), since bytes are feature-sensitive where blocks are not. A ceiling derived from the default-feature number would have left ~3% of room under the set CI actually gates with.
3. **Traversal count** (`middleware_stack_depth.rs`) — window tightened to `6..=9`, the measurement itself. With `oauth2`'s interceptor converted there is no feature spread left to absorb, so the old `+1` of headroom — which made the gate blind to exactly the regression it is named for — is gone.
4. **`type_name` assertions** — none of the converted services may return a `Pin<Box<dyn Future>>` again, plus a size assertion pinning the webhook box to its rare branch.

A control test measures one `from_fn` against the same no-op written as a named-future service, so the ceilings are demonstrably measured on an instrument that can see what they gate.

## Behaviour coverage

New `tests/integration/ingress_named_futures.rs`, plus per-service unit tests for the branches the assembled router cannot reach: the asset-cache-control success path, the webhook release **and cancellation** paths, the read-your-own-writes pin and `Set-Cookie`, and the startup barrier's 503.

## Public API

Nothing moved, with one documented exception: `read_your_writes::middleware` used to `unreachable!()` on `ReadYourWrites::Off` and now debug-asserts and falls back to an **inert** `Off` pin rather than panicking on the request path. `asset_cache_control`, `method_override_rejection_filter` and `webhook_replay_cleanup_middleware` remain exported `async fn`s with identical behaviour, now sharing their decision logic with the layers so the two forms cannot drift.

## Review

Reviewed from five angles (tower/async/pin correctness, behavioural equivalence, security, test quality and perf-claim honesty, API/semver and repo conventions). Findings fixed in this branch include: the timeout future not dropping the cancelled handler at the deadline (`tokio::time::Timeout` does not drop its inner on elapse — a terminal variant restores the `from_fn` drop point); task-local scopes now build the inner future inside `sync_scope`, matching the rule `capsule/capture.rs` documents; the RYW `Off` fallback corrected from the *active* `Request` mode to inert `Off`; the panic-gate manifest entry and its module-count floor; re-derived ceilings; and several stale comments and doc links naming the removed functions.

One automated P1 was declined with evidence: it held that delegating `poll_ready` takes downstream readiness out of the deadline. `axum-0.8.9/src/middleware/from_fn.rs` shows `FromFn::poll_ready` delegated identically (line 279) and `Next::run` calls `inner.call` directly with no readiness poll (line 344), so the sequence is unchanged — and arming the timer before readiness would mean calling a service that has not returned `Poll::Ready`. [Full reply.](https://github.com/autumn-foundation/autumn/pull/2219#discussion_r3792526521)

## Verification

- `cargo fmt --all --check` ✅
- `cargo clippy -p autumn-web --all-targets -- -D warnings` ✅
- `cargo test -p autumn-web --lib` — 4518 passed ✅
- `cargo test -p autumn-web --test config_alloc_gate` — 7 passed ✅
- `cargo test -p autumn-web --test integration_tests` — 1334 passed locally; the one failure (`schema_drift_guard::schema_keys_snapshot_guard`) reproduces on the unmodified base commit and is unrelated. The `compile_fail` trybuild targets were skipped locally for scratch-space reasons and are covered by CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X32HptrYvomdqmiKjsmQkD