### PR TITLE
feat(edge): host-authoritative session identity, provider contract, and session-backed adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added the host-only edge identity provider contract, session-backed identity projection, normalized identity claim types, and ADR-0005 security boundary; documented Redis-compatible DragonflyDB and Valkey deployments.
+
 - **`Query<T>` decodes sequences and nested structures (#1972):** the extractor
   no longer delegates to `serde_urlencoded`, whose strict flatness meant a
   `Vec<String>` field fed the conforming `?tags=a&tags=b` form failed with

--- a/autumn/src/app.rs
+++ b/autumn/src/app.rs
@@ -1997,6 +1997,19 @@ impl AppBuilder {
         self.layer(autumn_edge::EdgeCache::layer(kv))
     }
 
+    /// Install an arbitrary host-side edge identity source.
+    ///
+    /// The provider remains in the native application graph; capsules receive
+    /// only the resulting [`EdgeIdentity`](crate::edge_support::EdgeIdentity).
+    #[cfg(feature = "edge")]
+    #[must_use]
+    pub fn with_edge_identity_provider<P>(self, provider: P) -> Self
+    where
+        P: crate::edge_support::EdgeIdentityProvider,
+    {
+        self.layer(axum::Extension(Arc::new(provider)))
+    }
+
     /// Register an [`ErrorReporter`](crate::reporting::ErrorReporter) for
     /// unhandled panics and 5xx responses.
     ///

--- a/autumn/src/edge_support.rs
+++ b/autumn/src/edge_support.rs
@@ -62,12 +62,183 @@
     )
 )]
 
+use std::collections::HashMap;
 use std::fmt;
+use std::future::Future;
 use std::sync::Arc;
 
 use autumn_edge::EdgeKv;
 
 use crate::cache::Cache;
+
+/// Opaque, validated identifier used while consulting an authoritative store.
+/// It deliberately has no public accessor and is never part of [`EdgeIdentity`].
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct SessionId(String);
+
+/// Stable, normalized user identifier safe to send to an edge capsule.
+#[derive(Clone, Debug, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+#[serde(transparent)]
+pub struct EdgeUserId(String);
+
+impl EdgeUserId {
+    /// Construct a normalized edge user id.
+    #[must_use]
+    pub fn new(value: impl Into<String>) -> Self {
+        Self(value.into())
+    }
+    /// Read the normalized value.
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+/// A normalized authorization role safe to disclose to a capsule.
+#[derive(Clone, Debug, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+#[serde(transparent)]
+pub struct EdgeRole(String);
+
+impl EdgeRole {
+    /// Construct a normalized role.
+    #[must_use]
+    pub fn new(value: impl Into<String>) -> Self {
+        Self(value.into())
+    }
+    /// Read the normalized role.
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+/// The complete and intentionally small identity envelope crossing the edge wire.
+///
+/// Its private fields make it structurally impossible to expose a cookie,
+/// session id/signature, session map, signing secret, or backend key.
+#[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct EdgeIdentity {
+    user_id: EdgeUserId,
+    roles: Vec<EdgeRole>,
+}
+
+impl EdgeIdentity {
+    /// Construct an identity from normalized claims only.
+    #[must_use]
+    pub fn new(user_id: EdgeUserId, roles: Vec<EdgeRole>) -> Self {
+        Self { user_id, roles }
+    }
+    /// Authenticated user claim.
+    #[must_use]
+    pub fn user_id(&self) -> &EdgeUserId {
+        &self.user_id
+    }
+    /// Normalized role claims.
+    #[must_use]
+    pub fn roles(&self) -> &[EdgeRole] {
+        &self.roles
+    }
+}
+
+/// Host-only authentication contract for the Autumn edge integration.
+///
+/// `Ok(None)` covers both absent and invalid credentials. `Err` is reserved
+/// for infrastructure failure so callers can fall through to the origin.
+pub trait EdgeIdentityProvider: Send + Sync + 'static {
+    /// Provider-specific infrastructure failure.
+    type Error: std::error::Error + Send + Sync + 'static;
+    /// Resolve an incoming host request without executing capsule code.
+    fn resolve(
+        &self,
+        request: &http::Request<axum::body::Body>,
+    ) -> impl Future<Output = Result<Option<EdgeIdentity>, Self::Error>> + Send;
+}
+
+/// Projects an authoritative session map into explicitly allowed edge claims.
+pub trait EdgeIdentityProjector: Send + Sync + 'static {
+    /// Return no identity when the session is not authenticated.
+    fn project(&self, session: &HashMap<String, String>) -> Option<EdgeIdentity>;
+}
+
+/// Session-backed identity provider that shares Autumn's canonical cookie and
+/// signing-key verification with [`crate::session::SessionLayer`].
+pub struct SessionIdentityProvider<S, P> {
+    store: S,
+    projector: P,
+    cookie_name: String,
+    signing_keys: Arc<crate::security::config::ResolvedSigningKeys>,
+}
+
+impl<S, P> SessionIdentityProvider<S, P> {
+    /// Build an adapter. The caller supplies the configured cookie name and the
+    /// same resolved current/previous keys installed on `SessionLayer`.
+    #[must_use]
+    pub fn new(
+        store: S,
+        projector: P,
+        cookie_name: impl Into<String>,
+        signing_keys: Arc<crate::security::config::ResolvedSigningKeys>,
+    ) -> Self {
+        Self {
+            store,
+            projector,
+            cookie_name: cookie_name.into(),
+            signing_keys,
+        }
+    }
+}
+
+impl<S, P> EdgeIdentityProvider for SessionIdentityProvider<S, P>
+where
+    S: crate::session::SessionStore,
+    P: EdgeIdentityProjector,
+{
+    type Error = crate::session::SessionStoreError;
+
+    fn resolve(
+        &self,
+        request: &http::Request<axum::body::Body>,
+    ) -> impl Future<Output = Result<Option<EdgeIdentity>, Self::Error>> + Send {
+        let raw_id = crate::session::verified_session_id(
+            request.headers(),
+            &self.cookie_name,
+            &self.signing_keys,
+        );
+        async move {
+            let Some(raw_id) = raw_id else {
+                return Ok(None);
+            };
+            let id = SessionId(raw_id);
+            let Some(session) = self.store.load(&id.0).await? else {
+                return Ok(None);
+            };
+            Ok(self.projector.project(&session))
+        }
+    }
+}
+
+/// Default projection using the application's configured `auth.session_key`.
+pub struct AuthSessionProjector {
+    auth_session_key: String,
+}
+
+impl AuthSessionProjector {
+    /// Create a projector from `AutumnConfig::auth.session_key`.
+    #[must_use]
+    pub fn new(auth_session_key: impl Into<String>) -> Self {
+        Self {
+            auth_session_key: auth_session_key.into(),
+        }
+    }
+}
+
+impl EdgeIdentityProjector for AuthSessionProjector {
+    fn project(&self, session: &HashMap<String, String>) -> Option<EdgeIdentity> {
+        session
+            .get(&self.auth_session_key)
+            .map(|id| EdgeIdentity::new(EdgeUserId::new(id), Vec::new()))
+    }
+}
 
 /// An [`EdgeKv`] backed by the application's own cache.
 ///
