### PR TITLE
fix(cli): keep AWS bootstrap images away from production secrets

### DIFF
--- a/autumn-cli/src/release.rs
+++ b/autumn-cli/src/release.rs
@@ -3607,7 +3607,7 @@ previous_secrets = []
         );
         assert!(
             service_block
-                .contains("ignore_changes = [source_configuration, health_check_configuration]"),
+                .contains("ignore_changes = [source_configuration, instance_configuration, health_check_configuration]"),
             "the App Runner service must ignore source_configuration drift once CI/the manual \
              walkthrough deploys the real image: {service_block}"
         );
@@ -3661,7 +3661,7 @@ previous_secrets = []
             .expect("main.tf must declare the App Runner service");
         assert!(
             service_block
-                .contains("ignore_changes = [source_configuration, health_check_configuration]"),
+                .contains("ignore_changes = [source_configuration, instance_configuration, health_check_configuration]"),
             "the App Runner service must ignore health_check_configuration drift alongside \
              source_configuration: {service_block}"
         );
@@ -3690,13 +3690,29 @@ previous_secrets = []
     }
 
     #[test]
-    fn aws_app_runner_service_waits_for_secret_versions_before_starting() {
-        // runtime_environment_secrets only references the secret
-        // CONTAINERS (aws_secretsmanager_secret.*.arn), so Terraform's
-        // implicit dependency graph doesn't wait for the *_version
-        // resources that actually write the secret values — without an
-        // explicit depends_on, the service can start (and fail to resolve
-        // AUTUMN_DATABASE__PRIMARY_URL) before RDS-derived value exists.
+    fn aws_app_runner_public_bootstrap_has_no_production_secrets_or_runtime_role() {
+        let tmp = TempDir::new().unwrap();
+        let dir = make_project(&tmp, "my-app");
+        init(&dir, "my-app", false, Target::AwsAppRunner, false).unwrap();
+        let content = fs::read_to_string(dir.join("main.tf")).unwrap();
+        let service = content
+            .split("resource \"aws_apprunner_service\" \"this\"")
+            .nth(1)
+            .expect("main.tf must declare the App Runner service");
+        assert!(!service.contains("runtime_environment_secrets ="));
+        let instance = service
+            .split("instance_configuration {")
+            .nth(1)
+            .and_then(|block| block.split('}').next())
+            .expect("service must configure its bootstrap instance size");
+        assert!(!instance.contains("instance_role_arn"));
+
+        let outputs = fs::read_to_string(dir.join("outputs.tf")).unwrap();
+        assert!(outputs.contains("output \"apprunner_instance_role_arn\""));
+    }
+
+    #[test]
+    fn aws_app_runner_public_bootstrap_does_not_wait_for_or_access_secrets() {
         let tmp = TempDir::new().unwrap();
         let dir = make_project(&tmp, "my-app");
         init(&dir, "my-app", false, Target::AwsAppRunner, false).unwrap();
@@ -3705,16 +3721,9 @@ previous_secrets = []
             .split("resource \"aws_apprunner_service\" \"this\"")
             .nth(1)
             .expect("main.tf must declare aws_apprunner_service.this");
-        for dep in [
-            "aws_secretsmanager_secret_version.database_url",
-            "aws_secretsmanager_secret_version.signing_secret",
-        ] {
-            assert!(
-                service_block.contains(dep),
-                "aws_apprunner_service.this must depend on {dep}, not just the secret \
-                 container it references by ARN: {service_block}"
-            );
-        }
+        assert!(!service_block.contains("aws_iam_role_policy.apprunner_instance_secrets"));
+        assert!(!service_block.contains("aws_secretsmanager_secret_version.database_url"));
+        assert!(!service_block.contains("aws_secretsmanager_secret_version.signing_secret"));
     }
 
     #[test]
@@ -4112,6 +4121,24 @@ previous_secrets = []
             "the ECS service must ignore task_definition drift so CI-registered revisions \
              aren't reverted by a later `terraform apply`: {service_block}"
         );
+    }
+
+    #[test]
+    fn aws_ecs_public_app_bootstrap_has_no_secrets_and_deploy_restores_them() {
+        let tmp = TempDir::new().unwrap();
+        let dir = make_project(&tmp, "my-app");
+        init(&dir, "my-app", false, Target::AwsEcs, true).unwrap();
+        let content = fs::read_to_string(dir.join("main.tf")).unwrap();
+        let app = content
+            .split("resource \"aws_ecs_task_definition\" \"app\"")
+            .nth(1)
+            .and_then(|block| block.split("\nresource").next())
+            .expect("main.tf must declare the app task definition");
+        assert!(app.contains("secrets     = []"));
+
+        let workflow = fs::read_to_string(dir.join(".github/workflows/aws-deploy.yml")).unwrap();
+        assert!(workflow.contains("--argjson SECRETS"));
+        assert!(workflow.contains(".containerDefinitions[0].secrets = $SECRETS"));
     }
 
     #[test]

