### PR TITLE
Promote authorization_policies to a provable security-manifest dimension (#1627)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,47 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   before. See `docs/guide/retention-sweeps.md` and the `examples/saas`
   `PasswordResetToken` demo.
 
+- **security:** `autumn routes audit` now proves *what* a route is authorized
+  to do, not merely that it is guarded. The security posture manifest moves to
+  schema v3 and gains a fourth dimension, `authorization_policies`
+  (`provenance: "provable"`, `source: "macro:#[authorize]"`): one
+  `(action, resource)` entry per `#[authorize]` binding, recovered from the
+  macro expansion in either attribute order and through stacked guards, then
+  sorted by `(path, method, action, resource)` and deduplicated so a rebuild
+  of unchanged code stays byte-identical. The dimension carries a required
+  `runtime_caveat` naming the one step a build cannot prove — which
+  `impl Policy<R>` the `PolicyRegistry` serves at boot — rather than shipping
+  a bare `provable` tag it cannot defend. `authorization_policies` therefore
+  leaves the `excluded` list; `policy_registration` stays there for the
+  boot-time fact, reworded to point at that caveat, and a new
+  `repository_policy_bindings` entry discloses that
+  `#[repository(api = ..., policy = ...)]` auto-APIs set
+  `routes.entries[].policy` without leaving a binding the macro can recover
+  (`routes.entries[].policy` is a superset of the proven bindings, and stays
+  one). Carrying the bindings adds two pieces of route metadata:
+  `ApiDoc::authorize_bindings` (compile-time `&'static [AuthorizeBinding]`)
+  and its `RouteInfo::authorize_bindings` wire twin
+  (`Vec<AuthorizeBindingInfo>`, elided from the routes dump when empty, so
+  older dumps still deserialize unchanged). The recorded resource is the
+  identifier as written, never the `Policy` impl. The provenance rubric
+  deciding when a dimension may claim `provable`, `declared`, or
+  `runtime-only` — and when a mostly-provable dimension ships with a caveat
+  instead of a demotion, with outbound HTTP worked through as `declared` — is
+  now documented in `docs/guide/security-posture-manifest.md` (#1627).
+
 ### Fixed
+
+- **security:** `#[secured]`'s roles and scopes are no longer lost when another
+  guard wraps the handler body. With `#[secured("admin")]` written above
+  `#[authorize]`, `#[secured]` expands first and `#[authorize]` then buries its
+  role/scope marker consts one level deeper, inside the generated
+  `let __autumn_inner: T = (async move { … }).await;` wrapper — a shape the
+  marker walks did not descend. Extraction fell through
+  to the policy-check fallback, and the route reported `secured: true` with
+  empty `roles`/`scopes`: a *provable* manifest dimension silently understating
+  the posture it exists to prove. Both walks now descend the generated wrapper
+  through the same helper the `#[authorize]` binding walk uses, so the sibling
+  extractors can no longer disagree about depth (#1627).
 
 - **`generate admin` over an `#[encrypted]` model:** the generated admin adapter
   did not compile — it bound `&new_row` to `.values(…)` and `&diesel_changeset`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   through the same helper the `#[authorize]` binding walk uses, so the sibling
   extractors can no longer disagree about depth (#1627).
 
+- **security:** two sibling route-metadata losses found by review of the same
+  extraction ladder: (1) `#[secured]` above the route macro with `#[authorize]`
+  below it dropped the roles/scopes to `&[]` — the live `#[authorize]`
+  attribute short-circuited the marker read, so deleting the `#[secured(...)]`
+  line produced zero manifest diff; the marker read now runs first. (2) The
+  `#[public]` marker walk could not descend a wrapping guard's generated body,
+  so `#[public]` above `#[throttle]` lost `public: true` and false-failed the
+  coverage gate as `unclassified`; the walk now uses the same shared
+  wrapper-descent helper as the other marker extractors (#1627).
+
 - **`generate admin` over an `#[encrypted]` model:** the generated admin adapter
   did not compile — it bound `&new_row` to `.values(…)` and `&diesel_changeset`
   to `.set(…)`, and diesel implements `Insertable`/`AsChangeset` only for the

--- a/autumn-cli/src/routes_audit.rs
+++ b/autumn-cli/src/routes_audit.rs
@@ -17,7 +17,8 @@
 use std::process::Command;
 
 use autumn_web::route_listing::{
-    CsrfDump, HeadersDump, OMITTED_ROUTES_MARKER, SECURITY_CONFIG_MARKER, SecurityDump,
+    AuthorizeBindingInfo, CsrfDump, HeadersDump, OMITTED_ROUTES_MARKER, SECURITY_CONFIG_MARKER,
+    SecurityDump,
 };
 use serde::{Deserialize, Serialize};
 
@@ -26,11 +27,19 @@ use crate::routes;
 /// Schema version of the emitted manifest. Bumped only on breaking changes to
 /// the document shape.
 ///
-/// v2 (#1627) wraps each dimension in a provenance envelope
-/// (`{ provenance, source, entries }`), adds the `csrf` and `security_headers`
-/// dimensions, and adds a top-level `excluded` list. The `routes` entries keep
+/// v2 (#1627) wrapped each dimension in a provenance envelope
+/// (`{ provenance, source, entries }`), added the `csrf` and `security_headers`
+/// dimensions, and added a top-level `excluded` list. The `routes` entries keep
 /// their v1 shape, only wrapped in the envelope.
-pub const MANIFEST_SCHEMA_VERSION: u32 = 2;
+///
+/// v3 (#1627) promotes `authorization_policies` from `excluded` to a fourth
+/// emitted dimension: the route→action→resource bindings proven from expanded
+/// `#[authorize]` attributes, in a provenance envelope that carries an extra
+/// `runtime_caveat` naming the one part of the story a build cannot prove.
+/// `excluded` keeps `policy_registration` for that runtime fact and gains
+/// `repository_policy_bindings` for the auto-API guards whose policy type the
+/// macro discards. The v2 dimensions are unchanged.
+pub const MANIFEST_SCHEMA_VERSION: u32 = 3;
 
 /// Options controlling `autumn routes audit`.
 pub struct AuditOptions<'a> {
@@ -74,6 +83,11 @@ pub struct AuditRoute {
     /// `location` in the dump).
     #[serde(default)]
     pub location: Option<String>,
+    /// Record-level `(action, resource)` bindings proven from the handler's
+    /// `#[authorize]` attributes, already sorted and deduplicated by the dump.
+    /// Absent on older dumps and on routes that declare none.
+    #[serde(default)]
+    pub authorize_bindings: Vec<AuthorizeBindingInfo>,
 }
 
 impl AuditRoute {
@@ -89,7 +103,7 @@ impl AuditRoute {
     }
 }
 
-// ── Manifest document (schema v2, #1627) ────────────────────────────────────
+// ── Manifest document (schema v3, #1627) ────────────────────────────────────
 
 /// Provenance class of a manifest dimension. A small closed enum serialized to
 /// the exact lowercase tags used throughout the manifest.
@@ -108,7 +122,7 @@ pub enum Provenance {
     RuntimeOnly,
 }
 
-/// Top-level security manifest (schema v2).
+/// Top-level security manifest (schema v3).
 #[derive(Debug, Serialize)]
 pub struct Manifest {
     pub schema_version: u32,
@@ -119,12 +133,15 @@ pub struct Manifest {
 }
 
 /// Manifest dimensions. Order is fixed (`routes`, then `csrf`, then
-/// `security_headers`) so the serialized document is diff-stable.
+/// `security_headers`, then `authorization_policies`) so the serialized
+/// document is diff-stable. New dimensions append, keeping the v2 keys in
+/// place.
 #[derive(Debug, Serialize)]
 pub struct Dimensions {
     pub routes: RoutesDimension,
     pub csrf: CsrfDimension,
     pub security_headers: HeadersDimension,
+    pub authorization_policies: AuthorizationPoliciesDimension,
 }
 
 /// The `routes` dimension: provable auth posture per mounted route.
@@ -193,6 +210,38 @@ pub struct HeaderEntry {
     pub header: String,
     pub value: String,
     pub emitted: bool,
+}
+
+/// The `authorization_policies` dimension: provable record-level authorization
+/// bindings, one entry per route × `#[authorize]` binding.
+///
+/// Provable, because every entry is recovered from macro-expanded code — but
+/// only as far as the resource *identifier*. Which `impl Policy<Resource>`
+/// answers the check is a boot fact, disclosed on the dimension itself as
+/// [`Self::runtime_caveat`] rather than left for the reader to infer.
+#[derive(Debug, Serialize)]
+pub struct AuthorizationPoliciesDimension {
+    pub provenance: Provenance,
+    pub source: &'static str,
+    /// The part of the authorization story a build-time manifest cannot prove,
+    /// stated on the dimension itself instead of being buried in `excluded`.
+    pub runtime_caveat: &'static str,
+    pub entries: Vec<AuthorizationPolicyEntry>,
+}
+
+/// One authorization binding: a route plus the `(action, resource)` pair one of
+/// its `#[authorize]` attributes declares. A route carrying several bindings
+/// contributes several entries.
+#[derive(Debug, Serialize)]
+pub struct AuthorizationPolicyEntry {
+    pub path: String,
+    pub method: String,
+    pub name: String,
+    pub action: String,
+    pub resource: String,
+    /// How the binding was established. `"provable"` means it was derived from
+    /// macro-expanded code (route + `#[authorize]` arguments).
+    pub provenance: &'static str,
 }
 
 /// A dimension deliberately not yet emitted in this manifest build.
@@ -357,16 +406,68 @@ fn header_entry(header: &str, value: String) -> HeaderEntry {
     }
 }
 
+/// Build the `authorization_policies` dimension (provable): one flat entry per
+/// route × `#[authorize]` binding, ordered by `(path, method, action,
+/// resource)`.
+///
+/// Framework routes are skipped. The framework mounts them itself, so they can
+/// carry no `#[authorize]`; `route_listing::authorize_bindings_of` already
+/// drops any binding on them, and repeating the rule here keeps a malformed
+/// dump from inventing an authorization claim the code never made.
+///
+/// A route with `policy: true` but no bindings contributes nothing: that
+/// boolean is a superset also covering inline `__check_policy` calls and
+/// `#[repository(policy = ...)]` auto-APIs, neither of which proves an
+/// `(action, resource)` pair (see the `repository_policy_bindings` entry in
+/// [`excluded_dimensions`]).
+fn build_authorization_policies_dimension(routes: &[AuditRoute]) -> AuthorizationPoliciesDimension {
+    let mut entries: Vec<AuthorizationPolicyEntry> = routes
+        .iter()
+        .filter(|r| r.source != "framework")
+        .flat_map(|r| {
+            r.authorize_bindings
+                .iter()
+                .map(move |b| AuthorizationPolicyEntry {
+                    path: r.path.clone(),
+                    method: r.method.clone(),
+                    name: r.handler.clone(),
+                    action: b.action.clone(),
+                    resource: b.resource.clone(),
+                    provenance: "provable",
+                })
+        })
+        .collect();
+    entries.sort_by(|a, b| {
+        a.path
+            .cmp(&b.path)
+            .then_with(|| a.method.cmp(&b.method))
+            .then_with(|| a.action.cmp(&b.action))
+            .then_with(|| a.resource.cmp(&b.resource))
+    });
+
+    AuthorizationPoliciesDimension {
+        provenance: Provenance::Provable,
+        source: "macro:#[authorize]",
+        runtime_caveat: "the route→action→resource binding is proven from macro-expanded code; \
+                         which impl Policy<Resource> serves it is resolved from the \
+                         PolicyRegistry at boot (AppBuilder::policy::<R, _>(...)). A missing \
+                         registration is not visible at build time — see the policy_registration \
+                         entry in `excluded`.",
+        entries,
+    }
+}
+
 /// The fixed, deterministically-ordered list of dimensions deliberately
-/// excluded from this manifest build (#1627 slice 1).
+/// excluded from this manifest build (#1627).
 fn excluded_dimensions() -> Vec<ExcludedDimension> {
     vec![
         ExcludedDimension {
-            dimension: "authorization_policies",
+            dimension: "repository_policy_bindings",
             eventual_provenance: Provenance::Provable,
-            reason: "phase-1 follow-up: full #[authorize] action→policy-type binding needs new \
-                     macro metadata; boolean policy presence already ships in \
-                     routes.entries[].policy",
+            reason: "#[repository(api = ..., policy = ...)] auto-API handlers enforce fixed \
+                     show/create/update/delete policy actions, but the macro discards the policy \
+                     type at expansion and RepositoryApiMeta carries only a type-erased probe; \
+                     their presence still shows as routes.entries[].policy",
         },
         ExcludedDimension {
             dimension: "sessions",
@@ -402,7 +503,9 @@ fn excluded_dimensions() -> Vec<ExcludedDimension> {
         ExcludedDimension {
             dimension: "policy_registration",
             eventual_provenance: Provenance::RuntimeOnly,
-            reason: "boot-time fact; excluded from a build-time manifest by design",
+            reason: "boot-time fact; excluded from a build-time manifest by design — the \
+                     authorization_policies dimension proves bindings and carries this as its \
+                     runtime_caveat",
         },
         ExcludedDimension {
             dimension: "serve_path_routers",
@@ -439,12 +542,14 @@ const fn empty_headers_dimension() -> HeadersDimension {
     }
 }
 
-/// Build a stable-ordered security manifest (schema v2) from the audited routes
+/// Build a stable-ordered security manifest (schema v3) from the audited routes
 /// and the resolved security configuration.
 ///
 /// When `security` is `None` (an older dump with no security-config marker) the
 /// declared dimensions are emitted empty rather than fabricated, keeping the
-/// schema stable without asserting configuration the dump did not report.
+/// schema stable without asserting configuration the dump did not report. The
+/// provable dimensions (`routes`, `authorization_policies`) read the dumped
+/// listing alone, so they are identical either way.
 ///
 /// All dimensions are deterministically ordered so the manifest is diff-friendly
 /// and reproducible across runs.
@@ -467,6 +572,7 @@ pub fn build_manifest(routes: &[AuditRoute], security: Option<&SecurityDump>) ->
             routes: routes_dim,
             csrf,
             security_headers,
+            authorization_policies: build_authorization_policies_dimension(routes),
         },
         excluded: excluded_dimensions(),
     }
@@ -700,7 +806,30 @@ mod tests {
             policy: false,
             module: None,
             location: None,
+            authorize_bindings: Vec::new(),
         }
+    }
+
+    /// A route guarded by one or more `#[authorize]` attributes: the dump
+    /// carries the `(action, resource)` pairs *and* sets `policy: true`, since
+    /// the expanded guard is a policy check like any other.
+    fn route_with_bindings(
+        method: &str,
+        path: &str,
+        handler: &str,
+        classification: &str,
+        bindings: &[(&str, &str)],
+    ) -> AuditRoute {
+        let mut r = route(method, path, handler, classification);
+        r.policy = true;
+        r.authorize_bindings = bindings
+            .iter()
+            .map(|(action, resource)| AuthorizeBindingInfo {
+                action: (*action).to_owned(),
+                resource: (*resource).to_owned(),
+            })
+            .collect();
+        r
     }
 
     // ── classification / gate ────────────────────────────────────────────────
@@ -794,7 +923,7 @@ mod tests {
         assert_eq!(manifest.dimensions.routes.entries[0].provenance, "provable");
 
         let json: serde_json::Value = serde_json::from_str(&manifest_json(&manifest)).unwrap();
-        assert_eq!(json["schema_version"], 2);
+        assert_eq!(json["schema_version"], 3);
         let entry = &json["dimensions"]["routes"]["entries"][0];
         for key in [
             "path",
@@ -881,11 +1010,11 @@ mod tests {
         serde_json::from_str(&manifest_json(m)).unwrap()
     }
 
-    /// AC-1: the top-level document is schema v2, carries the three dimensions
+    /// AC-1: the top-level document is schema v3, carries the four dimensions
     /// with the correct provenance labels, and the `excluded` list with its
     /// closed provenance enum values.
     #[test]
-    fn manifest_v2_envelope_shape_and_provenance_labels() {
+    fn manifest_envelope_shape_and_provenance_labels() {
         let routes = vec![
             route("GET", "/health", "health", "framework"),
             route("POST", "/widgets", "create_widget", "gated"),
@@ -893,7 +1022,7 @@ mod tests {
         let sec = security_dump(true, &[]);
         let json = manifest_value(&build_manifest(&routes, Some(&sec)));
 
-        assert_eq!(json["schema_version"], 2);
+        assert_eq!(json["schema_version"], 3);
         assert_eq!(json["dimensions"]["routes"]["provenance"], "provable");
         assert_eq!(
             json["dimensions"]["routes"]["source"],
@@ -909,12 +1038,40 @@ mod tests {
             json["dimensions"]["security_headers"]["source"],
             "config:security.headers"
         );
+        assert_eq!(
+            json["dimensions"]["authorization_policies"]["provenance"],
+            "provable"
+        );
+        assert_eq!(
+            json["dimensions"]["authorization_policies"]["source"],
+            "macro:#[authorize]"
+        );
+        // The provable dimension states its own limit on the wire rather than
+        // leaving readers to infer it from `excluded`.
+        assert!(
+            !json["dimensions"]["authorization_policies"]["runtime_caveat"]
+                .as_str()
+                .expect("runtime_caveat string")
+                .is_empty(),
+            "the authorization_policies dimension must carry a non-empty runtime_caveat"
+        );
 
         // Excluded list is present, ordered, and uses the closed enum values.
         let excluded = json["excluded"].as_array().expect("excluded array");
         assert_eq!(excluded.len(), 9);
-        assert_eq!(excluded[0]["dimension"], "authorization_policies");
+        assert_eq!(excluded[0]["dimension"], "repository_policy_bindings");
         assert_eq!(excluded[0]["eventual_provenance"], "provable");
+        // v3: `authorization_policies` graduated out of `excluded` into a real
+        // dimension; leaving a stale excluded entry behind would claim the
+        // manifest still cannot prove what it now proves.
+        assert!(
+            !excluded
+                .iter()
+                .any(|e| e["dimension"] == "authorization_policies"),
+            "authorization_policies is emitted now and must not also be listed as excluded"
+        );
+        // The registry lookup that resolves a binding to an `impl Policy<_>`
+        // stays a boot fact, so `policy_registration` stays excluded.
         let runtime_only = excluded
             .iter()
             .find(|e| e["dimension"] == "policy_registration")
@@ -929,6 +1086,264 @@ mod tests {
             .find(|e| e["dimension"] == "serve_path_routers")
             .expect("serve_path_routers excluded");
         assert_eq!(serve_path["eventual_provenance"], "provable");
+    }
+
+    // ── authorization_policies dimension (#1627 slice 2) ─────────────────────
+
+    /// AC-4: an `authorization_policies` entry carries exactly the route
+    /// coordinates plus the proven `(action, resource)` pair and its own
+    /// provenance tag — no more (the `from = ident` parameter name is a binding
+    /// detail, not a security fact) and no less.
+    #[test]
+    fn manifest_authorization_policies_entry_shape() {
+        let routes = vec![route_with_bindings(
+            "POST",
+            "/notes/{id}",
+            "update_note",
+            "gated",
+            &[("update", "Note")],
+        )];
+        let json = manifest_value(&build_manifest(&routes, None));
+        let entry = &json["dimensions"]["authorization_policies"]["entries"][0];
+        let obj = entry.as_object().expect("entry object");
+
+        let keys = ["path", "method", "name", "action", "resource", "provenance"];
+        for key in keys {
+            assert!(obj.contains_key(key), "entry missing `{key}`: {entry}");
+        }
+        assert_eq!(obj.len(), keys.len(), "unexpected extra keys: {entry}");
+
+        assert_eq!(entry["path"], "/notes/{id}");
+        assert_eq!(entry["method"], "POST");
+        assert_eq!(entry["name"], "update_note");
+        assert_eq!(entry["action"], "update");
+        assert_eq!(entry["resource"], "Note");
+        assert_eq!(entry["provenance"], "provable");
+    }
+
+    /// AC-4 keystone: removing one `#[authorize]` from a handler removes
+    /// exactly that binding's entry and leaves every other dimension
+    /// byte-identical. This is the falsifiability claim the dimension makes —
+    /// if the manifest kept reporting a binding whose attribute is gone, the
+    /// "provable" tag would be a lie.
+    #[test]
+    fn removing_an_authorize_binding_flips_only_that_entry() {
+        let dump = |bindings: &[(&str, &str)]| {
+            vec![
+                route("GET", "/health", "health", "framework"),
+                route_with_bindings("POST", "/notes/{id}", "update_note", "gated", bindings),
+            ]
+        };
+        let sec = security_dump(true, &[]);
+        let both = manifest_value(&build_manifest(
+            &dump(&[("delete", "Note"), ("update", "Note")]),
+            Some(&sec),
+        ));
+        let one = manifest_value(&build_manifest(&dump(&[("update", "Note")]), Some(&sec)));
+
+        // Every other dimension is untouched: the route is still `gated`, still
+        // carries `policy: true`, and is still the same mutating CSRF entry.
+        assert_eq!(both["dimensions"]["routes"], one["dimensions"]["routes"]);
+        assert_eq!(both["dimensions"]["csrf"], one["dimensions"]["csrf"]);
+        assert_eq!(
+            both["dimensions"]["security_headers"],
+            one["dimensions"]["security_headers"]
+        );
+
+        let entries = |v: &serde_json::Value| -> Vec<serde_json::Value> {
+            v["dimensions"]["authorization_policies"]["entries"]
+                .as_array()
+                .expect("entries array")
+                .clone()
+        };
+        let (both_entries, one_entries) = (entries(&both), entries(&one));
+        assert_eq!(both_entries.len(), 2, "{both_entries:?}");
+        assert_eq!(one_entries.len(), 1, "{one_entries:?}");
+
+        // The difference is exactly the removed binding; the surviving entry is
+        // byte-identical to the one it was listed beside.
+        let removed: Vec<&serde_json::Value> = both_entries
+            .iter()
+            .filter(|e| !one_entries.contains(e))
+            .collect();
+        assert_eq!(removed.len(), 1, "exactly one entry may disappear");
+        assert_eq!(removed[0]["action"], "delete");
+        assert_eq!(removed[0]["resource"], "Note");
+        assert_eq!(one_entries[0]["action"], "update");
+    }
+
+    /// The mirror claim (closing AC-7 in the other direction): changing a
+    /// route's *classification* moves the `routes` dimension and nothing else.
+    /// The route reclassified here is a safe-method GET with no bindings, so a
+    /// leak into `csrf` or `authorization_policies` can only be a bug.
+    #[test]
+    fn reclassifying_a_route_flips_only_the_routes_dimension() {
+        let dump = |cls: &str, roles: &[&str]| {
+            let mut reports = route("GET", "/reports", "reports", cls);
+            reports.roles = roles.iter().map(|r| (*r).to_owned()).collect();
+            vec![
+                reports,
+                route_with_bindings(
+                    "POST",
+                    "/notes/{id}",
+                    "update_note",
+                    "gated",
+                    &[("update", "Note")],
+                ),
+            ]
+        };
+        let sec = security_dump(true, &[]);
+        let before = manifest_value(&build_manifest(&dump("unclassified", &[]), Some(&sec)));
+        let after = manifest_value(&build_manifest(&dump("gated", &["admin"]), Some(&sec)));
+
+        assert_ne!(
+            before["dimensions"]["routes"], after["dimensions"]["routes"],
+            "reclassifying a route must be visible in the routes dimension"
+        );
+        assert_eq!(before["dimensions"]["csrf"], after["dimensions"]["csrf"]);
+        assert_eq!(
+            before["dimensions"]["security_headers"],
+            after["dimensions"]["security_headers"]
+        );
+        // Sanity: the comparison below is a real claim only while the dimension
+        // actually has entries to differ in.
+        assert!(
+            !before["dimensions"]["authorization_policies"]["entries"]
+                .as_array()
+                .expect("entries array")
+                .is_empty(),
+            "the fixture must seed at least one binding"
+        );
+        assert_eq!(
+            before["dimensions"]["authorization_policies"],
+            after["dimensions"]["authorization_policies"]
+        );
+    }
+
+    /// AC-6 ordering: entries are globally sorted by
+    /// `(path, method, action, resource)` regardless of dump order, so the
+    /// manifest diff stays reviewable.
+    #[test]
+    fn authorization_policies_entries_are_sorted() {
+        let routes = vec![
+            route_with_bindings(
+                "POST",
+                "/notes/{id}",
+                "update_note",
+                "gated",
+                &[("update", "Note"), ("delete", "Note")],
+            ),
+            route_with_bindings(
+                "GET",
+                "/notes/{id}",
+                "show_note",
+                "gated",
+                &[("show", "Note")],
+            ),
+            route_with_bindings(
+                "POST",
+                "/albums/{id}",
+                "update_album",
+                "gated",
+                &[("update", "Photo"), ("update", "Album")],
+            ),
+        ];
+        let manifest = build_manifest(&routes, None);
+        let order: Vec<(&str, &str, &str, &str)> = manifest
+            .dimensions
+            .authorization_policies
+            .entries
+            .iter()
+            .map(|e| {
+                (
+                    e.path.as_str(),
+                    e.method.as_str(),
+                    e.action.as_str(),
+                    e.resource.as_str(),
+                )
+            })
+            .collect();
+        assert_eq!(
+            order,
+            vec![
+                ("/albums/{id}", "POST", "update", "Album"),
+                ("/albums/{id}", "POST", "update", "Photo"),
+                ("/notes/{id}", "GET", "show", "Note"),
+                ("/notes/{id}", "POST", "delete", "Note"),
+                ("/notes/{id}", "POST", "update", "Note"),
+            ],
+            "entries sort by (path, method, action, resource)"
+        );
+    }
+
+    /// D6 pin: `routes.entries[].policy` is a *superset* boolean.
+    /// A `#[repository(policy = ...)]` auto-API route, or a handler calling
+    /// `__check_policy` inline, dumps `policy: true` with no bindings — and
+    /// must contribute no authorization entry rather than a fabricated one.
+    /// That gap is disclosed by the `repository_policy_bindings` excluded entry.
+    #[test]
+    fn policy_true_without_bindings_produces_no_authorization_entry() {
+        let mut r = route("POST", "/api/notes", "notes::create", "gated");
+        r.policy = true;
+        let json = manifest_value(&build_manifest(&[r], None));
+
+        assert_eq!(json["dimensions"]["routes"]["entries"][0]["policy"], true);
+        assert!(
+            json["dimensions"]["authorization_policies"]["entries"]
+                .as_array()
+                .expect("entries array")
+                .is_empty(),
+            "a bare `policy: true` proves no (action, resource) binding"
+        );
+
+        let excluded = json["excluded"].as_array().expect("excluded array");
+        let repo = excluded
+            .iter()
+            .find(|e| e["dimension"] == "repository_policy_bindings")
+            .expect("repository_policy_bindings excluded");
+        assert_eq!(repo["eventual_provenance"], "provable");
+        assert!(
+            repo["reason"]
+                .as_str()
+                .expect("reason string")
+                .contains("routes.entries[].policy"),
+            "the excluded entry must point readers at the superset boolean: {repo}"
+        );
+    }
+
+    /// Defense in depth at the CLI layer: framework routes are mounted by the
+    /// framework itself and can carry no `#[authorize]`, so
+    /// `route_listing::authorize_bindings_of` already drops any binding on
+    /// them. A dump claiming otherwise is malformed by construction, and the
+    /// builder mirrors that rule instead of trusting its input.
+    #[test]
+    fn framework_routes_never_contribute_authorization_entries() {
+        let mut framework = route_with_bindings(
+            "POST",
+            "/_autumn/unsubscribe",
+            "unsubscribe",
+            "framework",
+            &[("update", "Subscriber")],
+        );
+        framework.source = "framework".to_owned();
+        let routes = vec![
+            framework,
+            route_with_bindings(
+                "POST",
+                "/notes/{id}",
+                "update_note",
+                "gated",
+                &[("update", "Note")],
+            ),
+        ];
+        let manifest = build_manifest(&routes, None);
+        let entries = &manifest.dimensions.authorization_policies.entries;
+        assert_eq!(entries.len(), 1, "{entries:?}");
+        assert_eq!(entries[0].path, "/notes/{id}");
+        assert!(
+            !entries.iter().any(|e| e.path == "/_autumn/unsubscribe"),
+            "no framework route may appear: {entries:?}"
+        );
     }
 
     /// AC-2 falsifiability: one CSRF entry per mutating route; a safe-method
@@ -1318,18 +1733,29 @@ mod tests {
     }
 
     /// AC-6: two builds of identical source + config produce byte-identical
-    /// manifest JSON.
+    /// manifest JSON. Seeded with a multi-binding route so the
+    /// `authorization_policies` dimension is exercised too.
     #[test]
     fn manifest_rebuild_is_byte_identical() {
         let routes = vec![
             route("GET", "/health", "health", "framework"),
             route("POST", "/widgets", "create_widget", "gated"),
-            route("DELETE", "/widgets/{id}", "delete_widget", "gated"),
+            route_with_bindings(
+                "DELETE",
+                "/widgets/{id}",
+                "delete_widget",
+                "gated",
+                &[("delete", "Widget"), ("update", "Widget")],
+            ),
         ];
         let sec = security_dump(true, &["/api/", "/webhooks/"]);
         let a = manifest_json(&build_manifest(&routes, Some(&sec)));
         let b = manifest_json(&build_manifest(&routes, Some(&sec)));
         assert_eq!(a, b, "manifest must be reproducible byte-for-byte");
+        assert!(
+            a.contains("\"resource\": \"Widget\""),
+            "the seeded bindings must appear in the manifest: {a}"
+        );
     }
 
     /// The `parse_security_config` reader recovers the dump from a stderr stream

--- a/autumn-macros/src/api_doc.rs
+++ b/autumn-macros/src/api_doc.rs
@@ -876,6 +876,160 @@ fn extract_secured_scopes_marker_from_expr(expr: &syn::Expr) -> Option<Vec<Strin
     }
 }
 
+/// Name of the marker const `#[authorize]` prepends to a guarded body so the
+/// binding survives the attribute's own removal.
+const AUTHORIZE_BINDINGS_MARKER: &str = "__AUTUMN_AUTHORIZE_BINDINGS";
+
+/// Extract the `#[authorize]` bindings declared on a handler, as
+/// `(action, resource)` pairs in source order.
+///
+/// Mirrors [`extract_secured_info`]'s attribute/marker duality, but takes the
+/// **union** of the two rather than the first that matches: a mixed stack
+/// (`#[authorize(A)]` above the route macro, `#[authorize(B)]` below it) leaves
+/// one already-expanded marker *and* one live attribute, and both are real
+/// bindings.
+///
+/// 1. Attributes still present — the route macro is outermost, so `#[authorize]`
+///    has not expanded yet. Parsed with the `#[authorize]` grammar itself
+///    ([`crate::authorize::parse_with_leading_literal`]) so the two sites cannot
+///    drift apart. Every matching attribute contributes, since nothing stops a
+///    handler from stacking several.
+/// 2. Marker consts in the body — `#[authorize]` expanded first and deleted its
+///    own attribute. The walk descends the generated `(async move { … }).await`
+///    wrappers, because each guard that expands afterwards buries the marker one
+///    level deeper, and collects every level instead of stopping at the first.
+///
+/// Markers are decoded structurally (`&[( "action", "Resource" ), …]`), never by
+/// scanning stringified tokens, so handler *text* that merely spells the marker
+/// cannot forge a binding. A same-named const of any other shape is not ours to
+/// interpret and contributes nothing rather than erroring.
+pub fn extract_authorize_bindings(input_fn: &syn::ItemFn) -> Vec<(String, String)> {
+    let mut bindings = Vec::new();
+
+    for attr in &input_fn.attrs {
+        if attr.path().is_ident("authorize")
+            || attr
+                .path()
+                .segments
+                .last()
+                .is_some_and(|s| s.ident == "authorize")
+        {
+            bindings.extend(authorize_binding_from_attr(attr));
+        }
+    }
+
+    collect_authorize_markers_in_stmts(&input_fn.block.stmts, &mut bindings);
+    bindings
+}
+
+/// Read one still-unexpanded `#[authorize(...)]` attribute.
+///
+/// Returns `None` for an attribute the `#[authorize]` macro will itself reject
+/// (a bare `#[authorize]` with no arguments, a missing action or resource): the
+/// macro reports the diagnostic, and metadata extraction stays silent rather
+/// than emitting a second error or a half-formed binding.
+fn authorize_binding_from_attr(attr: &syn::Attribute) -> Option<(String, String)> {
+    let syn::Meta::List(list) = &attr.meta else {
+        return None;
+    };
+    let args = crate::authorize::parse_with_leading_literal(list.tokens.clone()).ok()?;
+    Some((args.action?, args.resource?.to_string()))
+}
+
+fn collect_authorize_markers_in_stmts(stmts: &[syn::Stmt], out: &mut Vec<(String, String)>) {
+    for stmt in stmts {
+        collect_authorize_markers_in_stmt(stmt, out);
+    }
+}
+
+fn collect_authorize_markers_in_stmt(stmt: &syn::Stmt, out: &mut Vec<(String, String)>) {
+    match stmt {
+        syn::Stmt::Item(syn::Item::Const(item_const))
+            if item_const.ident == AUTHORIZE_BINDINGS_MARKER =>
+        {
+            collect_authorize_bindings_from_marker_expr(&item_const.expr, out);
+        }
+        syn::Stmt::Expr(expr, _) => collect_authorize_markers_in_expr(expr, out),
+        syn::Stmt::Local(local) => {
+            if let Some(init) = &local.init {
+                collect_authorize_markers_in_expr(&init.expr, out);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn collect_authorize_markers_in_expr(expr: &syn::Expr, out: &mut Vec<(String, String)>) {
+    match expr {
+        syn::Expr::Block(block) => collect_authorize_markers_in_stmts(&block.block.stmts, out),
+        syn::Expr::Unsafe(block) => collect_authorize_markers_in_stmts(&block.block.stmts, out),
+        // Everything the body guards generate — `(async move { … }).await`,
+        // optionally inside `IntoResponse::into_response(…)`, parens or
+        // invisible groups — is unwrapped by the shared helper, so a marker
+        // stays reachable however many guards expanded around it.
+        _ => {
+            if let Some(block) = crate::idempotency_guard::expr_nested_async_body(expr) {
+                collect_authorize_markers_in_stmts(&block.stmts, out);
+            }
+        }
+    }
+}
+
+/// Decode a `&[("action", "Resource"), …]` marker initializer.
+///
+/// All-or-nothing per marker: one element of an unexpected shape means the const
+/// is not the one we emit, so none of it is recorded.
+fn collect_authorize_bindings_from_marker_expr(expr: &syn::Expr, out: &mut Vec<(String, String)>) {
+    let syn::Expr::Reference(reference) = expr else {
+        return;
+    };
+    let syn::Expr::Array(array) = reference.expr.as_ref() else {
+        return;
+    };
+
+    let mut decoded = Vec::with_capacity(array.elems.len());
+    for elem in &array.elems {
+        let syn::Expr::Tuple(tuple) = elem else {
+            return;
+        };
+        let [action, resource] = tuple.elems.iter().collect::<Vec<_>>()[..] else {
+            return;
+        };
+        let (Some(action), Some(resource)) =
+            (string_literal_value(action), string_literal_value(resource))
+        else {
+            return;
+        };
+        decoded.push((action, resource));
+    }
+    out.extend(decoded);
+}
+
+fn string_literal_value(expr: &syn::Expr) -> Option<String> {
+    match expr {
+        syn::Expr::Lit(syn::ExprLit {
+            lit: syn::Lit::Str(s),
+            ..
+        }) => Some(s.value()),
+        _ => None,
+    }
+}
+
+/// Emit the `&'static [AuthorizeBinding]` slice for `ApiDoc::authorize_bindings`.
+pub fn emit_authorize_binding_slice(bindings: &[(String, String)]) -> TokenStream {
+    if bindings.is_empty() {
+        return quote! { &[] };
+    }
+    let entries = bindings.iter().map(|(action, resource)| {
+        let action = LitStr::new(action, Span::call_site());
+        let resource = LitStr::new(resource, Span::call_site());
+        quote! {
+            ::autumn_web::openapi::AuthorizeBinding { action: #action, resource: #resource }
+        }
+    });
+    quote! { &[#(#entries),*] }
+}
+
 fn emit_static_str_slice(items: &[String]) -> TokenStream {
     if items.is_empty() {
         quote! { &[] }
@@ -1100,5 +1254,113 @@ mod tests {
             async fn handler() {}
         };
         assert!(!is_public(&input_fn));
+    }
+
+    // ── #[authorize] binding extraction (#1627) ──────────────────────────────
+
+    #[test]
+    fn extract_authorize_bindings_from_attribute() {
+        let input_fn: syn::ItemFn = syn::parse_quote! {
+            #[authorize("update", resource = Note)]
+            async fn handler(note: Note) {}
+        };
+        assert_eq!(
+            extract_authorize_bindings(&input_fn),
+            vec![("update".to_owned(), "Note".to_owned())]
+        );
+    }
+
+    #[test]
+    fn extract_authorize_bindings_from_marker() {
+        let input_fn: syn::ItemFn = syn::parse_quote! {
+            async fn handler() {
+                const __AUTUMN_AUTHORIZE_BINDINGS: &[(&str, &str)] = &[("update", "Note")];
+            }
+        };
+        assert_eq!(
+            extract_authorize_bindings(&input_fn),
+            vec![("update".to_owned(), "Note".to_owned())]
+        );
+    }
+
+    #[test]
+    fn extract_authorize_bindings_from_nested_marker() {
+        // A guard that expanded after `#[authorize]` wraps the marker in
+        // `(async move { … }).await`, one level per stacked guard.
+        let input_fn: syn::ItemFn = syn::parse_quote! {
+            async fn handler() -> ::autumn_web::reexports::axum::response::Response {
+                let __autumn_inner: ::autumn_web::reexports::axum::response::Response =
+                    (async move {
+                        const __AUTUMN_AUTHORIZE_BINDINGS: &[(&str, &str)] = &[("update", "Note")];
+                    })
+                    .await;
+                ::autumn_web::reexports::axum::response::IntoResponse::into_response(__autumn_inner)
+            }
+        };
+        assert_eq!(
+            extract_authorize_bindings(&input_fn),
+            vec![("update".to_owned(), "Note".to_owned())]
+        );
+    }
+
+    #[test]
+    fn extract_authorize_bindings_is_empty_without_authorize() {
+        let input_fn: syn::ItemFn = syn::parse_quote! {
+            async fn handler() {}
+        };
+        assert_eq!(
+            extract_authorize_bindings(&input_fn),
+            Vec::<(String, String)>::new()
+        );
+    }
+
+    #[test]
+    fn extract_authorize_bindings_handles_string_literal_resource() {
+        // `resource = "Note"` is accepted by the #[authorize] grammar and
+        // normalized back to an identifier; reading the attribute through that
+        // same parser keeps both spellings recording the same binding.
+        let input_fn: syn::ItemFn = syn::parse_quote! {
+            #[authorize("update", resource = "Note")]
+            async fn handler(note: Note) {}
+        };
+        assert_eq!(
+            extract_authorize_bindings(&input_fn),
+            vec![("update".to_owned(), "Note".to_owned())]
+        );
+    }
+
+    #[test]
+    fn extract_authorize_bindings_unions_attr_and_marker() {
+        // A mixed stack (`#[authorize(A)]` above the route macro, `#[authorize(B)]`
+        // below it) leaves one marker and one attribute — both are real bindings,
+        // so neither case may short-circuit the other.
+        let input_fn: syn::ItemFn = syn::parse_quote! {
+            #[authorize("publish", resource = Note)]
+            async fn handler(note: Note) {
+                const __AUTUMN_AUTHORIZE_BINDINGS: &[(&str, &str)] = &[("update", "Note")];
+            }
+        };
+        assert_eq!(
+            extract_authorize_bindings(&input_fn),
+            vec![
+                ("publish".to_owned(), "Note".to_owned()),
+                ("update".to_owned(), "Note".to_owned()),
+            ]
+        );
+    }
+
+    #[test]
+    fn extract_authorize_bindings_ignores_malformed_marker() {
+        // A same-named const of a foreign shape is not ours to interpret: it
+        // contributes nothing rather than panicking on the unexpected AST.
+        let input_fn: syn::ItemFn = syn::parse_quote! {
+            async fn handler() {
+                const __AUTUMN_AUTHORIZE_BINDINGS: &[(&str, u32)] = &[("update", 1)];
+            }
+        };
+        assert_eq!(
+            extract_authorize_bindings(&input_fn),
+            Vec::<(String, String)>::new()
+        );
     }
 }

--- a/autumn-macros/src/api_doc.rs
+++ b/autumn-macros/src/api_doc.rs
@@ -625,7 +625,25 @@ pub fn extract_secured_info(input_fn: &syn::ItemFn) -> (bool, TokenStream, Token
         }
     }
 
-    // Case 1b — #[authorize] or #[autumn_web::authorize] visible as a remaining attribute.
+    // Case 2 — #[secured] was above the route macro and already expanded;
+    // read the markers emitted into the guarded function body. This runs
+    // BEFORE the live-#[authorize] fallback below: `#[secured]` above the
+    // route macro with `#[authorize]` below it leaves both an expanded marker
+    // and a live attribute, and letting the attribute win would drop the
+    // roles/scopes to `&[]` while `secured` stayed true — deleting the
+    // `#[secured(...)]` line would then produce zero manifest diff on a
+    // `provable` dimension.
+    if let Some(roles) = extract_secured_roles_marker(input_fn) {
+        let scopes = extract_secured_scopes_marker(input_fn).unwrap_or_default();
+        return (
+            true,
+            emit_static_str_slice(&roles),
+            emit_static_str_slice(&scopes),
+        );
+    }
+
+    // Case 1b — #[authorize] or #[autumn_web::authorize] visible as a remaining
+    // attribute (and no secured markers anywhere in the body).
     for attr in &input_fn.attrs {
         if attr.path().is_ident("authorize")
             || attr
@@ -636,17 +654,6 @@ pub fn extract_secured_info(input_fn: &syn::ItemFn) -> (bool, TokenStream, Token
         {
             return (true, quote! { &[] }, quote! { &[] });
         }
-    }
-
-    // Case 2 — #[secured] was above the route macro and already expanded;
-    // read the markers emitted into the guarded function body.
-    if let Some(roles) = extract_secured_roles_marker(input_fn) {
-        let scopes = extract_secured_scopes_marker(input_fn).unwrap_or_default();
-        return (
-            true,
-            emit_static_str_slice(&roles),
-            emit_static_str_slice(&scopes),
-        );
     }
 
     // Case 2b — #[authorize] was above the route macro and already expanded;
@@ -714,9 +721,13 @@ fn has_public_marker_in_stmt(stmt: &syn::Stmt) -> bool {
 fn has_public_marker_in_expr(expr: &syn::Expr) -> bool {
     match expr {
         syn::Expr::Block(block) => has_public_marker_in_stmts(&block.block.stmts),
-        syn::Expr::Async(block) => has_public_marker_in_stmts(&block.block.stmts),
         syn::Expr::Unsafe(block) => has_public_marker_in_stmts(&block.block.stmts),
-        _ => false,
+        // Same generated-wrapper descent as the secured/authorize marker walks:
+        // a body guard expanding after `#[public]` (e.g. `#[throttle]`) buries
+        // the marker inside `(async move { … }).await`, and losing it here
+        // flips the route to `unclassified` and false-fails the coverage gate.
+        _ => crate::idempotency_guard::expr_nested_async_body(expr)
+            .is_some_and(|block| has_public_marker_in_stmts(&block.stmts)),
     }
 }
 
@@ -1388,6 +1399,52 @@ mod tests {
                 ("first".to_owned(), "Note".to_owned()),
                 ("second".to_owned(), "Note".to_owned()),
             ]
+        );
+    }
+
+    #[test]
+    fn secured_markers_survive_live_authorize_attribute() {
+        // `#[secured]` ABOVE the route macro (already expanded into markers)
+        // with `#[authorize]` BELOW it (still a live attribute): the marker
+        // read must win over the authorize-attribute fallback, or the roles
+        // and scopes silently drop to `&[]` while `secured` stays true.
+        let input_fn: syn::ItemFn = syn::parse_quote! {
+            #[authorize("update", resource = Note)]
+            async fn handler(note: Note) {
+                const __AUTUMN_SECURED_ROLES: &[&str] = &["admin"];
+                const __AUTUMN_SECURED_SCOPES: &[&str] = &["notes:write"];
+            }
+        };
+        let (secured, roles, scopes) = extract_secured_info(&input_fn);
+        assert!(secured);
+        assert!(
+            roles.to_string().contains("\"admin\""),
+            "roles from an expanded #[secured] must survive a live #[authorize] attribute: {roles}"
+        );
+        assert!(
+            scopes.to_string().contains("\"notes:write\""),
+            "scopes must survive alongside the roles: {scopes}"
+        );
+    }
+
+    #[test]
+    fn public_marker_survives_generated_wrapper() {
+        // `#[public]` above a wrapping guard (e.g. `#[throttle]`): the guard
+        // buries the `__AUTUMN_PUBLIC` marker inside its generated
+        // `(async move { … }).await` body. The walk must descend that wrapper,
+        // or the route silently loses `public: true` and false-fails the
+        // coverage gate as `unclassified`.
+        let public = crate::public::public_macro(
+            quote::quote! {},
+            quote::quote! { async fn h() -> &'static str { "ok" } },
+        );
+        let throttled =
+            crate::throttle::throttle_macro(quote::quote! { limit = 5, per = "1m" }, public);
+        let parsed: syn::ItemFn =
+            syn::parse2(throttled).expect("#[throttle] over #[public] output must parse");
+        assert!(
+            is_public(&parsed),
+            "the public marker must survive a #[throttle] wrapper"
         );
     }
 

--- a/autumn-macros/src/api_doc.rs
+++ b/autumn-macros/src/api_doc.rs
@@ -889,15 +889,21 @@ const AUTHORIZE_BINDINGS_MARKER: &str = "__AUTUMN_AUTHORIZE_BINDINGS";
 /// one already-expanded marker *and* one live attribute, and both are real
 /// bindings.
 ///
-/// 1. Attributes still present — the route macro is outermost, so `#[authorize]`
+/// 1. Marker consts in the body — `#[authorize]` expanded first and deleted its
+///    own attribute. The walk descends the generated `(async move { … }).await`
+///    wrappers, because each guard that expands afterwards buries the marker one
+///    level deeper, and collects every level instead of stopping at the first.
+/// 2. Attributes still present — the route macro is outermost, so `#[authorize]`
 ///    has not expanded yet. Parsed with the `#[authorize]` grammar itself
 ///    ([`crate::authorize::parse_with_leading_literal`]) so the two sites cannot
 ///    drift apart. Every matching attribute contributes, since nothing stops a
 ///    handler from stacking several.
-/// 2. Marker consts in the body — `#[authorize]` expanded first and deleted its
-///    own attribute. The walk descends the generated `(async move { … }).await`
-///    wrappers, because each guard that expands afterwards buries the marker one
-///    level deeper, and collects every level instead of stopping at the first.
+///
+/// The result is source-ordered. Markers precede live attributes because a
+/// marker only ever comes from an attribute *above* the route macro, and live
+/// attributes sit *below* it; within the markers, deeper nesting means an
+/// earlier expansion — i.e. higher in the source stack — so the walk records
+/// nested markers before the level that wraps them.
 ///
 /// Markers are decoded structurally (`&[( "action", "Resource" ), …]`), never by
 /// scanning stringified tokens, so handler *text* that merely spells the marker
@@ -905,6 +911,8 @@ const AUTHORIZE_BINDINGS_MARKER: &str = "__AUTUMN_AUTHORIZE_BINDINGS";
 /// interpret and contributes nothing rather than erroring.
 pub fn extract_authorize_bindings(input_fn: &syn::ItemFn) -> Vec<(String, String)> {
     let mut bindings = Vec::new();
+
+    collect_authorize_markers_in_stmts(&input_fn.block.stmts, &mut bindings);
 
     for attr in &input_fn.attrs {
         if attr.path().is_ident("authorize")
@@ -918,7 +926,6 @@ pub fn extract_authorize_bindings(input_fn: &syn::ItemFn) -> Vec<(String, String
         }
     }
 
-    collect_authorize_markers_in_stmts(&input_fn.block.stmts, &mut bindings);
     bindings
 }
 
@@ -937,25 +944,26 @@ fn authorize_binding_from_attr(attr: &syn::Attribute) -> Option<(String, String)
 }
 
 fn collect_authorize_markers_in_stmts(stmts: &[syn::Stmt], out: &mut Vec<(String, String)>) {
+    // Nested wrappers first: a deeper marker was expanded earlier, i.e. its
+    // attribute sat higher in the source stack, so it must be recorded before
+    // this level's own marker for the result to stay source-ordered.
     for stmt in stmts {
-        collect_authorize_markers_in_stmt(stmt, out);
+        match stmt {
+            syn::Stmt::Expr(expr, _) => collect_authorize_markers_in_expr(expr, out),
+            syn::Stmt::Local(local) => {
+                if let Some(init) = &local.init {
+                    collect_authorize_markers_in_expr(&init.expr, out);
+                }
+            }
+            _ => {}
+        }
     }
-}
-
-fn collect_authorize_markers_in_stmt(stmt: &syn::Stmt, out: &mut Vec<(String, String)>) {
-    match stmt {
-        syn::Stmt::Item(syn::Item::Const(item_const))
-            if item_const.ident == AUTHORIZE_BINDINGS_MARKER =>
+    for stmt in stmts {
+        if let syn::Stmt::Item(syn::Item::Const(item_const)) = stmt
+            && item_const.ident == AUTHORIZE_BINDINGS_MARKER
         {
             collect_authorize_bindings_from_marker_expr(&item_const.expr, out);
         }
-        syn::Stmt::Expr(expr, _) => collect_authorize_markers_in_expr(expr, out),
-        syn::Stmt::Local(local) => {
-            if let Some(init) = &local.init {
-                collect_authorize_markers_in_expr(&init.expr, out);
-            }
-        }
-        _ => {}
     }
 }
 
@@ -1333,7 +1341,8 @@ mod tests {
     fn extract_authorize_bindings_unions_attr_and_marker() {
         // A mixed stack (`#[authorize(A)]` above the route macro, `#[authorize(B)]`
         // below it) leaves one marker and one attribute — both are real bindings,
-        // so neither case may short-circuit the other.
+        // so neither case may short-circuit the other. The marker comes from the
+        // attribute *above* the route macro, so source order puts it first.
         let input_fn: syn::ItemFn = syn::parse_quote! {
             #[authorize("publish", resource = Note)]
             async fn handler(note: Note) {
@@ -1343,8 +1352,35 @@ mod tests {
         assert_eq!(
             extract_authorize_bindings(&input_fn),
             vec![
-                ("publish".to_owned(), "Note".to_owned()),
                 ("update".to_owned(), "Note".to_owned()),
+                ("publish".to_owned(), "Note".to_owned()),
+            ]
+        );
+    }
+
+    #[test]
+    fn extract_authorize_bindings_orders_stacked_markers_by_source() {
+        // Two `#[authorize]`s above the route macro expand top-down: the first
+        // (higher in source) is wrapped by the second, so its marker sits one
+        // wrapper level *deeper*. Source order is therefore deepest-first, and
+        // the walk must record nested markers before the level that wraps them.
+        let input_fn: syn::ItemFn = syn::parse_quote! {
+            async fn handler() -> ::autumn_web::reexports::axum::response::Response {
+                const __AUTUMN_AUTHORIZE_BINDINGS: &[(&str, &str)] = &[("second", "Note")];
+                let __autumn_inner: ::autumn_web::reexports::axum::response::Response =
+                    (async move {
+                        const __AUTUMN_AUTHORIZE_BINDINGS: &[(&str, &str)] =
+                            &[("first", "Note")];
+                    })
+                    .await;
+                ::autumn_web::reexports::axum::response::IntoResponse::into_response(__autumn_inner)
+            }
+        };
+        assert_eq!(
+            extract_authorize_bindings(&input_fn),
+            vec![
+                ("first".to_owned(), "Note".to_owned()),
+                ("second".to_owned(), "Note".to_owned()),
             ]
         );
     }

--- a/autumn-macros/src/api_doc.rs
+++ b/autumn-macros/src/api_doc.rs
@@ -749,9 +749,13 @@ fn extract_secured_roles_marker_from_stmt(stmt: &syn::Stmt) -> Option<Vec<String
 fn extract_secured_roles_marker_from_expr(expr: &syn::Expr) -> Option<Vec<String>> {
     match expr {
         syn::Expr::Block(block) => extract_secured_roles_marker_from_stmts(&block.block.stmts),
-        syn::Expr::Async(block) => extract_secured_roles_marker_from_stmts(&block.block.stmts),
         syn::Expr::Unsafe(block) => extract_secured_roles_marker_from_stmts(&block.block.stmts),
-        _ => None,
+        // A guard that expands after `#[secured]` (e.g. `#[authorize]`) buries
+        // the marker inside `let __autumn_inner: T = (async move { … }).await;`
+        // — descend that generated wrapper or the roles silently vanish from
+        // the route metadata while `secured` stays `true` via the fallbacks.
+        _ => crate::idempotency_guard::expr_nested_async_body(expr)
+            .and_then(|block| extract_secured_roles_marker_from_stmts(&block.stmts)),
     }
 }
 
@@ -870,9 +874,11 @@ fn extract_secured_scopes_marker_from_stmt(stmt: &syn::Stmt) -> Option<Vec<Strin
 fn extract_secured_scopes_marker_from_expr(expr: &syn::Expr) -> Option<Vec<String>> {
     match expr {
         syn::Expr::Block(block) => extract_secured_scopes_marker_from_stmts(&block.block.stmts),
-        syn::Expr::Async(block) => extract_secured_scopes_marker_from_stmts(&block.block.stmts),
         syn::Expr::Unsafe(block) => extract_secured_scopes_marker_from_stmts(&block.block.stmts),
-        _ => None,
+        // Same generated-wrapper descent as the roles walk above: the scopes
+        // marker sits wherever the roles marker sits.
+        _ => crate::idempotency_guard::expr_nested_async_body(expr)
+            .and_then(|block| extract_secured_scopes_marker_from_stmts(&block.stmts)),
     }
 }
 
@@ -1382,6 +1388,36 @@ mod tests {
                 ("first".to_owned(), "Note".to_owned()),
                 ("second".to_owned(), "Note".to_owned()),
             ]
+        );
+    }
+
+    #[test]
+    fn secured_roles_survive_authorize_wrapper() {
+        // `#[secured]`'s role markers end up under the
+        // `let __autumn_inner: T = (async move { … }).await;` wrapper when a
+        // guard expands after it. The roles walk must descend that shape, like
+        // the authorize-binding walk does, or the roles silently vanish.
+        let input_fn: syn::ItemFn = syn::parse_quote! {
+            async fn handler() -> ::autumn_web::reexports::axum::response::Response {
+                const __AUTUMN_AUTHORIZE_BINDINGS: &[(&str, &str)] = &[("update", "Note")];
+                let __autumn_inner: ::autumn_web::reexports::axum::response::Response =
+                    (async move {
+                        const __AUTUMN_SECURED_ROLES: &[&str] = &["admin"];
+                        const __AUTUMN_SECURED_SCOPES: &[&str] = &["notes:write"];
+                    })
+                    .await;
+                ::autumn_web::reexports::axum::response::IntoResponse::into_response(__autumn_inner)
+            }
+        };
+        let (secured, roles, scopes) = extract_secured_info(&input_fn);
+        assert!(secured);
+        assert!(
+            roles.to_string().contains("\"admin\""),
+            "roles buried under a generated wrapper must be recovered: {roles}"
+        );
+        assert!(
+            scopes.to_string().contains("\"notes:write\""),
+            "scopes buried under a generated wrapper must be recovered: {scopes}"
         );
     }
 

--- a/autumn-macros/src/authorize.rs
+++ b/autumn-macros/src/authorize.rs
@@ -20,10 +20,16 @@ use quote::{format_ident, quote};
 use syn::parse::Parser as _;
 use syn::{Expr, ExprLit, Ident, ItemFn, Lit, LitStr, Meta, Token, parse_quote};
 
+/// Parsed `#[authorize(...)]` arguments.
+///
+/// Visible to the crate so the route macro's metadata extractor
+/// (`api_doc::extract_authorize_bindings`) reads an attribute that has not
+/// expanded yet through this same grammar, keeping one source of truth for the
+/// syntax.
 #[derive(Default)]
-struct AuthorizeArgs {
-    action: Option<String>,
-    resource: Option<Ident>,
+pub struct AuthorizeArgs {
+    pub action: Option<String>,
+    pub resource: Option<Ident>,
     from: Option<Ident>,
 }
 
@@ -242,6 +248,8 @@ pub fn authorize_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
     }
 
     let action_lit = syn::LitStr::new(&action_str, proc_macro2::Span::call_site());
+    let resource_lit =
+        syn::LitStr::new(&resource_ident.to_string(), proc_macro2::Span::call_site());
     let original_body = &input_fn.block;
     let original_response = match &input_fn.sig.output {
         syn::ReturnType::Default => quote! {
@@ -279,6 +287,12 @@ pub fn authorize_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
     };
     input_fn.block = parse_quote! {
         {
+            // Route macros read this marker when #[authorize] expands before
+            // #[get]/#[post]/etc. It records the resource *identifier as
+            // written*, not the `Policy` impl that serves the check — that is
+            // resolved from the registry at boot and has no compile-time name.
+            // Inert: nothing reads it at runtime.
+            const __AUTUMN_AUTHORIZE_BINDINGS: &[(&str, &str)] = &[(#action_lit, #resource_lit)];
             if let ::core::result::Result::Err(__autumn_error) = ::autumn_web::authorization::__check_policy_scoped::<#resource_ident>(
                 &__autumn_state,
                 &__autumn_session,
@@ -318,7 +332,7 @@ pub fn authorize_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
 /// string literal as the action: `#[authorize("update", resource = Foo)]`.
 /// Standard `Meta` parsing rejects bare literals as the first item,
 /// so we strip and re-thread it before the punctuated parse.
-fn parse_with_leading_literal(attr: TokenStream) -> syn::Result<AuthorizeArgs> {
+pub fn parse_with_leading_literal(attr: TokenStream) -> syn::Result<AuthorizeArgs> {
     use proc_macro2::TokenTree;
     let mut iter = attr.into_iter().peekable();
     let mut leading_action: Option<String> = None;
@@ -446,6 +460,52 @@ mod tests {
         assert!(
             !generated.contains("__check_policy (") && !generated.contains("__check_policy("),
             "#[authorize] must not generate the old unscoped __check_policy call: {generated}"
+        );
+    }
+
+    #[test]
+    fn authorize_emits_binding_marker_const() {
+        let generated = authorize_macro(
+            quote::quote! { "update", resource = Post },
+            quote::quote! {
+                async fn update_post(post: Post) -> &'static str {
+                    "ok"
+                }
+            },
+        )
+        .to_string();
+
+        assert!(
+            generated.contains(
+                r#"const __AUTUMN_AUTHORIZE_BINDINGS : & [(& str , & str)] = & [("update" , "Post")] ;"#
+            ),
+            "#[authorize] must leave a binding marker the route macro can read back when it \
+             expands first: {generated}"
+        );
+    }
+
+    #[test]
+    fn authorize_marker_precedes_policy_check() {
+        let generated = authorize_macro(
+            quote::quote! { "update", resource = Post },
+            quote::quote! {
+                async fn update_post(post: Post) -> &'static str {
+                    "ok"
+                }
+            },
+        )
+        .to_string();
+
+        let marker = generated
+            .find("__AUTUMN_AUTHORIZE_BINDINGS")
+            .unwrap_or_else(|| panic!("binding marker must be emitted: {generated}"));
+        let check = generated
+            .find("__check_policy_scoped")
+            .unwrap_or_else(|| panic!("policy check must be emitted: {generated}"));
+        assert!(
+            marker < check,
+            "the binding marker must be the first statement of the guarded body, so extractors \
+             find it before any generated control flow: {generated}"
         );
     }
 }

--- a/autumn-macros/src/idempotency_guard.rs
+++ b/autumn-macros/src/idempotency_guard.rs
@@ -956,6 +956,16 @@ mod tests {
         // stops the walk, so the replay guard behind it would look absent and
         // the enclosing guard would emit a second one ahead of the policy
         // check — serving a cached response before authorization runs.
+        //
+        // Scope of this test: it pins the SKIP-LIST behavior on the
+        // marker-plus-policy-check prologue prefix, via a reduced hand-written
+        // block. It deliberately does NOT run the walk over full real
+        // `#[authorize]` output: the walk already fails there on the
+        // unrecognized sunset-check statement the guard emits between the
+        // policy check and the replay stop — a pre-existing gap that predates
+        // the marker (and equally affects `#[secured]`'s UNAUTHORIZED-wrapped
+        // failure branch), tracked as its own follow-up because recognizing
+        // those statements changes replay-layer composition at runtime.
         let generated = crate::authorize::authorize_macro(
             quote::quote! { "update", resource = Post },
             quote::quote! {
@@ -970,7 +980,8 @@ mod tests {
                 Some(syn::Stmt::Item(syn::Item::Const(item)))
                     if item.ident == "__AUTUMN_AUTHORIZE_BINDINGS"
             ),
-            "this test's hand-written prologue must keep matching what #[authorize] emits"
+            "the reduced block's FIRST statement must keep matching what #[authorize] emits \
+             (the rest of the real expansion is deliberately not walked here — see above)"
         );
 
         let block: syn::Block = syn::parse_quote!({

--- a/autumn-macros/src/idempotency_guard.rs
+++ b/autumn-macros/src/idempotency_guard.rs
@@ -49,10 +49,17 @@ fn stmt_is_generated_replay_guard(stmt: &Stmt) -> bool {
 }
 
 fn stmt_is_generated_auth_prologue(stmt: &Stmt) -> bool {
+    // Marker consts the auth guards prepend ahead of their check. They carry no
+    // behaviour, so the scan must step over them: a prologue statement that is
+    // not recognized stops the walk, the replay guard behind it reads as absent,
+    // and an enclosing guard emits a second one *ahead* of the auth check —
+    // serving a cached response before authentication/authorization runs.
     if matches!(
         stmt,
         Stmt::Item(Item::Const(item))
-            if item.ident == "__AUTUMN_SECURED_ROLES" || item.ident == "__AUTUMN_SECURED_SCOPES"
+            if item.ident == "__AUTUMN_SECURED_ROLES"
+                || item.ident == "__AUTUMN_SECURED_SCOPES"
+                || item.ident == "__AUTUMN_AUTHORIZE_BINDINGS"
     ) {
         return true;
     }
@@ -459,7 +466,15 @@ fn pat_binds_inner_response(pat: &Pat) -> bool {
     }
 }
 
-fn expr_nested_async_body(expr: &Expr) -> Option<&Block> {
+/// Unwrap the `(async move { … }).await` wrapper the body guards (`#[secured]`,
+/// `#[authorize]`, `#[throttle]`, …) put a handler's original body inside —
+/// including the `IntoResponse::into_response(…)` call, parens, and invisible
+/// groups they may sit behind — and yield the inner block.
+///
+/// Shared with `api_doc`'s marker walks: each guard that expands *before*
+/// another buries the earlier guard's marker consts one wrapper level deeper,
+/// so a walk that does not descend through this shape silently loses them.
+pub fn expr_nested_async_body(expr: &Expr) -> Option<&Block> {
     match expr {
         Expr::Async(expr_async) => Some(&expr_async.block),
         Expr::Await(await_expr) => expr_nested_async_body(&await_expr.base),
@@ -928,6 +943,58 @@ mod tests {
             })
             .await;
             ::autumn_web::reexports::axum::response::IntoResponse::into_response(__autumn_inner)
+        });
+
+        assert!(block_has_replay_guard(&block));
+    }
+
+    #[test]
+    fn generated_authorize_bindings_marker_does_not_hide_replay_guard() {
+        // `#[authorize]` prepends a binding marker const ahead of its policy
+        // check (#1627). Like the `#[secured]` role/scope markers, it must be
+        // transparent to this scan: a prologue statement that is not skipped
+        // stops the walk, so the replay guard behind it would look absent and
+        // the enclosing guard would emit a second one ahead of the policy
+        // check — serving a cached response before authorization runs.
+        let generated = crate::authorize::authorize_macro(
+            quote::quote! { "update", resource = Post },
+            quote::quote! {
+                async fn update_post(post: Post) -> &'static str { "ok" }
+            },
+        );
+        let generated_fn: syn::ItemFn =
+            syn::parse2(generated).expect("#[authorize] must emit a parseable function");
+        assert!(
+            matches!(
+                generated_fn.block.stmts.first(),
+                Some(syn::Stmt::Item(syn::Item::Const(item)))
+                    if item.ident == "__AUTUMN_AUTHORIZE_BINDINGS"
+            ),
+            "this test's hand-written prologue must keep matching what #[authorize] emits"
+        );
+
+        let block: syn::Block = syn::parse_quote!({
+            const __AUTUMN_AUTHORIZE_BINDINGS: &[(&str, &str)] = &[("update", "Post")];
+            if let ::core::result::Result::Err(__autumn_error) =
+                ::autumn_web::authorization::__check_policy_scoped::<Post>(
+                    &__autumn_state,
+                    &__autumn_session,
+                    __autumn_token_scopes.as_ref().map(|__e| &__e.0),
+                    "update",
+                    &post,
+                )
+                .await
+            {
+                return ::autumn_web::reexports::axum::response::IntoResponse::into_response(
+                    __autumn_error,
+                );
+            }
+            const __AUTUMN_IDEMPOTENCY_REPLAY_GUARD: () = ();
+            if let ::core::option::Option::Some(__autumn_response) =
+                ::autumn_web::idempotency::__replay_response(&__autumn_idempotency_replay)
+            {
+                return __autumn_response;
+            }
         });
 
         assert!(block_has_replay_guard(&block));

--- a/autumn-macros/src/route.rs
+++ b/autumn-macros/src/route.rs
@@ -1163,6 +1163,38 @@ mod tests {
     }
 
     #[test]
+    fn route_macro_orders_marker_binding_before_live_attribute() {
+        // Mixed arrangement: `#[authorize(A)]` ABOVE `#[post]` (already
+        // expanded into a marker by the time the route macro runs) and
+        // `#[authorize(B)]` BELOW it (still a live attribute). A is higher in
+        // the source than B, so the recorded order must be [A, B] — the marker
+        // before the attribute, not the collection-mechanism order.
+        let authorized = crate::authorize::authorize_macro(
+            quote! { "update", resource = Note },
+            quote! {
+                async fn update_note(note: Note) -> &'static str { "ok" }
+            },
+        );
+        let mixed = quote! {
+            #[authorize("publish", resource = Note)]
+            #authorized
+        };
+        let generated = route_macro("POST", "post", quote! { "/notes/{id}" }, mixed).to_string();
+
+        let update = generated
+            .find(r#"AuthorizeBinding { action : "update" , resource : "Note" }"#)
+            .unwrap_or_else(|| panic!("the marker binding must be recorded: {generated}"));
+        let publish = generated
+            .find(r#"AuthorizeBinding { action : "publish" , resource : "Note" }"#)
+            .unwrap_or_else(|| panic!("the live-attribute binding must be recorded: {generated}"));
+        assert!(
+            update < publish,
+            "the marker comes from the attribute above the route macro, so it precedes the \
+             live attribute below it in source order: {generated}"
+        );
+    }
+
+    #[test]
     fn route_macro_string_literal_authorize_marker_is_not_a_binding() {
         // Handler *text* that merely spells the marker const must not be
         // mistaken for one: the marker is decoded structurally, never scanned

--- a/autumn-macros/src/route.rs
+++ b/autumn-macros/src/route.rs
@@ -1163,6 +1163,36 @@ mod tests {
     }
 
     #[test]
+    fn route_macro_preserves_secured_roles_when_authorize_wraps_them() {
+        // `#[secured("admin")]` above `#[authorize]` above `#[post]`: secured
+        // expands first and leaves its role marker in the body; authorize then
+        // wraps that body in `let __autumn_inner: T = (async move { … }).await;`.
+        // The roles walk must descend that generated wrapper — otherwise the
+        // route silently reports `required_roles: &[]` and a `provable` manifest
+        // dimension under-states the posture.
+        let secured = crate::secured::secured_macro(
+            quote! { "admin" },
+            quote! {
+                async fn update_note(note: Note) -> &'static str { "ok" }
+            },
+        );
+        let authorized =
+            crate::authorize::authorize_macro(quote! { "update", resource = Note }, secured);
+        let generated =
+            route_macro("POST", "post", quote! { "/notes/{id}" }, authorized).to_string();
+
+        assert!(
+            generated.contains(r#"required_roles : & ["admin"]"#),
+            "roles from a #[secured] buried under an #[authorize] wrapper must survive: \
+             {generated}"
+        );
+        assert!(
+            generated.contains(r#"AuthorizeBinding { action : "update" , resource : "Note" }"#),
+            "…and the authorize binding must be recorded alongside them: {generated}"
+        );
+    }
+
+    #[test]
     fn route_macro_orders_marker_binding_before_live_attribute() {
         // Mixed arrangement: `#[authorize(A)]` ABOVE `#[post]` (already
         // expanded into a marker by the time the route macro runs) and

--- a/autumn-macros/src/route.rs
+++ b/autumn-macros/src/route.rs
@@ -1193,6 +1193,39 @@ mod tests {
     }
 
     #[test]
+    fn route_macro_preserves_secured_roles_when_authorize_is_still_an_attribute() {
+        // The remaining ordering of {secured, route, authorize}: `#[secured]`
+        // ABOVE `#[post]` (already expanded into markers) with `#[authorize]`
+        // BELOW it (still a live attribute). The marker read must not be
+        // short-circuited by the live-authorize fallback — both idioms are the
+        // documented house style, and losing the roles here means deleting the
+        // `#[secured(...)]` line produces zero manifest diff on a `provable`
+        // dimension.
+        let secured = crate::secured::secured_macro(
+            quote! { "admin", scopes = ["notes:write"] },
+            quote! {
+                #[authorize("update", resource = Note)]
+                async fn update_note(note: Note) -> &'static str { "ok" }
+            },
+        );
+        let generated = route_macro("POST", "post", quote! { "/notes/{id}" }, secured).to_string();
+
+        assert!(
+            generated.contains(r#"required_roles : & ["admin"]"#),
+            "roles from an expanded #[secured] must survive a live #[authorize] attribute: \
+             {generated}"
+        );
+        assert!(
+            generated.contains(r#"required_scopes : & ["notes:write"]"#),
+            "scopes must survive alongside the roles: {generated}"
+        );
+        assert!(
+            generated.contains(r#"AuthorizeBinding { action : "update" , resource : "Note" }"#),
+            "…and the authorize binding must be recorded alongside them: {generated}"
+        );
+    }
+
+    #[test]
     fn route_macro_orders_marker_binding_before_live_attribute() {
         // Mixed arrangement: `#[authorize(A)]` ABOVE `#[post]` (already
         // expanded into a marker by the time the route macro runs) and

--- a/autumn-macros/src/route.rs
+++ b/autumn-macros/src/route.rs
@@ -189,6 +189,11 @@ pub fn route_macro(
         }
     };
     let has_policy_val = has_policy_only(&input_fn);
+    // Source order is preserved here on purpose: `ApiDoc` stays faithful to the
+    // handler as written, and the route listing canonicalizes (sorts/dedupes)
+    // when it projects these onto the wire.
+    let authorize_bindings =
+        api_doc::emit_authorize_binding_slice(&api_doc::extract_authorize_bindings(&input_fn));
     let seo_defaults = route_args.seo.emit();
 
     // ── Path helper ─────────────────────────────────────────────
@@ -224,6 +229,7 @@ pub fn route_macro(
                     api_version: #api_version_expr,
                     sunset_opt_out: #sunset_opt_out_val,
                     has_policy: #has_policy_val,
+                    authorize_bindings: #authorize_bindings,
                     public: #is_public,
                     module_path: ::core::module_path!(),
                     source_file: ::core::file!(),
@@ -1039,6 +1045,144 @@ mod tests {
         assert!(
             generated.contains("RouteTimeout :: Disabled"),
             "timeout = \"off\" must emit RouteTimeout::Disabled: {generated}"
+        );
+    }
+
+    // ── #[authorize] bindings recorded in ApiDoc (#1627) ────────────────────
+
+    #[test]
+    fn route_macro_emits_empty_authorize_bindings_by_default() {
+        let generated = route_macro(
+            "POST",
+            "post",
+            quote! { "/widgets" },
+            quote! { async fn create_widget() -> &'static str { "ok" } },
+        )
+        .to_string();
+
+        assert!(
+            generated.contains("authorize_bindings : & []"),
+            "an unguarded route must record no authorization bindings: {generated}"
+        );
+    }
+
+    #[test]
+    fn route_macro_records_authorize_binding_when_attribute_present() {
+        // Ordering A: `#[post]` outermost, `#[authorize]` still an attribute
+        // below it, so the route macro reads the arguments straight off the
+        // unexpanded attribute.
+        let generated = route_macro(
+            "POST",
+            "post",
+            quote! { "/notes/{id}" },
+            quote! {
+                #[authorize("update", resource = Note)]
+                async fn update_note(note: Note) -> &'static str { "ok" }
+            },
+        )
+        .to_string();
+
+        assert!(
+            generated.contains(r#"AuthorizeBinding { action : "update" , resource : "Note" }"#),
+            "an #[authorize] attribute must record its (action, resource) binding: {generated}"
+        );
+    }
+
+    #[test]
+    fn route_macro_records_authorize_binding_from_expanded_marker() {
+        // Ordering B: `#[authorize]` written ABOVE `#[post]`, so it expands
+        // first, removes its own attribute and leaves only the generated body.
+        // The binding must survive in the marker const it injects.
+        let authorized = crate::authorize::authorize_macro(
+            quote! { "update", resource = Note },
+            quote! {
+                async fn update_note(note: Note) -> &'static str { "ok" }
+            },
+        );
+        let generated =
+            route_macro("POST", "post", quote! { "/notes/{id}" }, authorized).to_string();
+
+        assert!(
+            generated.contains(r#"AuthorizeBinding { action : "update" , resource : "Note" }"#),
+            "an already-expanded #[authorize] must still record its binding: {generated}"
+        );
+    }
+
+    #[test]
+    fn route_macro_records_authorize_binding_under_secured_wrapper() {
+        // `#[authorize]` above `#[secured]` above `#[post]`: authorize expands
+        // first, then secured wraps that whole body in
+        // `(async move { … }).await`, burying the marker one level down. The
+        // walk must descend the generated wrapper instead of stopping at the
+        // outermost statement list.
+        let authorized = crate::authorize::authorize_macro(
+            quote! { "update", resource = Note },
+            quote! {
+                async fn update_note(note: Note) -> &'static str { "ok" }
+            },
+        );
+        let secured = crate::secured::secured_macro(quote! { "admin" }, authorized);
+        let generated = route_macro("POST", "post", quote! { "/notes/{id}" }, secured).to_string();
+
+        assert!(
+            generated.contains(r#"AuthorizeBinding { action : "update" , resource : "Note" }"#),
+            "a binding nested inside a #[secured] wrapper must not be lost: {generated}"
+        );
+    }
+
+    #[test]
+    fn route_macro_records_all_bindings_for_stacked_authorize_attributes() {
+        // Every attribute contributes: the existing `policy` boolean collapses
+        // N bindings into one flag, so the list must not do the same.
+        let generated = route_macro(
+            "POST",
+            "post",
+            quote! { "/notes/{id}" },
+            quote! {
+                #[authorize("update", resource = Note)]
+                #[authorize("publish", resource = Note)]
+                async fn update_note(note: Note) -> &'static str { "ok" }
+            },
+        )
+        .to_string();
+
+        let update = generated
+            .find(r#"AuthorizeBinding { action : "update" , resource : "Note" }"#)
+            .unwrap_or_else(|| {
+                panic!("the first stacked #[authorize] must record a binding: {generated}")
+            });
+        let publish = generated
+            .find(r#"AuthorizeBinding { action : "publish" , resource : "Note" }"#)
+            .unwrap_or_else(|| {
+                panic!("the second stacked #[authorize] must record a binding: {generated}")
+            });
+        assert!(
+            update < publish,
+            "stacked bindings must be recorded in source order: {generated}"
+        );
+    }
+
+    #[test]
+    fn route_macro_string_literal_authorize_marker_is_not_a_binding() {
+        // Handler *text* that merely spells the marker const must not be
+        // mistaken for one: the marker is decoded structurally, never scanned
+        // for as a string.
+        let generated = route_macro(
+            "POST",
+            "post",
+            quote! { "/items" },
+            quote! {
+                async fn create_item() -> &'static str {
+                    let _ = "const __AUTUMN_AUTHORIZE_BINDINGS: &[(&str, &str)] = &[(\"update\", \"Note\")];";
+                    "created"
+                }
+            },
+        )
+        .to_string();
+
+        assert!(
+            generated.contains("authorize_bindings : & []"),
+            "a string literal must not be mistaken for a generated binding marker: {generated}"
         );
     }
 }

--- a/autumn/src/openapi.rs
+++ b/autumn/src/openapi.rs
@@ -128,6 +128,15 @@ pub struct ApiDoc {
     pub sunset_opt_out: bool,
     /// Whether this route uses dynamic policy authorization.
     pub has_policy: bool,
+    /// Record-level authorization bindings declared by `#[authorize]` on the
+    /// handler, in source order — one entry per attribute, empty when the
+    /// handler declares none.
+    ///
+    /// This is the provable subset of [`Self::has_policy`], never a
+    /// replacement for it: that boolean is also `true` for a hand-written
+    /// `__check_policy` call in the body, which carries no binding a macro can
+    /// recover.
+    pub authorize_bindings: &'static [AuthorizeBinding],
     /// True when the handler is explicitly declared public via `#[public]`.
     ///
     /// Populated by the route macros from the `#[public]` marker. Used by the
@@ -164,6 +173,28 @@ pub struct ApiDoc {
     /// schema, this flag also exempts the tool from the JSON-out eligibility
     /// gate that otherwise excludes schema-less routes.
     pub mcp_stream: bool,
+}
+
+/// A record-level authorization binding declared by `#[authorize]`.
+///
+/// One entry per `#[authorize("action", resource = Type)]` attribute on a
+/// handler, recovered from the macro expansion, so a binding disappears from
+/// the metadata exactly when the attribute disappears from the source.
+///
+/// This is deliberately **not** the `Policy` implementation that serves the
+/// check. `#[authorize]` names only the resource `R`; the concrete
+/// `impl Policy<R>` is resolved from the `PolicyRegistry` at boot
+/// (`AppBuilder::policy::<R, _>(...)`) and is therefore not knowable at build
+/// time. [`Self::resource`] is likewise the identifier as written at the use
+/// site rather than a resolved path, so two same-named types in different
+/// modules are indistinguishable here.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct AuthorizeBinding {
+    /// Action verb passed to the policy check — the first `#[authorize]`
+    /// argument, recorded verbatim.
+    pub action: &'static str,
+    /// Resource type identifier exactly as written in `resource = Type`.
+    pub resource: &'static str,
 }
 
 /// Reference to a schema definition, produced by the route macros.

--- a/autumn/src/route_listing.rs
+++ b/autumn/src/route_listing.rs
@@ -252,6 +252,25 @@ impl<'de> Deserialize<'de> for RouteSource {
     }
 }
 
+/// One record-level authorization binding declared by `#[authorize]`.
+///
+/// Wire twin of [`AuthorizeBinding`](crate::openapi::AuthorizeBinding): the
+/// same `("action", resource = Type)` pair in owned form, so it round-trips
+/// through the routes-dump JSON. (The `*Info` suffix follows [`RouteInfo`].)
+///
+/// [`Self::resource`] is the identifier exactly as written at the use site,
+/// not a resolved path, and never the `impl Policy<_>` that serves the check:
+/// that binding is established from the `PolicyRegistry` at boot
+/// (`AppBuilder::policy::<R, _>(...)`) and is not knowable at build time.
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+pub struct AuthorizeBindingInfo {
+    /// Action verb passed to the policy check — the first `#[authorize]`
+    /// argument, recorded verbatim.
+    pub action: String,
+    /// Resource type identifier exactly as written in `resource = Type`.
+    pub resource: String,
+}
+
 /// Metadata for a single mounted route, suitable for display and JSON export.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct RouteInfo {
@@ -298,6 +317,17 @@ pub struct RouteInfo {
     /// `None` for routes without a known location.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub location: Option<String>,
+    /// Record-level authorization bindings proven from the handler's
+    /// `#[authorize]` attributes — one `(action, resource)` entry per binding,
+    /// sorted and deduplicated. Empty for routes that declare none.
+    ///
+    /// This is the provable *subset* of [`Self::policy`], never a replacement
+    /// for it: that boolean is also `true` for a hand-written `__check_policy`
+    /// call in the body and for a `policy = ...` repository auto-API, neither
+    /// of which carries a binding a macro can recover. A route with
+    /// `policy: true` and no bindings is therefore normal, not a defect.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub authorize_bindings: Vec<AuthorizeBindingInfo>,
 }
 
 /// `skip_serializing_if` helper: elide `false` booleans from JSON output.
@@ -410,6 +440,41 @@ fn source_location_of(api_doc: &crate::openapi::ApiDoc) -> Option<String> {
         .then(|| format!("{}:{}", api_doc.source_file, api_doc.source_line))
 }
 
+/// The route's `#[authorize]` bindings, canonicalized for the wire.
+///
+/// Framework routes are pre-classified and carry no handler metadata, so —
+/// like [`classify`], which short-circuits before it reads the `ApiDoc` at all
+/// — they never report a binding.
+///
+/// The list is sorted by `(action, resource)` and then deduplicated. That
+/// diverges deliberately from `roles`/`scopes`, which preserve `#[secured]`
+/// attribute source order: the audit's falsifiability claim over these
+/// bindings is a *set* claim ("removing an `#[authorize]` removes exactly that
+/// binding"), so a stable set serves it better than a stable sequence, and the
+/// manifest diff stays byte-deterministic — the same contract
+/// [`SecurityDump::from_config`] holds every list it emits to. Sorting must run
+/// *first*: [`Vec::dedup`] only collapses adjacent duplicates, so two equal
+/// bindings written apart in the source would otherwise both survive.
+fn authorize_bindings_of(
+    source: &RouteSource,
+    api_doc: &crate::openapi::ApiDoc,
+) -> Vec<AuthorizeBindingInfo> {
+    if matches!(source, RouteSource::Framework) {
+        return Vec::new();
+    }
+    let mut bindings: Vec<AuthorizeBindingInfo> = api_doc
+        .authorize_bindings
+        .iter()
+        .map(|binding| AuthorizeBindingInfo {
+            action: binding.action.to_owned(),
+            resource: binding.resource.to_owned(),
+        })
+        .collect();
+    bindings.sort();
+    bindings.dedup();
+    bindings
+}
+
 /// Helper type alias representing version name, status string, and sunset opt-out flag.
 type RouteVersionInfo = (Option<String>, Option<String>, Option<bool>);
 
@@ -476,6 +541,7 @@ pub fn collect_route_infos(
             resolve_status(route.name, route.api_version, route.sunset_opt_out)?;
         let (classification, roles, scopes, policy) =
             classify(&source, &route.api_doc, route.repository.as_ref());
+        let authorize_bindings = authorize_bindings_of(&source, &route.api_doc);
         infos.push(RouteInfo {
             method: route.method.to_string(),
             path: route.path.to_owned(),
@@ -491,6 +557,7 @@ pub fn collect_route_infos(
             policy,
             module: module_of(&route.api_doc),
             location: source_location_of(&route.api_doc),
+            authorize_bindings,
         });
     }
 
@@ -516,6 +583,7 @@ pub fn collect_route_infos(
                 policy,
                 module: module_of(&route.api_doc),
                 location: source_location_of(&route.api_doc),
+                authorize_bindings: authorize_bindings_of(&group.source, &route.api_doc),
             });
         }
     }
@@ -756,6 +824,14 @@ mod tests {
 
     fn make_route(method: Method, path: &'static str, name: &'static str) -> Route {
         make_route_with(method, path, name, dummy_api_doc())
+    }
+
+    /// Shorthand for an expected wire-side `#[authorize]` binding.
+    fn binding(action: &str, resource: &str) -> AuthorizeBindingInfo {
+        AuthorizeBindingInfo {
+            action: action.to_owned(),
+            resource: resource.to_owned(),
+        }
     }
 
     /// Build a [`RepositoryApiMeta`](crate::route::RepositoryApiMeta) with the
@@ -1120,6 +1196,173 @@ mod tests {
         let route = make_route_with(Method::GET, "/widgets", "list_widgets", api_doc);
         let infos = collect_route_infos(&[route], &[RouteSource::User], &[], &[]).unwrap();
         assert_eq!(infos[0].module.as_deref(), Some("myapp::widgets"));
+    }
+
+    // ── #[authorize] bindings (#1627) ──────────────────────────────────────
+
+    /// The wire list is a *set* of bindings, not a transcript of the source:
+    /// unlike `roles`/`scopes` (which keep `#[secured]` attribute order), it is
+    /// sorted by `(action, resource)` and deduplicated so the manifest diff is
+    /// byte-deterministic and the audit's "removing an `#[authorize]` removes
+    /// exactly that binding" claim is order-independent.
+    #[test]
+    fn authorize_bindings_are_sorted_and_deduped() {
+        let api_doc = crate::openapi::ApiDoc {
+            has_policy: true,
+            authorize_bindings: &[
+                crate::openapi::AuthorizeBinding {
+                    action: "update",
+                    resource: "Note",
+                },
+                crate::openapi::AuthorizeBinding {
+                    action: "delete",
+                    resource: "Note",
+                },
+                crate::openapi::AuthorizeBinding {
+                    action: "update",
+                    resource: "Note",
+                },
+                crate::openapi::AuthorizeBinding {
+                    action: "update",
+                    resource: "Comment",
+                },
+            ],
+            ..dummy_api_doc()
+        };
+
+        let bindings = authorize_bindings_of(&RouteSource::User, &api_doc);
+
+        assert_eq!(
+            bindings,
+            vec![
+                binding("delete", "Note"),
+                binding("update", "Comment"),
+                binding("update", "Note"),
+            ],
+            "bindings must be sorted by (action, resource) and deduplicated"
+        );
+    }
+
+    /// `Vec::dedup` only collapses *adjacent* equal elements, so a helper that
+    /// deduped before sorting would leave the duplicate pair in place. Pin the
+    /// order of the two operations with duplicates that are separated in the
+    /// source.
+    #[test]
+    fn authorize_bindings_dedup_runs_after_sorting() {
+        let api_doc = crate::openapi::ApiDoc {
+            authorize_bindings: &[
+                crate::openapi::AuthorizeBinding {
+                    action: "show",
+                    resource: "Note",
+                },
+                crate::openapi::AuthorizeBinding {
+                    action: "delete",
+                    resource: "Note",
+                },
+                crate::openapi::AuthorizeBinding {
+                    action: "show",
+                    resource: "Note",
+                },
+            ],
+            ..dummy_api_doc()
+        };
+
+        assert_eq!(
+            authorize_bindings_of(&RouteSource::User, &api_doc),
+            vec![binding("delete", "Note"), binding("show", "Note")],
+        );
+    }
+
+    /// Framework routes are pre-classified and carry no handler metadata, so
+    /// they never report a binding — mirroring `classify`, which short-circuits
+    /// on [`RouteSource::Framework`] before reading the `ApiDoc` at all.
+    #[test]
+    fn framework_routes_carry_no_authorize_bindings() {
+        let api_doc = crate::openapi::ApiDoc {
+            has_policy: true,
+            authorize_bindings: &[crate::openapi::AuthorizeBinding {
+                action: "update",
+                resource: "Note",
+            }],
+            ..dummy_api_doc()
+        };
+
+        assert!(
+            authorize_bindings_of(&RouteSource::Framework, &api_doc).is_empty(),
+            "a framework route must never report an #[authorize] binding"
+        );
+    }
+
+    /// End-to-end through `collect_route_infos`: the bindings recorded by the
+    /// route macros reach the `RouteInfo` the dump serializes.
+    #[test]
+    fn collect_carries_authorize_bindings() {
+        let api_doc = crate::openapi::ApiDoc {
+            has_policy: true,
+            authorize_bindings: &[crate::openapi::AuthorizeBinding {
+                action: "update",
+                resource: "Note",
+            }],
+            ..dummy_api_doc()
+        };
+        let route = make_route_with(Method::POST, "/notes/{id}", "update_note", api_doc);
+        let infos = collect_route_infos(&[route], &[RouteSource::User], &[], &[]).unwrap();
+
+        assert_eq!(infos[0].authorize_bindings, vec![binding("update", "Note")]);
+        assert!(infos[0].policy, "a bound route is still policy-guarded");
+    }
+
+    /// Field 15 follows the field 9-14 convention: elided when empty, so the
+    /// first fourteen keys of every existing dump entry stay byte-stable and an
+    /// *old* consumer sees the JSON it already knows.
+    #[test]
+    fn route_info_elides_empty_authorize_bindings() {
+        let info = RouteInfo {
+            method: "GET".to_owned(),
+            path: "/health".to_owned(),
+            handler: "health".to_owned(),
+            ..Default::default()
+        };
+        let value = serde_json::to_value(&info).unwrap();
+        assert!(
+            value.get("authorize_bindings").is_none(),
+            "an empty binding list must not be serialized: {value}"
+        );
+
+        let bound = RouteInfo {
+            authorize_bindings: vec![binding("update", "Note")],
+            ..info
+        };
+        let value = serde_json::to_value(&bound).unwrap();
+        assert_eq!(
+            value["authorize_bindings"],
+            serde_json::json!([{ "action": "update", "resource": "Note" }]),
+        );
+        let decoded: RouteInfo = serde_json::from_value(value).unwrap();
+        assert_eq!(decoded.authorize_bindings, vec![binding("update", "Note")]);
+    }
+
+    /// The other half of the compatibility contract: `#[serde(default)]` lets a
+    /// *new* consumer read a dump produced before the field existed, rather
+    /// than failing the whole parse on a missing key.
+    #[test]
+    fn route_info_deserializes_old_dump_without_bindings() {
+        let old = serde_json::json!({
+            "method": "POST",
+            "path": "/notes/{id}",
+            "handler": "update_note",
+            "source": "user",
+            "middleware": [],
+            "classification": "gated",
+            "policy": true,
+        });
+
+        let decoded: RouteInfo = serde_json::from_value(old).unwrap();
+        assert!(
+            decoded.authorize_bindings.is_empty(),
+            "a dump without the key must decode to an empty list"
+        );
+        assert!(decoded.policy, "the pre-existing keys must still decode");
     }
 
     #[test]

--- a/autumn/tests/integration/api_versioning_integration.rs
+++ b/autumn/tests/integration/api_versioning_integration.rs
@@ -392,3 +392,25 @@ async fn test_api_versioning_auth_preservation() {
         .await;
     resp.assert_status(410); // Authorized sunset request is 410 Gone!
 }
+
+/// `#[authorize]` written *above* `#[get]` (#1627): the authorize macro expands
+/// first and removes its own attribute, so by the time the route macro runs
+/// there is nothing left but the rewritten body. The binding is recovered from
+/// the marker const `#[authorize]` leaves behind, which is why this pure
+/// ordering-B handler records the same `(action, resource)` pair the
+/// route-macro-outermost handlers do.
+#[test]
+fn authorize_above_route_macro_records_binding() {
+    let route = __autumn_route_info_api_authorize_policy_denial_reverse_sunset();
+    let bindings: Vec<(&str, &str)> = route
+        .api_doc
+        .authorize_bindings
+        .iter()
+        .map(|b| (b.action, b.resource))
+        .collect();
+    assert_eq!(
+        bindings,
+        vec![("show", "SunsetPolicyDenialNote")],
+        "an #[authorize] that expanded before the route macro must still record its binding"
+    );
+}

--- a/autumn/tests/integration/authorization_integration.rs
+++ b/autumn/tests/integration/authorization_integration.rs
@@ -746,3 +746,126 @@ async fn reversed_attribute_order_owner_passes_both() {
     let response = post_with_session(&client, "/notes-reversed/1", "sess-owner").await;
     assert_eq!(response.status, StatusCode::OK);
 }
+
+// ── #[authorize] bindings recorded in route metadata (#1627) ──
+//
+// The route macros record every `#[authorize("action", resource = Type)]` on a
+// handler into `ApiDoc::authorize_bindings`, which the routes dump carries as
+// `RouteInfo::authorize_bindings` for the security manifest's
+// `authorization_policies` dimension. These tests assert on the real handlers
+// above — the same functions the behavioural tests exercise — so a binding
+// disappears from the metadata exactly when the attribute disappears from the
+// source.
+
+/// Project a route's compile-time bindings onto comparable pairs.
+fn bindings_of(route: &autumn_web::Route) -> Vec<(&'static str, &'static str)> {
+    route
+        .api_doc
+        .authorize_bindings
+        .iter()
+        .map(|b| (b.action, b.resource))
+        .collect()
+}
+
+/// The same bindings after the routes-dump projection — the owned, sorted form
+/// the security manifest actually consumes.
+fn wire_bindings_of(route: autumn_web::Route) -> Vec<(String, String)> {
+    let infos = autumn_web::route_listing::collect_route_infos(
+        &[route],
+        &[autumn_web::route_listing::RouteSource::User],
+        &[],
+        &[],
+    )
+    .expect("these handlers declare no api_version, so version resolution cannot fail");
+    infos[0]
+        .authorize_bindings
+        .iter()
+        .map(|b| (b.action.clone(), b.resource.clone()))
+        .collect()
+}
+
+/// Shorthand for an expected wire-side binding pair.
+fn wire(action: &str, resource: &str) -> (String, String) {
+    (action.to_owned(), resource.to_owned())
+}
+
+/// `#[post]` outermost, `#[authorize]` still an unexpanded attribute below it:
+/// the route macro reads the arguments straight off the attribute.
+#[test]
+fn authorize_attr_below_route_macro_records_binding() {
+    let route = __autumn_route_info_update_note_attr();
+    assert_eq!(
+        bindings_of(&route),
+        vec![("update", "Note")],
+        "the #[authorize] attribute below #[post] must record its binding"
+    );
+    assert!(
+        route.api_doc.has_policy,
+        "has_policy stays the superset boolean it always was"
+    );
+    assert_eq!(
+        wire_bindings_of(__autumn_route_info_update_note_attr()),
+        vec![wire("update", "Note")],
+        "…and the binding must reach the routes dump the manifest reads"
+    );
+}
+
+/// `#[post]` + `#[secured]` + `#[authorize]`: the `#[secured]` guard between
+/// the two must not swallow the binding.
+#[test]
+fn stacked_secured_and_authorize_records_binding() {
+    let route = __autumn_route_info_update_note_stacked_with_secured();
+    assert_eq!(
+        bindings_of(&route),
+        vec![("update", "Note")],
+        "a binding stacked under #[secured] must survive"
+    );
+    assert_eq!(
+        wire_bindings_of(__autumn_route_info_update_note_stacked_with_secured()),
+        vec![wire("update", "Note")],
+    );
+}
+
+/// The reverse stacking (`#[authorize]` above `#[secured]`, both below
+/// `#[post]`) records the same binding: the metadata describes the handler, not
+/// the order its guards happen to be written in.
+#[test]
+fn authorize_above_secured_records_binding() {
+    let route = __autumn_route_info_update_note_reversed_attribute_order();
+    assert_eq!(
+        bindings_of(&route),
+        vec![("update", "Note")],
+        "attribute order must not change the recorded binding"
+    );
+    assert_eq!(
+        wire_bindings_of(__autumn_route_info_update_note_reversed_attribute_order()),
+        vec![wire("update", "Note")],
+    );
+}
+
+/// The falsifying half (D6): `authorize_bindings` is the *provable subset* of
+/// the `policy` boolean, so a handler that authorizes by hand — or one guarded
+/// only by `#[secured]` — records no binding at all.
+#[test]
+fn handler_without_authorize_has_no_bindings() {
+    let hand_written = __autumn_route_info_update_note_inline();
+    assert!(
+        bindings_of(&hand_written).is_empty(),
+        "a hand-written authorize::<Note>() call carries no recoverable binding"
+    );
+    assert!(
+        wire_bindings_of(__autumn_route_info_update_note_inline()).is_empty(),
+        "and it stays empty on the wire, so the key is elided from the dump"
+    );
+
+    let secured_only = __autumn_route_info_secured_admin_mutation();
+    assert!(
+        bindings_of(&secured_only).is_empty(),
+        "#[secured] is a role check, not a record-level policy binding"
+    );
+    assert_eq!(
+        secured_only.api_doc.required_roles,
+        &["admin"],
+        "…while its role guard is still recorded, unchanged"
+    );
+}

--- a/docs/guide/authorization.md
+++ b/docs/guide/authorization.md
@@ -179,6 +179,17 @@ let post: Post = posts::table.find(id).first(&mut *db).await?;
 authorize::<Post>(&state, &session, "update", &post).await?;
 ```
 
+Every `#[authorize]` attribute is also recorded in the build-time security
+manifest: `autumn routes audit` emits one `(action, resource)` entry per
+binding in its provable `authorization_policies` dimension, so deleting an
+attribute deletes exactly that entry. The recorded resource is the identifier
+as written — `Post`, not the `PostPolicy` impl, which the attribute never names
+and the registry only resolves at boot. The inline `authorize::<Post>`
+call above is invisible to the audit by contrast: it is a call site, not an
+attribute, so it contributes no binding *and* no classification — a handler
+relying on it still needs `#[secured]` or `#[public]` to pass the coverage
+gate. See [Security Posture Manifest](./security-posture-manifest.md).
+
 ## The `#[repository] policy =` argument
 
 `#[repository(api = "/posts")]` auto-mounts JSON CRUD endpoints. Without

--- a/docs/guide/macro-transparency.md
+++ b/docs/guide/macro-transparency.md
@@ -1187,8 +1187,9 @@ async fn admin_panel(__autumn_session: Session) -> AutumnResult<&'static str> {
 
 ### `#[authorize("action", resource = Type)]`
 
-Injects hidden `Session` and `State<AppState>` extractors and a
-record-level [`Policy`](./authorization.md) check at the top of your
+Injects hidden extractors (`Session`, `State<AppState>`, the granted
+API-token scopes, and the route-version/idempotency-replay extensions) and
+a record-level [`Policy`](./authorization.md) check at the top of your
 handler. Mirrors `#[secured]` but answers "are you allowed to act on
 *this* record?" instead of "are you allowed to call this *route*?"
 
@@ -1207,17 +1208,31 @@ async fn edit_post(post: Post) -> AutumnResult<Markup> {
 ```rust
 #[get("/posts/{id}/edit")]
 async fn edit_post(
+    __autumn_token_scopes: Option<Extension<ApiTokenScopes>>,
     __autumn_session: Session,
     State(__autumn_state): State<AppState>,
+    // … plus hidden route-version and idempotency-replay extractors
     post: Post,
-) -> AutumnResult<Markup> {
-    ::autumn_web::authorization::__check_policy::<Post>(
+) -> Response {
+    // Inert build-time marker — nothing reads it at runtime. It lets the
+    // route macro recover the binding when `#[authorize]` expands *before*
+    // `#[get]` (attribute order decides which macro sees the other's output).
+    const __AUTUMN_AUTHORIZE_BINDINGS: &[(&str, &str)] = &[("update", "Post")];
+
+    if let Err(__autumn_error) = ::autumn_web::authorization::__check_policy_scoped::<Post>(
         &__autumn_state,
         &__autumn_session,
+        __autumn_token_scopes.as_ref().map(|__e| &__e.0),
         "update",
         &post,
-    ).await?;
-    Ok(html! { h1 { (post.title) } })
+    ).await {
+        return __autumn_error.into_response();
+    }
+    // … sunset check and idempotency-replay short-circuit …
+    let __autumn_inner: AutumnResult<Markup> = (async move {
+        Ok(html! { h1 { (post.title) } })
+    }).await;
+    __autumn_inner.into_response()
 }
 ```
 
@@ -1226,8 +1241,21 @@ async fn edit_post(
 - The check returns the configured deny status — `404` by default to
   avoid leaking record existence, configurable via
   `[security] forbidden_response = "403"`.
+- The scope-aware `__check_policy_scoped` takes the request's granted API-token
+  scopes as its third argument, so a policy can decide on `ctx.has_scope(...)`
+  for token-authenticated principals as well as session ones.
+- The handler is rewritten to return `Response`, and the original body is
+  wrapped in `(async move { … }).await` so the deny path can return early
+  before it runs.
+- `__AUTUMN_AUTHORIZE_BINDINGS` records the resource *identifier as written*,
+  never the `Policy` impl that serves the check — that is resolved from the
+  registry at boot. It is what puts the route's `(action, resource)` pair into
+  the `authorization_policies` dimension of the build-time security manifest;
+  see [Security Posture Manifest](./security-posture-manifest.md).
 - Coexists with `#[secured]`: stack both attributes when a route should
-  require both authentication/role gating and a record-level check.
+  require both authentication/role gating and a record-level check. Each
+  attribute leaves its own marker, so both the roles and the binding survive
+  however the two expand around each other.
 
 ### `#[step_up]` / `#[step_up(max_age = "5m")]`
 

--- a/docs/guide/route-auth-coverage.md
+++ b/docs/guide/route-auth-coverage.md
@@ -121,6 +121,21 @@ Add a guard (`#[secured]` / `#[authorize]`) or mark the route deliberately open 
 Fix it either way — add a guard, or add `#[public]` — and the gate goes
 green.
 
+### Static routes only classify via `#[public]`
+
+`#[static_get]` routes honor exactly one marker: `#[public]`. Stacking
+`#[secured]` or `#[authorize]` on one still compiles — the guard expands and
+runs on requests that fall through to the dynamic handler — but prerendered
+responses are served from the static output *without invoking the handler*,
+so no handler-body guard can be proven to cover every response the route
+serves. The audit therefore deliberately refuses to call such a route
+`gated`: it stays `unclassified`, fails the gate, and contributes no
+`authorization_policies` binding. That is the honest outcome, not a gap — a
+`gated` label here would claim a per-response guarantee the static serving
+path does not provide. A route that needs authentication or authorization
+should be a dynamic route (`#[get]`/`#[post]`/…); a static route that is
+deliberately open says so with `#[public]`.
+
 ## Running the audit
 
 ```bash

--- a/docs/guide/route-auth-coverage.md
+++ b/docs/guide/route-auth-coverage.md
@@ -29,8 +29,8 @@ no fourth, silent, default state — a route that fits none of these is
 Anything already carrying `#[secured]` or `#[authorize]` is `gated`
 automatically; there is nothing new to add. See the [Authorization
 guide](authorization.md) for `#[secured]` vs. `#[authorize]` vs. the `Policy`
-trait. The manifest also carries the declared roles/scopes and whether a
-dynamic policy is attached:
+trait. The manifest also carries the declared roles/scopes and a `policy`
+boolean recording that a record-level check runs:
 
 ```rust
 use autumn_web::prelude::*;
@@ -43,6 +43,27 @@ async fn delete_widget(/* … */) -> AutumnResult<()> { /* … */ }
 ```json
 { "path": "/widgets/{id}", "method": "DELETE", "classification": "gated", "roles": ["admin"] }
 ```
+
+For `#[authorize]` the manifest goes one step further than the boolean: the
+separate `authorization_policies` dimension records the `(action, resource)`
+binding each attribute declares, so you can read *what* the route is guarded to
+do rather than only *that* it is guarded.
+
+```rust
+#[get("/posts/{id}/edit")]
+#[authorize("update", resource = Post)]
+async fn edit_post(post: Post) -> AutumnResult<Markup> { /* … */ }
+```
+
+```json
+{ "path": "/posts/{id}/edit", "method": "GET", "name": "edit_post", "action": "update", "resource": "Post", "provenance": "provable" }
+```
+
+The two are not redundant, and `policy` is the wider of the pair: a route can
+set the boolean without contributing a binding — a `#[repository(api = ...,
+policy = ...)]` auto-API does exactly that. Both readings, and that superset
+relationship, are covered in the [Security Posture
+Manifest](security-posture-manifest.md).
 
 A `#[repository(api = ..., policy = ...)]` or `scope = ...` auto-API route is
 also `gated` — its guard lives on the generated CRUD handler, not on a
@@ -154,10 +175,14 @@ the nest enumerable.
 
 The `routes` dimension of the emitted JSON manifest is `provenance:
 "provable"` — every classification is a direct consequence of macro-expanded
-code, not a report of configuration. See [Security Posture Manifest —
-Provenance Classes](security-posture-manifest.md) for how the `routes`,
-`csrf`, and `security_headers` dimensions are tagged, and what `declared` and
-`runtime-only` mean for the dimensions that aren't (yet) provable this way.
+code, not a report of configuration. So is `authorization_policies`, which
+carries the `#[authorize]` bindings, with a `runtime_caveat` naming the one
+step it cannot prove (which `Policy` impl the registry serves at boot). See
+[Security Posture Manifest — Provenance Classes](security-posture-manifest.md)
+for how the `routes`, `csrf`, `security_headers`, and `authorization_policies`
+dimensions are tagged, for the rubric that decides a dimension's class, and for
+what `declared` and `runtime-only` mean for the dimensions that aren't (yet)
+provable this way.
 
 ## See also
 

--- a/docs/guide/security-posture-manifest.md
+++ b/docs/guide/security-posture-manifest.md
@@ -11,19 +11,101 @@ runtime. Reading the manifest starts with reading these tags.
 
 ```json
 {
-  "schema_version": 2,
+  "schema_version": 3,
   "dimensions": {
     "routes":           { "provenance": "provable",  "source": "macro:#[secured]/#[authorize]/#[public]", "entries": [ … ] },
     "csrf":             { "provenance": "declared",  "source": "config:security.csrf",     "entries": [ … ] },
-    "security_headers": { "provenance": "declared",  "source": "config:security.headers",  "entries": [ … ] }
+    "security_headers": { "provenance": "declared",  "source": "config:security.headers",  "entries": [ … ] },
+    "authorization_policies": {
+      "provenance": "provable",
+      "source": "macro:#[authorize]",
+      "runtime_caveat": "the route→action→resource binding is proven from macro-expanded code; which impl Policy<Resource> serves it is resolved from the PolicyRegistry at boot (AppBuilder::policy::<R, _>(...)). A missing registration is not visible at build time — see the policy_registration entry in `excluded`.",
+      "entries": [
+        { "path": "/posts/{id}/edit", "method": "GET", "name": "edit_post", "action": "update", "resource": "Post", "provenance": "provable" }
+      ]
+    }
   },
   "excluded": [
-    { "dimension": "policy_registration", "eventual_provenance": "runtime-only", "reason": "boot-time fact; excluded from a build-time manifest by design" }
+    { "dimension": "repository_policy_bindings", "eventual_provenance": "provable",     "reason": "… their presence still shows as routes.entries[].policy" },
+    { "dimension": "policy_registration",        "eventual_provenance": "runtime-only", "reason": "boot-time fact; excluded from a build-time manifest by design — the authorization_policies dimension proves bindings and carries this as its runtime_caveat" },
+    …
   ]
 }
 ```
 
-There are exactly three provenance classes.
+There are exactly three provenance classes — `provable`, `declared`, and
+`runtime-only`. Which one a dimension carries is a rule, not a judgement call.
+
+## Choosing a provenance class
+
+Ask these three questions **in order** and take the first `yes`:
+
+1. **Can the fact be recovered from macro-expanded code alone** — no config
+   file read, no process started? → `provable`.
+2. **Is the fact read from typed configuration that the runtime then applies?**
+   → `declared`.
+3. **Does the fact only come into existence after boot, or per request?** →
+   `runtime-only`, and the dimension is named in `excluded` rather than
+   emitted.
+
+The order matters because the classes are strictly decreasing in strength, and
+a dimension may only claim the class it can defend. When two of the answers
+apply to **the same fact**, the later — weaker — one wins.
+
+### The tie-breaker: `provable` with a `runtime_caveat`
+
+When two answers apply to **different steps** of one dimension, the dimension
+is not demoted. Most real dimensions are not pure, and
+`authorization_policies` is the worked case: the route→action→resource binding
+is fully recoverable from the expansion (question 1 is `yes` for the entries),
+while the `impl Policy<Post>` that actually answers the check is chosen from
+the `PolicyRegistry` at boot (question 3 is `yes` for that adjacent step).
+
+Such a dimension ships as **`provable` with a `runtime_caveat`**. Demoting it
+to `declared` would understate what the build genuinely proves, and quietly
+shipping it as `provable` with the boot dependency unmentioned would overstate
+it. The caveat is a required, non-empty string
+carried *on the dimension itself*, so a reader hits it in the same object as
+the claim it qualifies, and it cannot be dropped by a later refactor without
+failing the manifest's own tests.
+
+Note what the caveat is **not** licensed to do: it qualifies a step *adjacent*
+to the proven fact. It cannot be used to hand-wave the proven fact itself. If
+the entries would be wrong without a runtime assumption, the dimension is not
+`provable`.
+
+### Worked example: outbound HTTP is `declared`
+
+`[http.client.base_urls]` gives each upstream an alias, and handlers call it by
+name:
+
+```toml
+[http.client.base_urls]
+stripe   = "https://api.stripe.com"
+sendgrid = "https://api.sendgrid.com"
+```
+
+Run the rubric on "which outbound hosts can this app reach?":
+
+1. *Provable?* **No.** The alias table is a convenience, not a chokepoint —
+   nothing at build time proves that every outbound call goes through a named
+   client. A handler can build its own `Client` and pass an absolute URL, and
+   the macros never see it.
+2. *Declared?* **Yes.** The allowlist is typed configuration the runtime
+   applies when a call resolves an alias.
+
+So `outbound_http` is `declared`, and its `excluded` entry says so —
+`eventual_provenance: "declared"`, with the reason naming exactly the gap
+("named-client `base_urls` allowlist is config, nothing proves every outbound
+call routes through a named client"). See [Outbound HTTP
+Client](outbound-http.md) for the alias mechanism itself.
+
+That entry is the shape every future dimension follows. **This rubric is the
+honest-labeling gate: no dimension may ship claiming more than it knows.** A
+change that adds or promotes a dimension has to answer the three questions,
+and if the answer is "provable, with a boot- or request-time step", it has to
+name that step in a `runtime_caveat` rather than leave the reader to discover
+it.
 
 ## `provable`
 
@@ -55,6 +137,59 @@ the route surfaces in the manifest as a proven `gated` classification:
 Nothing about this can drift: the classification *is* the expansion of the
 macro. An unannotated mutating handler classifies `unclassified`, and the audit
 gate fails and names it.
+
+**Example — an `#[authorize]` binding in the `authorization_policies`
+dimension.** Where `routes` answers "is this endpoint guarded at all?", this
+dimension answers "guarded *to do what, to which resource?*". A record-level
+guard:
+
+```rust
+#[get("/posts/{id}/edit")]
+#[authorize("update", resource = Post)]
+async fn edit_post(post: Post) -> AutumnResult<Markup> { /* … */ }
+```
+
+contributes one entry per binding, keyed by the route it sits on:
+
+```json
+{
+  "path": "/posts/{id}/edit",
+  "method": "GET",
+  "name": "edit_post",
+  "action": "update",
+  "resource": "Post",
+  "provenance": "provable"
+}
+```
+
+The same route also appears in the `routes` dimension with `"policy": true` —
+the boolean says *a* record-level check runs, this dimension says *which* one.
+
+Two properties of `resource` are load-bearing when you read these entries:
+
+- **It is the resource identifier exactly as written at the use site** — the
+  `Post` in `resource = Post`. It is deliberately *not* the `Policy`
+  implementation that serves the check: `#[authorize]` never names one. The
+  concrete `impl Policy<Post>` is looked up from the `PolicyRegistry` at boot,
+  which is precisely what the dimension's `runtime_caveat` discloses.
+- **It is an identifier, not a resolved path** — so two same-named types in
+  different modules (`billing::Invoice` and `reporting::Invoice`) are
+  indistinguishable in the manifest. That is a known limitation of proving
+  from an expansion: name resolution is the compiler's job, and it happens
+  after the macro has run.
+
+Entries are sorted by `(path, method, action, resource)`, and each route's own
+bindings are sorted and deduplicated before they reach the manifest, so a
+rebuild of unchanged code is byte-identical and a diff shows only what actually
+moved. Stacking several `#[authorize]` attributes on one handler yields several
+entries; framework-owned routes never contribute any.
+
+The falsifiability that makes this a `provable` dimension is direct: delete one
+of a handler's `#[authorize]` attributes and exactly that entry disappears from
+the next manifest, while the `routes`, `csrf`, and `security_headers`
+dimensions stay byte-identical. (Delete a handler's *only* guard and the
+`routes` dimension moves too — reclassifying it to `unclassified` and failing
+the gate. That is the other dimension doing its own job, not this one leaking.)
 
 ## `declared`
 
@@ -88,15 +223,32 @@ observe**. Rather than fabricate it, the manifest lists the dimension in
 `excluded` with the provenance class it will *eventually* carry once (and if) it
 becomes observable.
 
-**Example — policy registration at boot.** Which authorization policies are
-actually registered in the `PolicyRegistry` is decided when the app boots, not
-when it compiles. It therefore appears only in the `excluded` block:
+**Example — policy registration at boot.** `#[authorize("update", resource =
+Post)]` proves the binding, but not that anyone ever called
+`.policy::<Post, _>(PostPolicy)` on the app builder. The registry is populated
+when the app boots, so an application can carry a perfectly proven binding and
+still have no policy behind it — a fact no build can see.
+
+That fact is stated twice, on purpose, and the two statements say different
+things. On the dimension, as its `runtime_caveat`, where it qualifies the
+claim at the point of use:
+
+```json
+"runtime_caveat": "the route→action→resource binding is proven from macro-expanded code; which impl Policy<Resource> serves it is resolved from the PolicyRegistry at boot (AppBuilder::policy::<R, _>(...)). A missing registration is not visible at build time — see the policy_registration entry in `excluded`."
+```
+
+and in `excluded`, where it stands as its own deferred dimension — because
+enumerating *the registry's contents* is a separate, still-unsolved problem.
+`PolicyRegistry` exposes only per-type lookups (`policy::<R>()`,
+`has_policy::<R>()`) over `TypeId`-keyed, type-erased entries, and the route
+dump never runs the registrations at all — it exits with the route listing
+before the builder applies them:
 
 ```json
 {
   "dimension": "policy_registration",
   "eventual_provenance": "runtime-only",
-  "reason": "boot-time fact; excluded from a build-time manifest by design"
+  "reason": "boot-time fact; excluded from a build-time manifest by design — the authorization_policies dimension proves bindings and carries this as its runtime_caveat"
 }
 ```
 
@@ -104,6 +256,8 @@ The `excluded` list is how the manifest stays honest about its own boundaries:
 every dimension that is not yet emitted is named, with the class it will carry
 and why it is deferred — so a reader can tell the difference between "proven
 absent" and "not yet measured".
+
+### Another boundary: serve-path routers
 
 That honesty also covers a runtime boundary: the `serve_path_routers` entry
 records that opt-in serve-path HTTP surfaces (MCP, inbound-mail, storage, SEO)
@@ -113,10 +267,47 @@ mutating endpoints (MCP, inbound-mail) run outside the framework CSRF layer and
 rely on their own protections; enumerating them is deferred to a dump-plumbing
 follow-up.
 
+## Reading `policy` against the proven bindings
+
+The `routes` dimension's `policy` boolean and the `authorization_policies`
+entries do not measure the same thing, and the manifest never pretends they do:
+
+```
+routes.entries[].policy  ⊇  authorization_policies.entries
+```
+
+Every route with a binding has `policy: true`, but not every route with
+`policy: true` has a binding. Two guards set the boolean while leaving nothing
+a macro can recover:
+
+- **An inline `__check_policy` / `__check_policy_scoped` call** in the handler
+  body. That is the shape `#[authorize]` itself expands to, and the route macro
+  recognizes the call by name — so a body carrying one is `gated` with
+  `policy: true` whether or not the attribute is still visible. What the macro
+  cannot do is read an `(action, resource)` pair back out of a hand-written
+  call, where both are ordinary expression arguments rather than attribute
+  syntax.
+- **A `#[repository(api = ..., policy = ...)]` auto-API**, whose generated CRUD
+  handlers enforce fixed `show`/`create`/`update`/`delete` actions but whose
+  policy type the macro discards at expansion, leaving only a type-erased
+  registry probe behind. This gap is disclosed in `excluded` as
+  `repository_policy_bindings` with `eventual_provenance: "provable"` —
+  recoverable in principle, simply not plumbed yet.
+
+So a route with `"policy": true` and no matching `authorization_policies` entry
+is **normal, not a defect**. Read the boolean as "a record-level check runs
+here" and the entries as "and here is the part of it we can prove". The
+manifest deliberately keeps the wider claim rather than redefining `policy` as
+"has a recoverable binding": narrowing it would throw away the only signal
+those two guards leave behind.
+
 ## See also
 
 - [Route Auth Coverage — the Default-Deny Posture Model](route-auth-coverage.md)
   — the default-deny classification model behind the `routes` dimension, and
   how to classify the three route kinds (`gated`, `public`, `framework`).
+- [Record-Level Authorization](authorization.md) — the `Policy` trait,
+  `#[authorize]`, and the `#[repository(policy = ...)]` argument behind the
+  `authorization_policies` dimension.
 - [`autumn routes` — Route Inspection CLI](routes-cli.md) — the `audit`
   subcommand that emits this manifest.

--- a/docs/guide/security-posture-manifest.md
+++ b/docs/guide/security-posture-manifest.md
@@ -165,7 +165,7 @@ contributes one entry per binding, keyed by the route it sits on:
 The same route also appears in the `routes` dimension with `"policy": true` —
 the boolean says *a* record-level check runs, this dimension says *which* one.
 
-Two properties of `resource` are load-bearing when you read these entries:
+Three properties of these entries are load-bearing when you read them:
 
 - **It is the resource identifier exactly as written at the use site** — the
   `Post` in `resource = Post`. It is deliberately *not* the `Policy`
@@ -177,6 +177,18 @@ Two properties of `resource` are load-bearing when you read these entries:
   indistinguishable in the manifest. That is a known limitation of proving
   from an expansion: name resolution is the compiler's job, and it happens
   after the macro has run.
+- **Attribute detection is by name, not by resolved import** — the same
+  no-name-resolution boundary, on the attribute side. When `#[authorize]` sits
+  *below* the route attribute it is recognized textually (`authorize`, or a
+  path ending in it, e.g. `#[autumn_web::authorize]`). Import the macro under
+  an alias — `use autumn_web::authorize as policy;` — and a `#[policy(...)]`
+  written below the route attribute still guards the route at runtime but
+  records no binding (and no `policy: true` either; every name-based attribute
+  check in the route macros — `#[secured]`, `#[public]`, `#[throttle]` — has
+  always shared this boundary). Written *above* the route attribute the alias
+  is harmless: the guard expands first and the route macro reads the marker
+  its expansion emits, whatever name invoked it. If you alias the guard
+  macros, put them above the route attribute — or don't alias them.
 
 Entries are sorted by `(path, method, action, resource)`, and each route's own
 bindings are sorted and deduplicated before they reach the manifest, so a

--- a/docs/guide/security-posture-manifest.md
+++ b/docs/guide/security-posture-manifest.md
@@ -190,6 +190,18 @@ Three properties of these entries are load-bearing when you read them:
   its expansion emits, whatever name invoked it. If you alias the guard
   macros, put them above the route attribute — or don't alias them.
 
+One boundary applies to every marker-read fact in the manifest, not just this
+dimension: the marker consts (`__AUTUMN_AUTHORIZE_BINDINGS`,
+`__AUTUMN_SECURED_ROLES`, `__AUTUMN_PUBLIC`, …) are framework-internal
+declarations the macros emit, and the extractors take them at their word.
+Hand-writing one in a handler body forges the corresponding claim — a forged
+public marker even turns the coverage gate green for an unguarded route. The
+manifest's threat model is **drift detection, not an adversarial author**: it
+proves what your code declares, so an author lying to their own manifest is an
+author lying in their own code, and that is what code review of the
+application is for. The audit deliberately does not try to out-verify a
+developer with commit access to the code it audits.
+
 Entries are sorted by `(path, method, action, resource)`, and each route's own
 bindings are sorted and deduplicated before they reach the manifest, so a
 rebuild of unchanged code is byte-identical and a diff shows only what actually
@@ -288,9 +300,9 @@ entries do not measure the same thing, and the manifest never pretends they do:
 routes.entries[].policy  ⊇  authorization_policies.entries
 ```
 
-Every route with a binding has `policy: true`, but not every route with
-`policy: true` has a binding. Two guards set the boolean while leaving nothing
-a macro can recover:
+For every route the macros generate, a binding implies `policy: true` — but not
+every route with `policy: true` has a binding. Two guards set the boolean while
+leaving nothing a macro can recover:
 
 - **An inline `__check_policy` / `__check_policy_scoped` call** in the handler
   body. That is the shape `#[authorize]` itself expands to, and the route macro

--- a/skills/routes/SKILL.md
+++ b/skills/routes/SKILL.md
@@ -80,7 +80,7 @@ omitted. They do not need to be shown unless the user asks:
 If `autumn routes` fails because the project has not been compiled, tell the
 user to run `cargo build` first, then retry.
 
-## Auth-coverage audit (unreleased — trunk-dev, issues #1604, #1850)
+## Auth-coverage audit (unreleased — trunk-dev, issues #1604, #1850, #1627)
 
 On trunk-dev, `autumn routes audit` audits every route's authentication
 exposure. It prints each route's classification — `gated`, `public`,
@@ -101,6 +101,21 @@ An unclassified-route diagnostic now names the offending handler's `file:line`
 jumped to directly. See `docs/guide/route-auth-coverage.md` for the full
 default-deny posture model and how to classify `gated`/`public`/`framework`
 routes.
+
+The manifest (schema v3) carries four dimensions, each tagged with a provenance
+class:
+
+- `routes` (`provable`) — the per-route classification above.
+- `csrf` (`declared`) — CSRF enforcement per mutating route, from config.
+- `security_headers` (`declared`) — effective response headers, from config.
+- `authorization_policies` (`provable`) — one `(action, resource)` entry per
+  `#[authorize]` binding, plus a `runtime_caveat` recording that which
+  `impl Policy<R>` serves the check is a boot fact the build cannot see.
+
+Dimensions that are not yet emitted are named in the manifest's `excluded`
+list with the class they will eventually carry. See
+`docs/guide/security-posture-manifest.md` for the provenance rubric that
+decides a dimension's class.
 
 ## Comparing expected vs actual routes
 


### PR DESCRIPTION
Implements the remaining slice of #1627: the `authorization_policies` dimension graduates from the manifest's `excluded` list to a real, provable dimension — every `#[authorize]` binding recorded as **route → action → resource**, with the boot-time policy-registration fact carried as a required `runtime_caveat` on the dimension itself.

## What landed

**Macro layer** (`2270ea1`, `a8e4edc`)
- `#[authorize]` emits an inert `__AUTUMN_AUTHORIZE_BINDINGS` marker const as the first statement of its rewritten body, so the binding survives the attribute's own expansion.
- `api_doc::extract_authorize_bindings` records every binding as the union of still-visible attributes (parsed through the `#[authorize]` grammar itself) and marker consts recovered by a structural walk that descends the generated `(async move { … }).await` wrappers. Both attribute orderings, stacked and mixed arrangements covered, genuinely **source-ordered**; string-literal decoys cannot forge a binding.
- New `ApiDoc::authorize_bindings: &'static [AuthorizeBinding]` — the resource is recorded **as written**, deliberately not the `Policy` impl type (which is resolved from the `PolicyRegistry` at boot and has no compile-time name). `has_policy` is untouched: it remains the superset boolean.
- The marker is registered in the idempotency replay-guard prologue skip list, so guard composition is unchanged.

**Wire plumbing** (`8bd9ea2`)
- `RouteInfo.authorize_bindings` (wire twin `AuthorizeBindingInfo`), appended with the established serde-default/elide convention so old and new dumps interoperate both ways; sorted by `(action, resource)` + deduplicated at the `route_listing` boundary (set semantics for the falsifiability claim — deliberately unlike `roles`/`scopes` source order). `classify()` untouched.

**CLI manifest** (`398cbc2`)
- Schema **v3**: fourth dimension `authorization_policies` (`provenance: "provable"`, `source: "macro:#[authorize]"`, required `runtime_caveat`), entries flat per route×binding, ordered `(path, method, action, resource)`.
- `excluded` surgery: `authorization_policies` graduates out; `repository_policy_bindings` discloses the auto-API gap in its place; `policy_registration` stays runtime-only, cross-referencing the caveat.
- AC keystone tests: `removing_an_authorize_binding_flips_only_that_entry` (exactly one entry disappears, other dimensions byte-identical), `reclassifying_a_route_flips_only_the_routes_dimension`, byte-identical rebuilds with bindings seeded, `policy: true`-without-bindings contributes no entries, framework routes never contribute.

**Metadata-loss fixes surfaced by review** (`6555472`, `f6ab22a` — red-first, `### Fixed` bullets)
- `#[secured]` roles/scopes were silently dropped from the manifest in two arrangements: buried under a wrapping `#[authorize]`'s generated body (walker couldn't descend), and short-circuited by a live `#[authorize]` attribute below the route macro. Both walks now share the same wrapper-descent helper and the marker read wins over the attribute fallback.
- The `#[public]` marker is no longer lost under a wrapping guard (e.g. `#[throttle]`), which previously false-failed the coverage gate as `unclassified`.

**Docs** (`6749322`, `bf75ef4`, `6252db6`)
- `security-posture-manifest.md` on the v3 contract, with a new **"Choosing a provenance class"** rubric: the three-question decision rule, the provable-with-`runtime_caveat` tie-breaker, and the worked **outbound-HTTP-as-`declared`** example — the honest-labeling gate for future dimensions. Documented boundaries: resource-ident collisions, name-based attribute detection (aliased imports), static routes classifying only via `#[public]` (and why populating bindings there would overstate), and the marker trust boundary (drift detection, not an adversarial author).
- `route-auth-coverage.md`, `authorization.md`, `macro-transparency.md` (expansion sketch refreshed to current codegen), `skills/routes/SKILL.md`, CHANGELOG Unreleased bullets. No workspace version bump.

## Process

Planned via brainstorming / reverse brainstorming / six-hats over a three-way code recon; implemented red → green → refactor with failing-test evidence captured per stage; reviewed by five angle-specific reviewers whose findings were each independently, adversarially verified (6 upheld findings → fixed here; 3 refuted with reproductions). All Codex review threads addressed and resolved.

## Follow-ups filed / noted

- #2233 — pre-existing: `block_has_replay_guard` rejects real guard output (sunset check / UNAUTHORIZED wrapper), so stacked guards emit duplicate replay guards; a replayed 2xx can precede the record-level policy check. Out of scope here (runtime behavior change).
- Repository `policy = X` bindings (the one genuinely provable policy *type* in the workspace) — disclosed via the `repository_policy_bindings` excluded entry; enriching `RepositoryApiMeta` is the named next slice.
- `autumn routes --format json` still drops security metadata (pre-existing; its narrow `RouteInfo` mirror predates the audit).
- No trybuild fixture covers `#[authorize]`'s five diagnostics (pre-existing).

Closes #1627 (phase-1 scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ULnSQACCXweuh3PWvANg7b