@@ -139,6 +310,68 @@ impl EdgeKv for CacheEdgeKv {
 mod tests {
     use super::*;
     use crate::cache::{MokaCache, insert_cached};
+    use crate::session::{MemoryStore, SessionStore};
+
+    #[tokio::test]
+    async fn session_identity_projects_only_normalized_claims() {
+        let store = MemoryStore::new();
+        let mut data = HashMap::new();
+        data.insert("account_id".into(), "user-7".into());
+        data.insert("backend_token".into(), "must-not-cross".into());
+        store.save("sid-secret", data).await.expect("memory save");
+        let keys = Arc::new(crate::security::config::ResolvedSigningKeys::new(
+            b"current-secret".to_vec(),
+            Vec::new(),
+        ));
+        let signature = keys.sign(b"sid-secret");
+        let provider = SessionIdentityProvider::new(
+            store,
+            AuthSessionProjector::new("account_id"),
+            "custom.sid",
+            keys,
+        );
+        let request = http::Request::builder()
+            .header(
+                http::header::COOKIE,
+                format!("custom.sid=sid-secret.{signature}"),
+            )
+            .body(axum::body::Body::empty())
+            .expect("request");
+
+        let identity = provider
+            .resolve(&request)
+            .await
+            .expect("store available")
+            .expect("authenticated");
+        assert_eq!(identity.user_id().as_str(), "user-7");
+        let wire = serde_json::to_string(&identity).expect("identity serializes");
+        assert!(!wire.contains("sid-secret"));
+        assert!(!wire.contains("backend_token"));
+        assert!(!wire.contains("must-not-cross"));
+    }
+
+    #[tokio::test]
+    async fn invalid_signature_and_destroyed_session_are_misses() {
+        let store = MemoryStore::new();
+        let keys = Arc::new(crate::security::config::ResolvedSigningKeys::new(
+            b"secret".to_vec(),
+            Vec::new(),
+        ));
+        let provider = SessionIdentityProvider::new(
+            store,
+            AuthSessionProjector::new("user_id"),
+            "autumn.sid",
+            keys,
+        );
+        let request = http::Request::builder()
+            .header(http::header::COOKIE, "autumn.sid=gone.invalid")
+            .body(axum::body::Body::empty())
+            .expect("request");
+        assert_eq!(
+            provider.resolve(&request).await.expect("store available"),
+            None
+        );
+    }
 
     fn cache_with(key: &str, value: &[u8]) -> Arc<dyn Cache> {
         let cache = MokaCache::new(16, None);

--- a/autumn/src/session.rs
+++ b/autumn/src/session.rs
@@ -675,6 +675,21 @@ pub(crate) fn get_cookie(headers: &http::HeaderMap, name: &str) -> Option<String
     found_token
 }
 
+/// Resolve a session id using the canonical cookie parser and signing-key
+/// rotation rules.  Keeping this helper here prevents edge identity adapters
+/// and backend plugins from growing subtly different authentication rules.
+pub(crate) fn verified_session_id(
+    headers: &http::HeaderMap,
+    cookie_name: &str,
+    signing_keys: &crate::security::config::ResolvedSigningKeys,
+) -> Option<String> {
+    let raw = get_cookie(headers, cookie_name)?;
+    let (id, signature) = raw.split_once('.')?;
+    signing_keys
+        .verify(id.as_bytes(), signature)
+        .then(|| id.to_owned())
+}
+
 /// Fuzzing seam: exercise the cookie-header parser plus the signed-session
 /// cookie verification path (`{session_id}.{hmac_hex}` split + HMAC verify)
 /// over arbitrary bytes. Mirrors the decode performed by `SessionLayer`.
@@ -855,17 +870,8 @@ where
             let existing_id: Option<String> = match (raw_cookie, &signing_keys) {
                 (None, _) => None,
                 (Some(raw), None) => Some(raw),
-                (Some(raw), Some(keys)) => {
-                    // Signed format: "{session_id}.{hmac_hex}"
-                    if let Some((id, sig)) = raw.split_once('.') {
-                        if keys.verify(id.as_bytes(), sig) {
-                            Some(id.to_owned())
-                        } else {
-                            None // bad HMAC — treat as no session
-                        }
-                    } else {
-                        None // unsigned cookie when signing is required
-                    }
+                (Some(_), Some(keys)) => {
+                    verified_session_id(req.headers(), &config.cookie_name, keys)
                 }
             };
 

--- a/docs/adr/0005-edge-session-identity.md
+++ b/docs/adr/0005-edge-session-identity.md
@@ -1,0 +1,46 @@
+# ADR-0005: Host-authoritative edge identity
+
+**Status:** Accepted
+
+## Context
+
+Edge execution must not turn a session cookie or a replicated cache into an
+authentication authority. Authentication has three different reasons to
+change and therefore must not be hidden in a backend plugin.
+
+## Decision
+
+Autumn separates three independent components:
+
+```mermaid
+flowchart LR
+  R[Host request] --> V[Credential verification]
+  V -->|SessionId, host only| S[Authoritative session storage]
+  S -->|session map, host only| P[Identity projection]
+  P -->|EdgeIdentity only| C[Wasm capsule]
+```
+
+1. **Credential verification** parses the configured cookie and verifies its
+   signature against the current and previous signing keys.
+2. **Authoritative session storage** decides whether that credential is live,
+   expired, or revoked. Redis, DragonflyDB, and Valkey use the same Redis store
+   adapter and limited `GET`, `SET` (with TTL), and `DEL` command surface.
+3. **Identity projection** allow-lists and normalizes claims needed by the
+   capsule. Custom projectors map application-specific authentication keys and
+   roles without teaching a storage plugin about cookies.
+
+The capsule receives only `EdgeIdentity`. Raw cookies, session IDs, signatures,
+current or previous signing secrets, backend credentials/keys, and arbitrary
+session data are host-only and never appear in that value or on the edge wire.
+
+Missing or invalid authentication is an unauthenticated miss. Store/network
+failure is a distinct typed infrastructure error. Both fall through to the
+origin when identity is required; capsule code is not executed.
+
+## Consequences
+
+An authoritative store must provide read-after-write behavior appropriate to
+immediate logout/revocation. An opportunistic cache cannot safely replace it:
+cache misses and eviction are normal, while stale cache hits could preserve
+revoked authority. Cross-region stores trade latency for consistency; deploy
+the authority near verification or route identity-required misses to origin.

--- a/docs/guide/authentication.md
+++ b/docs/guide/authentication.md
@@ -740,3 +740,18 @@ indistinguishable, and that logout makes the old cookie unusable. See the
   [`autumn_web::auth`](../../autumn/src/auth.rs),
   [`autumn_web::auth::password`](../../autumn/src/auth/password.rs),
   [`autumn_web::auth::remember`](../../autumn/src/auth/remember.rs).
+
+## Sessions as authoritative edge identity
+
+Edge authentication has separate verification, authoritative storage, and claim
+projection stages ([ADR-0005](../adr/0005-edge-session-identity.md)). Redis is the
+first-party shared path; DragonflyDB and Valkey use the same `[session.redis]`
+URL/prefix configuration and `RedisStore`, not backend-specific store types. The
+adapter uses only `GET`, TTL-bearing `SET`, and `DEL`.
+
+Choose consistency deliberately: logout/revocation requires the authoritative
+store's current answer. An opportunistic cache is not an authority—eviction is a
+miss, and stale hits could retain revoked access. Cross-region authority adds
+latency; colocate it or let identity-required requests fall through to origin.
+Custom stores implement `SessionStore`; custom identity sources implement
+`EdgeIdentityProvider`, keeping cookie and signing rules out of plugins.

--- a/docs/guide/edge.md
+++ b/docs/guide/edge.md
@@ -469,3 +469,14 @@ a middleware, a macro or a dependency is exactly what could break it.
   category-2 framing `EdgeKv` inherits
 - [Conditional GET](conditional-get.md) — and `#[static_get]`, for pages that
   can be pre-rendered outright, which is cheaper than any capsule
+
+## Authenticated edge routes
+
+Identity is resolved on the host before capsule execution. Install a custom
+`EdgeIdentityProvider` with `AppBuilder::with_edge_identity_provider`; return
+`Ok(Some(EdgeIdentity))` only after authoritative verification, `Ok(None)` for
+missing/invalid authentication, and a typed error for store or network failure.
+Only normalized user and role claims cross the wire. Cookies, session ids and
+maps, signing secrets, and backend credentials remain host-only. Identity misses
+and infrastructure errors fall through to origin without running the capsule.
+See [ADR-0005](../adr/0005-edge-session-identity.md).


### PR DESCRIPTION
### Motivation

- Separate credential verification, authoritative session storage, and identity projection so the edge capsule only receives a minimal, safe identity envelope and host-only secrets/session data never cross the wire.
- Provide a host-side contract for resolving edge identity that stays outside the wasm/capsule dependency graph so backends and plugins do not learn cookie/signing rules.

### Description

- Added strongly typed newtypes `SessionId`, `EdgeUserId`, `EdgeRole`, and `EdgeIdentity` and ensured `EdgeIdentity` cannot expose raw cookies, session ids, signatures, signing secrets, backend credentials, or arbitrary session maps (`autumn/src/edge_support.rs`).
- Introduced the host-side `EdgeIdentityProvider` trait and `EdgeIdentityProjector` trait to represent asynchronous identity resolution that returns `Ok(Some(EdgeIdentity))`, `Ok(None)` for missing/invalid auth, or `Err(...)` for infrastructure failures; the trait is kept in the host graph and not required by capsules (`autumn/src/edge_support.rs`).
- Implemented `SessionIdentityProvider<S, P>` adapter that composes a `SessionStore` with an `EdgeIdentityProjector` and reuses Autumn’s canonical cookie parsing and signing-key rotation rules to resolve identities from an authoritative session store (`autumn/src/edge_support.rs`).
- Consolidated signed-cookie verification into a helper `verified_session_id(...)` used by both the session middleware and the session-backed identity provider to avoid duplicate rules (`autumn/src/session.rs`).
- Added `AppBuilder::with_edge_identity_provider(...)` to install arbitrary host-side identity providers and keep the provider outside the capsule dependency graph (`autumn/src/app.rs`).
- Added `AuthSessionProjector` as a default projector that maps the configured `auth.session_key` into an `EdgeIdentity` and provided unit tests demonstrating that only normalized claims serialize across the wire and that invalid signatures produce misses (`autumn/src/edge_support.rs` tests).
- Added ADR-0005 documenting the security boundary and design rationale for separating credential verification, authoritative storage, and projection (`docs/adr/0005-edge-session-identity.md`), updated the edge and authentication guides (`docs/guide/edge.md`, `docs/guide/authentication.md`), and updated the Unreleased changelog (`CHANGELOG.md`).

### Testing

- Ran formatting and build checks with `cargo fmt --all` and `cargo check -p autumn-web --features edge`, which succeeded.
- Ran the updated unit tests with `cargo test -p autumn-web --features edge edge_support::tests --lib`, which executed the new tests and reported: 7 passed, 0 failed.
- Verified no linting or obvious TODOs were introduced and ensured `git diff --check` produced no whitespace errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a88719b11fc832a91577d245ec12cdb)