### PR TITLE
Close doc/hardening gaps in fake-data seeding (#1343)

### DIFF
--- a/autumn-cli/src/main.rs
+++ b/autumn-cli/src/main.rs
@@ -553,6 +553,9 @@ enum Commands {
     ///
     /// `autumn seed` checks for pending migrations before running and exits 1
     /// if any are found — run `autumn migrate` first.
+    ///
+    /// A `--count`/`--model` fake-seed request against a `prod`/`production`
+    /// profile is blocked unless `--yes-i-mean-prod` is also given.
     Seed {
         /// Profile forwarded to the seed binary via `AUTUMN_ENV`
         /// (default: `dev`).
@@ -571,6 +574,11 @@ enum Commands {
         /// Model to fake rows for (e.g. `Post`). Requires --count.
         #[arg(long, requires = "count")]
         model: Option<String>,
+        /// Confirm generating faked rows (`--count`/`--model`) against a
+        /// `prod`/`production` profile. Required to bypass the production
+        /// guard; has no effect otherwise.
+        #[arg(long)]
+        yes_i_mean_prod: bool,
     },
     /// Replay a recorded failure capsule against the application.
     ///
@@ -3215,7 +3223,14 @@ fn run_command(command: Commands) {
             package,
             count,
             model,
-        } => seed::run(&profile, package.as_deref(), count, model.as_deref()),
+            yes_i_mean_prod,
+        } => seed::run(
+            &profile,
+            package.as_deref(),
+            count,
+            model.as_deref(),
+            yes_i_mean_prod,
+        ),
         Commands::Replay {
             capsule,
             package,
@@ -5675,12 +5690,36 @@ mod tests {
                 package,
                 count,
                 model,
+                yes_i_mean_prod,
             } => {
                 assert_eq!(profile, "dev");
                 assert!(package.is_none());
                 assert!(count.is_none());
                 assert!(model.is_none());
+                assert!(!yes_i_mean_prod);
             }
+            _ => panic!("expected Seed command"),
+        }
+    }
+
+    #[test]
+    fn parse_seed_with_yes_i_mean_prod() {
+        let cli = Cli::try_parse_from([
+            "autumn",
+            "seed",
+            "--count",
+            "200",
+            "--model",
+            "Post",
+            "--profile",
+            "prod",
+            "--yes-i-mean-prod",
+        ])
+        .unwrap();
+        match cli.command {
+            Commands::Seed {
+                yes_i_mean_prod, ..
+            } => assert!(yes_i_mean_prod),
             _ => panic!("expected Seed command"),
         }
     }

--- a/autumn-cli/src/seed.rs
+++ b/autumn-cli/src/seed.rs
@@ -2,7 +2,9 @@
 //!
 //! Delegates to `cargo run --bin seed` after:
 //!   1. Verifying `src/bin/seed.rs` exists.
-//!   2. Checking for pending migrations via the diesel CLI.
+//!   2. Blocking a `--count`/`--model` fake-seed request against a
+//!      `prod`/`production` profile unless `--yes-i-mean-prod` is given.
+//!   3. Checking for pending migrations via the diesel CLI.
 //!
 //! The seed binary receives the active profile through the `AUTUMN_ENV`
 //! environment variable, matching how the rest of the framework resolves
@@ -10,6 +12,8 @@
 
 use std::path::{Path, PathBuf};
 use std::process::Command;
+
+use crate::migrate::is_production_profile_name;
 
 /// Errors surfaced by the seed runner.
 #[derive(Debug, thiserror::Error, PartialEq, Eq)]
@@ -29,6 +33,12 @@ pub enum SeedError {
          to run the project seed binary"
     )]
     IncompleteFakeFlags,
+
+    #[error(
+        "production profile detected; generating faked rows in production requires \
+         explicit confirmation\n  Re-run with --yes-i-mean-prod to proceed."
+    )]
+    ProductionFakeSeedBlocked,
 }
 
 /// Resolve the `--count`/`--model` pair into the fake-seed request, if any.
