### PR TITLE
Preserve tenant accounting domains across eviction

### DIFF
--- a/autumn/src/tenant_cell.rs
+++ b/autumn/src/tenant_cell.rs
@@ -31,7 +31,7 @@
 //! handler makes outside the cell's API are out of scope by design. This is a
 //! safe-Rust accounting cell, not a bounding allocator.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::fmt;
 use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex, RwLock, Weak};
@@ -43,6 +43,11 @@ use std::time::{Duration, Instant};
 /// scratch entries against the quota, so a tenant storing many tiny entries
 /// cannot amplify its footprint past the configured cap via map growth.
 const SCRATCH_ENTRY_OVERHEAD: usize = std::mem::size_of::<(String, Vec<u8>)>() + 16;
+
+/// Maximum lifecycle tombstones examined by one mutating registry operation.
+/// This amortizes cleanup so high-cardinality in-flight traffic cannot turn a
+/// cache miss into a scan of every live accounting domain under the write lock.
+const LIFECYCLE_SWEEP_BUDGET: usize = 16;
 
 /// Error returned when a charge would exceed a tenant's soft memory quota.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -506,6 +511,10 @@ struct RegistryInner {
 struct RegistryState {
     resident: HashMap<String, Arc<TenantCell>>,
     lifecycle: HashMap<String, Weak<TenantCellInner>>,
+    /// Non-resident lifecycle records awaiting bounded, round-robin cleanup.
+    lifecycle_candidates: VecDeque<String>,
+    /// Deduplicates `lifecycle_candidates` across repeated evictions.
+    queued_lifecycles: HashSet<String>,
 }
 
 impl fmt::Debug for TenantCellRegistry {
@@ -650,12 +659,15 @@ impl TenantCellRegistry {
         // accounting domain for the tenant.
         if let Some(inner) = state.lifecycle.get(tenant_id).and_then(Weak::upgrade) {
             let cell = Arc::new(TenantCell { inner });
-            cell.touch(self.now_millis(), self.next_seq());
+            // Use one clock sample for both the touch and TTL enforcement. A
+            // second sample could cross a millisecond boundary and immediately
+            // evict a freshly resurrected cell when the configured TTL is zero.
+            let now = self.now_millis();
+            cell.touch(now, self.next_seq());
             cell.set_quota_bytes(quota_bytes);
             state
                 .resident
                 .insert(tenant_id.to_string(), Arc::clone(&cell));
-            let now = self.now_millis();
             self.enforce_limits_locked(&mut state, now);
             return cell;
         }
@@ -698,9 +710,16 @@ impl TenantCellRegistry {
     fn enforce_limits_locked(&self, state: &mut RegistryState, now: u64) {
         if let Some(ttl) = self.inner.idle_ttl {
             let ttl_millis = u64::try_from(ttl.as_millis()).unwrap_or(u64::MAX);
-            state
+            let expired_ids: Vec<_> = state
                 .resident
-                .retain(|_, cell| now.saturating_sub(cell.last_access_millis()) <= ttl_millis);
+                .iter()
+                .filter(|(_, cell)| now.saturating_sub(cell.last_access_millis()) > ttl_millis)
+                .map(|(tenant_id, _)| tenant_id.clone())
+                .collect();
+            for tenant_id in expired_ids {
+                state.resident.remove(&tenant_id);
+                Self::enqueue_lifecycle_candidate_locked(state, tenant_id);
+            }
         }
         let max_cells = self.inner.max_cells;
         if max_cells > 0 {
@@ -719,20 +738,39 @@ impl TenantCellRegistry {
                     break;
                 };
                 state.resident.remove(&victim);
+                Self::enqueue_lifecycle_candidate_locked(state, victim);
             }
         }
-        Self::sweep_expired_lifecycles_locked(state);
+        Self::sweep_lifecycle_candidates_locked(state);
     }
 
-    /// Remove weak lifecycle records whose accounting domain has torn down.
-    /// Live records are never removed, preserving same-tenant resurrection.
-    fn sweep_expired_lifecycles_locked(state: &mut RegistryState) {
-        state.lifecycle.retain(|_, lifecycle| {
-            // No registry operation can create a new strong reference without
-            // this write lock, so a failed upgrade is permanently dead and its
-            // owned tenant-id key is safe to reclaim.
-            lifecycle.upgrade().is_some()
-        });
+    fn enqueue_lifecycle_candidate_locked(state: &mut RegistryState, tenant_id: String) {
+        if state.queued_lifecycles.insert(tenant_id.clone()) {
+            state.lifecycle_candidates.push_back(tenant_id);
+        }
+    }
+
+    /// Examine a fixed number of non-resident records. Live domains rotate to
+    /// the back; dead domains and records made resident again leave the queue.
+    fn sweep_lifecycle_candidates_locked(state: &mut RegistryState) {
+        for _ in 0..LIFECYCLE_SWEEP_BUDGET {
+            let Some(tenant_id) = state.lifecycle_candidates.pop_front() else {
+                break;
+            };
+            state.queued_lifecycles.remove(&tenant_id);
+            if state.resident.contains_key(&tenant_id) {
+                continue;
+            }
+            let alive = state
+                .lifecycle
+                .get(&tenant_id)
+                .is_some_and(|lifecycle| lifecycle.upgrade().is_some());
+            if alive {
+                Self::enqueue_lifecycle_candidate_locked(state, tenant_id);
+            } else {
+                state.lifecycle.remove(&tenant_id);
+            }
+        }
     }
 
     /// Evict `tenant_id`'s cell from the resident cache and return it.
@@ -752,8 +790,13 @@ impl TenantCellRegistry {
             .state
             .write()
             .expect("tenant cell registry lock poisoned");
-        Self::sweep_expired_lifecycles_locked(&mut state);
-        state.resident.remove(tenant_id)
+        let removed = state.resident.remove(tenant_id);
+        if removed.is_some() {
+            Self::enqueue_lifecycle_candidate_locked(&mut state, tenant_id.to_string());
+        }
+        Self::sweep_lifecycle_candidates_locked(&mut state);
+        drop(state);
+        removed
     }
 
     /// Evict every resident cell whose most recent access is older than `ttl`
@@ -780,11 +823,18 @@ impl TenantCellRegistry {
         // lock wait cannot age out a cell another thread just touched.
         let now = self.now_millis();
         let before = state.resident.len();
-        state
+        let expired_ids: Vec<_> = state
             .resident
-            .retain(|_, cell| now.saturating_sub(cell.last_access_millis()) <= ttl_millis);
+            .iter()
+            .filter(|(_, cell)| now.saturating_sub(cell.last_access_millis()) > ttl_millis)
+            .map(|(tenant_id, _)| tenant_id.clone())
+            .collect();
+        for tenant_id in expired_ids {
+            state.resident.remove(&tenant_id);
+            Self::enqueue_lifecycle_candidate_locked(&mut state, tenant_id);
+        }
         let removed = before - state.resident.len();
-        Self::sweep_expired_lifecycles_locked(&mut state);
+        Self::sweep_lifecycle_candidates_locked(&mut state);
         drop(state);
         removed
     }
@@ -819,8 +869,8 @@ impl TenantCellRegistry {
     /// Number of tenant accounting lifecycle records, including resident cells
     /// and evicted domains still owned by in-flight work.
     ///
-    /// Expired weak records are removed by the next mutating registry operation,
-    /// so this count remains bounded under churn when eviction is configured.
+    /// Expired weak records are removed incrementally by future mutating registry
+    /// operations, so cleanup work per operation remains bounded under churn.
     ///
     /// # Panics
     ///

--- a/autumn/src/tenant_cell.rs
+++ b/autumn/src/tenant_cell.rs
@@ -34,7 +34,7 @@
 use std::collections::HashMap;
 use std::fmt;
 use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
-use std::sync::{Arc, Mutex, RwLock};
+use std::sync::{Arc, Mutex, RwLock, Weak};
 use std::time::{Duration, Instant};
 
 /// Fixed bytes charged per scratch entry to cover the map's per-entry overhead:
@@ -480,7 +480,7 @@ pub struct TenantCellRegistry {
 }
 
 struct RegistryInner {
-    cells: RwLock<HashMap<String, Arc<TenantCell>>>,
+    state: RwLock<RegistryState>,
     global_tracked: Arc<AtomicUsize>,
     /// Maximum number of resident cells; least-recently-used cells are evicted
     /// once the count exceeds this. `0` disables the bound (unlimited).
@@ -496,6 +496,16 @@ struct RegistryInner {
     /// the touched cell's `last_access_seq`, giving LRU eviction a unique,
     /// tie-free ordering so the just-inserted cell is never the victim.
     seq: AtomicU64,
+}
+
+/// Registry residency and tenant accounting lifetimes deliberately have
+/// different boundaries. `resident` is the bounded scratch cache; `lifecycle`
+/// retains a weak tombstone after eviction so a later request cannot create a
+/// second accounting domain while an old request still owns the first one.
+#[derive(Default)]
+struct RegistryState {
+    resident: HashMap<String, Arc<TenantCell>>,
+    lifecycle: HashMap<String, Weak<TenantCellInner>>,
 }
 
 impl fmt::Debug for TenantCellRegistry {
@@ -529,7 +539,7 @@ impl TenantCellRegistry {
     pub fn with_limits(max_cells: usize, idle_ttl: Option<Duration>) -> Self {
         Self {
             inner: Arc::new(RegistryInner {
-                cells: RwLock::new(HashMap::new()),
+                state: RwLock::new(RegistryState::default()),
                 global_tracked: Arc::new(AtomicUsize::new(0)),
                 max_cells,
                 idle_ttl,
@@ -564,7 +574,7 @@ impl TenantCellRegistry {
     pub fn get(&self, tenant_id: &str) -> Option<Arc<TenantCell>> {
         let guard = self
             .inner
-            .cells
+            .state
             .read()
             .expect("tenant cell registry lock poisoned");
         // Refresh the access time/sequence WHILE the read guard is still held,
@@ -574,7 +584,7 @@ impl TenantCellRegistry {
         // lock wait can never stamp the cell. `touch` is relaxed atomic
         // `fetch_max` stores through the shared `&Arc<TenantCell>`, safe under
         // the read lock.
-        if let Some(cell) = guard.get(tenant_id) {
+        if let Some(cell) = guard.resident.get(tenant_id) {
             cell.touch(self.now_millis(), self.next_seq());
             return Some(Arc::clone(cell));
         }
@@ -608,10 +618,10 @@ impl TenantCellRegistry {
         {
             let guard = self
                 .inner
-                .cells
+                .state
                 .read()
                 .expect("tenant cell registry lock poisoned");
-            if let Some(cell) = guard.get(tenant_id) {
+            if let Some(cell) = guard.resident.get(tenant_id) {
                 // Capture `now` here, under the guard and immediately before the
                 // touch, so a timestamp taken before a lock wait can never stamp
                 // a fresh access time as stale.
@@ -620,20 +630,36 @@ impl TenantCellRegistry {
                 return Arc::clone(cell);
             }
         }
-        let mut cells = self
+        let mut state = self
             .inner
-            .cells
+            .state
             .write()
             .expect("tenant cell registry lock poisoned");
         // Another writer may have inserted between dropping the read lock and
         // taking the write lock.
-        if let Some(cell) = cells.get(tenant_id) {
+        if let Some(cell) = state.resident.get(tenant_id) {
             let cell = Arc::clone(cell);
             // Fresh `now` under the write guard, right before the touch.
             cell.touch(self.now_millis(), self.next_seq());
             cell.set_quota_bytes(quota_bytes);
             return cell;
         }
+        // An eviction only removes cache residency. If an in-flight request
+        // still owns the former cell, resurrect that exact cell (and therefore
+        // its quota counter and scratch map) rather than minting a second
+        // accounting domain for the tenant.
+        if let Some(inner) = state.lifecycle.get(tenant_id).and_then(Weak::upgrade) {
+            let cell = Arc::new(TenantCell { inner });
+            cell.touch(self.now_millis(), self.next_seq());
+            cell.set_quota_bytes(quota_bytes);
+            state
+                .resident
+                .insert(tenant_id.to_string(), Arc::clone(&cell));
+            let now = self.now_millis();
+            self.enforce_limits_locked(&mut state.resident, now);
+            return cell;
+        }
+        state.lifecycle.remove(tenant_id);
         let cell = Arc::new(TenantCell::new(
             tenant_id.to_string(),
             quota_bytes,
@@ -647,12 +673,17 @@ impl TenantCellRegistry {
         // Stamp the new cell's access sequence BEFORE enforcing limits, so it
         // holds the greatest sequence and is never chosen as the LRU victim.
         cell.touch(now, self.next_seq());
-        cells.insert(tenant_id.to_string(), Arc::clone(&cell));
+        state
+            .lifecycle
+            .insert(tenant_id.to_string(), Arc::downgrade(&cell.inner));
+        state
+            .resident
+            .insert(tenant_id.to_string(), Arc::clone(&cell));
         // Enforce eviction limits while we already hold the write lock. The
         // just-touched new cell has the newest access time and the greatest
         // access sequence, so it is never the idle or LRU victim.
-        self.enforce_limits_locked(&mut cells, now);
-        drop(cells);
+        self.enforce_limits_locked(&mut state.resident, now);
+        drop(state);
         cell
     }
 
@@ -688,9 +719,12 @@ impl TenantCellRegistry {
         }
     }
 
-    /// Evict `tenant_id`'s cell, removing it from the registry and returning it.
-    /// When the returned handle (and any outstanding request references) drop,
-    /// the cell's owned memory is deterministically reclaimed.
+    /// Evict `tenant_id`'s cell from the resident cache and return it.
+    ///
+    /// Teardown is deferred while this returned handle or an outstanding
+    /// request owns the cell. A weak tenant-keyed tombstone remains during that
+    /// time, and [`get_or_create`](Self::get_or_create) resurrects the same cell
+    /// rather than creating an independent quota or scratch domain.
     ///
     /// # Panics
     ///
@@ -698,9 +732,10 @@ impl TenantCellRegistry {
     #[must_use = "the evicted cell is returned so it (and its memory) can be dropped"]
     pub fn evict(&self, tenant_id: &str) -> Option<Arc<TenantCell>> {
         self.inner
-            .cells
+            .state
             .write()
             .expect("tenant cell registry lock poisoned")
+            .resident
             .remove(tenant_id)
     }
 
@@ -719,17 +754,19 @@ impl TenantCellRegistry {
     #[must_use]
     pub fn evict_idle_older_than(&self, ttl: Duration) -> usize {
         let ttl_millis = u64::try_from(ttl.as_millis()).unwrap_or(u64::MAX);
-        let mut cells = self
+        let mut state = self
             .inner
-            .cells
+            .state
             .write()
             .expect("tenant cell registry lock poisoned");
         // Read the clock under the write guard, so a `now` captured before a
         // lock wait cannot age out a cell another thread just touched.
         let now = self.now_millis();
-        let before = cells.len();
-        cells.retain(|_, cell| now.saturating_sub(cell.last_access_millis()) <= ttl_millis);
-        before - cells.len()
+        let before = state.resident.len();
+        state
+            .resident
+            .retain(|_, cell| now.saturating_sub(cell.last_access_millis()) <= ttl_millis);
+        before - state.resident.len()
     }
 
     /// The configured maximum number of resident cells (`0` = unbounded).
@@ -752,9 +789,10 @@ impl TenantCellRegistry {
     #[must_use]
     pub fn len(&self) -> usize {
         self.inner
-            .cells
+            .state
             .read()
             .expect("tenant cell registry lock poisoned")
+            .resident
             .len()
     }
 

--- a/autumn/src/tenant_cell.rs
+++ b/autumn/src/tenant_cell.rs
@@ -656,7 +656,7 @@ impl TenantCellRegistry {
                 .resident
                 .insert(tenant_id.to_string(), Arc::clone(&cell));
             let now = self.now_millis();
-            self.enforce_limits_locked(&mut state.resident, now);
+            self.enforce_limits_locked(&mut state, now);
             return cell;
         }
         state.lifecycle.remove(tenant_id);
@@ -682,41 +682,57 @@ impl TenantCellRegistry {
         // Enforce eviction limits while we already hold the write lock. The
         // just-touched new cell has the newest access time and the greatest
         // access sequence, so it is never the idle or LRU victim.
-        self.enforce_limits_locked(&mut state.resident, now);
+        self.enforce_limits_locked(&mut state, now);
         drop(state);
         cell
     }
 
-    /// Evict idle and over-capacity cells from an already write-locked map.
+    /// Evict idle and over-capacity cells and sweep expired lifecycle records
+    /// from already write-locked registry state.
     ///
-    /// Must be called while holding the `cells` write lock; it never re-locks,
+    /// Must be called while holding the `state` write lock; it never re-locks,
     /// so it is safe to invoke from inside [`get_or_create`]'s miss branch.
     /// Removal is a plain `HashMap::remove`, which drops only the registry's
     /// strong reference — any outstanding `Arc<TenantCell>` (e.g. one held by an
     /// in-flight request) stays valid and reclaims deterministically on drop.
-    fn enforce_limits_locked(&self, cells: &mut HashMap<String, Arc<TenantCell>>, now: u64) {
+    fn enforce_limits_locked(&self, state: &mut RegistryState, now: u64) {
         if let Some(ttl) = self.inner.idle_ttl {
             let ttl_millis = u64::try_from(ttl.as_millis()).unwrap_or(u64::MAX);
-            cells.retain(|_, cell| now.saturating_sub(cell.last_access_millis()) <= ttl_millis);
+            state
+                .resident
+                .retain(|_, cell| now.saturating_sub(cell.last_access_millis()) <= ttl_millis);
         }
         let max_cells = self.inner.max_cells;
         if max_cells > 0 {
-            while cells.len() > max_cells {
+            while state.resident.len() > max_cells {
                 // Evict the least-recently-used cell, chosen by the smallest
                 // access *sequence*. The sequence is globally unique and
                 // monotonic, so there are no ties (unlike millisecond
                 // timestamps) and the just-inserted cell — which drew the
                 // greatest sequence above — is never the victim.
-                let Some(victim) = cells
+                let Some(victim) = state
+                    .resident
                     .iter()
                     .min_by_key(|(_, cell)| cell.last_access_seq())
                     .map(|(key, _)| key.clone())
                 else {
                     break;
                 };
-                cells.remove(&victim);
+                state.resident.remove(&victim);
             }
         }
+        Self::sweep_expired_lifecycles_locked(state);
+    }
+
+    /// Remove weak lifecycle records whose accounting domain has torn down.
+    /// Live records are never removed, preserving same-tenant resurrection.
+    fn sweep_expired_lifecycles_locked(state: &mut RegistryState) {
+        state.lifecycle.retain(|_, lifecycle| {
+            // No registry operation can create a new strong reference without
+            // this write lock, so a failed upgrade is permanently dead and its
+            // owned tenant-id key is safe to reclaim.
+            lifecycle.upgrade().is_some()
+        });
     }
 
     /// Evict `tenant_id`'s cell from the resident cache and return it.
@@ -731,12 +747,13 @@ impl TenantCellRegistry {
     /// Panics if the registry lock is poisoned.
     #[must_use = "the evicted cell is returned so it (and its memory) can be dropped"]
     pub fn evict(&self, tenant_id: &str) -> Option<Arc<TenantCell>> {
-        self.inner
+        let mut state = self
+            .inner
             .state
             .write()
-            .expect("tenant cell registry lock poisoned")
-            .resident
-            .remove(tenant_id)
+            .expect("tenant cell registry lock poisoned");
+        Self::sweep_expired_lifecycles_locked(&mut state);
+        state.resident.remove(tenant_id)
     }
 
     /// Evict every resident cell whose most recent access is older than `ttl`
@@ -766,7 +783,10 @@ impl TenantCellRegistry {
         state
             .resident
             .retain(|_, cell| now.saturating_sub(cell.last_access_millis()) <= ttl_millis);
-        before - state.resident.len()
+        let removed = before - state.resident.len();
+        Self::sweep_expired_lifecycles_locked(&mut state);
+        drop(state);
+        removed
     }
 
     /// The configured maximum number of resident cells (`0` = unbounded).
@@ -796,13 +816,34 @@ impl TenantCellRegistry {
             .len()
     }
 
+    /// Number of tenant accounting lifecycle records, including resident cells
+    /// and evicted domains still owned by in-flight work.
+    ///
+    /// Expired weak records are removed by the next mutating registry operation,
+    /// so this count remains bounded under churn when eviction is configured.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the registry lock is poisoned.
+    #[must_use]
+    pub fn accounting_domain_count(&self) -> usize {
+        self.inner
+            .state
+            .read()
+            .expect("tenant cell registry lock poisoned")
+            .lifecycle
+            .len()
+    }
+
     /// Whether the registry holds no cells.
     #[must_use]
     pub fn is_empty(&self) -> bool {
         self.len() == 0
     }
 
-    /// Total bytes tracked across every resident cell.
+    /// Total bytes tracked across every live accounting domain, whether its
+    /// cell is resident or temporarily held only by in-flight work after
+    /// eviction.
     #[must_use]
     pub fn total_tracked_bytes(&self) -> usize {
         self.inner.global_tracked.load(Ordering::Relaxed)

--- a/autumn/tests/integration/tenant_cell_unit.rs
+++ b/autumn/tests/integration/tenant_cell_unit.rs
@@ -187,6 +187,35 @@ fn eviction_does_not_split_a_live_tenant_accounting_domain() {
     assert_eq!(registry.total_tracked_bytes(), 0);
 }
 
+/// Dead weak lifecycle tombstones must not turn a bounded resident cache into
+/// an unbounded tenant-id string cache under one-off, request-controlled IDs.
+#[test]
+fn eviction_sweeps_expired_lifecycle_tombstones_under_churn() {
+    let registry = TenantCellRegistry::with_limits(1, None);
+
+    for i in 0..1_000 {
+        let cell = registry.get_or_create(&format!("one-off-{i}"), 1_000);
+        drop(cell);
+        assert_eq!(registry.len(), 1);
+        assert_eq!(
+            registry.accounting_domain_count(),
+            1,
+            "capacity enforcement must discard dead tenant lifecycle keys"
+        );
+    }
+
+    // A live evicted domain is preserved, then swept only after its last handle
+    // drops and the next mutation gives the registry an opportunity to prune.
+    let live = registry.get_or_create("live", 1_000);
+    let evicted = registry.evict("live").expect("live tenant was resident");
+    assert!(registry.accounting_domain_count() >= 1);
+    drop(live);
+    drop(evicted);
+    let next = registry.get_or_create("next", 1_000);
+    drop(next);
+    assert_eq!(registry.accounting_domain_count(), 1);
+}
+
 /// Density smoke test: 1000 concurrent cells each holding a small buffer track
 /// exactly, and evicting all of them reclaims everything.
 #[test]

--- a/autumn/tests/integration/tenant_cell_unit.rs
+++ b/autumn/tests/integration/tenant_cell_unit.rs
@@ -147,6 +147,46 @@ fn eviction_reclaims_to_zero() {
     );
 }
 
+/// Eviction ends cache residency, not the tenant's accounting lifetime. An
+/// in-flight owner forces a subsequent lookup to rejoin the same quota counter
+/// and scratch domain until every owner has gone away.
+#[test]
+fn eviction_does_not_split_a_live_tenant_accounting_domain() {
+    let registry = TenantCellRegistry::new();
+    let old = registry.get_or_create("t", 1_000);
+    old.scratch_insert("shared", vec![7; 100])
+        .expect("initial scratch allocation fits");
+    let initial = old.tracked_bytes();
+    let old_charge = old.try_charge(600).expect("initial charge fits");
+    let in_flight = Arc::clone(&old);
+
+    let evicted = registry.evict("t").expect("tenant was resident");
+    assert_eq!(registry.len(), 0, "eviction removes cache residency");
+
+    let replacement = registry.get_or_create("t", 1_000);
+    assert_eq!(
+        replacement.scratch_get("shared"),
+        Some(vec![7; 100]),
+        "the replacement must use the still-live scratch domain"
+    );
+    let remaining = 1_000 - initial - old_charge.bytes();
+    replacement
+        .try_charge(remaining + 1)
+        .expect_err("old and new requests share one aggregate tenant quota");
+    assert_eq!(replacement.tracked_bytes(), initial + 600);
+
+    drop(old_charge);
+    drop(old);
+    drop(in_flight);
+    drop(evicted);
+    let final_resident = registry
+        .evict("t")
+        .expect("resurrected cell remains resident until explicitly evicted");
+    drop(replacement);
+    drop(final_resident);
+    assert_eq!(registry.total_tracked_bytes(), 0);
+}
+
 /// Density smoke test: 1000 concurrent cells each holding a small buffer track
 /// exactly, and evicting all of them reclaims everything.
 #[test]

--- a/autumn/tests/integration/tenant_cell_unit.rs
+++ b/autumn/tests/integration/tenant_cell_unit.rs
@@ -216,6 +216,43 @@ fn eviction_sweeps_expired_lifecycle_tombstones_under_churn() {
     assert_eq!(registry.accounting_domain_count(), 1);
 }
 
+/// Lifecycle cleanup is amortized: many simultaneously-live evicted domains
+/// are retained, then reclaimed in bounded batches after their owners drop.
+#[test]
+fn lifecycle_tombstones_are_swept_incrementally() {
+    let registry = TenantCellRegistry::with_limits(1, None);
+    let mut in_flight = Vec::new();
+    for i in 0..100 {
+        in_flight.push(registry.get_or_create(&format!("stream-{i}"), 1_000));
+    }
+    assert_eq!(registry.accounting_domain_count(), 100);
+
+    drop(in_flight);
+    // Each mutation examines a fixed-size batch. Seven batches are enough for
+    // the 99 non-resident candidates; the final resident domain remains.
+    for _ in 0..7 {
+        assert!(registry.evict("not-present").is_none());
+    }
+    assert_eq!(registry.accounting_domain_count(), 1);
+}
+
+/// A resurrected cell must use one timestamp for touching and TTL enforcement,
+/// otherwise a millisecond rollover can immediately evict it at a zero TTL.
+#[test]
+fn resurrection_with_zero_idle_ttl_remains_resident() {
+    let registry = TenantCellRegistry::with_limits(0, Some(Duration::ZERO));
+    let original = registry.get_or_create("t", 1_000);
+    let evicted = registry.evict("t").expect("tenant was resident");
+
+    let resurrected = registry.get_or_create("t", 1_000);
+    assert_eq!(registry.len(), 1);
+    assert!(registry.get("t").is_some());
+
+    drop(original);
+    drop(evicted);
+    drop(resurrected);
+}
+
 /// Density smoke test: 1000 concurrent cells each holding a small buffer track
 /// exactly, and evicting all of them reclaims everything.
 #[test]

--- a/docs/guide/tenant-cells.md
+++ b/docs/guide/tenant-cells.md
@@ -131,7 +131,8 @@ async fn stash() -> AutumnResult<&'static str> {
 
         // Removing frees only the key + value capacity back to the quota; the
         // fixed per-entry overhead is retained (against the entry high-water
-        // mark) until the cell is evicted.
+        // mark) until the accounting domain is no longer resident and its last
+        // request/eviction handle drops.
         let _ = cell.scratch_remove("draft");
     }
     Ok("ok")
@@ -158,32 +159,45 @@ the memory it owns, not every byte a handler touches on the way there.
 ## Eviction and lifecycle
 
 Cells live in a process-wide `TenantCellRegistry` shared by every clone of the
-app state. Two properties matter operationally:
+app state. Three properties matter operationally:
 
 - **Lazy creation.** Binding a request to a tenant does not allocate a cell;
   the first call to `current_tenant_cell()` (internally a registry
   `get_or_create`) materializes it. Routes that never touch tenant memory leave
   the registry untouched.
-- **Deterministic eviction.** `TenantCellRegistry::evict(tenant_id)` removes
-  the tenant's cell from the registry and returns it; once that handle and any
-  outstanding request references drop, the cell's owned memory (scratch buffer
-  and all) is reclaimed, and its tracked bytes leave the process-wide gauge.
-  This is ordinary Rust `Drop`, not a background sweep — reclaim is immediate
-  and predictable.
+- **Residency eviction with deferred teardown.**
+  `TenantCellRegistry::evict(tenant_id)` removes the tenant's cell from the
+  resident cache and returns it. Eviction does not create permission for a
+  second accounting domain: while the returned handle, an outstanding request,
+  or a live `Charge` still owns the old domain, a subsequent `get_or_create` for
+  that tenant resurrects the same quota counter and scratch map and makes it
+  resident again. The scratch contents therefore remain visible to that
+  subsequent request, and its charges aggregate with the earlier request's
+  charges under one tenant quota.
+
+  Teardown occurs only after the domain is no longer resident and its final
+  strong owner drops. At that point the scratch buffer is reclaimed and its
+  tracked bytes leave the process-wide gauge through ordinary Rust `Drop`, not
+  a background reclamation task. If an operator needs to purge a tenant's
+  scratch state, traffic for that tenant must first quiesce; then call `evict`
+  and drop its returned handle after all outstanding request/charge handles have
+  completed. A request arriving before teardown prevents the purge by
+  resurrecting and re-residenting the existing domain.
 - **Automatic eviction.** With `max_cells` or `idle_ttl_secs` set (see
   [Configuration](#configuration)), the registry evicts on its own — LRU cells
   above the cap, and cells idle past the TTL — enforced lazily on cell insert.
-  Automatic eviction reclaims memory exactly like the manual `evict` above: it
-  drops only the registry's strong reference, so the same deterministic `Drop`
-  applies and an in-flight holder is never disturbed.
+  Automatic eviction has the same residency-versus-lifecycle semantics as
+  manual `evict`: it drops only the resident-cache reference, so an in-flight
+  holder is never disturbed and a same-tenant request arriving before teardown
+  reuses and re-residents the domain.
 
 Eviction is safe to do mid-request. Each in-flight request caches the cell it
-first materialized, so evicting a tenant while one of its requests is running
-does **not** reset that request's state or hand it a fresh empty cell: the
-running request keeps its own cached `Arc` and its stable cell to completion,
-its memory reclaiming on drop, and the eviction takes effect for subsequent
-requests. The registry also exposes `len()`, `is_empty()`, and
-`total_tracked_bytes()` for observability.
+first materialized, so eviction does **not** reset that request's state. It also
+does not hand a subsequent request a fresh empty cell while the old domain is
+alive: both requests share its scratch state and aggregate quota. `len()` and
+`is_empty()` report resident-cache membership, `accounting_domain_count()` also
+includes evicted domains retained by in-flight work, and
+`total_tracked_bytes()` covers every live domain regardless of residency.
 
 **Dynamic quota.** A cell's `quota_bytes` is stored atomically rather than
 frozen at creation. Every access refreshes a resident cell's quota from the
@@ -204,15 +218,17 @@ refresh simply re-applies the same configured value.
 - a fixed per-entry overhead, exposed as
   `TenantCell::scratch_entry_overhead()`, charged against the **high-water mark**
   of live scratch entries (not the current count), so that a tenant storing many
-  tiny entries cannot amplify its footprint past the cap via map growth. Because a
-  `HashMap` never shrinks its bucket array on removal, this overhead is *retained*
-  after a `scratch_remove` (which frees only the removed key and value capacity)
-  and is reclaimed only when the cell is dropped on eviction. So `tracked_bytes()`
-  can stay elevated after you insert then remove scratch entries, and re-inserting
-  within the prior peak adds no new overhead (churn-safe).
+  tiny entries cannot amplify its footprint past the cap via map growth. Because
+  a `HashMap` never shrinks its bucket array on removal, this overhead is
+  *retained* after a `scratch_remove` (which frees only the removed key and value
+  capacity) and is reclaimed only when the evicted accounting domain's final
+  owner drops. So `tracked_bytes()` can stay elevated after you insert then
+  remove scratch entries, and re-inserting within the prior peak adds no new
+  overhead (churn-safe).
 
-Everything tracked is deterministically reclaimed when the cell is dropped on
-eviction. What it is **not**: a measurement of the tenant's true process RSS.
+Everything tracked is deterministically reclaimed when a non-resident
+accounting domain's final owner drops. What it is **not**: a measurement of the
+tenant's true process RSS.
 Allocator-internal fragmentation, size-class rounding, and any allocation a
 handler makes *outside* the cell's API (a bare `Box::new`, a `Vec` you build
 and never charge) are invisible to the counter by design. Charge through the

--- a/docs/guide/tenant-cells.md
+++ b/docs/guide/tenant-cells.md
@@ -196,8 +196,9 @@ first materialized, so eviction does **not** reset that request's state. It also
 does not hand a subsequent request a fresh empty cell while the old domain is
 alive: both requests share its scratch state and aggregate quota. `len()` and
 `is_empty()` report resident-cache membership, `accounting_domain_count()` also
-includes evicted domains retained by in-flight work, and
-`total_tracked_bytes()` covers every live domain regardless of residency.
+includes evicted domains retained by in-flight work (plus dead tombstones
+awaiting bounded incremental cleanup), and `total_tracked_bytes()` covers every
+live domain regardless of residency.
 
 **Dynamic quota.** A cell's `quota_bytes` is stored atomically rather than
 frozen at creation. Every access refreshes a resident cell's quota from the


### PR DESCRIPTION
### Motivation

- Prevent a new request from creating a fresh tenant accounting/scratch domain while an evicted cell for the same tenant remains live, so quota and scratch state remain a single logical domain until all handles drop.
- Separate cache residency (bounded scratch cache) from the tenant accounting lifecycle so eviction only removes cache residency and teardown is deferred while outstanding strong references exist.

### Description

- Introduced `RegistryState` with `resident: HashMap<String, Arc<TenantCell>>` and `lifecycle: HashMap<String, Weak<TenantCellInner>>` and replaced the old `cells` lock with `state: RwLock<RegistryState>` to separate residency from lifecycle.
- Updated `get_or_create` to check `lifecycle` and `Weak::upgrade` and, when an evicted-but-still-live `TenantCellInner` exists, resurrect and re-stamp the same accounting domain (refresh quota and re-insert into `resident`) instead of creating an independent domain.
- Adjusted explicit `evict`, `evict_idle_older_than`, `enforce_limits_locked`, `get`, and `len` to operate on `state.resident` and document that explicit eviction removes residency while teardown is deferred until all strong handles drop (a weak tombstone remains in `lifecycle`).
- Added an integration test `eviction_does_not_split_a_live_tenant_accounting_domain` under `autumn/tests/integration/tenant_cell_unit.rs` that charges a tenant, retains an in-flight `Arc`, evicts the tenant, requests it again and verifies that the old and new requests share a single quota/accounting domain and that global tracked bytes return to zero after all handles are dropped.

### Testing

- Ran `cargo fmt --all -- --check` and formatting passed.
- Ran the integration unit tests with `cargo test -p autumn-web --test integration_tests tenant_cell_unit -- --nocapture` and the suite completed successfully (22 tests passed, 0 failed). 
- Ran `cargo clippy -p autumn-web --lib -- -D warnings` which is blocked by a pre-existing `clippy::similar_names` warning in `autumn-macros/src/repository.rs` that is unrelated to these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a87342e17e4832ab85d9bc3d6c68657)