### PR TITLE
⚡ Bolt: share validate_password's lowercase between its two checks (allocs -23.5%/call)

### DIFF
--- a/autumn/Cargo.toml
+++ b/autumn/Cargo.toml
@@ -451,6 +451,14 @@ path = "tests/integration_tests.rs"
 name = "config_alloc_gate"
 path = "tests/config_alloc_gate.rs"
 
+# Allocation gate for `auth::validate_password` on a realistic signup-form
+# workload (Bolt follow-up to #2198/#2205/#2214/#2232, looking at the password
+# path). Own binary for the same `allocation-counter` global-allocator reason
+# as `config_alloc_gate` above.
+[[test]]
+name = "password_policy_alloc_gate"
+path = "tests/password_policy_alloc_gate.rs"
+
 # SQLite runtime-lane boot+serve proof (issue #1614, PR2). Only meaningful under
 # `--features sqlite`; the file is `#![cfg(feature = "sqlite")]` so a default
 # `cargo test` compiles it to an empty (passing) binary. Run explicitly:

--- a/autumn/src/auth/password.rs
+++ b/autumn/src/auth/password.rs
@@ -241,8 +241,10 @@ fn common_passwords() -> &'static HashSet<&'static str> {
 /// - any token of length ≥ 4 is a substring of the (lowercased) password; or
 /// - the password with trailing digits stripped (length ≥ 3) equals a token
 ///   (catches `john2024`).
-fn is_similar_to_context(password: &str, context: &[&str]) -> bool {
-    let pw = password.to_lowercase();
+///
+/// `pw` is the already-lowercased password — shared with the common-corpus
+/// check in [`validate_password`] rather than lowercased again here.
+fn is_similar_to_context(pw: &str, context: &[&str]) -> bool {
     let pw_stripped = pw.trim_end_matches(|c: char| c.is_ascii_digit());
     for raw in context {
         let ctx = raw.trim();
@@ -344,16 +346,19 @@ pub async fn validate_password(
         });
     }
 
+    // Lowercased once and shared: the common-corpus check below and
+    // `is_similar_to_context` both need it, and it's always needed (context
+    // similarity runs unconditionally), so hoisting it here costs nothing
+    // extra when `reject_common` is off and saves one allocation when it's on.
+    let lower = password.to_lowercase();
+
     // 2. Common/weak corpus.
-    if policy.reject_common {
-        let lower = password.to_lowercase();
-        if common_passwords().contains(lower.as_str()) {
-            failures.push(PasswordFailure::TooCommon);
-        }
+    if policy.reject_common && common_passwords().contains(lower.as_str()) {
+        failures.push(PasswordFailure::TooCommon);
     }
 
     // 3. Context similarity.
-    if is_similar_to_context(password, context) {
+    if is_similar_to_context(&lower, context) {
         failures.push(PasswordFailure::SimilarToContext);
     }
 
@@ -510,14 +515,24 @@ mod tests {
 
     #[test]
     fn similarity_helper_ignores_unrelated_and_empty() {
+        // `is_similar_to_context` now takes an already-lowercased password
+        // (callers, i.e. `validate_password`, lowercase once and share it) —
+        // lowercase these inline so the assertions still exercise the same
+        // real-world (mixed-case) inputs as before.
         assert!(!is_similar_to_context(
-            "Tr0ub4dour&3-Staple-Horse",
+            &"Tr0ub4dour&3-Staple-Horse".to_lowercase(),
             &["john@example.com"]
         ));
-        assert!(!is_similar_to_context("Tr0ub4dour&3", &[]));
-        assert!(!is_similar_to_context("Tr0ub4dour&3", &["  "]));
+        assert!(!is_similar_to_context(&"Tr0ub4dour&3".to_lowercase(), &[]));
+        assert!(!is_similar_to_context(
+            &"Tr0ub4dour&3".to_lowercase(),
+            &["  "]
+        ));
         // ".com" (len 3) must not trigger a false positive.
-        assert!(!is_similar_to_context("Tr0ub4dour&3.com", &["a@b.com"]));
+        assert!(!is_similar_to_context(
+            &"Tr0ub4dour&3.com".to_lowercase(),
+            &["a@b.com"]
+        ));
     }
 
     #[tokio::test]

--- a/autumn/src/auth/password.rs
+++ b/autumn/src/auth/password.rs
@@ -361,6 +361,12 @@ pub async fn validate_password(
     if is_similar_to_context(&lower, context) {
         failures.push(PasswordFailure::SimilarToContext);
     }
+    // Drop explicitly rather than let scope do it: `validate_password` is
+    // async and `lower` would otherwise live in the generated future's state
+    // across the `.await` below, holding the allocation for as long as the
+    // breach-check request is in flight instead of releasing it once the two
+    // synchronous checks above are done with it.
+    drop(lower);
 
     // 4. Breach check.
     if policy.breach_check != BreachCheck::Off {

--- a/autumn/tests/password_policy_alloc_gate.rs
+++ b/autumn/tests/password_policy_alloc_gate.rs
@@ -1,0 +1,105 @@
+//! Isolated integration test: allocation gate for
+//! [`autumn_web::auth::validate_password`] on a realistic signup-form
+//! workload (Bolt follow-up to the request-ingress allocation gates —
+//! #2198/#2205/#2214/#2232 — looking at the password path instead).
+//!
+//! Its own binary for the same reason `config_alloc_gate` is: `allocation-counter`
+//! installs a process-wide counting `#[global_allocator]`, a process-wide side
+//! effect per CLAUDE.md's isolated-test rules, and taxing every allocation in
+//! the consolidated suite to measure a handful here is not a trade worth making.
+//!
+//! `validate_password` runs on every registration and password-change
+//! submission — a real, public entry point, independent of whether the caller
+//! goes on to bcrypt-hash the password. Bcrypt's own cost (deliberately
+//! ~100ms+ at the default cost factor) dwarfs anything measured here by many
+//! orders of magnitude, so this gate isolates the pure-Rust policy-check cost
+//! the same way the `version_history`/`attribute_encryption` benches isolate
+//! their pure-Rust component from the DB round trip alongside it — a
+//! deliberately slow security primitive elsewhere in the request is not a
+//! reason to stop counting allocations in the code around it.
+
+use autumn_web::auth::{BreachCheck, PasswordPolicy, validate_password};
+
+/// Enough repetitions that a per-call allocation cannot hide inside noise.
+const CALLS: usize = 100;
+
+/// A signup-form-shaped workload: some weak/common passwords, some strong
+/// passphrases, mixed-case and multibyte, each checked against a realistic
+/// two-string context (email + username) the way a registration handler
+/// would call it. `validate_password` accumulates every applicable failure
+/// rather than short-circuiting, so a weak password's checks all still run.
+fn workload() -> Vec<(&'static str, [&'static str; 2])> {
+    vec![
+        ("password123", ["alice@example.com", "alice"]),
+        ("Tr0ub4dour&3-Staple-Horse", ["bob@example.com", "bob"]),
+        ("qwerty", ["carol@example.com", "carol"]),
+        ("Correct-Horse-Battery-Staple-9", ["dave@example.com", "dave"]),
+        ("héllo-wörld-42", ["eve@example.com", "eve"]),
+        ("N0t-A-C0mm0n-Passphrase!", ["frank@example.com", "frank"]),
+        ("letmein2024", ["grace@example.com", "grace"]),
+        ("Zx9!kQ2m-Lp7$Wc4", ["heidi@example.com", "heidi"]),
+    ]
+}
+
+fn policy() -> PasswordPolicy {
+    PasswordPolicy::new(8, true, BreachCheck::Off)
+}
+
+/// The runtime has to be current-thread, matching `config_alloc_gate`'s
+/// `measure_per_request`: `allocation-counter` counts thread-locally, so
+/// anything a worker thread allocated would go uncounted.
+#[test]
+fn validate_password_allocations_on_a_signup_workload() {
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("current-thread runtime should build");
+    let runtime_policy = policy();
+    let items = workload();
+
+    // Warm-up outside the measured window: builds the `OnceLock` weak-password
+    // corpus, which a steady-state call must not pay for.
+    runtime.block_on(async {
+        for (pw, ctx) in &items {
+            let _ = validate_password(pw, &runtime_policy, ctx).await;
+        }
+    });
+
+    let info = allocation_counter::measure(|| {
+        runtime.block_on(async {
+            for _ in 0..CALLS {
+                for (pw, ctx) in &items {
+                    let v = validate_password(pw, &runtime_policy, ctx).await;
+                    std::hint::black_box(&v);
+                }
+            }
+        });
+    });
+
+    let calls = (CALLS * items.len()) as u64;
+    let per_call_blocks = info.count_total / calls;
+    let per_call_bytes = info.bytes_total / calls;
+    println!(
+        "validate_password: {per_call_blocks} blocks / {per_call_bytes} bytes per call \
+         ({calls} calls, {} blocks / {} bytes total)",
+        info.count_total, info.bytes_total
+    );
+
+    // Baseline (this workload, `reject_common = true`, 2-string context,
+    // debug profile, deterministic across runs): 3,401 blocks / 67,648 bytes
+    // for 800 calls (4 blocks / 84 bytes per call, average). The password gets
+    // `.to_lowercase()`'d twice per call — once in the common-corpus check,
+    // once more inside `is_similar_to_context` — for the same string.
+    assert!(
+        info.count_total <= 3_401,
+        "validate_password allocated {} blocks over {calls} calls, over the \
+         3,401-block baseline ceiling",
+        info.count_total,
+    );
+    assert!(
+        info.bytes_total <= 67_648,
+        "validate_password allocated {} bytes over {calls} calls, over the \
+         67,648-byte baseline ceiling",
+        info.bytes_total,
+    );
+}

--- a/autumn/tests/password_policy_alloc_gate.rs
+++ b/autumn/tests/password_policy_alloc_gate.rs
@@ -33,7 +33,10 @@ fn workload() -> Vec<(&'static str, [&'static str; 2])> {
         ("password123", ["alice@example.com", "alice"]),
         ("Tr0ub4dour&3-Staple-Horse", ["bob@example.com", "bob"]),
         ("qwerty", ["carol@example.com", "carol"]),
-        ("Correct-Horse-Battery-Staple-9", ["dave@example.com", "dave"]),
+        (
+            "Correct-Horse-Battery-Staple-9",
+            ["dave@example.com", "dave"],
+        ),
         ("héllo-wörld-42", ["eve@example.com", "eve"]),
         ("N0t-A-C0mm0n-Passphrase!", ["frank@example.com", "frank"]),
         ("letmein2024", ["grace@example.com", "grace"]),
@@ -41,7 +44,7 @@ fn workload() -> Vec<(&'static str, [&'static str; 2])> {
     ]
 }
 
-fn policy() -> PasswordPolicy {
+const fn policy() -> PasswordPolicy {
     PasswordPolicy::new(8, true, BreachCheck::Off)
 }
 
@@ -85,21 +88,26 @@ fn validate_password_allocations_on_a_signup_workload() {
         info.count_total, info.bytes_total
     );
 
-    // Baseline (this workload, `reject_common = true`, 2-string context,
-    // debug profile, deterministic across runs): 3,401 blocks / 67,648 bytes
-    // for 800 calls (4 blocks / 84 bytes per call, average). The password gets
-    // `.to_lowercase()`'d twice per call — once in the common-corpus check,
-    // once more inside `is_similar_to_context` — for the same string.
+    // This workload, `reject_common = true`, 2-string context, debug profile,
+    // deterministic across runs: 3,401 blocks / 67,648 bytes for 800 calls
+    // before the fix below (the password got `.to_lowercase()`'d twice per
+    // call — once in the common-corpus check, once more inside
+    // `is_similar_to_context` — for the same string), **2,601 / 53,772**
+    // after sharing the one lowercase between both checks (-23.5% blocks /
+    // -20.5% bytes). The ceiling sits at the current measurement plus a little
+    // headroom for feature-set variance, same convention as
+    // `config_alloc_gate`'s ceilings; a failure a hair over the line means
+    // re-measure and re-derive, not nudge upwards.
     assert!(
-        info.count_total <= 3_401,
+        info.count_total <= 2_700,
         "validate_password allocated {} blocks over {calls} calls, over the \
-         3,401-block baseline ceiling",
+         2,700-block ceiling (2,601 measured; 3,401 was the pre-fix baseline)",
         info.count_total,
     );
     assert!(
-        info.bytes_total <= 67_648,
+        info.bytes_total <= 56_000,
         "validate_password allocated {} bytes over {calls} calls, over the \
-         67,648-byte baseline ceiling",
+         56,000-byte ceiling (53,772 measured; 67,648 was the pre-fix baseline)",
         info.bytes_total,
     );
 }


### PR DESCRIPTION
🎯 **Workload**

`autumn::auth::validate_password` — the password-policy check run on every registration and password-change submission, independent of whether the caller goes on to bcrypt-hash the password. New committed harness: `autumn/tests/password_policy_alloc_gate.rs` (own `[[test]]` binary, same reason as `config_alloc_gate`: `allocation-counter` installs a process-wide counting global allocator). Workload: 8 realistic signup-form password/context pairs (mix of common/weak and strong passphrases, mixed-case, multibyte, each checked against a 2-string email+username context), 800 calls total.

```sh
cargo test -p autumn-web --test password_policy_alloc_gate -- --nocapture
```

📈 **Profile**

Reading `validate_password`'s own control flow (it's a small, linear function — four sequential checks, no loops over large data): the password is lowercased once inside the common-corpus check (`policy.reject_common` is `true` by default) and then lowercased **again** inside `is_similar_to_context`, which runs unconditionally right after. Two `String` allocations of the same input for the same call, back to back. Confirmed by allocation count, not just code reading — see Measurement.

This isn't the request-ingress path (see #2193/#2232 for that): it's a standalone, self-contained, CPU-bound entry point, chosen specifically because it's *not* dominated by bcrypt's deliberately-expensive KDF (a `hash_password` call elsewhere in the same flow costs ~100ms+ at the default cost factor — many orders of magnitude more than anything measured here, the same reason `version_history`/`attribute_encryption` isolate their pure-Rust component from a DB round trip alongside it).

💡 **Hypothesis**

Sharing one `to_lowercase()` between the common-corpus check and `is_similar_to_context` removes a redundant allocation on every call where `reject_common` is on (the default). Context-similarity runs unconditionally regardless of `reject_common`, so hoisting the lowercase to the top of `validate_password` costs nothing extra when `reject_common` is off (the lowercase was already needed there) and saves exactly one allocation when it's on.

🔧 **Change**

- `validate_password`: lowercase the password once, share the result with both the common-corpus check and `is_similar_to_context`.
- `is_similar_to_context`: now takes the already-lowercased password instead of lowercasing it itself (doc comment updated to say so).
- Its two direct unit tests updated to pass pre-lowered literals so they exercise the same real-world (mixed-case) inputs as before — assertions/outcomes unchanged, only the literal arguments are pre-lowered to match the new contract.

📊 **Measurement**

`allocation-counter`, 800 `validate_password` calls, debug profile, deterministic across runs (confirmed via 2 repeat runs pre-fix, identical to the byte):

| Metric | Before | After | Delta |
|---|---|---|---|
| Allocation blocks | 3,401 | 2,601 | **-23.5%** |
| Allocation bytes | 67,648 | 53,772 | **-20.5%** |

Both clear the ≥10% allocation-count/bytes impact floor. `cargo fmt --all`, `cargo clippy -p autumn-web --all-targets -- -D warnings`, and the full `auth::` unit test suite (114 tests, including the two updated `is_similar_to_context` direct tests) all pass unchanged.

🔬 **Reproduce**

```sh
git checkout <RED commit>   # benchmark + pre-fix baseline
cargo test -p autumn-web --test password_policy_alloc_gate -- --nocapture
# validate_password: 4 blocks / 84 bytes per call (800 calls, 3401 blocks / 67648 bytes total)

git checkout <GREEN commit>  # the fix
cargo test -p autumn-web --test password_policy_alloc_gate -- --nocapture
# validate_password: 3 blocks / 67 bytes per call (800 calls, 2601 blocks / 53772 bytes total)
```

Checked for duplicate/in-flight work first: no open PR touches `auth/password.rs` or the password path (`list_pull_requests`, state=open).


---
_Generated by [Claude Code](https://claude.ai/code/session_01JT9NHyZdgaK2DfypRa79SC)_