### PR TITLE
fix(cli): keep Azure bootstrap app scaled to zero

### DIFF
--- a/autumn-cli/src/release.rs
+++ b/autumn-cli/src/release.rs
@@ -2187,6 +2187,36 @@ previous_secrets = []
     }
 
     #[test]
+    fn azure_container_apps_defaults_to_zero_replicas_for_bootstrap_safety() {
+        // The initial Terraform-managed app revision uses a public placeholder image
+        // solely because Container Apps requires an image before the user's ACR has
+        // one. Keep it scaled to zero by default so that placeholder is not started
+        // with production secret refs or the app's Key Vault-capable identity.
+        let tmp = TempDir::new().unwrap();
+        let dir = make_project(&tmp, "my-app");
+        init(&dir, "my-app", false, Target::AzureContainerApps, false).unwrap();
+
+        let variables_tf = fs::read_to_string(dir.join("variables.tf")).unwrap();
+        let min_replicas_block = variables_tf
+            .split("variable \"min_replicas\"")
+            .nth(1)
+            .and_then(|rest| rest.split("\n}").next())
+            .expect("variables.tf must declare min_replicas");
+        assert!(
+            min_replicas_block.contains("default     = 0")
+                || min_replicas_block.contains("default = 0"),
+            "min_replicas must default to 0 so the public bootstrap image is not run \
+             with production secrets before the first real deploy: {variables_tf}"
+        );
+
+        let tfvars = fs::read_to_string(dir.join("terraform.tfvars.example")).unwrap();
+        assert!(
+            tfvars.contains("min_replicas        = 0") || tfvars.contains("min_replicas = 0"),
+            "terraform.tfvars.example must preserve the safe bootstrap default: {tfvars}"
+        );
+    }
+
+    #[test]
     fn variables_tf_marks_secret_inputs_sensitive_with_no_default() {
         let tmp = TempDir::new().unwrap();
         let dir = make_project(&tmp, "my-app");

--- a/autumn-cli/src/templates/release/terraform.tfvars.example.tmpl
+++ b/autumn-cli/src/templates/release/terraform.tfvars.example.tmpl
@@ -11,9 +11,9 @@ db_sku          = "B_Standard_B1ms"
 #   az account show --query id -o tsv
 subscription_id = "00000000-0000-0000-0000-000000000000"
 
-# bootstrap_image = "mcr.microsoft.com/k8se/quickstart:latest"  # rarely needs to change
+# bootstrap_image = "mcr.microsoft.com/k8se/quickstart:latest"  # keep min_replicas = 0 until your real image is deployed
 
-min_replicas        = 1
+min_replicas        = 0
 max_replicas        = 10
 enable_redis_cache  = false
 

--- a/autumn-cli/src/templates/release/variables.tf.tmpl
+++ b/autumn-cli/src/templates/release/variables.tf.tmpl
@@ -28,9 +28,11 @@ variable "image_tag" {
 # points both at this public placeholder on the first apply, then ignores
 # further image drift (see the `lifecycle.ignore_changes` blocks in main.tf)
 # once `az containerapp update`/the migration job start in azure-deploy.yml
-# take over managing the real image.
+# take over managing the real image. Keep min_replicas at 0 until after the
+# first real deploy so the placeholder app container is never started with
+# production secret refs or a Key Vault-capable managed identity.
 variable "bootstrap_image" {
-  description = "Public placeholder image Terraform uses to create the Container App and migration job before any real image has been pushed to ACR."
+  description = "Public placeholder image Terraform uses only to create inactive first revisions before any real image has been pushed to ACR. Keep min_replicas at 0 until after the first real deploy so this image never starts with production secrets."
   type        = string
   default     = "mcr.microsoft.com/k8se/quickstart:latest"
 }
@@ -42,14 +44,16 @@ variable "db_sku" {
 }
 
 # ── Scale config defaults ────────────────────────────────────────────────────
-# Min replicas: 1, Max: 10. The http_scale_rule in main.tf (concurrent_requests
-# = 10) decides when Container Apps scales between these bounds; it will not
-# scale to zero while min_replicas > 0. Set min_replicas = 0 for scale-to-zero.
+# Min replicas: 0, Max: 10. Keep the default at 0 for the initial Terraform
+# apply: the first revision uses the public bootstrap image, and scaling it up
+# before the real image is deployed would start that placeholder with
+# production secret refs and the app's managed identity. Raise this after the
+# first real deploy if you do not want scale-to-zero.
 
 variable "min_replicas" {
   description = "Minimum number of Container App replicas kept running."
   type        = number
-  default     = 1
+  default     = 0
 }
 
 variable "max_replicas" {

--- a/docs/guide/deployment.md
+++ b/docs/guide/deployment.md
@@ -852,7 +852,7 @@ This generates:
 | File | Purpose |
 |---|---|
 | `main.tf` | Resource group, Azure Container Registry, Log Analytics workspace, Container Apps environment + the Container App itself, a one-shot migration job, Azure Database for PostgreSQL Flexible Server, and a Key Vault that feeds secrets into the app via a user-assigned managed identity. An optional Redis Cache is gated behind `enable_redis_cache` — **infrastructure only**, see the callout below. |
-| `variables.tf` | `app_name`, `subscription_id` (required — AzureRM v4 needs it explicitly, even under `az login`), `location`, `image_tag`, `db_sku`, `bootstrap_image`, `min_replicas`/`max_replicas` (default 1/10), `enable_redis_cache`, and `sensitive`, no-default secret variables (`database_admin_password`, `signing_secret`). |
+| `variables.tf` | `app_name`, `subscription_id` (required — AzureRM v4 needs it explicitly, even under `az login`), `location`, `image_tag`, `db_sku`, `bootstrap_image`, `min_replicas`/`max_replicas` (default 0/10), `enable_redis_cache`, and `sensitive`, no-default secret variables (`database_admin_password`, `signing_secret`). |
 | `outputs.tf` | `app_fqdn`, `acr_login_server`, `resource_group_name`, `migrate_job_name`, and `app_name`. |
 | `terraform.tfvars.example` | Non-secret defaults only — secrets are documented as `TF_VAR_*` exports, never committed. |
 | `.github/workflows/azure-deploy.yml` | Opt-in CI/CD: builds the release image, pushes it to ACR, runs the migration job to completion, and runs `az containerapp update` on a `v*` tag push (or manual dispatch). |
@@ -912,8 +912,11 @@ terraform apply
 
 The Container App and migration job both start from a public placeholder
 image (`bootstrap_image` — Container Apps must pull *some* image to create a
-first revision, and a brand-new ACR has none yet). Build and push your real
-image, run migrations, then cut the app over:
+first revision, and a brand-new ACR has none yet). The generated
+`min_replicas = 0` default is intentional: keep it at zero for the initial
+apply so the placeholder app container is not started with production secret
+refs or the app's Key Vault-capable managed identity. Build and push your
+real image, run migrations, then cut the app over:
 
 ```bash
 APP_NAME="$(terraform output -raw app_name)"           # sanitized — may differ from your Cargo package name


### PR DESCRIPTION
### Motivation
- The Azure Container Apps scaffold used a public bootstrap image for the initial revision while provisioning Key Vault secrets and a user-assigned identity, which could start the placeholder container with production secrets and leak credentials. 
- The change aims to prevent that exposure by ensuring the placeholder revision is not started by default until the real image is deployed.

### Description
- Change the default `min_replicas` to `0` in the Azure release template so the initial Terraform-created revision remains scaled to zero (`autumn-cli/src/templates/release/variables.tf.tmpl`).
- Update the generated example `terraform.tfvars.example` to preserve the safe `min_replicas = 0` default (`autumn-cli/src/templates/release/terraform.tfvars.example.tmpl`).
- Clarify the deployment guide to explain the safety rationale and the expected bootstrap workflow (`docs/guide/deployment.md`).
- Add a regression test that asserts the generated `variables.tf` and `terraform.tfvars.example` default `min_replicas` to zero (`autumn-cli/src/release.rs`).

### Testing
- Ran `cargo test -p autumn-cli azure_container_apps_defaults_to_zero_replicas_for_bootstrap_safety` and the test passed. 
- Also ran `cargo test -p autumn-cli variables_tf_declares_expected_inputs` which passed in the same test session. 
- Ran `git diff --check` and `git status` to verify no whitespace or other diff issues, both succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7265e4ebe0832a99a10ef96049bc6f)