@@ -51,6 +61,23 @@ fn resolve_fake_request(
 /// Returns `true` if the seed binary source file exists at `path`.
 fn seed_binary_exists_at(path: &Path) -> bool {
     path.is_file()
+}
+
+/// Guard against accidentally mass-inserting faked rows into a production
+/// database. Only fires for an actual fake-seed request (`--count`/`--model`
+/// both given) targeting a `prod`/`production` profile without
+/// `--yes-i-mean-prod` — a plain `autumn seed` (running the project's own
+/// seed binary) is unaffected, matching `autumn migrate`'s existing
+/// production guard scope (see `is_production_profile_name`).
+fn check_production_guard(
+    profile: &str,
+    fake_request: Option<&(usize, String)>,
+    yes_i_mean_prod: bool,
+) -> Result<(), SeedError> {
+    if fake_request.is_some() && is_production_profile_name(profile) && !yes_i_mean_prod {
+        return Err(SeedError::ProductionFakeSeedBlocked);
+    }
+    Ok(())
 }
 
 /// Locate the directory of a Cargo package by name using `cargo metadata`.
@@ -192,7 +219,19 @@ fn check_pending_migrations(database_url: &str, migrations_dir: &str) -> Result<
 /// that many faked rows for the named model instead of running its hand-written
 /// seed body. Supplying only one of the two is an error; supplying neither
 /// preserves the original behavior (run the project seed binary).
-pub fn run(profile: &str, package: Option<&str>, count: Option<usize>, model: Option<&str>) {
+///
+/// A fake-seed request (`--count`/`--model`) targeting a `prod`/`production`
+/// profile is blocked unless `yes_i_mean_prod` is set, mirroring `autumn
+/// migrate`'s production guard — generating hundreds of faked rows in
+/// production by accident (e.g. a copy-pasted `--profile prod`) should require
+/// explicit confirmation, not a typo-away default.
+pub fn run(
+    profile: &str,
+    package: Option<&str>,
+    count: Option<usize>,
+    model: Option<&str>,
+    yes_i_mean_prod: bool,
+) {
     eprintln!("\u{1F342} autumn seed\n");
     eprintln!("  Profile: {profile}");
 
@@ -203,6 +242,10 @@ pub fn run(profile: &str, package: Option<&str>, count: Option<usize>, model: Op
             std::process::exit(1);
         }
     };
+    if let Err(e) = check_production_guard(profile, fake_request.as_ref(), yes_i_mean_prod) {
+        eprintln!("\u{2717} {e}");
+        std::process::exit(1);
+    }
     if let Some((count, model)) = &fake_request {
         // Do not claim the rows were created: this command only *delegates* the
         // request to the project's seed binary (via AUTUMN_SEED_COUNT/MODEL).
@@ -322,6 +365,64 @@ mod tests {
         assert!(
             msg.contains("pending"),
             "error should mention pending migrations, got: {msg}"
+        );
+    }
+
+    // ── check_production_guard (production-fake-seed confirmation) ──────────
+
+    #[test]
+    fn production_guard_blocks_fake_seed_without_confirmation() {
+        let req = Some((200, "Post".to_string()));
+        assert_eq!(
+            check_production_guard("prod", req.as_ref(), false),
+            Err(SeedError::ProductionFakeSeedBlocked)
+        );
+    }
+
+    #[test]
+    fn production_guard_accepts_production_spelling() {
+        let req = Some((200, "Post".to_string()));
+        assert_eq!(
+            check_production_guard("production", req.as_ref(), false),
+            Err(SeedError::ProductionFakeSeedBlocked)
+        );
+    }
+
+    #[test]
+    fn production_guard_is_case_insensitive() {
+        let req = Some((200, "Post".to_string()));
+        assert_eq!(
+            check_production_guard("PROD", req.as_ref(), false),
+            Err(SeedError::ProductionFakeSeedBlocked)
+        );
+    }
+
+    #[test]
+    fn production_guard_allows_fake_seed_with_confirmation() {
+        let req = Some((200, "Post".to_string()));
+        assert_eq!(check_production_guard("prod", req.as_ref(), true), Ok(()));
+    }
+
+    #[test]
+    fn production_guard_allows_non_production_profiles() {
+        let req = Some((200, "Post".to_string()));
+        assert_eq!(check_production_guard("dev", req.as_ref(), false), Ok(()));
+        assert_eq!(check_production_guard("demo", req.as_ref(), false), Ok(()));
+    }
+
+    #[test]
+    fn production_guard_ignores_plain_seed_without_fake_request() {
+        // No --count/--model: running the project's own seed binary against
+        // prod is unaffected by this guard (existing, unrelated behavior).
+        assert_eq!(check_production_guard("prod", None, false), Ok(()));
+    }
+
+    #[test]
+    fn production_fake_seed_blocked_error_mentions_flag() {
+        let msg = SeedError::ProductionFakeSeedBlocked.to_string();
+        assert!(
+            msg.contains("--yes-i-mean-prod"),
+            "error should mention --yes-i-mean-prod, got: {msg}"
         );
     }
 

--- a/autumn/src/fake.rs
+++ b/autumn/src/fake.rs
@@ -17,7 +17,7 @@
 //!   clock, so even timestamps are reproducible.
 //!
 //!   `AUTUMN_FAKE_SEED` is read exactly once, on the first `fake::*` call in
-//!   the process (the RNG lives behind a [`OnceLock`]) — setting or changing
+//!   the process (the RNG lives behind a [`OnceLock`](std::sync::OnceLock)) — setting or changing
 //!   it later in the same process has no effect. This is transparent for the
 //!   `autumn` CLI (always a fresh process) but matters for tests that call
 //!   `std::env::set_var("AUTUMN_FAKE_SEED", ..)` at runtime: call

--- a/autumn/src/fake.rs
+++ b/autumn/src/fake.rs
@@ -15,6 +15,14 @@
 //!   reproducible fixtures. In this mode time-based helpers such as
 //!   [`recent_datetime`](crate::fake::recent_datetime) anchor to a fixed base instant rather than the wall
 //!   clock, so even timestamps are reproducible.
+//!
+//!   `AUTUMN_FAKE_SEED` is read exactly once, on the first `fake::*` call in
+//!   the process (the RNG lives behind a [`OnceLock`]) — setting or changing
+//!   it later in the same process has no effect. This is transparent for the
+//!   `autumn` CLI (always a fresh process) but matters for tests that call
+//!   `std::env::set_var("AUTUMN_FAKE_SEED", ..)` at runtime: call
+//!   [`reseed`](crate::fake::reseed) directly instead, which always takes
+//!   effect immediately.
 //! - **Random**: with no seed configured, the RNG is seeded from OS entropy and
 //!   output varies per run.
 //!

--- a/autumn/src/seed.rs
+++ b/autumn/src/seed.rs
@@ -295,7 +295,26 @@ pub enum FakeSeedError {
         /// The raw `AUTUMN_SEED_COUNT` value that failed to parse.
         value: String,
     },
+
+    /// The `AUTUMN_SEED_COUNT` value exceeds [`MAX_FAKE_SEED_COUNT`], the
+    /// sanity ceiling on a single fake-seed request.
+    #[error("AUTUMN_SEED_COUNT {value} exceeds the maximum of {max} rows per fake-seed request")]
+    CountTooLarge {
+        /// The requested count.
+        value: usize,
+        /// The ceiling it exceeded ([`MAX_FAKE_SEED_COUNT`]).
+        max: usize,
+    },
 }
+
+/// Sanity ceiling on a single `--count`/`AUTUMN_SEED_COUNT` fake-seed request.
+///
+/// Generously above any realistic dev-seeding volume, this exists solely to
+/// turn a mistyped or pasted-wrong count (e.g. an extra digit, or a stray
+/// `usize::MAX`) into a clear [`FakeSeedError::CountTooLarge`] instead of a
+/// `Vec::with_capacity` allocation panic deep inside the generated factory's
+/// `create_many`/`build_many`.
+pub const MAX_FAKE_SEED_COUNT: usize = 1_000_000;
 
 /// The names of every registered faked model, sorted, for diagnostics.
 #[must_use]
@@ -381,6 +400,12 @@ pub async fn maybe_fake_seed(pool: &Pool<RuntimeConnection>) -> Result<bool, Fak
         .trim()
         .parse()
         .map_err(|_| FakeSeedError::InvalidCount { value: count })?;
+    if count > MAX_FAKE_SEED_COUNT {
+        return Err(FakeSeedError::CountTooLarge {
+            value: count,
+            max: MAX_FAKE_SEED_COUNT,
+        });
+    }
     let inserted = fake_seed_model(&model, count, pool).await?;
     println!("Inserted {inserted} faked `{model}` row(s).");
     Ok(true)
@@ -504,6 +529,60 @@ mod tests {
                 );
             },
         );
