### PR TITLE
MCP schema quality Part 3: Query&lt;T&gt; decodes sequences and nested structures (Part 3 of #1972)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,10 +33,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   scalar arrays as repeated keys, containers bracketed), so the advertised
   contract and the dispatch actually agree. A JSON `null` renders no parameter
   at all instead of the literal text `null`, and nesting past the decoder's cap
-  is refused up front. The build-time "nested query field" warning is gone —
-  nested query fields are now honored rather than steered away — while the
-  opaque-`{"type":"object"}`-placeholder warnings remain.
-
+  is refused up front. An argument the encoding cannot carry — an empty array or
+  object, a `null` array element, an object field name containing `[` or `]` —
+  is an invalid-params error rather than a silently altered dispatch, and one
+  call's query expansion is bounded. The build-time "nested query field" warning
+  is gone — nested query fields are now honored rather than steered away — while
+  the opaque-`{"type":"object"}`-placeholder warnings remain.
 - **`autumn generate webhook` for signed, replay-safe provider intake
   (#1366):** the `SignedWebhook` substrate has shipped since 0.4.0, but every
   Stripe/GitHub/Slack integration still hand-rolled the route, the endpoint
@@ -204,6 +206,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `runtime-only` — and when a mostly-provable dimension ships with a caveat
   instead of a demotion, with outbound HTTP worked through as `declared` — is
   now documented in `docs/guide/security-posture-manifest.md` (#1627).
+
+### Changed
+
+- **`Query<T>` treats `[` and `]` in a query key as structure (#1972).** A
+  target that types a parameter as a plain value — `Query<HashMap<String,
+  String>>` is the common one — used to receive `?filter[a]=1` as the literal
+  key `"filter[a]"`; it now sees a nested object and reports a decode error
+  naming the fix. Give such a field a nested type, or accept it as
+  `serde_json::Value`. A key the grammar cannot resolve (one name used as both a
+  scalar and a container, or nesting past the cap) fails only if the target
+  actually claims it, so an unrecognised parameter stays ignorable exactly as
+  before.
+- **`Query<T>` rejects a duplicated key in a single-valued position (#1972).**
+  `?q=a&q=b` against a `String` field is a 400, as it was under
+  `serde_urlencoded` + serde's derive (`duplicate field`). A **map**-typed
+  target previously resolved this silently to the last value; resolving
+  parameter pollution quietly is how the resulting bugs are built, so it is now
+  loud. A sequence field still takes every occurrence.
+- **Query decode errors no longer echo the submitted value (#1972).** A
+  coercion failure names the field path and the expected type
+  (`page: invalid u32 value`) but never the text — the message is returned in
+  the 400 Problem Details body and recorded by every error reporter, and a query
+  parameter can hold a secret. Key text embedded in an error is bounded and
+  stripped of control characters.
+- **`Query<Vec<(String, String)>>` yields key-sorted pairs (#1972)** rather than
+  submission order; occurrences of one key keep their relative order. The
+  `#[edge]` extractor is unaffected — `autumn_edge`'s prelude re-exports axum's
+  `Query`.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`Query<T>` decodes sequences and nested structures (#1972):** the extractor
+  no longer delegates to `serde_urlencoded`, whose strict flatness meant a
+  `Vec<String>` field fed the conforming `?tags=a&tags=b` form failed with
+  `invalid type: string "a", expected a sequence`, and a nested struct field was
+  unrepresentable by any encoding — so builders fell back to comma-separated
+  strings and JSON-in-a-string. It now decodes a **superset** of the flat form
+  (a query string of unique scalar keys behaves exactly as before) that also
+  accepts repeated keys (`tags=a&tags=b`), the append and indexed sequence forms
+  (`tags[]=a`, `tags[0]=a`), nested objects (`filter[status]=open`), and arrays
+  of objects (`items[0][sku]=A-1`) — the same bracketed dialect
+  `NestedChangesetForm` already uses for `has_many` rows. Scalar coercion,
+  present-but-empty `Option` handling, and unknown-key tolerance keep
+  `serde_urlencoded` parity; decode errors now name the failing field path
+  (`filter.limit: invalid value …`). Nesting is depth-capped and indices key an
+  ordered map rather than a `Vec`, so neither deep nesting nor `tags[4000000000]`
+  can drive unbounded allocation.
+- **MCP `tools/call` dispatch honors structured query arguments (#1972):** the
+  dispatcher already expanded an array query argument to repeated keys, which
+  the handler then rejected — a tool whose derived `inputSchema` advertised
+  `tags: array` dispatched a request its own handler answered with 400. Query
+  arguments are now rendered into the extractor's own wire format (scalars flat,
+  scalar arrays as repeated keys, containers bracketed), so the advertised
+  contract and the dispatch actually agree. A JSON `null` renders no parameter
+  at all instead of the literal text `null`, and nesting past the decoder's cap
+  is refused up front. The build-time "nested query field" warning is gone —
+  nested query fields are now honored rather than steered away — while the
+  opaque-`{"type":"object"}`-placeholder warnings remain.
+
 - **`autumn generate webhook` for signed, replay-safe provider intake
   (#1366):** the `SignedWebhook` substrate has shipped since 0.4.0, but every
   Stripe/GitHub/Slack integration still hand-rolled the route, the endpoint

--- a/autumn/src/extract.rs
+++ b/autumn/src/extract.rs
@@ -144,29 +144,31 @@ where
 
 /// Deserialize URL query string parameters.
 ///
-/// Wraps [`axum::extract::Query`] so query parse failures use Autumn's
-/// Problem Details error contract.
+/// Query parse failures use Autumn's Problem Details error contract.
 ///
-/// # Query strings are flat
+/// # Sequences and nested structures
 ///
-/// Deserialization goes through
-/// [`serde_urlencoded`](https://docs.rs/serde_urlencoded), which is **strictly
-/// flat**: it decodes scalar fields (`?q=foo&page=2`) and nothing else. It
-/// **cannot** deserialize a nested struct by any encoding — neither bracketed
-/// (`key[sub]=`) nor JSON-in-a-string — and it **cannot** collect repeated
-/// keys into a sequence: a `Vec<String>` field fed `?tags=a&tags=b` fails with
-/// `invalid type: string "a", expected a sequence`. If a request needs a
-/// sequence or structured/nested input, take it as a JSON body
-/// ([`Json<T>`](crate::extract::Json)) instead of a query struct.
+/// Decoding goes through [`query_string`](crate::query_string), a **superset**
+/// of the flat `serde_urlencoded` form: a query string of unique scalar keys
+/// decodes exactly as it always did, and on top of that
+///
+/// ```text
+/// tags=a&tags=b               // repeated key   → Vec<String>
+/// tags[]=a&tags[]=b           // append form    → Vec<String>
+/// tags[0]=a&tags[2]=c         // indexed form   → Vec<String> (gaps compacted)
+/// filter[status]=open         // nested object  → struct field
+/// items[0][sku]=A-1           // array of objects
+/// ```
+///
+/// are all accepted — the same bracketed dialect
+/// [`nested_form`](crate::nested_form) already uses for `has_many` form rows.
+/// See [`query_string`](crate::query_string) for the exact semantics (scalar
+/// coercion, first-occurrence-wins, shape conflicts, the depth cap).
 ///
 /// This also shapes MCP tool exposure (issue #1972): a `Query<T>` becomes the
-/// tool's `query` object property, and dispatch renders it as flat `key=value`
-/// pairs. A `Query<T>` whose schema has a nested object / array-of-object field
-/// therefore cannot round-trip, and Autumn emits a build-time `tracing::warn`
-/// steering that input to a JSON body. See the [MCP guide]'s "Query is flat"
-/// note.
-///
-/// [MCP guide]: https://docs.rs/autumn-web (guide/mcp.md)
+/// tool's `query` object property, and `tools/call` dispatch renders that
+/// object into this same wire format, so a tool advertising a sequence or a
+/// nested object round-trips back into the handler's typed struct.
 #[derive(Debug, Clone, Copy, Default)]
 pub struct Query<T>(pub T);
 
@@ -175,19 +177,23 @@ impl_extractor_deref!(Query);
 impl<S, T> FromRequestParts<S> for Query<T>
 where
     S: Send + Sync,
-    axum::extract::Query<T>:
-        FromRequestParts<S, Rejection = axum::extract::rejection::QueryRejection>,
+    T: serde::de::DeserializeOwned,
 {
     type Rejection = crate::AutumnError;
 
     async fn from_request_parts(
         parts: &mut axum::http::request::Parts,
-        state: &S,
+        _state: &S,
     ) -> Result<Self, Self::Rejection> {
-        axum::extract::Query::from_request_parts(parts, state)
-            .await
-            .map(|axum::extract::Query(value)| Self(value))
-            .map_err(|err| rejection_to_error(err.status(), err.body_text()))
+        let query = parts.uri.query().unwrap_or_default();
+        crate::query_string::from_query_str::<T>(query)
+            .map(Self)
+            .map_err(|err| {
+                rejection_to_error(
+                    http::StatusCode::BAD_REQUEST,
+                    format!("Failed to deserialize query string: {err}"),
+                )
+            })
     }
 }
 

--- a/autumn/src/extract.rs
+++ b/autumn/src/extract.rs
@@ -1,7 +1,10 @@
-//! Re-exports of Axum extractors for use in Autumn handlers.
+//! Autumn's request extractors.
 //!
-//! These are provided so users don't need `axum` as a direct dependency
-//! for the most common extractor types.
+//! Most are thin wrappers over the Axum extractor of the same name, provided so
+//! users don't need `axum` as a direct dependency and so parse failures use
+//! Autumn's Problem Details error contract. [`Query`] is the exception: it
+//! decodes through [`crate::query_string`], which accepts sequences and nested
+//! structures the flat `serde_urlencoded` form cannot express.
 //!
 //! | Extractor | Purpose |
 //! |-----------|---------|
@@ -160,10 +163,13 @@ where
 /// items[0][sku]=A-1           // array of objects
 /// ```
 ///
-/// are all accepted — the same bracketed dialect
-/// [`nested_form`](crate::nested_form) already uses for `has_many` form rows.
-/// See [`query_string`](crate::query_string) for the exact semantics (scalar
-/// coercion, first-occurrence-wins, shape conflicts, the depth cap).
+/// are all accepted — a bracketed dialect whose `items[0][sku]` shape matches
+/// the repeated-row encoding [`nested_form`](crate::nested_form) renders,
+/// generalized to arbitrary objects, sequences and depths. It applies to the
+/// query string only: [`Form<T>`] still decodes request bodies through
+/// `serde_urlencoded`. See [`query_string`](crate::query_string) for the exact
+/// semantics — scalar coercion, duplicate-key rejection, shape conflicts, the
+/// depth cap, and what changed for `HashMap`-typed targets.
 ///
 /// This also shapes MCP tool exposure (issue #1972): a `Query<T>` becomes the
 /// tool's `query` object property, and `tools/call` dispatch renders that

--- a/autumn/src/lib.rs
+++ b/autumn/src/lib.rs
@@ -194,6 +194,7 @@ pub(crate) mod pg_conn_str;
 pub mod plugin;
 pub mod plugin_conformance;
 pub mod probe;
+pub mod query_string;
 
 /// Re-export of the [`include_dir`](https://docs.rs/include_dir) crate.
 ///

--- a/autumn/src/mcp.rs
+++ b/autumn/src/mcp.rs
@@ -543,10 +543,6 @@ enum SchemaDegradation {
     /// The `body` property resolved to a bare `{"type":"object"}` placeholder,
     /// so the tool advertises no body fields.
     OpaqueBody,
-    /// A `query` field is itself a nested object (or an array of objects) — a
-    /// shape `serde_urlencoded` (which `Query<T>` delegates to) cannot parse,
-    /// so dispatch of such an argument could never round-trip to the handler.
-    NestedQuery,
 }
 
 /// Resolve a schema node through a single `#/$defs/X` indirection (the form
@@ -574,46 +570,6 @@ fn is_opaque_object(schema: &Value) -> bool {
             .is_none_or(|map| !map.contains_key("properties"))
 }
 
-/// True when a `oneOf`/`anyOf` branch is the `{"type":"null"}` arm the
-/// `OpenApiSchema` derive emits for the `None` case of an `Option<T>` field.
-fn is_null_branch(branch: &Value) -> bool {
-    branch.get("type").and_then(Value::as_str) == Some("null")
-}
-
-/// True when `schema` (already ref-resolved) is a nested object or an array of
-/// objects — the shapes flat `serde_urlencoded` query decoding cannot handle.
-///
-/// A nullable query field (`Option<Struct>`, `Option<Vec<Struct>>`) derives to a
-/// `oneOf`/`anyOf` with the nested-shape branch plus a `{"type":"null"}` branch
-/// and therefore carries no top-level `type`; unwrap those wrappers and treat the
-/// field as nested when ANY non-null branch is itself nested, so a nullable
-/// structured query field warns exactly like its non-nullable form (issue #1972).
-fn is_nested_query_shape(root: &Value, schema: &Value) -> bool {
-    if let Some(branches) = schema
-        .get("oneOf")
-        .or_else(|| schema.get("anyOf"))
-        .and_then(Value::as_array)
-    {
-        return branches
-            .iter()
-            .filter(|branch| !is_null_branch(branch))
-            .map(|branch| resolve_local_ref(root, branch))
-            .any(|branch| is_nested_query_shape(root, branch));
-    }
-
-    match schema.get("type").and_then(Value::as_str) {
-        // A non-placeholder object nested under a query field.
-        Some("object") => schema
-            .as_object()
-            .is_some_and(|map| map.contains_key("properties")),
-        Some("array") => schema
-            .get("items")
-            .map(|items| resolve_local_ref(root, items))
-            .is_some_and(|items| is_nested_query_shape(root, items)),
-        _ => false,
-    }
-}
-
 /// Inspect a built `inputSchema` for the degradations in [`SchemaDegradation`].
 ///
 /// Pure and self-contained (no logging) so it is unit-testable; [`derive_tools`]
@@ -633,21 +589,14 @@ fn detect_schema_degradations(
         out.push(SchemaDegradation::OpaqueBody);
     }
 
-    if has_query && let Some(query) = props.and_then(|p| p.get("query")) {
-        let resolved = resolve_local_ref(input_schema, query);
-        if is_opaque_object(resolved) {
-            out.push(SchemaDegradation::OpaqueQuery);
-        } else if let Some(fields) = resolved.get("properties").and_then(Value::as_object) {
-            // A `Query<T>` whose schema is real but has a nested/object-of-array
-            // field can't round-trip through `serde_urlencoded`.
-            let nested = fields
-                .values()
-                .map(|field| resolve_local_ref(input_schema, field))
-                .any(|field| is_nested_query_shape(input_schema, field));
-            if nested {
-                out.push(SchemaDegradation::NestedQuery);
-            }
-        }
+    // A nested/array query field is NOT a degradation: `Query<T>` decodes the
+    // bracketed dialect `build_request` renders it into (issue #1972), so the
+    // advertised structure round-trips. Only a missing field-level schema is.
+    if has_query
+        && let Some(query) = props.and_then(|p| p.get("query"))
+        && is_opaque_object(resolve_local_ref(input_schema, query))
+    {
+        out.push(SchemaDegradation::OpaqueQuery);
     }
 
     out
@@ -677,15 +626,6 @@ fn warn_on_degraded_input_schema(doc: &ApiDoc, input_schema: &Value) {
                 "MCP tool query has no field-level schema (opaque object); derive or \
                  impl `OpenApiSchema` on the `Query<T>` type so the tool advertises \
                  its real query parameters instead of a bare `{{\"type\":\"object\"}}` placeholder"
-            ),
-            SchemaDegradation::NestedQuery => tracing::warn!(
-                operation_id = doc.operation_id,
-                method = doc.method,
-                path = doc.path,
-                "MCP tool query advertises a nested object/array-of-object field; \
-                 `Query<T>` decodes with `serde_urlencoded`, which is strictly flat and \
-                 cannot parse nested query parameters — move the structured input to a \
-                 JSON request body (`Json<T>`) so it round-trips losslessly"
             ),
         }
     }
@@ -2023,17 +1963,7 @@ fn build_request(
         };
         let mut pairs: Vec<(String, String)> = Vec::new();
         for (key, value) in map {
-            match value {
-                // Form/explode semantics: an array field expands to repeated
-                // keys (`tags=a&tags=b`), matching the OpenAPI query model the
-                // tool schema advertises — not a single `tags=["a","b"]`.
-                Value::Array(items) => {
-                    for item in items {
-                        pairs.push((key.clone(), query_scalar(item)));
-                    }
-                }
-                other => pairs.push((key.clone(), query_scalar(other))),
-            }
+            encode_query_arg(key, value, 1, &mut pairs)?;
         }
         if !pairs.is_empty() {
             let qs = serde_urlencoded::to_string(&pairs)
@@ -2101,6 +2031,75 @@ fn query_scalar(value: &Value) -> String {
     match value {
         Value::String(s) => s.clone(),
         other => other.to_string(),
+    }
+}
+
+/// Flatten one `query` argument into the `key=value` pairs the
+/// [`Query<T>`](crate::extract::Query) extractor decodes (issue #1972).
+///
+/// The wire format is the extractor's own dialect
+/// ([`query_string`](crate::query_string)), so a tool's advertised
+/// `inputSchema` and the request dispatch actually agree:
+///
+/// * scalars render flat (`page=2`);
+/// * an array of scalars expands to repeated keys (`tags=a&tags=b`) — the
+///   OpenAPI `form`/`explode` shape;
+/// * an array containing any container uses explicit positions
+///   (`items[0][sku]=A-1`), so element order survives;
+/// * an object nests by key (`filter[status]=open`).
+///
+/// A JSON `null` renders **no pair at all**: a query string has no null, and
+/// emitting the literal text `null` would fail the handler's coercion instead
+/// of decoding as the absent/`None` the caller meant.
+///
+/// # Errors
+///
+/// Returns an error when nesting exceeds
+/// [`query_string::MAX_DEPTH`](crate::query_string::MAX_DEPTH) — the depth the
+/// decoder on the other side accepts — rather than emitting keys that would
+/// then be rejected downstream.
+fn encode_query_arg(
+    key: &str,
+    value: &Value,
+    depth: usize,
+    out: &mut Vec<(String, String)>,
+) -> Result<(), String> {
+    if depth > crate::query_string::MAX_DEPTH {
+        return Err(format!(
+            "query argument `{key}` nests deeper than the maximum of {}",
+            crate::query_string::MAX_DEPTH
+        ));
+    }
+    match value {
+        Value::Null => Ok(()),
+        Value::Array(items) => {
+            let all_scalar = items
+                .iter()
+                .all(|item| !matches!(item, Value::Array(_) | Value::Object(_)));
+            if all_scalar {
+                for item in items {
+                    if !item.is_null() {
+                        out.push((key.to_owned(), query_scalar(item)));
+                    }
+                }
+                Ok(())
+            } else {
+                for (index, item) in items.iter().enumerate() {
+                    encode_query_arg(&format!("{key}[{index}]"), item, depth + 1, out)?;
+                }
+                Ok(())
+            }
+        }
+        Value::Object(fields) => {
+            for (field, nested) in fields {
+                encode_query_arg(&format!("{key}[{field}]"), nested, depth + 1, out)?;
+            }
+            Ok(())
+        }
+        scalar => {
+            out.push((key.to_owned(), query_scalar(scalar)));
+            Ok(())
+        }
     }
 }
 
@@ -2493,7 +2492,6 @@ mod tests {
         let degradations = detect_schema_degradations(&schema, true, true);
         assert!(degradations.contains(&SchemaDegradation::OpaqueQuery));
         assert!(degradations.contains(&SchemaDegradation::OpaqueBody));
-        assert!(!degradations.contains(&SchemaDegradation::NestedQuery));
     }
 
     #[test]
@@ -2514,9 +2512,11 @@ mod tests {
     }
 
     #[test]
-    fn detect_degradation_flags_nested_query_object_and_array() {
-        // A query field that is itself an object → nested (flat-encoding cannot
-        // round-trip). Also cover an array-of-objects field.
+    fn detect_degradation_accepts_structured_query_fields() {
+        // Nested objects, arrays of objects, `$ref`s and their nullable
+        // (`oneOf [.., {"type":"null"}]`) forms are all round-trippable now that
+        // `Query<T>` decodes the bracketed dialect `build_request` emits
+        // (issue #1972), so none of them may be reported as a degradation.
         let schema = json!({
             "type": "object",
             "properties": {
@@ -2525,69 +2525,9 @@ mod tests {
                     "properties": {
                         "filter": { "type": "object", "properties": { "min": { "type": "integer" } } },
                         "rows": { "type": "array", "items": { "type": "object", "properties": { "k": { "type": "string" } } } },
-                    },
-                },
-            },
-        });
-        let degradations = detect_schema_degradations(&schema, true, false);
-        assert!(degradations.contains(&SchemaDegradation::NestedQuery));
-        assert!(!degradations.contains(&SchemaDegradation::OpaqueQuery));
-    }
-
-    #[test]
-    fn detect_degradation_flags_nested_query_via_ref() {
-        // A query field that is a `$ref` to an object def is still nested.
-        let schema = json!({
-            "type": "object",
-            "properties": {
-                "query": {
-                    "type": "object",
-                    "properties": { "filter": { "$ref": "#/$defs/Filter" } },
-                },
-            },
-            "$defs": { "Filter": { "type": "object", "properties": { "min": { "type": "integer" } } } },
-        });
-        assert!(
-            detect_schema_degradations(&schema, true, false)
-                .contains(&SchemaDegradation::NestedQuery)
-        );
-    }
-
-    #[test]
-    fn detect_degradation_flags_nullable_nested_query_field() {
-        // `filter: Option<Filter>` derives to a nullable `oneOf` (the nested
-        // object branch + a `{"type":"null"}` branch) with no top-level `type`.
-        // The detector must still flag it — `serde_urlencoded` cannot decode the
-        // structured value whether or not the field is optional (issue #1972).
-        let schema = json!({
-            "type": "object",
-            "properties": {
-                "query": {
-                    "type": "object",
-                    "properties": {
-                        "filter": { "oneOf": [ { "$ref": "#/$defs/Filter" }, { "type": "null" } ] },
-                    },
-                },
-            },
-            "$defs": { "Filter": { "type": "object", "properties": { "min": { "type": "integer" } } } },
-        });
-        let degradations = detect_schema_degradations(&schema, true, false);
-        assert!(
-            degradations.contains(&SchemaDegradation::NestedQuery),
-            "nullable nested query field must warn: {degradations:?}"
-        );
-    }
-
-    #[test]
-    fn detect_degradation_flags_nullable_array_of_objects_query_field() {
-        // `filter: Option<Vec<Filter>>` → `oneOf[{array of $ref}, {null}]`.
-        let schema = json!({
-            "type": "object",
-            "properties": {
-                "query": {
-                    "type": "object",
-                    "properties": {
-                        "filters": { "oneOf": [
+                        "ref_filter": { "$ref": "#/$defs/Filter" },
+                        "maybe_filter": { "oneOf": [ { "$ref": "#/$defs/Filter" }, { "type": "null" } ] },
+                        "maybe_rows": { "oneOf": [
                             { "type": "array", "items": { "$ref": "#/$defs/Filter" } },
                             { "type": "null" },
                         ] },
@@ -2597,37 +2537,48 @@ mod tests {
             "$defs": { "Filter": { "type": "object", "properties": { "min": { "type": "integer" } } } },
         });
         assert!(
-            detect_schema_degradations(&schema, true, false)
-                .contains(&SchemaDegradation::NestedQuery),
-            "nullable array-of-objects query field must warn"
+            detect_schema_degradations(&schema, true, false).is_empty(),
+            "structured query fields are honored, not degraded"
         );
     }
 
     #[test]
-    fn detect_degradation_ignores_nullable_scalar_query_field() {
-        // `q: Option<String>` → `oneOf[{type:string}, {type:null}]` and
-        // `tags: Option<Vec<String>>` → `oneOf[{array of scalar}, {null}]`: both
-        // are flat-encodable, so neither may produce a false positive.
-        let schema = json!({
-            "type": "object",
-            "properties": {
-                "query": {
-                    "type": "object",
-                    "properties": {
-                        "q": { "oneOf": [ { "type": "string" }, { "type": "null" } ] },
-                        "tags": { "oneOf": [
-                            { "type": "array", "items": { "type": "string" } },
-                            { "type": "null" },
-                        ] },
-                    },
-                },
-            },
-        });
-        assert!(
-            !detect_schema_degradations(&schema, true, false)
-                .contains(&SchemaDegradation::NestedQuery),
-            "nullable scalar / scalar-array query fields must NOT warn"
+    fn encode_query_arg_renders_the_extractor_dialect() {
+        let mut pairs = Vec::new();
+        encode_query_arg("page", &json!(2), 1, &mut pairs).expect("scalar");
+        encode_query_arg("tags", &json!(["a", "b"]), 1, &mut pairs).expect("scalar array");
+        encode_query_arg("filter", &json!({ "status": "open" }), 1, &mut pairs).expect("object");
+        encode_query_arg("items", &json!([{ "sku": "A" }]), 1, &mut pairs).expect("object array");
+        assert_eq!(
+            pairs,
+            vec![
+                ("page".to_owned(), "2".to_owned()),
+                ("tags".to_owned(), "a".to_owned()),
+                ("tags".to_owned(), "b".to_owned()),
+                ("filter[status]".to_owned(), "open".to_owned()),
+                ("items[0][sku]".to_owned(), "A".to_owned()),
+            ]
         );
+    }
+
+    #[test]
+    fn encode_query_arg_omits_nulls_rather_than_stringifying_them() {
+        let mut pairs = Vec::new();
+        encode_query_arg("page", &json!(null), 1, &mut pairs).expect("null");
+        encode_query_arg("filter", &json!({ "status": null }), 1, &mut pairs).expect("null field");
+        assert!(pairs.is_empty(), "a JSON null renders no pair: {pairs:?}");
+    }
+
+    #[test]
+    fn encode_query_arg_rejects_nesting_past_the_decoder_cap() {
+        // Build an object nested one level deeper than the decoder accepts, so
+        // the encoder refuses instead of emitting keys the extractor rejects.
+        let mut value = json!("leaf");
+        for _ in 0..crate::query_string::MAX_DEPTH {
+            value = json!({ "deeper": value });
+        }
+        let mut pairs = Vec::new();
+        assert!(encode_query_arg("root", &value, 1, &mut pairs).is_err());
     }
 
     #[test]

--- a/autumn/src/mcp.rs
+++ b/autumn/src/mcp.rs
@@ -2209,8 +2209,20 @@ fn encode_query_arg(
                 .iter()
                 .all(|item| !matches!(item, Value::Array(_) | Value::Object(_)));
             if all_scalar {
-                for item in items {
-                    out.push(key, query_scalar(item))?;
+                if let [only] = items.as_slice() {
+                    // Repeated keys carry a sequence only from the *second*
+                    // occurrence on: one `tags=only` pair is indistinguishable
+                    // from a scalar, so `deserialize_any` (an untyped
+                    // `serde_json::Value` target) would yield `"only"` for the
+                    // `["only"]` the caller sent — and the field would turn
+                    // back into an array on gaining a second element. The
+                    // explicit position pins the kind. A typed `Vec` target
+                    // decodes either form identically.
+                    out.push(&format!("{key}[0]"), query_scalar(only))?;
+                } else {
+                    for item in items {
+                        out.push(key, query_scalar(item))?;
+                    }
                 }
             } else {
                 for (index, item) in items.iter().enumerate() {
@@ -2233,10 +2245,23 @@ fn encode_query_arg(
         // the target, so it refuses the shape rather than dispatch a value the
         // caller did not ask for. Mixed keys are fine: the named one forces the
         // decoder to promote the whole node to a map.
+        // A `null` field emits no pair, so it cannot disambiguate anything: it
+        // is invisible to the decoder. Judging the shape on *declared* keys let
+        // `{"0": 5, "kind": null}` through, which reaches the wire as the bare
+        // `counts[0]=5` this arm exists to refuse. So the check runs over the
+        // fields that actually emit. An all-null object is left to fall through
+        // to the collapse check below, which describes it better.
         Value::Object(fields)
-            if fields
-                .keys()
-                .all(|field| !field.is_empty() && field.bytes().all(|b| b.is_ascii_digit())) =>
+            if {
+                let mut emitting = fields
+                    .iter()
+                    .filter(|(_, value)| !value.is_null())
+                    .peekable();
+                emitting.peek().is_some()
+                    && emitting.all(|(field, _)| {
+                        !field.is_empty() && field.bytes().all(|b| b.is_ascii_digit())
+                    })
+            } =>
         {
             return Err(format!(
                 "query argument `{key}` is an object whose field names are all numeric; a \
@@ -2891,6 +2916,51 @@ mod tests {
         let err = encode_query_arg("counts", &json!({ "": 1 }), 1, &mut pairs)
             .expect_err("an empty field name is inexpressible");
         assert!(err.contains("may not be empty"), "{err}");
+    }
+
+    #[test]
+    fn a_singleton_scalar_array_keeps_its_container_kind() {
+        // Codex P2: one repeated key is indistinguishable from a scalar, so a
+        // one-element array must use the explicit position instead.
+        let mut pairs = QueryPairs::new();
+        encode_query_arg("tags", &json!(["only"]), 1, &mut pairs).expect("encodes");
+        assert_eq!(
+            pairs.pairs,
+            vec![("tags[0]".to_owned(), "only".to_owned())],
+            "a singleton must pin its kind"
+        );
+
+        // Two or more still use the repeated-key (OpenAPI form/explode) shape.
+        let mut pairs = QueryPairs::new();
+        encode_query_arg("tags", &json!(["a", "b"]), 1, &mut pairs).expect("encodes");
+        assert_eq!(
+            pairs.pairs,
+            vec![
+                ("tags".to_owned(), "a".to_owned()),
+                ("tags".to_owned(), "b".to_owned())
+            ]
+        );
+    }
+
+    #[test]
+    fn the_numeric_object_check_ignores_fields_that_emit_nothing() {
+        // Codex P2: a `null` field emits no pair, so it cannot disambiguate —
+        // judging on declared keys let this reach the wire as bare `counts[0]=5`.
+        let mut pairs = QueryPairs::new();
+        let err = encode_query_arg("counts", &json!({ "0": 5, "kind": null }), 1, &mut pairs)
+            .expect_err("the null field cannot disambiguate");
+        assert!(err.contains("all numeric"), "{err}");
+
+        // A named field that *does* emit still disambiguates, as before.
+        let mut pairs = QueryPairs::new();
+        encode_query_arg("counts", &json!({ "0": 5, "kind": "x" }), 1, &mut pairs)
+            .expect("an emitting named key resolves the shape");
+
+        // An all-null object keeps its own, more specific collapse error.
+        let mut pairs = QueryPairs::new();
+        let err = encode_query_arg("counts", &json!({ "0": null }), 1, &mut pairs)
+            .expect_err("an all-null object carries no value");
+        assert!(err.contains("carries no value"), "{err}");
     }
 
     #[test]

--- a/autumn/src/mcp.rs
+++ b/autumn/src/mcp.rs
@@ -1961,12 +1961,12 @@ fn build_request(
         let Value::Object(map) = query else {
             return Err("`query` must be a JSON object".to_owned());
         };
-        let mut pairs: Vec<(String, String)> = Vec::new();
+        let mut pairs = QueryPairs::new();
         for (key, value) in map {
             encode_query_arg(key, value, 1, &mut pairs)?;
         }
-        if !pairs.is_empty() {
-            let qs = serde_urlencoded::to_string(&pairs)
+        if !pairs.pairs.is_empty() {
+            let qs = serde_urlencoded::to_string(&pairs.pairs)
                 .map_err(|e| format!("invalid query arguments: {e}"))?;
             path = format!("{path}?{qs}");
         }
@@ -2034,6 +2034,49 @@ fn query_scalar(value: &Value) -> String {
     }
 }
 
+/// Upper bound on the pairs one tool call may expand its `query` object into.
+///
+/// `tools/call` arguments are client-supplied and only bounded by the request
+/// body limit (32 MiB by default), while building a bracketed key copies its
+/// whole prefix per child — quadratic in the argument size. Both this and
+/// [`MAX_QUERY_BYTES`] bail out long before that matters, and well inside the
+/// 64 KiB `http::Uri` limit the assembled request would hit anyway.
+const MAX_QUERY_PAIRS: usize = 1024;
+
+/// Upper bound on the total key+value bytes one tool call may expand into.
+const MAX_QUERY_BYTES: usize = 8 * 1024;
+
+/// Accumulator for the `key=value` pairs a tool call's `query` object expands
+/// into, enforcing [`MAX_QUERY_PAIRS`] / [`MAX_QUERY_BYTES`].
+struct QueryPairs {
+    pairs: Vec<(String, String)>,
+    bytes: usize,
+}
+
+impl QueryPairs {
+    const fn new() -> Self {
+        Self {
+            pairs: Vec::new(),
+            bytes: 0,
+        }
+    }
+
+    fn push(&mut self, key: &str, value: String) -> Result<(), String> {
+        self.bytes = self
+            .bytes
+            .saturating_add(key.len())
+            .saturating_add(value.len());
+        if self.pairs.len() >= MAX_QUERY_PAIRS || self.bytes > MAX_QUERY_BYTES {
+            return Err(format!(
+                "query arguments expand past the dispatch limit of {MAX_QUERY_PAIRS} \
+                 parameters / {MAX_QUERY_BYTES} bytes"
+            ));
+        }
+        self.pairs.push((key.to_owned(), value));
+        Ok(())
+    }
+}
+
 /// Flatten one `query` argument into the `key=value` pairs the
 /// [`Query<T>`](crate::extract::Query) extractor decodes (issue #1972).
 ///
@@ -2043,26 +2086,35 @@ fn query_scalar(value: &Value) -> String {
 ///
 /// * scalars render flat (`page=2`);
 /// * an array of scalars expands to repeated keys (`tags=a&tags=b`) — the
-///   OpenAPI `form`/`explode` shape;
+///   `OpenAPI` `form`/`explode` shape;
 /// * an array containing any container uses explicit positions
 ///   (`items[0][sku]=A-1`), so element order survives;
 /// * an object nests by key (`filter[status]=open`).
 ///
-/// A JSON `null` renders **no pair at all**: a query string has no null, and
+/// A `null` **field** renders no pair at all: a query string has no null, and
 /// emitting the literal text `null` would fail the handler's coercion instead
 /// of decoding as the absent/`None` the caller meant.
 ///
 /// # Errors
 ///
-/// Returns an error when nesting exceeds
-/// [`query_string::MAX_DEPTH`](crate::query_string::MAX_DEPTH) — the depth the
-/// decoder on the other side accepts — rather than emitting keys that would
-/// then be rejected downstream.
+/// Refuses, rather than silently dispatching something the caller did not ask
+/// for, when the argument cannot be expressed in a query string:
+///
+/// * an **empty** array or object — dropping it would turn a present-but-empty
+///   value into an absent one (and 400 a required field downstream);
+/// * a `null` **array element** — dropping it would shorten the sequence and
+///   shift every later element;
+/// * an object field name that is empty or contains `[` / `]` — those are
+///   structure in the bracketed dialect, so interpolating one would invent or
+///   lose a nesting level;
+/// * nesting past
+///   [`query_string::MAX_DEPTH`](crate::query_string::MAX_DEPTH), or an
+///   expansion past [`MAX_QUERY_PAIRS`] / [`MAX_QUERY_BYTES`].
 fn encode_query_arg(
     key: &str,
     value: &Value,
     depth: usize,
-    out: &mut Vec<(String, String)>,
+    out: &mut QueryPairs,
 ) -> Result<(), String> {
     if depth > crate::query_string::MAX_DEPTH {
         return Err(format!(
@@ -2070,36 +2122,58 @@ fn encode_query_arg(
             crate::query_string::MAX_DEPTH
         ));
     }
+    // Bail before formatting any child key: a single absurd key would otherwise
+    // be copied once per descendant.
+    if key.len() > MAX_QUERY_BYTES {
+        return Err(format!(
+            "query argument key exceeds {MAX_QUERY_BYTES} bytes"
+        ));
+    }
     match value {
         Value::Null => Ok(()),
+        Value::Array(items) if items.is_empty() => Err(format!(
+            "query argument `{key}` is an empty array; a query string cannot express an \
+             empty sequence — omit the argument, or move the field to a JSON body"
+        )),
         Value::Array(items) => {
+            if let Some(position) = items.iter().position(Value::is_null) {
+                return Err(format!(
+                    "query argument `{key}[{position}]` is null; a query string cannot \
+                     express a null element — omit it, or move the field to a JSON body"
+                ));
+            }
             let all_scalar = items
                 .iter()
                 .all(|item| !matches!(item, Value::Array(_) | Value::Object(_)));
             if all_scalar {
                 for item in items {
-                    if !item.is_null() {
-                        out.push((key.to_owned(), query_scalar(item)));
-                    }
+                    out.push(key, query_scalar(item))?;
                 }
-                Ok(())
             } else {
                 for (index, item) in items.iter().enumerate() {
                     encode_query_arg(&format!("{key}[{index}]"), item, depth + 1, out)?;
                 }
-                Ok(())
             }
+            Ok(())
         }
+        Value::Object(fields) if fields.is_empty() => Err(format!(
+            "query argument `{key}` is an empty object; a query string cannot express an \
+             empty object — omit the argument, or move the field to a JSON body"
+        )),
         Value::Object(fields) => {
             for (field, nested) in fields {
+                if field.is_empty() || field.contains('[') || field.contains(']') {
+                    return Err(format!(
+                        "query argument `{key}` has a field name that a query string \
+                         cannot carry: a name may not be empty or contain `[` or `]`, \
+                         which are structure in the query encoding"
+                    ));
+                }
                 encode_query_arg(&format!("{key}[{field}]"), nested, depth + 1, out)?;
             }
             Ok(())
         }
-        scalar => {
-            out.push((key.to_owned(), query_scalar(scalar)));
-            Ok(())
-        }
+        scalar => out.push(key, query_scalar(scalar)),
     }
 }
 
@@ -2544,13 +2618,13 @@ mod tests {
 
     #[test]
     fn encode_query_arg_renders_the_extractor_dialect() {
-        let mut pairs = Vec::new();
+        let mut pairs = QueryPairs::new();
         encode_query_arg("page", &json!(2), 1, &mut pairs).expect("scalar");
         encode_query_arg("tags", &json!(["a", "b"]), 1, &mut pairs).expect("scalar array");
         encode_query_arg("filter", &json!({ "status": "open" }), 1, &mut pairs).expect("object");
         encode_query_arg("items", &json!([{ "sku": "A" }]), 1, &mut pairs).expect("object array");
         assert_eq!(
-            pairs,
+            pairs.pairs,
             vec![
                 ("page".to_owned(), "2".to_owned()),
                 ("tags".to_owned(), "a".to_owned()),
@@ -2562,11 +2636,60 @@ mod tests {
     }
 
     #[test]
-    fn encode_query_arg_omits_nulls_rather_than_stringifying_them() {
-        let mut pairs = Vec::new();
+    fn encode_query_arg_omits_null_fields_rather_than_stringifying_them() {
+        let mut pairs = QueryPairs::new();
         encode_query_arg("page", &json!(null), 1, &mut pairs).expect("null");
         encode_query_arg("filter", &json!({ "status": null }), 1, &mut pairs).expect("null field");
-        assert!(pairs.is_empty(), "a JSON null renders no pair: {pairs:?}");
+        assert!(
+            pairs.pairs.is_empty(),
+            "a null field renders no pair: {:?}",
+            pairs.pairs
+        );
+    }
+
+    #[test]
+    fn encode_query_arg_refuses_values_a_query_string_cannot_carry() {
+        // Each of these would otherwise dispatch something the caller did not
+        // ask for: a vanished field, a shortened sequence, or an invented
+        // nesting level (issue #1972 review follow-ups).
+        for (label, value) in [
+            ("empty array", json!({ "tags": [] })),
+            ("empty object", json!({ "filter": {} })),
+            ("empty nested array", json!({ "matrix": [[1], []] })),
+            ("null array element", json!({ "tags": ["a", null] })),
+            (
+                "null object-array element",
+                json!({ "items": [null, { "sku": "A" }] }),
+            ),
+            ("bracket in field name", json!({ "filter": { "a[b]": 1 } })),
+            ("empty field name", json!({ "filter": { "": 1 } })),
+        ] {
+            let mut pairs = QueryPairs::new();
+            let Value::Object(fields) = &value else {
+                unreachable!()
+            };
+            let result = fields
+                .iter()
+                .try_for_each(|(key, v)| encode_query_arg(key, v, 1, &mut pairs));
+            assert!(
+                result.is_err(),
+                "{label} must be refused, not silently dropped"
+            );
+        }
+    }
+
+    #[test]
+    fn encode_query_arg_bounds_its_expansion() {
+        // A wide array cannot be turned into an unbounded pair list: expansion
+        // stops at the dispatch limit instead of building a giant URI.
+        let wide: Vec<Value> = (0..(MAX_QUERY_PAIRS * 2)).map(|i| json!(i)).collect();
+        let mut pairs = QueryPairs::new();
+        assert!(encode_query_arg("tags", &Value::Array(wide), 1, &mut pairs).is_err());
+
+        // A single absurd key is refused before any child key is formatted.
+        let mut pairs = QueryPairs::new();
+        let huge = "k".repeat(MAX_QUERY_BYTES + 1);
+        assert!(encode_query_arg(&huge, &json!({ "a": 1 }), 1, &mut pairs).is_err());
     }
 
     #[test]
@@ -2577,7 +2700,7 @@ mod tests {
         for _ in 0..crate::query_string::MAX_DEPTH {
             value = json!({ "deeper": value });
         }
-        let mut pairs = Vec::new();
+        let mut pairs = QueryPairs::new();
         assert!(encode_query_arg("root", &value, 1, &mut pairs).is_err());
     }
 

--- a/autumn/src/mcp.rs
+++ b/autumn/src/mcp.rs
@@ -1963,6 +1963,13 @@ fn build_request(
         };
         let mut pairs = QueryPairs::new();
         for (key, value) in map {
+            // The tool's own `query` property names get the same rule its
+            // nested object fields do — a dynamic query object can carry an
+            // arbitrary key here, and `filter[x]` would otherwise reach the
+            // decoder as structure rather than as the name the caller sent.
+            if !is_expressible_field_name(key) {
+                return Err(inexpressible_field_name("query"));
+            }
             encode_query_arg(key, value, 1, &mut pairs)?;
         }
         if !pairs.pairs.is_empty() {
@@ -2077,6 +2084,25 @@ impl QueryPairs {
     }
 }
 
+/// True when a JSON field name survives the bracketed query encoding.
+///
+/// `[` and `]` are structure in that encoding and an empty name addresses the
+/// append position, so a field called any of those cannot be carried: emitting
+/// it verbatim would invent, move, or lose a nesting level on the way back in.
+/// Applied to every name the encoder introduces — the tool's top-level `query`
+/// properties as well as nested object fields.
+fn is_expressible_field_name(name: &str) -> bool {
+    !name.is_empty() && !name.contains('[') && !name.contains(']')
+}
+
+/// The error for a field name [`is_expressible_field_name`] rejects.
+fn inexpressible_field_name(owner: &str) -> String {
+    format!(
+        "query argument `{owner}` has a field name that a query string cannot carry: a name \
+         may not be empty or contain `[` or `]`, which are structure in the query encoding"
+    )
+}
+
 /// Flatten one `query` argument into the `key=value` pairs the
 /// [`Query<T>`](crate::extract::Query) extractor decodes (issue #1972).
 ///
@@ -2167,12 +2193,8 @@ fn encode_query_arg(
         }
         Value::Object(fields) => {
             for (field, nested) in fields {
-                if field.is_empty() || field.contains('[') || field.contains(']') {
-                    return Err(format!(
-                        "query argument `{key}` has a field name that a query string \
-                         cannot carry: a name may not be empty or contain `[` or `]`, \
-                         which are structure in the query encoding"
-                    ));
+                if !is_expressible_field_name(field) {
+                    return Err(inexpressible_field_name(key));
                 }
                 encode_query_arg(&format!("{key}[{field}]"), nested, depth + 1, out)?;
             }
@@ -2735,6 +2757,17 @@ mod tests {
         let mut pairs = QueryPairs::new();
         encode_query_arg("filter", &json!({ "a": 1, "b": null }), 1, &mut pairs).expect("partial");
         assert_eq!(pairs.pairs, vec![("filter[a]".to_owned(), "1".to_owned())]);
+    }
+
+    #[test]
+    fn top_level_query_keys_are_validated_like_nested_field_names() {
+        // Codex P2: a dynamic query object can carry an arbitrary top-level
+        // key, and `filter[x]` would otherwise reach the decoder as structure.
+        assert!(!is_expressible_field_name("filter[x]"));
+        assert!(!is_expressible_field_name(""));
+        assert!(!is_expressible_field_name("a]b"));
+        assert!(is_expressible_field_name("filter"));
+        assert!(is_expressible_field_name("sort_by"));
     }
 
     #[test]

--- a/autumn/src/mcp.rs
+++ b/autumn/src/mcp.rs
@@ -2054,10 +2054,22 @@ const MAX_QUERY_PAIRS: usize = 1024;
 const MAX_QUERY_BYTES: usize = 8 * 1024;
 
 /// Accumulator for the `key=value` pairs a tool call's `query` object expands
+/// Ceiling on **nodes visited** while flattening, whether or not a node emits a
+/// pair.
+///
+/// [`MAX_QUERY_PAIRS`] / [`MAX_QUERY_BYTES`] bound only what reaches the wire,
+/// so a container of hundreds of thousands of `null` fields paid nothing: each
+/// one still cost a formatted child key (copying the parent), and the all-null
+/// check that rejects it runs only *after* the whole subtree is walked. Charging
+/// every visit stops that traversal at a fixed bound instead, so a body inside
+/// the documented limit cannot amplify into unbounded key-copying work.
+const MAX_QUERY_NODES: usize = 4 * MAX_QUERY_PAIRS;
+
 /// into, enforcing [`MAX_QUERY_PAIRS`] / [`MAX_QUERY_BYTES`].
 struct QueryPairs {
     pairs: Vec<(String, String)>,
     bytes: usize,
+    nodes: usize,
 }
 
 impl QueryPairs {
@@ -2065,7 +2077,24 @@ impl QueryPairs {
         Self {
             pairs: Vec::new(),
             bytes: 0,
+            nodes: 0,
         }
+    }
+
+    /// Charge one visited node against [`MAX_QUERY_NODES`].
+    ///
+    /// Called for every node the encoder descends into — including the ones
+    /// that emit nothing (`null`, and containers before their leaves are
+    /// known) — so traversal cost is bounded independently of output size.
+    fn visit(&mut self) -> Result<(), String> {
+        self.nodes += 1;
+        if self.nodes > MAX_QUERY_NODES {
+            return Err(format!(
+                "query arguments traverse more than {MAX_QUERY_NODES} values; \
+                 move the field to a JSON body"
+            ));
+        }
+        Ok(())
     }
 
     fn push(&mut self, key: &str, value: String) -> Result<(), String> {
@@ -2155,6 +2184,10 @@ fn encode_query_arg(
             "query argument key exceeds {MAX_QUERY_BYTES} bytes"
         ));
     }
+    // Before descending, and so before any child key is formatted: a `null`
+    // leaf emits no pair, so without this it would pay nothing for the parent
+    // key its sibling count forces the encoder to copy.
+    out.visit()?;
     let is_container = matches!(value, Value::Array(_) | Value::Object(_));
     let before = out.pairs.len();
     match value {
@@ -2189,6 +2222,26 @@ fn encode_query_arg(
             return Err(format!(
                 "query argument `{key}` is an empty object; a query string cannot express an \
                  empty object — omit the argument, or move the field to a JSON body"
+            ));
+        }
+        // Every key digit-only means every segment decodes as a *position*
+        // (`query_string::classify_segment`), so the tree comes back a sequence
+        // and an untyped target (`serde_json::Value`, which takes whatever
+        // `deserialize_any` yields) receives an array where the caller sent an
+        // object — with the tell that adding one named key silently flips it
+        // back. A typed map target is unaffected, but the encoder cannot see
+        // the target, so it refuses the shape rather than dispatch a value the
+        // caller did not ask for. Mixed keys are fine: the named one forces the
+        // decoder to promote the whole node to a map.
+        Value::Object(fields)
+            if fields
+                .keys()
+                .all(|field| !field.is_empty() && field.bytes().all(|b| b.is_ascii_digit())) =>
+        {
+            return Err(format!(
+                "query argument `{key}` is an object whose field names are all numeric; a \
+                 query string cannot tell that from a sequence — rename a field, or move the \
+                 field to a JSON body"
             ));
         }
         Value::Object(fields) => {
@@ -2782,6 +2835,62 @@ mod tests {
         let mut pairs = QueryPairs::new();
         let huge = "k".repeat(MAX_QUERY_BYTES + 1);
         assert!(encode_query_arg(&huge, &json!({ "a": 1 }), 1, &mut pairs).is_err());
+    }
+
+    #[test]
+    fn encode_query_arg_charges_null_leaves_for_the_traversal_they_cost() {
+        // Codex P2: `null` emits no pair, so a container of them paid nothing
+        // against the pair/byte limits while still forcing one formatted child
+        // key per field — the all-null check only fires after the full walk.
+        // The traversal budget now stops it early.
+        let nulls: serde_json::Map<String, Value> = (0..(MAX_QUERY_NODES * 2))
+            .map(|i| (format!("f{i}"), Value::Null))
+            .collect();
+        let mut pairs = QueryPairs::new();
+        let err = encode_query_arg("root", &Value::Object(nulls), 1, &mut pairs)
+            .expect_err("a traversal this wide must be refused");
+        assert!(err.contains("traverse"), "{err}");
+        assert!(
+            pairs.nodes <= MAX_QUERY_NODES + 1,
+            "traversal must stop at the bound, visited {}",
+            pairs.nodes
+        );
+
+        // The budget is generous enough that ordinary nesting is unaffected.
+        let mut pairs = QueryPairs::new();
+        encode_query_arg(
+            "filter",
+            &json!({ "status": "open", "tag": null }),
+            1,
+            &mut pairs,
+        )
+        .expect("a small object still encodes");
+    }
+
+    #[test]
+    fn encode_query_arg_refuses_an_all_numeric_keyed_object() {
+        // Codex P2: every key digit-only decodes as a sequence, so an untyped
+        // target would receive an array where the caller sent an object.
+        let mut pairs = QueryPairs::new();
+        let err = encode_query_arg("counts", &json!({ "0": 5, "1": 6 }), 1, &mut pairs)
+            .expect_err("an all-numeric-keyed object is ambiguous on the wire");
+        assert!(err.contains("all numeric"), "{err}");
+
+        // One named key is enough to force map promotion on the way back in,
+        // so the mixed shape stays expressible.
+        let mut pairs = QueryPairs::new();
+        encode_query_arg("counts", &json!({ "0": 5, "total": 6 }), 1, &mut pairs)
+            .expect("a mixed-key object round-trips as a map");
+
+        // The check is per-object, so it also catches a nested one.
+        let mut pairs = QueryPairs::new();
+        assert!(encode_query_arg("filter", &json!({ "by": { "7": "x" } }), 1, &mut pairs).is_err());
+
+        // An empty field name still gets its own, more specific error.
+        let mut pairs = QueryPairs::new();
+        let err = encode_query_arg("counts", &json!({ "": 1 }), 1, &mut pairs)
+            .expect_err("an empty field name is inexpressible");
+        assert!(err.contains("may not be empty"), "{err}");
     }
 
     #[test]

--- a/autumn/src/mcp.rs
+++ b/autumn/src/mcp.rs
@@ -2129,12 +2129,16 @@ fn encode_query_arg(
             "query argument key exceeds {MAX_QUERY_BYTES} bytes"
         ));
     }
+    let is_container = matches!(value, Value::Array(_) | Value::Object(_));
+    let before = out.pairs.len();
     match value {
-        Value::Null => Ok(()),
-        Value::Array(items) if items.is_empty() => Err(format!(
-            "query argument `{key}` is an empty array; a query string cannot express an \
-             empty sequence — omit the argument, or move the field to a JSON body"
-        )),
+        Value::Null => {}
+        Value::Array(items) if items.is_empty() => {
+            return Err(format!(
+                "query argument `{key}` is an empty array; a query string cannot express an \
+                 empty sequence — omit the argument, or move the field to a JSON body"
+            ));
+        }
         Value::Array(items) => {
             if let Some(position) = items.iter().position(Value::is_null) {
                 return Err(format!(
@@ -2154,12 +2158,13 @@ fn encode_query_arg(
                     encode_query_arg(&format!("{key}[{index}]"), item, depth + 1, out)?;
                 }
             }
-            Ok(())
         }
-        Value::Object(fields) if fields.is_empty() => Err(format!(
-            "query argument `{key}` is an empty object; a query string cannot express an \
-             empty object — omit the argument, or move the field to a JSON body"
-        )),
+        Value::Object(fields) if fields.is_empty() => {
+            return Err(format!(
+                "query argument `{key}` is an empty object; a query string cannot express an \
+                 empty object — omit the argument, or move the field to a JSON body"
+            ));
+        }
         Value::Object(fields) => {
             for (field, nested) in fields {
                 if field.is_empty() || field.contains('[') || field.contains(']') {
@@ -2171,10 +2176,22 @@ fn encode_query_arg(
                 }
                 encode_query_arg(&format!("{key}[{field}]"), nested, depth + 1, out)?;
             }
-            Ok(())
         }
-        scalar => out.push(key, query_scalar(scalar)),
+        scalar => out.push(key, query_scalar(scalar))?,
     }
+    // A container every one of whose leaves is `null` emits no pair at all.
+    // Left alone it would vanish — and inside an array the decoder would then
+    // compact the gap, shortening the sequence. That is the same silent
+    // alteration the empty-container and null-element checks above prevent, so
+    // it is refused here rather than dispatched. A `null` **field** is exempt by
+    // construction: it is not a container, so it stays the absent marker.
+    if is_container && out.pairs.len() == before {
+        return Err(format!(
+            "query argument `{key}` carries no value; a query string cannot express a \
+             container whose every field is null — omit it, or move the field to a JSON body"
+        ));
+    }
+    Ok(())
 }
 
 /// Replace a single `{name}` / `{name:regex}` capture in a path template.
@@ -2637,13 +2654,28 @@ mod tests {
 
     #[test]
     fn encode_query_arg_omits_null_fields_rather_than_stringifying_them() {
+        // A null argument is the documented "absent" marker: no pair, no error.
         let mut pairs = QueryPairs::new();
         encode_query_arg("page", &json!(null), 1, &mut pairs).expect("null");
-        encode_query_arg("filter", &json!({ "status": null }), 1, &mut pairs).expect("null field");
         assert!(
             pairs.pairs.is_empty(),
-            "a null field renders no pair: {:?}",
+            "a null argument renders no pair: {:?}",
             pairs.pairs
+        );
+
+        // The same holds for a null field alongside a carried one — only a
+        // container that collapses ENTIRELY is refused (see the collapse test).
+        let mut pairs = QueryPairs::new();
+        encode_query_arg(
+            "filter",
+            &json!({ "status": null, "kind": "a" }),
+            1,
+            &mut pairs,
+        )
+        .expect("null field beside a carried one");
+        assert_eq!(
+            pairs.pairs,
+            vec![("filter[kind]".to_owned(), "a".to_owned())]
         );
     }
 
@@ -2676,6 +2708,33 @@ mod tests {
                 "{label} must be refused, not silently dropped"
             );
         }
+    }
+
+    #[test]
+    fn encode_query_arg_refuses_containers_that_collapse_to_nothing() {
+        // Codex P2: every field of an element being null emits no pair, so the
+        // element would vanish and the decoder would compact the gap — the same
+        // silent shortening a direct null element is already refused for.
+        let mut pairs = QueryPairs::new();
+        assert!(
+            encode_query_arg(
+                "items",
+                &json!([{ "note": null }, { "note": "x" }]),
+                1,
+                &mut pairs
+            )
+            .is_err(),
+            "an all-null element must not silently shorten the sequence"
+        );
+
+        // Same one level up, for an object-typed field.
+        let mut pairs = QueryPairs::new();
+        assert!(encode_query_arg("filter", &json!({ "note": null }), 1, &mut pairs).is_err());
+
+        // A `null` FIELD is still the documented absent marker, not a collapse.
+        let mut pairs = QueryPairs::new();
+        encode_query_arg("filter", &json!({ "a": 1, "b": null }), 1, &mut pairs).expect("partial");
+        assert_eq!(pairs.pairs, vec![("filter[a]".to_owned(), "1".to_owned())]);
     }
 
     #[test]

--- a/autumn/src/openapi.rs
+++ b/autumn/src/openapi.rs
@@ -649,7 +649,11 @@ pub struct Parameter {
     /// The schema defining the type used for the parameter.
     pub schema: serde_json::Value,
     /// Serialization style. `"form"` with `explode: true` makes each object
-    /// property a separate query key — the correct mapping for `Query<T>`.
+    /// property a separate query key — the accurate mapping for a `Query<T>`
+    /// whose fields are scalars or scalar arrays. A **nested** field decodes
+    /// from the bracketed form (`?filter[status]=open`) that
+    /// [`crate::query_string`] defines, which `form`/`explode` leaves
+    /// undefined; see the "Known gaps" note in `docs/guide/openapi.md`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub style: Option<String>,
     /// When `true` with `style: "form"`, each schema property becomes an
@@ -1201,8 +1205,14 @@ fn operation_for(
 
     // Query parameters from `Query<T>` extractor.
     // Use `style: form, explode: true` so each field of the query struct
-    // is serialized as an independent query key (e.g. `?q=foo&page=2`),
-    // which matches what the server's `Query<T>` deserialization expects.
+    // is serialized as an independent query key (e.g. `?q=foo&page=2`).
+    // That is exact for scalar and scalar-array fields. A nested field
+    // (an object, or an array of objects) is decoded from the bracketed form
+    // `crate::query_string` defines — `?filter[status]=open` — which no OpenAPI
+    // style expresses in full (`deepObject` covers one object level but not an
+    // array of objects, and would also re-introduce the parameter name that
+    // `form`/`explode` correctly drops). Documented in docs/guide/openapi.md
+    // rather than misdescribed here (issue #1972).
     if let Some(query_entry) = &api_doc.query_schema {
         parameters.push(Parameter {
             name: query_entry.name.to_owned(),

--- a/autumn/src/query_string.rs
+++ b/autumn/src/query_string.rs
@@ -157,9 +157,109 @@ impl fmt::Display for QueryError {
 impl std::error::Error for QueryError {}
 
 impl de::Error for QueryError {
+    /// The catch-all serde uses for a `#[serde(deserialize_with)]` helper's own
+    /// message. Its content is out of our hands, so it is bounded and stripped
+    /// rather than trusted; the shaped constructors below intercept the serde
+    /// messages that would otherwise embed request text verbatim.
     fn custom<T: fmt::Display>(msg: T) -> Self {
-        Self::msg(msg.to_string())
+        Self::msg(sanitize_message(&msg.to_string()))
     }
+
+    /// `invalid type: string "SUPERSECRET", expected u32` — serde's default
+    /// renders the **value**. Report the shape only.
+    fn invalid_type(unexp: de::Unexpected<'_>, exp: &dyn de::Expected) -> Self {
+        Self::msg(format!(
+            "invalid type: {}, expected {exp}",
+            unexpected_shape(&unexp)
+        ))
+    }
+
+    /// Same reasoning as [`Self::invalid_type`]: the value is the secret-bearing
+    /// half of the message.
+    fn invalid_value(unexp: de::Unexpected<'_>, exp: &dyn de::Expected) -> Self {
+        Self::msg(format!(
+            "invalid value: {}, expected {exp}",
+            unexpected_shape(&unexp)
+        ))
+    }
+
+    /// serde renders the rejected variant name, which is request text. The
+    /// `expected` list is compile-time and safe to keep.
+    fn unknown_variant(variant: &str, expected: &'static [&'static str]) -> Self {
+        let _ = variant;
+        Self::msg(format!(
+            "unknown variant, expected one of {}",
+            quoted_list(expected)
+        ))
+    }
+
+    /// `#[serde(deny_unknown_fields)]` feeds the submitted key here, which is
+    /// both attacker-chosen and unbounded.
+    fn unknown_field(field: &str, expected: &'static [&'static str]) -> Self {
+        let _ = field;
+        Self::msg(format!(
+            "unknown field, expected one of {}",
+            quoted_list(expected)
+        ))
+    }
+
+    // `missing_field` and `duplicate_field` take a `&'static str` that can only
+    // come from the target struct, so their defaults are safe as-is.
+}
+
+/// Name a [`de::Unexpected`]'s shape without reproducing its value.
+const fn unexpected_shape(unexp: &de::Unexpected<'_>) -> &'static str {
+    match unexp {
+        de::Unexpected::Bool(_) => "a boolean",
+        de::Unexpected::Unsigned(_) | de::Unexpected::Signed(_) => "an integer",
+        de::Unexpected::Float(_) => "a float",
+        de::Unexpected::Char(_) => "a character",
+        de::Unexpected::Str(_) => "a string",
+        de::Unexpected::Bytes(_) => "a byte string",
+        de::Unexpected::Unit => "a unit value",
+        de::Unexpected::Option => "an optional value",
+        de::Unexpected::NewtypeStruct => "a newtype struct",
+        de::Unexpected::Seq => "a sequence",
+        de::Unexpected::Map => "an object",
+        de::Unexpected::Enum => "an enum",
+        de::Unexpected::UnitVariant => "a unit variant",
+        de::Unexpected::NewtypeVariant => "a newtype variant",
+        de::Unexpected::TupleVariant => "a tuple variant",
+        de::Unexpected::StructVariant => "a struct variant",
+        // `Other` carries a borrowed description that may be built from request
+        // text, so it gets the same treatment as everything else here.
+        de::Unexpected::Other(_) => "a value",
+    }
+}
+
+/// Render a compile-time `expected` list for an error message.
+fn quoted_list(expected: &'static [&'static str]) -> String {
+    if expected.is_empty() {
+        return "no variants".to_owned();
+    }
+    expected
+        .iter()
+        .map(|name| format!("`{name}`"))
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+/// Bound and clean a message serde built for us.
+///
+/// Only reachable through [`de::Error::custom`], i.e. a `deserialize_with`
+/// helper's own text. The shaped constructors above already keep request text
+/// out of every message serde's derive generates.
+fn sanitize_message(raw: &str) -> String {
+    const MAX: usize = 160;
+    let mut out: String = raw
+        .chars()
+        .take(MAX)
+        .map(|c| if c.is_control() { '.' } else { c })
+        .collect();
+    if raw.chars().nth(MAX).is_some() {
+        out.push('…');
+    }
+    out
 }
 
 /// Bound and clean attacker-supplied key text before it reaches an error
@@ -336,6 +436,12 @@ fn insert(root: &mut BTreeMap<String, Node>, base: &str, segments: &[Segment<'_>
         let next = segments.get(position.saturating_add(1));
         match segment {
             Segment::Key(name) => {
+                // A container that has so far only seen positions is not
+                // necessarily a sequence: `?filter[0]=zero&filter[name]=value`
+                // is a perfectly good dynamic object, and which it is only
+                // becomes knowable when a named key arrives. Promote rather
+                // than declare a conflict.
+                promote_to_map(node);
                 let Node::Map(entries) = node else {
                     return poison(node, conflict(base, segments, position, "an object"));
                 };
@@ -343,31 +449,64 @@ fn insert(root: &mut BTreeMap<String, Node>, base: &str, segments: &[Segment<'_>
                     .entry((*name).to_owned())
                     .or_insert_with(|| empty_for(next));
             }
-            Segment::Index(index) => {
-                let Node::Seq(entries) = node else {
-                    return poison(node, conflict(base, segments, position, "a sequence"));
-                };
-                node = entries.entry(*index).or_insert_with(|| empty_for(next));
-            }
-            Segment::Append => {
-                let Node::Seq(entries) = node else {
-                    return poison(node, conflict(base, segments, position, "a sequence"));
-                };
-                // `k[]` appends after the highest position seen so far, so
-                // repeated appends stay in submission order even when mixed
-                // with explicit indices.
-                let index = entries
-                    .keys()
-                    .next_back()
-                    .map_or(0, |last| last.saturating_add(1));
-                node = entries.entry(index).or_insert_with(|| empty_for(next));
-            }
+            // A position addressed on an already-promoted map keeps its decimal
+            // key, so the two orderings of the same query agree.
+            Segment::Index(index) => match node {
+                Node::Seq(entries) => {
+                    node = entries.entry(*index).or_insert_with(|| empty_for(next));
+                }
+                Node::Map(entries) => {
+                    node = entries
+                        .entry(index.to_string())
+                        .or_insert_with(|| empty_for(next));
+                }
+                other => {
+                    return poison(other, conflict(base, segments, position, "a sequence"));
+                }
+            },
+            // `k[]` appends after the highest position seen so far, so repeated
+            // appends stay in submission order even when mixed with explicit
+            // indices.
+            Segment::Append => match node {
+                Node::Seq(entries) => {
+                    let index = entries
+                        .keys()
+                        .next_back()
+                        .map_or(0, |last| last.saturating_add(1));
+                    node = entries.entry(index).or_insert_with(|| empty_for(next));
+                }
+                Node::Map(entries) => {
+                    let index = entries
+                        .keys()
+                        .filter_map(|key| key.parse::<usize>().ok())
+                        .max()
+                        .map_or(0, |last| last.saturating_add(1));
+                    node = entries
+                        .entry(index.to_string())
+                        .or_insert_with(|| empty_for(next));
+                }
+                other => {
+                    return poison(other, conflict(base, segments, position, "a sequence"));
+                }
+            },
         }
     }
 
     match node {
         Node::Scalar(values) => values.push(value),
         _ => poison(node, conflict(base, segments, segments.len(), "a value")),
+    }
+}
+
+/// Turn a positional node into a named one, rendering each index as its decimal
+/// key, so a container that mixes `k[0]=` and `k[name]=` stays usable.
+fn promote_to_map(node: &mut Node) {
+    if let Node::Seq(entries) = node {
+        let promoted = std::mem::take(entries)
+            .into_iter()
+            .map(|(index, child)| (index.to_string(), child))
+            .collect();
+        *node = Node::Map(promoted);
     }
 }
 
@@ -1204,6 +1343,66 @@ mod tests {
         assert!(
             from_query_str::<Args>("tags[99999999999999999999]=a&tags[99999999999999999999]=b")
                 .is_err()
+        );
+    }
+
+    #[test]
+    fn serde_generated_errors_never_echo_request_text() {
+        // Codex P1: serde builds its own messages for these cases and the
+        // defaults embed the submitted text. All three must stay redacted.
+        #[derive(Debug, Deserialize)]
+        #[serde(rename_all = "lowercase")]
+        enum Sort {
+            Asc,
+        }
+        #[derive(Debug, Deserialize)]
+        struct Sorted {
+            #[allow(dead_code)]
+            sort: Sort,
+        }
+        #[derive(Debug, Deserialize)]
+        #[serde(deny_unknown_fields)]
+        struct Strict {
+            #[allow(dead_code)]
+            q: String,
+        }
+        // `invalid type` renders the value in serde's default message.
+        #[derive(Debug, Deserialize)]
+        struct Nested {
+            #[allow(dead_code)]
+            filter: std::collections::HashMap<String, String>,
+        }
+
+        let err = from_query_str::<Sorted>("sort=SUPERSECRET").expect_err("unknown variant");
+        assert!(!err.to_string().contains("SUPERSECRET"), "{err}");
+        let err = from_query_str::<Strict>("q=x&SUPERSECRET=1").expect_err("unknown field");
+        assert!(!err.to_string().contains("SUPERSECRET"), "{err}");
+        let err =
+            from_query_str::<Nested>("filter[a]=x&filter=SUPERSECRET").expect_err("shape conflict");
+        assert!(!err.to_string().contains("SUPERSECRET"), "{err}");
+    }
+
+    #[test]
+    fn a_container_may_mix_numeric_and_named_keys() {
+        // Codex P2: `filter[0]=zero&filter[name]=value` is a valid dynamic
+        // object; classifying `0` as a position must not poison it.
+        #[derive(Debug, Deserialize)]
+        struct Dynamic {
+            filter: std::collections::HashMap<String, String>,
+        }
+        let out: Dynamic = from_query_str("filter[0]=zero&filter[name]=value").expect("decodes");
+        assert_eq!(out.filter.get("0").map(String::as_str), Some("zero"));
+        assert_eq!(out.filter.get("name").map(String::as_str), Some("value"));
+
+        // The reverse submission order agrees.
+        let out: Dynamic = from_query_str("filter[name]=value&filter[0]=zero").expect("decodes");
+        assert_eq!(out.filter.get("0").map(String::as_str), Some("zero"));
+        assert_eq!(out.filter.get("name").map(String::as_str), Some("value"));
+
+        // Promotion does not disturb a purely positional container.
+        assert_eq!(
+            args("tags[0]=a&tags[1]=b").tags.unwrap(),
+            vec!["a".to_owned(), "b".to_owned()]
         );
     }
 

--- a/autumn/src/query_string.rs
+++ b/autumn/src/query_string.rs
@@ -17,9 +17,13 @@
 //! # Wire format
 //!
 //! The decoder is a **superset** of the flat form: a query string with unique
-//! scalar keys decodes exactly as it did before. On top of that it accepts the
-//! bracketed dialect the framework already speaks in
-//! [`nested_form`](crate::nested_form):
+//! scalar keys decodes exactly as it did before. On top of that it accepts a
+//! bracketed dialect whose `items[0][sku]` shape matches the repeated-row
+//! encoding [`nested_form`](crate::nested_form) renders — generalized here to
+//! arbitrary objects, sequences and depths. Note this applies to the **query
+//! string only**: [`Form<T>`](crate::form) and
+//! [`NestedChangesetForm`](crate::nested_form::NestedChangesetForm) still decode
+//! request *bodies* through `serde_urlencoded` and its own nested-row parser.
 //!
 //! ```text
 //! q=foo                       // scalar
@@ -42,17 +46,31 @@
 //!   `u32` and `flag=true` fills a `bool`. An `Option<T>` field that is
 //!   *present but empty* (`?page=`) still visits `Some`, exactly as
 //!   `serde_urlencoded` does — only an **absent** key is `None`.
-//! * **First occurrence wins for scalars.** `?q=a&q=b` fills a `String` field
-//!   with `"a"`. Deserializing the same key into a sequence field yields both.
-//! * **Shape conflicts are errors.** `?filter=flat&filter[status]=open` uses
-//!   one key as both a scalar and a container; that is rejected rather than
-//!   resolved by last-write-wins.
+//! * **A duplicated key is an error in a single-valued position.** `?q=a&q=b`
+//!   against a `String` field is rejected — `serde_urlencoded` + serde's derive
+//!   rejected it too (`duplicate field`), and quietly picking one of two values
+//!   is how parameter-pollution bugs are built. A **sequence** field takes every
+//!   occurrence; that is the whole point of the repeated-key form.
+//! * **Errors never echo a value.** A decode failure names the field path and
+//!   the expected type, never the submitted text — the message is returned in
+//!   the 400 body and recorded by error reporters, and a query parameter can
+//!   hold a secret.
+//! * **Shape conflicts poison one key, not the request.**
+//!   `?filter=flat&filter[status]=open` uses one name as both a scalar and a
+//!   container. That key is rejected *if the target claims it*; a target that
+//!   ignores it (ad-tracking junk, a crawler's garbage parameter) still decodes,
+//!   exactly as it did when the key was merely unrecognised.
 //! * **Malformed brackets stay literal.** A key the bracket grammar cannot
 //!   parse (`weird[unclosed`) is used verbatim as a flat key, so a stray
 //!   bracket never turns into a parse failure.
 //! * **Nesting is depth-capped** at [`MAX_DEPTH`] and indices key an ordered
 //!   map rather than a `Vec`, so neither deep nesting nor a huge index
 //!   (`tags[4000000000]=x`) lets a request drive unbounded allocation.
+//!
+//! * **Map iteration is key-ordered.** The tree keys each level with a
+//!   `BTreeMap`, so a `Query<Vec<(String, String)>>` target sees pairs sorted
+//!   by key rather than in submission order (occurrences of one key keep their
+//!   order). Deterministic either way, but not the wire order.
 //!
 //! # Compatibility note
 //!
@@ -144,6 +162,27 @@ impl de::Error for QueryError {
     }
 }
 
+/// Bound and clean attacker-supplied key text before it reaches an error
+/// message.
+///
+/// A decode failure is returned in the 400 Problem Details body and recorded by
+/// every registered error reporter, so raw request text must never flow into it
+/// unbounded: a long key would bloat the response and an embedded control
+/// character could forge a log line. Values are never included at all — a
+/// mistyped secret (`?token=…` against a typed field) must not be echoed back.
+fn sanitize_key(raw: &str) -> String {
+    const MAX: usize = 48;
+    let mut out: String = raw
+        .chars()
+        .take(MAX)
+        .map(|c| if c.is_control() { '.' } else { c })
+        .collect();
+    if raw.chars().nth(MAX).is_some() {
+        out.push('…');
+    }
+    out
+}
+
 // ──────────────────────────────────────────────────────────────────
 // Key parsing
 // ──────────────────────────────────────────────────────────────────
@@ -216,6 +255,15 @@ enum Node {
     Seq(BTreeMap<usize, Self>),
     /// Named children (`k[name]`).
     Map(BTreeMap<String, Self>),
+    /// A key the grammar could not resolve — one name used as two shapes
+    /// (`?filter=flat&filter[status]=open`), or nesting past [`MAX_DEPTH`].
+    ///
+    /// Poisoning the node instead of failing the whole parse keeps decoding a
+    /// **superset** of the old flat form: a target that never asks for this key
+    /// (ad-tracking junk, a crawler's garbage parameter) still decodes, exactly
+    /// as it did when the key was simply unrecognised. Only a target that
+    /// actually claims the key sees the error.
+    Conflict(String),
 }
 
 impl Node {
@@ -225,6 +273,7 @@ impl Node {
             Self::Scalar(_) => "a value",
             Self::Seq(_) => "a sequence",
             Self::Map(_) => "an object",
+            Self::Conflict(_) => "an unresolvable key",
         }
     }
 }
@@ -254,20 +303,26 @@ fn key_path(base: &str, segments: &[Segment<'_>], upto: usize) -> String {
 }
 
 /// Insert one decoded `key=value` pair into the tree rooted at `root`.
-fn insert(
-    root: &mut BTreeMap<String, Node>,
-    base: &str,
-    segments: &[Segment<'_>],
-    value: String,
-) -> Result<(), QueryError> {
+///
+/// Infallible by design: a key the grammar cannot resolve poisons **that key's
+/// node** ([`Node::Conflict`]) rather than failing the request, so an
+/// unrecognised parameter stays ignorable and only a claimed one errors.
+fn insert(root: &mut BTreeMap<String, Node>, base: &str, segments: &[Segment<'_>], value: String) {
     // `segments.len()` counts the bracketed steps; the base key is the first
     // level, so the total depth is `len + 1` — expressed as `>=` to stay clear
     // of the request-path gate's arithmetic ban.
     if segments.len() >= MAX_DEPTH {
-        return Err(QueryError::msg(format!(
-            "query key nesting exceeds the maximum depth of {MAX_DEPTH}"
-        ))
-        .with_segment(base));
+        let node = root
+            .entry(base.to_owned())
+            .or_insert_with(|| Node::Scalar(Vec::new()));
+        poison(
+            node,
+            format!(
+                "query key `{}` nests deeper than the maximum of {MAX_DEPTH}",
+                sanitize_key(base)
+            ),
+        );
+        return;
     }
 
     // Descend to the node this key addresses, creating containers on the way.
@@ -282,7 +337,7 @@ fn insert(
         match segment {
             Segment::Key(name) => {
                 let Node::Map(entries) = node else {
-                    return Err(conflict(base, segments, position, node, "an object"));
+                    return poison(node, conflict(base, segments, position, "an object"));
                 };
                 node = entries
                     .entry((*name).to_owned())
@@ -290,13 +345,13 @@ fn insert(
             }
             Segment::Index(index) => {
                 let Node::Seq(entries) = node else {
-                    return Err(conflict(base, segments, position, node, "a sequence"));
+                    return poison(node, conflict(base, segments, position, "a sequence"));
                 };
                 node = entries.entry(*index).or_insert_with(|| empty_for(next));
             }
             Segment::Append => {
                 let Node::Seq(entries) = node else {
-                    return Err(conflict(base, segments, position, node, "a sequence"));
+                    return poison(node, conflict(base, segments, position, "a sequence"));
                 };
                 // `k[]` appends after the highest position seen so far, so
                 // repeated appends stay in submission order even when mixed
@@ -311,11 +366,16 @@ fn insert(
     }
 
     match node {
-        Node::Scalar(values) => {
-            values.push(value);
-            Ok(())
-        }
-        other => Err(conflict(base, segments, segments.len(), other, "a value")),
+        Node::Scalar(values) => values.push(value),
+        _ => poison(node, conflict(base, segments, segments.len(), "a value")),
+    }
+}
+
+/// Mark a node unresolvable, keeping the FIRST diagnosis when a key collides
+/// more than once.
+fn poison(node: &mut Node, message: String) {
+    if !matches!(node, Node::Conflict(_)) {
+        *node = Node::Conflict(message);
     }
 }
 
@@ -328,33 +388,26 @@ const fn empty_for(next: Option<&Segment<'_>>) -> Node {
     }
 }
 
-fn conflict(
-    base: &str,
-    segments: &[Segment<'_>],
-    upto: usize,
-    found: &Node,
-    wanted: &str,
-) -> QueryError {
-    QueryError::msg(format!(
-        "query key `{}` is used as both {} and {wanted}",
-        key_path(base, segments, upto),
-        found.kind()
-    ))
+fn conflict(base: &str, segments: &[Segment<'_>], upto: usize, wanted: &str) -> String {
+    format!(
+        "query key `{}` is used as both a container and {wanted}",
+        sanitize_key(&key_path(base, segments, upto))
+    )
 }
 
 /// Build the query tree from an already-percent-decoded pair sequence.
 fn build_tree<'a>(
     pairs: impl Iterator<Item = (std::borrow::Cow<'a, str>, std::borrow::Cow<'a, str>)>,
-) -> Result<BTreeMap<String, Node>, QueryError> {
+) -> BTreeMap<String, Node> {
     let mut root = BTreeMap::new();
     for (key, value) in pairs {
         match parse_key(&key) {
-            Some((base, segments)) => insert(&mut root, base, &segments, value.into_owned())?,
+            Some((base, segments)) => insert(&mut root, base, &segments, value.into_owned()),
             // Not a well-formed bracket key: treat it as a flat literal name.
-            None => insert(&mut root, &key, &[], value.into_owned())?,
+            None => insert(&mut root, &key, &[], value.into_owned()),
         }
     }
-    Ok(root)
+    root
 }
 
 /// Decode a raw (still percent-encoded) query string into `T`.
@@ -369,7 +422,7 @@ fn build_tree<'a>(
 /// both a scalar and a container), when nesting exceeds [`MAX_DEPTH`], or when
 /// a value cannot be coerced into the target field's type.
 pub fn from_query_str<T: DeserializeOwned>(query: &str) -> Result<T, QueryError> {
-    let root = build_tree(url::form_urlencoded::parse(query.as_bytes()))?;
+    let root = build_tree(url::form_urlencoded::parse(query.as_bytes()));
     T::deserialize(NodeDeserializer {
         node: &Node::Map(root),
     })
@@ -389,12 +442,12 @@ macro_rules! parse_scalar {
     ($($method:ident => $visit:ident : $ty:ty),* $(,)?) => {
         $(
             fn $method<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, QueryError> {
+                // The offending text is deliberately NOT echoed: the error
+                // reaches the 400 body and every error reporter, and a query
+                // parameter can hold a secret. The field path already names
+                // which parameter failed.
                 let parsed: $ty = self.value.parse().map_err(|_| {
-                    QueryError::msg(format!(
-                        "invalid value `{}` for {}",
-                        self.value,
-                        stringify!($ty)
-                    ))
+                    QueryError::msg(concat!("invalid ", stringify!($ty), " value"))
                 })?;
                 visitor.$visit(parsed)
             }
@@ -469,10 +522,7 @@ impl<'de> de::Deserializer<'de> for ValueDeserializer<'_> {
     }
 
     fn deserialize_seq<V: Visitor<'de>>(self, _visitor: V) -> Result<V::Value, QueryError> {
-        Err(QueryError::msg(format!(
-            "expected a sequence, found the value `{}`",
-            self.value
-        )))
+        Err(QueryError::msg("expected a sequence, found a single value"))
     }
 
     fn deserialize_tuple<V: Visitor<'de>>(
@@ -493,10 +543,7 @@ impl<'de> de::Deserializer<'de> for ValueDeserializer<'_> {
     }
 
     fn deserialize_map<V: Visitor<'de>>(self, _visitor: V) -> Result<V::Value, QueryError> {
-        Err(QueryError::msg(format!(
-            "expected an object, found the value `{}`",
-            self.value
-        )))
+        Err(QueryError::msg("expected an object, found a single value"))
     }
 
     fn deserialize_struct<V: Visitor<'de>>(
@@ -588,10 +635,32 @@ struct NodeDeserializer<'a> {
 }
 
 impl<'a> NodeDeserializer<'a> {
-    /// The leaf view of a scalar node: its first submitted value (first
-    /// occurrence wins), or an error naming the container shape found instead.
-    fn as_value(&self, wanted: &str) -> Result<ValueDeserializer<'a>, QueryError> {
+    /// Refuse a node whose key the grammar could not resolve.
+    ///
+    /// Checked by every entry point EXCEPT `deserialize_ignored_any`, so a
+    /// conflicting key a target never claims stays ignorable.
+    fn check(&self) -> Result<(), QueryError> {
         match self.node {
+            Node::Conflict(message) => Err(QueryError::msg(message.clone())),
+            _ => Ok(()),
+        }
+    }
+
+    /// The leaf view of a scalar node.
+    ///
+    /// A key submitted more than once is an **error** in a single-valued
+    /// position, not a silent first- or last-wins pick: `serde_urlencoded` +
+    /// serde's derive rejected `?sig=a&sig=b` with `duplicate field`, and
+    /// resolving it quietly here would hand a security-relevant handler one of
+    /// two values while a proxy or log pipeline recorded the other. Sequence
+    /// fields still take every occurrence — that is [`Self::deserialize_seq`].
+    fn as_value(&self, wanted: &str) -> Result<ValueDeserializer<'a>, QueryError> {
+        self.check()?;
+        match self.node {
+            Node::Scalar(values) if values.len() > 1 => Err(QueryError::msg(
+                "duplicate query parameter: more than one value was submitted for a \
+                 single-valued field",
+            )),
             Node::Scalar(values) => Ok(ValueDeserializer {
                 // A scalar node is only ever created by pushing a value, so it
                 // is never empty; the fallback keeps this total regardless.
@@ -629,12 +698,13 @@ impl<'de> de::Deserializer<'de> for NodeDeserializer<'_> {
     /// `serde_json::Value`: a multi-valued key becomes a sequence, a single
     /// value stays a string.
     fn deserialize_any<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, QueryError> {
+        self.check()?;
         match self.node {
             Node::Scalar(values) if values.len() == 1 => {
                 visitor.visit_str(values.first().map_or("", String::as_str))
             }
             Node::Scalar(_) | Node::Seq(_) => self.deserialize_seq(visitor),
-            Node::Map(_) => self.deserialize_map(visitor),
+            Node::Map(_) | Node::Conflict(_) => self.deserialize_map(visitor),
         }
     }
 
@@ -673,6 +743,7 @@ impl<'de> de::Deserializer<'de> for NodeDeserializer<'_> {
     }
 
     fn deserialize_seq<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, QueryError> {
+        self.check()?;
         match self.node {
             // Repeated keys: every submitted value is one element.
             Node::Scalar(values) => visitor.visit_seq(ValueSeq {
@@ -687,6 +758,8 @@ impl<'de> de::Deserializer<'de> for NodeDeserializer<'_> {
             Node::Map(entries) => visitor.visit_seq(PairSeq {
                 pairs: flatten_pairs(entries).into_iter(),
             }),
+            // Rejected by `check` above.
+            Node::Conflict(message) => Err(QueryError::msg(message.clone())),
         }
     }
 
@@ -708,8 +781,19 @@ impl<'de> de::Deserializer<'de> for NodeDeserializer<'_> {
     }
 
     fn deserialize_map<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, QueryError> {
+        self.check()?;
         match self.node {
             Node::Map(entries) => visitor.visit_map(NodeMap {
+                entries: entries.iter(),
+                value: None,
+                key: String::new(),
+            }),
+            // An all-digit key (`counts[2024]=5`) parses as a position, because
+            // the tree is built before the target type is known. Serving a
+            // positional node as a map — index rendered as its decimal key —
+            // lets such a field still land in a `HashMap`/struct target instead
+            // of failing on a shape the caller never chose.
+            Node::Seq(entries) => visitor.visit_map(IndexMap {
                 entries: entries.iter(),
                 value: None,
                 key: String::new(),
@@ -738,6 +822,7 @@ impl<'de> de::Deserializer<'de> for NodeDeserializer<'_> {
         variants: &'static [&'static str],
         visitor: V,
     ) -> Result<V::Value, QueryError> {
+        self.check()?;
         match self.node {
             Node::Scalar(_) => self
                 .as_value("a value")?
@@ -769,7 +854,7 @@ enum PairValue<'a> {
 
 /// Flatten a map into `(key, value)` pairs, expanding a repeated key into one
 /// pair per submitted value so the pair view matches the wire.
-fn flatten_pairs<'a>(entries: &'a BTreeMap<String, Node>) -> Vec<(&'a str, PairValue<'a>)> {
+fn flatten_pairs(entries: &BTreeMap<String, Node>) -> Vec<(&str, PairValue<'_>)> {
     let mut out = Vec::new();
     for (key, node) in entries {
         match node {
@@ -931,7 +1016,47 @@ impl<'de> MapAccess<'de> for NodeMap<'_> {
         // Tag the failure with the field it came from, so a caller sees
         // `filter.limit: invalid value …` rather than a bare parse error.
         seed.deserialize(NodeDeserializer { node })
-            .map_err(|err| err.with_segment(self.key.clone()))
+            .map_err(|err| err.with_segment(sanitize_key(&self.key)))
+    }
+
+    fn size_hint(&self) -> Option<usize> {
+        Some(self.entries.len())
+    }
+}
+
+/// `MapAccess` over a positional node, rendering each index as its decimal key.
+struct IndexMap<'a> {
+    entries: std::collections::btree_map::Iter<'a, usize, Node>,
+    value: Option<&'a Node>,
+    key: String,
+}
+
+impl<'de> MapAccess<'de> for IndexMap<'_> {
+    type Error = QueryError;
+
+    fn next_key_seed<K: DeserializeSeed<'de>>(
+        &mut self,
+        seed: K,
+    ) -> Result<Option<K::Value>, QueryError> {
+        let Some((index, node)) = self.entries.next() else {
+            return Ok(None);
+        };
+        self.value = Some(node);
+        self.key = index.to_string();
+        seed.deserialize(ValueDeserializer { value: &self.key })
+            .map(Some)
+    }
+
+    fn next_value_seed<V: DeserializeSeed<'de>>(
+        &mut self,
+        seed: V,
+    ) -> Result<V::Value, QueryError> {
+        let node = self.value.take().ok_or_else(|| {
+            QueryError::msg("internal error: query map value requested before its key")
+        })?;
+        let key = self.key.clone();
+        seed.deserialize(NodeDeserializer { node })
+            .map_err(|err| err.with_segment(key))
     }
 
     fn size_hint(&self) -> Option<usize> {
@@ -1055,12 +1180,76 @@ mod tests {
     }
 
     #[test]
-    fn repeated_keys_fill_a_sequence_and_first_wins_for_a_scalar() {
+    fn repeated_keys_fill_a_sequence_but_a_duplicated_scalar_is_rejected() {
         assert_eq!(
             args("tags=a&tags=b").tags.unwrap(),
             vec!["a".to_owned(), "b".to_owned()]
         );
-        assert_eq!(args("q=first&q=second").q.as_deref(), Some("first"));
+        // Fail closed: picking one of two values for a single-valued field is
+        // how parameter-pollution bugs are built, and `serde_urlencoded` +
+        // serde's derive rejected it too.
+        let err = from_query_str::<Args>("q=first&q=second").expect_err("duplicate scalar");
+        assert!(
+            err.to_string().contains("duplicate query parameter"),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn index_aliasing_is_rejected_rather_than_silently_dropping_a_value() {
+        // `tags[0]` and `tags[00]` address one position, as do two indices that
+        // both saturate. Both land two values in one slot — an error, not a
+        // silent loss of the second.
+        assert!(from_query_str::<Args>("tags[0]=a&tags[00]=b").is_err());
+        assert!(
+            from_query_str::<Args>("tags[99999999999999999999]=a&tags[99999999999999999999]=b")
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn errors_never_echo_the_submitted_value() {
+        // The message reaches the 400 body and every error reporter, so a
+        // mistyped secret must not come back out.
+        let err = from_query_str::<Args>("page=SUPERSECRET").expect_err("coercion failure");
+        let rendered = err.to_string();
+        assert!(
+            !rendered.contains("SUPERSECRET"),
+            "value leaked: {rendered}"
+        );
+        assert!(rendered.contains("page"), "field path kept: {rendered}");
+    }
+
+    #[test]
+    fn error_text_bounds_and_cleans_attacker_supplied_key_text() {
+        let long = "k".repeat(500);
+        let rendered = sanitize_key(&long);
+        assert!(
+            rendered.chars().count() <= 49,
+            "bounded: {}",
+            rendered.len()
+        );
+        assert_eq!(sanitize_key("a\nb"), "a.b");
+    }
+
+    #[test]
+    fn a_conflicting_key_the_target_ignores_is_still_ignored() {
+        // Pre-existing behaviour for an unrecognised parameter: it does not
+        // fail the request. Junk like `?utm=1&utm[src]=x` must stay ignorable.
+        let out = args("q=ok&utm=1&utm[src]=x");
+        assert_eq!(out.q.as_deref(), Some("ok"));
+        // Same for a key that nests past the cap but is never claimed.
+        let deep = format!("q=ok&junk{}=1", "[x]".repeat(MAX_DEPTH));
+        assert_eq!(args(&deep).q.as_deref(), Some("ok"));
+    }
+
+    #[test]
+    fn an_all_digit_object_key_still_lands_in_a_map_target() {
+        // `counts[2024]=5` parses as a position (the tree is built before the
+        // target type is known), so a positional node must still serve a map.
+        let out: std::collections::HashMap<String, std::collections::HashMap<String, u32>> =
+            from_query_str("counts[2024]=5").expect("decodes");
+        assert_eq!(out["counts"]["2024"], 5);
     }
 
     #[test]
@@ -1173,12 +1362,13 @@ mod tests {
     }
 
     #[test]
-    fn nesting_deeper_than_the_cap_is_rejected() {
-        let deep = format!("a{}=1", "[x]".repeat(MAX_DEPTH));
+    fn nesting_deeper_than_the_cap_is_rejected_for_a_claimed_key() {
+        let deep = format!("filter{}=1", "[x]".repeat(MAX_DEPTH));
         let err = from_query_str::<Args>(&deep).expect_err("depth-capped");
-        assert!(err.to_string().contains("depth"), "{err}");
-        // One level under the cap is still accepted.
-        let ok = format!("a{}=1", "[x]".repeat(MAX_DEPTH - 2));
+        assert!(err.to_string().contains("deeper"), "{err}");
+        // One level under the cap parses; `filter` then fails on its own shape,
+        // not on the depth guard.
+        let ok = format!("q=x&junk{}=1", "[x]".repeat(MAX_DEPTH - 2));
         assert!(from_query_str::<Args>(&ok).is_ok());
     }
 
@@ -1187,6 +1377,13 @@ mod tests {
         let err = from_query_str::<Args>("filter[status]=open&filter[limit]=nope")
             .expect_err("coercion failure");
         assert!(err.to_string().starts_with("filter.limit:"), "{err}");
+    }
+
+    #[test]
+    fn shape_conflicts_surface_only_when_the_target_claims_the_key() {
+        let err = from_query_str::<Args>("filter=flat&filter[status]=open")
+            .expect_err("claimed conflicting key");
+        assert!(err.to_string().contains("used as both"), "{err}");
     }
 
     #[test]

--- a/autumn/src/query_string.rs
+++ b/autumn/src/query_string.rs
@@ -293,7 +293,12 @@ enum Segment<'a> {
     /// `k[]` — append at the next free position.
     Append,
     /// `k[3]` — an explicit position.
-    Index(usize),
+    ///
+    /// Carries both the parsed ordering value and the **raw** spelling: a map
+    /// target must receive the key the caller actually sent (`00` stays `00`,
+    /// and an index past `usize::MAX` is not rewritten to the saturated one),
+    /// while a sequence target still orders by `position`.
+    Index { position: usize, raw: &'a str },
     /// `k[name]` — a named entry.
     Key(&'a str),
 }
@@ -331,7 +336,12 @@ fn classify_segment(inner: &str) -> Segment<'_> {
         return Segment::Append;
     }
     if inner.bytes().all(|b| b.is_ascii_digit()) {
-        return Segment::Index(inner.parse().unwrap_or(usize::MAX));
+        return Segment::Index {
+            // Saturation only affects ORDERING; `raw` keeps the submitted text,
+            // so nothing about the key itself is platform-dependent.
+            position: inner.parse().unwrap_or(usize::MAX),
+            raw: inner,
+        };
     }
     Segment::Key(inner)
 }
@@ -349,10 +359,10 @@ enum Node {
     /// same node serve a scalar field (first wins) and a sequence field (all
     /// values) without the parser needing to know the target type.
     Scalar(Vec<String>),
-    /// Positional children (`k[]`, `k[3]`), ordered by index. A `BTreeMap`
+    /// Positional children (`k[]`, `k[3]`), ordered by [`SeqKey`]. A `BTreeMap`
     /// keeps sparse and out-of-order indices cheap: `tags[4000000000]` costs
     /// one entry, not four billion.
-    Seq(BTreeMap<usize, Self>),
+    Seq(BTreeMap<SeqKey, Self>),
     /// Named children (`k[name]`).
     Map(BTreeMap<String, Self>),
     /// A key the grammar could not resolve — one name used as two shapes
@@ -378,6 +388,30 @@ impl Node {
     }
 }
 
+/// A positional child's key: its ordering value plus the spelling that produced
+/// it.
+///
+/// Ordering is by `position` first, so a sequence target sees ascending indices
+/// regardless of how they were written. `raw` breaks ties and is what a **map**
+/// target receives, so `counts[0]` and `counts[00]` stay two distinct keys
+/// rather than colliding on one — and neither is rewritten on the way through.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+struct SeqKey {
+    position: usize,
+    raw: String,
+}
+
+impl SeqKey {
+    /// A key for a position the caller did not spell out (the `k[]` append
+    /// form), rendered canonically.
+    fn synthesized(position: usize) -> Self {
+        Self {
+            position,
+            raw: position.to_string(),
+        }
+    }
+}
+
 /// Render the key path up to (and including) `upto` segments, for error text.
 ///
 /// Built only when a conflict is being reported — the success path never
@@ -391,9 +425,9 @@ fn key_path(base: &str, segments: &[Segment<'_>], upto: usize) -> String {
                 out.push_str(name);
                 out.push(']');
             }
-            Segment::Index(index) => {
+            Segment::Index { raw, .. } => {
                 out.push('[');
-                out.push_str(&index.to_string());
+                out.push_str(raw);
                 out.push(']');
             }
             Segment::Append => out.push_str("[]"),
@@ -451,13 +485,21 @@ fn insert(root: &mut BTreeMap<String, Node>, base: &str, segments: &[Segment<'_>
             }
             // A position addressed on an already-promoted map keeps its decimal
             // key, so the two orderings of the same query agree.
-            Segment::Index(index) => match node {
+            Segment::Index {
+                position: index,
+                raw,
+            } => match node {
                 Node::Seq(entries) => {
-                    node = entries.entry(*index).or_insert_with(|| empty_for(next));
+                    node = entries
+                        .entry(SeqKey {
+                            position: *index,
+                            raw: (*raw).to_owned(),
+                        })
+                        .or_insert_with(|| empty_for(next));
                 }
                 Node::Map(entries) => {
                     node = entries
-                        .entry(index.to_string())
+                        .entry((*raw).to_owned())
                         .or_insert_with(|| empty_for(next));
                 }
                 other => {
@@ -472,8 +514,10 @@ fn insert(root: &mut BTreeMap<String, Node>, base: &str, segments: &[Segment<'_>
                     let index = entries
                         .keys()
                         .next_back()
-                        .map_or(0, |last| last.saturating_add(1));
-                    node = entries.entry(index).or_insert_with(|| empty_for(next));
+                        .map_or(0, |last| last.position.saturating_add(1));
+                    node = entries
+                        .entry(SeqKey::synthesized(index))
+                        .or_insert_with(|| empty_for(next));
                 }
                 Node::Map(entries) => {
                     let index = entries
@@ -504,7 +548,7 @@ fn promote_to_map(node: &mut Node) {
     if let Node::Seq(entries) = node {
         let promoted = std::mem::take(entries)
             .into_iter()
-            .map(|(index, child)| (index.to_string(), child))
+            .map(|(key, child)| (key.raw, child))
             .collect();
         *node = Node::Map(promoted);
     }
@@ -523,7 +567,7 @@ const fn empty_for(next: Option<&Segment<'_>>) -> Node {
     match next {
         None => Node::Scalar(Vec::new()),
         Some(Segment::Key(_)) => Node::Map(BTreeMap::new()),
-        Some(Segment::Append | Segment::Index(_)) => Node::Seq(BTreeMap::new()),
+        Some(Segment::Append | Segment::Index { .. }) => Node::Seq(BTreeMap::new()),
     }
 }
 
@@ -1035,7 +1079,7 @@ impl<'de> SeqAccess<'de> for ValueSeq<'_> {
 }
 
 struct NodeSeq<'a> {
-    entries: std::collections::btree_map::Iter<'a, usize, Node>,
+    entries: std::collections::btree_map::Iter<'a, SeqKey, Node>,
 }
 
 impl<'de> SeqAccess<'de> for NodeSeq<'_> {
@@ -1045,12 +1089,14 @@ impl<'de> SeqAccess<'de> for NodeSeq<'_> {
         &mut self,
         seed: T,
     ) -> Result<Option<T::Value>, QueryError> {
-        let Some((index, node)) = self.entries.next() else {
+        let Some((key, node)) = self.entries.next() else {
             return Ok(None);
         };
         seed.deserialize(NodeDeserializer { node })
             .map(Some)
-            .map_err(|err| err.with_segment(index.to_string()))
+            // `raw` is the submitted spelling, so it gets the same bounding and
+            // control-character stripping every other request-derived segment does.
+            .map_err(|err| err.with_segment(sanitize_key(&key.raw)))
     }
 
     fn size_hint(&self) -> Option<usize> {
@@ -1173,7 +1219,7 @@ impl<'de> MapAccess<'de> for NodeMap<'_> {
 
 /// `MapAccess` over a positional node, rendering each index as its decimal key.
 struct IndexMap<'a> {
-    entries: std::collections::btree_map::Iter<'a, usize, Node>,
+    entries: std::collections::btree_map::Iter<'a, SeqKey, Node>,
     value: Option<&'a Node>,
     key: String,
 }
@@ -1185,11 +1231,13 @@ impl<'de> MapAccess<'de> for IndexMap<'_> {
         &mut self,
         seed: K,
     ) -> Result<Option<K::Value>, QueryError> {
-        let Some((index, node)) = self.entries.next() else {
+        let Some((key, node)) = self.entries.next() else {
             return Ok(None);
         };
         self.value = Some(node);
-        self.key = index.to_string();
+        // The submitted spelling, so `counts[00]` reaches a map target as
+        // `"00"` rather than as a re-rendered `"0"`.
+        self.key = key.raw.clone();
         seed.deserialize(ValueDeserializer { value: &self.key })
             .map(Some)
     }
@@ -1201,7 +1249,7 @@ impl<'de> MapAccess<'de> for IndexMap<'_> {
         let node = self.value.take().ok_or_else(|| {
             QueryError::msg("internal error: query map value requested before its key")
         })?;
-        let key = self.key.clone();
+        let key = sanitize_key(&self.key);
         seed.deserialize(NodeDeserializer { node })
             .map_err(|err| err.with_segment(key))
     }
@@ -1244,7 +1292,12 @@ struct NodeContent<'a> {
 impl<'de> VariantAccess<'de> for NodeContent<'_> {
     type Error = QueryError;
 
+    /// A unit variant carries no data, but the node selecting it is still
+    /// *claimed*: `?mode[asc][unexpected]=v` must not quietly select `Asc` and
+    /// discard the attached object, and a shape-conflicted node must not pass.
+    /// Same principle as the unit-field path — validate, then discard.
     fn unit_variant(self) -> Result<(), QueryError> {
+        NodeDeserializer { node: self.content }.as_value("a value")?;
         Ok(())
     }
 
@@ -1343,15 +1396,60 @@ mod tests {
     }
 
     #[test]
-    fn index_aliasing_is_rejected_rather_than_silently_dropping_a_value() {
-        // `tags[0]` and `tags[00]` address one position, as do two indices that
-        // both saturate. Both land two values in one slot — an error, not a
-        // silent loss of the second.
-        assert!(from_query_str::<Args>("tags[0]=a&tags[00]=b").is_err());
-        assert!(
-            from_query_str::<Args>("tags[99999999999999999999]=a&tags[99999999999999999999]=b")
-                .is_err()
+    fn distinct_index_spellings_stay_distinct() {
+        // Codex P2: `0` and `00` are different keys, so neither may overwrite
+        // the other. A sequence target orders them by position and keeps both;
+        // a map target receives each spelling unchanged.
+        #[derive(Debug, Deserialize)]
+        struct Counts {
+            counts: std::collections::HashMap<String, u32>,
+        }
+
+        assert_eq!(
+            args("tags[0]=a&tags[00]=b").tags.unwrap(),
+            vec!["a".to_owned(), "b".to_owned()]
         );
+
+        let out: Counts = from_query_str("counts[00]=5&counts[0]=6").expect("decodes");
+        assert_eq!(
+            out.counts.get("00"),
+            Some(&5),
+            "spelling preserved: {out:?}"
+        );
+        assert_eq!(out.counts.get("0"), Some(&6));
+
+        // An index past `usize::MAX` is not rewritten to the saturated value.
+        let out: Counts = from_query_str("counts[99999999999999999999]=7").expect("decodes");
+        assert_eq!(out.counts.get("99999999999999999999"), Some(&7));
+
+        // The SAME spelling twice is still a genuine duplicate.
+        assert!(from_query_str::<Args>("tags[0]=a&tags[0]=b").is_err());
+    }
+
+    #[test]
+    fn a_unit_variant_still_validates_the_node_it_claims() {
+        // Codex P2: selecting a unit variant must not silently discard an
+        // attached payload or accept a poisoned node.
+        #[derive(Debug, Deserialize, PartialEq)]
+        #[serde(rename_all = "lowercase")]
+        enum Mode {
+            Asc,
+        }
+        #[derive(Debug, Deserialize)]
+        struct Sorted {
+            mode: Mode,
+        }
+        assert_eq!(
+            from_query_str::<Sorted>("mode[asc]=1")
+                .expect("decodes")
+                .mode,
+            Mode::Asc
+        );
+        assert!(
+            from_query_str::<Sorted>("mode[asc][unexpected]=value").is_err(),
+            "an attached payload must not be silently discarded"
+        );
+        assert!(from_query_str::<Sorted>("mode=asc").is_ok());
     }
 
     #[test]
@@ -1596,7 +1694,16 @@ mod tests {
     fn bracket_keys_parse_into_segments() {
         assert_eq!(
             parse_key("items[0][sku]"),
-            Some(("items", vec![Segment::Index(0), Segment::Key("sku")]))
+            Some((
+                "items",
+                vec![
+                    Segment::Index {
+                        position: 0,
+                        raw: "0"
+                    },
+                    Segment::Key("sku")
+                ]
+            ))
         );
         assert_eq!(parse_key("tags[]"), Some(("tags", vec![Segment::Append])));
     }

--- a/autumn/src/query_string.rs
+++ b/autumn/src/query_string.rs
@@ -158,11 +158,20 @@ impl std::error::Error for QueryError {}
 
 impl de::Error for QueryError {
     /// The catch-all serde uses for a `#[serde(deserialize_with)]` helper's own
-    /// message. Its content is out of our hands, so it is bounded and stripped
-    /// rather than trusted; the shaped constructors below intercept the serde
-    /// messages that would otherwise embed request text verbatim.
-    fn custom<T: fmt::Display>(msg: T) -> Self {
-        Self::msg(sanitize_message(&msg.to_string()))
+    /// message — **discarded**, not bounded.
+    ///
+    /// A helper is free to write `E::custom(format!("invalid token {value}"))`,
+    /// and this module cannot audit what it interpolates. Truncating and
+    /// control-stripping such a message still surfaces the leading 160
+    /// characters of it into the 400 body and every error reporter, which does
+    /// not satisfy the module's guarantee that an error never echoes a
+    /// submitted value — a query parameter can hold a secret. So the content is
+    /// dropped entirely and replaced with a fixed message; the field path is
+    /// attached separately and is derived from the target type, not the
+    /// request. A handler wanting a specific user-facing message should
+    /// validate after extraction, where it controls what the response says.
+    fn custom<T: fmt::Display>(_msg: T) -> Self {
+        Self::msg("a value was rejected by a custom deserializer".to_owned())
     }
 
     /// `invalid type: string "SUPERSECRET", expected u32` — serde's default
@@ -242,24 +251,6 @@ fn quoted_list(expected: &'static [&'static str]) -> String {
         .map(|name| format!("`{name}`"))
         .collect::<Vec<_>>()
         .join(", ")
-}
-
-/// Bound and clean a message serde built for us.
-///
-/// Only reachable through [`de::Error::custom`], i.e. a `deserialize_with`
-/// helper's own text. The shaped constructors above already keep request text
-/// out of every message serde's derive generates.
-fn sanitize_message(raw: &str) -> String {
-    const MAX: usize = 160;
-    let mut out: String = raw
-        .chars()
-        .take(MAX)
-        .map(|c| if c.is_control() { '.' } else { c })
-        .collect();
-    if raw.chars().nth(MAX).is_some() {
-        out.push('…');
-    }
-    out
 }
 
 /// Bound and clean attacker-supplied key text before it reaches an error
@@ -1424,6 +1415,46 @@ mod tests {
 
         // The SAME spelling twice is still a genuine duplicate.
         assert!(from_query_str::<Args>("tags[0]=a&tags[0]=b").is_err());
+    }
+
+    #[test]
+    fn a_custom_deserializer_message_is_discarded_not_merely_bounded() {
+        // Codex P1: a `deserialize_with` helper can interpolate the submitted
+        // value into its own message. Truncating that still surfaces the first
+        // 160 characters, so the content is dropped outright.
+        fn picky<'de, D>(deserializer: D) -> Result<String, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            let raw = String::deserialize(deserializer)?;
+            Err(serde::de::Error::custom(format!("invalid token {raw}")))
+        }
+
+        #[derive(Debug, Deserialize)]
+        struct Guarded {
+            #[serde(deserialize_with = "picky")]
+            #[allow(
+                dead_code,
+                reason = "the helper always errors; the field is never built"
+            )]
+            token: String,
+        }
+
+        let err = from_query_str::<Guarded>("token=SUPERSECRET").expect_err("helper rejects");
+        let rendered = err.to_string();
+        assert!(!rendered.contains("SUPERSECRET"), "leaked: {rendered}");
+        assert!(
+            !rendered.contains("invalid token"),
+            "retained content: {rendered}"
+        );
+        // The field path still identifies *where* the failure was; it comes
+        // from the target type, not from the request.
+        assert!(rendered.contains("token"), "{rendered}");
+
+        // A secret longer than the old 160-char bound is equally absent.
+        let long = "S3CRET".repeat(60);
+        let err = from_query_str::<Guarded>(&format!("token={long}")).expect_err("helper rejects");
+        assert!(!err.to_string().contains("S3CRET"), "{err}");
     }
 
     #[test]

--- a/autumn/src/query_string.rs
+++ b/autumn/src/query_string.rs
@@ -1,0 +1,1260 @@
+//! Structured query-string decoding for [`Query<T>`](crate::extract::Query)
+//! (issue #1972).
+//!
+//! # Why this exists
+//!
+//! `Query<T>` used to delegate straight to
+//! [`serde_urlencoded`](https://docs.rs/serde_urlencoded), which is **strictly
+//! flat**: it decodes `?q=foo&page=2` and nothing else. A `Vec<String>` field
+//! fed the repeated-key form `?tags=a&tags=b` failed with `invalid type: string
+//! "a", expected a sequence`, and a nested struct field was unrepresentable by
+//! any encoding. That left MCP tool contracts unhonorable — `tools/call`
+//! dispatch renders an array query argument as repeated keys, so a tool whose
+//! `inputSchema` advertised `tags: array` dispatched a request its own handler
+//! rejected — and pushed builders onto comma-separated strings and
+//! JSON-in-a-string fields.
+//!
+//! # Wire format
+//!
+//! The decoder is a **superset** of the flat form: a query string with unique
+//! scalar keys decodes exactly as it did before. On top of that it accepts the
+//! bracketed dialect the framework already speaks in
+//! [`nested_form`](crate::nested_form):
+//!
+//! ```text
+//! q=foo                       // scalar
+//! page=2                      // scalar, coerced to the field's type
+//! tags=a&tags=b               // repeated key   → sequence ["a", "b"]
+//! tags[]=a&tags[]=b           // append form    → sequence ["a", "b"]
+//! tags[0]=a&tags[2]=c         // indexed form   → sequence ["a", "c"]
+//! filter[status]=open         // nested object  → { status: "open" }
+//! items[0][sku]=A-1           // array of objects
+//! ```
+//!
+//! Percent-encoded brackets (`%5B` / `%5D`) are the same thing: keys are
+//! percent-decoded before parsing, so a client that encodes them round-trips
+//! identically.
+//!
+//! # Deliberate semantics
+//!
+//! * **Scalar coercion matches `serde_urlencoded`.** Values arrive as text and
+//!   are parsed with [`str::parse`] into the field's type, so `page=2` fills a
+//!   `u32` and `flag=true` fills a `bool`. An `Option<T>` field that is
+//!   *present but empty* (`?page=`) still visits `Some`, exactly as
+//!   `serde_urlencoded` does — only an **absent** key is `None`.
+//! * **First occurrence wins for scalars.** `?q=a&q=b` fills a `String` field
+//!   with `"a"`. Deserializing the same key into a sequence field yields both.
+//! * **Shape conflicts are errors.** `?filter=flat&filter[status]=open` uses
+//!   one key as both a scalar and a container; that is rejected rather than
+//!   resolved by last-write-wins.
+//! * **Malformed brackets stay literal.** A key the bracket grammar cannot
+//!   parse (`weird[unclosed`) is used verbatim as a flat key, so a stray
+//!   bracket never turns into a parse failure.
+//! * **Nesting is depth-capped** at [`MAX_DEPTH`] and indices key an ordered
+//!   map rather than a `Vec`, so neither deep nesting nor a huge index
+//!   (`tags[4000000000]=x`) lets a request drive unbounded allocation.
+//!
+//! # Compatibility note
+//!
+//! Brackets are now *structure*, not part of the key text. A target that types
+//! a parameter as a plain value — `Query<HashMap<String, String>>` is the
+//! common one — used to receive `?filter[a]=1` as the literal key
+//! `"filter[a]"`; it now sees a nested object and reports a decode error
+//! naming the fix. Type such a field as a nested struct, or as
+//! `HashMap<String, serde_json::Value>` to accept either shape.
+
+// autumn-panic-gate: request-path module — production code path must be panic-free.
+// See CONTRIBUTING.md "Request-path panic gate". Justify exceptions with
+// #[allow(clippy::<lint>, reason = "…")] at the narrowest scope.
+#![cfg_attr(
+    not(test),
+    deny(
+        clippy::unwrap_used,
+        clippy::expect_used,
+        clippy::panic,
+        clippy::unreachable,
+        clippy::todo,
+        clippy::unimplemented,
+        clippy::indexing_slicing,
+        clippy::string_slice,
+        clippy::arithmetic_side_effects,
+    )
+)]
+
+use std::collections::BTreeMap;
+use std::fmt;
+
+use serde::de::{
+    self, DeserializeOwned, DeserializeSeed, EnumAccess, MapAccess, SeqAccess, VariantAccess,
+    Visitor,
+};
+
+/// Maximum bracket nesting depth accepted in a query key.
+///
+/// `a[b][c]` is depth 3. Anything deeper is rejected as a decode error rather
+/// than allocated, so a hostile query string cannot drive unbounded tree
+/// construction. Real nested query arguments are one or two levels deep.
+pub const MAX_DEPTH: usize = 16;
+
+// ──────────────────────────────────────────────────────────────────
+// Error
+// ──────────────────────────────────────────────────────────────────
+
+/// A query-string decode failure, carrying the field path it occurred at.
+///
+/// Rendered as `filter.limit: invalid digit found in string` so a caller sees
+/// *which* parameter failed, not just that something did.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct QueryError {
+    /// Field path from the root of the query object, outermost first.
+    path: Vec<String>,
+    message: String,
+}
+
+impl QueryError {
+    fn msg(message: impl Into<String>) -> Self {
+        Self {
+            path: Vec::new(),
+            message: message.into(),
+        }
+    }
+
+    /// Prepend one path segment as the error bubbles out of a nested value.
+    fn with_segment(mut self, segment: impl Into<String>) -> Self {
+        self.path.insert(0, segment.into());
+        self
+    }
+}
+
+impl fmt::Display for QueryError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if self.path.is_empty() {
+            f.write_str(&self.message)
+        } else {
+            write!(f, "{}: {}", self.path.join("."), self.message)
+        }
+    }
+}
+
+impl std::error::Error for QueryError {}
+
+impl de::Error for QueryError {
+    fn custom<T: fmt::Display>(msg: T) -> Self {
+        Self::msg(msg.to_string())
+    }
+}
+
+// ──────────────────────────────────────────────────────────────────
+// Key parsing
+// ──────────────────────────────────────────────────────────────────
+
+/// One bracketed step in a query key.
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum Segment<'a> {
+    /// `k[]` — append at the next free position.
+    Append,
+    /// `k[3]` — an explicit position.
+    Index(usize),
+    /// `k[name]` — a named entry.
+    Key(&'a str),
+}
+
+/// Split `base[seg][seg]…` into its base key and bracketed segments.
+///
+/// Returns `None` when the remainder after the first `[` is not a well-formed
+/// run of bracket groups covering the whole key — the caller then treats the
+/// key as a flat literal, so a stray bracket is never a hard error.
+fn parse_key(key: &str) -> Option<(&str, Vec<Segment<'_>>)> {
+    let open = key.find('[')?;
+    let (base, mut rest) = key.split_at(open);
+    let mut segments = Vec::new();
+    while !rest.is_empty() {
+        // Every remaining group must start with `[` and close with `]`.
+        let (inner, remainder) = rest.strip_prefix('[')?.split_once(']')?;
+        // A nested `[` inside a group means the key is malformed, not nested.
+        if inner.contains('[') {
+            return None;
+        }
+        segments.push(classify_segment(inner));
+        rest = remainder;
+    }
+    Some((base, segments))
+}
+
+/// Classify one bracket group's contents.
+///
+/// An all-digit group is a position. Its value is **saturated** rather than
+/// wrapped or rejected, so an absurd index (`tags[99999999999999999999]`) still
+/// sorts last instead of changing the key's meaning between 32- and 64-bit
+/// targets.
+fn classify_segment(inner: &str) -> Segment<'_> {
+    if inner.is_empty() {
+        return Segment::Append;
+    }
+    if inner.bytes().all(|b| b.is_ascii_digit()) {
+        return Segment::Index(inner.parse().unwrap_or(usize::MAX));
+    }
+    Segment::Key(inner)
+}
+
+// ──────────────────────────────────────────────────────────────────
+// Tree
+// ──────────────────────────────────────────────────────────────────
+
+/// One decoded position in the query tree.
+#[derive(Debug)]
+enum Node {
+    /// Every value submitted under this exact key path, in submission order.
+    ///
+    /// Holding all of them (rather than collapsing to one) is what lets the
+    /// same node serve a scalar field (first wins) and a sequence field (all
+    /// values) without the parser needing to know the target type.
+    Scalar(Vec<String>),
+    /// Positional children (`k[]`, `k[3]`), ordered by index. A `BTreeMap`
+    /// keeps sparse and out-of-order indices cheap: `tags[4000000000]` costs
+    /// one entry, not four billion.
+    Seq(BTreeMap<usize, Self>),
+    /// Named children (`k[name]`).
+    Map(BTreeMap<String, Self>),
+}
+
+impl Node {
+    /// Human-readable shape name, for conflict and type-mismatch messages.
+    const fn kind(&self) -> &'static str {
+        match self {
+            Self::Scalar(_) => "a value",
+            Self::Seq(_) => "a sequence",
+            Self::Map(_) => "an object",
+        }
+    }
+}
+
+/// Render the key path up to (and including) `upto` segments, for error text.
+///
+/// Built only when a conflict is being reported — the success path never
+/// allocates a path string.
+fn key_path(base: &str, segments: &[Segment<'_>], upto: usize) -> String {
+    let mut out = base.to_owned();
+    for segment in segments.iter().take(upto) {
+        match segment {
+            Segment::Key(name) => {
+                out.push('[');
+                out.push_str(name);
+                out.push(']');
+            }
+            Segment::Index(index) => {
+                out.push('[');
+                out.push_str(&index.to_string());
+                out.push(']');
+            }
+            Segment::Append => out.push_str("[]"),
+        }
+    }
+    out
+}
+
+/// Insert one decoded `key=value` pair into the tree rooted at `root`.
+fn insert(
+    root: &mut BTreeMap<String, Node>,
+    base: &str,
+    segments: &[Segment<'_>],
+    value: String,
+) -> Result<(), QueryError> {
+    // `segments.len()` counts the bracketed steps; the base key is the first
+    // level, so the total depth is `len + 1` — expressed as `>=` to stay clear
+    // of the request-path gate's arithmetic ban.
+    if segments.len() >= MAX_DEPTH {
+        return Err(QueryError::msg(format!(
+            "query key nesting exceeds the maximum depth of {MAX_DEPTH}"
+        ))
+        .with_segment(base));
+    }
+
+    // Descend to the node this key addresses, creating containers on the way.
+    // The *next* segment decides which container the current entry must be, so
+    // the shape is always known before the entry is materialized.
+    let mut node = root
+        .entry(base.to_owned())
+        .or_insert_with(|| empty_for(segments.first()));
+
+    for (position, segment) in segments.iter().enumerate() {
+        let next = segments.get(position.saturating_add(1));
+        match segment {
+            Segment::Key(name) => {
+                let Node::Map(entries) = node else {
+                    return Err(conflict(base, segments, position, node, "an object"));
+                };
+                node = entries
+                    .entry((*name).to_owned())
+                    .or_insert_with(|| empty_for(next));
+            }
+            Segment::Index(index) => {
+                let Node::Seq(entries) = node else {
+                    return Err(conflict(base, segments, position, node, "a sequence"));
+                };
+                node = entries.entry(*index).or_insert_with(|| empty_for(next));
+            }
+            Segment::Append => {
+                let Node::Seq(entries) = node else {
+                    return Err(conflict(base, segments, position, node, "a sequence"));
+                };
+                // `k[]` appends after the highest position seen so far, so
+                // repeated appends stay in submission order even when mixed
+                // with explicit indices.
+                let index = entries
+                    .keys()
+                    .next_back()
+                    .map_or(0, |last| last.saturating_add(1));
+                node = entries.entry(index).or_insert_with(|| empty_for(next));
+            }
+        }
+    }
+
+    match node {
+        Node::Scalar(values) => {
+            values.push(value);
+            Ok(())
+        }
+        other => Err(conflict(base, segments, segments.len(), other, "a value")),
+    }
+}
+
+/// The empty container a segment's *successor* requires.
+const fn empty_for(next: Option<&Segment<'_>>) -> Node {
+    match next {
+        None => Node::Scalar(Vec::new()),
+        Some(Segment::Key(_)) => Node::Map(BTreeMap::new()),
+        Some(Segment::Append | Segment::Index(_)) => Node::Seq(BTreeMap::new()),
+    }
+}
+
+fn conflict(
+    base: &str,
+    segments: &[Segment<'_>],
+    upto: usize,
+    found: &Node,
+    wanted: &str,
+) -> QueryError {
+    QueryError::msg(format!(
+        "query key `{}` is used as both {} and {wanted}",
+        key_path(base, segments, upto),
+        found.kind()
+    ))
+}
+
+/// Build the query tree from an already-percent-decoded pair sequence.
+fn build_tree<'a>(
+    pairs: impl Iterator<Item = (std::borrow::Cow<'a, str>, std::borrow::Cow<'a, str>)>,
+) -> Result<BTreeMap<String, Node>, QueryError> {
+    let mut root = BTreeMap::new();
+    for (key, value) in pairs {
+        match parse_key(&key) {
+            Some((base, segments)) => insert(&mut root, base, &segments, value.into_owned())?,
+            // Not a well-formed bracket key: treat it as a flat literal name.
+            None => insert(&mut root, &key, &[], value.into_owned())?,
+        }
+    }
+    Ok(root)
+}
+
+/// Decode a raw (still percent-encoded) query string into `T`.
+///
+/// The string is the part **after** `?`, exactly as
+/// [`Uri::query`](axum::http::Uri::query) returns it. An empty string decodes
+/// into any type whose fields are all optional or defaulted.
+///
+/// # Errors
+///
+/// Returns a [`QueryError`] when the key grammar conflicts (one key used as
+/// both a scalar and a container), when nesting exceeds [`MAX_DEPTH`], or when
+/// a value cannot be coerced into the target field's type.
+pub fn from_query_str<T: DeserializeOwned>(query: &str) -> Result<T, QueryError> {
+    let root = build_tree(url::form_urlencoded::parse(query.as_bytes()))?;
+    T::deserialize(NodeDeserializer {
+        node: &Node::Map(root),
+    })
+}
+
+// ──────────────────────────────────────────────────────────────────
+// Scalar (leaf) deserializer
+// ──────────────────────────────────────────────────────────────────
+
+/// Deserializer for one textual value, coercing with [`str::parse`] exactly as
+/// `serde_urlencoded`'s part deserializer does.
+struct ValueDeserializer<'a> {
+    value: &'a str,
+}
+
+macro_rules! parse_scalar {
+    ($($method:ident => $visit:ident : $ty:ty),* $(,)?) => {
+        $(
+            fn $method<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, QueryError> {
+                let parsed: $ty = self.value.parse().map_err(|_| {
+                    QueryError::msg(format!(
+                        "invalid value `{}` for {}",
+                        self.value,
+                        stringify!($ty)
+                    ))
+                })?;
+                visitor.$visit(parsed)
+            }
+        )*
+    };
+}
+
+impl<'de> de::Deserializer<'de> for ValueDeserializer<'_> {
+    type Error = QueryError;
+
+    fn deserialize_any<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, QueryError> {
+        visitor.visit_str(self.value)
+    }
+
+    parse_scalar! {
+        deserialize_bool => visit_bool: bool,
+        deserialize_i8 => visit_i8: i8,
+        deserialize_i16 => visit_i16: i16,
+        deserialize_i32 => visit_i32: i32,
+        deserialize_i64 => visit_i64: i64,
+        deserialize_i128 => visit_i128: i128,
+        deserialize_u8 => visit_u8: u8,
+        deserialize_u16 => visit_u16: u16,
+        deserialize_u32 => visit_u32: u32,
+        deserialize_u64 => visit_u64: u64,
+        deserialize_u128 => visit_u128: u128,
+        deserialize_f32 => visit_f32: f32,
+        deserialize_f64 => visit_f64: f64,
+        deserialize_char => visit_char: char,
+    }
+
+    fn deserialize_str<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, QueryError> {
+        visitor.visit_str(self.value)
+    }
+
+    fn deserialize_string<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, QueryError> {
+        visitor.visit_str(self.value)
+    }
+
+    fn deserialize_bytes<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, QueryError> {
+        visitor.visit_bytes(self.value.as_bytes())
+    }
+
+    fn deserialize_byte_buf<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, QueryError> {
+        visitor.visit_bytes(self.value.as_bytes())
+    }
+
+    /// A key that is *present* always visits `Some`, matching
+    /// `serde_urlencoded`: only an absent key deserializes as `None`.
+    fn deserialize_option<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, QueryError> {
+        visitor.visit_some(self)
+    }
+
+    fn deserialize_unit<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, QueryError> {
+        visitor.visit_unit()
+    }
+
+    fn deserialize_unit_struct<V: Visitor<'de>>(
+        self,
+        _name: &'static str,
+        visitor: V,
+    ) -> Result<V::Value, QueryError> {
+        visitor.visit_unit()
+    }
+
+    fn deserialize_newtype_struct<V: Visitor<'de>>(
+        self,
+        _name: &'static str,
+        visitor: V,
+    ) -> Result<V::Value, QueryError> {
+        visitor.visit_newtype_struct(self)
+    }
+
+    fn deserialize_seq<V: Visitor<'de>>(self, _visitor: V) -> Result<V::Value, QueryError> {
+        Err(QueryError::msg(format!(
+            "expected a sequence, found the value `{}`",
+            self.value
+        )))
+    }
+
+    fn deserialize_tuple<V: Visitor<'de>>(
+        self,
+        _len: usize,
+        visitor: V,
+    ) -> Result<V::Value, QueryError> {
+        self.deserialize_seq(visitor)
+    }
+
+    fn deserialize_tuple_struct<V: Visitor<'de>>(
+        self,
+        _name: &'static str,
+        _len: usize,
+        visitor: V,
+    ) -> Result<V::Value, QueryError> {
+        self.deserialize_seq(visitor)
+    }
+
+    fn deserialize_map<V: Visitor<'de>>(self, _visitor: V) -> Result<V::Value, QueryError> {
+        Err(QueryError::msg(format!(
+            "expected an object, found the value `{}`",
+            self.value
+        )))
+    }
+
+    fn deserialize_struct<V: Visitor<'de>>(
+        self,
+        _name: &'static str,
+        _fields: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value, QueryError> {
+        self.deserialize_map(visitor)
+    }
+
+    /// A bare value selects a unit variant (`?sort=asc` → `Sort::Asc`).
+    fn deserialize_enum<V: Visitor<'de>>(
+        self,
+        _name: &'static str,
+        _variants: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value, QueryError> {
+        visitor.visit_enum(UnitVariant { value: self.value })
+    }
+
+    fn deserialize_identifier<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, QueryError> {
+        visitor.visit_str(self.value)
+    }
+
+    fn deserialize_ignored_any<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, QueryError> {
+        visitor.visit_unit()
+    }
+}
+
+/// `EnumAccess` for the `?sort=asc` unit-variant form.
+struct UnitVariant<'a> {
+    value: &'a str,
+}
+
+impl<'de> EnumAccess<'de> for UnitVariant<'_> {
+    type Error = QueryError;
+    type Variant = Self;
+
+    fn variant_seed<V: DeserializeSeed<'de>>(
+        self,
+        seed: V,
+    ) -> Result<(V::Value, Self), QueryError> {
+        let variant = seed.deserialize(ValueDeserializer { value: self.value })?;
+        Ok((variant, self))
+    }
+}
+
+impl<'de> VariantAccess<'de> for UnitVariant<'_> {
+    type Error = QueryError;
+
+    fn unit_variant(self) -> Result<(), QueryError> {
+        Ok(())
+    }
+
+    fn newtype_variant_seed<T: DeserializeSeed<'de>>(
+        self,
+        _seed: T,
+    ) -> Result<T::Value, QueryError> {
+        Err(QueryError::msg(
+            "expected a unit variant; a data-carrying variant needs the bracketed form \
+             `key[variant][field]=…`",
+        ))
+    }
+
+    fn tuple_variant<V: Visitor<'de>>(
+        self,
+        _len: usize,
+        _visitor: V,
+    ) -> Result<V::Value, QueryError> {
+        Err(QueryError::msg("expected a unit variant"))
+    }
+
+    fn struct_variant<V: Visitor<'de>>(
+        self,
+        _fields: &'static [&'static str],
+        _visitor: V,
+    ) -> Result<V::Value, QueryError> {
+        Err(QueryError::msg("expected a unit variant"))
+    }
+}
+
+// ──────────────────────────────────────────────────────────────────
+// Node deserializer
+// ──────────────────────────────────────────────────────────────────
+
+struct NodeDeserializer<'a> {
+    node: &'a Node,
+}
+
+impl<'a> NodeDeserializer<'a> {
+    /// The leaf view of a scalar node: its first submitted value (first
+    /// occurrence wins), or an error naming the container shape found instead.
+    fn as_value(&self, wanted: &str) -> Result<ValueDeserializer<'a>, QueryError> {
+        match self.node {
+            Node::Scalar(values) => Ok(ValueDeserializer {
+                // A scalar node is only ever created by pushing a value, so it
+                // is never empty; the fallback keeps this total regardless.
+                value: values.first().map_or("", String::as_str),
+            }),
+            // The caller sent the bracketed form for a key the target types as
+            // a plain value. Name the fix rather than just the mismatch: this is
+            // the one shape that used to arrive as a literal `key[sub]` string
+            // under `serde_urlencoded`.
+            other => Err(QueryError::msg(format!(
+                "expected {wanted}, found {} — the request used the bracketed form \
+                 (`key[…]=`) for this parameter, so give the field a nested type or \
+                 accept it as `serde_json::Value`",
+                other.kind()
+            ))),
+        }
+    }
+}
+
+/// Forward a scalar-shaped `deserialize_*` call to the leaf deserializer.
+macro_rules! forward_scalar {
+    ($($method:ident),* $(,)?) => {
+        $(
+            fn $method<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, QueryError> {
+                self.as_value("a value")?.$method(visitor)
+            }
+        )*
+    };
+}
+
+impl<'de> de::Deserializer<'de> for NodeDeserializer<'_> {
+    type Error = QueryError;
+
+    /// Self-describing decode, used by untyped targets such as
+    /// `serde_json::Value`: a multi-valued key becomes a sequence, a single
+    /// value stays a string.
+    fn deserialize_any<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, QueryError> {
+        match self.node {
+            Node::Scalar(values) if values.len() == 1 => {
+                visitor.visit_str(values.first().map_or("", String::as_str))
+            }
+            Node::Scalar(_) | Node::Seq(_) => self.deserialize_seq(visitor),
+            Node::Map(_) => self.deserialize_map(visitor),
+        }
+    }
+
+    forward_scalar! {
+        deserialize_bool,
+        deserialize_i8, deserialize_i16, deserialize_i32, deserialize_i64, deserialize_i128,
+        deserialize_u8, deserialize_u16, deserialize_u32, deserialize_u64, deserialize_u128,
+        deserialize_f32, deserialize_f64,
+        deserialize_char, deserialize_str, deserialize_string,
+        deserialize_bytes, deserialize_byte_buf,
+        deserialize_identifier,
+    }
+
+    fn deserialize_option<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, QueryError> {
+        visitor.visit_some(self)
+    }
+
+    fn deserialize_unit<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, QueryError> {
+        visitor.visit_unit()
+    }
+
+    fn deserialize_unit_struct<V: Visitor<'de>>(
+        self,
+        _name: &'static str,
+        visitor: V,
+    ) -> Result<V::Value, QueryError> {
+        visitor.visit_unit()
+    }
+
+    fn deserialize_newtype_struct<V: Visitor<'de>>(
+        self,
+        _name: &'static str,
+        visitor: V,
+    ) -> Result<V::Value, QueryError> {
+        visitor.visit_newtype_struct(self)
+    }
+
+    fn deserialize_seq<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, QueryError> {
+        match self.node {
+            // Repeated keys: every submitted value is one element.
+            Node::Scalar(values) => visitor.visit_seq(ValueSeq {
+                values: values.iter(),
+            }),
+            // Indexed/append form: ascending index order, gaps compacted.
+            Node::Seq(entries) => visitor.visit_seq(NodeSeq {
+                entries: entries.iter(),
+            }),
+            // An object addressed as a sequence yields its `(key, value)`
+            // pairs, so the `Query<Vec<(String, String)>>` idiom keeps working.
+            Node::Map(entries) => visitor.visit_seq(PairSeq {
+                pairs: flatten_pairs(entries).into_iter(),
+            }),
+        }
+    }
+
+    fn deserialize_tuple<V: Visitor<'de>>(
+        self,
+        _len: usize,
+        visitor: V,
+    ) -> Result<V::Value, QueryError> {
+        self.deserialize_seq(visitor)
+    }
+
+    fn deserialize_tuple_struct<V: Visitor<'de>>(
+        self,
+        _name: &'static str,
+        _len: usize,
+        visitor: V,
+    ) -> Result<V::Value, QueryError> {
+        self.deserialize_seq(visitor)
+    }
+
+    fn deserialize_map<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, QueryError> {
+        match self.node {
+            Node::Map(entries) => visitor.visit_map(NodeMap {
+                entries: entries.iter(),
+                value: None,
+                key: String::new(),
+            }),
+            other => Err(QueryError::msg(format!(
+                "expected an object, found {}",
+                other.kind()
+            ))),
+        }
+    }
+
+    fn deserialize_struct<V: Visitor<'de>>(
+        self,
+        _name: &'static str,
+        _fields: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value, QueryError> {
+        self.deserialize_map(visitor)
+    }
+
+    /// `?sort=asc` selects a unit variant; `?sort[custom][field]=x` selects a
+    /// data-carrying variant through the single-entry object form.
+    fn deserialize_enum<V: Visitor<'de>>(
+        self,
+        name: &'static str,
+        variants: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value, QueryError> {
+        match self.node {
+            Node::Scalar(_) => self
+                .as_value("a value")?
+                .deserialize_enum(name, variants, visitor),
+            Node::Map(entries) if entries.len() == 1 => match entries.iter().next() {
+                Some((variant, content)) => visitor.visit_enum(NodeVariant { variant, content }),
+                // Unreachable given the `len() == 1` guard, but the request-path
+                // gate forbids proving that with a panic.
+                None => Err(QueryError::msg("expected an enum variant name")),
+            },
+            other => Err(QueryError::msg(format!(
+                "expected an enum variant name or a single-entry object, found {}",
+                other.kind()
+            ))),
+        }
+    }
+
+    /// Unknown keys are discarded without walking their subtree.
+    fn deserialize_ignored_any<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, QueryError> {
+        visitor.visit_unit()
+    }
+}
+
+/// One `(key, value)` pair of a map addressed as a sequence.
+enum PairValue<'a> {
+    Value(&'a str),
+    Node(&'a Node),
+}
+
+/// Flatten a map into `(key, value)` pairs, expanding a repeated key into one
+/// pair per submitted value so the pair view matches the wire.
+fn flatten_pairs<'a>(entries: &'a BTreeMap<String, Node>) -> Vec<(&'a str, PairValue<'a>)> {
+    let mut out = Vec::new();
+    for (key, node) in entries {
+        match node {
+            Node::Scalar(values) => {
+                out.extend(values.iter().map(|v| (key.as_str(), PairValue::Value(v))));
+            }
+            other => out.push((key.as_str(), PairValue::Node(other))),
+        }
+    }
+    out
+}
+
+struct ValueSeq<'a> {
+    values: std::slice::Iter<'a, String>,
+}
+
+impl<'de> SeqAccess<'de> for ValueSeq<'_> {
+    type Error = QueryError;
+
+    fn next_element_seed<T: DeserializeSeed<'de>>(
+        &mut self,
+        seed: T,
+    ) -> Result<Option<T::Value>, QueryError> {
+        self.values
+            .next()
+            .map(|value| seed.deserialize(ValueDeserializer { value }))
+            .transpose()
+    }
+
+    fn size_hint(&self) -> Option<usize> {
+        Some(self.values.len())
+    }
+}
+
+struct NodeSeq<'a> {
+    entries: std::collections::btree_map::Iter<'a, usize, Node>,
+}
+
+impl<'de> SeqAccess<'de> for NodeSeq<'_> {
+    type Error = QueryError;
+
+    fn next_element_seed<T: DeserializeSeed<'de>>(
+        &mut self,
+        seed: T,
+    ) -> Result<Option<T::Value>, QueryError> {
+        let Some((index, node)) = self.entries.next() else {
+            return Ok(None);
+        };
+        seed.deserialize(NodeDeserializer { node })
+            .map(Some)
+            .map_err(|err| err.with_segment(index.to_string()))
+    }
+
+    fn size_hint(&self) -> Option<usize> {
+        Some(self.entries.len())
+    }
+}
+
+struct PairSeq<'a> {
+    pairs: std::vec::IntoIter<(&'a str, PairValue<'a>)>,
+}
+
+impl<'de> SeqAccess<'de> for PairSeq<'_> {
+    type Error = QueryError;
+
+    fn next_element_seed<T: DeserializeSeed<'de>>(
+        &mut self,
+        seed: T,
+    ) -> Result<Option<T::Value>, QueryError> {
+        let Some((key, value)) = self.pairs.next() else {
+            return Ok(None);
+        };
+        seed.deserialize(PairDeserializer { key, value })
+            .map(Some)
+            .map_err(|err| err.with_segment(key))
+    }
+
+    fn size_hint(&self) -> Option<usize> {
+        Some(self.pairs.len())
+    }
+}
+
+/// Deserializes one `(key, value)` pair as a two-element tuple.
+struct PairDeserializer<'a> {
+    key: &'a str,
+    value: PairValue<'a>,
+}
+
+impl<'de> de::Deserializer<'de> for PairDeserializer<'_> {
+    type Error = QueryError;
+
+    fn deserialize_any<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, QueryError> {
+        visitor.visit_seq(PairElements {
+            key: Some(self.key),
+            value: Some(self.value),
+        })
+    }
+
+    serde::forward_to_deserialize_any! {
+        bool i8 i16 i32 i64 i128 u8 u16 u32 u64 u128 f32 f64 char str string
+        bytes byte_buf option unit unit_struct newtype_struct seq tuple
+        tuple_struct map struct enum identifier ignored_any
+    }
+}
+
+struct PairElements<'a> {
+    key: Option<&'a str>,
+    value: Option<PairValue<'a>>,
+}
+
+impl<'de> SeqAccess<'de> for PairElements<'_> {
+    type Error = QueryError;
+
+    fn next_element_seed<T: DeserializeSeed<'de>>(
+        &mut self,
+        seed: T,
+    ) -> Result<Option<T::Value>, QueryError> {
+        if let Some(key) = self.key.take() {
+            return seed.deserialize(ValueDeserializer { value: key }).map(Some);
+        }
+        match self.value.take() {
+            Some(PairValue::Value(value)) => {
+                seed.deserialize(ValueDeserializer { value }).map(Some)
+            }
+            Some(PairValue::Node(node)) => seed.deserialize(NodeDeserializer { node }).map(Some),
+            None => Ok(None),
+        }
+    }
+}
+
+struct NodeMap<'a> {
+    entries: std::collections::btree_map::Iter<'a, String, Node>,
+    value: Option<&'a Node>,
+    key: String,
+}
+
+impl<'de> MapAccess<'de> for NodeMap<'_> {
+    type Error = QueryError;
+
+    fn next_key_seed<K: DeserializeSeed<'de>>(
+        &mut self,
+        seed: K,
+    ) -> Result<Option<K::Value>, QueryError> {
+        let Some((key, node)) = self.entries.next() else {
+            return Ok(None);
+        };
+        self.value = Some(node);
+        self.key = key.clone();
+        seed.deserialize(ValueDeserializer { value: key }).map(Some)
+    }
+
+    fn next_value_seed<V: DeserializeSeed<'de>>(
+        &mut self,
+        seed: V,
+    ) -> Result<V::Value, QueryError> {
+        let node = self.value.take().ok_or_else(|| {
+            QueryError::msg("internal error: query map value requested before its key")
+        })?;
+        // Tag the failure with the field it came from, so a caller sees
+        // `filter.limit: invalid value …` rather than a bare parse error.
+        seed.deserialize(NodeDeserializer { node })
+            .map_err(|err| err.with_segment(self.key.clone()))
+    }
+
+    fn size_hint(&self) -> Option<usize> {
+        Some(self.entries.len())
+    }
+}
+
+/// `EnumAccess` for the single-entry-object variant form.
+struct NodeVariant<'a> {
+    variant: &'a str,
+    content: &'a Node,
+}
+
+impl<'de, 'a> EnumAccess<'de> for NodeVariant<'a> {
+    type Error = QueryError;
+    type Variant = NodeContent<'a>;
+
+    fn variant_seed<V: DeserializeSeed<'de>>(
+        self,
+        seed: V,
+    ) -> Result<(V::Value, NodeContent<'a>), QueryError> {
+        let variant = seed.deserialize(ValueDeserializer {
+            value: self.variant,
+        })?;
+        Ok((
+            variant,
+            NodeContent {
+                content: self.content,
+            },
+        ))
+    }
+}
+
+struct NodeContent<'a> {
+    content: &'a Node,
+}
+
+impl<'de> VariantAccess<'de> for NodeContent<'_> {
+    type Error = QueryError;
+
+    fn unit_variant(self) -> Result<(), QueryError> {
+        Ok(())
+    }
+
+    fn newtype_variant_seed<T: DeserializeSeed<'de>>(
+        self,
+        seed: T,
+    ) -> Result<T::Value, QueryError> {
+        seed.deserialize(NodeDeserializer { node: self.content })
+    }
+
+    fn tuple_variant<V: Visitor<'de>>(
+        self,
+        _len: usize,
+        visitor: V,
+    ) -> Result<V::Value, QueryError> {
+        de::Deserializer::deserialize_seq(NodeDeserializer { node: self.content }, visitor)
+    }
+
+    fn struct_variant<V: Visitor<'de>>(
+        self,
+        _fields: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value, QueryError> {
+        de::Deserializer::deserialize_map(NodeDeserializer { node: self.content }, visitor)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde::Deserialize;
+
+    #[derive(Debug, Deserialize, PartialEq)]
+    struct Filter {
+        status: String,
+        limit: Option<u32>,
+    }
+
+    #[derive(Debug, Deserialize, PartialEq)]
+    struct Item {
+        sku: String,
+        qty: u32,
+    }
+
+    #[derive(Debug, Deserialize, PartialEq, Default)]
+    struct Args {
+        q: Option<String>,
+        page: Option<u32>,
+        flag: Option<bool>,
+        tags: Option<Vec<String>>,
+        filter: Option<Filter>,
+        items: Option<Vec<Item>>,
+    }
+
+    fn args(query: &str) -> Args {
+        from_query_str(query).expect("decodes")
+    }
+
+    #[test]
+    fn flat_scalars_match_the_previous_urlencoded_behaviour() {
+        let out = args("q=foo&page=2&flag=true");
+        assert_eq!(out.q.as_deref(), Some("foo"));
+        assert_eq!(out.page, Some(2));
+        assert_eq!(out.flag, Some(true));
+    }
+
+    #[test]
+    fn absent_keys_are_none_and_an_empty_query_decodes() {
+        assert_eq!(args(""), Args::default());
+    }
+
+    #[test]
+    fn a_present_but_empty_optional_still_visits_some() {
+        // Parity with `serde_urlencoded`: presence, not emptiness, decides.
+        assert_eq!(args("q=").q.as_deref(), Some(""));
+        assert!(
+            from_query_str::<Args>("page=").is_err(),
+            "an empty value for a numeric field is still a coercion failure"
+        );
+    }
+
+    #[test]
+    fn repeated_keys_fill_a_sequence_and_first_wins_for_a_scalar() {
+        assert_eq!(
+            args("tags=a&tags=b").tags.unwrap(),
+            vec!["a".to_owned(), "b".to_owned()]
+        );
+        assert_eq!(args("q=first&q=second").q.as_deref(), Some("first"));
+    }
+
+    #[test]
+    fn append_and_indexed_forms_fill_a_sequence() {
+        assert_eq!(
+            args("tags[]=a&tags[]=b").tags.unwrap(),
+            vec!["a".to_owned(), "b".to_owned()]
+        );
+        assert_eq!(
+            args("tags[1]=b&tags[0]=a").tags.unwrap(),
+            vec!["a".to_owned(), "b".to_owned()]
+        );
+    }
+
+    #[test]
+    fn gapped_indices_compact_in_ascending_order() {
+        assert_eq!(
+            args("tags[4]=c&tags[0]=a&tags[2]=b").tags.unwrap(),
+            vec!["a".to_owned(), "b".to_owned(), "c".to_owned()]
+        );
+    }
+
+    #[test]
+    fn an_absurd_index_sorts_last_without_preallocating() {
+        assert_eq!(
+            args("tags[99999999999999999999]=last&tags[3]=first")
+                .tags
+                .unwrap(),
+            vec!["first".to_owned(), "last".to_owned()]
+        );
+    }
+
+    #[test]
+    fn appends_continue_after_the_highest_explicit_index() {
+        assert_eq!(
+            args("tags[]=a&tags[5]=b&tags[]=c").tags.unwrap(),
+            vec!["a".to_owned(), "b".to_owned(), "c".to_owned()]
+        );
+    }
+
+    #[test]
+    fn nested_objects_decode() {
+        assert_eq!(
+            args("filter[status]=open&filter[limit]=5").filter.unwrap(),
+            Filter {
+                status: "open".to_owned(),
+                limit: Some(5),
+            }
+        );
+    }
+
+    #[test]
+    fn arrays_of_objects_decode() {
+        let out = args("items[0][sku]=A-1&items[0][qty]=2&items[1][sku]=B-2&items[1][qty]=3");
+        assert_eq!(
+            out.items.unwrap(),
+            vec![
+                Item {
+                    sku: "A-1".to_owned(),
+                    qty: 2
+                },
+                Item {
+                    sku: "B-2".to_owned(),
+                    qty: 3
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn percent_encoded_brackets_parse_identically() {
+        assert_eq!(
+            args("filter%5Bstatus%5D=open").filter.unwrap().status,
+            "open"
+        );
+    }
+
+    #[test]
+    fn plus_is_decoded_as_a_space() {
+        assert_eq!(args("q=hello+world").q.as_deref(), Some("hello world"));
+    }
+
+    #[test]
+    fn malformed_bracket_keys_stay_literal() {
+        assert_eq!(parse_key("weird[unclosed"), None);
+        assert_eq!(parse_key("a[b][c"), None);
+        assert_eq!(parse_key("a[[b]]"), None);
+        assert_eq!(parse_key("plain"), None);
+        // A literal key with no matching field is simply ignored.
+        assert_eq!(args("weird[unclosed=1&q=ok").q.as_deref(), Some("ok"));
+    }
+
+    #[test]
+    fn bracket_keys_parse_into_segments() {
+        assert_eq!(
+            parse_key("items[0][sku]"),
+            Some(("items", vec![Segment::Index(0), Segment::Key("sku")]))
+        );
+        assert_eq!(parse_key("tags[]"), Some(("tags", vec![Segment::Append])));
+    }
+
+    #[test]
+    fn shape_conflicts_are_rejected() {
+        let scalar_then_object = from_query_str::<Args>("filter=flat&filter[status]=open");
+        assert!(scalar_then_object.is_err());
+        let object_then_scalar = from_query_str::<Args>("filter[status]=open&filter=flat");
+        assert!(object_then_scalar.is_err());
+        let seq_then_object = from_query_str::<Args>("tags[0]=a&tags[name]=b");
+        assert!(seq_then_object.is_err());
+    }
+
+    #[test]
+    fn nesting_deeper_than_the_cap_is_rejected() {
+        let deep = format!("a{}=1", "[x]".repeat(MAX_DEPTH));
+        let err = from_query_str::<Args>(&deep).expect_err("depth-capped");
+        assert!(err.to_string().contains("depth"), "{err}");
+        // One level under the cap is still accepted.
+        let ok = format!("a{}=1", "[x]".repeat(MAX_DEPTH - 2));
+        assert!(from_query_str::<Args>(&ok).is_ok());
+    }
+
+    #[test]
+    fn errors_name_the_failing_field_path() {
+        let err = from_query_str::<Args>("filter[status]=open&filter[limit]=nope")
+            .expect_err("coercion failure");
+        assert!(err.to_string().starts_with("filter.limit:"), "{err}");
+    }
+
+    #[test]
+    fn untyped_targets_decode_through_deserialize_any() {
+        let out: serde_json::Value =
+            from_query_str("q=foo&tags=a&tags=b&filter[status]=open").expect("decodes");
+        assert_eq!(out["q"], "foo");
+        assert_eq!(out["tags"], serde_json::json!(["a", "b"]));
+        assert_eq!(out["filter"]["status"], "open");
+    }
+
+    #[test]
+    fn map_targets_keep_working() {
+        let out: std::collections::HashMap<String, String> =
+            from_query_str("a=1&b=2").expect("decodes");
+        assert_eq!(out.get("a").map(String::as_str), Some("1"));
+        assert_eq!(out.get("b").map(String::as_str), Some("2"));
+    }
+
+    #[test]
+    fn pair_sequence_targets_keep_working() {
+        // The `Query<Vec<(String, String)>>` idiom: one pair per occurrence.
+        let out: Vec<(String, String)> = from_query_str("a=1&a=2&b=3").expect("decodes");
+        assert_eq!(
+            out,
+            vec![
+                ("a".to_owned(), "1".to_owned()),
+                ("a".to_owned(), "2".to_owned()),
+                ("b".to_owned(), "3".to_owned()),
+            ]
+        );
+    }
+
+    #[test]
+    fn unit_enum_variants_decode_from_a_bare_value() {
+        #[derive(Debug, Deserialize, PartialEq)]
+        #[serde(rename_all = "lowercase")]
+        enum Sort {
+            Asc,
+            Desc,
+        }
+        #[derive(Debug, Deserialize)]
+        struct Sorted {
+            sort: Sort,
+        }
+        let out: Sorted = from_query_str("sort=desc").expect("decodes");
+        assert_eq!(out.sort, Sort::Desc);
+    }
+
+    #[test]
+    fn unknown_keys_are_ignored_including_nested_ones() {
+        let out = args("q=ok&unknown[deep][deeper]=1&other=2");
+        assert_eq!(out.q.as_deref(), Some("ok"));
+    }
+
+    #[test]
+    fn a_missing_required_field_still_fails() {
+        assert!(from_query_str::<Filter>("limit=5").is_err());
+    }
+
+    #[test]
+    fn serde_renames_are_honored_because_serde_resolves_the_key() {
+        #[derive(Debug, Deserialize)]
+        #[serde(rename_all = "camelCase")]
+        struct Renamed {
+            word_count: u32,
+        }
+        let out: Renamed = from_query_str("wordCount=7").expect("decodes");
+        assert_eq!(out.word_count, 7);
+    }
+}

--- a/autumn/src/query_string.rs
+++ b/autumn/src/query_string.rs
@@ -174,7 +174,7 @@ impl de::Error for QueryError {
         ))
     }
 
-    /// Same reasoning as [`Self::invalid_type`]: the value is the secret-bearing
+    /// Same reasoning as `invalid_type` above: the value is the secret-bearing
     /// half of the message.
     fn invalid_value(unexp: de::Unexpected<'_>, exp: &dyn de::Expected) -> Self {
         Self::msg(format!(
@@ -861,7 +861,12 @@ impl<'de> de::Deserializer<'de> for NodeDeserializer<'_> {
         visitor.visit_some(self)
     }
 
+    /// A `()`/unit-struct field still has to be a *claimable scalar*: routing
+    /// through `as_value` applies both the poisoned-key check and the shape
+    /// requirement, so `?flag=x&flag[y]=z` cannot decode successfully just
+    /// because the target happens to discard the value.
     fn deserialize_unit<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, QueryError> {
+        self.as_value("a value")?;
         visitor.visit_unit()
     }
 
@@ -870,6 +875,7 @@ impl<'de> de::Deserializer<'de> for NodeDeserializer<'_> {
         _name: &'static str,
         visitor: V,
     ) -> Result<V::Value, QueryError> {
+        self.as_value("a value")?;
         visitor.visit_unit()
     }
 
@@ -1068,7 +1074,9 @@ impl<'de> SeqAccess<'de> for PairSeq<'_> {
         };
         seed.deserialize(PairDeserializer { key, value })
             .map(Some)
-            .map_err(|err| err.with_segment(key))
+            // Same bounding/stripping `NodeMap` applies: this key is raw,
+            // percent-decoded request text.
+            .map_err(|err| err.with_segment(sanitize_key(key)))
     }
 
     fn size_hint(&self) -> Option<usize> {
@@ -1380,6 +1388,49 @@ mod tests {
         let err =
             from_query_str::<Nested>("filter[a]=x&filter=SUPERSECRET").expect_err("shape conflict");
         assert!(!err.to_string().contains("SUPERSECRET"), "{err}");
+    }
+
+    #[test]
+    fn a_unit_field_still_validates_the_node_it_claims() {
+        // Codex P2: `()` discards its value, but the key is still *claimed* —
+        // a poisoned shape conflict or a bracketed container under it must not
+        // decode successfully just because the target throws the value away.
+        #[derive(Debug, Deserialize)]
+        struct WithUnit {
+            #[allow(dead_code)]
+            flag: (),
+        }
+        assert!(
+            from_query_str::<WithUnit>("flag=x&flag[y]=z").is_err(),
+            "a claimed conflicting key must fail even for a unit field"
+        );
+        assert!(
+            from_query_str::<WithUnit>("flag[y]=z").is_err(),
+            "a bracketed container is not a value"
+        );
+        assert!(from_query_str::<WithUnit>("flag=x").is_ok());
+    }
+
+    #[test]
+    fn pair_sequence_errors_sanitize_their_key() {
+        // Codex P2: this path annotated errors with the raw, percent-decoded
+        // key while `NodeMap` sanitized — the same control characters and
+        // unbounded length would have reached the 400 body.
+        let err = from_query_str::<Vec<(String, u32)>>("\nATTACKER=not-a-number")
+            .expect_err("coercion failure");
+        let rendered = err.to_string();
+        assert!(
+            !rendered.contains('\n'),
+            "control chars stripped: {rendered:?}"
+        );
+
+        let long = format!("{}=not-a-number", "k".repeat(500));
+        let err = from_query_str::<Vec<(String, u32)>>(&long).expect_err("coercion failure");
+        assert!(
+            err.to_string().chars().count() < 200,
+            "key bounded: {}",
+            err.to_string().len()
+        );
     }
 
     #[test]

--- a/autumn/tests/integration/mcp_structured_query.rs
+++ b/autumn/tests/integration/mcp_structured_query.rs
@@ -136,6 +136,40 @@ async fn scalar_query_arguments_still_round_trip() {
     assert_eq!(echoed["page"], 3);
 }
 
+/// Values a query string cannot carry are refused up front rather than
+/// dispatched as something the caller did not ask for: an empty array would
+/// vanish (400-ing a required field), and a null element would shorten the
+/// sequence and shift every later element.
+#[tokio::test]
+async fn inexpressible_query_arguments_are_refused_not_silently_altered() {
+    for (label, query) in [
+        ("empty array", serde_json::json!({ "q": "x", "tags": [] })),
+        (
+            "empty object",
+            serde_json::json!({ "q": "x", "filter": {} }),
+        ),
+        (
+            "null array element",
+            serde_json::json!({ "q": "x", "tags": ["a", null] }),
+        ),
+    ] {
+        let out = rpc(
+            &client(),
+            serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "tools/call",
+                "params": { "name": "structured_search", "arguments": { "query": query } }
+            }),
+        )
+        .await;
+        assert!(
+            out["error"].is_object() || out["result"]["isError"] == serde_json::Value::Bool(true),
+            "{label} must be refused, not silently altered: {out}"
+        );
+    }
+}
+
 /// The advertised `inputSchema` exposes the nested field structure — the tool
 /// contract the dispatch path now actually honours.
 #[tokio::test]

--- a/autumn/tests/integration/mcp_structured_query.rs
+++ b/autumn/tests/integration/mcp_structured_query.rs
@@ -1,0 +1,170 @@
+//! MCP `tools/call` dispatch honours structured query arguments (issue #1972).
+//!
+//! `build_request` renders a tool's `query` object into the dispatched URL. It
+//! already expanded an array field to repeated keys, but `Query<T>` could not
+//! decode repeated keys — so a tool whose derived `inputSchema` advertised
+//! `tags: array` dispatched a request its own handler rejected with 400. Nested
+//! objects were worse: they were stringified to JSON-in-a-string, which nothing
+//! downstream could parse.
+//!
+//! These tests drive the full loop — derived schema → `tools/call` →
+//! `build_request` → real handler pipeline → echoed JSON — so the advertised
+//! contract and the wire encoding are proven to agree.
+
+#![cfg(feature = "mcp")]
+
+use autumn_web::openapi::OpenApiSchema;
+use autumn_web::prelude::*;
+use autumn_web::test::{TestApp, TestClient};
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, OpenApiSchema)]
+struct QueryFilter {
+    status: String,
+    limit: Option<u32>,
+}
+
+#[derive(Serialize, Deserialize, OpenApiSchema)]
+struct QueryItem {
+    sku: String,
+    qty: u32,
+}
+
+#[derive(Serialize, Deserialize, OpenApiSchema)]
+struct StructuredSearch {
+    q: String,
+    page: Option<u32>,
+    tags: Option<Vec<String>>,
+    filter: Option<QueryFilter>,
+    items: Option<Vec<QueryItem>>,
+}
+
+#[get("/api/structured-search")]
+#[api_doc(mcp, summary = "Search with structured query arguments")]
+async fn structured_search(
+    Query(args): Query<StructuredSearch>,
+) -> AutumnResult<Json<StructuredSearch>> {
+    Ok(Json(args))
+}
+
+fn client() -> TestClient {
+    TestApp::new()
+        .routes(routes![structured_search])
+        .mount_mcp("/mcp")
+        .build()
+}
+
+async fn rpc(client: &TestClient, body: serde_json::Value) -> serde_json::Value {
+    let resp = client.post("/mcp").json(&body).send().await;
+    resp.assert_ok();
+    resp.json::<serde_json::Value>()
+}
+
+/// Call the tool with `arguments.query` and return the handler's echoed struct.
+async fn call_query(query: serde_json::Value) -> serde_json::Value {
+    let out = rpc(
+        &client(),
+        serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": { "name": "structured_search", "arguments": { "query": query } }
+        }),
+    )
+    .await;
+    assert_ne!(
+        out["result"]["isError"],
+        serde_json::Value::Bool(true),
+        "tool call must not error: {out}"
+    );
+    let text = out["result"]["content"][0]["text"]
+        .as_str()
+        .expect("text content");
+    serde_json::from_str(text).expect("handler echoes JSON")
+}
+
+/// The regression the issue names: an array query argument expands to repeated
+/// keys, and the handler must now decode them into its `Vec<String>` field.
+#[tokio::test]
+async fn array_query_argument_round_trips_to_a_vec_field() {
+    let echoed = call_query(serde_json::json!({ "q": "x", "tags": ["a", "b"] })).await;
+    assert_eq!(echoed["tags"], serde_json::json!(["a", "b"]));
+}
+
+/// A nested object query argument round-trips instead of arriving as
+/// JSON-in-a-string the extractor cannot parse.
+#[tokio::test]
+async fn nested_object_query_argument_round_trips() {
+    let echoed =
+        call_query(serde_json::json!({ "q": "x", "filter": { "status": "open", "limit": 5 } }))
+            .await;
+    assert_eq!(echoed["filter"]["status"], "open");
+    assert_eq!(echoed["filter"]["limit"], 5);
+}
+
+/// An array-of-objects query argument round-trips through the indexed form.
+#[tokio::test]
+async fn array_of_objects_query_argument_round_trips() {
+    let echoed = call_query(serde_json::json!({
+        "q": "x",
+        "items": [ { "sku": "A-1", "qty": 2 }, { "sku": "B-2", "qty": 3 } ]
+    }))
+    .await;
+    assert_eq!(echoed["items"][0]["sku"], "A-1");
+    assert_eq!(echoed["items"][0]["qty"], 2);
+    assert_eq!(echoed["items"][1]["sku"], "B-2");
+    assert_eq!(echoed["items"][1]["qty"], 3);
+}
+
+/// An explicit JSON `null` for an optional field means "absent", not the
+/// literal four-character string `null` (which coerced to a 400).
+#[tokio::test]
+async fn null_query_argument_is_omitted_rather_than_stringified() {
+    let echoed = call_query(serde_json::json!({ "q": "x", "page": null })).await;
+    assert!(
+        echoed["page"].is_null(),
+        "page must decode as None: {echoed}"
+    );
+    assert_eq!(echoed["q"], "x");
+}
+
+/// Scalars keep their existing flat rendering.
+#[tokio::test]
+async fn scalar_query_arguments_still_round_trip() {
+    let echoed = call_query(serde_json::json!({ "q": "hello", "page": 3 })).await;
+    assert_eq!(echoed["q"], "hello");
+    assert_eq!(echoed["page"], 3);
+}
+
+/// The advertised `inputSchema` exposes the nested field structure — the tool
+/// contract the dispatch path now actually honours.
+#[tokio::test]
+async fn tool_schema_advertises_the_nested_query_structure() {
+    let out = rpc(
+        &client(),
+        serde_json::json!({"jsonrpc":"2.0","id":2,"method":"tools/list"}),
+    )
+    .await;
+    let tools = out["result"]["tools"].as_array().expect("tools array");
+    let tool = tools
+        .iter()
+        .find(|t| t["name"] == "structured_search")
+        .expect("tool present");
+    let schema = &tool["inputSchema"];
+
+    // `query` resolves (possibly through `$defs`) to the real field set.
+    let query = &schema["properties"]["query"];
+    let resolved = query["$ref"]
+        .as_str()
+        .and_then(|r| r.strip_prefix("#/$defs/"))
+        .map_or(query, |name| &schema["$defs"][name]);
+    assert_eq!(resolved["type"], "object", "query schema: {schema}");
+    assert!(
+        resolved["properties"]["filter"].is_object(),
+        "nested `filter` field is advertised: {schema}"
+    );
+    assert_eq!(
+        resolved["properties"]["tags"]["oneOf"][0]["type"], "array",
+        "sequence field is advertised as an array: {schema}"
+    );
+}

--- a/autumn/tests/integration/mod.rs
+++ b/autumn/tests/integration/mod.rs
@@ -150,6 +150,8 @@ mod mcp_repository;
 mod mcp_schema_derive;
 #[cfg(feature = "mcp")]
 mod mcp_streaming;
+#[cfg(feature = "mcp")]
+mod mcp_structured_query;
 mod middleware_introspection;
 mod middleware_pipeline;
 mod middleware_stack_depth;
@@ -199,6 +201,7 @@ mod problem_details;
 #[cfg(feature = "redis")]
 mod process_role_worker_gating;
 mod query_count_asserts;
+mod query_structured;
 #[cfg(feature = "redis")]
 mod queue_dedicated_capacity;
 mod range;

--- a/autumn/tests/integration/query_structured.rs
+++ b/autumn/tests/integration/query_structured.rs
@@ -69,7 +69,7 @@ async fn absent_optionals_are_none() {
     assert!(out["filter"].is_null());
 }
 
-/// Repeated keys collect into a sequence — the OpenAPI `form`/`explode` shape
+/// Repeated keys collect into a sequence — the `OpenAPI` `form`/`explode` shape
 /// MCP dispatch already emitted but the handler could not previously decode.
 #[tokio::test]
 async fn repeated_keys_decode_into_a_sequence() {
@@ -189,9 +189,51 @@ async fn conflicting_shapes_for_one_key_are_rejected() {
 /// recursion during tree construction.
 #[tokio::test]
 async fn excessive_nesting_depth_is_rejected() {
-    let deep = "a".to_owned() + &"[x]".repeat(64);
+    let deep = "filter".to_owned() + &"[x]".repeat(64);
     let resp = client().get(&format!("/search?q=x&{deep}=1")).send().await;
     resp.assert_status(400);
+}
+
+/// A key the grammar cannot resolve poisons only that key. Junk parameters a
+/// handler never reads (ad tracking, crawler noise) stay ignorable, exactly as
+/// they were when the bracketed form was merely an unrecognised key name.
+#[tokio::test]
+async fn unresolvable_keys_the_handler_ignores_do_not_fail_the_request() {
+    let resp = client()
+        .get("/search?q=x&utm=1&utm[source]=news&junk[a][b][c][d][e][f][g][h][i][j][k][l][m][n][o][p][q]=1")
+        .send()
+        .await;
+    resp.assert_ok();
+    let out: serde_json::Value = resp.json();
+    assert_eq!(out["q"], "x");
+}
+
+/// A key submitted twice for a single-valued field fails closed rather than
+/// quietly resolving to one of the two values — the parameter-pollution
+/// hardening `serde_urlencoded` + serde's derive provided before.
+#[tokio::test]
+async fn a_duplicated_scalar_parameter_is_rejected() {
+    let resp = client().get("/search?q=first&q=second").send().await;
+    resp.assert_status(400);
+}
+
+/// A coercion failure must not echo the submitted text: the message lands in
+/// the 400 body and in every error reporter, and a query parameter can hold a
+/// secret.
+#[tokio::test]
+async fn a_failed_coercion_does_not_echo_the_value() {
+    let resp = client().get("/search?q=x&page=SUPERSECRET").send().await;
+    resp.assert_status(400);
+    let body: serde_json::Value = resp.json();
+    let rendered = body.to_string();
+    assert!(
+        !rendered.contains("SUPERSECRET"),
+        "value must not be reflected: {rendered}"
+    );
+    assert!(
+        rendered.contains("page"),
+        "the field path is still named: {rendered}"
+    );
 }
 
 /// A very large explicit index is accepted as a sparse position rather than

--- a/autumn/tests/integration/query_structured.rs
+++ b/autumn/tests/integration/query_structured.rs
@@ -1,0 +1,208 @@
+//! Structured `Query<T>` decoding — sequences and nested objects (issue #1972).
+//!
+//! Before this, `Query<T>` delegated to `axum::extract::Query` →
+//! `serde_urlencoded`, which is strictly flat: a `Vec<String>` field fed
+//! `?tags=a&tags=b` failed with `invalid type: string "a", expected a
+//! sequence`, and a nested struct field was unrepresentable by *any* encoding.
+//! That made the MCP tool contract unhonorable — `tools/call` dispatch renders
+//! an array query argument as repeated keys, which the handler then rejected.
+//!
+//! These tests pin the decoding contract end to end, through the real
+//! extractor, for both the shapes that already worked (flat scalars — parity)
+//! and the shapes that did not (sequences, nested objects, arrays of objects).
+
+use autumn_web::prelude::*;
+use autumn_web::test::{TestApp, TestClient};
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Default)]
+struct Filter {
+    status: String,
+    limit: Option<u32>,
+}
+
+#[derive(Serialize, Deserialize)]
+struct Item {
+    sku: String,
+    qty: u32,
+}
+
+#[derive(Serialize, Deserialize, Default)]
+struct SearchArgs {
+    q: String,
+    page: Option<u32>,
+    tags: Option<Vec<String>>,
+    filter: Option<Filter>,
+    items: Option<Vec<Item>>,
+}
+
+#[get("/search")]
+async fn search(Query(args): Query<SearchArgs>) -> AutumnResult<Json<SearchArgs>> {
+    Ok(Json(args))
+}
+
+fn client() -> TestClient {
+    TestApp::new().routes(routes![search]).build()
+}
+
+/// Parity: the flat scalar shape `serde_urlencoded` already handled must decode
+/// exactly as before — string passthrough plus integer coercion from text.
+#[tokio::test]
+async fn flat_scalars_still_decode() {
+    let resp = client().get("/search?q=foo&page=2").send().await;
+    resp.assert_ok();
+    let out: serde_json::Value = resp.json();
+    assert_eq!(out["q"], "foo");
+    assert_eq!(out["page"], 2);
+    assert!(out["tags"].is_null(), "absent field stays None: {out}");
+}
+
+/// An absent optional field is `None`, and an entirely empty query string is
+/// still a valid decode for an all-defaultable struct.
+#[tokio::test]
+async fn absent_optionals_are_none() {
+    let resp = client().get("/search?q=").send().await;
+    resp.assert_ok();
+    let out: serde_json::Value = resp.json();
+    assert_eq!(out["q"], "");
+    assert!(out["page"].is_null());
+    assert!(out["filter"].is_null());
+}
+
+/// Repeated keys collect into a sequence — the OpenAPI `form`/`explode` shape
+/// MCP dispatch already emitted but the handler could not previously decode.
+#[tokio::test]
+async fn repeated_keys_decode_into_a_sequence() {
+    let resp = client().get("/search?q=x&tags=a&tags=b").send().await;
+    resp.assert_ok();
+    let out: serde_json::Value = resp.json();
+    assert_eq!(out["tags"], serde_json::json!(["a", "b"]));
+}
+
+/// A single repeated-key occurrence is still a one-element sequence, so a
+/// client need not know the arity up front.
+#[tokio::test]
+async fn single_occurrence_decodes_into_a_one_element_sequence() {
+    let resp = client().get("/search?q=x&tags=only").send().await;
+    resp.assert_ok();
+    let out: serde_json::Value = resp.json();
+    assert_eq!(out["tags"], serde_json::json!(["only"]));
+}
+
+/// The explicit empty-bracket append form (`tags[]=a&tags[]=b`).
+#[tokio::test]
+async fn empty_bracket_append_form_decodes_into_a_sequence() {
+    let resp = client().get("/search?q=x&tags[]=a&tags[]=b").send().await;
+    resp.assert_ok();
+    let out: serde_json::Value = resp.json();
+    assert_eq!(out["tags"], serde_json::json!(["a", "b"]));
+}
+
+/// Explicit indices, including out-of-order and gapped ones, decode in
+/// ascending index order — the same compaction `nested_form` applies to
+/// `items[0]` / `items[2]` after client-side row removal.
+#[tokio::test]
+async fn indexed_form_decodes_in_ascending_index_order() {
+    let resp = client().get("/search?q=x&tags[2]=c&tags[0]=a").send().await;
+    resp.assert_ok();
+    let out: serde_json::Value = resp.json();
+    assert_eq!(out["tags"], serde_json::json!(["a", "c"]));
+}
+
+/// A nested object field decodes from the bracketed form — the shape the issue
+/// reports as unrepresentable, which forced builders onto JSON-in-a-string.
+#[tokio::test]
+async fn nested_object_field_decodes() {
+    let resp = client()
+        .get("/search?q=x&filter[status]=open&filter[limit]=5")
+        .send()
+        .await;
+    resp.assert_ok();
+    let out: serde_json::Value = resp.json();
+    assert_eq!(out["filter"]["status"], "open");
+    assert_eq!(out["filter"]["limit"], 5);
+}
+
+/// An array of objects uses the same `items[i][field]` wire format the
+/// `NestedChangesetForm` has always used, so the framework speaks one dialect.
+#[tokio::test]
+async fn array_of_objects_decodes() {
+    let resp = client()
+        .get("/search?q=x&items[0][sku]=A-1&items[0][qty]=2&items[1][sku]=B-2&items[1][qty]=3")
+        .send()
+        .await;
+    resp.assert_ok();
+    let out: serde_json::Value = resp.json();
+    assert_eq!(out["items"][0]["sku"], "A-1");
+    assert_eq!(out["items"][0]["qty"], 2);
+    assert_eq!(out["items"][1]["sku"], "B-2");
+    assert_eq!(out["items"][1]["qty"], 3);
+}
+
+/// Percent-encoded brackets are the same wire form: `form_urlencoded` decodes
+/// `%5B`/`%5D` before the path is parsed, so a client that encodes them (as
+/// `serde_urlencoded::to_string` does) round-trips identically.
+#[tokio::test]
+async fn percent_encoded_brackets_are_equivalent() {
+    let resp = client()
+        .get("/search?q=x&filter%5Bstatus%5D=open")
+        .send()
+        .await;
+    resp.assert_ok();
+    let out: serde_json::Value = resp.json();
+    assert_eq!(out["filter"]["status"], "open");
+}
+
+/// A malformed bracket key is not a parse failure: it stays a literal key, and
+/// an unknown literal key is ignored like any other unknown query parameter.
+#[tokio::test]
+async fn malformed_bracket_keys_stay_literal_and_are_ignored() {
+    let resp = client().get("/search?q=x&weird[unclosed=1").send().await;
+    resp.assert_ok();
+    let out: serde_json::Value = resp.json();
+    assert_eq!(out["q"], "x");
+}
+
+/// A value that cannot coerce to the field's type is still a 400 with the
+/// Problem Details contract — the pre-existing behaviour for `?page=nope`.
+#[tokio::test]
+async fn scalar_coercion_failure_is_a_problem_details_400() {
+    let resp = client().get("/search?q=x&page=not-a-number").send().await;
+    resp.assert_status(400);
+    resp.assert_header_contains("content-type", "application/problem+json");
+    let out: serde_json::Value = resp.json();
+    assert_eq!(out["code"], "autumn.bad_request");
+}
+
+/// A shape conflict (the same key used as both a scalar and a container) is a
+/// deterministic 400 rather than a silent last-write-wins.
+#[tokio::test]
+async fn conflicting_shapes_for_one_key_are_rejected() {
+    let resp = client()
+        .get("/search?q=x&filter=flat&filter[status]=open")
+        .send()
+        .await;
+    resp.assert_status(400);
+}
+
+/// Nesting is depth-capped so a hostile query string cannot drive unbounded
+/// recursion during tree construction.
+#[tokio::test]
+async fn excessive_nesting_depth_is_rejected() {
+    let deep = "a".to_owned() + &"[x]".repeat(64);
+    let resp = client().get(&format!("/search?q=x&{deep}=1")).send().await;
+    resp.assert_status(400);
+}
+
+/// A very large explicit index is accepted as a sparse position rather than
+/// preallocating: indices key an ordered map, never a `Vec` of that length.
+#[tokio::test]
+async fn huge_indices_do_not_preallocate() {
+    let resp = client()
+        .get("/search?q=x&tags[4000000000]=late&tags[1]=early")
+        .send()
+        .await;
+    resp.assert_ok();
+    let out: serde_json::Value = resp.json();
+    assert_eq!(out["tags"], serde_json::json!(["early", "late"]));
+}

--- a/docs/guide/mcp.md
+++ b/docs/guide/mcp.md
@@ -125,33 +125,42 @@ The per-tool `inputSchema` is generated from the request types via the `OpenApiS
 ### Structured query arguments round-trip
 
 A `Query<T>` field does **not** have to be a scalar. `Query<T>` decodes a
-superset of the flat `key=value` form — the same bracketed dialect
-`NestedChangesetForm` uses for `has_many` rows — and `tools/call` dispatch
-renders the tool's `query` object into exactly that wire format:
+superset of the flat `key=value` form — a bracketed dialect whose
+`items[0][sku]` shape matches the rows `NestedChangesetForm` renders,
+generalized to arbitrary objects, sequences and depths — and `tools/call`
+dispatch renders the tool's `query` object into exactly that format:
 
-| Tool argument | Dispatched query string | Handler field |
+| Tool argument | Decoded query keys | Handler field |
 | --- | --- | --- |
 | `{"page": 2}` | `page=2` | `u32` |
 | `{"tags": ["a","b"]}` | `tags=a&tags=b` | `Vec<String>` |
 | `{"filter": {"status":"open"}}` | `filter[status]=open` | a nested struct |
 | `{"items": [{"sku":"A"}]}` | `items[0][sku]=A` | `Vec<Item>` |
 
+(The keys are percent-encoded on the wire — `filter%5Bstatus%5D=open` — and
+decoded before the brackets are parsed, so the two forms are equivalent.)
+
 So an agent can pass structured arguments directly, instead of the
 comma-separated strings and JSON-in-a-string fields the flat form used to
-force. Three details are worth knowing:
+force. What the encoding cannot carry, dispatch **refuses** rather than quietly
+altering:
 
-- A JSON `null` renders **no** query parameter at all — a query string has no
-  null, so an explicitly-null optional argument arrives as absent (`None`)
-  rather than as the literal text `null`.
-- An **empty** array or object likewise renders no parameter, so a field that
-  must distinguish "empty" from "absent" belongs in a JSON body.
-- Nesting is capped at 16 levels on both the encode and decode side.
+- A `null` **field** renders no query parameter — a query string has no null, so
+  an explicitly-null optional argument arrives as absent (`None`) rather than as
+  the literal text `null`. That is the one silent conversion, and it matches
+  what the caller meant.
+- An **empty** array or object, a `null` **array element**, and an object field
+  name that is empty or contains `[` / `]` are all invalid-params errors: each
+  would otherwise vanish a field, shorten a sequence, or invent a nesting level.
+  A field that must distinguish "empty" from "absent" belongs in a JSON body.
+- Nesting is depth-capped (`autumn_web::query_string::MAX_DEPTH`) and one call's
+  query expansion is bounded, on both the encode and decode side.
 
 For genuinely large or deeply structured input, a JSON body (`Json<T>`) is
 still the better contract: it round-trips losslessly through the tool's `body`
 property and carries real JSON types rather than coerced text.
 
-### Build-time warnings
+### Build-time warning
 
 When assembling `/mcp`, Autumn emits a build-time `tracing::warn` for a tool
 whose `query` or `body` resolves to a bare `{"type":"object"}` placeholder —
@@ -159,7 +168,7 @@ the arg type has no `OpenApiSchema`, so its fields aren't advertised. Fix it by
 deriving (`#[derive(OpenApiSchema)]`) or implementing `OpenApiSchema` on the
 arg type.
 
-These are warnings, not errors: the app still builds and the tool is still
+It is a warning, not an error: the app still builds and the tool is still
 exposed.
 
 ### Safety annotations

--- a/docs/guide/mcp.md
+++ b/docs/guide/mcp.md
@@ -120,30 +120,44 @@ Because every piece comes from the same `SchemaEntry` data the OpenAPI
 generator uses, **there is no second schema to maintain** and no way for the
 tool catalog to drift from the handler.
 
-The per-tool `inputSchema` is generated from the request types via the `OpenApiSchema` derive, so there is no second schema to hand-maintain; serde `rename`s are honoured, tool identity is collision-proof, and a build-time guard warns when a nested `Query<T>` field should instead be carried as a `Json<T>` body.
+The per-tool `inputSchema` is generated from the request types via the `OpenApiSchema` derive, so there is no second schema to hand-maintain; serde `rename`s are honoured and tool identity is collision-proof.
 
-### Query is flat — put structured input in the body
+### Structured query arguments round-trip
 
-`Query<T>` deserializes with
-[`serde_urlencoded`](https://docs.rs/serde_urlencoded), which is **strictly
-flat**: it can decode scalars (`?q=foo&page=2`) and repeated keys for a
-sequence field (`?tags=a&tags=b`), but it **cannot** deserialize a nested
-struct by any encoding — not `key[sub]=`, not JSON-in-a-string. MCP `tools/call`
-dispatch honors this: query values are rendered as flat `key=value` pairs
-(arrays expand to repeated keys), so a query field that is itself an object or
-an array of objects could never round-trip back to the handler.
+A `Query<T>` field does **not** have to be a scalar. `Query<T>` decodes a
+superset of the flat `key=value` form — the same bracketed dialect
+`NestedChangesetForm` uses for `has_many` rows — and `tools/call` dispatch
+renders the tool's `query` object into exactly that wire format:
 
-So keep query parameters flat and **steer structured/nested input to a JSON
-body** (`Json<T>`), which round-trips losslessly through the tool's `body`
-property. When assembling `/mcp`, Autumn emits a build-time `tracing::warn` for
-a tool whose:
+| Tool argument | Dispatched query string | Handler field |
+| --- | --- | --- |
+| `{"page": 2}` | `page=2` | `u32` |
+| `{"tags": ["a","b"]}` | `tags=a&tags=b` | `Vec<String>` |
+| `{"filter": {"status":"open"}}` | `filter[status]=open` | a nested struct |
+| `{"items": [{"sku":"A"}]}` | `items[0][sku]=A` | `Vec<Item>` |
 
-- `query` or `body` resolves to a bare `{"type":"object"}` placeholder — the
-  arg type has no `OpenApiSchema`, so its fields aren't advertised. Fix it by
-  deriving (`#[derive(OpenApiSchema)]`) or implementing `OpenApiSchema` on the
-  arg type.
-- `query` advertises a nested object / array-of-object field — move that input
-  to a `Json<T>` body.
+So an agent can pass structured arguments directly, instead of the
+comma-separated strings and JSON-in-a-string fields the flat form used to
+force. Three details are worth knowing:
+
+- A JSON `null` renders **no** query parameter at all — a query string has no
+  null, so an explicitly-null optional argument arrives as absent (`None`)
+  rather than as the literal text `null`.
+- An **empty** array or object likewise renders no parameter, so a field that
+  must distinguish "empty" from "absent" belongs in a JSON body.
+- Nesting is capped at 16 levels on both the encode and decode side.
+
+For genuinely large or deeply structured input, a JSON body (`Json<T>`) is
+still the better contract: it round-trips losslessly through the tool's `body`
+property and carries real JSON types rather than coerced text.
+
+### Build-time warnings
+
+When assembling `/mcp`, Autumn emits a build-time `tracing::warn` for a tool
+whose `query` or `body` resolves to a bare `{"type":"object"}` placeholder —
+the arg type has no `OpenApiSchema`, so its fields aren't advertised. Fix it by
+deriving (`#[derive(OpenApiSchema)]`) or implementing `OpenApiSchema` on the
+arg type.
 
 These are warnings, not errors: the app still builds and the tool is still
 exposed.

--- a/docs/guide/openapi.md
+++ b/docs/guide/openapi.md
@@ -134,9 +134,15 @@ will not accept. None of them fails the build:
 > (`?filter[status]=open`, `?items[0][sku]=A-1`) that
 > [`query_string`](https://docs.rs/autumn-web/latest/autumn_web/query_string/)
 > defines and MCP `tools/call` dispatch emits — but OpenAPI's `form`/`explode`
-> style leaves nested values undefined, so the generated document does not spell
-> that encoding out for a third-party client. Document the bracketed form for
-> external consumers, or take deeply structured input as a JSON body.
+> style leaves composite values undefined, so the generated document does not
+> spell that encoding out for a third-party client. OAS 3.x's `deepObject` style
+> expresses one object level (`filter[status]=open`) but not an array of
+> objects, and it re-introduces the parameter name that `form`/`explode`
+> correctly drops for an exploded query struct — so Autumn emits `form`
+> unconditionally rather than a style that is right for some fields and wrong
+> for others. Document the bracketed form for external consumers, or take
+> deeply structured input as a JSON body. MCP `tools/call` dispatch is not
+> affected: it renders the bracketed form directly.
 
 > **The query parameter is always `required: false`.** That flag is emitted
 > unconditionally, whatever `T` looks like. If `T` has a non-`Option` field, a

--- a/docs/guide/openapi.md
+++ b/docs/guide/openapi.md
@@ -126,18 +126,17 @@ contributes an operation with no response body schema.
 Several places where the generated document can describe a request the handler
 will not accept. None of them fails the build:
 
-> **`Query<T>` must be flat — scalars only.** The `style: form, explode: true`
-> mapping is accurate only while every field of `T` is a scalar. `Query<T>`
-> decodes with `serde_urlencoded`, which handles neither nested objects nor
-> **sequences**: a `Vec<String>` field advertised as an array is sent by a
-> conforming client as `?tags=a&tags=b` and fails to deserialize with
-> `invalid type: string "a", expected a sequence`. Take anything but scalars as
-> a JSON body.
->
-> The MCP projection notices the nested-object case and logs a build-time
-> `tracing::warn`, but it still publishes the tool — so it appears in
-> `tools/list` and fails when an agent calls it. Neither output refuses to
-> generate; both only warn at best.
+> **`style: form, explode: true` cannot describe a nested `Query<T>` field.**
+> The mapping is exact for scalar and scalar-sequence fields: a `Vec<String>`
+> field advertised as an array is sent by a conforming client as
+> `?tags=a&tags=b`, and `Query<T>` decodes that. A **nested** field (an object,
+> or an array of objects) is decoded from the bracketed form
+> (`?filter[status]=open`, `?items[0][sku]=A-1`) that
+> [`query_string`](https://docs.rs/autumn-web/latest/autumn_web/query_string/)
+> defines and MCP `tools/call` dispatch emits — but OpenAPI's `form`/`explode`
+> style leaves nested values undefined, so the generated document does not spell
+> that encoding out for a third-party client. Document the bracketed form for
+> external consumers, or take deeply structured input as a JSON body.
 
 > **The query parameter is always `required: false`.** That flag is emitted
 > unconditionally, whatever `T` looks like. If `T` has a non-`Option` field, a

--- a/scripts/check-panic-gate.sh
+++ b/scripts/check-panic-gate.sh
@@ -89,6 +89,7 @@ REQUEST_PATH_MODULES=(
   autumn/src/form.rs:default
   autumn/src/nested_form.rs:default
   autumn/src/extract.rs:default
+  autumn/src/query_string.rs:default
   autumn/src/idempotency.rs:default
   autumn/src/time_math.rs:default
   autumn/src/mail.rs:mail
@@ -137,7 +138,7 @@ REQUEST_PATH_MODULES=(
 # cannot quietly shrink the gate's surface. It tracks the manifest's length, so
 # it moves with every addition too — otherwise a one-entry revert would shrink
 # the manifest back under the floor while the gate still passed.
-MODULE_COUNT_FLOOR=44
+MODULE_COUNT_FLOOR=45
 
 # Gated modules whose feature is KNOWINGLY not enabled by any enforcing CI clippy
 # lane, as `<path>:<feature>`. Their headers are real but unenforced: the deny

--- a/skills/autumn-web/references/api-reference.md
+++ b/skills/autumn-web/references/api-reference.md
@@ -332,6 +332,44 @@ back to the model's default order, and an invalid `dir` falls back to `asc`
 so only real columns can reach SQL (unknown sort/filter columns are ignored, not
 injected).
 
+**(unreleased)** — `Query<T>` decodes sequences and nested structures (#1972):
+the extractor no longer delegates to `serde_urlencoded`, so a query field does
+**not** have to be a scalar. A query string of unique scalar keys behaves
+exactly as before; on top of that it accepts
+
+| Wire form | Decodes into |
+| --- | --- |
+| `?tags=a&tags=b` | `Vec<String>` (repeated key) |
+| `?tags[]=a&tags[]=b` | `Vec<String>` (append form) |
+| `?tags[0]=a&tags[2]=c` | `Vec<String>` (indexed; gaps compacted) |
+| `?filter[status]=open` | a nested struct / map field |
+| `?items[0][sku]=A-1` | `Vec<Item>` |
+
+So prefer a real nested type over the comma-separated-string and
+JSON-in-a-string workarounds. This is the same bracket syntax `ListQuery`'s
+`?filter[<col>]=<val>` already used, generalized to arbitrary objects,
+sequences and depths — and it applies to the **query string only**: `Form<T>`
+still decodes bodies through `serde_urlencoded`.
+
+Behaviour worth knowing when writing handlers:
+
+- A duplicated key in a **single-valued** position is a 400 (`?q=a&q=b` against
+  a `String`), matching what serde's derive did before. A sequence field takes
+  every occurrence.
+- `[` and `]` in a key are now **structure**, so a `Query<HashMap<String,
+  String>>` that used to receive `?filter[a]=1` as the literal key
+  `"filter[a]"` now sees a nested object — give such a field a nested type, or
+  accept it as `serde_json::Value`.
+- An unrecognised key that the target never reads stays ignorable even if its
+  bracket syntax is malformed or contradictory.
+- Decode errors name the failing field path (`filter.limit: invalid u32 value`)
+  and never echo the submitted value.
+
+MCP `tools/call` dispatch renders a tool's `query` object into this same wire
+format, so a tool advertising a sequence or nested object round-trips into the
+handler's typed struct. See `docs/guide/mcp.md` and the
+`autumn_web::query_string` module docs.
+
 ## Optimistic concurrency (`#[lock_version]`)
 
 Declare a non-nullable `i32`/`i64` field named `lock_version` on a `#[model]`


### PR DESCRIPTION
Part of #1972. Part 1 was #1983 (the `#[derive(OpenApiSchema)]` derive), Part 2 was #1992 (serde-rename fidelity, collision-proof identity, flat-query guard). This is the remaining half of the issue: the builder's opening complaint that **"`Query` extraction can't express nested sequences/maps, so builders fall back to comma-separated strings and JSON-in-a-string fields."**

## The bug this also fixes

`tools/call` dispatch already expanded an array query argument to repeated keys (`tags=a&tags=b`), but `Query<T>` → `serde_urlencoded` **cannot decode repeated keys into a sequence** — it fails with `invalid type: string "a", expected a sequence`. So a tool whose derived `inputSchema` advertised `tags: array` dispatched a request its own handler answered with **400**. That is exactly the "provably the handler's typed contract" promise #1117 set and #1972 says the placeholder fallback undercuts.

(`docs/guide/mcp.md` claimed `serde_urlencoded` handled repeated keys; `autumn/src/extract.rs` correctly said it did not. The rustdoc was right.)

## What changed

**`Query<T>` now decodes a superset of the flat form** — new module `autumn/src/query_string.rs`. A query string of unique scalar keys decodes exactly as before; on top of that:

```text
tags=a&tags=b               // repeated key   → Vec<String>
tags[]=a&tags[]=b           // append form    → Vec<String>
tags[0]=a&tags[2]=c         // indexed form   → Vec<String> (gaps compacted)
filter[status]=open         // nested object  → struct field
items[0][sku]=A-1           // array of objects
```

The `items[i][field]` shape matches what `NestedChangesetForm` already renders for `has_many` rows, generalized to arbitrary objects, sequences and depths. This applies to the **query string only** — `Form<T>` still decodes bodies through `serde_urlencoded`.

**MCP dispatch renders the tool's `query` object into that same wire format**, so the advertised schema and the dispatch agree. `SchemaDegradation::NestedQuery` is removed with the limitation it warned about; the opaque-placeholder warnings stay.

## Design decision

The issue's Proposal 3 offered three options for a schema the dispatch path can't honor: document it, reject it, or flatten it. I took the fourth: **make dispatch honor it**. Rejecting would delete a tool rather than a limitation, and flattening invents a third dialect. Since Autumn owns both ends of the MCP wire, the encoding is a choice, not a constraint — so the honest fix is to pick one and implement it on both sides.

No new dependency: `url::form_urlencoded` was already a direct dep. `serde_qs` would have imported a different dialect (no repeated-key sequences) plus a supply-chain and `deny.toml` surface.

## Deliberate semantics

- **Scalar coercion matches `serde_urlencoded`** (`str::parse`), including present-but-empty `Option` visiting `Some`.
- **A duplicated key in a single-valued position is an error.** `serde_urlencoded` + serde's derive rejected `?q=a&q=b` (`duplicate field`); a map target silently took the last. Resolving parameter pollution quietly is how those bugs are built, so it is loud. Sequence fields still take every occurrence.
- **Shape conflicts poison one key, not the request.** `?utm=1&utm[source]=x` fails only if the target claims `utm`; an unrecognised parameter stays ignorable, as it was when the bracketed form was merely an unknown key name.
- **Errors never echo the submitted value.** They name the field path and expected type (`page: invalid u32 value`) — the message reaches the 400 Problem Details body and every error reporter, and a query parameter can hold a secret. Embedded key text is bounded and stripped of control characters.
- **Bounded by construction.** Nesting is depth-capped; indices key a `BTreeMap`, so `tags[4000000000]` costs one entry, not four billion. On the encode side, expansion is capped by pair count and total bytes so a wide or long-keyed tool argument cannot drive the quadratic key-prefix copying into an OOM.
- **Inexpressible arguments are refused, not altered.** An empty array or object, a `null` array element, and an object field name containing `[` / `]` are invalid-params errors — each would otherwise vanish a field, shorten a sequence, or invent a nesting level.

The module joins the request-path panic gate (`scripts/check-panic-gate.sh`, now 45 modules).

## Known gap, not closed here

For a **non-MCP** client generating from the OpenAPI document, `operation_for` still emits `style: form, explode: true`, which does not describe the bracketed encoding for a nested query field. `deepObject` is not a drop-in — it covers one object level but not an array of objects, and reintroduces the parameter name that `form`/`explode` correctly drops for an exploded query struct. Describing it properly means emitting one parameter per query-struct field, which would rewrite every generated spec. Documented in `docs/guide/openapi.md` and in the code comment; filed as a follow-up.

## Tests

TDD: the failing tests came first (9 of 14 extractor tests and 4 of 6 MCP tests failed against `trunk-dev`), then the implementation.

- `autumn/src/query_string.rs` — 26 unit tests: parity, repeated/append/indexed forms, nesting, percent-encoded brackets, malformed keys, shape conflicts, depth cap, index aliasing, duplicate rejection, value redaction, `HashMap`/`Vec<(String,String)>`/`serde_json::Value` targets, unit enums, serde renames.
- `autumn/tests/integration/query_structured.rs` — 17 end-to-end extractor tests.
- `autumn/tests/integration/mcp_structured_query.rs` — 7 `tools/list` → `tools/call` → handler round-trip tests.
- `autumn/src/mcp.rs` — encoder unit tests for the dialect, null omission, refusal cases, and the expansion bound.

Green: panic gate, determinism gate, `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace --no-run`, `cargo test --workspace --doc` (262 autumn-web doctests), plus the mcp/openapi/schema/problem-details suites (82 unit + 156 integration).

_Uses "Part of #1972" — the OpenAPI-consumer gap above is still open._

---
_Generated by [Claude Code](https://claude.ai/code/session_01Km65ZFF2DtCz3zznU6po75)_