### PR TITLE
Fix POSIX installer release namespace

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 # Autumn CLI installer.
 #
-#   curl -fsSL https://raw.githubusercontent.com/madmax983/autumn/trunk-dev/scripts/install.sh | sh
+#   curl -fsSL https://raw.githubusercontent.com/autumn-foundation/autumn/trunk-dev/scripts/install.sh | sh
 #
 # Downloads a prebuilt `autumn` binary from GitHub Releases, verifies its sha256
 # checksum, and installs it. Linux and macOS (x86_64 and aarch64) are supported.
@@ -11,10 +11,10 @@
 #   AUTUMN_VERSION      version tag to install, or "latest" (default: latest)
 #   AUTUMN_INSTALL_DIR  install directory (default: $HOME/.local/bin)
 #   AUTUMN_TARGET       force target triple (default: autodetected)
-#   AUTUMN_BASE_URL     release base URL (default: https://github.com/madmax983/autumn/releases)
+#   AUTUMN_BASE_URL     release base URL (default: https://github.com/autumn-foundation/autumn/releases)
 set -eu
 
-REPO_SLUG="madmax983/autumn"
+REPO_SLUG="autumn-foundation/autumn"
 DEFAULT_BASE_URL="https://github.com/${REPO_SLUG}/releases"
 
 VERSION="${AUTUMN_VERSION:-latest}"
@@ -50,7 +50,7 @@ Environment overrides (flags --version/--dir/--target mirror them):
   AUTUMN_VERSION      version tag to install, or "latest" (default: latest)
   AUTUMN_INSTALL_DIR  install directory (default: $HOME/.local/bin)
   AUTUMN_TARGET       force target triple (default: autodetected)
-  AUTUMN_BASE_URL     release base URL (default: https://github.com/madmax983/autumn/releases)
+  AUTUMN_BASE_URL     release base URL (default: https://github.com/autumn-foundation/autumn/releases)
 EOF
       exit 0 ;;
     *) err "unknown argument: $1 (try --help)" ;;


### PR DESCRIPTION
### Motivation
- Remediate a supply-chain regression where `scripts/install.sh` defaulted to the stale `madmax983/autumn` release namespace while public installer entry points had moved to `autumn-foundation/autumn`, which allowed attacker-controlled artifacts and checksums to be trusted.

### Description
- Change the installer example and help text to reference `autumn-foundation/autumn` and set `REPO_SLUG="autumn-foundation/autumn"` so `DEFAULT_BASE_URL` and `BASE_URL` default to `https://github.com/autumn-foundation/autumn/releases` unless overridden.

### Testing
- Ran `sh scripts/install.sh --help` and confirmed the help text shows the updated `AUTUMN_BASE_URL`; ran `rg` checks to ensure no `madmax983/autumn` remains and `autumn-foundation/autumn` is present; executed a fake-`curl` regression check with `sh scripts/install.sh --version v9.9.9 --target x86_64-unknown-linux-musl` to verify the default download URL is `https://github.com/autumn-foundation/autumn/releases/download/...` and no `madmax983/autumn` was requested; all automated checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5f16a61a98832ab0269396a7e4308d)