+    }
+
+    #[test]
+    fn maybe_fake_seed_errors_on_count_above_max() {
+        let pool = lazy_pool();
+        let too_large = (MAX_FAKE_SEED_COUNT + 1).to_string();
+        temp_env::with_vars(
+            [
+                ("AUTUMN_SEED_MODEL", Some("DummyFakeSeederModel")),
+                ("AUTUMN_SEED_COUNT", Some(too_large.as_str())),
+            ],
+            || {
+                let err = futures::executor::block_on(maybe_fake_seed(&pool)).expect_err(
+                    "a count above the sanity ceiling must be a clean error, not a later \
+                     capacity-overflow panic inside create_many/build_many",
+                );
+                assert!(
+                    matches!(err, FakeSeedError::CountTooLarge { .. }),
+                    "expected CountTooLarge, got: {err:?}"
+                );
+            },
+        );
+    }
+
+    #[test]
+    fn maybe_fake_seed_allows_count_at_max() {
+        // The boundary itself (MAX_FAKE_SEED_COUNT exactly) must not be
+        // rejected by the ceiling check — only values strictly above it.
+        // DummyFakeSeederModel's `run` just echoes `count` back without
+        // allocating, so this exercises the guard without a live database.
+        let pool = lazy_pool();
+        let at_max = MAX_FAKE_SEED_COUNT.to_string();
+        temp_env::with_vars(
+            [
+                ("AUTUMN_SEED_MODEL", Some("DummyFakeSeederModel")),
+                ("AUTUMN_SEED_COUNT", Some(at_max.as_str())),
+            ],
+            || {
+                let handled = futures::executor::block_on(maybe_fake_seed(&pool))
+                    .expect("count exactly at the ceiling must be accepted");
+                assert!(handled);
+            },
+        );
+    }
+
+    #[test]
+    fn count_too_large_error_message_reports_value_and_max() {
+        let msg = FakeSeedError::CountTooLarge {
+            value: 5_000_000,
+            max: MAX_FAKE_SEED_COUNT,
+        }
+        .to_string();
+        assert!(msg.contains("5000000"), "got: {msg}");
+        assert!(msg.contains(&MAX_FAKE_SEED_COUNT.to_string()), "got: {msg}");
     }
 
     // ── resolve_profile ────────────────────────────────────────────────────

