### PR TITLE
Ship codemods with `autumn upgrade` for breaking API renames (#1629)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,13 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
+  # `Cli::try_parse_from` builds this CLI's entire clap command tree inside a
+  # single `Commands::augment_subcommands` frame, which is close enough to the
+  # 2 MiB default thread stack that adding one subcommand can overflow it — and
+  # the margin differs per platform, so it surfaces on Windows first. The tests
+  # are correct; only the stack they run on is marginal. Raise it explicitly
+  # rather than leaving the suite one variant away from aborting.
+  RUST_MIN_STACK: 8388608
 
 jobs:
   meta:

--- a/.github/workflows/cold-start-latency.yml
+++ b/.github/workflows/cold-start-latency.yml
@@ -57,6 +57,13 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
+  # `Cli::try_parse_from` builds this CLI's entire clap command tree inside a
+  # single `Commands::augment_subcommands` frame, which is close enough to the
+  # 2 MiB default thread stack that adding one subcommand can overflow it — and
+  # the margin differs per platform, so it surfaces on Windows first. The tests
+  # are correct; only the stack they run on is marginal. Raise it explicitly
+  # rather than leaving the suite one variant away from aborting.
+  RUST_MIN_STACK: 8388608
 
 # Minimal token scope: every job only needs to read the repo. Artifact upload
 # and step-summary writes do not require additional permissions.

--- a/.github/workflows/dev-loop-latency.yml
+++ b/.github/workflows/dev-loop-latency.yml
@@ -46,6 +46,13 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
+  # `Cli::try_parse_from` builds this CLI's entire clap command tree inside a
+  # single `Commands::augment_subcommands` frame, which is close enough to the
+  # 2 MiB default thread stack that adding one subcommand can overflow it — and
+  # the margin differs per platform, so it surfaces on Windows first. The tests
+  # are correct; only the stack they run on is marginal. Raise it explicitly
+  # rather than leaving the suite one variant away from aborting.
+  RUST_MIN_STACK: 8388608
 
 jobs:
   # ── Budget table smoke-check (runs on every PR, no live server) ────────────

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Codemods with `autumn upgrade` (#1629):** the new `autumn upgrade` command
+  applies each release's *mechanical* app-code migrations to your own Rust
+  source. For every release between the `autumn-web` version your `Cargo.toml`
+  records and the target, it rewrites that release's machine-applyable changes
+  — first shipped: 0.6.0's `with_pool` → `with_pool_untracked` repository
+  constructor rename. It writes nothing by default: a bare `autumn upgrade`
+  prints a per-file diff plus a count of affected sites, and `--apply` is the
+  explicit write step. Rewrites match whole tokens through a token-level parse
+  rather than a text substitution, so string literals, comments, same-named
+  locals and `with_pool_provider` are untouched, formatting and comments
+  survive byte-for-byte, and a second run is a no-op. Anything the tool cannot
+  safely reach — a call site inside a macro invocation or an attribute — is
+  reported with `file:line` under `manual` with a link to the guide section,
+  never guessed at. Every documented breaking change now carries an
+  `**Automation:**` confidence label (`auto` / `review` / `manual`) in its
+  migration guide, and `scripts/check-migration-guides.sh` fails a rename-level
+  break that has neither a shipped codemod nor a stated reason for staying
+  manual. See `docs/guide/upgrading.md`.
+  <!-- migration-guide-gate: describes tooling for breaking changes; the
+  command and the gate are both additive -->
+
 - **Declarative data-retention sweeps (#1342):** `#[repository(Model,
   retention(after = "30d", basis = created_at))]` — and the soft-delete
   `purge_deleted_after = "90d"` variant, composable with `after` — compiles to

--- a/README.md
+++ b/README.md
@@ -260,6 +260,7 @@ See [EXAMPLES.md](EXAMPLES.md) for the full catalog with personas, journeys, pre
 - [API Reference](https://docs.rs/autumn-web)
 - [Pre-rendering Design Notes](docs/design/hybrid-rendering.md)
 - [Stability Policy](STABILITY.md) — SemVer, MSRV, and migration commitments
+- [Upgrading](docs/guide/upgrading.md) — `autumn upgrade` applies each release's mechanical API migrations to your own code after showing you the diff; everything it cannot safely rewrite is listed with `file:line` and a guide link
 - [Transition effects](docs/guide/transition-effects.md) — per-edge `on` / `on_commit` side effects on `#[state_machine]` transitions.
 - [Counter Caches](docs/guide/counter-cache.md) — `#[belongs_to(Post, counter_cache)]` keeps `posts.comment_count` current atomically, in the same transaction, with an idempotent `recompute` for drift
 - [Votes, Likes and Reactions](docs/guide/votable.md) — `#[votable(by = ..., aggregate = sum|count)]`, the race-safe `react()` / `reaction_of()` helpers, and the no-JS `reaction_controls` widget

--- a/autumn-cli/src/doctor.rs
+++ b/autumn-cli/src/doctor.rs
@@ -2476,9 +2476,11 @@ pub enum AutumnWebDependency {
     /// Declared with a version requirement.
     Version(String),
     /// Declared, but with no version to read — a path or git entry.
-    /// (`{ workspace = true }` is [`Absent`](Self::Absent): it inherits the
-    /// root entry, which is read on its own.)
     WithoutVersion,
+    /// `{ workspace = true }`: the version lives in the enclosing workspace's
+    /// `[workspace.dependencies]`, which may be in an *ancestor* directory when
+    /// the command is pointed at a member rather than the workspace root.
+    Inherited,
 }
 
 /// Read the `autumn-web` version requirement from the `Cargo.toml` at `root`.
@@ -2491,7 +2493,9 @@ pub fn read_autumn_web_version_at(root: &std::path::Path) -> Option<String> {
         .into_iter()
         .find_map(|declaration| match declaration {
             AutumnWebDependency::Version(version) => Some(version),
-            AutumnWebDependency::Absent | AutumnWebDependency::WithoutVersion => None,
+            AutumnWebDependency::Absent
+            | AutumnWebDependency::WithoutVersion
+            | AutumnWebDependency::Inherited => None,
         })
 }
 
@@ -2532,11 +2536,9 @@ pub fn autumn_web_declarations_at(root: &std::path::Path) -> Vec<AutumnWebDepend
                 .map_or_else(
                     || {
                         if table.get("workspace").and_then(toml::Value::as_bool) == Some(true) {
-                            // `{ workspace = true }` inherits the root's
-                            // `[workspace.dependencies]` entry, which is read
-                            // separately — this manifest adds no version of
-                            // its own.
-                            AutumnWebDependency::Absent
+                            // Resolved against the enclosing workspace, which
+                            // is not necessarily inside the scanned tree.
+                            AutumnWebDependency::Inherited
                         } else {
                             // A path or git entry: declared, no version to read.
                             AutumnWebDependency::WithoutVersion
@@ -2582,10 +2584,41 @@ pub fn autumn_web_declarations_at(root: &std::path::Path) -> Vec<AutumnWebDepend
                 .filter(|(key, entry)| is_autumn_web(key, entry))
                 .map(|(_, entry)| classify(entry))
         })
-        // `Absent` here means "inherits the workspace entry", which is read on
-        // its own — it is not a declaration this manifest contributes.
         .filter(|declaration| *declaration != AutumnWebDependency::Absent)
         .collect()
+}
+
+/// The `[workspace.dependencies]` entry for `autumn-web` in the `Cargo.toml` at
+/// `dir`, if that manifest defines a workspace at all.
+///
+/// Used to resolve `{ workspace = true }` when `autumn upgrade` is pointed at a
+/// member directory: Cargo walks up to the workspace root, and so must this.
+pub fn workspace_dependency_at(dir: &std::path::Path) -> Option<AutumnWebDependency> {
+    let content = std::fs::read_to_string(dir.join("Cargo.toml")).ok()?;
+    let table = toml::from_str::<toml::Table>(&content).ok()?;
+    let entry = table
+        .get("workspace")?
+        .get("dependencies")?
+        .as_table()?
+        .iter()
+        .find(|(key, entry)| {
+            *key == "autumn-web"
+                || entry
+                    .get("package")
+                    .and_then(toml::Value::as_str)
+                    .is_some_and(|package| package == "autumn-web")
+        })
+        .map(|(_, entry)| entry)?;
+    Some(match entry {
+        toml::Value::String(version) => AutumnWebDependency::Version(version.clone()),
+        toml::Value::Table(table) => table
+            .get("version")
+            .and_then(toml::Value::as_str)
+            .map_or(AutumnWebDependency::WithoutVersion, |version| {
+                AutumnWebDependency::Version(version.to_owned())
+            }),
+        _ => AutumnWebDependency::WithoutVersion,
+    })
 }
 
 /// Try to TCP-connect to a host:port within a short timeout.

--- a/autumn-cli/src/doctor.rs
+++ b/autumn-cli/src/doctor.rs
@@ -2463,24 +2463,69 @@ fn read_autumn_web_version() -> Option<String> {
     read_autumn_web_version_at(std::path::Path::new("."))
 }
 
+/// How a manifest declares `autumn-web`, if it does.
+///
+/// `autumn upgrade` needs the middle case told apart from the absent one: a
+/// `{ path = "../autumn" }` or `{ git = "..." }` dependency *is* a declaration,
+/// it just carries no version to compare. Treating it as "not declared" lets a
+/// sibling manifest pick the floor for a crate whose version is unknown.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AutumnWebDependency {
+    /// The manifest does not mention `autumn-web`.
+    Absent,
+    /// Declared with a version requirement.
+    Version(String),
+    /// Declared, but with no version to read — a path or git entry.
+    /// (`{ workspace = true }` is [`Absent`](Self::Absent): it inherits the
+    /// root entry, which is read on its own.)
+    WithoutVersion,
+}
+
 /// Read the `autumn-web` version requirement from the `Cargo.toml` at `root`.
 ///
 /// Shared with `autumn upgrade`, which needs the same answer for a directory
 /// it was pointed at rather than the process's working directory.
 pub fn read_autumn_web_version_at(root: &std::path::Path) -> Option<String> {
-    let content = std::fs::read_to_string(root.join("Cargo.toml")).ok()?;
-    let table: toml::Table = toml::from_str(&content).ok()?;
+    match read_autumn_web_dependency_at(root) {
+        AutumnWebDependency::Version(version) => Some(version),
+        AutumnWebDependency::Absent | AutumnWebDependency::WithoutVersion => None,
+    }
+}
 
-    let find_in_deps = |deps: &toml::Value| -> Option<String> {
+/// As [`read_autumn_web_version_at`], but distinguishing a declaration with no
+/// readable version from no declaration at all.
+pub fn read_autumn_web_dependency_at(root: &std::path::Path) -> AutumnWebDependency {
+    let Ok(content) = std::fs::read_to_string(root.join("Cargo.toml")) else {
+        return AutumnWebDependency::Absent;
+    };
+    let Ok(table) = toml::from_str::<toml::Table>(&content) else {
+        return AutumnWebDependency::Absent;
+    };
+
+    let find_in_deps = |deps: &toml::Value| -> Option<AutumnWebDependency> {
         let entry = deps.get("autumn-web")?;
-        match entry {
-            toml::Value::String(v) => Some(v.clone()),
-            toml::Value::Table(t) => t
-                .get("version")?
-                .as_str()
-                .map(std::borrow::ToOwned::to_owned),
-            _ => None,
-        }
+        Some(match entry {
+            toml::Value::String(version) => AutumnWebDependency::Version(version.clone()),
+            toml::Value::Table(table) => table
+                .get("version")
+                .and_then(toml::Value::as_str)
+                .map_or_else(
+                    || {
+                        if table.get("workspace").and_then(toml::Value::as_bool) == Some(true) {
+                            // `{ workspace = true }` inherits the root's
+                            // `[workspace.dependencies]` entry, which is read
+                            // separately — this manifest adds no version of
+                            // its own.
+                            AutumnWebDependency::Absent
+                        } else {
+                            // A path or git entry: declared, no version to read.
+                            AutumnWebDependency::WithoutVersion
+                        }
+                    },
+                    |version| AutumnWebDependency::Version(version.to_owned()),
+                ),
+            _ => AutumnWebDependency::WithoutVersion,
+        })
     };
 
     // [dependencies], then [workspace.dependencies], then any
@@ -2505,6 +2550,7 @@ pub fn read_autumn_web_version_at(root: &std::path::Path) -> Option<String> {
                 .filter_map(|target| target.get("dependencies"))
                 .find_map(&find_in_deps)
         })
+        .unwrap_or(AutumnWebDependency::Absent)
 }
 
 /// Try to TCP-connect to a host:port within a short timeout.

--- a/autumn-cli/src/doctor.rs
+++ b/autumn-cli/src/doctor.rs
@@ -2483,15 +2483,27 @@ pub fn read_autumn_web_version_at(root: &std::path::Path) -> Option<String> {
         }
     };
 
-    // [dependencies] then [workspace.dependencies]
+    // [dependencies], then [workspace.dependencies], then any
+    // [target.'cfg(...)'.dependencies] — Cargo honours all three, so a version
+    // declared only under a target table is a real declaration and reporting
+    // "cannot determine the version" for it would be wrong. Same traversal
+    // `autumn console` documents for its dependency scan.
     table
         .get("dependencies")
-        .and_then(find_in_deps)
+        .and_then(&find_in_deps)
         .or_else(|| {
             table
                 .get("workspace")
-                .and_then(|w| w.get("dependencies"))
-                .and_then(find_in_deps)
+                .and_then(|workspace| workspace.get("dependencies"))
+                .and_then(&find_in_deps)
+        })
+        .or_else(|| {
+            table
+                .get("target")?
+                .as_table()?
+                .values()
+                .filter_map(|target| target.get("dependencies"))
+                .find_map(&find_in_deps)
         })
 }
 

--- a/autumn-cli/src/doctor.rs
+++ b/autumn-cli/src/doctor.rs
@@ -2477,6 +2477,13 @@ pub enum AutumnWebDependency {
     Version(String),
     /// Declared, but with no version to read — a path or git entry.
     WithoutVersion,
+    /// The manifest exists but could not be read or parsed.
+    ///
+    /// Distinct from [`Self::Absent`] on purpose: a crate whose manifest cannot
+    /// be read may well be the oldest in the workspace, and reading it as
+    /// "declares nothing" lets a newer sibling decide the floor while this
+    /// crate's sources are scanned and rewritten anyway.
+    Unreadable,
     /// `{ workspace = true }`: the version lives in the enclosing workspace's
     /// `[workspace.dependencies]`, which may be in an *ancestor* directory when
     /// the command is pointed at a member rather than the workspace root.
@@ -2500,6 +2507,7 @@ pub fn read_autumn_web_version_at(root: &std::path::Path) -> Option<String> {
         .find_map(|declaration| match declaration {
             AutumnWebDependency::Version(version) => Some(version),
             AutumnWebDependency::Absent
+            | AutumnWebDependency::Unreadable
             | AutumnWebDependency::WithoutVersion
             | AutumnWebDependency::Inherited(_) => None,
         })
@@ -2564,11 +2572,18 @@ pub fn autumn_web_declarations_at(root: &std::path::Path) -> Vec<AutumnWebDepend
         }
     }
 
-    let Ok(content) = std::fs::read_to_string(root.join("Cargo.toml")) else {
-        return Vec::new();
+    let manifest = root.join("Cargo.toml");
+    let Ok(content) = std::fs::read_to_string(&manifest) else {
+        // No manifest at all is a directory that is not a crate. One that
+        // exists and cannot be read is a crate whose version is unknown.
+        return if manifest.exists() {
+            vec![AutumnWebDependency::Unreadable]
+        } else {
+            Vec::new()
+        };
     };
     let Ok(table) = toml::from_str::<toml::Table>(&content) else {
-        return Vec::new();
+        return vec![AutumnWebDependency::Unreadable];
     };
 
     // Every dependency table Cargo reads: the package's own, the workspace's,

--- a/autumn-cli/src/doctor.rs
+++ b/autumn-cli/src/doctor.rs
@@ -2508,6 +2508,12 @@ pub fn read_autumn_web_version_at(root: &std::path::Path) -> Option<String> {
 ///
 /// An empty result means the manifest does not mention `autumn-web` at all.
 pub fn autumn_web_declarations_at(root: &std::path::Path) -> Vec<AutumnWebDependency> {
+    /// Every dependency-table kind Cargo reads. `dev-` and `build-` count: a
+    /// crate depending on autumn-web only for its tests or its `build.rs` still
+    /// has those sources scanned and rewritten, so it gets a vote on the
+    /// version.
+    const KINDS: [&str; 3] = ["dependencies", "dev-dependencies", "build-dependencies"];
+
     /// Whether this dependency entry is `autumn-web`, under either spelling.
     fn is_autumn_web(key: &str, entry: &toml::Value) -> bool {
         key == "autumn-web"
@@ -2550,20 +2556,22 @@ pub fn autumn_web_declarations_at(root: &std::path::Path) -> Vec<AutumnWebDepend
     };
 
     // Every dependency table Cargo reads: the package's own, the workspace's,
-    // and one per target predicate.
+    // and one per target predicate — in each of the three kinds.
     let mut tables: Vec<&toml::Value> = Vec::new();
-    tables.extend(table.get("dependencies"));
-    tables.extend(
-        table
-            .get("workspace")
-            .and_then(|workspace| workspace.get("dependencies")),
-    );
-    if let Some(targets) = table.get("target").and_then(toml::Value::as_table) {
+    for kind in KINDS {
+        tables.extend(table.get(kind));
         tables.extend(
-            targets
-                .values()
-                .filter_map(|target| target.get("dependencies")),
+            table
+                .get("workspace")
+                .and_then(|workspace| workspace.get(kind)),
         );
+    }
+    if let Some(targets) = table.get("target").and_then(toml::Value::as_table) {
+        for target in targets.values() {
+            for kind in KINDS {
+                tables.extend(target.get(kind));
+            }
+        }
     }
 
     tables

--- a/autumn-cli/src/doctor.rs
+++ b/autumn-cli/src/doctor.rs
@@ -2480,7 +2480,13 @@ pub enum AutumnWebDependency {
     /// `{ workspace = true }`: the version lives in the enclosing workspace's
     /// `[workspace.dependencies]`, which may be in an *ancestor* directory when
     /// the command is pointed at a member rather than the workspace root.
-    Inherited,
+    ///
+    /// Carries the *key* the member used, because that is the only handle on
+    /// the entry: under Cargo's renamed form the member writes `autumn =
+    /// { workspace = true }` and nothing but the workspace entry it points at
+    /// says the package is `autumn-web`. Resolve it with
+    /// [`workspace_dependency_for`].
+    Inherited(String),
 }
 
 /// Read the `autumn-web` version requirement from the `Cargo.toml` at `root`.
@@ -2495,7 +2501,7 @@ pub fn read_autumn_web_version_at(root: &std::path::Path) -> Option<String> {
             AutumnWebDependency::Version(version) => Some(version),
             AutumnWebDependency::Absent
             | AutumnWebDependency::WithoutVersion
-            | AutumnWebDependency::Inherited => None,
+            | AutumnWebDependency::Inherited(_) => None,
         })
 }
 
@@ -2527,7 +2533,15 @@ pub fn autumn_web_declarations_at(root: &std::path::Path) -> Vec<AutumnWebDepend
                 .is_some_and(|package| package == "autumn-web")
     }
 
-    fn classify(entry: &toml::Value) -> AutumnWebDependency {
+    /// Whether this entry defers to the enclosing workspace.
+    fn is_inherited(entry: &toml::Value) -> bool {
+        entry
+            .get("workspace")
+            .and_then(toml::Value::as_bool)
+            .unwrap_or(false)
+    }
+
+    fn classify(key: &str, entry: &toml::Value) -> AutumnWebDependency {
         match entry {
             toml::Value::String(version) => AutumnWebDependency::Version(version.clone()),
             toml::Value::Table(table) => table
@@ -2538,7 +2552,7 @@ pub fn autumn_web_declarations_at(root: &std::path::Path) -> Vec<AutumnWebDepend
                         if table.get("workspace").and_then(toml::Value::as_bool) == Some(true) {
                             // Resolved against the enclosing workspace, which
                             // is not necessarily inside the scanned tree.
-                            AutumnWebDependency::Inherited
+                            AutumnWebDependency::Inherited(key.to_owned())
                         } else {
                             // A path or git entry: declared, no version to read.
                             AutumnWebDependency::WithoutVersion
@@ -2581,19 +2595,29 @@ pub fn autumn_web_declarations_at(root: &std::path::Path) -> Vec<AutumnWebDepend
         .filter_map(toml::Value::as_table)
         .flat_map(|deps| {
             deps.iter()
-                .filter(|(key, entry)| is_autumn_web(key, entry))
-                .map(|(_, entry)| classify(entry))
+                // Inherited entries come along under *any* key: a member
+                // writing `autumn = { workspace = true }` names neither
+                // `autumn-web` nor a `package`, so whether it is this
+                // dependency can only be answered by the workspace entry it
+                // points at. The caller resolves them and drops the ones that
+                // turn out to be some other crate.
+                .filter(|(key, entry)| is_autumn_web(key, entry) || is_inherited(entry))
+                .map(|(key, entry)| classify(key, entry))
         })
         .filter(|declaration| *declaration != AutumnWebDependency::Absent)
         .collect()
 }
 
-/// The `[workspace.dependencies]` entry for `autumn-web` in the `Cargo.toml` at
-/// `dir`, if that manifest defines a workspace at all.
+/// The `[workspace.dependencies]` entry named `key` in the `Cargo.toml` at
+/// `dir`, but only when that entry resolves to `autumn-web`.
 ///
 /// Used to resolve `{ workspace = true }` when `autumn upgrade` is pointed at a
 /// member directory: Cargo walks up to the workspace root, and so must this.
-pub fn workspace_dependency_at(dir: &std::path::Path) -> Option<AutumnWebDependency> {
+/// The lookup is by the member's key rather than by the crate name because a
+/// renamed workspace entry — `autumn = { package = "autumn-web", … }` — is the
+/// only place the real package is written down. `None` means the workspace does
+/// not define `key`, or defines it as a different crate.
+pub fn workspace_dependency_for(dir: &std::path::Path, key: &str) -> Option<AutumnWebDependency> {
     let content = std::fs::read_to_string(dir.join("Cargo.toml")).ok()?;
     let table = toml::from_str::<toml::Table>(&content).ok()?;
     let entry = table
@@ -2601,12 +2625,13 @@ pub fn workspace_dependency_at(dir: &std::path::Path) -> Option<AutumnWebDepende
         .get("dependencies")?
         .as_table()?
         .iter()
-        .find(|(key, entry)| {
-            *key == "autumn-web"
-                || entry
-                    .get("package")
-                    .and_then(toml::Value::as_str)
-                    .is_some_and(|package| package == "autumn-web")
+        .find(|(candidate, entry)| {
+            *candidate == key
+                && (key == "autumn-web"
+                    || entry
+                        .get("package")
+                        .and_then(toml::Value::as_str)
+                        .is_some_and(|package| package == "autumn-web"))
         })
         .map(|(_, entry)| entry)?;
     Some(match entry {

--- a/autumn-cli/src/doctor.rs
+++ b/autumn-cli/src/doctor.rs
@@ -2460,7 +2460,15 @@ fn read_msrv() -> Option<String> {
 
 /// Read the `autumn-web` version requirement from the project's `Cargo.toml`.
 fn read_autumn_web_version() -> Option<String> {
-    let content = std::fs::read_to_string("Cargo.toml").ok()?;
+    read_autumn_web_version_at(std::path::Path::new("."))
+}
+
+/// Read the `autumn-web` version requirement from the `Cargo.toml` at `root`.
+///
+/// Shared with `autumn upgrade`, which needs the same answer for a directory
+/// it was pointed at rather than the process's working directory.
+pub fn read_autumn_web_version_at(root: &std::path::Path) -> Option<String> {
+    let content = std::fs::read_to_string(root.join("Cargo.toml")).ok()?;
     let table: toml::Table = toml::from_str(&content).ok()?;
 
     let find_in_deps = |deps: &toml::Value| -> Option<String> {

--- a/autumn-cli/src/doctor.rs
+++ b/autumn-cli/src/doctor.rs
@@ -2483,28 +2483,42 @@ pub enum AutumnWebDependency {
 
 /// Read the `autumn-web` version requirement from the `Cargo.toml` at `root`.
 ///
-/// Shared with `autumn upgrade`, which needs the same answer for a directory
-/// it was pointed at rather than the process's working directory.
+/// The first readable version across every dependency table. Callers that need
+/// *all* of them — `autumn upgrade`, which takes the oldest floor — use
+/// [`autumn_web_declarations_at`] instead.
 pub fn read_autumn_web_version_at(root: &std::path::Path) -> Option<String> {
-    match read_autumn_web_dependency_at(root) {
-        AutumnWebDependency::Version(version) => Some(version),
-        AutumnWebDependency::Absent | AutumnWebDependency::WithoutVersion => None,
-    }
+    autumn_web_declarations_at(root)
+        .into_iter()
+        .find_map(|declaration| match declaration {
+            AutumnWebDependency::Version(version) => Some(version),
+            AutumnWebDependency::Absent | AutumnWebDependency::WithoutVersion => None,
+        })
 }
 
-/// As [`read_autumn_web_version_at`], but distinguishing a declaration with no
-/// readable version from no declaration at all.
-pub fn read_autumn_web_dependency_at(root: &std::path::Path) -> AutumnWebDependency {
-    let Ok(content) = std::fs::read_to_string(root.join("Cargo.toml")) else {
-        return AutumnWebDependency::Absent;
-    };
-    let Ok(table) = toml::from_str::<toml::Table>(&content) else {
-        return AutumnWebDependency::Absent;
-    };
+/// Every `autumn-web` declaration in the `Cargo.toml` at `root`.
+///
+/// All of them, not the first: a manifest can declare the dependency under
+/// `[dependencies]`, `[workspace.dependencies]`, and any number of
+/// `[target.'cfg(…)'.dependencies]` tables, and Cargo honours each. Returning
+/// the first match let a newer target-specific requirement hide an older one
+/// while the older target's `#[cfg]` code was still scanned and rewritten.
+///
+/// Both spellings are recognised: the literal `autumn-web` key, and Cargo's
+/// renamed form `autumn_web = { package = "autumn-web", version = "…" }`.
+///
+/// An empty result means the manifest does not mention `autumn-web` at all.
+pub fn autumn_web_declarations_at(root: &std::path::Path) -> Vec<AutumnWebDependency> {
+    /// Whether this dependency entry is `autumn-web`, under either spelling.
+    fn is_autumn_web(key: &str, entry: &toml::Value) -> bool {
+        key == "autumn-web"
+            || entry
+                .get("package")
+                .and_then(toml::Value::as_str)
+                .is_some_and(|package| package == "autumn-web")
+    }
 
-    let find_in_deps = |deps: &toml::Value| -> Option<AutumnWebDependency> {
-        let entry = deps.get("autumn-web")?;
-        Some(match entry {
+    fn classify(entry: &toml::Value) -> AutumnWebDependency {
+        match entry {
             toml::Value::String(version) => AutumnWebDependency::Version(version.clone()),
             toml::Value::Table(table) => table
                 .get("version")
@@ -2525,32 +2539,45 @@ pub fn read_autumn_web_dependency_at(root: &std::path::Path) -> AutumnWebDepende
                     |version| AutumnWebDependency::Version(version.to_owned()),
                 ),
             _ => AutumnWebDependency::WithoutVersion,
-        })
+        }
+    }
+
+    let Ok(content) = std::fs::read_to_string(root.join("Cargo.toml")) else {
+        return Vec::new();
+    };
+    let Ok(table) = toml::from_str::<toml::Table>(&content) else {
+        return Vec::new();
     };
 
-    // [dependencies], then [workspace.dependencies], then any
-    // [target.'cfg(...)'.dependencies] — Cargo honours all three, so a version
-    // declared only under a target table is a real declaration and reporting
-    // "cannot determine the version" for it would be wrong. Same traversal
-    // `autumn console` documents for its dependency scan.
-    table
-        .get("dependencies")
-        .and_then(&find_in_deps)
-        .or_else(|| {
-            table
-                .get("workspace")
-                .and_then(|workspace| workspace.get("dependencies"))
-                .and_then(&find_in_deps)
-        })
-        .or_else(|| {
-            table
-                .get("target")?
-                .as_table()?
+    // Every dependency table Cargo reads: the package's own, the workspace's,
+    // and one per target predicate.
+    let mut tables: Vec<&toml::Value> = Vec::new();
+    tables.extend(table.get("dependencies"));
+    tables.extend(
+        table
+            .get("workspace")
+            .and_then(|workspace| workspace.get("dependencies")),
+    );
+    if let Some(targets) = table.get("target").and_then(toml::Value::as_table) {
+        tables.extend(
+            targets
                 .values()
-                .filter_map(|target| target.get("dependencies"))
-                .find_map(&find_in_deps)
+                .filter_map(|target| target.get("dependencies")),
+        );
+    }
+
+    tables
+        .into_iter()
+        .filter_map(toml::Value::as_table)
+        .flat_map(|deps| {
+            deps.iter()
+                .filter(|(key, entry)| is_autumn_web(key, entry))
+                .map(|(_, entry)| classify(entry))
         })
-        .unwrap_or(AutumnWebDependency::Absent)
+        // `Absent` here means "inherits the workspace entry", which is read on
+        // its own — it is not a declaration this manifest contributes.
+        .filter(|declaration| *declaration != AutumnWebDependency::Absent)
+        .collect()
 }
 
 /// Try to TCP-connect to a host:port within a short timeout.

--- a/autumn-cli/src/main.rs
+++ b/autumn-cli/src/main.rs
@@ -267,26 +267,26 @@ struct Cli {
 /// argument-parsing tests overflow. An `Args` struct moves this command's share
 /// into `UpgradeArgs::augment_args`, which gets its own frame and pops.
 #[derive(clap::Args, Debug)]
-pub struct UpgradeArgs {
+struct UpgradeArgs {
     /// Project directory to migrate (defaults to the current directory).
     #[arg(value_name = "PATH", default_value = ".")]
-    pub path: String,
+    path: String,
     /// Release this app is upgrading from. Defaults to the `autumn-web`
     /// requirement recorded in the project's `Cargo.toml`.
     #[arg(long, value_name = "VERSION")]
-    pub from: Option<String>,
+    from: Option<String>,
     /// Release to upgrade to. Defaults to this CLI's own version.
     #[arg(long, value_name = "VERSION")]
-    pub to: Option<String>,
+    to: Option<String>,
     /// Write the rewrites. Without it the command only previews them.
     #[arg(long)]
-    pub apply: bool,
+    apply: bool,
     /// Emit the machine-readable report instead of the human one.
     #[arg(long)]
-    pub json: bool,
+    json: bool,
     /// List the shipped app-code migrations and exit without scanning.
     #[arg(long = "list-migrations")]
-    pub list_migrations: bool,
+    list_migrations: bool,
 }
 
 /// Available subcommands.

--- a/autumn-cli/src/main.rs
+++ b/autumn-cli/src/main.rs
@@ -257,6 +257,38 @@ struct Cli {
     command: Commands,
 }
 
+/// Arguments for [`Commands::Upgrade`].
+///
+/// A separate `Args` struct rather than inline variant fields, deliberately.
+/// clap's derive builds every inline field of every variant inside one
+/// `Commands::augment_subcommands` frame, and with this many subcommands that
+/// frame is within a kilobyte of libtest's 2 MiB thread stack — close enough
+/// that a codegen difference between two rustc builds decides whether the
+/// argument-parsing tests overflow. An `Args` struct moves this command's share
+/// into `UpgradeArgs::augment_args`, which gets its own frame and pops.
+#[derive(clap::Args, Debug)]
+pub struct UpgradeArgs {
+    /// Project directory to migrate (defaults to the current directory).
+    #[arg(value_name = "PATH", default_value = ".")]
+    pub path: String,
+    /// Release this app is upgrading from. Defaults to the `autumn-web`
+    /// requirement recorded in the project's `Cargo.toml`.
+    #[arg(long, value_name = "VERSION")]
+    pub from: Option<String>,
+    /// Release to upgrade to. Defaults to this CLI's own version.
+    #[arg(long, value_name = "VERSION")]
+    pub to: Option<String>,
+    /// Write the rewrites. Without it the command only previews them.
+    #[arg(long)]
+    pub apply: bool,
+    /// Emit the machine-readable report instead of the human one.
+    #[arg(long)]
+    pub json: bool,
+    /// List the shipped app-code migrations and exit without scanning.
+    #[arg(long = "list-migrations")]
+    pub list_migrations: bool,
+}
+
 /// Available subcommands.
 #[derive(Subcommand)]
 enum Commands {
@@ -395,27 +427,7 @@ enum Commands {
     ///   autumn upgrade --list-migrations   # what ships today
     #[allow(clippy::doc_markdown)]
     #[command(verbatim_doc_comment)]
-    Upgrade {
-        /// Project directory to migrate (defaults to the current directory).
-        #[arg(value_name = "PATH", default_value = ".")]
-        path: String,
-        /// Release this app is upgrading from. Defaults to the `autumn-web`
-        /// requirement recorded in the project's `Cargo.toml`.
-        #[arg(long, value_name = "VERSION")]
-        from: Option<String>,
-        /// Release to upgrade to. Defaults to this CLI's own version.
-        #[arg(long, value_name = "VERSION")]
-        to: Option<String>,
-        /// Write the rewrites. Without it the command only previews them.
-        #[arg(long)]
-        apply: bool,
-        /// Emit the machine-readable report instead of the human one.
-        #[arg(long)]
-        json: bool,
-        /// List the shipped app-code migrations and exit without scanning.
-        #[arg(long = "list-migrations")]
-        list_migrations: bool,
-    },
+    Upgrade(UpgradeArgs),
     /// Run or inspect database migrations
     Migrate {
         #[command(subcommand)]
@@ -3471,14 +3483,14 @@ fn run_command(command: Commands) {
                 std::process::exit(1);
             }
         }
-        Commands::Upgrade {
+        Commands::Upgrade(UpgradeArgs {
             path,
             from,
             to,
             apply,
             json,
             list_migrations,
-        } => {
+        }) => {
             let code = upgrade::run_in(
                 std::path::Path::new(&path),
                 &upgrade::UpgradeOptions {

--- a/autumn-cli/src/main.rs
+++ b/autumn-cli/src/main.rs
@@ -52,6 +52,7 @@ mod task;
 mod test_cmd;
 mod text_width;
 mod token;
+mod upgrade;
 mod webhook;
 /// Subcommands for `autumn check`.
 #[derive(Subcommand, Clone, Debug, PartialEq, Eq)]
@@ -372,6 +373,48 @@ enum Commands {
     Assets {
         #[command(subcommand)]
         action: AssetsCommands,
+    },
+    /// Apply a release's mechanical app-code migrations to your own source.
+    ///
+    /// For each release between the `autumn-web` version this app records and
+    /// the target, `autumn upgrade` applies that release's machine-applyable
+    /// migrations -- today, API renames -- to the app's own Rust code.
+    ///
+    /// It writes nothing by default: a bare `autumn upgrade` prints a per-file
+    /// diff plus a count of affected sites, and `--apply` is the explicit write
+    /// step. Anything it cannot safely rewrite (a call site inside a macro
+    /// invocation, or a change with no mechanical form) is listed with its
+    /// location and a link to the guide section, never guessed at.
+    ///
+    /// Run it BEFORE bumping the `autumn-web` dependency: the release it
+    /// migrates *from* is the one the project manifest records. If the bump
+    /// already happened, pass `--from <previous-version>`.
+    ///
+    ///   autumn upgrade                     # preview
+    ///   autumn upgrade --apply             # write the rewrites
+    ///   autumn upgrade --list-migrations   # what ships today
+    #[allow(clippy::doc_markdown)]
+    #[command(verbatim_doc_comment)]
+    Upgrade {
+        /// Project directory to migrate (defaults to the current directory).
+        #[arg(value_name = "PATH", default_value = ".")]
+        path: String,
+        /// Release this app is upgrading from. Defaults to the `autumn-web`
+        /// requirement recorded in the project's `Cargo.toml`.
+        #[arg(long, value_name = "VERSION")]
+        from: Option<String>,
+        /// Release to upgrade to. Defaults to this CLI's own version.
+        #[arg(long, value_name = "VERSION")]
+        to: Option<String>,
+        /// Write the rewrites. Without it the command only previews them.
+        #[arg(long)]
+        apply: bool,
+        /// Emit the machine-readable report instead of the human one.
+        #[arg(long)]
+        json: bool,
+        /// List the shipped app-code migrations and exit without scanning.
+        #[arg(long = "list-migrations")]
+        list_migrations: bool,
     },
     /// Run or inspect database migrations
     Migrate {
@@ -3427,6 +3470,26 @@ fn run_command(command: Commands) {
                 );
                 std::process::exit(1);
             }
+        }
+        Commands::Upgrade {
+            path,
+            from,
+            to,
+            apply,
+            json,
+            list_migrations,
+        } => {
+            let code = upgrade::run_in(
+                std::path::Path::new(&path),
+                &upgrade::UpgradeOptions {
+                    from,
+                    to,
+                    apply,
+                    json,
+                    list: list_migrations,
+                },
+            );
+            std::process::exit(code);
         }
         Commands::Doctor {
             json,

--- a/autumn-cli/src/upgrade/diff.rs
+++ b/autumn-cli/src/upgrade/diff.rs
@@ -1,0 +1,123 @@
+//! Per-file preview rendering for `autumn upgrade` (issue #1629).
+//!
+//! `autumn upgrade` writes nothing by default, so the diff *is* the product of
+//! the default invocation. It stays deliberately small: the rewrites this
+//! command ships are identifier renames, which never add or remove a line, so a
+//! line-for-line comparison is exact and no LCS machinery is needed. The
+//! degenerate case where the line counts do differ is still rendered (as one
+//! hunk from the first divergence) rather than trusted away.
+
+/// Render a unified-ish diff of `original` → `updated`.
+///
+/// Returns an empty string when the two are identical.
+pub fn render(original: &str, updated: &str) -> String {
+    use std::fmt::Write as _;
+
+    if original == updated {
+        return String::new();
+    }
+    let before: Vec<&str> = original.lines().collect();
+    let after: Vec<&str> = updated.lines().collect();
+
+    if before.len() != after.len() {
+        // Not reachable from an identifier rename, which cannot add or remove a
+        // line. Rendered rather than asserted away so a future rewrite kind
+        // that *does* change the shape still previews something honest.
+        let first = (0..before.len().min(after.len()))
+            .find(|&index| before[index] != after[index])
+            .unwrap_or_else(|| before.len().min(after.len()));
+        let span = (before.len() - first).max(after.len() - first);
+        let mut out = header(first + 1, first + span);
+        for line in &before[first..] {
+            let _ = writeln!(out, "-{line}");
+        }
+        for line in &after[first..] {
+            let _ = writeln!(out, "+{line}");
+        }
+        return out;
+    }
+
+    let changed: Vec<usize> = (0..before.len())
+        .filter(|&index| before[index] != after[index])
+        .collect();
+
+    let mut out = String::new();
+    let mut cursor = 0;
+    while cursor < changed.len() {
+        // One hunk per run of consecutive changed lines.
+        let mut end = cursor;
+        while end + 1 < changed.len() && changed[end + 1] == changed[end] + 1 {
+            end += 1;
+        }
+        out.push_str(&header(changed[cursor] + 1, changed[end] + 1));
+        for &index in &changed[cursor..=end] {
+            let _ = writeln!(out, "-{}", before[index]);
+        }
+        for &index in &changed[cursor..=end] {
+            let _ = writeln!(out, "+{}", after[index]);
+        }
+        cursor = end + 1;
+    }
+    out
+}
+
+/// `@@ line 12 @@` for one line, `@@ lines 12-14 @@` for a run.
+fn header(first: usize, last: usize) -> String {
+    if first >= last {
+        format!("@@ line {first} @@\n")
+    } else {
+        format!("@@ lines {first}-{last} @@\n")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn identical_input_renders_nothing() {
+        assert_eq!(render("a\nb\n", "a\nb\n"), "");
+    }
+
+    #[test]
+    fn renders_a_single_changed_line_with_its_number() {
+        let out = render(
+            "fn f() {\n    let r = Repo::with_pool(p);\n}\n",
+            "fn f() {\n    let r = Repo::with_pool_untracked(p);\n}\n",
+        );
+        assert_eq!(
+            out,
+            "@@ line 2 @@\n-    let r = Repo::with_pool(p);\n+    let r = Repo::with_pool_untracked(p);\n"
+        );
+    }
+
+    #[test]
+    fn groups_adjacent_changed_lines_into_one_hunk() {
+        let out = render("a\nb\nc\n", "a\nB\nC\n");
+        assert_eq!(out, "@@ lines 2-3 @@\n-b\n-c\n+B\n+C\n");
+    }
+
+    #[test]
+    fn separates_non_adjacent_changes_into_their_own_hunks() {
+        let out = render("a\nb\nc\nd\n", "A\nb\nc\nD\n");
+        assert_eq!(out, "@@ line 1 @@\n-a\n+A\n@@ line 4 @@\n-d\n+D\n");
+    }
+
+    #[test]
+    fn renders_a_line_count_change_as_one_hunk_from_the_first_divergence() {
+        let out = render("a\nb\n", "a\nb\nc\n");
+        assert!(
+            out.starts_with("@@ line 3 @@"),
+            "unexpected rendering: {out}"
+        );
+        assert!(out.contains("+c"), "unexpected rendering: {out}");
+    }
+
+    #[test]
+    fn strips_carriage_returns_from_displayed_lines() {
+        // The file keeps its CRLF; showing a stray `\r` in the terminal does not
+        // help anyone read the diff.
+        let out = render("a\r\nb\r\n", "a\r\nB\r\n");
+        assert_eq!(out, "@@ line 2 @@\n-b\n+B\n");
+    }
+}

--- a/autumn-cli/src/upgrade/engine.rs
+++ b/autumn-cli/src/upgrade/engine.rs
@@ -490,13 +490,44 @@ fn takes_arguments(trees: &[TokenTree], index: usize, want: usize) -> bool {
 fn count_arguments(group: &proc_macro2::Group) -> usize {
     let mut arguments = 0;
     let mut in_argument = false;
+    // Angle brackets are not a `Group`, so the comma in
+    // `with_pool(make_pool::<Primary, Replica>())` sits at the same token level
+    // as a real argument separator. Depth is tracked only for a *turbofish*
+    // `::<`, which is unambiguous: opening on any bare `<` would let a
+    // comparison (`f(a < b, c)`) swallow the separator after it and undercount,
+    // and undercounting is the direction that produces a wrong edit. Other
+    // comma-bearing generic syntax still overcounts, which reports the site
+    // instead of rewriting it — the safe way to be wrong.
+    let mut generics = 0usize;
+    let mut previous_colons = 0usize;
+
     for tree in group.stream() {
         match &tree {
-            TokenTree::Punct(punct) if punct.as_char() == ',' => {
+            TokenTree::Punct(punct) if punct.as_char() == ',' && generics == 0 => {
                 arguments += 1;
                 in_argument = false;
+                previous_colons = 0;
             }
-            _ => in_argument = true,
+            TokenTree::Punct(punct) => {
+                in_argument = true;
+                match punct.as_char() {
+                    ':' => previous_colons += 1,
+                    '<' if previous_colons >= 2 => {
+                        generics += 1;
+                        previous_colons = 0;
+                    }
+                    // The `>` of a `->` closes nothing.
+                    '>' if generics > 0 => {
+                        generics -= 1;
+                        previous_colons = 0;
+                    }
+                    _ => previous_colons = 0,
+                }
+            }
+            _ => {
+                in_argument = true;
+                previous_colons = 0;
+            }
         }
     }
     // A trailing comma closes the last argument rather than opening one.
@@ -677,6 +708,26 @@ mod tests {
         let path_form =
             rewrite_source("fn f(p: P) { B::old_step(p); }", &[&METHOD_RENAME]).expect("parses");
         assert_eq!(path_form.updated, None, "a method rename leaves `::` alone");
+    }
+
+    #[test]
+    fn a_turbofish_inside_the_argument_does_not_inflate_the_arity() {
+        // The comma in `::<Primary, Replica>` is not an argument separator.
+        let out =
+            rewritten("fn f() { PgPostRepository::with_pool(make_pool::<Primary, Replica>()); }");
+        assert!(
+            out.contains("with_pool_untracked(make_pool::<Primary, Replica>())"),
+            "{out}"
+        );
+    }
+
+    #[test]
+    fn a_comparison_in_the_argument_does_not_hide_a_separator() {
+        // Undercounting is the direction that produces a wrong edit, so a bare
+        // `<` must not open generic depth: this two-argument call stays a
+        // two-argument call and is left alone.
+        let result = run("fn f() { PgPostRepository::with_pool(a < b, pool); }");
+        assert_eq!(result.updated, None);
     }
 
     #[test]

--- a/autumn-cli/src/upgrade/engine.rs
+++ b/autumn-cli/src/upgrade/engine.rs
@@ -33,6 +33,11 @@ pub enum ManualReason {
     Macro,
     /// Inside a `#[…]` / `#![…]` attribute.
     Attribute,
+    /// The call form and arity match, but the receiver is not the type the
+    /// framework generates this function on — an app's own same-named
+    /// associated function, or the framework one reached through an aliased
+    /// import. Rewriting would be a guess either way.
+    UnexpectedReceiver,
     /// The renamed name is *referenced* rather than called — passed as a
     /// function item (`.map(Repo::with_pool)`), bound to a variable, or read as
     /// a same-named field. A rename is only safe at a call site, so the
@@ -47,6 +52,7 @@ impl ManualReason {
             Self::Macro => "inside a macro invocation",
             Self::Attribute => "inside an attribute",
             Self::NotACall => "referenced without being called",
+            Self::UnexpectedReceiver => "receiver is not a generated repository",
         }
     }
 }
@@ -125,6 +131,8 @@ struct Rename {
     form: CallForm,
     /// Exact top-level argument count of the renamed function.
     args: usize,
+    /// Required prefix on the receiver path segment, if any.
+    receiver: Option<&'static str>,
 }
 
 /// Apply `migrations` to one file's `source`.
@@ -148,12 +156,14 @@ pub fn rewrite_source(
                 to,
                 form,
                 args,
+                receiver,
             } => Some(Rename {
                 id: migration.id,
                 from,
                 to,
                 form,
                 args,
+                receiver,
             }),
             Rewrite::GuideOnly => None,
         })
@@ -320,9 +330,16 @@ fn scan(stream: &TokenStream, context: Context, renames: &[Rename], hits: &mut V
                 else {
                     continue;
                 };
-                let manual = context.manual_reason().or_else(|| {
-                    (!takes_arguments(&trees, index, rename.args)).then_some(ManualReason::NotACall)
-                });
+                let manual = context
+                    .manual_reason()
+                    .or_else(|| {
+                        (!takes_arguments(&trees, index, rename.args))
+                            .then_some(ManualReason::NotACall)
+                    })
+                    .or_else(|| {
+                        (!receiver_matches(&trees, index, rename.receiver))
+                            .then_some(ManualReason::UnexpectedReceiver)
+                    });
                 let span = ident.span();
                 let start = span.start();
                 hits.push(Hit {
@@ -518,6 +535,27 @@ fn turbofish_argument_list(trees: &[TokenTree], angle: usize) -> Option<&proc_ma
     None
 }
 
+/// Whether the receiver path segment carries the prefix the framework gives
+/// the type this function is generated on.
+///
+/// `#[repository]` names its concrete type `Pg{trait}`, so `PgPostRepository`
+/// is a genuine receiver and an app's own `Cache` is not. A rename with no
+/// declared prefix accepts any receiver.
+fn receiver_matches(trees: &[TokenTree], index: usize, required: Option<&str>) -> bool {
+    let Some(required) = required else {
+        return true;
+    };
+    // `PgPostRepository :: with_pool` — the receiver sits three tokens back,
+    // past the pair of colons. Anything else (a `>` closing `<T as Trait>`, a
+    // macro-built path) is not a plain receiver and is reported rather than
+    // rewritten.
+    let Some(at) = index.checked_sub(3) else {
+        return false;
+    };
+    matches!(trees.get(at), Some(TokenTree::Ident(ident))
+        if ident.to_string().starts_with(required))
+}
+
 /// Which call form `trees[index]` is written in, if any: `.` makes it a method
 /// call, a full `::` makes it an associated-function call.
 ///
@@ -562,6 +600,8 @@ mod tests {
             to: "with_pool_untracked",
             form: CallForm::AssociatedFunction,
             args: 1,
+            // Mirrors the shipped migration: `#[repository]` emits `Pg{trait}`.
+            receiver: Some("Pg"),
         },
     };
 
@@ -580,10 +620,12 @@ mod tests {
 
     #[test]
     fn rewrites_an_associated_function_call() {
-        let out = rewritten("fn f(p: Pool) { let r = PostRepository::with_pool(p); }");
+        // `#[repository]` emits `Pg{trait}`, so the concrete type an app calls
+        // this on is `PgPostRepository`, never the trait `PostRepository`.
+        let out = rewritten("fn f(p: Pool) { let r = PgPostRepository::with_pool(p); }");
         assert_eq!(
             out,
-            "fn f(p: Pool) { let r = PostRepository::with_pool_untracked(p); }"
+            "fn f(p: Pool) { let r = PgPostRepository::with_pool_untracked(p); }"
         );
     }
 
@@ -618,6 +660,7 @@ mod tests {
                 to: "new_step",
                 form: CallForm::Method,
                 args: 1,
+                receiver: None,
             },
         };
         let result = rewrite_source("fn f(b: B, p: P) { b.old_step(p); }", &[&METHOD_RENAME])
@@ -644,23 +687,23 @@ mod tests {
     fn arity_is_counted_at_the_top_level_only() {
         // A comma nested inside an argument is not an argument separator, and
         // a trailing comma does not open a new argument.
-        let out = rewritten("fn f() { Repo::with_pool(make(a, b),); }");
+        let out = rewritten("fn f() { PgRepo::with_pool(make(a, b),); }");
         assert!(out.contains("with_pool_untracked(make(a, b),)"), "{out}");
     }
 
     #[test]
     fn rewrites_a_turbofished_call() {
-        let out = rewritten("fn f() { Repo::with_pool::<Pg>(p); }");
-        assert_eq!(out, "fn f() { Repo::with_pool_untracked::<Pg>(p); }");
+        let out = rewritten("fn f() { PgRepo::with_pool::<Pg>(p); }");
+        assert_eq!(out, "fn f() { PgRepo::with_pool_untracked::<Pg>(p); }");
     }
 
     #[test]
     fn preserves_formatting_comments_and_line_endings() {
-        let source = "fn f() {\r\n    // build it with_pool, historically\r\n    let r = Repo::with_pool(p);   // trailing\r\n}\r\n";
+        let source = "fn f() {\r\n    // build it with_pool, historically\r\n    let r = PgRepo::with_pool(p);   // trailing\r\n}\r\n";
         let out = rewritten(source);
         assert_eq!(
             out,
-            "fn f() {\r\n    // build it with_pool, historically\r\n    let r = Repo::with_pool_untracked(p);   // trailing\r\n}\r\n"
+            "fn f() {\r\n    // build it with_pool, historically\r\n    let r = PgRepo::with_pool_untracked(p);   // trailing\r\n}\r\n"
         );
     }
 
@@ -668,14 +711,14 @@ mod tests {
     fn leaves_the_already_renamed_call_untouched() {
         // Applying twice is a no-op: the rename is matched on whole tokens, so
         // the new name is simply a different identifier.
-        let result = run("fn f() { Repo::with_pool_untracked(p); }");
+        let result = run("fn f() { PgRepo::with_pool_untracked(p); }");
         assert_eq!(result.updated, None);
         assert!(result.rewritten.is_empty());
     }
 
     #[test]
     fn leaves_a_different_identifier_with_the_same_prefix_untouched() {
-        let result = run("fn f() { Repo::with_pool_provider(p); }");
+        let result = run("fn f() { PgRepo::with_pool_provider(p); }");
         assert_eq!(result.updated, None);
     }
 
@@ -704,7 +747,7 @@ mod tests {
 
     #[test]
     fn reports_a_macro_body_site_as_manual_without_rewriting_it() {
-        let source = "fn f() {\n    make_repo! { Repo::with_pool(p) }\n}\n";
+        let source = "fn f() {\n    make_repo! { PgRepo::with_pool(p) }\n}\n";
         let result = run(source);
         assert_eq!(result.updated, None, "a macro body is never rewritten");
         assert!(result.rewritten.is_empty());
@@ -717,7 +760,7 @@ mod tests {
 
     #[test]
     fn reports_a_nested_macro_body_site_as_manual() {
-        let source = "fn f() {\n    outer!(inner!(Repo::with_pool(p)));\n}\n";
+        let source = "fn f() {\n    outer!(inner!(PgRepo::with_pool(p)));\n}\n";
         let result = run(source);
         assert_eq!(result.updated, None);
         assert_eq!(result.manual.len(), 1);
@@ -726,7 +769,7 @@ mod tests {
 
     #[test]
     fn reports_an_attribute_site_as_manual() {
-        let source = "#[derive_repo(build = Repo::with_pool(p))]\nstruct S;\n";
+        let source = "#[derive_repo(build = PgRepo::with_pool(p))]\nstruct S;\n";
         let result = run(source);
         assert_eq!(result.updated, None);
         assert_eq!(result.manual.len(), 1);
@@ -745,12 +788,12 @@ mod tests {
     #[test]
     fn records_line_and_column_for_every_rewritten_site() {
         let source =
-            "fn f() {\n    let a = Repo::with_pool(p);\n    let b = Other::with_pool(q);\n}\n";
+            "fn f() {\n    let a = PgRepo::with_pool(p);\n    let b = PgOther::with_pool(q);\n}\n";
         let result = run(source);
         assert_eq!(result.rewritten.len(), 2);
         assert_eq!(result.rewritten[0].line, 2);
         assert_eq!(
-            result.rewritten[0].column, 19,
+            result.rewritten[0].column, 21,
             "1-based column of `with_pool`"
         );
         assert_eq!(result.rewritten[1].line, 3);
@@ -761,23 +804,23 @@ mod tests {
     fn splices_correctly_after_multibyte_characters() {
         // Byte offsets, not char offsets: an em dash before the site shifts the
         // two apart, and getting it wrong corrupts the file.
-        let source = "fn f() {\n    // — a note —\n    let r = Repo::with_pool(p);\n}\n";
+        let source = "fn f() {\n    // — a note —\n    let r = PgRepo::with_pool(p);\n}\n";
         let out = rewritten(source);
         assert_eq!(
             out,
-            "fn f() {\n    // — a note —\n    let r = Repo::with_pool_untracked(p);\n}\n"
+            "fn f() {\n    // — a note —\n    let r = PgRepo::with_pool_untracked(p);\n}\n"
         );
     }
 
     #[test]
     fn rewrites_every_site_in_a_file() {
-        let source = "fn f() { A::with_pool(p); B::with_pool(q); C::with_pool(r); }";
+        let source = "fn f() { PgA::with_pool(p); PgB::with_pool(q); PgC::with_pool(r); }";
         let result = run(source);
         assert_eq!(result.rewritten.len(), 3);
         assert_eq!(
             result.updated.as_deref(),
             Some(
-                "fn f() { A::with_pool_untracked(p); B::with_pool_untracked(q); C::with_pool_untracked(r); }"
+                "fn f() { PgA::with_pool_untracked(p); PgB::with_pool_untracked(q); PgC::with_pool_untracked(r); }"
             )
         );
     }
@@ -786,7 +829,7 @@ mod tests {
     fn rewrites_inside_cfg_disabled_code() {
         // `#[cfg(...)]` code is still the app's source and still has to compile
         // on the configuration that enables it.
-        let source = "#[cfg(feature = \"db\")]\nfn f() { Repo::with_pool(p); }\n";
+        let source = "#[cfg(feature = \"db\")]\nfn f() { PgRepo::with_pool(p); }\n";
         let out = rewritten(source);
         assert!(out.contains("with_pool_untracked"));
     }
@@ -802,7 +845,7 @@ mod tests {
             rewrite: Rewrite::GuideOnly,
         };
         let result =
-            rewrite_source("fn f() { Repo::with_pool(p); }", &[&GUIDE_ONLY]).expect("parses");
+            rewrite_source("fn f() { PgRepo::with_pool(p); }", &[&GUIDE_ONLY]).expect("parses");
         assert_eq!(result.updated, None);
         assert!(result.rewritten.is_empty());
         assert!(result.manual.is_empty());
@@ -842,13 +885,13 @@ mod tests {
     #[test]
     fn every_macro_definition_shape_is_treated_as_macro_input() {
         for source in [
-            "macro_rules! m { () => { R::with_pool(p) }; }",
-            "macro_rules! m ( () => ( R::with_pool(p) ); );",
-            "macro_rules! m [ () => [ R::with_pool(p) ]; ];",
-            "#[macro_export]\nmacro_rules! m { () => { R::with_pool(p) }; }",
-            "fn outer() { macro_rules! m { () => { R::with_pool(p) }; } }",
-            "pub macro m() { R::with_pool(p) }",
-            "pub macro m { () => { R::with_pool(p) } }",
+            "macro_rules! m { () => { PgR::with_pool(p) }; }",
+            "macro_rules! m ( () => ( PgR::with_pool(p) ); );",
+            "macro_rules! m [ () => [ PgR::with_pool(p) ]; ];",
+            "#[macro_export]\nmacro_rules! m { () => { PgR::with_pool(p) }; }",
+            "fn outer() { macro_rules! m { () => { PgR::with_pool(p) }; } }",
+            "pub macro m() { PgR::with_pool(p) }",
+            "pub macro m { () => { PgR::with_pool(p) } }",
         ] {
             let result = run(source);
             assert_eq!(result.updated, None, "must not rewrite: {source}");
@@ -885,9 +928,9 @@ mod tests {
         // "No site is silently skipped": a function item handed somewhere else
         // still stops compiling after the rename, so it has to be reported.
         for source in [
-            "fn f() { xs.iter().map(Repo::with_pool); }",
-            "fn f() { let g = Repo::with_pool; g(p); }",
-            "fn f() { let g: fn(P) -> R = Repo::with_pool; }",
+            "fn f() { xs.iter().map(PgRepo::with_pool); }",
+            "fn f() { let g = PgRepo::with_pool; g(p); }",
+            "fn f() { let g: fn(P) -> R = PgRepo::with_pool; }",
         ] {
             let result = run(source);
             assert_eq!(
@@ -907,14 +950,14 @@ mod tests {
 
     #[test]
     fn a_raw_identifier_call_site_is_rewritten_keeping_its_prefix() {
-        let out = rewritten("fn f() { Repo::r#with_pool(p); }");
-        assert_eq!(out, "fn f() { Repo::r#with_pool_untracked(p); }");
+        let out = rewritten("fn f() { PgRepo::r#with_pool(p); }");
+        assert_eq!(out, "fn f() { PgRepo::r#with_pool_untracked(p); }");
     }
 
     #[test]
     fn a_turbofish_that_is_not_a_call_is_not_rewritten() {
-        // `Vec<Repo::with_pool::<T>>` is a type path, not a call.
-        let result = run("fn f(x: Vec<Repo::with_pool::<T>>) {}");
+        // `Vec<PgRepo::with_pool::<T>>` is a type path, not a call.
+        let result = run("fn f(x: Vec<PgRepo::with_pool::<T>>) {}");
         assert_eq!(result.updated, None);
         assert!(
             result
@@ -927,7 +970,7 @@ mod tests {
     #[test]
     fn a_turbofish_returning_a_function_type_still_reads_as_a_call() {
         // The `>` of the `->` inside the generic argument closes nothing.
-        let out = rewritten("fn f() { Repo::with_pool::<fn(A) -> B>(p); }");
+        let out = rewritten("fn f() { PgRepo::with_pool::<fn(A) -> B>(p); }");
         assert!(
             out.contains("with_pool_untracked::<fn(A) -> B>(p)"),
             "{out}"
@@ -950,6 +993,7 @@ mod tests {
                 to: "with_pool_untracked",
                 form: CallForm::AssociatedFunction,
                 args: 1,
+                receiver: None,
             },
         };
         static SECOND: AppMigration = AppMigration {
@@ -963,15 +1007,16 @@ mod tests {
                 to: "untracked_pool",
                 form: CallForm::AssociatedFunction,
                 args: 1,
+                receiver: None,
             },
         };
         let chain: [&'static AppMigration; 2] = [&FIRST, &SECOND];
 
         let first_run =
-            rewrite_source_for_releases("fn f() { R::with_pool(p); }", &chain).expect("parses");
+            rewrite_source_for_releases("fn f() { PgR::with_pool(p); }", &chain).expect("parses");
         assert_eq!(
             first_run.updated.as_deref(),
-            Some("fn f() { R::untracked_pool(p); }"),
+            Some("fn f() { PgR::untracked_pool(p); }"),
             "one run reaches the newest name"
         );
 
@@ -994,6 +1039,7 @@ mod tests {
                 to: "with_pool_untracked",
                 form: CallForm::AssociatedFunction,
                 args: 1,
+                receiver: None,
             },
         };
         static B: AppMigration = AppMigration {
@@ -1007,10 +1053,11 @@ mod tests {
                 to: "new_name",
                 form: CallForm::AssociatedFunction,
                 args: 1,
+                receiver: None,
             },
         };
         // `old_name` (0.7.0) is on line 2, `with_pool` (0.6.0) on line 3.
-        let source = "fn f() {\n    R::old_name(p);\n    R::with_pool(p);\n}\n";
+        let source = "fn f() {\n    R::old_name(p);\n    PgR::with_pool(p);\n}\n";
         let result = rewrite_source_for_releases(source, &[&A, &B]).expect("parses");
         let lines: Vec<usize> = result.rewritten.iter().map(|site| site.line).collect();
         assert_eq!(
@@ -1021,12 +1068,77 @@ mod tests {
     }
 
     #[test]
+    fn leaves_an_unrelated_associated_function_with_the_same_name_alone() {
+        // `#[repository]` names its concrete type `Pg{trait}`, so an app's own
+        // `Cache::with_pool(pool)` is not the renamed constructor. It is
+        // reported rather than dropped, because an aliased import of a real
+        // repository would look exactly like this.
+        let result = run("fn f(p: Pool) { let c = Cache::with_pool(p); }");
+        assert_eq!(result.updated, None, "an unrelated type is not rewritten");
+        assert_eq!(result.manual.len(), 1, "and not silently skipped either");
+        assert_eq!(
+            result.manual[0].manual,
+            Some(ManualReason::UnexpectedReceiver)
+        );
+    }
+
+    #[test]
+    fn rewrites_a_generated_repository_receiver_however_it_is_pathed() {
+        // The prefix is on the final path segment, so a fully-qualified path to
+        // a generated repository still matches.
+        let out = rewritten("fn f(p: Pool) { crate::repos::PgPostRepository::with_pool(p); }");
+        assert!(
+            out.contains("PgPostRepository::with_pool_untracked(p)"),
+            "{out}"
+        );
+    }
+
+    #[test]
+    fn a_qualified_trait_call_is_reported_not_rewritten() {
+        // `<T as Repo>::with_pool(p)` has no plain receiver ident to check.
+        let result = run("fn f(p: Pool) { <T as Repo>::with_pool(p); }");
+        assert_eq!(result.updated, None);
+        assert_eq!(
+            result.manual[0].manual,
+            Some(ManualReason::UnexpectedReceiver)
+        );
+    }
+
+    #[test]
+    fn a_rename_with_no_receiver_constraint_accepts_any_receiver() {
+        static ANY: AppMigration = AppMigration {
+            id: "test-any-receiver",
+            version: "0.7.0",
+            title: "any receiver",
+            confidence: Confidence::Auto,
+            guide: "docs/migrations/0.7.0.md#anchor",
+            rewrite: Rewrite::CallRename {
+                from: "old_ctor",
+                to: "new_ctor",
+                form: CallForm::AssociatedFunction,
+                args: 1,
+                receiver: None,
+            },
+        };
+        let result =
+            rewrite_source("fn f(p: P) { Anything::old_ctor(p); }", &[&ANY]).expect("parses");
+        assert_eq!(
+            result.updated.as_deref(),
+            Some("fn f(p: P) { Anything::new_ctor(p); }")
+        );
+    }
+
+    #[test]
     fn manual_reasons_read_as_a_sentence_fragment() {
         assert_eq!(ManualReason::Macro.describe(), "inside a macro invocation");
         assert_eq!(ManualReason::Attribute.describe(), "inside an attribute");
         assert_eq!(
             ManualReason::NotACall.describe(),
             "referenced without being called"
+        );
+        assert_eq!(
+            ManualReason::UnexpectedReceiver.describe(),
+            "receiver is not a generated repository"
         );
     }
 }

--- a/autumn-cli/src/upgrade/engine.rs
+++ b/autumn-cli/src/upgrade/engine.rs
@@ -1,0 +1,917 @@
+//! The rewrite engine behind `autumn upgrade` (issue #1629).
+//!
+//! # Why tokens and not `syn` (or `sed`)
+//!
+//! The guide for 0.6.0 offers a `sed 's/\bwith_pool\b/…/g'` one-liner, which is
+//! exactly the class of edit this command exists to stop shipping as prose: it
+//! rewrites the word inside string literals, comments, and any same-named local
+//! the app happens to own. Parsing to a `syn` AST and re-printing goes too far
+//! the other way — it reformats the whole file and drops every comment.
+//!
+//! So the engine parses to a `proc_macro2::TokenStream` (which keeps
+//! `span-locations` byte offsets into the *original* text), finds identifiers in
+//! call position, and splices the replacement into the original bytes. Nothing
+//! outside the renamed identifiers moves: whitespace, comments, and line endings
+//! survive byte-for-byte.
+//!
+//! # What is deliberately not rewritten
+//!
+//! Tokens inside a macro invocation body or an attribute are reported as
+//! `manual` with `file:line` rather than guessed at (issue #1629: "No site is
+//! silently skipped"). A `foo! { … }` body is arbitrary input to arbitrary code
+//! — the tokens that look like a call may never become one, and a macro is free
+//! to build the identifier by concatenation, so a rewrite there is a guess.
+
+use proc_macro2::{Delimiter, TokenStream, TokenTree};
+
+use super::migrations::{AppMigration, Rewrite};
+
+/// Why a site was left for a human.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ManualReason {
+    /// Inside a `foo!(…)` / `foo! { … }` invocation body.
+    Macro,
+    /// Inside a `#[…]` / `#![…]` attribute.
+    Attribute,
+    /// The renamed name is *referenced* rather than called — passed as a
+    /// function item (`.map(Repo::with_pool)`), bound to a variable, or read as
+    /// a same-named field. A rename is only safe at a call site, so the
+    /// reference is reported instead of guessed at.
+    NotACall,
+}
+
+impl ManualReason {
+    /// Human-readable phrase used in the summary.
+    pub const fn describe(self) -> &'static str {
+        match self {
+            Self::Macro => "inside a macro invocation",
+            Self::Attribute => "inside an attribute",
+            Self::NotACall => "referenced without being called",
+        }
+    }
+}
+
+/// One call site the engine acted on, or declined to act on.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Site {
+    /// 1-based line in the source file.
+    pub line: usize,
+    /// 1-based column in the source file.
+    pub column: usize,
+    /// [`AppMigration::id`] of the migration that matched.
+    pub migration: &'static str,
+    /// `None` when the site was rewritten; `Some` when it was left for a human.
+    pub manual: Option<ManualReason>,
+}
+
+/// The outcome of running a set of migrations over one file's text.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct SourceRewrite {
+    /// The rewritten text, or `None` when nothing matched.
+    pub updated: Option<String>,
+    /// Sites that were rewritten, in source order.
+    pub rewritten: Vec<Site>,
+    /// Sites left for a human, in source order.
+    pub manual: Vec<Site>,
+}
+
+/// Rust keywords that can legally sit immediately before a `!` that is *not* a
+/// macro bang (`return !(a)`, `if !(a) {}`). Without this list, the `Ident`,
+/// `!`, `Group` shape of such an expression reads as a macro invocation, and
+/// every call site inside the parentheses would be over-reported as `manual`.
+/// Over-reporting is the safe direction, but it is still wrong.
+const NON_MACRO_KEYWORDS: &[&str] = &[
+    "return", "break", "if", "while", "match", "else", "in", "yield", "loop", "await", "move",
+];
+
+/// Where in the token tree we are. Tokens inside a macro body or an attribute
+/// are input to code that has not run yet, so they are reported, never edited.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Context {
+    Code,
+    Macro,
+    Attribute,
+}
+
+impl Context {
+    const fn manual_reason(self) -> Option<ManualReason> {
+        match self {
+            Self::Code => None,
+            Self::Macro => Some(ManualReason::Macro),
+            Self::Attribute => Some(ManualReason::Attribute),
+        }
+    }
+}
+
+/// One matched identifier, before anything is spliced.
+#[derive(Debug, Clone)]
+struct Hit {
+    range: std::ops::Range<usize>,
+    site: Site,
+    /// The identifier the span is expected to contain, re-checked before the
+    /// splice so a span/text disagreement can never corrupt a file. Carries the
+    /// `r#` prefix when the source wrote the name as a raw identifier.
+    expected: String,
+    /// The identifier the site is renamed to, when it is rewritable.
+    replacement: String,
+}
+
+/// A rename this run is looking for.
+struct Rename {
+    id: &'static str,
+    from: &'static str,
+    to: &'static str,
+}
+
+/// Apply `migrations` to one file's `source`.
+///
+/// # Errors
+///
+/// Returns the parse error when `source` is not valid Rust, or when a matched
+/// span does not contain the identifier it claims to (which would mean the byte
+/// offsets and the text disagree). Either way the caller reports the file as
+/// skipped and writes nothing — this function never returns a partially
+/// spliced string.
+pub fn rewrite_source(
+    source: &str,
+    migrations: &[&'static AppMigration],
+) -> Result<SourceRewrite, String> {
+    let renames: Vec<Rename> = migrations
+        .iter()
+        .filter_map(|migration| match migration.rewrite {
+            Rewrite::CallRename { from, to } => Some(Rename {
+                id: migration.id,
+                from,
+                to,
+            }),
+            Rewrite::GuideOnly => None,
+        })
+        .collect();
+    if renames.is_empty() {
+        return Ok(SourceRewrite::default());
+    }
+
+    let stream: TokenStream = source
+        .parse()
+        .map_err(|error: proc_macro2::LexError| error.to_string())?;
+
+    let mut hits = Vec::new();
+    scan(&stream, Context::Code, &renames, &mut hits);
+    // Token order is source order for a single stream, but nested groups are
+    // walked depth-first, so the flattened list is not. Sorting makes the diff,
+    // the reported sites, and the splice all read top-to-bottom.
+    hits.sort_by_key(|hit| hit.range.start);
+
+    let mut result = SourceRewrite::default();
+    let mut updated = String::new();
+    let mut cursor = 0;
+    for hit in hits {
+        if hit.site.manual.is_some() {
+            result.manual.push(hit.site);
+            continue;
+        }
+        // Fail closed: if the span and the text ever disagree, splicing would
+        // corrupt the file rather than migrate it.
+        let matched = source.get(hit.range.clone()).ok_or_else(|| {
+            format!(
+                "internal error: span {}..{} is not a character range of this file",
+                hit.range.start, hit.range.end
+            )
+        })?;
+        if matched != hit.expected {
+            return Err(format!(
+                "internal error: expected `{}` at byte {}, found `{matched}`",
+                hit.expected, hit.range.start
+            ));
+        }
+        if cursor > hit.range.start {
+            return Err(format!(
+                "internal error: overlapping rewrite at byte {}",
+                hit.range.start
+            ));
+        }
+        updated.push_str(&source[cursor..hit.range.start]);
+        updated.push_str(&hit.replacement);
+        cursor = hit.range.end;
+        result.rewritten.push(hit.site);
+    }
+
+    if result.rewritten.is_empty() {
+        return Ok(result);
+    }
+    updated.push_str(&source[cursor..]);
+    // Belt and braces on a tool that edits source in place: the rewrite is a
+    // rename, so the result must still lex. If it does not, something about the
+    // splice was wrong and the file is reported as skipped rather than written.
+    if let Err(error) = updated.parse::<TokenStream>() {
+        return Err(format!(
+            "internal error: the rewritten file no longer parses ({error}); left untouched"
+        ));
+    }
+    result.updated = Some(updated);
+    Ok(result)
+}
+
+/// Apply `migrations` **release by release**, oldest first, feeding each
+/// release's output into the next.
+///
+/// One pass over the original text would be wrong the moment two releases chain
+/// — a `0.6.0` rename `a → b` followed by a `0.7.0` rename `b → c` would leave
+/// the file on the intermediate name `b`, and running the command a second time
+/// would move it again, so "applying twice is a no-op" would quietly stop being
+/// true. Passing release by release lands on `c` in one run and finds nothing
+/// on the next.
+///
+/// Reported line numbers survive this because a rename never adds or removes a
+/// line; a column on a line that an earlier release already touched can shift
+/// by the length difference of that earlier rename.
+///
+/// # Errors
+///
+/// Propagates the parse error from [`rewrite_source`] for the first pass that
+/// cannot read the file. Nothing is written by this function.
+pub fn rewrite_source_for_releases(
+    source: &str,
+    migrations: &[&'static AppMigration],
+) -> Result<SourceRewrite, String> {
+    let mut current = source.to_owned();
+    let mut combined = SourceRewrite::default();
+    let mut rewritten_anything = false;
+
+    for release in releases(migrations) {
+        let pass = rewrite_source(&current, &release)?;
+        combined.rewritten.extend(pass.rewritten);
+        combined.manual.extend(pass.manual);
+        if let Some(updated) = pass.updated {
+            current = updated;
+            rewritten_anything = true;
+        }
+    }
+
+    // Each pass reports in its own source order; the caller wants one list that
+    // reads top-to-bottom.
+    combined
+        .rewritten
+        .sort_by_key(|site| (site.line, site.column));
+    combined.manual.sort_by_key(|site| (site.line, site.column));
+    if rewritten_anything {
+        combined.updated = Some(current);
+    }
+    Ok(combined)
+}
+
+/// Split a version-ordered selection into one group per release.
+fn releases(migrations: &[&'static AppMigration]) -> Vec<Vec<&'static AppMigration>> {
+    let mut groups: Vec<Vec<&'static AppMigration>> = Vec::new();
+    for migration in migrations {
+        match groups.last_mut() {
+            Some(group) if group[0].version == migration.version => group.push(migration),
+            _ => groups.push(vec![migration]),
+        }
+    }
+    groups
+}
+
+/// Walk a token stream, recording every matching call site.
+fn scan(stream: &TokenStream, context: Context, renames: &[Rename], hits: &mut Vec<Hit>) {
+    let trees: Vec<TokenTree> = stream.clone().into_iter().collect();
+    for (index, tree) in trees.iter().enumerate() {
+        match tree {
+            TokenTree::Group(group) => {
+                scan(
+                    &group.stream(),
+                    group_context(&trees, index, context),
+                    renames,
+                    hits,
+                );
+            }
+            TokenTree::Ident(ident) => {
+                // The separator is what makes this the framework API rather
+                // than any other use of the word; whether an argument list
+                // follows decides between rewriting it and reporting it.
+                if !is_receiver_separator(&trees, index) {
+                    continue;
+                }
+                let name = ident.to_string();
+                // `r#with_pool` is the same name written raw. Match on the bare
+                // name and carry the prefix through to the splice, or the site
+                // is missed in silence.
+                let (prefix, bare) = name
+                    .strip_prefix("r#")
+                    .map_or(("", name.as_str()), |bare| ("r#", bare));
+                let Some(rename) = renames.iter().find(|rename| rename.from == bare) else {
+                    continue;
+                };
+                let manual = context.manual_reason().or_else(|| {
+                    (!has_argument_list(&trees, index)).then_some(ManualReason::NotACall)
+                });
+                let span = ident.span();
+                let start = span.start();
+                hits.push(Hit {
+                    range: span.byte_range(),
+                    site: Site {
+                        line: start.line,
+                        column: start.column + 1,
+                        migration: rename.id,
+                        manual,
+                    },
+                    expected: name.clone(),
+                    replacement: format!("{prefix}{}", rename.to),
+                });
+            }
+            TokenTree::Punct(_) | TokenTree::Literal(_) => {}
+        }
+    }
+}
+
+/// The context the contents of `trees[index]` (a group) are read in.
+///
+/// Once inside a macro body or an attribute, everything nested stays there —
+/// an inner group of a macro body is still macro input.
+fn group_context(trees: &[TokenTree], index: usize, outer: Context) -> Context {
+    if outer != Context::Code {
+        return outer;
+    }
+    let TokenTree::Group(group) = &trees[index] else {
+        return outer;
+    };
+    // `#[...]` and `#![...]`: an attribute's body is input to a derive/attribute
+    // macro, or to the compiler. Checked before the macro shape so the `!` of an
+    // inner attribute is not mistaken for a macro bang.
+    if group.delimiter() == Delimiter::Bracket {
+        // `#[...]` sits directly after the hash; `#![...]` has the inner-attribute
+        // bang in between.
+        let hash_at = previous_punct(trees, index, '!').map_or_else(
+            || previous_punct(trees, index, '#'),
+            |bang| previous_punct(trees, bang, '#'),
+        );
+        if hash_at.is_some() {
+            return Context::Attribute;
+        }
+    }
+    // `name!(...)`, `name! { ... }`, `path::name![...]`.
+    if let Some(bang) = previous_punct(trees, index, '!')
+        && is_macro_name(trees, bang)
+    {
+        return Context::Macro;
+    }
+    // A macro *definition* body is macro input too — and the more dangerous
+    // half: rewriting `macro_rules! m { ($x . with_pool (…)) => … }` edits the
+    // matcher, so the macro stops accepting the calls its users write, while
+    // those call sites are (correctly) reported as manual and left alone. The
+    // definition name sits between the bang and the body, so the invocation
+    // shape above does not see it.
+    if is_macro_definition_body(trees, index) {
+        return Context::Macro;
+    }
+    outer
+}
+
+/// Whether `trees[index]` is the body of a macro *definition*.
+///
+/// Two shapes: `macro_rules! name { … }` (also `( … );` and `[ … ];`), and the
+/// declarative-macro-2.0 `macro name(args) { … }` / `macro name { … }`.
+fn is_macro_definition_body(trees: &[TokenTree], index: usize) -> bool {
+    let ident_at = |at: usize, want: &str| matches!(trees.get(at), Some(TokenTree::Ident(ident)) if ident == want);
+    let is_ident = |at: usize| matches!(trees.get(at), Some(TokenTree::Ident(_)));
+
+    // macro_rules ! name <body>
+    if index >= 3
+        && ident_at(index - 3, "macro_rules")
+        && matches!(&trees[index - 2], TokenTree::Punct(punct) if punct.as_char() == '!')
+        && is_ident(index - 1)
+    {
+        return true;
+    }
+    // macro name <body>
+    if index >= 2 && ident_at(index - 2, "macro") && is_ident(index - 1) {
+        return true;
+    }
+    // macro name (args) <body>
+    index >= 3
+        && ident_at(index - 3, "macro")
+        && is_ident(index - 2)
+        && matches!(&trees[index - 1], TokenTree::Group(group)
+            if group.delimiter() == Delimiter::Parenthesis)
+}
+
+/// Index of `trees[index - 1]` when it is the punctuation `ch`.
+fn previous_punct(trees: &[TokenTree], index: usize, ch: char) -> Option<usize> {
+    let before = index.checked_sub(1)?;
+    match &trees[before] {
+        TokenTree::Punct(punct) if punct.as_char() == ch => Some(before),
+        _ => None,
+    }
+}
+
+/// Whether the token before `bang` names a macro rather than being the operand
+/// boundary of a unary `!`.
+fn is_macro_name(trees: &[TokenTree], bang: usize) -> bool {
+    let Some(before) = bang.checked_sub(1) else {
+        return false;
+    };
+    match &trees[before] {
+        // `path::name!` — the `::` guarantees a path, so the bang is a macro's.
+        TokenTree::Punct(punct) => punct.as_char() == ':',
+        TokenTree::Ident(ident) => !NON_MACRO_KEYWORDS.contains(&ident.to_string().as_str()),
+        TokenTree::Group(_) | TokenTree::Literal(_) => false,
+    }
+}
+
+/// Whether an argument list follows `trees[index]`, directly or past a
+/// turbofish — the half that separates a *call* from a mere reference.
+///
+/// A reference is not renamed: `xs.map(Repo::with_pool)` hands the function
+/// itself somewhere, and the tool has no way to know the receiver's type. Such
+/// a site is reported as [`ManualReason::NotACall`] rather than skipped.
+fn has_argument_list(trees: &[TokenTree], index: usize) -> bool {
+    match trees.get(index + 1) {
+        Some(TokenTree::Group(group)) => group.delimiter() == Delimiter::Parenthesis,
+        // Turbofish: `name::<T>(...)` is a call; `Vec<Repo::with_pool::<T>>` is
+        // a type, so the closing angle has to be followed by an argument list.
+        Some(TokenTree::Punct(punct)) if punct.as_char() == ':' => {
+            matches!(trees.get(index + 2), Some(TokenTree::Punct(second)) if second.as_char() == ':')
+                && matches!(trees.get(index + 3), Some(TokenTree::Punct(angle)) if angle.as_char() == '<')
+                && turbofish_closes_on_a_call(trees, index + 3)
+        }
+        _ => false,
+    }
+}
+
+/// Walk from the `<` at `angle` to its matching `>` and report whether an
+/// argument list follows it.
+fn turbofish_closes_on_a_call(trees: &[TokenTree], angle: usize) -> bool {
+    let mut depth = 0usize;
+    for at in angle..trees.len() {
+        let TokenTree::Punct(punct) = &trees[at] else {
+            continue;
+        };
+        match punct.as_char() {
+            '<' => depth += 1,
+            // The `>` of a `->` inside `::<fn(A) -> B>` closes nothing.
+            '>' if !matches!(trees.get(at.wrapping_sub(1)),
+                             Some(TokenTree::Punct(dash)) if dash.as_char() == '-') =>
+            {
+                depth -= 1;
+                if depth == 0 {
+                    return matches!(trees.get(at + 1), Some(TokenTree::Group(group))
+                        if group.delimiter() == Delimiter::Parenthesis);
+                }
+            }
+            _ => {}
+        }
+    }
+    false
+}
+
+/// Whether `trees[index]` is preceded by a `.` or a full `::`.
+///
+/// The `::` test insists on *both* colons: a single `:` before an identifier is
+/// a struct-literal field value or a type ascription (`Config { pool: with_pool }`),
+/// which is not the renamed associated function.
+fn is_receiver_separator(trees: &[TokenTree], index: usize) -> bool {
+    let Some(before) = index.checked_sub(1) else {
+        return false;
+    };
+    let TokenTree::Punct(punct) = &trees[before] else {
+        return false;
+    };
+    match punct.as_char() {
+        // A second `.` makes this a range or struct-update expression
+        // (`0..with_pool(n)`, `C { ..with_pool(d) }`), whose operand is a free
+        // function — not a method on a receiver.
+        '.' => !matches!(
+            before.checked_sub(1).map(|at| &trees[at]),
+            Some(TokenTree::Punct(first)) if first.as_char() == '.'
+        ),
+        ':' => matches!(
+            before.checked_sub(1).map(|at| &trees[at]),
+            Some(TokenTree::Punct(first)) if first.as_char() == ':'
+        ),
+        _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::upgrade::migrations::{AppMigration, Confidence};
+
+    /// The shipped 0.6.0 rename, used by every case below.
+    static RENAME: AppMigration = AppMigration {
+        id: "test-with-pool",
+        version: "0.6.0",
+        title: "test rename",
+        confidence: Confidence::Auto,
+        guide: "docs/migrations/0.6.0.md#anchor",
+        rewrite: Rewrite::CallRename {
+            from: "with_pool",
+            to: "with_pool_untracked",
+        },
+    };
+
+    fn run(source: &str) -> SourceRewrite {
+        rewrite_source(source, &[&RENAME]).expect("source parses")
+    }
+
+    fn rewritten(source: &str) -> String {
+        let out = run(source).updated.expect("source was rewritten");
+        // AC: "those sites compile without further edits". Lexing is the half
+        // this layer can check, and it catches every splice-level corruption.
+        out.parse::<TokenStream>()
+            .unwrap_or_else(|error| panic!("rewritten source no longer parses: {error}\n{out}"));
+        out
+    }
+
+    #[test]
+    fn rewrites_an_associated_function_call() {
+        let out = rewritten("fn f(p: Pool) { let r = PostRepository::with_pool(p); }");
+        assert_eq!(
+            out,
+            "fn f(p: Pool) { let r = PostRepository::with_pool_untracked(p); }"
+        );
+    }
+
+    #[test]
+    fn rewrites_a_method_call() {
+        let out = rewritten("fn f(b: B, p: Pool) { let r = b.with_pool(p); }");
+        assert_eq!(
+            out,
+            "fn f(b: B, p: Pool) { let r = b.with_pool_untracked(p); }"
+        );
+    }
+
+    #[test]
+    fn rewrites_a_turbofished_call() {
+        let out = rewritten("fn f() { Repo::with_pool::<Pg>(p); }");
+        assert_eq!(out, "fn f() { Repo::with_pool_untracked::<Pg>(p); }");
+    }
+
+    #[test]
+    fn preserves_formatting_comments_and_line_endings() {
+        let source = "fn f() {\r\n    // build it with_pool, historically\r\n    let r = Repo::with_pool(p);   // trailing\r\n}\r\n";
+        let out = rewritten(source);
+        assert_eq!(
+            out,
+            "fn f() {\r\n    // build it with_pool, historically\r\n    let r = Repo::with_pool_untracked(p);   // trailing\r\n}\r\n"
+        );
+    }
+
+    #[test]
+    fn leaves_the_already_renamed_call_untouched() {
+        // Applying twice is a no-op: the rename is matched on whole tokens, so
+        // the new name is simply a different identifier.
+        let result = run("fn f() { Repo::with_pool_untracked(p); }");
+        assert_eq!(result.updated, None);
+        assert!(result.rewritten.is_empty());
+    }
+
+    #[test]
+    fn leaves_a_different_identifier_with_the_same_prefix_untouched() {
+        let result = run("fn f() { Repo::with_pool_provider(p); }");
+        assert_eq!(result.updated, None);
+    }
+
+    #[test]
+    fn leaves_a_local_binding_of_the_same_name_untouched() {
+        let result = run("fn f() { let with_pool = 1; dbg(with_pool); }");
+        assert_eq!(result.updated, None);
+        assert!(result.rewritten.is_empty());
+        assert!(result.manual.is_empty());
+    }
+
+    #[test]
+    fn leaves_a_struct_field_and_free_function_untouched() {
+        // Neither is a `.`/`::` call site, so neither is the renamed API.
+        let result = run(
+            "struct S { with_pool: bool } fn with_pool() {} fn g(s: S) { let _ = s.with_pool; }",
+        );
+        assert_eq!(result.updated, None);
+    }
+
+    #[test]
+    fn leaves_string_literals_and_comments_untouched() {
+        let result = run("fn f() { let s = \"with_pool\"; /* with_pool */ }");
+        assert_eq!(result.updated, None);
+    }
+
+    #[test]
+    fn reports_a_macro_body_site_as_manual_without_rewriting_it() {
+        let source = "fn f() {\n    make_repo! { Repo::with_pool(p) }\n}\n";
+        let result = run(source);
+        assert_eq!(result.updated, None, "a macro body is never rewritten");
+        assert!(result.rewritten.is_empty());
+        assert_eq!(result.manual.len(), 1, "the site must still be reported");
+        let site = &result.manual[0];
+        assert_eq!(site.line, 2);
+        assert_eq!(site.manual, Some(ManualReason::Macro));
+        assert_eq!(site.migration, "test-with-pool");
+    }
+
+    #[test]
+    fn reports_a_nested_macro_body_site_as_manual() {
+        let source = "fn f() {\n    outer!(inner!(Repo::with_pool(p)));\n}\n";
+        let result = run(source);
+        assert_eq!(result.updated, None);
+        assert_eq!(result.manual.len(), 1);
+        assert_eq!(result.manual[0].manual, Some(ManualReason::Macro));
+    }
+
+    #[test]
+    fn reports_an_attribute_site_as_manual() {
+        let source = "#[derive_repo(build = Repo::with_pool(p))]\nstruct S;\n";
+        let result = run(source);
+        assert_eq!(result.updated, None);
+        assert_eq!(result.manual.len(), 1);
+        assert_eq!(result.manual[0].manual, Some(ManualReason::Attribute));
+        assert_eq!(result.manual[0].line, 1);
+    }
+
+    #[test]
+    fn a_macro_path_segment_is_not_itself_a_call_site() {
+        // `with_pool!(…)` is a macro of that name, not the renamed function.
+        let result = run("fn f() { with_pool!(p); }");
+        assert_eq!(result.updated, None);
+        assert!(result.manual.is_empty());
+    }
+
+    #[test]
+    fn records_line_and_column_for_every_rewritten_site() {
+        let source =
+            "fn f() {\n    let a = Repo::with_pool(p);\n    let b = other.with_pool(q);\n}\n";
+        let result = run(source);
+        assert_eq!(result.rewritten.len(), 2);
+        assert_eq!(result.rewritten[0].line, 2);
+        assert_eq!(
+            result.rewritten[0].column, 19,
+            "1-based column of `with_pool`"
+        );
+        assert_eq!(result.rewritten[1].line, 3);
+        assert!(result.rewritten.iter().all(|s| s.manual.is_none()));
+    }
+
+    #[test]
+    fn splices_correctly_after_multibyte_characters() {
+        // Byte offsets, not char offsets: an em dash before the site shifts the
+        // two apart, and getting it wrong corrupts the file.
+        let source = "fn f() {\n    // — a note —\n    let r = Repo::with_pool(p);\n}\n";
+        let out = rewritten(source);
+        assert_eq!(
+            out,
+            "fn f() {\n    // — a note —\n    let r = Repo::with_pool_untracked(p);\n}\n"
+        );
+    }
+
+    #[test]
+    fn rewrites_every_site_in_a_file() {
+        let source = "fn f() { A::with_pool(p); B::with_pool(q); c.with_pool(r); }";
+        let result = run(source);
+        assert_eq!(result.rewritten.len(), 3);
+        assert_eq!(
+            result.updated.as_deref(),
+            Some(
+                "fn f() { A::with_pool_untracked(p); B::with_pool_untracked(q); c.with_pool_untracked(r); }"
+            )
+        );
+    }
+
+    #[test]
+    fn rewrites_inside_cfg_disabled_code() {
+        // `#[cfg(...)]` code is still the app's source and still has to compile
+        // on the configuration that enables it.
+        let source = "#[cfg(feature = \"db\")]\nfn f() { Repo::with_pool(p); }\n";
+        let out = rewritten(source);
+        assert!(out.contains("with_pool_untracked"));
+    }
+
+    #[test]
+    fn a_guide_only_migration_rewrites_nothing() {
+        static GUIDE_ONLY: AppMigration = AppMigration {
+            id: "test-guide-only",
+            version: "0.6.0",
+            title: "guide only",
+            confidence: Confidence::Manual,
+            guide: "docs/migrations/0.6.0.md#anchor",
+            rewrite: Rewrite::GuideOnly,
+        };
+        let result =
+            rewrite_source("fn f() { Repo::with_pool(p); }", &[&GUIDE_ONLY]).expect("parses");
+        assert_eq!(result.updated, None);
+        assert!(result.rewritten.is_empty());
+        assert!(result.manual.is_empty());
+    }
+
+    #[test]
+    fn an_unparsable_file_is_an_error_not_a_rewrite() {
+        let err = rewrite_source("fn f( {", &[&RENAME]).expect_err("must not silently succeed");
+        assert!(!err.is_empty(), "the parse error is reported to the user");
+    }
+
+    #[test]
+    fn a_macro_rules_definition_is_never_rewritten_matcher_or_transcriber() {
+        // The dangerous half: rewriting the matcher makes the macro reject the
+        // invocations its users write, while those invocations are (correctly)
+        // reported as manual and left alone — a tree that does not compile.
+        let source = "macro_rules! forward {\n    ($s:ident . with_pool ( $p:expr )) => { $s.with_pool($p) };\n}\n";
+        let result = run(source);
+        assert_eq!(
+            result.updated, None,
+            "a macro definition body is macro input"
+        );
+        assert_eq!(
+            result.manual.len(),
+            2,
+            "both sites are reported: {:?}",
+            result.manual
+        );
+        assert!(
+            result
+                .manual
+                .iter()
+                .all(|s| s.manual == Some(ManualReason::Macro))
+        );
+    }
+
+    #[test]
+    fn every_macro_definition_shape_is_treated_as_macro_input() {
+        for source in [
+            "macro_rules! m { () => { R::with_pool(p) }; }",
+            "macro_rules! m ( () => ( R::with_pool(p) ); );",
+            "macro_rules! m [ () => [ R::with_pool(p) ]; ];",
+            "#[macro_export]\nmacro_rules! m { () => { R::with_pool(p) }; }",
+            "fn outer() { macro_rules! m { () => { R::with_pool(p) }; } }",
+            "pub macro m() { R::with_pool(p) }",
+            "pub macro m { () => { R::with_pool(p) } }",
+        ] {
+            let result = run(source);
+            assert_eq!(result.updated, None, "must not rewrite: {source}");
+            assert!(
+                result
+                    .manual
+                    .iter()
+                    .all(|s| s.manual == Some(ManualReason::Macro)),
+                "must report as macro input: {source} -> {:?}",
+                result.manual
+            );
+            assert!(!result.manual.is_empty(), "must not stay silent: {source}");
+        }
+    }
+
+    #[test]
+    fn a_range_or_struct_update_expression_is_not_a_method_call() {
+        // The operand of `..` is a free function, not a method on a receiver.
+        // Renaming it breaks an app that happens to own that name.
+        for source in [
+            "fn f() { for i in 0..with_pool(n) {} }",
+            "fn f() { let c = C { a: 1, ..with_pool(d) }; }",
+            "fn f() { let s = &v[a..with_pool(b)]; }",
+            "fn f() { let s = &v[..with_pool(b)]; }",
+        ] {
+            let result = run(source);
+            assert_eq!(result.updated, None, "must not rewrite: {source}");
+            assert!(result.manual.is_empty(), "not a site at all: {source}");
+        }
+    }
+
+    #[test]
+    fn a_reference_that_is_never_called_is_reported_not_skipped() {
+        // "No site is silently skipped": a function item handed somewhere else
+        // still stops compiling after the rename, so it has to be reported.
+        for source in [
+            "fn f() { xs.iter().map(Repo::with_pool); }",
+            "fn f() { let g = Repo::with_pool; g(p); }",
+            "fn f() { let g: fn(P) -> R = Repo::with_pool; }",
+        ] {
+            let result = run(source);
+            assert_eq!(
+                result.updated, None,
+                "a reference is not rewritten: {source}"
+            );
+            assert!(
+                result
+                    .manual
+                    .iter()
+                    .any(|s| s.manual == Some(ManualReason::NotACall)),
+                "must be reported for a human: {source} -> {:?}",
+                result.manual
+            );
+        }
+    }
+
+    #[test]
+    fn a_raw_identifier_call_site_is_rewritten_keeping_its_prefix() {
+        let out = rewritten("fn f() { Repo::r#with_pool(p); }");
+        assert_eq!(out, "fn f() { Repo::r#with_pool_untracked(p); }");
+    }
+
+    #[test]
+    fn a_turbofish_that_is_not_a_call_is_not_rewritten() {
+        // `Vec<Repo::with_pool::<T>>` is a type path, not a call.
+        let result = run("fn f(x: Vec<Repo::with_pool::<T>>) {}");
+        assert_eq!(result.updated, None);
+        assert!(
+            result
+                .manual
+                .iter()
+                .any(|s| s.manual == Some(ManualReason::NotACall))
+        );
+    }
+
+    #[test]
+    fn a_turbofish_returning_a_function_type_still_reads_as_a_call() {
+        // The `>` of the `->` inside the generic argument closes nothing.
+        let out = rewritten("fn f() { Repo::with_pool::<fn(A) -> B>(p); }");
+        assert!(
+            out.contains("with_pool_untracked::<fn(A) -> B>(p)"),
+            "{out}"
+        );
+    }
+
+    #[test]
+    fn chained_renames_across_releases_land_on_the_final_name_in_one_run() {
+        // Two releases in range, the second renaming what the first produced.
+        // A single pass over the original text would stop on the intermediate
+        // name and make a second run change the file again.
+        static FIRST: AppMigration = AppMigration {
+            id: "0.6.0-first",
+            version: "0.6.0",
+            title: "first",
+            confidence: Confidence::Auto,
+            guide: "docs/migrations/0.6.0.md#a",
+            rewrite: Rewrite::CallRename {
+                from: "with_pool",
+                to: "with_pool_untracked",
+            },
+        };
+        static SECOND: AppMigration = AppMigration {
+            id: "0.7.0-second",
+            version: "0.7.0",
+            title: "second",
+            confidence: Confidence::Auto,
+            guide: "docs/migrations/0.7.0.md#a",
+            rewrite: Rewrite::CallRename {
+                from: "with_pool_untracked",
+                to: "untracked_pool",
+            },
+        };
+        let chain: [&'static AppMigration; 2] = [&FIRST, &SECOND];
+
+        let first_run =
+            rewrite_source_for_releases("fn f() { R::with_pool(p); }", &chain).expect("parses");
+        assert_eq!(
+            first_run.updated.as_deref(),
+            Some("fn f() { R::untracked_pool(p); }"),
+            "one run reaches the newest name"
+        );
+
+        let second_run =
+            rewrite_source_for_releases(first_run.updated.as_deref().expect("rewritten"), &chain)
+                .expect("parses");
+        assert_eq!(second_run.updated, None, "and a second run is a no-op");
+    }
+
+    #[test]
+    fn sites_from_several_releases_are_reported_in_source_order() {
+        static A: AppMigration = AppMigration {
+            id: "0.6.0-a",
+            version: "0.6.0",
+            title: "a",
+            confidence: Confidence::Auto,
+            guide: "docs/migrations/0.6.0.md#a",
+            rewrite: Rewrite::CallRename {
+                from: "with_pool",
+                to: "with_pool_untracked",
+            },
+        };
+        static B: AppMigration = AppMigration {
+            id: "0.7.0-b",
+            version: "0.7.0",
+            title: "b",
+            confidence: Confidence::Auto,
+            guide: "docs/migrations/0.7.0.md#b",
+            rewrite: Rewrite::CallRename {
+                from: "old_name",
+                to: "new_name",
+            },
+        };
+        // `old_name` (0.7.0) is on line 2, `with_pool` (0.6.0) on line 3.
+        let source = "fn f() {\n    R::old_name(p);\n    R::with_pool(p);\n}\n";
+        let result = rewrite_source_for_releases(source, &[&A, &B]).expect("parses");
+        let lines: Vec<usize> = result.rewritten.iter().map(|site| site.line).collect();
+        assert_eq!(
+            lines,
+            vec![2, 3],
+            "reported top-to-bottom, not pass by pass"
+        );
+    }
+
+    #[test]
+    fn manual_reasons_read_as_a_sentence_fragment() {
+        assert_eq!(ManualReason::Macro.describe(), "inside a macro invocation");
+        assert_eq!(ManualReason::Attribute.describe(), "inside an attribute");
+        assert_eq!(
+            ManualReason::NotACall.describe(),
+            "referenced without being called"
+        );
+    }
+}

--- a/autumn-cli/src/upgrade/engine.rs
+++ b/autumn-cli/src/upgrade/engine.rs
@@ -23,6 +23,7 @@
 //! to build the identifier by concatenation, so a rewrite there is a guess.
 
 use proc_macro2::{Delimiter, TokenStream, TokenTree};
+use std::collections::BTreeSet;
 
 use super::migrations::{AppMigration, CallForm, ReceiverShape, Rewrite};
 
@@ -43,6 +44,12 @@ pub enum ManualReason {
     /// a same-named field. A rename is only safe at a call site, so the
     /// reference is reported instead of guessed at.
     NotACall,
+    /// The receiver is spelled like a generated repository, but no
+    /// `#[repository]` trait anywhere in the scanned source generates that
+    /// type. The naming convention on its own is not evidence: an app is free
+    /// to write its own `PgAuditRepository` with its own `with_pool`, and
+    /// rewriting that produces a call to a method which does not exist.
+    UnverifiedReceiver,
 }
 
 impl ManualReason {
@@ -53,6 +60,9 @@ impl ManualReason {
             Self::Attribute => "inside an attribute",
             Self::NotACall => "referenced without being called",
             Self::UnexpectedReceiver => "receiver is not a generated repository",
+            Self::UnverifiedReceiver => {
+                "no `#[repository]` trait in this app generates this receiver"
+            }
         }
     }
 }
@@ -147,6 +157,7 @@ struct Rename {
 pub fn rewrite_source(
     source: &str,
     migrations: &[&'static AppMigration],
+    generated: &BTreeSet<String>,
 ) -> Result<SourceRewrite, String> {
     let renames: Vec<Rename> = migrations
         .iter()
@@ -177,7 +188,7 @@ pub fn rewrite_source(
         .map_err(|error: proc_macro2::LexError| error.to_string())?;
 
     let mut hits = Vec::new();
-    scan(&stream, Context::Code, &renames, &mut hits);
+    scan(&stream, Context::Code, &renames, generated, &mut hits);
     // Token order is source order for a single stream, but nested groups are
     // walked depth-first, so the flattened list is not. Sorting makes the diff,
     // the reported sites, and the splice all read top-to-bottom.
@@ -254,13 +265,14 @@ pub fn rewrite_source(
 pub fn rewrite_source_for_releases(
     source: &str,
     migrations: &[&'static AppMigration],
+    generated: &BTreeSet<String>,
 ) -> Result<SourceRewrite, String> {
     let mut current = source.to_owned();
     let mut combined = SourceRewrite::default();
     let mut rewritten_anything = false;
 
     for release in releases(migrations) {
-        let pass = rewrite_source(&current, &release)?;
+        let pass = rewrite_source(&current, &release, generated)?;
         combined.rewritten.extend(pass.rewritten);
         combined.manual.extend(pass.manual);
         if let Some(updated) = pass.updated {
@@ -294,7 +306,13 @@ fn releases(migrations: &[&'static AppMigration]) -> Vec<Vec<&'static AppMigrati
 }
 
 /// Walk a token stream, recording every matching call site.
-fn scan(stream: &TokenStream, context: Context, renames: &[Rename], hits: &mut Vec<Hit>) {
+fn scan(
+    stream: &TokenStream,
+    context: Context,
+    renames: &[Rename],
+    generated: &BTreeSet<String>,
+    hits: &mut Vec<Hit>,
+) {
     let trees: Vec<TokenTree> = stream.clone().into_iter().collect();
     for (index, tree) in trees.iter().enumerate() {
         match tree {
@@ -303,6 +321,7 @@ fn scan(stream: &TokenStream, context: Context, renames: &[Rename], hits: &mut V
                     &group.stream(),
                     group_context(&trees, index, context),
                     renames,
+                    generated,
                     hits,
                 );
             }
@@ -336,10 +355,7 @@ fn scan(stream: &TokenStream, context: Context, renames: &[Rename], hits: &mut V
                         (!takes_arguments(&trees, index, rename.args))
                             .then_some(ManualReason::NotACall)
                     })
-                    .or_else(|| {
-                        (!receiver_matches(&trees, index, rename.receiver))
-                            .then_some(ManualReason::UnexpectedReceiver)
-                    });
+                    .or_else(|| receiver_verdict(&trees, index, rename.receiver, generated));
                 let span = ident.span();
                 let start = span.start();
                 hits.push(Hit {
@@ -566,26 +582,126 @@ fn turbofish_argument_list(trees: &[TokenTree], angle: usize) -> Option<&proc_ma
     None
 }
 
+/// The concrete types `#[repository]` generates from the traits in `source`.
+///
+/// `#[repository]` names its type `Pg{trait}`, so a trait `PostRepository`
+/// yields `PgPostRepository`. Collecting these across the scan turns the
+/// receiver test from a naming convention into evidence: a call on a type no
+/// scanned trait generates is the app's own, however it is spelled.
+///
+/// A file that does not parse contributes nothing rather than failing the scan
+/// — it is already reported as skipped on its own account.
+#[must_use]
+pub fn generated_repository_types(source: &str) -> Vec<String> {
+    let Ok(stream) = source.parse::<TokenStream>() else {
+        return Vec::new();
+    };
+    let mut found = Vec::new();
+    collect_repository_types(&stream, &mut found);
+    found
+}
+
+fn collect_repository_types(stream: &TokenStream, found: &mut Vec<String>) {
+    let trees: Vec<TokenTree> = stream.clone().into_iter().collect();
+    for (index, tree) in trees.iter().enumerate() {
+        match tree {
+            // `# [repository ...]` — the attribute is a `#` followed by a
+            // bracket group whose first token is the macro's name.
+            TokenTree::Punct(punct) if punct.as_char() == '#' => {
+                let Some(TokenTree::Group(group)) = trees.get(index + 1) else {
+                    continue;
+                };
+                if group.delimiter() != Delimiter::Bracket {
+                    continue;
+                }
+                let Some(TokenTree::Ident(name)) = group.stream().into_iter().next() else {
+                    continue;
+                };
+                if name != "repository" {
+                    continue;
+                }
+                if let Some(trait_name) = trait_name_after(&trees, index + 2) {
+                    found.push(format!("Pg{trait_name}"));
+                }
+            }
+            TokenTree::Group(group) => collect_repository_types(&group.stream(), found),
+            _ => {}
+        }
+    }
+}
+
+/// The name of the trait an attribute at `from` is applied to.
+///
+/// Skips whatever sits between the attribute and the `trait` keyword — further
+/// attributes, doc comments (which are attributes by the time this sees them),
+/// and a visibility modifier. Anything else means the attribute is not on a
+/// trait, and nothing is generated.
+fn trait_name_after(trees: &[TokenTree], from: usize) -> Option<String> {
+    let mut index = from;
+    while let Some(tree) = trees.get(index) {
+        match tree {
+            TokenTree::Punct(punct) if punct.as_char() == '#' => {
+                // Another attribute: step over it and its bracket group.
+                index += 2;
+            }
+            TokenTree::Ident(ident) if ident == "pub" => {
+                index += 1;
+                // An optional `(crate)` / `(super)` restriction.
+                if matches!(trees.get(index), Some(TokenTree::Group(group))
+                    if group.delimiter() == Delimiter::Parenthesis)
+                {
+                    index += 1;
+                }
+            }
+            TokenTree::Ident(ident) if ident == "unsafe" || ident == "auto" => index += 1,
+            TokenTree::Ident(ident) if ident == "trait" => {
+                return match trees.get(index + 1) {
+                    Some(TokenTree::Ident(name)) => Some(name.to_string()),
+                    _ => None,
+                };
+            }
+            _ => return None,
+        }
+    }
+    None
+}
+
 /// Whether the receiver path segment carries the prefix the framework gives
 /// the type this function is generated on.
 ///
 /// `#[repository]` names its concrete type `Pg{trait}` and the scaffold names
-/// every trait `{Model}Repository`, so `PgPostRepository` is a genuine receiver
-/// while an app's own `Cache` or `PgCache` is not. A rename with no declared
-/// shape accepts any receiver.
-fn receiver_matches(trees: &[TokenTree], index: usize, required: Option<ReceiverShape>) -> bool {
-    let Some(required) = required else {
-        return true;
-    };
+/// every trait `{Model}Repository`, so `PgPostRepository` has the shape of a
+/// genuine receiver while an app's own `Cache` or `PgCache` does not. A rename
+/// with no declared shape accepts any receiver.
+///
+/// The shape is the first of two tests. `generated` carries the types the
+/// scanned `#[repository]` traits actually generate, and a receiver that looks
+/// right but is not among them is the app's own — reported, never rewritten.
+fn receiver_verdict(
+    trees: &[TokenTree],
+    index: usize,
+    required: Option<ReceiverShape>,
+    generated: &BTreeSet<String>,
+) -> Option<ManualReason> {
+    let required = required?;
     // `PgPostRepository :: with_pool` — the receiver sits three tokens back,
     // past the pair of colons. Anything else (a `>` closing `<T as Trait>`, a
     // macro-built path) is not a plain receiver and is reported rather than
     // rewritten.
     let Some(at) = index.checked_sub(3) else {
-        return false;
+        return Some(ManualReason::UnexpectedReceiver);
     };
-    matches!(trees.get(at), Some(TokenTree::Ident(ident))
-        if required.matches(&ident.to_string()))
+    let Some(TokenTree::Ident(ident)) = trees.get(at) else {
+        return Some(ManualReason::UnexpectedReceiver);
+    };
+    let receiver = ident.to_string();
+    if !required.matches(&receiver) {
+        return Some(ManualReason::UnexpectedReceiver);
+    }
+    if generated.contains(&receiver) {
+        return None;
+    }
+    Some(ManualReason::UnverifiedReceiver)
 }
 
 /// Which call form `trees[index]` is written in, if any: `.` makes it a method
@@ -641,8 +757,100 @@ mod tests {
         },
     };
 
+    /// The receivers the shape/form/arity fixtures use, taken as generated.
+    ///
+    /// Those tests are about whether a *call* is the renamed one — call form,
+    /// arity, macro context, splicing. Requiring each of them to also declare a
+    /// `#[repository]` trait would test the verification layer over and over
+    /// and obscure what each case is actually pinning. `PgCache` is left out on
+    /// purpose: it is the fixture for a receiver of the wrong *shape*, which
+    /// must fail before verification is ever consulted.
+    fn assumed_generated() -> BTreeSet<String> {
+        [
+            "PgPostRepository",
+            "PgCommentRepository",
+            "PgAlphaRepository",
+            "PgBetaRepository",
+            "PgGammaRepository",
+        ]
+        .into_iter()
+        .map(str::to_owned)
+        .collect()
+    }
+
+    #[test]
+    fn collects_the_type_each_repository_trait_generates() {
+        // Every spelling the attribute is written in, including the arguments
+        // form (`tenant_scoped`) and a doc comment between the two, which is
+        // itself an attribute by the time the token stream sees it.
+        let types = generated_repository_types(
+            "#[repository]\npub trait PostRepository {}\n\
+             #[repository(tenant_scoped)]\ntrait CommentRepository {}\n\
+             #[repository]\n/// docs\npub(crate) trait TagRepository {}\n",
+        );
+        assert_eq!(
+            types,
+            vec!["PgPostRepository", "PgCommentRepository", "PgTagRepository"]
+        );
+    }
+
+    #[test]
+    fn ignores_repository_attributes_that_are_not_on_a_trait() {
+        // Nothing is generated, so nothing may be claimed as generated.
+        assert!(generated_repository_types("#[repository]\nstruct Post;\n").is_empty());
+        assert!(generated_repository_types("#[serde(rename)]\ntrait Post {}\n").is_empty());
+        // A file that does not parse contributes nothing rather than failing
+        // the whole scan; it is reported as skipped on its own account.
+        assert!(generated_repository_types("fn f( {").is_empty());
+    }
+
+    #[test]
+    fn finds_traits_nested_inside_a_module() {
+        let types = generated_repository_types(
+            "mod repositories {\n    #[repository]\n    pub trait PostRepository {}\n}\n",
+        );
+        assert_eq!(types, vec!["PgPostRepository"]);
+    }
+
+    #[test]
+    fn a_conventional_name_no_trait_generates_is_reported_not_rewritten() {
+        // The whole point of collecting the traits: `PgAuditRepository` has the
+        // generated shape exactly, and is still the app's own type.
+        let result = rewrite_source(
+            "fn f(p: P) { PgAuditRepository::with_pool(p); }",
+            &[&RENAME],
+            &assumed_generated(),
+        )
+        .expect("parses");
+        assert!(result.updated.is_none(), "nothing may be rewritten");
+        assert_eq!(
+            result.manual.first().map(|site| site.manual),
+            Some(Some(ManualReason::UnverifiedReceiver)),
+            "and the site is reported with the reason, got {:?}",
+            result.manual
+        );
+    }
+
+    #[test]
+    fn a_receiver_of_the_wrong_shape_is_still_the_shape_complaint() {
+        // Verification does not swallow the earlier test: `PgCache` fails on
+        // shape, and saying "no trait generates this" would misdescribe it.
+        let result = rewrite_source(
+            "fn f(p: P) { PgCache::with_pool(p); }",
+            &[&RENAME],
+            &assumed_generated(),
+        )
+        .expect("parses");
+        assert_eq!(
+            result.manual.first().map(|site| site.manual),
+            Some(Some(ManualReason::UnexpectedReceiver)),
+            "got {:?}",
+            result.manual
+        );
+    }
+
     fn run(source: &str) -> SourceRewrite {
-        rewrite_source(source, &[&RENAME]).expect("source parses")
+        rewrite_source(source, &[&RENAME], &assumed_generated()).expect("source parses")
     }
 
     fn rewritten(source: &str) -> String {
@@ -699,14 +907,22 @@ mod tests {
                 receiver: None,
             },
         };
-        let result = rewrite_source("fn f(b: B, p: P) { b.old_step(p); }", &[&METHOD_RENAME])
-            .expect("parses");
+        let result = rewrite_source(
+            "fn f(b: B, p: P) { b.old_step(p); }",
+            &[&METHOD_RENAME],
+            &assumed_generated(),
+        )
+        .expect("parses");
         assert_eq!(
             result.updated.as_deref(),
             Some("fn f(b: B, p: P) { b.new_step(p); }")
         );
-        let path_form =
-            rewrite_source("fn f(p: P) { B::old_step(p); }", &[&METHOD_RENAME]).expect("parses");
+        let path_form = rewrite_source(
+            "fn f(p: P) { B::old_step(p); }",
+            &[&METHOD_RENAME],
+            &assumed_generated(),
+        )
+        .expect("parses");
         assert_eq!(path_form.updated, None, "a method rename leaves `::` alone");
     }
 
@@ -903,8 +1119,12 @@ mod tests {
             guide: "docs/migrations/0.6.0.md#anchor",
             rewrite: Rewrite::GuideOnly,
         };
-        let result = rewrite_source("fn f() { PgPostRepository::with_pool(p); }", &[&GUIDE_ONLY])
-            .expect("parses");
+        let result = rewrite_source(
+            "fn f() { PgPostRepository::with_pool(p); }",
+            &[&GUIDE_ONLY],
+            &assumed_generated(),
+        )
+        .expect("parses");
         assert_eq!(result.updated, None);
         assert!(result.rewritten.is_empty());
         assert!(result.manual.is_empty());
@@ -912,7 +1132,8 @@ mod tests {
 
     #[test]
     fn an_unparsable_file_is_an_error_not_a_rewrite() {
-        let err = rewrite_source("fn f( {", &[&RENAME]).expect_err("must not silently succeed");
+        let err = rewrite_source("fn f( {", &[&RENAME], &assumed_generated())
+            .expect_err("must not silently succeed");
         assert!(!err.is_empty(), "the parse error is reported to the user");
     }
 
@@ -1074,18 +1295,24 @@ mod tests {
         };
         let chain: [&'static AppMigration; 2] = [&FIRST, &SECOND];
 
-        let first_run =
-            rewrite_source_for_releases("fn f() { PgPostRepository::with_pool(p); }", &chain)
-                .expect("parses");
+        let first_run = rewrite_source_for_releases(
+            "fn f() { PgPostRepository::with_pool(p); }",
+            &chain,
+            &assumed_generated(),
+        )
+        .expect("parses");
         assert_eq!(
             first_run.updated.as_deref(),
             Some("fn f() { PgPostRepository::untracked_pool(p); }"),
             "one run reaches the newest name"
         );
 
-        let second_run =
-            rewrite_source_for_releases(first_run.updated.as_deref().expect("rewritten"), &chain)
-                .expect("parses");
+        let second_run = rewrite_source_for_releases(
+            first_run.updated.as_deref().expect("rewritten"),
+            &chain,
+            &assumed_generated(),
+        )
+        .expect("parses");
         assert_eq!(second_run.updated, None, "and a second run is a no-op");
     }
 
@@ -1121,7 +1348,8 @@ mod tests {
         };
         // `old_name` (0.7.0) is on line 2, `with_pool` (0.6.0) on line 3.
         let source = "fn f() {\n    R::old_name(p);\n    PgPostRepository::with_pool(p);\n}\n";
-        let result = rewrite_source_for_releases(source, &[&A, &B]).expect("parses");
+        let result =
+            rewrite_source_for_releases(source, &[&A, &B], &assumed_generated()).expect("parses");
         let lines: Vec<usize> = result.rewritten.iter().map(|site| site.line).collect();
         assert_eq!(
             lines,
@@ -1196,8 +1424,12 @@ mod tests {
                 receiver: None,
             },
         };
-        let result =
-            rewrite_source("fn f(p: P) { Anything::old_ctor(p); }", &[&ANY]).expect("parses");
+        let result = rewrite_source(
+            "fn f(p: P) { Anything::old_ctor(p); }",
+            &[&ANY],
+            &assumed_generated(),
+        )
+        .expect("parses");
         assert_eq!(
             result.updated.as_deref(),
             Some("fn f(p: P) { Anything::new_ctor(p); }")

--- a/autumn-cli/src/upgrade/engine.rs
+++ b/autumn-cli/src/upgrade/engine.rs
@@ -614,10 +614,7 @@ fn collect_repository_types(stream: &TokenStream, found: &mut Vec<String>) {
                 if group.delimiter() != Delimiter::Bracket {
                     continue;
                 }
-                let Some(TokenTree::Ident(name)) = group.stream().into_iter().next() else {
-                    continue;
-                };
-                if name != "repository" {
+                if !is_repository_attribute(&group.stream()) {
                     continue;
                 }
                 if let Some(trait_name) = trait_name_after(&trees, index + 2) {
@@ -628,6 +625,33 @@ fn collect_repository_types(stream: &TokenStream, found: &mut Vec<String>) {
             _ => {}
         }
     }
+}
+
+/// Whether an attribute body names the `repository` macro.
+///
+/// Matched on the *last* path segment, because the qualified spelling
+/// `#[autumn_web::repository(...)]` is the one the scaffold emits — insisting
+/// the attribute begin with `repository` missed the common case and classified
+/// every call site in a scaffolded app as unverified. The crate segment cannot
+/// be pinned down either: a manifest is free to rename the dependency
+/// (`autumn = { package = "autumn-web" }`), which makes the attribute
+/// `#[autumn::repository]`.
+///
+/// Only the path is read. Anything with an argument list — `#[cfg(feature =
+/// "repository")]` — is judged by its own name, not by what its arguments say.
+fn is_repository_attribute(stream: &TokenStream) -> bool {
+    let mut last_segment = None;
+    for tree in stream.clone() {
+        match tree {
+            TokenTree::Ident(ident) => last_segment = Some(ident.to_string()),
+            // Path separators, and a leading `::` for a fully-qualified path.
+            TokenTree::Punct(punct) if punct.as_char() == ':' => {}
+            // The argument list ends the path; anything else is not a path at
+            // all, and either way the name is already whatever came before it.
+            _ => break,
+        }
+    }
+    last_segment.is_some_and(|segment| segment == "repository")
 }
 
 /// The name of the trait an attribute at `from` is applied to.
@@ -791,6 +815,38 @@ mod tests {
         assert_eq!(
             types,
             vec!["PgPostRepository", "PgCommentRepository", "PgTagRepository"]
+        );
+    }
+
+    #[test]
+    fn recognises_the_qualified_attribute_spelling() {
+        // What the scaffold emits, plus the renamed-dependency spelling a
+        // manifest can produce and a fully-qualified path.
+        for attribute in [
+            "#[autumn_web::repository(Post, table = \"posts\")]",
+            "#[autumn::repository(Post)]",
+            "#[::autumn_web::repository]",
+        ] {
+            let types = generated_repository_types(&format!(
+                "{attribute}\npub trait PostRepository {{}}\n"
+            ));
+            assert_eq!(types, vec!["PgPostRepository"], "for {attribute}");
+        }
+    }
+
+    #[test]
+    fn does_not_read_repository_out_of_another_attributes_arguments() {
+        // The path is what names the macro. `#[cfg(feature = "repository")]`
+        // is a `cfg`, whatever its arguments happen to spell.
+        assert!(
+            generated_repository_types(
+                "#[cfg(feature = \"repository\")]\npub trait PostRepository {}\n"
+            )
+            .is_empty()
+        );
+        assert!(
+            generated_repository_types("#[derive(repository)]\npub trait PostRepository {}\n")
+                .is_empty()
         );
     }
 

--- a/autumn-cli/src/upgrade/engine.rs
+++ b/autumn-cli/src/upgrade/engine.rs
@@ -601,6 +601,55 @@ pub fn generated_repository_types(source: &str) -> Vec<(String, Vec<String>)> {
     found
 }
 
+/// Type names the source *writes out* — `struct`, `enum`, `union`, `type`.
+///
+/// `#[repository]` produces its type from a macro, so it never appears here. A
+/// name that does appear is therefore a hand-written type, which is what makes
+/// this the counter-evidence to a generated name: an app that declares
+/// `#[repository] trait AuditRepository` in one place and writes
+/// `struct PgAuditRepository` in another has two different types spelled the
+/// same, and an unqualified call cannot be attributed to either.
+#[must_use]
+pub fn defined_type_names(source: &str) -> Vec<String> {
+    let Ok(stream) = source.parse::<TokenStream>() else {
+        return Vec::new();
+    };
+    let mut found = Vec::new();
+    collect_defined_types(&stream, Context::Code, &mut found);
+    found
+}
+
+fn collect_defined_types(stream: &TokenStream, context: Context, found: &mut Vec<String>) {
+    let trees: Vec<TokenTree> = stream.clone().into_iter().collect();
+    for (index, tree) in trees.iter().enumerate() {
+        match tree {
+            TokenTree::Ident(keyword)
+                if context == Context::Code
+                    && matches!(keyword.to_string().as_str(), "struct" | "enum" | "union") =>
+            {
+                if let Some(TokenTree::Ident(name)) = trees.get(index + 1) {
+                    found.push(name.to_string());
+                }
+            }
+            // `type Alias = …;`, but not the `type` of an associated item
+            // binding, which is followed by `=` only after a generic list.
+            TokenTree::Ident(keyword) if context == Context::Code && keyword == "type" => {
+                if let Some(TokenTree::Ident(name)) = trees.get(index + 1) {
+                    found.push(name.to_string());
+                }
+            }
+            TokenTree::Group(group) => {
+                collect_defined_types(
+                    &group.stream(),
+                    group_context(&trees, index, context),
+                    found,
+                );
+            }
+            _ => {}
+        }
+    }
+}
+
 /// The generated repository types an app declares, and where.
 ///
 /// The module path matters because a name on its own can be ambiguous: an app
@@ -608,15 +657,23 @@ pub fn generated_repository_types(source: &str) -> Vec<(String, Vec<String>)> {
 /// `custom::PgAuditRepository`, and a call written against the second one would
 /// otherwise be verified by the first.
 #[derive(Debug, Default)]
-pub struct GeneratedRepositories(BTreeMap<String, BTreeSet<Vec<String>>>);
+pub struct GeneratedRepositories {
+    declared: BTreeMap<String, BTreeSet<Vec<String>>>,
+    /// Names the scanned source defines as ordinary types. See
+    /// [`defined_type_names`].
+    handwritten: BTreeSet<String>,
+}
 
 impl FromIterator<(String, Vec<String>)> for GeneratedRepositories {
     fn from_iter<I: IntoIterator<Item = (String, Vec<String>)>>(iter: I) -> Self {
-        let mut map: BTreeMap<String, BTreeSet<Vec<String>>> = BTreeMap::new();
+        let mut declared: BTreeMap<String, BTreeSet<Vec<String>>> = BTreeMap::new();
         for (name, module) in iter {
-            map.entry(name).or_default().insert(module);
+            declared.entry(name).or_default().insert(module);
         }
-        Self(map)
+        Self {
+            declared,
+            handwritten: BTreeSet::new(),
+        }
     }
 }
 
@@ -632,9 +689,14 @@ impl GeneratedRepositories {
     /// `repositories::…`, `crate::repositories::…` and a bare `…` inside that
     /// module all are. A qualifier naming a module that generates nothing —
     /// `custom::PgAuditRepository` — is not this type.
+    /// Record the type names the scanned source writes out itself.
+    pub fn note_handwritten<I: IntoIterator<Item = String>>(&mut self, names: I) {
+        self.handwritten.extend(names);
+    }
+
     #[must_use]
     pub fn accepts(&self, name: &str, qualifier: &[String]) -> bool {
-        let Some(declared) = self.0.get(name) else {
+        let Some(declared) = self.declared.get(name) else {
             return false;
         };
         // `crate::`, `self::` and `super::` say where to start resolving, not
@@ -647,7 +709,11 @@ impl GeneratedRepositories {
             .cloned()
             .collect();
         if qualifier.is_empty() {
-            return true;
+            // Nothing in the call says which module it means, so a hand-written
+            // type of the same name anywhere in the scan makes it ambiguous —
+            // including one in a different crate, since a `use` can bring
+            // either spelling into scope unqualified. Reported, not guessed at.
+            return !self.handwritten.contains(name);
         }
         declared
             .iter()
@@ -985,6 +1051,44 @@ mod tests {
         // A file that does not parse contributes nothing rather than failing
         // the whole scan; it is reported as skipped on its own account.
         assert!(generated_names("fn f( {").is_empty());
+    }
+
+    #[test]
+    fn a_handwritten_type_of_the_same_name_makes_an_unqualified_call_ambiguous() {
+        let mut generated: GeneratedRepositories = std::iter::once((
+            "PgAuditRepository".to_owned(),
+            vec!["repositories".to_owned()],
+        ))
+        .collect();
+        assert!(
+            generated.accepts("PgAuditRepository", &[]),
+            "with nothing else of that name, the generated type is the only reading"
+        );
+
+        generated.note_handwritten(std::iter::once("PgAuditRepository".to_owned()));
+        assert!(
+            !generated.accepts("PgAuditRepository", &[]),
+            "once the source writes out a type of that name the call is ambiguous"
+        );
+        // A qualifier still decides it: the author said which module they meant.
+        assert!(generated.accepts("PgAuditRepository", &["repositories".to_owned()]));
+    }
+
+    #[test]
+    fn reads_the_type_names_the_source_writes_out() {
+        assert_eq!(
+            defined_type_names("pub struct PgAuditRepository;\nenum E {}\ntype Alias = u8;"),
+            vec!["PgAuditRepository", "E", "Alias"]
+        );
+        // `#[repository]` output never appears in source, so a trait declaring
+        // one contributes nothing here — that is what makes the two sets
+        // independent evidence.
+        assert!(defined_type_names("#[repository]\npub trait PostRepository {}").is_empty());
+        // Macro input is not a definition, for the same reason it is not a
+        // declaration.
+        assert!(
+            defined_type_names("macro_rules! m { () => { struct PgAuditRepository; } }").is_empty()
+        );
     }
 
     #[test]

--- a/autumn-cli/src/upgrade/engine.rs
+++ b/autumn-cli/src/upgrade/engine.rs
@@ -597,17 +597,25 @@ pub fn generated_repository_types(source: &str) -> Vec<String> {
         return Vec::new();
     };
     let mut found = Vec::new();
-    collect_repository_types(&stream, &mut found);
+    collect_repository_types(&stream, Context::Code, &mut found);
     found
 }
 
-fn collect_repository_types(stream: &TokenStream, found: &mut Vec<String>) {
+/// Only declarations in ordinary code count.
+///
+/// Tokens inside a macro definition or invocation may never be expanded, or may
+/// be consumed as data — the same reason call sites there are reported rather
+/// than rewritten. Reading a declaration out of one would let a template that
+/// merely mentions `#[repository] trait AuditRepository` verify an unrelated
+/// `PgAuditRepository` elsewhere, which is the wrong rewrite this verification
+/// exists to prevent.
+fn collect_repository_types(stream: &TokenStream, context: Context, found: &mut Vec<String>) {
     let trees: Vec<TokenTree> = stream.clone().into_iter().collect();
     for (index, tree) in trees.iter().enumerate() {
         match tree {
             // `# [repository ...]` — the attribute is a `#` followed by a
             // bracket group whose first token is the macro's name.
-            TokenTree::Punct(punct) if punct.as_char() == '#' => {
+            TokenTree::Punct(punct) if punct.as_char() == '#' && context == Context::Code => {
                 let Some(TokenTree::Group(group)) = trees.get(index + 1) else {
                     continue;
                 };
@@ -621,7 +629,11 @@ fn collect_repository_types(stream: &TokenStream, found: &mut Vec<String>) {
                     found.push(format!("Pg{trait_name}"));
                 }
             }
-            TokenTree::Group(group) => collect_repository_types(&group.stream(), found),
+            TokenTree::Group(group) => collect_repository_types(
+                &group.stream(),
+                group_context(&trees, index, context),
+                found,
+            ),
             _ => {}
         }
     }
@@ -858,6 +870,25 @@ mod tests {
         // A file that does not parse contributes nothing rather than failing
         // the whole scan; it is reported as skipped on its own account.
         assert!(generated_repository_types("fn f( {").is_empty());
+    }
+
+    #[test]
+    fn a_trait_inside_macro_input_is_not_evidence() {
+        // Tokens inside a macro definition or invocation may never be expanded,
+        // or may be consumed as data. Treating them as declarations would let a
+        // template that merely *mentions* `#[repository] trait AuditRepository`
+        // verify an unrelated `PgAuditRepository` elsewhere in the app — the
+        // exact wrong rewrite the verification exists to prevent.
+        assert!(
+            generated_repository_types(
+                "macro_rules! template { () => { #[repository] trait AuditRepository {} } }"
+            )
+            .is_empty()
+        );
+        assert!(
+            generated_repository_types("declare! { #[repository] trait AuditRepository {} }")
+                .is_empty()
+        );
     }
 
     #[test]

--- a/autumn-cli/src/upgrade/engine.rs
+++ b/autumn-cli/src/upgrade/engine.rs
@@ -23,7 +23,7 @@
 //! to build the identifier by concatenation, so a rewrite there is a guess.
 
 use proc_macro2::{Delimiter, TokenStream, TokenTree};
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 
 use super::migrations::{AppMigration, CallForm, ReceiverShape, Rewrite};
 
@@ -157,7 +157,7 @@ struct Rename {
 pub fn rewrite_source(
     source: &str,
     migrations: &[&'static AppMigration],
-    generated: &BTreeSet<String>,
+    generated: &GeneratedRepositories,
 ) -> Result<SourceRewrite, String> {
     let renames: Vec<Rename> = migrations
         .iter()
@@ -265,7 +265,7 @@ pub fn rewrite_source(
 pub fn rewrite_source_for_releases(
     source: &str,
     migrations: &[&'static AppMigration],
-    generated: &BTreeSet<String>,
+    generated: &GeneratedRepositories,
 ) -> Result<SourceRewrite, String> {
     let mut current = source.to_owned();
     let mut combined = SourceRewrite::default();
@@ -310,7 +310,7 @@ fn scan(
     stream: &TokenStream,
     context: Context,
     renames: &[Rename],
-    generated: &BTreeSet<String>,
+    generated: &GeneratedRepositories,
     hits: &mut Vec<Hit>,
 ) {
     let trees: Vec<TokenTree> = stream.clone().into_iter().collect();
@@ -592,13 +592,67 @@ fn turbofish_argument_list(trees: &[TokenTree], angle: usize) -> Option<&proc_ma
 /// A file that does not parse contributes nothing rather than failing the scan
 /// — it is already reported as skipped on its own account.
 #[must_use]
-pub fn generated_repository_types(source: &str) -> Vec<String> {
+pub fn generated_repository_types(source: &str) -> Vec<(String, Vec<String>)> {
     let Ok(stream) = source.parse::<TokenStream>() else {
         return Vec::new();
     };
     let mut found = Vec::new();
-    collect_repository_types(&stream, Context::Code, &mut found);
+    collect_repository_types(&stream, Context::Code, &[], &mut found);
     found
+}
+
+/// The generated repository types an app declares, and where.
+///
+/// The module path matters because a name on its own can be ambiguous: an app
+/// with a real `repositories::PgAuditRepository` may also have an unrelated
+/// `custom::PgAuditRepository`, and a call written against the second one would
+/// otherwise be verified by the first.
+#[derive(Debug, Default)]
+pub struct GeneratedRepositories(BTreeMap<String, BTreeSet<Vec<String>>>);
+
+impl FromIterator<(String, Vec<String>)> for GeneratedRepositories {
+    fn from_iter<I: IntoIterator<Item = (String, Vec<String>)>>(iter: I) -> Self {
+        let mut map: BTreeMap<String, BTreeSet<Vec<String>>> = BTreeMap::new();
+        for (name, module) in iter {
+            map.entry(name).or_default().insert(module);
+        }
+        Self(map)
+    }
+}
+
+impl GeneratedRepositories {
+    /// Whether a call on `name`, written with `qualifier` in front of it,
+    /// refers to a type some `#[repository]` trait generates.
+    ///
+    /// An unqualified receiver is accepted on the name alone — that is how the
+    /// overwhelming majority of call sites are written, and resolving it
+    /// properly would mean following `use` declarations. A *qualified* one
+    /// carries the module the author meant, so it is checked: the qualifier has
+    /// to be a trailing part of some declaration's own path, which is what
+    /// `repositories::…`, `crate::repositories::…` and a bare `…` inside that
+    /// module all are. A qualifier naming a module that generates nothing —
+    /// `custom::PgAuditRepository` — is not this type.
+    #[must_use]
+    pub fn accepts(&self, name: &str, qualifier: &[String]) -> bool {
+        let Some(declared) = self.0.get(name) else {
+            return false;
+        };
+        // `crate::`, `self::` and `super::` say where to start resolving, not
+        // which module declares the type. `super` cannot be resolved without
+        // knowing the caller's own module, so it is dropped rather than guessed
+        // at — erring toward accepting a name that is generated somewhere.
+        let qualifier: Vec<String> = qualifier
+            .iter()
+            .skip_while(|segment| matches!(segment.as_str(), "crate" | "self" | "super" | "$crate"))
+            .cloned()
+            .collect();
+        if qualifier.is_empty() {
+            return true;
+        }
+        declared
+            .iter()
+            .any(|path| path.len() >= qualifier.len() && path.ends_with(&qualifier[..]))
+    }
 }
 
 /// Only declarations in ordinary code count.
@@ -609,7 +663,12 @@ pub fn generated_repository_types(source: &str) -> Vec<String> {
 /// merely mentions `#[repository] trait AuditRepository` verify an unrelated
 /// `PgAuditRepository` elsewhere, which is the wrong rewrite this verification
 /// exists to prevent.
-fn collect_repository_types(stream: &TokenStream, context: Context, found: &mut Vec<String>) {
+fn collect_repository_types(
+    stream: &TokenStream,
+    context: Context,
+    module: &[String],
+    found: &mut Vec<(String, Vec<String>)>,
+) {
     let trees: Vec<TokenTree> = stream.clone().into_iter().collect();
     for (index, tree) in trees.iter().enumerate() {
         match tree {
@@ -626,14 +685,25 @@ fn collect_repository_types(stream: &TokenStream, context: Context, found: &mut 
                     continue;
                 }
                 if let Some(trait_name) = trait_name_after(&trees, index + 2) {
-                    found.push(format!("Pg{trait_name}"));
+                    found.push((format!("Pg{trait_name}"), module.to_vec()));
                 }
             }
-            TokenTree::Group(group) => collect_repository_types(
-                &group.stream(),
-                group_context(&trees, index, context),
-                found,
-            ),
+            TokenTree::Group(group) => {
+                // `mod name { … }` opens a module; every other brace is just a
+                // block, and the path it holds is the one it inherits.
+                let nested = module_name_before(&trees, index).map(|name| {
+                    let mut nested = module.to_vec();
+                    nested.push(name);
+                    nested
+                });
+                let inner = nested.as_deref().unwrap_or(module);
+                collect_repository_types(
+                    &group.stream(),
+                    group_context(&trees, index, context),
+                    inner,
+                    found,
+                );
+            }
             _ => {}
         }
     }
@@ -664,6 +734,23 @@ fn is_repository_attribute(stream: &TokenStream) -> bool {
         }
     }
     last_segment.is_some_and(|segment| segment == "repository")
+}
+
+/// The module name when `trees[index]` is the body of `mod name { … }`.
+fn module_name_before(trees: &[TokenTree], index: usize) -> Option<String> {
+    let TokenTree::Group(group) = &trees[index] else {
+        return None;
+    };
+    if group.delimiter() != Delimiter::Brace {
+        return None;
+    }
+    let Some(TokenTree::Ident(name)) = trees.get(index.checked_sub(1)?) else {
+        return None;
+    };
+    // The `mod` keyword sits directly before the name under either spelling —
+    // `pub mod name { … }` puts the visibility before the keyword, not after.
+    let keyword = trees.get(index.checked_sub(2)?);
+    matches!(keyword, Some(TokenTree::Ident(keyword)) if keyword == "mod").then(|| name.to_string())
 }
 
 /// The name of the trait an attribute at `from` is applied to.
@@ -717,7 +804,7 @@ fn receiver_verdict(
     trees: &[TokenTree],
     index: usize,
     required: Option<ReceiverShape>,
-    generated: &BTreeSet<String>,
+    generated: &GeneratedRepositories,
 ) -> Option<ManualReason> {
     let required = required?;
     // `PgPostRepository :: with_pool` — the receiver sits three tokens back,
@@ -734,10 +821,36 @@ fn receiver_verdict(
     if !required.matches(&receiver) {
         return Some(ManualReason::UnexpectedReceiver);
     }
-    if generated.contains(&receiver) {
+    if generated.accepts(&receiver, &path_qualifier(trees, at)) {
         return None;
     }
     Some(ManualReason::UnverifiedReceiver)
+}
+
+/// The module path written in front of the receiver at `at`, outermost first.
+///
+/// `custom::PgAuditRepository::with_pool` yields `["custom"]`; a bare
+/// `PgAuditRepository::with_pool` yields nothing.
+fn path_qualifier(trees: &[TokenTree], at: usize) -> Vec<String> {
+    let mut segments = Vec::new();
+    let mut index = at;
+    // Each step back over `ident ::` is one more segment.
+    while index >= 3 {
+        let separator = matches!(&trees[index - 1], TokenTree::Punct(punct) if punct.as_char() == ':')
+            && matches!(&trees[index - 2], TokenTree::Punct(punct) if punct.as_char() == ':');
+        if !separator {
+            break;
+        }
+        let Some(TokenTree::Ident(ident)) = trees.get(index - 3) else {
+            break;
+        };
+        segments.push(ident.to_string());
+        index -= 3;
+    }
+    // A leading `::` on a fully-qualified path leaves no ident to read, and the
+    // segments were collected innermost first.
+    segments.reverse();
+    segments
 }
 
 /// Which call form `trees[index]` is written in, if any: `.` makes it a method
@@ -801,7 +914,7 @@ mod tests {
     /// and obscure what each case is actually pinning. `PgCache` is left out on
     /// purpose: it is the fixture for a receiver of the wrong *shape*, which
     /// must fail before verification is ever consulted.
-    fn assumed_generated() -> BTreeSet<String> {
+    fn assumed_generated() -> GeneratedRepositories {
         [
             "PgPostRepository",
             "PgCommentRepository",
@@ -810,8 +923,17 @@ mod tests {
             "PgGammaRepository",
         ]
         .into_iter()
-        .map(str::to_owned)
+        .map(|name| (name.to_owned(), Vec::new()))
         .collect()
+    }
+
+    /// Just the generated type names, for the cases that are about detection
+    /// rather than about where the trait lives.
+    fn generated_names(source: &str) -> Vec<String> {
+        generated_repository_types(source)
+            .into_iter()
+            .map(|(name, _)| name)
+            .collect()
     }
 
     #[test]
@@ -819,7 +941,7 @@ mod tests {
         // Every spelling the attribute is written in, including the arguments
         // form (`tenant_scoped`) and a doc comment between the two, which is
         // itself an attribute by the time the token stream sees it.
-        let types = generated_repository_types(
+        let types = generated_names(
             "#[repository]\npub trait PostRepository {}\n\
              #[repository(tenant_scoped)]\ntrait CommentRepository {}\n\
              #[repository]\n/// docs\npub(crate) trait TagRepository {}\n",
@@ -839,9 +961,7 @@ mod tests {
             "#[autumn::repository(Post)]",
             "#[::autumn_web::repository]",
         ] {
-            let types = generated_repository_types(&format!(
-                "{attribute}\npub trait PostRepository {{}}\n"
-            ));
+            let types = generated_names(&format!("{attribute}\npub trait PostRepository {{}}\n"));
             assert_eq!(types, vec!["PgPostRepository"], "for {attribute}");
         }
     }
@@ -851,25 +971,61 @@ mod tests {
         // The path is what names the macro. `#[cfg(feature = "repository")]`
         // is a `cfg`, whatever its arguments happen to spell.
         assert!(
-            generated_repository_types(
-                "#[cfg(feature = \"repository\")]\npub trait PostRepository {}\n"
-            )
-            .is_empty()
-        );
-        assert!(
-            generated_repository_types("#[derive(repository)]\npub trait PostRepository {}\n")
+            generated_names("#[cfg(feature = \"repository\")]\npub trait PostRepository {}\n")
                 .is_empty()
         );
+        assert!(generated_names("#[derive(repository)]\npub trait PostRepository {}\n").is_empty());
     }
 
     #[test]
     fn ignores_repository_attributes_that_are_not_on_a_trait() {
         // Nothing is generated, so nothing may be claimed as generated.
-        assert!(generated_repository_types("#[repository]\nstruct Post;\n").is_empty());
-        assert!(generated_repository_types("#[serde(rename)]\ntrait Post {}\n").is_empty());
+        assert!(generated_names("#[repository]\nstruct Post;\n").is_empty());
+        assert!(generated_names("#[serde(rename)]\ntrait Post {}\n").is_empty());
         // A file that does not parse contributes nothing rather than failing
         // the whole scan; it is reported as skipped on its own account.
-        assert!(generated_repository_types("fn f( {").is_empty());
+        assert!(generated_names("fn f( {").is_empty());
+    }
+
+    #[test]
+    fn a_qualifier_decides_between_same_named_types() {
+        let generated: GeneratedRepositories = std::iter::once((
+            "PgAuditRepository".to_owned(),
+            vec!["repositories".to_owned()],
+        ))
+        .collect();
+
+        // Unqualified: accepted on the name. Resolving it would mean following
+        // `use` declarations, and this is how nearly every call site is written.
+        assert!(generated.accepts("PgAuditRepository", &[]));
+        // The module it is actually declared in, however the path is spelled.
+        assert!(generated.accepts("PgAuditRepository", &["repositories".to_owned()]));
+        assert!(generated.accepts(
+            "PgAuditRepository",
+            &["crate".to_owned(), "repositories".to_owned()]
+        ));
+        // A module that generates nothing of that name.
+        assert!(!generated.accepts("PgAuditRepository", &["custom".to_owned()]));
+        // And a name nothing generates at all.
+        assert!(!generated.accepts("PgOtherRepository", &[]));
+    }
+
+    #[test]
+    fn records_the_module_a_trait_is_declared_in() {
+        assert_eq!(
+            generated_repository_types(
+                "mod repositories {\n  mod inner { #[repository] pub trait PostRepository {} }\n}"
+            ),
+            vec![(
+                "PgPostRepository".to_owned(),
+                vec!["repositories".to_owned(), "inner".to_owned()]
+            )]
+        );
+        // A plain block is not a module and contributes no path segment.
+        assert_eq!(
+            generated_repository_types("fn f() { #[repository] trait PostRepository {} }"),
+            vec![("PgPostRepository".to_owned(), Vec::<String>::new())]
+        );
     }
 
     #[test]
@@ -880,20 +1036,17 @@ mod tests {
         // verify an unrelated `PgAuditRepository` elsewhere in the app — the
         // exact wrong rewrite the verification exists to prevent.
         assert!(
-            generated_repository_types(
+            generated_names(
                 "macro_rules! template { () => { #[repository] trait AuditRepository {} } }"
             )
             .is_empty()
         );
-        assert!(
-            generated_repository_types("declare! { #[repository] trait AuditRepository {} }")
-                .is_empty()
-        );
+        assert!(generated_names("declare! { #[repository] trait AuditRepository {} }").is_empty());
     }
 
     #[test]
     fn finds_traits_nested_inside_a_module() {
-        let types = generated_repository_types(
+        let types = generated_names(
             "mod repositories {\n    #[repository]\n    pub trait PostRepository {}\n}\n",
         );
         assert_eq!(types, vec!["PgPostRepository"]);
@@ -1476,8 +1629,19 @@ mod tests {
     #[test]
     fn rewrites_a_generated_repository_receiver_however_it_is_pathed() {
         // The prefix is on the final path segment, so a fully-qualified path to
-        // a generated repository still matches.
-        let out = rewritten("fn f(p: Pool) { crate::repos::PgPostRepository::with_pool(p); }");
+        // a generated repository still matches — provided the path leads to the
+        // module the trait is declared in, which is what makes it *this* type
+        // rather than a same-named one somewhere else.
+        let generated: GeneratedRepositories =
+            std::iter::once(("PgPostRepository".to_owned(), vec!["repos".to_owned()])).collect();
+        let out = rewrite_source(
+            "fn f(p: Pool) { crate::repos::PgPostRepository::with_pool(p); }",
+            &[&RENAME],
+            &generated,
+        )
+        .expect("parses")
+        .updated
+        .expect("source was rewritten");
         assert!(
             out.contains("PgPostRepository::with_pool_untracked(p)"),
             "{out}"

--- a/autumn-cli/src/upgrade/engine.rs
+++ b/autumn-cli/src/upgrade/engine.rs
@@ -613,7 +613,7 @@ pub fn generated_repository_types(source: &str) -> Vec<(String, Vec<String>)> {
         return Vec::new();
     };
     let mut found = Vec::new();
-    collect_repository_types(&stream, Context::Code, &[], &mut found);
+    collect_repository_types(&stream, Context::Code, &[], Scope::Module, &mut found);
     found
 }
 
@@ -781,6 +781,17 @@ impl GeneratedRepositories {
     }
 }
 
+/// Whether a declaration here is visible to the rest of the module.
+///
+/// `#[repository]` inside a function body generates a type scoped to that body;
+/// recording it against the enclosing module let it vouch for an unrelated
+/// same-named import elsewhere in the file.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Scope {
+    Module,
+    Block,
+}
+
 /// Only declarations in ordinary code count.
 ///
 /// Tokens inside a macro definition or invocation may never be expanded, or may
@@ -793,6 +804,7 @@ fn collect_repository_types(
     stream: &TokenStream,
     context: Context,
     module: &[String],
+    scope: Scope,
     found: &mut Vec<(String, Vec<String>)>,
 ) {
     let trees: Vec<TokenTree> = stream.clone().into_iter().collect();
@@ -817,7 +829,12 @@ fn collect_repository_types(
                 if attribute_run_is_cfg_gated(&trees, index) {
                     continue;
                 }
-                if let Some(trait_name) = trait_name_after(&trees, index + 2) {
+                // A declaration inside a block generates a type visible only
+                // in that block, so it vouches for nothing beyond it — and the
+                // calls it could vouch for are all inside it too.
+                if scope == Scope::Module
+                    && let Some(trait_name) = trait_name_after(&trees, index + 2)
+                {
                     found.push((format!("Pg{trait_name}"), module.to_vec()));
                 }
             }
@@ -830,10 +847,19 @@ fn collect_repository_types(
                     nested
                 });
                 let inner = nested.as_deref().unwrap_or(module);
+                // Anything that is not a `mod` body is a block: a `mod` written
+                // *inside* one is still only visible there, so the scope never
+                // widens again once it has narrowed.
+                let inner_scope = if nested.is_some() && scope == Scope::Module {
+                    Scope::Module
+                } else {
+                    Scope::Block
+                };
                 collect_repository_types(
                     &group.stream(),
                     group_context(&trees, index, context),
                     inner,
+                    inner_scope,
                     found,
                 );
             }
@@ -1310,10 +1336,44 @@ mod tests {
                 vec!["repositories".to_owned(), "inner".to_owned()]
             )]
         );
-        // A plain block is not a module and contributes no path segment.
+        // A declaration inside a plain block is scoped to that block, so it is
+        // not evidence for anything — see the block-scope test below.
+        assert!(
+            generated_repository_types("fn f() { #[repository] trait PostRepository {} }")
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn a_block_local_repository_is_not_module_wide_evidence() {
+        // Codex review on #2231: a trait declared in a function body generates a
+        // type visible only in that body, so recording it against the enclosing
+        // module let an unrelated `PgPostRepository` imported elsewhere in that
+        // module be treated as verified and rewritten.
+        for source in [
+            "fn f() { #[repository] trait PostRepository {} }",
+            "mod repositories { fn f() { #[repository] trait PostRepository {} } }",
+            // A `mod` nested inside a block is still only visible in the block.
+            "fn f() { mod inner { #[repository] trait PostRepository {} } }",
+        ] {
+            assert!(
+                generated_repository_types(source).is_empty(),
+                "for {source}",
+            );
+        }
+    }
+
+    #[test]
+    fn a_module_level_repository_is_still_evidence() {
+        // The scope fix must not swing the other way.
         assert_eq!(
-            generated_repository_types("fn f() { #[repository] trait PostRepository {} }"),
-            vec![("PgPostRepository".to_owned(), Vec::<String>::new())]
+            generated_repository_types(
+                "mod repositories { #[repository] trait PostRepository {} }"
+            ),
+            vec![(
+                "PgPostRepository".to_owned(),
+                vec!["repositories".to_owned()]
+            )]
         );
     }
 

--- a/autumn-cli/src/upgrade/engine.rs
+++ b/autumn-cli/src/upgrade/engine.rs
@@ -855,7 +855,42 @@ fn collect_repository_types(
 /// Only the path is read. Anything with an argument list — `#[cfg(feature =
 /// "repository")]` — is judged by its own name, not by what its arguments say.
 fn is_repository_attribute(stream: &TokenStream) -> bool {
-    attribute_last_segment(stream).is_some_and(|segment| segment == "repository")
+    let segments = attribute_path_segments(stream);
+    let Some((last, crate_segment)) = segments.split_last() else {
+        return false;
+    };
+    if last != "repository" {
+        return false;
+    }
+    // A qualified path names the crate the macro comes from, and only Autumn's
+    // proves Autumn generated the type: another dependency's
+    // `#[other_macros::repository]` was otherwise read as evidence, which then
+    // licensed rewriting an unrelated same-named import. A manifest may rename
+    // the dependency, so a rename combined with the *qualified* spelling is
+    // reported rather than rewritten — the safe direction, and the bare
+    // `#[repository]` the scaffold emits is unaffected.
+    crate_segment
+        .first()
+        .is_none_or(|krate| matches!(krate.as_str(), "autumn_web" | "autumn"))
+}
+
+/// The path segments of an attribute body, outermost first.
+///
+/// `autumn_web::repository(Post)` yields `["autumn_web", "repository"]`; the
+/// argument list ends the path.
+fn attribute_path_segments(stream: &TokenStream) -> Vec<String> {
+    let mut segments = Vec::new();
+    for tree in stream.clone() {
+        match tree {
+            TokenTree::Ident(ident) => segments.push(ident.to_string()),
+            // Path separators, and a leading `::` for a fully-qualified path.
+            TokenTree::Punct(punct) if punct.as_char() == ':' => {}
+            // The argument list ends the path; anything else is not a path at
+            // all, and either way the name is already whatever came before it.
+            _ => break,
+        }
+    }
+    segments
 }
 
 /// The last path segment of an attribute body, or `None` if it names no path.
@@ -1130,6 +1165,25 @@ mod tests {
             types,
             vec!["PgPostRepository", "PgCommentRepository", "PgTagRepository"]
         );
+    }
+
+    #[test]
+    fn a_foreign_repository_attribute_is_not_evidence() {
+        // Codex review on #2231: the matcher read only the last path segment,
+        // so another crate's `repository` attribute proved that Autumn had
+        // generated `PgAuditRepository` — and an unrelated imported type of
+        // that name was then rewritten.
+        for attribute in [
+            "#[other_macros::repository]",
+            "#[diesel::repository(Audit)]",
+            "#[::sea_orm::repository]",
+        ] {
+            assert!(
+                generated_names(&format!("{attribute}\npub trait AuditRepository {{}}\n"))
+                    .is_empty(),
+                "for {attribute}",
+            );
+        }
     }
 
     #[test]

--- a/autumn-cli/src/upgrade/engine.rs
+++ b/autumn-cli/src/upgrade/engine.rs
@@ -601,6 +601,14 @@ fn turbofish_argument_list(trees: &[TokenTree], angle: usize) -> Option<&proc_ma
 /// — it is already reported as skipped on its own account.
 #[must_use]
 pub fn generated_repository_types(source: &str) -> Vec<(String, Vec<String>)> {
+    // Positive evidence has to be sound: `#[repository] trait AuditRepository;`
+    // tokenises and generates nothing, because a trait without a body is not
+    // Rust. Believing it would verify an unrelated `PgAuditRepository` in a file
+    // that *is* valid. The counter-evidence in `defined_type_names` deliberately
+    // does not do this — see there.
+    if syn::parse_file(source).is_err() {
+        return Vec::new();
+    }
     let Ok(stream) = source.parse::<TokenStream>() else {
         return Vec::new();
     };
@@ -610,6 +618,12 @@ pub fn generated_repository_types(source: &str) -> Vec<(String, Vec<String>)> {
 }
 
 /// Type names the source *writes out* — `struct`, `enum`, `union`, `type`.
+///
+/// Deliberately not gated on the file parsing, unlike
+/// [`generated_repository_types`]. This is counter-evidence: it only ever moves
+/// a call from rewritten to reported. A file too broken to parse is exactly
+/// where a hand-written `PgAuditRepository` might be hiding, and ignoring it
+/// would err toward rewriting.
 ///
 /// `#[repository]` produces its type from a macro, so it never appears here. A
 /// name that does appear is therefore a hand-written type, which is what makes

--- a/autumn-cli/src/upgrade/engine.rs
+++ b/autumn-cli/src/upgrade/engine.rs
@@ -24,7 +24,7 @@
 
 use proc_macro2::{Delimiter, TokenStream, TokenTree};
 
-use super::migrations::{AppMigration, Rewrite};
+use super::migrations::{AppMigration, CallForm, Rewrite};
 
 /// Why a site was left for a human.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -121,6 +121,10 @@ struct Rename {
     id: &'static str,
     from: &'static str,
     to: &'static str,
+    /// Which call form the renamed function actually has.
+    form: CallForm,
+    /// Exact top-level argument count of the renamed function.
+    args: usize,
 }
 
 /// Apply `migrations` to one file's `source`.
@@ -139,10 +143,17 @@ pub fn rewrite_source(
     let renames: Vec<Rename> = migrations
         .iter()
         .filter_map(|migration| match migration.rewrite {
-            Rewrite::CallRename { from, to } => Some(Rename {
+            Rewrite::CallRename {
+                from,
+                to,
+                form,
+                args,
+            } => Some(Rename {
                 id: migration.id,
                 from,
                 to,
+                form,
+                args,
             }),
             Rewrite::GuideOnly => None,
         })
@@ -286,12 +297,12 @@ fn scan(stream: &TokenStream, context: Context, renames: &[Rename], hits: &mut V
                 );
             }
             TokenTree::Ident(ident) => {
-                // The separator is what makes this the framework API rather
-                // than any other use of the word; whether an argument list
-                // follows decides between rewriting it and reporting it.
-                if !is_receiver_separator(&trees, index) {
+                // The separator is what makes this a call on something rather
+                // than any other use of the word, and *which* separator says
+                // whether it can be the renamed function at all.
+                let Some(separator) = receiver_separator(&trees, index) else {
                     continue;
-                }
+                };
                 let name = ident.to_string();
                 // `r#with_pool` is the same name written raw. Match on the bare
                 // name and carry the prefix through to the splice, or the site
@@ -299,11 +310,18 @@ fn scan(stream: &TokenStream, context: Context, renames: &[Rename], hits: &mut V
                 let (prefix, bare) = name
                     .strip_prefix("r#")
                     .map_or(("", name.as_str()), |bare| ("r#", bare));
-                let Some(rename) = renames.iter().find(|rename| rename.from == bare) else {
+                // The form must match too. `AppState::with_pool` is a *builder
+                // method* that keeps the old name, so a `.with_pool(pool)` call
+                // is provably not the renamed constructor — not a site this
+                // declines to rewrite, a site that is a different function.
+                let Some(rename) = renames
+                    .iter()
+                    .find(|rename| rename.from == bare && rename.form == separator)
+                else {
                     continue;
                 };
                 let manual = context.manual_reason().or_else(|| {
-                    (!has_argument_list(&trees, index)).then_some(ManualReason::NotACall)
+                    (!takes_arguments(&trees, index, rename.args)).then_some(ManualReason::NotACall)
                 });
                 let span = ident.span();
                 let start = span.start();
@@ -424,23 +442,53 @@ fn is_macro_name(trees: &[TokenTree], bang: usize) -> bool {
 /// A reference is not renamed: `xs.map(Repo::with_pool)` hands the function
 /// itself somewhere, and the tool has no way to know the receiver's type. Such
 /// a site is reported as [`ManualReason::NotACall`] rather than skipped.
-fn has_argument_list(trees: &[TokenTree], index: usize) -> bool {
-    match trees.get(index + 1) {
-        Some(TokenTree::Group(group)) => group.delimiter() == Delimiter::Parenthesis,
+fn takes_arguments(trees: &[TokenTree], index: usize, want: usize) -> bool {
+    let arguments = match trees.get(index + 1) {
+        Some(TokenTree::Group(group)) if group.delimiter() == Delimiter::Parenthesis => group,
         // Turbofish: `name::<T>(...)` is a call; `Vec<Repo::with_pool::<T>>` is
         // a type, so the closing angle has to be followed by an argument list.
         Some(TokenTree::Punct(punct)) if punct.as_char() == ':' => {
-            matches!(trees.get(index + 2), Some(TokenTree::Punct(second)) if second.as_char() == ':')
-                && matches!(trees.get(index + 3), Some(TokenTree::Punct(angle)) if angle.as_char() == '<')
-                && turbofish_closes_on_a_call(trees, index + 3)
+            if !matches!(trees.get(index + 2), Some(TokenTree::Punct(second)) if second.as_char() == ':')
+                || !matches!(trees.get(index + 3), Some(TokenTree::Punct(angle)) if angle.as_char() == '<')
+            {
+                return false;
+            }
+            match turbofish_argument_list(trees, index + 3) {
+                Some(group) => group,
+                None => return false,
+            }
         }
-        _ => false,
-    }
+        _ => return false,
+    };
+    count_arguments(arguments) == want
 }
 
-/// Walk from the `<` at `angle` to its matching `>` and report whether an
-/// argument list follows it.
-fn turbofish_closes_on_a_call(trees: &[TokenTree], angle: usize) -> bool {
+/// Top-level arguments in a call's parentheses.
+///
+/// A rename cannot change arity, so this is what separates the renamed
+/// function from a same-named one reached through UFCS: the generated
+/// `Repo::with_pool(pool)` takes one argument, while `AppState::with_pool`
+/// written as `AppState::with_pool(state, pool)` takes two. Nested groups are
+/// atomic token trees, so every comma seen here is an argument separator.
+fn count_arguments(group: &proc_macro2::Group) -> usize {
+    let mut arguments = 0;
+    let mut in_argument = false;
+    for tree in group.stream() {
+        match &tree {
+            TokenTree::Punct(punct) if punct.as_char() == ',' => {
+                arguments += 1;
+                in_argument = false;
+            }
+            _ => in_argument = true,
+        }
+    }
+    // A trailing comma closes the last argument rather than opening one.
+    arguments + usize::from(in_argument)
+}
+
+/// Walk from the `<` at `angle` to its matching `>` and return the argument
+/// list that follows it, if any.
+fn turbofish_argument_list(trees: &[TokenTree], angle: usize) -> Option<&proc_macro2::Group> {
     let mut depth = 0usize;
     for at in angle..trees.len() {
         let TokenTree::Punct(punct) = &trees[at] else {
@@ -454,48 +502,53 @@ fn turbofish_closes_on_a_call(trees: &[TokenTree], angle: usize) -> bool {
             {
                 depth -= 1;
                 if depth == 0 {
-                    return matches!(trees.get(at + 1), Some(TokenTree::Group(group))
-                        if group.delimiter() == Delimiter::Parenthesis);
+                    return match trees.get(at + 1) {
+                        Some(TokenTree::Group(group))
+                            if group.delimiter() == Delimiter::Parenthesis =>
+                        {
+                            Some(group)
+                        }
+                        _ => None,
+                    };
                 }
             }
             _ => {}
         }
     }
-    false
+    None
 }
 
-/// Whether `trees[index]` is preceded by a `.` or a full `::`.
+/// Which call form `trees[index]` is written in, if any: `.` makes it a method
+/// call, a full `::` makes it an associated-function call.
 ///
 /// The `::` test insists on *both* colons: a single `:` before an identifier is
 /// a struct-literal field value or a type ascription (`Config { pool: with_pool }`),
-/// which is not the renamed associated function.
-fn is_receiver_separator(trees: &[TokenTree], index: usize) -> bool {
-    let Some(before) = index.checked_sub(1) else {
-        return false;
-    };
+/// which is not a call at all.
+fn receiver_separator(trees: &[TokenTree], index: usize) -> Option<CallForm> {
+    let before = index.checked_sub(1)?;
     let TokenTree::Punct(punct) = &trees[before] else {
-        return false;
+        return None;
+    };
+    let preceded_by = |ch: char| {
+        matches!(
+            before.checked_sub(1).map(|at| &trees[at]),
+            Some(TokenTree::Punct(first)) if first.as_char() == ch
+        )
     };
     match punct.as_char() {
         // A second `.` makes this a range or struct-update expression
         // (`0..with_pool(n)`, `C { ..with_pool(d) }`), whose operand is a free
         // function — not a method on a receiver.
-        '.' => !matches!(
-            before.checked_sub(1).map(|at| &trees[at]),
-            Some(TokenTree::Punct(first)) if first.as_char() == '.'
-        ),
-        ':' => matches!(
-            before.checked_sub(1).map(|at| &trees[at]),
-            Some(TokenTree::Punct(first)) if first.as_char() == ':'
-        ),
-        _ => false,
+        '.' if !preceded_by('.') => Some(CallForm::Method),
+        ':' if preceded_by(':') => Some(CallForm::AssociatedFunction),
+        _ => None,
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::upgrade::migrations::{AppMigration, Confidence};
+    use crate::upgrade::migrations::{AppMigration, CallForm, Confidence};
 
     /// The shipped 0.6.0 rename, used by every case below.
     static RENAME: AppMigration = AppMigration {
@@ -507,6 +560,8 @@ mod tests {
         rewrite: Rewrite::CallRename {
             from: "with_pool",
             to: "with_pool_untracked",
+            form: CallForm::AssociatedFunction,
+            args: 1,
         },
     };
 
@@ -533,12 +588,64 @@ mod tests {
     }
 
     #[test]
-    fn rewrites_a_method_call() {
-        let out = rewritten("fn f(b: B, p: Pool) { let r = b.with_pool(p); }");
-        assert_eq!(
-            out,
-            "fn f(b: B, p: Pool) { let r = b.with_pool_untracked(p); }"
+    fn leaves_a_same_named_builder_method_alone() {
+        // `AppState::with_pool` and `AuthzContext::with_pool` are *current*
+        // framework builder methods that keep the old name. The renamed
+        // constructor takes no `self`, so a `.with_pool(pool)` call is provably
+        // a different function — rewriting it would break
+        // `AppState::for_test().with_pool(pool)`, which is ordinary test setup.
+        let result = run("fn f(s: AppState, p: Pool) { let s = s.with_pool(p); }");
+        assert_eq!(result.updated, None);
+        assert!(
+            result.manual.is_empty(),
+            "not an ambiguous site to flag — a different function entirely: {:?}",
+            result.manual
         );
+    }
+
+    #[test]
+    fn rewrites_a_method_call_for_a_method_form_rename() {
+        // The form is a property of the migration, not a global rule: a future
+        // rename of a real method rewrites the `.` form and not the `::` one.
+        static METHOD_RENAME: AppMigration = AppMigration {
+            id: "test-method-rename",
+            version: "0.7.0",
+            title: "method rename",
+            confidence: Confidence::Auto,
+            guide: "docs/migrations/0.7.0.md#anchor",
+            rewrite: Rewrite::CallRename {
+                from: "old_step",
+                to: "new_step",
+                form: CallForm::Method,
+                args: 1,
+            },
+        };
+        let result = rewrite_source("fn f(b: B, p: P) { b.old_step(p); }", &[&METHOD_RENAME])
+            .expect("parses");
+        assert_eq!(
+            result.updated.as_deref(),
+            Some("fn f(b: B, p: P) { b.new_step(p); }")
+        );
+        let path_form =
+            rewrite_source("fn f(p: P) { B::old_step(p); }", &[&METHOD_RENAME]).expect("parses");
+        assert_eq!(path_form.updated, None, "a method rename leaves `::` alone");
+    }
+
+    #[test]
+    fn leaves_a_ufcs_call_with_the_wrong_arity_alone() {
+        // `AppState::with_pool(state, pool)` is the builder method reached
+        // through UFCS: same name, same `::` form, one argument too many. A
+        // rename cannot change arity, so arity tells them apart.
+        let result = run("fn f(s: AppState, p: Pool) { let s = AppState::with_pool(s, p); }");
+        assert_eq!(result.updated, None);
+    }
+
+    #[test]
+    fn arity_is_counted_at_the_top_level_only() {
+        // A comma nested inside an argument is not an argument separator, and
+        // a trailing comma does not open a new argument.
+        let out = rewritten("fn f() { Repo::with_pool(make(a, b),); }");
+        assert!(out.contains("with_pool_untracked(make(a, b),)"), "{out}");
     }
 
     #[test]
@@ -638,7 +745,7 @@ mod tests {
     #[test]
     fn records_line_and_column_for_every_rewritten_site() {
         let source =
-            "fn f() {\n    let a = Repo::with_pool(p);\n    let b = other.with_pool(q);\n}\n";
+            "fn f() {\n    let a = Repo::with_pool(p);\n    let b = Other::with_pool(q);\n}\n";
         let result = run(source);
         assert_eq!(result.rewritten.len(), 2);
         assert_eq!(result.rewritten[0].line, 2);
@@ -664,13 +771,13 @@ mod tests {
 
     #[test]
     fn rewrites_every_site_in_a_file() {
-        let source = "fn f() { A::with_pool(p); B::with_pool(q); c.with_pool(r); }";
+        let source = "fn f() { A::with_pool(p); B::with_pool(q); C::with_pool(r); }";
         let result = run(source);
         assert_eq!(result.rewritten.len(), 3);
         assert_eq!(
             result.updated.as_deref(),
             Some(
-                "fn f() { A::with_pool_untracked(p); B::with_pool_untracked(q); c.with_pool_untracked(r); }"
+                "fn f() { A::with_pool_untracked(p); B::with_pool_untracked(q); C::with_pool_untracked(r); }"
             )
         );
     }
@@ -712,7 +819,7 @@ mod tests {
         // The dangerous half: rewriting the matcher makes the macro reject the
         // invocations its users write, while those invocations are (correctly)
         // reported as manual and left alone — a tree that does not compile.
-        let source = "macro_rules! forward {\n    ($s:ident . with_pool ( $p:expr )) => { $s.with_pool($p) };\n}\n";
+        let source = "macro_rules! forward {\n    ($t:ident :: with_pool ( $p:expr )) => { $t::with_pool($p) };\n}\n";
         let result = run(source);
         assert_eq!(
             result.updated, None,
@@ -841,6 +948,8 @@ mod tests {
             rewrite: Rewrite::CallRename {
                 from: "with_pool",
                 to: "with_pool_untracked",
+                form: CallForm::AssociatedFunction,
+                args: 1,
             },
         };
         static SECOND: AppMigration = AppMigration {
@@ -852,6 +961,8 @@ mod tests {
             rewrite: Rewrite::CallRename {
                 from: "with_pool_untracked",
                 to: "untracked_pool",
+                form: CallForm::AssociatedFunction,
+                args: 1,
             },
         };
         let chain: [&'static AppMigration; 2] = [&FIRST, &SECOND];
@@ -881,6 +992,8 @@ mod tests {
             rewrite: Rewrite::CallRename {
                 from: "with_pool",
                 to: "with_pool_untracked",
+                form: CallForm::AssociatedFunction,
+                args: 1,
             },
         };
         static B: AppMigration = AppMigration {
@@ -892,6 +1005,8 @@ mod tests {
             rewrite: Rewrite::CallRename {
                 from: "old_name",
                 to: "new_name",
+                form: CallForm::AssociatedFunction,
+                args: 1,
             },
         };
         // `old_name` (0.7.0) is on line 2, `with_pool` (0.6.0) on line 3.

--- a/autumn-cli/src/upgrade/engine.rs
+++ b/autumn-cli/src/upgrade/engine.rs
@@ -24,7 +24,7 @@
 
 use proc_macro2::{Delimiter, TokenStream, TokenTree};
 
-use super::migrations::{AppMigration, CallForm, Rewrite};
+use super::migrations::{AppMigration, CallForm, ReceiverShape, Rewrite};
 
 /// Why a site was left for a human.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -131,8 +131,8 @@ struct Rename {
     form: CallForm,
     /// Exact top-level argument count of the renamed function.
     args: usize,
-    /// Required prefix on the receiver path segment, if any.
-    receiver: Option<&'static str>,
+    /// Naming shape the receiver must have, if the framework fixes one.
+    receiver: Option<ReceiverShape>,
 }
 
 /// Apply `migrations` to one file's `source`.
@@ -538,10 +538,11 @@ fn turbofish_argument_list(trees: &[TokenTree], angle: usize) -> Option<&proc_ma
 /// Whether the receiver path segment carries the prefix the framework gives
 /// the type this function is generated on.
 ///
-/// `#[repository]` names its concrete type `Pg{trait}`, so `PgPostRepository`
-/// is a genuine receiver and an app's own `Cache` is not. A rename with no
-/// declared prefix accepts any receiver.
-fn receiver_matches(trees: &[TokenTree], index: usize, required: Option<&str>) -> bool {
+/// `#[repository]` names its concrete type `Pg{trait}` and the scaffold names
+/// every trait `{Model}Repository`, so `PgPostRepository` is a genuine receiver
+/// while an app's own `Cache` or `PgCache` is not. A rename with no declared
+/// shape accepts any receiver.
+fn receiver_matches(trees: &[TokenTree], index: usize, required: Option<ReceiverShape>) -> bool {
     let Some(required) = required else {
         return true;
     };
@@ -553,7 +554,7 @@ fn receiver_matches(trees: &[TokenTree], index: usize, required: Option<&str>) -
         return false;
     };
     matches!(trees.get(at), Some(TokenTree::Ident(ident))
-        if ident.to_string().starts_with(required))
+        if required.matches(&ident.to_string()))
 }
 
 /// Which call form `trees[index]` is written in, if any: `.` makes it a method
@@ -600,8 +601,12 @@ mod tests {
             to: "with_pool_untracked",
             form: CallForm::AssociatedFunction,
             args: 1,
-            // Mirrors the shipped migration: `#[repository]` emits `Pg{trait}`.
-            receiver: Some("Pg"),
+            // Mirrors the shipped migration: `#[repository]` emits `Pg{trait}`
+            // and the scaffold names every trait `{Model}Repository`.
+            receiver: Some(ReceiverShape {
+                prefix: "Pg",
+                suffix: "Repository",
+            }),
         },
     };
 
@@ -687,23 +692,26 @@ mod tests {
     fn arity_is_counted_at_the_top_level_only() {
         // A comma nested inside an argument is not an argument separator, and
         // a trailing comma does not open a new argument.
-        let out = rewritten("fn f() { PgRepo::with_pool(make(a, b),); }");
+        let out = rewritten("fn f() { PgPostRepository::with_pool(make(a, b),); }");
         assert!(out.contains("with_pool_untracked(make(a, b),)"), "{out}");
     }
 
     #[test]
     fn rewrites_a_turbofished_call() {
-        let out = rewritten("fn f() { PgRepo::with_pool::<Pg>(p); }");
-        assert_eq!(out, "fn f() { PgRepo::with_pool_untracked::<Pg>(p); }");
+        let out = rewritten("fn f() { PgPostRepository::with_pool::<Pg>(p); }");
+        assert_eq!(
+            out,
+            "fn f() { PgPostRepository::with_pool_untracked::<Pg>(p); }"
+        );
     }
 
     #[test]
     fn preserves_formatting_comments_and_line_endings() {
-        let source = "fn f() {\r\n    // build it with_pool, historically\r\n    let r = PgRepo::with_pool(p);   // trailing\r\n}\r\n";
+        let source = "fn f() {\r\n    // build it with_pool, historically\r\n    let r = PgPostRepository::with_pool(p);   // trailing\r\n}\r\n";
         let out = rewritten(source);
         assert_eq!(
             out,
-            "fn f() {\r\n    // build it with_pool, historically\r\n    let r = PgRepo::with_pool_untracked(p);   // trailing\r\n}\r\n"
+            "fn f() {\r\n    // build it with_pool, historically\r\n    let r = PgPostRepository::with_pool_untracked(p);   // trailing\r\n}\r\n"
         );
     }
 
@@ -711,14 +719,14 @@ mod tests {
     fn leaves_the_already_renamed_call_untouched() {
         // Applying twice is a no-op: the rename is matched on whole tokens, so
         // the new name is simply a different identifier.
-        let result = run("fn f() { PgRepo::with_pool_untracked(p); }");
+        let result = run("fn f() { PgPostRepository::with_pool_untracked(p); }");
         assert_eq!(result.updated, None);
         assert!(result.rewritten.is_empty());
     }
 
     #[test]
     fn leaves_a_different_identifier_with_the_same_prefix_untouched() {
-        let result = run("fn f() { PgRepo::with_pool_provider(p); }");
+        let result = run("fn f() { PgPostRepository::with_pool_provider(p); }");
         assert_eq!(result.updated, None);
     }
 
@@ -747,7 +755,7 @@ mod tests {
 
     #[test]
     fn reports_a_macro_body_site_as_manual_without_rewriting_it() {
-        let source = "fn f() {\n    make_repo! { PgRepo::with_pool(p) }\n}\n";
+        let source = "fn f() {\n    make_repo! { PgPostRepository::with_pool(p) }\n}\n";
         let result = run(source);
         assert_eq!(result.updated, None, "a macro body is never rewritten");
         assert!(result.rewritten.is_empty());
@@ -760,7 +768,7 @@ mod tests {
 
     #[test]
     fn reports_a_nested_macro_body_site_as_manual() {
-        let source = "fn f() {\n    outer!(inner!(PgRepo::with_pool(p)));\n}\n";
+        let source = "fn f() {\n    outer!(inner!(PgPostRepository::with_pool(p)));\n}\n";
         let result = run(source);
         assert_eq!(result.updated, None);
         assert_eq!(result.manual.len(), 1);
@@ -769,7 +777,7 @@ mod tests {
 
     #[test]
     fn reports_an_attribute_site_as_manual() {
-        let source = "#[derive_repo(build = PgRepo::with_pool(p))]\nstruct S;\n";
+        let source = "#[derive_repo(build = PgPostRepository::with_pool(p))]\nstruct S;\n";
         let result = run(source);
         assert_eq!(result.updated, None);
         assert_eq!(result.manual.len(), 1);
@@ -787,13 +795,12 @@ mod tests {
 
     #[test]
     fn records_line_and_column_for_every_rewritten_site() {
-        let source =
-            "fn f() {\n    let a = PgRepo::with_pool(p);\n    let b = PgOther::with_pool(q);\n}\n";
+        let source = "fn f() {\n    let a = PgPostRepository::with_pool(p);\n    let b = PgCommentRepository::with_pool(q);\n}\n";
         let result = run(source);
         assert_eq!(result.rewritten.len(), 2);
         assert_eq!(result.rewritten[0].line, 2);
         assert_eq!(
-            result.rewritten[0].column, 21,
+            result.rewritten[0].column, 31,
             "1-based column of `with_pool`"
         );
         assert_eq!(result.rewritten[1].line, 3);
@@ -804,23 +811,24 @@ mod tests {
     fn splices_correctly_after_multibyte_characters() {
         // Byte offsets, not char offsets: an em dash before the site shifts the
         // two apart, and getting it wrong corrupts the file.
-        let source = "fn f() {\n    // — a note —\n    let r = PgRepo::with_pool(p);\n}\n";
+        let source =
+            "fn f() {\n    // — a note —\n    let r = PgPostRepository::with_pool(p);\n}\n";
         let out = rewritten(source);
         assert_eq!(
             out,
-            "fn f() {\n    // — a note —\n    let r = PgRepo::with_pool_untracked(p);\n}\n"
+            "fn f() {\n    // — a note —\n    let r = PgPostRepository::with_pool_untracked(p);\n}\n"
         );
     }
 
     #[test]
     fn rewrites_every_site_in_a_file() {
-        let source = "fn f() { PgA::with_pool(p); PgB::with_pool(q); PgC::with_pool(r); }";
+        let source = "fn f() { PgAlphaRepository::with_pool(p); PgBetaRepository::with_pool(q); PgGammaRepository::with_pool(r); }";
         let result = run(source);
         assert_eq!(result.rewritten.len(), 3);
         assert_eq!(
             result.updated.as_deref(),
             Some(
-                "fn f() { PgA::with_pool_untracked(p); PgB::with_pool_untracked(q); PgC::with_pool_untracked(r); }"
+                "fn f() { PgAlphaRepository::with_pool_untracked(p); PgBetaRepository::with_pool_untracked(q); PgGammaRepository::with_pool_untracked(r); }"
             )
         );
     }
@@ -829,7 +837,7 @@ mod tests {
     fn rewrites_inside_cfg_disabled_code() {
         // `#[cfg(...)]` code is still the app's source and still has to compile
         // on the configuration that enables it.
-        let source = "#[cfg(feature = \"db\")]\nfn f() { PgRepo::with_pool(p); }\n";
+        let source = "#[cfg(feature = \"db\")]\nfn f() { PgPostRepository::with_pool(p); }\n";
         let out = rewritten(source);
         assert!(out.contains("with_pool_untracked"));
     }
@@ -844,8 +852,8 @@ mod tests {
             guide: "docs/migrations/0.6.0.md#anchor",
             rewrite: Rewrite::GuideOnly,
         };
-        let result =
-            rewrite_source("fn f() { PgRepo::with_pool(p); }", &[&GUIDE_ONLY]).expect("parses");
+        let result = rewrite_source("fn f() { PgPostRepository::with_pool(p); }", &[&GUIDE_ONLY])
+            .expect("parses");
         assert_eq!(result.updated, None);
         assert!(result.rewritten.is_empty());
         assert!(result.manual.is_empty());
@@ -885,13 +893,13 @@ mod tests {
     #[test]
     fn every_macro_definition_shape_is_treated_as_macro_input() {
         for source in [
-            "macro_rules! m { () => { PgR::with_pool(p) }; }",
-            "macro_rules! m ( () => ( PgR::with_pool(p) ); );",
-            "macro_rules! m [ () => [ PgR::with_pool(p) ]; ];",
-            "#[macro_export]\nmacro_rules! m { () => { PgR::with_pool(p) }; }",
-            "fn outer() { macro_rules! m { () => { PgR::with_pool(p) }; } }",
-            "pub macro m() { PgR::with_pool(p) }",
-            "pub macro m { () => { PgR::with_pool(p) } }",
+            "macro_rules! m { () => { PgPostRepository::with_pool(p) }; }",
+            "macro_rules! m ( () => ( PgPostRepository::with_pool(p) ); );",
+            "macro_rules! m [ () => [ PgPostRepository::with_pool(p) ]; ];",
+            "#[macro_export]\nmacro_rules! m { () => { PgPostRepository::with_pool(p) }; }",
+            "fn outer() { macro_rules! m { () => { PgPostRepository::with_pool(p) }; } }",
+            "pub macro m() { PgPostRepository::with_pool(p) }",
+            "pub macro m { () => { PgPostRepository::with_pool(p) } }",
         ] {
             let result = run(source);
             assert_eq!(result.updated, None, "must not rewrite: {source}");
@@ -928,9 +936,9 @@ mod tests {
         // "No site is silently skipped": a function item handed somewhere else
         // still stops compiling after the rename, so it has to be reported.
         for source in [
-            "fn f() { xs.iter().map(PgRepo::with_pool); }",
-            "fn f() { let g = PgRepo::with_pool; g(p); }",
-            "fn f() { let g: fn(P) -> R = PgRepo::with_pool; }",
+            "fn f() { xs.iter().map(PgPostRepository::with_pool); }",
+            "fn f() { let g = PgPostRepository::with_pool; g(p); }",
+            "fn f() { let g: fn(P) -> R = PgPostRepository::with_pool; }",
         ] {
             let result = run(source);
             assert_eq!(
@@ -950,14 +958,17 @@ mod tests {
 
     #[test]
     fn a_raw_identifier_call_site_is_rewritten_keeping_its_prefix() {
-        let out = rewritten("fn f() { PgRepo::r#with_pool(p); }");
-        assert_eq!(out, "fn f() { PgRepo::r#with_pool_untracked(p); }");
+        let out = rewritten("fn f() { PgPostRepository::r#with_pool(p); }");
+        assert_eq!(
+            out,
+            "fn f() { PgPostRepository::r#with_pool_untracked(p); }"
+        );
     }
 
     #[test]
     fn a_turbofish_that_is_not_a_call_is_not_rewritten() {
-        // `Vec<PgRepo::with_pool::<T>>` is a type path, not a call.
-        let result = run("fn f(x: Vec<PgRepo::with_pool::<T>>) {}");
+        // `Vec<PgPostRepository::with_pool::<T>>` is a type path, not a call.
+        let result = run("fn f(x: Vec<PgPostRepository::with_pool::<T>>) {}");
         assert_eq!(result.updated, None);
         assert!(
             result
@@ -970,7 +981,7 @@ mod tests {
     #[test]
     fn a_turbofish_returning_a_function_type_still_reads_as_a_call() {
         // The `>` of the `->` inside the generic argument closes nothing.
-        let out = rewritten("fn f() { PgRepo::with_pool::<fn(A) -> B>(p); }");
+        let out = rewritten("fn f() { PgPostRepository::with_pool::<fn(A) -> B>(p); }");
         assert!(
             out.contains("with_pool_untracked::<fn(A) -> B>(p)"),
             "{out}"
@@ -1013,10 +1024,11 @@ mod tests {
         let chain: [&'static AppMigration; 2] = [&FIRST, &SECOND];
 
         let first_run =
-            rewrite_source_for_releases("fn f() { PgR::with_pool(p); }", &chain).expect("parses");
+            rewrite_source_for_releases("fn f() { PgPostRepository::with_pool(p); }", &chain)
+                .expect("parses");
         assert_eq!(
             first_run.updated.as_deref(),
-            Some("fn f() { PgR::untracked_pool(p); }"),
+            Some("fn f() { PgPostRepository::untracked_pool(p); }"),
             "one run reaches the newest name"
         );
 
@@ -1057,7 +1069,7 @@ mod tests {
             },
         };
         // `old_name` (0.7.0) is on line 2, `with_pool` (0.6.0) on line 3.
-        let source = "fn f() {\n    R::old_name(p);\n    PgR::with_pool(p);\n}\n";
+        let source = "fn f() {\n    R::old_name(p);\n    PgPostRepository::with_pool(p);\n}\n";
         let result = rewrite_source_for_releases(source, &[&A, &B]).expect("parses");
         let lines: Vec<usize> = result.rewritten.iter().map(|site| site.line).collect();
         assert_eq!(
@@ -1076,6 +1088,19 @@ mod tests {
         let result = run("fn f(p: Pool) { let c = Cache::with_pool(p); }");
         assert_eq!(result.updated, None, "an unrelated type is not rewritten");
         assert_eq!(result.manual.len(), 1, "and not silently skipped either");
+        assert_eq!(
+            result.manual[0].manual,
+            Some(ManualReason::UnexpectedReceiver)
+        );
+    }
+
+    #[test]
+    fn leaves_an_app_type_that_merely_starts_with_pg_alone() {
+        // `PgCache` is an ordinary Postgres helper someone wrote, not a type
+        // `#[repository]` emitted. Reported, so an aliased repository is not
+        // lost, but never rewritten.
+        let result = run("fn f(p: Pool) { let c = PgCache::with_pool(p); }");
+        assert_eq!(result.updated, None);
         assert_eq!(
             result.manual[0].manual,
             Some(ManualReason::UnexpectedReceiver)

--- a/autumn-cli/src/upgrade/engine.rs
+++ b/autumn-cli/src/upgrade/engine.rs
@@ -22,7 +22,7 @@
 //! — the tokens that look like a call may never become one, and a macro is free
 //! to build the identifier by concatenation, so a rewrite there is a guess.
 
-use proc_macro2::{Delimiter, TokenStream, TokenTree};
+use proc_macro2::{Delimiter, Group, TokenStream, TokenTree};
 use std::collections::{BTreeMap, BTreeSet};
 
 use super::migrations::{AppMigration, CallForm, ReceiverShape, Rewrite};
@@ -744,13 +744,23 @@ impl GeneratedRepositories {
         let Some(declared) = self.declared.get(name) else {
             return false;
         };
-        // `crate::`, `self::` and `super::` say where to start resolving, not
-        // which module declares the type. `super` cannot be resolved without
-        // knowing the caller's own module, so it is dropped rather than guessed
-        // at — erring toward accepting a name that is generated somewhere.
+        // `self::` and `super::` are relative to the module the *call* is
+        // written in, which this command does not track. Dropping them and
+        // judging the call as if it were unqualified let a generated type in
+        // any module vouch for it, so `self::PgAuditRepository::with_pool`
+        // could be rewritten on the strength of a repository declared
+        // elsewhere entirely. Unresolvable means reported, as everywhere else.
+        if matches!(
+            qualifier.first().map(String::as_str),
+            Some("self" | "super")
+        ) {
+            return false;
+        }
+        // `crate::` is absolute: it says where to start resolving, not which
+        // module declares the type.
         let qualifier: Vec<String> = qualifier
             .iter()
-            .skip_while(|segment| matches!(segment.as_str(), "crate" | "self" | "super" | "$crate"))
+            .skip_while(|segment| matches!(segment.as_str(), "crate" | "$crate"))
             .cloned()
             .collect();
         if qualifier.is_empty() {
@@ -800,6 +810,13 @@ fn collect_repository_types(
                 if !is_repository_attribute(&group.stream()) {
                     continue;
                 }
+                // The generated type exists only in the configuration the
+                // `#[cfg]` selects. Under the other one the same name may be an
+                // unrelated import, so a conditional declaration cannot vouch
+                // for a call unconditionally.
+                if attribute_run_is_cfg_gated(&trees, index) {
+                    continue;
+                }
                 if let Some(trait_name) = trait_name_after(&trees, index + 2) {
                     found.push((format!("Pg{trait_name}"), module.to_vec()));
                 }
@@ -838,6 +855,11 @@ fn collect_repository_types(
 /// Only the path is read. Anything with an argument list — `#[cfg(feature =
 /// "repository")]` — is judged by its own name, not by what its arguments say.
 fn is_repository_attribute(stream: &TokenStream) -> bool {
+    attribute_last_segment(stream).is_some_and(|segment| segment == "repository")
+}
+
+/// The last path segment of an attribute body, or `None` if it names no path.
+fn attribute_last_segment(stream: &TokenStream) -> Option<String> {
     let mut last_segment = None;
     for tree in stream.clone() {
         match tree {
@@ -849,7 +871,49 @@ fn is_repository_attribute(stream: &TokenStream) -> bool {
             _ => break,
         }
     }
-    last_segment.is_some_and(|segment| segment == "repository")
+    last_segment
+}
+
+/// Whether an attribute makes the item it decorates conditional.
+fn is_cfg_attribute(stream: &TokenStream) -> bool {
+    attribute_last_segment(stream).is_some_and(|segment| segment == "cfg" || segment == "cfg_attr")
+}
+
+/// Whether the attribute run containing `trees[index]` carries a `#[cfg]`.
+///
+/// Attributes stack in whatever order the author chose, so the run is walked in
+/// both directions from the `#[repository]` that was just matched.
+fn attribute_run_is_cfg_gated(trees: &[TokenTree], index: usize) -> bool {
+    fn attribute_at(trees: &[TokenTree], at: usize) -> Option<&Group> {
+        match (trees.get(at), trees.get(at + 1)) {
+            (Some(TokenTree::Punct(punct)), Some(TokenTree::Group(group)))
+                if punct.as_char() == '#' && group.delimiter() == Delimiter::Bracket =>
+            {
+                Some(group)
+            }
+            _ => None,
+        }
+    }
+
+    let mut before = index;
+    while before >= 2 {
+        let Some(group) = attribute_at(trees, before - 2) else {
+            break;
+        };
+        if is_cfg_attribute(&group.stream()) {
+            return true;
+        }
+        before -= 2;
+    }
+
+    let mut after = index + 2;
+    while let Some(group) = attribute_at(trees, after) {
+        if is_cfg_attribute(&group.stream()) {
+            return true;
+        }
+        after += 2;
+    }
+    false
 }
 
 /// The module name when `trees[index]` is the body of `mod name { … }`.
@@ -1816,6 +1880,79 @@ mod tests {
         assert!(
             out.contains("PgPostRepository::with_pool_untracked(p)"),
             "{out}"
+        );
+    }
+
+    #[test]
+    fn a_self_qualified_receiver_is_reported_not_rewritten() {
+        // Codex review on #2231: `self::` was stripped and the call then judged
+        // as if it were unqualified, so a generated type of that name in *any*
+        // module vouched for it. `self::` means the caller's own module, which
+        // this command cannot resolve, so the site is reported instead.
+        let generated: GeneratedRepositories =
+            std::iter::once(("PgPostRepository".to_owned(), vec!["repos".to_owned()])).collect();
+        let result = rewrite_source(
+            "fn f(p: Pool) { self::PgPostRepository::with_pool(p); }",
+            &[&RENAME],
+            &generated,
+        )
+        .expect("parses");
+        assert_eq!(result.updated, None);
+        assert_eq!(
+            result.manual[0].manual,
+            Some(ManualReason::UnverifiedReceiver)
+        );
+    }
+
+    #[test]
+    fn a_super_qualified_receiver_is_reported_not_rewritten() {
+        let generated: GeneratedRepositories =
+            std::iter::once(("PgPostRepository".to_owned(), vec!["repos".to_owned()])).collect();
+        let result = rewrite_source(
+            "fn f(p: Pool) { super::PgPostRepository::with_pool(p); }",
+            &[&RENAME],
+            &generated,
+        )
+        .expect("parses");
+        assert_eq!(result.updated, None);
+        assert_eq!(
+            result.manual[0].manual,
+            Some(ManualReason::UnverifiedReceiver)
+        );
+    }
+
+    #[test]
+    fn a_cfg_gated_repository_declaration_is_not_evidence() {
+        // Codex review on #2231: the generated type only exists in the
+        // configuration the `#[cfg]` selects, so it cannot vouch for a call
+        // unconditionally — under the other configuration the same name may be
+        // an unrelated import.
+        assert!(
+            generated_names(
+                "#[cfg(feature = \"postgres\")]\n#[repository]\npub trait AuditRepository {}\n"
+            )
+            .is_empty(),
+            "a conditional declaration is conditional evidence",
+        );
+    }
+
+    #[test]
+    fn a_cfg_gated_repository_declaration_is_not_evidence_when_cfg_follows() {
+        // Attribute order is the author's choice, not a signal.
+        assert!(
+            generated_names(
+                "#[repository]\n#[cfg(feature = \"postgres\")]\npub trait AuditRepository {}\n"
+            )
+            .is_empty(),
+        );
+    }
+
+    #[test]
+    fn an_unconditional_repository_declaration_is_still_evidence() {
+        // The cfg fix must not swing the other way.
+        assert_eq!(
+            generated_names("#[repository]\npub trait AuditRepository {}\n"),
+            vec!["PgAuditRepository".to_owned()],
         );
     }
 

--- a/autumn-cli/src/upgrade/engine.rs
+++ b/autumn-cli/src/upgrade/engine.rs
@@ -183,6 +183,14 @@ pub fn rewrite_source(
         return Ok(SourceRewrite::default());
     }
 
+    // A token stream proves the file *lexes*, not that it is Rust: `let = f();`
+    // has balanced delimiters and valid tokens and is still rejected by the
+    // compiler. Splicing into a file like that would produce a rewrite of
+    // something that was never going to build, and count it as migrated.
+    // Parsing first is what makes "not valid Rust is reported, not rewritten"
+    // true rather than approximately true.
+    syn::parse_file(source).map_err(|error| error.to_string())?;
+
     let stream: TokenStream = source
         .parse()
         .map_err(|error: proc_macro2::LexError| error.to_string())?;

--- a/autumn-cli/src/upgrade/engine.rs
+++ b/autumn-cli/src/upgrade/engine.rs
@@ -610,16 +610,21 @@ pub fn generated_repository_types(source: &str) -> Vec<(String, Vec<String>)> {
 /// `struct PgAuditRepository` in another has two different types spelled the
 /// same, and an unqualified call cannot be attributed to either.
 #[must_use]
-pub fn defined_type_names(source: &str) -> Vec<String> {
+pub fn defined_type_names(source: &str) -> Vec<(String, Vec<String>)> {
     let Ok(stream) = source.parse::<TokenStream>() else {
         return Vec::new();
     };
     let mut found = Vec::new();
-    collect_defined_types(&stream, Context::Code, &mut found);
+    collect_defined_types(&stream, Context::Code, &[], &mut found);
     found
 }
 
-fn collect_defined_types(stream: &TokenStream, context: Context, found: &mut Vec<String>) {
+fn collect_defined_types(
+    stream: &TokenStream,
+    context: Context,
+    module: &[String],
+    found: &mut Vec<(String, Vec<String>)>,
+) {
     let trees: Vec<TokenTree> = stream.clone().into_iter().collect();
     for (index, tree) in trees.iter().enumerate() {
         match tree {
@@ -628,20 +633,26 @@ fn collect_defined_types(stream: &TokenStream, context: Context, found: &mut Vec
                     && matches!(keyword.to_string().as_str(), "struct" | "enum" | "union") =>
             {
                 if let Some(TokenTree::Ident(name)) = trees.get(index + 1) {
-                    found.push(name.to_string());
+                    found.push((name.to_string(), module.to_vec()));
                 }
             }
             // `type Alias = …;`, but not the `type` of an associated item
             // binding, which is followed by `=` only after a generic list.
             TokenTree::Ident(keyword) if context == Context::Code && keyword == "type" => {
                 if let Some(TokenTree::Ident(name)) = trees.get(index + 1) {
-                    found.push(name.to_string());
+                    found.push((name.to_string(), module.to_vec()));
                 }
             }
             TokenTree::Group(group) => {
+                let nested = module_name_before(&trees, index).map(|name| {
+                    let mut nested = module.to_vec();
+                    nested.push(name);
+                    nested
+                });
                 collect_defined_types(
                     &group.stream(),
                     group_context(&trees, index, context),
+                    nested.as_deref().unwrap_or(module),
                     found,
                 );
             }
@@ -659,9 +670,9 @@ fn collect_defined_types(stream: &TokenStream, context: Context, found: &mut Vec
 #[derive(Debug, Default)]
 pub struct GeneratedRepositories {
     declared: BTreeMap<String, BTreeSet<Vec<String>>>,
-    /// Names the scanned source defines as ordinary types. See
+    /// Names the scanned source defines as ordinary types, and where. See
     /// [`defined_type_names`].
-    handwritten: BTreeSet<String>,
+    handwritten: BTreeMap<String, BTreeSet<Vec<String>>>,
 }
 
 impl FromIterator<(String, Vec<String>)> for GeneratedRepositories {
@@ -672,7 +683,7 @@ impl FromIterator<(String, Vec<String>)> for GeneratedRepositories {
         }
         Self {
             declared,
-            handwritten: BTreeSet::new(),
+            handwritten: BTreeMap::new(),
         }
     }
 }
@@ -689,9 +700,21 @@ impl GeneratedRepositories {
     /// `repositories::…`, `crate::repositories::…` and a bare `…` inside that
     /// module all are. A qualifier naming a module that generates nothing —
     /// `custom::PgAuditRepository` — is not this type.
-    /// Record the type names the scanned source writes out itself.
-    pub fn note_handwritten<I: IntoIterator<Item = String>>(&mut self, names: I) {
-        self.handwritten.extend(names);
+    /// Record the type names the scanned source writes out itself, with the
+    /// module each is written in.
+    pub fn note_handwritten<I: IntoIterator<Item = (String, Vec<String>)>>(&mut self, names: I) {
+        for (name, module) in names {
+            self.handwritten.entry(name).or_default().insert(module);
+        }
+    }
+
+    /// Whether any recorded path ends with `qualifier`.
+    fn any_path_matches(paths: Option<&BTreeSet<Vec<String>>>, qualifier: &[String]) -> bool {
+        paths.is_some_and(|paths| {
+            paths
+                .iter()
+                .any(|path| path.len() >= qualifier.len() && path.ends_with(qualifier))
+        })
     }
 
     #[must_use]
@@ -713,11 +736,16 @@ impl GeneratedRepositories {
             // type of the same name anywhere in the scan makes it ambiguous —
             // including one in a different crate, since a `use` can bring
             // either spelling into scope unqualified. Reported, not guessed at.
-            return !self.handwritten.contains(name);
+            return !self.handwritten.contains_key(name);
         }
-        declared
-            .iter()
-            .any(|path| path.len() >= qualifier.len() && path.ends_with(&qualifier[..]))
+        // A qualifier narrows both sides equally. Module paths carry no crate
+        // identity, so `repositories::PgAuditRepository` can name a generated
+        // type in one crate and a hand-written one in another; when the
+        // qualifier fits both, it has decided nothing.
+        if Self::any_path_matches(self.handwritten.get(name), &qualifier) {
+            return false;
+        }
+        Self::any_path_matches(Some(declared), &qualifier)
     }
 }
 
@@ -1065,19 +1093,36 @@ mod tests {
             "with nothing else of that name, the generated type is the only reading"
         );
 
-        generated.note_handwritten(std::iter::once("PgAuditRepository".to_owned()));
+        generated.note_handwritten(std::iter::once((
+            "PgAuditRepository".to_owned(),
+            vec!["custom".to_owned()],
+        )));
         assert!(
             !generated.accepts("PgAuditRepository", &[]),
             "once the source writes out a type of that name the call is ambiguous"
         );
-        // A qualifier still decides it: the author said which module they meant.
+        // A qualifier still decides it when the two live in different modules:
+        // the author said which one they meant.
         assert!(generated.accepts("PgAuditRepository", &["repositories".to_owned()]));
+        assert!(!generated.accepts("PgAuditRepository", &["custom".to_owned()]));
+
+        // But a hand-written type at the *same* module path — another crate's
+        // `repositories`, since these paths carry no crate identity — leaves
+        // the qualifier deciding nothing.
+        generated.note_handwritten(std::iter::once((
+            "PgAuditRepository".to_owned(),
+            vec!["repositories".to_owned()],
+        )));
+        assert!(!generated.accepts("PgAuditRepository", &["repositories".to_owned()]));
     }
 
     #[test]
     fn reads_the_type_names_the_source_writes_out() {
         assert_eq!(
-            defined_type_names("pub struct PgAuditRepository;\nenum E {}\ntype Alias = u8;"),
+            defined_type_names("pub struct PgAuditRepository;\nenum E {}\ntype Alias = u8;")
+                .into_iter()
+                .map(|(name, _)| name)
+                .collect::<Vec<_>>(),
             vec!["PgAuditRepository", "E", "Alias"]
         );
         // `#[repository]` output never appears in source, so a trait declaring

--- a/autumn-cli/src/upgrade/migrations.rs
+++ b/autumn-cli/src/upgrade/migrations.rs
@@ -233,16 +233,59 @@ pub fn app_migrations() -> &'static [AppMigration] {
 }
 
 /// A `major.minor.patch` version.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Version {
     pub major: u64,
     pub minor: u64,
     pub patch: u64,
+    /// Whether this is a pre-release of the triple (`0.7.0-rc.1`).
+    ///
+    /// A flag rather than the identifier, because the only comparison that has
+    /// to be right is pre-release against *stable*: every registry version is a
+    /// released one, so `rc.1` vs `rc.2` never decides which migrations apply.
+    /// Two pre-releases of the same triple therefore compare equal, and when
+    /// they are two workspace members racing to set the floor either answer
+    /// selects the same migrations.
+    pub prerelease: bool,
+}
+
+impl Version {
+    /// A released version.
+    #[must_use]
+    pub const fn new(major: u64, minor: u64, patch: u64) -> Self {
+        Self {
+            major,
+            minor,
+            patch,
+            prerelease: false,
+        }
+    }
+}
+
+impl Ord for Version {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        (self.major, self.minor, self.patch)
+            .cmp(&(other.major, other.minor, other.patch))
+            // `0.7.0-rc.1` precedes `0.7.0`, so an app on the candidate is
+            // *behind* the release and still needs its migrations. Derived
+            // ordering would have put `false` first and inverted this.
+            .then_with(|| other.prerelease.cmp(&self.prerelease))
+    }
+}
+
+impl PartialOrd for Version {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
 }
 
 impl std::fmt::Display for Version {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}.{}.{}", self.major, self.minor, self.patch)
+        write!(f, "{}.{}.{}", self.major, self.minor, self.patch)?;
+        if self.prerelease {
+            f.write_str("-pre")?;
+        }
+        Ok(())
     }
 }
 
@@ -266,16 +309,17 @@ pub fn parse_version_req(req: &str) -> Option<Version> {
     if req.starts_with('<') {
         return None;
     }
-    let core = req
+    // Build metadata is not part of the version; a pre-release suffix is, and
+    // it sorts *below* the release, so it is remembered rather than dropped.
+    let without_build = req
         .trim_start_matches(['=', '^', '~', '>'])
         .trim()
-        // Build metadata and a pre-release suffix both leave the release
-        // identity alone: 0.7.0-rc.1 is the 0.7.0 line for migration purposes.
         .split('+')
-        .next()?
-        .split('-')
-        .next()?
-        .trim();
+        .next()?;
+    let (core, prerelease) = without_build
+        .split_once('-')
+        .map_or((without_build, false), |(core, _)| (core, true));
+    let core = core.trim();
     if core.is_empty() {
         return None;
     }
@@ -295,9 +339,8 @@ pub fn parse_version_req(req: &str) -> Option<Version> {
         return None;
     }
     Some(Version {
-        major,
-        minor,
-        patch,
+        prerelease,
+        ..Version::new(major, minor, patch)
     })
 }
 
@@ -332,10 +375,14 @@ mod tests {
     use super::*;
 
     fn v(major: u64, minor: u64, patch: u64) -> Version {
+        Version::new(major, minor, patch)
+    }
+
+    /// A pre-release of the triple, e.g. `0.7.0-rc.1`.
+    fn pre(major: u64, minor: u64, patch: u64) -> Version {
         Version {
-            major,
-            minor,
-            patch,
+            prerelease: true,
+            ..Version::new(major, minor, patch)
         }
     }
 
@@ -358,9 +405,34 @@ mod tests {
     }
 
     #[test]
-    fn ignores_prerelease_and_build_metadata() {
-        assert_eq!(parse_version_req("0.7.0-rc.1"), Some(v(0, 7, 0)));
+    fn ignores_build_metadata_but_keeps_the_prerelease() {
         assert_eq!(parse_version_req("0.7.0+build.5"), Some(v(0, 7, 0)));
+        assert_eq!(parse_version_req("0.7.0-rc.1"), Some(pre(0, 7, 0)));
+        assert_eq!(parse_version_req("0.7.0-rc.1+build.5"), Some(pre(0, 7, 0)));
+    }
+
+    #[test]
+    fn a_prerelease_sorts_below_its_release() {
+        assert!(pre(0, 7, 0) < v(0, 7, 0), "0.7.0-rc.1 precedes 0.7.0");
+        assert!(v(0, 6, 0) < pre(0, 7, 0), "and still follows 0.6.0");
+        assert_ne!(pre(0, 7, 0), v(0, 7, 0));
+    }
+
+    #[test]
+    fn an_app_on_a_release_candidate_still_needs_that_releases_migrations() {
+        // Upgrading 0.7.0-rc.1 -> 0.7.0: the candidate is *behind* the release,
+        // so the release's migrations apply. Treating the two as equal selected
+        // nothing.
+        let ids = ids(&select_between(FIXTURE_REGISTRY, pre(0, 7, 0), v(0, 7, 0)));
+        assert_eq!(ids, vec!["0.7.0-c"]);
+    }
+
+    #[test]
+    fn targeting_a_release_candidate_does_not_select_the_release() {
+        // `--to 0.7.0-rc.1` must not pull in migrations registered for the
+        // finished 0.7.0.
+        let ids = ids(&select_between(FIXTURE_REGISTRY, v(0, 6, 0), pre(0, 7, 0)));
+        assert!(ids.is_empty(), "0.7.0 is not reached yet, got {ids:?}");
     }
 
     #[test]

--- a/autumn-cli/src/upgrade/migrations.rs
+++ b/autumn-cli/src/upgrade/migrations.rs
@@ -297,6 +297,11 @@ impl std::fmt::Display for Version {
 /// multi-comparator range, a git branch name) returns `None` so the caller can
 /// ask for `--from` instead of rewriting against a guessed release.
 pub fn parse_version_req(req: &str) -> Option<Version> {
+    /// A `*`/`x`/`X` segment: Cargo's wildcard requirement, floored at zero.
+    fn is_wildcard(part: &str) -> bool {
+        matches!(part, "*" | "x" | "X")
+    }
+
     let req = req.trim();
     // A comma is Cargo's comparator separator: `>=0.4, <0.6` pins a range whose
     // floor says nothing about which migrations the app has already taken.
@@ -324,16 +329,32 @@ pub fn parse_version_req(req: &str) -> Option<Version> {
         return None;
     }
     let mut parts = core.split('.');
-    // An omitted segment is Cargo's "any value here", whose floor is zero.
-    let major = parts.next()?.parse::<u64>().ok()?;
-    let minor = match parts.next() {
-        Some(part) => part.parse::<u64>().ok()?,
-        None => 0,
+    // An omitted segment is Cargo's "any value here", whose floor is zero, and
+    // an explicit wildcard segment says the same thing: `0.5.*` and `0.5` pin
+    // the same floor. Only the *major* wildcard is refused — a bare `*` accepts
+    // every release, so reading it as 0.0.0 would silently select every
+    // migration ever written instead of asking for `--from`.
+    let first = parts.next()?;
+    if is_wildcard(first) {
+        return None;
+    }
+    let major = first.parse::<u64>().ok()?;
+    let mut wildcarded = false;
+    let mut segment = |part: Option<&str>| -> Option<u64> {
+        match part {
+            None => Some(0),
+            Some(part) if is_wildcard(part) => {
+                wildcarded = true;
+                Some(0)
+            }
+            // `1.*.3` is not a requirement Cargo accepts, and reading the `3`
+            // after a wildcard would invent precision the user did not write.
+            Some(_) if wildcarded => None,
+            Some(part) => part.parse::<u64>().ok(),
+        }
     };
-    let patch = match parts.next() {
-        Some(part) => part.parse::<u64>().ok()?,
-        None => 0,
-    };
+    let minor = segment(parts.next())?;
+    let patch = segment(parts.next())?;
     // A fourth segment is not semver; refuse rather than silently ignore it.
     if parts.next().is_some() {
         return None;
@@ -342,6 +363,27 @@ pub fn parse_version_req(req: &str) -> Option<Version> {
         prerelease,
         ..Version::new(major, minor, patch)
     })
+}
+
+/// Where the migration guides live, for a reader who is not standing in the
+/// Autumn repository.
+///
+/// The registry stores repo-relative paths because that is what the release
+/// gate checks against the tree. Printed verbatim by an installed CLI running
+/// in someone's app, `docs/migrations/0.6.0.md` names a file in *their*
+/// project — a dead end at exactly the point the report says to go read
+/// something. The human report renders this prefix instead.
+///
+/// Pinned to the default branch rather than to each release's tag: guides are
+/// append-only historical documents, the branch always resolves, and a
+/// migration registered for a release that has not been tagged yet — the case
+/// `docs/migrations/next.md` exists for — would otherwise link to a 404.
+pub const GUIDE_BASE_URL: &str = "https://github.com/autumn-foundation/autumn/blob/trunk-dev/";
+
+/// A repo-relative guide location as a URL anyone can open.
+#[must_use]
+pub fn guide_url(guide: &str) -> String {
+    format!("{GUIDE_BASE_URL}{guide}")
 }
 
 /// The migrations that apply when upgrading `from` → `to`.
@@ -448,7 +490,25 @@ mod tests {
         assert_eq!(parse_version_req("<=0.6.0"), None);
         assert_eq!(parse_version_req(""), None);
         assert_eq!(parse_version_req("trunk-dev"), None);
-        assert_eq!(parse_version_req("0.x"), None);
+        // A wildcard *major* is the bare `*` in another spelling.
+        assert_eq!(parse_version_req("x"), None);
+        assert_eq!(parse_version_req("X.1"), None);
+        // Precision after a wildcard is not a requirement Cargo accepts, and
+        // honouring the `3` would invent a floor the user did not write.
+        assert_eq!(parse_version_req("1.*.3"), None);
+    }
+
+    #[test]
+    fn a_wildcard_segment_floors_at_zero() {
+        // Cargo's wildcard requirements. `0.5.*` and `0.5` are the same
+        // requirement, so they have to parse to the same floor — and `0.*` is
+        // `0` written out, which this has always accepted as 0.0.0. Only the
+        // major position is refused, because `*` alone accepts every release.
+        assert_eq!(parse_version_req("0.5.*"), Some(Version::new(0, 5, 0)));
+        assert_eq!(parse_version_req("0.5.x"), Some(Version::new(0, 5, 0)));
+        assert_eq!(parse_version_req("^1.2.*"), Some(Version::new(1, 2, 0)));
+        assert_eq!(parse_version_req("0.*"), parse_version_req("0"));
+        assert_eq!(parse_version_req("0.x"), Some(Version::new(0, 0, 0)));
     }
 
     #[test]

--- a/autumn-cli/src/upgrade/migrations.rs
+++ b/autumn-cli/src/upgrade/migrations.rs
@@ -1,0 +1,463 @@
+//! The per-release registry of machine-applyable app-code migrations
+//! (issue #1629).
+//!
+//! This is the app-code sibling of `autumn_web::config::DEPRECATED_CONFIG_KEYS`:
+//! a static, reviewable table describing what each breaking release did to the
+//! *user's own Rust source*, so `autumn upgrade` can apply the mechanical part
+//! instead of every maintainer hand-editing call sites out of a prose guide.
+//!
+//! # Adding an entry
+//!
+//! One [`AppMigration`] per documented breaking change, including the ones no
+//! codemod can touch — a [`Rewrite::GuideOnly`] entry is what makes the upgrade
+//! summary *link* the guide section rather than staying silent about a break
+//! the user still has to handle. `scripts/check-migration-guides.sh` reads the
+//! [`id`](AppMigration::id) strings out of this file, so the guide's
+//! `**Automation:**` label and the shipped codemod cannot drift apart.
+
+/// How much trust a migration's rewrite earns, mirroring the labels the
+/// migration guides carry (issue #1629).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Confidence {
+    /// Safe by construction — a rename or import move. Rewritten sites are
+    /// reported as a count plus the diff.
+    Auto,
+    /// Rewritten, but each site is listed individually in the summary for a
+    /// human to read before committing.
+    Review,
+    /// Never rewritten. The summary links the exact guide section.
+    Manual,
+}
+
+impl Confidence {
+    /// The lowercase label used in guides, `--json` output, and the gate.
+    pub const fn label(self) -> &'static str {
+        match self {
+            Self::Auto => "auto",
+            Self::Review => "review",
+            Self::Manual => "manual",
+        }
+    }
+}
+
+/// What a migration mechanically does to app source.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Rewrite {
+    /// Rename a method or associated function *at its call sites*: `.from(` and
+    /// `::from(` become `.to(` / `::to(`. Only the name changes, so the
+    /// replacement never spans a line break.
+    CallRename {
+        from: &'static str,
+        to: &'static str,
+    },
+    /// Nothing is rewritten; the change is reported with its guide link so the
+    /// user still sees it in the upgrade summary.
+    GuideOnly,
+}
+
+/// One release's machine-applyable (or explicitly guide-only) app-code change.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct AppMigration {
+    /// Stable identifier, `<version>-<slug>`. Named in the guide's
+    /// `**Automation:**` label and in `--json` output; never reused.
+    pub id: &'static str,
+    /// The release that introduced the break. A migration applies when the
+    /// app's recorded version is *older* than this and the target is at least
+    /// this.
+    pub version: &'static str,
+    /// One-line description, shown in the upgrade summary.
+    pub title: &'static str,
+    /// Confidence label — see [`Confidence`].
+    pub confidence: Confidence,
+    /// Repo-relative path plus anchor of the guide section documenting it.
+    pub guide: &'static str,
+    /// The mechanical rewrite, if any.
+    pub rewrite: Rewrite,
+}
+
+/// The canonical registry of app-code migrations, oldest release first.
+pub static APP_MIGRATIONS: &[AppMigration] = &[
+    AppMigration {
+        id: "0.6.0-tenancy-jwt-secret-secretstring",
+        version: "0.6.0",
+        title: "`TenancyConfig::jwt_secret` is now a `secrecy::SecretString`",
+        confidence: Confidence::Manual,
+        guide: "docs/migrations/0.6.0.md#security-tenancyconfigjwt_secret-is-now-a-secrecysecretstring",
+        rewrite: Rewrite::GuideOnly,
+    },
+    AppMigration {
+        id: "0.6.0-repository-with-pool-untracked",
+        version: "0.6.0",
+        title: "repository constructor `with_pool` is renamed to `with_pool_untracked`",
+        confidence: Confidence::Auto,
+        guide: "docs/migrations/0.6.0.md#repository-with_pool-is-renamed-to-with_pool_untracked",
+        rewrite: Rewrite::CallRename {
+            from: "with_pool",
+            to: "with_pool_untracked",
+        },
+    },
+];
+
+/// The full registry.
+pub fn app_migrations() -> &'static [AppMigration] {
+    APP_MIGRATIONS
+}
+
+/// A `major.minor.patch` version.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct Version {
+    pub major: u64,
+    pub minor: u64,
+    pub patch: u64,
+}
+
+impl std::fmt::Display for Version {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}.{}.{}", self.major, self.minor, self.patch)
+    }
+}
+
+/// Parse a Cargo dependency requirement into the *lowest* version it admits.
+///
+/// `"0.5"`, `"^0.5.0"` and `"=0.5.0"` all floor at `0.5.0` — the question this
+/// answers is "what is the app definitely already past?", and the floor is the
+/// only honest answer to that. A requirement with no single floor (`"*"`, a
+/// multi-comparator range, a git branch name) returns `None` so the caller can
+/// ask for `--from` instead of rewriting against a guessed release.
+pub fn parse_version_req(req: &str) -> Option<Version> {
+    let req = req.trim();
+    // A comma is Cargo's comparator separator: `>=0.4, <0.6` pins a range whose
+    // floor says nothing about which migrations the app has already taken.
+    if req.is_empty() || req.contains(',') {
+        return None;
+    }
+    let core = req
+        .trim_start_matches(['=', '^', '~', '>', '<'])
+        .trim()
+        // Build metadata and a pre-release suffix both leave the release
+        // identity alone: 0.7.0-rc.1 is the 0.7.0 line for migration purposes.
+        .split('+')
+        .next()?
+        .split('-')
+        .next()?
+        .trim();
+    if core.is_empty() {
+        return None;
+    }
+    let mut parts = core.split('.');
+    // An omitted segment is Cargo's "any value here", whose floor is zero.
+    let major = parts.next()?.parse::<u64>().ok()?;
+    let minor = match parts.next() {
+        Some(part) => part.parse::<u64>().ok()?,
+        None => 0,
+    };
+    let patch = match parts.next() {
+        Some(part) => part.parse::<u64>().ok()?,
+        None => 0,
+    };
+    // A fourth segment is not semver; refuse rather than silently ignore it.
+    if parts.next().is_some() {
+        return None;
+    }
+    Some(Version {
+        major,
+        minor,
+        patch,
+    })
+}
+
+/// The migrations that apply when upgrading `from` → `to`.
+///
+/// A migration applies when its release is newer than what the app records and
+/// no newer than the target: `from < version <= to`. An app already on the
+/// release that broke the API has, by definition, already dealt with the break.
+/// Registry order is preserved, so the result is oldest release first.
+pub fn migrations_between(from: Version, to: Version) -> Vec<&'static AppMigration> {
+    select_between(APP_MIGRATIONS, from, to)
+}
+
+/// [`migrations_between`] over an explicit registry, so the selection rule is
+/// testable against a table with more than one release in it.
+pub fn select_between(
+    registry: &'static [AppMigration],
+    from: Version,
+    to: Version,
+) -> Vec<&'static AppMigration> {
+    registry
+        .iter()
+        .filter(|migration| {
+            parse_version_req(migration.version)
+                .is_some_and(|version| version > from && version <= to)
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn v(major: u64, minor: u64, patch: u64) -> Version {
+        Version {
+            major,
+            minor,
+            patch,
+        }
+    }
+
+    #[test]
+    fn parses_bare_and_operator_prefixed_requirements() {
+        assert_eq!(parse_version_req("0.6.0"), Some(v(0, 6, 0)));
+        assert_eq!(parse_version_req("=0.5.0"), Some(v(0, 5, 0)));
+        assert_eq!(parse_version_req("^0.5.1"), Some(v(0, 5, 1)));
+        assert_eq!(parse_version_req(">=0.4"), Some(v(0, 4, 0)));
+        assert_eq!(parse_version_req("~0.5"), Some(v(0, 5, 0)));
+        assert_eq!(parse_version_req("  0.6.0  "), Some(v(0, 6, 0)));
+    }
+
+    #[test]
+    fn parses_partial_requirements_as_their_lowest_admitted_version() {
+        // `autumn-web = "0.5"` admits 0.5.0 and up; the app is *at least* on
+        // 0.5.0, so a 0.5.0 migration is already applied and must not re-run.
+        assert_eq!(parse_version_req("0.5"), Some(v(0, 5, 0)));
+        assert_eq!(parse_version_req("1"), Some(v(1, 0, 0)));
+    }
+
+    #[test]
+    fn ignores_prerelease_and_build_metadata() {
+        assert_eq!(parse_version_req("0.7.0-rc.1"), Some(v(0, 7, 0)));
+        assert_eq!(parse_version_req("0.7.0+build.5"), Some(v(0, 7, 0)));
+    }
+
+    #[test]
+    fn rejects_unparsable_requirements() {
+        // A wildcard, a multi-comparator range, and a git/branch style pin
+        // carry no single lower bound this command can trust — better to ask
+        // for `--from` than to guess and rewrite against the wrong release.
+        assert_eq!(parse_version_req("*"), None);
+        assert_eq!(parse_version_req(">=0.4, <0.6"), None);
+        assert_eq!(parse_version_req(""), None);
+        assert_eq!(parse_version_req("trunk-dev"), None);
+        assert_eq!(parse_version_req("0.x"), None);
+    }
+
+    #[test]
+    fn selects_migrations_newer_than_the_recorded_version() {
+        let ids: Vec<_> = migrations_between(v(0, 5, 0), v(0, 6, 0))
+            .iter()
+            .map(|m| m.id)
+            .collect();
+        assert!(
+            ids.contains(&"0.6.0-repository-with-pool-untracked"),
+            "0.5.0 -> 0.6.0 must include the 0.6.0 rename, got {ids:?}"
+        );
+    }
+
+    #[test]
+    fn excludes_migrations_the_app_is_already_past() {
+        let ids: Vec<_> = migrations_between(v(0, 6, 0), v(0, 7, 0))
+            .iter()
+            .map(|m| m.id)
+            .collect();
+        assert!(
+            ids.is_empty(),
+            "an app already on 0.6.0 needs no 0.6.0 migration, got {ids:?}"
+        );
+    }
+
+    #[test]
+    fn excludes_migrations_newer_than_the_target() {
+        let ids: Vec<_> = migrations_between(v(0, 4, 0), v(0, 5, 0))
+            .iter()
+            .map(|m| m.id)
+            .collect();
+        assert!(
+            ids.is_empty(),
+            "a 0.6.0 migration must not run when targeting 0.5.0, got {ids:?}"
+        );
+    }
+
+    #[test]
+    fn selection_is_empty_when_target_is_not_newer() {
+        assert!(migrations_between(v(0, 6, 0), v(0, 6, 0)).is_empty());
+        assert!(migrations_between(v(0, 6, 0), v(0, 5, 0)).is_empty());
+    }
+
+    #[test]
+    fn selection_is_ordered_oldest_release_first() {
+        let selected = migrations_between(v(0, 0, 0), v(9, 9, 9));
+        let mut previous = v(0, 0, 0);
+        for migration in &selected {
+            let current = parse_version_req(migration.version)
+                .unwrap_or_else(|| panic!("registry version {} must parse", migration.version));
+            assert!(
+                current >= previous,
+                "registry must stay sorted oldest-first: {current} after {previous}"
+            );
+            previous = current;
+        }
+        assert_eq!(selected.len(), APP_MIGRATIONS.len());
+    }
+
+    /// A registry with three releases in it — the shipped one has a single
+    /// release, so the multi-release half of the selection rule is otherwise
+    /// unreachable.
+    static FIXTURE_REGISTRY: &[AppMigration] = &[
+        AppMigration {
+            id: "0.5.0-a",
+            version: "0.5.0",
+            title: "a",
+            confidence: Confidence::Manual,
+            guide: "docs/migrations/0.5.0.md#a",
+            rewrite: Rewrite::GuideOnly,
+        },
+        AppMigration {
+            id: "0.6.0-b",
+            version: "0.6.0",
+            title: "b",
+            confidence: Confidence::Auto,
+            guide: "docs/migrations/0.6.0.md#b",
+            rewrite: Rewrite::CallRename {
+                from: "old",
+                to: "new",
+            },
+        },
+        AppMigration {
+            id: "0.7.0-c",
+            version: "0.7.0",
+            title: "c",
+            confidence: Confidence::Review,
+            guide: "docs/migrations/0.7.0.md#c",
+            rewrite: Rewrite::CallRename {
+                from: "older",
+                to: "newer",
+            },
+        },
+    ];
+
+    fn ids(selected: &[&'static AppMigration]) -> Vec<&'static str> {
+        selected.iter().map(|m| m.id).collect()
+    }
+
+    #[test]
+    fn a_multi_release_range_selects_every_release_it_spans_in_order() {
+        assert_eq!(
+            ids(&select_between(FIXTURE_REGISTRY, v(0, 4, 0), v(0, 7, 0))),
+            vec!["0.5.0-a", "0.6.0-b", "0.7.0-c"],
+        );
+    }
+
+    #[test]
+    fn a_multi_release_range_excludes_both_ends_correctly() {
+        // Already on 0.5.0, upgrading to 0.6.0: only 0.6.0 is ahead.
+        assert_eq!(
+            ids(&select_between(FIXTURE_REGISTRY, v(0, 5, 0), v(0, 6, 0))),
+            vec!["0.6.0-b"],
+        );
+        // Skipping a release still picks up the one in the middle.
+        assert_eq!(
+            ids(&select_between(FIXTURE_REGISTRY, v(0, 5, 0), v(0, 7, 0))),
+            vec!["0.6.0-b", "0.7.0-c"],
+        );
+        assert!(select_between(FIXTURE_REGISTRY, v(0, 7, 0), v(0, 7, 0)).is_empty());
+    }
+
+    #[test]
+    fn registry_entries_are_well_formed() {
+        let mut seen = std::collections::HashSet::new();
+        for migration in app_migrations() {
+            assert!(
+                seen.insert(migration.id),
+                "duplicate migration id {}",
+                migration.id
+            );
+            assert!(
+                parse_version_req(migration.version).is_some(),
+                "{} has an unparsable version {}",
+                migration.id,
+                migration.version
+            );
+            assert!(
+                migration.id.starts_with(migration.version),
+                "{} must be prefixed with its release version",
+                migration.id
+            );
+            assert!(
+                migration.guide.starts_with("docs/migrations/") && migration.guide.contains('#'),
+                "{} must link a guide section, got {}",
+                migration.id,
+                migration.guide
+            );
+            match migration.rewrite {
+                Rewrite::CallRename { from, to } => {
+                    assert_ne!(from, to, "{} renames nothing", migration.id);
+                    assert_ne!(
+                        migration.confidence,
+                        Confidence::Manual,
+                        "{} rewrites code, so it cannot be labelled manual",
+                        migration.id
+                    );
+                }
+                Rewrite::GuideOnly => assert_eq!(
+                    migration.confidence,
+                    Confidence::Manual,
+                    "{} rewrites nothing, so it must be labelled manual",
+                    migration.id
+                ),
+            }
+        }
+    }
+
+    #[test]
+    fn no_two_renames_in_one_release_chain_into_each_other() {
+        // `rewrite_source_for_releases` iterates release by release, so a chain
+        // that crosses releases resolves in one run. A chain *within* one
+        // release would need a second pass that does not happen — so it is
+        // forbidden rather than half-supported.
+        for migration in app_migrations() {
+            let Rewrite::CallRename { to, .. } = migration.rewrite else {
+                continue;
+            };
+            for other in app_migrations() {
+                let Rewrite::CallRename { from, .. } = other.rewrite else {
+                    continue;
+                };
+                assert!(
+                    from != to || migration.version != other.version,
+                    "{} renames to `{to}`, which {} renames again in the same release",
+                    migration.id,
+                    other.id
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn the_first_shipped_codemod_is_the_with_pool_rename() {
+        let migration = app_migrations()
+            .iter()
+            .find(|m| m.id == "0.6.0-repository-with-pool-untracked")
+            .expect("the with_pool rename is the first shipped codemod (issue #1629)");
+        assert_eq!(migration.confidence, Confidence::Auto);
+        assert_eq!(
+            migration.rewrite,
+            Rewrite::CallRename {
+                from: "with_pool",
+                to: "with_pool_untracked",
+            }
+        );
+    }
+
+    #[test]
+    fn confidence_labels_match_the_guide_vocabulary() {
+        assert_eq!(Confidence::Auto.label(), "auto");
+        assert_eq!(Confidence::Review.label(), "review");
+        assert_eq!(Confidence::Manual.label(), "manual");
+    }
+
+    #[test]
+    fn versions_order_by_major_then_minor_then_patch() {
+        assert!(v(0, 5, 9) < v(0, 6, 0));
+        assert!(v(1, 0, 0) > v(0, 9, 9));
+        assert_eq!(v(0, 6, 1), v(0, 6, 1));
+    }
+}

--- a/autumn-cli/src/upgrade/migrations.rs
+++ b/autumn-cli/src/upgrade/migrations.rs
@@ -40,15 +40,41 @@ impl Confidence {
     }
 }
 
+/// How the renamed function is called — the property that tells the framework
+/// API apart from every same-named API that is *not* being renamed.
+///
+/// This matters because names collide inside Autumn itself: 0.6.0 renamed the
+/// generated repository constructor `with_pool`, while `AppState::with_pool`
+/// and `AuthzContext::with_pool` are current, unrenamed builder methods. The
+/// two are distinguishable without type inference, because a constructor takes
+/// no `self` and a builder does: `Repo::with_pool(pool)` can only be the
+/// former and `state.with_pool(pool)` can only be the latter.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CallForm {
+    /// `Type::name(args)` — an associated function, no `self` parameter. Only
+    /// the `::` call form is rewritten.
+    AssociatedFunction,
+    /// `value.name(args)` — a method taking `self`. Only the `.` call form is
+    /// rewritten.
+    Method,
+}
+
 /// What a migration mechanically does to app source.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Rewrite {
-    /// Rename a method or associated function *at its call sites*: `.from(` and
-    /// `::from(` become `.to(` / `::to(`. Only the name changes, so the
+    /// Rename a function *at its call sites*. Only the name changes, so the
     /// replacement never spans a line break.
+    ///
+    /// A site matches only when the call *form* and the exact top-level
+    /// argument count both agree with the renamed function's real signature —
+    /// a rename changes neither, and insisting on both is what keeps a
+    /// same-named API on another type from being rewritten.
     CallRename {
         from: &'static str,
         to: &'static str,
+        form: CallForm,
+        /// Exact number of top-level arguments the function takes.
+        args: usize,
     },
     /// Nothing is rewritten; the change is reported with its guide link so the
     /// user still sees it in the upgrade summary.
@@ -77,6 +103,70 @@ pub struct AppMigration {
 
 /// The canonical registry of app-code migrations, oldest release first.
 pub static APP_MIGRATIONS: &[AppMigration] = &[
+    // 0.4.0 and 0.5.0 ship no codemod — every break in those releases is
+    // semantic or configuration-level. They are registered anyway: without an
+    // entry, an app upgrading 0.3.x -> 0.6.0 would be told about the two 0.6.0
+    // changes and nothing else, which reads as "those are the only breaks in
+    // range". A `GuideOnly` entry is how the summary names the change and links
+    // its guide section. `MIGRATION_GUIDE_FLOOR` in
+    // `scripts/check-migration-guides.sh` is 0.4.0, so that is where this
+    // starts too.
+    AppMigration {
+        id: "0.4.0-security-production-signing-secret",
+        version: "0.4.0",
+        title: "a production signing secret is required",
+        confidence: Confidence::Manual,
+        guide: "docs/migrations/0.4.0.md#security-production-signing-secret-is-required",
+        rewrite: Rewrite::GuideOnly,
+    },
+    AppMigration {
+        id: "0.4.0-storage-s3-plugin-crate",
+        version: "0.4.0",
+        title: "`storage-s3` moved to the `autumn-storage-s3` plugin crate",
+        confidence: Confidence::Manual,
+        guide: "docs/migrations/0.4.0.md#storage-storage-s3-moved-to-a-plugin-crate",
+        rewrite: Rewrite::GuideOnly,
+    },
+    AppMigration {
+        id: "0.4.0-authorization-policy-required",
+        version: "0.4.0",
+        title: "repository APIs require a policy in production",
+        confidence: Confidence::Manual,
+        guide: "docs/migrations/0.4.0.md#authorization-repository-apis-require-a-policy-in-production",
+        rewrite: Rewrite::GuideOnly,
+    },
+    AppMigration {
+        id: "0.4.0-mail-deliver-later-durable",
+        version: "0.4.0",
+        title: "production `deliver_later` must be durable or acknowledged",
+        confidence: Confidence::Manual,
+        guide: "docs/migrations/0.4.0.md#mail-production-deliver_later-must-be-durable-or-acknowledged",
+        rewrite: Rewrite::GuideOnly,
+    },
+    AppMigration {
+        id: "0.5.0-security-forwarded-header-trust",
+        version: "0.5.0",
+        title: "forwarded-header trust is declared once, centrally",
+        confidence: Confidence::Manual,
+        guide: "docs/migrations/0.5.0.md#security-forwarded-header-trust-is-now-declared-once",
+        rewrite: Rewrite::GuideOnly,
+    },
+    AppMigration {
+        id: "0.5.0-deprecated-configuration-keys",
+        version: "0.5.0",
+        title: "deprecated configuration keys",
+        confidence: Confidence::Manual,
+        guide: "docs/migrations/0.5.0.md#deprecated-configuration-keys",
+        rewrite: Rewrite::GuideOnly,
+    },
+    AppMigration {
+        id: "0.5.0-client-identity-extractors",
+        version: "0.5.0",
+        title: "read client identity through `ClientAddr` / `ClientHost` / `ClientScheme`",
+        confidence: Confidence::Manual,
+        guide: "docs/migrations/0.5.0.md#reading-client-identity-clientaddr-clienthost-clientscheme",
+        rewrite: Rewrite::GuideOnly,
+    },
     AppMigration {
         id: "0.6.0-tenancy-jwt-secret-secretstring",
         version: "0.6.0",
@@ -94,6 +184,12 @@ pub static APP_MIGRATIONS: &[AppMigration] = &[
         rewrite: Rewrite::CallRename {
             from: "with_pool",
             to: "with_pool_untracked",
+            // `pub fn with_pool_untracked(pool) -> Self` — an associated
+            // function taking exactly the pool. `AppState::with_pool(pool)`
+            // and `AuthzContext::with_pool(pool)` are builder *methods* that
+            // still carry the old name and must not be touched.
+            form: CallForm::AssociatedFunction,
+            args: 1,
         },
     },
 ];
@@ -131,8 +227,14 @@ pub fn parse_version_req(req: &str) -> Option<Version> {
     if req.is_empty() || req.contains(',') {
         return None;
     }
+    // An upper bound is not a floor. `autumn-web = "<0.6"` says nothing about
+    // which release the app is on — stripping the `<` would read it as 0.6.0
+    // and skip the very 0.6.0 codemod a 0.5.x app needs. Ask for `--from`.
+    if req.starts_with('<') {
+        return None;
+    }
     let core = req
-        .trim_start_matches(['=', '^', '~', '>', '<'])
+        .trim_start_matches(['=', '^', '~', '>'])
         .trim()
         // Build metadata and a pre-release suffix both leave the release
         // identity alone: 0.7.0-rc.1 is the 0.7.0 line for migration purposes.
@@ -235,6 +337,10 @@ mod tests {
         // for `--from` than to guess and rewrite against the wrong release.
         assert_eq!(parse_version_req("*"), None);
         assert_eq!(parse_version_req(">=0.4, <0.6"), None);
+        // An upper bound is not a floor: reading `<0.6` as 0.6.0 would skip
+        // the 0.6.0 codemod on an app actually resolved to 0.5.x.
+        assert_eq!(parse_version_req("<0.6"), None);
+        assert_eq!(parse_version_req("<=0.6.0"), None);
         assert_eq!(parse_version_req(""), None);
         assert_eq!(parse_version_req("trunk-dev"), None);
         assert_eq!(parse_version_req("0.x"), None);
@@ -266,13 +372,15 @@ mod tests {
 
     #[test]
     fn excludes_migrations_newer_than_the_target() {
-        let ids: Vec<_> = migrations_between(v(0, 4, 0), v(0, 5, 0))
-            .iter()
-            .map(|m| m.id)
-            .collect();
+        let selected = migrations_between(v(0, 4, 0), v(0, 5, 0));
         assert!(
-            ids.is_empty(),
-            "a 0.6.0 migration must not run when targeting 0.5.0, got {ids:?}"
+            selected.iter().all(|m| m.version == "0.5.0"),
+            "targeting 0.5.0 selects 0.5.0 and nothing newer, got {:?}",
+            selected.iter().map(|m| m.id).collect::<Vec<_>>()
+        );
+        assert!(
+            !selected.is_empty(),
+            "0.5.0 is ahead of 0.4.0 and its changes must be reported"
         );
     }
 
@@ -319,6 +427,8 @@ mod tests {
             rewrite: Rewrite::CallRename {
                 from: "old",
                 to: "new",
+                form: CallForm::AssociatedFunction,
+                args: 1,
             },
         },
         AppMigration {
@@ -330,6 +440,8 @@ mod tests {
             rewrite: Rewrite::CallRename {
                 from: "older",
                 to: "newer",
+                form: CallForm::AssociatedFunction,
+                args: 1,
             },
         },
     ];
@@ -388,7 +500,7 @@ mod tests {
                 migration.guide
             );
             match migration.rewrite {
-                Rewrite::CallRename { from, to } => {
+                Rewrite::CallRename { from, to, .. } => {
                     assert_ne!(from, to, "{} renames nothing", migration.id);
                     assert_ne!(
                         migration.confidence,
@@ -443,6 +555,8 @@ mod tests {
             Rewrite::CallRename {
                 from: "with_pool",
                 to: "with_pool_untracked",
+                form: CallForm::AssociatedFunction,
+                args: 1,
             }
         );
     }

--- a/autumn-cli/src/upgrade/migrations.rs
+++ b/autumn-cli/src/upgrade/migrations.rs
@@ -233,20 +233,25 @@ pub fn app_migrations() -> &'static [AppMigration] {
 }
 
 /// A `major.minor.patch` version.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Version {
     pub major: u64,
     pub minor: u64,
     pub patch: u64,
-    /// Whether this is a pre-release of the triple (`0.7.0-rc.1`).
+    /// The pre-release identifier, if this is a pre-release of the triple:
+    /// `Some("rc.1")` for `0.7.0-rc.1`.
     ///
-    /// A flag rather than the identifier, because the only comparison that has
-    /// to be right is pre-release against *stable*: every registry version is a
-    /// released one, so `rc.1` vs `rc.2` never decides which migrations apply.
-    /// Two pre-releases of the same triple therefore compare equal, and when
-    /// they are two workspace members racing to set the floor either answer
-    /// selects the same migrations.
-    pub prerelease: bool,
+    /// Kept verbatim so the report can echo the version that was actually asked
+    /// for — `0.7.0-rc.1` and `0.7.0-beta.2` are different releases, and a
+    /// machine-readable record that flattens both to `0.7.0-pre` is not a
+    /// record of anything.
+    ///
+    /// *Ordering* still only distinguishes pre-release from stable. That is the
+    /// one comparison that has to be right: every registry version is a
+    /// released one, so `rc.1` vs `rc.2` never decides which migrations apply,
+    /// and when two workspace members race to set the floor either answer
+    /// selects the same set.
+    pub prerelease: Option<String>,
 }
 
 impl Version {
@@ -257,7 +262,7 @@ impl Version {
             major,
             minor,
             patch,
-            prerelease: false,
+            prerelease: None,
         }
     }
 }
@@ -269,7 +274,7 @@ impl Ord for Version {
             // `0.7.0-rc.1` precedes `0.7.0`, so an app on the candidate is
             // *behind* the release and still needs its migrations. Derived
             // ordering would have put `false` first and inverted this.
-            .then_with(|| other.prerelease.cmp(&self.prerelease))
+            .then_with(|| other.prerelease.is_some().cmp(&self.prerelease.is_some()))
     }
 }
 
@@ -282,8 +287,8 @@ impl PartialOrd for Version {
 impl std::fmt::Display for Version {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}.{}.{}", self.major, self.minor, self.patch)?;
-        if self.prerelease {
-            f.write_str("-pre")?;
+        if let Some(prerelease) = &self.prerelease {
+            write!(f, "-{prerelease}")?;
         }
         Ok(())
     }
@@ -321,9 +326,10 @@ pub fn parse_version_req(req: &str) -> Option<Version> {
         .trim()
         .split('+')
         .next()?;
-    let (core, prerelease) = without_build
-        .split_once('-')
-        .map_or((without_build, false), |(core, _)| (core, true));
+    let (core, prerelease) = without_build.split_once('-').map_or_else(
+        || (without_build, None),
+        |(core, identifier)| (core, Some(identifier.to_owned())),
+    );
     let core = core.trim();
     if core.is_empty() {
         return None;
@@ -392,7 +398,7 @@ pub fn guide_url(guide: &str) -> String {
 /// no newer than the target: `from < version <= to`. An app already on the
 /// release that broke the API has, by definition, already dealt with the break.
 /// Registry order is preserved, so the result is oldest release first.
-pub fn migrations_between(from: Version, to: Version) -> Vec<&'static AppMigration> {
+pub fn migrations_between(from: &Version, to: &Version) -> Vec<&'static AppMigration> {
     select_between(APP_MIGRATIONS, from, to)
 }
 
@@ -400,14 +406,14 @@ pub fn migrations_between(from: Version, to: Version) -> Vec<&'static AppMigrati
 /// testable against a table with more than one release in it.
 pub fn select_between(
     registry: &'static [AppMigration],
-    from: Version,
-    to: Version,
+    from: &Version,
+    to: &Version,
 ) -> Vec<&'static AppMigration> {
     registry
         .iter()
         .filter(|migration| {
             parse_version_req(migration.version)
-                .is_some_and(|version| version > from && version <= to)
+                .is_some_and(|version| version > *from && version <= *to)
         })
         .collect()
 }
@@ -421,9 +427,15 @@ mod tests {
     }
 
     /// A pre-release of the triple, e.g. `0.7.0-rc.1`.
+    /// A pre-release of the triple. The identifier is kept verbatim, so tests
+    /// that care about it can name it and the rest can use the default.
     fn pre(major: u64, minor: u64, patch: u64) -> Version {
+        pre_id(major, minor, patch, "rc.1")
+    }
+
+    fn pre_id(major: u64, minor: u64, patch: u64, identifier: &str) -> Version {
         Version {
-            prerelease: true,
+            prerelease: Some(identifier.to_owned()),
             ..Version::new(major, minor, patch)
         }
     }
@@ -451,6 +463,38 @@ mod tests {
         assert_eq!(parse_version_req("0.7.0+build.5"), Some(v(0, 7, 0)));
         assert_eq!(parse_version_req("0.7.0-rc.1"), Some(pre(0, 7, 0)));
         assert_eq!(parse_version_req("0.7.0-rc.1+build.5"), Some(pre(0, 7, 0)));
+        // The identifier is carried verbatim, not flattened: the report has to
+        // be able to echo the version that was actually asked for.
+        assert_eq!(
+            parse_version_req("0.7.0-beta.2"),
+            Some(pre_id(0, 7, 0, "beta.2"))
+        );
+        assert_eq!(
+            parse_version_req("0.7.0-rc.1")
+                .map(|v| v.to_string())
+                .as_deref(),
+            Some("0.7.0-rc.1")
+        );
+        assert_eq!(
+            parse_version_req("0.7.0-beta.2")
+                .map(|v| v.to_string())
+                .as_deref(),
+            Some("0.7.0-beta.2")
+        );
+    }
+
+    #[test]
+    fn prereleases_of_one_triple_are_interchangeable_for_selection() {
+        // Ordering only has to separate pre-release from stable: every registry
+        // version is a released one, so `rc.1` vs `beta.2` never decides which
+        // migrations apply. Display keeps them distinct; comparison does not.
+        assert_eq!(pre_id(0, 7, 0, "rc.1"), pre_id(0, 7, 0, "rc.1"));
+        assert!(pre_id(0, 7, 0, "beta.2") < v(0, 7, 0));
+        assert_eq!(
+            pre_id(0, 7, 0, "rc.1").cmp(&pre_id(0, 7, 0, "beta.2")),
+            std::cmp::Ordering::Equal,
+            "two pre-releases of one triple are interchangeable for selection"
+        );
     }
 
     #[test]
@@ -465,7 +509,11 @@ mod tests {
         // Upgrading 0.7.0-rc.1 -> 0.7.0: the candidate is *behind* the release,
         // so the release's migrations apply. Treating the two as equal selected
         // nothing.
-        let ids = ids(&select_between(FIXTURE_REGISTRY, pre(0, 7, 0), v(0, 7, 0)));
+        let ids = ids(&select_between(
+            FIXTURE_REGISTRY,
+            &pre(0, 7, 0),
+            &v(0, 7, 0),
+        ));
         assert_eq!(ids, vec!["0.7.0-c"]);
     }
 
@@ -473,7 +521,11 @@ mod tests {
     fn targeting_a_release_candidate_does_not_select_the_release() {
         // `--to 0.7.0-rc.1` must not pull in migrations registered for the
         // finished 0.7.0.
-        let ids = ids(&select_between(FIXTURE_REGISTRY, v(0, 6, 0), pre(0, 7, 0)));
+        let ids = ids(&select_between(
+            FIXTURE_REGISTRY,
+            &v(0, 6, 0),
+            &pre(0, 7, 0),
+        ));
         assert!(ids.is_empty(), "0.7.0 is not reached yet, got {ids:?}");
     }
 
@@ -513,7 +565,7 @@ mod tests {
 
     #[test]
     fn selects_migrations_newer_than_the_recorded_version() {
-        let ids: Vec<_> = migrations_between(v(0, 5, 0), v(0, 6, 0))
+        let ids: Vec<_> = migrations_between(&v(0, 5, 0), &v(0, 6, 0))
             .iter()
             .map(|m| m.id)
             .collect();
@@ -525,7 +577,7 @@ mod tests {
 
     #[test]
     fn excludes_migrations_the_app_is_already_past() {
-        let ids: Vec<_> = migrations_between(v(0, 6, 0), v(0, 7, 0))
+        let ids: Vec<_> = migrations_between(&v(0, 6, 0), &v(0, 7, 0))
             .iter()
             .map(|m| m.id)
             .collect();
@@ -537,7 +589,7 @@ mod tests {
 
     #[test]
     fn excludes_migrations_newer_than_the_target() {
-        let selected = migrations_between(v(0, 4, 0), v(0, 5, 0));
+        let selected = migrations_between(&v(0, 4, 0), &v(0, 5, 0));
         assert!(
             selected.iter().all(|m| m.version == "0.5.0"),
             "targeting 0.5.0 selects 0.5.0 and nothing newer, got {:?}",
@@ -551,13 +603,13 @@ mod tests {
 
     #[test]
     fn selection_is_empty_when_target_is_not_newer() {
-        assert!(migrations_between(v(0, 6, 0), v(0, 6, 0)).is_empty());
-        assert!(migrations_between(v(0, 6, 0), v(0, 5, 0)).is_empty());
+        assert!(migrations_between(&v(0, 6, 0), &v(0, 6, 0)).is_empty());
+        assert!(migrations_between(&v(0, 6, 0), &v(0, 5, 0)).is_empty());
     }
 
     #[test]
     fn selection_is_ordered_oldest_release_first() {
-        let selected = migrations_between(v(0, 0, 0), v(9, 9, 9));
+        let selected = migrations_between(&v(0, 0, 0), &v(9, 9, 9));
         let mut previous = v(0, 0, 0);
         for migration in &selected {
             let current = parse_version_req(migration.version)
@@ -620,7 +672,7 @@ mod tests {
     #[test]
     fn a_multi_release_range_selects_every_release_it_spans_in_order() {
         assert_eq!(
-            ids(&select_between(FIXTURE_REGISTRY, v(0, 4, 0), v(0, 7, 0))),
+            ids(&select_between(FIXTURE_REGISTRY, &v(0, 4, 0), &v(0, 7, 0))),
             vec!["0.5.0-a", "0.6.0-b", "0.7.0-c"],
         );
     }
@@ -629,15 +681,15 @@ mod tests {
     fn a_multi_release_range_excludes_both_ends_correctly() {
         // Already on 0.5.0, upgrading to 0.6.0: only 0.6.0 is ahead.
         assert_eq!(
-            ids(&select_between(FIXTURE_REGISTRY, v(0, 5, 0), v(0, 6, 0))),
+            ids(&select_between(FIXTURE_REGISTRY, &v(0, 5, 0), &v(0, 6, 0))),
             vec!["0.6.0-b"],
         );
         // Skipping a release still picks up the one in the middle.
         assert_eq!(
-            ids(&select_between(FIXTURE_REGISTRY, v(0, 5, 0), v(0, 7, 0))),
+            ids(&select_between(FIXTURE_REGISTRY, &v(0, 5, 0), &v(0, 7, 0))),
             vec!["0.6.0-b", "0.7.0-c"],
         );
-        assert!(select_between(FIXTURE_REGISTRY, v(0, 7, 0), v(0, 7, 0)).is_empty());
+        assert!(select_between(FIXTURE_REGISTRY, &v(0, 7, 0), &v(0, 7, 0)).is_empty());
     }
 
     #[test]

--- a/autumn-cli/src/upgrade/migrations.rs
+++ b/autumn-cli/src/upgrade/migrations.rs
@@ -75,6 +75,16 @@ pub enum Rewrite {
         form: CallForm,
         /// Exact number of top-level arguments the function takes.
         args: usize,
+        /// Required prefix on the receiver path segment, when the framework
+        /// names the type carrying this function.
+        ///
+        /// `#[repository]` emits its concrete type as `format_ident!("Pg{trait}")`
+        /// — every generated repository is `PgPostRepository`, `PgBookmarkRepository`,
+        /// and so on — so a genuine call site reads `PgFooRepository::with_pool(pool)`.
+        /// Requiring the prefix keeps an app's own `Cache::with_pool(pool)` out of
+        /// the rewrite. A receiver that does not match is *reported*, not skipped:
+        /// it could be an aliased import.
+        receiver: Option<&'static str>,
     },
     /// Nothing is rewritten; the change is reported with its guide link so the
     /// user still sees it in the upgrade summary.
@@ -190,6 +200,7 @@ pub static APP_MIGRATIONS: &[AppMigration] = &[
             // still carry the old name and must not be touched.
             form: CallForm::AssociatedFunction,
             args: 1,
+            receiver: Some("Pg"),
         },
     },
 ];
@@ -429,6 +440,7 @@ mod tests {
                 to: "new",
                 form: CallForm::AssociatedFunction,
                 args: 1,
+                receiver: None,
             },
         },
         AppMigration {
@@ -442,6 +454,7 @@ mod tests {
                 to: "newer",
                 form: CallForm::AssociatedFunction,
                 args: 1,
+                receiver: None,
             },
         },
     ];
@@ -557,6 +570,7 @@ mod tests {
                 to: "with_pool_untracked",
                 form: CallForm::AssociatedFunction,
                 args: 1,
+                receiver: Some("Pg"),
             }
         );
     }

--- a/autumn-cli/src/upgrade/migrations.rs
+++ b/autumn-cli/src/upgrade/migrations.rs
@@ -59,6 +59,33 @@ pub enum CallForm {
     Method,
 }
 
+/// The naming shape the framework gives the type a renamed function lives on.
+///
+/// `#[repository]` emits its concrete type as `Pg{trait}`, and every trait the
+/// scaffold generates is `{Model}Repository`, so a generated repository is
+/// `PgPostRepository`, `PgSubredditRepository`, and so on. Matching the whole
+/// shape rather than just the `Pg` prefix keeps an app's own `PgCache` out of
+/// the rewrite.
+///
+/// A hand-named trait that breaks the convention (`PostStore` -> `PgPostStore`)
+/// does not match and is *reported* under `manual` — a site to apply by hand,
+/// never a silent miss and never a wrong edit.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ReceiverShape {
+    pub prefix: &'static str,
+    pub suffix: &'static str,
+}
+
+impl ReceiverShape {
+    /// Whether `ident` is a name the framework would have generated.
+    #[must_use]
+    pub fn matches(&self, ident: &str) -> bool {
+        ident.len() >= self.prefix.len() + self.suffix.len()
+            && ident.starts_with(self.prefix)
+            && ident.ends_with(self.suffix)
+    }
+}
+
 /// What a migration mechanically does to app source.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Rewrite {
@@ -75,16 +102,8 @@ pub enum Rewrite {
         form: CallForm,
         /// Exact number of top-level arguments the function takes.
         args: usize,
-        /// Required prefix on the receiver path segment, when the framework
-        /// names the type carrying this function.
-        ///
-        /// `#[repository]` emits its concrete type as `format_ident!("Pg{trait}")`
-        /// — every generated repository is `PgPostRepository`, `PgBookmarkRepository`,
-        /// and so on — so a genuine call site reads `PgFooRepository::with_pool(pool)`.
-        /// Requiring the prefix keeps an app's own `Cache::with_pool(pool)` out of
-        /// the rewrite. A receiver that does not match is *reported*, not skipped:
-        /// it could be an aliased import.
-        receiver: Option<&'static str>,
+        /// Naming shape the receiver must have — see [`ReceiverShape`].
+        receiver: Option<ReceiverShape>,
     },
     /// Nothing is rewritten; the change is reported with its guide link so the
     /// user still sees it in the upgrade summary.
@@ -200,7 +219,10 @@ pub static APP_MIGRATIONS: &[AppMigration] = &[
             // still carry the old name and must not be touched.
             form: CallForm::AssociatedFunction,
             args: 1,
-            receiver: Some("Pg"),
+            receiver: Some(ReceiverShape {
+                prefix: "Pg",
+                suffix: "Repository",
+            }),
         },
     },
 ];
@@ -570,9 +592,31 @@ mod tests {
                 to: "with_pool_untracked",
                 form: CallForm::AssociatedFunction,
                 args: 1,
-                receiver: Some("Pg"),
+                receiver: Some(ReceiverShape {
+                    prefix: "Pg",
+                    suffix: "Repository",
+                }),
             }
         );
+    }
+
+    #[test]
+    fn the_receiver_shape_matches_what_the_repository_macro_emits() {
+        let shape = ReceiverShape {
+            prefix: "Pg",
+            suffix: "Repository",
+        };
+        // `#[repository]` on `trait PostRepository` emits `PgPostRepository`.
+        assert!(shape.matches("PgPostRepository"));
+        assert!(shape.matches("PgSubredditRepository"));
+        assert!(shape.matches("PgRepository"), "a trait named `Repository`");
+        // An app type that merely starts with `Pg`, or merely ends in
+        // `Repository`, is not something the macro generated.
+        assert!(!shape.matches("PgCache"));
+        assert!(!shape.matches("PgConnectionPool"));
+        assert!(!shape.matches("PostRepository"), "that is the trait");
+        assert!(!shape.matches("Cache"));
+        assert!(!shape.matches("Pg"));
     }
 
     #[test]

--- a/autumn-cli/src/upgrade/mod.rs
+++ b/autumn-cli/src/upgrade/mod.rs
@@ -101,11 +101,6 @@ pub enum Outcome {
 }
 
 impl Outcome {
-    /// Whether anything at all reached the disk.
-    pub const fn wrote_anything(self) -> bool {
-        matches!(self, Self::Applied | Self::Partial { .. })
-    }
-
     /// The label used in `--json`.
     pub const fn label(self) -> &'static str {
         match self {
@@ -299,39 +294,62 @@ fn render_skipped(out: &mut String, report: &Report) {
 fn render_summary(out: &mut String, report: &Report) {
     use std::fmt::Write as _;
     let sites = report.rewritten_sites();
-    if sites > 0 {
-        let files = report.files.len();
-        let _ = writeln!(
-            out,
-            "\n{sites} site{} in {files} file{} {}; {} file(s) scanned.",
-            plural(sites),
-            plural(files),
-            if report.outcome.wrote_anything() {
-                "rewritten"
-            } else {
-                "would be rewritten"
-            },
-            report.files_scanned
-        );
+    if sites == 0 {
+        return;
     }
-    if let Outcome::Partial { written } = report.outcome {
-        let _ = writeln!(
-            out,
-            "Partially applied: {written} file{} written before the run stopped. \
-             `git diff` shows exactly which.",
-            plural(written)
-        );
-    } else if report.outcome == Outcome::Applied {
-        if sites > 0 {
+    let files = report.files.len();
+
+    match report.outcome {
+        // Whole-plan totals would claim every site landed. Only the files
+        // before the failure did, so the two halves are counted separately —
+        // saying "N sites rewritten" and "3 files written" in the same summary
+        // is worse than either number alone.
+        Outcome::Partial { written } => {
+            let written_sites: usize = report
+                .files
+                .iter()
+                .take(written)
+                .map(|file| file.sites.len())
+                .sum();
+            let _ = writeln!(
+                out,
+                "\n{written_sites} site{} in {written} file{} written before the run stopped; \
+                 {} site{} in {} file{} planned and not written.",
+                plural(written_sites),
+                plural(written),
+                sites - written_sites,
+                plural(sites - written_sites),
+                files - written,
+                plural(files - written),
+            );
+            let _ = writeln!(
+                out,
+                "`git diff` shows exactly what landed; the error below names the file that stopped it."
+            );
+        }
+        Outcome::Applied => {
+            let _ = writeln!(
+                out,
+                "\n{sites} site{} in {files} file{} rewritten; {} file(s) scanned.",
+                plural(sites),
+                plural(files),
+                report.files_scanned
+            );
             let _ = writeln!(out, "Review the result with `git diff` before committing.");
         }
-    } else if sites > 0 {
-        // Only offered when `--apply` would actually write something: a run
-        // whose every remaining site is `manual` has nothing for it to do.
-        let _ = writeln!(
-            out,
-            "Nothing was written. Re-run with `--apply` to write these changes."
-        );
+        Outcome::Preview => {
+            let _ = writeln!(
+                out,
+                "\n{sites} site{} in {files} file{} would be rewritten; {} file(s) scanned.",
+                plural(sites),
+                plural(files),
+                report.files_scanned
+            );
+            let _ = writeln!(
+                out,
+                "Nothing was written. Re-run with `--apply` to write these changes."
+            );
+        }
     }
 }
 
@@ -447,10 +465,19 @@ fn recorded_version(root: &Path) -> Option<String> {
     // root would let a workspace whose root records 0.6.0 hide a member that
     // still pins 0.5.0 — the walk then migrates that member's source with no
     // 0.5.0 -> 0.6.0 migration selected.
+    use crate::doctor::AutumnWebDependency;
+
     let mut lowest: Option<(Version, String)> = None;
     for directory in std::iter::once(root.to_path_buf()).chain(member_manifests(root)) {
-        let Some(requirement) = crate::doctor::read_autumn_web_version_at(&directory) else {
-            continue;
+        let requirement = match crate::doctor::read_autumn_web_dependency_at(&directory) {
+            AutumnWebDependency::Absent => continue,
+            // Declared as a path or git dependency: this crate is on *some*
+            // version of autumn-web and the manifest does not say which.
+            // Letting a sibling decide the floor would migrate this crate's
+            // source against a version nobody checked — and a vendored
+            // checkout is exactly the population the 0.6.0 rename affects.
+            AutumnWebDependency::WithoutVersion => return None,
+            AutumnWebDependency::Version(requirement) => requirement,
         };
         // A manifest that *declares* `autumn-web` with a requirement carrying no
         // usable floor makes the whole answer a guess. Dropping it and taking
@@ -467,9 +494,19 @@ fn recorded_version(root: &Path) -> Option<String> {
 
 /// Directories under `root` (excluding `root` itself) that hold a `Cargo.toml`.
 ///
-/// Found by walking rather than by parsing `[workspace] members`, which would
-/// mean implementing Cargo's glob patterns; the walk already knows which
-/// directories are not the app's own code.
+/// Deliberately every nested manifest, not Cargo's `[workspace] members` /
+/// `exclude` set. The rule this keeps is *the floor is taken across exactly the
+/// code this command will rewrite*: the source walk visits every directory
+/// here, so a crate whose sources are about to be migrated also gets a vote on
+/// which migrations apply. Deriving membership from Cargo metadata would split
+/// those two sets — a crate under `exclude` would be rewritten against a floor
+/// chosen without it.
+///
+/// The cost is a crate outside the workspace proper (an excluded fixture, a
+/// standalone example) pulling the floor back or, if its requirement is
+/// ambiguous, making the command ask for `--from`. Both err toward doing more
+/// migration or doing none, never toward migrating against the wrong version,
+/// and both are visible in the report.
 fn member_manifests(root: &Path) -> Vec<PathBuf> {
     let mut found = Vec::new();
     collect_manifests(root, root, &mut found);
@@ -1100,13 +1137,42 @@ mod tests {
         // The failure mode this guards: some files already rewritten, and the
         // report telling the user to "re-run with --apply" as if the tree were
         // untouched.
+        // Two planned files, one of them written.
         let mut report = sample(Outcome::Preview);
-        report.outcome = Outcome::Partial { written: 3 };
+        report.files.push(FileReport {
+            path: "src/second.rs".into(),
+            sites: vec![
+                engine::Site {
+                    line: 4,
+                    column: 9,
+                    migration: AUTO.id,
+                    manual: None,
+                },
+                engine::Site {
+                    line: 7,
+                    column: 9,
+                    migration: AUTO.id,
+                    manual: None,
+                },
+            ],
+            diff: "@@ line 4 @@\n-a\n+b\n".into(),
+            updated: "b\n".into(),
+            absolute: PathBuf::from("/tmp/app/src/second.rs"),
+        });
+        report.outcome = Outcome::Partial { written: 1 };
 
         let text = render_text(&report);
         assert!(
-            text.contains("Partially applied: 3 files written"),
-            "{text}"
+            text.contains("1 site in 1 file written before the run stopped"),
+            "only what landed is counted as written: {text}"
+        );
+        assert!(
+            text.contains("2 sites in 1 file planned and not written"),
+            "and the rest is named as not written: {text}"
+        );
+        assert!(
+            !text.contains("3 sites in 2 files rewritten"),
+            "the whole plan must not be claimed as rewritten: {text}"
         );
         assert!(
             !text.to_lowercase().contains("nothing was written"),
@@ -1120,7 +1186,7 @@ mod tests {
         let json: serde_json::Value =
             serde_json::from_str(&render_json(&report)).expect("valid JSON");
         assert_eq!(json["outcome"], "partial");
-        assert_eq!(json["files_written"], 3);
+        assert_eq!(json["files_written"], 1);
         assert_eq!(
             json["applied"], false,
             "`applied` stays a strict did-everything-land flag"

--- a/autumn-cli/src/upgrade/mod.rs
+++ b/autumn-cli/src/upgrade/mod.rs
@@ -469,14 +469,35 @@ fn recorded_version(root: &Path) -> Option<String> {
     // 0.5.0 -> 0.6.0 migration selected.
     use crate::doctor::AutumnWebDependency;
 
+    // `{ workspace = true }` resolves against the enclosing workspace, and that
+    // manifest is *above* the scan when the command is pointed at a member
+    // directory. Cargo walks up to find it; not doing so aborted a member with
+    // "cannot tell which version" over a version Cargo resolves fine.
+    // Canonicalised first: the scan root is usually the relative `.`, and
+    // `Path::new(".").ancestors()` yields only `.` — the walk upward would
+    // never leave the member directory it was pointed at.
+    let absolute_root = std::fs::canonicalize(root).unwrap_or_else(|_| root.to_path_buf());
+    let inherited = absolute_root
+        .ancestors()
+        .find_map(crate::doctor::workspace_dependency_at);
+
     let mut lowest: Option<(Version, String)> = None;
     for directory in std::iter::once(root.to_path_buf()).chain(member_manifests(root)) {
         // *Every* declaration in the manifest, not the first: a target-specific
         // requirement can be older than the package-wide one, and the source
         // scan rewrites that target's `#[cfg]` code either way.
         for declaration in crate::doctor::autumn_web_declarations_at(&directory) {
+            let declaration = match declaration {
+                // Substitute the workspace entry the member inherits. With no
+                // enclosing workspace to resolve it the manifest would not
+                // build at all, so asking for `--from` is the honest answer.
+                AutumnWebDependency::Inherited => inherited
+                    .clone()
+                    .unwrap_or(AutumnWebDependency::WithoutVersion),
+                other => other,
+            };
             let requirement = match declaration {
-                AutumnWebDependency::Absent => continue,
+                AutumnWebDependency::Absent | AutumnWebDependency::Inherited => continue,
                 // Declared as a path or git dependency: this crate is on *some*
                 // version of autumn-web and the manifest does not say which.
                 // Letting a sibling decide the floor would migrate this crate's

--- a/autumn-cli/src/upgrade/mod.rs
+++ b/autumn-cli/src/upgrade/mod.rs
@@ -489,9 +489,14 @@ fn recorded_version(root: &Path) -> Option<String> {
     // `Path::new(".").ancestors()` yields only `.` — the walk upward would
     // never leave the member directory it was pointed at.
     let absolute_root = std::fs::canonicalize(root).unwrap_or_else(|_| root.to_path_buf());
-    let inherited = absolute_root
-        .ancestors()
-        .find_map(crate::doctor::workspace_dependency_at);
+    // By the member's own key, not by the crate name: `autumn = { workspace =
+    // true }` paired with a renamed workspace entry is the shape where nothing
+    // on the member side mentions `autumn-web` at all.
+    let inherited = |key: &str| {
+        absolute_root
+            .ancestors()
+            .find_map(|ancestor| crate::doctor::workspace_dependency_for(ancestor, key))
+    };
 
     let mut lowest: Option<(Version, String)> = None;
     for directory in std::iter::once(root.to_path_buf()).chain(member_manifests(root)) {
@@ -500,16 +505,25 @@ fn recorded_version(root: &Path) -> Option<String> {
         // scan rewrites that target's `#[cfg]` code either way.
         for declaration in crate::doctor::autumn_web_declarations_at(&directory) {
             let declaration = match declaration {
-                // Substitute the workspace entry the member inherits. With no
-                // enclosing workspace to resolve it the manifest would not
-                // build at all, so asking for `--from` is the honest answer.
-                AutumnWebDependency::Inherited => inherited
-                    .clone()
-                    .unwrap_or(AutumnWebDependency::WithoutVersion),
+                // Substitute the workspace entry the member inherits.
+                //
+                // Unresolved splits two ways. A literal `autumn-web =
+                // { workspace = true }` that resolves nowhere is a manifest
+                // that would not build, so asking for `--from` is the honest
+                // answer. Any other key that resolves nowhere is simply some
+                // other crate's inherited dependency — every `{ workspace =
+                // true }` entry is collected because the member side cannot
+                // tell them apart, and this is where the ones that are not
+                // autumn-web drop out.
+                AutumnWebDependency::Inherited(key) => match inherited(&key) {
+                    Some(resolved) => resolved,
+                    None if key == "autumn-web" => AutumnWebDependency::WithoutVersion,
+                    None => continue,
+                },
                 other => other,
             };
             let requirement = match declaration {
-                AutumnWebDependency::Absent | AutumnWebDependency::Inherited => continue,
+                AutumnWebDependency::Absent | AutumnWebDependency::Inherited(_) => continue,
                 // Declared as a path or git dependency: this crate is on *some*
                 // version of autumn-web and the manifest does not say which.
                 // Letting a sibling decide the floor would migrate this crate's
@@ -558,6 +572,11 @@ fn collect_manifests(root: &Path, dir: &Path, found: &mut Vec<PathBuf>) {
     let Ok(entries) = std::fs::read_dir(dir) else {
         return;
     };
+    // Exactly the exclusions the source walk uses, for exactly its reason: the
+    // floor has to be taken over the same crates the rewrite covers. A blanket
+    // dot-directory skip here let a hidden crate's sources be scanned and
+    // rewritten while its `Cargo.toml` had no vote on which migrations ran.
+    let at_crate_root = dir.join("Cargo.toml").is_file();
     for entry in entries.flatten() {
         let Ok(file_type) = entry.file_type() else {
             continue;
@@ -566,7 +585,9 @@ fn collect_manifests(root: &Path, dir: &Path, found: &mut Vec<PathBuf>) {
             continue;
         }
         let name = entry.file_name().to_string_lossy().into_owned();
-        if name.starts_with('.') || SKIPPED_DIRS.contains(&name.as_str()) {
+        let is_metadata = SKIPPED_HIDDEN_DIRS.contains(&name.as_str());
+        let is_build_output = at_crate_root && SKIPPED_DIRS.contains(&name.as_str());
+        if is_metadata || is_build_output {
             continue;
         }
         let path = entry.path();
@@ -880,6 +901,16 @@ pub fn run_in(root: &Path, opts: &UpgradeOptions) -> i32 {
         return 2;
     };
 
+    // A path typo must not read as "your app is already migrated" — the same
+    // rule `autumn a11y verify` states for its scan root.
+    if !root.is_dir() {
+        eprintln!(
+            "autumn upgrade: `{}` is not a readable directory.",
+            root.display()
+        );
+        return 2;
+    }
+
     let recorded = opts.from.clone().or_else(|| recorded_version(root));
     let Some(recorded) = recorded else {
         eprintln!(
@@ -895,16 +926,6 @@ pub fn run_in(root: &Path, opts: &UpgradeOptions) -> i32 {
         );
         return 2;
     };
-
-    // A path typo must not read as "your app is already migrated" — the same
-    // rule `autumn a11y verify` states for its scan root.
-    if !root.is_dir() {
-        eprintln!(
-            "autumn upgrade: `{}` is not a readable directory.",
-            root.display()
-        );
-        return 2;
-    }
 
     let mut report = plan(root, from, to);
     let mut failure = None;

--- a/autumn-cli/src/upgrade/mod.rs
+++ b/autumn-cli/src/upgrade/mod.rs
@@ -650,8 +650,8 @@ fn collect_manifests(
     }
 }
 
-/// Every directory Cargo has been told to put build output in, anywhere in the
-/// scan.
+/// Every directory Cargo has been told to hold generated or third-party code,
+/// anywhere in the scan.
 ///
 /// `CARGO_TARGET_DIR` and `.cargo/config.toml`'s `build.target-dir` both move
 /// output somewhere the `target` basename check will never look, and the walk
@@ -663,25 +663,29 @@ fn collect_manifests(
 /// `tools/helper/.cargo/config.toml` may say `target-dir = "../../build"`, and
 /// that directory is reached by a different branch of the walk entirely.
 ///
-/// `CARGO_TARGET_DIR` overrides every config file, so when it is set it is the
-/// only answer.
+/// Two kinds: build output (`build.target-dir`) and vendored dependencies
+/// (`[source.*] directory`, which is where `cargo vendor <path>` puts them).
+/// Neither is the app's own code, and rewriting the second corrupts a
+/// dependency.
+///
+/// `CARGO_TARGET_DIR` overrides every config file's `target-dir`, but has no
+/// equivalent for vendoring, so the config walk runs either way.
 fn configured_target_dirs(root: &Path) -> BTreeSet<PathBuf> {
-    if let Some(configured) = std::env::var_os("CARGO_TARGET_DIR") {
-        return std::env::current_dir()
-            .ok()
-            .and_then(|cwd| resolve_against(&cwd, &configured.to_string_lossy()))
-            .into_iter()
-            .collect();
-    }
+    let forced_target_dir = std::env::var_os("CARGO_TARGET_DIR").and_then(|configured| {
+        let cwd = std::env::current_dir().ok()?;
+        resolve_against(&cwd, &configured.to_string_lossy())
+    });
+    let target_dir_from_config = forced_target_dir.is_none();
 
     let mut found = BTreeSet::new();
+    found.extend(forced_target_dir);
     // Cargo reads `.cargo/config.toml` from the invocation directory upward, so
     // a redirect above the scan root applies to everything inside it.
     let absolute_root = std::fs::canonicalize(root).unwrap_or_else(|_| root.to_path_buf());
     for ancestor in absolute_root.ancestors() {
-        found.extend(config_target_dir_at(ancestor));
+        found.extend(config_excluded_dirs_at(ancestor, target_dir_from_config));
     }
-    collect_target_dirs(&absolute_root, &mut found);
+    collect_target_dirs(&absolute_root, target_dir_from_config, &mut found);
     found
 }
 
@@ -698,8 +702,8 @@ fn configured_target_dirs(root: &Path) -> BTreeSet<PathBuf> {
 /// the walk happens to learn of it first; directory order is not guaranteed.
 /// The source walk excludes it either way, so what is at stake there is the
 /// traversal cost, not whether the directory is migrated.
-fn collect_target_dirs(dir: &Path, found: &mut BTreeSet<PathBuf>) {
-    found.extend(config_target_dir_at(dir));
+fn collect_target_dirs(dir: &Path, target_dir_from_config: bool, found: &mut BTreeSet<PathBuf>) {
+    found.extend(config_excluded_dirs_at(dir, target_dir_from_config));
     let Ok(entries) = std::fs::read_dir(dir) else {
         return;
     };
@@ -723,7 +727,7 @@ fn collect_target_dirs(dir: &Path, found: &mut BTreeSet<PathBuf>) {
         if is_target_dir(&path, found) {
             continue;
         }
-        collect_target_dirs(&path, found);
+        collect_target_dirs(&path, target_dir_from_config, found);
     }
 }
 
@@ -738,14 +742,17 @@ fn resolve_against(base: &Path, path: &str) -> Option<PathBuf> {
     std::fs::canonicalize(absolute).ok()
 }
 
-/// `build.target-dir` from the `.cargo/config.toml` in `dir` itself, if any.
+/// The directories the `.cargo/config.toml` in `dir` itself declares as
+/// generated or third-party: `build.target-dir`, and the `directory` of every
+/// `[source.*]` replacement.
 ///
 /// Cargo resolves a relative entry against the directory holding the `.cargo`
-/// that declares it, so that is what this resolves against.
-fn config_target_dir_at(dir: &Path) -> Option<PathBuf> {
+/// that declares it, so that is what these resolve against. `target_dir` is
+/// false when `CARGO_TARGET_DIR` has already decided that question.
+fn config_excluded_dirs_at(dir: &Path, target_dir: bool) -> Vec<PathBuf> {
     let config_dir = dir.join(".cargo");
     if !config_dir.is_dir() {
-        return None;
+        return Vec::new();
     }
     for name in ["config.toml", "config"] {
         let Ok(content) = std::fs::read_to_string(config_dir.join(name)) else {
@@ -754,15 +761,27 @@ fn config_target_dir_at(dir: &Path) -> Option<PathBuf> {
         let Ok(table) = toml::from_str::<toml::Table>(&content) else {
             continue;
         };
-        if let Some(configured) = table
-            .get("build")
-            .and_then(|build| build.get("target-dir"))
-            .and_then(toml::Value::as_str)
+        let mut found = Vec::new();
+        if target_dir
+            && let Some(configured) = table
+                .get("build")
+                .and_then(|build| build.get("target-dir"))
+                .and_then(toml::Value::as_str)
         {
-            return resolve_against(dir, configured);
+            found.extend(resolve_against(dir, configured));
         }
+        // `[source.vendored-sources] directory = "third-party"` — where
+        // `cargo vendor <path>` was told to put dependency sources.
+        if let Some(sources) = table.get("source").and_then(toml::Value::as_table) {
+            for source in sources.values() {
+                if let Some(directory) = source.get("directory").and_then(toml::Value::as_str) {
+                    found.extend(resolve_against(dir, directory));
+                }
+            }
+        }
+        return found;
     }
-    None
+    Vec::new()
 }
 
 /// Every `.rs` file under `root` that belongs to the app, in a stable order.

--- a/autumn-cli/src/upgrade/mod.rs
+++ b/autumn-cli/src/upgrade/mod.rs
@@ -386,11 +386,64 @@ pub fn render_json(report: &Report) -> String {
 
 /// Read the `autumn-web` requirement recorded by the app at `root`.
 ///
-/// Both `[dependencies]` and `[workspace.dependencies]` are read, in that
-/// order, so a workspace root that pins the version once for its members
-/// answers for the whole tree.
+/// The root manifest answers first — `[dependencies]` then
+/// `[workspace.dependencies]`, so a workspace that pins the version once for
+/// its members speaks for the whole tree. A *virtual* workspace root declares
+/// neither: its members each carry their own `autumn-web` line, and reading
+/// only the root would abort a perfectly ordinary layout with "cannot tell
+/// which version".
+///
+/// When members disagree, the **oldest** floor wins. That is the conservative
+/// answer: a migration for a release a member is already past finds nothing to
+/// do in that member (the rename it applies has already been applied), while
+/// taking the newest floor would skip a member that is genuinely behind.
 fn recorded_version(root: &Path) -> Option<String> {
-    crate::doctor::read_autumn_web_version_at(root)
+    if let Some(version) = crate::doctor::read_autumn_web_version_at(root) {
+        return Some(version);
+    }
+    member_manifests(root)
+        .into_iter()
+        .filter_map(|directory| crate::doctor::read_autumn_web_version_at(&directory))
+        .filter_map(|requirement| {
+            migrations::parse_version_req(&requirement).map(|version| (version, requirement))
+        })
+        .min_by_key(|(version, _)| *version)
+        .map(|(_, requirement)| requirement)
+}
+
+/// Directories under `root` (excluding `root` itself) that hold a `Cargo.toml`.
+///
+/// Found by walking rather than by parsing `[workspace] members`, which would
+/// mean implementing Cargo's glob patterns; the walk already knows which
+/// directories are not the app's own code.
+fn member_manifests(root: &Path) -> Vec<PathBuf> {
+    let mut found = Vec::new();
+    collect_manifests(root, root, &mut found);
+    found.sort();
+    found
+}
+
+fn collect_manifests(root: &Path, dir: &Path, found: &mut Vec<PathBuf>) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let Ok(file_type) = entry.file_type() else {
+            continue;
+        };
+        if !file_type.is_dir() {
+            continue;
+        }
+        let name = entry.file_name().to_string_lossy().into_owned();
+        if name.starts_with('.') || SKIPPED_DIRS.contains(&name.as_str()) {
+            continue;
+        }
+        let path = entry.path();
+        if path.join("Cargo.toml").is_file() && path != root {
+            found.push(path.clone());
+        }
+        collect_manifests(root, &path, found);
+    }
 }
 
 /// Every `.rs` file under `root` that belongs to the app, in a stable order.

--- a/autumn-cli/src/upgrade/mod.rs
+++ b/autumn-cli/src/upgrade/mod.rs
@@ -922,11 +922,7 @@ mod tests {
     };
 
     fn version(major: u64, minor: u64, patch: u64) -> Version {
-        Version {
-            major,
-            minor,
-            patch,
-        }
+        Version::new(major, minor, patch)
     }
 
     fn sample(outcome: Outcome) -> Report {

--- a/autumn-cli/src/upgrade/mod.rs
+++ b/autumn-cli/src/upgrade/mod.rs
@@ -35,6 +35,7 @@ pub mod diff;
 pub mod engine;
 pub mod migrations;
 
+use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
 
 use migrations::{AppMigration, Version};
@@ -812,6 +813,21 @@ fn display_path(root: &Path, path: &Path) -> String {
         .join("/")
 }
 
+/// Which types the app's own `#[repository]` traits generate.
+///
+/// Collected across the whole scan before any rewriting: this is what turns the
+/// receiver test from a naming convention into evidence, and the trait and the
+/// call site normally live in different modules. A file that cannot be read or
+/// parsed contributes nothing rather than failing the scan — it is reported on
+/// its own account when the rewrite pass reaches it.
+fn generated_receivers(files: &[PathBuf]) -> BTreeSet<String> {
+    files
+        .iter()
+        .filter_map(|path| std::fs::read_to_string(path).ok())
+        .flat_map(|source| engine::generated_repository_types(&source))
+        .collect()
+}
+
 /// Build the report for `root` without writing anything.
 fn plan(root: &Path, from: Version, to: Version) -> Report {
     plan_with(root, from, to, &migrations::migrations_between(from, to))
@@ -878,6 +894,7 @@ fn plan_with(
             "directory could not be read - nothing under it was migrated".to_owned(),
         ));
     }
+    let generated = generated_receivers(&scan.files);
     for path in scan.files {
         let display = display_path(root, &path);
         let source = match std::fs::read_to_string(&path) {
@@ -888,7 +905,7 @@ fn plan_with(
             }
         };
         report.files_scanned += 1;
-        let rewrite = match engine::rewrite_source_for_releases(&source, selected) {
+        let rewrite = match engine::rewrite_source_for_releases(&source, selected, &generated) {
             Ok(rewrite) => rewrite,
             Err(error) => {
                 report.skipped.push((display, error));

--- a/autumn-cli/src/upgrade/mod.rs
+++ b/autumn-cli/src/upgrade/mod.rs
@@ -137,9 +137,30 @@ pub struct Report {
 }
 
 impl Report {
-    /// Total rewritten sites across every file.
+    /// Total rewritten sites across every file in the plan.
     pub fn rewritten_sites(&self) -> usize {
         self.files.iter().map(|f| f.sites.len()).sum()
+    }
+
+    /// Sites in the files that actually reached disk.
+    ///
+    /// The same as [`Self::rewritten_sites`] for a complete apply and zero for
+    /// a preview; for a partial apply it counts only the prefix of files
+    /// written before the failure. Reported separately because they are
+    /// different questions — "what did this run plan" and "what is on disk
+    /// now" — and automation that gates on the wrong one treats an interrupted
+    /// run as a finished one.
+    pub fn written_sites(&self) -> usize {
+        match self.outcome {
+            Outcome::Preview => 0,
+            Outcome::Applied => self.rewritten_sites(),
+            Outcome::Partial { written } => self
+                .files
+                .iter()
+                .take(written)
+                .map(|file| file.sites.len())
+                .sum(),
+        }
     }
 }
 
@@ -323,12 +344,7 @@ fn render_summary(out: &mut String, report: &Report) {
         // saying "N sites rewritten" and "3 files written" in the same summary
         // is worse than either number alone.
         Outcome::Partial { written } => {
-            let written_sites: usize = report
-                .files
-                .iter()
-                .take(written)
-                .map(|file| file.sites.len())
-                .sum();
+            let written_sites = report.written_sites();
             let _ = writeln!(
                 out,
                 "\n{written_sites} site{} in {written} file{} written before the run stopped; \
@@ -455,7 +471,11 @@ pub fn render_json(report: &Report) -> String {
             Outcome::Preview => 0,
         },
         "files_scanned": report.files_scanned,
+        // The plan, and the part of it that reached disk. Equal for a complete
+        // apply; the second is what to gate on when the question is what the
+        // working tree now contains.
         "rewritten_sites": report.rewritten_sites(),
+        "written_sites": report.written_sites(),
         "migrations": migrations_json(&report.migrations),
         "files": files,
         "review": manual_json(&report.review),
@@ -1549,6 +1569,16 @@ mod tests {
             json["applied"], false,
             "`applied` stays a strict did-everything-land flag"
         );
+        // The two site counts must not be conflated: automation gating on what
+        // landed would otherwise read the whole plan as having landed.
+        assert_eq!(
+            json["rewritten_sites"], 3,
+            "the plan is still reported in full"
+        );
+        assert_eq!(
+            json["written_sites"], 1,
+            "but only the sites in the files that reached disk are written"
+        );
     }
 
     #[test]
@@ -1558,6 +1588,10 @@ mod tests {
         assert_eq!(json["outcome"], "applied");
         assert_eq!(json["applied"], true);
         assert_eq!(json["files_written"], 1);
+        assert_eq!(
+            json["written_sites"], json["rewritten_sites"],
+            "a complete apply writes everything it planned"
+        );
     }
 
     #[test]

--- a/autumn-cli/src/upgrade/mod.rs
+++ b/autumn-cli/src/upgrade/mod.rs
@@ -219,7 +219,7 @@ fn render_migrations(out: &mut String, report: &Report) {
             migration.id,
             migration.title
         );
-        let _ = writeln!(out, "          {}", migration.guide);
+        let _ = writeln!(out, "          {}", migrations::guide_url(migration.guide));
     }
 }
 
@@ -288,7 +288,7 @@ fn render_entries(out: &mut String, heading: &str, entries: &[ManualEntry]) {
             entry.migration,
             entry.reason
         );
-        let _ = writeln!(out, "      {}", entry.guide);
+        let _ = writeln!(out, "      {}", migrations::guide_url(entry.guide));
     }
 }
 
@@ -395,6 +395,7 @@ fn migrations_json(migrations: &[&'static AppMigration]) -> serde_json::Value {
                     "title": migration.title,
                     "confidence": migration.confidence.label(),
                     "guide": migration.guide,
+                    "guide_url": migrations::guide_url(migration.guide),
                     "rewrites_code": !matches!(migration.rewrite, migrations::Rewrite::GuideOnly),
                 })
             })
@@ -413,6 +414,7 @@ fn manual_json(entries: &[ManualEntry]) -> serde_json::Value {
                     "migration": entry.migration,
                     "reason": entry.reason,
                     "guide": entry.guide,
+                    "guide_url": migrations::guide_url(entry.guide),
                 })
             })
             .collect(),
@@ -1018,7 +1020,7 @@ pub fn run_in(root: &Path, opts: &UpgradeOptions) -> i32 {
                     migration.id,
                     migration.title
                 );
-                println!("          {}", migration.guide);
+                println!("          {}", migrations::guide_url(migration.guide));
             }
         }
         return 0;

--- a/autumn-cli/src/upgrade/mod.rs
+++ b/autumn-cli/src/upgrade/mod.rs
@@ -820,7 +820,7 @@ fn display_path(root: &Path, path: &Path) -> String {
 /// parsed contributes nothing rather than failing the scan — it is reported on
 /// its own account when the rewrite pass reaches it.
 fn generated_receivers(files: &[PathBuf]) -> engine::GeneratedRepositories {
-    files
+    let mut generated: engine::GeneratedRepositories = files
         .iter()
         .filter_map(|path| {
             let source = std::fs::read_to_string(path).ok()?;
@@ -834,7 +834,14 @@ fn generated_receivers(files: &[PathBuf]) -> engine::GeneratedRepositories {
             ))
         })
         .flatten()
-        .collect()
+        .collect();
+    generated.note_handwritten(
+        files
+            .iter()
+            .filter_map(|path| std::fs::read_to_string(path).ok())
+            .flat_map(|source| engine::defined_type_names(&source)),
+    );
+    generated
 }
 
 /// The module path a file contributes, from Cargo's file-to-module mapping.

--- a/autumn-cli/src/upgrade/mod.rs
+++ b/autumn-cli/src/upgrade/mod.rs
@@ -736,7 +736,7 @@ pub fn run_in(root: &Path, opts: &UpgradeOptions) -> i32 {
 
 #[cfg(test)]
 mod tests {
-    use super::migrations::{Confidence, Rewrite};
+    use super::migrations::{CallForm, Confidence, Rewrite};
     use super::*;
 
     static AUTO: AppMigration = AppMigration {
@@ -748,6 +748,8 @@ mod tests {
         rewrite: Rewrite::CallRename {
             from: "with_pool",
             to: "with_pool_untracked",
+            form: CallForm::AssociatedFunction,
+            args: 1,
         },
     };
 
@@ -892,6 +894,8 @@ mod tests {
         rewrite: Rewrite::CallRename {
             from: "with_pool",
             to: "with_pool_untracked",
+            form: CallForm::AssociatedFunction,
+            args: 1,
         },
     };
 

--- a/autumn-cli/src/upgrade/mod.rs
+++ b/autumn-cli/src/upgrade/mod.rs
@@ -35,7 +35,6 @@ pub mod diff;
 pub mod engine;
 pub mod migrations;
 
-use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
 
 use migrations::{AppMigration, Version};
@@ -820,12 +819,52 @@ fn display_path(root: &Path, path: &Path) -> String {
 /// call site normally live in different modules. A file that cannot be read or
 /// parsed contributes nothing rather than failing the scan — it is reported on
 /// its own account when the rewrite pass reaches it.
-fn generated_receivers(files: &[PathBuf]) -> BTreeSet<String> {
+fn generated_receivers(files: &[PathBuf]) -> engine::GeneratedRepositories {
     files
         .iter()
-        .filter_map(|path| std::fs::read_to_string(path).ok())
-        .flat_map(|source| engine::generated_repository_types(&source))
+        .filter_map(|path| {
+            let source = std::fs::read_to_string(path).ok()?;
+            let prefix = file_module_path(path);
+            Some(engine::generated_repository_types(&source).into_iter().map(
+                move |(name, inner)| {
+                    let mut module = prefix.clone();
+                    module.extend(inner);
+                    (name, module)
+                },
+            ))
+        })
+        .flatten()
         .collect()
+}
+
+/// The module path a file contributes, from Cargo's file-to-module mapping.
+///
+/// `src/repositories.rs` is the module `repositories`, `src/a/b.rs` is `a::b`,
+/// and `mod.rs` / `lib.rs` / `main.rs` name their directory rather than
+/// themselves. A file outside a `src` directory — a test or an example — is
+/// treated as the crate root, which only ever makes verification more
+/// permissive.
+///
+/// `#[path = "…"]` can move a module somewhere this does not predict. The cost
+/// is a *qualified* call being reported for a human instead of rewritten, which
+/// is the safe direction and is visible in the report.
+fn file_module_path(path: &Path) -> Vec<String> {
+    let components: Vec<String> = path
+        .components()
+        .map(|component| component.as_os_str().to_string_lossy().into_owned())
+        .collect();
+    let Some(src_at) = components.iter().rposition(|component| component == "src") else {
+        return Vec::new();
+    };
+    let mut module: Vec<String> = components[src_at + 1..].to_vec();
+    let Some(last) = module.pop() else {
+        return Vec::new();
+    };
+    let stem = last.strip_suffix(".rs").unwrap_or(&last);
+    if !matches!(stem, "mod" | "lib" | "main") {
+        module.push(stem.to_owned());
+    }
+    module
 }
 
 /// Build the report for `root` without writing anything.

--- a/autumn-cli/src/upgrade/mod.rs
+++ b/autumn-cli/src/upgrade/mod.rs
@@ -563,12 +563,12 @@ fn recorded_version(root: &Path) -> Option<String> {
 /// and both are visible in the report.
 fn member_manifests(root: &Path) -> Vec<PathBuf> {
     let mut found = Vec::new();
-    collect_manifests(
-        root,
-        root,
-        configured_target_dir(root).as_deref(),
-        &mut found,
-    );
+    let (forced, target_dir) = root_target_dir(root);
+    let target_dir = TargetDir {
+        forced,
+        path: target_dir.as_deref(),
+    };
+    collect_manifests(root, root, target_dir, &mut found);
     found.sort();
     found
 }
@@ -583,7 +583,7 @@ fn is_target_dir(path: &Path, target_dir: Option<&Path>) -> bool {
     })
 }
 
-fn collect_manifests(root: &Path, dir: &Path, target_dir: Option<&Path>, found: &mut Vec<PathBuf>) {
+fn collect_manifests(root: &Path, dir: &Path, target_dir: TargetDir<'_>, found: &mut Vec<PathBuf>) {
     let Ok(entries) = std::fs::read_dir(dir) else {
         return;
     };
@@ -603,73 +603,129 @@ fn collect_manifests(root: &Path, dir: &Path, target_dir: Option<&Path>, found: 
         let is_metadata = SKIPPED_HIDDEN_DIRS.contains(&name.as_str());
         let is_build_output = at_crate_root && SKIPPED_DIRS.contains(&name.as_str());
         let path = entry.path();
-        if is_metadata || is_build_output || is_target_dir(&path, target_dir) {
+        if is_metadata || is_build_output || is_target_dir(&path, target_dir.path) {
             continue;
         }
         if path.join("Cargo.toml").is_file() && path != root {
             found.push(path.clone());
         }
-        collect_manifests(root, &path, target_dir, found);
+        let nested = target_dir.nested_at(&path);
+        collect_manifests(root, &path, target_dir.or_inherited(nested.as_ref()), found);
     }
 }
 
-/// Cargo's output directory for `root`, when it is not the default `target/`.
+/// Where Cargo's build output lands for the directory currently being walked.
 ///
 /// `CARGO_TARGET_DIR` and `.cargo/config.toml`'s `build.target-dir` both move
-/// build output somewhere the `target` basename check will never look, and the
-/// walk then descends into generated code — `--apply` rewriting artifacts the
-/// next `cargo build` overwrites. Resolved the way Cargo resolves it: the
-/// environment variable against the current directory, a config entry against
-/// the directory holding the `.cargo` that declares it.
+/// output somewhere the `target` basename check will never look, and the walk
+/// then descends into generated code — `--apply` rewriting artifacts the next
+/// `cargo build` overwrites.
 ///
-/// `None` means the default, which the basename check already covers.
-fn configured_target_dir(root: &Path) -> Option<PathBuf> {
-    fn canonical(path: PathBuf) -> Option<PathBuf> {
-        std::fs::canonicalize(path).ok()
+/// It is a walk-time value rather than one path for the whole scan because
+/// Cargo reads `.cargo/config.toml` from the invocation directory upward: a
+/// nested standalone crate redirects its *own* output, and a redirect declared
+/// there applies to that subtree only. The environment variable is the one
+/// exception — it overrides every config file, so when it is set no nested
+/// config is consulted at all.
+#[derive(Clone, Copy, Default)]
+struct TargetDir<'a> {
+    /// `CARGO_TARGET_DIR` decided this, so nested configs are not in effect.
+    forced: bool,
+    /// The resolved output directory, or `None` for the default `target/`,
+    /// which the basename check already covers.
+    path: Option<&'a Path>,
+}
+
+impl TargetDir<'_> {
+    /// What applies inside `dir`, given what applies to its parent.
+    ///
+    /// Returns the nested override so the caller can own it for the length of
+    /// the recursive call; `None` means `dir` inherits.
+    fn nested_at(self, dir: &Path) -> Option<PathBuf> {
+        if self.forced {
+            return None;
+        }
+        config_target_dir_at(dir)
     }
 
-    if let Some(configured) = std::env::var_os("CARGO_TARGET_DIR") {
-        let configured = PathBuf::from(configured);
-        return canonical(if configured.is_absolute() {
-            configured
-        } else {
-            std::env::current_dir().ok()?.join(configured)
-        });
+    /// The same value with `nested` substituted when there is one.
+    fn or_inherited<'n>(self, nested: Option<&'n PathBuf>) -> TargetDir<'n>
+    where
+        Self: 'n,
+    {
+        TargetDir {
+            forced: self.forced,
+            path: nested.map(PathBuf::as_path).or(self.path),
+        }
     }
+}
 
-    // Cargo reads `.cargo/config.toml` from the working directory upward, so a
-    // member inherits the workspace root's redirect.
-    let absolute_root = std::fs::canonicalize(root).ok()?;
-    for ancestor in absolute_root.ancestors() {
-        for name in ["config.toml", "config"] {
-            let Ok(content) = std::fs::read_to_string(ancestor.join(".cargo").join(name)) else {
-                continue;
-            };
-            let Ok(table) = toml::from_str::<toml::Table>(&content) else {
-                continue;
-            };
-            let Some(configured) = table
-                .get("build")
-                .and_then(|build| build.get("target-dir"))
-                .and_then(toml::Value::as_str)
-            else {
-                continue;
-            };
-            let configured = PathBuf::from(configured);
-            return canonical(if configured.is_absolute() {
-                configured
-            } else {
-                ancestor.join(configured)
-            });
+/// Resolve `path` against `base` unless it is already absolute, then canonicalise.
+fn resolve_against(base: &Path, path: &str) -> Option<PathBuf> {
+    let path = PathBuf::from(path);
+    let absolute = if path.is_absolute() {
+        path
+    } else {
+        base.join(path)
+    };
+    std::fs::canonicalize(absolute).ok()
+}
+
+/// `build.target-dir` from the `.cargo/config.toml` in `dir` itself, if any.
+///
+/// Cargo resolves a relative entry against the directory holding the `.cargo`
+/// that declares it, so that is what this resolves against.
+fn config_target_dir_at(dir: &Path) -> Option<PathBuf> {
+    let config_dir = dir.join(".cargo");
+    if !config_dir.is_dir() {
+        return None;
+    }
+    for name in ["config.toml", "config"] {
+        let Ok(content) = std::fs::read_to_string(config_dir.join(name)) else {
+            continue;
+        };
+        let Ok(table) = toml::from_str::<toml::Table>(&content) else {
+            continue;
+        };
+        if let Some(configured) = table
+            .get("build")
+            .and_then(|build| build.get("target-dir"))
+            .and_then(toml::Value::as_str)
+        {
+            return resolve_against(dir, configured);
         }
     }
     None
 }
 
+/// What applies at the scan root, before the walk starts.
+///
+/// The environment variable resolves against the current directory, the way
+/// Cargo resolves it. Failing that, `.cargo/config.toml` is searched from the
+/// root *upward*, so a member inherits the workspace root's redirect.
+fn root_target_dir(root: &Path) -> (bool, Option<PathBuf>) {
+    if let Some(configured) = std::env::var_os("CARGO_TARGET_DIR") {
+        let resolved = std::env::current_dir()
+            .ok()
+            .and_then(|cwd| resolve_against(&cwd, &configured.to_string_lossy()));
+        return (true, resolved);
+    }
+    let Ok(absolute_root) = std::fs::canonicalize(root) else {
+        return (false, None);
+    };
+    let found = absolute_root.ancestors().find_map(config_target_dir_at);
+    (false, found)
+}
+
 /// Every `.rs` file under `root` that belongs to the app, in a stable order.
 fn app_sources(root: &Path) -> SourceScan {
     let mut scan = SourceScan::default();
-    collect_sources(root, configured_target_dir(root).as_deref(), &mut scan);
+    let (forced, target_dir) = root_target_dir(root);
+    let target_dir = TargetDir {
+        forced,
+        path: target_dir.as_deref(),
+    };
+    collect_sources(root, target_dir, &mut scan);
     scan.files.sort();
     scan.symlinks.sort();
     scan.unreadable.sort();
@@ -690,7 +746,7 @@ struct SourceScan {
 
 /// Collect `.rs` files, recording what was deliberately or accidentally left
 /// out so the caller can report it rather than drop it silently.
-fn collect_sources(dir: &Path, target_dir: Option<&Path>, scan: &mut SourceScan) {
+fn collect_sources(dir: &Path, target_dir: TargetDir<'_>, scan: &mut SourceScan) {
     let Ok(entries) = std::fs::read_dir(dir) else {
         scan.unreadable.push(dir.to_path_buf());
         return;
@@ -715,10 +771,11 @@ fn collect_sources(dir: &Path, target_dir: Option<&Path>, scan: &mut SourceScan)
         if file_type.is_dir() {
             let is_metadata = SKIPPED_HIDDEN_DIRS.contains(&name.as_str());
             let is_build_output = at_crate_root && SKIPPED_DIRS.contains(&name.as_str());
-            if is_metadata || is_build_output || is_target_dir(&path, target_dir) {
+            if is_metadata || is_build_output || is_target_dir(&path, target_dir.path) {
                 continue;
             }
-            collect_sources(&path, target_dir, scan);
+            let nested = target_dir.nested_at(&path);
+            collect_sources(&path, target_dir.or_inherited(nested.as_ref()), scan);
         } else if file_type.is_symlink() {
             // A symlinked *directory* has `is_dir() == false`, so gating this
             // on a `.rs` extension hid a linked `src/` entirely: no traversal,

--- a/autumn-cli/src/upgrade/mod.rs
+++ b/autumn-cli/src/upgrade/mod.rs
@@ -1,0 +1,983 @@
+//! `autumn upgrade` — apply each release's mechanical app-code migrations
+//! (issue #1629).
+//!
+//! Autumn ships every 2-4 weeks and, pre-1.0, most releases can break existing
+//! apps. Issue #1588 made a written migration guide a release gate, and #1593
+//! reconciles framework-owned scaffold files — but both leave the user's own
+//! Rust code out of bounds, so a purely mechanical rename like 0.6.0's
+//! `with_pool` -> `with_pool_untracked` still had to be hand-applied call site
+//! by call site from prose.
+//!
+//! This command closes that half. For each release between the app's recorded
+//! `autumn-web` version and the target, it applies that release's
+//! machine-applyable migrations (see [`migrations`]) to the app's own source,
+//! and reports everything it could not safely rewrite with `file:line` and a
+//! guide link rather than guessing.
+//!
+//! # Safety posture
+//!
+//! - **Preview by default.** A bare `autumn upgrade` writes nothing: it prints
+//!   a per-file diff and a count of affected sites. `--apply` is the explicit
+//!   write step.
+//! - **Plan first, then write.** Every file is read, parsed, and rewritten in
+//!   memory before a single byte is written, so a parse failure halfway through
+//!   cannot leave the tree half-migrated.
+//! - **Idempotent.** Rewrites match whole tokens, so a second run finds
+//!   nothing; an app that never used the affected APIs reports nothing to
+//!   change.
+//! - **Nothing silent.** A site the engine declines to rewrite (inside a macro
+//!   invocation or an attribute) is listed under `manual` with its location.
+//!
+//! `autumn upgrade` is also where #1593's scaffold reconciliation lands when it
+//! ships; this slice is the app-code step only.
+
+pub mod diff;
+pub mod engine;
+pub mod migrations;
+
+use std::path::{Path, PathBuf};
+
+use migrations::{AppMigration, Version};
+
+/// Options for `autumn upgrade`.
+#[derive(Debug, Clone, Default)]
+pub struct UpgradeOptions {
+    /// Override the detected `autumn-web` version the app is upgrading *from*.
+    pub from: Option<String>,
+    /// Override the version being upgraded *to* (defaults to this CLI's own
+    /// version).
+    pub to: Option<String>,
+    /// Write the rewrites. Without it the command is preview-only.
+    pub apply: bool,
+    /// Emit the machine-readable report instead of the human one.
+    pub json: bool,
+    /// List the registry and exit, without scanning any source.
+    pub list: bool,
+}
+
+/// A site the user has to handle themselves, with where to read about it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ManualEntry {
+    /// Repo-relative file, or `None` for a whole-change (guide-only) entry.
+    pub path: Option<String>,
+    /// 1-based line, or `None` for a whole-change entry.
+    pub line: Option<usize>,
+    /// [`AppMigration::id`].
+    pub migration: &'static str,
+    /// Why it was not rewritten.
+    pub reason: String,
+    /// Guide section to read.
+    pub guide: &'static str,
+}
+
+/// One file's planned or applied rewrite.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FileReport {
+    /// Path as displayed, relative to the scan root.
+    pub path: String,
+    /// Rewritten sites in this file.
+    pub sites: Vec<engine::Site>,
+    /// Rendered preview diff.
+    pub diff: String,
+    /// The full rewritten text (not serialized; used by the apply step).
+    pub updated: String,
+    /// Absolute path to write to.
+    pub absolute: PathBuf,
+}
+
+/// Everything one `autumn upgrade` run found.
+#[derive(Debug, Clone)]
+pub struct Report {
+    pub from: Version,
+    pub to: Version,
+    /// Whether the rewrites were written to disk.
+    pub applied: bool,
+    /// `.rs` files read.
+    pub files_scanned: usize,
+    /// Migrations selected for this version range.
+    pub migrations: Vec<&'static AppMigration>,
+    /// Files with at least one rewrite.
+    pub files: Vec<FileReport>,
+    /// Sites belonging to a `review`-confidence migration, listed individually.
+    pub review: Vec<ManualEntry>,
+    /// Sites and changes left for a human.
+    pub manual: Vec<ManualEntry>,
+    /// Files that could not be read or parsed, with the reason.
+    pub skipped: Vec<(String, String)>,
+}
+
+impl Report {
+    /// Total rewritten sites across every file.
+    pub fn rewritten_sites(&self) -> usize {
+        self.files.iter().map(|f| f.sites.len()).sum()
+    }
+}
+
+/// Directory names never scanned: build output and vendored third-party
+/// sources are not the app's own code, and rewriting them is at best wasted
+/// work and at worst a corrupted dependency.
+const SKIPPED_DIRS: &[&str] = &["target", "vendor", "node_modules", "dist", "tmp"];
+
+/// Render the human-readable report.
+pub fn render_text(report: &Report) -> String {
+    use std::fmt::Write as _;
+    let mut out = String::new();
+
+    let _ = writeln!(
+        out,
+        "autumn upgrade - app-code migrations {} -> {}",
+        report.from, report.to
+    );
+
+    if report.migrations.is_empty() {
+        let _ = writeln!(
+            out,
+            "\nNothing to change: no shipped migration falls in this version range."
+        );
+        if report.from >= report.to {
+            // Overwhelmingly the reason someone sees an empty range: the
+            // dependency was bumped before running the codemods, so the app
+            // now records the version it is being upgraded *to*.
+            let _ = writeln!(
+                out,
+                "This app already records `autumn-web {}`. If you bumped the dependency\n\
+                 before running the codemods, pass the release you came from:\n\
+                 `autumn upgrade --from <previous-version>`.",
+                report.from
+            );
+        }
+        return out;
+    }
+
+    render_migrations(&mut out, report);
+    render_diffs(&mut out, report);
+    render_entries(
+        &mut out,
+        "Review - rewritten, but read each of these before committing",
+        &report.review,
+    );
+    render_entries(
+        &mut out,
+        "Manual - not rewritten; read the guide section",
+        &report.manual,
+    );
+    render_skipped(&mut out, report);
+    render_summary(&mut out, report);
+    out
+}
+
+/// The migrations selected for this version range, each with its confidence
+/// label and the guide section it points at.
+fn render_migrations(out: &mut String, report: &Report) {
+    use std::fmt::Write as _;
+    let _ = writeln!(out, "\nMigrations in range ({}):", report.migrations.len());
+    for migration in &report.migrations {
+        let _ = writeln!(
+            out,
+            "  {:<6}  {}  {}",
+            migration.confidence.label(),
+            migration.id,
+            migration.title
+        );
+        let _ = writeln!(out, "          {}", migration.guide);
+    }
+}
+
+/// The per-file diff — the product of the default, preview-only invocation.
+fn render_diffs(out: &mut String, report: &Report) {
+    use std::fmt::Write as _;
+    if report.files.is_empty() {
+        // Nothing to *rewrite*. Say which kind of nothing it is: a site only a
+        // human can take is not the same answer as a clean tree, and telling
+        // someone to re-run with `--apply` when `--apply` would write nothing
+        // is the worst of the three.
+        let human_sites = report
+            .manual
+            .iter()
+            .filter(|entry| entry.path.is_some())
+            .count();
+        if human_sites > 0 {
+            let _ = writeln!(
+                out,
+                "\nNothing to rewrite: {human_sites} site{} need{} a human — see Manual below.",
+                plural(human_sites),
+                if human_sites == 1 { "s" } else { "" }
+            );
+        } else {
+            let _ = writeln!(
+                out,
+                "\nNothing to change: no affected call site found in {} scanned file(s).",
+                report.files_scanned
+            );
+        }
+        return;
+    }
+    let _ = writeln!(
+        out,
+        "\n{}:",
+        if report.applied {
+            "Applied"
+        } else {
+            "Preview (nothing is written without --apply)"
+        }
+    );
+    for file in &report.files {
+        let _ = writeln!(
+            out,
+            "\n{} ({} site{})",
+            file.path,
+            file.sites.len(),
+            plural(file.sites.len())
+        );
+        out.push_str(&file.diff);
+    }
+}
+
+/// A `review` or `manual` list: one line per entry, one line per guide link.
+fn render_entries(out: &mut String, heading: &str, entries: &[ManualEntry]) {
+    use std::fmt::Write as _;
+    if entries.is_empty() {
+        return;
+    }
+    let _ = writeln!(out, "\n{heading}:");
+    for entry in entries {
+        let _ = writeln!(
+            out,
+            "  {}  {} ({})",
+            entry.location(),
+            entry.migration,
+            entry.reason
+        );
+        let _ = writeln!(out, "      {}", entry.guide);
+    }
+}
+
+/// Files that could not be read or parsed. They were left exactly as they were.
+fn render_skipped(out: &mut String, report: &Report) {
+    use std::fmt::Write as _;
+    if report.skipped.is_empty() {
+        return;
+    }
+    let _ = writeln!(out, "\nSkipped - left untouched:");
+    for (path, reason) in &report.skipped {
+        let _ = writeln!(out, "  {path}: {reason}");
+    }
+}
+
+/// The closing counts, and — in preview — how to actually take the changes.
+fn render_summary(out: &mut String, report: &Report) {
+    use std::fmt::Write as _;
+    let sites = report.rewritten_sites();
+    if sites > 0 {
+        let files = report.files.len();
+        let _ = writeln!(
+            out,
+            "\n{sites} site{} in {files} file{} {}; {} file(s) scanned.",
+            plural(sites),
+            plural(files),
+            if report.applied {
+                "rewritten"
+            } else {
+                "would be rewritten"
+            },
+            report.files_scanned
+        );
+    }
+    if report.applied {
+        if sites > 0 {
+            let _ = writeln!(out, "Review the result with `git diff` before committing.");
+        }
+    } else if sites > 0 {
+        // Only offered when `--apply` would actually write something: a run
+        // whose every remaining site is `manual` has nothing for it to do.
+        let _ = writeln!(
+            out,
+            "Nothing was written. Re-run with `--apply` to write these changes."
+        );
+    }
+}
+
+/// `""` or `"s"`.
+const fn plural(count: usize) -> &'static str {
+    if count == 1 { "" } else { "s" }
+}
+
+impl ManualEntry {
+    /// `path:line`, or the migration's own name for a whole-change entry.
+    fn location(&self) -> String {
+        match (&self.path, self.line) {
+            (Some(path), Some(line)) => format!("{path}:{line}"),
+            (Some(path), None) => path.clone(),
+            _ => "(whole change)".to_owned(),
+        }
+    }
+}
+
+/// The registry as JSON, shared by the report and `--list-migrations --json`.
+fn migrations_json(migrations: &[&'static AppMigration]) -> serde_json::Value {
+    serde_json::Value::Array(
+        migrations
+            .iter()
+            .map(|migration| {
+                serde_json::json!({
+                    "id": migration.id,
+                    "version": migration.version,
+                    "title": migration.title,
+                    "confidence": migration.confidence.label(),
+                    "guide": migration.guide,
+                    "rewrites_code": !matches!(migration.rewrite, migrations::Rewrite::GuideOnly),
+                })
+            })
+            .collect(),
+    )
+}
+
+fn manual_json(entries: &[ManualEntry]) -> serde_json::Value {
+    serde_json::Value::Array(
+        entries
+            .iter()
+            .map(|entry| {
+                serde_json::json!({
+                    "path": entry.path,
+                    "line": entry.line,
+                    "migration": entry.migration,
+                    "reason": entry.reason,
+                    "guide": entry.guide,
+                })
+            })
+            .collect(),
+    )
+}
+
+/// Render the machine-readable report.
+pub fn render_json(report: &Report) -> String {
+    let files: Vec<serde_json::Value> = report
+        .files
+        .iter()
+        .map(|file| {
+            serde_json::json!({
+                "path": file.path,
+                "diff": file.diff,
+                "sites": file.sites.iter().map(|site| serde_json::json!({
+                    "line": site.line,
+                    "column": site.column,
+                    "migration": site.migration,
+                })).collect::<Vec<_>>(),
+            })
+        })
+        .collect();
+    let value = serde_json::json!({
+        "from": report.from.to_string(),
+        "to": report.to.to_string(),
+        "applied": report.applied,
+        "files_scanned": report.files_scanned,
+        "rewritten_sites": report.rewritten_sites(),
+        "migrations": migrations_json(&report.migrations),
+        "files": files,
+        "review": manual_json(&report.review),
+        "manual": manual_json(&report.manual),
+        "skipped": report.skipped.iter().map(|(path, reason)| serde_json::json!({
+            "path": path,
+            "reason": reason,
+        })).collect::<Vec<_>>(),
+    });
+    serde_json::to_string_pretty(&value).unwrap_or_else(|_| "{}".to_owned())
+}
+
+/// Read the `autumn-web` requirement recorded by the app at `root`.
+///
+/// Both `[dependencies]` and `[workspace.dependencies]` are read, in that
+/// order, so a workspace root that pins the version once for its members
+/// answers for the whole tree.
+fn recorded_version(root: &Path) -> Option<String> {
+    crate::doctor::read_autumn_web_version_at(root)
+}
+
+/// Every `.rs` file under `root` that belongs to the app, in a stable order.
+fn app_sources(root: &Path) -> SourceScan {
+    let mut scan = SourceScan::default();
+    collect_sources(root, &mut scan);
+    scan.files.sort();
+    scan.symlinks.sort();
+    scan.unreadable.sort();
+    scan
+}
+
+/// What a walk of the app's tree turned up.
+#[derive(Debug, Default)]
+struct SourceScan {
+    /// Regular `.rs` files to migrate.
+    files: Vec<PathBuf>,
+    /// Symlinked `.rs` files, reported rather than followed.
+    symlinks: Vec<PathBuf>,
+    /// Directories the walk could not read.
+    unreadable: Vec<PathBuf>,
+}
+
+/// Collect `.rs` files, recording what was deliberately or accidentally left
+/// out so the caller can report it rather than drop it silently.
+fn collect_sources(dir: &Path, scan: &mut SourceScan) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        scan.unreadable.push(dir.to_path_buf());
+        return;
+    };
+    for entry in entries.flatten() {
+        // `file_type` does not follow symlinks, so a link into `target/`, a
+        // link out of the project, or a cycle is neither descended into nor
+        // rewritten. A linked `.rs` file is still *reported*: quietly leaving a
+        // source file out of the migration is the failure mode this command
+        // exists to remove.
+        let Ok(file_type) = entry.file_type() else {
+            continue;
+        };
+        let path = entry.path();
+        let name = entry.file_name().to_string_lossy().into_owned();
+        if file_type.is_dir() {
+            if name.starts_with('.') || SKIPPED_DIRS.contains(&name.as_str()) {
+                continue;
+            }
+            collect_sources(&path, scan);
+        } else if path.extension().is_some_and(|ext| ext == "rs") {
+            if file_type.is_file() {
+                scan.files.push(path);
+            } else if file_type.is_symlink() {
+                scan.symlinks.push(path);
+            }
+        }
+    }
+}
+
+/// Display form of `path` relative to `root`, with `/` separators on every
+/// platform so the reported `file:line` is copy-pasteable.
+fn display_path(root: &Path, path: &Path) -> String {
+    path.strip_prefix(root)
+        .unwrap_or(path)
+        .components()
+        .map(|component| component.as_os_str().to_string_lossy().into_owned())
+        .collect::<Vec<_>>()
+        .join("/")
+}
+
+/// Build the report for `root` without writing anything.
+fn plan(root: &Path, from: Version, to: Version) -> Report {
+    plan_with(root, from, to, &migrations::migrations_between(from, to))
+}
+
+/// [`plan`] over an explicit migration selection.
+///
+/// Split out so the `review` and multi-release paths are testable: the shipped
+/// registry is a `static` with a single release in it, so a selection taken
+/// from it can never exercise either.
+fn plan_with(
+    root: &Path,
+    from: Version,
+    to: Version,
+    selected: &[&'static AppMigration],
+) -> Report {
+    let mut report = Report {
+        from,
+        to,
+        applied: false,
+        files_scanned: 0,
+        migrations: selected.to_vec(),
+        files: Vec::new(),
+        review: Vec::new(),
+        manual: Vec::new(),
+        skipped: Vec::new(),
+    };
+
+    // A change with no machine-applyable rewrite is still the user's problem;
+    // surface it with its guide section rather than staying silent.
+    for migration in selected {
+        if matches!(migration.rewrite, migrations::Rewrite::GuideOnly) {
+            report.manual.push(ManualEntry {
+                path: None,
+                line: None,
+                migration: migration.id,
+                reason: "no machine-applyable rewrite".to_owned(),
+                guide: migration.guide,
+            });
+        }
+    }
+
+    // Every reported site names a migration from this same selection, so the
+    // lookup only fails if the two ever drift; the index page is the honest
+    // fallback rather than a guessed confidence level.
+    let selected_by_id = |id: &str| {
+        selected
+            .iter()
+            .copied()
+            .find(|migration| migration.id == id)
+    };
+    let guide_for = |id: &str| selected_by_id(id).map_or("docs/migrations/README.md", |m| m.guide);
+
+    let scan = app_sources(root);
+    for path in scan.symlinks {
+        report.skipped.push((
+            display_path(root, &path),
+            "symbolic link - not followed, migrate it in its own checkout".to_owned(),
+        ));
+    }
+    for path in scan.unreadable {
+        report.skipped.push((
+            display_path(root, &path),
+            "directory could not be read - nothing under it was migrated".to_owned(),
+        ));
+    }
+    for path in scan.files {
+        let display = display_path(root, &path);
+        let source = match std::fs::read_to_string(&path) {
+            Ok(source) => source,
+            Err(error) => {
+                report.skipped.push((display, error.to_string()));
+                continue;
+            }
+        };
+        report.files_scanned += 1;
+        let rewrite = match engine::rewrite_source_for_releases(&source, selected) {
+            Ok(rewrite) => rewrite,
+            Err(error) => {
+                report.skipped.push((display, error));
+                continue;
+            }
+        };
+
+        for site in &rewrite.manual {
+            report.manual.push(ManualEntry {
+                path: Some(display.clone()),
+                line: Some(site.line),
+                migration: site.migration,
+                reason: site.manual.map_or_else(
+                    || "not rewritable".to_owned(),
+                    |reason| reason.describe().to_owned(),
+                ),
+                guide: guide_for(site.migration),
+            });
+        }
+
+        // A `review` migration rewrites, but every site it touched is listed
+        // individually so a human reads them before committing.
+        for site in &rewrite.rewritten {
+            if selected_by_id(site.migration)
+                .is_some_and(|m| m.confidence == migrations::Confidence::Review)
+            {
+                report.review.push(ManualEntry {
+                    path: Some(display.clone()),
+                    line: Some(site.line),
+                    migration: site.migration,
+                    reason: "rewritten - confirm the new call is what you meant".to_owned(),
+                    guide: guide_for(site.migration),
+                });
+            }
+        }
+
+        if let Some(updated) = rewrite.updated {
+            report.files.push(FileReport {
+                path: display,
+                sites: rewrite.rewritten,
+                diff: diff::render(&source, &updated),
+                updated,
+                absolute: path,
+            });
+        }
+    }
+
+    report
+}
+
+/// Write every planned rewrite.
+///
+/// Each file is written through a sibling temporary file and renamed over the
+/// original, so an interrupted write leaves the original intact rather than a
+/// truncated source file.
+fn write_plan(report: &Report) -> Result<(), WriteFailure> {
+    for file in &report.files {
+        write_one(file).map_err(|error| WriteFailure {
+            path: file.path.clone(),
+            error,
+        })?;
+    }
+    Ok(())
+}
+
+/// Which file the apply step died on, and why. Without the path, a failure
+/// halfway through a multi-file apply tells the user nothing about what state
+/// their tree is in.
+#[derive(Debug)]
+struct WriteFailure {
+    path: String,
+    error: std::io::Error,
+}
+
+/// Write one file through a sibling temporary file renamed over the original.
+fn write_one(file: &FileReport) -> std::io::Result<()> {
+    use std::io::Write as _;
+
+    let directory = file.absolute.parent().unwrap_or_else(|| Path::new("."));
+    let mut temp = tempfile::Builder::new()
+        // Deliberately not `.rs`: a temporary left behind by a killed run must
+        // not be picked up as app source by the next one.
+        .prefix(".autumn-upgrade-")
+        .suffix(".tmp")
+        .tempfile_in(directory)?;
+    temp.write_all(file.updated.as_bytes())?;
+    temp.flush()?;
+    // Rename is atomic, but only against a *crash* if the bytes reached the
+    // disk first — otherwise the rename can land before the data and leave the
+    // user with an empty source file.
+    temp.as_file().sync_all()?;
+    // A fresh temporary file is created 0600; the rename would otherwise
+    // silently tighten the mode of every migrated source file.
+    if let Ok(metadata) = std::fs::metadata(&file.absolute) {
+        let _ = temp.as_file().set_permissions(metadata.permissions());
+    }
+    temp.persist(&file.absolute)
+        .map_err(|error| std::io::Error::other(error.to_string()))?;
+    Ok(())
+}
+
+/// Run `autumn upgrade` against `root`, returning the process exit code.
+///
+/// `0` on any completed scan — including one that found sites only a human can
+/// take, or files it could not parse, both of which the report names. `1` when
+/// the apply step failed partway through, `2` for a bad argument or an
+/// unreadable scan root.
+#[must_use]
+pub fn run_in(root: &Path, opts: &UpgradeOptions) -> i32 {
+    if opts.list {
+        let all: Vec<&'static AppMigration> = migrations::app_migrations().iter().collect();
+        if opts.json {
+            println!(
+                "{}",
+                serde_json::to_string_pretty(
+                    &serde_json::json!({ "migrations": migrations_json(&all) })
+                )
+                .unwrap_or_else(|_| "{}".to_owned())
+            );
+        } else {
+            println!("Shipped app-code migrations ({}):", all.len());
+            for migration in &all {
+                println!(
+                    "  {:<6}  {}  {}",
+                    migration.confidence.label(),
+                    migration.id,
+                    migration.title
+                );
+                println!("          {}", migration.guide);
+            }
+        }
+        return 0;
+    }
+
+    let target = opts
+        .to
+        .clone()
+        .unwrap_or_else(|| env!("CARGO_PKG_VERSION").to_owned());
+    let Some(to) = migrations::parse_version_req(&target) else {
+        eprintln!("autumn upgrade: cannot parse --to version `{target}`");
+        return 2;
+    };
+
+    let recorded = opts.from.clone().or_else(|| recorded_version(root));
+    let Some(recorded) = recorded else {
+        eprintln!(
+            "autumn upgrade: cannot tell which autumn-web version this app is on.\n\
+             Add an `autumn-web` dependency to Cargo.toml, or pass `--from <version>`."
+        );
+        return 2;
+    };
+    let Some(from) = migrations::parse_version_req(&recorded) else {
+        eprintln!(
+            "autumn upgrade: cannot parse the recorded autumn-web version `{recorded}`.\n\
+             Pass `--from <version>` with the release this app is upgrading from."
+        );
+        return 2;
+    };
+
+    // A path typo must not read as "your app is already migrated" — the same
+    // rule `autumn a11y verify` states for its scan root.
+    if !root.is_dir() {
+        eprintln!(
+            "autumn upgrade: `{}` is not a readable directory.",
+            root.display()
+        );
+        return 2;
+    }
+
+    let mut report = plan(root, from, to);
+    let mut failure = None;
+    if opts.apply {
+        report.applied = true;
+        if let Err(write_failure) = write_plan(&report) {
+            // Report first, fail second: a partial apply is exactly when the
+            // user most needs to see which files were in the plan and which one
+            // stopped it.
+            report.applied = false;
+            failure = Some(write_failure);
+        }
+    }
+
+    if opts.json {
+        println!("{}", render_json(&report));
+    } else {
+        print!("{}", render_text(&report));
+    }
+
+    if let Some(WriteFailure { path, error }) = failure {
+        eprintln!(
+            "autumn upgrade: failed while writing {path}: {error}\n\
+             Files listed before it in the report above were already written; \
+             `git diff` shows exactly what changed."
+        );
+        return 1;
+    }
+    0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::migrations::{Confidence, Rewrite};
+    use super::*;
+
+    static AUTO: AppMigration = AppMigration {
+        id: "0.6.0-pool-rename",
+        version: "0.6.0",
+        title: "`with_pool` is renamed to `with_pool_untracked`",
+        confidence: Confidence::Auto,
+        guide: "docs/migrations/0.6.0.md#rename",
+        rewrite: Rewrite::CallRename {
+            from: "with_pool",
+            to: "with_pool_untracked",
+        },
+    };
+
+    static MANUAL: AppMigration = AppMigration {
+        id: "0.6.0-jwt-secret",
+        version: "0.6.0",
+        title: "`jwt_secret` is now a `SecretString`",
+        confidence: Confidence::Manual,
+        guide: "docs/migrations/0.6.0.md#secret",
+        rewrite: Rewrite::GuideOnly,
+    };
+
+    fn version(major: u64, minor: u64, patch: u64) -> Version {
+        Version {
+            major,
+            minor,
+            patch,
+        }
+    }
+
+    fn sample(applied: bool) -> Report {
+        Report {
+            from: version(0, 5, 0),
+            to: version(0, 6, 0),
+            applied,
+            files_scanned: 7,
+            migrations: vec![&AUTO, &MANUAL],
+            files: vec![FileReport {
+                path: "src/main.rs".into(),
+                sites: vec![engine::Site {
+                    line: 12,
+                    column: 19,
+                    migration: AUTO.id,
+                    manual: None,
+                }],
+                diff: "@@ line 12 @@\n-a\n+b\n".into(),
+                updated: "b\n".into(),
+                absolute: PathBuf::from("/tmp/app/src/main.rs"),
+            }],
+            review: Vec::new(),
+            manual: vec![
+                ManualEntry {
+                    path: Some("src/lib.rs".into()),
+                    line: Some(40),
+                    migration: AUTO.id,
+                    reason: "inside a macro invocation".into(),
+                    guide: AUTO.guide,
+                },
+                ManualEntry {
+                    path: None,
+                    line: None,
+                    migration: MANUAL.id,
+                    reason: "no machine-applyable rewrite".into(),
+                    guide: MANUAL.guide,
+                },
+            ],
+            skipped: vec![("src/broken.rs".into(), "expected `{`".into())],
+        }
+    }
+
+    fn empty(applied: bool) -> Report {
+        Report {
+            from: version(0, 6, 0),
+            to: version(0, 6, 0),
+            applied,
+            files_scanned: 3,
+            migrations: Vec::new(),
+            files: Vec::new(),
+            review: Vec::new(),
+            manual: Vec::new(),
+            skipped: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn rewritten_sites_totals_every_file() {
+        assert_eq!(sample(false).rewritten_sites(), 1);
+        assert_eq!(empty(false).rewritten_sites(), 0);
+    }
+
+    #[test]
+    fn preview_text_shows_the_diff_the_counts_and_that_nothing_was_written() {
+        let out = render_text(&sample(false));
+        assert!(out.contains("src/main.rs"), "{out}");
+        assert!(out.contains("@@ line 12 @@"), "{out}");
+        assert!(out.contains("1 site"), "site count is reported: {out}");
+        assert!(
+            out.contains("--apply"),
+            "the preview must name the explicit write step: {out}"
+        );
+        assert!(out.to_lowercase().contains("nothing was written"), "{out}");
+    }
+
+    #[test]
+    fn preview_text_lists_every_manual_site_with_location_and_guide() {
+        let out = render_text(&sample(false));
+        assert!(out.contains("src/lib.rs:40"), "{out}");
+        assert!(out.contains("inside a macro invocation"), "{out}");
+        assert!(out.contains("docs/migrations/0.6.0.md#rename"), "{out}");
+        assert!(out.contains("docs/migrations/0.6.0.md#secret"), "{out}");
+    }
+
+    #[test]
+    fn preview_text_labels_each_selected_migration_with_its_confidence() {
+        let out = render_text(&sample(false));
+        // The fixture ids deliberately contain neither word, so these can only
+        // pass if the label column is actually rendered.
+        assert!(out.contains("auto    0.6.0-pool-rename"), "{out}");
+        assert!(out.contains("manual  0.6.0-jwt-secret"), "{out}");
+    }
+
+    #[test]
+    fn preview_text_reports_skipped_files() {
+        let out = render_text(&sample(false));
+        assert!(out.contains("src/broken.rs"), "{out}");
+        assert!(out.contains("expected `{`"), "{out}");
+    }
+
+    #[test]
+    fn applied_text_says_what_was_written_and_not_what_would_be() {
+        let out = render_text(&sample(true));
+        assert!(!out.to_lowercase().contains("nothing was written"), "{out}");
+        assert!(out.contains("1 site in 1 file rewritten"), "{out}");
+    }
+
+    #[test]
+    fn an_unaffected_app_reports_nothing_to_change() {
+        let out = render_text(&empty(false));
+        assert!(
+            out.to_lowercase().contains("nothing to change"),
+            "an app that never used the affected APIs must say so plainly: {out}"
+        );
+        assert!(!out.contains("@@"), "no diff to show: {out}");
+    }
+
+    static REVIEW: AppMigration = AppMigration {
+        id: "0.6.0-review-rename",
+        version: "0.6.0",
+        title: "a rename worth a second look",
+        confidence: Confidence::Review,
+        guide: "docs/migrations/0.6.0.md#review",
+        rewrite: Rewrite::CallRename {
+            from: "with_pool",
+            to: "with_pool_untracked",
+        },
+    };
+
+    #[test]
+    fn a_review_migration_rewrites_and_flags_every_site_it_touched() {
+        // The shipped registry has no `review` entry, so this path is only
+        // reachable through an injected selection — and it is an acceptance
+        // criterion, not dead code.
+        let root = tempfile::TempDir::new().expect("tempdir");
+        std::fs::create_dir_all(root.path().join("src")).expect("src");
+        std::fs::write(
+            root.path().join("src/main.rs"),
+            "fn a(p: Pool) {\n    Repo::with_pool(p);\n}\n",
+        )
+        .expect("source");
+
+        let report = plan_with(root.path(), version(0, 5, 0), version(0, 6, 0), &[&REVIEW]);
+
+        assert_eq!(
+            report.rewritten_sites(),
+            1,
+            "a review migration still rewrites"
+        );
+        assert_eq!(report.review.len(), 1, "and flags the site it rewrote");
+        assert_eq!(report.review[0].path.as_deref(), Some("src/main.rs"));
+        assert_eq!(report.review[0].line, Some(2));
+        assert_eq!(report.review[0].migration, REVIEW.id);
+        assert_eq!(report.review[0].guide, REVIEW.guide);
+        assert!(
+            report.manual.is_empty(),
+            "a review site is not a manual one"
+        );
+
+        let text = render_text(&report);
+        assert!(text.contains("Review - rewritten"), "{text}");
+        assert!(text.contains("src/main.rs:2"), "{text}");
+        assert!(text.contains("review  0.6.0-review-rename"), "{text}");
+
+        let json: serde_json::Value =
+            serde_json::from_str(&render_json(&report)).expect("valid JSON");
+        assert_eq!(json["review"][0]["line"], 2);
+        assert_eq!(json["migrations"][0]["confidence"], "review");
+    }
+
+    #[test]
+    fn an_auto_migration_flags_no_sites_for_review() {
+        // The distinction between `auto` and `review` is exactly this list.
+        let root = tempfile::TempDir::new().expect("tempdir");
+        std::fs::create_dir_all(root.path().join("src")).expect("src");
+        std::fs::write(
+            root.path().join("src/main.rs"),
+            "fn a(p: Pool) {\n    Repo::with_pool(p);\n}\n",
+        )
+        .expect("source");
+
+        let report = plan_with(root.path(), version(0, 5, 0), version(0, 6, 0), &[&AUTO]);
+        assert_eq!(report.rewritten_sites(), 1);
+        assert!(
+            report.review.is_empty(),
+            "auto sites are not flagged one by one"
+        );
+    }
+
+    #[test]
+    fn json_report_carries_the_range_counts_and_labels() {
+        let out = render_json(&sample(false));
+        let value: serde_json::Value = serde_json::from_str(&out).expect("valid JSON");
+        assert_eq!(value["from"], "0.5.0");
+        assert_eq!(value["to"], "0.6.0");
+        assert_eq!(value["applied"], false);
+        assert_eq!(value["files_scanned"], 7);
+        assert_eq!(value["rewritten_sites"], 1);
+        assert_eq!(value["migrations"][0]["id"], "0.6.0-pool-rename");
+        assert_eq!(value["migrations"][0]["confidence"], "auto");
+        assert_eq!(value["files"][0]["path"], "src/main.rs");
+        assert_eq!(value["files"][0]["sites"][0]["line"], 12);
+        assert_eq!(value["manual"][0]["path"], "src/lib.rs");
+        assert_eq!(value["manual"][0]["line"], 40);
+        assert_eq!(value["skipped"][0]["path"], "src/broken.rs");
+    }
+
+    #[test]
+    fn json_report_omits_the_rewritten_file_bodies() {
+        // The report is a summary, not a payload: dumping every rewritten file
+        // into it would make `--json` unusable on a real app.
+        let out = render_json(&sample(false));
+        assert!(!out.contains("\"updated\""), "{out}");
+    }
+}

--- a/autumn-cli/src/upgrade/mod.rs
+++ b/autumn-cli/src/upgrade/mod.rs
@@ -563,12 +563,27 @@ fn recorded_version(root: &Path) -> Option<String> {
 /// and both are visible in the report.
 fn member_manifests(root: &Path) -> Vec<PathBuf> {
     let mut found = Vec::new();
-    collect_manifests(root, root, &mut found);
+    collect_manifests(
+        root,
+        root,
+        configured_target_dir(root).as_deref(),
+        &mut found,
+    );
     found.sort();
     found
 }
 
-fn collect_manifests(root: &Path, dir: &Path, found: &mut Vec<PathBuf>) {
+/// Whether `path` is Cargo's configured output directory.
+///
+/// By resolved path, not by name: with the target directory redirected to
+/// `out/`, an unrelated `src/out/mod.rs` is ordinary app code.
+fn is_target_dir(path: &Path, target_dir: Option<&Path>) -> bool {
+    target_dir.is_some_and(|target_dir| {
+        std::fs::canonicalize(path).is_ok_and(|resolved| resolved == target_dir)
+    })
+}
+
+fn collect_manifests(root: &Path, dir: &Path, target_dir: Option<&Path>, found: &mut Vec<PathBuf>) {
     let Ok(entries) = std::fs::read_dir(dir) else {
         return;
     };
@@ -587,21 +602,74 @@ fn collect_manifests(root: &Path, dir: &Path, found: &mut Vec<PathBuf>) {
         let name = entry.file_name().to_string_lossy().into_owned();
         let is_metadata = SKIPPED_HIDDEN_DIRS.contains(&name.as_str());
         let is_build_output = at_crate_root && SKIPPED_DIRS.contains(&name.as_str());
-        if is_metadata || is_build_output {
+        let path = entry.path();
+        if is_metadata || is_build_output || is_target_dir(&path, target_dir) {
             continue;
         }
-        let path = entry.path();
         if path.join("Cargo.toml").is_file() && path != root {
             found.push(path.clone());
         }
-        collect_manifests(root, &path, found);
+        collect_manifests(root, &path, target_dir, found);
     }
+}
+
+/// Cargo's output directory for `root`, when it is not the default `target/`.
+///
+/// `CARGO_TARGET_DIR` and `.cargo/config.toml`'s `build.target-dir` both move
+/// build output somewhere the `target` basename check will never look, and the
+/// walk then descends into generated code — `--apply` rewriting artifacts the
+/// next `cargo build` overwrites. Resolved the way Cargo resolves it: the
+/// environment variable against the current directory, a config entry against
+/// the directory holding the `.cargo` that declares it.
+///
+/// `None` means the default, which the basename check already covers.
+fn configured_target_dir(root: &Path) -> Option<PathBuf> {
+    fn canonical(path: PathBuf) -> Option<PathBuf> {
+        std::fs::canonicalize(path).ok()
+    }
+
+    if let Some(configured) = std::env::var_os("CARGO_TARGET_DIR") {
+        let configured = PathBuf::from(configured);
+        return canonical(if configured.is_absolute() {
+            configured
+        } else {
+            std::env::current_dir().ok()?.join(configured)
+        });
+    }
+
+    // Cargo reads `.cargo/config.toml` from the working directory upward, so a
+    // member inherits the workspace root's redirect.
+    let absolute_root = std::fs::canonicalize(root).ok()?;
+    for ancestor in absolute_root.ancestors() {
+        for name in ["config.toml", "config"] {
+            let Ok(content) = std::fs::read_to_string(ancestor.join(".cargo").join(name)) else {
+                continue;
+            };
+            let Ok(table) = toml::from_str::<toml::Table>(&content) else {
+                continue;
+            };
+            let Some(configured) = table
+                .get("build")
+                .and_then(|build| build.get("target-dir"))
+                .and_then(toml::Value::as_str)
+            else {
+                continue;
+            };
+            let configured = PathBuf::from(configured);
+            return canonical(if configured.is_absolute() {
+                configured
+            } else {
+                ancestor.join(configured)
+            });
+        }
+    }
+    None
 }
 
 /// Every `.rs` file under `root` that belongs to the app, in a stable order.
 fn app_sources(root: &Path) -> SourceScan {
     let mut scan = SourceScan::default();
-    collect_sources(root, &mut scan);
+    collect_sources(root, configured_target_dir(root).as_deref(), &mut scan);
     scan.files.sort();
     scan.symlinks.sort();
     scan.unreadable.sort();
@@ -622,7 +690,7 @@ struct SourceScan {
 
 /// Collect `.rs` files, recording what was deliberately or accidentally left
 /// out so the caller can report it rather than drop it silently.
-fn collect_sources(dir: &Path, scan: &mut SourceScan) {
+fn collect_sources(dir: &Path, target_dir: Option<&Path>, scan: &mut SourceScan) {
     let Ok(entries) = std::fs::read_dir(dir) else {
         scan.unreadable.push(dir.to_path_buf());
         return;
@@ -647,10 +715,10 @@ fn collect_sources(dir: &Path, scan: &mut SourceScan) {
         if file_type.is_dir() {
             let is_metadata = SKIPPED_HIDDEN_DIRS.contains(&name.as_str());
             let is_build_output = at_crate_root && SKIPPED_DIRS.contains(&name.as_str());
-            if is_metadata || is_build_output {
+            if is_metadata || is_build_output || is_target_dir(&path, target_dir) {
                 continue;
             }
-            collect_sources(&path, scan);
+            collect_sources(&path, target_dir, scan);
         } else if file_type.is_symlink() {
             // A symlinked *directory* has `is_dir() == false`, so gating this
             // on a `.rs` extension hid a linked `src/` entirely: no traversal,
@@ -902,8 +970,11 @@ pub fn run_in(root: &Path, opts: &UpgradeOptions) -> i32 {
     };
 
     // A path typo must not read as "your app is already migrated" — the same
-    // rule `autumn a11y verify` states for its scan root.
-    if !root.is_dir() {
+    // rule `autumn a11y verify` states for its scan root. Readability, not just
+    // `is_dir`: a directory the process cannot open answers "yes" to `is_dir`,
+    // and the walk would then report the root under `skipped` and exit 0 having
+    // examined no source at all.
+    if std::fs::read_dir(root).is_err() {
         eprintln!(
             "autumn upgrade: `{}` is not a readable directory.",
             root.display()

--- a/autumn-cli/src/upgrade/mod.rs
+++ b/autumn-cli/src/upgrade/mod.rs
@@ -469,24 +469,29 @@ fn recorded_version(root: &Path) -> Option<String> {
 
     let mut lowest: Option<(Version, String)> = None;
     for directory in std::iter::once(root.to_path_buf()).chain(member_manifests(root)) {
-        let requirement = match crate::doctor::read_autumn_web_dependency_at(&directory) {
-            AutumnWebDependency::Absent => continue,
-            // Declared as a path or git dependency: this crate is on *some*
-            // version of autumn-web and the manifest does not say which.
-            // Letting a sibling decide the floor would migrate this crate's
-            // source against a version nobody checked — and a vendored
-            // checkout is exactly the population the 0.6.0 rename affects.
-            AutumnWebDependency::WithoutVersion => return None,
-            AutumnWebDependency::Version(requirement) => requirement,
-        };
-        // A manifest that *declares* `autumn-web` with a requirement carrying no
-        // usable floor makes the whole answer a guess. Dropping it and taking
-        // some other manifest's version would silently skip that member —
-        // exactly what refusing an upper-bound-only requirement was meant to
-        // prevent. Fail detection and let the caller ask for `--from`.
-        let version = migrations::parse_version_req(&requirement)?;
-        if lowest.as_ref().is_none_or(|(lowest, _)| version < *lowest) {
-            lowest = Some((version, requirement));
+        // *Every* declaration in the manifest, not the first: a target-specific
+        // requirement can be older than the package-wide one, and the source
+        // scan rewrites that target's `#[cfg]` code either way.
+        for declaration in crate::doctor::autumn_web_declarations_at(&directory) {
+            let requirement = match declaration {
+                AutumnWebDependency::Absent => continue,
+                // Declared as a path or git dependency: this crate is on *some*
+                // version of autumn-web and the manifest does not say which.
+                // Letting a sibling decide the floor would migrate this crate's
+                // source against a version nobody checked — and a vendored
+                // checkout is exactly the population the 0.6.0 rename affects.
+                AutumnWebDependency::WithoutVersion => return None,
+                AutumnWebDependency::Version(requirement) => requirement,
+            };
+            // A requirement carrying no usable floor makes the whole answer a
+            // guess. Dropping it and taking another declaration's version would
+            // silently skip that crate — exactly what refusing an
+            // upper-bound-only requirement was meant to prevent. Fail detection
+            // and let the caller ask for `--from`.
+            let version = migrations::parse_version_req(&requirement)?;
+            if lowest.as_ref().is_none_or(|(lowest, _)| version < *lowest) {
+                lowest = Some((version, requirement));
+            }
         }
     }
     lowest.map(|(_, requirement)| requirement)

--- a/autumn-cli/src/upgrade/mod.rs
+++ b/autumn-cli/src/upgrade/mod.rs
@@ -35,7 +35,7 @@ pub mod diff;
 pub mod engine;
 pub mod migrations;
 
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 use std::path::{Path, PathBuf};
 
 use migrations::{AppMigration, Version};
@@ -692,23 +692,86 @@ fn configured_target_dirs(root: &Path) -> BTreeSet<PathBuf> {
     // The two settings read here merge differently and must not be pooled:
     // `build.target-dir` is a scalar, so the *nearest* declaration wins and the
     // rest are overridden — unioning them pruned directories that are really
-    // app source. The `[source.*]` tables merge, so every level contributes.
+    // app source. The `[source.*]` tables merge into one table across every
+    // level, so `replace-with` in one file can name a source another defines;
+    // resolving each file alone found neither half.
+    let mut levels: Vec<(PathBuf, PathBuf)> = absolute_root
+        .ancestors()
+        .map(|ancestor| (ancestor.join(".cargo"), ancestor.to_path_buf()))
+        .collect();
+    levels.extend(cargo_home().map(|home| (home.clone(), home)));
+
+    let mut sources = Sources::new();
     let mut nearest_target = None;
-    for ancestor in absolute_root.ancestors() {
-        let (target, vendored) =
-            config_excluded_dirs_in(&ancestor.join(".cargo"), ancestor, target_dir_from_config);
-        nearest_target = nearest_target.or(target);
-        found.extend(vendored);
-    }
-    if let Some(home) = cargo_home() {
-        let (target, vendored) = config_excluded_dirs_in(&home, &home, target_dir_from_config);
-        nearest_target = nearest_target.or(target);
-        found.extend(vendored);
+    // Farthest first, so a nearer level overwrites what it declares and leaves
+    // the rest of the merged table standing.
+    for (config_dir, base) in levels.iter().rev() {
+        let (target, declared) = config_at(config_dir, base, target_dir_from_config);
+        if target.is_some() {
+            nearest_target = target;
+        }
+        merge_sources(&mut sources, declared);
     }
     found.extend(nearest_target);
+    found.extend(active_vendor_dirs(&sources));
 
-    collect_target_dirs(&absolute_root, target_dir_from_config, &mut found);
+    collect_target_dirs(&absolute_root, target_dir_from_config, &sources, &mut found);
     found
+}
+
+/// One `[source.*]` entry: where it points, and what it is replaced with.
+///
+/// `directory` is already resolved against the base of the config that declared
+/// it, because a merged table mixes entries from levels with different bases.
+#[derive(Clone, Default)]
+struct SourceEntry {
+    directory: Option<PathBuf>,
+    replace_with: Option<String>,
+}
+
+type Sources = BTreeMap<String, SourceEntry>;
+
+/// Overlay `nearer` onto `sources`, field by field.
+fn merge_sources(sources: &mut Sources, nearer: Sources) {
+    for (name, entry) in nearer {
+        let merged = sources.entry(name).or_default();
+        if entry.directory.is_some() {
+            merged.directory = entry.directory;
+        }
+        if entry.replace_with.is_some() {
+            merged.replace_with = entry.replace_with;
+        }
+    }
+}
+
+/// The directories of every source that something is actually replaced *with*.
+///
+/// Source replacement is activated by `replace-with`: defining `[source.archive]
+/// directory = "src"` and never replacing anything with it leaves `src` as
+/// ordinary app source. A replacement may itself be replaced, so the chain is
+/// followed to its end.
+fn active_vendor_dirs(sources: &Sources) -> Vec<PathBuf> {
+    let mut active: BTreeSet<&str> = BTreeSet::new();
+    let mut pending: Vec<&str> = sources
+        .values()
+        .filter_map(|entry| entry.replace_with.as_deref())
+        .collect();
+    // `active` doubles as the seen-set, so a config that points two sources at
+    // each other terminates instead of spinning.
+    while let Some(name) = pending.pop() {
+        if !active.insert(name) {
+            continue;
+        }
+        pending.extend(
+            sources
+                .get(name)
+                .and_then(|entry| entry.replace_with.as_deref()),
+        );
+    }
+    active
+        .into_iter()
+        .filter_map(|name| sources.get(name)?.directory.clone())
+        .collect()
 }
 
 /// Cargo's own configuration directory — `$CARGO_HOME`, or `~/.cargo`.
@@ -738,8 +801,19 @@ fn cargo_home() -> Option<PathBuf> {
 /// the walk happens to learn of it first; directory order is not guaranteed.
 /// The source walk excludes it either way, so what is at stake there is the
 /// traversal cost, not whether the directory is migrated.
-fn collect_target_dirs(dir: &Path, target_dir_from_config: bool, found: &mut BTreeSet<PathBuf>) {
-    found.extend(config_excluded_dirs_at(dir, target_dir_from_config));
+fn collect_target_dirs(
+    dir: &Path,
+    target_dir_from_config: bool,
+    inherited: &Sources,
+    found: &mut BTreeSet<PathBuf>,
+) {
+    // A nested crate inherits the hierarchy above it, so its own `replace-with`
+    // may name a source one of those levels defines.
+    let (target, declared) = config_at(&dir.join(".cargo"), dir, target_dir_from_config);
+    found.extend(target);
+    let mut sources = inherited.clone();
+    merge_sources(&mut sources, declared);
+    found.extend(active_vendor_dirs(&sources));
     let Ok(entries) = std::fs::read_dir(dir) else {
         return;
     };
@@ -763,7 +837,7 @@ fn collect_target_dirs(dir: &Path, target_dir_from_config: bool, found: &mut BTr
         if is_target_dir(&path, found) {
             continue;
         }
-        collect_target_dirs(&path, target_dir_from_config, found);
+        collect_target_dirs(&path, target_dir_from_config, inherited, found);
     }
 }
 
@@ -778,34 +852,19 @@ fn resolve_against(base: &Path, path: &str) -> Option<PathBuf> {
     std::fs::canonicalize(absolute).ok()
 }
 
-/// The directories the `.cargo/config.toml` in `dir` itself declares as
-/// generated or third-party: `build.target-dir`, and the `directory` of every
-/// `[source.*]` replacement.
-///
-/// Cargo resolves a relative entry against the directory holding the `.cargo`
-/// that declares it, so that is what these resolve against. `target_dir` is
-/// false when `CARGO_TARGET_DIR` has already decided that question.
-fn config_excluded_dirs_at(dir: &Path, target_dir: bool) -> Vec<PathBuf> {
-    let (target, mut found) = config_excluded_dirs_in(&dir.join(".cargo"), dir, target_dir);
-    found.extend(target);
-    found
-}
-
-/// The `build.target-dir` and the `[source.*]` directories a Cargo config in
+/// The `build.target-dir` and the `[source.*]` entries a Cargo config in
 /// `config_dir` declares, resolved against `base`.
 ///
 /// Cargo resolves a relative entry against the directory holding the config
-/// that declares it, so that is what these resolve against. `target_dir` is
-/// false when `CARGO_TARGET_DIR` has already decided that question.
+/// that declares it, so that is what these resolve against — and why the
+/// resolution happens here rather than after merging, when the base is gone.
+/// `target_dir` is false when `CARGO_TARGET_DIR` has already decided that
+/// question.
 ///
 /// `config` is read before `config.toml`: when a project holds both, Cargo uses
 /// the extensionless name and warns. Reading the other one first meant the
 /// directory Cargo actually builds into was scanned as app source.
-fn config_excluded_dirs_in(
-    config_dir: &Path,
-    base: &Path,
-    target_dir: bool,
-) -> (Option<PathBuf>, Vec<PathBuf>) {
+fn config_at(config_dir: &Path, base: &Path, target_dir: bool) -> (Option<PathBuf>, Sources) {
     for name in ["config", "config.toml"] {
         let Ok(content) = std::fs::read_to_string(config_dir.join(name)) else {
             continue;
@@ -821,45 +880,27 @@ fn config_excluded_dirs_in(
             .and_then(|configured| resolve_against(base, configured));
         // `[source.vendored-sources] directory = "third-party"` — where
         // `cargo vendor <path>` was told to put dependency sources.
-        //
-        // Only sources that are actually *replaced with* count. Defining
-        // `[source.archive] directory = "src"` activates nothing on its own, and
-        // excluding it dropped the whole app from the scan without a word.
-        let mut found = Vec::new();
-        if let Some(sources) = table.get("source").and_then(toml::Value::as_table) {
-            let replacement_of = |name: &str| {
-                sources
-                    .get(name)
-                    .and_then(|source| source.get("replace-with"))
-                    .and_then(toml::Value::as_str)
-            };
-            // A replacement may itself be replaced, so the chain is followed to
-            // its end. `active` doubles as the seen-set, so a config that points
-            // two sources at each other terminates instead of spinning.
-            let mut active: BTreeSet<&str> = BTreeSet::new();
-            let mut pending: Vec<&str> = sources
-                .values()
-                .filter_map(|source| source.get("replace-with").and_then(toml::Value::as_str))
-                .collect();
-            while let Some(name) = pending.pop() {
-                if !active.insert(name) {
-                    continue;
-                }
-                pending.extend(replacement_of(name));
-            }
-            for name in active {
-                if let Some(directory) = sources
-                    .get(name)
-                    .and_then(|source| source.get("directory"))
-                    .and_then(toml::Value::as_str)
-                {
-                    found.extend(resolve_against(base, directory));
-                }
+        let mut sources = Sources::new();
+        if let Some(declared) = table.get("source").and_then(toml::Value::as_table) {
+            for (source_name, source) in declared {
+                sources.insert(
+                    source_name.clone(),
+                    SourceEntry {
+                        directory: source
+                            .get("directory")
+                            .and_then(toml::Value::as_str)
+                            .and_then(|directory| resolve_against(base, directory)),
+                        replace_with: source
+                            .get("replace-with")
+                            .and_then(toml::Value::as_str)
+                            .map(str::to_owned),
+                    },
+                );
             }
         }
-        return (target, found);
+        return (target, sources);
     }
-    (None, Vec::new())
+    (None, Sources::new())
 }
 
 /// Every `.rs` file under `root` that belongs to the app, in a stable order.

--- a/autumn-cli/src/upgrade/mod.rs
+++ b/autumn-cli/src/upgrade/mod.rs
@@ -142,6 +142,8 @@ impl Report {
 /// Directory names never scanned: build output and vendored third-party
 /// sources are not the app's own code, and rewriting them is at best wasted
 /// work and at worst a corrupted dependency.
+/// Skipped only where a crate begins — a directory holding a `Cargo.toml`.
+/// Beneath that, these are ordinary module names.
 const SKIPPED_DIRS: &[&str] = &["target", "vendor", "node_modules", "dist", "tmp"];
 
 /// Render the human-readable report.
@@ -557,7 +559,8 @@ fn app_sources(root: &Path) -> SourceScan {
 struct SourceScan {
     /// Regular `.rs` files to migrate.
     files: Vec<PathBuf>,
-    /// Symlinked `.rs` files, reported rather than followed.
+    /// Symlinked `.rs` files and symlinked directories, reported rather than
+    /// followed.
     symlinks: Vec<PathBuf>,
     /// Directories the walk could not read.
     unreadable: Vec<PathBuf>,
@@ -570,28 +573,40 @@ fn collect_sources(dir: &Path, scan: &mut SourceScan) {
         scan.unreadable.push(dir.to_path_buf());
         return;
     };
+    // `target/`, `vendor/` and friends name build output or third-party code
+    // only where a crate begins. Matching the basename at *any* depth silently
+    // dropped ordinary modules like `src/vendor/mod.rs` — the app then fails to
+    // compile after the bump with nothing in the report to explain why.
+    let at_crate_root = dir.join("Cargo.toml").is_file();
+
     for entry in entries.flatten() {
         // `file_type` does not follow symlinks, so a link into `target/`, a
         // link out of the project, or a cycle is neither descended into nor
-        // rewritten. A linked `.rs` file is still *reported*: quietly leaving a
-        // source file out of the migration is the failure mode this command
-        // exists to remove.
+        // rewritten. Links are still *reported*: quietly leaving source out of
+        // the migration is the failure mode this command exists to remove.
         let Ok(file_type) = entry.file_type() else {
             continue;
         };
         let path = entry.path();
         let name = entry.file_name().to_string_lossy().into_owned();
+
         if file_type.is_dir() {
-            if name.starts_with('.') || SKIPPED_DIRS.contains(&name.as_str()) {
+            if name.starts_with('.') || (at_crate_root && SKIPPED_DIRS.contains(&name.as_str())) {
                 continue;
             }
             collect_sources(&path, scan);
-        } else if path.extension().is_some_and(|ext| ext == "rs") {
-            if file_type.is_file() {
-                scan.files.push(path);
-            } else if file_type.is_symlink() {
+        } else if file_type.is_symlink() {
+            // A symlinked *directory* has `is_dir() == false`, so gating this
+            // on a `.rs` extension hid a linked `src/` entirely: no traversal,
+            // no report, and a run that says "nothing to change" about an app
+            // it never looked at.
+            let links_to_directory =
+                std::fs::metadata(&path).is_ok_and(|metadata| metadata.is_dir());
+            if links_to_directory || path.extension().is_some_and(|ext| ext == "rs") {
                 scan.symlinks.push(path);
             }
+        } else if file_type.is_file() && path.extension().is_some_and(|ext| ext == "rs") {
+            scan.files.push(path);
         }
     }
 }

--- a/autumn-cli/src/upgrade/mod.rs
+++ b/autumn-cli/src/upgrade/mod.rs
@@ -921,7 +921,8 @@ fn file_module_path(path: &Path) -> Vec<String> {
 
 /// Build the report for `root` without writing anything.
 fn plan(root: &Path, from: Version, to: Version) -> Report {
-    plan_with(root, from, to, &migrations::migrations_between(from, to))
+    let selected = migrations::migrations_between(&from, &to);
+    plan_with(root, from, to, &selected)
 }
 
 /// [`plan`] over an explicit migration selection.

--- a/autumn-cli/src/upgrade/mod.rs
+++ b/autumn-cli/src/upgrade/mod.rs
@@ -744,6 +744,15 @@ fn merge_sources(sources: &mut Sources, nearer: Sources) {
     }
 }
 
+/// Whether Cargo would consult this source without something pointing at it.
+///
+/// The default registry, and the URL-keyed entries `cargo vendor` writes for
+/// git and alternative-registry dependencies. A plain name like `vendored` is a
+/// local alias: real until something is replaced *with* it, inert otherwise.
+fn is_consulted_source(name: &str) -> bool {
+    name == "crates-io" || name.contains("://")
+}
+
 /// The directories of every source that something is actually replaced *with*.
 ///
 /// Source replacement is activated by `replace-with`: defining `[source.archive]
@@ -752,9 +761,14 @@ fn merge_sources(sources: &mut Sources, nearer: Sources) {
 /// followed to its end.
 fn active_vendor_dirs(sources: &Sources) -> Vec<PathBuf> {
     let mut active: BTreeSet<&str> = BTreeSet::new();
+    // Reachability starts at the sources Cargo actually consults, not at every
+    // declared edge: `[source.unused] replace-with = "vendored"` that nothing
+    // references activates nothing, and treating it as active excluded whatever
+    // `vendored` pointed at — the app's own `src/`, in the reported case.
     let mut pending: Vec<&str> = sources
-        .values()
-        .filter_map(|entry| entry.replace_with.as_deref())
+        .iter()
+        .filter(|(name, _)| is_consulted_source(name))
+        .filter_map(|(_, entry)| entry.replace_with.as_deref())
         .collect();
     // `active` doubles as the seen-set, so a config that points two sources at
     // each other terminates instead of spinning.
@@ -837,7 +851,7 @@ fn collect_target_dirs(
         if is_target_dir(&path, found) {
             continue;
         }
-        collect_target_dirs(&path, target_dir_from_config, inherited, found);
+        collect_target_dirs(&path, target_dir_from_config, &sources, found);
     }
 }
 

--- a/autumn-cli/src/upgrade/mod.rs
+++ b/autumn-cli/src/upgrade/mod.rs
@@ -665,6 +665,19 @@ fn configured_target_dirs(root: &Path) -> BTreeSet<PathBuf> {
     found
 }
 
+/// Walk `dir` for `.cargo/config.toml` redirects, adding each to `found`.
+///
+/// Directories already known to be build output are not descended into. That
+/// is partly cost — a populated target tree holds tens of thousands of
+/// directories, and this walk runs on every invocation — and partly
+/// correctness: a `.cargo/config.toml` that got copied or generated inside
+/// build output is not this project's configuration, and honouring it can
+/// exclude real source.
+///
+/// A redirect that points *outside* the crate declaring it is only pruned if
+/// the walk happens to learn of it first; directory order is not guaranteed.
+/// The source walk excludes it either way, so what is at stake there is the
+/// traversal cost, not whether the directory is migrated.
 fn collect_target_dirs(dir: &Path, found: &mut BTreeSet<PathBuf>) {
     found.extend(config_target_dir_at(dir));
     let Ok(entries) = std::fs::read_dir(dir) else {
@@ -686,7 +699,11 @@ fn collect_target_dirs(dir: &Path, found: &mut BTreeSet<PathBuf>) {
         {
             continue;
         }
-        collect_target_dirs(&entry.path(), found);
+        let path = entry.path();
+        if is_target_dir(&path, found) {
+            continue;
+        }
+        collect_target_dirs(&path, found);
     }
 }
 

--- a/autumn-cli/src/upgrade/mod.rs
+++ b/autumn-cli/src/upgrade/mod.rs
@@ -447,14 +447,22 @@ fn recorded_version(root: &Path) -> Option<String> {
     // root would let a workspace whose root records 0.6.0 hide a member that
     // still pins 0.5.0 — the walk then migrates that member's source with no
     // 0.5.0 -> 0.6.0 migration selected.
-    std::iter::once(root.to_path_buf())
-        .chain(member_manifests(root))
-        .filter_map(|directory| crate::doctor::read_autumn_web_version_at(&directory))
-        .filter_map(|requirement| {
-            migrations::parse_version_req(&requirement).map(|version| (version, requirement))
-        })
-        .min_by_key(|(version, _)| *version)
-        .map(|(_, requirement)| requirement)
+    let mut lowest: Option<(Version, String)> = None;
+    for directory in std::iter::once(root.to_path_buf()).chain(member_manifests(root)) {
+        let Some(requirement) = crate::doctor::read_autumn_web_version_at(&directory) else {
+            continue;
+        };
+        // A manifest that *declares* `autumn-web` with a requirement carrying no
+        // usable floor makes the whole answer a guess. Dropping it and taking
+        // some other manifest's version would silently skip that member —
+        // exactly what refusing an upper-bound-only requirement was meant to
+        // prevent. Fail detection and let the caller ask for `--from`.
+        let version = migrations::parse_version_req(&requirement)?;
+        if lowest.as_ref().is_none_or(|(lowest, _)| version < *lowest) {
+            lowest = Some((version, requirement));
+        }
+    }
+    lowest.map(|(_, requirement)| requirement)
 }
 
 /// Directories under `root` (excluding `root` itself) that hold a `Cargo.toml`.

--- a/autumn-cli/src/upgrade/mod.rs
+++ b/autumn-cli/src/upgrade/mod.rs
@@ -537,12 +537,17 @@ fn recorded_version(root: &Path) -> Option<String> {
             };
             let requirement = match declaration {
                 AutumnWebDependency::Absent | AutumnWebDependency::Inherited(_) => continue,
-                // Declared as a path or git dependency: this crate is on *some*
-                // version of autumn-web and the manifest does not say which.
-                // Letting a sibling decide the floor would migrate this crate's
-                // source against a version nobody checked — and a vendored
-                // checkout is exactly the population the 0.6.0 rename affects.
-                AutumnWebDependency::WithoutVersion => return None,
+                // Two ways to know a crate's version is unknown rather than
+                // absent: a path or git dependency, which says this crate is on
+                // *some* version without saying which; and a manifest that
+                // exists but cannot be read or parsed, which says nothing at
+                // all. Letting a sibling decide the floor in either case would
+                // migrate this crate's source against a version nobody checked
+                // — and a vendored checkout is exactly the population the 0.6.0
+                // rename affects.
+                AutumnWebDependency::WithoutVersion | AutumnWebDependency::Unreadable => {
+                    return None;
+                }
                 AutumnWebDependency::Version(requirement) => requirement,
             };
             // A requirement carrying no usable floor makes the whole answer a

--- a/autumn-cli/src/upgrade/mod.rs
+++ b/autumn-cli/src/upgrade/mod.rs
@@ -146,6 +146,18 @@ impl Report {
 /// Beneath that, these are ordinary module names.
 const SKIPPED_DIRS: &[&str] = &["target", "vendor", "node_modules", "dist", "tmp"];
 
+/// Hidden directories that hold tool or VCS metadata rather than app code.
+///
+/// Skipping *every* dot-directory dropped source an app really compiles —
+/// `#[path = ".generated/repositories.rs"] mod repositories;` is legal, and the
+/// files behind it kept the old API with nothing in the report to say so. These
+/// names are skipped by name instead, and any other hidden directory is
+/// scanned like a normal one.
+const SKIPPED_HIDDEN_DIRS: &[&str] = &[
+    ".git", ".github", ".gitlab", ".hg", ".svn", ".cargo", ".vscode", ".idea", ".direnv", ".venv",
+    ".tox", ".claude",
+];
+
 /// Render the human-readable report.
 pub fn render_text(report: &Report) -> String {
     use std::fmt::Write as _;
@@ -612,7 +624,9 @@ fn collect_sources(dir: &Path, scan: &mut SourceScan) {
         let name = entry.file_name().to_string_lossy().into_owned();
 
         if file_type.is_dir() {
-            if name.starts_with('.') || (at_crate_root && SKIPPED_DIRS.contains(&name.as_str())) {
+            let is_metadata = SKIPPED_HIDDEN_DIRS.contains(&name.as_str());
+            let is_build_output = at_crate_root && SKIPPED_DIRS.contains(&name.as_str());
+            if is_metadata || is_build_output {
                 continue;
             }
             collect_sources(&path, scan);

--- a/autumn-cli/src/upgrade/mod.rs
+++ b/autumn-cli/src/upgrade/mod.rs
@@ -481,22 +481,29 @@ fn recorded_version(root: &Path) -> Option<String> {
     // 0.5.0 -> 0.6.0 migration selected.
     use crate::doctor::AutumnWebDependency;
 
-    // `{ workspace = true }` resolves against the enclosing workspace, and that
-    // manifest is *above* the scan when the command is pointed at a member
-    // directory. Cargo walks up to find it; not doing so aborted a member with
-    // "cannot tell which version" over a version Cargo resolves fine.
-    // Canonicalised first: the scan root is usually the relative `.`, and
-    // `Path::new(".").ancestors()` yields only `.` — the walk upward would
-    // never leave the member directory it was pointed at.
-    let absolute_root = std::fs::canonicalize(root).unwrap_or_else(|_| root.to_path_buf());
+    // `{ workspace = true }` resolves against the enclosing workspace, and Cargo
+    // finds that manifest by walking *up from the crate that inherits*. Not
+    // doing so aborted a member with "cannot tell which version" over a version
+    // Cargo resolves fine.
+    //
+    // Up from the crate, not up from the scan root: a whole workspace can sit
+    // inside the scanned tree, and then the entry its members inherit lives
+    // between them and the root. Searching the root's ancestors misses it, and
+    // an unresolved literal `autumn-web` reads as a declaration with no version
+    // — which fails detection for the entire run, not just that member.
+    //
     // By the member's own key, not by the crate name: `autumn = { workspace =
     // true }` paired with a renamed workspace entry is the shape where nothing
     // on the member side mentions `autumn-web` at all.
-    let inherited = |key: &str| {
-        absolute_root
+    fn inherited(from: &Path, key: &str) -> Option<AutumnWebDependency> {
+        // Canonicalised first: the scan root is usually the relative `.`, and
+        // `Path::new(".").ancestors()` yields only `.` — the walk upward would
+        // never leave the directory it started in.
+        let absolute = std::fs::canonicalize(from).unwrap_or_else(|_| from.to_path_buf());
+        absolute
             .ancestors()
             .find_map(|ancestor| crate::doctor::workspace_dependency_for(ancestor, key))
-    };
+    }
 
     let mut lowest: Option<(Version, String)> = None;
     for directory in std::iter::once(root.to_path_buf()).chain(member_manifests(root)) {
@@ -515,7 +522,7 @@ fn recorded_version(root: &Path) -> Option<String> {
                 // true }` entry is collected because the member side cannot
                 // tell them apart, and this is where the ones that are not
                 // autumn-web drop out.
-                AutumnWebDependency::Inherited(key) => match inherited(&key) {
+                AutumnWebDependency::Inherited(key) => match inherited(&directory, &key) {
                     Some(resolved) => resolved,
                     None if key == "autumn-web" => AutumnWebDependency::WithoutVersion,
                     None => continue,

--- a/autumn-cli/src/upgrade/mod.rs
+++ b/autumn-cli/src/upgrade/mod.rs
@@ -671,10 +671,17 @@ fn collect_manifests(
 /// `CARGO_TARGET_DIR` overrides every config file's `target-dir`, but has no
 /// equivalent for vendoring, so the config walk runs either way.
 fn configured_target_dirs(root: &Path) -> BTreeSet<PathBuf> {
-    let forced_target_dir = std::env::var_os("CARGO_TARGET_DIR").and_then(|configured| {
-        let cwd = std::env::current_dir().ok()?;
-        resolve_against(&cwd, &configured.to_string_lossy())
-    });
+    // `CARGO_TARGET_DIR` is the dedicated variable; `CARGO_BUILD_TARGET_DIR` is
+    // the generic `CARGO_BUILD_<key>` form Cargo documents for `build.target-dir`.
+    // Either one overrides every config file, so both are read here.
+    let forced_target_dir = ["CARGO_TARGET_DIR", "CARGO_BUILD_TARGET_DIR"]
+        .into_iter()
+        .filter_map(std::env::var_os)
+        .find(|configured| !configured.is_empty())
+        .and_then(|configured| {
+            let cwd = std::env::current_dir().ok()?;
+            resolve_against(&cwd, &configured.to_string_lossy())
+        });
     let target_dir_from_config = forced_target_dir.is_none();
 
     let mut found = BTreeSet::new();
@@ -814,10 +821,38 @@ fn config_excluded_dirs_in(
             .and_then(|configured| resolve_against(base, configured));
         // `[source.vendored-sources] directory = "third-party"` — where
         // `cargo vendor <path>` was told to put dependency sources.
+        //
+        // Only sources that are actually *replaced with* count. Defining
+        // `[source.archive] directory = "src"` activates nothing on its own, and
+        // excluding it dropped the whole app from the scan without a word.
         let mut found = Vec::new();
         if let Some(sources) = table.get("source").and_then(toml::Value::as_table) {
-            for source in sources.values() {
-                if let Some(directory) = source.get("directory").and_then(toml::Value::as_str) {
+            let replacement_of = |name: &str| {
+                sources
+                    .get(name)
+                    .and_then(|source| source.get("replace-with"))
+                    .and_then(toml::Value::as_str)
+            };
+            // A replacement may itself be replaced, so the chain is followed to
+            // its end. `active` doubles as the seen-set, so a config that points
+            // two sources at each other terminates instead of spinning.
+            let mut active: BTreeSet<&str> = BTreeSet::new();
+            let mut pending: Vec<&str> = sources
+                .values()
+                .filter_map(|source| source.get("replace-with").and_then(toml::Value::as_str))
+                .collect();
+            while let Some(name) = pending.pop() {
+                if !active.insert(name) {
+                    continue;
+                }
+                pending.extend(replacement_of(name));
+            }
+            for name in active {
+                if let Some(directory) = sources
+                    .get(name)
+                    .and_then(|source| source.get("directory"))
+                    .and_then(toml::Value::as_str)
+                {
                     found.extend(resolve_against(base, directory));
                 }
             }

--- a/autumn-cli/src/upgrade/mod.rs
+++ b/autumn-cli/src/upgrade/mod.rs
@@ -35,6 +35,7 @@ pub mod diff;
 pub mod engine;
 pub mod migrations;
 
+use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
 
 use migrations::{AppMigration, Version};
@@ -81,6 +82,9 @@ pub struct FileReport {
     pub diff: String,
     /// The full rewritten text (not serialized; used by the apply step).
     pub updated: String,
+    /// The text this rewrite was computed from, kept so the apply step can
+    /// prove the file has not changed underneath it.
+    pub original: String,
     /// Absolute path to write to.
     pub absolute: PathBuf,
 }
@@ -572,12 +576,7 @@ fn recorded_version(root: &Path) -> Option<String> {
 /// and both are visible in the report.
 fn member_manifests(root: &Path) -> Vec<PathBuf> {
     let mut found = Vec::new();
-    let (forced, target_dir) = root_target_dir(root);
-    let target_dir = TargetDir {
-        forced,
-        path: target_dir.as_deref(),
-    };
-    collect_manifests(root, root, target_dir, &mut found);
+    collect_manifests(root, root, &configured_target_dirs(root), &mut found);
     found.sort();
     found
 }
@@ -586,13 +585,17 @@ fn member_manifests(root: &Path) -> Vec<PathBuf> {
 ///
 /// By resolved path, not by name: with the target directory redirected to
 /// `out/`, an unrelated `src/out/mod.rs` is ordinary app code.
-fn is_target_dir(path: &Path, target_dir: Option<&Path>) -> bool {
-    target_dir.is_some_and(|target_dir| {
-        std::fs::canonicalize(path).is_ok_and(|resolved| resolved == target_dir)
-    })
+fn is_target_dir(path: &Path, target_dirs: &BTreeSet<PathBuf>) -> bool {
+    !target_dirs.is_empty()
+        && std::fs::canonicalize(path).is_ok_and(|resolved| target_dirs.contains(&resolved))
 }
 
-fn collect_manifests(root: &Path, dir: &Path, target_dir: TargetDir<'_>, found: &mut Vec<PathBuf>) {
+fn collect_manifests(
+    root: &Path,
+    dir: &Path,
+    target_dirs: &BTreeSet<PathBuf>,
+    found: &mut Vec<PathBuf>,
+) {
     let Ok(entries) = std::fs::read_dir(dir) else {
         return;
     };
@@ -612,60 +615,73 @@ fn collect_manifests(root: &Path, dir: &Path, target_dir: TargetDir<'_>, found: 
         let is_metadata = SKIPPED_HIDDEN_DIRS.contains(&name.as_str());
         let is_build_output = at_crate_root && SKIPPED_DIRS.contains(&name.as_str());
         let path = entry.path();
-        if is_metadata || is_build_output || is_target_dir(&path, target_dir.path) {
+        if is_metadata || is_build_output || is_target_dir(&path, target_dirs) {
             continue;
         }
         if path.join("Cargo.toml").is_file() && path != root {
             found.push(path.clone());
         }
-        let nested = target_dir.nested_at(&path);
-        collect_manifests(root, &path, target_dir.or_inherited(nested.as_ref()), found);
+        collect_manifests(root, &path, target_dirs, found);
     }
 }
 
-/// Where Cargo's build output lands for the directory currently being walked.
+/// Every directory Cargo has been told to put build output in, anywhere in the
+/// scan.
 ///
 /// `CARGO_TARGET_DIR` and `.cargo/config.toml`'s `build.target-dir` both move
 /// output somewhere the `target` basename check will never look, and the walk
 /// then descends into generated code — `--apply` rewriting artifacts the next
 /// `cargo build` overwrites.
 ///
-/// It is a walk-time value rather than one path for the whole scan because
-/// Cargo reads `.cargo/config.toml` from the invocation directory upward: a
-/// nested standalone crate redirects its *own* output, and a redirect declared
-/// there applies to that subtree only. The environment variable is the one
-/// exception — it overrides every config file, so when it is set no nested
-/// config is consulted at all.
-#[derive(Clone, Copy, Default)]
-struct TargetDir<'a> {
-    /// `CARGO_TARGET_DIR` decided this, so nested configs are not in effect.
-    forced: bool,
-    /// The resolved output directory, or `None` for the default `target/`,
-    /// which the basename check already covers.
-    path: Option<&'a Path>,
-}
-
-impl TargetDir<'_> {
-    /// What applies inside `dir`, given what applies to its parent.
-    ///
-    /// Returns the nested override so the caller can own it for the length of
-    /// the recursive call; `None` means `dir` inherits.
-    fn nested_at(self, dir: &Path) -> Option<PathBuf> {
-        if self.forced {
-            return None;
-        }
-        config_target_dir_at(dir)
+/// Collected as a set over the whole tree rather than inherited downward,
+/// because a configured path need not sit under the crate that declares it:
+/// `tools/helper/.cargo/config.toml` may say `target-dir = "../../build"`, and
+/// that directory is reached by a different branch of the walk entirely.
+///
+/// `CARGO_TARGET_DIR` overrides every config file, so when it is set it is the
+/// only answer.
+fn configured_target_dirs(root: &Path) -> BTreeSet<PathBuf> {
+    if let Some(configured) = std::env::var_os("CARGO_TARGET_DIR") {
+        return std::env::current_dir()
+            .ok()
+            .and_then(|cwd| resolve_against(&cwd, &configured.to_string_lossy()))
+            .into_iter()
+            .collect();
     }
 
-    /// The same value with `nested` substituted when there is one.
-    fn or_inherited<'n>(self, nested: Option<&'n PathBuf>) -> TargetDir<'n>
-    where
-        Self: 'n,
-    {
-        TargetDir {
-            forced: self.forced,
-            path: nested.map(PathBuf::as_path).or(self.path),
+    let mut found = BTreeSet::new();
+    // Cargo reads `.cargo/config.toml` from the invocation directory upward, so
+    // a redirect above the scan root applies to everything inside it.
+    let absolute_root = std::fs::canonicalize(root).unwrap_or_else(|_| root.to_path_buf());
+    for ancestor in absolute_root.ancestors() {
+        found.extend(config_target_dir_at(ancestor));
+    }
+    collect_target_dirs(&absolute_root, &mut found);
+    found
+}
+
+fn collect_target_dirs(dir: &Path, found: &mut BTreeSet<PathBuf>) {
+    found.extend(config_target_dir_at(dir));
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    let at_crate_root = dir.join("Cargo.toml").is_file();
+    for entry in entries.flatten() {
+        let Ok(file_type) = entry.file_type() else {
+            continue;
+        };
+        if !file_type.is_dir() {
+            continue;
         }
+        let name = entry.file_name().to_string_lossy().into_owned();
+        // The same pruning the source walk uses: a `.cargo` inside a vendored
+        // tree is not this project's configuration.
+        if SKIPPED_HIDDEN_DIRS.contains(&name.as_str())
+            || (at_crate_root && SKIPPED_DIRS.contains(&name.as_str()))
+        {
+            continue;
+        }
+        collect_target_dirs(&entry.path(), found);
     }
 }
 
@@ -707,34 +723,10 @@ fn config_target_dir_at(dir: &Path) -> Option<PathBuf> {
     None
 }
 
-/// What applies at the scan root, before the walk starts.
-///
-/// The environment variable resolves against the current directory, the way
-/// Cargo resolves it. Failing that, `.cargo/config.toml` is searched from the
-/// root *upward*, so a member inherits the workspace root's redirect.
-fn root_target_dir(root: &Path) -> (bool, Option<PathBuf>) {
-    if let Some(configured) = std::env::var_os("CARGO_TARGET_DIR") {
-        let resolved = std::env::current_dir()
-            .ok()
-            .and_then(|cwd| resolve_against(&cwd, &configured.to_string_lossy()));
-        return (true, resolved);
-    }
-    let Ok(absolute_root) = std::fs::canonicalize(root) else {
-        return (false, None);
-    };
-    let found = absolute_root.ancestors().find_map(config_target_dir_at);
-    (false, found)
-}
-
 /// Every `.rs` file under `root` that belongs to the app, in a stable order.
 fn app_sources(root: &Path) -> SourceScan {
     let mut scan = SourceScan::default();
-    let (forced, target_dir) = root_target_dir(root);
-    let target_dir = TargetDir {
-        forced,
-        path: target_dir.as_deref(),
-    };
-    collect_sources(root, target_dir, &mut scan);
+    collect_sources(root, &configured_target_dirs(root), &mut scan);
     scan.files.sort();
     scan.symlinks.sort();
     scan.unreadable.sort();
@@ -755,7 +747,7 @@ struct SourceScan {
 
 /// Collect `.rs` files, recording what was deliberately or accidentally left
 /// out so the caller can report it rather than drop it silently.
-fn collect_sources(dir: &Path, target_dir: TargetDir<'_>, scan: &mut SourceScan) {
+fn collect_sources(dir: &Path, target_dirs: &BTreeSet<PathBuf>, scan: &mut SourceScan) {
     let Ok(entries) = std::fs::read_dir(dir) else {
         scan.unreadable.push(dir.to_path_buf());
         return;
@@ -780,11 +772,10 @@ fn collect_sources(dir: &Path, target_dir: TargetDir<'_>, scan: &mut SourceScan)
         if file_type.is_dir() {
             let is_metadata = SKIPPED_HIDDEN_DIRS.contains(&name.as_str());
             let is_build_output = at_crate_root && SKIPPED_DIRS.contains(&name.as_str());
-            if is_metadata || is_build_output || is_target_dir(&path, target_dir.path) {
+            if is_metadata || is_build_output || is_target_dir(&path, target_dirs) {
                 continue;
             }
-            let nested = target_dir.nested_at(&path);
-            collect_sources(&path, target_dir.or_inherited(nested.as_ref()), scan);
+            collect_sources(&path, target_dirs, scan);
         } else if file_type.is_symlink() {
             // A symlinked *directory* has `is_dir() == false`, so gating this
             // on a `.rs` extension hid a linked `src/` entirely: no traversal,
@@ -838,8 +829,20 @@ fn generated_receivers(files: &[PathBuf]) -> engine::GeneratedRepositories {
     generated.note_handwritten(
         files
             .iter()
-            .filter_map(|path| std::fs::read_to_string(path).ok())
-            .flat_map(|source| engine::defined_type_names(&source)),
+            .filter_map(|path| {
+                let source = std::fs::read_to_string(path).ok()?;
+                let prefix = file_module_path(path);
+                Some(
+                    engine::defined_type_names(&source)
+                        .into_iter()
+                        .map(move |(name, inner)| {
+                            let mut module = prefix.clone();
+                            module.extend(inner);
+                            (name, module)
+                        }),
+                )
+            })
+            .flatten(),
     );
     generated
 }
@@ -994,6 +997,7 @@ fn plan_with(
                 sites: rewrite.rewritten,
                 diff: diff::render(&source, &updated),
                 updated,
+                original: source,
                 absolute: path,
             });
         }
@@ -1051,9 +1055,67 @@ fn write_one(file: &FileReport) -> std::io::Result<()> {
     if let Ok(metadata) = std::fs::metadata(&file.absolute) {
         let _ = temp.as_file().set_permissions(metadata.permissions());
     }
+    // Planning reads every file before anything is written, so a formatter, a
+    // generator, or the user's editor can change one inside that window. The
+    // rewrite was computed from a snapshot; writing it now would silently
+    // revert whatever landed since. Re-read and compare first, and skip the
+    // file rather than take the newer content away.
+    match std::fs::read_to_string(&file.absolute) {
+        Ok(current) if current == file.original => {}
+        Ok(_) => {
+            return Err(std::io::Error::other(
+                "file changed on disk after it was planned - re-run `autumn upgrade` to \
+                 migrate it against its current contents",
+            ));
+        }
+        Err(error) => return Err(error),
+    }
     temp.persist(&file.absolute)
         .map_err(|error| std::io::Error::other(error.to_string()))?;
     Ok(())
+}
+
+#[cfg(test)]
+mod write_guard_tests {
+    use super::*;
+
+    #[test]
+    fn a_file_changed_after_planning_is_not_overwritten() {
+        // Planning reads every file before anything is written. A formatter or
+        // an editor saving inside that window would otherwise have its work
+        // silently replaced by the rewrite of a stale snapshot.
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let path = tmp.path().join("main.rs");
+        std::fs::write(&path, "fn main() {}\n").expect("write");
+
+        let planned = FileReport {
+            path: "main.rs".to_owned(),
+            sites: Vec::new(),
+            diff: String::new(),
+            updated: "fn main() { /* rewritten */ }\n".to_owned(),
+            original: "fn main() {}\n".to_owned(),
+            absolute: path.clone(),
+        };
+        // Unchanged: the write lands.
+        write_one(&planned).expect("an untouched file is written");
+        assert_eq!(
+            std::fs::read_to_string(&path).expect("read"),
+            planned.updated
+        );
+
+        // Changed underneath the plan: refused, and what is on disk survives.
+        std::fs::write(&path, "fn main() { /* someone else */ }\n").expect("write");
+        let error = write_one(&planned).expect_err("a changed file must not be overwritten");
+        assert!(
+            error.to_string().contains("changed on disk"),
+            "the reason names the cause: {error}"
+        );
+        assert_eq!(
+            std::fs::read_to_string(&path).expect("read"),
+            "fn main() { /* someone else */ }\n",
+            "the newer contents are left alone"
+        );
+    }
 }
 
 /// Run `autumn upgrade` against `root`, returning the process exit code.
@@ -1213,6 +1275,7 @@ mod tests {
                 }],
                 diff: "@@ line 12 @@\n-a\n+b\n".into(),
                 updated: "b\n".into(),
+                original: "a\n".into(),
                 absolute: PathBuf::from("/tmp/app/src/main.rs"),
             }],
             review: Vec::new(),
@@ -1429,6 +1492,7 @@ mod tests {
             ],
             diff: "@@ line 4 @@\n-a\n+b\n".into(),
             updated: "b\n".into(),
+            original: "a\n".into(),
             absolute: PathBuf::from("/tmp/app/src/second.rs"),
         });
         report.outcome = Outcome::Partial { written: 1 };

--- a/autumn-cli/src/upgrade/mod.rs
+++ b/autumn-cli/src/upgrade/mod.rs
@@ -679,14 +679,43 @@ fn configured_target_dirs(root: &Path) -> BTreeSet<PathBuf> {
 
     let mut found = BTreeSet::new();
     found.extend(forced_target_dir);
-    // Cargo reads `.cargo/config.toml` from the invocation directory upward, so
-    // a redirect above the scan root applies to everything inside it.
     let absolute_root = std::fs::canonicalize(root).unwrap_or_else(|_| root.to_path_buf());
+
+    // Cargo's hierarchy is the invocation directory upward, then Cargo home.
+    // The two settings read here merge differently and must not be pooled:
+    // `build.target-dir` is a scalar, so the *nearest* declaration wins and the
+    // rest are overridden — unioning them pruned directories that are really
+    // app source. The `[source.*]` tables merge, so every level contributes.
+    let mut nearest_target = None;
     for ancestor in absolute_root.ancestors() {
-        found.extend(config_excluded_dirs_at(ancestor, target_dir_from_config));
+        let (target, vendored) =
+            config_excluded_dirs_in(&ancestor.join(".cargo"), ancestor, target_dir_from_config);
+        nearest_target = nearest_target.or(target);
+        found.extend(vendored);
     }
+    if let Some(home) = cargo_home() {
+        let (target, vendored) = config_excluded_dirs_in(&home, &home, target_dir_from_config);
+        nearest_target = nearest_target.or(target);
+        found.extend(vendored);
+    }
+    found.extend(nearest_target);
+
     collect_target_dirs(&absolute_root, target_dir_from_config, &mut found);
     found
+}
+
+/// Cargo's own configuration directory — `$CARGO_HOME`, or `~/.cargo`.
+///
+/// The last level of the hierarchy, and the one with no `.cargo` component:
+/// the file is `$CARGO_HOME/config.toml`, not `$CARGO_HOME/.cargo/config.toml`.
+fn cargo_home() -> Option<PathBuf> {
+    if let Some(configured) = std::env::var_os("CARGO_HOME") {
+        let path = PathBuf::from(configured);
+        if !path.as_os_str().is_empty() {
+            return Some(path);
+        }
+    }
+    Some(directories::BaseDirs::new()?.home_dir().join(".cargo"))
 }
 
 /// Walk `dir` for `.cargo/config.toml` redirects, adding each to `found`.
@@ -750,38 +779,52 @@ fn resolve_against(base: &Path, path: &str) -> Option<PathBuf> {
 /// that declares it, so that is what these resolve against. `target_dir` is
 /// false when `CARGO_TARGET_DIR` has already decided that question.
 fn config_excluded_dirs_at(dir: &Path, target_dir: bool) -> Vec<PathBuf> {
-    let config_dir = dir.join(".cargo");
-    if !config_dir.is_dir() {
-        return Vec::new();
-    }
-    for name in ["config.toml", "config"] {
+    let (target, mut found) = config_excluded_dirs_in(&dir.join(".cargo"), dir, target_dir);
+    found.extend(target);
+    found
+}
+
+/// The `build.target-dir` and the `[source.*]` directories a Cargo config in
+/// `config_dir` declares, resolved against `base`.
+///
+/// Cargo resolves a relative entry against the directory holding the config
+/// that declares it, so that is what these resolve against. `target_dir` is
+/// false when `CARGO_TARGET_DIR` has already decided that question.
+///
+/// `config` is read before `config.toml`: when a project holds both, Cargo uses
+/// the extensionless name and warns. Reading the other one first meant the
+/// directory Cargo actually builds into was scanned as app source.
+fn config_excluded_dirs_in(
+    config_dir: &Path,
+    base: &Path,
+    target_dir: bool,
+) -> (Option<PathBuf>, Vec<PathBuf>) {
+    for name in ["config", "config.toml"] {
         let Ok(content) = std::fs::read_to_string(config_dir.join(name)) else {
             continue;
         };
         let Ok(table) = toml::from_str::<toml::Table>(&content) else {
             continue;
         };
-        let mut found = Vec::new();
-        if target_dir
-            && let Some(configured) = table
-                .get("build")
-                .and_then(|build| build.get("target-dir"))
-                .and_then(toml::Value::as_str)
-        {
-            found.extend(resolve_against(dir, configured));
-        }
+        let target = table
+            .get("build")
+            .and_then(|build| build.get("target-dir"))
+            .and_then(toml::Value::as_str)
+            .filter(|_| target_dir)
+            .and_then(|configured| resolve_against(base, configured));
         // `[source.vendored-sources] directory = "third-party"` — where
         // `cargo vendor <path>` was told to put dependency sources.
+        let mut found = Vec::new();
         if let Some(sources) = table.get("source").and_then(toml::Value::as_table) {
             for source in sources.values() {
                 if let Some(directory) = source.get("directory").and_then(toml::Value::as_str) {
-                    found.extend(resolve_against(dir, directory));
+                    found.extend(resolve_against(base, directory));
                 }
             }
         }
-        return found;
+        return (target, found);
     }
-    Vec::new()
+    (None, Vec::new())
 }
 
 /// Every `.rs` file under `root` that belongs to the app, in a stable order.

--- a/autumn-cli/src/upgrade/mod.rs
+++ b/autumn-cli/src/upgrade/mod.rs
@@ -85,13 +85,44 @@ pub struct FileReport {
     pub absolute: PathBuf,
 }
 
+/// What became of the planned rewrites.
+///
+/// A partial apply is its own state rather than a `false`: reporting "nothing
+/// was written" after some files were already rewritten is the one message
+/// that could send someone looking in the wrong place.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Outcome {
+    /// Preview only — nothing was written.
+    Preview,
+    /// Every planned file was written.
+    Applied,
+    /// The apply step failed partway. This many files were already written.
+    Partial { written: usize },
+}
+
+impl Outcome {
+    /// Whether anything at all reached the disk.
+    pub const fn wrote_anything(self) -> bool {
+        matches!(self, Self::Applied | Self::Partial { .. })
+    }
+
+    /// The label used in `--json`.
+    pub const fn label(self) -> &'static str {
+        match self {
+            Self::Preview => "preview",
+            Self::Applied => "applied",
+            Self::Partial { .. } => "partial",
+        }
+    }
+}
+
 /// Everything one `autumn upgrade` run found.
 #[derive(Debug, Clone)]
 pub struct Report {
     pub from: Version,
     pub to: Version,
-    /// Whether the rewrites were written to disk.
-    pub applied: bool,
+    /// What the apply step actually did.
+    pub outcome: Outcome,
     /// `.rs` files read.
     pub files_scanned: usize,
     /// Migrations selected for this version range.
@@ -215,10 +246,10 @@ fn render_diffs(out: &mut String, report: &Report) {
     let _ = writeln!(
         out,
         "\n{}:",
-        if report.applied {
-            "Applied"
-        } else {
-            "Preview (nothing is written without --apply)"
+        match report.outcome {
+            Outcome::Applied => "Applied",
+            Outcome::Partial { .. } => "Applied in part — see the error below",
+            Outcome::Preview => "Preview (nothing is written without --apply)",
         }
     );
     for file in &report.files {
@@ -275,7 +306,7 @@ fn render_summary(out: &mut String, report: &Report) {
             "\n{sites} site{} in {files} file{} {}; {} file(s) scanned.",
             plural(sites),
             plural(files),
-            if report.applied {
+            if report.outcome.wrote_anything() {
                 "rewritten"
             } else {
                 "would be rewritten"
@@ -283,7 +314,14 @@ fn render_summary(out: &mut String, report: &Report) {
             report.files_scanned
         );
     }
-    if report.applied {
+    if let Outcome::Partial { written } = report.outcome {
+        let _ = writeln!(
+            out,
+            "Partially applied: {written} file{} written before the run stopped. \
+             `git diff` shows exactly which.",
+            plural(written)
+        );
+    } else if report.outcome == Outcome::Applied {
         if sites > 0 {
             let _ = writeln!(out, "Review the result with `git diff` before committing.");
         }
@@ -369,7 +407,15 @@ pub fn render_json(report: &Report) -> String {
     let value = serde_json::json!({
         "from": report.from.to_string(),
         "to": report.to.to_string(),
-        "applied": report.applied,
+        "outcome": report.outcome.label(),
+        // Kept as a bool for anything already reading it; true only for a
+        // *complete* apply, with `outcome` carrying the partial case.
+        "applied": report.outcome == Outcome::Applied,
+        "files_written": match report.outcome {
+            Outcome::Partial { written } => written,
+            Outcome::Applied => report.files.len(),
+            Outcome::Preview => 0,
+        },
         "files_scanned": report.files_scanned,
         "rewritten_sites": report.rewritten_sites(),
         "migrations": migrations_json(&report.migrations),
@@ -386,23 +432,23 @@ pub fn render_json(report: &Report) -> String {
 
 /// Read the `autumn-web` requirement recorded by the app at `root`.
 ///
-/// The root manifest answers first — `[dependencies]` then
-/// `[workspace.dependencies]`, so a workspace that pins the version once for
-/// its members speaks for the whole tree. A *virtual* workspace root declares
-/// neither: its members each carry their own `autumn-web` line, and reading
-/// only the root would abort a perfectly ordinary layout with "cannot tell
-/// which version".
+/// The root manifest (`[dependencies]`, then `[workspace.dependencies]`) and
+/// every member manifest are read together. A *virtual* workspace root
+/// declares neither, so reading only the root would abort a perfectly ordinary
+/// layout with "cannot tell which version"; and a root that *does* declare one
+/// can still be paired with a member that pins something older.
 ///
-/// When members disagree, the **oldest** floor wins. That is the conservative
+/// When they disagree, the **oldest** floor wins. That is the conservative
 /// answer: a migration for a release a member is already past finds nothing to
 /// do in that member (the rename it applies has already been applied), while
 /// taking the newest floor would skip a member that is genuinely behind.
 fn recorded_version(root: &Path) -> Option<String> {
-    if let Some(version) = crate::doctor::read_autumn_web_version_at(root) {
-        return Some(version);
-    }
-    member_manifests(root)
-        .into_iter()
+    // The root and the members are read *together*. Returning early on the
+    // root would let a workspace whose root records 0.6.0 hide a member that
+    // still pins 0.5.0 — the walk then migrates that member's source with no
+    // 0.5.0 -> 0.6.0 migration selected.
+    std::iter::once(root.to_path_buf())
+        .chain(member_manifests(root))
         .filter_map(|directory| crate::doctor::read_autumn_web_version_at(&directory))
         .filter_map(|requirement| {
             migrations::parse_version_req(&requirement).map(|version| (version, requirement))
@@ -530,7 +576,7 @@ fn plan_with(
     let mut report = Report {
         from,
         to,
-        applied: false,
+        outcome: Outcome::Preview,
         files_scanned: 0,
         migrations: selected.to_vec(),
         files: Vec::new(),
@@ -644,10 +690,11 @@ fn plan_with(
 /// original, so an interrupted write leaves the original intact rather than a
 /// truncated source file.
 fn write_plan(report: &Report) -> Result<(), WriteFailure> {
-    for file in &report.files {
+    for (written, file) in report.files.iter().enumerate() {
         write_one(file).map_err(|error| WriteFailure {
             path: file.path.clone(),
             error,
+            written,
         })?;
     }
     Ok(())
@@ -660,6 +707,8 @@ fn write_plan(report: &Report) -> Result<(), WriteFailure> {
 struct WriteFailure {
     path: String,
     error: std::io::Error,
+    /// Files successfully written before this one.
+    written: usize,
 }
 
 /// Write one file through a sibling temporary file renamed over the original.
@@ -760,13 +809,19 @@ pub fn run_in(root: &Path, opts: &UpgradeOptions) -> i32 {
     let mut report = plan(root, from, to);
     let mut failure = None;
     if opts.apply {
-        report.applied = true;
-        if let Err(write_failure) = write_plan(&report) {
-            // Report first, fail second: a partial apply is exactly when the
-            // user most needs to see which files were in the plan and which one
-            // stopped it.
-            report.applied = false;
-            failure = Some(write_failure);
+        match write_plan(&report) {
+            Ok(()) => report.outcome = Outcome::Applied,
+            Err(write_failure) => {
+                // Report first, fail second: a partial apply is exactly when
+                // the user most needs to see which files were in the plan and
+                // which one stopped it — and saying "nothing was written" when
+                // some files already changed would be worse than saying
+                // nothing at all.
+                report.outcome = Outcome::Partial {
+                    written: write_failure.written,
+                };
+                failure = Some(write_failure);
+            }
         }
     }
 
@@ -776,7 +831,7 @@ pub fn run_in(root: &Path, opts: &UpgradeOptions) -> i32 {
         print!("{}", render_text(&report));
     }
 
-    if let Some(WriteFailure { path, error }) = failure {
+    if let Some(WriteFailure { path, error, .. }) = failure {
         eprintln!(
             "autumn upgrade: failed while writing {path}: {error}\n\
              Files listed before it in the report above were already written; \
@@ -803,6 +858,7 @@ mod tests {
             to: "with_pool_untracked",
             form: CallForm::AssociatedFunction,
             args: 1,
+            receiver: None,
         },
     };
 
@@ -823,11 +879,11 @@ mod tests {
         }
     }
 
-    fn sample(applied: bool) -> Report {
+    fn sample(outcome: Outcome) -> Report {
         Report {
             from: version(0, 5, 0),
             to: version(0, 6, 0),
-            applied,
+            outcome,
             files_scanned: 7,
             migrations: vec![&AUTO, &MANUAL],
             files: vec![FileReport {
@@ -863,11 +919,11 @@ mod tests {
         }
     }
 
-    fn empty(applied: bool) -> Report {
+    fn empty(outcome: Outcome) -> Report {
         Report {
             from: version(0, 6, 0),
             to: version(0, 6, 0),
-            applied,
+            outcome,
             files_scanned: 3,
             migrations: Vec::new(),
             files: Vec::new(),
@@ -879,13 +935,13 @@ mod tests {
 
     #[test]
     fn rewritten_sites_totals_every_file() {
-        assert_eq!(sample(false).rewritten_sites(), 1);
-        assert_eq!(empty(false).rewritten_sites(), 0);
+        assert_eq!(sample(Outcome::Preview).rewritten_sites(), 1);
+        assert_eq!(empty(Outcome::Preview).rewritten_sites(), 0);
     }
 
     #[test]
     fn preview_text_shows_the_diff_the_counts_and_that_nothing_was_written() {
-        let out = render_text(&sample(false));
+        let out = render_text(&sample(Outcome::Preview));
         assert!(out.contains("src/main.rs"), "{out}");
         assert!(out.contains("@@ line 12 @@"), "{out}");
         assert!(out.contains("1 site"), "site count is reported: {out}");
@@ -898,7 +954,7 @@ mod tests {
 
     #[test]
     fn preview_text_lists_every_manual_site_with_location_and_guide() {
-        let out = render_text(&sample(false));
+        let out = render_text(&sample(Outcome::Preview));
         assert!(out.contains("src/lib.rs:40"), "{out}");
         assert!(out.contains("inside a macro invocation"), "{out}");
         assert!(out.contains("docs/migrations/0.6.0.md#rename"), "{out}");
@@ -907,7 +963,7 @@ mod tests {
 
     #[test]
     fn preview_text_labels_each_selected_migration_with_its_confidence() {
-        let out = render_text(&sample(false));
+        let out = render_text(&sample(Outcome::Preview));
         // The fixture ids deliberately contain neither word, so these can only
         // pass if the label column is actually rendered.
         assert!(out.contains("auto    0.6.0-pool-rename"), "{out}");
@@ -916,21 +972,21 @@ mod tests {
 
     #[test]
     fn preview_text_reports_skipped_files() {
-        let out = render_text(&sample(false));
+        let out = render_text(&sample(Outcome::Preview));
         assert!(out.contains("src/broken.rs"), "{out}");
         assert!(out.contains("expected `{`"), "{out}");
     }
 
     #[test]
     fn applied_text_says_what_was_written_and_not_what_would_be() {
-        let out = render_text(&sample(true));
+        let out = render_text(&sample(Outcome::Applied));
         assert!(!out.to_lowercase().contains("nothing was written"), "{out}");
         assert!(out.contains("1 site in 1 file rewritten"), "{out}");
     }
 
     #[test]
     fn an_unaffected_app_reports_nothing_to_change() {
-        let out = render_text(&empty(false));
+        let out = render_text(&empty(Outcome::Preview));
         assert!(
             out.to_lowercase().contains("nothing to change"),
             "an app that never used the affected APIs must say so plainly: {out}"
@@ -949,6 +1005,7 @@ mod tests {
             to: "with_pool_untracked",
             form: CallForm::AssociatedFunction,
             args: 1,
+            receiver: None,
         },
     };
 
@@ -1014,7 +1071,7 @@ mod tests {
 
     #[test]
     fn json_report_carries_the_range_counts_and_labels() {
-        let out = render_json(&sample(false));
+        let out = render_json(&sample(Outcome::Preview));
         let value: serde_json::Value = serde_json::from_str(&out).expect("valid JSON");
         assert_eq!(value["from"], "0.5.0");
         assert_eq!(value["to"], "0.6.0");
@@ -1031,10 +1088,60 @@ mod tests {
     }
 
     #[test]
+    fn a_partial_apply_never_claims_nothing_was_written() {
+        // The failure mode this guards: some files already rewritten, and the
+        // report telling the user to "re-run with --apply" as if the tree were
+        // untouched.
+        let mut report = sample(Outcome::Preview);
+        report.outcome = Outcome::Partial { written: 3 };
+
+        let text = render_text(&report);
+        assert!(
+            text.contains("Partially applied: 3 files written"),
+            "{text}"
+        );
+        assert!(
+            !text.to_lowercase().contains("nothing was written"),
+            "the tree was modified: {text}"
+        );
+        assert!(
+            !text.contains("Re-run with `--apply`"),
+            "the apply step already ran: {text}"
+        );
+
+        let json: serde_json::Value =
+            serde_json::from_str(&render_json(&report)).expect("valid JSON");
+        assert_eq!(json["outcome"], "partial");
+        assert_eq!(json["files_written"], 3);
+        assert_eq!(
+            json["applied"], false,
+            "`applied` stays a strict did-everything-land flag"
+        );
+    }
+
+    #[test]
+    fn a_complete_apply_reports_every_file_it_wrote() {
+        let json: serde_json::Value =
+            serde_json::from_str(&render_json(&sample(Outcome::Applied))).expect("valid JSON");
+        assert_eq!(json["outcome"], "applied");
+        assert_eq!(json["applied"], true);
+        assert_eq!(json["files_written"], 1);
+    }
+
+    #[test]
+    fn a_preview_wrote_nothing_and_says_so_in_json() {
+        let json: serde_json::Value =
+            serde_json::from_str(&render_json(&sample(Outcome::Preview))).expect("valid JSON");
+        assert_eq!(json["outcome"], "preview");
+        assert_eq!(json["applied"], false);
+        assert_eq!(json["files_written"], 0);
+    }
+
+    #[test]
     fn json_report_omits_the_rewritten_file_bodies() {
         // The report is a summary, not a payload: dumping every rewritten file
         // into it would make `--json` unusable on a real app.
-        let out = render_json(&sample(false));
+        let out = render_json(&sample(Outcome::Preview));
         assert!(!out.contains("\"updated\""), "{out}");
     }
 }

--- a/autumn-cli/tests/integration/mod.rs
+++ b/autumn-cli/tests/integration/mod.rs
@@ -42,4 +42,5 @@ mod seed_model_linking;
 mod serve;
 mod tauri_mobile_thin_client;
 mod test_command;
+mod upgrade_codemod;
 mod webhook_sim;

--- a/autumn-cli/tests/integration/repo_hygiene.rs
+++ b/autumn-cli/tests/integration/repo_hygiene.rs
@@ -8500,3 +8500,108 @@ fn codemod_gate_does_not_accept_a_guide_only_id_as_a_codemod() {
         gate_report(&output),
     );
 }
+
+#[test]
+fn codemod_gate_rejects_an_id_that_merely_starts_with_a_shipped_one() {
+    // Codex review on #2231: the known-id test was `index(visible, id)`, a bare
+    // substring, so a guide could name `0.7.0-with-pool-extra` — a codemod
+    // nobody wrote — and be vouched for by the shipped `0.7.0-with-pool`.
+    let mut guide = guide_with_breaking_change(
+        "0.7.0",
+        "Repository: `with_pool` is renamed to `with_pool_untracked`",
+        "**Automation:** `auto` — `autumn upgrade` rewrites every call site; \
+         codemod `0.7.0-with-pool-extra`.",
+    );
+    guide = guide.replace(
+        "- **Status:** performed 2026-01-01",
+        "- **Codemod:** `autumn upgrade --apply` covered the rename.\n\
+         - **Status:** performed 2026-01-01",
+    );
+    let tmp = gate_fixture_with_guide("0.7.0", &guide);
+    write_fixture_registry(&tmp, &["0.7.0-with-pool"]);
+    let output = run_migration_gate(tmp.path());
+    assert!(
+        !output.status.success(),
+        "a longer id is a different codemod, not the shipped one\n{}",
+        gate_report(&output),
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("names no shipped codemod"),
+        "{}",
+        gate_report(&output),
+    );
+}
+
+#[test]
+fn codemod_gate_accepts_a_shipped_id_that_is_a_prefix_of_a_longer_one() {
+    // The boundary fix must not swing the other way: naming the shipped
+    // `0.7.0-with-pool` is still valid when a longer id also ships.
+    let mut guide = guide_with_breaking_change(
+        "0.7.0",
+        "Repository: `with_pool` is renamed to `with_pool_untracked`",
+        "**Automation:** `auto` — `autumn upgrade` rewrites every call site; \
+         codemod `0.7.0-with-pool`.",
+    );
+    guide = guide.replace(
+        "- **Status:** performed 2026-01-01",
+        "- **Codemod:** `autumn upgrade --apply` covered the rename.\n\
+         - **Status:** performed 2026-01-01",
+    );
+    let tmp = gate_fixture_with_guide("0.7.0", &guide);
+    write_fixture_registry(&tmp, &["0.7.0-with-pool", "0.7.0-with-pool-extra"]);
+    let output = run_migration_gate(tmp.path());
+    assert!(output.status.success(), "{}", gate_report(&output));
+}
+
+#[test]
+fn codemod_gate_rejects_a_walkthrough_codemod_bullet_that_ran_nothing() {
+    // Codex review on #2231: the walk-through requirement matched the
+    // `- **Codemod:**` label alone, so `none` recorded a codemod-first
+    // walk-through that never ran the codemod.
+    let mut guide = guide_with_breaking_change(
+        "0.7.0",
+        "Repository: `with_pool` is renamed to `with_pool_untracked`",
+        "**Automation:** `auto` — `autumn upgrade` rewrites every call site; \
+         codemod `0.7.0-with-pool`.",
+    );
+    guide = guide.replace(
+        "- **Status:** performed 2026-01-01",
+        "- **Codemod:** none\n\
+         - **Status:** performed 2026-01-01",
+    );
+    let tmp = gate_fixture_with_guide("0.7.0", &guide);
+    write_fixture_registry(&tmp, &["0.7.0-with-pool"]);
+    let output = run_migration_gate(tmp.path());
+    assert!(
+        !output.status.success(),
+        "`none` is not a codemod-first walk-through\n{}",
+        gate_report(&output),
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("codemod-first walk-through"),
+        "{}",
+        gate_report(&output),
+    );
+}
+
+#[test]
+fn codemod_gate_accepts_a_walkthrough_codemod_bullet_wrapped_onto_a_continuation() {
+    // The value check reads the whole bullet, so a wrapped invocation — the
+    // shape `TEMPLATE.md` itself uses — still counts.
+    let mut guide = guide_with_breaking_change(
+        "0.7.0",
+        "Repository: `with_pool` is renamed to `with_pool_untracked`",
+        "**Automation:** `auto` — `autumn upgrade` rewrites every call site; \
+         codemod `0.7.0-with-pool`.",
+    );
+    guide = guide.replace(
+        "- **Status:** performed 2026-01-01",
+        "- **Codemod:** the preview first, then\n    \
+         `autumn upgrade --apply` for the rename.\n\
+         - **Status:** performed 2026-01-01",
+    );
+    let tmp = gate_fixture_with_guide("0.7.0", &guide);
+    write_fixture_registry(&tmp, &["0.7.0-with-pool"]);
+    let output = run_migration_gate(tmp.path());
+    assert!(output.status.success(), "{}", gate_report(&output));
+}

--- a/autumn-cli/tests/integration/repo_hygiene.rs
+++ b/autumn-cli/tests/integration/repo_hygiene.rs
@@ -7898,3 +7898,531 @@ fn migration_guide_gate_does_not_match_an_unescaped_label_to_an_escaped_one() {
         "an unescaped label does not resolve to an escaped definition",
     );
 }
+
+// ---------------------------------------------------------------------------
+// Codemod coverage (issue #1629).
+//
+// #1588 made the migration guide a release gate; these pin the follow-on gate:
+// a rename-level break -- the class `autumn upgrade` can rewrite -- does not
+// ship without either a codemod that actually exists in the registry, or a
+// stated reason it stays manual.
+// ---------------------------------------------------------------------------
+
+/// A codemod registry the gate can read, in the shape it greps for.
+fn write_fixture_registry(tmp: &tempfile::TempDir, ids: &[&str]) {
+    let dir = tmp.path().join("autumn-cli/src/upgrade");
+    std::fs::create_dir_all(&dir).expect("registry dir");
+    let mut body = String::from("pub static APP_MIGRATIONS: &[AppMigration] = &[\n");
+    for id in ids {
+        let _ = writeln!(body, "    AppMigration {{\n        id: \"{id}\",\n    }},");
+    }
+    body.push_str("];\n");
+    std::fs::write(dir.join("migrations.rs"), body).expect("registry");
+}
+
+/// A guide whose single breaking change is `body`, appended under the heading.
+fn guide_with_breaking_change(version: &str, heading: &str, body: &str) -> String {
+    format!(
+        "# Migrating to `{version}`\n\n\
+         ## At a glance\n\n\
+         - **New version:** `autumn-web {version}`\n\n\
+         ## Summary\n\n\
+         Why this release breaks.\n\n\
+         ## Before you start\n\n\
+         Pin the old version and get green.\n\n\
+         ## Breaking changes\n\n\
+         ### {heading}\n\n\
+         {body}\n\n\
+         ## How to verify\n\n\
+         Run `cargo check`.\n\n\
+         ### Guide-only upgrade walkthrough\n\n\
+         - **Status:** performed 2026-01-01\n"
+    )
+}
+
+/// The changelog every fixture below shares: one breaking entry, guide linked.
+fn breaking_changelog(version: &str) -> String {
+    format!(
+        "# Changelog\n\n\
+         ## [{version}] - 2026-09-01\n\n\
+         ### Changed\n\n\
+         - **db:** **Breaking:** the constructor changed. See the \
+         [migration guide](docs/migrations/{version}.md).\n"
+    )
+}
+
+fn gate_fixture_with_guide(version: &str, guide: &str) -> tempfile::TempDir {
+    let tmp = migration_gate_fixture(version);
+    write_fixture_guide(&tmp, version, guide);
+    std::fs::write(tmp.path().join("CHANGELOG.md"), breaking_changelog(version))
+        .expect("changelog");
+    tmp
+}
+
+#[test]
+fn codemod_gate_fails_a_rename_with_no_automation_label() {
+    let tmp = gate_fixture_with_guide(
+        "0.7.0",
+        &guide_with_breaking_change(
+            "0.7.0",
+            "Repository: `with_pool` is renamed to `with_pool_untracked`",
+            "Only the name changes.",
+        ),
+    );
+    let output = run_migration_gate(tmp.path());
+    assert!(
+        !output.status.success(),
+        "a rename-level break must be classified (issue #1629)\n{}",
+        gate_report(&output),
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("automation label"),
+        "{}",
+        gate_report(&output),
+    );
+}
+
+#[test]
+fn codemod_gate_ignores_a_semantic_change_with_no_automation_label() {
+    // "Semantic/behavioral changes remain guide-only with no justification
+    // needed" — the gate must not turn every behaviour change into paperwork.
+    let tmp = gate_fixture_with_guide(
+        "0.7.0",
+        &guide_with_breaking_change(
+            "0.7.0",
+            "Security: the signing secret is required in production",
+            "Set `AUTUMN_TENANCY__JWT_SECRET` before booting.",
+        ),
+    );
+    let output = run_migration_gate(tmp.path());
+    assert!(output.status.success(), "{}", gate_report(&output));
+}
+
+#[test]
+fn codemod_gate_fails_an_auto_label_naming_no_shipped_codemod() {
+    let tmp = gate_fixture_with_guide(
+        "0.7.0",
+        &guide_with_breaking_change(
+            "0.7.0",
+            "Repository: `with_pool` is renamed to `with_pool_untracked`",
+            "**Automation:** `auto` — `autumn upgrade` rewrites every call site; \
+             codemod `0.7.0-not-shipped`.",
+        ),
+    );
+    write_fixture_registry(&tmp, &["0.6.0-something-else"]);
+    let output = run_migration_gate(tmp.path());
+    assert!(
+        !output.status.success(),
+        "a guide may not promise a codemod nobody wrote\n{}",
+        gate_report(&output),
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("names no shipped codemod"),
+        "{}",
+        gate_report(&output),
+    );
+}
+
+#[test]
+fn codemod_gate_accepts_an_auto_label_backed_by_the_registry() {
+    let mut guide = guide_with_breaking_change(
+        "0.7.0",
+        "Repository: `with_pool` is renamed to `with_pool_untracked`",
+        "**Automation:** `auto` — `autumn upgrade` rewrites every call site; \
+         codemod `0.7.0-with-pool`.",
+    );
+    // A shipped codemod also has to have been used by the walk-through.
+    guide = guide.replace(
+        "- **Status:** performed 2026-01-01",
+        "- **Codemod:** `autumn upgrade --apply` covered the rename.\n\
+         - **Status:** performed 2026-01-01",
+    );
+    let tmp = gate_fixture_with_guide("0.7.0", &guide);
+    write_fixture_registry(&tmp, &["0.7.0-with-pool"]);
+    let output = run_migration_gate(tmp.path());
+    assert!(output.status.success(), "{}", gate_report(&output));
+}
+
+#[test]
+fn codemod_gate_fails_a_shipped_codemod_with_no_codemod_first_walkthrough() {
+    let tmp = gate_fixture_with_guide(
+        "0.7.0",
+        &guide_with_breaking_change(
+            "0.7.0",
+            "Repository: `with_pool` is renamed to `with_pool_untracked`",
+            "**Automation:** `auto` — codemod `0.7.0-with-pool` rewrites every site.",
+        ),
+    );
+    write_fixture_registry(&tmp, &["0.7.0-with-pool"]);
+    let output = run_migration_gate(tmp.path());
+    assert!(
+        !output.status.success(),
+        "the walk-through is performed codemod-first (issue #1629)\n{}",
+        gate_report(&output),
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("codemod-first walk-through"),
+        "{}",
+        gate_report(&output),
+    );
+}
+
+#[test]
+fn codemod_gate_fails_a_rename_left_manual_without_a_reason() {
+    let tmp = gate_fixture_with_guide(
+        "0.7.0",
+        &guide_with_breaking_change(
+            "0.7.0",
+            "Repository: `with_pool` is renamed to `with_pool_untracked`",
+            "**Automation:** `manual`",
+        ),
+    );
+    let output = run_migration_gate(tmp.path());
+    assert!(
+        !output.status.success(),
+        "a rename left manual has to say why\n{}",
+        gate_report(&output),
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("no reason given"),
+        "{}",
+        gate_report(&output),
+    );
+}
+
+#[test]
+fn codemod_gate_accepts_a_rename_left_manual_with_a_reason() {
+    let tmp = gate_fixture_with_guide(
+        "0.7.0",
+        &guide_with_breaking_change(
+            "0.7.0",
+            "Repository: `with_pool` is renamed to `with_pool_untracked`",
+            "**Automation:** `manual` — the new name is only reachable from \
+             inside the `repository!` macro, which no codemod may rewrite.",
+        ),
+    );
+    let output = run_migration_gate(tmp.path());
+    assert!(output.status.success(), "{}", gate_report(&output));
+}
+
+#[test]
+fn codemod_gate_rejects_an_unknown_automation_label() {
+    let tmp = gate_fixture_with_guide(
+        "0.7.0",
+        &guide_with_breaking_change(
+            "0.7.0",
+            "Repository: `with_pool` is renamed to `with_pool_untracked`",
+            "**Automation:** `probably` — we think a codemod could do this.",
+        ),
+    );
+    let output = run_migration_gate(tmp.path());
+    assert!(
+        !output.status.success(),
+        "only auto/review/manual are labels\n{}",
+        gate_report(&output),
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("unknown automation"),
+        "{}",
+        gate_report(&output),
+    );
+}
+
+#[test]
+fn codemod_gate_reads_a_label_from_the_code_span_not_the_prose() {
+    // "…we chose `manual` because auto was unsafe" must not read as `auto`.
+    let tmp = gate_fixture_with_guide(
+        "0.7.0",
+        &guide_with_breaking_change(
+            "0.7.0",
+            "Repository: `with_pool` is renamed to `with_pool_untracked`",
+            "**Automation:** `manual` — an auto rewrite would need type \
+             inference this tool does not have.",
+        ),
+    );
+    let output = run_migration_gate(tmp.path());
+    assert!(output.status.success(), "{}", gate_report(&output));
+}
+
+#[test]
+fn codemod_gate_does_not_read_labels_out_of_fenced_samples() {
+    // A guide that *documents* the convention shows the label in a fence; that
+    // is a sample, not a declaration, and must not satisfy a real entry.
+    let tmp = gate_fixture_with_guide(
+        "0.7.0",
+        &guide_with_breaking_change(
+            "0.7.0",
+            "Repository: `with_pool` is renamed to `with_pool_untracked`",
+            "```markdown\n**Automation:** `auto` — codemod `0.7.0-with-pool`.\n```",
+        ),
+    );
+    write_fixture_registry(&tmp, &["0.7.0-with-pool"]);
+    let output = run_migration_gate(tmp.path());
+    assert!(
+        !output.status.success(),
+        "a label inside a fence is a sample, not a classification\n{}",
+        gate_report(&output),
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("automation label"),
+        "the entry must fail as unclassified, not for some unrelated reason\n{}",
+        gate_report(&output),
+    );
+}
+
+#[test]
+fn codemod_gate_reads_the_registry_this_repository_actually_ships() {
+    // The real registry and the real guides have to agree with each other, and
+    // the gate is the thing that keeps them agreeing.
+    let root = workspace_root();
+    let registry = root.join("autumn-cli/src/upgrade/migrations.rs");
+    assert!(
+        registry.is_file(),
+        "the codemod registry is the path the gate greps: {}",
+        registry.display(),
+    );
+    let body = std::fs::read_to_string(&registry).expect("read registry");
+    assert!(
+        body.contains("id: \"0.6.0-repository-with-pool-untracked\""),
+        "the first shipped codemod is the 0.6.0 with_pool rename (issue #1629)",
+    );
+    // The whole-repo gate run itself is asserted by
+    // `migration_guide_gate_passes_for_this_repository`; this test pins the
+    // path and the id the gate greps for.
+    assert!(
+        std::fs::read_to_string(root.join("docs/migrations/0.6.0.md"))
+            .expect("read the 0.6.0 guide")
+            .contains("0.6.0-repository-with-pool-untracked"),
+        "the guide and the registry name the same codemod",
+    );
+}
+
+#[test]
+fn codemod_gate_reads_a_label_written_as_a_list_item() {
+    // A bulleted label renders as the same declaration a reader sees, so it has
+    // to be held to the same rule — otherwise a bullet is a way to promise a
+    // codemod nobody wrote.
+    let tmp = gate_fixture_with_guide(
+        "0.7.0",
+        &guide_with_breaking_change(
+            "0.7.0",
+            "Config: the `session.ttl` default changed",
+            "- **Automation:** `auto` — `autumn upgrade` fixes every call site; \
+             codemod `0.7.0-vapourware`.",
+        ),
+    );
+    write_fixture_registry(&tmp, &["0.7.0-something-else"]);
+    let output = run_migration_gate(tmp.path());
+    assert!(
+        !output.status.success(),
+        "a bulleted label is still a label\n{}",
+        gate_report(&output),
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("names no shipped codemod"),
+        "{}",
+        gate_report(&output),
+    );
+}
+
+#[test]
+fn codemod_gate_reads_entries_outside_the_breaking_changes_section() {
+    // A rename documented under `## Behavior changes` breaks apps exactly as
+    // hard as one under `## Breaking changes`.
+    let guide = valid_migration_guide("0.7.0").replace(
+        "## How to verify",
+        "## Behavior changes\n\n\
+         ### Routing: `Router::mount` is renamed to `Router::attach`\n\n\
+         Only the name changes.\n\n\
+         ## How to verify",
+    );
+    let tmp = gate_fixture_with_guide("0.7.0", &guide);
+    let output = run_migration_gate(tmp.path());
+    assert!(
+        !output.status.success(),
+        "a rename outside `## Breaking changes` must still be classified\n{}",
+        gate_report(&output),
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("automation label"),
+        "{}",
+        gate_report(&output),
+    );
+}
+
+#[test]
+fn codemod_gate_does_not_accept_another_releases_codemod() {
+    // Citing the previous release's codemod says nothing about this release.
+    let tmp = gate_fixture_with_guide(
+        "0.7.0",
+        &guide_with_breaking_change(
+            "0.7.0",
+            "Repository: `foo` is renamed to `bar`",
+            "**Automation:** `auto` — codemod \
+             `0.6.0-repository-with-pool-untracked` rewrites every site.",
+        ),
+    );
+    write_fixture_registry(&tmp, &["0.6.0-repository-with-pool-untracked"]);
+    let output = run_migration_gate(tmp.path());
+    assert!(
+        !output.status.success(),
+        "a 0.6.0 codemod does not cover a 0.7.0 rename\n{}",
+        gate_report(&output),
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("names no shipped codemod"),
+        "{}",
+        gate_report(&output),
+    );
+}
+
+#[test]
+fn codemod_gate_scopes_the_codemod_record_to_the_walkthrough_section() {
+    // A `- **Codemod:**` bullet parked under a later sibling heading is not a
+    // record of a codemod-first walk-through.
+    let guide = guide_with_breaking_change(
+        "0.7.0",
+        "Repository: `with_pool` is renamed to `with_pool_untracked`",
+        "**Automation:** `auto` — codemod `0.7.0-with-pool` rewrites every site.",
+    )
+    .replace(
+        "- **Status:** performed 2026-01-01",
+        "- **Status:** performed 2026-01-01\n\n\
+         ### An unrelated later subsection\n\n\
+         - **Codemod:** `autumn upgrade --apply`\n",
+    );
+    let tmp = gate_fixture_with_guide("0.7.0", &guide);
+    write_fixture_registry(&tmp, &["0.7.0-with-pool"]);
+    let output = run_migration_gate(tmp.path());
+    assert!(
+        !output.status.success(),
+        "the codemod record has to sit under the walk-through heading\n{}",
+        gate_report(&output),
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("codemod-first walk-through"),
+        "{}",
+        gate_report(&output),
+    );
+}
+
+#[test]
+fn codemod_gate_rejects_a_label_that_is_not_in_a_code_span() {
+    // `**Automation:** auto` is prose, not a declaration the parser can read;
+    // failing it beats silently reading the first word of the sentence.
+    let tmp = gate_fixture_with_guide(
+        "0.7.0",
+        &guide_with_breaking_change(
+            "0.7.0",
+            "Repository: `with_pool` is renamed to `with_pool_untracked`",
+            "**Automation:** auto — we think a codemod covers this.",
+        ),
+    );
+    let output = run_migration_gate(tmp.path());
+    assert!(
+        !output.status.success(),
+        "an unbackticked label is not a label\n{}",
+        gate_report(&output),
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("unknown automation"),
+        "{}",
+        gate_report(&output),
+    );
+}
+
+#[test]
+fn codemod_gate_accepts_a_reason_wrapped_across_lines() {
+    // Real guides wrap. A justification whose *first* line is short is still a
+    // justification, and rejecting it would push authors to write one long line.
+    let tmp = gate_fixture_with_guide(
+        "0.7.0",
+        &guide_with_breaking_change(
+            "0.7.0",
+            "Repository: `with_pool` is renamed to `with_pool_untracked`",
+            "**Automation:** `manual` — no\nmechanical rewrite is possible here.",
+        ),
+    );
+    let output = run_migration_gate(tmp.path());
+    assert!(output.status.success(), "{}", gate_report(&output));
+}
+
+#[test]
+fn codemod_gate_accepts_the_reason_the_error_message_suggests() {
+    // The `NOJUSTIFY` message offers "needs new arguments" as an acceptable
+    // reason; a threshold that rejects it would be telling authors a lie.
+    let tmp = gate_fixture_with_guide(
+        "0.7.0",
+        &guide_with_breaking_change(
+            "0.7.0",
+            "Repository: `with_pool` is renamed to `with_pool_untracked`",
+            "**Automation:** `manual` — needs new arguments.",
+        ),
+    );
+    let output = run_migration_gate(tmp.path());
+    assert!(output.status.success(), "{}", gate_report(&output));
+}
+
+#[test]
+fn codemod_gate_honours_the_documented_suppression_token() {
+    // An entry that *documents* the convention rather than declaring a break
+    // uses the same escape hatch every other check in this gate offers.
+    let tmp = gate_fixture_with_guide(
+        "0.7.0",
+        &guide_with_breaking_change(
+            "0.7.0",
+            "Process: how a rename is classified",
+            "Explains the labels. \
+             <!-- migration-guide-gate: describes the convention itself -->",
+        ),
+    );
+    let output = run_migration_gate(tmp.path());
+    assert!(output.status.success(), "{}", gate_report(&output));
+}
+
+#[test]
+fn codemod_gate_survives_a_registry_it_cannot_read() {
+    // Fails closed and says so, rather than reading an unreadable registry as
+    // "no codemods shipped" and blaming the guide.
+    let tmp = gate_fixture_with_guide(
+        "0.7.0",
+        &guide_with_breaking_change(
+            "0.7.0",
+            "Security: the signing secret is required",
+            "Set it before booting.",
+        ),
+    );
+    let registry = tmp.path().join("unreadable-registry.rs");
+    std::fs::write(&registry, "id: \"0.7.0-x\",\n").expect("registry");
+    let mut permissions = std::fs::metadata(&registry)
+        .expect("metadata")
+        .permissions();
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt as _;
+        permissions.set_mode(0o000);
+    }
+    std::fs::set_permissions(&registry, permissions).expect("chmod");
+
+    let output = bash_command()
+        .arg("scripts/check-migration-guides.sh")
+        .env("CODEMOD_REGISTRY", "unreadable-registry.rs")
+        .current_dir(tmp.path())
+        .output()
+        .expect("run migration-guide gate");
+
+    // Running as root defeats the permission bits; only assert when it took.
+    if std::fs::read_to_string(&registry).is_ok() {
+        return;
+    }
+    assert!(
+        !output.status.success(),
+        "an unreadable registry is a broken checkout, not an empty one\n{}",
+        gate_report(&output),
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("cannot be read"),
+        "{}",
+        gate_report(&output),
+    );
+}

--- a/autumn-cli/tests/integration/repo_hygiene.rs
+++ b/autumn-cli/tests/integration/repo_hygiene.rs
@@ -7908,15 +7908,37 @@ fn migration_guide_gate_does_not_match_an_unescaped_label_to_an_escaped_one() {
 // stated reason it stays manual.
 // ---------------------------------------------------------------------------
 
-/// A codemod registry the gate can read, in the shape it greps for.
+/// A codemod registry the gate can read, in the shape it greps for: entries of
+/// the production `APP_MIGRATIONS` table that actually carry a rewrite.
 fn write_fixture_registry(tmp: &tempfile::TempDir, ids: &[&str]) {
+    write_fixture_registry_with(tmp, ids, &[]);
+}
+
+/// As [`write_fixture_registry`], plus `guide_only` ids that rewrite nothing —
+/// the gate must not accept those as backing an `auto`/`review` label.
+fn write_fixture_registry_with(tmp: &tempfile::TempDir, rewriting: &[&str], guide_only: &[&str]) {
     let dir = tmp.path().join("autumn-cli/src/upgrade");
     std::fs::create_dir_all(&dir).expect("registry dir");
     let mut body = String::from("pub static APP_MIGRATIONS: &[AppMigration] = &[\n");
-    for id in ids {
-        let _ = writeln!(body, "    AppMigration {{\n        id: \"{id}\",\n    }},");
+    for id in rewriting {
+        let _ = writeln!(
+            body,
+            "    AppMigration {{\n        id: \"{id}\",\n                     rewrite: Rewrite::CallRename {{ from: \"a\", to: \"b\" }},\n    }},"
+        );
+    }
+    for id in guide_only {
+        let _ = writeln!(
+            body,
+            "    AppMigration {{\n        id: \"{id}\",\n                     rewrite: Rewrite::GuideOnly,\n    }},"
+        );
     }
     body.push_str("];\n");
+    // A `#[cfg(test)]` fixture table lives in the real file below the
+    // production one; ids from it must never count as shipped.
+    body.push_str(
+        "\n#[cfg(test)]\nmod tests {\n    static FIXTURE_REGISTRY: &[AppMigration] = &[\n\
+         \x20       AppMigration {\n            id: \"9.9.9-test-only\",\n                     rewrite: Rewrite::CallRename { from: \"x\", to: \"y\" },\n        },\n    ];\n}\n",
+    );
     std::fs::write(dir.join("migrations.rs"), body).expect("registry");
 }
 
@@ -8422,6 +8444,58 @@ fn codemod_gate_survives_a_registry_it_cannot_read() {
     );
     assert!(
         String::from_utf8_lossy(&output.stderr).contains("cannot be read"),
+        "{}",
+        gate_report(&output),
+    );
+}
+
+#[test]
+fn codemod_gate_does_not_accept_a_test_only_registry_id() {
+    // The registry file carries a `#[cfg(test)]` fixture table below the
+    // production one. A guide citing an id from it names no shipped codemod.
+    let tmp = gate_fixture_with_guide(
+        "0.7.0",
+        &guide_with_breaking_change(
+            "0.7.0",
+            "Repository: `foo` is renamed to `bar`",
+            "**Automation:** `auto` — codemod `9.9.9-test-only` rewrites every site.",
+        ),
+    );
+    write_fixture_registry(&tmp, &["0.7.0-real"]);
+    let output = run_migration_gate(tmp.path());
+    assert!(
+        !output.status.success(),
+        "a test-fixture id is not a shipped codemod\n{}",
+        gate_report(&output),
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("names no shipped codemod"),
+        "{}",
+        gate_report(&output),
+    );
+}
+
+#[test]
+fn codemod_gate_does_not_accept_a_guide_only_id_as_a_codemod() {
+    // A `GuideOnly` entry exists so the upgrade summary can link the guide; it
+    // rewrites nothing, so it cannot back an `auto` label.
+    let tmp = gate_fixture_with_guide(
+        "0.7.0",
+        &guide_with_breaking_change(
+            "0.7.0",
+            "Repository: `foo` is renamed to `bar`",
+            "**Automation:** `auto` — codemod `0.7.0-guide-only` rewrites every site.",
+        ),
+    );
+    write_fixture_registry_with(&tmp, &[], &["0.7.0-guide-only"]);
+    let output = run_migration_gate(tmp.path());
+    assert!(
+        !output.status.success(),
+        "a migration that rewrites nothing is not a codemod\n{}",
+        gate_report(&output),
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("names no shipped codemod"),
         "{}",
         gate_report(&output),
     );

--- a/autumn-cli/tests/integration/upgrade_codemod.rs
+++ b/autumn-cli/tests/integration/upgrade_codemod.rs
@@ -29,12 +29,16 @@ fn read(root: &Path, rel: &str) -> String {
 }
 
 fn run_upgrade(root: &Path, args: &[&str]) -> Output {
-    Command::new(autumn_bin())
-        .arg("upgrade")
-        .args(args)
-        .current_dir(root)
-        .output()
-        .expect("failed to run autumn upgrade")
+    run_upgrade_with_env(root, args, &[])
+}
+
+fn run_upgrade_with_env(root: &Path, args: &[&str], env: &[(&str, &str)]) -> Output {
+    let mut command = Command::new(autumn_bin());
+    command.arg("upgrade").args(args).current_dir(root);
+    for (key, value) in env {
+        command.env(key, value);
+    }
+    command.output().expect("failed to run autumn upgrade")
 }
 
 fn stdout_of(output: &Output) -> String {
@@ -1463,5 +1467,117 @@ fn a_path_typo_is_reported_as_a_bad_path_not_a_missing_dependency() {
         !stderr.contains("Add an `autumn-web` dependency"),
         "and does not send the user to a manifest that does not exist:\n{}",
         report(&output)
+    );
+}
+
+#[test]
+#[cfg(unix)]
+fn a_scan_root_that_cannot_be_read_is_a_failure_not_an_empty_report() {
+    // `is_dir()` answers "yes" for a directory with no read permission, so the
+    // root landed in `skipped` and the run exited 0 having examined nothing --
+    // a `--apply` that migrated no file at all, reported as success.
+    use std::os::unix::fs::PermissionsExt;
+
+    let tmp = TempDir::new().expect("tempdir");
+    let locked = tmp.path().join("locked");
+    fs::create_dir(&locked).unwrap();
+    write(&locked, "src/main.rs", USES_WITH_POOL);
+    fs::set_permissions(&locked, fs::Permissions::from_mode(0o000)).unwrap();
+
+    // Root ignores directory permissions, so there is nothing to assert when
+    // the suite runs as root. Restore the mode either way so the tempdir can be
+    // cleaned up.
+    let enforced = fs::read_dir(&locked).is_err();
+    let output = run_upgrade(
+        tmp.path(),
+        &["locked", "--from", "0.5.0", "--to", "0.6.0", "--apply"],
+    );
+    fs::set_permissions(&locked, fs::Permissions::from_mode(0o755)).unwrap();
+    if !enforced {
+        return;
+    }
+
+    assert!(!output.status.success(), "{}", report(&output));
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("not a readable directory"),
+        "an unreadable root is the bad-root exit, not an empty report:\n{}",
+        report(&output)
+    );
+}
+
+#[test]
+fn a_redirected_cargo_target_directory_is_still_build_output() {
+    // `CARGO_TARGET_DIR=build` puts build output somewhere the `target` name
+    // check never looks, so the walk descended into generated code and `--apply`
+    // rewrote artifacts that the next `cargo build` overwrites anyway.
+    let tmp = app("0.5.0");
+    write(tmp.path(), "src/main.rs", USES_WITH_POOL);
+    write(tmp.path(), "build/debug/build/generated.rs", USES_WITH_POOL);
+
+    let output = run_upgrade_with_env(
+        tmp.path(),
+        &["--to", "0.6.0", "--apply"],
+        &[("CARGO_TARGET_DIR", "build")],
+    );
+    assert!(output.status.success(), "{}", report(&output));
+    assert!(
+        read(tmp.path(), "src/main.rs").contains("with_pool_untracked("),
+        "app source is still migrated:\n{}",
+        stdout_of(&output)
+    );
+    assert!(
+        read(tmp.path(), "build/debug/build/generated.rs").contains("with_pool(pool.clone())"),
+        "the configured target directory is build output:\n{}",
+        stdout_of(&output)
+    );
+}
+
+#[test]
+fn a_target_directory_configured_in_cargo_config_is_still_build_output() {
+    // The same redirection, written down in `.cargo/config.toml` instead of the
+    // environment -- the form a project commits rather than exports.
+    let tmp = app("0.5.0");
+    write(tmp.path(), "src/main.rs", USES_WITH_POOL);
+    write(
+        tmp.path(),
+        ".cargo/config.toml",
+        "[build]\ntarget-dir = \"out\"\n",
+    );
+    write(tmp.path(), "out/debug/build/generated.rs", USES_WITH_POOL);
+
+    let output = run_upgrade(tmp.path(), &["--to", "0.6.0", "--apply"]);
+    assert!(output.status.success(), "{}", report(&output));
+    assert!(
+        read(tmp.path(), "src/main.rs").contains("with_pool_untracked("),
+        "app source is still migrated:\n{}",
+        stdout_of(&output)
+    );
+    assert!(
+        read(tmp.path(), "out/debug/build/generated.rs").contains("with_pool(pool.clone())"),
+        "a committed target-dir redirect is build output too:\n{}",
+        stdout_of(&output)
+    );
+}
+
+#[test]
+fn a_module_named_like_a_redirected_target_directory_is_still_migrated() {
+    // The exclusion follows the *configured path*, not the name. With the target
+    // directory redirected to `out/`, an unrelated `src/out/mod.rs` is ordinary
+    // app code and must be migrated like any other module.
+    let tmp = app("0.5.0");
+    write(tmp.path(), "src/main.rs", "fn main() {}\n");
+    write(tmp.path(), "src/out/mod.rs", USES_WITH_POOL);
+    write(
+        tmp.path(),
+        ".cargo/config.toml",
+        "[build]\ntarget-dir = \"out\"\n",
+    );
+
+    let output = run_upgrade(tmp.path(), &["--to", "0.6.0", "--apply"]);
+    assert!(output.status.success(), "{}", report(&output));
+    assert!(
+        read(tmp.path(), "src/out/mod.rs").contains("with_pool_untracked("),
+        "only the configured path is build output, not the name:\n{}",
+        stdout_of(&output)
     );
 }

--- a/autumn-cli/tests/integration/upgrade_codemod.rs
+++ b/autumn-cli/tests/integration/upgrade_codemod.rs
@@ -2073,3 +2073,89 @@ fn a_locally_defined_type_is_not_verified_by_another_crates_trait() {
         stdout_of(&output)
     );
 }
+
+#[test]
+fn a_qualified_receiver_is_vetoed_by_a_same_pathed_handwritten_type() {
+    // Crate `api` generates `repositories::PgAuditRepository`; crate `tools`
+    // writes its own type at the same module path and calls it with that path.
+    // Matching the qualifier against generated declarations alone accepted the
+    // wrong crate's evidence.
+    let tmp = TempDir::new().expect("tempdir");
+    write(
+        tmp.path(),
+        "Cargo.toml",
+        "[workspace]\nmembers = [\"api\", \"tools\"]\n",
+    );
+    for member in ["api", "tools"] {
+        write(
+            tmp.path(),
+            &format!("{member}/Cargo.toml"),
+            &format!(
+                "[package]\nname = \"{member}\"\nversion = \"0.1.0\"\nedition = \"2024\"\n\n\
+                 [dependencies]\nautumn-web = \"0.5.0\"\n"
+            ),
+        );
+    }
+    write(
+        tmp.path(),
+        "api/src/repositories.rs",
+        "use autumn_web::prelude::*;\n\n\
+         #[repository]\npub trait AuditRepository {\n    fn noop(&self);\n}\n",
+    );
+    write(
+        tmp.path(),
+        "tools/src/repositories.rs",
+        "pub struct PgAuditRepository;\n\n\
+         impl PgAuditRepository {\n    \
+         pub fn with_pool(_pool: Pool) -> Self {\n        Self\n    }\n}\n",
+    );
+    write(
+        tmp.path(),
+        "tools/src/lib.rs",
+        "pub mod repositories;\n\n\
+         pub fn build(pool: Pool) -> repositories::PgAuditRepository {\n    \
+         repositories::PgAuditRepository::with_pool(pool)\n}\n",
+    );
+
+    let output = run_upgrade(tmp.path(), &["--to", "0.6.0", "--apply"]);
+    assert!(output.status.success(), "{}", report(&output));
+    assert!(
+        read(tmp.path(), "tools/src/lib.rs")
+            .contains("repositories::PgAuditRepository::with_pool(pool)"),
+        "a hand-written type at the same module path makes the qualifier ambiguous:\n{}",
+        stdout_of(&output)
+    );
+}
+
+#[test]
+fn a_target_directory_pointing_outside_its_crate_is_still_excluded() {
+    // `target-dir = "../../build"` puts the output beside the workspace root,
+    // not under the crate that configured it. Carrying the override only while
+    // descending never reaches that sibling directory.
+    let tmp = app("0.5.0");
+    write(tmp.path(), "src/main.rs", USES_WITH_POOL);
+    write(
+        tmp.path(),
+        "tools/helper/Cargo.toml",
+        "[package]\nname = \"helper\"\nversion = \"0.1.0\"\nedition = \"2024\"\n",
+    );
+    write(
+        tmp.path(),
+        "tools/helper/.cargo/config.toml",
+        "[build]\ntarget-dir = \"../../build\"\n",
+    );
+    write(tmp.path(), "build/debug/generated.rs", USES_WITH_POOL);
+
+    let output = run_upgrade(tmp.path(), &["--to", "0.6.0", "--apply"]);
+    assert!(output.status.success(), "{}", report(&output));
+    assert!(
+        read(tmp.path(), "src/main.rs").contains("with_pool_untracked("),
+        "app source is still migrated:\n{}",
+        stdout_of(&output)
+    );
+    assert!(
+        read(tmp.path(), "build/debug/generated.rs").contains("with_pool(pool.clone())"),
+        "a target directory outside the declaring crate is still build output:\n{}",
+        stdout_of(&output)
+    );
+}

--- a/autumn-cli/tests/integration/upgrade_codemod.rs
+++ b/autumn-cli/tests/integration/upgrade_codemod.rs
@@ -370,6 +370,10 @@ fn json_output_is_machine_readable() {
     assert_eq!(value["to"], "0.6.0");
     assert_eq!(value["applied"], false);
     assert_eq!(value["rewritten_sites"], 2);
+    assert_eq!(
+        value["written_sites"], 0,
+        "a preview plans sites without writing any"
+    );
     let confidences: Vec<&str> = value["migrations"]
         .as_array()
         .expect("migrations array")

--- a/autumn-cli/tests/integration/upgrade_codemod.rs
+++ b/autumn-cli/tests/integration/upgrade_codemod.rs
@@ -1237,3 +1237,56 @@ fn a_symlinked_source_directory_is_reported_rather_than_ignored() {
         );
     }
 }
+
+#[test]
+fn running_inside_a_member_resolves_the_inherited_workspace_version() {
+    // `autumn upgrade` pointed at a member, not the workspace root. The
+    // member's only declaration is `{ workspace = true }`, and the entry it
+    // inherits lives one directory *up* — outside the scanned tree. Cargo walks
+    // up to find it; refusing to do so aborted over a version Cargo resolves.
+    let tmp = TempDir::new().expect("tempdir");
+    write(
+        tmp.path(),
+        "Cargo.toml",
+        "[workspace]\nmembers = [\"api\"]\n\n\
+         [workspace.dependencies]\nautumn-web = \"0.5.0\"\n",
+    );
+    write(
+        tmp.path(),
+        "api/Cargo.toml",
+        "[package]\nname = \"api\"\nversion = \"0.1.0\"\nedition = \"2024\"\n\n\
+         [dependencies]\nautumn-web = { workspace = true }\n",
+    );
+    write(tmp.path(), "api/src/lib.rs", USES_WITH_POOL);
+
+    let member = tmp.path().join("api");
+    let output = run_upgrade(&member, &["--to", "0.6.0", "--apply"]);
+    assert!(output.status.success(), "{}", report(&output));
+    assert!(
+        read(tmp.path(), "api/src/lib.rs").contains("with_pool_untracked("),
+        "the inherited 0.5.0 puts the member in range:\n{}",
+        stdout_of(&output)
+    );
+}
+
+#[test]
+fn an_unresolvable_inherited_dependency_asks_for_from() {
+    // `{ workspace = true }` with no enclosing workspace to resolve it. The
+    // manifest would not build, so guessing a range for it is not an option.
+    let tmp = TempDir::new().expect("tempdir");
+    write(
+        tmp.path(),
+        "Cargo.toml",
+        "[package]\nname = \"demo\"\nversion = \"0.1.0\"\nedition = \"2024\"\n\n\
+         [dependencies]\nautumn-web = { workspace = true }\n",
+    );
+    write(tmp.path(), "src/main.rs", USES_WITH_POOL);
+
+    let output = run_upgrade(tmp.path(), &["--to", "0.6.0", "--apply"]);
+    assert!(!output.status.success(), "{}", report(&output));
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("--from"),
+        "{}",
+        report(&output),
+    );
+}

--- a/autumn-cli/tests/integration/upgrade_codemod.rs
+++ b/autumn-cli/tests/integration/upgrade_codemod.rs
@@ -2582,3 +2582,98 @@ fn a_source_replacement_split_across_config_levels_is_followed() {
         stdout_of(&output)
     );
 }
+
+#[test]
+fn a_nested_config_inherits_the_level_above_it() {
+    // Codex review on #2231: the recursion passed the scan root's map instead of
+    // the one merged at the current directory, so `tools/helper` never saw the
+    // `[source.vendored]` that `tools` defines.
+    let tmp = app("0.5.0");
+    write(tmp.path(), "src/main.rs", USES_WITH_POOL);
+    write(
+        tmp.path(),
+        "tools/.cargo/config.toml",
+        "[source.vendored]\ndirectory = 'third-party'\n",
+    );
+    write(
+        tmp.path(),
+        "tools/helper/Cargo.toml",
+        "[package]\nname = \"helper\"\nversion = \"0.1.0\"\nedition = \"2024\"\n",
+    );
+    write(
+        tmp.path(),
+        "tools/helper/.cargo/config.toml",
+        "[source.crates-io]\nreplace-with = 'vendored'\n",
+    );
+    write(
+        tmp.path(),
+        "tools/third-party/some-crate/src/lib.rs",
+        USES_WITH_POOL,
+    );
+
+    let output = run_upgrade(tmp.path(), &["--to", "0.6.0", "--apply"]);
+    assert!(output.status.success(), "{}", report(&output));
+    assert!(
+        read(tmp.path(), "tools/third-party/some-crate/src/lib.rs")
+            .contains("with_pool(pool.clone())"),
+        "the nested config inherits the definition above it:\n{}",
+        stdout_of(&output)
+    );
+    assert!(
+        read(tmp.path(), "src/main.rs").contains("with_pool_untracked("),
+        "and app source is still migrated:\n{}",
+        stdout_of(&output)
+    );
+}
+
+#[test]
+fn a_disconnected_replacement_chain_excludes_nothing() {
+    // Codex review on #2231: seeding the traversal from every `replace-with`
+    // edge made `vendored` active because an unreferenced `unused` pointed at
+    // it — which excluded the application's own `src/` and migrated nothing.
+    let tmp = app("0.5.0");
+    write(tmp.path(), "src/main.rs", USES_WITH_POOL);
+    write(
+        tmp.path(),
+        ".cargo/config.toml",
+        "[source.unused]\nreplace-with = 'vendored'\n\n\
+         [source.vendored]\ndirectory = 'src'\n",
+    );
+
+    let output = run_upgrade(tmp.path(), &["--to", "0.6.0", "--apply"]);
+    assert!(output.status.success(), "{}", report(&output));
+    assert!(
+        read(tmp.path(), "src/main.rs").contains("with_pool_untracked("),
+        "nothing replaces crates-io, so nothing is vendored:\n{}",
+        stdout_of(&output)
+    );
+}
+
+#[test]
+fn a_vendored_git_source_is_still_excluded() {
+    // `cargo vendor` writes a URL-keyed source for a git dependency, and that
+    // key is a source Cargo really consults — it must keep seeding traversal.
+    let tmp = app("0.5.0");
+    write(tmp.path(), "src/main.rs", USES_WITH_POOL);
+    write(
+        tmp.path(),
+        ".cargo/config.toml",
+        "[source.\"git+https://github.com/example/dep\"]\n\
+         git = 'https://github.com/example/dep'\n\
+         replace-with = 'vendored-sources'\n\n\
+         [source.vendored-sources]\ndirectory = 'third-party'\n",
+    );
+    write(
+        tmp.path(),
+        "third-party/some-crate/src/lib.rs",
+        USES_WITH_POOL,
+    );
+
+    let output = run_upgrade(tmp.path(), &["--to", "0.6.0", "--apply"]);
+    assert!(output.status.success(), "{}", report(&output));
+    assert!(
+        read(tmp.path(), "third-party/some-crate/src/lib.rs").contains("with_pool(pool.clone())"),
+        "a vendored git source is still a vendor directory:\n{}",
+        stdout_of(&output)
+    );
+}

--- a/autumn-cli/tests/integration/upgrade_codemod.rs
+++ b/autumn-cli/tests/integration/upgrade_codemod.rs
@@ -2159,3 +2159,61 @@ fn a_target_directory_pointing_outside_its_crate_is_still_excluded() {
         stdout_of(&output)
     );
 }
+
+#[test]
+fn a_syntactically_invalid_file_is_skipped_not_rewritten() {
+    // `let = …;` tokenises perfectly well — balanced delimiters, valid tokens —
+    // but it is not valid Rust. Accepting the token stream as proof of validity
+    // meant rewriting a file the compiler will reject anyway, and counting it
+    // as migrated.
+    let tmp = app("0.5.0");
+    write(tmp.path(), "src/main.rs", USES_WITH_POOL);
+    write(
+        tmp.path(),
+        "src/broken.rs",
+        "#[repository]\npub trait PostRepository { fn noop(&self); }\n\n\
+         pub fn build(pool: Pool) {\n    let = PgPostRepository::with_pool(pool);\n}\n",
+    );
+
+    let output = run_upgrade(tmp.path(), &["--to", "0.6.0", "--apply"]);
+    assert!(output.status.success(), "{}", report(&output));
+    assert!(
+        read(tmp.path(), "src/broken.rs").contains("let = PgPostRepository::with_pool(pool);"),
+        "a file that is not valid Rust must be left alone:\n{}",
+        stdout_of(&output)
+    );
+    let stdout = stdout_of(&output);
+    assert!(
+        stdout.contains("src/broken.rs"),
+        "and reported under Skipped:\n{stdout}"
+    );
+    assert!(
+        read(tmp.path(), "src/main.rs").contains("with_pool_untracked("),
+        "one unparsable file does not stop the rest:\n{stdout}"
+    );
+}
+
+#[test]
+fn an_unparsable_member_manifest_fails_detection() {
+    // A member whose `Cargo.toml` cannot be parsed may well be the oldest crate
+    // in the workspace. Reading it as "declares nothing" let a newer sibling
+    // pick the floor and skip the migration its sources still need.
+    let tmp = TempDir::new().expect("tempdir");
+    write(
+        tmp.path(),
+        "Cargo.toml",
+        "[package]\nname = \"demo\"\nversion = \"0.1.0\"\nedition = \"2024\"\n\n\
+         [dependencies]\nautumn-web = \"0.6.0\"\n",
+    );
+    write(tmp.path(), "src/main.rs", "fn main() {}\n");
+    write(tmp.path(), "member/Cargo.toml", "[package\nname = broken\n");
+    write(tmp.path(), "member/src/lib.rs", USES_WITH_POOL);
+
+    let output = run_upgrade(tmp.path(), &["--to", "0.6.0", "--apply"]);
+    assert!(!output.status.success(), "{}", report(&output));
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("--from"),
+        "a manifest that cannot be read is not evidence of absence:\n{}",
+        report(&output)
+    );
+}

--- a/autumn-cli/tests/integration/upgrade_codemod.rs
+++ b/autumn-cli/tests/integration/upgrade_codemod.rs
@@ -2217,3 +2217,39 @@ fn an_unparsable_member_manifest_fails_detection() {
         report(&output)
     );
 }
+
+#[test]
+fn a_config_inside_build_output_does_not_exclude_app_source() {
+    // Target-directory discovery walks the tree looking for `.cargo/config.toml`.
+    // A populated target tree is huge, and anything inside it is build output --
+    // including a config that got copied there. Descending into a directory
+    // already known to be output let such a file exclude `src/` itself.
+    let tmp = app("0.5.0");
+    write(tmp.path(), "src/main.rs", USES_WITH_POOL);
+    write(
+        tmp.path(),
+        ".cargo/config.toml",
+        "[build]\ntarget-dir = \"out\"\n",
+    );
+    write(tmp.path(), "out/debug/generated.rs", USES_WITH_POOL);
+    // A stray config inside the output tree, naming the app's own source.
+    write(
+        tmp.path(),
+        "out/debug/vendored/.cargo/config.toml",
+        // Three levels up from `out/debug/vendored` is the project root.
+        "[build]\ntarget-dir = \"../../../src\"\n",
+    );
+
+    let output = run_upgrade(tmp.path(), &["--to", "0.6.0", "--apply"]);
+    assert!(output.status.success(), "{}", report(&output));
+    assert!(
+        read(tmp.path(), "src/main.rs").contains("with_pool_untracked("),
+        "app source must not be excluded by a config found inside build output:\n{}",
+        stdout_of(&output)
+    );
+    assert!(
+        read(tmp.path(), "out/debug/generated.rs").contains("with_pool(pool.clone())"),
+        "and the configured output directory is still excluded:\n{}",
+        stdout_of(&output)
+    );
+}

--- a/autumn-cli/tests/integration/upgrade_codemod.rs
+++ b/autumn-cli/tests/integration/upgrade_codemod.rs
@@ -1085,3 +1085,70 @@ fn an_aliased_path_dependency_is_still_ambiguous() {
         report(&output),
     );
 }
+
+#[test]
+fn a_dev_only_dependency_still_records_the_version() {
+    // A test-support crate depends on autumn-web only for its tests — and its
+    // `tests/` are scanned and rewritten, so it has to get a vote.
+    let tmp = TempDir::new().expect("tempdir");
+    write(
+        tmp.path(),
+        "Cargo.toml",
+        "[package]\nname = \"demo\"\nversion = \"0.1.0\"\nedition = \"2024\"\n\n\
+         [dev-dependencies]\nautumn-web = \"0.5.0\"\n",
+    );
+    write(tmp.path(), "tests/repo.rs", USES_WITH_POOL);
+
+    let output = run_upgrade(tmp.path(), &["--to", "0.6.0", "--apply"]);
+    assert!(output.status.success(), "{}", report(&output));
+    assert!(read(tmp.path(), "tests/repo.rs").contains("with_pool_untracked("));
+}
+
+#[test]
+fn an_older_dev_dependency_decides_the_floor_against_a_newer_normal_one() {
+    let tmp = TempDir::new().expect("tempdir");
+    write(
+        tmp.path(),
+        "Cargo.toml",
+        "[package]\nname = \"demo\"\nversion = \"0.1.0\"\nedition = \"2024\"\n\n\
+         [dependencies]\nautumn-web = \"0.6.0\"\n\n\
+         [dev-dependencies]\nautumn-web = \"0.5.0\"\n",
+    );
+    write(tmp.path(), "tests/repo.rs", USES_WITH_POOL);
+
+    let output = run_upgrade(tmp.path(), &["--to", "0.6.0", "--apply"]);
+    assert!(output.status.success(), "{}", report(&output));
+    assert!(
+        read(tmp.path(), "tests/repo.rs").contains("with_pool_untracked("),
+        "the older dev-dependency must decide the floor:\n{}",
+        stdout_of(&output)
+    );
+}
+
+#[test]
+fn an_app_on_a_release_candidate_is_migrated_to_the_release() {
+    // Autumn ships release candidates (the migration-guide gate handles
+    // `## [0.7.0-rc.1]` sections), so this is a real upgrade path: the
+    // candidate precedes the release and still needs its migrations.
+    let tmp = app("0.5.0-rc.1");
+    write(tmp.path(), "src/main.rs", USES_WITH_POOL);
+
+    let output = run_upgrade(tmp.path(), &["--to", "0.6.0", "--apply"]);
+    assert!(output.status.success(), "{}", report(&output));
+    assert!(read(tmp.path(), "src/main.rs").contains("with_pool_untracked("));
+}
+
+#[test]
+fn an_app_on_the_release_candidate_of_the_target_still_gets_that_release() {
+    // 0.6.0-rc.1 -> 0.6.0: equal triples, but the candidate is behind.
+    let tmp = app("0.6.0-rc.1");
+    write(tmp.path(), "src/main.rs", USES_WITH_POOL);
+
+    let output = run_upgrade(tmp.path(), &["--to", "0.6.0", "--apply"]);
+    assert!(output.status.success(), "{}", report(&output));
+    assert!(
+        read(tmp.path(), "src/main.rs").contains("with_pool_untracked("),
+        "a candidate of the target release is still behind it:\n{}",
+        stdout_of(&output)
+    );
+}

--- a/autumn-cli/tests/integration/upgrade_codemod.rs
+++ b/autumn-cli/tests/integration/upgrade_codemod.rs
@@ -535,8 +535,8 @@ fn a_file_with_both_rewritable_and_macro_sites_gets_both_treatments() {
     write(
         tmp.path(),
         "src/main.rs",
-        "pub fn a(pool: Pool) -> Repo {\n    PgRepo::with_pool(pool)\n}\n\n\
-         pub fn b(pool: Pool) {\n    make_repo! { PgRepo::with_pool(pool) }\n}\n",
+        "pub fn a(pool: Pool) -> Repo {\n    PgPostRepository::with_pool(pool)\n}\n\n\
+         pub fn b(pool: Pool) {\n    make_repo! { PgPostRepository::with_pool(pool) }\n}\n",
     );
 
     let output = run_upgrade(tmp.path(), &["--to", "0.6.0", "--apply"]);
@@ -544,11 +544,11 @@ fn a_file_with_both_rewritable_and_macro_sites_gets_both_treatments() {
 
     let after = read(tmp.path(), "src/main.rs");
     assert!(
-        after.contains("PgRepo::with_pool_untracked(pool)\n}"),
+        after.contains("PgPostRepository::with_pool_untracked(pool)\n}"),
         "the reachable site is rewritten:\n{after}"
     );
     assert!(
-        after.contains("make_repo! { PgRepo::with_pool(pool) }"),
+        after.contains("make_repo! { PgPostRepository::with_pool(pool) }"),
         "the macro body is left alone:\n{after}"
     );
     let out = stdout_of(&output);
@@ -566,7 +566,7 @@ fn a_function_reference_that_is_never_called_is_reported_not_skipped() {
     write(
         tmp.path(),
         "src/main.rs",
-        "pub fn a(xs: Vec<Pool>) {\n    xs.into_iter().map(PgRepo::with_pool);\n}\n",
+        "pub fn a(xs: Vec<Pool>) {\n    xs.into_iter().map(PgPostRepository::with_pool);\n}\n",
     );
 
     let output = run_upgrade(tmp.path(), &["--to", "0.6.0", "--apply"]);
@@ -575,7 +575,7 @@ fn a_function_reference_that_is_never_called_is_reported_not_skipped() {
     assert!(out.contains("src/main.rs:2"), "{out}");
     assert!(out.contains("referenced without being called"), "{out}");
     assert!(
-        read(tmp.path(), "src/main.rs").contains("map(PgRepo::with_pool)"),
+        read(tmp.path(), "src/main.rs").contains("map(PgPostRepository::with_pool)"),
         "a reference is reported, never rewritten"
     );
 }
@@ -719,7 +719,7 @@ fn a_preview_whose_every_site_is_manual_does_not_offer_apply() {
     write(
         tmp.path(),
         "src/lib.rs",
-        "pub fn f(pool: Pool) {\n    make_repo! { PgRepo::with_pool(pool) }\n}\n",
+        "pub fn f(pool: Pool) {\n    make_repo! { PgPostRepository::with_pool(pool) }\n}\n",
     );
 
     let output = run_upgrade(tmp.path(), &["--to", "0.6.0"]);
@@ -913,4 +913,62 @@ fn an_unrelated_type_with_the_same_associated_function_is_reported_not_rewritten
         out.contains("receiver is not a generated repository"),
         "and the reason is given: {out}"
     );
+}
+
+#[test]
+fn an_ambiguous_member_requirement_fails_detection_instead_of_being_ignored() {
+    // Root says 0.6.0, one member declares `<0.6` — a requirement with no
+    // usable floor. Dropping that member and trusting the root would migrate
+    // nothing while scanning its 0.5.x source, which is what refusing
+    // upper-bound-only requirements exists to prevent.
+    let tmp = TempDir::new().expect("tempdir");
+    write(
+        tmp.path(),
+        "Cargo.toml",
+        "[workspace]\nmembers = [\"api\", \"legacy\"]\n\n\
+         [workspace.dependencies]\nautumn-web = \"0.6.0\"\n",
+    );
+    write(
+        tmp.path(),
+        "api/Cargo.toml",
+        "[package]\nname = \"api\"\nversion = \"0.1.0\"\nedition = \"2024\"\n",
+    );
+    write(tmp.path(), "api/src/lib.rs", "pub fn f() {}\n");
+    write(
+        tmp.path(),
+        "legacy/Cargo.toml",
+        "[package]\nname = \"legacy\"\nversion = \"0.1.0\"\nedition = \"2024\"\n\n\
+         [dependencies]\nautumn-web = \"<0.6\"\n",
+    );
+    write(tmp.path(), "legacy/src/lib.rs", USES_WITH_POOL);
+
+    let output = run_upgrade(tmp.path(), &["--to", "0.6.0", "--apply"]);
+    assert!(!output.status.success(), "{}", report(&output));
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("--from"),
+        "{}",
+        report(&output),
+    );
+    assert!(
+        read(tmp.path(), "legacy/src/lib.rs").contains("with_pool(pool.clone())"),
+        "nothing is rewritten while the range is a guess"
+    );
+}
+
+#[test]
+fn a_target_specific_dependency_declaration_is_a_declaration() {
+    // Cargo honours `[target.'cfg(unix)'.dependencies]`, so reporting "cannot
+    // determine the version" for one would be wrong.
+    let tmp = TempDir::new().expect("tempdir");
+    write(
+        tmp.path(),
+        "Cargo.toml",
+        "[package]\nname = \"demo\"\nversion = \"0.1.0\"\nedition = \"2024\"\n\n\
+         [target.'cfg(unix)'.dependencies]\nautumn-web = \"0.5.0\"\n",
+    );
+    write(tmp.path(), "src/main.rs", USES_WITH_POOL);
+
+    let output = run_upgrade(tmp.path(), &["--to", "0.6.0", "--apply"]);
+    assert!(output.status.success(), "{}", report(&output));
+    assert!(read(tmp.path(), "src/main.rs").contains("with_pool_untracked("));
 }

--- a/autumn-cli/tests/integration/upgrade_codemod.rs
+++ b/autumn-cli/tests/integration/upgrade_codemod.rs
@@ -1929,3 +1929,100 @@ fn a_qualified_repository_attribute_is_recognised() {
         stdout_of(&output)
     );
 }
+
+#[test]
+fn a_same_named_type_in_another_module_is_not_verified_by_the_real_one() {
+    // `#[repository] trait AuditRepository` in `repositories` makes
+    // `PgAuditRepository` a generated type *there*. An app is free to have an
+    // unrelated type of the same name elsewhere, and a call written against
+    // that one names the module it came from.
+    let tmp = app("0.5.0");
+    write(
+        tmp.path(),
+        "src/repositories.rs",
+        "use autumn_web::prelude::*;\n\n\
+         #[repository]\npub trait AuditRepository {\n    fn noop(&self);\n}\n",
+    );
+    write(
+        tmp.path(),
+        "src/custom.rs",
+        "pub struct PgAuditRepository;\n\n\
+         impl PgAuditRepository {\n    \
+         pub fn with_pool(_pool: Pool) -> Self {\n        Self\n    }\n}\n",
+    );
+    write(
+        tmp.path(),
+        "src/main.rs",
+        "mod custom;\nmod repositories;\n\n\
+         pub fn build(pool: Pool) -> custom::PgAuditRepository {\n    \
+         custom::PgAuditRepository::with_pool(pool)\n}\n",
+    );
+
+    let output = run_upgrade(tmp.path(), &["--to", "0.6.0", "--apply"]);
+    assert!(output.status.success(), "{}", report(&output));
+    assert!(
+        read(tmp.path(), "src/main.rs").contains("custom::PgAuditRepository::with_pool(pool)"),
+        "a receiver qualified with a module that generates nothing must not be rewritten:\n{}",
+        stdout_of(&output)
+    );
+}
+
+#[test]
+fn a_module_qualified_generated_receiver_is_still_rewritten() {
+    // The common way to write it once the trait lives in its own module. This
+    // must keep working: scoping the check must not cost the ordinary path.
+    let tmp = app("0.5.0");
+    write(
+        tmp.path(),
+        "src/repositories.rs",
+        "use autumn_web::prelude::*;\n\n\
+         #[repository]\npub trait PostRepository {\n    fn noop(&self);\n}\n",
+    );
+    write(
+        tmp.path(),
+        "src/main.rs",
+        "mod repositories;\n\n\
+         pub fn a(pool: Pool) -> repositories::PgPostRepository {\n    \
+         repositories::PgPostRepository::with_pool(pool)\n}\n\n\
+         pub fn b(pool: Pool) -> crate::repositories::PgPostRepository {\n    \
+         crate::repositories::PgPostRepository::with_pool(pool)\n}\n",
+    );
+
+    let output = run_upgrade(tmp.path(), &["--to", "0.6.0", "--apply"]);
+    assert!(output.status.success(), "{}", report(&output));
+    let after = read(tmp.path(), "src/main.rs");
+    assert!(
+        after.contains("repositories::PgPostRepository::with_pool_untracked(pool)"),
+        "a module-qualified generated receiver is still the generated type:\n{}",
+        stdout_of(&output)
+    );
+    assert_eq!(
+        after.matches("with_pool_untracked").count(),
+        2,
+        "both the relative and the `crate::` spelling:\n{after}"
+    );
+}
+
+#[test]
+fn an_inline_module_qualifier_matching_the_declaration_is_rewritten() {
+    // The trait declared in an inline `mod` block, called with that module as
+    // the qualifier from the file's top level.
+    let tmp = app("0.5.0");
+    write(
+        tmp.path(),
+        "src/main.rs",
+        "use autumn_web::prelude::*;\n\n\
+         mod repositories {\n    \
+         #[repository]\n    pub trait PostRepository {\n        fn noop(&self);\n    }\n}\n\n\
+         pub fn build(pool: Pool) -> repositories::PgPostRepository {\n    \
+         repositories::PgPostRepository::with_pool(pool)\n}\n",
+    );
+
+    let output = run_upgrade(tmp.path(), &["--to", "0.6.0", "--apply"]);
+    assert!(output.status.success(), "{}", report(&output));
+    assert!(
+        read(tmp.path(), "src/main.rs").contains("with_pool_untracked(pool)"),
+        "{}",
+        stdout_of(&output)
+    );
+}

--- a/autumn-cli/tests/integration/upgrade_codemod.rs
+++ b/autumn-cli/tests/integration/upgrade_codemod.rs
@@ -1581,3 +1581,85 @@ fn a_module_named_like_a_redirected_target_directory_is_still_migrated() {
         stdout_of(&output)
     );
 }
+
+#[test]
+fn a_nested_crate_redirects_its_own_target_directory() {
+    // Cargo reads `.cargo/config.toml` from the invocation directory upward, so
+    // a nested crate redirects its *own* output. Resolving the redirect once at
+    // the scan root left `tools/helper/build/` looking like app source.
+    let tmp = app("0.5.0");
+    write(tmp.path(), "src/main.rs", USES_WITH_POOL);
+    write(
+        tmp.path(),
+        "tools/helper/Cargo.toml",
+        "[package]\nname = \"helper\"\nversion = \"0.1.0\"\nedition = \"2024\"\n",
+    );
+    write(
+        tmp.path(),
+        "tools/helper/.cargo/config.toml",
+        "[build]\ntarget-dir = \"build\"\n",
+    );
+    write(tmp.path(), "tools/helper/src/main.rs", USES_WITH_POOL);
+    write(
+        tmp.path(),
+        "tools/helper/build/debug/generated.rs",
+        USES_WITH_POOL,
+    );
+
+    let output = run_upgrade(tmp.path(), &["--to", "0.6.0", "--apply"]);
+    assert!(output.status.success(), "{}", report(&output));
+    assert!(
+        read(tmp.path(), "tools/helper/src/main.rs").contains("with_pool_untracked("),
+        "the nested crate's own source is still app code:\n{}",
+        stdout_of(&output)
+    );
+    assert!(
+        read(tmp.path(), "tools/helper/build/debug/generated.rs")
+            .contains("with_pool(pool.clone())"),
+        "the nested crate's configured output directory is build output:\n{}",
+        stdout_of(&output)
+    );
+    assert!(
+        read(tmp.path(), "src/main.rs").contains("with_pool_untracked("),
+        "and the redirect does not leak upward:\n{}",
+        stdout_of(&output)
+    );
+}
+
+#[test]
+fn an_environment_target_redirect_wins_over_a_nested_config() {
+    // `CARGO_TARGET_DIR` overrides every `.cargo/config.toml`, so a nested
+    // crate's `target-dir` is not in effect at all when it is set — that
+    // directory is ordinary source and must be migrated like any other.
+    let tmp = app("0.5.0");
+    write(tmp.path(), "src/main.rs", "fn main() {}\n");
+    write(
+        tmp.path(),
+        "tools/helper/Cargo.toml",
+        "[package]\nname = \"helper\"\nversion = \"0.1.0\"\nedition = \"2024\"\n",
+    );
+    write(
+        tmp.path(),
+        "tools/helper/.cargo/config.toml",
+        "[build]\ntarget-dir = \"build\"\n",
+    );
+    write(tmp.path(), "tools/helper/build/mod.rs", USES_WITH_POOL);
+    write(tmp.path(), "out/debug/generated.rs", USES_WITH_POOL);
+
+    let output = run_upgrade_with_env(
+        tmp.path(),
+        &["--to", "0.6.0", "--apply"],
+        &[("CARGO_TARGET_DIR", "out")],
+    );
+    assert!(output.status.success(), "{}", report(&output));
+    assert!(
+        read(tmp.path(), "tools/helper/build/mod.rs").contains("with_pool_untracked("),
+        "the overridden config is not in effect:\n{}",
+        stdout_of(&output)
+    );
+    assert!(
+        read(tmp.path(), "out/debug/generated.rs").contains("with_pool(pool.clone())"),
+        "the environment redirect is where output actually lands:\n{}",
+        stdout_of(&output)
+    );
+}

--- a/autumn-cli/tests/integration/upgrade_codemod.rs
+++ b/autumn-cli/tests/integration/upgrade_codemod.rs
@@ -1663,3 +1663,42 @@ fn an_environment_target_redirect_wins_over_a_nested_config() {
         stdout_of(&output)
     );
 }
+
+#[test]
+fn a_nested_workspaces_member_resolves_against_its_own_workspace() {
+    // A whole workspace sitting inside the scanned tree. Its member inherits
+    // with the literal key, and the entry lives in `tools/ws/Cargo.toml` --
+    // *between* the member and the scan root. Resolving inheritance from the
+    // scan root's ancestors instead of the member's finds nothing, and an
+    // unresolved literal `autumn-web` is treated as a declaration with no
+    // readable version, which fails detection for the entire run.
+    let tmp = TempDir::new().expect("tempdir");
+    write(
+        tmp.path(),
+        "Cargo.toml",
+        "[package]\nname = \"demo\"\nversion = \"0.1.0\"\nedition = \"2024\"\n\n\
+         [dependencies]\nautumn-web = \"0.6.0\"\n",
+    );
+    write(tmp.path(), "src/main.rs", "fn main() {}\n");
+    write(
+        tmp.path(),
+        "tools/ws/Cargo.toml",
+        "[workspace]\nmembers = [\"api\"]\n\n\
+         [workspace.dependencies]\nautumn-web = \"0.5.0\"\n",
+    );
+    write(
+        tmp.path(),
+        "tools/ws/api/Cargo.toml",
+        "[package]\nname = \"api\"\nversion = \"0.1.0\"\nedition = \"2024\"\n\n\
+         [dependencies]\nautumn-web = { workspace = true }\n",
+    );
+    write(tmp.path(), "tools/ws/api/src/lib.rs", USES_WITH_POOL);
+
+    let output = run_upgrade(tmp.path(), &["--to", "0.6.0", "--apply"]);
+    assert!(output.status.success(), "{}", report(&output));
+    assert!(
+        read(tmp.path(), "tools/ws/api/src/lib.rs").contains("with_pool_untracked("),
+        "the nested workspace's own entry records 0.5.0:\n{}",
+        report(&output)
+    );
+}

--- a/autumn-cli/tests/integration/upgrade_codemod.rs
+++ b/autumn-cli/tests/integration/upgrade_codemod.rs
@@ -69,7 +69,22 @@ fn app(version: &str) -> TempDir {
 }
 
 /// The 0.6.0 rename's call sites, as an app on 0.5.x would have written them.
+///
+/// The `#[repository]` traits are part of the fixture, not decoration: they are
+/// what makes `PgPostRepository` and `PgCommentRepository` generated types
+/// rather than names that merely look like them, and the codemod refuses to
+/// rewrite a receiver no scanned trait accounts for.
 const USES_WITH_POOL: &str = r"use autumn_web::prelude::*;
+
+#[repository]
+pub trait PostRepository {
+    fn noop(&self);
+}
+
+#[repository]
+pub trait CommentRepository {
+    fn noop(&self);
+}
 
 pub fn build(pool: Pool) -> PostRepository {
     // Historically this was `with_pool`.
@@ -539,7 +554,8 @@ fn a_file_with_both_rewritable_and_macro_sites_gets_both_treatments() {
     write(
         tmp.path(),
         "src/main.rs",
-        "pub fn a(pool: Pool) -> Repo {\n    PgPostRepository::with_pool(pool)\n}\n\n\
+        "#[repository]\npub trait PostRepository {\n    fn noop(&self);\n}\n\n\
+         pub fn a(pool: Pool) -> Repo {\n    PgPostRepository::with_pool(pool)\n}\n\n\
          pub fn b(pool: Pool) {\n    make_repo! { PgPostRepository::with_pool(pool) }\n}\n",
     );
 
@@ -557,7 +573,9 @@ fn a_file_with_both_rewritable_and_macro_sites_gets_both_treatments() {
     );
     let out = stdout_of(&output);
     assert!(
-        out.contains("src/main.rs:6"),
+        // The `#[repository]` trait the fixture declares occupies the first
+        // five lines, so the macro site sits at 11.
+        out.contains("src/main.rs:11"),
         "the macro site is named: {out}"
     );
 }
@@ -748,7 +766,8 @@ fn a_same_named_framework_builder_method_is_never_rewritten() {
     write(
         tmp.path(),
         "src/main.rs",
-        "pub fn setup(state: AppState, pool: Pool) -> AppState {\n\
+        "#[repository]\npub trait PostRepository {\n    fn noop(&self);\n}\n\n\
+         pub fn setup(state: AppState, pool: Pool) -> AppState {\n\
         \x20   let repo = PgPostRepository::with_pool(pool.clone());\n\
         \x20   drop(repo);\n\
         \x20   state.with_pool(pool)\n\
@@ -1811,5 +1830,75 @@ fn a_bare_wildcard_requirement_still_has_no_floor() {
         String::from_utf8_lossy(&output.stderr).contains("--from"),
         "{}",
         report(&output)
+    );
+}
+
+/// A `#[repository]` trait, which is what makes `Pg{Trait}` a generated type.
+fn repository_trait(name: &str) -> String {
+    format!(
+        "use autumn_web::prelude::*;\n\n\
+         #[repository]\npub trait {name} {{\n    fn noop(&self);\n}}\n"
+    )
+}
+
+#[test]
+fn a_receiver_no_repository_trait_generates_is_reported_not_rewritten() {
+    // `PgAuditRepository` follows the generated naming convention exactly, but
+    // nothing in this app declares `#[repository] trait AuditRepository`, so the
+    // type is the app's own. Rewriting it produces a call to a method that does
+    // not exist; the convention alone is not evidence.
+    let tmp = app("0.5.0");
+    write(
+        tmp.path(),
+        "src/repositories.rs",
+        &repository_trait("PostRepository"),
+    );
+    write(
+        tmp.path(),
+        "src/audit.rs",
+        "pub struct PgAuditRepository;\n\n\
+         impl PgAuditRepository {\n    \
+         pub fn with_pool(_pool: Pool) -> Self {\n        Self\n    }\n}\n\n\
+         pub fn build(pool: Pool) -> PgAuditRepository {\n    \
+         PgAuditRepository::with_pool(pool)\n}\n",
+    );
+
+    let output = run_upgrade(tmp.path(), &["--to", "0.6.0", "--apply"]);
+    assert!(output.status.success(), "{}", report(&output));
+    assert!(
+        read(tmp.path(), "src/audit.rs").contains("PgAuditRepository::with_pool(pool)"),
+        "an app's own type must not be rewritten:\n{}",
+        stdout_of(&output)
+    );
+    let stdout = stdout_of(&output);
+    assert!(
+        stdout.contains("src/audit.rs:10"),
+        "and it must be reported, not silently skipped:\n{stdout}"
+    );
+}
+
+#[test]
+fn a_receiver_backed_by_a_repository_trait_in_another_file_is_rewritten() {
+    // The trait and the call site normally live in different modules, so the
+    // evidence has to be collected across the whole scan rather than per file.
+    let tmp = app("0.5.0");
+    write(
+        tmp.path(),
+        "src/repositories.rs",
+        &repository_trait("PostRepository"),
+    );
+    write(
+        tmp.path(),
+        "src/routes.rs",
+        "pub fn build(pool: Pool) -> PgPostRepository {\n    \
+         PgPostRepository::with_pool(pool)\n}\n",
+    );
+
+    let output = run_upgrade(tmp.path(), &["--to", "0.6.0", "--apply"]);
+    assert!(output.status.success(), "{}", report(&output));
+    assert!(
+        read(tmp.path(), "src/routes.rs").contains("with_pool_untracked(pool)"),
+        "a trait declared elsewhere in the app still generates this type:\n{}",
+        stdout_of(&output)
     );
 }

--- a/autumn-cli/tests/integration/upgrade_codemod.rs
+++ b/autumn-cli/tests/integration/upgrade_codemod.rs
@@ -787,3 +787,68 @@ fn every_pre_target_release_in_range_is_reported_not_just_the_newest() {
         );
     }
 }
+
+#[test]
+fn a_virtual_workspace_whose_members_declare_the_dependency_is_migrated() {
+    // A virtual root has no `[dependencies]` and no `[workspace.dependencies]`;
+    // each member carries its own `autumn-web` line. Reading only the root
+    // would abort an ordinary layout with "cannot tell which version".
+    let tmp = TempDir::new().expect("tempdir");
+    write(
+        tmp.path(),
+        "Cargo.toml",
+        "[workspace]\nmembers = [\"api\", \"worker\"]\n",
+    );
+    for member in ["api", "worker"] {
+        write(
+            tmp.path(),
+            &format!("{member}/Cargo.toml"),
+            &format!(
+                "[package]\nname = \"{member}\"\nversion = \"0.1.0\"\nedition = \"2024\"\n\n\
+                 [dependencies]\nautumn-web = \"0.5.0\"\n"
+            ),
+        );
+        write(tmp.path(), &format!("{member}/src/lib.rs"), USES_WITH_POOL);
+    }
+
+    let output = run_upgrade(tmp.path(), &["--to", "0.6.0", "--apply"]);
+    assert!(output.status.success(), "{}", report(&output));
+    for member in ["api", "worker"] {
+        assert!(
+            read(tmp.path(), &format!("{member}/src/lib.rs")).contains("with_pool_untracked("),
+            "{member} declares autumn-web itself and must be migrated"
+        );
+    }
+}
+
+#[test]
+fn members_on_different_versions_take_the_oldest_floor() {
+    // The member that is furthest behind decides: a migration the other member
+    // is already past finds nothing to do there, while taking the newest floor
+    // would strand the one that is genuinely behind.
+    let tmp = TempDir::new().expect("tempdir");
+    write(
+        tmp.path(),
+        "Cargo.toml",
+        "[workspace]\nmembers = [\"old\", \"new\"]\n",
+    );
+    for (member, version) in [("old", "0.5.0"), ("new", "0.6.0")] {
+        write(
+            tmp.path(),
+            &format!("{member}/Cargo.toml"),
+            &format!(
+                "[package]\nname = \"{member}\"\nversion = \"0.1.0\"\nedition = \"2024\"\n\n\
+                 [dependencies]\nautumn-web = \"{version}\"\n"
+            ),
+        );
+    }
+    write(tmp.path(), "old/src/lib.rs", USES_WITH_POOL);
+    write(tmp.path(), "new/src/lib.rs", "pub fn f() {}\n");
+
+    let output = run_upgrade(tmp.path(), &["--to", "0.6.0", "--apply"]);
+    assert!(output.status.success(), "{}", report(&output));
+    assert!(
+        read(tmp.path(), "old/src/lib.rs").contains("with_pool_untracked("),
+        "the member still on 0.5.0 is migrated"
+    );
+}

--- a/autumn-cli/tests/integration/upgrade_codemod.rs
+++ b/autumn-cli/tests/integration/upgrade_codemod.rs
@@ -1017,3 +1017,71 @@ fn a_path_dependency_without_a_version_fails_detection() {
     assert!(forced.status.success(), "{}", report(&forced));
     assert!(read(tmp.path(), "vendored/src/lib.rs").contains("with_pool_untracked("));
 }
+
+#[test]
+fn an_aliased_dependency_declaration_is_recognised() {
+    // Cargo's renamed-dependency form. An exact-key lookup reads this as "no
+    // autumn-web here", which in a workspace lets a sibling pick the floor for
+    // a crate whose sources are rewritten anyway.
+    let tmp = TempDir::new().expect("tempdir");
+    write(
+        tmp.path(),
+        "Cargo.toml",
+        "[package]\nname = \"demo\"\nversion = \"0.1.0\"\nedition = \"2024\"\n\n\
+         [dependencies]\nautumn_web = { package = \"autumn-web\", version = \"0.5.0\" }\n",
+    );
+    write(tmp.path(), "src/main.rs", USES_WITH_POOL);
+
+    let output = run_upgrade(tmp.path(), &["--to", "0.6.0", "--apply"]);
+    assert!(output.status.success(), "{}", report(&output));
+    assert!(
+        read(tmp.path(), "src/main.rs").contains("with_pool_untracked("),
+        "an aliased declaration still records the version"
+    );
+}
+
+#[test]
+fn the_oldest_target_specific_requirement_decides_the_floor() {
+    // Disjoint target tables at different versions. Taking the first match
+    // could pick 0.6.0 and skip the codemod, while the source scan rewrites the
+    // 0.5.x target's `#[cfg]` code regardless.
+    let tmp = TempDir::new().expect("tempdir");
+    write(
+        tmp.path(),
+        "Cargo.toml",
+        "[package]\nname = \"demo\"\nversion = \"0.1.0\"\nedition = \"2024\"\n\n\
+         [target.'cfg(windows)'.dependencies]\nautumn-web = \"0.6.0\"\n\n\
+         [target.'cfg(unix)'.dependencies]\nautumn-web = \"0.5.0\"\n",
+    );
+    write(tmp.path(), "src/main.rs", USES_WITH_POOL);
+
+    let output = run_upgrade(tmp.path(), &["--to", "0.6.0", "--apply"]);
+    assert!(output.status.success(), "{}", report(&output));
+    assert!(
+        read(tmp.path(), "src/main.rs").contains("with_pool_untracked("),
+        "the older target requirement must decide the floor:\n{}",
+        stdout_of(&output)
+    );
+}
+
+#[test]
+fn an_aliased_path_dependency_is_still_ambiguous() {
+    // The alias must not become a way to slip a version-less declaration past
+    // the ambiguity check.
+    let tmp = TempDir::new().expect("tempdir");
+    write(
+        tmp.path(),
+        "Cargo.toml",
+        "[package]\nname = \"demo\"\nversion = \"0.1.0\"\nedition = \"2024\"\n\n\
+         [dependencies]\nautumn_web = { package = \"autumn-web\", path = \"../autumn\" }\n",
+    );
+    write(tmp.path(), "src/main.rs", USES_WITH_POOL);
+
+    let output = run_upgrade(tmp.path(), &["--to", "0.6.0", "--apply"]);
+    assert!(!output.status.success(), "{}", report(&output));
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("--from"),
+        "{}",
+        report(&output),
+    );
+}

--- a/autumn-cli/tests/integration/upgrade_codemod.rs
+++ b/autumn-cli/tests/integration/upgrade_codemod.rs
@@ -1347,3 +1347,121 @@ fn tool_and_vcs_metadata_directories_are_still_skipped() {
         "and metadata is skipped quietly, not reported on every run"
     );
 }
+
+#[test]
+fn a_hidden_workspace_member_still_decides_the_floor() {
+    // The source walk now scans non-metadata hidden directories, so a crate
+    // under one gets its sources rewritten. The manifest walk has to agree:
+    // reading only the root's 0.6.0 selects no migration at all, and the hidden
+    // crate's call sites — scanned, planned, and left alone — stay on the old
+    // name with the report claiming there was nothing to do.
+    let tmp = TempDir::new().expect("tempdir");
+    write(
+        tmp.path(),
+        "Cargo.toml",
+        "[package]\nname = \"demo\"\nversion = \"0.1.0\"\nedition = \"2024\"\n\n\
+         [dependencies]\nautumn-web = \"0.6.0\"\n",
+    );
+    write(tmp.path(), "src/main.rs", "fn main() {}\n");
+    write(
+        tmp.path(),
+        ".generated-app/Cargo.toml",
+        "[package]\nname = \"generated\"\nversion = \"0.1.0\"\nedition = \"2024\"\n\n\
+         [dependencies]\nautumn-web = \"0.5.0\"\n",
+    );
+    write(tmp.path(), ".generated-app/src/lib.rs", USES_WITH_POOL);
+
+    let output = run_upgrade(tmp.path(), &["--to", "0.6.0", "--apply"]);
+    assert!(output.status.success(), "{}", report(&output));
+    assert!(
+        read(tmp.path(), ".generated-app/src/lib.rs").contains("with_pool_untracked("),
+        "a hidden crate the walk scans must also vote on the floor:\n{}",
+        stdout_of(&output)
+    );
+}
+
+#[test]
+fn an_inherited_aliased_dependency_resolves_through_the_workspace_key() {
+    // The member says `autumn = { workspace = true }` — no literal `autumn-web`
+    // key and no `package` field of its own. Only the workspace entry names the
+    // real crate. Matching the member's key against that entry is the only way
+    // to see the dependency Cargo resolves without trouble.
+    let tmp = TempDir::new().expect("tempdir");
+    write(
+        tmp.path(),
+        "Cargo.toml",
+        "[workspace]\nmembers = [\"api\"]\n\n\
+         [workspace.dependencies]\n\
+         autumn = { package = \"autumn-web\", version = \"0.5.0\" }\n",
+    );
+    write(
+        tmp.path(),
+        "api/Cargo.toml",
+        "[package]\nname = \"api\"\nversion = \"0.1.0\"\nedition = \"2024\"\n\n\
+         [dependencies]\nautumn = { workspace = true }\n",
+    );
+    write(tmp.path(), "api/src/lib.rs", USES_WITH_POOL);
+
+    let member = tmp.path().join("api");
+    let output = run_upgrade(&member, &["--to", "0.6.0", "--apply"]);
+    assert!(output.status.success(), "{}", report(&output));
+    assert!(
+        read(tmp.path(), "api/src/lib.rs").contains("with_pool_untracked("),
+        "the aliased workspace entry records 0.5.0:\n{}",
+        stdout_of(&output)
+    );
+}
+
+#[test]
+fn an_inherited_dependency_on_another_crate_is_not_mistaken_for_autumn_web() {
+    // Resolving inherited entries by key must not turn every `{ workspace =
+    // true }` line into an autumn-web declaration: this app inherits `serde`
+    // and declares autumn-web outright, and the serde entry has no bearing on
+    // the floor.
+    let tmp = TempDir::new().expect("tempdir");
+    write(
+        tmp.path(),
+        "Cargo.toml",
+        "[workspace]\nmembers = [\"api\"]\n\n\
+         [workspace.dependencies]\nserde = \"1\"\n",
+    );
+    write(
+        tmp.path(),
+        "api/Cargo.toml",
+        "[package]\nname = \"api\"\nversion = \"0.1.0\"\nedition = \"2024\"\n\n\
+         [dependencies]\nserde = { workspace = true }\nautumn-web = \"0.5.0\"\n",
+    );
+    write(tmp.path(), "api/src/lib.rs", USES_WITH_POOL);
+
+    let member = tmp.path().join("api");
+    let output = run_upgrade(&member, &["--to", "0.6.0", "--apply"]);
+    assert!(output.status.success(), "{}", report(&output));
+    assert!(
+        read(tmp.path(), "api/src/lib.rs").contains("with_pool_untracked("),
+        "an inherited serde must not make the autumn-web version unreadable:\n{}",
+        stdout_of(&output)
+    );
+}
+
+#[test]
+fn a_path_typo_is_reported_as_a_bad_path_not_a_missing_dependency() {
+    // `recorded_version` on a nonexistent directory finds nothing, so running
+    // it first turned an ordinary typo into "add an `autumn-web` dependency to
+    // Cargo.toml" — advice about a manifest that is not there either. The scan
+    // root is checked before anything is read from it.
+    let tmp = TempDir::new().expect("tempdir");
+
+    let output = run_upgrade(tmp.path(), &["no-such-directory", "--to", "0.6.0"]);
+    assert!(!output.status.success(), "{}", report(&output));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("is not a readable directory"),
+        "a path typo names the path:\n{}",
+        report(&output)
+    );
+    assert!(
+        !stderr.contains("Add an `autumn-web` dependency"),
+        "and does not send the user to a manifest that does not exist:\n{}",
+        report(&output)
+    );
+}

--- a/autumn-cli/tests/integration/upgrade_codemod.rs
+++ b/autumn-cli/tests/integration/upgrade_codemod.rs
@@ -2451,3 +2451,87 @@ fn the_nearest_cargo_config_decides_the_target_directory() {
         stdout_of(&output)
     );
 }
+
+#[test]
+fn the_environment_form_of_build_target_dir_is_honoured() {
+    // Codex review on #2231: Cargo maps `CARGO_BUILD_TARGET_DIR` to
+    // `build.target-dir`. Only the special `CARGO_TARGET_DIR` was read, so a
+    // build redirected the documented config-env way had its output scanned.
+    let tmp = app("0.5.0");
+    write(tmp.path(), "src/main.rs", USES_WITH_POOL);
+    write(tmp.path(), "out/debug/generated.rs", USES_WITH_POOL);
+
+    let output = run_upgrade_with_env(
+        tmp.path(),
+        &["--to", "0.6.0", "--apply"],
+        &[(
+            "CARGO_BUILD_TARGET_DIR",
+            tmp.path().join("out").to_str().expect("utf-8 path"),
+        )],
+    );
+    assert!(output.status.success(), "{}", report(&output));
+    assert!(
+        read(tmp.path(), "out/debug/generated.rs").contains("with_pool(pool.clone())"),
+        "`CARGO_BUILD_TARGET_DIR` redirects the target directory:\n{}",
+        stdout_of(&output)
+    );
+    assert!(
+        read(tmp.path(), "src/main.rs").contains("with_pool_untracked("),
+        "and app source is still migrated:\n{}",
+        stdout_of(&output)
+    );
+}
+
+#[test]
+fn a_defined_but_unreplaced_source_does_not_exclude_anything() {
+    // Codex review on #2231: `[source.x] directory = …` does nothing until
+    // something is replaced *with* it. Treating every definition as vendored
+    // let a config that merely names `src` silently drop the whole app.
+    let tmp = app("0.5.0");
+    write(tmp.path(), "src/main.rs", USES_WITH_POOL);
+    write(
+        tmp.path(),
+        ".cargo/config.toml",
+        "[source.archive]\ndirectory = 'src'\n",
+    );
+
+    let output = run_upgrade(tmp.path(), &["--to", "0.6.0", "--apply"]);
+    assert!(output.status.success(), "{}", report(&output));
+    assert!(
+        read(tmp.path(), "src/main.rs").contains("with_pool_untracked("),
+        "an inactive source definition is not a vendor directory:\n{}",
+        stdout_of(&output)
+    );
+}
+
+#[test]
+fn a_chained_source_replacement_is_followed() {
+    // `replace-with` may point at a source that is itself a replacement.
+    let tmp = app("0.5.0");
+    write(tmp.path(), "src/main.rs", USES_WITH_POOL);
+    write(
+        tmp.path(),
+        ".cargo/config.toml",
+        "[source.crates-io]\nreplace-with = 'mirror'\n\n\
+         [source.mirror]\nreplace-with = 'vendored'\n\n\
+         [source.vendored]\ndirectory = 'third-party'\n",
+    );
+    write(
+        tmp.path(),
+        "third-party/some-crate/src/lib.rs",
+        USES_WITH_POOL,
+    );
+
+    let output = run_upgrade(tmp.path(), &["--to", "0.6.0", "--apply"]);
+    assert!(output.status.success(), "{}", report(&output));
+    assert!(
+        read(tmp.path(), "third-party/some-crate/src/lib.rs").contains("with_pool(pool.clone())"),
+        "the end of the replacement chain is the vendor directory:\n{}",
+        stdout_of(&output)
+    );
+    assert!(
+        read(tmp.path(), "src/main.rs").contains("with_pool_untracked("),
+        "and app source is still migrated:\n{}",
+        stdout_of(&output)
+    );
+}

--- a/autumn-cli/tests/integration/upgrade_codemod.rs
+++ b/autumn-cli/tests/integration/upgrade_codemod.rs
@@ -1902,3 +1902,30 @@ fn a_receiver_backed_by_a_repository_trait_in_another_file_is_rewritten() {
         stdout_of(&output)
     );
 }
+
+#[test]
+fn a_qualified_repository_attribute_is_recognised() {
+    // `#[autumn_web::repository(...)]` is what the scaffold itself emits, so
+    // this is the *common* spelling, not an exotic one. Requiring the
+    // attribute's first token to be `repository` missed it, and every call site
+    // in a scaffolded app was then classified as an unverified receiver and
+    // left on the old name.
+    let tmp = app("0.5.0");
+    write(
+        tmp.path(),
+        "src/repositories.rs",
+        "use autumn_web::prelude::*;\n\n\
+         #[autumn_web::repository(Post, table = \"posts\")]\n\
+         pub trait PostRepository {\n    fn noop(&self);\n}\n\n\
+         pub fn build(pool: Pool) -> PgPostRepository {\n    \
+         PgPostRepository::with_pool(pool)\n}\n",
+    );
+
+    let output = run_upgrade(tmp.path(), &["--to", "0.6.0", "--apply"]);
+    assert!(output.status.success(), "{}", report(&output));
+    assert!(
+        read(tmp.path(), "src/repositories.rs").contains("with_pool_untracked(pool)"),
+        "the qualified spelling generates the type just the same:\n{}",
+        stdout_of(&output)
+    );
+}

--- a/autumn-cli/tests/integration/upgrade_codemod.rs
+++ b/autumn-cli/tests/integration/upgrade_codemod.rs
@@ -1152,3 +1152,88 @@ fn an_app_on_the_release_candidate_of_the_target_still_gets_that_release() {
         stdout_of(&output)
     );
 }
+
+#[test]
+fn an_app_module_named_like_a_build_directory_is_still_migrated() {
+    // `target`, `vendor`, `tmp` name build output or third-party code only at
+    // a crate root. Under `src/` they are ordinary modules, and skipping them
+    // left the app failing to compile with nothing in the report to say why.
+    let tmp = app("0.5.0");
+    write(tmp.path(), "src/main.rs", "fn main() {}\n");
+    for module in [
+        "src/vendor/mod.rs",
+        "src/tmp/helper.rs",
+        "src/target/mod.rs",
+        "src/dist/mod.rs",
+    ] {
+        write(tmp.path(), module, USES_WITH_POOL);
+    }
+
+    let output = run_upgrade(tmp.path(), &["--to", "0.6.0", "--apply"]);
+    assert!(output.status.success(), "{}", report(&output));
+    for module in [
+        "src/vendor/mod.rs",
+        "src/tmp/helper.rs",
+        "src/target/mod.rs",
+        "src/dist/mod.rs",
+    ] {
+        assert!(
+            read(tmp.path(), module).contains("with_pool_untracked("),
+            "{module} is an app module, not a build tree"
+        );
+    }
+}
+
+#[test]
+fn build_directories_at_a_workspace_member_root_are_still_skipped() {
+    // The rule is "at a crate root", so a member's own `target/` is skipped
+    // just as the workspace root's is.
+    let tmp = TempDir::new().expect("tempdir");
+    write(
+        tmp.path(),
+        "Cargo.toml",
+        "[workspace]\nmembers = [\"api\"]\n\n\
+         [workspace.dependencies]\nautumn-web = \"0.5.0\"\n",
+    );
+    write(
+        tmp.path(),
+        "api/Cargo.toml",
+        "[package]\nname = \"api\"\nversion = \"0.1.0\"\nedition = \"2024\"\n",
+    );
+    write(tmp.path(), "api/src/lib.rs", USES_WITH_POOL);
+    write(tmp.path(), "api/target/debug/gen.rs", USES_WITH_POOL);
+
+    let output = run_upgrade(tmp.path(), &["--to", "0.6.0", "--apply"]);
+    assert!(output.status.success(), "{}", report(&output));
+    assert!(read(tmp.path(), "api/src/lib.rs").contains("with_pool_untracked("));
+    assert!(
+        read(tmp.path(), "api/target/debug/gen.rs").contains("with_pool(pool.clone())"),
+        "a member's own build output is not app source"
+    );
+}
+
+#[test]
+fn a_symlinked_source_directory_is_reported_rather_than_ignored() {
+    // A linked `src/` has `is_dir() == false`, so an extension-gated check saw
+    // nothing at all: no traversal, no report, and a run that says "nothing to
+    // change" about an app it never looked at.
+    #[cfg(not(unix))]
+    return;
+    #[cfg(unix)]
+    {
+        let tmp = app("0.5.0");
+        write(tmp.path(), "real/lib.rs", USES_WITH_POOL);
+        std::os::unix::fs::symlink(tmp.path().join("real"), tmp.path().join("src"))
+            .expect("symlink");
+
+        let output = run_upgrade(tmp.path(), &["--to", "0.6.0", "--apply"]);
+        assert!(output.status.success(), "{}", report(&output));
+        let out = stdout_of(&output);
+        assert!(out.contains("src"), "the linked directory is named: {out}");
+        assert!(out.contains("symbolic link"), "{out}");
+        assert!(
+            !out.to_lowercase().contains("nothing to change"),
+            "a linked source tree must not read as a clean app: {out}"
+        );
+    }
+}

--- a/autumn-cli/tests/integration/upgrade_codemod.rs
+++ b/autumn-cli/tests/integration/upgrade_codemod.rs
@@ -2026,3 +2026,50 @@ fn an_inline_module_qualifier_matching_the_declaration_is_rewritten() {
         stdout_of(&output)
     );
 }
+
+#[test]
+fn a_locally_defined_type_is_not_verified_by_another_crates_trait() {
+    // Two crates in one scan. `api` declares `#[repository] trait
+    // AuditRepository`, so `PgAuditRepository` is generated *there*. `tools`
+    // defines its own struct of that name and calls it unqualified. A global
+    // name set verified the wrong one.
+    let tmp = TempDir::new().expect("tempdir");
+    write(
+        tmp.path(),
+        "Cargo.toml",
+        "[workspace]\nmembers = [\"api\", \"tools\"]\n",
+    );
+    for member in ["api", "tools"] {
+        write(
+            tmp.path(),
+            &format!("{member}/Cargo.toml"),
+            &format!(
+                "[package]\nname = \"{member}\"\nversion = \"0.1.0\"\nedition = \"2024\"\n\n\
+                 [dependencies]\nautumn-web = \"0.5.0\"\n"
+            ),
+        );
+    }
+    write(
+        tmp.path(),
+        "api/src/lib.rs",
+        "use autumn_web::prelude::*;\n\n\
+         #[repository]\npub trait AuditRepository {\n    fn noop(&self);\n}\n",
+    );
+    write(
+        tmp.path(),
+        "tools/src/lib.rs",
+        "pub struct PgAuditRepository;\n\n\
+         impl PgAuditRepository {\n    \
+         pub fn with_pool(_pool: Pool) -> Self {\n        Self\n    }\n}\n\n\
+         pub fn build(pool: Pool) -> PgAuditRepository {\n    \
+         PgAuditRepository::with_pool(pool)\n}\n",
+    );
+
+    let output = run_upgrade(tmp.path(), &["--to", "0.6.0", "--apply"]);
+    assert!(output.status.success(), "{}", report(&output));
+    assert!(
+        read(tmp.path(), "tools/src/lib.rs").contains("PgAuditRepository::with_pool(pool)"),
+        "a hand-written type must not be verified by a trait elsewhere:\n{}",
+        stdout_of(&output)
+    );
+}

--- a/autumn-cli/tests/integration/upgrade_codemod.rs
+++ b/autumn-cli/tests/integration/upgrade_codemod.rs
@@ -2314,3 +2314,36 @@ fn an_unparsable_file_is_not_evidence_for_a_receiver_elsewhere() {
         stdout_of(&output)
     );
 }
+
+#[test]
+fn a_configured_vendor_directory_is_never_rewritten() {
+    // `cargo vendor third-party` puts dependency sources somewhere the `vendor`
+    // basename check never looks, and `[source.vendored-sources]` is what says
+    // where. Rewriting a third-party crate corrupts a dependency.
+    let tmp = app("0.5.0");
+    write(tmp.path(), "src/main.rs", USES_WITH_POOL);
+    write(
+        tmp.path(),
+        ".cargo/config.toml",
+        "[source.crates-io]\nreplace-with = \"vendored-sources\"\n\n\
+         [source.vendored-sources]\ndirectory = \"third-party\"\n",
+    );
+    write(
+        tmp.path(),
+        "third-party/some-crate/src/lib.rs",
+        USES_WITH_POOL,
+    );
+
+    let output = run_upgrade(tmp.path(), &["--to", "0.6.0", "--apply"]);
+    assert!(output.status.success(), "{}", report(&output));
+    assert!(
+        read(tmp.path(), "src/main.rs").contains("with_pool_untracked("),
+        "app source is still migrated:\n{}",
+        stdout_of(&output)
+    );
+    assert!(
+        read(tmp.path(), "third-party/some-crate/src/lib.rs").contains("with_pool(pool.clone())"),
+        "a configured vendor directory holds dependencies, not app code:\n{}",
+        stdout_of(&output)
+    );
+}

--- a/autumn-cli/tests/integration/upgrade_codemod.rs
+++ b/autumn-cli/tests/integration/upgrade_codemod.rs
@@ -636,6 +636,9 @@ fn an_unreadable_path_is_a_failure_not_an_empty_report() {
 
 #[test]
 fn generated_and_dependency_trees_are_never_scanned() {
+    // Hidden directories are covered separately: only *known* metadata names
+    // are skipped, because an unknown dot-directory can hold compiled source
+    // (see `source_in_a_hidden_directory_is_migrated_not_dropped`).
     let tmp = app("0.5.0");
     write(tmp.path(), "src/main.rs", "fn main() {}\n");
     for excluded in [
@@ -644,7 +647,6 @@ fn generated_and_dependency_trees_are_never_scanned() {
         "node_modules/thing/x.rs",
         "dist/out.rs",
         "tmp/scratch.rs",
-        ".cargo-cache/dep.rs",
     ] {
         write(tmp.path(), excluded, USES_WITH_POOL);
     }
@@ -657,7 +659,6 @@ fn generated_and_dependency_trees_are_never_scanned() {
         "node_modules/thing/x.rs",
         "dist/out.rs",
         "tmp/scratch.rs",
-        ".cargo-cache/dep.rs",
     ] {
         assert!(
             read(tmp.path(), excluded).contains("with_pool(pool.clone())"),
@@ -1288,5 +1289,61 @@ fn an_unresolvable_inherited_dependency_asks_for_from() {
         String::from_utf8_lossy(&output.stderr).contains("--from"),
         "{}",
         report(&output),
+    );
+}
+
+#[test]
+fn source_in_a_hidden_directory_is_migrated_not_dropped() {
+    // `#[path = ".generated/repositories.rs"] mod repositories;` is legal, and
+    // the file behind it is compiled app code. Skipping every dot-directory
+    // left it on the old API with nothing in the report to say so.
+    let tmp = app("0.5.0");
+    write(
+        tmp.path(),
+        "src/main.rs",
+        "#[path = \"../.generated/repositories.rs\"]\nmod repositories;\n\nfn main() {}\n",
+    );
+    write(tmp.path(), ".generated/repositories.rs", USES_WITH_POOL);
+
+    let output = run_upgrade(tmp.path(), &["--to", "0.6.0", "--apply"]);
+    assert!(output.status.success(), "{}", report(&output));
+    assert!(
+        read(tmp.path(), ".generated/repositories.rs").contains("with_pool_untracked("),
+        "compiled source in a hidden directory must be migrated:\n{}",
+        stdout_of(&output)
+    );
+}
+
+#[test]
+fn tool_and_vcs_metadata_directories_are_still_skipped() {
+    // The exclusion is by name now, so the dot-directories that hold metadata
+    // rather than app code stay out — without reporting noise on every run.
+    let tmp = app("0.5.0");
+    write(tmp.path(), "src/main.rs", "fn main() {}\n");
+    for metadata in [
+        ".git/hooks/x.rs",
+        ".github/scripts/x.rs",
+        ".cargo/registry/x.rs",
+        ".vscode/x.rs",
+    ] {
+        write(tmp.path(), metadata, USES_WITH_POOL);
+    }
+
+    let output = run_upgrade(tmp.path(), &["--to", "0.6.0", "--apply"]);
+    assert!(output.status.success(), "{}", report(&output));
+    for metadata in [
+        ".git/hooks/x.rs",
+        ".github/scripts/x.rs",
+        ".cargo/registry/x.rs",
+        ".vscode/x.rs",
+    ] {
+        assert!(
+            read(tmp.path(), metadata).contains("with_pool(pool.clone())"),
+            "{metadata} is metadata, not app source"
+        );
+    }
+    assert!(
+        !stdout_of(&output).contains(".git"),
+        "and metadata is skipped quietly, not reported on every run"
     );
 }

--- a/autumn-cli/tests/integration/upgrade_codemod.rs
+++ b/autumn-cli/tests/integration/upgrade_codemod.rs
@@ -1,0 +1,733 @@
+//! Integration tests for `autumn upgrade`'s app-code migration step
+//! (issue #1629).
+//!
+//! Each test scaffolds a throwaway app in a `TempDir` — a `Cargo.toml` pinning
+//! an old `autumn-web` plus a few `src/*.rs` files — and runs the real `autumn`
+//! binary against it. The fixture sources are only ever *parsed*, so they must
+//! be syntactically valid Rust but need not compile or link.
+
+use std::fs;
+use std::path::Path;
+use std::process::{Command, Output};
+
+use tempfile::TempDir;
+
+const fn autumn_bin() -> &'static str {
+    env!("CARGO_BIN_EXE_autumn")
+}
+
+fn write(root: &Path, rel: &str, contents: &str) {
+    let path = root.join(rel);
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).unwrap();
+    }
+    fs::write(path, contents).unwrap();
+}
+
+fn read(root: &Path, rel: &str) -> String {
+    fs::read_to_string(root.join(rel)).unwrap()
+}
+
+fn run_upgrade(root: &Path, args: &[&str]) -> Output {
+    Command::new(autumn_bin())
+        .arg("upgrade")
+        .args(args)
+        .current_dir(root)
+        .output()
+        .expect("failed to run autumn upgrade")
+}
+
+fn stdout_of(output: &Output) -> String {
+    String::from_utf8_lossy(&output.stdout).into_owned()
+}
+
+fn report(output: &Output) -> String {
+    format!(
+        "status: {}\nstdout:\n{}\nstderr:\n{}",
+        output.status,
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    )
+}
+
+/// An app pinned to `version` of `autumn-web`.
+fn app(version: &str) -> TempDir {
+    let tmp = TempDir::new().expect("tempdir");
+    write(
+        tmp.path(),
+        "Cargo.toml",
+        &format!(
+            "[package]\nname = \"demo\"\nversion = \"0.1.0\"\nedition = \"2024\"\n\n\
+             [dependencies]\nautumn-web = \"{version}\"\n"
+        ),
+    );
+    tmp
+}
+
+/// The 0.6.0 rename's call sites, as an app on 0.5.x would have written them.
+const USES_WITH_POOL: &str = r"use autumn_web::prelude::*;
+
+pub fn build(pool: Pool) -> PostRepository {
+    // Historically this was `with_pool`.
+    PostRepository::with_pool(pool.clone())
+}
+
+pub fn build_two(pool: Pool) -> CommentRepository {
+    let repo = CommentRepository::with_pool(pool);
+    repo
+}
+";
+
+#[test]
+fn preview_is_the_default_and_writes_nothing() {
+    let tmp = app("0.5.0");
+    write(tmp.path(), "src/main.rs", USES_WITH_POOL);
+    let before = read(tmp.path(), "src/main.rs");
+
+    let output = run_upgrade(tmp.path(), &["--to", "0.6.0"]);
+    assert!(output.status.success(), "{}", report(&output));
+
+    let out = stdout_of(&output);
+    assert!(out.contains("src/main.rs"), "{out}");
+    assert!(
+        out.contains("with_pool_untracked"),
+        "the diff shows the new name: {out}"
+    );
+    assert!(
+        out.contains("2 site"),
+        "the affected-site count is reported: {out}"
+    );
+    assert!(out.contains("--apply"), "{out}");
+    assert_eq!(
+        read(tmp.path(), "src/main.rs"),
+        before,
+        "a bare `autumn upgrade` must not write anything"
+    );
+}
+
+#[test]
+fn apply_rewrites_every_call_site() {
+    let tmp = app("0.5.0");
+    write(tmp.path(), "src/main.rs", USES_WITH_POOL);
+
+    let output = run_upgrade(tmp.path(), &["--to", "0.6.0", "--apply"]);
+    assert!(output.status.success(), "{}", report(&output));
+
+    let after = read(tmp.path(), "src/main.rs");
+    assert!(
+        !after.contains("PostRepository::with_pool("),
+        "no bare `with_pool` call site remains:\n{after}"
+    );
+    assert_eq!(
+        after.matches("with_pool_untracked(").count(),
+        2,
+        "both call sites were rewritten:\n{after}"
+    );
+    assert!(
+        after.contains("// Historically this was `with_pool`."),
+        "comments are left exactly as they were:\n{after}"
+    );
+}
+
+#[test]
+fn applying_twice_is_a_no_op() {
+    let tmp = app("0.5.0");
+    write(tmp.path(), "src/main.rs", USES_WITH_POOL);
+
+    let first = run_upgrade(tmp.path(), &["--to", "0.6.0", "--apply"]);
+    assert!(first.status.success(), "{}", report(&first));
+    let after_first = read(tmp.path(), "src/main.rs");
+
+    let second = run_upgrade(tmp.path(), &["--to", "0.6.0", "--apply"]);
+    assert!(second.status.success(), "{}", report(&second));
+    assert_eq!(
+        read(tmp.path(), "src/main.rs"),
+        after_first,
+        "a second apply must change nothing"
+    );
+    assert!(
+        stdout_of(&second)
+            .to_lowercase()
+            .contains("nothing to change"),
+        "{}",
+        report(&second)
+    );
+}
+
+#[test]
+fn an_app_that_never_used_the_api_reports_nothing_to_change() {
+    let tmp = app("0.5.0");
+    write(
+        tmp.path(),
+        "src/main.rs",
+        "fn main() {\n    println!(\"hello\");\n}\n",
+    );
+
+    let output = run_upgrade(tmp.path(), &["--to", "0.6.0"]);
+    assert!(output.status.success(), "{}", report(&output));
+    assert!(
+        stdout_of(&output)
+            .to_lowercase()
+            .contains("nothing to change"),
+        "{}",
+        report(&output)
+    );
+}
+
+#[test]
+fn macro_call_sites_are_listed_as_manual_with_file_and_line() {
+    let tmp = app("0.5.0");
+    write(
+        tmp.path(),
+        "src/lib.rs",
+        "pub fn f(pool: Pool) {\n    make_repo! { PostRepository::with_pool(pool) }\n}\n",
+    );
+
+    let output = run_upgrade(tmp.path(), &["--to", "0.6.0", "--apply"]);
+    assert!(output.status.success(), "{}", report(&output));
+
+    let out = stdout_of(&output);
+    assert!(out.contains("manual"), "{out}");
+    assert!(
+        out.contains("src/lib.rs:2"),
+        "the exact site is named: {out}"
+    );
+    assert!(out.contains("inside a macro invocation"), "{out}");
+    assert!(
+        out.contains("docs/migrations/0.6.0.md"),
+        "the guide is linked: {out}"
+    );
+    assert!(
+        read(tmp.path(), "src/lib.rs").contains("PostRepository::with_pool(pool)"),
+        "a macro body is never rewritten"
+    );
+}
+
+#[test]
+fn guide_only_changes_in_range_are_reported_with_their_guide_section() {
+    let tmp = app("0.5.0");
+    write(tmp.path(), "src/main.rs", "fn main() {}\n");
+
+    let output = run_upgrade(tmp.path(), &["--to", "0.6.0"]);
+    assert!(output.status.success(), "{}", report(&output));
+    let out = stdout_of(&output);
+    assert!(
+        out.contains("0.6.0-tenancy-jwt-secret-secretstring"),
+        "a manual change in the range is still surfaced: {out}"
+    );
+    assert!(out.contains("docs/migrations/0.6.0.md#"), "{out}");
+}
+
+#[test]
+fn the_version_range_is_read_from_the_apps_cargo_manifest() {
+    // Already on 0.6.0: the 0.6.0 migrations are behind this app, not ahead.
+    let tmp = app("0.6.0");
+    write(tmp.path(), "src/main.rs", USES_WITH_POOL);
+
+    let output = run_upgrade(tmp.path(), &["--to", "0.6.0"]);
+    assert!(output.status.success(), "{}", report(&output));
+    assert!(
+        stdout_of(&output)
+            .to_lowercase()
+            .contains("nothing to change"),
+        "{}",
+        report(&output)
+    );
+    assert!(
+        read(tmp.path(), "src/main.rs").contains("PostRepository::with_pool(pool.clone())"),
+        "nothing was rewritten"
+    );
+}
+
+#[test]
+fn an_undetectable_version_asks_for_from_instead_of_guessing() {
+    let tmp = TempDir::new().expect("tempdir");
+    write(
+        tmp.path(),
+        "Cargo.toml",
+        "[package]\nname = \"demo\"\nversion = \"0.1.0\"\nedition = \"2024\"\n",
+    );
+    write(tmp.path(), "src/main.rs", USES_WITH_POOL);
+
+    let output = run_upgrade(tmp.path(), &["--to", "0.6.0", "--apply"]);
+    assert!(!output.status.success(), "{}", report(&output));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("--from"), "{stderr}");
+    assert!(
+        read(tmp.path(), "src/main.rs").contains("PostRepository::with_pool(pool.clone())"),
+        "a run that cannot determine its range must not rewrite anything"
+    );
+}
+
+#[test]
+fn from_overrides_the_detected_version() {
+    let tmp = app("0.6.0");
+    write(tmp.path(), "src/main.rs", USES_WITH_POOL);
+
+    let output = run_upgrade(tmp.path(), &["--from", "0.5.0", "--to", "0.6.0", "--apply"]);
+    assert!(output.status.success(), "{}", report(&output));
+    assert!(read(tmp.path(), "src/main.rs").contains("with_pool_untracked("));
+}
+
+#[test]
+fn build_artifacts_and_vendored_sources_are_never_scanned() {
+    let tmp = app("0.5.0");
+    write(tmp.path(), "src/main.rs", "fn main() {}\n");
+    write(tmp.path(), "target/debug/build/gen.rs", USES_WITH_POOL);
+    write(tmp.path(), "vendor/autumn-web/src/lib.rs", USES_WITH_POOL);
+
+    let output = run_upgrade(tmp.path(), &["--to", "0.6.0", "--apply"]);
+    assert!(output.status.success(), "{}", report(&output));
+    assert!(read(tmp.path(), "target/debug/build/gen.rs").contains("with_pool(pool.clone())"));
+    assert!(read(tmp.path(), "vendor/autumn-web/src/lib.rs").contains("with_pool(pool.clone())"));
+}
+
+#[test]
+fn tests_and_examples_are_app_code_and_are_rewritten() {
+    let tmp = app("0.5.0");
+    write(tmp.path(), "src/main.rs", "fn main() {}\n");
+    write(tmp.path(), "tests/repo.rs", USES_WITH_POOL);
+    write(tmp.path(), "examples/demo.rs", USES_WITH_POOL);
+    write(tmp.path(), "benches/bench.rs", USES_WITH_POOL);
+
+    let output = run_upgrade(tmp.path(), &["--to", "0.6.0", "--apply"]);
+    assert!(output.status.success(), "{}", report(&output));
+    for file in ["tests/repo.rs", "examples/demo.rs", "benches/bench.rs"] {
+        assert!(
+            read(tmp.path(), file).contains("with_pool_untracked("),
+            "{file} is the app's own source and must be migrated"
+        );
+    }
+}
+
+#[test]
+fn a_workspace_member_is_migrated_too() {
+    let tmp = TempDir::new().expect("tempdir");
+    write(
+        tmp.path(),
+        "Cargo.toml",
+        "[workspace]\nmembers = [\"api\"]\n\n[workspace.dependencies]\nautumn-web = \"0.5.0\"\n",
+    );
+    write(
+        tmp.path(),
+        "api/Cargo.toml",
+        "[package]\nname = \"api\"\nversion = \"0.1.0\"\nedition = \"2024\"\n",
+    );
+    write(tmp.path(), "api/src/lib.rs", USES_WITH_POOL);
+
+    let output = run_upgrade(tmp.path(), &["--to", "0.6.0", "--apply"]);
+    assert!(output.status.success(), "{}", report(&output));
+    assert!(read(tmp.path(), "api/src/lib.rs").contains("with_pool_untracked("));
+}
+
+#[test]
+fn an_unparsable_file_is_skipped_and_reported_never_written() {
+    let tmp = app("0.5.0");
+    write(tmp.path(), "src/main.rs", USES_WITH_POOL);
+    write(tmp.path(), "src/broken.rs", "fn f( { this is not rust\n");
+    let broken_before = read(tmp.path(), "src/broken.rs");
+
+    let output = run_upgrade(tmp.path(), &["--to", "0.6.0", "--apply"]);
+    assert!(output.status.success(), "{}", report(&output));
+    let out = stdout_of(&output);
+    assert!(out.contains("src/broken.rs"), "the skip is reported: {out}");
+    assert_eq!(read(tmp.path(), "src/broken.rs"), broken_before);
+    assert!(
+        read(tmp.path(), "src/main.rs").contains("with_pool_untracked("),
+        "one unparsable file does not stop the rest of the migration"
+    );
+}
+
+#[test]
+fn json_output_is_machine_readable() {
+    let tmp = app("0.5.0");
+    write(tmp.path(), "src/main.rs", USES_WITH_POOL);
+
+    let output = run_upgrade(tmp.path(), &["--to", "0.6.0", "--json"]);
+    assert!(output.status.success(), "{}", report(&output));
+    let value: serde_json::Value =
+        serde_json::from_str(&stdout_of(&output)).expect("stdout is a single JSON document");
+    assert_eq!(value["from"], "0.5.0");
+    assert_eq!(value["to"], "0.6.0");
+    assert_eq!(value["applied"], false);
+    assert_eq!(value["rewritten_sites"], 2);
+    let confidences: Vec<&str> = value["migrations"]
+        .as_array()
+        .expect("migrations array")
+        .iter()
+        .map(|m| m["confidence"].as_str().expect("confidence label"))
+        .collect();
+    assert!(confidences.contains(&"auto"), "{confidences:?}");
+    assert!(confidences.contains(&"manual"), "{confidences:?}");
+}
+
+#[test]
+fn list_migrations_prints_the_registry_without_scanning() {
+    let tmp = TempDir::new().expect("tempdir");
+    let output = run_upgrade(tmp.path(), &["--list-migrations"]);
+    assert!(output.status.success(), "{}", report(&output));
+    let out = stdout_of(&output);
+    assert!(
+        out.contains("0.6.0-repository-with-pool-untracked"),
+        "{out}"
+    );
+    assert!(out.contains("auto"), "{out}");
+    assert!(out.contains("docs/migrations/0.6.0.md#"), "{out}");
+}
+
+#[test]
+fn every_registry_guide_link_resolves_to_a_real_guide_section() {
+    // The registry, the guides, and the release gate have to agree; a dangling
+    // anchor turns the `manual` list into a dead end.
+    let root = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("workspace root")
+        .to_path_buf();
+    let output = run_upgrade(&root, &["--list-migrations", "--json"]);
+    assert!(output.status.success(), "{}", report(&output));
+    let value: serde_json::Value = serde_json::from_str(&stdout_of(&output)).expect("valid JSON");
+
+    for migration in value["migrations"].as_array().expect("migrations") {
+        let id = migration["id"].as_str().expect("id");
+        let guide = migration["guide"].as_str().expect("guide");
+        let (path, anchor) = guide.split_once('#').expect("guide link carries an anchor");
+        let body = fs::read_to_string(root.join(path))
+            .unwrap_or_else(|e| panic!("{id}: cannot read {path}: {e}"));
+        let anchors: Vec<String> = body
+            .lines()
+            .filter(|line| line.starts_with("### "))
+            .map(|line| github_anchor(line.trim_start_matches("### ")))
+            .collect();
+        assert!(
+            anchors.iter().any(|a| a == anchor),
+            "{id}: {path} has no section anchored `#{anchor}`; found {anchors:?}"
+        );
+        assert!(
+            body.contains(id),
+            "{id}: {path} must name the codemod id in its `**Automation:**` label"
+        );
+    }
+}
+
+/// GitHub's heading-anchor slug: lowercase, drop everything but word
+/// characters, spaces and hyphens, then spaces to hyphens.
+fn github_anchor(heading: &str) -> String {
+    heading
+        .to_lowercase()
+        .chars()
+        .filter(|c| c.is_alphanumeric() || *c == ' ' || *c == '-' || *c == '_')
+        .collect::<String>()
+        .replace(' ', "-")
+}
+
+#[test]
+fn every_breaking_change_in_every_guide_carries_a_confidence_label() {
+    // Issue #1629 AC: "Every documented breaking change in a release is
+    // classified in its migration guide with a confidence label." The shell
+    // gate enforces this where it is load-bearing (rename-level changes); this
+    // reads the guides as a set and holds the whole repository to it.
+    let root = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("workspace root")
+        .join("docs/migrations");
+
+    let mut guides: Vec<_> = fs::read_dir(&root)
+        .expect("read docs/migrations")
+        .filter_map(Result::ok)
+        .map(|entry| entry.path())
+        .filter(|path| {
+            path.extension().is_some_and(|ext| ext == "md")
+                && !matches!(
+                    path.file_name().and_then(|name| name.to_str()),
+                    Some("README.md" | "TEMPLATE.md")
+                )
+        })
+        .collect();
+    guides.sort();
+    assert!(!guides.is_empty(), "no migration guides found in {root:?}");
+
+    let mut classified = 0usize;
+    for guide in guides {
+        let entries = breaking_entries(&fs::read_to_string(&guide).expect("read guide"));
+        assert!(
+            !entries.is_empty(),
+            "{}: no breaking-change entries found — either the guide has none, \
+             or `breaking_entries` stopped recognising the section shape and \
+             this test is now vacuous",
+            guide.display(),
+        );
+        for (heading, label) in entries {
+            classified += 1;
+            let label = label.unwrap_or_else(|| {
+                panic!(
+                    "{}: breaking change `{heading}` carries no `**Automation:**` label \
+                     (issue #1629)",
+                    guide.display()
+                )
+            });
+            assert!(
+                matches!(label.as_str(), "auto" | "review" | "manual"),
+                "{}: breaking change `{heading}` has an unknown automation label `{label}`",
+                guide.display(),
+            );
+        }
+    }
+    assert!(
+        classified >= 10,
+        "only {classified} breaking changes were read across every guide; the \
+         parser has almost certainly stopped seeing them",
+    );
+}
+
+/// Every `### ` entry under `## Breaking changes`, paired with the value of its
+/// `**Automation:**` label if it has one.
+///
+/// Fenced blocks are skipped: a guide that *shows* the convention in a sample
+/// is not declaring it.
+fn breaking_entries(body: &str) -> Vec<(String, Option<String>)> {
+    let mut entries: Vec<(String, Option<String>)> = Vec::new();
+    let mut in_breaking = false;
+    let mut in_fence = false;
+    for line in body.lines() {
+        if line.trim_start().starts_with("```") {
+            in_fence = !in_fence;
+            continue;
+        }
+        if in_fence {
+            continue;
+        }
+        if let Some(title) = line.strip_prefix("## ") {
+            in_breaking = title.trim().eq_ignore_ascii_case("Breaking changes");
+            continue;
+        }
+        if let Some(title) = line.strip_prefix("### ") {
+            if in_breaking {
+                entries.push((title.trim().to_owned(), None));
+            }
+            continue;
+        }
+        // A label written as a bullet is the same declaration a reader sees.
+        // The marker is only a marker when whitespace follows it — stripping
+        // bare `-`/`*` would eat the `**` of the label itself.
+        let trimmed = line.trim_start();
+        let body = ["- ", "* ", "+ "]
+            .iter()
+            .find_map(|marker| trimmed.strip_prefix(marker))
+            .unwrap_or(trimmed)
+            .trim_start();
+        if let Some(rest) = body.strip_prefix("**Automation:**")
+            && let Some(entry) = entries.last_mut()
+            && entry.1.is_none()
+        {
+            entry.1 = rest
+                .trim()
+                .strip_prefix('`')
+                .and_then(|rest| rest.split('`').next())
+                .map(str::to_owned);
+        }
+    }
+    entries
+}
+
+#[test]
+fn a_file_with_both_rewritable_and_macro_sites_gets_both_treatments() {
+    let tmp = app("0.5.0");
+    write(
+        tmp.path(),
+        "src/main.rs",
+        "pub fn a(pool: Pool) -> Repo {\n    Repo::with_pool(pool)\n}\n\n\
+         pub fn b(pool: Pool) {\n    make_repo! { Repo::with_pool(pool) }\n}\n",
+    );
+
+    let output = run_upgrade(tmp.path(), &["--to", "0.6.0", "--apply"]);
+    assert!(output.status.success(), "{}", report(&output));
+
+    let after = read(tmp.path(), "src/main.rs");
+    assert!(
+        after.contains("Repo::with_pool_untracked(pool)\n}"),
+        "the reachable site is rewritten:\n{after}"
+    );
+    assert!(
+        after.contains("make_repo! { Repo::with_pool(pool) }"),
+        "the macro body is left alone:\n{after}"
+    );
+    let out = stdout_of(&output);
+    assert!(
+        out.contains("src/main.rs:6"),
+        "the macro site is named: {out}"
+    );
+}
+
+#[test]
+fn a_function_reference_that_is_never_called_is_reported_not_skipped() {
+    // It stops compiling after the rename just the same, so staying silent
+    // about it would break the "nothing is silently skipped" promise.
+    let tmp = app("0.5.0");
+    write(
+        tmp.path(),
+        "src/main.rs",
+        "pub fn a(xs: Vec<Pool>) {\n    xs.into_iter().map(Repo::with_pool);\n}\n",
+    );
+
+    let output = run_upgrade(tmp.path(), &["--to", "0.6.0", "--apply"]);
+    assert!(output.status.success(), "{}", report(&output));
+    let out = stdout_of(&output);
+    assert!(out.contains("src/main.rs:2"), "{out}");
+    assert!(out.contains("referenced without being called"), "{out}");
+    assert!(
+        read(tmp.path(), "src/main.rs").contains("map(Repo::with_pool)"),
+        "a reference is reported, never rewritten"
+    );
+}
+
+#[test]
+fn a_symlinked_source_file_is_reported_rather_than_followed() {
+    let tmp = app("0.5.0");
+    write(tmp.path(), "src/real.rs", USES_WITH_POOL);
+    #[cfg(unix)]
+    std::os::unix::fs::symlink(
+        tmp.path().join("src/real.rs"),
+        tmp.path().join("src/link.rs"),
+    )
+    .expect("symlink");
+    #[cfg(not(unix))]
+    return;
+
+    let output = run_upgrade(tmp.path(), &["--to", "0.6.0", "--apply"]);
+    assert!(output.status.success(), "{}", report(&output));
+    let out = stdout_of(&output);
+    assert!(out.contains("src/link.rs"), "the link is named: {out}");
+    assert!(out.contains("symbolic link"), "{out}");
+    // The real file, reached directly, is still migrated.
+    assert!(read(tmp.path(), "src/real.rs").contains("with_pool_untracked("));
+}
+
+#[test]
+fn a_positional_path_migrates_that_directory_not_the_working_one() {
+    let outside = TempDir::new().expect("tempdir");
+    let tmp = app("0.5.0");
+    write(tmp.path(), "src/main.rs", USES_WITH_POOL);
+
+    let output = Command::new(autumn_bin())
+        .args(["upgrade", tmp.path().to_str().expect("utf-8 path")])
+        .args(["--to", "0.6.0", "--apply"])
+        .current_dir(outside.path())
+        .output()
+        .expect("failed to run autumn upgrade");
+    assert!(output.status.success(), "{}", report(&output));
+    assert!(read(tmp.path(), "src/main.rs").contains("with_pool_untracked("));
+}
+
+#[test]
+fn an_unreadable_path_is_a_failure_not_an_empty_report() {
+    // A path typo must not read as "your app is already migrated".
+    let tmp = app("0.5.0");
+    let output = run_upgrade(
+        tmp.path(),
+        &["no-such-directory", "--from", "0.5.0", "--to", "0.6.0"],
+    );
+    assert!(!output.status.success(), "{}", report(&output));
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("not a readable directory"),
+        "{}",
+        report(&output),
+    );
+}
+
+#[test]
+fn generated_and_dependency_trees_are_never_scanned() {
+    let tmp = app("0.5.0");
+    write(tmp.path(), "src/main.rs", "fn main() {}\n");
+    for excluded in [
+        "target/debug/gen.rs",
+        "vendor/dep/src/lib.rs",
+        "node_modules/thing/x.rs",
+        "dist/out.rs",
+        "tmp/scratch.rs",
+        ".cargo-cache/dep.rs",
+    ] {
+        write(tmp.path(), excluded, USES_WITH_POOL);
+    }
+
+    let output = run_upgrade(tmp.path(), &["--to", "0.6.0", "--apply"]);
+    assert!(output.status.success(), "{}", report(&output));
+    for excluded in [
+        "target/debug/gen.rs",
+        "vendor/dep/src/lib.rs",
+        "node_modules/thing/x.rs",
+        "dist/out.rs",
+        "tmp/scratch.rs",
+        ".cargo-cache/dep.rs",
+    ] {
+        assert!(
+            read(tmp.path(), excluded).contains("with_pool(pool.clone())"),
+            "{excluded} is not the app's own source and must not be rewritten"
+        );
+    }
+}
+
+#[test]
+fn an_unparsable_target_version_is_rejected_before_anything_is_scanned() {
+    let tmp = app("0.5.0");
+    write(tmp.path(), "src/main.rs", USES_WITH_POOL);
+
+    let output = run_upgrade(tmp.path(), &["--to", "banana", "--apply"]);
+    assert!(!output.status.success(), "{}", report(&output));
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("--to"),
+        "{}",
+        report(&output),
+    );
+    assert!(read(tmp.path(), "src/main.rs").contains("with_pool(pool.clone())"));
+}
+
+#[test]
+fn an_unparsable_recorded_version_asks_for_from() {
+    let tmp = TempDir::new().expect("tempdir");
+    write(
+        tmp.path(),
+        "Cargo.toml",
+        "[package]\nname = \"demo\"\nversion = \"0.1.0\"\nedition = \"2024\"\n\n\
+         [dependencies]\nautumn-web = \"*\"\n",
+    );
+    write(tmp.path(), "src/main.rs", USES_WITH_POOL);
+
+    let output = run_upgrade(tmp.path(), &["--to", "0.6.0", "--apply"]);
+    assert!(!output.status.success(), "{}", report(&output));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("--from"), "{stderr}");
+    assert!(read(tmp.path(), "src/main.rs").contains("with_pool(pool.clone())"));
+}
+
+#[test]
+fn an_already_bumped_manifest_is_told_how_to_recover() {
+    // The commonest way to see an empty range: the dependency was bumped
+    // before the codemods were run, so the app records the target release.
+    let tmp = app("0.6.0");
+    write(tmp.path(), "src/main.rs", USES_WITH_POOL);
+
+    let output = run_upgrade(tmp.path(), &["--to", "0.6.0"]);
+    assert!(output.status.success(), "{}", report(&output));
+    let out = stdout_of(&output);
+    assert!(out.contains("--from"), "the recovery is spelled out: {out}");
+}
+
+#[test]
+fn a_preview_whose_every_site_is_manual_does_not_offer_apply() {
+    // `--apply` would write nothing here, so offering it is a lie.
+    let tmp = app("0.5.0");
+    write(
+        tmp.path(),
+        "src/lib.rs",
+        "pub fn f(pool: Pool) {\n    make_repo! { Repo::with_pool(pool) }\n}\n",
+    );
+
+    let output = run_upgrade(tmp.path(), &["--to", "0.6.0"]);
+    assert!(output.status.success(), "{}", report(&output));
+    let out = stdout_of(&output);
+    assert!(
+        !out.contains("Re-run with `--apply`"),
+        "there is nothing for --apply to write: {out}"
+    );
+    assert!(out.contains("a human"), "{out}");
+}

--- a/autumn-cli/tests/integration/upgrade_codemod.rs
+++ b/autumn-cli/tests/integration/upgrade_codemod.rs
@@ -1702,3 +1702,114 @@ fn a_nested_workspaces_member_resolves_against_its_own_workspace() {
         report(&output)
     );
 }
+
+#[test]
+fn guide_locations_are_printed_as_urls_the_user_can_open() {
+    // The registry stores repo-relative paths so the release gate can check
+    // them against the tree. Printed verbatim by an installed CLI running in
+    // someone's app, `docs/migrations/0.6.0.md#...` names a file in *their*
+    // project -- a dead end at exactly the point the report is telling them to
+    // go read something.
+    let tmp = app("0.5.0");
+    write(tmp.path(), "src/main.rs", USES_WITH_POOL);
+
+    let output = run_upgrade(tmp.path(), &["--to", "0.6.0"]);
+    assert!(output.status.success(), "{}", report(&output));
+    let stdout = stdout_of(&output);
+    assert!(
+        stdout.contains(
+            "https://github.com/autumn-foundation/autumn/blob/trunk-dev/docs/migrations/0.6.0.md#"
+        ),
+        "guide locations are openable URLs:\n{stdout}"
+    );
+    assert!(
+        !stdout.contains(" docs/migrations/"),
+        "and no bare repo-relative path is left in the report:\n{stdout}"
+    );
+}
+
+#[test]
+fn list_migrations_prints_guide_urls_too() {
+    let tmp = app("0.5.0");
+    let output = run_upgrade(tmp.path(), &["--list-migrations"]);
+    assert!(output.status.success(), "{}", report(&output));
+    let stdout = stdout_of(&output);
+    assert!(
+        stdout.contains("https://github.com/autumn-foundation/autumn/blob/trunk-dev/docs/"),
+        "{stdout}"
+    );
+    assert!(!stdout.contains(" docs/migrations/"), "{stdout}");
+}
+
+#[test]
+fn json_keeps_the_repo_relative_guide_and_adds_the_url() {
+    // Automation pinned to the registry's own paths keeps working; the URL is
+    // additive.
+    let tmp = app("0.5.0");
+    write(tmp.path(), "src/main.rs", USES_WITH_POOL);
+
+    let output = run_upgrade(tmp.path(), &["--to", "0.6.0", "--json"]);
+    assert!(output.status.success(), "{}", report(&output));
+    let parsed: serde_json::Value = serde_json::from_str(&stdout_of(&output)).expect("json");
+    let migration = &parsed["migrations"][0];
+    assert!(
+        migration["guide"]
+            .as_str()
+            .expect("guide")
+            .starts_with("docs/migrations/"),
+        "{parsed:#}"
+    );
+    assert!(
+        migration["guide_url"]
+            .as_str()
+            .expect("guide_url")
+            .starts_with("https://github.com/autumn-foundation/autumn/blob/trunk-dev/docs/"),
+        "{parsed:#}"
+    );
+}
+
+#[test]
+fn a_wildcard_version_requirement_has_a_floor() {
+    // `autumn-web = "0.5.*"` is a documented Cargo requirement whose floor is
+    // unambiguously 0.5.0 -- the same floor as `"0.5"`, which is already
+    // accepted. Refusing it sent the user to `--from` for no reason.
+    let tmp = TempDir::new().expect("tempdir");
+    write(
+        tmp.path(),
+        "Cargo.toml",
+        "[package]\nname = \"demo\"\nversion = \"0.1.0\"\nedition = \"2024\"\n\n\
+         [dependencies]\nautumn-web = \"0.5.*\"\n",
+    );
+    write(tmp.path(), "src/main.rs", USES_WITH_POOL);
+
+    let output = run_upgrade(tmp.path(), &["--to", "0.6.0", "--apply"]);
+    assert!(output.status.success(), "{}", report(&output));
+    assert!(
+        read(tmp.path(), "src/main.rs").contains("with_pool_untracked("),
+        "0.5.* floors at 0.5.0:\n{}",
+        report(&output)
+    );
+}
+
+#[test]
+fn a_bare_wildcard_requirement_still_has_no_floor() {
+    // `*` accepts every release, so it says nothing about which one the app is
+    // on. Reading it as 0.0.0 would silently select every migration ever
+    // written; asking for `--from` is the honest answer.
+    let tmp = TempDir::new().expect("tempdir");
+    write(
+        tmp.path(),
+        "Cargo.toml",
+        "[package]\nname = \"demo\"\nversion = \"0.1.0\"\nedition = \"2024\"\n\n\
+         [dependencies]\nautumn-web = \"*\"\n",
+    );
+    write(tmp.path(), "src/main.rs", USES_WITH_POOL);
+
+    let output = run_upgrade(tmp.path(), &["--to", "0.6.0", "--apply"]);
+    assert!(!output.status.success(), "{}", report(&output));
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("--from"),
+        "{}",
+        report(&output)
+    );
+}

--- a/autumn-cli/tests/integration/upgrade_codemod.rs
+++ b/autumn-cli/tests/integration/upgrade_codemod.rs
@@ -2535,3 +2535,50 @@ fn a_chained_source_replacement_is_followed() {
         stdout_of(&output)
     );
 }
+
+#[test]
+fn a_source_replacement_split_across_config_levels_is_followed() {
+    // Codex review on #2231, and a regression from making activation per-file:
+    // Cargo merges `[source.*]` across the hierarchy, so `replace-with` in the
+    // project config can name a source another level defines. Resolving each
+    // file alone found neither half, and vendored dependencies were rewritten.
+    let outer = TempDir::new().expect("tempdir");
+    write(
+        outer.path(),
+        "app/Cargo.toml",
+        "[package]\nname = \"demo\"\nversion = \"0.1.0\"\nedition = \"2024\"\n\n\
+         [dependencies]\nautumn-web = \"0.5.0\"\n",
+    );
+    write(outer.path(), "app/src/main.rs", USES_WITH_POOL);
+    // The activation lives here …
+    write(
+        outer.path(),
+        "app/.cargo/config.toml",
+        "[source.crates-io]\nreplace-with = 'vendored'\n",
+    );
+    // … and the directory it names lives a level up, relative to *that* file.
+    write(
+        outer.path(),
+        ".cargo/config.toml",
+        "[source.vendored]\ndirectory = 'app/third-party'\n",
+    );
+    write(
+        outer.path(),
+        "app/third-party/some-crate/src/lib.rs",
+        USES_WITH_POOL,
+    );
+
+    let output = run_upgrade(&outer.path().join("app"), &["--to", "0.6.0", "--apply"]);
+    assert!(output.status.success(), "{}", report(&output));
+    assert!(
+        read(outer.path(), "app/third-party/some-crate/src/lib.rs")
+            .contains("with_pool(pool.clone())"),
+        "the merged replacement names a vendor directory:\n{}",
+        stdout_of(&output)
+    );
+    assert!(
+        read(outer.path(), "app/src/main.rs").contains("with_pool_untracked("),
+        "and app source is still migrated:\n{}",
+        stdout_of(&output)
+    );
+}

--- a/autumn-cli/tests/integration/upgrade_codemod.rs
+++ b/autumn-cli/tests/integration/upgrade_codemod.rs
@@ -972,3 +972,48 @@ fn a_target_specific_dependency_declaration_is_a_declaration() {
     assert!(output.status.success(), "{}", report(&output));
     assert!(read(tmp.path(), "src/main.rs").contains("with_pool_untracked("));
 }
+
+#[test]
+fn a_path_dependency_without_a_version_fails_detection() {
+    // `autumn-web = { path = "../autumn" }` is a declaration with no version
+    // to read — and a vendored checkout is exactly the population the 0.6.0
+    // rename affects. Letting the sibling's 0.6.0 decide the floor would
+    // migrate this crate's source against a version nobody checked.
+    let tmp = TempDir::new().expect("tempdir");
+    write(
+        tmp.path(),
+        "Cargo.toml",
+        "[workspace]\nmembers = [\"api\", \"vendored\"]\n",
+    );
+    write(
+        tmp.path(),
+        "api/Cargo.toml",
+        "[package]\nname = \"api\"\nversion = \"0.1.0\"\nedition = \"2024\"\n\n\
+         [dependencies]\nautumn-web = \"0.6.0\"\n",
+    );
+    write(tmp.path(), "api/src/lib.rs", "pub fn f() {}\n");
+    write(
+        tmp.path(),
+        "vendored/Cargo.toml",
+        "[package]\nname = \"vendored\"\nversion = \"0.1.0\"\nedition = \"2024\"\n\n\
+         [dependencies]\nautumn-web = { path = \"../../autumn\" }\n",
+    );
+    write(tmp.path(), "vendored/src/lib.rs", USES_WITH_POOL);
+
+    let output = run_upgrade(tmp.path(), &["--to", "0.6.0", "--apply"]);
+    assert!(!output.status.success(), "{}", report(&output));
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("--from"),
+        "{}",
+        report(&output),
+    );
+    assert!(
+        read(tmp.path(), "vendored/src/lib.rs").contains("with_pool(pool.clone())"),
+        "nothing is rewritten while the range is a guess"
+    );
+
+    // With the range stated explicitly, the same tree migrates.
+    let forced = run_upgrade(tmp.path(), &["--from", "0.5.0", "--to", "0.6.0", "--apply"]);
+    assert!(forced.status.success(), "{}", report(&forced));
+    assert!(read(tmp.path(), "vendored/src/lib.rs").contains("with_pool_untracked("));
+}

--- a/autumn-cli/tests/integration/upgrade_codemod.rs
+++ b/autumn-cli/tests/integration/upgrade_codemod.rs
@@ -69,11 +69,11 @@ const USES_WITH_POOL: &str = r"use autumn_web::prelude::*;
 
 pub fn build(pool: Pool) -> PostRepository {
     // Historically this was `with_pool`.
-    PostRepository::with_pool(pool.clone())
+    PgPostRepository::with_pool(pool.clone())
 }
 
 pub fn build_two(pool: Pool) -> CommentRepository {
-    let repo = CommentRepository::with_pool(pool);
+    let repo = PgCommentRepository::with_pool(pool);
     repo
 }
 ";
@@ -115,7 +115,7 @@ fn apply_rewrites_every_call_site() {
 
     let after = read(tmp.path(), "src/main.rs");
     assert!(
-        !after.contains("PostRepository::with_pool("),
+        !after.contains("PgPostRepository::with_pool("),
         "no bare `with_pool` call site remains:\n{after}"
     );
     assert_eq!(
@@ -180,7 +180,7 @@ fn macro_call_sites_are_listed_as_manual_with_file_and_line() {
     write(
         tmp.path(),
         "src/lib.rs",
-        "pub fn f(pool: Pool) {\n    make_repo! { PostRepository::with_pool(pool) }\n}\n",
+        "pub fn f(pool: Pool) {\n    make_repo! { PgPostRepository::with_pool(pool) }\n}\n",
     );
 
     let output = run_upgrade(tmp.path(), &["--to", "0.6.0", "--apply"]);
@@ -198,7 +198,7 @@ fn macro_call_sites_are_listed_as_manual_with_file_and_line() {
         "the guide is linked: {out}"
     );
     assert!(
-        read(tmp.path(), "src/lib.rs").contains("PostRepository::with_pool(pool)"),
+        read(tmp.path(), "src/lib.rs").contains("PgPostRepository::with_pool(pool)"),
         "a macro body is never rewritten"
     );
 }
@@ -234,7 +234,7 @@ fn the_version_range_is_read_from_the_apps_cargo_manifest() {
         report(&output)
     );
     assert!(
-        read(tmp.path(), "src/main.rs").contains("PostRepository::with_pool(pool.clone())"),
+        read(tmp.path(), "src/main.rs").contains("PgPostRepository::with_pool(pool.clone())"),
         "nothing was rewritten"
     );
 }
@@ -254,7 +254,7 @@ fn an_undetectable_version_asks_for_from_instead_of_guessing() {
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(stderr.contains("--from"), "{stderr}");
     assert!(
-        read(tmp.path(), "src/main.rs").contains("PostRepository::with_pool(pool.clone())"),
+        read(tmp.path(), "src/main.rs").contains("PgPostRepository::with_pool(pool.clone())"),
         "a run that cannot determine its range must not rewrite anything"
     );
 }
@@ -535,8 +535,8 @@ fn a_file_with_both_rewritable_and_macro_sites_gets_both_treatments() {
     write(
         tmp.path(),
         "src/main.rs",
-        "pub fn a(pool: Pool) -> Repo {\n    Repo::with_pool(pool)\n}\n\n\
-         pub fn b(pool: Pool) {\n    make_repo! { Repo::with_pool(pool) }\n}\n",
+        "pub fn a(pool: Pool) -> Repo {\n    PgRepo::with_pool(pool)\n}\n\n\
+         pub fn b(pool: Pool) {\n    make_repo! { PgRepo::with_pool(pool) }\n}\n",
     );
 
     let output = run_upgrade(tmp.path(), &["--to", "0.6.0", "--apply"]);
@@ -544,11 +544,11 @@ fn a_file_with_both_rewritable_and_macro_sites_gets_both_treatments() {
 
     let after = read(tmp.path(), "src/main.rs");
     assert!(
-        after.contains("Repo::with_pool_untracked(pool)\n}"),
+        after.contains("PgRepo::with_pool_untracked(pool)\n}"),
         "the reachable site is rewritten:\n{after}"
     );
     assert!(
-        after.contains("make_repo! { Repo::with_pool(pool) }"),
+        after.contains("make_repo! { PgRepo::with_pool(pool) }"),
         "the macro body is left alone:\n{after}"
     );
     let out = stdout_of(&output);
@@ -566,7 +566,7 @@ fn a_function_reference_that_is_never_called_is_reported_not_skipped() {
     write(
         tmp.path(),
         "src/main.rs",
-        "pub fn a(xs: Vec<Pool>) {\n    xs.into_iter().map(Repo::with_pool);\n}\n",
+        "pub fn a(xs: Vec<Pool>) {\n    xs.into_iter().map(PgRepo::with_pool);\n}\n",
     );
 
     let output = run_upgrade(tmp.path(), &["--to", "0.6.0", "--apply"]);
@@ -575,7 +575,7 @@ fn a_function_reference_that_is_never_called_is_reported_not_skipped() {
     assert!(out.contains("src/main.rs:2"), "{out}");
     assert!(out.contains("referenced without being called"), "{out}");
     assert!(
-        read(tmp.path(), "src/main.rs").contains("map(Repo::with_pool)"),
+        read(tmp.path(), "src/main.rs").contains("map(PgRepo::with_pool)"),
         "a reference is reported, never rewritten"
     );
 }
@@ -719,7 +719,7 @@ fn a_preview_whose_every_site_is_manual_does_not_offer_apply() {
     write(
         tmp.path(),
         "src/lib.rs",
-        "pub fn f(pool: Pool) {\n    make_repo! { Repo::with_pool(pool) }\n}\n",
+        "pub fn f(pool: Pool) {\n    make_repo! { PgRepo::with_pool(pool) }\n}\n",
     );
 
     let output = run_upgrade(tmp.path(), &["--to", "0.6.0"]);
@@ -744,7 +744,7 @@ fn a_same_named_framework_builder_method_is_never_rewritten() {
         tmp.path(),
         "src/main.rs",
         "pub fn setup(state: AppState, pool: Pool) -> AppState {\n\
-        \x20   let repo = PostRepository::with_pool(pool.clone());\n\
+        \x20   let repo = PgPostRepository::with_pool(pool.clone());\n\
         \x20   drop(repo);\n\
         \x20   state.with_pool(pool)\n\
          }\n",
@@ -755,7 +755,7 @@ fn a_same_named_framework_builder_method_is_never_rewritten() {
 
     let after = read(tmp.path(), "src/main.rs");
     assert!(
-        after.contains("PostRepository::with_pool_untracked(pool.clone())"),
+        after.contains("PgPostRepository::with_pool_untracked(pool.clone())"),
         "the repository constructor is migrated:\n{after}"
     );
     assert!(
@@ -850,5 +850,67 @@ fn members_on_different_versions_take_the_oldest_floor() {
     assert!(
         read(tmp.path(), "old/src/lib.rs").contains("with_pool_untracked("),
         "the member still on 0.5.0 is migrated"
+    );
+}
+
+#[test]
+fn a_member_pinned_behind_the_workspace_root_still_decides_the_floor() {
+    // The root records 0.6.0 but one member is still on 0.5.0. Taking the root
+    // alone would select no migration while happily scanning that member's
+    // source, leaving it unmigrated.
+    let tmp = TempDir::new().expect("tempdir");
+    write(
+        tmp.path(),
+        "Cargo.toml",
+        "[workspace]\nmembers = [\"api\", \"legacy\"]\n\n\
+         [workspace.dependencies]\nautumn-web = \"0.6.0\"\n",
+    );
+    write(
+        tmp.path(),
+        "api/Cargo.toml",
+        "[package]\nname = \"api\"\nversion = \"0.1.0\"\nedition = \"2024\"\n\n\
+         [dependencies]\nautumn-web = { workspace = true }\n",
+    );
+    write(tmp.path(), "api/src/lib.rs", "pub fn f() {}\n");
+    write(
+        tmp.path(),
+        "legacy/Cargo.toml",
+        "[package]\nname = \"legacy\"\nversion = \"0.1.0\"\nedition = \"2024\"\n\n\
+         [dependencies]\nautumn-web = \"0.5.0\"\n",
+    );
+    write(tmp.path(), "legacy/src/lib.rs", USES_WITH_POOL);
+
+    let output = run_upgrade(tmp.path(), &["--to", "0.6.0", "--apply"]);
+    assert!(output.status.success(), "{}", report(&output));
+    assert!(
+        read(tmp.path(), "legacy/src/lib.rs").contains("with_pool_untracked("),
+        "the member still on 0.5.0 must be migrated:\n{}",
+        stdout_of(&output)
+    );
+}
+
+#[test]
+fn an_unrelated_type_with_the_same_associated_function_is_reported_not_rewritten() {
+    // `#[repository]` names its concrete type `Pg{trait}`, so an app's own
+    // `Cache::with_pool(pool)` is not the renamed constructor — but it is
+    // reported, because an aliased import would look identical.
+    let tmp = app("0.5.0");
+    write(
+        tmp.path(),
+        "src/cache.rs",
+        "pub fn build(pool: Pool) -> Cache {\n    Cache::with_pool(pool)\n}\n",
+    );
+
+    let output = run_upgrade(tmp.path(), &["--to", "0.6.0", "--apply"]);
+    assert!(output.status.success(), "{}", report(&output));
+    assert!(
+        read(tmp.path(), "src/cache.rs").contains("Cache::with_pool(pool)"),
+        "an unrelated type must not be rewritten"
+    );
+    let out = stdout_of(&output);
+    assert!(out.contains("src/cache.rs:2"), "the site is named: {out}");
+    assert!(
+        out.contains("receiver is not a generated repository"),
+        "and the reason is given: {out}"
     );
 }

--- a/autumn-cli/tests/integration/upgrade_codemod.rs
+++ b/autumn-cli/tests/integration/upgrade_codemod.rs
@@ -731,3 +731,59 @@ fn a_preview_whose_every_site_is_manual_does_not_offer_apply() {
     );
     assert!(out.contains("a human"), "{out}");
 }
+
+#[test]
+fn a_same_named_framework_builder_method_is_never_rewritten() {
+    // `AppState::with_pool` and `AuthzContext::with_pool` are *current*
+    // framework builders that still carry the old name. The renamed repository
+    // constructor takes no `self`, so the `.` call form is a different function
+    // — rewriting it would break ordinary test setup and the app would not
+    // compile, which is the one thing this command must never do.
+    let tmp = app("0.5.0");
+    write(
+        tmp.path(),
+        "src/main.rs",
+        "pub fn setup(state: AppState, pool: Pool) -> AppState {\n\
+        \x20   let repo = PostRepository::with_pool(pool.clone());\n\
+        \x20   drop(repo);\n\
+        \x20   state.with_pool(pool)\n\
+         }\n",
+    );
+
+    let output = run_upgrade(tmp.path(), &["--to", "0.6.0", "--apply"]);
+    assert!(output.status.success(), "{}", report(&output));
+
+    let after = read(tmp.path(), "src/main.rs");
+    assert!(
+        after.contains("PostRepository::with_pool_untracked(pool.clone())"),
+        "the repository constructor is migrated:\n{after}"
+    );
+    assert!(
+        after.contains("state.with_pool(pool)"),
+        "the AppState builder method is left exactly as it was:\n{after}"
+    );
+}
+
+#[test]
+fn every_pre_target_release_in_range_is_reported_not_just_the_newest() {
+    // An app coming from 0.3.x has 0.4.0 and 0.5.0 breaks ahead of it too.
+    // Reporting only the 0.6.0 ones would read as "those are the only breaks".
+    let tmp = app("0.3.0");
+    write(tmp.path(), "src/main.rs", "fn main() {}\n");
+
+    let output = run_upgrade(tmp.path(), &["--to", "0.6.0", "--json"]);
+    assert!(output.status.success(), "{}", report(&output));
+    let value: serde_json::Value = serde_json::from_str(&stdout_of(&output)).expect("valid JSON");
+    let versions: Vec<&str> = value["migrations"]
+        .as_array()
+        .expect("migrations")
+        .iter()
+        .map(|m| m["version"].as_str().expect("version"))
+        .collect();
+    for release in ["0.4.0", "0.5.0", "0.6.0"] {
+        assert!(
+            versions.contains(&release),
+            "{release} is in range and must be reported, got {versions:?}"
+        );
+    }
+}

--- a/autumn-cli/tests/integration/upgrade_codemod.rs
+++ b/autumn-cli/tests/integration/upgrade_codemod.rs
@@ -2347,3 +2347,107 @@ fn a_configured_vendor_directory_is_never_rewritten() {
         stdout_of(&output)
     );
 }
+
+#[test]
+fn the_extensionless_cargo_config_wins_when_both_exist() {
+    // Codex review on #2231: Cargo gives `.cargo/config` precedence over
+    // `.cargo/config.toml` when both are present (and warns). Reading
+    // `config.toml` first meant the real target directory was scanned, and
+    // `--apply` rewrote build output.
+    let tmp = app("0.5.0");
+    write(tmp.path(), "src/main.rs", USES_WITH_POOL);
+    write(tmp.path(), ".cargo/config", "[build]\ntarget-dir = 'out'\n");
+    write(
+        tmp.path(),
+        ".cargo/config.toml",
+        "[build]\ntarget-dir = 'ignored'\n",
+    );
+    write(tmp.path(), "out/debug/generated.rs", USES_WITH_POOL);
+
+    let output = run_upgrade(tmp.path(), &["--to", "0.6.0", "--apply"]);
+    assert!(output.status.success(), "{}", report(&output));
+    assert!(
+        read(tmp.path(), "out/debug/generated.rs").contains("with_pool(pool.clone())"),
+        "`.cargo/config` decides the target directory when both exist:\n{}",
+        stdout_of(&output)
+    );
+    assert!(
+        read(tmp.path(), "src/main.rs").contains("with_pool_untracked("),
+        "and app source is still migrated:\n{}",
+        stdout_of(&output)
+    );
+}
+
+#[test]
+fn a_target_directory_configured_in_cargo_home_is_build_output() {
+    // Codex review on #2231: `$CARGO_HOME/config.toml` is the last level of
+    // Cargo's hierarchy. An absolute in-tree `target-dir` set there applies
+    // even though no ancestor of the project holds a `.cargo` directory.
+    let tmp = app("0.5.0");
+    let home = TempDir::new().expect("tempdir");
+    write(tmp.path(), "src/main.rs", USES_WITH_POOL);
+    write(tmp.path(), "out/debug/generated.rs", USES_WITH_POOL);
+    let target = tmp.path().join("out");
+    write(
+        home.path(),
+        "config.toml",
+        // A literal string: a Windows path is full of backslashes, which a
+        // basic TOML string would read as escapes.
+        &format!("[build]\ntarget-dir = '{}'\n", target.display()),
+    );
+
+    let output = run_upgrade_with_env(
+        tmp.path(),
+        &["--to", "0.6.0", "--apply"],
+        &[("CARGO_HOME", home.path().to_str().expect("utf-8 path"))],
+    );
+    assert!(output.status.success(), "{}", report(&output));
+    assert!(
+        read(tmp.path(), "out/debug/generated.rs").contains("with_pool(pool.clone())"),
+        "Cargo home's config redirects the target directory too:\n{}",
+        stdout_of(&output)
+    );
+}
+
+#[test]
+fn the_nearest_cargo_config_decides_the_target_directory() {
+    // Codex review on #2231: `build.target-dir` is a scalar, so Cargo takes the
+    // nearest value rather than every ancestor's. Unioning them pruned a
+    // directory that is really app source, leaving its call sites unmigrated —
+    // silently, which is the one thing the report is meant not to do.
+    let outer = TempDir::new().expect("tempdir");
+    write(
+        outer.path(),
+        "app/Cargo.toml",
+        "[package]\nname = \"demo\"\nversion = \"0.1.0\"\nedition = \"2024\"\n\n\
+         [dependencies]\nautumn-web = \"0.5.0\"\n",
+    );
+    write(outer.path(), "app/src/main.rs", USES_WITH_POOL);
+    // The nearer config wins for `target-dir` …
+    write(
+        outer.path(),
+        "app/.cargo/config.toml",
+        "[build]\ntarget-dir = 'out'\n",
+    );
+    // … so this ancestor value is overridden, and `app/keep` is app source.
+    write(
+        outer.path(),
+        ".cargo/config.toml",
+        "[build]\ntarget-dir = 'app/keep'\n",
+    );
+    write(outer.path(), "app/out/debug/generated.rs", USES_WITH_POOL);
+    write(outer.path(), "app/keep/mod.rs", USES_WITH_POOL);
+
+    let output = run_upgrade(&outer.path().join("app"), &["--to", "0.6.0", "--apply"]);
+    assert!(output.status.success(), "{}", report(&output));
+    assert!(
+        read(outer.path(), "app/out/debug/generated.rs").contains("with_pool(pool.clone())"),
+        "the nearest config names the real target directory:\n{}",
+        stdout_of(&output)
+    );
+    assert!(
+        read(outer.path(), "app/keep/mod.rs").contains("with_pool_untracked("),
+        "the overridden ancestor path is app source, not build output:\n{}",
+        stdout_of(&output)
+    );
+}

--- a/autumn-cli/tests/integration/upgrade_codemod.rs
+++ b/autumn-cli/tests/integration/upgrade_codemod.rs
@@ -2257,3 +2257,60 @@ fn a_config_inside_build_output_does_not_exclude_app_source() {
         stdout_of(&output)
     );
 }
+
+#[test]
+fn a_prerelease_is_reported_as_the_version_that_was_asked_for() {
+    // `0.7.0-rc.1` and `0.7.0-beta.2` are different releases. Reporting either
+    // as `0.7.0-pre` makes the human heading wrong and the JSON record of what
+    // was migrated unusable.
+    let tmp = app("0.6.0");
+    write(tmp.path(), "src/main.rs", "fn main() {}\n");
+
+    let output = run_upgrade(tmp.path(), &["--to", "0.7.0-rc.1", "--json"]);
+    assert!(output.status.success(), "{}", report(&output));
+    let value: serde_json::Value = serde_json::from_str(&stdout_of(&output)).expect("json");
+    assert_eq!(value["to"], "0.7.0-rc.1", "{value:#}");
+
+    let human = run_upgrade(
+        tmp.path(),
+        &["--from", "0.6.0-beta.2", "--to", "0.7.0-rc.1"],
+    );
+    assert!(human.status.success(), "{}", report(&human));
+    assert!(
+        stdout_of(&human).contains("0.6.0-beta.2 -> 0.7.0-rc.1"),
+        "the heading echoes what was asked for:\n{}",
+        stdout_of(&human)
+    );
+}
+
+#[test]
+fn an_unparsable_file_is_not_evidence_for_a_receiver_elsewhere() {
+    // `#[repository] trait AuditRepository;` tokenises but is not valid Rust —
+    // a trait needs a body — so nothing is generated from it. Counting it as a
+    // declaration let it verify an unrelated `PgAuditRepository` in a file that
+    // *is* valid, and that call was rewritten.
+    let tmp = app("0.5.0");
+    write(
+        tmp.path(),
+        "src/broken.rs",
+        "#[repository]\npub trait AuditRepository;\n",
+    );
+    // The type is imported from a dependency, so nothing in the scan writes it
+    // out and the hand-written veto cannot help — the bogus declaration is the
+    // only evidence in play.
+    write(
+        tmp.path(),
+        "src/main.rs",
+        "use other_crate::PgAuditRepository;\n\n\
+         pub fn build(pool: Pool) -> PgAuditRepository {\n    \
+         PgAuditRepository::with_pool(pool)\n}\n",
+    );
+
+    let output = run_upgrade(tmp.path(), &["--to", "0.6.0", "--apply"]);
+    assert!(output.status.success(), "{}", report(&output));
+    assert!(
+        read(tmp.path(), "src/main.rs").contains("PgAuditRepository::with_pool(pool)"),
+        "a declaration in a file that is not valid Rust generates nothing:\n{}",
+        stdout_of(&output)
+    );
+}

--- a/docs/guide/upgrading.md
+++ b/docs/guide/upgrading.md
@@ -161,7 +161,9 @@ Manual - not rewritten; read the guide section:
 The name alone is not enough, though, because an app is free to write its own
 `PgAuditRepository` with its own one-argument `with_pool`. So the shape is only
 the first test: `autumn upgrade` also collects every `#[repository]` trait in
-the source it scans and derives the types they generate. A receiver has to be
+the source it scans — under any spelling of the attribute path, including the
+`#[autumn_web::repository(...)]` the scaffold emits — and derives the types they
+generate. A receiver has to be
 one of those to be rewritten. One that looks right but is not — because no
 `#[repository]` trait in the app accounts for it, or because the trait lives in
 a crate outside the scan — is reported rather than guessed at:

--- a/docs/guide/upgrading.md
+++ b/docs/guide/upgrading.md
@@ -105,6 +105,10 @@ not:
   count, while another crate's `#[other_macros::repository]` does not. If your
   manifest renames the dependency to something else *and* you use the qualified
   spelling, those call sites are reported rather than rewritten.
+- **A `#[repository]` trait declared inside a function body.** The type it
+  generates is visible only in that block, so it cannot vouch for a call
+  elsewhere in the module; such calls are reported. Declare the trait at module
+  level and it is rewritten as usual.
 - **`#[cfg]`-gated repository declarations.** A `#[cfg(feature = "postgres")] #[repository] trait AuditRepository`
   generates its type only when that feature is on, so it cannot vouch for a
   call unconditionally; under the other configuration the same name may be an

--- a/docs/guide/upgrading.md
+++ b/docs/guide/upgrading.md
@@ -172,3 +172,8 @@ if your app keeps real source behind one, migrate it in its own checkout.
 `target/`, `vendor/`, `node_modules/`, `dist/` and `tmp/` are skipped where a
 crate begins — a directory holding a `Cargo.toml`. Beneath that they are
 ordinary module names, so `src/vendor/mod.rs` is migrated like any other file.
+
+Hidden directories are skipped by name — `.git`, `.github`, `.cargo`, `.vscode`
+and the like — not because they start with a dot. A dot-directory that holds
+compiled source, say a `#[path = ".generated/repositories.rs"]` module, is
+migrated.

--- a/docs/guide/upgrading.md
+++ b/docs/guide/upgrading.md
@@ -33,9 +33,9 @@ autumn upgrade - app-code migrations 0.5.0 -> 0.6.0
 
 Migrations in range (2):
   manual  0.6.0-tenancy-jwt-secret-secretstring  `TenancyConfig::jwt_secret` is now a `secrecy::SecretString`
-          docs/migrations/0.6.0.md#security-tenancyconfigjwt_secret-is-now-a-secrecysecretstring
+          https://github.com/autumn-foundation/autumn/blob/trunk-dev/docs/migrations/0.6.0.md#security-tenancyconfigjwt_secret-is-now-a-secrecysecretstring
   auto    0.6.0-repository-with-pool-untracked  repository constructor `with_pool` is renamed to `with_pool_untracked`
-          docs/migrations/0.6.0.md#repository-with_pool-is-renamed-to-with_pool_untracked
+          https://github.com/autumn-foundation/autumn/blob/trunk-dev/docs/migrations/0.6.0.md#repository-with_pool-is-renamed-to-with_pool_untracked
 
 Preview (nothing is written without --apply):
 
@@ -49,7 +49,7 @@ src/repositories.rs (2 sites)
 
 Manual - not rewritten; read the guide section:
   (whole change)  0.6.0-tenancy-jwt-secret-secretstring (no machine-applyable rewrite)
-      docs/migrations/0.6.0.md#security-tenancyconfigjwt_secret-is-now-a-secrecysecretstring
+      https://github.com/autumn-foundation/autumn/blob/trunk-dev/docs/migrations/0.6.0.md#security-tenancyconfigjwt_secret-is-now-a-secrecysecretstring
 
 2 sites in 1 file would be rewritten; 14 file(s) scanned.
 Nothing was written. Re-run with `--apply` to write these changes.
@@ -82,7 +82,7 @@ look like a call may never become one:
 ```text
 Manual - not rewritten; read the guide section:
   src/repositories.rs:40  0.6.0-repository-with-pool-untracked (inside a macro invocation)
-      docs/migrations/0.6.0.md#repository-with_pool-is-renamed-to-with_pool_untracked
+      https://github.com/autumn-foundation/autumn/blob/trunk-dev/docs/migrations/0.6.0.md#repository-with_pool-is-renamed-to-with_pool_untracked
 ```
 
 A file that is not valid Rust is reported under **Skipped** and left exactly as
@@ -94,7 +94,7 @@ it was; one unparsable file never stops the rest of the migration.
 |------|--------|
 | `PATH` | Project directory to migrate (positional, defaults to `.`). |
 | `--apply` | Write the rewrites. Without it the command only previews. |
-| `--from VERSION` | Override the recorded `autumn-web` version. Needed when you already bumped the dependency, or when any manifest declares a requirement with no single floor — a git pin, `*`, a multi-comparator range, or an upper bound like `"<0.6"`. The root and every workspace member are read together (including `[target.'cfg(…)'.dependencies]`), the oldest floor wins, and one ambiguous declaration anywhere makes the whole answer a guess rather than being ignored. |
+| `--from VERSION` | Override the recorded `autumn-web` version. Needed when you already bumped the dependency, or when any manifest declares a requirement with no single floor — a git pin, a bare `*`, a multi-comparator range, or an upper bound like `"<0.6"`. A wildcard in a later position does have a floor and is read: `"0.5.*"` is `0.5.0`, the same as `"0.5"`. The root and every workspace member are read together (including `[target.'cfg(…)'.dependencies]`), the oldest floor wins, and one ambiguous declaration anywhere makes the whole answer a guess rather than being ignored. |
 | `--to VERSION` | Upgrade to this release instead of the CLI's own version. |
 | `--json` | Machine-readable report — the same content, for CI. |
 | `--list-migrations` | Print the shipped codemods and exit, without scanning. |

--- a/docs/guide/upgrading.md
+++ b/docs/guide/upgrading.md
@@ -158,12 +158,23 @@ Manual - not rewritten; read the guide section:
   src/cache.rs:18  0.6.0-repository-with-pool-untracked (receiver is not a generated repository)
 ```
 
-What remains is an app type named `Pg…Repository` with a one-argument
-associated `with_pool` of its own. This is why preview is the default and why the diff
-names every file and line — read it before you `--apply`, and `git diff` after.
-It is also the line the `auto` label draws: a change that needs to know a
-receiver's *type* rather than its name is labelled `review` or `manual`, never
-`auto`.
+The name alone is not enough, though, because an app is free to write its own
+`PgAuditRepository` with its own one-argument `with_pool`. So the shape is only
+the first test: `autumn upgrade` also collects every `#[repository]` trait in
+the source it scans and derives the types they generate. A receiver has to be
+one of those to be rewritten. One that looks right but is not — because no
+`#[repository]` trait in the app accounts for it, or because the trait lives in
+a crate outside the scan — is reported rather than guessed at:
+
+```text
+Manual - not rewritten; read the guide section:
+  src/audit.rs:10  0.6.0-repository-with-pool-untracked (no `#[repository]` trait in this app generates this receiver)
+```
+
+Preview is still the default and the diff still names every file and line —
+read it before you `--apply`, and `git diff` after. This is also the line the
+`auto` label draws: a change that needs to know a receiver's *type* rather than
+what generates it is labelled `review` or `manual`, never `auto`.
 
 Symlinked source files and directories are not followed. Rewriting through a
 link could write outside the project, so a symlink is reported and left alone;

--- a/docs/guide/upgrading.md
+++ b/docs/guide/upgrading.md
@@ -134,14 +134,23 @@ change*, for the label convention and the release gate that enforces it.
 
 ## What it can get wrong
 
-The tool matches identifiers in call position; it does not resolve types. If
-your own code happens to define a method with the same name as a renamed
-framework API and calls it as `thing.with_pool(…)`, that call is rewritten too.
-This is why preview is the default and why the diff names every file and line:
-read it before you `--apply`, and `git diff` after. The rename this ships is
-deliberately framework-specific for exactly that reason, and the risk is the
-line the `auto` label draws — a change that needs to know a receiver's type is
-labelled `review` or `manual` instead, never `auto`.
+The tool matches call sites by name, call form, and argument count; it does not
+resolve types.
+
+Form and arity carry more weight than they might look like. Autumn itself has
+same-named APIs that are *not* being renamed: `AppState::with_pool` and
+`AuthzContext::with_pool` are current builder methods. They survive the 0.6.0
+codemod because the renamed repository constructor takes no `self` and exactly
+one argument, so only `Repo::with_pool(pool)` matches — `state.with_pool(pool)`
+and the UFCS `AppState::with_pool(state, pool)` are provably different
+functions and are left alone.
+
+What remains is a same-named API in *your* code with the same form and arity:
+a one-argument associated `with_pool` on a type of your own would be rewritten.
+This is why preview is the default and why the diff names every file and line —
+read it before you `--apply`, and `git diff` after. It is also the line the
+`auto` label draws: a change that needs to know a receiver's type is labelled
+`review` or `manual`, never `auto`.
 
 Symlinked source files are not followed. Rewriting through a link could write
 outside the project, so a symlink is left alone; if your app keeps real source

--- a/docs/guide/upgrading.md
+++ b/docs/guide/upgrading.md
@@ -90,6 +90,20 @@ it was; one unparsable file never stops the rest of the migration. "Valid" means
 it parses as Rust, not merely that its delimiters balance — `let = f();` is
 skipped, not rewritten.
 
+The same applies to a receiver the tool cannot pin down to a generated
+repository. Two cases are worth naming, because both look rewritable and are
+not:
+
+- **`self::` and `super::` receivers.** These are relative to the module the
+  call is written in, which this command does not track. `self::PgAuditRepository::with_pool(pool)`
+  is reported rather than matched against a repository declared in some other
+  module. Spell the path from the crate root — `crate::repositories::PgAuditRepository`
+  — and it is rewritten.
+- **`#[cfg]`-gated repository declarations.** A `#[cfg(feature = "postgres")] #[repository] trait AuditRepository`
+  generates its type only when that feature is on, so it cannot vouch for a
+  call unconditionally; under the other configuration the same name may be an
+  unrelated import. Calls to such a type are reported for a human.
+
 ## Flags
 
 | Flag | Effect |

--- a/docs/guide/upgrading.md
+++ b/docs/guide/upgrading.md
@@ -99,6 +99,12 @@ not:
   is reported rather than matched against a repository declared in some other
   module. Spell the path from the crate root — `crate::repositories::PgAuditRepository`
   — and it is rewritten.
+- **A `#[repository]` attribute qualified by a renamed dependency.** Only
+  Autumn's own attribute is evidence, so `#[autumn_web::repository]`,
+  `#[autumn::repository]` and the bare `#[repository]` the scaffold emits all
+  count, while another crate's `#[other_macros::repository]` does not. If your
+  manifest renames the dependency to something else *and* you use the qualified
+  spelling, those call sites are reported rather than rewritten.
 - **`#[cfg]`-gated repository declarations.** A `#[cfg(feature = "postgres")] #[repository] trait AuditRepository`
   generates its type only when that feature is on, so it cannot vouch for a
   call unconditionally; under the other configuration the same name may be an

--- a/docs/guide/upgrading.md
+++ b/docs/guide/upgrading.md
@@ -165,6 +165,10 @@ It is also the line the `auto` label draws: a change that needs to know a
 receiver's *type* rather than its name is labelled `review` or `manual`, never
 `auto`.
 
-Symlinked source files are not followed. Rewriting through a link could write
-outside the project, so a symlink is left alone; if your app keeps real source
-behind one, migrate it in its own checkout.
+Symlinked source files and directories are not followed. Rewriting through a
+link could write outside the project, so a symlink is reported and left alone;
+if your app keeps real source behind one, migrate it in its own checkout.
+
+`target/`, `vendor/`, `node_modules/`, `dist/` and `tmp/` are skipped where a
+crate begins — a directory holding a `Cargo.toml`. Beneath that they are
+ordinary module names, so `src/vendor/mod.rs` is migrated like any other file.

--- a/docs/guide/upgrading.md
+++ b/docs/guide/upgrading.md
@@ -173,6 +173,12 @@ Manual - not rewritten; read the guide section:
   src/audit.rs:10  0.6.0-repository-with-pool-untracked (no `#[repository]` trait in this app generates this receiver)
 ```
 
+A receiver written with a module in front of it is checked against that module
+too, so a real `repositories::PgAuditRepository` does not vouch for an unrelated
+`custom::PgAuditRepository`. An unqualified receiver is accepted on its name
+alone: resolving it would mean following `use` declarations, so an alias that
+imports a same-named type from elsewhere is the one case this cannot tell apart.
+
 Preview is still the default and the diff still names every file and line —
 read it before you `--apply`, and `git diff` after. This is also the line the
 `auto` label draws: a change that needs to know a receiver's *type* rather than

--- a/docs/guide/upgrading.md
+++ b/docs/guide/upgrading.md
@@ -105,7 +105,7 @@ it was; one unparsable file never stops the rest of the migration.
 |------|---------|
 | `0` | The scan completed. This includes a run that reported `manual` sites or skipped an unparsable file — both are in the report, and neither is a failure of the command. |
 | `1` | The apply step failed partway through. The report names the file it died on; the ones listed before it were already written. |
-| `2` | A bad argument, an unreadable `PATH`, or a version this command cannot parse. Nothing was scanned. |
+| `2` | A bad argument, a `PATH` that is not a readable directory, or a version this command cannot parse. Nothing was scanned. |
 
 There is no "found something" exit code: a preview that finds work is the
 command working. Gate on the `--json` report's `manual`, `skipped`, and
@@ -172,6 +172,11 @@ if your app keeps real source behind one, migrate it in its own checkout.
 `target/`, `vendor/`, `node_modules/`, `dist/` and `tmp/` are skipped where a
 crate begins — a directory holding a `Cargo.toml`. Beneath that they are
 ordinary module names, so `src/vendor/mod.rs` is migrated like any other file.
+
+If Cargo's output directory has been moved — `CARGO_TARGET_DIR`, or
+`build.target-dir` in `.cargo/config.toml` — that directory is skipped too,
+resolved as a path rather than matched by name. With the output in `out/`, an
+unrelated `src/out/mod.rs` is still migrated.
 
 Hidden directories are skipped by name — `.git`, `.github`, `.cargo`, `.vscode`
 and the like — not because they start with a dot. A dot-directory that holds

--- a/docs/guide/upgrading.md
+++ b/docs/guide/upgrading.md
@@ -94,7 +94,7 @@ it was; one unparsable file never stops the rest of the migration.
 |------|--------|
 | `PATH` | Project directory to migrate (positional, defaults to `.`). |
 | `--apply` | Write the rewrites. Without it the command only previews. |
-| `--from VERSION` | Override the recorded `autumn-web` version. Needed when you already bumped the dependency, or when the requirement has no single floor — a git pin, `*`, a multi-comparator range, or an upper bound like `"<0.6"`. In a virtual workspace the members' own manifests are read, and the oldest floor among them wins. |
+| `--from VERSION` | Override the recorded `autumn-web` version. Needed when you already bumped the dependency, or when any manifest declares a requirement with no single floor — a git pin, `*`, a multi-comparator range, or an upper bound like `"<0.6"`. The root and every workspace member are read together (including `[target.'cfg(…)'.dependencies]`), the oldest floor wins, and one ambiguous declaration anywhere makes the whole answer a guess rather than being ignored. |
 | `--to VERSION` | Upgrade to this release instead of the CLI's own version. |
 | `--json` | Machine-readable report — the same content, for CI. |
 | `--list-migrations` | Print the shipped codemods and exit, without scanning. |
@@ -145,19 +145,21 @@ one argument, so only `Repo::with_pool(pool)` matches — `state.with_pool(pool)
 and the UFCS `AppState::with_pool(state, pool)` are provably different
 functions and are left alone.
 
-The receiver narrows it further. `#[repository]` names its concrete type
-`Pg` + the trait name, so only a `PgSomething::with_pool(pool)` call is
-rewritten — your own `Cache::with_pool(pool)` is not. A receiver that does not
-match is *reported* rather than dropped, because an aliased import
-(`use PgPostRepository as Repo;`) would look the same from the outside:
+The receiver narrows it further. `#[repository]` names its concrete type `Pg` +
+the trait name, and the scaffold names every trait `{Model}Repository`, so only
+a `PgSomethingRepository::with_pool(pool)` call is rewritten — your own
+`Cache::with_pool(pool)` and `PgCache::with_pool(pool)` are not. A receiver that
+does not match is *reported* rather than dropped, because an aliased import
+(`use PgPostRepository as Repo;`) or a hand-named trait (`PostStore` →
+`PgPostStore`) would look the same from the outside:
 
 ```text
 Manual - not rewritten; read the guide section:
   src/cache.rs:18  0.6.0-repository-with-pool-untracked (receiver is not a generated repository)
 ```
 
-What remains is an app type named `Pg…` with a one-argument associated
-`with_pool` of its own. This is why preview is the default and why the diff
+What remains is an app type named `Pg…Repository` with a one-argument
+associated `with_pool` of its own. This is why preview is the default and why the diff
 names every file and line — read it before you `--apply`, and `git diff` after.
 It is also the line the `auto` label draws: a change that needs to know a
 receiver's *type* rather than its name is labelled `review` or `manual`, never

--- a/docs/guide/upgrading.md
+++ b/docs/guide/upgrading.md
@@ -225,7 +225,12 @@ unrelated `src/out/mod.rs` is still migrated.
 Every `.cargo/config.toml` in the scan is read, not just the one at the root: a
 nested standalone crate redirects its own output, and the path it names need not
 sit under that crate. `CARGO_TARGET_DIR` is the exception — it overrides every
-config file, so when it is set no config redirect applies.
+config file's `target-dir`, so when it is set no config redirect applies to
+build output.
+
+Vendored dependencies are excluded the same way. `cargo vendor third-party`
+records the path in `[source.vendored-sources]`, and that directory is skipped
+wherever it is — the `vendor` name is only Cargo's default, not the rule.
 
 Hidden directories are skipped by name — `.git`, `.github`, `.cargo`, `.vscode`
 and the like — not because they start with a dot. A dot-directory that holds

--- a/docs/guide/upgrading.md
+++ b/docs/guide/upgrading.md
@@ -41,11 +41,11 @@ Preview (nothing is written without --apply):
 
 src/repositories.rs (2 sites)
 @@ line 12 @@
--    let repo = PostRepository::with_pool(pool.clone());
-+    let repo = PostRepository::with_pool_untracked(pool.clone());
+-    let repo = PgPostRepository::with_pool(pool.clone());
++    let repo = PgPostRepository::with_pool_untracked(pool.clone());
 @@ line 18 @@
--    let repo = CommentRepository::with_pool(pool.clone());
-+    let repo = CommentRepository::with_pool_untracked(pool.clone());
+-    let repo = PgCommentRepository::with_pool(pool.clone());
++    let repo = PgCommentRepository::with_pool_untracked(pool.clone());
 
 Manual - not rewritten; read the guide section:
   (whole change)  0.6.0-tenancy-jwt-secret-secretstring (no machine-applyable rewrite)
@@ -145,12 +145,23 @@ one argument, so only `Repo::with_pool(pool)` matches — `state.with_pool(pool)
 and the UFCS `AppState::with_pool(state, pool)` are provably different
 functions and are left alone.
 
-What remains is a same-named API in *your* code with the same form and arity:
-a one-argument associated `with_pool` on a type of your own would be rewritten.
-This is why preview is the default and why the diff names every file and line —
-read it before you `--apply`, and `git diff` after. It is also the line the
-`auto` label draws: a change that needs to know a receiver's type is labelled
-`review` or `manual`, never `auto`.
+The receiver narrows it further. `#[repository]` names its concrete type
+`Pg` + the trait name, so only a `PgSomething::with_pool(pool)` call is
+rewritten — your own `Cache::with_pool(pool)` is not. A receiver that does not
+match is *reported* rather than dropped, because an aliased import
+(`use PgPostRepository as Repo;`) would look the same from the outside:
+
+```text
+Manual - not rewritten; read the guide section:
+  src/cache.rs:18  0.6.0-repository-with-pool-untracked (receiver is not a generated repository)
+```
+
+What remains is an app type named `Pg…` with a one-argument associated
+`with_pool` of its own. This is why preview is the default and why the diff
+names every file and line — read it before you `--apply`, and `git diff` after.
+It is also the line the `auto` label draws: a change that needs to know a
+receiver's *type* rather than its name is labelled `review` or `manual`, never
+`auto`.
 
 Symlinked source files are not followed. Rewriting through a link could write
 outside the project, so a symlink is left alone; if your app keeps real source

--- a/docs/guide/upgrading.md
+++ b/docs/guide/upgrading.md
@@ -86,7 +86,9 @@ Manual - not rewritten; read the guide section:
 ```
 
 A file that is not valid Rust is reported under **Skipped** and left exactly as
-it was; one unparsable file never stops the rest of the migration.
+it was; one unparsable file never stops the rest of the migration. "Valid" means
+it parses as Rust, not merely that its delimiters balance — `let = f();` is
+skipped, not rewritten.
 
 ## Flags
 

--- a/docs/guide/upgrading.md
+++ b/docs/guide/upgrading.md
@@ -178,6 +178,11 @@ If Cargo's output directory has been moved — `CARGO_TARGET_DIR`, or
 resolved as a path rather than matched by name. With the output in `out/`, an
 unrelated `src/out/mod.rs` is still migrated.
 
+The redirect is resolved the way Cargo resolves it, which means per subtree: a
+nested standalone crate with its own `.cargo/config.toml` redirects only its own
+output. `CARGO_TARGET_DIR` is the exception — it overrides every config file, so
+when it is set no nested config applies.
+
 Hidden directories are skipped by name — `.git`, `.github`, `.cargo`, `.vscode`
 and the like — not because they start with a dot. A dot-directory that holds
 compiled source, say a `#[path = ".generated/repositories.rs"]` module, is

--- a/docs/guide/upgrading.md
+++ b/docs/guide/upgrading.md
@@ -1,0 +1,148 @@
+# Upgrading with `autumn upgrade`
+
+Autumn ships every 2–4 weeks and, pre-1.0, most releases can break existing
+apps ([Stability Policy](../../STABILITY.md)). Every breaking release ships a
+[migration guide](../migrations/README.md) — and for the mechanical part of the
+upgrade, a codemod you can run instead of hand-editing call sites out of prose.
+
+```bash
+autumn upgrade            # preview: per-file diff, nothing written
+autumn upgrade --apply    # take the rewrites
+```
+
+## What it does
+
+For each release between the `autumn-web` version your `Cargo.toml` records and
+the version you are upgrading to, `autumn upgrade` applies that release's
+machine-applyable migrations to **your own Rust source** — `src/`, `tests/`,
+`examples/`, `benches/`, and every workspace member. Build output (`target/`)
+and vendored sources are never touched.
+
+It is deliberately narrow. Today the shipped rewrites are API **renames**:
+`0.6.0`'s `with_pool` → `with_pool_untracked`, for instance. Configuration
+files, dependency versions, and framework-owned scaffold files are out of
+scope — `autumn doctor` and the migration guides cover those.
+
+## Preview first, always
+
+A bare `autumn upgrade` writes nothing. It prints the diff it *would* apply,
+per file, plus a count of affected sites:
+
+```text
+autumn upgrade - app-code migrations 0.5.0 -> 0.6.0
+
+Migrations in range (2):
+  manual  0.6.0-tenancy-jwt-secret-secretstring  `TenancyConfig::jwt_secret` is now a `secrecy::SecretString`
+          docs/migrations/0.6.0.md#security-tenancyconfigjwt_secret-is-now-a-secrecysecretstring
+  auto    0.6.0-repository-with-pool-untracked  repository constructor `with_pool` is renamed to `with_pool_untracked`
+          docs/migrations/0.6.0.md#repository-with_pool-is-renamed-to-with_pool_untracked
+
+Preview (nothing is written without --apply):
+
+src/repositories.rs (2 sites)
+@@ line 12 @@
+-    let repo = PostRepository::with_pool(pool.clone());
++    let repo = PostRepository::with_pool_untracked(pool.clone());
+@@ line 18 @@
+-    let repo = CommentRepository::with_pool(pool.clone());
++    let repo = CommentRepository::with_pool_untracked(pool.clone());
+
+Manual - not rewritten; read the guide section:
+  (whole change)  0.6.0-tenancy-jwt-secret-secretstring (no machine-applyable rewrite)
+      docs/migrations/0.6.0.md#security-tenancyconfigjwt_secret-is-now-a-secrecysecretstring
+
+2 sites in 1 file would be rewritten; 14 file(s) scanned.
+Nothing was written. Re-run with `--apply` to write these changes.
+```
+
+Migrations are listed in release order, so a `manual` change from earlier in the
+release can appear above an `auto` one.
+
+Running it twice is a no-op — the rewrites match whole identifiers, so an
+already-migrated call site does not match again. An app that never used the
+affected APIs reports **nothing to change**.
+
+## Confidence labels
+
+Every documented breaking change is classified in its migration guide, and the
+same label appears in the upgrade summary:
+
+| Label | What it means |
+|-------|---------------|
+| `auto` | Safe by construction — a rename or an import move. Rewritten in full. |
+| `review` | Rewritten, and **every** rewritten site is listed for you to read. |
+| `manual` | No mechanical rewrite. The summary links the exact guide section. |
+
+## Nothing is silently skipped
+
+A call site the tool cannot safely rewrite is reported, not guessed at. That
+means a call inside a macro invocation or an attribute, where the tokens that
+look like a call may never become one:
+
+```text
+Manual - not rewritten; read the guide section:
+  src/repositories.rs:40  0.6.0-repository-with-pool-untracked (inside a macro invocation)
+      docs/migrations/0.6.0.md#repository-with_pool-is-renamed-to-with_pool_untracked
+```
+
+A file that is not valid Rust is reported under **Skipped** and left exactly as
+it was; one unparsable file never stops the rest of the migration.
+
+## Flags
+
+| Flag | Effect |
+|------|--------|
+| `PATH` | Project directory to migrate (positional, defaults to `.`). |
+| `--apply` | Write the rewrites. Without it the command only previews. |
+| `--from VERSION` | Override the recorded `autumn-web` version. Needed when you already bumped the dependency, or when it is a git pin or a range with no single floor. |
+| `--to VERSION` | Upgrade to this release instead of the CLI's own version. |
+| `--json` | Machine-readable report — the same content, for CI. |
+| `--list-migrations` | Print the shipped codemods and exit, without scanning. |
+
+## Exit codes
+
+| Code | Meaning |
+|------|---------|
+| `0` | The scan completed. This includes a run that reported `manual` sites or skipped an unparsable file — both are in the report, and neither is a failure of the command. |
+| `1` | The apply step failed partway through. The report names the file it died on; the ones listed before it were already written. |
+| `2` | A bad argument, an unreadable `PATH`, or a version this command cannot parse. Nothing was scanned. |
+
+There is no "found something" exit code: a preview that finds work is the
+command working. Gate on the `--json` report's `manual`, `skipped`, and
+`rewritten_sites` fields instead.
+
+## Before you run it
+
+**Run it before you bump the dependency.** The release it migrates *from* is
+the one your `Cargo.toml` records, so bumping `autumn-web` first leaves nothing
+in range and the command reports "nothing to change". Install the new
+`autumn-cli`, run `autumn upgrade --apply`, *then* bump the dependency and
+`cargo check`. (If you bumped first, `--from <previous-version>` gets you back
+on track — the command says so when the range comes out empty.)
+
+Commit or stash first. `autumn upgrade --apply` edits files in place, and the
+diff you reviewed in the preview is the only record of what changed — `git
+diff` afterwards is how you check its work.
+
+## Adding a codemod (contributors)
+
+The registry is `autumn-cli/src/upgrade/migrations.rs`, one `AppMigration` per
+documented breaking change — including the ones with no mechanical form, whose
+entries are what make the summary link the guide section. See
+[`docs/migrations/README.md`](../migrations/README.md), *Classifying a breaking
+change*, for the label convention and the release gate that enforces it.
+
+## What it can get wrong
+
+The tool matches identifiers in call position; it does not resolve types. If
+your own code happens to define a method with the same name as a renamed
+framework API and calls it as `thing.with_pool(…)`, that call is rewritten too.
+This is why preview is the default and why the diff names every file and line:
+read it before you `--apply`, and `git diff` after. The rename this ships is
+deliberately framework-specific for exactly that reason, and the risk is the
+line the `auto` label draws — a change that needs to know a receiver's type is
+labelled `review` or `manual` instead, never `auto`.
+
+Symlinked source files are not followed. Rewriting through a link could write
+outside the project, so a symlink is left alone; if your app keeps real source
+behind one, migrate it in its own checkout.

--- a/docs/guide/upgrading.md
+++ b/docs/guide/upgrading.md
@@ -176,8 +176,16 @@ Manual - not rewritten; read the guide section:
 A receiver written with a module in front of it is checked against that module
 too, so a real `repositories::PgAuditRepository` does not vouch for an unrelated
 `custom::PgAuditRepository`. An unqualified receiver is accepted on its name
-alone: resolving it would mean following `use` declarations, so an alias that
-imports a same-named type from elsewhere is the one case this cannot tell apart.
+alone — with one guard: because `#[repository]` produces its type from a macro,
+that type never appears in your source, so a `struct PgAuditRepository` written
+out anywhere in the scan is proof of a *different*, hand-written type. When both
+exist, an unqualified call could mean either and is reported rather than
+rewritten. Write the module in front of it to say which you mean.
+
+What remains unresolved is an alias: `use custom::PgAuditRepository;` followed by
+an unqualified call, where nothing in the scan spells out a competing
+definition. Following `use` declarations is name resolution, which this command
+does not do.
 
 Preview is still the default and the diff still names every file and line —
 read it before you `--apply`, and `git diff` after. This is also the line the

--- a/docs/guide/upgrading.md
+++ b/docs/guide/upgrading.md
@@ -124,6 +124,12 @@ Commit or stash first. `autumn upgrade --apply` edits files in place, and the
 diff you reviewed in the preview is the only record of what changed — `git
 diff` afterwards is how you check its work.
 
+Every file is read before any file is written, so a rewrite is computed from a
+snapshot. If something else changes one of those files in between — a formatter,
+a code generator, an editor saving — that file is refused rather than
+overwritten with the rewrite of stale contents, and the run reports it. Re-run
+to migrate it against what is now on disk.
+
 ## Adding a codemod (contributors)
 
 The registry is `autumn-cli/src/upgrade/migrations.rs`, one `AppMigration` per
@@ -180,7 +186,9 @@ alone — with one guard: because `#[repository]` produces its type from a macro
 that type never appears in your source, so a `struct PgAuditRepository` written
 out anywhere in the scan is proof of a *different*, hand-written type. When both
 exist, an unqualified call could mean either and is reported rather than
-rewritten. Write the module in front of it to say which you mean.
+rewritten. Write the module in front of it to say which you mean — unless the
+two sit at the same module path in different crates, in which case even that
+does not distinguish them and the call is still reported.
 
 What remains unresolved is an alias: `use custom::PgAuditRepository;` followed by
 an unqualified call, where nothing in the scan spells out a competing
@@ -205,10 +213,10 @@ If Cargo's output directory has been moved — `CARGO_TARGET_DIR`, or
 resolved as a path rather than matched by name. With the output in `out/`, an
 unrelated `src/out/mod.rs` is still migrated.
 
-The redirect is resolved the way Cargo resolves it, which means per subtree: a
-nested standalone crate with its own `.cargo/config.toml` redirects only its own
-output. `CARGO_TARGET_DIR` is the exception — it overrides every config file, so
-when it is set no nested config applies.
+Every `.cargo/config.toml` in the scan is read, not just the one at the root: a
+nested standalone crate redirects its own output, and the path it names need not
+sit under that crate. `CARGO_TARGET_DIR` is the exception — it overrides every
+config file, so when it is set no config redirect applies.
 
 Hidden directories are skipped by name — `.git`, `.github`, `.cargo`, `.vscode`
 and the like — not because they start with a dot. A dot-directory that holds

--- a/docs/guide/upgrading.md
+++ b/docs/guide/upgrading.md
@@ -177,3 +177,7 @@ Hidden directories are skipped by name — `.git`, `.github`, `.cargo`, `.vscode
 and the like — not because they start with a dot. A dot-directory that holds
 compiled source, say a `#[path = ".generated/repositories.rs"]` module, is
 migrated.
+
+The same exclusions decide which `Cargo.toml` files the version floor is read
+from, so a crate whose sources are rewritten always gets a vote on which
+migrations run.

--- a/docs/guide/upgrading.md
+++ b/docs/guide/upgrading.md
@@ -94,7 +94,7 @@ it was; one unparsable file never stops the rest of the migration.
 |------|--------|
 | `PATH` | Project directory to migrate (positional, defaults to `.`). |
 | `--apply` | Write the rewrites. Without it the command only previews. |
-| `--from VERSION` | Override the recorded `autumn-web` version. Needed when you already bumped the dependency, or when it is a git pin or a range with no single floor. |
+| `--from VERSION` | Override the recorded `autumn-web` version. Needed when you already bumped the dependency, or when the requirement has no single floor — a git pin, `*`, a multi-comparator range, or an upper bound like `"<0.6"`. In a virtual workspace the members' own manifests are read, and the oldest floor among them wins. |
 | `--to VERSION` | Upgrade to this release instead of the CLI's own version. |
 | `--json` | Machine-readable report — the same content, for CI. |
 | `--list-migrations` | Print the shipped codemods and exit, without scanning. |

--- a/docs/guide/upgrading.md
+++ b/docs/guide/upgrading.md
@@ -110,8 +110,15 @@ skipped, not rewritten.
 | `2` | A bad argument, a `PATH` that is not a readable directory, or a version this command cannot parse. Nothing was scanned. |
 
 There is no "found something" exit code: a preview that finds work is the
-command working. Gate on the `--json` report's `manual`, `skipped`, and
-`rewritten_sites` fields instead.
+command working. Gate on the `--json` report's `manual`, `skipped`, and site
+counts instead.
+
+The report carries two site counts, because "what did this run plan" and "what
+is on disk now" are different questions. `rewritten_sites` is the plan;
+`written_sites` is the part of it that reached disk — equal after a complete
+apply, zero for a preview, and only the files written before the failure after
+a partial one. Gate on `written_sites` when you care about the state of the
+working tree.
 
 ## Before you run it
 

--- a/docs/migrations/0.4.0.md
+++ b/docs/migrations/0.4.0.md
@@ -35,6 +35,8 @@ changes below before rolling the new binary.
 **Automation:** `manual` — no mechanical rewrite. This is a production
 default, satisfied by configuration and deployment secrets rather than by an
 edit to the app's source.
+Registry id `0.4.0-security-production-signing-secret`, so `autumn upgrade` still names this change and links
+this section when it falls in range.
 
 Production profiles now refuse to bind unless a stable signing secret is
 configured. This protects sessions, CSRF tokens, flash/signed-cookie state, and
@@ -61,6 +63,8 @@ previous_secrets = ["old-secret-hex-value"]
 dependency in `Cargo.toml` and a builder registration, so rewriting the
 import alone would not compile. Dependency edits are out of scope for
 `autumn upgrade`.
+Registry id `0.4.0-storage-s3-plugin-crate`, so `autumn upgrade` still names this change and links
+this section when it falls in range.
 
 The `storage-s3` feature no longer exists on `autumn-web`.
 
@@ -88,6 +92,8 @@ autumn_web::app()
 
 **Automation:** `manual` — no mechanical rewrite. Which policy a repository
 should carry is an application decision the tool cannot infer.
+Registry id `0.4.0-authorization-policy-required`, so `autumn upgrade` still names this change and links
+this section when it falls in range.
 
 Generated repository APIs must be paired with a policy in `prod`/`production`.
 
@@ -109,6 +115,8 @@ allow_unauthorized_repository_api = true
 **Automation:** `manual` — no mechanical rewrite. The fix is a deployment
 choice (a durable queue) or an explicit acknowledgement, not an edit to a
 call site.
+Registry id `0.4.0-mail-deliver-later-durable`, so `autumn upgrade` still names this change and links
+this section when it falls in range.
 
 `Mailer::deliver_later` and generated `deliver_later_*` helpers now require a
 durable `MailDeliveryQueue` in production unless mail transport is disabled.

--- a/docs/migrations/0.4.0.md
+++ b/docs/migrations/0.4.0.md
@@ -32,6 +32,10 @@ changes below before rolling the new binary.
 
 ### Security: production signing secret is required
 
+**Automation:** `manual` — no mechanical rewrite. This is a production
+default, satisfied by configuration and deployment secrets rather than by an
+edit to the app's source.
+
 Production profiles now refuse to bind unless a stable signing secret is
 configured. This protects sessions, CSRF tokens, flash/signed-cookie state, and
 signed storage URLs from per-process key churn.
@@ -52,6 +56,11 @@ previous_secrets = ["old-secret-hex-value"]
 ```
 
 ### Storage: `storage-s3` moved to a plugin crate
+
+**Automation:** `manual` — no mechanical rewrite. The move needs a new
+dependency in `Cargo.toml` and a builder registration, so rewriting the
+import alone would not compile. Dependency edits are out of scope for
+`autumn upgrade`.
 
 The `storage-s3` feature no longer exists on `autumn-web`.
 
@@ -77,6 +86,9 @@ autumn_web::app()
 
 ### Authorization: repository APIs require a policy in production
 
+**Automation:** `manual` — no mechanical rewrite. Which policy a repository
+should carry is an application decision the tool cannot infer.
+
 Generated repository APIs must be paired with a policy in `prod`/`production`.
 
 ```rust,ignore
@@ -93,6 +105,10 @@ allow_unauthorized_repository_api = true
 ```
 
 ### Mail: production `deliver_later` must be durable or acknowledged
+
+**Automation:** `manual` — no mechanical rewrite. The fix is a deployment
+choice (a durable queue) or an explicit acknowledgement, not an edit to a
+call site.
 
 `Mailer::deliver_later` and generated `deliver_later_*` helpers now require a
 durable `MailDeliveryQueue` in production unless mail transport is disabled.

--- a/docs/migrations/0.5.0.md
+++ b/docs/migrations/0.5.0.md
@@ -66,6 +66,8 @@ Full commit-level picture: the [0.5.0 CHANGELOG entry](../../CHANGELOG.md).
 `autumn.toml` keys and in which component decides trust, not in a Rust
 identifier; config rewriting is out of scope for `autumn upgrade`
 (the keys carry deprecation warnings via `DEPRECATED_CONFIG_KEYS`).
+Registry id `0.5.0-security-forwarded-header-trust`, so `autumn upgrade` still names this change and links
+this section when it falls in range.
 
 **Why:** three separate middlewares each decided independently whether to
 believe `X-Forwarded-*`, and an attacker who could set those headers could
@@ -109,6 +111,8 @@ rg -n 'AUTUMN_SECURITY__RATE_LIMIT__TRUST' .  # and their env overrides
 **Automation:** `manual` — no mechanical rewrite. These are `autumn.toml`
 keys, not app code; `autumn doctor` reports each one and the loader warns at
 startup.
+Registry id `0.5.0-deprecated-configuration-keys`, so `autumn upgrade` still names this change and links
+this section when it falls in range.
 
 `security.rate_limit.trusted_proxies` and
 `security.rate_limit.trust_forwarded_headers` keep working — they are
@@ -128,6 +132,8 @@ confusing place to leave a security boundary.
 **Automation:** `manual` — no mechanical rewrite. Replacing hand-rolled
 header parsing with an extractor changes the shape of the handler, not the
 name of a call.
+Registry id `0.5.0-client-identity-extractors`, so `autumn upgrade` still names this change and links
+this section when it falls in range.
 
 **Why:** a handler that reads `X-Forwarded-For` itself re-opens the hole the
 central policy just closed, because it applies no trust boundary at all.

--- a/docs/migrations/0.5.0.md
+++ b/docs/migrations/0.5.0.md
@@ -62,6 +62,11 @@ Full commit-level picture: the [0.5.0 CHANGELOG entry](../../CHANGELOG.md).
 
 ### Security: forwarded-header trust is now declared once
 
+**Automation:** `manual` — no mechanical rewrite. The change is in
+`autumn.toml` keys and in which component decides trust, not in a Rust
+identifier; config rewriting is out of scope for `autumn upgrade`
+(the keys carry deprecation warnings via `DEPRECATED_CONFIG_KEYS`).
+
 **Why:** three separate middlewares each decided independently whether to
 believe `X-Forwarded-*`, and an attacker who could set those headers could
 bypass rate limiting and defeat the CSRF/method-override origin checks. 0.5.0
@@ -101,6 +106,10 @@ rg -n 'AUTUMN_SECURITY__RATE_LIMIT__TRUST' .  # and their env overrides
 
 ### Deprecated configuration keys
 
+**Automation:** `manual` — no mechanical rewrite. These are `autumn.toml`
+keys, not app code; `autumn doctor` reports each one and the loader warns at
+startup.
+
 `security.rate_limit.trusted_proxies` and
 `security.rate_limit.trust_forwarded_headers` keep working — they are
 registered for removal in `1.0.0` — and log a deprecation warning at startup.
@@ -115,6 +124,10 @@ confusing place to leave a security boundary.
 | `security.rate_limit.trust_forwarded_headers` / `AUTUMN_SECURITY__RATE_LIMIT__TRUST_FORWARDED_HEADERS` | `security.trusted_proxies.trust_forwarded_headers` | `0.5.0` | `1.0.0` |
 
 ### Reading client identity: `ClientAddr`, `ClientHost`, `ClientScheme`
+
+**Automation:** `manual` — no mechanical rewrite. Replacing hand-rolled
+header parsing with an extractor changes the shape of the handler, not the
+name of a call.
 
 **Why:** a handler that reads `X-Forwarded-For` itself re-opens the hole the
 central policy just closed, because it applies no trust boundary at all.

--- a/docs/migrations/0.6.0.md
+++ b/docs/migrations/0.6.0.md
@@ -37,6 +37,14 @@ all you need.
 
 ### Security: `TenancyConfig::jwt_secret` is now a `secrecy::SecretString`
 
+**Automation:** `manual` — no mechanical rewrite. Reads become
+`.expose_secret()` and writes become `.into()`, which is a type change at
+each use rather than a rename, and the right call depends on what the
+surrounding code does with the value. Codemod id
+`0.6.0-tenancy-jwt-secret-secretstring` reserves the slot in the registry
+(`autumn-cli/src/upgrade/migrations.rs`) so `autumn upgrade` still surfaces
+this change and links this section.
+
 The field type changed from `Option<String>` to `Option<secrecy::SecretString>`
 so the raw signing secret is redacted from `Debug` output (and anything that
 formats the config) and zeroized on drop.
@@ -76,6 +84,12 @@ error[E0308]: mismatched types
 ```
 
 ### Repository: `with_pool` is renamed to `with_pool_untracked`
+
+**Automation:** `auto` — `autumn upgrade` rewrites every call site; codemod
+`0.6.0-repository-with-pool-untracked`. Run `autumn upgrade` to preview the
+diff and `autumn upgrade --apply` to write it. Call sites inside a macro
+invocation are reported with `file:line` under `manual` instead of being
+rewritten.
 
 The generated repository constructor that takes a bare pool is now called
 `with_pool_untracked`, so the call site says out loud that request
@@ -140,10 +154,16 @@ outside a request — startup tasks, one-off scripts, tests.
 ### Guide-only upgrade walkthrough
 
 The release checklist requires upgrading an app scaffolded with `autumn new` on
-the previous release using **only** this guide — no changelog, no source
-reading. See [`docs/release-checklist.md`](../release-checklist.md), *Migration
-Guide Gate*.
+the previous release **codemod-first** — `autumn upgrade` before any manual
+step — and using **only** this guide for what remains. See
+[`docs/release-checklist.md`](../release-checklist.md), *Migration Guide Gate*.
 
+- **Codemod:** `autumn upgrade` (preview) then `autumn upgrade --apply` covers
+  the `with_pool` rename in full; codemod
+  `0.6.0-repository-with-pool-untracked`. The command did not exist when 0.6.0
+  shipped — it landed with issue #1629 — so this record is retrospective. From
+  the next release the walk-through runs it before any manual step, and the
+  manual steps that remain are only those labelled `review` or `manual` above.
 - **Status:** backfilled — the `with_pool` section was written by #1588 after
   0.6.0 shipped, so the guide-only upgrade was never performed for this
   release. It is a required, recorded step from the next release onward.

--- a/docs/migrations/0.6.0.md
+++ b/docs/migrations/0.6.0.md
@@ -105,11 +105,15 @@ vendored checkout) between 0.5.0 and 0.6.0, or are following an older
 
 ```rust,ignore
 // trunk-dev, before the rename
-let repo = PostRepository::with_pool(pool.clone());
+let repo = PgPostRepository::with_pool(pool.clone());
 
 // 0.6.0
-let repo = PostRepository::with_pool_untracked(pool.clone());
+let repo = PgPostRepository::with_pool_untracked(pool.clone());
 ```
+
+(`#[repository]` emits its concrete type as `Pg` + the trait name, so the type
+carrying this constructor is `PgPostRepository`, not the `PostRepository`
+trait you declared.)
 
 Only the name changes — the signature and the semantics are identical:
 
@@ -122,9 +126,9 @@ The compiler error you will see if you skip this:
 
 ```
 error[E0599]: no function or associated item named `with_pool` found for struct
-              `PostRepository` in the current scope
-note: if you're trying to build a new `PostRepository`, consider using
-      `PostRepository::with_pool_untracked` which returns `PostRepository`
+              `PgPostRepository` in the current scope
+note: if you're trying to build a new `PgPostRepository`, consider using
+      `PgPostRepository::with_pool_untracked` which returns `PgPostRepository`
 ```
 
 Prefer the tracked constructors where you can. `from_shard(&ShardedDb)` (new in

--- a/docs/migrations/README.md
+++ b/docs/migrations/README.md
@@ -70,6 +70,35 @@ tooling, policy docs — append an explicit suppression naming its reason:
 It is greppable and shows up in the diff, so using it on a real break is a
 reviewable act rather than a silent one.
 
+## Classifying a breaking change: the automation label
+
+Every breaking change in a guide carries one line saying how much of it a
+machine can apply, so a reader knows before starting whether the upgrade is a
+command or an afternoon (issue #1629):
+
+```markdown
+**Automation:** `auto` — `autumn upgrade` rewrites every call site; codemod
+`0.6.0-repository-with-pool-untracked`.
+```
+
+| Label | Meaning | What the reader does |
+|-------|---------|----------------------|
+| `auto` | Safe by construction — a rename or an import move. `autumn upgrade` rewrites every reachable call site. | Run `autumn upgrade --apply` and read the diff. |
+| `review` | `autumn upgrade` rewrites it, and flags **every** rewritten site in the summary. | Run it, then read each flagged site. |
+| `manual` | No mechanical rewrite. This guide section is the fix path. | Follow the section. |
+
+An `auto`/`review` entry names the shipped codemod id from the registry in
+[`autumn-cli/src/upgrade/migrations.rs`](../../autumn-cli/src/upgrade/migrations.rs);
+that registry is what `autumn upgrade` actually runs, so the guide cannot
+promise a codemod nobody wrote. A `manual` label on a *rename-level* change —
+the class the tool can apply safely — has to say why it stays manual. Semantic
+and behavioural changes need no justification: the label is the whole answer.
+
+Nothing is silently skipped at either end. A change the codemod cannot reach —
+a call site inside a macro invocation, a generated file — is reported by
+`autumn upgrade` with `file:line` under `manual`, pointing at the guide section
+named in the registry entry.
+
 ## Process for a breaking release
 
 1. **Open the draft with the first breaking change.** The first PR that lands a
@@ -79,10 +108,12 @@ reviewable act rather than a silent one.
    breaking-change PR appends a section with *before* / *after* snippets and the
    compiler error the user will see. For a contributor opening a
    breaking-change PR, that section is part of "done".
-3. **Perform the guide-only walk-through before publishing.** Upgrade an app
-   scaffolded with `autumn new` on the *previous* release using only the guide —
-   no changelog, no source reading — and record the result in the guide's
-   `### Guide-only upgrade walkthrough` section. See
+3. **Perform the walk-through before publishing, codemod-first.** Upgrade an
+   app scaffolded with `autumn new` on the *previous* release: run
+   `autumn upgrade` **before any manual step**, then follow the guide — and
+   only the guide, no changelog, no source reading — for the changes labelled
+   `review` and `manual`. Record both the codemod invocation and the result in
+   the guide's `### Guide-only upgrade walkthrough` section. See
    [`docs/release-checklist.md`](../release-checklist.md).
 4. **Rename at release.** `next.md` becomes `<version>.md`, its version
    placeholders are filled in, the index above is updated, and the changelog
@@ -129,6 +160,25 @@ It fails when:
   empty-section checks — the release checklist recreates it from
   `TEMPLATE.md` after every release, and the template ships placeholders by
   design. Every exemption lapses the moment it is renamed to `<version>.md`.
+- a change in a guide that reads as a rename or an import move carries no
+  `**Automation:**` label; any label whose value is not `auto`/`review`/`manual`
+  (a bare `auto` outside a code span is not a label); an `auto`/`review` label
+  that names no codemod id shipped in
+  `autumn-cli/src/upgrade/migrations.rs` **for that release** (an id from an
+  earlier release does not cover a later one, and an id shown only inside a
+  fenced sample is a sample); or a rename-level change labelled `manual` with no
+  reason given (issue #1629). Entries are read under every `## ` section, not
+  only `## Breaking changes`, and rename detection is textual and errs toward
+  asking: a false positive costs one sentence, a false negative strands users on
+  a hand-edit the tool could have done. A released guide that ships an
+  `auto`/`review` codemod must also record a `- **Codemod:**` line under
+  `### Guide-only upgrade walkthrough`, because the walk-through is performed
+  codemod-first. An entry carrying the `migration-guide-gate` suppression is
+  exempt from all of this, exactly as for the changelog checks above.
+
+  That *every* breaking change carries a label — not only the rename-level ones
+  the shell gate insists on — is asserted over this repository's guides as a set
+  by `autumn-cli`'s `upgrade_codemod` test suite;
 - `next.md` is missing. The rolling draft is permanent, not conditional on
   there being an unreleased break: this file and `STABILITY.md` both link it by
   name, and nothing here checks markdown links;

--- a/docs/migrations/TEMPLATE.md
+++ b/docs/migrations/TEMPLATE.md
@@ -42,22 +42,37 @@ full commit-level picture.
 
 ## Step-by-step
 
-1. **Bump the dependency.**
+1. **Run `autumn upgrade`** — *before* the dependency bump. The release it
+   migrates from is the one your `Cargo.toml` still records, so bumping first
+   leaves nothing in range. It previews every mechanical change this release
+   can apply to your own source — a per-file diff plus a count of affected
+   sites — and writes nothing; re-run with `--apply` to take them. Anything it
+   cannot safely rewrite is listed with `file:line` and a link to the guide
+   section that explains it.
+
+   ```bash
+   cargo install autumn-cli --version {X.Z.0}
+   autumn upgrade            # preview
+   autumn upgrade --apply    # take it
+   ```
+
+2. **Bump the dependency.**
    ```toml
    # Cargo.toml
    [dependencies]
    autumn-web = "{(X+1).0}"
    ```
 
-2. **Run `cargo check`.** Work through the compiler errors section by
-   section using the cheat sheet below.
+3. **Run `cargo check`.** Work through the compiler errors section by
+   section using the cheat sheet below. Only the changes labelled `review` or
+   `manual` above should still need you.
 
-3. **Apply configuration changes** (see
+4. **Apply configuration changes** (see
    [Configuration changes](#configuration-changes)).
 
-4. **Run the test suite.**
+5. **Run the test suite.**
 
-5. **Run the application locally** and exercise each feature at least
+6. **Run the application locally** and exercise each feature at least
    once. Pay attention to the [Behavior changes](#behavior-changes)
    section.
 
@@ -83,8 +98,16 @@ care about.
 // paste the equivalent on the new version
 ```
 
-**If you are automating the upgrade:** optional `sed`/`rg` one-liner or
-note about a `cargo fix --edition`-style tool if one applies.
+**Automation:** `manual` — {why no codemod applies: it needs new arguments, it
+is a configuration or behaviour change, it is only reachable inside a macro, ….
+For a change `autumn upgrade` *does* rewrite, use `auto` (safe by construction:
+renames and import moves) or `review` (rewritten, every site flagged for a
+human) instead, and name the shipped codemod id from
+`autumn-cli/src/upgrade/migrations.rs` in this paragraph.}
+
+Every breaking change carries this label — `scripts/check-migration-guides.sh`
+fails without it, and fails an `auto`/`review` label that names no shipped
+codemod, or a rename-level change left `manual` with no reason (issue #1629).
 
 ---
 
@@ -161,17 +184,25 @@ commands with expected output, not "make sure everything works". Required by
 
 ### Guide-only upgrade walkthrough
 
-Upgrade an app scaffolded with `autumn new` on the **previous** release using
-only this guide — no changelog, no source reading — and record the result here
-before publishing to crates.io. See
-[`docs/release-checklist.md`](../release-checklist.md), *Migration Guide Gate*.
+(The heading keeps its historical name; the walk-through itself is
+codemod-first.) Upgrade an app scaffolded with `autumn new` on the **previous** release
+**codemod-first** — `autumn upgrade` before any manual step — using only this
+guide for what remains, and record the result here before publishing to
+crates.io. See [`docs/release-checklist.md`](../release-checklist.md),
+*Migration Guide Gate*.
 
+- **Codemod:** {the `autumn upgrade` invocation the walk-through ran first, and
+  what it covered. Required once this release ships any `auto`/`review`
+  codemod; the remaining manual steps below must be only the `review`/`manual`
+  changes.}
 - **Status:** pending
   {the value must *begin* with `performed YYYY-MM-DD` once the walk-through is
   done, or `backfilled` for a guide written after its release shipped;
   `pending` is accepted only while this file is still `next.md`}
 - **From → to:** `autumn-cli {X.Y.Z}` app upgraded to `autumn-web {X.Z.0}`
-- **Elapsed:** {minutes — the success metric is under 30}
+- **Elapsed:** {minutes — the budget is under 30 for a guide-only
+  walk-through, and under 10 once `autumn upgrade` covers this release's
+  rename-level changes (issue #1629)}
 - **Gaps found and fixed in this guide:** {none, or what the walk-through
   exposed}
 

--- a/docs/migrations/next.md
+++ b/docs/migrations/next.md
@@ -56,6 +56,10 @@ only a layer implemented non-generically against `Route` itself can notice.
 
 ### Routing: `Route` and `StaticRouteMeta` gained an `seo` field
 
+**Automation:** `manual` — no mechanical rewrite. A new struct field needs a
+value, and only the author of the route knows which one; adding arguments is
+outside the rename-level scope of `autumn upgrade`.
+
 **Why:** route-level SEO defaults (`#[get("/about", seo(title = "..."))]`) are
 recorded on the route itself, so the router can install the request extension
 only for routes that declared something and routes without `seo(...)` pay
@@ -101,6 +105,9 @@ rg -n 'Route \{|StaticRouteMeta \{' src/
 
 ### JSON API: a `lock_version` model now requires the version on `PUT`/`PATCH`
 
+**Automation:** `manual` — no mechanical rewrite. The change is on the wire,
+in clients this tool never sees, not in the app's Rust source.
+
 **Why:** declaring a column literally named `lock_version` opts a model into
 optimistic locking (#1318). `#[lock_version]` carries the column on
 `Update{Model}` as the *expected* version, which is what lets the repository
@@ -137,6 +144,9 @@ generate` prints a warning naming this escape hatch whenever it detects the
 name.
 
 ### App-wide layers are now erased
+
+**Automation:** `manual` — no mechanical rewrite. The fix is to make a layer
+impl generic, which is a change of shape rather than of name.
 
 **Why:** `AppBuilder::layer` / `static_gate` registrations (including plugin
 layers) are type-erased at registration time and composed into a single
@@ -180,6 +190,11 @@ rg -n 'Layer<axum::routing::Route>|Layer<Route>' src/
 ## Deprecations (non-breaking)
 
 ### `scheduler::now_unix_secs` / `scheduler::now_unix_duration`
+
+**Automation:** `manual` — no mechanical rewrite. The replacement takes the
+app's injected clock as a new argument, and finding the right `AppState` in
+scope is inference well beyond a rename — explicitly out of scope for
+`autumn upgrade` (issue #1629).
 
 Both read the real system clock directly, off the framework's injected-clock
 seam, so anything derived from them — a scheduled-task tick key, an expiry

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -206,6 +206,13 @@ guide** — the guide is a gate, not a courtesy (issue #1588). See
   index entry.
 - [ ] `./scripts/check-migration-guides.sh --list` shows the breaking-entry
   count for the release being cut, and it matches what you expect to ship.
+- [ ] Every breaking change in the guide carries an `**Automation:**` label
+  (`auto` / `review` / `manual`), and each `auto`/`review` entry names a codemod
+  that is actually shipped in `autumn-cli/src/upgrade/migrations.rs`. The same
+  gate enforces this — see [`docs/migrations/README.md`](migrations/README.md),
+  *Classifying a breaking change* (issue #1629).
+- [ ] `cargo run -p autumn-cli --bin autumn -- upgrade --list-migrations` shows
+  the codemods this release ships, and each one's guide link resolves.
 
 ### Rename the rolling draft
 
@@ -226,26 +233,42 @@ guide** — the guide is a gate, not a courtesy (issue #1588). See
 - [ ] Update the index in [`docs/migrations/README.md`](migrations/README.md):
   add `X.Y.Z.md`, keep `next.md`.
 
-### Guide-only upgrade walk-through (required before `cargo publish`)
+### Upgrade walk-through (required before `cargo publish`)
 
 The guide is only proven when someone who has not read the diff can follow it.
-Perform this against the **previous** release and record the result — the
-success metric is under 30 minutes.
+Perform this against the **previous** release and record the result. It is
+**codemod-first**: `autumn upgrade` runs before any manual step, so the steps
+that remain are only the changes labelled `review` and `manual` (issue #1629).
+The budget is under 30 minutes guide-only, and under 10 once a codemod covers
+the release's rename-level changes.
 
 - [ ] `cargo install autumn-cli --version <previous-version>`
 - [ ] `autumn new upgrade-probe && cd upgrade-probe && autumn setup`
 - [ ] Give the app something to break against: `autumn generate scaffold Post
   title:String body:Text published:bool`, `autumn migrate`, `cargo test`, and a
   `GET /posts` that responds. This is the green baseline.
-- [ ] Upgrade to the release candidate **following only
-  `docs/migrations/X.Y.Z.md`** — no changelog, no source reading, no asking the
-  author. If you have to look outside the guide, that is a gap in the guide:
-  fix the guide and restart from this step.
+- [ ] **Run the codemods first, before touching `Cargo.toml`.** The release
+  `autumn upgrade` migrates *from* is the one the probe app still records, so
+  bumping the dependency first leaves nothing in range and the command reports
+  "nothing to change" — which would make this gate pass for the wrong reason.
+  Install the candidate CLI, then `autumn upgrade` to read the preview diff and
+  the affected-site count, then `autumn upgrade --apply`. Note anything it
+  reports under `manual` — those are the sites the guide still has to carry.
+- [ ] Now bump `autumn-web` to the release candidate and `cargo check`.
+- [ ] Upgrade the rest **following only `docs/migrations/X.Y.Z.md`** — no
+  changelog, no source reading, no asking the author. If you have to look
+  outside the guide, that is a gap in the guide: fix the guide and restart from
+  this step. If a step you had to do by hand was a plain rename, that is a gap
+  in the *codemods*: add the migration to
+  `autumn-cli/src/upgrade/migrations.rs` and restart.
 - [ ] `cargo check`, `cargo test`, and every step in the guide's *How to verify*
   section pass.
 - [ ] Record the outcome in the guide's `### Guide-only upgrade walkthrough`
-  section: status, from → to versions, elapsed minutes, and any gap the
-  walk-through exposed. `check-migration-guides.sh` enforces this — a versioned
+  section (the heading keeps its historical name; the walk-through itself is
+  codemod-first): the `- **Codemod:**` invocation you ran first and what it covered,
+  then status, from → to versions, elapsed minutes, and any gap the
+  walk-through exposed. A guide shipping an `auto`/`review` codemod without the
+  codemod line fails the gate. `check-migration-guides.sh` enforces this — a versioned
   guide's status must **begin** with `performed YYYY-MM-DD`. `pending` is
   accepted only on the rolling `next.md` draft, and the one other accepted
   opening, `backfilled`, means "this guide was written after its release
@@ -294,7 +317,7 @@ Before pushing the release tag:
    `### Breaking Changes` heading) and links its migration guide.
 4. **Complete the [Migration Guide Gate](#migration-guide-gate)** — rename
    `docs/migrations/next.md`, repoint the changelog links, and perform and
-   record the guide-only upgrade walk-through.
+   record the codemod-first upgrade walk-through.
 5. **Run all gate scripts locally** to catch problems before CI sees the tag:
    ```bash
    ./scripts/check-crate-metadata.sh

--- a/scripts/check-migration-guides.sh
+++ b/scripts/check-migration-guides.sh
@@ -2249,6 +2249,7 @@ if [[ -d "$MIGRATIONS_DIR" ]]; then
             # Scoped like check 4 scopes the `Status:` line: only bullets under
             # this exact heading count, not ones under a later sibling.
             in_walkthrough = (text == walkthrough_heading)
+            in_codemod_bullet = 0
             if (in_walkthrough) next
             heading = text
             sub(/^###[[:space:]]*/, "", heading)
@@ -2266,8 +2267,20 @@ if [[ -d "$MIGRATIONS_DIR" ]]; then
           }
           next
         }
+        # The bullet counts only if it records an `autumn upgrade` run:
+        # `- **Codemod:** none` names the label without doing the thing. The
+        # value may wrap onto continuation lines, as `TEMPLATE.md` shows, so
+        # the whole bullet is scanned rather than just its first line.
         in_walkthrough && visible ~ /^-[[:space:]]+\*\*Codemod:\*\*/ {
-          walkthrough_codemod = 1
+          in_codemod_bullet = 1
+          if (visible ~ /autumn upgrade/) walkthrough_codemod = 1
+        }
+        in_walkthrough && in_codemod_bullet && visible !~ /^-[[:space:]]+\*\*Codemod:\*\*/ {
+          if (visible ~ /^[[:space:]]*$/ || visible ~ /^-[[:space:]]/) {
+            in_codemod_bullet = 0
+          } else if (visible ~ /autumn upgrade/) {
+            walkthrough_codemod = 1
+          }
         }
         heading != "" {
           if (suppressed_by_comment(raw)) suppressed = 1
@@ -2275,8 +2288,11 @@ if [[ -d "$MIGRATIONS_DIR" ]]; then
           # An id from *another* release does not cover this one: citing
           # the 0.6.0 codemod in the 0.7.0 guide would otherwise satisfy the
           # check. The draft has no version yet, so it accepts any shipped id.
+          # Matched as a complete code span: a bare substring would let
+          # `0.7.0-with-pool-extra` — a codemod nobody wrote — be vouched for
+          # by the shipped `0.7.0-with-pool`. Every guide spells ids this way.
           for (id in known) {
-            if (index(visible, id) == 0) continue
+            if (index(visible, "`" id "`") == 0) continue
             if (guide_version == "" || index(id, guide_version "-") == 1) named_known = 1
           }
 

--- a/scripts/check-migration-guides.sh
+++ b/scripts/check-migration-guides.sh
@@ -2053,6 +2053,294 @@ if [[ -d "$MIGRATIONS_DIR" ]]; then
   shopt -u nullglob
 fi
 
+# ---------------------------------------------------------------------------
+# Check 5: codemod coverage (issue #1629).
+#
+# #1588 made the guide a gate; this makes the *automation* a gate. Every
+# breaking entry in a guide -- each `### ` section under `## Breaking changes`
+# -- declares how much of it a machine can apply, with a one-word confidence
+# label that a reader and this script both understand:
+#
+#   **Automation:** `auto`   -- `autumn upgrade` rewrites every call site.
+#   **Automation:** `review` -- it rewrites, and flags each site for a human.
+#   **Automation:** `manual` -- no rewrite; this guide section is the fix path.
+#
+# Four things are enforced:
+#
+#   1. Classification where it is load-bearing. A rename-level entry -- the
+#      class `autumn upgrade` can apply -- must carry a label; shipping one
+#      unclassified is the exact failure issue #1629 exists to prevent. That
+#      *every* breaking entry in this repository's guides carries a label is
+#      asserted separately, over the real guides as a set, by the
+#      `upgrade_codemod` test suite in autumn-cli.
+#
+#      Entries are read under *every* `## ` section, not only
+#      `## Breaking changes`: a rename documented under `## Behavior changes`
+#      or `## Configuration changes` breaks apps exactly as hard, and scoping
+#      the scan to one heading let it through. `### Guide-only upgrade
+#      walkthrough` is the one `### ` that is never an entry.
+#   2. The codemod exists. An `auto`/`review` entry must name a migration id
+#      that is actually shipped in the registry ($CODEMOD_REGISTRY). A guide
+#      promising a codemod nobody wrote is worse than no promise.
+#   3. Rename-level changes justify staying manual. A rename or an import move
+#      is the class `autumn upgrade` can apply safely, so `manual` there needs
+#      a stated reason. Semantic and behavioural changes need no justification:
+#      the label alone is the whole answer for them.
+#   4. Codemod-first walk-through. A released guide that ships an `auto`/
+#      `review` codemod records a `- **Codemod:**` line under
+#      `### Guide-only upgrade walkthrough`, because #1629 requires the
+#      per-release walk-through to run `autumn upgrade` before any manual step.
+#
+# Rename detection is textual, like the unmarked-break lint above, and it
+# deliberately errs toward *over*-detecting: a false positive costs the author
+# one sentence of justification, while a false negative is a release that
+# strands users on a hand-edit the tool could have done. Negations are not
+# special-cased for that reason.
+#
+# The registry is read as text rather than by building the CLI, so this stays a
+# lint-job-speed check. A missing registry file reads as "no codemods shipped",
+# which makes the gate stricter (every `auto`/`review` claim fails), never
+# laxer.
+#
+# An entry carrying the `<!-- migration-guide-gate: <reason> -->` suppression
+# (the same one check 1 reads) is exempt from all four, so an entry that merely
+# *documents* the convention does not have to satisfy it. Like every use of
+# that token it is greppable and shows up in the diff.
+#
+# Residual risk, stated plainly: a breaking change written as prose with no
+# `### ` heading of its own -- including one written as a setext heading -- is
+# not an entry here, so it is not classified. TEMPLATE.md gives every change its
+# own ATX heading; reviewers remain the backstop.
+# ---------------------------------------------------------------------------
+CODEMOD_REGISTRY="${CODEMOD_REGISTRY:-autumn-cli/src/upgrade/migrations.rs}"
+codemod_ids="$defs_dir/codemod.ids"
+: >"$codemod_ids"
+if [[ -e "$CODEMOD_REGISTRY" ]]; then
+  # A registry that exists but cannot be read is not "no codemods shipped" —
+  # it is a broken checkout, and reading it as an empty list would turn every
+  # honest `auto` label into a failure with a misleading message.
+  if [[ ! -r "$CODEMOD_REGISTRY" ]]; then
+    die "$CODEMOD_REGISTRY exists but cannot be read."
+  fi
+  # `    id: "0.6.0-repository-with-pool-untracked",` -> the bare id.
+  if ! sed -n 's/^[[:space:]]*id:[[:space:]]*"\([^"]*\)".*/\1/p' "$CODEMOD_REGISTRY" >"$codemod_ids"; then
+    die "$CODEMOD_REGISTRY could not be scanned for codemod ids."
+    : >"$codemod_ids"
+  fi
+fi
+
+if [[ -d "$MIGRATIONS_DIR" ]]; then
+  shopt -s nullglob
+  for guide in "$MIGRATIONS_DIR"/*.md; do
+    base="$(basename "$guide")"
+    [[ "$base" == "README.md" || "$base" == "TEMPLATE.md" ]] && continue
+
+    # The rolling draft is a skeleton recreated from TEMPLATE.md after every
+    # release; it has no walk-through to have performed yet, and no version of
+    # its own to match codemod ids against.
+    guide_is_draft=0
+    [[ "$guide" == "$UNRELEASED_GUIDE" ]] && guide_is_draft=1
+    guide_version="${base%.md}"
+    [[ "$guide_is_draft" == "1" ]] && guide_version=""
+
+    codemod_findings="$(
+      awk -v codemod_ids="$codemod_ids" -v is_draft="$guide_is_draft" \
+          -v guide_version="$guide_version" \
+          -v walkthrough_heading="### Guide-only upgrade walkthrough" \
+          "$AWK_MARKDOWN_LIB"'
+        function load_codemods(path,   line) {
+          while ((getline line < path) > 0) {
+            sub(/[[:space:]]+$/, "", line)
+            if (line != "") known[line] = 1
+          }
+          close(path)
+        }
+        # The text of a line with its indentation and any list marker removed.
+        # A label written as a bullet is the same declaration a reader sees as
+        # one; reading only unmarked paragraphs let a bulleted `auto` claim a
+        # codemod nobody wrote, unchecked.
+        function label_line_body(text,   body) {
+          body = block_body(text)
+          sub(/^[-*+][[:space:]]+/, "", body)
+          sub(/^[0-9]+[.)][[:space:]]+/, "", body)
+          sub(/^[[:space:]]+/, "", body)
+          return body
+        }
+        # A rename or an import move is the class `autumn upgrade` can apply.
+        function looks_mechanical(text,   t) {
+          t = tolower(text)
+          return (t ~ /renam/ || t ~ /moved (to|from|into)/ || t ~ /import move/)
+        }
+        # The entry just finished: report what it failed to say.
+        function flush_entry() {
+          if (heading == "") return
+          if (suppressed) { heading = ""; return }
+          if (!has_label) {
+            # Classification of *every* breaking change is asserted over the
+            # real guides by the `upgrade_codemod` suite in autumn-cli, which
+            # reads them as a set. Here the gate demands a label where the
+            # decision is load-bearing: a rename or import move is the class
+            # `autumn upgrade` applies, so shipping one unclassified is the
+            # exact failure issue #1629 exists to prevent.
+            if (rename_level) {
+              printf "NOLABEL\t%s\t%d\t-\n", heading, heading_line
+            }
+          } else if (label_value != "auto" && label_value != "review" &&
+                     label_value != "manual") {
+            printf "BADLABEL\t%s\t%d\t%s\n", heading, label_line, label_value
+          } else if (label_value == "auto" || label_value == "review") {
+            if (named_known) {
+              guide_ships = 1
+            } else {
+              printf "NOCODEMOD\t%s\t%d\t%s\n", heading, label_line, label_value
+            }
+          } else if (rename_level && !justified) {
+            printf "NOJUSTIFY\t%s\t%d\t-\n", heading, label_line
+          }
+          heading = ""
+        }
+        BEGIN { load_codemods(codemod_ids) }
+        {
+          if (!md_in_fence) track_block_indent($0)
+          raw = $0
+          visible = visible_text($0)
+          if (md_fence_hit) next
+          # A fenced body, a comment and a raw HTML block are all sample or
+          # invisible text: an `**Automation:**` label was never going to live
+          # in one, and a before/after snippet is not a declaration.
+          if (md_in_fence || md_in_comment || md_in_html_block) {
+            # A sample interrupts the label paragraph: prose after it is new
+            # prose, not a continuation of the justification.
+            in_label_block = 0
+            next
+          }
+        }
+        is_atx_heading(visible) {
+          text = heading_text(visible)
+          level = 0
+          while (substr(text, level + 1, 1) == "#") level++
+          if (level <= 3) flush_entry()
+          if (level <= 2) in_walkthrough = 0
+          if (level == 2) next
+          if (level == 3) {
+            # Scoped like check 4 scopes the `Status:` line: only bullets under
+            # this exact heading count, not ones under a later sibling.
+            in_walkthrough = (text == walkthrough_heading)
+            if (in_walkthrough) next
+            heading = text
+            sub(/^###[[:space:]]*/, "", heading)
+            heading_line = NR
+            has_label = 0
+            label_value = ""
+            label_line = 0
+            named_known = 0
+            justified = 0
+            justification = ""
+            in_label_block = 0
+            suppressed = suppressed_by_comment(raw)
+            rename_level = looks_mechanical(heading)
+            next
+          }
+          next
+        }
+        in_walkthrough && visible ~ /^-[[:space:]]+\*\*Codemod:\*\*/ {
+          walkthrough_codemod = 1
+        }
+        heading != "" {
+          if (suppressed_by_comment(raw)) suppressed = 1
+          if (looks_mechanical(visible)) rename_level = 1
+          # An id from *another* release does not cover this one: citing
+          # the 0.6.0 codemod in the 0.7.0 guide would otherwise satisfy the
+          # check. The draft has no version yet, so it accepts any shipped id.
+          for (id in known) {
+            if (index(visible, id) == 0) continue
+            if (guide_version == "" || index(id, guide_version "-") == 1) named_known = 1
+          }
+
+          if (label_line_body(visible) ~ /^\*\*Automation:\*\*/) {
+            has_label = 1
+            label_line = NR
+            in_label_block = 1
+            rest = label_line_body(visible)
+            sub(/^\*\*Automation:\*\*[[:space:]]*/, "", rest)
+            # The label is the first code span, so `auto` is read from
+            # `` `auto` `` and never from the sentence that follows it.
+            if (match(rest, /^`[a-z]+`/)) {
+              label_value = substr(rest, RSTART + 1, RLENGTH - 2)
+              rest = substr(rest, RSTART + RLENGTH)
+            } else {
+              label_value = "(none)"
+            }
+            justification = rest
+          } else if (in_label_block) {
+            if (visible ~ /^[[:space:]]*$/) {
+              in_label_block = 0
+            } else {
+              justification = justification " " visible
+            }
+          }
+          if (has_label) {
+            plain = justification
+            gsub(/[^[:alnum:]]/, "", plain)
+            # A bare label is a classification, not a reason. Twelve
+            # alphanumerics is a few words -- enough to carry one, and low
+            # enough that the reasons this gate itself suggests ("needs new
+            # arguments") clear it.
+            justified = (length(plain) >= 12)
+          }
+        }
+        END {
+          flush_entry()
+          if (!is_draft && guide_ships && !walkthrough_codemod) {
+            printf "NOWALKTHROUGH\t-\t0\t-\n"
+          }
+        }
+      ' "$guide"
+    )"
+
+    [[ -z "$codemod_findings" ]] && continue
+    while IFS=$'\t' read -r kind entry line detail; do
+      [[ -n "$kind" ]] || continue
+      case "$kind" in
+        NOLABEL)
+          die "$guide:$line: breaking change '$entry' carries no automation label.
+       Classify it under the heading (issue #1629):
+         **Automation:** \`auto\` | \`review\` | \`manual\` - <one clause>
+       An \`auto\`/\`review\` entry also names the shipped codemod id from
+       $CODEMOD_REGISTRY."
+          ;;
+        BADLABEL)
+          die "$guide:$line: breaking change '$entry' has an unknown automation
+       label \`$detail\`. Use \`auto\`, \`review\`, or \`manual\`."
+          ;;
+        NOCODEMOD)
+          die "$guide:$line: breaking change '$entry' is labelled \`$detail\` but
+       names no shipped codemod for this release. Add the migration id from
+       $CODEMOD_REGISTRY to the entry -- in its prose, not inside a fenced
+       sample, and prefixed with this release version -- or relabel it
+       \`manual\` with the reason no codemod applies."
+          ;;
+        NOJUSTIFY)
+          die "$guide:$line: breaking change '$entry' reads as a rename or an
+       import move but is labelled \`manual\` with no reason given.
+       Rename-level changes are the class \`autumn upgrade\` applies safely, so
+       staying manual is a decision that needs stating: say why in the same
+       paragraph (needs new arguments, only reachable inside a macro, a config
+       key rather than app code, ...). Issue #1629."
+          ;;
+        NOWALKTHROUGH)
+          die "$guide ships a codemod but records no codemod-first walk-through.
+       Add a '- **Codemod:** ...' line under
+       '### Guide-only upgrade walkthrough' naming the \`autumn upgrade\`
+       invocation the walk-through ran before any manual step (issue #1629,
+       docs/release-checklist.md)."
+          ;;
+      esac
+    done <<<"$codemod_findings"
+  done
+  shopt -u nullglob
+fi
+
 echo ""
 if [[ "$failures" -gt 0 ]]; then
   echo "Migration guide gate FAILED with $failures finding(s)." >&2

--- a/scripts/check-migration-guides.sh
+++ b/scripts/check-migration-guides.sh
@@ -2122,8 +2122,31 @@ if [[ -e "$CODEMOD_REGISTRY" ]]; then
   if [[ ! -r "$CODEMOD_REGISTRY" ]]; then
     die "$CODEMOD_REGISTRY exists but cannot be read."
   fi
-  # `    id: "0.6.0-repository-with-pool-untracked",` -> the bare id.
-  if ! sed -n 's/^[[:space:]]*id:[[:space:]]*"\([^"]*\)".*/\1/p' "$CODEMOD_REGISTRY" >"$codemod_ids"; then
+  # Only ids that name a *shipped rewrite*: entries of the production
+  # `APP_MIGRATIONS` table whose `rewrite` is a `CallRename`. A blanket scan for
+  # `id:` also picked up the `#[cfg(test)]` fixture registry and every
+  # `GuideOnly` entry, so a guide could satisfy an `auto` label by citing a
+  # test id or a migration that rewrites nothing — which is the one thing this
+  # check exists to prevent.
+  if ! awk '
+        /^pub static APP_MIGRATIONS/ { in_registry = 1; next }
+        in_registry && /^\];/       { in_registry = 0 }
+        !in_registry                { next }
+        /AppMigration[[:space:]]*\{/ { entry = 1; id = ""; rewrites = 0 }
+        !entry { next }
+        {
+          if (match($0, /id:[[:space:]]*"[^"]*"/)) {
+            id = substr($0, RSTART, RLENGTH)
+            sub(/^id:[[:space:]]*"/, "", id)
+            sub(/"$/, "", id)
+          }
+          if ($0 ~ /Rewrite::CallRename/) rewrites = 1
+        }
+        /^[[:space:]]{4}\},/ {
+          if (id != "" && rewrites) print id
+          entry = 0
+        }
+      ' "$CODEMOD_REGISTRY" >"$codemod_ids"; then
     die "$CODEMOD_REGISTRY could not be scanned for codemod ids."
     : >"$codemod_ids"
   fi

--- a/skills/autumn-web/SKILL.md
+++ b/skills/autumn-web/SKILL.md
@@ -699,7 +699,7 @@ raw Diesel:
 | `primary_reads` (attr) / `on_primary()` | Pin reads to primary; read-your-writes after a save |
 | `soft_delete`, `tenant_scoped` (attrs), `across_tenants()` | Soft deletion and tenant scoping |
 | `hooks = MyHooks` (attr) | `before_/after_create/update/delete` + `after_*_commit` lifecycle hooks with `MutationContext` |
-| `from_shard(&ShardedDb)`, `with_pool_untracked(pool)` | **(unreleased)** shard-scoped construction; `with_pool_untracked` is new on trunk-dev — published 0.5.0 repositories have **no** pool constructor at all |
+| `from_shard(&ShardedDb)`, `with_pool_untracked(pool)` | **(unreleased)** shard-scoped construction; `with_pool_untracked` is new on trunk-dev — published 0.5.0 repositories have **no** pool constructor at all. An app carrying the older `with_pool` name is migrated by `autumn upgrade --apply` (codemod `0.6.0-repository-with-pool-untracked`, issue #1629) rather than by hand |
 | `find_in_batches(batch_size)`, `find_each(batch_size)` | **(unreleased)** Bounded-memory whole-table iteration via a primary-key keyset cursor (`WHERE id > last ORDER BY id ASC LIMIT batch_size` — never `LIMIT`/`OFFSET`), generated on every repository. `find_in_batches` returns a `FindInBatches` handle — drive with `while let Some(chunk) = b.next_batch().await?`; `find_each` returns `FindEach` yielding one model per `next().await?`. Inherits soft-delete filtering, tenant scoping, and read routing like `find_all`; errors are retryable (cursor advances only on success; `Ok(None)` always means completion); `batch_size == 0` errors instead of spinning; `batch_size` is **not** clamped to `MAX_PAGE_SIZE`; sharded repos reject cross-shard `across_tenants()` iteration (iterate per shard via `from_shard`). Handle types: `autumn_web::batches::{FindInBatches, FindEach, BatchSource}` (not in the prelude). See "Batched iteration" in `docs/guide/pagination.md` |
 | `find_or_create_by_<field>[_and_<field>...](<field>, &new)` | **(unreleased)** Race-safe get-or-insert; declare `fn find_or_create_by_slug(slug: String);` (lookup fields only) to generate an inherent `find_or_create_by_slug(&self, slug: String, new: &NewModel) -> AutumnResult<(Model, bool)>`. Reads on the read path first (tenant/soft-delete aware), else inserts on the primary with `ON CONFLICT DO NOTHING` — under concurrency exactly one row is created, exactly one caller sees `created == true`, and no `23505` escapes. `before_/after_create` + commit hooks fire only on the created path; works on hooked repos (unlike `upsert_many`). **Requires a unique constraint on the lookup column(s)** (`_or_` is rejected). See "Race-safe get-or-insert" in `docs/guide/repositories.md` |
 | `retention(after = "30d", basis = created_at)` / `retention(purge_deleted_after = "90d")` (attr) | **(unreleased)** Declarative data-retention: reach for this instead of hand-writing a `#[scheduled]` cleanup fn for expiring sessions, drafts, one-time codes, or other transient rows. Compiles to a batched (`batch_size`, default 500), cursor-paginated sweep auto-registered with fleet coordination — no `tasks![...]` entry needed. On a `soft_delete` repository, `after` soft-deletes (never re-touching an already-deleted row) and `purge_deleted_after` hard-purges (re-checking `deleted_at` at delete time so a concurrent `restore()` survives); without `soft_delete`, `after` hard-deletes. Sweeps run across **all** tenants on a `tenant_scoped` repository (no per-tenant opt-out) and are not supported on `sharded` repositories (compile error). `autumn retention --dry-run [--model NAME]` reports rows-that-would-be-swept without deleting. Emits `retention_sweep_rows_total` / `retention_sweep_duration_seconds` metrics + a structured log line per run. See `docs/guide/retention-sweeps.md` |
@@ -1877,7 +1877,37 @@ autumn release init --target azure-container-apps   # Terraform scaffold: main.t
 autumn release init --target aws-app-runner      # Fast/minimal AWS path: main.tf/variables.tf/outputs.tf/terraform.tfvars.example (ECR, App Runner behind a VPC connector, RDS Postgres, Secrets Manager). No CI workflow (#1279); see docs/guide/deployment.md.
 autumn release init --target aws-ecs             # Production AWS path: main.tf/variables.tf/outputs.tf/terraform.tfvars.example (VPC, ALB+ACM DNS-validated HTTPS, ECS Fargate w/ circuit-breaker rollback, Application Auto Scaling, RDS, opt-in Redis) + .github/workflows/aws-deploy.yml (#1279); see docs/guide/deployment.md.
 autumn release init --target gcp-cloud-run       # GCP path: main.tf/variables.tf/outputs.tf/terraform.tfvars.example (Artifact Registry, Cloud Run, Cloud SQL Postgres behind a VPC connector, Secret Manager, opt-in Memorystore Redis) + .github/workflows/gcp-deploy.yml (#1280); see docs/guide/deployment.md.
+autumn upgrade                   # preview each release's mechanical app-code migrations (renames) as a per-file diff; writes nothing
+autumn upgrade --apply           # take them; --from/--to override the range, --list-migrations shows what ships (#1629)
 ```
+
+### Upgrading an app across releases — `autumn upgrade` (unreleased — trunk-dev, issue #1629)
+
+**Reach for this before hand-editing call sites out of a migration guide.**
+For each release between the `autumn-web` version the app's `Cargo.toml`
+records and the target, it applies that release's *mechanical* migrations —
+API renames — to the app's own Rust source. First shipped: 0.6.0's
+`with_pool` → `with_pool_untracked`.
+
+Three things to get right when advising on it:
+
+- **Run it before bumping the dependency.** The release it migrates *from* is
+  the one the manifest still records, so bumping `autumn-web` first leaves
+  nothing in range and the command reports "nothing to change". If the bump
+  already happened, pass `--from <previous-version>`.
+- **Preview is the default.** A bare `autumn upgrade` prints a per-file diff
+  plus a count of affected sites and writes nothing; `--apply` is the write
+  step. Tell users to commit or stash first — `git diff` is how they check
+  its work.
+- **It reports what it will not touch.** A call site inside a macro
+  invocation, a `macro_rules!` body, or an attribute, and a reference that is
+  never called (`.map(Repo::with_pool)`), are listed with `file:line` and a
+  guide link under `manual` — those are the ones a human (or you) still has to
+  edit. `--json` gives the same report for scripting.
+
+Every breaking change in `docs/migrations/*.md` carries an `**Automation:**`
+label — `auto` (the codemod does it), `review` (it rewrites, and flags each
+site), or `manual` (read the guide section). See `docs/guide/upgrading.md`.
 
 `autumn console` is Autumn's `rails console` equivalent. Rust has no stable
 `eval`, so it follows loco.rs's edit-and-run model instead of shipping a REPL:


### PR DESCRIPTION
Closes #1629.

Autumn 0.6.0 renamed the generated repository constructor `with_pool` → `with_pool_untracked` — a purely mechanical rename that every affected maintainer nevertheless had to hand-apply call site by call site from prose. #1588 made a written migration guide a release gate and #1593 reconciles framework-owned scaffold files, but both leave the user's own Rust code out of bounds. This PR closes that half.

`autumn upgrade` applies each release's machine-applyable app-code migrations to the app's own source, for every release between the `autumn-web` version the project manifest records and the target.

```bash
autumn upgrade            # preview: per-file diff, nothing written
autumn upgrade --apply    # take the rewrites
```

## Safety posture

This edits the user's source in place, so the design is built around that:

- **Preview by default.** A bare `autumn upgrade` prints a per-file diff plus a count of affected sites and writes nothing. `--apply` is the explicit write step, and it is offered only when there is something for it to write.
- **Token-level matching, not text substitution.** Each file is parsed to a `proc_macro2::TokenStream` and the replacement is spliced into the original bytes by span. String literals, comments, same-named locals, `with_pool_provider`, struct fields, and the operand of a `..range` are untouched; whitespace, comments and line endings survive byte-for-byte.
- **The file must be Rust, not merely lexable.** Sources are parsed with `syn` before any splicing — `let = f();` tokenises fine and is still rejected — and the result is re-parsed before it is written. A file that fails either check is left alone and reported.
- **Receivers are verified, not just name-matched.** `#[repository]` produces its type from a macro, so the codemod collects every `#[repository]` trait in the scanned source (under any spelling of the attribute path) and rewrites only receivers those traits actually generate. Evidence is scoped to the declaring module, so `custom::PgAuditRepository` is not vouched for by a real `repositories::PgAuditRepository`. And because a generated type never appears in source, a `struct`/`enum`/`type` of the same name written anywhere is proof of a *different*, hand-written type — which vetoes the call rather than rewriting it.
- **Nothing silently skipped.** A call site inside a macro invocation, inside a `macro_rules!` *definition* body, inside an attribute, a reference that is never called (`.map(Repo::with_pool)`), or a receiver the evidence above cannot account for is reported with `file:line` and a link to the guide section — never guessed at.
- **Idempotent.** Renames are applied release by release, so a chain across releases lands on the newest name in one run and a second run finds nothing. An app that never used the affected APIs reports nothing to change.
- **Durable writes.** Every file is planned in memory first, then written through a sibling temp file that is fsynced, has the original's permissions applied, and is renamed over the original. A failure partway through prints the report *first*, then names the file it died on, and the JSON report distinguishes what was planned (`rewritten_sites`) from what reached disk (`written_sites`).
- **Concurrent edits are not clobbered.** Planning reads every file before any is written, so each planned file keeps the text its rewrite was computed from and the apply step re-reads before replacing. A file changed in that window — by a formatter, a generator, an editor — is refused and reported, not overwritten with a rewrite of stale contents.
- **Generated and third-party trees are excluded by resolved path, not by name.** Cargo's output directory is skipped wherever `CARGO_TARGET_DIR` or any `.cargo/config.toml` in the scan puts it, and so is every configured vendor directory (`[source.*] directory`) — so `cargo vendor third-party` is covered, not just the default `vendor/`. Symlinked files and directories are never followed, and symlinks and unreadable directories are reported rather than dropped in silence.

## Release-gate coverage (phase 2)

- Every documented breaking change in every migration guide now carries an `**Automation:**` confidence label — `auto` (safe by construction), `review` (rewritten, every site flagged), or `manual` (no rewrite; the guide section is the fix path).
- `scripts/check-migration-guides.sh` gains a codemod-coverage check: a rename-level break must carry a label; an `auto`/`review` label must name a codemod actually shipped in the registry **for that release**; a rename-level change left `manual` must state why; and a released guide shipping a codemod must record a codemod-first walk-through. Semantic and behavioural changes stay guide-only with no justification needed.
- The per-release walk-through in `docs/release-checklist.md` is now codemod-first, and runs `autumn upgrade` **before** the dependency bump — the release it migrates *from* is the one the manifest still records, so bumping first would have made the gate pass for the wrong reason.

## What's in the diff

| Area | Files |
|------|-------|
| Command | `autumn-cli/src/upgrade/{mod,engine,migrations,diff}.rs`, `main.rs` dispatch |
| Registry | `autumn-cli/src/upgrade/migrations.rs` — the app-code sibling of `DEPRECATED_CONFIG_KEYS` |
| Release gate | `scripts/check-migration-guides.sh` "Check 5: codemod coverage" |
| Guides | `docs/migrations/{0.4.0,0.5.0,0.6.0,next,TEMPLATE,README}.md` |
| Process | `docs/release-checklist.md` |
| User docs | `docs/guide/upgrading.md` (new), `README.md`, `CHANGELOG.md` |

## Testing

Built red-first: 30 failing tests against stubs, then implemented. Every review finding since has been reproduced as a failing test before being fixed.

Counts as of `7573684`:

- **94 unit tests** across `upgrade/{migrations,engine,diff,mod}.rs` — version-range selection over a multi-release fixture registry, every rewrite and non-rewrite case, macro/attribute/`macro_rules!`/range/raw-identifier/turbofish handling, repository-trait discovery and receiver verification, diff rendering, and the report paths for preview, complete apply and partial apply.
- **81 integration tests** (`tests/integration/upgrade_codemod.rs`) driving the real binary over throwaway apps and workspaces: preview writes nothing, apply rewrites, twice is a no-op, macro sites listed with `file:line`, workspace members and version-floor selection across every manifest shape, excluded/redirected build trees and configured vendor directories, hidden directories, symlinks, unparsable files and manifests, concurrent modification, and `--json`.
- **22 gate tests** (`tests/integration/repo_hygiene.rs`) over crafted guide fixtures, each asserting the *specific* finding rather than just a non-zero exit.
- Registry ↔ guide ↔ gate consistency is asserted three ways: every registry guide link resolves to a real heading anchor, every guide names its codemod id, and every breaking change in every guide carries a valid label.

`cargo fmt --check`, `cargo clippy -p autumn-cli --all-targets -- -D warnings`, `cargo test -p autumn-cli` (5136 + 664 + 185 passing), `./scripts/check-migration-guides.sh`, and `./scripts/check-docs.sh` are all green.

## Known limits

Stated here rather than left to be discovered:

- An **unqualified receiver reached through a `use` alias** — `use custom::PgAuditRepository;` with no competing definition spelled out in the scan — cannot be told from the generated type. Resolving it is name resolution, which this command does not do.
- A **`#[path = "…"]` module** can sit where the file-to-module mapping does not predict. The cost is a qualified call being reported for a human instead of rewritten.
- A **repository trait defined outside the scanned tree** leaves its call sites reported rather than rewritten.

All three fail toward reporting, never toward a wrong rewrite.

## Note on the version in the issue

The issue attributes the `with_pool` rename to 0.5.0. The repository shows it shipped in **0.6.0** — `docs/migrations/0.6.0.md` and the header of `check-migration-guides.sh` agree, and the published 0.5.0 crates generate no pool constructor at all — so the codemod is registered under 0.6.0.

## Out of scope, per the issue

Semantic/behavioural migrations, signature changes needing new arguments or inference, framework-owned scaffold files (#1593), `autumn.toml` config keys (#1002), and dependency bumping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EZtTWF3MPYLG1arUpXBsjZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01EZtTWF3MPYLG1arUpXBsjZ)_