### PR TITLE
Orchestrate zero-downtime autumn deploy across a server fleet (#1621)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   serving throughout. One release id per run, and **migrations run exactly
   once** — on the first host still on a previous release, before its cutover;
   every other host skips them, and an all-first-deploy fleet migrates nowhere and
-  says so, naming `autumn migrate`. A failure **halts** the rollout (the
+  says so, naming `autumn migrate`. **List already-deployed hosts first when you
+  scale up**: the migration lands on the first host still on a previous release,
+  so a *new* host listed ahead of it cuts over with no migrate step and serves the
+  new release against the old schema until the rollout reaches the migrating host
+  — the rollout names that hazard and the hosts it affects up front rather than
+  silently resequencing a list whose order is the documented contract. A failure
+  **halts** the rollout (the
   remaining hosts are never touched) and, by default, compensates the hosts that
   already cut over in reverse rollout order — rolling each back to its previous
   release, or removing a just-completed first deploy — best-effort-continue and
@@ -38,9 +44,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   before any remote command runs — a `sqlite://` database (N independent files),
   `[media.mediamtx]` (no teardown path), and `[deploy.tls]` (terminate TLS at the
   load balancer that fronts the fleet) — and `[database] auto_migrate` on a fleet
-  is a loud warning. The preflight grades **every** targeted host before any host
-  is touched, and `autumn doctor` grades the same list. See
-  `docs/guide/fleet-deploys.md`.
+  is a loud warning, as are the per-process background-work defaults
+  (`[jobs] backend = "local"`, `[scheduler] backend = "in_process"`), which are
+  correct on one host and become N independent queues and N cron timers on a
+  fleet. The preflight grades **every** targeted host before any host is touched,
+  and `autumn doctor` grades the same list. Note that no host is ever *drained*
+  for the rollout's sake — a host's `/ready` never goes `503` and it is never
+  removed from your load balancer's pool; each host is replaced in place by its
+  own kamal-proxy flipping loopback slots. See `docs/guide/fleet-deploys.md`.
 
 - **`autumn deploy status` — read-only fleet state and drift (#1621):** one row
   per configured host in rollout order — mode, deployed release (from the
@@ -69,15 +80,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `/ready` stays `200` by design, so a maintained host keeps taking traffic and
   answers it with `503`. See `docs/guide/maintenance-mode.md`.
 
-- **`autumn deploy` hardening that also applies to a single host (#1621):** the
-  deploy now refuses a **release-directory collision** — the release id has
-  one-second granularity, so a fast re-run could re-upload into the directory
-  `shared/previous-release` still points at and make a later rollback roll
-  *forward* — and refuses equally when the probe cannot prove the directory is
-  absent. Every `ssh`/`scp` invocation also carries `ConnectTimeout=10`,
+- **`autumn deploy` hardening that also applies to a single host (#1621):** a
+  one-entry `hosts` list behaves exactly like `host`, but a single-host deploy is
+  *not* unchanged from the previous release — these apply to every deploy,
+  whatever the host count. The deploy now refuses a **release-directory
+  collision** — the release id has one-second granularity, so a fast re-run could
+  re-upload into the directory `shared/previous-release` still points at and make
+  a later rollback roll *forward* — and refuses equally when the probe cannot
+  prove the directory is absent; concretely, a re-run of `autumn deploy up`
+  inside the same second now exits non-zero where it previously proceeded, at the
+  cost of one extra read-only round-trip before anything is mutated. Every
+  `ssh`/`scp` invocation also carries `ConnectTimeout=10`,
   `ServerAliveInterval=15` and `ServerAliveCountMax=4`, so a host that accepts
   TCP and then wedges produces a finite error instead of hanging the deploy
-  forever. See `docs/guide/deployment.md`.
+  forever. Slot units now carry
+  `Environment=AUTUMN_MAINTENANCE_FLAG_FILE={app_dir}/shared/autumn-maintenance.json`,
+  so an active maintenance flag survives a cutover instead of being orphaned by
+  it — which also means the **local** `autumn maintenance on`, run on a
+  deploy-managed host, writes a path the app no longer reads: use
+  `autumn deploy maintenance` there. Three smaller changes complete the list: the
+  ops that complete a cutover append an advisory fragment recording a
+  `shared/last-deploy` marker naming the action that completed (what
+  `deploy status` reads, and it can never fail the op it rides on); the existing
+  `detect-current` probe resolves the `current`
+  symlink in the same round-trip via one extra delimited section; and the "no
+  target host configured" hint now names `[deploy] hosts` alongside
+  `[deploy] host`. See `docs/guide/deployment.md`.
 
 - **`autumn generate webhook` for signed, replay-safe provider intake
   (#1366):** the `SignedWebhook` substrate has shipped since 0.4.0, but every

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Multi-server fleet deploys — `[deploy] hosts` (#1621):** list several
   SSH-reachable servers under `[deploy] hosts` (mutually exclusive with the
   single-server `[deploy] host`; also `AUTUMN_DEPLOY__HOSTS` as CSV) and the same
-  `autumn deploy up` becomes a **rolling deploy across the fleet**. The list
+  `autumn deploy up` becomes a **rolling deploy across the fleet**. Either env
+  spelling, set non-empty, now **clears the other spelling from `autumn.toml`**,
+  so the documented env-over-TOML precedence retargets a single-host project as a
+  fleet (or a fleet project at one server) instead of tripping the
+  mutual-exclusion refusal; setting *both* env spellings non-empty is still
+  refused as an ambiguous rollout order, and an empty or blank value still means
+  *unset* and leaves the TOML spelling alone. The list
   order *is* the rollout order: hosts are replaced strictly one at a time, each
   running the unchanged per-host blue/green cutover against its own kamal-proxy
   and finishing before the next is started, so the rest of the fleet keeps
@@ -60,11 +66,39 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (per-host marker damage that will fail that host's *next* deploy closed: a
   `live-slot` marker disagreeing with the running proxy, an unreadable
   `shared/proxy-options`, a proxy bound to a different public port than
-  `[server] port`). It mutates nothing, so it is safe mid-incident; an
-  unreachable host is a row, not an abort, and a host whose release cannot be
-  read is reported as unknown and explicitly **not** counted as drift. `--strict`
-  exits non-zero on any drift so it is alertable from cron; `--json` emits a
-  stable report. See `docs/guide/fleet-deploys.md`.
+  `[server] port`, no release deployed while the rest of the fleet serves one,
+  and a `current` symlink that resolves to no readable release). It mutates
+  nothing, so it is safe mid-incident; an unreachable host is a row, not an
+  abort, and a host whose release cannot be read is reported as unknown and
+  explicitly **not** counted as *version* drift — though a reachable host that
+  proved it has a `current` symlink and still resolves to nothing readable is
+  state drift, so `--strict` exits non-zero on it. The **maintenance column
+  reports the flag file that host's *running* slot unit polls**, resolved on the
+  host from that unit's `Environment=AUTUMN_MAINTENANCE_FLAG_FILE` (falling back
+  to its `WorkingDirectory` plus the legacy relative
+  `tmp/autumn-maintenance.json`) rather than reading the shared path
+  unconditionally — which would report `off` for a maintained host whose unit
+  polls elsewhere and `ON` for a host still taking traffic. It is therefore
+  three-valued: `maintenance ON` / `maintenance off` / `maintenance ?`, the last
+  when the live slot unit could not be read at all, which is never rendered as a
+  confident `off`. Two matching state-drift reasons come with it — an unreadable
+  live slot unit, and a host whose app polls a release-local maintenance flag
+  instead of the shared one (a unit predating that override; the remedy is to
+  redeploy it), so a host deployed before this feature reports its release-local
+  flag until it is redeployed. The column states which file the running unit
+  polls and whether that file exists — not the app's in-memory state, which
+  follows on its own 500 ms poll. `--strict` exits non-zero on any drift so it is
+  alertable from cron; `--json` emits a stable report, in which `maintenance` is
+  correspondingly `true` / `false` / `null` (`null` = which file that host's unit
+  polls could not be proved) — both `false` and `null` stay falsy, so an existing
+  `maintenance == true` check is unaffected. Unlike `deploy check`, `up` and
+  `rollback`, `status` does **not** abort when the application config fails to
+  validate under the deploy profile: it needs only `[server] port`, so it prints
+  a caveat on stderr (in `--json` mode too, leaving stdout's shape untouched)
+  naming the config error and the declared port it probes against, and reports
+  the fleet anyway. The state-changing commands still refuse — they grade and
+  upload runtime values, so an invalid config must stop them. See
+  `docs/guide/fleet-deploys.md`.
 
 - **`autumn deploy maintenance on|off` — fleet-wide maintenance over SSH
   (#1621):** turns [maintenance mode](docs/guide/maintenance-mode.md) on or off

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,10 +106,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `autumn maintenance on` (`--message`, `--allow-ips`, `--readonly`,
   `--bypass-header`) and the same wire format, so running apps react within their
   500 ms poll with no restart and no deploy — unlike the local command, which
-  only writes the machine it runs on. Best-effort-and-aggregate: every host is
-  attempted, the per-host table names what changed, the command exits non-zero if
-  any host failed, and the hosts that *did* change are deliberately not reversed
-  (that would reopen the window being closed). Every surface repeats the rule
+  only writes the machine it runs on. The authoritative shared flag
+  (`{app_dir}/shared/autumn-maintenance.json`) is written first; for a host whose
+  slot unit predates that override, the file *that unit* polls is written too,
+  resolved from the host's **live slot unit** — the slot the proxy is serving —
+  and never from the `current` symlink, which is rewritten after the proxy flip
+  and so can name a release nothing is running. Best-effort-and-aggregate: every
+  host is attempted, the per-host table names what changed, and the hosts that
+  *did* change are deliberately not reversed (that would reopen the window being
+  closed) — the "Changed anyway" line lists only the fully-changed ones. The
+  command exits non-zero if any host failed, and it **fails closed on a partial
+  change**: a host whose shared flag was written but whose running unit's own
+  file was not (its unit could not be read, or that write failed) renders a
+  `PARTIAL` row and counts as a failure, so `on` never claims a host is
+  maintained when it could not prove which file that host polls, and `off` never
+  claims to have removed one. A host with no promoted release is the one
+  shared-flag-only case, and it is a success. Like `deploy status`, the fan-out
+  keeps running when the app config fails to validate under the deploy profile —
+  same stderr caveat, then the declared `[server] port` read without validation,
+  used only to identify which slot unit each host runs. Every surface repeats the rule
   that matters: **maintenance does not drain a host from a load balancer** —
   `/ready` stays `200` by design, so a maintained host keeps taking traffic and
   answers it with `503`. See `docs/guide/maintenance-mode.md`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   release) is reported with the exact by-hand recovery command instead of being
   guessed at. Compensation and `autumn deploy rollback` restore **binaries only**
   — a migration that already ran is never rolled back, which is stated on every
-  surface that can reach that state. `--only <HOST>` (repeatable) narrows `up` or
+  surface that can reach that state. The closing `Fleet state:` summary states it
+  in whichever of three tenses is TRUE, gated on the **migration** having been
+  reached rather than on whether the fleet compensated: a host still on the new
+  release gets the forward-looking `the schema has moved …` note; a fleet that
+  actually *restored* a host or *removed* a just-completed first deploy gets `the
+  compensating rollback restored BINARIES only …` (a compensation that merely
+  **failed** no longer claims this — that host is still serving the new release,
+  so it takes the forward-looking note instead, and both notes appear together
+  when a halt compensated some hosts and left others forward); and the case that
+  previously printed **nothing at all** — no host forward and nothing to
+  compensate, because the migrating host itself failed after `migrate` but before
+  its cutover and tore its own candidate down — now gets its own `no host is
+  serving the new release, but the migration that already ran was NOT rolled back
+  …` note. An all-first-deploy fleet schedules no migration and stays silent, so
+  the summary never contradicts the prologue's "run `autumn migrate` yourself".
+  (A failed *single-host* deploy still renders no summary and so still says
+  nothing about a migration that already ran — tracked as #2276.)
+  `--only <HOST>` (repeatable) narrows `up` or
   `rollback` to a subset as a repair lever, warning loudly every time that the
   fleet may end up mixed; `--no-rollback` halts and freezes for inspection
   instead. `autumn deploy rollback` rolls the whole fleet back newest-first and
@@ -54,7 +71,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (`[jobs] backend = "local"`, `[scheduler] backend = "in_process"`), which are
   correct on one host and become N independent queues and N cron timers on a
   fleet. The preflight grades **every** targeted host before any host is touched,
-  and `autumn doctor` grades the same list. Note that no host is ever *drained*
+  and `autumn doctor` grades the same list; it is also the fail-fast boundary that
+  `up`, `check` and `rollback` all abort on, so it now **fails closed on a fleet
+  with no entries at all** (#2274) — returning the same `no target host
+  configured` `ssh_reachability` failure the single-host path uses, rather than
+  zero checks, which would read as "0 failed" and walk the run past the gate into
+  a panic downstream. Note that no host is ever *drained*
   for the rollout's sake — a host's `/ready` never goes `503` and it is never
   removed from your load balancer's pool; each host is replaced in place by its
   own kamal-proxy flipping loopback slots. See `docs/guide/fleet-deploys.md`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,76 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Multi-server fleet deploys — `[deploy] hosts` (#1621):** list several
+  SSH-reachable servers under `[deploy] hosts` (mutually exclusive with the
+  single-server `[deploy] host`; also `AUTUMN_DEPLOY__HOSTS` as CSV) and the same
+  `autumn deploy up` becomes a **rolling deploy across the fleet**. The list
+  order *is* the rollout order: hosts are replaced strictly one at a time, each
+  running the unchanged per-host blue/green cutover against its own kamal-proxy
+  and finishing before the next is started, so the rest of the fleet keeps
+  serving throughout. One release id per run, and **migrations run exactly
+  once** — on the first host still on a previous release, before its cutover;
+  every other host skips them, and an all-first-deploy fleet migrates nowhere and
+  says so, naming `autumn migrate`. A failure **halts** the rollout (the
+  remaining hosts are never touched) and, by default, compensates the hosts that
+  already cut over in reverse rollout order — rolling each back to its previous
+  release, or removing a just-completed first deploy — best-effort-continue and
+  never silently: post-cutover *housekeeping* failures (`record-proxy-options`,
+  `drain-old`, `prune`) leave the host live and healthy, so the rollout warns and
+  keeps going, while a host whose rollback target is in doubt (markers left
+  mid-transaction, a missing or unverifiable target dir, no recorded previous
+  release) is reported with the exact by-hand recovery command instead of being
+  guessed at. Compensation and `autumn deploy rollback` restore **binaries only**
+  — a migration that already ran is never rolled back, which is stated on every
+  surface that can reach that state. `--only <HOST>` (repeatable) narrows `up` or
+  `rollback` to a subset as a repair lever, warning loudly every time that the
+  fleet may end up mixed; `--no-rollback` halts and freezes for inspection
+  instead. `autumn deploy rollback` rolls the whole fleet back newest-first and
+  exits non-zero unless every host came back. Fleet-unsafe topologies fail closed
+  before any remote command runs — a `sqlite://` database (N independent files),
+  `[media.mediamtx]` (no teardown path), and `[deploy.tls]` (terminate TLS at the
+  load balancer that fronts the fleet) — and `[database] auto_migrate` on a fleet
+  is a loud warning. The preflight grades **every** targeted host before any host
+  is touched, and `autumn doctor` grades the same list. See
+  `docs/guide/fleet-deploys.md`.
+
+- **`autumn deploy status` — read-only fleet state and drift (#1621):** one row
+  per configured host in rollout order — mode, deployed release (from the
+  `current` symlink), live slot, `/ready` status, maintenance flag and proxy port
+  — plus **version drift** (hosts on different releases) and **state drift**
+  (per-host marker damage that will fail that host's *next* deploy closed: a
+  `live-slot` marker disagreeing with the running proxy, an unreadable
+  `shared/proxy-options`, a proxy bound to a different public port than
+  `[server] port`). It mutates nothing, so it is safe mid-incident; an
+  unreachable host is a row, not an abort, and a host whose release cannot be
+  read is reported as unknown and explicitly **not** counted as drift. `--strict`
+  exits non-zero on any drift so it is alertable from cron; `--json` emits a
+  stable report. See `docs/guide/fleet-deploys.md`.
+
+- **`autumn deploy maintenance on|off` — fleet-wide maintenance over SSH
+  (#1621):** turns [maintenance mode](docs/guide/maintenance-mode.md) on or off
+  on every deploy-configured host, with the same flags as the local
+  `autumn maintenance on` (`--message`, `--allow-ips`, `--readonly`,
+  `--bypass-header`) and the same wire format, so running apps react within their
+  500 ms poll with no restart and no deploy — unlike the local command, which
+  only writes the machine it runs on. Best-effort-and-aggregate: every host is
+  attempted, the per-host table names what changed, the command exits non-zero if
+  any host failed, and the hosts that *did* change are deliberately not reversed
+  (that would reopen the window being closed). Every surface repeats the rule
+  that matters: **maintenance does not drain a host from a load balancer** —
+  `/ready` stays `200` by design, so a maintained host keeps taking traffic and
+  answers it with `503`. See `docs/guide/maintenance-mode.md`.
+
+- **`autumn deploy` hardening that also applies to a single host (#1621):** the
+  deploy now refuses a **release-directory collision** — the release id has
+  one-second granularity, so a fast re-run could re-upload into the directory
+  `shared/previous-release` still points at and make a later rollback roll
+  *forward* — and refuses equally when the probe cannot prove the directory is
+  absent. Every `ssh`/`scp` invocation also carries `ConnectTimeout=10`,
+  `ServerAliveInterval=15` and `ServerAliveCountMax=4`, so a host that accepts
+  TCP and then wedges produces a finite error instead of hanging the deploy
+  forever. See `docs/guide/deployment.md`.
+
 - **`autumn generate webhook` for signed, replay-safe provider intake
   (#1366):** the `SignedWebhook` substrate has shipped since 0.4.0, but every
   Stripe/GitHub/Slack integration still hand-rolled the route, the endpoint
@@ -178,6 +248,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   now documented in `docs/guide/security-posture-manifest.md` (#1627).
 
 ### Fixed
+
+- **deploy:** a cutover no longer orphans an active maintenance flag. The
+  maintenance flag path is now resolved through the new
+  `AUTUMN_MAINTENANCE_FLAG_FILE` environment variable (falling back to the
+  historical cwd-relative `tmp/autumn-maintenance.json` when unset, so a
+  non-deploy-managed app is unaffected), and `autumn deploy` stamps it into every
+  slot unit it writes, pointing at the per-app `shared/` directory. A slot unit's
+  `WorkingDirectory` is the *release* directory — new on every deploy — so on the
+  cwd-relative path a cutover silently un-maintained the host, and the blue and
+  green slots could not see each other's flag at all. Both read sites (the boot
+  load and the 500 ms poller) go through the same resolver. See
+  `docs/guide/maintenance-mode.md` (#1621).
 
 - **security:** `#[secured]`'s roles and scopes are no longer lost when another
   guard wraps the handler body. With `#[secured("admin")]` written above

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,7 +101,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `autumn deploy maintenance` there. Three smaller changes complete the list: the
   ops that complete a cutover append an advisory fragment recording a
   `shared/last-deploy` marker naming the action that completed (what
-  `deploy status` reads, and it can never fail the op it rides on); the existing
+  `deploy status` reads, and it can never fail the op it rides on — a
+  compensated first-deploy teardown records `torn down`, so a host with nothing
+  installed never reads back as deployed); the existing
   `detect-current` probe resolves the `current`
   symlink in the same round-trip via one extra delimited section; and the "no
   target host configured" hint now names `[deploy] hosts` alongside

--- a/README.md
+++ b/README.md
@@ -243,6 +243,7 @@ See [EXAMPLES.md](EXAMPLES.md) for the full catalog with personas, journeys, pre
 - [One-Off Tasks](docs/guide/tasks.md) - `#[task]`, `one_off_tasks![]`, and `autumn task`
 - [Embedded Clustering](docs/guide/clustering.md) — zero-dependency two-node clustering: `[cluster]` config, authenticated gossip membership, the cluster-wide CRDT counter via `ClusterHandle`, and the `cluster:membership` health indicator
 - [Multi-Replica Scheduled Tasks](docs/guide/scheduled-multi-replica.md) - `#[scheduled]` with Postgres advisory-lock coordination
+- [Fleet Deploys](docs/guide/fleet-deploys.md) — `[deploy] hosts`: `autumn deploy up` rolls a release across several VPS hosts one at a time (per-host blue/green, migrations exactly once, halt-and-roll-back on failure), plus `deploy status` drift detection, fleet maintenance, and the load-balancer contract
 - [Data-Retention Sweeps](docs/guide/retention-sweeps.md) — `retention(...)` on `#[repository(...)]`: batched, soft-delete-aware, fleet-coordinated auto-purge, plus `autumn retention --dry-run`
 - [Horizontal Sharding](docs/guide/sharding.md) — `[[database.shards]]`, slot-based routing, `ShardedDb`/`Shards` extractors, per-shard health and migrations
 - [Per-Tenant Memory Cells](docs/guide/tenant-cells.md) — `TenantCell` byte accounting with the `tenancy.quota_bytes` soft quota and deterministic per-tenant eviction

--- a/autumn-cli/src/deploy.rs
+++ b/autumn-cli/src/deploy.rs
@@ -91,6 +91,30 @@ pub enum DeployError {
     /// rarest path is the right trade.
     #[error("{0}")]
     FleetHalted(Box<FleetHalt>),
+
+    /// A fleet-wide `deploy rollback` did not restore every host (issue #1621).
+    ///
+    /// Unlike [`Self::FleetHalted`] this is not a partial-state report: a fleet
+    /// rollback is **best-effort-continue**, so every host was attempted and the
+    /// per-host table printed above it is the detail. Two counts are all this
+    /// carries — never a host-specific string built from a driver error.
+    ///
+    /// Returned when ANY host was left un-rolled-back — its rollback failed, or it
+    /// had no previous release to return to. Partial success is failure here: the
+    /// contract is that the FLEET returns to its previous release, and a fleet where
+    /// one host could not follow the others is mixed.
+    #[error(
+        "fleet rollback incomplete: {not_rolled_back} of {total} host(s) were not rolled back \
+         — see the per-host table above. A host with no previous release recorded cannot be \
+         rolled back; deploy the intended release to it explicitly, or retry one host with \
+         `autumn deploy rollback --only <host>`"
+    )]
+    FleetRollbackFailed {
+        /// Hosts left un-rolled-back (failed, or nothing to roll back to).
+        not_rolled_back: usize,
+        /// Hosts attempted.
+        total: usize,
+    },
 }
 
 /// The partial-fleet state a halted rollout leaves behind (issue #1621, AC-3).
@@ -139,6 +163,31 @@ pub enum DeployAction {
     Rollback,
     /// Run the preflight, then perform a REAL first deploy over SSH.
     Up,
+}
+
+/// Flags that modify a [`DeployAction`] (issue #1621, plan §3.1).
+///
+/// Carried **beside** the action rather than inside it: [`DeployAction`] is a
+/// fieldless `Copy` enum matched 1:1 by `run_deploy_command`, and giving its
+/// variants payloads would ripple into every call site and test for no gain. This
+/// struct is also the natural home for the later fleet flags (`--json`,
+/// `--strict`, the maintenance verb) and, in Phase 2, `--role` — so it derives
+/// [`Default`] and every construction site outside the CLI uses
+/// `..DeployOptions::default()`, making each addition a non-event.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct DeployOptions {
+    /// Restrict the command to these hosts, a subset of `[deploy] hosts` (the
+    /// repeatable `--only`). Empty means the whole configured fleet.
+    ///
+    /// A **repair lever, not a convenience**: narrowing a rollout is how an
+    /// operator ends up with a mixed fleet on purpose, so the CLI says so out
+    /// loud whenever this excludes a configured host.
+    pub only: Vec<String>,
+    /// Halt and FREEZE a failed rollout instead of compensating it (`--no-rollback`).
+    ///
+    /// The hosts that already cut over are left exactly as they are for
+    /// inspection, and named in the state table. See [`FleetUpInput::auto_rollback`].
+    pub no_rollback: bool,
 }
 
 /// A `[deploy]` section with all defaults resolved to concrete values.
@@ -392,6 +441,56 @@ fn deploy_host_list(cfg: &DeployConfig) -> Result<Vec<String>, String> {
     }
 
     Ok(hosts)
+}
+
+/// Narrow the configured host list to the `--only` selection (issue #1621, §3.2)
+/// — **pure**, so the refusal lands before any config is even resolved.
+///
+/// Rules:
+///
+/// - An empty selection is the whole fleet (the default, and the only shape a
+///   single-host config ever sees).
+/// - The result keeps **declaration order**, not the order the flags were typed:
+///   `[deploy] hosts` order IS the rollout order, and letting `--only c --only a`
+///   reverse it would silently invert a rolling deploy.
+/// - An unknown name is a hard error that quotes the name and lists the configured
+///   hosts. Guessing (prefix match, DNS resolution) would let a typo deploy the
+///   wrong machine, and silently deploying nothing would be worse still.
+/// - A repeated name selects that host once.
+///
+/// # Errors
+///
+/// Returns a message naming the unmatched entry and listing the configured hosts.
+fn select_hosts(configured: &[String], only: &[String]) -> Result<Vec<String>, String> {
+    if only.is_empty() {
+        return Ok(configured.to_vec());
+    }
+
+    for wanted in only {
+        let wanted = wanted.trim();
+        if !configured.iter().any(|host| host == wanted) {
+            let known = if configured.is_empty() {
+                "none — set `[deploy] hosts` in autumn.toml first".to_owned()
+            } else {
+                configured.join(", ")
+            };
+            return Err(format!(
+                "`--only {wanted}` names a host that is not in this project's deploy \
+                 configuration. Configured hosts: {known}. `--only` selects from that list \
+                 verbatim — it never resolves or guesses a name, so a typo can't deploy the \
+                 wrong machine (#1621)"
+            ));
+        }
+    }
+
+    // Filter the CONFIGURED list rather than mapping over `only`: `[deploy] hosts`
+    // order is the rollout order, so `--only c --only a` must not reverse it. This
+    // also de-duplicates a repeated flag for free.
+    Ok(configured
+        .iter()
+        .filter(|host| only.iter().any(|wanted| wanted.trim() == host.as_str()))
+        .cloned()
+        .collect())
 }
 
 /// An ordered fleet of deploy targets, each a fully-resolved
@@ -1073,7 +1172,7 @@ pub fn build_rollback_plan(cfg: &ResolvedDeployConfig) -> Vec<DeployStep> {
 ///
 /// Returns [`DeployError::Config`] when the project config cannot be loaded and
 /// [`DeployError::PreflightFailed`] when `check` finds a failing grader.
-pub fn run(action: DeployAction) -> Result<(), DeployError> {
+pub fn run(action: DeployAction, options: &DeployOptions) -> Result<(), DeployError> {
     // Ambient load (the operator's shell profile, `dev` by default): used ONLY to
     // read `[deploy]` and compute `resolved` — in particular `resolved.profile`,
     // the profile the deployed service will actually boot under (default `prod`).
@@ -1094,6 +1193,15 @@ pub fn run(action: DeployAction) -> Result<(), DeployError> {
     // `ResolvedFleet` lands in a later slice, so the single-host paths below are
     // deliberately untouched.
     let host_list = deploy_host_list(&deploy_cfg).map_err(DeployError::Config)?;
+    // #1621: `--only` narrows the rollout to a subset of that list, in DECLARATION
+    // order. Resolved here — before the config is even resolved and long before any
+    // preflight probe — so a typo'd host name costs nothing and names itself.
+    let targets = select_hosts(&host_list, &options.only).map_err(DeployError::Config)?;
+    // A narrowed rollout is a deliberate repair lever that leaves the fleet on two
+    // versions, so it is never silent.
+    for line in fleet::only_selection_warning_lines(&host_list, &targets) {
+        eprintln!("{line}");
+    }
     let resolved = ResolvedDeployConfig::resolve(&deploy_cfg, &resolve_project_name())
         .map_err(DeployError::Config)?;
 
@@ -1117,15 +1225,19 @@ pub fn run(action: DeployAction) -> Result<(), DeployError> {
         // deploy profile — not the operator's ambient/dev config. Reload here.
         // `check`/`rollback` deliberately do NOT load the media config.
         DeployAction::Check => run_check(&load_runtime_config(&resolved)?, &resolved),
-        DeployAction::Rollback => run_rollback(&load_runtime_config(&resolved)?, &resolved),
+        DeployAction::Rollback => {
+            run_rollback(&load_runtime_config(&resolved)?, &resolved, &targets)
+        }
         DeployAction::Up => {
             let (media_cfg, ffmpeg_bin) = load_media_host_config(&resolved)?;
             run_up(
                 &load_runtime_config(&resolved)?,
                 &resolved,
-                &host_list,
+                &targets,
+                host_list.len(),
                 &media_cfg,
                 &ffmpeg_bin,
+                options,
             )
         }
     }
@@ -2094,6 +2206,130 @@ fn refuse_unprovable_proxy_options(marker: &exec::ProxyOptionsMarker) -> Result<
     }
 }
 
+// ── Fleet-wide fail-closed refusals (issue #1621, §4.8) ──────────────────────
+//
+// All three are **pure predicates over the CONFIGURED host count**, evaluated in
+// the rollout prologue before a single remote command runs, and all three are
+// gated on `configured > 1` rather than on the number of hosts this run happens to
+// touch: `--only` narrows a rollout, it does not change the topology that makes
+// these unsafe. Each names the config key and the tracking issue, matching the
+// house style of `reject_sqlite_sharding_topology` (`migrate.rs`).
+
+/// Refuse a multi-host deploy backed by `SQLite` (issue #1621, §4.8).
+///
+/// `build_env_file` ships a byte-identical `AUTUMN_DATABASE__URL` to every host, so
+/// a `sqlite://` URL means N independent database FILES — one per machine. There is
+/// no advisory lock across them, "migrate exactly once" degenerates to "migrated on
+/// exactly one host's database", and every host serves a different dataset behind
+/// the same load balancer. That is data-destroying by construction, not a
+/// performance footgun, so it fails closed.
+fn refuse_sqlite_fleet(configured_hosts: usize, writable_db_sqlite: bool) -> Result<(), String> {
+    if configured_hosts > 1 && writable_db_sqlite {
+        return Err(
+            "\u{2717} A multi-host deploy cannot run on SQLite. `[deploy] hosts` lists more \
+             than one server and the configured `[database]` URL is a sqlite:// target, but \
+             every host receives the SAME database URL — which means N independent database \
+             FILES, one per machine: no shared schema, no advisory lock to serialize \
+             migrations, and each host serving a different dataset behind your load \
+             balancer. Point `[database] url` at a Postgres server every host can reach, or \
+             deploy a single host with `[deploy] host`. Tracking: #1621."
+                .to_owned(),
+        );
+    }
+    Ok(())
+}
+
+/// Refuse a multi-host deploy with `[media.mediamtx] enabled` (issue #1621, §4.8).
+///
+/// `provision_media_host` runs after the cutover and has **no** teardown or
+/// rollback path by design. Fanning it out would give N `MediaMTX` daemons on
+/// identical ports with divergent recording sets, and nothing to undo them with
+/// when the app rollout is compensated.
+fn refuse_media_fleet(configured_hosts: usize, media_enabled: bool) -> Result<(), String> {
+    if configured_hosts > 1 && media_enabled {
+        return Err(
+            "\u{2717} A multi-host deploy cannot provision MediaMTX. `[deploy] hosts` lists \
+             more than one server and `[media.mediamtx] enabled = true`, but host media \
+             provisioning has no teardown or rollback path: fanning it out would leave one \
+             MediaMTX daemon per host on identical ports, with divergent recording sets and \
+             nothing to undo them with when the app rollout is rolled back. Deploy media on \
+             a single host with `[deploy] host`, or set `[media.mediamtx] enabled = false` \
+             and provision the media host separately. Tracking: #1621."
+                .to_owned(),
+        );
+    }
+    Ok(())
+}
+
+/// Refuse a multi-host deploy with `[deploy.tls] enabled` (issue #1621, §4.8).
+///
+/// kamal-proxy is PER HOST — it binds that host's public port; it is not a fleet
+/// load balancer. N hosts would each attempt ACME for the same `[deploy.tls] host`
+/// from behind the operator's load balancer, only one can answer a given challenge,
+/// and the rest burn Let's Encrypt failed-validation and duplicate-certificate rate
+/// limits. Behind a load balancer, TLS terminates at the load balancer.
+fn refuse_tls_fleet(configured_hosts: usize, tls_enabled: bool) -> Result<(), String> {
+    if configured_hosts > 1 && tls_enabled {
+        return Err(
+            "\u{2717} A multi-host deploy cannot terminate TLS per host. `[deploy] hosts` \
+             lists more than one server and `[deploy.tls] enabled = true`, but the \
+             deploy-managed proxy runs on EVERY host: each one would request a certificate \
+             for the same `[deploy.tls] host` from behind your load balancer, only one can \
+             answer a given ACME challenge, and the rest burn Let's Encrypt \
+             failed-validation and duplicate-certificate rate limits. Terminate TLS at the \
+             load balancer that fronts the fleet and set `[deploy.tls] enabled = false`. \
+             Tracking: #1621."
+                .to_owned(),
+        );
+    }
+    Ok(())
+}
+
+/// The loud line printed when a fleet deploys an app that auto-applies migrations
+/// at boot (issue #1621, §4.8).
+///
+/// A **warning, not a refusal**: it is a real hazard but not a certainty, and
+/// making it a refusal (or a preflight grader) would break existing single-host
+/// users' scale-up and force a doctor-parity change for a rule the rollout itself
+/// does not depend on.
+const FLEET_AUTO_MIGRATE_WARNING: &str = "`[database] auto_migrate` is on and this deploy targets more than one host: every \
+     host applies migrations at boot, so the hosts RACE each other during the rollout \
+     and a checksum mismatch exits the process under `Restart=on-failure` — a crash \
+     loop mid-rollout. Turn it off for fleets and let the rollout's single `migrate` \
+     step own the schema (#1621).";
+
+/// Whether the fleet must be warned about boot-time auto-migration (issue #1621,
+/// §4.8) — pure.
+///
+/// `auto_migrate` supersedes the `auto_migrate_in_production` back-compat alias
+/// (`auto_migrate` wins when set), mirroring the runtime's own resolution. The
+/// alias is honoured without checking the profile: a deploy defaults to `prod`, and
+/// under-warning about a crash loop is worse than over-warning.
+fn fleet_auto_migrate_warning(
+    configured_hosts: usize,
+    auto_migrate: Option<bool>,
+    auto_migrate_in_production: bool,
+) -> Option<&'static str> {
+    let enabled = auto_migrate.unwrap_or(auto_migrate_in_production);
+    (configured_hosts > 1 && enabled).then_some(FLEET_AUTO_MIGRATE_WARNING)
+}
+
+/// Whether the resolved writable database URL names a `SQLite` backend (issue
+/// #1621, §4.8).
+///
+/// Resolves the same URL the deploy would SHIP to every host
+/// ([`resolve_writable_db_url`]) and reduces it to one bool **here**, so the URL —
+/// which carries credentials — never enters the rollout driver's inputs, its
+/// errors, or its output.
+fn writable_db_is_sqlite(db: &autumn_web::config::DatabaseConfig) -> bool {
+    resolve_writable_db_url(db).is_some_and(|url| {
+        matches!(
+            autumn_web::config::DatabaseBackend::detect(url),
+            Some(autumn_web::config::DatabaseBackend::Sqlite)
+        )
+    })
+}
+
 /// Perform a real deploy of the whole configured fleet (issue #1607, Slices 1–3;
 /// issue #1621).
 ///
@@ -2112,8 +2348,10 @@ fn run_up(
     config: &AutumnConfig,
     resolved: &ResolvedDeployConfig,
     hosts: &[String],
+    configured_host_count: usize,
     media_cfg: &media::MediaMtxHostConfig,
     ffmpeg_bin: &str,
+    options: &DeployOptions,
 ) -> Result<(), DeployError> {
     eprintln!("\u{1F342} autumn deploy up\n");
 
@@ -2167,10 +2405,19 @@ fn run_up(
             public_port,
             media_cfg,
             ffmpeg_bin,
-            writable_db_configured: resolve_writable_db_url(&config.database).is_some(),
+            configured_host_count,
+            // Every fact is reduced to a bool HERE so the database URL (credentials
+            // and all) never reaches the driver, its errors, or its output.
+            db: FleetDatabaseFacts {
+                writable_configured: resolve_writable_db_url(&config.database).is_some(),
+                sqlite: writable_db_is_sqlite(&config.database),
+                auto_migrate: config.database.auto_migrate,
+                auto_migrate_in_production: config.database.auto_migrate_in_production,
+            },
             // AC-3's default: a halted rollout compensates the hosts that already
-            // cut over rather than leaving the fleet on two versions.
-            auto_rollback: true,
+            // cut over rather than leaving the fleet on two versions. `--no-rollback`
+            // is halt-and-freeze: stop, report, change nothing else.
+            auto_rollback: !options.no_rollback,
         },
         // Host presence is guaranteed by the passing ssh_reachability grader above,
         // so this `None` arm is unreachable in practice; it keeps the pre-#1621
@@ -2181,6 +2428,28 @@ fn run_up(
                 .ok_or_else(|| DeployError::Config(DEPLOY_HOST_MISSING_DETAIL.to_owned()))
         },
     )
+}
+
+/// What this project's `[database]` config means for a fleet rollout (issue #1621,
+/// §4.8).
+///
+/// Grouped rather than passed as loose flags because they answer ONE question
+/// together — "what happens to the schema during this rollout?" — and because of
+/// what is deliberately absent: the database URL itself. It carries credentials, so
+/// every fact here is reduced to a bool at the point the URL is resolved, and the
+/// rollout driver, its errors and its output can never quote it.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+struct FleetDatabaseFacts {
+    /// Whether a writable database URL is configured at all — the fleet warns
+    /// loudly when it is and the rollout schedules no migration.
+    writable_configured: bool,
+    /// Whether that URL names a `SQLite` backend (the §4.8 refusal).
+    sqlite: bool,
+    /// `[database] auto_migrate`, verbatim (the §4.8 warning).
+    auto_migrate: Option<bool>,
+    /// `[database] auto_migrate_in_production` — the back-compat alias
+    /// `auto_migrate` supersedes.
+    auto_migrate_in_production: bool,
 }
 
 /// Everything the fleet rollout loop needs, already resolved by [`run_up`].
@@ -2213,9 +2482,23 @@ struct FleetUpInput<'a, P: ProxyController> {
     media_cfg: &'a media::MediaMtxHostConfig,
     /// Resolved `FFmpeg` binary path for the media preflight.
     ffmpeg_bin: &'a str,
-    /// Whether a writable database URL is configured — the fleet warns loudly when
-    /// it is and the rollout schedules no migration at all.
-    writable_db_configured: bool,
+    /// How many hosts the CONFIG declares, before `--only` narrowed `fleet`
+    /// (issue #1621, §3.2/§4.8).
+    ///
+    /// Two things turn on this rather than on `fleet.hosts.len()`:
+    ///
+    /// - The §4.8 refusals describe a TOPOLOGY (one `SQLite` file per machine, N
+    ///   `MediaMTX` daemons, N ACME clients racing for one certificate). Deploying
+    ///   a subset of that topology does not make it safe, so `--only` must not be a
+    ///   way to sneak past them.
+    /// - The byte-identical single-host path (AC-1) is for a config that declares
+    ///   ONE host — not for a three-host fleet narrowed to one. A narrowed rollout
+    ///   keeps the fleet framing, the state table and the compensation semantics,
+    ///   because the other two hosts still exist and are still on another release.
+    configured_host_count: usize,
+    /// What this project's `[database]` config means for the rollout — resolved
+    /// once in the prologue, never re-read here.
+    db: FleetDatabaseFacts,
     /// Whether a halted rollout automatically compensates the hosts that already
     /// cut over (issue #1621, §4.7). `true` in production; `false` is halt-and-freeze
     /// — the rollout stops and reports, leaving every host exactly as it is for
@@ -2436,8 +2719,32 @@ where
     F: Fn(&ResolvedDeployConfig) -> Result<E, DeployError>,
 {
     let fleet = input.fleet;
-    let single = fleet.is_single();
+    // The pre-#1621 path is for a config that declares ONE host — see
+    // [`FleetUpInput::configured_host_count`] for why a `--only`-narrowed fleet is
+    // deliberately NOT single.
+    let single = fleet.is_single() && input.configured_host_count <= 1;
     let total = fleet.hosts.len();
+
+    // ── FLEET-WIDE FAIL-CLOSED REFUSALS (§4.8) ───────────────────────────────
+    // First thing in the driver, before an executor is even built: these describe
+    // topologies that cannot be deployed safely at all, so the honest answer is to
+    // refuse with zero remote commands rather than discover it after a cutover.
+    refuse_sqlite_fleet(input.configured_host_count, input.db.sqlite)
+        .map_err(DeployError::Config)?;
+    refuse_media_fleet(input.configured_host_count, input.media_cfg.enabled)
+        .map_err(DeployError::Config)?;
+    refuse_tls_fleet(input.configured_host_count, fleet.hosts[0].tls_enabled)
+        .map_err(DeployError::Config)?;
+    // A warning, not a refusal: hosts racing to auto-migrate at boot is a real
+    // hazard but not a certainty, and refusing would break an existing single-host
+    // user's scale-up.
+    if let Some(warning) = fleet_auto_migrate_warning(
+        input.configured_host_count,
+        input.db.auto_migrate,
+        input.db.auto_migrate_in_production,
+    ) {
+        eprintln!("\u{26A0}\u{FE0F}  {warning}\n");
+    }
 
     // ONE executor per host, built up front and reused for that host's read-only
     // probe AND its execution.
@@ -2453,17 +2760,12 @@ where
     // until after the app cutover succeeds (below) so a rolled-back app deploy
     // never touches the host MediaMTX unit. No-op unless enabled (see fn).
     //
-    // Single-host only for now: `provision_media_host` has no teardown/rollback
-    // path, so fanning it out would leave N media daemons on identical ports with
-    // divergent recording sets and nothing to undo them with. Until the fleet-wide
-    // refusal lands a fleet therefore provisions NO media and prints nothing new.
-    //
-    // slice 5: refusal — a media-enabled fleet (`[media.mediamtx] enabled` with
-    // more than one host) must be REFUSED in the prologue, alongside the sqlite and
-    // TLS fleet refusals, rather than silently skipped here.
-    if single {
-        check_media_host_preflight(input.media_cfg, input.ffmpeg_bin, &executors[0])?;
-    }
+    // Single-host by construction, not by branch: `provision_media_host` has no
+    // teardown/rollback path, so a media-enabled FLEET is refused outright above
+    // (§4.8). Reaching here with media enabled therefore proves the config declares
+    // exactly one host, and `executors[0]` is it. With media disabled both this and
+    // the provisioning call below are no-ops, so no host-count branch is needed.
+    check_media_host_preflight(input.media_cfg, input.ffmpeg_bin, &executors[0])?;
 
     // ── ALL-HOSTS PROBE (read-only, serial, rollout order) ───────────────────
     // Nothing anywhere in the fleet is mutated by this phase.
@@ -2479,7 +2781,7 @@ where
 
     if !single {
         for line in
-            fleet::fleet_rollout_lines(&plan, input.release_id, input.writable_db_configured)
+            fleet::fleet_rollout_lines(&plan, input.release_id, input.db.writable_configured)
         {
             eprintln!("{line}");
         }
@@ -2647,8 +2949,10 @@ where
     // is no longer a rollback path. Only NOW provision the host MediaMTX unit
     // (write config/unit + restart) — deferring the mutation past this point means
     // a failed/rolled-back app deploy above never wrote or restarted MediaMTX
-    // (#1974 Slice 7). No-op unless enabled (see fn).
-    if single {
+    // (#1974 Slice 7). No-op unless enabled (see fn), and a media-enabled fleet is
+    // refused in the prologue (§4.8), so `executors[0]` is the only host whenever
+    // this does anything at all.
+    {
         let executor = &executors[0];
         provision_media_host(input.media_cfg, executor)?;
     }
@@ -2950,50 +3254,235 @@ fn fleet_halted(
 /// there is nothing to roll back to — and drives [`exec::rollback_ops`]: bring the
 /// previous slot's unit back up, flip the proxy back to it, repoint `current`, and
 /// re-probe `/ready`.
-fn run_rollback(config: &AutumnConfig, resolved: &ResolvedDeployConfig) -> Result<(), DeployError> {
+/// `hosts` is the ordered target list, already narrowed by `--only` (issue #1621).
+/// With more than one entry this becomes a FLEET rollback: every host, in strict
+/// REVERSE declaration order, best-effort-continue. With one entry (or none — a
+/// config with no target still flows into the preflight report) it is the
+/// pre-#1621 single-host path verbatim.
+fn run_rollback(
+    config: &AutumnConfig,
+    resolved: &ResolvedDeployConfig,
+    hosts: &[String],
+) -> Result<(), DeployError> {
     eprintln!("\u{1F342} autumn deploy rollback\n");
 
-    // Fail fast: same preflight/gate as `up`, before any remote call.
-    let checks = collect_preflight(config, resolved);
+    // The rollback targets, in declaration order. A single-host config (either
+    // spelling) resolves to a one-host fleet whose only element IS today's
+    // `resolved`, so the branch below is the pre-#1621 sequence at N = 1.
+    let fleet = ResolvedFleet::from_targets(resolved, hosts);
+
+    // Fail fast: same preflight/gate as `up`, before any remote call. Every host is
+    // graded, so an unreachable host in position 3 is reported before host 3 — or
+    // any other host — is touched.
+    let checks = collect_fleet_preflight(config, &fleet);
     let failed = report_preflight(&checks);
     if failed > 0 {
         return Err(DeployError::PreflightFailed(failed));
     }
 
     // Show what a rollback will do before it runs (descriptive, not a dry-run gate).
+    // These are the steps EACH host runs; the fleet ordering is printed below them.
     eprintln!("Rollback steps:");
     for (i, step) in build_rollback_plan(resolved).iter().enumerate() {
         eprintln!("  {}. [{}] {}", i + 1, step.label, step.description);
     }
     eprintln!();
 
-    let target = exec::SshTarget::from_resolved(resolved)
-        .ok_or_else(|| DeployError::Config(DEPLOY_HOST_MISSING_DETAIL.to_owned()))?;
     let public_port = config.server.port;
     let proxy = proxy::KamalProxyController::new(resolved.readiness_timeout_secs)
         .with_tls_host(resolved.tls_host.clone());
+
+    if !fleet.is_single() {
+        return run_fleet_rollback_with(&checks, &fleet, &proxy, public_port, |cfg| {
+            exec::SshTarget::from_resolved(cfg)
+                .map(exec::SshExecutor::new)
+                .ok_or_else(|| DeployError::Config(DEPLOY_HOST_MISSING_DETAIL.to_owned()))
+        });
+    }
+
+    let single = &fleet.hosts[0];
+    let target = exec::SshTarget::from_resolved(single)
+        .ok_or_else(|| DeployError::Config(DEPLOY_HOST_MISSING_DETAIL.to_owned()))?;
     let executor = exec::SshExecutor::new(target);
 
     // Resolve the previous release to roll back to (non-zero error if none).
-    let rollback_target = exec::resolve_rollback_target(resolved, public_port, &executor)
+    let rollback_target = exec::resolve_rollback_target(single, public_port, &executor)
         .map_err(|e| DeployError::Exec(e.to_string()))?;
     eprintln!(
         "Rolling back {} to {} ({})\u{2026}\n",
-        resolved.host.as_deref().unwrap_or_default(),
+        single.host.as_deref().unwrap_or_default(),
         rollback_target.release_dir,
         rollback_target.slot,
     );
 
-    let ops = exec::rollback_ops(resolved, &proxy, &rollback_target);
+    let ops = exec::rollback_ops(single, &proxy, &rollback_target);
     // If the rollback fails at or before the health-gated flip, disable the slot it
     // restarted so the original release is left cleanly serving (the flip never
     // moved traffic, and no marker is written until after the flip).
-    let teardown = exec::rollback_teardown_ops(resolved, &rollback_target);
+    let teardown = exec::rollback_teardown_ops(single, &rollback_target);
     exec::execute_rollback(&checks, &ops, &teardown, &executor)
         .map_err(|e| DeployError::Exec(e.to_string()))?;
 
     eprintln!("\n\u{2705} Rollback complete.");
     Ok(())
+}
+
+/// Roll EVERY host in `fleet` back to its previous release, newest first (issue
+/// #1621, §3.2).
+///
+/// The executor factory is injected (generic, never `dyn`, no `Send`/`Sync` bound)
+/// so the whole loop is unit-testable against one scripted fake per host.
+///
+/// Three deliberate differences from the rollout driver, all following from the
+/// fact that a rollback is a RECOVERY action rather than a change:
+///
+/// 1. **Reverse declaration order.** The rollout replaces hosts front to back, so
+///    the hosts at the back have been on the new release for the shortest time;
+///    undoing them first shrinks the mixed window from the newest end and mirrors
+///    the compensation order exactly.
+/// 2. **Best-effort continue, never halt.** A host that fails does not stop the
+///    others: stopping would leave MORE hosts on the release the operator is trying
+///    to leave. Every failure is recorded and reported — never swallowed.
+/// 3. **No previous release is not fatal — to the OTHER hosts.** A host that has
+///    never been redeployed (or was just added to the fleet) has no marker to roll
+///    back to. It is reported as a SKIP rather than as a failed rollback, and it
+///    never stops the rest of the fleet.
+///
+/// **Exit semantics (deliberate):** the command succeeds only when EVERY host
+/// rolled back. A host that failed and a host that had nothing to roll back to are
+/// distinguished in the table and in the operator's remedy, but both exit non-zero,
+/// because the contract of a fleet rollback is that the FLEET returns to its
+/// previous release — and a fleet where one host could not follow the others is
+/// mixed. Reporting that as success is how a mixed fleet survives an incident
+/// unnoticed.
+fn run_fleet_rollback_with<E, P, F>(
+    checks: &[PreflightCheck],
+    fleet: &ResolvedFleet,
+    proxy: &P,
+    public_port: u16,
+    make_executor: F,
+) -> Result<(), DeployError>
+where
+    E: exec::DeployExecutor,
+    P: ProxyController,
+    F: Fn(&ResolvedDeployConfig) -> Result<E, DeployError>,
+{
+    let total = fleet.hosts.len();
+    // ONE executor per host, built up front: a host with no SSH target is a config
+    // error, and finding it here means nothing has been flipped yet.
+    let executors = fleet
+        .hosts
+        .iter()
+        .map(&make_executor)
+        .collect::<Result<Vec<E>, DeployError>>()?;
+
+    let names: Vec<String> = fleet
+        .hosts
+        .iter()
+        .map(|cfg| cfg.host.clone().unwrap_or_default())
+        .collect();
+    eprintln!(
+        "Rolling {total} hosts back to their previous release, ONE AT A TIME, NEWEST FIRST \
+         (the reverse of `[deploy] hosts` order):\n"
+    );
+
+    // Every slot is overwritten below — the loop is exhaustive and, unlike the
+    // rollout driver, never breaks early — so the seed value is unobservable. It is
+    // the conservative one regardless: "nothing was rolled back here".
+    let mut outcomes = vec![fleet::RollbackOutcome::NoPreviousRelease; total];
+    for index in (0..total).rev() {
+        let cfg = &fleet.hosts[index];
+        let host = names[index].as_str();
+        eprintln!("[{}/{total} {host}] rolling back\u{2026}", index + 1);
+        outcomes[index] =
+            rollback_one_host(checks, cfg, proxy, public_port, host, &executors[index]);
+        eprintln!();
+    }
+
+    for line in fleet::fleet_rollback_summary_lines(&names, &outcomes) {
+        eprintln!("{line}");
+    }
+
+    let rolled_back = outcomes
+        .iter()
+        .filter(|outcome| matches!(outcome, fleet::RollbackOutcome::RolledBack))
+        .count();
+    // Non-zero unless EVERY host came back: a fleet that half-rolled-back is mixed,
+    // and reporting that as success is how a mixed fleet survives an incident
+    // unnoticed. The table above distinguishes "failed" from "nothing to roll back
+    // to", which is what the operator's next move turns on.
+    if rolled_back < total {
+        return Err(DeployError::FleetRollbackFailed {
+            not_rolled_back: total - rolled_back,
+            total,
+        });
+    }
+    eprintln!("\n\u{2705} Fleet rollback complete \u{2014} all {total} hosts restored.");
+    Ok(())
+}
+
+/// Roll ONE host back to its previous release for a fleet-wide rollback.
+///
+/// Uses the UNCHANGED on-demand primitives ([`exec::resolve_rollback_target`] →
+/// [`exec::rollback_ops`] → [`exec::execute_rollback`], with the same
+/// [`exec::rollback_teardown_ops`]), so a fleet rollback is literally N single-host
+/// rollbacks and can never drift from the one the operator runs by hand.
+///
+/// Returns an outcome instead of an error because the caller continues past a
+/// failure: the report is the aggregate, and nothing here is swallowed. Only the
+/// `&'static str` step LABEL is printed — never the driver's message, which can
+/// carry remote output.
+fn rollback_one_host<E, P>(
+    checks: &[PreflightCheck],
+    cfg: &ResolvedDeployConfig,
+    proxy: &P,
+    public_port: u16,
+    host: &str,
+    executor: &E,
+) -> fleet::RollbackOutcome
+where
+    E: exec::DeployExecutor,
+    P: ProxyController,
+{
+    let target = match exec::resolve_rollback_target(cfg, public_port, executor) {
+        Ok(target) => target,
+        Err(exec::DeployExecError::NoPreviousRelease) => {
+            eprintln!(
+                "\u{26A0}\u{FE0F}  [{host}] no previous release recorded \u{2014} nothing to \
+                 roll back to on this host; it keeps serving what it is serving now."
+            );
+            return fleet::RollbackOutcome::NoPreviousRelease;
+        }
+        Err(err) => {
+            let failed_step = fleet::failed_step_label(&err);
+            eprintln!(
+                "\u{274C} [{host}] could not resolve the previous release (`{failed_step}`) \
+                 \u{2014} this host was NOT rolled back. The remaining hosts still are."
+            );
+            return fleet::RollbackOutcome::Failed { failed_step };
+        }
+    };
+    eprintln!(
+        "  \u{2192} {host} returns to {} ({})",
+        target.release_dir, target.slot,
+    );
+
+    let ops = exec::rollback_ops(cfg, proxy, &target);
+    // Same teardown as the on-demand rollback: a failure at or before the
+    // health-gated flip disables the slot it just restarted, so this host is left
+    // serving exactly what it served before the attempt.
+    let teardown = exec::rollback_teardown_ops(cfg, &target);
+    match exec::execute_rollback(checks, &ops, &teardown, executor) {
+        Ok(()) => fleet::RollbackOutcome::RolledBack,
+        Err(err) => {
+            let failed_step = fleet::failed_step_label(&err);
+            eprintln!(
+                "\u{274C} [{host}] the rollback FAILED at `{failed_step}` \u{2014} this host \
+                 was not restored. The remaining hosts still are."
+            );
+            fleet::RollbackOutcome::Failed { failed_step }
+        }
+    }
 }
 
 #[cfg(test)]
@@ -5061,6 +5550,21 @@ mod tests {
         "prune",
     ];
 
+    /// The exact ordered `Run` labels ONE host records in a fleet-wide rollback:
+    /// the read-only previous-release probe, then the UNCHANGED on-demand
+    /// `rollback_ops` sequence (`write-target-unit` is an upload, so it is not a
+    /// `Run`). Restated here rather than imported so a fleet rollback can never
+    /// quietly grow a step the single-host rollback does not have.
+    const FLEET_ROLLBACK_RUN_LABELS: [&str; 7] = [
+        "resolve-previous",
+        "daemon-reload",
+        "restart-previous",
+        "proxy-flip",
+        "commit-markers",
+        "readiness-gate",
+        "drain-rolled-back-slot",
+    ];
+
     const FLEET_RELEASE_ID: &str = "20260714T120000Z";
     const FLEET_PUBLIC_PORT: u16 = 3000;
 
@@ -5238,7 +5742,12 @@ mod tests {
                 public_port: FLEET_PUBLIC_PORT,
                 media_cfg: &self.media_cfg,
                 ffmpeg_bin: "ffmpeg",
-                writable_db_configured: true,
+                // No `--only`: the rollout covers everything the config declares.
+                configured_host_count: fleet.hosts.len(),
+                db: FleetDatabaseFacts {
+                    writable_configured: true,
+                    ..FleetDatabaseFacts::default()
+                },
                 auto_rollback: true,
             }
         }
@@ -6140,6 +6649,605 @@ mod tests {
                 .collect::<Vec<_>>(),
             "the one host runs today's exact sequence and nothing more — no \
              compensation, no extra probe"
+        );
+    }
+
+    // ── Fleet-wide fail-closed refusals (issue #1621, slice 5, §4.8) ─────────
+
+    /// A resolved fleet with `[deploy.tls]` enabled for a public hostname — the
+    /// shape §4.8 refuses for more than one host.
+    fn tls_fleet_of(hosts: &[&str]) -> ResolvedFleet {
+        ResolvedFleet::resolve(
+            &DeployConfig {
+                hosts: hosts.iter().map(|h| (*h).to_owned()).collect(),
+                tls: autumn_web::config::DeployTlsConfig {
+                    enabled: true,
+                    host: Some("shop.example.com".to_owned()),
+                },
+                ..DeployConfig::default()
+            },
+            "myapp",
+        )
+        .expect("a well-formed TLS fleet resolves")
+    }
+
+    #[test]
+    fn the_fleet_refusals_name_their_config_key_and_spare_a_single_host() {
+        // #1621 (§4.8, T1.22). Three topologies that cannot be deployed safely to
+        // more than one host at all. Each refusal is a PURE predicate over the
+        // CONFIGURED host count, so it is decided before any executor exists — and
+        // each names the config key the operator must change plus the tracking
+        // issue, matching `reject_sqlite_sharding_topology`'s house style.
+        let sqlite = refuse_sqlite_fleet(3, true).expect_err("a sqlite fleet must be refused");
+        assert!(
+            sqlite.contains("sqlite") && sqlite.contains("#1621"),
+            "the sqlite refusal must name the backend and the issue: {sqlite}"
+        );
+        assert!(
+            sqlite.contains("[database]"),
+            "the sqlite refusal must name the config section to change: {sqlite}"
+        );
+
+        let media = refuse_media_fleet(3, true).expect_err("a media fleet must be refused");
+        assert!(
+            media.contains("[media.mediamtx]") && media.contains("#1621"),
+            "the media refusal must name the config key and the issue: {media}"
+        );
+
+        let tls = refuse_tls_fleet(3, true).expect_err("a TLS fleet must be refused");
+        assert!(
+            tls.contains("[deploy.tls]") && tls.contains("#1621"),
+            "the TLS refusal must name the config key and the issue: {tls}"
+        );
+        assert!(
+            tls.contains("load balancer"),
+            "the TLS refusal must point at LB-terminated TLS: {tls}"
+        );
+
+        // None of the three constrains a single-host deploy — that is exactly
+        // today's supported topology (AC-1).
+        assert!(refuse_sqlite_fleet(1, true).is_ok());
+        assert!(refuse_media_fleet(1, true).is_ok());
+        assert!(refuse_tls_fleet(1, true).is_ok());
+        // Nor a fleet that does not have the offending feature turned on.
+        assert!(refuse_sqlite_fleet(3, false).is_ok());
+        assert!(refuse_media_fleet(3, false).is_ok());
+        assert!(refuse_tls_fleet(3, false).is_ok());
+    }
+
+    #[test]
+    fn writable_db_is_sqlite_reads_the_url_the_deploy_would_ship() {
+        // The refusal grades the SAME url `build_env_file` writes to every host, so
+        // it must follow the primary/compat/shard resolution rather than peeking at
+        // one field. Reduced to a bool here so the URL never reaches the driver.
+        use autumn_web::config::DatabaseConfig;
+        let sqlite = DatabaseConfig {
+            url: Some("sqlite://app.db".to_owned()),
+            ..DatabaseConfig::default()
+        };
+        assert!(writable_db_is_sqlite(&sqlite));
+
+        let postgres = DatabaseConfig {
+            url: Some("postgres://user:pw@db.internal/app".to_owned()),
+            ..DatabaseConfig::default()
+        };
+        assert!(!writable_db_is_sqlite(&postgres));
+        assert!(!writable_db_is_sqlite(&DatabaseConfig::default()));
+    }
+
+    #[test]
+    fn a_sqlite_fleet_is_refused_before_any_remote_command() {
+        // #1621 (T1.22). `build_env_file` ships a byte-identical database URL to
+        // every host, so a `sqlite://` fleet is N independent database FILES — no
+        // shared schema, no advisory lock, and every host serving a different
+        // dataset behind one load balancer. Refused with ZERO remote commands: not
+        // even the read-only probes run.
+        let fleet = fleet_of(&["web-a", "web-b", "web-c"]);
+        let recorder = fleet::test_support::FleetRecorder::new();
+        let fixture = FleetFixture::new();
+        let input = FleetUpInput {
+            db: FleetDatabaseFacts {
+                sqlite: true,
+                ..FleetDatabaseFacts::default()
+            },
+            ..fixture.input(&fleet)
+        };
+
+        let err = run_up_with(&input, |cfg| Ok(recorder.executor(cfg)))
+            .expect_err("a sqlite fleet must be refused");
+
+        match &err {
+            DeployError::Config(message) => assert!(
+                message.contains("sqlite") && message.contains("#1621"),
+                "the refusal must name the backend and the issue: {message}"
+            ),
+            other => panic!("expected a config refusal, got: {other:?}"),
+        }
+        assert!(
+            recorder.mutating(&[]).is_empty(),
+            "a refused fleet must run NO remote command at all, probes included: {:?}",
+            recorder.mutating(&[])
+        );
+    }
+
+    #[test]
+    fn a_media_fleet_is_refused_before_any_remote_command() {
+        // #1621 (T1.22). `provision_media_host` has no teardown or rollback path by
+        // design, so fanning it out gives N MediaMTX daemons on identical ports with
+        // divergent recording sets and nothing to undo them with when the app
+        // rollout is compensated. Refused in the prologue — which is also what makes
+        // the driver's single unguarded `executors[0]` media call correct.
+        let fleet = fleet_of(&["web-a", "web-b"]);
+        let recorder = fleet::test_support::FleetRecorder::new();
+        let mut fixture = FleetFixture::new();
+        fixture.media_cfg.enabled = true;
+        let input = fixture.input(&fleet);
+
+        let err = run_up_with(&input, |cfg| Ok(recorder.executor(cfg)))
+            .expect_err("a media-enabled fleet must be refused");
+
+        match &err {
+            DeployError::Config(message) => assert!(
+                message.contains("[media.mediamtx]") && message.contains("#1621"),
+                "the refusal must name the config key and the issue: {message}"
+            ),
+            other => panic!("expected a config refusal, got: {other:?}"),
+        }
+        assert!(
+            recorder.mutating(&[]).is_empty(),
+            "a refused fleet must run NO remote command at all, probes included: {:?}",
+            recorder.mutating(&[])
+        );
+    }
+
+    #[test]
+    fn a_tls_fleet_is_refused_before_any_remote_command() {
+        // #1621 (T1.22). kamal-proxy is PER HOST, so N hosts would each attempt ACME
+        // for the same `[deploy.tls] host` from behind the operator's load balancer:
+        // only one can answer a challenge and the rest burn Let's Encrypt rate
+        // limits. Behind a load balancer, TLS terminates at the load balancer.
+        let fleet = tls_fleet_of(&["web-a", "web-b"]);
+        let recorder = fleet::test_support::FleetRecorder::new();
+        let fixture = FleetFixture::new();
+
+        let err = run_up_with(&fixture.input(&fleet), |cfg| Ok(recorder.executor(cfg)))
+            .expect_err("a TLS-enabled fleet must be refused");
+
+        match &err {
+            DeployError::Config(message) => assert!(
+                message.contains("[deploy.tls]") && message.contains("load balancer"),
+                "the refusal must name the config key and point at LB-terminated TLS: \
+                 {message}"
+            ),
+            other => panic!("expected a config refusal, got: {other:?}"),
+        }
+        assert!(
+            recorder.mutating(&[]).is_empty(),
+            "a refused fleet must run NO remote command at all, probes included: {:?}",
+            recorder.mutating(&[])
+        );
+    }
+
+    #[test]
+    fn the_refusals_grade_the_configured_topology_not_the_narrowed_rollout() {
+        // #1621 (§4.8). `--only` narrows which hosts a run TOUCHES; it does not
+        // change the topology. A three-host sqlite fleet is just as broken when one
+        // host is deployed, so the refusal is keyed on the CONFIGURED count and
+        // `--only` can never be used to sneak past it.
+        let fleet = fleet_of(&["web-b"]);
+        let recorder = fleet::test_support::FleetRecorder::new();
+        let fixture = FleetFixture::new();
+        let input = FleetUpInput {
+            configured_host_count: 3,
+            db: FleetDatabaseFacts {
+                sqlite: true,
+                ..FleetDatabaseFacts::default()
+            },
+            ..fixture.input(&fleet)
+        };
+
+        let err = run_up_with(&input, |cfg| Ok(recorder.executor(cfg)))
+            .expect_err("`--only` must not defeat a topology refusal");
+        assert!(
+            matches!(&err, DeployError::Config(m) if m.contains("sqlite")),
+            "expected the sqlite refusal, got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn auto_migrate_warns_for_a_fleet_and_stays_silent_for_one_host() {
+        // #1621 (§4.8, last paragraph). A WARNING, not a refusal: with
+        // `auto_migrate` on, every host applies migrations at BOOT, so the hosts
+        // race each other mid-rollout and a checksum mismatch exits the process
+        // under `Restart=on-failure` — a crash loop. Real hazard, not a certainty,
+        // so it is said loudly and the deploy proceeds.
+        let warning = fleet_auto_migrate_warning(3, Some(true), false)
+            .expect("a fleet with auto_migrate on must be warned");
+        assert!(
+            warning.contains("auto_migrate") && warning.contains("#1621"),
+            "the warning must name the key and the issue: {warning}"
+        );
+        assert!(
+            warning.contains("boot") && warning.contains("crash loop"),
+            "the warning must name the mechanism (boot races) and the symptom: {warning}"
+        );
+
+        // The back-compat alias is honoured, and `auto_migrate` supersedes it — the
+        // runtime's own resolution rule.
+        assert!(fleet_auto_migrate_warning(3, None, true).is_some());
+        assert!(
+            fleet_auto_migrate_warning(3, Some(false), true).is_none(),
+            "an explicit `auto_migrate = false` wins over the alias"
+        );
+
+        // Silent for a single host (that is today's supported shape) and silent when
+        // the app does not auto-migrate at all.
+        assert!(fleet_auto_migrate_warning(1, Some(true), true).is_none());
+        assert!(fleet_auto_migrate_warning(3, None, false).is_none());
+    }
+
+    // ── `--only` (issue #1621, slice 5, §3.2) ────────────────────────────────
+
+    #[test]
+    fn only_selects_in_declaration_order_and_rejects_an_unknown_host() {
+        // #1621 (§3.2). `[deploy] hosts` order IS the rollout order, so the
+        // selection is filtered from the CONFIGURED list rather than built from the
+        // flag order: `--only web-c --only web-a` must not silently reverse a
+        // rolling deploy. An unknown name is a hard error naming itself — guessing
+        // (prefix, DNS) could deploy the wrong machine, and deploying nothing
+        // silently would be worse.
+        let configured: Vec<String> = ["web-a", "web-b", "web-c"]
+            .iter()
+            .map(|h| (*h).to_owned())
+            .collect();
+
+        assert_eq!(
+            select_hosts(&configured, &[]).expect("an empty selection is the whole fleet"),
+            configured,
+            "no `--only` must select the whole fleet, in order"
+        );
+        assert_eq!(
+            select_hosts(&configured, &["web-c".to_owned(), "web-a".to_owned()])
+                .expect("a valid selection resolves"),
+            vec!["web-a".to_owned(), "web-c".to_owned()],
+            "the selection must keep DECLARATION order, not flag order"
+        );
+        assert_eq!(
+            select_hosts(&configured, &["web-b".to_owned(), "web-b".to_owned()])
+                .expect("a repeated name is not an error"),
+            vec!["web-b".to_owned()],
+            "a repeated `--only` selects that host once"
+        );
+
+        let err = select_hosts(&configured, &["web-9".to_owned()])
+            .expect_err("an unknown host must be refused");
+        assert!(
+            err.contains("web-9") && err.contains("--only"),
+            "the error must quote the unmatched value and the flag: {err}"
+        );
+        for host in &configured {
+            assert!(
+                err.contains(host.as_str()),
+                "the error must list the configured hosts so the operator can fix the \
+                 typo: {err}"
+            );
+        }
+    }
+
+    #[test]
+    fn only_restricts_the_rollout_and_moves_the_migration_with_it() {
+        // #1621 (§3.2). `--only web-b` on a three-host fleet touches web-b and
+        // nothing else — not even the read-only probes run against the hosts it
+        // skips, which is deliberate: an excluded host's drifted marker must not
+        // refuse the repair deploy aimed at a different host.
+        //
+        // Migrate placement is computed over the SELECTED hosts: web-b is the first
+        // redeploy in this rollout, so web-b migrates. (Over the full fleet web-a
+        // would have.) That is the honest reading of "exactly once" for a narrowed
+        // rollout — the schema is fleet-wide, and the hosts left out are not being
+        // deployed at all.
+        let selected = select_hosts(
+            &["web-a", "web-b", "web-c"]
+                .iter()
+                .map(|h| (*h).to_owned())
+                .collect::<Vec<_>>(),
+            &["web-b".to_owned()],
+        )
+        .expect("web-b is in the configured fleet");
+        let fleet = ResolvedFleet::from_targets(&resolved_defaults(), &selected);
+        let recorder = script_redeploy(fleet::test_support::FleetRecorder::new(), "web-b");
+        let fixture = FleetFixture::new();
+        let input = FleetUpInput {
+            configured_host_count: 3,
+            ..fixture.input(&fleet)
+        };
+
+        run_up_with(&input, |cfg| Ok(recorder.executor(cfg)))
+            .expect("a narrowed rollout deploys the selected host");
+
+        assert_eq!(
+            recorder.run_labels_for("web-b"),
+            READ_ONLY_PROBES
+                .iter()
+                .copied()
+                .chain(REDEPLOY_RUN_LABELS)
+                .collect::<Vec<_>>(),
+            "the selected host runs the full redeploy, migration included"
+        );
+        for skipped in ["web-a", "web-c"] {
+            assert!(
+                recorder.calls_for(skipped).is_empty(),
+                "`--only` must not touch {skipped} at all — not even a read-only probe"
+            );
+        }
+    }
+
+    #[test]
+    fn a_narrowed_rollout_keeps_fleet_semantics_rather_than_the_single_host_path() {
+        // #1621 (AC-1 boundary). The byte-identical pre-#1621 path is for a config
+        // that declares ONE host. A three-host fleet narrowed to one is NOT that: the
+        // other two hosts exist and are on another release, so the run keeps the
+        // fleet vocabulary, the state table and the compensation semantics. Proven
+        // by the error TYPE: the single-host path returns the raw executor error,
+        // the fleet path a `FleetHalted` report.
+        let fleet = fleet_of(&["web-b"]);
+        let recorder = script_redeploy(fleet::test_support::FleetRecorder::new(), "web-b")
+            .fail("web-b", "readiness-gate");
+        let fixture = FleetFixture::new();
+        let input = FleetUpInput {
+            configured_host_count: 3,
+            ..fixture.input(&fleet)
+        };
+
+        let err = run_up_with(&input, |cfg| Ok(recorder.executor(cfg)))
+            .expect_err("the selected host's failure must fail the deploy");
+
+        let halt = fleet_halt_of(&err);
+        assert_eq!(halt.failed_host, "web-b");
+        assert_eq!(halt.failed_step, "readiness-gate");
+    }
+
+    #[test]
+    fn no_rollback_freezes_the_fleet_instead_of_compensating() {
+        // #1621 (§4.7). `--no-rollback` is halt-and-FREEZE: the rollout stops and
+        // reports, and every host is left exactly as it is for inspection. web-b
+        // fails post-boundary (a dropped transport at `drain-old`, which carries no
+        // op label and so classifies as FUNCTIONAL), so both web-a and web-b are on
+        // the new release — and, unlike the default path, they STAY there.
+        let hosts = ["web-a", "web-b", "web-c"];
+        let fleet = fleet_of(&hosts);
+        let mut recorder = fleet::test_support::FleetRecorder::new();
+        for host in hosts {
+            recorder = script_redeploy(recorder, host);
+        }
+        recorder = recorder.transport_fail("web-b", "drain-old");
+        let fixture = FleetFixture::new();
+
+        let err = run_up_with(&fixture.input_frozen(&fleet), |cfg| {
+            Ok(recorder.executor(cfg))
+        })
+        .expect_err("a post-boundary failure must fail the deploy");
+
+        let halt = fleet_halt_of(&err);
+        assert_eq!(
+            halt.still_on_new,
+            vec!["web-a".to_owned(), "web-b".to_owned()],
+            "a frozen fleet reports every host left on the new release"
+        );
+        assert!(
+            halt.rolled_back.is_empty() && halt.torn_down.is_empty(),
+            "freezing compensates NOTHING: {:?} / {:?}",
+            halt.rolled_back,
+            halt.torn_down
+        );
+        // The observable proof: web-a flipped exactly once (its cutover). A
+        // compensating rollback would flip it a second time.
+        assert_eq!(
+            recorder
+                .positions_of("proxy-flip")
+                .iter()
+                .filter(|_| true)
+                .count(),
+            2,
+            "exactly two flips happened (web-a's and web-b's cutovers) — no host was \
+             flipped back"
+        );
+        assert!(
+            !recorder
+                .run_labels_for("web-a")
+                .contains(&"restart-previous"),
+            "a frozen rollout must not roll web-a back"
+        );
+
+        // And the flag is actually wired to the seam this test drives.
+        assert!(
+            include_str!("deploy.rs").contains("auto_rollback: !options.no_rollback"),
+            "`--no-rollback` must map to the `auto_rollback` driver seam"
+        );
+    }
+
+    // ── Fleet-wide `deploy rollback` (issue #1621, slice 5, §3.2) ────────────
+
+    /// Script one host's previous-release marker for a fleet-wide rollback.
+    fn script_previous_release(
+        recorder: fleet::test_support::FleetRecorder,
+        host: &str,
+    ) -> fleet::test_support::FleetRecorder {
+        recorder.script(
+            host,
+            "resolve-previous",
+            format!("prev:{PREVIOUS_RELEASE_DIR}\tblue\t3001"),
+        )
+    }
+
+    /// Drive a fleet-wide rollback against a scripted recorder.
+    fn drive_fleet_rollback(
+        fleet: &ResolvedFleet,
+        recorder: &fleet::test_support::FleetRecorder,
+    ) -> Result<(), DeployError> {
+        let proxy = proxy::KamalProxyController::new(60);
+        run_fleet_rollback_with(&[], fleet, &proxy, FLEET_PUBLIC_PORT, |cfg| {
+            Ok(recorder.executor(cfg))
+        })
+    }
+
+    #[test]
+    fn fleet_rollback_rolls_back_every_host_newest_first() {
+        // #1621 (§3.2). `deploy rollback` on a `[deploy] hosts` config rolls back the
+        // WHOLE fleet, in strict REVERSE declaration order: the hosts that cut over
+        // last have been on the new release for the shortest time, so undoing them
+        // first shrinks the mixed window from the newest end — the same order fleet
+        // compensation uses.
+        let hosts = ["web-a", "web-b", "web-c"];
+        let fleet = fleet_of(&hosts);
+        let mut recorder = fleet::test_support::FleetRecorder::new();
+        for host in hosts {
+            recorder = script_previous_release(recorder, host);
+        }
+
+        drive_fleet_rollback(&fleet, &recorder).expect("every host rolls back cleanly");
+
+        for host in hosts {
+            assert_eq!(
+                recorder.run_labels_for(host),
+                FLEET_ROLLBACK_RUN_LABELS.to_vec(),
+                "{host} must run the UNCHANGED on-demand rollback sequence"
+            );
+        }
+        let flips: Vec<usize> = hosts
+            .iter()
+            .map(|host| {
+                recorder
+                    .index_of(host, "proxy-flip")
+                    .unwrap_or_else(|| panic!("{host} must flip back"))
+            })
+            .collect();
+        assert!(
+            flips[2] < flips[1] && flips[1] < flips[0],
+            "hosts must roll back newest-first (web-c, web-b, web-a), got positions {flips:?}"
+        );
+    }
+
+    #[test]
+    fn fleet_rollback_skips_a_host_with_no_previous_release_and_rolls_the_rest_back() {
+        // #1621 (§3.2). A host that has never been redeployed — a first deploy
+        // clears the marker, and a host just added to the fleet never had one — has
+        // nothing to roll back TO. That is a reported SKIP rather than a failed
+        // rollback, and it must NOT stop the other hosts: halting there would leave
+        // them on the release the operator is trying to leave.
+        //
+        // It does still make the COMMAND exit non-zero. The contract of a fleet
+        // rollback is that the FLEET returns to its previous release, and a fleet
+        // where one host cannot follow the others is mixed — reporting that as
+        // success is how a mixed fleet survives an incident unnoticed.
+        let hosts = ["web-a", "web-b", "web-c"];
+        let fleet = fleet_of(&hosts);
+        let mut recorder = fleet::test_support::FleetRecorder::new();
+        for host in ["web-a", "web-c"] {
+            recorder = script_previous_release(recorder, host);
+        }
+        // web-b's marker is absent: the probe answers `none`.
+        recorder = recorder.script("web-b", "resolve-previous", "none");
+
+        let err = drive_fleet_rollback(&fleet, &recorder)
+            .expect_err("a fleet that did not fully converge must exit non-zero");
+        assert!(
+            matches!(
+                &err,
+                DeployError::FleetRollbackFailed {
+                    not_rolled_back: 1,
+                    total: 3
+                }
+            ),
+            "exactly one host must be reported as un-rolled-back, got: {err:?}"
+        );
+        assert!(
+            err.to_string().contains("no previous release"),
+            "the error must explain the skipped case, not just count it: {err}"
+        );
+
+        assert_eq!(
+            recorder.run_labels_for("web-b"),
+            vec!["resolve-previous"],
+            "a host with no previous release must be probed and then left ALONE"
+        );
+        for host in ["web-a", "web-c"] {
+            assert_eq!(
+                recorder.run_labels_for(host),
+                FLEET_ROLLBACK_RUN_LABELS.to_vec(),
+                "{host} must still roll back — a skip is not a halt"
+            );
+        }
+    }
+
+    #[test]
+    fn fleet_rollback_continues_past_a_failed_host_and_exits_non_zero() {
+        // #1621 (§3.2). Best-effort continue, never swallowed: web-c's rollback
+        // fails at its readiness gate, and web-b and web-a are still rolled back —
+        // stopping would leave MORE hosts on the release being abandoned. The
+        // command still exits non-zero, with counts only (never a driver message).
+        let hosts = ["web-a", "web-b", "web-c"];
+        let fleet = fleet_of(&hosts);
+        let mut recorder = fleet::test_support::FleetRecorder::new();
+        for host in hosts {
+            recorder = script_previous_release(recorder, host);
+        }
+        recorder = recorder.fail("web-c", "readiness-gate");
+
+        let err = drive_fleet_rollback(&fleet, &recorder)
+            .expect_err("a failed host must fail the fleet rollback");
+
+        match &err {
+            DeployError::FleetRollbackFailed {
+                not_rolled_back,
+                total,
+            } => {
+                assert_eq!((*not_rolled_back, *total), (1, 3));
+            }
+            other => panic!("expected a fleet-rollback failure, got: {other:?}"),
+        }
+        for host in ["web-a", "web-b"] {
+            assert!(
+                recorder.run_labels_for(host).contains(&"proxy-flip"),
+                "{host} must still be rolled back after web-c failed"
+            );
+        }
+        let rendered = format!("{err}\n{err:?}");
+        for secret in [
+            "postgres://",
+            "topsecret",
+            "AUTUMN_SECURITY__SIGNING_SECRET",
+        ] {
+            assert!(
+                !rendered.contains(secret),
+                "the fleet-rollback error must never carry `{secret}`: {rendered}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_fleet_rollback_that_rolled_nothing_back_is_an_error() {
+        // #1621 (§3.2). Every host reports no previous release, so nothing happened
+        // at all. Exiting zero would tell the operator their fleet was rolled back
+        // when it was not — the one outcome worse than failing.
+        let hosts = ["web-a", "web-b"];
+        let fleet = fleet_of(&hosts);
+        let mut recorder = fleet::test_support::FleetRecorder::new();
+        for host in hosts {
+            recorder = recorder.script(host, "resolve-previous", "none");
+        }
+
+        let err = drive_fleet_rollback(&fleet, &recorder)
+            .expect_err("a rollback that rolled nothing back must not report success");
+        assert!(
+            matches!(
+                &err,
+                DeployError::FleetRollbackFailed {
+                    not_rolled_back: 2,
+                    total: 2
+                }
+            ),
+            "expected all-hosts-unrolled, got: {err:?}"
         );
     }
 }

--- a/autumn-cli/src/deploy.rs
+++ b/autumn-cli/src/deploy.rs
@@ -82,22 +82,50 @@ pub enum DeployError {
     Exec(String),
 
     /// A multi-host rollout stopped mid-fleet (issue #1621, AC-3).
-    #[error(
-        "fleet rollout halted at {failed_host} during `{failed_step}` — the remaining hosts were \
-         not touched"
-    )]
-    FleetHalted {
-        /// Host the rollout stopped on.
-        failed_host: String,
-        /// Label of the step that failed on it.
-        failed_step: &'static str,
-        /// Hosts whose candidate was rolled back (their previous release still serves).
-        rolled_back: Vec<String>,
-        /// Hosts whose first-deploy candidate was torn down (nothing serves there).
-        torn_down: Vec<String>,
-        /// Hosts left running the NEW release, in rollout order.
-        still_on_new: Vec<String>,
-    },
+    ///
+    /// **Boxed deliberately.** The payload is seven fields (160 bytes) and
+    /// `DeployError` is the `Err` type of essentially every function in this
+    /// module, so inlining it would make each of ~30 `Result`s carry the halt
+    /// report on its happy path — which `clippy::result_large_err` (armed by the
+    /// workspace's `-D warnings` gate) refuses, correctly. One allocation on the
+    /// rarest path is the right trade.
+    #[error("{0}")]
+    FleetHalted(Box<FleetHalt>),
+}
+
+/// The partial-fleet state a halted rollout leaves behind (issue #1621, AC-3).
+///
+/// Every field is a host name or a `&'static str` op label — never a shell line, a
+/// remote path, or a formatted driver error (a failed migration's source can embed
+/// the database URL). The lists describe the FINAL state, after any automatic
+/// compensation: a host whose rollback failed stays in `still_on_new`, which is the
+/// whole point of reporting them.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+#[error(
+    "fleet rollout halted at {failed_host} during `{failed_step}` — the remaining hosts were \
+     not touched, and any migration that already ran was NOT rolled back (automatic \
+     compensation restores binaries only)"
+)]
+pub struct FleetHalt {
+    /// Host the rollout stopped on.
+    pub failed_host: String,
+    /// Label of the step that failed on it.
+    pub failed_step: &'static str,
+    /// Hosts whose previous release is serving again — either their own
+    /// pre-boundary teardown or the fleet's compensating rollback.
+    pub rolled_back: Vec<String>,
+    /// Hosts left with nothing installed — either a torn-down first-deploy
+    /// candidate or a first deploy the fleet compensated away.
+    pub torn_down: Vec<String>,
+    /// Hosts left running the NEW release, in rollout order.
+    pub still_on_new: Vec<String>,
+    /// Hosts that cut over but whose post-cutover housekeeping failed, with the
+    /// step label. Recorded even when the host was later compensated, because the
+    /// debris (an unwritten `shared/proxy-options` marker in particular) outlives
+    /// the rollback and fails the NEXT deploy closed.
+    pub degraded: Vec<(String, &'static str)>,
+    /// Hosts the fleet deliberately did NOT roll back, with the reason.
+    pub manual: Vec<(String, &'static str)>,
 }
 
 /// Which `autumn deploy` subcommand to run.
@@ -2140,6 +2168,9 @@ fn run_up(
             media_cfg,
             ffmpeg_bin,
             writable_db_configured: resolve_writable_db_url(&config.database).is_some(),
+            // AC-3's default: a halted rollout compensates the hosts that already
+            // cut over rather than leaving the fleet on two versions.
+            auto_rollback: true,
         },
         // Host presence is guaranteed by the passing ssh_reachability grader above,
         // so this `None` arm is unreachable in practice; it keeps the pre-#1621
@@ -2185,6 +2216,13 @@ struct FleetUpInput<'a, P: ProxyController> {
     /// Whether a writable database URL is configured — the fleet warns loudly when
     /// it is and the rollout schedules no migration at all.
     writable_db_configured: bool,
+    /// Whether a halted rollout automatically compensates the hosts that already
+    /// cut over (issue #1621, §4.7). `true` in production; `false` is halt-and-freeze
+    /// — the rollout stops and reports, leaving every host exactly as it is for
+    /// inspection. The operator-facing `--no-rollback` flag that sets it lands with
+    /// the fleet CLI surface; today it is an internal seam so the freeze path is
+    /// tested, not dead.
+    auto_rollback: bool,
 }
 
 /// One host's read-only probe result: everything the rollout needs to know about
@@ -2374,9 +2412,22 @@ where
 ///   auto-rollback boundary with the FIRST matching label, so a flat vector would
 ///   classify every later host's pre-flip failure as post-boundary and silently
 ///   disable teardown.
-/// - **A failure HALTS the rollout.** Hosts after the failing one are never
-///   touched. Compensating the hosts that already cut over is the next slice; the
-///   typed [`DeployError::FleetHalted`] already names them.
+/// - **A failure HALTS the rollout, then compensates** (issue #1621, §4.6/§4.7).
+///   Hosts after the failing one are never touched, and the hosts that already cut
+///   over are rolled back in reverse order so the fleet converges on ONE version —
+///   binaries only; a migration that already ran is never undone. The one exception
+///   is a post-boundary HOUSEKEEPING failure (`record-proxy-options`, `drain-old`,
+///   `prune`): the host is live and healthy on the new release, so the rollout
+///   warns, marks it degraded, and CONTINUES. A rollout whose only failures are
+///   housekeeping therefore succeeds (`Ok`) with degraded hosts named in the state
+///   table — rolling a whole fleet back because an `rm -rf` of old release dirs
+///   failed would be a self-inflicted outage.
+///
+/// **N = 1 is exempt from all of it.** A single-host config takes the pre-#1621
+/// path verbatim: the raw executor error, no fleet vocabulary, no state table, no
+/// compensation (there is no other host to converge with, and its own boundary
+/// teardown already ran). That is AC-1, and it is why the `single` branches below
+/// are not cosmetic.
 #[allow(clippy::too_many_lines)]
 fn run_up_with<E, P, F>(input: &FleetUpInput<'_, P>, make_executor: F) -> Result<(), DeployError>
 where
@@ -2437,6 +2488,14 @@ where
 
     // ── EXECUTION (serial, one host at a time, rollout order) ────────────────
     let mut outcomes = vec![fleet::HostOutcome::Untouched; total];
+    // Housekeeping debris is recorded OUTSIDE the outcome slot: a degraded host that
+    // is later compensated becomes `CompensatedRollback`, and the failed
+    // `record-proxy-options` that will fail its NEXT deploy closed must survive that
+    // overwrite.
+    let mut degraded: Vec<(String, &'static str)> = Vec::new();
+    // Set when the rollout stops. Compensation runs after the loop, not inside it,
+    // so the compensation set is computed from the FINAL per-host outcomes.
+    let mut halt: Option<(String, &'static str)> = None;
     for (index, host_plan) in plan.hosts.iter().enumerate() {
         let cfg = &fleet.hosts[index];
         let state = &probes[index];
@@ -2525,32 +2584,63 @@ where
                 }
             }
             Err(err) => {
-                outcomes[index] = fleet::classify_failure(&err);
                 // A one-host fleet keeps today's error verbatim: the per-host
                 // executor already told the whole story, and inventing a fleet
-                // vocabulary for one host would change pre-#1621 output.
+                // vocabulary for one host would change pre-#1621 output. This
+                // returns BEFORE any classification, degrade-and-continue or
+                // compensation, so N = 1 is byte-identical on every failure shape,
+                // post-boundary ones included.
                 if single {
                     return Err(DeployError::Exec(err.to_string()));
                 }
                 let failed_step = fleet::failed_step_label(&err);
+                outcomes[index] = fleet::classify_host_outcome(&err);
+                // Post-boundary housekeeping: the proxy is already serving the new
+                // release on this host and only bookkeeping failed. Warn, record the
+                // debris, and keep rolling — the alternative is an outage caused by
+                // a failed `rm -rf` (#1621, §4.6).
+                if let fleet::HostOutcome::Degraded { label } = outcomes[index] {
+                    degraded.push((host_plan.host.clone(), label));
+                    eprintln!(
+                        "\u{26A0}\u{FE0F}  [{}/{total} {}] serving {} \u{2014} but `{label}` \
+                         failed AFTER the cutover. Traffic is healthy, so the rollout \
+                         continues; repair this host (a redeploy does) before the next \
+                         deploy, which will refuse it.\n",
+                        index + 1,
+                        host_plan.host,
+                        input.release_id,
+                    );
+                    continue;
+                }
                 eprintln!(
                     "\n\u{274C} rollout halted at {} (`{failed_step}`) \u{2014} the remaining \
                      hosts were not touched.\n",
                     host_plan.host,
                 );
-                // Print the per-host state on the way out: a halted rollout is
-                // exactly when the operator has no other source of truth.
-                for line in fleet::fleet_summary_lines(&plan, &outcomes, input.release_id) {
-                    eprintln!("{line}");
-                }
-                return Err(fleet_halted(
-                    &plan,
-                    &outcomes,
-                    host_plan.host.clone(),
-                    failed_step,
-                ));
+                halt = Some((host_plan.host.clone(), failed_step));
+                break;
             }
         }
+    }
+
+    if let Some((failed_host, failed_step)) = halt {
+        if input.auto_rollback {
+            compensate_fleet(input, &plan, &probes, &executors, &mut outcomes);
+        }
+        // Print the per-host state on the way out — AFTER compensation, so the table
+        // describes where the fleet actually IS, and even when the compensating
+        // rollback itself failed. That is precisely the case where the operator has
+        // no other source of truth.
+        for line in fleet::fleet_summary_lines(&plan, &outcomes, input.release_id) {
+            eprintln!("{line}");
+        }
+        return Err(fleet_halted(
+            &plan,
+            &outcomes,
+            &degraded,
+            failed_host,
+            failed_step,
+        ));
     }
 
     // App deploy is committed on every host here: the cutovers succeeded and there
@@ -2569,12 +2659,214 @@ where
         for line in fleet::fleet_summary_lines(&plan, &outcomes, input.release_id) {
             eprintln!("{line}");
         }
-        eprintln!(
-            "\n\u{2705} Fleet deploy complete \u{2014} all {total} hosts serving {}.",
-            input.release_id,
-        );
+        // Every host serves the new release either way; a degraded host is live and
+        // healthy, so this is a success — but claiming an unqualified "complete"
+        // when a host's `record-proxy-options` never landed would hide the thing
+        // that fails its NEXT deploy closed.
+        if degraded.is_empty() {
+            eprintln!(
+                "\n\u{2705} Fleet deploy complete \u{2014} all {total} hosts serving {}.",
+                input.release_id,
+            );
+        } else {
+            eprintln!(
+                "\n\u{26A0}\u{FE0F}  Fleet deploy complete \u{2014} all {total} hosts serve {}, \
+                 but {} finished with post-cutover housekeeping failures (above). Repair \
+                 them before the next deploy.",
+                input.release_id,
+                degraded.len(),
+            );
+        }
     }
     Ok(())
+}
+
+/// Compensate a halted rollout: undo every host that is already on the new release,
+/// in strict REVERSE rollout order (issue #1621, §4.7, AC-3).
+///
+/// Three rules are load-bearing:
+///
+/// 1. **Best-effort CONTINUE.** A failed rollback on host j does not stop host j-1.
+///    Stopping would leave MORE hosts on the new release — a bigger mixed fleet,
+///    which is the harm AC-3 names.
+/// 2. **Never swallowed.** Each host's result is recorded into its outcome slot and
+///    reported. This deliberately does NOT reuse [`exec::run_ops`]'s teardown
+///    sibling `run_teardown`, whose `let _ = …` is right for cleanup that must not
+///    mask a real failure and actively dangerous at fleet scale.
+/// 3. **Binaries only.** [`exec::rollback_ops`] and
+///    [`exec::first_deploy_teardown_ops`] contain no `migrate` op by construction,
+///    so a migration that already ran stays applied. The summary says so out loud.
+///
+/// Nothing here is new machinery: a redeploy host is compensated with exactly the
+/// on-demand `autumn deploy rollback` primitives, and a completed FIRST deploy with
+/// the first-deploy teardown (it has no previous release to return to).
+fn compensate_fleet<E, P>(
+    input: &FleetUpInput<'_, P>,
+    plan: &fleet::FleetPlan,
+    probes: &[HostProbeState],
+    executors: &[E],
+    outcomes: &mut [fleet::HostOutcome],
+) where
+    E: exec::DeployExecutor,
+    P: ProxyController,
+{
+    let modes: Vec<fleet::HostMode> = plan.hosts.iter().map(|host| host.mode).collect();
+    let actions = fleet::fleet_rollback_set(outcomes, &modes);
+    if actions.is_empty() {
+        return;
+    }
+
+    eprintln!(
+        "\u{21A9}\u{FE0F}  Compensating {} host(s) in reverse rollout order \u{2014} BINARIES \
+         only; a migration that already ran is NOT rolled back.\n",
+        actions.len(),
+    );
+    for action in actions {
+        let index = match action {
+            fleet::RollbackAction::Rollback(index)
+            | fleet::RollbackAction::Teardown(index)
+            | fleet::RollbackAction::Manual(index, _) => index,
+        };
+        let cfg = &input.fleet.hosts[index];
+        let host = plan.hosts[index].host.as_str();
+        outcomes[index] = match action {
+            fleet::RollbackAction::Rollback(_) => {
+                eprintln!(
+                    "\u{21A9}\u{FE0F}  [{host}] rolling back to the previous release\u{2026}"
+                );
+                compensate_rollback(cfg, input, &executors[index])
+            }
+            fleet::RollbackAction::Teardown(_) => {
+                eprintln!(
+                    "\u{21A9}\u{FE0F}  [{host}] removing this run's first deploy \
+                     (no previous release to return to)\u{2026}"
+                );
+                compensate_teardown(cfg, input, &probes[index].slots, &executors[index])
+            }
+            fleet::RollbackAction::Manual(_, reason) => {
+                for line in fleet::manual_recovery_lines(cfg, reason) {
+                    eprintln!("{line}");
+                }
+                // An ambiguous-marker host already describes itself more precisely
+                // than "manual" does; keep the specific state.
+                if matches!(outcomes[index], fleet::HostOutcome::AmbiguousMarkers) {
+                    fleet::HostOutcome::AmbiguousMarkers
+                } else {
+                    fleet::HostOutcome::Manual { reason }
+                }
+            }
+        };
+        eprintln!();
+    }
+}
+
+/// Roll ONE host back to its previous release, with the target-dir precheck
+/// (issue #1621, §4.7).
+///
+/// Every refusal fails CLOSED to [`fleet::HostOutcome::Manual`]: the host stays on
+/// the new release and is reported, which is strictly better than flipping it at a
+/// release dir we cannot prove exists — that failure lands post-boundary, with no
+/// teardown, turning one broken host into two.
+fn compensate_rollback<E, P>(
+    cfg: &ResolvedDeployConfig,
+    input: &FleetUpInput<'_, P>,
+    executor: &E,
+) -> fleet::HostOutcome
+where
+    E: exec::DeployExecutor,
+    P: ProxyController,
+{
+    let target = match exec::resolve_rollback_target(cfg, input.public_port, executor) {
+        Ok(target) => target,
+        // The host records no previous release (a first deploy clears the marker,
+        // and a host deployed before the marker existed simply has none).
+        Err(exec::DeployExecError::NoPreviousRelease) => {
+            return manual_outcome(cfg, fleet::MANUAL_NO_PREVIOUS_RELEASE);
+        }
+        // The probe itself could not run: we know nothing, so we change nothing.
+        Err(_) => {
+            return manual_outcome(cfg, fleet::MANUAL_ROLLBACK_TARGET_UNPROVABLE);
+        }
+    };
+    match exec::probe_rollback_target_dir(&target.release_dir, executor) {
+        Ok(exec::ReleaseDirState::Present) => {}
+        Ok(exec::ReleaseDirState::Absent) => {
+            return manual_outcome(cfg, fleet::MANUAL_ROLLBACK_TARGET_MISSING);
+        }
+        Ok(exec::ReleaseDirState::Unreadable) | Err(_) => {
+            return manual_outcome(cfg, fleet::MANUAL_ROLLBACK_TARGET_UNPROVABLE);
+        }
+    }
+
+    let ops = exec::rollback_ops(cfg, input.proxy, &target);
+    // Same teardown as the on-demand rollback: a failure at or before the
+    // health-gated flip disables the slot it just restarted, so the host is left
+    // serving what it was serving when compensation started.
+    let teardown = exec::rollback_teardown_ops(cfg, &target);
+    match exec::execute_rollback(input.checks, &ops, &teardown, executor) {
+        Ok(()) => fleet::HostOutcome::CompensatedRollback,
+        Err(err) => {
+            let failed_step = fleet::failed_step_label(&err);
+            eprintln!(
+                "\u{274C} [{}] the compensating rollback FAILED at `{failed_step}` \u{2014} this \
+                 host is still on {}. The remaining hosts are still compensated.",
+                cfg.host.as_deref().unwrap_or_default(),
+                input.release_id,
+            );
+            fleet::HostOutcome::CompensationFailed { failed_step }
+        }
+    }
+}
+
+/// Remove ONE host's just-completed FIRST deploy (issue #1621, §4.7).
+///
+/// A first deploy has no `shared/previous-release` marker, so there is nothing to
+/// roll back to: the honest compensation is the first-deploy teardown, which stops
+/// the slot unit, removes this run's release dir, and clears the `current` symlink
+/// and slot markers — leaving the host in the nothing-installed state that makes
+/// the next `deploy up` correctly take the First path again.
+///
+/// Driven through [`exec::run_ops`], not `run_teardown`: at fleet scale a silently
+/// swallowed cleanup failure is how a host ends up half-removed with nobody told.
+///
+/// **Known residue:** [`ProxyController`] has no deregister op, so this host's
+/// kamal-proxy still holds a route for the service pointing at the stopped slot —
+/// its public port answers 502 rather than refusing the connection until it is
+/// deployed again. Removing the route needs a new controller method (and its own
+/// exact-vector tests); the state table names the host so this is never a surprise.
+fn compensate_teardown<E, P>(
+    cfg: &ResolvedDeployConfig,
+    input: &FleetUpInput<'_, P>,
+    slots: &exec::SlotPlan,
+    executor: &E,
+) -> fleet::HostOutcome
+where
+    E: exec::DeployExecutor,
+    P: ProxyController,
+{
+    let ops = exec::first_deploy_teardown_ops(cfg, input.release_id, slots);
+    match exec::run_ops(&ops, executor) {
+        Ok(()) => fleet::HostOutcome::CompensatedTeardown,
+        Err(err) => {
+            let failed_step = fleet::failed_step_label(&err);
+            eprintln!(
+                "\u{274C} [{}] removing the first deploy FAILED at `{failed_step}` \u{2014} this \
+                 host is still on {}. The remaining hosts are still compensated.",
+                cfg.host.as_deref().unwrap_or_default(),
+                input.release_id,
+            );
+            fleet::HostOutcome::CompensationFailed { failed_step }
+        }
+    }
+}
+
+/// Decline the automatic rollback for one host, print the by-hand recovery block,
+/// and record the reason.
+fn manual_outcome(cfg: &ResolvedDeployConfig, reason: &'static str) -> fleet::HostOutcome {
+    for line in fleet::manual_recovery_lines(cfg, reason) {
+        eprintln!("{line}");
+    }
+    fleet::HostOutcome::Manual { reason }
 }
 
 /// Build the typed halt error from the recorded per-host outcomes (issue #1621,
@@ -2583,9 +2875,19 @@ where
 /// Secrets discipline: every field is a host name or a `&'static str` op label —
 /// never a shell line, a remote path, or a formatted driver error (a migration
 /// failure's source can embed the database URL).
+///
+/// The lists describe the FINAL state, so this must be built after compensation:
+/// a host the fleet rolled back is `rolled_back`, and a host whose rollback FAILED
+/// stays in `still_on_new` — reporting the attempt instead of the result is how an
+/// operator ends up believing a mixed fleet converged.
+///
+/// `degraded` is passed in rather than derived, because a degraded host that was
+/// later compensated no longer carries that state in its outcome slot and its
+/// housekeeping debris outlives the rollback.
 fn fleet_halted(
     plan: &fleet::FleetPlan,
     outcomes: &[fleet::HostOutcome],
+    degraded: &[(String, &'static str)],
     failed_host: String,
     failed_step: &'static str,
 ) -> DeployError {
@@ -2597,18 +2899,46 @@ fn fleet_halted(
             .map(|(host, _)| host.host.clone())
             .collect()
     };
-    DeployError::FleetHalted {
+    DeployError::FleetHalted(Box::new(FleetHalt {
         failed_host,
         failed_step,
-        rolled_back: named(|o| matches!(o, fleet::HostOutcome::RolledBack { .. })),
-        torn_down: named(|o| matches!(o, fleet::HostOutcome::TornDown { .. })),
+        rolled_back: named(|o| {
+            matches!(
+                o,
+                fleet::HostOutcome::RolledBack { .. } | fleet::HostOutcome::CompensatedRollback
+            )
+        }),
+        torn_down: named(|o| {
+            matches!(
+                o,
+                fleet::HostOutcome::TornDown { .. } | fleet::HostOutcome::CompensatedTeardown
+            )
+        }),
         still_on_new: named(|o| {
             matches!(
                 o,
-                fleet::HostOutcome::Serving | fleet::HostOutcome::LiveOnNew { .. }
+                fleet::HostOutcome::Serving
+                    | fleet::HostOutcome::Degraded { .. }
+                    | fleet::HostOutcome::LiveOnNew { .. }
+                    | fleet::HostOutcome::AmbiguousMarkers
+                    | fleet::HostOutcome::Manual { .. }
+                    | fleet::HostOutcome::CompensationFailed { .. }
             )
         }),
-    }
+        degraded: degraded.to_vec(),
+        manual: plan
+            .hosts
+            .iter()
+            .zip(outcomes)
+            .filter_map(|(host, outcome)| match outcome {
+                fleet::HostOutcome::AmbiguousMarkers => {
+                    Some((host.host.clone(), fleet::MANUAL_AMBIGUOUS_MARKERS))
+                }
+                fleet::HostOutcome::Manual { reason } => Some((host.host.clone(), *reason)),
+                _ => None,
+            })
+            .collect(),
+    }))
 }
 
 /// Perform a real on-demand rollback (issue #1607, Slice 3, AC-4).
@@ -4648,8 +4978,10 @@ mod tests {
         let preflight_at = up_body
             .find("check_media_host_preflight(input.media_cfg")
             .expect("preflight call present on the up path");
-        // The per-host cutovers happen inside this loop; a failed host returns from
-        // inside it (after the per-host teardown) before anything below runs.
+        // The per-host cutovers happen inside this loop. A failed host breaks out of
+        // it and returns from the halt block immediately below — after its own
+        // teardown and after any fleet compensation (#1621 slice 4) — so nothing
+        // past that point runs.
         let commit_at = up_body
             .find("for (index, host_plan) in plan.hosts.iter().enumerate()")
             .expect("per-host execution loop present on the up path");
@@ -4664,7 +4996,8 @@ mod tests {
         assert!(
             commit_at < provision_at,
             "MediaMTX provisioning must run only AFTER every host's cutover commits — so a \
-             rolled-back or halted rollout (which returns from inside the loop) never reaches it",
+             rolled-back or halted rollout (which returns from the loop's halt path) never \
+             reaches it",
         );
 
         // The preflight itself is non-mutating: it runs the doctor checks but must
@@ -4688,7 +5021,7 @@ mod tests {
         assert!(
             after_commit.contains("provision_media_host(input.media_cfg, executor)?;"),
             "provisioning must sit on the post-commit path (unreachable when a host's \
-             deploy errors out inside the rollout loop)",
+             deploy errors out and the rollout halts)",
         );
     }
 
@@ -4730,6 +5063,17 @@ mod tests {
 
     const FLEET_RELEASE_ID: &str = "20260714T120000Z";
     const FLEET_PUBLIC_PORT: u16 = 3000;
+
+    /// The halt report inside a [`DeployError::FleetHalted`], or a panic naming
+    /// what came instead. Every fleet-failure test asserts on the same shape, so
+    /// unwrapping it once keeps those assertions about the FLEET rather than about
+    /// the boxing.
+    fn fleet_halt_of(err: &DeployError) -> &FleetHalt {
+        match err {
+            DeployError::FleetHalted(halt) => halt,
+            other => panic!("expected a fleet halt, got: {other:?}"),
+        }
+    }
 
     fn fleet_of(hosts: &[&str]) -> ResolvedFleet {
         ResolvedFleet::resolve(
@@ -4795,6 +5139,68 @@ mod tests {
             .script(host, "probe-release-dir", "absent")
     }
 
+    /// Script one host as a healthy FIRST deploy.
+    fn script_first_deploy(
+        recorder: fleet::test_support::FleetRecorder,
+        host: &str,
+    ) -> fleet::test_support::FleetRecorder {
+        recorder
+            .script(host, "proxy-compat-probe", compatible_deploy_help())
+            .script(host, "detect-current", first_deploy_probe())
+            .script(host, "probe-release-dir", "absent")
+    }
+
+    /// The release a compensated redeploy host rolls BACK to — the blue release it
+    /// was serving before this run flipped it to green.
+    const PREVIOUS_RELEASE_DIR: &str = "/srv/autumn/myapp/releases/20260101T000000Z";
+
+    /// Script the two read-only probes a compensating rollback runs on a host: the
+    /// previous-release marker, and the §4.7 precheck that the dir it names still
+    /// exists. `target_dir` is the precheck's answer (`present`/`absent`/garbage).
+    fn script_compensation(
+        recorder: fleet::test_support::FleetRecorder,
+        host: &str,
+        target_dir: &'static str,
+    ) -> fleet::test_support::FleetRecorder {
+        recorder
+            .script(
+                host,
+                "resolve-previous",
+                format!("prev:{PREVIOUS_RELEASE_DIR}\tblue\t3001"),
+            )
+            .script(host, "probe-rollback-target", target_dir)
+    }
+
+    /// The ordered `Run` labels of a compensating rollback on one host: the two
+    /// read-only probes, then the unchanged on-demand `rollback_ops` sequence
+    /// (`write-target-unit` is an upload, so it is not a `Run`).
+    const COMPENSATION_RUN_LABELS: [&str; 8] = [
+        "resolve-previous",
+        "probe-rollback-target",
+        "daemon-reload",
+        "restart-previous",
+        "proxy-flip",
+        "commit-markers",
+        "readiness-gate",
+        "drain-rolled-back-slot",
+    ];
+
+    /// The `Run` labels a host records for a full redeploy plus the compensating
+    /// rollback that followed it.
+    fn redeploy_then_compensated(migrated: bool) -> Vec<&'static str> {
+        READ_ONLY_PROBES
+            .iter()
+            .copied()
+            .chain(
+                REDEPLOY_RUN_LABELS
+                    .iter()
+                    .copied()
+                    .filter(|label| migrated || *label != "migrate"),
+            )
+            .chain(COMPENSATION_RUN_LABELS)
+            .collect()
+    }
+
     /// Build a driver input over `fleet` with every fleet-wide value fixed, so the
     /// per-host op vectors are byte-comparable against the single-host builders.
     struct FleetFixture {
@@ -4816,6 +5222,7 @@ mod tests {
             }
         }
 
+        /// The production shape: a halt compensates the hosts that already cut over.
         fn input<'a>(
             &'a self,
             fleet: &'a ResolvedFleet,
@@ -4832,6 +5239,20 @@ mod tests {
                 media_cfg: &self.media_cfg,
                 ffmpeg_bin: "ffmpeg",
                 writable_db_configured: true,
+                auto_rollback: true,
+            }
+        }
+
+        /// Halt-and-freeze: stop at the first failure and change nothing else, for
+        /// inspection (#1621, §4.7 — the internal seam behind the `--no-rollback`
+        /// flag the fleet CLI surface adds).
+        fn input_frozen<'a>(
+            &'a self,
+            fleet: &'a ResolvedFleet,
+        ) -> FleetUpInput<'a, proxy::KamalProxyController> {
+            FleetUpInput {
+                auto_rollback: false,
+                ..self.input(fleet)
             }
         }
 
@@ -4911,11 +5332,12 @@ mod tests {
                 ],
             },
             &[
-                fleet::HostOutcome::Serving,
-                fleet::HostOutcome::RolledBack {
-                    failed_step: "migrate",
-                },
+                fleet::HostOutcome::Degraded { label: "prune" },
+                fleet::HostOutcome::AmbiguousMarkers,
             ],
+            // #1621 slice 4: the degraded log and the manual list are the two
+            // richest new fields, so the secrets assertion below covers them too.
+            &[("web-a".to_owned(), "prune")],
             "web-b".to_owned(),
             "migrate",
         );
@@ -4924,6 +5346,19 @@ mod tests {
         assert!(
             rendered.contains("web-b") && rendered.contains("migrate"),
             "the halt must name the failing host and step: {rendered}"
+        );
+        assert!(
+            rendered.contains("prune") && rendered.contains("web-a"),
+            "the degraded log must name the host and the housekeeping label: {rendered}"
+        );
+        assert!(
+            rendered.contains(fleet::MANUAL_AMBIGUOUS_MARKERS),
+            "an ambiguous-marker host must be reported as needing a human: {rendered}"
+        );
+        assert!(
+            rendered.contains("NOT rolled back"),
+            "the halt must state that the schema did not come back with the binaries: \
+             {rendered}"
         );
         for secret in [
             "postgres://",
@@ -5156,8 +5591,15 @@ mod tests {
         // #1621 (AC-3). Host 2's readiness gate fails — a PRE-boundary failure, so
         // its candidate is torn down by the existing per-host auto-rollback and its
         // old release keeps serving. The rollout then HALTS: host 3 is never
-        // touched. Host 1 is left on the new release; compensating it back is the
-        // next slice's job, and the typed error already names it as such.
+        // touched. Host 1 is left on the new release and NAMED, so the operator can
+        // reverse it.
+        //
+        // #1621 slice 4 pins this against the HALT-AND-FREEZE seam (`auto_rollback:
+        // false`, the internal form of `--no-rollback`): freezing is exactly the
+        // "stop and let me look" behaviour, so it must keep reporting partial state
+        // truthfully. The default path — which compensates web-a instead of leaving
+        // it forward — is
+        // `a_pre_boundary_failure_rolls_the_already_cut_over_hosts_back`.
         let hosts = ["web-a", "web-b", "web-c"];
         let fleet = fleet_of(&hosts);
         let mut recorder = fleet::test_support::FleetRecorder::new();
@@ -5167,39 +5609,41 @@ mod tests {
         recorder = recorder.fail("web-b", "readiness-gate");
         let fixture = FleetFixture::new();
 
-        let err = run_up_with(&fixture.input(&fleet), |cfg| Ok(recorder.executor(cfg)))
-            .expect_err("a mid-rollout failure must halt the rollout");
+        let err = run_up_with(&fixture.input_frozen(&fleet), |cfg| {
+            Ok(recorder.executor(cfg))
+        })
+        .expect_err("a mid-rollout failure must halt the rollout");
 
-        match &err {
-            DeployError::FleetHalted {
-                failed_host,
-                failed_step,
-                rolled_back,
-                torn_down,
-                still_on_new,
-            } => {
-                assert_eq!(failed_host, "web-b", "the halt must name the failing host");
-                assert_eq!(
-                    *failed_step, "readiness-gate",
-                    "the halt must name the failing step"
-                );
-                assert_eq!(
-                    rolled_back,
-                    &vec!["web-b".to_owned()],
-                    "a pre-boundary failure rolls the failing host's candidate back"
-                );
-                assert!(
-                    torn_down.is_empty(),
-                    "a redeploy host is rolled back, not torn down: {torn_down:?}"
-                );
-                assert_eq!(
-                    still_on_new,
-                    &vec!["web-a".to_owned()],
-                    "the already-cut-over hosts must be named so they can be compensated"
-                );
-            }
-            other => panic!("expected a fleet halt, got: {other:?}"),
-        }
+        let halt = fleet_halt_of(&err);
+        assert!(
+            halt.degraded.is_empty() && halt.manual.is_empty(),
+            "a clean pre-boundary halt needs no degraded/manual rows: {:?} / {:?}",
+            halt.degraded,
+            halt.manual
+        );
+        assert_eq!(
+            halt.failed_host, "web-b",
+            "the halt must name the failing host"
+        );
+        assert_eq!(
+            halt.failed_step, "readiness-gate",
+            "the halt must name the failing step"
+        );
+        assert_eq!(
+            halt.rolled_back,
+            vec!["web-b".to_owned()],
+            "a pre-boundary failure rolls the failing host's candidate back"
+        );
+        assert!(
+            halt.torn_down.is_empty(),
+            "a redeploy host is rolled back, not torn down: {:?}",
+            halt.torn_down
+        );
+        assert_eq!(
+            halt.still_on_new,
+            vec!["web-a".to_owned()],
+            "the already-cut-over hosts must be named so they can be compensated"
+        );
 
         // Host 1 completed its cutover.
         assert!(
@@ -5224,6 +5668,478 @@ mod tests {
         assert!(
             web_c.is_empty(),
             "the rollout must halt: web-c must be mutated in no way, got: {web_c:?}"
+        );
+    }
+
+    // ── Fleet compensation (issue #1621, slice 4, §4.6-4.7) ──────────────────
+
+    #[test]
+    fn a_pre_boundary_failure_rolls_the_already_cut_over_hosts_back() {
+        // #1621 (AC-3, T1.13 case a). Host 2's readiness gate fails BEFORE its flip,
+        // so its own auto-rollback tears the candidate down and its old release
+        // keeps serving — but host 1 has already cut over. Left alone, the fleet
+        // runs two versions at rest, which is the exact failure AC-3 forbids. So the
+        // rollout compensates host 1 with the UNCHANGED on-demand rollback
+        // primitives, and host 3 — never reached — stays untouched.
+        let hosts = ["web-a", "web-b", "web-c"];
+        let fleet = fleet_of(&hosts);
+        let mut recorder = fleet::test_support::FleetRecorder::new();
+        for host in hosts {
+            recorder = script_redeploy(recorder, host);
+        }
+        recorder =
+            script_compensation(recorder, "web-a", "present").fail("web-b", "readiness-gate");
+        let fixture = FleetFixture::new();
+
+        let err = run_up_with(&fixture.input(&fleet), |cfg| Ok(recorder.executor(cfg)))
+            .expect_err("a mid-rollout failure must halt the rollout");
+
+        // Host 1 ran its full cutover and then the full rollback sequence — the same
+        // ops `autumn deploy rollback` runs, in the same order, nothing invented.
+        assert_eq!(
+            recorder.run_labels_for("web-a"),
+            redeploy_then_compensated(true),
+            "web-a must be rolled back with the on-demand rollback primitives"
+        );
+        assert!(
+            recorder
+                .mutating(&READ_ONLY_PROBES)
+                .iter()
+                .all(|(host, _)| host != "web-c"),
+            "web-c was never reached, so compensation must not touch it either"
+        );
+
+        let halt = fleet_halt_of(&err);
+        assert_eq!(
+            halt.rolled_back,
+            vec!["web-a".to_owned(), "web-b".to_owned()],
+            "both the compensated host and the self-torn-down host are back on their \
+             previous release"
+        );
+        assert!(
+            halt.still_on_new.is_empty() && halt.torn_down.is_empty() && halt.manual.is_empty(),
+            "the fleet converged: nothing left forward, nothing manual — got {:?} / {:?} / {:?}",
+            halt.still_on_new,
+            halt.torn_down,
+            halt.manual
+        );
+    }
+
+    #[test]
+    fn a_post_boundary_functional_failure_compensates_newest_first_including_itself() {
+        // #1621 (AC-3, T1.13 case b). Host 2's ssh transport drops during `drain-old`
+        // — AFTER its flip, so traffic already moved and no teardown ran. That host
+        // IS on the new release, so the compensation set includes it, and the order
+        // is strictly newest-cutover-first: undoing from the newest end shrinks the
+        // mixed window instead of widening it.
+        let hosts = ["web-a", "web-b", "web-c"];
+        let fleet = fleet_of(&hosts);
+        let mut recorder = fleet::test_support::FleetRecorder::new();
+        for host in hosts {
+            recorder = script_redeploy(recorder, host);
+        }
+        recorder = script_compensation(recorder, "web-a", "present");
+        recorder =
+            script_compensation(recorder, "web-b", "present").transport_fail("web-b", "drain-old");
+        let fixture = FleetFixture::new();
+
+        let err = run_up_with(&fixture.input(&fleet), |cfg| Ok(recorder.executor(cfg)))
+            .expect_err("a post-boundary failure must halt the rollout");
+
+        // Reverse order, asserted on the fleet-wide tape: `restart-previous` belongs
+        // only to `rollback_ops`, so it is the unambiguous marker of each host's
+        // compensation.
+        let web_b = recorder
+            .index_of("web-b", "restart-previous")
+            .expect("web-b must be compensated — it is live on the new release");
+        let web_a = recorder
+            .index_of("web-a", "restart-previous")
+            .expect("web-a must be compensated");
+        assert!(
+            web_b < web_a,
+            "compensation must run in REVERSE rollout order: web-b's rollback at \
+             {web_b}, web-a's at {web_a}"
+        );
+        assert!(
+            recorder.index_of("web-c", "restart-previous").is_none(),
+            "web-c never cut over, so it must not be rolled back"
+        );
+
+        let halt = fleet_halt_of(&err);
+        assert_eq!(halt.failed_host, "web-b");
+        assert_eq!(
+            halt.failed_step, "ssh-transport",
+            "a dropped transport attributes to the transport, never to a fabricated \
+             step label"
+        );
+        assert_eq!(
+            halt.rolled_back,
+            vec!["web-a".to_owned(), "web-b".to_owned()],
+            "the post-boundary host is compensated TOO — it is on the new release"
+        );
+        assert!(
+            halt.still_on_new.is_empty(),
+            "the fleet must converge on one version: {:?}",
+            halt.still_on_new
+        );
+    }
+
+    #[test]
+    fn a_completed_first_deploy_is_compensated_by_teardown_not_rollback() {
+        // #1621 (AC-3, T1.13 case c). A first-deploy host has no
+        // `shared/previous-release` marker, so there is nothing to roll back TO:
+        // `resolve_rollback_target` would fail. Its honest compensation is the
+        // first-deploy teardown, which returns it to nothing-installed — the state
+        // that makes the next `deploy up` correctly take the First path again. A
+        // half-installed host an LB may already be probing is worse than a clean
+        // absence.
+        let fleet = fleet_of(&["web-a", "web-b"]);
+        let mut recorder = fleet::test_support::FleetRecorder::new();
+        recorder = script_first_deploy(recorder, "web-a");
+        recorder = script_redeploy(recorder, "web-b").fail("web-b", "readiness-gate");
+        let fixture = FleetFixture::new();
+
+        let err = run_up_with(&fixture.input(&fleet), |cfg| Ok(recorder.executor(cfg)))
+            .expect_err("a mid-rollout failure must halt the rollout");
+
+        let web_a = recorder.run_labels_for("web-a");
+        for teardown in [
+            "teardown-candidate-unit",
+            "teardown-candidate-dir",
+            "teardown-current-symlink",
+            "teardown-slot-markers",
+        ] {
+            assert!(
+                web_a.contains(&teardown),
+                "a compensated first deploy must run `{teardown}`: {web_a:?}"
+            );
+        }
+        assert!(
+            !web_a.contains(&"resolve-previous") && !web_a.contains(&"restart-previous"),
+            "a first-deploy host has no previous release, so it must never be sent \
+             through the rollback primitives: {web_a:?}"
+        );
+
+        let halt = fleet_halt_of(&err);
+        assert_eq!(
+            halt.torn_down,
+            vec!["web-a".to_owned()],
+            "the compensated first deploy is reported as torn down, not rolled back"
+        );
+        assert_eq!(
+            halt.rolled_back,
+            vec!["web-b".to_owned()],
+            "the failing redeploy host's own candidate teardown still stands"
+        );
+        assert!(
+            halt.still_on_new.is_empty(),
+            "nothing may be left on the new release"
+        );
+    }
+
+    #[test]
+    fn a_failed_compensation_does_not_stop_the_earlier_hosts() {
+        // #1621 (AC-3, T1.13 case d). Host 3 fails post-boundary; compensation runs
+        // c → b → a and host 2's rollback fails at `restart-previous`. Stopping there
+        // would leave MORE hosts on the new release — a BIGGER mixed fleet — so the
+        // driver continues to host 1 and reports host 2 honestly. This is the one
+        // place the repo's `let _ = run_one(..)` teardown idiom must NOT be reused:
+        // a swallowed compensation failure is how a fleet silently stays mixed.
+        let hosts = ["web-a", "web-b", "web-c"];
+        let fleet = fleet_of(&hosts);
+        let mut recorder = fleet::test_support::FleetRecorder::new();
+        for host in hosts {
+            recorder = script_redeploy(recorder, host);
+        }
+        recorder = script_compensation(recorder, "web-a", "present");
+        recorder =
+            script_compensation(recorder, "web-b", "present").fail("web-b", "restart-previous");
+        recorder =
+            script_compensation(recorder, "web-c", "present").transport_fail("web-c", "drain-old");
+        let fixture = FleetFixture::new();
+
+        let err = run_up_with(&fixture.input(&fleet), |cfg| Ok(recorder.executor(cfg)))
+            .expect_err("a post-boundary failure must halt the rollout");
+
+        // Host 2's rollback failed at or before the flip, so its restarted slot was
+        // disabled again and it is still serving the NEW release.
+        let web_b = recorder.run_labels_for("web-b");
+        assert!(
+            web_b.contains(&"restart-previous")
+                && !web_b
+                    .iter()
+                    .skip_while(|l| **l != "restart-previous")
+                    .any(|l| *l == "commit-markers")
+                && web_b.contains(&"teardown-rollback-slot"),
+            "web-b's rollback must fail before its flip and disable the slot it \
+             restarted: {web_b:?}"
+        );
+        // …and host 1 is still compensated afterwards.
+        let web_a = recorder
+            .index_of("web-a", "restart-previous")
+            .expect("web-a must still be compensated after web-b's rollback failed");
+        let web_b_attempt = recorder
+            .index_of("web-b", "restart-previous")
+            .expect("web-b's rollback was attempted");
+        assert!(
+            web_b_attempt < web_a,
+            "the failed rollback must not stop the earlier host: web-b at \
+             {web_b_attempt}, web-a at {web_a}"
+        );
+
+        let halt = fleet_halt_of(&err);
+        assert_eq!(
+            halt.rolled_back,
+            vec!["web-a".to_owned(), "web-c".to_owned()],
+            "every host whose compensation SUCCEEDED is reported as rolled back"
+        );
+        assert_eq!(
+            halt.still_on_new,
+            vec!["web-b".to_owned()],
+            "a host whose compensation failed is still on the new release and must be \
+             named as such — reporting the attempt instead of the result is how an \
+             operator believes a mixed fleet converged"
+        );
+    }
+
+    #[test]
+    fn a_missing_rollback_target_dir_declines_the_rollback() {
+        // #1621 (AC-3, T1.13 case e / §4.7). `prune` runs per host, so hosts with
+        // divergent deploy history legitimately retain different release sets: the
+        // previous-release marker can name a dir this host no longer has. Flipping
+        // at it anyway starts a unit whose ExecStart points nowhere, passes systemd,
+        // and fails the readiness gate POST-boundary with no teardown — one broken
+        // host becomes two. So the precheck declines, and the host is reported.
+        let fleet = fleet_of(&["web-a", "web-b"]);
+        let mut recorder = fleet::test_support::FleetRecorder::new();
+        for host in ["web-a", "web-b"] {
+            recorder = script_redeploy(recorder, host);
+        }
+        recorder = script_compensation(recorder, "web-a", "absent").fail("web-b", "readiness-gate");
+        let fixture = FleetFixture::new();
+
+        let err = run_up_with(&fixture.input(&fleet), |cfg| Ok(recorder.executor(cfg)))
+            .expect_err("a mid-rollout failure must halt the rollout");
+
+        let web_a = recorder.run_labels_for("web-a");
+        assert!(
+            web_a.contains(&"probe-rollback-target"),
+            "the precheck must actually run: {web_a:?}"
+        );
+        assert!(
+            !web_a.contains(&"restart-previous") && !web_a.contains(&"drain-rolled-back-slot"),
+            "a declined rollback must run NO rollback ops: {web_a:?}"
+        );
+        assert_eq!(
+            web_a.iter().filter(|label| **label == "proxy-flip").count(),
+            1,
+            "the declined host must keep exactly its cutover flip — zero further \
+             flips: {web_a:?}"
+        );
+
+        let halt = fleet_halt_of(&err);
+        assert_eq!(
+            halt.manual,
+            vec![("web-a".to_owned(), fleet::MANUAL_ROLLBACK_TARGET_MISSING)],
+            "the declined host must be reported with its reason"
+        );
+        assert_eq!(
+            halt.still_on_new,
+            vec!["web-a".to_owned()],
+            "a host that was NOT rolled back is still on the new release"
+        );
+        assert_eq!(
+            halt.rolled_back,
+            vec!["web-b".to_owned()],
+            "the failing host's own teardown still stands"
+        );
+    }
+
+    #[test]
+    fn a_commit_markers_failure_is_never_auto_rolled_back() {
+        // #1621 (§4.6, T1.15). `commit-markers` writes previous-release + `current` +
+        // live-slot as ONE remote transaction. A failure inside it can leave any
+        // subset applied, so `resolve_rollback_target` may name the WRONG release —
+        // rolling back could move that host FORWARD, or onto a release it never
+        // served. Fail closed: halt, do not touch that host, print the by-hand
+        // recovery. Earlier hosts are still compensated.
+        let fleet = fleet_of(&["web-a", "web-b"]);
+        let mut recorder = fleet::test_support::FleetRecorder::new();
+        for host in ["web-a", "web-b"] {
+            recorder = script_redeploy(recorder, host);
+        }
+        recorder =
+            script_compensation(recorder, "web-a", "present").fail("web-b", "commit-markers");
+        let fixture = FleetFixture::new();
+
+        let err = run_up_with(&fixture.input(&fleet), |cfg| Ok(recorder.executor(cfg)))
+            .expect_err("an ambiguous-marker failure must halt the rollout");
+
+        let web_b = recorder.run_labels_for("web-b");
+        for rollback_op in [
+            "resolve-previous",
+            "probe-rollback-target",
+            "restart-previous",
+            "drain-rolled-back-slot",
+        ] {
+            assert!(
+                !web_b.contains(&rollback_op),
+                "an ambiguous-marker host must see ZERO rollback-flavoured ops, got \
+                 `{rollback_op}`: {web_b:?}"
+            );
+        }
+        assert_eq!(
+            recorder.run_labels_for("web-a"),
+            redeploy_then_compensated(true),
+            "the earlier host is still compensated"
+        );
+
+        let halt = fleet_halt_of(&err);
+        assert_eq!(halt.failed_step, "commit-markers");
+        assert_eq!(
+            halt.manual,
+            vec![("web-b".to_owned(), fleet::MANUAL_AMBIGUOUS_MARKERS)],
+            "the ambiguous host must be reported as needing a human"
+        );
+        assert_eq!(
+            halt.still_on_new,
+            vec!["web-b".to_owned()],
+            "it was not rolled back, so it is still on the new release"
+        );
+        assert_eq!(halt.rolled_back, vec!["web-a".to_owned()]);
+    }
+
+    #[test]
+    fn a_housekeeping_failure_degrades_the_host_and_continues_the_rollout() {
+        // #1621 (§4.6, T1.15). `prune` runs AFTER the flip: the proxy is already
+        // serving the new release, so a failed `rm -rf` of old release dirs affects
+        // no traffic at all. Rolling three hosts back over it would be a
+        // self-inflicted outage. The rollout warns, marks the host degraded, and
+        // CONTINUES — and the deploy SUCCEEDS, because every host really is serving
+        // the new release.
+        let hosts = ["web-a", "web-b", "web-c"];
+        let fleet = fleet_of(&hosts);
+        let mut recorder = fleet::test_support::FleetRecorder::new();
+        for host in hosts {
+            recorder = script_redeploy(recorder, host);
+        }
+        recorder = recorder.fail("web-b", "prune");
+        let fixture = FleetFixture::new();
+
+        run_up_with(&fixture.input(&fleet), |cfg| Ok(recorder.executor(cfg)))
+            .expect("a post-cutover housekeeping failure must not fail the rollout");
+
+        assert_eq!(
+            recorder.run_labels_for("web-c"),
+            READ_ONLY_PROBES
+                .iter()
+                .copied()
+                .chain(
+                    REDEPLOY_RUN_LABELS
+                        .iter()
+                        .copied()
+                        .filter(|label| *label != "migrate")
+                )
+                .collect::<Vec<_>>(),
+            "the rollout must CONTINUE past a degraded host"
+        );
+        let web_b = recorder.run_labels_for("web-b");
+        assert!(
+            web_b.contains(&"prune")
+                && !web_b.contains(&"teardown-candidate-unit")
+                && !web_b.contains(&"restart-previous"),
+            "a degraded host is live and healthy: nothing may be torn down or rolled \
+             back on it: {web_b:?}"
+        );
+        assert!(
+            recorder.positions_of("resolve-previous").is_empty(),
+            "a rollout that only degraded must compensate NOTHING anywhere"
+        );
+    }
+
+    #[test]
+    fn compensation_never_touches_the_schema() {
+        // #1621 (AC-3, T1.12). Auto-rollback is BINARY-ONLY. `rollback_ops` and
+        // `first_deploy_teardown_ops` contain no `migrate` op by construction, and
+        // that must stay true as they evolve: `rolling_deploy_blocked` grades
+        // `up.sql` only, so an automatic `migrate down` would run exactly the SQL
+        // nothing reviews, unattended, mid-flip. The error text says so too, because
+        // an operator watching binaries go back will otherwise assume the schema did.
+        let hosts = ["web-a", "web-b"];
+        let fleet = fleet_of(&hosts);
+        let mut recorder = fleet::test_support::FleetRecorder::new();
+        for host in hosts {
+            recorder = script_redeploy(recorder, host);
+        }
+        recorder = script_compensation(recorder, "web-a", "present");
+        recorder =
+            script_compensation(recorder, "web-b", "present").transport_fail("web-b", "drain-old");
+        let fixture = FleetFixture::new();
+
+        let err = run_up_with(&fixture.input(&fleet), |cfg| Ok(recorder.executor(cfg)))
+            .expect_err("a post-boundary failure must halt the rollout");
+
+        // Exactly one `migrate` in the WHOLE run — the fleet's single scheduled one,
+        // on the first host's cutover — and none of it after compensation began.
+        let migrations = recorder.positions_of("migrate");
+        assert_eq!(
+            migrations.len(),
+            1,
+            "the fleet migrates once and compensation adds none: {migrations:?}"
+        );
+        let compensation_started = recorder
+            .positions_of("resolve-previous")
+            .first()
+            .copied()
+            .expect("compensation ran");
+        assert!(
+            migrations[0] < compensation_started,
+            "the only migration must predate compensation: migrate at {}, compensation \
+             from {compensation_started}",
+            migrations[0]
+        );
+        assert!(
+            err.to_string().contains("NOT rolled back"),
+            "the halt must state that the schema did not come back with the binaries: {err}"
+        );
+    }
+
+    #[test]
+    fn a_single_host_failure_keeps_todays_error_and_compensates_nothing() {
+        // #1621 (AC-1). N = 1 is exempt from the whole fleet vocabulary: a
+        // single-host deploy that fails must return the pre-#1621 error verbatim —
+        // no classification, no degrade-and-continue, no compensation, no state
+        // table. `prune` is the sharpest case: in a FLEET it degrades and the deploy
+        // succeeds, while for one host it must stay exactly today's failure.
+        let fleet = fleet_of(&["203.0.113.10"]);
+        let recorder = script_redeploy(fleet::test_support::FleetRecorder::new(), "203.0.113.10")
+            .fail("203.0.113.10", "prune");
+        let fixture = FleetFixture::new();
+
+        let err = run_up_with(&fixture.input(&fleet), |cfg| Ok(recorder.executor(cfg)))
+            .expect_err("a single-host post-boundary failure must still fail the deploy");
+
+        match &err {
+            DeployError::Exec(message) => assert_eq!(
+                *message,
+                exec::DeployExecError::CommandFailed {
+                    label: "prune",
+                    message: "scripted failure".to_owned(),
+                }
+                .to_string(),
+                "the single-host path must surface the raw executor error verbatim"
+            ),
+            other => panic!("N = 1 must never produce fleet vocabulary, got: {other:?}"),
+        }
+        assert_eq!(
+            recorder.run_labels_for("203.0.113.10"),
+            READ_ONLY_PROBES
+                .iter()
+                .copied()
+                .chain(REDEPLOY_RUN_LABELS)
+                .collect::<Vec<_>>(),
+            "the one host runs today's exact sequence and nothing more — no \
+             compensation, no extra probe"
         );
     }
 }

--- a/autumn-cli/src/deploy.rs
+++ b/autumn-cli/src/deploy.rs
@@ -115,6 +115,35 @@ pub enum DeployError {
         /// Hosts attempted.
         total: usize,
     },
+
+    /// `deploy status --strict` found drift (issue #1621, AC-6).
+    ///
+    /// Carries no payload: the status table printed above IS the report, and this
+    /// error exists so drift is alertable from cron — the default (non-`--strict`)
+    /// status never fails on drift.
+    #[error(
+        "fleet drift detected — the status table above names each host and reason          (`--strict` exits non-zero on drift so it can be alerted on)"
+    )]
+    DriftDetected,
+
+    /// A fleet `deploy maintenance on|off` did not reach every host (issue #1621,
+    /// AC-5).
+    ///
+    /// Best-effort-and-aggregate: every host was attempted, the per-host table
+    /// above names the ones that DID change (they are deliberately NOT reversed —
+    /// that would reopen the window the operator is closing), and this carries
+    /// only counts — never a host-derived string.
+    #[error(
+        "fleet maintenance {verb} incomplete: {failed} of {total} host(s) failed — the          table above names the hosts that DID change, so they can be reversed by hand          if the fleet must stay consistent"
+    )]
+    FleetMaintenanceFailed {
+        /// Which verb was fanned out (`"on"` / `"off"`).
+        verb: &'static str,
+        /// Hosts whose change failed.
+        failed: usize,
+        /// Hosts attempted.
+        total: usize,
+    },
 }
 
 /// The partial-fleet state a halted rollout leaves behind (issue #1621, AC-3).
@@ -163,6 +192,37 @@ pub enum DeployAction {
     Rollback,
     /// Run the preflight, then perform a REAL first deploy over SSH.
     Up,
+    /// Report every configured host's state, read-only (issue #1621, AC-6).
+    Status,
+    /// Turn maintenance mode ON across every configured host (issue #1621, AC-5).
+    ///
+    /// The flags travel in [`DeployOptions::maintenance`] so this enum stays
+    /// fieldless and `Copy`.
+    MaintenanceOn,
+    /// Turn maintenance mode OFF across every configured host (issue #1621, AC-5).
+    MaintenanceOff,
+}
+
+/// The `autumn deploy maintenance on` flags (issue #1621, AC-5).
+///
+/// Exactly the flag set of the existing local `autumn maintenance on`, because the
+/// two write the SAME wire format — `autumn_web::maintenance::MaintenanceConfig` —
+/// and an operator who knows one must not have to learn the other. This is a plain
+/// owned mirror of `MaintenanceOnOptions` (which borrows, and carries a test-only
+/// path override that has no meaning for a remote host).
+///
+/// Carried in [`DeployOptions`] rather than as a [`DeployAction`] payload so the
+/// action enum stays fieldless and `Copy`.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct MaintenanceOnArgs {
+    /// Human-readable message shown in the 503 body.
+    pub message: Option<String>,
+    /// CIDR blocks / IPs whose requests bypass the gate.
+    pub allow_ips: Vec<String>,
+    /// Let GET/HEAD/OPTIONS through while blocking writes.
+    pub readonly: bool,
+    /// `(header name, expected value)` that bypasses the gate.
+    pub bypass_header: Option<(String, String)>,
 }
 
 /// Flags that modify a [`DeployAction`] (issue #1621, plan §3.1).
@@ -188,6 +248,17 @@ pub struct DeployOptions {
     /// The hosts that already cut over are left exactly as they are for
     /// inspection, and named in the state table. See [`FleetUpInput::auto_rollback`].
     pub no_rollback: bool,
+    /// `deploy status --json`: emit the stable machine-readable report (the repo's
+    /// skills are a first-class consumer) instead of the table.
+    pub json: bool,
+    /// `deploy status --strict`: exit non-zero when ANY drift is detected, so
+    /// drift is alertable from cron. The default status always exits 0 (it is a
+    /// report, not a judgement).
+    pub strict: bool,
+    /// The `deploy maintenance on` flags. `Some` only for
+    /// [`DeployAction::MaintenanceOn`]; `None` everywhere else (including
+    /// `MaintenanceOff`, which takes no flags).
+    pub maintenance: Option<MaintenanceOnArgs>,
 }
 
 /// A `[deploy]` section with all defaults resolved to concrete values.
@@ -371,6 +442,28 @@ impl ResolvedDeployConfig {
     pub fn current_symlink(&self) -> String {
         format!("{}/current", self.app_dir)
     }
+
+    /// The maintenance flag file this host's slot units read (issue #1621, R1).
+    ///
+    /// It lives in the SHARED dir, not a release dir: the runtime's default flag
+    /// path is cwd-relative and a slot unit's `WorkingDirectory` is the release dir,
+    /// so a cutover would orphan the flag and silently un-maintain the host.
+    /// `shared/` is created by `prepare-dirs`, survives cutovers, rollbacks and
+    /// pruning, and is seen by BOTH slots — so a flag written here means the same
+    /// thing before and after a deploy. [`render_app_unit`] stamps this path into
+    /// every slot unit via `AUTUMN_MAINTENANCE_FLAG_FILE`, and the fleet
+    /// `deploy maintenance` fan-out writes exactly here.
+    ///
+    /// The file NAME comes from `autumn_web` — the CLI never re-declares a wire
+    /// path the framework owns.
+    #[must_use]
+    pub fn maintenance_flag_file(&self) -> String {
+        format!(
+            "{}/{}",
+            self.shared_dir(),
+            autumn_web::maintenance::MAINTENANCE_FLAG_BASENAME
+        )
+    }
 }
 
 /// Validate the `[deploy]` host spelling(s) and return the ordered target list
@@ -390,7 +483,13 @@ impl ResolvedDeployConfig {
 ///
 /// Returns a message when `host` and `hosts` are both configured, when a `hosts`
 /// entry is blank, or when a `hosts` entry repeats (compared after trimming).
-fn deploy_host_list(cfg: &DeployConfig) -> Result<Vec<String>, String> {
+// `pub(crate)` (not private): `doctor` enumerates the deploy target list through
+// THIS function so its deploy branch grades the same fleet `deploy check` does —
+// re-deriving the rules there is exactly the drift the parity invariant forbids.
+// In this bin-only crate `deploy` is a private module, so clippy flags the
+// `pub(crate)` as redundant; it is kept to document the intended visibility.
+#[allow(clippy::redundant_pub_crate)]
+pub(crate) fn deploy_host_list(cfg: &DeployConfig) -> Result<Vec<String>, String> {
     let host = cfg
         .host
         .as_deref()
@@ -529,7 +628,6 @@ impl ResolvedFleet {
     // (`ssh_reachability`), byte-identically to pre-#1621, instead of being
     // rejected earlier here with a different message and no report. This is the
     // seam the read-only fleet surfaces (`status`, `maintenance`) use.
-    #[cfg_attr(not(test), allow(dead_code))]
     pub fn resolve(cfg: &DeployConfig, project_name: &str) -> Result<Self, String> {
         let addresses = deploy_host_list(cfg)?;
         if addresses.is_empty() {
@@ -607,7 +705,21 @@ impl DeployStep {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PreflightCheck {
     /// Short stable identifier for the check.
+    ///
+    /// **Deliberately still `&'static str`.** It is the operator-visible key in
+    /// `autumn doctor --json`, so it must not become host-specific; a fleet names
+    /// the host in [`Self::scope`] instead. (Making it dynamic would need a
+    /// `Cow`/`Box::leak` — an unbounded per-host-per-run leak clippy will not flag
+    /// — and would change a published contract for no gain.)
     pub name: &'static str,
+    /// Which fleet host this grader graded, when that is a meaningful question
+    /// (issue #1621, plan §5.2).
+    ///
+    /// `Some(host)` only for a per-host grader in a fleet of MORE THAN ONE host;
+    /// `None` for every project-wide grader and for every check in a single-host
+    /// deploy — which is what keeps single-host output byte-identical to pre-#1621
+    /// (AC-1). [`preflight_label`] is the single place it is rendered.
+    pub scope: Option<String>,
     /// Whether the check passed.
     pub passed: bool,
     /// Whether the check could not be verified here and is deliberately
@@ -627,6 +739,7 @@ impl PreflightCheck {
     fn pass(name: &'static str, detail: impl Into<String>) -> Self {
         Self {
             name,
+            scope: None,
             passed: true,
             deferred: false,
             detail: detail.into(),
@@ -637,11 +750,22 @@ impl PreflightCheck {
     fn fail(name: &'static str, detail: impl Into<String>, hint: &'static str) -> Self {
         Self {
             name,
+            scope: None,
             passed: false,
             deferred: false,
             detail: detail.into(),
             hint: Some(hint),
         }
+    }
+
+    /// Attach the fleet host this check graded (issue #1621).
+    ///
+    /// Always called with `None` for a single-host fleet, so the rendered line is
+    /// byte-identical to pre-#1621.
+    #[must_use]
+    fn scoped(mut self, scope: Option<String>) -> Self {
+        self.scope = scope;
+        self
     }
 
     /// Whether this check must abort the deploy. A check blocks only when it
@@ -656,6 +780,52 @@ impl PreflightCheck {
 }
 
 // ── Preflight graders (AC-6) ─────────────────────────────────────────────────
+
+/// The preflight graders BOTH `autumn deploy check` and `autumn doctor` run, in
+/// the order `deploy check` reports them (issue #1621, plan §5.5).
+///
+/// This is the **single shared source** for the parity invariant that the two
+/// surfaces grade the same things. Doctor's own operator-visible check names are
+/// mechanically this list with a `deploy_` prefix — see
+/// [`DOCTOR_PREFLIGHT_GRADERS`] and the test that pins the derivation.
+///
+/// `ssh_reachability` is the only PER-HOST grader: a fleet emits one row per host
+/// (distinguished by [`PreflightCheck::scope`]) and the other three once, because
+/// they grade the project, not the target.
+#[allow(clippy::redundant_pub_crate)]
+// Consumed by the parity tests (deploy-side and doctor-side). Kept in production
+// code rather than `#[cfg(test)]` because it IS the documented shared source the
+// two surfaces derive from — hiding it in a test module would invite a third,
+// unchecked hand-written list.
+#[cfg_attr(not(test), allow(dead_code))]
+pub(crate) const PREFLIGHT_GRADERS: [&str; 4] = [
+    "ssh_reachability",
+    "signing_secret",
+    "database_url",
+    "migrate_check",
+];
+
+/// `autumn doctor`'s names for [`PREFLIGHT_GRADERS`], in the same order.
+///
+/// These strings are an operator-visible `doctor --json` contract, so they are
+/// spelled out literally (a `const fn` concat is not available for `&'static str`)
+/// and pinned against [`PREFLIGHT_GRADERS`] by
+/// `doctor_deploy_check_names_are_the_shared_grader_names_prefixed`. The doctor
+/// branch indexes THIS array rather than repeating the literals, so a rename can
+/// only happen in one place.
+///
+/// Two doctor deploy checks are deliberately NOT here: `deploy_config` (a
+/// doctor-only config-load guard) and `deploy_host` (the OFFLINE host-presence
+/// grader, which exists because doctor grades a deploy target without `--online`;
+/// `deploy check` subsumes it into `ssh_reachability`, which reports the identical
+/// missing-host detail and hint).
+#[allow(clippy::redundant_pub_crate)]
+pub(crate) const DOCTOR_PREFLIGHT_GRADERS: [&str; 4] = [
+    "deploy_ssh_reachability",
+    "deploy_signing_secret",
+    "deploy_database_url",
+    "deploy_migrate_check",
+];
 
 /// Grade that a deploy target host is configured — a pure, OFFLINE check with no
 /// network I/O. This is deliberately split out from [`grade_ssh_reachability`]
@@ -673,6 +843,99 @@ pub fn grade_deploy_host_present(host: Option<&str>) -> PreflightCheck {
             DEPLOY_HOST_MISSING_DETAIL,
             DEPLOY_HOST_MISSING_HINT,
         ),
+    }
+}
+
+/// Grade that at least one deploy target is configured, across BOTH host
+/// spellings (issue #1621) — the fleet sibling of [`grade_deploy_host_present`].
+///
+/// `hosts` is the validated, ordered list from [`deploy_host_list`]. Used by
+/// `autumn doctor`, whose `deploy_host` check must grade a `[deploy] hosts` fleet
+/// rather than reporting "no target host configured" because the scalar `host` is
+/// unset.
+///
+/// The empty and single-host cases produce **byte-identical** detail/hint to
+/// [`grade_deploy_host_present`], so single-server doctor output is unchanged; only
+/// a real fleet gets the extra host enumeration. That enumeration lives in the
+/// DETAIL text rather than in per-host check names because `CheckResult.name` is an
+/// operator-visible `doctor --json` key (plan §5.2).
+#[must_use]
+pub fn grade_deploy_hosts_present(hosts: &[String]) -> PreflightCheck {
+    match hosts {
+        // Delegate the historical shapes to the historical grader, so their
+        // detail/hint are identical BY CONSTRUCTION rather than by copy.
+        [] => grade_deploy_host_present(None),
+        [only] => grade_deploy_host_present(Some(only)),
+        many => PreflightCheck::pass(
+            "deploy_host",
+            format!(
+                "{} deploy target hosts configured, in rollout order: {}",
+                many.len(),
+                many.join(", ")
+            ),
+        ),
+    }
+}
+
+/// Probe SSH reachability for EVERY configured host and aggregate the result into
+/// ONE check (issue #1621) — the shape `autumn doctor` needs.
+///
+/// `deploy check` reports one `ssh_reachability` row per host (distinguished by
+/// [`PreflightCheck::scope`]); doctor cannot, because its `CheckResult.name` is a
+/// `&'static str` `--json` key that must stay stable and unique. So doctor grades
+/// the same hosts with the same grader and folds the per-host outcomes into the
+/// detail text: the NAME set stays identical between the two surfaces (the parity
+/// invariant, plan §5.5) while the fleet detail is not lost.
+///
+/// A single-host list delegates straight through, so its detail/hint are
+/// byte-identical to pre-#1621. The check fails when ANY host is unreachable — a
+/// rollout touches all of them.
+#[must_use]
+pub fn grade_fleet_ssh_reachability(
+    hosts: &[String],
+    ssh_port: u16,
+    timeout: Duration,
+) -> PreflightCheck {
+    match hosts {
+        [] => grade_ssh_reachability(None, ssh_port, timeout),
+        [only] => grade_ssh_reachability(Some(only.as_str()), ssh_port, timeout),
+        many => {
+            let graded: Vec<(&str, PreflightCheck)> = many
+                .iter()
+                .map(|host| {
+                    (
+                        host.as_str(),
+                        grade_ssh_reachability(Some(host.as_str()), ssh_port, timeout),
+                    )
+                })
+                .collect();
+            let unreachable: Vec<&str> = graded
+                .iter()
+                .filter(|(_, check)| !check.passed)
+                .map(|(host, _)| *host)
+                .collect();
+            if unreachable.is_empty() {
+                PreflightCheck::pass(
+                    "ssh_reachability",
+                    format!(
+                        "SSH port reachable on all {} fleet hosts: {}",
+                        many.len(),
+                        many.join(", ")
+                    ),
+                )
+            } else {
+                PreflightCheck::fail(
+                    "ssh_reachability",
+                    format!(
+                        "cannot reach {} of {} fleet hosts on port {ssh_port}: {}",
+                        unreachable.len(),
+                        many.len(),
+                        unreachable.join(", ")
+                    ),
+                    "Confirm the server is up, the SSH port is open, and any firewall allows your IP",
+                )
+            }
+        }
     }
 }
 
@@ -989,6 +1252,7 @@ pub fn render_app_unit(
          WorkingDirectory={release_dir}\n\
          EnvironmentFile={env_file}\n\
          Environment=AUTUMN_MANIFEST_DIR={manifest_dir}\n\
+         Environment={maintenance_env}={maintenance_flag}\n\
          Environment=AUTUMN_SERVER__HOST=127.0.0.1\n\
          Environment=AUTUMN_SERVER__PORT={app_port}\n\
          ExecStart={release_dir}/{app}\n\
@@ -1008,6 +1272,15 @@ pub fn render_app_unit(
         // release's OWN manifest. Non-secret → unit Environment=, not the 0600 env
         // file.
         manifest_dir = release_dir,
+        // #1621 R1: point the runtime's maintenance flag at the per-app SHARED dir
+        // instead of leaving it cwd-relative (i.e. release-relative, because
+        // `WorkingDirectory` above is the release dir). Without this a cutover
+        // orphans an active maintenance flag and silently un-maintains the host —
+        // and the blue and green slots cannot see each other's flag at all. The
+        // variable name and file name are the framework's, imported (never
+        // re-declared here). Non-secret → unit `Environment=`.
+        maintenance_env = autumn_web::maintenance::MAINTENANCE_FLAG_FILE_ENV,
+        maintenance_flag = cfg.maintenance_flag_file(),
     )
 }
 
@@ -1224,9 +1497,27 @@ pub fn run(action: DeployAction, options: &DeployOptions) -> Result<(), DeployEr
         // and DB URL, so they must see those VALUES resolved under the TARGET
         // deploy profile — not the operator's ambient/dev config. Reload here.
         // `check`/`rollback` deliberately do NOT load the media config.
-        DeployAction::Check => run_check(&load_runtime_config(&resolved)?, &resolved),
+        DeployAction::Check => run_check(&load_runtime_config(&resolved)?, &resolved, &targets),
         DeployAction::Rollback => {
             run_rollback(&load_runtime_config(&resolved)?, &resolved, &targets)
+        }
+        // The read-only fleet surfaces (#1621). Both resolve through
+        // `ResolvedFleet::resolve` — the seam that rejects a malformed/absent target
+        // with one actionable message — and neither loads the media config (they
+        // provision nothing).
+        DeployAction::Status => {
+            let fleet = ResolvedFleet::resolve(&deploy_cfg, &resolve_project_name())
+                .map_err(DeployError::Config)?;
+            run_status(&load_runtime_config(&resolved)?, &fleet, options)
+        }
+        DeployAction::MaintenanceOn | DeployAction::MaintenanceOff => {
+            let fleet = ResolvedFleet::resolve(&deploy_cfg, &resolve_project_name())
+                .map_err(DeployError::Config)?;
+            run_fleet_maintenance_with(&fleet, action, options.maintenance.as_ref(), |cfg| {
+                exec::SshTarget::from_resolved(cfg)
+                    .map(exec::SshExecutor::new)
+                    .ok_or_else(|| DeployError::Config(DEPLOY_HOST_MISSING_DETAIL.to_owned()))
+            })
         }
         DeployAction::Up => {
             let (media_cfg, ffmpeg_bin) = load_media_host_config(&resolved)?;
@@ -1657,10 +1948,16 @@ fn collect_project_preflight(
 /// project-wide graders **once** (issue #1621, AC-7).
 ///
 /// A single-host fleet returns exactly [`collect_preflight`]'s vector, so its
-/// report is byte-identical to pre-#1621 (AC-1). For a real fleet the per-host
-/// rows are distinguished by the grader's own detail text, which already names the
-/// host (`SSH port reachable at web-2:22`) — the structured `scope` field that
-/// `doctor --json` will also carry lands with the CLI-surface slice.
+/// report is byte-identical to pre-#1621 (AC-1). For a real fleet each per-host row
+/// additionally carries [`PreflightCheck::scope`], so `report_preflight` can render
+/// `✅ ssh_reachability (web-2): …` without the grader NAME — a `doctor --json`
+/// contract — ever becoming host-specific.
+///
+/// **No fleet grader ever returns `deferred`** (plan §5.3, pinned by
+/// `no_fleet_preflight_grader_returns_deferred`): `report_preflight` treats deferred
+/// as a non-blocking warning while doctor maps it to a hard `Fail`, so a deferring
+/// fleet grader would make `doctor --strict` reject a config `deploy check` accepts.
+/// These graders pass or they fail.
 ///
 /// The probes run SERIALLY here: they are a bounded TCP connect each, the report
 /// must come out in declaration order, and threading them would put a `Sync` bound
@@ -1676,7 +1973,12 @@ fn collect_fleet_preflight(config: &AutumnConfig, fleet: &ResolvedFleet) -> Vec<
     let mut checks: Vec<PreflightCheck> = fleet
         .hosts
         .iter()
-        .map(|cfg| grade_ssh_reachability(cfg.host.as_deref(), cfg.ssh_port, SSH_PROBE_TIMEOUT))
+        .map(|cfg| {
+            grade_ssh_reachability(cfg.host.as_deref(), cfg.ssh_port, SSH_PROBE_TIMEOUT)
+                // Scope only ever names a host in a REAL fleet — the single-host
+                // branch above returns before this point.
+                .scoped(cfg.host.clone())
+        })
         .collect();
     checks.extend(collect_project_preflight(config, shared));
     checks
@@ -1710,23 +2012,37 @@ fn requires_database_pool(config: &AutumnConfig) -> bool {
         || config.scheduler.backend == autumn_web::config::SchedulerBackend::Postgres
 }
 
+/// The label a preflight line leads with: the stable grader name, plus the fleet
+/// host in parentheses when the check is scoped (issue #1621, plan §5.2).
+///
+/// Pure so the fleet rendering rule is testable without capturing stderr. An
+/// unscoped check (every check in a single-host deploy, and every project-wide
+/// grader in a fleet) renders as the bare name — byte-identical to pre-#1621.
+fn preflight_label(check: &PreflightCheck) -> String {
+    check.scope.as_ref().map_or_else(
+        || check.name.to_owned(),
+        |scope| format!("{} ({scope})", check.name),
+    )
+}
+
 /// Print each preflight check as a pass/fail line and return the failure count.
 /// Shared by `check` and `up` so both surfaces report graders identically.
 fn report_preflight(checks: &[PreflightCheck]) -> usize {
     let mut failed = 0_usize;
     for check in checks {
+        let label = preflight_label(check);
         if check.passed {
-            eprintln!("\u{2705} {}: {}", check.name, check.detail);
+            eprintln!("\u{2705} {label}: {}", check.detail);
         } else if check.deferred {
             // Non-blocking: verified in the service's own runtime, not here.
             // Surfaced as a warning so it is visible but never aborts the deploy.
-            eprintln!("\u{26A0}\u{FE0F}  {}: {}", check.name, check.detail);
+            eprintln!("\u{26A0}\u{FE0F}  {label}: {}", check.detail);
             if let Some(hint) = check.hint {
                 eprintln!("   \u{2192} {hint}");
             }
         } else {
             failed += 1;
-            eprintln!("\u{274C} {}: {}", check.name, check.detail);
+            eprintln!("\u{274C} {label}: {}", check.detail);
             if let Some(hint) = check.hint {
                 eprintln!("   \u{2192} {hint}");
             }
@@ -1736,10 +2052,23 @@ fn report_preflight(checks: &[PreflightCheck]) -> usize {
     failed
 }
 
-fn run_check(config: &AutumnConfig, resolved: &ResolvedDeployConfig) -> Result<(), DeployError> {
+/// Run the preflight over EVERY configured host and report it (issue #1621, AC-7).
+///
+/// `hosts` is the ordered target list from [`deploy_host_list`]. With more than one
+/// entry the per-host `ssh_reachability` grader runs once per host — so an
+/// unreachable host in position 3 is named before any host is touched — and the
+/// three project-wide graders run once. With at most one entry this is the
+/// pre-#1621 single-host report verbatim, down to the absent `scope` suffix (AC-1;
+/// proved by `deploy_check_output_is_identical_for_host_and_a_single_entry_hosts_list`).
+fn run_check(
+    config: &AutumnConfig,
+    resolved: &ResolvedDeployConfig,
+    hosts: &[String],
+) -> Result<(), DeployError> {
     eprintln!("\u{1F342} autumn deploy check\n");
 
-    let checks = collect_preflight(config, resolved);
+    let fleet = ResolvedFleet::from_targets(resolved, hosts);
+    let checks = collect_fleet_preflight(config, &fleet);
     let failed = report_preflight(&checks);
 
     if failed == 0 {
@@ -3485,6 +3814,334 @@ where
     }
 }
 
+// ── `deploy status` (issue #1621, AC-6) ──────────────────────────────────────
+
+/// Probe every fleet host read-only and collect its status row (issue #1621).
+///
+/// Serial and deterministic (declaration order), like every other fleet loop here:
+/// threading the probes would put a `Sync` bound on `DeployExecutor` that the
+/// `RefCell`-based test fake cannot satisfy, and status output must come out in
+/// rollout order anyway. Parallelism is a later, isolated optimisation.
+///
+/// A host whose probe fails becomes an `unreachable` ROW, never an abort:
+/// `deploy status` exists for incidents, and an incident is exactly when a host
+/// may not answer. Only an executor-construction failure (a config with no SSH
+/// target at all) aborts, because then NO host could be probed.
+fn collect_fleet_status<E, F>(
+    fleet: &ResolvedFleet,
+    public_port: u16,
+    make_executor: F,
+) -> Result<Vec<fleet::HostStatus>, DeployError>
+where
+    E: exec::DeployExecutor,
+    F: Fn(&ResolvedDeployConfig) -> Result<E, DeployError>,
+{
+    let mut statuses = Vec::with_capacity(fleet.hosts.len());
+    for cfg in &fleet.hosts {
+        let executor = make_executor(cfg)?;
+        // The probe error is deliberately not printed: it can carry remote stderr,
+        // and "unreachable" in the table is the operator-facing fact.
+        let status = exec::probe_host_status(cfg, public_port, &executor).map_or_else(
+            |_| fleet::HostStatus::unreachable(cfg.host.clone().unwrap_or_default()),
+            |probe| fleet::HostStatus::from_probe(cfg, public_port, &probe),
+        );
+        statuses.push(status);
+    }
+    Ok(statuses)
+}
+
+/// The stable `deploy status --json` shape (issue #1621, AC-6).
+///
+/// The repo's skills are a first-class consumer, so the field set is a documented
+/// contract:
+///
+/// - `hosts`: one object per host, in `[deploy] hosts` (rollout) order, with
+///   `host` (string), `reachable` (bool), `mode`
+///   (`"deployed"`/`"not deployed"`/`"unknown"`/`"unreachable"`), `release`
+///   (string or null when unknown), `live_slot` (string or null), `ready` (HTTP
+///   status number or null), `maintenance` (bool), `proxy_port` (number or null),
+///   and `drift` (array of reason strings, empty when none).
+/// - `version_drift` (bool), `state_drift` (array of `{host, reason}`), and
+///   `drifted` (bool — the `--strict` condition).
+///
+/// Everything here is a host name, an enum word, a number, or a `&'static str`
+/// reason — never a shell line, a remote capture, or a driver error, so no secret
+/// can reach it.
+fn fleet_status_json(
+    statuses: &[fleet::HostStatus],
+    report: &fleet::DriftReport,
+) -> serde_json::Value {
+    let hosts: Vec<serde_json::Value> = statuses
+        .iter()
+        .map(|status| {
+            let mode = if status.reachable {
+                match status.mode {
+                    Some(fleet::HostMode::First) => "not deployed",
+                    Some(fleet::HostMode::Redeploy) => "deployed",
+                    None => "unknown",
+                }
+            } else {
+                "unreachable"
+            };
+            serde_json::json!({
+                "host": status.host,
+                "reachable": status.reachable,
+                "mode": mode,
+                "release": match &status.release {
+                    fleet::ReleaseId::Known(id) => serde_json::Value::String(id.clone()),
+                    fleet::ReleaseId::Unknown => serde_json::Value::Null,
+                },
+                "live_slot": status.live_slot,
+                "ready": status.ready_code,
+                "maintenance": status.maintenance_on,
+                "proxy_port": match status.installed_proxy_port {
+                    exec::InstalledProxyPort::Port(port) => {
+                        serde_json::Value::Number(port.into())
+                    }
+                    _ => serde_json::Value::Null,
+                },
+                "drift": report
+                    .state_drift
+                    .iter()
+                    .filter(|(host, _)| *host == status.host)
+                    .map(|(_, reason)| *reason)
+                    .collect::<Vec<_>>(),
+            })
+        })
+        .collect();
+    serde_json::json!({
+        "hosts": hosts,
+        "version_drift": report.version_drift,
+        "state_drift": report
+            .state_drift
+            .iter()
+            .map(|(host, reason)| serde_json::json!({ "host": host, "reason": reason }))
+            .collect::<Vec<_>>(),
+        "drifted": report.drifted(),
+    })
+}
+
+/// `autumn deploy status`: probe every host read-only and render the shared
+/// per-host table (or `--json`), exiting non-zero on drift only under `--strict`
+/// (issue #1621, AC-6).
+fn run_status(
+    config: &AutumnConfig,
+    fleet: &ResolvedFleet,
+    options: &DeployOptions,
+) -> Result<(), DeployError> {
+    if !options.json {
+        eprintln!("\u{1F342} autumn deploy status\n");
+    }
+    let statuses = collect_fleet_status(fleet, config.server.port, |cfg| {
+        exec::SshTarget::from_resolved(cfg)
+            .map(exec::SshExecutor::new)
+            .ok_or_else(|| DeployError::Config(DEPLOY_HOST_MISSING_DETAIL.to_owned()))
+    })?;
+    let report = fleet::fleet_drift(&statuses);
+    if options.json {
+        // Reports (like `plan`) go to stdout; a `Value` cannot fail to serialise.
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&fleet_status_json(&statuses, &report))
+                .expect("a serde_json::Value always serializes")
+        );
+    } else {
+        for line in fleet::fleet_status_lines(&statuses, &report) {
+            println!("{line}");
+        }
+    }
+    if options.strict && report.drifted() {
+        return Err(DeployError::DriftDetected);
+    }
+    Ok(())
+}
+
+// ── `deploy maintenance on|off` fan-out (issue #1621, AC-5) ──────────────────
+
+/// Serialize the maintenance flag body from the CLI flags (issue #1621).
+///
+/// Goes through `autumn_web::maintenance::MaintenanceConfig` — the exact struct
+/// the RUNTIME deserializes — and the same pretty-printed JSON
+/// `MaintenanceState::save_to_file` writes locally, so the fleet fan-out and the
+/// local `autumn maintenance on` can never disagree about the wire format.
+fn maintenance_flag_body(args: &MaintenanceOnArgs) -> String {
+    let config = autumn_web::maintenance::MaintenanceConfig {
+        message: args.message.clone(),
+        allow_ips: args.allow_ips.clone(),
+        readonly: args.readonly,
+        bypass_header: args.bypass_header.clone(),
+    };
+    serde_json::to_string_pretty(&config).expect("MaintenanceConfig always serializes")
+}
+
+/// Fan `maintenance on|off` out over every fleet host (issue #1621, AC-5).
+///
+/// **Best-effort-and-aggregate — deliberately the OPPOSITE of the rollout
+/// driver** (plan §6.2). Rollout halts and compensates because a mixed-version
+/// fleet is the harm; a control-plane switch that succeeded on 2 of 3 hosts must
+/// NOT be rolled back (that pushes users back into the live window the operator is
+/// closing) and must NOT stop at the failure (the remaining hosts are still
+/// serving). Every host is attempted, every outcome is named in the table, and the
+/// command exits non-zero when ANY host failed.
+///
+/// Per amendment A2 each `on` writes BOTH flag paths:
+///
+/// - `{app_dir}/shared/autumn-maintenance.json` — the authoritative path the
+///   #1621 slot units point `AUTUMN_MAINTENANCE_FLAG_FILE` at; survives cutovers.
+/// - `{current_release_dir}/tmp/autumn-maintenance.json` — the legacy cwd-relative
+///   path units deployed BEFORE #1621 still poll. Written only when the host's
+///   `current` symlink resolves (read from the same read-only probe round-trip);
+///   a host with no resolvable release gets the shared flag only and its row says
+///   so.
+///
+/// `off` removes both (`rm -f`, absent files are not an error).
+///
+/// The executor factory is injected (generic, never `dyn`, no `Send`/`Sync`
+/// bound) so the whole loop is unit-testable against one scripted fake per host.
+fn run_fleet_maintenance_with<E, F>(
+    fleet: &ResolvedFleet,
+    action: DeployAction,
+    args: Option<&MaintenanceOnArgs>,
+    make_executor: F,
+) -> Result<(), DeployError>
+where
+    E: exec::DeployExecutor,
+    F: Fn(&ResolvedDeployConfig) -> Result<E, DeployError>,
+{
+    let on = matches!(action, DeployAction::MaintenanceOn);
+    let verb = if on { "on" } else { "off" };
+    eprintln!("\u{1F342} autumn deploy maintenance {verb}\n");
+
+    let total = fleet.hosts.len();
+    // ONE executor per host, built up front: a host with no SSH target is a config
+    // error, and finding it here means no host has been half-changed yet.
+    let executors = fleet
+        .hosts
+        .iter()
+        .map(&make_executor)
+        .collect::<Result<Vec<E>, DeployError>>()?;
+    let names: Vec<String> = fleet
+        .hosts
+        .iter()
+        .map(|cfg| cfg.host.clone().unwrap_or_default())
+        .collect();
+
+    let default_args = MaintenanceOnArgs::default();
+    let body = maintenance_flag_body(args.unwrap_or(&default_args));
+
+    let mut outcomes = Vec::with_capacity(total);
+    for (index, cfg) in fleet.hosts.iter().enumerate() {
+        eprintln!(
+            "[{}/{total} {}] maintenance {verb}\u{2026}",
+            index + 1,
+            names[index],
+        );
+        outcomes.push(maintenance_one_host(cfg, on, &body, &executors[index]));
+        eprintln!();
+    }
+
+    for line in fleet::fleet_maintenance_summary_lines(&names, &outcomes, on) {
+        eprintln!("{line}");
+    }
+
+    let failed = outcomes
+        .iter()
+        .filter(|outcome| matches!(outcome, fleet::MaintenanceOutcome::Failed { .. }))
+        .count();
+    if failed > 0 {
+        return Err(DeployError::FleetMaintenanceFailed {
+            verb: if on { "on" } else { "off" },
+            failed,
+            total,
+        });
+    }
+    Ok(())
+}
+
+/// Apply `maintenance on|off` to ONE host, returning what happened — never an
+/// error, because the caller continues past a failure (issue #1621, §6.2).
+///
+/// One read-only probe first (`detect-current`, the same shared probe `up` runs)
+/// to resolve the `current` release dir the legacy flag lives under; then the
+/// writes/removals per amendment A2. Only op LABELS ever leave this function —
+/// the raw error can carry remote stderr, and the aggregate report must not.
+fn maintenance_one_host<E: exec::DeployExecutor>(
+    cfg: &ResolvedDeployConfig,
+    on: bool,
+    body: &str,
+    executor: &E,
+) -> fleet::MaintenanceOutcome {
+    let current = match exec::probe_deploy_state(cfg, executor) {
+        Ok(probe) => probe.current_release_dir,
+        Err(_) => {
+            return fleet::MaintenanceOutcome::Failed {
+                failed_step: "detect-current",
+            };
+        }
+    };
+
+    let shared = cfg.maintenance_flag_file();
+    let mut ops: Vec<exec::DeployOp> = Vec::new();
+    if on {
+        // Shared (authoritative) flag first: a #1621 unit reacts within 500 ms of
+        // this single write, so the window starts closing even if the legacy write
+        // below fails.
+        ops.push(exec::DeployOp::WriteFile {
+            label: "maintenance-write-shared",
+            contents: exec::FileContents::Plain(body.to_owned()),
+            remote_path: shared,
+            mode: Some(0o644),
+        });
+        if let Some(dir) = &current {
+            // Legacy path for units deployed before #1621 (amendment A2). The
+            // release-scoped tmp/ dir may not exist yet — the runtime only creates
+            // it when IT writes a flag — so mkdir -p first.
+            ops.push(exec::DeployOp::Run(exec::RemoteCommand::new(
+                "maintenance-prepare-release-tmp",
+                format!("mkdir -p {}", exec::shell_quote(&format!("{dir}/tmp"))),
+            )));
+            ops.push(exec::DeployOp::WriteFile {
+                label: "maintenance-write-release",
+                contents: exec::FileContents::Plain(body.to_owned()),
+                remote_path: format!("{dir}/{}", autumn_web::maintenance::MAINTENANCE_FLAG_FILE),
+                mode: Some(0o644),
+            });
+        }
+    } else {
+        // `rm -f` both paths in one op: absent files are the NORMAL case for at
+        // least one of them (a host has either the new unit or the old), so a
+        // missing file must never fail the `off`.
+        let mut paths = exec::shell_quote(&shared);
+        if let Some(dir) = &current {
+            paths.push(' ');
+            paths.push_str(&exec::shell_quote(&format!(
+                "{dir}/{}",
+                autumn_web::maintenance::MAINTENANCE_FLAG_FILE
+            )));
+        }
+        ops.push(exec::DeployOp::Run(exec::RemoteCommand::new(
+            "maintenance-clear",
+            format!("rm -f {paths}"),
+        )));
+    }
+
+    for op in &ops {
+        if exec::run_ops(std::slice::from_ref(op), executor).is_err() {
+            // The op label is known HERE regardless of the error's shape (an
+            // upload failure carries no label), so the report can always name the
+            // step without quoting the error.
+            return fleet::MaintenanceOutcome::Failed {
+                failed_step: op.label(),
+            };
+        }
+    }
+    if current.is_none() {
+        fleet::MaintenanceOutcome::AppliedSharedOnly
+    } else {
+        fleet::MaintenanceOutcome::Applied
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -3894,6 +4551,166 @@ mod tests {
              fleet: {:?}, single: {expected:?}",
             fleet.hosts[0]
         );
+    }
+
+    /// A minimal loaded config for the preflight graders — no DB, no migrations,
+    /// no secret — so the three project graders return stable, host-independent
+    /// results and the assertions below are about SCOPE, not grading.
+    fn preflight_config() -> AutumnConfig {
+        AutumnConfig::default()
+    }
+
+    #[test]
+    fn preflight_scope_is_none_for_one_host_and_the_host_for_a_fleet() {
+        // #1621 (T1.24, plan §5.2): `scope` is the additive field that lets a fleet
+        // name WHICH host a per-host grader graded, without touching
+        // `PreflightCheck::name` — an operator-visible `doctor --json` contract.
+        //
+        // It is `None` for a single-host fleet, which is what keeps `deploy check`
+        // output byte-identical to pre-#1621 (AC-1, artifact 4). Do not "simplify"
+        // this to always-Some.
+        let config = preflight_config();
+
+        let one = ResolvedFleet::resolve(&fleet_cfg(&["web-1.example.test"]), "myapp")
+            .expect("one-host fleet resolves");
+        let checks = collect_fleet_preflight(&config, &one);
+        assert!(
+            checks.iter().all(|check| check.scope.is_none()),
+            "a single-host fleet must carry no scope (AC-1): {:?}",
+            checks
+                .iter()
+                .map(|c| (c.name, &c.scope))
+                .collect::<Vec<_>>()
+        );
+
+        let many = ResolvedFleet::resolve(
+            &fleet_cfg(&["web-1.example.test", "web-2.example.test"]),
+            "myapp",
+        )
+        .expect("two-host fleet resolves");
+        let checks = collect_fleet_preflight(&config, &many);
+        let scoped: Vec<(&str, Option<&str>)> = checks
+            .iter()
+            .map(|check| (check.name, check.scope.as_deref()))
+            .collect();
+        assert_eq!(
+            scoped
+                .iter()
+                .filter(|(name, _)| *name == "ssh_reachability")
+                .map(|(_, scope)| *scope)
+                .collect::<Vec<_>>(),
+            vec![Some("web-1.example.test"), Some("web-2.example.test")],
+            "each per-host grader must name its host, in rollout order: {scoped:?}"
+        );
+        // The project-wide graders grade the PROJECT, not a host, so they stay
+        // unscoped even in a fleet — scoping them would imply they were run N times.
+        assert!(
+            scoped
+                .iter()
+                .filter(|(name, _)| *name != "ssh_reachability")
+                .all(|(_, scope)| scope.is_none()),
+            "project-wide graders must stay unscoped: {scoped:?}"
+        );
+    }
+
+    #[test]
+    fn no_fleet_preflight_grader_returns_deferred() {
+        // #1621 (T1.16, plan §5.3): `deploy_preflight_result` maps `deferred` →
+        // `CheckStatus::Fail` while `report_preflight` treats it as a NON-blocking
+        // warning, so a deferred fleet grader would mean `doctor --strict` fails a
+        // config `deploy check` passes. The resolution is a rule, not a
+        // reconciliation: FLEET graders pass or they fail — they never defer.
+        // (`deferred` remains in use for the media graders, which are single-host by
+        // construction; see the `[media]` fleet refusal.)
+        let config = preflight_config();
+        for hosts in [
+            vec!["web-1.example.test"],
+            vec!["web-1.example.test", "web-2.example.test"],
+            vec![
+                "web-1.example.test",
+                "web-2.example.test",
+                "web-3.example.test",
+            ],
+        ] {
+            let fleet =
+                ResolvedFleet::resolve(&fleet_cfg(&hosts), "myapp").expect("fleet resolves");
+            for check in collect_fleet_preflight(&config, &fleet) {
+                assert!(
+                    !check.deferred,
+                    "fleet grader `{}` must never defer (scope {:?}): {}",
+                    check.name, check.scope, check.detail
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn preflight_report_label_appends_the_scope_only_when_present() {
+        // #1621 (plan §5.2): `✅ ssh_reachability (web-2): …`. The NAME is unchanged
+        // and stays the stable identifier; the host rides in parentheses after it,
+        // so a single-host run (scope `None`) prints the pre-#1621 label verbatim.
+        let plain = PreflightCheck::pass("ssh_reachability", "reachable");
+        assert_eq!(preflight_label(&plain), "ssh_reachability");
+        let scoped = plain.scoped(Some("web-2.example.test".to_owned()));
+        assert_eq!(
+            preflight_label(&scoped),
+            "ssh_reachability (web-2.example.test)"
+        );
+        assert_eq!(
+            scoped.name, "ssh_reachability",
+            "the stable identifier must not absorb the host"
+        );
+    }
+
+    #[test]
+    fn doctor_deploy_check_names_are_the_shared_grader_names_prefixed() {
+        // #1621 (T2.5, plan §5.5): doctor's deploy checks and `deploy check`'s
+        // graders are enumerated from ONE ordered list, and doctor's operator-visible
+        // `--json` names are exactly that list with a `deploy_` prefix. Deriving the
+        // mapping mechanically (rather than trusting two hand-maintained literal
+        // lists to stay in step) is what turns the comment-enforced parity invariant
+        // into a machine-enforced one.
+        assert_eq!(
+            PREFLIGHT_GRADERS.len(),
+            DOCTOR_PREFLIGHT_GRADERS.len(),
+            "the two lists must stay the same length"
+        );
+        for (grader, doctor_name) in PREFLIGHT_GRADERS.iter().zip(DOCTOR_PREFLIGHT_GRADERS) {
+            assert_eq!(
+                doctor_name,
+                format!("deploy_{grader}"),
+                "doctor's name for `{grader}` must be the prefixed grader name"
+            );
+        }
+        // …and the list is exactly what a fleet preflight emits (the per-host grader
+        // once per host, then the project graders once).
+        let fleet = ResolvedFleet::resolve(
+            &fleet_cfg(&["web-1.example.test", "web-2.example.test"]),
+            "myapp",
+        )
+        .expect("fleet resolves");
+        let emitted: Vec<&str> = collect_fleet_preflight(&preflight_config(), &fleet)
+            .iter()
+            .map(|check| check.name)
+            .collect();
+        assert_eq!(
+            emitted,
+            vec![
+                "ssh_reachability",
+                "ssh_reachability",
+                "signing_secret",
+                "database_url",
+                "migrate_check"
+            ],
+            "the fleet preflight emits the per-host grader once per host, then the \
+             project graders once"
+        );
+        let mut distinct = emitted.clone();
+        distinct.sort_unstable();
+        distinct.dedup();
+        let mut expected = PREFLIGHT_GRADERS.to_vec();
+        expected.sort_unstable();
+        assert_eq!(distinct, expected);
     }
 
     #[test]
@@ -4385,6 +5202,53 @@ mod tests {
         // config loading at `current` (matching its WorkingDirectory), where the
         // active release's uploaded autumn.toml is reachable.
         assert!(unit.contains("Environment=AUTUMN_MANIFEST_DIR=/srv/autumn/shop/current"));
+    }
+
+    #[test]
+    fn app_unit_points_the_maintenance_flag_at_the_shared_dir() {
+        // #1621 R1 (the deliberate cross-cutting register entry): the runtime's
+        // maintenance flag path is cwd-relative and the slot unit's WorkingDirectory
+        // is the RELEASE dir, so before this line a cutover ORPHANED the flag and
+        // silently un-maintained the host. Pointing the override at the per-app
+        // `shared/` dir — which `prepare-dirs` already creates, which survives
+        // cutovers/rollbacks/pruning, and which BOTH slots see — is what makes
+        // `autumn deploy maintenance on` mean anything.
+        //
+        // This line is added to BOTH host spellings equally (it comes from
+        // `render_app_unit`, which the fleet driver and the single-host path share),
+        // so the AC-1 differential invariant is untouched.
+        let cfg = ResolvedDeployConfig::resolve(
+            &DeployConfig {
+                app_name: Some("shop".to_owned()),
+                ..DeployConfig::default()
+            },
+            "shop",
+        )
+        .expect("deploy config resolves");
+        let unit = render_app_unit(&cfg, "/srv/autumn/shop/releases/r1", 3001, "blue");
+        assert!(
+            unit.contains(
+                "Environment=AUTUMN_MAINTENANCE_FLAG_FILE=/srv/autumn/shop/shared/autumn-maintenance.json"
+            ),
+            "slot unit must point the maintenance flag at the shared dir: {unit}"
+        );
+        // It must NOT land under the release dir — that is the defect being fixed.
+        assert!(
+            !unit.contains("AUTUMN_MAINTENANCE_FLAG_FILE=/srv/autumn/shop/releases"),
+            "the maintenance flag must not be release-scoped: {unit}"
+        );
+        // The path the unit stamps IS the one the fan-out writes to.
+        assert!(unit.contains(&format!(
+            "Environment=AUTUMN_MAINTENANCE_FLAG_FILE={}",
+            cfg.maintenance_flag_file()
+        )));
+        // …and it uses the framework's own env-var name and file name, never a
+        // CLI-local re-declaration.
+        assert!(unit.contains(autumn_web::maintenance::MAINTENANCE_FLAG_FILE_ENV));
+        assert!(
+            cfg.maintenance_flag_file()
+                .ends_with(autumn_web::maintenance::MAINTENANCE_FLAG_BASENAME)
+        );
     }
 
     #[test]
@@ -7089,6 +7953,455 @@ mod tests {
         run_fleet_rollback_with(&[], fleet, &proxy, FLEET_PUBLIC_PORT, |cfg| {
             Ok(recorder.executor(cfg))
         })
+    }
+
+    // ── `deploy status` (issue #1621, AC-6) ──────────────────────────────────
+
+    /// Full five-section probe stdout: redeploy on blue, proxy serving blue,
+    /// public port 3000, TLS off, on `release`.
+    fn status_probe(release: &str) -> String {
+        format!(
+            "redeploy:blue\t3001\n\
+             ---autumn-kamal-proxy-list---\n\
+             Service   Host          Target            State    TLS\n\
+             myapp     example.com   127.0.0.1:3001    running  no\n\
+             ---autumn-kamal-proxy-unit---\n--http-port 3000\n\
+             ---autumn-kamal-proxy-options---\n0\t\n\
+             ---autumn-current-release---\n/srv/autumn/myapp/releases/{release}"
+        )
+    }
+
+    /// Script a host's two read-only status probes.
+    fn script_status(
+        recorder: fleet::test_support::FleetRecorder,
+        host: &str,
+        release: &str,
+        ready: &str,
+        maintenance: bool,
+    ) -> fleet::test_support::FleetRecorder {
+        recorder
+            .script(host, "detect-current", status_probe(release))
+            .script(
+                host,
+                "probe-host-status",
+                format!(
+                    "{ready}\n---autumn-host-status---\n{}",
+                    if maintenance { "maintenance-on" } else { "" }
+                ),
+            )
+    }
+
+    fn drive_status(
+        fleet: &ResolvedFleet,
+        recorder: &fleet::test_support::FleetRecorder,
+    ) -> Result<Vec<fleet::HostStatus>, DeployError> {
+        collect_fleet_status(fleet, FLEET_PUBLIC_PORT, |cfg| Ok(recorder.executor(cfg)))
+    }
+
+    #[test]
+    fn fleet_status_reports_every_host_read_only_and_in_declaration_order() {
+        // #1621 (AC-6): `deploy status` is the surface an operator reaches for
+        // mid-incident, so it (a) touches nothing, (b) reports EVERY host, and (c)
+        // keeps declaration order — the same order a rollout would replace them in.
+        let hosts = ["web-a", "web-b", "web-c"];
+        let fleet = fleet_of(&hosts);
+        let mut recorder = fleet::test_support::FleetRecorder::new();
+        for host in hosts {
+            recorder = script_status(recorder, host, "20260714T120000Z", "200", false);
+        }
+
+        let statuses =
+            drive_status(&fleet, &recorder).expect("a read-only status never fails the command");
+
+        assert_eq!(
+            statuses.iter().map(|s| s.host.as_str()).collect::<Vec<_>>(),
+            hosts.to_vec(),
+            "status must keep `[deploy] hosts` order"
+        );
+        for host in hosts {
+            assert_eq!(
+                recorder.run_labels_for(host),
+                vec!["detect-current", "probe-host-status"],
+                "{host}: status must run ONLY the two read-only probes"
+            );
+        }
+        assert!(
+            recorder
+                .mutating(&["detect-current", "probe-host-status"])
+                .is_empty(),
+            "`deploy status` must never mutate a host"
+        );
+        let report = fleet::fleet_drift(&statuses);
+        assert!(!report.drifted(), "a converged fleet reports no drift");
+    }
+
+    #[test]
+    fn fleet_status_reports_an_unreachable_host_as_a_row_not_an_abort() {
+        // A dropped SSH transport on host 2 must NOT abort the report: the fleet's
+        // state is exactly what the operator is trying to learn, and hosts 1 and 3
+        // still have answers. The unreachable host is a row with an unknown release,
+        // and contributes NO drift (a network outage is not a deploy defect).
+        let hosts = ["web-a", "web-b", "web-c"];
+        let fleet = fleet_of(&hosts);
+        let mut recorder = fleet::test_support::FleetRecorder::new();
+        recorder = script_status(recorder, "web-a", "r1", "200", false);
+        recorder = script_status(recorder, "web-b", "r1", "200", false)
+            .transport_fail("web-b", "detect-current");
+        recorder = script_status(recorder, "web-c", "r1", "200", false);
+
+        let statuses = drive_status(&fleet, &recorder).expect("status reports");
+        assert_eq!(statuses.len(), 3, "every host gets a row");
+        assert!(!statuses[1].reachable, "host 2 is reported unreachable");
+        assert!(statuses[0].reachable && statuses[2].reachable);
+        let report = fleet::fleet_drift(&statuses);
+        assert!(
+            !report.version_drift && report.state_drift.is_empty(),
+            "an unreachable host must not manufacture drift: {report:?}"
+        );
+        assert_eq!(report.unknown_releases(), vec!["web-b"]);
+    }
+
+    #[test]
+    fn fleet_status_surfaces_version_drift_across_mixed_releases() {
+        // #1621 (T1.20 at the driver level): two hosts on different releases is the
+        // mixed fleet a rolling deploy exists to avoid, and `--strict` is what makes
+        // it alertable from cron.
+        let hosts = ["web-a", "web-b"];
+        let fleet = fleet_of(&hosts);
+        let mut recorder = fleet::test_support::FleetRecorder::new();
+        recorder = script_status(recorder, "web-a", "20260714T120000Z", "200", false);
+        recorder = script_status(recorder, "web-b", "20260714T130000Z", "200", true);
+
+        let statuses = drive_status(&fleet, &recorder).expect("status reports");
+        let report = fleet::fleet_drift(&statuses);
+        assert!(report.version_drift, "different releases are drift");
+        assert!(statuses[1].maintenance_on, "the flag file is read per host");
+        assert!(
+            statuses[1].ready_code == Some(200),
+            "maintenance does NOT change readiness — the two are orthogonal"
+        );
+
+        let json = fleet_status_json(&statuses, &report);
+        assert_eq!(json["version_drift"], serde_json::json!(true));
+        assert_eq!(
+            json["hosts"][0]["release"],
+            serde_json::json!("20260714T120000Z")
+        );
+        assert_eq!(json["hosts"][1]["maintenance"], serde_json::json!(true));
+        assert_eq!(json["hosts"][1]["ready"], serde_json::json!(200));
+    }
+
+    #[test]
+    fn fleet_status_json_shape_is_stable_and_carries_no_secret() {
+        // The repo's own skills are a first-class consumer of `--json`, so the field
+        // names are a contract. Nothing here is derived from a shell line or a driver
+        // error, so no secret can reach it.
+        let fleet = fleet_of(&["web-a", "web-b"]);
+        let mut recorder = fleet::test_support::FleetRecorder::new();
+        recorder = script_status(recorder, "web-a", "r1", "200", false);
+        recorder = script_status(recorder, "web-b", "r1", "503", false);
+        let statuses = drive_status(&fleet, &recorder).expect("status reports");
+        let json = fleet_status_json(&statuses, &fleet::fleet_drift(&statuses));
+
+        let host = &json["hosts"][0];
+        for field in [
+            "host",
+            "reachable",
+            "mode",
+            "release",
+            "live_slot",
+            "ready",
+            "maintenance",
+            "proxy_port",
+            "drift",
+        ] {
+            assert!(
+                host.get(field).is_some(),
+                "the documented per-host field `{field}` must be present: {json}"
+            );
+        }
+        for field in ["hosts", "version_drift", "state_drift", "drifted"] {
+            assert!(
+                json.get(field).is_some(),
+                "the documented top-level field `{field}` must be present: {json}"
+            );
+        }
+        assert_eq!(host["host"], serde_json::json!("web-a"));
+        assert_eq!(host["mode"], serde_json::json!("deployed"));
+        assert_eq!(json["hosts"][1]["ready"], serde_json::json!(503));
+        let rendered = json.to_string();
+        for secret in ["AUTUMN_SECURITY__SIGNING_SECRET", "postgres://", "curl"] {
+            assert!(
+                !rendered.contains(secret),
+                "the status JSON must never carry `{secret}`: {rendered}"
+            );
+        }
+    }
+
+    // ── `deploy maintenance on|off` fan-out (issue #1621, AC-5) ──────────────
+
+    /// The remote paths a maintenance `on` writes on one host, per amendment A2.
+    const MAINTENANCE_SHARED_PATH: &str = "/srv/autumn/myapp/shared/autumn-maintenance.json";
+    const MAINTENANCE_LEGACY_PATH: &str =
+        "/srv/autumn/myapp/releases/r1/tmp/autumn-maintenance.json";
+
+    fn drive_maintenance(
+        fleet: &ResolvedFleet,
+        recorder: &fleet::test_support::FleetRecorder,
+        verb: DeployAction,
+        args: Option<&MaintenanceOnArgs>,
+    ) -> Result<(), DeployError> {
+        run_fleet_maintenance_with(fleet, verb, args, |cfg| Ok(recorder.executor(cfg)))
+    }
+
+    /// The remote paths `host` was asked to upload to, in order.
+    fn upload_paths(recorder: &fleet::test_support::FleetRecorder, host: &str) -> Vec<String> {
+        recorder
+            .calls_for(host)
+            .iter()
+            .filter_map(|call| match call {
+                exec::test_support::RecordedCall::Upload { remote_path, .. } => {
+                    Some(remote_path.clone())
+                }
+                exec::test_support::RecordedCall::Run { .. } => None,
+            })
+            .collect()
+    }
+
+    #[test]
+    fn fleet_maintenance_on_writes_both_flag_paths_on_every_host() {
+        // #1621 (AC-5, amendment A2): a host deployed BEFORE this release runs a slot
+        // unit with no `AUTUMN_MAINTENANCE_FLAG_FILE`, so its runtime still polls the
+        // cwd-relative `{release_dir}/tmp/…`. Writing only the shared path would make
+        // `deploy maintenance on` silently do nothing on exactly the hosts an operator
+        // is most likely to be maintaining. So both paths are written: the shared one
+        // is authoritative for redeployed hosts, the release-scoped one keeps the
+        // not-yet-redeployed ones working.
+        let hosts = ["web-a", "web-b"];
+        let fleet = fleet_of(&hosts);
+        let mut recorder = fleet::test_support::FleetRecorder::new();
+        for host in hosts {
+            recorder = script_status(recorder, host, "r1", "200", false);
+        }
+
+        let args = MaintenanceOnArgs {
+            message: Some("Upgrading the database".to_owned()),
+            readonly: true,
+            ..MaintenanceOnArgs::default()
+        };
+        drive_maintenance(&fleet, &recorder, DeployAction::MaintenanceOn, Some(&args))
+            .expect("every host accepts the write");
+
+        for host in hosts {
+            let paths = upload_paths(&recorder, host);
+            assert!(
+                paths.iter().any(|p| p == MAINTENANCE_SHARED_PATH),
+                "{host} must get the shared (authoritative) flag: {paths:?}"
+            );
+            assert!(
+                paths.iter().any(|p| p == MAINTENANCE_LEGACY_PATH),
+                "{host} must also get the release-scoped flag for pre-#1621 units: {paths:?}"
+            );
+            // The release-scoped `tmp/` dir may not exist yet.
+            assert!(
+                recorder
+                    .run_labels_for(host)
+                    .contains(&"maintenance-prepare-release-tmp"),
+                "{host} must create the release tmp dir before writing into it"
+            );
+        }
+    }
+
+    #[test]
+    fn fleet_maintenance_on_writes_shared_only_when_current_is_unresolvable() {
+        // A host with no promoted release (its first deploy has not happened yet, or
+        // `current` dangles) has no release dir to carry the legacy flag. The shared
+        // write still happens — a #1621 unit will honour it — and the outcome says
+        // shared-only rather than pretending both landed. Also proves the fan-out
+        // works for an N==1 "fleet" (the deploy-config'd remote host, as distinct
+        // from the LOCAL `autumn maintenance`).
+        let fleet = fleet_of(&["web-a"]);
+        let recorder = fleet::test_support::FleetRecorder::new().script(
+            "web-a",
+            "detect-current",
+            "first\n---autumn-kamal-proxy-list---\n",
+        );
+
+        drive_maintenance(
+            &fleet,
+            &recorder,
+            DeployAction::MaintenanceOn,
+            Some(&MaintenanceOnArgs::default()),
+        )
+        .expect("a shared-only write is a success, not a failure");
+
+        let paths = upload_paths(&recorder, "web-a");
+        assert_eq!(
+            paths,
+            vec![MAINTENANCE_SHARED_PATH.to_owned()],
+            "only the shared flag can be written without a resolvable release"
+        );
+        assert!(
+            !recorder
+                .run_labels_for("web-a")
+                .contains(&"maintenance-prepare-release-tmp"),
+            "no release dir means no release-tmp preparation"
+        );
+    }
+
+    #[test]
+    fn fleet_maintenance_serializes_the_framework_wire_format() {
+        // The flag file's shape is `autumn_web::maintenance::MaintenanceConfig` — the
+        // struct the RUNTIME deserializes. The CLI serialises that type rather than
+        // hand-rolling JSON, so the two can never drift.
+        let args = MaintenanceOnArgs {
+            message: Some("Upgrading".to_owned()),
+            allow_ips: vec!["10.0.0.0/8".to_owned()],
+            readonly: true,
+            bypass_header: Some(("X-Bypass".to_owned(), "tok".to_owned())),
+        };
+        let body = maintenance_flag_body(&args);
+        let parsed: autumn_web::maintenance::MaintenanceConfig =
+            serde_json::from_str(&body).expect("the body must be a MaintenanceConfig");
+        assert_eq!(parsed.message.as_deref(), Some("Upgrading"));
+        assert!(parsed.readonly);
+        assert_eq!(parsed.allow_ips, vec!["10.0.0.0/8"]);
+        assert_eq!(
+            parsed
+                .bypass_header
+                .as_ref()
+                .map(|(n, v)| (n.as_str(), v.as_str())),
+            Some(("X-Bypass", "tok"))
+        );
+    }
+
+    #[test]
+    fn fleet_maintenance_off_removes_both_flag_paths() {
+        let hosts = ["web-a", "web-b"];
+        let fleet = fleet_of(&hosts);
+        let mut recorder = fleet::test_support::FleetRecorder::new();
+        for host in hosts {
+            recorder = script_status(recorder, host, "r1", "200", true);
+        }
+
+        drive_maintenance(&fleet, &recorder, DeployAction::MaintenanceOff, None)
+            .expect("every host clears cleanly");
+
+        for host in hosts {
+            let shell = recorder
+                .calls_for(host)
+                .iter()
+                .find_map(|call| match call {
+                    exec::test_support::RecordedCall::Run { label, shell }
+                        if *label == "maintenance-clear" =>
+                    {
+                        Some(shell.clone())
+                    }
+                    _ => None,
+                })
+                .unwrap_or_else(|| panic!("{host} must run the clear op"));
+            assert!(
+                shell.contains(MAINTENANCE_SHARED_PATH) && shell.contains(MAINTENANCE_LEGACY_PATH),
+                "{host} must clear BOTH paths: {shell}"
+            );
+            assert!(
+                shell.contains("rm -f"),
+                "clearing an absent flag must not be an error: {shell}"
+            );
+            assert!(
+                upload_paths(&recorder, host).is_empty(),
+                "`off` writes nothing"
+            );
+        }
+    }
+
+    #[test]
+    fn fleet_maintenance_attempts_every_host_and_reports_the_ones_that_failed() {
+        // #1621 (T1.21, plan §6.2): control-plane fan-out is best-effort-and-aggregate,
+        // the OPPOSITE of the rollout driver. `maintenance on` that succeeded on 2 of 3
+        // hosts must NOT be rolled back — that would push users back into the very live
+        // window the operator is trying to close — and it must NOT stop at host 2,
+        // because host 3 is still serving. Every host is attempted, all three are named
+        // with their state, and the command exits non-zero.
+        let hosts = ["web-a", "web-b", "web-c"];
+        let fleet = fleet_of(&hosts);
+        let mut recorder = fleet::test_support::FleetRecorder::new();
+        for host in hosts {
+            recorder = script_status(recorder, host, "r1", "200", false);
+        }
+        recorder = recorder.fail_upload("web-b", MAINTENANCE_SHARED_PATH);
+
+        let err = drive_maintenance(
+            &fleet,
+            &recorder,
+            DeployAction::MaintenanceOn,
+            Some(&MaintenanceOnArgs::default()),
+        )
+        .expect_err("a failed host must exit non-zero");
+        let message = err.to_string();
+        assert!(
+            message.contains("1 of 3"),
+            "the error must count the failures against the fleet: {message}"
+        );
+
+        // Hosts 1 and 3 were still attempted AND still wrote — the point of
+        // best-effort-and-aggregate.
+        for host in ["web-a", "web-c"] {
+            assert!(
+                upload_paths(&recorder, host)
+                    .iter()
+                    .any(|p| p == MAINTENANCE_SHARED_PATH),
+                "{host} must still be attempted (and changed) after web-b failed"
+            );
+        }
+        assert!(
+            upload_paths(&recorder, "web-b")
+                .iter()
+                .any(|p| p == MAINTENANCE_SHARED_PATH),
+            "the failing host is attempted too, not skipped"
+        );
+        // Nothing about the failure leaks a shell line or a remote message.
+        for noise in ["scripted upload failure", "rm -f", "printf"] {
+            assert!(
+                !message.contains(noise),
+                "the aggregate error must carry no remote detail: {message}"
+            );
+        }
+    }
+
+    #[test]
+    fn fleet_maintenance_rows_name_every_host_and_the_orthogonality_note() {
+        // Every host is named with what happened to it, so an operator who has to
+        // reverse a partial change knows which hosts changed. And the output states —
+        // every time — that maintenance mode does not drain a host from the LB, because
+        // the opposite assumption causes an outage.
+        let rendered = fleet::fleet_maintenance_summary_lines(
+            &["web-a".to_owned(), "web-b".to_owned(), "web-c".to_owned()],
+            &[
+                fleet::MaintenanceOutcome::Applied,
+                fleet::MaintenanceOutcome::Failed {
+                    failed_step: "maintenance-write-shared",
+                },
+                fleet::MaintenanceOutcome::AppliedSharedOnly,
+            ],
+            true,
+        )
+        .join("\n");
+        for host in ["web-a", "web-b", "web-c"] {
+            assert!(rendered.contains(host), "every host is named:\n{rendered}");
+        }
+        assert!(
+            rendered.contains(fleet::MAINTENANCE_DOES_NOT_DRAIN_NOTE),
+            "the orthogonality note must be printed:\n{rendered}"
+        );
+        assert!(
+            rendered.contains("maintenance-write-shared"),
+            "a failure names its step label:\n{rendered}"
+        );
+        assert!(
+            rendered.contains("Changed anyway: web-a, web-c"),
+            "the hosts that DID change must be named so they can be reversed:\n{rendered}"
+        );
     }
 
     #[test]

--- a/autumn-cli/src/deploy.rs
+++ b/autumn-cli/src/deploy.rs
@@ -1557,11 +1557,24 @@ pub fn run(action: DeployAction, options: &DeployOptions) -> Result<(), DeployEr
         DeployAction::MaintenanceOn | DeployAction::MaintenanceOff => {
             let fleet = ResolvedFleet::resolve(&deploy_cfg, &resolve_project_name())
                 .map_err(DeployError::Config)?;
-            run_fleet_maintenance_with(&fleet, action, options.maintenance.as_ref(), |cfg| {
-                exec::SshTarget::from_resolved(cfg)
-                    .map(exec::SshExecutor::new)
-                    .ok_or_else(|| DeployError::Config(DEPLOY_HOST_MISSING_DETAIL.to_owned()))
-            })
+            // Review round 3: the fan-out writes the flag file each host's LIVE slot
+            // unit actually polls, and deciding WHICH slot that is maps the proxy's
+            // routed target port through the public port. Resolved exactly as
+            // `status` resolves it — same degraded fallback — because maintenance is
+            // switched mid-incident too.
+            let port = status_public_port(&resolved)?;
+            run_fleet_maintenance_with(
+                &fleet,
+                &port,
+                &resolved.profile,
+                action,
+                options.maintenance.as_ref(),
+                |cfg| {
+                    exec::SshTarget::from_resolved(cfg)
+                        .map(exec::SshExecutor::new)
+                        .ok_or_else(|| DeployError::Config(DEPLOY_HOST_MISSING_DETAIL.to_owned()))
+                },
+            )
         }
         DeployAction::Up => {
             let (media_cfg, ffmpeg_bin) = load_media_host_config(&resolved)?;
@@ -4205,9 +4218,10 @@ where
 ///   slot unit observes it, or `null` when the CLI could not prove which flag file
 ///   that unit polls — see `fleet::DRIFT_MAINTENANCE_UNPROVEN`), `proxy_port`
 ///   (number or null),
-///   `last_deploy` (AC-6's third fact: `{result, at}` — `result` is `"deployed"`
-///   or `"rolled back"`, `at` the host's UTC timestamp or null — and the whole
-///   object is null when the host has never completed a cutover or the marker
+///   `last_deploy` (AC-6's third fact: `{result, at}` — `result` is `"deployed"`,
+///   `"rolled back"` or `"torn down"` (a first deploy the driver compensated away,
+///   so the host serves nothing), `at` the host's UTC timestamp or null — and the
+///   whole object is null when the host has never completed a cutover or the marker
 ///   could not be read), and `drift` (array of reason strings, empty when none).
 ///   `last_deploy` is the host's own last COMPLETED action, not a verdict on the
 ///   last rollout: a deploy that failed before cutover never rewrites it (see
@@ -4288,6 +4302,25 @@ fn fleet_status_json(
 /// `autumn deploy status`: probe every host read-only and render the shared
 /// per-host table (or `--json`), exiting non-zero on drift only under `--strict`
 /// (issue #1621, AC-6).
+/// Say out loud that the public port was resolved WITHOUT validating the app
+/// config, and what this command does about it (issue #1621, review round 1).
+///
+/// Never silent, and never on stdout: a `--json` consumer keeps the documented
+/// shape while a human still sees WHY the port was resolved the hard way and WHICH
+/// port the command is working against. `continues` is the caller's own second
+/// line, because `status` (read-only) and `maintenance` (which uses the port only
+/// to identify the live slot unit) owe the operator different sentences.
+fn warn_degraded_port(port: &StatusPort, profile: &str, continues: &str) {
+    let Some(reason) = &port.degraded else {
+        return;
+    };
+    eprintln!(
+        "\u{26A0}\u{FE0F}  this project's configuration does not validate under the \
+         `{profile}` deploy profile: {reason}"
+    );
+    eprintln!("{continues}\n");
+}
+
 fn run_status(
     port: &StatusPort,
     profile: &str,
@@ -4297,21 +4330,16 @@ fn run_status(
     if !options.json {
         eprintln!("\u{1F342} autumn deploy status\n");
     }
-    // Never silent, and never on stdout: a `--json` consumer keeps the documented
-    // shape while a human still sees WHY the port was resolved the hard way and
-    // WHICH port the report is graded against.
-    if let Some(reason) = &port.degraded {
-        eprintln!(
-            "\u{26A0}\u{FE0F}  this project's configuration does not validate under the \
-             `{profile}` deploy profile: {reason}"
-        );
-        eprintln!(
+    warn_degraded_port(
+        port,
+        profile,
+        &format!(
             "   `deploy status` is read-only, so it continues against the DECLARED \
              `[server] port = {}` for that profile (read without validation). \
-             `autumn deploy check`/`up` still refuse to run until the config is fixed.\n",
+             `autumn deploy check`/`up` still refuse to run until the config is fixed.",
             port.port
-        );
-    }
+        ),
+    );
     let statuses = collect_fleet_status(fleet, port.port, |cfg| {
         exec::SshTarget::from_resolved(cfg)
             .map(exec::SshExecutor::new)
@@ -4364,22 +4392,32 @@ fn maintenance_flag_body(args: &MaintenanceOnArgs) -> String {
 /// serving). Every host is attempted, every outcome is named in the table, and the
 /// command exits non-zero when ANY host failed.
 ///
-/// Per amendment A2 each `on` writes BOTH flag paths:
+/// Per amendment A2 each `on` writes up to two flag paths, shared one FIRST:
 ///
 /// - `{app_dir}/shared/autumn-maintenance.json` — the authoritative path the
 ///   #1621 slot units point `AUTUMN_MAINTENANCE_FLAG_FILE` at; survives cutovers.
-/// - `{current_release_dir}/tmp/autumn-maintenance.json` — the legacy cwd-relative
-///   path units deployed BEFORE #1621 still poll. Written only when the host's
-///   `current` symlink resolves (read from the same read-only probe round-trip);
-///   a host with no resolvable release gets the shared flag only and its row says
-///   so.
+///   Always written first, so a #1621 unit reacts within its 500 ms poll even if
+///   the second write fails.
+/// - the file the host's **live slot unit** actually makes the app poll, when that
+///   is a DIFFERENT file — a unit deployed before #1621 carries no override and
+///   polls its own `WorkingDirectory`-relative `tmp/autumn-maintenance.json`.
+///   Resolved from the proxy-selected live slot's unit, exactly as `deploy status`
+///   resolves the flag it REPORTS (review round 3); never from the `current`
+///   symlink, which can name a different release than the unit that is running.
 ///
-/// `off` removes both (`rm -f`, absent files are not an error).
+/// `off` removes the same set (`rm -f`, absent files are not an error).
+///
+/// `public_port` is what maps the proxy's routed target back to a slot, so it is
+/// resolved exactly as `deploy status` resolves it — degraded fallback included,
+/// because a maintenance window gets closed mid-incident and an unrelated invalid
+/// setting must not stand in the way.
 ///
 /// The executor factory is injected (generic, never `dyn`, no `Send`/`Sync`
 /// bound) so the whole loop is unit-testable against one scripted fake per host.
 fn run_fleet_maintenance_with<E, F>(
     fleet: &ResolvedFleet,
+    port: &StatusPort,
+    profile: &str,
     action: DeployAction,
     args: Option<&MaintenanceOnArgs>,
     make_executor: F,
@@ -4391,6 +4429,17 @@ where
     let on = matches!(action, DeployAction::MaintenanceOn);
     let verb = if on { "on" } else { "off" };
     eprintln!("\u{1F342} autumn deploy maintenance {verb}\n");
+    warn_degraded_port(
+        port,
+        profile,
+        &format!(
+            "   `deploy maintenance` continues against the DECLARED `[server] port = {}` \
+             for that profile (read without validation); it uses that port only to identify \
+             which slot unit each host is running. `autumn deploy check`/`up` still refuse \
+             to run until the config is fixed.",
+            port.port
+        ),
+    );
 
     let total = fleet.hosts.len();
     // ONE executor per host, built up front: a host with no SSH target is a config
@@ -4416,7 +4465,13 @@ where
             index + 1,
             names[index],
         );
-        outcomes.push(maintenance_one_host(cfg, on, &body, &executors[index]));
+        outcomes.push(maintenance_one_host(
+            cfg,
+            port.port,
+            on,
+            &body,
+            &executors[index],
+        ));
         eprintln!();
     }
 
@@ -4424,10 +4479,7 @@ where
         eprintln!("{line}");
     }
 
-    let failed = outcomes
-        .iter()
-        .filter(|outcome| matches!(outcome, fleet::MaintenanceOutcome::Failed { .. }))
-        .count();
+    let failed = outcomes.iter().filter(|outcome| outcome.failed()).count();
     if failed > 0 {
         return Err(DeployError::FleetMaintenanceFailed {
             verb: if on { "on" } else { "off" },
@@ -4438,34 +4490,75 @@ where
     Ok(())
 }
 
+/// What the write path could prove about the file this host's RUNNING unit polls
+/// (issue #1621, review round 3).
+enum LiveFlagTarget {
+    /// Nothing is promoted on this host, so no unit is serving and the shared write
+    /// is the whole job.
+    NoRelease,
+    /// The live slot's unit resolves to exactly this file.
+    Path(String),
+    /// A release IS live, but its unit could not be read — so which file the
+    /// application polls is NOT proved. Fail closed: never guessed from `current`.
+    Unproved,
+}
+
 /// Apply `maintenance on|off` to ONE host, returning what happened — never an
 /// error, because the caller continues past a failure (issue #1621, §6.2).
 ///
-/// One read-only probe first (`detect-current`, the same shared probe `up` runs)
-/// to resolve the `current` release dir the legacy flag lives under; then the
-/// writes/removals per amendment A2. Only op LABELS ever leave this function —
-/// the raw error can carry remote stderr, and the aggregate report must not.
+/// Two read-only probes first: `detect-current` (the same shared probe `up` runs)
+/// for the live-slot decision, then `detect-maintenance-flag` — the SAME on-host
+/// resolution `deploy status` reads the maintenance verdict with
+/// ([`exec::probe_live_maintenance_flag`]) — for the file that slot's unit actually
+/// makes the app poll. Resolving the write target the way the read path resolves
+/// its answer is the point: the `current` symlink and the running unit disagree
+/// whenever a proxy flip landed and `commit-markers` did not, and a flag written
+/// under `current` is then a file nothing polls (review round 3).
+///
+/// Then the writes/removals per amendment A2, shared path FIRST.
+///
+/// Only op LABELS ever leave this function — the raw error can carry remote
+/// stderr, and the aggregate report must not.
 fn maintenance_one_host<E: exec::DeployExecutor>(
     cfg: &ResolvedDeployConfig,
+    public_port: u16,
     on: bool,
     body: &str,
     executor: &E,
 ) -> fleet::MaintenanceOutcome {
-    let current = match exec::probe_deploy_state(cfg, executor) {
-        Ok(probe) => probe.current_release_dir,
-        Err(_) => {
-            return fleet::MaintenanceOutcome::Failed {
-                failed_step: "detect-current",
-            };
+    let Ok(probe) = exec::probe_deploy_state(cfg, executor) else {
+        return fleet::MaintenanceOutcome::Failed {
+            failed_step: "detect-current",
+        };
+    };
+    let target = match probe.reconcile(cfg, public_port) {
+        None => LiveFlagTarget::NoRelease,
+        // An unreadable unit AND an unrunnable probe both mean the same thing here:
+        // nothing is proved. The shared write still goes ahead below — it is the
+        // authoritative path and costs nothing to be right about — but the host is
+        // reported as only partially changed.
+        Some(reconcile) => {
+            match exec::probe_live_maintenance_flag(cfg, reconcile.live_slot, executor) {
+                Ok(Some(flag)) => LiveFlagTarget::Path(flag.path),
+                Ok(None) | Err(_) => LiveFlagTarget::Unproved,
+            }
         }
     };
 
     let shared = cfg.maintenance_flag_file();
+    // The file the live unit polls, ONLY when it is not the shared one already
+    // being written: a #1621 unit points at the shared path, and writing a second
+    // copy nothing reads would just leave litter for the next operator to wonder at.
+    let live_path = match &target {
+        LiveFlagTarget::Path(path) if *path != shared => Some(path.clone()),
+        _ => None,
+    };
+
     let mut ops: Vec<exec::DeployOp> = Vec::new();
     if on {
         // Shared (authoritative) flag first: a #1621 unit reacts within 500 ms of
-        // this single write, so the window starts closing even if the legacy write
-        // below fails.
+        // this single write, so the window starts closing even if the write below
+        // fails (amendment A2).
         ops.push(exec::DeployOp::WriteFile {
             label: "maintenance-write-shared",
             contents: exec::FileContents::Plain(body.to_owned()),
@@ -4477,18 +4570,20 @@ fn maintenance_one_host<E: exec::DeployExecutor>(
             // 0600 is sufficient — same rule as the 0600 env file (AC-5).
             mode: Some(0o600),
         });
-        if let Some(dir) = &current {
-            // Legacy path for units deployed before #1621 (amendment A2). The
-            // release-scoped tmp/ dir may not exist yet — the runtime only creates
-            // it when IT writes a flag — so mkdir -p first.
-            ops.push(exec::DeployOp::Run(exec::RemoteCommand::new(
-                "maintenance-prepare-release-tmp",
-                format!("mkdir -p {}", exec::shell_quote(&format!("{dir}/tmp"))),
-            )));
+        if let Some(path) = &live_path {
+            // The dir holding a pre-#1621 unit's flag (its `WorkingDirectory`'s
+            // `tmp/`) may not exist yet — the runtime only creates it when IT
+            // writes a flag — so mkdir -p first.
+            if let Some(parent) = remote_parent_dir(path) {
+                ops.push(exec::DeployOp::Run(exec::RemoteCommand::new(
+                    "maintenance-prepare-live-flag-dir",
+                    format!("mkdir -p {}", exec::shell_quote(parent)),
+                )));
+            }
             ops.push(exec::DeployOp::WriteFile {
-                label: "maintenance-write-release",
+                label: "maintenance-write-live-flag",
                 contents: exec::FileContents::Plain(body.to_owned()),
-                remote_path: format!("{dir}/{}", autumn_web::maintenance::MAINTENANCE_FLAG_FILE),
+                remote_path: path.clone(),
                 // 0600 for the same reason as the shared write above.
                 mode: Some(0o600),
             });
@@ -4498,12 +4593,9 @@ fn maintenance_one_host<E: exec::DeployExecutor>(
         // least one of them (a host has either the new unit or the old), so a
         // missing file must never fail the `off`.
         let mut paths = exec::shell_quote(&shared);
-        if let Some(dir) = &current {
+        if let Some(path) = &live_path {
             paths.push(' ');
-            paths.push_str(&exec::shell_quote(&format!(
-                "{dir}/{}",
-                autumn_web::maintenance::MAINTENANCE_FLAG_FILE
-            )));
+            paths.push_str(&exec::shell_quote(path));
         }
         ops.push(exec::DeployOp::Run(exec::RemoteCommand::new(
             "maintenance-clear",
@@ -4511,21 +4603,38 @@ fn maintenance_one_host<E: exec::DeployExecutor>(
         )));
     }
 
-    for op in &ops {
+    for (index, op) in ops.iter().enumerate() {
         if exec::run_ops(std::slice::from_ref(op), executor).is_err() {
             // The op label is known HERE regardless of the error's shape (an
             // upload failure carries no label), so the report can always name the
             // step without quoting the error.
-            return fleet::MaintenanceOutcome::Failed {
-                failed_step: op.label(),
+            let failed_step = op.label();
+            // Op 0 is the shared path in both directions, so failing it leaves the
+            // host genuinely UNCHANGED; failing anything after it means the shared
+            // flag landed but the running unit's own file did not.
+            return if index == 0 {
+                fleet::MaintenanceOutcome::Failed { failed_step }
+            } else {
+                fleet::MaintenanceOutcome::LiveUnitUnchanged { failed_step }
             };
         }
     }
-    if current.is_none() {
-        fleet::MaintenanceOutcome::AppliedSharedOnly
-    } else {
-        fleet::MaintenanceOutcome::Applied
+    match target {
+        LiveFlagTarget::NoRelease => fleet::MaintenanceOutcome::AppliedSharedOnly,
+        LiveFlagTarget::Path(_) => fleet::MaintenanceOutcome::Applied,
+        // Fail closed. The shared flag changed, but a pre-#1621 unit would ignore
+        // it, so this host must NOT be reported as maintained (or as released from
+        // maintenance) when nothing proved which file it reads.
+        LiveFlagTarget::Unproved => fleet::MaintenanceOutcome::LiveUnitUnchanged {
+            failed_step: "detect-maintenance-flag",
+        },
     }
+}
+
+/// The parent directory of a remote absolute path, or `None` when it has none.
+fn remote_parent_dir(path: &str) -> Option<&str> {
+    let (parent, _) = path.rsplit_once('/')?;
+    (!parent.is_empty()).then_some(parent)
 }
 
 #[cfg(test)]
@@ -9003,6 +9112,10 @@ mod tests {
     const MAINTENANCE_SHARED_PATH: &str = "/srv/autumn/myapp/shared/autumn-maintenance.json";
     const MAINTENANCE_LEGACY_PATH: &str =
         "/srv/autumn/myapp/releases/r1/tmp/autumn-maintenance.json";
+    /// The flag path a pre-#1621 unit resolves to when it is running a DIFFERENT
+    /// release than the one `current` names — the round-3 disagreement.
+    const MAINTENANCE_LIVE_UNIT_PATH: &str =
+        "/srv/autumn/myapp/releases/r2/tmp/autumn-maintenance.json";
 
     fn drive_maintenance(
         fleet: &ResolvedFleet,
@@ -9010,7 +9123,35 @@ mod tests {
         verb: DeployAction,
         args: Option<&MaintenanceOnArgs>,
     ) -> Result<(), DeployError> {
-        run_fleet_maintenance_with(fleet, verb, args, |cfg| Ok(recorder.executor(cfg)))
+        let port = StatusPort {
+            port: FLEET_PUBLIC_PORT,
+            degraded: None,
+        };
+        run_fleet_maintenance_with(fleet, &port, "prod", verb, args, |cfg| {
+            Ok(recorder.executor(cfg))
+        })
+    }
+
+    /// Script one host for the maintenance fan-out: the shared deploy probe, plus
+    /// the flag path that host's LIVE slot unit resolves to (`""` scripts a unit
+    /// that could not be read).
+    fn script_maintenance(
+        recorder: fleet::test_support::FleetRecorder,
+        host: &str,
+        release: &str,
+        unit_flag: &str,
+    ) -> fleet::test_support::FleetRecorder {
+        recorder
+            .script(host, "detect-current", status_probe(release))
+            .script(
+                host,
+                "detect-maintenance-flag",
+                if unit_flag.is_empty() {
+                    String::new()
+                } else {
+                    format!("{unit_flag}\n")
+                },
+            )
     }
 
     /// The remote paths `host` was asked to upload to, in order.
@@ -9040,7 +9181,7 @@ mod tests {
         let fleet = fleet_of(&hosts);
         let mut recorder = fleet::test_support::FleetRecorder::new();
         for host in hosts {
-            recorder = script_status(recorder, host, "r1", "200", false);
+            recorder = script_maintenance(recorder, host, "r1", MAINTENANCE_LEGACY_PATH);
         }
 
         let args = MaintenanceOnArgs {
@@ -9065,8 +9206,9 @@ mod tests {
             assert!(
                 recorder
                     .run_labels_for(host)
-                    .contains(&"maintenance-prepare-release-tmp"),
-                "{host} must create the release tmp dir before writing into it"
+                    .contains(&"maintenance-prepare-live-flag-dir"),
+                "{host} must create the dir holding the running unit's flag before \
+                 writing into it"
             );
         }
     }
@@ -9085,7 +9227,7 @@ mod tests {
         let fleet = fleet_of(&hosts);
         let mut recorder = fleet::test_support::FleetRecorder::new();
         for host in hosts {
-            recorder = script_status(recorder, host, "r1", "200", false);
+            recorder = script_maintenance(recorder, host, "r1", MAINTENANCE_LEGACY_PATH);
         }
 
         let args = MaintenanceOnArgs {
@@ -9131,13 +9273,14 @@ mod tests {
     }
 
     #[test]
-    fn fleet_maintenance_on_writes_shared_only_when_current_is_unresolvable() {
-        // A host with no promoted release (its first deploy has not happened yet, or
-        // `current` dangles) has no release dir to carry the legacy flag. The shared
-        // write still happens — a #1621 unit will honour it — and the outcome says
-        // shared-only rather than pretending both landed. Also proves the fan-out
-        // works for an N==1 "fleet" (the deploy-config'd remote host, as distinct
-        // from the LOCAL `autumn maintenance`).
+    fn fleet_maintenance_on_writes_shared_only_when_no_release_is_promoted() {
+        // A host whose first deploy has not happened yet runs no slot unit at all, so
+        // no application polls a release-local flag and the shared write IS the whole
+        // job — the next deploy installs a #1621 unit that honours it. The outcome says
+        // shared-only rather than pretending two files landed, and unlike the unproved
+        // case (where a unit IS serving) this is a success, not a failure. Also proves
+        // the fan-out works for an N==1 "fleet" (the deploy-config'd remote host, as
+        // distinct from the LOCAL `autumn maintenance`).
         let fleet = fleet_of(&["web-a"]);
         let recorder = fleet::test_support::FleetRecorder::new().script(
             "web-a",
@@ -9162,8 +9305,131 @@ mod tests {
         assert!(
             !recorder
                 .run_labels_for("web-a")
-                .contains(&"maintenance-prepare-release-tmp"),
-            "no release dir means no release-tmp preparation"
+                .contains(&"maintenance-prepare-live-flag-dir"),
+            "no running unit means no second flag dir to prepare"
+        );
+    }
+
+    #[test]
+    fn fleet_maintenance_writes_the_flag_the_running_unit_polls_not_the_symlink_target() {
+        // #1621 review round 3. `current` and the RUNNING unit can disagree: the proxy
+        // flip landed and `commit-markers` did not, so the symlink still names the OLD
+        // release while the live slot unit keeps serving from another one. Deriving the
+        // legacy flag path from `current` then writes a file NOTHING polls — `on`
+        // reports success while the application carries on serving traffic. The write
+        // path must resolve the file from the proxy-selected live slot's unit, exactly
+        // as the status probe reads it, so read and write agree by construction.
+        let fleet = fleet_of(&["web-a"]);
+        let recorder = script_maintenance(
+            fleet::test_support::FleetRecorder::new(),
+            "web-a",
+            "r1",
+            MAINTENANCE_LIVE_UNIT_PATH,
+        );
+
+        drive_maintenance(
+            &fleet,
+            &recorder,
+            DeployAction::MaintenanceOn,
+            Some(&MaintenanceOnArgs::default()),
+        )
+        .expect("both writes land");
+
+        assert_eq!(
+            upload_paths(&recorder, "web-a"),
+            vec![
+                MAINTENANCE_SHARED_PATH.to_owned(),
+                MAINTENANCE_LIVE_UNIT_PATH.to_owned(),
+            ],
+            "the shared flag first (A2), then the file the RUNNING unit polls — and \
+             never the stale `current` target"
+        );
+    }
+
+    #[test]
+    fn fleet_maintenance_on_fails_closed_when_the_running_units_flag_is_unproved() {
+        // The live slot's unit could not be read, so which file the application polls
+        // is NOT proved. The shared (authoritative) write still happens — a #1621 unit
+        // reacts to it within 500 ms — but the host must not be reported as maintained:
+        // a pre-#1621 unit ignores the shared flag entirely, so claiming success here
+        // is exactly the lie the round-3 finding is about.
+        let fleet = fleet_of(&["web-a"]);
+        let recorder =
+            script_maintenance(fleet::test_support::FleetRecorder::new(), "web-a", "r1", "");
+
+        let err = drive_maintenance(
+            &fleet,
+            &recorder,
+            DeployAction::MaintenanceOn,
+            Some(&MaintenanceOnArgs::default()),
+        )
+        .expect_err("an unproved live-unit flag must not exit 0");
+        assert!(
+            err.to_string().contains("1 of 1"),
+            "the host counts as failed in the aggregate: {err}"
+        );
+        assert_eq!(
+            upload_paths(&recorder, "web-a"),
+            vec![MAINTENANCE_SHARED_PATH.to_owned()],
+            "the shared flag is still written first; nothing is GUESSED for the rest"
+        );
+    }
+
+    #[test]
+    fn fleet_maintenance_off_never_claims_to_clear_a_flag_it_cannot_locate() {
+        // The mirror of the `on` case: `off` that cannot prove which file the running
+        // unit polls must not report the host as un-maintained, and must not pretend to
+        // have removed a release-local flag whose path it only guessed from `current`.
+        let fleet = fleet_of(&["web-a"]);
+        let recorder =
+            script_maintenance(fleet::test_support::FleetRecorder::new(), "web-a", "r1", "");
+
+        drive_maintenance(&fleet, &recorder, DeployAction::MaintenanceOff, None)
+            .expect_err("an unproved live-unit flag must not exit 0");
+
+        let shell = recorder
+            .calls_for("web-a")
+            .iter()
+            .find_map(|call| match call {
+                exec::test_support::RecordedCall::Run { label, shell }
+                    if *label == "maintenance-clear" =>
+                {
+                    Some(shell.clone())
+                }
+                _ => None,
+            })
+            .expect("the shared flag is still cleared");
+        assert!(
+            shell.contains(MAINTENANCE_SHARED_PATH),
+            "the shared flag is still removed: {shell}"
+        );
+        assert!(
+            !shell.contains(MAINTENANCE_LEGACY_PATH),
+            "a path derived from `current` must not be removed on a hunch: {shell}"
+        );
+    }
+
+    #[test]
+    fn fleet_maintenance_row_says_the_running_units_flag_was_not_changed() {
+        // The row for a partially-changed host must say BOTH true things: the shared
+        // flag did change (so an operator reversing by hand knows), and the file the
+        // running unit polls did NOT (so nobody reads the row as "this host is
+        // maintained").
+        let rendered = fleet::fleet_maintenance_summary_lines(
+            &["web-a".to_owned()],
+            &[fleet::MaintenanceOutcome::LiveUnitUnchanged {
+                failed_step: "detect-maintenance-flag",
+            }],
+            true,
+        )
+        .join("\n");
+        assert!(
+            rendered.contains("detect-maintenance-flag"),
+            "the row names the step that could not be proved:\n{rendered}"
+        );
+        assert!(
+            rendered.contains("shared flag") && rendered.contains("RUNNING"),
+            "the row must distinguish the shared flag from the running unit's:\n{rendered}"
         );
     }
 
@@ -9199,7 +9465,7 @@ mod tests {
         let fleet = fleet_of(&hosts);
         let mut recorder = fleet::test_support::FleetRecorder::new();
         for host in hosts {
-            recorder = script_status(recorder, host, "r1", "200", true);
+            recorder = script_maintenance(recorder, host, "r1", MAINTENANCE_LEGACY_PATH);
         }
 
         drive_maintenance(&fleet, &recorder, DeployAction::MaintenanceOff, None)
@@ -9245,7 +9511,7 @@ mod tests {
         let fleet = fleet_of(&hosts);
         let mut recorder = fleet::test_support::FleetRecorder::new();
         for host in hosts {
-            recorder = script_status(recorder, host, "r1", "200", false);
+            recorder = script_maintenance(recorder, host, "r1", MAINTENANCE_LEGACY_PATH);
         }
         recorder = recorder.fail_upload("web-b", MAINTENANCE_SHARED_PATH);
 

--- a/autumn-cli/src/deploy.rs
+++ b/autumn-cli/src/deploy.rs
@@ -122,7 +122,8 @@ pub enum DeployError {
     /// error exists so drift is alertable from cron — the default (non-`--strict`)
     /// status never fails on drift.
     #[error(
-        "fleet drift detected — the status table above names each host and reason          (`--strict` exits non-zero on drift so it can be alerted on)"
+        "fleet drift detected — the status table above names each host and reason \
+         (`--strict` exits non-zero on drift so it can be alerted on)"
     )]
     DriftDetected,
 
@@ -134,7 +135,9 @@ pub enum DeployError {
     /// that would reopen the window the operator is closing), and this carries
     /// only counts — never a host-derived string.
     #[error(
-        "fleet maintenance {verb} incomplete: {failed} of {total} host(s) failed — the          table above names the hosts that DID change, so they can be reversed by hand          if the fleet must stay consistent"
+        "fleet maintenance {verb} incomplete: {failed} of {total} host(s) failed — the \
+         table above names the hosts that DID change, so they can be reversed by hand \
+         if the fleet must stay consistent"
     )]
     FleetMaintenanceFailed {
         /// Which verb was fanned out (`"on"` / `"off"`).
@@ -2643,6 +2646,61 @@ fn fleet_auto_migrate_warning(
     (configured_hosts > 1 && enabled).then_some(FLEET_AUTO_MIGRATE_WARNING)
 }
 
+/// The loud line printed when a fleet deploys an app whose background-work
+/// backends are per-process (issue #1621, AC-8).
+///
+/// A **warning, not a refusal**, for the same reason as
+/// [`FLEET_AUTO_MIGRATE_WARNING`] and more so: `[jobs] backend = "local"` and
+/// `[scheduler] backend = "in_process"` are the DEFAULTS every un-configured app
+/// runs, and they are exactly right on one host. Refusing would break every
+/// existing single-host user's scale-up — the one flow AC-8's guide exists to
+/// make easy — for a hazard the rollout itself does not depend on.
+///
+/// Composed rather than constant because it names only the key(s) that actually
+/// apply; see [`fleet_shared_backend_warning`].
+const FLEET_SHARED_BACKEND_WARNING_TAIL: &str = "each host then runs its OWN copy, so work enqueued on one host is only ever run by \
+     that host, whatever is still queued dies when the next rollout drains that host's \
+     old slot, `unique`/`concurrency` limits stop being enforced fleet-wide, and every \
+     scheduled task fires once PER HOST. Move them to a shared backend (`postgres` or \
+     `redis`) before you rely on background work across the fleet \u{2014} see \
+     docs/guide/fleet-deploys.md (#1621).";
+
+/// Whether the fleet must be warned that its background-work backends are
+/// per-process (issue #1621, AC-8) — pure.
+///
+/// `jobs_backend` is compared case-insensitively after trimming, and anything that
+/// is not the in-process `local` default is treated as durable: a backend this CLI
+/// does not know about is the operator having configured something deliberately,
+/// and over-warning them every deploy is worse than staying quiet.
+///
+/// Returns `None` for a single-host config — the in-process defaults are correct
+/// there, and this must be silent on the byte-identical N==1 path (AC-1).
+fn fleet_shared_backend_warning(
+    configured_hosts: usize,
+    jobs_backend: &str,
+    scheduler_in_process: bool,
+) -> Option<String> {
+    if configured_hosts <= 1 {
+        return None;
+    }
+    let jobs_local = jobs_backend.trim().eq_ignore_ascii_case("local");
+    let keys = match (jobs_local, scheduler_in_process) {
+        (true, true) => {
+            "`[jobs] backend = \"local\"` (an in-process queue) and `[scheduler] \
+                         backend = \"in_process\"` (a per-process timer) are in effect"
+        }
+        (true, false) => "`[jobs] backend = \"local\"` (an in-process queue) is in effect",
+        (false, true) => {
+            "`[scheduler] backend = \"in_process\"` (a per-process timer) is in effect"
+        }
+        (false, false) => return None,
+    };
+    Some(format!(
+        "{keys} and this deploy targets more than one host \u{2014} they are PER HOST: \
+         {FLEET_SHARED_BACKEND_WARNING_TAIL}"
+    ))
+}
+
 /// Whether the resolved writable database URL names a `SQLite` backend (issue
 /// #1621, §4.8).
 ///
@@ -2743,6 +2801,11 @@ fn run_up(
                 auto_migrate: config.database.auto_migrate,
                 auto_migrate_in_production: config.database.auto_migrate_in_production,
             },
+            jobs_backend: &config.jobs.backend,
+            scheduler_in_process: matches!(
+                config.scheduler.backend,
+                autumn_web::config::SchedulerBackend::InProcess
+            ),
             // AC-3's default: a halted rollout compensates the hosts that already
             // cut over rather than leaving the fleet on two versions. `--no-rollback`
             // is halt-and-freeze: stop, report, change nothing else.
@@ -2828,6 +2891,13 @@ struct FleetUpInput<'a, P: ProxyController> {
     /// What this project's `[database]` config means for the rollout — resolved
     /// once in the prologue, never re-read here.
     db: FleetDatabaseFacts,
+    /// `[jobs] backend`, verbatim — for the per-host background-work warning
+    /// (AC-8). Not a secret and not host-derived; see
+    /// [`fleet_shared_backend_warning`].
+    jobs_backend: &'a str,
+    /// Whether `[scheduler] backend` is the per-process timer (the default), for
+    /// the same warning.
+    scheduler_in_process: bool,
     /// Whether a halted rollout automatically compensates the hosts that already
     /// cut over (issue #1621, §4.7). `true` in production; `false` is halt-and-freeze
     /// — the rollout stops and reports, leaving every host exactly as it is for
@@ -3074,6 +3144,16 @@ where
     ) {
         eprintln!("\u{26A0}\u{FE0F}  {warning}\n");
     }
+    // Same rule, same reason (AC-8): the in-process job queue and scheduler are
+    // the DEFAULTS every un-configured app runs and are correct on one host, so a
+    // fleet is warned rather than refused.
+    if let Some(warning) = fleet_shared_backend_warning(
+        input.configured_host_count,
+        input.jobs_backend,
+        input.scheduler_in_process,
+    ) {
+        eprintln!("\u{26A0}\u{FE0F}  {warning}\n");
+    }
 
     // ONE executor per host, built up front and reused for that host's read-only
     // probe AND its execution.
@@ -3295,21 +3375,18 @@ where
         // Every host serves the new release either way; a degraded host is live and
         // healthy, so this is a success — but claiming an unqualified "complete"
         // when a host's `record-proxy-options` never landed would hide the thing
-        // that fails its NEXT deploy closed.
-        if degraded.is_empty() {
-            eprintln!(
-                "\n\u{2705} Fleet deploy complete \u{2014} all {total} hosts serving {}.",
+        // that fails its NEXT deploy closed. And on a `--only`-narrowed run `total`
+        // is the SELECTED count, so "all N hosts" would read as a full-fleet
+        // success while the skipped hosts sit on their old release.
+        eprintln!(
+            "{}",
+            fleet::fleet_completion_line(
                 input.release_id,
-            );
-        } else {
-            eprintln!(
-                "\n\u{26A0}\u{FE0F}  Fleet deploy complete \u{2014} all {total} hosts serve {}, \
-                 but {} finished with post-cutover housekeeping failures (above). Repair \
-                 them before the next deploy.",
-                input.release_id,
+                total,
+                input.configured_host_count,
                 degraded.len(),
-            );
-        }
+            )
+        );
     }
     Ok(())
 }
@@ -3939,7 +4016,13 @@ where
 ///   (`"deployed"`/`"not deployed"`/`"unknown"`/`"unreachable"`), `release`
 ///   (string or null when unknown), `live_slot` (string or null), `ready` (HTTP
 ///   status number or null), `maintenance` (bool), `proxy_port` (number or null),
-///   and `drift` (array of reason strings, empty when none).
+///   `last_deploy` (AC-6's third fact: `{result, at}` — `result` is `"deployed"`
+///   or `"rolled back"`, `at` the host's UTC timestamp or null — and the whole
+///   object is null when the host has never completed a cutover or the marker
+///   could not be read), and `drift` (array of reason strings, empty when none).
+///   `last_deploy` is the host's own last COMPLETED action, not a verdict on the
+///   last rollout: a deploy that failed before cutover never rewrites it (see
+///   `fleet::LAST_DEPLOY_SCOPE_NOTE`).
 /// - `version_drift` (bool), `state_drift` (array of `{host, reason}`), and
 ///   `drifted` (bool — the `--strict` condition).
 ///
@@ -3979,6 +4062,10 @@ fn fleet_status_json(
                     }
                     _ => serde_json::Value::Null,
                 },
+                "last_deploy": status.last_deploy.as_ref().map_or(
+                    serde_json::Value::Null,
+                    |last| serde_json::json!({ "result": last.result, "at": last.at }),
+                ),
                 "drift": report
                     .state_drift
                     .iter()
@@ -4169,7 +4256,12 @@ fn maintenance_one_host<E: exec::DeployExecutor>(
             label: "maintenance-write-shared",
             contents: exec::FileContents::Plain(body.to_owned()),
             remote_path: shared,
-            mode: Some(0o644),
+            // 0600: the body can carry the `--bypass-header NAME:VALUE` token (a
+            // credential that skips the 503 gate) and the `--allow-ips` list, and
+            // this mode is applied to the local staging copy too. The flag is
+            // written and read by the same `cfg.user` the slot unit runs as, so
+            // 0600 is sufficient — same rule as the 0600 env file (AC-5).
+            mode: Some(0o600),
         });
         if let Some(dir) = &current {
             // Legacy path for units deployed before #1621 (amendment A2). The
@@ -4183,7 +4275,8 @@ fn maintenance_one_host<E: exec::DeployExecutor>(
                 label: "maintenance-write-release",
                 contents: exec::FileContents::Plain(body.to_owned()),
                 remote_path: format!("{dir}/{}", autumn_web::maintenance::MAINTENANCE_FLAG_FILE),
-                mode: Some(0o644),
+                // 0600 for the same reason as the shared write above.
+                mode: Some(0o600),
             });
         }
     } else {
@@ -6691,6 +6784,10 @@ mod tests {
                     writable_configured: true,
                     ..FleetDatabaseFacts::default()
                 },
+                // Durable by default in the fakes: the AC-8 warning has its own
+                // unit test, and it must not add a line to every driver tape.
+                jobs_backend: "postgres",
+                scheduler_in_process: false,
                 auto_rollback: true,
             }
         }
@@ -7884,6 +7981,53 @@ mod tests {
         assert!(fleet_auto_migrate_warning(3, None, false).is_none());
     }
 
+    #[test]
+    fn per_host_job_and_scheduler_backends_warn_for_a_fleet_and_stay_silent_for_one_host() {
+        // #1621. `[jobs] backend` defaults to `local` (an in-process queue) and
+        // `[scheduler] backend` to `in_process` (a per-process timer). On ONE host
+        // that is correct and is what every un-configured app runs; on N hosts it
+        // silently means N independent queues and N schedulers — enqueued work is
+        // only ever run by the host that took the request, pending work dies with
+        // every `drain-old`, `unique`/`concurrency` stop being enforced fleet-wide,
+        // and every cron fires N times. A WARNING, never a refusal: these are the
+        // DEFAULTS, so refusing would break every existing single-host user's
+        // scale-up (same rule as `FLEET_AUTO_MIGRATE_WARNING`).
+        let warning = fleet_shared_backend_warning(3, "local", true)
+            .expect("a fleet on the in-process defaults must be warned");
+        assert!(
+            warning.contains("[jobs] backend")
+                && warning.contains("[scheduler] backend")
+                && warning.contains("#1621"),
+            "the warning must name both keys and the issue: {warning}"
+        );
+        assert!(
+            warning.to_lowercase().contains("per host") && warning.contains("drain"),
+            "the warning must name the mechanism (a queue per host, drained away): {warning}"
+        );
+
+        // Each backend alone still warns, naming only the key that applies.
+        let jobs_only = fleet_shared_backend_warning(2, "local", false)
+            .expect("a per-host job queue alone must warn");
+        assert!(
+            jobs_only.contains("[jobs] backend") && !jobs_only.contains("[scheduler] backend"),
+            "a durable scheduler must not be named as a problem: {jobs_only}"
+        );
+        let scheduler_only = fleet_shared_backend_warning(2, "postgres", true)
+            .expect("a per-host scheduler alone must warn");
+        assert!(
+            scheduler_only.contains("[scheduler] backend")
+                && !scheduler_only.contains("[jobs] backend"),
+            "a durable job backend must not be named as a problem: {scheduler_only}"
+        );
+
+        // Silent for a single host — the in-process defaults are exactly right
+        // there, and a warning on every `autumn deploy up` would be noise.
+        assert!(fleet_shared_backend_warning(1, "local", true).is_none());
+        // Silent for durable backends, whatever their spelling/case.
+        assert!(fleet_shared_backend_warning(5, "postgres", false).is_none());
+        assert!(fleet_shared_backend_warning(5, " Redis ", false).is_none());
+    }
+
     // ── `--only` (issue #1621, slice 5, §3.2) ────────────────────────────────
 
     #[test]
@@ -8119,9 +8263,27 @@ mod tests {
                 host,
                 "probe-host-status",
                 format!(
-                    "{ready}\n---autumn-host-status---\n{}",
+                    "{ready}\n---autumn-host-status---\n{}\n---autumn-host-status---\n\
+                     deployed\t2026-07-14T12:00:03Z",
                     if maintenance { "maintenance-on" } else { "" }
                 ),
+            )
+    }
+
+    /// `script_status`, but with an explicit last-deploy marker body (AC-6's third
+    /// fact) — `""` scripts a host whose marker is absent/unreadable.
+    fn script_status_last_deploy(
+        recorder: fleet::test_support::FleetRecorder,
+        host: &str,
+        release: &str,
+        last_deploy: &str,
+    ) -> fleet::test_support::FleetRecorder {
+        recorder
+            .script(host, "detect-current", status_probe(release))
+            .script(
+                host,
+                "probe-host-status",
+                format!("200\n---autumn-host-status---\n\n---autumn-host-status---\n{last_deploy}"),
             )
     }
 
@@ -8226,6 +8388,70 @@ mod tests {
     }
 
     #[test]
+    fn status_reports_the_last_deploy_result_per_host() {
+        // #1621 AC-6, third per-host fact. Its motivating case: a rollout halts,
+        // compensation succeeds, and ten minutes later every host reads back
+        // `deployed / R1 / ready 200 / no drift` — a healthy converged fleet with
+        // no trace that the last deploy failed and was compensated. `last deploy`
+        // is what distinguishes those two fleets.
+        let fleet = fleet_of(&["web-a", "web-b", "web-c"]);
+        let mut recorder = fleet::test_support::FleetRecorder::new();
+        recorder =
+            script_status_last_deploy(recorder, "web-a", "r1", "rolled back\t2026-07-14T12:31:10Z");
+        recorder =
+            script_status_last_deploy(recorder, "web-b", "r1", "deployed\t2026-07-14T12:00:03Z");
+        // A host that has never completed a cutover (or whose marker is
+        // unreadable) reports the honest absence, never a fabricated result.
+        recorder = script_status_last_deploy(recorder, "web-c", "r1", "");
+
+        let statuses = drive_status(&fleet, &recorder).expect("status reports");
+        assert_eq!(
+            statuses[0].last_deploy.as_ref().map(|l| l.result.as_str()),
+            Some("rolled back"),
+        );
+        assert_eq!(
+            statuses[0]
+                .last_deploy
+                .as_ref()
+                .and_then(|l| l.at.as_deref()),
+            Some("2026-07-14T12:31:10Z"),
+        );
+        assert_eq!(
+            statuses[1].last_deploy.as_ref().map(|l| l.result.as_str()),
+            Some("deployed"),
+        );
+        assert_eq!(statuses[2].last_deploy, None);
+
+        let report = fleet::fleet_drift(&statuses);
+        // Reported, NOT counted as drift: the fleet is genuinely converged on r1,
+        // and turning a past rollback into a standing alert would page forever.
+        assert!(!report.drifted(), "a past rollback is not fleet drift");
+
+        let rendered = fleet::fleet_status_lines(&statuses, &report).join("\n");
+        assert!(
+            rendered.contains("last deploy: rolled back 2026-07-14T12:31:10Z")
+                && rendered.contains("last deploy: deployed 2026-07-14T12:00:03Z")
+                && rendered.contains("last deploy: ?"),
+            "every host's last-deploy cell must be rendered:\n{rendered}"
+        );
+        // The column's LIMITS are printed where it is read, not only in the guide:
+        // a pre-cutover failure never rewrites the marker, so this is the host's
+        // own last completed action rather than a verdict on the last rollout.
+        assert!(
+            rendered.contains(fleet::LAST_DEPLOY_SCOPE_NOTE),
+            "the status table must state what `last deploy` does and does not know:\n{rendered}"
+        );
+
+        // And the machine-readable surface carries it as a documented object.
+        let json = fleet_status_json(&statuses, &report);
+        assert_eq!(
+            json["hosts"][0]["last_deploy"],
+            serde_json::json!({ "result": "rolled back", "at": "2026-07-14T12:31:10Z" }),
+        );
+        assert_eq!(json["hosts"][2]["last_deploy"], serde_json::Value::Null);
+    }
+
+    #[test]
     fn fleet_status_json_shape_is_stable_and_carries_no_secret() {
         // The repo's own skills are a first-class consumer of `--json`, so the field
         // names are a contract. Nothing here is derived from a shell line or a driver
@@ -8247,6 +8473,7 @@ mod tests {
             "ready",
             "maintenance",
             "proxy_port",
+            "last_deploy",
             "drift",
         ] {
             assert!(
@@ -8344,6 +8571,65 @@ mod tests {
                 "{host} must create the release tmp dir before writing into it"
             );
         }
+    }
+
+    #[test]
+    fn fleet_maintenance_flag_is_written_0600_and_never_echoes_the_bypass_token() {
+        // #1621 review finding 8. The flag body embeds `--bypass-header NAME:VALUE`
+        // — a credential that lets a request skip the 503 gate for the whole
+        // maintenance window — plus the `--allow-ips` list. Both the remote file
+        // and the local staging copy inherit the op's mode, so 0644 exposed the
+        // token to every local account on every fleet host AND in the operator's
+        // own `/tmp`. The file is written and read by the same `cfg.user` that
+        // `render_app_unit` emits as `User=`, so 0600 works exactly as it does for
+        // the env file carrying the signing secret (`exec::env_file` / AC-5).
+        let hosts = ["web-a", "web-b"];
+        let fleet = fleet_of(&hosts);
+        let mut recorder = fleet::test_support::FleetRecorder::new();
+        for host in hosts {
+            recorder = script_status(recorder, host, "r1", "200", false);
+        }
+
+        let args = MaintenanceOnArgs {
+            message: Some("Upgrading the database".to_owned()),
+            allow_ips: vec!["10.0.0.0/8".to_owned()],
+            readonly: true,
+            bypass_header: Some(("X-Dev-Bypass".to_owned(), "s3cr3t-bypass".to_owned())),
+        };
+        drive_maintenance(&fleet, &recorder, DeployAction::MaintenanceOn, Some(&args))
+            .expect("every host accepts the write");
+
+        for host in hosts {
+            let uploads: Vec<(String, Option<u32>)> = recorder
+                .calls_for(host)
+                .iter()
+                .filter_map(|call| match call {
+                    exec::test_support::RecordedCall::Upload { remote_path, mode } => {
+                        Some((remote_path.clone(), *mode))
+                    }
+                    exec::test_support::RecordedCall::Run { .. } => None,
+                })
+                .collect();
+            assert_eq!(
+                uploads.len(),
+                2,
+                "{host} writes the shared and the release-scoped flag: {uploads:?}"
+            );
+            for (path, mode) in &uploads {
+                assert_eq!(
+                    *mode,
+                    Some(0o600),
+                    "{host}: {path} carries the bypass token, so it must not be world-readable"
+                );
+            }
+        }
+
+        // The token must never ride in an op label or a rendered shell line.
+        let calls_debug = format!("{:#?}", recorder.calls_for("web-a"));
+        assert!(
+            !calls_debug.contains("s3cr3t-bypass"),
+            "the bypass token leaked into the recorded executor calls: {calls_debug}"
+        );
     }
 
     #[test]
@@ -8800,5 +9086,43 @@ mod tests {
             ),
             "expected all-hosts-unrolled, got: {err:?}"
         );
+    }
+
+    #[test]
+    fn operator_facing_fleet_error_text_carries_no_line_continuation_gutter() {
+        // #1621 review finding 12. These messages are `\`-continued multi-line
+        // literals; a missing continuation backslash bakes the source indentation
+        // into the message as a long run of spaces mid-sentence. `DriftDetected`
+        // has no placeholders, so its Display output is the literal byte-for-byte.
+        assert_eq!(
+            DeployError::DriftDetected.to_string(),
+            "fleet drift detected \u{2014} the status table above names each host and reason \
+             (`--strict` exits non-zero on drift so it can be alerted on)",
+        );
+        assert_eq!(
+            DeployError::FleetMaintenanceFailed {
+                verb: "on",
+                failed: 1,
+                total: 3,
+            }
+            .to_string(),
+            "fleet maintenance on incomplete: 1 of 3 host(s) failed \u{2014} the table above \
+             names the hosts that DID change, so they can be reversed by hand if the fleet \
+             must stay consistent",
+        );
+        for rendered in [
+            DeployError::DriftDetected.to_string(),
+            DeployError::FleetMaintenanceFailed {
+                verb: "off",
+                failed: 2,
+                total: 5,
+            }
+            .to_string(),
+        ] {
+            assert!(
+                !rendered.contains("   "),
+                "a run of spaces mid-sentence means a `\\` continuation was dropped: {rendered}",
+            );
+        }
     }
 }

--- a/autumn-cli/src/deploy.rs
+++ b/autumn-cli/src/deploy.rs
@@ -47,8 +47,13 @@ const DEPLOY_HOST_MISSING_DETAIL: &str = "no target host configured";
 
 /// Remediation hint for a missing/blank `[deploy] host`. Shared so every surface
 /// (offline `doctor`, online `deploy check`) points at the same fix.
-const DEPLOY_HOST_MISSING_HINT: &str =
-    "Set `[deploy] host` in autumn.toml to your server's SSH-reachable address";
+///
+/// #1621 EXTENDED this text with the fleet spelling rather than replacing it: the
+/// literal substring `` `[deploy] host` `` is asserted by
+/// `deploy_check_fails_fast_without_host` and quoted in operator runbooks, so it
+/// must survive verbatim.
+const DEPLOY_HOST_MISSING_HINT: &str = "Set `[deploy] host` in autumn.toml to your server's SSH-reachable address \
+     (or `[deploy] hosts = [\"<address>\", …]` to deploy a fleet)";
 
 /// Errors surfaced by `autumn deploy`.
 #[derive(Debug, thiserror::Error)]
@@ -266,6 +271,143 @@ impl ResolvedDeployConfig {
     #[must_use]
     pub fn current_symlink(&self) -> String {
         format!("{}/current", self.app_dir)
+    }
+}
+
+/// Validate the `[deploy]` host spelling(s) and return the ordered target list
+/// (issue #1621, AC-1).
+///
+/// Accepts either the historical scalar `[deploy] host` or the fleet list
+/// `[deploy] hosts`, never both, and returns the trimmed addresses **in
+/// declaration order** — the order of `hosts` IS the rollout order, so nothing
+/// here may sort or regroup it. An empty result means neither spelling configured
+/// a target; that is a valid state at rest (`deploy plan` renders without one and
+/// the `ssh_reachability` grader reports it), so it is NOT an error here.
+///
+/// Every rule fails closed BEFORE any remote command runs and names the offending
+/// key/index/value, matching the house style of the other deploy refusals.
+///
+/// # Errors
+///
+/// Returns a message when `host` and `hosts` are both configured, when a `hosts`
+/// entry is blank, or when a `hosts` entry repeats (compared after trimming).
+fn deploy_host_list(cfg: &DeployConfig) -> Result<Vec<String>, String> {
+    let host = cfg
+        .host
+        .as_deref()
+        .map(str::trim)
+        .filter(|host| !host.is_empty());
+
+    // 1. Mutual exclusion. With both set the rollout order is ambiguous, so name
+    //    BOTH keys and let the operator delete one.
+    if host.is_some() && !cfg.hosts.is_empty() {
+        return Err(
+            "`[deploy] host` and `[deploy] hosts` are mutually exclusive: keep the \
+             single-server `[deploy] host = \"<address>\"` or the fleet list \
+             `[deploy] hosts = [\"<address>\", …]` in autumn.toml, not both (#1621)"
+                .to_owned(),
+        );
+    }
+
+    if cfg.hosts.is_empty() {
+        return Ok(host.map(str::to_owned).into_iter().collect());
+    }
+
+    // 2. A blank entry would resolve to a hostless SSH target and blow up
+    //    mid-rollout, with earlier hosts already cut over. The index is 0-based so
+    //    the operator can find the line in a long list.
+    let mut hosts: Vec<String> = Vec::with_capacity(cfg.hosts.len());
+    for (index, entry) in cfg.hosts.iter().enumerate() {
+        let trimmed = entry.trim();
+        if trimmed.is_empty() {
+            return Err(format!(
+                "`[deploy] hosts` entry {index} is blank: every fleet entry must be an \
+                 SSH-reachable hostname or IP (#1621)"
+            ));
+        }
+
+        // 3. A duplicate deploys the same machine twice: the second pass sees its
+        //    OWN new release as live, ping-pongs the blue/green slots and corrupts
+        //    the previous-release chain a fleet rollback depends on. Compared after
+        //    trimming; DNS aliases are a documented limitation (same as
+        //    `migrate`'s `reject_duplicate_target_urls`).
+        if hosts.iter().any(|seen| seen == trimmed) {
+            return Err(format!(
+                "`[deploy] hosts` lists `{trimmed}` more than once: each fleet host must \
+                 appear exactly once — deploying the same server twice corrupts its \
+                 previous-release chain (#1621)"
+            ));
+        }
+        hosts.push(trimmed.to_owned());
+    }
+
+    Ok(hosts)
+}
+
+/// An ordered fleet of deploy targets, each a fully-resolved
+/// [`ResolvedDeployConfig`] (issue #1621, AC-1).
+///
+/// The elements differ **only** in `host`: the shared shape (the `app_name` →
+/// `app_dir` → `service_name` chain, the TLS-requires-host rejection, profile
+/// trimming) is resolved ONCE through [`ResolvedDeployConfig::resolve`] and then
+/// cloned per host. That is what makes a one-entry `hosts` list byte-for-byte the
+/// historical single-server deploy *by construction* rather than by review —
+/// everything below `exec::SshTarget::from_resolved` keeps working unchanged.
+///
+/// The list is never empty and is always in declaration (rollout) order.
+#[derive(Debug, Clone, PartialEq, Eq)]
+// Reachable from the unit tests today; the rollout driver that consumes it lands
+// in a later slice of #1621, so the non-test binary build is allowed not to use
+// it yet (mirroring `exec::run_ops`'s test-only reachability).
+#[cfg_attr(not(test), allow(dead_code))]
+pub struct ResolvedFleet {
+    /// The resolved targets, in rollout order. Guaranteed non-empty.
+    pub hosts: Vec<ResolvedDeployConfig>,
+}
+
+#[cfg_attr(not(test), allow(dead_code))]
+impl ResolvedFleet {
+    /// Resolve a [`DeployConfig`] into an ordered fleet against the project name.
+    ///
+    /// Validation runs first, in the documented order (mutual exclusion → blank
+    /// entry → duplicate entry → no target at all), so a malformed fleet is
+    /// refused before any host is touched.
+    ///
+    /// # Errors
+    ///
+    /// Returns a message when [`deploy_host_list`] rejects the host spelling(s),
+    /// when neither `host` nor `hosts` configures a target, or when
+    /// [`ResolvedDeployConfig::resolve`] rejects the shared shape (e.g.
+    /// `[deploy.tls] enabled = true` with no `host`).
+    pub fn resolve(cfg: &DeployConfig, project_name: &str) -> Result<Self, String> {
+        let addresses = deploy_host_list(cfg)?;
+        if addresses.is_empty() {
+            // 4. Neither spelling configured a target. Reuse the shared
+            //    missing-host strings so `deploy check`, `doctor` and this seam
+            //    report the case identically.
+            return Err(format!(
+                "{DEPLOY_HOST_MISSING_DETAIL}: {DEPLOY_HOST_MISSING_HINT}"
+            ));
+        }
+
+        // Resolve the shared shape ONCE, then vary only `host`.
+        let shared = ResolvedDeployConfig::resolve(cfg, project_name)?;
+        let hosts = addresses
+            .into_iter()
+            .map(|host| ResolvedDeployConfig {
+                host: Some(host),
+                ..shared.clone()
+            })
+            .collect();
+
+        Ok(Self { hosts })
+    }
+
+    /// Whether this fleet is a single server — the shape every pre-#1621 config
+    /// resolves to, and the one that must behave identically to today.
+    #[must_use]
+    pub const fn is_single(&self) -> bool {
+        self.hosts.len() == 1
     }
 }
 
@@ -871,6 +1013,13 @@ pub fn run(action: DeployAction) -> Result<(), DeployError> {
     let ambient_config = AutumnConfig::load_lenient_unknown_roots()
         .map_err(|e| DeployError::Config(e.to_string()))?;
     let deploy_cfg = ambient_config.deploy.unwrap_or_default();
+    // #1621: refuse a malformed host spelling — `host` AND `hosts` together, a
+    // blank entry, a duplicate entry — before ANY other work, so the operator sees
+    // one actionable message instead of a preflight report graded against a target
+    // list we could not make sense of. The resolved list itself is consumed by
+    // `ResolvedFleet` (the rollout driver lands in a later slice); here only the
+    // refusal matters, and the single-host path below is deliberately untouched.
+    deploy_host_list(&deploy_cfg).map_err(DeployError::Config)?;
     let resolved = ResolvedDeployConfig::resolve(&deploy_cfg, &resolve_project_name())
         .map_err(DeployError::Config)?;
 
@@ -2297,6 +2446,270 @@ mod tests {
                 "error should name the section and the missing key, got: {err}",
             );
         }
+    }
+
+    // ── fleet host list (#1621) ───────────────────────────────────
+
+    /// A `[deploy]` config carrying only the fleet list, so the fleet tests read
+    /// as the TOML an operator would write.
+    fn fleet_cfg(hosts: &[&str]) -> DeployConfig {
+        DeployConfig {
+            hosts: hosts.iter().map(|h| (*h).to_owned()).collect(),
+            ..DeployConfig::default()
+        }
+    }
+
+    #[test]
+    fn fleet_resolve_keeps_declaration_order_as_the_rollout_order() {
+        // #1621 (AC-1/AC-2): the order of `[deploy] hosts` IS the rollout order —
+        // it is a documented contract, not an implementation detail, so resolution
+        // must never sort or dedupe-reorder it.
+        let fleet = ResolvedFleet::resolve(&fleet_cfg(&["web-3", "web-1", "web-2"]), "myapp")
+            .expect("a well-formed fleet resolves");
+        let hosts: Vec<Option<&str>> = fleet.hosts.iter().map(|h| h.host.as_deref()).collect();
+        assert_eq!(
+            hosts,
+            vec![Some("web-3"), Some("web-1"), Some("web-2")],
+            "fleet resolution must preserve declaration order, got: {hosts:?}"
+        );
+        assert!(
+            !fleet.is_single(),
+            "a 3-host fleet must not report as single-host, got: {:?}",
+            fleet.hosts.len()
+        );
+    }
+
+    #[test]
+    fn fleet_resolve_rejects_host_and_hosts_set_together_naming_both_keys() {
+        // #1621 (AC-1): the two spellings are mutually exclusive — with both set
+        // the rollout order is ambiguous, so this fails closed BEFORE any remote
+        // command runs, naming both keys so the operator knows what to delete.
+        let cfg = DeployConfig {
+            host: Some("203.0.113.10".to_owned()),
+            hosts: vec!["web-1.example.com".to_owned()],
+            ..DeployConfig::default()
+        };
+        let err = ResolvedFleet::resolve(&cfg, "myapp")
+            .expect_err("host + hosts together must be rejected");
+        assert!(
+            err.contains("[deploy] host") && err.contains("[deploy] hosts"),
+            "the mutual-exclusion error must name BOTH keys, got: {err}"
+        );
+        assert!(
+            err.contains("#1621"),
+            "fail-closed refusals cite the tracking issue, got: {err}"
+        );
+    }
+
+    #[test]
+    fn fleet_resolve_rejects_a_blank_hosts_entry_naming_its_index() {
+        // #1621 (AC-1): a blank entry would resolve to a hostless SSH target and
+        // fail mid-rollout with hosts already cut over. The index is 0-based and
+        // named so the operator can find the offending line in a long list.
+        for (index, hosts) in [
+            (0_usize, vec![String::new(), "web-2".to_owned()]),
+            (1, vec!["web-1".to_owned(), "   ".to_owned()]),
+            (
+                2,
+                vec!["web-1".to_owned(), "web-2".to_owned(), "\t".to_owned()],
+            ),
+        ] {
+            let cfg = DeployConfig {
+                hosts,
+                ..DeployConfig::default()
+            };
+            let err = ResolvedFleet::resolve(&cfg, "myapp")
+                .expect_err("a blank hosts entry must be rejected");
+            assert!(
+                err.contains("[deploy] hosts") && err.contains(&format!("{index}")),
+                "the blank-entry error must name the key and the 0-based index {index}, got: {err}"
+            );
+        }
+    }
+
+    #[test]
+    fn fleet_resolve_rejects_duplicate_hosts_after_trimming_naming_the_value() {
+        // #1621 (AC-1/AC-3): deploying the same machine twice makes the second
+        // pass see its OWN new release as live, ping-pongs the blue/green slots and
+        // corrupts the previous-release chain a fleet rollback depends on. Trim
+        // first so `"web-1"` and `" web-1 "` are recognised as the same host.
+        // (Literal duplicates only — DNS aliases are a documented limitation.)
+        let cfg = fleet_cfg(&["web-1.example.com", "web-2", " web-1.example.com "]);
+        let err = ResolvedFleet::resolve(&cfg, "myapp")
+            .expect_err("a duplicate hosts entry must be rejected");
+        assert!(
+            err.contains("web-1.example.com"),
+            "the duplicate error must name the repeated value, got: {err}"
+        );
+        assert!(
+            err.contains("[deploy] hosts"),
+            "the duplicate error must name the config key, got: {err}"
+        );
+    }
+
+    #[test]
+    fn fleet_resolve_without_any_host_keeps_the_deploy_host_message() {
+        // #1621 (AC-1): with neither key set the operator sees the SAME
+        // missing-host text as before, EXTENDED to mention the fleet spelling. The
+        // literal substring "[deploy] host" is asserted by
+        // `deploy_check_fails_fast_without_host` and quoted in operator runbooks,
+        // so it must survive the extension verbatim.
+        let err = ResolvedFleet::resolve(&DeployConfig::default(), "myapp")
+            .expect_err("no host and no hosts must be rejected");
+        assert!(
+            err.contains("[deploy] host"),
+            "the missing-target error must keep the historical `[deploy] host` \
+             substring, got: {err}"
+        );
+        assert!(
+            err.contains("hosts"),
+            "the missing-target error must also offer the fleet spelling, got: {err}"
+        );
+
+        // A blank scalar host is the same case as an absent one.
+        let blank = DeployConfig {
+            host: Some("   ".to_owned()),
+            ..DeployConfig::default()
+        };
+        let blank_err = ResolvedFleet::resolve(&blank, "myapp")
+            .expect_err("a blank host must be rejected like an absent one");
+        assert!(
+            blank_err.contains("[deploy] host"),
+            "a blank host must report the missing-target message, got: {blank_err}"
+        );
+    }
+
+    #[test]
+    fn single_entry_hosts_resolves_to_the_same_view_as_host() {
+        // #1621 (AC-1, proof P5): a one-entry `hosts` list is byte-for-byte the
+        // historical single-server deploy. Value equality against
+        // `ResolvedDeployConfig::resolve` of the equivalent `host` config is the
+        // structural guarantee — everything below `SshTarget::from_resolved` then
+        // behaves identically by construction.
+        let single = DeployConfig {
+            host: Some("203.0.113.10".to_owned()),
+            app_name: Some("shop".to_owned()),
+            user: "deploy".to_owned(),
+            ssh_port: 2222,
+            readiness_timeout_secs: 90,
+            keep_releases: 5,
+            profile: "staging".to_owned(),
+            ..DeployConfig::default()
+        };
+        let fleet_cfg = DeployConfig {
+            host: None,
+            hosts: vec!["203.0.113.10".to_owned()],
+            ..single.clone()
+        };
+
+        let expected =
+            ResolvedDeployConfig::resolve(&single, "myapp").expect("single host resolves");
+        let fleet =
+            ResolvedFleet::resolve(&fleet_cfg, "myapp").expect("single-entry fleet resolves");
+        assert!(
+            fleet.is_single(),
+            "a one-entry hosts list must report as single-host, got {} hosts",
+            fleet.hosts.len()
+        );
+        assert_eq!(
+            fleet.hosts[0], expected,
+            "a one-entry `hosts` list must resolve to exactly the `host` view; \
+             fleet: {:?}, single: {expected:?}",
+            fleet.hosts[0]
+        );
+    }
+
+    #[test]
+    fn fleet_resolve_trims_each_host_like_the_single_host_path() {
+        // #1621 (AC-1): `ResolvedDeployConfig::resolve` trims the scalar `host`,
+        // so the fleet list must trim each entry identically — otherwise a stray
+        // space produces a different SSH target under the two spellings.
+        let padded = fleet_cfg(&["  203.0.113.10  "]);
+        let fleet = ResolvedFleet::resolve(&padded, "myapp").expect("padded fleet resolves");
+        let expected = ResolvedDeployConfig::resolve(
+            &DeployConfig {
+                host: Some("  203.0.113.10  ".to_owned()),
+                ..DeployConfig::default()
+            },
+            "myapp",
+        )
+        .expect("padded single host resolves");
+        assert_eq!(
+            fleet.hosts[0], expected,
+            "each fleet entry must be trimmed exactly like the scalar host, got: {:?}",
+            fleet.hosts[0]
+        );
+    }
+
+    #[test]
+    fn fleet_resolve_shares_the_single_host_defaults_and_tls_validation() {
+        // #1621 (AC-1): the fleet resolves the SHARED shape once through
+        // `ResolvedDeployConfig::resolve`, so the app_name → app_dir →
+        // service_name chain and the TLS-requires-host rejection are literally the
+        // same code — they cannot drift between the two spellings.
+        let fleet = ResolvedFleet::resolve(&fleet_cfg(&["web-1", "web-2"]), "myapp")
+            .expect("a well-formed fleet resolves");
+        for host in &fleet.hosts {
+            assert_eq!(host.app_name, "myapp", "got: {host:?}");
+            assert_eq!(host.app_dir, "/srv/autumn/myapp", "got: {host:?}");
+            assert_eq!(host.service_name, "myapp", "got: {host:?}");
+            assert_eq!(host.profile, "prod", "got: {host:?}");
+        }
+
+        // `[deploy.tls] enabled` without a host is rejected for a fleet exactly as
+        // it is for a single server — before any host is touched.
+        let cfg = DeployConfig {
+            hosts: vec!["web-1".to_owned(), "web-2".to_owned()],
+            tls: autumn_web::config::DeployTlsConfig {
+                enabled: true,
+                host: None,
+            },
+            ..DeployConfig::default()
+        };
+        let err = ResolvedFleet::resolve(&cfg, "myapp")
+            .expect_err("enabled TLS without a host must be rejected for a fleet too");
+        assert!(
+            err.contains("[deploy.tls]") && err.contains("host"),
+            "the fleet must reuse the single-host TLS rejection, got: {err}"
+        );
+    }
+
+    #[test]
+    fn fleet_of_one_renders_todays_unit() {
+        // #1621 (AC-1, proof P7): the rendered systemd unit — the artifact that
+        // actually lands on the server — must be byte-identical under both
+        // spellings. This is the observable downstream of P5.
+        let single = DeployConfig {
+            host: Some("203.0.113.10".to_owned()),
+            app_name: Some("shop".to_owned()),
+            user: "deploy".to_owned(),
+            ..DeployConfig::default()
+        };
+        let fleet_spelling = DeployConfig {
+            host: None,
+            hosts: vec!["203.0.113.10".to_owned()],
+            ..single.clone()
+        };
+
+        let today = ResolvedDeployConfig::resolve(&single, "shop").expect("single host resolves");
+        let fleet =
+            ResolvedFleet::resolve(&fleet_spelling, "shop").expect("single-entry fleet resolves");
+
+        let release_dir = "/srv/autumn/shop/releases/20240101120000";
+        let today_unit = render_app_unit(&today, release_dir, 3001, "blue");
+        let fleet_unit = render_app_unit(&fleet.hosts[0], release_dir, 3001, "blue");
+        assert_eq!(
+            fleet_unit, today_unit,
+            "a one-entry fleet must render today's slot unit verbatim;\nfleet:\n{fleet_unit}\ntoday:\n{today_unit}"
+        );
+
+        // The `current`-symlink renderer stays in lockstep too.
+        let today_service = render_systemd_unit(&today);
+        let fleet_service = render_systemd_unit(&fleet.hosts[0]);
+        assert_eq!(
+            fleet_service, today_service,
+            "a one-entry fleet must render today's service unit verbatim;\nfleet:\n{fleet_service}\ntoday:\n{today_service}"
+        );
     }
 
     #[test]

--- a/autumn-cli/src/deploy.rs
+++ b/autumn-cli/src/deploy.rs
@@ -678,10 +678,38 @@ impl ResolvedFleet {
 
     /// Whether this fleet is a single server — the shape every pre-#1621 config
     /// resolves to, and the one that must behave identically to today.
+    ///
+    /// This answers "how many hosts is this RUN targeting?", which is **not** the
+    /// same question as "is this the byte-identical pre-#1621 single-host deploy?" —
+    /// a three-host config narrowed by `--only` to one host is a one-host fleet but
+    /// not a single-host deploy. Use [`is_single_host_deploy`] for the latter.
     #[must_use]
     pub const fn is_single(&self) -> bool {
         self.hosts.len() == 1
     }
+}
+
+/// Whether this run is the genuine pre-#1621 **single-host deploy**: the config
+/// declares ONE host and `--only` has not narrowed anything (issue #1621, AC-1).
+///
+/// This is the one predicate every "does this run keep the pre-#1621 shape?"
+/// decision asks, so those decisions can never drift apart. It is deliberately
+/// stricter than [`ResolvedFleet::is_single`]: a three-host fleet narrowed to one
+/// host resolves to a one-host `ResolvedFleet`, but it is NOT a single-host deploy —
+/// the other two hosts exist and are on another release, so the run keeps the fleet
+/// vocabulary, the state table, the compensation semantics, and — the reason this
+/// was extracted — **host attribution on every message**. An unattributed refusal
+/// during a `--only` repair is exactly the wrong output at exactly the wrong moment.
+/// See [`FleetUpInput::configured_host_count`].
+///
+/// Asked at three sites: the rollout driver ([`run_up_with`]), the per-host probe
+/// refusals ([`probe_host_for_up`]), and the preflight report
+/// ([`collect_fleet_preflight`]). [`run_rollback`] deliberately still branches on
+/// `is_single()` alone — that is a choice of which CODE PATH runs, not of how a
+/// message is worded, and narrowing a rollback to one host genuinely is a
+/// single-host rollback; it is tracked separately.
+const fn is_single_host_deploy(fleet: &ResolvedFleet, configured_host_count: usize) -> bool {
+    fleet.is_single() && configured_host_count <= 1
 }
 
 /// A single ordered step in a deploy or rollback plan. Purely descriptive — a
@@ -1500,10 +1528,18 @@ pub fn run(action: DeployAction, options: &DeployOptions) -> Result<(), DeployEr
         // and DB URL, so they must see those VALUES resolved under the TARGET
         // deploy profile — not the operator's ambient/dev config. Reload here.
         // `check`/`rollback` deliberately do NOT load the media config.
-        DeployAction::Check => run_check(&load_runtime_config(&resolved)?, &resolved, &targets),
-        DeployAction::Rollback => {
-            run_rollback(&load_runtime_config(&resolved)?, &resolved, &targets)
-        }
+        DeployAction::Check => run_check(
+            &load_runtime_config(&resolved)?,
+            &resolved,
+            &targets,
+            host_list.len(),
+        ),
+        DeployAction::Rollback => run_rollback(
+            &load_runtime_config(&resolved)?,
+            &resolved,
+            &targets,
+            host_list.len(),
+        ),
         // The read-only fleet surfaces (#1621). Both resolve through
         // `ResolvedFleet::resolve` — the seam that rejects a malformed/absent target
         // with one actionable message — and neither loads the media config (they
@@ -1966,11 +2002,15 @@ fn collect_project_preflight(
 /// must come out in declaration order, and threading them would put a `Sync` bound
 /// on machinery the `RefCell`-based recording fake cannot satisfy. Parallelising
 /// the pure TCP graders is a later, isolated change.
-fn collect_fleet_preflight(config: &AutumnConfig, fleet: &ResolvedFleet) -> Vec<PreflightCheck> {
+fn collect_fleet_preflight(
+    config: &AutumnConfig,
+    fleet: &ResolvedFleet,
+    configured_host_count: usize,
+) -> Vec<PreflightCheck> {
     let Some(shared) = fleet.hosts.first() else {
         return Vec::new();
     };
-    if fleet.is_single() {
+    if is_single_host_deploy(fleet, configured_host_count) {
         return collect_preflight(config, shared);
     }
     let mut checks: Vec<PreflightCheck> = fleet
@@ -2067,11 +2107,12 @@ fn run_check(
     config: &AutumnConfig,
     resolved: &ResolvedDeployConfig,
     hosts: &[String],
+    configured_host_count: usize,
 ) -> Result<(), DeployError> {
     eprintln!("\u{1F342} autumn deploy check\n");
 
     let fleet = ResolvedFleet::from_targets(resolved, hosts);
-    let checks = collect_fleet_preflight(config, &fleet);
+    let checks = collect_fleet_preflight(config, &fleet, configured_host_count);
     let failed = report_preflight(&checks);
 
     if failed == 0 {
@@ -2750,7 +2791,7 @@ fn run_up(
     // Fail fast: run the full preflight and abort BEFORE any remote call. Every
     // host is graded here, so an unreachable host in position 3 is reported before
     // host 1 is touched.
-    let checks = collect_fleet_preflight(config, &fleet);
+    let checks = collect_fleet_preflight(config, &fleet, configured_host_count);
     let failed = report_preflight(&checks);
     if failed > 0 {
         return Err(DeployError::PreflightFailed(failed));
@@ -2943,7 +2984,10 @@ where
     P: ProxyController,
 {
     let host = cfg.host.as_deref().unwrap_or_default();
-    let single = input.fleet.is_single();
+    // The SAME question the driver asks (`is_single_host_deploy`), not
+    // `fleet.is_single()`: a `--only`-narrowed repair on a multi-host fleet must
+    // keep naming the host it is refusing to touch.
+    let single = is_single_host_deploy(input.fleet, input.configured_host_count);
     // Host attribution is carried in the MESSAGE, never in an op label: labels are
     // `&'static str` and are load-bearing for the auto-rollback boundary lookup and
     // for every exact-vector test (#1621).
@@ -3121,7 +3165,7 @@ where
     // The pre-#1621 path is for a config that declares ONE host — see
     // [`FleetUpInput::configured_host_count`] for why a `--only`-narrowed fleet is
     // deliberately NOT single.
-    let single = fleet.is_single() && input.configured_host_count <= 1;
+    let single = is_single_host_deploy(fleet, input.configured_host_count);
     let total = fleet.hosts.len();
 
     // ── FLEET-WIDE FAIL-CLOSED REFUSALS (§4.8) ───────────────────────────────
@@ -3669,6 +3713,7 @@ fn run_rollback(
     config: &AutumnConfig,
     resolved: &ResolvedDeployConfig,
     hosts: &[String],
+    configured_host_count: usize,
 ) -> Result<(), DeployError> {
     eprintln!("\u{1F342} autumn deploy rollback\n");
 
@@ -3676,14 +3721,20 @@ fn run_rollback(
     // spelling) resolves to a one-host fleet whose only element IS today's
     // `resolved`, so the branch below is the pre-#1621 sequence at N = 1.
     let fleet = ResolvedFleet::from_targets(resolved, hosts);
+    // Which rollback path this run takes, decided ONCE and reused by the preflight
+    // gate below and the driver branch further down, so the two can never disagree.
+    // Note this is `is_single()`, not `is_single_host_deploy`: rolling ONE host back
+    // — whether that is the whole config or a `--only` narrowing of it — really is a
+    // single-host rollback, and the fleet driver has no second host to converge with.
+    let fleet_rollback = !fleet.is_single();
 
     // Fail fast: the same preflight as `up`, before any remote call. Every host is
     // graded, so an unreachable host in position 3 is reported before host 3 — or
     // any other host — is touched. The GATE is narrower than `up`'s, though: see
     // [`blocking_rollback_failures`].
-    let checks = collect_fleet_preflight(config, &fleet);
+    let checks = collect_fleet_preflight(config, &fleet, configured_host_count);
     let failed = report_preflight(&checks);
-    if blocking_rollback_failures(&checks) > 0 {
+    if blocking_rollback_failures(&checks, fleet_rollback) > 0 {
         return Err(DeployError::PreflightFailed(failed));
     }
     if failed > 0 {
@@ -3707,7 +3758,7 @@ fn run_rollback(
     let proxy = proxy::KamalProxyController::new(resolved.readiness_timeout_secs)
         .with_tls_host(resolved.tls_host.clone());
 
-    if !fleet.is_single() {
+    if fleet_rollback {
         return run_fleet_rollback_with(&checks, &fleet, &proxy, public_port, |cfg| {
             exec::SshTarget::from_resolved(cfg)
                 .map(exec::SshExecutor::new)
@@ -3773,12 +3824,18 @@ fn is_per_host_reachability(check: &PreflightCheck) -> bool {
 ///
 /// Everything else keeps the hard gate. A project-wide grader describes the release
 /// being rolled back TO rather than one host's reachability, and a SINGLE-host
-/// rollback keeps the pre-#1621 gate verbatim — its checks are unscoped, so none of
-/// them qualify (AC-1).
-fn blocking_rollback_failures(checks: &[PreflightCheck]) -> usize {
+/// rollback keeps the pre-#1621 gate verbatim (AC-1) — which is what
+/// `fleet_rollback` is for: the softening only makes sense when
+/// [`run_fleet_rollback_with`] is the code that actually runs, because only it
+/// skips-and-reports the unreachable host. The single-host path would sail past the
+/// gate straight into an SSH it already knows will fail, so for it EVERY failure
+/// blocks, exactly as before #1621. (Pre-#1621 this fell out of the rows being
+/// unscoped; since a `--only`-narrowed run now scopes its rows for attribution, the
+/// gate keys on the path instead of inferring it.)
+fn blocking_rollback_failures(checks: &[PreflightCheck], fleet_rollback: bool) -> usize {
     checks
         .iter()
-        .filter(|check| check.blocking() && !is_per_host_reachability(check))
+        .filter(|check| check.blocking() && !(fleet_rollback && is_per_host_reachability(check)))
         .count()
 }
 
@@ -4745,7 +4802,7 @@ mod tests {
 
         let one = ResolvedFleet::resolve(&fleet_cfg(&["web-1.example.test"]), "myapp")
             .expect("one-host fleet resolves");
-        let checks = collect_fleet_preflight(&config, &one);
+        let checks = collect_fleet_preflight(&config, &one, 1);
         assert!(
             checks.iter().all(|check| check.scope.is_none()),
             "a single-host fleet must carry no scope (AC-1): {:?}",
@@ -4760,7 +4817,7 @@ mod tests {
             "myapp",
         )
         .expect("two-host fleet resolves");
-        let checks = collect_fleet_preflight(&config, &many);
+        let checks = collect_fleet_preflight(&config, &many, 2);
         let scoped: Vec<(&str, Option<&str>)> = checks
             .iter()
             .map(|check| (check.name, check.scope.as_deref()))
@@ -4806,7 +4863,7 @@ mod tests {
         ] {
             let fleet =
                 ResolvedFleet::resolve(&fleet_cfg(&hosts), "myapp").expect("fleet resolves");
-            for check in collect_fleet_preflight(&config, &fleet) {
+            for check in collect_fleet_preflight(&config, &fleet, hosts.len()) {
                 assert!(
                     !check.deferred,
                     "fleet grader `{}` must never defer (scope {:?}): {}",
@@ -4861,7 +4918,7 @@ mod tests {
             "myapp",
         )
         .expect("fleet resolves");
-        let emitted: Vec<&str> = collect_fleet_preflight(&preflight_config(), &fleet)
+        let emitted: Vec<&str> = collect_fleet_preflight(&preflight_config(), &fleet, 2)
             .iter()
             .map(|check| check.name)
             .collect();
@@ -7387,6 +7444,63 @@ mod tests {
     }
 
     #[test]
+    fn a_compensated_first_deploy_stops_reporting_a_successful_last_deploy() {
+        // #1621 (AC-6, audit gap G3). `CompensatedTeardown` returns web-a to
+        // nothing-installed — but its first deploy had already written
+        // `shared/last-deploy = deployed <ts>` via `record-proxy-options`. Left
+        // alone, `deploy status` would show `last deploy: deployed <ts>` for a host
+        // carrying no release at all, which is the worst possible moment for a
+        // wrong value: the operator is inspecting the fleet precisely BECAUSE the
+        // rollout halted.
+        //
+        // The teardown's last op rewrites the marker to `torn down`, so the column
+        // reports what actually happened instead of a deploy that was undone.
+        let fleet = fleet_of(&["web-a", "web-b"]);
+        let mut recorder = fleet::test_support::FleetRecorder::new();
+        recorder = script_first_deploy(recorder, "web-a");
+        recorder = script_redeploy(recorder, "web-b").fail("web-b", "readiness-gate");
+        let fixture = FleetFixture::new();
+
+        run_up_with(&fixture.input(&fleet), |cfg| Ok(recorder.executor(cfg)))
+            .expect_err("a mid-rollout failure must halt the rollout");
+
+        let calls = recorder.calls_for("web-a");
+        let last_deploy_writes: Vec<(&'static str, &str)> = calls
+            .iter()
+            .filter_map(|call| match call {
+                exec::test_support::RecordedCall::Run { label, shell }
+                    if shell.contains("shared/last-deploy") =>
+                {
+                    Some((*label, shell.as_str()))
+                }
+                _ => None,
+            })
+            .collect();
+
+        let (last_label, last_shell) = *last_deploy_writes
+            .last()
+            .expect("the compensated host writes the last-deploy marker at least once");
+        assert_eq!(
+            last_label, "teardown-last-deploy",
+            "the TEARDOWN must have the last word on this host's last-deploy marker, \
+             got: {last_deploy_writes:?}"
+        );
+        assert!(
+            last_shell.contains("'torn down'") && !last_shell.contains("'deployed'"),
+            "a torn-down host must not report a successful deploy: {last_shell}"
+        );
+        // Non-vacuous: the first deploy really did claim `deployed` before the
+        // compensation ran, so this is a correction, not an absence.
+        assert!(
+            last_deploy_writes
+                .iter()
+                .any(|(label, shell)| *label == "record-proxy-options"
+                    && shell.contains("'deployed'")),
+            "the first deploy must have recorded `deployed` first: {last_deploy_writes:?}"
+        );
+    }
+
+    #[test]
     fn a_failed_compensation_does_not_stop_the_earlier_hosts() {
         // #1621 (AC-3, T1.13 case d). Host 3 fails post-boundary; compensation runs
         // c → b → a and host 2's rollback fails at `restart-previous`. Stopping there
@@ -8147,6 +8261,94 @@ mod tests {
         let halt = fleet_halt_of(&err);
         assert_eq!(halt.failed_host, "web-b");
         assert_eq!(halt.failed_step, "readiness-gate");
+    }
+
+    #[test]
+    fn a_narrowed_probe_refusal_still_names_its_host() {
+        // #1621 (AC-1 boundary, audit gap G10). "Is this really a single-host
+        // deploy?" has ONE answer, `is_single_host_deploy`, and every site asks it
+        // the same way. `probe_host_for_up` used to ask `fleet.is_single()` alone,
+        // so a three-host fleet narrowed to one lost the `host {x}: ` prefix on a
+        // probe-phase refusal — an unattributed error during a repair operation on
+        // a fleet whose other hosts are on another release.
+        let narrowed = fleet_of(&["web-b"]);
+        let recorder = fleet::test_support::FleetRecorder::new()
+            .script("web-b", "proxy-compat-probe", compatible_deploy_help())
+            .script("web-b", "detect-current", redeploy_probe())
+            .script("web-b", "probe-release-dir", "present");
+        let fixture = FleetFixture::new();
+        let input = FleetUpInput {
+            configured_host_count: 3,
+            ..fixture.input(&narrowed)
+        };
+
+        let narrowed_message = run_up_with(&input, |cfg| Ok(recorder.executor(cfg)))
+            .expect_err("an existing release dir must refuse the rollout")
+            .to_string();
+        assert!(
+            narrowed_message.contains("host web-b: release directory"),
+            "a narrowed run keeps fleet attribution on probe refusals, got: \
+             {narrowed_message}"
+        );
+
+        // …and a GENUINE one-host config is byte-identical to the pre-#1621 text:
+        // no prefix, nothing else changed (AC-1).
+        let single = fleet_of(&["web-b"]);
+        let single_recorder = fleet::test_support::FleetRecorder::new()
+            .script("web-b", "proxy-compat-probe", compatible_deploy_help())
+            .script("web-b", "detect-current", redeploy_probe())
+            .script("web-b", "probe-release-dir", "present");
+        let single_message = run_up_with(&fixture.input(&single), |cfg| {
+            Ok(single_recorder.executor(cfg))
+        })
+        .expect_err("an existing release dir must refuse the rollout")
+        .to_string();
+        assert!(
+            !single_message.contains("host web-b: "),
+            "a genuine single-host refusal must keep the unattributed pre-#1621 \
+             text, got: {single_message}"
+        );
+        assert_eq!(
+            narrowed_message.replace("host web-b: ", ""),
+            single_message,
+            "the two must differ ONLY by the attribution prefix"
+        );
+    }
+
+    #[test]
+    fn a_narrowed_preflight_still_scopes_its_reachability_row() {
+        // #1621 (AC-1 boundary, audit gap G10). The same predicate governs the
+        // preflight report: `deploy up --only web-2` on a three-host config is not
+        // the single-host path, so its `ssh_reachability` row still names the host
+        // it graded. A genuine one-host config stays unscoped (AC-1).
+        let config = preflight_config();
+        let narrowed = ResolvedFleet::resolve(&fleet_cfg(&["web-2.example.test"]), "myapp")
+            .expect("a narrowed fleet resolves");
+
+        let scoped = collect_fleet_preflight(&config, &narrowed, 3);
+        assert_eq!(
+            scoped
+                .iter()
+                .filter(|check| check.name == SSH_REACHABILITY_CHECK)
+                .map(|check| check.scope.as_deref())
+                .collect::<Vec<_>>(),
+            vec![Some("web-2.example.test")],
+            "a narrowed run must keep host attribution: {:?}",
+            scoped
+                .iter()
+                .map(|c| (c.name, &c.scope))
+                .collect::<Vec<_>>()
+        );
+
+        let genuine = collect_fleet_preflight(&config, &narrowed, 1);
+        assert!(
+            genuine.iter().all(|check| check.scope.is_none()),
+            "a genuine one-host config must stay unscoped (AC-1): {:?}",
+            genuine
+                .iter()
+                .map(|c| (c.name, &c.scope))
+                .collect::<Vec<_>>()
+        );
     }
 
     #[test]
@@ -8934,7 +9136,7 @@ mod tests {
             .scoped(Some("web-b".to_owned())),
         ];
         assert_eq!(
-            blocking_rollback_failures(&reachable_fleet),
+            blocking_rollback_failures(&reachable_fleet, true),
             0,
             "a per-host reachability failure must not block the reachable hosts"
         );
@@ -8946,22 +9148,40 @@ mod tests {
             "fix them",
         ));
         assert_eq!(
-            blocking_rollback_failures(&project_wide),
+            blocking_rollback_failures(&project_wide, true),
             1,
             "a project-wide grader still aborts the whole command"
         );
 
-        // The single-host path is untouched: its rows carry no scope, so its
-        // reachability failure is still blocking (pre-#1621 behavior verbatim).
+        // The single-host path is untouched: every failure blocks it (pre-#1621
+        // behavior verbatim).
         let single = vec![PreflightCheck::fail(
             "ssh_reachability",
             "cannot reach web-a:22",
             "check the host",
         )];
         assert_eq!(
-            blocking_rollback_failures(&single),
+            blocking_rollback_failures(&single, false),
             1,
             "a single-host rollback must keep aborting before touching the server"
+        );
+        // …including when the row IS scoped. A `--only`-narrowed rollback scopes its
+        // reachability row for attribution (#1621 audit gap G10) but still runs the
+        // single-host path, which has no skip-and-report step — so downgrading the
+        // row there would send it straight into an SSH the preflight already knows
+        // will fail. The gate keys on the PATH, never on the scope alone.
+        let narrowed = vec![
+            PreflightCheck::fail(
+                "ssh_reachability",
+                "cannot reach web-b:22",
+                "check the host",
+            )
+            .scoped(Some("web-b".to_owned())),
+        ];
+        assert_eq!(
+            blocking_rollback_failures(&narrowed, false),
+            1,
+            "a narrowed single-host rollback must still abort before touching the server"
         );
     }
 

--- a/autumn-cli/src/deploy.rs
+++ b/autumn-cli/src/deploy.rs
@@ -1547,7 +1547,12 @@ pub fn run(action: DeployAction, options: &DeployOptions) -> Result<(), DeployEr
         DeployAction::Status => {
             let fleet = ResolvedFleet::resolve(&deploy_cfg, &resolve_project_name())
                 .map_err(DeployError::Config)?;
-            run_status(&load_runtime_config(&resolved)?, &fleet, options)
+            // Review round 1: `status` is READ-ONLY and needs exactly one value
+            // from the app config (`server.port`), so an unrelated invalid
+            // production setting must not take it offline mid-incident. See
+            // `status_public_port`.
+            let port = status_public_port(&resolved)?;
+            run_status(&port, &resolved.profile, &fleet, options)
         }
         DeployAction::MaintenanceOn | DeployAction::MaintenanceOff => {
             let fleet = ResolvedFleet::resolve(&deploy_cfg, &resolve_project_name())
@@ -1834,6 +1839,130 @@ fn load_runtime_config(resolved: &ResolvedDeployConfig) -> Result<AutumnConfig, 
     // `[media]`) as opaque — app boot stays the authoritative strict gate.
     AutumnConfig::load_with_env_lenient_unknown_roots(&forced)
         .map_err(|e| DeployError::Config(e.to_string()))
+}
+
+/// The public port `autumn deploy status` probes each host against, plus the
+/// reason it had to be resolved the hard way (issue #1621, review round 1).
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct StatusPort {
+    /// The port `[server] port` resolves to under the TARGET deploy profile.
+    port: u16,
+    /// `None` on the normal path (the whole runtime config validated). `Some` when
+    /// the config did NOT validate under the deploy profile and the port was read
+    /// from the layered TOML/env without validation — the caller must say so out
+    /// loud rather than report against a silently-chosen port.
+    degraded: Option<String>,
+}
+
+/// Resolve the probe port for `deploy status` WITHOUT making an unrelated
+/// application-config error take the fleet's only read-only incident command
+/// offline (issue #1621, review round 1).
+///
+/// `status` needs exactly one value from the application config: `server.port`,
+/// the public port kamal-proxy binds — the number every per-host slot port is
+/// derived from and the one the proxy-port-mismatch drift rule compares against.
+/// Routing that through [`load_runtime_config`] validated the ENTIRE config under
+/// the deploy profile, so an invalid `[scheduler]`, `[mail]`, `[database]` or
+/// `[security]` setting aborted the command **before a single host was probed** —
+/// exactly when an operator needs to see the fleet.
+///
+/// The strict load stays the primary path, so a project whose config is fine gets
+/// byte-identical behaviour and the identical port. Only when it fails does this
+/// fall back to reading the DECLARED port out of the same base+profile TOML layers
+/// (plus the same `.env.<profile>`/OS env layer) the loader itself resolves it
+/// from, and it reports the degradation. It never guesses: the fallback value is
+/// the operator's own declared port, or the framework default when nothing
+/// declares one.
+///
+/// `check`, `rollback` and `up` deliberately keep the strict load: they grade and
+/// upload runtime VALUES (the signing secret, the DB URL), so an invalid config
+/// must stop them. `plan` never loads the runtime config at all.
+fn status_public_port(resolved: &ResolvedDeployConfig) -> Result<StatusPort, DeployError> {
+    let loaded = load_runtime_config(resolved);
+    status_public_port_with(&manifest_project_dirs(), &resolved.profile, loaded)
+}
+
+/// Pure core of [`status_public_port`] over an explicit search path and an
+/// already-attempted load, so both branches are unit-testable against temp dirs.
+fn status_public_port_with(
+    dirs: &[PathBuf],
+    profile_raw: &str,
+    loaded: Result<AutumnConfig, DeployError>,
+) -> Result<StatusPort, DeployError> {
+    match loaded {
+        Ok(config) => Ok(StatusPort {
+            port: config.server.port,
+            degraded: None,
+        }),
+        Err(err) => {
+            // The `.env.<profile>` + OS env layer, selected exactly as the strict
+            // load selects it — so an `AUTUMN_SERVER__PORT` that only exists in
+            // `.env.prod` still wins here, as it would at runtime. A `.env` that
+            // cannot be read is still fatal: that is not an unrelated app setting.
+            let overlay = deploy_profile_env_overlay(profile_raw)?;
+            Ok(StatusPort {
+                port: declared_server_port_in(dirs, profile_raw, &overlay)
+                    .unwrap_or_else(|| AutumnConfig::default().server.port),
+                degraded: Some(err.to_string()),
+            })
+        }
+    }
+}
+
+/// Read the DECLARED `[server] port` for a deploy profile without validating (or
+/// even fully deserializing) the application config (issue #1621, review round 1).
+///
+/// Layers exactly as [`load_media_host_config_in`] does — base `autumn.toml` ←
+/// inline `[profile.<name>]` ← `autumn-<profile>.toml` — because that is the same
+/// order `AutumnConfig::load_with_env` merges them in, and then applies the env
+/// layer ON TOP, because `AUTUMN_SERVER__PORT` is the highest-priority layer in the
+/// loader too. So the number returned here is the number the strict load would
+/// have produced, minus the validation.
+///
+/// `None` means no layer declares a port; the caller substitutes the framework
+/// default rather than inventing one. A malformed/unreadable layer is skipped
+/// rather than fatal: this function runs only on the already-degraded path, where
+/// refusing again would leave `deploy status` just as unavailable as before.
+fn declared_server_port_in(dirs: &[PathBuf], profile_raw: &str, env: &dyn Env) -> Option<u16> {
+    // Highest layer first: `apply_env_overrides` applies `AUTUMN_SERVER__PORT`
+    // last, so it wins over every TOML layer. An unparseable value is ignored for
+    // the same reason the loader ignores it (it warns and keeps the layered value).
+    if let Ok(raw) = env.var("AUTUMN_SERVER__PORT")
+        && let Ok(port) = raw.trim().parse::<u16>()
+    {
+        return Some(port);
+    }
+
+    let mut merged = toml::Value::Table(toml::map::Map::new());
+    let base_toml: Option<toml::Value> = first_dir_with_file(dirs, "autumn.toml")
+        .and_then(|path| std::fs::read_to_string(path).ok())
+        .and_then(|text| toml::from_str::<toml::Value>(&text).ok());
+    let canonical = canonicalize_deploy_profile(profile_raw);
+    if let Some(base) = &base_toml {
+        deep_merge_toml(&mut merged, base.clone());
+        for name in profile_inline_lookup_names(&canonical) {
+            if let Some(section) = profile_section_from_base_toml(base, name) {
+                deep_merge_toml(&mut merged, section);
+            }
+        }
+    }
+    for name in autumn_web::config::profile_override_file_lookup_names(&canonical, profile_raw) {
+        let Some(path) = first_dir_with_file(dirs, &format!("autumn-{name}.toml")) else {
+            continue;
+        };
+        if let Ok(text) = std::fs::read_to_string(&path)
+            && let Ok(overlay) = toml::from_str::<toml::Value>(&text)
+        {
+            deep_merge_toml(&mut merged, overlay);
+        }
+        break;
+    }
+
+    merged
+        .get("server")
+        .and_then(|server| server.get("port"))
+        .and_then(toml::Value::as_integer)
+        .and_then(|port| u16::try_from(port).ok())
 }
 
 /// Build the profile-aware env overlay that [`load_runtime_config`] resolves the
@@ -4072,7 +4201,10 @@ where
 ///   `host` (string), `reachable` (bool), `mode`
 ///   (`"deployed"`/`"not deployed"`/`"unknown"`/`"unreachable"`), `release`
 ///   (string or null when unknown), `live_slot` (string or null), `ready` (HTTP
-///   status number or null), `maintenance` (bool), `proxy_port` (number or null),
+///   status number or null), `maintenance` (`true`/`false` as the host's RUNNING
+///   slot unit observes it, or `null` when the CLI could not prove which flag file
+///   that unit polls — see `fleet::DRIFT_MAINTENANCE_UNPROVEN`), `proxy_port`
+///   (number or null),
 ///   `last_deploy` (AC-6's third fact: `{result, at}` — `result` is `"deployed"`
 ///   or `"rolled back"`, `at` the host's UTC timestamp or null — and the whole
 ///   object is null when the host has never completed a cutover or the marker
@@ -4112,7 +4244,16 @@ fn fleet_status_json(
                 },
                 "live_slot": status.live_slot,
                 "ready": status.ready_code,
-                "maintenance": status.maintenance_on,
+                // Three-valued since #1621 review round 1: `true`/`false` are
+                // proved states of the file the RUNNING slot unit polls, and
+                // `null` is "the CLI could not prove which file that is". Both
+                // false and null stay falsy for a consumer that tests the field
+                // directly, so `maintenance == true` never widens.
+                "maintenance": match status.maintenance {
+                    exec::MaintenanceStatus::On => serde_json::Value::Bool(true),
+                    exec::MaintenanceStatus::Off => serde_json::Value::Bool(false),
+                    exec::MaintenanceStatus::Unknown => serde_json::Value::Null,
+                },
                 "proxy_port": match status.installed_proxy_port {
                     exec::InstalledProxyPort::Port(port) => {
                         serde_json::Value::Number(port.into())
@@ -4148,14 +4289,30 @@ fn fleet_status_json(
 /// per-host table (or `--json`), exiting non-zero on drift only under `--strict`
 /// (issue #1621, AC-6).
 fn run_status(
-    config: &AutumnConfig,
+    port: &StatusPort,
+    profile: &str,
     fleet: &ResolvedFleet,
     options: &DeployOptions,
 ) -> Result<(), DeployError> {
     if !options.json {
         eprintln!("\u{1F342} autumn deploy status\n");
     }
-    let statuses = collect_fleet_status(fleet, config.server.port, |cfg| {
+    // Never silent, and never on stdout: a `--json` consumer keeps the documented
+    // shape while a human still sees WHY the port was resolved the hard way and
+    // WHICH port the report is graded against.
+    if let Some(reason) = &port.degraded {
+        eprintln!(
+            "\u{26A0}\u{FE0F}  this project's configuration does not validate under the \
+             `{profile}` deploy profile: {reason}"
+        );
+        eprintln!(
+            "   `deploy status` is read-only, so it continues against the DECLARED \
+             `[server] port = {}` for that profile (read without validation). \
+             `autumn deploy check`/`up` still refuse to run until the config is fixed.\n",
+            port.port
+        );
+    }
+    let statuses = collect_fleet_status(fleet, port.port, |cfg| {
         exec::SshTarget::from_resolved(cfg)
             .map(exec::SshExecutor::new)
             .ok_or_else(|| DeployError::Config(DEPLOY_HOST_MISSING_DETAIL.to_owned()))
@@ -5048,6 +5205,132 @@ mod tests {
             env_file.expose().lines().any(|l| l == "AUTUMN_ENV=prod"),
             "env file should pin AUTUMN_ENV=prod by default, got: {:?}",
             env_file.expose()
+        );
+    }
+
+    #[test]
+    fn deploy_status_reads_its_probe_port_under_the_deploy_profile_without_validating() {
+        // #1621 review round 1 (Codex 3). `deploy status` is the read-only command
+        // an operator reaches for mid-incident, and it needs exactly ONE value from
+        // the application config: `server.port`. Routing that through
+        // `load_runtime_config` validated the WHOLE config under the deploy profile,
+        // so an unrelated invalid production setting aborted the command before a
+        // single host was probed.
+        //
+        // The port must still come from the SAME profile resolution the deploy
+        // itself uses, or status reports against the wrong port — so the fallback
+        // layers base ← `[profile.prod]` ← `autumn-prod.toml` ← env, exactly like
+        // the loader.
+        use autumn_web::config::MockEnv;
+
+        let dir = tempfile::TempDir::new().expect("temp project dir");
+        std::fs::write(
+            dir.path().join("autumn.toml"),
+            "[server]\n\
+             port = 8080\n\
+             \n\
+             [profile.prod.server]\n\
+             port = 9090\n",
+        )
+        .expect("write autumn.toml");
+        let dirs = vec![dir.path().to_path_buf()];
+
+        // The PROFILE's port wins over the base one — a status graded against 8080
+        // would derive the wrong slot ports and report a bogus proxy-port mismatch.
+        assert_eq!(
+            declared_server_port_in(&dirs, "prod", &MockEnv::new()),
+            Some(9090),
+        );
+        // …and the alias spelling resolves the same file/section set.
+        assert_eq!(
+            declared_server_port_in(&dirs, "production", &MockEnv::new()),
+            Some(9090),
+        );
+        // A different profile falls through to the base declaration.
+        assert_eq!(
+            declared_server_port_in(&dirs, "staging", &MockEnv::new()),
+            Some(8080),
+        );
+        // `AUTUMN_SERVER__PORT` is the loader's highest layer, so it wins here too.
+        assert_eq!(
+            declared_server_port_in(
+                &dirs,
+                "prod",
+                &MockEnv::new().with("AUTUMN_SERVER__PORT", "7070")
+            ),
+            Some(7070),
+        );
+        // The profile override FILE layers on top of the inline section, matching
+        // `AutumnConfig::load_with_env`'s merge order.
+        std::fs::write(
+            dir.path().join("autumn-prod.toml"),
+            "[server]\nport = 9191\n",
+        )
+        .expect("write autumn-prod.toml");
+        assert_eq!(
+            declared_server_port_in(&dirs, "prod", &MockEnv::new()),
+            Some(9191),
+        );
+        // Nothing declared anywhere → `None`, so the caller substitutes the
+        // framework default instead of this function inventing one.
+        let empty = tempfile::TempDir::new().expect("temp dir");
+        assert_eq!(
+            declared_server_port_in(&[empty.path().to_path_buf()], "prod", &MockEnv::new()),
+            None,
+        );
+    }
+
+    #[test]
+    fn deploy_status_degrades_instead_of_aborting_on_an_unrelated_config_error() {
+        // #1621 review round 1 (Codex 3), the seam. A config error under the deploy
+        // profile must NOT take the read-only fleet report offline; it must be
+        // reported, with the probe still graded against the profile's declared port.
+        let dir = tempfile::TempDir::new().expect("temp project dir");
+        std::fs::write(
+            dir.path().join("autumn.toml"),
+            "[server]\nport = 8080\n\n[profile.prod.server]\nport = 9090\n",
+        )
+        .expect("write autumn.toml");
+        let dirs = vec![dir.path().to_path_buf()];
+
+        let degraded = status_public_port_with(
+            &dirs,
+            "prod",
+            Err(DeployError::Config(
+                "scheduler.max_concurrency must be greater than 0".to_owned(),
+            )),
+        )
+        .expect("a read-only status must not abort on an unrelated config error");
+        assert_eq!(degraded.port, 9090, "the PROFILE's declared port is used");
+        assert!(
+            degraded
+                .degraded
+                .as_deref()
+                .is_some_and(|reason| reason.contains("scheduler.max_concurrency")),
+            "the degradation must be reported, never silent: {:?}",
+            degraded.degraded
+        );
+
+        // The happy path is unchanged: a config that validates supplies the port and
+        // reports no caveat at all.
+        let ok = status_public_port_with(
+            &dirs,
+            "prod",
+            Ok(AutumnConfig {
+                server: autumn_web::config::ServerConfig {
+                    port: 4321,
+                    ..autumn_web::config::ServerConfig::default()
+                },
+                ..AutumnConfig::default()
+            }),
+        )
+        .expect("a valid config resolves");
+        assert_eq!(
+            ok,
+            StatusPort {
+                port: 4321,
+                degraded: None,
+            },
         );
     }
 
@@ -8452,6 +8735,11 @@ mod tests {
     }
 
     /// Script a host's two read-only status probes.
+    /// The shared maintenance flag path a #1621 slot unit points
+    /// `AUTUMN_MAINTENANCE_FLAG_FILE` at for the `myapp` fleet fixtures — the
+    /// fourth `probe-host-status` section resolves to it on a healthy host.
+    const STATUS_SHARED_FLAG: &str = "/srv/autumn/myapp/shared/autumn-maintenance.json";
+
     fn script_status(
         recorder: fleet::test_support::FleetRecorder,
         host: &str,
@@ -8465,9 +8753,10 @@ mod tests {
                 host,
                 "probe-host-status",
                 format!(
-                    "{ready}\n---autumn-host-status---\n{}\n---autumn-host-status---\n\
-                     deployed\t2026-07-14T12:00:03Z",
-                    if maintenance { "maintenance-on" } else { "" }
+                    "{ready}\n---autumn-host-status---\n{flag}\n---autumn-host-status---\n\
+                     deployed\t2026-07-14T12:00:03Z\n---autumn-host-status---\n\
+                     {STATUS_SHARED_FLAG}\n{flag}",
+                    flag = if maintenance { "maintenance-on" } else { "" }
                 ),
             )
     }
@@ -8485,7 +8774,10 @@ mod tests {
             .script(
                 host,
                 "probe-host-status",
-                format!("200\n---autumn-host-status---\n\n---autumn-host-status---\n{last_deploy}"),
+                format!(
+                    "200\n---autumn-host-status---\n\n---autumn-host-status---\n{last_deploy}\n\
+                     ---autumn-host-status---\n{STATUS_SHARED_FLAG}\n"
+                ),
             )
     }
 
@@ -8573,7 +8865,11 @@ mod tests {
         let statuses = drive_status(&fleet, &recorder).expect("status reports");
         let report = fleet::fleet_drift(&statuses);
         assert!(report.version_drift, "different releases are drift");
-        assert!(statuses[1].maintenance_on, "the flag file is read per host");
+        assert_eq!(
+            statuses[1].maintenance,
+            exec::MaintenanceStatus::On,
+            "the flag file is read per host"
+        );
         assert!(
             statuses[1].ready_code == Some(200),
             "maintenance does NOT change readiness — the two are orthogonal"

--- a/autumn-cli/src/deploy.rs
+++ b/autumn-cli/src/deploy.rs
@@ -23,6 +23,10 @@
 //! shared with `autumn doctor`.
 
 pub mod exec;
+// #1621: the fleet planning layer is crate-internal — every item is `pub(crate)`
+// and only `deploy` (and, later, its rollout driver) consumes it, so the module
+// itself stays private rather than joining the `pub mod` siblings above.
+mod fleet;
 pub mod media;
 pub mod proxy;
 
@@ -1016,10 +1020,11 @@ pub fn run(action: DeployAction) -> Result<(), DeployError> {
     // #1621: refuse a malformed host spelling — `host` AND `hosts` together, a
     // blank entry, a duplicate entry — before ANY other work, so the operator sees
     // one actionable message instead of a preflight report graded against a target
-    // list we could not make sense of. The resolved list itself is consumed by
-    // `ResolvedFleet` (the rollout driver lands in a later slice); here only the
-    // refusal matters, and the single-host path below is deliberately untouched.
-    deploy_host_list(&deploy_cfg).map_err(DeployError::Config)?;
+    // list we could not make sense of. The ordered list is the rollout order and
+    // is rendered by `plan`; the rollout DRIVER that consumes it via
+    // `ResolvedFleet` lands in a later slice, so the single-host paths below are
+    // deliberately untouched.
+    let host_list = deploy_host_list(&deploy_cfg).map_err(DeployError::Config)?;
     let resolved = ResolvedDeployConfig::resolve(&deploy_cfg, &resolve_project_name())
         .map_err(DeployError::Config)?;
 
@@ -1035,7 +1040,7 @@ pub fn run(action: DeployAction) -> Result<(), DeployError> {
         // uploads runtime VALUES, so it needs no reload under the target profile.
         DeployAction::Plan => {
             let (media_cfg, _ffmpeg_bin) = load_media_host_config(&resolved)?;
-            print_plan(&resolved, &media_cfg);
+            print_plan(&resolved, &host_list, &media_cfg);
             Ok(())
         }
         // `check`/`rollback`/`up` grade and (for `up`) upload the signing secret
@@ -1521,7 +1526,19 @@ fn run_check(config: &AutumnConfig, resolved: &ResolvedDeployConfig) -> Result<(
     }
 }
 
-fn print_plan(resolved: &ResolvedDeployConfig, media_cfg: &media::MediaMtxHostConfig) {
+/// Print the `deploy plan` dry-run: the rendered slot unit, the ordered per-host
+/// steps, the fleet rollout section (multi-host only), and the `MediaMTX` section
+/// (media-enabled only).
+///
+/// `hosts` is the ordered target list from [`deploy_host_list`] — the rollout
+/// order. When it holds at most one entry, nothing fleet-specific is printed, so
+/// single-host output stays byte-identical to pre-#1621 (AC-1); the differential
+/// proof is `deploy_plan_output_is_identical_for_host_and_a_single_entry_hosts_list`.
+fn print_plan(
+    resolved: &ResolvedDeployConfig,
+    hosts: &[String],
+    media_cfg: &media::MediaMtxHostConfig,
+) {
     println!("\u{1F342} autumn deploy plan (dry-run)\n");
     println!("systemd unit ({}.service):\n", resolved.service_name);
     println!("{}", render_systemd_unit(resolved));
@@ -1529,6 +1546,15 @@ fn print_plan(resolved: &ResolvedDeployConfig, media_cfg: &media::MediaMtxHostCo
     println!("Deploy steps (zero-downtime):");
     for (i, step) in build_deploy_plan(resolved).iter().enumerate() {
         println!("  {}. [{}] {}", i + 1, step.label, step.description);
+    }
+
+    // Fleet rollout (issue #1621, AC-4): the steps above are what EACH host runs;
+    // this section is the order they run in and where the single fleet-wide
+    // migration lands. Printed only for a real fleet.
+    if hosts.len() > 1 {
+        for line in fleet::fleet_plan_lines(hosts) {
+            println!("{line}");
+        }
     }
 
     // MediaMTX host provisioning (issue #1974, Slice 7): only when the
@@ -2108,6 +2134,11 @@ fn run_up(
                 &release_id,
                 &plan,
                 &reregister_options,
+                // #1621: the single-host path IS a one-host fleet, and a one-host
+                // fleet's only host carries the migration — so this is today's
+                // sequence, unchanged. The fleet driver (next slice) is what varies
+                // this per host.
+                exec::MigrateStep::Run,
             );
             // Repair the drifted marker as an early op — before the cutover's
             // record-previous-release reads it — so the on-disk marker matches the
@@ -3644,6 +3675,114 @@ mod tests {
         assert!(
             pos("readiness-gate") < pos("drain-rolled-back-slot"),
             "the former-live slot is drained last, after the /ready re-probe"
+        );
+    }
+
+    #[test]
+    fn fleet_plan_matches_fleet_ops_sequence() {
+        // #1621 (AC-4, T1.26): the forward twin of
+        // `rollback_plan_matches_rollback_ops_sequence`. `build_deploy_plan` and the
+        // fleet section it is printed with are DESCRIPTIVE — nothing links them to
+        // `exec::cutover_ops` at compile time — so this guards the three claims the
+        // printed fleet plan actually makes against the ops that really run.
+        let fleet = ResolvedFleet::resolve(&fleet_cfg(&["web-a", "web-b", "web-c"]), "myapp")
+            .expect("a well-formed fleet resolves");
+        let modes = [
+            fleet::HostMode::Redeploy,
+            fleet::HostMode::Redeploy,
+            fleet::HostMode::Redeploy,
+        ];
+        let plan = fleet::plan_fleet(&fleet, &modes).expect("a well-formed fleet plans");
+
+        // (1) HOST ORDERING. The rendered section, the executable plan and the
+        // resolved fleet all agree on declaration order — the documented rollout
+        // contract.
+        let hosts: Vec<String> = fleet
+            .hosts
+            .iter()
+            .map(|h| h.host.clone().unwrap_or_default())
+            .collect();
+        let planned: Vec<String> = plan.hosts.iter().map(|h| h.host.clone()).collect();
+        assert_eq!(
+            planned, hosts,
+            "the executable fleet plan must keep declaration order"
+        );
+        let rendered = fleet::fleet_plan_lines(&hosts).join("\n");
+        let mut previous = 0usize;
+        for host in &hosts {
+            let at = rendered
+                .find(host.as_str())
+                .unwrap_or_else(|| panic!("{host} must be named in the plan:\n{rendered}"));
+            assert!(
+                at >= previous,
+                "the printed fleet plan must list hosts in rollout order:\n{rendered}"
+            );
+            previous = at;
+        }
+
+        // (2) SINGLE MIGRATE. The section promises the migration runs once; the real
+        // flattened op labels must carry exactly one `migrate`, before the first
+        // cutover boundary anywhere in the fleet.
+        let flat = fleet::test_support::fleet_op_labels(&fleet, &plan);
+        assert_eq!(
+            flat.iter().filter(|l| **l == "migrate").count(),
+            1,
+            "the plan promises one migration; the ops must schedule one: {flat:?}"
+        );
+        assert_eq!(
+            rendered
+                .matches(fleet::FLEET_MIGRATE_PLACEMENT_NOTE)
+                .count(),
+            1,
+            "the migrate placement is one fleet-wide note, not a per-host line:\n{rendered}"
+        );
+        let migrate = flat
+            .iter()
+            .position(|l| *l == "migrate")
+            .expect("the fleet migrates");
+        let boundary = flat
+            .iter()
+            .position(|l| *l == "proxy-flip" || *l == "proxy-route")
+            .expect("the fleet cuts over");
+        assert!(
+            migrate < boundary,
+            "the plan's `[migrate] < [cutover]` claim must hold in the real ops: \
+             migrate at {migrate}, boundary at {boundary}, labels: {flat:?}"
+        );
+
+        // (3) STEP-LABEL SUBSET. Every printed step label either names a real
+        // executed op or is one of the four deliberately MECHANISM-NEUTRAL labels
+        // (`build` is local, `upload` executes as `upload-binary`, `cutover` as
+        // `proxy-flip`, `drain` as `drain-old`). Partitioning — rather than a bare
+        // `contains` — means a NEW plan step forces a deliberate decision here
+        // instead of silently drifting away from the ops.
+        let step_labels: Vec<&str> = build_deploy_plan(&fleet.hosts[0])
+            .iter()
+            .map(|s| s.label)
+            .collect();
+        let (executed, neutral): (Vec<&str>, Vec<&str>) =
+            step_labels.iter().partition(|l| flat.contains(l));
+        assert_eq!(
+            executed,
+            vec!["migrate", "start-candidate", "readiness-gate", "prune"],
+            "these printed steps must name real executed ops: {step_labels:?} vs {flat:?}"
+        );
+        assert_eq!(
+            neutral,
+            vec!["build", "upload", "cutover", "drain"],
+            "only the documented mechanism-neutral plan labels may be absent from \
+             the ops: {step_labels:?} vs {flat:?}"
+        );
+        // The plan's last step is `prune`, and so is the fleet's last real op.
+        assert_eq!(
+            step_labels.last().copied(),
+            Some("prune"),
+            "the printed plan ends with prune"
+        );
+        assert_eq!(
+            flat.last().copied(),
+            Some("prune"),
+            "the fleet's last host ends with prune: {flat:?}"
         );
     }
 

--- a/autumn-cli/src/deploy.rs
+++ b/autumn-cli/src/deploy.rs
@@ -2150,7 +2150,17 @@ fn collect_fleet_preflight(
     configured_host_count: usize,
 ) -> Vec<PreflightCheck> {
     let Some(shared) = fleet.hosts.first() else {
-        return Vec::new();
+        // A fleet with no entries at all (issue #2274). `ResolvedFleet::from_targets`
+        // keeps a `None`-host entry rather than dropping it, so an unconfigured
+        // `[deploy]` reaches the arm below and reports `ssh_reachability` normally —
+        // this arm is unreachable today. It still must not return NO checks: this
+        // function IS the fail-fast boundary (`run_up`, `run_check` and
+        // `run_rollback` all abort on the count it produces), and zero checks reads
+        // as "0 failed", walks the run past that boundary, and leaves the
+        // `fleet.hosts[0]` sites downstream to panic on the empty vec. `hosts` is a
+        // `pub` field, so the non-empty promise in its doc comment is not a type —
+        // the gate fails CLOSED, in the same words the single-host path uses.
+        return vec![grade_ssh_reachability(None, 0, SSH_PROBE_TIMEOUT)];
     };
     if is_single_host_deploy(fleet, configured_host_count) {
         return collect_preflight(config, shared);
@@ -3318,7 +3328,15 @@ where
         .map_err(DeployError::Config)?;
     refuse_media_fleet(input.configured_host_count, input.media_cfg.enabled)
         .map_err(DeployError::Config)?;
-    refuse_tls_fleet(input.configured_host_count, fleet.hosts[0].tls_enabled)
+    // `first()` rather than `[0]`: the shared shape is identical across the fleet,
+    // and an empty `hosts` — which `collect_fleet_preflight` now refuses to let a
+    // run reach at all (#2274) — must still surface as the missing-host config
+    // error every other hostless path returns, never as an index panic.
+    let shared = fleet
+        .hosts
+        .first()
+        .ok_or_else(|| DeployError::Config(DEPLOY_HOST_MISSING_DETAIL.to_owned()))?;
+    refuse_tls_fleet(input.configured_host_count, shared.tls_enabled)
         .map_err(DeployError::Config)?;
     // A warning, not a refusal: hosts racing to auto-migrate at boot is a real
     // hazard but not a certainty, and refusing would break an existing single-host
@@ -3810,17 +3828,9 @@ fn fleet_halted(
                 fleet::HostOutcome::TornDown { .. } | fleet::HostOutcome::CompensatedTeardown
             )
         }),
-        still_on_new: named(|o| {
-            matches!(
-                o,
-                fleet::HostOutcome::Serving
-                    | fleet::HostOutcome::Degraded { .. }
-                    | fleet::HostOutcome::LiveOnNew { .. }
-                    | fleet::HostOutcome::AmbiguousMarkers
-                    | fleet::HostOutcome::Manual { .. }
-                    | fleet::HostOutcome::CompensationFailed { .. }
-            )
-        }),
+        // Shared with the summary table's own list, so the halt error and the state
+        // table can never disagree about which hosts are still forward.
+        still_on_new: named(fleet::HostOutcome::on_new_release),
         degraded: degraded.to_vec(),
         manual: plan
             .hosts
@@ -3908,7 +3918,12 @@ fn run_rollback(
         });
     }
 
-    let single = &fleet.hosts[0];
+    // Same rule as the `up` driver (#2274): a hostless fleet is a config error with
+    // a message, not an index panic.
+    let single = fleet
+        .hosts
+        .first()
+        .ok_or_else(|| DeployError::Config(DEPLOY_HOST_MISSING_DETAIL.to_owned()))?;
     let target = exec::SshTarget::from_resolved(single)
         .ok_or_else(|| DeployError::Config(DEPLOY_HOST_MISSING_DETAIL.to_owned()))?;
     let executor = exec::SshExecutor::new(target);
@@ -5105,6 +5120,33 @@ mod tests {
                 .filter(|(name, _)| *name != "ssh_reachability")
                 .all(|(_, scope)| scope.is_none()),
             "project-wide graders must stay unscoped: {scoped:?}"
+        );
+    }
+
+    #[test]
+    fn an_empty_fleet_still_fails_the_preflight_gate() {
+        // #2274: `collect_fleet_preflight` is the fail-fast boundary — `run_up`,
+        // `run_check` and `run_rollback` all abort on the count it produces. Handing
+        // back ZERO checks for a hostless fleet would report "0 failed", let the run
+        // walk past that boundary, and leave the three `fleet.hosts[0]` sites
+        // downstream to panic on the empty vec.
+        //
+        // `ResolvedFleet::from_targets` keeps a `None` host rather than dropping the
+        // entry, so today every real fleet has at least one element and this arm is
+        // unreachable — but `hosts` is a `pub` field on a `pub` struct, so the
+        // invariant is a promise, not a type. The gate fails CLOSED instead of
+        // trusting it.
+        let empty = ResolvedFleet { hosts: vec![] };
+        let checks = collect_fleet_preflight(&preflight_config(), &empty, 0);
+        assert!(
+            checks
+                .iter()
+                .any(|check| check.blocking() && check.detail.contains(DEPLOY_HOST_MISSING_DETAIL)),
+            "a fleet with no target must fail the preflight gate, not return no checks: {:?}",
+            checks
+                .iter()
+                .map(|c| (c.name, c.passed, &c.detail))
+                .collect::<Vec<_>>()
         );
     }
 

--- a/autumn-cli/src/deploy.rs
+++ b/autumn-cli/src/deploy.rs
@@ -3600,13 +3600,22 @@ fn run_rollback(
     // `resolved`, so the branch below is the pre-#1621 sequence at N = 1.
     let fleet = ResolvedFleet::from_targets(resolved, hosts);
 
-    // Fail fast: same preflight/gate as `up`, before any remote call. Every host is
+    // Fail fast: the same preflight as `up`, before any remote call. Every host is
     // graded, so an unreachable host in position 3 is reported before host 3 — or
-    // any other host — is touched.
+    // any other host — is touched. The GATE is narrower than `up`'s, though: see
+    // [`blocking_rollback_failures`].
     let checks = collect_fleet_preflight(config, &fleet);
     let failed = report_preflight(&checks);
-    if failed > 0 {
+    if blocking_rollback_failures(&checks) > 0 {
         return Err(DeployError::PreflightFailed(failed));
+    }
+    if failed > 0 {
+        eprintln!(
+            "\u{26A0}\u{FE0F}  {failed} host(s) above did not answer the reachability probe. A \
+             ROLLBACK continues without them \u{2014} stopping would leave the hosts that ARE \
+             reachable on the release you are leaving \u{2014} but each is reported as NOT \
+             rolled back and this command still exits non-zero.\n"
+        );
     }
 
     // Show what a rollback will do before it runs (descriptive, not a dry-run gate).
@@ -3654,6 +3663,46 @@ fn run_rollback(
 
     eprintln!("\n\u{2705} Rollback complete.");
     Ok(())
+}
+
+/// The grader name a per-host reachability row carries. Kept as one constant so
+/// the rollback gate below and the skip it implies can never key on different
+/// spellings than [`grade_ssh_reachability`] emits.
+const SSH_REACHABILITY_CHECK: &str = "ssh_reachability";
+
+/// Whether a preflight check is a PER-HOST reachability row of a real fleet
+/// (issue #1621): the grader name plus a scope, which
+/// [`collect_fleet_preflight`] attaches only for a fleet of more than one host.
+fn is_per_host_reachability(check: &PreflightCheck) -> bool {
+    check.name == SSH_REACHABILITY_CHECK && check.scope.is_some()
+}
+
+/// How many preflight failures must ABORT a fleet rollback before it touches
+/// anything (issue #1621, §3.2).
+///
+/// `deploy up` refuses the whole rollout if any host fails — AC-7 — because a
+/// rollout is a CHANGE, and starting one against a fleet it cannot finish is how a
+/// fleet ends up mixed. A rollback is the opposite kind of command: it is recovery,
+/// its documented contract is best-effort-continue
+/// ([`run_fleet_rollback_with`]), and the host that stopped answering SSH is very
+/// often the reason the operator is rolling back at all. Refusing to move the
+/// healthy majority off a bad release because one host is dead leaves MORE hosts on
+/// the release being abandoned — the exact outcome that contract exists to prevent.
+///
+/// So exactly one class is downgraded to a reported, non-blocking row: a per-host
+/// `ssh_reachability` failure in a real fleet. It is still printed by
+/// [`report_preflight`], that host is still skipped and reported as NOT rolled back,
+/// and the command still exits non-zero via [`DeployError::FleetRollbackFailed`].
+///
+/// Everything else keeps the hard gate. A project-wide grader describes the release
+/// being rolled back TO rather than one host's reachability, and a SINGLE-host
+/// rollback keeps the pre-#1621 gate verbatim — its checks are unscoped, so none of
+/// them qualify (AC-1).
+fn blocking_rollback_failures(checks: &[PreflightCheck]) -> usize {
+    checks
+        .iter()
+        .filter(|check| check.blocking() && !is_per_host_reachability(check))
+        .count()
 }
 
 /// Roll EVERY host in `fleet` back to its previous release, newest first (issue
@@ -3723,8 +3772,38 @@ where
         let cfg = &fleet.hosts[index];
         let host = names[index].as_str();
         eprintln!("[{}/{total} {host}] rolling back\u{2026}", index + 1);
-        outcomes[index] =
-            rollback_one_host(checks, cfg, proxy, public_port, host, &executors[index]);
+        // Preflight is fleet-wide, but a per-host reachability row belongs to ONE
+        // host: forwarding another host's failed row would abort this host's
+        // `execute_rollback` for a fault that is not its own
+        // (see `blocking_rollback_failures`).
+        let host_checks: Vec<PreflightCheck> = checks
+            .iter()
+            .filter(|check| {
+                !is_per_host_reachability(check) || check.scope.as_deref() == Some(host)
+            })
+            .cloned()
+            .collect();
+        outcomes[index] = if host_checks.iter().any(PreflightCheck::blocking) {
+            // Reported, never touched: its preflight row is already on screen, and
+            // probing a host that did not answer a TCP connect would only stall the
+            // hosts queued behind it.
+            eprintln!(
+                "\u{274C} [{host}] did not answer the preflight reachability probe \u{2014} \
+                 this host was NOT rolled back. The remaining hosts still are."
+            );
+            fleet::RollbackOutcome::Failed {
+                failed_step: SSH_REACHABILITY_CHECK,
+            }
+        } else {
+            rollback_one_host(
+                &host_checks,
+                cfg,
+                proxy,
+                public_port,
+                host,
+                &executors[index],
+            )
+        };
         eprintln!();
     }
 
@@ -7383,6 +7462,61 @@ mod tests {
     }
 
     #[test]
+    fn a_transport_failure_at_commit_markers_is_never_auto_rolled_back() {
+        // #1621 (§4.6, T1.15). The guard above must key on the OP that was running,
+        // not on the error shape that carried the failure. `DeployExecError::Spawn`
+        // carries no label of its own (`failed_step_label` synthesizes
+        // "ssh-transport"), so a dropped transport during `commit-markers` used to
+        // classify as Functional and auto-roll-back a host whose marker triple was
+        // never written — landing it on whatever `shared/previous-release` still
+        // named, which can be a release older than the one every other compensated
+        // host returns to, and reporting it as "previous release restored".
+        let fleet = fleet_of(&["web-a", "web-b"]);
+        let mut recorder = fleet::test_support::FleetRecorder::new();
+        for host in ["web-a", "web-b"] {
+            recorder = script_redeploy(recorder, host);
+        }
+        recorder = script_compensation(recorder, "web-a", "present")
+            .transport_fail("web-b", "commit-markers");
+        let fixture = FleetFixture::new();
+
+        let err = run_up_with(&fixture.input(&fleet), |cfg| Ok(recorder.executor(cfg)))
+            .expect_err("an ambiguous-marker failure must halt the rollout");
+
+        let web_b = recorder.run_labels_for("web-b");
+        for rollback_op in [
+            "resolve-previous",
+            "probe-rollback-target",
+            "restart-previous",
+            "drain-rolled-back-slot",
+        ] {
+            assert!(
+                !web_b.contains(&rollback_op),
+                "a host whose `commit-markers` failed must see ZERO rollback-flavoured \
+                 ops whatever the error shape, got `{rollback_op}`: {web_b:?}"
+            );
+        }
+        assert_eq!(
+            recorder.run_labels_for("web-a"),
+            redeploy_then_compensated(true),
+            "the earlier host is still compensated"
+        );
+
+        let halt = fleet_halt_of(&err);
+        assert_eq!(
+            halt.manual,
+            vec![("web-b".to_owned(), fleet::MANUAL_AMBIGUOUS_MARKERS)],
+            "the host with an unprovable marker triple must be reported as needing a human"
+        );
+        assert_eq!(
+            halt.still_on_new,
+            vec!["web-b".to_owned()],
+            "it was not rolled back, so it is still on the new release"
+        );
+        assert_eq!(halt.rolled_back, vec!["web-a".to_owned()]);
+    }
+
+    #[test]
     fn a_housekeeping_failure_degrades_the_host_and_continues_the_rollout() {
         // #1621 (§4.6, T1.15). `prune` runs AFTER the flip: the proxy is already
         // serving the new release, so a failed `rm -rf` of old release dirs affects
@@ -8438,6 +8572,110 @@ mod tests {
         assert!(
             flips[2] < flips[1] && flips[1] < flips[0],
             "hosts must roll back newest-first (web-c, web-b, web-a), got positions {flips:?}"
+        );
+    }
+
+    #[test]
+    fn fleet_rollback_rolls_the_reachable_hosts_back_past_a_dead_peer() {
+        // #1621 (§3.2 vs AC-7). `deploy up` refuses the whole rollout when any host
+        // fails preflight — a rollout is a change, and starting one it cannot finish
+        // is how a fleet ends up mixed. A ROLLBACK is the opposite: it is recovery,
+        // and the host that stopped answering SSH is very often the reason the
+        // operator is rolling back. Hard-gating there leaves the healthy majority on
+        // the bad release — MORE hosts on the release being abandoned, which is the
+        // outcome the best-effort-continue contract exists to prevent.
+        let hosts = ["web-a", "web-b", "web-c"];
+        let fleet = fleet_of(&hosts);
+        let mut recorder = fleet::test_support::FleetRecorder::new();
+        for host in ["web-a", "web-c"] {
+            recorder = script_previous_release(recorder, host);
+        }
+        // web-b never answered the preflight TCP probe. It is NOT scripted at all, so
+        // the strict recorder panics if the rollback so much as probes it.
+        let checks = vec![
+            PreflightCheck::fail(
+                "ssh_reachability",
+                "cannot reach web-b:22",
+                "check the host",
+            )
+            .scoped(Some("web-b".to_owned())),
+            PreflightCheck::pass("migrate_check", "ok"),
+        ];
+        let proxy = proxy::KamalProxyController::new(60);
+
+        let err = run_fleet_rollback_with(&checks, &fleet, &proxy, FLEET_PUBLIC_PORT, |cfg| {
+            Ok(recorder.executor(cfg))
+        })
+        .expect_err("a fleet that did not fully converge must exit non-zero");
+
+        assert!(
+            matches!(
+                &err,
+                DeployError::FleetRollbackFailed {
+                    not_rolled_back: 1,
+                    total: 3
+                }
+            ),
+            "the unreachable host is reported as NOT rolled back, got: {err:?}"
+        );
+        for host in ["web-a", "web-c"] {
+            assert_eq!(
+                recorder.run_labels_for(host),
+                FLEET_ROLLBACK_RUN_LABELS.to_vec(),
+                "{host} is reachable and must be rolled back despite web-b being dead"
+            );
+        }
+        assert!(
+            recorder.run_labels_for("web-b").is_empty(),
+            "an unreachable host must not be touched at all: {:?}",
+            recorder.run_labels_for("web-b")
+        );
+    }
+
+    #[test]
+    fn a_rollback_still_hard_gates_on_a_project_wide_preflight_failure() {
+        // …and the downgrade above is narrow by construction: only a PER-HOST
+        // reachability row is survivable. A project-wide grader describes the release
+        // being rolled back TO, not one host's reachability, so it keeps the
+        // pre-#1621 hard gate — as does every check of a single-host rollback, whose
+        // rows are unscoped.
+        let reachable_fleet = vec![
+            PreflightCheck::fail(
+                "ssh_reachability",
+                "cannot reach web-b:22",
+                "check the host",
+            )
+            .scoped(Some("web-b".to_owned())),
+        ];
+        assert_eq!(
+            blocking_rollback_failures(&reachable_fleet),
+            0,
+            "a per-host reachability failure must not block the reachable hosts"
+        );
+
+        let mut project_wide = reachable_fleet;
+        project_wide.push(PreflightCheck::fail(
+            "migrate_check",
+            "migrations do not compile",
+            "fix them",
+        ));
+        assert_eq!(
+            blocking_rollback_failures(&project_wide),
+            1,
+            "a project-wide grader still aborts the whole command"
+        );
+
+        // The single-host path is untouched: its rows carry no scope, so its
+        // reachability failure is still blocking (pre-#1621 behavior verbatim).
+        let single = vec![PreflightCheck::fail(
+            "ssh_reachability",
+            "cannot reach web-a:22",
+            "check the host",
+        )];
+        assert_eq!(
+            blocking_rollback_failures(&single),
+            1,
+            "a single-host rollback must keep aborting before touching the server"
         );
     }
 

--- a/autumn-cli/src/deploy.rs
+++ b/autumn-cli/src/deploy.rs
@@ -80,6 +80,24 @@ pub enum DeployError {
     /// Remote execution of the first deploy failed.
     #[error("deploy execution failed: {0}")]
     Exec(String),
+
+    /// A multi-host rollout stopped mid-fleet (issue #1621, AC-3).
+    #[error(
+        "fleet rollout halted at {failed_host} during `{failed_step}` — the remaining hosts were \
+         not touched"
+    )]
+    FleetHalted {
+        /// Host the rollout stopped on.
+        failed_host: String,
+        /// Label of the step that failed on it.
+        failed_step: &'static str,
+        /// Hosts whose candidate was rolled back (their previous release still serves).
+        rolled_back: Vec<String>,
+        /// Hosts whose first-deploy candidate was torn down (nothing serves there).
+        torn_down: Vec<String>,
+        /// Hosts left running the NEW release, in rollout order.
+        still_on_new: Vec<String>,
+    },
 }
 
 /// Which `autumn deploy` subcommand to run.
@@ -360,16 +378,11 @@ fn deploy_host_list(cfg: &DeployConfig) -> Result<Vec<String>, String> {
 ///
 /// The list is never empty and is always in declaration (rollout) order.
 #[derive(Debug, Clone, PartialEq, Eq)]
-// Reachable from the unit tests today; the rollout driver that consumes it lands
-// in a later slice of #1621, so the non-test binary build is allowed not to use
-// it yet (mirroring `exec::run_ops`'s test-only reachability).
-#[cfg_attr(not(test), allow(dead_code))]
 pub struct ResolvedFleet {
     /// The resolved targets, in rollout order. Guaranteed non-empty.
     pub hosts: Vec<ResolvedDeployConfig>,
 }
 
-#[cfg_attr(not(test), allow(dead_code))]
 impl ResolvedFleet {
     /// Resolve a [`DeployConfig`] into an ordered fleet against the project name.
     ///
@@ -383,6 +396,13 @@ impl ResolvedFleet {
     /// when neither `host` nor `hosts` configures a target, or when
     /// [`ResolvedDeployConfig::resolve`] rejects the shared shape (e.g.
     /// `[deploy.tls] enabled = true` with no `host`).
+    // `deploy up` deliberately does NOT come through here: it resolves the shared
+    // shape itself and builds the fleet with [`Self::from_targets`], so a config
+    // with no target at all still reaches — and fails at — the PREFLIGHT report
+    // (`ssh_reachability`), byte-identically to pre-#1621, instead of being
+    // rejected earlier here with a different message and no report. This is the
+    // seam the read-only fleet surfaces (`status`, `maintenance`) use.
+    #[cfg_attr(not(test), allow(dead_code))]
     pub fn resolve(cfg: &DeployConfig, project_name: &str) -> Result<Self, String> {
         let addresses = deploy_host_list(cfg)?;
         if addresses.is_empty() {
@@ -396,15 +416,36 @@ impl ResolvedFleet {
 
         // Resolve the shared shape ONCE, then vary only `host`.
         let shared = ResolvedDeployConfig::resolve(cfg, project_name)?;
-        let hosts = addresses
-            .into_iter()
-            .map(|host| ResolvedDeployConfig {
-                host: Some(host),
-                ..shared.clone()
-            })
-            .collect();
+        Ok(Self::from_targets(&shared, &addresses))
+    }
 
-        Ok(Self { hosts })
+    /// Build a fleet from an ALREADY-resolved shared config plus the ordered
+    /// address list from [`deploy_host_list`].
+    ///
+    /// The elements differ only in `host`, so a one-entry list is byte-for-byte
+    /// today's single-server deploy **by construction**. An empty or single-entry
+    /// list keeps `shared` verbatim — including a `None` host — so a config with no
+    /// target still flows into the normal preflight report rather than being
+    /// special-cased here.
+    #[must_use]
+    pub fn from_targets(shared: &ResolvedDeployConfig, addresses: &[String]) -> Self {
+        if addresses.len() <= 1 {
+            return Self {
+                hosts: vec![ResolvedDeployConfig {
+                    host: addresses.first().cloned().or_else(|| shared.host.clone()),
+                    ..shared.clone()
+                }],
+            };
+        }
+        Self {
+            hosts: addresses
+                .iter()
+                .map(|host| ResolvedDeployConfig {
+                    host: Some(host.clone()),
+                    ..shared.clone()
+                })
+                .collect(),
+        }
     }
 
     /// Whether this fleet is a single server — the shape every pre-#1621 config
@@ -1054,6 +1095,7 @@ pub fn run(action: DeployAction) -> Result<(), DeployError> {
             run_up(
                 &load_runtime_config(&resolved)?,
                 &resolved,
+                &host_list,
                 &media_cfg,
                 &ffmpeg_bin,
             )
@@ -1407,7 +1449,29 @@ fn resolve_writable_db_url(db: &autumn_web::config::DatabaseConfig) -> Option<&s
 
 /// Collect all preflight graders for the resolved config against the loaded
 /// runtime configuration.
+///
+/// Exactly ONE of the four graders is host-specific (`ssh_reachability`); the
+/// other three grade the project, not the target. The split is made explicit by
+/// [`collect_project_preflight`] so a fleet can run the host grader per host and
+/// the project graders once ([`collect_fleet_preflight`]) without re-deriving —
+/// and so a single-host run keeps this exact order and text.
 fn collect_preflight(
+    config: &AutumnConfig,
+    resolved: &ResolvedDeployConfig,
+) -> Vec<PreflightCheck> {
+    let mut checks = vec![grade_ssh_reachability(
+        resolved.host.as_deref(),
+        resolved.ssh_port,
+        SSH_PROBE_TIMEOUT,
+    )];
+    checks.extend(collect_project_preflight(config, resolved));
+    checks
+}
+
+/// The preflight graders that are fleet-wide by nature: they grade the project's
+/// signing secret, database URL and pending migrations, none of which vary per
+/// host. A fleet runs these ONCE (issue #1621, AC-7).
+fn collect_project_preflight(
     config: &AutumnConfig,
     resolved: &ResolvedDeployConfig,
 ) -> Vec<PreflightCheck> {
@@ -1422,11 +1486,6 @@ fn collect_preflight(
         || config.database.replica_url.is_some()
         || config.database.has_shards();
     vec![
-        grade_ssh_reachability(
-            resolved.host.as_deref(),
-            resolved.ssh_port,
-            SSH_PROBE_TIMEOUT,
-        ),
         // Grade the signing secret against the SAME profile that will be written
         // to the host env file (`AUTUMN_ENV=<resolved.profile>`, default `prod`),
         // not the local CLI runtime profile (`config.profile`, dev/None on a dev
@@ -1452,6 +1511,35 @@ fn collect_preflight(
         ),
         grade_migrate_check(Path::new(MIGRATIONS_DIR)),
     ]
+}
+
+/// Preflight for a whole fleet: `ssh_reachability` **per host**, then the three
+/// project-wide graders **once** (issue #1621, AC-7).
+///
+/// A single-host fleet returns exactly [`collect_preflight`]'s vector, so its
+/// report is byte-identical to pre-#1621 (AC-1). For a real fleet the per-host
+/// rows are distinguished by the grader's own detail text, which already names the
+/// host (`SSH port reachable at web-2:22`) — the structured `scope` field that
+/// `doctor --json` will also carry lands with the CLI-surface slice.
+///
+/// The probes run SERIALLY here: they are a bounded TCP connect each, the report
+/// must come out in declaration order, and threading them would put a `Sync` bound
+/// on machinery the `RefCell`-based recording fake cannot satisfy. Parallelising
+/// the pure TCP graders is a later, isolated change.
+fn collect_fleet_preflight(config: &AutumnConfig, fleet: &ResolvedFleet) -> Vec<PreflightCheck> {
+    let Some(shared) = fleet.hosts.first() else {
+        return Vec::new();
+    };
+    if fleet.is_single() {
+        return collect_preflight(config, shared);
+    }
+    let mut checks: Vec<PreflightCheck> = fleet
+        .hosts
+        .iter()
+        .map(|cfg| grade_ssh_reachability(cfg.host.as_deref(), cfg.ssh_port, SSH_PROBE_TIMEOUT))
+        .collect();
+    checks.extend(collect_project_preflight(config, shared));
+    checks
 }
 
 /// Whether the active profile is production, matching the exact rule the app boot
@@ -1978,35 +2066,55 @@ fn refuse_unprovable_proxy_options(marker: &exec::ProxyOptionsMarker) -> Result<
     }
 }
 
-// Linear deploy orchestrator; the added MediaMTX host-prep step (#1974 Slice 7)
-// tips it one line over the threshold, and it reads clearest as one sequence.
-#[allow(clippy::too_many_lines)]
+/// Perform a real deploy of the whole configured fleet (issue #1607, Slices 1–3;
+/// issue #1621).
+///
+/// Runs the same preflight as `check` — for EVERY configured host — and aborts
+/// before touching any server if anything fails (AC-6/AC-7). It then mints ONE
+/// release id for the whole run, probes every host read-only, plans the rollout,
+/// and replaces the hosts ONE AT A TIME in `[deploy] hosts` order.
+///
+/// A single-host config is a one-host fleet: same ops, same output, same errors as
+/// before #1621. The prologue here is the part that is fleet-wide by nature
+/// (preflight, release id, release binary, env file, manifests, port validation);
+/// everything host-shaped lives in [`run_up_with`], which takes those results as
+/// data so the rollout loop is unit-testable against per-host fakes with no host,
+/// no filesystem and no clock.
 fn run_up(
     config: &AutumnConfig,
     resolved: &ResolvedDeployConfig,
+    hosts: &[String],
     media_cfg: &media::MediaMtxHostConfig,
     ffmpeg_bin: &str,
 ) -> Result<(), DeployError> {
     eprintln!("\u{1F342} autumn deploy up\n");
 
-    // Fail fast: run the full preflight and abort BEFORE any remote call.
-    let checks = collect_preflight(config, resolved);
+    // The rollout targets, in declaration order. A single-host config resolves to
+    // a one-host fleet whose only element IS today's `resolved`, so everything
+    // below is the pre-#1621 sequence at N = 1.
+    let fleet = ResolvedFleet::from_targets(resolved, hosts);
+
+    // Fail fast: run the full preflight and abort BEFORE any remote call. Every
+    // host is graded here, so an unreachable host in position 3 is reported before
+    // host 1 is touched.
+    let checks = collect_fleet_preflight(config, &fleet);
     let failed = report_preflight(&checks);
     if failed > 0 {
         return Err(DeployError::PreflightFailed(failed));
     }
 
-    // Host presence is guaranteed by the passing ssh_reachability grader above.
-    let target = exec::SshTarget::from_resolved(resolved)
-        .ok_or_else(|| DeployError::Config(DEPLOY_HOST_MISSING_DETAIL.to_owned()))?;
     let binary = resolve_release_binary(resolved)?;
     let env_file = build_env_file(config, resolved);
     // Locate the project config manifest(s) to upload so the deployed app loads
     // the intended config rather than silent built-in defaults (#1952), and print
     // a loud line either confirming the upload or warning when there is no
-    // autumn.toml to ship.
+    // autumn.toml to ship. The same bytes go to every host.
     let manifests = locate_manifest_uploads(resolved);
     eprintln!("{}", manifest_preflight_notice(&manifests));
+    // Exactly ONE release id per fleet run (#1621): every host's `current` symlink
+    // then resolves to the same release, so drift reporting is meaningful and a
+    // rollback has a single target. Minting per host would give un-comparable
+    // version identities and permanent reported drift.
     let release_id = default_release_id();
     let public_port = config.server.port;
     // kamal-proxy `run` binds 443 for its HTTPS listener BY DEFAULT (regardless of
@@ -2018,55 +2126,171 @@ fn run_up(
     validate_public_port(public_port).map_err(DeployError::Config)?;
     let proxy = proxy::KamalProxyController::new(resolved.readiness_timeout_secs)
         .with_tls_host(resolved.tls_host.clone());
-    let executor = exec::SshExecutor::new(target);
-    // MediaMTX host preflight (#1974 Slice 7) — non-mutating doctor checks run
-    // BEFORE the app deploy so a bad media host fails fast without anything being
-    // written. The MUTATING provisioning (write config/unit + restart) is deferred
-    // until after the app cutover succeeds (below) so a rolled-back app deploy
-    // never touches the host MediaMTX unit. No-op unless enabled (see fn).
-    check_media_host_preflight(media_cfg, ffmpeg_bin, &executor)?;
+
+    run_up_with(
+        &FleetUpInput {
+            fleet: &fleet,
+            proxy: &proxy,
+            checks: &checks,
+            env_file: &env_file,
+            binary: &binary,
+            manifests: &manifests,
+            release_id: &release_id,
+            public_port,
+            media_cfg,
+            ffmpeg_bin,
+            writable_db_configured: resolve_writable_db_url(&config.database).is_some(),
+        },
+        // Host presence is guaranteed by the passing ssh_reachability grader above,
+        // so this `None` arm is unreachable in practice; it keeps the pre-#1621
+        // error verbatim rather than panicking on an invariant proved elsewhere.
+        |cfg| {
+            exec::SshTarget::from_resolved(cfg)
+                .map(exec::SshExecutor::new)
+                .ok_or_else(|| DeployError::Config(DEPLOY_HOST_MISSING_DETAIL.to_owned()))
+        },
+    )
+}
+
+/// Everything the fleet rollout loop needs, already resolved by [`run_up`].
+///
+/// Every field is either fleet-wide by construction (`release_id`, `env_file`,
+/// `binary`, `manifests`, `public_port` — the same bytes reach every host) or the
+/// fleet itself. Passing them as data rather than re-deriving them inside the loop
+/// is what makes the loop testable: nothing here reads the clock, the filesystem,
+/// or a socket.
+struct FleetUpInput<'a, P: ProxyController> {
+    /// The rollout targets, in order. Never empty.
+    fleet: &'a ResolvedFleet,
+    /// The proxy controller. kamal-proxy is PER HOST (it binds that host's public
+    /// port); it is not a fleet load balancer, so one controller value describes
+    /// every host's local proxy.
+    proxy: &'a P,
+    /// The preflight results the per-host executor gates on.
+    checks: &'a [PreflightCheck],
+    /// The secret env-file body, byte-identical on every host.
+    env_file: &'a exec::Secret,
+    /// Local path to the release binary uploaded to every host.
+    binary: &'a Path,
+    /// Config manifests uploaded into every host's release dir.
+    manifests: &'a [exec::ManifestUpload],
+    /// The ONE release id for this run.
+    release_id: &'a str,
+    /// The app's public port, fronted by each host's proxy.
+    public_port: u16,
+    /// `MediaMTX` host provisioning config.
+    media_cfg: &'a media::MediaMtxHostConfig,
+    /// Resolved `FFmpeg` binary path for the media preflight.
+    ffmpeg_bin: &'a str,
+    /// Whether a writable database URL is configured — the fleet warns loudly when
+    /// it is and the rollout schedules no migration at all.
+    writable_db_configured: bool,
+}
+
+/// One host's read-only probe result: everything the rollout needs to know about
+/// that host, decided BEFORE any host is touched.
+struct HostProbeState {
+    /// First deploy vs redeploy.
+    mode: fleet::HostMode,
+    /// That host's own blue/green slot layout.
+    slots: exec::SlotPlan,
+    /// Whether that host's live-slot marker drifted and must be repaired as the
+    /// first op of its sequence.
+    repair: bool,
+    /// Proxy options the durability re-register must preserve on that host (#2074).
+    reregister_options: exec::ProxyServiceOptions,
+    /// Operator-facing description of the path this host takes.
+    banner: String,
+}
+
+/// Probe ONE host read-only and apply every fail-closed refusal to it.
+///
+/// This runs for EVERY host before the first host is mutated (issue #1621, §4.3),
+/// which is what makes a fleet rollout all-or-nothing at the refusal level: a
+/// drifted host in position 3 refuses the rollout while hosts 1 and 2 are still
+/// serving their old releases, instead of being discovered after two cutovers.
+///
+/// The refusals themselves are the UNCHANGED single-host guards; the only fleet
+/// addition is that their messages name the host when there is more than one (a
+/// single-host deploy keeps the exact pre-#1621 text).
+fn probe_host_for_up<E, P>(
+    cfg: &ResolvedDeployConfig,
+    input: &FleetUpInput<'_, P>,
+    executor: &E,
+) -> Result<HostProbeState, DeployError>
+where
+    E: exec::DeployExecutor,
+    P: ProxyController,
+{
+    let host = cfg.host.as_deref().unwrap_or_default();
+    let single = input.fleet.is_single();
+    // Host attribution is carried in the MESSAGE, never in an op label: labels are
+    // `&'static str` and are load-bearing for the auto-rollback boundary lookup and
+    // for every exact-vector test (#1621).
+    let scoped = |message: String| {
+        if single {
+            message
+        } else {
+            format!("host {host}: {message}")
+        }
+    };
 
     // Fail closed on kamal-proxy CLI-surface drift BEFORE any cutover (#2053): the
     // controller consumes an UNPINNED kamal-proxy from host bootstrap, so a
     // renamed/removed subcommand or flag on `kamal-proxy deploy` would otherwise
     // break a real cutover with no warning. A compatible binary passes silently;
     // an incompatible one aborts here (read-only `--help` probe, nothing mutated).
-    exec::probe_proxy_compat(&proxy, &executor).map_err(|e| DeployError::Exec(e.to_string()))?;
-
-    let release_dir = format!("{}/{release_id}", resolved.releases_dir());
+    exec::probe_proxy_compat(input.proxy, executor)
+        .map_err(|e| DeployError::Exec(scoped(e.to_string())))?;
 
     // Probe the target to choose first-deploy vs zero-downtime redeploy. The same
     // round-trip also captures `kamal-proxy list` so a drifted live-slot marker
     // can be reconciled against the live proxy before slot-selection (#1938).
-    let probe = exec::probe_deploy_state(resolved, &executor)
-        .map_err(|e| DeployError::Exec(e.to_string()))?;
+    let probe = exec::probe_deploy_state(cfg, executor)
+        .map_err(|e| DeployError::Exec(scoped(e.to_string())))?;
 
-    let (ops, teardown, banner, is_first) = match probe.mode {
-        exec::DeployMode::First => {
-            let plan = exec::SlotPlan::first(public_port);
-            let unit = render_app_unit(
-                resolved,
-                &release_dir,
-                plan.candidate_port,
-                plan.candidate_slot,
-            );
-            let ops = exec::first_deploy_ops(
-                resolved,
-                &proxy,
-                &unit,
-                env_file,
-                &binary,
-                &manifests,
-                &release_id,
-                &plan,
-            );
-            // First-deploy teardown must also unlink `current` and clear the
-            // live-slot marker that first_deploy_ops creates — otherwise a failed
-            // first deploy leaves them behind and the next `deploy up` wrongly
-            // takes the redeploy path with nothing serving.
-            let teardown = exec::first_deploy_teardown_ops(resolved, &release_id, &plan);
-            (ops, teardown, "first deploy".to_owned(), true)
+    // Refuse a release-dir collision (#1621, §4.9). The release id has one-second
+    // granularity, so a fast retry re-uses it; re-uploading into the dir
+    // `shared/previous-release` still points at would make the "previous release"
+    // hold the NEW binary and roll FORWARD on the next rollback. Nothing detects
+    // that afterwards, so it is refused before anything is written.
+    match exec::probe_release_dir(cfg, input.release_id, executor)
+        .map_err(|e| DeployError::Exec(scoped(e.to_string())))?
+    {
+        exec::ReleaseDirState::Absent => {}
+        exec::ReleaseDirState::Present => {
+            return Err(DeployError::Config(scoped(format!(
+                "release directory {}/{} already exists — a previous run of this release \
+                 id already wrote into it, and re-uploading would put the NEW binary in \
+                 the directory `shared/previous-release` points at (so a rollback would \
+                 roll FORWARD). Wait a second and re-run `autumn deploy up`, or remove \
+                 that directory if you are certain it is stale. Tracked in #1621.",
+                cfg.releases_dir(),
+                input.release_id,
+            ))));
         }
+        exec::ReleaseDirState::Unreadable => {
+            return Err(DeployError::Config(scoped(format!(
+                "cannot verify whether release directory {}/{} already exists (the probe \
+                 returned neither sentinel), so a release-id collision cannot be ruled \
+                 out and the deploy is refused rather than risk overwriting the release \
+                 `shared/previous-release` points at. Tracked in #1621.",
+                cfg.releases_dir(),
+                input.release_id,
+            ))));
+        }
+    }
+
+    match probe.mode {
+        exec::DeployMode::First => Ok(HostProbeState {
+            mode: fleet::HostMode::from_deploy_mode(&probe.mode),
+            slots: exec::SlotPlan::first(input.public_port),
+            repair: false,
+            // A first deploy registers the NEW config's options; there is no old
+            // release whose options could need preserving.
+            reregister_options: input.proxy.proxy_service_options(),
+            banner: "first deploy".to_owned(),
+        }),
         exec::DeployMode::Redeploy { live_slot } => {
             // Pre-flight refuse (#2073): the reboot-durability restart-refresh (#2070)
             // re-execs `kamal-proxy run` on the public port and re-registers the
@@ -2079,14 +2303,14 @@ fn run_up(
             // (captured in the deploy-start probe) — so the live release keeps serving.
             // A live-safe port change is future work (Option C, #2073). No installed
             // unit → first-deploy shape (allowed); an unreadable unit → fail closed.
-            refuse_concurrent_public_port_change(&probe.installed_proxy_port, public_port)
-                .map_err(DeployError::Config)?;
+            refuse_concurrent_public_port_change(&probe.installed_proxy_port, input.public_port)
+                .map_err(|message| DeployError::Config(scoped(message)))?;
             // Pre-flight refuse (#2074): if the `shared/proxy-options` marker is present
             // but unreadable, we cannot prove the OLD release's TLS/host, so a concurrent
             // `deploy.tls.host` change can't be safely preserved across the durability
             // restart — fail closed BEFORE any op runs, so the live release keeps serving.
             refuse_unprovable_proxy_options(&probe.last_proxy_options)
-                .map_err(DeployError::Config)?;
+                .map_err(|message| DeployError::Config(scoped(message)))?;
             // Choose the options the durability-refresh re-register carries for the
             // still-live OLD release (#2074). PRESERVE the marker's recorded options
             // when known; on an ABSENT marker fall back to the NEW config (proceed as
@@ -2097,7 +2321,7 @@ fn run_up(
             // Unreadable case is already refused above, so it never reaches here.
             let reregister_options = match &probe.last_proxy_options {
                 exec::ProxyOptionsMarker::Options(old) => old.clone(),
-                _ => proxy.proxy_service_options(),
+                _ => input.proxy.proxy_service_options(),
             };
             // Reconcile the (possibly stale) live-slot marker against the live
             // proxy before choosing the candidate slot. On an UNAMBIGUOUS
@@ -2108,80 +2332,283 @@ fn run_up(
             let reconcile = exec::reconcile_live_slot(
                 live_slot,
                 &probe.proxy_list,
-                &resolved.service_name,
-                public_port,
+                &cfg.service_name,
+                input.public_port,
             );
             if let Some(warn) = &reconcile.warn {
                 // Loud + observable: drift is surfaced, not silently papered over.
                 // (autumn-cli installs no tracing subscriber, so the deploy module
                 // reports operator-facing state via eprintln! throughout.)
-                eprintln!("\u{26A0}\u{FE0F}  {warn}");
+                eprintln!("\u{26A0}\u{FE0F}  {}", scoped(warn.clone()));
             }
-            let plan = exec::SlotPlan::redeploy(public_port, reconcile.live_slot);
-            let unit = render_app_unit(
-                resolved,
-                &release_dir,
-                plan.candidate_port,
-                plan.candidate_slot,
+            let slots = exec::SlotPlan::redeploy(input.public_port, reconcile.live_slot);
+            let banner = format!(
+                "zero-downtime redeploy ({} \u{2192} {})",
+                slots.live_slot, slots.candidate_slot
             );
-            let mut ops = exec::cutover_ops(
-                resolved,
-                &proxy,
-                &unit,
-                env_file,
-                &binary,
-                &manifests,
-                &release_id,
-                &plan,
-                &reregister_options,
-                // #1621: the single-host path IS a one-host fleet, and a one-host
-                // fleet's only host carries the migration — so this is today's
-                // sequence, unchanged. The fleet driver (next slice) is what varies
-                // this per host.
-                exec::MigrateStep::Run,
-            );
-            // Repair the drifted marker as an early op — before the cutover's
-            // record-previous-release reads it — so the on-disk marker matches the
-            // proxy truth even if the rest of the deploy is later interrupted.
-            if reconcile.repair {
-                ops.insert(
-                    0,
-                    exec::live_slot_marker_repair_op(resolved, plan.live_slot, public_port),
-                );
-            }
-            let teardown = exec::candidate_teardown_ops(resolved, &release_id, &plan);
-            (
-                ops,
-                teardown,
-                format!(
-                    "zero-downtime redeploy ({} \u{2192} {})",
-                    plan.live_slot, plan.candidate_slot
-                ),
-                false,
-            )
+            Ok(HostProbeState {
+                mode: fleet::HostMode::from_deploy_mode(&probe.mode),
+                slots,
+                repair: reconcile.repair,
+                reregister_options,
+                banner,
+            })
         }
-    };
+    }
+}
 
-    eprintln!(
-        "Deploying release {release_id} to {} ({banner})\u{2026}\n",
-        resolved.host.as_deref().unwrap_or_default()
-    );
-    let result = if is_first {
-        exec::execute_first_deploy(&checks, &ops, &teardown, &executor)
+/// Drive the rollout: probe every host, plan, then replace the hosts ONE AT A TIME
+/// (issue #1621, AC-2/AC-3/AC-4).
+///
+/// The executor factory is injected (generic, never `dyn`, and with no `Send`/`Sync`
+/// bound) so a test can drive the whole loop — probe, plan, per-host execute — with
+/// one scripted fake per host. Production hands it an `SshExecutor` per target.
+///
+/// Structure that is load-bearing rather than stylistic:
+///
+/// - **Every host is probed before ANY host is mutated.** All the fail-closed
+///   refusals live in that phase, so a drifted host in position 3 refuses the whole
+///   rollout with hosts 1 and 2 untouched.
+/// - **Each host's ops are executed by their OWN `execute_*` call.** Two hosts' op
+///   vectors are never concatenated: `execute_with_teardown` resolves the
+///   auto-rollback boundary with the FIRST matching label, so a flat vector would
+///   classify every later host's pre-flip failure as post-boundary and silently
+///   disable teardown.
+/// - **A failure HALTS the rollout.** Hosts after the failing one are never
+///   touched. Compensating the hosts that already cut over is the next slice; the
+///   typed [`DeployError::FleetHalted`] already names them.
+#[allow(clippy::too_many_lines)]
+fn run_up_with<E, P, F>(input: &FleetUpInput<'_, P>, make_executor: F) -> Result<(), DeployError>
+where
+    E: exec::DeployExecutor,
+    P: ProxyController,
+    F: Fn(&ResolvedDeployConfig) -> Result<E, DeployError>,
+{
+    let fleet = input.fleet;
+    let single = fleet.is_single();
+    let total = fleet.hosts.len();
+
+    // ONE executor per host, built up front and reused for that host's read-only
+    // probe AND its execution.
+    let executors = fleet
+        .hosts
+        .iter()
+        .map(&make_executor)
+        .collect::<Result<Vec<E>, DeployError>>()?;
+
+    // MediaMTX host preflight (#1974 Slice 7) — non-mutating doctor checks run
+    // BEFORE the app deploy so a bad media host fails fast without anything being
+    // written. The MUTATING provisioning (write config/unit + restart) is deferred
+    // until after the app cutover succeeds (below) so a rolled-back app deploy
+    // never touches the host MediaMTX unit. No-op unless enabled (see fn).
+    //
+    // Single-host only for now: `provision_media_host` has no teardown/rollback
+    // path, so fanning it out would leave N media daemons on identical ports with
+    // divergent recording sets and nothing to undo them with. Until the fleet-wide
+    // refusal lands a fleet therefore provisions NO media and prints nothing new.
+    //
+    // slice 5: refusal — a media-enabled fleet (`[media.mediamtx] enabled` with
+    // more than one host) must be REFUSED in the prologue, alongside the sqlite and
+    // TLS fleet refusals, rather than silently skipped here.
+    if single {
+        check_media_host_preflight(input.media_cfg, input.ffmpeg_bin, &executors[0])?;
+    }
+
+    // ── ALL-HOSTS PROBE (read-only, serial, rollout order) ───────────────────
+    // Nothing anywhere in the fleet is mutated by this phase.
+    let probes = fleet
+        .hosts
+        .iter()
+        .zip(&executors)
+        .map(|(cfg, executor)| probe_host_for_up(cfg, input, executor))
+        .collect::<Result<Vec<HostProbeState>, DeployError>>()?;
+
+    let modes: Vec<fleet::HostMode> = probes.iter().map(|probe| probe.mode).collect();
+    let plan = fleet::plan_fleet(fleet, &modes).map_err(|e| DeployError::Config(e.to_string()))?;
+
+    if !single {
+        for line in
+            fleet::fleet_rollout_lines(&plan, input.release_id, input.writable_db_configured)
+        {
+            eprintln!("{line}");
+        }
+        eprintln!();
+    }
+
+    // ── EXECUTION (serial, one host at a time, rollout order) ────────────────
+    let mut outcomes = vec![fleet::HostOutcome::Untouched; total];
+    for (index, host_plan) in plan.hosts.iter().enumerate() {
+        let cfg = &fleet.hosts[index];
+        let state = &probes[index];
+        let executor = &executors[index];
+
+        let release_dir = format!("{}/{}", cfg.releases_dir(), input.release_id);
+        let unit = render_app_unit(
+            cfg,
+            &release_dir,
+            state.slots.candidate_port,
+            state.slots.candidate_slot,
+        );
+        let mut ops = fleet::host_ops(
+            host_plan,
+            &fleet::HostOpsInput {
+                cfg,
+                proxy: input.proxy,
+                unit: &unit,
+                env_file: input.env_file,
+                binary_local: input.binary,
+                manifests: input.manifests,
+                release_id: input.release_id,
+                slots: &state.slots,
+                reregister_options: &state.reregister_options,
+            },
+        );
+        // Repair the drifted marker as an early op — before the cutover's
+        // record-previous-release reads it — so the on-disk marker matches the
+        // proxy truth even if the rest of the deploy is later interrupted.
+        if state.repair {
+            ops.insert(
+                0,
+                exec::live_slot_marker_repair_op(cfg, state.slots.live_slot, input.public_port),
+            );
+        }
+        // First-deploy teardown must also unlink `current` and clear the live-slot
+        // marker that first_deploy_ops creates — otherwise a failed first deploy
+        // leaves them behind and the next `deploy up` wrongly takes the redeploy
+        // path with nothing serving.
+        let teardown = match host_plan.mode {
+            fleet::HostMode::First => {
+                exec::first_deploy_teardown_ops(cfg, input.release_id, &state.slots)
+            }
+            fleet::HostMode::Redeploy => {
+                exec::candidate_teardown_ops(cfg, input.release_id, &state.slots)
+            }
+        };
+
+        if single {
+            eprintln!(
+                "Deploying release {} to {} ({})\u{2026}\n",
+                input.release_id, host_plan.host, state.banner,
+            );
+        } else {
+            eprintln!(
+                "[{}/{total} {}] deploying release {} ({})\u{2026}",
+                index + 1,
+                host_plan.host,
+                input.release_id,
+                state.banner,
+            );
+        }
+
+        let result = match host_plan.mode {
+            fleet::HostMode::First => {
+                exec::execute_first_deploy(input.checks, &ops, &teardown, executor)
+            }
+            fleet::HostMode::Redeploy => {
+                exec::execute_redeploy(input.checks, &ops, &teardown, executor)
+            }
+        };
+
+        match result {
+            Ok(()) => {
+                outcomes[index] = fleet::HostOutcome::Serving;
+                if !single {
+                    if host_plan.migrate == exec::MigrateStep::Run {
+                        eprintln!("\u{26A0}\u{FE0F}  {}", fleet::FLEET_SCHEMA_MOVED_NOTE);
+                    }
+                    eprintln!(
+                        "\u{2705} [{}/{total} {}] serving {}\n",
+                        index + 1,
+                        host_plan.host,
+                        input.release_id,
+                    );
+                }
+            }
+            Err(err) => {
+                outcomes[index] = fleet::classify_failure(&err);
+                // A one-host fleet keeps today's error verbatim: the per-host
+                // executor already told the whole story, and inventing a fleet
+                // vocabulary for one host would change pre-#1621 output.
+                if single {
+                    return Err(DeployError::Exec(err.to_string()));
+                }
+                let failed_step = fleet::failed_step_label(&err);
+                eprintln!(
+                    "\n\u{274C} rollout halted at {} (`{failed_step}`) \u{2014} the remaining \
+                     hosts were not touched.\n",
+                    host_plan.host,
+                );
+                // Print the per-host state on the way out: a halted rollout is
+                // exactly when the operator has no other source of truth.
+                for line in fleet::fleet_summary_lines(&plan, &outcomes, input.release_id) {
+                    eprintln!("{line}");
+                }
+                return Err(fleet_halted(
+                    &plan,
+                    &outcomes,
+                    host_plan.host.clone(),
+                    failed_step,
+                ));
+            }
+        }
+    }
+
+    // App deploy is committed on every host here: the cutovers succeeded and there
+    // is no longer a rollback path. Only NOW provision the host MediaMTX unit
+    // (write config/unit + restart) — deferring the mutation past this point means
+    // a failed/rolled-back app deploy above never wrote or restarted MediaMTX
+    // (#1974 Slice 7). No-op unless enabled (see fn).
+    if single {
+        let executor = &executors[0];
+        provision_media_host(input.media_cfg, executor)?;
+    }
+
+    if single {
+        eprintln!("\n\u{2705} Deploy complete. Roll back with `autumn deploy rollback`.");
     } else {
-        exec::execute_redeploy(&checks, &ops, &teardown, &executor)
-    };
-    result.map_err(|e| DeployError::Exec(e.to_string()))?;
-
-    // App deploy is committed here: the cutover succeeded and there is no longer a
-    // rollback path. Only NOW provision the host MediaMTX unit (write config/unit +
-    // restart) — deferring the mutation past this point means a failed/rolled-back
-    // app deploy above never wrote or restarted MediaMTX (#1974 Slice 7). No-op
-    // unless enabled (see fn).
-    provision_media_host(media_cfg, &executor)?;
-
-    eprintln!("\n\u{2705} Deploy complete. Roll back with `autumn deploy rollback`.");
+        for line in fleet::fleet_summary_lines(&plan, &outcomes, input.release_id) {
+            eprintln!("{line}");
+        }
+        eprintln!(
+            "\n\u{2705} Fleet deploy complete \u{2014} all {total} hosts serving {}.",
+            input.release_id,
+        );
+    }
     Ok(())
+}
+
+/// Build the typed halt error from the recorded per-host outcomes (issue #1621,
+/// AC-3).
+///
+/// Secrets discipline: every field is a host name or a `&'static str` op label —
+/// never a shell line, a remote path, or a formatted driver error (a migration
+/// failure's source can embed the database URL).
+fn fleet_halted(
+    plan: &fleet::FleetPlan,
+    outcomes: &[fleet::HostOutcome],
+    failed_host: String,
+    failed_step: &'static str,
+) -> DeployError {
+    let named = |want: fn(&fleet::HostOutcome) -> bool| -> Vec<String> {
+        plan.hosts
+            .iter()
+            .zip(outcomes)
+            .filter(|(_, outcome)| want(outcome))
+            .map(|(host, _)| host.host.clone())
+            .collect()
+    };
+    DeployError::FleetHalted {
+        failed_host,
+        failed_step,
+        rolled_back: named(|o| matches!(o, fleet::HostOutcome::RolledBack { .. })),
+        torn_down: named(|o| matches!(o, fleet::HostOutcome::TornDown { .. })),
+        still_on_new: named(|o| {
+            matches!(
+                o,
+                fleet::HostOutcome::Serving | fleet::HostOutcome::LiveOnNew { .. }
+            )
+        }),
+    }
 }
 
 /// Perform a real on-demand rollback (issue #1607, Slice 3, AC-4).
@@ -4201,9 +4628,16 @@ mod tests {
         // gate, migrations) and leaves the OLD release serving, and there is
         // deliberately no media teardown — so writing/restarting the host MediaMTX
         // unit BEFORE the app is committed would strand a rolled-back release
-        // against a moved media daemon. We assert the `run_up` source order: the
-        // non-mutating preflight precedes the app deploy, and `provision_media_host`
-        // is invoked only after the committing `result.map_err(...)?` line.
+        // against a moved media daemon. We assert the source order of the `up`
+        // path: the non-mutating preflight precedes the rollout loop, and
+        // `provision_media_host` is invoked only after that loop has run every
+        // host to completion.
+        //
+        // #1621 re-anchored the middle marker. `run_up` is now a fleet-shaped
+        // driver (`run_up` prologue + `run_up_with` loop), so the commit point is
+        // no longer a single `result.map_err(...)?` line but the per-host execution
+        // LOOP — a strictly stronger statement: provisioning must follow the last
+        // host's cutover, not merely one host's.
         let src = include_str!("deploy.rs");
         let up_body = src
             .split("fn run_up(")
@@ -4212,26 +4646,25 @@ mod tests {
             .expect("run_up body present");
 
         let preflight_at = up_body
-            .find("check_media_host_preflight(media_cfg")
-            .expect("preflight call present in run_up");
-        // The app deploy is executed via execute_first_deploy/execute_redeploy and
-        // committed by this `result.map_err(...)?` line; a failed deploy returns
-        // here (after the teardown-on-failure) before anything below runs.
+            .find("check_media_host_preflight(input.media_cfg")
+            .expect("preflight call present on the up path");
+        // The per-host cutovers happen inside this loop; a failed host returns from
+        // inside it (after the per-host teardown) before anything below runs.
         let commit_at = up_body
-            .find("result.map_err(|e| DeployError::Exec(e.to_string()))?;")
-            .expect("app deploy commit line present in run_up");
+            .find("for (index, host_plan) in plan.hosts.iter().enumerate()")
+            .expect("per-host execution loop present on the up path");
         let provision_at = up_body
-            .find("provision_media_host(media_cfg, &executor)?;")
-            .expect("deferred provisioning call present in run_up");
+            .find("provision_media_host(input.media_cfg, executor)?;")
+            .expect("deferred provisioning call present on the up path");
 
         assert!(
             preflight_at < commit_at,
-            "media preflight must precede the app deploy commit",
+            "media preflight must precede the per-host execution loop",
         );
         assert!(
             commit_at < provision_at,
-            "MediaMTX provisioning must run only AFTER the app deploy commits — so a \
-             rolled-back app deploy (which returns at the commit line) never reaches it",
+            "MediaMTX provisioning must run only AFTER every host's cutover commits — so a \
+             rolled-back or halted rollout (which returns from inside the loop) never reaches it",
         );
 
         // The preflight itself is non-mutating: it runs the doctor checks but must
@@ -4253,9 +4686,544 @@ mod tests {
         // And the mutating provisioning is reachable only on the post-commit path.
         let after_commit = &up_body[commit_at..];
         assert!(
-            after_commit.contains("provision_media_host(media_cfg, &executor)?;"),
-            "provisioning must sit on the post-commit path (unreachable when the app \
-             deploy errors out at the commit line)",
+            after_commit.contains("provision_media_host(input.media_cfg, executor)?;"),
+            "provisioning must sit on the post-commit path (unreachable when a host's \
+             deploy errors out inside the rollout loop)",
+        );
+    }
+
+    // ── Fleet rollout driver (issue #1621, slice 3) ──────────────────────────
+    //
+    // These drive the WHOLE loop — prologue probe → plan → per-host execute —
+    // against one strict recording fake per host, through the `run_up_with` seam.
+    // Nothing here contacts a host, resolves a binary, or reads the filesystem:
+    // every filesystem-coupled prologue step (preflight, binary resolution,
+    // manifest location, release-id minting) is resolved by `run_up` and handed in
+    // as data, which is what makes the rollout itself unit-testable.
+
+    /// The read-only probe labels a rollout is allowed to run before (and without)
+    /// mutating anything. Enumerated here, not imported, so a new mutating op can
+    /// never quietly join the allowlist: the "zero mutations" assertions below are
+    /// only as strong as this list is short.
+    const READ_ONLY_PROBES: [&str; 3] =
+        ["proxy-compat-probe", "detect-current", "probe-release-dir"];
+
+    /// The exact ordered `Run` labels of today's single-host zero-downtime
+    /// redeploy — the same vector `redeploy_produces_exact_zero_downtime_sequence`
+    /// (`exec.rs`) pins, restated here so a fleet host's sequence is asserted
+    /// against the protected contract and not merely against itself.
+    const REDEPLOY_RUN_LABELS: [&str; 13] = [
+        "proxy-snapshot-unit",
+        "proxy-install",
+        "proxy-restart-if-changed",
+        "prepare-dirs",
+        "daemon-reload",
+        "start-candidate",
+        "migrate",
+        "readiness-gate",
+        "proxy-flip",
+        "commit-markers",
+        "record-proxy-options",
+        "drain-old",
+        "prune",
+    ];
+
+    const FLEET_RELEASE_ID: &str = "20260714T120000Z";
+    const FLEET_PUBLIC_PORT: u16 = 3000;
+
+    fn fleet_of(hosts: &[&str]) -> ResolvedFleet {
+        ResolvedFleet::resolve(
+            &DeployConfig {
+                hosts: hosts.iter().map(|h| (*h).to_owned()).collect(),
+                ..DeployConfig::default()
+            },
+            "myapp",
+        )
+        .expect("a well-formed fleet resolves")
+    }
+
+    /// Probe stdout for a host already serving on the blue slot. The unit/options
+    /// delimiters are deliberately absent, so the installed proxy port and the
+    /// proxy-options marker both degrade to `Absent` — "nothing to conflict with",
+    /// the shape a legacy host presents.
+    fn redeploy_probe() -> String {
+        "redeploy:blue\t3001\n---autumn-kamal-proxy-list---\n".to_owned()
+    }
+
+    /// Probe stdout for a host with nothing installed yet.
+    fn first_deploy_probe() -> String {
+        "first\n---autumn-kamal-proxy-list---\n".to_owned()
+    }
+
+    /// Probe stdout whose `shared/proxy-options` marker is PRESENT but unparseable
+    /// (no tab field) — the fail-closed `#2074` shape.
+    fn unreadable_proxy_options_probe() -> String {
+        "redeploy:blue\t3001\n\
+         ---autumn-kamal-proxy-list---\n\
+         ---autumn-kamal-proxy-unit---\n\
+         --http-port 3000\n\
+         ---autumn-kamal-proxy-options---\n\
+         garbage\n"
+            .to_owned()
+    }
+
+    /// A `kamal-proxy deploy --help` capture carrying every flag the cutover uses,
+    /// so the compat probe passes.
+    fn compatible_deploy_help() -> &'static str {
+        "Usage:\n  kamal-proxy deploy SERVICE [flags]\n\nFlags:\n  \
+         --target host:port\n  --health-check-path string\n  --host strings\n  \
+         --tls\n  --deploy-timeout duration\n  --drain-timeout duration\n  \
+         --force\n"
+    }
+
+    fn fleet_manifests() -> Vec<exec::ManifestUpload> {
+        vec![exec::ManifestUpload {
+            local: PathBuf::from("/local/autumn.toml"),
+            remote_basename: "autumn.toml".to_owned(),
+        }]
+    }
+
+    /// Script one host as a healthy redeploy: compatible proxy, serving on blue,
+    /// no release-dir collision.
+    fn script_redeploy(
+        recorder: fleet::test_support::FleetRecorder,
+        host: &str,
+    ) -> fleet::test_support::FleetRecorder {
+        recorder
+            .script(host, "proxy-compat-probe", compatible_deploy_help())
+            .script(host, "detect-current", redeploy_probe())
+            .script(host, "probe-release-dir", "absent")
+    }
+
+    /// Build a driver input over `fleet` with every fleet-wide value fixed, so the
+    /// per-host op vectors are byte-comparable against the single-host builders.
+    struct FleetFixture {
+        env_file: exec::Secret,
+        manifests: Vec<exec::ManifestUpload>,
+        proxy: proxy::KamalProxyController,
+        media_cfg: media::MediaMtxHostConfig,
+        binary: PathBuf,
+    }
+
+    impl FleetFixture {
+        fn new() -> Self {
+            Self {
+                env_file: exec::Secret::new("AUTUMN_SECURITY__SIGNING_SECRET=topsecret\n"),
+                manifests: fleet_manifests(),
+                proxy: proxy::KamalProxyController::new(60),
+                media_cfg: media::MediaMtxHostConfig::default(),
+                binary: PathBuf::from("/local/target/release/myapp"),
+            }
+        }
+
+        fn input<'a>(
+            &'a self,
+            fleet: &'a ResolvedFleet,
+        ) -> FleetUpInput<'a, proxy::KamalProxyController> {
+            FleetUpInput {
+                fleet,
+                proxy: &self.proxy,
+                checks: &[],
+                env_file: &self.env_file,
+                binary: &self.binary,
+                manifests: &self.manifests,
+                release_id: FLEET_RELEASE_ID,
+                public_port: FLEET_PUBLIC_PORT,
+                media_cfg: &self.media_cfg,
+                ffmpeg_bin: "ffmpeg",
+                writable_db_configured: true,
+            }
+        }
+
+        /// The exact ordered calls today's SINGLE-host `run_up` would record for
+        /// `cfg` on the given path — built from the same unchanged per-host
+        /// builders, driven through the same plain recording fake.
+        fn todays_calls(
+            &self,
+            cfg: &ResolvedDeployConfig,
+            mode: fleet::HostMode,
+            migrate: exec::MigrateStep,
+        ) -> Vec<exec::test_support::RecordedCall> {
+            let slots = match mode {
+                fleet::HostMode::First => exec::SlotPlan::first(FLEET_PUBLIC_PORT),
+                fleet::HostMode::Redeploy => {
+                    exec::SlotPlan::redeploy(FLEET_PUBLIC_PORT, exec::SLOT_BLUE)
+                }
+            };
+            let release_dir = format!("{}/{FLEET_RELEASE_ID}", cfg.releases_dir());
+            let unit = render_app_unit(
+                cfg,
+                &release_dir,
+                slots.candidate_port,
+                slots.candidate_slot,
+            );
+            let ops = match mode {
+                fleet::HostMode::First => exec::first_deploy_ops(
+                    cfg,
+                    &self.proxy,
+                    &unit,
+                    self.env_file.clone(),
+                    &self.binary,
+                    &self.manifests,
+                    FLEET_RELEASE_ID,
+                    &slots,
+                ),
+                fleet::HostMode::Redeploy => exec::cutover_ops(
+                    cfg,
+                    &self.proxy,
+                    &unit,
+                    self.env_file.clone(),
+                    &self.binary,
+                    &self.manifests,
+                    FLEET_RELEASE_ID,
+                    &slots,
+                    &self.proxy.proxy_service_options(),
+                    migrate,
+                ),
+            };
+            let recorder = exec::test_support::RecordingExecutor::new();
+            exec::run_ops(&ops, &recorder).expect("the recording fake never fails");
+            recorder.calls()
+        }
+    }
+
+    #[test]
+    fn fleet_halted_carries_only_host_names_and_static_labels() {
+        // #1621: `FleetHalted` is the one error type that describes partial fleet
+        // state, so it is the one most tempting to enrich with "context". Every
+        // field is a host name or a `&'static str` op label — never a shell line, a
+        // remote path, or a formatted source error (a failed migration's driver
+        // error can embed the database URL, which is exactly why
+        // `apply_pending_or_exit` redacts it).
+        let err = fleet_halted(
+            &fleet::FleetPlan {
+                hosts: vec![
+                    fleet::HostPlan {
+                        host: "web-a".to_owned(),
+                        mode: fleet::HostMode::Redeploy,
+                        migrate: exec::MigrateStep::Run,
+                    },
+                    fleet::HostPlan {
+                        host: "web-b".to_owned(),
+                        mode: fleet::HostMode::Redeploy,
+                        migrate: exec::MigrateStep::Skip,
+                    },
+                ],
+            },
+            &[
+                fleet::HostOutcome::Serving,
+                fleet::HostOutcome::RolledBack {
+                    failed_step: "migrate",
+                },
+            ],
+            "web-b".to_owned(),
+            "migrate",
+        );
+
+        let rendered = format!("{err}\n{err:?}");
+        assert!(
+            rendered.contains("web-b") && rendered.contains("migrate"),
+            "the halt must name the failing host and step: {rendered}"
+        );
+        for secret in [
+            "postgres://",
+            "topsecret",
+            "AUTUMN_SECURITY__SIGNING_SECRET",
+            "systemd-run",
+        ] {
+            assert!(
+                !rendered.contains(secret),
+                "FleetHalted must never carry `{secret}`: {rendered}"
+            );
+        }
+    }
+
+    #[test]
+    fn fleet_of_one_matches_todays_single_host_sequence() {
+        // #1621 (AC-1, T1.6 / plan P1). The hard invariant: a one-host fleet runs
+        // the SAME ops, in the same order, with the same rendered shell, as the
+        // pre-fleet single-host path — proven differentially against the unchanged
+        // per-host builders, not against a remembered vector.
+        let fleet = fleet_of(&["203.0.113.10"]);
+        let recorder = script_redeploy(fleet::test_support::FleetRecorder::new(), "203.0.113.10");
+        let fixture = FleetFixture::new();
+
+        run_up_with(&fixture.input(&fleet), |cfg| Ok(recorder.executor(cfg)))
+            .expect("a scripted one-host fleet deploys cleanly");
+
+        // (a) the exact protected label vector, behind the read-only prologue.
+        let expected_labels: Vec<&'static str> = READ_ONLY_PROBES
+            .iter()
+            .copied()
+            .chain(REDEPLOY_RUN_LABELS)
+            .collect();
+        assert_eq!(
+            recorder.run_labels_for("203.0.113.10"),
+            expected_labels,
+            "a one-host fleet must run today's exact zero-downtime sequence"
+        );
+
+        // (b) and byte-for-byte the same calls (shells, upload paths, modes) as the
+        // single-host builders produce — the differential form of AC-1.
+        let observed = recorder.calls_for("203.0.113.10");
+        let (probes, mutating) = observed.split_at(READ_ONLY_PROBES.len());
+        assert_eq!(
+            probes
+                .iter()
+                .filter_map(exec::test_support::RecordedCall::run_label)
+                .collect::<Vec<_>>(),
+            READ_ONLY_PROBES.to_vec(),
+            "the rollout prologue must be read-only probes only"
+        );
+        assert_eq!(
+            mutating,
+            fixture
+                .todays_calls(
+                    &fleet.hosts[0],
+                    fleet::HostMode::Redeploy,
+                    exec::MigrateStep::Run
+                )
+                .as_slice(),
+            "a one-host fleet's ops must be byte-identical to today's single-host ops"
+        );
+    }
+
+    #[test]
+    fn fleet_of_one_first_deploy_matches_todays_single_host_sequence() {
+        // #1621 (AC-1, T1.6): the same differential proof on the first-deploy path,
+        // which carries NO migrate op — an all-first-deploy fleet migrates nowhere,
+        // exactly today's documented single-host limitation.
+        let fleet = fleet_of(&["203.0.113.10"]);
+        let recorder = fleet::test_support::FleetRecorder::new()
+            .script(
+                "203.0.113.10",
+                "proxy-compat-probe",
+                compatible_deploy_help(),
+            )
+            .script("203.0.113.10", "detect-current", first_deploy_probe())
+            .script("203.0.113.10", "probe-release-dir", "absent");
+        let fixture = FleetFixture::new();
+
+        run_up_with(&fixture.input(&fleet), |cfg| Ok(recorder.executor(cfg)))
+            .expect("a scripted one-host first deploy runs cleanly");
+
+        let observed = recorder.calls_for("203.0.113.10");
+        let (_, mutating) = observed.split_at(READ_ONLY_PROBES.len());
+        assert_eq!(
+            mutating,
+            fixture
+                .todays_calls(
+                    &fleet.hosts[0],
+                    fleet::HostMode::First,
+                    exec::MigrateStep::Skip
+                )
+                .as_slice(),
+            "a one-host first deploy must be byte-identical to today's single-host first deploy"
+        );
+        assert!(
+            !recorder.run_labels_for("203.0.113.10").contains(&"migrate"),
+            "the first-deploy path carries no migrate op"
+        );
+    }
+
+    #[test]
+    fn rolling_order_replaces_hosts_strictly_in_sequence() {
+        // #1621 (AC-2, T1.11). The whole safety claim of a rolling deploy is an
+        // ORDERING claim: host k+1 is not touched until host k has cut over, so the
+        // rest of the fleet keeps serving throughout. Asserted on the fleet-wide
+        // tape, which is the only structure that can express it.
+        let hosts = ["web-a", "web-b", "web-c"];
+        let fleet = fleet_of(&hosts);
+        let mut recorder = fleet::test_support::FleetRecorder::new();
+        for host in hosts {
+            recorder = script_redeploy(recorder, host);
+        }
+        let fixture = FleetFixture::new();
+
+        run_up_with(&fixture.input(&fleet), |cfg| Ok(recorder.executor(cfg)))
+            .expect("a scripted three-host fleet rolls out cleanly");
+
+        // (a) each host runs its OWN complete redeploy vector; only the first
+        // carries the fleet's single migration.
+        for (index, host) in hosts.iter().enumerate() {
+            let expected: Vec<&'static str> = READ_ONLY_PROBES
+                .iter()
+                .copied()
+                .chain(
+                    REDEPLOY_RUN_LABELS
+                        .iter()
+                        .copied()
+                        .filter(|l| index == 0 || *l != "migrate"),
+                )
+                .collect();
+            assert_eq!(
+                recorder.run_labels_for(host),
+                expected,
+                "{host} must run the full per-host sequence ({}the migration)",
+                if index == 0 { "with " } else { "without " }
+            );
+        }
+
+        // (b) strict sequencing: host k+1's first MUTATING op comes after host k's
+        // proxy-flip. (Read-only probes all run up front, before any host is
+        // touched — that is the all-hosts preflight probe, not a mutation.)
+        for pair in hosts.windows(2) {
+            let (previous, next) = (pair[0], pair[1]);
+            let flip = recorder
+                .index_of(previous, "proxy-flip")
+                .unwrap_or_else(|| panic!("{previous} must cut over"));
+            let first_mutation = recorder
+                .first_mutating(next, &READ_ONLY_PROBES)
+                .unwrap_or_else(|| panic!("{next} must be deployed"));
+            assert!(
+                flip < first_mutation,
+                "{next} must not be touched until {previous} has cut over: \
+                 {previous}'s proxy-flip at {flip}, {next}'s first mutation at {first_mutation}"
+            );
+        }
+    }
+
+    #[test]
+    fn unreadable_marker_on_any_host_aborts_before_any_mutation() {
+        // #1621 (AC-7, T1.17). Every per-host fail-closed refusal is evaluated for
+        // ALL hosts BEFORE the first host is touched. Host 3's `shared/proxy-options`
+        // marker is present but unparseable (#2074), so the whole rollout is
+        // refused — with hosts 1 and 2 untouched, still serving their old releases.
+        let fleet = fleet_of(&["web-a", "web-b", "web-c"]);
+        let mut recorder = fleet::test_support::FleetRecorder::new();
+        for host in ["web-a", "web-b"] {
+            recorder = script_redeploy(recorder, host);
+        }
+        recorder = recorder
+            .script("web-c", "proxy-compat-probe", compatible_deploy_help())
+            .script("web-c", "detect-current", unreadable_proxy_options_probe())
+            .script("web-c", "probe-release-dir", "absent");
+        let fixture = FleetFixture::new();
+
+        let err = run_up_with(&fixture.input(&fleet), |cfg| Ok(recorder.executor(cfg)))
+            .expect_err("an unprovable proxy-options marker must refuse the rollout");
+        let message = err.to_string();
+        assert!(
+            message.contains("web-c"),
+            "the refusal must name the offending HOST, got: {message}"
+        );
+        assert!(
+            message.contains("proxy-options") && message.contains("#2074"),
+            "the refusal must keep the single-host #2074 message, got: {message}"
+        );
+
+        let mutating = recorder.mutating(&READ_ONLY_PROBES);
+        assert!(
+            mutating.is_empty(),
+            "a refused rollout must mutate NOTHING anywhere in the fleet, got: {mutating:?}"
+        );
+    }
+
+    #[test]
+    fn existing_release_dir_on_any_host_refuses_the_rollout() {
+        // #1621 (AC-3, T1.19). The release id has one-second granularity, so a fast
+        // retry can reuse it. Re-uploading into a dir `shared/previous-release`
+        // still points at would make the "previous release" hold the NEW binary and
+        // roll FORWARD. Refuse before touching anything, naming the host.
+        let fleet = fleet_of(&["web-a", "web-b", "web-c"]);
+        let mut recorder = fleet::test_support::FleetRecorder::new();
+        for host in ["web-a", "web-c"] {
+            recorder = script_redeploy(recorder, host);
+        }
+        recorder = recorder
+            .script("web-b", "proxy-compat-probe", compatible_deploy_help())
+            .script("web-b", "detect-current", redeploy_probe())
+            .script("web-b", "probe-release-dir", "present");
+        let fixture = FleetFixture::new();
+
+        let err = run_up_with(&fixture.input(&fleet), |cfg| Ok(recorder.executor(cfg)))
+            .expect_err("an existing release dir must refuse the rollout");
+        let message = err.to_string();
+        assert!(
+            message.contains("web-b") && message.contains(FLEET_RELEASE_ID),
+            "the refusal must name the host and the colliding release, got: {message}"
+        );
+
+        let mutating = recorder.mutating(&READ_ONLY_PROBES);
+        assert!(
+            mutating.is_empty(),
+            "a refused rollout must mutate NOTHING anywhere in the fleet, got: {mutating:?}"
+        );
+    }
+
+    #[test]
+    fn a_failed_host_halts_the_rollout_and_leaves_later_hosts_untouched() {
+        // #1621 (AC-3). Host 2's readiness gate fails — a PRE-boundary failure, so
+        // its candidate is torn down by the existing per-host auto-rollback and its
+        // old release keeps serving. The rollout then HALTS: host 3 is never
+        // touched. Host 1 is left on the new release; compensating it back is the
+        // next slice's job, and the typed error already names it as such.
+        let hosts = ["web-a", "web-b", "web-c"];
+        let fleet = fleet_of(&hosts);
+        let mut recorder = fleet::test_support::FleetRecorder::new();
+        for host in hosts {
+            recorder = script_redeploy(recorder, host);
+        }
+        recorder = recorder.fail("web-b", "readiness-gate");
+        let fixture = FleetFixture::new();
+
+        let err = run_up_with(&fixture.input(&fleet), |cfg| Ok(recorder.executor(cfg)))
+            .expect_err("a mid-rollout failure must halt the rollout");
+
+        match &err {
+            DeployError::FleetHalted {
+                failed_host,
+                failed_step,
+                rolled_back,
+                torn_down,
+                still_on_new,
+            } => {
+                assert_eq!(failed_host, "web-b", "the halt must name the failing host");
+                assert_eq!(
+                    *failed_step, "readiness-gate",
+                    "the halt must name the failing step"
+                );
+                assert_eq!(
+                    rolled_back,
+                    &vec!["web-b".to_owned()],
+                    "a pre-boundary failure rolls the failing host's candidate back"
+                );
+                assert!(
+                    torn_down.is_empty(),
+                    "a redeploy host is rolled back, not torn down: {torn_down:?}"
+                );
+                assert_eq!(
+                    still_on_new,
+                    &vec!["web-a".to_owned()],
+                    "the already-cut-over hosts must be named so they can be compensated"
+                );
+            }
+            other => panic!("expected a fleet halt, got: {other:?}"),
+        }
+
+        // Host 1 completed its cutover.
+        assert!(
+            recorder.run_labels_for("web-a").contains(&"prune"),
+            "web-a must have completed its cutover"
+        );
+        // Host 2 stopped at the readiness gate and tore its candidate down.
+        let web_b = recorder.run_labels_for("web-b");
+        assert!(
+            web_b.contains(&"readiness-gate")
+                && !web_b.contains(&"proxy-flip")
+                && web_b.contains(&"teardown-candidate-unit")
+                && web_b.contains(&"teardown-candidate-dir"),
+            "web-b must fail at the gate, never flip, and tear its candidate down: {web_b:?}"
+        );
+        // Host 3 was probed in the all-hosts prologue and then never touched.
+        let web_c: Vec<_> = recorder
+            .mutating(&READ_ONLY_PROBES)
+            .into_iter()
+            .filter(|(host, _)| host == "web-c")
+            .collect();
+        assert!(
+            web_c.is_empty(),
+            "the rollout must halt: web-c must be mutated in no way, got: {web_c:?}"
         );
     }
 }

--- a/autumn-cli/src/deploy/exec.rs
+++ b/autumn-cli/src/deploy/exec.rs
@@ -1659,6 +1659,27 @@ const NO_PROXY_UNIT_SENTINEL: &str = "---autumn-no-proxy-unit---";
 /// refuse guard never fires on synthetic input).
 const PROXY_OPTIONS_DELIM: &str = "---autumn-kamal-proxy-options---";
 
+/// Delimiter appended after the `shared/proxy-options` marker, before
+/// `readlink -f {app_dir}/current` (issue #1621, AC-6), so all five sections ride
+/// in ONE round-trip. Its ABSENCE (a host deployed before this feature, older
+/// recorded output, or a scripted test) leaves an empty section →
+/// [`DeployProbe::current_release_dir`] `None` — "unknown", never a guessed id.
+const CURRENT_RELEASE_DELIM: &str = "---autumn-current-release---";
+
+/// The release id encoded in a resolved `current` release dir: its basename
+/// (issue #1621, AC-6).
+///
+/// `None` for an empty or root-only path, so an unreadable symlink can never be
+/// mistaken for a release named `""` — the drift report treats an unknown release
+/// as a DISTINCT reported state and never as drift, and that distinction depends on
+/// this returning `None` rather than something empty-but-`Some`.
+#[must_use]
+pub fn release_id_from_dir(dir: &str) -> Option<&str> {
+    let trimmed = dir.trim().trim_end_matches('/');
+    let id = trimmed.rsplit('/').next().unwrap_or_default();
+    (!id.is_empty()).then_some(id)
+}
+
 /// The outcome of the deploy-start probe: the first-vs-redeploy [`DeployMode`],
 /// the raw `kamal-proxy list` output, AND the installed proxy unit's `--http-port`
 /// state — all captured in the SAME remote round-trip, so a drifted live-slot
@@ -1678,6 +1699,13 @@ pub struct DeployProbe {
     /// the redeploy path to PRESERVE the old release's options on the durability
     /// re-register — or FAIL CLOSED when the marker is present but unreadable.
     pub last_proxy_options: ProxyOptionsMarker,
+    /// The release dir the host's `current` symlink resolves to (#1621, AC-6); its
+    /// basename is the deployed release id ([`release_id_from_dir`]).
+    ///
+    /// `None` when the symlink is absent, dangling, or the probe output predates
+    /// this section — reported as "unknown", never guessed. `deploy status` and the
+    /// fleet `maintenance` fan-out read it; the rollout path ignores it.
+    pub current_release_dir: Option<String>,
 }
 
 /// Parse the probe's unit section into an [`InstalledProxyPort`] (#2073).
@@ -1747,7 +1775,9 @@ pub fn probe_deploy_state(
          if [ -f {unit} ]; then grep -hoE -e '--http-port[[:space:]]+[0-9]+' {unit} 2>/dev/null || true; \
          else printf '%s' '{no_unit}'; fi; \
          printf '\\n{opts_delim}\\n'; \
-         cat {opts_marker} 2>/dev/null || true",
+         cat {opts_marker} 2>/dev/null || true; \
+         printf '\\n{current_delim}\\n'; \
+         readlink -f {current} 2>/dev/null || true",
         current = shell_quote(&cfg.current_symlink()),
         marker = shell_quote(&live_slot_marker(cfg)),
         blue = SLOT_BLUE,
@@ -1757,6 +1787,7 @@ pub fn probe_deploy_state(
         no_unit = NO_PROXY_UNIT_SENTINEL,
         opts_delim = PROXY_OPTIONS_DELIM,
         opts_marker = shell_quote(&proxy_options_marker(cfg)),
+        current_delim = CURRENT_RELEASE_DELIM,
     );
     let out = exec.run(&RemoteCommand::new("detect-current", shell))?;
     let (mode_part, rest) = out
@@ -1766,21 +1797,34 @@ pub fn probe_deploy_state(
     // Split the proxy list from the installed-unit section. A missing unit delimiter
     // (older/scripted output) → empty unit + options sections → `Absent`/`Absent`
     // (never a spurious refuse, always proceed-as-legacy).
-    let (proxy_list, installed_proxy_port, last_proxy_options) =
+    let (proxy_list, installed_proxy_port, last_proxy_options, current_release_dir) =
         match rest.split_once(PROXY_UNIT_DELIM) {
             Some((list, after_unit)) => {
                 // The installed-unit section further splits into the `--http-port` grep and
                 // the proxy-options marker; a missing options delimiter → empty → `Absent`.
-                let (unit_section, opts_section) = after_unit
+                let (unit_section, after_opts) = after_unit
                     .split_once(PROXY_OPTIONS_DELIM)
                     .unwrap_or((after_unit, ""));
+                // …and the options section further splits into the marker `cat` and the
+                // `readlink -f current` result (#1621). A missing delimiter (a host
+                // deployed before this feature, or a scripted test) leaves an empty
+                // current section → `None` = "release unknown", never a guessed id.
+                let (opts_section, current_section) = after_opts
+                    .split_once(CURRENT_RELEASE_DELIM)
+                    .unwrap_or((after_opts, ""));
                 (
                     list,
                     parse_installed_proxy_port(unit_section),
                     parse_proxy_options(opts_section),
+                    parse_current_release(current_section),
                 )
             }
-            None => (rest, InstalledProxyPort::Absent, ProxyOptionsMarker::Absent),
+            None => (
+                rest,
+                InstalledProxyPort::Absent,
+                ProxyOptionsMarker::Absent,
+                None,
+            ),
         };
     let mode = mode_part
         .trim()
@@ -1800,6 +1844,140 @@ pub fn probe_deploy_state(
         proxy_list: proxy_list.to_owned(),
         installed_proxy_port,
         last_proxy_options,
+        current_release_dir,
+    })
+}
+
+/// Parse the probe's `readlink -f {app_dir}/current` section (#1621, AC-6).
+///
+/// Empty (absent/dangling symlink, or a probe capture predating this section) →
+/// `None`. Anything else is the resolved release DIR, trimmed of surrounding
+/// whitespace/newlines. Deliberately NOT fail-closed: this section is read-only
+/// reporting, and refusing to report a status because a symlink is unreadable would
+/// make `deploy status` useless on exactly the drifted host it exists to surface.
+fn parse_current_release(section: &str) -> Option<String> {
+    let trimmed = section.trim();
+    (!trimmed.is_empty()).then(|| trimmed.to_owned())
+}
+
+/// Delimiter separating the two facts only `deploy status` needs — the live slot's
+/// `/ready` HTTP code and the maintenance-flag presence — in one round-trip
+/// (issue #1621, AC-6).
+const HOST_STATUS_DELIM: &str = "---autumn-host-status---";
+
+/// Sentinel the status probe prints when the shared maintenance flag file exists.
+const MAINTENANCE_ON_SENTINEL: &str = "maintenance-on";
+
+/// Everything `autumn deploy status` reads from ONE host (issue #1621, AC-6).
+///
+/// Deliberately a superset of [`DeployProbe`] rather than an extension of it:
+/// `deploy up` must NOT pay for a `curl` and a flag-file `test` on every host, and
+/// the fields below are meaningless to a rollout. Keeping them here is what lets
+/// [`probe_deploy_state`] stay exactly as costly as it was.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HostStatusProbe {
+    /// The shared deploy-state probe: mode + live-slot marker, `kamal-proxy list`,
+    /// the installed proxy port, the proxy-options marker and the `current` release.
+    pub deploy: DeployProbe,
+    /// HTTP status the live slot's loopback `/ready` answered with, or `None` when
+    /// nothing answered (connection refused, no `curl`, a timeout, an
+    /// unparseable code). `None` is "we could not tell", never "unhealthy".
+    pub ready_code: Option<u16>,
+    /// Whether the SHARED maintenance flag file exists on this host.
+    ///
+    /// Read from `{app_dir}/shared/…` — the release-independent path the slot units
+    /// point `AUTUMN_MAINTENANCE_FLAG_FILE` at — so the answer survives a cutover,
+    /// which is the whole reason that override exists.
+    pub maintenance_on: bool,
+}
+
+impl HostStatusProbe {
+    /// The live-slot decision for this host, reconciled against the running proxy —
+    /// pure, and `None` for a host with no promoted release at all.
+    ///
+    /// Shared with the rollout path's slot selection ([`reconcile_live_slot`]), so
+    /// `status` reports the same slot a deploy would plan from, including the same
+    /// proxy-over-marker precedence on a disagreement.
+    #[must_use]
+    pub fn reconcile(&self, cfg: &ResolvedDeployConfig, public_port: u16) -> Option<SlotReconcile> {
+        match &self.deploy.mode {
+            DeployMode::First => None,
+            DeployMode::Redeploy { live_slot } => Some(reconcile_live_slot(
+                live_slot,
+                &self.deploy.proxy_list,
+                &cfg.service_name,
+                public_port,
+            )),
+        }
+    }
+}
+
+/// The read-only status probe: the shared deploy-state round-trip PLUS the live
+/// slot's `/ready` code and the maintenance-flag presence (issue #1621, AC-6).
+///
+/// Used ONLY by `deploy status`, never by `up` — see [`HostStatusProbe`]. Both
+/// commands it runs are read-only (`readlink`/`cat`/`grep`, then `curl` and
+/// `[ -f ]`), so this can be pointed at a production fleet mid-incident.
+///
+/// The readiness probe hits the LIVE slot's loopback port (the same
+/// `http://127.0.0.1:{slot_port}/ready` the deploy's readiness gate polls), not the
+/// public port: the public port is kamal-proxy's, and asking the proxy would report
+/// the proxy's health rather than the release's. It is bounded by `--max-time` so a
+/// hung app cannot stall a fleet-wide status, and its failure is never fatal —
+/// `deploy status` must report the whole fleet or it is useless during the incident
+/// it exists for.
+///
+/// # Errors
+///
+/// Returns the executor's error only when a probe command cannot run at all — the
+/// caller renders that host as unreachable rather than aborting the fleet report.
+pub fn probe_host_status(
+    cfg: &ResolvedDeployConfig,
+    public_port: u16,
+    exec: &impl DeployExecutor,
+) -> Result<HostStatusProbe, DeployExecError> {
+    let deploy = probe_deploy_state(cfg, exec)?;
+    // Poll whichever slot the proxy is actually serving; on a host with nothing
+    // promoted yet, blue is the slot a first deploy takes, and the probe simply
+    // reports that nothing answered.
+    let live_slot = match &deploy.mode {
+        DeployMode::First => SLOT_BLUE,
+        DeployMode::Redeploy { live_slot } => {
+            reconcile_live_slot(
+                live_slot,
+                &deploy.proxy_list,
+                &cfg.service_name,
+                public_port,
+            )
+            .live_slot
+        }
+    };
+    let shell = format!(
+        "curl -o /dev/null -s -m 5 -w '%{{http_code}}' http://127.0.0.1:{port}/ready 2>/dev/null \
+         || true; \
+         printf '\\n{delim}\\n'; \
+         if [ -f {flag} ]; then printf '%s' '{on}'; fi",
+        port = slot_app_port(public_port, live_slot),
+        delim = HOST_STATUS_DELIM,
+        flag = shell_quote(&cfg.maintenance_flag_file()),
+        on = MAINTENANCE_ON_SENTINEL,
+    );
+    let out = exec.run(&RemoteCommand::new("probe-host-status", shell))?;
+    let (ready_section, maintenance_section) = out
+        .stdout
+        .split_once(HOST_STATUS_DELIM)
+        .unwrap_or((out.stdout.as_str(), ""));
+    Ok(HostStatusProbe {
+        deploy,
+        // `curl` writes `000` when it never got a response; that is "nothing
+        // answered", not an HTTP status, so it degrades to `None` like every other
+        // unreadable capture.
+        ready_code: ready_section
+            .trim()
+            .parse::<u16>()
+            .ok()
+            .filter(|code| *code > 0),
+        maintenance_on: maintenance_section.trim() == MAINTENANCE_ON_SENTINEL,
     })
 }
 
@@ -2523,12 +2701,13 @@ pub(crate) mod test_support {
     /// [`super::DeployMode::First`] / `Absent`. A fleet test that forgets to script
     /// host N's probe would therefore exercise the first-deploy branch and still
     /// pass. [`RecordingExecutor::strict`] turns that into a loud panic.
-    pub(crate) const PROBE_LABELS: [&str; 5] = [
+    pub(crate) const PROBE_LABELS: [&str; 6] = [
         "proxy-compat-probe",
         "detect-current",
         "probe-release-dir",
         "probe-rollback-target",
         "resolve-previous",
+        "probe-host-status",
     ];
 
     /// One recorded executor call. Uploads carry no local path: op building is
@@ -2579,6 +2758,11 @@ pub(crate) mod test_support {
         transport_fail_labels: Vec<&'static str>,
         /// Scripted stdout returned for a given command label.
         stdout_by_label: Vec<(&'static str, String)>,
+        /// #1621: remote-path fragments whose `upload` should fail. Uploads carry
+        /// no label, so failure is keyed on the destination path — the only
+        /// identity an upload has. This is what lets a test fail a `WriteFile` op
+        /// (the maintenance fan-out's flag write) the way a dying scp would.
+        upload_fail_paths: Vec<String>,
         /// #1621: the host this executor targets, recorded onto the shared fleet
         /// tape. Empty for the single-host fakes, which never set a tape.
         host: String,
@@ -2634,6 +2818,15 @@ pub(crate) mod test_support {
             stdout: impl Into<String>,
         ) -> Self {
             self.stdout_by_label.push((label, stdout.into()));
+            self
+        }
+
+        /// Make `upload` fail for any remote path containing `fragment` (#1621).
+        ///
+        /// The upload is still RECORDED first, mirroring `run`'s scripted
+        /// failures, so a test can assert the attempt happened.
+        pub(crate) fn failing_upload(mut self, fragment: impl Into<String>) -> Self {
+            self.upload_fail_paths.push(fragment.into());
             self
         }
 
@@ -2736,6 +2929,16 @@ pub(crate) mod test_support {
                 remote_path: remote_path.to_owned(),
                 mode,
             });
+            if self
+                .upload_fail_paths
+                .iter()
+                .any(|fragment| remote_path.contains(fragment.as_str()))
+            {
+                return Err(DeployExecError::CommandFailed {
+                    label: "upload",
+                    message: "scripted upload failure".to_owned(),
+                });
+            }
             Ok(())
         }
     }
@@ -4983,6 +5186,238 @@ mod tests {
             ProxyOptionsMarker::Unreadable,
             "an unparseable proxy-options marker fails closed as Unreadable",
         );
+    }
+
+    #[test]
+    fn probe_deploy_state_captures_the_current_release_dir() {
+        // #1621 (AC-6, plan §7.1): `autumn deploy status` needs each host's DEPLOYED
+        // RELEASE, and the only honest source is the `current` symlink's target — no
+        // runtime endpoint reports a release id (the probe body's `version` is the
+        // FRAMEWORK crate version, identical on every host forever). It rides as a
+        // FIFTH delimited section on the existing probe, so `status` costs the same
+        // one ssh round-trip `up` already pays and it works retroactively on hosts
+        // deployed before this feature.
+        let cfg = resolved();
+        let stdout = format!(
+            "redeploy:blue\t3001\n---autumn-kamal-proxy-list---\n{}\n\
+             ---autumn-kamal-proxy-unit---\n--http-port 80\n\
+             ---autumn-kamal-proxy-options---\n0\t\n\
+             ---autumn-current-release---\n/srv/autumn/myapp/releases/20260714T120000Z",
+            proxy_list_serving("myapp", 3001)
+        );
+        let exec = RecordingExecutor::new().with_stdout("detect-current", stdout);
+        let probe = probe_deploy_state(&cfg, &exec).unwrap();
+        assert_eq!(
+            probe.current_release_dir.as_deref(),
+            Some("/srv/autumn/myapp/releases/20260714T120000Z"),
+        );
+        assert_eq!(
+            release_id_from_dir(probe.current_release_dir.as_deref().unwrap()),
+            Some("20260714T120000Z"),
+            "the release id is the release dir's basename"
+        );
+        // The earlier sections are still cleanly split off — the new delimiter must
+        // not leak into the proxy-options marker.
+        assert_eq!(
+            probe.last_proxy_options,
+            ProxyOptionsMarker::Options(ProxyServiceOptions {
+                tls: false,
+                host: None,
+            })
+        );
+        assert_eq!(probe.installed_proxy_port, InstalledProxyPort::Port(80));
+
+        // The probe shell resolves the symlink behind its own delimiter, best-effort.
+        let shell = exec.shell_for("detect-current").expect("probe ran");
+        assert!(
+            shell.contains("---autumn-current-release---")
+                && shell.contains("readlink -f '/srv/autumn/myapp/current'"),
+            "probe resolves the current symlink behind its delimiter: {shell}"
+        );
+        // The LABEL is unchanged: it is load-bearing for every exact-vector test and
+        // for the strict test fake's probe allow-list.
+        assert_eq!(
+            exec.run_labels(),
+            vec!["detect-current"],
+            "the probe's op label must not change when a section is added"
+        );
+    }
+
+    #[test]
+    fn probe_deploy_state_degrades_when_the_current_release_section_is_missing() {
+        // #1621: a host deployed before this feature (or a scripted test that stubs
+        // only the earlier sections) has no fifth delimiter. That degrades to
+        // "unknown", exactly like every other section — never to a guessed release id,
+        // because drift reporting treats Unknown as a DISTINCT state and never as
+        // drift. A false "these hosts differ" at 3 am is worse than no warning.
+        let cfg = resolved();
+        let legacy = RecordingExecutor::new().with_stdout(
+            "detect-current",
+            "redeploy:blue\t3001\n---autumn-kamal-proxy-list---\n\
+             ---autumn-kamal-proxy-unit---\n--http-port 80",
+        );
+        assert!(
+            probe_deploy_state(&cfg, &legacy)
+                .unwrap()
+                .current_release_dir
+                .is_none(),
+            "a missing fifth delimiter degrades to unknown"
+        );
+
+        // Present but empty (`readlink` on a dangling/absent symlink prints nothing).
+        let empty = RecordingExecutor::new().with_stdout(
+            "detect-current",
+            "first\n---autumn-kamal-proxy-list---\n\
+             ---autumn-kamal-proxy-unit---\n---autumn-no-proxy-unit---\n\
+             ---autumn-kamal-proxy-options---\n\n---autumn-current-release---\n",
+        );
+        let probe = probe_deploy_state(&cfg, &empty).unwrap();
+        assert_eq!(probe.mode, DeployMode::First);
+        assert!(
+            probe.current_release_dir.is_none(),
+            "an empty current section is unknown, not an empty release id"
+        );
+    }
+
+    /// Full five-section `detect-current` stdout for a redeploy host on `release`.
+    fn status_probe_stdout(release: &str, live_port: u16) -> String {
+        format!(
+            "redeploy:blue\t{live_port}\n---autumn-kamal-proxy-list---\n{}\n\
+             ---autumn-kamal-proxy-unit---\n--http-port 3000\n\
+             ---autumn-kamal-proxy-options---\n0\t\n\
+             ---autumn-current-release---\n/srv/autumn/myapp/releases/{release}",
+            proxy_list_serving("myapp", live_port)
+        )
+    }
+
+    #[test]
+    fn probe_host_status_reads_readiness_and_maintenance_off_the_live_slot() {
+        // #1621 (AC-6, plan §7.1): `deploy status` needs two facts `up` must never
+        // pay for — the live slot's `/ready` code and whether the SHARED maintenance
+        // flag exists. They ride on their own labelled round-trip so
+        // `probe_deploy_state` (and therefore every `deploy up`) is unchanged.
+        let cfg = resolved();
+        let exec = RecordingExecutor::new()
+            .with_stdout(
+                "detect-current",
+                status_probe_stdout("20260714T120000Z", 3001),
+            )
+            .with_stdout(
+                "probe-host-status",
+                "200\n---autumn-host-status---\nmaintenance-on",
+            );
+        let probe = probe_host_status(&cfg, 3000, &exec).unwrap();
+        assert_eq!(probe.ready_code, Some(200));
+        assert!(probe.maintenance_on);
+        assert_eq!(
+            probe.deploy.current_release_dir.as_deref(),
+            Some("/srv/autumn/myapp/releases/20260714T120000Z")
+        );
+
+        // It polls the LIVE slot's loopback port (blue = public + 1), not the public
+        // port — the public port is kamal-proxy's, and asking it would report the
+        // proxy's health rather than the release's.
+        let shell = exec
+            .shell_for("probe-host-status")
+            .expect("status probe ran");
+        assert!(
+            shell.contains("http://127.0.0.1:3001/ready"),
+            "readiness is polled on the live slot's loopback port: {shell}"
+        );
+        // Bounded, so one hung app cannot stall a fleet-wide status.
+        assert!(shell.contains("-m 5"), "the curl must be bounded: {shell}");
+        // The maintenance flag is read from the RELEASE-INDEPENDENT shared path —
+        // reading a release dir would report "off" for every host after a cutover,
+        // which is the very defect the shared path exists to fix.
+        assert!(
+            shell.contains("'/srv/autumn/myapp/shared/autumn-maintenance.json'"),
+            "the maintenance flag is read from the shared dir: {shell}"
+        );
+        assert!(
+            !shell.contains("/releases/"),
+            "the status probe must not look for a release-scoped flag: {shell}"
+        );
+        // Read-only: exactly the two probe labels, nothing mutating.
+        assert_eq!(
+            exec.run_labels(),
+            vec!["detect-current", "probe-host-status"],
+            "`deploy status` must never mutate a host"
+        );
+    }
+
+    #[test]
+    fn probe_host_status_degrades_to_unknown_readiness_rather_than_failing() {
+        // A host with no `curl`, a refused connection, or a timeout writes `000`
+        // (or nothing). That is "we could not tell" — reporting it as an HTTP status
+        // would be a lie, and failing the probe would make `deploy status` useless on
+        // exactly the broken host it exists to surface.
+        let cfg = resolved();
+        for capture in [
+            "000\n---autumn-host-status---\n",
+            "---autumn-host-status---\n",
+            "",
+        ] {
+            let exec = RecordingExecutor::new()
+                .with_stdout("detect-current", status_probe_stdout("r1", 3001))
+                .with_stdout("probe-host-status", capture);
+            let probe = probe_host_status(&cfg, 3000, &exec).unwrap();
+            assert_eq!(
+                probe.ready_code, None,
+                "capture {capture:?} must degrade to unknown readiness"
+            );
+            assert!(
+                !probe.maintenance_on,
+                "no sentinel means maintenance is off, never unknown-as-on"
+            );
+        }
+    }
+
+    #[test]
+    fn probe_host_status_polls_the_slot_the_proxy_is_actually_serving() {
+        // The live-slot marker can drift from what kamal-proxy serves (an interrupted
+        // post-flip marker write). `status` reconciles exactly like the rollout path
+        // does, so it reports the slot a deploy would plan from — polling the marker's
+        // slot instead would report the IDLE release's readiness.
+        let cfg = resolved();
+        let drifted = format!(
+            "redeploy:blue\t3001\n---autumn-kamal-proxy-list---\n{}\n\
+             ---autumn-kamal-proxy-unit---\n--http-port 3000\n\
+             ---autumn-kamal-proxy-options---\n0\t\n\
+             ---autumn-current-release---\n/srv/autumn/myapp/releases/r1",
+            // the proxy is serving GREEN (public + 2) while the marker says blue
+            proxy_list_serving("myapp", 3002)
+        );
+        let exec = RecordingExecutor::new()
+            .with_stdout("detect-current", drifted)
+            .with_stdout("probe-host-status", "200\n---autumn-host-status---\n");
+        let probe = probe_host_status(&cfg, 3000, &exec).unwrap();
+        let reconcile = probe
+            .reconcile(&cfg, 3000)
+            .expect("a redeploy host reconciles");
+        assert_eq!(reconcile.live_slot, SLOT_GREEN);
+        assert!(reconcile.repair, "the disagreement is reported as drift");
+        let shell = exec
+            .shell_for("probe-host-status")
+            .expect("status probe ran");
+        assert!(
+            shell.contains("http://127.0.0.1:3002/ready"),
+            "readiness must follow the PROXY's slot, not the marker's: {shell}"
+        );
+    }
+
+    #[test]
+    fn release_id_from_dir_takes_the_basename_and_rejects_junk() {
+        assert_eq!(
+            release_id_from_dir("/srv/autumn/myapp/releases/20260714T120000Z"),
+            Some("20260714T120000Z")
+        );
+        // Trailing slash (some readlink/shell shapes) still yields the id.
+        assert_eq!(
+            release_id_from_dir("/srv/autumn/myapp/releases/20260714T120000Z/"),
+            Some("20260714T120000Z")
+        );
+        assert_eq!(release_id_from_dir(""), None);
+        assert_eq!(release_id_from_dir("/"), None);
     }
 
     /// A compatible `kamal-proxy deploy --help` capture for the compat probe tests.

--- a/autumn-cli/src/deploy/exec.rs
+++ b/autumn-cli/src/deploy/exec.rs
@@ -569,6 +569,97 @@ fn proxy_options_marker(cfg: &ResolvedDeployConfig) -> String {
     format!("{}/shared/proxy-options", cfg.app_dir)
 }
 
+/// Remote marker file recording the LAST state-changing deploy action this host
+/// completed, stored as `{result}\t{utc-timestamp}` (issue #1621, AC-6).
+///
+/// AC-6 asks `deploy status` for the per-host *last deploy result*, and no other
+/// on-host artefact answers it: `current`, `live-slot` and `previous-release` all
+/// describe the release a host is serving, never how it got there. After a halted
+/// rollout that compensated cleanly, every host reads back as healthy and
+/// converged — which is exactly the state the operator wants distinguished from a
+/// fleet that simply deployed.
+///
+/// **What it knows, precisely.** It is written by the ops that COMPLETE a cutover
+/// ([`commit_markers_command`] and [`record_proxy_options`]), so it records the
+/// last action that actually moved this host: [`LAST_DEPLOY_DEPLOYED`] or
+/// [`LAST_DEPLOY_ROLLED_BACK`]. A deploy that fails BEFORE the cutover boundary
+/// never reaches those ops (the host keeps serving its old release and is torn
+/// down), so the marker still names the previous action — it is the host's last
+/// completed action, not a verdict on the last rollout. `deploy status` says so
+/// where it prints it.
+///
+/// Mirrors [`live_slot_marker`]'s path convention (all markers live under
+/// `shared/`), so it survives cutovers and is pruned with nothing.
+fn last_deploy_marker(cfg: &ResolvedDeployConfig) -> String {
+    format!("{}/shared/last-deploy", cfg.app_dir)
+}
+
+/// Marker word for a host that last completed a forward deploy (first deploy or
+/// redeploy cutover). See [`last_deploy_marker`].
+pub const LAST_DEPLOY_DEPLOYED: &str = "deployed";
+
+/// Marker word for a host whose last completed action was a rollback — an
+/// operator-invoked `autumn deploy rollback`, or the fleet driver compensating a
+/// halted rollout (AC-3). See [`last_deploy_marker`].
+pub const LAST_DEPLOY_ROLLED_BACK: &str = "rolled back";
+
+/// Shell fragment that records `result` into the [`last_deploy_marker`], written
+/// atomically (mktemp + `mv -f`) like every other marker.
+///
+/// **Advisory by construction.** The fragment is a `{ … || true; }` group, so a
+/// failure to write it can never fail the op it is appended to. That is
+/// deliberate: it rides on `commit-markers` — whose failure is the one the fleet
+/// driver refuses to auto-roll-back from, because a partially-applied marker
+/// triple makes the rollback target unprovable — and a cosmetic status field must
+/// not be able to push a host into that state.
+fn record_last_deploy_fragment(cfg: &ResolvedDeployConfig, result: &str) -> String {
+    let shared = cfg.shared_dir();
+    let tmpl = format!("{shared}/last-deploy.tmp.XXXXXX");
+    format!(
+        "{{ rtmp=$(mktemp {tmpl}) && printf '%s\\t%s' {result} \
+         \"$(date -u +%Y-%m-%dT%H:%M:%SZ)\" > \"$rtmp\" && mv -f \"$rtmp\" {marker} || true; }}",
+        tmpl = shell_quote(&tmpl),
+        result = shell_quote(result),
+        marker = shell_quote(&last_deploy_marker(cfg)),
+    )
+}
+
+/// The last completed deploy action a host reports, parsed from the
+/// [`last_deploy_marker`] (issue #1621, AC-6).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LastDeploy {
+    /// The recorded action word — [`LAST_DEPLOY_DEPLOYED`] or
+    /// [`LAST_DEPLOY_ROLLED_BACK`]. Kept as the raw string so a marker written by
+    /// a newer CLI is reported verbatim rather than degrading to "unknown".
+    pub result: String,
+    /// When it was recorded, as the host's UTC `date -u +%Y-%m-%dT%H:%M:%SZ`, or
+    /// `None` for a marker written before the timestamp field existed.
+    pub at: Option<String>,
+}
+
+/// Parse a [`last_deploy_marker`] body (`{result}\t{timestamp}`).
+///
+/// Degrades to `None` for an empty/whitespace-only body — a missing marker (a host
+/// that has never completed a cutover) and an unreadable one are the same "we
+/// cannot tell", never a fabricated result.
+fn parse_last_deploy(raw: &str) -> Option<LastDeploy> {
+    let raw = raw.trim();
+    if raw.is_empty() {
+        return None;
+    }
+    let (result, at) = raw.split_once('\t').unwrap_or((raw, ""));
+    let result = result.trim();
+    if result.is_empty() {
+        return None;
+    }
+    Some(LastDeploy {
+        result: result.to_owned(),
+        at: Some(at.trim())
+            .filter(|at| !at.is_empty())
+            .map(ToOwned::to_owned),
+    })
+}
+
 /// The resolved blue/green slot layout for a deploy.
 ///
 /// The candidate always takes the slot the live release is NOT using, so both
@@ -969,6 +1060,7 @@ pub fn cutover_ops(
                 slot: plan.live_slot,
                 port: plan.live_port,
             },
+            LAST_DEPLOY_DEPLOYED,
         )),
         // Record the proxy TLS/host options this cutover registered on the new
         // release (issue #2074) — the controller's NEW `tls_host`, NOT the preserved
@@ -1263,6 +1355,7 @@ pub fn rollback_ops(
                 slot: other_slot(target.slot),
                 port: former_live_fallback_port,
             },
+            LAST_DEPLOY_ROLLED_BACK,
         )),
         DeployOp::Run(RemoteCommand::new(
             "readiness-gate",
@@ -1362,10 +1455,15 @@ fn record_proxy_options(
     RemoteCommand::new(
         "record-proxy-options",
         format!(
-            "otmp=$(mktemp {tmpl}) && printf '%s' {value} > \"$otmp\" && mv -f \"$otmp\" {marker}",
+            "otmp=$(mktemp {tmpl}) && printf '%s' {value} > \"$otmp\" && mv -f \"$otmp\" {marker} \
+             && {last_deploy}",
             tmpl = shell_quote(&tmpl),
             value = shell_quote(&options.marker_value()),
             marker = shell_quote(&proxy_options_marker(cfg)),
+            // AC-6: this op is the LAST marker write on both forward paths (first
+            // deploy and redeploy cutover), so it is where "this host completed a
+            // deploy" is true. Advisory — see `record_last_deploy_fragment`.
+            last_deploy = record_last_deploy_fragment(cfg, LAST_DEPLOY_DEPLOYED),
         ),
     )
 }
@@ -1422,6 +1520,7 @@ fn commit_markers_command(
     slot: &str,
     port: u16,
     prev_fallback: PrevMarkerFallback<'_>,
+    last_deploy_result: &str,
 ) -> RemoteCommand {
     let shared = cfg.shared_dir();
     let prev_tmpl = format!("{shared}/previous-release.tmp.XXXXXX");
@@ -1443,7 +1542,14 @@ fn commit_markers_command(
              ln -sfn {release_dir} {current} && \
              ltmp=$(mktemp {live_tmpl}) && \
              printf '%s\\t%s' {slot} {port} > \"$ltmp\" && \
-             mv -f \"$ltmp\" {live_marker}",
+             mv -f \"$ltmp\" {live_marker} && \
+             {last_deploy}",
+            // AC-6: the last-deploy marker rides on the transaction that COMPLETES
+            // the cutover, so it is the one place both the redeploy and the
+            // rollback path agree on. Advisory — its failure can never turn a
+            // successful marker commit into the AmbiguousMarkers state (see
+            // `record_last_deploy_fragment`).
+            last_deploy = record_last_deploy_fragment(cfg, last_deploy_result),
             current = shell_quote(&cfg.current_symlink()),
             live_marker = shell_quote(&live_slot_marker(cfg)),
             prev_slot = shell_quote(prev_fallback.slot),
@@ -1912,6 +2018,14 @@ pub struct HostStatusProbe {
     /// point `AUTUMN_MAINTENANCE_FLAG_FILE` at — so the answer survives a cutover,
     /// which is the whole reason that override exists.
     pub maintenance_on: bool,
+    /// The last state-changing deploy action this host COMPLETED, from the
+    /// `shared/last-deploy` marker (AC-6), or `None` when the marker is absent or
+    /// unreadable.
+    ///
+    /// See [`last_deploy_marker`] for exactly what it does and does not know: a
+    /// deploy that failed before the cutover boundary never rewrites it, so it is
+    /// the host's last completed action rather than a verdict on the last rollout.
+    pub last_deploy: Option<LastDeploy>,
 }
 
 impl HostStatusProbe {
@@ -1979,17 +2093,26 @@ pub fn probe_host_status(
         "curl -o /dev/null -s -m 5 -w '%{{http_code}}' http://127.0.0.1:{port}/ready 2>/dev/null \
          || true; \
          printf '\\n{delim}\\n'; \
-         if [ -f {flag} ]; then printf '%s' '{on}'; fi",
+         if [ -f {flag} ]; then printf '%s' '{on}'; fi; \
+         printf '\\n{delim}\\n'; \
+         cat {last_deploy} 2>/dev/null || true",
         port = slot_app_port(public_port, live_slot),
         delim = HOST_STATUS_DELIM,
         flag = shell_quote(&cfg.maintenance_flag_file()),
         on = MAINTENANCE_ON_SENTINEL,
+        // AC-6, third fact: the last COMPLETED deploy action. Folded into this
+        // existing round-trip rather than a new per-host ssh — `deploy status` is
+        // run mid-incident across the whole fleet, and every extra round-trip is
+        // paid N times.
+        last_deploy = shell_quote(&last_deploy_marker(cfg)),
     );
     let out = exec.run(&RemoteCommand::new("probe-host-status", shell))?;
-    let (ready_section, maintenance_section) = out
-        .stdout
-        .split_once(HOST_STATUS_DELIM)
-        .unwrap_or((out.stdout.as_str(), ""));
+    // Section-count tolerant: a host still running a pre-#1621 probe shape (or a
+    // fixture written against it) simply reports no last-deploy section.
+    let mut sections = out.stdout.split(HOST_STATUS_DELIM);
+    let ready_section = sections.next().unwrap_or_default();
+    let maintenance_section = sections.next().unwrap_or_default();
+    let last_deploy_section = sections.next().unwrap_or_default();
     Ok(HostStatusProbe {
         deploy,
         // `curl` writes `000` when it never got a response; that is "nothing
@@ -2001,6 +2124,7 @@ pub fn probe_host_status(
             .ok()
             .filter(|code| *code > 0),
         maintenance_on: maintenance_section.trim() == MAINTENANCE_ON_SENTINEL,
+        last_deploy: parse_last_deploy(last_deploy_section),
     })
 }
 
@@ -5323,6 +5447,144 @@ mod tests {
              ---autumn-current-release---\n/srv/autumn/myapp/releases/{release}",
             proxy_list_serving("myapp", live_port)
         )
+    }
+
+    /// #1621 AC-6, third per-host fact. `deploy status` must report the last
+    /// deploy RESULT, and no other on-host artefact answers it — `current`,
+    /// `live-slot` and `previous-release` all describe which release a host
+    /// serves, never how it got there, so a cleanly compensated halt reads back as
+    /// a healthy converged fleet. The marker is written by the ops that COMPLETE a
+    /// cutover, so it rides on round-trips that already happen.
+    #[test]
+    fn the_cutover_and_the_rollback_record_the_last_deploy_result() {
+        let cfg = resolved();
+        let marker = "'/srv/autumn/myapp/shared/last-deploy'";
+
+        // Forward cutover: `commit-markers` (the transaction that completes the
+        // flip) records "deployed", and so does `record-proxy-options` — the last
+        // marker write on BOTH forward paths, which is how a FIRST deploy (whose
+        // ops contain no `commit-markers`) gets one too.
+        let ops = sample_cutover_ops(Secret::new("AUTUMN_SECURITY__SIGNING_SECRET=x\n"));
+        let exec = RecordingExecutor::new();
+        run_ops(&ops, &exec).expect("recording executor never fails");
+        for label in ["commit-markers", "record-proxy-options"] {
+            let shell = exec.shell_for(label).expect("op ran");
+            assert!(
+                shell.contains("mktemp '/srv/autumn/myapp/shared/last-deploy.tmp.XXXXXX'")
+                    && shell.contains(&format!("mv -f \"$rtmp\" {marker}")),
+                "{label} must write the last-deploy marker atomically: {shell}"
+            );
+            assert!(
+                shell.contains("printf '%s\\t%s' 'deployed'")
+                    && shell.contains("date -u +%Y-%m-%dT%H:%M:%SZ"),
+                "{label} must record `deployed` plus a UTC timestamp: {shell}"
+            );
+            // ADVISORY: the write is a `{ … || true; }` group, so it can never
+            // fail the op it rides on. That matters most on `commit-markers`,
+            // whose failure is the one the fleet driver refuses to auto-roll-back
+            // from — a cosmetic status field must not be able to push a host into
+            // that state.
+            assert!(
+                shell.contains("|| true; }"),
+                "the last-deploy write must be advisory, never able to fail its op: {shell}"
+            );
+        }
+
+        // A first deploy takes the same `record-proxy-options` route.
+        let first = sample_ops(Secret::new("AUTUMN_SECURITY__SIGNING_SECRET=x\n"));
+        let first_exec = RecordingExecutor::new();
+        run_ops(&first, &first_exec).expect("recording executor never fails");
+        let first_record = first_exec
+            .shell_for("record-proxy-options")
+            .expect("first deploy records proxy options");
+        assert!(
+            first_record.contains("printf '%s\\t%s' 'deployed'") && first_record.contains(marker),
+            "a first deploy must record its result too: {first_record}"
+        );
+
+        // Rollback records the OPPOSITE word through the same shared op, so a
+        // compensated host is distinguishable from one that simply deployed —
+        // exactly the state that is invisible once the rollout's output scrolls
+        // away.
+        let rb_exec = RecordingExecutor::new().with_stdout(
+            "resolve-previous",
+            "prev:/srv/autumn/myapp/releases/20260713T090000Z\tblue\t3001",
+        );
+        let target =
+            resolve_rollback_target(&cfg, 3000, &rb_exec).expect("previous release resolves");
+        let rb_ops = rollback_ops(&cfg, &proxy(), &target);
+        run_ops(&rb_ops, &rb_exec).expect("recording executor never fails");
+        let rb = rb_exec
+            .shell_for("commit-markers")
+            .expect("commit-markers ran");
+        assert!(
+            rb.contains("printf '%s\\t%s' 'rolled back'") && rb.contains(marker),
+            "a rollback must record `rolled back`, not `deployed`: {rb}"
+        );
+    }
+
+    #[test]
+    fn the_status_probe_reads_the_last_deploy_marker_and_degrades_to_unknown() {
+        // The marker rides on the EXISTING status round-trip — `deploy status` is
+        // run fleet-wide mid-incident, so a new per-host ssh would be paid N times.
+        let cfg = resolved();
+        let probe_with = |stdout: &str| {
+            let exec = RecordingExecutor::new()
+                .with_stdout(
+                    "detect-current",
+                    status_probe_stdout("20260714T120000Z", 3001),
+                )
+                .with_stdout("probe-host-status", stdout.to_owned());
+            (probe_host_status(&cfg, 3000, &exec).unwrap(), exec)
+        };
+
+        let (probe, exec) = probe_with(
+            "200\n---autumn-host-status---\n\n---autumn-host-status---\n\
+             rolled back\t2026-07-14T12:31:10Z",
+        );
+        assert_eq!(
+            probe.last_deploy,
+            Some(LastDeploy {
+                result: "rolled back".to_owned(),
+                at: Some("2026-07-14T12:31:10Z".to_owned()),
+            })
+        );
+        // Still read-only, still one round-trip, and still the shared path.
+        let shell = exec
+            .shell_for("probe-host-status")
+            .expect("status probe ran");
+        assert!(
+            shell.contains("cat '/srv/autumn/myapp/shared/last-deploy'"),
+            "the marker is read from the release-independent shared dir: {shell}"
+        );
+        assert_eq!(
+            exec.run_labels(),
+            vec!["detect-current", "probe-host-status"]
+        );
+
+        // A marker that predates the timestamp field still reports its result.
+        let (older, _) =
+            probe_with("200\n---autumn-host-status---\n\n---autumn-host-status---\ndeployed");
+        assert_eq!(
+            older.last_deploy,
+            Some(LastDeploy {
+                result: "deployed".to_owned(),
+                at: None,
+            })
+        );
+
+        // Absent/empty marker, and a host whose probe shape predates the section:
+        // both are "we could not tell", never a fabricated result.
+        for stdout in [
+            "200\n---autumn-host-status---\n\n---autumn-host-status---\n",
+            "200\n---autumn-host-status---\nmaintenance-on",
+        ] {
+            let (unknown, _) = probe_with(stdout);
+            assert_eq!(
+                unknown.last_deploy, None,
+                "an unreadable marker must not be reported as a result: {stdout:?}"
+            );
+        }
     }
 
     #[test]

--- a/autumn-cli/src/deploy/exec.rs
+++ b/autumn-cli/src/deploy/exec.rs
@@ -417,11 +417,35 @@ impl SshTarget {
 /// prevents any password prompt from hanging a deploy, and
 /// `StrictHostKeyChecking=accept-new` pins a first-seen host key without
 /// blocking on an interactive yes/no.
-const SSH_BATCH_OPTS: [&str; 4] = [
+///
+/// **The three liveness options are load-bearing for fleets (issue #1621, R2).**
+/// [`SshExecutor::run`] shells out with `Command::output()`, which has no timeout,
+/// and the deploy preflight is a bare TCP connect — it proves a host accepts a
+/// connection, not that its SSH daemon will ever answer. A host that accepts TCP
+/// and then hangs (a wedged sshd, a black-holing firewall, a box mid-freeze) would
+/// therefore block the deploy **forever**. For one server that is a stuck deploy
+/// someone Ctrl-Cs. For a fleet it is a rollout frozen mid-flight with *k* hosts
+/// already on the new release and the rest on the old one — the mixed fleet the
+/// whole rollout design exists to prevent, entered by way of a hang rather than a
+/// failure, and with no error for the driver to compensate. `ConnectTimeout` bounds
+/// the handshake; `ServerAliveInterval`/`ServerAliveCountMax` bound a session that
+/// goes silent AFTER connecting (60s of silence ends it), which is the shape a long
+/// `migrate` or binary upload actually fails in. Turning an infinite hang into a
+/// finite error is what lets the fleet driver halt and compensate.
+///
+/// `scp` forwards `-o` to its own ssh transport, so uploads — the longest single
+/// operation in a deploy — get the same bounds.
+const SSH_BATCH_OPTS: [&str; 10] = [
     "-o",
     "BatchMode=yes",
     "-o",
     "StrictHostKeyChecking=accept-new",
+    "-o",
+    "ConnectTimeout=10",
+    "-o",
+    "ServerAliveInterval=15",
+    "-o",
+    "ServerAliveCountMax=4",
 ];
 
 /// Build the argv passed to the system `ssh` binary to run `remote_shell` on the
@@ -5358,6 +5382,14 @@ mod tests {
 
     #[test]
     fn ssh_and_scp_argv_are_built_correctly() {
+        // #1621 (R2, T1.23) DELIBERATELY updated this vector: the three liveness
+        // options below are new, and they apply to single-host and fleet deploys
+        // alike. `SshExecutor::run` uses `Command::output()` with no timeout and the
+        // preflight is a bare TCP connect, so before this a host that accepted TCP
+        // and then hung the SSH handshake blocked the deploy FOREVER — which at
+        // fleet scale means a permanently half-flipped fleet with no timeout to
+        // recover from. Assert the exact argv (never `contains`), so any future
+        // change to the option set is a conscious one.
         let target = SshTarget {
             host: "203.0.113.10".to_owned(),
             user: "deploy".to_owned(),
@@ -5374,6 +5406,12 @@ mod tests {
                 "BatchMode=yes".to_owned(),
                 "-o".to_owned(),
                 "StrictHostKeyChecking=accept-new".to_owned(),
+                "-o".to_owned(),
+                "ConnectTimeout=10".to_owned(),
+                "-o".to_owned(),
+                "ServerAliveInterval=15".to_owned(),
+                "-o".to_owned(),
+                "ServerAliveCountMax=4".to_owned(),
                 "deploy@203.0.113.10".to_owned(),
                 "systemctl daemon-reload".to_owned(),
             ]
@@ -5394,6 +5432,14 @@ mod tests {
                 "BatchMode=yes".to_owned(),
                 "-o".to_owned(),
                 "StrictHostKeyChecking=accept-new".to_owned(),
+                // scp forwards -o to its ssh transport, so an upload — the longest
+                // single operation in a deploy — gets the same liveness guarantees.
+                "-o".to_owned(),
+                "ConnectTimeout=10".to_owned(),
+                "-o".to_owned(),
+                "ServerAliveInterval=15".to_owned(),
+                "-o".to_owned(),
+                "ServerAliveCountMax=4".to_owned(),
                 "/local/target/release/myapp".to_owned(),
                 "deploy@203.0.113.10:/srv/autumn/myapp/releases/r1/myapp".to_owned(),
             ]

--- a/autumn-cli/src/deploy/exec.rs
+++ b/autumn-cli/src/deploy/exec.rs
@@ -1824,16 +1824,56 @@ pub fn probe_release_dir(
     exec: &impl DeployExecutor,
 ) -> Result<ReleaseDirState, DeployExecError> {
     let release_dir = format!("{}/{release_id}", cfg.releases_dir());
+    probe_dir_state("probe-release-dir", &release_dir, exec)
+}
+
+/// Read-only probe: does the release dir a fleet compensation is about to roll a
+/// host back TO still exist? (issue #1621, §4.7.)
+///
+/// The same `[ -d … ]` shell as [`probe_release_dir`] under a DISTINCT label, so a
+/// tape can tell the two apart and the strict test fake can require it to be
+/// scripted. It is a separate call rather than a flag because it asks the opposite
+/// question about the opposite directory: the deploy refuses when this run's
+/// candidate dir is PRESENT, while compensation refuses when the rollback target is
+/// ABSENT.
+///
+/// It exists because `prune` runs per host and hosts with divergent deploy history
+/// legitimately retain different sets: `resolve_rollback_target` can name a dir a
+/// later prune already removed. Rolling back to it anyway would write a slot unit
+/// whose `ExecStart` points nowhere, start it successfully as far as systemd is
+/// concerned, and then fail the readiness gate — POST-boundary, with no teardown,
+/// turning a one-host incident into a two-host one. Missing → the caller declines
+/// the automatic rollback and reports the host.
+///
+/// # Errors
+///
+/// Returns the executor's error if the probe command cannot run.
+pub fn probe_rollback_target_dir(
+    release_dir: &str,
+    exec: &impl DeployExecutor,
+) -> Result<ReleaseDirState, DeployExecError> {
+    probe_dir_state("probe-rollback-target", release_dir, exec)
+}
+
+/// The shared read-only `[ -d … ]` directory probe behind [`probe_release_dir`] and
+/// [`probe_rollback_target_dir`]: two printf sentinels, nothing else, and any other
+/// capture fails closed to [`ReleaseDirState::Unreadable`] (an empty capture is the
+/// exact trap every other probe in this file degrades on).
+fn probe_dir_state(
+    label: &'static str,
+    dir: &str,
+    exec: &impl DeployExecutor,
+) -> Result<ReleaseDirState, DeployExecError> {
     let shell = format!(
         "if [ -d {dir} ]; then printf '%s' '{RELEASE_DIR_PRESENT}'; \
          else printf '%s' '{RELEASE_DIR_ABSENT}'; fi",
-        dir = shell_quote(&release_dir),
+        dir = shell_quote(dir),
     );
-    let out = exec.run(&RemoteCommand::new("probe-release-dir", shell))?;
+    let out = exec.run(&RemoteCommand::new(label, shell))?;
     Ok(match out.stdout.trim() {
         RELEASE_DIR_PRESENT => ReleaseDirState::Present,
         RELEASE_DIR_ABSENT => ReleaseDirState::Absent,
-        // Fail closed: an unexpected capture cannot prove the dir is free.
+        // Fail closed: an unexpected capture cannot prove the dir's state.
         _ => ReleaseDirState::Unreadable,
     })
 }
@@ -2265,14 +2305,15 @@ fn execute_with_teardown(
 ///
 /// The deploy/rollback entrypoints drive their sequences through
 /// [`execute_with_teardown`] (which adds boundary-aware teardown on failure); this
-/// plain driver is the un-gated form used by the pure-sequence tests, so it is
-/// allowed to be unused in the non-test binary build.
+/// plain driver is the un-gated form, used by the pure-sequence tests and by the
+/// fleet compensation path (issue #1621, §4.7), which tears a completed first
+/// deploy down and must **report** a failed step rather than swallow it the way
+/// [`run_teardown`] deliberately does.
 ///
 /// # Errors
 ///
 /// Returns the first [`DeployExecError`] produced by the executor (or by staging
 /// a local temp file for a [`DeployOp::WriteFile`]).
-#[cfg_attr(not(test), allow(dead_code))]
 pub fn run_ops(ops: &[DeployOp], exec: &impl DeployExecutor) -> Result<(), DeployExecError> {
     for op in ops {
         run_one(op, exec)?;
@@ -2458,10 +2499,11 @@ pub(crate) mod test_support {
     /// [`super::DeployMode::First`] / `Absent`. A fleet test that forgets to script
     /// host N's probe would therefore exercise the first-deploy branch and still
     /// pass. [`RecordingExecutor::strict`] turns that into a loud panic.
-    pub(crate) const PROBE_LABELS: [&str; 4] = [
+    pub(crate) const PROBE_LABELS: [&str; 5] = [
         "proxy-compat-probe",
         "detect-current",
         "probe-release-dir",
+        "probe-rollback-target",
         "resolve-previous",
     ];
 
@@ -2504,6 +2546,13 @@ pub(crate) mod test_support {
         /// Labels whose `run` should return a scripted failure (e.g. to simulate
         /// a readiness-gate timeout).
         fail_labels: Vec<&'static str>,
+        /// #1621: labels whose `run` should fail as a TRANSPORT error — ssh itself
+        /// could not be launched — rather than as a remote non-zero exit. The
+        /// distinction matters to the fleet: [`super::DeployExecError::Spawn`]
+        /// carries no op label, so it classifies as a FUNCTIONAL post-boundary
+        /// failure (fail closed) where a `CommandFailed` on the same step might be
+        /// mere housekeeping.
+        transport_fail_labels: Vec<&'static str>,
         /// Scripted stdout returned for a given command label.
         stdout_by_label: Vec<(&'static str, String)>,
         /// #1621: the host this executor targets, recorded onto the shared fleet
@@ -2537,6 +2586,19 @@ pub(crate) mod test_support {
         /// than one label (a fleet script needs per-host failure injection).
         pub(crate) fn failing(mut self, label: &'static str) -> Self {
             self.fail_labels.push(label);
+            self
+        }
+
+        /// Make one host's `label` fail as a TRANSPORT error (the ssh process could
+        /// not be launched) instead of a remote non-zero exit (#1621).
+        ///
+        /// This is the only realistic way to produce a FUNCTIONAL post-boundary
+        /// failure against today's op set: every op after `proxy-flip` is either
+        /// housekeeping or `commit-markers`, so the "the host is live on the new
+        /// release and something that matters broke" case arrives as a dropped
+        /// transport rather than a labelled remote failure.
+        pub(crate) fn transport_failing(mut self, label: &'static str) -> Self {
+            self.transport_fail_labels.push(label);
             self
         }
 
@@ -2604,6 +2666,12 @@ pub(crate) mod test_support {
                 label: cmd.label,
                 shell: cmd.shell.clone(),
             });
+            if self.transport_fail_labels.contains(&cmd.label) {
+                return Err(DeployExecError::Spawn {
+                    program: "ssh".to_owned(),
+                    source: std::io::Error::other("scripted transport failure"),
+                });
+            }
             if self.fail_labels.contains(&cmd.label) {
                 return Err(DeployExecError::CommandFailed {
                     label: cmd.label,
@@ -4542,6 +4610,56 @@ mod tests {
             probe_release_dir(&cfg, RELEASE_ID, &empty).unwrap(),
             ReleaseDirState::Unreadable,
             "empty output must fail closed (the trap every other probe degrades on)"
+        );
+    }
+
+    #[test]
+    fn probe_rollback_target_dir_is_read_only_and_distinctly_labelled() {
+        // #1621 (§4.7): before a fleet compensation flips a host back, it proves the
+        // release dir it is about to point at still exists — `prune` runs per host,
+        // so the previous-release marker can legitimately name a dir this host no
+        // longer has. Rolling back to a removed dir writes a unit whose ExecStart
+        // points nowhere, starts "successfully", and then fails the readiness gate
+        // POST-boundary with no teardown: a second broken host.
+        let previous = "/srv/autumn/myapp/releases/20260101T000000Z";
+
+        let present = RecordingExecutor::new().with_stdout("probe-rollback-target", "present");
+        assert_eq!(
+            probe_rollback_target_dir(previous, &present).unwrap(),
+            ReleaseDirState::Present,
+            "a retained rollback target is the normal case"
+        );
+        assert_eq!(
+            present
+                .shell_for("probe-rollback-target")
+                .expect("probe ran"),
+            format!(
+                "if [ -d '{previous}' ]; then printf '%s' 'present'; \
+                 else printf '%s' 'absent'; fi"
+            ),
+            "the target probe must be the same read-only directory test",
+        );
+        assert_eq!(
+            present.run_labels(),
+            vec!["probe-rollback-target"],
+            "the probe runs exactly one command, under its OWN label so a tape can \
+             tell it apart from the candidate-dir collision probe, and mutates nothing"
+        );
+
+        let absent = RecordingExecutor::new().with_stdout("probe-rollback-target", "absent\n");
+        assert_eq!(
+            probe_rollback_target_dir(previous, &absent).unwrap(),
+            ReleaseDirState::Absent,
+            "a pruned rollback target must be reported so the caller declines"
+        );
+        // Fail closed in the SAME direction as every other probe: proving nothing is
+        // not proving it is there.
+        let garbled =
+            RecordingExecutor::new().with_stdout("probe-rollback-target", "bash: -c: line 0");
+        assert_eq!(
+            probe_rollback_target_dir(previous, &garbled).unwrap(),
+            ReleaseDirState::Unreadable,
+            "an unexpected capture must fail closed, never degrade to Present"
         );
     }
 

--- a/autumn-cli/src/deploy/exec.rs
+++ b/autumn-cli/src/deploy/exec.rs
@@ -603,6 +603,13 @@ pub const LAST_DEPLOY_DEPLOYED: &str = "deployed";
 /// halted rollout (AC-3). See [`last_deploy_marker`].
 pub const LAST_DEPLOY_ROLLED_BACK: &str = "rolled back";
 
+/// Marker word for a host whose install was REMOVED again: a first deploy that was
+/// torn down, either by its own pre-boundary failure or by the fleet driver
+/// compensating a halted rollout (`CompensatedTeardown`). See
+/// [`first_deploy_teardown_ops`] for why a teardown REWRITES this marker instead of
+/// deleting it. See [`last_deploy_marker`].
+pub const LAST_DEPLOY_TORN_DOWN: &str = "torn down";
+
 /// Shell fragment that records `result` into the [`last_deploy_marker`], written
 /// atomically (mktemp + `mv -f`) like every other marker.
 ///
@@ -1095,6 +1102,12 @@ pub fn cutover_ops(
 /// driven through [`run_teardown`], which swallows executor errors — so a flaky
 /// cleanup can never mask the real deploy failure. Removing the release dir means
 /// a re-run uploads a fresh copy rather than reusing a half-written one.
+///
+/// It deliberately does NOT touch the [`last_deploy_marker`], unlike
+/// [`first_deploy_teardown_ops`]. A torn-down CANDIDATE leaves the PREVIOUS release
+/// serving and never moved traffic, so the marker's existing record still describes
+/// the release that is actually live; rewriting it would report a change that never
+/// happened and erase the true one.
 #[must_use]
 pub fn candidate_teardown_ops(
     cfg: &ResolvedDeployConfig,
@@ -1129,6 +1142,27 @@ pub fn candidate_teardown_ops(
 /// fails on a missing path) and driven through [`run_teardown`], which swallows
 /// executor errors so a flaky cleanup can never mask the real deploy failure.
 ///
+/// **It also records `torn down` in the [`last_deploy_marker`]** (issue #1621,
+/// AC-6). A first deploy writes `deployed` into that marker as part of
+/// [`record_proxy_options`], so a host the fleet driver compensates with this
+/// teardown — `HostOutcome::CompensatedTeardown`, i.e. nothing installed — would
+/// otherwise keep reporting `last deploy: deployed <ts>` in `deploy status` with no
+/// release on it at all. That is a wrong value in the column an operator reads
+/// first while triaging a halted rollout.
+///
+/// The marker is REWRITTEN rather than deleted, deliberately. An absent marker
+/// renders `last deploy: ?`, which is also what a host that was never deployed (or
+/// whose marker write failed) shows — so clearing it would erase precisely the fact
+/// triage needs: this host WAS taken back down, on purpose, at this time. The
+/// alternative loses information; this one adds it, and `mode: not deployed` plus
+/// the `DRIFT_HOST_NOT_DEPLOYED` reason already sit beside it in the same row.
+///
+/// Two safety properties, both load-bearing: the record is the LAST op, so an
+/// earlier failure stops [`run_ops`] before the marker is rewritten and the host
+/// keeps its previous — still true — record; and the write is the same advisory
+/// `{ … || true; }` fragment the cutover uses, so it can never turn a clean
+/// compensation into `HostOutcome::CompensationFailed`.
+///
 /// This must NOT be used for a redeploy: the redeploy teardown deliberately
 /// leaves the old release's `current`/live-slot markers intact because that old
 /// release is still serving.
@@ -1150,6 +1184,14 @@ pub fn first_deploy_teardown_ops(
             shell_quote(&live_slot_marker(cfg)),
             shell_quote(&previous_release_marker(cfg)),
         ),
+    )));
+    // AC-6: correct the last-deploy marker the first deploy already wrote, so a
+    // host with nothing installed can never report a successful deploy. LAST, and
+    // advisory — see this function's doc comment for why both matter and why the
+    // marker is rewritten rather than removed.
+    ops.push(DeployOp::Run(RemoteCommand::new(
+        "teardown-last-deploy",
+        record_last_deploy_fragment(cfg, LAST_DEPLOY_TORN_DOWN),
     )));
     ops
 }
@@ -4565,7 +4607,10 @@ mod tests {
         let plan = SlotPlan::first(3000);
         let teardown = first_deploy_teardown_ops(&cfg, RELEASE_ID, &plan);
         let labels: Vec<&str> = teardown.iter().map(DeployOp::label).collect();
-        // It is a superset of the candidate teardown, PLUS the marker cleanup.
+        // It is a superset of the candidate teardown, PLUS the marker cleanup, PLUS
+        // the `torn down` last-deploy record (#1621 audit gap G3) — see
+        // `first_deploy_teardown_records_the_torn_down_result` for why the marker is
+        // rewritten rather than removed.
         assert_eq!(
             labels,
             vec![
@@ -4573,6 +4618,7 @@ mod tests {
                 "teardown-candidate-dir",
                 "teardown-current-symlink",
                 "teardown-slot-markers",
+                "teardown-last-deploy",
             ],
             "first-deploy teardown must also clean current + markers: {labels:?}"
         );
@@ -4598,6 +4644,60 @@ mod tests {
     }
 
     #[test]
+    fn first_deploy_teardown_records_the_torn_down_result() {
+        // #1621 (AC-6, audit gap G3). A first-deploy teardown returns the host to
+        // NOTHING INSTALLED — that is what `CompensatedTeardown` means. Leaving
+        // `shared/last-deploy` untouched made `deploy status` report
+        // `last deploy: deployed <ts>` for a host carrying no release at all: a
+        // wrong value in the column an operator reads FIRST when inspecting a
+        // halted rollout.
+        //
+        // The teardown RECORDS `torn down` rather than deleting the marker. An
+        // absent marker renders `last deploy: ?`, which is also what a host that
+        // was never deployed shows, so clearing it would erase exactly the fact
+        // triage needs: this host WAS taken back down, on purpose, at this time.
+        let cfg = resolved();
+        let plan = SlotPlan::first(3000);
+        let teardown = first_deploy_teardown_ops(&cfg, RELEASE_ID, &plan);
+        let exec = RecordingExecutor::new();
+        run_teardown(&teardown, &exec);
+
+        let shell = exec
+            .shell_for("teardown-last-deploy")
+            .expect("teardown-last-deploy ran");
+        assert!(
+            shell.contains("printf '%s\\t%s' 'torn down'")
+                && shell.contains("date -u +%Y-%m-%dT%H:%M:%SZ"),
+            "the teardown must record `torn down` plus a UTC timestamp: {shell}"
+        );
+        assert!(
+            shell.contains("mv -f \"$rtmp\" '/srv/autumn/myapp/shared/last-deploy'"),
+            "it must land on the same marker `deploy status` reads: {shell}"
+        );
+        assert!(
+            !shell.contains("'deployed'"),
+            "a torn-down host must never claim a successful deploy: {shell}"
+        );
+        // ADVISORY, like the cutover's own fragment: `compensate_teardown` drives
+        // these ops through `run_ops`, so a marker write that could fail would turn
+        // a clean compensation into `CompensationFailed`.
+        assert!(
+            shell.contains("|| true; }"),
+            "the teardown's last-deploy write must never be able to fail the op: {shell}"
+        );
+
+        // It runs LAST, so it only claims a teardown that actually completed: if an
+        // earlier op fails, `run_ops` stops before the marker is rewritten and the
+        // host keeps its previous — still true — record.
+        let labels: Vec<&str> = teardown.iter().map(DeployOp::label).collect();
+        assert_eq!(
+            labels.last().copied(),
+            Some("teardown-last-deploy"),
+            "the last-deploy record must be the final teardown op: {labels:?}"
+        );
+    }
+
+    #[test]
     fn redeploy_teardown_leaves_current_and_markers_intact() {
         // The REDEPLOY teardown must NOT remove the old release's current/live-slot
         // markers — the old release is still serving after a candidate rollback.
@@ -4615,6 +4715,14 @@ mod tests {
         assert!(
             !labels.contains(&"teardown-slot-markers"),
             "redeploy teardown must not remove the live-slot marker: {labels:?}"
+        );
+        // …and it must not touch the last-deploy marker either (#1621 audit gap G3):
+        // a torn-down CANDIDATE leaves the PREVIOUS release serving, so the marker's
+        // existing record still describes the release that is actually live.
+        assert!(
+            !labels.contains(&"teardown-last-deploy"),
+            "redeploy teardown must not rewrite the last-deploy marker — the previous \
+             release is still serving: {labels:?}"
         );
     }
 

--- a/autumn-cli/src/deploy/exec.rs
+++ b/autumn-cli/src/deploy/exec.rs
@@ -1779,6 +1779,65 @@ pub fn probe_deploy_state(
     })
 }
 
+/// Sentinel [`probe_release_dir`] prints when `{releases_dir}/{release_id}` already
+/// exists on the host.
+const RELEASE_DIR_PRESENT: &str = "present";
+
+/// Sentinel [`probe_release_dir`] prints when the release dir is free.
+const RELEASE_DIR_ABSENT: &str = "absent";
+
+/// Whether this run's release dir already exists on a host (issue #1621, §4.9).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReleaseDirState {
+    /// The release dir is free — the normal case.
+    Absent,
+    /// The release dir already exists: a previous run of THIS release id already
+    /// wrote into it. Refused (see [`probe_release_dir`]).
+    Present,
+    /// The probe printed neither sentinel, so the dir's state cannot be proved.
+    /// **Fails closed** — the collision below is destructive and silent.
+    Unreadable,
+}
+
+/// Read-only probe: does `{releases_dir}/{release_id}` already exist on this host?
+/// (issue #1621, §4.9.)
+///
+/// `release_id` is a UTC timestamp with **one-second granularity**
+/// (`default_release_id`), and exactly ONE id is minted per fleet run. A fast
+/// retry within the same second therefore re-uses the id and would upload a NEW
+/// binary into the release dir `shared/previous-release` still points at — so the
+/// host's "previous release" would hold the new binary and a rollback would roll
+/// *forward*, silently. There is no marker that can detect this after the fact,
+/// so the deploy refuses up front, before anything is written.
+///
+/// It is deliberately its OWN round-trip rather than a fifth section on
+/// [`probe_deploy_state`]: that probe's shell is pinned by exact-content tests and
+/// its sections are all about the *live* release, while this one is about the
+/// *candidate* dir and must fail closed rather than degrade to `Absent`.
+///
+/// # Errors
+///
+/// Returns the executor's error if the probe command cannot run.
+pub fn probe_release_dir(
+    cfg: &ResolvedDeployConfig,
+    release_id: &str,
+    exec: &impl DeployExecutor,
+) -> Result<ReleaseDirState, DeployExecError> {
+    let release_dir = format!("{}/{release_id}", cfg.releases_dir());
+    let shell = format!(
+        "if [ -d {dir} ]; then printf '%s' '{RELEASE_DIR_PRESENT}'; \
+         else printf '%s' '{RELEASE_DIR_ABSENT}'; fi",
+        dir = shell_quote(&release_dir),
+    );
+    let out = exec.run(&RemoteCommand::new("probe-release-dir", shell))?;
+    Ok(match out.stdout.trim() {
+        RELEASE_DIR_PRESENT => ReleaseDirState::Present,
+        RELEASE_DIR_ABSENT => ReleaseDirState::Absent,
+        // Fail closed: an unexpected capture cannot prove the dir is free.
+        _ => ReleaseDirState::Unreadable,
+    })
+}
+
 /// Fail closed on reverse-proxy CLI-surface drift BEFORE any cutover (issue #2053).
 ///
 /// The proxy controller ([`KamalProxyController`](super::proxy::KamalProxyController))
@@ -2371,83 +2430,177 @@ impl DeployExecutor for SshExecutor {
     }
 }
 
+/// The recording executor fake, shared across the deploy module's test suites.
+///
+/// Lives outside `mod tests` (and is `pub(crate)`) so the fleet rollout driver's
+/// tests can drive N of these — one per host — against the SAME fake as the
+/// single-host op-sequence tests, instead of growing a third near-duplicate copy
+/// (issue #1621, plan §9.2). `#[cfg(test)]`, so nothing here reaches a release
+/// build.
 #[cfg(test)]
-mod tests {
-    use super::*;
+// In this bin-only crate `deploy` is a private module, so clippy flags every
+// `pub(crate)` here as redundant; they are kept to document the intended
+// visibility (crate-internal test support) rather than widening to `pub`.
+#[allow(clippy::redundant_pub_crate)]
+pub(crate) mod test_support {
+    use super::{CommandOutput, DeployExecError, DeployExecutor, Path, RemoteCommand};
     use std::cell::RefCell;
+    use std::rc::Rc;
+
+    /// The fleet-wide `(host, call)` tape shared by every host's executor in one
+    /// rollout — the structure cross-host ordering assertions read.
+    pub(crate) type FleetTape = Rc<RefCell<Vec<(String, RecordedCall)>>>;
+
+    /// Command labels whose **stdout is parsed** by the caller, i.e. the read-only
+    /// probes. An unscripted probe is the single most dangerous silent hole in this
+    /// fake: `run` returns `Ok` with EMPTY stdout for anything unscripted, and
+    /// [`super::probe_deploy_state`] reads an empty section as
+    /// [`super::DeployMode::First`] / `Absent`. A fleet test that forgets to script
+    /// host N's probe would therefore exercise the first-deploy branch and still
+    /// pass. [`RecordingExecutor::strict`] turns that into a loud panic.
+    pub(crate) const PROBE_LABELS: [&str; 4] = [
+        "proxy-compat-probe",
+        "detect-current",
+        "probe-release-dir",
+        "resolve-previous",
+    ];
+
+    /// One recorded executor call. Uploads carry no local path: op building is
+    /// pure, so the local path is an input the assertions never need.
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    pub(crate) enum RecordedCall {
+        /// A `run` call.
+        Run {
+            /// The op's stable `&'static str` label.
+            label: &'static str,
+            /// The rendered remote shell line.
+            shell: String,
+        },
+        /// An `upload` call (a `UploadFile` or a staged `WriteFile`).
+        Upload {
+            /// Remote destination path.
+            remote_path: String,
+            /// Requested mode, when the op set one.
+            mode: Option<u32>,
+        },
+    }
+
+    impl RecordedCall {
+        /// The label of a `Run` call, or `None` for an upload.
+        pub(crate) const fn run_label(&self) -> Option<&'static str> {
+            match self {
+                Self::Run { label, .. } => Some(*label),
+                Self::Upload { .. } => None,
+            }
+        }
+    }
 
     /// A recording fake executor: it records every `run`/`upload` call in order
     /// and returns scripted outputs, so tests assert the exact remote-command
     /// sequence (and env-file mode) without a live host.
     #[derive(Default)]
-    struct RecordingExecutor {
+    pub(crate) struct RecordingExecutor {
         calls: RefCell<Vec<RecordedCall>>,
         /// Labels whose `run` should return a scripted failure (e.g. to simulate
         /// a readiness-gate timeout).
         fail_labels: Vec<&'static str>,
         /// Scripted stdout returned for a given command label.
         stdout_by_label: Vec<(&'static str, String)>,
-    }
-
-    #[derive(Debug, Clone, PartialEq, Eq)]
-    enum RecordedCall {
-        Run {
-            label: &'static str,
-            shell: String,
-        },
-        Upload {
-            remote_path: String,
-            mode: Option<u32>,
-        },
+        /// #1621: the host this executor targets, recorded onto the shared fleet
+        /// tape. Empty for the single-host fakes, which never set a tape.
+        host: String,
+        /// #1621: a tape shared by every host's executor in one fleet run, so
+        /// CROSS-host interleaving ("host B's first mutating op came after host A's
+        /// `proxy-flip`") is assertable — something a per-host call list cannot
+        /// express.
+        tape: Option<FleetTape>,
+        /// #1621: panic on an unscripted [`PROBE_LABELS`] entry instead of
+        /// silently returning empty stdout.
+        strict: bool,
     }
 
     impl RecordingExecutor {
-        fn new() -> Self {
+        /// A fake that scripts nothing and fails nothing.
+        pub(crate) fn new() -> Self {
             Self::default()
         }
 
-        fn failing_on(label: &'static str) -> Self {
+        /// A fake whose `run` fails for `label`.
+        pub(crate) fn failing_on(label: &'static str) -> Self {
             Self {
                 fail_labels: vec![label],
                 ..Self::default()
             }
         }
 
+        /// Chainable sibling of [`Self::failing_on`], so one fake can fail on more
+        /// than one label (a fleet script needs per-host failure injection).
+        pub(crate) fn failing(mut self, label: &'static str) -> Self {
+            self.fail_labels.push(label);
+            self
+        }
+
         /// Script the stdout returned for a given command label (used to drive
-        /// [`probe_deploy_state`]'s first-vs-redeploy probe).
-        fn with_stdout(mut self, label: &'static str, stdout: impl Into<String>) -> Self {
+        /// [`super::probe_deploy_state`]'s first-vs-redeploy probe).
+        pub(crate) fn with_stdout(
+            mut self,
+            label: &'static str,
+            stdout: impl Into<String>,
+        ) -> Self {
             self.stdout_by_label.push((label, stdout.into()));
             self
         }
 
-        fn calls(&self) -> Vec<RecordedCall> {
+        /// Fail LOUDLY (panic) on an unscripted read-only probe label instead of
+        /// returning empty stdout, which every probe parser degrades to
+        /// "absent / first deploy" (issue #1621, plan §9.2).
+        pub(crate) fn strict(mut self) -> Self {
+            self.strict = true;
+            self
+        }
+
+        /// Record this executor's calls onto a fleet-wide `tape` under `host`, in
+        /// addition to its own per-host list.
+        pub(crate) fn recording_as(mut self, host: impl Into<String>, tape: FleetTape) -> Self {
+            self.host = host.into();
+            self.tape = Some(tape);
+            self
+        }
+
+        /// Every recorded call, in order.
+        pub(crate) fn calls(&self) -> Vec<RecordedCall> {
             self.calls.borrow().clone()
         }
 
         /// Labels of the recorded `Run` calls, in order (upload calls excluded).
-        fn run_labels(&self) -> Vec<&'static str> {
+        pub(crate) fn run_labels(&self) -> Vec<&'static str> {
             self.calls
                 .borrow()
                 .iter()
-                .filter_map(|c| match c {
-                    RecordedCall::Run { label, .. } => Some(*label),
-                    RecordedCall::Upload { .. } => None,
-                })
+                .filter_map(RecordedCall::run_label)
                 .collect()
         }
 
         /// The shell recorded for the first `Run` with `label`, if any.
-        fn shell_for(&self, label: &str) -> Option<String> {
+        pub(crate) fn shell_for(&self, label: &str) -> Option<String> {
             self.calls.borrow().iter().find_map(|c| match c {
                 RecordedCall::Run { label: l, shell } if *l == label => Some(shell.clone()),
                 _ => None,
             })
         }
+
+        /// Push one call onto the per-host list and, when set, the fleet tape.
+        fn record(&self, call: RecordedCall) {
+            if let Some(tape) = &self.tape {
+                tape.borrow_mut().push((self.host.clone(), call.clone()));
+            }
+            self.calls.borrow_mut().push(call);
+        }
     }
 
     impl DeployExecutor for RecordingExecutor {
         fn run(&self, cmd: &RemoteCommand) -> Result<CommandOutput, DeployExecError> {
-            self.calls.borrow_mut().push(RecordedCall::Run {
+            self.record(RecordedCall::Run {
                 label: cmd.label,
                 shell: cmd.shell.clone(),
             });
@@ -2457,14 +2610,26 @@ mod tests {
                     message: "scripted failure".to_owned(),
                 });
             }
-            let stdout = self
+            let scripted = self
                 .stdout_by_label
                 .iter()
                 .find(|(l, _)| *l == cmd.label)
-                .map(|(_, out)| out.clone())
-                .unwrap_or_default();
+                .map(|(_, out)| out.clone());
+            assert!(
+                !(self.strict && scripted.is_none() && PROBE_LABELS.contains(&cmd.label)),
+                "unscripted probe `{}`{}: this fake would return EMPTY stdout, which every \
+                 probe parser degrades to \"absent / first deploy\" — script it with \
+                 `.with_stdout(\"{}\", …)` (issue #1621)",
+                cmd.label,
+                if self.host.is_empty() {
+                    String::new()
+                } else {
+                    format!(" on host {}", self.host)
+                },
+                cmd.label,
+            );
             Ok(CommandOutput {
-                stdout,
+                stdout: scripted.unwrap_or_default(),
                 stderr: String::new(),
             })
         }
@@ -2475,13 +2640,19 @@ mod tests {
             remote_path: &str,
             mode: Option<u32>,
         ) -> Result<(), DeployExecError> {
-            self.calls.borrow_mut().push(RecordedCall::Upload {
+            self.record(RecordedCall::Upload {
                 remote_path: remote_path.to_owned(),
                 mode,
             });
             Ok(())
         }
     }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::test_support::{RecordedCall, RecordingExecutor};
+    use super::*;
 
     fn resolved() -> ResolvedDeployConfig {
         ResolvedDeployConfig::resolve(
@@ -4315,6 +4486,98 @@ mod tests {
                 .installed_proxy_port,
             InstalledProxyPort::Unreadable,
             "a present unit with no readable --http-port fails closed as Unreadable"
+        );
+    }
+
+    #[test]
+    fn probe_release_dir_is_read_only_and_fails_closed() {
+        // #1621 (§4.9): the release id has one-second granularity and exactly one
+        // is minted per run, so a fast retry re-uses it. Uploading into a release
+        // dir `shared/previous-release` still points at would put the NEW binary
+        // behind the "previous release" and make a rollback roll FORWARD — silently
+        // and undetectably. So the deploy probes for the collision up front.
+        let cfg = resolved();
+
+        let absent = RecordingExecutor::new().with_stdout("probe-release-dir", "absent");
+        assert_eq!(
+            probe_release_dir(&cfg, RELEASE_ID, &absent).unwrap(),
+            ReleaseDirState::Absent,
+            "a free release dir is the normal case"
+        );
+
+        // The probe is READ-ONLY: a `[ -d … ]` test and two printfs, nothing else,
+        // aimed at this run's release dir.
+        let shell = absent.shell_for("probe-release-dir").expect("probe ran");
+        assert_eq!(
+            shell,
+            format!(
+                "if [ -d '{RELEASE_DIR}' ]; then printf '%s' 'present'; \
+                     else printf '%s' 'absent'; fi"
+            ),
+            "the collision probe must be a read-only directory test",
+        );
+        assert_eq!(
+            absent.run_labels(),
+            vec!["probe-release-dir"],
+            "the probe runs exactly one command and mutates nothing"
+        );
+
+        let present = RecordingExecutor::new().with_stdout("probe-release-dir", "present\n");
+        assert_eq!(
+            probe_release_dir(&cfg, RELEASE_ID, &present).unwrap(),
+            ReleaseDirState::Present,
+            "an existing release dir is reported"
+        );
+
+        // Neither sentinel → we cannot PROVE the dir is free, and the failure mode
+        // is destructive, so fail closed rather than degrade to Absent.
+        let garbled = RecordingExecutor::new().with_stdout("probe-release-dir", "bash: -c: line 0");
+        assert_eq!(
+            probe_release_dir(&cfg, RELEASE_ID, &garbled).unwrap(),
+            ReleaseDirState::Unreadable,
+            "an unexpected capture must fail closed, never degrade to Absent"
+        );
+        let empty = RecordingExecutor::new();
+        assert_eq!(
+            probe_release_dir(&cfg, RELEASE_ID, &empty).unwrap(),
+            ReleaseDirState::Unreadable,
+            "empty output must fail closed (the trap every other probe degrades on)"
+        );
+    }
+
+    #[test]
+    fn strict_recording_executor_refuses_to_fake_an_unscripted_probe() {
+        // #1621 (plan §9.2): the fake returns Ok+EMPTY stdout for anything
+        // unscripted, and every probe parser reads empty as "absent / first
+        // deploy". A fleet test that forgot to script host N's probe would
+        // therefore exercise the first-deploy branch and PASS. Strict mode turns
+        // that silent hole into a panic.
+        let cfg = resolved();
+        let strict = RecordingExecutor::new().strict();
+        let panicked = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let _ = probe_deploy_state(&cfg, &strict);
+        }));
+        assert!(
+            panicked.is_err(),
+            "an unscripted probe must fail loudly under strict mode"
+        );
+
+        // A scripted probe is unaffected, and non-probe labels never need scripting.
+        let scripted = RecordingExecutor::new()
+            .strict()
+            .with_stdout("detect-current", "first\n");
+        assert_eq!(
+            probe_deploy_state(&cfg, &scripted).unwrap().mode,
+            DeployMode::First,
+            "strict mode changes nothing for a scripted probe"
+        );
+        assert!(
+            run_ops(
+                &[DeployOp::Run(RemoteCommand::new("prune", "true"))],
+                &RecordingExecutor::new().strict()
+            )
+            .is_ok(),
+            "strict mode only guards labels whose stdout is parsed"
         );
     }
 

--- a/autumn-cli/src/deploy/exec.rs
+++ b/autumn-cli/src/deploy/exec.rs
@@ -358,6 +358,29 @@ pub enum DeployExecError {
         #[source]
         source: Box<Self>,
     },
+    /// A step failed strictly AFTER the go-live boundary: traffic had already
+    /// moved, so nothing was torn down and the candidate is live. The wrapper
+    /// exists for ONE reason — to name the op that was actually running (issue
+    /// #1621, §4.6).
+    ///
+    /// Several executor errors carry no label of their own ([`Self::Spawn`],
+    /// [`Self::UploadFailed`], [`Self::Stage`]), and post-boundary the fleet's
+    /// never-auto-roll-back guard is keyed on the op label: a dropped transport
+    /// during `commit-markers` must fail closed exactly like a non-zero exit from
+    /// it, because either way the marker triple may be mid-transaction and the
+    /// rollback target unprovable.
+    ///
+    /// `Display` delegates to the wrapped error verbatim, so every operator-facing
+    /// message — the single-host path's included — is byte-for-byte what it was
+    /// before this wrapper existed. Only the fleet classifier looks inside.
+    #[error("{source}")]
+    PostCutover {
+        /// Label of the op that was running when the failure landed.
+        failed_step: &'static str,
+        /// The underlying failure (its `Display` is already redacted).
+        #[source]
+        source: Box<Self>,
+    },
 }
 
 /// Executes remote operations for a deploy. Injectable so tests can substitute a
@@ -2467,14 +2490,26 @@ fn execute_with_teardown(
     let boundary = ops.iter().position(|op| op.label() == boundary_label);
     for (index, op) in ops.iter().enumerate() {
         if let Err(source) = run_one(op, exec) {
-            // Fail safe: if the boundary op was never found (`None`), we do NOT
-            // know whether the candidate is already live, so we must never tear
-            // it down — a missing/mislabeled boundary surfaces the raw error
-            // instead of risking teardown of a possibly-live app. Only a known
-            // boundary index at or after the failing step permits teardown.
-            let at_or_before_boundary = boundary.is_some_and(|b| index <= b);
-            if !at_or_before_boundary {
-                return Err(source);
+            match boundary {
+                // Past a KNOWN boundary: traffic already moved, so the candidate is
+                // live and nothing may be torn down. The error is attributed to the
+                // op that was running — several executor errors carry no label of
+                // their own, and post-boundary policy is decided by op
+                // (`DeployExecError::PostCutover`, issue #1621 §4.6).
+                Some(b) if index > b => {
+                    return Err(DeployExecError::PostCutover {
+                        failed_step: op.label(),
+                        source: Box::new(source),
+                    });
+                }
+                // Fail safe: if the boundary op was never found (`None`), we do NOT
+                // know whether the candidate is already live, so we must never tear
+                // it down — a missing/mislabeled boundary surfaces the raw error
+                // instead of risking teardown of a possibly-live app, and does not
+                // claim to know which side of the cutover the failure landed on.
+                None => return Err(source),
+                // At or before a known boundary: teardown is safe.
+                Some(_) => {}
             }
             eprintln!(
                 "  \u{2717} {} failed — {}\u{2026}",

--- a/autumn-cli/src/deploy/exec.rs
+++ b/autumn-cli/src/deploy/exec.rs
@@ -2036,8 +2036,49 @@ fn parse_current_release(section: &str) -> Option<String> {
 /// (issue #1621, AC-6).
 const HOST_STATUS_DELIM: &str = "---autumn-host-status---";
 
-/// Sentinel the status probe prints when the shared maintenance flag file exists.
+/// Sentinel the status probe prints when a maintenance flag file exists.
 const MAINTENANCE_ON_SENTINEL: &str = "maintenance-on";
+
+/// Whether a host is in maintenance, **as the unit it is actually running sees
+/// it** (issue #1621, review round 1).
+///
+/// Deliberately three-valued rather than a `bool`. The flag file the runtime polls
+/// is chosen by `AUTUMN_MAINTENANCE_FLAG_FILE` (see
+/// [`autumn_web::maintenance::flag_file_path_from`]), which slot units only carry
+/// from #1621 onwards — so on a host whose unit predates this feature the app polls
+/// a release-local path the fleet switch does not own. Reading one fixed path and
+/// calling the answer `on`/`off` therefore lies in both directions: `off` for a
+/// host that is maintained, and `ON` for a host still taking traffic. When the CLI
+/// cannot prove WHICH file the running unit polls it says so instead of guessing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MaintenanceStatus {
+    /// The file the running unit polls exists: the app is serving maintenance.
+    On,
+    /// The file the running unit polls does not exist: the app is serving traffic.
+    Off,
+    /// The live slot unit could not be read, so the file the app polls is unknown.
+    /// **Fails closed** — never rendered as a confident `ON`/`off`.
+    Unknown,
+}
+
+/// Which maintenance flag file the host's live slot unit resolves to (issue #1621,
+/// review round 1).
+///
+/// Reported alongside [`MaintenanceStatus`] because it is the actionable half: a
+/// host that does not poll the shared path will have its flag orphaned by the next
+/// cutover, and a fleet-wide `deploy maintenance on` cannot reach it reliably.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MaintenanceFlagSource {
+    /// The unit declares `AUTUMN_MAINTENANCE_FLAG_FILE` and it is exactly the
+    /// per-app shared path this CLI manages — the #1621 shape.
+    Shared,
+    /// The unit resolves to some OTHER file: no override at all (a pre-#1621 unit,
+    /// polling `WorkingDirectory`-relative `tmp/autumn-maintenance.json`), or an
+    /// override pointing somewhere this CLI does not write.
+    Unshared,
+    /// The unit could not be read, so nothing about the flag path is proved.
+    Unknown,
+}
 
 /// Everything `autumn deploy status` reads from ONE host (issue #1621, AC-6).
 ///
@@ -2056,10 +2097,17 @@ pub struct HostStatusProbe {
     pub ready_code: Option<u16>,
     /// Whether the SHARED maintenance flag file exists on this host.
     ///
-    /// Read from `{app_dir}/shared/…` — the release-independent path the slot units
-    /// point `AUTUMN_MAINTENANCE_FLAG_FILE` at — so the answer survives a cutover,
-    /// which is the whole reason that override exists.
-    pub maintenance_on: bool,
+    /// Read from `{app_dir}/shared/…` — the release-independent path the #1621 slot
+    /// units point `AUTUMN_MAINTENANCE_FLAG_FILE` at — so the answer survives a
+    /// cutover, which is the whole reason that override exists. It is the state of
+    /// ONE file, not a verdict: see [`Self::maintenance`] for what the RUNNING unit
+    /// observes.
+    pub shared_maintenance_flag: bool,
+    /// Maintenance as the host's live slot unit actually observes it — the fact
+    /// `deploy status` reports (issue #1621, review round 1).
+    pub maintenance: MaintenanceStatus,
+    /// Which file that verdict came from.
+    pub maintenance_flag_source: MaintenanceFlagSource,
     /// The last state-changing deploy action this host COMPLETED, from the
     /// `shared/last-deploy` marker (AC-6), or `None` when the marker is absent or
     /// unreadable.
@@ -2131,30 +2179,79 @@ pub fn probe_host_status(
             .live_slot
         }
     };
+    let shared_flag = cfg.maintenance_flag_file();
     let shell = format!(
         "curl -o /dev/null -s -m 5 -w '%{{http_code}}' http://127.0.0.1:{port}/ready 2>/dev/null \
          || true; \
          printf '\\n{delim}\\n'; \
          if [ -f {flag} ]; then printf '%s' '{on}'; fi; \
          printf '\\n{delim}\\n'; \
-         cat {last_deploy} 2>/dev/null || true",
+         cat {last_deploy} 2>/dev/null || true; \
+         printf '\\n{delim}\\n'; \
+         if [ -f {unit} ]; then \
+         autumn_mf=$(sed -n 's|^Environment={flag_env}=||p' {unit} 2>/dev/null | tail -n 1); \
+         autumn_wd=$(sed -n 's|^WorkingDirectory=||p' {unit} 2>/dev/null | tail -n 1); \
+         if [ -z \"$autumn_mf\" ] && [ -n \"$autumn_wd\" ]; then \
+         autumn_mf=\"$autumn_wd/{legacy_rel}\"; fi; \
+         if [ -n \"$autumn_mf\" ]; then printf '%s\\n' \"$autumn_mf\"; \
+         if [ -f \"$autumn_mf\" ]; then printf '%s' '{on}'; fi; fi; fi",
         port = slot_app_port(public_port, live_slot),
         delim = HOST_STATUS_DELIM,
-        flag = shell_quote(&cfg.maintenance_flag_file()),
+        flag = shell_quote(&shared_flag),
         on = MAINTENANCE_ON_SENTINEL,
         // AC-6, third fact: the last COMPLETED deploy action. Folded into this
         // existing round-trip rather than a new per-host ssh — `deploy status` is
         // run mid-incident across the whole fleet, and every extra round-trip is
         // paid N times.
         last_deploy = shell_quote(&last_deploy_marker(cfg)),
+        // Review round 1: resolve, ON THE HOST, the flag file the LIVE SLOT UNIT
+        // actually makes the app poll — the same rule
+        // `maintenance::flag_file_path_from` applies at runtime (the override when
+        // non-blank, else the cwd-relative legacy path, and `WorkingDirectory` IS
+        // the app's cwd). Doing it in-shell keeps `deploy status` at the same two
+        // round-trips per host; doing it from the unit rather than from `current`
+        // is what makes the answer true for a unit rendered before #1621, which
+        // carries no override line at all.
+        unit = shell_quote(&format!(
+            "/etc/systemd/system/{}.service",
+            slot_unit_name(&cfg.service_name, live_slot)
+        )),
+        flag_env = autumn_web::maintenance::MAINTENANCE_FLAG_FILE_ENV,
+        legacy_rel = autumn_web::maintenance::MAINTENANCE_FLAG_FILE,
     );
     let out = exec.run(&RemoteCommand::new("probe-host-status", shell))?;
     // Section-count tolerant: a host still running a pre-#1621 probe shape (or a
-    // fixture written against it) simply reports no last-deploy section.
+    // fixture written against it) simply reports no last-deploy section, and a
+    // capture predating the unit section leaves the maintenance verdict `Unknown`.
     let mut sections = out.stdout.split(HOST_STATUS_DELIM);
     let ready_section = sections.next().unwrap_or_default();
-    let maintenance_section = sections.next().unwrap_or_default();
+    let shared_flag_section = sections.next().unwrap_or_default();
     let last_deploy_section = sections.next().unwrap_or_default();
+    let unit_flag_section = sections.next().unwrap_or_default();
+    // The unit section is `{resolved path}\n[{sentinel}]`. A blank/absent path is
+    // "the unit could not be read" — fail closed rather than fall back to the
+    // shared path, whose state the running unit may well not observe.
+    let mut unit_lines = unit_flag_section.trim_start_matches('\n').lines();
+    let resolved_flag_path = unit_lines.next().unwrap_or_default().trim();
+    let (maintenance, maintenance_flag_source) = if resolved_flag_path.is_empty() {
+        (MaintenanceStatus::Unknown, MaintenanceFlagSource::Unknown)
+    } else {
+        let present = unit_lines
+            .next()
+            .is_some_and(|line| line.trim() == MAINTENANCE_ON_SENTINEL);
+        (
+            if present {
+                MaintenanceStatus::On
+            } else {
+                MaintenanceStatus::Off
+            },
+            if resolved_flag_path == shared_flag {
+                MaintenanceFlagSource::Shared
+            } else {
+                MaintenanceFlagSource::Unshared
+            },
+        )
+    };
     Ok(HostStatusProbe {
         deploy,
         // `curl` writes `000` when it never got a response; that is "nothing
@@ -2165,7 +2262,9 @@ pub fn probe_host_status(
             .parse::<u16>()
             .ok()
             .filter(|code| *code > 0),
-        maintenance_on: maintenance_section.trim() == MAINTENANCE_ON_SENTINEL,
+        shared_maintenance_flag: shared_flag_section.trim() == MAINTENANCE_ON_SENTINEL,
+        maintenance,
+        maintenance_flag_source,
         last_deploy: parse_last_deploy(last_deploy_section),
     })
 }
@@ -5696,6 +5795,166 @@ mod tests {
     }
 
     #[test]
+    fn probe_host_status_consults_the_live_slot_unit_for_the_maintenance_flag_path() {
+        // #1621 review round 1 (Codex 2). The status probe used to read ONLY the
+        // shared flag path. A host still running a slot unit rendered BEFORE #1621
+        // has no `Environment=AUTUMN_MAINTENANCE_FLAG_FILE=` line, so the app it is
+        // running polls the cwd-relative (release-local) `tmp/autumn-maintenance
+        // .json` instead — and `deploy status` reported the SHARED path's state for
+        // it anyway. So it could print `maintenance off` for a host that is
+        // actually maintained, and `maintenance ON` for one whose legacy write
+        // failed and which is therefore still taking traffic.
+        //
+        // The probe must instead ask the LIVE SLOT UNIT which file the running app
+        // polls, resolving it exactly as `maintenance::flag_file_path_from` does
+        // (the override when set, else `WorkingDirectory` + the legacy relative
+        // path), and report THAT file's presence.
+        let cfg = resolved();
+        let exec = RecordingExecutor::new()
+            .with_stdout("detect-current", status_probe_stdout(RELEASE_ID, 3001))
+            .with_stdout("probe-host-status", "200\n---autumn-host-status---\n");
+        probe_host_status(&cfg, 3000, &exec).expect("status probe runs");
+        let shell = exec
+            .shell_for("probe-host-status")
+            .expect("status probe ran");
+        assert!(
+            shell.contains("'/etc/systemd/system/myapp-blue.service'"),
+            "the status probe must read the LIVE SLOT UNIT to learn which flag file \
+             the running app polls: {shell}"
+        );
+        assert!(
+            shell.contains(autumn_web::maintenance::MAINTENANCE_FLAG_FILE_ENV),
+            "the probe must resolve the unit's flag-file override: {shell}"
+        );
+        assert!(
+            shell.contains(autumn_web::maintenance::MAINTENANCE_FLAG_FILE),
+            "the probe must fall back to the legacy cwd-relative path for a unit \
+             that declares no override: {shell}"
+        );
+        // Still read-only: exactly the two probe labels, nothing mutating.
+        assert_eq!(
+            exec.run_labels(),
+            vec!["detect-current", "probe-host-status"],
+            "`deploy status` must never mutate a host"
+        );
+    }
+
+    /// Build a `probe-host-status` capture from its four sections: the `/ready`
+    /// code, the shared-flag sentinel, the last-deploy marker, and the resolved
+    /// unit flag path + its own presence sentinel.
+    fn host_status_capture(ready: &str, shared_on: bool, unit_section: &str) -> String {
+        format!(
+            "{ready}\n{HOST_STATUS_DELIM}\n{shared}\n{HOST_STATUS_DELIM}\n\n{unit_section}",
+            shared = if shared_on {
+                MAINTENANCE_ON_SENTINEL
+            } else {
+                ""
+            },
+        )
+    }
+
+    #[test]
+    fn probe_host_status_reports_the_flag_state_the_running_unit_observes() {
+        // #1621 review round 1 (Codex 2), the semantics. In every case the reported
+        // state is the one the RUNNING unit sees, not the one the shared path holds.
+        let cfg = resolved();
+        let legacy_flag = format!(
+            "{RELEASE_DIR}/{}",
+            autumn_web::maintenance::MAINTENANCE_FLAG_FILE
+        );
+        let probe_with_sections = |shared_on: bool, unit_section: String| {
+            let exec = RecordingExecutor::new()
+                .with_stdout("detect-current", status_probe_stdout(RELEASE_ID, 3001))
+                .with_stdout(
+                    "probe-host-status",
+                    host_status_capture("200", shared_on, &unit_section),
+                );
+            probe_host_status(&cfg, 3000, &exec).expect("status probe runs")
+        };
+
+        // 1. A pre-#1621 unit whose LEGACY flag is present while the shared flag is
+        //    absent: the app IS maintained. Reporting `off` here is the defect.
+        let maintained = probe_with_sections(
+            false,
+            format!("{HOST_STATUS_DELIM}\n{legacy_flag}\n{MAINTENANCE_ON_SENTINEL}"),
+        );
+        assert_eq!(maintained.maintenance, MaintenanceStatus::On);
+        assert_eq!(
+            maintained.maintenance_flag_source,
+            MaintenanceFlagSource::Unshared,
+            "a unit with no override polls a path the fleet switch does not own",
+        );
+
+        // 2. The same host after a `maintenance on` whose legacy write FAILED: the
+        //    shared flag exists but the running app never sees it, so the host is
+        //    still taking traffic. `off` is the truthful answer — a confident `ON`
+        //    would send the operator into a live window believing it closed.
+        let shared_only =
+            probe_with_sections(true, format!("{HOST_STATUS_DELIM}\n{legacy_flag}\n"));
+        assert_eq!(shared_only.maintenance, MaintenanceStatus::Off);
+        assert_eq!(
+            shared_only.maintenance_flag_source,
+            MaintenanceFlagSource::Unshared
+        );
+
+        // 3. A #1621 unit: the resolved path IS the shared one, and its state is
+        //    reported with confidence — the pre-existing behaviour, unchanged.
+        let shared_path = cfg.maintenance_flag_file();
+        let modern = probe_with_sections(
+            true,
+            format!("{HOST_STATUS_DELIM}\n{shared_path}\n{MAINTENANCE_ON_SENTINEL}"),
+        );
+        assert_eq!(modern.maintenance, MaintenanceStatus::On);
+        assert_eq!(
+            modern.maintenance_flag_source,
+            MaintenanceFlagSource::Shared
+        );
+        let cleared = probe_with_sections(false, format!("{HOST_STATUS_DELIM}\n{shared_path}\n"));
+        assert_eq!(cleared.maintenance, MaintenanceStatus::Off);
+        assert_eq!(
+            cleared.maintenance_flag_source,
+            MaintenanceFlagSource::Shared
+        );
+    }
+
+    #[test]
+    fn probe_host_status_fails_closed_when_the_flag_path_cannot_be_proved() {
+        // #1621 review round 1 (Codex 2), the fail-closed half. A host whose live
+        // slot unit could not be read at all (absent, unreadable, or a capture that
+        // predates this section) leaves the CLI unable to say WHICH file the running
+        // app polls. That is "we could not tell" — never a confident `ON`/`off`,
+        // even though the shared flag below is set.
+        let cfg = resolved();
+        for unit_section in [
+            // No unit section at all (a capture from a CLI predating this probe).
+            String::new(),
+            // Section present but empty: no unit file on the host.
+            format!("{HOST_STATUS_DELIM}\n"),
+            // Section present but the path line is blank: the unit declared neither
+            // an override nor a `WorkingDirectory`, so nothing was probed.
+            format!("{HOST_STATUS_DELIM}\n   \n"),
+        ] {
+            let exec = RecordingExecutor::new()
+                .with_stdout("detect-current", status_probe_stdout(RELEASE_ID, 3001))
+                .with_stdout(
+                    "probe-host-status",
+                    host_status_capture("200", true, &unit_section),
+                );
+            let probe = probe_host_status(&cfg, 3000, &exec).expect("status probe runs");
+            assert_eq!(
+                probe.maintenance,
+                MaintenanceStatus::Unknown,
+                "an unprovable flag path must not render as a confident on/off: \
+                 {unit_section:?}"
+            );
+            assert_eq!(
+                probe.maintenance_flag_source,
+                MaintenanceFlagSource::Unknown
+            );
+        }
+    }
+
+    #[test]
     fn probe_host_status_reads_readiness_and_maintenance_off_the_live_slot() {
         // #1621 (AC-6, plan §7.1): `deploy status` needs two facts `up` must never
         // pay for — the live slot's `/ready` code and whether the SHARED maintenance
@@ -5709,11 +5968,16 @@ mod tests {
             )
             .with_stdout(
                 "probe-host-status",
-                "200\n---autumn-host-status---\nmaintenance-on",
+                format!(
+                    "200\n---autumn-host-status---\nmaintenance-on\n---autumn-host-status---\n\n\
+                     ---autumn-host-status---\n{}\nmaintenance-on",
+                    resolved().maintenance_flag_file()
+                ),
             );
         let probe = probe_host_status(&cfg, 3000, &exec).unwrap();
         assert_eq!(probe.ready_code, Some(200));
-        assert!(probe.maintenance_on);
+        assert!(probe.shared_maintenance_flag);
+        assert_eq!(probe.maintenance, MaintenanceStatus::On);
         assert_eq!(
             probe.deploy.current_release_dir.as_deref(),
             Some("/srv/autumn/myapp/releases/20260714T120000Z")
@@ -5771,9 +6035,12 @@ mod tests {
                 "capture {capture:?} must degrade to unknown readiness"
             );
             assert!(
-                !probe.maintenance_on,
-                "no sentinel means maintenance is off, never unknown-as-on"
+                !probe.shared_maintenance_flag,
+                "no sentinel means the shared flag is absent, never unknown-as-on"
             );
+            // …and with no unit section at all the VERDICT is `Unknown`, not a
+            // confident `off` (review round 1, Codex 2).
+            assert_eq!(probe.maintenance, MaintenanceStatus::Unknown);
         }
     }
 

--- a/autumn-cli/src/deploy/exec.rs
+++ b/autumn-cli/src/deploy/exec.rs
@@ -1879,6 +1879,31 @@ pub struct DeployProbe {
     pub current_release_dir: Option<String>,
 }
 
+impl DeployProbe {
+    /// The live-slot decision for this host, reconciled against the running proxy —
+    /// pure, and `None` for a host with no promoted release at all.
+    ///
+    /// The ONE seam every fleet surface decides "which slot, and therefore which
+    /// unit, is live" through: `deploy status` READS the maintenance flag off it and
+    /// the `deploy maintenance` fan-out WRITES to it (review round 3). Sharing it is
+    /// what stops the read path and the write path from disagreeing about which file
+    /// matters — a `current` symlink can name a different release than the unit the
+    /// proxy is actually serving (a flip that landed with a `commit-markers` that
+    /// did not), and only the unit's own view is true for the running app.
+    #[must_use]
+    pub fn reconcile(&self, cfg: &ResolvedDeployConfig, public_port: u16) -> Option<SlotReconcile> {
+        match &self.mode {
+            DeployMode::First => None,
+            DeployMode::Redeploy { live_slot } => Some(reconcile_live_slot(
+                live_slot,
+                &self.proxy_list,
+                &cfg.service_name,
+                public_port,
+            )),
+        }
+    }
+}
+
 /// Parse the probe's unit section into an [`InstalledProxyPort`] (#2073).
 ///
 /// The section is the stdout the probe shell prints between [`PROXY_UNIT_DELIM`]
@@ -2080,6 +2105,90 @@ pub enum MaintenanceFlagSource {
     Unknown,
 }
 
+/// The maintenance flag file the app on one slot ACTUALLY polls, resolved on the
+/// host from that slot's unit (issue #1621, review round 3).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LiveMaintenanceFlag {
+    /// The path the unit makes the runtime poll: its `AUTUMN_MAINTENANCE_FLAG_FILE`
+    /// when non-blank, else its `WorkingDirectory` joined with the cwd-relative
+    /// legacy path — the same rule
+    /// [`autumn_web::maintenance::flag_file_path_from`] applies at runtime.
+    pub path: String,
+    /// Whether that file existed at probe time.
+    pub present: bool,
+}
+
+/// Shell that resolves, ON THE HOST, the maintenance flag file `live_slot`'s unit
+/// makes the app poll — and whether it exists (issue #1621, review round 3).
+///
+/// The single copy of that rule. `deploy status` embeds it in its batched status
+/// round-trip to REPORT the flag, and the `deploy maintenance` fan-out runs it via
+/// [`probe_live_maintenance_flag`] to decide where to WRITE; a second copy is
+/// exactly how the two would drift back apart into reporting one file and writing
+/// another.
+///
+/// Prints nothing at all when the unit cannot be read — the caller's fail-closed
+/// signal, never a fallback to a path the running app may not poll.
+fn live_maintenance_flag_shell(cfg: &ResolvedDeployConfig, live_slot: &str) -> String {
+    format!(
+        "if [ -f {unit} ]; then \
+         autumn_mf=$(sed -n 's|^Environment={flag_env}=||p' {unit} 2>/dev/null | tail -n 1); \
+         autumn_wd=$(sed -n 's|^WorkingDirectory=||p' {unit} 2>/dev/null | tail -n 1); \
+         if [ -z \"$autumn_mf\" ] && [ -n \"$autumn_wd\" ]; then \
+         autumn_mf=\"$autumn_wd/{legacy_rel}\"; fi; \
+         if [ -n \"$autumn_mf\" ]; then printf '%s\\n' \"$autumn_mf\"; \
+         if [ -f \"$autumn_mf\" ]; then printf '%s' '{on}'; fi; fi; fi",
+        unit = shell_quote(&format!(
+            "/etc/systemd/system/{}.service",
+            slot_unit_name(&cfg.service_name, live_slot)
+        )),
+        flag_env = autumn_web::maintenance::MAINTENANCE_FLAG_FILE_ENV,
+        legacy_rel = autumn_web::maintenance::MAINTENANCE_FLAG_FILE,
+        on = MAINTENANCE_ON_SENTINEL,
+    )
+}
+
+/// Parse what [`live_maintenance_flag_shell`] printed: `{path}\n[{sentinel}]`.
+///
+/// `None` — a blank or absent path — means the unit could not be read. It is
+/// deliberately NOT degraded to the shared path: the whole point is that a
+/// pre-#1621 unit polls somewhere else entirely.
+fn parse_live_maintenance_flag(section: &str) -> Option<LiveMaintenanceFlag> {
+    let mut lines = section.trim_start_matches('\n').lines();
+    let path = lines.next().unwrap_or_default().trim();
+    if path.is_empty() {
+        return None;
+    }
+    Some(LiveMaintenanceFlag {
+        path: path.to_owned(),
+        present: lines
+            .next()
+            .is_some_and(|line| line.trim() == MAINTENANCE_ON_SENTINEL),
+    })
+}
+
+/// Resolve the maintenance flag file the host's live slot unit polls, in ONE
+/// read-only round-trip (issue #1621, review round 3).
+///
+/// `Ok(None)` is the fail-closed answer — the unit is absent or unreadable, so
+/// nothing about the running app's flag path is proved and the caller must not act
+/// as though it were.
+///
+/// # Errors
+///
+/// Returns the executor's error only when the probe command cannot run at all.
+pub fn probe_live_maintenance_flag(
+    cfg: &ResolvedDeployConfig,
+    live_slot: &str,
+    exec: &impl DeployExecutor,
+) -> Result<Option<LiveMaintenanceFlag>, DeployExecError> {
+    let out = exec.run(&RemoteCommand::new(
+        "detect-maintenance-flag",
+        live_maintenance_flag_shell(cfg, live_slot),
+    ))?;
+    Ok(parse_live_maintenance_flag(&out.stdout))
+}
+
 /// Everything `autumn deploy status` reads from ONE host (issue #1621, AC-6).
 ///
 /// Deliberately a superset of [`DeployProbe`] rather than an extension of it:
@@ -2122,20 +2231,14 @@ impl HostStatusProbe {
     /// The live-slot decision for this host, reconciled against the running proxy —
     /// pure, and `None` for a host with no promoted release at all.
     ///
-    /// Shared with the rollout path's slot selection ([`reconcile_live_slot`]), so
-    /// `status` reports the same slot a deploy would plan from, including the same
-    /// proxy-over-marker precedence on a disagreement.
+    /// Shared with the rollout path's slot selection ([`reconcile_live_slot`]) and
+    /// with the `deploy maintenance` fan-out through [`DeployProbe::reconcile`], so
+    /// `status` reports the same slot a deploy would plan from — and the same one
+    /// maintenance writes to — including the same proxy-over-marker precedence on a
+    /// disagreement.
     #[must_use]
     pub fn reconcile(&self, cfg: &ResolvedDeployConfig, public_port: u16) -> Option<SlotReconcile> {
-        match &self.deploy.mode {
-            DeployMode::First => None,
-            DeployMode::Redeploy { live_slot } => Some(reconcile_live_slot(
-                live_slot,
-                &self.deploy.proxy_list,
-                &cfg.service_name,
-                public_port,
-            )),
-        }
+        self.deploy.reconcile(cfg, public_port)
     }
 }
 
@@ -2167,18 +2270,9 @@ pub fn probe_host_status(
     // Poll whichever slot the proxy is actually serving; on a host with nothing
     // promoted yet, blue is the slot a first deploy takes, and the probe simply
     // reports that nothing answered.
-    let live_slot = match &deploy.mode {
-        DeployMode::First => SLOT_BLUE,
-        DeployMode::Redeploy { live_slot } => {
-            reconcile_live_slot(
-                live_slot,
-                &deploy.proxy_list,
-                &cfg.service_name,
-                public_port,
-            )
-            .live_slot
-        }
-    };
+    let live_slot = deploy
+        .reconcile(cfg, public_port)
+        .map_or(SLOT_BLUE, |reconcile| reconcile.live_slot);
     let shared_flag = cfg.maintenance_flag_file();
     let shell = format!(
         "curl -o /dev/null -s -m 5 -w '%{{http_code}}' http://127.0.0.1:{port}/ready 2>/dev/null \
@@ -2188,13 +2282,7 @@ pub fn probe_host_status(
          printf '\\n{delim}\\n'; \
          cat {last_deploy} 2>/dev/null || true; \
          printf '\\n{delim}\\n'; \
-         if [ -f {unit} ]; then \
-         autumn_mf=$(sed -n 's|^Environment={flag_env}=||p' {unit} 2>/dev/null | tail -n 1); \
-         autumn_wd=$(sed -n 's|^WorkingDirectory=||p' {unit} 2>/dev/null | tail -n 1); \
-         if [ -z \"$autumn_mf\" ] && [ -n \"$autumn_wd\" ]; then \
-         autumn_mf=\"$autumn_wd/{legacy_rel}\"; fi; \
-         if [ -n \"$autumn_mf\" ]; then printf '%s\\n' \"$autumn_mf\"; \
-         if [ -f \"$autumn_mf\" ]; then printf '%s' '{on}'; fi; fi; fi",
+         {unit_flag}",
         port = slot_app_port(public_port, live_slot),
         delim = HOST_STATUS_DELIM,
         flag = shell_quote(&shared_flag),
@@ -2205,19 +2293,13 @@ pub fn probe_host_status(
         // paid N times.
         last_deploy = shell_quote(&last_deploy_marker(cfg)),
         // Review round 1: resolve, ON THE HOST, the flag file the LIVE SLOT UNIT
-        // actually makes the app poll — the same rule
-        // `maintenance::flag_file_path_from` applies at runtime (the override when
-        // non-blank, else the cwd-relative legacy path, and `WorkingDirectory` IS
-        // the app's cwd). Doing it in-shell keeps `deploy status` at the same two
-        // round-trips per host; doing it from the unit rather than from `current`
-        // is what makes the answer true for a unit rendered before #1621, which
-        // carries no override line at all.
-        unit = shell_quote(&format!(
-            "/etc/systemd/system/{}.service",
-            slot_unit_name(&cfg.service_name, live_slot)
-        )),
-        flag_env = autumn_web::maintenance::MAINTENANCE_FLAG_FILE_ENV,
-        legacy_rel = autumn_web::maintenance::MAINTENANCE_FLAG_FILE,
+        // actually makes the app poll — doing it from the unit rather than from
+        // `current` is what makes the answer true for a unit rendered before #1621,
+        // which carries no override line at all. Folded into this round-trip (round
+        // 3 moved the fragment itself into `live_maintenance_flag_shell`, shared
+        // with the `deploy maintenance` WRITE path) so `deploy status` stays at the
+        // same two round-trips per host.
+        unit_flag = live_maintenance_flag_shell(cfg, live_slot),
     );
     let out = exec.run(&RemoteCommand::new("probe-host-status", shell))?;
     // Section-count tolerant: a host still running a pre-#1621 probe shape (or a
@@ -2231,27 +2313,22 @@ pub fn probe_host_status(
     // The unit section is `{resolved path}\n[{sentinel}]`. A blank/absent path is
     // "the unit could not be read" — fail closed rather than fall back to the
     // shared path, whose state the running unit may well not observe.
-    let mut unit_lines = unit_flag_section.trim_start_matches('\n').lines();
-    let resolved_flag_path = unit_lines.next().unwrap_or_default().trim();
-    let (maintenance, maintenance_flag_source) = if resolved_flag_path.is_empty() {
-        (MaintenanceStatus::Unknown, MaintenanceFlagSource::Unknown)
-    } else {
-        let present = unit_lines
-            .next()
-            .is_some_and(|line| line.trim() == MAINTENANCE_ON_SENTINEL);
-        (
-            if present {
-                MaintenanceStatus::On
-            } else {
-                MaintenanceStatus::Off
-            },
-            if resolved_flag_path == shared_flag {
-                MaintenanceFlagSource::Shared
-            } else {
-                MaintenanceFlagSource::Unshared
-            },
-        )
-    };
+    let (maintenance, maintenance_flag_source) =
+        match parse_live_maintenance_flag(unit_flag_section) {
+            None => (MaintenanceStatus::Unknown, MaintenanceFlagSource::Unknown),
+            Some(flag) => (
+                if flag.present {
+                    MaintenanceStatus::On
+                } else {
+                    MaintenanceStatus::Off
+                },
+                if flag.path == shared_flag {
+                    MaintenanceFlagSource::Shared
+                } else {
+                    MaintenanceFlagSource::Unshared
+                },
+            ),
+        };
     Ok(HostStatusProbe {
         deploy,
         // `curl` writes `000` when it never got a response; that is "nothing
@@ -3001,13 +3078,17 @@ pub(crate) mod test_support {
     /// [`super::DeployMode::First`] / `Absent`. A fleet test that forgets to script
     /// host N's probe would therefore exercise the first-deploy branch and still
     /// pass. [`RecordingExecutor::strict`] turns that into a loud panic.
-    pub(crate) const PROBE_LABELS: [&str; 6] = [
+    pub(crate) const PROBE_LABELS: [&str; 7] = [
         "proxy-compat-probe",
         "detect-current",
         "probe-release-dir",
         "probe-rollback-target",
         "resolve-previous",
         "probe-host-status",
+        // Round 3: the maintenance WRITE path parses this one to decide which file
+        // the running unit polls. Unscripted, it reads as "the unit could not be
+        // read" and the fan-out would fail closed for the wrong reason.
+        "detect-maintenance-flag",
     ];
 
     /// One recorded executor call. Uploads carry no local path: op building is
@@ -5836,6 +5917,59 @@ mod tests {
             exec.run_labels(),
             vec!["detect-current", "probe-host-status"],
             "`deploy status` must never mutate a host"
+        );
+    }
+
+    #[test]
+    fn the_status_read_and_the_maintenance_write_resolve_the_flag_with_one_shell() {
+        // #1621 review round 3. `deploy status` REPORTS the flag file the live slot
+        // unit polls; the `deploy maintenance` fan-out WRITES it. While the write
+        // path derived its path from the `current` symlink instead, the two
+        // disagreed exactly when it matters — a proxy flip that landed with a
+        // `commit-markers` that did not leaves `current` naming another release than
+        // the unit that is running — so `maintenance on` could report success while
+        // the application carried on serving traffic. One shell fragment, used by
+        // both, is what makes that class of drift unrepresentable.
+        let cfg = resolved();
+        let exec = RecordingExecutor::new()
+            .with_stdout("detect-current", status_probe_stdout(RELEASE_ID, 3001))
+            .with_stdout("probe-host-status", "200\n---autumn-host-status---\n")
+            .with_stdout(
+                "detect-maintenance-flag",
+                "/srv/autumn/myapp/releases/r9/tmp/autumn-maintenance.json\n",
+            );
+        probe_host_status(&cfg, 3000, &exec).expect("status probe runs");
+        let status_shell = exec
+            .shell_for("probe-host-status")
+            .expect("status probe ran");
+        let resolution = live_maintenance_flag_shell(&cfg, SLOT_BLUE);
+        assert!(
+            status_shell.contains(&resolution),
+            "`deploy status` must resolve the flag through the shared fragment: \
+             {status_shell}"
+        );
+
+        let flag = probe_live_maintenance_flag(&cfg, SLOT_BLUE, &exec)
+            .expect("the flag probe runs")
+            .expect("the unit resolved a path");
+        assert_eq!(
+            exec.shell_for("detect-maintenance-flag"),
+            Some(resolution),
+            "the write path must run the SAME resolution, not a second copy of it"
+        );
+        assert_eq!(
+            flag.path, "/srv/autumn/myapp/releases/r9/tmp/autumn-maintenance.json",
+            "the resolved path is the unit's, whatever `current` happens to say"
+        );
+        assert!(!flag.present, "no sentinel line means the file is absent");
+
+        // Fails closed: an unreadable unit prints nothing, and that is never
+        // degraded into "the shared path".
+        let blank = RecordingExecutor::new().with_stdout("detect-maintenance-flag", "");
+        assert_eq!(
+            probe_live_maintenance_flag(&cfg, SLOT_BLUE, &blank).expect("the probe runs"),
+            None,
+            "an unreadable unit proves nothing about which file the app polls"
         );
     }
 

--- a/autumn-cli/src/deploy/exec.rs
+++ b/autumn-cli/src/deploy/exec.rs
@@ -570,6 +570,45 @@ impl SlotPlan {
     }
 }
 
+/// Whether a cutover runs the pending-migration one-shot (issue #1621, AC-4).
+///
+/// A fleet's schema is **fleet-wide**, so a rollout migrates exactly once. A naive
+/// per-host loop would run the `AUTUMN_MIGRATE=1` one-shot on every host: the
+/// Postgres session advisory lock (`autumn/src/migrate.rs`) keeps that *correct*,
+/// but hosts 2..N each pay the lock wait and, far worse, a migration failing on
+/// host 2 **after** host 1 has already cut over is precisely the mixed-version
+/// fleet #1621 forbids. So the fleet driver schedules the migration on ONE host
+/// and builds every other host's cutover with [`Self::Skip`].
+///
+/// The op stays **inside** [`cutover_ops`] rather than being hoisted into a fleet
+/// pre-phase: in its historical position (between `start-candidate` and
+/// `readiness-gate`) it sits PRE-boundary relative to `proxy-flip`, so a failed
+/// migration keeps the entire existing, already-tested auto-rollback path for free
+/// — [`execute_with_teardown`] runs `candidate_teardown_ops`, the old release keeps
+/// serving, and the caller gets `CandidateRolledBack { failed_step: "migrate" }`.
+/// A standalone pre-phase would have to re-implement candidate teardown from
+/// scratch for zero gain.
+///
+/// This is an **enum, not a `bool`**, deliberately: Phase 2 of #1621 (role-based
+/// rollout — a designated migrator host, worker roles) needs to express more than
+/// yes/no and must not force a second signature break on [`cutover_ops`], the
+/// most exact-vector-asserted builder in the deploy path.
+///
+/// [`first_deploy_ops`] takes no such parameter: a first deploy has **never** run
+/// migrations (a documented single-host limitation), and keeping it byte-identical
+/// is what lets the one-entry-`hosts` fleet stay indistinguishable from today's
+/// single-server deploy.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MigrateStep {
+    /// Run the pending-migration one-shot before the flip — today's behavior, in
+    /// today's exact position.
+    Run,
+    /// Omit ONLY the migrate op; every other step keeps its identity and relative
+    /// position (the cutover boundary in particular). Used for every host in a
+    /// fleet run except the one that carries the migration.
+    Skip,
+}
+
 /// Build the ordered FIRST-deploy operation sequence (Slice 1 + proxy front).
 ///
 /// Pure — performs no I/O; `release_id` and the [`SlotPlan`] are injected for
@@ -723,7 +762,11 @@ pub fn first_deploy_ops(
 /// 6. start the candidate via `enable` + `restart` (old release untouched;
 ///    restart, not `enable --now`, so an already-active slot relaunches the
 ///    freshly written unit — see the op's comment),
-/// 7. run pending migrations BEFORE cutover (`AUTUMN_MIGRATE=1` one-shot),
+/// 7. run pending migrations BEFORE cutover (`AUTUMN_MIGRATE=1` one-shot) — the
+///    ONLY step this builder parameterises: `migrate` is [`MigrateStep::Run`] for
+///    a single-host deploy and for the one fleet host that carries the migration,
+///    and [`MigrateStep::Skip`] for every other fleet host (issue #1621, AC-4).
+///    `Skip` omits this op and nothing else,
 /// 8. bounded `/ready` poll on the candidate's separate loopback port,
 /// 9. health-gated proxy flip old→candidate (THE cutover),
 /// 10. commit the state markers as ONE atomic remote op (#1938): record the
@@ -748,6 +791,7 @@ pub fn cutover_ops(
     release_id: &str,
     plan: &SlotPlan,
     reregister_options: &ProxyServiceOptions,
+    migrate: MigrateStep,
 ) -> Vec<DeployOp> {
     let release_dir = format!("{}/{release_id}", cfg.releases_dir());
     let remote_binary = format!("{release_dir}/{}", cfg.app_name);
@@ -838,10 +882,20 @@ pub fn cutover_ops(
                  systemctl restart {candidate_unit}.service"
             ),
         )),
-        // Migrations run BEFORE the flip. `systemd-run --wait` returns the
-        // child's exit status, so a failed migration surfaces a non-zero error
-        // that stops run_ops before the flip — old release still serving (AC-3).
-        DeployOp::Run(release_migrate_command(cfg, &release_dir)),
+    ]);
+    // Migrations run BEFORE the flip. `systemd-run --wait` returns the child's
+    // exit status, so a failed migration surfaces a non-zero error that stops
+    // run_ops before the flip — old release still serving (AC-3).
+    //
+    // #1621: this is the ONE op a fleet parameterises. The position is unchanged
+    // (between `start-candidate` and `readiness-gate`, i.e. PRE-boundary, so the
+    // existing candidate-teardown path still covers a failed migration), and
+    // `MigrateStep::Skip` omits ONLY this op — hosts 2..N of a fleet, whose shared
+    // schema the first redeploying host already migrated. See [`MigrateStep`].
+    if matches!(migrate, MigrateStep::Run) {
+        ops.push(DeployOp::Run(release_migrate_command(cfg, &release_dir)));
+    }
+    ops.extend([
         DeployOp::Run(RemoteCommand::new(
             "readiness-gate",
             readiness_poll_shell(plan.candidate_port, cfg.readiness_timeout_secs),
@@ -2491,6 +2545,13 @@ mod tests {
     /// the redeploy path refuses a concurrent `server.port` change at pre-flight
     /// (#2073), so the public port is unchanged and derived == actual.
     fn sample_cutover_ops(env: Secret) -> Vec<DeployOp> {
+        sample_cutover_ops_with(env, MigrateStep::Run)
+    }
+
+    /// [`sample_cutover_ops`] with an explicit [`MigrateStep`] (issue #1621), so the
+    /// fleet's skip-the-migrate-op parameterisation is assertable while every
+    /// existing exact-vector call site keeps building today's `Run` sequence.
+    fn sample_cutover_ops_with(env: Secret, migrate: MigrateStep) -> Vec<DeployOp> {
         let cfg = resolved();
         let plan = SlotPlan::redeploy(3000, SLOT_BLUE);
         let unit = super::super::render_app_unit(
@@ -2514,6 +2575,7 @@ mod tests {
                 tls: false,
                 host: None,
             },
+            migrate,
         )
     }
 
@@ -2800,6 +2862,50 @@ mod tests {
             "commit the markers before draining the old release"
         );
         assert!(pos("drain-old") < pos("prune"), "drain before prune");
+    }
+
+    #[test]
+    fn cutover_ops_skip_omits_only_the_migrate_op() {
+        // #1621 (AC-4): a fleet's schema is fleet-wide, so it migrates EXACTLY
+        // ONCE — hosts 2..N build their cutover with `MigrateStep::Skip`. Skipping
+        // must remove the `migrate` op and NOTHING else: the boundary label
+        // (`proxy-flip`) keeps its identity and every other step keeps its relative
+        // position, or `execute_with_teardown`'s boundary lookup (and with it the
+        // per-host auto-rollback the fleet driver depends on) would silently change
+        // meaning on every host after the first.
+        //
+        // The assertion is differential — `Skip`'s vector is derived from `Run`'s —
+        // so it can never drift from the exact vector pinned by
+        // `redeploy_produces_exact_zero_downtime_sequence`.
+        let labels = |ops: &[DeployOp]| ops.iter().map(DeployOp::label).collect::<Vec<_>>();
+        let run = labels(&sample_cutover_ops_with(
+            Secret::new("AUTUMN_SECURITY__SIGNING_SECRET=x\n"),
+            MigrateStep::Run,
+        ));
+        let skip = labels(&sample_cutover_ops_with(
+            Secret::new("AUTUMN_SECURITY__SIGNING_SECRET=x\n"),
+            MigrateStep::Skip,
+        ));
+
+        assert_eq!(
+            run.iter().filter(|l| **l == "migrate").count(),
+            1,
+            "MigrateStep::Run must emit exactly one migrate op, got: {run:?}"
+        );
+        let expected: Vec<&'static str> = run.iter().copied().filter(|l| *l != "migrate").collect();
+        assert_eq!(
+            skip, expected,
+            "MigrateStep::Skip must be MigrateStep::Run minus exactly the `migrate` \
+             op\n  run:  {run:?}\n  skip: {skip:?}"
+        );
+        assert!(
+            !skip.contains(&"migrate"),
+            "a skipped cutover must carry no migrate op, got: {skip:?}"
+        );
+        assert!(
+            skip.contains(&"proxy-flip"),
+            "skipping the migration must not disturb the cutover boundary, got: {skip:?}"
+        );
     }
 
     #[test]

--- a/autumn-cli/src/deploy/fleet.rs
+++ b/autumn-cli/src/deploy/fleet.rs
@@ -387,6 +387,52 @@ pub(crate) enum HostOutcome {
     },
 }
 
+impl HostOutcome {
+    /// Whether this host is left RUNNING the new release, whatever route it took
+    /// there (issue #1621, §8.2).
+    ///
+    /// The question every recovery line turns on — which hosts still need undoing —
+    /// and it is deliberately answered in one place: the summary, the halt error's
+    /// `still_on_new` list and the schema notes must never disagree about it. A
+    /// `CompensationFailed` host belongs here precisely BECAUSE the compensation
+    /// failed: it is still forward.
+    pub(crate) const fn on_new_release(&self) -> bool {
+        matches!(
+            self,
+            Self::Serving
+                | Self::Degraded { .. }
+                | Self::LiveOnNew { .. }
+                | Self::AmbiguousMarkers
+                | Self::Manual { .. }
+                | Self::CompensationFailed { .. }
+        )
+    }
+
+    /// Whether this host was touched and ended up back OFF the new release — its
+    /// candidate torn down by its own pre-boundary teardown, or put back by fleet
+    /// compensation.
+    ///
+    /// With [`HostOutcome::on_new_release`] this exhaustively partitions every
+    /// variant except [`HostOutcome::Untouched`], which is the point: "the fleet is
+    /// not forward" is then provable rather than assumed, and a variant added later
+    /// cannot quietly fall into neither set — the `match` below has no wildcard.
+    pub(crate) const fn went_back(&self) -> bool {
+        match self {
+            Self::RolledBack { .. }
+            | Self::TornDown { .. }
+            | Self::CompensatedRollback
+            | Self::CompensatedTeardown => true,
+            Self::Untouched
+            | Self::Serving
+            | Self::Degraded { .. }
+            | Self::LiveOnNew { .. }
+            | Self::AmbiguousMarkers
+            | Self::Manual { .. }
+            | Self::CompensationFailed { .. } => false,
+        }
+    }
+}
+
 /// How bad a POST-boundary failure is (issue #1621, §4.6).
 ///
 /// "Post-boundary" means `exec::execute_with_teardown` returned the RAW executor
@@ -724,6 +770,22 @@ pub(crate) const FLEET_RECOVERY_HINT: &str = "Roll ONE back with `autumn deploy 
 pub(crate) const FLEET_SCHEMA_NOT_ROLLED_BACK_NOTE: &str = "the compensating rollback restored BINARIES only — the migration that already ran was \
      NOT rolled back; confirm the schema still fits the release now serving";
 
+/// The same binaries-versus-schema truth for the rollout where NOTHING was
+/// compensated because nothing needed to be (issue #1621).
+///
+/// The fleet's one migration runs on the first redeploy host, and a PRE-boundary
+/// failure after it — a `readiness-gate` timeout is the ordinary shape — makes that
+/// host tear its own candidate down ([`HostOutcome::RolledBack`]) while every later
+/// host stays [`HostOutcome::Untouched`]. No host ever reached the new release, so
+/// the fleet driver has nothing to compensate and never says the word: the operator
+/// is left reading a table of "previous release still serving" rows with no hint
+/// that the database underneath them has already moved on. Same hazard as
+/// [`FLEET_SCHEMA_NOT_ROLLED_BACK_NOTE`], different cause — so it gets its own
+/// sentence rather than borrowing one that claims a compensating rollback ran.
+pub(crate) const FLEET_SCHEMA_AHEAD_OF_BINARIES_NOTE: &str = "no host is serving the new release, but the migration that already ran was NOT rolled \
+     back — the binaries went back and the schema did not; confirm the release now serving \
+     still fits the migrated schema";
+
 /// Whether this rollout moved the schema, judged conservatively (issue #1621).
 ///
 /// True when the plan scheduled a migration AND the host carrying it was reached at
@@ -941,17 +1003,7 @@ pub(crate) fn fleet_summary_lines(
         .hosts
         .iter()
         .zip(outcomes)
-        .filter(|(_, outcome)| {
-            matches!(
-                outcome,
-                HostOutcome::Serving
-                    | HostOutcome::Degraded { .. }
-                    | HostOutcome::LiveOnNew { .. }
-                    | HostOutcome::AmbiguousMarkers
-                    | HostOutcome::Manual { .. }
-                    | HostOutcome::CompensationFailed { .. }
-            )
-        })
+        .filter(|(_, outcome)| outcome.on_new_release())
         .map(|(host, _)| host.host.as_str())
         .collect();
     if !on_new.is_empty() {
@@ -959,31 +1011,52 @@ pub(crate) fn fleet_summary_lines(
             "  On {release_id}: {}. {FLEET_RECOVERY_HINT}",
             on_new.join(", ")
         ));
-        // Gated on the MIGRATION, not on liveness: `on_new` says hosts are serving
-        // the new release, which is a different question. An all-first-deploy fleet
-        // schedules no migration at all, and the same run's header says so out loud
-        // ("run `autumn migrate` yourself before serving traffic") — asserting the
-        // schema moved here would negate that instruction on the last line before
-        // the green one.
-        if schema_moved(plan, outcomes) {
+    }
+    // The binaries-versus-schema truth, said once, in whichever tense is TRUE.
+    //
+    // The question the operator needs answered is never "did the fleet compensate"
+    // — it is "the schema is at the new release; where are the binaries?". So the
+    // migration is the gate, and the fleet's shape only picks the sentence:
+    //
+    // * some host is still forward — a rollback from here restores binaries only;
+    // * the fleet undid hosts itself — that rollback restored binaries only;
+    // * nothing is forward and nothing was compensated — the migrating host tore
+    //   its own candidate down (a pre-boundary failure AFTER `migrate`), so every
+    //   binary went back on its own and the schema stayed put. This last case used
+    //   to print NOTHING at all, which is the worst of the three to be silent about.
+    //
+    // Gating on the migration and not on liveness also keeps an all-first-deploy
+    // fleet silent: it schedules no migration, and the same run's header already
+    // told the operator to run `autumn migrate` themselves — asserting the schema
+    // moved here would negate that instruction on the last line before the green
+    // one.
+    if schema_moved(plan, outcomes) {
+        if !on_new.is_empty() {
             lines.push(format!("  \u{26A0}\u{FE0F}  {FLEET_SCHEMA_MOVED_NOTE}"));
         }
-    }
-    // Say the binaries-only truth once the fleet has ACTUALLY undone hosts: at that
-    // point the operator is looking at a fleet back on the old release with a schema
-    // that is not.
-    let compensated = outcomes.iter().any(|outcome| {
-        matches!(
-            outcome,
-            HostOutcome::CompensatedRollback
-                | HostOutcome::CompensatedTeardown
-                | HostOutcome::CompensationFailed { .. }
-        )
-    });
-    if compensated && schema_moved(plan, outcomes) {
-        lines.push(format!(
-            "  \u{26A0}\u{FE0F}  {FLEET_SCHEMA_NOT_ROLLED_BACK_NOTE}"
-        ));
+        // Only hosts the fleet actually PUT BACK count as compensated: a
+        // `CompensationFailed` host is still on the new release (it is in `on_new`
+        // above), so on its own it restored no binaries and the note would be false.
+        let compensated = outcomes.iter().any(|outcome| {
+            matches!(
+                outcome,
+                HostOutcome::CompensatedRollback | HostOutcome::CompensatedTeardown
+            )
+        });
+        if compensated {
+            lines.push(format!(
+                "  \u{26A0}\u{FE0F}  {FLEET_SCHEMA_NOT_ROLLED_BACK_NOTE}"
+            ));
+        } else if on_new.is_empty() && outcomes.iter().any(HostOutcome::went_back) {
+            // `on_new_release()` and `went_back()` partition every touched host, and
+            // `schema_moved` proves at least one host was touched — so the second
+            // half of this condition is implied by the first; it is spelled out so
+            // the sentence below ("the binaries went back") is read off the outcomes
+            // rather than inferred from them.
+            lines.push(format!(
+                "  \u{26A0}\u{FE0F}  {FLEET_SCHEMA_AHEAD_OF_BINARIES_NOTE}"
+            ));
+        }
     }
     lines
 }
@@ -3114,6 +3187,147 @@ mod tests {
             migrated.contains(FLEET_SCHEMA_MOVED_NOTE),
             "the migrating fleet DID move the schema and must say so:\n{migrated}"
         );
+    }
+
+    #[test]
+    fn the_summary_states_the_schema_truth_when_the_migrating_host_rolls_itself_back() {
+        // #1621: the fleet's single migration runs on the FIRST redeploy host, and a
+        // pre-boundary failure AFTER it (a `readiness-gate` timeout, say) tears that
+        // host's own candidate down — no fleet compensation is involved, and every
+        // later host stays untouched. That leaves the whole fleet on the PREVIOUS
+        // binaries against the NEW schema, which is exactly the state an operator
+        // must be told about; before this test the summary said nothing at all,
+        // because one note was gated on a host being on the new release and the
+        // other on fleet compensation having run.
+        let fleet = fleet_of(&["web-a", "web-b", "web-c"]);
+        let plan = plan_fleet(
+            &fleet,
+            &[HostMode::Redeploy, HostMode::Redeploy, HostMode::Redeploy],
+        )
+        .expect("a well-formed fleet plans");
+        assert_eq!(
+            plan.hosts[0].migrate,
+            MigrateStep::Run,
+            "the fleet migration lands on the first redeploy host"
+        );
+        let outcomes = [
+            HostOutcome::RolledBack {
+                failed_step: "readiness-gate",
+            },
+            HostOutcome::Untouched,
+            HostOutcome::Untouched,
+        ];
+        assert!(
+            schema_moved(&plan, &outcomes),
+            "the migrating host was reached, so the schema moved"
+        );
+        let rendered = fleet_summary_lines(&plan, &outcomes, "20260714T120000Z").join("\n");
+
+        assert!(
+            rendered.contains(FLEET_SCHEMA_AHEAD_OF_BINARIES_NOTE),
+            "the migration ran and every binary went back, so the summary must say the \
+             schema did NOT come back with them:\n{rendered}"
+        );
+        // …in the wording that is TRUE here: nothing was compensated (the host tore
+        // its own candidate down), and nothing is on the new release.
+        assert!(
+            !rendered.contains(FLEET_SCHEMA_NOT_ROLLED_BACK_NOTE)
+                && !rendered.contains(FLEET_SCHEMA_MOVED_NOTE),
+            "no compensation ran and no host is forward, so neither of those notes is \
+             true here:\n{rendered}"
+        );
+        assert!(
+            !rendered.contains(FLEET_RECOVERY_HINT),
+            "no host is on the new release, so there is nothing to roll back:\n{rendered}"
+        );
+    }
+
+    #[test]
+    fn exactly_one_schema_note_speaks_for_every_outcome_mix() {
+        // #1621: the three schema notes describe the SAME fact in three different
+        // states of the fleet, so two rules hold across every mix: whenever the
+        // migration ran, at least one of them speaks (the hole this pins shut), and
+        // the "nothing is forward" note never appears next to either the recovery
+        // hint or the compensation note, whose sentences would contradict it.
+        let fleet = fleet_of(&["web-a", "web-b", "web-c"]);
+        let plan = plan_fleet(
+            &fleet,
+            &[HostMode::Redeploy, HostMode::Redeploy, HostMode::Redeploy],
+        )
+        .expect("a well-formed fleet plans");
+        let readiness = "readiness-gate";
+        let mixes: [[HostOutcome; 3]; 7] = [
+            // The migrating host tears its own candidate down.
+            [
+                HostOutcome::RolledBack {
+                    failed_step: readiness,
+                },
+                HostOutcome::Untouched,
+                HostOutcome::Untouched,
+            ],
+            // A later host fails and the fleet compensates the migrating one.
+            [
+                HostOutcome::CompensatedRollback,
+                HostOutcome::RolledBack {
+                    failed_step: readiness,
+                },
+                HostOutcome::Untouched,
+            ],
+            // Compensation itself failed: that host is STILL on the new release.
+            [
+                HostOutcome::CompensationFailed {
+                    failed_step: "proxy-flip-back",
+                },
+                HostOutcome::RolledBack {
+                    failed_step: readiness,
+                },
+                HostOutcome::Untouched,
+            ],
+            // Partly compensated, partly stranded.
+            [
+                HostOutcome::CompensatedRollback,
+                HostOutcome::AmbiguousMarkers,
+                HostOutcome::Untouched,
+            ],
+            // Halted with hosts left forward, no compensation attempted.
+            [
+                HostOutcome::Serving,
+                HostOutcome::RolledBack {
+                    failed_step: readiness,
+                },
+                HostOutcome::Untouched,
+            ],
+            // A degraded but complete rollout.
+            [
+                HostOutcome::Serving,
+                HostOutcome::Degraded { label: "prune" },
+                HostOutcome::Serving,
+            ],
+            // Nothing was reached at all: no migration, no schema claim.
+            [
+                HostOutcome::Untouched,
+                HostOutcome::Untouched,
+                HostOutcome::Untouched,
+            ],
+        ];
+
+        for mix in &mixes {
+            let rendered = fleet_summary_lines(&plan, mix, "20260714T120000Z").join("\n");
+            let moved = rendered.contains(FLEET_SCHEMA_MOVED_NOTE);
+            let not_rolled_back = rendered.contains(FLEET_SCHEMA_NOT_ROLLED_BACK_NOTE);
+            let ahead = rendered.contains(FLEET_SCHEMA_AHEAD_OF_BINARIES_NOTE);
+            assert_eq!(
+                schema_moved(&plan, mix),
+                moved || not_rolled_back || ahead,
+                "the summary must state the schema truth exactly when the migration ran \
+                 ({mix:?}):\n{rendered}"
+            );
+            assert!(
+                !(ahead && (moved || not_rolled_back || rendered.contains(FLEET_RECOVERY_HINT))),
+                "\"nothing is forward\" cannot share a summary with a note that says \
+                 something is ({mix:?}):\n{rendered}"
+            );
+        }
     }
 
     #[test]

--- a/autumn-cli/src/deploy/fleet.rs
+++ b/autumn-cli/src/deploy/fleet.rs
@@ -1628,19 +1628,42 @@ pub(crate) fn fleet_status_lines(hosts: &[HostStatus], report: &DriftReport) -> 
 /// is REPORTED, never compensated.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum MaintenanceOutcome {
-    /// Both flag paths written/removed (amendment A2: the shared authoritative
-    /// path AND the release-local legacy path for units deployed before #1621).
+    /// The file the host's RUNNING slot unit polls was written/removed — either it
+    /// IS the shared authoritative path (a #1621 unit), or its own path was written
+    /// alongside the shared one (amendment A2, for a unit deployed before #1621).
     Applied,
-    /// Only the shared path was written/removed: the host's `current` symlink did
-    /// not resolve, so there is no release dir to carry the legacy flag. Fine for
-    /// a host already redeployed with #1621 units; noted so the operator knows.
+    /// Only the shared path was written/removed, and that is the whole job: no
+    /// release is promoted on this host, so no running unit polls anything else.
     AppliedSharedOnly,
-    /// The change failed on this host at this step. Never swallowed, and never a
-    /// shell line — the label only.
+    /// The shared (authoritative) flag WAS written/removed, but the file the host's
+    /// RUNNING unit polls was NOT: its unit could not be read, or the write to that
+    /// path failed (issue #1621, review round 3).
+    ///
+    /// **Counts as a failure** even though the host did change. A pre-#1621 unit
+    /// ignores the shared flag entirely, so `on` here may leave the application
+    /// serving traffic and `off` may leave it maintained — reporting either as
+    /// success is the lie this variant exists to prevent.
+    LiveUnitUnchanged {
+        /// Label of the step that could not be proved or failed.
+        failed_step: &'static str,
+    },
+    /// The change failed on this host at this step, before anything was written.
+    /// Never swallowed, and never a shell line — the label only.
     Failed {
         /// Label of the op that failed.
         failed_step: &'static str,
     },
+}
+
+impl MaintenanceOutcome {
+    /// Whether this host counts as a failure for the exit code.
+    ///
+    /// Fails CLOSED: a host whose running unit's flag could not be proved counts as
+    /// failed even though its shared flag changed, because the application may not
+    /// have observed the change at all.
+    pub(crate) const fn failed(self) -> bool {
+        matches!(self, Self::Failed { .. } | Self::LiveUnitUnchanged { .. })
+    }
 }
 
 /// The per-host table printed at the end of a `deploy maintenance on|off` fan-out.
@@ -1662,9 +1685,22 @@ pub(crate) fn fleet_maintenance_summary_lines(
             MaintenanceOutcome::AppliedSharedOnly => (
                 "\u{26A0}\u{FE0F} ",
                 format!(
-                    "maintenance {verb} (shared flag only \u{2014} no `current` release \
-                     resolved on this host, so the release-local flag for pre-#1621 units \
-                     was skipped)"
+                    "maintenance {verb} (shared flag only \u{2014} no release is promoted on \
+                     this host, so no running unit polls a release-local flag)"
+                ),
+            ),
+            MaintenanceOutcome::LiveUnitUnchanged { failed_step } => (
+                "\u{274C}",
+                format!(
+                    "PARTIAL \u{2014} shared flag {written}, but the file this host's RUNNING \
+                     unit polls was NOT (failed at `{failed_step}`), so this host may still \
+                     be {state}",
+                    written = if on { "written" } else { "removed" },
+                    state = if on {
+                        "serving traffic"
+                    } else {
+                        "in maintenance"
+                    },
                 ),
             ),
             MaintenanceOutcome::Failed { failed_step } => (
@@ -1679,13 +1715,17 @@ pub(crate) fn fleet_maintenance_summary_lines(
     let changed: Vec<&str> = hosts
         .iter()
         .zip(outcomes)
-        .filter(|(_, outcome)| !matches!(outcome, MaintenanceOutcome::Failed { .. }))
+        // Only the hosts that are DONE. A partially-changed host is named on the
+        // failed side instead, and its own row spells out that its shared flag did
+        // change — listing it as simply "changed" would read as "this host is
+        // maintained", which is the one thing it is not known to be.
+        .filter(|(_, outcome)| !outcome.failed())
         .map(|(host, _)| host.as_str())
         .collect();
     let failed: Vec<&str> = hosts
         .iter()
         .zip(outcomes)
-        .filter(|(_, outcome)| matches!(outcome, MaintenanceOutcome::Failed { .. }))
+        .filter(|(_, outcome)| outcome.failed())
         .map(|(host, _)| host.as_str())
         .collect();
     if !failed.is_empty() && !changed.is_empty() {

--- a/autumn-cli/src/deploy/fleet.rs
+++ b/autumn-cli/src/deploy/fleet.rs
@@ -547,18 +547,85 @@ pub(crate) fn fleet_rollback_set(
 /// Secrets discipline is load-bearing here: `DeployExecError`'s own `Display` is
 /// already redacted, but the fleet error/summary types quote only labels and host
 /// names, never a formatted source error.
-pub(crate) const fn failed_step_label(err: &exec::DeployExecError) -> &'static str {
+pub(crate) fn failed_step_label(err: &exec::DeployExecError) -> &'static str {
     match err {
         exec::DeployExecError::CommandFailed { label, .. } => label,
         exec::DeployExecError::CandidateRolledBack { failed_step, .. }
         | exec::DeployExecError::FirstDeployTornDown { failed_step, .. }
         | exec::DeployExecError::RollbackFailed { failed_step, .. } => failed_step,
+        // The post-cutover wrapper is a CLASSIFIER input, not a reporting one: it
+        // adds the op that was running, while the operator-facing step label stays
+        // exactly what the underlying failure would have reported on its own. A
+        // dropped transport is still attributed to the transport, never to a
+        // fabricated step (see `attributed_step_label` for the other question).
+        exec::DeployExecError::PostCutover { source, .. } => failed_step_label(source),
         exec::DeployExecError::UploadFailed { .. } => "upload",
         exec::DeployExecError::Stage { .. } => "stage-local-file",
         exec::DeployExecError::Spawn { .. } => "ssh-transport",
         exec::DeployExecError::PreflightAborted { .. } => "preflight",
         exec::DeployExecError::ProxyIncompatible { .. } => "proxy-compat-probe",
         exec::DeployExecError::NoPreviousRelease => "resolve-previous",
+    }
+}
+
+/// The label of the op that was actually RUNNING when this failure landed, when
+/// the error proves one — `None` when nothing does (issue #1621, §4.6).
+///
+/// Deliberately not the same question as [`failed_step_label`], which always
+/// answers something so it can be printed. Several executor errors name no op at
+/// all ([`exec::DeployExecError::Spawn`] and friends are raised by the local
+/// transport, not by a step), and post-boundary that distinction decides whether a
+/// host may be touched — so it is asked explicitly rather than inferred from a
+/// synthesized label string.
+///
+/// [`exec::execute_with_teardown`] attaches the op label to every failure past a
+/// known go-live boundary, which is what makes this answerable for the error shapes
+/// that carry none of their own.
+const fn attributed_step_label(err: &exec::DeployExecError) -> Option<&'static str> {
+    match err {
+        exec::DeployExecError::CommandFailed { label, .. } => Some(label),
+        exec::DeployExecError::PostCutover { failed_step, .. }
+        | exec::DeployExecError::CandidateRolledBack { failed_step, .. }
+        | exec::DeployExecError::FirstDeployTornDown { failed_step, .. }
+        | exec::DeployExecError::RollbackFailed { failed_step, .. } => Some(failed_step),
+        exec::DeployExecError::Spawn { .. }
+        | exec::DeployExecError::UploadFailed { .. }
+        | exec::DeployExecError::Stage { .. }
+        | exec::DeployExecError::PreflightAborted { .. }
+        | exec::DeployExecError::ProxyIncompatible { .. }
+        | exec::DeployExecError::NoPreviousRelease => None,
+    }
+}
+
+/// The post-boundary class for one executor ERROR, rather than for a bare label
+/// (issue #1621, §4.6).
+///
+/// [`classify_post_boundary`] answers "how bad is a failure of THIS op", which is
+/// the right question only when the op is known. Attribution is then used in
+/// exactly one direction — it can make the verdict more conservative, never less:
+///
+/// * **`commit-markers` always wins.** The marker triple is written as one remote
+///   transaction, so any failure inside it leaves the rollback target unprovable —
+///   whether it arrived as a non-zero remote exit or as a dropped transport that
+///   never launched the command. Keying that guard on the error shape is how a host
+///   gets auto-rolled-back onto a stale `shared/previous-release` target.
+/// * **A label-less failure never DOWNGRADES to housekeeping.** A transport that
+///   dropped during `drain-old` is not proof that only bookkeeping broke: the deploy
+///   host can no longer talk to this host at all, so nothing about it is provable
+///   and it stays [`PostBoundaryClass::Functional`] — halt and compensate — exactly
+///   as it does today.
+/// * **An unattributable failure fails CLOSED.** If nothing names the op, we cannot
+///   say which post-cutover step broke, which is precisely when the rollback target
+///   is least provable — so decline to touch the host
+///   ([`PostBoundaryClass::Ambiguous`]) rather than compensate it blind.
+fn post_boundary_class(err: &exec::DeployExecError, reported_label: &str) -> PostBoundaryClass {
+    match attributed_step_label(err) {
+        // The marker transaction (whatever error shape carried the failure), or a
+        // failure that names no op at all: both leave the rollback target unprovable.
+        Some(AMBIGUOUS_MARKERS_LABEL) | None => PostBoundaryClass::Ambiguous,
+        // Otherwise today's policy, keyed on the label the failure REPORTS — so a
+        // label-less transport error is never waved through as housekeeping.
+        Some(_) => classify_post_boundary(reported_label),
     }
 }
 
@@ -570,7 +637,7 @@ pub(crate) const fn failed_step_label(err: &exec::DeployExecError) -> &'static s
 /// `execute_with_teardown` returns the raw error precisely when the failure landed
 /// *after* the go-live boundary (or when the boundary could not be located, in
 /// which case it deliberately refuses to guess).
-pub(crate) const fn classify_failure(err: &exec::DeployExecError) -> HostOutcome {
+pub(crate) fn classify_failure(err: &exec::DeployExecError) -> HostOutcome {
     match err {
         exec::DeployExecError::CandidateRolledBack { failed_step, .. } => {
             HostOutcome::RolledBack { failed_step }
@@ -590,12 +657,13 @@ pub(crate) const fn classify_failure(err: &exec::DeployExecError) -> HostOutcome
 /// Kept as its own function — rather than folded into [`classify_failure`] —
 /// because the two questions have different inputs and different failure modes.
 /// `classify_failure` reads the executor's TYPED error and is the discriminator
-/// AC-3 turns on; this one reads a LABEL and encodes a policy about which
-/// post-cutover steps matter. A pre-boundary outcome passes through untouched: the
-/// executor already tore that candidate down, so there is nothing left to classify.
+/// AC-3 turns on; this one encodes a policy about which post-cutover steps matter
+/// (see [`post_boundary_class`] for how the failing op is attributed). A
+/// pre-boundary outcome passes through untouched: the executor already tore that
+/// candidate down, so there is nothing left to classify.
 pub(crate) fn classify_host_outcome(err: &exec::DeployExecError) -> HostOutcome {
     match classify_failure(err) {
-        HostOutcome::LiveOnNew { failed_step } => match classify_post_boundary(failed_step) {
+        HostOutcome::LiveOnNew { failed_step } => match post_boundary_class(err, failed_step) {
             PostBoundaryClass::Housekeeping => HostOutcome::Degraded { label: failed_step },
             PostBoundaryClass::Ambiguous => HostOutcome::AmbiguousMarkers,
             PostBoundaryClass::Functional => HostOutcome::LiveOnNew { failed_step },
@@ -613,6 +681,22 @@ pub(crate) fn classify_host_outcome(err: &exec::DeployExecError) -> HostOutcome 
 /// absence of a `migrate` line.
 pub(crate) const FLEET_NO_MIGRATION_NOTE: &str = "no host in this fleet is on a previous release, so this rollout runs NO migrations \
      (a first deploy never does) — run `autumn migrate` yourself before serving traffic";
+
+/// The loud line printed when first-deploy hosts sit AHEAD of the fleet's single
+/// migration in rollout order (issue #1621, AC-4).
+///
+/// [`migrate_placement`] puts the migration on the first host whose probed mode is
+/// `Redeploy` — a first-deploy host has no live release to keep serving if the
+/// migration fails, so it is the wrong place for it. The consequence is that any
+/// first deploy listed BEFORE that host runs [`exec::first_deploy_ops`] (which
+/// carries no migrate op) and goes live on the new release while the schema is
+/// still the old one. Declaration order is a documented contract — the guide tells
+/// operators to order the list themselves — so the rollout is not silently
+/// reordered; the hazard is named, with the hosts it applies to and the one-line
+/// remedy.
+pub(crate) const FLEET_FIRST_BEFORE_MIGRATE_NOTE: &str = "go live on the new release BEFORE the migration runs (a first deploy never migrates) \
+     — if this release needs the new schema they will serve against the old one until \
+     the migrating host is reached; list an already-deployed host first to avoid it";
 
 /// The one-line reminder printed once, after the fleet's single migration lands.
 pub(crate) const FLEET_SCHEMA_MOVED_NOTE: &str = "the schema has moved; from here an automatic rollback restores BINARIES only — \
@@ -724,6 +808,22 @@ pub(crate) fn fleet_rollout_lines(
                 migrating.host,
                 skipped.join(", "),
             ));
+            // Hosts listed AHEAD of the migrating one that are first deploys cut over
+            // before the schema moves (AC-4). Named rather than reordered — see
+            // `FLEET_FIRST_BEFORE_MIGRATE_NOTE`.
+            let before_migration: Vec<&str> = plan
+                .hosts
+                .iter()
+                .take_while(|h| h.host != migrating.host)
+                .filter(|h| h.mode == HostMode::First)
+                .map(|h| h.host.as_str())
+                .collect();
+            if writable_db_configured && !before_migration.is_empty() {
+                lines.push(format!(
+                    "  \u{26A0}\u{FE0F}  {} {FLEET_FIRST_BEFORE_MIGRATE_NOTE}",
+                    before_migration.join(", "),
+                ));
+            }
         }
         None if writable_db_configured => {
             lines.push(format!("  \u{26A0}\u{FE0F}  {FLEET_NO_MIGRATION_NOTE}"));
@@ -848,7 +948,15 @@ pub(crate) fn fleet_summary_lines(
             "  On {release_id}: {}. {FLEET_RECOVERY_HINT}",
             on_new.join(", ")
         ));
-        lines.push(format!("  \u{26A0}\u{FE0F}  {FLEET_SCHEMA_MOVED_NOTE}"));
+        // Gated on the MIGRATION, not on liveness: `on_new` says hosts are serving
+        // the new release, which is a different question. An all-first-deploy fleet
+        // schedules no migration at all, and the same run's header says so out loud
+        // ("run `autumn migrate` yourself before serving traffic") — asserting the
+        // schema moved here would negate that instruction on the last line before
+        // the green one.
+        if schema_moved(plan, outcomes) {
+            lines.push(format!("  \u{26A0}\u{FE0F}  {FLEET_SCHEMA_MOVED_NOTE}"));
+        }
     }
     // Say the binaries-only truth once the fleet has ACTUALLY undone hosts: at that
     // point the operator is looking at a fleet back on the old release with a schema
@@ -899,6 +1007,20 @@ pub(crate) enum ReleaseId {
 /// surfaces it before then.)
 pub(crate) const DRIFT_LIVE_SLOT_MARKER: &str =
     "live-slot marker disagrees with the slot kamal-proxy is serving";
+
+/// State drift: this host has no release deployed at all, while the rest of the
+/// fleet is serving one (issue #1621, AC-6).
+///
+/// Deliberately NOT version drift — [`ReleaseId::Unknown`] never contributes to
+/// that, and it must not start to. This is a different question: `HostMode::First`
+/// is a PROVEN absence (the probe shell tests `[ -L current ]`, so even a dangling
+/// symlink reports `Redeploy`), so a fleet whose peers are serving a release has a
+/// host that is carrying none of the traffic the operator provisioned it for. That
+/// is exactly the state the standing `deploy status --strict` alert exists to catch
+/// — a compensated first deploy, or a host added to `[deploy] hosts` and never
+/// deployed.
+pub(crate) const DRIFT_HOST_NOT_DEPLOYED: &str = "no release is deployed on this host while the rest of the fleet is serving one — it is \
+     carrying no traffic (deploy it with `autumn deploy up`)";
 
 /// State drift: the `shared/proxy-options` marker exists but cannot be parsed.
 ///
@@ -1091,8 +1213,20 @@ pub(crate) fn fleet_drift(hosts: &[HostStatus]) -> DriftReport {
         }
     }
 
+    // Whether ANY reachable host proved it is serving a release — the peer a
+    // not-deployed host is judged against.
+    let any_release_deployed = hosts
+        .iter()
+        .any(|status| status.reachable && matches!(status.release, ReleaseId::Known(_)));
+
     let mut state_drift: Vec<(String, &'static str)> = Vec::new();
     for status in hosts.iter().filter(|status| status.reachable) {
+        // A PROVEN absence, judged against the fleet: nothing is deployed here while
+        // a peer is serving a release. A fleet that has never been deployed at all
+        // has no peer to be out of step with, so it stays silent.
+        if status.mode == Some(HostMode::First) && any_release_deployed {
+            state_drift.push((status.host.clone(), DRIFT_HOST_NOT_DEPLOYED));
+        }
         if status.live_slot_marker_drift {
             state_drift.push((status.host.clone(), DRIFT_LIVE_SLOT_MARKER));
         }
@@ -1231,13 +1365,32 @@ pub(crate) fn fleet_status_lines(hosts: &[HostStatus], report: &DriftReport) -> 
     }
     let unknown = report.unknown_releases();
     if !unknown.is_empty() {
-        // Named, and explicitly NOT called drift — the evidence matters more than
-        // the verdict here.
-        lines.push(format!(
-            "  \u{2139}\u{FE0F}  release unknown on {} (the `current` symlink was unreadable) \
-             \u{2014} reported, not counted as drift.",
-            unknown.join(", "),
-        ));
+        // Two different facts, deliberately split: a host that reported
+        // `HostMode::First` PROVED it has no `current` symlink, while every other
+        // unknown really is "we could not read it". Describing the first as an
+        // unreadable symlink sends the operator to inspect something that was never
+        // there.
+        let (not_deployed, unreadable): (Vec<&str>, Vec<&str>) = unknown.iter().partition(|host| {
+            hosts.iter().any(|status| {
+                status.host == **host && status.reachable && status.mode == Some(HostMode::First)
+            })
+        });
+        if !not_deployed.is_empty() {
+            lines.push(format!(
+                "  \u{2139}\u{FE0F}  no release deployed on {} \u{2014} nothing is installed \
+                 there yet.",
+                not_deployed.join(", "),
+            ));
+        }
+        if !unreadable.is_empty() {
+            // Named, and explicitly NOT called drift — the evidence matters more than
+            // the verdict here.
+            lines.push(format!(
+                "  \u{2139}\u{FE0F}  release unknown on {} (the `current` symlink was unreadable) \
+                 \u{2014} reported, not counted as drift.",
+                unreadable.join(", "),
+            ));
+        }
     }
     for (host, reason) in &report.state_drift {
         lines.push(format!("  \u{26A0}\u{FE0F}  {host}: {reason}"));
@@ -2113,6 +2266,63 @@ mod tests {
     }
 
     #[test]
+    fn the_rollout_header_warns_when_first_deploys_cut_over_before_the_migration() {
+        // #1621 (AC-4): the migration lands on the first REDEPLOY host in rollout
+        // order, so every first-deploy host listed ahead of it goes live on the new
+        // release before the schema moves — `first_deploy_ops` carries no migrate op.
+        // Declaration order is a documented contract and reordering it silently would
+        // be worse, so the hazard is said out loud, naming the hosts it applies to.
+        let fleet = fleet_of(&["10.0.0.2", "10.0.0.3", "10.0.0.1"]);
+        let plan = plan_fleet(
+            &fleet,
+            &[HostMode::First, HostMode::First, HostMode::Redeploy],
+        )
+        .expect("a well-formed fleet plans");
+
+        let warned = fleet_rollout_lines(&plan, "20260714T120000Z", true).join("\n");
+        assert!(
+            warned.contains(FLEET_FIRST_BEFORE_MIGRATE_NOTE),
+            "hosts that cut over before the fleet's only migration must be warned \
+             about:\n{warned}"
+        );
+        assert!(
+            warned.contains("10.0.0.2, 10.0.0.3") && !warned.contains("10.0.0.1 go live"),
+            "the warning must name exactly the hosts ahead of the migrating one:\n{warned}"
+        );
+        let quiet = fleet_rollout_lines(&plan, "20260714T120000Z", false).join("\n");
+        assert!(
+            !quiet.contains(FLEET_FIRST_BEFORE_MIGRATE_NOTE),
+            "an app with no writable database has no schema to be behind:\n{quiet}"
+        );
+
+        // The mixed fleet whose migrating host runs FIRST is silent: nothing goes
+        // live before the schema moves, which is what AC-4 asks for.
+        let ordered = plan_fleet(
+            &fleet,
+            &[HostMode::Redeploy, HostMode::First, HostMode::First],
+        )
+        .expect("a well-formed fleet plans");
+        let silent = fleet_rollout_lines(&ordered, "20260714T120000Z", true).join("\n");
+        assert!(
+            !silent.contains(FLEET_FIRST_BEFORE_MIGRATE_NOTE),
+            "the migration runs before any cutover here — there is nothing to \
+             warn about:\n{silent}"
+        );
+        // …and so is an all-redeploy fleet, whose every host waits for the migration.
+        let all_redeploy = plan_fleet(
+            &fleet,
+            &[HostMode::Redeploy, HostMode::Redeploy, HostMode::Redeploy],
+        )
+        .expect("a well-formed fleet plans");
+        assert!(
+            !fleet_rollout_lines(&all_redeploy, "20260714T120000Z", true)
+                .join("\n")
+                .contains(FLEET_FIRST_BEFORE_MIGRATE_NOTE),
+            "no first deploy, no pre-migration cutover"
+        );
+    }
+
+    #[test]
     fn an_all_first_deploy_fleet_warns_only_when_a_database_is_configured() {
         // #1621 (AC-4): `first_deploy_ops` carries no migrate op, so an
         // all-first-deploy fleet migrates NOWHERE — today's documented single-host
@@ -2286,6 +2496,67 @@ mod tests {
                 failed_step: "readiness-gate"
             },
             "a pre-boundary outcome is already clean and must pass through unrefined"
+        );
+    }
+
+    #[test]
+    fn a_post_boundary_failure_is_classified_by_the_op_that_was_running() {
+        // #1621 (§4.6). The never-auto-roll-back guard is about an OP, not about an
+        // error shape. `DeployExecError::Spawn` carries no label of its own, so
+        // before `execute_with_teardown` attached one a dropped transport during
+        // `commit-markers` classified as Functional and the host was auto-rolled-back
+        // onto whatever `shared/previous-release` still named — a marker the failed
+        // command never rewrote.
+        let transport = || {
+            Box::new(exec::DeployExecError::Spawn {
+                program: "ssh".to_owned(),
+                source: std::io::Error::other("scripted"),
+            })
+        };
+        assert_eq!(
+            classify_host_outcome(&exec::DeployExecError::PostCutover {
+                failed_step: "commit-markers",
+                source: transport(),
+            }),
+            HostOutcome::AmbiguousMarkers,
+            "a transport that dropped during `commit-markers` leaves the marker triple \
+             exactly as unprovable as a non-zero exit does — it must fail closed too"
+        );
+        // Attribution only ever makes the verdict MORE conservative. A transport that
+        // dropped during housekeeping is not proof that only bookkeeping broke: the
+        // deploy host can no longer talk to this host at all, so it stays Functional.
+        assert_eq!(
+            classify_host_outcome(&exec::DeployExecError::PostCutover {
+                failed_step: "drain-old",
+                source: transport(),
+            }),
+            HostOutcome::LiveOnNew {
+                failed_step: "ssh-transport"
+            },
+            "a dropped transport must never be waved through as harmless housekeeping"
+        );
+        // …and a housekeeping op that really did report its own failure still degrades.
+        assert_eq!(
+            classify_host_outcome(&exec::DeployExecError::PostCutover {
+                failed_step: "prune",
+                source: Box::new(exec::DeployExecError::CommandFailed {
+                    label: "prune",
+                    message: "scripted".to_owned(),
+                }),
+            }),
+            HostOutcome::Degraded { label: "prune" },
+            "a remote `prune` failure is still bookkeeping — the rollout continues"
+        );
+        // Nothing names the failing op: we cannot say WHICH post-cutover step broke,
+        // which is exactly when the rollback target is least provable. Fail closed to
+        // "do not touch this host" rather than compensating it blind.
+        assert_eq!(
+            classify_host_outcome(&exec::DeployExecError::Spawn {
+                program: "ssh".to_owned(),
+                source: std::io::Error::other("scripted"),
+            }),
+            HostOutcome::AmbiguousMarkers,
+            "an unattributable post-boundary failure must decline the automatic rollback"
         );
     }
 
@@ -2476,6 +2747,35 @@ mod tests {
         assert!(
             !rendered.contains(FLEET_SCHEMA_NOT_ROLLED_BACK_NOTE),
             "no migration ran, so there is no schema statement to make:\n{rendered}"
+        );
+        // …and neither must the SUCCESS path. An all-first-deploy fleet is the shape
+        // the header warns runs NO migrations ("run `autumn migrate` yourself before
+        // serving traffic"); ending the same run with "the schema has moved" negates
+        // that instruction on the last line the operator reads before the green one.
+        let served = fleet_summary_lines(
+            &first_only,
+            &[HostOutcome::Serving, HostOutcome::Serving],
+            "20260714T120000Z",
+        )
+        .join("\n");
+        assert!(
+            !served.contains(FLEET_SCHEMA_MOVED_NOTE),
+            "a rollout that scheduled no migration must never claim the schema moved:\n{served}"
+        );
+        assert!(
+            served.contains(FLEET_RECOVERY_HINT),
+            "the recovery lever is still named — hosts ARE on the new release:\n{served}"
+        );
+        // The note is still printed where it is true: a fleet that did migrate.
+        let migrated = fleet_summary_lines(
+            &migrating,
+            &[HostOutcome::Serving, HostOutcome::Serving],
+            "20260714T120000Z",
+        )
+        .join("\n");
+        assert!(
+            migrated.contains(FLEET_SCHEMA_MOVED_NOTE),
+            "the migrating fleet DID move the schema and must say so:\n{migrated}"
         );
     }
 
@@ -2756,6 +3056,60 @@ mod tests {
         // A clean fleet reports nothing at all.
         let clean = fleet_drift(&[status("web-a", Some("r1")), status("web-b", Some("r1"))]);
         assert!(!clean.drifted() && clean.state_drift.is_empty());
+    }
+
+    #[test]
+    fn fleet_drift_flags_a_host_that_is_not_deployed_at_all() {
+        // #1621 (AC-6). A host the probe proved has NO `current` symlink is not
+        // "unknown", it is empty: `HostMode::First` is a positive fact (the probe
+        // shell tests `[ -L current ]`, and even a dangling symlink takes the
+        // redeploy branch). Folding it into `ReleaseId::Unknown` made `--strict`
+        // exit 0 on a fleet running a fraction of its capacity — the documented cron
+        // alert never fired — and blamed an "unreadable symlink" that was never there.
+        let mut not_deployed = status("web-b", None);
+        not_deployed.mode = Some(HostMode::First);
+        let report = fleet_drift(&[status("web-a", Some("r1")), not_deployed.clone()]);
+        assert!(
+            !report.version_drift,
+            "one known release is still not VERSION drift — this is a separate signal"
+        );
+        assert_eq!(
+            report.state_drift,
+            vec![("web-b".to_owned(), DRIFT_HOST_NOT_DEPLOYED)],
+            "a host carrying no release while its peers serve one is drift"
+        );
+        assert!(
+            report.drifted(),
+            "`deploy status --strict` must exit non-zero on it"
+        );
+
+        // A fleet where NOTHING is deployed yet is not drifted: there is no peer
+        // serving a release for it to be out of step with (the first `deploy up` of a
+        // brand-new fleet must not page anyone).
+        let mut second = status("web-a", None);
+        second.mode = Some(HostMode::First);
+        let fresh = fleet_drift(&[second, not_deployed.clone()]);
+        assert!(
+            !fresh.drifted() && fresh.state_drift.is_empty(),
+            "a fleet that has never been deployed is not drifted: {:?}",
+            fresh.state_drift
+        );
+
+        // The row and the footer must say what is actually true.
+        let rows = [status("web-a", Some("r1")), not_deployed];
+        let rendered = fleet_status_lines(&rows, &fleet_drift(&rows)).join("\n");
+        assert!(
+            rendered.contains(DRIFT_HOST_NOT_DEPLOYED),
+            "the drift reason must be named on the row:\n{rendered}"
+        );
+        assert!(
+            !rendered.contains("web-b, ") && rendered.contains("no release deployed on web-b"),
+            "a host that is not deployed must be described as such:\n{rendered}"
+        );
+        assert!(
+            !rendered.contains("`current` symlink was unreadable"),
+            "…and never blamed on a symlink that was never there:\n{rendered}"
+        );
     }
 
     #[test]

--- a/autumn-cli/src/deploy/fleet.rs
+++ b/autumn-cli/src/deploy/fleet.rs
@@ -144,7 +144,9 @@ impl FleetPlan {
 /// Planning is pure and **total**: it returns a typed refusal rather than
 /// panicking, because a panic here would abort a CLI process that may already
 /// have cut hosts over. The operator-facing fleet-wide refusals (`SQLite` fleet,
-/// media fleet, TLS fleet) are prologue concerns and land with the driver.
+/// media fleet, TLS fleet) are prologue concerns and live with the driver
+/// (`refuse_sqlite_fleet` and friends in `deploy.rs`), not here: they grade the
+/// project's CONFIG, while this grades the plan's internal consistency.
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
 pub(crate) enum FleetPlanError {
     /// The probe-mode list did not line up with the resolved host list — a caller
@@ -616,6 +618,15 @@ pub(crate) const FLEET_NO_MIGRATION_NOTE: &str = "no host in this fleet is on a 
 pub(crate) const FLEET_SCHEMA_MOVED_NOTE: &str = "the schema has moved; from here an automatic rollback restores BINARIES only — \
      it never rolls a migration back";
 
+/// The recovery lever named for every host the summary reports as still on the new
+/// release (issue #1621, §8.2).
+///
+/// Both halves matter: `--only <host>` is how a single stranded host is reversed
+/// without disturbing the ones that are fine, and the bare command is how a fleet
+/// that halted mid-rollout converges back onto one release.
+pub(crate) const FLEET_RECOVERY_HINT: &str = "Roll ONE back with `autumn deploy rollback --only <host>`, or the whole fleet with \
+     `autumn deploy rollback`.";
+
 /// The line the summary prints once a fleet rollout has actually COMPENSATED hosts
 /// after a migration ran (issue #1621, §4.7, T1.12).
 ///
@@ -650,10 +661,12 @@ pub(crate) fn schema_moved(plan: &FleetPlan, outcomes: &[HostOutcome]) -> bool {
 /// Printed for every [`RollbackAction::Manual`], because "we did not touch it" is
 /// only useful next to "here is what to look at". The command is read-only and
 /// carries nothing secret: an SSH user, a host, and the two marker paths the deploy
-/// already prints on every run. It does NOT tell the operator to run
-/// `autumn deploy rollback`: with a `[deploy] hosts` fleet that command has no
-/// single target today (per-host targeting lands with the fleet CLI surface), and
-/// printing a command that cannot work is worse than printing none.
+/// already prints on every run. It deliberately does NOT tell the operator to run
+/// `autumn deploy rollback --only <host>`, even though that command exists: every
+/// `MANUAL_*` reason is a case where the ROLLBACK TARGET ITSELF is in doubt (markers
+/// mid-transaction, target dir missing, target unprovable, no previous release), so
+/// pointing at the command that trusts that target is precisely the wrong advice.
+/// The markers come first; the command comes after a human has read them.
 pub(crate) fn manual_recovery_lines(cfg: &ResolvedDeployConfig, reason: &str) -> Vec<String> {
     let host = cfg.host.as_deref().unwrap_or_default();
     let shared = cfg.shared_dir();
@@ -817,8 +830,8 @@ pub(crate) fn fleet_summary_lines(
         .collect();
     if !on_new.is_empty() {
         lines.push(format!(
-            "  On {release_id}: {}. Roll a host back with `autumn deploy rollback`.",
-            on_new.join(", "),
+            "  On {release_id}: {}. {FLEET_RECOVERY_HINT}",
+            on_new.join(", ")
         ));
         lines.push(format!("  \u{26A0}\u{FE0F}  {FLEET_SCHEMA_MOVED_NOTE}"));
     }
@@ -838,6 +851,133 @@ pub(crate) fn fleet_summary_lines(
             "  \u{26A0}\u{FE0F}  {FLEET_SCHEMA_NOT_ROLLED_BACK_NOTE}"
         ));
     }
+    lines
+}
+
+// ── `--only`: the repair lever (issue #1621, §3.2) ───────────────────────────
+
+/// The loud warning printed whenever `--only` excludes a configured host.
+///
+/// `--only` is the lever an operator reaches for when one host is broken, and its
+/// whole purpose is to touch a SUBSET — which is, definitionally, the mixed-version
+/// fleet the rollout driver otherwise works so hard to prevent. Making that trade
+/// silently would train operators to leave fleets half-deployed; saying it out loud
+/// every single time is the point.
+pub(crate) const FLEET_ONLY_MIXED_WARNING: &str = "`--only` narrows this command to part of the fleet, so the hosts it skips keep \
+     running whatever they are running now — THE FLEET MAY END UP MIXED. This is a \
+     repair lever, not a faster deploy: finish with a full `autumn deploy up` (no \
+     `--only`) so every host converges on one release (#1621).";
+
+/// The warning block for a `--only` selection — empty when nothing was excluded.
+///
+/// Pure and total: an empty or full selection prints nothing, so an ordinary deploy
+/// (and every single-host deploy, which can never exclude anything) is byte-identical
+/// to pre-#1621.
+pub(crate) fn only_selection_warning_lines(
+    configured: &[String],
+    selected: &[String],
+) -> Vec<String> {
+    let skipped: Vec<&str> = configured
+        .iter()
+        .filter(|host| !selected.iter().any(|picked| picked == *host))
+        .map(String::as_str)
+        .collect();
+    if skipped.is_empty() {
+        return Vec::new();
+    }
+    vec![
+        format!("\u{26A0}\u{FE0F}  {FLEET_ONLY_MIXED_WARNING}"),
+        format!(
+            "   this run touches: {}",
+            selected
+                .iter()
+                .map(String::as_str)
+                .collect::<Vec<_>>()
+                .join(", "),
+        ),
+        format!("   left as they are: {}", skipped.join(", ")),
+        String::new(),
+    ]
+}
+
+// ── Fleet-wide `deploy rollback` (issue #1621, §3.2) ─────────────────────────
+
+/// What a fleet-wide rollback did to ONE host.
+///
+/// Only three states, because a fleet rollback is best-effort-continue: every host
+/// is attempted, and the interesting question afterwards is simply whether it came
+/// back, had nothing to come back to, or failed trying.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum RollbackOutcome {
+    /// The host is serving its previous release again.
+    RolledBack,
+    /// The host records no previous release, so there is nothing to roll back to —
+    /// a first deploy clears the marker, and a host just added to the fleet never
+    /// had one. Reported and SKIPPED: it is not a failure of this host's rollback,
+    /// and it must not stop the other hosts.
+    NoPreviousRelease,
+    /// The rollback was attempted on this host and failed at this step. Never
+    /// swallowed, and never a shell line — the label only.
+    Failed {
+        /// Label of the step that failed.
+        failed_step: &'static str,
+    },
+}
+
+/// The per-host table printed at the end of a fleet-wide rollback.
+///
+/// Printed on **every** exit path: after a partial rollback the operator's fleet is
+/// deliberately mixed, and this table is the only record of which half is which.
+pub(crate) fn fleet_rollback_summary_lines(
+    hosts: &[String],
+    outcomes: &[RollbackOutcome],
+) -> Vec<String> {
+    let mut lines = vec!["Fleet rollback state:".to_owned()];
+    let width = hosts.iter().map(|h| h.chars().count()).max().unwrap_or(0);
+    for (host, outcome) in hosts.iter().zip(outcomes) {
+        let (marker, state) = match outcome {
+            RollbackOutcome::RolledBack => {
+                ("\u{21A9}\u{FE0F} ", "previous release restored".to_owned())
+            }
+            RollbackOutcome::NoPreviousRelease => (
+                "\u{26A0}\u{FE0F} ",
+                "SKIPPED \u{2014} no previous release recorded on this host, so there is \
+                 nothing to roll back to; it still serves what it served before"
+                    .to_owned(),
+            ),
+            RollbackOutcome::Failed { failed_step } => (
+                "\u{274C}",
+                format!(
+                    "NOT rolled back \u{2014} failed at `{failed_step}`; this host still \
+                     serves what it served before"
+                ),
+            ),
+        };
+        lines.push(format!("  {marker} {host:<width$}  {state}"));
+    }
+    let stalled: Vec<&str> = hosts
+        .iter()
+        .zip(outcomes)
+        .filter(|(_, outcome)| !matches!(outcome, RollbackOutcome::RolledBack))
+        .map(|(host, _)| host.as_str())
+        .collect();
+    if !stalled.is_empty() {
+        // A partly-rolled-back fleet is mixed on purpose-by-accident: say which half
+        // is which, and name the single-host lever for finishing the job.
+        lines.push(format!(
+            "  \u{26A0}\u{FE0F}  The fleet is now MIXED: {} did not roll back. Retry one host \
+             with `autumn deploy rollback --only <host>`, or deploy the intended release to \
+             it explicitly.",
+            stalled.join(", "),
+        ));
+    }
+    // The mirror of the rollout's promise, and just as important here: a rollback
+    // moves binaries, never schema.
+    lines.push(
+        "  \u{26A0}\u{FE0F}  This restored BINARIES only \u{2014} no migration was rolled \
+         back; confirm the schema still fits the release now serving."
+            .to_owned(),
+    );
     lines
 }
 
@@ -1900,5 +2040,92 @@ mod tests {
             1,
             "the migrate placement is a single fleet-wide note, not a per-host line:\n{rendered}"
         );
+    }
+    #[test]
+    fn only_warns_loudly_whenever_it_excludes_a_configured_host() {
+        // #1621 (§3.2). `--only` is a repair lever: it deliberately leaves the
+        // hosts it skips on their old release, which IS the mixed fleet the rollout
+        // driver otherwise refuses to create. That trade is never made silently —
+        // the warning names every skipped host and the command that converges the
+        // fleet again.
+        let configured = ["web-a".to_owned(), "web-b".to_owned(), "web-c".to_owned()];
+        let rendered = only_selection_warning_lines(&configured, &["web-b".to_owned()]).join("\n");
+
+        assert!(
+            rendered.contains(FLEET_ONLY_MIXED_WARNING),
+            "a narrowing selection must print the mixed-fleet warning:\n{rendered}"
+        );
+        assert!(
+            rendered.contains("web-a") && rendered.contains("web-c"),
+            "the warning must name the hosts left behind:\n{rendered}"
+        );
+        assert!(
+            rendered.contains("web-b"),
+            "the warning must name the hosts it WILL touch:\n{rendered}"
+        );
+        assert!(
+            rendered.contains("autumn deploy up"),
+            "the warning must name the command that converges the fleet again:\n{rendered}"
+        );
+    }
+
+    #[test]
+    fn a_selection_that_excludes_nothing_prints_nothing() {
+        // AC-1: an ordinary deploy — and every single-host deploy, which can never
+        // exclude anything — must be byte-identical to pre-#1621, so the warning
+        // block is empty unless a host was actually skipped.
+        let configured = ["web-a".to_owned(), "web-b".to_owned()];
+        assert!(
+            only_selection_warning_lines(&configured, &configured).is_empty(),
+            "selecting the whole fleet excludes nothing and must print nothing"
+        );
+        assert!(
+            only_selection_warning_lines(&["web-a".to_owned()], &["web-a".to_owned()]).is_empty(),
+            "a single-host deploy must print nothing new"
+        );
+    }
+
+    #[test]
+    fn the_fleet_rollback_table_names_every_host_and_its_state() {
+        // #1621 (§3.2): after a partial rollback the fleet is deliberately mixed,
+        // and this table is the operator's only record of which half is which — so
+        // every host appears, including the ones nothing happened to.
+        let hosts = ["web-a".to_owned(), "web-b".to_owned(), "web-c".to_owned()];
+        let rendered = fleet_rollback_summary_lines(
+            &hosts,
+            &[
+                RollbackOutcome::RolledBack,
+                RollbackOutcome::NoPreviousRelease,
+                RollbackOutcome::Failed {
+                    failed_step: "readiness-gate",
+                },
+            ],
+        )
+        .join("\n");
+
+        for host in &hosts {
+            assert!(
+                rendered.contains(host.as_str()),
+                "every attempted host must appear in the table:\n{rendered}"
+            );
+        }
+        assert!(
+            rendered.contains("readiness-gate"),
+            "a failed host must name the step it failed at:\n{rendered}"
+        );
+        assert!(
+            rendered.contains("no previous release"),
+            "a skipped host must say WHY nothing happened to it:\n{rendered}"
+        );
+        for secret in [
+            "AUTUMN_SECURITY__SIGNING_SECRET",
+            "postgres://",
+            "topsecret",
+        ] {
+            assert!(
+                !rendered.contains(secret),
+                "the rollback table must never carry `{secret}`:\n{rendered}"
+            );
+        }
     }
 }

--- a/autumn-cli/src/deploy/fleet.rs
+++ b/autumn-cli/src/deploy/fleet.rs
@@ -784,9 +784,10 @@ pub(crate) fn fleet_rollout_lines(
 ) -> Vec<String> {
     let count = plan.hosts.len();
     let mut lines = Vec::with_capacity(count + 3);
+    let host_word = if count == 1 { "host" } else { "hosts" };
     lines.push(format!(
-        "Rolling release {release_id} across {count} hosts, ONE AT A TIME, in `[deploy] hosts` \
-         order:"
+        "Rolling release {release_id} across {count} {host_word}, ONE AT A TIME, in \
+         `[deploy] hosts` order:"
     ));
     for (index, host) in plan.hosts.iter().enumerate() {
         let mode = match host.mode {
@@ -803,11 +804,21 @@ pub(crate) fn fleet_rollout_lines(
                 .filter(|h| h.host != migrating.host)
                 .map(|h| h.host.as_str())
                 .collect();
-            lines.push(format!(
-                "  \u{2192} migrate ({} only \u{2014} the schema is fleet-wide; {} skip it)",
-                migrating.host,
-                skipped.join(", "),
-            ));
+            // A `--only`-narrowed repair reaches here with a one-host plan, so there
+            // is nobody left to skip the migration; the "; N skip it" clause would
+            // render as a dangling fragment ("fleet-wide;  skip it").
+            lines.push(if skipped.is_empty() {
+                format!(
+                    "  \u{2192} migrate ({} only \u{2014} the schema is fleet-wide)",
+                    migrating.host,
+                )
+            } else {
+                format!(
+                    "  \u{2192} migrate ({} only \u{2014} the schema is fleet-wide; {} skip it)",
+                    migrating.host,
+                    skipped.join(", "),
+                )
+            });
             // Hosts listed AHEAD of the migrating one that are first deploys cut over
             // before the schema moves (AC-4). Named rather than reordered — see
             // `FLEET_FIRST_BEFORE_MIGRATE_NOTE`.
@@ -977,6 +988,66 @@ pub(crate) fn fleet_summary_lines(
     lines
 }
 
+/// The closing line of a successful fleet rollout (issue #1621, §8.2).
+///
+/// Pure so both shapes can be pinned by a unit test rather than by reading
+/// stderr. Two axes, and both must be said out loud:
+///
+/// * **Degraded hosts.** Every host serves the new release, so this is still a
+///   success — but a host whose `record-proxy-options` never landed fails its
+///   NEXT deploy closed, so an unqualified "complete" would hide it.
+/// * **A narrowed run.** `--only` builds the plan, the outcomes and the state
+///   table over the SELECTED hosts only, so `total` is the narrowed count. Saying
+///   "all {total} hosts serving …" there reads as a full-fleet success while the
+///   hosts the operator deliberately skipped are still on their old release —
+///   hundreds of lines after the `--only` warning that said so. The excluded hosts
+///   are counted, never named as a state: their state was never probed (probing
+///   skipped hosts is deliberately refused), so naming a release for them would be
+///   inventing it.
+pub(crate) fn fleet_completion_line(
+    release_id: &str,
+    total: usize,
+    configured_host_count: usize,
+    degraded: usize,
+) -> String {
+    let hosts_word = if total == 1 { "host" } else { "hosts" };
+    let untouched = configured_host_count.saturating_sub(total);
+    let degraded_clause = if degraded == 0 {
+        String::new()
+    } else {
+        format!(
+            " {degraded} finished with post-cutover housekeeping failures (above) \u{2014} \
+             repair them before the next deploy."
+        )
+    };
+    let marker = if degraded == 0 {
+        "\u{2705}"
+    } else {
+        "\u{26A0}\u{FE0F} "
+    };
+    if untouched == 0 {
+        // Byte-identical to pre-review for a full fleet.
+        return if degraded == 0 {
+            format!(
+                "\n\u{2705} Fleet deploy complete \u{2014} all {total} hosts serving {release_id}."
+            )
+        } else {
+            format!(
+                "\n\u{26A0}\u{FE0F}  Fleet deploy complete \u{2014} all {total} hosts serve \
+                 {release_id}, but {degraded} finished with post-cutover housekeeping failures \
+                 (above). Repair them before the next deploy."
+            )
+        };
+    }
+    let untouched_word = if untouched == 1 { "host" } else { "hosts" };
+    format!(
+        "\n{marker} `--only` run complete \u{2014} the {total} {hosts_word} it targeted now serve \
+         {release_id}.{degraded_clause} THIS RUN WAS NARROWED: the other {untouched} configured \
+         {untouched_word} were NOT touched and may be on another release \u{2014} finish with a \
+         full `autumn deploy up` (no `--only`) so the fleet converges."
+    )
+}
+
 // ── `deploy status`: per-host state and drift (issue #1621, AC-6) ────────────
 
 /// The deployed release a host reports, or the honest absence of one.
@@ -1038,6 +1109,21 @@ pub(crate) const DRIFT_PROXY_OPTIONS_UNREADABLE: &str =
 pub(crate) const DRIFT_PROXY_PORT_MISMATCH: &str =
     "the installed proxy unit binds a different public port than `[server] port` configures";
 
+/// The sentence printed under the status table to bound the `last deploy` column
+/// (issue #1621, AC-6).
+///
+/// The column exists because AC-6 asks for the per-host last deploy result, and no
+/// other on-host artefact answers it. Its scope is narrow and stating it is the
+/// whole point: the marker is written by the ops that COMPLETE a cutover, so a
+/// deploy that failed BEFORE the cutover boundary is torn down without touching
+/// it and the host still shows its previous action. It is therefore the host's own
+/// last completed action, never a verdict on the last fleet rollout — the rollout
+/// itself exits non-zero and prints the per-host outcome table.
+pub(crate) const LAST_DEPLOY_SCOPE_NOTE: &str = "`last deploy` is the last action each host COMPLETED (`deployed` / `rolled back`, with \
+     the host's UTC time) \u{2014} a `rolled back` host was compensated or rolled back after its \
+     last cutover. A deploy that failed BEFORE cutover never changes it, so it is not a verdict \
+     on the last rollout, and it is reported rather than counted as drift.";
+
 /// The sentence every maintenance-related surface prints, because the mechanism is
 /// counter-intuitive and getting it wrong causes an outage (plan §6.4).
 ///
@@ -1084,6 +1170,15 @@ pub(crate) struct HostStatus {
     pub(crate) public_port: u16,
     /// Whether the live-slot marker disagrees with the running proxy.
     pub(crate) live_slot_marker_drift: bool,
+    /// The last state-changing deploy action this host COMPLETED (AC-6's third
+    /// per-host fact), or `None` when the host has never completed one and when
+    /// the marker could not be read.
+    ///
+    /// Scope is narrow and stated in the output: it is the host's own last
+    /// completed action (`deployed` / `rolled back` + when), NOT a verdict on the
+    /// last fleet rollout — a host whose deploy failed before the cutover boundary
+    /// is torn down without rewriting it. See `exec::last_deploy_marker`.
+    pub(crate) last_deploy: Option<exec::LastDeploy>,
 }
 
 impl HostStatus {
@@ -1105,6 +1200,7 @@ impl HostStatus {
             proxy_options: exec::ProxyOptionsMarker::Absent,
             public_port: 0,
             live_slot_marker_drift: false,
+            last_deploy: None,
         }
     }
 
@@ -1133,6 +1229,7 @@ impl HostStatus {
             proxy_options: probe.deploy.last_proxy_options.clone(),
             public_port,
             live_slot_marker_drift: reconcile.is_some_and(|r| r.repair),
+            last_deploy: probe.last_deploy.clone(),
         }
     }
 }
@@ -1249,11 +1346,16 @@ pub(crate) fn fleet_drift(hosts: &[HostStatus]) -> DriftReport {
     }
 }
 
-/// One status row's seven display cells, in column order: mode, release, slot,
-/// readiness, maintenance, proxy port, drift reasons. Extracted from
+/// One status row's eight display cells, in column order: mode, release, slot,
+/// readiness, maintenance, proxy port, last deploy, drift reasons. Extracted from
 /// [`fleet_status_lines`] so the renderer stays within the line budget and the
 /// cell wording has one home.
-fn status_row_cells(status: &HostStatus, report: &DriftReport) -> [String; 7] {
+///
+/// The last-deploy cell is AC-6's third per-host fact. It reads `last deploy: ?`
+/// whenever the marker is absent — a host that has never completed a cutover, or
+/// one deployed by a CLI that predates the marker — because "we could not tell"
+/// must never render as a result.
+fn status_row_cells(status: &HostStatus, report: &DriftReport) -> [String; 8] {
     [
         match status.mode {
             _ if !status.reachable => "unreachable".to_owned(),
@@ -1279,6 +1381,17 @@ fn status_row_cells(status: &HostStatus, report: &DriftReport) -> [String; 7] {
             exec::InstalledProxyPort::Absent => "proxy absent".to_owned(),
             exec::InstalledProxyPort::Unreadable => "proxy ?".to_owned(),
         },
+        status.last_deploy.as_ref().map_or_else(
+            || "last deploy: ?".to_owned(),
+            |last| {
+                let mut cell = format!("last deploy: {}", last.result);
+                if let Some(at) = &last.at {
+                    cell.push(' ');
+                    cell.push_str(at);
+                }
+                cell
+            },
+        ),
         {
             let reasons: Vec<&str> = report
                 .state_drift
@@ -1304,14 +1417,14 @@ fn status_row_cells(status: &HostStatus, report: &DriftReport) -> [String; 7] {
 /// Readiness and maintenance are deliberately SEPARATE columns; see
 /// [`MAINTENANCE_DOES_NOT_DRAIN_NOTE`].
 pub(crate) fn fleet_status_lines(hosts: &[HostStatus], report: &DriftReport) -> Vec<String> {
-    let cells: Vec<[String; 7]> = hosts
+    let cells: Vec<[String; 8]> = hosts
         .iter()
         .map(|status| status_row_cells(status, report))
         .collect();
 
     // Column widths, so the composite "state" the shared row renderer prints is
     // itself aligned. The last column is ragged by design (it is prose).
-    let mut widths = [0_usize; 7];
+    let mut widths = [0_usize; 8];
     for row in &cells {
         for (width, cell) in widths.iter_mut().zip(row) {
             *width = (*width).max(cell.chars().count());
@@ -1394,6 +1507,13 @@ pub(crate) fn fleet_status_lines(hosts: &[HostStatus], report: &DriftReport) -> 
     }
     for (host, reason) in &report.state_drift {
         lines.push(format!("  \u{26A0}\u{FE0F}  {host}: {reason}"));
+    }
+    // AC-6's third fact carries its own limits, printed where it is read rather
+    // than only in the guide — a column whose scope is misread is worse than no
+    // column. Only when there is a reachable host, so an all-unreachable report
+    // stays about the outage.
+    if hosts.iter().any(|status| status.reachable) {
+        lines.push(format!("  \u{2139}\u{FE0F}  {LAST_DEPLOY_SCOPE_NOTE}"));
     }
     if hosts.iter().any(|status| status.maintenance_on) {
         lines.push(format!(
@@ -2266,6 +2386,37 @@ mod tests {
     }
 
     #[test]
+    fn the_rollout_header_drops_the_skip_clause_for_a_one_host_plan() {
+        // #1621 review finding 4. A `--only`-narrowed repair reaches this renderer
+        // with a ONE-host plan (`single` is false whenever the config declares more
+        // than one host), so nobody is left to "skip it": `skipped.join(", ")` is
+        // empty and the sentence used to render as "…fleet-wide;  skip it)" — a
+        // dangling clause with a doubled space, on the one line that tells the
+        // operator where the fleet's single migration lands.
+        let fleet = fleet_of(&["web-b"]);
+        let plan =
+            plan_fleet(&fleet, &[HostMode::Redeploy]).expect("a one-host plan is well-formed");
+        let rendered = fleet_rollout_lines(&plan, "20260714T120000Z", true).join("\n");
+
+        assert!(
+            rendered.contains("  \u{2192} migrate (web-b only \u{2014} the schema is fleet-wide)"),
+            "a one-host plan must render the migrate line with no skip clause:\n{rendered}"
+        );
+        assert!(
+            !rendered.contains("skip it"),
+            "there is no other host in this run to skip the migration:\n{rendered}"
+        );
+        assert!(
+            !rendered.contains(";  "),
+            "no dangling clause may survive on the migrate line:\n{rendered}"
+        );
+        assert!(
+            rendered.contains("across 1 host,"),
+            "a one-host plan must not say `across 1 hosts`:\n{rendered}"
+        );
+    }
+
+    #[test]
     fn the_rollout_header_warns_when_first_deploys_cut_over_before_the_migration() {
         // #1621 (AC-4): the migration lands on the first REDEPLOY host in rollout
         // order, so every first-deploy host listed ahead of it goes live on the new
@@ -2342,6 +2493,57 @@ mod tests {
         assert!(
             !quiet.contains(FLEET_NO_MIGRATION_NOTE),
             "an app with no writable database has no schema to warn about:\n{quiet}"
+        );
+    }
+
+    #[test]
+    fn the_completion_line_is_honest_about_a_narrowed_run() {
+        // #1621 review finding 2. `--only` narrows the plan, the outcomes AND the
+        // state table, so `total` is the SELECTED count: "all 1 hosts serving R2"
+        // on a 3-host config reads as a full-fleet success while web-a/web-c are
+        // still on the previous release. The closing line must say it was narrowed
+        // and that the untouched hosts may be on another release.
+        let narrowed = fleet_completion_line("20260714T120000Z", 1, 3, 0);
+        assert!(
+            !narrowed.contains("Fleet deploy complete"),
+            "a narrowed run must not claim the fleet is complete:\n{narrowed}"
+        );
+        assert!(
+            narrowed.contains("`--only` run complete")
+                && narrowed.contains("the 1 host it targeted now serve 20260714T120000Z")
+                && narrowed.contains("THIS RUN WAS NARROWED")
+                && narrowed.contains("the other 2 configured hosts were NOT touched")
+                && narrowed.contains("may be on another release")
+                && narrowed.contains("full `autumn deploy up` (no `--only`)"),
+            "the narrowed line must name the narrowing, the untouched count and the \
+             converging command:\n{narrowed}"
+        );
+        // Degraded hosts on a narrowed run keep BOTH warnings.
+        let narrowed_degraded = fleet_completion_line("20260714T120000Z", 2, 5, 1);
+        assert!(
+            narrowed_degraded.contains("THIS RUN WAS NARROWED")
+                && narrowed_degraded.contains("the other 3 configured hosts")
+                && narrowed_degraded.contains("post-cutover housekeeping failures"),
+            "a narrowed run with a degraded host must say both:\n{narrowed_degraded}"
+        );
+
+        // A FULL run is byte-identical to the pre-review text — the e2e harness
+        // pins this exact string.
+        assert_eq!(
+            fleet_completion_line("20260714T120000Z", 2, 2, 0),
+            "\n\u{2705} Fleet deploy complete \u{2014} all 2 hosts serving 20260714T120000Z.",
+        );
+        assert_eq!(
+            fleet_completion_line("20260714T120000Z", 3, 3, 1),
+            "\n\u{26A0}\u{FE0F}  Fleet deploy complete \u{2014} all 3 hosts serve \
+             20260714T120000Z, but 1 finished with post-cutover housekeeping failures (above). \
+             Repair them before the next deploy.",
+        );
+        // `configured_host_count` is never *smaller* than the plan, but a defensive
+        // saturating subtraction must not turn an ordinary run into a narrowed one.
+        assert!(
+            fleet_completion_line("R", 3, 0, 0).contains("Fleet deploy complete"),
+            "an under-reported configured count must not fabricate a narrowed run"
         );
     }
 
@@ -2948,6 +3150,10 @@ mod tests {
             }),
             public_port: 3000,
             live_slot_marker_drift: false,
+            last_deploy: Some(exec::LastDeploy {
+                result: exec::LAST_DEPLOY_DEPLOYED.to_owned(),
+                at: Some("2026-07-14T12:00:03Z".to_owned()),
+            }),
         }
     }
 

--- a/autumn-cli/src/deploy/fleet.rs
+++ b/autumn-cli/src/deploy/fleet.rs
@@ -1,0 +1,712 @@
+//! Fleet planning for `autumn deploy` (issue #1621) — the PURE layer.
+//!
+//! A fleet rollout is a **thin, pure orchestration shell above unchanged per-host
+//! op builders**. Nothing below [`exec::SshTarget`] moves: this module decides
+//! *which* host does *what*, and then delegates to [`exec::first_deploy_ops`] /
+//! [`exec::cutover_ops`] verbatim. Everything here is a pure function of its
+//! inputs — no I/O, no clock, no host contact — so the "no mixed versions"
+//! reasoning is unit-testable against synthetic probe modes with no server.
+//!
+//! Three rules are load-bearing and easy to break by accident:
+//!
+//! 1. **Each host's ops stay in their OWN `Vec`.** No code path may concatenate
+//!    two hosts' [`exec::DeployOp`] vectors. [`exec::execute_with_teardown`]
+//!    resolves the auto-rollback boundary with
+//!    `ops.iter().position(|op| op.label() == boundary_label)` — the FIRST match —
+//!    so a flat fleet-wide vector would classify every later host's *pre*-flip
+//!    failure as post-boundary and silently disable teardown, leaving a candidate
+//!    half-installed with no rollback. [`host_ops`] therefore returns one vector
+//!    per [`HostPlan`], and `every_fleet_host_vector_carries_exactly_one_boundary_label`
+//!    is the tripwire.
+//!
+//! 2. **Host identity NEVER enters [`exec::RemoteCommand::label`].** Labels are
+//!    `&'static str` and are load-bearing three times over: the boundary lookup
+//!    above, `CandidateRolledBack { failed_step }`, and every exact-vector test.
+//!    Making a label host-specific would need a `Box::leak` (an unbounded
+//!    per-host-per-run leak with non-deterministic identity that clippy will not
+//!    flag) and would break boundary matching. The host travels in this module's
+//!    plan/result types — never in an op.
+//!
+//! 3. **Exactly ONE `release_id` per fleet run.** It is minted once by the driver
+//!    and threaded into every host's builders, so every host's `current` symlink
+//!    resolves to the same release, drift reporting is meaningful, and a rollback
+//!    has a single target. Regenerating per host would give un-comparable version
+//!    identities and permanent reported drift.
+//!
+//! The migration is scheduled by [`migrate_placement`]: the first host in rollout
+//! order that is a *redeploy*, since a first-deploy host has no live release to
+//! keep serving if the migration fails, and [`exec::first_deploy_ops`] carries no
+//! migrate op at all. Every other host builds with [`exec::MigrateStep::Skip`].
+
+// Every item here is crate-internal by design (see the note on `mod fleet` in
+// `deploy.rs`). In this bin-only crate `deploy` is a private module, so clippy
+// flags each `pub(crate)` as redundant; they are kept to document the intended
+// visibility rather than widening to `pub`.
+#![allow(clippy::redundant_pub_crate)]
+// The planning types and the ops helper are consumed by this module's tests and
+// by the plan drift guard today; the serial rollout DRIVER that consumes them in
+// production lands in the next slice of #1621 (mirroring how `ResolvedFleet`
+// itself was landed).
+#![cfg_attr(not(test), allow(dead_code))]
+
+use std::path::Path;
+
+use super::exec::{
+    self, DeployOp, ManifestUpload, MigrateStep, ProxyServiceOptions, Secret, SlotPlan,
+};
+use super::proxy::ProxyController;
+use super::{ResolvedDeployConfig, ResolvedFleet};
+
+/// The single fleet-wide sentence `deploy plan` prints about migrate placement.
+///
+/// Held as a constant so the plan text and the drift guard that checks it against
+/// the real op sequence (`fleet_plan_matches_fleet_ops_sequence`) can never
+/// disagree about what was promised.
+pub(crate) const FLEET_MIGRATE_PLACEMENT_NOTE: &str = "[migrate] runs once, on the first host still on a previous release, before its \
+     cutover — hosts 2..N skip it";
+
+/// Which path a single host takes in a fleet rollout.
+///
+/// This is the payload-free projection of [`exec::DeployMode`]: the planner only
+/// needs to know *first deploy vs redeploy*, while the live slot that
+/// `DeployMode::Redeploy` carries is a per-host detail belonging to that host's
+/// [`SlotPlan`], resolved by the driver from the same probe. Keeping the planning
+/// input this small is what makes the whole module testable from synthetic values
+/// with no probe round-trip.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum HostMode {
+    /// No promoted `current` release yet — [`exec::first_deploy_ops`].
+    First,
+    /// A `current` release already serves — [`exec::cutover_ops`].
+    Redeploy,
+}
+
+impl HostMode {
+    /// Project a probed [`exec::DeployMode`] onto the planning input. A thin
+    /// mapping (rather than reusing `DeployMode` directly) keeps the planner
+    /// decoupled from the probe's slot payload.
+    pub(crate) const fn from_deploy_mode(mode: &exec::DeployMode) -> Self {
+        match mode {
+            exec::DeployMode::First => Self::First,
+            exec::DeployMode::Redeploy { .. } => Self::Redeploy,
+        }
+    }
+}
+
+/// Where in the rollout the single fleet-wide migration runs (issue #1621, AC-4).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum MigratePlacement {
+    /// Index, in rollout order, of the first host taking the redeploy path.
+    FirstRedeploy(usize),
+    /// No host in this fleet is a redeploy, so nothing migrates — today's
+    /// documented "the first deploy does not migrate" limitation, generalised.
+    None,
+}
+
+/// The index of the first host in rollout order whose mode is
+/// [`HostMode::Redeploy`], or [`MigratePlacement::None`].
+///
+/// Pure and total: an empty slice, or one with no redeploy, yields `None`.
+pub(crate) fn migrate_placement(modes: &[HostMode]) -> MigratePlacement {
+    modes
+        .iter()
+        .position(|mode| matches!(mode, HostMode::Redeploy))
+        .map_or(MigratePlacement::None, MigratePlacement::FirstRedeploy)
+}
+
+/// What one host does in a fleet rollout.
+///
+/// Deliberately NOT the host's ops: the ops are built from this plus that host's
+/// resolved config and slot layout (see [`host_ops`]), one vector per host.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct HostPlan {
+    /// The SSH-reachable address, carried here — never in an op label (rule 2).
+    pub(crate) host: String,
+    /// Which per-host builder this host takes.
+    pub(crate) mode: HostMode,
+    /// Whether this host carries the fleet's single migration.
+    pub(crate) migrate: MigrateStep,
+}
+
+/// The whole rollout, one entry per host, in rollout (declaration) order.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct FleetPlan {
+    /// Per-host plans, in rollout order.
+    pub(crate) hosts: Vec<HostPlan>,
+}
+
+impl FleetPlan {
+    /// The host carrying the fleet's single migration, if any.
+    pub(crate) fn migrating_host(&self) -> Option<&HostPlan> {
+        self.hosts
+            .iter()
+            .find(|h| matches!(h.migrate, MigrateStep::Run))
+    }
+}
+
+/// Why a fleet could not be planned.
+///
+/// Planning is pure and **total**: it returns a typed refusal rather than
+/// panicking, because a panic here would abort a CLI process that may already
+/// have cut hosts over. The operator-facing fleet-wide refusals (`SQLite` fleet,
+/// media fleet, TLS fleet) are prologue concerns and land with the driver.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub(crate) enum FleetPlanError {
+    /// The probe-mode list did not line up with the resolved host list — a caller
+    /// bug (the two are produced together), reported instead of indexed past.
+    #[error(
+        "fleet plan input mismatch: {hosts} resolved host(s) but {modes} probe mode(s) — every \
+         host must be probed before any host is touched (#1621)"
+    )]
+    ModeCountMismatch {
+        /// Number of resolved hosts.
+        hosts: usize,
+        /// Number of probe modes supplied.
+        modes: usize,
+    },
+}
+
+/// Turn a resolved fleet plus one probed mode per host into the executable plan
+/// (issue #1621, AC-3/AC-4) — **pure, no I/O**.
+///
+/// This is where "no mixed versions" is actually won: the migration is assigned to
+/// exactly one host, and every other host is explicitly told to skip it.
+///
+/// # Errors
+///
+/// Returns [`FleetPlanError::ModeCountMismatch`] when `modes` does not have one
+/// entry per resolved host.
+pub(crate) fn plan_fleet(
+    fleet: &ResolvedFleet,
+    modes: &[HostMode],
+) -> Result<FleetPlan, FleetPlanError> {
+    if fleet.hosts.len() != modes.len() {
+        return Err(FleetPlanError::ModeCountMismatch {
+            hosts: fleet.hosts.len(),
+            modes: modes.len(),
+        });
+    }
+
+    let placement = migrate_placement(modes);
+    let hosts = fleet
+        .hosts
+        .iter()
+        .zip(modes)
+        .enumerate()
+        .map(|(index, (cfg, mode))| HostPlan {
+            // `ResolvedFleet` guarantees a non-blank host for every entry; the
+            // total fallback keeps this function panic-free rather than
+            // `expect`-ing an invariant enforced two modules away.
+            host: cfg.host.clone().unwrap_or_default(),
+            mode: *mode,
+            // Exactly one host runs the migration; everyone else skips it. A
+            // `HostMode::First` host can never be the placement (a first deploy
+            // has no live release to keep serving if the migration fails, and
+            // `first_deploy_ops` carries no migrate op), so its `Skip` is both
+            // correct and inert.
+            migrate: if placement == MigratePlacement::FirstRedeploy(index) {
+                MigrateStep::Run
+            } else {
+                MigrateStep::Skip
+            },
+        })
+        .collect();
+    Ok(FleetPlan { hosts })
+}
+
+/// Everything ONE host's op vector needs beyond its [`HostPlan`].
+///
+/// The fleet-wide values (`env_file`, `binary_local`, `manifests`, `release_id`)
+/// are identical for every host by construction — that is rule 3 — while `cfg`,
+/// `unit` and `slots` are that host's own. The driver builds one of these per host
+/// and hands it straight to [`host_ops`].
+pub(crate) struct HostOpsInput<'a, P: ProxyController> {
+    /// This host's resolved config (differs from its siblings only in `host`).
+    pub(crate) cfg: &'a ResolvedDeployConfig,
+    /// The proxy controller (per-host kamal-proxy, not a fleet load balancer).
+    pub(crate) proxy: &'a P,
+    /// This host's rendered slot unit, for its own candidate slot/port.
+    pub(crate) unit: &'a str,
+    /// The env-file body — byte-identical on every host, hence a shared secret
+    /// cloned per host rather than rebuilt.
+    pub(crate) env_file: &'a Secret,
+    /// Local path to the release binary uploaded to every host.
+    pub(crate) binary_local: &'a Path,
+    /// Config manifests uploaded into every host's release dir.
+    pub(crate) manifests: &'a [ManifestUpload],
+    /// The ONE release id for this fleet run (rule 3).
+    pub(crate) release_id: &'a str,
+    /// This host's blue/green slot layout.
+    pub(crate) slots: &'a SlotPlan,
+    /// Proxy options to preserve on this host's durability re-register (`#2074`);
+    /// unused on the first-deploy path.
+    pub(crate) reregister_options: &'a ProxyServiceOptions,
+}
+
+/// Build ONE host's ordered op vector from its plan, via the existing per-host
+/// builders — unchanged, unwrapped, and never concatenated with another host's
+/// (rule 1).
+///
+/// A [`HostMode::First`] host always plans [`MigrateStep::Skip`]
+/// ([`exec::first_deploy_ops`] has no migrate op at all), so `plan.migrate` only
+/// ever reaches [`exec::cutover_ops`].
+pub(crate) fn host_ops<P: ProxyController>(
+    plan: &HostPlan,
+    input: &HostOpsInput<'_, P>,
+) -> Vec<DeployOp> {
+    match plan.mode {
+        HostMode::First => exec::first_deploy_ops(
+            input.cfg,
+            input.proxy,
+            input.unit,
+            input.env_file.clone(),
+            input.binary_local,
+            input.manifests,
+            input.release_id,
+            input.slots,
+        ),
+        HostMode::Redeploy => exec::cutover_ops(
+            input.cfg,
+            input.proxy,
+            input.unit,
+            input.env_file.clone(),
+            input.binary_local,
+            input.manifests,
+            input.release_id,
+            input.slots,
+            input.reregister_options,
+            plan.migrate,
+        ),
+    }
+}
+
+/// The `deploy plan` fleet section: the rollout order and the migrate-placement
+/// rule (issue #1621, AC-4).
+///
+/// `deploy plan` is **offline** — it contacts no host — so it cannot know which
+/// hosts are first deploys and which are redeploys. It therefore renders the
+/// migrate placement as the RULE `deploy up` applies after probing every host,
+/// never as a named host; and, like [`super::build_deploy_plan`], the section is
+/// descriptive rather than the thing that executes (the drift guard
+/// `fleet_plan_matches_fleet_ops_sequence` is what keeps the two honest).
+///
+/// Only rendered when more than one host is configured, so single-host `deploy
+/// plan` output stays byte-identical to pre-#1621.
+pub(crate) fn fleet_plan_lines(hosts: &[String]) -> Vec<String> {
+    let mut lines = Vec::with_capacity(hosts.len() + 5);
+    lines.push(String::new());
+    lines.push(format!(
+        "Fleet rollout ({} hosts, in `[deploy] hosts` declaration order):",
+        hosts.len()
+    ));
+    for (index, host) in hosts.iter().enumerate() {
+        lines.push(format!("  {}. {host}", index + 1));
+    }
+    lines.push(
+        "  Hosts roll out ONE AT A TIME in the order above: each host runs the steps \
+         above in full and must finish its cutover before the next host is started, so \
+         the rest of the fleet keeps serving throughout."
+            .to_owned(),
+    );
+    lines.push(format!("  {FLEET_MIGRATE_PLACEMENT_NOTE}."));
+    lines.push(
+        "  This section is descriptive, like the steps above: `deploy plan` contacts no \
+         host, so it cannot know which hosts are first deploys and which are redeploys \
+         — the migrate placement is the rule `autumn deploy up` applies after probing \
+         every host, not a host named here."
+            .to_owned(),
+    );
+    lines
+}
+
+/// Test-only fixtures shared by this module's unit tests and the `deploy` plan↔ops
+/// drift guard, so both drive the ops through the SAME per-host inputs the slice-3
+/// driver will use.
+#[cfg(test)]
+pub(crate) mod test_support {
+    use super::{FleetPlan, HostMode, HostOpsInput, HostPlan, host_ops};
+    use crate::deploy::ResolvedDeployConfig;
+    use crate::deploy::exec::{
+        DeployOp, ManifestUpload, ProxyServiceOptions, SLOT_BLUE, Secret, SlotPlan,
+    };
+    use crate::deploy::{ResolvedFleet, render_app_unit};
+    use std::path::{Path, PathBuf};
+
+    /// The one release id every host in a test fleet deploys (rule 3).
+    pub(crate) const RELEASE_ID: &str = "20260714T120000Z";
+    /// Public port fronted by each host's proxy.
+    pub(crate) const PUBLIC_PORT: u16 = 3000;
+
+    fn manifests() -> Vec<ManifestUpload> {
+        vec![ManifestUpload {
+            local: PathBuf::from("/local/autumn.toml"),
+            remote_basename: "autumn.toml".to_owned(),
+        }]
+    }
+
+    /// Build ONE host's op vector exactly the way the driver will: its own
+    /// [`SlotPlan`], its own rendered unit, and the fleet-wide release id.
+    pub(crate) fn host_ops_for(cfg: &ResolvedDeployConfig, plan: &HostPlan) -> Vec<DeployOp> {
+        let slots = match plan.mode {
+            HostMode::First => SlotPlan::first(PUBLIC_PORT),
+            HostMode::Redeploy => SlotPlan::redeploy(PUBLIC_PORT, SLOT_BLUE),
+        };
+        let release_dir = format!("{}/{RELEASE_ID}", cfg.releases_dir());
+        let unit = render_app_unit(
+            cfg,
+            &release_dir,
+            slots.candidate_port,
+            slots.candidate_slot,
+        );
+        host_ops(
+            plan,
+            &HostOpsInput {
+                cfg,
+                proxy: &crate::deploy::proxy::KamalProxyController::new(60),
+                unit: &unit,
+                env_file: &Secret::new("AUTUMN_SECURITY__SIGNING_SECRET=x\n"),
+                binary_local: Path::new("/local/target/release/myapp"),
+                manifests: &manifests(),
+                release_id: RELEASE_ID,
+                slots: &slots,
+                reregister_options: &ProxyServiceOptions {
+                    tls: false,
+                    host: None,
+                },
+            },
+        )
+    }
+
+    /// Every host's ops, each in its OWN vector (rule 1 — never concatenated).
+    pub(crate) fn per_host_ops(fleet: &ResolvedFleet, plan: &FleetPlan) -> Vec<Vec<DeployOp>> {
+        fleet
+            .hosts
+            .iter()
+            .zip(&plan.hosts)
+            .map(|(cfg, host_plan)| host_ops_for(cfg, host_plan))
+            .collect()
+    }
+
+    /// The fleet's op labels flattened in rollout order — for assertions ONLY;
+    /// execution never sees a flattened vector.
+    pub(crate) fn fleet_op_labels(fleet: &ResolvedFleet, plan: &FleetPlan) -> Vec<&'static str> {
+        per_host_ops(fleet, plan)
+            .iter()
+            .flat_map(|ops| ops.iter().map(DeployOp::label).collect::<Vec<_>>())
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::test_support::per_host_ops;
+    use super::*;
+    use autumn_web::config::DeployConfig;
+
+    /// A resolved fleet from the fleet spelling an operator would write.
+    fn fleet_of(hosts: &[&str]) -> ResolvedFleet {
+        ResolvedFleet::resolve(
+            &DeployConfig {
+                hosts: hosts.iter().map(|h| (*h).to_owned()).collect(),
+                ..DeployConfig::default()
+            },
+            "myapp",
+        )
+        .expect("a well-formed fleet resolves")
+    }
+
+    fn labels(ops: &[DeployOp]) -> Vec<&'static str> {
+        ops.iter().map(DeployOp::label).collect()
+    }
+
+    fn shell_for<'a>(ops: &'a [DeployOp], label: &str) -> Option<&'a str> {
+        ops.iter().find_map(|op| match op {
+            DeployOp::Run(cmd) if cmd.label == label => Some(cmd.shell.as_str()),
+            _ => None,
+        })
+    }
+
+    fn upload_path<'a>(ops: &'a [DeployOp], label: &str) -> Option<&'a str> {
+        ops.iter().find_map(|op| match op {
+            DeployOp::UploadFile {
+                label: l,
+                remote_path,
+                ..
+            } if *l == label => Some(remote_path.as_str()),
+            _ => None,
+        })
+    }
+
+    /// Plan a fleet and build every host's op vector, keeping each host's ops in
+    /// its OWN `Vec` (rule 1 forbids concatenating them — `execute_with_teardown`
+    /// resolves its boundary with the FIRST matching label, so a flat vector would
+    /// silently disable teardown for every host after the first).
+    fn plan_and_build(hosts: &[&str], modes: &[HostMode]) -> (FleetPlan, Vec<Vec<DeployOp>>) {
+        let fleet = fleet_of(hosts);
+        let plan = plan_fleet(&fleet, modes).expect("a well-formed fleet plans");
+        let ops = per_host_ops(&fleet, &plan);
+        (plan, ops)
+    }
+
+    #[test]
+    fn fleet_plan_runs_migrations_exactly_once() {
+        // #1621 (AC-4, T1.8): the schema is fleet-wide, so a rollout migrates ONCE,
+        // before the first host's cutover. A naive per-host loop would run the
+        // one-shot N times: the Postgres advisory lock keeps that safe, but hosts
+        // 2..N each pay the lock wait and — worse — a migration failing on host 2
+        // AFTER host 1 cut over is exactly the mixed-version fleet AC-3 forbids.
+        let (plan, per_host) = plan_and_build(
+            &["web-a", "web-b", "web-c"],
+            &[HostMode::Redeploy, HostMode::Redeploy, HostMode::Redeploy],
+        );
+
+        // (a) the plan itself names exactly one migrating host — the first in
+        // rollout order — and the built ops agree.
+        assert_eq!(
+            plan.migrating_host().map(|h| h.host.as_str()),
+            Some("web-a"),
+            "an all-redeploy fleet migrates on the first host, got: {:?}",
+            plan.hosts
+        );
+        assert_eq!(
+            plan.hosts
+                .iter()
+                .filter(|h| h.migrate == MigrateStep::Run)
+                .count(),
+            1,
+            "exactly one host may be assigned the migration, got: {:?}",
+            plan.hosts
+        );
+
+        let flat: Vec<&'static str> = per_host.iter().flat_map(|ops| labels(ops)).collect();
+        assert_eq!(
+            flat.iter().filter(|l| **l == "migrate").count(),
+            1,
+            "a fleet rollout must schedule exactly one migrate op, got: {flat:?}"
+        );
+
+        // (b) the single migrate precedes the FIRST cutover anywhere in the fleet,
+        // so no host is serving the new release before the schema is at it.
+        let migrate = flat
+            .iter()
+            .position(|l| *l == "migrate")
+            .expect("the fleet migrates");
+        let first_flip = flat
+            .iter()
+            .position(|l| *l == "proxy-flip" || *l == "proxy-route")
+            .expect("the fleet cuts over somewhere");
+        assert!(
+            migrate < first_flip,
+            "the migration must precede the first cutover in the fleet: \
+             migrate at {migrate}, first boundary at {first_flip}, labels: {flat:?}"
+        );
+
+        // (c) the migrate op is still the real, blocking one-shot: `--wait` is what
+        // propagates a failed migration into an abort, and `AUTUMN_MIGRATE=1` is the
+        // runtime trigger.
+        let migrate_shell = per_host
+            .iter()
+            .find_map(|ops| shell_for(ops, "migrate"))
+            .expect("one host carries the migrate op");
+        assert!(
+            migrate_shell.contains("--setenv=AUTUMN_MIGRATE=1"),
+            "the fleet migrate op must still trigger the app's migrate-only mode: {migrate_shell}"
+        );
+        assert!(
+            migrate_shell.contains("--wait"),
+            "the fleet migrate op must still block on the one-shot's exit status: {migrate_shell}"
+        );
+    }
+
+    #[test]
+    fn every_fleet_host_vector_carries_exactly_one_boundary_label() {
+        // #1621 (AC-3, T1.9): `execute_with_teardown` resolves the boundary with
+        // `ops.iter().position(|op| op.label() == boundary)` — the FIRST match. Two
+        // hosts' ops in one vector would make every later host's pre-flip failure
+        // look post-boundary and silently disable auto-rollback. This is the
+        // structural tripwire for that: one boundary per host vector, `proxy-flip`
+        // for a redeploy and `proxy-route` for a first deploy.
+        let (plan, per_host) = plan_and_build(
+            &["web-a", "web-b", "web-c"],
+            &[HostMode::First, HostMode::Redeploy, HostMode::Redeploy],
+        );
+
+        for (host_plan, ops) in plan.hosts.iter().zip(&per_host) {
+            let host_labels = labels(ops);
+            let expected = match host_plan.mode {
+                HostMode::First => "proxy-route",
+                HostMode::Redeploy => "proxy-flip",
+            };
+            assert_eq!(
+                host_labels.iter().filter(|l| **l == expected).count(),
+                1,
+                "{} must carry exactly one `{expected}` boundary, got: {host_labels:?}",
+                host_plan.host
+            );
+            let other = match host_plan.mode {
+                HostMode::First => "proxy-flip",
+                HostMode::Redeploy => "proxy-route",
+            };
+            assert!(
+                !host_labels.contains(&other),
+                "{} must not carry the other mode's boundary `{other}`, got: {host_labels:?}",
+                host_plan.host
+            );
+        }
+    }
+
+    #[test]
+    fn migrate_placement_picks_the_first_redeploy_host_in_rollout_order() {
+        // #1621 (AC-4, T1.10): the migration runs on the first host that is ALREADY
+        // on a previous release — a first-deploy host has no live release to keep
+        // serving if the migration fails, and `first_deploy_ops` deliberately
+        // carries no migrate op at all.
+        assert_eq!(
+            migrate_placement(&[HostMode::First, HostMode::Redeploy, HostMode::Redeploy]),
+            MigratePlacement::FirstRedeploy(1),
+            "the migration belongs to the first REDEPLOY host, not the first host"
+        );
+        assert_eq!(
+            migrate_placement(&[HostMode::Redeploy, HostMode::Redeploy]),
+            MigratePlacement::FirstRedeploy(0),
+            "an all-redeploy fleet migrates on host 1"
+        );
+        // An all-first-deploy fleet migrates NOWHERE — today's documented
+        // single-host limitation, generalised. (The operator warning that names
+        // `autumn migrate` lands with the driver.)
+        assert_eq!(
+            migrate_placement(&[HostMode::First, HostMode::First]),
+            MigratePlacement::None,
+            "an all-first-deploy fleet has no host to migrate on"
+        );
+        assert_eq!(
+            migrate_placement(&[]),
+            MigratePlacement::None,
+            "an empty mode list places no migration"
+        );
+    }
+
+    #[test]
+    fn host_mode_projects_the_probed_deploy_mode() {
+        // #1621: the planner's input is the payload-free projection of the probe's
+        // `DeployMode`. The live slot the probe carries belongs to the host's
+        // `SlotPlan`, not to the planning decision, so the driver maps once here
+        // instead of threading the probe type through the pure layer.
+        assert_eq!(
+            HostMode::from_deploy_mode(&exec::DeployMode::First),
+            HostMode::First,
+            "an unpromoted host takes the first-deploy path"
+        );
+        assert_eq!(
+            HostMode::from_deploy_mode(&exec::DeployMode::Redeploy {
+                live_slot: exec::SLOT_GREEN
+            }),
+            HostMode::Redeploy,
+            "a host already serving takes the cutover path, whichever slot is live"
+        );
+        assert_eq!(
+            HostMode::from_deploy_mode(&exec::DeployMode::Redeploy {
+                live_slot: exec::SLOT_BLUE
+            }),
+            HostMode::Redeploy,
+            "the live slot must not change the planning decision"
+        );
+    }
+
+    #[test]
+    fn an_all_first_deploy_fleet_schedules_no_migration() {
+        // #1621 (AC-4): the companion of the placement rule at the op level —
+        // `first_deploy_ops` stays byte-identical, so an all-first fleet carries no
+        // `migrate` op anywhere.
+        let (plan, per_host) =
+            plan_and_build(&["web-a", "web-b"], &[HostMode::First, HostMode::First]);
+        assert!(
+            plan.hosts.iter().all(|h| h.migrate == MigrateStep::Skip),
+            "no first-deploy host may be assigned the migration, got: {:?}",
+            plan.hosts
+        );
+        let flat: Vec<&'static str> = per_host.iter().flat_map(|ops| labels(ops)).collect();
+        assert!(
+            !flat.contains(&"migrate"),
+            "an all-first-deploy fleet must schedule no migration, got: {flat:?}"
+        );
+    }
+
+    #[test]
+    fn every_fleet_host_deploys_the_identical_release_id() {
+        // #1621 (AC-3/AC-6, T1.18): ONE release id per fleet run. Minting per host
+        // would give un-comparable `current` symlink targets (permanent reported
+        // drift) and no single rollback target for the whole fleet.
+        let (_plan, per_host) = plan_and_build(
+            &["web-a", "web-b", "web-c"],
+            &[HostMode::Redeploy, HostMode::Redeploy, HostMode::Redeploy],
+        );
+
+        let expected_dir = "/srv/autumn/myapp/releases/20260714T120000Z";
+        let mut binary_paths: Vec<&str> = Vec::new();
+        for ops in &per_host {
+            let binary = upload_path(ops, "upload-binary").expect("each host uploads the binary");
+            assert_eq!(
+                binary,
+                format!("{expected_dir}/myapp"),
+                "every host must upload into the SAME fleet release dir"
+            );
+            let prepare = shell_for(ops, "prepare-dirs").expect("each host prepares its dirs");
+            assert!(
+                prepare.contains(expected_dir),
+                "every host must prepare the SAME fleet release dir: {prepare}"
+            );
+            binary_paths.push(binary);
+        }
+        binary_paths.dedup();
+        assert_eq!(
+            binary_paths.len(),
+            1,
+            "the fleet must deploy exactly one release id, got: {binary_paths:?}"
+        );
+    }
+
+    #[test]
+    fn plan_fleet_refuses_a_mode_count_mismatch_without_panicking() {
+        // #1621: `plan_fleet` is pure and total — a caller that hands it a probe
+        // list of the wrong length gets a typed refusal, never a panic mid-rollout.
+        let fleet = fleet_of(&["web-a", "web-b"]);
+        let err = plan_fleet(&fleet, &[HostMode::Redeploy])
+            .expect_err("a short mode list must be refused");
+        assert_eq!(
+            err,
+            FleetPlanError::ModeCountMismatch { hosts: 2, modes: 1 },
+            "the refusal must name both counts, got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn fleet_plan_lines_render_hosts_in_rollout_order_with_one_migrate_note() {
+        // #1621 (AC-4): the offline `deploy plan` fleet section. `plan` contacts no
+        // host, so it cannot know per-host first-vs-redeploy modes — it therefore
+        // renders the migrate placement as a RULE, exactly once, not per host.
+        let hosts = vec![
+            "web-1.example.com".to_owned(),
+            "web-2.example.com".to_owned(),
+            "web-3.example.com".to_owned(),
+        ];
+        let rendered = fleet_plan_lines(&hosts).join("\n");
+
+        let mut previous = 0usize;
+        for host in &hosts {
+            let at = rendered
+                .find(host.as_str())
+                .unwrap_or_else(|| panic!("{host} must appear in the fleet plan:\n{rendered}"));
+            assert!(
+                at >= previous,
+                "hosts must render in declaration (rollout) order:\n{rendered}"
+            );
+            previous = at;
+        }
+        assert_eq!(
+            rendered.matches(FLEET_MIGRATE_PLACEMENT_NOTE).count(),
+            1,
+            "the migrate placement is a single fleet-wide note, not a per-host line:\n{rendered}"
+        );
+    }
+}

--- a/autumn-cli/src/deploy/fleet.rs
+++ b/autumn-cli/src/deploy/fleet.rs
@@ -733,6 +733,29 @@ pub(crate) fn fleet_rollout_lines(
     lines
 }
 
+/// The ONE per-host table renderer every fleet view goes through (issue #1621,
+/// §7.3): the end-of-rollout summary, the fleet rollback summary, the maintenance
+/// fan-out summary, and `deploy status`.
+///
+/// Sharing the primitive is the point. Several surfaces describing the same fleet
+/// in slightly different layouts is how an operator ends up comparing tables that
+/// disagree at 3 am; here they cannot, because the host column width, the marker
+/// slot and the row shape are computed in exactly one place. Each caller supplies
+/// its own marker and its own already-composed state text.
+fn state_table_lines(title: &str, rows: &[(&'static str, &str, String)]) -> Vec<String> {
+    let width = rows
+        .iter()
+        .map(|(_, host, _)| host.chars().count())
+        .max()
+        .unwrap_or(0);
+    let mut lines = Vec::with_capacity(rows.len() + 1);
+    lines.push(title.to_owned());
+    for (marker, host, state) in rows {
+        lines.push(format!("  {marker} {host:<width$}  {state}"));
+    }
+    lines
+}
+
 /// The per-host state table printed at the END of every fleet rollout — success or
 /// halt (issue #1621, §8.2).
 ///
@@ -744,13 +767,7 @@ pub(crate) fn fleet_summary_lines(
     outcomes: &[HostOutcome],
     release_id: &str,
 ) -> Vec<String> {
-    let mut lines = vec!["Fleet state:".to_owned()];
-    let width = plan
-        .hosts
-        .iter()
-        .map(|h| h.host.chars().count())
-        .max()
-        .unwrap_or(0);
+    let mut rows: Vec<(&'static str, &str, String)> = Vec::with_capacity(plan.hosts.len());
     for (host, outcome) in plan.hosts.iter().zip(outcomes) {
         let state = match outcome {
             HostOutcome::Untouched => "untouched (not reached)".to_owned(),
@@ -806,11 +823,9 @@ pub(crate) fn fleet_summary_lines(
             }
             _ => "\u{274C}",
         };
-        lines.push(format!(
-            "  {marker} {host:<width$}  {state}",
-            host = host.host,
-        ));
+        rows.push((marker, host.host.as_str(), state));
     }
+    let mut lines = state_table_lines("Fleet state:", &rows);
     let on_new: Vec<&str> = plan
         .hosts
         .iter()
@@ -849,6 +864,478 @@ pub(crate) fn fleet_summary_lines(
     if compensated && schema_moved(plan, outcomes) {
         lines.push(format!(
             "  \u{26A0}\u{FE0F}  {FLEET_SCHEMA_NOT_ROLLED_BACK_NOTE}"
+        ));
+    }
+    lines
+}
+
+// ── `deploy status`: per-host state and drift (issue #1621, AC-6) ────────────
+
+/// The deployed release a host reports, or the honest absence of one.
+///
+/// `Unknown` is a first-class, DISTINCT state — never folded into drift. The only
+/// release identity a host can be asked for is its `current` symlink's basename
+/// (no runtime endpoint reports one: the probe body's `version` is the framework
+/// crate version, identical on every host forever), and that symlink can be
+/// missing on a host that has never been deployed, dangling mid-incident, or
+/// unreadable because the SSH round-trip degraded. Calling any of those "a
+/// different version" would report a mixed fleet that does not exist, and a false
+/// alarm at 3 am is worse than no alarm.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum ReleaseId {
+    /// The release id read from the host's `current` symlink.
+    Known(String),
+    /// The host did not report a release (never deployed, symlink unreadable, or
+    /// the host was unreachable). Reported, never counted as drift.
+    Unknown,
+}
+
+/// State drift: the live-slot marker names a different slot than the proxy is
+/// actually serving.
+///
+/// Not cosmetic — the next redeploy picks the candidate slot from this marker, so
+/// a drifted marker makes it restart the slot that is CURRENTLY SERVING, taking
+/// the host down mid-deploy. (`deploy up` repairs it automatically; `status`
+/// surfaces it before then.)
+pub(crate) const DRIFT_LIVE_SLOT_MARKER: &str =
+    "live-slot marker disagrees with the slot kamal-proxy is serving";
+
+/// State drift: the `shared/proxy-options` marker exists but cannot be parsed.
+///
+/// The refuse-unprovable-proxy-options guard fails CLOSED on this, so the next
+/// deploy of this host is already broken — it just has not been attempted yet.
+/// That is exactly the kind of debris a status command exists to surface.
+pub(crate) const DRIFT_PROXY_OPTIONS_UNREADABLE: &str =
+    "shared/proxy-options marker is unreadable — the NEXT deploy of this host will refuse";
+
+/// State drift: the installed kamal-proxy unit binds a different public port than
+/// this project configures.
+///
+/// The redeploy path refuses a concurrent public-port change (it would strand the
+/// old port mid-cutover), so this host cannot be redeployed until the two agree.
+pub(crate) const DRIFT_PROXY_PORT_MISMATCH: &str =
+    "the installed proxy unit binds a different public port than `[server] port` configures";
+
+/// The sentence every maintenance-related surface prints, because the mechanism is
+/// counter-intuitive and getting it wrong causes an outage (plan §6.4).
+///
+/// `build_maintenance_layer` puts `/ready` on the probe-bypass list, so a host in
+/// maintenance mode keeps answering its load balancer's health check with 200 and
+/// stays in rotation, serving 503s with `Retry-After` to real users. That is
+/// DELIBERATE — gating `/ready` would eject every host from the pool the moment
+/// maintenance was enabled — but it means maintenance mode is not a drain, and
+/// `deploy status` therefore reports readiness and maintenance in SEPARATE columns.
+pub(crate) const MAINTENANCE_DOES_NOT_DRAIN_NOTE: &str = "maintenance mode does NOT drain a host from your load balancer: `/ready` stays 200 by \
+     design, so a maintained host keeps taking traffic and answers it with 503. Drain at the \
+     load balancer if you need the host out of rotation.";
+
+/// One host's observed state, as `deploy status` reports it (issue #1621, AC-6).
+///
+/// Pure data assembled from a read-only probe. It carries the FACTS, never a
+/// verdict: [`fleet_drift`] is the (pure) function that turns a fleet of these into
+/// a report, so the drift rules are unit-testable against synthetic hosts.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct HostStatus {
+    /// The SSH-reachable address (never an op label — rule 2).
+    pub(crate) host: String,
+    /// Whether the read-only probe completed at all. Everything below is
+    /// unknown/false for an unreachable host, and [`fleet_drift`] never derives
+    /// drift from it — a network outage is not a deploy defect.
+    pub(crate) reachable: bool,
+    /// First-deploy vs redeploy, as probed.
+    pub(crate) mode: Option<HostMode>,
+    /// The release the host's `current` symlink names.
+    pub(crate) release: ReleaseId,
+    /// The slot serving now, reconciled against the live proxy.
+    pub(crate) live_slot: Option<&'static str>,
+    /// HTTP status the live slot's loopback `/ready` returned, `None` when nothing
+    /// answered.
+    pub(crate) ready_code: Option<u16>,
+    /// Whether the shared maintenance flag file is present. ORTHOGONAL to
+    /// `ready_code` — see [`MAINTENANCE_DOES_NOT_DRAIN_NOTE`].
+    pub(crate) maintenance_on: bool,
+    /// The `--http-port` the installed proxy unit binds.
+    pub(crate) installed_proxy_port: exec::InstalledProxyPort,
+    /// The TLS/host options the last forward deploy recorded.
+    pub(crate) proxy_options: exec::ProxyOptionsMarker,
+    /// The public port THIS project configures, for the mismatch comparison.
+    pub(crate) public_port: u16,
+    /// Whether the live-slot marker disagrees with the running proxy.
+    pub(crate) live_slot_marker_drift: bool,
+}
+
+impl HostStatus {
+    /// The status of a host whose read-only probe could not be completed.
+    ///
+    /// Deliberately not an error: `deploy status` reports the whole fleet or it is
+    /// useless during the incident it exists for, so one unreachable host is a row,
+    /// not an abort.
+    pub(crate) fn unreachable(host: impl Into<String>) -> Self {
+        Self {
+            host: host.into(),
+            reachable: false,
+            mode: None,
+            release: ReleaseId::Unknown,
+            live_slot: None,
+            ready_code: None,
+            maintenance_on: false,
+            installed_proxy_port: exec::InstalledProxyPort::Absent,
+            proxy_options: exec::ProxyOptionsMarker::Absent,
+            public_port: 0,
+            live_slot_marker_drift: false,
+        }
+    }
+
+    /// Assemble a status row from one host's read-only probe — PURE, so every
+    /// mapping rule is testable from synthetic probe values.
+    pub(crate) fn from_probe(
+        cfg: &ResolvedDeployConfig,
+        public_port: u16,
+        probe: &exec::HostStatusProbe,
+    ) -> Self {
+        let reconcile = probe.reconcile(cfg, public_port);
+        Self {
+            host: cfg.host.clone().unwrap_or_default(),
+            reachable: true,
+            mode: Some(HostMode::from_deploy_mode(&probe.deploy.mode)),
+            release: probe
+                .deploy
+                .current_release_dir
+                .as_deref()
+                .and_then(exec::release_id_from_dir)
+                .map_or(ReleaseId::Unknown, |id| ReleaseId::Known(id.to_owned())),
+            live_slot: reconcile.as_ref().map(|r| r.live_slot),
+            ready_code: probe.ready_code,
+            maintenance_on: probe.maintenance_on,
+            installed_proxy_port: probe.deploy.installed_proxy_port.clone(),
+            proxy_options: probe.deploy.last_proxy_options.clone(),
+            public_port,
+            live_slot_marker_drift: reconcile.is_some_and(|r| r.repair),
+        }
+    }
+}
+
+/// What `deploy status` concluded about the fleet (issue #1621, §7.2).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct DriftReport {
+    /// Each host's reported release, in declaration order — the EVIDENCE, printed
+    /// alongside the verdict so an operator can check it.
+    pub(crate) releases: Vec<(String, ReleaseId)>,
+    /// More than one DISTINCT KNOWN release across the fleet.
+    pub(crate) version_drift: bool,
+    /// Per-host state disagreements, each with its reason. Kept separate from
+    /// `version_drift` because these are the failures that will make a FUTURE
+    /// deploy fail closed — folding them into "version drift" would hide them
+    /// behind a perfectly converged fleet.
+    pub(crate) state_drift: Vec<(String, &'static str)>,
+}
+
+impl DriftReport {
+    /// Whether ANY drift was found — the `--strict` exit condition.
+    pub(crate) const fn drifted(&self) -> bool {
+        self.version_drift || !self.state_drift.is_empty()
+    }
+
+    /// Hosts that reported no release, named so "unknown" is visible rather than
+    /// inferred from a blank column.
+    pub(crate) fn unknown_releases(&self) -> Vec<&str> {
+        self.releases
+            .iter()
+            .filter(|(_, release)| matches!(release, ReleaseId::Unknown))
+            .map(|(host, _)| host.as_str())
+            .collect()
+    }
+
+    /// The distinct KNOWN releases across the fleet, in first-seen order — what
+    /// version drift is actually about.
+    pub(crate) fn known_releases(&self) -> Vec<&str> {
+        let mut seen: Vec<&str> = Vec::new();
+        for (_, release) in &self.releases {
+            if let ReleaseId::Known(id) = release
+                && !seen.contains(&id.as_str())
+            {
+                seen.push(id.as_str());
+            }
+        }
+        seen
+    }
+}
+
+/// Reduce a fleet's observed status to a drift report — PURE (issue #1621, §7.2).
+///
+/// Two rules carry all the weight:
+///
+/// 1. **Version drift is more than one DISTINCT KNOWN release.** `Unknown` never
+///    contributes (see [`ReleaseId`]). A partially-compensated fleet legitimately
+///    holds up to three distinct ids, and the report says so — that is information,
+///    not corruption.
+/// 2. **State drift is per host and separate.** Each reason is a `&'static str`
+///    (never a shell line or a driver error), and each names a condition that will
+///    make a FUTURE deploy of that host fail closed or take the wrong slot.
+///
+/// An UNREACHABLE host contributes an `Unknown` release and no state drift at all:
+/// its markers were never read, so deriving drift from their absence would report
+/// a network outage as a deploy defect.
+pub(crate) fn fleet_drift(hosts: &[HostStatus]) -> DriftReport {
+    let releases: Vec<(String, ReleaseId)> = hosts
+        .iter()
+        .map(|status| (status.host.clone(), status.release.clone()))
+        .collect();
+
+    let mut known: Vec<&str> = Vec::new();
+    for status in hosts {
+        if let ReleaseId::Known(id) = &status.release
+            && !known.contains(&id.as_str())
+        {
+            known.push(id.as_str());
+        }
+    }
+
+    let mut state_drift: Vec<(String, &'static str)> = Vec::new();
+    for status in hosts.iter().filter(|status| status.reachable) {
+        if status.live_slot_marker_drift {
+            state_drift.push((status.host.clone(), DRIFT_LIVE_SLOT_MARKER));
+        }
+        if matches!(status.proxy_options, exec::ProxyOptionsMarker::Unreadable) {
+            state_drift.push((status.host.clone(), DRIFT_PROXY_OPTIONS_UNREADABLE));
+        }
+        // Only a PROVEN different port is drift: `Absent` (no unit yet) and
+        // `Unreadable` are handled by the deploy path's own fail-closed guard, and
+        // reporting them here would flag every never-deployed host.
+        if matches!(status.installed_proxy_port, exec::InstalledProxyPort::Port(port) if port != status.public_port)
+        {
+            state_drift.push((status.host.clone(), DRIFT_PROXY_PORT_MISMATCH));
+        }
+    }
+
+    DriftReport {
+        version_drift: known.len() > 1,
+        releases,
+        state_drift,
+    }
+}
+
+/// One status row's seven display cells, in column order: mode, release, slot,
+/// readiness, maintenance, proxy port, drift reasons. Extracted from
+/// [`fleet_status_lines`] so the renderer stays within the line budget and the
+/// cell wording has one home.
+fn status_row_cells(status: &HostStatus, report: &DriftReport) -> [String; 7] {
+    [
+        match status.mode {
+            _ if !status.reachable => "unreachable".to_owned(),
+            Some(HostMode::First) => "not deployed".to_owned(),
+            Some(HostMode::Redeploy) => "deployed".to_owned(),
+            None => "unknown".to_owned(),
+        },
+        match &status.release {
+            ReleaseId::Known(id) => id.clone(),
+            ReleaseId::Unknown => "release unknown".to_owned(),
+        },
+        status.live_slot.unwrap_or("slot ?").to_owned(),
+        status
+            .ready_code
+            .map_or_else(|| "ready ?".to_owned(), |code| format!("ready {code}")),
+        if status.maintenance_on {
+            "maintenance ON".to_owned()
+        } else {
+            "maintenance off".to_owned()
+        },
+        match &status.installed_proxy_port {
+            exec::InstalledProxyPort::Port(port) => format!("proxy {port}"),
+            exec::InstalledProxyPort::Absent => "proxy absent".to_owned(),
+            exec::InstalledProxyPort::Unreadable => "proxy ?".to_owned(),
+        },
+        {
+            let reasons: Vec<&str> = report
+                .state_drift
+                .iter()
+                .filter(|(host, _)| *host == status.host)
+                .map(|(_, reason)| *reason)
+                .collect();
+            if reasons.is_empty() {
+                String::new()
+            } else {
+                format!("\u{26A0}\u{FE0F}  {}", reasons.join("; "))
+            }
+        },
+    ]
+}
+
+/// The `deploy status` table: one aligned row per host, then the verdict.
+///
+/// Rendered through [`state_table_lines`] — the SAME primitive the rollout summary
+/// and the fleet rollback summary use — so the fleet views can never disagree
+/// about how a host row looks (plan §7.3).
+///
+/// Readiness and maintenance are deliberately SEPARATE columns; see
+/// [`MAINTENANCE_DOES_NOT_DRAIN_NOTE`].
+pub(crate) fn fleet_status_lines(hosts: &[HostStatus], report: &DriftReport) -> Vec<String> {
+    let cells: Vec<[String; 7]> = hosts
+        .iter()
+        .map(|status| status_row_cells(status, report))
+        .collect();
+
+    // Column widths, so the composite "state" the shared row renderer prints is
+    // itself aligned. The last column is ragged by design (it is prose).
+    let mut widths = [0_usize; 7];
+    for row in &cells {
+        for (width, cell) in widths.iter_mut().zip(row) {
+            *width = (*width).max(cell.chars().count());
+        }
+    }
+
+    let rows: Vec<(&'static str, &str, String)> = hosts
+        .iter()
+        .zip(&cells)
+        .map(|(status, cells)| {
+            let marker = if !status.reachable {
+                "\u{274C}"
+            } else if report
+                .state_drift
+                .iter()
+                .any(|(host, _)| *host == status.host)
+                || status.maintenance_on
+            {
+                "\u{26A0}\u{FE0F} "
+            } else {
+                "\u{2705}"
+            };
+            let mut state = String::new();
+            for (index, cell) in cells.iter().enumerate() {
+                if index > 0 {
+                    state.push_str("  ");
+                }
+                state.push_str(cell);
+                // Pad every column but the last (the ragged prose column) by hand
+                // — no `format!` allocation per cell.
+                if index + 1 < cells.len() {
+                    for _ in cell.chars().count()..widths[index] {
+                        state.push(' ');
+                    }
+                }
+            }
+            (marker, status.host.as_str(), state.trim_end().to_owned())
+        })
+        .collect();
+
+    let mut lines = state_table_lines("Fleet status:", &rows);
+
+    if report.version_drift {
+        lines.push(format!(
+            "  \u{26A0}\u{FE0F}  VERSION DRIFT: {} distinct releases across this fleet ({}). \
+             Converge with `autumn deploy up`, or roll the fleet back with \
+             `autumn deploy rollback`.",
+            report.known_releases().len(),
+            report.known_releases().join(", "),
+        ));
+    }
+    let unknown = report.unknown_releases();
+    if !unknown.is_empty() {
+        // Named, and explicitly NOT called drift — the evidence matters more than
+        // the verdict here.
+        lines.push(format!(
+            "  \u{2139}\u{FE0F}  release unknown on {} (the `current` symlink was unreadable) \
+             \u{2014} reported, not counted as drift.",
+            unknown.join(", "),
+        ));
+    }
+    for (host, reason) in &report.state_drift {
+        lines.push(format!("  \u{26A0}\u{FE0F}  {host}: {reason}"));
+    }
+    if hosts.iter().any(|status| status.maintenance_on) {
+        lines.push(format!(
+            "  \u{2139}\u{FE0F}  {MAINTENANCE_DOES_NOT_DRAIN_NOTE}"
+        ));
+    }
+    lines
+}
+
+// ── Fleet-wide `deploy maintenance` (issue #1621, AC-5) ──────────────────────
+
+/// What the maintenance fan-out did to ONE host (issue #1621, §6.2).
+///
+/// Best-effort-and-aggregate — the OPPOSITE of the rollout driver. Turning
+/// maintenance on for 2 of 3 hosts and then "rolling back" the 2 would push users
+/// back into the very window the operator is trying to close, so a partial result
+/// is REPORTED, never compensated.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum MaintenanceOutcome {
+    /// Both flag paths written/removed (amendment A2: the shared authoritative
+    /// path AND the release-local legacy path for units deployed before #1621).
+    Applied,
+    /// Only the shared path was written/removed: the host's `current` symlink did
+    /// not resolve, so there is no release dir to carry the legacy flag. Fine for
+    /// a host already redeployed with #1621 units; noted so the operator knows.
+    AppliedSharedOnly,
+    /// The change failed on this host at this step. Never swallowed, and never a
+    /// shell line — the label only.
+    Failed {
+        /// Label of the op that failed.
+        failed_step: &'static str,
+    },
+}
+
+/// The per-host table printed at the end of a `deploy maintenance on|off` fan-out.
+///
+/// Printed on EVERY exit path: after a partial change the operator must know which
+/// hosts DID change (they may need reversing by hand), and the orthogonality note
+/// is repeated because assuming maintenance drains a host from the LB causes an
+/// outage (plan §6.4).
+pub(crate) fn fleet_maintenance_summary_lines(
+    hosts: &[String],
+    outcomes: &[MaintenanceOutcome],
+    on: bool,
+) -> Vec<String> {
+    let verb = if on { "enabled" } else { "disabled" };
+    let mut rows: Vec<(&'static str, &str, String)> = Vec::with_capacity(hosts.len());
+    for (host, outcome) in hosts.iter().zip(outcomes) {
+        let (marker, state) = match outcome {
+            MaintenanceOutcome::Applied => ("\u{2705}", format!("maintenance {verb}")),
+            MaintenanceOutcome::AppliedSharedOnly => (
+                "\u{26A0}\u{FE0F} ",
+                format!(
+                    "maintenance {verb} (shared flag only \u{2014} no `current` release \
+                     resolved on this host, so the release-local flag for pre-#1621 units \
+                     was skipped)"
+                ),
+            ),
+            MaintenanceOutcome::Failed { failed_step } => (
+                "\u{274C}",
+                format!("UNCHANGED \u{2014} failed at `{failed_step}`"),
+            ),
+        };
+        rows.push((marker, host.as_str(), state));
+    }
+    let mut lines = state_table_lines("Fleet maintenance state:", &rows);
+
+    let changed: Vec<&str> = hosts
+        .iter()
+        .zip(outcomes)
+        .filter(|(_, outcome)| !matches!(outcome, MaintenanceOutcome::Failed { .. }))
+        .map(|(host, _)| host.as_str())
+        .collect();
+    let failed: Vec<&str> = hosts
+        .iter()
+        .zip(outcomes)
+        .filter(|(_, outcome)| matches!(outcome, MaintenanceOutcome::Failed { .. }))
+        .map(|(host, _)| host.as_str())
+        .collect();
+    if !failed.is_empty() && !changed.is_empty() {
+        // Naming the hosts that DID change is the point: a partial change is never
+        // rolled back automatically (that would reopen the window being closed), so
+        // the operator needs the exact list to reverse by hand if that is the call.
+        lines.push(format!(
+            "  \u{26A0}\u{FE0F}  Changed anyway: {changed}. NOT reversed automatically \u{2014} \
+             reverse them with `autumn deploy maintenance {reverse}` if the fleet must stay \
+             consistent while {failed} is repaired.",
+            changed = changed.join(", "),
+            reverse = if on { "off" } else { "on" },
+            failed = failed.join(", "),
+        ));
+    }
+    if on {
+        lines.push(format!(
+            "  \u{2139}\u{FE0F}  {MAINTENANCE_DOES_NOT_DRAIN_NOTE}"
         ));
     }
     lines
@@ -932,8 +1419,7 @@ pub(crate) fn fleet_rollback_summary_lines(
     hosts: &[String],
     outcomes: &[RollbackOutcome],
 ) -> Vec<String> {
-    let mut lines = vec!["Fleet rollback state:".to_owned()];
-    let width = hosts.iter().map(|h| h.chars().count()).max().unwrap_or(0);
+    let mut rows: Vec<(&'static str, &str, String)> = Vec::with_capacity(hosts.len());
     for (host, outcome) in hosts.iter().zip(outcomes) {
         let (marker, state) = match outcome {
             RollbackOutcome::RolledBack => {
@@ -953,8 +1439,9 @@ pub(crate) fn fleet_rollback_summary_lines(
                 ),
             ),
         };
-        lines.push(format!("  {marker} {host:<width$}  {state}"));
+        rows.push((marker, host.as_str(), state));
     }
+    let mut lines = state_table_lines("Fleet rollback state:", &rows);
     let stalled: Vec<&str> = hosts
         .iter()
         .zip(outcomes)
@@ -1003,6 +1490,7 @@ pub(crate) mod test_support {
         stdout: Vec<(&'static str, String)>,
         fail: Vec<&'static str>,
         transport_fail: Vec<&'static str>,
+        upload_fail: Vec<String>,
     }
 
     /// A fleet-shaped recording fake: ONE
@@ -1072,6 +1560,15 @@ pub(crate) mod test_support {
             self
         }
 
+        /// Make one host's UPLOAD fail for any remote path containing `fragment`
+        /// (#1621). Uploads carry no label, so this is keyed on the destination —
+        /// how a test fails a `WriteFile` op (e.g. the maintenance flag write) the
+        /// way a dying scp would.
+        pub(crate) fn fail_upload(mut self, host: &str, fragment: impl Into<String>) -> Self {
+            self.entry(host).upload_fail.push(fragment.into());
+            self
+        }
+
         /// The executor factory the fleet driver is injected with: one strict,
         /// tape-sharing fake per host.
         pub(crate) fn executor(&self, cfg: &ResolvedDeployConfig) -> RecordingExecutor {
@@ -1088,6 +1585,9 @@ pub(crate) mod test_support {
                 }
                 for label in &script.transport_fail {
                     exec = exec.transport_failing(label);
+                }
+                for fragment in &script.upload_fail {
+                    exec = exec.failing_upload(fragment.clone());
                 }
             }
             exec
@@ -2127,5 +2627,193 @@ mod tests {
                 "the rollback table must never carry `{secret}`:\n{rendered}"
             );
         }
+    }
+    // ── `deploy status`: per-host state and drift (issue #1621, AC-6) ─────────
+
+    /// A synthetic status row, with every "everything is fine" default in place so
+    /// each test varies exactly the one fact it is about.
+    fn status(host: &str, release: Option<&str>) -> HostStatus {
+        HostStatus {
+            host: host.to_owned(),
+            reachable: true,
+            mode: Some(HostMode::Redeploy),
+            release: release.map_or(ReleaseId::Unknown, |id| ReleaseId::Known(id.to_owned())),
+            live_slot: Some(exec::SLOT_BLUE),
+            ready_code: Some(200),
+            maintenance_on: false,
+            installed_proxy_port: exec::InstalledProxyPort::Port(3000),
+            proxy_options: exec::ProxyOptionsMarker::Options(exec::ProxyServiceOptions {
+                tls: false,
+                host: None,
+            }),
+            public_port: 3000,
+            live_slot_marker_drift: false,
+        }
+    }
+
+    #[test]
+    fn fleet_drift_reports_two_different_releases_as_version_drift() {
+        // #1621 (T1.20, AC-6): the whole point of `deploy status`. Two hosts on
+        // different KNOWN releases is a mixed fleet — the state a rolling deploy
+        // exists to avoid — so it must be reported as drift, with the evidence.
+        let report = fleet_drift(&[
+            status("web-a", Some("20260714T120000Z")),
+            status("web-b", Some("20260714T130000Z")),
+        ]);
+        assert!(report.version_drift, "differing releases are version drift");
+        assert_eq!(
+            report.releases,
+            vec![
+                (
+                    "web-a".to_owned(),
+                    ReleaseId::Known("20260714T120000Z".to_owned())
+                ),
+                (
+                    "web-b".to_owned(),
+                    ReleaseId::Known("20260714T130000Z".to_owned())
+                ),
+            ],
+            "the report names each host's release as its evidence"
+        );
+        assert!(
+            report.state_drift.is_empty(),
+            "version drift is not state drift: {:?}",
+            report.state_drift
+        );
+
+        // The converging case: one release everywhere is NOT drift.
+        let converged = fleet_drift(&[
+            status("web-a", Some("20260714T120000Z")),
+            status("web-b", Some("20260714T120000Z")),
+            status("web-c", Some("20260714T120000Z")),
+        ]);
+        assert!(!converged.version_drift);
+    }
+
+    #[test]
+    fn fleet_drift_never_treats_an_unknown_release_as_drift() {
+        // #1621 (T1.20): an unreadable `current` symlink means "we do not know",
+        // not "this host differs". A false "your fleet is mixed" at 3 am trains
+        // operators to ignore the warning, which is worse than no warning — so
+        // Unknown is a DISTINCT reported state that never contributes to drift.
+        let all_unknown = fleet_drift(&[status("web-a", None), status("web-b", None)]);
+        assert!(
+            !all_unknown.version_drift,
+            "an all-unknown fleet is not drifted, it is unreported"
+        );
+        assert_eq!(
+            all_unknown.releases,
+            vec![
+                ("web-a".to_owned(), ReleaseId::Unknown),
+                ("web-b".to_owned(), ReleaseId::Unknown),
+            ],
+            "…and the unknowns are still named"
+        );
+        assert!(all_unknown.unknown_releases().contains(&"web-a"));
+
+        // One known + one unknown is likewise not drift: there is exactly one known
+        // release, and the unknown is reported separately.
+        let mixed = fleet_drift(&[
+            status("web-a", Some("20260714T120000Z")),
+            status("web-b", None),
+        ]);
+        assert!(!mixed.version_drift, "one known release is not drift");
+        assert_eq!(mixed.unknown_releases(), vec!["web-b"]);
+    }
+
+    #[test]
+    fn fleet_drift_reports_state_drift_separately_from_version_drift() {
+        // #1621 (T1.20, plan §7.2): these are two different things and collapsing
+        // them hides the dangerous one. Every state-drift reason below makes a
+        // FUTURE deploy of that host fail closed or take the wrong slot, on a fleet
+        // that is perfectly converged version-wise.
+        let mut marker_drift = status("web-a", Some("r1"));
+        marker_drift.live_slot_marker_drift = true;
+        let mut unreadable_options = status("web-b", Some("r1"));
+        unreadable_options.proxy_options = exec::ProxyOptionsMarker::Unreadable;
+        let mut wrong_port = status("web-c", Some("r1"));
+        wrong_port.installed_proxy_port = exec::InstalledProxyPort::Port(8080);
+
+        let report = fleet_drift(&[marker_drift, unreadable_options, wrong_port]);
+        assert!(
+            !report.version_drift,
+            "every host is on r1 — this is state drift, not version drift"
+        );
+        assert_eq!(
+            report.state_drift,
+            vec![
+                ("web-a".to_owned(), DRIFT_LIVE_SLOT_MARKER),
+                ("web-b".to_owned(), DRIFT_PROXY_OPTIONS_UNREADABLE),
+                ("web-c".to_owned(), DRIFT_PROXY_PORT_MISMATCH),
+            ],
+            "each host is named with its own reason"
+        );
+        assert!(
+            report.drifted(),
+            "state drift alone must make --strict fail"
+        );
+
+        // A clean fleet reports nothing at all.
+        let clean = fleet_drift(&[status("web-a", Some("r1")), status("web-b", Some("r1"))]);
+        assert!(!clean.drifted() && clean.state_drift.is_empty());
+    }
+
+    #[test]
+    fn fleet_drift_never_flags_a_host_it_could_not_reach() {
+        // An unreachable host has no facts, so inventing drift from its absent
+        // markers would report the network outage as a deploy defect. It is listed
+        // with an unknown release and nothing else.
+        let report = fleet_drift(&[
+            status("web-a", Some("r1")),
+            HostStatus::unreachable("web-b"),
+        ]);
+        assert!(!report.version_drift);
+        assert!(
+            report.state_drift.is_empty(),
+            "an unreachable host contributes no state drift: {:?}",
+            report.state_drift
+        );
+        assert_eq!(report.unknown_releases(), vec!["web-b"]);
+    }
+
+    #[test]
+    fn fleet_status_table_shows_readiness_and_maintenance_as_separate_columns() {
+        // #1621 (plan §6.4/§7.3): maintenance mode does NOT drain a host from a load
+        // balancer — `/ready` is on the probe-bypass list, so a maintained host stays
+        // in rotation serving 503s to real users. Reporting them in one column would
+        // teach exactly the wrong mental model, so they are separate and the table
+        // says so.
+        let mut maintained = status("web-b", Some("r1"));
+        maintained.maintenance_on = true;
+        let rows = [status("web-a", Some("r1")), maintained];
+        let report = fleet_drift(&rows);
+        let rendered = fleet_status_lines(&rows, &report).join("\n");
+
+        for host in ["web-a", "web-b"] {
+            assert!(rendered.contains(host), "every host is a row:\n{rendered}");
+        }
+        assert!(rendered.contains("r1"), "the release column:\n{rendered}");
+        assert!(rendered.contains("200"), "the ready column:\n{rendered}");
+        assert!(
+            rendered.contains(MAINTENANCE_DOES_NOT_DRAIN_NOTE),
+            "the table must state the orthogonality out loud:\n{rendered}"
+        );
+    }
+
+    #[test]
+    fn fleet_status_table_names_every_drift_reason() {
+        let mut drifted = status("web-b", Some("r2"));
+        drifted.proxy_options = exec::ProxyOptionsMarker::Unreadable;
+        let rows = [status("web-a", Some("r1")), drifted];
+        let report = fleet_drift(&rows);
+        let rendered = fleet_status_lines(&rows, &report).join("\n");
+        assert!(
+            rendered.contains(DRIFT_PROXY_OPTIONS_UNREADABLE),
+            "a state-drift reason must be spelled out, not abbreviated:\n{rendered}"
+        );
+        assert!(
+            rendered.contains("r1") && rendered.contains("r2"),
+            "version drift must show WHICH releases:\n{rendered}"
+        );
     }
 }

--- a/autumn-cli/src/deploy/fleet.rs
+++ b/autumn-cli/src/deploy/fleet.rs
@@ -43,11 +43,6 @@
 // flags each `pub(crate)` as redundant; they are kept to document the intended
 // visibility rather than widening to `pub`.
 #![allow(clippy::redundant_pub_crate)]
-// The planning types and the ops helper are consumed by this module's tests and
-// by the plan drift guard today; the serial rollout DRIVER that consumes them in
-// production lands in the next slice of #1621 (mirroring how `ResolvedFleet`
-// itself was landed).
-#![cfg_attr(not(test), allow(dead_code))]
 
 use std::path::Path;
 
@@ -319,6 +314,219 @@ pub(crate) fn fleet_plan_lines(hosts: &[String]) -> Vec<String> {
     lines
 }
 
+/// Where one host ended up after a fleet rollout (issue #1621, AC-3/AC-6).
+///
+/// Recorded per host by the driver and reported on **every** exit path — success
+/// or halt — because a halted rollout is exactly the moment an operator has no
+/// other source of truth about which host is running what.
+///
+/// The variants are deliberately the ones the EXISTING per-host executor already
+/// distinguishes, so nothing is inferred: [`exec::execute_with_teardown`] returns
+/// `CandidateRolledBack`/`FirstDeployTornDown` **only** for a failure at or before
+/// the go-live boundary (traffic never moved, the candidate was cleaned up), and
+/// the raw error otherwise (the host is live on the new release). The finer
+/// post-boundary classification — housekeeping vs ambiguous-markers vs functional —
+/// and the fleet-wide compensation it drives land with the next slice.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum HostOutcome {
+    /// The rollout halted before this host was reached. Nothing was mutated on it.
+    Untouched,
+    /// The host is serving the new release.
+    Serving,
+    /// A pre-boundary failure on a REDEPLOY host: the candidate was torn down and
+    /// this host's previous release is still serving.
+    RolledBack {
+        /// Label of the step that failed.
+        failed_step: &'static str,
+    },
+    /// A pre-boundary failure on a FIRST-deploy host: there was no previous
+    /// release, so the candidate was torn down and nothing serves here.
+    TornDown {
+        /// Label of the step that failed.
+        failed_step: &'static str,
+    },
+    /// A post-boundary failure: traffic has already moved, so this host IS running
+    /// the new release even though the deploy reported failure.
+    LiveOnNew {
+        /// Label of the step that failed.
+        failed_step: &'static str,
+    },
+}
+
+/// The step label to attribute a failure to — always a `&'static str` op label, so
+/// a fleet error can never carry a shell line, a remote path, or a driver message.
+///
+/// Secrets discipline is load-bearing here: `DeployExecError`'s own `Display` is
+/// already redacted, but the fleet error/summary types quote only labels and host
+/// names, never a formatted source error.
+pub(crate) const fn failed_step_label(err: &exec::DeployExecError) -> &'static str {
+    match err {
+        exec::DeployExecError::CommandFailed { label, .. } => label,
+        exec::DeployExecError::CandidateRolledBack { failed_step, .. }
+        | exec::DeployExecError::FirstDeployTornDown { failed_step, .. }
+        | exec::DeployExecError::RollbackFailed { failed_step, .. } => failed_step,
+        exec::DeployExecError::UploadFailed { .. } => "upload",
+        exec::DeployExecError::Stage { .. } => "stage-local-file",
+        exec::DeployExecError::Spawn { .. } => "ssh-transport",
+        exec::DeployExecError::PreflightAborted { .. } => "preflight",
+        exec::DeployExecError::ProxyIncompatible { .. } => "proxy-compat-probe",
+        exec::DeployExecError::NoPreviousRelease => "resolve-previous",
+    }
+}
+
+/// Classify one host's execution failure into its [`HostOutcome`] — pure, and the
+/// discriminator AC-3 turns on.
+///
+/// Anything that is NOT one of the executor's two clean-failure variants is
+/// treated as **live on the new release**: that is the fail-closed reading, since
+/// `execute_with_teardown` returns the raw error precisely when the failure landed
+/// *after* the go-live boundary (or when the boundary could not be located, in
+/// which case it deliberately refuses to guess).
+pub(crate) const fn classify_failure(err: &exec::DeployExecError) -> HostOutcome {
+    match err {
+        exec::DeployExecError::CandidateRolledBack { failed_step, .. } => {
+            HostOutcome::RolledBack { failed_step }
+        }
+        exec::DeployExecError::FirstDeployTornDown { failed_step, .. } => {
+            HostOutcome::TornDown { failed_step }
+        }
+        _ => HostOutcome::LiveOnNew {
+            failed_step: failed_step_label(err),
+        },
+    }
+}
+
+/// The loud line printed when a fleet rollout schedules no migration at all.
+///
+/// [`exec::first_deploy_ops`] carries no migrate op (a first deploy has never run
+/// migrations — a documented single-host limitation), so an all-first-deploy fleet
+/// migrates NOWHERE. That is fine for a brand-new app and catastrophic for one
+/// with pending migrations, so it is said out loud rather than inferred from the
+/// absence of a `migrate` line.
+pub(crate) const FLEET_NO_MIGRATION_NOTE: &str = "no host in this fleet is on a previous release, so this rollout runs NO migrations \
+     (a first deploy never does) — run `autumn migrate` yourself before serving traffic";
+
+/// The one-line reminder printed once, after the fleet's single migration lands.
+pub(crate) const FLEET_SCHEMA_MOVED_NOTE: &str = "the schema has moved; from here an automatic rollback restores BINARIES only — \
+     it never rolls a migration back";
+
+/// The `deploy up` fleet header: rollout order, each host's probed mode, and where
+/// the single fleet-wide migration lands (issue #1621, §8.1).
+///
+/// Rendered **only** when more than one host is configured, so single-host output
+/// stays byte-identical to pre-#1621.
+///
+/// `writable_db_configured` gates the no-migration warning: an app with no
+/// writable database has no schema to be behind, so warning about it would be
+/// noise.
+pub(crate) fn fleet_rollout_lines(
+    plan: &FleetPlan,
+    release_id: &str,
+    writable_db_configured: bool,
+) -> Vec<String> {
+    let count = plan.hosts.len();
+    let mut lines = Vec::with_capacity(count + 3);
+    lines.push(format!(
+        "Rolling release {release_id} across {count} hosts, ONE AT A TIME, in `[deploy] hosts` \
+         order:"
+    ));
+    for (index, host) in plan.hosts.iter().enumerate() {
+        let mode = match host.mode {
+            HostMode::First => "first deploy",
+            HostMode::Redeploy => "zero-downtime redeploy",
+        };
+        lines.push(format!("  {}. {} — {mode}", index + 1, host.host));
+    }
+    match plan.migrating_host() {
+        Some(migrating) => {
+            let skipped: Vec<&str> = plan
+                .hosts
+                .iter()
+                .filter(|h| h.host != migrating.host)
+                .map(|h| h.host.as_str())
+                .collect();
+            lines.push(format!(
+                "  \u{2192} migrate ({} only \u{2014} the schema is fleet-wide; {} skip it)",
+                migrating.host,
+                skipped.join(", "),
+            ));
+        }
+        None if writable_db_configured => {
+            lines.push(format!("  \u{26A0}\u{FE0F}  {FLEET_NO_MIGRATION_NOTE}"));
+        }
+        None => {}
+    }
+    lines
+}
+
+/// The per-host state table printed at the END of every fleet rollout — success or
+/// halt (issue #1621, §8.2).
+///
+/// On a halt this is the operator's only source of truth about which host runs
+/// what, so it names the recovery command for each host left on the new release
+/// and states plainly that the schema was NOT rolled back.
+pub(crate) fn fleet_summary_lines(
+    plan: &FleetPlan,
+    outcomes: &[HostOutcome],
+    release_id: &str,
+) -> Vec<String> {
+    let mut lines = vec!["Fleet state:".to_owned()];
+    let width = plan
+        .hosts
+        .iter()
+        .map(|h| h.host.chars().count())
+        .max()
+        .unwrap_or(0);
+    for (host, outcome) in plan.hosts.iter().zip(outcomes) {
+        let state = match outcome {
+            HostOutcome::Untouched => "untouched (not reached)".to_owned(),
+            HostOutcome::Serving => format!("serving {release_id}"),
+            // Traffic already moved before the failure, so this host IS on the new
+            // release — saying only "failed" would be the dangerous half-truth.
+            HostOutcome::LiveOnNew { failed_step } => {
+                format!(
+                    "serving {release_id} \u{2014} but `{failed_step}` failed AFTER the cutover"
+                )
+            }
+            HostOutcome::RolledBack { failed_step } => {
+                format!("previous release still serving (rolled back at `{failed_step}`)")
+            }
+            HostOutcome::TornDown { failed_step } => {
+                format!("NOTHING serving (first deploy torn down at `{failed_step}`)")
+            }
+        };
+        let marker = match outcome {
+            HostOutcome::Serving => "\u{2705}",
+            HostOutcome::Untouched => "\u{2013}",
+            _ => "\u{274C}",
+        };
+        lines.push(format!(
+            "  {marker} {host:<width$}  {state}",
+            host = host.host,
+        ));
+    }
+    let on_new: Vec<&str> = plan
+        .hosts
+        .iter()
+        .zip(outcomes)
+        .filter(|(_, outcome)| {
+            matches!(
+                outcome,
+                HostOutcome::Serving | HostOutcome::LiveOnNew { .. }
+            )
+        })
+        .map(|(host, _)| host.host.as_str())
+        .collect();
+    if !on_new.is_empty() {
+        lines.push(format!(
+            "  On {release_id}: {}. Roll a host back with `autumn deploy rollback`.",
+            on_new.join(", "),
+        ));
+        lines.push(format!("  \u{26A0}\u{FE0F}  {FLEET_SCHEMA_MOVED_NOTE}"));
+    }
+    lines
+}
+
 /// Test-only fixtures shared by this module's unit tests and the `deploy` plan↔ops
 /// drift guard, so both drive the ops through the SAME per-host inputs the slice-3
 /// driver will use.
@@ -326,11 +534,144 @@ pub(crate) fn fleet_plan_lines(hosts: &[String]) -> Vec<String> {
 pub(crate) mod test_support {
     use super::{FleetPlan, HostMode, HostOpsInput, HostPlan, host_ops};
     use crate::deploy::ResolvedDeployConfig;
+    use crate::deploy::exec::test_support::{FleetTape, RecordedCall, RecordingExecutor};
     use crate::deploy::exec::{
         DeployOp, ManifestUpload, ProxyServiceOptions, SLOT_BLUE, Secret, SlotPlan,
     };
     use crate::deploy::{ResolvedFleet, render_app_unit};
     use std::path::{Path, PathBuf};
+    use std::rc::Rc;
+
+    /// One host's scripted responses inside a [`FleetRecorder`].
+    #[derive(Default)]
+    struct HostScript {
+        host: String,
+        stdout: Vec<(&'static str, String)>,
+        fail: Vec<&'static str>,
+    }
+
+    /// A fleet-shaped recording fake: ONE
+    /// [`RecordingExecutor`](crate::deploy::exec::test_support::RecordingExecutor)
+    /// per host, all writing `(host, call)` onto one shared tape (issue #1621,
+    /// plan §9.2).
+    ///
+    /// The shared tape is the point. A per-host call list can say "host B ran
+    /// `start-candidate`", but it cannot say **when** relative to host A — and the
+    /// whole safety claim of a rolling deploy is an ordering claim ("host k+1 is
+    /// not touched until host k has cut over"). The tape makes that assertable
+    /// directly.
+    ///
+    /// Every executor it hands out is [`RecordingExecutor::strict`], so a host
+    /// whose probe was not scripted panics loudly instead of silently taking the
+    /// first-deploy branch on empty stdout.
+    #[derive(Default)]
+    pub(crate) struct FleetRecorder {
+        tape: FleetTape,
+        scripts: Vec<HostScript>,
+    }
+
+    impl FleetRecorder {
+        /// An empty recorder; hosts are registered by [`Self::script`] /
+        /// [`Self::fail`] / [`Self::host`].
+        pub(crate) fn new() -> Self {
+            Self::default()
+        }
+
+        fn entry(&mut self, host: &str) -> &mut HostScript {
+            if let Some(index) = self.scripts.iter().position(|s| s.host == host) {
+                return &mut self.scripts[index];
+            }
+            self.scripts.push(HostScript {
+                host: host.to_owned(),
+                ..HostScript::default()
+            });
+            self.scripts
+                .last_mut()
+                .expect("a script was just pushed for this host")
+        }
+
+        /// Script one host's stdout for `label`.
+        pub(crate) fn script(
+            mut self,
+            host: &str,
+            label: &'static str,
+            stdout: impl Into<String>,
+        ) -> Self {
+            let stdout = stdout.into();
+            self.entry(host).stdout.push((label, stdout));
+            self
+        }
+
+        /// Make one host's `label` fail (a scripted `CommandFailed`).
+        pub(crate) fn fail(mut self, host: &str, label: &'static str) -> Self {
+            self.entry(host).fail.push(label);
+            self
+        }
+
+        /// The executor factory the fleet driver is injected with: one strict,
+        /// tape-sharing fake per host.
+        pub(crate) fn executor(&self, cfg: &ResolvedDeployConfig) -> RecordingExecutor {
+            let host = cfg.host.clone().unwrap_or_default();
+            let mut exec = RecordingExecutor::new()
+                .strict()
+                .recording_as(host.clone(), Rc::clone(&self.tape));
+            if let Some(script) = self.scripts.iter().find(|s| s.host == host) {
+                for (label, stdout) in &script.stdout {
+                    exec = exec.with_stdout(label, stdout.clone());
+                }
+                for label in &script.fail {
+                    exec = exec.failing(label);
+                }
+            }
+            exec
+        }
+
+        /// One host's calls, in order (uploads included).
+        pub(crate) fn calls_for(&self, host: &str) -> Vec<RecordedCall> {
+            self.tape
+                .borrow()
+                .iter()
+                .filter(|(h, _)| h == host)
+                .map(|(_, call)| call.clone())
+                .collect()
+        }
+
+        /// One host's `Run` labels, in order.
+        pub(crate) fn run_labels_for(&self, host: &str) -> Vec<&'static str> {
+            self.calls_for(host)
+                .iter()
+                .filter_map(RecordedCall::run_label)
+                .collect()
+        }
+
+        /// Global index of the first call on `host` whose label is NOT in
+        /// `read_only` — i.e. that host's first MUTATING op (an upload counts).
+        pub(crate) fn first_mutating(&self, host: &str, read_only: &[&str]) -> Option<usize> {
+            self.tape.borrow().iter().position(|(h, call)| {
+                h == host && !call.run_label().is_some_and(|l| read_only.contains(&l))
+            })
+        }
+
+        /// Global index of the first `Run` of `label` on `host`.
+        pub(crate) fn index_of(&self, host: &str, label: &str) -> Option<usize> {
+            self.tape
+                .borrow()
+                .iter()
+                .position(|(h, call)| h == host && call.run_label() == Some(label))
+        }
+
+        /// Every call across the fleet that is NOT one of the `read_only` probe
+        /// labels — the "did anything get mutated?" query. Uploads are always
+        /// mutating (they have no label to allowlist).
+        pub(crate) fn mutating(&self, read_only: &[&str]) -> Vec<(String, RecordedCall)> {
+            self.tape
+                .borrow()
+                .iter()
+                .filter(|(_, call)| !call.run_label().is_some_and(|l| read_only.contains(&l)))
+                .cloned()
+                .collect()
+        }
+    }
 
     /// The one release id every host in a test fleet deploys (rule 3).
     pub(crate) const RELEASE_ID: &str = "20260714T120000Z";
@@ -677,6 +1018,210 @@ mod tests {
             err,
             FleetPlanError::ModeCountMismatch { hosts: 2, modes: 1 },
             "the refusal must name both counts, got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn failure_classification_distinguishes_a_clean_host_from_a_live_one() {
+        // #1621 (AC-3): the whole "no mixed versions" decision turns on ONE
+        // question per host — did traffic move? `execute_with_teardown` already
+        // answers it: it returns `CandidateRolledBack`/`FirstDeployTornDown` ONLY
+        // for a failure at or before the go-live boundary, and the raw error
+        // otherwise. Nothing here re-derives that; it only names the two cases.
+        let boxed = || {
+            Box::new(exec::DeployExecError::CommandFailed {
+                label: "readiness-gate",
+                message: "scripted".to_owned(),
+            })
+        };
+        assert_eq!(
+            classify_failure(&exec::DeployExecError::CandidateRolledBack {
+                failed_step: "readiness-gate",
+                source: boxed(),
+            }),
+            HostOutcome::RolledBack {
+                failed_step: "readiness-gate"
+            },
+            "a pre-boundary redeploy failure leaves the previous release serving"
+        );
+        assert_eq!(
+            classify_failure(&exec::DeployExecError::FirstDeployTornDown {
+                failed_step: "readiness-gate",
+                source: boxed(),
+            }),
+            HostOutcome::TornDown {
+                failed_step: "readiness-gate"
+            },
+            "a pre-boundary first deploy has no previous release to fall back to"
+        );
+        // Fail closed: anything else means the executor did NOT tear down, which it
+        // only declines to do when the failure landed after the boundary (or when
+        // the boundary could not be located) — either way, assume the host is live.
+        assert_eq!(
+            classify_failure(&exec::DeployExecError::CommandFailed {
+                label: "drain-old",
+                message: "scripted".to_owned(),
+            }),
+            HostOutcome::LiveOnNew {
+                failed_step: "drain-old"
+            },
+            "a post-boundary failure leaves the host running the NEW release"
+        );
+    }
+
+    #[test]
+    fn failed_step_labels_are_static_and_never_quote_a_driver_message() {
+        // #1621: every fleet-facing error/summary field is a host name or a
+        // `&'static str` op label. A migration driver error can embed the database
+        // URL, so a fleet error must never format a source error into its own text.
+        assert_eq!(
+            failed_step_label(&exec::DeployExecError::CommandFailed {
+                label: "migrate",
+                message: "postgres://user:pw@db/app is unreachable".to_owned(),
+            }),
+            "migrate",
+            "the label is taken, the message is not"
+        );
+        assert_eq!(
+            failed_step_label(&exec::DeployExecError::UploadFailed {
+                remote_path: "/srv/autumn/myapp/shared/autumn.env".to_owned(),
+                message: "scripted".to_owned(),
+            }),
+            "upload",
+            "an upload failure attributes to a fixed label, never the remote path"
+        );
+        assert_eq!(
+            failed_step_label(&exec::DeployExecError::ProxyIncompatible {
+                message: "missing --drain-timeout".to_owned(),
+            }),
+            "proxy-compat-probe",
+        );
+        assert_eq!(
+            failed_step_label(&exec::DeployExecError::NoPreviousRelease),
+            "resolve-previous",
+        );
+    }
+
+    #[test]
+    fn the_rollout_header_names_the_single_migrating_host_and_who_skips() {
+        // #1621 (AC-4, §8.1): three hosts is ~48 visually identical op lines, and
+        // the first 3 a.m. question is "which host was that on?". The header answers
+        // it up front, and states where the ONE migration lands.
+        let fleet = fleet_of(&["web-a", "web-b", "web-c"]);
+        let plan = plan_fleet(
+            &fleet,
+            &[HostMode::First, HostMode::Redeploy, HostMode::Redeploy],
+        )
+        .expect("a well-formed fleet plans");
+        let rendered = fleet_rollout_lines(&plan, "20260714T120000Z", true).join("\n");
+
+        assert!(
+            rendered.contains("1. web-a — first deploy")
+                && rendered.contains("2. web-b — zero-downtime redeploy")
+                && rendered.contains("3. web-c — zero-downtime redeploy"),
+            "the header must show rollout order and each host's probed mode:\n{rendered}"
+        );
+        assert!(
+            rendered.contains("migrate (web-b only") && rendered.contains("web-a, web-c skip it"),
+            "the header must name the migrating host and the hosts that skip:\n{rendered}"
+        );
+        assert!(
+            !rendered.contains(FLEET_NO_MIGRATION_NOTE),
+            "a fleet that DOES migrate must not warn that it does not:\n{rendered}"
+        );
+    }
+
+    #[test]
+    fn an_all_first_deploy_fleet_warns_only_when_a_database_is_configured() {
+        // #1621 (AC-4): `first_deploy_ops` carries no migrate op, so an
+        // all-first-deploy fleet migrates NOWHERE — today's documented single-host
+        // limitation, generalised. That is fine for a brand-new app and
+        // catastrophic for one with pending migrations, so it is said out loud —
+        // but only when there is a writable database to be behind.
+        let fleet = fleet_of(&["web-a", "web-b"]);
+        let plan = plan_fleet(&fleet, &[HostMode::First, HostMode::First])
+            .expect("a well-formed fleet plans");
+
+        let warned = fleet_rollout_lines(&plan, "20260714T120000Z", true).join("\n");
+        assert!(
+            warned.contains(FLEET_NO_MIGRATION_NOTE) && warned.contains("autumn migrate"),
+            "a database-backed all-first fleet must name the operator's step:\n{warned}"
+        );
+        let quiet = fleet_rollout_lines(&plan, "20260714T120000Z", false).join("\n");
+        assert!(
+            !quiet.contains(FLEET_NO_MIGRATION_NOTE),
+            "an app with no writable database has no schema to warn about:\n{quiet}"
+        );
+    }
+
+    #[test]
+    fn the_summary_names_every_host_state_and_the_recovery_command() {
+        // #1621 (§8.2): a halted rollout is exactly the moment the operator has no
+        // other source of truth, so the last thing printed is per-host state — with
+        // the recovery command and the plain statement that the schema did NOT move
+        // back.
+        let fleet = fleet_of(&["web-a", "web-b", "web-c"]);
+        let plan = plan_fleet(
+            &fleet,
+            &[HostMode::Redeploy, HostMode::Redeploy, HostMode::Redeploy],
+        )
+        .expect("a well-formed fleet plans");
+        let rendered = fleet_summary_lines(
+            &plan,
+            &[
+                HostOutcome::Serving,
+                HostOutcome::RolledBack {
+                    failed_step: "readiness-gate",
+                },
+                HostOutcome::Untouched,
+            ],
+            "20260714T120000Z",
+        )
+        .join("\n");
+
+        assert!(
+            rendered.contains("web-a") && rendered.contains("serving 20260714T120000Z"),
+            "a cut-over host must be reported with the release it serves:\n{rendered}"
+        );
+        assert!(
+            rendered.contains("previous release still serving")
+                && rendered.contains("readiness-gate"),
+            "a rolled-back host must name the step that failed:\n{rendered}"
+        );
+        assert!(
+            rendered.contains("untouched"),
+            "an unreached host must be reported as untouched, not silently omitted:\n{rendered}"
+        );
+        assert!(
+            rendered.contains("autumn deploy rollback") && rendered.contains("web-a"),
+            "the summary must name the recovery command for hosts on the new release:\n{rendered}"
+        );
+        assert!(
+            rendered.contains(FLEET_SCHEMA_MOVED_NOTE),
+            "the summary must state that an automatic rollback restores binaries only:\n{rendered}"
+        );
+
+        // A fleet where nothing cut over offers no rollback command (there is
+        // nothing to roll back) and makes no schema claim.
+        let none = fleet_summary_lines(
+            &plan,
+            &[
+                HostOutcome::TornDown {
+                    failed_step: "readiness-gate",
+                },
+                HostOutcome::Untouched,
+                HostOutcome::Untouched,
+            ],
+            "20260714T120000Z",
+        )
+        .join("\n");
+        assert!(
+            !none.contains("autumn deploy rollback") && !none.contains(FLEET_SCHEMA_MOVED_NOTE),
+            "with no host on the new release there is nothing to roll back:\n{none}"
+        );
+        assert!(
+            none.contains("NOTHING serving"),
+            "a torn-down first deploy leaves nothing serving and must say so:\n{none}"
         );
     }
 

--- a/autumn-cli/src/deploy/fleet.rs
+++ b/autumn-cli/src/deploy/fleet.rs
@@ -3361,6 +3361,43 @@ mod tests {
     }
 
     #[test]
+    fn a_torn_down_host_never_renders_as_a_successful_deploy() {
+        // #1621 (AC-6, audit gap G3). A host compensated by `CompensatedTeardown`
+        // has nothing installed, and its teardown records
+        // `LAST_DEPLOY_TORN_DOWN` over the `deployed` its first deploy wrote. The
+        // status column must show that verbatim: `not deployed` in the mode cell
+        // and a last-deploy cell that does not claim a deploy.
+        let mut torn_down = status("web-a", None);
+        torn_down.mode = Some(HostMode::First);
+        torn_down.release = ReleaseId::Unknown;
+        torn_down.last_deploy = Some(exec::LastDeploy {
+            result: exec::LAST_DEPLOY_TORN_DOWN.to_owned(),
+            at: Some("2026-07-14T12:00:09Z".to_owned()),
+        });
+        let rows = [torn_down, status("web-b", Some("r1"))];
+        let report = fleet_drift(&rows);
+        let rendered = fleet_status_lines(&rows, &report).join("\n");
+
+        assert!(
+            rendered.contains("last deploy: torn down 2026-07-14T12:00:09Z"),
+            "the torn-down host must report what actually happened:\n{rendered}"
+        );
+        let web_a_row = rendered
+            .lines()
+            .find(|line| line.contains("web-a"))
+            .expect("web-a has a row");
+        assert!(
+            !web_a_row.contains("last deploy: deployed"),
+            "a host with nothing installed must never read as a successful \
+             deploy: {web_a_row}"
+        );
+        assert!(
+            web_a_row.contains("not deployed"),
+            "…and the mode cell still says so out loud: {web_a_row}"
+        );
+    }
+
+    #[test]
     fn fleet_status_table_names_every_drift_reason() {
         let mut drifted = status("web-b", Some("r2"));
         drifted.proxy_options = exec::ProxyOptionsMarker::Unreadable;

--- a/autumn-cli/src/deploy/fleet.rs
+++ b/autumn-cli/src/deploy/fleet.rs
@@ -10,7 +10,7 @@
 //! Three rules are load-bearing and easy to break by accident:
 //!
 //! 1. **Each host's ops stay in their OWN `Vec`.** No code path may concatenate
-//!    two hosts' [`exec::DeployOp`] vectors. [`exec::execute_with_teardown`]
+//!    two hosts' [`exec::DeployOp`] vectors. `exec::execute_with_teardown`
 //!    resolves the auto-rollback boundary with
 //!    `ops.iter().position(|op| op.label() == boundary_label)` — the FIRST match —
 //!    so a flat fleet-wide vector would classify every later host's *pre*-flip
@@ -324,7 +324,7 @@ pub(crate) fn fleet_plan_lines(hosts: &[String]) -> Vec<String> {
 ///
 /// The first five variants are deliberately the ones the EXISTING per-host
 /// executor already distinguishes, so nothing is inferred:
-/// [`exec::execute_with_teardown`] returns `CandidateRolledBack`/`FirstDeployTornDown`
+/// `exec::execute_with_teardown` returns `CandidateRolledBack`/`FirstDeployTornDown`
 /// **only** for a failure at or before the go-live boundary (traffic never moved,
 /// the candidate was cleaned up), and the raw error otherwise (the host is live on
 /// the new release). [`classify_post_boundary`] then refines that raw
@@ -389,7 +389,7 @@ pub(crate) enum HostOutcome {
 
 /// How bad a POST-boundary failure is (issue #1621, §4.6).
 ///
-/// "Post-boundary" means [`exec::execute_with_teardown`] returned the RAW executor
+/// "Post-boundary" means `exec::execute_with_teardown` returned the RAW executor
 /// error rather than one of its two clean-failure variants: the go-live op already
 /// succeeded, no teardown ran, and the host **is** on the new release. What to do
 /// about that depends entirely on WHICH step failed, and the three answers are
@@ -578,7 +578,7 @@ pub(crate) fn failed_step_label(err: &exec::DeployExecError) -> &'static str {
 /// host may be touched — so it is asked explicitly rather than inferred from a
 /// synthesized label string.
 ///
-/// [`exec::execute_with_teardown`] attaches the op label to every failure past a
+/// `exec::execute_with_teardown` attaches the op label to every failure past a
 /// known go-live boundary, which is what makes this answerable for the error shapes
 /// that carry none of their own.
 const fn attributed_step_label(err: &exec::DeployExecError) -> Option<&'static str> {
@@ -1109,6 +1109,46 @@ pub(crate) const DRIFT_PROXY_OPTIONS_UNREADABLE: &str =
 pub(crate) const DRIFT_PROXY_PORT_MISMATCH: &str =
     "the installed proxy unit binds a different public port than `[server] port` configures";
 
+/// State drift: this host claims a promoted release its `current` symlink could
+/// not be resolved to (issue #1621, review round 2).
+///
+/// The probe shell tests `[ -L current ]`, which succeeds for a symlink whose
+/// target cannot be canonicalized, so such a host reports `HostMode::Redeploy`
+/// while `readlink -f` yields nothing and the release reads back
+/// [`ReleaseId::Unknown`]. That combination is not "we have not looked" — it is a
+/// host that says it is serving a release nobody can name, which is exactly the
+/// unprovable state this feature fails closed on.
+///
+/// It stays out of VERSION drift (an unknown release still names no version to be
+/// mixed with), and it is the reason the NEXT deploy matters: `commit-markers`
+/// copies `readlink current` verbatim into `previous-release`, so deploying this
+/// host records an unresolvable directory as its rollback target — the rollback
+/// then refuses (`probe_rollback_target_dir` fails closed) instead of working.
+pub(crate) const DRIFT_RELEASE_UNREADABLE: &str = "this host has a `current` symlink but the release it points at could not be read (a broken \
+     symlink or a missing releases dir) — repair it before the next deploy, which would record \
+     that unresolvable target as this host's rollback point";
+
+/// State drift: this host's live slot unit could not be read, so the CLI cannot
+/// prove WHICH maintenance flag file the running app polls (issue #1621, review
+/// round 1).
+///
+/// The maintenance column reports `?` rather than a confident `ON`/`off` — an
+/// operator closing a live window must never be told it is closed on the strength
+/// of a file the running unit may not even read.
+pub(crate) const DRIFT_MAINTENANCE_UNPROVEN: &str = "the live slot unit could not be read, so which maintenance flag file this host's app \
+     polls is unknown — the maintenance column reports `?` rather than guessing";
+
+/// State drift: this host's app polls a maintenance flag file OTHER than the
+/// per-app shared one (issue #1621, review round 1).
+///
+/// Almost always a slot unit rendered BEFORE #1621: it carries no
+/// `AUTUMN_MAINTENANCE_FLAG_FILE`, so the runtime falls back to the cwd-relative
+/// `tmp/autumn-maintenance.json` under its release dir. The maintenance column
+/// reports THAT file (the truth for this host), but the flag is orphaned by the
+/// next cutover and a fleet-wide `deploy maintenance` reaches it only best-effort.
+pub(crate) const DRIFT_MAINTENANCE_UNSHARED_FLAG: &str = "this host's app polls a release-local maintenance flag file, not the shared one (its slot \
+     unit predates AUTUMN_MAINTENANCE_FLAG_FILE) — redeploy it so maintenance survives cutovers";
+
 /// The sentence printed under the status table to bound the `last deploy` column
 /// (issue #1621, AC-6).
 ///
@@ -1159,9 +1199,13 @@ pub(crate) struct HostStatus {
     /// HTTP status the live slot's loopback `/ready` returned, `None` when nothing
     /// answered.
     pub(crate) ready_code: Option<u16>,
-    /// Whether the shared maintenance flag file is present. ORTHOGONAL to
-    /// `ready_code` — see [`MAINTENANCE_DOES_NOT_DRAIN_NOTE`].
-    pub(crate) maintenance_on: bool,
+    /// Maintenance as the host's RUNNING slot unit observes it — three-valued, so
+    /// an unprovable state is never rendered as a confident on/off (issue #1621,
+    /// review round 1). ORTHOGONAL to `ready_code` — see
+    /// [`MAINTENANCE_DOES_NOT_DRAIN_NOTE`].
+    pub(crate) maintenance: exec::MaintenanceStatus,
+    /// Which flag file that verdict came from.
+    pub(crate) maintenance_flag_source: exec::MaintenanceFlagSource,
     /// The `--http-port` the installed proxy unit binds.
     pub(crate) installed_proxy_port: exec::InstalledProxyPort,
     /// The TLS/host options the last forward deploy recorded.
@@ -1195,7 +1239,10 @@ impl HostStatus {
             release: ReleaseId::Unknown,
             live_slot: None,
             ready_code: None,
-            maintenance_on: false,
+            // Nothing was probed, so nothing is proved — and `fleet_drift` never
+            // derives drift from an unreachable host, so this stays a bare `?`.
+            maintenance: exec::MaintenanceStatus::Unknown,
+            maintenance_flag_source: exec::MaintenanceFlagSource::Unknown,
             installed_proxy_port: exec::InstalledProxyPort::Absent,
             proxy_options: exec::ProxyOptionsMarker::Absent,
             public_port: 0,
@@ -1224,7 +1271,8 @@ impl HostStatus {
                 .map_or(ReleaseId::Unknown, |id| ReleaseId::Known(id.to_owned())),
             live_slot: reconcile.as_ref().map(|r| r.live_slot),
             ready_code: probe.ready_code,
-            maintenance_on: probe.maintenance_on,
+            maintenance: probe.maintenance,
+            maintenance_flag_source: probe.maintenance_flag_source,
             installed_proxy_port: probe.deploy.installed_proxy_port.clone(),
             proxy_options: probe.deploy.last_proxy_options.clone(),
             public_port,
@@ -1324,6 +1372,15 @@ pub(crate) fn fleet_drift(hosts: &[HostStatus]) -> DriftReport {
         if status.mode == Some(HostMode::First) && any_release_deployed {
             state_drift.push((status.host.clone(), DRIFT_HOST_NOT_DEPLOYED));
         }
+        // The mirror image, and the one `--strict` used to exit 0 on: the host
+        // PROVED it has a `current` symlink (that is what `Redeploy` means) yet the
+        // release behind it could not be read. Unknown still contributes no VERSION
+        // drift — rule 1 above is untouched — but it is actionable marker damage,
+        // so it is state drift. Judged against nothing: a lone damaged host needs
+        // the same alert a damaged host in a big fleet does.
+        if status.mode == Some(HostMode::Redeploy) && matches!(status.release, ReleaseId::Unknown) {
+            state_drift.push((status.host.clone(), DRIFT_RELEASE_UNREADABLE));
+        }
         if status.live_slot_marker_drift {
             state_drift.push((status.host.clone(), DRIFT_LIVE_SLOT_MARKER));
         }
@@ -1336,6 +1393,23 @@ pub(crate) fn fleet_drift(hosts: &[HostStatus]) -> DriftReport {
         if matches!(status.installed_proxy_port, exec::InstalledProxyPort::Port(port) if port != status.public_port)
         {
             state_drift.push((status.host.clone(), DRIFT_PROXY_PORT_MISMATCH));
+        }
+        // Review round 1: the maintenance column is only as good as the CLI's
+        // knowledge of WHICH file the running unit polls. Both failure shapes are
+        // named here rather than buried in the column, because both need an
+        // operator action (inspect the unit / redeploy the host). A host with
+        // nothing deployed has no slot unit by definition and is already reported
+        // as such, so it is not double-flagged.
+        if status.mode == Some(HostMode::Redeploy) {
+            match status.maintenance_flag_source {
+                exec::MaintenanceFlagSource::Unknown => {
+                    state_drift.push((status.host.clone(), DRIFT_MAINTENANCE_UNPROVEN));
+                }
+                exec::MaintenanceFlagSource::Unshared => {
+                    state_drift.push((status.host.clone(), DRIFT_MAINTENANCE_UNSHARED_FLAG));
+                }
+                exec::MaintenanceFlagSource::Shared => {}
+            }
         }
     }
 
@@ -1371,10 +1445,12 @@ fn status_row_cells(status: &HostStatus, report: &DriftReport) -> [String; 8] {
         status
             .ready_code
             .map_or_else(|| "ready ?".to_owned(), |code| format!("ready {code}")),
-        if status.maintenance_on {
-            "maintenance ON".to_owned()
-        } else {
-            "maintenance off".to_owned()
+        match status.maintenance {
+            exec::MaintenanceStatus::On => "maintenance ON".to_owned(),
+            exec::MaintenanceStatus::Off => "maintenance off".to_owned(),
+            // Fail closed: "we could not tell" is its own cell, never an `off` that
+            // reads as proof the host is serving traffic normally.
+            exec::MaintenanceStatus::Unknown => "maintenance ?".to_owned(),
         },
         match &status.installed_proxy_port {
             exec::InstalledProxyPort::Port(port) => format!("proxy {port}"),
@@ -1441,7 +1517,7 @@ pub(crate) fn fleet_status_lines(hosts: &[HostStatus], report: &DriftReport) -> 
                 .state_drift
                 .iter()
                 .any(|(host, _)| *host == status.host)
-                || status.maintenance_on
+                || status.maintenance == exec::MaintenanceStatus::On
             {
                 "\u{26A0}\u{FE0F} "
             } else {
@@ -1483,11 +1559,27 @@ pub(crate) fn fleet_status_lines(hosts: &[HostStatus], report: &DriftReport) -> 
         // unknown really is "we could not read it". Describing the first as an
         // unreadable symlink sends the operator to inspect something that was never
         // there.
-        let (not_deployed, unreadable): (Vec<&str>, Vec<&str>) = unknown.iter().partition(|host| {
+        let (not_deployed, rest): (Vec<&str>, Vec<&str>) = unknown.iter().partition(|host| {
             hosts.iter().any(|status| {
                 status.host == **host && status.reachable && status.mode == Some(HostMode::First)
             })
         });
+        // Review round 2: a REACHABLE host that reports a `current` symlink whose
+        // release could not be read is now state drift, and its reason is printed
+        // per host below. Repeating it here under "reported, not counted as drift"
+        // would contradict that line — so this footer now covers only the hosts it
+        // is still true for (chiefly the unreachable ones, whose markers were never
+        // read at all).
+        let unreadable: Vec<&str> = rest
+            .into_iter()
+            .filter(|host| {
+                !hosts.iter().any(|status| {
+                    status.host == **host
+                        && status.reachable
+                        && status.mode == Some(HostMode::Redeploy)
+                })
+            })
+            .collect();
         if !not_deployed.is_empty() {
             lines.push(format!(
                 "  \u{2139}\u{FE0F}  no release deployed on {} \u{2014} nothing is installed \
@@ -1515,7 +1607,10 @@ pub(crate) fn fleet_status_lines(hosts: &[HostStatus], report: &DriftReport) -> 
     if hosts.iter().any(|status| status.reachable) {
         lines.push(format!("  \u{2139}\u{FE0F}  {LAST_DEPLOY_SCOPE_NOTE}"));
     }
-    if hosts.iter().any(|status| status.maintenance_on) {
+    if hosts
+        .iter()
+        .any(|status| status.maintenance == exec::MaintenanceStatus::On)
+    {
         lines.push(format!(
             "  \u{2139}\u{FE0F}  {MAINTENANCE_DOES_NOT_DRAIN_NOTE}"
         ));
@@ -3142,7 +3237,8 @@ mod tests {
             release: release.map_or(ReleaseId::Unknown, |id| ReleaseId::Known(id.to_owned())),
             live_slot: Some(exec::SLOT_BLUE),
             ready_code: Some(200),
-            maintenance_on: false,
+            maintenance: exec::MaintenanceStatus::Off,
+            maintenance_flag_source: exec::MaintenanceFlagSource::Shared,
             installed_proxy_port: exec::InstalledProxyPort::Port(3000),
             proxy_options: exec::ProxyOptionsMarker::Options(exec::ProxyServiceOptions {
                 tls: false,
@@ -3319,6 +3415,68 @@ mod tests {
     }
 
     #[test]
+    fn a_deployed_host_whose_release_is_unreadable_is_state_drift() {
+        // #1621 review round 2. `[ -L current ]` succeeds for a symlink whose target
+        // cannot be canonicalized, so such a host reports `Redeploy` while `readlink
+        // -f` yields nothing and the release reads back `Unknown`. That combination
+        // used to produce ONLY the footer line explicitly labelled "reported, not
+        // counted as drift", so `deploy status --strict` exited 0 on a host with
+        // actionable marker damage — and the next deploy's `commit-markers` copies
+        // `readlink current` verbatim into `previous-release`, recording an
+        // unresolvable directory as that host's rollback point.
+        let damaged = status("web-b", None); // Redeploy + ReleaseId::Unknown
+        let rows = [status("web-a", Some("r1")), damaged];
+        let report = fleet_drift(&rows);
+
+        // Rule 1 is untouched: an unknown release still names no version, so it can
+        // never make a converged fleet look mixed.
+        assert!(
+            !report.version_drift,
+            "unknown is still never VERSION drift: {:?}",
+            report.releases
+        );
+        assert_eq!(
+            report.state_drift,
+            vec![("web-b".to_owned(), DRIFT_RELEASE_UNREADABLE)],
+            "the damaged host is named with its own reason"
+        );
+        assert!(
+            report.drifted(),
+            "`deploy status --strict` must exit non-zero on it"
+        );
+
+        // A lone damaged host is still drift — there is no peer to be judged
+        // against, because the damage is on the host itself.
+        let alone = [status("web-a", None)];
+        assert!(fleet_drift(&alone).drifted());
+
+        let rendered = fleet_status_lines(&rows, &report).join("\n");
+        assert!(
+            rendered.contains(DRIFT_RELEASE_UNREADABLE),
+            "the drift reason must be named on the row:\n{rendered}"
+        );
+        assert!(
+            !rendered.contains("reported, not counted as drift"),
+            "the footer must not contradict the drift it is now counted as:\n{rendered}"
+        );
+
+        // An UNREACHABLE host keeps the old, still-true footer: its markers were
+        // never read, so nothing about them is drift.
+        let outage = [
+            status("web-a", Some("r1")),
+            HostStatus::unreachable("web-b"),
+        ];
+        let outage_report = fleet_drift(&outage);
+        assert!(outage_report.state_drift.is_empty());
+        assert!(
+            fleet_status_lines(&outage, &outage_report)
+                .join("\n")
+                .contains("reported, not counted as drift"),
+            "an unreachable host is still reported, not blamed",
+        );
+    }
+
+    #[test]
     fn fleet_drift_never_flags_a_host_it_could_not_reach() {
         // An unreachable host has no facts, so inventing drift from its absent
         // markers would report the network outage as a deploy defect. It is listed
@@ -3344,7 +3502,7 @@ mod tests {
         // teach exactly the wrong mental model, so they are separate and the table
         // says so.
         let mut maintained = status("web-b", Some("r1"));
-        maintained.maintenance_on = true;
+        maintained.maintenance = exec::MaintenanceStatus::On;
         let rows = [status("web-a", Some("r1")), maintained];
         let report = fleet_drift(&rows);
         let rendered = fleet_status_lines(&rows, &report).join("\n");

--- a/autumn-cli/src/deploy/fleet.rs
+++ b/autumn-cli/src/deploy/fleet.rs
@@ -320,19 +320,27 @@ pub(crate) fn fleet_plan_lines(hosts: &[String]) -> Vec<String> {
 /// or halt — because a halted rollout is exactly the moment an operator has no
 /// other source of truth about which host is running what.
 ///
-/// The variants are deliberately the ones the EXISTING per-host executor already
-/// distinguishes, so nothing is inferred: [`exec::execute_with_teardown`] returns
-/// `CandidateRolledBack`/`FirstDeployTornDown` **only** for a failure at or before
-/// the go-live boundary (traffic never moved, the candidate was cleaned up), and
-/// the raw error otherwise (the host is live on the new release). The finer
-/// post-boundary classification — housekeeping vs ambiguous-markers vs functional —
-/// and the fleet-wide compensation it drives land with the next slice.
+/// The first five variants are deliberately the ones the EXISTING per-host
+/// executor already distinguishes, so nothing is inferred:
+/// [`exec::execute_with_teardown`] returns `CandidateRolledBack`/`FirstDeployTornDown`
+/// **only** for a failure at or before the go-live boundary (traffic never moved,
+/// the candidate was cleaned up), and the raw error otherwise (the host is live on
+/// the new release). [`classify_post_boundary`] then refines that raw
+/// "live on the new release" case by the failing LABEL, and the compensation
+/// variants record what the fleet driver did about it afterwards.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum HostOutcome {
     /// The rollout halted before this host was reached. Nothing was mutated on it.
     Untouched,
     /// The host is serving the new release.
     Serving,
+    /// A post-boundary HOUSEKEEPING failure ([`PostBoundaryClass::Housekeeping`]):
+    /// the host is live and healthy on the new release, and only bookkeeping that
+    /// does not touch traffic failed. The rollout CONTINUES past it (§4.6).
+    Degraded {
+        /// Label of the housekeeping step that failed.
+        label: &'static str,
+    },
     /// A pre-boundary failure on a REDEPLOY host: the candidate was torn down and
     /// this host's previous release is still serving.
     RolledBack {
@@ -345,12 +353,190 @@ pub(crate) enum HostOutcome {
         /// Label of the step that failed.
         failed_step: &'static str,
     },
-    /// A post-boundary failure: traffic has already moved, so this host IS running
-    /// the new release even though the deploy reported failure.
+    /// A post-boundary FUNCTIONAL failure: traffic has already moved, so this host
+    /// IS running the new release even though the deploy reported failure.
     LiveOnNew {
         /// Label of the step that failed.
         failed_step: &'static str,
     },
+    /// A post-boundary failure at `commit-markers`
+    /// ([`PostBoundaryClass::Ambiguous`]): the host is on the new release AND its
+    /// marker triple is mid-transaction, so it is **never** rolled back
+    /// automatically — [`exec::resolve_rollback_target`] could resolve the wrong
+    /// release. Fails closed to a manual recovery.
+    AmbiguousMarkers,
+    /// Fleet compensation rolled this host back to its previous release.
+    CompensatedRollback,
+    /// Fleet compensation removed this host's just-completed FIRST deploy, so it is
+    /// back to nothing-installed (see [`RollbackAction::Teardown`]).
+    CompensatedTeardown,
+    /// Fleet compensation was attempted on this host and FAILED — it is still on
+    /// the new release. Never swallowed: the failing step is named.
+    CompensationFailed {
+        /// Label of the compensation step that failed.
+        failed_step: &'static str,
+    },
+    /// Fleet compensation was deliberately NOT attempted on this host: it is still
+    /// on the new release and needs a human (see the `MANUAL_*` reasons).
+    Manual {
+        /// Why the automatic rollback was declined — a `&'static str`, never a
+        /// shell line or a driver message.
+        reason: &'static str,
+    },
+}
+
+/// How bad a POST-boundary failure is (issue #1621, §4.6).
+///
+/// "Post-boundary" means [`exec::execute_with_teardown`] returned the RAW executor
+/// error rather than one of its two clean-failure variants: the go-live op already
+/// succeeded, no teardown ran, and the host **is** on the new release. What to do
+/// about that depends entirely on WHICH step failed, and the three answers are
+/// materially different — which is why this is a classification and not a boolean.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum PostBoundaryClass {
+    /// The host is live and healthy; only bookkeeping failed. **Warn and continue**
+    /// the rollout — rolling a whole fleet back because an `rm -rf` of old release
+    /// dirs failed on host 3 is a self-inflicted outage.
+    Housekeeping,
+    /// The marker triple is mid-transaction. **Halt, and never auto-roll-back this
+    /// host** — the rollback target cannot be trusted.
+    Ambiguous,
+    /// The host is live on the new release and something that matters failed.
+    /// **Halt and compensate**, including this host.
+    Functional,
+}
+
+/// Post-boundary labels that do not affect traffic (issue #1621, §4.6).
+///
+/// All three run strictly AFTER `proxy-flip`, so the proxy is already serving the
+/// new release when they run:
+///
+/// - `record-proxy-options` — writes the `shared/proxy-options` marker. Its failure
+///   is invisible today and fails the NEXT deploy closed
+///   (`refuse_unprovable_proxy_options`), which is exactly why it must be surfaced
+///   rather than swallowed.
+/// - `drain-old` — disables the now-idle old slot unit. Two slots running is
+///   untidy, not an outage.
+/// - `prune` — removes old release dirs. Disk hygiene.
+pub(crate) const HOUSEKEEPING_LABELS: [&str; 3] = ["record-proxy-options", "drain-old", "prune"];
+
+/// The one post-boundary label whose failure makes a host's rollback target
+/// unprovable: `commit-markers` writes previous-release + `current` + live-slot as
+/// ONE remote transaction, so a failure inside it can leave any subset applied.
+pub(crate) const AMBIGUOUS_MARKERS_LABEL: &str = "commit-markers";
+
+/// Classify a POST-boundary failure by its op label (issue #1621, §4.6, T1.15).
+///
+/// Unknown labels fall through to [`PostBoundaryClass::Functional`] — the
+/// fail-closed direction. A future op added after the boundary is then treated as
+/// mattering until someone deliberately adds it to [`HOUSEKEEPING_LABELS`], rather
+/// than being silently waved through as harmless.
+pub(crate) fn classify_post_boundary(label: &str) -> PostBoundaryClass {
+    if HOUSEKEEPING_LABELS.contains(&label) {
+        PostBoundaryClass::Housekeeping
+    } else if label == AMBIGUOUS_MARKERS_LABEL {
+        PostBoundaryClass::Ambiguous
+    } else {
+        PostBoundaryClass::Functional
+    }
+}
+
+/// Why an automatic rollback was declined at `commit-markers`.
+pub(crate) const MANUAL_AMBIGUOUS_MARKERS: &str =
+    "release markers left mid-transaction by `commit-markers`";
+
+/// Why an automatic rollback was declined by the target-dir precheck (§4.7).
+pub(crate) const MANUAL_ROLLBACK_TARGET_MISSING: &str = "rollback target release dir missing";
+
+/// Why an automatic rollback was declined when the target-dir probe proved nothing.
+pub(crate) const MANUAL_ROLLBACK_TARGET_UNPROVABLE: &str =
+    "rollback target release dir could not be verified";
+
+/// Why an automatic rollback was declined when the host records no previous release.
+pub(crate) const MANUAL_NO_PREVIOUS_RELEASE: &str = "no previous release recorded to roll back to";
+
+/// What the fleet does to ONE host when compensating a halted rollout (issue
+/// #1621, §4.7).
+///
+/// The `usize` is the host's index in rollout order, which is index-parallel to
+/// `FleetPlan::hosts` / `ResolvedFleet::hosts` / the probe list — the same
+/// convention the driver uses everywhere, and the reason no host name appears here.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum RollbackAction {
+    /// Roll this host back to its previous release with the EXISTING on-demand
+    /// rollback primitives ([`exec::resolve_rollback_target`] →
+    /// [`exec::rollback_ops`] → [`exec::execute_rollback`]).
+    Rollback(usize),
+    /// Remove this host's just-completed FIRST deploy
+    /// ([`exec::first_deploy_teardown_ops`]).
+    ///
+    /// A first deploy has no `shared/previous-release` marker, so there is nothing
+    /// to roll back TO: the honest compensation is to return the host to
+    /// nothing-installed, which is also the state that makes the next `deploy up`
+    /// correctly take the First path again. A half-installed host an external load
+    /// balancer may already be probing is worse than a clean absence.
+    ///
+    /// **Known gap (documented, not fixed here):** [`ProxyController`] exposes no
+    /// deregister op, so the host's kamal-proxy still holds a route for the service
+    /// pointing at the (now stopped) slot port — that host's public port answers
+    /// 502 instead of connection-refused until it is deployed again. Removing the
+    /// route needs a new `ProxyController` method and its own exact-vector tests;
+    /// it is tracked as follow-up work, and the state table names the host so the
+    /// operator is never surprised by it.
+    Teardown(usize),
+    /// Do NOT touch this host automatically; report it and the reason.
+    Manual(usize, &'static str),
+}
+
+/// The compensation set for a halted rollout — **pure**, in strict REVERSE rollout
+/// order (issue #1621, §4.7, AC-3).
+///
+/// Reverse order is not cosmetic: the hosts that cut over LAST are the ones that
+/// have been serving the new release for the shortest time, and undoing them first
+/// shrinks the mixed window from the newest end. Every host that is on the new
+/// release is in the set, including the host that failed post-boundary and
+/// including hosts marked [`HostOutcome::Degraded`] — a degraded host is live and
+/// healthy on the NEW release, so leaving it there while every other host returns
+/// to the old one is precisely the mixed-version fleet AC-3 forbids. (Its
+/// housekeeping debris is still reported: the driver records it independently of
+/// this outcome slot.)
+///
+/// Hosts that are already clean ([`HostOutcome::RolledBack`] /
+/// [`HostOutcome::TornDown`] — their own per-host teardown ran) and hosts that were
+/// never reached are absent. `modes` decides rollback-vs-teardown per host; the
+/// function is total, so a short `modes` slice simply yields a shorter set rather
+/// than panicking mid-rollout.
+pub(crate) fn fleet_rollback_set(
+    outcomes: &[HostOutcome],
+    modes: &[HostMode],
+) -> Vec<RollbackAction> {
+    outcomes
+        .iter()
+        .zip(modes)
+        .enumerate()
+        .rev()
+        .filter_map(|(index, (outcome, mode))| match outcome {
+            // On the new release: compensate by this host's deploy path.
+            HostOutcome::Serving | HostOutcome::Degraded { .. } | HostOutcome::LiveOnNew { .. } => {
+                Some(match mode {
+                    HostMode::First => RollbackAction::Teardown(index),
+                    HostMode::Redeploy => RollbackAction::Rollback(index),
+                })
+            }
+            // On the new release, but its rollback target cannot be trusted.
+            HostOutcome::AmbiguousMarkers => {
+                Some(RollbackAction::Manual(index, MANUAL_AMBIGUOUS_MARKERS))
+            }
+            // Already clean, never reached, or already compensated.
+            HostOutcome::Untouched
+            | HostOutcome::RolledBack { .. }
+            | HostOutcome::TornDown { .. }
+            | HostOutcome::CompensatedRollback
+            | HostOutcome::CompensatedTeardown
+            | HostOutcome::CompensationFailed { .. }
+            | HostOutcome::Manual { .. } => None,
+        })
+        .collect()
 }
 
 /// The step label to attribute a failure to — always a `&'static str` op label, so
@@ -396,6 +582,26 @@ pub(crate) const fn classify_failure(err: &exec::DeployExecError) -> HostOutcome
     }
 }
 
+/// The outcome the fleet driver records for one failed host: [`classify_failure`]
+/// (did traffic move?) refined by [`classify_post_boundary`] (how bad is it?).
+///
+/// Kept as its own function — rather than folded into [`classify_failure`] —
+/// because the two questions have different inputs and different failure modes.
+/// `classify_failure` reads the executor's TYPED error and is the discriminator
+/// AC-3 turns on; this one reads a LABEL and encodes a policy about which
+/// post-cutover steps matter. A pre-boundary outcome passes through untouched: the
+/// executor already tore that candidate down, so there is nothing left to classify.
+pub(crate) fn classify_host_outcome(err: &exec::DeployExecError) -> HostOutcome {
+    match classify_failure(err) {
+        HostOutcome::LiveOnNew { failed_step } => match classify_post_boundary(failed_step) {
+            PostBoundaryClass::Housekeeping => HostOutcome::Degraded { label: failed_step },
+            PostBoundaryClass::Ambiguous => HostOutcome::AmbiguousMarkers,
+            PostBoundaryClass::Functional => HostOutcome::LiveOnNew { failed_step },
+        },
+        clean => clean,
+    }
+}
+
 /// The loud line printed when a fleet rollout schedules no migration at all.
 ///
 /// [`exec::first_deploy_ops`] carries no migrate op (a first deploy has never run
@@ -409,6 +615,61 @@ pub(crate) const FLEET_NO_MIGRATION_NOTE: &str = "no host in this fleet is on a 
 /// The one-line reminder printed once, after the fleet's single migration lands.
 pub(crate) const FLEET_SCHEMA_MOVED_NOTE: &str = "the schema has moved; from here an automatic rollback restores BINARIES only — \
      it never rolls a migration back";
+
+/// The line the summary prints once a fleet rollout has actually COMPENSATED hosts
+/// after a migration ran (issue #1621, §4.7, T1.12).
+///
+/// The compensation op vectors are [`exec::rollback_ops`] /
+/// [`exec::first_deploy_teardown_ops`], neither of which contains a `migrate` op by
+/// construction — so the binaries went back and the schema did not. That asymmetry
+/// is the single most dangerous thing about an automatic fleet rollback, so it is
+/// stated out loud rather than left to be inferred from the absence of a line.
+/// (`rolling_deploy_blocked` grades `up.sql` only, so an automatic `migrate down`
+/// would run exactly the SQL nothing reviews, unattended, mid-flip.)
+pub(crate) const FLEET_SCHEMA_NOT_ROLLED_BACK_NOTE: &str = "the compensating rollback restored BINARIES only — the migration that already ran was \
+     NOT rolled back; confirm the schema still fits the release now serving";
+
+/// Whether this rollout moved the schema, judged conservatively (issue #1621).
+///
+/// True when the plan scheduled a migration AND the host carrying it was reached at
+/// all. It deliberately does NOT try to prove the one-shot itself succeeded: the
+/// only signal available is the failing step label, and a pre-boundary failure
+/// *after* `migrate` (a readiness timeout, say) moves the schema and still rolls
+/// the candidate back. Erring toward "the schema moved" costs one line of output;
+/// erring the other way lets an operator roll binaries back believing the schema
+/// came with them.
+pub(crate) fn schema_moved(plan: &FleetPlan, outcomes: &[HostOutcome]) -> bool {
+    plan.hosts.iter().zip(outcomes).any(|(host, outcome)| {
+        host.migrate == MigrateStep::Run && !matches!(outcome, HostOutcome::Untouched)
+    })
+}
+
+/// The exact by-hand recovery instructions for a host the fleet deliberately did
+/// NOT roll back (issue #1621, §4.7/§8.2).
+///
+/// Printed for every [`RollbackAction::Manual`], because "we did not touch it" is
+/// only useful next to "here is what to look at". The command is read-only and
+/// carries nothing secret: an SSH user, a host, and the two marker paths the deploy
+/// already prints on every run. It does NOT tell the operator to run
+/// `autumn deploy rollback`: with a `[deploy] hosts` fleet that command has no
+/// single target today (per-host targeting lands with the fleet CLI surface), and
+/// printing a command that cannot work is worse than printing none.
+pub(crate) fn manual_recovery_lines(cfg: &ResolvedDeployConfig, reason: &str) -> Vec<String> {
+    let host = cfg.host.as_deref().unwrap_or_default();
+    let shared = cfg.shared_dir();
+    vec![
+        format!("  \u{2757} {host}: NOT rolled back automatically \u{2014} {reason}."),
+        format!(
+            "     inspect: ssh {user}@{host} 'cat {shared}/previous-release {shared}/live-slot; \
+             ls {releases}'",
+            user = cfg.user,
+            releases = cfg.releases_dir(),
+        ),
+        "     the previous-release marker names the release dir, slot and port this host \
+         should return to; restore it by hand before deploying the fleet again."
+            .to_owned(),
+    ]
+}
 
 /// The `deploy up` fleet header: rollout order, each host's probed mode, and where
 /// the single fleet-wide migration lands (issue #1621, §8.1).
@@ -481,6 +742,14 @@ pub(crate) fn fleet_summary_lines(
         let state = match outcome {
             HostOutcome::Untouched => "untouched (not reached)".to_owned(),
             HostOutcome::Serving => format!("serving {release_id}"),
+            // Live and healthy on the new release: only bookkeeping failed. The
+            // remedy is named because a failed `record-proxy-options` makes the NEXT
+            // deploy of this host fail closed.
+            HostOutcome::Degraded { label } => format!(
+                "serving {release_id} \u{2014} DEGRADED: `{label}` failed after the cutover; \
+                 traffic is fine, but repair it (a redeploy of this host does) before the \
+                 next deploy refuses it"
+            ),
             // Traffic already moved before the failure, so this host IS on the new
             // release — saying only "failed" would be the dangerous half-truth.
             HostOutcome::LiveOnNew { failed_step } => {
@@ -488,16 +757,40 @@ pub(crate) fn fleet_summary_lines(
                     "serving {release_id} \u{2014} but `{failed_step}` failed AFTER the cutover"
                 )
             }
+            HostOutcome::AmbiguousMarkers => format!(
+                "serving {release_id} \u{2014} `{AMBIGUOUS_MARKERS_LABEL}` failed AFTER the \
+                 cutover, so the release markers are mid-transaction and this host was NOT \
+                 rolled back automatically"
+            ),
+            HostOutcome::Manual { reason } => {
+                format!("serving {release_id} \u{2014} NOT rolled back automatically: {reason}")
+            }
             HostOutcome::RolledBack { failed_step } => {
                 format!("previous release still serving (rolled back at `{failed_step}`)")
             }
             HostOutcome::TornDown { failed_step } => {
                 format!("NOTHING serving (first deploy torn down at `{failed_step}`)")
             }
+            HostOutcome::CompensatedRollback => {
+                "previous release restored (rolled back by the fleet)".to_owned()
+            }
+            HostOutcome::CompensatedTeardown => {
+                "NOTHING serving (the fleet removed this host's new first deploy; its proxy \
+                 still holds the route until the next deploy)"
+                    .to_owned()
+            }
+            HostOutcome::CompensationFailed { failed_step } => format!(
+                "serving {release_id} \u{2014} the compensating rollback FAILED at \
+                 `{failed_step}`"
+            ),
         };
         let marker = match outcome {
             HostOutcome::Serving => "\u{2705}",
             HostOutcome::Untouched => "\u{2013}",
+            HostOutcome::Degraded { .. } => "\u{26A0}\u{FE0F} ",
+            HostOutcome::CompensatedRollback | HostOutcome::CompensatedTeardown => {
+                "\u{21A9}\u{FE0F} "
+            }
             _ => "\u{274C}",
         };
         lines.push(format!(
@@ -512,7 +805,12 @@ pub(crate) fn fleet_summary_lines(
         .filter(|(_, outcome)| {
             matches!(
                 outcome,
-                HostOutcome::Serving | HostOutcome::LiveOnNew { .. }
+                HostOutcome::Serving
+                    | HostOutcome::Degraded { .. }
+                    | HostOutcome::LiveOnNew { .. }
+                    | HostOutcome::AmbiguousMarkers
+                    | HostOutcome::Manual { .. }
+                    | HostOutcome::CompensationFailed { .. }
             )
         })
         .map(|(host, _)| host.host.as_str())
@@ -523,6 +821,22 @@ pub(crate) fn fleet_summary_lines(
             on_new.join(", "),
         ));
         lines.push(format!("  \u{26A0}\u{FE0F}  {FLEET_SCHEMA_MOVED_NOTE}"));
+    }
+    // Say the binaries-only truth once the fleet has ACTUALLY undone hosts: at that
+    // point the operator is looking at a fleet back on the old release with a schema
+    // that is not.
+    let compensated = outcomes.iter().any(|outcome| {
+        matches!(
+            outcome,
+            HostOutcome::CompensatedRollback
+                | HostOutcome::CompensatedTeardown
+                | HostOutcome::CompensationFailed { .. }
+        )
+    });
+    if compensated && schema_moved(plan, outcomes) {
+        lines.push(format!(
+            "  \u{26A0}\u{FE0F}  {FLEET_SCHEMA_NOT_ROLLED_BACK_NOTE}"
+        ));
     }
     lines
 }
@@ -548,6 +862,7 @@ pub(crate) mod test_support {
         host: String,
         stdout: Vec<(&'static str, String)>,
         fail: Vec<&'static str>,
+        transport_fail: Vec<&'static str>,
     }
 
     /// A fleet-shaped recording fake: ONE
@@ -608,6 +923,15 @@ pub(crate) mod test_support {
             self
         }
 
+        /// Make one host's `label` fail as a dropped SSH TRANSPORT rather than a
+        /// remote non-zero exit — the shape that carries no op label and so
+        /// classifies as a FUNCTIONAL post-boundary failure (see
+        /// [`RecordingExecutor::transport_failing`]).
+        pub(crate) fn transport_fail(mut self, host: &str, label: &'static str) -> Self {
+            self.entry(host).transport_fail.push(label);
+            self
+        }
+
         /// The executor factory the fleet driver is injected with: one strict,
         /// tape-sharing fake per host.
         pub(crate) fn executor(&self, cfg: &ResolvedDeployConfig) -> RecordingExecutor {
@@ -621,6 +945,9 @@ pub(crate) mod test_support {
                 }
                 for label in &script.fail {
                     exec = exec.failing(label);
+                }
+                for label in &script.transport_fail {
+                    exec = exec.transport_failing(label);
                 }
             }
             exec
@@ -650,6 +977,20 @@ pub(crate) mod test_support {
             self.tape.borrow().iter().position(|(h, call)| {
                 h == host && !call.run_label().is_some_and(|l| read_only.contains(&l))
             })
+        }
+
+        /// Global tape positions of every `Run` of `label`, on ANY host — the query
+        /// "did this label ever run again, and when relative to that one?" that
+        /// compensation assertions need (a compensated host runs `proxy-flip`
+        /// twice: once to cut over, once to come back).
+        pub(crate) fn positions_of(&self, label: &str) -> Vec<usize> {
+            self.tape
+                .borrow()
+                .iter()
+                .enumerate()
+                .filter(|(_, (_, call))| call.run_label() == Some(label))
+                .map(|(index, _)| index)
+                .collect()
         }
 
         /// Global index of the first `Run` of `label` on `host`.
@@ -1223,6 +1564,312 @@ mod tests {
             none.contains("NOTHING serving"),
             "a torn-down first deploy leaves nothing serving and must say so:\n{none}"
         );
+    }
+
+    #[test]
+    fn classify_post_boundary_separates_housekeeping_from_functional_failures() {
+        // #1621 (AC-3, T1.15 / §4.6). After the go-live boundary the host IS on the
+        // new release, so "it failed" is not enough to decide anything: the three
+        // answers below are materially different, and getting them wrong in either
+        // direction is an outage — roll a fleet back because `prune` failed and you
+        // caused one; auto-roll-back on mid-transaction markers and you may restore
+        // the WRONG release.
+        for label in ["record-proxy-options", "drain-old", "prune"] {
+            assert_eq!(
+                classify_post_boundary(label),
+                PostBoundaryClass::Housekeeping,
+                "`{label}` runs after the flip and does not touch traffic, so the rollout \
+                 must continue"
+            );
+        }
+        assert_eq!(
+            classify_post_boundary("commit-markers"),
+            PostBoundaryClass::Ambiguous,
+            "`commit-markers` writes the marker triple as one transaction — a failure \
+             inside it leaves the rollback target unprovable, so it must fail closed"
+        );
+        // Fail closed on anything unknown: a NEW op added after the boundary is
+        // treated as mattering until someone deliberately lists it as housekeeping.
+        for label in ["proxy-flip", "some-future-post-flip-op", ""] {
+            assert_eq!(
+                classify_post_boundary(label),
+                PostBoundaryClass::Functional,
+                "an unrecognised post-boundary label (`{label}`) must fail closed to \
+                 Functional, never be waved through as housekeeping"
+            );
+        }
+    }
+
+    #[test]
+    fn a_post_boundary_housekeeping_failure_degrades_instead_of_halting() {
+        // #1621 (§4.6): the composition the driver actually calls. A pre-boundary
+        // outcome passes through untouched (the executor already tore the candidate
+        // down); a post-boundary raw error is refined by its label.
+        let boxed = || {
+            Box::new(exec::DeployExecError::CommandFailed {
+                label: "prune",
+                message: "scripted".to_owned(),
+            })
+        };
+        assert_eq!(
+            classify_host_outcome(&exec::DeployExecError::CommandFailed {
+                label: "prune",
+                message: "scripted".to_owned(),
+            }),
+            HostOutcome::Degraded { label: "prune" },
+            "a failed `prune` leaves the host live and healthy on the new release"
+        );
+        assert_eq!(
+            classify_host_outcome(&exec::DeployExecError::CommandFailed {
+                label: "commit-markers",
+                message: "scripted".to_owned(),
+            }),
+            HostOutcome::AmbiguousMarkers,
+            "a failed `commit-markers` must never be auto-rolled-back"
+        );
+        assert_eq!(
+            classify_host_outcome(&exec::DeployExecError::CommandFailed {
+                label: "some-future-post-flip-op",
+                message: "scripted".to_owned(),
+            }),
+            HostOutcome::LiveOnNew {
+                failed_step: "some-future-post-flip-op"
+            },
+            "an unknown post-boundary failure halts and compensates"
+        );
+        assert_eq!(
+            classify_host_outcome(&exec::DeployExecError::CandidateRolledBack {
+                failed_step: "readiness-gate",
+                source: boxed(),
+            }),
+            HostOutcome::RolledBack {
+                failed_step: "readiness-gate"
+            },
+            "a pre-boundary outcome is already clean and must pass through unrefined"
+        );
+    }
+
+    #[test]
+    fn the_compensation_set_is_the_reverse_of_the_rollout_order() {
+        // #1621 (AC-3, T1.13 / §4.7). Everything on the NEW release is compensated,
+        // newest cutover first; everything already clean or never reached is left
+        // alone. Mode decides HOW: a redeploy host rolls back to its previous
+        // release, a first-deploy host has no previous release and is torn down.
+        let actions = fleet_rollback_set(
+            &[
+                HostOutcome::Serving,
+                HostOutcome::Serving,
+                HostOutcome::LiveOnNew {
+                    failed_step: "record-live-slot",
+                },
+                HostOutcome::Untouched,
+            ],
+            &[
+                HostMode::Redeploy,
+                HostMode::First,
+                HostMode::Redeploy,
+                HostMode::Redeploy,
+            ],
+        );
+        assert_eq!(
+            actions,
+            vec![
+                RollbackAction::Rollback(2),
+                RollbackAction::Teardown(1),
+                RollbackAction::Rollback(0),
+            ],
+            "compensation runs strictly newest-first, includes the post-boundary host \
+             itself, skips the unreached host, and tears down (not rolls back) a first \
+             deploy"
+        );
+    }
+
+    #[test]
+    fn a_degraded_host_is_still_compensated_when_the_fleet_rolls_back() {
+        // #1621 (§4.7): a degraded host is live and HEALTHY on the new release —
+        // that is exactly why it must come back with everyone else. Leaving it
+        // forward while hosts 1..k return to the old release is the mixed-version
+        // fleet AC-3 forbids. (Its housekeeping debris is reported separately, from
+        // the driver's own record, so compensating it does not erase the warning.)
+        let actions = fleet_rollback_set(
+            &[
+                HostOutcome::Degraded { label: "prune" },
+                HostOutcome::LiveOnNew {
+                    failed_step: "record-live-slot",
+                },
+            ],
+            &[HostMode::Redeploy, HostMode::Redeploy],
+        );
+        assert_eq!(
+            actions,
+            vec![RollbackAction::Rollback(1), RollbackAction::Rollback(0)],
+            "a degraded host must not be stranded on the new release"
+        );
+    }
+
+    #[test]
+    fn clean_and_ambiguous_hosts_are_never_auto_rolled_back() {
+        // #1621 (§4.7): the two "hands off" cases. A host whose own pre-boundary
+        // teardown ran is already back where it started — touching it again would
+        // roll it back PAST the release it is serving. A host whose markers are
+        // mid-transaction cannot be resolved safely, so it fails closed to Manual.
+        let actions = fleet_rollback_set(
+            &[
+                HostOutcome::RolledBack {
+                    failed_step: "readiness-gate",
+                },
+                HostOutcome::TornDown {
+                    failed_step: "readiness-gate",
+                },
+                HostOutcome::AmbiguousMarkers,
+            ],
+            &[HostMode::Redeploy, HostMode::First, HostMode::Redeploy],
+        );
+        assert_eq!(
+            actions,
+            vec![RollbackAction::Manual(2, MANUAL_AMBIGUOUS_MARKERS)],
+            "only the ambiguous host is reported, and never touched"
+        );
+        assert!(
+            fleet_rollback_set(&[], &[]).is_empty(),
+            "an empty fleet compensates nothing"
+        );
+    }
+
+    #[test]
+    fn the_summary_reports_degraded_compensated_and_manual_hosts() {
+        // #1621 (§8.2): after a compensated halt the state table is the operator's
+        // only source of truth, so every distinct state must render as itself —
+        // "rolled back by the fleet" is a very different sentence from "rolled back
+        // at `readiness-gate`", and a degraded host must not read as a failure.
+        let fleet = fleet_of(&["web-a", "web-b", "web-c", "web-d"]);
+        let plan = plan_fleet(
+            &fleet,
+            &[
+                HostMode::Redeploy,
+                HostMode::Redeploy,
+                HostMode::First,
+                HostMode::Redeploy,
+            ],
+        )
+        .expect("a well-formed fleet plans");
+        let rendered = fleet_summary_lines(
+            &plan,
+            &[
+                HostOutcome::CompensatedRollback,
+                HostOutcome::Degraded { label: "prune" },
+                HostOutcome::CompensatedTeardown,
+                HostOutcome::AmbiguousMarkers,
+            ],
+            "20260714T120000Z",
+        )
+        .join("\n");
+
+        assert!(
+            rendered.contains("previous release restored"),
+            "a fleet-compensated host must say so, not borrow the per-host wording:\n\
+             {rendered}"
+        );
+        assert!(
+            rendered.contains("DEGRADED") && rendered.contains("prune"),
+            "a degraded host must name the housekeeping step that failed:\n{rendered}"
+        );
+        assert!(
+            rendered.contains("NOTHING serving") && rendered.contains("still holds the route"),
+            "a torn-down first deploy must state the proxy-route residue:\n{rendered}"
+        );
+        assert!(
+            rendered.contains("mid-transaction") && rendered.contains("NOT rolled back"),
+            "an ambiguous host must say it was deliberately left alone:\n{rendered}"
+        );
+        assert!(
+            rendered.contains(FLEET_SCHEMA_NOT_ROLLED_BACK_NOTE),
+            "a compensated fleet whose migration ran must state that the schema did NOT \
+             come back with the binaries:\n{rendered}"
+        );
+    }
+
+    #[test]
+    fn the_schema_note_tracks_whether_the_migration_host_was_reached() {
+        // #1621 (T1.12): the note is conservative by design — it fires whenever the
+        // migrating host was REACHED, because the only evidence available is a step
+        // label and a pre-boundary failure after `migrate` still moves the schema.
+        let fleet = fleet_of(&["web-a", "web-b"]);
+        let migrating = plan_fleet(&fleet, &[HostMode::Redeploy, HostMode::Redeploy])
+            .expect("a well-formed fleet plans");
+        assert!(
+            schema_moved(
+                &migrating,
+                &[
+                    HostOutcome::RolledBack {
+                        failed_step: "readiness-gate"
+                    },
+                    HostOutcome::Untouched
+                ]
+            ),
+            "a pre-boundary failure AFTER `migrate` still moved the schema"
+        );
+        assert!(
+            !schema_moved(
+                &migrating,
+                &[HostOutcome::Untouched, HostOutcome::Untouched]
+            ),
+            "an unreached migrating host migrated nothing"
+        );
+        let first_only = plan_fleet(&fleet, &[HostMode::First, HostMode::First])
+            .expect("a well-formed fleet plans");
+        assert!(
+            !schema_moved(&first_only, &[HostOutcome::Serving, HostOutcome::Serving]),
+            "an all-first-deploy fleet schedules no migration at all"
+        );
+        // A compensated fleet that never migrated must not claim a schema it does
+        // not have.
+        let rendered = fleet_summary_lines(
+            &first_only,
+            &[
+                HostOutcome::CompensatedTeardown,
+                HostOutcome::CompensatedTeardown,
+            ],
+            "20260714T120000Z",
+        )
+        .join("\n");
+        assert!(
+            !rendered.contains(FLEET_SCHEMA_NOT_ROLLED_BACK_NOTE),
+            "no migration ran, so there is no schema statement to make:\n{rendered}"
+        );
+    }
+
+    #[test]
+    fn manual_recovery_lines_name_the_markers_and_carry_no_secret() {
+        // #1621 (§8.2): "we did not touch it" is only useful next to "here is what
+        // to look at". The command is read-only, works today, and quotes nothing but
+        // the SSH user, the host and the marker paths the deploy already prints.
+        let cfg = &fleet_of(&["web-b"]).hosts[0];
+        let rendered = manual_recovery_lines(cfg, MANUAL_AMBIGUOUS_MARKERS).join("\n");
+
+        assert!(
+            rendered.contains("web-b") && rendered.contains(MANUAL_AMBIGUOUS_MARKERS),
+            "the block must name the host and the reason:\n{rendered}"
+        );
+        assert!(
+            rendered.contains("previous-release") && rendered.contains("live-slot"),
+            "the block must name both markers a human has to reconcile:\n{rendered}"
+        );
+        assert!(
+            !rendered.contains("autumn deploy rollback"),
+            "`deploy rollback` has no single target under `[deploy] hosts` today, so the \
+             manual block must not promise it:\n{rendered}"
+        );
+        for secret in [
+            "AUTUMN_SECURITY__SIGNING_SECRET",
+            "postgres://",
+            "topsecret",
+        ] {
+            assert!(
+                !rendered.contains(secret),
+                "manual recovery output must never carry `{secret}`:\n{rendered}"
+            );
+        }
     }
 
     #[test]

--- a/autumn-cli/src/deploy/media.rs
+++ b/autumn-cli/src/deploy/media.rs
@@ -767,6 +767,7 @@ pub fn ffmpeg_preflight(exec: &impl DeployExecutor, ffmpeg_bin: &str) -> Preflig
     if ffmpeg_bin.trim().is_empty() || ffmpeg_bin.contains("${") {
         return PreflightCheck {
             name: CHECK_FFMPEG_PREFLIGHT,
+            scope: None,
             passed: false,
             deferred: true,
             detail: format!(
@@ -783,6 +784,7 @@ pub fn ffmpeg_preflight(exec: &impl DeployExecutor, ffmpeg_bin: &str) -> Preflig
     match exec.run(&cmd) {
         Ok(out) if out.stdout.contains("ffmpeg version") => PreflightCheck {
             name: CHECK_FFMPEG_PREFLIGHT,
+            scope: None,
             passed: true,
             deferred: false,
             detail: format!("FFmpeg resolves at `{ffmpeg_bin}` and reports a version banner"),
@@ -790,6 +792,7 @@ pub fn ffmpeg_preflight(exec: &impl DeployExecutor, ffmpeg_bin: &str) -> Preflig
         },
         Ok(_) => PreflightCheck {
             name: CHECK_FFMPEG_PREFLIGHT,
+            scope: None,
             passed: false,
             deferred: false,
             detail: format!(
@@ -800,6 +803,7 @@ pub fn ffmpeg_preflight(exec: &impl DeployExecutor, ffmpeg_bin: &str) -> Preflig
         },
         Err(err) => PreflightCheck {
             name: CHECK_FFMPEG_PREFLIGHT,
+            scope: None,
             passed: false,
             deferred: false,
             detail: format!("could not run `{ffmpeg_bin} -version` on the host: {err}"),
@@ -828,6 +832,7 @@ pub fn recordings_dir_writable(
     match exec.run(&cmd) {
         Ok(_) => PreflightCheck {
             name: CHECK_RECORDINGS_DIR_WRITABLE,
+            scope: None,
             passed: true,
             deferred: false,
             detail: format!("recordings directory `{dir}` exists and is writable"),
@@ -835,6 +840,7 @@ pub fn recordings_dir_writable(
         },
         Err(err) => PreflightCheck {
             name: CHECK_RECORDINGS_DIR_WRITABLE,
+            scope: None,
             passed: false,
             deferred: false,
             detail: format!("recordings directory `{dir}` is missing or not writable: {err}"),
@@ -1004,6 +1010,7 @@ pub fn mediamtx_ports_available(
         Err(err) => {
             return PreflightCheck {
                 name: CHECK_MEDIAMTX_PORTS_AVAILABLE,
+                scope: None,
                 passed: false,
                 deferred: false,
                 detail: format!("could not verify MediaMTX port availability (`ss` failed): {err}"),
@@ -1019,6 +1026,7 @@ pub fn mediamtx_ports_available(
     if sockets.is_empty() && !output.trim().is_empty() {
         return PreflightCheck {
             name: CHECK_MEDIAMTX_PORTS_AVAILABLE,
+            scope: None,
             passed: false,
             deferred: false,
             detail: "could not verify MediaMTX port availability: `ss` output did not parse into \
@@ -1092,6 +1100,7 @@ pub fn mediamtx_ports_available(
     if !conflict_msgs.is_empty() {
         return PreflightCheck {
             name: CHECK_MEDIAMTX_PORTS_AVAILABLE,
+            scope: None,
             passed: false,
             deferred: false,
             detail: conflict_msgs.join("; "),
@@ -1110,6 +1119,7 @@ pub fn mediamtx_ports_available(
     };
     PreflightCheck {
         name: CHECK_MEDIAMTX_PORTS_AVAILABLE,
+        scope: None,
         passed: true,
         deferred: false,
         detail,
@@ -1160,6 +1170,7 @@ pub fn mediamtx_binary_preflight(
     match exec.run(&cmd) {
         Ok(_) => PreflightCheck {
             name: CHECK_MEDIAMTX_BINARY,
+            scope: None,
             passed: true,
             deferred: false,
             detail: format!("MediaMTX binary `{bin}` exists and is executable"),
@@ -1167,6 +1178,7 @@ pub fn mediamtx_binary_preflight(
         },
         Err(err) => PreflightCheck {
             name: CHECK_MEDIAMTX_BINARY,
+            scope: None,
             passed: false,
             deferred: false,
             detail: format!(
@@ -1222,6 +1234,7 @@ pub fn mediamtx_ports_distinct(cfg: &MediaMtxHostConfig) -> PreflightCheck {
     if conflicts.is_empty() {
         PreflightCheck {
             name: CHECK_MEDIAMTX_PORTS_DISTINCT,
+            scope: None,
             passed: true,
             deferred: false,
             detail: "all MediaMTX TCP listener ports are distinct".to_owned(),
@@ -1230,6 +1243,7 @@ pub fn mediamtx_ports_distinct(cfg: &MediaMtxHostConfig) -> PreflightCheck {
     } else {
         PreflightCheck {
             name: CHECK_MEDIAMTX_PORTS_DISTINCT,
+            scope: None,
             passed: false,
             deferred: false,
             detail: format!(

--- a/autumn-cli/src/doctor.rs
+++ b/autumn-cli/src/doctor.rs
@@ -6173,6 +6173,22 @@ fn deploy_profile_config_load_check(
 
 // ─── Main entry point ─────────────────────────────────────────────────────────
 
+/// Remedy printed when `[deploy] host` / `[deploy] hosts` are spelled in a way the
+/// shared validator refuses (both keys set, a blank entry, a duplicate).
+///
+/// A named constant so a unit test can pin its exact text: it is a `hint` field on
+/// `CheckResult`, so it is emitted verbatim into `autumn doctor --json` as well as
+/// the terminal, and a dropped `\` continuation would ship a run of spaces
+/// mid-sentence on a machine-readable surface (issue #1621).
+const DEPLOY_HOST_SPELLING_HINT: &str = "Fix the [deploy] host spelling in autumn.toml — \
+     set either `host` (one server) or `hosts` (a fleet), never both (see `autumn deploy \
+     check`)";
+
+/// Remedy printed on the SSH-reachability row when the host spelling itself is
+/// broken, so there is no list to probe. See [`DEPLOY_HOST_SPELLING_HINT`].
+const DEPLOY_HOST_SPELLING_REACHABILITY_HINT: &str = "Fix the [deploy] host spelling in autumn.toml before probing reachability (see \
+     `autumn deploy check`)";
+
 /// Run all doctor checks and report results.
 ///
 /// Checks are organised in two phases:
@@ -6707,9 +6723,7 @@ pub fn run(opts: DoctorOptions) {
                     name: "deploy_host",
                     status: CheckStatus::Fail,
                     detail: Some(message.clone()),
-                    hint: Some(
-                        "Fix the [deploy] host spelling in autumn.toml — set either `host`                          (one server) or `hosts` (a fleet), never both (see `autumn deploy                          check`)",
-                    ),
+                    hint: Some(DEPLOY_HOST_SPELLING_HINT),
                 },
             }
         }));
@@ -6732,9 +6746,7 @@ pub fn run(opts: DoctorOptions) {
                     name: crate::deploy::DOCTOR_PREFLIGHT_GRADERS[0],
                     status: CheckStatus::Fail,
                     detail: Some(message.clone()),
-                    hint: Some(
-                        "Fix the [deploy] host spelling in autumn.toml before probing                          reachability (see `autumn deploy check`)",
-                    ),
+                    hint: Some(DEPLOY_HOST_SPELLING_REACHABILITY_HINT),
                 },
             }));
         }
@@ -8275,6 +8287,33 @@ mod tests {
     /// One marked, registered, guard-free handler — the healthy shape.
     fn healthy_edge_scan() -> crate::edge_scan::EdgeScan {
         edge_scan_of("#[edge]\nfn greet() {}\nfn wire() { edge_routes![greet]; }")
+    }
+
+    /// #1621 review finding 12. Both hints are `hint` fields on `CheckResult`, so
+    /// they are serialized verbatim into `autumn doctor --json`; a dropped `\`
+    /// line continuation bakes the source indentation into the message as a long
+    /// run of spaces mid-sentence. Pin the exact text.
+    #[test]
+    fn deploy_host_spelling_hints_carry_no_line_continuation_gutter() {
+        assert_eq!(
+            DEPLOY_HOST_SPELLING_HINT,
+            "Fix the [deploy] host spelling in autumn.toml \u{2014} set either `host` (one \
+             server) or `hosts` (a fleet), never both (see `autumn deploy check`)",
+        );
+        assert_eq!(
+            DEPLOY_HOST_SPELLING_REACHABILITY_HINT,
+            "Fix the [deploy] host spelling in autumn.toml before probing reachability \
+             (see `autumn deploy check`)",
+        );
+        for hint in [
+            DEPLOY_HOST_SPELLING_HINT,
+            DEPLOY_HOST_SPELLING_REACHABILITY_HINT,
+        ] {
+            assert!(
+                !hint.contains("   "),
+                "a run of spaces mid-sentence means a `\\` continuation was dropped: {hint}",
+            );
+        }
     }
 
     #[test]

--- a/autumn-cli/src/doctor.rs
+++ b/autumn-cli/src/doctor.rs
@@ -6683,27 +6683,59 @@ pub fn run(opts: DoctorOptions) {
         // --strict` must fail on it too rather than green-lighting a config the
         // deploy path rejects. Only the actual TCP connect probe is gated behind
         // `--online`.
-        let host = deploy_cfg.host.clone();
+        //
+        // #1621: the target is a LIST — `[deploy] host` (one) or `[deploy] hosts`
+        // (a fleet, in rollout order) — and doctor enumerates it exactly as
+        // `deploy check` does, through the same shared validator, so a fleet config
+        // is graded rather than reported as "no target host configured". A malformed
+        // spelling (both keys set, a blank entry, a duplicate) is the same hard
+        // refusal `deploy check` makes, surfaced here as a failing `deploy_host`.
+        //
+        // Doctor keeps ONE check per grader name even for a fleet: `CheckResult.name`
+        // is `&'static str` and an operator-visible `--json` key, so the per-host
+        // detail rides in the DETAIL text instead of multiplying names. See
+        // `crate::deploy::DOCTOR_PREFLIGHT_GRADERS`.
+        let deploy_hosts = crate::deploy::deploy_host_list(&deploy_cfg);
         tasks.push(Box::new({
-            let host = host.clone();
-            move || {
-                deploy_preflight_result(
+            let deploy_hosts = deploy_hosts.clone();
+            move || match &deploy_hosts {
+                Ok(hosts) => deploy_preflight_result(
                     "deploy_host",
-                    crate::deploy::grade_deploy_host_present(host.as_deref()),
-                )
+                    crate::deploy::grade_deploy_hosts_present(hosts),
+                ),
+                Err(message) => CheckResult {
+                    name: "deploy_host",
+                    status: CheckStatus::Fail,
+                    detail: Some(message.clone()),
+                    hint: Some(
+                        "Fix the [deploy] host spelling in autumn.toml — set either `host`                          (one server) or `hosts` (a fleet), never both (see `autumn deploy                          check`)",
+                    ),
+                },
             }
         }));
         if opts.online {
             let ssh_port = deploy_cfg.ssh_port;
-            tasks.push(Box::new(move || {
-                deploy_preflight_result(
-                    "deploy_ssh_reachability",
-                    crate::deploy::grade_ssh_reachability(
-                        host.as_deref(),
+            tasks.push(Box::new(move || match &deploy_hosts {
+                Ok(hosts) => deploy_preflight_result(
+                    crate::deploy::DOCTOR_PREFLIGHT_GRADERS[0],
+                    crate::deploy::grade_fleet_ssh_reachability(
+                        hosts,
                         ssh_port,
                         std::time::Duration::from_secs(5),
                     ),
-                )
+                ),
+                // The spelling itself is broken, so there is no list to probe; the
+                // `deploy_host` check above already names the problem. Report the
+                // reachability check as failing rather than silently omitting it —
+                // omission would change the `--json` key set.
+                Err(message) => CheckResult {
+                    name: crate::deploy::DOCTOR_PREFLIGHT_GRADERS[0],
+                    status: CheckStatus::Fail,
+                    detail: Some(message.clone()),
+                    hint: Some(
+                        "Fix the [deploy] host spelling in autumn.toml before probing                          reachability (see `autumn deploy check`)",
+                    ),
+                },
             }));
         }
 
@@ -6711,7 +6743,7 @@ pub fn run(opts: DoctorOptions) {
             Ok(deploy_previous_signing) => {
                 tasks.push(Box::new(move || {
                     deploy_preflight_result(
-                        "deploy_signing_secret",
+                        crate::deploy::DOCTOR_PREFLIGHT_GRADERS[1],
                         crate::deploy::grade_signing_secret(
                             deploy_signing.as_deref(),
                             &deploy_previous_signing,
@@ -6729,7 +6761,7 @@ pub fn run(opts: DoctorOptions) {
                 // strong current secret green-light a config the deploy path
                 // rejects.
                 tasks.push(Box::new(move || CheckResult {
-                    name: "deploy_signing_secret",
+                    name: crate::deploy::DOCTOR_PREFLIGHT_GRADERS[1],
                     status: CheckStatus::Fail,
                     detail: Some(format!(
                         "security.signing_secret.previous_secrets is present but invalid: {msg}"
@@ -6745,7 +6777,7 @@ pub fn run(opts: DoctorOptions) {
             Ok(deploy_db_url) => {
                 tasks.push(Box::new(move || {
                     deploy_preflight_result(
-                        "deploy_database_url",
+                        crate::deploy::DOCTOR_PREFLIGHT_GRADERS[2],
                         crate::deploy::grade_database_url(
                             deploy_db_url.as_deref(),
                             std::path::Path::new("migrations"),
@@ -6760,7 +6792,7 @@ pub fn run(opts: DoctorOptions) {
                 // check instead of exiting the process, so `autumn doctor --json`
                 // still emits valid JSON with a clear, actionable failure.
                 tasks.push(Box::new(move || CheckResult {
-                    name: "deploy_database_url",
+                    name: crate::deploy::DOCTOR_PREFLIGHT_GRADERS[2],
                     status: CheckStatus::Fail,
                     detail: Some(format!("[[database.shards]] is present but invalid: {msg}")),
                     hint: Some(
@@ -6772,7 +6804,7 @@ pub fn run(opts: DoctorOptions) {
         }
         tasks.push(Box::new(|| {
             deploy_preflight_result(
-                "deploy_migrate_check",
+                crate::deploy::DOCTOR_PREFLIGHT_GRADERS[3],
                 crate::deploy::grade_migrate_check(std::path::Path::new("migrations")),
             )
         }));

--- a/autumn-cli/src/main.rs
+++ b/autumn-cli/src/main.rs
@@ -856,6 +856,15 @@ enum Commands {
     ///   --no-rollback   on `up`, halt and FREEZE a failed rollout for inspection
     ///                   instead of automatically rolling the cut-over hosts back.
     ///
+    /// Fleet visibility and control (issue #1621):
+    ///   status          read-only per-host state (release, readiness, maintenance,
+    ///                   proxy) plus version/state drift; `--json` for machines,
+    ///                   `--strict` exits non-zero on drift (cron-alertable).
+    ///   maintenance     turn maintenance mode on|off on EVERY configured host over
+    ///                   SSH (the local `autumn maintenance` only writes this
+    ///                   machine's working directory). NOTE: maintenance does not
+    ///                   drain a host from your load balancer — /ready stays 200.
+    ///
     /// # Examples
     ///
     ///   autumn deploy check
@@ -865,6 +874,9 @@ enum Commands {
     ///   autumn deploy up
     ///   autumn deploy up --only web-2.example.com
     ///   autumn deploy up --no-rollback
+    ///   autumn deploy status --json --strict
+    ///   autumn deploy maintenance on --message "Upgrading database schema"
+    ///   autumn deploy maintenance off
     #[command(subcommand, verbatim_doc_comment)]
     Deploy(DeployCommands),
 
@@ -1117,6 +1129,11 @@ enum Commands {
     /// Writes (or removes) a JSON flag file that the running app polls every
     /// 500 ms. Within one second every replica responds 503 to non-bypassed
     /// HTTP traffic while health-check routes stay green.
+    ///
+    /// LOCAL only: the flag lands in THIS working directory. For servers
+    /// managed by `autumn deploy` (`[deploy] host`/`hosts`), use
+    /// `autumn deploy maintenance on|off`, which fans the same flag out to
+    /// every host over SSH (issue #1621).
     ///
     /// # Examples
     ///
@@ -2251,6 +2268,78 @@ enum DeployCommands {
         #[arg(long)]
         no_rollback: bool,
     },
+
+    /// Report every configured host's deploy state, read-only (issue #1621).
+    ///
+    /// One row per `[deploy] hosts` entry: mode, deployed release (from the
+    /// `current` symlink), live slot, /ready status, maintenance flag, and proxy
+    /// port — plus version drift (hosts on different releases) and state drift
+    /// (per-host marker damage that will fail the NEXT deploy closed). Touches
+    /// nothing; safe mid-incident.
+    Status {
+        /// Emit the stable JSON report on stdout instead of the table.
+        #[arg(long)]
+        json: bool,
+        /// Exit non-zero when ANY drift is detected, so drift is alertable from
+        /// cron. The default exits 0 — status is a report, not a judgement.
+        #[arg(long)]
+        strict: bool,
+    },
+
+    /// Fleet-wide maintenance mode over SSH (issue #1621).
+    ///
+    /// Applies to the DEPLOY-CONFIGURED host(s) — `[deploy] host` or `[deploy]
+    /// hosts` — unlike the top-level `autumn maintenance`, which only writes this
+    /// machine's own working directory. Best-effort: every host is attempted, the
+    /// per-host table names what changed, and the command exits non-zero if any
+    /// host failed (the changed hosts are NOT reversed).
+    ///
+    /// Maintenance mode does NOT drain a host from your load balancer: /ready
+    /// stays 200 by design, so a maintained host keeps taking traffic and answers
+    /// it with 503. Drain at the load balancer if you need a host out of rotation.
+    #[command(subcommand)]
+    Maintenance(DeployMaintenanceCommands),
+}
+
+/// Subcommands for `autumn deploy maintenance` (issue #1621).
+#[derive(Subcommand)]
+enum DeployMaintenanceCommands {
+    /// Enable maintenance mode on every configured deploy host.
+    ///
+    /// Writes the same flag file the local `autumn maintenance on` writes, to the
+    /// per-app shared dir on each host (and, for hosts still running pre-#1621
+    /// units, to the current release's tmp/ dir), so running apps react within
+    /// 500 ms without a restart.
+    ///
+    /// # Examples
+    ///
+    ///   autumn deploy maintenance on
+    ///   autumn deploy maintenance on --message "Upgrading database schema"
+    ///   autumn deploy maintenance on --readonly
+    ///   autumn deploy maintenance on --allow-ips 10.0.0.0/8 --bypass-header X-Dev-Bypass:mytoken
+    #[command(verbatim_doc_comment)]
+    On {
+        /// Human-readable message shown to users in the 503 response body.
+        #[arg(long, value_name = "MSG")]
+        message: Option<String>,
+        /// CIDR block or IP address whose requests bypass maintenance.
+        /// Repeatable: `--allow-ips 10.0.0.0/8 --allow-ips 172.16.0.1`
+        #[arg(long, value_name = "CIDR")]
+        allow_ips: Vec<String>,
+        /// Allow GET, HEAD, OPTIONS through while blocking writes.
+        #[arg(long)]
+        readonly: bool,
+        /// Bypass header in NAME:VALUE format.
+        /// Requests carrying this header+value bypass the 503.
+        /// Example: `--bypass-header X-Autumn-Maintenance-Bypass:mytoken`
+        #[arg(long, value_name = "NAME:VALUE")]
+        bypass_header: Option<String>,
+    },
+    /// Disable maintenance mode on every configured deploy host.
+    ///
+    /// Removes the flag file(s); a host where maintenance was already off is a
+    /// success, not an error.
+    Off,
 }
 
 /// Subcommands for `autumn generate`.
@@ -4133,8 +4222,54 @@ fn run_deploy_command(cmd: &DeployCommands) {
             deploy::DeployOptions {
                 only: only.clone(),
                 no_rollback: *no_rollback,
+                ..deploy::DeployOptions::default()
             },
         ),
+        DeployCommands::Status { json, strict } => (
+            deploy::DeployAction::Status,
+            deploy::DeployOptions {
+                json: *json,
+                strict: *strict,
+                ..deploy::DeployOptions::default()
+            },
+        ),
+        DeployCommands::Maintenance(cmd) => match cmd {
+            DeployMaintenanceCommands::On {
+                message,
+                allow_ips,
+                readonly,
+                bypass_header,
+            } => {
+                // Same parse (and same failure behavior) as the local
+                // `autumn maintenance on`, so the two surfaces reject a malformed
+                // NAME:VALUE identically.
+                let parsed_bypass = bypass_header.as_deref().map(|s| {
+                    maintenance::parse_bypass_header(s).map_or_else(
+                        |e| {
+                            eprintln!("autumn deploy maintenance on: {e}");
+                            std::process::exit(1);
+                        },
+                        |(name, value)| (name.to_owned(), value.to_owned()),
+                    )
+                });
+                (
+                    deploy::DeployAction::MaintenanceOn,
+                    deploy::DeployOptions {
+                        maintenance: Some(deploy::MaintenanceOnArgs {
+                            message: message.clone(),
+                            allow_ips: allow_ips.clone(),
+                            readonly: *readonly,
+                            bypass_header: parsed_bypass,
+                        }),
+                        ..deploy::DeployOptions::default()
+                    },
+                )
+            }
+            DeployMaintenanceCommands::Off => (
+                deploy::DeployAction::MaintenanceOff,
+                deploy::DeployOptions::default(),
+            ),
+        },
     };
     if let Err(e) = deploy::run(action, &options) {
         eprintln!("autumn deploy: {e}");

--- a/autumn-cli/src/main.rs
+++ b/autumn-cli/src/main.rs
@@ -841,19 +841,30 @@ enum Commands {
     #[command(subcommand, verbatim_doc_comment)]
     Release(ReleaseCommands),
 
-    /// Push-button, zero-downtime deploys to a VPS (issue #1607).
+    /// Push-button, zero-downtime deploys to a VPS or a fleet (issues #1607, #1621).
     ///
-    /// Run from the project root. `check` runs a local preflight, `plan` and
-    /// `rollback` print dry-run plans, and `up` performs a real first deploy over
-    /// SSH (cutover/rollback land in follow-ups). Configure the target under
-    /// `[deploy]` in autumn.toml.
+    /// Run from the project root. `check` runs a preflight against every configured
+    /// host, `plan` prints the dry-run plan, `up` performs a real rolling deploy over
+    /// SSH, and `rollback` returns the fleet to its previous release. Configure the
+    /// target under `[deploy] host` (one server) or `[deploy] hosts` (a fleet, in
+    /// rollout order) in autumn.toml.
+    ///
+    /// Fleet flags:
+    ///   --only <HOST>   repeatable; restrict `up`/`rollback` to these hosts. A
+    ///                   REPAIR LEVER: it leaves the skipped hosts on their current
+    ///                   release, so the fleet may end up mixed.
+    ///   --no-rollback   on `up`, halt and FREEZE a failed rollout for inspection
+    ///                   instead of automatically rolling the cut-over hosts back.
     ///
     /// # Examples
     ///
     ///   autumn deploy check
     ///   autumn deploy plan
     ///   autumn deploy rollback
+    ///   autumn deploy rollback --only web-2.example.com
     ///   autumn deploy up
+    ///   autumn deploy up --only web-2.example.com
+    ///   autumn deploy up --no-rollback
     #[command(subcommand, verbatim_doc_comment)]
     Deploy(DeployCommands),
 
@@ -2197,7 +2208,18 @@ enum DeployCommands {
     /// Resolves the previous release on the target, brings its slot back up,
     /// flips the proxy back to it, repoints `current`, and re-probes `/ready`.
     /// Fails loudly (non-zero) when there is no previous release to roll back to.
-    Rollback,
+    ///
+    /// With `[deploy] hosts` this rolls back EVERY host, newest first, continuing
+    /// past a host that fails (each is reported) and exiting non-zero if any host
+    /// did not come back.
+    Rollback {
+        /// Roll back only this host; repeat the flag for several (issue #1621).
+        ///
+        /// Each value must appear in `[deploy] hosts`. The hosts left out keep
+        /// running whatever they are running now, so the fleet may end up mixed.
+        #[arg(long, value_name = "HOST")]
+        only: Vec<String>,
+    },
 
     /// Run the preflight, then perform a REAL deploy over SSH.
     ///
@@ -2207,7 +2229,28 @@ enum DeployCommands {
     /// installs the proxy and stands the release up behind it; a redeploy runs a
     /// zero-downtime cutover and auto-rolls-back the candidate on a pre-cutover
     /// failure.
-    Up,
+    ///
+    /// With `[deploy] hosts` the hosts are replaced ONE AT A TIME in declaration
+    /// order, migrations run exactly once, and a mid-rollout failure halts the
+    /// rollout and rolls the hosts that already cut over back.
+    Up {
+        /// Deploy only this host; repeat the flag for several (issue #1621).
+        ///
+        /// Each value must appear in `[deploy] hosts`. A REPAIR LEVER, not a faster
+        /// deploy: the skipped hosts keep their current release, so finish with a
+        /// full `autumn deploy up` to converge the fleet.
+        #[arg(long, value_name = "HOST")]
+        only: Vec<String>,
+
+        /// Halt and FREEZE a failed rollout instead of rolling the cut-over hosts
+        /// back (issue #1621).
+        ///
+        /// Every host is left exactly as it is — including the ones already on the
+        /// new release — and named in the final state table, so the failure can be
+        /// inspected before anything else moves.
+        #[arg(long)]
+        no_rollback: bool,
+    },
 }
 
 /// Subcommands for `autumn generate`.
@@ -4065,14 +4108,35 @@ fn run_release_command(cmd: ReleaseCommands) {
     }
 }
 
+/// Map a `deploy` subcommand onto the (action, options) pair `deploy::run` takes.
+///
+/// [`deploy::DeployAction`] stays a fieldless `Copy` enum and the flags travel
+/// beside it in [`deploy::DeployOptions`] (issue #1621, §3.1), so adding a flag
+/// never ripples through the action enum or its call sites. Every construction here
+/// spreads `..Default::default()` for the same reason.
 fn run_deploy_command(cmd: &DeployCommands) {
-    let action = match cmd {
-        DeployCommands::Check => deploy::DeployAction::Check,
-        DeployCommands::Plan => deploy::DeployAction::Plan,
-        DeployCommands::Rollback => deploy::DeployAction::Rollback,
-        DeployCommands::Up => deploy::DeployAction::Up,
+    let (action, options) = match cmd {
+        DeployCommands::Check => (
+            deploy::DeployAction::Check,
+            deploy::DeployOptions::default(),
+        ),
+        DeployCommands::Plan => (deploy::DeployAction::Plan, deploy::DeployOptions::default()),
+        DeployCommands::Rollback { only } => (
+            deploy::DeployAction::Rollback,
+            deploy::DeployOptions {
+                only: only.clone(),
+                ..deploy::DeployOptions::default()
+            },
+        ),
+        DeployCommands::Up { only, no_rollback } => (
+            deploy::DeployAction::Up,
+            deploy::DeployOptions {
+                only: only.clone(),
+                no_rollback: *no_rollback,
+            },
+        ),
     };
-    if let Err(e) = deploy::run(action) {
+    if let Err(e) = deploy::run(action, &options) {
         eprintln!("autumn deploy: {e}");
         std::process::exit(1);
     }

--- a/autumn-cli/tests/deploy_e2e.rs
+++ b/autumn-cli/tests/deploy_e2e.rs
@@ -1317,7 +1317,9 @@ fn fleet_rolling_deploy_lifecycle() {
         body_a.contains("e2eapp v2") && body_b.contains("e2eapp v2"),
         "both hosts must still serve v2 after the halted rollout, got {body_a:?} / {body_b:?}"
     );
-    eprintln!("[fleet] 3. halt-on-host-1 OK — exit non-zero, host 2 untouched, both still serve v2");
+    eprintln!(
+        "[fleet] 3. halt-on-host-1 OK — exit non-zero, host 2 untouched, both still serve v2"
+    );
 
     // ── 4. Failure on host 2 AFTER host 1 cut over: host 1 auto-rolled back ──
     thread::sleep(Duration::from_millis(1200));
@@ -1466,7 +1468,11 @@ fn fleet_rolling_deploy_lifecycle() {
         assert!(!host["live_slot"].is_null(), "{report}");
         assert_eq!(host["drift"], serde_json::json!([]), "{report}");
     }
-    assert_eq!(report["version_drift"], serde_json::json!(false), "{report}");
+    assert_eq!(
+        report["version_drift"],
+        serde_json::json!(false),
+        "{report}"
+    );
     assert_eq!(report["state_drift"], serde_json::json!([]), "{report}");
     assert_eq!(report["drifted"], serde_json::json!(false), "{report}");
 

--- a/autumn-cli/tests/deploy_e2e.rs
+++ b/autumn-cli/tests/deploy_e2e.rs
@@ -29,6 +29,15 @@
 //!   against a pre-baked fixture image and both belong in a manual/where-a-real-VPS
 //!   -exists follow-up (see the report / tracking issue).
 //!
+//! ## The fleet lane (issue #1621, Slice 6a)
+//!
+//! [`fleet_rolling_deploy_lifecycle`] is the multi-server sibling: TWO fixture
+//! containers named by `[deploy] hosts`, driven through a serial rolling deploy,
+//! a forced pre-boundary halt, and a fleet auto-rollback compensation — again over
+//! real ssh, with nothing mocked. See the note on [`FleetNode`] for why it
+//! addresses its hosts by docker BRIDGE IP where the single-host tests use mapped
+//! loopback ports.
+//!
 //! Run it with:
 //! ```text
 //! cargo test -p autumn-cli --test deploy_e2e -- --ignored --nocapture
@@ -37,7 +46,7 @@
 #![allow(clippy::unwrap_used, clippy::expect_used)]
 
 use std::io::{Read, Write};
-use std::net::TcpStream;
+use std::net::{SocketAddr, TcpStream};
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output};
 use std::sync::Arc;
@@ -47,7 +56,7 @@ use std::time::{Duration, Instant};
 
 use testcontainers::core::{CgroupnsMode, ContainerPort, Mount, WaitFor};
 use testcontainers::runners::SyncRunner as _;
-use testcontainers::{GenericImage, ImageExt};
+use testcontainers::{Container, GenericImage, ImageExt};
 
 /// App name used throughout — the deploy derives every remote path and the
 /// systemd unit name from it, and uploads `target/release/{APP_NAME}`.
@@ -276,9 +285,26 @@ fn extract_kamal_proxy(dest: &Path) {
     );
 }
 
-/// Build the fixture image, writing the Dockerfile, the generated
-/// `authorized_keys`, and the extracted kamal-proxy into a fresh build context.
-/// Returns the image tag.
+/// Stable fixture-image tag for [`deploy_e2e_full_lifecycle`] (`pam_systemd` off).
+const FIXTURE_TAG_DEFAULT: &str = "autumn-deploy-e2e:test";
+/// Stable fixture-image tag for [`deploy_e2e_pam_systemd_control_socket`]
+/// (`pam_systemd` left enabled — the real-host `XDG_RUNTIME_DIR` shape).
+const FIXTURE_TAG_PAM: &str = "autumn-deploy-e2e:pam";
+/// Stable fixture-image tag for [`fleet_rolling_deploy_lifecycle`].
+///
+/// **A distinct tag is a correctness requirement, not a nicety.** Each test's
+/// [`Workspace`] mints its OWN throwaway keypair and bakes its public half into the
+/// image, and libtest runs these `#[ignore]`d tests in PARALLEL threads (the CI
+/// Docker step passes no `--test-threads=1` for this binary). Two tests sharing one
+/// stable tag would therefore race: the second `docker build` re-points the tag at an
+/// image carrying the *other* run's `authorized_keys`, and whichever test starts its
+/// container after that build cannot authenticate to it. Distinct tags also stop one
+/// test's end-of-run `docker rmi -f` from yanking the tag out from under a sibling
+/// that has not started its containers yet. The fixture shape is identical to
+/// `FIXTURE_TAG_DEFAULT`'s, so the expensive apt layer is a cache hit.
+const FIXTURE_TAG_FLEET: &str = "autumn-deploy-e2e:fleet";
+
+/// Build the fixture image under the stable tag matching `enable_pam`.
 ///
 /// `enable_pam` selects the `ENABLE_PAM_SYSTEMD` build arg (issue #1948 item 4):
 /// `false` (default fixture shape) disables `pam_systemd` so ssh sessions inherit
@@ -287,6 +313,24 @@ fn extract_kamal_proxy(dest: &Path) {
 /// control-socket regression shape. The two shapes get DISTINCT stable tags so
 /// they never clobber each other's cache.
 fn build_fixture_image(ctx: &Path, pubkey: &str, enable_pam: bool) -> String {
+    let tag = if enable_pam {
+        FIXTURE_TAG_PAM
+    } else {
+        FIXTURE_TAG_DEFAULT
+    };
+    build_fixture_image_as(ctx, pubkey, enable_pam, tag)
+}
+
+/// Build the fixture image under an EXPLICIT tag, writing the Dockerfile, the
+/// generated `authorized_keys`, and the extracted kamal-proxy into a fresh build
+/// context. Returns the image tag.
+///
+/// Tags are STABLE (rather than unique per run) so at most one fixture image per
+/// tag ever exists: each run overwrites it and reuses the cached apt layers, and the
+/// end-of-test `docker rmi` keeps disk bounded even if a previous run's cleanup
+/// raced with container teardown. Every concurrently-running test needs its OWN tag
+/// — see [`FIXTURE_TAG_FLEET`] for why.
+fn build_fixture_image_as(ctx: &Path, pubkey: &str, enable_pam: bool, tag: &str) -> String {
     std::fs::write(
         ctx.join("Dockerfile"),
         include_str!("fixtures/deploy/Dockerfile"),
@@ -295,27 +339,18 @@ fn build_fixture_image(ctx: &Path, pubkey: &str, enable_pam: bool) -> String {
     std::fs::write(ctx.join("authorized_keys"), pubkey).expect("write authorized_keys");
     extract_kamal_proxy(&ctx.join("kamal-proxy"));
 
-    // STABLE per-shape tags (rather than unique ones) so at most one fixture
-    // image per shape ever exists: each run overwrites it and reuses the cached
-    // apt layers, and the end-of-test `docker rmi` keeps disk bounded even if a
-    // previous run's cleanup raced with container teardown.
-    let tag = if enable_pam {
-        "autumn-deploy-e2e:pam".to_string()
-    } else {
-        "autumn-deploy-e2e:test".to_string()
-    };
     run_ok(
         Command::new("docker").args([
             "build",
             "--build-arg",
             &format!("ENABLE_PAM_SYSTEMD={}", u8::from(enable_pam)),
             "-t",
-            &tag,
+            tag,
             &ctx.display().to_string(),
         ]),
         "docker build fixture image",
     );
-    tag
+    tag.to_owned()
 }
 
 // ── Test-app compilation ─────────────────────────────────────────────────────
@@ -437,6 +472,31 @@ impl Workspace {
             ),
         )
         .expect("write autumn.toml");
+    }
+
+    /// Write `autumn.toml` into the project dir naming a FLEET (issue #1621):
+    /// `[deploy] hosts = [...]` in rollout order, sharing one `ssh_port`.
+    ///
+    /// `hosts` and `ssh_port` are separate parameters because `[deploy]` has exactly
+    /// ONE `ssh_port` for the whole fleet — `ResolvedFleet::from_targets` clones the
+    /// resolved config and varies only `host` — which is precisely why the fleet test
+    /// cannot address its containers by their (distinct, random) mapped loopback
+    /// ports. See the note on [`FleetNode`].
+    fn write_config_fleet(&self, hosts: &[&str], ssh_port: u16) {
+        let list = hosts
+            .iter()
+            .map(|host| format!("\"{host}\""))
+            .collect::<Vec<_>>()
+            .join(", ");
+        std::fs::write(
+            self.project.join("autumn.toml"),
+            format!(
+                "[server]\nport = {PUBLIC_PORT}\n\n\
+                 [deploy]\nhosts = [{list}]\nuser = \"root\"\nssh_port = {ssh_port}\n\
+                 app_name = \"{APP_NAME}\"\nreadiness_timeout_secs = {READINESS_TIMEOUT_SECS}\n",
+            ),
+        )
+        .expect("write fleet autumn.toml");
     }
 
     /// Stage `bin` as the release binary the next `autumn deploy up` uploads
@@ -783,6 +843,646 @@ fn deploy_e2e_pam_systemd_control_socket() {
     );
 
     drop(container);
+    let _ = Command::new("docker")
+        .args(["rmi", "-f", &image_tag])
+        .output();
+}
+
+// ── Fleet harness (issue #1621, Slice 6a) ────────────────────────────────────
+
+/// One booted fixture container in the fleet, with the three addresses this test
+/// needs — and the reason there are three rather than one.
+///
+/// ## Why the fleet is addressed by BRIDGE IP, not by mapped loopback port
+///
+/// `[deploy]` carries exactly ONE `ssh_port` for the whole fleet:
+/// `ResolvedFleet::from_targets` resolves the shared shape once and then varies
+/// **only** `host` per entry, and `SshTarget::from_resolved` reads `cfg.ssh_port`
+/// for every host. `[deploy] hosts` entries are bare addresses — there is no
+/// `host:port` spelling — so two containers published on two DIFFERENT random host
+/// ports simply cannot both be named in one fleet. (Extending the config to carry a
+/// per-host port is product work, deliberately out of scope for a test slice.)
+///
+/// The shape the config DOES support is N addresses at one shared port, and each
+/// container already has exactly that: its own docker-bridge IP, with sshd on the
+/// container's own port 22. So `[deploy] hosts = ["<ip-a>", "<ip-b>"]` with
+/// `ssh_port = 22`.
+///
+/// **Limitation, stated rather than hidden:** container bridge IPs are routable from
+/// the docker host only on Linux (and only when the runner IS the docker host rather
+/// than a sibling container). That is exactly the environment this test runs in —
+/// the Linux-only "Run Docker-dependent tests" CI step — and
+/// [`assert_bridge_reachable`] fails fast with an explicit message if it ever is not,
+/// instead of surfacing as an opaque ssh failure mid-rollout.
+///
+/// The HARNESS's own probes never depend on the bridge: [`Workspace::ssh`] and
+/// [`http_get`] keep using the MAPPED loopback ports, exactly like the single-host
+/// tests. Only the product's ssh/scp path uses the bridge, which is the thing under
+/// test.
+struct FleetNode {
+    /// Held for the lifetime of the test; dropping it removes the container.
+    _container: Container<GenericImage>,
+    /// Mapped host port for the container's sshd — the HARNESS's own probes only.
+    ssh_port: u16,
+    /// Mapped host port for the container's public (kamal-proxy) port — the
+    /// harness's HTTP assertions and zero-downtime probers.
+    public_port: u16,
+    /// The container's docker-bridge IP: what `[deploy] hosts` names, reached by
+    /// the product on the container's own port 22.
+    ip: String,
+}
+
+/// Read a container's docker-bridge IPv4 address.
+///
+/// Goes through the `docker` CLI (as [`extract_kamal_proxy`] already does) rather
+/// than `Container::get_bridge_ip_address`, whose implementation additionally
+/// inspects the NETWORK named by `HostConfig.NetworkMode` — a lookup that has its
+/// own failure modes. This template reads the address straight off the container.
+fn container_bridge_ip(id: &str) -> String {
+    let out = run_ok(
+        Command::new("docker").args([
+            "inspect",
+            "-f",
+            "{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}",
+            id,
+        ]),
+        "docker inspect container bridge ip",
+    );
+    let ip = String::from_utf8_lossy(&out.stdout).trim().to_owned();
+    assert!(
+        ip.parse::<std::net::Ipv4Addr>().is_ok(),
+        "expected an IPv4 bridge address for container {id}, got {ip:?} \
+         (the fleet e2e names hosts by bridge IP — see the note on FleetNode)"
+    );
+    ip
+}
+
+/// Start one fleet container from the (already built) fixture image.
+///
+/// Identical to the single-host launch except for `.with_network("bridge")`, which
+/// pins the container to docker's DEFAULT bridge — the only network whose addresses
+/// are routable from the docker host, and therefore the one the fleet's bridge-IP
+/// addressing depends on.
+fn start_fleet_node(image_tag: &str) -> FleetNode {
+    let (repo, tag) = image_tag.split_once(':').unwrap();
+    let container = GenericImage::new(repo.to_string(), tag.to_string())
+        .with_exposed_port(ContainerPort::Tcp(22))
+        .with_exposed_port(ContainerPort::Tcp(PUBLIC_PORT))
+        .with_wait_for(WaitFor::Nothing)
+        .with_privileged(true)
+        .with_cgroupns_mode(CgroupnsMode::Host)
+        .with_network("bridge")
+        .with_mount(Mount::bind_mount("/sys/fs/cgroup", "/sys/fs/cgroup"))
+        .with_mount(Mount::tmpfs_mount("/run"))
+        .with_mount(Mount::tmpfs_mount("/run/lock"))
+        .with_startup_timeout(Duration::from_secs(180))
+        .start()
+        .expect("start fleet fixture container");
+
+    let ssh_port = container
+        .get_host_port_ipv4(ContainerPort::Tcp(22))
+        .expect("mapped ssh port");
+    let public_port = container
+        .get_host_port_ipv4(ContainerPort::Tcp(PUBLIC_PORT))
+        .expect("mapped public port");
+    let ip = container_bridge_ip(container.id());
+    FleetNode {
+        _container: container,
+        ssh_port,
+        public_port,
+        ip,
+    }
+}
+
+/// Fail fast (with the reason) unless this host can reach `ip:22` directly.
+///
+/// The fleet addresses its hosts by bridge IP out of necessity (see [`FleetNode`]),
+/// and that is the one environmental assumption this test makes. Proving it up front
+/// turns an otherwise baffling `ssh: connect to host … Connection timed out` in the
+/// middle of a rollout into one sentence naming the assumption.
+fn assert_bridge_reachable(ip: &str) {
+    let addr: SocketAddr = format!("{ip}:22")
+        .parse()
+        .unwrap_or_else(|e| panic!("bad bridge address {ip}:22: {e}"));
+    let deadline = Instant::now() + Duration::from_secs(30);
+    let mut last = String::from("(never attempted)");
+    while Instant::now() < deadline {
+        match TcpStream::connect_timeout(&addr, Duration::from_secs(3)) {
+            Ok(_) => return,
+            Err(e) => last = e.to_string(),
+        }
+        thread::sleep(Duration::from_millis(300));
+    }
+    panic!(
+        "container bridge address {ip}:22 is not reachable from this host ({last}). The fleet \
+         e2e must address its hosts by docker bridge IP because `[deploy]` carries ONE \
+         fleet-wide `ssh_port` (see the FleetNode note); that needs a Linux docker host whose \
+         default bridge is routable, which is what the CI Docker-dependent step provides."
+    );
+}
+
+/// The release id a host is currently serving: the basename of its `current`
+/// symlink — the exact identity `deploy status` reports (`release_id_from_dir` over
+/// `readlink -f current`), so the two can be compared directly.
+fn current_release(ws: &Workspace, ssh_port: u16) -> String {
+    let out = ws.ssh(
+        ssh_port,
+        &format!("readlink -f /srv/autumn/{APP_NAME}/current 2>/dev/null || true"),
+    );
+    String::from_utf8_lossy(&out.stdout)
+        .trim()
+        .rsplit('/')
+        .next()
+        .unwrap_or_default()
+        .to_owned()
+}
+
+/// A host's sorted release-dir listing — the "was this host touched at all?"
+/// fingerprint, used to prove a halted rollout never reached the hosts after the
+/// failing one.
+fn releases_listing(ws: &Workspace, ssh_port: u16) -> String {
+    let out = ws.ssh(
+        ssh_port,
+        &format!("ls -1 /srv/autumn/{APP_NAME}/releases 2>/dev/null | sort || true"),
+    );
+    String::from_utf8_lossy(&out.stdout).trim().to_owned()
+}
+
+/// How many times the deploy's pre-cutover migrate one-shot has actually RUN on a
+/// host.
+///
+/// The deploy runs migrations as `systemd-run --wait … --setenv=AUTUMN_MIGRATE=1
+/// {release}/{app}`, and the fixture app answers that trigger by printing
+/// `migrate: no-op (version …)` and exiting 0. The transient unit's stdout lands in
+/// the container's journal, so counting that line per host is direct evidence for
+/// AC-4 — the fleet migrates on exactly ONE host and never on hosts 2..N. Counting
+/// over the whole journal (rather than one transient unit, which `--collect` removes
+/// on exit) makes the count cumulative across scenarios, which is what the
+/// assertions want: host 2's count must stay 0 for the entire test.
+fn migrate_run_count(ws: &Workspace, ssh_port: u16) -> u32 {
+    let out = ws.ssh(
+        ssh_port,
+        "journalctl --no-pager --output=cat 2>/dev/null | grep -c 'migrate: no-op' || true",
+    );
+    String::from_utf8_lossy(&out.stdout)
+        .trim()
+        .parse()
+        .unwrap_or(0)
+}
+
+/// Assert some stderr line names `host` and contains `state` — used against both
+/// the rollout header's per-host lines and the shared fleet state table.
+///
+/// Matched line-wise rather than as one substring because `state_table_lines`
+/// pads the host column to the widest host name in the fleet, so the exact spacing
+/// between a host and its state depends on which two bridge IPs this run happened to
+/// get.
+fn assert_state_row(stderr: &str, host: &str, state: &str) {
+    assert!(
+        stderr
+            .lines()
+            .any(|line| line.contains(host) && line.contains(state)),
+        "expected a fleet row naming {host} with state {state:?}; full stderr:\n{stderr}"
+    );
+}
+
+// ── The fleet lifecycle ──────────────────────────────────────────────────────
+
+/// Two orchestrated containers exercise the whole FLEET lifecycle in order
+/// (issue #1621): fleet first deploy → zero-downtime rolling redeploy with
+/// exactly-once migrate → forced pre-boundary halt on host 1 (host 2 never touched)
+/// → forced failure on host 2 with host 1 auto-rolled back → `deploy status`.
+///
+/// ORDERING NOTE (the fleet analogue of the single-host test's): the two failure
+/// scenarios run in this order on purpose, and each depends on what the previous one
+/// left behind.
+///
+/// * Scenario 3 fails on the FIRST host. No earlier host has cut over, so
+///   `fleet_rollback_set` is empty and NO compensation runs — which is what makes it
+///   a clean, deterministic proof of "halt, and never touch the hosts after the
+///   failing one". Putting a first-host failure later, after other hosts were on the
+///   new release, would conflate halt with compensation.
+/// * Scenario 4 then fails on the SECOND host, which is the only way to observe
+///   compensation at all: serial rollout guarantees host 2 is touched **only after
+///   host 1's cutover completes**, so ANY pre-scripted breakage of host 2 yields a
+///   deterministic "host 1 is live on the new release when the rollout halts" — no
+///   timing, no racing `docker stop`. The injection used is a read-only bind mount
+///   over host 2's `releases` dir: every read-only probe in the all-hosts probe phase
+///   still succeeds (so the rollout is NOT refused before host 1 is touched), and the
+///   first MUTATING op of host 2's cutover — `prepare-dirs`' `mkdir -p {release_dir}`
+///   — fails with EROFS. That is pre-boundary, so host 2 tears its own candidate down
+///   and keeps serving, while host 1 is compensated back to its previous release.
+/// * Scenario 4 is also safe to run AFTER scenario 3 despite the single-host
+///   ordering hazard (a torn-down candidate leaves its slot's unit pointing at the
+///   failed release): scenario 4's own cutover rewrites host 1's candidate-slot unit
+///   before starting it, and the compensating rollback goes through `rollback_ops`,
+///   which re-renders the TARGET slot's unit from the target release dir
+///   (`write-target-unit`) rather than trusting whatever is on disk.
+#[test]
+#[ignore = "requires Docker + ssh client; run with --ignored"]
+// A single, deliberately linear orchestration (two booted containers, four ordered
+// scenarios, one status report) reads more honestly end-to-end than six fragmented
+// helpers that would each have to re-establish the same fleet state.
+#[allow(clippy::too_many_lines)]
+fn fleet_rolling_deploy_lifecycle() {
+    let ws = Workspace::build();
+
+    // Own stable tag: this test runs CONCURRENTLY with its two single-host siblings
+    // and bakes its own throwaway key into the image (see `FIXTURE_TAG_FLEET`).
+    let ctx = tempfile::tempdir().expect("ctx tempdir");
+    let image_tag = build_fixture_image_as(ctx.path(), &ws.pubkey, false, FIXTURE_TAG_FLEET);
+
+    // Both containers are started before either is waited on, so they boot in
+    // parallel rather than serially.
+    let host_a = start_fleet_node(&image_tag);
+    let host_b = start_fleet_node(&image_tag);
+    eprintln!(
+        "[fleet] host 1: ip={} ssh={} public={}",
+        host_a.ip, host_a.ssh_port, host_a.public_port
+    );
+    eprintln!(
+        "[fleet] host 2: ip={} ssh={} public={}",
+        host_b.ip, host_b.ssh_port, host_b.public_port
+    );
+    wait_for_boot(&ws, host_a.ssh_port);
+    wait_for_boot(&ws, host_b.ssh_port);
+    eprintln!("[fleet] both containers booted");
+
+    // The one environmental assumption, proved before anything else runs.
+    assert_bridge_reachable(&host_a.ip);
+    assert_bridge_reachable(&host_b.ip);
+
+    // The PRODUCT's ssh passes no `-o UserKnownHostsFile`, so it pins host keys in
+    // the ambient `~/.ssh/known_hosts` (resolved from the passwd database, not
+    // `$HOME` — see the `SshAgent` note). Bridge IPs are recycled across runs while
+    // each run's fixture image carries fresh host keys, so a PERSISTENT runner can
+    // hold a stale pin for this run's IP, and `StrictHostKeyChecking=accept-new`
+    // would then correctly refuse to connect. Drop any stale pin first; the
+    // harness's own ssh is immune (it passes a per-run known-hosts file).
+    for ip in [host_a.ip.as_str(), host_b.ip.as_str()] {
+        let _ = Command::new("ssh-keygen").args(["-R", ip]).output();
+    }
+
+    ws.write_config_fleet(&[host_a.ip.as_str(), host_b.ip.as_str()], 22);
+
+    // ── 1. Fleet FIRST deploy (v1) ──────────────────────────────────────────
+    ws.stage_release(&ws.app_v1);
+    let out = ws.autumn_deploy(&["up"]);
+    let stderr = String::from_utf8_lossy(&out.stderr).into_owned();
+    assert!(out.status.success(), "fleet first deploy failed:\n{stderr}");
+    assert!(
+        stderr.contains("across 2 hosts, ONE AT A TIME"),
+        "the rollout header should announce a serial 2-host rollout:\n{stderr}"
+    );
+    assert_state_row(&stderr, &host_a.ip, "first deploy");
+    assert_state_row(&stderr, &host_b.ip, "first deploy");
+    assert!(
+        stderr.contains(&format!("[1/2 {}] deploying release", host_a.ip))
+            && stderr.contains(&format!("[2/2 {}] deploying release", host_b.ip)),
+        "hosts must roll out in `[deploy] hosts` declaration order:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("Fleet deploy complete") && stderr.contains("all 2 hosts serving"),
+        "a clean fleet rollout should report every host serving:\n{stderr}"
+    );
+
+    let body_a = wait_for_http_ok(host_a.public_port, "/", Duration::from_secs(30));
+    let body_b = wait_for_http_ok(host_b.public_port, "/", Duration::from_secs(30));
+    assert!(
+        body_a.contains("e2eapp v1") && body_b.contains("e2eapp v1"),
+        "both hosts should serve v1 after the fleet first deploy, got {body_a:?} / {body_b:?}"
+    );
+
+    // ONE release id per fleet run: every host's `current` resolves to the same
+    // release, which is what makes drift reporting and a fleet rollback meaningful.
+    let rel_v1 = current_release(&ws, host_a.ssh_port);
+    assert!(!rel_v1.is_empty(), "host 1 should have a `current` release");
+    assert_eq!(
+        rel_v1,
+        current_release(&ws, host_b.ssh_port),
+        "a fleet run mints exactly ONE release id for every host (#1621)"
+    );
+    eprintln!("[fleet] 1. fleet first deploy OK — both hosts serve v1 as release {rel_v1}");
+
+    // ── 2. Rolling redeploy to v2, both hosts under load (AC-2 + AC-4) ──────
+    thread::sleep(Duration::from_millis(1200)); // distinct per-second release id
+    ws.stage_release(&ws.app_v2);
+    let prober_a = Prober::start(host_a.public_port);
+    let prober_b = Prober::start(host_b.public_port);
+    let out = ws.autumn_deploy(&["up"]);
+    let (total_a, failures_a) = prober_a.finish();
+    let (total_b, failures_b) = prober_b.finish();
+    let stderr = String::from_utf8_lossy(&out.stderr).into_owned();
+    assert!(
+        out.status.success(),
+        "fleet rolling redeploy failed:\n{stderr}"
+    );
+    assert_eq!(
+        failures_a, 0,
+        "host 1 dropped {failures_a}/{total_a} requests during the rolling redeploy"
+    );
+    assert_eq!(
+        failures_b, 0,
+        "host 2 dropped {failures_b}/{total_b} requests during the rolling redeploy"
+    );
+    assert!(
+        total_a > 0 && total_b > 0,
+        "both probers must have made requests ({total_a} / {total_b})"
+    );
+    assert_state_row(&stderr, &host_a.ip, "zero-downtime redeploy");
+    assert_state_row(&stderr, &host_b.ip, "zero-downtime redeploy");
+
+    // AC-4, as the driver PLANS it: the fleet-wide schema moves exactly once, on the
+    // first host still on a previous release, and every other host is told to skip.
+    assert!(
+        stderr.contains(&format!("migrate ({} only", host_a.ip))
+            && stderr.contains("the schema is fleet-wide")
+            && stderr.contains(&format!("{} skip it", host_b.ip)),
+        "the rollout header should place the single migration on host 1 only:\n{stderr}"
+    );
+    assert!(
+        stderr.contains(
+            "the schema has moved; from here an automatic rollback restores BINARIES only"
+        ),
+        "the fleet should say out loud that a rollback will not undo the migration:\n{stderr}"
+    );
+
+    // AC-4, as it actually EXECUTED: the `AUTUMN_MIGRATE=1` one-shot ran on host 1
+    // and never on host 2.
+    let migrated_a = migrate_run_count(&ws, host_a.ssh_port);
+    let migrated_b = migrate_run_count(&ws, host_b.ssh_port);
+    eprintln!("[fleet]    migrate one-shot runs: host 1 = {migrated_a}, host 2 = {migrated_b}");
+    assert!(
+        migrated_a >= 1,
+        "the migrate one-shot must have run on host 1 (journal showed {migrated_a} runs)"
+    );
+    assert_eq!(
+        migrated_b, 0,
+        "hosts 2..N must NEVER run the fleet migration (journal showed {migrated_b} runs)"
+    );
+
+    let rel_v2 = current_release(&ws, host_a.ssh_port);
+    assert_eq!(
+        rel_v2,
+        current_release(&ws, host_b.ssh_port),
+        "both hosts must converge on the redeploy's single release id"
+    );
+    assert_ne!(rel_v2, rel_v1, "the redeploy must mint a NEW release id");
+    let body_a = wait_for_http_ok(host_a.public_port, "/", Duration::from_secs(30));
+    let body_b = wait_for_http_ok(host_b.public_port, "/", Duration::from_secs(30));
+    assert!(
+        body_a.contains("e2eapp v2") && body_b.contains("e2eapp v2"),
+        "both hosts should serve v2 after the rolling redeploy, got {body_a:?} / {body_b:?}"
+    );
+    eprintln!(
+        "[fleet] 2. rolling redeploy OK — 0/{total_a} and 0/{total_b} requests failed; \
+         both hosts serve v2 as release {rel_v2}"
+    );
+
+    // ── 3. Forced PRE-boundary failure on host 1: halt, host 2 never touched ─
+    thread::sleep(Duration::from_millis(1200));
+    let releases_b_before = releases_listing(&ws, host_b.ssh_port);
+    ws.stage_release(&ws.app_bad); // refuses /ready forever
+    let prober_a = Prober::start(host_a.public_port);
+    let prober_b = Prober::start(host_b.public_port);
+    let out = ws.autumn_deploy(&["up"]);
+    let (total_a, failures_a) = prober_a.finish();
+    let (total_b, failures_b) = prober_b.finish();
+    let stderr = String::from_utf8_lossy(&out.stderr).into_owned();
+    assert!(
+        !out.status.success(),
+        "a readiness-gate timeout on host 1 must exit non-zero:\n{stderr}"
+    );
+    assert_eq!(
+        failures_a, 0,
+        "host 1's old release must keep serving through the failed attempt \
+         ({failures_a}/{total_a} dropped)"
+    );
+    assert_eq!(
+        failures_b, 0,
+        "host 2 was never touched and must not drop a request \
+         ({failures_b}/{total_b} dropped)"
+    );
+    assert!(
+        stderr.contains(&format!(
+            "rollout halted at {} (`readiness-gate`)",
+            host_a.ip
+        )) && stderr.contains("the remaining hosts were not touched"),
+        "the rollout must halt at host 1's readiness gate:\n{stderr}"
+    );
+    assert!(
+        stderr.contains(&format!(
+            "fleet rollout halted at {} during `readiness-gate`",
+            host_a.ip
+        )),
+        "the process error must name the failing host and step:\n{stderr}"
+    );
+    assert_state_row(
+        &stderr,
+        &host_a.ip,
+        "previous release still serving (rolled back at `readiness-gate`)",
+    );
+    assert_state_row(&stderr, &host_b.ip, "untouched (not reached)");
+    // Host 1 is the FIRST host, so no earlier host is on the new release: the
+    // compensation set is empty and the driver must not print a compensation pass.
+    assert!(
+        !stderr.contains("Compensating"),
+        "a failure on the FIRST host has nothing to compensate:\n{stderr}"
+    );
+
+    // Host 2 is untouched at the filesystem level, not just in the report.
+    assert_eq!(
+        releases_listing(&ws, host_b.ssh_port),
+        releases_b_before,
+        "host 2 must have no release dir from the halted rollout"
+    );
+    assert_eq!(
+        current_release(&ws, host_b.ssh_port),
+        rel_v2,
+        "host 2's `current` must be unchanged by the halted rollout"
+    );
+    assert_eq!(
+        migrate_run_count(&ws, host_b.ssh_port),
+        0,
+        "host 2 must still never have migrated"
+    );
+    assert_eq!(
+        current_release(&ws, host_a.ssh_port),
+        rel_v2,
+        "host 1's candidate was torn down, so its `current` must still be the v2 release"
+    );
+    let body_a = wait_for_http_ok(host_a.public_port, "/", Duration::from_secs(15));
+    let body_b = wait_for_http_ok(host_b.public_port, "/", Duration::from_secs(15));
+    assert!(
+        body_a.contains("e2eapp v2") && body_b.contains("e2eapp v2"),
+        "both hosts must still serve v2 after the halted rollout, got {body_a:?} / {body_b:?}"
+    );
+    eprintln!("[fleet] 3. halt-on-host-1 OK — exit non-zero, host 2 untouched, both still serve v2");
+
+    // ── 4. Failure on host 2 AFTER host 1 cut over: host 1 auto-rolled back ──
+    thread::sleep(Duration::from_millis(1200));
+    // Pre-scripted, timing-free injection (see the ORDERING NOTE): make host 2's
+    // release dir read-only. Every read-only probe still succeeds, so the all-hosts
+    // probe phase passes and host 1 is genuinely deployed and cut over; host 2's
+    // first MUTATING op (`prepare-dirs`) then fails with EROFS — pre-boundary, so
+    // host 2 keeps serving and host 1 is the host that needs compensating.
+    let releases_dir = format!("/srv/autumn/{APP_NAME}/releases");
+    let mounted = ws.ssh(
+        host_b.ssh_port,
+        &format!(
+            "mount --bind {releases_dir} {releases_dir} && \
+             mount -o remount,bind,ro {releases_dir} {releases_dir}"
+        ),
+    );
+    assert!(
+        mounted.status.success(),
+        "could not remount host 2's releases dir read-only: {}",
+        String::from_utf8_lossy(&mounted.stderr)
+    );
+    let writable = ws.ssh(
+        host_b.ssh_port,
+        &format!(
+            "touch {releases_dir}/.e2e-write-probe >/dev/null 2>&1 && echo writable \
+             || echo readonly"
+        ),
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&writable.stdout).trim(),
+        "readonly",
+        "the scenario-4 injection is inoperative: host 2's releases dir is still writable, \
+         so host 2 would deploy successfully and nothing would be compensated"
+    );
+
+    let releases_b_before = releases_listing(&ws, host_b.ssh_port);
+    // A HEALTHY release, so host 1 genuinely cuts over before host 2 fails.
+    ws.stage_release(&ws.app_v2);
+    let out = ws.autumn_deploy(&["up"]);
+    let stderr = String::from_utf8_lossy(&out.stderr).into_owned();
+    assert!(
+        !out.status.success(),
+        "a failed host 2 must exit non-zero even though host 1 succeeded:\n{stderr}"
+    );
+    // Serial ordering: host 1 finished its cutover BEFORE host 2 was started.
+    assert!(
+        stderr.contains(&format!("[1/2 {}] serving", host_a.ip)),
+        "host 1 must have cut over before host 2 was touched:\n{stderr}"
+    );
+    assert!(
+        stderr.contains(&format!("rollout halted at {} (", host_b.ip))
+            && stderr.contains(&format!("fleet rollout halted at {} during ", host_b.ip)),
+        "the halt (and the process error) must name host 2:\n{stderr}"
+    );
+    // The compensation AC-3 turns on: the host that already cut over is undone, in
+    // reverse rollout order, binaries only.
+    assert!(
+        stderr.contains("Compensating 1 host(s) in reverse rollout order"),
+        "host 1 was on the new release, so the fleet must compensate it:\n{stderr}"
+    );
+    assert!(
+        stderr.contains(&format!(
+            "[{}] rolling back to the previous release",
+            host_a.ip
+        )),
+        "the compensation must name host 1:\n{stderr}"
+    );
+    assert_state_row(
+        &stderr,
+        &host_a.ip,
+        "previous release restored (rolled back by the fleet)",
+    );
+    assert_state_row(
+        &stderr,
+        &host_b.ip,
+        "previous release still serving (rolled back at `",
+    );
+    assert!(
+        stderr.contains("the compensating rollback restored BINARIES only"),
+        "the fleet must say the migration was NOT rolled back with the binaries:\n{stderr}"
+    );
+
+    assert_eq!(
+        current_release(&ws, host_a.ssh_port),
+        rel_v2,
+        "host 1 must be back on its pre-scenario release after the compensating rollback"
+    );
+    assert_eq!(
+        current_release(&ws, host_b.ssh_port),
+        rel_v2,
+        "host 2's `current` must be untouched by the failed cutover"
+    );
+    assert_eq!(
+        releases_listing(&ws, host_b.ssh_port),
+        releases_b_before,
+        "host 2's pre-boundary failure must leave no release dir behind"
+    );
+    let body_a = wait_for_http_ok(host_a.public_port, "/", Duration::from_secs(30));
+    let body_b = wait_for_http_ok(host_b.public_port, "/", Duration::from_secs(30));
+    assert!(
+        body_a.contains("e2eapp v2") && body_b.contains("e2eapp v2"),
+        "the fleet must converge back on v2, got {body_a:?} / {body_b:?}"
+    );
+    eprintln!("[fleet] 4. compensation OK — host 1 auto-rolled back, fleet converged on {rel_v2}");
+
+    // ── 5. `deploy status`: one converged fleet, no drift (AC-6) ────────────
+    let out = ws.autumn_deploy(&["status", "--json"]);
+    assert!(
+        out.status.success(),
+        "`deploy status --json` failed:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let report: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap_or_else(|e| {
+        panic!(
+            "`deploy status --json` did not emit JSON on stdout ({e}):\n{}",
+            String::from_utf8_lossy(&out.stdout)
+        )
+    });
+    let hosts = report["hosts"].as_array().expect("a `hosts` array");
+    assert_eq!(
+        hosts.len(),
+        2,
+        "status must report every fleet host: {report}"
+    );
+    assert_eq!(
+        hosts[0]["host"],
+        serde_json::json!(host_a.ip),
+        "status rows keep `[deploy] hosts` declaration order: {report}"
+    );
+    assert_eq!(hosts[1]["host"], serde_json::json!(host_b.ip));
+    for host in hosts {
+        assert_eq!(host["reachable"], serde_json::json!(true), "{report}");
+        assert_eq!(host["mode"], serde_json::json!("deployed"), "{report}");
+        assert_eq!(
+            host["release"],
+            serde_json::json!(rel_v2),
+            "both hosts must report the SAME release: {report}"
+        );
+        assert_eq!(host["ready"], serde_json::json!(200), "{report}");
+        assert_eq!(host["maintenance"], serde_json::json!(false), "{report}");
+        assert_eq!(
+            host["proxy_port"],
+            serde_json::json!(PUBLIC_PORT),
+            "{report}"
+        );
+        assert!(!host["live_slot"].is_null(), "{report}");
+        assert_eq!(host["drift"], serde_json::json!([]), "{report}");
+    }
+    assert_eq!(report["version_drift"], serde_json::json!(false), "{report}");
+    assert_eq!(report["state_drift"], serde_json::json!([]), "{report}");
+    assert_eq!(report["drifted"], serde_json::json!(false), "{report}");
+
+    // `--strict`'s exit condition IS `drifted`, so a converged fleet exits 0.
+    let out = ws.autumn_deploy(&["status", "--strict"]);
+    assert!(
+        out.status.success(),
+        "`deploy status --strict` must exit 0 on an undrifted fleet:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    eprintln!("[fleet] 5. deploy status OK — 2 hosts, one release, no drift");
+    eprintln!("[fleet] all #1621 fleet rollout assertions passed");
+
+    // Best-effort image cleanup (the containers are removed on drop).
+    drop(host_a);
+    drop(host_b);
     let _ = Command::new("docker")
         .args(["rmi", "-f", &image_tag])
         .output();

--- a/autumn-cli/tests/integration/deploy.rs
+++ b/autumn-cli/tests/integration/deploy.rs
@@ -1085,3 +1085,24 @@ fn deploy_up_rejects_an_only_host_that_is_not_in_the_fleet() {
         "the error must list the configured hosts\nstdout:\n{stdout}\nstderr:\n{stderr}"
     );
 }
+
+#[test]
+fn deploy_up_fails_fast_without_host() {
+    // #2274: forgetting `[deploy] host` is an ordinary first-run mistake, and `up`
+    // must report it the way `check` does — at the preflight boundary, before any
+    // local prerequisite work and long before anything indexes the fleet's first
+    // host. The tier-2 harness runs with an empty `PATH`, so this asserts the
+    // fail-fast boundary itself: the run must end in the missing-host preflight
+    // report, never a panic.
+    let dir = project("");
+    let (stdout, stderr) = run_autumn_fail(dir.path(), &["deploy", "up"], &[]);
+    let combined = format!("{stdout}{stderr}");
+    assert!(
+        !combined.contains("panicked"),
+        "a hostless `up` must fail cleanly, not panic\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    assert!(
+        combined.contains("[deploy] host") && combined.contains("hosts"),
+        "the missing-host report must name both spellings\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+}

--- a/autumn-cli/tests/integration/deploy.rs
+++ b/autumn-cli/tests/integration/deploy.rs
@@ -725,6 +725,77 @@ fn deploy_check_respects_explicit_autumn_dotenv_off() {
     );
 }
 
+/// The single fleet-wide migrate-placement sentence `deploy plan` prints for a
+/// multi-host `[deploy] hosts` (issue #1621, AC-4). Kept in sync by hand with
+/// `deploy::fleet::FLEET_MIGRATE_PLACEMENT_NOTE`; the unit-level drift guard is
+/// `fleet_plan_matches_fleet_ops_sequence`.
+const MIGRATE_PLACEMENT_NOTE: &str =
+    "runs once, on the first host still on a previous release, before its cutover";
+
+#[test]
+fn deploy_plan_renders_the_fleet_rollout_order_and_one_migrate_note() {
+    // #1621 (AC-4, T2.2): `deploy plan` is offline — it contacts no host, so it
+    // cannot know which hosts are first deploys. It therefore prints the rollout
+    // ORDER (declaration order, the documented contract) plus the migrate
+    // placement as a single fleet-wide RULE, never a per-host line.
+    let dir =
+        project("hosts = [\"web-1.example.com\", \"web-2.example.com\", \"web-3.example.com\"]\n");
+    let (stdout, stderr, code) = run_autumn(dir.path(), &["deploy", "plan"], &[]);
+    assert_eq!(
+        code,
+        Some(0),
+        "deploy plan should succeed for a fleet\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+
+    let first = stdout
+        .find("web-1.example.com")
+        .unwrap_or_else(|| panic!("web-1 must be listed\nstdout:\n{stdout}"));
+    let second = stdout
+        .find("web-2.example.com")
+        .unwrap_or_else(|| panic!("web-2 must be listed\nstdout:\n{stdout}"));
+    let third = stdout
+        .find("web-3.example.com")
+        .unwrap_or_else(|| panic!("web-3 must be listed\nstdout:\n{stdout}"));
+    assert!(
+        first < second && second < third,
+        "the fleet plan must list hosts in declaration (rollout) order\nstdout:\n{stdout}"
+    );
+
+    assert_eq!(
+        stdout.matches(MIGRATE_PLACEMENT_NOTE).count(),
+        1,
+        "the fleet plan must carry exactly one migrate-placement note\nstdout:\n{stdout}"
+    );
+}
+
+#[test]
+fn deploy_plan_output_is_identical_for_host_and_a_single_entry_hosts_list() {
+    // #1621 (AC-1, differential half of T2.1): a one-entry `hosts` list IS today's
+    // single-server deploy. The two projects differ by exactly the `[deploy]` host
+    // spelling, so any fleet-specific divergence in `deploy plan` — an extra
+    // section, a reordered line, a changed byte — shows up here. Stronger than a
+    // checked-in golden fixture: it can never go stale and depends on nothing
+    // about the machine it runs on.
+    let scalar = project("host = \"203.0.113.10\"\n");
+    let list = project("hosts = [\"203.0.113.10\"]\n");
+
+    let (scalar_out, scalar_err, scalar_code) = run_autumn(scalar.path(), &["deploy", "plan"], &[]);
+    let (list_out, list_err, list_code) = run_autumn(list.path(), &["deploy", "plan"], &[]);
+
+    assert_eq!(
+        scalar_code, list_code,
+        "exit codes must match\n`host` stderr:\n{scalar_err}\n`hosts` stderr:\n{list_err}"
+    );
+    assert_eq!(
+        scalar_out, list_out,
+        "`deploy plan` stdout must be byte-identical under both spellings"
+    );
+    assert_eq!(
+        scalar_err, list_err,
+        "`deploy plan` stderr must be byte-identical under both spellings"
+    );
+}
+
 #[test]
 fn deploy_help_lists_subcommands() {
     let dir = tempfile::tempdir().expect("temp dir");

--- a/autumn-cli/tests/integration/deploy.rs
+++ b/autumn-cli/tests/integration/deploy.rs
@@ -768,6 +768,198 @@ fn deploy_plan_renders_the_fleet_rollout_order_and_one_migrate_note() {
     );
 }
 
+/// The grader names `deploy check` printed, in order, read off its report lines
+/// (`✅ name: detail`, `❌ name (host): detail`, `⚠️  name: detail`).
+///
+/// Scope suffixes are stripped, so this returns the STABLE identifiers — which is
+/// exactly the set `autumn doctor` must mirror (issue #1621, plan §5.5).
+fn preflight_grader_names(output: &str) -> Vec<String> {
+    output
+        .lines()
+        .filter_map(|line| {
+            let rest = line
+                .strip_prefix("\u{2705} ")
+                .or_else(|| line.strip_prefix("\u{274C} "))
+                .or_else(|| line.strip_prefix("\u{26A0}\u{FE0F}  "))?;
+            let name = rest.split(':').next()?.trim();
+            // Drop the ` (host)` scope suffix a fleet row carries.
+            let name = name.split(" (").next()?.trim();
+            (!name.is_empty() && name.chars().all(|c| c.is_ascii_lowercase() || c == '_'))
+                .then(|| name.to_owned())
+        })
+        .collect()
+}
+
+#[test]
+fn deploy_check_reports_ssh_reachability_per_fleet_host() {
+    // #1621 (T2.3, AC-7): every host is graded BEFORE anything is touched, and each
+    // per-host row names its host — otherwise "cannot reach the server" in a
+    // three-host fleet does not say which server. The three project-wide graders
+    // (signing secret, database URL, migrate check) grade the PROJECT, so they run
+    // once and stay unscoped.
+    //
+    // `.test` addresses never resolve (RFC 2606), so the ssh grader fails fast per
+    // host with no network dependence.
+    let dir = project(
+        "hosts = [\"web-1.example.test\", \"web-2.example.test\", \"web-3.example.test\"]\n",
+    );
+    let (stdout, stderr) = run_autumn_fail(dir.path(), &["deploy", "check"], &[]);
+    let combined = format!("{stdout}{stderr}");
+
+    for host in [
+        "web-1.example.test",
+        "web-2.example.test",
+        "web-3.example.test",
+    ] {
+        assert!(
+            combined.contains(&format!("ssh_reachability ({host})")),
+            "every fleet host needs its own scoped ssh_reachability row; missing \
+             {host}\nstdout:\n{stdout}\nstderr:\n{stderr}"
+        );
+    }
+
+    let names = preflight_grader_names(&combined);
+    assert_eq!(
+        names
+            .iter()
+            .filter(|name| *name == "ssh_reachability")
+            .count(),
+        3,
+        "one ssh_reachability row per host\nnames: {names:?}\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    for project_grader in ["signing_secret", "database_url", "migrate_check"] {
+        assert_eq!(
+            names.iter().filter(|name| *name == project_grader).count(),
+            1,
+            "the project-wide grader `{project_grader}` runs ONCE for the whole \
+             fleet\nnames: {names:?}\nstdout:\n{stdout}\nstderr:\n{stderr}"
+        );
+        assert!(
+            !combined.contains(&format!("{project_grader} (")),
+            "`{project_grader}` grades the project, not a host, so it must not be \
+             scoped\nstdout:\n{stdout}\nstderr:\n{stderr}"
+        );
+    }
+    // Six checks in total (three hosts + three project graders) and the count
+    // includes every failing host, so the operator learns about host 3 before host 1
+    // is touched.
+    assert!(
+        combined.contains("of 6 preflight check(s) failed"),
+        "the report must count every host's grader\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    assert_eq!(
+        combined.matches("could not resolve web-").count(),
+        3,
+        "every host must be probed, not just the first\nstderr:\n{stderr}"
+    );
+}
+
+#[test]
+fn deploy_check_and_doctor_grade_the_same_fleet_graders() {
+    // #1621 (T2.5, plan §5.5): `autumn doctor` mirroring the deploy preflight is a
+    // hard invariant that has, until now, been enforced only by comments. Both
+    // surfaces build their names from ONE ordered list
+    // (`deploy::PREFLIGHT_GRADERS` / `deploy::DOCTOR_PREFLIGHT_GRADERS`, whose
+    // `deploy_`-prefix derivation is pinned by a unit test); this asserts the two
+    // really do emit the same grader set for the SAME fleet config.
+    //
+    // Doctor emits one `deploy_ssh_reachability` for the whole fleet (its check
+    // names are `&'static str` `--json` keys and must stay unique) while
+    // `deploy check` emits one row per host — so the comparison is over the SET of
+    // stable identifiers, not the row count.
+    let dir = project("hosts = [\"web-1.example.test\", \"web-2.example.test\"]\n");
+
+    let (check_out, check_err, _) = run_autumn(dir.path(), &["deploy", "check"], &[]);
+    let mut from_check: Vec<String> = preflight_grader_names(&format!("{check_out}{check_err}"))
+        .into_iter()
+        .map(|name| format!("deploy_{name}"))
+        .collect();
+    from_check.sort_unstable();
+    from_check.dedup();
+
+    // `--online` is what enables doctor's TCP reachability probe; without it the
+    // deploy branch deliberately runs only the offline graders.
+    let (doctor_out, doctor_err, _) =
+        run_autumn(dir.path(), &["doctor", "--json", "--online"], &[]);
+    let report: serde_json::Value = serde_json::from_str(&doctor_out).unwrap_or_else(|e| {
+        panic!(
+            "doctor --json must emit valid JSON: {e}\nstdout:\n{doctor_out}\nstderr:\n{doctor_err}"
+        )
+    });
+    let mut from_doctor: Vec<String> = report["checks"]
+        .as_array()
+        .expect("doctor --json carries a checks array")
+        .iter()
+        .filter_map(|check| check["name"].as_str())
+        .filter(|name| name.starts_with("deploy_"))
+        // `deploy_host` (offline host presence) and `deploy_config` (a config-load
+        // guard) are doctor-only by design — `deploy check` folds host presence into
+        // `ssh_reachability`, which reports the identical missing-host detail.
+        .filter(|name| *name != "deploy_host" && *name != "deploy_config")
+        .map(str::to_owned)
+        .collect();
+    from_doctor.sort_unstable();
+    from_doctor.dedup();
+
+    assert_eq!(
+        from_check, from_doctor,
+        "`deploy check` and `doctor` must grade the SAME deploy graders for the same \
+         fleet config\ncheck stdout:\n{check_out}\ncheck stderr:\n{check_err}\ndoctor \
+         stdout:\n{doctor_out}"
+    );
+    assert!(
+        !from_check.is_empty(),
+        "the parity assertion must not pass vacuously\ncheck stderr:\n{check_err}"
+    );
+
+    // …and doctor really did enumerate the fleet rather than reporting "no target
+    // host configured" because the scalar `[deploy] host` is unset.
+    assert!(
+        doctor_out.contains("web-1.example.test") && doctor_out.contains("web-2.example.test"),
+        "doctor must enumerate the configured fleet hosts\nstdout:\n{doctor_out}"
+    );
+}
+
+#[test]
+fn deploy_check_output_is_identical_for_host_and_a_single_entry_hosts_list() {
+    // #1621 (AC-1, the `check` half of T2.1): the same differential proof the `plan`
+    // half makes, over the surface that grades. `deploy check` now runs the FLEET
+    // preflight, so this is what pins "a one-entry `hosts` list is byte-for-byte
+    // today's single-server deploy" against the scope field, the per-host rows and
+    // the failure counting all at once.
+    let scalar = project("host = \"deploy.example.test\"\n");
+    let list = project("hosts = [\"deploy.example.test\"]\n");
+
+    let (scalar_out, scalar_err, scalar_code) =
+        run_autumn(scalar.path(), &["deploy", "check"], &[]);
+    let (list_out, list_err, list_code) = run_autumn(list.path(), &["deploy", "check"], &[]);
+
+    assert_eq!(
+        scalar_code, list_code,
+        "exit codes must match\n`host` stderr:\n{scalar_err}\n`hosts` stderr:\n{list_err}"
+    );
+    assert_eq!(
+        scalar_out, list_out,
+        "`deploy check` stdout must be byte-identical under both spellings"
+    );
+    assert_eq!(
+        scalar_err, list_err,
+        "`deploy check` stderr must be byte-identical under both spellings"
+    );
+    // Non-vacuous: the report really was produced (not two empty strings from an
+    // early config refusal).
+    assert!(
+        scalar_err.contains("ssh_reachability"),
+        "the differential must compare a real preflight report\nstderr:\n{scalar_err}"
+    );
+    // A single-host report carries NO scope suffix — that is what "identical" means
+    // here (AC-1 artifact 4).
+    assert!(
+        !scalar_err.contains("ssh_reachability ("),
+        "a single-host preflight must not print a scope suffix\nstderr:\n{scalar_err}"
+    );
+}
+
 #[test]
 fn deploy_plan_output_is_identical_for_host_and_a_single_entry_hosts_list() {
     // #1621 (AC-1, differential half of T2.1): a one-entry `hosts` list IS today's
@@ -828,6 +1020,45 @@ fn deploy_help_lists_subcommands() {
     assert!(
         combined.contains("--no-rollback"),
         "help should document the fleet `--no-rollback` flag\n{combined}"
+    );
+    // #1621 (T2.4): the fleet status + maintenance surfaces must be discoverable
+    // from the group help, flags included.
+    assert!(
+        combined.contains("status"),
+        "help should list the status subcommand\n{combined}"
+    );
+    assert!(
+        combined.contains("maintenance"),
+        "help should list the maintenance subcommand\n{combined}"
+    );
+    assert!(
+        combined.contains("--json"),
+        "help should document status --json\n{combined}"
+    );
+    assert!(
+        combined.contains("--strict"),
+        "help should document status --strict\n{combined}"
+    );
+}
+
+#[test]
+fn maintenance_help_cross_references_the_deploy_fan_out() {
+    // #1621 (plan §3.3): the top-level `autumn maintenance` is LOCAL-only (it
+    // writes the flag in the CLI's own working directory), and the fleet fan-out
+    // lives under `autumn deploy maintenance`. The local command's help must point
+    // at the deploy one, or operators of deploy-managed hosts will run the local
+    // command and wonder why nothing happened.
+    let dir = tempfile::tempdir().expect("temp dir");
+    let (stdout, stderr, code) = run_autumn(dir.path(), &["maintenance", "--help"], &[]);
+    assert_eq!(
+        code,
+        Some(0),
+        "maintenance --help should succeed\nstderr:\n{stderr}"
+    );
+    let combined = format!("{stdout}{stderr}");
+    assert!(
+        combined.contains("deploy maintenance"),
+        "the local maintenance help must cross-reference `autumn deploy maintenance`          for deploy-managed hosts\n{combined}"
     );
 }
 

--- a/autumn-cli/tests/integration/deploy.rs
+++ b/autumn-cli/tests/integration/deploy.rs
@@ -1058,7 +1058,8 @@ fn maintenance_help_cross_references_the_deploy_fan_out() {
     let combined = format!("{stdout}{stderr}");
     assert!(
         combined.contains("deploy maintenance"),
-        "the local maintenance help must cross-reference `autumn deploy maintenance`          for deploy-managed hosts\n{combined}"
+        "the local maintenance help must cross-reference `autumn deploy maintenance` \
+         for deploy-managed hosts\n{combined}"
     );
 }
 

--- a/autumn-cli/tests/integration/deploy.rs
+++ b/autumn-cli/tests/integration/deploy.rs
@@ -72,6 +72,11 @@ fn deploy_plan_prints_unit_and_steps() {
 fn deploy_check_fails_fast_without_host() {
     // A bare [deploy] table has no host; check must fail with an actionable
     // message naming the key to set, and exit non-zero.
+    //
+    // #1621: the fleet spelling (`[deploy] hosts`) EXTENDS this message rather
+    // than replacing it — the literal `[deploy] host` substring is quoted in
+    // operator runbooks, so it must survive verbatim while the message also
+    // offers the fleet alternative.
     let dir = project("");
     let (stdout, stderr) = run_autumn_fail(dir.path(), &["deploy", "check"], &[]);
     let combined = format!("{stdout}{stderr}");
@@ -82,6 +87,65 @@ fn deploy_check_fails_fast_without_host() {
     assert!(
         combined.contains("[deploy] host"),
         "check should name the config key\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    assert!(
+        combined.contains("hosts"),
+        "check should also offer the #1621 fleet spelling\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+}
+
+#[test]
+fn deploy_check_rejects_host_and_hosts_configured_together() {
+    // #1621 (AC-1): `[deploy] host` and `[deploy] hosts` are mutually exclusive —
+    // with both set there is no unambiguous rollout order, so the CLI refuses
+    // before any remote work, naming BOTH keys so the operator knows which one to
+    // delete.
+    let dir = project("host = \"203.0.113.10\"\nhosts = [\"web-1.example.com\"]\n");
+    let (stdout, stderr) = run_autumn_fail(dir.path(), &["deploy", "check"], &[]);
+    let combined = format!("{stdout}{stderr}");
+    assert!(
+        combined.contains("[deploy] host"),
+        "the refusal must name the legacy key\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    assert!(
+        combined.contains("[deploy] hosts"),
+        "the refusal must name the fleet key\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+}
+
+#[test]
+fn deploy_check_rejects_a_blank_hosts_entry() {
+    // #1621 (AC-1): a blank fleet entry is a typo that would otherwise resolve to
+    // a hostless SSH target mid-rollout. The refusal names the 0-based index so
+    // the operator can find the offending line.
+    let dir = project("hosts = [\"web-1.example.com\", \"  \"]\n");
+    let (stdout, stderr) = run_autumn_fail(dir.path(), &["deploy", "check"], &[]);
+    let combined = format!("{stdout}{stderr}");
+    assert!(
+        combined.contains("[deploy] hosts"),
+        "the refusal must name the fleet key\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    assert!(
+        combined.contains('1'),
+        "the refusal must name the 0-based index of the blank entry\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+}
+
+#[test]
+fn deploy_check_rejects_duplicate_hosts_entries() {
+    // #1621 (AC-1/AC-3): deploying the same machine twice corrupts its blue/green
+    // previous-release chain, which a fleet rollback depends on. Duplicates are
+    // compared after trimming and the repeated value is named.
+    let dir = project("hosts = [\"web-1.example.com\", \" web-1.example.com \"]\n");
+    let (stdout, stderr) = run_autumn_fail(dir.path(), &["deploy", "check"], &[]);
+    let combined = format!("{stdout}{stderr}");
+    assert!(
+        combined.contains("web-1.example.com"),
+        "the refusal must name the repeated host\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    assert!(
+        combined.contains("[deploy] hosts"),
+        "the refusal must name the fleet key\nstdout:\n{stdout}\nstderr:\n{stderr}"
     );
 }
 

--- a/autumn-cli/tests/integration/deploy.rs
+++ b/autumn-cli/tests/integration/deploy.rs
@@ -818,4 +818,38 @@ fn deploy_help_lists_subcommands() {
         combined.contains("rollback"),
         "help should list rollback\n{combined}"
     );
+    // #1621 (T2.4): the group doc comment IS the help text (verbatim_doc_comment),
+    // so the fleet flags must be documented there or `autumn deploy --help` starts
+    // lying about what the command can do.
+    assert!(
+        combined.contains("--only"),
+        "help should document the fleet `--only` flag\n{combined}"
+    );
+    assert!(
+        combined.contains("--no-rollback"),
+        "help should document the fleet `--no-rollback` flag\n{combined}"
+    );
+}
+
+#[test]
+fn deploy_up_rejects_an_only_host_that_is_not_in_the_fleet() {
+    // #1621 (§3.2): `--only` is checked against `[deploy] hosts` before anything
+    // else happens — no preflight, no SSH, no build. A typo names itself and the
+    // configured hosts are listed, because the alternative (guessing, or silently
+    // deploying nothing) can put the wrong machine into production.
+    let dir = project("hosts = [\"web-1.example.com\", \"web-2.example.com\"]\n");
+    let (stdout, stderr) = run_autumn_fail(
+        dir.path(),
+        &["deploy", "up", "--only", "web-9.example.com"],
+        &[],
+    );
+    let combined = format!("{stdout}{stderr}");
+    assert!(
+        combined.contains("web-9.example.com"),
+        "the error must quote the unmatched host\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    assert!(
+        combined.contains("web-1.example.com") && combined.contains("web-2.example.com"),
+        "the error must list the configured hosts\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
 }

--- a/autumn/src/app.rs
+++ b/autumn/src/app.rs
@@ -3292,20 +3292,31 @@ impl AppBuilder {
         }
 
         // Instantiate MaintenanceState, load flag synchronously at startup, insert as extension, and start background poller task
+        //
+        // #1621: the flag path comes from `maintenance::resolve_flag_file_path()`,
+        // NOT the bare cwd-relative const. A deploy-managed slot unit runs with
+        // `WorkingDirectory={release_dir}` — a fresh dir every release — so the
+        // legacy path made a cutover ORPHAN the flag and silently un-maintain the
+        // host. The resolver honours `AUTUMN_MAINTENANCE_FLAG_FILE` (stamped by
+        // `autumn deploy` at the per-app `shared/` dir, which survives cutovers) and
+        // falls back to the legacy path when unset, so a non-deploy-managed app is
+        // unaffected. Both read sites — this boot load and the 500 ms poller below —
+        // go through the SAME resolver so they can never disagree.
         let maintenance_state = crate::maintenance::MaintenanceState::new();
-        let flag_path = std::path::Path::new(crate::maintenance::MAINTENANCE_FLAG_FILE);
-        if let Ok(Some(cfg)) = crate::maintenance::MaintenanceState::load_from_file(flag_path) {
+        let flag_path = crate::maintenance::resolve_flag_file_path();
+        if let Ok(Some(cfg)) = crate::maintenance::MaintenanceState::load_from_file(&flag_path) {
             maintenance_state.enable(cfg);
         }
         state.insert_extension(maintenance_state.clone());
 
         let poller_state = maintenance_state.clone();
         tokio::spawn(async move {
-            let path = std::path::Path::new(crate::maintenance::MAINTENANCE_FLAG_FILE);
+            let path = crate::maintenance::resolve_flag_file_path();
             let interval = std::time::Duration::from_millis(500);
             loop {
+                let poll_path = path.clone();
                 let load_res = tokio::task::spawn_blocking(move || {
-                    crate::maintenance::MaintenanceState::load_from_file(path)
+                    crate::maintenance::MaintenanceState::load_from_file(&poll_path)
                 })
                 .await;
 

--- a/autumn/src/config.rs
+++ b/autumn/src/config.rs
@@ -1346,6 +1346,9 @@ pub struct DeployTlsConfig {
 /// ```toml
 /// [deploy]
 /// host = "203.0.113.10"      # required at deploy time; SSH-reachable address
+/// # hosts = ["10.0.0.1", "10.0.0.2"]  # fleet alternative to `host` (#1621);
+/// #                                   # mutually exclusive with it, and the
+/// #                                   # order is the rollout order
 /// user = "deploy"            # SSH user (default: "root")
 /// ssh_port = 22              # SSH port (default: 22)
 /// app_name = "myapp"         # default: the crate's package name
@@ -1364,6 +1367,25 @@ pub struct DeployConfig {
     /// [`validate`](Self::validate).
     #[serde(default)]
     pub host: Option<String>,
+
+    /// SSH-reachable addresses of the target fleet, in rollout order (#1621).
+    ///
+    /// Mutually exclusive with [`host`](Self::host): a single-entry `hosts` list
+    /// is byte-for-byte the historical single-server deploy, and the order of the
+    /// list **is** the rollout order (a documented operator contract, not an
+    /// implementation detail — the fleet driver never sorts or regroups it).
+    /// Empty by default, so every pre-#1621 `[deploy]` table is unchanged.
+    ///
+    /// `[deploy.tls] host` stays fleet-singular: it is the PUBLIC DNS name the
+    /// certificate is issued for, semantically distinct from these SSH targets.
+    ///
+    /// Blank entries and duplicates (compared after trimming) are rejected, as is
+    /// setting this alongside `host`. The enforcing seam is the CLI's
+    /// `ResolvedFleet::resolve` — the only validation a deploy actually calls;
+    /// [`validate`](Self::validate) mirrors the same rules so the two never
+    /// disagree about what a valid `[deploy]` table looks like.
+    #[serde(default)]
+    pub hosts: Vec<String>,
 
     /// SSH user to connect as. Default: `"root"`.
     #[serde(default = "default_deploy_user")]
@@ -1415,6 +1437,9 @@ impl Default for DeployConfig {
     fn default() -> Self {
         Self {
             host: None,
+            // #1621: empty, so an existing single-host `[deploy]` table (and the
+            // type default) is byte-for-byte unchanged.
+            hosts: Vec::new(),
             user: default_deploy_user(),
             ssh_port: default_deploy_ssh_port(),
             app_name: None,
@@ -1435,18 +1460,75 @@ impl DeployConfig {
     /// this rejects a missing or blank `host` with an actionable message so the
     /// operator knows exactly which key to set.
     ///
+    /// Since #1621 it also mirrors the fleet rules the CLI's
+    /// `ResolvedFleet::resolve` enforces — `host`/`hosts` mutual exclusion, no
+    /// blank entry, no duplicate entry — in the same order, so the two surfaces
+    /// never disagree about what a valid `[deploy]` table looks like.
+    ///
+    /// **This method has no production call site** (it is not reached from
+    /// [`AutumnConfig::validate`]); the CLI's resolve step is the enforcing seam.
+    /// Keep the rules here in sync anyway: a future wiring must not change
+    /// behavior.
+    ///
     /// # Errors
     ///
-    /// Returns a message when `host` is unset or empty.
+    /// Returns a message when `host` and `hosts` are both set, when a `hosts`
+    /// entry is blank or duplicated, or when neither key provides a target.
     pub fn validate(&self) -> Result<(), String> {
-        match self.host.as_deref() {
-            Some(host) if !host.trim().is_empty() => Ok(()),
-            _ => Err(
-                "[deploy] requires a target host: set `[deploy] host = \"<address>\"` in \
-                      autumn.toml to the SSH-reachable hostname or IP of your server"
+        let host = self
+            .host
+            .as_deref()
+            .map(str::trim)
+            .filter(|host| !host.is_empty());
+
+        // 1. Mutual exclusion: with both spellings set the rollout order is
+        //    ambiguous, so name BOTH keys and let the operator pick one.
+        if host.is_some() && !self.hosts.is_empty() {
+            return Err(
+                "[deploy] host and [deploy] hosts are mutually exclusive: keep the \
+                 single-server `[deploy] host = \"<address>\"` or the fleet list \
+                 `[deploy] hosts = [\"<address>\", …]` in autumn.toml, not both (#1621)"
                     .to_owned(),
-            ),
+            );
         }
+
+        // 2. A blank entry would resolve to a hostless SSH target mid-rollout.
+        for (index, entry) in self.hosts.iter().enumerate() {
+            if entry.trim().is_empty() {
+                return Err(format!(
+                    "[deploy] hosts entry {index} is blank: every fleet entry must be an \
+                     SSH-reachable hostname or IP (#1621)"
+                ));
+            }
+        }
+
+        // 3. A duplicate would deploy the same server twice — the second pass sees
+        //    its own new release as live and corrupts the previous-release chain a
+        //    rollback depends on. Compared after trimming; DNS aliases are a
+        //    documented limitation.
+        let mut seen: Vec<&str> = Vec::with_capacity(self.hosts.len());
+        for entry in &self.hosts {
+            let trimmed = entry.trim();
+            if seen.contains(&trimmed) {
+                return Err(format!(
+                    "[deploy] hosts lists `{trimmed}` more than once: each fleet host must \
+                     appear exactly once (#1621)"
+                ));
+            }
+            seen.push(trimmed);
+        }
+
+        // 4. Neither spelling provides a target.
+        if host.is_none() && self.hosts.is_empty() {
+            return Err(
+                "[deploy] requires a target host: set `[deploy] host = \"<address>\"` in \
+                      autumn.toml to the SSH-reachable hostname or IP of your server, or \
+                      `[deploy] hosts = [\"<address>\", …]` for a fleet (#1621)"
+                    .to_owned(),
+            );
+        }
+
+        Ok(())
     }
 }
 
@@ -7509,8 +7591,14 @@ pub struct CompressionConfig {
 // Exposed for autumn-cli's `autumn deploy` preflight (doctor) to reuse the deploy env-override logic; not yet a stable public API.
 #[doc(hidden)]
 pub fn apply_deploy_env_overrides(deploy: &mut Option<DeployConfig>, env: &dyn Env) {
-    const KEYS: [&str; 11] = [
+    // This array is a PRESENCE PROBE gating materialization of the ENTIRE
+    // `[deploy]` table: a key missing from it means an env-only config that sets
+    // only that key produces no deploy section at all — a silent skip, not an
+    // error, in both `AutumnConfig::load` and `autumn doctor`. Every key parsed
+    // below MUST appear here.
+    const KEYS: [&str; 12] = [
         "AUTUMN_DEPLOY__HOST",
+        "AUTUMN_DEPLOY__HOSTS",
         "AUTUMN_DEPLOY__USER",
         "AUTUMN_DEPLOY__SSH_PORT",
         "AUTUMN_DEPLOY__APP_NAME",
@@ -7527,6 +7615,11 @@ pub fn apply_deploy_env_overrides(deploy: &mut Option<DeployConfig>, env: &dyn E
     }
     let deploy = deploy.get_or_insert_with(DeployConfig::default);
     parse_env_option_string(env, "AUTUMN_DEPLOY__HOST", &mut deploy.host);
+    // #1621: the fleet host list, as CSV. It REPLACES the whole TOML list (a
+    // fleet-level retarget), matching every other `AUTUMN_DEPLOY__*` override.
+    // Entries are trimmed by `parse_env_csv`; blank/duplicate entries are
+    // rejected downstream by the CLI's `ResolvedFleet::resolve`.
+    parse_env_csv(env, "AUTUMN_DEPLOY__HOSTS", &mut deploy.hosts);
     parse_env_string(env, "AUTUMN_DEPLOY__USER", &mut deploy.user);
     parse_env(env, "AUTUMN_DEPLOY__SSH_PORT", &mut deploy.ssh_port);
     parse_env_option_string(env, "AUTUMN_DEPLOY__APP_NAME", &mut deploy.app_name);
@@ -12764,6 +12857,177 @@ path = "/healthz"
         let mut config = AutumnConfig::default();
         config.apply_env_overrides_with_env(&env);
         assert!(config.deploy.is_none());
+    }
+
+    // ── deploy fleet hosts (#1621) ────────────────────────────────
+
+    #[test]
+    fn deploy_hosts_list_parses_in_declaration_order_and_defaults_to_empty() {
+        // #1621 (AC-1): `[deploy] hosts` is the fleet spelling of the target
+        // list. Declaration order IS the rollout order, so parsing must preserve
+        // it verbatim, and a `[deploy]` table without the key stays empty so
+        // every pre-#1621 config is unchanged.
+        let config: AutumnConfig = toml::from_str(
+            r#"
+            [deploy]
+            hosts = ["web-1.example.com", "web-2.example.com", "web-3.example.com"]
+            "#,
+        )
+        .expect("[deploy] hosts list should parse");
+        let deploy = config.deploy.expect("deploy configured");
+        assert_eq!(
+            deploy.hosts,
+            vec![
+                "web-1.example.com".to_owned(),
+                "web-2.example.com".to_owned(),
+                "web-3.example.com".to_owned(),
+            ],
+            "hosts must parse in declaration order (the documented rollout order), got: {:?}",
+            deploy.hosts
+        );
+        assert_eq!(
+            deploy.host, None,
+            "the fleet spelling must not populate the legacy scalar, got: {:?}",
+            deploy.host
+        );
+
+        let bare: AutumnConfig =
+            toml::from_str("[deploy]\nhost = \"203.0.113.10\"\n").expect("legacy table parses");
+        let bare_deploy = bare.deploy.expect("deploy configured");
+        assert!(
+            bare_deploy.hosts.is_empty(),
+            "a pre-#1621 [deploy] table must resolve to an empty hosts list, got: {:?}",
+            bare_deploy.hosts
+        );
+        assert!(
+            DeployConfig::default().hosts.is_empty(),
+            "the hand-written Default impl must seed an empty hosts list, got: {:?}",
+            DeployConfig::default().hosts
+        );
+    }
+
+    #[test]
+    fn deploy_validate_rejects_host_and_hosts_set_together() {
+        // #1621 (AC-1): `host` and `hosts` are mutually exclusive — with both set
+        // there is no unambiguous rollout order. `DeployConfig::validate` is not
+        // wired into `AutumnConfig::validate` (the CLI's `ResolvedFleet::resolve`
+        // is the enforcing seam), but it must MIRROR the same rules so the two
+        // never disagree about what a valid `[deploy]` table looks like.
+        let cfg = DeployConfig {
+            host: Some("203.0.113.10".to_owned()),
+            hosts: vec!["web-1.example.com".to_owned()],
+            ..DeployConfig::default()
+        };
+        let err = cfg
+            .validate()
+            .expect_err("host + hosts together must be rejected");
+        assert!(
+            err.contains("[deploy] host") && err.contains("[deploy] hosts"),
+            "the mutual-exclusion error must name BOTH keys so the operator knows \
+             which one to delete, got: {err}"
+        );
+    }
+
+    #[test]
+    fn deploy_validate_rejects_blank_and_duplicate_hosts_entries() {
+        // #1621 (AC-1): a blank entry is a typo that would otherwise resolve to a
+        // hostless SSH target mid-rollout, and a duplicate entry would deploy the
+        // same machine twice (the second pass sees its own new release as live and
+        // corrupts the blue/green previous-release chain).
+        let blank = DeployConfig {
+            hosts: vec!["web-1.example.com".to_owned(), "   ".to_owned()],
+            ..DeployConfig::default()
+        };
+        let blank_err = blank
+            .validate()
+            .expect_err("a blank hosts entry must be rejected");
+        assert!(
+            blank_err.contains("hosts") && blank_err.contains('1'),
+            "the blank-entry error must name `hosts` and the 0-based index, got: {blank_err}"
+        );
+
+        let duplicate = DeployConfig {
+            hosts: vec![
+                "web-1.example.com".to_owned(),
+                " web-1.example.com ".to_owned(),
+            ],
+            ..DeployConfig::default()
+        };
+        let duplicate_err = duplicate
+            .validate()
+            .expect_err("a duplicate hosts entry must be rejected");
+        assert!(
+            duplicate_err.contains("web-1.example.com"),
+            "the duplicate error must name the repeated value, got: {duplicate_err}"
+        );
+
+        let ok = DeployConfig {
+            hosts: vec![
+                "web-1.example.com".to_owned(),
+                "web-2.example.com".to_owned(),
+            ],
+            ..DeployConfig::default()
+        };
+        assert!(
+            ok.validate().is_ok(),
+            "a well-formed fleet list must validate, got: {:?}",
+            ok.validate()
+        );
+    }
+
+    #[test]
+    fn env_override_materializes_deploy_from_hosts_only() {
+        // #1621: `KEYS` in `apply_deploy_env_overrides` is a PRESENCE PROBE that
+        // gates materialisation of the ENTIRE `[deploy]` table. If
+        // `AUTUMN_DEPLOY__HOSTS` is missing from that array, an env-only fleet
+        // config produces no deploy section at all — a silent skip, not an error,
+        // in both `AutumnConfig::load` and `autumn doctor`. This is the trap test.
+        let env = MockEnv::new().with(
+            "AUTUMN_DEPLOY__HOSTS",
+            "web-1.example.com,web-2.example.com",
+        );
+        let mut config = AutumnConfig::default();
+        assert!(config.deploy.is_none());
+        config.apply_env_overrides_with_env(&env);
+        let deploy = config
+            .deploy
+            .expect("AUTUMN_DEPLOY__HOSTS alone must materialize the [deploy] table");
+        assert_eq!(
+            deploy.hosts,
+            vec![
+                "web-1.example.com".to_owned(),
+                "web-2.example.com".to_owned(),
+            ],
+            "the CSV env value must parse into the ordered fleet list, got: {:?}",
+            deploy.hosts
+        );
+        // Every other key falls back to its documented default.
+        assert_eq!(deploy.host, None, "got: {:?}", deploy.host);
+        assert_eq!(deploy.user, "root");
+        assert_eq!(deploy.ssh_port, 22);
+    }
+
+    #[test]
+    fn env_override_hosts_replaces_the_whole_toml_list() {
+        // #1621: `AUTUMN_DEPLOY__HOSTS` is a fleet-level RETARGET — it replaces
+        // the TOML list wholesale rather than appending, matching every other
+        // `AUTUMN_DEPLOY__*` override (env wins).
+        let mut config: AutumnConfig = toml::from_str(
+            r#"
+            [deploy]
+            hosts = ["toml-1", "toml-2", "toml-3"]
+            "#,
+        )
+        .expect("[deploy] hosts list should parse");
+        let env = MockEnv::new().with("AUTUMN_DEPLOY__HOSTS", "env-1, env-2");
+        config.apply_env_overrides_with_env(&env);
+        let deploy = config.deploy.expect("deploy configured");
+        assert_eq!(
+            deploy.hosts,
+            vec!["env-1".to_owned(), "env-2".to_owned()],
+            "env must REPLACE the TOML fleet list (and trim each entry), got: {:?}",
+            deploy.hosts
+        );
     }
 
     // ── server.tls.acme (#1608) ───────────────────────────────────

--- a/autumn/src/config.rs
+++ b/autumn/src/config.rs
@@ -7614,6 +7614,28 @@ pub fn apply_deploy_env_overrides(deploy: &mut Option<DeployConfig>, env: &dyn E
         return;
     }
     let deploy = deploy.get_or_insert_with(DeployConfig::default);
+    // #1621 review round 1: `host` and `hosts` are MUTUALLY EXCLUSIVE downstream,
+    // so applying one spelling from the environment on top of the OTHER spelling in
+    // TOML produced a config that refuses every `autumn deploy` subcommand — even
+    // though `AUTUMN_DEPLOY__*` is documented to WIN over TOML. Whether each
+    // spelling was set NON-EMPTY in the environment is therefore captured BEFORE
+    // either is applied, so a non-empty env value can clear the TOML alternate
+    // below.
+    //
+    // "Non-empty" is judged conservatively — a value that is blank AFTER TRIMMING
+    // never clears the other spelling — so the established empty-means-unset
+    // semantics survive: `AUTUMN_DEPLOY__HOST=` / ` ` and `AUTUMN_DEPLOY__HOSTS=` /
+    // `,` / ` , ` are the shape a CI or compose template emits for an unfilled
+    // slot. They say NOTHING about the other spelling. (`parse_env_option_string`
+    // below still applies its own, unchanged, `is_empty()` rule to `host` itself;
+    // trimming here only makes the CLEARING decision stricter, so a whitespace-only
+    // value can never silently drop a configured fleet list.)
+    let env_set_host = env
+        .var("AUTUMN_DEPLOY__HOST")
+        .is_ok_and(|value| !value.trim().is_empty());
+    let env_set_hosts = env
+        .var("AUTUMN_DEPLOY__HOSTS")
+        .is_ok_and(|value| value.split(',').any(|entry| !entry.trim().is_empty()));
     parse_env_option_string(env, "AUTUMN_DEPLOY__HOST", &mut deploy.host);
     // #1621: the fleet host list, as CSV. It REPLACES the whole TOML list (a
     // fleet-level retarget), matching every other `AUTUMN_DEPLOY__*` override.
@@ -7623,6 +7645,20 @@ pub fn apply_deploy_env_overrides(deploy: &mut Option<DeployConfig>, env: &dyn E
     // CLI as a blank fleet entry that refuses every deploy subcommand. Duplicate
     // entries are still rejected downstream by the CLI's `ResolvedFleet::resolve`.
     parse_env_csv_non_empty(env, "AUTUMN_DEPLOY__HOSTS", &mut deploy.hosts);
+    // Env-over-TOML precedence, applied to the spelling the operator did NOT set:
+    // retargeting a `[deploy] host` project as a fleet (or a `[deploy] hosts`
+    // project at a single server) is a legitimate env override, not a conflict.
+    //
+    // It is deliberately NOT a tie-break: when BOTH env spellings are set
+    // non-empty the rollout order is genuinely ambiguous — an operator error, not a
+    // precedence question — so both survive and the existing mutual-exclusion
+    // refusal (`DeployConfig::validate` / the CLI's `deploy_host_list`) still fires
+    // naming both keys.
+    if env_set_hosts && !env_set_host {
+        deploy.host = None;
+    } else if env_set_host && !env_set_hosts {
+        deploy.hosts.clear();
+    }
     parse_env_string(env, "AUTUMN_DEPLOY__USER", &mut deploy.user);
     parse_env(env, "AUTUMN_DEPLOY__SSH_PORT", &mut deploy.ssh_port);
     parse_env_option_string(env, "AUTUMN_DEPLOY__APP_NAME", &mut deploy.app_name);
@@ -13125,6 +13161,157 @@ path = "/healthz"
                 deploy.validate()
             );
         }
+    }
+
+    #[test]
+    fn a_non_empty_deploy_host_env_override_clears_the_toml_alternate_spelling() {
+        // #1621 review round 1 (Codex 1). `host` and `hosts` are MUTUALLY
+        // EXCLUSIVE downstream, so an env override that sets one spelling while the
+        // TOML still holds the other produced a config that refuses every `autumn
+        // deploy` subcommand — even though `AUTUMN_DEPLOY__*` is documented to WIN
+        // over TOML. Retargeting a `[deploy] host` project as a fleet with
+        // `AUTUMN_DEPLOY__HOSTS=a,b` (and the reverse) must simply work.
+        let mut fleet_over_scalar: AutumnConfig = toml::from_str(
+            r#"
+            [deploy]
+            host = "203.0.113.10"
+            "#,
+        )
+        .expect("[deploy] host should parse");
+        fleet_over_scalar.apply_env_overrides_with_env(
+            &MockEnv::new().with("AUTUMN_DEPLOY__HOSTS", "web-1,web-2"),
+        );
+        let deploy = fleet_over_scalar.deploy.expect("deploy configured");
+        assert_eq!(
+            deploy.hosts,
+            vec!["web-1".to_owned(), "web-2".to_owned()],
+            "the env fleet list must win, got: {:?}",
+            deploy.hosts
+        );
+        assert_eq!(
+            deploy.host, None,
+            "a non-empty AUTUMN_DEPLOY__HOSTS must CLEAR the TOML `host`, got: {:?}",
+            deploy.host
+        );
+        assert!(
+            deploy.validate().is_ok(),
+            "env-over-TOML retarget must not trip mutual exclusion, got: {:?}",
+            deploy.validate()
+        );
+
+        let mut scalar_over_fleet: AutumnConfig = toml::from_str(
+            r#"
+            [deploy]
+            hosts = ["toml-1", "toml-2"]
+            "#,
+        )
+        .expect("[deploy] hosts should parse");
+        scalar_over_fleet
+            .apply_env_overrides_with_env(&MockEnv::new().with("AUTUMN_DEPLOY__HOST", "single-1"));
+        let deploy = scalar_over_fleet.deploy.expect("deploy configured");
+        assert_eq!(deploy.host.as_deref(), Some("single-1"));
+        assert!(
+            deploy.hosts.is_empty(),
+            "a non-empty AUTUMN_DEPLOY__HOST must CLEAR the TOML `hosts`, got: {:?}",
+            deploy.hosts
+        );
+        assert!(
+            deploy.validate().is_ok(),
+            "env-over-TOML narrowing must not trip mutual exclusion, got: {:?}",
+            deploy.validate()
+        );
+    }
+
+    #[test]
+    fn two_conflicting_non_empty_deploy_host_env_overrides_are_still_refused() {
+        // #1621 review round 1 (Codex 1), the other half: env-over-TOML precedence
+        // is NOT a licence to pick a winner between two conflicting env vars. Both
+        // spellings set NON-EMPTY in the environment is a genuine operator error —
+        // the rollout order is ambiguous — so both survive and the downstream
+        // mutual-exclusion refusal still fires.
+        for toml_src in [
+            "[deploy]\n",
+            "[deploy]\nhost = \"toml-host\"\n",
+            "[deploy]\nhosts = [\"toml-1\"]\n",
+        ] {
+            let mut config: AutumnConfig =
+                toml::from_str(toml_src).expect("[deploy] table should parse");
+            config.apply_env_overrides_with_env(
+                &MockEnv::new()
+                    .with("AUTUMN_DEPLOY__HOST", "env-single")
+                    .with("AUTUMN_DEPLOY__HOSTS", "env-1,env-2"),
+            );
+            let deploy = config.deploy.expect("deploy configured");
+            assert_eq!(
+                deploy.host.as_deref(),
+                Some("env-single"),
+                "both env spellings must survive so the conflict is visible ({toml_src:?})"
+            );
+            assert_eq!(
+                deploy.hosts,
+                vec!["env-1".to_owned(), "env-2".to_owned()],
+                "both env spellings must survive so the conflict is visible ({toml_src:?})"
+            );
+            assert!(
+                deploy.validate().is_err(),
+                "two conflicting NON-EMPTY env spellings must still be refused ({toml_src:?})",
+            );
+        }
+    }
+
+    #[test]
+    fn an_empty_deploy_host_env_override_never_clears_the_toml_alternate_spelling() {
+        // #1621 review round 1 (Codex 1). The established empty-means-unset
+        // semantics must survive the clearing rule above: `AUTUMN_DEPLOY__HOST=`
+        // and `AUTUMN_DEPLOY__HOSTS=` (the shape a CI/compose template emits for an
+        // unfilled slot) say NOTHING about the alternate spelling, so the TOML value
+        // stands.
+        for blank in ["", "   ", ",", " , "] {
+            let mut config: AutumnConfig = toml::from_str(
+                r#"
+                [deploy]
+                host = "203.0.113.10"
+                "#,
+            )
+            .expect("[deploy] host should parse");
+            config
+                .apply_env_overrides_with_env(&MockEnv::new().with("AUTUMN_DEPLOY__HOSTS", blank));
+            let deploy = config.deploy.expect("deploy configured");
+            assert_eq!(
+                deploy.host.as_deref(),
+                Some("203.0.113.10"),
+                "AUTUMN_DEPLOY__HOSTS={blank:?} must not clear the TOML `host`"
+            );
+            assert!(deploy.hosts.is_empty());
+        }
+
+        for blank in ["", "   "] {
+            let mut config: AutumnConfig = toml::from_str(
+                r#"
+                [deploy]
+                hosts = ["toml-1", "toml-2"]
+                "#,
+            )
+            .expect("[deploy] hosts should parse");
+            config.apply_env_overrides_with_env(&MockEnv::new().with("AUTUMN_DEPLOY__HOST", blank));
+            let deploy = config.deploy.expect("deploy configured");
+            assert_eq!(
+                deploy.hosts,
+                vec!["toml-1".to_owned(), "toml-2".to_owned()],
+                "AUTUMN_DEPLOY__HOST={blank:?} must not clear the TOML `hosts`"
+            );
+        }
+        // `AUTUMN_DEPLOY__HOST=` (truly empty) keeps its own documented
+        // clears-the-scalar meaning — the clearing rule above changes nothing here.
+        let mut config = AutumnConfig {
+            deploy: Some(DeployConfig {
+                host: Some("toml-host".to_owned()),
+                ..DeployConfig::default()
+            }),
+            ..AutumnConfig::default()
+        };
+        config.apply_env_overrides_with_env(&MockEnv::new().with("AUTUMN_DEPLOY__HOST", ""));
+        assert_eq!(config.deploy.expect("deploy configured").host, None);
     }
 
     // ── server.tls.acme (#1608) ───────────────────────────────────

--- a/autumn/src/config.rs
+++ b/autumn/src/config.rs
@@ -7617,9 +7617,12 @@ pub fn apply_deploy_env_overrides(deploy: &mut Option<DeployConfig>, env: &dyn E
     parse_env_option_string(env, "AUTUMN_DEPLOY__HOST", &mut deploy.host);
     // #1621: the fleet host list, as CSV. It REPLACES the whole TOML list (a
     // fleet-level retarget), matching every other `AUTUMN_DEPLOY__*` override.
-    // Entries are trimmed by `parse_env_csv`; blank/duplicate entries are
-    // rejected downstream by the CLI's `ResolvedFleet::resolve`.
-    parse_env_csv(env, "AUTUMN_DEPLOY__HOSTS", &mut deploy.hosts);
+    // Entries are trimmed by `parse_env_csv_non_empty`, which also DROPS blank
+    // segments: `AUTUMN_DEPLOY__HOSTS=` means unset (as `AUTUMN_DEPLOY__HOST=`
+    // does) and a trailing/doubled comma is tolerated, rather than reaching the
+    // CLI as a blank fleet entry that refuses every deploy subcommand. Duplicate
+    // entries are still rejected downstream by the CLI's `ResolvedFleet::resolve`.
+    parse_env_csv_non_empty(env, "AUTUMN_DEPLOY__HOSTS", &mut deploy.hosts);
     parse_env_string(env, "AUTUMN_DEPLOY__USER", &mut deploy.user);
     parse_env(env, "AUTUMN_DEPLOY__SSH_PORT", &mut deploy.ssh_port);
     parse_env_option_string(env, "AUTUMN_DEPLOY__APP_NAME", &mut deploy.app_name);
@@ -7715,6 +7718,33 @@ fn parse_env_option_bool(env: &dyn Env, key: &str, target: &mut Option<bool>) {
 fn parse_env_csv(env: &dyn Env, key: &str, target: &mut Vec<String>) {
     if let Ok(val) = env.var(key) {
         *target = val.split(',').map(|s| s.trim().to_owned()).collect();
+    }
+}
+
+/// CSV env override that drops blank segments (issue #1621).
+///
+/// Same shape as [`parse_env_csv`], but an empty/whitespace-only segment is not a
+/// list entry. Two consequences, both deliberate:
+///
+/// * `KEY=` (or `KEY="   "`) means **unset**, i.e. the list is cleared rather than
+///   set to a one-element vector holding a blank string. That is the shape a CI or
+///   compose env template produces for a not-yet-filled-in value, and it matches
+///   [`parse_env_option_string`]'s empty-is-unset rule for the sibling scalar keys
+///   (and `crate::maintenance::flag_file_path_from`'s blank-is-unset rule).
+/// * A trailing or doubled comma — routine in generated env lists — is tolerated
+///   instead of surfacing downstream as a blank entry.
+///
+/// Used only for `AUTUMN_DEPLOY__HOSTS`, whose downstream consumer turns a blank
+/// entry into a hard refusal of every `autumn deploy` subcommand; the other CSV
+/// overrides keep [`parse_env_csv`]'s long-standing behaviour.
+fn parse_env_csv_non_empty(env: &dyn Env, key: &str, target: &mut Vec<String>) {
+    if let Ok(val) = env.var(key) {
+        *target = val
+            .split(',')
+            .map(str::trim)
+            .filter(|entry| !entry.is_empty())
+            .map(ToOwned::to_owned)
+            .collect();
     }
 }
 
@@ -13028,6 +13058,73 @@ path = "/healthz"
             "env must REPLACE the TOML fleet list (and trim each entry), got: {:?}",
             deploy.hosts
         );
+    }
+
+    #[test]
+    fn an_empty_deploy_hosts_env_override_behaves_as_unset() {
+        // #1621 review finding 13. `AUTUMN_DEPLOY__HOSTS=` is the shape a CI or
+        // compose env template produces for "fill in for a fleet" — exactly what
+        // the sibling `AUTUMN_DEPLOY__HOST=` harmlessly takes. Splitting it
+        // unconditionally yielded `[""]`, a NON-empty fleet list holding a blank
+        // string, so a project keeping `[deploy] host` in autumn.toml hard-failed
+        // every `autumn deploy` subcommand (and `autumn doctor`) with "`[deploy]
+        // host` and `[deploy] hosts` are mutually exclusive" — naming a key the
+        // operator never set.
+        for blank in ["", "   ", ",", " , "] {
+            let mut config: AutumnConfig = toml::from_str(
+                r#"
+                [deploy]
+                host = "203.0.113.10"
+                "#,
+            )
+            .expect("[deploy] host should parse");
+            let env = MockEnv::new().with("AUTUMN_DEPLOY__HOSTS", blank);
+            config.apply_env_overrides_with_env(&env);
+            let deploy = config.deploy.expect("deploy configured");
+            assert!(
+                deploy.hosts.is_empty(),
+                "AUTUMN_DEPLOY__HOSTS={blank:?} must behave as unset, got: {:?}",
+                deploy.hosts
+            );
+            assert_eq!(deploy.host.as_deref(), Some("203.0.113.10"));
+            assert!(
+                deploy.validate().is_ok(),
+                "a blank fleet override must not trip the mutual-exclusion refusal, got: {:?}",
+                deploy.validate()
+            );
+        }
+    }
+
+    #[test]
+    fn a_trailing_comma_in_the_deploy_hosts_env_override_is_tolerated() {
+        // #1621 review finding 13. Generated env lists routinely carry a trailing
+        // (or doubled) comma; the blank segment it produces used to reach the CLI
+        // as a blank fleet entry and refuse the whole command. Blank segments are
+        // dropped, so the list is exactly the addresses the operator wrote.
+        for (value, expected) in [
+            ("10.0.0.1,10.0.0.2,", vec!["10.0.0.1", "10.0.0.2"]),
+            ("10.0.0.1,,10.0.0.2", vec!["10.0.0.1", "10.0.0.2"]),
+            (" 10.0.0.1 , 10.0.0.2 , ", vec!["10.0.0.1", "10.0.0.2"]),
+        ] {
+            let mut config = AutumnConfig::default();
+            let env = MockEnv::new().with("AUTUMN_DEPLOY__HOSTS", value);
+            config.apply_env_overrides_with_env(&env);
+            let deploy = config.deploy.expect("deploy configured");
+            assert_eq!(
+                deploy.hosts,
+                expected
+                    .iter()
+                    .map(|h| (*h).to_owned())
+                    .collect::<Vec<String>>(),
+                "AUTUMN_DEPLOY__HOSTS={value:?} must drop blank segments, got: {:?}",
+                deploy.hosts
+            );
+            assert!(
+                deploy.validate().is_ok(),
+                "a tolerated trailing comma must not refuse the fleet, got: {:?}",
+                deploy.validate()
+            );
+        }
     }
 
     // ── server.tls.acme (#1608) ───────────────────────────────────

--- a/autumn/src/maintenance.rs
+++ b/autumn/src/maintenance.rs
@@ -13,13 +13,72 @@
 //!   in-memory without disk I/O.
 
 use std::net::IpAddr;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::{Arc, RwLock};
 
 use serde::{Deserialize, Serialize};
 
 /// Default path for the maintenance flag file, relative to the project root.
 pub const MAINTENANCE_FLAG_FILE: &str = "tmp/autumn-maintenance.json";
+
+/// File name of the maintenance flag, without any directory part.
+///
+/// Split out from [`MAINTENANCE_FLAG_FILE`] (whose tail it is — pinned by
+/// `maintenance_flag_basename_is_the_tail_of_the_legacy_path`) so a deploy tool
+/// can compose the flag's path under a *different* directory — the per-app
+/// `shared/` dir — without re-declaring the file name. Autumn's house rule is that
+/// anything the framework and a CLI both depend on lives here and is imported.
+pub const MAINTENANCE_FLAG_BASENAME: &str = "autumn-maintenance.json";
+
+/// Environment variable that overrides where the runtime reads the maintenance
+/// flag file (issue #1621).
+///
+/// # Why this exists
+///
+/// [`MAINTENANCE_FLAG_FILE`] is **relative to the process's working directory**,
+/// and a deploy-managed slot unit sets `WorkingDirectory={release_dir}` — a fresh
+/// directory on every release. So, before this override:
+///
+/// - a flag written into the blue slot's release dir is invisible to the green
+///   slot, and
+/// - the next cutover **orphans** the flag entirely, silently un-maintaining the
+///   host with no error and no log line.
+///
+/// A maintenance switch that lies is worse than no switch, so `autumn deploy`
+/// stamps this variable into every slot unit, pointing it at the per-app
+/// `shared/` directory that survives cutovers, rollbacks and pruning and is shared
+/// by both slots.
+///
+/// Unset (the default, and every non-deploy-managed app) → behaviour is exactly as
+/// before: the cwd-relative [`MAINTENANCE_FLAG_FILE`].
+pub const MAINTENANCE_FLAG_FILE_ENV: &str = "AUTUMN_MAINTENANCE_FLAG_FILE";
+
+/// Resolve the maintenance flag file path from an already-read override value —
+/// the pure core of [`resolve_flag_file_path`] (issue #1621).
+///
+/// A blank/whitespace-only override is treated as unset: an empty env var is the
+/// shape a half-written unit file or a `Environment=AUTUMN_MAINTENANCE_FLAG_FILE=`
+/// line produces, and resolving it to `""` would make every poll fail to find the
+/// flag with no diagnostic. Falling back to the legacy path keeps the pre-#1621
+/// behaviour in exactly the cases where the override says nothing.
+#[must_use]
+pub fn flag_file_path_from(override_value: Option<&str>) -> PathBuf {
+    override_value
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map_or_else(|| PathBuf::from(MAINTENANCE_FLAG_FILE), PathBuf::from)
+}
+
+/// The path the runtime reads (and re-polls) the maintenance flag file from.
+///
+/// Honours [`MAINTENANCE_FLAG_FILE_ENV`], defaulting to the cwd-relative
+/// [`MAINTENANCE_FLAG_FILE`] — so behaviour is unchanged when the variable is
+/// unset. Consumed at BOTH runtime read sites (the synchronous boot load and the
+/// 500 ms poller) so the two can never disagree about where the flag lives.
+#[must_use]
+pub fn resolve_flag_file_path() -> PathBuf {
+    flag_file_path_from(std::env::var(MAINTENANCE_FLAG_FILE_ENV).ok().as_deref())
+}
 
 /// Configuration for an active maintenance window.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
@@ -311,6 +370,72 @@ mod tests {
         assert!(c.allow_ips.is_empty());
         assert!(!c.readonly);
         assert!(c.bypass_header.is_none());
+    }
+
+    // ── Flag-file path resolution (issue #1621) ───────────────────────────────
+
+    #[test]
+    fn flag_file_path_honors_the_env_override() {
+        // #1621 R1: a deploy-managed slot unit stamps
+        // `Environment=AUTUMN_MAINTENANCE_FLAG_FILE={app_dir}/shared/…` so the flag
+        // lives OUTSIDE the per-release WorkingDirectory a cutover replaces. Without
+        // this the flag is orphaned on every deploy and the host silently
+        // un-maintains itself.
+        assert_eq!(
+            flag_file_path_from(Some("/srv/autumn/shop/shared/autumn-maintenance.json")),
+            PathBuf::from("/srv/autumn/shop/shared/autumn-maintenance.json"),
+        );
+    }
+
+    #[test]
+    fn flag_file_path_without_override_is_the_legacy_cwd_relative_path() {
+        // Unset → byte-for-byte pre-#1621 behaviour, so every app that does not go
+        // through `autumn deploy` is unaffected.
+        assert_eq!(
+            flag_file_path_from(None),
+            PathBuf::from(MAINTENANCE_FLAG_FILE),
+        );
+    }
+
+    #[test]
+    fn flag_file_path_treats_a_blank_override_as_unset() {
+        // An empty/whitespace value is what a half-written unit line produces;
+        // resolving it to "" would make every poll silently miss the flag.
+        assert_eq!(
+            flag_file_path_from(Some("")),
+            PathBuf::from(MAINTENANCE_FLAG_FILE),
+        );
+        assert_eq!(
+            flag_file_path_from(Some("   ")),
+            PathBuf::from(MAINTENANCE_FLAG_FILE),
+        );
+    }
+
+    #[test]
+    fn resolve_flag_file_path_reads_the_documented_env_var() {
+        // The env-reading wrapper is a one-liner over `flag_file_path_from`; pin the
+        // variable NAME (it is a deploy-unit contract) and the unset default. Guarded
+        // rather than mutating process env, which is `unsafe` in edition 2024.
+        assert_eq!(MAINTENANCE_FLAG_FILE_ENV, "AUTUMN_MAINTENANCE_FLAG_FILE");
+        if std::env::var(MAINTENANCE_FLAG_FILE_ENV).is_err() {
+            assert_eq!(
+                resolve_flag_file_path(),
+                PathBuf::from(MAINTENANCE_FLAG_FILE)
+            );
+        }
+    }
+
+    #[test]
+    fn maintenance_flag_basename_is_the_tail_of_the_legacy_path() {
+        // The deploy CLI composes `{app_dir}/shared/{BASENAME}` and
+        // `{release_dir}/{MAINTENANCE_FLAG_FILE}`; both must name the same file, or a
+        // host deployed before #1621 and one deployed after would read different
+        // files under the same command.
+        assert!(MAINTENANCE_FLAG_FILE.ends_with(MAINTENANCE_FLAG_BASENAME));
+        assert_eq!(
+            Path::new(MAINTENANCE_FLAG_FILE).file_name().unwrap(),
+            MAINTENANCE_FLAG_BASENAME,
+        );
     }
 
     // ── IP allow-list ─────────────────────────────────────────────────────────

--- a/autumn/src/router.rs
+++ b/autumn/src/router.rs
@@ -10907,6 +10907,65 @@ mod trusted_host_tests {
         );
     }
 
+    /// `/ready` must keep answering 200 while maintenance mode is ON (issue
+    /// #1621, T1.25) — this pins an EXISTING, deliberate contract that a fleet
+    /// deploy depends on, so nobody "fixes" it later.
+    ///
+    /// [`build_maintenance_layer`] wires `with_probe_paths(probe_bypass_paths(cfg))`,
+    /// which includes `health.ready_path`. The consequence operators must be told
+    /// about: **maintenance mode does not drain a host from a load balancer.** The
+    /// host stays in rotation (its `/ready` is green) and serves 503s with
+    /// `Retry-After` to real users — by design, because the alternative would make
+    /// every LB-fronted deployment eject every host the moment maintenance is
+    /// enabled. `autumn deploy status` therefore reports readiness and maintenance
+    /// as SEPARATE columns, and `autumn deploy maintenance on` says so out loud.
+    #[tokio::test]
+    async fn ready_probe_stays_green_while_maintenance_mode_is_active() {
+        let cfg = AutumnConfig::default();
+        let state = crate::state::AppState::for_test();
+        // Startup must be complete or `/ready` is 503 for an unrelated reason and
+        // the assertion below would pass vacuously.
+        state.probes().mark_startup_complete();
+        let maintenance = crate::maintenance::MaintenanceState::new();
+        maintenance.enable(crate::maintenance::MaintenanceConfig::default());
+        state.insert_extension(maintenance);
+        let router = build_router(vec![], &cfg, state);
+
+        let ready = router
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri(&cfg.health.ready_path)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            ready.status(),
+            StatusCode::OK,
+            "/ready must BYPASS maintenance mode: it is the load balancer's health \
+             signal, and gating it would eject every host from rotation the moment \
+             maintenance is enabled (#1621)"
+        );
+
+        // …while ordinary traffic IS gated, proving the layer is actually active.
+        let app_route = router
+            .oneshot(
+                Request::builder()
+                    .uri("/some-app-route")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            app_route.status(),
+            StatusCode::SERVICE_UNAVAILABLE,
+            "maintenance mode must still gate non-probe traffic"
+        );
+    }
+
     #[tokio::test]
     async fn trusted_host_release_rejects_loopback_unless_listed() {
         let mut cfg = AutumnConfig {

--- a/autumn/tests/fixtures/schema_keys.snapshot
+++ b/autumn/tests/fixtures/schema_keys.snapshot
@@ -130,6 +130,7 @@ deploy
 deploy.app_dir
 deploy.app_name
 deploy.host
+deploy.hosts
 deploy.keep_releases
 deploy.profile
 deploy.readiness_timeout_secs

--- a/autumn/tests/integration/schema_drift_guard.rs
+++ b/autumn/tests/integration/schema_drift_guard.rs
@@ -304,6 +304,10 @@ fn deploy_child_keys_are_strictly_validated() {
         "deploy.service_name",
         "deploy.readiness_timeout_secs",
         "deploy.keep_releases",
+        // #1621: the fleet host list. Without this leaf a typo like
+        // `[deploy] hots = [...]` is silently ignored and the operator deploys to
+        // nothing (or, worse, to the stale single `host`).
+        "deploy.hosts",
     ] {
         assert!(
             leaves.contains(key),
@@ -318,6 +322,23 @@ fn deploy_child_keys_are_strictly_validated() {
     assert!(
         errors.iter().any(|(path, _)| path == "deploy.app_dr"),
         "a bogus [deploy] child key must be rejected by strict validation, got: {errors:?}"
+    );
+
+    // #1621: a near-miss of the new fleet key is flagged too — adding a list-typed
+    // leaf must not open a hole in the strict walk.
+    let hosts_typo =
+        AutumnConfig::validate_toml("[deploy]\nhots = [\"web-1.example.com\"]\n", &schema);
+    assert!(
+        hosts_typo.iter().any(|(path, _)| path == "deploy.hots"),
+        "a typo of the [deploy] hosts key must be rejected by strict validation, \
+         got: {hosts_typo:?}"
+    );
+    // ...while the correctly-spelled fleet list is accepted.
+    let hosts_ok =
+        AutumnConfig::validate_toml("[deploy]\nhosts = [\"web-1.example.com\"]\n", &schema);
+    assert!(
+        hosts_ok.is_empty(),
+        "[deploy] hosts must be accepted by strict validation, got: {hosts_ok:?}"
     );
 }
 

--- a/docs/guide/deployment.md
+++ b/docs/guide/deployment.md
@@ -333,6 +333,13 @@ queue are still on the old release — your load balancer always has healthy
 upstreams. See the [fleet deploys guide](fleet-deploys.md) for the load-balancer
 contract, the shared-state prerequisites, and the scale-up walkthrough.
 
+**No host is ever drained for the rollout's sake.** The host being replaced is
+not removed from your load-balancer pool and its `/ready` never goes `503`: the
+candidate comes up on that host's idle loopback slot, is health-gated there, and
+that host's own kamal-proxy flips upstreams atomically, with the old slot drained
+and stopped only afterwards. `autumn deploy` never touches your load balancer's
+membership — draining a host for a reboot or a scale-down stays your job.
+
 The whole run mints **one release id**, so every host's `current` symlink
 resolves to the same release and drift is meaningful.
 
@@ -377,6 +384,27 @@ serving traffic
 
 That warning only appears when a writable database is configured — an app with
 no database has no schema to be behind.
+
+**Put already-deployed hosts first in the list.** Because the migration lands on
+the first host that is still on a previous release, a *first-deploy* host listed
+ahead of it cuts over with no migrate step at all — it goes live on the new
+release while the schema is still the old one, and stays that way until the
+rollout reaches the migrating host. That is the one case where "migrations run
+before the first host cutover" does not hold, and it is exactly the shape of a
+scale-up: `hosts = ["<new>", "<new>", "<existing>"]`. Order the list
+`["<existing>", "<new>", "<new>"]` instead and the migration runs first. The
+rollout will not reorder it for you — declaration order is the contract — but it
+does name the hazard and the hosts it applies to before touching anything:
+
+```
+⚠️  10.0.0.2, 10.0.0.3 go live on the new release BEFORE the migration runs
+(a first deploy never migrates) — if this release needs the new schema they will
+serve against the old one until the migrating host is reached; list an
+already-deployed host first to avoid it
+```
+
+Like the warning above, it is gated on a writable database being resolvable from
+your config. See the [fleet deploys guide](fleet-deploys.md#list-the-already-deployed-hosts-first).
 
 Once the migrating host cuts over, the rollout says so:
 
@@ -504,14 +532,26 @@ each other during the rollout and a checksum mismatch exits the process under
 `Restart=on-failure` — a crash loop mid-rollout. Turn it off for fleets and let
 the rollout's single `migrate` step own the schema.
 
-#### Two safety nets that also apply to a single host
+#### What fleet support changed for an existing single-host deploy
 
-- **A release-directory collision is refused.** The release id has one-second
-  granularity, so a fast re-run can reuse it. Re-uploading into a directory that
-  `shared/previous-release` still points at would put the *new* binary there — a
-  later rollback would roll *forward*. The deploy probes for that directory and
-  refuses before writing anything (as it does when the probe cannot prove the
-  directory is absent). Wait a second and re-run.
+`[deploy] hosts = ["x"]` behaves exactly like `[deploy] host = "x"` — one entry
+is one host, and the two spellings produce byte-identical output, uploads and
+remote commands. What that guarantee does *not* mean is that a single-host deploy
+is unchanged from the release before fleets landed. Several hardening changes
+apply to **every** deploy, one host or five. In full, so an upgrade holds no
+surprises:
+
+- **A release-directory collision is now refused, and that is a new hard
+  failure.** The release id has one-second granularity, so a fast re-run can
+  reuse it. Re-uploading into a directory that `shared/previous-release` still
+  points at would put the *new* binary there — a later rollback would roll
+  *forward*. The deploy now probes for that directory first and refuses before
+  writing anything, as it does when the probe cannot prove the directory is
+  absent. **Concretely: a second `autumn deploy up` inside the same second now
+  exits 1 with `release directory … already exists` where it previously went
+  ahead.** Wait a second and re-run, or remove the directory if you are certain
+  it is stale. The probe also costs one extra SSH round-trip per deploy, before
+  anything is mutated.
 - **SSH sessions are bounded.** Every `ssh`/`scp` invocation carries
   `ConnectTimeout=10`, `ServerAliveInterval=15` and `ServerAliveCountMax=4`
   alongside `BatchMode=yes`. The preflight is a TCP connect, which proves a host
@@ -519,7 +559,46 @@ the rollout's single `migrate` step own the schema.
   a wedged host would hang the deploy forever. For one server that is a stuck
   command someone cancels — for a fleet it would be a rollout frozen mid-flight
   with no error to compensate. Turning an infinite hang into a finite error is
-  what lets the fleet halt and roll back.
+  what lets the fleet halt and roll back. A host that accepts TCP and then wedges
+  now fails the deploy instead of hanging it.
+- **The maintenance flag file moved to `shared/`.** Every slot unit is now
+  written with
+  `Environment=AUTUMN_MAINTENANCE_FLAG_FILE={app_dir}/shared/autumn-maintenance.json`,
+  so after the next deploy the app reads the flag from the shared directory
+  instead of the release directory's `tmp/`. This fixes a real bug — a cutover
+  used to orphan an active maintenance flag — but it is a behaviour change, and
+  it means the **local** `autumn maintenance on`, run on a deploy-managed host,
+  now writes a path the app no longer reads. Use `autumn deploy maintenance`
+  there; see [Maintenance mode](maintenance-mode.md#where-the-flag-file-lives).
+- **A `shared/last-deploy` marker appears.** The ops that complete a cutover
+  (`commit-markers`, and `record-proxy-options` on a first deploy) now append an
+  advisory shell fragment recording the action that completed plus the host's UTC
+  time. It is what `deploy status` reads for its `last deploy` cell.
+  The fragment can never fail the op it rides on, and it adds one small file
+  under `shared/`; the op labels and everything else those ops do are unchanged.
+- **The `detect-current` probe reads one more thing.** Its shell gained a
+  delimited section that resolves the `current` symlink, so the deployed release
+  id comes back in the same round-trip the deploy already made. Same op, same
+  label, no extra round-trip; only the remote shell text differs.
+- **The "no host configured" hint now mentions `hosts`.** A project with neither
+  key set still fails with `no target host configured`, but the remediation hint
+  gained the fleet spelling:
+
+  ```
+  no target host configured: Set `[deploy] host` in autumn.toml to your server's
+  SSH-reachable address (or `[deploy] hosts = ["<address>", …]` to deploy a fleet)
+  ```
+
+  Stderr text only; the failure and its exit code are unchanged.
+
+One further change is invisible on a single host and listed only for
+completeness: a post-cutover failure is now wrapped in an error type that records
+which step it landed on, so the fleet driver can decide whether that host may be
+auto-rolled-back. Its `Display` delegates to the wrapped error verbatim, so the
+single-host path prints byte-for-byte what it printed before.
+
+`autumn deploy --help` was also rewritten, and `up`/`rollback` gained `--only`
+and `--no-rollback`; no existing flag changed meaning.
 
 ### Rollback
 
@@ -553,6 +632,17 @@ follow the others is mixed. The per-host table distinguishes the two cases, whic
 is what your next move turns on; retry a single host with `autumn deploy rollback
 --only <host>`, or deploy the intended release to it explicitly.
 
+> **`--only` down to one host runs the single-host rollback path.** Everything
+> above describes a rollback with more than one target. Narrow it to one and you
+> get the pre-fleet behaviour instead: no per-host outcome table — just
+> `Rolling back <host> to <release>…` and `✅ Rollback complete.`, or a plain
+> error — and no benefit from the reachability softening described below, which
+> exists so that the *rest* of a fleet can still move past a dead host. With one
+> target there is no rest: a host that does not answer stops the command non-zero
+> having changed nothing. Worth knowing before an incident, because a stranded
+> host is exactly when this command gets reached for. Follow it with
+> `autumn deploy status` for the fleet-wide picture.
+
 Like the automatic compensation, a fleet rollback **restores binaries only** — no
 migration is rolled back. Confirm the schema still fits the release now serving.
 
@@ -561,6 +651,16 @@ migration is rolled back. Confirm the schema still fits the release now serving.
 > host — `autumn deploy rollback` runs the identical local preflight graders
 > (signing secret, database URL, migrate-safety, and — for a fleet — SSH
 > reachability for every host it targets) and aborts non-zero if any fail.
+>
+> One class is deliberately downgraded, and only on a multi-host rollback: a
+> per-host `ssh_reachability` failure is reported and the rollback continues
+> without that host, which is then named as `NOT rolled back` and still makes the
+> command exit non-zero. Refusing to move the healthy majority off a bad release
+> because one host is dead would strand *more* hosts on the release you are
+> abandoning. Every other grader keeps the hard gate, and a single-host rollback
+> — including a fleet narrowed with `--only` to one host — keeps it for
+> reachability too.
+>
 > So it needs the same local inputs as a deploy — your project's `.env`/signing
 > secret and database URL, and the `migrations/` dir — available **wherever you
 > invoke it**: an emergency rollback from a bare CI checkout or a machine without

--- a/docs/guide/deployment.md
+++ b/docs/guide/deployment.md
@@ -436,6 +436,71 @@ safe. `autumn migrate check` (already part of the preflight) classifies your
 local `migrations/` by rolling-deploy risk; the
 [fleet deploys guide](fleet-deploys.md) covers the pattern in full.
 
+##### The three schema notes on the `Fleet state:` summary
+
+The same binaries-versus-schema truth is repeated once at the end of the run, on
+the `Fleet state:` table described [below](#a-failure-halts-the-rollout-and-rolls-the-fleet-back).
+The question being answered is never "did the fleet compensate" — it is **the
+schema is at the new release; where are the binaries?** So the gate is the
+migration: the summary says nothing at all unless this run actually scheduled a
+migration *and* reached the host carrying it. (A fleet where every host is a
+first deploy schedules no migration and stays silent — the prologue already told
+you to run `autumn migrate` yourself.) Beyond that gate the fleet's shape only
+picks which sentence is true:
+
+- **Some host is still forward.** At least one host is on the new release —
+  deployed, degraded, left alone because its rollback target was in doubt, or one
+  whose compensating rollback *failed*. You get:
+
+  ```
+  ⚠️  the schema has moved; from here an automatic rollback restores BINARIES
+  only — it never rolls a migration back
+  ```
+
+  Forward-looking: it describes what a rollback you run *from here* will and will
+  not undo. It is the same sentence the rollout printed mid-run, repeated because
+  the run is ending with hosts still on the new release.
+
+- **The fleet actually put hosts back.** Compensation *restored* a host to its
+  previous release or *removed* a just-completed first deploy. You get:
+
+  ```
+  ⚠️  the compensating rollback restored BINARIES only — the migration that
+  already ran was NOT rolled back; confirm the schema still fits the release now
+  serving
+  ```
+
+  Past-tense: something already moved back underneath you. A compensation that
+  only **failed** does not count here — that host is still serving the new
+  release, so it lands in the first case instead, and claiming a rollback
+  "restored binaries" would be false.
+
+  These two are independent. A halt that compensated some hosts and left others
+  forward (a `NOT rolled back automatically` row, or a compensation that failed)
+  prints **both**.
+
+- **Nothing forward, and nothing compensated.** No host is on the new release and
+  the fleet never had anything to undo — because the migrating host itself failed
+  at a step *after* `migrate` but *before* its cutover (a `readiness-gate`
+  timeout is the ordinary shape) and tore its own candidate down, leaving every
+  later host untouched. The table is then all "previous release still serving"
+  rows with the database already moved on underneath them, so the summary says so
+  explicitly:
+
+  ```
+  ⚠️  no host is serving the new release, but the migration that already ran was
+  NOT rolled back — the binaries went back and the schema did not; confirm the
+  release now serving still fits the migrated schema
+  ```
+
+  This is the case that is easiest to misread as a clean no-op. It is not one:
+  the rollout aborted, but the migration stands.
+
+The gate is deliberately conservative. The rollout cannot prove from a failing
+step label whether the one-shot `migrate` itself succeeded, so it errs toward
+"the schema moved" — one extra line of output is cheaper than an operator rolling
+binaries back believing the schema came with them.
+
 #### A failure halts the rollout and rolls the fleet back
 
 A host that fails **stops the rollout**: the hosts behind it are never touched.
@@ -467,8 +532,13 @@ host never stops the next, and every result is named.
 Two things compensation deliberately does **not** do:
 
 - **It restores binaries, never schema.** A migration that already ran stays
-  applied. The summary says so out loud; confirm the schema still fits the
-  release now serving.
+  applied. The summary says so out loud — but only when compensation actually
+  *restored* a host to its previous release or *removed* a just-completed first
+  deploy. A compensation that merely **failed** leaves that host serving the new
+  release, so the summary prints the forward-looking `the schema has moved …`
+  note for it instead. Either way, confirm the schema still fits the release now
+  serving; the three notes and when each appears are spelled out under
+  [The three schema notes on the `Fleet state:` summary](#the-three-schema-notes-on-the-fleet-state-summary).
 - **It does not touch a host whose rollback target is in doubt.** Markers left
   mid-transaction, a missing or unverifiable target release dir, or no recorded
   previous release each produce a `NOT rolled back automatically` row plus the
@@ -622,6 +692,22 @@ single-host path prints byte-for-byte what it printed before.
 
 `autumn deploy --help` was also rewritten, and `up`/`rollback` gained `--only`
 and `--no-rollback`; no existing flag changed meaning.
+
+> **Known limitation — a single-host deploy that fails after its migration ran
+> says nothing about the schema (#2276).** On one host, a failure at any point is
+> reported as the plain per-host error and the command returns right there: the
+> single-host path deliberately keeps its pre-fleet output byte-for-byte, so it
+> renders no `Fleet state:` summary and therefore none of
+> [the three schema notes](#the-three-schema-notes-on-the-fleet-state-summary).
+> If the failure landed *after* `migrate` but before the cutover — a
+> `readiness-gate` timeout is the ordinary shape — the candidate is torn down and
+> your previous release keeps serving, **against the already-migrated schema**,
+> with nothing on screen saying so. The fleet path does warn in exactly this
+> situation; the single-host path does not yet. This is tracked as
+> [#2276](https://github.com/autumn-foundation/autumn/issues/2276) and is not fixed. Until
+> it is: after any failed single-host `deploy up`, check `autumn migrate status`
+> before assuming the failure left nothing behind — and write expand/contract
+> migrations so the still-serving release fits the migrated schema either way.
 
 ### Rollback
 
@@ -1032,6 +1118,13 @@ or error messages.
   down-migration mid-flip would run exactly the SQL nothing reviews. Use
   expand/contract migrations so a rolled-back binary still fits the migrated
   schema.
+- **A failed *single-host* deploy never warns that the schema moved** (#2276).
+  A fleet ends every run with a `Fleet state:` summary that names the
+  binaries-versus-schema state; the single-host path returns the per-host error
+  directly and renders no summary, so a failure after `migrate` but before the
+  cutover leaves the previous release serving against the migrated schema with
+  nothing saying so. See
+  [What fleet support changed for an existing single-host deploy](#what-fleet-support-changed-for-an-existing-single-host-deploy).
 - **A compensated first deploy leaves its proxy route behind.** When the fleet
   removes a host's just-completed *first* deploy, that host's kamal-proxy still
   holds a route pointing at the (now stopped) slot, so its public port answers

--- a/docs/guide/deployment.md
+++ b/docs/guide/deployment.md
@@ -158,6 +158,23 @@ deploy subcommand.
 > twice would corrupt its previous-release chain). A one-entry `hosts` list is
 > byte-for-byte the historical single-server deploy.
 
+**Env wins over the file for *both* spellings.** Because the two are mutually
+exclusive, setting one spelling in the environment now **clears the other from
+`autumn.toml`**: a non-empty `AUTUMN_DEPLOY__HOSTS` retargets a `[deploy] host`
+project as a fleet, and a non-empty `AUTUMN_DEPLOY__HOST` retargets a
+`[deploy] hosts` project at a single server. Neither combination is a conflict —
+it is the documented env-over-TOML precedence applied to the spelling you did
+*not* set. Two rules bound it:
+
+- **Setting both env spellings non-empty is still refused**, naming both keys.
+  That is not a precedence question; with both set the rollout order is genuinely
+  ambiguous, so it is treated as an operator error rather than tie-broken.
+- **An empty or blank value still means *unset*** and leaves the TOML spelling
+  alone. `AUTUMN_DEPLOY__HOST=`, a whitespace-only value, `AUTUMN_DEPLOY__HOSTS=`
+  and `AUTUMN_DEPLOY__HOSTS=" , "` are the shape a CI or compose template emits
+  for an unfilled slot, so they can never silently drop a fleet list configured
+  in the file.
+
 Put these two values in a project `.env` (git-ignored — never committed). The
 deploy reads them and writes **only** them to a `0600` env file
 (`app_dir/shared/autumn.env`) **on the server**:
@@ -688,8 +705,30 @@ an unreachable host becomes a row, never an abort. It works for a single
 
 Each row carries: mode (`deployed` / `not deployed` / `unreachable` /
 `unknown`), the deployed release (read from the host's `current` symlink), the
-live slot, the `/ready` status code, the maintenance flag, the proxy's bound
+live slot, the `/ready` status code, the maintenance flag
+(`maintenance ON` / `maintenance off` / `maintenance ?`), the proxy's bound
 port, that host's last deploy result, and any per-host drift reasons.
+
+> **The maintenance cell reports the flag file that host's *running* slot unit
+> polls.** It is resolved on the host from the live slot unit's
+> `Environment=AUTUMN_MAINTENANCE_FLAG_FILE=…`, falling back to that unit's
+> `WorkingDirectory` plus the legacy relative `tmp/autumn-maintenance.json` when
+> the unit carries no override — the same rule the runtime itself applies. It is
+> deliberately *not* a fixed read of the shared path, which would report `off`
+> for a maintained host whose unit polls somewhere else, and `ON` for a host
+> still taking traffic.
+>
+> Two consequences. First, **a host deployed before this feature reports its
+> release-local flag** — its unit carries no `AUTUMN_MAINTENANCE_FLAG_FILE`, so
+> the cell tells the truth about that host while also raising the "polls a
+> release-local maintenance flag file" drift reason below; redeploy it to move
+> it onto the shared path. Second, when the live slot unit cannot be read at all
+> the cell reads `maintenance ?` rather than guessing — "we could not tell" must
+> never render as a confident `off`.
+>
+> It reports which file the running unit polls and whether that file exists. It
+> is not a guarantee about the app's in-memory state: the running process picks
+> the change up on its own 500 ms poll.
 
 > **`last deploy` is the last action that host *completed*.** It reads
 > `last deploy: deployed <UTC time>`, `last deploy: rolled back <UTC time>` or
@@ -715,16 +754,36 @@ Two kinds of drift are reported, and they are deliberately separate:
   that host fail closed or take the wrong slot. Today's reasons are: the
   `live-slot` marker disagrees with the slot kamal-proxy is actually serving (the
   next redeploy would restart the *serving* slot); the `shared/proxy-options`
-  marker is unreadable (the next deploy of that host will refuse); and the
-  installed proxy unit binds a different public port than `[server] port`
-  configures.
+  marker is unreadable (the next deploy of that host will refuse); the installed
+  proxy unit binds a different public port than `[server] port` configures; no
+  release is deployed on this host while the rest of the fleet is serving one;
+  the host has a `current` symlink but the release behind it could not be read;
+  and the two maintenance-probe reasons —
 
-> **"Release unknown" is not drift.** The only release identity a host can be
-> asked for is its `current` symlink, and that can be missing on a
-> never-deployed host, dangling mid-incident, or unreadable because the host did
-> not answer. Those hosts are *named* in the report and explicitly excluded from
-> the version-drift verdict — reporting a mixed fleet that does not exist is
-> worse than reporting nothing.
+  - `the live slot unit could not be read, so which maintenance flag file this
+    host's app polls is unknown — the maintenance column reports ? rather than
+    guessing`, and
+  - `this host's app polls a release-local maintenance flag file, not the shared
+    one (its slot unit predates AUTUMN_MAINTENANCE_FLAG_FILE) — redeploy it so
+    maintenance survives cutovers`.
+
+  The remedy for the second is exactly what it says: **redeploy that host**, so
+  its slot unit is rewritten with the shared flag path and its maintenance flag
+  survives the next cutover.
+
+> **"Release unknown" is never *version* drift — but a broken `current` symlink
+> is *state* drift.** The only release identity a host can be asked for is its
+> `current` symlink, and that can be missing on a never-deployed host, dangling
+> mid-incident, or unreadable because the host did not answer. Those hosts are
+> *named* in the report and explicitly excluded from the version-drift verdict —
+> reporting a mixed fleet that does not exist is worse than reporting nothing.
+>
+> A reachable host that *proved* it has a `current` symlink and still resolves to
+> no readable release is a different case, and it is now **state drift** that
+> `--strict` exits non-zero on (it was previously reported without counting).
+> That host claims to serve a release nobody can name, and deploying it next
+> would copy the unresolvable target into `previous-release` — making a later
+> rollback refuse. Repair it before the next deploy.
 
 `--strict` exits non-zero when **any** drift is found, so drift is alertable from
 cron. The default exits `0`: status is a report, not a judgement. `--json` emits
@@ -733,11 +792,38 @@ a stable machine-readable report on stdout — `hosts[]` (with `host`, `reachabl
 `last_deploy`, `drift[]`), plus `version_drift`, `state_drift[]`, and `drifted`
 (the `--strict` condition).
 
+`maintenance` is **three-valued**: `true` and `false` are proved states of the
+file the host's *running* slot unit polls, and `null` means the CLI could not
+prove which file that is — the same condition the table renders as
+`maintenance ?`. Both `false` and
+`null` are falsy, so an existing `maintenance == true` check is unaffected — no
+consumer that tests the field for truth starts matching more hosts.
+
 `last_deploy` is `{"result", "at"}`, or `null` when the host reports no readable
-marker. `result` is `"deployed"` or `"rolled back"`; `at` is the host's own UTC
-timestamp (`null` for a marker written before the timestamp field existed). It
-records the host's last **completed** action, so a deploy that failed before
-cutover never rewrites it, and it is reported rather than counted as drift.
+marker. `result` is `"deployed"`, `"rolled back"` or `"torn down"`; `at` is the
+host's own UTC timestamp (`null` for a marker written before the timestamp field
+existed). It records the host's last **completed** action, so a deploy that
+failed before cutover never rewrites it, and it is reported rather than counted
+as drift.
+
+> **`deploy status` still runs when the app config does not validate.** It needs
+> exactly one value from your application config — `[server] port`, the public
+> port kamal-proxy binds and every loopback slot port is derived from — so an
+> unrelated invalid `[scheduler]`, `[mail]`, `[database]` or `[security]` setting
+> used to abort the fleet's only read-only incident command before a single host
+> was probed. It no longer does. When the config fails to validate under the
+> deploy profile, `status` prints a caveat **on stderr** (in both text and
+> `--json` mode, so the `--json` shape on stdout is untouched) naming the config
+> error and the declared port it is probing against, then reports the fleet. The
+> fallback port is your own declared `[server] port` for that profile, read from
+> the same TOML + `.env.<profile>`/env layers the loader would have used, just
+> without validation (or the framework default when no layer declares one) —
+> never a guess.
+>
+> **`deploy check`, `deploy up` and `deploy rollback` still refuse**, and that
+> asymmetry is deliberate: they grade and upload runtime *values* (the signing
+> secret, the database URL), so an invalid config must stop them. `status` only
+> reads. The caveat says so too.
 
 ### Fleet maintenance
 
@@ -761,7 +847,9 @@ survives cutovers, rollbacks and pruning and is visible to *both* blue and green
 slots — because `autumn deploy` stamps `AUTUMN_MAINTENANCE_FLAG_FILE` into every
 slot unit it writes. (For a host still running a unit deployed before this
 existed, `maintenance on` also writes the old release-relative path, and the
-per-host row says when it could not.)
+per-host row says when it could not. `autumn deploy status` names those hosts as
+state drift — "polls a release-local maintenance flag file, not the shared one"
+— because their flag is orphaned by the next cutover until they are redeployed.)
 
 The fan-out is **best-effort-and-aggregate**, deliberately the opposite of the
 rollout: every host is attempted, the per-host table names what changed, and the

--- a/docs/guide/deployment.md
+++ b/docs/guide/deployment.md
@@ -576,6 +576,12 @@ surprises:
   time. It is what `deploy status` reads for its `last deploy` cell.
   The fragment can never fail the op it rides on, and it adds one small file
   under `shared/`; the op labels and everything else those ops do are unchanged.
+  The first-deploy teardown writes it too, through one extra
+  `teardown-last-deploy` op recording `torn down`, so a host whose first deploy
+  was removed again can never keep reporting a successful one. That op runs only
+  on the first-deploy failure and compensation path — a redeploy's candidate
+  teardown leaves the marker alone, because the previous release is still serving
+  and the marker still describes it.
 - **The `detect-current` probe reads one more thing.** Its shell gained a
   delimited section that resolves the `current` symlink, so the deployed release
   id comes back in the same round-trip the deploy already made. Same op, same
@@ -686,13 +692,16 @@ live slot, the `/ready` status code, the maintenance flag, the proxy's bound
 port, that host's last deploy result, and any per-host drift reasons.
 
 > **`last deploy` is the last action that host *completed*.** It reads
-> `last deploy: deployed <UTC time>` or `last deploy: rolled back <UTC time>` —
+> `last deploy: deployed <UTC time>`, `last deploy: rolled back <UTC time>` or
+> `last deploy: torn down <UTC time>` —
 > the host's own `date -u` clock, from a marker written by the ops that complete
 > a cutover. A deploy that failed *before* the cutover boundary never rewrites
 > it, so the host still shows its previous action: this is a per-host fact, not
 > a verdict on the last fleet rollout (the rollout itself exits non-zero and
 > prints its own per-host outcome table). A `rolled back` host was rolled back
-> by hand or compensated after a halted rollout. The cell reads
+> by hand or compensated after a halted rollout. A `torn down` host had its
+> first deploy removed again by a halted rollout's compensation — nothing is
+> installed on it, and the row's `not deployed` mode says so too. The cell reads
 > `last deploy: ?` when the marker is absent or unreadable — a host that has
 > never completed a cutover, or one last deployed by a CLI that predates the
 > marker — because "we could not tell" must never render as a result. It is

--- a/docs/guide/deployment.md
+++ b/docs/guide/deployment.md
@@ -146,7 +146,11 @@ Every key also has an environment override (`AUTUMN_DEPLOY__HOST`,
 `AUTUMN_DEPLOY__HOSTS`, `AUTUMN_DEPLOY__USER`, `AUTUMN_DEPLOY__SSH_PORT`, …) if
 you prefer to keep the host out of the file. `AUTUMN_DEPLOY__HOSTS` takes a
 comma-separated list (`AUTUMN_DEPLOY__HOSTS=10.0.0.1,10.0.0.2`) and **replaces**
-the whole `hosts` list from the file rather than appending to it.
+the whole `hosts` list from the file rather than appending to it. Entries are
+trimmed and blank segments are dropped, so a trailing or doubled comma is
+tolerated, and `AUTUMN_DEPLOY__HOSTS=` (empty) means *unset* — the same as
+`AUTUMN_DEPLOY__HOST=` — rather than a blank fleet entry that would refuse every
+deploy subcommand.
 
 > **`host` and `hosts` are mutually exclusive.** Setting both is refused before
 > anything runs — with both set the rollout order would be ambiguous. A blank
@@ -579,7 +583,20 @@ an unreachable host becomes a row, never an abort. It works for a single
 Each row carries: mode (`deployed` / `not deployed` / `unreachable` /
 `unknown`), the deployed release (read from the host's `current` symlink), the
 live slot, the `/ready` status code, the maintenance flag, the proxy's bound
-port, and any per-host drift reasons.
+port, that host's last deploy result, and any per-host drift reasons.
+
+> **`last deploy` is the last action that host *completed*.** It reads
+> `last deploy: deployed <UTC time>` or `last deploy: rolled back <UTC time>` —
+> the host's own `date -u` clock, from a marker written by the ops that complete
+> a cutover. A deploy that failed *before* the cutover boundary never rewrites
+> it, so the host still shows its previous action: this is a per-host fact, not
+> a verdict on the last fleet rollout (the rollout itself exits non-zero and
+> prints its own per-host outcome table). A `rolled back` host was rolled back
+> by hand or compensated after a halted rollout. The cell reads
+> `last deploy: ?` when the marker is absent or unreadable — a host that has
+> never completed a cutover, or one last deployed by a CLI that predates the
+> marker — because "we could not tell" must never render as a result. It is
+> **reported, never counted as drift**.
 
 Two kinds of drift are reported, and they are deliberately separate:
 
@@ -603,8 +620,15 @@ Two kinds of drift are reported, and they are deliberately separate:
 `--strict` exits non-zero when **any** drift is found, so drift is alertable from
 cron. The default exits `0`: status is a report, not a judgement. `--json` emits
 a stable machine-readable report on stdout — `hosts[]` (with `host`, `reachable`,
-`mode`, `release`, `live_slot`, `ready`, `maintenance`, `proxy_port`, `drift[]`),
-plus `version_drift`, `state_drift[]`, and `drifted` (the `--strict` condition).
+`mode`, `release`, `live_slot`, `ready`, `maintenance`, `proxy_port`,
+`last_deploy`, `drift[]`), plus `version_drift`, `state_drift[]`, and `drifted`
+(the `--strict` condition).
+
+`last_deploy` is `{"result", "at"}`, or `null` when the host reports no readable
+marker. `result` is `"deployed"` or `"rolled back"`; `at` is the host's own UTC
+timestamp (`null` for a marker written before the timestamp field existed). It
+records the host's last **completed** action, so a deploy that failed before
+cutover never rewrites it, and it is reported rather than counted as drift.
 
 ### Fleet maintenance
 

--- a/docs/guide/deployment.md
+++ b/docs/guide/deployment.md
@@ -304,6 +304,219 @@ Because the run stops at the first failure, a bad migration or a candidate that
 never reports `/ready` leaves the previous version serving and tears the
 candidate down automatically — there is no half-deployed state serving traffic.
 
+### Rolling deploy across a fleet
+
+List more than one server under `[deploy] hosts` and the same `autumn deploy up`
+becomes a **rolling deploy across the fleet** — no new command, no new flags
+required:
+
+```toml
+[deploy]
+hosts = ["10.0.0.1", "10.0.0.2", "10.0.0.3"]
+```
+
+```bash
+autumn build --embed
+autumn deploy up
+```
+
+**The list order is the rollout order.** Nothing sorts or regroups it: hosts are
+replaced strictly front to back, **one at a time**, and each host must finish its
+own cutover before the next host is started. Every host runs the *same*
+zero-downtime blue/green sequence documented above, against its own kamal-proxy,
+so a host being replaced never stops serving and the hosts behind it in the
+queue are still on the old release — your load balancer always has healthy
+upstreams. See the [fleet deploys guide](fleet-deploys.md) for the load-balancer
+contract, the shared-state prerequisites, and the scale-up walkthrough.
+
+The whole run mints **one release id**, so every host's `current` symlink
+resolves to the same release and drift is meaningful.
+
+Abridged output for a three-host fleet:
+
+```
+Rolling release 20260821T101500Z across 3 hosts, ONE AT A TIME, in `[deploy] hosts` order:
+  1. 10.0.0.1 — zero-downtime redeploy
+  2. 10.0.0.2 — zero-downtime redeploy
+  3. 10.0.0.3 — zero-downtime redeploy
+  → migrate (10.0.0.1 only — the schema is fleet-wide; 10.0.0.2, 10.0.0.3 skip it)
+
+[1/3 10.0.0.1] deploying release 20260821T101500Z (zero-downtime redeploy)…
+✅ [1/3 10.0.0.1] serving 20260821T101500Z
+…
+Fleet state:
+  ✅ 10.0.0.1  serving 20260821T101500Z
+  ✅ 10.0.0.2  serving 20260821T101500Z
+  ✅ 10.0.0.3  serving 20260821T101500Z
+
+✅ Fleet deploy complete — all 3 hosts serving 20260821T101500Z.
+```
+
+#### Migrations run exactly once
+
+The schema is fleet-wide, so the rollout runs the pre-cutover migration on
+**exactly one host**: the first host in rollout order that is still on a previous
+release, immediately before *its* cutover. Every other host builds its cutover
+with the migrate step omitted. A first-deploy host is never chosen — it has no
+live release to keep serving if the migration fails.
+
+If **no** host in the fleet is on a previous release (a brand-new fleet where
+every host is a first deploy), the rollout runs **no migrations at all** and says
+so loudly, because a first deploy has never run migrations (see
+[Limitations](#limitations-and-known-gaps)):
+
+```
+⚠️  no host in this fleet is on a previous release, so this rollout runs NO
+migrations (a first deploy never does) — run `autumn migrate` yourself before
+serving traffic
+```
+
+That warning only appears when a writable database is configured — an app with
+no database has no schema to be behind.
+
+Once the migrating host cuts over, the rollout says so:
+
+```
+⚠️  the schema has moved; from here an automatic rollback restores BINARIES
+only — it never rolls a migration back
+```
+
+Design your migrations **expand/contract** so the old and new binaries can both
+run against the migrated schema — that is what makes the automatic rollback below
+safe. `autumn migrate check` (already part of the preflight) classifies your
+local `migrations/` by rolling-deploy risk; the
+[fleet deploys guide](fleet-deploys.md) covers the pattern in full.
+
+#### A failure halts the rollout and rolls the fleet back
+
+A host that fails **stops the rollout**: the hosts behind it are never touched.
+What happens to the hosts already on the new release depends on *where* the
+failure landed relative to the **go-live step** — `proxy-flip` on a redeploy,
+`proxy-route` on a first deploy:
+
+| Where it failed | What the host is | What the fleet does |
+|---|---|---|
+| At or before go-live, on a redeploy | Previous release still serving (the candidate was torn down) | Already clean — nothing to undo |
+| At or before go-live, on a first deploy | Nothing serving (the candidate was torn down) | Already clean — nothing to undo |
+| After go-live, in housekeeping (`record-proxy-options`, `drain-old`, `prune`) | **Live and healthy on the new release** | **Warn and keep rolling** — the host is fine; only bookkeeping failed |
+| After go-live, at `commit-markers` | Live on the new release, markers mid-transaction | Halt, and **never** auto-roll this host back — the rollback target cannot be trusted |
+| After go-live, anything else | Live on the new release | Halt and compensate, this host included |
+
+(The redeploy sequence is `start-candidate` → `migrate` → `readiness-gate` →
+`proxy-flip` → `commit-markers` → `record-proxy-options` → `drain-old` →
+`prune`, so a failed migration or a candidate that never reports `/ready` is
+always a pre-go-live failure with the old release still serving.)
+
+Compensation walks the hosts that are on the new release in **strict reverse
+rollout order** (newest cutover first — that shrinks the mixed window from the
+newest end) and, per host, either rolls it back to its previous release with the
+same primitives `autumn deploy rollback` uses, or — for a host whose *first*
+deploy had just completed — removes that first deploy so the host returns to
+nothing-installed. It is best-effort-**continue**: a failed compensation on one
+host never stops the next, and every result is named.
+
+Two things compensation deliberately does **not** do:
+
+- **It restores binaries, never schema.** A migration that already ran stays
+  applied. The summary says so out loud; confirm the schema still fits the
+  release now serving.
+- **It does not touch a host whose rollback target is in doubt.** Markers left
+  mid-transaction, a missing or unverifiable target release dir, or no recorded
+  previous release each produce a `NOT rolled back automatically` row plus the
+  exact read-only command to inspect that host's markers by hand (see
+  [Troubleshooting](#troubleshooting)).
+
+A **degraded** host — live and healthy on the new release, but whose post-cutover
+housekeeping failed — is worth repairing promptly: a failed `record-proxy-options`
+makes the **next** deploy of that host fail closed. A redeploy of that host
+repairs it, and the run's final line says how many hosts finished degraded.
+
+Every exit path — success, halt, or halt-plus-compensation — ends with the
+per-host `Fleet state:` table, printed **after** any compensation so it describes
+where the fleet actually is. On a halt it is your only source of truth about
+which host is running what. It names every host currently on the new release
+along with the levers for reversing them:
+
+```
+  On 20260821T101500Z: 10.0.0.2, 10.0.0.3. Roll ONE back with `autumn deploy
+  rollback --only <host>`, or the whole fleet with `autumn deploy rollback`.
+```
+
+#### `--only`: the repair lever
+
+```bash
+autumn deploy up --only 10.0.0.3          # repeatable: --only a --only b
+autumn deploy rollback --only 10.0.0.3
+```
+
+`--only` narrows `up` or `rollback` to a subset of `[deploy] hosts`. Each value
+must appear in that list **verbatim** — nothing is prefix-matched or DNS-resolved,
+so a typo can never deploy the wrong machine — and the selection keeps
+*declaration* order regardless of the order you typed the flags, so `--only c
+--only a` cannot invert a rolling deploy.
+
+It is a **repair lever, not a faster deploy.** Whenever it excludes a configured
+host the command says so before it starts:
+
+```
+⚠️  `--only` narrows this command to part of the fleet, so the hosts it skips
+keep running whatever they are running now — THE FLEET MAY END UP MIXED. This is
+a repair lever, not a faster deploy: finish with a full `autumn deploy up` (no
+`--only`) so every host converges on one release (#1621).
+   this run touches: 10.0.0.3
+   left as they are: 10.0.0.1, 10.0.0.2
+```
+
+Finish with a full `autumn deploy up`.
+
+#### `--no-rollback`: freeze a failed rollout
+
+```bash
+autumn deploy up --no-rollback
+```
+
+Halt and **freeze** instead of compensating: every host is left exactly as it is
+— including the ones already on the new release — and named in the final state
+table, so you can inspect the failure before anything else moves. Use it when you
+would rather diagnose a half-rolled fleet than automatically reverse it.
+
+#### Topologies a fleet deploy refuses
+
+Three configurations are refused in the rollout prologue, **before a single
+remote command runs**, because they cannot be deployed safely across more than
+one host. Each is gated on the number of *configured* hosts, so `--only` does not
+unlock them:
+
+| Config | Why it is refused |
+|---|---|
+| `[database] url` is a `sqlite://` target | Every host receives the same database URL, which for SQLite means N independent database *files* — no shared schema, no lock to serialize migrations, and every host serving a different dataset behind your load balancer. Point `[database] url` at a Postgres server every host can reach. |
+| `[media.mediamtx] enabled = true` | Host media provisioning has no teardown or rollback path; fanning it out would leave one MediaMTX daemon per host on identical ports with nothing to undo them with. Deploy media on a single host with `[deploy] host`. |
+| `[deploy.tls] enabled = true` | The deploy-managed kamal-proxy runs on **every** host, so each would request a certificate for the same `[deploy.tls] host` from behind your load balancer; only one can answer a given ACME challenge and the rest burn Let's Encrypt rate limits. **Terminate TLS at the load balancer that fronts the fleet** and set `[deploy.tls] enabled = false`. |
+
+One more fleet condition is a loud **warning** rather than a refusal:
+`[database] auto_migrate` (or the `auto_migrate_in_production` alias) on a
+multi-host deploy means every host applies migrations at boot, so the hosts race
+each other during the rollout and a checksum mismatch exits the process under
+`Restart=on-failure` — a crash loop mid-rollout. Turn it off for fleets and let
+the rollout's single `migrate` step own the schema.
+
+#### Two safety nets that also apply to a single host
+
+- **A release-directory collision is refused.** The release id has one-second
+  granularity, so a fast re-run can reuse it. Re-uploading into a directory that
+  `shared/previous-release` still points at would put the *new* binary there — a
+  later rollback would roll *forward*. The deploy probes for that directory and
+  refuses before writing anything (as it does when the probe cannot prove the
+  directory is absent). Wait a second and re-run.
+- **SSH sessions are bounded.** Every `ssh`/`scp` invocation carries
+  `ConnectTimeout=10`, `ServerAliveInterval=15` and `ServerAliveCountMax=4`
+  alongside `BatchMode=yes`. The preflight is a TCP connect, which proves a host
+  *accepts* a connection, not that its SSH daemon will ever answer; without these
+  a wedged host would hang the deploy forever. For one server that is a stuck
+  command someone cancels — for a fleet it would be a rollout frozen mid-flight
+  with no error to compensate. Turning an infinite hang into a finite error is
+  what lets the fleet halt and roll back.
+
 ### Rollback
 
 Roll back to the previous release on demand:
@@ -317,15 +530,119 @@ the proxy back to it (health-gated on `/ready`), repoints `current`, and
 re-probes `/ready`. It fails loudly and non-zero when there is no previous
 release to return to.
 
+**With `[deploy] hosts` this rolls back the whole fleet**, one host at a time, in
+**reverse** declaration order (newest cutover first — the mirror of the rollout,
+and of the automatic compensation above). It is best-effort-**continue**: a host
+that fails does not stop the others, because stopping would leave *more* hosts on
+the release you are trying to leave. Each host reports one of three outcomes:
+
+| Outcome | Meaning |
+|---|---|
+| `previous release restored` | The host is serving its previous release again. |
+| `SKIPPED — no previous release recorded on this host` | Nothing to roll back to (a first deploy clears the marker; a host just added to the fleet never had one). It keeps serving what it served before. |
+| `NOT rolled back — failed at <step>` | The attempt failed; this host still serves what it served before. |
+
+**The command exits non-zero unless *every* host rolled back** — a skip counts as
+a failure here. That is deliberate: the contract of a fleet rollback is that the
+*fleet* returns to its previous release, and a fleet where one host could not
+follow the others is mixed. The per-host table distinguishes the two cases, which
+is what your next move turns on; retry a single host with `autumn deploy rollback
+--only <host>`, or deploy the intended release to it explicitly.
+
+Like the automatic compensation, a fleet rollback **restores binaries only** — no
+migration is rolled back. Confirm the schema still fits the release now serving.
+
 > **Rollback runs the same local preflight as `deploy up` first.** Before it
 > makes any remote call — before it even resolves the previous release on the
 > host — `autumn deploy rollback` runs the identical local preflight graders
-> (signing secret, database URL, migrate-safety) and aborts non-zero if any fail.
+> (signing secret, database URL, migrate-safety, and — for a fleet — SSH
+> reachability for every host it targets) and aborts non-zero if any fail.
 > So it needs the same local inputs as a deploy — your project's `.env`/signing
 > secret and database URL, and the `migrations/` dir — available **wherever you
 > invoke it**: an emergency rollback from a bare CI checkout or a machine without
 > the project's secrets fails preflight before it ever reaches the host. Keep the
 > deploy inputs available where you would run a rollback.
+
+### Fleet status
+
+```bash
+autumn deploy status
+autumn deploy status --json
+autumn deploy status --strict
+```
+
+`deploy status` probes every configured host **read-only** and prints one row per
+host, in `[deploy] hosts` order. It mutates nothing, so it is safe mid-incident;
+an unreachable host becomes a row, never an abort. It works for a single
+`[deploy] host` too (one row).
+
+Each row carries: mode (`deployed` / `not deployed` / `unreachable` /
+`unknown`), the deployed release (read from the host's `current` symlink), the
+live slot, the `/ready` status code, the maintenance flag, the proxy's bound
+port, and any per-host drift reasons.
+
+Two kinds of drift are reported, and they are deliberately separate:
+
+- **Version drift** — more than one *distinct known* release across the fleet.
+  The remedy is `autumn deploy up` to converge, or `autumn deploy rollback`.
+- **State drift** — per-host marker damage that will make a **future** deploy of
+  that host fail closed or take the wrong slot. Today's reasons are: the
+  `live-slot` marker disagrees with the slot kamal-proxy is actually serving (the
+  next redeploy would restart the *serving* slot); the `shared/proxy-options`
+  marker is unreadable (the next deploy of that host will refuse); and the
+  installed proxy unit binds a different public port than `[server] port`
+  configures.
+
+> **"Release unknown" is not drift.** The only release identity a host can be
+> asked for is its `current` symlink, and that can be missing on a
+> never-deployed host, dangling mid-incident, or unreadable because the host did
+> not answer. Those hosts are *named* in the report and explicitly excluded from
+> the version-drift verdict — reporting a mixed fleet that does not exist is
+> worse than reporting nothing.
+
+`--strict` exits non-zero when **any** drift is found, so drift is alertable from
+cron. The default exits `0`: status is a report, not a judgement. `--json` emits
+a stable machine-readable report on stdout — `hosts[]` (with `host`, `reachable`,
+`mode`, `release`, `live_slot`, `ready`, `maintenance`, `proxy_port`, `drift[]`),
+plus `version_drift`, `state_drift[]`, and `drifted` (the `--strict` condition).
+
+### Fleet maintenance
+
+```bash
+autumn deploy maintenance on --message "Upgrading database schema"
+autumn deploy maintenance on --readonly --allow-ips 10.0.0.0/8
+autumn deploy maintenance off
+```
+
+`autumn deploy maintenance` turns [maintenance mode](maintenance-mode.md) on or
+off on **every deploy-configured host over SSH**, writing the same JSON flag file
+the local `autumn maintenance on` writes and taking the same flags
+(`--message`, `--allow-ips`, `--readonly`, `--bypass-header`). The running apps
+react within their 500 ms poll interval — no restart, no deploy.
+
+The distinction from the top-level `autumn maintenance` matters: that command
+writes **this machine's own working directory**, which is useless for a host you
+deploy to over SSH. Deploy-managed hosts get their flag file at
+`{app_dir}/shared/autumn-maintenance.json` — a path in the shared directory that
+survives cutovers, rollbacks and pruning and is visible to *both* blue and green
+slots — because `autumn deploy` stamps `AUTUMN_MAINTENANCE_FLAG_FILE` into every
+slot unit it writes. (For a host still running a unit deployed before this
+existed, `maintenance on` also writes the old release-relative path, and the
+per-host row says when it could not.)
+
+The fan-out is **best-effort-and-aggregate**, deliberately the opposite of the
+rollout: every host is attempted, the per-host table names what changed, and the
+command exits non-zero if any host failed. Hosts that *did* change are **not**
+reversed automatically — reversing them would push users back into the very
+window you are closing — so the summary names them explicitly, and reversing by
+hand is your call.
+
+> **Maintenance mode does not drain a host from your load balancer.** `/ready`
+> stays `200` while maintenance is on, by design: gating it would eject every
+> host from the pool the moment maintenance was enabled. A maintained host keeps
+> taking traffic and answers it with `503` + `Retry-After`. Drain at the load
+> balancer if you need a host out of rotation. This is why `deploy status`
+> reports readiness and maintenance in separate columns.
 
 ### Inspect the plan without touching the server
 
@@ -350,6 +667,15 @@ redeploy starts the candidate first and then runs the pre-cutover migration. Use
 `plan` to review the shape and what happens, not as a byte-exact order or unit
 reference.
 
+With `[deploy] hosts` set, `plan` adds a **fleet rollout** section listing the
+hosts in rollout order and stating the migrate-placement rule. That section is
+descriptive for the same reason: `plan` contacts no host, so it cannot know which
+hosts are first deploys and which are redeploys. It therefore renders the
+migration as the *rule* `autumn deploy up` applies after probing every host —
+"`[migrate]` runs once, on the first host still on a previous release, before its
+cutover — hosts 2..N skip it" — never as a named host. `deploy up` names the
+actual host once it has probed the fleet.
+
 ### Where secrets live
 
 The signing secret and database URL are written **only** to
@@ -371,6 +697,38 @@ or error messages.
   up` uploads the pre-built binary, it does not build for you.
 - **Nothing answers on the public port** — confirm the app's `server.port`
   matches the port you are curling, and that the host firewall allows it.
+- **A fleet rollout halted part-way.** Read the `Fleet state:` table it printed —
+  it describes where the fleet actually *is*, after any automatic compensation.
+  Then run `autumn deploy status` for an independent read-only view. To converge,
+  either re-run `autumn deploy up` (fix the cause first) or `autumn deploy
+  rollback` to take the whole fleet back. Remember that a migration which already
+  ran is still applied.
+- **One host is stranded on the new release.** Roll just that host back with
+  `autumn deploy rollback --only <host>`, then finish with a full `autumn deploy
+  up` (no `--only`) so the fleet converges on one release. `autumn deploy status
+  --strict` exits non-zero while the fleet is still mixed, which makes a good
+  gate for the "am I done?" question.
+- **A host says `NOT rolled back automatically`.** The fleet declined to touch it
+  because its rollback *target* is in doubt — release markers left
+  mid-transaction by `commit-markers`, a missing or unverifiable target release
+  dir, or no previous release recorded at all. Deliberately, the guidance is
+  **not** "run `deploy rollback --only <host>`": that command trusts the very
+  target that is in question. Read the markers first — the deploy prints the exact
+  read-only command for that host:
+
+  ```bash
+  ssh root@10.0.0.2 'cat /srv/autumn/myapp/shared/previous-release /srv/autumn/myapp/shared/live-slot; ls /srv/autumn/myapp/releases'
+  ```
+
+  The `previous-release` marker names the release dir, slot and port the host
+  should return to. Restore it by hand before deploying the fleet again.
+- **A host finished `DEGRADED`.** It is live and healthy on the new release; only
+  post-cutover bookkeeping failed. Repair it before the next deploy — a redeploy
+  of that host does — because a failed `record-proxy-options` makes the next
+  deploy of that host fail closed.
+- **`release directory … already exists`** — the one-second release id was reused
+  by a fast re-run. Wait a second and re-run `autumn deploy up`, or remove that
+  directory if you are certain it is stale.
 
 ### Limitations and known gaps
 
@@ -407,9 +765,31 @@ or error messages.
   `deploy up` stands the release up and health-gates it. For a database-backed
   app, ensure the schema is applied (e.g. a follow-up `autumn deploy up`, or an
   out-of-band `autumn migrate` against the primary) before relying on DB routes.
-- **Single host.** `[deploy] host` targets one server; there is no multi-host
-  fan-out. For horizontally scaled setups behind a shared load balancer, see
-  [Multi-replica setup](#multi-replica-setup).
+  The same limitation generalises to a fleet: a rollout where **every** host is a
+  first deploy migrates nowhere, and says so loudly, naming `autumn migrate` (see
+  [Migrations run exactly once](#migrations-run-exactly-once)).
+- **One load balancer, many app hosts — but the load balancer is yours.**
+  `[deploy] hosts` rolls a release across as many app servers as you list, but
+  `autumn deploy` provisions no load balancer and performs no LB membership
+  changes: kamal-proxy is per host and binds that host's public port. Run your
+  load balancer on a separate host in front of the fleet, health-check `/ready`,
+  and terminate TLS there (a fleet deploy refuses `[deploy.tls]` for exactly this
+  reason). See the [fleet deploys guide](fleet-deploys.md) for the contract, and
+  [Multi-replica setup](#multi-replica-setup) for the shared state every replica
+  needs.
+- **Fleet rollback restores binaries, never schema.** Neither the automatic
+  compensation nor `autumn deploy rollback` runs a `migrate down` — an unattended
+  down-migration mid-flip would run exactly the SQL nothing reviews. Use
+  expand/contract migrations so a rolled-back binary still fits the migrated
+  schema.
+- **A compensated first deploy leaves its proxy route behind.** When the fleet
+  removes a host's just-completed *first* deploy, that host's kamal-proxy still
+  holds a route pointing at the (now stopped) slot, so its public port answers
+  `502` instead of refusing the connection until the host is deployed again. The
+  state table names the host so this is never a surprise.
+- **Host identity is compared literally.** Duplicate `[deploy] hosts` entries are
+  refused after trimming, but two DNS names for the same machine are not detected
+  — the same limitation `autumn migrate` has for duplicate target URLs.
 - **Remote state is updated step-by-step, not transactionally** (#1938). The
   `current` symlink and the live/previous-release markers are written by
   individual SSH commands, so an interrupted deploy can leave state mid-flight;
@@ -526,9 +906,15 @@ systemd + kamal-proxy — nothing is mocked:
 
 - **Container e2e (every CI run):** `autumn-cli/tests/deploy_e2e.rs` drives first
   deploy, zero-downtime redeploy, on-demand rollback, and forced-failure
-  auto-rollback against a privileged systemd+sshd container. A container cannot
-  power-cycle, prep a stock host from scratch, or reproduce a real
-  pam_systemd session, so those are deferred to the real-VPS job below.
+  auto-rollback against a privileged systemd+sshd container. The same binary also
+  drives a **two-host fleet lifecycle** across two containers — rolling both
+  hosts onto one release, counting the migrate one-shot on each host to prove it
+  ran on exactly one, halting a rollout mid-fleet (the untouched host stays on
+  its old release), auto-rolling the already-cut-over host back, and asserting
+  `deploy status --json` / `--strict` — so the multi-host claims on this page are
+  covered by the same real ssh/scp + systemd + kamal-proxy harness, not by mocks.
+  A container cannot power-cycle, prep a stock host from scratch, or reproduce a
+  real pam_systemd session, so those are deferred to the real-VPS job below.
 - **Real-VPS validation (opt-in):** the
   [`Deploy real-VPS validation`](../../.github/workflows/deploy-real-vps.yml)
   GitHub Actions workflow provisions a throwaway Hetzner Cloud VM from a **stock

--- a/docs/guide/deployment.md
+++ b/docs/guide/deployment.md
@@ -845,18 +845,47 @@ deploy to over SSH. Deploy-managed hosts get their flag file at
 `{app_dir}/shared/autumn-maintenance.json` — a path in the shared directory that
 survives cutovers, rollbacks and pruning and is visible to *both* blue and green
 slots — because `autumn deploy` stamps `AUTUMN_MAINTENANCE_FLAG_FILE` into every
-slot unit it writes. (For a host still running a unit deployed before this
-existed, `maintenance on` also writes the old release-relative path, and the
-per-host row says when it could not. `autumn deploy status` names those hosts as
-state drift — "polls a release-local maintenance flag file, not the shared one"
-— because their flag is orphaned by the next cutover until they are redeployed.)
+slot unit it writes. The shared path is written **first**, because it is the
+authoritative one: a host running a current slot unit reacts within its next
+500 ms poll even if anything after it fails.
+
+For a host still running a unit deployed *before* that override existed,
+`maintenance on` then also writes the release-relative file that unit polls —
+resolved from the host's **live slot unit**, the slot the proxy is actually
+serving, and never from the `current` symlink (which is rewritten only after the
+proxy flip, so the two disagree exactly when a flip landed and the marker commit
+did not). `autumn deploy status` names those hosts as state drift — "polls a
+release-local maintenance flag file, not the shared one" — because their flag is
+orphaned by the next cutover until they are redeployed.
 
 The fan-out is **best-effort-and-aggregate**, deliberately the opposite of the
 rollout: every host is attempted, the per-host table names what changed, and the
 command exits non-zero if any host failed. Hosts that *did* change are **not**
 reversed automatically — reversing them would push users back into the very
-window you are closing — so the summary names them explicitly, and reversing by
-hand is your call.
+window you are closing — so the summary names them explicitly (the
+"Changed anyway: …" line, fully-changed hosts only), and reversing by hand is
+your call.
+
+Two per-host rows are worth recognising:
+
+- `maintenance enabled (shared flag only — no release is promoted on this host,
+  so no running unit polls a release-local flag)` — a **success**. Nothing is
+  promoted, so no unit is running and the shared write was the whole job.
+- `PARTIAL — shared flag written, but the file this host's RUNNING unit polls was
+  NOT (failed at …), so this host may still be serving traffic` — a **failure**,
+  and the command exits non-zero on it. The live slot unit could not be read (or
+  the write to its file failed), so which file the app polls was never proved.
+  `on` will not claim a host is maintained it could not prove, and `off` will not
+  claim to have released one (there the row ends `so this host may still be in
+  maintenance`).
+
+Like `deploy status`, `deploy maintenance` **still runs when the app config does
+not validate** — a maintenance window gets closed mid-incident, and an unrelated
+invalid setting must not stand in the way. It prints the same caveat on stderr
+naming the config error, and continues against the declared `[server] port` for
+that profile read without validation; it uses that port only to identify which
+slot unit each host is running. `autumn deploy check`/`up` still refuse until the
+config is fixed.
 
 > **Maintenance mode does not drain a host from your load balancer.** `/ready`
 > stays `200` while maintenance is on, by design: gating it would eject every

--- a/docs/guide/deployment.md
+++ b/docs/guide/deployment.md
@@ -34,11 +34,18 @@ internet connection.
 ## Push-button deploy to your own server (`autumn deploy`)
 
 `autumn deploy` takes a fresh project to a live, zero-downtime service on a
-single Linux VPS you control — no Dockerfile, no container registry, no PaaS
+Linux VPS you control — no Dockerfile, no container registry, no PaaS
 account. It uploads a single embedded binary, supervises it with systemd behind
 a reverse proxy, migrates before cutover, health-gates on `/ready`, and flips
 traffic atomically. Re-running it is a zero-downtime redeploy; one command rolls
 back.
+
+List several servers under `[deploy] hosts` instead of one under `[deploy] host`
+and the same command becomes a **rolling deploy across the fleet**: hosts are
+replaced one at a time in declaration order, migrations run exactly once, and a
+mid-rollout failure halts and rolls the hosts that already cut over back. See
+[Rolling deploy across a fleet](#rolling-deploy-across-a-fleet) and the
+[fleet deploys guide](fleet-deploys.md).
 
 This is the **primary** deployment path. A few alternatives remain documented
 below and are better fits in specific cases:
@@ -124,6 +131,10 @@ Point the deploy at your server by adding a `[deploy]` section to `autumn.toml`:
 ```toml
 [deploy]
 host = "203.0.113.10"     # SSH-reachable IP or hostname of your VPS (required)
+# hosts = ["10.0.0.1", "10.0.0.2", "10.0.0.3"]
+#                         # a FLEET instead of one server (see "Rolling deploy
+#                         # across a fleet"). Mutually exclusive with `host`;
+#                         # the list order IS the rollout order.
 # user = "root"           # SSH user (default: root)
 # ssh_port = 22           # SSH port (default: 22)
 # app_dir = "/srv/autumn/myapp"   # remote install dir (default: /srv/autumn/<app_name>)
@@ -132,8 +143,16 @@ host = "203.0.113.10"     # SSH-reachable IP or hostname of your VPS (required)
 ```
 
 Every key also has an environment override (`AUTUMN_DEPLOY__HOST`,
-`AUTUMN_DEPLOY__USER`, `AUTUMN_DEPLOY__SSH_PORT`, …) if you prefer to keep the
-host out of the file.
+`AUTUMN_DEPLOY__HOSTS`, `AUTUMN_DEPLOY__USER`, `AUTUMN_DEPLOY__SSH_PORT`, …) if
+you prefer to keep the host out of the file. `AUTUMN_DEPLOY__HOSTS` takes a
+comma-separated list (`AUTUMN_DEPLOY__HOSTS=10.0.0.1,10.0.0.2`) and **replaces**
+the whole `hosts` list from the file rather than appending to it.
+
+> **`host` and `hosts` are mutually exclusive.** Setting both is refused before
+> anything runs — with both set the rollout order would be ambiguous. A blank
+> entry or a repeated entry in `hosts` is refused too (deploying the same server
+> twice would corrupt its previous-release chain). A one-entry `hosts` list is
+> byte-for-byte the historical single-server deploy.
 
 Put these two values in a project `.env` (git-ignored — never committed). The
 deploy reads them and writes **only** them to a `0600` env file
@@ -210,7 +229,15 @@ from pending migrations — an old destructive migration file left in the direct
 fails the check even after it has been applied. Keep `migrations/` rolling-safe
 (remove or adjust an already-applied destructive migration if it trips the scan).
 The preflight exits non-zero if anything fails, so nothing touches the server
-until it is green:
+until it is green.
+
+With a fleet (`[deploy] hosts`), **every host the run targets is graded before
+any host is touched**: SSH reachability is probed once per host and reported on
+its own line (`ssh_reachability (10.0.0.3)`), while the project-wide graders —
+signing secret, database URL, migrate-safety — run once. So an unreachable host
+in position 3 is named before host 1 is deployed, not after two hosts have
+already cut over. `autumn deploy up` and `autumn deploy rollback` re-run this
+same fleet-wide preflight and abort on any failure.
 
 ```bash
 autumn deploy check      # doctor --online runs the same graders (plain doctor skips network probes)

--- a/docs/guide/fleet-deploys.md
+++ b/docs/guide/fleet-deploys.md
@@ -200,10 +200,33 @@ to create it: a host's candidate process starts before that host's `migrate` ste
 runs. `redis` reuses the Redis you already stood up for sessions and rate
 limiting; `[jobs.redis] key_prefix` keeps its keys separate.
 
-**Nothing refuses `local` on a fleet.** The doctor check that fails a `local`
-jobs backend (`process_role_backend`) only fires for a split `web`/`worker` role,
-and fleet hosts are all combined-role — so `deploy check`, the rollout preflight
-and `deploy status` are all silent about this. It is on you.
+**Nothing refuses `local` on a fleet — but `deploy up` does warn.** The
+in-process defaults are correct on one host and are what every un-configured app
+runs, so refusing them would break the scale-up this guide exists to make easy.
+Instead, whenever more than one host is configured, the rollout prologue prints:
+
+```
+⚠️  `[jobs] backend = "local"` (an in-process queue) and `[scheduler] backend =
+"in_process"` (a per-process timer) are in effect and this deploy targets more
+than one host — they are PER HOST: each host then runs its OWN copy, so work
+enqueued on one host is only ever run by that host, whatever is still queued dies
+when the next rollout drains that host's old slot, `unique`/`concurrency` limits
+stop being enforced fleet-wide, and every scheduled task fires once PER HOST.
+Move them to a shared backend (`postgres` or `redis`) before you rely on
+background work across the fleet — see docs/guide/fleet-deploys.md (#1621).
+```
+
+It names only the key(s) actually in effect, so a fleet on a shared queue with an
+in-process scheduler is warned about the scheduler alone. It is keyed on the
+number of *configured* hosts, so `--only` does not silence it, and it is silent
+for a single-host config, where the defaults are right.
+
+That warning is the **only** place this surfaces. It comes from the rollout
+driver, after the preflight report — so `deploy check`, `deploy plan` and
+`deploy status` say nothing about it, and neither does `autumn doctor` (its
+`process_role_backend` check only fires for a split `web`/`worker` role, and
+fleet hosts are all combined-role). Sessions and rate limiting get no warning at
+all. Work the table above yourself rather than waiting to be told.
 
 Full backend comparison, delivery semantics and the migration note are in the
 [jobs guide](jobs.md#backend-selection-autumntoml); don't duplicate them, read
@@ -230,8 +253,12 @@ above; a fleet on a `sqlite://` database is refused outright.
 
 This is also where you switch the backends that silently defaulted to per-host
 on a single server: sessions, rate limiting, `[jobs] backend` and
-`[scheduler] backend`. Nothing in the rollout refuses a per-host default — it
-just quietly becomes three of everything.
+`[scheduler] backend`. Nothing in the rollout *refuses* a per-host default — it
+becomes three of everything. It does not become three of everything quietly,
+though: `autumn deploy up` prints a loud ⚠️ naming `[jobs] backend = "local"`
+and/or `[scheduler] backend = "in_process"` whenever the deploy targets more than
+one host ([above](#background-jobs-the-default-queue-is-per-host)). Sessions and
+rate limiting get no such warning — those two are on you.
 
 ### 3. Swap `host` for `hosts`
 
@@ -287,6 +314,41 @@ Rolling release 20260821T101500Z across 3 hosts, ONE AT A TIME, in `[deploy] hos
 > so a brand-new fleet with no host on a previous release runs no migration at
 > all — and says so loudly, telling you to run `autumn migrate` yourself before
 > serving traffic. That warning is your cue, not a bug.
+
+#### List the already-deployed hosts first
+
+The example above works because `10.0.0.1` — the host that is already serving —
+is **first** in the list. That ordering is load-bearing, and nothing enforces it.
+
+The migration is placed on the first host in rollout order that is still on a
+previous release. A new host listed *ahead* of that one takes the first-deploy
+path, which carries no migrate step, so it **goes live on the new release before
+the schema moves**. With `hosts = ["10.0.0.2", "10.0.0.3", "10.0.0.1"]` — the two
+new hosts first — `10.0.0.2` and `10.0.0.3` serve the new release against the old
+schema until the rollout reaches `10.0.0.1`. If the release needs the new schema,
+that window is an outage on those hosts.
+
+So when you add hosts to an existing fleet: **put the already-deployed host (or
+hosts) at the front of `hosts` and append the new ones**. The list is never
+reordered for you — declaration order is the rollout contract, and silently
+resequencing it would be worse than the hazard.
+
+The rollout names the hazard when you hit it, in the header, before anything is
+touched:
+
+```
+⚠️  10.0.0.2, 10.0.0.3 go live on the new release BEFORE the migration runs
+(a first deploy never migrates) — if this release needs the new schema they will
+serve against the old one until the migrating host is reached; list an
+already-deployed host first to avoid it
+```
+
+Seeing that means exactly one thing: reorder `hosts` so an already-deployed host
+comes first and re-run, or accept the window knowingly because this release does
+not depend on the new schema. Like the other migration warnings it is only
+printed when the CLI can resolve a writable database URL from your config — an
+app whose database URL exists only in the host's environment gets no warning, so
+order the list correctly regardless.
 
 ### 6. Add the new hosts to the load balancer
 
@@ -372,6 +434,28 @@ because narrowing a rollout is precisely how a fleet ends up mixed on purpose.
 **Finish with a full `autumn deploy up`** and confirm with `deploy status
 --strict`.
 
+> **`--only` down to one host is a single-host run, and it behaves like one.**
+> This is worth knowing *before* an incident, because the fleet summary's
+> recovery line points you at exactly this command. Narrowing to a single target
+> takes the pre-fleet code path, so `autumn deploy rollback --only 10.0.0.2`:
+>
+> - prints **no `Fleet state:` table** and no per-host outcome rows — you get
+>   `Rolling back 10.0.0.2 to <release>…` and a single `✅ Rollback complete.`, or
+>   a plain error. Run `autumn deploy status` afterwards for the fleet-wide
+>   picture.
+> - gets **no benefit from the fleet rollback's reachability softening.** A
+>   multi-host rollback deliberately continues past a host that does not answer
+>   SSH, because stopping would strand the *other* hosts on the release you are
+>   abandoning. With one target there are no other hosts: an unreachable host
+>   stops the command non-zero having changed nothing.
+> - still needs the project's local inputs (signing secret, database URL,
+>   `migrations/`) wherever you invoke it — the preflight runs first either way.
+>
+> The same narrowing applies to `--only` on `deploy up`: only the selected hosts
+> are reachability-graded. The fleet-wide topology refusals (`sqlite://`,
+> `[media.mediamtx]`, `[deploy.tls]`) are keyed on the *configured* host count, so
+> `--only` never unlocks those.
+
 ### When the fleet says "NOT rolled back automatically"
 
 Four situations make a host's rollback *target* untrustworthy, and the fleet
@@ -441,8 +525,12 @@ Four things to know before you run it:
   cutover, a rollback and a prune all leave it in place, and both blue and green
   see the same flag. (See [maintenance-mode.md](maintenance-mode.md).)
 - **The local `autumn maintenance` is a different command.** It writes *this*
-  machine's working directory, which is not the host you deploy to. Use
-  `autumn deploy maintenance` for deploy-managed hosts.
+  machine's working directory, which is not the host you deploy to — and SSH-ing
+  into a host to run it there does not work either, because it writes the
+  cwd-relative `tmp/autumn-maintenance.json` while a deploy-managed app reads
+  `{app_dir}/shared/autumn-maintenance.json`. It exits `0` and changes nothing.
+  Use `autumn deploy maintenance` for deploy-managed hosts; see
+  [maintenance-mode.md](maintenance-mode.md#where-the-flag-file-lives).
 
 ---
 
@@ -489,6 +577,26 @@ Stated plainly so you can plan around it:
 - **No load-balancer management.** No provisioning, no health-check
   configuration, no adding or removing backends during a rollout. Your LB, your
   automation.
+- **No draining of a host, ever.** A rolling deploy does not take a host out of
+  rotation and does not push its `/ready` to `503` — not before the cutover, not
+  during it. Each host is replaced *in place*: the candidate starts on that
+  host's idle loopback slot, is `/ready`-gated on that loopback port, and the
+  host's own kamal-proxy flips upstreams atomically; the old slot is drained and
+  stopped only **after** the flip. From your load balancer's point of view the
+  host answers `200` on `/ready` the whole way through. If you need a host
+  genuinely out of the pool — a reboot, a scale-down, a host-level repair — you
+  drain it at the load balancer yourself, budgeting per
+  [rule 2](#2-budget-35-seconds-for-a-host-to-leave-rotation). Maintenance mode
+  is not that lever either ([rule 3](#3-maintenance-mode-does-not-drain-a-host)).
+- **No proof about *your* load balancer.** Autumn's end-to-end deploy test rolls
+  a real two-host fleet in CI and asserts that neither host returned a single
+  failed response during the rollout. Read it for what it is: the checker is a
+  **liveness prober** — one thread per host, one request at a time, roughly ten
+  requests a second — pointed at each host's *public port directly*, with no load
+  balancer in the harness at all. It is good evidence that a host being replaced
+  keeps answering. It is not a load test, it says nothing about behaviour under
+  concurrency, and it exercises none of your LB's health-check interval,
+  unhealthy threshold or deregistration delay. Those you validate yourself.
 - **No parallel rollout.** Hosts are replaced strictly one at a time. A batch or
   percentage rollout is not configurable.
 - **No canary weighting.** Autumn's canary primitives (version-labelled metrics,

--- a/docs/guide/fleet-deploys.md
+++ b/docs/guide/fleet-deploys.md
@@ -1,0 +1,450 @@
+# Fleet Deploys
+
+[`autumn deploy`](deployment.md) started as a one-server tool. This guide is
+about the other shape: **several app servers behind a load balancer you own**,
+rolled onto a new release one at a time, with `autumn deploy up` doing the
+rolling.
+
+Read this when you are about to add a second app server, or already run several
+and want the runbooks for drift, a half-finished rollout, and a fleet-wide
+maintenance window.
+
+Target time: **under 15 minutes** to take a working single-host deploy to a
+three-host fleet.
+
+> The mechanics of a single host — the release layout, the blue/green slots, the
+> `/ready` gate, the systemd units, where secrets live — are all in the
+> [deployment guide](deployment.md). This page assumes them and covers only what
+> changes when there is more than one host.
+
+---
+
+## The topology
+
+```
+                        ┌──────────────────────────────┐
+   internet ─── TLS ───▶│  YOUR load balancer          │   (separate host —
+                        │  health check: GET /ready    │    not managed by
+                        └───────┬───────┬───────┬──────┘    autumn deploy)
+                                │       │       │
+                  ┌─────────────┘       │       └─────────────┐
+                  ▼                     ▼                     ▼
+        ┌───────────────────┐ ┌───────────────────┐ ┌───────────────────┐
+        │ 10.0.0.1          │ │ 10.0.0.2          │ │ 10.0.0.3          │
+        │  kamal-proxy      │ │  kamal-proxy      │ │  kamal-proxy      │
+        │   ├ blue  (live)  │ │   ├ blue  (live)  │ │   ├ blue  (live)  │
+        │   └ green (idle)  │ │   └ green (idle)  │ │   └ green (idle)  │
+        └─────────┬─────────┘ └─────────┬─────────┘ └─────────┬─────────┘
+                  └─────────────────────┼─────────────────────┘
+                                        ▼
+                     shared Postgres · shared Redis · object storage
+```
+
+Two things follow from this picture, and they explain most of the rules below:
+
+1. **kamal-proxy is per host, not a fleet load balancer.** Each app server runs
+   its own proxy, owning that host's public port and flipping that host's
+   blue/green slots. Nothing in `autumn deploy` distributes traffic *between*
+   hosts.
+2. **The load balancer is yours.** `autumn deploy` neither provisions it nor
+   changes its membership. What Autumn gives you is a correct health signal
+   (`/ready`) and a rollout that touches one host at a time — and keeps even that
+   host serving throughout its own blue/green cutover.
+
+---
+
+## The load-balancer contract
+
+Four rules. Getting the first one wrong is the classic outage.
+
+### 1. Health-check `/ready`. Never `/live`
+
+Point your load balancer's health check at **`/ready`** (the path is
+`[health] ready_path`, default `/ready`).
+
+`/live` returns **`200` unconditionally** — it is a liveness probe, answering
+"is this process running?", and a supervisor uses it to decide whether to
+restart. It says nothing about whether the process can serve. A load balancer
+health-checking `/live` will keep a host in rotation while it is still starting
+up, while it is shutting down, and while its database pool is unusable.
+
+`/ready` gates on all of that: it is `503` until startup completes, `503` the
+instant a shutdown begins, and `503` when a dependency or a readiness
+[health indicator](health-indicators.md) is down. That is the signal you want.
+
+### 2. Budget ~35 seconds for a host to leave rotation
+
+When an app process is asked to stop, it does this, in order:
+
+1. `/ready` flips to `503` immediately — your load balancer should now stop
+   routing new requests here.
+2. It waits `[server] prestop_grace_secs` (default **5 s**) for the load balancer
+   to actually notice and drain its connection pool.
+3. The listener closes.
+4. In-flight requests finish, up to `[server] shutdown_timeout_secs`
+   (default **30 s**).
+
+So the default stop budget is about **35 seconds**. Tune `prestop_grace_secs` to
+your load balancer's health-check interval × unhealthy-threshold plus its
+deregistration delay: too short and the LB is still sending requests to a closed
+listener. See [Staged and zero-downtime deploys](staged-deploys.md) for the full
+drain lifecycle.
+
+Note that a *rolling deploy* does not normally exercise this path from the load
+balancer's point of view: the host's own kamal-proxy flips between slots
+atomically, so the host keeps answering `/ready` with `200` throughout. The
+budget matters when you take a host out of the fleet, reboot it, or scale down.
+
+### 3. Maintenance mode does **not** drain a host
+
+`/ready` deliberately **bypasses** maintenance mode: a host with the maintenance
+flag set keeps answering its health check with `200` and stays in rotation,
+serving `503` + `Retry-After` to real user traffic.
+
+That is intentional. If maintenance gated `/ready`, turning maintenance on across
+a fleet would eject *every* host from the load-balancer pool simultaneously —
+turning a controlled maintenance window into a hard outage, and, on many
+platforms, into a restart loop.
+
+The consequence for you: **if you need a host out of rotation, drain it at the
+load balancer.** Maintenance mode is a traffic *gate*, not a drain.
+`autumn deploy status` therefore reports readiness and maintenance in separate
+columns, and `autumn deploy maintenance on` repeats this warning every time.
+
+### 4. Terminate TLS at the load balancer
+
+A fleet deploy **refuses** `[deploy.tls] enabled = true`. Each host's kamal-proxy
+would request a certificate for the same public hostname from behind your load
+balancer; only one of them can answer any given ACME challenge, and the rest burn
+Let's Encrypt failed-validation and duplicate-certificate rate limits.
+
+Terminate TLS at the load balancer and set `[deploy.tls] enabled = false`.
+
+Run the load balancer on a **separate host**, too. kamal-proxy always binds
+`:443` on its host and cannot release it, so an external TLS terminator cannot
+share a deploy-managed box. (This is not fleet-specific — it is true of a
+single-host deploy as well; see the HTTPS/TLS note in the
+[deployment guide](deployment.md#push-button-deploy-to-your-own-server-autumn-deploy)
+and the [TLS guide](tls.md).)
+
+---
+
+## Shared state: what every host must agree on
+
+Every host in the fleet receives a **byte-identical** env file and manifest — the
+same signing secret, the same database URL, the same `autumn.toml`. That is what
+makes the fleet one application rather than N applications. It also means
+anything that must be shared has to live *outside* the hosts.
+
+| Concern | What a fleet needs | Where |
+|---|---|---|
+| Database | One Postgres every host can reach. A `sqlite://` URL is **refused** for a multi-host deploy — identical URL, N independent files. | [Topologies a fleet refuses](deployment.md#topologies-a-fleet-deploy-refuses) |
+| Signing secret | Identical on every host, or sessions, signed blob URLs and CSRF tokens break as soon as a request lands on a different host. The deploy already ships the same secret everywhere; keep it stable across deploys. | [signing-secrets.md](signing-secrets.md) |
+| Sessions | Redis session backend. In-memory sessions are per host. | [Multi-replica setup](deployment.md#multi-replica-setup) |
+| Rate limiting | Redis rate-limit backend, or an N-host fleet permits N× your configured rate. | [rate-limiting.md](rate-limiting.md) |
+| Uploaded files | Object storage (`[storage] backend = "s3"`). Local disk is per host, and a release dir is wiped by pruning. | [storage.md](storage.md) |
+| Scheduled tasks | Advisory-lock coordination so a `#[scheduled]` task runs once per fleet, not once per host. | [scheduled-multi-replica.md](scheduled-multi-replica.md) |
+| Migrations at boot | `[database] auto_migrate` **off**. Every host would apply migrations at boot and race the others. | below |
+
+The [Multi-replica setup](deployment.md#multi-replica-setup) section of the
+deployment guide has the concrete config for the shared session/rate-limit
+backends — it is the same configuration whether your replicas are containers or
+`autumn deploy` hosts. Don't duplicate it; read it there.
+
+---
+
+## Scaling one host to three
+
+You have a working single-host deploy. Here is the whole change.
+
+### 1. Provision the new hosts
+
+Each new host needs exactly what the first one needed
+([Preconditions](deployment.md#preconditions)): key-based SSH access for
+`[deploy] user`, and the `kamal-proxy` binary at `/usr/local/bin/kamal-proxy`.
+Nothing else — the release layout, units and directories are created for you.
+
+### 2. Move the shared state off the app host
+
+If your single host was running Postgres or Redis locally, move them now. Every
+host must reach the same database and the same Redis. Work through the table
+above; a fleet on a `sqlite://` database is refused outright.
+
+### 3. Swap `host` for `hosts`
+
+```toml
+[deploy]
+# host = "10.0.0.1"
+hosts = ["10.0.0.1", "10.0.0.2", "10.0.0.3"]
+```
+
+The two keys are mutually exclusive — keep one. **List order is rollout order**,
+so put the host you want replaced first, first. Blank and duplicate entries are
+refused.
+
+`AUTUMN_DEPLOY__HOSTS=10.0.0.1,10.0.0.2,10.0.0.3` does the same from the
+environment, replacing the file's list entirely.
+
+### 4. Check, then roll
+
+```bash
+autumn deploy check     # grades every host: SSH per host, project graders once
+autumn build --embed
+autumn deploy up
+```
+
+`deploy check` is the cheap step that catches the new hosts being unreachable,
+and it names them individually. `deploy plan` will additionally print the rollout
+order and the migrate-placement rule without contacting anything.
+
+### 5. What the first fleet rollout actually does
+
+The interesting part of a scale-up is that the hosts are in **different states**,
+and the rollout handles that explicitly:
+
+- `10.0.0.1` is already serving, so it takes the **zero-downtime redeploy** path:
+  candidate on the idle slot, migrate, `/ready` gate, atomic flip.
+- `10.0.0.2` and `10.0.0.3` have nothing installed, so they take the **first
+  deploy** path: install kamal-proxy, stand the release up, health-gate, route.
+- The migration runs on `10.0.0.1` **only** — the first host in rollout order
+  that is still on a previous release — before its cutover. The two new hosts
+  skip it, because the schema is fleet-wide and running it three times is at best
+  redundant and at worst a race.
+
+```
+Rolling release 20260821T101500Z across 3 hosts, ONE AT A TIME, in `[deploy] hosts` order:
+  1. 10.0.0.1 — zero-downtime redeploy
+  2. 10.0.0.2 — first deploy
+  3. 10.0.0.3 — first deploy
+  → migrate (10.0.0.1 only — the schema is fleet-wide; 10.0.0.2, 10.0.0.3 skip it)
+```
+
+> **A fleet where *every* host is a first deploy migrates nowhere.** A first
+> deploy has never run migrations (it stands the release up and health-gates it),
+> so a brand-new fleet with no host on a previous release runs no migration at
+> all — and says so loudly, telling you to run `autumn migrate` yourself before
+> serving traffic. That warning is your cue, not a bug.
+
+### 6. Add the new hosts to the load balancer
+
+Only after `deploy up` reports all three serving. `autumn deploy` does not touch
+your load balancer's membership — adding and removing backends is yours to
+automate.
+
+Confirm with:
+
+```bash
+autumn deploy status
+```
+
+Three rows, one release, no drift.
+
+---
+
+## Runbook: drift and partial rollouts
+
+### Detecting drift
+
+```bash
+autumn deploy status --strict
+```
+
+Read-only, safe mid-incident, and non-zero on any drift — so it belongs in cron
+or your monitoring:
+
+```
+# crontab: alert when the fleet stops being on one release
+*/10 * * * * cd /srv/deploy/myapp && autumn deploy status --strict --json >/var/log/autumn-fleet.json 2>&1
+```
+
+It reports two independent things:
+
+- **Version drift** — hosts on different releases. Something did not converge.
+- **State drift** — per-host marker damage that will make that host's **next**
+  deploy fail closed or take the wrong slot. A perfectly converged fleet can
+  still have state drift, which is exactly why the two are not merged.
+
+A host that does not answer is an `unreachable` row, and a host whose release
+cannot be read is reported as `release unknown` and explicitly **not** counted as
+version drift. A false "your fleet is mixed" alarm at 3 am is worse than no
+alarm.
+
+### Converging a mixed fleet
+
+The default answer to version drift is to roll forward:
+
+```bash
+autumn deploy up          # the whole fleet, one release, in order
+```
+
+or, if the new release is the problem, take everything back:
+
+```bash
+autumn deploy rollback    # every host, newest first
+```
+
+`rollback` exits non-zero unless every host came back — including a host that had
+*nothing* to roll back to, which is reported as a skip and still counts as
+failure. That is the honest signal: the fleet is not on one release.
+
+### Repairing one host
+
+When a single host is the problem, `--only` narrows either command:
+
+```bash
+autumn deploy rollback --only 10.0.0.2    # take one host back
+autumn deploy up --only 10.0.0.2          # or push the intended release to it
+```
+
+Every `--only` run prints a loud warning naming the hosts it is *not* touching,
+because narrowing a rollout is precisely how a fleet ends up mixed on purpose.
+**Finish with a full `autumn deploy up`** and confirm with `deploy status
+--strict`.
+
+### When the fleet says "NOT rolled back automatically"
+
+Four situations make a host's rollback *target* untrustworthy, and the fleet
+refuses to guess:
+
+| Reason | What it means |
+|---|---|
+| release markers left mid-transaction by `commit-markers` | The previous-release / `current` / live-slot triple is written as one remote transaction; a failure inside it can leave any subset applied. |
+| rollback target release dir missing | The marker names a release directory that is not there (pruned, or removed by hand). |
+| rollback target release dir could not be verified | The probe proved nothing either way. |
+| no previous release recorded to roll back to | A first deploy clears the marker; a freshly added host never had one. |
+
+In every one of these, running `autumn deploy rollback --only <host>` is the
+*wrong* first move — that command trusts the target that is in doubt. The deploy
+prints the exact read-only command to look first:
+
+```bash
+ssh root@10.0.0.2 'cat /srv/autumn/myapp/shared/previous-release /srv/autumn/myapp/shared/live-slot; ls /srv/autumn/myapp/releases'
+```
+
+`previous-release` names the release dir, slot and port the host should return
+to. Restore it by hand, then deploy the fleet again.
+
+### After any halted rollout: check the schema
+
+An automatic compensation restores **binaries only**. If the rollout got far
+enough to migrate, the schema is still forward while the binaries are back. That
+is safe *if* your migrations are expand/contract (below) and alarming if they are
+not — so confirm it explicitly rather than assuming the rollback undid
+everything.
+
+---
+
+## Runbook: a fleet-wide maintenance window
+
+For a change that genuinely needs write traffic stopped across the whole fleet —
+a destructive migration, a database failover:
+
+```bash
+# 1. Gate every host at once. Apps react within 500 ms; no restart, no deploy.
+autumn deploy maintenance on \
+  --message "Upgrading the database. Back by 14:30 UTC." \
+  --allow-ips 10.0.0.0/8
+
+# 2. Confirm every host actually took the flag.
+autumn deploy status
+
+# 3. Do the work.
+autumn migrate
+
+# 4. Reopen.
+autumn deploy maintenance off
+```
+
+Four things to know before you run it:
+
+- **It is not a drain.** Every host stays in your load-balancer pool and answers
+  user traffic with `503`. If the work requires *zero* traffic reaching the app,
+  drain at the load balancer as well.
+- **A partial result is reported, never reversed.** If host 2 fails, hosts 1 and
+  3 stay in maintenance and are named in the summary; the command exits non-zero.
+  Reversing them automatically would push users straight back into the window you
+  are closing. Reversing by hand (`autumn deploy maintenance off`) is your call.
+- **The flag survives deploys.** Deploy-managed hosts read
+  `{app_dir}/shared/autumn-maintenance.json`, in the shared directory, because
+  `autumn deploy` stamps `AUTUMN_MAINTENANCE_FLAG_FILE` into every slot unit. A
+  cutover, a rollback and a prune all leave it in place, and both blue and green
+  see the same flag. (See [maintenance-mode.md](maintenance-mode.md).)
+- **The local `autumn maintenance` is a different command.** It writes *this*
+  machine's working directory, which is not the host you deploy to. Use
+  `autumn deploy maintenance` for deploy-managed hosts.
+
+---
+
+## Expand/contract is the prerequisite for safe rollback
+
+The single most important schema rule for a fleet:
+
+> **Nothing ever rolls a migration back.** Not the automatic compensation after a
+> halted rollout, not `autumn deploy rollback`. Both restore binaries only.
+
+This is deliberate. An automatic `migrate down` would run, unattended and
+mid-incident, exactly the SQL that nothing reviews — `autumn migrate check`
+grades the `up` direction. Silently executing the un-reviewed half of a migration
+while a fleet is already in trouble is not a recovery mechanism.
+
+It also means a rolling deploy inherently runs **old and new binaries against the
+new schema at the same time** — that is not an edge case, it is every moment
+between host 1's cutover and host N's. Both facts point at the same discipline:
+
+**Expand → migrate → contract**, across two releases.
+
+| Release | Migration | Code |
+|---|---|---|
+| N | *Expand*: add the new nullable column / new table / new index. Additive only — nothing existing is dropped or renamed. | Writes both old and new; reads old. |
+| N (later) or N+1 | Backfill, then switch reads to the new shape. | Reads new, still writes both. |
+| N+2 | *Contract*: drop the old column, once no deployed release reads it. | Uses the new shape only. |
+
+Every step leaves the previous release able to run against the migrated schema —
+which is precisely what makes an automatic rollback safe, and what makes the
+mixed window during a rollout a non-event.
+
+`autumn migrate check` classifies your local `migrations/` by rolling-deploy risk
+and already runs as part of the deploy preflight, so an unsafe migration fails
+before anything is touched. For a change that genuinely cannot be made
+expand/contract, use the [maintenance window runbook](#runbook-a-fleet-wide-maintenance-window)
+above instead of hoping the rollback will save you.
+
+---
+
+## What a fleet deploy does not do
+
+Stated plainly so you can plan around it:
+
+- **No load-balancer management.** No provisioning, no health-check
+  configuration, no adding or removing backends during a rollout. Your LB, your
+  automation.
+- **No parallel rollout.** Hosts are replaced strictly one at a time. A batch or
+  percentage rollout is not configurable.
+- **No canary weighting.** Autumn's canary primitives (version-labelled metrics,
+  the `X-Canary` extractor, `autumn canary rollback`) are driven by a controller
+  moving traffic weights at *your* load balancer — see
+  [Canary deploys](staged-deploys.md#canary-deploys). `autumn deploy` does not
+  shift traffic between hosts.
+- **No per-role fleets.** Every host in `[deploy] hosts` gets the same release,
+  the same env file and the same unit. Splitting web and worker roles across
+  different host lists is not expressible today.
+- **No migration rollback.** As above.
+- **No media provisioning on a fleet.** `[media.mediamtx]` is refused for a
+  multi-host deploy — host media provisioning has no teardown path. Deploy media
+  on a single host.
+
+---
+
+## Next steps
+
+- **[Deployment guide](deployment.md)** — the full `autumn deploy` surface:
+  release layout, blue/green slots, secrets, `deploy plan`, MediaMTX, and the
+  container/PaaS alternatives.
+- **[Maintenance mode](maintenance-mode.md)** — the flag file, the allow-list
+  options, and the destructive-migration runbook.
+- **[Staged and zero-downtime deploys](staged-deploys.md)** — the drain
+  lifecycle, blue/green at the platform level, and canary primitives.
+- **[Multi-replica setup](deployment.md#multi-replica-setup)** — the shared
+  session, rate-limit and secret configuration every fleet needs.
+- **Alert on drift** — wire `autumn deploy status --strict` into cron so a fleet
+  that quietly stopped converging pages someone.

--- a/docs/guide/fleet-deploys.md
+++ b/docs/guide/fleet-deploys.md
@@ -332,6 +332,14 @@ cannot be read is reported as `release unknown` and explicitly **not** counted a
 version drift. A false "your fleet is mixed" alarm at 3 am is worse than no
 alarm.
 
+Each row also carries a `last deploy` cell — the last action that host
+*completed* (`deployed` or `rolled back`, with the host's UTC time; `?` when the
+marker is absent or unreadable). Mid-incident that is what tells a compensated
+host apart from one that simply deployed, since both read back healthy and on
+the same release. Mind its scope: a deploy that failed *before* cutover never
+rewrites it, so it is that host's own last completed action rather than a
+verdict on the last rollout, and it is reported, never counted as drift.
+
 ### Converging a mixed fleet
 
 The default answer to version drift is to roll forward:

--- a/docs/guide/fleet-deploys.md
+++ b/docs/guide/fleet-deploys.md
@@ -143,13 +143,71 @@ anything that must be shared has to live *outside* the hosts.
 | Sessions | Redis session backend. In-memory sessions are per host. | [Multi-replica setup](deployment.md#multi-replica-setup) |
 | Rate limiting | Redis rate-limit backend, or an N-host fleet permits N× your configured rate. | [rate-limiting.md](rate-limiting.md) |
 | Uploaded files | Object storage (`[storage] backend = "s3"`). Local disk is per host, and a release dir is wiped by pruning. | [storage.md](storage.md) |
-| Scheduled tasks | Advisory-lock coordination so a `#[scheduled]` task runs once per fleet, not once per host. | [scheduled-multi-replica.md](scheduled-multi-replica.md) |
+| Background jobs | A durable queue every host shares: `[jobs] backend = "postgres"` or `"redis"`. The default `local` backend is an in-process queue, so N hosts means N independent queues. | [below](#background-jobs-the-default-queue-is-per-host) |
+| Scheduled tasks | `[scheduler] backend = "postgres"` — advisory-lock coordination so a `#[scheduled]` task runs once per fleet, not once per host. The default is a per-process timer. | [scheduled-multi-replica.md](scheduled-multi-replica.md) |
 | Migrations at boot | `[database] auto_migrate` **off**. Every host would apply migrations at boot and race the others. | below |
 
 The [Multi-replica setup](deployment.md#multi-replica-setup) section of the
 deployment guide has the concrete config for the shared session/rate-limit
 backends — it is the same configuration whether your replicas are containers or
 `autumn deploy` hosts. Don't duplicate it; read it there.
+
+### Background jobs: the default queue is per host
+
+This is the row people miss, because on one host it is invisible.
+
+Every fleet host runs the **combined** process role — one env file and one unit
+go to every host, and nothing in `autumn deploy` sets a per-host role — so all
+three hosts serve HTTP *and* run job workers *and* run the cron scheduler. That
+is the right shape for a fleet, but only once the queue those workers drain is
+shared. `[jobs] backend` defaults to `local`, which is an in-process queue. Three
+hosts on the default are three independent queues:
+
+- **Work never balances.** A job enqueued while serving on `10.0.0.2` can only
+  ever be executed by `10.0.0.2`.
+- **A rollout drops pending work.** `local` holds queued and delayed jobs in
+  memory only; a rolling deploy stops each host's old slot in turn, so anything
+  not yet run is gone. The durable backends keep it (`run_at` column on Postgres,
+  a due-time ZSET on Redis).
+- **`unique` and `concurrency` caps are per host.** `#[job(unique)]` and
+  `concurrency = N` are distributed-safe only on the durable backends, so the
+  same "runs at most once" job can run once *per host*.
+- **Tracked-job polling breaks behind the load balancer.** The record store
+  behind `enqueue_tracked` follows the jobs backend; on `local` it is
+  process-local, so when the browser's next poll of `GET /_autumn/jobs/{token}`
+  lands on a different host, that host returns the same `404` it returns for an
+  unknown token.
+- **`/admin/jobs` shows one host.** The local runtime installs a process-local
+  dashboard backend, so the dashboard — and its retry/discard/cancel buttons —
+  act on whichever host the load balancer happened to pick. (`redis` installs a
+  cluster-wide dashboard backend automatically.) `/actuator/jobs` counters are
+  per host for the same reason.
+
+So pick a shared backend before the first fleet rollout:
+
+```toml
+[jobs]
+backend = "postgres"   # or "redis"
+```
+
+`postgres` is usually the cheaper choice for a fleet: a fleet already requires a
+shared Postgres (`sqlite://` is refused), the queue reuses the `[database]` pool,
+and no new service appears. It needs the framework's `autumn_jobs` table, which
+`autumn migrate` creates — so on a fleet that has already deployed against
+Postgres it is there, and on a brand-new fleet it arrives with the `autumn
+migrate` the guide already tells you to run. Do not count on the *same* rollout
+to create it: a host's candidate process starts before that host's `migrate` step
+runs. `redis` reuses the Redis you already stood up for sessions and rate
+limiting; `[jobs.redis] key_prefix` keeps its keys separate.
+
+**Nothing refuses `local` on a fleet.** The doctor check that fails a `local`
+jobs backend (`process_role_backend`) only fires for a split `web`/`worker` role,
+and fleet hosts are all combined-role — so `deploy check`, the rollout preflight
+and `deploy status` are all silent about this. It is on you.
+
+Full backend comparison, delivery semantics and the migration note are in the
+[jobs guide](jobs.md#backend-selection-autumntoml); don't duplicate them, read
+them there.
 
 ---
 
@@ -169,6 +227,11 @@ Nothing else — the release layout, units and directories are created for you.
 If your single host was running Postgres or Redis locally, move them now. Every
 host must reach the same database and the same Redis. Work through the table
 above; a fleet on a `sqlite://` database is refused outright.
+
+This is also where you switch the backends that silently defaulted to per-host
+on a single server: sessions, rate limiting, `[jobs] backend` and
+`[scheduler] backend`. Nothing in the rollout refuses a per-host default — it
+just quietly becomes three of everything.
 
 ### 3. Swap `host` for `hosts`
 
@@ -446,5 +509,9 @@ Stated plainly so you can plan around it:
   lifecycle, blue/green at the platform level, and canary primitives.
 - **[Multi-replica setup](deployment.md#multi-replica-setup)** — the shared
   session, rate-limit and secret configuration every fleet needs.
+- **[Background jobs](jobs.md#backend-selection-autumntoml)** and
+  **[Multi-replica scheduled tasks](scheduled-multi-replica.md)** — the durable
+  queue and the advisory-lock scheduler a fleet needs instead of the per-process
+  defaults.
 - **Alert on drift** — wire `autumn deploy status --strict` into cron so a fleet
   that quietly stopped converging pages someone.

--- a/docs/guide/fleet-deploys.md
+++ b/docs/guide/fleet-deploys.md
@@ -394,6 +394,40 @@ cannot be read is reported as `release unknown` and explicitly **not** counted a
 version drift. A false "your fleet is mixed" alarm at 3 am is worse than no
 alarm.
 
+That exclusion is about *version* drift only. A **reachable** host that proved it
+has a `current` symlink, yet resolves to no readable release, is now **state**
+drift and `--strict` exits non-zero on it (it was previously reported without
+counting). Its row says so:
+
+```
+⚠️  this host has a `current` symlink but the release it points at could not be
+read (a broken symlink or a missing releases dir) — repair it before the next
+deploy, which would record that unresolvable target as this host's rollback point
+```
+
+Two more state-drift reasons come from the maintenance probe, and both name the
+action they need:
+
+- `the live slot unit could not be read, so which maintenance flag file this
+  host's app polls is unknown — the maintenance column reports ? rather than
+  guessing` — inspect the unit on that host; the row's maintenance cell reads
+  `maintenance ?` instead of a confident `ON`/`off`.
+- `this host's app polls a release-local maintenance flag file, not the shared
+  one (its slot unit predates AUTUMN_MAINTENANCE_FLAG_FILE) — redeploy it so
+  maintenance survives cutovers` — **redeploy that host.** Until you do, its flag
+  is orphaned by the next cutover and a fleet-wide `deploy maintenance` reaches
+  it only best-effort.
+
+> **A broken app config no longer takes `deploy status` offline.** `status` needs
+> only `[server] port` from your application config, so a config that fails to
+> validate under the deploy profile is no longer fatal to it: it prints a caveat
+> on **stderr** (in `--json` mode too, leaving stdout's shape intact) naming the
+> config error and the declared port it is probing against, then reports the
+> fleet anyway. `deploy check`, `up` and `rollback` still refuse — they grade and
+> upload runtime *values*, so an invalid config has to stop them. That asymmetry
+> is deliberate: the read-only incident command stays available, the
+> state-changing ones do not.
+
 Each row also carries a `last deploy` cell — the last action that host
 *completed* (`deployed`, `rolled back` or `torn down`, with the host's UTC time;
 `?` when the marker is absent or unreadable). Mid-incident that is what tells a
@@ -512,6 +546,24 @@ autumn migrate
 # 4. Reopen.
 autumn deploy maintenance off
 ```
+
+Step 2 is a real check, not a formality. The `maintenance` column reports the
+flag file **the host's running slot unit actually polls** — resolved from that
+unit's `Environment=AUTUMN_MAINTENANCE_FLAG_FILE`, or from its
+`WorkingDirectory` plus the legacy relative `tmp/autumn-maintenance.json` when
+the unit predates that override. So read it as three answers, not two:
+
+| Cell | What it means | What to do |
+|---|---|---|
+| `maintenance ON` | The file that host's running unit polls exists. | Nothing — the window is closed on that host. |
+| `maintenance off` | That file does not exist. | The host is still serving normally. |
+| `maintenance ?` | The live slot unit could not be read, so *which* file the app polls is unproven. | Inspect the unit; never read this as "off". On a `deployed` host it is also state drift. |
+
+A host whose unit predates the shared flag path reads its **release-local** file
+here — true for that host, and flagged as state drift with `redeploy it so
+maintenance survives cutovers`. Note the column's scope: it proves which file the
+unit polls and whether that file is there, not what the process currently holds
+in memory — the app picks the change up on its own 500 ms poll.
 
 Four things to know before you run it:
 

--- a/docs/guide/fleet-deploys.md
+++ b/docs/guide/fleet-deploys.md
@@ -538,11 +538,37 @@ to. Restore it by hand, then deploy the fleet again.
 
 ### After any halted rollout: check the schema
 
-An automatic compensation restores **binaries only**. If the rollout got far
-enough to migrate, the schema is still forward while the binaries are back. That
-is safe *if* your migrations are expand/contract (below) and alarming if they are
-not — so confirm it explicitly rather than assuming the rollback undid
-everything.
+**The trigger is the migration, not the compensation.** If the rollout got far
+enough to reach the host carrying the migration, the schema is forward — whether
+or not the fleet ever compensated anything. That is safe *if* your migrations are
+expand/contract (below) and alarming if they are not, so confirm it explicitly
+rather than assuming the halt undid everything.
+
+The `Fleet state:` summary states which of three things is true, and it is worth
+reading the exact sentence rather than skimming for the ⚠️:
+
+- **Some host is still on the new release** → `the schema has moved; from here an
+  automatic rollback restores BINARIES only — it never rolls a migration back`.
+  Forward-looking: it describes what a rollback *you* run next will not undo.
+- **The fleet actually put a host back** — restored it to its previous release,
+  or removed its just-completed first deploy → `the compensating rollback
+  restored BINARIES only — the migration that already ran was NOT rolled back;
+  confirm the schema still fits the release now serving`. A compensation that
+  only **failed** does not produce this line: that host is still serving the new
+  release, so it gets the forward-looking note above instead. Both lines appear
+  together when a halt compensated some hosts and left others forward.
+- **Nothing is forward and nothing was compensated** — the migrating host failed
+  after `migrate` but before its own cutover (a `readiness-gate` timeout is the
+  usual shape) and tore its candidate down, so every later host was never touched
+  → `no host is serving the new release, but the migration that already ran was
+  NOT rolled back — the binaries went back and the schema did not; confirm the
+  release now serving still fits the migrated schema`. This is the one that reads
+  like a clean no-op and is not: the table is all "previous release still
+  serving" rows, and the database has already moved on.
+
+A fleet where *every* host is a first deploy schedules no migration at all, so it
+prints none of these — the prologue already told you to run `autumn migrate`
+yourself.
 
 ---
 

--- a/docs/guide/fleet-deploys.md
+++ b/docs/guide/fleet-deploys.md
@@ -415,8 +415,14 @@ action they need:
 - `this host's app polls a release-local maintenance flag file, not the shared
   one (its slot unit predates AUTUMN_MAINTENANCE_FLAG_FILE) — redeploy it so
   maintenance survives cutovers` — **redeploy that host.** Until you do, its flag
-  is orphaned by the next cutover and a fleet-wide `deploy maintenance` reaches
-  it only best-effort.
+  is orphaned by the next cutover, and a fleet-wide `deploy maintenance` has to
+  write that release-local file as a second write (resolved from the same live
+  slot unit) — reporting the host as a `PARTIAL` failure if it cannot.
+
+The first reason is also the one that makes `autumn deploy maintenance` fail
+closed on that host: if the live slot unit cannot be read, the fan-out writes the
+shared flag and then reports the host as `PARTIAL` with a non-zero exit, rather
+than guessing at a path from the `current` symlink.
 
 > **A broken app config no longer takes `deploy status` offline.** `status` needs
 > only `[server] port` from your application config, so a config that fails to
@@ -427,6 +433,20 @@ action they need:
 > upload runtime *values*, so an invalid config has to stop them. That asymmetry
 > is deliberate: the read-only incident command stays available, the
 > state-changing ones do not.
+>
+> `autumn deploy maintenance` is on the available side of that line too, for the
+> same reason: a window gets closed mid-incident. It prints the same caveat, then
+> continues against the declared port — which it uses **only** to identify which
+> slot unit each host is running:
+>
+> ```
+> ⚠️  this project's configuration does not validate under the `production` deploy
+> profile: <the config error>
+>    `deploy maintenance` continues against the DECLARED `[server] port = 80` for
+> that profile (read without validation); it uses that port only to identify which
+> slot unit each host is running. `autumn deploy check`/`up` still refuse to run
+> until the config is fixed.
+> ```
 
 Each row also carries a `last deploy` cell — the last action that host
 *completed* (`deployed`, `rolled back` or `torn down`, with the host's UTC time;
@@ -565,7 +585,7 @@ maintenance survives cutovers`. Note the column's scope: it proves which file th
 unit polls and whether that file is there, not what the process currently holds
 in memory — the app picks the change up on its own 500 ms poll.
 
-Four things to know before you run it:
+Five things to know before you run it:
 
 - **It is not a drain.** Every host stays in your load-balancer pool and answers
   user traffic with `503`. If the work requires *zero* traffic reaching the app,
@@ -574,6 +594,31 @@ Four things to know before you run it:
   3 stay in maintenance and are named in the summary; the command exits non-zero.
   Reversing them automatically would push users straight back into the window you
   are closing. Reversing by hand (`autumn deploy maintenance off`) is your call.
+  The `Changed anyway: …` line lists only the hosts that changed **fully** — a
+  partially-changed host is named on the failed side instead, so never treat that
+  line as "everything except these is done".
+- **A `PARTIAL` row means that host may still be serving traffic.** The fan-out
+  writes the shared flag first and then, when the host's live slot unit polls a
+  different file (a unit deployed before the shared path existed), that file too.
+  If the live unit cannot be read — or that second write fails — the row is:
+
+  ```
+  ❌ web-3  PARTIAL — shared flag written, but the file this host's RUNNING unit
+  polls was NOT (failed at `detect-maintenance-flag`), so this host may still be
+  serving traffic
+  ```
+
+  This **counts as a failure** and the command exits non-zero, even though the
+  host did change. Treat that host as **not maintained**: its shared flag is set,
+  but a unit that predates the shared path ignores it entirely, so it may still
+  be taking write traffic. Do not start the destructive work until you have
+  either fixed it or accepted it — run `autumn deploy status` to see what that
+  host's unit actually polls (a `maintenance ?` cell means the unit still cannot
+  be read), inspect
+  `/etc/systemd/system/{service}-{slot}.service` on the host, and redeploy it so
+  its unit carries `AUTUMN_MAINTENANCE_FLAG_FILE`. The same row on `off` ends
+  `so this host may still be in maintenance` — there, the host is the one still
+  gated after you thought you had reopened.
 - **The flag survives deploys.** Deploy-managed hosts read
   `{app_dir}/shared/autumn-maintenance.json`, in the shared directory, because
   `autumn deploy` stamps `AUTUMN_MAINTENANCE_FLAG_FILE` into every slot unit. A

--- a/docs/guide/fleet-deploys.md
+++ b/docs/guide/fleet-deploys.md
@@ -395,10 +395,13 @@ version drift. A false "your fleet is mixed" alarm at 3 am is worse than no
 alarm.
 
 Each row also carries a `last deploy` cell — the last action that host
-*completed* (`deployed` or `rolled back`, with the host's UTC time; `?` when the
-marker is absent or unreadable). Mid-incident that is what tells a compensated
-host apart from one that simply deployed, since both read back healthy and on
-the same release. Mind its scope: a deploy that failed *before* cutover never
+*completed* (`deployed`, `rolled back` or `torn down`, with the host's UTC time;
+`?` when the marker is absent or unreadable). Mid-incident that is what tells a
+compensated host apart from one that simply deployed, since both read back
+healthy and on the same release. A host the rollout compensated by removing its
+first deploy reads `torn down <time>`, which is how you tell it from a host that
+was never deployed at all — that one reads `?`. Mind its scope: a deploy that
+failed *before* cutover never
 rewrites it, so it is that host's own last completed action rather than a
 verdict on the last rollout, and it is reported, never counted as drift.
 

--- a/docs/guide/maintenance-mode.md
+++ b/docs/guide/maintenance-mode.md
@@ -36,7 +36,10 @@ Docker-compose mount, a Fly.io shared volume) reacts in lock-step.
 > machine it runs on. For hosts managed by `autumn deploy` (`[deploy] host` or
 > `[deploy] hosts`), use
 > [`autumn deploy maintenance on|off`](#fleet-wide-maintenance-autumn-deploy-maintenance),
-> which writes the same flag file to every configured host over SSH.
+> which writes the same flag file to every configured host over SSH. Running the
+> local command *on* a deploy-managed host does not help either — it writes a
+> path the app no longer reads, silently and with exit `0`. See
+> [Where the flag file lives](#where-the-flag-file-lives).
 
 ### Where the flag file lives
 
@@ -59,6 +62,26 @@ the default cwd-relative path a cutover would orphan an active maintenance flag
 and silently un-maintain the host, and the blue and green slots could not see
 each other's flag at all. The `shared/` directory survives cutovers, rollbacks
 and pruning, and both slots read it.
+
+> **On a deploy-managed host, the local `autumn maintenance` command no longer
+> does anything.** `autumn maintenance on|off` always writes and removes
+> `tmp/autumn-maintenance.json` relative to its own working directory — it is a
+> separate process from the app, it does not read the unit's `Environment=`, and
+> it has no flag to point it elsewhere. On a host deployed by `autumn deploy`,
+> the app reads `{app_dir}/shared/autumn-maintenance.json`, so SSH-ing in and
+> running `autumn maintenance on` writes a file nothing reads: the command exits
+> `0`, and the host keeps serving traffic normally. There is no error to warn
+> you.
+>
+> **On deploy-managed hosts, use
+> [`autumn deploy maintenance on|off`](#fleet-wide-maintenance-autumn-deploy-maintenance)**
+> — from your workstation or CI, not from the host. It writes the path the slot
+> units actually point at (and, for a host still running a unit deployed before
+> this existed, the old release-relative path as well), on every configured host,
+> and reports per host what it changed. The local command remains the right tool
+> for local development and for replicas that share a working directory
+> (docker-compose, a Fly.io volume) — anywhere the app and the CLI see the same
+> directory and no unit is overriding the path.
 
 When maintenance is active, all gated requests receive **503 Service Unavailable**
 with `Retry-After: 120`. The app never returns 200 for application routes while

--- a/docs/guide/maintenance-mode.md
+++ b/docs/guide/maintenance-mode.md
@@ -83,6 +83,28 @@ and pruning, and both slots read it.
 > (docker-compose, a Fly.io volume) — anywhere the app and the CLI see the same
 > directory and no unit is overriding the path.
 
+**`autumn deploy status` resolves this per host rather than assuming it.** Its
+maintenance column does not read one fixed path: for each host it reads the
+**live slot unit** and resolves the flag file that unit makes the app poll —
+`Environment=AUTUMN_MAINTENANCE_FLAG_FILE` when present, otherwise the unit's
+`WorkingDirectory` plus the relative default above — which is the same rule the
+runtime applies. Reading the shared path unconditionally would lie in both
+directions: `off` for a maintained host whose unit polls elsewhere, `ON` for a
+host still taking traffic.
+
+So a host deployed **before** slot units carried
+`AUTUMN_MAINTENANCE_FLAG_FILE` reports its release-local
+`{release_dir}/tmp/autumn-maintenance.json` — the truth for that host — and the
+row also carries a drift reason saying the app polls a release-local flag rather
+than the shared one, whose remedy is to **redeploy that host**. When the live
+slot unit cannot be read at all, the cell reads `maintenance ?` — never a
+confident `off` — and on a host reported as `deployed` that carries a drift
+reason of its own (a host with nothing deployed has no slot unit to read, and is
+already reported as such).
+The column reports which file the running unit polls and whether that file
+exists — it is not a statement about the app's in-memory state, which follows on
+the next 500 ms poll.
+
 When maintenance is active, all gated requests receive **503 Service Unavailable**
 with `Retry-After: 120`. The app never returns 200 for application routes while
 the flag is present.
@@ -340,7 +362,11 @@ Three behaviours worth knowing:
   balancer if you need a host out of rotation.
 
 `autumn deploy status` reports the maintenance flag per host, in its own column
-next to readiness, precisely because the two are orthogonal. See the
+next to readiness, precisely because the two are orthogonal. The cell is
+three-valued — `maintenance ON` / `maintenance off` / `maintenance ?` — and
+reports the flag file that host's *running* slot unit polls; see
+[Where the flag file lives](#where-the-flag-file-lives). In `--json` the same
+field is `true` / `false` / `null`, `null` being the unproven case. See the
 [fleet deploys guide](fleet-deploys.md#runbook-a-fleet-wide-maintenance-window)
 for the full window runbook.
 

--- a/docs/guide/maintenance-mode.md
+++ b/docs/guide/maintenance-mode.md
@@ -77,8 +77,10 @@ and pruning, and both slots read it.
 > [`autumn deploy maintenance on|off`](#fleet-wide-maintenance-autumn-deploy-maintenance)**
 > — from your workstation or CI, not from the host. It writes the path the slot
 > units actually point at (and, for a host still running a unit deployed before
-> this existed, the old release-relative path as well), on every configured host,
-> and reports per host what it changed. The local command remains the right tool
+> this existed, the old release-relative path as well — resolved from that host's
+> **live slot unit**, not from its `current` symlink), on every configured host,
+> and reports per host what it changed, failing closed on any host whose live unit
+> it could not read. The local command remains the right tool
 > for local development and for replicas that share a working directory
 > (docker-compose, a Fly.io volume) — anywhere the app and the CLI see the same
 > directory and no unit is overriding the path.
@@ -346,20 +348,52 @@ is deployed.
 Three behaviours worth knowing:
 
 - **Best-effort, aggregate, never reversed.** Every host is attempted, a per-host
-  table names what changed, and the command exits non-zero if any host failed.
-  The hosts that *did* change are deliberately **not** rolled back — that would
-  push users straight back into the window you are closing — so the summary names
-  them and the decision is yours.
-- **It writes the shared flag path** (`{app_dir}/shared/autumn-maintenance.json`)
-  that deploy-managed slot units point `AUTUMN_MAINTENANCE_FLAG_FILE` at. For a
-  host still running a unit deployed before that existed, `on` also writes the
-  old release-relative path; if the host's `current` release cannot be resolved,
-  its row says the shared flag only was written.
+  table names what changed, and the command exits non-zero if any host failed —
+  including a host that only *partially* changed (see the next bullet). The hosts
+  that *did* change are deliberately **not** rolled back — that would push users
+  straight back into the window you are closing — so the summary names them
+  ("Changed anyway: …", fully-changed hosts only) and the decision is yours.
+- **It writes the shared flag path first**
+  (`{app_dir}/shared/autumn-maintenance.json`), the path deploy-managed slot
+  units point `AUTUMN_MAINTENANCE_FLAG_FILE` at. That write is the authoritative
+  one and it goes first, so a host running a current slot unit reacts within its
+  next 500 ms poll even if anything after it fails. For a host still running a
+  unit deployed *before* that override existed, `on` then also writes the file
+  that unit makes the app poll — resolved from the host's **live slot unit** (the
+  one the proxy is actually serving), the same resolution `deploy status` reads
+  its verdict from, and **never** from the `current` symlink. `current` is
+  rewritten after the proxy flip, so the two disagree exactly when a flip landed
+  and the marker commit did not, and a flag written under `current` would then be
+  a file nothing polls. Two rows follow from that:
+
+  ```
+  ⚠️  host-b  maintenance enabled (shared flag only — no release is promoted on
+  this host, so no running unit polls a release-local flag)
+  ❌ host-c  PARTIAL — shared flag written, but the file this host's RUNNING unit
+  polls was NOT (failed at `detect-maintenance-flag`), so this host may still be
+  serving traffic
+  ```
+
+  The first is a **success**: nothing is promoted, so there is no running unit
+  and the shared write is the whole job. The second **counts as a failure** and
+  the command exits non-zero: the shared flag changed, but the file the running
+  unit polls did not, because that unit could not be read or the write to it
+  failed. `on` never claims a host is maintained when it could not prove which
+  file that host polls, and `off` never claims to have removed one (its rows read
+  `maintenance disabled …` and `shared flag removed …`, ending `so this host may
+  still be in maintenance`).
 - **It does not drain a host from your load balancer.** `/ready` stays `200`
   while maintenance is on — by design, since gating it would eject every host
   from the pool the moment maintenance was enabled. A maintained host keeps
   taking traffic and answers it with `503` + `Retry-After`. Drain at the load
   balancer if you need a host out of rotation.
+
+Like `autumn deploy status`, this command **still runs when your app config does
+not validate** under the deploy profile — a window is closed mid-incident, and an
+unrelated invalid setting must not block it. It prints the same caveat on stderr
+naming the config error, then continues against the declared `[server] port` read
+without validation, which it uses *only* to identify which slot unit each host is
+running. `autumn deploy check`/`up` still refuse until the config is fixed.
 
 `autumn deploy status` reports the maintenance flag per host, in its own column
 next to readiness, precisely because the two are orthogonal. The cell is

--- a/docs/guide/maintenance-mode.md
+++ b/docs/guide/maintenance-mode.md
@@ -30,6 +30,36 @@ alongside the app and needs no IPC or HTTP endpoint to communicate the state
 change. Any replica that can see the same working directory (local dev, a
 Docker-compose mount, a Fly.io shared volume) reacts in lock-step.
 
+> **"Same working directory" is the limit of that lock-step.** Replicas on
+> *different machines* do not see each other's flag file, so the local
+> `autumn maintenance` cannot gate a multi-host fleet — it only writes the
+> machine it runs on. For hosts managed by `autumn deploy` (`[deploy] host` or
+> `[deploy] hosts`), use
+> [`autumn deploy maintenance on|off`](#fleet-wide-maintenance-autumn-deploy-maintenance),
+> which writes the same flag file to every configured host over SSH.
+
+### Where the flag file lives
+
+The default path is `tmp/autumn-maintenance.json`, **relative to the process's
+working directory**. Set `AUTUMN_MAINTENANCE_FLAG_FILE` to an absolute path to
+put it somewhere else; the app reads that variable both at startup and in the
+500 ms poller, so the two can never disagree. An unset or blank value falls back
+to the default, so an app that does not set it is unaffected.
+
+Hosts deployed by `autumn deploy` get this automatically. Each slot unit is
+written with
+
+```ini
+Environment=AUTUMN_MAINTENANCE_FLAG_FILE=/srv/autumn/myapp/shared/autumn-maintenance.json
+```
+
+pointing at the per-app `shared/` directory. That matters because a slot unit's
+`WorkingDirectory` is the **release** directory, which is new on every deploy: on
+the default cwd-relative path a cutover would orphan an active maintenance flag
+and silently un-maintain the host, and the blue and green slots could not see
+each other's flag at all. The `shared/` directory survives cutovers, rollbacks
+and pruning, and both slots read it.
+
 When maintenance is active, all gated requests receive **503 Service Unavailable**
 with `Retry-After: 120`. The app never returns 200 for application routes while
 the flag is present.
@@ -50,6 +80,11 @@ autumn maintenance off
 
 # Check current status (also surfaced by `autumn doctor`)
 autumn doctor
+
+# Same thing, but on every host `autumn deploy` manages (over SSH)
+autumn deploy maintenance on --message "Down for scheduled maintenance."
+autumn deploy maintenance off
+autumn deploy status            # per-host maintenance + readiness columns
 ```
 
 ---
@@ -244,6 +279,50 @@ calling `autumn migrate` without `--with-maintenance`.
 
 ---
 
+## Fleet-wide maintenance (`autumn deploy maintenance`)
+
+The commands above write **this machine's** working directory. For hosts you
+deploy to with [`autumn deploy`](deployment.md), use the deploy-scoped verb
+instead — it fans the same flag file out to every configured host over SSH:
+
+```bash
+autumn deploy maintenance on --message "Upgrading database schema"
+autumn deploy maintenance on --readonly --allow-ips 10.0.0.0/8
+autumn deploy maintenance on --bypass-header X-Dev-Bypass:mytoken
+autumn deploy maintenance off
+```
+
+It applies to the deploy-configured target(s) — `[deploy] host` (one server) or
+`[deploy] hosts` (a fleet) — and takes exactly the same flags as
+`autumn maintenance on`, because both write the same wire format. Running apps
+react within the same 500 ms poll interval; nothing is restarted and no release
+is deployed.
+
+Three behaviours worth knowing:
+
+- **Best-effort, aggregate, never reversed.** Every host is attempted, a per-host
+  table names what changed, and the command exits non-zero if any host failed.
+  The hosts that *did* change are deliberately **not** rolled back — that would
+  push users straight back into the window you are closing — so the summary names
+  them and the decision is yours.
+- **It writes the shared flag path** (`{app_dir}/shared/autumn-maintenance.json`)
+  that deploy-managed slot units point `AUTUMN_MAINTENANCE_FLAG_FILE` at. For a
+  host still running a unit deployed before that existed, `on` also writes the
+  old release-relative path; if the host's `current` release cannot be resolved,
+  its row says the shared flag only was written.
+- **It does not drain a host from your load balancer.** `/ready` stays `200`
+  while maintenance is on — by design, since gating it would eject every host
+  from the pool the moment maintenance was enabled. A maintained host keeps
+  taking traffic and answers it with `503` + `Retry-After`. Drain at the load
+  balancer if you need a host out of rotation.
+
+`autumn deploy status` reports the maintenance flag per host, in its own column
+next to readiness, precisely because the two are orthogonal. See the
+[fleet deploys guide](fleet-deploys.md#runbook-a-fleet-wide-maintenance-window)
+for the full window runbook.
+
+---
+
 ## `autumn doctor` integration
 
 `autumn doctor` includes a maintenance-mode check. It reports:
@@ -395,12 +474,14 @@ Fly.io setup.
 | Migration safety | [deployment.md](deployment.md) | Ensures migrations run before web replicas start (schema-first rollout). |
 | Graceful shutdown | [deployment.md](deployment.md) | Ensures in-flight requests complete before the process exits (SIGTERM → drain → exit). |
 | Maintenance mode | This guide | Stops new requests from reaching the application while a maintenance operation runs. |
+| `autumn deploy maintenance` | [fleet-deploys.md](fleet-deploys.md) | Applies the same gate to **every deploy-managed host at once** over SSH, so a fleet enters and leaves the window together. Gates traffic; does **not** drain hosts from the load balancer. |
 
-The three features are complementary. A typical zero-downtime destructive
-migration uses all three: graceful shutdown ensures no request is abandoned
+These features are complementary. A typical zero-downtime destructive
+migration uses the first three: graceful shutdown ensures no request is abandoned
 mid-flight when the old replica exits; migration safety ensures the schema is
 updated before new replicas serve traffic; maintenance mode ensures writes are
-paused while the migration runs.
+paused while the migration runs. On a multi-host fleet, the fourth is how you
+open and close that window on every host at once.
 
 ---
 

--- a/docs/guide/staged-deploys.md
+++ b/docs/guide/staged-deploys.md
@@ -11,6 +11,7 @@ mode fit together to give you a safe rollout in each case.
 | Rolling | Standard incremental rollout | Full — probes + drain handle it automatically |
 | Blue/green | Instant cutover with easy rollback | Full — probe drain + LB switch |
 | Canary | Gradual traffic shift with automated promotion | Framework primitives — version-labelled metrics, a canary-route extractor, and a controller-driven rollback signal (see [Canary deploys](#canary-deploys)) |
+| Rolling across your own VPS fleet | Several app servers you own, behind your own load balancer, with no orchestrator | Full — `autumn deploy up` with `[deploy] hosts` rolls the hosts one at a time (per-host blue/green, migrations exactly once, halt-and-roll-back on failure); see the [fleet deploys guide](fleet-deploys.md) |
 
 ---
 
@@ -237,9 +238,15 @@ Then tear down green, diagnose the issue, and re-deploy when ready.
 - Autumn's probe contracts give you a deterministic signal for when green is
   ready (`/ready` → 200) and when blue has finished draining (process exits
   cleanly after SIGTERM).
-- The framework does not manage the LB switch — that is an operator or platform
-  concern. Autumn gives you the health signals; you decide when to pull the
-  lever.
+- **Autumn never distributes traffic between hosts.** How much traffic each
+  machine receives is a load-balancer concern — Autumn gives you the health
+  signals and you (or your platform) decide when to pull the lever. What Autumn
+  *does* manage is the blue/green switch **within** a single deploy-managed host:
+  `autumn deploy up` stands the candidate up on that host's idle slot,
+  health-gates it, and flips the host's own kamal-proxy atomically. Across
+  several hosts (`[deploy] hosts`) it repeats that host by host — still without
+  touching your load balancer's membership. See the
+  [fleet deploys guide](fleet-deploys.md).
 - Use `autumn doctor` on the green environment before switching traffic to catch
   misconfigured secrets, missing database URLs, or active maintenance flags:
 
@@ -435,6 +442,8 @@ the controller triggers.
 | High-risk release requiring fast rollback | Blue/green |
 | Incident response — stop traffic immediately | [Maintenance mode](maintenance-mode.md) |
 | Gradual rollout with automated promotion | [Canary](#canary-deploys) — platform traffic weights gated on Autumn's version-labelled metrics, with `autumn canary rollback` for a clean drain |
+| Several VPS hosts you own, no orchestrator | [`autumn deploy up` with `[deploy] hosts`](fleet-deploys.md) — serial rolling deploy driven by the CLI, per-host blue/green, one migration per fleet |
+| A whole fleet must pause writes at once | [`autumn deploy maintenance on`](fleet-deploys.md#runbook-a-fleet-wide-maintenance-window) — note it gates traffic, it does not drain hosts from the load balancer |
 
 ---
 

--- a/skills/autumn-web/SKILL.md
+++ b/skills/autumn-web/SKILL.md
@@ -2119,7 +2119,20 @@ order — except post-cutover housekeeping failures (`record-proxy-options`,
 and continues, and hosts whose rollback target is unprovable, which are reported
 for manual recovery rather than guessed at. **Rollback restores binaries only —
 no migration is ever rolled back**, so tell users to write expand/contract
-migrations. `--only <HOST>` (repeatable, `up` and `rollback`) is a repair lever
+migrations. The closing `Fleet state:` summary says which of THREE things is
+true, gated on the migration having been reached (never on whether the fleet
+compensated): a host still on the new release → `the schema has moved …`; the
+fleet actually restored a host or removed its just-completed first deploy → `the
+compensating rollback restored BINARIES only …` (a compensation that only FAILED
+leaves that host forward, so it takes the first note, and both can print
+together); nothing forward and nothing compensated, because the migrating host
+failed after `migrate` but before its cutover and tore its own candidate down →
+`no host is serving the new release, but the migration that already ran was NOT
+rolled back …`. An all-first-deploy fleet migrates nowhere and prints none of
+them. **A failed SINGLE-host deploy prints no summary and so warns about none of
+this** (known gap, #2276) — if a user's one-host `deploy up` failed, tell them to
+check `autumn migrate status` before assuming nothing was applied.
+`--only <HOST>` (repeatable, `up` and `rollback`) is a repair lever
 that warns about a mixed fleet; `--no-rollback` halts and freezes instead.
 `--only` narrowed to ONE host takes the single-host path: `deploy rollback --only
 <host>` prints no fleet state table and keeps the HARD preflight gate (a

--- a/skills/autumn-web/SKILL.md
+++ b/skills/autumn-web/SKILL.md
@@ -2094,7 +2094,12 @@ host = "203.0.113.10"                            # ONE server
 
 `host` and `hosts` are **mutually exclusive** (both set = refused), blank and
 duplicate entries are refused, and **the `hosts` order IS the rollout order**.
-`AUTUMN_DEPLOY__HOSTS` is the CSV env override and replaces the whole list.
+`AUTUMN_DEPLOY__HOSTS` is the CSV env override and replaces the whole list. Env
+wins over TOML for BOTH spellings: a non-empty `AUTUMN_DEPLOY__HOSTS` clears a
+TOML `[deploy] host` (and vice versa), so an env retarget never produces the
+mutually-exclusive refusal. Setting BOTH env spellings non-empty is still refused
+(ambiguous rollout order — an operator error, not a precedence question), and an
+empty/blank value still means *unset*, leaving the TOML spelling alone.
 
 With `hosts`, `deploy up` rolls the fleet **one host at a time** in declaration
 order — each host runs the unchanged per-host blue/green cutover against its own
@@ -2149,15 +2154,42 @@ one row per host (mode, release from the `current` symlink, live slot, `/ready`
 code, maintenance flag, proxy port, last deploy result, drift reasons) plus
 `version_drift` (hosts on different releases) and `state_drift` (per-host marker
 damage that fails the NEXT deploy closed). An unreachable host is a row, not an
-abort; an unreadable release is reported as unknown and is **not** drift.
+abort; an unreadable release is never **version** drift — but a REACHABLE host
+with a `current` symlink that resolves to no readable release IS state drift and
+exits non-zero under `--strict`.
 `last deploy` is the last action that host COMPLETED (`deployed` / `rolled back`
 / `torn down` + the host's UTC time, `?` when unreadable) — a deploy that failed before cutover
 never rewrites it, so it is never a verdict on the last rollout, and it is
-reported, not drift. `--strict` exits non-zero on any drift (cron-alertable);
+reported, not drift.
+
+The **maintenance cell is three-valued** — `maintenance ON` / `maintenance off` /
+`maintenance ?` — and reports the flag file the host's RUNNING slot unit polls,
+resolved on the host from that unit's `Environment=AUTUMN_MAINTENANCE_FLAG_FILE`
+(falling back to its `WorkingDirectory` + the legacy relative
+`tmp/autumn-maintenance.json`), not the shared path unconditionally. Never
+describe it as the app's in-memory state — it is which file the unit polls plus
+whether that file exists. Two state-drift reasons come from this probe (both only
+on a `deployed` host): the live slot unit could not be read (cell reads `?`,
+nothing is guessed), and the host's
+app polls a release-local flag rather than the shared one — a unit predating
+`AUTUMN_MAINTENANCE_FLAG_FILE`, whose remedy is to **redeploy that host**. So a
+host deployed before this feature reports its release-local flag until redeployed.
+
+`--strict` exits non-zero on any drift (cron-alertable);
 `--json` is a stable contract: `hosts[]` with `host`, `reachable`, `mode`,
 `release`, `live_slot`, `ready`, `maintenance`, `proxy_port`, `last_deploy`
-(`{result, at}` or null), `drift[]`, plus `version_drift`, `state_drift[]`,
-`drifted`.
+(`{result, at}` or null — `result` is `"deployed"`, `"rolled back"` or
+`"torn down"`), `drift[]`, plus `version_drift`, `state_drift[]`, `drifted`.
+`maintenance` is `true` / `false` / **`null`** (null = the CLI could not prove
+which flag file that host's running unit polls); both `false` and `null` are
+falsy, so an existing `maintenance == true` check is unaffected.
+
+Unlike `check`/`up`/`rollback`, `status` does NOT abort when the app config fails
+to validate under the deploy profile: it prints a caveat on **stderr** (text and
+`--json` alike, so stdout's shape is untouched) naming the config error and the
+DECLARED `[server] port` it probes against, then reports the fleet. `check`, `up`
+and `rollback` still refuse, deliberately — they grade and upload runtime values
+(signing secret, DB URL), so an invalid config must stop them.
 
 `autumn deploy maintenance on|off` fans maintenance mode out to every configured
 host over SSH (same flags and wire format as the local `autumn maintenance on`,

--- a/skills/autumn-web/SKILL.md
+++ b/skills/autumn-web/SKILL.md
@@ -2101,7 +2101,13 @@ order — each host runs the unchanged per-host blue/green cutover against its o
 kamal-proxy and must finish before the next starts, so the rest of the fleet
 keeps serving. One release id per run. **Migrations run exactly once**, on the
 first host still on a previous release, before its cutover; an all-first-deploy
-fleet migrates nowhere and warns, naming `autumn migrate`. A failure **halts**
+fleet migrates nowhere and warns, naming `autumn migrate`. **When a user adds
+hosts to an existing fleet, tell them to list the already-deployed host(s)
+first**: a first-deploy host ahead of the migrating host cuts over with no
+migrate step, so it serves the new release against the OLD schema until the
+rollout reaches the migrating host. The rollout warns by name (it never reorders
+the list — declaration order is the contract), and the warning is gated on a
+writable DB URL being resolvable locally. A failure **halts**
 the rollout and (by default) rolls the already-cut-over hosts back in reverse
 order — except post-cutover housekeeping failures (`record-proxy-options`,
 `drain-old`, `prune`), which leave the host live and healthy so the rollout warns
@@ -2110,6 +2116,26 @@ for manual recovery rather than guessed at. **Rollback restores binaries only �
 no migration is ever rolled back**, so tell users to write expand/contract
 migrations. `--only <HOST>` (repeatable, `up` and `rollback`) is a repair lever
 that warns about a mixed fleet; `--no-rollback` halts and freezes instead.
+`--only` narrowed to ONE host takes the single-host path: `deploy rollback --only
+<host>` prints no fleet state table and keeps the HARD preflight gate (a
+multi-host rollback downgrades a per-host `ssh_reachability` failure to a
+reported row and continues; a one-target run does not). Only the selected hosts
+are reachability-graded, but the topology refusals below key on the *configured*
+host count, so `--only` never unlocks them.
+
+No host is ever **drained** by a rollout: `/ready` never goes 503 for the
+rollout's sake and no host leaves the LB pool — each host is replaced in place
+(candidate on the idle loopback slot, `/ready`-gated there, atomic kamal-proxy
+flip, old slot drained after). Never describe a fleet rollout as draining hosts.
+
+`[jobs] backend = "local"` and `[scheduler] backend = "in_process"` are the
+per-process defaults; on a fleet each host runs its own copy (work never
+balances, queued work dies with the old slot, `unique`/`concurrency` stop being
+fleet-wide, scheduled tasks fire once PER HOST). `deploy up` prints a loud ⚠️
+naming the key(s) in effect whenever more than one host is configured — a
+warning, never a refusal, and nothing else says it (`deploy check`, `deploy plan`,
+`deploy status` and `autumn doctor` are all silent). Tell users to move to
+`postgres`/`redis` before relying on background work across a fleet.
 
 Fleet-unsafe topologies fail closed in the prologue, before any remote command:
 `sqlite://` databases (every host gets the same URL → N independent files),
@@ -2140,7 +2166,11 @@ every host attempted, non-zero if any failed, changed hosts NOT reversed.
 **Maintenance does not drain a host from a load balancer** — `/ready` stays 200
 by design — so never tell a user maintenance mode removes a host from rotation.
 Deploy-managed hosts read `{app_dir}/shared/autumn-maintenance.json` because the
-slot units carry `AUTUMN_MAINTENANCE_FLAG_FILE`.
+slot units carry `AUTUMN_MAINTENANCE_FLAG_FILE`. The local `autumn maintenance`
+has no override for that path — it always writes cwd-relative
+`tmp/autumn-maintenance.json` — so running it ON a deploy-managed host writes a
+file the app never reads and exits 0 with no warning. Always route users to
+`autumn deploy maintenance` for deploy-managed hosts.
 
 See `docs/guide/fleet-deploys.md`, `docs/guide/deployment.md`, and
 `docs/guide/maintenance-mode.md`.

--- a/skills/autumn-web/SKILL.md
+++ b/skills/autumn-web/SKILL.md
@@ -2120,13 +2120,18 @@ warning, not a refusal.
 
 `autumn deploy status [--json] [--strict]` is read-only and safe mid-incident:
 one row per host (mode, release from the `current` symlink, live slot, `/ready`
-code, maintenance flag, proxy port, drift reasons) plus `version_drift` (hosts on
-different releases) and `state_drift` (per-host marker damage that fails the NEXT
-deploy closed). An unreachable host is a row, not an abort; an unreadable release
-is reported as unknown and is **not** drift. `--strict` exits non-zero on any
-drift (cron-alertable); `--json` is a stable contract: `hosts[]` with `host`,
-`reachable`, `mode`, `release`, `live_slot`, `ready`, `maintenance`,
-`proxy_port`, `drift[]`, plus `version_drift`, `state_drift[]`, `drifted`.
+code, maintenance flag, proxy port, last deploy result, drift reasons) plus
+`version_drift` (hosts on different releases) and `state_drift` (per-host marker
+damage that fails the NEXT deploy closed). An unreachable host is a row, not an
+abort; an unreadable release is reported as unknown and is **not** drift.
+`last deploy` is the last action that host COMPLETED (`deployed` / `rolled back`
++ the host's UTC time, `?` when unreadable) — a deploy that failed before cutover
+never rewrites it, so it is never a verdict on the last rollout, and it is
+reported, not drift. `--strict` exits non-zero on any drift (cron-alertable);
+`--json` is a stable contract: `hosts[]` with `host`, `reachable`, `mode`,
+`release`, `live_slot`, `ready`, `maintenance`, `proxy_port`, `last_deploy`
+(`{result, at}` or null), `drift[]`, plus `version_drift`, `state_drift[]`,
+`drifted`.
 
 `autumn deploy maintenance on|off` fans maintenance mode out to every configured
 host over SSH (same flags and wire format as the local `autumn maintenance on`,

--- a/skills/autumn-web/SKILL.md
+++ b/skills/autumn-web/SKILL.md
@@ -2151,7 +2151,7 @@ code, maintenance flag, proxy port, last deploy result, drift reasons) plus
 damage that fails the NEXT deploy closed). An unreachable host is a row, not an
 abort; an unreadable release is reported as unknown and is **not** drift.
 `last deploy` is the last action that host COMPLETED (`deployed` / `rolled back`
-+ the host's UTC time, `?` when unreadable) — a deploy that failed before cutover
+/ `torn down` + the host's UTC time, `?` when unreadable) — a deploy that failed before cutover
 never rewrites it, so it is never a verdict on the last rollout, and it is
 reported, not drift. `--strict` exits non-zero on any drift (cron-alertable);
 `--json` is a stable contract: `hosts[]` with `host`, `reachable`, `mode`,

--- a/skills/autumn-web/SKILL.md
+++ b/skills/autumn-web/SKILL.md
@@ -1888,6 +1888,13 @@ autumn release init --target aws-ecs             # Production AWS path: main.tf/
 autumn release init --target gcp-cloud-run       # GCP path: main.tf/variables.tf/outputs.tf/terraform.tfvars.example (Artifact Registry, Cloud Run, Cloud SQL Postgres behind a VPC connector, Secret Manager, opt-in Memorystore Redis) + .github/workflows/gcp-deploy.yml (#1280); see docs/guide/deployment.md.
 autumn upgrade                   # preview each release's mechanical app-code migrations (renames) as a per-file diff; writes nothing
 autumn upgrade --apply           # take them; --from/--to override the range, --list-migrations shows what ships (#1629)
+autumn deploy check              # SSH/secret/DB/migrate-safety preflight per configured host; `doctor --online` runs the same graders
+autumn deploy plan               # dry-run: representative unit + ordered steps (+ fleet rollout order when `[deploy] hosts` is set)
+autumn deploy up                 # real deploy over SSH; with `[deploy] hosts` a serial rolling deploy across the fleet (#1621)
+autumn deploy up --only web-2 --no-rollback   # narrow to a subset (repair lever, warns about a mixed fleet) / halt-and-freeze on failure
+autumn deploy rollback           # previous release; with `[deploy] hosts` the whole fleet, newest first (`--only <HOST>` for one)
+autumn deploy status --json --strict          # read-only per-host state + version/state drift; --strict exits non-zero on drift (#1621)
+autumn deploy maintenance on --message "…"    # maintenance mode on EVERY deploy host over SSH; `off` reverses (#1621)
 ```
 
 ### Upgrading an app across releases — `autumn upgrade` (unreleased — trunk-dev, issue #1629)
@@ -2073,6 +2080,66 @@ Pointing the offsite bucket at the app's
 own `[storage.s3]` bucket at the same endpoint needs `allow_shared_bucket = true`. See
 `docs/guide/daemon.md`.
 
+### VPS deploys and fleets — `autumn deploy` (unreleased — trunk-dev, issues #1607/#1621)
+
+`autumn deploy {check | plan | up | rollback | status | maintenance on|off}`
+takes a project to a live, zero-downtime service on Linux servers the user owns
+— no Dockerfile, no registry, no PaaS. Configure the target in `autumn.toml`:
+
+```toml
+[deploy]
+host = "203.0.113.10"                            # ONE server
+# hosts = ["10.0.0.1", "10.0.0.2", "10.0.0.3"]   # …or a FLEET (#1621)
+```
+
+`host` and `hosts` are **mutually exclusive** (both set = refused), blank and
+duplicate entries are refused, and **the `hosts` order IS the rollout order**.
+`AUTUMN_DEPLOY__HOSTS` is the CSV env override and replaces the whole list.
+
+With `hosts`, `deploy up` rolls the fleet **one host at a time** in declaration
+order — each host runs the unchanged per-host blue/green cutover against its own
+kamal-proxy and must finish before the next starts, so the rest of the fleet
+keeps serving. One release id per run. **Migrations run exactly once**, on the
+first host still on a previous release, before its cutover; an all-first-deploy
+fleet migrates nowhere and warns, naming `autumn migrate`. A failure **halts**
+the rollout and (by default) rolls the already-cut-over hosts back in reverse
+order — except post-cutover housekeeping failures (`record-proxy-options`,
+`drain-old`, `prune`), which leave the host live and healthy so the rollout warns
+and continues, and hosts whose rollback target is unprovable, which are reported
+for manual recovery rather than guessed at. **Rollback restores binaries only —
+no migration is ever rolled back**, so tell users to write expand/contract
+migrations. `--only <HOST>` (repeatable, `up` and `rollback`) is a repair lever
+that warns about a mixed fleet; `--no-rollback` halts and freezes instead.
+
+Fleet-unsafe topologies fail closed in the prologue, before any remote command:
+`sqlite://` databases (every host gets the same URL → N independent files),
+`[media.mediamtx] enabled = true` (no teardown path), and `[deploy.tls] enabled
+= true` (each host would ACME the same hostname from behind the LB — terminate
+TLS at the load balancer instead). `[database] auto_migrate` on a fleet is a loud
+warning, not a refusal.
+
+`autumn deploy status [--json] [--strict]` is read-only and safe mid-incident:
+one row per host (mode, release from the `current` symlink, live slot, `/ready`
+code, maintenance flag, proxy port, drift reasons) plus `version_drift` (hosts on
+different releases) and `state_drift` (per-host marker damage that fails the NEXT
+deploy closed). An unreachable host is a row, not an abort; an unreadable release
+is reported as unknown and is **not** drift. `--strict` exits non-zero on any
+drift (cron-alertable); `--json` is a stable contract: `hosts[]` with `host`,
+`reachable`, `mode`, `release`, `live_slot`, `ready`, `maintenance`,
+`proxy_port`, `drift[]`, plus `version_drift`, `state_drift[]`, `drifted`.
+
+`autumn deploy maintenance on|off` fans maintenance mode out to every configured
+host over SSH (same flags and wire format as the local `autumn maintenance on`,
+which only writes THIS machine's working directory). Best-effort-and-aggregate:
+every host attempted, non-zero if any failed, changed hosts NOT reversed.
+**Maintenance does not drain a host from a load balancer** — `/ready` stays 200
+by design — so never tell a user maintenance mode removes a host from rotation.
+Deploy-managed hosts read `{app_dir}/shared/autumn-maintenance.json` because the
+slot units carry `AUTUMN_MAINTENANCE_FLAG_FILE`.
+
+See `docs/guide/fleet-deploys.md`, `docs/guide/deployment.md`, and
+`docs/guide/maintenance-mode.md`.
+
 `autumn destroy` mirrors `autumn generate` argument-for-argument and never
 touches a database — it only reverses generated files/migrations.
 
@@ -2225,6 +2292,9 @@ touched crate so examples compile from an external-consumer perspective.
 - `docs/guide/widget-styling.md`
 - `docs/guide/tabs.md`
 - `docs/guide/maintenance-mode.md`
+- `docs/guide/deployment.md`
+- `docs/guide/fleet-deploys.md`
+- `docs/guide/staged-deploys.md`
 - `docs/guide/dev-loop-latency.md`
 - `docs/guide/system-tests.md`
 - `docs/guide/testing.md`

--- a/skills/autumn-web/SKILL.md
+++ b/skills/autumn-web/SKILL.md
@@ -2194,11 +2194,26 @@ and `rollback` still refuse, deliberately — they grade and upload runtime valu
 `autumn deploy maintenance on|off` fans maintenance mode out to every configured
 host over SSH (same flags and wire format as the local `autumn maintenance on`,
 which only writes THIS machine's working directory). Best-effort-and-aggregate:
-every host attempted, non-zero if any failed, changed hosts NOT reversed.
+every host attempted, non-zero if any failed, changed hosts NOT reversed (the
+"Changed anyway: …" line lists only FULLY changed hosts).
 **Maintenance does not drain a host from a load balancer** — `/ready` stays 200
 by design — so never tell a user maintenance mode removes a host from rotation.
 Deploy-managed hosts read `{app_dir}/shared/autumn-maintenance.json` because the
-slot units carry `AUTUMN_MAINTENANCE_FLAG_FILE`. The local `autumn maintenance`
+slot units carry `AUTUMN_MAINTENANCE_FLAG_FILE`; that shared path is written
+FIRST (authoritative — a current unit reacts within 500 ms even if the next write
+fails). For a host whose unit predates that override, a second write goes to the
+file that unit polls, resolved from the host's **live slot unit** — never from
+the `current` symlink, which is rewritten after the proxy flip and so can name a
+release nothing is running. Two rows to recognise: `shared flag only — no release
+is promoted on this host` is a SUCCESS (nothing running polls anything else), and
+`PARTIAL — shared flag written, but the file this host's RUNNING unit polls was
+NOT` is a FAILURE with a non-zero exit (unit unreadable or that write failed) —
+never tell a user such a host is maintained; `on` may have left it serving
+traffic and `off` may have left it gated. Like `status`, `deploy maintenance`
+does NOT abort on a config that fails to validate under the deploy profile: same
+stderr caveat, then it continues against the DECLARED `[server] port`, used only
+to identify which slot unit each host runs (`deploy status --json`'s shape is
+unchanged by any of this). The local `autumn maintenance`
 has no override for that path — it always writes cwd-relative
 `tmp/autumn-maintenance.json` — so running it ON a deploy-managed host writes a
 file the app never reads and exits 0 with no warning. Always route users to

--- a/skills/doctor/SKILL.md
+++ b/skills/doctor/SKILL.md
@@ -71,6 +71,7 @@ These names match what `autumn doctor --json` actually emits in the `name` field
 | `jobs_queue_coverage` **(trunk-dev)** | Add the uncovered queue(s) to a tier's `jobs.pin` in `[jobs.fleet].tiers`, or run an unpinned tier that drains everything (fails once `[jobs.fleet]` is declared and a needed queue is uncovered; informational when `[jobs.fleet]` is absent) |
 | `offsite_backup` **(trunk-dev)** | Set `backup.offsite.s3.bucket`, or set `backup.offsite.allow_shared_bucket = true` if intentionally reusing the app `[storage.s3]` bucket |
 | `edge_target` **(trunk-dev)** | Run `rustup target add wasm32-wasip1` — the project has `#[edge]` routes, so `autumn build` needs that target to compile the edge capsule (passes with "no `#[edge]` routes" when the project has none) |
+| `deploy_host` **(trunk-dev)** | Set a deploy target in `autumn.toml`: `[deploy] host = "<address>"` (one server) **or** `[deploy] hosts = ["<a>", "<b>"]` (a fleet, in rollout order) — never both. Blank or duplicate `hosts` entries are refused (issue #1621) |
 | `edge_routes` **(trunk-dev)** | Fails when an `#[edge]` handler also carries `#[secured]`/`#[authorize]`/`#[step_up]`/`#[throttle]`/`#[intercept]`: remove one of the two — edge routes are unauthenticated read-path routes served without origin middleware. Warns when a marked handler is missing from `edge_routes![]`, or when `src/bin/edge-capsule.rs` is absent |
 
 ## Operator alert checks (unreleased — trunk-dev)
@@ -172,18 +173,48 @@ probes, gated behind the CLI `acme` feature:
 
 Offline stored-cert expiry is also graded. See issue #1858.
 
-## Deploy preflight checks (unreleased — trunk-dev, issue #1607)
+## Deploy preflight checks (unreleased — trunk-dev, issues #1607/#1621)
 
 When a `[deploy]` section is present in `autumn.toml`, `autumn doctor` runs the
 deploy preflight as a config-gated section, emitting deploy-namespaced checks:
-`deploy_config` (the `[deploy]` section parses), `deploy_host` (`[deploy] host`
-is set / SSH-reachable), `deploy_signing_secret`, and `deploy_database_url`. The
+`deploy_config` (the `[deploy]` section parses), `deploy_host` (a deploy target
+is configured), `deploy_ssh_reachability` (`--online` only),
+`deploy_signing_secret`, `deploy_database_url`, and `deploy_migrate_check`. The
 same graders back the standalone `autumn deploy check`, so the offline `doctor`
 and online `deploy check` surfaces report identically. The `[deploy]` profile
 defaults to the **production** profile (`"prod"`). The full flow is
-`autumn deploy {check | plan | up | rollback}` (SSH: install proxy on first
-deploy, zero-downtime cutover with auto-rollback on redeploy, and on-demand
-`rollback`).
+`autumn deploy {check | plan | up | rollback | status | maintenance on|off}`
+(SSH: install proxy on first deploy, zero-downtime cutover with auto-rollback on
+redeploy, on-demand `rollback`, and — with `[deploy] hosts` — a serial rolling
+deploy across a fleet).
+
+### Fleet grading (issue #1621)
+
+The deploy target is a **list**: `[deploy] host` (one server) or `[deploy] hosts`
+(a fleet, in rollout order). `doctor` enumerates it through the same validator
+`autumn deploy check` uses, so a fleet config is graded rather than reported as
+"no target host configured":
+
+- `deploy_host` — **passes** naming every configured host in rollout order
+  (`3 deploy target hosts configured, in rollout order: …`). It **fails** on a
+  malformed spelling — `host` and `hosts` both set, a blank `hosts` entry, or a
+  duplicate entry — with the same hard refusal `autumn deploy check` makes.
+  Remedy: keep either `host` or `hosts`, never both, and make every `hosts` entry
+  a distinct non-blank address.
+- `deploy_ssh_reachability` (`--online`) — probes **every** host and fails if
+  **any** is unreachable, naming the unreachable ones. A broken host spelling
+  fails this check too (there is no list to probe), so the `--json` key set never
+  changes shape.
+
+`doctor` keeps **one check per grader name** even for a fleet — `CheckResult.name`
+is a stable `--json` key — so the per-host detail rides in the `detail` text.
+`autumn deploy check` is the surface that prints one `ssh_reachability` line per
+host, scoped as `ssh_reachability (10.0.0.3)`.
+
+For live per-host state (deployed release, live slot, `/ready`, maintenance flag,
+proxy port, version/state drift) use `autumn deploy status [--json] [--strict]`
+rather than `doctor` — it probes the hosts read-only and `--strict` exits
+non-zero on drift. See `docs/guide/fleet-deploys.md`.
 
 ## SQLite backend awareness (unreleased — trunk-dev, issue #1614)
 


### PR DESCRIPTION
Closes #1621 (Phase 1).

Rolls a release across a small fleet of VPSes with the same zero-downtime guarantees `autumn deploy` already gives one box. Scaling from 1 to N servers becomes a config change: `[deploy] host = "x"` becomes `[deploy] hosts = ["a", "b", "c"]`.

Built TDD in six slices — config, pure planning, rollout driver, compensation, CLI surface, docs/e2e — then reviewed from six independent angles with adversarial verification of every finding, audited against each acceptance criterion, and taken through eight rounds of automated review.

> **⚠️ Read the Verification section before trusting this PR's test status.** CI's `test` job is gated `needs: [lint, meta]`, and `lint` fails on breakage inherited from `trunk-dev` — so **`cargo test --workspace` has never executed in CI on this branch**, and `coverage`/`loom` (gated behind `test`) were skipped on every head. The evidence below is local and partial. This is not a claim that the branch is CI-verified; it is a claim about exactly what was run and where.

## Why CI is red, and why it isn't this PR

`Lint` and `SQLite runtime` fail on `trunk-dev` itself — verified on seven consecutive heads here, including docs-only commits touching **zero** `.rs` files, and on the base commit `d69e5d2`. CI pins `dtolnay/rust-toolchain@stable` and stable has advanced past what the repo was last formatted and linted against (logs show clippy 1.98.0 and a rustfmt diff in `examples/reddit-clone/`, both untouched here). `cargo fmt --all --check` is clean locally across the whole tree.

**Consequence worth stating plainly:** because `lint` gates `test`, this red base is not merely cosmetic — it means no PR targeting `trunk-dev` currently gets its tests run at all. Fixing the base (reformat, or pin the toolchain) unblocks real verification for everyone, not just this branch.

`Documentation build` — the one failure genuinely caused by this PR, four broken intra-doc links to a private item — was fixed and is green.

## How it works

The fleet layer is a **thin, pure orchestration shell above unchanged per-host op builders**. Nothing below `exec::SshTarget` moved. `ResolvedFleet` resolves the shared deploy shape once and varies only the host, so a one-entry `hosts` list is the historical single-server deploy *by construction* rather than by review.

A rollout is: validate every host → probe every host read-only → plan (pure) → execute serially, one host at a time. Nothing mutates until every host has passed preflight and every refusal has been evaluated.

Three structural rules are load-bearing and enforced by tests:

- **Per-host op vectors are never concatenated.** `execute_with_teardown` finds its auto-rollback boundary via the *first* matching label, so a flat fleet-wide vector would classify every later host's pre-flip failure as post-boundary and silently disable teardown. A test asserts each host's vector carries exactly one boundary label.
- **Host identity never enters `RemoteCommand::label`.** Labels are `&'static str` and are load-bearing for boundary matching, `CandidateRolledBack { failed_step }`, and every exact-vector test.
- **One release id per fleet run**, so every host's `current` resolves to the same release and a rollback has a single target.

## Acceptance criteria

| AC | Verdict | Evidence |
|---|---|---|
| **1** — list config; one-entry list ≡ single-server | met (differentially — see below) | `deploy_check_output_is_identical_for_host_and_a_single_entry_hosts_list` drives the real binary and compares stdout+stderr+exit code; `fleet_of_one_matches_todays_single_host_sequence` compares recorded shells, upload paths and modes against the unchanged single-host builders |
| **2** — rolls host-by-host, ≥1 host always serving | ordering proven by unit test; **zero-drop claim unproven — see below** | `rolling_order_replaces_hosts_strictly_in_sequence` proves host k+1's first *mutating* op follows host k's `proxy-flip` on a shared cross-host tape |
| **3** — halt + auto-rollback, never silently mixed | met | `a_post_boundary_functional_failure_compensates_newest_first_including_itself`; `no_rollback_freezes_the_fleet_instead_of_compensating` asserts exactly two flips, i.e. no flip-back |
| **4** — migrations exactly once, before first cutover | met for all-redeploy fleets; **see limitation** for mixed | `fleet_plan_runs_migrations_exactly_once` asserts one `migrate` label across the flattened plan and that it precedes the first flip |
| **5** — fleet-wide maintenance in one command | met | `fleet_maintenance_attempts_every_host_and_reports_the_ones_that_failed` — one host fails, the others still apply, error names "1 of 3", no shell text leaks |
| **6** — per-host release, ready state, last deploy result | met for the three facts; **no #1610 alerting integration** (#2267) | `status_reports_the_last_deploy_result_per_host` covers all three plus the unknown case and the scope note |
| **7** — preflight every host, refuse if any fails | met | `deploy_check_reports_ssh_reachability_per_fleet_host` asserts the failure appears once per host; `deploy up` still hard-gates |
| **8** — "one server to a fleet" guide | met | `docs/guide/fleet-deploys.md`: LB contract, TLS placement, shared-state prerequisites (incl. per-host job/scheduler backends), scale-up walkthrough, drift/partial-rollout and maintenance runbooks |

## Limitations, stated plainly

- **AC-1 is a differential guarantee, not a freeze.** `hosts = ["x"]` is indistinguishable from `host = "x"` *at this commit* — but single-host behaviour is not identical to trunk. Eight changes apply to both spellings equally; the operator-visible ones are a new `probe-release-dir` refusal (a second `deploy up` within the same second now exits 1 where it previously proceeded), SSH `ConnectTimeout`/`ServerAlive*` options, and `Environment=AUTUMN_MAINTENANCE_FLAG_FILE` in the slot unit. All eight are enumerated in `deployment.md`.
- **AC-2, the zero-drop claim is NOT demonstrated.** The two-container e2e that would exercise it has **never been executed** — not here (no Docker or ssh client) and not in CI (its step lives inside the skipped `test` job). Even when it runs, its "load generator" is a ~10 req/s single-threaded **liveness prober** with **no load balancer in the harness**, so it could only ever show that a host answers continuously while its peer is replaced — not zero drops under concurrency or at LB level.
- **AC-4, mixed fleets.** With `hosts = [new, new, old]` the first-deploy hosts cut over *before* the migration runs. Reordering would break the documented declaration-order contract, so the CLI **warns by name** and the guide says to list already-deployed hosts first.
- **AC-2 wording.** No host is ever "drained" in the AC's sense. The mechanism is per-host blue/green behind kamal-proxy; a host's public `/ready` never goes 503.
- **Single-host schema gap (#2276).** A one-host deploy that fails *after* its migration ran leaves the schema ahead of the binaries and says nothing. Left alone deliberately: changing it breaks the AC-1 byte-identity this PR establishes.

## Safety design worth reviewing closely

- **Post-cutover failures are classified, not treated alike.** `prune`/`drain-old`/`record-proxy-options` degrade the host and the rollout *continues*; `commit-markers` fails closed to a manual outcome; anything else halts and compensates. **See #2279 — this classification has a known flaw worth deciding before merge.**
- **Unattributable post-cutover failures fail closed.** A transport-level SSH error carries no op label; attribution is one-directional (it can upgrade a verdict to "do not touch this host", never downgrade one to "degrade and continue").
- **Compensation is binaries-only.** `rollback_ops` contains no `migrate` op by construction, asserted by test. Three schema notes now cover every outcome shape.
- **Fleet topologies that cannot work are refused before anything mutates**: sqlite, MediaMTX, per-host TLS — graded against the *configured* topology so `--only` cannot bypass them.

## Review and audit

A six-angle adversarial review raised findings across driver correctness, AC compliance, secrets, test quality, operational safety and docs-vs-code; **13 survived independent refutation and all 13 are fixed** — including a transport-level failure at `commit-markers` that bypassed the never-auto-roll-back guard and could land one host a release behind the rest while reporting "previous release restored". The AC audit found three more, also fixed.

**Automated review: 8 rounds.** Rounds 1–3, 5 and 6 fixed; rounds 4, 7 and 8 filed rather than fixed once the review budget closed. Round 5 was a genuine P1.

## Verification — what was actually run, and where

**Run locally, with CI's `RUST_MIN_STACK=8388608`:**
- `cargo test -p autumn-cli --bin autumn` → **5539 passed, 0 failed**

**Run locally earlier in the session (same toolchain, warm build):**
- `cargo test -p autumn-cli` (all targets) → 5539 unit + 729 integration + 192 other, 0 failed
- `cargo test -p autumn-web --lib` → 4596 passed, 0 failed
- `cargo clippy --all-targets -- -D warnings` on both crates → clean
- `RUSTDOCFLAGS="-D rustdoc::broken-intra-doc-links" cargo doc` → clean
- `./scripts/pre-push-check.sh` → exit 0. **Note: this gate is compile-only** (`--no-run`, per CLAUDE.md). It proves the workspace's tests *compile*; it does not run them.
- The four protected exact-vector tests are byte-identical, verified by checksum.

**NOT run anywhere:**
- `cargo test --workspace` — CI skipped it (lint gating); locally it exhausts this container's disk allowance while building the example crates, so it could not be completed here either.
- The fleet Docker e2e (`fleet_rolling_deploy_lifecycle`) — no Docker/ssh locally, and its CI step is inside the skipped `test` job. It compiles and is wired into CI's existing `--ignored` sweep, but has never executed.
- macOS and Windows targets — CI-only, never reached.

**Caveat on all local results:** this environment's toolchain is older than CI's unpinned `@stable`, which is precisely what the inherited lint failure demonstrates. Local green does not guarantee green under CI's newer clippy/rustfmt.

No version bump; changelog entries are under the existing `## [Unreleased]`.

## Follow-ups (all filed)

| Issue | |
|---|---|
| #2267 | #1610 alerting integration for AC-6 |
| #2268 | Migration warnings suppressed when the DB URL is only visible to the host |
| #2269 | Direct test that `deploy up` refuses when any host fails preflight |
| #2270 | Compensated first deploy leaves a stale kamal-proxy route answering 502 |
| #2273 | `deploy status` shows a green marker for a host whose `/ready` is 503 |
| #2274 | Empty-fleet preflight guard (fixed here; issue documents the corrected analysis) |
| #2276 | Single-host deploy that fails after migrating says nothing about the schema |
| #2277 | `deploy status` reports a known release for a dangling `current` symlink |
| #2278 | `--strict` misses an unreadable installed proxy port |
| **#2279** | **A failed `drain-old` leaves the old slot running workers and the scheduler while the rollout reports success — the highest-severity open item** |
| #2280 | `deploy maintenance on` fails on a never-deployed host (`{app_dir}/shared` missing) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JGkoJGTs3rDQo3nWajfbzD