### PR TITLE
🗃️ Ledger: batch PgSyncBackend::apply_push round trips (statements/push 5n+1→6)

### DIFF
--- a/autumn/src/sync/server.rs
+++ b/autumn/src/sync/server.rs
@@ -45,7 +45,7 @@ use axum::routing::{get, post};
 use chrono::{DateTime, Utc};
 use diesel::prelude::*;
 use diesel::sql_query;
-use diesel::sql_types::{BigInt, Bool, Jsonb, Nullable, Text, Timestamptz};
+use diesel::sql_types::{Array, BigInt, Bool, Jsonb, Nullable, Text, Timestamptz};
 
 use super::SyncError;
 use super::protocol::{
@@ -956,10 +956,14 @@ struct PgVersionRecord {
     version: i64,
 }
 
-/// Dedup-record row: originally assigned version plus the resolved-row
-/// snapshot for `Resolved` outcomes (see [`AppliedRecord`]).
+/// Dedup-record row: the `change_id` it answers for (batched lookups return
+/// one row per matched `change_id`, so the caller needs it to key the result
+/// back to the change), plus the originally assigned version and the
+/// resolved-row snapshot for `Resolved` outcomes (see [`AppliedRecord`]).
 #[derive(QueryableByName)]
 struct PgAppliedRecord {
+    #[diesel(sql_type = Text)]
+    change_id: String,
     #[diesel(sql_type = BigInt)]
     version: i64,
     #[diesel(sql_type = Nullable<Jsonb>)]
@@ -984,20 +988,44 @@ struct PgSequenceRecord {
     is_called: bool,
 }
 
-fn pg_upsert_row<C>(
+/// Upsert every row in `stored` in ONE round trip via `UNNEST`-driven
+/// multi-row `INSERT … ON CONFLICT`, instead of one `INSERT` per row.
+///
+/// Callers must pass at most one entry per `(collection, pk)` — a single
+/// `INSERT … ON CONFLICT` statement cannot affect the same conflict target
+/// twice (Postgres raises "ON CONFLICT DO UPDATE command cannot affect row a
+/// second time"). [`SyncBackend::apply_push`] satisfies this by keeping only
+/// the LAST decided state per key in its `current` map before calling here.
+fn pg_upsert_rows<'a, C>(
     conn: &mut C,
     scope: &str,
-    stored: &ServerRow,
+    stored: impl Iterator<Item = &'a ServerRow>,
 ) -> Result<(), diesel::result::Error>
 where
     C: diesel::connection::LoadConnection<Backend = diesel::pg::Pg>,
 {
-    let row = &stored.row;
+    let stored: Vec<&ServerRow> = stored.collect();
+    if stored.is_empty() {
+        return Ok(());
+    }
+    let collections: Vec<&str> = stored.iter().map(|s| s.row.collection.as_str()).collect();
+    let pks: Vec<&str> = stored.iter().map(|s| s.row.pk.as_str()).collect();
+    let payloads: Vec<Option<serde_json::Value>> =
+        stored.iter().map(|s| s.row.payload.clone()).collect();
+    let versions: Vec<i64> = stored.iter().map(|s| s.row.version).collect();
+    let deleteds: Vec<bool> = stored.iter().map(|s| s.row.deleted).collect();
+    let updated_ats: Vec<DateTime<Utc>> = stored.iter().map(|s| s.row.updated_at).collect();
+    let device_ids: Vec<&str> = stored.iter().map(|s| s.row.device_id.as_str()).collect();
+    let created_versions: Vec<i64> = stored.iter().map(|s| s.created_version).collect();
+
     sql_query(
         "INSERT INTO autumn_sync_rows \
          (scope, collection, pk, payload, version, deleted, updated_at, device_id, \
           created_version) \
-         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9) \
+         SELECT $1, t.* FROM UNNEST( \
+           $2::text[], $3::text[], $4::jsonb[], $5::bigint[], $6::bool[], $7::timestamptz[], \
+           $8::text[], $9::bigint[] \
+         ) AS t(collection, pk, payload, version, deleted, updated_at, device_id, created_version) \
          ON CONFLICT (scope, collection, pk) DO UPDATE SET \
          payload = excluded.payload, version = excluded.version, \
          deleted = excluded.deleted, updated_at = excluded.updated_at, \
@@ -1005,25 +1033,69 @@ where
          created_version = excluded.created_version",
     )
     .bind::<Text, _>(scope)
-    .bind::<Text, _>(&row.collection)
-    .bind::<Text, _>(&row.pk)
-    .bind::<Nullable<Jsonb>, _>(&row.payload)
-    .bind::<BigInt, _>(row.version)
-    .bind::<Bool, _>(row.deleted)
-    .bind::<Timestamptz, _>(row.updated_at)
-    .bind::<Text, _>(&row.device_id)
-    .bind::<BigInt, _>(stored.created_version)
+    .bind::<Array<Text>, _>(collections)
+    .bind::<Array<Text>, _>(pks)
+    .bind::<Array<Nullable<Jsonb>>, _>(payloads)
+    .bind::<Array<BigInt>, _>(versions)
+    .bind::<Array<Bool>, _>(deleteds)
+    .bind::<Array<Timestamptz>, _>(updated_ats)
+    .bind::<Array<Text>, _>(device_ids)
+    .bind::<Array<BigInt>, _>(created_versions)
     .execute(conn)
     .map(|_| ())
 }
 
-fn pg_next_version<C>(conn: &mut C) -> Result<Version, diesel::result::Error>
+/// Insert every applied-change dedup record in ONE round trip via
+/// `UNNEST`-driven multi-row `INSERT`, instead of one `INSERT` per change.
+/// `change_id` is batch-unique (`validate_push` rejects repeats), so this
+/// insert can never collide with itself.
+fn pg_insert_applied<C>(
+    conn: &mut C,
+    scope: &str,
+    device_id: &str,
+    records: &[(String, Version, Option<serde_json::Value>)],
+) -> Result<(), diesel::result::Error>
 where
     C: diesel::connection::LoadConnection<Backend = diesel::pg::Pg>,
 {
-    sql_query("SELECT nextval('autumn_sync_version_seq') AS version")
-        .get_result::<PgVersionRecord>(conn)
-        .map(|record| record.version)
+    if records.is_empty() {
+        return Ok(());
+    }
+    let change_ids: Vec<&str> = records.iter().map(|(id, _, _)| id.as_str()).collect();
+    let versions: Vec<i64> = records.iter().map(|(_, version, _)| *version).collect();
+    let resolved_rows: Vec<Option<serde_json::Value>> =
+        records.iter().map(|(_, _, row)| row.clone()).collect();
+    sql_query(
+        "INSERT INTO autumn_sync_applied (scope, device_id, change_id, version, resolved_row) \
+         SELECT $1, $2, t.change_id, t.version, t.resolved_row \
+         FROM UNNEST($3::text[], $4::bigint[], $5::jsonb[]) \
+           AS t(change_id, version, resolved_row)",
+    )
+    .bind::<Text, _>(scope)
+    .bind::<Text, _>(device_id)
+    .bind::<Array<Text>, _>(change_ids)
+    .bind::<Array<BigInt>, _>(versions)
+    .bind::<Array<Nullable<Jsonb>>, _>(resolved_rows)
+    .execute(conn)
+    .map(|_| ())
+}
+
+/// Allocate `n` fresh, unique, monotonically increasing versions in ONE
+/// round trip, instead of one `nextval()` call per change. Ordering across
+/// calls to `next()` on the returned iterator matches the order `nextval()`
+/// would have assigned them one at a time (ascending), so a caller that
+/// consumes them in request order reproduces the old per-change assignment.
+fn pg_next_versions<C>(conn: &mut C, n: usize) -> Result<Vec<Version>, diesel::result::Error>
+where
+    C: diesel::connection::LoadConnection<Backend = diesel::pg::Pg>,
+{
+    if n == 0 {
+        return Ok(Vec::new());
+    }
+    sql_query("SELECT nextval('autumn_sync_version_seq') AS version FROM generate_series(1, $1)")
+        .bind::<BigInt, _>(i64::try_from(n).unwrap_or(i64::MAX))
+        .load::<PgVersionRecord>(conn)
+        .map(|records| records.into_iter().map(|record| record.version).collect())
 }
 
 /// The scope's tombstone GC horizon — `0` when no tombstone of that scope
@@ -1142,6 +1214,25 @@ impl PgSyncBackend {
 }
 
 impl SyncBackend for PgSyncBackend {
+    /// Batches the per-change round trips into a fixed number of statements
+    /// for the whole push, independent of `request.changes.len()`: one dedup
+    /// lookup, one `FOR UPDATE` row fetch, one version-sequence draw, one
+    /// row upsert, one dedup-record insert — instead of five per change (see
+    /// `docs/perf/sync-push-batching/` for the profile). `apply_change_row`
+    /// (the conflict-arm policy) is untouched and still runs once per
+    /// change, in request order, against the SAME inputs it always got —
+    /// only how those inputs are fetched changed.
+    ///
+    /// A pk touched more than once in one batch (two queued local edits, or
+    /// a create immediately followed by an edit, before either was ever
+    /// synced) still needs SEQUENTIAL semantics: the second change must see
+    /// the first's outcome as its `current` row, exactly as the old
+    /// same-transaction re-`SELECT … FOR UPDATE` would (Postgres read-your-
+    /// own-writes). Here that carry-forward is an in-memory map, seeded once
+    /// from a single batched fetch and updated after each change is decided
+    /// — so the loop below still runs sequentially in request order, it just
+    /// never talks to Postgres inside the loop.
+    #[allow(clippy::too_many_lines)] // one linear batching algorithm, clearest unsplit
     fn apply_push(
         &self,
         scope: &str,
@@ -1161,24 +1252,93 @@ impl SyncBackend for PgSyncBackend {
                 // GC serializes on the same advisory lock, so it cannot move
                 // mid-transaction.
                 let horizon = pg_horizon(conn, scope)?;
-                let mut outcomes = Vec::with_capacity(request.changes.len());
-                for change in &request.changes {
-                    let duplicate = sql_query(
-                        "SELECT version, resolved_row FROM autumn_sync_applied \
-                     WHERE scope = $1 AND device_id = $2 AND change_id = $3",
+
+                // 1. Batch dedup check: every change_id in one round trip.
+                // `validate_push` already rejected repeats within the batch,
+                // so this is a plain equality lookup against EARLIER pushes.
+                let change_ids: Vec<&str> = request
+                    .changes
+                    .iter()
+                    .map(|c| c.change_id.as_str())
+                    .collect();
+                let applied: HashMap<String, PgAppliedRecord> = if change_ids.is_empty() {
+                    HashMap::new()
+                } else {
+                    sql_query(
+                        "SELECT change_id, version, resolved_row FROM autumn_sync_applied \
+                         WHERE scope = $1 AND device_id = $2 AND change_id = ANY($3)",
                     )
                     .bind::<Text, _>(scope)
                     .bind::<Text, _>(&request.device_id)
-                    .bind::<Text, _>(&change.change_id)
-                    .get_result::<PgAppliedRecord>(conn)
-                    .optional()?;
-                    if let Some(record) = duplicate {
+                    .bind::<Array<Text>, _>(&change_ids)
+                    .load::<PgAppliedRecord>(conn)?
+                    .into_iter()
+                    .map(|record| (record.change_id.clone(), record))
+                    .collect()
+                };
+
+                // 2. Batch current-row fetch (FOR UPDATE): one round trip
+                // for every DISTINCT (collection, pk) among changes that
+                // will actually apply — a dedup hit never touches
+                // autumn_sync_rows, same as before.
+                let mut to_apply_keys: Vec<(&str, &str)> = Vec::new();
+                let mut seen_keys = std::collections::HashSet::new();
+                for change in &request.changes {
+                    if applied.contains_key(&change.change_id) {
+                        continue;
+                    }
+                    if seen_keys.insert((change.collection.as_str(), change.pk.as_str())) {
+                        to_apply_keys.push((change.collection.as_str(), change.pk.as_str()));
+                    }
+                }
+                let mut current: HashMap<(String, String), ServerRow> = if to_apply_keys.is_empty()
+                {
+                    HashMap::new()
+                } else {
+                    let collections: Vec<&str> = to_apply_keys.iter().map(|(c, _)| *c).collect();
+                    let pks: Vec<&str> = to_apply_keys.iter().map(|(_, p)| *p).collect();
+                    sql_query(
+                        "SELECT collection, pk, payload, version, deleted, updated_at, device_id, \
+                         created_version \
+                         FROM autumn_sync_rows \
+                         WHERE scope = $1 AND (collection, pk) IN ( \
+                           SELECT * FROM UNNEST($2::text[], $3::text[]) \
+                         ) FOR UPDATE",
+                    )
+                    .bind::<Text, _>(scope)
+                    .bind::<Array<Text>, _>(&collections)
+                    .bind::<Array<Text>, _>(&pks)
+                    .load::<PgRowRecord>(conn)?
+                    .into_iter()
+                    .map(|record| {
+                        (
+                            (record.collection.clone(), record.pk.clone()),
+                            record.into_server_row(),
+                        )
+                    })
+                    .collect()
+                };
+
+                // 3. Batch version allocation: exactly one nextval() per
+                // change that will actually apply — a dedup hit burns no
+                // version, same as before (`pg_next_version` was called
+                // AFTER the dedup `continue`).
+                let to_apply_count = request.changes.len().saturating_sub(applied.len());
+                let mut versions = pg_next_versions(conn, to_apply_count)?.into_iter();
+
+                // 4. Decide every change's outcome in memory (pure — see
+                // above), then batch-write.
+                let mut outcomes = Vec::with_capacity(request.changes.len());
+                let mut to_record: Vec<(String, Version, Option<serde_json::Value>)> =
+                    Vec::with_capacity(to_apply_count);
+                for change in &request.changes {
+                    if let Some(record) = applied.get(&change.change_id) {
                         // Replay the ORIGINAL outcome: a Resolved result must
                         // come back as the same Resolved row, not a
                         // clean-looking AlreadyApplied ack (see AppliedRecord).
-                        outcomes.push(match record.resolved_row {
+                        outcomes.push(match &record.resolved_row {
                             Some(value) => ChangeOutcome::Resolved {
-                                row: serde_json::from_value(value).map_err(|e| {
+                                row: serde_json::from_value(value.clone()).map_err(|e| {
                                     diesel::result::Error::DeserializationError(e.into())
                                 })?,
                             },
@@ -1189,37 +1349,36 @@ impl SyncBackend for PgSyncBackend {
                         continue;
                     }
 
-                    let current = sql_query(
-                        "SELECT collection, pk, payload, version, deleted, updated_at, device_id, \
-                     created_version \
-                     FROM autumn_sync_rows \
-                     WHERE scope = $1 AND collection = $2 AND pk = $3 FOR UPDATE",
-                    )
-                    .bind::<Text, _>(scope)
-                    .bind::<Text, _>(&change.collection)
-                    .bind::<Text, _>(&change.pk)
-                    .get_result::<PgRowRecord>(conn)
-                    .optional()?
-                    .map(PgRowRecord::into_server_row);
-
-                    let version = pg_next_version(conn)?;
-                    // The conflict-arm policy is the shared apply_change_row —
-                    // one authoritative copy for both backends.
+                    let Some(version) = versions.next() else {
+                        return Err(diesel::result::Error::QueryBuilderError(Box::new(
+                            std::io::Error::other(
+                                "apply_push: version pool exhausted (internal invariant \
+                                 violated — to_apply_count must equal the number of \
+                                 non-duplicate changes)",
+                            ),
+                        )));
+                    };
+                    let key = (change.collection.clone(), change.pk.clone());
+                    // The conflict-arm policy is the shared apply_change_row
+                    // — one authoritative copy for both backends. `current`
+                    // reflects any EARLIER change in this same batch to the
+                    // same key (inserted below), exactly like the old
+                    // re-SELECT would have.
                     let (stored, clean) = apply_change_row(
                         change,
                         &request.device_id,
-                        current.as_ref(),
+                        current.get(&key),
                         horizon,
                         resolver,
                         version,
                     );
-                    pg_upsert_row(conn, scope, &stored)?;
                     let outcome = if clean {
                         ChangeOutcome::Applied { version }
                     } else {
-                        ChangeOutcome::Resolved { row: stored.row }
+                        ChangeOutcome::Resolved {
+                            row: stored.row.clone(),
+                        }
                     };
-
                     let resolved_row = match &outcome {
                         ChangeOutcome::Resolved { row } => Some(
                             serde_json::to_value(row)
@@ -1227,19 +1386,21 @@ impl SyncBackend for PgSyncBackend {
                         ),
                         _ => None,
                     };
-                    sql_query(
-                        "INSERT INTO autumn_sync_applied \
-                     (scope, device_id, change_id, version, resolved_row) \
-                     VALUES ($1, $2, $3, $4, $5)",
-                    )
-                    .bind::<Text, _>(scope)
-                    .bind::<Text, _>(&request.device_id)
-                    .bind::<Text, _>(&change.change_id)
-                    .bind::<BigInt, _>(version)
-                    .bind::<Nullable<Jsonb>, _>(resolved_row)
-                    .execute(conn)?;
+                    to_record.push((change.change_id.clone(), version, resolved_row));
+                    // A pk written twice in this batch keeps only its LAST
+                    // value here — the same end state the old sequential
+                    // per-change UPSERTs left, just decided once instead of
+                    // written twice.
+                    current.insert(key, stored);
                     outcomes.push(outcome);
                 }
+
+                // 5. Batch-write: one UPSERT for the final state of every
+                // touched row, one INSERT for every applied change's dedup
+                // record.
+                pg_upsert_rows(conn, scope, current.values())?;
+                pg_insert_applied(conn, scope, &request.device_id, &to_record)?;
+
                 Ok(PushResponse { outcomes })
             })
             .map_err(backend_err)

--- a/autumn/src/sync/server.rs
+++ b/autumn/src/sync/server.rs
@@ -1085,6 +1085,14 @@ where
 /// calls to `next()` on the returned iterator matches the order `nextval()`
 /// would have assigned them one at a time (ascending), so a caller that
 /// consumes them in request order reproduces the old per-change assignment.
+///
+/// The `ORDER BY gs.ord` is load-bearing, not cosmetic: a plain `SELECT`
+/// over a `FROM` clause has no guaranteed row order without it, so nothing
+/// would otherwise pin "first row back" to "first `nextval()` call" — and a
+/// caller that assumes that pairing (as this one does) needs it to be exact
+/// (`nextval()` is `PARALLEL UNSAFE`, so this can't actually be parallelized
+/// today, but the explicit ordinal makes that a documented guarantee rather
+/// than an accident of the current planner).
 fn pg_next_versions<C>(conn: &mut C, n: usize) -> Result<Vec<Version>, diesel::result::Error>
 where
     C: diesel::connection::LoadConnection<Backend = diesel::pg::Pg>,
@@ -1092,10 +1100,14 @@ where
     if n == 0 {
         return Ok(Vec::new());
     }
-    sql_query("SELECT nextval('autumn_sync_version_seq') AS version FROM generate_series(1, $1)")
-        .bind::<BigInt, _>(i64::try_from(n).unwrap_or(i64::MAX))
-        .load::<PgVersionRecord>(conn)
-        .map(|records| records.into_iter().map(|record| record.version).collect())
+    sql_query(
+        "SELECT nextval('autumn_sync_version_seq') AS version \
+         FROM generate_series(1, $1) WITH ORDINALITY AS gs(n, ord) \
+         ORDER BY gs.ord",
+    )
+    .bind::<BigInt, _>(i64::try_from(n).unwrap_or(i64::MAX))
+    .load::<PgVersionRecord>(conn)
+    .map(|records| records.into_iter().map(|record| record.version).collect())
 }
 
 /// The scope's tombstone GC horizon — `0` when no tombstone of that scope

--- a/autumn/tests/integration/mod.rs
+++ b/autumn/tests/integration/mod.rs
@@ -170,6 +170,8 @@ mod offline_sync_engine;
 #[cfg(feature = "offline-sync")]
 mod offline_sync_pg;
 #[cfg(feature = "offline-sync")]
+mod offline_sync_push_batching_perf;
+#[cfg(feature = "offline-sync")]
 mod offline_sync_store;
 #[cfg(feature = "openapi")]
 mod openapi;

--- a/autumn/tests/integration/offline_sync_push_batching_perf.rs
+++ b/autumn/tests/integration/offline_sync_push_batching_perf.rs
@@ -40,6 +40,10 @@
 //! coincidence.
 
 #![cfg(feature = "offline-sync")]
+// Fixture indices/offsets are bounded well under i64::MAX by construction
+// (SEED_ROWS = 20_000, offsets in the low thousands) — every `as i64` here
+// is a fixture-index conversion, never untrusted input.
+#![allow(clippy::cast_possible_wrap)]
 
 use autumn_web::sync::{
     Change, ChangeOutcome, LwwResolver, Op, PgSyncBackend, PushRequest, SyncBackend, SyncScope,
@@ -67,7 +71,7 @@ fn seeded_pk(i: usize) -> String {
 /// here so changes referencing an existing seeded pk use the SAME
 /// `(collection, pk)` key the fixture actually wrote, not a mismatched pair
 /// that reads back as "never existed".
-fn seeded_collection(i: usize) -> &'static str {
+const fn seeded_collection(i: usize) -> &'static str {
     match i % 100 {
         0..=39 => "notes",
         40..=59 => "contacts",
@@ -112,8 +116,10 @@ fn seed_fixture(conn: &mut PgConnection) {
     .expect("advance version sequence past seeded rows");
     // Real dead tuples: supersede 20% of rows' device_id before ANALYZE, the
     // same way a mature (not freshly bulk-loaded) table accumulates them.
-    conn.batch_execute("UPDATE autumn_sync_rows SET device_id = 'seed-device-2' WHERE right(pk, 1) IN ('0', '1')")
-        .expect("create dead tuples");
+    conn.batch_execute(
+        "UPDATE autumn_sync_rows SET device_id = 'seed-device-2' WHERE right(pk, 1) IN ('0', '1')",
+    )
+    .expect("create dead tuples");
     conn.batch_execute("ANALYZE autumn_sync_rows, autumn_sync_applied, autumn_sync_horizons")
         .expect("analyze");
 }
@@ -130,6 +136,7 @@ struct Batch {
 }
 
 #[allow(clippy::arithmetic_side_effects)] // test-only fixture arithmetic on small constants
+#[allow(clippy::too_many_lines)] // one linear fixture builder, clearest unsplit
 fn build_batch(device_id: &str, m: usize, offset: usize) -> Batch {
     // Fixed proportions per the module doc: 65/20/5/8/2, expressed as exact
     // per-size counts (computed once here rather than via integer division
@@ -165,7 +172,7 @@ fn build_batch(device_id: &str, m: usize, offset: usize) -> Batch {
     let mut next_live_idx = || loop {
         let idx = next_idx;
         next_idx += 1;
-        if idx % 20 != 0 {
+        if !idx.is_multiple_of(20) {
             return idx;
         }
     };
@@ -313,7 +320,10 @@ fn assert_clean_outcomes(request: &PushRequest, outcomes: &[ChangeOutcome]) {
                 );
             }
             ChangeOutcome::AlreadyApplied { .. } => {
-                panic!("unexpected AlreadyApplied on a first push: {}", change.change_id);
+                panic!(
+                    "unexpected AlreadyApplied on a first push: {}",
+                    change.change_id
+                );
             }
         }
     }
@@ -437,6 +447,7 @@ fn dump_scope(conn: &mut PgConnection, prefix: &str) -> Vec<RowDump> {
 
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
+#[allow(clippy::too_many_lines)] // one linear profiling script, clearest unsplit
 async fn offline_sync_push_batching_profile() {
     // `shared_preload_libraries` must be set at server start, so it goes on
     // the container command rather than `CREATE EXTENSION` alone — the

--- a/autumn/tests/integration/offline_sync_push_batching_perf.rs
+++ b/autumn/tests/integration/offline_sync_push_batching_perf.rs
@@ -1,0 +1,573 @@
+//! Ledger perf harness for `PgSyncBackend::apply_push` — profiles Postgres
+//! round trips and buffers against a production-shaped fixture, through the
+//! real `SyncBackend::apply_push` entry point (the exact call `server::router`
+//! makes from `POST /push`).
+//!
+//! **Requires Docker.** CI runs it in the Docker-dependent sweep
+//! (`-- --ignored`, see CLAUDE.md). Run manually with:
+//!
+//! ```text
+//! cargo test -p autumn-web --features "test-support,offline-sync" \
+//!   --test integration_tests -- --ignored offline_sync_push_batching_profile --nocapture
+//! ```
+//!
+//! The committed `docs/perf/sync-push-batching/{baseline,after}.txt` files
+//! are this command's stdout, captured before and after the batching change
+//! in `autumn/src/sync/server.rs`.
+//!
+//! ## Fixture
+//!
+//! 20,000 pre-existing rows in one scope: six collections at a realistic
+//! frequency skew (40/20/15/15/7/3%), 5% tombstones, variable-length JSON
+//! payloads (some fields NULL), pks `pk-00000001` .. `pk-00020000`. A
+//! follow-up `UPDATE` on 20% of rows creates real dead tuples before
+//! `ANALYZE`, so the planner sees the same statistics shape a mature table
+//! would have — not the day-one shape of a freshly bulk-loaded table.
+//!
+//! ## Workload
+//!
+//! Three push batches (50 / 250 / 1000 changes — 1000 is
+//! `protocol::MAX_PUSH_CHANGES`) against disjoint slices of the fixture, each
+//! shaped like a device catching up after being offline: 65% edits of
+//! existing rows, 20% new inserts, 5% deletes, 8% two edits of the *same*
+//! existing pk in one batch (queued local edits, both against the last known
+//! server version), 2% two edits of the *same brand-new* pk in one batch
+//! (create-then-edit before ever syncing — the resolver runs on the second).
+//! All timestamps are fixed constants, not wall-clock, so two runs of this
+//! harness against identical code produce byte-identical `PushRequest`s and
+//! byte-identical resulting rows — that determinism is what makes the
+//! before/after row-dump diff in `equivalence` a real proof and not a
+//! coincidence.
+
+#![cfg(feature = "offline-sync")]
+
+use autumn_web::sync::{
+    Change, ChangeOutcome, LwwResolver, Op, PgSyncBackend, PushRequest, SyncBackend, SyncScope,
+};
+use chrono::{DateTime, TimeZone, Utc};
+use diesel::connection::SimpleConnection;
+use diesel::prelude::*;
+use diesel::sql_types::{BigInt, Text};
+use testcontainers::ImageExt;
+use testcontainers::runners::AsyncRunner;
+use testcontainers_modules::postgres::Postgres;
+
+const SCOPE: &str = SyncScope::GLOBAL;
+const SEED_ROWS: usize = 20_000;
+
+fn base_time() -> DateTime<Utc> {
+    Utc.with_ymd_and_hms(2026, 1, 1, 0, 0, 0).unwrap()
+}
+
+fn seeded_pk(i: usize) -> String {
+    format!("pk-{i:08}")
+}
+
+/// The collection `seed_fixture`'s `CASE` assigns index `i` to — mirrored
+/// here so changes referencing an existing seeded pk use the SAME
+/// `(collection, pk)` key the fixture actually wrote, not a mismatched pair
+/// that reads back as "never existed".
+fn seeded_collection(i: usize) -> &'static str {
+    match i % 100 {
+        0..=39 => "notes",
+        40..=59 => "contacts",
+        60..=74 => "tasks",
+        75..=89 => "files",
+        90..=96 => "tags",
+        _ => "archive",
+    }
+}
+
+/// Seed the production-shaped fixture and leave the planner with real
+/// statistics (`ANALYZE`, and real dead tuples from a follow-up `UPDATE`).
+fn seed_fixture(conn: &mut PgConnection) {
+    conn.batch_execute(&format!(
+        "INSERT INTO autumn_sync_rows \
+         (scope, collection, pk, payload, version, deleted, updated_at, device_id, created_version) \
+         SELECT \
+           '{SCOPE}', \
+           CASE WHEN i % 100 < 40 THEN 'notes' \
+                WHEN i % 100 < 60 THEN 'contacts' \
+                WHEN i % 100 < 75 THEN 'tasks' \
+                WHEN i % 100 < 90 THEN 'files' \
+                WHEN i % 100 < 97 THEN 'tags' \
+                ELSE 'archive' END, \
+           'pk-' || lpad(i::text, 8, '0'), \
+           jsonb_build_object( \
+             'title', repeat(md5(i::text), 1 + i % 10), \
+             'n', i, \
+             'note', CASE WHEN i % 7 = 0 THEN NULL ELSE md5((i * 7)::text) END \
+           ), \
+           i, \
+           (i % 20 = 0), \
+           TIMESTAMPTZ '2025-01-01 00:00:00Z' + (i || ' seconds')::interval, \
+           'seed-device', \
+           i \
+         FROM generate_series(1, {SEED_ROWS}) AS i"
+    ))
+    .expect("seed autumn_sync_rows");
+    conn.batch_execute(&format!(
+        "SELECT setval('autumn_sync_version_seq', {SEED_ROWS}, true)"
+    ))
+    .expect("advance version sequence past seeded rows");
+    // Real dead tuples: supersede 20% of rows' device_id before ANALYZE, the
+    // same way a mature (not freshly bulk-loaded) table accumulates them.
+    conn.batch_execute("UPDATE autumn_sync_rows SET device_id = 'seed-device-2' WHERE right(pk, 1) IN ('0', '1')")
+        .expect("create dead tuples");
+    conn.batch_execute("ANALYZE autumn_sync_rows, autumn_sync_applied, autumn_sync_horizons")
+        .expect("analyze");
+}
+
+/// One push batch shaped like a device catching up after being offline,
+/// built from a disjoint slice `[offset+1, offset+need]` of the seeded pk
+/// space so concurrent/sequential batches in the same fixture never touch
+/// the same row.
+struct Batch {
+    request: PushRequest,
+    /// `(index, expect_conflict)` for every existing-pk change, so the
+    /// caller can assert outcomes precisely.
+    existing_indices: Vec<usize>,
+}
+
+#[allow(clippy::arithmetic_side_effects)] // test-only fixture arithmetic on small constants
+fn build_batch(device_id: &str, m: usize, offset: usize) -> Batch {
+    // Fixed proportions per the module doc: 65/20/5/8/2, expressed as exact
+    // per-size counts (computed once here rather than via integer division
+    // at three different `m`, so the split is exact instead of rounded).
+    let (updates_n, inserts_n, deletes_n, dup_existing_pairs, dup_new_pairs) = match m {
+        50 => (30, 10, 4, 2, 1),
+        250 => (160, 50, 12, 10, 4),
+        1000 => (650, 200, 50, 40, 10),
+        _ => unreachable!("fixed batch sizes only"),
+    };
+    assert_eq!(
+        updates_n + inserts_n + deletes_n + dup_existing_pairs * 2 + dup_new_pairs * 2,
+        m,
+        "batch bucket sizes must sum to the batch size"
+    );
+
+    let base = base_time();
+    let mut changes = Vec::with_capacity(m);
+    let mut existing_indices = Vec::new();
+    let mut next_idx = offset + 1;
+    let mut seq = 0u32;
+    let mut next_change_id = || {
+        seq += 1;
+        format!("{device_id}-chg-{seq:06}")
+    };
+    // `seed_fixture` tombstones every 20th index. Skip those here: a change
+    // whose base_version equals a TOMBSTONE's version clean-applies as a
+    // revival and starts a NEW incarnation — correct behavior, but it turns
+    // a same-pk dup pair (see below) into the deterministic
+    // previous-incarnation KeepServer arm instead of the ordinary resolver
+    // path, which the plain-update/delete buckets don't need to model. Live
+    // rows keep every bucket's expected outcome simple and uniform.
+    let mut next_live_idx = || loop {
+        let idx = next_idx;
+        next_idx += 1;
+        if idx % 20 != 0 {
+            return idx;
+        }
+    };
+
+    // 65%: clean edit of an existing row, based on its seeded version.
+    for _ in 0..updates_n {
+        let idx = next_live_idx();
+        existing_indices.push(idx);
+        changes.push(Change {
+            change_id: next_change_id(),
+            collection: seeded_collection(idx).to_owned(),
+            pk: seeded_pk(idx),
+            op: Op::Upsert,
+            payload: Some(serde_json::json!({"edit": "update", "idx": idx})),
+            base_version: idx as i64,
+            updated_at: base + chrono::Duration::seconds(1_000_000 + idx as i64),
+        });
+    }
+    // 20%: brand-new pk, never seen by the server.
+    for k in 0..inserts_n {
+        changes.push(Change {
+            change_id: next_change_id(),
+            collection: "notes".to_owned(),
+            pk: format!("new-{device_id}-{k:06}"),
+            op: Op::Upsert,
+            payload: Some(serde_json::json!({"edit": "insert", "k": k})),
+            base_version: 0,
+            updated_at: base + chrono::Duration::seconds(2_000_000 + k as i64),
+        });
+    }
+    // 5%: delete of an existing row.
+    for _ in 0..deletes_n {
+        let idx = next_live_idx();
+        existing_indices.push(idx);
+        changes.push(Change {
+            change_id: next_change_id(),
+            collection: seeded_collection(idx).to_owned(),
+            pk: seeded_pk(idx),
+            op: Op::Delete,
+            payload: None,
+            base_version: idx as i64,
+            updated_at: base + chrono::Duration::seconds(3_000_000 + idx as i64),
+        });
+    }
+    // 8%: two queued local edits of the SAME existing pk in one batch, both
+    // against the last-known (seeded) server version — the second collides
+    // with the first's freshly-assigned version and the resolver decides.
+    for p in 0..dup_existing_pairs {
+        let idx = next_live_idx();
+        existing_indices.push(idx);
+        let pk = seeded_pk(idx);
+        let collection = seeded_collection(idx).to_owned();
+        changes.push(Change {
+            change_id: next_change_id(),
+            collection: collection.clone(),
+            pk: pk.clone(),
+            op: Op::Upsert,
+            payload: Some(serde_json::json!({"edit": "dup-existing-1", "p": p})),
+            base_version: idx as i64,
+            updated_at: base + chrono::Duration::seconds(4_000_000 + p as i64 * 10),
+        });
+        changes.push(Change {
+            change_id: next_change_id(),
+            collection,
+            pk,
+            op: Op::Upsert,
+            payload: Some(serde_json::json!({"edit": "dup-existing-2", "p": p})),
+            base_version: idx as i64,
+            // Strictly later than the first edit's timestamp: LwwResolver
+            // deterministically picks this (the client / second edit) as
+            // the winner, so the outcome is knowable ahead of time.
+            updated_at: base + chrono::Duration::seconds(4_000_000 + p as i64 * 10 + 5),
+        });
+    }
+    // 2%: create-then-edit of a brand-new pk within the same batch.
+    for p in 0..dup_new_pairs {
+        let pk = format!("newdup-{device_id}-{p:06}");
+        changes.push(Change {
+            change_id: next_change_id(),
+            collection: "notes".to_owned(),
+            pk: pk.clone(),
+            op: Op::Upsert,
+            payload: Some(serde_json::json!({"edit": "dup-new-1", "p": p})),
+            base_version: 0,
+            updated_at: base + chrono::Duration::seconds(5_000_000 + p as i64 * 10),
+        });
+        changes.push(Change {
+            change_id: next_change_id(),
+            collection: "notes".to_owned(),
+            pk,
+            op: Op::Upsert,
+            payload: Some(serde_json::json!({"edit": "dup-new-2", "p": p})),
+            base_version: 0,
+            updated_at: base + chrono::Duration::seconds(5_000_000 + p as i64 * 10 + 5),
+        });
+    }
+
+    assert_eq!(changes.len(), m);
+    Batch {
+        request: PushRequest {
+            device_id: device_id.to_owned(),
+            changes,
+        },
+        existing_indices,
+    }
+}
+
+/// Every outcome for a [`build_batch`] request must be `Applied` (clean
+/// create/update/delete) or `Resolved` (the second half of a dup pair,
+/// always won by the later-`updated_at` write — see `build_batch`), never
+/// `AlreadyApplied` (that only happens on retry, exercised separately by
+/// [`replay_is_idempotent`]).
+fn assert_clean_outcomes(request: &PushRequest, outcomes: &[ChangeOutcome]) {
+    assert_eq!(outcomes.len(), request.changes.len());
+    for (change, outcome) in request.changes.iter().zip(outcomes) {
+        // build_batch tags the second half of every dup pair with an
+        // "edit" payload field ending "-2" — that's the only change in the
+        // batch expected to collide with an earlier change's fresh write.
+        let is_second_of_dup_pair = change
+            .payload
+            .as_ref()
+            .and_then(|p| p.get("edit"))
+            .and_then(|v| v.as_str())
+            .is_some_and(|edit| edit.ends_with("-2"));
+        match outcome {
+            ChangeOutcome::Applied { .. } => {
+                assert!(
+                    !is_second_of_dup_pair,
+                    "expected the second half of a dup pair to conflict (Resolved), \
+                     got Applied for {}",
+                    change.change_id
+                );
+            }
+            ChangeOutcome::Resolved { row } => {
+                assert!(
+                    is_second_of_dup_pair,
+                    "unexpected Resolved outcome for {}",
+                    change.change_id
+                );
+                assert_eq!(
+                    change.payload.as_ref(),
+                    row.payload.as_ref(),
+                    "LwwResolver must pick the later (client/second) write for {}",
+                    change.change_id
+                );
+            }
+            ChangeOutcome::AlreadyApplied { .. } => {
+                panic!("unexpected AlreadyApplied on a first push: {}", change.change_id);
+            }
+        }
+    }
+}
+
+#[derive(QueryableByName, Debug)]
+struct StatementRow {
+    #[diesel(sql_type = Text)]
+    query: String,
+    #[diesel(sql_type = BigInt)]
+    calls: i64,
+    #[diesel(sql_type = BigInt)]
+    buffers: i64,
+}
+
+fn reset_stats(conn: &mut PgConnection) {
+    conn.batch_execute("SELECT pg_stat_statements_reset()")
+        .expect("reset pg_stat_statements");
+}
+
+fn print_profile(conn: &mut PgConnection, label: &str) -> i64 {
+    println!("\n=== pg_stat_statements: {label} ===");
+    let by_calls = diesel::sql_query(
+        "SELECT query, calls, (shared_blks_hit + shared_blks_read) AS buffers \
+         FROM pg_stat_statements \
+         WHERE (query ILIKE '%autumn_sync%' OR query ILIKE '%nextval%' \
+                OR query ILIKE '%generate_series%') \
+           AND query NOT ILIKE '%pg_stat_statements%' \
+         ORDER BY calls DESC LIMIT 10",
+    )
+    .load::<StatementRow>(conn)
+    .expect("query pg_stat_statements by calls");
+    let mut total_calls = 0i64;
+    let mut total_buffers = 0i64;
+    println!("-- top by calls --");
+    for row in &by_calls {
+        total_calls += row.calls;
+        total_buffers += row.buffers;
+        println!(
+            "calls={:<6} buffers={:<6} {}",
+            row.calls,
+            row.buffers,
+            row.query.split_whitespace().collect::<Vec<_>>().join(" ")
+        );
+    }
+    let by_buffers = diesel::sql_query(
+        "SELECT query, calls, (shared_blks_hit + shared_blks_read) AS buffers \
+         FROM pg_stat_statements \
+         WHERE (query ILIKE '%autumn_sync%' OR query ILIKE '%nextval%' \
+                OR query ILIKE '%generate_series%') \
+           AND query NOT ILIKE '%pg_stat_statements%' \
+         ORDER BY buffers DESC LIMIT 10",
+    )
+    .load::<StatementRow>(conn)
+    .expect("query pg_stat_statements by buffers");
+    println!("-- top by buffers --");
+    for row in &by_buffers {
+        println!(
+            "buffers={:<6} calls={:<6} {}",
+            row.buffers,
+            row.calls,
+            row.query.split_whitespace().collect::<Vec<_>>().join(" ")
+        );
+    }
+    println!(
+        "TOTAL sync-table statement calls={total_calls} buffers={total_buffers} (this batch, all statement shapes)"
+    );
+    total_calls
+}
+
+#[derive(QueryableByName, Debug)]
+struct ExplainLine {
+    #[diesel(sql_type = Text, column_name = "QUERY PLAN")]
+    line: String,
+}
+
+fn explain(conn: &mut PgConnection, label: &str, sql: &str) {
+    println!("\n=== EXPLAIN (ANALYZE, BUFFERS, VERBOSE, SETTINGS): {label} ===");
+    println!("{sql}");
+    let lines = diesel::sql_query(format!(
+        "EXPLAIN (ANALYZE, BUFFERS, VERBOSE, SETTINGS) {sql}"
+    ))
+    .load::<ExplainLine>(conn)
+    .expect("explain");
+    for line in lines {
+        println!("{}", line.line);
+    }
+}
+
+/// Dump the full scope, sorted deterministically (`collection, pk` is the
+/// table's primary key suffix — no ties), as the result-equivalence
+/// snapshot: run against baseline and after code with the *same* fixture and
+/// the *same* pushes, this must be byte-identical.
+#[derive(QueryableByName, Debug, PartialEq, Eq)]
+struct RowDump {
+    #[diesel(sql_type = Text)]
+    collection: String,
+    #[diesel(sql_type = Text)]
+    pk: String,
+    #[diesel(sql_type = diesel::sql_types::Nullable<Text>)]
+    payload: Option<String>,
+    #[diesel(sql_type = BigInt)]
+    version: i64,
+    #[diesel(sql_type = diesel::sql_types::Bool)]
+    deleted: bool,
+    #[diesel(sql_type = Text)]
+    device_id: String,
+    #[diesel(sql_type = BigInt)]
+    created_version: i64,
+}
+
+fn dump_scope(conn: &mut PgConnection, prefix: &str) -> Vec<RowDump> {
+    diesel::sql_query(format!(
+        "SELECT collection, pk, payload::text AS payload, version, deleted, device_id, created_version \
+         FROM autumn_sync_rows WHERE scope = '{SCOPE}' AND pk LIKE '{prefix}%' \
+         ORDER BY collection, pk"
+    ))
+    .load::<RowDump>(conn)
+    .expect("dump scope")
+}
+
+#[tokio::test]
+#[ignore = "requires Docker (testcontainers)"]
+async fn offline_sync_push_batching_profile() {
+    // `shared_preload_libraries` must be set at server start, so it goes on
+    // the container command rather than `CREATE EXTENSION` alone — the
+    // module fixes `-c fsync=off`; this overrides the whole cmd, so it's
+    // repeated here to keep container startup fast. Pinned to a current
+    // major version (the module defaults to 11-alpine, which predates
+    // `EXPLAIN (... SETTINGS)`, added in PG12) — 16 matches this host's
+    // installed server.
+    let container = Postgres::default()
+        .with_tag("16-alpine")
+        .with_cmd([
+            "-c",
+            "fsync=off",
+            "-c",
+            "shared_preload_libraries=pg_stat_statements",
+            "-c",
+            "pg_stat_statements.track=all",
+            "-c",
+            "pg_stat_statements.max=2000",
+        ])
+        .start()
+        .await
+        .expect("failed to start postgres container");
+    let host = container.get_host().await.expect("host");
+    let port = container.get_host_port_ipv4(5432).await.expect("port");
+    let url = format!("postgres://postgres:postgres@{host}:{port}/postgres");
+
+    let backend = PgSyncBackend::new(url.clone());
+    backend.ensure_schema().expect("ensure schema");
+
+    let mut conn = PgConnection::establish(&url).expect("db connection");
+    conn.batch_execute("CREATE EXTENSION IF NOT EXISTS pg_stat_statements")
+        .expect("create pg_stat_statements extension");
+
+    seed_fixture(&mut conn);
+
+    let resolver = LwwResolver;
+    let sizes_and_offsets = [(50usize, 0usize), (250, 5_000), (1000, 10_000)];
+    let mut calls_by_size = Vec::new();
+
+    for (size, offset) in sizes_and_offsets {
+        let device_id = format!("device-{size}");
+        let batch = build_batch(&device_id, size, offset);
+        reset_stats(&mut conn);
+        let outcomes = backend
+            .apply_push(SCOPE, &batch.request, &resolver)
+            .expect("apply_push")
+            .outcomes;
+        assert_clean_outcomes(&batch.request, &outcomes);
+        let total_calls = print_profile(&mut conn, &format!("push batch of {size} changes"));
+        calls_by_size.push((size, total_calls));
+
+        // Result-equivalence artifact: dump every row this batch could have
+        // touched (new + newdup pks share the device-scoped prefix; existing
+        // pks are the disjoint offset slice), sorted deterministically.
+        let dump = dump_scope(&mut conn, &format!("new%-{device_id}-"));
+        println!("-- row dump (new/newdup pks), {} rows --", dump.len());
+        for row in &dump {
+            println!("{row:?}");
+        }
+        let existing_dump: Vec<RowDump> = diesel::sql_query(format!(
+            "SELECT collection, pk, payload::text AS payload, version, deleted, device_id, created_version \
+             FROM autumn_sync_rows WHERE scope = '{SCOPE}' AND pk = ANY($1) ORDER BY pk"
+        ))
+        .bind::<diesel::sql_types::Array<Text>, _>(
+            batch
+                .existing_indices
+                .iter()
+                .map(|i| seeded_pk(*i))
+                .collect::<Vec<_>>(),
+        )
+        .load(&mut conn)
+        .expect("dump existing pks");
+        println!(
+            "-- row dump (existing pks touched by this batch), {} rows --",
+            existing_dump.len()
+        );
+        for row in &existing_dump {
+            println!("{row:?}");
+        }
+    }
+
+    println!("\n=== statement-count scaling ===");
+    for (size, calls) in &calls_by_size {
+        println!("batch size={size:<5} total sync-table statement calls={calls}");
+    }
+
+    // Retry/idempotency: replay the 250-change batch verbatim. Every outcome
+    // must be AlreadyApplied (clean applies) or a replayed Resolved (dup
+    // pairs) — never a second Applied, and nothing may be re-written.
+    let (replay_size, replay_offset) = (250, 5_000);
+    let replay_device = format!("device-{replay_size}");
+    let replay_batch = build_batch(&replay_device, replay_size, replay_offset);
+    reset_stats(&mut conn);
+    let replay_outcomes = backend
+        .apply_push(SCOPE, &replay_batch.request, &resolver)
+        .expect("replay apply_push")
+        .outcomes;
+    for (change, outcome) in replay_batch.request.changes.iter().zip(&replay_outcomes) {
+        assert!(
+            matches!(
+                outcome,
+                ChangeOutcome::AlreadyApplied { .. } | ChangeOutcome::Resolved { .. }
+            ),
+            "replay of {} must not apply again, got {outcome:?}",
+            change.change_id
+        );
+    }
+    print_profile(&mut conn, "replay of the 250-change batch (idempotency)");
+
+    // Representative EXPLAIN output: the two per-change point lookups that
+    // dominate `calls` (dedup check, current-row fetch) — both look trivial
+    // in isolation (single-row index lookups), which is exactly why they
+    // never show up as expensive in a plan-shape review and only show up in
+    // the `calls` ranking.
+    explain(
+        &mut conn,
+        "dedup check (typical case: miss)",
+        &format!(
+            "SELECT version, resolved_row FROM autumn_sync_applied \
+             WHERE scope = '{SCOPE}' AND device_id = 'device-1000' AND change_id = 'device-1000-chg-000001'"
+        ),
+    );
+    explain(
+        &mut conn,
+        "current-row fetch FOR UPDATE",
+        &format!(
+            "SELECT collection, pk, payload, version, deleted, updated_at, device_id, created_version \
+             FROM autumn_sync_rows WHERE scope = '{SCOPE}' AND collection = '{}' AND pk = '{}' FOR UPDATE",
+            seeded_collection(10_001),
+            seeded_pk(10_001)
+        ),
+    );
+}

--- a/docs/perf/sync-push-batching/README.md
+++ b/docs/perf/sync-push-batching/README.md
@@ -1,0 +1,43 @@
+# `PgSyncBackend::apply_push` — push batching perf record
+
+Ledger run profiling `POST /sync/push` (`PgSyncBackend::apply_push`,
+`autumn/src/sync/server.rs`) against a production-shaped fixture. See
+`autumn/tests/integration/offline_sync_push_batching_perf.rs` for the harness
+and fixture generator.
+
+## Reproduce
+
+```sh
+cargo test -p autumn-web --features "test-support,offline-sync" \
+  --test integration_tests -- --ignored offline_sync_push_batching_profile \
+  --nocapture --test-threads=1
+```
+
+Requires Docker. Starts a Postgres 16 testcontainer with
+`pg_stat_statements` preloaded, seeds 20,000 pre-existing rows (six
+collections at a 40/20/15/15/7/3% skew, 5% tombstones, real dead tuples from
+a post-seed `UPDATE`, `ANALYZE`'d), then runs push batches of 50/250/1000
+changes shaped like a device catching up after being offline.
+
+## Baseline (before batching) — `baseline.txt`
+
+One push batch of `n` changes issued exactly 5 round trips per change,
+independent of what the change actually did (update, insert, delete, or a
+conflict):
+
+| statement (per change)                          | calls @ n=50 | calls @ n=250 | calls @ n=1000 |
+|---------------------------------------------------|-------------:|--------------:|---------------:|
+| dedup check (`autumn_sync_applied` SELECT)         | 50           | 250           | 1000           |
+| current-row fetch (`autumn_sync_rows` SELECT FOR UPDATE) | 50    | 250           | 1000           |
+| version allocation (`nextval`)                     | 50           | 250           | 1000           |
+| row upsert (`autumn_sync_rows` INSERT ... ON CONFLICT) | 50       | 250           | 1000           |
+| dedup record insert (`autumn_sync_applied` INSERT) | 50           | 250           | 1000           |
+| **total (+1 constant horizon read)**               | **251**      | **1251**      | **5001**       |
+
+Statement count is exactly `5n + 1` at every size — a textbook N+1, invisible
+in a buffer-cost ranking (each statement is a cheap single-row point lookup:
+3–7 buffers) and only visible in the `calls` ranking.
+
+`EXPLAIN (ANALYZE, BUFFERS, VERBOSE, SETTINGS)` for the two SELECTs
+confirms they're individually trivial (`Index Scan`, 3 and 7 buffers,
+<0.1ms) — see `baseline.txt`, the two `=== EXPLAIN ... ===` sections.

--- a/docs/perf/sync-push-batching/README.md
+++ b/docs/perf/sync-push-batching/README.md
@@ -41,3 +41,50 @@ in a buffer-cost ranking (each statement is a cheap single-row point lookup:
 `EXPLAIN (ANALYZE, BUFFERS, VERBOSE, SETTINGS)` for the two SELECTs
 confirms they're individually trivial (`Index Scan`, 3 and 7 buffers,
 <0.1ms) — see `baseline.txt`, the two `=== EXPLAIN ... ===` sections.
+
+## After (batched) — `after.txt`
+
+`PgSyncBackend::apply_push` (`autumn/src/sync/server.rs`) now issues exactly
+6 statements per push, independent of `n`: one batched dedup lookup
+(`change_id = ANY($3)`), one batched `FOR UPDATE` fetch over the batch's
+distinct `(collection, pk)` pairs, one batched version draw
+(`generate_series`), one batched multi-row upsert (`UNNEST` + `ON CONFLICT`),
+one batched multi-row dedup-record insert, plus the one constant horizon
+read.
+
+| metric                         | n=50        | n=250        | n=1000        |
+|---------------------------------|------------:|-------------:|--------------:|
+| statement calls, before         | 251         | 1251         | 5001          |
+| statement calls, after          | **6**       | **6**        | **6**         |
+| buffers, before                 | 1085        | 5823         | 23372         |
+| buffers, after                  | 981         | 4962         | 20340         |
+| buffers reduction               | 9.6%        | 14.8%        | 13.0%         |
+
+Statement count drops from `5n + 1` to a **constant 6** — an N+1 elimination
+(the impact-floor category this change clears), independent of the buffers
+delta. Buffers also drop 10–15%, a side effect of fewer planner/executor
+round trips per row, not the primary claim.
+
+Idempotent replay (pushing the same 250-change batch again — every change
+either already applied or already resolved, nothing new to write) drops from
+251 statements / 750 buffers to **2 statements / 8 buffers**: the batched
+dedup check alone, no writes at all.
+
+## Equivalence
+
+The harness dumps every row touched by each batch (sorted deterministically
+by `collection, pk` — the table's key), plus the replay's outcomes, and
+prints them to stdout. Every `PushRequest` the harness builds uses fixed
+constant timestamps (not wall-clock), so two runs of the harness against
+identical code produce byte-identical input and — if the change preserves
+semantics — byte-identical output.
+
+`diff` between the row dumps in `baseline.txt` and `after.txt` (1233 lines
+each) is empty: every touched row, across all three batch sizes and every
+scenario (clean update, clean insert, clean delete, two edits of the same
+existing pk in one batch, create-then-edit of the same new pk in one batch,
+and idempotent replay) landed in the identical final state, byte for byte.
+The full existing `offline_sync_conformance` suite (39 tests, covers
+`MemorySyncBackend` and shared push/pull/dedup/conflict/GC/scope-isolation
+semantics) and the Docker-gated `offline_sync_pg` conformance suite both
+still pass unchanged.

--- a/docs/perf/sync-push-batching/after.txt
+++ b/docs/perf/sync-push-batching/after.txt
@@ -1,0 +1,1336 @@
+running 1 test
+test integration::offline_sync_push_batching_perf::offline_sync_push_batching_profile ... 
+=== pg_stat_statements: push batch of 50 changes ===
+-- top by calls --
+calls=1      buffers=0      SELECT change_id, version, resolved_row FROM autumn_sync_applied WHERE scope = $1 AND device_id = $2 AND change_id = ANY($3)
+calls=1      buffers=62     SELECT nextval($2) AS version FROM generate_series($3, $1)
+calls=1      buffers=593    INSERT INTO autumn_sync_rows (scope, collection, pk, payload, version, deleted, updated_at, device_id, created_version) SELECT $1, t.* FROM UNNEST( $2::text[], $3::text[], $4::jsonb[], $5::bigint[], $6::bool[], $7::timestamptz[], $8::text[], $9::bigint[] ) AS t(collection, pk, payload, version, deleted, updated_at, device_id, created_version) ON CONFLICT (scope, collection, pk) DO UPDATE SET payload = excluded.payload, version = excluded.version, deleted = excluded.deleted, updated_at = excluded.updated_at, device_id = excluded.device_id, created_version = excluded.created_version
+calls=1      buffers=225    SELECT collection, pk, payload, version, deleted, updated_at, device_id, created_version FROM autumn_sync_rows WHERE scope = $1 AND (collection, pk) IN ( SELECT * FROM UNNEST($2::text[], $3::text[]) ) FOR UPDATE
+calls=1      buffers=101    INSERT INTO autumn_sync_applied (scope, device_id, change_id, version, resolved_row) SELECT $1, $2, t.change_id, t.version, t.resolved_row FROM UNNEST($3::text[], $4::bigint[], $5::jsonb[]) AS t(change_id, version, resolved_row)
+calls=1      buffers=0      SELECT horizon AS version FROM autumn_sync_horizons WHERE scope = $1
+-- top by buffers --
+buffers=593    calls=1      INSERT INTO autumn_sync_rows (scope, collection, pk, payload, version, deleted, updated_at, device_id, created_version) SELECT $1, t.* FROM UNNEST( $2::text[], $3::text[], $4::jsonb[], $5::bigint[], $6::bool[], $7::timestamptz[], $8::text[], $9::bigint[] ) AS t(collection, pk, payload, version, deleted, updated_at, device_id, created_version) ON CONFLICT (scope, collection, pk) DO UPDATE SET payload = excluded.payload, version = excluded.version, deleted = excluded.deleted, updated_at = excluded.updated_at, device_id = excluded.device_id, created_version = excluded.created_version
+buffers=225    calls=1      SELECT collection, pk, payload, version, deleted, updated_at, device_id, created_version FROM autumn_sync_rows WHERE scope = $1 AND (collection, pk) IN ( SELECT * FROM UNNEST($2::text[], $3::text[]) ) FOR UPDATE
+buffers=101    calls=1      INSERT INTO autumn_sync_applied (scope, device_id, change_id, version, resolved_row) SELECT $1, $2, t.change_id, t.version, t.resolved_row FROM UNNEST($3::text[], $4::bigint[], $5::jsonb[]) AS t(change_id, version, resolved_row)
+buffers=62     calls=1      SELECT nextval($2) AS version FROM generate_series($3, $1)
+buffers=0      calls=1      SELECT change_id, version, resolved_row FROM autumn_sync_applied WHERE scope = $1 AND device_id = $2 AND change_id = ANY($3)
+buffers=0      calls=1      SELECT horizon AS version FROM autumn_sync_horizons WHERE scope = $1
+TOTAL sync-table statement calls=6 buffers=981 (this batch, all statement shapes)
+-- row dump (new/newdup pks), 11 rows --
+RowDump { collection: "notes", pk: "new-device-50-000000", payload: Some("{\"k\": 0, \"edit\": \"insert\"}"), version: 20031, deleted: false, device_id: "device-50", created_version: 20031 }
+RowDump { collection: "notes", pk: "new-device-50-000001", payload: Some("{\"k\": 1, \"edit\": \"insert\"}"), version: 20032, deleted: false, device_id: "device-50", created_version: 20032 }
+RowDump { collection: "notes", pk: "new-device-50-000002", payload: Some("{\"k\": 2, \"edit\": \"insert\"}"), version: 20033, deleted: false, device_id: "device-50", created_version: 20033 }
+RowDump { collection: "notes", pk: "new-device-50-000003", payload: Some("{\"k\": 3, \"edit\": \"insert\"}"), version: 20034, deleted: false, device_id: "device-50", created_version: 20034 }
+RowDump { collection: "notes", pk: "new-device-50-000004", payload: Some("{\"k\": 4, \"edit\": \"insert\"}"), version: 20035, deleted: false, device_id: "device-50", created_version: 20035 }
+RowDump { collection: "notes", pk: "new-device-50-000005", payload: Some("{\"k\": 5, \"edit\": \"insert\"}"), version: 20036, deleted: false, device_id: "device-50", created_version: 20036 }
+RowDump { collection: "notes", pk: "new-device-50-000006", payload: Some("{\"k\": 6, \"edit\": \"insert\"}"), version: 20037, deleted: false, device_id: "device-50", created_version: 20037 }
+RowDump { collection: "notes", pk: "new-device-50-000007", payload: Some("{\"k\": 7, \"edit\": \"insert\"}"), version: 20038, deleted: false, device_id: "device-50", created_version: 20038 }
+RowDump { collection: "notes", pk: "new-device-50-000008", payload: Some("{\"k\": 8, \"edit\": \"insert\"}"), version: 20039, deleted: false, device_id: "device-50", created_version: 20039 }
+RowDump { collection: "notes", pk: "new-device-50-000009", payload: Some("{\"k\": 9, \"edit\": \"insert\"}"), version: 20040, deleted: false, device_id: "device-50", created_version: 20040 }
+RowDump { collection: "notes", pk: "newdup-device-50-000000", payload: Some("{\"p\": 0, \"edit\": \"dup-new-2\"}"), version: 20050, deleted: false, device_id: "device-50", created_version: 20049 }
+-- row dump (existing pks touched by this batch), 36 rows --
+RowDump { collection: "notes", pk: "pk-00000001", payload: Some("{\"idx\": 1, \"edit\": \"update\"}"), version: 20001, deleted: false, device_id: "device-50", created_version: 1 }
+RowDump { collection: "notes", pk: "pk-00000002", payload: Some("{\"idx\": 2, \"edit\": \"update\"}"), version: 20002, deleted: false, device_id: "device-50", created_version: 2 }
+RowDump { collection: "notes", pk: "pk-00000003", payload: Some("{\"idx\": 3, \"edit\": \"update\"}"), version: 20003, deleted: false, device_id: "device-50", created_version: 3 }
+RowDump { collection: "notes", pk: "pk-00000004", payload: Some("{\"idx\": 4, \"edit\": \"update\"}"), version: 20004, deleted: false, device_id: "device-50", created_version: 4 }
+RowDump { collection: "notes", pk: "pk-00000005", payload: Some("{\"idx\": 5, \"edit\": \"update\"}"), version: 20005, deleted: false, device_id: "device-50", created_version: 5 }
+RowDump { collection: "notes", pk: "pk-00000006", payload: Some("{\"idx\": 6, \"edit\": \"update\"}"), version: 20006, deleted: false, device_id: "device-50", created_version: 6 }
+RowDump { collection: "notes", pk: "pk-00000007", payload: Some("{\"idx\": 7, \"edit\": \"update\"}"), version: 20007, deleted: false, device_id: "device-50", created_version: 7 }
+RowDump { collection: "notes", pk: "pk-00000008", payload: Some("{\"idx\": 8, \"edit\": \"update\"}"), version: 20008, deleted: false, device_id: "device-50", created_version: 8 }
+RowDump { collection: "notes", pk: "pk-00000009", payload: Some("{\"idx\": 9, \"edit\": \"update\"}"), version: 20009, deleted: false, device_id: "device-50", created_version: 9 }
+RowDump { collection: "notes", pk: "pk-00000010", payload: Some("{\"idx\": 10, \"edit\": \"update\"}"), version: 20010, deleted: false, device_id: "device-50", created_version: 10 }
+RowDump { collection: "notes", pk: "pk-00000011", payload: Some("{\"idx\": 11, \"edit\": \"update\"}"), version: 20011, deleted: false, device_id: "device-50", created_version: 11 }
+RowDump { collection: "notes", pk: "pk-00000012", payload: Some("{\"idx\": 12, \"edit\": \"update\"}"), version: 20012, deleted: false, device_id: "device-50", created_version: 12 }
+RowDump { collection: "notes", pk: "pk-00000013", payload: Some("{\"idx\": 13, \"edit\": \"update\"}"), version: 20013, deleted: false, device_id: "device-50", created_version: 13 }
+RowDump { collection: "notes", pk: "pk-00000014", payload: Some("{\"idx\": 14, \"edit\": \"update\"}"), version: 20014, deleted: false, device_id: "device-50", created_version: 14 }
+RowDump { collection: "notes", pk: "pk-00000015", payload: Some("{\"idx\": 15, \"edit\": \"update\"}"), version: 20015, deleted: false, device_id: "device-50", created_version: 15 }
+RowDump { collection: "notes", pk: "pk-00000016", payload: Some("{\"idx\": 16, \"edit\": \"update\"}"), version: 20016, deleted: false, device_id: "device-50", created_version: 16 }
+RowDump { collection: "notes", pk: "pk-00000017", payload: Some("{\"idx\": 17, \"edit\": \"update\"}"), version: 20017, deleted: false, device_id: "device-50", created_version: 17 }
+RowDump { collection: "notes", pk: "pk-00000018", payload: Some("{\"idx\": 18, \"edit\": \"update\"}"), version: 20018, deleted: false, device_id: "device-50", created_version: 18 }
+RowDump { collection: "notes", pk: "pk-00000019", payload: Some("{\"idx\": 19, \"edit\": \"update\"}"), version: 20019, deleted: false, device_id: "device-50", created_version: 19 }
+RowDump { collection: "notes", pk: "pk-00000021", payload: Some("{\"idx\": 21, \"edit\": \"update\"}"), version: 20020, deleted: false, device_id: "device-50", created_version: 21 }
+RowDump { collection: "notes", pk: "pk-00000022", payload: Some("{\"idx\": 22, \"edit\": \"update\"}"), version: 20021, deleted: false, device_id: "device-50", created_version: 22 }
+RowDump { collection: "notes", pk: "pk-00000023", payload: Some("{\"idx\": 23, \"edit\": \"update\"}"), version: 20022, deleted: false, device_id: "device-50", created_version: 23 }
+RowDump { collection: "notes", pk: "pk-00000024", payload: Some("{\"idx\": 24, \"edit\": \"update\"}"), version: 20023, deleted: false, device_id: "device-50", created_version: 24 }
+RowDump { collection: "notes", pk: "pk-00000025", payload: Some("{\"idx\": 25, \"edit\": \"update\"}"), version: 20024, deleted: false, device_id: "device-50", created_version: 25 }
+RowDump { collection: "notes", pk: "pk-00000026", payload: Some("{\"idx\": 26, \"edit\": \"update\"}"), version: 20025, deleted: false, device_id: "device-50", created_version: 26 }
+RowDump { collection: "notes", pk: "pk-00000027", payload: Some("{\"idx\": 27, \"edit\": \"update\"}"), version: 20026, deleted: false, device_id: "device-50", created_version: 27 }
+RowDump { collection: "notes", pk: "pk-00000028", payload: Some("{\"idx\": 28, \"edit\": \"update\"}"), version: 20027, deleted: false, device_id: "device-50", created_version: 28 }
+RowDump { collection: "notes", pk: "pk-00000029", payload: Some("{\"idx\": 29, \"edit\": \"update\"}"), version: 20028, deleted: false, device_id: "device-50", created_version: 29 }
+RowDump { collection: "notes", pk: "pk-00000030", payload: Some("{\"idx\": 30, \"edit\": \"update\"}"), version: 20029, deleted: false, device_id: "device-50", created_version: 30 }
+RowDump { collection: "notes", pk: "pk-00000031", payload: Some("{\"idx\": 31, \"edit\": \"update\"}"), version: 20030, deleted: false, device_id: "device-50", created_version: 31 }
+RowDump { collection: "notes", pk: "pk-00000032", payload: None, version: 20041, deleted: true, device_id: "device-50", created_version: 32 }
+RowDump { collection: "notes", pk: "pk-00000033", payload: None, version: 20042, deleted: true, device_id: "device-50", created_version: 33 }
+RowDump { collection: "notes", pk: "pk-00000034", payload: None, version: 20043, deleted: true, device_id: "device-50", created_version: 34 }
+RowDump { collection: "notes", pk: "pk-00000035", payload: None, version: 20044, deleted: true, device_id: "device-50", created_version: 35 }
+RowDump { collection: "notes", pk: "pk-00000036", payload: Some("{\"p\": 0, \"edit\": \"dup-existing-2\"}"), version: 20046, deleted: false, device_id: "device-50", created_version: 36 }
+RowDump { collection: "notes", pk: "pk-00000037", payload: Some("{\"p\": 1, \"edit\": \"dup-existing-2\"}"), version: 20048, deleted: false, device_id: "device-50", created_version: 37 }
+
+=== pg_stat_statements: push batch of 250 changes ===
+-- top by calls --
+calls=1      buffers=1      SELECT change_id, version, resolved_row FROM autumn_sync_applied WHERE scope = $1 AND device_id = $2 AND change_id = ANY($3)
+calls=1      buffers=262    SELECT nextval($2) AS version FROM generate_series($3, $1)
+calls=1      buffers=2912   INSERT INTO autumn_sync_rows (scope, collection, pk, payload, version, deleted, updated_at, device_id, created_version) SELECT $1, t.* FROM UNNEST( $2::text[], $3::text[], $4::jsonb[], $5::bigint[], $6::bool[], $7::timestamptz[], $8::text[], $9::bigint[] ) AS t(collection, pk, payload, version, deleted, updated_at, device_id, created_version) ON CONFLICT (scope, collection, pk) DO UPDATE SET payload = excluded.payload, version = excluded.version, deleted = excluded.deleted, updated_at = excluded.updated_at, device_id = excluded.device_id, created_version = excluded.created_version
+calls=1      buffers=1132   SELECT collection, pk, payload, version, deleted, updated_at, device_id, created_version FROM autumn_sync_rows WHERE scope = $1 AND (collection, pk) IN ( SELECT * FROM UNNEST($2::text[], $3::text[]) ) FOR UPDATE
+calls=1      buffers=655    INSERT INTO autumn_sync_applied (scope, device_id, change_id, version, resolved_row) SELECT $1, $2, t.change_id, t.version, t.resolved_row FROM UNNEST($3::text[], $4::bigint[], $5::jsonb[]) AS t(change_id, version, resolved_row)
+calls=1      buffers=0      SELECT horizon AS version FROM autumn_sync_horizons WHERE scope = $1
+-- top by buffers --
+buffers=2912   calls=1      INSERT INTO autumn_sync_rows (scope, collection, pk, payload, version, deleted, updated_at, device_id, created_version) SELECT $1, t.* FROM UNNEST( $2::text[], $3::text[], $4::jsonb[], $5::bigint[], $6::bool[], $7::timestamptz[], $8::text[], $9::bigint[] ) AS t(collection, pk, payload, version, deleted, updated_at, device_id, created_version) ON CONFLICT (scope, collection, pk) DO UPDATE SET payload = excluded.payload, version = excluded.version, deleted = excluded.deleted, updated_at = excluded.updated_at, device_id = excluded.device_id, created_version = excluded.created_version
+buffers=1132   calls=1      SELECT collection, pk, payload, version, deleted, updated_at, device_id, created_version FROM autumn_sync_rows WHERE scope = $1 AND (collection, pk) IN ( SELECT * FROM UNNEST($2::text[], $3::text[]) ) FOR UPDATE
+buffers=655    calls=1      INSERT INTO autumn_sync_applied (scope, device_id, change_id, version, resolved_row) SELECT $1, $2, t.change_id, t.version, t.resolved_row FROM UNNEST($3::text[], $4::bigint[], $5::jsonb[]) AS t(change_id, version, resolved_row)
+buffers=262    calls=1      SELECT nextval($2) AS version FROM generate_series($3, $1)
+buffers=1      calls=1      SELECT change_id, version, resolved_row FROM autumn_sync_applied WHERE scope = $1 AND device_id = $2 AND change_id = ANY($3)
+buffers=0      calls=1      SELECT horizon AS version FROM autumn_sync_horizons WHERE scope = $1
+TOTAL sync-table statement calls=6 buffers=4962 (this batch, all statement shapes)
+-- row dump (new/newdup pks), 54 rows --
+RowDump { collection: "notes", pk: "new-device-250-000000", payload: Some("{\"k\": 0, \"edit\": \"insert\"}"), version: 20211, deleted: false, device_id: "device-250", created_version: 20211 }
+RowDump { collection: "notes", pk: "new-device-250-000001", payload: Some("{\"k\": 1, \"edit\": \"insert\"}"), version: 20212, deleted: false, device_id: "device-250", created_version: 20212 }
+RowDump { collection: "notes", pk: "new-device-250-000002", payload: Some("{\"k\": 2, \"edit\": \"insert\"}"), version: 20213, deleted: false, device_id: "device-250", created_version: 20213 }
+RowDump { collection: "notes", pk: "new-device-250-000003", payload: Some("{\"k\": 3, \"edit\": \"insert\"}"), version: 20214, deleted: false, device_id: "device-250", created_version: 20214 }
+RowDump { collection: "notes", pk: "new-device-250-000004", payload: Some("{\"k\": 4, \"edit\": \"insert\"}"), version: 20215, deleted: false, device_id: "device-250", created_version: 20215 }
+RowDump { collection: "notes", pk: "new-device-250-000005", payload: Some("{\"k\": 5, \"edit\": \"insert\"}"), version: 20216, deleted: false, device_id: "device-250", created_version: 20216 }
+RowDump { collection: "notes", pk: "new-device-250-000006", payload: Some("{\"k\": 6, \"edit\": \"insert\"}"), version: 20217, deleted: false, device_id: "device-250", created_version: 20217 }
+RowDump { collection: "notes", pk: "new-device-250-000007", payload: Some("{\"k\": 7, \"edit\": \"insert\"}"), version: 20218, deleted: false, device_id: "device-250", created_version: 20218 }
+RowDump { collection: "notes", pk: "new-device-250-000008", payload: Some("{\"k\": 8, \"edit\": \"insert\"}"), version: 20219, deleted: false, device_id: "device-250", created_version: 20219 }
+RowDump { collection: "notes", pk: "new-device-250-000009", payload: Some("{\"k\": 9, \"edit\": \"insert\"}"), version: 20220, deleted: false, device_id: "device-250", created_version: 20220 }
+RowDump { collection: "notes", pk: "new-device-250-000010", payload: Some("{\"k\": 10, \"edit\": \"insert\"}"), version: 20221, deleted: false, device_id: "device-250", created_version: 20221 }
+RowDump { collection: "notes", pk: "new-device-250-000011", payload: Some("{\"k\": 11, \"edit\": \"insert\"}"), version: 20222, deleted: false, device_id: "device-250", created_version: 20222 }
+RowDump { collection: "notes", pk: "new-device-250-000012", payload: Some("{\"k\": 12, \"edit\": \"insert\"}"), version: 20223, deleted: false, device_id: "device-250", created_version: 20223 }
+RowDump { collection: "notes", pk: "new-device-250-000013", payload: Some("{\"k\": 13, \"edit\": \"insert\"}"), version: 20224, deleted: false, device_id: "device-250", created_version: 20224 }
+RowDump { collection: "notes", pk: "new-device-250-000014", payload: Some("{\"k\": 14, \"edit\": \"insert\"}"), version: 20225, deleted: false, device_id: "device-250", created_version: 20225 }
+RowDump { collection: "notes", pk: "new-device-250-000015", payload: Some("{\"k\": 15, \"edit\": \"insert\"}"), version: 20226, deleted: false, device_id: "device-250", created_version: 20226 }
+RowDump { collection: "notes", pk: "new-device-250-000016", payload: Some("{\"k\": 16, \"edit\": \"insert\"}"), version: 20227, deleted: false, device_id: "device-250", created_version: 20227 }
+RowDump { collection: "notes", pk: "new-device-250-000017", payload: Some("{\"k\": 17, \"edit\": \"insert\"}"), version: 20228, deleted: false, device_id: "device-250", created_version: 20228 }
+RowDump { collection: "notes", pk: "new-device-250-000018", payload: Some("{\"k\": 18, \"edit\": \"insert\"}"), version: 20229, deleted: false, device_id: "device-250", created_version: 20229 }
+RowDump { collection: "notes", pk: "new-device-250-000019", payload: Some("{\"k\": 19, \"edit\": \"insert\"}"), version: 20230, deleted: false, device_id: "device-250", created_version: 20230 }
+RowDump { collection: "notes", pk: "new-device-250-000020", payload: Some("{\"k\": 20, \"edit\": \"insert\"}"), version: 20231, deleted: false, device_id: "device-250", created_version: 20231 }
+RowDump { collection: "notes", pk: "new-device-250-000021", payload: Some("{\"k\": 21, \"edit\": \"insert\"}"), version: 20232, deleted: false, device_id: "device-250", created_version: 20232 }
+RowDump { collection: "notes", pk: "new-device-250-000022", payload: Some("{\"k\": 22, \"edit\": \"insert\"}"), version: 20233, deleted: false, device_id: "device-250", created_version: 20233 }
+RowDump { collection: "notes", pk: "new-device-250-000023", payload: Some("{\"k\": 23, \"edit\": \"insert\"}"), version: 20234, deleted: false, device_id: "device-250", created_version: 20234 }
+RowDump { collection: "notes", pk: "new-device-250-000024", payload: Some("{\"k\": 24, \"edit\": \"insert\"}"), version: 20235, deleted: false, device_id: "device-250", created_version: 20235 }
+RowDump { collection: "notes", pk: "new-device-250-000025", payload: Some("{\"k\": 25, \"edit\": \"insert\"}"), version: 20236, deleted: false, device_id: "device-250", created_version: 20236 }
+RowDump { collection: "notes", pk: "new-device-250-000026", payload: Some("{\"k\": 26, \"edit\": \"insert\"}"), version: 20237, deleted: false, device_id: "device-250", created_version: 20237 }
+RowDump { collection: "notes", pk: "new-device-250-000027", payload: Some("{\"k\": 27, \"edit\": \"insert\"}"), version: 20238, deleted: false, device_id: "device-250", created_version: 20238 }
+RowDump { collection: "notes", pk: "new-device-250-000028", payload: Some("{\"k\": 28, \"edit\": \"insert\"}"), version: 20239, deleted: false, device_id: "device-250", created_version: 20239 }
+RowDump { collection: "notes", pk: "new-device-250-000029", payload: Some("{\"k\": 29, \"edit\": \"insert\"}"), version: 20240, deleted: false, device_id: "device-250", created_version: 20240 }
+RowDump { collection: "notes", pk: "new-device-250-000030", payload: Some("{\"k\": 30, \"edit\": \"insert\"}"), version: 20241, deleted: false, device_id: "device-250", created_version: 20241 }
+RowDump { collection: "notes", pk: "new-device-250-000031", payload: Some("{\"k\": 31, \"edit\": \"insert\"}"), version: 20242, deleted: false, device_id: "device-250", created_version: 20242 }
+RowDump { collection: "notes", pk: "new-device-250-000032", payload: Some("{\"k\": 32, \"edit\": \"insert\"}"), version: 20243, deleted: false, device_id: "device-250", created_version: 20243 }
+RowDump { collection: "notes", pk: "new-device-250-000033", payload: Some("{\"k\": 33, \"edit\": \"insert\"}"), version: 20244, deleted: false, device_id: "device-250", created_version: 20244 }
+RowDump { collection: "notes", pk: "new-device-250-000034", payload: Some("{\"k\": 34, \"edit\": \"insert\"}"), version: 20245, deleted: false, device_id: "device-250", created_version: 20245 }
+RowDump { collection: "notes", pk: "new-device-250-000035", payload: Some("{\"k\": 35, \"edit\": \"insert\"}"), version: 20246, deleted: false, device_id: "device-250", created_version: 20246 }
+RowDump { collection: "notes", pk: "new-device-250-000036", payload: Some("{\"k\": 36, \"edit\": \"insert\"}"), version: 20247, deleted: false, device_id: "device-250", created_version: 20247 }
+RowDump { collection: "notes", pk: "new-device-250-000037", payload: Some("{\"k\": 37, \"edit\": \"insert\"}"), version: 20248, deleted: false, device_id: "device-250", created_version: 20248 }
+RowDump { collection: "notes", pk: "new-device-250-000038", payload: Some("{\"k\": 38, \"edit\": \"insert\"}"), version: 20249, deleted: false, device_id: "device-250", created_version: 20249 }
+RowDump { collection: "notes", pk: "new-device-250-000039", payload: Some("{\"k\": 39, \"edit\": \"insert\"}"), version: 20250, deleted: false, device_id: "device-250", created_version: 20250 }
+RowDump { collection: "notes", pk: "new-device-250-000040", payload: Some("{\"k\": 40, \"edit\": \"insert\"}"), version: 20251, deleted: false, device_id: "device-250", created_version: 20251 }
+RowDump { collection: "notes", pk: "new-device-250-000041", payload: Some("{\"k\": 41, \"edit\": \"insert\"}"), version: 20252, deleted: false, device_id: "device-250", created_version: 20252 }
+RowDump { collection: "notes", pk: "new-device-250-000042", payload: Some("{\"k\": 42, \"edit\": \"insert\"}"), version: 20253, deleted: false, device_id: "device-250", created_version: 20253 }
+RowDump { collection: "notes", pk: "new-device-250-000043", payload: Some("{\"k\": 43, \"edit\": \"insert\"}"), version: 20254, deleted: false, device_id: "device-250", created_version: 20254 }
+RowDump { collection: "notes", pk: "new-device-250-000044", payload: Some("{\"k\": 44, \"edit\": \"insert\"}"), version: 20255, deleted: false, device_id: "device-250", created_version: 20255 }
+RowDump { collection: "notes", pk: "new-device-250-000045", payload: Some("{\"k\": 45, \"edit\": \"insert\"}"), version: 20256, deleted: false, device_id: "device-250", created_version: 20256 }
+RowDump { collection: "notes", pk: "new-device-250-000046", payload: Some("{\"k\": 46, \"edit\": \"insert\"}"), version: 20257, deleted: false, device_id: "device-250", created_version: 20257 }
+RowDump { collection: "notes", pk: "new-device-250-000047", payload: Some("{\"k\": 47, \"edit\": \"insert\"}"), version: 20258, deleted: false, device_id: "device-250", created_version: 20258 }
+RowDump { collection: "notes", pk: "new-device-250-000048", payload: Some("{\"k\": 48, \"edit\": \"insert\"}"), version: 20259, deleted: false, device_id: "device-250", created_version: 20259 }
+RowDump { collection: "notes", pk: "new-device-250-000049", payload: Some("{\"k\": 49, \"edit\": \"insert\"}"), version: 20260, deleted: false, device_id: "device-250", created_version: 20260 }
+RowDump { collection: "notes", pk: "newdup-device-250-000000", payload: Some("{\"p\": 0, \"edit\": \"dup-new-2\"}"), version: 20294, deleted: false, device_id: "device-250", created_version: 20293 }
+RowDump { collection: "notes", pk: "newdup-device-250-000001", payload: Some("{\"p\": 1, \"edit\": \"dup-new-2\"}"), version: 20296, deleted: false, device_id: "device-250", created_version: 20295 }
+RowDump { collection: "notes", pk: "newdup-device-250-000002", payload: Some("{\"p\": 2, \"edit\": \"dup-new-2\"}"), version: 20298, deleted: false, device_id: "device-250", created_version: 20297 }
+RowDump { collection: "notes", pk: "newdup-device-250-000003", payload: Some("{\"p\": 3, \"edit\": \"dup-new-2\"}"), version: 20300, deleted: false, device_id: "device-250", created_version: 20299 }
+-- row dump (existing pks touched by this batch), 182 rows --
+RowDump { collection: "notes", pk: "pk-00005001", payload: Some("{\"idx\": 5001, \"edit\": \"update\"}"), version: 20051, deleted: false, device_id: "device-250", created_version: 5001 }
+RowDump { collection: "notes", pk: "pk-00005002", payload: Some("{\"idx\": 5002, \"edit\": \"update\"}"), version: 20052, deleted: false, device_id: "device-250", created_version: 5002 }
+RowDump { collection: "notes", pk: "pk-00005003", payload: Some("{\"idx\": 5003, \"edit\": \"update\"}"), version: 20053, deleted: false, device_id: "device-250", created_version: 5003 }
+RowDump { collection: "notes", pk: "pk-00005004", payload: Some("{\"idx\": 5004, \"edit\": \"update\"}"), version: 20054, deleted: false, device_id: "device-250", created_version: 5004 }
+RowDump { collection: "notes", pk: "pk-00005005", payload: Some("{\"idx\": 5005, \"edit\": \"update\"}"), version: 20055, deleted: false, device_id: "device-250", created_version: 5005 }
+RowDump { collection: "notes", pk: "pk-00005006", payload: Some("{\"idx\": 5006, \"edit\": \"update\"}"), version: 20056, deleted: false, device_id: "device-250", created_version: 5006 }
+RowDump { collection: "notes", pk: "pk-00005007", payload: Some("{\"idx\": 5007, \"edit\": \"update\"}"), version: 20057, deleted: false, device_id: "device-250", created_version: 5007 }
+RowDump { collection: "notes", pk: "pk-00005008", payload: Some("{\"idx\": 5008, \"edit\": \"update\"}"), version: 20058, deleted: false, device_id: "device-250", created_version: 5008 }
+RowDump { collection: "notes", pk: "pk-00005009", payload: Some("{\"idx\": 5009, \"edit\": \"update\"}"), version: 20059, deleted: false, device_id: "device-250", created_version: 5009 }
+RowDump { collection: "notes", pk: "pk-00005010", payload: Some("{\"idx\": 5010, \"edit\": \"update\"}"), version: 20060, deleted: false, device_id: "device-250", created_version: 5010 }
+RowDump { collection: "notes", pk: "pk-00005011", payload: Some("{\"idx\": 5011, \"edit\": \"update\"}"), version: 20061, deleted: false, device_id: "device-250", created_version: 5011 }
+RowDump { collection: "notes", pk: "pk-00005012", payload: Some("{\"idx\": 5012, \"edit\": \"update\"}"), version: 20062, deleted: false, device_id: "device-250", created_version: 5012 }
+RowDump { collection: "notes", pk: "pk-00005013", payload: Some("{\"idx\": 5013, \"edit\": \"update\"}"), version: 20063, deleted: false, device_id: "device-250", created_version: 5013 }
+RowDump { collection: "notes", pk: "pk-00005014", payload: Some("{\"idx\": 5014, \"edit\": \"update\"}"), version: 20064, deleted: false, device_id: "device-250", created_version: 5014 }
+RowDump { collection: "notes", pk: "pk-00005015", payload: Some("{\"idx\": 5015, \"edit\": \"update\"}"), version: 20065, deleted: false, device_id: "device-250", created_version: 5015 }
+RowDump { collection: "notes", pk: "pk-00005016", payload: Some("{\"idx\": 5016, \"edit\": \"update\"}"), version: 20066, deleted: false, device_id: "device-250", created_version: 5016 }
+RowDump { collection: "notes", pk: "pk-00005017", payload: Some("{\"idx\": 5017, \"edit\": \"update\"}"), version: 20067, deleted: false, device_id: "device-250", created_version: 5017 }
+RowDump { collection: "notes", pk: "pk-00005018", payload: Some("{\"idx\": 5018, \"edit\": \"update\"}"), version: 20068, deleted: false, device_id: "device-250", created_version: 5018 }
+RowDump { collection: "notes", pk: "pk-00005019", payload: Some("{\"idx\": 5019, \"edit\": \"update\"}"), version: 20069, deleted: false, device_id: "device-250", created_version: 5019 }
+RowDump { collection: "notes", pk: "pk-00005021", payload: Some("{\"idx\": 5021, \"edit\": \"update\"}"), version: 20070, deleted: false, device_id: "device-250", created_version: 5021 }
+RowDump { collection: "notes", pk: "pk-00005022", payload: Some("{\"idx\": 5022, \"edit\": \"update\"}"), version: 20071, deleted: false, device_id: "device-250", created_version: 5022 }
+RowDump { collection: "notes", pk: "pk-00005023", payload: Some("{\"idx\": 5023, \"edit\": \"update\"}"), version: 20072, deleted: false, device_id: "device-250", created_version: 5023 }
+RowDump { collection: "notes", pk: "pk-00005024", payload: Some("{\"idx\": 5024, \"edit\": \"update\"}"), version: 20073, deleted: false, device_id: "device-250", created_version: 5024 }
+RowDump { collection: "notes", pk: "pk-00005025", payload: Some("{\"idx\": 5025, \"edit\": \"update\"}"), version: 20074, deleted: false, device_id: "device-250", created_version: 5025 }
+RowDump { collection: "notes", pk: "pk-00005026", payload: Some("{\"idx\": 5026, \"edit\": \"update\"}"), version: 20075, deleted: false, device_id: "device-250", created_version: 5026 }
+RowDump { collection: "notes", pk: "pk-00005027", payload: Some("{\"idx\": 5027, \"edit\": \"update\"}"), version: 20076, deleted: false, device_id: "device-250", created_version: 5027 }
+RowDump { collection: "notes", pk: "pk-00005028", payload: Some("{\"idx\": 5028, \"edit\": \"update\"}"), version: 20077, deleted: false, device_id: "device-250", created_version: 5028 }
+RowDump { collection: "notes", pk: "pk-00005029", payload: Some("{\"idx\": 5029, \"edit\": \"update\"}"), version: 20078, deleted: false, device_id: "device-250", created_version: 5029 }
+RowDump { collection: "notes", pk: "pk-00005030", payload: Some("{\"idx\": 5030, \"edit\": \"update\"}"), version: 20079, deleted: false, device_id: "device-250", created_version: 5030 }
+RowDump { collection: "notes", pk: "pk-00005031", payload: Some("{\"idx\": 5031, \"edit\": \"update\"}"), version: 20080, deleted: false, device_id: "device-250", created_version: 5031 }
+RowDump { collection: "notes", pk: "pk-00005032", payload: Some("{\"idx\": 5032, \"edit\": \"update\"}"), version: 20081, deleted: false, device_id: "device-250", created_version: 5032 }
+RowDump { collection: "notes", pk: "pk-00005033", payload: Some("{\"idx\": 5033, \"edit\": \"update\"}"), version: 20082, deleted: false, device_id: "device-250", created_version: 5033 }
+RowDump { collection: "notes", pk: "pk-00005034", payload: Some("{\"idx\": 5034, \"edit\": \"update\"}"), version: 20083, deleted: false, device_id: "device-250", created_version: 5034 }
+RowDump { collection: "notes", pk: "pk-00005035", payload: Some("{\"idx\": 5035, \"edit\": \"update\"}"), version: 20084, deleted: false, device_id: "device-250", created_version: 5035 }
+RowDump { collection: "notes", pk: "pk-00005036", payload: Some("{\"idx\": 5036, \"edit\": \"update\"}"), version: 20085, deleted: false, device_id: "device-250", created_version: 5036 }
+RowDump { collection: "notes", pk: "pk-00005037", payload: Some("{\"idx\": 5037, \"edit\": \"update\"}"), version: 20086, deleted: false, device_id: "device-250", created_version: 5037 }
+RowDump { collection: "notes", pk: "pk-00005038", payload: Some("{\"idx\": 5038, \"edit\": \"update\"}"), version: 20087, deleted: false, device_id: "device-250", created_version: 5038 }
+RowDump { collection: "notes", pk: "pk-00005039", payload: Some("{\"idx\": 5039, \"edit\": \"update\"}"), version: 20088, deleted: false, device_id: "device-250", created_version: 5039 }
+RowDump { collection: "contacts", pk: "pk-00005041", payload: Some("{\"idx\": 5041, \"edit\": \"update\"}"), version: 20089, deleted: false, device_id: "device-250", created_version: 5041 }
+RowDump { collection: "contacts", pk: "pk-00005042", payload: Some("{\"idx\": 5042, \"edit\": \"update\"}"), version: 20090, deleted: false, device_id: "device-250", created_version: 5042 }
+RowDump { collection: "contacts", pk: "pk-00005043", payload: Some("{\"idx\": 5043, \"edit\": \"update\"}"), version: 20091, deleted: false, device_id: "device-250", created_version: 5043 }
+RowDump { collection: "contacts", pk: "pk-00005044", payload: Some("{\"idx\": 5044, \"edit\": \"update\"}"), version: 20092, deleted: false, device_id: "device-250", created_version: 5044 }
+RowDump { collection: "contacts", pk: "pk-00005045", payload: Some("{\"idx\": 5045, \"edit\": \"update\"}"), version: 20093, deleted: false, device_id: "device-250", created_version: 5045 }
+RowDump { collection: "contacts", pk: "pk-00005046", payload: Some("{\"idx\": 5046, \"edit\": \"update\"}"), version: 20094, deleted: false, device_id: "device-250", created_version: 5046 }
+RowDump { collection: "contacts", pk: "pk-00005047", payload: Some("{\"idx\": 5047, \"edit\": \"update\"}"), version: 20095, deleted: false, device_id: "device-250", created_version: 5047 }
+RowDump { collection: "contacts", pk: "pk-00005048", payload: Some("{\"idx\": 5048, \"edit\": \"update\"}"), version: 20096, deleted: false, device_id: "device-250", created_version: 5048 }
+RowDump { collection: "contacts", pk: "pk-00005049", payload: Some("{\"idx\": 5049, \"edit\": \"update\"}"), version: 20097, deleted: false, device_id: "device-250", created_version: 5049 }
+RowDump { collection: "contacts", pk: "pk-00005050", payload: Some("{\"idx\": 5050, \"edit\": \"update\"}"), version: 20098, deleted: false, device_id: "device-250", created_version: 5050 }
+RowDump { collection: "contacts", pk: "pk-00005051", payload: Some("{\"idx\": 5051, \"edit\": \"update\"}"), version: 20099, deleted: false, device_id: "device-250", created_version: 5051 }
+RowDump { collection: "contacts", pk: "pk-00005052", payload: Some("{\"idx\": 5052, \"edit\": \"update\"}"), version: 20100, deleted: false, device_id: "device-250", created_version: 5052 }
+RowDump { collection: "contacts", pk: "pk-00005053", payload: Some("{\"idx\": 5053, \"edit\": \"update\"}"), version: 20101, deleted: false, device_id: "device-250", created_version: 5053 }
+RowDump { collection: "contacts", pk: "pk-00005054", payload: Some("{\"idx\": 5054, \"edit\": \"update\"}"), version: 20102, deleted: false, device_id: "device-250", created_version: 5054 }
+RowDump { collection: "contacts", pk: "pk-00005055", payload: Some("{\"idx\": 5055, \"edit\": \"update\"}"), version: 20103, deleted: false, device_id: "device-250", created_version: 5055 }
+RowDump { collection: "contacts", pk: "pk-00005056", payload: Some("{\"idx\": 5056, \"edit\": \"update\"}"), version: 20104, deleted: false, device_id: "device-250", created_version: 5056 }
+RowDump { collection: "contacts", pk: "pk-00005057", payload: Some("{\"idx\": 5057, \"edit\": \"update\"}"), version: 20105, deleted: false, device_id: "device-250", created_version: 5057 }
+RowDump { collection: "contacts", pk: "pk-00005058", payload: Some("{\"idx\": 5058, \"edit\": \"update\"}"), version: 20106, deleted: false, device_id: "device-250", created_version: 5058 }
+RowDump { collection: "contacts", pk: "pk-00005059", payload: Some("{\"idx\": 5059, \"edit\": \"update\"}"), version: 20107, deleted: false, device_id: "device-250", created_version: 5059 }
+RowDump { collection: "tasks", pk: "pk-00005061", payload: Some("{\"idx\": 5061, \"edit\": \"update\"}"), version: 20108, deleted: false, device_id: "device-250", created_version: 5061 }
+RowDump { collection: "tasks", pk: "pk-00005062", payload: Some("{\"idx\": 5062, \"edit\": \"update\"}"), version: 20109, deleted: false, device_id: "device-250", created_version: 5062 }
+RowDump { collection: "tasks", pk: "pk-00005063", payload: Some("{\"idx\": 5063, \"edit\": \"update\"}"), version: 20110, deleted: false, device_id: "device-250", created_version: 5063 }
+RowDump { collection: "tasks", pk: "pk-00005064", payload: Some("{\"idx\": 5064, \"edit\": \"update\"}"), version: 20111, deleted: false, device_id: "device-250", created_version: 5064 }
+RowDump { collection: "tasks", pk: "pk-00005065", payload: Some("{\"idx\": 5065, \"edit\": \"update\"}"), version: 20112, deleted: false, device_id: "device-250", created_version: 5065 }
+RowDump { collection: "tasks", pk: "pk-00005066", payload: Some("{\"idx\": 5066, \"edit\": \"update\"}"), version: 20113, deleted: false, device_id: "device-250", created_version: 5066 }
+RowDump { collection: "tasks", pk: "pk-00005067", payload: Some("{\"idx\": 5067, \"edit\": \"update\"}"), version: 20114, deleted: false, device_id: "device-250", created_version: 5067 }
+RowDump { collection: "tasks", pk: "pk-00005068", payload: Some("{\"idx\": 5068, \"edit\": \"update\"}"), version: 20115, deleted: false, device_id: "device-250", created_version: 5068 }
+RowDump { collection: "tasks", pk: "pk-00005069", payload: Some("{\"idx\": 5069, \"edit\": \"update\"}"), version: 20116, deleted: false, device_id: "device-250", created_version: 5069 }
+RowDump { collection: "tasks", pk: "pk-00005070", payload: Some("{\"idx\": 5070, \"edit\": \"update\"}"), version: 20117, deleted: false, device_id: "device-250", created_version: 5070 }
+RowDump { collection: "tasks", pk: "pk-00005071", payload: Some("{\"idx\": 5071, \"edit\": \"update\"}"), version: 20118, deleted: false, device_id: "device-250", created_version: 5071 }
+RowDump { collection: "tasks", pk: "pk-00005072", payload: Some("{\"idx\": 5072, \"edit\": \"update\"}"), version: 20119, deleted: false, device_id: "device-250", created_version: 5072 }
+RowDump { collection: "tasks", pk: "pk-00005073", payload: Some("{\"idx\": 5073, \"edit\": \"update\"}"), version: 20120, deleted: false, device_id: "device-250", created_version: 5073 }
+RowDump { collection: "tasks", pk: "pk-00005074", payload: Some("{\"idx\": 5074, \"edit\": \"update\"}"), version: 20121, deleted: false, device_id: "device-250", created_version: 5074 }
+RowDump { collection: "files", pk: "pk-00005075", payload: Some("{\"idx\": 5075, \"edit\": \"update\"}"), version: 20122, deleted: false, device_id: "device-250", created_version: 5075 }
+RowDump { collection: "files", pk: "pk-00005076", payload: Some("{\"idx\": 5076, \"edit\": \"update\"}"), version: 20123, deleted: false, device_id: "device-250", created_version: 5076 }
+RowDump { collection: "files", pk: "pk-00005077", payload: Some("{\"idx\": 5077, \"edit\": \"update\"}"), version: 20124, deleted: false, device_id: "device-250", created_version: 5077 }
+RowDump { collection: "files", pk: "pk-00005078", payload: Some("{\"idx\": 5078, \"edit\": \"update\"}"), version: 20125, deleted: false, device_id: "device-250", created_version: 5078 }
+RowDump { collection: "files", pk: "pk-00005079", payload: Some("{\"idx\": 5079, \"edit\": \"update\"}"), version: 20126, deleted: false, device_id: "device-250", created_version: 5079 }
+RowDump { collection: "files", pk: "pk-00005081", payload: Some("{\"idx\": 5081, \"edit\": \"update\"}"), version: 20127, deleted: false, device_id: "device-250", created_version: 5081 }
+RowDump { collection: "files", pk: "pk-00005082", payload: Some("{\"idx\": 5082, \"edit\": \"update\"}"), version: 20128, deleted: false, device_id: "device-250", created_version: 5082 }
+RowDump { collection: "files", pk: "pk-00005083", payload: Some("{\"idx\": 5083, \"edit\": \"update\"}"), version: 20129, deleted: false, device_id: "device-250", created_version: 5083 }
+RowDump { collection: "files", pk: "pk-00005084", payload: Some("{\"idx\": 5084, \"edit\": \"update\"}"), version: 20130, deleted: false, device_id: "device-250", created_version: 5084 }
+RowDump { collection: "files", pk: "pk-00005085", payload: Some("{\"idx\": 5085, \"edit\": \"update\"}"), version: 20131, deleted: false, device_id: "device-250", created_version: 5085 }
+RowDump { collection: "files", pk: "pk-00005086", payload: Some("{\"idx\": 5086, \"edit\": \"update\"}"), version: 20132, deleted: false, device_id: "device-250", created_version: 5086 }
+RowDump { collection: "files", pk: "pk-00005087", payload: Some("{\"idx\": 5087, \"edit\": \"update\"}"), version: 20133, deleted: false, device_id: "device-250", created_version: 5087 }
+RowDump { collection: "files", pk: "pk-00005088", payload: Some("{\"idx\": 5088, \"edit\": \"update\"}"), version: 20134, deleted: false, device_id: "device-250", created_version: 5088 }
+RowDump { collection: "files", pk: "pk-00005089", payload: Some("{\"idx\": 5089, \"edit\": \"update\"}"), version: 20135, deleted: false, device_id: "device-250", created_version: 5089 }
+RowDump { collection: "tags", pk: "pk-00005090", payload: Some("{\"idx\": 5090, \"edit\": \"update\"}"), version: 20136, deleted: false, device_id: "device-250", created_version: 5090 }
+RowDump { collection: "tags", pk: "pk-00005091", payload: Some("{\"idx\": 5091, \"edit\": \"update\"}"), version: 20137, deleted: false, device_id: "device-250", created_version: 5091 }
+RowDump { collection: "tags", pk: "pk-00005092", payload: Some("{\"idx\": 5092, \"edit\": \"update\"}"), version: 20138, deleted: false, device_id: "device-250", created_version: 5092 }
+RowDump { collection: "tags", pk: "pk-00005093", payload: Some("{\"idx\": 5093, \"edit\": \"update\"}"), version: 20139, deleted: false, device_id: "device-250", created_version: 5093 }
+RowDump { collection: "tags", pk: "pk-00005094", payload: Some("{\"idx\": 5094, \"edit\": \"update\"}"), version: 20140, deleted: false, device_id: "device-250", created_version: 5094 }
+RowDump { collection: "tags", pk: "pk-00005095", payload: Some("{\"idx\": 5095, \"edit\": \"update\"}"), version: 20141, deleted: false, device_id: "device-250", created_version: 5095 }
+RowDump { collection: "tags", pk: "pk-00005096", payload: Some("{\"idx\": 5096, \"edit\": \"update\"}"), version: 20142, deleted: false, device_id: "device-250", created_version: 5096 }
+RowDump { collection: "archive", pk: "pk-00005097", payload: Some("{\"idx\": 5097, \"edit\": \"update\"}"), version: 20143, deleted: false, device_id: "device-250", created_version: 5097 }
+RowDump { collection: "archive", pk: "pk-00005098", payload: Some("{\"idx\": 5098, \"edit\": \"update\"}"), version: 20144, deleted: false, device_id: "device-250", created_version: 5098 }
+RowDump { collection: "archive", pk: "pk-00005099", payload: Some("{\"idx\": 5099, \"edit\": \"update\"}"), version: 20145, deleted: false, device_id: "device-250", created_version: 5099 }
+RowDump { collection: "notes", pk: "pk-00005101", payload: Some("{\"idx\": 5101, \"edit\": \"update\"}"), version: 20146, deleted: false, device_id: "device-250", created_version: 5101 }
+RowDump { collection: "notes", pk: "pk-00005102", payload: Some("{\"idx\": 5102, \"edit\": \"update\"}"), version: 20147, deleted: false, device_id: "device-250", created_version: 5102 }
+RowDump { collection: "notes", pk: "pk-00005103", payload: Some("{\"idx\": 5103, \"edit\": \"update\"}"), version: 20148, deleted: false, device_id: "device-250", created_version: 5103 }
+RowDump { collection: "notes", pk: "pk-00005104", payload: Some("{\"idx\": 5104, \"edit\": \"update\"}"), version: 20149, deleted: false, device_id: "device-250", created_version: 5104 }
+RowDump { collection: "notes", pk: "pk-00005105", payload: Some("{\"idx\": 5105, \"edit\": \"update\"}"), version: 20150, deleted: false, device_id: "device-250", created_version: 5105 }
+RowDump { collection: "notes", pk: "pk-00005106", payload: Some("{\"idx\": 5106, \"edit\": \"update\"}"), version: 20151, deleted: false, device_id: "device-250", created_version: 5106 }
+RowDump { collection: "notes", pk: "pk-00005107", payload: Some("{\"idx\": 5107, \"edit\": \"update\"}"), version: 20152, deleted: false, device_id: "device-250", created_version: 5107 }
+RowDump { collection: "notes", pk: "pk-00005108", payload: Some("{\"idx\": 5108, \"edit\": \"update\"}"), version: 20153, deleted: false, device_id: "device-250", created_version: 5108 }
+RowDump { collection: "notes", pk: "pk-00005109", payload: Some("{\"idx\": 5109, \"edit\": \"update\"}"), version: 20154, deleted: false, device_id: "device-250", created_version: 5109 }
+RowDump { collection: "notes", pk: "pk-00005110", payload: Some("{\"idx\": 5110, \"edit\": \"update\"}"), version: 20155, deleted: false, device_id: "device-250", created_version: 5110 }
+RowDump { collection: "notes", pk: "pk-00005111", payload: Some("{\"idx\": 5111, \"edit\": \"update\"}"), version: 20156, deleted: false, device_id: "device-250", created_version: 5111 }
+RowDump { collection: "notes", pk: "pk-00005112", payload: Some("{\"idx\": 5112, \"edit\": \"update\"}"), version: 20157, deleted: false, device_id: "device-250", created_version: 5112 }
+RowDump { collection: "notes", pk: "pk-00005113", payload: Some("{\"idx\": 5113, \"edit\": \"update\"}"), version: 20158, deleted: false, device_id: "device-250", created_version: 5113 }
+RowDump { collection: "notes", pk: "pk-00005114", payload: Some("{\"idx\": 5114, \"edit\": \"update\"}"), version: 20159, deleted: false, device_id: "device-250", created_version: 5114 }
+RowDump { collection: "notes", pk: "pk-00005115", payload: Some("{\"idx\": 5115, \"edit\": \"update\"}"), version: 20160, deleted: false, device_id: "device-250", created_version: 5115 }
+RowDump { collection: "notes", pk: "pk-00005116", payload: Some("{\"idx\": 5116, \"edit\": \"update\"}"), version: 20161, deleted: false, device_id: "device-250", created_version: 5116 }
+RowDump { collection: "notes", pk: "pk-00005117", payload: Some("{\"idx\": 5117, \"edit\": \"update\"}"), version: 20162, deleted: false, device_id: "device-250", created_version: 5117 }
+RowDump { collection: "notes", pk: "pk-00005118", payload: Some("{\"idx\": 5118, \"edit\": \"update\"}"), version: 20163, deleted: false, device_id: "device-250", created_version: 5118 }
+RowDump { collection: "notes", pk: "pk-00005119", payload: Some("{\"idx\": 5119, \"edit\": \"update\"}"), version: 20164, deleted: false, device_id: "device-250", created_version: 5119 }
+RowDump { collection: "notes", pk: "pk-00005121", payload: Some("{\"idx\": 5121, \"edit\": \"update\"}"), version: 20165, deleted: false, device_id: "device-250", created_version: 5121 }
+RowDump { collection: "notes", pk: "pk-00005122", payload: Some("{\"idx\": 5122, \"edit\": \"update\"}"), version: 20166, deleted: false, device_id: "device-250", created_version: 5122 }
+RowDump { collection: "notes", pk: "pk-00005123", payload: Some("{\"idx\": 5123, \"edit\": \"update\"}"), version: 20167, deleted: false, device_id: "device-250", created_version: 5123 }
+RowDump { collection: "notes", pk: "pk-00005124", payload: Some("{\"idx\": 5124, \"edit\": \"update\"}"), version: 20168, deleted: false, device_id: "device-250", created_version: 5124 }
+RowDump { collection: "notes", pk: "pk-00005125", payload: Some("{\"idx\": 5125, \"edit\": \"update\"}"), version: 20169, deleted: false, device_id: "device-250", created_version: 5125 }
+RowDump { collection: "notes", pk: "pk-00005126", payload: Some("{\"idx\": 5126, \"edit\": \"update\"}"), version: 20170, deleted: false, device_id: "device-250", created_version: 5126 }
+RowDump { collection: "notes", pk: "pk-00005127", payload: Some("{\"idx\": 5127, \"edit\": \"update\"}"), version: 20171, deleted: false, device_id: "device-250", created_version: 5127 }
+RowDump { collection: "notes", pk: "pk-00005128", payload: Some("{\"idx\": 5128, \"edit\": \"update\"}"), version: 20172, deleted: false, device_id: "device-250", created_version: 5128 }
+RowDump { collection: "notes", pk: "pk-00005129", payload: Some("{\"idx\": 5129, \"edit\": \"update\"}"), version: 20173, deleted: false, device_id: "device-250", created_version: 5129 }
+RowDump { collection: "notes", pk: "pk-00005130", payload: Some("{\"idx\": 5130, \"edit\": \"update\"}"), version: 20174, deleted: false, device_id: "device-250", created_version: 5130 }
+RowDump { collection: "notes", pk: "pk-00005131", payload: Some("{\"idx\": 5131, \"edit\": \"update\"}"), version: 20175, deleted: false, device_id: "device-250", created_version: 5131 }
+RowDump { collection: "notes", pk: "pk-00005132", payload: Some("{\"idx\": 5132, \"edit\": \"update\"}"), version: 20176, deleted: false, device_id: "device-250", created_version: 5132 }
+RowDump { collection: "notes", pk: "pk-00005133", payload: Some("{\"idx\": 5133, \"edit\": \"update\"}"), version: 20177, deleted: false, device_id: "device-250", created_version: 5133 }
+RowDump { collection: "notes", pk: "pk-00005134", payload: Some("{\"idx\": 5134, \"edit\": \"update\"}"), version: 20178, deleted: false, device_id: "device-250", created_version: 5134 }
+RowDump { collection: "notes", pk: "pk-00005135", payload: Some("{\"idx\": 5135, \"edit\": \"update\"}"), version: 20179, deleted: false, device_id: "device-250", created_version: 5135 }
+RowDump { collection: "notes", pk: "pk-00005136", payload: Some("{\"idx\": 5136, \"edit\": \"update\"}"), version: 20180, deleted: false, device_id: "device-250", created_version: 5136 }
+RowDump { collection: "notes", pk: "pk-00005137", payload: Some("{\"idx\": 5137, \"edit\": \"update\"}"), version: 20181, deleted: false, device_id: "device-250", created_version: 5137 }
+RowDump { collection: "notes", pk: "pk-00005138", payload: Some("{\"idx\": 5138, \"edit\": \"update\"}"), version: 20182, deleted: false, device_id: "device-250", created_version: 5138 }
+RowDump { collection: "notes", pk: "pk-00005139", payload: Some("{\"idx\": 5139, \"edit\": \"update\"}"), version: 20183, deleted: false, device_id: "device-250", created_version: 5139 }
+RowDump { collection: "contacts", pk: "pk-00005141", payload: Some("{\"idx\": 5141, \"edit\": \"update\"}"), version: 20184, deleted: false, device_id: "device-250", created_version: 5141 }
+RowDump { collection: "contacts", pk: "pk-00005142", payload: Some("{\"idx\": 5142, \"edit\": \"update\"}"), version: 20185, deleted: false, device_id: "device-250", created_version: 5142 }
+RowDump { collection: "contacts", pk: "pk-00005143", payload: Some("{\"idx\": 5143, \"edit\": \"update\"}"), version: 20186, deleted: false, device_id: "device-250", created_version: 5143 }
+RowDump { collection: "contacts", pk: "pk-00005144", payload: Some("{\"idx\": 5144, \"edit\": \"update\"}"), version: 20187, deleted: false, device_id: "device-250", created_version: 5144 }
+RowDump { collection: "contacts", pk: "pk-00005145", payload: Some("{\"idx\": 5145, \"edit\": \"update\"}"), version: 20188, deleted: false, device_id: "device-250", created_version: 5145 }
+RowDump { collection: "contacts", pk: "pk-00005146", payload: Some("{\"idx\": 5146, \"edit\": \"update\"}"), version: 20189, deleted: false, device_id: "device-250", created_version: 5146 }
+RowDump { collection: "contacts", pk: "pk-00005147", payload: Some("{\"idx\": 5147, \"edit\": \"update\"}"), version: 20190, deleted: false, device_id: "device-250", created_version: 5147 }
+RowDump { collection: "contacts", pk: "pk-00005148", payload: Some("{\"idx\": 5148, \"edit\": \"update\"}"), version: 20191, deleted: false, device_id: "device-250", created_version: 5148 }
+RowDump { collection: "contacts", pk: "pk-00005149", payload: Some("{\"idx\": 5149, \"edit\": \"update\"}"), version: 20192, deleted: false, device_id: "device-250", created_version: 5149 }
+RowDump { collection: "contacts", pk: "pk-00005150", payload: Some("{\"idx\": 5150, \"edit\": \"update\"}"), version: 20193, deleted: false, device_id: "device-250", created_version: 5150 }
+RowDump { collection: "contacts", pk: "pk-00005151", payload: Some("{\"idx\": 5151, \"edit\": \"update\"}"), version: 20194, deleted: false, device_id: "device-250", created_version: 5151 }
+RowDump { collection: "contacts", pk: "pk-00005152", payload: Some("{\"idx\": 5152, \"edit\": \"update\"}"), version: 20195, deleted: false, device_id: "device-250", created_version: 5152 }
+RowDump { collection: "contacts", pk: "pk-00005153", payload: Some("{\"idx\": 5153, \"edit\": \"update\"}"), version: 20196, deleted: false, device_id: "device-250", created_version: 5153 }
+RowDump { collection: "contacts", pk: "pk-00005154", payload: Some("{\"idx\": 5154, \"edit\": \"update\"}"), version: 20197, deleted: false, device_id: "device-250", created_version: 5154 }
+RowDump { collection: "contacts", pk: "pk-00005155", payload: Some("{\"idx\": 5155, \"edit\": \"update\"}"), version: 20198, deleted: false, device_id: "device-250", created_version: 5155 }
+RowDump { collection: "contacts", pk: "pk-00005156", payload: Some("{\"idx\": 5156, \"edit\": \"update\"}"), version: 20199, deleted: false, device_id: "device-250", created_version: 5156 }
+RowDump { collection: "contacts", pk: "pk-00005157", payload: Some("{\"idx\": 5157, \"edit\": \"update\"}"), version: 20200, deleted: false, device_id: "device-250", created_version: 5157 }
+RowDump { collection: "contacts", pk: "pk-00005158", payload: Some("{\"idx\": 5158, \"edit\": \"update\"}"), version: 20201, deleted: false, device_id: "device-250", created_version: 5158 }
+RowDump { collection: "contacts", pk: "pk-00005159", payload: Some("{\"idx\": 5159, \"edit\": \"update\"}"), version: 20202, deleted: false, device_id: "device-250", created_version: 5159 }
+RowDump { collection: "tasks", pk: "pk-00005161", payload: Some("{\"idx\": 5161, \"edit\": \"update\"}"), version: 20203, deleted: false, device_id: "device-250", created_version: 5161 }
+RowDump { collection: "tasks", pk: "pk-00005162", payload: Some("{\"idx\": 5162, \"edit\": \"update\"}"), version: 20204, deleted: false, device_id: "device-250", created_version: 5162 }
+RowDump { collection: "tasks", pk: "pk-00005163", payload: Some("{\"idx\": 5163, \"edit\": \"update\"}"), version: 20205, deleted: false, device_id: "device-250", created_version: 5163 }
+RowDump { collection: "tasks", pk: "pk-00005164", payload: Some("{\"idx\": 5164, \"edit\": \"update\"}"), version: 20206, deleted: false, device_id: "device-250", created_version: 5164 }
+RowDump { collection: "tasks", pk: "pk-00005165", payload: Some("{\"idx\": 5165, \"edit\": \"update\"}"), version: 20207, deleted: false, device_id: "device-250", created_version: 5165 }
+RowDump { collection: "tasks", pk: "pk-00005166", payload: Some("{\"idx\": 5166, \"edit\": \"update\"}"), version: 20208, deleted: false, device_id: "device-250", created_version: 5166 }
+RowDump { collection: "tasks", pk: "pk-00005167", payload: Some("{\"idx\": 5167, \"edit\": \"update\"}"), version: 20209, deleted: false, device_id: "device-250", created_version: 5167 }
+RowDump { collection: "tasks", pk: "pk-00005168", payload: Some("{\"idx\": 5168, \"edit\": \"update\"}"), version: 20210, deleted: false, device_id: "device-250", created_version: 5168 }
+RowDump { collection: "tasks", pk: "pk-00005169", payload: None, version: 20261, deleted: true, device_id: "device-250", created_version: 5169 }
+RowDump { collection: "tasks", pk: "pk-00005170", payload: None, version: 20262, deleted: true, device_id: "device-250", created_version: 5170 }
+RowDump { collection: "tasks", pk: "pk-00005171", payload: None, version: 20263, deleted: true, device_id: "device-250", created_version: 5171 }
+RowDump { collection: "tasks", pk: "pk-00005172", payload: None, version: 20264, deleted: true, device_id: "device-250", created_version: 5172 }
+RowDump { collection: "tasks", pk: "pk-00005173", payload: None, version: 20265, deleted: true, device_id: "device-250", created_version: 5173 }
+RowDump { collection: "tasks", pk: "pk-00005174", payload: None, version: 20266, deleted: true, device_id: "device-250", created_version: 5174 }
+RowDump { collection: "files", pk: "pk-00005175", payload: None, version: 20267, deleted: true, device_id: "device-250", created_version: 5175 }
+RowDump { collection: "files", pk: "pk-00005176", payload: None, version: 20268, deleted: true, device_id: "device-250", created_version: 5176 }
+RowDump { collection: "files", pk: "pk-00005177", payload: None, version: 20269, deleted: true, device_id: "device-250", created_version: 5177 }
+RowDump { collection: "files", pk: "pk-00005178", payload: None, version: 20270, deleted: true, device_id: "device-250", created_version: 5178 }
+RowDump { collection: "files", pk: "pk-00005179", payload: None, version: 20271, deleted: true, device_id: "device-250", created_version: 5179 }
+RowDump { collection: "files", pk: "pk-00005181", payload: None, version: 20272, deleted: true, device_id: "device-250", created_version: 5181 }
+RowDump { collection: "files", pk: "pk-00005182", payload: Some("{\"p\": 0, \"edit\": \"dup-existing-2\"}"), version: 20274, deleted: false, device_id: "device-250", created_version: 5182 }
+RowDump { collection: "files", pk: "pk-00005183", payload: Some("{\"p\": 1, \"edit\": \"dup-existing-2\"}"), version: 20276, deleted: false, device_id: "device-250", created_version: 5183 }
+RowDump { collection: "files", pk: "pk-00005184", payload: Some("{\"p\": 2, \"edit\": \"dup-existing-2\"}"), version: 20278, deleted: false, device_id: "device-250", created_version: 5184 }
+RowDump { collection: "files", pk: "pk-00005185", payload: Some("{\"p\": 3, \"edit\": \"dup-existing-2\"}"), version: 20280, deleted: false, device_id: "device-250", created_version: 5185 }
+RowDump { collection: "files", pk: "pk-00005186", payload: Some("{\"p\": 4, \"edit\": \"dup-existing-2\"}"), version: 20282, deleted: false, device_id: "device-250", created_version: 5186 }
+RowDump { collection: "files", pk: "pk-00005187", payload: Some("{\"p\": 5, \"edit\": \"dup-existing-2\"}"), version: 20284, deleted: false, device_id: "device-250", created_version: 5187 }
+RowDump { collection: "files", pk: "pk-00005188", payload: Some("{\"p\": 6, \"edit\": \"dup-existing-2\"}"), version: 20286, deleted: false, device_id: "device-250", created_version: 5188 }
+RowDump { collection: "files", pk: "pk-00005189", payload: Some("{\"p\": 7, \"edit\": \"dup-existing-2\"}"), version: 20288, deleted: false, device_id: "device-250", created_version: 5189 }
+RowDump { collection: "tags", pk: "pk-00005190", payload: Some("{\"p\": 8, \"edit\": \"dup-existing-2\"}"), version: 20290, deleted: false, device_id: "device-250", created_version: 5190 }
+RowDump { collection: "tags", pk: "pk-00005191", payload: Some("{\"p\": 9, \"edit\": \"dup-existing-2\"}"), version: 20292, deleted: false, device_id: "device-250", created_version: 5191 }
+
+=== pg_stat_statements: push batch of 1000 changes ===
+-- top by calls --
+calls=1      buffers=4      SELECT change_id, version, resolved_row FROM autumn_sync_applied WHERE scope = $1 AND device_id = $2 AND change_id = ANY($3)
+calls=1      buffers=1012   SELECT nextval($2) AS version FROM generate_series($3, $1)
+calls=1      buffers=11709  INSERT INTO autumn_sync_rows (scope, collection, pk, payload, version, deleted, updated_at, device_id, created_version) SELECT $1, t.* FROM UNNEST( $2::text[], $3::text[], $4::jsonb[], $5::bigint[], $6::bool[], $7::timestamptz[], $8::text[], $9::bigint[] ) AS t(collection, pk, payload, version, deleted, updated_at, device_id, created_version) ON CONFLICT (scope, collection, pk) DO UPDATE SET payload = excluded.payload, version = excluded.version, deleted = excluded.deleted, updated_at = excluded.updated_at, device_id = excluded.device_id, created_version = excluded.created_version
+calls=1      buffers=4560   SELECT collection, pk, payload, version, deleted, updated_at, device_id, created_version FROM autumn_sync_rows WHERE scope = $1 AND (collection, pk) IN ( SELECT * FROM UNNEST($2::text[], $3::text[]) ) FOR UPDATE
+calls=1      buffers=3055   INSERT INTO autumn_sync_applied (scope, device_id, change_id, version, resolved_row) SELECT $1, $2, t.change_id, t.version, t.resolved_row FROM UNNEST($3::text[], $4::bigint[], $5::jsonb[]) AS t(change_id, version, resolved_row)
+calls=1      buffers=0      SELECT horizon AS version FROM autumn_sync_horizons WHERE scope = $1
+-- top by buffers --
+buffers=11709  calls=1      INSERT INTO autumn_sync_rows (scope, collection, pk, payload, version, deleted, updated_at, device_id, created_version) SELECT $1, t.* FROM UNNEST( $2::text[], $3::text[], $4::jsonb[], $5::bigint[], $6::bool[], $7::timestamptz[], $8::text[], $9::bigint[] ) AS t(collection, pk, payload, version, deleted, updated_at, device_id, created_version) ON CONFLICT (scope, collection, pk) DO UPDATE SET payload = excluded.payload, version = excluded.version, deleted = excluded.deleted, updated_at = excluded.updated_at, device_id = excluded.device_id, created_version = excluded.created_version
+buffers=4560   calls=1      SELECT collection, pk, payload, version, deleted, updated_at, device_id, created_version FROM autumn_sync_rows WHERE scope = $1 AND (collection, pk) IN ( SELECT * FROM UNNEST($2::text[], $3::text[]) ) FOR UPDATE
+buffers=3055   calls=1      INSERT INTO autumn_sync_applied (scope, device_id, change_id, version, resolved_row) SELECT $1, $2, t.change_id, t.version, t.resolved_row FROM UNNEST($3::text[], $4::bigint[], $5::jsonb[]) AS t(change_id, version, resolved_row)
+buffers=1012   calls=1      SELECT nextval($2) AS version FROM generate_series($3, $1)
+buffers=4      calls=1      SELECT change_id, version, resolved_row FROM autumn_sync_applied WHERE scope = $1 AND device_id = $2 AND change_id = ANY($3)
+buffers=0      calls=1      SELECT horizon AS version FROM autumn_sync_horizons WHERE scope = $1
+TOTAL sync-table statement calls=6 buffers=20340 (this batch, all statement shapes)
+-- row dump (new/newdup pks), 210 rows --
+RowDump { collection: "notes", pk: "new-device-1000-000000", payload: Some("{\"k\": 0, \"edit\": \"insert\"}"), version: 20951, deleted: false, device_id: "device-1000", created_version: 20951 }
+RowDump { collection: "notes", pk: "new-device-1000-000001", payload: Some("{\"k\": 1, \"edit\": \"insert\"}"), version: 20952, deleted: false, device_id: "device-1000", created_version: 20952 }
+RowDump { collection: "notes", pk: "new-device-1000-000002", payload: Some("{\"k\": 2, \"edit\": \"insert\"}"), version: 20953, deleted: false, device_id: "device-1000", created_version: 20953 }
+RowDump { collection: "notes", pk: "new-device-1000-000003", payload: Some("{\"k\": 3, \"edit\": \"insert\"}"), version: 20954, deleted: false, device_id: "device-1000", created_version: 20954 }
+RowDump { collection: "notes", pk: "new-device-1000-000004", payload: Some("{\"k\": 4, \"edit\": \"insert\"}"), version: 20955, deleted: false, device_id: "device-1000", created_version: 20955 }
+RowDump { collection: "notes", pk: "new-device-1000-000005", payload: Some("{\"k\": 5, \"edit\": \"insert\"}"), version: 20956, deleted: false, device_id: "device-1000", created_version: 20956 }
+RowDump { collection: "notes", pk: "new-device-1000-000006", payload: Some("{\"k\": 6, \"edit\": \"insert\"}"), version: 20957, deleted: false, device_id: "device-1000", created_version: 20957 }
+RowDump { collection: "notes", pk: "new-device-1000-000007", payload: Some("{\"k\": 7, \"edit\": \"insert\"}"), version: 20958, deleted: false, device_id: "device-1000", created_version: 20958 }
+RowDump { collection: "notes", pk: "new-device-1000-000008", payload: Some("{\"k\": 8, \"edit\": \"insert\"}"), version: 20959, deleted: false, device_id: "device-1000", created_version: 20959 }
+RowDump { collection: "notes", pk: "new-device-1000-000009", payload: Some("{\"k\": 9, \"edit\": \"insert\"}"), version: 20960, deleted: false, device_id: "device-1000", created_version: 20960 }
+RowDump { collection: "notes", pk: "new-device-1000-000010", payload: Some("{\"k\": 10, \"edit\": \"insert\"}"), version: 20961, deleted: false, device_id: "device-1000", created_version: 20961 }
+RowDump { collection: "notes", pk: "new-device-1000-000011", payload: Some("{\"k\": 11, \"edit\": \"insert\"}"), version: 20962, deleted: false, device_id: "device-1000", created_version: 20962 }
+RowDump { collection: "notes", pk: "new-device-1000-000012", payload: Some("{\"k\": 12, \"edit\": \"insert\"}"), version: 20963, deleted: false, device_id: "device-1000", created_version: 20963 }
+RowDump { collection: "notes", pk: "new-device-1000-000013", payload: Some("{\"k\": 13, \"edit\": \"insert\"}"), version: 20964, deleted: false, device_id: "device-1000", created_version: 20964 }
+RowDump { collection: "notes", pk: "new-device-1000-000014", payload: Some("{\"k\": 14, \"edit\": \"insert\"}"), version: 20965, deleted: false, device_id: "device-1000", created_version: 20965 }
+RowDump { collection: "notes", pk: "new-device-1000-000015", payload: Some("{\"k\": 15, \"edit\": \"insert\"}"), version: 20966, deleted: false, device_id: "device-1000", created_version: 20966 }
+RowDump { collection: "notes", pk: "new-device-1000-000016", payload: Some("{\"k\": 16, \"edit\": \"insert\"}"), version: 20967, deleted: false, device_id: "device-1000", created_version: 20967 }
+RowDump { collection: "notes", pk: "new-device-1000-000017", payload: Some("{\"k\": 17, \"edit\": \"insert\"}"), version: 20968, deleted: false, device_id: "device-1000", created_version: 20968 }
+RowDump { collection: "notes", pk: "new-device-1000-000018", payload: Some("{\"k\": 18, \"edit\": \"insert\"}"), version: 20969, deleted: false, device_id: "device-1000", created_version: 20969 }
+RowDump { collection: "notes", pk: "new-device-1000-000019", payload: Some("{\"k\": 19, \"edit\": \"insert\"}"), version: 20970, deleted: false, device_id: "device-1000", created_version: 20970 }
+RowDump { collection: "notes", pk: "new-device-1000-000020", payload: Some("{\"k\": 20, \"edit\": \"insert\"}"), version: 20971, deleted: false, device_id: "device-1000", created_version: 20971 }
+RowDump { collection: "notes", pk: "new-device-1000-000021", payload: Some("{\"k\": 21, \"edit\": \"insert\"}"), version: 20972, deleted: false, device_id: "device-1000", created_version: 20972 }
+RowDump { collection: "notes", pk: "new-device-1000-000022", payload: Some("{\"k\": 22, \"edit\": \"insert\"}"), version: 20973, deleted: false, device_id: "device-1000", created_version: 20973 }
+RowDump { collection: "notes", pk: "new-device-1000-000023", payload: Some("{\"k\": 23, \"edit\": \"insert\"}"), version: 20974, deleted: false, device_id: "device-1000", created_version: 20974 }
+RowDump { collection: "notes", pk: "new-device-1000-000024", payload: Some("{\"k\": 24, \"edit\": \"insert\"}"), version: 20975, deleted: false, device_id: "device-1000", created_version: 20975 }
+RowDump { collection: "notes", pk: "new-device-1000-000025", payload: Some("{\"k\": 25, \"edit\": \"insert\"}"), version: 20976, deleted: false, device_id: "device-1000", created_version: 20976 }
+RowDump { collection: "notes", pk: "new-device-1000-000026", payload: Some("{\"k\": 26, \"edit\": \"insert\"}"), version: 20977, deleted: false, device_id: "device-1000", created_version: 20977 }
+RowDump { collection: "notes", pk: "new-device-1000-000027", payload: Some("{\"k\": 27, \"edit\": \"insert\"}"), version: 20978, deleted: false, device_id: "device-1000", created_version: 20978 }
+RowDump { collection: "notes", pk: "new-device-1000-000028", payload: Some("{\"k\": 28, \"edit\": \"insert\"}"), version: 20979, deleted: false, device_id: "device-1000", created_version: 20979 }
+RowDump { collection: "notes", pk: "new-device-1000-000029", payload: Some("{\"k\": 29, \"edit\": \"insert\"}"), version: 20980, deleted: false, device_id: "device-1000", created_version: 20980 }
+RowDump { collection: "notes", pk: "new-device-1000-000030", payload: Some("{\"k\": 30, \"edit\": \"insert\"}"), version: 20981, deleted: false, device_id: "device-1000", created_version: 20981 }
+RowDump { collection: "notes", pk: "new-device-1000-000031", payload: Some("{\"k\": 31, \"edit\": \"insert\"}"), version: 20982, deleted: false, device_id: "device-1000", created_version: 20982 }
+RowDump { collection: "notes", pk: "new-device-1000-000032", payload: Some("{\"k\": 32, \"edit\": \"insert\"}"), version: 20983, deleted: false, device_id: "device-1000", created_version: 20983 }
+RowDump { collection: "notes", pk: "new-device-1000-000033", payload: Some("{\"k\": 33, \"edit\": \"insert\"}"), version: 20984, deleted: false, device_id: "device-1000", created_version: 20984 }
+RowDump { collection: "notes", pk: "new-device-1000-000034", payload: Some("{\"k\": 34, \"edit\": \"insert\"}"), version: 20985, deleted: false, device_id: "device-1000", created_version: 20985 }
+RowDump { collection: "notes", pk: "new-device-1000-000035", payload: Some("{\"k\": 35, \"edit\": \"insert\"}"), version: 20986, deleted: false, device_id: "device-1000", created_version: 20986 }
+RowDump { collection: "notes", pk: "new-device-1000-000036", payload: Some("{\"k\": 36, \"edit\": \"insert\"}"), version: 20987, deleted: false, device_id: "device-1000", created_version: 20987 }
+RowDump { collection: "notes", pk: "new-device-1000-000037", payload: Some("{\"k\": 37, \"edit\": \"insert\"}"), version: 20988, deleted: false, device_id: "device-1000", created_version: 20988 }
+RowDump { collection: "notes", pk: "new-device-1000-000038", payload: Some("{\"k\": 38, \"edit\": \"insert\"}"), version: 20989, deleted: false, device_id: "device-1000", created_version: 20989 }
+RowDump { collection: "notes", pk: "new-device-1000-000039", payload: Some("{\"k\": 39, \"edit\": \"insert\"}"), version: 20990, deleted: false, device_id: "device-1000", created_version: 20990 }
+RowDump { collection: "notes", pk: "new-device-1000-000040", payload: Some("{\"k\": 40, \"edit\": \"insert\"}"), version: 20991, deleted: false, device_id: "device-1000", created_version: 20991 }
+RowDump { collection: "notes", pk: "new-device-1000-000041", payload: Some("{\"k\": 41, \"edit\": \"insert\"}"), version: 20992, deleted: false, device_id: "device-1000", created_version: 20992 }
+RowDump { collection: "notes", pk: "new-device-1000-000042", payload: Some("{\"k\": 42, \"edit\": \"insert\"}"), version: 20993, deleted: false, device_id: "device-1000", created_version: 20993 }
+RowDump { collection: "notes", pk: "new-device-1000-000043", payload: Some("{\"k\": 43, \"edit\": \"insert\"}"), version: 20994, deleted: false, device_id: "device-1000", created_version: 20994 }
+RowDump { collection: "notes", pk: "new-device-1000-000044", payload: Some("{\"k\": 44, \"edit\": \"insert\"}"), version: 20995, deleted: false, device_id: "device-1000", created_version: 20995 }
+RowDump { collection: "notes", pk: "new-device-1000-000045", payload: Some("{\"k\": 45, \"edit\": \"insert\"}"), version: 20996, deleted: false, device_id: "device-1000", created_version: 20996 }
+RowDump { collection: "notes", pk: "new-device-1000-000046", payload: Some("{\"k\": 46, \"edit\": \"insert\"}"), version: 20997, deleted: false, device_id: "device-1000", created_version: 20997 }
+RowDump { collection: "notes", pk: "new-device-1000-000047", payload: Some("{\"k\": 47, \"edit\": \"insert\"}"), version: 20998, deleted: false, device_id: "device-1000", created_version: 20998 }
+RowDump { collection: "notes", pk: "new-device-1000-000048", payload: Some("{\"k\": 48, \"edit\": \"insert\"}"), version: 20999, deleted: false, device_id: "device-1000", created_version: 20999 }
+RowDump { collection: "notes", pk: "new-device-1000-000049", payload: Some("{\"k\": 49, \"edit\": \"insert\"}"), version: 21000, deleted: false, device_id: "device-1000", created_version: 21000 }
+RowDump { collection: "notes", pk: "new-device-1000-000050", payload: Some("{\"k\": 50, \"edit\": \"insert\"}"), version: 21001, deleted: false, device_id: "device-1000", created_version: 21001 }
+RowDump { collection: "notes", pk: "new-device-1000-000051", payload: Some("{\"k\": 51, \"edit\": \"insert\"}"), version: 21002, deleted: false, device_id: "device-1000", created_version: 21002 }
+RowDump { collection: "notes", pk: "new-device-1000-000052", payload: Some("{\"k\": 52, \"edit\": \"insert\"}"), version: 21003, deleted: false, device_id: "device-1000", created_version: 21003 }
+RowDump { collection: "notes", pk: "new-device-1000-000053", payload: Some("{\"k\": 53, \"edit\": \"insert\"}"), version: 21004, deleted: false, device_id: "device-1000", created_version: 21004 }
+RowDump { collection: "notes", pk: "new-device-1000-000054", payload: Some("{\"k\": 54, \"edit\": \"insert\"}"), version: 21005, deleted: false, device_id: "device-1000", created_version: 21005 }
+RowDump { collection: "notes", pk: "new-device-1000-000055", payload: Some("{\"k\": 55, \"edit\": \"insert\"}"), version: 21006, deleted: false, device_id: "device-1000", created_version: 21006 }
+RowDump { collection: "notes", pk: "new-device-1000-000056", payload: Some("{\"k\": 56, \"edit\": \"insert\"}"), version: 21007, deleted: false, device_id: "device-1000", created_version: 21007 }
+RowDump { collection: "notes", pk: "new-device-1000-000057", payload: Some("{\"k\": 57, \"edit\": \"insert\"}"), version: 21008, deleted: false, device_id: "device-1000", created_version: 21008 }
+RowDump { collection: "notes", pk: "new-device-1000-000058", payload: Some("{\"k\": 58, \"edit\": \"insert\"}"), version: 21009, deleted: false, device_id: "device-1000", created_version: 21009 }
+RowDump { collection: "notes", pk: "new-device-1000-000059", payload: Some("{\"k\": 59, \"edit\": \"insert\"}"), version: 21010, deleted: false, device_id: "device-1000", created_version: 21010 }
+RowDump { collection: "notes", pk: "new-device-1000-000060", payload: Some("{\"k\": 60, \"edit\": \"insert\"}"), version: 21011, deleted: false, device_id: "device-1000", created_version: 21011 }
+RowDump { collection: "notes", pk: "new-device-1000-000061", payload: Some("{\"k\": 61, \"edit\": \"insert\"}"), version: 21012, deleted: false, device_id: "device-1000", created_version: 21012 }
+RowDump { collection: "notes", pk: "new-device-1000-000062", payload: Some("{\"k\": 62, \"edit\": \"insert\"}"), version: 21013, deleted: false, device_id: "device-1000", created_version: 21013 }
+RowDump { collection: "notes", pk: "new-device-1000-000063", payload: Some("{\"k\": 63, \"edit\": \"insert\"}"), version: 21014, deleted: false, device_id: "device-1000", created_version: 21014 }
+RowDump { collection: "notes", pk: "new-device-1000-000064", payload: Some("{\"k\": 64, \"edit\": \"insert\"}"), version: 21015, deleted: false, device_id: "device-1000", created_version: 21015 }
+RowDump { collection: "notes", pk: "new-device-1000-000065", payload: Some("{\"k\": 65, \"edit\": \"insert\"}"), version: 21016, deleted: false, device_id: "device-1000", created_version: 21016 }
+RowDump { collection: "notes", pk: "new-device-1000-000066", payload: Some("{\"k\": 66, \"edit\": \"insert\"}"), version: 21017, deleted: false, device_id: "device-1000", created_version: 21017 }
+RowDump { collection: "notes", pk: "new-device-1000-000067", payload: Some("{\"k\": 67, \"edit\": \"insert\"}"), version: 21018, deleted: false, device_id: "device-1000", created_version: 21018 }
+RowDump { collection: "notes", pk: "new-device-1000-000068", payload: Some("{\"k\": 68, \"edit\": \"insert\"}"), version: 21019, deleted: false, device_id: "device-1000", created_version: 21019 }
+RowDump { collection: "notes", pk: "new-device-1000-000069", payload: Some("{\"k\": 69, \"edit\": \"insert\"}"), version: 21020, deleted: false, device_id: "device-1000", created_version: 21020 }
+RowDump { collection: "notes", pk: "new-device-1000-000070", payload: Some("{\"k\": 70, \"edit\": \"insert\"}"), version: 21021, deleted: false, device_id: "device-1000", created_version: 21021 }
+RowDump { collection: "notes", pk: "new-device-1000-000071", payload: Some("{\"k\": 71, \"edit\": \"insert\"}"), version: 21022, deleted: false, device_id: "device-1000", created_version: 21022 }
+RowDump { collection: "notes", pk: "new-device-1000-000072", payload: Some("{\"k\": 72, \"edit\": \"insert\"}"), version: 21023, deleted: false, device_id: "device-1000", created_version: 21023 }
+RowDump { collection: "notes", pk: "new-device-1000-000073", payload: Some("{\"k\": 73, \"edit\": \"insert\"}"), version: 21024, deleted: false, device_id: "device-1000", created_version: 21024 }
+RowDump { collection: "notes", pk: "new-device-1000-000074", payload: Some("{\"k\": 74, \"edit\": \"insert\"}"), version: 21025, deleted: false, device_id: "device-1000", created_version: 21025 }
+RowDump { collection: "notes", pk: "new-device-1000-000075", payload: Some("{\"k\": 75, \"edit\": \"insert\"}"), version: 21026, deleted: false, device_id: "device-1000", created_version: 21026 }
+RowDump { collection: "notes", pk: "new-device-1000-000076", payload: Some("{\"k\": 76, \"edit\": \"insert\"}"), version: 21027, deleted: false, device_id: "device-1000", created_version: 21027 }
+RowDump { collection: "notes", pk: "new-device-1000-000077", payload: Some("{\"k\": 77, \"edit\": \"insert\"}"), version: 21028, deleted: false, device_id: "device-1000", created_version: 21028 }
+RowDump { collection: "notes", pk: "new-device-1000-000078", payload: Some("{\"k\": 78, \"edit\": \"insert\"}"), version: 21029, deleted: false, device_id: "device-1000", created_version: 21029 }
+RowDump { collection: "notes", pk: "new-device-1000-000079", payload: Some("{\"k\": 79, \"edit\": \"insert\"}"), version: 21030, deleted: false, device_id: "device-1000", created_version: 21030 }
+RowDump { collection: "notes", pk: "new-device-1000-000080", payload: Some("{\"k\": 80, \"edit\": \"insert\"}"), version: 21031, deleted: false, device_id: "device-1000", created_version: 21031 }
+RowDump { collection: "notes", pk: "new-device-1000-000081", payload: Some("{\"k\": 81, \"edit\": \"insert\"}"), version: 21032, deleted: false, device_id: "device-1000", created_version: 21032 }
+RowDump { collection: "notes", pk: "new-device-1000-000082", payload: Some("{\"k\": 82, \"edit\": \"insert\"}"), version: 21033, deleted: false, device_id: "device-1000", created_version: 21033 }
+RowDump { collection: "notes", pk: "new-device-1000-000083", payload: Some("{\"k\": 83, \"edit\": \"insert\"}"), version: 21034, deleted: false, device_id: "device-1000", created_version: 21034 }
+RowDump { collection: "notes", pk: "new-device-1000-000084", payload: Some("{\"k\": 84, \"edit\": \"insert\"}"), version: 21035, deleted: false, device_id: "device-1000", created_version: 21035 }
+RowDump { collection: "notes", pk: "new-device-1000-000085", payload: Some("{\"k\": 85, \"edit\": \"insert\"}"), version: 21036, deleted: false, device_id: "device-1000", created_version: 21036 }
+RowDump { collection: "notes", pk: "new-device-1000-000086", payload: Some("{\"k\": 86, \"edit\": \"insert\"}"), version: 21037, deleted: false, device_id: "device-1000", created_version: 21037 }
+RowDump { collection: "notes", pk: "new-device-1000-000087", payload: Some("{\"k\": 87, \"edit\": \"insert\"}"), version: 21038, deleted: false, device_id: "device-1000", created_version: 21038 }
+RowDump { collection: "notes", pk: "new-device-1000-000088", payload: Some("{\"k\": 88, \"edit\": \"insert\"}"), version: 21039, deleted: false, device_id: "device-1000", created_version: 21039 }
+RowDump { collection: "notes", pk: "new-device-1000-000089", payload: Some("{\"k\": 89, \"edit\": \"insert\"}"), version: 21040, deleted: false, device_id: "device-1000", created_version: 21040 }
+RowDump { collection: "notes", pk: "new-device-1000-000090", payload: Some("{\"k\": 90, \"edit\": \"insert\"}"), version: 21041, deleted: false, device_id: "device-1000", created_version: 21041 }
+RowDump { collection: "notes", pk: "new-device-1000-000091", payload: Some("{\"k\": 91, \"edit\": \"insert\"}"), version: 21042, deleted: false, device_id: "device-1000", created_version: 21042 }
+RowDump { collection: "notes", pk: "new-device-1000-000092", payload: Some("{\"k\": 92, \"edit\": \"insert\"}"), version: 21043, deleted: false, device_id: "device-1000", created_version: 21043 }
+RowDump { collection: "notes", pk: "new-device-1000-000093", payload: Some("{\"k\": 93, \"edit\": \"insert\"}"), version: 21044, deleted: false, device_id: "device-1000", created_version: 21044 }
+RowDump { collection: "notes", pk: "new-device-1000-000094", payload: Some("{\"k\": 94, \"edit\": \"insert\"}"), version: 21045, deleted: false, device_id: "device-1000", created_version: 21045 }
+RowDump { collection: "notes", pk: "new-device-1000-000095", payload: Some("{\"k\": 95, \"edit\": \"insert\"}"), version: 21046, deleted: false, device_id: "device-1000", created_version: 21046 }
+RowDump { collection: "notes", pk: "new-device-1000-000096", payload: Some("{\"k\": 96, \"edit\": \"insert\"}"), version: 21047, deleted: false, device_id: "device-1000", created_version: 21047 }
+RowDump { collection: "notes", pk: "new-device-1000-000097", payload: Some("{\"k\": 97, \"edit\": \"insert\"}"), version: 21048, deleted: false, device_id: "device-1000", created_version: 21048 }
+RowDump { collection: "notes", pk: "new-device-1000-000098", payload: Some("{\"k\": 98, \"edit\": \"insert\"}"), version: 21049, deleted: false, device_id: "device-1000", created_version: 21049 }
+RowDump { collection: "notes", pk: "new-device-1000-000099", payload: Some("{\"k\": 99, \"edit\": \"insert\"}"), version: 21050, deleted: false, device_id: "device-1000", created_version: 21050 }
+RowDump { collection: "notes", pk: "new-device-1000-000100", payload: Some("{\"k\": 100, \"edit\": \"insert\"}"), version: 21051, deleted: false, device_id: "device-1000", created_version: 21051 }
+RowDump { collection: "notes", pk: "new-device-1000-000101", payload: Some("{\"k\": 101, \"edit\": \"insert\"}"), version: 21052, deleted: false, device_id: "device-1000", created_version: 21052 }
+RowDump { collection: "notes", pk: "new-device-1000-000102", payload: Some("{\"k\": 102, \"edit\": \"insert\"}"), version: 21053, deleted: false, device_id: "device-1000", created_version: 21053 }
+RowDump { collection: "notes", pk: "new-device-1000-000103", payload: Some("{\"k\": 103, \"edit\": \"insert\"}"), version: 21054, deleted: false, device_id: "device-1000", created_version: 21054 }
+RowDump { collection: "notes", pk: "new-device-1000-000104", payload: Some("{\"k\": 104, \"edit\": \"insert\"}"), version: 21055, deleted: false, device_id: "device-1000", created_version: 21055 }
+RowDump { collection: "notes", pk: "new-device-1000-000105", payload: Some("{\"k\": 105, \"edit\": \"insert\"}"), version: 21056, deleted: false, device_id: "device-1000", created_version: 21056 }
+RowDump { collection: "notes", pk: "new-device-1000-000106", payload: Some("{\"k\": 106, \"edit\": \"insert\"}"), version: 21057, deleted: false, device_id: "device-1000", created_version: 21057 }
+RowDump { collection: "notes", pk: "new-device-1000-000107", payload: Some("{\"k\": 107, \"edit\": \"insert\"}"), version: 21058, deleted: false, device_id: "device-1000", created_version: 21058 }
+RowDump { collection: "notes", pk: "new-device-1000-000108", payload: Some("{\"k\": 108, \"edit\": \"insert\"}"), version: 21059, deleted: false, device_id: "device-1000", created_version: 21059 }
+RowDump { collection: "notes", pk: "new-device-1000-000109", payload: Some("{\"k\": 109, \"edit\": \"insert\"}"), version: 21060, deleted: false, device_id: "device-1000", created_version: 21060 }
+RowDump { collection: "notes", pk: "new-device-1000-000110", payload: Some("{\"k\": 110, \"edit\": \"insert\"}"), version: 21061, deleted: false, device_id: "device-1000", created_version: 21061 }
+RowDump { collection: "notes", pk: "new-device-1000-000111", payload: Some("{\"k\": 111, \"edit\": \"insert\"}"), version: 21062, deleted: false, device_id: "device-1000", created_version: 21062 }
+RowDump { collection: "notes", pk: "new-device-1000-000112", payload: Some("{\"k\": 112, \"edit\": \"insert\"}"), version: 21063, deleted: false, device_id: "device-1000", created_version: 21063 }
+RowDump { collection: "notes", pk: "new-device-1000-000113", payload: Some("{\"k\": 113, \"edit\": \"insert\"}"), version: 21064, deleted: false, device_id: "device-1000", created_version: 21064 }
+RowDump { collection: "notes", pk: "new-device-1000-000114", payload: Some("{\"k\": 114, \"edit\": \"insert\"}"), version: 21065, deleted: false, device_id: "device-1000", created_version: 21065 }
+RowDump { collection: "notes", pk: "new-device-1000-000115", payload: Some("{\"k\": 115, \"edit\": \"insert\"}"), version: 21066, deleted: false, device_id: "device-1000", created_version: 21066 }
+RowDump { collection: "notes", pk: "new-device-1000-000116", payload: Some("{\"k\": 116, \"edit\": \"insert\"}"), version: 21067, deleted: false, device_id: "device-1000", created_version: 21067 }
+RowDump { collection: "notes", pk: "new-device-1000-000117", payload: Some("{\"k\": 117, \"edit\": \"insert\"}"), version: 21068, deleted: false, device_id: "device-1000", created_version: 21068 }
+RowDump { collection: "notes", pk: "new-device-1000-000118", payload: Some("{\"k\": 118, \"edit\": \"insert\"}"), version: 21069, deleted: false, device_id: "device-1000", created_version: 21069 }
+RowDump { collection: "notes", pk: "new-device-1000-000119", payload: Some("{\"k\": 119, \"edit\": \"insert\"}"), version: 21070, deleted: false, device_id: "device-1000", created_version: 21070 }
+RowDump { collection: "notes", pk: "new-device-1000-000120", payload: Some("{\"k\": 120, \"edit\": \"insert\"}"), version: 21071, deleted: false, device_id: "device-1000", created_version: 21071 }
+RowDump { collection: "notes", pk: "new-device-1000-000121", payload: Some("{\"k\": 121, \"edit\": \"insert\"}"), version: 21072, deleted: false, device_id: "device-1000", created_version: 21072 }
+RowDump { collection: "notes", pk: "new-device-1000-000122", payload: Some("{\"k\": 122, \"edit\": \"insert\"}"), version: 21073, deleted: false, device_id: "device-1000", created_version: 21073 }
+RowDump { collection: "notes", pk: "new-device-1000-000123", payload: Some("{\"k\": 123, \"edit\": \"insert\"}"), version: 21074, deleted: false, device_id: "device-1000", created_version: 21074 }
+RowDump { collection: "notes", pk: "new-device-1000-000124", payload: Some("{\"k\": 124, \"edit\": \"insert\"}"), version: 21075, deleted: false, device_id: "device-1000", created_version: 21075 }
+RowDump { collection: "notes", pk: "new-device-1000-000125", payload: Some("{\"k\": 125, \"edit\": \"insert\"}"), version: 21076, deleted: false, device_id: "device-1000", created_version: 21076 }
+RowDump { collection: "notes", pk: "new-device-1000-000126", payload: Some("{\"k\": 126, \"edit\": \"insert\"}"), version: 21077, deleted: false, device_id: "device-1000", created_version: 21077 }
+RowDump { collection: "notes", pk: "new-device-1000-000127", payload: Some("{\"k\": 127, \"edit\": \"insert\"}"), version: 21078, deleted: false, device_id: "device-1000", created_version: 21078 }
+RowDump { collection: "notes", pk: "new-device-1000-000128", payload: Some("{\"k\": 128, \"edit\": \"insert\"}"), version: 21079, deleted: false, device_id: "device-1000", created_version: 21079 }
+RowDump { collection: "notes", pk: "new-device-1000-000129", payload: Some("{\"k\": 129, \"edit\": \"insert\"}"), version: 21080, deleted: false, device_id: "device-1000", created_version: 21080 }
+RowDump { collection: "notes", pk: "new-device-1000-000130", payload: Some("{\"k\": 130, \"edit\": \"insert\"}"), version: 21081, deleted: false, device_id: "device-1000", created_version: 21081 }
+RowDump { collection: "notes", pk: "new-device-1000-000131", payload: Some("{\"k\": 131, \"edit\": \"insert\"}"), version: 21082, deleted: false, device_id: "device-1000", created_version: 21082 }
+RowDump { collection: "notes", pk: "new-device-1000-000132", payload: Some("{\"k\": 132, \"edit\": \"insert\"}"), version: 21083, deleted: false, device_id: "device-1000", created_version: 21083 }
+RowDump { collection: "notes", pk: "new-device-1000-000133", payload: Some("{\"k\": 133, \"edit\": \"insert\"}"), version: 21084, deleted: false, device_id: "device-1000", created_version: 21084 }
+RowDump { collection: "notes", pk: "new-device-1000-000134", payload: Some("{\"k\": 134, \"edit\": \"insert\"}"), version: 21085, deleted: false, device_id: "device-1000", created_version: 21085 }
+RowDump { collection: "notes", pk: "new-device-1000-000135", payload: Some("{\"k\": 135, \"edit\": \"insert\"}"), version: 21086, deleted: false, device_id: "device-1000", created_version: 21086 }
+RowDump { collection: "notes", pk: "new-device-1000-000136", payload: Some("{\"k\": 136, \"edit\": \"insert\"}"), version: 21087, deleted: false, device_id: "device-1000", created_version: 21087 }
+RowDump { collection: "notes", pk: "new-device-1000-000137", payload: Some("{\"k\": 137, \"edit\": \"insert\"}"), version: 21088, deleted: false, device_id: "device-1000", created_version: 21088 }
+RowDump { collection: "notes", pk: "new-device-1000-000138", payload: Some("{\"k\": 138, \"edit\": \"insert\"}"), version: 21089, deleted: false, device_id: "device-1000", created_version: 21089 }
+RowDump { collection: "notes", pk: "new-device-1000-000139", payload: Some("{\"k\": 139, \"edit\": \"insert\"}"), version: 21090, deleted: false, device_id: "device-1000", created_version: 21090 }
+RowDump { collection: "notes", pk: "new-device-1000-000140", payload: Some("{\"k\": 140, \"edit\": \"insert\"}"), version: 21091, deleted: false, device_id: "device-1000", created_version: 21091 }
+RowDump { collection: "notes", pk: "new-device-1000-000141", payload: Some("{\"k\": 141, \"edit\": \"insert\"}"), version: 21092, deleted: false, device_id: "device-1000", created_version: 21092 }
+RowDump { collection: "notes", pk: "new-device-1000-000142", payload: Some("{\"k\": 142, \"edit\": \"insert\"}"), version: 21093, deleted: false, device_id: "device-1000", created_version: 21093 }
+RowDump { collection: "notes", pk: "new-device-1000-000143", payload: Some("{\"k\": 143, \"edit\": \"insert\"}"), version: 21094, deleted: false, device_id: "device-1000", created_version: 21094 }
+RowDump { collection: "notes", pk: "new-device-1000-000144", payload: Some("{\"k\": 144, \"edit\": \"insert\"}"), version: 21095, deleted: false, device_id: "device-1000", created_version: 21095 }
+RowDump { collection: "notes", pk: "new-device-1000-000145", payload: Some("{\"k\": 145, \"edit\": \"insert\"}"), version: 21096, deleted: false, device_id: "device-1000", created_version: 21096 }
+RowDump { collection: "notes", pk: "new-device-1000-000146", payload: Some("{\"k\": 146, \"edit\": \"insert\"}"), version: 21097, deleted: false, device_id: "device-1000", created_version: 21097 }
+RowDump { collection: "notes", pk: "new-device-1000-000147", payload: Some("{\"k\": 147, \"edit\": \"insert\"}"), version: 21098, deleted: false, device_id: "device-1000", created_version: 21098 }
+RowDump { collection: "notes", pk: "new-device-1000-000148", payload: Some("{\"k\": 148, \"edit\": \"insert\"}"), version: 21099, deleted: false, device_id: "device-1000", created_version: 21099 }
+RowDump { collection: "notes", pk: "new-device-1000-000149", payload: Some("{\"k\": 149, \"edit\": \"insert\"}"), version: 21100, deleted: false, device_id: "device-1000", created_version: 21100 }
+RowDump { collection: "notes", pk: "new-device-1000-000150", payload: Some("{\"k\": 150, \"edit\": \"insert\"}"), version: 21101, deleted: false, device_id: "device-1000", created_version: 21101 }
+RowDump { collection: "notes", pk: "new-device-1000-000151", payload: Some("{\"k\": 151, \"edit\": \"insert\"}"), version: 21102, deleted: false, device_id: "device-1000", created_version: 21102 }
+RowDump { collection: "notes", pk: "new-device-1000-000152", payload: Some("{\"k\": 152, \"edit\": \"insert\"}"), version: 21103, deleted: false, device_id: "device-1000", created_version: 21103 }
+RowDump { collection: "notes", pk: "new-device-1000-000153", payload: Some("{\"k\": 153, \"edit\": \"insert\"}"), version: 21104, deleted: false, device_id: "device-1000", created_version: 21104 }
+RowDump { collection: "notes", pk: "new-device-1000-000154", payload: Some("{\"k\": 154, \"edit\": \"insert\"}"), version: 21105, deleted: false, device_id: "device-1000", created_version: 21105 }
+RowDump { collection: "notes", pk: "new-device-1000-000155", payload: Some("{\"k\": 155, \"edit\": \"insert\"}"), version: 21106, deleted: false, device_id: "device-1000", created_version: 21106 }
+RowDump { collection: "notes", pk: "new-device-1000-000156", payload: Some("{\"k\": 156, \"edit\": \"insert\"}"), version: 21107, deleted: false, device_id: "device-1000", created_version: 21107 }
+RowDump { collection: "notes", pk: "new-device-1000-000157", payload: Some("{\"k\": 157, \"edit\": \"insert\"}"), version: 21108, deleted: false, device_id: "device-1000", created_version: 21108 }
+RowDump { collection: "notes", pk: "new-device-1000-000158", payload: Some("{\"k\": 158, \"edit\": \"insert\"}"), version: 21109, deleted: false, device_id: "device-1000", created_version: 21109 }
+RowDump { collection: "notes", pk: "new-device-1000-000159", payload: Some("{\"k\": 159, \"edit\": \"insert\"}"), version: 21110, deleted: false, device_id: "device-1000", created_version: 21110 }
+RowDump { collection: "notes", pk: "new-device-1000-000160", payload: Some("{\"k\": 160, \"edit\": \"insert\"}"), version: 21111, deleted: false, device_id: "device-1000", created_version: 21111 }
+RowDump { collection: "notes", pk: "new-device-1000-000161", payload: Some("{\"k\": 161, \"edit\": \"insert\"}"), version: 21112, deleted: false, device_id: "device-1000", created_version: 21112 }
+RowDump { collection: "notes", pk: "new-device-1000-000162", payload: Some("{\"k\": 162, \"edit\": \"insert\"}"), version: 21113, deleted: false, device_id: "device-1000", created_version: 21113 }
+RowDump { collection: "notes", pk: "new-device-1000-000163", payload: Some("{\"k\": 163, \"edit\": \"insert\"}"), version: 21114, deleted: false, device_id: "device-1000", created_version: 21114 }
+RowDump { collection: "notes", pk: "new-device-1000-000164", payload: Some("{\"k\": 164, \"edit\": \"insert\"}"), version: 21115, deleted: false, device_id: "device-1000", created_version: 21115 }
+RowDump { collection: "notes", pk: "new-device-1000-000165", payload: Some("{\"k\": 165, \"edit\": \"insert\"}"), version: 21116, deleted: false, device_id: "device-1000", created_version: 21116 }
+RowDump { collection: "notes", pk: "new-device-1000-000166", payload: Some("{\"k\": 166, \"edit\": \"insert\"}"), version: 21117, deleted: false, device_id: "device-1000", created_version: 21117 }
+RowDump { collection: "notes", pk: "new-device-1000-000167", payload: Some("{\"k\": 167, \"edit\": \"insert\"}"), version: 21118, deleted: false, device_id: "device-1000", created_version: 21118 }
+RowDump { collection: "notes", pk: "new-device-1000-000168", payload: Some("{\"k\": 168, \"edit\": \"insert\"}"), version: 21119, deleted: false, device_id: "device-1000", created_version: 21119 }
+RowDump { collection: "notes", pk: "new-device-1000-000169", payload: Some("{\"k\": 169, \"edit\": \"insert\"}"), version: 21120, deleted: false, device_id: "device-1000", created_version: 21120 }
+RowDump { collection: "notes", pk: "new-device-1000-000170", payload: Some("{\"k\": 170, \"edit\": \"insert\"}"), version: 21121, deleted: false, device_id: "device-1000", created_version: 21121 }
+RowDump { collection: "notes", pk: "new-device-1000-000171", payload: Some("{\"k\": 171, \"edit\": \"insert\"}"), version: 21122, deleted: false, device_id: "device-1000", created_version: 21122 }
+RowDump { collection: "notes", pk: "new-device-1000-000172", payload: Some("{\"k\": 172, \"edit\": \"insert\"}"), version: 21123, deleted: false, device_id: "device-1000", created_version: 21123 }
+RowDump { collection: "notes", pk: "new-device-1000-000173", payload: Some("{\"k\": 173, \"edit\": \"insert\"}"), version: 21124, deleted: false, device_id: "device-1000", created_version: 21124 }
+RowDump { collection: "notes", pk: "new-device-1000-000174", payload: Some("{\"k\": 174, \"edit\": \"insert\"}"), version: 21125, deleted: false, device_id: "device-1000", created_version: 21125 }
+RowDump { collection: "notes", pk: "new-device-1000-000175", payload: Some("{\"k\": 175, \"edit\": \"insert\"}"), version: 21126, deleted: false, device_id: "device-1000", created_version: 21126 }
+RowDump { collection: "notes", pk: "new-device-1000-000176", payload: Some("{\"k\": 176, \"edit\": \"insert\"}"), version: 21127, deleted: false, device_id: "device-1000", created_version: 21127 }
+RowDump { collection: "notes", pk: "new-device-1000-000177", payload: Some("{\"k\": 177, \"edit\": \"insert\"}"), version: 21128, deleted: false, device_id: "device-1000", created_version: 21128 }
+RowDump { collection: "notes", pk: "new-device-1000-000178", payload: Some("{\"k\": 178, \"edit\": \"insert\"}"), version: 21129, deleted: false, device_id: "device-1000", created_version: 21129 }
+RowDump { collection: "notes", pk: "new-device-1000-000179", payload: Some("{\"k\": 179, \"edit\": \"insert\"}"), version: 21130, deleted: false, device_id: "device-1000", created_version: 21130 }
+RowDump { collection: "notes", pk: "new-device-1000-000180", payload: Some("{\"k\": 180, \"edit\": \"insert\"}"), version: 21131, deleted: false, device_id: "device-1000", created_version: 21131 }
+RowDump { collection: "notes", pk: "new-device-1000-000181", payload: Some("{\"k\": 181, \"edit\": \"insert\"}"), version: 21132, deleted: false, device_id: "device-1000", created_version: 21132 }
+RowDump { collection: "notes", pk: "new-device-1000-000182", payload: Some("{\"k\": 182, \"edit\": \"insert\"}"), version: 21133, deleted: false, device_id: "device-1000", created_version: 21133 }
+RowDump { collection: "notes", pk: "new-device-1000-000183", payload: Some("{\"k\": 183, \"edit\": \"insert\"}"), version: 21134, deleted: false, device_id: "device-1000", created_version: 21134 }
+RowDump { collection: "notes", pk: "new-device-1000-000184", payload: Some("{\"k\": 184, \"edit\": \"insert\"}"), version: 21135, deleted: false, device_id: "device-1000", created_version: 21135 }
+RowDump { collection: "notes", pk: "new-device-1000-000185", payload: Some("{\"k\": 185, \"edit\": \"insert\"}"), version: 21136, deleted: false, device_id: "device-1000", created_version: 21136 }
+RowDump { collection: "notes", pk: "new-device-1000-000186", payload: Some("{\"k\": 186, \"edit\": \"insert\"}"), version: 21137, deleted: false, device_id: "device-1000", created_version: 21137 }
+RowDump { collection: "notes", pk: "new-device-1000-000187", payload: Some("{\"k\": 187, \"edit\": \"insert\"}"), version: 21138, deleted: false, device_id: "device-1000", created_version: 21138 }
+RowDump { collection: "notes", pk: "new-device-1000-000188", payload: Some("{\"k\": 188, \"edit\": \"insert\"}"), version: 21139, deleted: false, device_id: "device-1000", created_version: 21139 }
+RowDump { collection: "notes", pk: "new-device-1000-000189", payload: Some("{\"k\": 189, \"edit\": \"insert\"}"), version: 21140, deleted: false, device_id: "device-1000", created_version: 21140 }
+RowDump { collection: "notes", pk: "new-device-1000-000190", payload: Some("{\"k\": 190, \"edit\": \"insert\"}"), version: 21141, deleted: false, device_id: "device-1000", created_version: 21141 }
+RowDump { collection: "notes", pk: "new-device-1000-000191", payload: Some("{\"k\": 191, \"edit\": \"insert\"}"), version: 21142, deleted: false, device_id: "device-1000", created_version: 21142 }
+RowDump { collection: "notes", pk: "new-device-1000-000192", payload: Some("{\"k\": 192, \"edit\": \"insert\"}"), version: 21143, deleted: false, device_id: "device-1000", created_version: 21143 }
+RowDump { collection: "notes", pk: "new-device-1000-000193", payload: Some("{\"k\": 193, \"edit\": \"insert\"}"), version: 21144, deleted: false, device_id: "device-1000", created_version: 21144 }
+RowDump { collection: "notes", pk: "new-device-1000-000194", payload: Some("{\"k\": 194, \"edit\": \"insert\"}"), version: 21145, deleted: false, device_id: "device-1000", created_version: 21145 }
+RowDump { collection: "notes", pk: "new-device-1000-000195", payload: Some("{\"k\": 195, \"edit\": \"insert\"}"), version: 21146, deleted: false, device_id: "device-1000", created_version: 21146 }
+RowDump { collection: "notes", pk: "new-device-1000-000196", payload: Some("{\"k\": 196, \"edit\": \"insert\"}"), version: 21147, deleted: false, device_id: "device-1000", created_version: 21147 }
+RowDump { collection: "notes", pk: "new-device-1000-000197", payload: Some("{\"k\": 197, \"edit\": \"insert\"}"), version: 21148, deleted: false, device_id: "device-1000", created_version: 21148 }
+RowDump { collection: "notes", pk: "new-device-1000-000198", payload: Some("{\"k\": 198, \"edit\": \"insert\"}"), version: 21149, deleted: false, device_id: "device-1000", created_version: 21149 }
+RowDump { collection: "notes", pk: "new-device-1000-000199", payload: Some("{\"k\": 199, \"edit\": \"insert\"}"), version: 21150, deleted: false, device_id: "device-1000", created_version: 21150 }
+RowDump { collection: "notes", pk: "newdup-device-1000-000000", payload: Some("{\"p\": 0, \"edit\": \"dup-new-2\"}"), version: 21282, deleted: false, device_id: "device-1000", created_version: 21281 }
+RowDump { collection: "notes", pk: "newdup-device-1000-000001", payload: Some("{\"p\": 1, \"edit\": \"dup-new-2\"}"), version: 21284, deleted: false, device_id: "device-1000", created_version: 21283 }
+RowDump { collection: "notes", pk: "newdup-device-1000-000002", payload: Some("{\"p\": 2, \"edit\": \"dup-new-2\"}"), version: 21286, deleted: false, device_id: "device-1000", created_version: 21285 }
+RowDump { collection: "notes", pk: "newdup-device-1000-000003", payload: Some("{\"p\": 3, \"edit\": \"dup-new-2\"}"), version: 21288, deleted: false, device_id: "device-1000", created_version: 21287 }
+RowDump { collection: "notes", pk: "newdup-device-1000-000004", payload: Some("{\"p\": 4, \"edit\": \"dup-new-2\"}"), version: 21290, deleted: false, device_id: "device-1000", created_version: 21289 }
+RowDump { collection: "notes", pk: "newdup-device-1000-000005", payload: Some("{\"p\": 5, \"edit\": \"dup-new-2\"}"), version: 21292, deleted: false, device_id: "device-1000", created_version: 21291 }
+RowDump { collection: "notes", pk: "newdup-device-1000-000006", payload: Some("{\"p\": 6, \"edit\": \"dup-new-2\"}"), version: 21294, deleted: false, device_id: "device-1000", created_version: 21293 }
+RowDump { collection: "notes", pk: "newdup-device-1000-000007", payload: Some("{\"p\": 7, \"edit\": \"dup-new-2\"}"), version: 21296, deleted: false, device_id: "device-1000", created_version: 21295 }
+RowDump { collection: "notes", pk: "newdup-device-1000-000008", payload: Some("{\"p\": 8, \"edit\": \"dup-new-2\"}"), version: 21298, deleted: false, device_id: "device-1000", created_version: 21297 }
+RowDump { collection: "notes", pk: "newdup-device-1000-000009", payload: Some("{\"p\": 9, \"edit\": \"dup-new-2\"}"), version: 21300, deleted: false, device_id: "device-1000", created_version: 21299 }
+-- row dump (existing pks touched by this batch), 740 rows --
+RowDump { collection: "notes", pk: "pk-00010001", payload: Some("{\"idx\": 10001, \"edit\": \"update\"}"), version: 20301, deleted: false, device_id: "device-1000", created_version: 10001 }
+RowDump { collection: "notes", pk: "pk-00010002", payload: Some("{\"idx\": 10002, \"edit\": \"update\"}"), version: 20302, deleted: false, device_id: "device-1000", created_version: 10002 }
+RowDump { collection: "notes", pk: "pk-00010003", payload: Some("{\"idx\": 10003, \"edit\": \"update\"}"), version: 20303, deleted: false, device_id: "device-1000", created_version: 10003 }
+RowDump { collection: "notes", pk: "pk-00010004", payload: Some("{\"idx\": 10004, \"edit\": \"update\"}"), version: 20304, deleted: false, device_id: "device-1000", created_version: 10004 }
+RowDump { collection: "notes", pk: "pk-00010005", payload: Some("{\"idx\": 10005, \"edit\": \"update\"}"), version: 20305, deleted: false, device_id: "device-1000", created_version: 10005 }
+RowDump { collection: "notes", pk: "pk-00010006", payload: Some("{\"idx\": 10006, \"edit\": \"update\"}"), version: 20306, deleted: false, device_id: "device-1000", created_version: 10006 }
+RowDump { collection: "notes", pk: "pk-00010007", payload: Some("{\"idx\": 10007, \"edit\": \"update\"}"), version: 20307, deleted: false, device_id: "device-1000", created_version: 10007 }
+RowDump { collection: "notes", pk: "pk-00010008", payload: Some("{\"idx\": 10008, \"edit\": \"update\"}"), version: 20308, deleted: false, device_id: "device-1000", created_version: 10008 }
+RowDump { collection: "notes", pk: "pk-00010009", payload: Some("{\"idx\": 10009, \"edit\": \"update\"}"), version: 20309, deleted: false, device_id: "device-1000", created_version: 10009 }
+RowDump { collection: "notes", pk: "pk-00010010", payload: Some("{\"idx\": 10010, \"edit\": \"update\"}"), version: 20310, deleted: false, device_id: "device-1000", created_version: 10010 }
+RowDump { collection: "notes", pk: "pk-00010011", payload: Some("{\"idx\": 10011, \"edit\": \"update\"}"), version: 20311, deleted: false, device_id: "device-1000", created_version: 10011 }
+RowDump { collection: "notes", pk: "pk-00010012", payload: Some("{\"idx\": 10012, \"edit\": \"update\"}"), version: 20312, deleted: false, device_id: "device-1000", created_version: 10012 }
+RowDump { collection: "notes", pk: "pk-00010013", payload: Some("{\"idx\": 10013, \"edit\": \"update\"}"), version: 20313, deleted: false, device_id: "device-1000", created_version: 10013 }
+RowDump { collection: "notes", pk: "pk-00010014", payload: Some("{\"idx\": 10014, \"edit\": \"update\"}"), version: 20314, deleted: false, device_id: "device-1000", created_version: 10014 }
+RowDump { collection: "notes", pk: "pk-00010015", payload: Some("{\"idx\": 10015, \"edit\": \"update\"}"), version: 20315, deleted: false, device_id: "device-1000", created_version: 10015 }
+RowDump { collection: "notes", pk: "pk-00010016", payload: Some("{\"idx\": 10016, \"edit\": \"update\"}"), version: 20316, deleted: false, device_id: "device-1000", created_version: 10016 }
+RowDump { collection: "notes", pk: "pk-00010017", payload: Some("{\"idx\": 10017, \"edit\": \"update\"}"), version: 20317, deleted: false, device_id: "device-1000", created_version: 10017 }
+RowDump { collection: "notes", pk: "pk-00010018", payload: Some("{\"idx\": 10018, \"edit\": \"update\"}"), version: 20318, deleted: false, device_id: "device-1000", created_version: 10018 }
+RowDump { collection: "notes", pk: "pk-00010019", payload: Some("{\"idx\": 10019, \"edit\": \"update\"}"), version: 20319, deleted: false, device_id: "device-1000", created_version: 10019 }
+RowDump { collection: "notes", pk: "pk-00010021", payload: Some("{\"idx\": 10021, \"edit\": \"update\"}"), version: 20320, deleted: false, device_id: "device-1000", created_version: 10021 }
+RowDump { collection: "notes", pk: "pk-00010022", payload: Some("{\"idx\": 10022, \"edit\": \"update\"}"), version: 20321, deleted: false, device_id: "device-1000", created_version: 10022 }
+RowDump { collection: "notes", pk: "pk-00010023", payload: Some("{\"idx\": 10023, \"edit\": \"update\"}"), version: 20322, deleted: false, device_id: "device-1000", created_version: 10023 }
+RowDump { collection: "notes", pk: "pk-00010024", payload: Some("{\"idx\": 10024, \"edit\": \"update\"}"), version: 20323, deleted: false, device_id: "device-1000", created_version: 10024 }
+RowDump { collection: "notes", pk: "pk-00010025", payload: Some("{\"idx\": 10025, \"edit\": \"update\"}"), version: 20324, deleted: false, device_id: "device-1000", created_version: 10025 }
+RowDump { collection: "notes", pk: "pk-00010026", payload: Some("{\"idx\": 10026, \"edit\": \"update\"}"), version: 20325, deleted: false, device_id: "device-1000", created_version: 10026 }
+RowDump { collection: "notes", pk: "pk-00010027", payload: Some("{\"idx\": 10027, \"edit\": \"update\"}"), version: 20326, deleted: false, device_id: "device-1000", created_version: 10027 }
+RowDump { collection: "notes", pk: "pk-00010028", payload: Some("{\"idx\": 10028, \"edit\": \"update\"}"), version: 20327, deleted: false, device_id: "device-1000", created_version: 10028 }
+RowDump { collection: "notes", pk: "pk-00010029", payload: Some("{\"idx\": 10029, \"edit\": \"update\"}"), version: 20328, deleted: false, device_id: "device-1000", created_version: 10029 }
+RowDump { collection: "notes", pk: "pk-00010030", payload: Some("{\"idx\": 10030, \"edit\": \"update\"}"), version: 20329, deleted: false, device_id: "device-1000", created_version: 10030 }
+RowDump { collection: "notes", pk: "pk-00010031", payload: Some("{\"idx\": 10031, \"edit\": \"update\"}"), version: 20330, deleted: false, device_id: "device-1000", created_version: 10031 }
+RowDump { collection: "notes", pk: "pk-00010032", payload: Some("{\"idx\": 10032, \"edit\": \"update\"}"), version: 20331, deleted: false, device_id: "device-1000", created_version: 10032 }
+RowDump { collection: "notes", pk: "pk-00010033", payload: Some("{\"idx\": 10033, \"edit\": \"update\"}"), version: 20332, deleted: false, device_id: "device-1000", created_version: 10033 }
+RowDump { collection: "notes", pk: "pk-00010034", payload: Some("{\"idx\": 10034, \"edit\": \"update\"}"), version: 20333, deleted: false, device_id: "device-1000", created_version: 10034 }
+RowDump { collection: "notes", pk: "pk-00010035", payload: Some("{\"idx\": 10035, \"edit\": \"update\"}"), version: 20334, deleted: false, device_id: "device-1000", created_version: 10035 }
+RowDump { collection: "notes", pk: "pk-00010036", payload: Some("{\"idx\": 10036, \"edit\": \"update\"}"), version: 20335, deleted: false, device_id: "device-1000", created_version: 10036 }
+RowDump { collection: "notes", pk: "pk-00010037", payload: Some("{\"idx\": 10037, \"edit\": \"update\"}"), version: 20336, deleted: false, device_id: "device-1000", created_version: 10037 }
+RowDump { collection: "notes", pk: "pk-00010038", payload: Some("{\"idx\": 10038, \"edit\": \"update\"}"), version: 20337, deleted: false, device_id: "device-1000", created_version: 10038 }
+RowDump { collection: "notes", pk: "pk-00010039", payload: Some("{\"idx\": 10039, \"edit\": \"update\"}"), version: 20338, deleted: false, device_id: "device-1000", created_version: 10039 }
+RowDump { collection: "contacts", pk: "pk-00010041", payload: Some("{\"idx\": 10041, \"edit\": \"update\"}"), version: 20339, deleted: false, device_id: "device-1000", created_version: 10041 }
+RowDump { collection: "contacts", pk: "pk-00010042", payload: Some("{\"idx\": 10042, \"edit\": \"update\"}"), version: 20340, deleted: false, device_id: "device-1000", created_version: 10042 }
+RowDump { collection: "contacts", pk: "pk-00010043", payload: Some("{\"idx\": 10043, \"edit\": \"update\"}"), version: 20341, deleted: false, device_id: "device-1000", created_version: 10043 }
+RowDump { collection: "contacts", pk: "pk-00010044", payload: Some("{\"idx\": 10044, \"edit\": \"update\"}"), version: 20342, deleted: false, device_id: "device-1000", created_version: 10044 }
+RowDump { collection: "contacts", pk: "pk-00010045", payload: Some("{\"idx\": 10045, \"edit\": \"update\"}"), version: 20343, deleted: false, device_id: "device-1000", created_version: 10045 }
+RowDump { collection: "contacts", pk: "pk-00010046", payload: Some("{\"idx\": 10046, \"edit\": \"update\"}"), version: 20344, deleted: false, device_id: "device-1000", created_version: 10046 }
+RowDump { collection: "contacts", pk: "pk-00010047", payload: Some("{\"idx\": 10047, \"edit\": \"update\"}"), version: 20345, deleted: false, device_id: "device-1000", created_version: 10047 }
+RowDump { collection: "contacts", pk: "pk-00010048", payload: Some("{\"idx\": 10048, \"edit\": \"update\"}"), version: 20346, deleted: false, device_id: "device-1000", created_version: 10048 }
+RowDump { collection: "contacts", pk: "pk-00010049", payload: Some("{\"idx\": 10049, \"edit\": \"update\"}"), version: 20347, deleted: false, device_id: "device-1000", created_version: 10049 }
+RowDump { collection: "contacts", pk: "pk-00010050", payload: Some("{\"idx\": 10050, \"edit\": \"update\"}"), version: 20348, deleted: false, device_id: "device-1000", created_version: 10050 }
+RowDump { collection: "contacts", pk: "pk-00010051", payload: Some("{\"idx\": 10051, \"edit\": \"update\"}"), version: 20349, deleted: false, device_id: "device-1000", created_version: 10051 }
+RowDump { collection: "contacts", pk: "pk-00010052", payload: Some("{\"idx\": 10052, \"edit\": \"update\"}"), version: 20350, deleted: false, device_id: "device-1000", created_version: 10052 }
+RowDump { collection: "contacts", pk: "pk-00010053", payload: Some("{\"idx\": 10053, \"edit\": \"update\"}"), version: 20351, deleted: false, device_id: "device-1000", created_version: 10053 }
+RowDump { collection: "contacts", pk: "pk-00010054", payload: Some("{\"idx\": 10054, \"edit\": \"update\"}"), version: 20352, deleted: false, device_id: "device-1000", created_version: 10054 }
+RowDump { collection: "contacts", pk: "pk-00010055", payload: Some("{\"idx\": 10055, \"edit\": \"update\"}"), version: 20353, deleted: false, device_id: "device-1000", created_version: 10055 }
+RowDump { collection: "contacts", pk: "pk-00010056", payload: Some("{\"idx\": 10056, \"edit\": \"update\"}"), version: 20354, deleted: false, device_id: "device-1000", created_version: 10056 }
+RowDump { collection: "contacts", pk: "pk-00010057", payload: Some("{\"idx\": 10057, \"edit\": \"update\"}"), version: 20355, deleted: false, device_id: "device-1000", created_version: 10057 }
+RowDump { collection: "contacts", pk: "pk-00010058", payload: Some("{\"idx\": 10058, \"edit\": \"update\"}"), version: 20356, deleted: false, device_id: "device-1000", created_version: 10058 }
+RowDump { collection: "contacts", pk: "pk-00010059", payload: Some("{\"idx\": 10059, \"edit\": \"update\"}"), version: 20357, deleted: false, device_id: "device-1000", created_version: 10059 }
+RowDump { collection: "tasks", pk: "pk-00010061", payload: Some("{\"idx\": 10061, \"edit\": \"update\"}"), version: 20358, deleted: false, device_id: "device-1000", created_version: 10061 }
+RowDump { collection: "tasks", pk: "pk-00010062", payload: Some("{\"idx\": 10062, \"edit\": \"update\"}"), version: 20359, deleted: false, device_id: "device-1000", created_version: 10062 }
+RowDump { collection: "tasks", pk: "pk-00010063", payload: Some("{\"idx\": 10063, \"edit\": \"update\"}"), version: 20360, deleted: false, device_id: "device-1000", created_version: 10063 }
+RowDump { collection: "tasks", pk: "pk-00010064", payload: Some("{\"idx\": 10064, \"edit\": \"update\"}"), version: 20361, deleted: false, device_id: "device-1000", created_version: 10064 }
+RowDump { collection: "tasks", pk: "pk-00010065", payload: Some("{\"idx\": 10065, \"edit\": \"update\"}"), version: 20362, deleted: false, device_id: "device-1000", created_version: 10065 }
+RowDump { collection: "tasks", pk: "pk-00010066", payload: Some("{\"idx\": 10066, \"edit\": \"update\"}"), version: 20363, deleted: false, device_id: "device-1000", created_version: 10066 }
+RowDump { collection: "tasks", pk: "pk-00010067", payload: Some("{\"idx\": 10067, \"edit\": \"update\"}"), version: 20364, deleted: false, device_id: "device-1000", created_version: 10067 }
+RowDump { collection: "tasks", pk: "pk-00010068", payload: Some("{\"idx\": 10068, \"edit\": \"update\"}"), version: 20365, deleted: false, device_id: "device-1000", created_version: 10068 }
+RowDump { collection: "tasks", pk: "pk-00010069", payload: Some("{\"idx\": 10069, \"edit\": \"update\"}"), version: 20366, deleted: false, device_id: "device-1000", created_version: 10069 }
+RowDump { collection: "tasks", pk: "pk-00010070", payload: Some("{\"idx\": 10070, \"edit\": \"update\"}"), version: 20367, deleted: false, device_id: "device-1000", created_version: 10070 }
+RowDump { collection: "tasks", pk: "pk-00010071", payload: Some("{\"idx\": 10071, \"edit\": \"update\"}"), version: 20368, deleted: false, device_id: "device-1000", created_version: 10071 }
+RowDump { collection: "tasks", pk: "pk-00010072", payload: Some("{\"idx\": 10072, \"edit\": \"update\"}"), version: 20369, deleted: false, device_id: "device-1000", created_version: 10072 }
+RowDump { collection: "tasks", pk: "pk-00010073", payload: Some("{\"idx\": 10073, \"edit\": \"update\"}"), version: 20370, deleted: false, device_id: "device-1000", created_version: 10073 }
+RowDump { collection: "tasks", pk: "pk-00010074", payload: Some("{\"idx\": 10074, \"edit\": \"update\"}"), version: 20371, deleted: false, device_id: "device-1000", created_version: 10074 }
+RowDump { collection: "files", pk: "pk-00010075", payload: Some("{\"idx\": 10075, \"edit\": \"update\"}"), version: 20372, deleted: false, device_id: "device-1000", created_version: 10075 }
+RowDump { collection: "files", pk: "pk-00010076", payload: Some("{\"idx\": 10076, \"edit\": \"update\"}"), version: 20373, deleted: false, device_id: "device-1000", created_version: 10076 }
+RowDump { collection: "files", pk: "pk-00010077", payload: Some("{\"idx\": 10077, \"edit\": \"update\"}"), version: 20374, deleted: false, device_id: "device-1000", created_version: 10077 }
+RowDump { collection: "files", pk: "pk-00010078", payload: Some("{\"idx\": 10078, \"edit\": \"update\"}"), version: 20375, deleted: false, device_id: "device-1000", created_version: 10078 }
+RowDump { collection: "files", pk: "pk-00010079", payload: Some("{\"idx\": 10079, \"edit\": \"update\"}"), version: 20376, deleted: false, device_id: "device-1000", created_version: 10079 }
+RowDump { collection: "files", pk: "pk-00010081", payload: Some("{\"idx\": 10081, \"edit\": \"update\"}"), version: 20377, deleted: false, device_id: "device-1000", created_version: 10081 }
+RowDump { collection: "files", pk: "pk-00010082", payload: Some("{\"idx\": 10082, \"edit\": \"update\"}"), version: 20378, deleted: false, device_id: "device-1000", created_version: 10082 }
+RowDump { collection: "files", pk: "pk-00010083", payload: Some("{\"idx\": 10083, \"edit\": \"update\"}"), version: 20379, deleted: false, device_id: "device-1000", created_version: 10083 }
+RowDump { collection: "files", pk: "pk-00010084", payload: Some("{\"idx\": 10084, \"edit\": \"update\"}"), version: 20380, deleted: false, device_id: "device-1000", created_version: 10084 }
+RowDump { collection: "files", pk: "pk-00010085", payload: Some("{\"idx\": 10085, \"edit\": \"update\"}"), version: 20381, deleted: false, device_id: "device-1000", created_version: 10085 }
+RowDump { collection: "files", pk: "pk-00010086", payload: Some("{\"idx\": 10086, \"edit\": \"update\"}"), version: 20382, deleted: false, device_id: "device-1000", created_version: 10086 }
+RowDump { collection: "files", pk: "pk-00010087", payload: Some("{\"idx\": 10087, \"edit\": \"update\"}"), version: 20383, deleted: false, device_id: "device-1000", created_version: 10087 }
+RowDump { collection: "files", pk: "pk-00010088", payload: Some("{\"idx\": 10088, \"edit\": \"update\"}"), version: 20384, deleted: false, device_id: "device-1000", created_version: 10088 }
+RowDump { collection: "files", pk: "pk-00010089", payload: Some("{\"idx\": 10089, \"edit\": \"update\"}"), version: 20385, deleted: false, device_id: "device-1000", created_version: 10089 }
+RowDump { collection: "tags", pk: "pk-00010090", payload: Some("{\"idx\": 10090, \"edit\": \"update\"}"), version: 20386, deleted: false, device_id: "device-1000", created_version: 10090 }
+RowDump { collection: "tags", pk: "pk-00010091", payload: Some("{\"idx\": 10091, \"edit\": \"update\"}"), version: 20387, deleted: false, device_id: "device-1000", created_version: 10091 }
+RowDump { collection: "tags", pk: "pk-00010092", payload: Some("{\"idx\": 10092, \"edit\": \"update\"}"), version: 20388, deleted: false, device_id: "device-1000", created_version: 10092 }
+RowDump { collection: "tags", pk: "pk-00010093", payload: Some("{\"idx\": 10093, \"edit\": \"update\"}"), version: 20389, deleted: false, device_id: "device-1000", created_version: 10093 }
+RowDump { collection: "tags", pk: "pk-00010094", payload: Some("{\"idx\": 10094, \"edit\": \"update\"}"), version: 20390, deleted: false, device_id: "device-1000", created_version: 10094 }
+RowDump { collection: "tags", pk: "pk-00010095", payload: Some("{\"idx\": 10095, \"edit\": \"update\"}"), version: 20391, deleted: false, device_id: "device-1000", created_version: 10095 }
+RowDump { collection: "tags", pk: "pk-00010096", payload: Some("{\"idx\": 10096, \"edit\": \"update\"}"), version: 20392, deleted: false, device_id: "device-1000", created_version: 10096 }
+RowDump { collection: "archive", pk: "pk-00010097", payload: Some("{\"idx\": 10097, \"edit\": \"update\"}"), version: 20393, deleted: false, device_id: "device-1000", created_version: 10097 }
+RowDump { collection: "archive", pk: "pk-00010098", payload: Some("{\"idx\": 10098, \"edit\": \"update\"}"), version: 20394, deleted: false, device_id: "device-1000", created_version: 10098 }
+RowDump { collection: "archive", pk: "pk-00010099", payload: Some("{\"idx\": 10099, \"edit\": \"update\"}"), version: 20395, deleted: false, device_id: "device-1000", created_version: 10099 }
+RowDump { collection: "notes", pk: "pk-00010101", payload: Some("{\"idx\": 10101, \"edit\": \"update\"}"), version: 20396, deleted: false, device_id: "device-1000", created_version: 10101 }
+RowDump { collection: "notes", pk: "pk-00010102", payload: Some("{\"idx\": 10102, \"edit\": \"update\"}"), version: 20397, deleted: false, device_id: "device-1000", created_version: 10102 }
+RowDump { collection: "notes", pk: "pk-00010103", payload: Some("{\"idx\": 10103, \"edit\": \"update\"}"), version: 20398, deleted: false, device_id: "device-1000", created_version: 10103 }
+RowDump { collection: "notes", pk: "pk-00010104", payload: Some("{\"idx\": 10104, \"edit\": \"update\"}"), version: 20399, deleted: false, device_id: "device-1000", created_version: 10104 }
+RowDump { collection: "notes", pk: "pk-00010105", payload: Some("{\"idx\": 10105, \"edit\": \"update\"}"), version: 20400, deleted: false, device_id: "device-1000", created_version: 10105 }
+RowDump { collection: "notes", pk: "pk-00010106", payload: Some("{\"idx\": 10106, \"edit\": \"update\"}"), version: 20401, deleted: false, device_id: "device-1000", created_version: 10106 }
+RowDump { collection: "notes", pk: "pk-00010107", payload: Some("{\"idx\": 10107, \"edit\": \"update\"}"), version: 20402, deleted: false, device_id: "device-1000", created_version: 10107 }
+RowDump { collection: "notes", pk: "pk-00010108", payload: Some("{\"idx\": 10108, \"edit\": \"update\"}"), version: 20403, deleted: false, device_id: "device-1000", created_version: 10108 }
+RowDump { collection: "notes", pk: "pk-00010109", payload: Some("{\"idx\": 10109, \"edit\": \"update\"}"), version: 20404, deleted: false, device_id: "device-1000", created_version: 10109 }
+RowDump { collection: "notes", pk: "pk-00010110", payload: Some("{\"idx\": 10110, \"edit\": \"update\"}"), version: 20405, deleted: false, device_id: "device-1000", created_version: 10110 }
+RowDump { collection: "notes", pk: "pk-00010111", payload: Some("{\"idx\": 10111, \"edit\": \"update\"}"), version: 20406, deleted: false, device_id: "device-1000", created_version: 10111 }
+RowDump { collection: "notes", pk: "pk-00010112", payload: Some("{\"idx\": 10112, \"edit\": \"update\"}"), version: 20407, deleted: false, device_id: "device-1000", created_version: 10112 }
+RowDump { collection: "notes", pk: "pk-00010113", payload: Some("{\"idx\": 10113, \"edit\": \"update\"}"), version: 20408, deleted: false, device_id: "device-1000", created_version: 10113 }
+RowDump { collection: "notes", pk: "pk-00010114", payload: Some("{\"idx\": 10114, \"edit\": \"update\"}"), version: 20409, deleted: false, device_id: "device-1000", created_version: 10114 }
+RowDump { collection: "notes", pk: "pk-00010115", payload: Some("{\"idx\": 10115, \"edit\": \"update\"}"), version: 20410, deleted: false, device_id: "device-1000", created_version: 10115 }
+RowDump { collection: "notes", pk: "pk-00010116", payload: Some("{\"idx\": 10116, \"edit\": \"update\"}"), version: 20411, deleted: false, device_id: "device-1000", created_version: 10116 }
+RowDump { collection: "notes", pk: "pk-00010117", payload: Some("{\"idx\": 10117, \"edit\": \"update\"}"), version: 20412, deleted: false, device_id: "device-1000", created_version: 10117 }
+RowDump { collection: "notes", pk: "pk-00010118", payload: Some("{\"idx\": 10118, \"edit\": \"update\"}"), version: 20413, deleted: false, device_id: "device-1000", created_version: 10118 }
+RowDump { collection: "notes", pk: "pk-00010119", payload: Some("{\"idx\": 10119, \"edit\": \"update\"}"), version: 20414, deleted: false, device_id: "device-1000", created_version: 10119 }
+RowDump { collection: "notes", pk: "pk-00010121", payload: Some("{\"idx\": 10121, \"edit\": \"update\"}"), version: 20415, deleted: false, device_id: "device-1000", created_version: 10121 }
+RowDump { collection: "notes", pk: "pk-00010122", payload: Some("{\"idx\": 10122, \"edit\": \"update\"}"), version: 20416, deleted: false, device_id: "device-1000", created_version: 10122 }
+RowDump { collection: "notes", pk: "pk-00010123", payload: Some("{\"idx\": 10123, \"edit\": \"update\"}"), version: 20417, deleted: false, device_id: "device-1000", created_version: 10123 }
+RowDump { collection: "notes", pk: "pk-00010124", payload: Some("{\"idx\": 10124, \"edit\": \"update\"}"), version: 20418, deleted: false, device_id: "device-1000", created_version: 10124 }
+RowDump { collection: "notes", pk: "pk-00010125", payload: Some("{\"idx\": 10125, \"edit\": \"update\"}"), version: 20419, deleted: false, device_id: "device-1000", created_version: 10125 }
+RowDump { collection: "notes", pk: "pk-00010126", payload: Some("{\"idx\": 10126, \"edit\": \"update\"}"), version: 20420, deleted: false, device_id: "device-1000", created_version: 10126 }
+RowDump { collection: "notes", pk: "pk-00010127", payload: Some("{\"idx\": 10127, \"edit\": \"update\"}"), version: 20421, deleted: false, device_id: "device-1000", created_version: 10127 }
+RowDump { collection: "notes", pk: "pk-00010128", payload: Some("{\"idx\": 10128, \"edit\": \"update\"}"), version: 20422, deleted: false, device_id: "device-1000", created_version: 10128 }
+RowDump { collection: "notes", pk: "pk-00010129", payload: Some("{\"idx\": 10129, \"edit\": \"update\"}"), version: 20423, deleted: false, device_id: "device-1000", created_version: 10129 }
+RowDump { collection: "notes", pk: "pk-00010130", payload: Some("{\"idx\": 10130, \"edit\": \"update\"}"), version: 20424, deleted: false, device_id: "device-1000", created_version: 10130 }
+RowDump { collection: "notes", pk: "pk-00010131", payload: Some("{\"idx\": 10131, \"edit\": \"update\"}"), version: 20425, deleted: false, device_id: "device-1000", created_version: 10131 }
+RowDump { collection: "notes", pk: "pk-00010132", payload: Some("{\"idx\": 10132, \"edit\": \"update\"}"), version: 20426, deleted: false, device_id: "device-1000", created_version: 10132 }
+RowDump { collection: "notes", pk: "pk-00010133", payload: Some("{\"idx\": 10133, \"edit\": \"update\"}"), version: 20427, deleted: false, device_id: "device-1000", created_version: 10133 }
+RowDump { collection: "notes", pk: "pk-00010134", payload: Some("{\"idx\": 10134, \"edit\": \"update\"}"), version: 20428, deleted: false, device_id: "device-1000", created_version: 10134 }
+RowDump { collection: "notes", pk: "pk-00010135", payload: Some("{\"idx\": 10135, \"edit\": \"update\"}"), version: 20429, deleted: false, device_id: "device-1000", created_version: 10135 }
+RowDump { collection: "notes", pk: "pk-00010136", payload: Some("{\"idx\": 10136, \"edit\": \"update\"}"), version: 20430, deleted: false, device_id: "device-1000", created_version: 10136 }
+RowDump { collection: "notes", pk: "pk-00010137", payload: Some("{\"idx\": 10137, \"edit\": \"update\"}"), version: 20431, deleted: false, device_id: "device-1000", created_version: 10137 }
+RowDump { collection: "notes", pk: "pk-00010138", payload: Some("{\"idx\": 10138, \"edit\": \"update\"}"), version: 20432, deleted: false, device_id: "device-1000", created_version: 10138 }
+RowDump { collection: "notes", pk: "pk-00010139", payload: Some("{\"idx\": 10139, \"edit\": \"update\"}"), version: 20433, deleted: false, device_id: "device-1000", created_version: 10139 }
+RowDump { collection: "contacts", pk: "pk-00010141", payload: Some("{\"idx\": 10141, \"edit\": \"update\"}"), version: 20434, deleted: false, device_id: "device-1000", created_version: 10141 }
+RowDump { collection: "contacts", pk: "pk-00010142", payload: Some("{\"idx\": 10142, \"edit\": \"update\"}"), version: 20435, deleted: false, device_id: "device-1000", created_version: 10142 }
+RowDump { collection: "contacts", pk: "pk-00010143", payload: Some("{\"idx\": 10143, \"edit\": \"update\"}"), version: 20436, deleted: false, device_id: "device-1000", created_version: 10143 }
+RowDump { collection: "contacts", pk: "pk-00010144", payload: Some("{\"idx\": 10144, \"edit\": \"update\"}"), version: 20437, deleted: false, device_id: "device-1000", created_version: 10144 }
+RowDump { collection: "contacts", pk: "pk-00010145", payload: Some("{\"idx\": 10145, \"edit\": \"update\"}"), version: 20438, deleted: false, device_id: "device-1000", created_version: 10145 }
+RowDump { collection: "contacts", pk: "pk-00010146", payload: Some("{\"idx\": 10146, \"edit\": \"update\"}"), version: 20439, deleted: false, device_id: "device-1000", created_version: 10146 }
+RowDump { collection: "contacts", pk: "pk-00010147", payload: Some("{\"idx\": 10147, \"edit\": \"update\"}"), version: 20440, deleted: false, device_id: "device-1000", created_version: 10147 }
+RowDump { collection: "contacts", pk: "pk-00010148", payload: Some("{\"idx\": 10148, \"edit\": \"update\"}"), version: 20441, deleted: false, device_id: "device-1000", created_version: 10148 }
+RowDump { collection: "contacts", pk: "pk-00010149", payload: Some("{\"idx\": 10149, \"edit\": \"update\"}"), version: 20442, deleted: false, device_id: "device-1000", created_version: 10149 }
+RowDump { collection: "contacts", pk: "pk-00010150", payload: Some("{\"idx\": 10150, \"edit\": \"update\"}"), version: 20443, deleted: false, device_id: "device-1000", created_version: 10150 }
+RowDump { collection: "contacts", pk: "pk-00010151", payload: Some("{\"idx\": 10151, \"edit\": \"update\"}"), version: 20444, deleted: false, device_id: "device-1000", created_version: 10151 }
+RowDump { collection: "contacts", pk: "pk-00010152", payload: Some("{\"idx\": 10152, \"edit\": \"update\"}"), version: 20445, deleted: false, device_id: "device-1000", created_version: 10152 }
+RowDump { collection: "contacts", pk: "pk-00010153", payload: Some("{\"idx\": 10153, \"edit\": \"update\"}"), version: 20446, deleted: false, device_id: "device-1000", created_version: 10153 }
+RowDump { collection: "contacts", pk: "pk-00010154", payload: Some("{\"idx\": 10154, \"edit\": \"update\"}"), version: 20447, deleted: false, device_id: "device-1000", created_version: 10154 }
+RowDump { collection: "contacts", pk: "pk-00010155", payload: Some("{\"idx\": 10155, \"edit\": \"update\"}"), version: 20448, deleted: false, device_id: "device-1000", created_version: 10155 }
+RowDump { collection: "contacts", pk: "pk-00010156", payload: Some("{\"idx\": 10156, \"edit\": \"update\"}"), version: 20449, deleted: false, device_id: "device-1000", created_version: 10156 }
+RowDump { collection: "contacts", pk: "pk-00010157", payload: Some("{\"idx\": 10157, \"edit\": \"update\"}"), version: 20450, deleted: false, device_id: "device-1000", created_version: 10157 }
+RowDump { collection: "contacts", pk: "pk-00010158", payload: Some("{\"idx\": 10158, \"edit\": \"update\"}"), version: 20451, deleted: false, device_id: "device-1000", created_version: 10158 }
+RowDump { collection: "contacts", pk: "pk-00010159", payload: Some("{\"idx\": 10159, \"edit\": \"update\"}"), version: 20452, deleted: false, device_id: "device-1000", created_version: 10159 }
+RowDump { collection: "tasks", pk: "pk-00010161", payload: Some("{\"idx\": 10161, \"edit\": \"update\"}"), version: 20453, deleted: false, device_id: "device-1000", created_version: 10161 }
+RowDump { collection: "tasks", pk: "pk-00010162", payload: Some("{\"idx\": 10162, \"edit\": \"update\"}"), version: 20454, deleted: false, device_id: "device-1000", created_version: 10162 }
+RowDump { collection: "tasks", pk: "pk-00010163", payload: Some("{\"idx\": 10163, \"edit\": \"update\"}"), version: 20455, deleted: false, device_id: "device-1000", created_version: 10163 }
+RowDump { collection: "tasks", pk: "pk-00010164", payload: Some("{\"idx\": 10164, \"edit\": \"update\"}"), version: 20456, deleted: false, device_id: "device-1000", created_version: 10164 }
+RowDump { collection: "tasks", pk: "pk-00010165", payload: Some("{\"idx\": 10165, \"edit\": \"update\"}"), version: 20457, deleted: false, device_id: "device-1000", created_version: 10165 }
+RowDump { collection: "tasks", pk: "pk-00010166", payload: Some("{\"idx\": 10166, \"edit\": \"update\"}"), version: 20458, deleted: false, device_id: "device-1000", created_version: 10166 }
+RowDump { collection: "tasks", pk: "pk-00010167", payload: Some("{\"idx\": 10167, \"edit\": \"update\"}"), version: 20459, deleted: false, device_id: "device-1000", created_version: 10167 }
+RowDump { collection: "tasks", pk: "pk-00010168", payload: Some("{\"idx\": 10168, \"edit\": \"update\"}"), version: 20460, deleted: false, device_id: "device-1000", created_version: 10168 }
+RowDump { collection: "tasks", pk: "pk-00010169", payload: Some("{\"idx\": 10169, \"edit\": \"update\"}"), version: 20461, deleted: false, device_id: "device-1000", created_version: 10169 }
+RowDump { collection: "tasks", pk: "pk-00010170", payload: Some("{\"idx\": 10170, \"edit\": \"update\"}"), version: 20462, deleted: false, device_id: "device-1000", created_version: 10170 }
+RowDump { collection: "tasks", pk: "pk-00010171", payload: Some("{\"idx\": 10171, \"edit\": \"update\"}"), version: 20463, deleted: false, device_id: "device-1000", created_version: 10171 }
+RowDump { collection: "tasks", pk: "pk-00010172", payload: Some("{\"idx\": 10172, \"edit\": \"update\"}"), version: 20464, deleted: false, device_id: "device-1000", created_version: 10172 }
+RowDump { collection: "tasks", pk: "pk-00010173", payload: Some("{\"idx\": 10173, \"edit\": \"update\"}"), version: 20465, deleted: false, device_id: "device-1000", created_version: 10173 }
+RowDump { collection: "tasks", pk: "pk-00010174", payload: Some("{\"idx\": 10174, \"edit\": \"update\"}"), version: 20466, deleted: false, device_id: "device-1000", created_version: 10174 }
+RowDump { collection: "files", pk: "pk-00010175", payload: Some("{\"idx\": 10175, \"edit\": \"update\"}"), version: 20467, deleted: false, device_id: "device-1000", created_version: 10175 }
+RowDump { collection: "files", pk: "pk-00010176", payload: Some("{\"idx\": 10176, \"edit\": \"update\"}"), version: 20468, deleted: false, device_id: "device-1000", created_version: 10176 }
+RowDump { collection: "files", pk: "pk-00010177", payload: Some("{\"idx\": 10177, \"edit\": \"update\"}"), version: 20469, deleted: false, device_id: "device-1000", created_version: 10177 }
+RowDump { collection: "files", pk: "pk-00010178", payload: Some("{\"idx\": 10178, \"edit\": \"update\"}"), version: 20470, deleted: false, device_id: "device-1000", created_version: 10178 }
+RowDump { collection: "files", pk: "pk-00010179", payload: Some("{\"idx\": 10179, \"edit\": \"update\"}"), version: 20471, deleted: false, device_id: "device-1000", created_version: 10179 }
+RowDump { collection: "files", pk: "pk-00010181", payload: Some("{\"idx\": 10181, \"edit\": \"update\"}"), version: 20472, deleted: false, device_id: "device-1000", created_version: 10181 }
+RowDump { collection: "files", pk: "pk-00010182", payload: Some("{\"idx\": 10182, \"edit\": \"update\"}"), version: 20473, deleted: false, device_id: "device-1000", created_version: 10182 }
+RowDump { collection: "files", pk: "pk-00010183", payload: Some("{\"idx\": 10183, \"edit\": \"update\"}"), version: 20474, deleted: false, device_id: "device-1000", created_version: 10183 }
+RowDump { collection: "files", pk: "pk-00010184", payload: Some("{\"idx\": 10184, \"edit\": \"update\"}"), version: 20475, deleted: false, device_id: "device-1000", created_version: 10184 }
+RowDump { collection: "files", pk: "pk-00010185", payload: Some("{\"idx\": 10185, \"edit\": \"update\"}"), version: 20476, deleted: false, device_id: "device-1000", created_version: 10185 }
+RowDump { collection: "files", pk: "pk-00010186", payload: Some("{\"idx\": 10186, \"edit\": \"update\"}"), version: 20477, deleted: false, device_id: "device-1000", created_version: 10186 }
+RowDump { collection: "files", pk: "pk-00010187", payload: Some("{\"idx\": 10187, \"edit\": \"update\"}"), version: 20478, deleted: false, device_id: "device-1000", created_version: 10187 }
+RowDump { collection: "files", pk: "pk-00010188", payload: Some("{\"idx\": 10188, \"edit\": \"update\"}"), version: 20479, deleted: false, device_id: "device-1000", created_version: 10188 }
+RowDump { collection: "files", pk: "pk-00010189", payload: Some("{\"idx\": 10189, \"edit\": \"update\"}"), version: 20480, deleted: false, device_id: "device-1000", created_version: 10189 }
+RowDump { collection: "tags", pk: "pk-00010190", payload: Some("{\"idx\": 10190, \"edit\": \"update\"}"), version: 20481, deleted: false, device_id: "device-1000", created_version: 10190 }
+RowDump { collection: "tags", pk: "pk-00010191", payload: Some("{\"idx\": 10191, \"edit\": \"update\"}"), version: 20482, deleted: false, device_id: "device-1000", created_version: 10191 }
+RowDump { collection: "tags", pk: "pk-00010192", payload: Some("{\"idx\": 10192, \"edit\": \"update\"}"), version: 20483, deleted: false, device_id: "device-1000", created_version: 10192 }
+RowDump { collection: "tags", pk: "pk-00010193", payload: Some("{\"idx\": 10193, \"edit\": \"update\"}"), version: 20484, deleted: false, device_id: "device-1000", created_version: 10193 }
+RowDump { collection: "tags", pk: "pk-00010194", payload: Some("{\"idx\": 10194, \"edit\": \"update\"}"), version: 20485, deleted: false, device_id: "device-1000", created_version: 10194 }
+RowDump { collection: "tags", pk: "pk-00010195", payload: Some("{\"idx\": 10195, \"edit\": \"update\"}"), version: 20486, deleted: false, device_id: "device-1000", created_version: 10195 }
+RowDump { collection: "tags", pk: "pk-00010196", payload: Some("{\"idx\": 10196, \"edit\": \"update\"}"), version: 20487, deleted: false, device_id: "device-1000", created_version: 10196 }
+RowDump { collection: "archive", pk: "pk-00010197", payload: Some("{\"idx\": 10197, \"edit\": \"update\"}"), version: 20488, deleted: false, device_id: "device-1000", created_version: 10197 }
+RowDump { collection: "archive", pk: "pk-00010198", payload: Some("{\"idx\": 10198, \"edit\": \"update\"}"), version: 20489, deleted: false, device_id: "device-1000", created_version: 10198 }
+RowDump { collection: "archive", pk: "pk-00010199", payload: Some("{\"idx\": 10199, \"edit\": \"update\"}"), version: 20490, deleted: false, device_id: "device-1000", created_version: 10199 }
+RowDump { collection: "notes", pk: "pk-00010201", payload: Some("{\"idx\": 10201, \"edit\": \"update\"}"), version: 20491, deleted: false, device_id: "device-1000", created_version: 10201 }
+RowDump { collection: "notes", pk: "pk-00010202", payload: Some("{\"idx\": 10202, \"edit\": \"update\"}"), version: 20492, deleted: false, device_id: "device-1000", created_version: 10202 }
+RowDump { collection: "notes", pk: "pk-00010203", payload: Some("{\"idx\": 10203, \"edit\": \"update\"}"), version: 20493, deleted: false, device_id: "device-1000", created_version: 10203 }
+RowDump { collection: "notes", pk: "pk-00010204", payload: Some("{\"idx\": 10204, \"edit\": \"update\"}"), version: 20494, deleted: false, device_id: "device-1000", created_version: 10204 }
+RowDump { collection: "notes", pk: "pk-00010205", payload: Some("{\"idx\": 10205, \"edit\": \"update\"}"), version: 20495, deleted: false, device_id: "device-1000", created_version: 10205 }
+RowDump { collection: "notes", pk: "pk-00010206", payload: Some("{\"idx\": 10206, \"edit\": \"update\"}"), version: 20496, deleted: false, device_id: "device-1000", created_version: 10206 }
+RowDump { collection: "notes", pk: "pk-00010207", payload: Some("{\"idx\": 10207, \"edit\": \"update\"}"), version: 20497, deleted: false, device_id: "device-1000", created_version: 10207 }
+RowDump { collection: "notes", pk: "pk-00010208", payload: Some("{\"idx\": 10208, \"edit\": \"update\"}"), version: 20498, deleted: false, device_id: "device-1000", created_version: 10208 }
+RowDump { collection: "notes", pk: "pk-00010209", payload: Some("{\"idx\": 10209, \"edit\": \"update\"}"), version: 20499, deleted: false, device_id: "device-1000", created_version: 10209 }
+RowDump { collection: "notes", pk: "pk-00010210", payload: Some("{\"idx\": 10210, \"edit\": \"update\"}"), version: 20500, deleted: false, device_id: "device-1000", created_version: 10210 }
+RowDump { collection: "notes", pk: "pk-00010211", payload: Some("{\"idx\": 10211, \"edit\": \"update\"}"), version: 20501, deleted: false, device_id: "device-1000", created_version: 10211 }
+RowDump { collection: "notes", pk: "pk-00010212", payload: Some("{\"idx\": 10212, \"edit\": \"update\"}"), version: 20502, deleted: false, device_id: "device-1000", created_version: 10212 }
+RowDump { collection: "notes", pk: "pk-00010213", payload: Some("{\"idx\": 10213, \"edit\": \"update\"}"), version: 20503, deleted: false, device_id: "device-1000", created_version: 10213 }
+RowDump { collection: "notes", pk: "pk-00010214", payload: Some("{\"idx\": 10214, \"edit\": \"update\"}"), version: 20504, deleted: false, device_id: "device-1000", created_version: 10214 }
+RowDump { collection: "notes", pk: "pk-00010215", payload: Some("{\"idx\": 10215, \"edit\": \"update\"}"), version: 20505, deleted: false, device_id: "device-1000", created_version: 10215 }
+RowDump { collection: "notes", pk: "pk-00010216", payload: Some("{\"idx\": 10216, \"edit\": \"update\"}"), version: 20506, deleted: false, device_id: "device-1000", created_version: 10216 }
+RowDump { collection: "notes", pk: "pk-00010217", payload: Some("{\"idx\": 10217, \"edit\": \"update\"}"), version: 20507, deleted: false, device_id: "device-1000", created_version: 10217 }
+RowDump { collection: "notes", pk: "pk-00010218", payload: Some("{\"idx\": 10218, \"edit\": \"update\"}"), version: 20508, deleted: false, device_id: "device-1000", created_version: 10218 }
+RowDump { collection: "notes", pk: "pk-00010219", payload: Some("{\"idx\": 10219, \"edit\": \"update\"}"), version: 20509, deleted: false, device_id: "device-1000", created_version: 10219 }
+RowDump { collection: "notes", pk: "pk-00010221", payload: Some("{\"idx\": 10221, \"edit\": \"update\"}"), version: 20510, deleted: false, device_id: "device-1000", created_version: 10221 }
+RowDump { collection: "notes", pk: "pk-00010222", payload: Some("{\"idx\": 10222, \"edit\": \"update\"}"), version: 20511, deleted: false, device_id: "device-1000", created_version: 10222 }
+RowDump { collection: "notes", pk: "pk-00010223", payload: Some("{\"idx\": 10223, \"edit\": \"update\"}"), version: 20512, deleted: false, device_id: "device-1000", created_version: 10223 }
+RowDump { collection: "notes", pk: "pk-00010224", payload: Some("{\"idx\": 10224, \"edit\": \"update\"}"), version: 20513, deleted: false, device_id: "device-1000", created_version: 10224 }
+RowDump { collection: "notes", pk: "pk-00010225", payload: Some("{\"idx\": 10225, \"edit\": \"update\"}"), version: 20514, deleted: false, device_id: "device-1000", created_version: 10225 }
+RowDump { collection: "notes", pk: "pk-00010226", payload: Some("{\"idx\": 10226, \"edit\": \"update\"}"), version: 20515, deleted: false, device_id: "device-1000", created_version: 10226 }
+RowDump { collection: "notes", pk: "pk-00010227", payload: Some("{\"idx\": 10227, \"edit\": \"update\"}"), version: 20516, deleted: false, device_id: "device-1000", created_version: 10227 }
+RowDump { collection: "notes", pk: "pk-00010228", payload: Some("{\"idx\": 10228, \"edit\": \"update\"}"), version: 20517, deleted: false, device_id: "device-1000", created_version: 10228 }
+RowDump { collection: "notes", pk: "pk-00010229", payload: Some("{\"idx\": 10229, \"edit\": \"update\"}"), version: 20518, deleted: false, device_id: "device-1000", created_version: 10229 }
+RowDump { collection: "notes", pk: "pk-00010230", payload: Some("{\"idx\": 10230, \"edit\": \"update\"}"), version: 20519, deleted: false, device_id: "device-1000", created_version: 10230 }
+RowDump { collection: "notes", pk: "pk-00010231", payload: Some("{\"idx\": 10231, \"edit\": \"update\"}"), version: 20520, deleted: false, device_id: "device-1000", created_version: 10231 }
+RowDump { collection: "notes", pk: "pk-00010232", payload: Some("{\"idx\": 10232, \"edit\": \"update\"}"), version: 20521, deleted: false, device_id: "device-1000", created_version: 10232 }
+RowDump { collection: "notes", pk: "pk-00010233", payload: Some("{\"idx\": 10233, \"edit\": \"update\"}"), version: 20522, deleted: false, device_id: "device-1000", created_version: 10233 }
+RowDump { collection: "notes", pk: "pk-00010234", payload: Some("{\"idx\": 10234, \"edit\": \"update\"}"), version: 20523, deleted: false, device_id: "device-1000", created_version: 10234 }
+RowDump { collection: "notes", pk: "pk-00010235", payload: Some("{\"idx\": 10235, \"edit\": \"update\"}"), version: 20524, deleted: false, device_id: "device-1000", created_version: 10235 }
+RowDump { collection: "notes", pk: "pk-00010236", payload: Some("{\"idx\": 10236, \"edit\": \"update\"}"), version: 20525, deleted: false, device_id: "device-1000", created_version: 10236 }
+RowDump { collection: "notes", pk: "pk-00010237", payload: Some("{\"idx\": 10237, \"edit\": \"update\"}"), version: 20526, deleted: false, device_id: "device-1000", created_version: 10237 }
+RowDump { collection: "notes", pk: "pk-00010238", payload: Some("{\"idx\": 10238, \"edit\": \"update\"}"), version: 20527, deleted: false, device_id: "device-1000", created_version: 10238 }
+RowDump { collection: "notes", pk: "pk-00010239", payload: Some("{\"idx\": 10239, \"edit\": \"update\"}"), version: 20528, deleted: false, device_id: "device-1000", created_version: 10239 }
+RowDump { collection: "contacts", pk: "pk-00010241", payload: Some("{\"idx\": 10241, \"edit\": \"update\"}"), version: 20529, deleted: false, device_id: "device-1000", created_version: 10241 }
+RowDump { collection: "contacts", pk: "pk-00010242", payload: Some("{\"idx\": 10242, \"edit\": \"update\"}"), version: 20530, deleted: false, device_id: "device-1000", created_version: 10242 }
+RowDump { collection: "contacts", pk: "pk-00010243", payload: Some("{\"idx\": 10243, \"edit\": \"update\"}"), version: 20531, deleted: false, device_id: "device-1000", created_version: 10243 }
+RowDump { collection: "contacts", pk: "pk-00010244", payload: Some("{\"idx\": 10244, \"edit\": \"update\"}"), version: 20532, deleted: false, device_id: "device-1000", created_version: 10244 }
+RowDump { collection: "contacts", pk: "pk-00010245", payload: Some("{\"idx\": 10245, \"edit\": \"update\"}"), version: 20533, deleted: false, device_id: "device-1000", created_version: 10245 }
+RowDump { collection: "contacts", pk: "pk-00010246", payload: Some("{\"idx\": 10246, \"edit\": \"update\"}"), version: 20534, deleted: false, device_id: "device-1000", created_version: 10246 }
+RowDump { collection: "contacts", pk: "pk-00010247", payload: Some("{\"idx\": 10247, \"edit\": \"update\"}"), version: 20535, deleted: false, device_id: "device-1000", created_version: 10247 }
+RowDump { collection: "contacts", pk: "pk-00010248", payload: Some("{\"idx\": 10248, \"edit\": \"update\"}"), version: 20536, deleted: false, device_id: "device-1000", created_version: 10248 }
+RowDump { collection: "contacts", pk: "pk-00010249", payload: Some("{\"idx\": 10249, \"edit\": \"update\"}"), version: 20537, deleted: false, device_id: "device-1000", created_version: 10249 }
+RowDump { collection: "contacts", pk: "pk-00010250", payload: Some("{\"idx\": 10250, \"edit\": \"update\"}"), version: 20538, deleted: false, device_id: "device-1000", created_version: 10250 }
+RowDump { collection: "contacts", pk: "pk-00010251", payload: Some("{\"idx\": 10251, \"edit\": \"update\"}"), version: 20539, deleted: false, device_id: "device-1000", created_version: 10251 }
+RowDump { collection: "contacts", pk: "pk-00010252", payload: Some("{\"idx\": 10252, \"edit\": \"update\"}"), version: 20540, deleted: false, device_id: "device-1000", created_version: 10252 }
+RowDump { collection: "contacts", pk: "pk-00010253", payload: Some("{\"idx\": 10253, \"edit\": \"update\"}"), version: 20541, deleted: false, device_id: "device-1000", created_version: 10253 }
+RowDump { collection: "contacts", pk: "pk-00010254", payload: Some("{\"idx\": 10254, \"edit\": \"update\"}"), version: 20542, deleted: false, device_id: "device-1000", created_version: 10254 }
+RowDump { collection: "contacts", pk: "pk-00010255", payload: Some("{\"idx\": 10255, \"edit\": \"update\"}"), version: 20543, deleted: false, device_id: "device-1000", created_version: 10255 }
+RowDump { collection: "contacts", pk: "pk-00010256", payload: Some("{\"idx\": 10256, \"edit\": \"update\"}"), version: 20544, deleted: false, device_id: "device-1000", created_version: 10256 }
+RowDump { collection: "contacts", pk: "pk-00010257", payload: Some("{\"idx\": 10257, \"edit\": \"update\"}"), version: 20545, deleted: false, device_id: "device-1000", created_version: 10257 }
+RowDump { collection: "contacts", pk: "pk-00010258", payload: Some("{\"idx\": 10258, \"edit\": \"update\"}"), version: 20546, deleted: false, device_id: "device-1000", created_version: 10258 }
+RowDump { collection: "contacts", pk: "pk-00010259", payload: Some("{\"idx\": 10259, \"edit\": \"update\"}"), version: 20547, deleted: false, device_id: "device-1000", created_version: 10259 }
+RowDump { collection: "tasks", pk: "pk-00010261", payload: Some("{\"idx\": 10261, \"edit\": \"update\"}"), version: 20548, deleted: false, device_id: "device-1000", created_version: 10261 }
+RowDump { collection: "tasks", pk: "pk-00010262", payload: Some("{\"idx\": 10262, \"edit\": \"update\"}"), version: 20549, deleted: false, device_id: "device-1000", created_version: 10262 }
+RowDump { collection: "tasks", pk: "pk-00010263", payload: Some("{\"idx\": 10263, \"edit\": \"update\"}"), version: 20550, deleted: false, device_id: "device-1000", created_version: 10263 }
+RowDump { collection: "tasks", pk: "pk-00010264", payload: Some("{\"idx\": 10264, \"edit\": \"update\"}"), version: 20551, deleted: false, device_id: "device-1000", created_version: 10264 }
+RowDump { collection: "tasks", pk: "pk-00010265", payload: Some("{\"idx\": 10265, \"edit\": \"update\"}"), version: 20552, deleted: false, device_id: "device-1000", created_version: 10265 }
+RowDump { collection: "tasks", pk: "pk-00010266", payload: Some("{\"idx\": 10266, \"edit\": \"update\"}"), version: 20553, deleted: false, device_id: "device-1000", created_version: 10266 }
+RowDump { collection: "tasks", pk: "pk-00010267", payload: Some("{\"idx\": 10267, \"edit\": \"update\"}"), version: 20554, deleted: false, device_id: "device-1000", created_version: 10267 }
+RowDump { collection: "tasks", pk: "pk-00010268", payload: Some("{\"idx\": 10268, \"edit\": \"update\"}"), version: 20555, deleted: false, device_id: "device-1000", created_version: 10268 }
+RowDump { collection: "tasks", pk: "pk-00010269", payload: Some("{\"idx\": 10269, \"edit\": \"update\"}"), version: 20556, deleted: false, device_id: "device-1000", created_version: 10269 }
+RowDump { collection: "tasks", pk: "pk-00010270", payload: Some("{\"idx\": 10270, \"edit\": \"update\"}"), version: 20557, deleted: false, device_id: "device-1000", created_version: 10270 }
+RowDump { collection: "tasks", pk: "pk-00010271", payload: Some("{\"idx\": 10271, \"edit\": \"update\"}"), version: 20558, deleted: false, device_id: "device-1000", created_version: 10271 }
+RowDump { collection: "tasks", pk: "pk-00010272", payload: Some("{\"idx\": 10272, \"edit\": \"update\"}"), version: 20559, deleted: false, device_id: "device-1000", created_version: 10272 }
+RowDump { collection: "tasks", pk: "pk-00010273", payload: Some("{\"idx\": 10273, \"edit\": \"update\"}"), version: 20560, deleted: false, device_id: "device-1000", created_version: 10273 }
+RowDump { collection: "tasks", pk: "pk-00010274", payload: Some("{\"idx\": 10274, \"edit\": \"update\"}"), version: 20561, deleted: false, device_id: "device-1000", created_version: 10274 }
+RowDump { collection: "files", pk: "pk-00010275", payload: Some("{\"idx\": 10275, \"edit\": \"update\"}"), version: 20562, deleted: false, device_id: "device-1000", created_version: 10275 }
+RowDump { collection: "files", pk: "pk-00010276", payload: Some("{\"idx\": 10276, \"edit\": \"update\"}"), version: 20563, deleted: false, device_id: "device-1000", created_version: 10276 }
+RowDump { collection: "files", pk: "pk-00010277", payload: Some("{\"idx\": 10277, \"edit\": \"update\"}"), version: 20564, deleted: false, device_id: "device-1000", created_version: 10277 }
+RowDump { collection: "files", pk: "pk-00010278", payload: Some("{\"idx\": 10278, \"edit\": \"update\"}"), version: 20565, deleted: false, device_id: "device-1000", created_version: 10278 }
+RowDump { collection: "files", pk: "pk-00010279", payload: Some("{\"idx\": 10279, \"edit\": \"update\"}"), version: 20566, deleted: false, device_id: "device-1000", created_version: 10279 }
+RowDump { collection: "files", pk: "pk-00010281", payload: Some("{\"idx\": 10281, \"edit\": \"update\"}"), version: 20567, deleted: false, device_id: "device-1000", created_version: 10281 }
+RowDump { collection: "files", pk: "pk-00010282", payload: Some("{\"idx\": 10282, \"edit\": \"update\"}"), version: 20568, deleted: false, device_id: "device-1000", created_version: 10282 }
+RowDump { collection: "files", pk: "pk-00010283", payload: Some("{\"idx\": 10283, \"edit\": \"update\"}"), version: 20569, deleted: false, device_id: "device-1000", created_version: 10283 }
+RowDump { collection: "files", pk: "pk-00010284", payload: Some("{\"idx\": 10284, \"edit\": \"update\"}"), version: 20570, deleted: false, device_id: "device-1000", created_version: 10284 }
+RowDump { collection: "files", pk: "pk-00010285", payload: Some("{\"idx\": 10285, \"edit\": \"update\"}"), version: 20571, deleted: false, device_id: "device-1000", created_version: 10285 }
+RowDump { collection: "files", pk: "pk-00010286", payload: Some("{\"idx\": 10286, \"edit\": \"update\"}"), version: 20572, deleted: false, device_id: "device-1000", created_version: 10286 }
+RowDump { collection: "files", pk: "pk-00010287", payload: Some("{\"idx\": 10287, \"edit\": \"update\"}"), version: 20573, deleted: false, device_id: "device-1000", created_version: 10287 }
+RowDump { collection: "files", pk: "pk-00010288", payload: Some("{\"idx\": 10288, \"edit\": \"update\"}"), version: 20574, deleted: false, device_id: "device-1000", created_version: 10288 }
+RowDump { collection: "files", pk: "pk-00010289", payload: Some("{\"idx\": 10289, \"edit\": \"update\"}"), version: 20575, deleted: false, device_id: "device-1000", created_version: 10289 }
+RowDump { collection: "tags", pk: "pk-00010290", payload: Some("{\"idx\": 10290, \"edit\": \"update\"}"), version: 20576, deleted: false, device_id: "device-1000", created_version: 10290 }
+RowDump { collection: "tags", pk: "pk-00010291", payload: Some("{\"idx\": 10291, \"edit\": \"update\"}"), version: 20577, deleted: false, device_id: "device-1000", created_version: 10291 }
+RowDump { collection: "tags", pk: "pk-00010292", payload: Some("{\"idx\": 10292, \"edit\": \"update\"}"), version: 20578, deleted: false, device_id: "device-1000", created_version: 10292 }
+RowDump { collection: "tags", pk: "pk-00010293", payload: Some("{\"idx\": 10293, \"edit\": \"update\"}"), version: 20579, deleted: false, device_id: "device-1000", created_version: 10293 }
+RowDump { collection: "tags", pk: "pk-00010294", payload: Some("{\"idx\": 10294, \"edit\": \"update\"}"), version: 20580, deleted: false, device_id: "device-1000", created_version: 10294 }
+RowDump { collection: "tags", pk: "pk-00010295", payload: Some("{\"idx\": 10295, \"edit\": \"update\"}"), version: 20581, deleted: false, device_id: "device-1000", created_version: 10295 }
+RowDump { collection: "tags", pk: "pk-00010296", payload: Some("{\"idx\": 10296, \"edit\": \"update\"}"), version: 20582, deleted: false, device_id: "device-1000", created_version: 10296 }
+RowDump { collection: "archive", pk: "pk-00010297", payload: Some("{\"idx\": 10297, \"edit\": \"update\"}"), version: 20583, deleted: false, device_id: "device-1000", created_version: 10297 }
+RowDump { collection: "archive", pk: "pk-00010298", payload: Some("{\"idx\": 10298, \"edit\": \"update\"}"), version: 20584, deleted: false, device_id: "device-1000", created_version: 10298 }
+RowDump { collection: "archive", pk: "pk-00010299", payload: Some("{\"idx\": 10299, \"edit\": \"update\"}"), version: 20585, deleted: false, device_id: "device-1000", created_version: 10299 }
+RowDump { collection: "notes", pk: "pk-00010301", payload: Some("{\"idx\": 10301, \"edit\": \"update\"}"), version: 20586, deleted: false, device_id: "device-1000", created_version: 10301 }
+RowDump { collection: "notes", pk: "pk-00010302", payload: Some("{\"idx\": 10302, \"edit\": \"update\"}"), version: 20587, deleted: false, device_id: "device-1000", created_version: 10302 }
+RowDump { collection: "notes", pk: "pk-00010303", payload: Some("{\"idx\": 10303, \"edit\": \"update\"}"), version: 20588, deleted: false, device_id: "device-1000", created_version: 10303 }
+RowDump { collection: "notes", pk: "pk-00010304", payload: Some("{\"idx\": 10304, \"edit\": \"update\"}"), version: 20589, deleted: false, device_id: "device-1000", created_version: 10304 }
+RowDump { collection: "notes", pk: "pk-00010305", payload: Some("{\"idx\": 10305, \"edit\": \"update\"}"), version: 20590, deleted: false, device_id: "device-1000", created_version: 10305 }
+RowDump { collection: "notes", pk: "pk-00010306", payload: Some("{\"idx\": 10306, \"edit\": \"update\"}"), version: 20591, deleted: false, device_id: "device-1000", created_version: 10306 }
+RowDump { collection: "notes", pk: "pk-00010307", payload: Some("{\"idx\": 10307, \"edit\": \"update\"}"), version: 20592, deleted: false, device_id: "device-1000", created_version: 10307 }
+RowDump { collection: "notes", pk: "pk-00010308", payload: Some("{\"idx\": 10308, \"edit\": \"update\"}"), version: 20593, deleted: false, device_id: "device-1000", created_version: 10308 }
+RowDump { collection: "notes", pk: "pk-00010309", payload: Some("{\"idx\": 10309, \"edit\": \"update\"}"), version: 20594, deleted: false, device_id: "device-1000", created_version: 10309 }
+RowDump { collection: "notes", pk: "pk-00010310", payload: Some("{\"idx\": 10310, \"edit\": \"update\"}"), version: 20595, deleted: false, device_id: "device-1000", created_version: 10310 }
+RowDump { collection: "notes", pk: "pk-00010311", payload: Some("{\"idx\": 10311, \"edit\": \"update\"}"), version: 20596, deleted: false, device_id: "device-1000", created_version: 10311 }
+RowDump { collection: "notes", pk: "pk-00010312", payload: Some("{\"idx\": 10312, \"edit\": \"update\"}"), version: 20597, deleted: false, device_id: "device-1000", created_version: 10312 }
+RowDump { collection: "notes", pk: "pk-00010313", payload: Some("{\"idx\": 10313, \"edit\": \"update\"}"), version: 20598, deleted: false, device_id: "device-1000", created_version: 10313 }
+RowDump { collection: "notes", pk: "pk-00010314", payload: Some("{\"idx\": 10314, \"edit\": \"update\"}"), version: 20599, deleted: false, device_id: "device-1000", created_version: 10314 }
+RowDump { collection: "notes", pk: "pk-00010315", payload: Some("{\"idx\": 10315, \"edit\": \"update\"}"), version: 20600, deleted: false, device_id: "device-1000", created_version: 10315 }
+RowDump { collection: "notes", pk: "pk-00010316", payload: Some("{\"idx\": 10316, \"edit\": \"update\"}"), version: 20601, deleted: false, device_id: "device-1000", created_version: 10316 }
+RowDump { collection: "notes", pk: "pk-00010317", payload: Some("{\"idx\": 10317, \"edit\": \"update\"}"), version: 20602, deleted: false, device_id: "device-1000", created_version: 10317 }
+RowDump { collection: "notes", pk: "pk-00010318", payload: Some("{\"idx\": 10318, \"edit\": \"update\"}"), version: 20603, deleted: false, device_id: "device-1000", created_version: 10318 }
+RowDump { collection: "notes", pk: "pk-00010319", payload: Some("{\"idx\": 10319, \"edit\": \"update\"}"), version: 20604, deleted: false, device_id: "device-1000", created_version: 10319 }
+RowDump { collection: "notes", pk: "pk-00010321", payload: Some("{\"idx\": 10321, \"edit\": \"update\"}"), version: 20605, deleted: false, device_id: "device-1000", created_version: 10321 }
+RowDump { collection: "notes", pk: "pk-00010322", payload: Some("{\"idx\": 10322, \"edit\": \"update\"}"), version: 20606, deleted: false, device_id: "device-1000", created_version: 10322 }
+RowDump { collection: "notes", pk: "pk-00010323", payload: Some("{\"idx\": 10323, \"edit\": \"update\"}"), version: 20607, deleted: false, device_id: "device-1000", created_version: 10323 }
+RowDump { collection: "notes", pk: "pk-00010324", payload: Some("{\"idx\": 10324, \"edit\": \"update\"}"), version: 20608, deleted: false, device_id: "device-1000", created_version: 10324 }
+RowDump { collection: "notes", pk: "pk-00010325", payload: Some("{\"idx\": 10325, \"edit\": \"update\"}"), version: 20609, deleted: false, device_id: "device-1000", created_version: 10325 }
+RowDump { collection: "notes", pk: "pk-00010326", payload: Some("{\"idx\": 10326, \"edit\": \"update\"}"), version: 20610, deleted: false, device_id: "device-1000", created_version: 10326 }
+RowDump { collection: "notes", pk: "pk-00010327", payload: Some("{\"idx\": 10327, \"edit\": \"update\"}"), version: 20611, deleted: false, device_id: "device-1000", created_version: 10327 }
+RowDump { collection: "notes", pk: "pk-00010328", payload: Some("{\"idx\": 10328, \"edit\": \"update\"}"), version: 20612, deleted: false, device_id: "device-1000", created_version: 10328 }
+RowDump { collection: "notes", pk: "pk-00010329", payload: Some("{\"idx\": 10329, \"edit\": \"update\"}"), version: 20613, deleted: false, device_id: "device-1000", created_version: 10329 }
+RowDump { collection: "notes", pk: "pk-00010330", payload: Some("{\"idx\": 10330, \"edit\": \"update\"}"), version: 20614, deleted: false, device_id: "device-1000", created_version: 10330 }
+RowDump { collection: "notes", pk: "pk-00010331", payload: Some("{\"idx\": 10331, \"edit\": \"update\"}"), version: 20615, deleted: false, device_id: "device-1000", created_version: 10331 }
+RowDump { collection: "notes", pk: "pk-00010332", payload: Some("{\"idx\": 10332, \"edit\": \"update\"}"), version: 20616, deleted: false, device_id: "device-1000", created_version: 10332 }
+RowDump { collection: "notes", pk: "pk-00010333", payload: Some("{\"idx\": 10333, \"edit\": \"update\"}"), version: 20617, deleted: false, device_id: "device-1000", created_version: 10333 }
+RowDump { collection: "notes", pk: "pk-00010334", payload: Some("{\"idx\": 10334, \"edit\": \"update\"}"), version: 20618, deleted: false, device_id: "device-1000", created_version: 10334 }
+RowDump { collection: "notes", pk: "pk-00010335", payload: Some("{\"idx\": 10335, \"edit\": \"update\"}"), version: 20619, deleted: false, device_id: "device-1000", created_version: 10335 }
+RowDump { collection: "notes", pk: "pk-00010336", payload: Some("{\"idx\": 10336, \"edit\": \"update\"}"), version: 20620, deleted: false, device_id: "device-1000", created_version: 10336 }
+RowDump { collection: "notes", pk: "pk-00010337", payload: Some("{\"idx\": 10337, \"edit\": \"update\"}"), version: 20621, deleted: false, device_id: "device-1000", created_version: 10337 }
+RowDump { collection: "notes", pk: "pk-00010338", payload: Some("{\"idx\": 10338, \"edit\": \"update\"}"), version: 20622, deleted: false, device_id: "device-1000", created_version: 10338 }
+RowDump { collection: "notes", pk: "pk-00010339", payload: Some("{\"idx\": 10339, \"edit\": \"update\"}"), version: 20623, deleted: false, device_id: "device-1000", created_version: 10339 }
+RowDump { collection: "contacts", pk: "pk-00010341", payload: Some("{\"idx\": 10341, \"edit\": \"update\"}"), version: 20624, deleted: false, device_id: "device-1000", created_version: 10341 }
+RowDump { collection: "contacts", pk: "pk-00010342", payload: Some("{\"idx\": 10342, \"edit\": \"update\"}"), version: 20625, deleted: false, device_id: "device-1000", created_version: 10342 }
+RowDump { collection: "contacts", pk: "pk-00010343", payload: Some("{\"idx\": 10343, \"edit\": \"update\"}"), version: 20626, deleted: false, device_id: "device-1000", created_version: 10343 }
+RowDump { collection: "contacts", pk: "pk-00010344", payload: Some("{\"idx\": 10344, \"edit\": \"update\"}"), version: 20627, deleted: false, device_id: "device-1000", created_version: 10344 }
+RowDump { collection: "contacts", pk: "pk-00010345", payload: Some("{\"idx\": 10345, \"edit\": \"update\"}"), version: 20628, deleted: false, device_id: "device-1000", created_version: 10345 }
+RowDump { collection: "contacts", pk: "pk-00010346", payload: Some("{\"idx\": 10346, \"edit\": \"update\"}"), version: 20629, deleted: false, device_id: "device-1000", created_version: 10346 }
+RowDump { collection: "contacts", pk: "pk-00010347", payload: Some("{\"idx\": 10347, \"edit\": \"update\"}"), version: 20630, deleted: false, device_id: "device-1000", created_version: 10347 }
+RowDump { collection: "contacts", pk: "pk-00010348", payload: Some("{\"idx\": 10348, \"edit\": \"update\"}"), version: 20631, deleted: false, device_id: "device-1000", created_version: 10348 }
+RowDump { collection: "contacts", pk: "pk-00010349", payload: Some("{\"idx\": 10349, \"edit\": \"update\"}"), version: 20632, deleted: false, device_id: "device-1000", created_version: 10349 }
+RowDump { collection: "contacts", pk: "pk-00010350", payload: Some("{\"idx\": 10350, \"edit\": \"update\"}"), version: 20633, deleted: false, device_id: "device-1000", created_version: 10350 }
+RowDump { collection: "contacts", pk: "pk-00010351", payload: Some("{\"idx\": 10351, \"edit\": \"update\"}"), version: 20634, deleted: false, device_id: "device-1000", created_version: 10351 }
+RowDump { collection: "contacts", pk: "pk-00010352", payload: Some("{\"idx\": 10352, \"edit\": \"update\"}"), version: 20635, deleted: false, device_id: "device-1000", created_version: 10352 }
+RowDump { collection: "contacts", pk: "pk-00010353", payload: Some("{\"idx\": 10353, \"edit\": \"update\"}"), version: 20636, deleted: false, device_id: "device-1000", created_version: 10353 }
+RowDump { collection: "contacts", pk: "pk-00010354", payload: Some("{\"idx\": 10354, \"edit\": \"update\"}"), version: 20637, deleted: false, device_id: "device-1000", created_version: 10354 }
+RowDump { collection: "contacts", pk: "pk-00010355", payload: Some("{\"idx\": 10355, \"edit\": \"update\"}"), version: 20638, deleted: false, device_id: "device-1000", created_version: 10355 }
+RowDump { collection: "contacts", pk: "pk-00010356", payload: Some("{\"idx\": 10356, \"edit\": \"update\"}"), version: 20639, deleted: false, device_id: "device-1000", created_version: 10356 }
+RowDump { collection: "contacts", pk: "pk-00010357", payload: Some("{\"idx\": 10357, \"edit\": \"update\"}"), version: 20640, deleted: false, device_id: "device-1000", created_version: 10357 }
+RowDump { collection: "contacts", pk: "pk-00010358", payload: Some("{\"idx\": 10358, \"edit\": \"update\"}"), version: 20641, deleted: false, device_id: "device-1000", created_version: 10358 }
+RowDump { collection: "contacts", pk: "pk-00010359", payload: Some("{\"idx\": 10359, \"edit\": \"update\"}"), version: 20642, deleted: false, device_id: "device-1000", created_version: 10359 }
+RowDump { collection: "tasks", pk: "pk-00010361", payload: Some("{\"idx\": 10361, \"edit\": \"update\"}"), version: 20643, deleted: false, device_id: "device-1000", created_version: 10361 }
+RowDump { collection: "tasks", pk: "pk-00010362", payload: Some("{\"idx\": 10362, \"edit\": \"update\"}"), version: 20644, deleted: false, device_id: "device-1000", created_version: 10362 }
+RowDump { collection: "tasks", pk: "pk-00010363", payload: Some("{\"idx\": 10363, \"edit\": \"update\"}"), version: 20645, deleted: false, device_id: "device-1000", created_version: 10363 }
+RowDump { collection: "tasks", pk: "pk-00010364", payload: Some("{\"idx\": 10364, \"edit\": \"update\"}"), version: 20646, deleted: false, device_id: "device-1000", created_version: 10364 }
+RowDump { collection: "tasks", pk: "pk-00010365", payload: Some("{\"idx\": 10365, \"edit\": \"update\"}"), version: 20647, deleted: false, device_id: "device-1000", created_version: 10365 }
+RowDump { collection: "tasks", pk: "pk-00010366", payload: Some("{\"idx\": 10366, \"edit\": \"update\"}"), version: 20648, deleted: false, device_id: "device-1000", created_version: 10366 }
+RowDump { collection: "tasks", pk: "pk-00010367", payload: Some("{\"idx\": 10367, \"edit\": \"update\"}"), version: 20649, deleted: false, device_id: "device-1000", created_version: 10367 }
+RowDump { collection: "tasks", pk: "pk-00010368", payload: Some("{\"idx\": 10368, \"edit\": \"update\"}"), version: 20650, deleted: false, device_id: "device-1000", created_version: 10368 }
+RowDump { collection: "tasks", pk: "pk-00010369", payload: Some("{\"idx\": 10369, \"edit\": \"update\"}"), version: 20651, deleted: false, device_id: "device-1000", created_version: 10369 }
+RowDump { collection: "tasks", pk: "pk-00010370", payload: Some("{\"idx\": 10370, \"edit\": \"update\"}"), version: 20652, deleted: false, device_id: "device-1000", created_version: 10370 }
+RowDump { collection: "tasks", pk: "pk-00010371", payload: Some("{\"idx\": 10371, \"edit\": \"update\"}"), version: 20653, deleted: false, device_id: "device-1000", created_version: 10371 }
+RowDump { collection: "tasks", pk: "pk-00010372", payload: Some("{\"idx\": 10372, \"edit\": \"update\"}"), version: 20654, deleted: false, device_id: "device-1000", created_version: 10372 }
+RowDump { collection: "tasks", pk: "pk-00010373", payload: Some("{\"idx\": 10373, \"edit\": \"update\"}"), version: 20655, deleted: false, device_id: "device-1000", created_version: 10373 }
+RowDump { collection: "tasks", pk: "pk-00010374", payload: Some("{\"idx\": 10374, \"edit\": \"update\"}"), version: 20656, deleted: false, device_id: "device-1000", created_version: 10374 }
+RowDump { collection: "files", pk: "pk-00010375", payload: Some("{\"idx\": 10375, \"edit\": \"update\"}"), version: 20657, deleted: false, device_id: "device-1000", created_version: 10375 }
+RowDump { collection: "files", pk: "pk-00010376", payload: Some("{\"idx\": 10376, \"edit\": \"update\"}"), version: 20658, deleted: false, device_id: "device-1000", created_version: 10376 }
+RowDump { collection: "files", pk: "pk-00010377", payload: Some("{\"idx\": 10377, \"edit\": \"update\"}"), version: 20659, deleted: false, device_id: "device-1000", created_version: 10377 }
+RowDump { collection: "files", pk: "pk-00010378", payload: Some("{\"idx\": 10378, \"edit\": \"update\"}"), version: 20660, deleted: false, device_id: "device-1000", created_version: 10378 }
+RowDump { collection: "files", pk: "pk-00010379", payload: Some("{\"idx\": 10379, \"edit\": \"update\"}"), version: 20661, deleted: false, device_id: "device-1000", created_version: 10379 }
+RowDump { collection: "files", pk: "pk-00010381", payload: Some("{\"idx\": 10381, \"edit\": \"update\"}"), version: 20662, deleted: false, device_id: "device-1000", created_version: 10381 }
+RowDump { collection: "files", pk: "pk-00010382", payload: Some("{\"idx\": 10382, \"edit\": \"update\"}"), version: 20663, deleted: false, device_id: "device-1000", created_version: 10382 }
+RowDump { collection: "files", pk: "pk-00010383", payload: Some("{\"idx\": 10383, \"edit\": \"update\"}"), version: 20664, deleted: false, device_id: "device-1000", created_version: 10383 }
+RowDump { collection: "files", pk: "pk-00010384", payload: Some("{\"idx\": 10384, \"edit\": \"update\"}"), version: 20665, deleted: false, device_id: "device-1000", created_version: 10384 }
+RowDump { collection: "files", pk: "pk-00010385", payload: Some("{\"idx\": 10385, \"edit\": \"update\"}"), version: 20666, deleted: false, device_id: "device-1000", created_version: 10385 }
+RowDump { collection: "files", pk: "pk-00010386", payload: Some("{\"idx\": 10386, \"edit\": \"update\"}"), version: 20667, deleted: false, device_id: "device-1000", created_version: 10386 }
+RowDump { collection: "files", pk: "pk-00010387", payload: Some("{\"idx\": 10387, \"edit\": \"update\"}"), version: 20668, deleted: false, device_id: "device-1000", created_version: 10387 }
+RowDump { collection: "files", pk: "pk-00010388", payload: Some("{\"idx\": 10388, \"edit\": \"update\"}"), version: 20669, deleted: false, device_id: "device-1000", created_version: 10388 }
+RowDump { collection: "files", pk: "pk-00010389", payload: Some("{\"idx\": 10389, \"edit\": \"update\"}"), version: 20670, deleted: false, device_id: "device-1000", created_version: 10389 }
+RowDump { collection: "tags", pk: "pk-00010390", payload: Some("{\"idx\": 10390, \"edit\": \"update\"}"), version: 20671, deleted: false, device_id: "device-1000", created_version: 10390 }
+RowDump { collection: "tags", pk: "pk-00010391", payload: Some("{\"idx\": 10391, \"edit\": \"update\"}"), version: 20672, deleted: false, device_id: "device-1000", created_version: 10391 }
+RowDump { collection: "tags", pk: "pk-00010392", payload: Some("{\"idx\": 10392, \"edit\": \"update\"}"), version: 20673, deleted: false, device_id: "device-1000", created_version: 10392 }
+RowDump { collection: "tags", pk: "pk-00010393", payload: Some("{\"idx\": 10393, \"edit\": \"update\"}"), version: 20674, deleted: false, device_id: "device-1000", created_version: 10393 }
+RowDump { collection: "tags", pk: "pk-00010394", payload: Some("{\"idx\": 10394, \"edit\": \"update\"}"), version: 20675, deleted: false, device_id: "device-1000", created_version: 10394 }
+RowDump { collection: "tags", pk: "pk-00010395", payload: Some("{\"idx\": 10395, \"edit\": \"update\"}"), version: 20676, deleted: false, device_id: "device-1000", created_version: 10395 }
+RowDump { collection: "tags", pk: "pk-00010396", payload: Some("{\"idx\": 10396, \"edit\": \"update\"}"), version: 20677, deleted: false, device_id: "device-1000", created_version: 10396 }
+RowDump { collection: "archive", pk: "pk-00010397", payload: Some("{\"idx\": 10397, \"edit\": \"update\"}"), version: 20678, deleted: false, device_id: "device-1000", created_version: 10397 }
+RowDump { collection: "archive", pk: "pk-00010398", payload: Some("{\"idx\": 10398, \"edit\": \"update\"}"), version: 20679, deleted: false, device_id: "device-1000", created_version: 10398 }
+RowDump { collection: "archive", pk: "pk-00010399", payload: Some("{\"idx\": 10399, \"edit\": \"update\"}"), version: 20680, deleted: false, device_id: "device-1000", created_version: 10399 }
+RowDump { collection: "notes", pk: "pk-00010401", payload: Some("{\"idx\": 10401, \"edit\": \"update\"}"), version: 20681, deleted: false, device_id: "device-1000", created_version: 10401 }
+RowDump { collection: "notes", pk: "pk-00010402", payload: Some("{\"idx\": 10402, \"edit\": \"update\"}"), version: 20682, deleted: false, device_id: "device-1000", created_version: 10402 }
+RowDump { collection: "notes", pk: "pk-00010403", payload: Some("{\"idx\": 10403, \"edit\": \"update\"}"), version: 20683, deleted: false, device_id: "device-1000", created_version: 10403 }
+RowDump { collection: "notes", pk: "pk-00010404", payload: Some("{\"idx\": 10404, \"edit\": \"update\"}"), version: 20684, deleted: false, device_id: "device-1000", created_version: 10404 }
+RowDump { collection: "notes", pk: "pk-00010405", payload: Some("{\"idx\": 10405, \"edit\": \"update\"}"), version: 20685, deleted: false, device_id: "device-1000", created_version: 10405 }
+RowDump { collection: "notes", pk: "pk-00010406", payload: Some("{\"idx\": 10406, \"edit\": \"update\"}"), version: 20686, deleted: false, device_id: "device-1000", created_version: 10406 }
+RowDump { collection: "notes", pk: "pk-00010407", payload: Some("{\"idx\": 10407, \"edit\": \"update\"}"), version: 20687, deleted: false, device_id: "device-1000", created_version: 10407 }
+RowDump { collection: "notes", pk: "pk-00010408", payload: Some("{\"idx\": 10408, \"edit\": \"update\"}"), version: 20688, deleted: false, device_id: "device-1000", created_version: 10408 }
+RowDump { collection: "notes", pk: "pk-00010409", payload: Some("{\"idx\": 10409, \"edit\": \"update\"}"), version: 20689, deleted: false, device_id: "device-1000", created_version: 10409 }
+RowDump { collection: "notes", pk: "pk-00010410", payload: Some("{\"idx\": 10410, \"edit\": \"update\"}"), version: 20690, deleted: false, device_id: "device-1000", created_version: 10410 }
+RowDump { collection: "notes", pk: "pk-00010411", payload: Some("{\"idx\": 10411, \"edit\": \"update\"}"), version: 20691, deleted: false, device_id: "device-1000", created_version: 10411 }
+RowDump { collection: "notes", pk: "pk-00010412", payload: Some("{\"idx\": 10412, \"edit\": \"update\"}"), version: 20692, deleted: false, device_id: "device-1000", created_version: 10412 }
+RowDump { collection: "notes", pk: "pk-00010413", payload: Some("{\"idx\": 10413, \"edit\": \"update\"}"), version: 20693, deleted: false, device_id: "device-1000", created_version: 10413 }
+RowDump { collection: "notes", pk: "pk-00010414", payload: Some("{\"idx\": 10414, \"edit\": \"update\"}"), version: 20694, deleted: false, device_id: "device-1000", created_version: 10414 }
+RowDump { collection: "notes", pk: "pk-00010415", payload: Some("{\"idx\": 10415, \"edit\": \"update\"}"), version: 20695, deleted: false, device_id: "device-1000", created_version: 10415 }
+RowDump { collection: "notes", pk: "pk-00010416", payload: Some("{\"idx\": 10416, \"edit\": \"update\"}"), version: 20696, deleted: false, device_id: "device-1000", created_version: 10416 }
+RowDump { collection: "notes", pk: "pk-00010417", payload: Some("{\"idx\": 10417, \"edit\": \"update\"}"), version: 20697, deleted: false, device_id: "device-1000", created_version: 10417 }
+RowDump { collection: "notes", pk: "pk-00010418", payload: Some("{\"idx\": 10418, \"edit\": \"update\"}"), version: 20698, deleted: false, device_id: "device-1000", created_version: 10418 }
+RowDump { collection: "notes", pk: "pk-00010419", payload: Some("{\"idx\": 10419, \"edit\": \"update\"}"), version: 20699, deleted: false, device_id: "device-1000", created_version: 10419 }
+RowDump { collection: "notes", pk: "pk-00010421", payload: Some("{\"idx\": 10421, \"edit\": \"update\"}"), version: 20700, deleted: false, device_id: "device-1000", created_version: 10421 }
+RowDump { collection: "notes", pk: "pk-00010422", payload: Some("{\"idx\": 10422, \"edit\": \"update\"}"), version: 20701, deleted: false, device_id: "device-1000", created_version: 10422 }
+RowDump { collection: "notes", pk: "pk-00010423", payload: Some("{\"idx\": 10423, \"edit\": \"update\"}"), version: 20702, deleted: false, device_id: "device-1000", created_version: 10423 }
+RowDump { collection: "notes", pk: "pk-00010424", payload: Some("{\"idx\": 10424, \"edit\": \"update\"}"), version: 20703, deleted: false, device_id: "device-1000", created_version: 10424 }
+RowDump { collection: "notes", pk: "pk-00010425", payload: Some("{\"idx\": 10425, \"edit\": \"update\"}"), version: 20704, deleted: false, device_id: "device-1000", created_version: 10425 }
+RowDump { collection: "notes", pk: "pk-00010426", payload: Some("{\"idx\": 10426, \"edit\": \"update\"}"), version: 20705, deleted: false, device_id: "device-1000", created_version: 10426 }
+RowDump { collection: "notes", pk: "pk-00010427", payload: Some("{\"idx\": 10427, \"edit\": \"update\"}"), version: 20706, deleted: false, device_id: "device-1000", created_version: 10427 }
+RowDump { collection: "notes", pk: "pk-00010428", payload: Some("{\"idx\": 10428, \"edit\": \"update\"}"), version: 20707, deleted: false, device_id: "device-1000", created_version: 10428 }
+RowDump { collection: "notes", pk: "pk-00010429", payload: Some("{\"idx\": 10429, \"edit\": \"update\"}"), version: 20708, deleted: false, device_id: "device-1000", created_version: 10429 }
+RowDump { collection: "notes", pk: "pk-00010430", payload: Some("{\"idx\": 10430, \"edit\": \"update\"}"), version: 20709, deleted: false, device_id: "device-1000", created_version: 10430 }
+RowDump { collection: "notes", pk: "pk-00010431", payload: Some("{\"idx\": 10431, \"edit\": \"update\"}"), version: 20710, deleted: false, device_id: "device-1000", created_version: 10431 }
+RowDump { collection: "notes", pk: "pk-00010432", payload: Some("{\"idx\": 10432, \"edit\": \"update\"}"), version: 20711, deleted: false, device_id: "device-1000", created_version: 10432 }
+RowDump { collection: "notes", pk: "pk-00010433", payload: Some("{\"idx\": 10433, \"edit\": \"update\"}"), version: 20712, deleted: false, device_id: "device-1000", created_version: 10433 }
+RowDump { collection: "notes", pk: "pk-00010434", payload: Some("{\"idx\": 10434, \"edit\": \"update\"}"), version: 20713, deleted: false, device_id: "device-1000", created_version: 10434 }
+RowDump { collection: "notes", pk: "pk-00010435", payload: Some("{\"idx\": 10435, \"edit\": \"update\"}"), version: 20714, deleted: false, device_id: "device-1000", created_version: 10435 }
+RowDump { collection: "notes", pk: "pk-00010436", payload: Some("{\"idx\": 10436, \"edit\": \"update\"}"), version: 20715, deleted: false, device_id: "device-1000", created_version: 10436 }
+RowDump { collection: "notes", pk: "pk-00010437", payload: Some("{\"idx\": 10437, \"edit\": \"update\"}"), version: 20716, deleted: false, device_id: "device-1000", created_version: 10437 }
+RowDump { collection: "notes", pk: "pk-00010438", payload: Some("{\"idx\": 10438, \"edit\": \"update\"}"), version: 20717, deleted: false, device_id: "device-1000", created_version: 10438 }
+RowDump { collection: "notes", pk: "pk-00010439", payload: Some("{\"idx\": 10439, \"edit\": \"update\"}"), version: 20718, deleted: false, device_id: "device-1000", created_version: 10439 }
+RowDump { collection: "contacts", pk: "pk-00010441", payload: Some("{\"idx\": 10441, \"edit\": \"update\"}"), version: 20719, deleted: false, device_id: "device-1000", created_version: 10441 }
+RowDump { collection: "contacts", pk: "pk-00010442", payload: Some("{\"idx\": 10442, \"edit\": \"update\"}"), version: 20720, deleted: false, device_id: "device-1000", created_version: 10442 }
+RowDump { collection: "contacts", pk: "pk-00010443", payload: Some("{\"idx\": 10443, \"edit\": \"update\"}"), version: 20721, deleted: false, device_id: "device-1000", created_version: 10443 }
+RowDump { collection: "contacts", pk: "pk-00010444", payload: Some("{\"idx\": 10444, \"edit\": \"update\"}"), version: 20722, deleted: false, device_id: "device-1000", created_version: 10444 }
+RowDump { collection: "contacts", pk: "pk-00010445", payload: Some("{\"idx\": 10445, \"edit\": \"update\"}"), version: 20723, deleted: false, device_id: "device-1000", created_version: 10445 }
+RowDump { collection: "contacts", pk: "pk-00010446", payload: Some("{\"idx\": 10446, \"edit\": \"update\"}"), version: 20724, deleted: false, device_id: "device-1000", created_version: 10446 }
+RowDump { collection: "contacts", pk: "pk-00010447", payload: Some("{\"idx\": 10447, \"edit\": \"update\"}"), version: 20725, deleted: false, device_id: "device-1000", created_version: 10447 }
+RowDump { collection: "contacts", pk: "pk-00010448", payload: Some("{\"idx\": 10448, \"edit\": \"update\"}"), version: 20726, deleted: false, device_id: "device-1000", created_version: 10448 }
+RowDump { collection: "contacts", pk: "pk-00010449", payload: Some("{\"idx\": 10449, \"edit\": \"update\"}"), version: 20727, deleted: false, device_id: "device-1000", created_version: 10449 }
+RowDump { collection: "contacts", pk: "pk-00010450", payload: Some("{\"idx\": 10450, \"edit\": \"update\"}"), version: 20728, deleted: false, device_id: "device-1000", created_version: 10450 }
+RowDump { collection: "contacts", pk: "pk-00010451", payload: Some("{\"idx\": 10451, \"edit\": \"update\"}"), version: 20729, deleted: false, device_id: "device-1000", created_version: 10451 }
+RowDump { collection: "contacts", pk: "pk-00010452", payload: Some("{\"idx\": 10452, \"edit\": \"update\"}"), version: 20730, deleted: false, device_id: "device-1000", created_version: 10452 }
+RowDump { collection: "contacts", pk: "pk-00010453", payload: Some("{\"idx\": 10453, \"edit\": \"update\"}"), version: 20731, deleted: false, device_id: "device-1000", created_version: 10453 }
+RowDump { collection: "contacts", pk: "pk-00010454", payload: Some("{\"idx\": 10454, \"edit\": \"update\"}"), version: 20732, deleted: false, device_id: "device-1000", created_version: 10454 }
+RowDump { collection: "contacts", pk: "pk-00010455", payload: Some("{\"idx\": 10455, \"edit\": \"update\"}"), version: 20733, deleted: false, device_id: "device-1000", created_version: 10455 }
+RowDump { collection: "contacts", pk: "pk-00010456", payload: Some("{\"idx\": 10456, \"edit\": \"update\"}"), version: 20734, deleted: false, device_id: "device-1000", created_version: 10456 }
+RowDump { collection: "contacts", pk: "pk-00010457", payload: Some("{\"idx\": 10457, \"edit\": \"update\"}"), version: 20735, deleted: false, device_id: "device-1000", created_version: 10457 }
+RowDump { collection: "contacts", pk: "pk-00010458", payload: Some("{\"idx\": 10458, \"edit\": \"update\"}"), version: 20736, deleted: false, device_id: "device-1000", created_version: 10458 }
+RowDump { collection: "contacts", pk: "pk-00010459", payload: Some("{\"idx\": 10459, \"edit\": \"update\"}"), version: 20737, deleted: false, device_id: "device-1000", created_version: 10459 }
+RowDump { collection: "tasks", pk: "pk-00010461", payload: Some("{\"idx\": 10461, \"edit\": \"update\"}"), version: 20738, deleted: false, device_id: "device-1000", created_version: 10461 }
+RowDump { collection: "tasks", pk: "pk-00010462", payload: Some("{\"idx\": 10462, \"edit\": \"update\"}"), version: 20739, deleted: false, device_id: "device-1000", created_version: 10462 }
+RowDump { collection: "tasks", pk: "pk-00010463", payload: Some("{\"idx\": 10463, \"edit\": \"update\"}"), version: 20740, deleted: false, device_id: "device-1000", created_version: 10463 }
+RowDump { collection: "tasks", pk: "pk-00010464", payload: Some("{\"idx\": 10464, \"edit\": \"update\"}"), version: 20741, deleted: false, device_id: "device-1000", created_version: 10464 }
+RowDump { collection: "tasks", pk: "pk-00010465", payload: Some("{\"idx\": 10465, \"edit\": \"update\"}"), version: 20742, deleted: false, device_id: "device-1000", created_version: 10465 }
+RowDump { collection: "tasks", pk: "pk-00010466", payload: Some("{\"idx\": 10466, \"edit\": \"update\"}"), version: 20743, deleted: false, device_id: "device-1000", created_version: 10466 }
+RowDump { collection: "tasks", pk: "pk-00010467", payload: Some("{\"idx\": 10467, \"edit\": \"update\"}"), version: 20744, deleted: false, device_id: "device-1000", created_version: 10467 }
+RowDump { collection: "tasks", pk: "pk-00010468", payload: Some("{\"idx\": 10468, \"edit\": \"update\"}"), version: 20745, deleted: false, device_id: "device-1000", created_version: 10468 }
+RowDump { collection: "tasks", pk: "pk-00010469", payload: Some("{\"idx\": 10469, \"edit\": \"update\"}"), version: 20746, deleted: false, device_id: "device-1000", created_version: 10469 }
+RowDump { collection: "tasks", pk: "pk-00010470", payload: Some("{\"idx\": 10470, \"edit\": \"update\"}"), version: 20747, deleted: false, device_id: "device-1000", created_version: 10470 }
+RowDump { collection: "tasks", pk: "pk-00010471", payload: Some("{\"idx\": 10471, \"edit\": \"update\"}"), version: 20748, deleted: false, device_id: "device-1000", created_version: 10471 }
+RowDump { collection: "tasks", pk: "pk-00010472", payload: Some("{\"idx\": 10472, \"edit\": \"update\"}"), version: 20749, deleted: false, device_id: "device-1000", created_version: 10472 }
+RowDump { collection: "tasks", pk: "pk-00010473", payload: Some("{\"idx\": 10473, \"edit\": \"update\"}"), version: 20750, deleted: false, device_id: "device-1000", created_version: 10473 }
+RowDump { collection: "tasks", pk: "pk-00010474", payload: Some("{\"idx\": 10474, \"edit\": \"update\"}"), version: 20751, deleted: false, device_id: "device-1000", created_version: 10474 }
+RowDump { collection: "files", pk: "pk-00010475", payload: Some("{\"idx\": 10475, \"edit\": \"update\"}"), version: 20752, deleted: false, device_id: "device-1000", created_version: 10475 }
+RowDump { collection: "files", pk: "pk-00010476", payload: Some("{\"idx\": 10476, \"edit\": \"update\"}"), version: 20753, deleted: false, device_id: "device-1000", created_version: 10476 }
+RowDump { collection: "files", pk: "pk-00010477", payload: Some("{\"idx\": 10477, \"edit\": \"update\"}"), version: 20754, deleted: false, device_id: "device-1000", created_version: 10477 }
+RowDump { collection: "files", pk: "pk-00010478", payload: Some("{\"idx\": 10478, \"edit\": \"update\"}"), version: 20755, deleted: false, device_id: "device-1000", created_version: 10478 }
+RowDump { collection: "files", pk: "pk-00010479", payload: Some("{\"idx\": 10479, \"edit\": \"update\"}"), version: 20756, deleted: false, device_id: "device-1000", created_version: 10479 }
+RowDump { collection: "files", pk: "pk-00010481", payload: Some("{\"idx\": 10481, \"edit\": \"update\"}"), version: 20757, deleted: false, device_id: "device-1000", created_version: 10481 }
+RowDump { collection: "files", pk: "pk-00010482", payload: Some("{\"idx\": 10482, \"edit\": \"update\"}"), version: 20758, deleted: false, device_id: "device-1000", created_version: 10482 }
+RowDump { collection: "files", pk: "pk-00010483", payload: Some("{\"idx\": 10483, \"edit\": \"update\"}"), version: 20759, deleted: false, device_id: "device-1000", created_version: 10483 }
+RowDump { collection: "files", pk: "pk-00010484", payload: Some("{\"idx\": 10484, \"edit\": \"update\"}"), version: 20760, deleted: false, device_id: "device-1000", created_version: 10484 }
+RowDump { collection: "files", pk: "pk-00010485", payload: Some("{\"idx\": 10485, \"edit\": \"update\"}"), version: 20761, deleted: false, device_id: "device-1000", created_version: 10485 }
+RowDump { collection: "files", pk: "pk-00010486", payload: Some("{\"idx\": 10486, \"edit\": \"update\"}"), version: 20762, deleted: false, device_id: "device-1000", created_version: 10486 }
+RowDump { collection: "files", pk: "pk-00010487", payload: Some("{\"idx\": 10487, \"edit\": \"update\"}"), version: 20763, deleted: false, device_id: "device-1000", created_version: 10487 }
+RowDump { collection: "files", pk: "pk-00010488", payload: Some("{\"idx\": 10488, \"edit\": \"update\"}"), version: 20764, deleted: false, device_id: "device-1000", created_version: 10488 }
+RowDump { collection: "files", pk: "pk-00010489", payload: Some("{\"idx\": 10489, \"edit\": \"update\"}"), version: 20765, deleted: false, device_id: "device-1000", created_version: 10489 }
+RowDump { collection: "tags", pk: "pk-00010490", payload: Some("{\"idx\": 10490, \"edit\": \"update\"}"), version: 20766, deleted: false, device_id: "device-1000", created_version: 10490 }
+RowDump { collection: "tags", pk: "pk-00010491", payload: Some("{\"idx\": 10491, \"edit\": \"update\"}"), version: 20767, deleted: false, device_id: "device-1000", created_version: 10491 }
+RowDump { collection: "tags", pk: "pk-00010492", payload: Some("{\"idx\": 10492, \"edit\": \"update\"}"), version: 20768, deleted: false, device_id: "device-1000", created_version: 10492 }
+RowDump { collection: "tags", pk: "pk-00010493", payload: Some("{\"idx\": 10493, \"edit\": \"update\"}"), version: 20769, deleted: false, device_id: "device-1000", created_version: 10493 }
+RowDump { collection: "tags", pk: "pk-00010494", payload: Some("{\"idx\": 10494, \"edit\": \"update\"}"), version: 20770, deleted: false, device_id: "device-1000", created_version: 10494 }
+RowDump { collection: "tags", pk: "pk-00010495", payload: Some("{\"idx\": 10495, \"edit\": \"update\"}"), version: 20771, deleted: false, device_id: "device-1000", created_version: 10495 }
+RowDump { collection: "tags", pk: "pk-00010496", payload: Some("{\"idx\": 10496, \"edit\": \"update\"}"), version: 20772, deleted: false, device_id: "device-1000", created_version: 10496 }
+RowDump { collection: "archive", pk: "pk-00010497", payload: Some("{\"idx\": 10497, \"edit\": \"update\"}"), version: 20773, deleted: false, device_id: "device-1000", created_version: 10497 }
+RowDump { collection: "archive", pk: "pk-00010498", payload: Some("{\"idx\": 10498, \"edit\": \"update\"}"), version: 20774, deleted: false, device_id: "device-1000", created_version: 10498 }
+RowDump { collection: "archive", pk: "pk-00010499", payload: Some("{\"idx\": 10499, \"edit\": \"update\"}"), version: 20775, deleted: false, device_id: "device-1000", created_version: 10499 }
+RowDump { collection: "notes", pk: "pk-00010501", payload: Some("{\"idx\": 10501, \"edit\": \"update\"}"), version: 20776, deleted: false, device_id: "device-1000", created_version: 10501 }
+RowDump { collection: "notes", pk: "pk-00010502", payload: Some("{\"idx\": 10502, \"edit\": \"update\"}"), version: 20777, deleted: false, device_id: "device-1000", created_version: 10502 }
+RowDump { collection: "notes", pk: "pk-00010503", payload: Some("{\"idx\": 10503, \"edit\": \"update\"}"), version: 20778, deleted: false, device_id: "device-1000", created_version: 10503 }
+RowDump { collection: "notes", pk: "pk-00010504", payload: Some("{\"idx\": 10504, \"edit\": \"update\"}"), version: 20779, deleted: false, device_id: "device-1000", created_version: 10504 }
+RowDump { collection: "notes", pk: "pk-00010505", payload: Some("{\"idx\": 10505, \"edit\": \"update\"}"), version: 20780, deleted: false, device_id: "device-1000", created_version: 10505 }
+RowDump { collection: "notes", pk: "pk-00010506", payload: Some("{\"idx\": 10506, \"edit\": \"update\"}"), version: 20781, deleted: false, device_id: "device-1000", created_version: 10506 }
+RowDump { collection: "notes", pk: "pk-00010507", payload: Some("{\"idx\": 10507, \"edit\": \"update\"}"), version: 20782, deleted: false, device_id: "device-1000", created_version: 10507 }
+RowDump { collection: "notes", pk: "pk-00010508", payload: Some("{\"idx\": 10508, \"edit\": \"update\"}"), version: 20783, deleted: false, device_id: "device-1000", created_version: 10508 }
+RowDump { collection: "notes", pk: "pk-00010509", payload: Some("{\"idx\": 10509, \"edit\": \"update\"}"), version: 20784, deleted: false, device_id: "device-1000", created_version: 10509 }
+RowDump { collection: "notes", pk: "pk-00010510", payload: Some("{\"idx\": 10510, \"edit\": \"update\"}"), version: 20785, deleted: false, device_id: "device-1000", created_version: 10510 }
+RowDump { collection: "notes", pk: "pk-00010511", payload: Some("{\"idx\": 10511, \"edit\": \"update\"}"), version: 20786, deleted: false, device_id: "device-1000", created_version: 10511 }
+RowDump { collection: "notes", pk: "pk-00010512", payload: Some("{\"idx\": 10512, \"edit\": \"update\"}"), version: 20787, deleted: false, device_id: "device-1000", created_version: 10512 }
+RowDump { collection: "notes", pk: "pk-00010513", payload: Some("{\"idx\": 10513, \"edit\": \"update\"}"), version: 20788, deleted: false, device_id: "device-1000", created_version: 10513 }
+RowDump { collection: "notes", pk: "pk-00010514", payload: Some("{\"idx\": 10514, \"edit\": \"update\"}"), version: 20789, deleted: false, device_id: "device-1000", created_version: 10514 }
+RowDump { collection: "notes", pk: "pk-00010515", payload: Some("{\"idx\": 10515, \"edit\": \"update\"}"), version: 20790, deleted: false, device_id: "device-1000", created_version: 10515 }
+RowDump { collection: "notes", pk: "pk-00010516", payload: Some("{\"idx\": 10516, \"edit\": \"update\"}"), version: 20791, deleted: false, device_id: "device-1000", created_version: 10516 }
+RowDump { collection: "notes", pk: "pk-00010517", payload: Some("{\"idx\": 10517, \"edit\": \"update\"}"), version: 20792, deleted: false, device_id: "device-1000", created_version: 10517 }
+RowDump { collection: "notes", pk: "pk-00010518", payload: Some("{\"idx\": 10518, \"edit\": \"update\"}"), version: 20793, deleted: false, device_id: "device-1000", created_version: 10518 }
+RowDump { collection: "notes", pk: "pk-00010519", payload: Some("{\"idx\": 10519, \"edit\": \"update\"}"), version: 20794, deleted: false, device_id: "device-1000", created_version: 10519 }
+RowDump { collection: "notes", pk: "pk-00010521", payload: Some("{\"idx\": 10521, \"edit\": \"update\"}"), version: 20795, deleted: false, device_id: "device-1000", created_version: 10521 }
+RowDump { collection: "notes", pk: "pk-00010522", payload: Some("{\"idx\": 10522, \"edit\": \"update\"}"), version: 20796, deleted: false, device_id: "device-1000", created_version: 10522 }
+RowDump { collection: "notes", pk: "pk-00010523", payload: Some("{\"idx\": 10523, \"edit\": \"update\"}"), version: 20797, deleted: false, device_id: "device-1000", created_version: 10523 }
+RowDump { collection: "notes", pk: "pk-00010524", payload: Some("{\"idx\": 10524, \"edit\": \"update\"}"), version: 20798, deleted: false, device_id: "device-1000", created_version: 10524 }
+RowDump { collection: "notes", pk: "pk-00010525", payload: Some("{\"idx\": 10525, \"edit\": \"update\"}"), version: 20799, deleted: false, device_id: "device-1000", created_version: 10525 }
+RowDump { collection: "notes", pk: "pk-00010526", payload: Some("{\"idx\": 10526, \"edit\": \"update\"}"), version: 20800, deleted: false, device_id: "device-1000", created_version: 10526 }
+RowDump { collection: "notes", pk: "pk-00010527", payload: Some("{\"idx\": 10527, \"edit\": \"update\"}"), version: 20801, deleted: false, device_id: "device-1000", created_version: 10527 }
+RowDump { collection: "notes", pk: "pk-00010528", payload: Some("{\"idx\": 10528, \"edit\": \"update\"}"), version: 20802, deleted: false, device_id: "device-1000", created_version: 10528 }
+RowDump { collection: "notes", pk: "pk-00010529", payload: Some("{\"idx\": 10529, \"edit\": \"update\"}"), version: 20803, deleted: false, device_id: "device-1000", created_version: 10529 }
+RowDump { collection: "notes", pk: "pk-00010530", payload: Some("{\"idx\": 10530, \"edit\": \"update\"}"), version: 20804, deleted: false, device_id: "device-1000", created_version: 10530 }
+RowDump { collection: "notes", pk: "pk-00010531", payload: Some("{\"idx\": 10531, \"edit\": \"update\"}"), version: 20805, deleted: false, device_id: "device-1000", created_version: 10531 }
+RowDump { collection: "notes", pk: "pk-00010532", payload: Some("{\"idx\": 10532, \"edit\": \"update\"}"), version: 20806, deleted: false, device_id: "device-1000", created_version: 10532 }
+RowDump { collection: "notes", pk: "pk-00010533", payload: Some("{\"idx\": 10533, \"edit\": \"update\"}"), version: 20807, deleted: false, device_id: "device-1000", created_version: 10533 }
+RowDump { collection: "notes", pk: "pk-00010534", payload: Some("{\"idx\": 10534, \"edit\": \"update\"}"), version: 20808, deleted: false, device_id: "device-1000", created_version: 10534 }
+RowDump { collection: "notes", pk: "pk-00010535", payload: Some("{\"idx\": 10535, \"edit\": \"update\"}"), version: 20809, deleted: false, device_id: "device-1000", created_version: 10535 }
+RowDump { collection: "notes", pk: "pk-00010536", payload: Some("{\"idx\": 10536, \"edit\": \"update\"}"), version: 20810, deleted: false, device_id: "device-1000", created_version: 10536 }
+RowDump { collection: "notes", pk: "pk-00010537", payload: Some("{\"idx\": 10537, \"edit\": \"update\"}"), version: 20811, deleted: false, device_id: "device-1000", created_version: 10537 }
+RowDump { collection: "notes", pk: "pk-00010538", payload: Some("{\"idx\": 10538, \"edit\": \"update\"}"), version: 20812, deleted: false, device_id: "device-1000", created_version: 10538 }
+RowDump { collection: "notes", pk: "pk-00010539", payload: Some("{\"idx\": 10539, \"edit\": \"update\"}"), version: 20813, deleted: false, device_id: "device-1000", created_version: 10539 }
+RowDump { collection: "contacts", pk: "pk-00010541", payload: Some("{\"idx\": 10541, \"edit\": \"update\"}"), version: 20814, deleted: false, device_id: "device-1000", created_version: 10541 }
+RowDump { collection: "contacts", pk: "pk-00010542", payload: Some("{\"idx\": 10542, \"edit\": \"update\"}"), version: 20815, deleted: false, device_id: "device-1000", created_version: 10542 }
+RowDump { collection: "contacts", pk: "pk-00010543", payload: Some("{\"idx\": 10543, \"edit\": \"update\"}"), version: 20816, deleted: false, device_id: "device-1000", created_version: 10543 }
+RowDump { collection: "contacts", pk: "pk-00010544", payload: Some("{\"idx\": 10544, \"edit\": \"update\"}"), version: 20817, deleted: false, device_id: "device-1000", created_version: 10544 }
+RowDump { collection: "contacts", pk: "pk-00010545", payload: Some("{\"idx\": 10545, \"edit\": \"update\"}"), version: 20818, deleted: false, device_id: "device-1000", created_version: 10545 }
+RowDump { collection: "contacts", pk: "pk-00010546", payload: Some("{\"idx\": 10546, \"edit\": \"update\"}"), version: 20819, deleted: false, device_id: "device-1000", created_version: 10546 }
+RowDump { collection: "contacts", pk: "pk-00010547", payload: Some("{\"idx\": 10547, \"edit\": \"update\"}"), version: 20820, deleted: false, device_id: "device-1000", created_version: 10547 }
+RowDump { collection: "contacts", pk: "pk-00010548", payload: Some("{\"idx\": 10548, \"edit\": \"update\"}"), version: 20821, deleted: false, device_id: "device-1000", created_version: 10548 }
+RowDump { collection: "contacts", pk: "pk-00010549", payload: Some("{\"idx\": 10549, \"edit\": \"update\"}"), version: 20822, deleted: false, device_id: "device-1000", created_version: 10549 }
+RowDump { collection: "contacts", pk: "pk-00010550", payload: Some("{\"idx\": 10550, \"edit\": \"update\"}"), version: 20823, deleted: false, device_id: "device-1000", created_version: 10550 }
+RowDump { collection: "contacts", pk: "pk-00010551", payload: Some("{\"idx\": 10551, \"edit\": \"update\"}"), version: 20824, deleted: false, device_id: "device-1000", created_version: 10551 }
+RowDump { collection: "contacts", pk: "pk-00010552", payload: Some("{\"idx\": 10552, \"edit\": \"update\"}"), version: 20825, deleted: false, device_id: "device-1000", created_version: 10552 }
+RowDump { collection: "contacts", pk: "pk-00010553", payload: Some("{\"idx\": 10553, \"edit\": \"update\"}"), version: 20826, deleted: false, device_id: "device-1000", created_version: 10553 }
+RowDump { collection: "contacts", pk: "pk-00010554", payload: Some("{\"idx\": 10554, \"edit\": \"update\"}"), version: 20827, deleted: false, device_id: "device-1000", created_version: 10554 }
+RowDump { collection: "contacts", pk: "pk-00010555", payload: Some("{\"idx\": 10555, \"edit\": \"update\"}"), version: 20828, deleted: false, device_id: "device-1000", created_version: 10555 }
+RowDump { collection: "contacts", pk: "pk-00010556", payload: Some("{\"idx\": 10556, \"edit\": \"update\"}"), version: 20829, deleted: false, device_id: "device-1000", created_version: 10556 }
+RowDump { collection: "contacts", pk: "pk-00010557", payload: Some("{\"idx\": 10557, \"edit\": \"update\"}"), version: 20830, deleted: false, device_id: "device-1000", created_version: 10557 }
+RowDump { collection: "contacts", pk: "pk-00010558", payload: Some("{\"idx\": 10558, \"edit\": \"update\"}"), version: 20831, deleted: false, device_id: "device-1000", created_version: 10558 }
+RowDump { collection: "contacts", pk: "pk-00010559", payload: Some("{\"idx\": 10559, \"edit\": \"update\"}"), version: 20832, deleted: false, device_id: "device-1000", created_version: 10559 }
+RowDump { collection: "tasks", pk: "pk-00010561", payload: Some("{\"idx\": 10561, \"edit\": \"update\"}"), version: 20833, deleted: false, device_id: "device-1000", created_version: 10561 }
+RowDump { collection: "tasks", pk: "pk-00010562", payload: Some("{\"idx\": 10562, \"edit\": \"update\"}"), version: 20834, deleted: false, device_id: "device-1000", created_version: 10562 }
+RowDump { collection: "tasks", pk: "pk-00010563", payload: Some("{\"idx\": 10563, \"edit\": \"update\"}"), version: 20835, deleted: false, device_id: "device-1000", created_version: 10563 }
+RowDump { collection: "tasks", pk: "pk-00010564", payload: Some("{\"idx\": 10564, \"edit\": \"update\"}"), version: 20836, deleted: false, device_id: "device-1000", created_version: 10564 }
+RowDump { collection: "tasks", pk: "pk-00010565", payload: Some("{\"idx\": 10565, \"edit\": \"update\"}"), version: 20837, deleted: false, device_id: "device-1000", created_version: 10565 }
+RowDump { collection: "tasks", pk: "pk-00010566", payload: Some("{\"idx\": 10566, \"edit\": \"update\"}"), version: 20838, deleted: false, device_id: "device-1000", created_version: 10566 }
+RowDump { collection: "tasks", pk: "pk-00010567", payload: Some("{\"idx\": 10567, \"edit\": \"update\"}"), version: 20839, deleted: false, device_id: "device-1000", created_version: 10567 }
+RowDump { collection: "tasks", pk: "pk-00010568", payload: Some("{\"idx\": 10568, \"edit\": \"update\"}"), version: 20840, deleted: false, device_id: "device-1000", created_version: 10568 }
+RowDump { collection: "tasks", pk: "pk-00010569", payload: Some("{\"idx\": 10569, \"edit\": \"update\"}"), version: 20841, deleted: false, device_id: "device-1000", created_version: 10569 }
+RowDump { collection: "tasks", pk: "pk-00010570", payload: Some("{\"idx\": 10570, \"edit\": \"update\"}"), version: 20842, deleted: false, device_id: "device-1000", created_version: 10570 }
+RowDump { collection: "tasks", pk: "pk-00010571", payload: Some("{\"idx\": 10571, \"edit\": \"update\"}"), version: 20843, deleted: false, device_id: "device-1000", created_version: 10571 }
+RowDump { collection: "tasks", pk: "pk-00010572", payload: Some("{\"idx\": 10572, \"edit\": \"update\"}"), version: 20844, deleted: false, device_id: "device-1000", created_version: 10572 }
+RowDump { collection: "tasks", pk: "pk-00010573", payload: Some("{\"idx\": 10573, \"edit\": \"update\"}"), version: 20845, deleted: false, device_id: "device-1000", created_version: 10573 }
+RowDump { collection: "tasks", pk: "pk-00010574", payload: Some("{\"idx\": 10574, \"edit\": \"update\"}"), version: 20846, deleted: false, device_id: "device-1000", created_version: 10574 }
+RowDump { collection: "files", pk: "pk-00010575", payload: Some("{\"idx\": 10575, \"edit\": \"update\"}"), version: 20847, deleted: false, device_id: "device-1000", created_version: 10575 }
+RowDump { collection: "files", pk: "pk-00010576", payload: Some("{\"idx\": 10576, \"edit\": \"update\"}"), version: 20848, deleted: false, device_id: "device-1000", created_version: 10576 }
+RowDump { collection: "files", pk: "pk-00010577", payload: Some("{\"idx\": 10577, \"edit\": \"update\"}"), version: 20849, deleted: false, device_id: "device-1000", created_version: 10577 }
+RowDump { collection: "files", pk: "pk-00010578", payload: Some("{\"idx\": 10578, \"edit\": \"update\"}"), version: 20850, deleted: false, device_id: "device-1000", created_version: 10578 }
+RowDump { collection: "files", pk: "pk-00010579", payload: Some("{\"idx\": 10579, \"edit\": \"update\"}"), version: 20851, deleted: false, device_id: "device-1000", created_version: 10579 }
+RowDump { collection: "files", pk: "pk-00010581", payload: Some("{\"idx\": 10581, \"edit\": \"update\"}"), version: 20852, deleted: false, device_id: "device-1000", created_version: 10581 }
+RowDump { collection: "files", pk: "pk-00010582", payload: Some("{\"idx\": 10582, \"edit\": \"update\"}"), version: 20853, deleted: false, device_id: "device-1000", created_version: 10582 }
+RowDump { collection: "files", pk: "pk-00010583", payload: Some("{\"idx\": 10583, \"edit\": \"update\"}"), version: 20854, deleted: false, device_id: "device-1000", created_version: 10583 }
+RowDump { collection: "files", pk: "pk-00010584", payload: Some("{\"idx\": 10584, \"edit\": \"update\"}"), version: 20855, deleted: false, device_id: "device-1000", created_version: 10584 }
+RowDump { collection: "files", pk: "pk-00010585", payload: Some("{\"idx\": 10585, \"edit\": \"update\"}"), version: 20856, deleted: false, device_id: "device-1000", created_version: 10585 }
+RowDump { collection: "files", pk: "pk-00010586", payload: Some("{\"idx\": 10586, \"edit\": \"update\"}"), version: 20857, deleted: false, device_id: "device-1000", created_version: 10586 }
+RowDump { collection: "files", pk: "pk-00010587", payload: Some("{\"idx\": 10587, \"edit\": \"update\"}"), version: 20858, deleted: false, device_id: "device-1000", created_version: 10587 }
+RowDump { collection: "files", pk: "pk-00010588", payload: Some("{\"idx\": 10588, \"edit\": \"update\"}"), version: 20859, deleted: false, device_id: "device-1000", created_version: 10588 }
+RowDump { collection: "files", pk: "pk-00010589", payload: Some("{\"idx\": 10589, \"edit\": \"update\"}"), version: 20860, deleted: false, device_id: "device-1000", created_version: 10589 }
+RowDump { collection: "tags", pk: "pk-00010590", payload: Some("{\"idx\": 10590, \"edit\": \"update\"}"), version: 20861, deleted: false, device_id: "device-1000", created_version: 10590 }
+RowDump { collection: "tags", pk: "pk-00010591", payload: Some("{\"idx\": 10591, \"edit\": \"update\"}"), version: 20862, deleted: false, device_id: "device-1000", created_version: 10591 }
+RowDump { collection: "tags", pk: "pk-00010592", payload: Some("{\"idx\": 10592, \"edit\": \"update\"}"), version: 20863, deleted: false, device_id: "device-1000", created_version: 10592 }
+RowDump { collection: "tags", pk: "pk-00010593", payload: Some("{\"idx\": 10593, \"edit\": \"update\"}"), version: 20864, deleted: false, device_id: "device-1000", created_version: 10593 }
+RowDump { collection: "tags", pk: "pk-00010594", payload: Some("{\"idx\": 10594, \"edit\": \"update\"}"), version: 20865, deleted: false, device_id: "device-1000", created_version: 10594 }
+RowDump { collection: "tags", pk: "pk-00010595", payload: Some("{\"idx\": 10595, \"edit\": \"update\"}"), version: 20866, deleted: false, device_id: "device-1000", created_version: 10595 }
+RowDump { collection: "tags", pk: "pk-00010596", payload: Some("{\"idx\": 10596, \"edit\": \"update\"}"), version: 20867, deleted: false, device_id: "device-1000", created_version: 10596 }
+RowDump { collection: "archive", pk: "pk-00010597", payload: Some("{\"idx\": 10597, \"edit\": \"update\"}"), version: 20868, deleted: false, device_id: "device-1000", created_version: 10597 }
+RowDump { collection: "archive", pk: "pk-00010598", payload: Some("{\"idx\": 10598, \"edit\": \"update\"}"), version: 20869, deleted: false, device_id: "device-1000", created_version: 10598 }
+RowDump { collection: "archive", pk: "pk-00010599", payload: Some("{\"idx\": 10599, \"edit\": \"update\"}"), version: 20870, deleted: false, device_id: "device-1000", created_version: 10599 }
+RowDump { collection: "notes", pk: "pk-00010601", payload: Some("{\"idx\": 10601, \"edit\": \"update\"}"), version: 20871, deleted: false, device_id: "device-1000", created_version: 10601 }
+RowDump { collection: "notes", pk: "pk-00010602", payload: Some("{\"idx\": 10602, \"edit\": \"update\"}"), version: 20872, deleted: false, device_id: "device-1000", created_version: 10602 }
+RowDump { collection: "notes", pk: "pk-00010603", payload: Some("{\"idx\": 10603, \"edit\": \"update\"}"), version: 20873, deleted: false, device_id: "device-1000", created_version: 10603 }
+RowDump { collection: "notes", pk: "pk-00010604", payload: Some("{\"idx\": 10604, \"edit\": \"update\"}"), version: 20874, deleted: false, device_id: "device-1000", created_version: 10604 }
+RowDump { collection: "notes", pk: "pk-00010605", payload: Some("{\"idx\": 10605, \"edit\": \"update\"}"), version: 20875, deleted: false, device_id: "device-1000", created_version: 10605 }
+RowDump { collection: "notes", pk: "pk-00010606", payload: Some("{\"idx\": 10606, \"edit\": \"update\"}"), version: 20876, deleted: false, device_id: "device-1000", created_version: 10606 }
+RowDump { collection: "notes", pk: "pk-00010607", payload: Some("{\"idx\": 10607, \"edit\": \"update\"}"), version: 20877, deleted: false, device_id: "device-1000", created_version: 10607 }
+RowDump { collection: "notes", pk: "pk-00010608", payload: Some("{\"idx\": 10608, \"edit\": \"update\"}"), version: 20878, deleted: false, device_id: "device-1000", created_version: 10608 }
+RowDump { collection: "notes", pk: "pk-00010609", payload: Some("{\"idx\": 10609, \"edit\": \"update\"}"), version: 20879, deleted: false, device_id: "device-1000", created_version: 10609 }
+RowDump { collection: "notes", pk: "pk-00010610", payload: Some("{\"idx\": 10610, \"edit\": \"update\"}"), version: 20880, deleted: false, device_id: "device-1000", created_version: 10610 }
+RowDump { collection: "notes", pk: "pk-00010611", payload: Some("{\"idx\": 10611, \"edit\": \"update\"}"), version: 20881, deleted: false, device_id: "device-1000", created_version: 10611 }
+RowDump { collection: "notes", pk: "pk-00010612", payload: Some("{\"idx\": 10612, \"edit\": \"update\"}"), version: 20882, deleted: false, device_id: "device-1000", created_version: 10612 }
+RowDump { collection: "notes", pk: "pk-00010613", payload: Some("{\"idx\": 10613, \"edit\": \"update\"}"), version: 20883, deleted: false, device_id: "device-1000", created_version: 10613 }
+RowDump { collection: "notes", pk: "pk-00010614", payload: Some("{\"idx\": 10614, \"edit\": \"update\"}"), version: 20884, deleted: false, device_id: "device-1000", created_version: 10614 }
+RowDump { collection: "notes", pk: "pk-00010615", payload: Some("{\"idx\": 10615, \"edit\": \"update\"}"), version: 20885, deleted: false, device_id: "device-1000", created_version: 10615 }
+RowDump { collection: "notes", pk: "pk-00010616", payload: Some("{\"idx\": 10616, \"edit\": \"update\"}"), version: 20886, deleted: false, device_id: "device-1000", created_version: 10616 }
+RowDump { collection: "notes", pk: "pk-00010617", payload: Some("{\"idx\": 10617, \"edit\": \"update\"}"), version: 20887, deleted: false, device_id: "device-1000", created_version: 10617 }
+RowDump { collection: "notes", pk: "pk-00010618", payload: Some("{\"idx\": 10618, \"edit\": \"update\"}"), version: 20888, deleted: false, device_id: "device-1000", created_version: 10618 }
+RowDump { collection: "notes", pk: "pk-00010619", payload: Some("{\"idx\": 10619, \"edit\": \"update\"}"), version: 20889, deleted: false, device_id: "device-1000", created_version: 10619 }
+RowDump { collection: "notes", pk: "pk-00010621", payload: Some("{\"idx\": 10621, \"edit\": \"update\"}"), version: 20890, deleted: false, device_id: "device-1000", created_version: 10621 }
+RowDump { collection: "notes", pk: "pk-00010622", payload: Some("{\"idx\": 10622, \"edit\": \"update\"}"), version: 20891, deleted: false, device_id: "device-1000", created_version: 10622 }
+RowDump { collection: "notes", pk: "pk-00010623", payload: Some("{\"idx\": 10623, \"edit\": \"update\"}"), version: 20892, deleted: false, device_id: "device-1000", created_version: 10623 }
+RowDump { collection: "notes", pk: "pk-00010624", payload: Some("{\"idx\": 10624, \"edit\": \"update\"}"), version: 20893, deleted: false, device_id: "device-1000", created_version: 10624 }
+RowDump { collection: "notes", pk: "pk-00010625", payload: Some("{\"idx\": 10625, \"edit\": \"update\"}"), version: 20894, deleted: false, device_id: "device-1000", created_version: 10625 }
+RowDump { collection: "notes", pk: "pk-00010626", payload: Some("{\"idx\": 10626, \"edit\": \"update\"}"), version: 20895, deleted: false, device_id: "device-1000", created_version: 10626 }
+RowDump { collection: "notes", pk: "pk-00010627", payload: Some("{\"idx\": 10627, \"edit\": \"update\"}"), version: 20896, deleted: false, device_id: "device-1000", created_version: 10627 }
+RowDump { collection: "notes", pk: "pk-00010628", payload: Some("{\"idx\": 10628, \"edit\": \"update\"}"), version: 20897, deleted: false, device_id: "device-1000", created_version: 10628 }
+RowDump { collection: "notes", pk: "pk-00010629", payload: Some("{\"idx\": 10629, \"edit\": \"update\"}"), version: 20898, deleted: false, device_id: "device-1000", created_version: 10629 }
+RowDump { collection: "notes", pk: "pk-00010630", payload: Some("{\"idx\": 10630, \"edit\": \"update\"}"), version: 20899, deleted: false, device_id: "device-1000", created_version: 10630 }
+RowDump { collection: "notes", pk: "pk-00010631", payload: Some("{\"idx\": 10631, \"edit\": \"update\"}"), version: 20900, deleted: false, device_id: "device-1000", created_version: 10631 }
+RowDump { collection: "notes", pk: "pk-00010632", payload: Some("{\"idx\": 10632, \"edit\": \"update\"}"), version: 20901, deleted: false, device_id: "device-1000", created_version: 10632 }
+RowDump { collection: "notes", pk: "pk-00010633", payload: Some("{\"idx\": 10633, \"edit\": \"update\"}"), version: 20902, deleted: false, device_id: "device-1000", created_version: 10633 }
+RowDump { collection: "notes", pk: "pk-00010634", payload: Some("{\"idx\": 10634, \"edit\": \"update\"}"), version: 20903, deleted: false, device_id: "device-1000", created_version: 10634 }
+RowDump { collection: "notes", pk: "pk-00010635", payload: Some("{\"idx\": 10635, \"edit\": \"update\"}"), version: 20904, deleted: false, device_id: "device-1000", created_version: 10635 }
+RowDump { collection: "notes", pk: "pk-00010636", payload: Some("{\"idx\": 10636, \"edit\": \"update\"}"), version: 20905, deleted: false, device_id: "device-1000", created_version: 10636 }
+RowDump { collection: "notes", pk: "pk-00010637", payload: Some("{\"idx\": 10637, \"edit\": \"update\"}"), version: 20906, deleted: false, device_id: "device-1000", created_version: 10637 }
+RowDump { collection: "notes", pk: "pk-00010638", payload: Some("{\"idx\": 10638, \"edit\": \"update\"}"), version: 20907, deleted: false, device_id: "device-1000", created_version: 10638 }
+RowDump { collection: "notes", pk: "pk-00010639", payload: Some("{\"idx\": 10639, \"edit\": \"update\"}"), version: 20908, deleted: false, device_id: "device-1000", created_version: 10639 }
+RowDump { collection: "contacts", pk: "pk-00010641", payload: Some("{\"idx\": 10641, \"edit\": \"update\"}"), version: 20909, deleted: false, device_id: "device-1000", created_version: 10641 }
+RowDump { collection: "contacts", pk: "pk-00010642", payload: Some("{\"idx\": 10642, \"edit\": \"update\"}"), version: 20910, deleted: false, device_id: "device-1000", created_version: 10642 }
+RowDump { collection: "contacts", pk: "pk-00010643", payload: Some("{\"idx\": 10643, \"edit\": \"update\"}"), version: 20911, deleted: false, device_id: "device-1000", created_version: 10643 }
+RowDump { collection: "contacts", pk: "pk-00010644", payload: Some("{\"idx\": 10644, \"edit\": \"update\"}"), version: 20912, deleted: false, device_id: "device-1000", created_version: 10644 }
+RowDump { collection: "contacts", pk: "pk-00010645", payload: Some("{\"idx\": 10645, \"edit\": \"update\"}"), version: 20913, deleted: false, device_id: "device-1000", created_version: 10645 }
+RowDump { collection: "contacts", pk: "pk-00010646", payload: Some("{\"idx\": 10646, \"edit\": \"update\"}"), version: 20914, deleted: false, device_id: "device-1000", created_version: 10646 }
+RowDump { collection: "contacts", pk: "pk-00010647", payload: Some("{\"idx\": 10647, \"edit\": \"update\"}"), version: 20915, deleted: false, device_id: "device-1000", created_version: 10647 }
+RowDump { collection: "contacts", pk: "pk-00010648", payload: Some("{\"idx\": 10648, \"edit\": \"update\"}"), version: 20916, deleted: false, device_id: "device-1000", created_version: 10648 }
+RowDump { collection: "contacts", pk: "pk-00010649", payload: Some("{\"idx\": 10649, \"edit\": \"update\"}"), version: 20917, deleted: false, device_id: "device-1000", created_version: 10649 }
+RowDump { collection: "contacts", pk: "pk-00010650", payload: Some("{\"idx\": 10650, \"edit\": \"update\"}"), version: 20918, deleted: false, device_id: "device-1000", created_version: 10650 }
+RowDump { collection: "contacts", pk: "pk-00010651", payload: Some("{\"idx\": 10651, \"edit\": \"update\"}"), version: 20919, deleted: false, device_id: "device-1000", created_version: 10651 }
+RowDump { collection: "contacts", pk: "pk-00010652", payload: Some("{\"idx\": 10652, \"edit\": \"update\"}"), version: 20920, deleted: false, device_id: "device-1000", created_version: 10652 }
+RowDump { collection: "contacts", pk: "pk-00010653", payload: Some("{\"idx\": 10653, \"edit\": \"update\"}"), version: 20921, deleted: false, device_id: "device-1000", created_version: 10653 }
+RowDump { collection: "contacts", pk: "pk-00010654", payload: Some("{\"idx\": 10654, \"edit\": \"update\"}"), version: 20922, deleted: false, device_id: "device-1000", created_version: 10654 }
+RowDump { collection: "contacts", pk: "pk-00010655", payload: Some("{\"idx\": 10655, \"edit\": \"update\"}"), version: 20923, deleted: false, device_id: "device-1000", created_version: 10655 }
+RowDump { collection: "contacts", pk: "pk-00010656", payload: Some("{\"idx\": 10656, \"edit\": \"update\"}"), version: 20924, deleted: false, device_id: "device-1000", created_version: 10656 }
+RowDump { collection: "contacts", pk: "pk-00010657", payload: Some("{\"idx\": 10657, \"edit\": \"update\"}"), version: 20925, deleted: false, device_id: "device-1000", created_version: 10657 }
+RowDump { collection: "contacts", pk: "pk-00010658", payload: Some("{\"idx\": 10658, \"edit\": \"update\"}"), version: 20926, deleted: false, device_id: "device-1000", created_version: 10658 }
+RowDump { collection: "contacts", pk: "pk-00010659", payload: Some("{\"idx\": 10659, \"edit\": \"update\"}"), version: 20927, deleted: false, device_id: "device-1000", created_version: 10659 }
+RowDump { collection: "tasks", pk: "pk-00010661", payload: Some("{\"idx\": 10661, \"edit\": \"update\"}"), version: 20928, deleted: false, device_id: "device-1000", created_version: 10661 }
+RowDump { collection: "tasks", pk: "pk-00010662", payload: Some("{\"idx\": 10662, \"edit\": \"update\"}"), version: 20929, deleted: false, device_id: "device-1000", created_version: 10662 }
+RowDump { collection: "tasks", pk: "pk-00010663", payload: Some("{\"idx\": 10663, \"edit\": \"update\"}"), version: 20930, deleted: false, device_id: "device-1000", created_version: 10663 }
+RowDump { collection: "tasks", pk: "pk-00010664", payload: Some("{\"idx\": 10664, \"edit\": \"update\"}"), version: 20931, deleted: false, device_id: "device-1000", created_version: 10664 }
+RowDump { collection: "tasks", pk: "pk-00010665", payload: Some("{\"idx\": 10665, \"edit\": \"update\"}"), version: 20932, deleted: false, device_id: "device-1000", created_version: 10665 }
+RowDump { collection: "tasks", pk: "pk-00010666", payload: Some("{\"idx\": 10666, \"edit\": \"update\"}"), version: 20933, deleted: false, device_id: "device-1000", created_version: 10666 }
+RowDump { collection: "tasks", pk: "pk-00010667", payload: Some("{\"idx\": 10667, \"edit\": \"update\"}"), version: 20934, deleted: false, device_id: "device-1000", created_version: 10667 }
+RowDump { collection: "tasks", pk: "pk-00010668", payload: Some("{\"idx\": 10668, \"edit\": \"update\"}"), version: 20935, deleted: false, device_id: "device-1000", created_version: 10668 }
+RowDump { collection: "tasks", pk: "pk-00010669", payload: Some("{\"idx\": 10669, \"edit\": \"update\"}"), version: 20936, deleted: false, device_id: "device-1000", created_version: 10669 }
+RowDump { collection: "tasks", pk: "pk-00010670", payload: Some("{\"idx\": 10670, \"edit\": \"update\"}"), version: 20937, deleted: false, device_id: "device-1000", created_version: 10670 }
+RowDump { collection: "tasks", pk: "pk-00010671", payload: Some("{\"idx\": 10671, \"edit\": \"update\"}"), version: 20938, deleted: false, device_id: "device-1000", created_version: 10671 }
+RowDump { collection: "tasks", pk: "pk-00010672", payload: Some("{\"idx\": 10672, \"edit\": \"update\"}"), version: 20939, deleted: false, device_id: "device-1000", created_version: 10672 }
+RowDump { collection: "tasks", pk: "pk-00010673", payload: Some("{\"idx\": 10673, \"edit\": \"update\"}"), version: 20940, deleted: false, device_id: "device-1000", created_version: 10673 }
+RowDump { collection: "tasks", pk: "pk-00010674", payload: Some("{\"idx\": 10674, \"edit\": \"update\"}"), version: 20941, deleted: false, device_id: "device-1000", created_version: 10674 }
+RowDump { collection: "files", pk: "pk-00010675", payload: Some("{\"idx\": 10675, \"edit\": \"update\"}"), version: 20942, deleted: false, device_id: "device-1000", created_version: 10675 }
+RowDump { collection: "files", pk: "pk-00010676", payload: Some("{\"idx\": 10676, \"edit\": \"update\"}"), version: 20943, deleted: false, device_id: "device-1000", created_version: 10676 }
+RowDump { collection: "files", pk: "pk-00010677", payload: Some("{\"idx\": 10677, \"edit\": \"update\"}"), version: 20944, deleted: false, device_id: "device-1000", created_version: 10677 }
+RowDump { collection: "files", pk: "pk-00010678", payload: Some("{\"idx\": 10678, \"edit\": \"update\"}"), version: 20945, deleted: false, device_id: "device-1000", created_version: 10678 }
+RowDump { collection: "files", pk: "pk-00010679", payload: Some("{\"idx\": 10679, \"edit\": \"update\"}"), version: 20946, deleted: false, device_id: "device-1000", created_version: 10679 }
+RowDump { collection: "files", pk: "pk-00010681", payload: Some("{\"idx\": 10681, \"edit\": \"update\"}"), version: 20947, deleted: false, device_id: "device-1000", created_version: 10681 }
+RowDump { collection: "files", pk: "pk-00010682", payload: Some("{\"idx\": 10682, \"edit\": \"update\"}"), version: 20948, deleted: false, device_id: "device-1000", created_version: 10682 }
+RowDump { collection: "files", pk: "pk-00010683", payload: Some("{\"idx\": 10683, \"edit\": \"update\"}"), version: 20949, deleted: false, device_id: "device-1000", created_version: 10683 }
+RowDump { collection: "files", pk: "pk-00010684", payload: Some("{\"idx\": 10684, \"edit\": \"update\"}"), version: 20950, deleted: false, device_id: "device-1000", created_version: 10684 }
+RowDump { collection: "files", pk: "pk-00010685", payload: None, version: 21151, deleted: true, device_id: "device-1000", created_version: 10685 }
+RowDump { collection: "files", pk: "pk-00010686", payload: None, version: 21152, deleted: true, device_id: "device-1000", created_version: 10686 }
+RowDump { collection: "files", pk: "pk-00010687", payload: None, version: 21153, deleted: true, device_id: "device-1000", created_version: 10687 }
+RowDump { collection: "files", pk: "pk-00010688", payload: None, version: 21154, deleted: true, device_id: "device-1000", created_version: 10688 }
+RowDump { collection: "files", pk: "pk-00010689", payload: None, version: 21155, deleted: true, device_id: "device-1000", created_version: 10689 }
+RowDump { collection: "tags", pk: "pk-00010690", payload: None, version: 21156, deleted: true, device_id: "device-1000", created_version: 10690 }
+RowDump { collection: "tags", pk: "pk-00010691", payload: None, version: 21157, deleted: true, device_id: "device-1000", created_version: 10691 }
+RowDump { collection: "tags", pk: "pk-00010692", payload: None, version: 21158, deleted: true, device_id: "device-1000", created_version: 10692 }
+RowDump { collection: "tags", pk: "pk-00010693", payload: None, version: 21159, deleted: true, device_id: "device-1000", created_version: 10693 }
+RowDump { collection: "tags", pk: "pk-00010694", payload: None, version: 21160, deleted: true, device_id: "device-1000", created_version: 10694 }
+RowDump { collection: "tags", pk: "pk-00010695", payload: None, version: 21161, deleted: true, device_id: "device-1000", created_version: 10695 }
+RowDump { collection: "tags", pk: "pk-00010696", payload: None, version: 21162, deleted: true, device_id: "device-1000", created_version: 10696 }
+RowDump { collection: "archive", pk: "pk-00010697", payload: None, version: 21163, deleted: true, device_id: "device-1000", created_version: 10697 }
+RowDump { collection: "archive", pk: "pk-00010698", payload: None, version: 21164, deleted: true, device_id: "device-1000", created_version: 10698 }
+RowDump { collection: "archive", pk: "pk-00010699", payload: None, version: 21165, deleted: true, device_id: "device-1000", created_version: 10699 }
+RowDump { collection: "notes", pk: "pk-00010701", payload: None, version: 21166, deleted: true, device_id: "device-1000", created_version: 10701 }
+RowDump { collection: "notes", pk: "pk-00010702", payload: None, version: 21167, deleted: true, device_id: "device-1000", created_version: 10702 }
+RowDump { collection: "notes", pk: "pk-00010703", payload: None, version: 21168, deleted: true, device_id: "device-1000", created_version: 10703 }
+RowDump { collection: "notes", pk: "pk-00010704", payload: None, version: 21169, deleted: true, device_id: "device-1000", created_version: 10704 }
+RowDump { collection: "notes", pk: "pk-00010705", payload: None, version: 21170, deleted: true, device_id: "device-1000", created_version: 10705 }
+RowDump { collection: "notes", pk: "pk-00010706", payload: None, version: 21171, deleted: true, device_id: "device-1000", created_version: 10706 }
+RowDump { collection: "notes", pk: "pk-00010707", payload: None, version: 21172, deleted: true, device_id: "device-1000", created_version: 10707 }
+RowDump { collection: "notes", pk: "pk-00010708", payload: None, version: 21173, deleted: true, device_id: "device-1000", created_version: 10708 }
+RowDump { collection: "notes", pk: "pk-00010709", payload: None, version: 21174, deleted: true, device_id: "device-1000", created_version: 10709 }
+RowDump { collection: "notes", pk: "pk-00010710", payload: None, version: 21175, deleted: true, device_id: "device-1000", created_version: 10710 }
+RowDump { collection: "notes", pk: "pk-00010711", payload: None, version: 21176, deleted: true, device_id: "device-1000", created_version: 10711 }
+RowDump { collection: "notes", pk: "pk-00010712", payload: None, version: 21177, deleted: true, device_id: "device-1000", created_version: 10712 }
+RowDump { collection: "notes", pk: "pk-00010713", payload: None, version: 21178, deleted: true, device_id: "device-1000", created_version: 10713 }
+RowDump { collection: "notes", pk: "pk-00010714", payload: None, version: 21179, deleted: true, device_id: "device-1000", created_version: 10714 }
+RowDump { collection: "notes", pk: "pk-00010715", payload: None, version: 21180, deleted: true, device_id: "device-1000", created_version: 10715 }
+RowDump { collection: "notes", pk: "pk-00010716", payload: None, version: 21181, deleted: true, device_id: "device-1000", created_version: 10716 }
+RowDump { collection: "notes", pk: "pk-00010717", payload: None, version: 21182, deleted: true, device_id: "device-1000", created_version: 10717 }
+RowDump { collection: "notes", pk: "pk-00010718", payload: None, version: 21183, deleted: true, device_id: "device-1000", created_version: 10718 }
+RowDump { collection: "notes", pk: "pk-00010719", payload: None, version: 21184, deleted: true, device_id: "device-1000", created_version: 10719 }
+RowDump { collection: "notes", pk: "pk-00010721", payload: None, version: 21185, deleted: true, device_id: "device-1000", created_version: 10721 }
+RowDump { collection: "notes", pk: "pk-00010722", payload: None, version: 21186, deleted: true, device_id: "device-1000", created_version: 10722 }
+RowDump { collection: "notes", pk: "pk-00010723", payload: None, version: 21187, deleted: true, device_id: "device-1000", created_version: 10723 }
+RowDump { collection: "notes", pk: "pk-00010724", payload: None, version: 21188, deleted: true, device_id: "device-1000", created_version: 10724 }
+RowDump { collection: "notes", pk: "pk-00010725", payload: None, version: 21189, deleted: true, device_id: "device-1000", created_version: 10725 }
+RowDump { collection: "notes", pk: "pk-00010726", payload: None, version: 21190, deleted: true, device_id: "device-1000", created_version: 10726 }
+RowDump { collection: "notes", pk: "pk-00010727", payload: None, version: 21191, deleted: true, device_id: "device-1000", created_version: 10727 }
+RowDump { collection: "notes", pk: "pk-00010728", payload: None, version: 21192, deleted: true, device_id: "device-1000", created_version: 10728 }
+RowDump { collection: "notes", pk: "pk-00010729", payload: None, version: 21193, deleted: true, device_id: "device-1000", created_version: 10729 }
+RowDump { collection: "notes", pk: "pk-00010730", payload: None, version: 21194, deleted: true, device_id: "device-1000", created_version: 10730 }
+RowDump { collection: "notes", pk: "pk-00010731", payload: None, version: 21195, deleted: true, device_id: "device-1000", created_version: 10731 }
+RowDump { collection: "notes", pk: "pk-00010732", payload: None, version: 21196, deleted: true, device_id: "device-1000", created_version: 10732 }
+RowDump { collection: "notes", pk: "pk-00010733", payload: None, version: 21197, deleted: true, device_id: "device-1000", created_version: 10733 }
+RowDump { collection: "notes", pk: "pk-00010734", payload: None, version: 21198, deleted: true, device_id: "device-1000", created_version: 10734 }
+RowDump { collection: "notes", pk: "pk-00010735", payload: None, version: 21199, deleted: true, device_id: "device-1000", created_version: 10735 }
+RowDump { collection: "notes", pk: "pk-00010736", payload: None, version: 21200, deleted: true, device_id: "device-1000", created_version: 10736 }
+RowDump { collection: "notes", pk: "pk-00010737", payload: Some("{\"p\": 0, \"edit\": \"dup-existing-2\"}"), version: 21202, deleted: false, device_id: "device-1000", created_version: 10737 }
+RowDump { collection: "notes", pk: "pk-00010738", payload: Some("{\"p\": 1, \"edit\": \"dup-existing-2\"}"), version: 21204, deleted: false, device_id: "device-1000", created_version: 10738 }
+RowDump { collection: "notes", pk: "pk-00010739", payload: Some("{\"p\": 2, \"edit\": \"dup-existing-2\"}"), version: 21206, deleted: false, device_id: "device-1000", created_version: 10739 }
+RowDump { collection: "contacts", pk: "pk-00010741", payload: Some("{\"p\": 3, \"edit\": \"dup-existing-2\"}"), version: 21208, deleted: false, device_id: "device-1000", created_version: 10741 }
+RowDump { collection: "contacts", pk: "pk-00010742", payload: Some("{\"p\": 4, \"edit\": \"dup-existing-2\"}"), version: 21210, deleted: false, device_id: "device-1000", created_version: 10742 }
+RowDump { collection: "contacts", pk: "pk-00010743", payload: Some("{\"p\": 5, \"edit\": \"dup-existing-2\"}"), version: 21212, deleted: false, device_id: "device-1000", created_version: 10743 }
+RowDump { collection: "contacts", pk: "pk-00010744", payload: Some("{\"p\": 6, \"edit\": \"dup-existing-2\"}"), version: 21214, deleted: false, device_id: "device-1000", created_version: 10744 }
+RowDump { collection: "contacts", pk: "pk-00010745", payload: Some("{\"p\": 7, \"edit\": \"dup-existing-2\"}"), version: 21216, deleted: false, device_id: "device-1000", created_version: 10745 }
+RowDump { collection: "contacts", pk: "pk-00010746", payload: Some("{\"p\": 8, \"edit\": \"dup-existing-2\"}"), version: 21218, deleted: false, device_id: "device-1000", created_version: 10746 }
+RowDump { collection: "contacts", pk: "pk-00010747", payload: Some("{\"p\": 9, \"edit\": \"dup-existing-2\"}"), version: 21220, deleted: false, device_id: "device-1000", created_version: 10747 }
+RowDump { collection: "contacts", pk: "pk-00010748", payload: Some("{\"p\": 10, \"edit\": \"dup-existing-2\"}"), version: 21222, deleted: false, device_id: "device-1000", created_version: 10748 }
+RowDump { collection: "contacts", pk: "pk-00010749", payload: Some("{\"p\": 11, \"edit\": \"dup-existing-2\"}"), version: 21224, deleted: false, device_id: "device-1000", created_version: 10749 }
+RowDump { collection: "contacts", pk: "pk-00010750", payload: Some("{\"p\": 12, \"edit\": \"dup-existing-2\"}"), version: 21226, deleted: false, device_id: "device-1000", created_version: 10750 }
+RowDump { collection: "contacts", pk: "pk-00010751", payload: Some("{\"p\": 13, \"edit\": \"dup-existing-2\"}"), version: 21228, deleted: false, device_id: "device-1000", created_version: 10751 }
+RowDump { collection: "contacts", pk: "pk-00010752", payload: Some("{\"p\": 14, \"edit\": \"dup-existing-2\"}"), version: 21230, deleted: false, device_id: "device-1000", created_version: 10752 }
+RowDump { collection: "contacts", pk: "pk-00010753", payload: Some("{\"p\": 15, \"edit\": \"dup-existing-2\"}"), version: 21232, deleted: false, device_id: "device-1000", created_version: 10753 }
+RowDump { collection: "contacts", pk: "pk-00010754", payload: Some("{\"p\": 16, \"edit\": \"dup-existing-2\"}"), version: 21234, deleted: false, device_id: "device-1000", created_version: 10754 }
+RowDump { collection: "contacts", pk: "pk-00010755", payload: Some("{\"p\": 17, \"edit\": \"dup-existing-2\"}"), version: 21236, deleted: false, device_id: "device-1000", created_version: 10755 }
+RowDump { collection: "contacts", pk: "pk-00010756", payload: Some("{\"p\": 18, \"edit\": \"dup-existing-2\"}"), version: 21238, deleted: false, device_id: "device-1000", created_version: 10756 }
+RowDump { collection: "contacts", pk: "pk-00010757", payload: Some("{\"p\": 19, \"edit\": \"dup-existing-2\"}"), version: 21240, deleted: false, device_id: "device-1000", created_version: 10757 }
+RowDump { collection: "contacts", pk: "pk-00010758", payload: Some("{\"p\": 20, \"edit\": \"dup-existing-2\"}"), version: 21242, deleted: false, device_id: "device-1000", created_version: 10758 }
+RowDump { collection: "contacts", pk: "pk-00010759", payload: Some("{\"p\": 21, \"edit\": \"dup-existing-2\"}"), version: 21244, deleted: false, device_id: "device-1000", created_version: 10759 }
+RowDump { collection: "tasks", pk: "pk-00010761", payload: Some("{\"p\": 22, \"edit\": \"dup-existing-2\"}"), version: 21246, deleted: false, device_id: "device-1000", created_version: 10761 }
+RowDump { collection: "tasks", pk: "pk-00010762", payload: Some("{\"p\": 23, \"edit\": \"dup-existing-2\"}"), version: 21248, deleted: false, device_id: "device-1000", created_version: 10762 }
+RowDump { collection: "tasks", pk: "pk-00010763", payload: Some("{\"p\": 24, \"edit\": \"dup-existing-2\"}"), version: 21250, deleted: false, device_id: "device-1000", created_version: 10763 }
+RowDump { collection: "tasks", pk: "pk-00010764", payload: Some("{\"p\": 25, \"edit\": \"dup-existing-2\"}"), version: 21252, deleted: false, device_id: "device-1000", created_version: 10764 }
+RowDump { collection: "tasks", pk: "pk-00010765", payload: Some("{\"p\": 26, \"edit\": \"dup-existing-2\"}"), version: 21254, deleted: false, device_id: "device-1000", created_version: 10765 }
+RowDump { collection: "tasks", pk: "pk-00010766", payload: Some("{\"p\": 27, \"edit\": \"dup-existing-2\"}"), version: 21256, deleted: false, device_id: "device-1000", created_version: 10766 }
+RowDump { collection: "tasks", pk: "pk-00010767", payload: Some("{\"p\": 28, \"edit\": \"dup-existing-2\"}"), version: 21258, deleted: false, device_id: "device-1000", created_version: 10767 }
+RowDump { collection: "tasks", pk: "pk-00010768", payload: Some("{\"p\": 29, \"edit\": \"dup-existing-2\"}"), version: 21260, deleted: false, device_id: "device-1000", created_version: 10768 }
+RowDump { collection: "tasks", pk: "pk-00010769", payload: Some("{\"p\": 30, \"edit\": \"dup-existing-2\"}"), version: 21262, deleted: false, device_id: "device-1000", created_version: 10769 }
+RowDump { collection: "tasks", pk: "pk-00010770", payload: Some("{\"p\": 31, \"edit\": \"dup-existing-2\"}"), version: 21264, deleted: false, device_id: "device-1000", created_version: 10770 }
+RowDump { collection: "tasks", pk: "pk-00010771", payload: Some("{\"p\": 32, \"edit\": \"dup-existing-2\"}"), version: 21266, deleted: false, device_id: "device-1000", created_version: 10771 }
+RowDump { collection: "tasks", pk: "pk-00010772", payload: Some("{\"p\": 33, \"edit\": \"dup-existing-2\"}"), version: 21268, deleted: false, device_id: "device-1000", created_version: 10772 }
+RowDump { collection: "tasks", pk: "pk-00010773", payload: Some("{\"p\": 34, \"edit\": \"dup-existing-2\"}"), version: 21270, deleted: false, device_id: "device-1000", created_version: 10773 }
+RowDump { collection: "tasks", pk: "pk-00010774", payload: Some("{\"p\": 35, \"edit\": \"dup-existing-2\"}"), version: 21272, deleted: false, device_id: "device-1000", created_version: 10774 }
+RowDump { collection: "files", pk: "pk-00010775", payload: Some("{\"p\": 36, \"edit\": \"dup-existing-2\"}"), version: 21274, deleted: false, device_id: "device-1000", created_version: 10775 }
+RowDump { collection: "files", pk: "pk-00010776", payload: Some("{\"p\": 37, \"edit\": \"dup-existing-2\"}"), version: 21276, deleted: false, device_id: "device-1000", created_version: 10776 }
+RowDump { collection: "files", pk: "pk-00010777", payload: Some("{\"p\": 38, \"edit\": \"dup-existing-2\"}"), version: 21278, deleted: false, device_id: "device-1000", created_version: 10777 }
+RowDump { collection: "files", pk: "pk-00010778", payload: Some("{\"p\": 39, \"edit\": \"dup-existing-2\"}"), version: 21280, deleted: false, device_id: "device-1000", created_version: 10778 }
+
+=== statement-count scaling ===
+batch size=50    total sync-table statement calls=6
+batch size=250   total sync-table statement calls=6
+batch size=1000  total sync-table statement calls=6
+
+=== pg_stat_statements: replay of the 250-change batch (idempotency) ===
+-- top by calls --
+calls=1      buffers=8      SELECT change_id, version, resolved_row FROM autumn_sync_applied WHERE scope = $1 AND device_id = $2 AND change_id = ANY($3)
+calls=1      buffers=0      SELECT horizon AS version FROM autumn_sync_horizons WHERE scope = $1
+-- top by buffers --
+buffers=8      calls=1      SELECT change_id, version, resolved_row FROM autumn_sync_applied WHERE scope = $1 AND device_id = $2 AND change_id = ANY($3)
+buffers=0      calls=1      SELECT horizon AS version FROM autumn_sync_horizons WHERE scope = $1
+TOTAL sync-table statement calls=2 buffers=8 (this batch, all statement shapes)
+
+=== EXPLAIN (ANALYZE, BUFFERS, VERBOSE, SETTINGS): dedup check (typical case: miss) ===
+SELECT version, resolved_row FROM autumn_sync_applied WHERE scope = 'global' AND device_id = 'device-1000' AND change_id = 'device-1000-chg-000001'
+Index Scan using autumn_sync_applied_pkey on public.autumn_sync_applied  (cost=0.28..8.30 rows=1 width=40) (actual time=0.170..0.171 rows=1 loops=1)
+  Output: version, resolved_row
+  Index Cond: ((autumn_sync_applied.scope = 'global'::text) AND (autumn_sync_applied.device_id = 'device-1000'::text) AND (autumn_sync_applied.change_id = 'device-1000-chg-000001'::text))
+  Buffers: shared hit=3
+Query Identifier: 5474131966345183344
+Planning:
+  Buffers: shared hit=17
+Planning Time: 0.343 ms
+Execution Time: 0.207 ms
+
+=== EXPLAIN (ANALYZE, BUFFERS, VERBOSE, SETTINGS): current-row fetch FOR UPDATE ===
+SELECT collection, pk, payload, version, deleted, updated_at, device_id, created_version FROM autumn_sync_rows WHERE scope = 'global' AND collection = 'notes' AND pk = 'pk-00010001' FOR UPDATE
+LockRows  (cost=0.41..8.44 rows=1 width=317) (actual time=0.050..0.056 rows=1 loops=1)
+  Output: collection, pk, payload, version, deleted, updated_at, device_id, created_version, ctid
+  Buffers: shared hit=7
+  ->  Index Scan using autumn_sync_rows_pkey on public.autumn_sync_rows  (cost=0.41..8.43 rows=1 width=317) (actual time=0.032..0.037 rows=1 loops=1)
+        Output: collection, pk, payload, version, deleted, updated_at, device_id, created_version, ctid
+        Index Cond: ((autumn_sync_rows.scope = 'global'::text) AND (autumn_sync_rows.collection = 'notes'::text) AND (autumn_sync_rows.pk = 'pk-00010001'::text))
+        Buffers: shared hit=6
+Query Identifier: -3770326553474516971
+Planning:
+  Buffers: shared hit=3
+Planning Time: 0.134 ms
+Execution Time: 0.124 ms
+ok
+
+test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 1573 filtered out; finished in 6.27s
+

--- a/docs/perf/sync-push-batching/after.txt
+++ b/docs/perf/sync-push-batching/after.txt
@@ -3,8 +3,8 @@ test integration::offline_sync_push_batching_perf::offline_sync_push_batching_pr
 === pg_stat_statements: push batch of 50 changes ===
 -- top by calls --
 calls=1      buffers=0      SELECT change_id, version, resolved_row FROM autumn_sync_applied WHERE scope = $1 AND device_id = $2 AND change_id = ANY($3)
-calls=1      buffers=62     SELECT nextval($2) AS version FROM generate_series($3, $1)
 calls=1      buffers=593    INSERT INTO autumn_sync_rows (scope, collection, pk, payload, version, deleted, updated_at, device_id, created_version) SELECT $1, t.* FROM UNNEST( $2::text[], $3::text[], $4::jsonb[], $5::bigint[], $6::bool[], $7::timestamptz[], $8::text[], $9::bigint[] ) AS t(collection, pk, payload, version, deleted, updated_at, device_id, created_version) ON CONFLICT (scope, collection, pk) DO UPDATE SET payload = excluded.payload, version = excluded.version, deleted = excluded.deleted, updated_at = excluded.updated_at, device_id = excluded.device_id, created_version = excluded.created_version
+calls=1      buffers=62     SELECT nextval($2) AS version FROM generate_series($3, $1) WITH ORDINALITY AS gs(n, ord) ORDER BY gs.ord
 calls=1      buffers=225    SELECT collection, pk, payload, version, deleted, updated_at, device_id, created_version FROM autumn_sync_rows WHERE scope = $1 AND (collection, pk) IN ( SELECT * FROM UNNEST($2::text[], $3::text[]) ) FOR UPDATE
 calls=1      buffers=101    INSERT INTO autumn_sync_applied (scope, device_id, change_id, version, resolved_row) SELECT $1, $2, t.change_id, t.version, t.resolved_row FROM UNNEST($3::text[], $4::bigint[], $5::jsonb[]) AS t(change_id, version, resolved_row)
 calls=1      buffers=0      SELECT horizon AS version FROM autumn_sync_horizons WHERE scope = $1
@@ -12,7 +12,7 @@ calls=1      buffers=0      SELECT horizon AS version FROM autumn_sync_horizons 
 buffers=593    calls=1      INSERT INTO autumn_sync_rows (scope, collection, pk, payload, version, deleted, updated_at, device_id, created_version) SELECT $1, t.* FROM UNNEST( $2::text[], $3::text[], $4::jsonb[], $5::bigint[], $6::bool[], $7::timestamptz[], $8::text[], $9::bigint[] ) AS t(collection, pk, payload, version, deleted, updated_at, device_id, created_version) ON CONFLICT (scope, collection, pk) DO UPDATE SET payload = excluded.payload, version = excluded.version, deleted = excluded.deleted, updated_at = excluded.updated_at, device_id = excluded.device_id, created_version = excluded.created_version
 buffers=225    calls=1      SELECT collection, pk, payload, version, deleted, updated_at, device_id, created_version FROM autumn_sync_rows WHERE scope = $1 AND (collection, pk) IN ( SELECT * FROM UNNEST($2::text[], $3::text[]) ) FOR UPDATE
 buffers=101    calls=1      INSERT INTO autumn_sync_applied (scope, device_id, change_id, version, resolved_row) SELECT $1, $2, t.change_id, t.version, t.resolved_row FROM UNNEST($3::text[], $4::bigint[], $5::jsonb[]) AS t(change_id, version, resolved_row)
-buffers=62     calls=1      SELECT nextval($2) AS version FROM generate_series($3, $1)
+buffers=62     calls=1      SELECT nextval($2) AS version FROM generate_series($3, $1) WITH ORDINALITY AS gs(n, ord) ORDER BY gs.ord
 buffers=0      calls=1      SELECT change_id, version, resolved_row FROM autumn_sync_applied WHERE scope = $1 AND device_id = $2 AND change_id = ANY($3)
 buffers=0      calls=1      SELECT horizon AS version FROM autumn_sync_horizons WHERE scope = $1
 TOTAL sync-table statement calls=6 buffers=981 (this batch, all statement shapes)
@@ -69,19 +69,19 @@ RowDump { collection: "notes", pk: "pk-00000037", payload: Some("{\"p\": 1, \"ed
 === pg_stat_statements: push batch of 250 changes ===
 -- top by calls --
 calls=1      buffers=1      SELECT change_id, version, resolved_row FROM autumn_sync_applied WHERE scope = $1 AND device_id = $2 AND change_id = ANY($3)
-calls=1      buffers=262    SELECT nextval($2) AS version FROM generate_series($3, $1)
-calls=1      buffers=2912   INSERT INTO autumn_sync_rows (scope, collection, pk, payload, version, deleted, updated_at, device_id, created_version) SELECT $1, t.* FROM UNNEST( $2::text[], $3::text[], $4::jsonb[], $5::bigint[], $6::bool[], $7::timestamptz[], $8::text[], $9::bigint[] ) AS t(collection, pk, payload, version, deleted, updated_at, device_id, created_version) ON CONFLICT (scope, collection, pk) DO UPDATE SET payload = excluded.payload, version = excluded.version, deleted = excluded.deleted, updated_at = excluded.updated_at, device_id = excluded.device_id, created_version = excluded.created_version
+calls=1      buffers=2914   INSERT INTO autumn_sync_rows (scope, collection, pk, payload, version, deleted, updated_at, device_id, created_version) SELECT $1, t.* FROM UNNEST( $2::text[], $3::text[], $4::jsonb[], $5::bigint[], $6::bool[], $7::timestamptz[], $8::text[], $9::bigint[] ) AS t(collection, pk, payload, version, deleted, updated_at, device_id, created_version) ON CONFLICT (scope, collection, pk) DO UPDATE SET payload = excluded.payload, version = excluded.version, deleted = excluded.deleted, updated_at = excluded.updated_at, device_id = excluded.device_id, created_version = excluded.created_version
+calls=1      buffers=262    SELECT nextval($2) AS version FROM generate_series($3, $1) WITH ORDINALITY AS gs(n, ord) ORDER BY gs.ord
 calls=1      buffers=1132   SELECT collection, pk, payload, version, deleted, updated_at, device_id, created_version FROM autumn_sync_rows WHERE scope = $1 AND (collection, pk) IN ( SELECT * FROM UNNEST($2::text[], $3::text[]) ) FOR UPDATE
 calls=1      buffers=655    INSERT INTO autumn_sync_applied (scope, device_id, change_id, version, resolved_row) SELECT $1, $2, t.change_id, t.version, t.resolved_row FROM UNNEST($3::text[], $4::bigint[], $5::jsonb[]) AS t(change_id, version, resolved_row)
 calls=1      buffers=0      SELECT horizon AS version FROM autumn_sync_horizons WHERE scope = $1
 -- top by buffers --
-buffers=2912   calls=1      INSERT INTO autumn_sync_rows (scope, collection, pk, payload, version, deleted, updated_at, device_id, created_version) SELECT $1, t.* FROM UNNEST( $2::text[], $3::text[], $4::jsonb[], $5::bigint[], $6::bool[], $7::timestamptz[], $8::text[], $9::bigint[] ) AS t(collection, pk, payload, version, deleted, updated_at, device_id, created_version) ON CONFLICT (scope, collection, pk) DO UPDATE SET payload = excluded.payload, version = excluded.version, deleted = excluded.deleted, updated_at = excluded.updated_at, device_id = excluded.device_id, created_version = excluded.created_version
+buffers=2914   calls=1      INSERT INTO autumn_sync_rows (scope, collection, pk, payload, version, deleted, updated_at, device_id, created_version) SELECT $1, t.* FROM UNNEST( $2::text[], $3::text[], $4::jsonb[], $5::bigint[], $6::bool[], $7::timestamptz[], $8::text[], $9::bigint[] ) AS t(collection, pk, payload, version, deleted, updated_at, device_id, created_version) ON CONFLICT (scope, collection, pk) DO UPDATE SET payload = excluded.payload, version = excluded.version, deleted = excluded.deleted, updated_at = excluded.updated_at, device_id = excluded.device_id, created_version = excluded.created_version
 buffers=1132   calls=1      SELECT collection, pk, payload, version, deleted, updated_at, device_id, created_version FROM autumn_sync_rows WHERE scope = $1 AND (collection, pk) IN ( SELECT * FROM UNNEST($2::text[], $3::text[]) ) FOR UPDATE
 buffers=655    calls=1      INSERT INTO autumn_sync_applied (scope, device_id, change_id, version, resolved_row) SELECT $1, $2, t.change_id, t.version, t.resolved_row FROM UNNEST($3::text[], $4::bigint[], $5::jsonb[]) AS t(change_id, version, resolved_row)
-buffers=262    calls=1      SELECT nextval($2) AS version FROM generate_series($3, $1)
+buffers=262    calls=1      SELECT nextval($2) AS version FROM generate_series($3, $1) WITH ORDINALITY AS gs(n, ord) ORDER BY gs.ord
 buffers=1      calls=1      SELECT change_id, version, resolved_row FROM autumn_sync_applied WHERE scope = $1 AND device_id = $2 AND change_id = ANY($3)
 buffers=0      calls=1      SELECT horizon AS version FROM autumn_sync_horizons WHERE scope = $1
-TOTAL sync-table statement calls=6 buffers=4962 (this batch, all statement shapes)
+TOTAL sync-table statement calls=6 buffers=4964 (this batch, all statement shapes)
 -- row dump (new/newdup pks), 54 rows --
 RowDump { collection: "notes", pk: "new-device-250-000000", payload: Some("{\"k\": 0, \"edit\": \"insert\"}"), version: 20211, deleted: false, device_id: "device-250", created_version: 20211 }
 RowDump { collection: "notes", pk: "new-device-250-000001", payload: Some("{\"k\": 1, \"edit\": \"insert\"}"), version: 20212, deleted: false, device_id: "device-250", created_version: 20212 }
@@ -324,19 +324,19 @@ RowDump { collection: "tags", pk: "pk-00005191", payload: Some("{\"p\": 9, \"edi
 === pg_stat_statements: push batch of 1000 changes ===
 -- top by calls --
 calls=1      buffers=4      SELECT change_id, version, resolved_row FROM autumn_sync_applied WHERE scope = $1 AND device_id = $2 AND change_id = ANY($3)
-calls=1      buffers=1012   SELECT nextval($2) AS version FROM generate_series($3, $1)
-calls=1      buffers=11709  INSERT INTO autumn_sync_rows (scope, collection, pk, payload, version, deleted, updated_at, device_id, created_version) SELECT $1, t.* FROM UNNEST( $2::text[], $3::text[], $4::jsonb[], $5::bigint[], $6::bool[], $7::timestamptz[], $8::text[], $9::bigint[] ) AS t(collection, pk, payload, version, deleted, updated_at, device_id, created_version) ON CONFLICT (scope, collection, pk) DO UPDATE SET payload = excluded.payload, version = excluded.version, deleted = excluded.deleted, updated_at = excluded.updated_at, device_id = excluded.device_id, created_version = excluded.created_version
+calls=1      buffers=11718  INSERT INTO autumn_sync_rows (scope, collection, pk, payload, version, deleted, updated_at, device_id, created_version) SELECT $1, t.* FROM UNNEST( $2::text[], $3::text[], $4::jsonb[], $5::bigint[], $6::bool[], $7::timestamptz[], $8::text[], $9::bigint[] ) AS t(collection, pk, payload, version, deleted, updated_at, device_id, created_version) ON CONFLICT (scope, collection, pk) DO UPDATE SET payload = excluded.payload, version = excluded.version, deleted = excluded.deleted, updated_at = excluded.updated_at, device_id = excluded.device_id, created_version = excluded.created_version
+calls=1      buffers=1012   SELECT nextval($2) AS version FROM generate_series($3, $1) WITH ORDINALITY AS gs(n, ord) ORDER BY gs.ord
 calls=1      buffers=4560   SELECT collection, pk, payload, version, deleted, updated_at, device_id, created_version FROM autumn_sync_rows WHERE scope = $1 AND (collection, pk) IN ( SELECT * FROM UNNEST($2::text[], $3::text[]) ) FOR UPDATE
 calls=1      buffers=3055   INSERT INTO autumn_sync_applied (scope, device_id, change_id, version, resolved_row) SELECT $1, $2, t.change_id, t.version, t.resolved_row FROM UNNEST($3::text[], $4::bigint[], $5::jsonb[]) AS t(change_id, version, resolved_row)
 calls=1      buffers=0      SELECT horizon AS version FROM autumn_sync_horizons WHERE scope = $1
 -- top by buffers --
-buffers=11709  calls=1      INSERT INTO autumn_sync_rows (scope, collection, pk, payload, version, deleted, updated_at, device_id, created_version) SELECT $1, t.* FROM UNNEST( $2::text[], $3::text[], $4::jsonb[], $5::bigint[], $6::bool[], $7::timestamptz[], $8::text[], $9::bigint[] ) AS t(collection, pk, payload, version, deleted, updated_at, device_id, created_version) ON CONFLICT (scope, collection, pk) DO UPDATE SET payload = excluded.payload, version = excluded.version, deleted = excluded.deleted, updated_at = excluded.updated_at, device_id = excluded.device_id, created_version = excluded.created_version
+buffers=11718  calls=1      INSERT INTO autumn_sync_rows (scope, collection, pk, payload, version, deleted, updated_at, device_id, created_version) SELECT $1, t.* FROM UNNEST( $2::text[], $3::text[], $4::jsonb[], $5::bigint[], $6::bool[], $7::timestamptz[], $8::text[], $9::bigint[] ) AS t(collection, pk, payload, version, deleted, updated_at, device_id, created_version) ON CONFLICT (scope, collection, pk) DO UPDATE SET payload = excluded.payload, version = excluded.version, deleted = excluded.deleted, updated_at = excluded.updated_at, device_id = excluded.device_id, created_version = excluded.created_version
 buffers=4560   calls=1      SELECT collection, pk, payload, version, deleted, updated_at, device_id, created_version FROM autumn_sync_rows WHERE scope = $1 AND (collection, pk) IN ( SELECT * FROM UNNEST($2::text[], $3::text[]) ) FOR UPDATE
 buffers=3055   calls=1      INSERT INTO autumn_sync_applied (scope, device_id, change_id, version, resolved_row) SELECT $1, $2, t.change_id, t.version, t.resolved_row FROM UNNEST($3::text[], $4::bigint[], $5::jsonb[]) AS t(change_id, version, resolved_row)
-buffers=1012   calls=1      SELECT nextval($2) AS version FROM generate_series($3, $1)
+buffers=1012   calls=1      SELECT nextval($2) AS version FROM generate_series($3, $1) WITH ORDINALITY AS gs(n, ord) ORDER BY gs.ord
 buffers=4      calls=1      SELECT change_id, version, resolved_row FROM autumn_sync_applied WHERE scope = $1 AND device_id = $2 AND change_id = ANY($3)
 buffers=0      calls=1      SELECT horizon AS version FROM autumn_sync_horizons WHERE scope = $1
-TOTAL sync-table statement calls=6 buffers=20340 (this batch, all statement shapes)
+TOTAL sync-table statement calls=6 buffers=20349 (this batch, all statement shapes)
 -- row dump (new/newdup pks), 210 rows --
 RowDump { collection: "notes", pk: "new-device-1000-000000", payload: Some("{\"k\": 0, \"edit\": \"insert\"}"), version: 20951, deleted: false, device_id: "device-1000", created_version: 20951 }
 RowDump { collection: "notes", pk: "new-device-1000-000001", payload: Some("{\"k\": 1, \"edit\": \"insert\"}"), version: 20952, deleted: false, device_id: "device-1000", created_version: 20952 }
@@ -1306,31 +1306,31 @@ TOTAL sync-table statement calls=2 buffers=8 (this batch, all statement shapes)
 
 === EXPLAIN (ANALYZE, BUFFERS, VERBOSE, SETTINGS): dedup check (typical case: miss) ===
 SELECT version, resolved_row FROM autumn_sync_applied WHERE scope = 'global' AND device_id = 'device-1000' AND change_id = 'device-1000-chg-000001'
-Index Scan using autumn_sync_applied_pkey on public.autumn_sync_applied  (cost=0.28..8.30 rows=1 width=40) (actual time=0.170..0.171 rows=1 loops=1)
+Index Scan using autumn_sync_applied_pkey on public.autumn_sync_applied  (cost=0.28..8.30 rows=1 width=40) (actual time=0.096..0.097 rows=1 loops=1)
   Output: version, resolved_row
   Index Cond: ((autumn_sync_applied.scope = 'global'::text) AND (autumn_sync_applied.device_id = 'device-1000'::text) AND (autumn_sync_applied.change_id = 'device-1000-chg-000001'::text))
   Buffers: shared hit=3
 Query Identifier: 5474131966345183344
 Planning:
   Buffers: shared hit=17
-Planning Time: 0.343 ms
-Execution Time: 0.207 ms
+Planning Time: 0.264 ms
+Execution Time: 0.120 ms
 
 === EXPLAIN (ANALYZE, BUFFERS, VERBOSE, SETTINGS): current-row fetch FOR UPDATE ===
 SELECT collection, pk, payload, version, deleted, updated_at, device_id, created_version FROM autumn_sync_rows WHERE scope = 'global' AND collection = 'notes' AND pk = 'pk-00010001' FOR UPDATE
-LockRows  (cost=0.41..8.44 rows=1 width=317) (actual time=0.050..0.056 rows=1 loops=1)
+LockRows  (cost=0.41..8.44 rows=1 width=317) (actual time=0.045..0.050 rows=1 loops=1)
   Output: collection, pk, payload, version, deleted, updated_at, device_id, created_version, ctid
   Buffers: shared hit=7
-  ->  Index Scan using autumn_sync_rows_pkey on public.autumn_sync_rows  (cost=0.41..8.43 rows=1 width=317) (actual time=0.032..0.037 rows=1 loops=1)
+  ->  Index Scan using autumn_sync_rows_pkey on public.autumn_sync_rows  (cost=0.41..8.43 rows=1 width=317) (actual time=0.032..0.036 rows=1 loops=1)
         Output: collection, pk, payload, version, deleted, updated_at, device_id, created_version, ctid
         Index Cond: ((autumn_sync_rows.scope = 'global'::text) AND (autumn_sync_rows.collection = 'notes'::text) AND (autumn_sync_rows.pk = 'pk-00010001'::text))
         Buffers: shared hit=6
 Query Identifier: -3770326553474516971
 Planning:
   Buffers: shared hit=3
-Planning Time: 0.134 ms
-Execution Time: 0.124 ms
+Planning Time: 0.124 ms
+Execution Time: 0.078 ms
 ok
 
-test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 1573 filtered out; finished in 6.27s
+test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 1573 filtered out; finished in 4.77s
 

--- a/docs/perf/sync-push-batching/baseline.txt
+++ b/docs/perf/sync-push-batching/baseline.txt
@@ -1,0 +1,1336 @@
+running 1 test
+test integration::offline_sync_push_batching_perf::offline_sync_push_batching_profile ... 
+=== pg_stat_statements: push batch of 50 changes ===
+-- top by calls --
+calls=50     buffers=62     SELECT nextval($1) AS version
+calls=50     buffers=632    INSERT INTO autumn_sync_rows (scope, collection, pk, payload, version, deleted, updated_at, device_id, created_version) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9) ON CONFLICT (scope, collection, pk) DO UPDATE SET payload = excluded.payload, version = excluded.version, deleted = excluded.deleted, updated_at = excluded.updated_at, device_id = excluded.device_id, created_version = excluded.created_version
+calls=50     buffers=100    INSERT INTO autumn_sync_applied (scope, device_id, change_id, version, resolved_row) VALUES ($1, $2, $3, $4, $5)
+calls=50     buffers=49     SELECT version, resolved_row FROM autumn_sync_applied WHERE scope = $1 AND device_id = $2 AND change_id = $3
+calls=50     buffers=242    SELECT collection, pk, payload, version, deleted, updated_at, device_id, created_version FROM autumn_sync_rows WHERE scope = $1 AND collection = $2 AND pk = $3 FOR UPDATE
+calls=1      buffers=0      SELECT horizon AS version FROM autumn_sync_horizons WHERE scope = $1
+-- top by buffers --
+buffers=632    calls=50     INSERT INTO autumn_sync_rows (scope, collection, pk, payload, version, deleted, updated_at, device_id, created_version) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9) ON CONFLICT (scope, collection, pk) DO UPDATE SET payload = excluded.payload, version = excluded.version, deleted = excluded.deleted, updated_at = excluded.updated_at, device_id = excluded.device_id, created_version = excluded.created_version
+buffers=242    calls=50     SELECT collection, pk, payload, version, deleted, updated_at, device_id, created_version FROM autumn_sync_rows WHERE scope = $1 AND collection = $2 AND pk = $3 FOR UPDATE
+buffers=100    calls=50     INSERT INTO autumn_sync_applied (scope, device_id, change_id, version, resolved_row) VALUES ($1, $2, $3, $4, $5)
+buffers=62     calls=50     SELECT nextval($1) AS version
+buffers=49     calls=50     SELECT version, resolved_row FROM autumn_sync_applied WHERE scope = $1 AND device_id = $2 AND change_id = $3
+buffers=0      calls=1      SELECT horizon AS version FROM autumn_sync_horizons WHERE scope = $1
+TOTAL sync-table statement calls=251 buffers=1085 (this batch, all statement shapes)
+-- row dump (new/newdup pks), 11 rows --
+RowDump { collection: "notes", pk: "new-device-50-000000", payload: Some("{\"k\": 0, \"edit\": \"insert\"}"), version: 20031, deleted: false, device_id: "device-50", created_version: 20031 }
+RowDump { collection: "notes", pk: "new-device-50-000001", payload: Some("{\"k\": 1, \"edit\": \"insert\"}"), version: 20032, deleted: false, device_id: "device-50", created_version: 20032 }
+RowDump { collection: "notes", pk: "new-device-50-000002", payload: Some("{\"k\": 2, \"edit\": \"insert\"}"), version: 20033, deleted: false, device_id: "device-50", created_version: 20033 }
+RowDump { collection: "notes", pk: "new-device-50-000003", payload: Some("{\"k\": 3, \"edit\": \"insert\"}"), version: 20034, deleted: false, device_id: "device-50", created_version: 20034 }
+RowDump { collection: "notes", pk: "new-device-50-000004", payload: Some("{\"k\": 4, \"edit\": \"insert\"}"), version: 20035, deleted: false, device_id: "device-50", created_version: 20035 }
+RowDump { collection: "notes", pk: "new-device-50-000005", payload: Some("{\"k\": 5, \"edit\": \"insert\"}"), version: 20036, deleted: false, device_id: "device-50", created_version: 20036 }
+RowDump { collection: "notes", pk: "new-device-50-000006", payload: Some("{\"k\": 6, \"edit\": \"insert\"}"), version: 20037, deleted: false, device_id: "device-50", created_version: 20037 }
+RowDump { collection: "notes", pk: "new-device-50-000007", payload: Some("{\"k\": 7, \"edit\": \"insert\"}"), version: 20038, deleted: false, device_id: "device-50", created_version: 20038 }
+RowDump { collection: "notes", pk: "new-device-50-000008", payload: Some("{\"k\": 8, \"edit\": \"insert\"}"), version: 20039, deleted: false, device_id: "device-50", created_version: 20039 }
+RowDump { collection: "notes", pk: "new-device-50-000009", payload: Some("{\"k\": 9, \"edit\": \"insert\"}"), version: 20040, deleted: false, device_id: "device-50", created_version: 20040 }
+RowDump { collection: "notes", pk: "newdup-device-50-000000", payload: Some("{\"p\": 0, \"edit\": \"dup-new-2\"}"), version: 20050, deleted: false, device_id: "device-50", created_version: 20049 }
+-- row dump (existing pks touched by this batch), 36 rows --
+RowDump { collection: "notes", pk: "pk-00000001", payload: Some("{\"idx\": 1, \"edit\": \"update\"}"), version: 20001, deleted: false, device_id: "device-50", created_version: 1 }
+RowDump { collection: "notes", pk: "pk-00000002", payload: Some("{\"idx\": 2, \"edit\": \"update\"}"), version: 20002, deleted: false, device_id: "device-50", created_version: 2 }
+RowDump { collection: "notes", pk: "pk-00000003", payload: Some("{\"idx\": 3, \"edit\": \"update\"}"), version: 20003, deleted: false, device_id: "device-50", created_version: 3 }
+RowDump { collection: "notes", pk: "pk-00000004", payload: Some("{\"idx\": 4, \"edit\": \"update\"}"), version: 20004, deleted: false, device_id: "device-50", created_version: 4 }
+RowDump { collection: "notes", pk: "pk-00000005", payload: Some("{\"idx\": 5, \"edit\": \"update\"}"), version: 20005, deleted: false, device_id: "device-50", created_version: 5 }
+RowDump { collection: "notes", pk: "pk-00000006", payload: Some("{\"idx\": 6, \"edit\": \"update\"}"), version: 20006, deleted: false, device_id: "device-50", created_version: 6 }
+RowDump { collection: "notes", pk: "pk-00000007", payload: Some("{\"idx\": 7, \"edit\": \"update\"}"), version: 20007, deleted: false, device_id: "device-50", created_version: 7 }
+RowDump { collection: "notes", pk: "pk-00000008", payload: Some("{\"idx\": 8, \"edit\": \"update\"}"), version: 20008, deleted: false, device_id: "device-50", created_version: 8 }
+RowDump { collection: "notes", pk: "pk-00000009", payload: Some("{\"idx\": 9, \"edit\": \"update\"}"), version: 20009, deleted: false, device_id: "device-50", created_version: 9 }
+RowDump { collection: "notes", pk: "pk-00000010", payload: Some("{\"idx\": 10, \"edit\": \"update\"}"), version: 20010, deleted: false, device_id: "device-50", created_version: 10 }
+RowDump { collection: "notes", pk: "pk-00000011", payload: Some("{\"idx\": 11, \"edit\": \"update\"}"), version: 20011, deleted: false, device_id: "device-50", created_version: 11 }
+RowDump { collection: "notes", pk: "pk-00000012", payload: Some("{\"idx\": 12, \"edit\": \"update\"}"), version: 20012, deleted: false, device_id: "device-50", created_version: 12 }
+RowDump { collection: "notes", pk: "pk-00000013", payload: Some("{\"idx\": 13, \"edit\": \"update\"}"), version: 20013, deleted: false, device_id: "device-50", created_version: 13 }
+RowDump { collection: "notes", pk: "pk-00000014", payload: Some("{\"idx\": 14, \"edit\": \"update\"}"), version: 20014, deleted: false, device_id: "device-50", created_version: 14 }
+RowDump { collection: "notes", pk: "pk-00000015", payload: Some("{\"idx\": 15, \"edit\": \"update\"}"), version: 20015, deleted: false, device_id: "device-50", created_version: 15 }
+RowDump { collection: "notes", pk: "pk-00000016", payload: Some("{\"idx\": 16, \"edit\": \"update\"}"), version: 20016, deleted: false, device_id: "device-50", created_version: 16 }
+RowDump { collection: "notes", pk: "pk-00000017", payload: Some("{\"idx\": 17, \"edit\": \"update\"}"), version: 20017, deleted: false, device_id: "device-50", created_version: 17 }
+RowDump { collection: "notes", pk: "pk-00000018", payload: Some("{\"idx\": 18, \"edit\": \"update\"}"), version: 20018, deleted: false, device_id: "device-50", created_version: 18 }
+RowDump { collection: "notes", pk: "pk-00000019", payload: Some("{\"idx\": 19, \"edit\": \"update\"}"), version: 20019, deleted: false, device_id: "device-50", created_version: 19 }
+RowDump { collection: "notes", pk: "pk-00000021", payload: Some("{\"idx\": 21, \"edit\": \"update\"}"), version: 20020, deleted: false, device_id: "device-50", created_version: 21 }
+RowDump { collection: "notes", pk: "pk-00000022", payload: Some("{\"idx\": 22, \"edit\": \"update\"}"), version: 20021, deleted: false, device_id: "device-50", created_version: 22 }
+RowDump { collection: "notes", pk: "pk-00000023", payload: Some("{\"idx\": 23, \"edit\": \"update\"}"), version: 20022, deleted: false, device_id: "device-50", created_version: 23 }
+RowDump { collection: "notes", pk: "pk-00000024", payload: Some("{\"idx\": 24, \"edit\": \"update\"}"), version: 20023, deleted: false, device_id: "device-50", created_version: 24 }
+RowDump { collection: "notes", pk: "pk-00000025", payload: Some("{\"idx\": 25, \"edit\": \"update\"}"), version: 20024, deleted: false, device_id: "device-50", created_version: 25 }
+RowDump { collection: "notes", pk: "pk-00000026", payload: Some("{\"idx\": 26, \"edit\": \"update\"}"), version: 20025, deleted: false, device_id: "device-50", created_version: 26 }
+RowDump { collection: "notes", pk: "pk-00000027", payload: Some("{\"idx\": 27, \"edit\": \"update\"}"), version: 20026, deleted: false, device_id: "device-50", created_version: 27 }
+RowDump { collection: "notes", pk: "pk-00000028", payload: Some("{\"idx\": 28, \"edit\": \"update\"}"), version: 20027, deleted: false, device_id: "device-50", created_version: 28 }
+RowDump { collection: "notes", pk: "pk-00000029", payload: Some("{\"idx\": 29, \"edit\": \"update\"}"), version: 20028, deleted: false, device_id: "device-50", created_version: 29 }
+RowDump { collection: "notes", pk: "pk-00000030", payload: Some("{\"idx\": 30, \"edit\": \"update\"}"), version: 20029, deleted: false, device_id: "device-50", created_version: 30 }
+RowDump { collection: "notes", pk: "pk-00000031", payload: Some("{\"idx\": 31, \"edit\": \"update\"}"), version: 20030, deleted: false, device_id: "device-50", created_version: 31 }
+RowDump { collection: "notes", pk: "pk-00000032", payload: None, version: 20041, deleted: true, device_id: "device-50", created_version: 32 }
+RowDump { collection: "notes", pk: "pk-00000033", payload: None, version: 20042, deleted: true, device_id: "device-50", created_version: 33 }
+RowDump { collection: "notes", pk: "pk-00000034", payload: None, version: 20043, deleted: true, device_id: "device-50", created_version: 34 }
+RowDump { collection: "notes", pk: "pk-00000035", payload: None, version: 20044, deleted: true, device_id: "device-50", created_version: 35 }
+RowDump { collection: "notes", pk: "pk-00000036", payload: Some("{\"p\": 0, \"edit\": \"dup-existing-2\"}"), version: 20046, deleted: false, device_id: "device-50", created_version: 36 }
+RowDump { collection: "notes", pk: "pk-00000037", payload: Some("{\"p\": 1, \"edit\": \"dup-existing-2\"}"), version: 20048, deleted: false, device_id: "device-50", created_version: 37 }
+
+=== pg_stat_statements: push batch of 250 changes ===
+-- top by calls --
+calls=250    buffers=262    SELECT nextval($1) AS version
+calls=250    buffers=3105   INSERT INTO autumn_sync_rows (scope, collection, pk, payload, version, deleted, updated_at, device_id, created_version) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9) ON CONFLICT (scope, collection, pk) DO UPDATE SET payload = excluded.payload, version = excluded.version, deleted = excluded.deleted, updated_at = excluded.updated_at, device_id = excluded.device_id, created_version = excluded.created_version
+calls=250    buffers=655    INSERT INTO autumn_sync_applied (scope, device_id, change_id, version, resolved_row) VALUES ($1, $2, $3, $4, $5)
+calls=250    buffers=595    SELECT version, resolved_row FROM autumn_sync_applied WHERE scope = $1 AND device_id = $2 AND change_id = $3
+calls=250    buffers=1206   SELECT collection, pk, payload, version, deleted, updated_at, device_id, created_version FROM autumn_sync_rows WHERE scope = $1 AND collection = $2 AND pk = $3 FOR UPDATE
+calls=1      buffers=0      SELECT horizon AS version FROM autumn_sync_horizons WHERE scope = $1
+-- top by buffers --
+buffers=3105   calls=250    INSERT INTO autumn_sync_rows (scope, collection, pk, payload, version, deleted, updated_at, device_id, created_version) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9) ON CONFLICT (scope, collection, pk) DO UPDATE SET payload = excluded.payload, version = excluded.version, deleted = excluded.deleted, updated_at = excluded.updated_at, device_id = excluded.device_id, created_version = excluded.created_version
+buffers=1206   calls=250    SELECT collection, pk, payload, version, deleted, updated_at, device_id, created_version FROM autumn_sync_rows WHERE scope = $1 AND collection = $2 AND pk = $3 FOR UPDATE
+buffers=655    calls=250    INSERT INTO autumn_sync_applied (scope, device_id, change_id, version, resolved_row) VALUES ($1, $2, $3, $4, $5)
+buffers=595    calls=250    SELECT version, resolved_row FROM autumn_sync_applied WHERE scope = $1 AND device_id = $2 AND change_id = $3
+buffers=262    calls=250    SELECT nextval($1) AS version
+buffers=0      calls=1      SELECT horizon AS version FROM autumn_sync_horizons WHERE scope = $1
+TOTAL sync-table statement calls=1251 buffers=5823 (this batch, all statement shapes)
+-- row dump (new/newdup pks), 54 rows --
+RowDump { collection: "notes", pk: "new-device-250-000000", payload: Some("{\"k\": 0, \"edit\": \"insert\"}"), version: 20211, deleted: false, device_id: "device-250", created_version: 20211 }
+RowDump { collection: "notes", pk: "new-device-250-000001", payload: Some("{\"k\": 1, \"edit\": \"insert\"}"), version: 20212, deleted: false, device_id: "device-250", created_version: 20212 }
+RowDump { collection: "notes", pk: "new-device-250-000002", payload: Some("{\"k\": 2, \"edit\": \"insert\"}"), version: 20213, deleted: false, device_id: "device-250", created_version: 20213 }
+RowDump { collection: "notes", pk: "new-device-250-000003", payload: Some("{\"k\": 3, \"edit\": \"insert\"}"), version: 20214, deleted: false, device_id: "device-250", created_version: 20214 }
+RowDump { collection: "notes", pk: "new-device-250-000004", payload: Some("{\"k\": 4, \"edit\": \"insert\"}"), version: 20215, deleted: false, device_id: "device-250", created_version: 20215 }
+RowDump { collection: "notes", pk: "new-device-250-000005", payload: Some("{\"k\": 5, \"edit\": \"insert\"}"), version: 20216, deleted: false, device_id: "device-250", created_version: 20216 }
+RowDump { collection: "notes", pk: "new-device-250-000006", payload: Some("{\"k\": 6, \"edit\": \"insert\"}"), version: 20217, deleted: false, device_id: "device-250", created_version: 20217 }
+RowDump { collection: "notes", pk: "new-device-250-000007", payload: Some("{\"k\": 7, \"edit\": \"insert\"}"), version: 20218, deleted: false, device_id: "device-250", created_version: 20218 }
+RowDump { collection: "notes", pk: "new-device-250-000008", payload: Some("{\"k\": 8, \"edit\": \"insert\"}"), version: 20219, deleted: false, device_id: "device-250", created_version: 20219 }
+RowDump { collection: "notes", pk: "new-device-250-000009", payload: Some("{\"k\": 9, \"edit\": \"insert\"}"), version: 20220, deleted: false, device_id: "device-250", created_version: 20220 }
+RowDump { collection: "notes", pk: "new-device-250-000010", payload: Some("{\"k\": 10, \"edit\": \"insert\"}"), version: 20221, deleted: false, device_id: "device-250", created_version: 20221 }
+RowDump { collection: "notes", pk: "new-device-250-000011", payload: Some("{\"k\": 11, \"edit\": \"insert\"}"), version: 20222, deleted: false, device_id: "device-250", created_version: 20222 }
+RowDump { collection: "notes", pk: "new-device-250-000012", payload: Some("{\"k\": 12, \"edit\": \"insert\"}"), version: 20223, deleted: false, device_id: "device-250", created_version: 20223 }
+RowDump { collection: "notes", pk: "new-device-250-000013", payload: Some("{\"k\": 13, \"edit\": \"insert\"}"), version: 20224, deleted: false, device_id: "device-250", created_version: 20224 }
+RowDump { collection: "notes", pk: "new-device-250-000014", payload: Some("{\"k\": 14, \"edit\": \"insert\"}"), version: 20225, deleted: false, device_id: "device-250", created_version: 20225 }
+RowDump { collection: "notes", pk: "new-device-250-000015", payload: Some("{\"k\": 15, \"edit\": \"insert\"}"), version: 20226, deleted: false, device_id: "device-250", created_version: 20226 }
+RowDump { collection: "notes", pk: "new-device-250-000016", payload: Some("{\"k\": 16, \"edit\": \"insert\"}"), version: 20227, deleted: false, device_id: "device-250", created_version: 20227 }
+RowDump { collection: "notes", pk: "new-device-250-000017", payload: Some("{\"k\": 17, \"edit\": \"insert\"}"), version: 20228, deleted: false, device_id: "device-250", created_version: 20228 }
+RowDump { collection: "notes", pk: "new-device-250-000018", payload: Some("{\"k\": 18, \"edit\": \"insert\"}"), version: 20229, deleted: false, device_id: "device-250", created_version: 20229 }
+RowDump { collection: "notes", pk: "new-device-250-000019", payload: Some("{\"k\": 19, \"edit\": \"insert\"}"), version: 20230, deleted: false, device_id: "device-250", created_version: 20230 }
+RowDump { collection: "notes", pk: "new-device-250-000020", payload: Some("{\"k\": 20, \"edit\": \"insert\"}"), version: 20231, deleted: false, device_id: "device-250", created_version: 20231 }
+RowDump { collection: "notes", pk: "new-device-250-000021", payload: Some("{\"k\": 21, \"edit\": \"insert\"}"), version: 20232, deleted: false, device_id: "device-250", created_version: 20232 }
+RowDump { collection: "notes", pk: "new-device-250-000022", payload: Some("{\"k\": 22, \"edit\": \"insert\"}"), version: 20233, deleted: false, device_id: "device-250", created_version: 20233 }
+RowDump { collection: "notes", pk: "new-device-250-000023", payload: Some("{\"k\": 23, \"edit\": \"insert\"}"), version: 20234, deleted: false, device_id: "device-250", created_version: 20234 }
+RowDump { collection: "notes", pk: "new-device-250-000024", payload: Some("{\"k\": 24, \"edit\": \"insert\"}"), version: 20235, deleted: false, device_id: "device-250", created_version: 20235 }
+RowDump { collection: "notes", pk: "new-device-250-000025", payload: Some("{\"k\": 25, \"edit\": \"insert\"}"), version: 20236, deleted: false, device_id: "device-250", created_version: 20236 }
+RowDump { collection: "notes", pk: "new-device-250-000026", payload: Some("{\"k\": 26, \"edit\": \"insert\"}"), version: 20237, deleted: false, device_id: "device-250", created_version: 20237 }
+RowDump { collection: "notes", pk: "new-device-250-000027", payload: Some("{\"k\": 27, \"edit\": \"insert\"}"), version: 20238, deleted: false, device_id: "device-250", created_version: 20238 }
+RowDump { collection: "notes", pk: "new-device-250-000028", payload: Some("{\"k\": 28, \"edit\": \"insert\"}"), version: 20239, deleted: false, device_id: "device-250", created_version: 20239 }
+RowDump { collection: "notes", pk: "new-device-250-000029", payload: Some("{\"k\": 29, \"edit\": \"insert\"}"), version: 20240, deleted: false, device_id: "device-250", created_version: 20240 }
+RowDump { collection: "notes", pk: "new-device-250-000030", payload: Some("{\"k\": 30, \"edit\": \"insert\"}"), version: 20241, deleted: false, device_id: "device-250", created_version: 20241 }
+RowDump { collection: "notes", pk: "new-device-250-000031", payload: Some("{\"k\": 31, \"edit\": \"insert\"}"), version: 20242, deleted: false, device_id: "device-250", created_version: 20242 }
+RowDump { collection: "notes", pk: "new-device-250-000032", payload: Some("{\"k\": 32, \"edit\": \"insert\"}"), version: 20243, deleted: false, device_id: "device-250", created_version: 20243 }
+RowDump { collection: "notes", pk: "new-device-250-000033", payload: Some("{\"k\": 33, \"edit\": \"insert\"}"), version: 20244, deleted: false, device_id: "device-250", created_version: 20244 }
+RowDump { collection: "notes", pk: "new-device-250-000034", payload: Some("{\"k\": 34, \"edit\": \"insert\"}"), version: 20245, deleted: false, device_id: "device-250", created_version: 20245 }
+RowDump { collection: "notes", pk: "new-device-250-000035", payload: Some("{\"k\": 35, \"edit\": \"insert\"}"), version: 20246, deleted: false, device_id: "device-250", created_version: 20246 }
+RowDump { collection: "notes", pk: "new-device-250-000036", payload: Some("{\"k\": 36, \"edit\": \"insert\"}"), version: 20247, deleted: false, device_id: "device-250", created_version: 20247 }
+RowDump { collection: "notes", pk: "new-device-250-000037", payload: Some("{\"k\": 37, \"edit\": \"insert\"}"), version: 20248, deleted: false, device_id: "device-250", created_version: 20248 }
+RowDump { collection: "notes", pk: "new-device-250-000038", payload: Some("{\"k\": 38, \"edit\": \"insert\"}"), version: 20249, deleted: false, device_id: "device-250", created_version: 20249 }
+RowDump { collection: "notes", pk: "new-device-250-000039", payload: Some("{\"k\": 39, \"edit\": \"insert\"}"), version: 20250, deleted: false, device_id: "device-250", created_version: 20250 }
+RowDump { collection: "notes", pk: "new-device-250-000040", payload: Some("{\"k\": 40, \"edit\": \"insert\"}"), version: 20251, deleted: false, device_id: "device-250", created_version: 20251 }
+RowDump { collection: "notes", pk: "new-device-250-000041", payload: Some("{\"k\": 41, \"edit\": \"insert\"}"), version: 20252, deleted: false, device_id: "device-250", created_version: 20252 }
+RowDump { collection: "notes", pk: "new-device-250-000042", payload: Some("{\"k\": 42, \"edit\": \"insert\"}"), version: 20253, deleted: false, device_id: "device-250", created_version: 20253 }
+RowDump { collection: "notes", pk: "new-device-250-000043", payload: Some("{\"k\": 43, \"edit\": \"insert\"}"), version: 20254, deleted: false, device_id: "device-250", created_version: 20254 }
+RowDump { collection: "notes", pk: "new-device-250-000044", payload: Some("{\"k\": 44, \"edit\": \"insert\"}"), version: 20255, deleted: false, device_id: "device-250", created_version: 20255 }
+RowDump { collection: "notes", pk: "new-device-250-000045", payload: Some("{\"k\": 45, \"edit\": \"insert\"}"), version: 20256, deleted: false, device_id: "device-250", created_version: 20256 }
+RowDump { collection: "notes", pk: "new-device-250-000046", payload: Some("{\"k\": 46, \"edit\": \"insert\"}"), version: 20257, deleted: false, device_id: "device-250", created_version: 20257 }
+RowDump { collection: "notes", pk: "new-device-250-000047", payload: Some("{\"k\": 47, \"edit\": \"insert\"}"), version: 20258, deleted: false, device_id: "device-250", created_version: 20258 }
+RowDump { collection: "notes", pk: "new-device-250-000048", payload: Some("{\"k\": 48, \"edit\": \"insert\"}"), version: 20259, deleted: false, device_id: "device-250", created_version: 20259 }
+RowDump { collection: "notes", pk: "new-device-250-000049", payload: Some("{\"k\": 49, \"edit\": \"insert\"}"), version: 20260, deleted: false, device_id: "device-250", created_version: 20260 }
+RowDump { collection: "notes", pk: "newdup-device-250-000000", payload: Some("{\"p\": 0, \"edit\": \"dup-new-2\"}"), version: 20294, deleted: false, device_id: "device-250", created_version: 20293 }
+RowDump { collection: "notes", pk: "newdup-device-250-000001", payload: Some("{\"p\": 1, \"edit\": \"dup-new-2\"}"), version: 20296, deleted: false, device_id: "device-250", created_version: 20295 }
+RowDump { collection: "notes", pk: "newdup-device-250-000002", payload: Some("{\"p\": 2, \"edit\": \"dup-new-2\"}"), version: 20298, deleted: false, device_id: "device-250", created_version: 20297 }
+RowDump { collection: "notes", pk: "newdup-device-250-000003", payload: Some("{\"p\": 3, \"edit\": \"dup-new-2\"}"), version: 20300, deleted: false, device_id: "device-250", created_version: 20299 }
+-- row dump (existing pks touched by this batch), 182 rows --
+RowDump { collection: "notes", pk: "pk-00005001", payload: Some("{\"idx\": 5001, \"edit\": \"update\"}"), version: 20051, deleted: false, device_id: "device-250", created_version: 5001 }
+RowDump { collection: "notes", pk: "pk-00005002", payload: Some("{\"idx\": 5002, \"edit\": \"update\"}"), version: 20052, deleted: false, device_id: "device-250", created_version: 5002 }
+RowDump { collection: "notes", pk: "pk-00005003", payload: Some("{\"idx\": 5003, \"edit\": \"update\"}"), version: 20053, deleted: false, device_id: "device-250", created_version: 5003 }
+RowDump { collection: "notes", pk: "pk-00005004", payload: Some("{\"idx\": 5004, \"edit\": \"update\"}"), version: 20054, deleted: false, device_id: "device-250", created_version: 5004 }
+RowDump { collection: "notes", pk: "pk-00005005", payload: Some("{\"idx\": 5005, \"edit\": \"update\"}"), version: 20055, deleted: false, device_id: "device-250", created_version: 5005 }
+RowDump { collection: "notes", pk: "pk-00005006", payload: Some("{\"idx\": 5006, \"edit\": \"update\"}"), version: 20056, deleted: false, device_id: "device-250", created_version: 5006 }
+RowDump { collection: "notes", pk: "pk-00005007", payload: Some("{\"idx\": 5007, \"edit\": \"update\"}"), version: 20057, deleted: false, device_id: "device-250", created_version: 5007 }
+RowDump { collection: "notes", pk: "pk-00005008", payload: Some("{\"idx\": 5008, \"edit\": \"update\"}"), version: 20058, deleted: false, device_id: "device-250", created_version: 5008 }
+RowDump { collection: "notes", pk: "pk-00005009", payload: Some("{\"idx\": 5009, \"edit\": \"update\"}"), version: 20059, deleted: false, device_id: "device-250", created_version: 5009 }
+RowDump { collection: "notes", pk: "pk-00005010", payload: Some("{\"idx\": 5010, \"edit\": \"update\"}"), version: 20060, deleted: false, device_id: "device-250", created_version: 5010 }
+RowDump { collection: "notes", pk: "pk-00005011", payload: Some("{\"idx\": 5011, \"edit\": \"update\"}"), version: 20061, deleted: false, device_id: "device-250", created_version: 5011 }
+RowDump { collection: "notes", pk: "pk-00005012", payload: Some("{\"idx\": 5012, \"edit\": \"update\"}"), version: 20062, deleted: false, device_id: "device-250", created_version: 5012 }
+RowDump { collection: "notes", pk: "pk-00005013", payload: Some("{\"idx\": 5013, \"edit\": \"update\"}"), version: 20063, deleted: false, device_id: "device-250", created_version: 5013 }
+RowDump { collection: "notes", pk: "pk-00005014", payload: Some("{\"idx\": 5014, \"edit\": \"update\"}"), version: 20064, deleted: false, device_id: "device-250", created_version: 5014 }
+RowDump { collection: "notes", pk: "pk-00005015", payload: Some("{\"idx\": 5015, \"edit\": \"update\"}"), version: 20065, deleted: false, device_id: "device-250", created_version: 5015 }
+RowDump { collection: "notes", pk: "pk-00005016", payload: Some("{\"idx\": 5016, \"edit\": \"update\"}"), version: 20066, deleted: false, device_id: "device-250", created_version: 5016 }
+RowDump { collection: "notes", pk: "pk-00005017", payload: Some("{\"idx\": 5017, \"edit\": \"update\"}"), version: 20067, deleted: false, device_id: "device-250", created_version: 5017 }
+RowDump { collection: "notes", pk: "pk-00005018", payload: Some("{\"idx\": 5018, \"edit\": \"update\"}"), version: 20068, deleted: false, device_id: "device-250", created_version: 5018 }
+RowDump { collection: "notes", pk: "pk-00005019", payload: Some("{\"idx\": 5019, \"edit\": \"update\"}"), version: 20069, deleted: false, device_id: "device-250", created_version: 5019 }
+RowDump { collection: "notes", pk: "pk-00005021", payload: Some("{\"idx\": 5021, \"edit\": \"update\"}"), version: 20070, deleted: false, device_id: "device-250", created_version: 5021 }
+RowDump { collection: "notes", pk: "pk-00005022", payload: Some("{\"idx\": 5022, \"edit\": \"update\"}"), version: 20071, deleted: false, device_id: "device-250", created_version: 5022 }
+RowDump { collection: "notes", pk: "pk-00005023", payload: Some("{\"idx\": 5023, \"edit\": \"update\"}"), version: 20072, deleted: false, device_id: "device-250", created_version: 5023 }
+RowDump { collection: "notes", pk: "pk-00005024", payload: Some("{\"idx\": 5024, \"edit\": \"update\"}"), version: 20073, deleted: false, device_id: "device-250", created_version: 5024 }
+RowDump { collection: "notes", pk: "pk-00005025", payload: Some("{\"idx\": 5025, \"edit\": \"update\"}"), version: 20074, deleted: false, device_id: "device-250", created_version: 5025 }
+RowDump { collection: "notes", pk: "pk-00005026", payload: Some("{\"idx\": 5026, \"edit\": \"update\"}"), version: 20075, deleted: false, device_id: "device-250", created_version: 5026 }
+RowDump { collection: "notes", pk: "pk-00005027", payload: Some("{\"idx\": 5027, \"edit\": \"update\"}"), version: 20076, deleted: false, device_id: "device-250", created_version: 5027 }
+RowDump { collection: "notes", pk: "pk-00005028", payload: Some("{\"idx\": 5028, \"edit\": \"update\"}"), version: 20077, deleted: false, device_id: "device-250", created_version: 5028 }
+RowDump { collection: "notes", pk: "pk-00005029", payload: Some("{\"idx\": 5029, \"edit\": \"update\"}"), version: 20078, deleted: false, device_id: "device-250", created_version: 5029 }
+RowDump { collection: "notes", pk: "pk-00005030", payload: Some("{\"idx\": 5030, \"edit\": \"update\"}"), version: 20079, deleted: false, device_id: "device-250", created_version: 5030 }
+RowDump { collection: "notes", pk: "pk-00005031", payload: Some("{\"idx\": 5031, \"edit\": \"update\"}"), version: 20080, deleted: false, device_id: "device-250", created_version: 5031 }
+RowDump { collection: "notes", pk: "pk-00005032", payload: Some("{\"idx\": 5032, \"edit\": \"update\"}"), version: 20081, deleted: false, device_id: "device-250", created_version: 5032 }
+RowDump { collection: "notes", pk: "pk-00005033", payload: Some("{\"idx\": 5033, \"edit\": \"update\"}"), version: 20082, deleted: false, device_id: "device-250", created_version: 5033 }
+RowDump { collection: "notes", pk: "pk-00005034", payload: Some("{\"idx\": 5034, \"edit\": \"update\"}"), version: 20083, deleted: false, device_id: "device-250", created_version: 5034 }
+RowDump { collection: "notes", pk: "pk-00005035", payload: Some("{\"idx\": 5035, \"edit\": \"update\"}"), version: 20084, deleted: false, device_id: "device-250", created_version: 5035 }
+RowDump { collection: "notes", pk: "pk-00005036", payload: Some("{\"idx\": 5036, \"edit\": \"update\"}"), version: 20085, deleted: false, device_id: "device-250", created_version: 5036 }
+RowDump { collection: "notes", pk: "pk-00005037", payload: Some("{\"idx\": 5037, \"edit\": \"update\"}"), version: 20086, deleted: false, device_id: "device-250", created_version: 5037 }
+RowDump { collection: "notes", pk: "pk-00005038", payload: Some("{\"idx\": 5038, \"edit\": \"update\"}"), version: 20087, deleted: false, device_id: "device-250", created_version: 5038 }
+RowDump { collection: "notes", pk: "pk-00005039", payload: Some("{\"idx\": 5039, \"edit\": \"update\"}"), version: 20088, deleted: false, device_id: "device-250", created_version: 5039 }
+RowDump { collection: "contacts", pk: "pk-00005041", payload: Some("{\"idx\": 5041, \"edit\": \"update\"}"), version: 20089, deleted: false, device_id: "device-250", created_version: 5041 }
+RowDump { collection: "contacts", pk: "pk-00005042", payload: Some("{\"idx\": 5042, \"edit\": \"update\"}"), version: 20090, deleted: false, device_id: "device-250", created_version: 5042 }
+RowDump { collection: "contacts", pk: "pk-00005043", payload: Some("{\"idx\": 5043, \"edit\": \"update\"}"), version: 20091, deleted: false, device_id: "device-250", created_version: 5043 }
+RowDump { collection: "contacts", pk: "pk-00005044", payload: Some("{\"idx\": 5044, \"edit\": \"update\"}"), version: 20092, deleted: false, device_id: "device-250", created_version: 5044 }
+RowDump { collection: "contacts", pk: "pk-00005045", payload: Some("{\"idx\": 5045, \"edit\": \"update\"}"), version: 20093, deleted: false, device_id: "device-250", created_version: 5045 }
+RowDump { collection: "contacts", pk: "pk-00005046", payload: Some("{\"idx\": 5046, \"edit\": \"update\"}"), version: 20094, deleted: false, device_id: "device-250", created_version: 5046 }
+RowDump { collection: "contacts", pk: "pk-00005047", payload: Some("{\"idx\": 5047, \"edit\": \"update\"}"), version: 20095, deleted: false, device_id: "device-250", created_version: 5047 }
+RowDump { collection: "contacts", pk: "pk-00005048", payload: Some("{\"idx\": 5048, \"edit\": \"update\"}"), version: 20096, deleted: false, device_id: "device-250", created_version: 5048 }
+RowDump { collection: "contacts", pk: "pk-00005049", payload: Some("{\"idx\": 5049, \"edit\": \"update\"}"), version: 20097, deleted: false, device_id: "device-250", created_version: 5049 }
+RowDump { collection: "contacts", pk: "pk-00005050", payload: Some("{\"idx\": 5050, \"edit\": \"update\"}"), version: 20098, deleted: false, device_id: "device-250", created_version: 5050 }
+RowDump { collection: "contacts", pk: "pk-00005051", payload: Some("{\"idx\": 5051, \"edit\": \"update\"}"), version: 20099, deleted: false, device_id: "device-250", created_version: 5051 }
+RowDump { collection: "contacts", pk: "pk-00005052", payload: Some("{\"idx\": 5052, \"edit\": \"update\"}"), version: 20100, deleted: false, device_id: "device-250", created_version: 5052 }
+RowDump { collection: "contacts", pk: "pk-00005053", payload: Some("{\"idx\": 5053, \"edit\": \"update\"}"), version: 20101, deleted: false, device_id: "device-250", created_version: 5053 }
+RowDump { collection: "contacts", pk: "pk-00005054", payload: Some("{\"idx\": 5054, \"edit\": \"update\"}"), version: 20102, deleted: false, device_id: "device-250", created_version: 5054 }
+RowDump { collection: "contacts", pk: "pk-00005055", payload: Some("{\"idx\": 5055, \"edit\": \"update\"}"), version: 20103, deleted: false, device_id: "device-250", created_version: 5055 }
+RowDump { collection: "contacts", pk: "pk-00005056", payload: Some("{\"idx\": 5056, \"edit\": \"update\"}"), version: 20104, deleted: false, device_id: "device-250", created_version: 5056 }
+RowDump { collection: "contacts", pk: "pk-00005057", payload: Some("{\"idx\": 5057, \"edit\": \"update\"}"), version: 20105, deleted: false, device_id: "device-250", created_version: 5057 }
+RowDump { collection: "contacts", pk: "pk-00005058", payload: Some("{\"idx\": 5058, \"edit\": \"update\"}"), version: 20106, deleted: false, device_id: "device-250", created_version: 5058 }
+RowDump { collection: "contacts", pk: "pk-00005059", payload: Some("{\"idx\": 5059, \"edit\": \"update\"}"), version: 20107, deleted: false, device_id: "device-250", created_version: 5059 }
+RowDump { collection: "tasks", pk: "pk-00005061", payload: Some("{\"idx\": 5061, \"edit\": \"update\"}"), version: 20108, deleted: false, device_id: "device-250", created_version: 5061 }
+RowDump { collection: "tasks", pk: "pk-00005062", payload: Some("{\"idx\": 5062, \"edit\": \"update\"}"), version: 20109, deleted: false, device_id: "device-250", created_version: 5062 }
+RowDump { collection: "tasks", pk: "pk-00005063", payload: Some("{\"idx\": 5063, \"edit\": \"update\"}"), version: 20110, deleted: false, device_id: "device-250", created_version: 5063 }
+RowDump { collection: "tasks", pk: "pk-00005064", payload: Some("{\"idx\": 5064, \"edit\": \"update\"}"), version: 20111, deleted: false, device_id: "device-250", created_version: 5064 }
+RowDump { collection: "tasks", pk: "pk-00005065", payload: Some("{\"idx\": 5065, \"edit\": \"update\"}"), version: 20112, deleted: false, device_id: "device-250", created_version: 5065 }
+RowDump { collection: "tasks", pk: "pk-00005066", payload: Some("{\"idx\": 5066, \"edit\": \"update\"}"), version: 20113, deleted: false, device_id: "device-250", created_version: 5066 }
+RowDump { collection: "tasks", pk: "pk-00005067", payload: Some("{\"idx\": 5067, \"edit\": \"update\"}"), version: 20114, deleted: false, device_id: "device-250", created_version: 5067 }
+RowDump { collection: "tasks", pk: "pk-00005068", payload: Some("{\"idx\": 5068, \"edit\": \"update\"}"), version: 20115, deleted: false, device_id: "device-250", created_version: 5068 }
+RowDump { collection: "tasks", pk: "pk-00005069", payload: Some("{\"idx\": 5069, \"edit\": \"update\"}"), version: 20116, deleted: false, device_id: "device-250", created_version: 5069 }
+RowDump { collection: "tasks", pk: "pk-00005070", payload: Some("{\"idx\": 5070, \"edit\": \"update\"}"), version: 20117, deleted: false, device_id: "device-250", created_version: 5070 }
+RowDump { collection: "tasks", pk: "pk-00005071", payload: Some("{\"idx\": 5071, \"edit\": \"update\"}"), version: 20118, deleted: false, device_id: "device-250", created_version: 5071 }
+RowDump { collection: "tasks", pk: "pk-00005072", payload: Some("{\"idx\": 5072, \"edit\": \"update\"}"), version: 20119, deleted: false, device_id: "device-250", created_version: 5072 }
+RowDump { collection: "tasks", pk: "pk-00005073", payload: Some("{\"idx\": 5073, \"edit\": \"update\"}"), version: 20120, deleted: false, device_id: "device-250", created_version: 5073 }
+RowDump { collection: "tasks", pk: "pk-00005074", payload: Some("{\"idx\": 5074, \"edit\": \"update\"}"), version: 20121, deleted: false, device_id: "device-250", created_version: 5074 }
+RowDump { collection: "files", pk: "pk-00005075", payload: Some("{\"idx\": 5075, \"edit\": \"update\"}"), version: 20122, deleted: false, device_id: "device-250", created_version: 5075 }
+RowDump { collection: "files", pk: "pk-00005076", payload: Some("{\"idx\": 5076, \"edit\": \"update\"}"), version: 20123, deleted: false, device_id: "device-250", created_version: 5076 }
+RowDump { collection: "files", pk: "pk-00005077", payload: Some("{\"idx\": 5077, \"edit\": \"update\"}"), version: 20124, deleted: false, device_id: "device-250", created_version: 5077 }
+RowDump { collection: "files", pk: "pk-00005078", payload: Some("{\"idx\": 5078, \"edit\": \"update\"}"), version: 20125, deleted: false, device_id: "device-250", created_version: 5078 }
+RowDump { collection: "files", pk: "pk-00005079", payload: Some("{\"idx\": 5079, \"edit\": \"update\"}"), version: 20126, deleted: false, device_id: "device-250", created_version: 5079 }
+RowDump { collection: "files", pk: "pk-00005081", payload: Some("{\"idx\": 5081, \"edit\": \"update\"}"), version: 20127, deleted: false, device_id: "device-250", created_version: 5081 }
+RowDump { collection: "files", pk: "pk-00005082", payload: Some("{\"idx\": 5082, \"edit\": \"update\"}"), version: 20128, deleted: false, device_id: "device-250", created_version: 5082 }
+RowDump { collection: "files", pk: "pk-00005083", payload: Some("{\"idx\": 5083, \"edit\": \"update\"}"), version: 20129, deleted: false, device_id: "device-250", created_version: 5083 }
+RowDump { collection: "files", pk: "pk-00005084", payload: Some("{\"idx\": 5084, \"edit\": \"update\"}"), version: 20130, deleted: false, device_id: "device-250", created_version: 5084 }
+RowDump { collection: "files", pk: "pk-00005085", payload: Some("{\"idx\": 5085, \"edit\": \"update\"}"), version: 20131, deleted: false, device_id: "device-250", created_version: 5085 }
+RowDump { collection: "files", pk: "pk-00005086", payload: Some("{\"idx\": 5086, \"edit\": \"update\"}"), version: 20132, deleted: false, device_id: "device-250", created_version: 5086 }
+RowDump { collection: "files", pk: "pk-00005087", payload: Some("{\"idx\": 5087, \"edit\": \"update\"}"), version: 20133, deleted: false, device_id: "device-250", created_version: 5087 }
+RowDump { collection: "files", pk: "pk-00005088", payload: Some("{\"idx\": 5088, \"edit\": \"update\"}"), version: 20134, deleted: false, device_id: "device-250", created_version: 5088 }
+RowDump { collection: "files", pk: "pk-00005089", payload: Some("{\"idx\": 5089, \"edit\": \"update\"}"), version: 20135, deleted: false, device_id: "device-250", created_version: 5089 }
+RowDump { collection: "tags", pk: "pk-00005090", payload: Some("{\"idx\": 5090, \"edit\": \"update\"}"), version: 20136, deleted: false, device_id: "device-250", created_version: 5090 }
+RowDump { collection: "tags", pk: "pk-00005091", payload: Some("{\"idx\": 5091, \"edit\": \"update\"}"), version: 20137, deleted: false, device_id: "device-250", created_version: 5091 }
+RowDump { collection: "tags", pk: "pk-00005092", payload: Some("{\"idx\": 5092, \"edit\": \"update\"}"), version: 20138, deleted: false, device_id: "device-250", created_version: 5092 }
+RowDump { collection: "tags", pk: "pk-00005093", payload: Some("{\"idx\": 5093, \"edit\": \"update\"}"), version: 20139, deleted: false, device_id: "device-250", created_version: 5093 }
+RowDump { collection: "tags", pk: "pk-00005094", payload: Some("{\"idx\": 5094, \"edit\": \"update\"}"), version: 20140, deleted: false, device_id: "device-250", created_version: 5094 }
+RowDump { collection: "tags", pk: "pk-00005095", payload: Some("{\"idx\": 5095, \"edit\": \"update\"}"), version: 20141, deleted: false, device_id: "device-250", created_version: 5095 }
+RowDump { collection: "tags", pk: "pk-00005096", payload: Some("{\"idx\": 5096, \"edit\": \"update\"}"), version: 20142, deleted: false, device_id: "device-250", created_version: 5096 }
+RowDump { collection: "archive", pk: "pk-00005097", payload: Some("{\"idx\": 5097, \"edit\": \"update\"}"), version: 20143, deleted: false, device_id: "device-250", created_version: 5097 }
+RowDump { collection: "archive", pk: "pk-00005098", payload: Some("{\"idx\": 5098, \"edit\": \"update\"}"), version: 20144, deleted: false, device_id: "device-250", created_version: 5098 }
+RowDump { collection: "archive", pk: "pk-00005099", payload: Some("{\"idx\": 5099, \"edit\": \"update\"}"), version: 20145, deleted: false, device_id: "device-250", created_version: 5099 }
+RowDump { collection: "notes", pk: "pk-00005101", payload: Some("{\"idx\": 5101, \"edit\": \"update\"}"), version: 20146, deleted: false, device_id: "device-250", created_version: 5101 }
+RowDump { collection: "notes", pk: "pk-00005102", payload: Some("{\"idx\": 5102, \"edit\": \"update\"}"), version: 20147, deleted: false, device_id: "device-250", created_version: 5102 }
+RowDump { collection: "notes", pk: "pk-00005103", payload: Some("{\"idx\": 5103, \"edit\": \"update\"}"), version: 20148, deleted: false, device_id: "device-250", created_version: 5103 }
+RowDump { collection: "notes", pk: "pk-00005104", payload: Some("{\"idx\": 5104, \"edit\": \"update\"}"), version: 20149, deleted: false, device_id: "device-250", created_version: 5104 }
+RowDump { collection: "notes", pk: "pk-00005105", payload: Some("{\"idx\": 5105, \"edit\": \"update\"}"), version: 20150, deleted: false, device_id: "device-250", created_version: 5105 }
+RowDump { collection: "notes", pk: "pk-00005106", payload: Some("{\"idx\": 5106, \"edit\": \"update\"}"), version: 20151, deleted: false, device_id: "device-250", created_version: 5106 }
+RowDump { collection: "notes", pk: "pk-00005107", payload: Some("{\"idx\": 5107, \"edit\": \"update\"}"), version: 20152, deleted: false, device_id: "device-250", created_version: 5107 }
+RowDump { collection: "notes", pk: "pk-00005108", payload: Some("{\"idx\": 5108, \"edit\": \"update\"}"), version: 20153, deleted: false, device_id: "device-250", created_version: 5108 }
+RowDump { collection: "notes", pk: "pk-00005109", payload: Some("{\"idx\": 5109, \"edit\": \"update\"}"), version: 20154, deleted: false, device_id: "device-250", created_version: 5109 }
+RowDump { collection: "notes", pk: "pk-00005110", payload: Some("{\"idx\": 5110, \"edit\": \"update\"}"), version: 20155, deleted: false, device_id: "device-250", created_version: 5110 }
+RowDump { collection: "notes", pk: "pk-00005111", payload: Some("{\"idx\": 5111, \"edit\": \"update\"}"), version: 20156, deleted: false, device_id: "device-250", created_version: 5111 }
+RowDump { collection: "notes", pk: "pk-00005112", payload: Some("{\"idx\": 5112, \"edit\": \"update\"}"), version: 20157, deleted: false, device_id: "device-250", created_version: 5112 }
+RowDump { collection: "notes", pk: "pk-00005113", payload: Some("{\"idx\": 5113, \"edit\": \"update\"}"), version: 20158, deleted: false, device_id: "device-250", created_version: 5113 }
+RowDump { collection: "notes", pk: "pk-00005114", payload: Some("{\"idx\": 5114, \"edit\": \"update\"}"), version: 20159, deleted: false, device_id: "device-250", created_version: 5114 }
+RowDump { collection: "notes", pk: "pk-00005115", payload: Some("{\"idx\": 5115, \"edit\": \"update\"}"), version: 20160, deleted: false, device_id: "device-250", created_version: 5115 }
+RowDump { collection: "notes", pk: "pk-00005116", payload: Some("{\"idx\": 5116, \"edit\": \"update\"}"), version: 20161, deleted: false, device_id: "device-250", created_version: 5116 }
+RowDump { collection: "notes", pk: "pk-00005117", payload: Some("{\"idx\": 5117, \"edit\": \"update\"}"), version: 20162, deleted: false, device_id: "device-250", created_version: 5117 }
+RowDump { collection: "notes", pk: "pk-00005118", payload: Some("{\"idx\": 5118, \"edit\": \"update\"}"), version: 20163, deleted: false, device_id: "device-250", created_version: 5118 }
+RowDump { collection: "notes", pk: "pk-00005119", payload: Some("{\"idx\": 5119, \"edit\": \"update\"}"), version: 20164, deleted: false, device_id: "device-250", created_version: 5119 }
+RowDump { collection: "notes", pk: "pk-00005121", payload: Some("{\"idx\": 5121, \"edit\": \"update\"}"), version: 20165, deleted: false, device_id: "device-250", created_version: 5121 }
+RowDump { collection: "notes", pk: "pk-00005122", payload: Some("{\"idx\": 5122, \"edit\": \"update\"}"), version: 20166, deleted: false, device_id: "device-250", created_version: 5122 }
+RowDump { collection: "notes", pk: "pk-00005123", payload: Some("{\"idx\": 5123, \"edit\": \"update\"}"), version: 20167, deleted: false, device_id: "device-250", created_version: 5123 }
+RowDump { collection: "notes", pk: "pk-00005124", payload: Some("{\"idx\": 5124, \"edit\": \"update\"}"), version: 20168, deleted: false, device_id: "device-250", created_version: 5124 }
+RowDump { collection: "notes", pk: "pk-00005125", payload: Some("{\"idx\": 5125, \"edit\": \"update\"}"), version: 20169, deleted: false, device_id: "device-250", created_version: 5125 }
+RowDump { collection: "notes", pk: "pk-00005126", payload: Some("{\"idx\": 5126, \"edit\": \"update\"}"), version: 20170, deleted: false, device_id: "device-250", created_version: 5126 }
+RowDump { collection: "notes", pk: "pk-00005127", payload: Some("{\"idx\": 5127, \"edit\": \"update\"}"), version: 20171, deleted: false, device_id: "device-250", created_version: 5127 }
+RowDump { collection: "notes", pk: "pk-00005128", payload: Some("{\"idx\": 5128, \"edit\": \"update\"}"), version: 20172, deleted: false, device_id: "device-250", created_version: 5128 }
+RowDump { collection: "notes", pk: "pk-00005129", payload: Some("{\"idx\": 5129, \"edit\": \"update\"}"), version: 20173, deleted: false, device_id: "device-250", created_version: 5129 }
+RowDump { collection: "notes", pk: "pk-00005130", payload: Some("{\"idx\": 5130, \"edit\": \"update\"}"), version: 20174, deleted: false, device_id: "device-250", created_version: 5130 }
+RowDump { collection: "notes", pk: "pk-00005131", payload: Some("{\"idx\": 5131, \"edit\": \"update\"}"), version: 20175, deleted: false, device_id: "device-250", created_version: 5131 }
+RowDump { collection: "notes", pk: "pk-00005132", payload: Some("{\"idx\": 5132, \"edit\": \"update\"}"), version: 20176, deleted: false, device_id: "device-250", created_version: 5132 }
+RowDump { collection: "notes", pk: "pk-00005133", payload: Some("{\"idx\": 5133, \"edit\": \"update\"}"), version: 20177, deleted: false, device_id: "device-250", created_version: 5133 }
+RowDump { collection: "notes", pk: "pk-00005134", payload: Some("{\"idx\": 5134, \"edit\": \"update\"}"), version: 20178, deleted: false, device_id: "device-250", created_version: 5134 }
+RowDump { collection: "notes", pk: "pk-00005135", payload: Some("{\"idx\": 5135, \"edit\": \"update\"}"), version: 20179, deleted: false, device_id: "device-250", created_version: 5135 }
+RowDump { collection: "notes", pk: "pk-00005136", payload: Some("{\"idx\": 5136, \"edit\": \"update\"}"), version: 20180, deleted: false, device_id: "device-250", created_version: 5136 }
+RowDump { collection: "notes", pk: "pk-00005137", payload: Some("{\"idx\": 5137, \"edit\": \"update\"}"), version: 20181, deleted: false, device_id: "device-250", created_version: 5137 }
+RowDump { collection: "notes", pk: "pk-00005138", payload: Some("{\"idx\": 5138, \"edit\": \"update\"}"), version: 20182, deleted: false, device_id: "device-250", created_version: 5138 }
+RowDump { collection: "notes", pk: "pk-00005139", payload: Some("{\"idx\": 5139, \"edit\": \"update\"}"), version: 20183, deleted: false, device_id: "device-250", created_version: 5139 }
+RowDump { collection: "contacts", pk: "pk-00005141", payload: Some("{\"idx\": 5141, \"edit\": \"update\"}"), version: 20184, deleted: false, device_id: "device-250", created_version: 5141 }
+RowDump { collection: "contacts", pk: "pk-00005142", payload: Some("{\"idx\": 5142, \"edit\": \"update\"}"), version: 20185, deleted: false, device_id: "device-250", created_version: 5142 }
+RowDump { collection: "contacts", pk: "pk-00005143", payload: Some("{\"idx\": 5143, \"edit\": \"update\"}"), version: 20186, deleted: false, device_id: "device-250", created_version: 5143 }
+RowDump { collection: "contacts", pk: "pk-00005144", payload: Some("{\"idx\": 5144, \"edit\": \"update\"}"), version: 20187, deleted: false, device_id: "device-250", created_version: 5144 }
+RowDump { collection: "contacts", pk: "pk-00005145", payload: Some("{\"idx\": 5145, \"edit\": \"update\"}"), version: 20188, deleted: false, device_id: "device-250", created_version: 5145 }
+RowDump { collection: "contacts", pk: "pk-00005146", payload: Some("{\"idx\": 5146, \"edit\": \"update\"}"), version: 20189, deleted: false, device_id: "device-250", created_version: 5146 }
+RowDump { collection: "contacts", pk: "pk-00005147", payload: Some("{\"idx\": 5147, \"edit\": \"update\"}"), version: 20190, deleted: false, device_id: "device-250", created_version: 5147 }
+RowDump { collection: "contacts", pk: "pk-00005148", payload: Some("{\"idx\": 5148, \"edit\": \"update\"}"), version: 20191, deleted: false, device_id: "device-250", created_version: 5148 }
+RowDump { collection: "contacts", pk: "pk-00005149", payload: Some("{\"idx\": 5149, \"edit\": \"update\"}"), version: 20192, deleted: false, device_id: "device-250", created_version: 5149 }
+RowDump { collection: "contacts", pk: "pk-00005150", payload: Some("{\"idx\": 5150, \"edit\": \"update\"}"), version: 20193, deleted: false, device_id: "device-250", created_version: 5150 }
+RowDump { collection: "contacts", pk: "pk-00005151", payload: Some("{\"idx\": 5151, \"edit\": \"update\"}"), version: 20194, deleted: false, device_id: "device-250", created_version: 5151 }
+RowDump { collection: "contacts", pk: "pk-00005152", payload: Some("{\"idx\": 5152, \"edit\": \"update\"}"), version: 20195, deleted: false, device_id: "device-250", created_version: 5152 }
+RowDump { collection: "contacts", pk: "pk-00005153", payload: Some("{\"idx\": 5153, \"edit\": \"update\"}"), version: 20196, deleted: false, device_id: "device-250", created_version: 5153 }
+RowDump { collection: "contacts", pk: "pk-00005154", payload: Some("{\"idx\": 5154, \"edit\": \"update\"}"), version: 20197, deleted: false, device_id: "device-250", created_version: 5154 }
+RowDump { collection: "contacts", pk: "pk-00005155", payload: Some("{\"idx\": 5155, \"edit\": \"update\"}"), version: 20198, deleted: false, device_id: "device-250", created_version: 5155 }
+RowDump { collection: "contacts", pk: "pk-00005156", payload: Some("{\"idx\": 5156, \"edit\": \"update\"}"), version: 20199, deleted: false, device_id: "device-250", created_version: 5156 }
+RowDump { collection: "contacts", pk: "pk-00005157", payload: Some("{\"idx\": 5157, \"edit\": \"update\"}"), version: 20200, deleted: false, device_id: "device-250", created_version: 5157 }
+RowDump { collection: "contacts", pk: "pk-00005158", payload: Some("{\"idx\": 5158, \"edit\": \"update\"}"), version: 20201, deleted: false, device_id: "device-250", created_version: 5158 }
+RowDump { collection: "contacts", pk: "pk-00005159", payload: Some("{\"idx\": 5159, \"edit\": \"update\"}"), version: 20202, deleted: false, device_id: "device-250", created_version: 5159 }
+RowDump { collection: "tasks", pk: "pk-00005161", payload: Some("{\"idx\": 5161, \"edit\": \"update\"}"), version: 20203, deleted: false, device_id: "device-250", created_version: 5161 }
+RowDump { collection: "tasks", pk: "pk-00005162", payload: Some("{\"idx\": 5162, \"edit\": \"update\"}"), version: 20204, deleted: false, device_id: "device-250", created_version: 5162 }
+RowDump { collection: "tasks", pk: "pk-00005163", payload: Some("{\"idx\": 5163, \"edit\": \"update\"}"), version: 20205, deleted: false, device_id: "device-250", created_version: 5163 }
+RowDump { collection: "tasks", pk: "pk-00005164", payload: Some("{\"idx\": 5164, \"edit\": \"update\"}"), version: 20206, deleted: false, device_id: "device-250", created_version: 5164 }
+RowDump { collection: "tasks", pk: "pk-00005165", payload: Some("{\"idx\": 5165, \"edit\": \"update\"}"), version: 20207, deleted: false, device_id: "device-250", created_version: 5165 }
+RowDump { collection: "tasks", pk: "pk-00005166", payload: Some("{\"idx\": 5166, \"edit\": \"update\"}"), version: 20208, deleted: false, device_id: "device-250", created_version: 5166 }
+RowDump { collection: "tasks", pk: "pk-00005167", payload: Some("{\"idx\": 5167, \"edit\": \"update\"}"), version: 20209, deleted: false, device_id: "device-250", created_version: 5167 }
+RowDump { collection: "tasks", pk: "pk-00005168", payload: Some("{\"idx\": 5168, \"edit\": \"update\"}"), version: 20210, deleted: false, device_id: "device-250", created_version: 5168 }
+RowDump { collection: "tasks", pk: "pk-00005169", payload: None, version: 20261, deleted: true, device_id: "device-250", created_version: 5169 }
+RowDump { collection: "tasks", pk: "pk-00005170", payload: None, version: 20262, deleted: true, device_id: "device-250", created_version: 5170 }
+RowDump { collection: "tasks", pk: "pk-00005171", payload: None, version: 20263, deleted: true, device_id: "device-250", created_version: 5171 }
+RowDump { collection: "tasks", pk: "pk-00005172", payload: None, version: 20264, deleted: true, device_id: "device-250", created_version: 5172 }
+RowDump { collection: "tasks", pk: "pk-00005173", payload: None, version: 20265, deleted: true, device_id: "device-250", created_version: 5173 }
+RowDump { collection: "tasks", pk: "pk-00005174", payload: None, version: 20266, deleted: true, device_id: "device-250", created_version: 5174 }
+RowDump { collection: "files", pk: "pk-00005175", payload: None, version: 20267, deleted: true, device_id: "device-250", created_version: 5175 }
+RowDump { collection: "files", pk: "pk-00005176", payload: None, version: 20268, deleted: true, device_id: "device-250", created_version: 5176 }
+RowDump { collection: "files", pk: "pk-00005177", payload: None, version: 20269, deleted: true, device_id: "device-250", created_version: 5177 }
+RowDump { collection: "files", pk: "pk-00005178", payload: None, version: 20270, deleted: true, device_id: "device-250", created_version: 5178 }
+RowDump { collection: "files", pk: "pk-00005179", payload: None, version: 20271, deleted: true, device_id: "device-250", created_version: 5179 }
+RowDump { collection: "files", pk: "pk-00005181", payload: None, version: 20272, deleted: true, device_id: "device-250", created_version: 5181 }
+RowDump { collection: "files", pk: "pk-00005182", payload: Some("{\"p\": 0, \"edit\": \"dup-existing-2\"}"), version: 20274, deleted: false, device_id: "device-250", created_version: 5182 }
+RowDump { collection: "files", pk: "pk-00005183", payload: Some("{\"p\": 1, \"edit\": \"dup-existing-2\"}"), version: 20276, deleted: false, device_id: "device-250", created_version: 5183 }
+RowDump { collection: "files", pk: "pk-00005184", payload: Some("{\"p\": 2, \"edit\": \"dup-existing-2\"}"), version: 20278, deleted: false, device_id: "device-250", created_version: 5184 }
+RowDump { collection: "files", pk: "pk-00005185", payload: Some("{\"p\": 3, \"edit\": \"dup-existing-2\"}"), version: 20280, deleted: false, device_id: "device-250", created_version: 5185 }
+RowDump { collection: "files", pk: "pk-00005186", payload: Some("{\"p\": 4, \"edit\": \"dup-existing-2\"}"), version: 20282, deleted: false, device_id: "device-250", created_version: 5186 }
+RowDump { collection: "files", pk: "pk-00005187", payload: Some("{\"p\": 5, \"edit\": \"dup-existing-2\"}"), version: 20284, deleted: false, device_id: "device-250", created_version: 5187 }
+RowDump { collection: "files", pk: "pk-00005188", payload: Some("{\"p\": 6, \"edit\": \"dup-existing-2\"}"), version: 20286, deleted: false, device_id: "device-250", created_version: 5188 }
+RowDump { collection: "files", pk: "pk-00005189", payload: Some("{\"p\": 7, \"edit\": \"dup-existing-2\"}"), version: 20288, deleted: false, device_id: "device-250", created_version: 5189 }
+RowDump { collection: "tags", pk: "pk-00005190", payload: Some("{\"p\": 8, \"edit\": \"dup-existing-2\"}"), version: 20290, deleted: false, device_id: "device-250", created_version: 5190 }
+RowDump { collection: "tags", pk: "pk-00005191", payload: Some("{\"p\": 9, \"edit\": \"dup-existing-2\"}"), version: 20292, deleted: false, device_id: "device-250", created_version: 5191 }
+
+=== pg_stat_statements: push batch of 1000 changes ===
+-- top by calls --
+calls=1000   buffers=1012   SELECT nextval($1) AS version
+calls=1000   buffers=12401  INSERT INTO autumn_sync_rows (scope, collection, pk, payload, version, deleted, updated_at, device_id, created_version) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9) ON CONFLICT (scope, collection, pk) DO UPDATE SET payload = excluded.payload, version = excluded.version, deleted = excluded.deleted, updated_at = excluded.updated_at, device_id = excluded.device_id, created_version = excluded.created_version
+calls=1000   buffers=3055   INSERT INTO autumn_sync_applied (scope, device_id, change_id, version, resolved_row) VALUES ($1, $2, $3, $4, $5)
+calls=1000   buffers=2076   SELECT version, resolved_row FROM autumn_sync_applied WHERE scope = $1 AND device_id = $2 AND change_id = $3
+calls=1000   buffers=4828   SELECT collection, pk, payload, version, deleted, updated_at, device_id, created_version FROM autumn_sync_rows WHERE scope = $1 AND collection = $2 AND pk = $3 FOR UPDATE
+calls=1      buffers=0      SELECT horizon AS version FROM autumn_sync_horizons WHERE scope = $1
+-- top by buffers --
+buffers=12401  calls=1000   INSERT INTO autumn_sync_rows (scope, collection, pk, payload, version, deleted, updated_at, device_id, created_version) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9) ON CONFLICT (scope, collection, pk) DO UPDATE SET payload = excluded.payload, version = excluded.version, deleted = excluded.deleted, updated_at = excluded.updated_at, device_id = excluded.device_id, created_version = excluded.created_version
+buffers=4828   calls=1000   SELECT collection, pk, payload, version, deleted, updated_at, device_id, created_version FROM autumn_sync_rows WHERE scope = $1 AND collection = $2 AND pk = $3 FOR UPDATE
+buffers=3055   calls=1000   INSERT INTO autumn_sync_applied (scope, device_id, change_id, version, resolved_row) VALUES ($1, $2, $3, $4, $5)
+buffers=2076   calls=1000   SELECT version, resolved_row FROM autumn_sync_applied WHERE scope = $1 AND device_id = $2 AND change_id = $3
+buffers=1012   calls=1000   SELECT nextval($1) AS version
+buffers=0      calls=1      SELECT horizon AS version FROM autumn_sync_horizons WHERE scope = $1
+TOTAL sync-table statement calls=5001 buffers=23372 (this batch, all statement shapes)
+-- row dump (new/newdup pks), 210 rows --
+RowDump { collection: "notes", pk: "new-device-1000-000000", payload: Some("{\"k\": 0, \"edit\": \"insert\"}"), version: 20951, deleted: false, device_id: "device-1000", created_version: 20951 }
+RowDump { collection: "notes", pk: "new-device-1000-000001", payload: Some("{\"k\": 1, \"edit\": \"insert\"}"), version: 20952, deleted: false, device_id: "device-1000", created_version: 20952 }
+RowDump { collection: "notes", pk: "new-device-1000-000002", payload: Some("{\"k\": 2, \"edit\": \"insert\"}"), version: 20953, deleted: false, device_id: "device-1000", created_version: 20953 }
+RowDump { collection: "notes", pk: "new-device-1000-000003", payload: Some("{\"k\": 3, \"edit\": \"insert\"}"), version: 20954, deleted: false, device_id: "device-1000", created_version: 20954 }
+RowDump { collection: "notes", pk: "new-device-1000-000004", payload: Some("{\"k\": 4, \"edit\": \"insert\"}"), version: 20955, deleted: false, device_id: "device-1000", created_version: 20955 }
+RowDump { collection: "notes", pk: "new-device-1000-000005", payload: Some("{\"k\": 5, \"edit\": \"insert\"}"), version: 20956, deleted: false, device_id: "device-1000", created_version: 20956 }
+RowDump { collection: "notes", pk: "new-device-1000-000006", payload: Some("{\"k\": 6, \"edit\": \"insert\"}"), version: 20957, deleted: false, device_id: "device-1000", created_version: 20957 }
+RowDump { collection: "notes", pk: "new-device-1000-000007", payload: Some("{\"k\": 7, \"edit\": \"insert\"}"), version: 20958, deleted: false, device_id: "device-1000", created_version: 20958 }
+RowDump { collection: "notes", pk: "new-device-1000-000008", payload: Some("{\"k\": 8, \"edit\": \"insert\"}"), version: 20959, deleted: false, device_id: "device-1000", created_version: 20959 }
+RowDump { collection: "notes", pk: "new-device-1000-000009", payload: Some("{\"k\": 9, \"edit\": \"insert\"}"), version: 20960, deleted: false, device_id: "device-1000", created_version: 20960 }
+RowDump { collection: "notes", pk: "new-device-1000-000010", payload: Some("{\"k\": 10, \"edit\": \"insert\"}"), version: 20961, deleted: false, device_id: "device-1000", created_version: 20961 }
+RowDump { collection: "notes", pk: "new-device-1000-000011", payload: Some("{\"k\": 11, \"edit\": \"insert\"}"), version: 20962, deleted: false, device_id: "device-1000", created_version: 20962 }
+RowDump { collection: "notes", pk: "new-device-1000-000012", payload: Some("{\"k\": 12, \"edit\": \"insert\"}"), version: 20963, deleted: false, device_id: "device-1000", created_version: 20963 }
+RowDump { collection: "notes", pk: "new-device-1000-000013", payload: Some("{\"k\": 13, \"edit\": \"insert\"}"), version: 20964, deleted: false, device_id: "device-1000", created_version: 20964 }
+RowDump { collection: "notes", pk: "new-device-1000-000014", payload: Some("{\"k\": 14, \"edit\": \"insert\"}"), version: 20965, deleted: false, device_id: "device-1000", created_version: 20965 }
+RowDump { collection: "notes", pk: "new-device-1000-000015", payload: Some("{\"k\": 15, \"edit\": \"insert\"}"), version: 20966, deleted: false, device_id: "device-1000", created_version: 20966 }
+RowDump { collection: "notes", pk: "new-device-1000-000016", payload: Some("{\"k\": 16, \"edit\": \"insert\"}"), version: 20967, deleted: false, device_id: "device-1000", created_version: 20967 }
+RowDump { collection: "notes", pk: "new-device-1000-000017", payload: Some("{\"k\": 17, \"edit\": \"insert\"}"), version: 20968, deleted: false, device_id: "device-1000", created_version: 20968 }
+RowDump { collection: "notes", pk: "new-device-1000-000018", payload: Some("{\"k\": 18, \"edit\": \"insert\"}"), version: 20969, deleted: false, device_id: "device-1000", created_version: 20969 }
+RowDump { collection: "notes", pk: "new-device-1000-000019", payload: Some("{\"k\": 19, \"edit\": \"insert\"}"), version: 20970, deleted: false, device_id: "device-1000", created_version: 20970 }
+RowDump { collection: "notes", pk: "new-device-1000-000020", payload: Some("{\"k\": 20, \"edit\": \"insert\"}"), version: 20971, deleted: false, device_id: "device-1000", created_version: 20971 }
+RowDump { collection: "notes", pk: "new-device-1000-000021", payload: Some("{\"k\": 21, \"edit\": \"insert\"}"), version: 20972, deleted: false, device_id: "device-1000", created_version: 20972 }
+RowDump { collection: "notes", pk: "new-device-1000-000022", payload: Some("{\"k\": 22, \"edit\": \"insert\"}"), version: 20973, deleted: false, device_id: "device-1000", created_version: 20973 }
+RowDump { collection: "notes", pk: "new-device-1000-000023", payload: Some("{\"k\": 23, \"edit\": \"insert\"}"), version: 20974, deleted: false, device_id: "device-1000", created_version: 20974 }
+RowDump { collection: "notes", pk: "new-device-1000-000024", payload: Some("{\"k\": 24, \"edit\": \"insert\"}"), version: 20975, deleted: false, device_id: "device-1000", created_version: 20975 }
+RowDump { collection: "notes", pk: "new-device-1000-000025", payload: Some("{\"k\": 25, \"edit\": \"insert\"}"), version: 20976, deleted: false, device_id: "device-1000", created_version: 20976 }
+RowDump { collection: "notes", pk: "new-device-1000-000026", payload: Some("{\"k\": 26, \"edit\": \"insert\"}"), version: 20977, deleted: false, device_id: "device-1000", created_version: 20977 }
+RowDump { collection: "notes", pk: "new-device-1000-000027", payload: Some("{\"k\": 27, \"edit\": \"insert\"}"), version: 20978, deleted: false, device_id: "device-1000", created_version: 20978 }
+RowDump { collection: "notes", pk: "new-device-1000-000028", payload: Some("{\"k\": 28, \"edit\": \"insert\"}"), version: 20979, deleted: false, device_id: "device-1000", created_version: 20979 }
+RowDump { collection: "notes", pk: "new-device-1000-000029", payload: Some("{\"k\": 29, \"edit\": \"insert\"}"), version: 20980, deleted: false, device_id: "device-1000", created_version: 20980 }
+RowDump { collection: "notes", pk: "new-device-1000-000030", payload: Some("{\"k\": 30, \"edit\": \"insert\"}"), version: 20981, deleted: false, device_id: "device-1000", created_version: 20981 }
+RowDump { collection: "notes", pk: "new-device-1000-000031", payload: Some("{\"k\": 31, \"edit\": \"insert\"}"), version: 20982, deleted: false, device_id: "device-1000", created_version: 20982 }
+RowDump { collection: "notes", pk: "new-device-1000-000032", payload: Some("{\"k\": 32, \"edit\": \"insert\"}"), version: 20983, deleted: false, device_id: "device-1000", created_version: 20983 }
+RowDump { collection: "notes", pk: "new-device-1000-000033", payload: Some("{\"k\": 33, \"edit\": \"insert\"}"), version: 20984, deleted: false, device_id: "device-1000", created_version: 20984 }
+RowDump { collection: "notes", pk: "new-device-1000-000034", payload: Some("{\"k\": 34, \"edit\": \"insert\"}"), version: 20985, deleted: false, device_id: "device-1000", created_version: 20985 }
+RowDump { collection: "notes", pk: "new-device-1000-000035", payload: Some("{\"k\": 35, \"edit\": \"insert\"}"), version: 20986, deleted: false, device_id: "device-1000", created_version: 20986 }
+RowDump { collection: "notes", pk: "new-device-1000-000036", payload: Some("{\"k\": 36, \"edit\": \"insert\"}"), version: 20987, deleted: false, device_id: "device-1000", created_version: 20987 }
+RowDump { collection: "notes", pk: "new-device-1000-000037", payload: Some("{\"k\": 37, \"edit\": \"insert\"}"), version: 20988, deleted: false, device_id: "device-1000", created_version: 20988 }
+RowDump { collection: "notes", pk: "new-device-1000-000038", payload: Some("{\"k\": 38, \"edit\": \"insert\"}"), version: 20989, deleted: false, device_id: "device-1000", created_version: 20989 }
+RowDump { collection: "notes", pk: "new-device-1000-000039", payload: Some("{\"k\": 39, \"edit\": \"insert\"}"), version: 20990, deleted: false, device_id: "device-1000", created_version: 20990 }
+RowDump { collection: "notes", pk: "new-device-1000-000040", payload: Some("{\"k\": 40, \"edit\": \"insert\"}"), version: 20991, deleted: false, device_id: "device-1000", created_version: 20991 }
+RowDump { collection: "notes", pk: "new-device-1000-000041", payload: Some("{\"k\": 41, \"edit\": \"insert\"}"), version: 20992, deleted: false, device_id: "device-1000", created_version: 20992 }
+RowDump { collection: "notes", pk: "new-device-1000-000042", payload: Some("{\"k\": 42, \"edit\": \"insert\"}"), version: 20993, deleted: false, device_id: "device-1000", created_version: 20993 }
+RowDump { collection: "notes", pk: "new-device-1000-000043", payload: Some("{\"k\": 43, \"edit\": \"insert\"}"), version: 20994, deleted: false, device_id: "device-1000", created_version: 20994 }
+RowDump { collection: "notes", pk: "new-device-1000-000044", payload: Some("{\"k\": 44, \"edit\": \"insert\"}"), version: 20995, deleted: false, device_id: "device-1000", created_version: 20995 }
+RowDump { collection: "notes", pk: "new-device-1000-000045", payload: Some("{\"k\": 45, \"edit\": \"insert\"}"), version: 20996, deleted: false, device_id: "device-1000", created_version: 20996 }
+RowDump { collection: "notes", pk: "new-device-1000-000046", payload: Some("{\"k\": 46, \"edit\": \"insert\"}"), version: 20997, deleted: false, device_id: "device-1000", created_version: 20997 }
+RowDump { collection: "notes", pk: "new-device-1000-000047", payload: Some("{\"k\": 47, \"edit\": \"insert\"}"), version: 20998, deleted: false, device_id: "device-1000", created_version: 20998 }
+RowDump { collection: "notes", pk: "new-device-1000-000048", payload: Some("{\"k\": 48, \"edit\": \"insert\"}"), version: 20999, deleted: false, device_id: "device-1000", created_version: 20999 }
+RowDump { collection: "notes", pk: "new-device-1000-000049", payload: Some("{\"k\": 49, \"edit\": \"insert\"}"), version: 21000, deleted: false, device_id: "device-1000", created_version: 21000 }
+RowDump { collection: "notes", pk: "new-device-1000-000050", payload: Some("{\"k\": 50, \"edit\": \"insert\"}"), version: 21001, deleted: false, device_id: "device-1000", created_version: 21001 }
+RowDump { collection: "notes", pk: "new-device-1000-000051", payload: Some("{\"k\": 51, \"edit\": \"insert\"}"), version: 21002, deleted: false, device_id: "device-1000", created_version: 21002 }
+RowDump { collection: "notes", pk: "new-device-1000-000052", payload: Some("{\"k\": 52, \"edit\": \"insert\"}"), version: 21003, deleted: false, device_id: "device-1000", created_version: 21003 }
+RowDump { collection: "notes", pk: "new-device-1000-000053", payload: Some("{\"k\": 53, \"edit\": \"insert\"}"), version: 21004, deleted: false, device_id: "device-1000", created_version: 21004 }
+RowDump { collection: "notes", pk: "new-device-1000-000054", payload: Some("{\"k\": 54, \"edit\": \"insert\"}"), version: 21005, deleted: false, device_id: "device-1000", created_version: 21005 }
+RowDump { collection: "notes", pk: "new-device-1000-000055", payload: Some("{\"k\": 55, \"edit\": \"insert\"}"), version: 21006, deleted: false, device_id: "device-1000", created_version: 21006 }
+RowDump { collection: "notes", pk: "new-device-1000-000056", payload: Some("{\"k\": 56, \"edit\": \"insert\"}"), version: 21007, deleted: false, device_id: "device-1000", created_version: 21007 }
+RowDump { collection: "notes", pk: "new-device-1000-000057", payload: Some("{\"k\": 57, \"edit\": \"insert\"}"), version: 21008, deleted: false, device_id: "device-1000", created_version: 21008 }
+RowDump { collection: "notes", pk: "new-device-1000-000058", payload: Some("{\"k\": 58, \"edit\": \"insert\"}"), version: 21009, deleted: false, device_id: "device-1000", created_version: 21009 }
+RowDump { collection: "notes", pk: "new-device-1000-000059", payload: Some("{\"k\": 59, \"edit\": \"insert\"}"), version: 21010, deleted: false, device_id: "device-1000", created_version: 21010 }
+RowDump { collection: "notes", pk: "new-device-1000-000060", payload: Some("{\"k\": 60, \"edit\": \"insert\"}"), version: 21011, deleted: false, device_id: "device-1000", created_version: 21011 }
+RowDump { collection: "notes", pk: "new-device-1000-000061", payload: Some("{\"k\": 61, \"edit\": \"insert\"}"), version: 21012, deleted: false, device_id: "device-1000", created_version: 21012 }
+RowDump { collection: "notes", pk: "new-device-1000-000062", payload: Some("{\"k\": 62, \"edit\": \"insert\"}"), version: 21013, deleted: false, device_id: "device-1000", created_version: 21013 }
+RowDump { collection: "notes", pk: "new-device-1000-000063", payload: Some("{\"k\": 63, \"edit\": \"insert\"}"), version: 21014, deleted: false, device_id: "device-1000", created_version: 21014 }
+RowDump { collection: "notes", pk: "new-device-1000-000064", payload: Some("{\"k\": 64, \"edit\": \"insert\"}"), version: 21015, deleted: false, device_id: "device-1000", created_version: 21015 }
+RowDump { collection: "notes", pk: "new-device-1000-000065", payload: Some("{\"k\": 65, \"edit\": \"insert\"}"), version: 21016, deleted: false, device_id: "device-1000", created_version: 21016 }
+RowDump { collection: "notes", pk: "new-device-1000-000066", payload: Some("{\"k\": 66, \"edit\": \"insert\"}"), version: 21017, deleted: false, device_id: "device-1000", created_version: 21017 }
+RowDump { collection: "notes", pk: "new-device-1000-000067", payload: Some("{\"k\": 67, \"edit\": \"insert\"}"), version: 21018, deleted: false, device_id: "device-1000", created_version: 21018 }
+RowDump { collection: "notes", pk: "new-device-1000-000068", payload: Some("{\"k\": 68, \"edit\": \"insert\"}"), version: 21019, deleted: false, device_id: "device-1000", created_version: 21019 }
+RowDump { collection: "notes", pk: "new-device-1000-000069", payload: Some("{\"k\": 69, \"edit\": \"insert\"}"), version: 21020, deleted: false, device_id: "device-1000", created_version: 21020 }
+RowDump { collection: "notes", pk: "new-device-1000-000070", payload: Some("{\"k\": 70, \"edit\": \"insert\"}"), version: 21021, deleted: false, device_id: "device-1000", created_version: 21021 }
+RowDump { collection: "notes", pk: "new-device-1000-000071", payload: Some("{\"k\": 71, \"edit\": \"insert\"}"), version: 21022, deleted: false, device_id: "device-1000", created_version: 21022 }
+RowDump { collection: "notes", pk: "new-device-1000-000072", payload: Some("{\"k\": 72, \"edit\": \"insert\"}"), version: 21023, deleted: false, device_id: "device-1000", created_version: 21023 }
+RowDump { collection: "notes", pk: "new-device-1000-000073", payload: Some("{\"k\": 73, \"edit\": \"insert\"}"), version: 21024, deleted: false, device_id: "device-1000", created_version: 21024 }
+RowDump { collection: "notes", pk: "new-device-1000-000074", payload: Some("{\"k\": 74, \"edit\": \"insert\"}"), version: 21025, deleted: false, device_id: "device-1000", created_version: 21025 }
+RowDump { collection: "notes", pk: "new-device-1000-000075", payload: Some("{\"k\": 75, \"edit\": \"insert\"}"), version: 21026, deleted: false, device_id: "device-1000", created_version: 21026 }
+RowDump { collection: "notes", pk: "new-device-1000-000076", payload: Some("{\"k\": 76, \"edit\": \"insert\"}"), version: 21027, deleted: false, device_id: "device-1000", created_version: 21027 }
+RowDump { collection: "notes", pk: "new-device-1000-000077", payload: Some("{\"k\": 77, \"edit\": \"insert\"}"), version: 21028, deleted: false, device_id: "device-1000", created_version: 21028 }
+RowDump { collection: "notes", pk: "new-device-1000-000078", payload: Some("{\"k\": 78, \"edit\": \"insert\"}"), version: 21029, deleted: false, device_id: "device-1000", created_version: 21029 }
+RowDump { collection: "notes", pk: "new-device-1000-000079", payload: Some("{\"k\": 79, \"edit\": \"insert\"}"), version: 21030, deleted: false, device_id: "device-1000", created_version: 21030 }
+RowDump { collection: "notes", pk: "new-device-1000-000080", payload: Some("{\"k\": 80, \"edit\": \"insert\"}"), version: 21031, deleted: false, device_id: "device-1000", created_version: 21031 }
+RowDump { collection: "notes", pk: "new-device-1000-000081", payload: Some("{\"k\": 81, \"edit\": \"insert\"}"), version: 21032, deleted: false, device_id: "device-1000", created_version: 21032 }
+RowDump { collection: "notes", pk: "new-device-1000-000082", payload: Some("{\"k\": 82, \"edit\": \"insert\"}"), version: 21033, deleted: false, device_id: "device-1000", created_version: 21033 }
+RowDump { collection: "notes", pk: "new-device-1000-000083", payload: Some("{\"k\": 83, \"edit\": \"insert\"}"), version: 21034, deleted: false, device_id: "device-1000", created_version: 21034 }
+RowDump { collection: "notes", pk: "new-device-1000-000084", payload: Some("{\"k\": 84, \"edit\": \"insert\"}"), version: 21035, deleted: false, device_id: "device-1000", created_version: 21035 }
+RowDump { collection: "notes", pk: "new-device-1000-000085", payload: Some("{\"k\": 85, \"edit\": \"insert\"}"), version: 21036, deleted: false, device_id: "device-1000", created_version: 21036 }
+RowDump { collection: "notes", pk: "new-device-1000-000086", payload: Some("{\"k\": 86, \"edit\": \"insert\"}"), version: 21037, deleted: false, device_id: "device-1000", created_version: 21037 }
+RowDump { collection: "notes", pk: "new-device-1000-000087", payload: Some("{\"k\": 87, \"edit\": \"insert\"}"), version: 21038, deleted: false, device_id: "device-1000", created_version: 21038 }
+RowDump { collection: "notes", pk: "new-device-1000-000088", payload: Some("{\"k\": 88, \"edit\": \"insert\"}"), version: 21039, deleted: false, device_id: "device-1000", created_version: 21039 }
+RowDump { collection: "notes", pk: "new-device-1000-000089", payload: Some("{\"k\": 89, \"edit\": \"insert\"}"), version: 21040, deleted: false, device_id: "device-1000", created_version: 21040 }
+RowDump { collection: "notes", pk: "new-device-1000-000090", payload: Some("{\"k\": 90, \"edit\": \"insert\"}"), version: 21041, deleted: false, device_id: "device-1000", created_version: 21041 }
+RowDump { collection: "notes", pk: "new-device-1000-000091", payload: Some("{\"k\": 91, \"edit\": \"insert\"}"), version: 21042, deleted: false, device_id: "device-1000", created_version: 21042 }
+RowDump { collection: "notes", pk: "new-device-1000-000092", payload: Some("{\"k\": 92, \"edit\": \"insert\"}"), version: 21043, deleted: false, device_id: "device-1000", created_version: 21043 }
+RowDump { collection: "notes", pk: "new-device-1000-000093", payload: Some("{\"k\": 93, \"edit\": \"insert\"}"), version: 21044, deleted: false, device_id: "device-1000", created_version: 21044 }
+RowDump { collection: "notes", pk: "new-device-1000-000094", payload: Some("{\"k\": 94, \"edit\": \"insert\"}"), version: 21045, deleted: false, device_id: "device-1000", created_version: 21045 }
+RowDump { collection: "notes", pk: "new-device-1000-000095", payload: Some("{\"k\": 95, \"edit\": \"insert\"}"), version: 21046, deleted: false, device_id: "device-1000", created_version: 21046 }
+RowDump { collection: "notes", pk: "new-device-1000-000096", payload: Some("{\"k\": 96, \"edit\": \"insert\"}"), version: 21047, deleted: false, device_id: "device-1000", created_version: 21047 }
+RowDump { collection: "notes", pk: "new-device-1000-000097", payload: Some("{\"k\": 97, \"edit\": \"insert\"}"), version: 21048, deleted: false, device_id: "device-1000", created_version: 21048 }
+RowDump { collection: "notes", pk: "new-device-1000-000098", payload: Some("{\"k\": 98, \"edit\": \"insert\"}"), version: 21049, deleted: false, device_id: "device-1000", created_version: 21049 }
+RowDump { collection: "notes", pk: "new-device-1000-000099", payload: Some("{\"k\": 99, \"edit\": \"insert\"}"), version: 21050, deleted: false, device_id: "device-1000", created_version: 21050 }
+RowDump { collection: "notes", pk: "new-device-1000-000100", payload: Some("{\"k\": 100, \"edit\": \"insert\"}"), version: 21051, deleted: false, device_id: "device-1000", created_version: 21051 }
+RowDump { collection: "notes", pk: "new-device-1000-000101", payload: Some("{\"k\": 101, \"edit\": \"insert\"}"), version: 21052, deleted: false, device_id: "device-1000", created_version: 21052 }
+RowDump { collection: "notes", pk: "new-device-1000-000102", payload: Some("{\"k\": 102, \"edit\": \"insert\"}"), version: 21053, deleted: false, device_id: "device-1000", created_version: 21053 }
+RowDump { collection: "notes", pk: "new-device-1000-000103", payload: Some("{\"k\": 103, \"edit\": \"insert\"}"), version: 21054, deleted: false, device_id: "device-1000", created_version: 21054 }
+RowDump { collection: "notes", pk: "new-device-1000-000104", payload: Some("{\"k\": 104, \"edit\": \"insert\"}"), version: 21055, deleted: false, device_id: "device-1000", created_version: 21055 }
+RowDump { collection: "notes", pk: "new-device-1000-000105", payload: Some("{\"k\": 105, \"edit\": \"insert\"}"), version: 21056, deleted: false, device_id: "device-1000", created_version: 21056 }
+RowDump { collection: "notes", pk: "new-device-1000-000106", payload: Some("{\"k\": 106, \"edit\": \"insert\"}"), version: 21057, deleted: false, device_id: "device-1000", created_version: 21057 }
+RowDump { collection: "notes", pk: "new-device-1000-000107", payload: Some("{\"k\": 107, \"edit\": \"insert\"}"), version: 21058, deleted: false, device_id: "device-1000", created_version: 21058 }
+RowDump { collection: "notes", pk: "new-device-1000-000108", payload: Some("{\"k\": 108, \"edit\": \"insert\"}"), version: 21059, deleted: false, device_id: "device-1000", created_version: 21059 }
+RowDump { collection: "notes", pk: "new-device-1000-000109", payload: Some("{\"k\": 109, \"edit\": \"insert\"}"), version: 21060, deleted: false, device_id: "device-1000", created_version: 21060 }
+RowDump { collection: "notes", pk: "new-device-1000-000110", payload: Some("{\"k\": 110, \"edit\": \"insert\"}"), version: 21061, deleted: false, device_id: "device-1000", created_version: 21061 }
+RowDump { collection: "notes", pk: "new-device-1000-000111", payload: Some("{\"k\": 111, \"edit\": \"insert\"}"), version: 21062, deleted: false, device_id: "device-1000", created_version: 21062 }
+RowDump { collection: "notes", pk: "new-device-1000-000112", payload: Some("{\"k\": 112, \"edit\": \"insert\"}"), version: 21063, deleted: false, device_id: "device-1000", created_version: 21063 }
+RowDump { collection: "notes", pk: "new-device-1000-000113", payload: Some("{\"k\": 113, \"edit\": \"insert\"}"), version: 21064, deleted: false, device_id: "device-1000", created_version: 21064 }
+RowDump { collection: "notes", pk: "new-device-1000-000114", payload: Some("{\"k\": 114, \"edit\": \"insert\"}"), version: 21065, deleted: false, device_id: "device-1000", created_version: 21065 }
+RowDump { collection: "notes", pk: "new-device-1000-000115", payload: Some("{\"k\": 115, \"edit\": \"insert\"}"), version: 21066, deleted: false, device_id: "device-1000", created_version: 21066 }
+RowDump { collection: "notes", pk: "new-device-1000-000116", payload: Some("{\"k\": 116, \"edit\": \"insert\"}"), version: 21067, deleted: false, device_id: "device-1000", created_version: 21067 }
+RowDump { collection: "notes", pk: "new-device-1000-000117", payload: Some("{\"k\": 117, \"edit\": \"insert\"}"), version: 21068, deleted: false, device_id: "device-1000", created_version: 21068 }
+RowDump { collection: "notes", pk: "new-device-1000-000118", payload: Some("{\"k\": 118, \"edit\": \"insert\"}"), version: 21069, deleted: false, device_id: "device-1000", created_version: 21069 }
+RowDump { collection: "notes", pk: "new-device-1000-000119", payload: Some("{\"k\": 119, \"edit\": \"insert\"}"), version: 21070, deleted: false, device_id: "device-1000", created_version: 21070 }
+RowDump { collection: "notes", pk: "new-device-1000-000120", payload: Some("{\"k\": 120, \"edit\": \"insert\"}"), version: 21071, deleted: false, device_id: "device-1000", created_version: 21071 }
+RowDump { collection: "notes", pk: "new-device-1000-000121", payload: Some("{\"k\": 121, \"edit\": \"insert\"}"), version: 21072, deleted: false, device_id: "device-1000", created_version: 21072 }
+RowDump { collection: "notes", pk: "new-device-1000-000122", payload: Some("{\"k\": 122, \"edit\": \"insert\"}"), version: 21073, deleted: false, device_id: "device-1000", created_version: 21073 }
+RowDump { collection: "notes", pk: "new-device-1000-000123", payload: Some("{\"k\": 123, \"edit\": \"insert\"}"), version: 21074, deleted: false, device_id: "device-1000", created_version: 21074 }
+RowDump { collection: "notes", pk: "new-device-1000-000124", payload: Some("{\"k\": 124, \"edit\": \"insert\"}"), version: 21075, deleted: false, device_id: "device-1000", created_version: 21075 }
+RowDump { collection: "notes", pk: "new-device-1000-000125", payload: Some("{\"k\": 125, \"edit\": \"insert\"}"), version: 21076, deleted: false, device_id: "device-1000", created_version: 21076 }
+RowDump { collection: "notes", pk: "new-device-1000-000126", payload: Some("{\"k\": 126, \"edit\": \"insert\"}"), version: 21077, deleted: false, device_id: "device-1000", created_version: 21077 }
+RowDump { collection: "notes", pk: "new-device-1000-000127", payload: Some("{\"k\": 127, \"edit\": \"insert\"}"), version: 21078, deleted: false, device_id: "device-1000", created_version: 21078 }
+RowDump { collection: "notes", pk: "new-device-1000-000128", payload: Some("{\"k\": 128, \"edit\": \"insert\"}"), version: 21079, deleted: false, device_id: "device-1000", created_version: 21079 }
+RowDump { collection: "notes", pk: "new-device-1000-000129", payload: Some("{\"k\": 129, \"edit\": \"insert\"}"), version: 21080, deleted: false, device_id: "device-1000", created_version: 21080 }
+RowDump { collection: "notes", pk: "new-device-1000-000130", payload: Some("{\"k\": 130, \"edit\": \"insert\"}"), version: 21081, deleted: false, device_id: "device-1000", created_version: 21081 }
+RowDump { collection: "notes", pk: "new-device-1000-000131", payload: Some("{\"k\": 131, \"edit\": \"insert\"}"), version: 21082, deleted: false, device_id: "device-1000", created_version: 21082 }
+RowDump { collection: "notes", pk: "new-device-1000-000132", payload: Some("{\"k\": 132, \"edit\": \"insert\"}"), version: 21083, deleted: false, device_id: "device-1000", created_version: 21083 }
+RowDump { collection: "notes", pk: "new-device-1000-000133", payload: Some("{\"k\": 133, \"edit\": \"insert\"}"), version: 21084, deleted: false, device_id: "device-1000", created_version: 21084 }
+RowDump { collection: "notes", pk: "new-device-1000-000134", payload: Some("{\"k\": 134, \"edit\": \"insert\"}"), version: 21085, deleted: false, device_id: "device-1000", created_version: 21085 }
+RowDump { collection: "notes", pk: "new-device-1000-000135", payload: Some("{\"k\": 135, \"edit\": \"insert\"}"), version: 21086, deleted: false, device_id: "device-1000", created_version: 21086 }
+RowDump { collection: "notes", pk: "new-device-1000-000136", payload: Some("{\"k\": 136, \"edit\": \"insert\"}"), version: 21087, deleted: false, device_id: "device-1000", created_version: 21087 }
+RowDump { collection: "notes", pk: "new-device-1000-000137", payload: Some("{\"k\": 137, \"edit\": \"insert\"}"), version: 21088, deleted: false, device_id: "device-1000", created_version: 21088 }
+RowDump { collection: "notes", pk: "new-device-1000-000138", payload: Some("{\"k\": 138, \"edit\": \"insert\"}"), version: 21089, deleted: false, device_id: "device-1000", created_version: 21089 }
+RowDump { collection: "notes", pk: "new-device-1000-000139", payload: Some("{\"k\": 139, \"edit\": \"insert\"}"), version: 21090, deleted: false, device_id: "device-1000", created_version: 21090 }
+RowDump { collection: "notes", pk: "new-device-1000-000140", payload: Some("{\"k\": 140, \"edit\": \"insert\"}"), version: 21091, deleted: false, device_id: "device-1000", created_version: 21091 }
+RowDump { collection: "notes", pk: "new-device-1000-000141", payload: Some("{\"k\": 141, \"edit\": \"insert\"}"), version: 21092, deleted: false, device_id: "device-1000", created_version: 21092 }
+RowDump { collection: "notes", pk: "new-device-1000-000142", payload: Some("{\"k\": 142, \"edit\": \"insert\"}"), version: 21093, deleted: false, device_id: "device-1000", created_version: 21093 }
+RowDump { collection: "notes", pk: "new-device-1000-000143", payload: Some("{\"k\": 143, \"edit\": \"insert\"}"), version: 21094, deleted: false, device_id: "device-1000", created_version: 21094 }
+RowDump { collection: "notes", pk: "new-device-1000-000144", payload: Some("{\"k\": 144, \"edit\": \"insert\"}"), version: 21095, deleted: false, device_id: "device-1000", created_version: 21095 }
+RowDump { collection: "notes", pk: "new-device-1000-000145", payload: Some("{\"k\": 145, \"edit\": \"insert\"}"), version: 21096, deleted: false, device_id: "device-1000", created_version: 21096 }
+RowDump { collection: "notes", pk: "new-device-1000-000146", payload: Some("{\"k\": 146, \"edit\": \"insert\"}"), version: 21097, deleted: false, device_id: "device-1000", created_version: 21097 }
+RowDump { collection: "notes", pk: "new-device-1000-000147", payload: Some("{\"k\": 147, \"edit\": \"insert\"}"), version: 21098, deleted: false, device_id: "device-1000", created_version: 21098 }
+RowDump { collection: "notes", pk: "new-device-1000-000148", payload: Some("{\"k\": 148, \"edit\": \"insert\"}"), version: 21099, deleted: false, device_id: "device-1000", created_version: 21099 }
+RowDump { collection: "notes", pk: "new-device-1000-000149", payload: Some("{\"k\": 149, \"edit\": \"insert\"}"), version: 21100, deleted: false, device_id: "device-1000", created_version: 21100 }
+RowDump { collection: "notes", pk: "new-device-1000-000150", payload: Some("{\"k\": 150, \"edit\": \"insert\"}"), version: 21101, deleted: false, device_id: "device-1000", created_version: 21101 }
+RowDump { collection: "notes", pk: "new-device-1000-000151", payload: Some("{\"k\": 151, \"edit\": \"insert\"}"), version: 21102, deleted: false, device_id: "device-1000", created_version: 21102 }
+RowDump { collection: "notes", pk: "new-device-1000-000152", payload: Some("{\"k\": 152, \"edit\": \"insert\"}"), version: 21103, deleted: false, device_id: "device-1000", created_version: 21103 }
+RowDump { collection: "notes", pk: "new-device-1000-000153", payload: Some("{\"k\": 153, \"edit\": \"insert\"}"), version: 21104, deleted: false, device_id: "device-1000", created_version: 21104 }
+RowDump { collection: "notes", pk: "new-device-1000-000154", payload: Some("{\"k\": 154, \"edit\": \"insert\"}"), version: 21105, deleted: false, device_id: "device-1000", created_version: 21105 }
+RowDump { collection: "notes", pk: "new-device-1000-000155", payload: Some("{\"k\": 155, \"edit\": \"insert\"}"), version: 21106, deleted: false, device_id: "device-1000", created_version: 21106 }
+RowDump { collection: "notes", pk: "new-device-1000-000156", payload: Some("{\"k\": 156, \"edit\": \"insert\"}"), version: 21107, deleted: false, device_id: "device-1000", created_version: 21107 }
+RowDump { collection: "notes", pk: "new-device-1000-000157", payload: Some("{\"k\": 157, \"edit\": \"insert\"}"), version: 21108, deleted: false, device_id: "device-1000", created_version: 21108 }
+RowDump { collection: "notes", pk: "new-device-1000-000158", payload: Some("{\"k\": 158, \"edit\": \"insert\"}"), version: 21109, deleted: false, device_id: "device-1000", created_version: 21109 }
+RowDump { collection: "notes", pk: "new-device-1000-000159", payload: Some("{\"k\": 159, \"edit\": \"insert\"}"), version: 21110, deleted: false, device_id: "device-1000", created_version: 21110 }
+RowDump { collection: "notes", pk: "new-device-1000-000160", payload: Some("{\"k\": 160, \"edit\": \"insert\"}"), version: 21111, deleted: false, device_id: "device-1000", created_version: 21111 }
+RowDump { collection: "notes", pk: "new-device-1000-000161", payload: Some("{\"k\": 161, \"edit\": \"insert\"}"), version: 21112, deleted: false, device_id: "device-1000", created_version: 21112 }
+RowDump { collection: "notes", pk: "new-device-1000-000162", payload: Some("{\"k\": 162, \"edit\": \"insert\"}"), version: 21113, deleted: false, device_id: "device-1000", created_version: 21113 }
+RowDump { collection: "notes", pk: "new-device-1000-000163", payload: Some("{\"k\": 163, \"edit\": \"insert\"}"), version: 21114, deleted: false, device_id: "device-1000", created_version: 21114 }
+RowDump { collection: "notes", pk: "new-device-1000-000164", payload: Some("{\"k\": 164, \"edit\": \"insert\"}"), version: 21115, deleted: false, device_id: "device-1000", created_version: 21115 }
+RowDump { collection: "notes", pk: "new-device-1000-000165", payload: Some("{\"k\": 165, \"edit\": \"insert\"}"), version: 21116, deleted: false, device_id: "device-1000", created_version: 21116 }
+RowDump { collection: "notes", pk: "new-device-1000-000166", payload: Some("{\"k\": 166, \"edit\": \"insert\"}"), version: 21117, deleted: false, device_id: "device-1000", created_version: 21117 }
+RowDump { collection: "notes", pk: "new-device-1000-000167", payload: Some("{\"k\": 167, \"edit\": \"insert\"}"), version: 21118, deleted: false, device_id: "device-1000", created_version: 21118 }
+RowDump { collection: "notes", pk: "new-device-1000-000168", payload: Some("{\"k\": 168, \"edit\": \"insert\"}"), version: 21119, deleted: false, device_id: "device-1000", created_version: 21119 }
+RowDump { collection: "notes", pk: "new-device-1000-000169", payload: Some("{\"k\": 169, \"edit\": \"insert\"}"), version: 21120, deleted: false, device_id: "device-1000", created_version: 21120 }
+RowDump { collection: "notes", pk: "new-device-1000-000170", payload: Some("{\"k\": 170, \"edit\": \"insert\"}"), version: 21121, deleted: false, device_id: "device-1000", created_version: 21121 }
+RowDump { collection: "notes", pk: "new-device-1000-000171", payload: Some("{\"k\": 171, \"edit\": \"insert\"}"), version: 21122, deleted: false, device_id: "device-1000", created_version: 21122 }
+RowDump { collection: "notes", pk: "new-device-1000-000172", payload: Some("{\"k\": 172, \"edit\": \"insert\"}"), version: 21123, deleted: false, device_id: "device-1000", created_version: 21123 }
+RowDump { collection: "notes", pk: "new-device-1000-000173", payload: Some("{\"k\": 173, \"edit\": \"insert\"}"), version: 21124, deleted: false, device_id: "device-1000", created_version: 21124 }
+RowDump { collection: "notes", pk: "new-device-1000-000174", payload: Some("{\"k\": 174, \"edit\": \"insert\"}"), version: 21125, deleted: false, device_id: "device-1000", created_version: 21125 }
+RowDump { collection: "notes", pk: "new-device-1000-000175", payload: Some("{\"k\": 175, \"edit\": \"insert\"}"), version: 21126, deleted: false, device_id: "device-1000", created_version: 21126 }
+RowDump { collection: "notes", pk: "new-device-1000-000176", payload: Some("{\"k\": 176, \"edit\": \"insert\"}"), version: 21127, deleted: false, device_id: "device-1000", created_version: 21127 }
+RowDump { collection: "notes", pk: "new-device-1000-000177", payload: Some("{\"k\": 177, \"edit\": \"insert\"}"), version: 21128, deleted: false, device_id: "device-1000", created_version: 21128 }
+RowDump { collection: "notes", pk: "new-device-1000-000178", payload: Some("{\"k\": 178, \"edit\": \"insert\"}"), version: 21129, deleted: false, device_id: "device-1000", created_version: 21129 }
+RowDump { collection: "notes", pk: "new-device-1000-000179", payload: Some("{\"k\": 179, \"edit\": \"insert\"}"), version: 21130, deleted: false, device_id: "device-1000", created_version: 21130 }
+RowDump { collection: "notes", pk: "new-device-1000-000180", payload: Some("{\"k\": 180, \"edit\": \"insert\"}"), version: 21131, deleted: false, device_id: "device-1000", created_version: 21131 }
+RowDump { collection: "notes", pk: "new-device-1000-000181", payload: Some("{\"k\": 181, \"edit\": \"insert\"}"), version: 21132, deleted: false, device_id: "device-1000", created_version: 21132 }
+RowDump { collection: "notes", pk: "new-device-1000-000182", payload: Some("{\"k\": 182, \"edit\": \"insert\"}"), version: 21133, deleted: false, device_id: "device-1000", created_version: 21133 }
+RowDump { collection: "notes", pk: "new-device-1000-000183", payload: Some("{\"k\": 183, \"edit\": \"insert\"}"), version: 21134, deleted: false, device_id: "device-1000", created_version: 21134 }
+RowDump { collection: "notes", pk: "new-device-1000-000184", payload: Some("{\"k\": 184, \"edit\": \"insert\"}"), version: 21135, deleted: false, device_id: "device-1000", created_version: 21135 }
+RowDump { collection: "notes", pk: "new-device-1000-000185", payload: Some("{\"k\": 185, \"edit\": \"insert\"}"), version: 21136, deleted: false, device_id: "device-1000", created_version: 21136 }
+RowDump { collection: "notes", pk: "new-device-1000-000186", payload: Some("{\"k\": 186, \"edit\": \"insert\"}"), version: 21137, deleted: false, device_id: "device-1000", created_version: 21137 }
+RowDump { collection: "notes", pk: "new-device-1000-000187", payload: Some("{\"k\": 187, \"edit\": \"insert\"}"), version: 21138, deleted: false, device_id: "device-1000", created_version: 21138 }
+RowDump { collection: "notes", pk: "new-device-1000-000188", payload: Some("{\"k\": 188, \"edit\": \"insert\"}"), version: 21139, deleted: false, device_id: "device-1000", created_version: 21139 }
+RowDump { collection: "notes", pk: "new-device-1000-000189", payload: Some("{\"k\": 189, \"edit\": \"insert\"}"), version: 21140, deleted: false, device_id: "device-1000", created_version: 21140 }
+RowDump { collection: "notes", pk: "new-device-1000-000190", payload: Some("{\"k\": 190, \"edit\": \"insert\"}"), version: 21141, deleted: false, device_id: "device-1000", created_version: 21141 }
+RowDump { collection: "notes", pk: "new-device-1000-000191", payload: Some("{\"k\": 191, \"edit\": \"insert\"}"), version: 21142, deleted: false, device_id: "device-1000", created_version: 21142 }
+RowDump { collection: "notes", pk: "new-device-1000-000192", payload: Some("{\"k\": 192, \"edit\": \"insert\"}"), version: 21143, deleted: false, device_id: "device-1000", created_version: 21143 }
+RowDump { collection: "notes", pk: "new-device-1000-000193", payload: Some("{\"k\": 193, \"edit\": \"insert\"}"), version: 21144, deleted: false, device_id: "device-1000", created_version: 21144 }
+RowDump { collection: "notes", pk: "new-device-1000-000194", payload: Some("{\"k\": 194, \"edit\": \"insert\"}"), version: 21145, deleted: false, device_id: "device-1000", created_version: 21145 }
+RowDump { collection: "notes", pk: "new-device-1000-000195", payload: Some("{\"k\": 195, \"edit\": \"insert\"}"), version: 21146, deleted: false, device_id: "device-1000", created_version: 21146 }
+RowDump { collection: "notes", pk: "new-device-1000-000196", payload: Some("{\"k\": 196, \"edit\": \"insert\"}"), version: 21147, deleted: false, device_id: "device-1000", created_version: 21147 }
+RowDump { collection: "notes", pk: "new-device-1000-000197", payload: Some("{\"k\": 197, \"edit\": \"insert\"}"), version: 21148, deleted: false, device_id: "device-1000", created_version: 21148 }
+RowDump { collection: "notes", pk: "new-device-1000-000198", payload: Some("{\"k\": 198, \"edit\": \"insert\"}"), version: 21149, deleted: false, device_id: "device-1000", created_version: 21149 }
+RowDump { collection: "notes", pk: "new-device-1000-000199", payload: Some("{\"k\": 199, \"edit\": \"insert\"}"), version: 21150, deleted: false, device_id: "device-1000", created_version: 21150 }
+RowDump { collection: "notes", pk: "newdup-device-1000-000000", payload: Some("{\"p\": 0, \"edit\": \"dup-new-2\"}"), version: 21282, deleted: false, device_id: "device-1000", created_version: 21281 }
+RowDump { collection: "notes", pk: "newdup-device-1000-000001", payload: Some("{\"p\": 1, \"edit\": \"dup-new-2\"}"), version: 21284, deleted: false, device_id: "device-1000", created_version: 21283 }
+RowDump { collection: "notes", pk: "newdup-device-1000-000002", payload: Some("{\"p\": 2, \"edit\": \"dup-new-2\"}"), version: 21286, deleted: false, device_id: "device-1000", created_version: 21285 }
+RowDump { collection: "notes", pk: "newdup-device-1000-000003", payload: Some("{\"p\": 3, \"edit\": \"dup-new-2\"}"), version: 21288, deleted: false, device_id: "device-1000", created_version: 21287 }
+RowDump { collection: "notes", pk: "newdup-device-1000-000004", payload: Some("{\"p\": 4, \"edit\": \"dup-new-2\"}"), version: 21290, deleted: false, device_id: "device-1000", created_version: 21289 }
+RowDump { collection: "notes", pk: "newdup-device-1000-000005", payload: Some("{\"p\": 5, \"edit\": \"dup-new-2\"}"), version: 21292, deleted: false, device_id: "device-1000", created_version: 21291 }
+RowDump { collection: "notes", pk: "newdup-device-1000-000006", payload: Some("{\"p\": 6, \"edit\": \"dup-new-2\"}"), version: 21294, deleted: false, device_id: "device-1000", created_version: 21293 }
+RowDump { collection: "notes", pk: "newdup-device-1000-000007", payload: Some("{\"p\": 7, \"edit\": \"dup-new-2\"}"), version: 21296, deleted: false, device_id: "device-1000", created_version: 21295 }
+RowDump { collection: "notes", pk: "newdup-device-1000-000008", payload: Some("{\"p\": 8, \"edit\": \"dup-new-2\"}"), version: 21298, deleted: false, device_id: "device-1000", created_version: 21297 }
+RowDump { collection: "notes", pk: "newdup-device-1000-000009", payload: Some("{\"p\": 9, \"edit\": \"dup-new-2\"}"), version: 21300, deleted: false, device_id: "device-1000", created_version: 21299 }
+-- row dump (existing pks touched by this batch), 740 rows --
+RowDump { collection: "notes", pk: "pk-00010001", payload: Some("{\"idx\": 10001, \"edit\": \"update\"}"), version: 20301, deleted: false, device_id: "device-1000", created_version: 10001 }
+RowDump { collection: "notes", pk: "pk-00010002", payload: Some("{\"idx\": 10002, \"edit\": \"update\"}"), version: 20302, deleted: false, device_id: "device-1000", created_version: 10002 }
+RowDump { collection: "notes", pk: "pk-00010003", payload: Some("{\"idx\": 10003, \"edit\": \"update\"}"), version: 20303, deleted: false, device_id: "device-1000", created_version: 10003 }
+RowDump { collection: "notes", pk: "pk-00010004", payload: Some("{\"idx\": 10004, \"edit\": \"update\"}"), version: 20304, deleted: false, device_id: "device-1000", created_version: 10004 }
+RowDump { collection: "notes", pk: "pk-00010005", payload: Some("{\"idx\": 10005, \"edit\": \"update\"}"), version: 20305, deleted: false, device_id: "device-1000", created_version: 10005 }
+RowDump { collection: "notes", pk: "pk-00010006", payload: Some("{\"idx\": 10006, \"edit\": \"update\"}"), version: 20306, deleted: false, device_id: "device-1000", created_version: 10006 }
+RowDump { collection: "notes", pk: "pk-00010007", payload: Some("{\"idx\": 10007, \"edit\": \"update\"}"), version: 20307, deleted: false, device_id: "device-1000", created_version: 10007 }
+RowDump { collection: "notes", pk: "pk-00010008", payload: Some("{\"idx\": 10008, \"edit\": \"update\"}"), version: 20308, deleted: false, device_id: "device-1000", created_version: 10008 }
+RowDump { collection: "notes", pk: "pk-00010009", payload: Some("{\"idx\": 10009, \"edit\": \"update\"}"), version: 20309, deleted: false, device_id: "device-1000", created_version: 10009 }
+RowDump { collection: "notes", pk: "pk-00010010", payload: Some("{\"idx\": 10010, \"edit\": \"update\"}"), version: 20310, deleted: false, device_id: "device-1000", created_version: 10010 }
+RowDump { collection: "notes", pk: "pk-00010011", payload: Some("{\"idx\": 10011, \"edit\": \"update\"}"), version: 20311, deleted: false, device_id: "device-1000", created_version: 10011 }
+RowDump { collection: "notes", pk: "pk-00010012", payload: Some("{\"idx\": 10012, \"edit\": \"update\"}"), version: 20312, deleted: false, device_id: "device-1000", created_version: 10012 }
+RowDump { collection: "notes", pk: "pk-00010013", payload: Some("{\"idx\": 10013, \"edit\": \"update\"}"), version: 20313, deleted: false, device_id: "device-1000", created_version: 10013 }
+RowDump { collection: "notes", pk: "pk-00010014", payload: Some("{\"idx\": 10014, \"edit\": \"update\"}"), version: 20314, deleted: false, device_id: "device-1000", created_version: 10014 }
+RowDump { collection: "notes", pk: "pk-00010015", payload: Some("{\"idx\": 10015, \"edit\": \"update\"}"), version: 20315, deleted: false, device_id: "device-1000", created_version: 10015 }
+RowDump { collection: "notes", pk: "pk-00010016", payload: Some("{\"idx\": 10016, \"edit\": \"update\"}"), version: 20316, deleted: false, device_id: "device-1000", created_version: 10016 }
+RowDump { collection: "notes", pk: "pk-00010017", payload: Some("{\"idx\": 10017, \"edit\": \"update\"}"), version: 20317, deleted: false, device_id: "device-1000", created_version: 10017 }
+RowDump { collection: "notes", pk: "pk-00010018", payload: Some("{\"idx\": 10018, \"edit\": \"update\"}"), version: 20318, deleted: false, device_id: "device-1000", created_version: 10018 }
+RowDump { collection: "notes", pk: "pk-00010019", payload: Some("{\"idx\": 10019, \"edit\": \"update\"}"), version: 20319, deleted: false, device_id: "device-1000", created_version: 10019 }
+RowDump { collection: "notes", pk: "pk-00010021", payload: Some("{\"idx\": 10021, \"edit\": \"update\"}"), version: 20320, deleted: false, device_id: "device-1000", created_version: 10021 }
+RowDump { collection: "notes", pk: "pk-00010022", payload: Some("{\"idx\": 10022, \"edit\": \"update\"}"), version: 20321, deleted: false, device_id: "device-1000", created_version: 10022 }
+RowDump { collection: "notes", pk: "pk-00010023", payload: Some("{\"idx\": 10023, \"edit\": \"update\"}"), version: 20322, deleted: false, device_id: "device-1000", created_version: 10023 }
+RowDump { collection: "notes", pk: "pk-00010024", payload: Some("{\"idx\": 10024, \"edit\": \"update\"}"), version: 20323, deleted: false, device_id: "device-1000", created_version: 10024 }
+RowDump { collection: "notes", pk: "pk-00010025", payload: Some("{\"idx\": 10025, \"edit\": \"update\"}"), version: 20324, deleted: false, device_id: "device-1000", created_version: 10025 }
+RowDump { collection: "notes", pk: "pk-00010026", payload: Some("{\"idx\": 10026, \"edit\": \"update\"}"), version: 20325, deleted: false, device_id: "device-1000", created_version: 10026 }
+RowDump { collection: "notes", pk: "pk-00010027", payload: Some("{\"idx\": 10027, \"edit\": \"update\"}"), version: 20326, deleted: false, device_id: "device-1000", created_version: 10027 }
+RowDump { collection: "notes", pk: "pk-00010028", payload: Some("{\"idx\": 10028, \"edit\": \"update\"}"), version: 20327, deleted: false, device_id: "device-1000", created_version: 10028 }
+RowDump { collection: "notes", pk: "pk-00010029", payload: Some("{\"idx\": 10029, \"edit\": \"update\"}"), version: 20328, deleted: false, device_id: "device-1000", created_version: 10029 }
+RowDump { collection: "notes", pk: "pk-00010030", payload: Some("{\"idx\": 10030, \"edit\": \"update\"}"), version: 20329, deleted: false, device_id: "device-1000", created_version: 10030 }
+RowDump { collection: "notes", pk: "pk-00010031", payload: Some("{\"idx\": 10031, \"edit\": \"update\"}"), version: 20330, deleted: false, device_id: "device-1000", created_version: 10031 }
+RowDump { collection: "notes", pk: "pk-00010032", payload: Some("{\"idx\": 10032, \"edit\": \"update\"}"), version: 20331, deleted: false, device_id: "device-1000", created_version: 10032 }
+RowDump { collection: "notes", pk: "pk-00010033", payload: Some("{\"idx\": 10033, \"edit\": \"update\"}"), version: 20332, deleted: false, device_id: "device-1000", created_version: 10033 }
+RowDump { collection: "notes", pk: "pk-00010034", payload: Some("{\"idx\": 10034, \"edit\": \"update\"}"), version: 20333, deleted: false, device_id: "device-1000", created_version: 10034 }
+RowDump { collection: "notes", pk: "pk-00010035", payload: Some("{\"idx\": 10035, \"edit\": \"update\"}"), version: 20334, deleted: false, device_id: "device-1000", created_version: 10035 }
+RowDump { collection: "notes", pk: "pk-00010036", payload: Some("{\"idx\": 10036, \"edit\": \"update\"}"), version: 20335, deleted: false, device_id: "device-1000", created_version: 10036 }
+RowDump { collection: "notes", pk: "pk-00010037", payload: Some("{\"idx\": 10037, \"edit\": \"update\"}"), version: 20336, deleted: false, device_id: "device-1000", created_version: 10037 }
+RowDump { collection: "notes", pk: "pk-00010038", payload: Some("{\"idx\": 10038, \"edit\": \"update\"}"), version: 20337, deleted: false, device_id: "device-1000", created_version: 10038 }
+RowDump { collection: "notes", pk: "pk-00010039", payload: Some("{\"idx\": 10039, \"edit\": \"update\"}"), version: 20338, deleted: false, device_id: "device-1000", created_version: 10039 }
+RowDump { collection: "contacts", pk: "pk-00010041", payload: Some("{\"idx\": 10041, \"edit\": \"update\"}"), version: 20339, deleted: false, device_id: "device-1000", created_version: 10041 }
+RowDump { collection: "contacts", pk: "pk-00010042", payload: Some("{\"idx\": 10042, \"edit\": \"update\"}"), version: 20340, deleted: false, device_id: "device-1000", created_version: 10042 }
+RowDump { collection: "contacts", pk: "pk-00010043", payload: Some("{\"idx\": 10043, \"edit\": \"update\"}"), version: 20341, deleted: false, device_id: "device-1000", created_version: 10043 }
+RowDump { collection: "contacts", pk: "pk-00010044", payload: Some("{\"idx\": 10044, \"edit\": \"update\"}"), version: 20342, deleted: false, device_id: "device-1000", created_version: 10044 }
+RowDump { collection: "contacts", pk: "pk-00010045", payload: Some("{\"idx\": 10045, \"edit\": \"update\"}"), version: 20343, deleted: false, device_id: "device-1000", created_version: 10045 }
+RowDump { collection: "contacts", pk: "pk-00010046", payload: Some("{\"idx\": 10046, \"edit\": \"update\"}"), version: 20344, deleted: false, device_id: "device-1000", created_version: 10046 }
+RowDump { collection: "contacts", pk: "pk-00010047", payload: Some("{\"idx\": 10047, \"edit\": \"update\"}"), version: 20345, deleted: false, device_id: "device-1000", created_version: 10047 }
+RowDump { collection: "contacts", pk: "pk-00010048", payload: Some("{\"idx\": 10048, \"edit\": \"update\"}"), version: 20346, deleted: false, device_id: "device-1000", created_version: 10048 }
+RowDump { collection: "contacts", pk: "pk-00010049", payload: Some("{\"idx\": 10049, \"edit\": \"update\"}"), version: 20347, deleted: false, device_id: "device-1000", created_version: 10049 }
+RowDump { collection: "contacts", pk: "pk-00010050", payload: Some("{\"idx\": 10050, \"edit\": \"update\"}"), version: 20348, deleted: false, device_id: "device-1000", created_version: 10050 }
+RowDump { collection: "contacts", pk: "pk-00010051", payload: Some("{\"idx\": 10051, \"edit\": \"update\"}"), version: 20349, deleted: false, device_id: "device-1000", created_version: 10051 }
+RowDump { collection: "contacts", pk: "pk-00010052", payload: Some("{\"idx\": 10052, \"edit\": \"update\"}"), version: 20350, deleted: false, device_id: "device-1000", created_version: 10052 }
+RowDump { collection: "contacts", pk: "pk-00010053", payload: Some("{\"idx\": 10053, \"edit\": \"update\"}"), version: 20351, deleted: false, device_id: "device-1000", created_version: 10053 }
+RowDump { collection: "contacts", pk: "pk-00010054", payload: Some("{\"idx\": 10054, \"edit\": \"update\"}"), version: 20352, deleted: false, device_id: "device-1000", created_version: 10054 }
+RowDump { collection: "contacts", pk: "pk-00010055", payload: Some("{\"idx\": 10055, \"edit\": \"update\"}"), version: 20353, deleted: false, device_id: "device-1000", created_version: 10055 }
+RowDump { collection: "contacts", pk: "pk-00010056", payload: Some("{\"idx\": 10056, \"edit\": \"update\"}"), version: 20354, deleted: false, device_id: "device-1000", created_version: 10056 }
+RowDump { collection: "contacts", pk: "pk-00010057", payload: Some("{\"idx\": 10057, \"edit\": \"update\"}"), version: 20355, deleted: false, device_id: "device-1000", created_version: 10057 }
+RowDump { collection: "contacts", pk: "pk-00010058", payload: Some("{\"idx\": 10058, \"edit\": \"update\"}"), version: 20356, deleted: false, device_id: "device-1000", created_version: 10058 }
+RowDump { collection: "contacts", pk: "pk-00010059", payload: Some("{\"idx\": 10059, \"edit\": \"update\"}"), version: 20357, deleted: false, device_id: "device-1000", created_version: 10059 }
+RowDump { collection: "tasks", pk: "pk-00010061", payload: Some("{\"idx\": 10061, \"edit\": \"update\"}"), version: 20358, deleted: false, device_id: "device-1000", created_version: 10061 }
+RowDump { collection: "tasks", pk: "pk-00010062", payload: Some("{\"idx\": 10062, \"edit\": \"update\"}"), version: 20359, deleted: false, device_id: "device-1000", created_version: 10062 }
+RowDump { collection: "tasks", pk: "pk-00010063", payload: Some("{\"idx\": 10063, \"edit\": \"update\"}"), version: 20360, deleted: false, device_id: "device-1000", created_version: 10063 }
+RowDump { collection: "tasks", pk: "pk-00010064", payload: Some("{\"idx\": 10064, \"edit\": \"update\"}"), version: 20361, deleted: false, device_id: "device-1000", created_version: 10064 }
+RowDump { collection: "tasks", pk: "pk-00010065", payload: Some("{\"idx\": 10065, \"edit\": \"update\"}"), version: 20362, deleted: false, device_id: "device-1000", created_version: 10065 }
+RowDump { collection: "tasks", pk: "pk-00010066", payload: Some("{\"idx\": 10066, \"edit\": \"update\"}"), version: 20363, deleted: false, device_id: "device-1000", created_version: 10066 }
+RowDump { collection: "tasks", pk: "pk-00010067", payload: Some("{\"idx\": 10067, \"edit\": \"update\"}"), version: 20364, deleted: false, device_id: "device-1000", created_version: 10067 }
+RowDump { collection: "tasks", pk: "pk-00010068", payload: Some("{\"idx\": 10068, \"edit\": \"update\"}"), version: 20365, deleted: false, device_id: "device-1000", created_version: 10068 }
+RowDump { collection: "tasks", pk: "pk-00010069", payload: Some("{\"idx\": 10069, \"edit\": \"update\"}"), version: 20366, deleted: false, device_id: "device-1000", created_version: 10069 }
+RowDump { collection: "tasks", pk: "pk-00010070", payload: Some("{\"idx\": 10070, \"edit\": \"update\"}"), version: 20367, deleted: false, device_id: "device-1000", created_version: 10070 }
+RowDump { collection: "tasks", pk: "pk-00010071", payload: Some("{\"idx\": 10071, \"edit\": \"update\"}"), version: 20368, deleted: false, device_id: "device-1000", created_version: 10071 }
+RowDump { collection: "tasks", pk: "pk-00010072", payload: Some("{\"idx\": 10072, \"edit\": \"update\"}"), version: 20369, deleted: false, device_id: "device-1000", created_version: 10072 }
+RowDump { collection: "tasks", pk: "pk-00010073", payload: Some("{\"idx\": 10073, \"edit\": \"update\"}"), version: 20370, deleted: false, device_id: "device-1000", created_version: 10073 }
+RowDump { collection: "tasks", pk: "pk-00010074", payload: Some("{\"idx\": 10074, \"edit\": \"update\"}"), version: 20371, deleted: false, device_id: "device-1000", created_version: 10074 }
+RowDump { collection: "files", pk: "pk-00010075", payload: Some("{\"idx\": 10075, \"edit\": \"update\"}"), version: 20372, deleted: false, device_id: "device-1000", created_version: 10075 }
+RowDump { collection: "files", pk: "pk-00010076", payload: Some("{\"idx\": 10076, \"edit\": \"update\"}"), version: 20373, deleted: false, device_id: "device-1000", created_version: 10076 }
+RowDump { collection: "files", pk: "pk-00010077", payload: Some("{\"idx\": 10077, \"edit\": \"update\"}"), version: 20374, deleted: false, device_id: "device-1000", created_version: 10077 }
+RowDump { collection: "files", pk: "pk-00010078", payload: Some("{\"idx\": 10078, \"edit\": \"update\"}"), version: 20375, deleted: false, device_id: "device-1000", created_version: 10078 }
+RowDump { collection: "files", pk: "pk-00010079", payload: Some("{\"idx\": 10079, \"edit\": \"update\"}"), version: 20376, deleted: false, device_id: "device-1000", created_version: 10079 }
+RowDump { collection: "files", pk: "pk-00010081", payload: Some("{\"idx\": 10081, \"edit\": \"update\"}"), version: 20377, deleted: false, device_id: "device-1000", created_version: 10081 }
+RowDump { collection: "files", pk: "pk-00010082", payload: Some("{\"idx\": 10082, \"edit\": \"update\"}"), version: 20378, deleted: false, device_id: "device-1000", created_version: 10082 }
+RowDump { collection: "files", pk: "pk-00010083", payload: Some("{\"idx\": 10083, \"edit\": \"update\"}"), version: 20379, deleted: false, device_id: "device-1000", created_version: 10083 }
+RowDump { collection: "files", pk: "pk-00010084", payload: Some("{\"idx\": 10084, \"edit\": \"update\"}"), version: 20380, deleted: false, device_id: "device-1000", created_version: 10084 }
+RowDump { collection: "files", pk: "pk-00010085", payload: Some("{\"idx\": 10085, \"edit\": \"update\"}"), version: 20381, deleted: false, device_id: "device-1000", created_version: 10085 }
+RowDump { collection: "files", pk: "pk-00010086", payload: Some("{\"idx\": 10086, \"edit\": \"update\"}"), version: 20382, deleted: false, device_id: "device-1000", created_version: 10086 }
+RowDump { collection: "files", pk: "pk-00010087", payload: Some("{\"idx\": 10087, \"edit\": \"update\"}"), version: 20383, deleted: false, device_id: "device-1000", created_version: 10087 }
+RowDump { collection: "files", pk: "pk-00010088", payload: Some("{\"idx\": 10088, \"edit\": \"update\"}"), version: 20384, deleted: false, device_id: "device-1000", created_version: 10088 }
+RowDump { collection: "files", pk: "pk-00010089", payload: Some("{\"idx\": 10089, \"edit\": \"update\"}"), version: 20385, deleted: false, device_id: "device-1000", created_version: 10089 }
+RowDump { collection: "tags", pk: "pk-00010090", payload: Some("{\"idx\": 10090, \"edit\": \"update\"}"), version: 20386, deleted: false, device_id: "device-1000", created_version: 10090 }
+RowDump { collection: "tags", pk: "pk-00010091", payload: Some("{\"idx\": 10091, \"edit\": \"update\"}"), version: 20387, deleted: false, device_id: "device-1000", created_version: 10091 }
+RowDump { collection: "tags", pk: "pk-00010092", payload: Some("{\"idx\": 10092, \"edit\": \"update\"}"), version: 20388, deleted: false, device_id: "device-1000", created_version: 10092 }
+RowDump { collection: "tags", pk: "pk-00010093", payload: Some("{\"idx\": 10093, \"edit\": \"update\"}"), version: 20389, deleted: false, device_id: "device-1000", created_version: 10093 }
+RowDump { collection: "tags", pk: "pk-00010094", payload: Some("{\"idx\": 10094, \"edit\": \"update\"}"), version: 20390, deleted: false, device_id: "device-1000", created_version: 10094 }
+RowDump { collection: "tags", pk: "pk-00010095", payload: Some("{\"idx\": 10095, \"edit\": \"update\"}"), version: 20391, deleted: false, device_id: "device-1000", created_version: 10095 }
+RowDump { collection: "tags", pk: "pk-00010096", payload: Some("{\"idx\": 10096, \"edit\": \"update\"}"), version: 20392, deleted: false, device_id: "device-1000", created_version: 10096 }
+RowDump { collection: "archive", pk: "pk-00010097", payload: Some("{\"idx\": 10097, \"edit\": \"update\"}"), version: 20393, deleted: false, device_id: "device-1000", created_version: 10097 }
+RowDump { collection: "archive", pk: "pk-00010098", payload: Some("{\"idx\": 10098, \"edit\": \"update\"}"), version: 20394, deleted: false, device_id: "device-1000", created_version: 10098 }
+RowDump { collection: "archive", pk: "pk-00010099", payload: Some("{\"idx\": 10099, \"edit\": \"update\"}"), version: 20395, deleted: false, device_id: "device-1000", created_version: 10099 }
+RowDump { collection: "notes", pk: "pk-00010101", payload: Some("{\"idx\": 10101, \"edit\": \"update\"}"), version: 20396, deleted: false, device_id: "device-1000", created_version: 10101 }
+RowDump { collection: "notes", pk: "pk-00010102", payload: Some("{\"idx\": 10102, \"edit\": \"update\"}"), version: 20397, deleted: false, device_id: "device-1000", created_version: 10102 }
+RowDump { collection: "notes", pk: "pk-00010103", payload: Some("{\"idx\": 10103, \"edit\": \"update\"}"), version: 20398, deleted: false, device_id: "device-1000", created_version: 10103 }
+RowDump { collection: "notes", pk: "pk-00010104", payload: Some("{\"idx\": 10104, \"edit\": \"update\"}"), version: 20399, deleted: false, device_id: "device-1000", created_version: 10104 }
+RowDump { collection: "notes", pk: "pk-00010105", payload: Some("{\"idx\": 10105, \"edit\": \"update\"}"), version: 20400, deleted: false, device_id: "device-1000", created_version: 10105 }
+RowDump { collection: "notes", pk: "pk-00010106", payload: Some("{\"idx\": 10106, \"edit\": \"update\"}"), version: 20401, deleted: false, device_id: "device-1000", created_version: 10106 }
+RowDump { collection: "notes", pk: "pk-00010107", payload: Some("{\"idx\": 10107, \"edit\": \"update\"}"), version: 20402, deleted: false, device_id: "device-1000", created_version: 10107 }
+RowDump { collection: "notes", pk: "pk-00010108", payload: Some("{\"idx\": 10108, \"edit\": \"update\"}"), version: 20403, deleted: false, device_id: "device-1000", created_version: 10108 }
+RowDump { collection: "notes", pk: "pk-00010109", payload: Some("{\"idx\": 10109, \"edit\": \"update\"}"), version: 20404, deleted: false, device_id: "device-1000", created_version: 10109 }
+RowDump { collection: "notes", pk: "pk-00010110", payload: Some("{\"idx\": 10110, \"edit\": \"update\"}"), version: 20405, deleted: false, device_id: "device-1000", created_version: 10110 }
+RowDump { collection: "notes", pk: "pk-00010111", payload: Some("{\"idx\": 10111, \"edit\": \"update\"}"), version: 20406, deleted: false, device_id: "device-1000", created_version: 10111 }
+RowDump { collection: "notes", pk: "pk-00010112", payload: Some("{\"idx\": 10112, \"edit\": \"update\"}"), version: 20407, deleted: false, device_id: "device-1000", created_version: 10112 }
+RowDump { collection: "notes", pk: "pk-00010113", payload: Some("{\"idx\": 10113, \"edit\": \"update\"}"), version: 20408, deleted: false, device_id: "device-1000", created_version: 10113 }
+RowDump { collection: "notes", pk: "pk-00010114", payload: Some("{\"idx\": 10114, \"edit\": \"update\"}"), version: 20409, deleted: false, device_id: "device-1000", created_version: 10114 }
+RowDump { collection: "notes", pk: "pk-00010115", payload: Some("{\"idx\": 10115, \"edit\": \"update\"}"), version: 20410, deleted: false, device_id: "device-1000", created_version: 10115 }
+RowDump { collection: "notes", pk: "pk-00010116", payload: Some("{\"idx\": 10116, \"edit\": \"update\"}"), version: 20411, deleted: false, device_id: "device-1000", created_version: 10116 }
+RowDump { collection: "notes", pk: "pk-00010117", payload: Some("{\"idx\": 10117, \"edit\": \"update\"}"), version: 20412, deleted: false, device_id: "device-1000", created_version: 10117 }
+RowDump { collection: "notes", pk: "pk-00010118", payload: Some("{\"idx\": 10118, \"edit\": \"update\"}"), version: 20413, deleted: false, device_id: "device-1000", created_version: 10118 }
+RowDump { collection: "notes", pk: "pk-00010119", payload: Some("{\"idx\": 10119, \"edit\": \"update\"}"), version: 20414, deleted: false, device_id: "device-1000", created_version: 10119 }
+RowDump { collection: "notes", pk: "pk-00010121", payload: Some("{\"idx\": 10121, \"edit\": \"update\"}"), version: 20415, deleted: false, device_id: "device-1000", created_version: 10121 }
+RowDump { collection: "notes", pk: "pk-00010122", payload: Some("{\"idx\": 10122, \"edit\": \"update\"}"), version: 20416, deleted: false, device_id: "device-1000", created_version: 10122 }
+RowDump { collection: "notes", pk: "pk-00010123", payload: Some("{\"idx\": 10123, \"edit\": \"update\"}"), version: 20417, deleted: false, device_id: "device-1000", created_version: 10123 }
+RowDump { collection: "notes", pk: "pk-00010124", payload: Some("{\"idx\": 10124, \"edit\": \"update\"}"), version: 20418, deleted: false, device_id: "device-1000", created_version: 10124 }
+RowDump { collection: "notes", pk: "pk-00010125", payload: Some("{\"idx\": 10125, \"edit\": \"update\"}"), version: 20419, deleted: false, device_id: "device-1000", created_version: 10125 }
+RowDump { collection: "notes", pk: "pk-00010126", payload: Some("{\"idx\": 10126, \"edit\": \"update\"}"), version: 20420, deleted: false, device_id: "device-1000", created_version: 10126 }
+RowDump { collection: "notes", pk: "pk-00010127", payload: Some("{\"idx\": 10127, \"edit\": \"update\"}"), version: 20421, deleted: false, device_id: "device-1000", created_version: 10127 }
+RowDump { collection: "notes", pk: "pk-00010128", payload: Some("{\"idx\": 10128, \"edit\": \"update\"}"), version: 20422, deleted: false, device_id: "device-1000", created_version: 10128 }
+RowDump { collection: "notes", pk: "pk-00010129", payload: Some("{\"idx\": 10129, \"edit\": \"update\"}"), version: 20423, deleted: false, device_id: "device-1000", created_version: 10129 }
+RowDump { collection: "notes", pk: "pk-00010130", payload: Some("{\"idx\": 10130, \"edit\": \"update\"}"), version: 20424, deleted: false, device_id: "device-1000", created_version: 10130 }
+RowDump { collection: "notes", pk: "pk-00010131", payload: Some("{\"idx\": 10131, \"edit\": \"update\"}"), version: 20425, deleted: false, device_id: "device-1000", created_version: 10131 }
+RowDump { collection: "notes", pk: "pk-00010132", payload: Some("{\"idx\": 10132, \"edit\": \"update\"}"), version: 20426, deleted: false, device_id: "device-1000", created_version: 10132 }
+RowDump { collection: "notes", pk: "pk-00010133", payload: Some("{\"idx\": 10133, \"edit\": \"update\"}"), version: 20427, deleted: false, device_id: "device-1000", created_version: 10133 }
+RowDump { collection: "notes", pk: "pk-00010134", payload: Some("{\"idx\": 10134, \"edit\": \"update\"}"), version: 20428, deleted: false, device_id: "device-1000", created_version: 10134 }
+RowDump { collection: "notes", pk: "pk-00010135", payload: Some("{\"idx\": 10135, \"edit\": \"update\"}"), version: 20429, deleted: false, device_id: "device-1000", created_version: 10135 }
+RowDump { collection: "notes", pk: "pk-00010136", payload: Some("{\"idx\": 10136, \"edit\": \"update\"}"), version: 20430, deleted: false, device_id: "device-1000", created_version: 10136 }
+RowDump { collection: "notes", pk: "pk-00010137", payload: Some("{\"idx\": 10137, \"edit\": \"update\"}"), version: 20431, deleted: false, device_id: "device-1000", created_version: 10137 }
+RowDump { collection: "notes", pk: "pk-00010138", payload: Some("{\"idx\": 10138, \"edit\": \"update\"}"), version: 20432, deleted: false, device_id: "device-1000", created_version: 10138 }
+RowDump { collection: "notes", pk: "pk-00010139", payload: Some("{\"idx\": 10139, \"edit\": \"update\"}"), version: 20433, deleted: false, device_id: "device-1000", created_version: 10139 }
+RowDump { collection: "contacts", pk: "pk-00010141", payload: Some("{\"idx\": 10141, \"edit\": \"update\"}"), version: 20434, deleted: false, device_id: "device-1000", created_version: 10141 }
+RowDump { collection: "contacts", pk: "pk-00010142", payload: Some("{\"idx\": 10142, \"edit\": \"update\"}"), version: 20435, deleted: false, device_id: "device-1000", created_version: 10142 }
+RowDump { collection: "contacts", pk: "pk-00010143", payload: Some("{\"idx\": 10143, \"edit\": \"update\"}"), version: 20436, deleted: false, device_id: "device-1000", created_version: 10143 }
+RowDump { collection: "contacts", pk: "pk-00010144", payload: Some("{\"idx\": 10144, \"edit\": \"update\"}"), version: 20437, deleted: false, device_id: "device-1000", created_version: 10144 }
+RowDump { collection: "contacts", pk: "pk-00010145", payload: Some("{\"idx\": 10145, \"edit\": \"update\"}"), version: 20438, deleted: false, device_id: "device-1000", created_version: 10145 }
+RowDump { collection: "contacts", pk: "pk-00010146", payload: Some("{\"idx\": 10146, \"edit\": \"update\"}"), version: 20439, deleted: false, device_id: "device-1000", created_version: 10146 }
+RowDump { collection: "contacts", pk: "pk-00010147", payload: Some("{\"idx\": 10147, \"edit\": \"update\"}"), version: 20440, deleted: false, device_id: "device-1000", created_version: 10147 }
+RowDump { collection: "contacts", pk: "pk-00010148", payload: Some("{\"idx\": 10148, \"edit\": \"update\"}"), version: 20441, deleted: false, device_id: "device-1000", created_version: 10148 }
+RowDump { collection: "contacts", pk: "pk-00010149", payload: Some("{\"idx\": 10149, \"edit\": \"update\"}"), version: 20442, deleted: false, device_id: "device-1000", created_version: 10149 }
+RowDump { collection: "contacts", pk: "pk-00010150", payload: Some("{\"idx\": 10150, \"edit\": \"update\"}"), version: 20443, deleted: false, device_id: "device-1000", created_version: 10150 }
+RowDump { collection: "contacts", pk: "pk-00010151", payload: Some("{\"idx\": 10151, \"edit\": \"update\"}"), version: 20444, deleted: false, device_id: "device-1000", created_version: 10151 }
+RowDump { collection: "contacts", pk: "pk-00010152", payload: Some("{\"idx\": 10152, \"edit\": \"update\"}"), version: 20445, deleted: false, device_id: "device-1000", created_version: 10152 }
+RowDump { collection: "contacts", pk: "pk-00010153", payload: Some("{\"idx\": 10153, \"edit\": \"update\"}"), version: 20446, deleted: false, device_id: "device-1000", created_version: 10153 }
+RowDump { collection: "contacts", pk: "pk-00010154", payload: Some("{\"idx\": 10154, \"edit\": \"update\"}"), version: 20447, deleted: false, device_id: "device-1000", created_version: 10154 }
+RowDump { collection: "contacts", pk: "pk-00010155", payload: Some("{\"idx\": 10155, \"edit\": \"update\"}"), version: 20448, deleted: false, device_id: "device-1000", created_version: 10155 }
+RowDump { collection: "contacts", pk: "pk-00010156", payload: Some("{\"idx\": 10156, \"edit\": \"update\"}"), version: 20449, deleted: false, device_id: "device-1000", created_version: 10156 }
+RowDump { collection: "contacts", pk: "pk-00010157", payload: Some("{\"idx\": 10157, \"edit\": \"update\"}"), version: 20450, deleted: false, device_id: "device-1000", created_version: 10157 }
+RowDump { collection: "contacts", pk: "pk-00010158", payload: Some("{\"idx\": 10158, \"edit\": \"update\"}"), version: 20451, deleted: false, device_id: "device-1000", created_version: 10158 }
+RowDump { collection: "contacts", pk: "pk-00010159", payload: Some("{\"idx\": 10159, \"edit\": \"update\"}"), version: 20452, deleted: false, device_id: "device-1000", created_version: 10159 }
+RowDump { collection: "tasks", pk: "pk-00010161", payload: Some("{\"idx\": 10161, \"edit\": \"update\"}"), version: 20453, deleted: false, device_id: "device-1000", created_version: 10161 }
+RowDump { collection: "tasks", pk: "pk-00010162", payload: Some("{\"idx\": 10162, \"edit\": \"update\"}"), version: 20454, deleted: false, device_id: "device-1000", created_version: 10162 }
+RowDump { collection: "tasks", pk: "pk-00010163", payload: Some("{\"idx\": 10163, \"edit\": \"update\"}"), version: 20455, deleted: false, device_id: "device-1000", created_version: 10163 }
+RowDump { collection: "tasks", pk: "pk-00010164", payload: Some("{\"idx\": 10164, \"edit\": \"update\"}"), version: 20456, deleted: false, device_id: "device-1000", created_version: 10164 }
+RowDump { collection: "tasks", pk: "pk-00010165", payload: Some("{\"idx\": 10165, \"edit\": \"update\"}"), version: 20457, deleted: false, device_id: "device-1000", created_version: 10165 }
+RowDump { collection: "tasks", pk: "pk-00010166", payload: Some("{\"idx\": 10166, \"edit\": \"update\"}"), version: 20458, deleted: false, device_id: "device-1000", created_version: 10166 }
+RowDump { collection: "tasks", pk: "pk-00010167", payload: Some("{\"idx\": 10167, \"edit\": \"update\"}"), version: 20459, deleted: false, device_id: "device-1000", created_version: 10167 }
+RowDump { collection: "tasks", pk: "pk-00010168", payload: Some("{\"idx\": 10168, \"edit\": \"update\"}"), version: 20460, deleted: false, device_id: "device-1000", created_version: 10168 }
+RowDump { collection: "tasks", pk: "pk-00010169", payload: Some("{\"idx\": 10169, \"edit\": \"update\"}"), version: 20461, deleted: false, device_id: "device-1000", created_version: 10169 }
+RowDump { collection: "tasks", pk: "pk-00010170", payload: Some("{\"idx\": 10170, \"edit\": \"update\"}"), version: 20462, deleted: false, device_id: "device-1000", created_version: 10170 }
+RowDump { collection: "tasks", pk: "pk-00010171", payload: Some("{\"idx\": 10171, \"edit\": \"update\"}"), version: 20463, deleted: false, device_id: "device-1000", created_version: 10171 }
+RowDump { collection: "tasks", pk: "pk-00010172", payload: Some("{\"idx\": 10172, \"edit\": \"update\"}"), version: 20464, deleted: false, device_id: "device-1000", created_version: 10172 }
+RowDump { collection: "tasks", pk: "pk-00010173", payload: Some("{\"idx\": 10173, \"edit\": \"update\"}"), version: 20465, deleted: false, device_id: "device-1000", created_version: 10173 }
+RowDump { collection: "tasks", pk: "pk-00010174", payload: Some("{\"idx\": 10174, \"edit\": \"update\"}"), version: 20466, deleted: false, device_id: "device-1000", created_version: 10174 }
+RowDump { collection: "files", pk: "pk-00010175", payload: Some("{\"idx\": 10175, \"edit\": \"update\"}"), version: 20467, deleted: false, device_id: "device-1000", created_version: 10175 }
+RowDump { collection: "files", pk: "pk-00010176", payload: Some("{\"idx\": 10176, \"edit\": \"update\"}"), version: 20468, deleted: false, device_id: "device-1000", created_version: 10176 }
+RowDump { collection: "files", pk: "pk-00010177", payload: Some("{\"idx\": 10177, \"edit\": \"update\"}"), version: 20469, deleted: false, device_id: "device-1000", created_version: 10177 }
+RowDump { collection: "files", pk: "pk-00010178", payload: Some("{\"idx\": 10178, \"edit\": \"update\"}"), version: 20470, deleted: false, device_id: "device-1000", created_version: 10178 }
+RowDump { collection: "files", pk: "pk-00010179", payload: Some("{\"idx\": 10179, \"edit\": \"update\"}"), version: 20471, deleted: false, device_id: "device-1000", created_version: 10179 }
+RowDump { collection: "files", pk: "pk-00010181", payload: Some("{\"idx\": 10181, \"edit\": \"update\"}"), version: 20472, deleted: false, device_id: "device-1000", created_version: 10181 }
+RowDump { collection: "files", pk: "pk-00010182", payload: Some("{\"idx\": 10182, \"edit\": \"update\"}"), version: 20473, deleted: false, device_id: "device-1000", created_version: 10182 }
+RowDump { collection: "files", pk: "pk-00010183", payload: Some("{\"idx\": 10183, \"edit\": \"update\"}"), version: 20474, deleted: false, device_id: "device-1000", created_version: 10183 }
+RowDump { collection: "files", pk: "pk-00010184", payload: Some("{\"idx\": 10184, \"edit\": \"update\"}"), version: 20475, deleted: false, device_id: "device-1000", created_version: 10184 }
+RowDump { collection: "files", pk: "pk-00010185", payload: Some("{\"idx\": 10185, \"edit\": \"update\"}"), version: 20476, deleted: false, device_id: "device-1000", created_version: 10185 }
+RowDump { collection: "files", pk: "pk-00010186", payload: Some("{\"idx\": 10186, \"edit\": \"update\"}"), version: 20477, deleted: false, device_id: "device-1000", created_version: 10186 }
+RowDump { collection: "files", pk: "pk-00010187", payload: Some("{\"idx\": 10187, \"edit\": \"update\"}"), version: 20478, deleted: false, device_id: "device-1000", created_version: 10187 }
+RowDump { collection: "files", pk: "pk-00010188", payload: Some("{\"idx\": 10188, \"edit\": \"update\"}"), version: 20479, deleted: false, device_id: "device-1000", created_version: 10188 }
+RowDump { collection: "files", pk: "pk-00010189", payload: Some("{\"idx\": 10189, \"edit\": \"update\"}"), version: 20480, deleted: false, device_id: "device-1000", created_version: 10189 }
+RowDump { collection: "tags", pk: "pk-00010190", payload: Some("{\"idx\": 10190, \"edit\": \"update\"}"), version: 20481, deleted: false, device_id: "device-1000", created_version: 10190 }
+RowDump { collection: "tags", pk: "pk-00010191", payload: Some("{\"idx\": 10191, \"edit\": \"update\"}"), version: 20482, deleted: false, device_id: "device-1000", created_version: 10191 }
+RowDump { collection: "tags", pk: "pk-00010192", payload: Some("{\"idx\": 10192, \"edit\": \"update\"}"), version: 20483, deleted: false, device_id: "device-1000", created_version: 10192 }
+RowDump { collection: "tags", pk: "pk-00010193", payload: Some("{\"idx\": 10193, \"edit\": \"update\"}"), version: 20484, deleted: false, device_id: "device-1000", created_version: 10193 }
+RowDump { collection: "tags", pk: "pk-00010194", payload: Some("{\"idx\": 10194, \"edit\": \"update\"}"), version: 20485, deleted: false, device_id: "device-1000", created_version: 10194 }
+RowDump { collection: "tags", pk: "pk-00010195", payload: Some("{\"idx\": 10195, \"edit\": \"update\"}"), version: 20486, deleted: false, device_id: "device-1000", created_version: 10195 }
+RowDump { collection: "tags", pk: "pk-00010196", payload: Some("{\"idx\": 10196, \"edit\": \"update\"}"), version: 20487, deleted: false, device_id: "device-1000", created_version: 10196 }
+RowDump { collection: "archive", pk: "pk-00010197", payload: Some("{\"idx\": 10197, \"edit\": \"update\"}"), version: 20488, deleted: false, device_id: "device-1000", created_version: 10197 }
+RowDump { collection: "archive", pk: "pk-00010198", payload: Some("{\"idx\": 10198, \"edit\": \"update\"}"), version: 20489, deleted: false, device_id: "device-1000", created_version: 10198 }
+RowDump { collection: "archive", pk: "pk-00010199", payload: Some("{\"idx\": 10199, \"edit\": \"update\"}"), version: 20490, deleted: false, device_id: "device-1000", created_version: 10199 }
+RowDump { collection: "notes", pk: "pk-00010201", payload: Some("{\"idx\": 10201, \"edit\": \"update\"}"), version: 20491, deleted: false, device_id: "device-1000", created_version: 10201 }
+RowDump { collection: "notes", pk: "pk-00010202", payload: Some("{\"idx\": 10202, \"edit\": \"update\"}"), version: 20492, deleted: false, device_id: "device-1000", created_version: 10202 }
+RowDump { collection: "notes", pk: "pk-00010203", payload: Some("{\"idx\": 10203, \"edit\": \"update\"}"), version: 20493, deleted: false, device_id: "device-1000", created_version: 10203 }
+RowDump { collection: "notes", pk: "pk-00010204", payload: Some("{\"idx\": 10204, \"edit\": \"update\"}"), version: 20494, deleted: false, device_id: "device-1000", created_version: 10204 }
+RowDump { collection: "notes", pk: "pk-00010205", payload: Some("{\"idx\": 10205, \"edit\": \"update\"}"), version: 20495, deleted: false, device_id: "device-1000", created_version: 10205 }
+RowDump { collection: "notes", pk: "pk-00010206", payload: Some("{\"idx\": 10206, \"edit\": \"update\"}"), version: 20496, deleted: false, device_id: "device-1000", created_version: 10206 }
+RowDump { collection: "notes", pk: "pk-00010207", payload: Some("{\"idx\": 10207, \"edit\": \"update\"}"), version: 20497, deleted: false, device_id: "device-1000", created_version: 10207 }
+RowDump { collection: "notes", pk: "pk-00010208", payload: Some("{\"idx\": 10208, \"edit\": \"update\"}"), version: 20498, deleted: false, device_id: "device-1000", created_version: 10208 }
+RowDump { collection: "notes", pk: "pk-00010209", payload: Some("{\"idx\": 10209, \"edit\": \"update\"}"), version: 20499, deleted: false, device_id: "device-1000", created_version: 10209 }
+RowDump { collection: "notes", pk: "pk-00010210", payload: Some("{\"idx\": 10210, \"edit\": \"update\"}"), version: 20500, deleted: false, device_id: "device-1000", created_version: 10210 }
+RowDump { collection: "notes", pk: "pk-00010211", payload: Some("{\"idx\": 10211, \"edit\": \"update\"}"), version: 20501, deleted: false, device_id: "device-1000", created_version: 10211 }
+RowDump { collection: "notes", pk: "pk-00010212", payload: Some("{\"idx\": 10212, \"edit\": \"update\"}"), version: 20502, deleted: false, device_id: "device-1000", created_version: 10212 }
+RowDump { collection: "notes", pk: "pk-00010213", payload: Some("{\"idx\": 10213, \"edit\": \"update\"}"), version: 20503, deleted: false, device_id: "device-1000", created_version: 10213 }
+RowDump { collection: "notes", pk: "pk-00010214", payload: Some("{\"idx\": 10214, \"edit\": \"update\"}"), version: 20504, deleted: false, device_id: "device-1000", created_version: 10214 }
+RowDump { collection: "notes", pk: "pk-00010215", payload: Some("{\"idx\": 10215, \"edit\": \"update\"}"), version: 20505, deleted: false, device_id: "device-1000", created_version: 10215 }
+RowDump { collection: "notes", pk: "pk-00010216", payload: Some("{\"idx\": 10216, \"edit\": \"update\"}"), version: 20506, deleted: false, device_id: "device-1000", created_version: 10216 }
+RowDump { collection: "notes", pk: "pk-00010217", payload: Some("{\"idx\": 10217, \"edit\": \"update\"}"), version: 20507, deleted: false, device_id: "device-1000", created_version: 10217 }
+RowDump { collection: "notes", pk: "pk-00010218", payload: Some("{\"idx\": 10218, \"edit\": \"update\"}"), version: 20508, deleted: false, device_id: "device-1000", created_version: 10218 }
+RowDump { collection: "notes", pk: "pk-00010219", payload: Some("{\"idx\": 10219, \"edit\": \"update\"}"), version: 20509, deleted: false, device_id: "device-1000", created_version: 10219 }
+RowDump { collection: "notes", pk: "pk-00010221", payload: Some("{\"idx\": 10221, \"edit\": \"update\"}"), version: 20510, deleted: false, device_id: "device-1000", created_version: 10221 }
+RowDump { collection: "notes", pk: "pk-00010222", payload: Some("{\"idx\": 10222, \"edit\": \"update\"}"), version: 20511, deleted: false, device_id: "device-1000", created_version: 10222 }
+RowDump { collection: "notes", pk: "pk-00010223", payload: Some("{\"idx\": 10223, \"edit\": \"update\"}"), version: 20512, deleted: false, device_id: "device-1000", created_version: 10223 }
+RowDump { collection: "notes", pk: "pk-00010224", payload: Some("{\"idx\": 10224, \"edit\": \"update\"}"), version: 20513, deleted: false, device_id: "device-1000", created_version: 10224 }
+RowDump { collection: "notes", pk: "pk-00010225", payload: Some("{\"idx\": 10225, \"edit\": \"update\"}"), version: 20514, deleted: false, device_id: "device-1000", created_version: 10225 }
+RowDump { collection: "notes", pk: "pk-00010226", payload: Some("{\"idx\": 10226, \"edit\": \"update\"}"), version: 20515, deleted: false, device_id: "device-1000", created_version: 10226 }
+RowDump { collection: "notes", pk: "pk-00010227", payload: Some("{\"idx\": 10227, \"edit\": \"update\"}"), version: 20516, deleted: false, device_id: "device-1000", created_version: 10227 }
+RowDump { collection: "notes", pk: "pk-00010228", payload: Some("{\"idx\": 10228, \"edit\": \"update\"}"), version: 20517, deleted: false, device_id: "device-1000", created_version: 10228 }
+RowDump { collection: "notes", pk: "pk-00010229", payload: Some("{\"idx\": 10229, \"edit\": \"update\"}"), version: 20518, deleted: false, device_id: "device-1000", created_version: 10229 }
+RowDump { collection: "notes", pk: "pk-00010230", payload: Some("{\"idx\": 10230, \"edit\": \"update\"}"), version: 20519, deleted: false, device_id: "device-1000", created_version: 10230 }
+RowDump { collection: "notes", pk: "pk-00010231", payload: Some("{\"idx\": 10231, \"edit\": \"update\"}"), version: 20520, deleted: false, device_id: "device-1000", created_version: 10231 }
+RowDump { collection: "notes", pk: "pk-00010232", payload: Some("{\"idx\": 10232, \"edit\": \"update\"}"), version: 20521, deleted: false, device_id: "device-1000", created_version: 10232 }
+RowDump { collection: "notes", pk: "pk-00010233", payload: Some("{\"idx\": 10233, \"edit\": \"update\"}"), version: 20522, deleted: false, device_id: "device-1000", created_version: 10233 }
+RowDump { collection: "notes", pk: "pk-00010234", payload: Some("{\"idx\": 10234, \"edit\": \"update\"}"), version: 20523, deleted: false, device_id: "device-1000", created_version: 10234 }
+RowDump { collection: "notes", pk: "pk-00010235", payload: Some("{\"idx\": 10235, \"edit\": \"update\"}"), version: 20524, deleted: false, device_id: "device-1000", created_version: 10235 }
+RowDump { collection: "notes", pk: "pk-00010236", payload: Some("{\"idx\": 10236, \"edit\": \"update\"}"), version: 20525, deleted: false, device_id: "device-1000", created_version: 10236 }
+RowDump { collection: "notes", pk: "pk-00010237", payload: Some("{\"idx\": 10237, \"edit\": \"update\"}"), version: 20526, deleted: false, device_id: "device-1000", created_version: 10237 }
+RowDump { collection: "notes", pk: "pk-00010238", payload: Some("{\"idx\": 10238, \"edit\": \"update\"}"), version: 20527, deleted: false, device_id: "device-1000", created_version: 10238 }
+RowDump { collection: "notes", pk: "pk-00010239", payload: Some("{\"idx\": 10239, \"edit\": \"update\"}"), version: 20528, deleted: false, device_id: "device-1000", created_version: 10239 }
+RowDump { collection: "contacts", pk: "pk-00010241", payload: Some("{\"idx\": 10241, \"edit\": \"update\"}"), version: 20529, deleted: false, device_id: "device-1000", created_version: 10241 }
+RowDump { collection: "contacts", pk: "pk-00010242", payload: Some("{\"idx\": 10242, \"edit\": \"update\"}"), version: 20530, deleted: false, device_id: "device-1000", created_version: 10242 }
+RowDump { collection: "contacts", pk: "pk-00010243", payload: Some("{\"idx\": 10243, \"edit\": \"update\"}"), version: 20531, deleted: false, device_id: "device-1000", created_version: 10243 }
+RowDump { collection: "contacts", pk: "pk-00010244", payload: Some("{\"idx\": 10244, \"edit\": \"update\"}"), version: 20532, deleted: false, device_id: "device-1000", created_version: 10244 }
+RowDump { collection: "contacts", pk: "pk-00010245", payload: Some("{\"idx\": 10245, \"edit\": \"update\"}"), version: 20533, deleted: false, device_id: "device-1000", created_version: 10245 }
+RowDump { collection: "contacts", pk: "pk-00010246", payload: Some("{\"idx\": 10246, \"edit\": \"update\"}"), version: 20534, deleted: false, device_id: "device-1000", created_version: 10246 }
+RowDump { collection: "contacts", pk: "pk-00010247", payload: Some("{\"idx\": 10247, \"edit\": \"update\"}"), version: 20535, deleted: false, device_id: "device-1000", created_version: 10247 }
+RowDump { collection: "contacts", pk: "pk-00010248", payload: Some("{\"idx\": 10248, \"edit\": \"update\"}"), version: 20536, deleted: false, device_id: "device-1000", created_version: 10248 }
+RowDump { collection: "contacts", pk: "pk-00010249", payload: Some("{\"idx\": 10249, \"edit\": \"update\"}"), version: 20537, deleted: false, device_id: "device-1000", created_version: 10249 }
+RowDump { collection: "contacts", pk: "pk-00010250", payload: Some("{\"idx\": 10250, \"edit\": \"update\"}"), version: 20538, deleted: false, device_id: "device-1000", created_version: 10250 }
+RowDump { collection: "contacts", pk: "pk-00010251", payload: Some("{\"idx\": 10251, \"edit\": \"update\"}"), version: 20539, deleted: false, device_id: "device-1000", created_version: 10251 }
+RowDump { collection: "contacts", pk: "pk-00010252", payload: Some("{\"idx\": 10252, \"edit\": \"update\"}"), version: 20540, deleted: false, device_id: "device-1000", created_version: 10252 }
+RowDump { collection: "contacts", pk: "pk-00010253", payload: Some("{\"idx\": 10253, \"edit\": \"update\"}"), version: 20541, deleted: false, device_id: "device-1000", created_version: 10253 }
+RowDump { collection: "contacts", pk: "pk-00010254", payload: Some("{\"idx\": 10254, \"edit\": \"update\"}"), version: 20542, deleted: false, device_id: "device-1000", created_version: 10254 }
+RowDump { collection: "contacts", pk: "pk-00010255", payload: Some("{\"idx\": 10255, \"edit\": \"update\"}"), version: 20543, deleted: false, device_id: "device-1000", created_version: 10255 }
+RowDump { collection: "contacts", pk: "pk-00010256", payload: Some("{\"idx\": 10256, \"edit\": \"update\"}"), version: 20544, deleted: false, device_id: "device-1000", created_version: 10256 }
+RowDump { collection: "contacts", pk: "pk-00010257", payload: Some("{\"idx\": 10257, \"edit\": \"update\"}"), version: 20545, deleted: false, device_id: "device-1000", created_version: 10257 }
+RowDump { collection: "contacts", pk: "pk-00010258", payload: Some("{\"idx\": 10258, \"edit\": \"update\"}"), version: 20546, deleted: false, device_id: "device-1000", created_version: 10258 }
+RowDump { collection: "contacts", pk: "pk-00010259", payload: Some("{\"idx\": 10259, \"edit\": \"update\"}"), version: 20547, deleted: false, device_id: "device-1000", created_version: 10259 }
+RowDump { collection: "tasks", pk: "pk-00010261", payload: Some("{\"idx\": 10261, \"edit\": \"update\"}"), version: 20548, deleted: false, device_id: "device-1000", created_version: 10261 }
+RowDump { collection: "tasks", pk: "pk-00010262", payload: Some("{\"idx\": 10262, \"edit\": \"update\"}"), version: 20549, deleted: false, device_id: "device-1000", created_version: 10262 }
+RowDump { collection: "tasks", pk: "pk-00010263", payload: Some("{\"idx\": 10263, \"edit\": \"update\"}"), version: 20550, deleted: false, device_id: "device-1000", created_version: 10263 }
+RowDump { collection: "tasks", pk: "pk-00010264", payload: Some("{\"idx\": 10264, \"edit\": \"update\"}"), version: 20551, deleted: false, device_id: "device-1000", created_version: 10264 }
+RowDump { collection: "tasks", pk: "pk-00010265", payload: Some("{\"idx\": 10265, \"edit\": \"update\"}"), version: 20552, deleted: false, device_id: "device-1000", created_version: 10265 }
+RowDump { collection: "tasks", pk: "pk-00010266", payload: Some("{\"idx\": 10266, \"edit\": \"update\"}"), version: 20553, deleted: false, device_id: "device-1000", created_version: 10266 }
+RowDump { collection: "tasks", pk: "pk-00010267", payload: Some("{\"idx\": 10267, \"edit\": \"update\"}"), version: 20554, deleted: false, device_id: "device-1000", created_version: 10267 }
+RowDump { collection: "tasks", pk: "pk-00010268", payload: Some("{\"idx\": 10268, \"edit\": \"update\"}"), version: 20555, deleted: false, device_id: "device-1000", created_version: 10268 }
+RowDump { collection: "tasks", pk: "pk-00010269", payload: Some("{\"idx\": 10269, \"edit\": \"update\"}"), version: 20556, deleted: false, device_id: "device-1000", created_version: 10269 }
+RowDump { collection: "tasks", pk: "pk-00010270", payload: Some("{\"idx\": 10270, \"edit\": \"update\"}"), version: 20557, deleted: false, device_id: "device-1000", created_version: 10270 }
+RowDump { collection: "tasks", pk: "pk-00010271", payload: Some("{\"idx\": 10271, \"edit\": \"update\"}"), version: 20558, deleted: false, device_id: "device-1000", created_version: 10271 }
+RowDump { collection: "tasks", pk: "pk-00010272", payload: Some("{\"idx\": 10272, \"edit\": \"update\"}"), version: 20559, deleted: false, device_id: "device-1000", created_version: 10272 }
+RowDump { collection: "tasks", pk: "pk-00010273", payload: Some("{\"idx\": 10273, \"edit\": \"update\"}"), version: 20560, deleted: false, device_id: "device-1000", created_version: 10273 }
+RowDump { collection: "tasks", pk: "pk-00010274", payload: Some("{\"idx\": 10274, \"edit\": \"update\"}"), version: 20561, deleted: false, device_id: "device-1000", created_version: 10274 }
+RowDump { collection: "files", pk: "pk-00010275", payload: Some("{\"idx\": 10275, \"edit\": \"update\"}"), version: 20562, deleted: false, device_id: "device-1000", created_version: 10275 }
+RowDump { collection: "files", pk: "pk-00010276", payload: Some("{\"idx\": 10276, \"edit\": \"update\"}"), version: 20563, deleted: false, device_id: "device-1000", created_version: 10276 }
+RowDump { collection: "files", pk: "pk-00010277", payload: Some("{\"idx\": 10277, \"edit\": \"update\"}"), version: 20564, deleted: false, device_id: "device-1000", created_version: 10277 }
+RowDump { collection: "files", pk: "pk-00010278", payload: Some("{\"idx\": 10278, \"edit\": \"update\"}"), version: 20565, deleted: false, device_id: "device-1000", created_version: 10278 }
+RowDump { collection: "files", pk: "pk-00010279", payload: Some("{\"idx\": 10279, \"edit\": \"update\"}"), version: 20566, deleted: false, device_id: "device-1000", created_version: 10279 }
+RowDump { collection: "files", pk: "pk-00010281", payload: Some("{\"idx\": 10281, \"edit\": \"update\"}"), version: 20567, deleted: false, device_id: "device-1000", created_version: 10281 }
+RowDump { collection: "files", pk: "pk-00010282", payload: Some("{\"idx\": 10282, \"edit\": \"update\"}"), version: 20568, deleted: false, device_id: "device-1000", created_version: 10282 }
+RowDump { collection: "files", pk: "pk-00010283", payload: Some("{\"idx\": 10283, \"edit\": \"update\"}"), version: 20569, deleted: false, device_id: "device-1000", created_version: 10283 }
+RowDump { collection: "files", pk: "pk-00010284", payload: Some("{\"idx\": 10284, \"edit\": \"update\"}"), version: 20570, deleted: false, device_id: "device-1000", created_version: 10284 }
+RowDump { collection: "files", pk: "pk-00010285", payload: Some("{\"idx\": 10285, \"edit\": \"update\"}"), version: 20571, deleted: false, device_id: "device-1000", created_version: 10285 }
+RowDump { collection: "files", pk: "pk-00010286", payload: Some("{\"idx\": 10286, \"edit\": \"update\"}"), version: 20572, deleted: false, device_id: "device-1000", created_version: 10286 }
+RowDump { collection: "files", pk: "pk-00010287", payload: Some("{\"idx\": 10287, \"edit\": \"update\"}"), version: 20573, deleted: false, device_id: "device-1000", created_version: 10287 }
+RowDump { collection: "files", pk: "pk-00010288", payload: Some("{\"idx\": 10288, \"edit\": \"update\"}"), version: 20574, deleted: false, device_id: "device-1000", created_version: 10288 }
+RowDump { collection: "files", pk: "pk-00010289", payload: Some("{\"idx\": 10289, \"edit\": \"update\"}"), version: 20575, deleted: false, device_id: "device-1000", created_version: 10289 }
+RowDump { collection: "tags", pk: "pk-00010290", payload: Some("{\"idx\": 10290, \"edit\": \"update\"}"), version: 20576, deleted: false, device_id: "device-1000", created_version: 10290 }
+RowDump { collection: "tags", pk: "pk-00010291", payload: Some("{\"idx\": 10291, \"edit\": \"update\"}"), version: 20577, deleted: false, device_id: "device-1000", created_version: 10291 }
+RowDump { collection: "tags", pk: "pk-00010292", payload: Some("{\"idx\": 10292, \"edit\": \"update\"}"), version: 20578, deleted: false, device_id: "device-1000", created_version: 10292 }
+RowDump { collection: "tags", pk: "pk-00010293", payload: Some("{\"idx\": 10293, \"edit\": \"update\"}"), version: 20579, deleted: false, device_id: "device-1000", created_version: 10293 }
+RowDump { collection: "tags", pk: "pk-00010294", payload: Some("{\"idx\": 10294, \"edit\": \"update\"}"), version: 20580, deleted: false, device_id: "device-1000", created_version: 10294 }
+RowDump { collection: "tags", pk: "pk-00010295", payload: Some("{\"idx\": 10295, \"edit\": \"update\"}"), version: 20581, deleted: false, device_id: "device-1000", created_version: 10295 }
+RowDump { collection: "tags", pk: "pk-00010296", payload: Some("{\"idx\": 10296, \"edit\": \"update\"}"), version: 20582, deleted: false, device_id: "device-1000", created_version: 10296 }
+RowDump { collection: "archive", pk: "pk-00010297", payload: Some("{\"idx\": 10297, \"edit\": \"update\"}"), version: 20583, deleted: false, device_id: "device-1000", created_version: 10297 }
+RowDump { collection: "archive", pk: "pk-00010298", payload: Some("{\"idx\": 10298, \"edit\": \"update\"}"), version: 20584, deleted: false, device_id: "device-1000", created_version: 10298 }
+RowDump { collection: "archive", pk: "pk-00010299", payload: Some("{\"idx\": 10299, \"edit\": \"update\"}"), version: 20585, deleted: false, device_id: "device-1000", created_version: 10299 }
+RowDump { collection: "notes", pk: "pk-00010301", payload: Some("{\"idx\": 10301, \"edit\": \"update\"}"), version: 20586, deleted: false, device_id: "device-1000", created_version: 10301 }
+RowDump { collection: "notes", pk: "pk-00010302", payload: Some("{\"idx\": 10302, \"edit\": \"update\"}"), version: 20587, deleted: false, device_id: "device-1000", created_version: 10302 }
+RowDump { collection: "notes", pk: "pk-00010303", payload: Some("{\"idx\": 10303, \"edit\": \"update\"}"), version: 20588, deleted: false, device_id: "device-1000", created_version: 10303 }
+RowDump { collection: "notes", pk: "pk-00010304", payload: Some("{\"idx\": 10304, \"edit\": \"update\"}"), version: 20589, deleted: false, device_id: "device-1000", created_version: 10304 }
+RowDump { collection: "notes", pk: "pk-00010305", payload: Some("{\"idx\": 10305, \"edit\": \"update\"}"), version: 20590, deleted: false, device_id: "device-1000", created_version: 10305 }
+RowDump { collection: "notes", pk: "pk-00010306", payload: Some("{\"idx\": 10306, \"edit\": \"update\"}"), version: 20591, deleted: false, device_id: "device-1000", created_version: 10306 }
+RowDump { collection: "notes", pk: "pk-00010307", payload: Some("{\"idx\": 10307, \"edit\": \"update\"}"), version: 20592, deleted: false, device_id: "device-1000", created_version: 10307 }
+RowDump { collection: "notes", pk: "pk-00010308", payload: Some("{\"idx\": 10308, \"edit\": \"update\"}"), version: 20593, deleted: false, device_id: "device-1000", created_version: 10308 }
+RowDump { collection: "notes", pk: "pk-00010309", payload: Some("{\"idx\": 10309, \"edit\": \"update\"}"), version: 20594, deleted: false, device_id: "device-1000", created_version: 10309 }
+RowDump { collection: "notes", pk: "pk-00010310", payload: Some("{\"idx\": 10310, \"edit\": \"update\"}"), version: 20595, deleted: false, device_id: "device-1000", created_version: 10310 }
+RowDump { collection: "notes", pk: "pk-00010311", payload: Some("{\"idx\": 10311, \"edit\": \"update\"}"), version: 20596, deleted: false, device_id: "device-1000", created_version: 10311 }
+RowDump { collection: "notes", pk: "pk-00010312", payload: Some("{\"idx\": 10312, \"edit\": \"update\"}"), version: 20597, deleted: false, device_id: "device-1000", created_version: 10312 }
+RowDump { collection: "notes", pk: "pk-00010313", payload: Some("{\"idx\": 10313, \"edit\": \"update\"}"), version: 20598, deleted: false, device_id: "device-1000", created_version: 10313 }
+RowDump { collection: "notes", pk: "pk-00010314", payload: Some("{\"idx\": 10314, \"edit\": \"update\"}"), version: 20599, deleted: false, device_id: "device-1000", created_version: 10314 }
+RowDump { collection: "notes", pk: "pk-00010315", payload: Some("{\"idx\": 10315, \"edit\": \"update\"}"), version: 20600, deleted: false, device_id: "device-1000", created_version: 10315 }
+RowDump { collection: "notes", pk: "pk-00010316", payload: Some("{\"idx\": 10316, \"edit\": \"update\"}"), version: 20601, deleted: false, device_id: "device-1000", created_version: 10316 }
+RowDump { collection: "notes", pk: "pk-00010317", payload: Some("{\"idx\": 10317, \"edit\": \"update\"}"), version: 20602, deleted: false, device_id: "device-1000", created_version: 10317 }
+RowDump { collection: "notes", pk: "pk-00010318", payload: Some("{\"idx\": 10318, \"edit\": \"update\"}"), version: 20603, deleted: false, device_id: "device-1000", created_version: 10318 }
+RowDump { collection: "notes", pk: "pk-00010319", payload: Some("{\"idx\": 10319, \"edit\": \"update\"}"), version: 20604, deleted: false, device_id: "device-1000", created_version: 10319 }
+RowDump { collection: "notes", pk: "pk-00010321", payload: Some("{\"idx\": 10321, \"edit\": \"update\"}"), version: 20605, deleted: false, device_id: "device-1000", created_version: 10321 }
+RowDump { collection: "notes", pk: "pk-00010322", payload: Some("{\"idx\": 10322, \"edit\": \"update\"}"), version: 20606, deleted: false, device_id: "device-1000", created_version: 10322 }
+RowDump { collection: "notes", pk: "pk-00010323", payload: Some("{\"idx\": 10323, \"edit\": \"update\"}"), version: 20607, deleted: false, device_id: "device-1000", created_version: 10323 }
+RowDump { collection: "notes", pk: "pk-00010324", payload: Some("{\"idx\": 10324, \"edit\": \"update\"}"), version: 20608, deleted: false, device_id: "device-1000", created_version: 10324 }
+RowDump { collection: "notes", pk: "pk-00010325", payload: Some("{\"idx\": 10325, \"edit\": \"update\"}"), version: 20609, deleted: false, device_id: "device-1000", created_version: 10325 }
+RowDump { collection: "notes", pk: "pk-00010326", payload: Some("{\"idx\": 10326, \"edit\": \"update\"}"), version: 20610, deleted: false, device_id: "device-1000", created_version: 10326 }
+RowDump { collection: "notes", pk: "pk-00010327", payload: Some("{\"idx\": 10327, \"edit\": \"update\"}"), version: 20611, deleted: false, device_id: "device-1000", created_version: 10327 }
+RowDump { collection: "notes", pk: "pk-00010328", payload: Some("{\"idx\": 10328, \"edit\": \"update\"}"), version: 20612, deleted: false, device_id: "device-1000", created_version: 10328 }
+RowDump { collection: "notes", pk: "pk-00010329", payload: Some("{\"idx\": 10329, \"edit\": \"update\"}"), version: 20613, deleted: false, device_id: "device-1000", created_version: 10329 }
+RowDump { collection: "notes", pk: "pk-00010330", payload: Some("{\"idx\": 10330, \"edit\": \"update\"}"), version: 20614, deleted: false, device_id: "device-1000", created_version: 10330 }
+RowDump { collection: "notes", pk: "pk-00010331", payload: Some("{\"idx\": 10331, \"edit\": \"update\"}"), version: 20615, deleted: false, device_id: "device-1000", created_version: 10331 }
+RowDump { collection: "notes", pk: "pk-00010332", payload: Some("{\"idx\": 10332, \"edit\": \"update\"}"), version: 20616, deleted: false, device_id: "device-1000", created_version: 10332 }
+RowDump { collection: "notes", pk: "pk-00010333", payload: Some("{\"idx\": 10333, \"edit\": \"update\"}"), version: 20617, deleted: false, device_id: "device-1000", created_version: 10333 }
+RowDump { collection: "notes", pk: "pk-00010334", payload: Some("{\"idx\": 10334, \"edit\": \"update\"}"), version: 20618, deleted: false, device_id: "device-1000", created_version: 10334 }
+RowDump { collection: "notes", pk: "pk-00010335", payload: Some("{\"idx\": 10335, \"edit\": \"update\"}"), version: 20619, deleted: false, device_id: "device-1000", created_version: 10335 }
+RowDump { collection: "notes", pk: "pk-00010336", payload: Some("{\"idx\": 10336, \"edit\": \"update\"}"), version: 20620, deleted: false, device_id: "device-1000", created_version: 10336 }
+RowDump { collection: "notes", pk: "pk-00010337", payload: Some("{\"idx\": 10337, \"edit\": \"update\"}"), version: 20621, deleted: false, device_id: "device-1000", created_version: 10337 }
+RowDump { collection: "notes", pk: "pk-00010338", payload: Some("{\"idx\": 10338, \"edit\": \"update\"}"), version: 20622, deleted: false, device_id: "device-1000", created_version: 10338 }
+RowDump { collection: "notes", pk: "pk-00010339", payload: Some("{\"idx\": 10339, \"edit\": \"update\"}"), version: 20623, deleted: false, device_id: "device-1000", created_version: 10339 }
+RowDump { collection: "contacts", pk: "pk-00010341", payload: Some("{\"idx\": 10341, \"edit\": \"update\"}"), version: 20624, deleted: false, device_id: "device-1000", created_version: 10341 }
+RowDump { collection: "contacts", pk: "pk-00010342", payload: Some("{\"idx\": 10342, \"edit\": \"update\"}"), version: 20625, deleted: false, device_id: "device-1000", created_version: 10342 }
+RowDump { collection: "contacts", pk: "pk-00010343", payload: Some("{\"idx\": 10343, \"edit\": \"update\"}"), version: 20626, deleted: false, device_id: "device-1000", created_version: 10343 }
+RowDump { collection: "contacts", pk: "pk-00010344", payload: Some("{\"idx\": 10344, \"edit\": \"update\"}"), version: 20627, deleted: false, device_id: "device-1000", created_version: 10344 }
+RowDump { collection: "contacts", pk: "pk-00010345", payload: Some("{\"idx\": 10345, \"edit\": \"update\"}"), version: 20628, deleted: false, device_id: "device-1000", created_version: 10345 }
+RowDump { collection: "contacts", pk: "pk-00010346", payload: Some("{\"idx\": 10346, \"edit\": \"update\"}"), version: 20629, deleted: false, device_id: "device-1000", created_version: 10346 }
+RowDump { collection: "contacts", pk: "pk-00010347", payload: Some("{\"idx\": 10347, \"edit\": \"update\"}"), version: 20630, deleted: false, device_id: "device-1000", created_version: 10347 }
+RowDump { collection: "contacts", pk: "pk-00010348", payload: Some("{\"idx\": 10348, \"edit\": \"update\"}"), version: 20631, deleted: false, device_id: "device-1000", created_version: 10348 }
+RowDump { collection: "contacts", pk: "pk-00010349", payload: Some("{\"idx\": 10349, \"edit\": \"update\"}"), version: 20632, deleted: false, device_id: "device-1000", created_version: 10349 }
+RowDump { collection: "contacts", pk: "pk-00010350", payload: Some("{\"idx\": 10350, \"edit\": \"update\"}"), version: 20633, deleted: false, device_id: "device-1000", created_version: 10350 }
+RowDump { collection: "contacts", pk: "pk-00010351", payload: Some("{\"idx\": 10351, \"edit\": \"update\"}"), version: 20634, deleted: false, device_id: "device-1000", created_version: 10351 }
+RowDump { collection: "contacts", pk: "pk-00010352", payload: Some("{\"idx\": 10352, \"edit\": \"update\"}"), version: 20635, deleted: false, device_id: "device-1000", created_version: 10352 }
+RowDump { collection: "contacts", pk: "pk-00010353", payload: Some("{\"idx\": 10353, \"edit\": \"update\"}"), version: 20636, deleted: false, device_id: "device-1000", created_version: 10353 }
+RowDump { collection: "contacts", pk: "pk-00010354", payload: Some("{\"idx\": 10354, \"edit\": \"update\"}"), version: 20637, deleted: false, device_id: "device-1000", created_version: 10354 }
+RowDump { collection: "contacts", pk: "pk-00010355", payload: Some("{\"idx\": 10355, \"edit\": \"update\"}"), version: 20638, deleted: false, device_id: "device-1000", created_version: 10355 }
+RowDump { collection: "contacts", pk: "pk-00010356", payload: Some("{\"idx\": 10356, \"edit\": \"update\"}"), version: 20639, deleted: false, device_id: "device-1000", created_version: 10356 }
+RowDump { collection: "contacts", pk: "pk-00010357", payload: Some("{\"idx\": 10357, \"edit\": \"update\"}"), version: 20640, deleted: false, device_id: "device-1000", created_version: 10357 }
+RowDump { collection: "contacts", pk: "pk-00010358", payload: Some("{\"idx\": 10358, \"edit\": \"update\"}"), version: 20641, deleted: false, device_id: "device-1000", created_version: 10358 }
+RowDump { collection: "contacts", pk: "pk-00010359", payload: Some("{\"idx\": 10359, \"edit\": \"update\"}"), version: 20642, deleted: false, device_id: "device-1000", created_version: 10359 }
+RowDump { collection: "tasks", pk: "pk-00010361", payload: Some("{\"idx\": 10361, \"edit\": \"update\"}"), version: 20643, deleted: false, device_id: "device-1000", created_version: 10361 }
+RowDump { collection: "tasks", pk: "pk-00010362", payload: Some("{\"idx\": 10362, \"edit\": \"update\"}"), version: 20644, deleted: false, device_id: "device-1000", created_version: 10362 }
+RowDump { collection: "tasks", pk: "pk-00010363", payload: Some("{\"idx\": 10363, \"edit\": \"update\"}"), version: 20645, deleted: false, device_id: "device-1000", created_version: 10363 }
+RowDump { collection: "tasks", pk: "pk-00010364", payload: Some("{\"idx\": 10364, \"edit\": \"update\"}"), version: 20646, deleted: false, device_id: "device-1000", created_version: 10364 }
+RowDump { collection: "tasks", pk: "pk-00010365", payload: Some("{\"idx\": 10365, \"edit\": \"update\"}"), version: 20647, deleted: false, device_id: "device-1000", created_version: 10365 }
+RowDump { collection: "tasks", pk: "pk-00010366", payload: Some("{\"idx\": 10366, \"edit\": \"update\"}"), version: 20648, deleted: false, device_id: "device-1000", created_version: 10366 }
+RowDump { collection: "tasks", pk: "pk-00010367", payload: Some("{\"idx\": 10367, \"edit\": \"update\"}"), version: 20649, deleted: false, device_id: "device-1000", created_version: 10367 }
+RowDump { collection: "tasks", pk: "pk-00010368", payload: Some("{\"idx\": 10368, \"edit\": \"update\"}"), version: 20650, deleted: false, device_id: "device-1000", created_version: 10368 }
+RowDump { collection: "tasks", pk: "pk-00010369", payload: Some("{\"idx\": 10369, \"edit\": \"update\"}"), version: 20651, deleted: false, device_id: "device-1000", created_version: 10369 }
+RowDump { collection: "tasks", pk: "pk-00010370", payload: Some("{\"idx\": 10370, \"edit\": \"update\"}"), version: 20652, deleted: false, device_id: "device-1000", created_version: 10370 }
+RowDump { collection: "tasks", pk: "pk-00010371", payload: Some("{\"idx\": 10371, \"edit\": \"update\"}"), version: 20653, deleted: false, device_id: "device-1000", created_version: 10371 }
+RowDump { collection: "tasks", pk: "pk-00010372", payload: Some("{\"idx\": 10372, \"edit\": \"update\"}"), version: 20654, deleted: false, device_id: "device-1000", created_version: 10372 }
+RowDump { collection: "tasks", pk: "pk-00010373", payload: Some("{\"idx\": 10373, \"edit\": \"update\"}"), version: 20655, deleted: false, device_id: "device-1000", created_version: 10373 }
+RowDump { collection: "tasks", pk: "pk-00010374", payload: Some("{\"idx\": 10374, \"edit\": \"update\"}"), version: 20656, deleted: false, device_id: "device-1000", created_version: 10374 }
+RowDump { collection: "files", pk: "pk-00010375", payload: Some("{\"idx\": 10375, \"edit\": \"update\"}"), version: 20657, deleted: false, device_id: "device-1000", created_version: 10375 }
+RowDump { collection: "files", pk: "pk-00010376", payload: Some("{\"idx\": 10376, \"edit\": \"update\"}"), version: 20658, deleted: false, device_id: "device-1000", created_version: 10376 }
+RowDump { collection: "files", pk: "pk-00010377", payload: Some("{\"idx\": 10377, \"edit\": \"update\"}"), version: 20659, deleted: false, device_id: "device-1000", created_version: 10377 }
+RowDump { collection: "files", pk: "pk-00010378", payload: Some("{\"idx\": 10378, \"edit\": \"update\"}"), version: 20660, deleted: false, device_id: "device-1000", created_version: 10378 }
+RowDump { collection: "files", pk: "pk-00010379", payload: Some("{\"idx\": 10379, \"edit\": \"update\"}"), version: 20661, deleted: false, device_id: "device-1000", created_version: 10379 }
+RowDump { collection: "files", pk: "pk-00010381", payload: Some("{\"idx\": 10381, \"edit\": \"update\"}"), version: 20662, deleted: false, device_id: "device-1000", created_version: 10381 }
+RowDump { collection: "files", pk: "pk-00010382", payload: Some("{\"idx\": 10382, \"edit\": \"update\"}"), version: 20663, deleted: false, device_id: "device-1000", created_version: 10382 }
+RowDump { collection: "files", pk: "pk-00010383", payload: Some("{\"idx\": 10383, \"edit\": \"update\"}"), version: 20664, deleted: false, device_id: "device-1000", created_version: 10383 }
+RowDump { collection: "files", pk: "pk-00010384", payload: Some("{\"idx\": 10384, \"edit\": \"update\"}"), version: 20665, deleted: false, device_id: "device-1000", created_version: 10384 }
+RowDump { collection: "files", pk: "pk-00010385", payload: Some("{\"idx\": 10385, \"edit\": \"update\"}"), version: 20666, deleted: false, device_id: "device-1000", created_version: 10385 }
+RowDump { collection: "files", pk: "pk-00010386", payload: Some("{\"idx\": 10386, \"edit\": \"update\"}"), version: 20667, deleted: false, device_id: "device-1000", created_version: 10386 }
+RowDump { collection: "files", pk: "pk-00010387", payload: Some("{\"idx\": 10387, \"edit\": \"update\"}"), version: 20668, deleted: false, device_id: "device-1000", created_version: 10387 }
+RowDump { collection: "files", pk: "pk-00010388", payload: Some("{\"idx\": 10388, \"edit\": \"update\"}"), version: 20669, deleted: false, device_id: "device-1000", created_version: 10388 }
+RowDump { collection: "files", pk: "pk-00010389", payload: Some("{\"idx\": 10389, \"edit\": \"update\"}"), version: 20670, deleted: false, device_id: "device-1000", created_version: 10389 }
+RowDump { collection: "tags", pk: "pk-00010390", payload: Some("{\"idx\": 10390, \"edit\": \"update\"}"), version: 20671, deleted: false, device_id: "device-1000", created_version: 10390 }
+RowDump { collection: "tags", pk: "pk-00010391", payload: Some("{\"idx\": 10391, \"edit\": \"update\"}"), version: 20672, deleted: false, device_id: "device-1000", created_version: 10391 }
+RowDump { collection: "tags", pk: "pk-00010392", payload: Some("{\"idx\": 10392, \"edit\": \"update\"}"), version: 20673, deleted: false, device_id: "device-1000", created_version: 10392 }
+RowDump { collection: "tags", pk: "pk-00010393", payload: Some("{\"idx\": 10393, \"edit\": \"update\"}"), version: 20674, deleted: false, device_id: "device-1000", created_version: 10393 }
+RowDump { collection: "tags", pk: "pk-00010394", payload: Some("{\"idx\": 10394, \"edit\": \"update\"}"), version: 20675, deleted: false, device_id: "device-1000", created_version: 10394 }
+RowDump { collection: "tags", pk: "pk-00010395", payload: Some("{\"idx\": 10395, \"edit\": \"update\"}"), version: 20676, deleted: false, device_id: "device-1000", created_version: 10395 }
+RowDump { collection: "tags", pk: "pk-00010396", payload: Some("{\"idx\": 10396, \"edit\": \"update\"}"), version: 20677, deleted: false, device_id: "device-1000", created_version: 10396 }
+RowDump { collection: "archive", pk: "pk-00010397", payload: Some("{\"idx\": 10397, \"edit\": \"update\"}"), version: 20678, deleted: false, device_id: "device-1000", created_version: 10397 }
+RowDump { collection: "archive", pk: "pk-00010398", payload: Some("{\"idx\": 10398, \"edit\": \"update\"}"), version: 20679, deleted: false, device_id: "device-1000", created_version: 10398 }
+RowDump { collection: "archive", pk: "pk-00010399", payload: Some("{\"idx\": 10399, \"edit\": \"update\"}"), version: 20680, deleted: false, device_id: "device-1000", created_version: 10399 }
+RowDump { collection: "notes", pk: "pk-00010401", payload: Some("{\"idx\": 10401, \"edit\": \"update\"}"), version: 20681, deleted: false, device_id: "device-1000", created_version: 10401 }
+RowDump { collection: "notes", pk: "pk-00010402", payload: Some("{\"idx\": 10402, \"edit\": \"update\"}"), version: 20682, deleted: false, device_id: "device-1000", created_version: 10402 }
+RowDump { collection: "notes", pk: "pk-00010403", payload: Some("{\"idx\": 10403, \"edit\": \"update\"}"), version: 20683, deleted: false, device_id: "device-1000", created_version: 10403 }
+RowDump { collection: "notes", pk: "pk-00010404", payload: Some("{\"idx\": 10404, \"edit\": \"update\"}"), version: 20684, deleted: false, device_id: "device-1000", created_version: 10404 }
+RowDump { collection: "notes", pk: "pk-00010405", payload: Some("{\"idx\": 10405, \"edit\": \"update\"}"), version: 20685, deleted: false, device_id: "device-1000", created_version: 10405 }
+RowDump { collection: "notes", pk: "pk-00010406", payload: Some("{\"idx\": 10406, \"edit\": \"update\"}"), version: 20686, deleted: false, device_id: "device-1000", created_version: 10406 }
+RowDump { collection: "notes", pk: "pk-00010407", payload: Some("{\"idx\": 10407, \"edit\": \"update\"}"), version: 20687, deleted: false, device_id: "device-1000", created_version: 10407 }
+RowDump { collection: "notes", pk: "pk-00010408", payload: Some("{\"idx\": 10408, \"edit\": \"update\"}"), version: 20688, deleted: false, device_id: "device-1000", created_version: 10408 }
+RowDump { collection: "notes", pk: "pk-00010409", payload: Some("{\"idx\": 10409, \"edit\": \"update\"}"), version: 20689, deleted: false, device_id: "device-1000", created_version: 10409 }
+RowDump { collection: "notes", pk: "pk-00010410", payload: Some("{\"idx\": 10410, \"edit\": \"update\"}"), version: 20690, deleted: false, device_id: "device-1000", created_version: 10410 }
+RowDump { collection: "notes", pk: "pk-00010411", payload: Some("{\"idx\": 10411, \"edit\": \"update\"}"), version: 20691, deleted: false, device_id: "device-1000", created_version: 10411 }
+RowDump { collection: "notes", pk: "pk-00010412", payload: Some("{\"idx\": 10412, \"edit\": \"update\"}"), version: 20692, deleted: false, device_id: "device-1000", created_version: 10412 }
+RowDump { collection: "notes", pk: "pk-00010413", payload: Some("{\"idx\": 10413, \"edit\": \"update\"}"), version: 20693, deleted: false, device_id: "device-1000", created_version: 10413 }
+RowDump { collection: "notes", pk: "pk-00010414", payload: Some("{\"idx\": 10414, \"edit\": \"update\"}"), version: 20694, deleted: false, device_id: "device-1000", created_version: 10414 }
+RowDump { collection: "notes", pk: "pk-00010415", payload: Some("{\"idx\": 10415, \"edit\": \"update\"}"), version: 20695, deleted: false, device_id: "device-1000", created_version: 10415 }
+RowDump { collection: "notes", pk: "pk-00010416", payload: Some("{\"idx\": 10416, \"edit\": \"update\"}"), version: 20696, deleted: false, device_id: "device-1000", created_version: 10416 }
+RowDump { collection: "notes", pk: "pk-00010417", payload: Some("{\"idx\": 10417, \"edit\": \"update\"}"), version: 20697, deleted: false, device_id: "device-1000", created_version: 10417 }
+RowDump { collection: "notes", pk: "pk-00010418", payload: Some("{\"idx\": 10418, \"edit\": \"update\"}"), version: 20698, deleted: false, device_id: "device-1000", created_version: 10418 }
+RowDump { collection: "notes", pk: "pk-00010419", payload: Some("{\"idx\": 10419, \"edit\": \"update\"}"), version: 20699, deleted: false, device_id: "device-1000", created_version: 10419 }
+RowDump { collection: "notes", pk: "pk-00010421", payload: Some("{\"idx\": 10421, \"edit\": \"update\"}"), version: 20700, deleted: false, device_id: "device-1000", created_version: 10421 }
+RowDump { collection: "notes", pk: "pk-00010422", payload: Some("{\"idx\": 10422, \"edit\": \"update\"}"), version: 20701, deleted: false, device_id: "device-1000", created_version: 10422 }
+RowDump { collection: "notes", pk: "pk-00010423", payload: Some("{\"idx\": 10423, \"edit\": \"update\"}"), version: 20702, deleted: false, device_id: "device-1000", created_version: 10423 }
+RowDump { collection: "notes", pk: "pk-00010424", payload: Some("{\"idx\": 10424, \"edit\": \"update\"}"), version: 20703, deleted: false, device_id: "device-1000", created_version: 10424 }
+RowDump { collection: "notes", pk: "pk-00010425", payload: Some("{\"idx\": 10425, \"edit\": \"update\"}"), version: 20704, deleted: false, device_id: "device-1000", created_version: 10425 }
+RowDump { collection: "notes", pk: "pk-00010426", payload: Some("{\"idx\": 10426, \"edit\": \"update\"}"), version: 20705, deleted: false, device_id: "device-1000", created_version: 10426 }
+RowDump { collection: "notes", pk: "pk-00010427", payload: Some("{\"idx\": 10427, \"edit\": \"update\"}"), version: 20706, deleted: false, device_id: "device-1000", created_version: 10427 }
+RowDump { collection: "notes", pk: "pk-00010428", payload: Some("{\"idx\": 10428, \"edit\": \"update\"}"), version: 20707, deleted: false, device_id: "device-1000", created_version: 10428 }
+RowDump { collection: "notes", pk: "pk-00010429", payload: Some("{\"idx\": 10429, \"edit\": \"update\"}"), version: 20708, deleted: false, device_id: "device-1000", created_version: 10429 }
+RowDump { collection: "notes", pk: "pk-00010430", payload: Some("{\"idx\": 10430, \"edit\": \"update\"}"), version: 20709, deleted: false, device_id: "device-1000", created_version: 10430 }
+RowDump { collection: "notes", pk: "pk-00010431", payload: Some("{\"idx\": 10431, \"edit\": \"update\"}"), version: 20710, deleted: false, device_id: "device-1000", created_version: 10431 }
+RowDump { collection: "notes", pk: "pk-00010432", payload: Some("{\"idx\": 10432, \"edit\": \"update\"}"), version: 20711, deleted: false, device_id: "device-1000", created_version: 10432 }
+RowDump { collection: "notes", pk: "pk-00010433", payload: Some("{\"idx\": 10433, \"edit\": \"update\"}"), version: 20712, deleted: false, device_id: "device-1000", created_version: 10433 }
+RowDump { collection: "notes", pk: "pk-00010434", payload: Some("{\"idx\": 10434, \"edit\": \"update\"}"), version: 20713, deleted: false, device_id: "device-1000", created_version: 10434 }
+RowDump { collection: "notes", pk: "pk-00010435", payload: Some("{\"idx\": 10435, \"edit\": \"update\"}"), version: 20714, deleted: false, device_id: "device-1000", created_version: 10435 }
+RowDump { collection: "notes", pk: "pk-00010436", payload: Some("{\"idx\": 10436, \"edit\": \"update\"}"), version: 20715, deleted: false, device_id: "device-1000", created_version: 10436 }
+RowDump { collection: "notes", pk: "pk-00010437", payload: Some("{\"idx\": 10437, \"edit\": \"update\"}"), version: 20716, deleted: false, device_id: "device-1000", created_version: 10437 }
+RowDump { collection: "notes", pk: "pk-00010438", payload: Some("{\"idx\": 10438, \"edit\": \"update\"}"), version: 20717, deleted: false, device_id: "device-1000", created_version: 10438 }
+RowDump { collection: "notes", pk: "pk-00010439", payload: Some("{\"idx\": 10439, \"edit\": \"update\"}"), version: 20718, deleted: false, device_id: "device-1000", created_version: 10439 }
+RowDump { collection: "contacts", pk: "pk-00010441", payload: Some("{\"idx\": 10441, \"edit\": \"update\"}"), version: 20719, deleted: false, device_id: "device-1000", created_version: 10441 }
+RowDump { collection: "contacts", pk: "pk-00010442", payload: Some("{\"idx\": 10442, \"edit\": \"update\"}"), version: 20720, deleted: false, device_id: "device-1000", created_version: 10442 }
+RowDump { collection: "contacts", pk: "pk-00010443", payload: Some("{\"idx\": 10443, \"edit\": \"update\"}"), version: 20721, deleted: false, device_id: "device-1000", created_version: 10443 }
+RowDump { collection: "contacts", pk: "pk-00010444", payload: Some("{\"idx\": 10444, \"edit\": \"update\"}"), version: 20722, deleted: false, device_id: "device-1000", created_version: 10444 }
+RowDump { collection: "contacts", pk: "pk-00010445", payload: Some("{\"idx\": 10445, \"edit\": \"update\"}"), version: 20723, deleted: false, device_id: "device-1000", created_version: 10445 }
+RowDump { collection: "contacts", pk: "pk-00010446", payload: Some("{\"idx\": 10446, \"edit\": \"update\"}"), version: 20724, deleted: false, device_id: "device-1000", created_version: 10446 }
+RowDump { collection: "contacts", pk: "pk-00010447", payload: Some("{\"idx\": 10447, \"edit\": \"update\"}"), version: 20725, deleted: false, device_id: "device-1000", created_version: 10447 }
+RowDump { collection: "contacts", pk: "pk-00010448", payload: Some("{\"idx\": 10448, \"edit\": \"update\"}"), version: 20726, deleted: false, device_id: "device-1000", created_version: 10448 }
+RowDump { collection: "contacts", pk: "pk-00010449", payload: Some("{\"idx\": 10449, \"edit\": \"update\"}"), version: 20727, deleted: false, device_id: "device-1000", created_version: 10449 }
+RowDump { collection: "contacts", pk: "pk-00010450", payload: Some("{\"idx\": 10450, \"edit\": \"update\"}"), version: 20728, deleted: false, device_id: "device-1000", created_version: 10450 }
+RowDump { collection: "contacts", pk: "pk-00010451", payload: Some("{\"idx\": 10451, \"edit\": \"update\"}"), version: 20729, deleted: false, device_id: "device-1000", created_version: 10451 }
+RowDump { collection: "contacts", pk: "pk-00010452", payload: Some("{\"idx\": 10452, \"edit\": \"update\"}"), version: 20730, deleted: false, device_id: "device-1000", created_version: 10452 }
+RowDump { collection: "contacts", pk: "pk-00010453", payload: Some("{\"idx\": 10453, \"edit\": \"update\"}"), version: 20731, deleted: false, device_id: "device-1000", created_version: 10453 }
+RowDump { collection: "contacts", pk: "pk-00010454", payload: Some("{\"idx\": 10454, \"edit\": \"update\"}"), version: 20732, deleted: false, device_id: "device-1000", created_version: 10454 }
+RowDump { collection: "contacts", pk: "pk-00010455", payload: Some("{\"idx\": 10455, \"edit\": \"update\"}"), version: 20733, deleted: false, device_id: "device-1000", created_version: 10455 }
+RowDump { collection: "contacts", pk: "pk-00010456", payload: Some("{\"idx\": 10456, \"edit\": \"update\"}"), version: 20734, deleted: false, device_id: "device-1000", created_version: 10456 }
+RowDump { collection: "contacts", pk: "pk-00010457", payload: Some("{\"idx\": 10457, \"edit\": \"update\"}"), version: 20735, deleted: false, device_id: "device-1000", created_version: 10457 }
+RowDump { collection: "contacts", pk: "pk-00010458", payload: Some("{\"idx\": 10458, \"edit\": \"update\"}"), version: 20736, deleted: false, device_id: "device-1000", created_version: 10458 }
+RowDump { collection: "contacts", pk: "pk-00010459", payload: Some("{\"idx\": 10459, \"edit\": \"update\"}"), version: 20737, deleted: false, device_id: "device-1000", created_version: 10459 }
+RowDump { collection: "tasks", pk: "pk-00010461", payload: Some("{\"idx\": 10461, \"edit\": \"update\"}"), version: 20738, deleted: false, device_id: "device-1000", created_version: 10461 }
+RowDump { collection: "tasks", pk: "pk-00010462", payload: Some("{\"idx\": 10462, \"edit\": \"update\"}"), version: 20739, deleted: false, device_id: "device-1000", created_version: 10462 }
+RowDump { collection: "tasks", pk: "pk-00010463", payload: Some("{\"idx\": 10463, \"edit\": \"update\"}"), version: 20740, deleted: false, device_id: "device-1000", created_version: 10463 }
+RowDump { collection: "tasks", pk: "pk-00010464", payload: Some("{\"idx\": 10464, \"edit\": \"update\"}"), version: 20741, deleted: false, device_id: "device-1000", created_version: 10464 }
+RowDump { collection: "tasks", pk: "pk-00010465", payload: Some("{\"idx\": 10465, \"edit\": \"update\"}"), version: 20742, deleted: false, device_id: "device-1000", created_version: 10465 }
+RowDump { collection: "tasks", pk: "pk-00010466", payload: Some("{\"idx\": 10466, \"edit\": \"update\"}"), version: 20743, deleted: false, device_id: "device-1000", created_version: 10466 }
+RowDump { collection: "tasks", pk: "pk-00010467", payload: Some("{\"idx\": 10467, \"edit\": \"update\"}"), version: 20744, deleted: false, device_id: "device-1000", created_version: 10467 }
+RowDump { collection: "tasks", pk: "pk-00010468", payload: Some("{\"idx\": 10468, \"edit\": \"update\"}"), version: 20745, deleted: false, device_id: "device-1000", created_version: 10468 }
+RowDump { collection: "tasks", pk: "pk-00010469", payload: Some("{\"idx\": 10469, \"edit\": \"update\"}"), version: 20746, deleted: false, device_id: "device-1000", created_version: 10469 }
+RowDump { collection: "tasks", pk: "pk-00010470", payload: Some("{\"idx\": 10470, \"edit\": \"update\"}"), version: 20747, deleted: false, device_id: "device-1000", created_version: 10470 }
+RowDump { collection: "tasks", pk: "pk-00010471", payload: Some("{\"idx\": 10471, \"edit\": \"update\"}"), version: 20748, deleted: false, device_id: "device-1000", created_version: 10471 }
+RowDump { collection: "tasks", pk: "pk-00010472", payload: Some("{\"idx\": 10472, \"edit\": \"update\"}"), version: 20749, deleted: false, device_id: "device-1000", created_version: 10472 }
+RowDump { collection: "tasks", pk: "pk-00010473", payload: Some("{\"idx\": 10473, \"edit\": \"update\"}"), version: 20750, deleted: false, device_id: "device-1000", created_version: 10473 }
+RowDump { collection: "tasks", pk: "pk-00010474", payload: Some("{\"idx\": 10474, \"edit\": \"update\"}"), version: 20751, deleted: false, device_id: "device-1000", created_version: 10474 }
+RowDump { collection: "files", pk: "pk-00010475", payload: Some("{\"idx\": 10475, \"edit\": \"update\"}"), version: 20752, deleted: false, device_id: "device-1000", created_version: 10475 }
+RowDump { collection: "files", pk: "pk-00010476", payload: Some("{\"idx\": 10476, \"edit\": \"update\"}"), version: 20753, deleted: false, device_id: "device-1000", created_version: 10476 }
+RowDump { collection: "files", pk: "pk-00010477", payload: Some("{\"idx\": 10477, \"edit\": \"update\"}"), version: 20754, deleted: false, device_id: "device-1000", created_version: 10477 }
+RowDump { collection: "files", pk: "pk-00010478", payload: Some("{\"idx\": 10478, \"edit\": \"update\"}"), version: 20755, deleted: false, device_id: "device-1000", created_version: 10478 }
+RowDump { collection: "files", pk: "pk-00010479", payload: Some("{\"idx\": 10479, \"edit\": \"update\"}"), version: 20756, deleted: false, device_id: "device-1000", created_version: 10479 }
+RowDump { collection: "files", pk: "pk-00010481", payload: Some("{\"idx\": 10481, \"edit\": \"update\"}"), version: 20757, deleted: false, device_id: "device-1000", created_version: 10481 }
+RowDump { collection: "files", pk: "pk-00010482", payload: Some("{\"idx\": 10482, \"edit\": \"update\"}"), version: 20758, deleted: false, device_id: "device-1000", created_version: 10482 }
+RowDump { collection: "files", pk: "pk-00010483", payload: Some("{\"idx\": 10483, \"edit\": \"update\"}"), version: 20759, deleted: false, device_id: "device-1000", created_version: 10483 }
+RowDump { collection: "files", pk: "pk-00010484", payload: Some("{\"idx\": 10484, \"edit\": \"update\"}"), version: 20760, deleted: false, device_id: "device-1000", created_version: 10484 }
+RowDump { collection: "files", pk: "pk-00010485", payload: Some("{\"idx\": 10485, \"edit\": \"update\"}"), version: 20761, deleted: false, device_id: "device-1000", created_version: 10485 }
+RowDump { collection: "files", pk: "pk-00010486", payload: Some("{\"idx\": 10486, \"edit\": \"update\"}"), version: 20762, deleted: false, device_id: "device-1000", created_version: 10486 }
+RowDump { collection: "files", pk: "pk-00010487", payload: Some("{\"idx\": 10487, \"edit\": \"update\"}"), version: 20763, deleted: false, device_id: "device-1000", created_version: 10487 }
+RowDump { collection: "files", pk: "pk-00010488", payload: Some("{\"idx\": 10488, \"edit\": \"update\"}"), version: 20764, deleted: false, device_id: "device-1000", created_version: 10488 }
+RowDump { collection: "files", pk: "pk-00010489", payload: Some("{\"idx\": 10489, \"edit\": \"update\"}"), version: 20765, deleted: false, device_id: "device-1000", created_version: 10489 }
+RowDump { collection: "tags", pk: "pk-00010490", payload: Some("{\"idx\": 10490, \"edit\": \"update\"}"), version: 20766, deleted: false, device_id: "device-1000", created_version: 10490 }
+RowDump { collection: "tags", pk: "pk-00010491", payload: Some("{\"idx\": 10491, \"edit\": \"update\"}"), version: 20767, deleted: false, device_id: "device-1000", created_version: 10491 }
+RowDump { collection: "tags", pk: "pk-00010492", payload: Some("{\"idx\": 10492, \"edit\": \"update\"}"), version: 20768, deleted: false, device_id: "device-1000", created_version: 10492 }
+RowDump { collection: "tags", pk: "pk-00010493", payload: Some("{\"idx\": 10493, \"edit\": \"update\"}"), version: 20769, deleted: false, device_id: "device-1000", created_version: 10493 }
+RowDump { collection: "tags", pk: "pk-00010494", payload: Some("{\"idx\": 10494, \"edit\": \"update\"}"), version: 20770, deleted: false, device_id: "device-1000", created_version: 10494 }
+RowDump { collection: "tags", pk: "pk-00010495", payload: Some("{\"idx\": 10495, \"edit\": \"update\"}"), version: 20771, deleted: false, device_id: "device-1000", created_version: 10495 }
+RowDump { collection: "tags", pk: "pk-00010496", payload: Some("{\"idx\": 10496, \"edit\": \"update\"}"), version: 20772, deleted: false, device_id: "device-1000", created_version: 10496 }
+RowDump { collection: "archive", pk: "pk-00010497", payload: Some("{\"idx\": 10497, \"edit\": \"update\"}"), version: 20773, deleted: false, device_id: "device-1000", created_version: 10497 }
+RowDump { collection: "archive", pk: "pk-00010498", payload: Some("{\"idx\": 10498, \"edit\": \"update\"}"), version: 20774, deleted: false, device_id: "device-1000", created_version: 10498 }
+RowDump { collection: "archive", pk: "pk-00010499", payload: Some("{\"idx\": 10499, \"edit\": \"update\"}"), version: 20775, deleted: false, device_id: "device-1000", created_version: 10499 }
+RowDump { collection: "notes", pk: "pk-00010501", payload: Some("{\"idx\": 10501, \"edit\": \"update\"}"), version: 20776, deleted: false, device_id: "device-1000", created_version: 10501 }
+RowDump { collection: "notes", pk: "pk-00010502", payload: Some("{\"idx\": 10502, \"edit\": \"update\"}"), version: 20777, deleted: false, device_id: "device-1000", created_version: 10502 }
+RowDump { collection: "notes", pk: "pk-00010503", payload: Some("{\"idx\": 10503, \"edit\": \"update\"}"), version: 20778, deleted: false, device_id: "device-1000", created_version: 10503 }
+RowDump { collection: "notes", pk: "pk-00010504", payload: Some("{\"idx\": 10504, \"edit\": \"update\"}"), version: 20779, deleted: false, device_id: "device-1000", created_version: 10504 }
+RowDump { collection: "notes", pk: "pk-00010505", payload: Some("{\"idx\": 10505, \"edit\": \"update\"}"), version: 20780, deleted: false, device_id: "device-1000", created_version: 10505 }
+RowDump { collection: "notes", pk: "pk-00010506", payload: Some("{\"idx\": 10506, \"edit\": \"update\"}"), version: 20781, deleted: false, device_id: "device-1000", created_version: 10506 }
+RowDump { collection: "notes", pk: "pk-00010507", payload: Some("{\"idx\": 10507, \"edit\": \"update\"}"), version: 20782, deleted: false, device_id: "device-1000", created_version: 10507 }
+RowDump { collection: "notes", pk: "pk-00010508", payload: Some("{\"idx\": 10508, \"edit\": \"update\"}"), version: 20783, deleted: false, device_id: "device-1000", created_version: 10508 }
+RowDump { collection: "notes", pk: "pk-00010509", payload: Some("{\"idx\": 10509, \"edit\": \"update\"}"), version: 20784, deleted: false, device_id: "device-1000", created_version: 10509 }
+RowDump { collection: "notes", pk: "pk-00010510", payload: Some("{\"idx\": 10510, \"edit\": \"update\"}"), version: 20785, deleted: false, device_id: "device-1000", created_version: 10510 }
+RowDump { collection: "notes", pk: "pk-00010511", payload: Some("{\"idx\": 10511, \"edit\": \"update\"}"), version: 20786, deleted: false, device_id: "device-1000", created_version: 10511 }
+RowDump { collection: "notes", pk: "pk-00010512", payload: Some("{\"idx\": 10512, \"edit\": \"update\"}"), version: 20787, deleted: false, device_id: "device-1000", created_version: 10512 }
+RowDump { collection: "notes", pk: "pk-00010513", payload: Some("{\"idx\": 10513, \"edit\": \"update\"}"), version: 20788, deleted: false, device_id: "device-1000", created_version: 10513 }
+RowDump { collection: "notes", pk: "pk-00010514", payload: Some("{\"idx\": 10514, \"edit\": \"update\"}"), version: 20789, deleted: false, device_id: "device-1000", created_version: 10514 }
+RowDump { collection: "notes", pk: "pk-00010515", payload: Some("{\"idx\": 10515, \"edit\": \"update\"}"), version: 20790, deleted: false, device_id: "device-1000", created_version: 10515 }
+RowDump { collection: "notes", pk: "pk-00010516", payload: Some("{\"idx\": 10516, \"edit\": \"update\"}"), version: 20791, deleted: false, device_id: "device-1000", created_version: 10516 }
+RowDump { collection: "notes", pk: "pk-00010517", payload: Some("{\"idx\": 10517, \"edit\": \"update\"}"), version: 20792, deleted: false, device_id: "device-1000", created_version: 10517 }
+RowDump { collection: "notes", pk: "pk-00010518", payload: Some("{\"idx\": 10518, \"edit\": \"update\"}"), version: 20793, deleted: false, device_id: "device-1000", created_version: 10518 }
+RowDump { collection: "notes", pk: "pk-00010519", payload: Some("{\"idx\": 10519, \"edit\": \"update\"}"), version: 20794, deleted: false, device_id: "device-1000", created_version: 10519 }
+RowDump { collection: "notes", pk: "pk-00010521", payload: Some("{\"idx\": 10521, \"edit\": \"update\"}"), version: 20795, deleted: false, device_id: "device-1000", created_version: 10521 }
+RowDump { collection: "notes", pk: "pk-00010522", payload: Some("{\"idx\": 10522, \"edit\": \"update\"}"), version: 20796, deleted: false, device_id: "device-1000", created_version: 10522 }
+RowDump { collection: "notes", pk: "pk-00010523", payload: Some("{\"idx\": 10523, \"edit\": \"update\"}"), version: 20797, deleted: false, device_id: "device-1000", created_version: 10523 }
+RowDump { collection: "notes", pk: "pk-00010524", payload: Some("{\"idx\": 10524, \"edit\": \"update\"}"), version: 20798, deleted: false, device_id: "device-1000", created_version: 10524 }
+RowDump { collection: "notes", pk: "pk-00010525", payload: Some("{\"idx\": 10525, \"edit\": \"update\"}"), version: 20799, deleted: false, device_id: "device-1000", created_version: 10525 }
+RowDump { collection: "notes", pk: "pk-00010526", payload: Some("{\"idx\": 10526, \"edit\": \"update\"}"), version: 20800, deleted: false, device_id: "device-1000", created_version: 10526 }
+RowDump { collection: "notes", pk: "pk-00010527", payload: Some("{\"idx\": 10527, \"edit\": \"update\"}"), version: 20801, deleted: false, device_id: "device-1000", created_version: 10527 }
+RowDump { collection: "notes", pk: "pk-00010528", payload: Some("{\"idx\": 10528, \"edit\": \"update\"}"), version: 20802, deleted: false, device_id: "device-1000", created_version: 10528 }
+RowDump { collection: "notes", pk: "pk-00010529", payload: Some("{\"idx\": 10529, \"edit\": \"update\"}"), version: 20803, deleted: false, device_id: "device-1000", created_version: 10529 }
+RowDump { collection: "notes", pk: "pk-00010530", payload: Some("{\"idx\": 10530, \"edit\": \"update\"}"), version: 20804, deleted: false, device_id: "device-1000", created_version: 10530 }
+RowDump { collection: "notes", pk: "pk-00010531", payload: Some("{\"idx\": 10531, \"edit\": \"update\"}"), version: 20805, deleted: false, device_id: "device-1000", created_version: 10531 }
+RowDump { collection: "notes", pk: "pk-00010532", payload: Some("{\"idx\": 10532, \"edit\": \"update\"}"), version: 20806, deleted: false, device_id: "device-1000", created_version: 10532 }
+RowDump { collection: "notes", pk: "pk-00010533", payload: Some("{\"idx\": 10533, \"edit\": \"update\"}"), version: 20807, deleted: false, device_id: "device-1000", created_version: 10533 }
+RowDump { collection: "notes", pk: "pk-00010534", payload: Some("{\"idx\": 10534, \"edit\": \"update\"}"), version: 20808, deleted: false, device_id: "device-1000", created_version: 10534 }
+RowDump { collection: "notes", pk: "pk-00010535", payload: Some("{\"idx\": 10535, \"edit\": \"update\"}"), version: 20809, deleted: false, device_id: "device-1000", created_version: 10535 }
+RowDump { collection: "notes", pk: "pk-00010536", payload: Some("{\"idx\": 10536, \"edit\": \"update\"}"), version: 20810, deleted: false, device_id: "device-1000", created_version: 10536 }
+RowDump { collection: "notes", pk: "pk-00010537", payload: Some("{\"idx\": 10537, \"edit\": \"update\"}"), version: 20811, deleted: false, device_id: "device-1000", created_version: 10537 }
+RowDump { collection: "notes", pk: "pk-00010538", payload: Some("{\"idx\": 10538, \"edit\": \"update\"}"), version: 20812, deleted: false, device_id: "device-1000", created_version: 10538 }
+RowDump { collection: "notes", pk: "pk-00010539", payload: Some("{\"idx\": 10539, \"edit\": \"update\"}"), version: 20813, deleted: false, device_id: "device-1000", created_version: 10539 }
+RowDump { collection: "contacts", pk: "pk-00010541", payload: Some("{\"idx\": 10541, \"edit\": \"update\"}"), version: 20814, deleted: false, device_id: "device-1000", created_version: 10541 }
+RowDump { collection: "contacts", pk: "pk-00010542", payload: Some("{\"idx\": 10542, \"edit\": \"update\"}"), version: 20815, deleted: false, device_id: "device-1000", created_version: 10542 }
+RowDump { collection: "contacts", pk: "pk-00010543", payload: Some("{\"idx\": 10543, \"edit\": \"update\"}"), version: 20816, deleted: false, device_id: "device-1000", created_version: 10543 }
+RowDump { collection: "contacts", pk: "pk-00010544", payload: Some("{\"idx\": 10544, \"edit\": \"update\"}"), version: 20817, deleted: false, device_id: "device-1000", created_version: 10544 }
+RowDump { collection: "contacts", pk: "pk-00010545", payload: Some("{\"idx\": 10545, \"edit\": \"update\"}"), version: 20818, deleted: false, device_id: "device-1000", created_version: 10545 }
+RowDump { collection: "contacts", pk: "pk-00010546", payload: Some("{\"idx\": 10546, \"edit\": \"update\"}"), version: 20819, deleted: false, device_id: "device-1000", created_version: 10546 }
+RowDump { collection: "contacts", pk: "pk-00010547", payload: Some("{\"idx\": 10547, \"edit\": \"update\"}"), version: 20820, deleted: false, device_id: "device-1000", created_version: 10547 }
+RowDump { collection: "contacts", pk: "pk-00010548", payload: Some("{\"idx\": 10548, \"edit\": \"update\"}"), version: 20821, deleted: false, device_id: "device-1000", created_version: 10548 }
+RowDump { collection: "contacts", pk: "pk-00010549", payload: Some("{\"idx\": 10549, \"edit\": \"update\"}"), version: 20822, deleted: false, device_id: "device-1000", created_version: 10549 }
+RowDump { collection: "contacts", pk: "pk-00010550", payload: Some("{\"idx\": 10550, \"edit\": \"update\"}"), version: 20823, deleted: false, device_id: "device-1000", created_version: 10550 }
+RowDump { collection: "contacts", pk: "pk-00010551", payload: Some("{\"idx\": 10551, \"edit\": \"update\"}"), version: 20824, deleted: false, device_id: "device-1000", created_version: 10551 }
+RowDump { collection: "contacts", pk: "pk-00010552", payload: Some("{\"idx\": 10552, \"edit\": \"update\"}"), version: 20825, deleted: false, device_id: "device-1000", created_version: 10552 }
+RowDump { collection: "contacts", pk: "pk-00010553", payload: Some("{\"idx\": 10553, \"edit\": \"update\"}"), version: 20826, deleted: false, device_id: "device-1000", created_version: 10553 }
+RowDump { collection: "contacts", pk: "pk-00010554", payload: Some("{\"idx\": 10554, \"edit\": \"update\"}"), version: 20827, deleted: false, device_id: "device-1000", created_version: 10554 }
+RowDump { collection: "contacts", pk: "pk-00010555", payload: Some("{\"idx\": 10555, \"edit\": \"update\"}"), version: 20828, deleted: false, device_id: "device-1000", created_version: 10555 }
+RowDump { collection: "contacts", pk: "pk-00010556", payload: Some("{\"idx\": 10556, \"edit\": \"update\"}"), version: 20829, deleted: false, device_id: "device-1000", created_version: 10556 }
+RowDump { collection: "contacts", pk: "pk-00010557", payload: Some("{\"idx\": 10557, \"edit\": \"update\"}"), version: 20830, deleted: false, device_id: "device-1000", created_version: 10557 }
+RowDump { collection: "contacts", pk: "pk-00010558", payload: Some("{\"idx\": 10558, \"edit\": \"update\"}"), version: 20831, deleted: false, device_id: "device-1000", created_version: 10558 }
+RowDump { collection: "contacts", pk: "pk-00010559", payload: Some("{\"idx\": 10559, \"edit\": \"update\"}"), version: 20832, deleted: false, device_id: "device-1000", created_version: 10559 }
+RowDump { collection: "tasks", pk: "pk-00010561", payload: Some("{\"idx\": 10561, \"edit\": \"update\"}"), version: 20833, deleted: false, device_id: "device-1000", created_version: 10561 }
+RowDump { collection: "tasks", pk: "pk-00010562", payload: Some("{\"idx\": 10562, \"edit\": \"update\"}"), version: 20834, deleted: false, device_id: "device-1000", created_version: 10562 }
+RowDump { collection: "tasks", pk: "pk-00010563", payload: Some("{\"idx\": 10563, \"edit\": \"update\"}"), version: 20835, deleted: false, device_id: "device-1000", created_version: 10563 }
+RowDump { collection: "tasks", pk: "pk-00010564", payload: Some("{\"idx\": 10564, \"edit\": \"update\"}"), version: 20836, deleted: false, device_id: "device-1000", created_version: 10564 }
+RowDump { collection: "tasks", pk: "pk-00010565", payload: Some("{\"idx\": 10565, \"edit\": \"update\"}"), version: 20837, deleted: false, device_id: "device-1000", created_version: 10565 }
+RowDump { collection: "tasks", pk: "pk-00010566", payload: Some("{\"idx\": 10566, \"edit\": \"update\"}"), version: 20838, deleted: false, device_id: "device-1000", created_version: 10566 }
+RowDump { collection: "tasks", pk: "pk-00010567", payload: Some("{\"idx\": 10567, \"edit\": \"update\"}"), version: 20839, deleted: false, device_id: "device-1000", created_version: 10567 }
+RowDump { collection: "tasks", pk: "pk-00010568", payload: Some("{\"idx\": 10568, \"edit\": \"update\"}"), version: 20840, deleted: false, device_id: "device-1000", created_version: 10568 }
+RowDump { collection: "tasks", pk: "pk-00010569", payload: Some("{\"idx\": 10569, \"edit\": \"update\"}"), version: 20841, deleted: false, device_id: "device-1000", created_version: 10569 }
+RowDump { collection: "tasks", pk: "pk-00010570", payload: Some("{\"idx\": 10570, \"edit\": \"update\"}"), version: 20842, deleted: false, device_id: "device-1000", created_version: 10570 }
+RowDump { collection: "tasks", pk: "pk-00010571", payload: Some("{\"idx\": 10571, \"edit\": \"update\"}"), version: 20843, deleted: false, device_id: "device-1000", created_version: 10571 }
+RowDump { collection: "tasks", pk: "pk-00010572", payload: Some("{\"idx\": 10572, \"edit\": \"update\"}"), version: 20844, deleted: false, device_id: "device-1000", created_version: 10572 }
+RowDump { collection: "tasks", pk: "pk-00010573", payload: Some("{\"idx\": 10573, \"edit\": \"update\"}"), version: 20845, deleted: false, device_id: "device-1000", created_version: 10573 }
+RowDump { collection: "tasks", pk: "pk-00010574", payload: Some("{\"idx\": 10574, \"edit\": \"update\"}"), version: 20846, deleted: false, device_id: "device-1000", created_version: 10574 }
+RowDump { collection: "files", pk: "pk-00010575", payload: Some("{\"idx\": 10575, \"edit\": \"update\"}"), version: 20847, deleted: false, device_id: "device-1000", created_version: 10575 }
+RowDump { collection: "files", pk: "pk-00010576", payload: Some("{\"idx\": 10576, \"edit\": \"update\"}"), version: 20848, deleted: false, device_id: "device-1000", created_version: 10576 }
+RowDump { collection: "files", pk: "pk-00010577", payload: Some("{\"idx\": 10577, \"edit\": \"update\"}"), version: 20849, deleted: false, device_id: "device-1000", created_version: 10577 }
+RowDump { collection: "files", pk: "pk-00010578", payload: Some("{\"idx\": 10578, \"edit\": \"update\"}"), version: 20850, deleted: false, device_id: "device-1000", created_version: 10578 }
+RowDump { collection: "files", pk: "pk-00010579", payload: Some("{\"idx\": 10579, \"edit\": \"update\"}"), version: 20851, deleted: false, device_id: "device-1000", created_version: 10579 }
+RowDump { collection: "files", pk: "pk-00010581", payload: Some("{\"idx\": 10581, \"edit\": \"update\"}"), version: 20852, deleted: false, device_id: "device-1000", created_version: 10581 }
+RowDump { collection: "files", pk: "pk-00010582", payload: Some("{\"idx\": 10582, \"edit\": \"update\"}"), version: 20853, deleted: false, device_id: "device-1000", created_version: 10582 }
+RowDump { collection: "files", pk: "pk-00010583", payload: Some("{\"idx\": 10583, \"edit\": \"update\"}"), version: 20854, deleted: false, device_id: "device-1000", created_version: 10583 }
+RowDump { collection: "files", pk: "pk-00010584", payload: Some("{\"idx\": 10584, \"edit\": \"update\"}"), version: 20855, deleted: false, device_id: "device-1000", created_version: 10584 }
+RowDump { collection: "files", pk: "pk-00010585", payload: Some("{\"idx\": 10585, \"edit\": \"update\"}"), version: 20856, deleted: false, device_id: "device-1000", created_version: 10585 }
+RowDump { collection: "files", pk: "pk-00010586", payload: Some("{\"idx\": 10586, \"edit\": \"update\"}"), version: 20857, deleted: false, device_id: "device-1000", created_version: 10586 }
+RowDump { collection: "files", pk: "pk-00010587", payload: Some("{\"idx\": 10587, \"edit\": \"update\"}"), version: 20858, deleted: false, device_id: "device-1000", created_version: 10587 }
+RowDump { collection: "files", pk: "pk-00010588", payload: Some("{\"idx\": 10588, \"edit\": \"update\"}"), version: 20859, deleted: false, device_id: "device-1000", created_version: 10588 }
+RowDump { collection: "files", pk: "pk-00010589", payload: Some("{\"idx\": 10589, \"edit\": \"update\"}"), version: 20860, deleted: false, device_id: "device-1000", created_version: 10589 }
+RowDump { collection: "tags", pk: "pk-00010590", payload: Some("{\"idx\": 10590, \"edit\": \"update\"}"), version: 20861, deleted: false, device_id: "device-1000", created_version: 10590 }
+RowDump { collection: "tags", pk: "pk-00010591", payload: Some("{\"idx\": 10591, \"edit\": \"update\"}"), version: 20862, deleted: false, device_id: "device-1000", created_version: 10591 }
+RowDump { collection: "tags", pk: "pk-00010592", payload: Some("{\"idx\": 10592, \"edit\": \"update\"}"), version: 20863, deleted: false, device_id: "device-1000", created_version: 10592 }
+RowDump { collection: "tags", pk: "pk-00010593", payload: Some("{\"idx\": 10593, \"edit\": \"update\"}"), version: 20864, deleted: false, device_id: "device-1000", created_version: 10593 }
+RowDump { collection: "tags", pk: "pk-00010594", payload: Some("{\"idx\": 10594, \"edit\": \"update\"}"), version: 20865, deleted: false, device_id: "device-1000", created_version: 10594 }
+RowDump { collection: "tags", pk: "pk-00010595", payload: Some("{\"idx\": 10595, \"edit\": \"update\"}"), version: 20866, deleted: false, device_id: "device-1000", created_version: 10595 }
+RowDump { collection: "tags", pk: "pk-00010596", payload: Some("{\"idx\": 10596, \"edit\": \"update\"}"), version: 20867, deleted: false, device_id: "device-1000", created_version: 10596 }
+RowDump { collection: "archive", pk: "pk-00010597", payload: Some("{\"idx\": 10597, \"edit\": \"update\"}"), version: 20868, deleted: false, device_id: "device-1000", created_version: 10597 }
+RowDump { collection: "archive", pk: "pk-00010598", payload: Some("{\"idx\": 10598, \"edit\": \"update\"}"), version: 20869, deleted: false, device_id: "device-1000", created_version: 10598 }
+RowDump { collection: "archive", pk: "pk-00010599", payload: Some("{\"idx\": 10599, \"edit\": \"update\"}"), version: 20870, deleted: false, device_id: "device-1000", created_version: 10599 }
+RowDump { collection: "notes", pk: "pk-00010601", payload: Some("{\"idx\": 10601, \"edit\": \"update\"}"), version: 20871, deleted: false, device_id: "device-1000", created_version: 10601 }
+RowDump { collection: "notes", pk: "pk-00010602", payload: Some("{\"idx\": 10602, \"edit\": \"update\"}"), version: 20872, deleted: false, device_id: "device-1000", created_version: 10602 }
+RowDump { collection: "notes", pk: "pk-00010603", payload: Some("{\"idx\": 10603, \"edit\": \"update\"}"), version: 20873, deleted: false, device_id: "device-1000", created_version: 10603 }
+RowDump { collection: "notes", pk: "pk-00010604", payload: Some("{\"idx\": 10604, \"edit\": \"update\"}"), version: 20874, deleted: false, device_id: "device-1000", created_version: 10604 }
+RowDump { collection: "notes", pk: "pk-00010605", payload: Some("{\"idx\": 10605, \"edit\": \"update\"}"), version: 20875, deleted: false, device_id: "device-1000", created_version: 10605 }
+RowDump { collection: "notes", pk: "pk-00010606", payload: Some("{\"idx\": 10606, \"edit\": \"update\"}"), version: 20876, deleted: false, device_id: "device-1000", created_version: 10606 }
+RowDump { collection: "notes", pk: "pk-00010607", payload: Some("{\"idx\": 10607, \"edit\": \"update\"}"), version: 20877, deleted: false, device_id: "device-1000", created_version: 10607 }
+RowDump { collection: "notes", pk: "pk-00010608", payload: Some("{\"idx\": 10608, \"edit\": \"update\"}"), version: 20878, deleted: false, device_id: "device-1000", created_version: 10608 }
+RowDump { collection: "notes", pk: "pk-00010609", payload: Some("{\"idx\": 10609, \"edit\": \"update\"}"), version: 20879, deleted: false, device_id: "device-1000", created_version: 10609 }
+RowDump { collection: "notes", pk: "pk-00010610", payload: Some("{\"idx\": 10610, \"edit\": \"update\"}"), version: 20880, deleted: false, device_id: "device-1000", created_version: 10610 }
+RowDump { collection: "notes", pk: "pk-00010611", payload: Some("{\"idx\": 10611, \"edit\": \"update\"}"), version: 20881, deleted: false, device_id: "device-1000", created_version: 10611 }
+RowDump { collection: "notes", pk: "pk-00010612", payload: Some("{\"idx\": 10612, \"edit\": \"update\"}"), version: 20882, deleted: false, device_id: "device-1000", created_version: 10612 }
+RowDump { collection: "notes", pk: "pk-00010613", payload: Some("{\"idx\": 10613, \"edit\": \"update\"}"), version: 20883, deleted: false, device_id: "device-1000", created_version: 10613 }
+RowDump { collection: "notes", pk: "pk-00010614", payload: Some("{\"idx\": 10614, \"edit\": \"update\"}"), version: 20884, deleted: false, device_id: "device-1000", created_version: 10614 }
+RowDump { collection: "notes", pk: "pk-00010615", payload: Some("{\"idx\": 10615, \"edit\": \"update\"}"), version: 20885, deleted: false, device_id: "device-1000", created_version: 10615 }
+RowDump { collection: "notes", pk: "pk-00010616", payload: Some("{\"idx\": 10616, \"edit\": \"update\"}"), version: 20886, deleted: false, device_id: "device-1000", created_version: 10616 }
+RowDump { collection: "notes", pk: "pk-00010617", payload: Some("{\"idx\": 10617, \"edit\": \"update\"}"), version: 20887, deleted: false, device_id: "device-1000", created_version: 10617 }
+RowDump { collection: "notes", pk: "pk-00010618", payload: Some("{\"idx\": 10618, \"edit\": \"update\"}"), version: 20888, deleted: false, device_id: "device-1000", created_version: 10618 }
+RowDump { collection: "notes", pk: "pk-00010619", payload: Some("{\"idx\": 10619, \"edit\": \"update\"}"), version: 20889, deleted: false, device_id: "device-1000", created_version: 10619 }
+RowDump { collection: "notes", pk: "pk-00010621", payload: Some("{\"idx\": 10621, \"edit\": \"update\"}"), version: 20890, deleted: false, device_id: "device-1000", created_version: 10621 }
+RowDump { collection: "notes", pk: "pk-00010622", payload: Some("{\"idx\": 10622, \"edit\": \"update\"}"), version: 20891, deleted: false, device_id: "device-1000", created_version: 10622 }
+RowDump { collection: "notes", pk: "pk-00010623", payload: Some("{\"idx\": 10623, \"edit\": \"update\"}"), version: 20892, deleted: false, device_id: "device-1000", created_version: 10623 }
+RowDump { collection: "notes", pk: "pk-00010624", payload: Some("{\"idx\": 10624, \"edit\": \"update\"}"), version: 20893, deleted: false, device_id: "device-1000", created_version: 10624 }
+RowDump { collection: "notes", pk: "pk-00010625", payload: Some("{\"idx\": 10625, \"edit\": \"update\"}"), version: 20894, deleted: false, device_id: "device-1000", created_version: 10625 }
+RowDump { collection: "notes", pk: "pk-00010626", payload: Some("{\"idx\": 10626, \"edit\": \"update\"}"), version: 20895, deleted: false, device_id: "device-1000", created_version: 10626 }
+RowDump { collection: "notes", pk: "pk-00010627", payload: Some("{\"idx\": 10627, \"edit\": \"update\"}"), version: 20896, deleted: false, device_id: "device-1000", created_version: 10627 }
+RowDump { collection: "notes", pk: "pk-00010628", payload: Some("{\"idx\": 10628, \"edit\": \"update\"}"), version: 20897, deleted: false, device_id: "device-1000", created_version: 10628 }
+RowDump { collection: "notes", pk: "pk-00010629", payload: Some("{\"idx\": 10629, \"edit\": \"update\"}"), version: 20898, deleted: false, device_id: "device-1000", created_version: 10629 }
+RowDump { collection: "notes", pk: "pk-00010630", payload: Some("{\"idx\": 10630, \"edit\": \"update\"}"), version: 20899, deleted: false, device_id: "device-1000", created_version: 10630 }
+RowDump { collection: "notes", pk: "pk-00010631", payload: Some("{\"idx\": 10631, \"edit\": \"update\"}"), version: 20900, deleted: false, device_id: "device-1000", created_version: 10631 }
+RowDump { collection: "notes", pk: "pk-00010632", payload: Some("{\"idx\": 10632, \"edit\": \"update\"}"), version: 20901, deleted: false, device_id: "device-1000", created_version: 10632 }
+RowDump { collection: "notes", pk: "pk-00010633", payload: Some("{\"idx\": 10633, \"edit\": \"update\"}"), version: 20902, deleted: false, device_id: "device-1000", created_version: 10633 }
+RowDump { collection: "notes", pk: "pk-00010634", payload: Some("{\"idx\": 10634, \"edit\": \"update\"}"), version: 20903, deleted: false, device_id: "device-1000", created_version: 10634 }
+RowDump { collection: "notes", pk: "pk-00010635", payload: Some("{\"idx\": 10635, \"edit\": \"update\"}"), version: 20904, deleted: false, device_id: "device-1000", created_version: 10635 }
+RowDump { collection: "notes", pk: "pk-00010636", payload: Some("{\"idx\": 10636, \"edit\": \"update\"}"), version: 20905, deleted: false, device_id: "device-1000", created_version: 10636 }
+RowDump { collection: "notes", pk: "pk-00010637", payload: Some("{\"idx\": 10637, \"edit\": \"update\"}"), version: 20906, deleted: false, device_id: "device-1000", created_version: 10637 }
+RowDump { collection: "notes", pk: "pk-00010638", payload: Some("{\"idx\": 10638, \"edit\": \"update\"}"), version: 20907, deleted: false, device_id: "device-1000", created_version: 10638 }
+RowDump { collection: "notes", pk: "pk-00010639", payload: Some("{\"idx\": 10639, \"edit\": \"update\"}"), version: 20908, deleted: false, device_id: "device-1000", created_version: 10639 }
+RowDump { collection: "contacts", pk: "pk-00010641", payload: Some("{\"idx\": 10641, \"edit\": \"update\"}"), version: 20909, deleted: false, device_id: "device-1000", created_version: 10641 }
+RowDump { collection: "contacts", pk: "pk-00010642", payload: Some("{\"idx\": 10642, \"edit\": \"update\"}"), version: 20910, deleted: false, device_id: "device-1000", created_version: 10642 }
+RowDump { collection: "contacts", pk: "pk-00010643", payload: Some("{\"idx\": 10643, \"edit\": \"update\"}"), version: 20911, deleted: false, device_id: "device-1000", created_version: 10643 }
+RowDump { collection: "contacts", pk: "pk-00010644", payload: Some("{\"idx\": 10644, \"edit\": \"update\"}"), version: 20912, deleted: false, device_id: "device-1000", created_version: 10644 }
+RowDump { collection: "contacts", pk: "pk-00010645", payload: Some("{\"idx\": 10645, \"edit\": \"update\"}"), version: 20913, deleted: false, device_id: "device-1000", created_version: 10645 }
+RowDump { collection: "contacts", pk: "pk-00010646", payload: Some("{\"idx\": 10646, \"edit\": \"update\"}"), version: 20914, deleted: false, device_id: "device-1000", created_version: 10646 }
+RowDump { collection: "contacts", pk: "pk-00010647", payload: Some("{\"idx\": 10647, \"edit\": \"update\"}"), version: 20915, deleted: false, device_id: "device-1000", created_version: 10647 }
+RowDump { collection: "contacts", pk: "pk-00010648", payload: Some("{\"idx\": 10648, \"edit\": \"update\"}"), version: 20916, deleted: false, device_id: "device-1000", created_version: 10648 }
+RowDump { collection: "contacts", pk: "pk-00010649", payload: Some("{\"idx\": 10649, \"edit\": \"update\"}"), version: 20917, deleted: false, device_id: "device-1000", created_version: 10649 }
+RowDump { collection: "contacts", pk: "pk-00010650", payload: Some("{\"idx\": 10650, \"edit\": \"update\"}"), version: 20918, deleted: false, device_id: "device-1000", created_version: 10650 }
+RowDump { collection: "contacts", pk: "pk-00010651", payload: Some("{\"idx\": 10651, \"edit\": \"update\"}"), version: 20919, deleted: false, device_id: "device-1000", created_version: 10651 }
+RowDump { collection: "contacts", pk: "pk-00010652", payload: Some("{\"idx\": 10652, \"edit\": \"update\"}"), version: 20920, deleted: false, device_id: "device-1000", created_version: 10652 }
+RowDump { collection: "contacts", pk: "pk-00010653", payload: Some("{\"idx\": 10653, \"edit\": \"update\"}"), version: 20921, deleted: false, device_id: "device-1000", created_version: 10653 }
+RowDump { collection: "contacts", pk: "pk-00010654", payload: Some("{\"idx\": 10654, \"edit\": \"update\"}"), version: 20922, deleted: false, device_id: "device-1000", created_version: 10654 }
+RowDump { collection: "contacts", pk: "pk-00010655", payload: Some("{\"idx\": 10655, \"edit\": \"update\"}"), version: 20923, deleted: false, device_id: "device-1000", created_version: 10655 }
+RowDump { collection: "contacts", pk: "pk-00010656", payload: Some("{\"idx\": 10656, \"edit\": \"update\"}"), version: 20924, deleted: false, device_id: "device-1000", created_version: 10656 }
+RowDump { collection: "contacts", pk: "pk-00010657", payload: Some("{\"idx\": 10657, \"edit\": \"update\"}"), version: 20925, deleted: false, device_id: "device-1000", created_version: 10657 }
+RowDump { collection: "contacts", pk: "pk-00010658", payload: Some("{\"idx\": 10658, \"edit\": \"update\"}"), version: 20926, deleted: false, device_id: "device-1000", created_version: 10658 }
+RowDump { collection: "contacts", pk: "pk-00010659", payload: Some("{\"idx\": 10659, \"edit\": \"update\"}"), version: 20927, deleted: false, device_id: "device-1000", created_version: 10659 }
+RowDump { collection: "tasks", pk: "pk-00010661", payload: Some("{\"idx\": 10661, \"edit\": \"update\"}"), version: 20928, deleted: false, device_id: "device-1000", created_version: 10661 }
+RowDump { collection: "tasks", pk: "pk-00010662", payload: Some("{\"idx\": 10662, \"edit\": \"update\"}"), version: 20929, deleted: false, device_id: "device-1000", created_version: 10662 }
+RowDump { collection: "tasks", pk: "pk-00010663", payload: Some("{\"idx\": 10663, \"edit\": \"update\"}"), version: 20930, deleted: false, device_id: "device-1000", created_version: 10663 }
+RowDump { collection: "tasks", pk: "pk-00010664", payload: Some("{\"idx\": 10664, \"edit\": \"update\"}"), version: 20931, deleted: false, device_id: "device-1000", created_version: 10664 }
+RowDump { collection: "tasks", pk: "pk-00010665", payload: Some("{\"idx\": 10665, \"edit\": \"update\"}"), version: 20932, deleted: false, device_id: "device-1000", created_version: 10665 }
+RowDump { collection: "tasks", pk: "pk-00010666", payload: Some("{\"idx\": 10666, \"edit\": \"update\"}"), version: 20933, deleted: false, device_id: "device-1000", created_version: 10666 }
+RowDump { collection: "tasks", pk: "pk-00010667", payload: Some("{\"idx\": 10667, \"edit\": \"update\"}"), version: 20934, deleted: false, device_id: "device-1000", created_version: 10667 }
+RowDump { collection: "tasks", pk: "pk-00010668", payload: Some("{\"idx\": 10668, \"edit\": \"update\"}"), version: 20935, deleted: false, device_id: "device-1000", created_version: 10668 }
+RowDump { collection: "tasks", pk: "pk-00010669", payload: Some("{\"idx\": 10669, \"edit\": \"update\"}"), version: 20936, deleted: false, device_id: "device-1000", created_version: 10669 }
+RowDump { collection: "tasks", pk: "pk-00010670", payload: Some("{\"idx\": 10670, \"edit\": \"update\"}"), version: 20937, deleted: false, device_id: "device-1000", created_version: 10670 }
+RowDump { collection: "tasks", pk: "pk-00010671", payload: Some("{\"idx\": 10671, \"edit\": \"update\"}"), version: 20938, deleted: false, device_id: "device-1000", created_version: 10671 }
+RowDump { collection: "tasks", pk: "pk-00010672", payload: Some("{\"idx\": 10672, \"edit\": \"update\"}"), version: 20939, deleted: false, device_id: "device-1000", created_version: 10672 }
+RowDump { collection: "tasks", pk: "pk-00010673", payload: Some("{\"idx\": 10673, \"edit\": \"update\"}"), version: 20940, deleted: false, device_id: "device-1000", created_version: 10673 }
+RowDump { collection: "tasks", pk: "pk-00010674", payload: Some("{\"idx\": 10674, \"edit\": \"update\"}"), version: 20941, deleted: false, device_id: "device-1000", created_version: 10674 }
+RowDump { collection: "files", pk: "pk-00010675", payload: Some("{\"idx\": 10675, \"edit\": \"update\"}"), version: 20942, deleted: false, device_id: "device-1000", created_version: 10675 }
+RowDump { collection: "files", pk: "pk-00010676", payload: Some("{\"idx\": 10676, \"edit\": \"update\"}"), version: 20943, deleted: false, device_id: "device-1000", created_version: 10676 }
+RowDump { collection: "files", pk: "pk-00010677", payload: Some("{\"idx\": 10677, \"edit\": \"update\"}"), version: 20944, deleted: false, device_id: "device-1000", created_version: 10677 }
+RowDump { collection: "files", pk: "pk-00010678", payload: Some("{\"idx\": 10678, \"edit\": \"update\"}"), version: 20945, deleted: false, device_id: "device-1000", created_version: 10678 }
+RowDump { collection: "files", pk: "pk-00010679", payload: Some("{\"idx\": 10679, \"edit\": \"update\"}"), version: 20946, deleted: false, device_id: "device-1000", created_version: 10679 }
+RowDump { collection: "files", pk: "pk-00010681", payload: Some("{\"idx\": 10681, \"edit\": \"update\"}"), version: 20947, deleted: false, device_id: "device-1000", created_version: 10681 }
+RowDump { collection: "files", pk: "pk-00010682", payload: Some("{\"idx\": 10682, \"edit\": \"update\"}"), version: 20948, deleted: false, device_id: "device-1000", created_version: 10682 }
+RowDump { collection: "files", pk: "pk-00010683", payload: Some("{\"idx\": 10683, \"edit\": \"update\"}"), version: 20949, deleted: false, device_id: "device-1000", created_version: 10683 }
+RowDump { collection: "files", pk: "pk-00010684", payload: Some("{\"idx\": 10684, \"edit\": \"update\"}"), version: 20950, deleted: false, device_id: "device-1000", created_version: 10684 }
+RowDump { collection: "files", pk: "pk-00010685", payload: None, version: 21151, deleted: true, device_id: "device-1000", created_version: 10685 }
+RowDump { collection: "files", pk: "pk-00010686", payload: None, version: 21152, deleted: true, device_id: "device-1000", created_version: 10686 }
+RowDump { collection: "files", pk: "pk-00010687", payload: None, version: 21153, deleted: true, device_id: "device-1000", created_version: 10687 }
+RowDump { collection: "files", pk: "pk-00010688", payload: None, version: 21154, deleted: true, device_id: "device-1000", created_version: 10688 }
+RowDump { collection: "files", pk: "pk-00010689", payload: None, version: 21155, deleted: true, device_id: "device-1000", created_version: 10689 }
+RowDump { collection: "tags", pk: "pk-00010690", payload: None, version: 21156, deleted: true, device_id: "device-1000", created_version: 10690 }
+RowDump { collection: "tags", pk: "pk-00010691", payload: None, version: 21157, deleted: true, device_id: "device-1000", created_version: 10691 }
+RowDump { collection: "tags", pk: "pk-00010692", payload: None, version: 21158, deleted: true, device_id: "device-1000", created_version: 10692 }
+RowDump { collection: "tags", pk: "pk-00010693", payload: None, version: 21159, deleted: true, device_id: "device-1000", created_version: 10693 }
+RowDump { collection: "tags", pk: "pk-00010694", payload: None, version: 21160, deleted: true, device_id: "device-1000", created_version: 10694 }
+RowDump { collection: "tags", pk: "pk-00010695", payload: None, version: 21161, deleted: true, device_id: "device-1000", created_version: 10695 }
+RowDump { collection: "tags", pk: "pk-00010696", payload: None, version: 21162, deleted: true, device_id: "device-1000", created_version: 10696 }
+RowDump { collection: "archive", pk: "pk-00010697", payload: None, version: 21163, deleted: true, device_id: "device-1000", created_version: 10697 }
+RowDump { collection: "archive", pk: "pk-00010698", payload: None, version: 21164, deleted: true, device_id: "device-1000", created_version: 10698 }
+RowDump { collection: "archive", pk: "pk-00010699", payload: None, version: 21165, deleted: true, device_id: "device-1000", created_version: 10699 }
+RowDump { collection: "notes", pk: "pk-00010701", payload: None, version: 21166, deleted: true, device_id: "device-1000", created_version: 10701 }
+RowDump { collection: "notes", pk: "pk-00010702", payload: None, version: 21167, deleted: true, device_id: "device-1000", created_version: 10702 }
+RowDump { collection: "notes", pk: "pk-00010703", payload: None, version: 21168, deleted: true, device_id: "device-1000", created_version: 10703 }
+RowDump { collection: "notes", pk: "pk-00010704", payload: None, version: 21169, deleted: true, device_id: "device-1000", created_version: 10704 }
+RowDump { collection: "notes", pk: "pk-00010705", payload: None, version: 21170, deleted: true, device_id: "device-1000", created_version: 10705 }
+RowDump { collection: "notes", pk: "pk-00010706", payload: None, version: 21171, deleted: true, device_id: "device-1000", created_version: 10706 }
+RowDump { collection: "notes", pk: "pk-00010707", payload: None, version: 21172, deleted: true, device_id: "device-1000", created_version: 10707 }
+RowDump { collection: "notes", pk: "pk-00010708", payload: None, version: 21173, deleted: true, device_id: "device-1000", created_version: 10708 }
+RowDump { collection: "notes", pk: "pk-00010709", payload: None, version: 21174, deleted: true, device_id: "device-1000", created_version: 10709 }
+RowDump { collection: "notes", pk: "pk-00010710", payload: None, version: 21175, deleted: true, device_id: "device-1000", created_version: 10710 }
+RowDump { collection: "notes", pk: "pk-00010711", payload: None, version: 21176, deleted: true, device_id: "device-1000", created_version: 10711 }
+RowDump { collection: "notes", pk: "pk-00010712", payload: None, version: 21177, deleted: true, device_id: "device-1000", created_version: 10712 }
+RowDump { collection: "notes", pk: "pk-00010713", payload: None, version: 21178, deleted: true, device_id: "device-1000", created_version: 10713 }
+RowDump { collection: "notes", pk: "pk-00010714", payload: None, version: 21179, deleted: true, device_id: "device-1000", created_version: 10714 }
+RowDump { collection: "notes", pk: "pk-00010715", payload: None, version: 21180, deleted: true, device_id: "device-1000", created_version: 10715 }
+RowDump { collection: "notes", pk: "pk-00010716", payload: None, version: 21181, deleted: true, device_id: "device-1000", created_version: 10716 }
+RowDump { collection: "notes", pk: "pk-00010717", payload: None, version: 21182, deleted: true, device_id: "device-1000", created_version: 10717 }
+RowDump { collection: "notes", pk: "pk-00010718", payload: None, version: 21183, deleted: true, device_id: "device-1000", created_version: 10718 }
+RowDump { collection: "notes", pk: "pk-00010719", payload: None, version: 21184, deleted: true, device_id: "device-1000", created_version: 10719 }
+RowDump { collection: "notes", pk: "pk-00010721", payload: None, version: 21185, deleted: true, device_id: "device-1000", created_version: 10721 }
+RowDump { collection: "notes", pk: "pk-00010722", payload: None, version: 21186, deleted: true, device_id: "device-1000", created_version: 10722 }
+RowDump { collection: "notes", pk: "pk-00010723", payload: None, version: 21187, deleted: true, device_id: "device-1000", created_version: 10723 }
+RowDump { collection: "notes", pk: "pk-00010724", payload: None, version: 21188, deleted: true, device_id: "device-1000", created_version: 10724 }
+RowDump { collection: "notes", pk: "pk-00010725", payload: None, version: 21189, deleted: true, device_id: "device-1000", created_version: 10725 }
+RowDump { collection: "notes", pk: "pk-00010726", payload: None, version: 21190, deleted: true, device_id: "device-1000", created_version: 10726 }
+RowDump { collection: "notes", pk: "pk-00010727", payload: None, version: 21191, deleted: true, device_id: "device-1000", created_version: 10727 }
+RowDump { collection: "notes", pk: "pk-00010728", payload: None, version: 21192, deleted: true, device_id: "device-1000", created_version: 10728 }
+RowDump { collection: "notes", pk: "pk-00010729", payload: None, version: 21193, deleted: true, device_id: "device-1000", created_version: 10729 }
+RowDump { collection: "notes", pk: "pk-00010730", payload: None, version: 21194, deleted: true, device_id: "device-1000", created_version: 10730 }
+RowDump { collection: "notes", pk: "pk-00010731", payload: None, version: 21195, deleted: true, device_id: "device-1000", created_version: 10731 }
+RowDump { collection: "notes", pk: "pk-00010732", payload: None, version: 21196, deleted: true, device_id: "device-1000", created_version: 10732 }
+RowDump { collection: "notes", pk: "pk-00010733", payload: None, version: 21197, deleted: true, device_id: "device-1000", created_version: 10733 }
+RowDump { collection: "notes", pk: "pk-00010734", payload: None, version: 21198, deleted: true, device_id: "device-1000", created_version: 10734 }
+RowDump { collection: "notes", pk: "pk-00010735", payload: None, version: 21199, deleted: true, device_id: "device-1000", created_version: 10735 }
+RowDump { collection: "notes", pk: "pk-00010736", payload: None, version: 21200, deleted: true, device_id: "device-1000", created_version: 10736 }
+RowDump { collection: "notes", pk: "pk-00010737", payload: Some("{\"p\": 0, \"edit\": \"dup-existing-2\"}"), version: 21202, deleted: false, device_id: "device-1000", created_version: 10737 }
+RowDump { collection: "notes", pk: "pk-00010738", payload: Some("{\"p\": 1, \"edit\": \"dup-existing-2\"}"), version: 21204, deleted: false, device_id: "device-1000", created_version: 10738 }
+RowDump { collection: "notes", pk: "pk-00010739", payload: Some("{\"p\": 2, \"edit\": \"dup-existing-2\"}"), version: 21206, deleted: false, device_id: "device-1000", created_version: 10739 }
+RowDump { collection: "contacts", pk: "pk-00010741", payload: Some("{\"p\": 3, \"edit\": \"dup-existing-2\"}"), version: 21208, deleted: false, device_id: "device-1000", created_version: 10741 }
+RowDump { collection: "contacts", pk: "pk-00010742", payload: Some("{\"p\": 4, \"edit\": \"dup-existing-2\"}"), version: 21210, deleted: false, device_id: "device-1000", created_version: 10742 }
+RowDump { collection: "contacts", pk: "pk-00010743", payload: Some("{\"p\": 5, \"edit\": \"dup-existing-2\"}"), version: 21212, deleted: false, device_id: "device-1000", created_version: 10743 }
+RowDump { collection: "contacts", pk: "pk-00010744", payload: Some("{\"p\": 6, \"edit\": \"dup-existing-2\"}"), version: 21214, deleted: false, device_id: "device-1000", created_version: 10744 }
+RowDump { collection: "contacts", pk: "pk-00010745", payload: Some("{\"p\": 7, \"edit\": \"dup-existing-2\"}"), version: 21216, deleted: false, device_id: "device-1000", created_version: 10745 }
+RowDump { collection: "contacts", pk: "pk-00010746", payload: Some("{\"p\": 8, \"edit\": \"dup-existing-2\"}"), version: 21218, deleted: false, device_id: "device-1000", created_version: 10746 }
+RowDump { collection: "contacts", pk: "pk-00010747", payload: Some("{\"p\": 9, \"edit\": \"dup-existing-2\"}"), version: 21220, deleted: false, device_id: "device-1000", created_version: 10747 }
+RowDump { collection: "contacts", pk: "pk-00010748", payload: Some("{\"p\": 10, \"edit\": \"dup-existing-2\"}"), version: 21222, deleted: false, device_id: "device-1000", created_version: 10748 }
+RowDump { collection: "contacts", pk: "pk-00010749", payload: Some("{\"p\": 11, \"edit\": \"dup-existing-2\"}"), version: 21224, deleted: false, device_id: "device-1000", created_version: 10749 }
+RowDump { collection: "contacts", pk: "pk-00010750", payload: Some("{\"p\": 12, \"edit\": \"dup-existing-2\"}"), version: 21226, deleted: false, device_id: "device-1000", created_version: 10750 }
+RowDump { collection: "contacts", pk: "pk-00010751", payload: Some("{\"p\": 13, \"edit\": \"dup-existing-2\"}"), version: 21228, deleted: false, device_id: "device-1000", created_version: 10751 }
+RowDump { collection: "contacts", pk: "pk-00010752", payload: Some("{\"p\": 14, \"edit\": \"dup-existing-2\"}"), version: 21230, deleted: false, device_id: "device-1000", created_version: 10752 }
+RowDump { collection: "contacts", pk: "pk-00010753", payload: Some("{\"p\": 15, \"edit\": \"dup-existing-2\"}"), version: 21232, deleted: false, device_id: "device-1000", created_version: 10753 }
+RowDump { collection: "contacts", pk: "pk-00010754", payload: Some("{\"p\": 16, \"edit\": \"dup-existing-2\"}"), version: 21234, deleted: false, device_id: "device-1000", created_version: 10754 }
+RowDump { collection: "contacts", pk: "pk-00010755", payload: Some("{\"p\": 17, \"edit\": \"dup-existing-2\"}"), version: 21236, deleted: false, device_id: "device-1000", created_version: 10755 }
+RowDump { collection: "contacts", pk: "pk-00010756", payload: Some("{\"p\": 18, \"edit\": \"dup-existing-2\"}"), version: 21238, deleted: false, device_id: "device-1000", created_version: 10756 }
+RowDump { collection: "contacts", pk: "pk-00010757", payload: Some("{\"p\": 19, \"edit\": \"dup-existing-2\"}"), version: 21240, deleted: false, device_id: "device-1000", created_version: 10757 }
+RowDump { collection: "contacts", pk: "pk-00010758", payload: Some("{\"p\": 20, \"edit\": \"dup-existing-2\"}"), version: 21242, deleted: false, device_id: "device-1000", created_version: 10758 }
+RowDump { collection: "contacts", pk: "pk-00010759", payload: Some("{\"p\": 21, \"edit\": \"dup-existing-2\"}"), version: 21244, deleted: false, device_id: "device-1000", created_version: 10759 }
+RowDump { collection: "tasks", pk: "pk-00010761", payload: Some("{\"p\": 22, \"edit\": \"dup-existing-2\"}"), version: 21246, deleted: false, device_id: "device-1000", created_version: 10761 }
+RowDump { collection: "tasks", pk: "pk-00010762", payload: Some("{\"p\": 23, \"edit\": \"dup-existing-2\"}"), version: 21248, deleted: false, device_id: "device-1000", created_version: 10762 }
+RowDump { collection: "tasks", pk: "pk-00010763", payload: Some("{\"p\": 24, \"edit\": \"dup-existing-2\"}"), version: 21250, deleted: false, device_id: "device-1000", created_version: 10763 }
+RowDump { collection: "tasks", pk: "pk-00010764", payload: Some("{\"p\": 25, \"edit\": \"dup-existing-2\"}"), version: 21252, deleted: false, device_id: "device-1000", created_version: 10764 }
+RowDump { collection: "tasks", pk: "pk-00010765", payload: Some("{\"p\": 26, \"edit\": \"dup-existing-2\"}"), version: 21254, deleted: false, device_id: "device-1000", created_version: 10765 }
+RowDump { collection: "tasks", pk: "pk-00010766", payload: Some("{\"p\": 27, \"edit\": \"dup-existing-2\"}"), version: 21256, deleted: false, device_id: "device-1000", created_version: 10766 }
+RowDump { collection: "tasks", pk: "pk-00010767", payload: Some("{\"p\": 28, \"edit\": \"dup-existing-2\"}"), version: 21258, deleted: false, device_id: "device-1000", created_version: 10767 }
+RowDump { collection: "tasks", pk: "pk-00010768", payload: Some("{\"p\": 29, \"edit\": \"dup-existing-2\"}"), version: 21260, deleted: false, device_id: "device-1000", created_version: 10768 }
+RowDump { collection: "tasks", pk: "pk-00010769", payload: Some("{\"p\": 30, \"edit\": \"dup-existing-2\"}"), version: 21262, deleted: false, device_id: "device-1000", created_version: 10769 }
+RowDump { collection: "tasks", pk: "pk-00010770", payload: Some("{\"p\": 31, \"edit\": \"dup-existing-2\"}"), version: 21264, deleted: false, device_id: "device-1000", created_version: 10770 }
+RowDump { collection: "tasks", pk: "pk-00010771", payload: Some("{\"p\": 32, \"edit\": \"dup-existing-2\"}"), version: 21266, deleted: false, device_id: "device-1000", created_version: 10771 }
+RowDump { collection: "tasks", pk: "pk-00010772", payload: Some("{\"p\": 33, \"edit\": \"dup-existing-2\"}"), version: 21268, deleted: false, device_id: "device-1000", created_version: 10772 }
+RowDump { collection: "tasks", pk: "pk-00010773", payload: Some("{\"p\": 34, \"edit\": \"dup-existing-2\"}"), version: 21270, deleted: false, device_id: "device-1000", created_version: 10773 }
+RowDump { collection: "tasks", pk: "pk-00010774", payload: Some("{\"p\": 35, \"edit\": \"dup-existing-2\"}"), version: 21272, deleted: false, device_id: "device-1000", created_version: 10774 }
+RowDump { collection: "files", pk: "pk-00010775", payload: Some("{\"p\": 36, \"edit\": \"dup-existing-2\"}"), version: 21274, deleted: false, device_id: "device-1000", created_version: 10775 }
+RowDump { collection: "files", pk: "pk-00010776", payload: Some("{\"p\": 37, \"edit\": \"dup-existing-2\"}"), version: 21276, deleted: false, device_id: "device-1000", created_version: 10776 }
+RowDump { collection: "files", pk: "pk-00010777", payload: Some("{\"p\": 38, \"edit\": \"dup-existing-2\"}"), version: 21278, deleted: false, device_id: "device-1000", created_version: 10777 }
+RowDump { collection: "files", pk: "pk-00010778", payload: Some("{\"p\": 39, \"edit\": \"dup-existing-2\"}"), version: 21280, deleted: false, device_id: "device-1000", created_version: 10778 }
+
+=== statement-count scaling ===
+batch size=50    total sync-table statement calls=251
+batch size=250   total sync-table statement calls=1251
+batch size=1000  total sync-table statement calls=5001
+
+=== pg_stat_statements: replay of the 250-change batch (idempotency) ===
+-- top by calls --
+calls=250    buffers=750    SELECT version, resolved_row FROM autumn_sync_applied WHERE scope = $1 AND device_id = $2 AND change_id = $3
+calls=1      buffers=0      SELECT horizon AS version FROM autumn_sync_horizons WHERE scope = $1
+-- top by buffers --
+buffers=750    calls=250    SELECT version, resolved_row FROM autumn_sync_applied WHERE scope = $1 AND device_id = $2 AND change_id = $3
+buffers=0      calls=1      SELECT horizon AS version FROM autumn_sync_horizons WHERE scope = $1
+TOTAL sync-table statement calls=251 buffers=750 (this batch, all statement shapes)
+
+=== EXPLAIN (ANALYZE, BUFFERS, VERBOSE, SETTINGS): dedup check (typical case: miss) ===
+SELECT version, resolved_row FROM autumn_sync_applied WHERE scope = 'global' AND device_id = 'device-1000' AND change_id = 'device-1000-chg-000001'
+Index Scan using autumn_sync_applied_pkey on public.autumn_sync_applied  (cost=0.28..8.30 rows=1 width=40) (actual time=0.032..0.033 rows=1 loops=1)
+  Output: version, resolved_row
+  Index Cond: ((autumn_sync_applied.scope = 'global'::text) AND (autumn_sync_applied.device_id = 'device-1000'::text) AND (autumn_sync_applied.change_id = 'device-1000-chg-000001'::text))
+  Buffers: shared hit=3
+Query Identifier: 5474131966345183344
+Planning:
+  Buffers: shared hit=17
+Planning Time: 0.186 ms
+Execution Time: 0.051 ms
+
+=== EXPLAIN (ANALYZE, BUFFERS, VERBOSE, SETTINGS): current-row fetch FOR UPDATE ===
+SELECT collection, pk, payload, version, deleted, updated_at, device_id, created_version FROM autumn_sync_rows WHERE scope = 'global' AND collection = 'notes' AND pk = 'pk-00010001' FOR UPDATE
+LockRows  (cost=0.41..8.44 rows=1 width=317) (actual time=0.036..0.040 rows=1 loops=1)
+  Output: collection, pk, payload, version, deleted, updated_at, device_id, created_version, ctid
+  Buffers: shared hit=7
+  ->  Index Scan using autumn_sync_rows_pkey on public.autumn_sync_rows  (cost=0.41..8.43 rows=1 width=317) (actual time=0.023..0.027 rows=1 loops=1)
+        Output: collection, pk, payload, version, deleted, updated_at, device_id, created_version, ctid
+        Index Cond: ((autumn_sync_rows.scope = 'global'::text) AND (autumn_sync_rows.collection = 'notes'::text) AND (autumn_sync_rows.pk = 'pk-00010001'::text))
+        Buffers: shared hit=6
+Query Identifier: -3770326553474516971
+Planning:
+  Buffers: shared hit=3
+Planning Time: 0.085 ms
+Execution Time: 0.062 ms
+ok
+
+test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 1573 filtered out; finished in 6.85s
+


### PR DESCRIPTION
## 🎯 Workload

`PgSyncBackend::apply_push` (`autumn/src/sync/server.rs`) — the code `POST /sync/push` calls for every push batch in the offline-sync engine. Profiled through the real `SyncBackend::apply_push` entry point (not a copy) against a production-shaped fixture: 20,000 pre-existing rows in one scope, six collections at a 40/20/15/15/7/3% skew, 5% tombstones, variable-length JSON payloads with some NULL fields, real dead tuples from a post-seed `UPDATE`, `ANALYZE`'d. Push batches of 50/250/1000 changes (1000 = `MAX_PUSH_CHANGES`) shaped like a device catching up after being offline: 65% edits of existing rows, 20% new inserts, 5% deletes, 8% two edits of the *same* existing pk in one batch, 2% two edits of the *same brand-new* pk in one batch (create-then-edit before ever syncing).

Reproduce:
```sh
cargo test -p autumn-web --features "test-support,offline-sync" \
  --test integration_tests -- --ignored offline_sync_push_batching_profile \
  --nocapture --test-threads=1
```
Requires Docker (spins up a Postgres 16 testcontainer with `pg_stat_statements` preloaded). Harness: `autumn/tests/integration/offline_sync_push_batching_perf.rs`.

## 📈 Profile

`apply_push` *is* the workload being profiled (not one query among many) — there's no larger request to rank it against. The profile is the `pg_stat_statements` `calls` ranking of the 5 statements it issues per pushed change: each is individually a trivial single-row index-scan point lookup (3–7 buffers, <0.1ms), so a buffer-cost ranking alone would rank this as "inherent, nothing to see here." It only shows up as a problem in `calls`: exactly `5n + 1` statements per push, confirmed at three sizes (251 / 1251 / 5001 for n=50/250/1000) — see `docs/perf/sync-push-batching/baseline.txt`.

## 🧭 Plan

Each pushed change (`apply_change_row`) is decided against `current` (the existing row, if any) and a freshly allocated `version`, then written. Before, all 5 round trips were per-change: `EXPLAIN (ANALYZE, BUFFERS, VERBOSE, SETTINGS)` for the dedup check and the `FOR UPDATE` current-row fetch (`baseline.txt`) shows `Index Scan` / `LockRows` plans, 3 and 7 buffers, <0.1ms — no plan-shape defect, just issued once per change instead of once per batch.

## 💡 Hypothesis

The dedup lookup, current-row fetch, version draw, row upsert, and dedup-record insert are each naturally batchable across a whole push: `change_id`s are batch-unique (`validate_push` already rejects repeats), so the dedup check is one `change_id = ANY(...)` lookup; the current-row fetch is one `FOR UPDATE` over the batch's distinct `(collection, pk)` pairs; versions can be drawn `generate_series`-many at once; the upsert and dedup-insert are multi-row `INSERT ... UNNEST`. Mechanism: this is a Diesel-codebase N+1 (`.execute()`/`.get_result()` inside a `for change in &request.changes` loop) — the single highest-value change available, per the guidance in this repo's Ledger playbook.

## 🔧 Change

Rewrote `PgSyncBackend::apply_push` to run the 5 operations once per push instead of once per change:
1. Batch dedup check (`change_id = ANY($3)`)
2. Batch current-row fetch (`(collection, pk) IN (SELECT * FROM UNNEST(...))  FOR UPDATE`)
3. Batch version allocation (`nextval(...) FROM generate_series(1, n)`)
4. Decide every change in memory — `apply_change_row` unchanged, called once per change in request order, exactly as before
5. Batch upsert (`INSERT ... SELECT * FROM UNNEST(...) ON CONFLICT ...`) and batch dedup-record insert

No migration — no schema change, no new index, same tables, same transaction, same `pg_advisory_xact_lock` serialization against concurrent pushes/GC.

**The one correctness-relevant subtlety:** a pk touched twice in one batch (two queued local edits, or create-then-edit before either synced) needs the second change to see the first's outcome as `current` — exactly like the old same-transaction re-`SELECT` would (Postgres read-your-own-writes). That's now an in-memory map, seeded from the one batched fetch and updated after each change is decided; the decision loop still runs sequentially in request order, it just never talks to Postgres inside the loop. And since a single `INSERT ... ON CONFLICT` can't target the same conflict row twice, the batched upsert keeps only the **last** decided value per `(collection, pk)` — the same end state the old sequential per-change UPSERTs left.

## 📊 Measurement

| metric                    | n=50   | n=250   | n=1000   | tool |
|----------------------------|-------:|--------:|---------:|------|
| statement calls, before    | 251    | 1251    | 5001     | `pg_stat_statements.calls` |
| statement calls, after     | **6**  | **6**   | **6**    | `pg_stat_statements.calls` |
| buffers, before             | 1085   | 5823    | 23372    | `shared_blks_hit + shared_blks_read` |
| buffers, after               | 981    | 4962    | 20340    | `shared_blks_hit + shared_blks_read` |
| buffers reduction           | 9.6%   | 14.8%   | 13.0%    | — |

Idempotent replay of an all-duplicate 250-change batch (retry, nothing new to apply): **251 statements / 750 buffers → 2 statements / 8 buffers**.

Statement count drops from `5n + 1` to a **constant 6**, independent of batch size — clears the impact floor as an N+1 elimination (O(n)→O(1) statements) on its own; the 10–15% buffers reduction is a side effect, not the primary claim.

## ✅ Equivalence

The harness dumps every touched row (sorted deterministically by `collection, pk`, the table's key) after each batch, using `PushRequest`s built from fixed constant timestamps (never wall-clock), so two runs against identical code produce byte-identical input and — if the change preserves semantics — byte-identical output.

`diff` between `baseline.txt` and `after.txt`'s row dumps (1233 lines each, all three batch sizes plus the idempotent replay, covering clean update/insert/delete, two-edits-of-the-same-existing-pk, create-then-edit-of-the-same-new-pk, and dedup replay) is **empty**.

Also passing, unchanged:
- The existing 39-test `offline_sync_conformance` suite (shared push/pull/dedup/conflict/GC/scope-isolation script, runs against `MemorySyncBackend`)
- The Docker-gated `offline_sync_pg` suite (same conformance script against the real `PgSyncBackend`)

No ANN/vector-search path involved — no recall@k applicable.

## 💸 Write cost

No index added or dropped — same tables, same columns, same constraints. WAL bytes per push are unaffected in shape (same rows ultimately written); not separately measured since this change touches read/round-trip cost, not row content or count.

## 🔬 Reproduce

```sh
# Baseline (checkout the harness commit before the batching commit):
cargo test -p autumn-web --features "test-support,offline-sync" \
  --test integration_tests -- --ignored offline_sync_push_batching_profile \
  --nocapture --test-threads=1

# Existing conformance suites (unaffected code paths, must stay green):
cargo test -p autumn-web --features "test-support,offline-sync" \
  --test integration_tests -- offline_sync --test-threads=4
cargo test -p autumn-web --features "test-support,offline-sync" \
  --test integration_tests -- offline_sync_pg --ignored --test-threads=1

cargo fmt --all
cargo clippy -p autumn-web --all-targets --features "test-support,offline-sync" -- -D warnings
```

Full artifacts: `docs/perf/sync-push-batching/{README.md,baseline.txt,after.txt}`.


---
_Generated by [Claude Code](https://claude.ai/code/session_016aWkSfYRxH3Cuq6FiRynpD)_