--- a/autumn-cli/src/templates/release/aws-app-runner-main.tf.tmpl
+++ b/autumn-cli/src/templates/release/aws-app-runner-main.tf.tmpl
@@ -536,10 +536,9 @@ resource "aws_apprunner_service" "this" {
           AUTUMN_PROFILE = "prod"
         }
 
-        runtime_environment_secrets = {
-          AUTUMN_DATABASE__PRIMARY_URL    = aws_secretsmanager_secret.database_url.arn
-          AUTUMN_SECURITY__SIGNING_SECRET = aws_secretsmanager_secret.signing_secret.arn
-        }
+        # The public bootstrap image only serves a health check and must
+        # never receive production secrets. The deploy walkthrough supplies
+        # them when it replaces this image with the trusted application.
       }
     }
 
@@ -549,7 +548,9 @@ resource "aws_apprunner_service" "this" {
   instance_configuration {
     cpu                = var.instance_cpu
     memory             = var.instance_memory
-    instance_role_arn  = aws_iam_role.apprunner_instance.arn
+    # Do not give the public bootstrap image the secret-reading runtime
+    # role. The real-image cutover attaches it in the same update-service
+    # operation that supplies RuntimeEnvironmentSecrets.
   }
 
   network_configuration {
@@ -570,19 +571,8 @@ resource "aws_apprunner_service" "this" {
     path     = "/"
   }
 
-  # The database_url/signing_secret *version* resources (not just the
-  # secret containers referenced by ARN above) must exist before App Runner
-  # starts: runtime_environment_secrets only implies a dependency on the
-  # empty secret container, since that's the resource actually referenced
-  # by .arn — without this, Terraform is free to create the service as soon
-  # as the (still-valueless) secret exists, racing the version write. App
-  # Runner then fails to resolve the secret value at bootstrap-image
-  # startup and the first apply never stabilizes.
   depends_on = [
     aws_iam_role_policy_attachment.apprunner_access,
-    aws_iam_role_policy.apprunner_instance_secrets,
-    aws_secretsmanager_secret_version.database_url,
-    aws_secretsmanager_secret_version.signing_secret,
   ]
 
   lifecycle {
@@ -601,6 +591,6 @@ resource "aws_apprunner_service" "this" {
     # too, a later `terraform apply` would see that as drift from this
     # resource's own declared "/" and revert it — breaking the real app's
     # health check the moment anyone re-applies.
-    ignore_changes = [source_configuration, health_check_configuration]
+    ignore_changes = [source_configuration, instance_configuration, health_check_configuration]
   }
 }

--- a/autumn-cli/src/templates/release/aws-app-runner-outputs.tf.tmpl
+++ b/autumn-cli/src/templates/release/aws-app-runner-outputs.tf.tmpl
@@ -42,6 +42,11 @@ output "apprunner_access_role_arn" {
   value       = aws_iam_role.apprunner_access.arn
 }
 
+output "apprunner_instance_role_arn" {
+  description = "Secret-reading runtime role for the real application image. The bootstrap image deliberately receives no instance role; the deploy walkthrough attaches this role during cutover."
+  value       = aws_iam_role.apprunner_instance.arn
+}
+
 # `aws apprunner update-service --source-configuration` REPLACES the image
 # configuration wholesale, not merges it — the deploy walkthrough's cutover
 # call must therefore re-supply RuntimeEnvironmentSecrets explicitly (using

--- a/autumn-cli/src/templates/release/aws-deploy.yml.tmpl
+++ b/autumn-cli/src/templates/release/aws-deploy.yml.tmpl
@@ -197,7 +197,9 @@ jobs:
           NEW_DEF=$(aws ecs describe-task-definition --task-definition "$APP_TASK_FAMILY" \
             --query 'taskDefinition' | \
             jq --arg IMAGE "$ECR_REPOSITORY_URL:$IMAGE_TAG" \
+               --argjson SECRETS "$(aws ecs describe-task-definition --task-definition "$MIGRATE_TASK_FAMILY" --query 'taskDefinition.containerDefinitions[0].secrets' --output json)" \
               '.containerDefinitions[0].image = $IMAGE |
+               .containerDefinitions[0].secrets = $SECRETS |
                del(.containerDefinitions[0].entryPoint, .containerDefinitions[0].command) |
                del(.taskDefinitionArn, .revision, .status, .requiresAttributes,
                    .compatibilities, .registeredAt, .registeredBy, .deregisteredAt)')
@@ -206,6 +208,7 @@ jobs:
           echo "arn=$NEW_ARN" >> "$GITHUB_OUTPUT"
         env:
           APP_TASK_FAMILY: ${{ vars.APP_TASK_FAMILY }}
+          MIGRATE_TASK_FAMILY: ${{ vars.MIGRATE_TASK_FAMILY }}
           ECR_REPOSITORY_URL: ${{ vars.ECR_REPOSITORY_URL }}
           IMAGE_TAG: ${{ steps.image_tag.outputs.value }}
 

--- a/autumn-cli/src/templates/release/aws-ecs-main.tf.tmpl
+++ b/autumn-cli/src/templates/release/aws-ecs-main.tf.tmpl
@@ -671,7 +671,10 @@ resource "aws_ecs_task_definition" "app" {
       ]
 
       environment = local.container_environment
-      secrets     = local.container_secrets
+      # A public bootstrap image must not receive production credentials.
+      # Deploys copy the secret references from the non-running migration
+      # task definition only when registering the trusted real app image.
+      secrets     = []
 
       logConfiguration = {
         logDriver = "awslogs"

--- a/docs/guide/deployment.md
+++ b/docs/guide/deployment.md
@@ -1174,6 +1174,7 @@ export AWS_REGION="$(terraform output -raw region)"
 ECR="$(terraform output -raw ecr_repository_url)"
 SERVICE_ARN="$(terraform output -raw service_arn)"
 ACCESS_ROLE="$(terraform output -raw apprunner_access_role_arn)"
+INSTANCE_ROLE="$(terraform output -raw apprunner_instance_role_arn)"
 DATABASE_URL_ARN="$(terraform output -raw database_url_secret_arn)"
 SIGNING_SECRET_ARN="$(terraform output -raw signing_secret_secret_arn)"
 TAG="$(git rev-parse --short=12 HEAD)-$(date -u +%Y%m%d%H%M%S)"
@@ -1253,6 +1254,7 @@ APP_URL="$(terraform output -raw app_url)"   # known only after the FIRST apply 
 # — main.tf's bootstrap revision used "/" (nginx's own default response)
 # since the bootstrap placeholder doesn't serve /health.
 OPERATION_ID=$(aws apprunner update-service --service-arn "$SERVICE_ARN" \
+  --instance-configuration "{\"InstanceRoleArn\": \"$INSTANCE_ROLE\"}" \
   --health-check-configuration "{\"Protocol\": \"HTTP\", \"Path\": \"/health\"}" \
   --source-configuration "{
   \"ImageRepository\": {
@@ -1422,12 +1424,16 @@ docker push "$ECR:$TAG"
 # would exit immediately. The "migrate" family's own command (`autumn
 # migrate`) is intentional and permanent, not bootstrap-specific, so it's
 # left untouched.
+APP_SECRETS=$(aws ecs describe-task-definition \
+  --task-definition "$(terraform output -raw migrate_task_family)" \
+  --query 'taskDefinition.containerDefinitions[0].secrets' --output json)
 for FAMILY_OUT in app_task_family:APP migrate_task_family:MIGRATE; do
   FAMILY="$(terraform output -raw "${FAMILY_OUT%%:*}")"
   STRIP_ENTRYPOINT="del(.containerDefinitions[0].entryPoint, .containerDefinitions[0].command) | "
   [ "${FAMILY_OUT##*:}" = "MIGRATE" ] && STRIP_ENTRYPOINT=""
   NEW_DEF=$(aws ecs describe-task-definition --task-definition "$FAMILY" --query 'taskDefinition' | \
-    jq --arg IMAGE "$ECR:$TAG" ".containerDefinitions[0].image = \$IMAGE | ${STRIP_ENTRYPOINT}
+    jq --arg IMAGE "$ECR:$TAG" --argjson SECRETS "$APP_SECRETS" ".containerDefinitions[0].image = \$IMAGE |
+      (if \"${FAMILY_OUT##*:}\" == \"APP\" then .containerDefinitions[0].secrets = \$SECRETS else . end) | ${STRIP_ENTRYPOINT}
       del(.taskDefinitionArn, .revision, .status, .requiresAttributes, .compatibilities,
           .registeredAt, .registeredBy, .deregisteredAt)")
   ARN=$(echo "$NEW_DEF" | aws ecs register-task-definition --cli-input-json file:///dev/stdin \


### PR DESCRIPTION
### Motivation

- Prevent a mutable public bootstrap image from receiving production secrets or a secret-reading runtime role during the initial Terraform apply, which could allow secret exfiltration or DB access if the placeholder image is compromised.
- Ensure the trusted application cutover restores required secret access and runtime role only when the real image is deployed.

### Description

- Removed `runtime_environment_secrets` and the `instance_role_arn` from the App Runner bootstrap configuration so the public placeholder never receives production secrets or the secret-reading role. 
- Added a new output `apprunner_instance_role_arn` and updated the manual App Runner deploy walkthrough to attach that instance role only during `aws apprunner update-service` cutover. 
- Cleared `secrets` for the ECS bootstrap `app` task definition and changed the CI/manual `aws-deploy.yml` workflow to copy the migration task's `secrets` into the registered `app` task definition when registering the trusted image. 
- Added/updated regression tests in `autumn-cli/src/release.rs` to assert the bootstrap revisions do not contain production secrets or runtime roles and to verify the deploy workflow hydrates secrets for the real image; also updated `ignore_changes` to include `instance_configuration` so later `terraform apply` does not remove runtime role settings after cutover.

### Testing

- Ran unit tests with `cargo test -p autumn-cli` (including the `aws_app_runner` and `aws_ecs` target tests) and all relevant tests passed. 
- Ran formatting/lint checks with `cargo fmt --all -- --check` and `git diff --check`, which returned no issues. 
- Searched for unfinished markers (`rg -n "TODO|FIXME|Stub:"`) in affected files and found none.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a743ddce008832aaa995a833b48efc6)