--- a/docs/guide/seeding.md
+++ b/docs/guide/seeding.md
@@ -107,7 +107,8 @@ autumn seed --profile demo
 1. **Checks that `src/bin/seed.rs` exists.** If it does not, you get a clear
    error:
    ```
-   ✗ no seed binary found; create `src/bin/seed.rs` or run `autumn generate seed`
+   ✗ no seed binary found; create `src/bin/seed.rs`
+   See: https://autumn.rs/guide/seeding
    ```
 
 2. **Checks for pending migrations** (when the `diesel` CLI is available).
@@ -209,13 +210,107 @@ autumn migrate && autumn seed && autumn dev
 
 ---
 
+## Faking realistic volume data
+
+Hand-writing a few fixture rows is fine for a handful of records, but list
+views — pagination, full-text search, sort/filter, CSV export — need
+hundreds of *varied* rows before you can tell whether they actually work.
+Every `#[autumn_web::model]` gets a generated `{Model}Factory` whose
+`.fake()` fills any field you didn't explicitly set with realistic data
+inferred from the field's name and type (an `email` field gets a fake email,
+a `title` gets fake words, a `created_at` gets a recent timestamp, and so
+on).
+
+### One-line faked seed
+
+```rust
+use autumn_web::seed::SeedContext;
+
+#[autumn_web::main]
+async fn main() {
+    let ctx = SeedContext::build().expect("seed context");
+
+    // 200 faked posts, each with distinct fake title/body — enough to
+    // exercise pagination and search.
+    Post::factory().fake().create_many(200, ctx.pool()).await;
+}
+```
+
+`.fake()` never overwrites a field you set explicitly:
+
+```rust
+// `title` stays fixed; every other field is faked.
+Post::factory().title("Pinned announcement").fake().create(&pool).await;
+```
+
+Other factory methods that pair with `.fake()`:
+
+| Method | Description |
+|--------|-------------|
+| `.fake()` / `.fake_all()` | Fill every unset field with a fake value (aliases of each other). |
+| `.build()` | Construct one in-memory instance without persisting it. |
+| `.build_many(n)` | Construct `n` in-memory instances, each faked independently. |
+| `.create(&pool)` | Persist one instance. |
+| `.create_many(n, &pool)` | Persist `n` instances, returning `Vec<Model>`. |
+
+See `examples/bookmarks/src/bin/seed.rs` and its
+[README](../../examples/bookmarks/README.md#seeding-fake-data) for a
+complete working example that populates 200 rows this way.
+
+### The `fake` module directly
+
+`autumn_web::fake` also works standalone, outside a factory, when you want a
+realistic value for one field: `fake::name()`, `fake::username()`,
+`fake::email()`, `fake::word()` / `fake::words(n)` / `fake::sentence()` /
+`fake::paragraph()`, `fake::url()`, `fake::boolean()`,
+`fake::int_range(lo, hi)`, `fake::decimal()`, `fake::recent_datetime()`, and
+`fake::uuid()`.
+
+### Reproducible fake data
+
+Set `AUTUMN_FAKE_SEED` to a `u64` to make every `fake::*` call and every
+`.fake()`-driven factory deterministic — the same sequence of calls always
+produces the same values, which keeps golden-data tests and CI fixtures
+reproducible:
+
+```sh
+AUTUMN_FAKE_SEED=42 autumn seed --count 200 --model Post
+```
+
+Without `AUTUMN_FAKE_SEED` set, output varies from run to run. Tests can
+call `autumn_web::fake::reseed(seed)` directly instead of setting the env
+var.
+
+### Generating rows without editing `src/bin/seed.rs`
+
+`autumn seed --count N --model M` drives a registered model's factory
+directly — generate and insert `N` faked rows for model `M` without touching
+your seed binary at all:
+
+```sh
+autumn seed --count 200 --model Post
+```
+
+`--count` and `--model` must be passed together; passing neither preserves
+the default behavior described above (run `src/bin/seed.rs`). Every
+`#[autumn_web::model]` registers itself automatically, so any scaffolded
+model is reachable this way as soon as it exists — projects generated with
+`autumn new --with-seed` (or a model added via `autumn generate scaffold`)
+already wire their `src/bin/seed.rs` to handle this request via
+`autumn_web::seed::maybe_fake_seed`, so `--count`/`--model` work out of the
+box with no manual edits.
+
+---
+
 ## Out of scope
 
 - **Test fixtures** — use `autumn_web::test` helpers for integration test data.
 - **YAML/JSON/CSV loaders** — author a thin loader inside your seed binary if
   you want declarative fixtures.
-- **Faker / factory libraries** — compose with `fake`, `proptest`, `rand`, or
-  whatever you prefer; Autumn owns the runner, not the data generation.
+- **Relationship-aware faking** — `.fake()` fills scalar fields on a single
+  model; it does not generate a fake foreign key that points at a real seeded
+  parent row. Build the parent first (or set the FK field explicitly) and let
+  `.fake()` fill the rest.
 - **`autumn generate seed`** — tracked in #493 follow-up work.
 
 ---

--- a/docs/guide/seeding.md
+++ b/docs/guide/seeding.md
@@ -308,9 +308,14 @@ box with no manual edits.
 - **YAML/JSON/CSV loaders** — author a thin loader inside your seed binary if
   you want declarative fixtures.
 - **Relationship-aware faking** — `.fake()` fills scalar fields on a single
-  model; it does not generate a fake foreign key that points at a real seeded
-  parent row. Build the parent first (or set the FK field explicitly) and let
-  `.fake()` fill the rest.
+  model; it does not know which rows exist in a parent table, so a foreign-key
+  field left unset gets a plain fake integer (or stays at `Default::default()`
+  without `.fake()`) rather than a valid parent id — either way, inserting
+  without addressing the FK will fail. For a model with a foreign key, either
+  set that field explicitly (`.user_id(id)`) or mark it `#[factory_assoc(Type)]`
+  in the `#[model]` definition so the factory creates (or accepts) a parent
+  automatically; see the `#[factory_assoc]` docs for the associated-model
+  factory pattern.
 - **`autumn generate seed`** — tracked in #493 follow-up work.
 
 ---


### PR DESCRIPTION
## Summary

Investigating #1343 ("Add a fake-data source for factories and bulk seed generation") found that the feature itself is **already fully implemented and released** (CHANGELOG `[0.6.0]`): `autumn_web::fake`, `{Model}Factory::.fake()`/`.fake_all()`/`.build_many()`/`.create_many()`, `AUTUMN_FAKE_SEED` determinism, `autumn seed --count/--model` (with automatic scaffold wiring from #1718), and the `examples/bookmarks` one-line faked seed. All 6 acceptance criteria pass against the shipped code — see the checklist below.

This PR closes the two real gaps a fresh audit turned up:

- **`docs/guide/seeding.md` was stale** — it predated the feature landing, still listed "Faker / factory libraries" under *Out of scope* (contradicting the shipped API), and quoted a since-changed error message. Rewrote it with a full section on `.fake()`, `create_many`, determinism, and `--count`/`--model`, and fixed the error text.
- **Two review-flagged hardening gaps**, found via a 4-angle review (correctness, security, API design, performance) of the shipped implementation:
  - `autumn seed --count N --model M` had no production guard, unlike `autumn migrate`'s `--yes-i-mean-prod`. Added the same guard (reusing `is_production_profile_name`), scoped to fake-seed requests only — plain `autumn seed` is unaffected.
  - `AUTUMN_SEED_COUNT` had no upper bound, so an absurd value crashed with a raw `Vec::with_capacity` allocation panic instead of a clean error. Added `MAX_FAKE_SEED_COUNT` (1,000,000) and `FakeSeedError::CountTooLarge`.
  - Documented the read-once `AUTUMN_FAKE_SEED` semantics and the `#[factory_assoc]` pattern for foreign-key fields more explicitly.

Reviewed-but-not-changed: FK-column faking (issue explicitly defers relationship-aware faking to a follow-up), `reseed()`'s process-global stickiness (by design), registry name collisions on duplicate model names (edge case, no real-world trigger reported), and a few public-API naming nitpicks (`fake_all` alias, `decimal_f64` name) — renaming shipped public API wasn't warranted for this pass.

## Acceptance criteria

| # | Criterion | Status | Evidence |
|---|---|---|---|
| 1 | `fake` module: name/username/email/word(s)/sentence/paragraph/url/bool/int_range/decimal/recent DateTime/uuid | ✅ | `autumn/src/fake.rs`; `tests/integration/fake_generators.rs` (11 tests, all passing) |
| 2 | `.fake()`/`.fake_all()` fills unset fields via name→type inference; explicit fields never overwritten | ✅ | `autumn-macros/src/model.rs` (`fake_expr_core`, `fake_string_expr`, `__autumn_set`); `tests/integration/factory_fake.rs` (`fake_fills_unset_fields`, `explicit_override_wins_over_fake`, `explicit_override_regardless_of_call_order`, `fake_all_is_an_alias_for_fake`) |
| 3 | `create_many` persists many records, distinct PKs, varied fields | ✅ | `model.rs` `create_many`/`build_many`; `build_many_with_fake_varies` (passing), `create_many_persists_distinct_records` (Docker-gated, correctness-verified by source review) |
| 4 | `autumn seed --count N --model M` with no seed.rs edits; absent flags preserve old behavior | ✅ | `autumn-cli/src/seed.rs`, `autumn/src/seed.rs` (`FakeSeeder` registry, `maybe_fake_seed`), scaffold auto-linking (#1718); now also production-guarded (this PR) |
| 5 | Deterministic under `AUTUMN_FAKE_SEED` | ✅ | `autumn/src/fake.rs` (`ChaCha8Rng`, `reseed`); `fake_is_deterministic_under_seed`, `reseed_makes_output_deterministic`, `different_seeds_diverge`, `seeded_rng_is_deterministic_across_threads_and_tasks` |
| 6 | ≥1 example ships a one-line faked seed; docs show 100+ rows | ✅ | `examples/bookmarks/src/bin/seed.rs` (`create_many(200, ...)`); now also `docs/guide/seeding.md` (this PR) |

## Test plan

- [x] `cargo check -p autumn-cli -p autumn-web` — clean
- [x] `cargo clippy -p autumn-cli -p autumn-web --all-targets --features "test-support,seed" -- -D warnings` — clean
- [x] `cargo test -p autumn-cli --bin autumn seed` — 64 passed (includes new production-guard and `--yes-i-mean-prod` parsing tests)
- [x] `cargo test -p autumn-web --lib --features seed seed::` — 19 passed (includes new `MAX_FAKE_SEED_COUNT` boundary tests)
- [x] `cargo test -p autumn-web --test integration_tests --features "test-support,seed" fake_generators` — 11 passed (unaffected)
- [x] `cargo test -p autumn-web --test integration_tests --features "test-support,seed" factory_fake` — 9 passed, 1 Docker-gated ignored (unaffected)

Closes #1343

---
_Generated by [Claude Code](https://claude.ai/code/session_01KRkoQJS6GHcpxU4sQ8zDjT)_