### PR TITLE
Release prep for 0.7.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,6 +105,19 @@ jobs:
         # queueing behind ~20 minutes of workspace clippy in `lint` — and a
         # clippy failure can't stop it from running.
         run: ./scripts/check-migration-guides.sh
+      - name: Skill version marker gate
+        # The `autumn-web` agent skill annotates each API with the release it
+        # arrived in. Those markers are hand-maintained and drifted badly
+        # across the 0.6.0 -> 0.7.0 cut — a marker naming too NEW a release
+        # tells a reader an API is out of reach when it already shipped, which
+        # is the damaging direction. Nothing mechanical caught it; a review
+        # did, repeatedly. This resolves every issue-referenced marker against
+        # the CHANGELOG section that introduced it.
+        #
+        # Shares the docs-only `migration-guides` job for the same reason that
+        # job exists standalone: no toolchain, no cache, reports in seconds,
+        # and cannot be blocked by a clippy failure in `lint`.
+        run: ./scripts/check-skill-version-markers.sh
 
   supply-chain:
     name: Supply chain (cargo-deny)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+Nothing yet.
+
+## [0.7.0] - 2026-08-23
+
+For a narrative tour of this release, see the
+[0.7.0 release walkthrough](docs/releases/0.7.0.md); for the upgrade path from
+0.6.x, see the [migration guide](docs/migrations/0.7.0.md).
+
 ### Added
 
 - **`autumn deploy` prepares the host and migrates on the first deploy (#1607):**
@@ -522,172 +530,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   instead of a demotion, with outbound HTTP worked through as `declared` — is
   now documented in `docs/guide/security-posture-manifest.md` (#1627).
 
-### Changed
-
-- **`Query<T>` treats `[` and `]` in a query key as structure (#1972).** A
-  target that types a parameter as a plain value — `Query<HashMap<String,
-  String>>` is the common one — used to receive `?filter[a]=1` as the literal
-  key `"filter[a]"`; it now sees a nested object and reports a decode error
-  naming the fix. Give such a field a nested type, or accept it as
-  `serde_json::Value`. A key the grammar cannot resolve (one name used as both a
-  scalar and a container, or nesting past the cap) fails only if the target
-  actually claims it, so an unrecognised parameter stays ignorable exactly as
-  before.
-- **`Query<T>` rejects a duplicated key in a single-valued position (#1972).**
-  `?q=a&q=b` against a `String` field is a 400, as it was under
-  `serde_urlencoded` + serde's derive (`duplicate field`). A **map**-typed
-  target previously resolved this silently to the last value; resolving
-  parameter pollution quietly is how the resulting bugs are built, so it is now
-  loud. A sequence field still takes every occurrence.
-- **Query decode errors no longer echo the submitted value (#1972).** A
-  coercion failure names the field path and the expected type
-  (`page: invalid u32 value`) but never the text — the message is returned in
-  the 400 Problem Details body and recorded by every error reporter, and a query
-  parameter can hold a secret. Key text embedded in an error is bounded and
-  stripped of control characters.
-- **`Query<Vec<(String, String)>>` yields key-sorted pairs (#1972)** rather than
-  submission order; occurrences of one key keep their relative order. The
-  `#[edge]` extractor is unaffected — `autumn_edge`'s prelude re-exports axum's
-  `Query`.
-
-### Fixed
-
-- **deploy:** a cutover no longer orphans an active maintenance flag. The
-  maintenance flag path is now resolved through the new
-  `AUTUMN_MAINTENANCE_FLAG_FILE` environment variable (falling back to the
-  historical cwd-relative `tmp/autumn-maintenance.json` when unset, so a
-  non-deploy-managed app is unaffected), and `autumn deploy` stamps it into every
-  slot unit it writes, pointing at the per-app `shared/` directory. A slot unit's
-  `WorkingDirectory` is the *release* directory — new on every deploy — so on the
-  cwd-relative path a cutover silently un-maintained the host, and the blue and
-  green slots could not see each other's flag at all. Both read sites (the boot
-  load and the 500 ms poller) go through the same resolver. See
-  `docs/guide/maintenance-mode.md` (#1621).
-
-- **security:** `#[secured]`'s roles and scopes are no longer lost when another
-  guard wraps the handler body. With `#[secured("admin")]` written above
-  `#[authorize]`, `#[secured]` expands first and `#[authorize]` then buries its
-  role/scope marker consts one level deeper, inside the generated
-  `let __autumn_inner: T = (async move { … }).await;` wrapper — a shape the
-  marker walks did not descend. Extraction fell through
-  to the policy-check fallback, and the route reported `secured: true` with
-  empty `roles`/`scopes`: a *provable* manifest dimension silently understating
-  the posture it exists to prove. Both walks now descend the generated wrapper
-  through the same helper the `#[authorize]` binding walk uses, so the sibling
-  extractors can no longer disagree about depth (#1627).
-
-- **security:** two sibling route-metadata losses found by review of the same
-  extraction ladder: (1) `#[secured]` above the route macro with `#[authorize]`
-  below it dropped the roles/scopes to `&[]` — the live `#[authorize]`
-  attribute short-circuited the marker read, so deleting the `#[secured(...)]`
-  line produced zero manifest diff; the marker read now runs first. (2) The
-  `#[public]` marker walk could not descend a wrapping guard's generated body,
-  so `#[public]` above `#[throttle]` lost `public: true` and false-failed the
-  coverage gate as `unclassified`; the walk now uses the same shared
-  wrapper-descent helper as the other marker extractors (#1627).
-
-- **`generate admin` over an `#[encrypted]` model:** the generated admin adapter
-  did not compile — it bound `&new_row` to `.values(…)` and `&diesel_changeset`
-  to `.set(…)`, and diesel implements `Insertable`/`AsChangeset` only for the
-  owned value once a column uses `#[diesel(serialize_as = …)]`, as every
-  encrypted field does. Both now pass owned records when the model has an
-  encrypted column; plaintext models keep the borrowed form byte-for-byte.
-  Separately, **every admin edit of such a model failed**: the plugin renders an
-  encrypted column's edit control disabled and with no `name` (it is managed
-  outside the admin), so the form submits no key for it, while the handler
-  deserialized the submitted map into `New{Model}`, where the encrypted `String`
-  is required — so `serde_json::from_value` returned a "missing field" error even
-  when only a plaintext column was edited. Encrypted columns are now excluded
-  from the update entirely (matching what the form can actually submit), and the
-  handler back-fills a placeholder purely to satisfy that deserialization. That
-  exclusion also closes a plaintext write: the `lock_version` update path emits a
-  raw `col.eq(value)` tuple that never builds an `Update{Model}` changeset, so it
-  would have bypassed the encrypting wrapper and stored **plaintext** in the
-  encrypted column.
-
-- **`#[repository]` with hooks over an `#[encrypted]` model:** a repository
-  declared `broadcasts = true` (or with an explicit `hooks = …` type) over a
-  model carrying any `#[encrypted]` column failed to compile —
-  `the trait bound `&Model: AsChangeset` is not satisfied`. The hooks-aware
-  bulk-update path bound a *borrowed* proposed row to `.set(…)`, and diesel
-  implements `AsChangeset` only for the owned model once a field uses
-  `#[diesel(serialize_as = …)]`, as every encrypted field does. It now passes
-  the owned record, matching the single-record hooks paths. Reachable from
-  `autumn generate scaffold --live` with an encrypted column.
-
-- **failure capsules:** the resolved client identity now obeys
-  `[log] filter_parameters`. `client_addr`/`client_host`/`client_scheme` are
-  derived from `Forwarded`, `X-Forwarded-*` and `Host`, and were copied into
-  the capsule *after* header redaction ran — so an operator who filtered
-  `x-forwarded-host` saw it masked under `headers` and sitting in cleartext one
-  key away under `client_host`. Each field is now dropped when any header it
-  could have been resolved from is filtered — including `X-Real-IP`, a
-  fallback source for the address. Where a filtered source actually supplied a
-  value the capsule is additionally **refused** by replay: replay pre-inserts
-  the recorded identity whole whenever any field survives, so a suppressed
-  host would reach the handler as `None` rather than not at all, and a handler
-  that branches on it would report a `mismatch` the guide tells operators to
-  read as "the bug is gone".
-- **failure capsules:** the capsule format version is now `2`. The new
-  `db_roles` field changes what a capsule *means* — a reader that skips it
-  rebuilds no database topology and replays a shape the recording never had —
-  and `serde` would otherwise let an older reader ignore it silently, which is
-  exactly what the version gate exists to prevent. Version 1 never appeared in
-  a release, so no capsule anyone holds is affected; a capsule written by an
-  unreleased build off `trunk-dev` is refused with the usual
-  re-record-the-capsule message.
-- **failure capsules:** six fidelity and redaction gaps found in review of
-  #1598 (#2202). A capsule whose request body the handler read only *partly* —
-  or never got to at all — is now marked incomplete and **refused** by replay
-  rather than replayed with a shorter body: the handler would otherwise be
-  judged on input the failing request never carried, and the resulting
-  `mismatch` is exactly what the guide tells operators means "the bug is gone".
-  The client identity is recorded again for capsules written by the real
-  server: `App::run` wraps the finished router in an *outer*
-  `TrustedProxiesLayer` that resolves before the capture scope exists, so the
-  inner instance found the extension already present and skipped recording,
-  leaving `client_addr`/`client_host`/`client_scheme` empty on every
-  production capsule while the test harness (which has no outer layer) recorded
-  them. A second cause sat behind the first: the capture layer passed
-  `inner.call(req)` to `CAPSULE_SCOPE.scope` as an *argument*, which Rust
-  evaluates before the call, so every inner layer's synchronous `call` — where
-  a hand-written Tower middleware does its work — ran before the task-local
-  existed and saw no scope. The inner call is now made from inside the scoped
-  future, which fixes the class rather than the one layer.
-  Replay now rebuilds the database *shape* the recording had even when
-  the request issued no wire traffic at all — "this request ran no queries" and
-  "this application has no database" were the same `None`, so a handler or
-  state initializer that checks `state.pool()` or replica availability before
-  querying took a branch production never took. Redaction reaches two things it
-  used to miss: the credential *inside* a masked header (the token after
-  `Bearer`, what a `Basic` credential decodes to, each value of an auth-param
-  list such as SigV4's `Signature=`, each cookie value — the form
-  a handler actually extracts and may echo into an error message or a SQL bind,
-  where the whole header value never
-  matched), and values shorter than four characters, which are now masked where
-  they stand as a whole token, so a three-digit CVV quoted back by a failure no
-  longer reaches disk while timestamps and identifiers stay readable. Finally,
-  `SET LOCAL ...` is no longer treated as framework housekeeping: `Db::checkout`
-  issues a plain session-level `SET statement_timeout`, so a transaction-scoped
-  setting is application code and belongs on the ordered tape, where changing or
-  removing it shows up as a divergence instead of being synthesized away.
-- **duplicate Markdown heading anchors:** `markdown::render` now hands out
-  document-unique heading `id`s. A page that repeated a heading — and real docs
-  repeat "Example", "Usage", and "Notes" constantly — emitted the same `id`
-  twice, which is invalid HTML and made every table-of-contents entry for the
-  repeated heading jump to the first occurrence. Every heading still keeps the
-  slug its own text produces, so anchors already published in URLs keep
-  resolving; only *repeats* of an already-claimed slug get a `-1`, `-2`, …
-  suffix, the convention GitHub, mdBook, and Hugo share. Because the renderer
-  reserves every heading's natural slug before handing out any suffix, a repeat
-  can never steal a slug another heading owns by name regardless of the order
-  the two appear in: `## Example` / `## Example` / `## Example 1` renders
-  `example`, `example-2`, `example-1`, leaving `#example-1` pointing at
-  "Example 1". Headings with no alphanumeric characters still emit no `id` at
-  all and stay out of the anchor namespace.
-
-### Added
-
 - **`autumn generate scaffold --i18n` emits translatable views** (issue #1349).
   Autumn already shipped the whole Fluent stack — the `t!(locale, "key")` macro
   with compile-time key validation, the `i18n/<tag>.ftl` convention, fallback
@@ -785,171 +627,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `static_params_for("page")`, because a `StaticParams` entry keyed `"slug"`
   leaves `{page}` unsubstituted. `static_params()` is unchanged and now
   delegates to it with `"slug"`.
-
-### Performance
-
-- **ingress middleware no longer boxes a future per layer per request:** every
-  `axum::middleware::from_fn` on the framework's always-on request path is now a
-  hand-rolled `tower::Service` with a **named** future. `from_fn` cannot avoid
-  the cost it was paying: the async block it generates has no nameable type, so
-  `FromFn::call` returns it as `Box::pin(..)` — one heap allocation per call
-  site per request, sized by everything that block captures across its single
-  `.await`, which for an outer layer is the whole downstream continuation. DHAT
-  measured those boxes at **19.57% of every byte** the `request_pipeline`
-  benchmark allocated (5,267,600 of 26,918,238 bytes over 650 requests) while
-  being only 2.14% of the blocks — the largest single allocation cost in the
-  profile (issue #2214).
-
-  Converted: the asset cache-control layer, the event-bus app context, the
-  webhook replay-key cleanup, the method-override rejection filter, the
-  trusted-host gate, the startup barrier, the per-request timeout, the
-  read-your-own-writes pin, and (under `oauth2`) the HTTP-interceptor scope.
-  Each keeps its behaviour and its position in the stack exactly; what goes away
-  is the box and, with it, the `self.inner.clone()` `from_fn` needed to move the
-  inner service into that box — which for an erased `BoxCloneSyncService` was a
-  recursive `clone_box` down the rest of the stack, so each conversion took a
-  whole deep-clone cascade with it too.
-
-  Re-run of the issue's own DHAT recipe on `benches/request_pipeline.rs`
-  (release, 200 iterations = 650 requests), before and after on the same
-  machine — filtering allocation sites whose second stack frame is
-  `FromFn<..>::call` exactly, as the issue specifies:
-
-  | | `FromFn::call` `Box::pin` | share of run bytes | marginal blocks/req | marginal bytes/req |
-  | --- | ---: | ---: | ---: | ---: |
-  | before | 3,250 blocks / 5,215,600 bytes | 19.80% | 168.8 | 36,826 |
-  | after | **0 / 0** (0 sites) | **0%** | 139.2 | 25,943 |
-
-  The before column reproduces the issue's measurement exactly on block count
-  (3,250) and to within 1% on bytes. Overall: **−17.5% allocations** and
-  **−29.6% bytes** per request.
-
-  The same movement is pinned as a regression gate in the debug profile, where
-  it is deterministic run to run: **172 → 140 allocation blocks** and
-  **37,819 → 26,030 bytes** per request under the default feature set. The ingress clone-on-call traversal count drops from 13 to 9 in
-  the same move, on the default set and on a 13-feature build alike. One layer
-  also sheds an allocation of its own: the asset cache-control layer no longer
-  clones the request path into a `String` on every request in the app.
-
-  Two middlewares are deliberately **not** converted, because they `.await`
-  before calling the inner service and their futures therefore cannot be named
-  without `type_alias_impl_trait`: the tenancy middleware (async tenant
-  extraction) and the rate-limit principal shim (async session read). Both are
-  off by default. `webhook_replay_cleanup` keeps one box, taken only on a `5xx`
-  that actually registered replay keys; on every other request its future is
-  unboxed (it still mints the per-request replay cell it always did).
-
-  One public behaviour change: `read_your_writes::middleware` used to
-  `unreachable!()` when handed `ReadYourWrites::Off`. It now debug-asserts and
-  falls back to an inert `Off` pin instead of panicking on the request path.
-  Both call sites gate on `mode != Off`, so the arm stays unreachable in
-  practice. Otherwise nothing public moved: `asset_cache_control`,
-  `method_override_rejection_filter` and `webhook_replay_cleanup_middleware`
-  remain exported `async fn`s with identical behaviour, now sharing their
-  decision logic with the layers so the two forms cannot drift.
-
-  Four gates keep the win from eroding: a per-request allocation **blocks**
-  ceiling tight enough that restoring a single `from_fn` fails it, a companion
-  **bytes** ceiling derived under the wider feature set CI actually gates with,
-  the ingress traversal count pinned to its exact measurement, and a
-  `type_name`-based assertion that none of the converted services ever returns a
-  `Pin<Box<dyn Future>>` again.
-
-- **config reads on the request path:** generated auth handlers, the admin
-  plugin, the `saas` starter, and the `blog`/`saas`/`teams` examples now read
-  configuration through `AppState::config_arc()` instead of
-  `AppState::config()`. `config()` returns an owned `AutumnConfig`, so every
-  call deep-clones **every** config section — 64 allocations and 1,384 bytes
-  against a default config, and more as an app's config grows — even to read a
-  single `bool` or `usize`. On a handler that cost is paid per request, and a
-  handler reading two or three sections paid it two or three times over: a
-  downstream app profiling its request path measured whole-config clones at
-  ~30% of its per-request allocations and ~42% of its per-request bytes.
-  `config_arc()` hands back the shared `Arc<AutumnConfig>` the state already
-  holds, so the same read is a refcount bump and handlers borrow the section
-  they need off the handle (`&config.auth.password`).
-
-  Nothing about the framework's own ingress path changed — that was already
-  allocation-free as of #2199 — and no public signature moved: `config()`
-  remains the per-boot owned-snapshot accessor, and the one generated call site
-  that still uses it is the boot-time `remember_me_startup` hook, which needs an
-  owned `RememberConfig`. Apps calling `state.config()` in their own handlers
-  keep compiling; switching them to `state.config_arc()` is the fix, and
-  `docs/guide/authentication.md` now teaches that as the default. A new
-  generator test pins the emitted handlers to `config_arc()` so the deep clone
-  cannot reappear in scaffolded apps.
-
-- **jobs:** the Postgres job worker's claim query (`SELECT … FOR UPDATE SKIP
-  LOCKED`) no longer scans and sorts the entire ready backlog for a queue
-  before picking one row, for apps that don't configure `[jobs] queues`
-  priority (the common case: a single `"default"` queue). The claim query's
-  `ORDER BY array_position($2::text[], candidate.queue), candidate.run_at`
-  was opaque to the planner — `array_position` depends on the bound queue-
-  order array, so even though it's constant across every candidate row when
-  only one queue is in play, Postgres couldn't prove that and fell back to a
-  `Bitmap Heap Scan` of the whole ready-in-queue backlog followed by a
-  `Sort` and `LockRows` over every one of those rows, before `LIMIT 1`
-  picked the winner. Single-queue workers now send a query that drops
-  `array_position` from `ORDER BY` and uses `queue = $2` (scalar), which
-  lets the planner recognize the existing `idx_autumn_jobs_queue_ready
-  (queue, run_at)` index order and do a plain `Index Scan` + `Limit 1`
-  instead. Measured (`EXPLAIN (ANALYZE, BUFFERS)`, production-shaped
-  fixture): 703→21 buffers at 4.4k ready rows, 3,342→22 at 44.6k, and
-  57,093→22 (eliminating an external-merge sort spill to disk) at 444k;
-  workload-level (`pg_stat_statements`, 50 claims) 166,437→1,410 total
-  buffers, a 99.15% reduction. No index or migration changes — see
-  `docs/reports/2026-08-14-ledger-job-claim-single-queue/`.
-
-- **state:** `AppState::profile` and `AppState::auth_session_key` no longer
-  deep-clone a `String` on every `AppState::clone()`. `AppState` is cloned
-  once per hop of the ingress tower stack (`Route::call` deep-clones the
-  boxed service beneath it, per #2193/#2198), so the two fields still held
-  as an owned `Option<String>`/`String` — rather than shared behind an
-  `Arc` like the rest of the struct — paid a fresh heap allocation on every
-  one of those clones instead of once per request. Both now live behind an
-  `Arc<str>`; `profile()` and `auth_session_key()` are unchanged (`&str`
-  via `Deref`), and `with_profile`/`with_auth_session_key` still take
-  `impl Into<String>`. Measured with the debug-profile allocation-counter
-  gate already used for #2198's `config_arc` work (`autumn/tests/config_alloc_gate.rs`):
-  a `TestClient` request drops from 220 to 172 allocation blocks (-22%),
-  identical across repeated runs.
-- **mail:** list-mail sends (`Mailer::send` with `list_unsubscribe` set) now
-  resolve suppression for the whole recipient batch in one query instead of
-  one `SELECT` per recipient. The `SuppressionStore` trait gained a batched
-  `is_suppressed_many` method (default implementation loops over
-  `is_suppressed`, so existing custom stores keep working unchanged);
-  `DbSuppressionStore` overrides it with a single `WHERE list_id = $1 AND
-  subscriber = ANY($2)` query, chunked at 50,000 recipients on Postgres (a
-  backstop against an unbounded single-statement bind, not a tuning knob for
-  ordinary sends: a tighter chunk size can land statements past a planner
-  cost crossover where `= ANY(...)` stops using the index and falls back to
-  a table scan, then re-pay that scan's fixed cost once per chunk) and at
-  `repository::MAX_BIND_PARAMS - 1` on SQLite, which binds `eq_any` as one
-  parameter per element instead of Postgres's single array parameter.
-  Measured
-  (`pg_stat_statements`, production-shaped `mail_unsubscribes` fixture):
-  statement count per send drops from N to 1 at every batch size tested
-  (200/2,000/20,000 recipients); total buffers 660→604 (200), 6,600→6,004
-  (2,000), and 66,000→8,070 (20,000, −87.8%). No index or migration changes
-  — see `docs/reports/2026-08-15-ledger-mail-suppression-batch/`.
-- **scaffold:** the generated `index` page for a `belongs_to`/`references`
-  field with a resolved display column (#1146) no longer scans the *entire*
-  referenced table to label the ~20 rows on one page. `autumn-cli`'s
-  `render_index_reference_label_loads` reused the create/edit form's
-  `{name}_select_options` loader — a full, unfiltered `SELECT id, col FROM
-  table ORDER BY id` that genuinely needs every row for a `<select>` — to
-  build the index's parent-label map too, so every index page view re-read
-  the whole referenced table regardless of page size. It now scopes the
-  query to `WHERE id = ANY(...)` the page's own FK values
-  (`page_data.content`, already fetched), and the identical fix applies to
-  the `--belongs-to` nested list (`children_section_with`). Measured
-  (`EXPLAIN (ANALYZE, BUFFERS)` + `pg_stat_statements`, production-shaped
-  fixture): rows read at the scan node drop from 500,000→20 (-99.996%) at
-  500k parent rows, with total buffers 7,051→83 (-98.8%); 707→61 (-91.4%)
-  at 50k rows and 72→54 (-25.0%) at 5k rows. No index or migration changes
-  — see `docs/reports/2026-08-16-ledger-scaffold-index-label-scope/`.
-
-### Added
 
 - **cluster:** an embedded, zero-dependency self-clustering substrate (#1762).
   Two instances of the same binary, started with a shared secret and no
@@ -2277,7 +1954,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `autumn_web::Route { .. }` or `autumn_web::static_gen::StaticRouteMeta { .. }`
   literally (plugins building a `Vec<Route>` by hand rather than through
   `routes![]`) must add `seo: autumn_web::seo::SeoRouteDefaults::EMPTY`. See the
-  [migration guide](docs/migrations/next.md).
+  [migration guide](docs/migrations/0.7.0.md).
   `SeoRouteDefaults` is itself `#[non_exhaustive]` and built by chaining its
   `const fn with_*` setters from `EMPTY`, so future SEO keys stay additive.
 - **cli:** `autumn console` (alias `autumn c`) — a one-command, pre-wired data
@@ -2694,7 +2371,75 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   The plugin's `api-reference.md` (*Config layering and env keys*) documents
   when to reach for which accessor.
 
+- **router:** new `health.enabled` config knob (default `true`,
+  `AUTUMN_HEALTH__ENABLED`) — an opt-out that suppresses all built-in probe
+  endpoints (`/health`, `/live`, `/ready`, `/startup`) so an app can own those
+  paths entirely (or expose none). Enabled by default, so behavior is
+  byte-identical to before when unset. Completes the probe-conflict work begun
+  in #1977 (which already lets a hand-written user route at a probe path win),
+  with explicit regression tests for both the user-route-wins and
+  probes-disabled cases (#1971).
+
+- **sim-testing:** `#[sim_test]` macro and public `Sim` skeleton for
+  deterministic simulation tests (seed-driven, replay-on-panic) (#1797). [no-plugin]
+
+- **security:** `autumn routes audit` (#1604) is now wired into every
+  scaffolded app's CI by default — `autumn new` adds a "Route auth coverage
+  (security manifest)" step to `.github/workflows/ci.yml`, right after the
+  a11y-verify step whose prebuilt CLI it reuses, so a route someone forgot to
+  classify fails CI on day one instead of waiting for an app to opt in.
+  Unclassified-route diagnostics now also name the offending handler's
+  `file:line` (from `file!()`/`line!()`, captured by the `#[get]`/`#[post]`/…,
+  `#[ws]`, and static-route macros alongside the existing module path), so a
+  failing gate points straight at the line to fix. A new [Route Auth
+  Coverage](docs/guide/route-auth-coverage.md) guide documents the
+  default-deny posture model and how to classify the three route kinds
+  (`gated`, `public`, `framework`), completing the deferred items from #1604's
+  first slice (#1850).
+
 ### Changed
+
+- **deps:** refreshed the whole dependency floor for the release rather than
+  tagging on a month-old lockfile — `diesel` `2.3.10` -> `2.3.12` (upstream's
+  Postgres (de)serialization panic fixes and the SQLite batch-insert `.load()`
+  fix), `libsqlite3-sys` `0.37` -> `0.38` (bundled SQLite 3.51.x), `redis`
+  `1.4` -> `1.6`, plus every semver-compatible update `cargo update` resolves.
+  The `time` upper bound widens to `<0.3.56` in the three manifests that carry
+  it for the testcontainers/bollard and aws-smithy graphs. This is **not** a
+  breaking change for application code: `libsqlite3-sys` is a build-time
+  transitive of the optional `sqlite` feature and is not re-exported, so it is
+  visible only to an app that already depends on it directly — see the
+  [migration guide](docs/migrations/0.7.0.md#upstream-dependency-updates).
+  Dependency majors that need API work (`rand` 0.10, `sha1` 0.11, `aes-gcm`
+  0.11, `matchit` 0.9, `x509-parser` 0.18, `tokio-tungstenite` 0.30,
+  `tokio-postgres-rustls` 0.14) are deliberately not carried here; each is its
+  own change.
+
+- **`Query<T>` treats `[` and `]` in a query key as structure (#1972).** A
+  target that types a parameter as a plain value — `Query<HashMap<String,
+  String>>` is the common one — used to receive `?filter[a]=1` as the literal
+  key `"filter[a]"`; it now sees a nested object and reports a decode error
+  naming the fix. Give such a field a nested type, or accept it as
+  `serde_json::Value`. A key the grammar cannot resolve (one name used as both a
+  scalar and a container, or nesting past the cap) fails only if the target
+  actually claims it, so an unrecognised parameter stays ignorable exactly as
+  before.
+- **`Query<T>` rejects a duplicated key in a single-valued position (#1972).**
+  `?q=a&q=b` against a `String` field is a 400, as it was under
+  `serde_urlencoded` + serde's derive (`duplicate field`). A **map**-typed
+  target previously resolved this silently to the last value; resolving
+  parameter pollution quietly is how the resulting bugs are built, so it is now
+  loud. A sequence field still takes every occurrence.
+- **Query decode errors no longer echo the submitted value (#1972).** A
+  coercion failure names the field path and the expected type
+  (`page: invalid u32 value`) but never the text — the message is returned in
+  the 400 Problem Details body and recorded by every error reporter, and a query
+  parameter can hold a secret. Key text embedded in an error is bounded and
+  stripped of control characters.
+- **`Query<Vec<(String, String)>>` yields key-sorted pairs (#1972)** rather than
+  submission order; occurrences of one key keep their relative order. The
+  `#[edge]` extractor is unaffected — `autumn_edge`'s prelude re-exports axum's
+  `Query`.
 
 - **docs:** rewrote the getting-started guide (`docs/guide/getting-started.md`)
   against the current scaffold and CLI. The guide had drifted: it announced the
@@ -2785,7 +2530,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   both bounds, so the move is invisible in practice; only a layer written
   against `axum::routing::Route` specifically stops compiling, and its fix is
   one line (see
-  [the migration guide](docs/migrations/next.md#app-wide-layers-are-now-erased)).
+  [the migration guide](docs/migrations/0.7.0.md#app-wide-layers-are-now-erased)).
   `docs/guide/middleware.md` describes the new shape.
 
   [no-plugin] — internal router assembly: the registration API, its ordering
@@ -2846,7 +2591,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `PUT`/`PATCH` clients must now send the version they read. That is what gives
   the JSON path conflict-checking, but existing clients that omit the field will
   fail deserialization. See the
-  [migration guide](docs/migrations/next.md).
+  [migration guide](docs/migrations/0.7.0.md).
 
 - **generate:** finished the zero-JS file-upload slice (#1236) on the read-back
   side. A scaffold with an `Attachment` column now *shows* what it stored: the
@@ -3002,7 +2747,198 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   with `db_transient_errors`; an explicit schedule entry always wins. An empty
   schedule / zero rate installs nothing, so a default `Chaos` is unchanged. This
   is W5.a; it stacks on W5.0 and is a sibling of W5.b (item 6). [no-plugin]
+
+- **cli:** the accessibility (a11y) verify step in the generated-app CI template
+  (`autumn new`) is now an **enforcing gate** — its `continue-on-error: true`
+  escape hatch has been removed, so an a11y violation now fails the job. The step
+  was shipped non-blocking in #2018 only until a pinned autumn release published
+  prebuilt CLI binaries; with v0.6.0 now published with prebuilt binaries, the
+  step runs against the release binary and blocks. Checklist item #7 of #2040.
+
+- **panic gate:** the request-path panic gate (#1611) now also denies
+  `clippy::string_slice` and `clippy::arithmetic_side_effects` in every gated
+  module, and the manifest grows to 30 modules (adds `inbound_mail.rs`,
+  `nested_form.rs` — which carried the header but had drifted out of the
+  manifest — and the new crate-private `time_math` saturating-arithmetic
+  helpers). `scripts/check-panic-gate.sh` gains header anchoring, anti-spoof
+  checks for module-wide `allow`s, `reason =` hygiene on per-site allows,
+  reverse-manifest drift detection, a module-count floor, a CI
+  feature-reachability check (with a validated, self-expiring exemption list —
+  `middleware/trace_context.rs` is behind `telemetry-otlp`, which the lint runner
+  cannot enable without `protoc`, and the gate now says so on every run instead
+  of leaving it silently unenforced), and a `--self-test` mode that runs by
+  default;
+  `scripts/pre-push-check.sh` now runs the gate and the gated-features clippy
+  lane. CI lints the `inbound-mail`/`inbound-mailgun`/`inbound-ses`/`storage`
+  features and runs the inbound-mail test suites. [no-plugin]
+- **panic gate:** hardened `scripts/check-panic-gate.sh` against a set of
+  reviewer-confirmed bypasses that had passed both the script and `cargo clippy
+  -- -D warnings` while shipping a production panic (#1611). Header validation is
+  now structural (the block must open *exactly* `#![cfg_attr(not(test), deny(`
+  after comment/whitespace stripping), so a widened `all(not(test), any())`
+  predicate or a `not(test)` living only in a comment no longer passes. A new
+  tree-wide inner-suppression scan rejects any `#![allow(…)]`/`#![expect(…)]`
+  (including the `cfg_attr(…, allow(…))` form) that re-permits a gated lint or a
+  blanket group (`restriction`/`all`/`pedantic`/`nursery`) across **every** `*.rs`
+  under the scan roots — closing the unmarked-submodule hole — while exempting
+  `#[cfg(test)]` scopes; the scan roots now include the sibling framework crates
+  (`autumn-admin-plugin`, `autumn-media-plugin`, `autumn-storage-s3`,
+  `autumn-cache-redis`). Per-site allows must now carry a **non-empty** reason,
+  and the feature-reachability check only counts an *enforcing* CI clippy lane
+  (`-p autumn-web` + `-D warnings`, not commented out), so a stubbed lane can no
+  longer fake coverage. The `--self-test` suite grows to 34 cases, one per bypass.
+  CONTRIBUTING.md documents the enforced-subset scoping (the manifest is an
+  incremental subset of the request path, not the whole of it) and the
+  `macro_rules!` expansion blind spot the gate cannot see. [no-plugin]
+- **inbound_mail:** `compute_mailgun_signature` delegates to
+  `security::config::hmac_sha256_hex` (output byte-identical); removed a dead
+  re-parse in the SNS certificate DER reader (#1611). [no-plugin]
+
+### Deprecated
+
+- **scheduler:** `scheduler::now_unix_secs` and `scheduler::now_unix_duration`
+  read real wall time off the injected-clock seam, so a tick key derived from
+  them is not reproducible under a `#[sim_test]`. Use
+  `time::clock_unix_secs(state.clock())` / `time::clock_unix_duration(state.clock())`
+  instead — which is what the framework's own scheduler already does. Neither
+  function has a remaining production caller inside autumn (#1797). See
+  [the migration guide](docs/migrations/0.7.0.md).
+
 ### Fixed
+
+- **deploy:** a cutover no longer orphans an active maintenance flag. The
+  maintenance flag path is now resolved through the new
+  `AUTUMN_MAINTENANCE_FLAG_FILE` environment variable (falling back to the
+  historical cwd-relative `tmp/autumn-maintenance.json` when unset, so a
+  non-deploy-managed app is unaffected), and `autumn deploy` stamps it into every
+  slot unit it writes, pointing at the per-app `shared/` directory. A slot unit's
+  `WorkingDirectory` is the *release* directory — new on every deploy — so on the
+  cwd-relative path a cutover silently un-maintained the host, and the blue and
+  green slots could not see each other's flag at all. Both read sites (the boot
+  load and the 500 ms poller) go through the same resolver. See
+  `docs/guide/maintenance-mode.md` (#1621).
+
+- **security:** `#[secured]`'s roles and scopes are no longer lost when another
+  guard wraps the handler body. With `#[secured("admin")]` written above
+  `#[authorize]`, `#[secured]` expands first and `#[authorize]` then buries its
+  role/scope marker consts one level deeper, inside the generated
+  `let __autumn_inner: T = (async move { … }).await;` wrapper — a shape the
+  marker walks did not descend. Extraction fell through
+  to the policy-check fallback, and the route reported `secured: true` with
+  empty `roles`/`scopes`: a *provable* manifest dimension silently understating
+  the posture it exists to prove. Both walks now descend the generated wrapper
+  through the same helper the `#[authorize]` binding walk uses, so the sibling
+  extractors can no longer disagree about depth (#1627).
+
+- **security:** two sibling route-metadata losses found by review of the same
+  extraction ladder: (1) `#[secured]` above the route macro with `#[authorize]`
+  below it dropped the roles/scopes to `&[]` — the live `#[authorize]`
+  attribute short-circuited the marker read, so deleting the `#[secured(...)]`
+  line produced zero manifest diff; the marker read now runs first. (2) The
+  `#[public]` marker walk could not descend a wrapping guard's generated body,
+  so `#[public]` above `#[throttle]` lost `public: true` and false-failed the
+  coverage gate as `unclassified`; the walk now uses the same shared
+  wrapper-descent helper as the other marker extractors (#1627).
+
+- **`generate admin` over an `#[encrypted]` model:** the generated admin adapter
+  did not compile — it bound `&new_row` to `.values(…)` and `&diesel_changeset`
+  to `.set(…)`, and diesel implements `Insertable`/`AsChangeset` only for the
+  owned value once a column uses `#[diesel(serialize_as = …)]`, as every
+  encrypted field does. Both now pass owned records when the model has an
+  encrypted column; plaintext models keep the borrowed form byte-for-byte.
+  Separately, **every admin edit of such a model failed**: the plugin renders an
+  encrypted column's edit control disabled and with no `name` (it is managed
+  outside the admin), so the form submits no key for it, while the handler
+  deserialized the submitted map into `New{Model}`, where the encrypted `String`
+  is required — so `serde_json::from_value` returned a "missing field" error even
+  when only a plaintext column was edited. Encrypted columns are now excluded
+  from the update entirely (matching what the form can actually submit), and the
+  handler back-fills a placeholder purely to satisfy that deserialization. That
+  exclusion also closes a plaintext write: the `lock_version` update path emits a
+  raw `col.eq(value)` tuple that never builds an `Update{Model}` changeset, so it
+  would have bypassed the encrypting wrapper and stored **plaintext** in the
+  encrypted column.
+
+- **`#[repository]` with hooks over an `#[encrypted]` model:** a repository
+  declared `broadcasts = true` (or with an explicit `hooks = …` type) over a
+  model carrying any `#[encrypted]` column failed to compile —
+  `the trait bound `&Model: AsChangeset` is not satisfied`. The hooks-aware
+  bulk-update path bound a *borrowed* proposed row to `.set(…)`, and diesel
+  implements `AsChangeset` only for the owned model once a field uses
+  `#[diesel(serialize_as = …)]`, as every encrypted field does. It now passes
+  the owned record, matching the single-record hooks paths. Reachable from
+  `autumn generate scaffold --live` with an encrypted column.
+
+- **failure capsules:** the resolved client identity now obeys
+  `[log] filter_parameters`. `client_addr`/`client_host`/`client_scheme` are
+  derived from `Forwarded`, `X-Forwarded-*` and `Host`, and were copied into
+  the capsule *after* header redaction ran — so an operator who filtered
+  `x-forwarded-host` saw it masked under `headers` and sitting in cleartext one
+  key away under `client_host`. Each field is now dropped when any header it
+  could have been resolved from is filtered — including `X-Real-IP`, a
+  fallback source for the address. Where a filtered source actually supplied a
+  value the capsule is additionally **refused** by replay: replay pre-inserts
+  the recorded identity whole whenever any field survives, so a suppressed
+  host would reach the handler as `None` rather than not at all, and a handler
+  that branches on it would report a `mismatch` the guide tells operators to
+  read as "the bug is gone".
+- **failure capsules:** the capsule format version is now `2`. The new
+  `db_roles` field changes what a capsule *means* — a reader that skips it
+  rebuilds no database topology and replays a shape the recording never had —
+  and `serde` would otherwise let an older reader ignore it silently, which is
+  exactly what the version gate exists to prevent. Version 1 never appeared in
+  a release, so no capsule anyone holds is affected; a capsule written by an
+  unreleased build off `trunk-dev` is refused with the usual
+  re-record-the-capsule message.
+- **failure capsules:** six fidelity and redaction gaps found in review of
+  #1598 (#2202). A capsule whose request body the handler read only *partly* —
+  or never got to at all — is now marked incomplete and **refused** by replay
+  rather than replayed with a shorter body: the handler would otherwise be
+  judged on input the failing request never carried, and the resulting
+  `mismatch` is exactly what the guide tells operators means "the bug is gone".
+  The client identity is recorded again for capsules written by the real
+  server: `App::run` wraps the finished router in an *outer*
+  `TrustedProxiesLayer` that resolves before the capture scope exists, so the
+  inner instance found the extension already present and skipped recording,
+  leaving `client_addr`/`client_host`/`client_scheme` empty on every
+  production capsule while the test harness (which has no outer layer) recorded
+  them. A second cause sat behind the first: the capture layer passed
+  `inner.call(req)` to `CAPSULE_SCOPE.scope` as an *argument*, which Rust
+  evaluates before the call, so every inner layer's synchronous `call` — where
+  a hand-written Tower middleware does its work — ran before the task-local
+  existed and saw no scope. The inner call is now made from inside the scoped
+  future, which fixes the class rather than the one layer.
+  Replay now rebuilds the database *shape* the recording had even when
+  the request issued no wire traffic at all — "this request ran no queries" and
+  "this application has no database" were the same `None`, so a handler or
+  state initializer that checks `state.pool()` or replica availability before
+  querying took a branch production never took. Redaction reaches two things it
+  used to miss: the credential *inside* a masked header (the token after
+  `Bearer`, what a `Basic` credential decodes to, each value of an auth-param
+  list such as SigV4's `Signature=`, each cookie value — the form
+  a handler actually extracts and may echo into an error message or a SQL bind,
+  where the whole header value never
+  matched), and values shorter than four characters, which are now masked where
+  they stand as a whole token, so a three-digit CVV quoted back by a failure no
+  longer reaches disk while timestamps and identifiers stay readable. Finally,
+  `SET LOCAL ...` is no longer treated as framework housekeeping: `Db::checkout`
+  issues a plain session-level `SET statement_timeout`, so a transaction-scoped
+  setting is application code and belongs on the ordered tape, where changing or
+  removing it shows up as a divergence instead of being synthesized away.
+- **duplicate Markdown heading anchors:** `markdown::render` now hands out
+  document-unique heading `id`s. A page that repeated a heading — and real docs
+  repeat "Example", "Usage", and "Notes" constantly — emitted the same `id`
+  twice, which is invalid HTML and made every table-of-contents entry for the
+  repeated heading jump to the first occurrence. Every heading still keeps the
+  slug its own text produces, so anchors already published in URLs keep
+  resolving; only *repeats* of an already-claimed slug get a `-1`, `-2`, …
+  suffix, the convention GitHub, mdBook, and Hugo share. Because the renderer
+  reserves every heading's natural slug before handing out any suffix, a repeat
+  can never steal a slug another heading owns by name regardless of the order
+  the two appear in: `## Example` / `## Example` / `## Example 1` renders
+  `example`, `example-2`, `example-1`, leaving `#example-1` pointing at
+  "Example 1". Headings with no alphanumeric characters still emit no `id` at
+  all and stay out of the anchor namespace.
 
 - **system-tests:** `SystemTest` and `autumn doctor` no longer report
   "no browser" on a Windows host that has Chrome installed (#1456), for three
@@ -3150,17 +3086,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   it can never be `--all-features`'d anyway (it keeps its dedicated `-p` test
   lanes). A dedicated `-p autumn-web --features "sqlite,mail"` lane preserves the
   `sqlite` + `mail` union compile in the coverage job. [no-plugin]
-### Added
-
-- **router:** new `health.enabled` config knob (default `true`,
-  `AUTUMN_HEALTH__ENABLED`) — an opt-out that suppresses all built-in probe
-  endpoints (`/health`, `/live`, `/ready`, `/startup`) so an app can own those
-  paths entirely (or expose none). Enabled by default, so behavior is
-  byte-identical to before when unset. Completes the probe-conflict work begun
-  in #1977 (which already lets a hand-written user route at a probe path win),
-  with explicit regression tests for both the user-route-wins and
-  probes-disabled cases (#1971).
-### Fixed
 
 - **deploy:** the one-time kamal-proxy reboot-durability upgrade (#2070/#2071) no
   longer stamps a new/removed `deploy.tls.host` onto the still-live OLD release
@@ -3176,46 +3101,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   self-heals by writing the marker; an unreadable marker fails closed at
   pre-flight (mirroring the #2073 port-change refuse) with two-deploy repair
   guidance. Part of #1607.
-### Added
-
-- **sim-testing:** `#[sim_test]` macro and public `Sim` skeleton for
-  deterministic simulation tests (seed-driven, replay-on-panic) (#1797). [no-plugin]
-### Changed
-
-- **cli:** the accessibility (a11y) verify step in the generated-app CI template
-  (`autumn new`) is now an **enforcing gate** — its `continue-on-error: true`
-  escape hatch has been removed, so an a11y violation now fails the job. The step
-  was shipped non-blocking in #2018 only until a pinned autumn release published
-  prebuilt CLI binaries; with v0.6.0 now published with prebuilt binaries, the
-  step runs against the release binary and blocks. Checklist item #7 of #2040.
-### Added
-
-- **security:** `autumn routes audit` (#1604) is now wired into every
-  scaffolded app's CI by default — `autumn new` adds a "Route auth coverage
-  (security manifest)" step to `.github/workflows/ci.yml`, right after the
-  a11y-verify step whose prebuilt CLI it reuses, so a route someone forgot to
-  classify fails CI on day one instead of waiting for an app to opt in.
-  Unclassified-route diagnostics now also name the offending handler's
-  `file:line` (from `file!()`/`line!()`, captured by the `#[get]`/`#[post]`/…,
-  `#[ws]`, and static-route macros alongside the existing module path), so a
-  failing gate points straight at the line to fix. A new [Route Auth
-  Coverage](docs/guide/route-auth-coverage.md) guide documents the
-  default-deny posture model and how to classify the three route kinds
-  (`gated`, `public`, `framework`), completing the deferred items from #1604's
-  first slice (#1850).
-
-### Security
-
-- **inbound_mail:** cap `multipart/*` nesting at 16 levels (`MAX_MIME_DEPTH`). A
-  deeply nested MIME body on an unauthenticated inbound-mail webhook could
-  previously recurse until the stack overflowed, aborting the process. Past the
-  cap the remaining subtree is kept verbatim as an opaque attachment — never
-  dropped (#1611).
-- **inbound_mail:** reject MIME boundaries RFC 2046 §5.1.1 does not permit —
-  empty, or longer than 70 characters. Such a `Content-Type` now takes the
-  existing single-part fallback instead of driving a boundary scan (#1611).
-
-### Fixed
 
 - **inbound_mail:** quoted MIME parameter values are no longer Latin-1 mangled
   (`filename="café.pdf"` came back as `cafÃ©.pdf`); the parser scans `char`s
@@ -3230,49 +3115,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **jobs:** pathological `#[job(unique_for = ...)]` windows and Redis maintenance
   intervals clamp their deadlines instead of overflowing `Instant + Duration`
   (#1611).
-
-### Changed
-
-- **panic gate:** the request-path panic gate (#1611) now also denies
-  `clippy::string_slice` and `clippy::arithmetic_side_effects` in every gated
-  module, and the manifest grows to 30 modules (adds `inbound_mail.rs`,
-  `nested_form.rs` — which carried the header but had drifted out of the
-  manifest — and the new crate-private `time_math` saturating-arithmetic
-  helpers). `scripts/check-panic-gate.sh` gains header anchoring, anti-spoof
-  checks for module-wide `allow`s, `reason =` hygiene on per-site allows,
-  reverse-manifest drift detection, a module-count floor, a CI
-  feature-reachability check (with a validated, self-expiring exemption list —
-  `middleware/trace_context.rs` is behind `telemetry-otlp`, which the lint runner
-  cannot enable without `protoc`, and the gate now says so on every run instead
-  of leaving it silently unenforced), and a `--self-test` mode that runs by
-  default;
-  `scripts/pre-push-check.sh` now runs the gate and the gated-features clippy
-  lane. CI lints the `inbound-mail`/`inbound-mailgun`/`inbound-ses`/`storage`
-  features and runs the inbound-mail test suites. [no-plugin]
-- **panic gate:** hardened `scripts/check-panic-gate.sh` against a set of
-  reviewer-confirmed bypasses that had passed both the script and `cargo clippy
-  -- -D warnings` while shipping a production panic (#1611). Header validation is
-  now structural (the block must open *exactly* `#![cfg_attr(not(test), deny(`
-  after comment/whitespace stripping), so a widened `all(not(test), any())`
-  predicate or a `not(test)` living only in a comment no longer passes. A new
-  tree-wide inner-suppression scan rejects any `#![allow(…)]`/`#![expect(…)]`
-  (including the `cfg_attr(…, allow(…))` form) that re-permits a gated lint or a
-  blanket group (`restriction`/`all`/`pedantic`/`nursery`) across **every** `*.rs`
-  under the scan roots — closing the unmarked-submodule hole — while exempting
-  `#[cfg(test)]` scopes; the scan roots now include the sibling framework crates
-  (`autumn-admin-plugin`, `autumn-media-plugin`, `autumn-storage-s3`,
-  `autumn-cache-redis`). Per-site allows must now carry a **non-empty** reason,
-  and the feature-reachability check only counts an *enforcing* CI clippy lane
-  (`-p autumn-web` + `-D warnings`, not commented out), so a stubbed lane can no
-  longer fake coverage. The `--self-test` suite grows to 34 cases, one per bypass.
-  CONTRIBUTING.md documents the enforced-subset scoping (the manifest is an
-  incremental subset of the request path, not the whole of it) and the
-  `macro_rules!` expansion blind spot the gate cannot see. [no-plugin]
-- **inbound_mail:** `compute_mailgun_signature` delegates to
-  `security::config::hmac_sha256_hex` (output byte-identical); removed a dead
-  re-parse in the SNS certificate DER reader (#1611). [no-plugin]
-
-### Fixed
 
 - **sim-testing:** `job::enqueue_in` / `enqueue_at`'s delayed enqueues now
   resolve their absolute due instant from the running job runtime's **injected**
@@ -3301,16 +3143,179 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   on a fresh clone while passing locally. `scripts/`, `scripts/lib/`, and
   `scripts/self-hosted-runner/` are now negated back in.
 
-### Deprecated
+### Security
 
-- **scheduler:** `scheduler::now_unix_secs` and `scheduler::now_unix_duration`
-  read real wall time off the injected-clock seam, so a tick key derived from
-  them is not reproducible under a `#[sim_test]`. Use
-  `time::clock_unix_secs(state.clock())` / `time::clock_unix_duration(state.clock())`
-  instead — which is what the framework's own scheduler already does. Neither
-  function has a remaining production caller inside autumn (#1797). See
-  [the migration guide](docs/migrations/next.md).
+- **inbound_mail:** cap `multipart/*` nesting at 16 levels (`MAX_MIME_DEPTH`). A
+  deeply nested MIME body on an unauthenticated inbound-mail webhook could
+  previously recurse until the stack overflowed, aborting the process. Past the
+  cap the remaining subtree is kept verbatim as an opaque attachment — never
+  dropped (#1611).
+- **inbound_mail:** reject MIME boundaries RFC 2046 §5.1.1 does not permit —
+  empty, or longer than 70 characters. Such a `Content-Type` now takes the
+  existing single-part fallback instead of driving a boundary scan (#1611).
 
+### Performance
+
+- **ingress middleware no longer boxes a future per layer per request:** every
+  `axum::middleware::from_fn` on the framework's always-on request path is now a
+  hand-rolled `tower::Service` with a **named** future. `from_fn` cannot avoid
+  the cost it was paying: the async block it generates has no nameable type, so
+  `FromFn::call` returns it as `Box::pin(..)` — one heap allocation per call
+  site per request, sized by everything that block captures across its single
+  `.await`, which for an outer layer is the whole downstream continuation. DHAT
+  measured those boxes at **19.57% of every byte** the `request_pipeline`
+  benchmark allocated (5,267,600 of 26,918,238 bytes over 650 requests) while
+  being only 2.14% of the blocks — the largest single allocation cost in the
+  profile (issue #2214).
+
+  Converted: the asset cache-control layer, the event-bus app context, the
+  webhook replay-key cleanup, the method-override rejection filter, the
+  trusted-host gate, the startup barrier, the per-request timeout, the
+  read-your-own-writes pin, and (under `oauth2`) the HTTP-interceptor scope.
+  Each keeps its behaviour and its position in the stack exactly; what goes away
+  is the box and, with it, the `self.inner.clone()` `from_fn` needed to move the
+  inner service into that box — which for an erased `BoxCloneSyncService` was a
+  recursive `clone_box` down the rest of the stack, so each conversion took a
+  whole deep-clone cascade with it too.
+
+  Re-run of the issue's own DHAT recipe on `benches/request_pipeline.rs`
+  (release, 200 iterations = 650 requests), before and after on the same
+  machine — filtering allocation sites whose second stack frame is
+  `FromFn<..>::call` exactly, as the issue specifies:
+
+  | | `FromFn::call` `Box::pin` | share of run bytes | marginal blocks/req | marginal bytes/req |
+  | --- | ---: | ---: | ---: | ---: |
+  | before | 3,250 blocks / 5,215,600 bytes | 19.80% | 168.8 | 36,826 |
+  | after | **0 / 0** (0 sites) | **0%** | 139.2 | 25,943 |
+
+  The before column reproduces the issue's measurement exactly on block count
+  (3,250) and to within 1% on bytes. Overall: **−17.5% allocations** and
+  **−29.6% bytes** per request.
+
+  The same movement is pinned as a regression gate in the debug profile, where
+  it is deterministic run to run: **172 → 140 allocation blocks** and
+  **37,819 → 26,030 bytes** per request under the default feature set. The ingress clone-on-call traversal count drops from 13 to 9 in
+  the same move, on the default set and on a 13-feature build alike. One layer
+  also sheds an allocation of its own: the asset cache-control layer no longer
+  clones the request path into a `String` on every request in the app.
+
+  Two middlewares are deliberately **not** converted, because they `.await`
+  before calling the inner service and their futures therefore cannot be named
+  without `type_alias_impl_trait`: the tenancy middleware (async tenant
+  extraction) and the rate-limit principal shim (async session read). Both are
+  off by default. `webhook_replay_cleanup` keeps one box, taken only on a `5xx`
+  that actually registered replay keys; on every other request its future is
+  unboxed (it still mints the per-request replay cell it always did).
+
+  One public behaviour change: `read_your_writes::middleware` used to
+  `unreachable!()` when handed `ReadYourWrites::Off`. It now debug-asserts and
+  falls back to an inert `Off` pin instead of panicking on the request path.
+  Both call sites gate on `mode != Off`, so the arm stays unreachable in
+  practice. Otherwise nothing public moved: `asset_cache_control`,
+  `method_override_rejection_filter` and `webhook_replay_cleanup_middleware`
+  remain exported `async fn`s with identical behaviour, now sharing their
+  decision logic with the layers so the two forms cannot drift.
+
+  Four gates keep the win from eroding: a per-request allocation **blocks**
+  ceiling tight enough that restoring a single `from_fn` fails it, a companion
+  **bytes** ceiling derived under the wider feature set CI actually gates with,
+  the ingress traversal count pinned to its exact measurement, and a
+  `type_name`-based assertion that none of the converted services ever returns a
+  `Pin<Box<dyn Future>>` again.
+
+- **config reads on the request path:** generated auth handlers, the admin
+  plugin, the `saas` starter, and the `blog`/`saas`/`teams` examples now read
+  configuration through `AppState::config_arc()` instead of
+  `AppState::config()`. `config()` returns an owned `AutumnConfig`, so every
+  call deep-clones **every** config section — 64 allocations and 1,384 bytes
+  against a default config, and more as an app's config grows — even to read a
+  single `bool` or `usize`. On a handler that cost is paid per request, and a
+  handler reading two or three sections paid it two or three times over: a
+  downstream app profiling its request path measured whole-config clones at
+  ~30% of its per-request allocations and ~42% of its per-request bytes.
+  `config_arc()` hands back the shared `Arc<AutumnConfig>` the state already
+  holds, so the same read is a refcount bump and handlers borrow the section
+  they need off the handle (`&config.auth.password`).
+
+  Nothing about the framework's own ingress path changed — that was already
+  allocation-free as of #2199 — and no public signature moved: `config()`
+  remains the per-boot owned-snapshot accessor, and the one generated call site
+  that still uses it is the boot-time `remember_me_startup` hook, which needs an
+  owned `RememberConfig`. Apps calling `state.config()` in their own handlers
+  keep compiling; switching them to `state.config_arc()` is the fix, and
+  `docs/guide/authentication.md` now teaches that as the default. A new
+  generator test pins the emitted handlers to `config_arc()` so the deep clone
+  cannot reappear in scaffolded apps.
+
+- **jobs:** the Postgres job worker's claim query (`SELECT … FOR UPDATE SKIP
+  LOCKED`) no longer scans and sorts the entire ready backlog for a queue
+  before picking one row, for apps that don't configure `[jobs] queues`
+  priority (the common case: a single `"default"` queue). The claim query's
+  `ORDER BY array_position($2::text[], candidate.queue), candidate.run_at`
+  was opaque to the planner — `array_position` depends on the bound queue-
+  order array, so even though it's constant across every candidate row when
+  only one queue is in play, Postgres couldn't prove that and fell back to a
+  `Bitmap Heap Scan` of the whole ready-in-queue backlog followed by a
+  `Sort` and `LockRows` over every one of those rows, before `LIMIT 1`
+  picked the winner. Single-queue workers now send a query that drops
+  `array_position` from `ORDER BY` and uses `queue = $2` (scalar), which
+  lets the planner recognize the existing `idx_autumn_jobs_queue_ready
+  (queue, run_at)` index order and do a plain `Index Scan` + `Limit 1`
+  instead. Measured (`EXPLAIN (ANALYZE, BUFFERS)`, production-shaped
+  fixture): 703→21 buffers at 4.4k ready rows, 3,342→22 at 44.6k, and
+  57,093→22 (eliminating an external-merge sort spill to disk) at 444k;
+  workload-level (`pg_stat_statements`, 50 claims) 166,437→1,410 total
+  buffers, a 99.15% reduction. No index or migration changes — see
+  `docs/reports/2026-08-14-ledger-job-claim-single-queue/`.
+
+- **state:** `AppState::profile` and `AppState::auth_session_key` no longer
+  deep-clone a `String` on every `AppState::clone()`. `AppState` is cloned
+  once per hop of the ingress tower stack (`Route::call` deep-clones the
+  boxed service beneath it, per #2193/#2198), so the two fields still held
+  as an owned `Option<String>`/`String` — rather than shared behind an
+  `Arc` like the rest of the struct — paid a fresh heap allocation on every
+  one of those clones instead of once per request. Both now live behind an
+  `Arc<str>`; `profile()` and `auth_session_key()` are unchanged (`&str`
+  via `Deref`), and `with_profile`/`with_auth_session_key` still take
+  `impl Into<String>`. Measured with the debug-profile allocation-counter
+  gate already used for #2198's `config_arc` work (`autumn/tests/config_alloc_gate.rs`):
+  a `TestClient` request drops from 220 to 172 allocation blocks (-22%),
+  identical across repeated runs.
+- **mail:** list-mail sends (`Mailer::send` with `list_unsubscribe` set) now
+  resolve suppression for the whole recipient batch in one query instead of
+  one `SELECT` per recipient. The `SuppressionStore` trait gained a batched
+  `is_suppressed_many` method (default implementation loops over
+  `is_suppressed`, so existing custom stores keep working unchanged);
+  `DbSuppressionStore` overrides it with a single `WHERE list_id = $1 AND
+  subscriber = ANY($2)` query, chunked at 50,000 recipients on Postgres (a
+  backstop against an unbounded single-statement bind, not a tuning knob for
+  ordinary sends: a tighter chunk size can land statements past a planner
+  cost crossover where `= ANY(...)` stops using the index and falls back to
+  a table scan, then re-pay that scan's fixed cost once per chunk) and at
+  `repository::MAX_BIND_PARAMS - 1` on SQLite, which binds `eq_any` as one
+  parameter per element instead of Postgres's single array parameter.
+  Measured
+  (`pg_stat_statements`, production-shaped `mail_unsubscribes` fixture):
+  statement count per send drops from N to 1 at every batch size tested
+  (200/2,000/20,000 recipients); total buffers 660→604 (200), 6,600→6,004
+  (2,000), and 66,000→8,070 (20,000, −87.8%). No index or migration changes
+  — see `docs/reports/2026-08-15-ledger-mail-suppression-batch/`.
+- **scaffold:** the generated `index` page for a `belongs_to`/`references`
+  field with a resolved display column (#1146) no longer scans the *entire*
+  referenced table to label the ~20 rows on one page. `autumn-cli`'s
+  `render_index_reference_label_loads` reused the create/edit form's
+  `{name}_select_options` loader — a full, unfiltered `SELECT id, col FROM
+  table ORDER BY id` that genuinely needs every row for a `<select>` — to
+  build the index's parent-label map too, so every index page view re-read
+  the whole referenced table regardless of page size. It now scopes the
+  query to `WHERE id = ANY(...)` the page's own FK values
+  (`page_data.content`, already fetched), and the identical fix applies to
+  the `--belongs-to` nested list (`children_section_with`). Measured
+  (`EXPLAIN (ANALYZE, BUFFERS)` + `pg_stat_statements`, production-shaped
+  fixture): rows read at the scan node drop from 500,000→20 (-99.996%) at
+  500k parent rows, with total buffers 7,051→83 (-98.8%); 707→61 (-91.4%)
+  at 50k rows and 72→54 (-25.0%) at 5k rows. No index or migration changes
+  — see `docs/reports/2026-08-16-ledger-scaffold-index-label-scope/`.
 
 ## [0.6.0] - 2026-07-18
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -67,9 +67,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.4"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+checksum = "c982642fa9e8606056828ee9a8505737230110bb1099153c79efe865c59d12ba"
 dependencies = [
  "memchr",
 ]
@@ -113,7 +113,7 @@ version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab097a7be305dd66b2b6917f5efb6b723129ce4b2cd11aa1a0afcc293c7dc08e"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "brotli-decompressor",
  "encoding_rs",
  "enumflags2",
@@ -144,9 +144,9 @@ dependencies = [
 
 [[package]]
 name = "android_system_properties"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+checksum = "ae221649c9976a6f6c56ae1facf410f3ddb33cc661c4b7b61020a912d4237fbc"
 dependencies = [
  "libc",
 ]
@@ -265,7 +265,7 @@ dependencies = [
  "nom 7.1.3",
  "num-traits",
  "rusticata-macros",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "time",
 ]
 
@@ -277,7 +277,7 @@ checksum = "965c2d33e53cb6b267e148a4cb0760bc01f4904c1cd4bb4002a085bb016d1490"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
  "synstructure",
 ]
 
@@ -289,7 +289,7 @@ checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
  "synstructure",
 ]
 
@@ -301,20 +301,20 @@ checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "astral-tokio-tar"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08648fef353ab39a9d26f909ad53fc4f071be4c91853b78523f5cc3d9e5ebffd"
+checksum = "b18457efd137254e016bbde5e1d88df61c4e1a5ae2223746e56123bac6af2463"
 dependencies = [
  "futures-core",
  "libc",
  "portable-atomic",
  "rustc-hash",
- "rustix 0.38.44",
+ "rustix",
  "tokio",
  "tokio-stream",
  "xattr",
@@ -322,9 +322,9 @@ dependencies = [
 
 [[package]]
 name = "async-compression"
-version = "0.4.42"
+version = "0.4.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e79b3f8a79cccc2898f31920fc69f304859b3bd567490f75ebf51ae1c792a9ac"
+checksum = "3976abdc8fe7d1133d43d304afd42abdf5bc3e1319d263d223bde07b5efc4be8"
 dependencies = [
  "compression-codecs",
  "compression-core",
@@ -362,18 +362,18 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "async-trait"
-version = "0.1.89"
+version = "0.1.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+checksum = "82f6aeea286b8eb4dd3431a1be1b59d290ace00f5bfd8e2a159bc2a05e2c1667"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -425,7 +425,7 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "autumn-admin-plugin"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "autumn-web",
  "axum",
@@ -435,13 +435,13 @@ dependencies = [
  "diesel-async",
  "form_urlencoded",
  "futures",
- "http 1.4.2",
+ "http 1.5.0",
  "maud",
  "serde",
  "serde_json",
  "testcontainers",
  "testcontainers-modules",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tower",
  "tracing",
@@ -449,7 +449,7 @@ dependencies = [
 
 [[package]]
 name = "autumn-cache-redis"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "autumn-web",
  "redis",
@@ -458,7 +458,7 @@ dependencies = [
  "serde_json",
  "testcontainers",
  "testcontainers-modules",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tower",
  "tracing",
@@ -466,7 +466,7 @@ dependencies = [
 
 [[package]]
 name = "autumn-cli"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "autumn-schema-core",
  "autumn-web",
@@ -497,30 +497,30 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.9",
- "syn 2.0.118",
+ "syn 2.0.119",
  "temp-env",
  "tempfile",
  "testcontainers",
  "testcontainers-modules",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tokio-postgres",
  "tokio-postgres-rustls",
- "toml 1.1.2+spec-1.1.0",
+ "toml 1.1.4+spec-1.1.0",
  "toml_edit",
  "url",
- "whoami 2.1.2",
+ "whoami 2.1.3",
 ]
 
 [[package]]
 name = "autumn-edge"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "autumn-macros",
  "axum",
  "base64 0.22.1",
  "futures",
- "http 1.4.2",
+ "http 1.5.0",
  "serde",
  "serde_json",
  "tower",
@@ -529,16 +529,16 @@ dependencies = [
 
 [[package]]
 name = "autumn-macros"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "autumn-media-plugin"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "autumn-web",
  "aws-config",
@@ -558,17 +558,17 @@ dependencies = [
  "tempfile",
  "testcontainers",
  "testcontainers-modules",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "time",
  "tokio",
- "toml 1.1.2+spec-1.1.0",
+ "toml 1.1.4+spec-1.1.0",
  "tracing",
  "uuid",
 ]
 
 [[package]]
 name = "autumn-schema-core"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -576,7 +576,7 @@ dependencies = [
 
 [[package]]
 name = "autumn-search"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "autumn-web",
  "diesel",
@@ -586,15 +586,15 @@ dependencies = [
  "tempfile",
  "testcontainers",
  "testcontainers-modules",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
- "toml 1.1.2+spec-1.1.0",
+ "toml 1.1.4+spec-1.1.0",
  "tracing",
 ]
 
 [[package]]
 name = "autumn-storage-s3"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "autumn-web",
  "aws-config",
@@ -607,7 +607,7 @@ dependencies = [
  "bytes",
  "futures",
  "temp-env",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "time",
  "tokio",
  "tracing",
@@ -615,7 +615,7 @@ dependencies = [
 
 [[package]]
 name = "autumn-web"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "aes-gcm",
  "allocation-counter",
@@ -643,7 +643,7 @@ dependencies = [
  "getrandom 0.2.17",
  "hex",
  "hmac 0.12.1",
- "http 1.4.2",
+ "http 1.5.0",
  "http-body 1.1.0",
  "http-body-util",
  "image",
@@ -672,7 +672,7 @@ dependencies = [
  "printpdf",
  "proptest",
  "pulldown-cmark",
- "rand 0.9.4",
+ "rand 0.9.5",
  "rand_chacha 0.9.0",
  "rcgen",
  "redis",
@@ -698,7 +698,7 @@ dependencies = [
  "tempfile",
  "testcontainers",
  "testcontainers-modules",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "time",
  "tokio",
  "tokio-cron-scheduler",
@@ -708,7 +708,7 @@ dependencies = [
  "tokio-stream",
  "tokio-tungstenite",
  "tokio-util",
- "toml 1.1.2+spec-1.1.0",
+ "toml 1.1.4+spec-1.1.0",
  "tower",
  "tower-http 0.7.0",
  "tracing",
@@ -745,7 +745,7 @@ dependencies = [
  "bytes",
  "fastrand",
  "hex",
- "http 1.4.2",
+ "http 1.5.0",
  "ring",
  "time",
  "tokio",
@@ -768,9 +768,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.17.1"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4342d8937fc7e5dd9b1c60292261c0670c882a2cd1719cfc11b1af41731e32ad"
+checksum = "ce2b2dcc879c3bae0d371e77c99f2238400ef24ec001394befa67b6e543add9e"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -778,9 +778,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.42.0"
+version = "0.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d9ceb1da931507a12f4fccea479dccd00da1943e1b4ae72d8e502d707361444"
+checksum = "f09fae7be8bb3174e05c6afdb34199e6dc0c7c04ba9fa237b1967adfbde27483"
 dependencies = [
  "cc",
  "cmake",
@@ -807,7 +807,7 @@ dependencies = [
  "bytes",
  "fastrand",
  "http 0.2.12",
- "http 1.4.2",
+ "http 1.5.0",
  "http-body 0.4.6",
  "http-body 1.1.0",
  "percent-encoding",
@@ -841,7 +841,7 @@ dependencies = [
  "hex",
  "hmac 0.12.1",
  "http 0.2.12",
- "http 1.4.2",
+ "http 1.5.0",
  "http-body 1.1.0",
  "lru 0.16.4",
  "percent-encoding",
@@ -870,7 +870,7 @@ dependencies = [
  "bytes",
  "fastrand",
  "http 0.2.12",
- "http 1.4.2",
+ "http 1.5.0",
  "regex-lite",
  "tracing",
 ]
@@ -894,7 +894,7 @@ dependencies = [
  "bytes",
  "fastrand",
  "http 0.2.12",
- "http 1.4.2",
+ "http 1.5.0",
  "regex-lite",
  "tracing",
 ]
@@ -919,7 +919,7 @@ dependencies = [
  "aws-types",
  "fastrand",
  "http 0.2.12",
- "http 1.4.2",
+ "http 1.5.0",
  "regex-lite",
  "tracing",
 ]
@@ -941,7 +941,7 @@ dependencies = [
  "hex",
  "hmac 0.12.1",
  "http 0.2.12",
- "http 1.4.2",
+ "http 1.5.0",
  "p256 0.11.1",
  "percent-encoding",
  "ring",
@@ -974,7 +974,7 @@ dependencies = [
  "bytes",
  "crc-fast",
  "hex",
- "http 1.4.2",
+ "http 1.5.0",
  "http-body 1.1.0",
  "http-body-util",
  "md-5 0.10.6",
@@ -1008,7 +1008,7 @@ dependencies = [
  "bytes-utils",
  "futures-core",
  "futures-util",
- "http 1.4.2",
+ "http 1.5.0",
  "http-body 1.1.0",
  "http-body-util",
  "percent-encoding",
@@ -1027,7 +1027,7 @@ dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "h2",
- "http 1.4.2",
+ "http 1.5.0",
  "hyper",
  "hyper-rustls",
  "hyper-util",
@@ -1084,7 +1084,7 @@ dependencies = [
  "bytes",
  "fastrand",
  "http 0.2.12",
- "http 1.4.2",
+ "http 1.5.0",
  "http-body 0.4.6",
  "http-body 1.1.0",
  "http-body-util",
@@ -1104,7 +1104,7 @@ dependencies = [
  "aws-smithy-types",
  "bytes",
  "http 0.2.12",
- "http 1.4.2",
+ "http 1.5.0",
  "pin-project-lite",
  "tokio",
  "tracing",
@@ -1122,7 +1122,7 @@ dependencies = [
  "bytes-utils",
  "futures-core",
  "http 0.2.12",
- "http 1.4.2",
+ "http 1.5.0",
  "http-body 0.4.6",
  "http-body 1.1.0",
  "http-body-util",
@@ -1172,7 +1172,7 @@ dependencies = [
  "bytes",
  "form_urlencoded",
  "futures-util",
- "http 1.4.2",
+ "http 1.5.0",
  "http-body 1.1.0",
  "http-body-util",
  "hyper",
@@ -1206,7 +1206,7 @@ checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
 dependencies = [
  "bytes",
  "futures-core",
- "http 1.4.2",
+ "http 1.5.0",
  "http-body 1.1.0",
  "http-body-util",
  "mime",
@@ -1225,7 +1225,7 @@ checksum = "7aa268c23bfbbd2c4363b9cd302a4f504fb2a9dfe7e3451d66f35dd392e20aca"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1262,6 +1262,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
+
+[[package]]
 name = "base64-simd"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1290,11 +1296,11 @@ dependencies = [
 
 [[package]]
 name = "bcrypt"
-version = "0.19.2"
+version = "0.19.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f3c067aa24dd4ed5c79cf222a38f260c8f23d3b82a062fba3f28c6fe563b753"
+checksum = "a0cd0bd35a28836d528d2b58ad499bc3c5641d59379421b1be9eeb0c2f2b912a"
 dependencies = [
- "base64 0.22.1",
+ "base64 0.23.1",
  "blowfish",
  "getrandom 0.4.3",
  "subtle",
@@ -1308,7 +1314,7 @@ dependencies = [
  "anyhow",
  "serde",
  "serde_json",
- "toml 1.1.2+spec-1.1.0",
+ "toml 1.1.4+spec-1.1.0",
 ]
 
 [[package]]
@@ -1358,9 +1364,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.13.0"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
 name = "bitvec"
@@ -1446,7 +1452,7 @@ checksum = "ee04c4c84f1f811b017f2fbb7dd8815c976e7ca98593de9c1e2afad0f636bff4"
 dependencies = [
  "async-stream",
  "base64 0.22.1",
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "bollard-buildkit-proto",
  "bollard-stubs",
  "bytes",
@@ -1454,7 +1460,7 @@ dependencies = [
  "futures-util",
  "hex",
  "home",
- "http 1.4.2",
+ "http 1.5.0",
  "http-body-util",
  "hyper",
  "hyper-named-pipe",
@@ -1464,7 +1470,7 @@ dependencies = [
  "log",
  "num",
  "pin-project-lite",
- "rand 0.9.4",
+ "rand 0.9.5",
  "rustls",
  "rustls-native-certs",
  "rustls-pki-types",
@@ -1472,7 +1478,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "serde_urlencoded",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "time",
  "tokio",
  "tokio-stream",
@@ -1514,7 +1520,7 @@ dependencies = [
 
 [[package]]
 name = "bookmarks"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "autumn-web",
  "chrono",
@@ -1534,7 +1540,7 @@ dependencies = [
 
 [[package]]
 name = "bookmarks-distributed"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "autumn-cache-redis",
  "autumn-web",
@@ -1552,14 +1558,14 @@ dependencies = [
  "testcontainers",
  "testcontainers-modules",
  "tokio",
- "toml 1.1.2+spec-1.1.0",
+ "toml 1.1.4+spec-1.1.0",
  "tracing",
  "validator",
 ]
 
 [[package]]
 name = "bookmarks-sharded"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "autumn-web",
  "chrono",
@@ -1577,9 +1583,9 @@ dependencies = [
 
 [[package]]
 name = "borsh"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f3f6da4992df95bbcd9af42a6c7dcb994498fc9048230405f3b36ff7cd3f145"
+checksum = "a88b7ea17d208c4193f2c1e6de3c35fe71f98c96982d5ced308bdcc749ff6e1f"
 dependencies = [
  "borsh-derive",
  "bytes",
@@ -1588,15 +1594,15 @@ dependencies = [
 
 [[package]]
 name = "borsh-derive"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ae8fb4fb5740e4b2c4884ff95f5f32f5e8479db1e8fd8eb49ddbe09eb09bb7c"
+checksum = "d8f347189c62a579b8cd5f80714efa178f52e461dc2e6d701d264f5ff22e566c"
 dependencies = [
  "once_cell",
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1665,9 +1671,9 @@ dependencies = [
 
 [[package]]
 name = "bytemuck"
-version = "1.25.0"
+version = "1.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+checksum = "95832e849adfb21180ccb6826a99da14e5d266ae5c2e668e1602cf234f153797"
 
 [[package]]
 name = "byteorder"
@@ -1717,9 +1723,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.66"
+version = "1.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5d6cac793997bd970000024b2934968efe83b382de4fdcf4fcb46b6ee4ad996"
+checksum = "0ad534f4357a5264cce5019c989cf66a4f0dc4e0d1b1d15f8aacec0ff7360273"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -1746,9 +1752,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cfg_aliases"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "chacha20"
@@ -1779,7 +1785,7 @@ dependencies = [
  "reqwest 0.13.4",
  "serde",
  "serde_json",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tracing",
  "url",
@@ -1871,9 +1877,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.3"
+version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fb99565819980999fb7b4a1796046a5c949e6d4ff132cf5fadf5a641e20d776"
+checksum = "473c7e07f409a8d772161724aa8db6a765a2532a70f9667eeb7b49d3d02fbdca"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1881,9 +1887,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.6.2"
+version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f09628afdcc538b57f3c6341e9c8e9970f18e4a481690a64974d7023bd33548b"
+checksum = "7b48fea5a88e9ae728a2dcbedbfc0e730f7d60da42e1cb049a83c9fb8b789889"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1893,14 +1899,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.3"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32f2392eae7f16557a3d727ef3a12e57b2b2ca6f98566a5f4fb41ffe305df077"
+checksum = "d012d2b9d65aca7f18f4d9878a045bc17899bba951561ba5ec3c2ba1eed9a061"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -2011,9 +2017,9 @@ dependencies = [
 
 [[package]]
 name = "cookie"
-version = "0.18.1"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747"
+checksum = "1a373e3602691c3cdea496d2f0ee5935151e6168fe87739483c463db1b2f2f87"
 dependencies = [
  "percent-encoding",
  "time",
@@ -2102,14 +2108,14 @@ dependencies = [
  "crc",
  "digest 0.10.7",
  "rustversion",
- "spin 0.10.0",
+ "spin 0.10.1",
 ]
 
 [[package]]
 name = "crc32fast"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+checksum = "8498c871161e1742aaa9d52551b2d6ebdd4c3d45a3be423e3728f33b955be550"
 dependencies = [
  "cfg-if",
 ]
@@ -2170,13 +2176,13 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "crossterm_winapi",
  "derive_more",
  "document-features",
  "mio",
  "parking_lot 0.12.5",
- "rustix 1.1.4",
+ "rustix",
  "signal-hook",
  "signal-hook-mio",
  "winapi",
@@ -2243,9 +2249,9 @@ dependencies = [
 
 [[package]]
 name = "css-inline"
-version = "0.21.0"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2f845f973dd2b71c48976c504756d7a163c5068dd6857b8d2f8ee1e92a190f6"
+checksum = "75a48bb4803d11b7129efb4d8eabac1c49c1483dcc6fe962f3d3aaba889e7b60"
 dependencies = [
  "cssparser",
  "html5ever",
@@ -2287,7 +2293,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10a2a99df6e410a8ff4245aa2006499ea662245f967cc7c0a38c83ef8eb44dbf"
 dependencies = [
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2364,7 +2370,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2398,6 +2404,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed17f5901b6630b993ca003def43f2f8ef4014fc13b047b57aad617ff32bc2ec"
+dependencies = [
+ "darling_core 0.24.1",
+ "darling_macro 0.24.1",
+]
+
+[[package]]
 name = "darling_core"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2408,7 +2424,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2422,7 +2438,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2435,7 +2451,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.118",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6837e2cf7485aaae18f86181d2f0e9a7ed297a025e220aeabf63fdebd3a2ddff"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -2446,7 +2475,7 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core 0.20.11",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2457,7 +2486,7 @@ checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
 dependencies = [
  "darling_core 0.21.3",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2468,14 +2497,25 @@ checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core 0.23.0",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ac7135c3ef02b2f7833bbeb1be5ba7f966dcde8a87c6b87f65a778d71a02785"
+dependencies = [
+ "darling_core 0.24.1",
+ "quote",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "data-encoding"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+checksum = "4583a4551df46e2792f82ceeac45e850d2e2d5debba0b91f102385cda5b11f06"
 
 [[package]]
 name = "deadpool"
@@ -2495,6 +2535,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2657f61fb1dd8bf37a8d51093cc7cee4e77125b22f7753f49b289f831bec2bae"
 dependencies = [
  "tokio",
+]
+
+[[package]]
+name = "defmt"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2953bfe4f93bbd20cc71198842756f77d161884c99ebbabc41d80231ded88d1"
+dependencies = [
+ "bitflags 1.3.2",
+ "defmt-macros",
+]
+
+[[package]]
+name = "defmt-macros"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bad9c72e7ca2137e0dc3813245a0d282fd6daad32fd800af018306a9169b5fe8"
+dependencies = [
+ "defmt-parser",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "defmt-parser"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
+dependencies = [
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -2535,7 +2606,7 @@ dependencies = [
  "asn1-rs 0.6.2",
  "displaydoc",
  "nom 7.1.3",
- "num-bigint",
+ "num-bigint 0.4.8",
  "num-traits",
  "rusticata-macros",
 ]
@@ -2549,7 +2620,7 @@ dependencies = [
  "asn1-rs 0.7.2",
  "displaydoc",
  "nom 7.1.3",
- "num-bigint",
+ "num-bigint 0.4.8",
  "num-traits",
  "rusticata-macros",
 ]
@@ -2562,7 +2633,7 @@ checksum = "8034092389675178f570469e6c3b0465d3d30b4505c294a6550db47f3c17ad18"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2592,7 +2663,7 @@ dependencies = [
  "darling 0.20.11",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2602,7 +2673,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
 dependencies = [
  "derive_builder_core",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2624,16 +2695,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "diesel"
-version = "2.3.10"
+version = "2.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29fe29a87fb84c631ffb3ba21798c4b1f3a964701ba78f0dce4bf8668562ec88"
+checksum = "715377c6e464cb44bb89bd8487584240516c8d5052bc645d6babc50bb8be46c3"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "byteorder",
  "chrono",
  "diesel_derives",
@@ -2671,7 +2742,7 @@ dependencies = [
  "dsl_auto_type",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2691,7 +2762,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe2444076b48641147115697648dc743c2c00b61adade0f01ce67133c7babe8c"
 dependencies = [
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2745,7 +2816,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "block2",
  "libc",
  "objc2",
@@ -2753,13 +2824,13 @@ dependencies = [
 
 [[package]]
 name = "displaydoc"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
+checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -2811,7 +2882,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2843,9 +2914,9 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "ecb"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbfbf3db731928d6912bc3beda911d55b834cee3df6131ba79b337a1298a3fa9"
+checksum = "26f2a8b3e564eba0877223dc343703ad0385794e882e6d13f3a4dd5c6b1f41ac"
 dependencies = [
  "cipher 0.5.2",
 ]
@@ -2912,9 +2983,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.16.0"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+checksum = "252afb9ae5eaa683babdc6a068b3f5726eb19e05070c731f9b2a23a7c3e8ed34"
 dependencies = [
  "serde",
 ]
@@ -2962,11 +3033,11 @@ dependencies = [
 
 [[package]]
 name = "email-encoding"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9298e6504d9b9e780ed3f7dfd43a61be8cd0e09eb07f7706a945b0072b6670b6"
+checksum = "420b9da095f052ea597503e39073b5b3c522f7db933fbac202d91d24492693fd"
 dependencies = [
- "base64 0.22.1",
+ "base64 0.23.1",
  "memchr",
 ]
 
@@ -3008,7 +3079,7 @@ checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3086,7 +3157,7 @@ dependencies = [
  "reqwest 0.12.28",
  "testcontainers",
  "testcontainers-modules",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
 ]
 
@@ -3107,16 +3178,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "fast-srgb8"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd2e7510819d6fbf51a5545c8f922716ecfb14df168a3242f7d33e0239efe6a1"
-
-[[package]]
 name = "fastrand"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "fdeflate"
@@ -3187,9 +3252,9 @@ dependencies = [
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.9"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+checksum = "d45db016d36b838f563236e9193d0ee6ce38f3f68b6c94e914b4929c96bbb890"
 
 [[package]]
 name = "finl_unicode"
@@ -3294,9 +3359,9 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a88cf1f829d945f548cf8fec32c61b1f202b6d93b45848602fc02af4b12ad218"
+checksum = "9a31d2a3fbaaeb2af2368bbdd904aa8e812d3c04a1ee10d3171f52d556e5d0a3"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -3309,9 +3374,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "262590f4fe6afeb0bc83be1daa64e52657fe185690a958af7f3ad0e92085c5ae"
+checksum = "b1f9e3d69d39e4862ffed03ed071a76f9a13ba1d9109d355b0f0aa6b15e393c4"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -3319,15 +3384,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cd50c473c80f6d7c3670a752354b8e569b1a7cbfdc0419ec88e5edad85e0dc7"
+checksum = "92d699e522242e69e3003b94ecc1f960f3a5e015aa7c5d7486e65ad01dd94f5e"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6754879cc9f2c66f88c6e5c35344bb0bdb0708b0352b1201815667c7eabc7458"
+checksum = "031b47cf1a3c6cc8bc2fc76cd437f521619387907d469316e7c0bc278f1f5432"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -3347,32 +3412,32 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4577ecaa3c4f96589d473f679a71b596316f6641bc350038b962a5daf0085d7a"
+checksum = "53c0fa8157de1303bfffdaa1cc2a673bfffb60102f76b0ef4441659124373fed"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d6d3cde68c518367be28956066ddfef33813991b77a55005a69dae04bf3b10b"
+checksum = "9fb9654ba8355388abeb8dcb4fc62f511300867002afc858860463bdd9fe0c44"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e34418ac499d6305c2fb5ad0ed2f6ac998c5f8ca209b4510f7f94242c647e307"
+checksum = "1944426bf7d03f1d14f708785e4b33efd750b36d48a157b836b3efc15ede8e1d"
 
 [[package]]
 name = "futures-task"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b231ed28831efb4a61a08580c4bc233ec56bc009f4cd8f52da2c3cb97df0c109"
+checksum = "cd417de3d1d015fc3bfd2b1ea46dfc7bab72ef86f1cc7cc9c78e728b34a6d1fd"
 
 [[package]]
 name = "futures-timer"
@@ -3382,9 +3447,9 @@ checksum = "af43fadb8a98512d547e37b4e92e0ced13e205c061b87b4623eff01d918d6968"
 
 [[package]]
 name = "futures-util"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a77a90a256fce34da66415271e30f94ee91c57b04b8a2c042d9cf3220179deaa"
+checksum = "0d50a92467f8ba5dd6e3ee5d4bd04d73ab2e4e1c44474a0674821dfce14b79bc"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -3474,9 +3539,9 @@ dependencies = [
 
 [[package]]
 name = "glob"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+checksum = "e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b"
 
 [[package]]
 name = "glyph-names"
@@ -3508,16 +3573,16 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.16"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
+checksum = "839c0e8a181239723652be9062bb56ca5bf5f64011f73b623f6f4fc59086a228"
 dependencies = [
  "atomic-waker",
  "bytes",
  "fnv",
  "futures-core",
  "futures-sink",
- "http 1.4.2",
+ "http 1.5.0",
  "indexmap 2.14.0",
  "slab",
  "tokio",
@@ -3679,9 +3744,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.4.2"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
+checksum = "918d3568bebf352712bc2ef3d46a8bcf1a75b373be6539de198e9105cbbf9ce0"
 dependencies = [
  "bytes",
  "itoa",
@@ -3705,18 +3770,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca2a8f2913ee65f60facd6a5905613afaa448497a0230cc41ce022d93290bc2c"
 dependencies = [
  "bytes",
- "http 1.4.2",
+ "http 1.5.0",
 ]
 
 [[package]]
 name = "http-body-util"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9f41fd6a08e4d4ec69df65976da761afd5ad5e58a9d4acb46bd1c953a9e3ff2"
+checksum = "23169fe34a5fbcdd3f3862e78fb9b6fccd5f02a6dc6f732547005d45631ce71c"
 dependencies = [
  "bytes",
  "futures-core",
- "http 1.4.2",
+ "http 1.5.0",
  "http-body 1.1.0",
  "pin-project-lite",
 ]
@@ -3741,25 +3806,25 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
+checksum = "707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b"
 dependencies = [
  "typenum",
 ]
 
 [[package]]
 name = "hyper"
-version = "1.10.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
+checksum = "d22053281f852e11534f5198498373cbb59295120a20771d90f7ed1897490a72"
 dependencies = [
  "atomic-waker",
  "bytes",
  "futures-channel",
  "futures-core",
  "h2",
- "http 1.4.2",
+ "http 1.5.0",
  "http-body 1.1.0",
  "httparse",
  "httpdate",
@@ -3772,9 +3837,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-named-pipe"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73b7d8abf35697b81a825e386fc151e0d503e8cb5fcb93cc8669c376dfd6f278"
+checksum = "fab3637d6b04a8037af8a266fdf6cf92ea957e8c53981a2bf6136572531025bf"
 dependencies = [
  "hex",
  "hyper",
@@ -3782,7 +3847,6 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tower-service",
- "winapi",
 ]
 
 [[package]]
@@ -3791,7 +3855,7 @@ version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
- "http 1.4.2",
+ "http 1.5.0",
  "hyper",
  "hyper-util",
  "rustls",
@@ -3826,7 +3890,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http 1.4.2",
+ "http 1.5.0",
  "http-body 1.1.0",
  "hyper",
  "ipnet",
@@ -3880,9 +3944,9 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+checksum = "fa68d21081c4a05d5a901a1c62add574c77048b6a1c67be3b50ce0b60d4ca513"
 dependencies = [
  "displaydoc",
  "potential_utf",
@@ -3894,9 +3958,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+checksum = "d56e28588da92eee5c3201a6eff33fabdd49b62269c8938d4ff050ce4d900deb"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -3907,9 +3971,9 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+checksum = "12f9cf5f235641ed274641dd81c3f28d870e276763d0797aeeab72317b1c646f"
 dependencies = [
  "icu_collections",
  "icu_normalizer_data",
@@ -3921,16 +3985,17 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+checksum = "1563da1ed3e0b3bf3d74c9b85917ac9c56464d2f57242270c09c9e752f8021a0"
 
 [[package]]
 name = "icu_properties"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+checksum = "7e7ca276ad3145661a65914e6daf131ca5120cd3dcee8f8f3214b8875184a148"
 dependencies = [
+ "displaydoc",
  "icu_collections",
  "icu_locale_core",
  "icu_properties_data",
@@ -3941,15 +4006,15 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+checksum = "e590f038c1464a96894fd6d10127e90a8be4509f56ff7ecef851b15cee0b7caa"
 
 [[package]]
 name = "icu_provider"
-version = "2.2.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+checksum = "d27bbb9d3abbefac45d55f647c9de1d44aafcd1186eb91879afef17c396c3e73"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -4088,11 +4153,11 @@ dependencies = [
 
 [[package]]
 name = "inotify"
-version = "0.11.3"
+version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd854a95a4ac672fed8c054136039fd32c22cf039ff09ead7280afe920486483"
+checksum = "4cc00ea907cab49550b7da656f80ebb97be1b997d931fbcd28d39734e17ce592"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "inotify-sys",
  "libc",
 ]
@@ -4127,15 +4192,15 @@ dependencies = [
 
 [[package]]
 name = "instability"
-version = "0.3.12"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5eb2d60ef19920a3a9193c3e371f726ec1dafc045dac788d0fb3704272458971"
+checksum = "2bf84e73fa6f27f299dec58e13223cf70db80da872eb921d4f6138342a0eabc8"
 dependencies = [
- "darling 0.23.0",
+ "darling 0.24.1",
  "indoc",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -4159,7 +4224,7 @@ dependencies = [
  "async-trait",
  "base64 0.22.1",
  "bytes",
- "http 1.4.2",
+ "http 1.5.0",
  "http-body 1.1.0",
  "http-body-util",
  "httpdate",
@@ -4172,7 +4237,7 @@ dependencies = [
  "rustls-pki-types",
  "serde",
  "serde_json",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
 ]
 
@@ -4198,9 +4263,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.12.0"
+version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+checksum = "6a756c3fac73139e83f14c2d742155dd2b78d3ee56597b419a0579b7bdd6dd78"
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -4224,6 +4289,59 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "jiff"
+version = "0.2.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "668b7183bd07af9a4885f5c35b0cc5c83c4607a913c16b7e17291832910d2dcc"
+dependencies = [
+ "defmt",
+ "jiff-core",
+ "jiff-static",
+ "jiff-tzdb-platform",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde_core",
+ "windows-link",
+]
+
+[[package]]
+name = "jiff-core"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7feca88439efe53da3754500c1851dedf3cb36c524dd5cf8225cc0794de95d09"
+dependencies = [
+ "defmt",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a69dcb3a21cfb32ce1cd056169337ca284af0766dd766e7878819b251a49204"
+dependencies = [
+ "jiff-core",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "jiff-tzdb"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "142bd39932ad231f10513df9ab62661fead8719872150b7ad02a2df79f4e141e"
+
+[[package]]
+name = "jiff-tzdb-platform"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "875a5a69ac2bab1a891711cf5eccbec1ce0341ea805560dcd90b7a2e925132e8"
+dependencies = [
+ "jiff-tzdb",
+]
+
+[[package]]
 name = "jni"
 version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4235,7 +4353,7 @@ dependencies = [
  "jni-sys",
  "log",
  "simd_cesu8",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "walkdir",
  "windows-link",
 ]
@@ -4250,7 +4368,7 @@ dependencies = [
  "quote",
  "rustc_version",
  "simd_cesu8",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4269,7 +4387,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
 dependencies = [
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4284,9 +4402,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.103"
+version = "0.3.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
+checksum = "0e0c1080212aad755ea003d18543e8768dd432c48819efd73a7bf1e39b7a5a3a"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -4306,7 +4424,7 @@ dependencies = [
  "js-sys",
  "p256 0.13.2",
  "p384",
- "rand 0.8.6",
+ "rand 0.8.7",
  "rsa",
  "serde",
  "serde_json",
@@ -4323,14 +4441,14 @@ checksum = "bde5057d6143cc94e861d90f591b9303d6716c6b9602309150bd068853c10899"
 dependencies = [
  "hashbrown 0.16.1",
  "portable-atomic",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
 name = "kqueue"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "273c0752728918e0ac4976f2b275b6fefb9ecd400585dec929419f3844cd87b5"
+checksum = "8d763e5b24120b4ddf50de6c92308156765aabfbbccebf401da7cff2d70a41ea"
 dependencies = [
  "kqueue-sys",
  "libc",
@@ -4342,7 +4460,7 @@ version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07293a4e297ac234359b510362495713f75ea345d5307140414f20c69ffeb087"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "libc",
 ]
 
@@ -4358,17 +4476,17 @@ version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 dependencies = [
- "spin 0.9.8",
+ "spin 0.9.9",
 ]
 
 [[package]]
 name = "lettre"
-version = "0.11.22"
+version = "0.11.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0da65617f6cb926332d039cb578aad56178da86e128db6a1b09f4c94fa5b3349"
+checksum = "f2c646bd5cc763b1087b15493e29a64be6147ba8f19342004fa52048ee596eae"
 dependencies = [
  "async-trait",
- "base64 0.22.1",
+ "base64 0.23.1",
  "email-encoding",
  "email_address",
  "fastrand",
@@ -4390,9 +4508,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.188"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22053b6a34f84abc97f9129e61334f40174659a1b9bd18c970b83db6a9a6348b"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "libm"
@@ -4402,21 +4520,21 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
-version = "0.1.18"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c943259e342f1e06ff2da7a83eabdfe7f92ce10262688dbf1895ff0b3e6e4652"
+checksum = "28d0a00925a9f930d679b6789b721e3a7f9ed110f41b86d2497caa780c3a070a"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "libc",
  "plain",
- "redox_syscall 0.9.0",
+ "redox_syscall 0.9.3",
 ]
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.37.0"
+version = "0.38.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f111c8c41e7c61a49cd34e44c7619462967221a6443b0ec299e0ac30cfb9b1"
+checksum = "f1d20bef17f513b9b3004532233187769cd072d790971f4e4da0e346eb6401e8"
 dependencies = [
  "cc",
  "pkg-config",
@@ -4425,18 +4543,12 @@ dependencies = [
 
 [[package]]
 name = "line-clipping"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f50e8f47623268b5407192d26876c4d7f89d686ca130fdc53bced4814cd29f8"
+checksum = "e752191d037c44ad111a8caa762921926658402f01cc1253f7bef2020ece4f5e"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
 ]
-
-[[package]]
-name = "linux-raw-sys"
-version = "0.4.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
@@ -4446,9 +4558,9 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+checksum = "47d9d19d1d6efa0109d2f65ff4c85cddd50bd572e5a00127ab10987290bcefae"
 
 [[package]]
 name = "litrs"
@@ -4467,9 +4579,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.33"
+version = "0.4.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
+checksum = "f9f8bd3e56ce4dfc153cf470fffbfa98c7620958b312ca5c3a4b8d5181fd13c6"
 
 [[package]]
 name = "loom"
@@ -4491,7 +4603,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e2ec995d822e05cabc3f06d196ee43650af3fe4fe38012cacb35e0c3d113b68"
 dependencies = [
  "aes 0.9.2",
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "cbc",
  "ecb",
  "encoding_rs",
@@ -4506,7 +4618,7 @@ dependencies = [
  "rangemap",
  "sha2 0.11.0",
  "stringprep",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "weezl",
 ]
 
@@ -4583,7 +4695,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8156733e27020ea5c684db5beac5d1d611e1272ab17901a49466294b84fc217e"
 dependencies = [
  "axum-core",
- "http 1.4.2",
+ "http 1.5.0",
  "itoa",
  "maud_macros",
 ]
@@ -4597,7 +4709,7 @@ dependencies = [
  "proc-macro2",
  "proc-macro2-diagnostics",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4709,9 +4821,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
+checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
 dependencies = [
  "libc",
  "log",
@@ -4721,9 +4833,9 @@ dependencies = [
 
 [[package]]
 name = "moka"
-version = "0.12.15"
+version = "0.12.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "957228ad12042ee839f93c8f257b62b4c0ab5eaae1d4fa60de53b27c9d7c5046"
+checksum = "4293f18e7567a1caf3c584855554377025c65e0aa445344d04171f5ad63d19b9"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-epoch",
@@ -4755,11 +4867,11 @@ dependencies = [
  "bytes",
  "encoding_rs",
  "futures-util",
- "http 1.4.2",
+ "http 1.5.0",
  "httparse",
  "memchr",
  "mime",
- "spin 0.9.8",
+ "spin 0.9.9",
  "version_check",
 ]
 
@@ -4781,7 +4893,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -4794,7 +4906,7 @@ version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -4826,7 +4938,7 @@ version = "8.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "fsevent-sys",
  "inotify",
  "kqueue",
@@ -4856,7 +4968,7 @@ version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
 ]
 
 [[package]]
@@ -4874,7 +4986,7 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
 dependencies = [
- "num-bigint",
+ "num-bigint 0.4.8",
  "num-complex",
  "num-integer",
  "num-iter",
@@ -4893,6 +5005,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93e7820bc0a80a0238e650327316f929ba18d5be054b647490a3a6a339f3e7c0"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-bigint-dig"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4903,7 +5025,7 @@ dependencies = [
  "num-integer",
  "num-iter",
  "num-traits",
- "rand 0.8.6",
+ "rand 0.8.7",
  "smallvec",
  "zeroize",
 ]
@@ -4931,7 +5053,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4946,9 +5068,9 @@ dependencies = [
 
 [[package]]
 name = "num-integer"
-version = "0.1.46"
+version = "0.1.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+checksum = "7ce2d95d4b3734dc35aa2f45e1aa22cd416814592a4f9d9205e11affd5b8e10b"
 dependencies = [
  "num-traits",
 ]
@@ -4969,7 +5091,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
 dependencies = [
- "num-bigint",
+ "num-bigint 0.4.8",
  "num-integer",
  "num-traits",
 ]
@@ -5018,7 +5140,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
 ]
 
 [[package]]
@@ -5078,7 +5200,7 @@ version = "0.10.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -5094,7 +5216,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5125,7 +5247,7 @@ dependencies = [
  "futures-sink",
  "js-sys",
  "pin-project-lite",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -5136,7 +5258,7 @@ checksum = "5683015d09e2df236ef005b17f6f196f0d5f6313c4fa43a7b6a53b52776e4331"
 dependencies = [
  "async-trait",
  "bytes",
- "http 1.4.2",
+ "http 1.5.0",
  "opentelemetry",
  "reqwest 0.13.4",
 ]
@@ -5147,14 +5269,14 @@ version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9966929966d17620d7c316c643ba62631826e10021409357772d5eea84f62c35"
 dependencies = [
- "http 1.4.2",
+ "http 1.5.0",
  "opentelemetry",
  "opentelemetry-http",
  "opentelemetry-proto",
  "opentelemetry_sdk",
  "prost",
  "reqwest 0.13.4",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tonic",
  "tonic-types",
@@ -5185,8 +5307,8 @@ dependencies = [
  "opentelemetry",
  "percent-encoding",
  "portable-atomic",
- "rand 0.9.4",
- "thiserror 2.0.19",
+ "rand 0.9.5",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -5225,7 +5347,7 @@ dependencies = [
  "proc-macro2",
  "proc-macro2-diagnostics",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5271,26 +5393,35 @@ dependencies = [
 
 [[package]]
 name = "palette"
-version = "0.7.6"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cbf71184cc5ecc2e4e1baccdb21026c20e5fc3dcf63028a086131b3ab00b6e6"
+checksum = "ddeed8580d347d2abf3dcf06a5f0b3dc020258338526b277847cd4248a70fc64"
 dependencies = [
  "approx",
- "fast-srgb8",
  "libm",
  "palette_derive",
+ "palette_math",
 ]
 
 [[package]]
 name = "palette_derive"
-version = "0.7.6"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5030daf005bface118c096f510ffb781fc28f9ab6a32ab224d8631be6851d30"
+checksum = "88537020289b719d81be994ccf1bbf4990f477e2f69ee52fe3e45f43a02e56be"
 dependencies = [
  "by_address",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "palette_math"
+version = "0.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e6eb142958d64335fb0e345c5b9ead2ecd6fc438c307e9d7d3c4fd428dbaf12"
+dependencies = [
+ "libm",
 ]
 
 [[package]]
@@ -5369,7 +5500,7 @@ dependencies = [
  "regex",
  "regex-syntax",
  "structmeta",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5424,9 +5555,9 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pest"
-version = "2.8.7"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47627dd7305c6a2d6c8c6bcd24c5a4c17dbbf425f4f9c5313e724b38fc9782e9"
+checksum = "5a07a60cc7a4d00c91f95c685609d1d2f79050e6804b70ebedd7650f0b839bcf"
 dependencies = [
  "memchr",
  "ucd-trie",
@@ -5434,9 +5565,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.8.7"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b4254325ecad416ab689e27ba51da03ba01a9632bc6e108f5fe7c3c4ad29d58"
+checksum = "b3a83744a5c8455b8b3e0dc5031362780a347c878bdd11584d1a8984228cc88d"
 dependencies = [
  "pest",
  "pest_generator",
@@ -5444,22 +5575,22 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.8.7"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c4c0e91ead7a8f7acecbca6f003fc2e8282b1dbe2dd9c9d2f16aba42995e0a7"
+checksum = "e0cd3451aa3de60d4b9a1e736885e4dea6b31617598026f12256ad566d63304a"
 dependencies = [
  "pest",
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "pest_meta"
-version = "2.8.7"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9744bc48116fee06334924bb5f2bad41eed5e89bd26e29b0b799f9a3f82c210"
+checksum = "e04d3a0849e241d7dfce834c83b1c5edc8622009e8dd51a12ba1927c32f05496"
 dependencies = [
  "pest",
 ]
@@ -5521,7 +5652,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
  "phf_shared 0.11.3",
- "rand 0.8.6",
+ "rand 0.8.7",
 ]
 
 [[package]]
@@ -5544,7 +5675,7 @@ dependencies = [
  "phf_shared 0.11.3",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5557,7 +5688,7 @@ dependencies = [
  "phf_shared 0.13.1",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5604,7 +5735,7 @@ checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5652,9 +5783,9 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+checksum = "f6b464fbc74e149a392436b17d523f769e057cb6877f6a5c4618bc6f11800548"
 
 [[package]]
 name = "plain"
@@ -5668,7 +5799,7 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "crc32fast",
  "fdeflate",
  "flate2",
@@ -5689,9 +5820,18 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic"
-version = "1.13.1"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+checksum = "05c8b63e8d9609db387f0324918f81d68fe27748f084ef092fb35954d0539a85"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
+dependencies = [
+ "portable-atomic",
+]
 
 [[package]]
 name = "postgres-protocol"
@@ -5747,7 +5887,7 @@ dependencies = [
  "tar",
  "target-triple 0.1.4",
  "tempfile",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tracing",
  "url",
 ]
@@ -5758,7 +5898,7 @@ version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9cc8653c31df5ffcd3bc114641dfae5390404d6e22bc21fd7473760f22cdc20b"
 dependencies = [
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tracing",
 ]
@@ -5772,12 +5912,12 @@ dependencies = [
  "anyhow",
  "postgresql_archive",
  "postgresql_commands",
- "rand 0.9.4",
+ "rand 0.9.5",
  "semver",
  "sqlx",
  "target-triple 0.1.4",
  "tempfile",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tracing",
  "url",
@@ -5785,9 +5925,9 @@ dependencies = [
 
 [[package]]
 name = "potential_utf"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+checksum = "d83eb9bc6d8e5cf568e7a1101d60ee05e81ed50ea106026f3d18deeb046d7661"
 dependencies = [
  "zerovec",
 ]
@@ -5845,9 +5985,9 @@ dependencies = [
 
 [[package]]
 name = "printpdf"
-version = "0.12.5"
+version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8830a8a6c6431286333c8a64d109f7f0e7e050270c8b8eba0a4c541626059da5"
+checksum = "e75e1f6d16f80c8f34918a4cc68743d703e8ee5016fac9508e223eb8e60445a0"
 dependencies = [
  "allsorts-azul",
  "base64 0.22.1",
@@ -5874,25 +6014,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-error-attr2"
-version = "2.0.0"
+name = "proc-macro-error-attr3"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
+checksum = "b0084e6206a967a2dad822180626b2f6b07a3b379325e8f1ec0438e33a469ba7"
 dependencies = [
  "proc-macro2",
  "quote",
 ]
 
 [[package]]
-name = "proc-macro-error2"
-version = "2.0.1"
+name = "proc-macro-error3"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+checksum = "0cf066225f2373bc711684792b69bdeac0356019b007e721090c24d92d5d5a50"
 dependencies = [
- "proc-macro-error-attr2",
+ "proc-macro-error-attr3",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -5912,7 +6052,7 @@ checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
  "version_check",
  "yansi",
 ]
@@ -5925,9 +6065,9 @@ checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
 dependencies = [
  "bit-set 0.8.0",
  "bit-vec 0.8.0",
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "num-traits",
- "rand 0.9.4",
+ "rand 0.9.5",
  "rand_chacha 0.9.0",
  "rand_xorshift",
  "regex-syntax",
@@ -5956,7 +6096,7 @@ dependencies = [
  "itertools",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -6010,7 +6150,7 @@ version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9f068eba8e7071c5f9511831b44f32c740d5adf574e990f946ddb53db2f314e"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "memchr",
  "pulldown-cmark-escape",
  "unicase",
@@ -6054,7 +6194,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tracing",
  "web-time",
@@ -6062,9 +6202,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.16"
+version = "0.11.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
+checksum = "04759210543be93709136e28212294a659ef5001836ff4eab4d663e4529bba83"
 dependencies = [
  "aws-lc-rs",
  "bytes",
@@ -6077,7 +6217,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tinyvec",
  "tracing",
  "web-time",
@@ -6132,9 +6272,9 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -6143,9 +6283,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -6226,9 +6366,9 @@ dependencies = [
 
 [[package]]
 name = "rangemap"
-version = "1.7.1"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "973443cf09a9c8656b574a866ab68dfa19f0867d0340648c7d2f6a71b8a8ea68"
+checksum = "a611d15b50743feb4c76b7d03edcb0e64f399c26961e4efe6975bc398be6aa3d"
 
 [[package]]
 name = "ratatui"
@@ -6252,7 +6392,7 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cbb175c433c8e28a809d1f5773a2ae96e68c0ce40db865cbab1020bf33ae479c"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "compact_str",
  "critical-section",
  "hashbrown 0.17.1",
@@ -6262,7 +6402,7 @@ dependencies = [
  "palette",
  "serde",
  "strum 0.28.0",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "unicode-segmentation",
  "unicode-truncate",
  "unicode-width",
@@ -6317,7 +6457,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66e3d19bcc9130ca376277d93b60767ff121ace3be06f5f95f81dd68956407d1"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "hashbrown 0.17.1",
  "indoc",
  "instability",
@@ -6333,9 +6473,9 @@ dependencies = [
 
 [[package]]
 name = "rcgen"
-version = "0.14.8"
+version = "0.14.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57f6d249aad744e274e682777a50283a225a32705394ee6d5fcc01efa25e4055"
+checksum = "091e7a8e7d86e6feb87a27ce8e2cba29d49eff9507afeebefab7eeb2ca667fb4"
 dependencies = [
  "pem",
  "ring",
@@ -6347,7 +6487,7 @@ dependencies = [
 
 [[package]]
 name = "reddit-clone"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "async-stream",
  "autumn-storage-s3",
@@ -6371,11 +6511,11 @@ dependencies = [
  "tempfile",
  "testcontainers",
  "testcontainers-modules",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tokio-stream",
  "tokio-util",
- "toml 1.1.2+spec-1.1.0",
+ "toml 1.1.4+spec-1.1.0",
  "tracing",
  "tracing-subscriber",
  "url",
@@ -6385,9 +6525,9 @@ dependencies = [
 
 [[package]]
 name = "redis"
-version = "1.4.1"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0b9503711b03773e43b31668c7b5bd279ee7cd9b7d18cff7c23a42cc1d08e5a"
+checksum = "e37a4ca5c6ca42aa3e6df2fd32b987a65d32a4c2159a6f3fe0fd1df306a2658f"
 dependencies = [
  "arc-swap",
  "arcstr",
@@ -6399,7 +6539,7 @@ dependencies = [
  "futures-channel",
  "futures-util",
  "itoa",
- "num-bigint",
+ "num-bigint 0.5.1",
  "percent-encoding",
  "pin-project-lite",
  "rustls",
@@ -6429,16 +6569,16 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
 ]
 
 [[package]]
 name = "redox_syscall"
-version = "0.9.0"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5102a6aaa05aa011a238e178e6bca86d2cb56fc9f586d37cb80f5bca6e07759"
+checksum = "d678d17679829e73d371e96880897e98fee2ded7acc0a50bdf8af2affa4b2fe5"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
 ]
 
 [[package]]
@@ -6449,34 +6589,34 @@ checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
  "getrandom 0.2.17",
  "libredox",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
 name = "ref-cast"
-version = "1.0.25"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+checksum = "7e440fb4e4b4147295338efb76001ab9e4efc0e5839df2c47fc5ac2381d365c3"
 dependencies = [
  "ref-cast-impl",
 ]
 
 [[package]]
 name = "ref-cast-impl"
-version = "1.0.25"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+checksum = "92ecd8964f8453721699a1ed72037b0db49ce2f5a5138486ee89bed6f67cdf3a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "regex"
-version = "1.12.4"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
+checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -6486,9 +6626,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.14"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+checksum = "ad8553b9b26413251cbf30e620595c7a41b3887f03da04579c0e6b0d6a06b4b2"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -6526,7 +6666,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-util",
- "http 1.4.2",
+ "http 1.5.0",
  "http-body 1.1.0",
  "http-body-util",
  "hyper",
@@ -6571,7 +6711,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "http 1.4.2",
+ "http 1.5.0",
  "http-body 1.1.0",
  "http-body-util",
  "hyper",
@@ -6608,7 +6748,7 @@ checksum = "57f17d28a6e6acfe1733fe24bcd30774d13bffa4b8a22535b4c8c98423088d4e"
 dependencies = [
  "anyhow",
  "async-trait",
- "http 1.4.2",
+ "http 1.5.0",
  "reqwest 0.12.28",
  "serde",
  "thiserror 1.0.69",
@@ -6625,7 +6765,7 @@ dependencies = [
  "async-trait",
  "futures",
  "getrandom 0.2.17",
- "http 1.4.2",
+ "http 1.5.0",
  "hyper",
  "parking_lot 0.11.2",
  "reqwest 0.12.28",
@@ -6646,7 +6786,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "getrandom 0.2.17",
- "http 1.4.2",
+ "http 1.5.0",
  "matchit",
  "reqwest 0.12.28",
  "reqwest-middleware",
@@ -6659,7 +6799,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5875471e6cab2871bc150ecb8c727db5113c9338cc3354dc5ee3425b6aa40a1c"
 dependencies = [
- "rand 0.8.6",
+ "rand 0.8.7",
 ]
 
 [[package]]
@@ -6753,7 +6893,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c51c9ae4df8a7fba42103df5c621fa3c37eccf3a3c650879e90fc48b11cc192c"
 dependencies = [
  "hashbrown 0.16.1",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -6766,7 +6906,7 @@ dependencies = [
  "borsh",
  "bytes",
  "num-traits",
- "rand 0.8.6",
+ "rand 0.8.7",
  "rkyv",
  "serde",
  "serde_json",
@@ -6799,35 +6939,22 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
-dependencies = [
- "bitflags 2.13.0",
- "errno",
- "libc",
- "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "errno",
  "libc",
- "linux-raw-sys 0.12.1",
+ "linux-raw-sys",
  "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "rustls"
-version = "0.23.42"
+version = "0.23.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c54fcab019b409d04215d3a17cb438fd7fbf192ee61461f20f4fe18704bc138"
+checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -6853,9 +6980,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.15.0"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "764899a24af3980067ee14bc143654f297b22eaebfe3c7b6b211920a5a59b046"
+checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
 dependencies = [
  "web-time",
  "zeroize",
@@ -6890,9 +7017,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.13"
+version = "0.103.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+checksum = "f3c3cf1d8b1e7d4927e2d154c3fcb02979afb9939629c62cd9048d4f07b60ac2"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -6974,9 +7101,9 @@ dependencies = [
 
 [[package]]
 name = "schemars"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
+checksum = "687274d293b6cdc6e73e0fee520bf2049650090d7164f87672d212a3c530cf4a"
 dependencies = [
  "dyn-clone",
  "ref-cast",
@@ -7055,7 +7182,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -7074,11 +7201,11 @@ dependencies = [
 
 [[package]]
 name = "selectors"
-version = "0.38.0"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8adfa1c298912827b8a28b223b3b874357397ae706e6190acd9bf28cee99114d"
+checksum = "eeee001a77567bb05e71652718d3ff76d8697c151ac523e68e9513194eb2b75a"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "cssparser",
  "derive_more",
  "log",
@@ -7134,7 +7261,7 @@ checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.2",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -7163,13 +7290,13 @@ dependencies = [
 
 [[package]]
 name = "serde_repr"
-version = "0.1.20"
+version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
+checksum = "8d3b1629de253c70a0508c3899572da79ca359fdab27c7920ff00406df418906"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -7195,9 +7322,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.21.0"
+version = "3.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76a5c54c7310e7b8b9577c286d7e399ddd876c3e12b3ed917a8aabc4b96e9e8c"
+checksum = "ee78f1fbe43ac4a0e47aadb3dbd357b69eb0d3793e948624cd03dd2750ab1c0a"
 dependencies = [
  "base64 0.22.1",
  "bs58",
@@ -7205,8 +7332,9 @@ dependencies = [
  "hex",
  "indexmap 1.9.3",
  "indexmap 2.14.0",
+ "jiff",
  "schemars 0.9.0",
- "schemars 1.2.1",
+ "schemars 1.2.2",
  "serde_core",
  "serde_json",
  "serde_with_macros",
@@ -7215,14 +7343,14 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.21.0"
+version = "3.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84d57bc0c8b9a17920c178daa6bb924850d54a9c97ab45194bb8c17ad66bb660"
+checksum = "8705578779c2b6bd90d84d66eb2e206b708b1a4d7b9f17641b293545bf1c7e46"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -7249,9 +7377,9 @@ dependencies = [
 
 [[package]]
 name = "sha1"
-version = "0.10.6"
+version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+checksum = "a978451301f4db1d02937a4ab3ccce137717b81826e79b7d49ffe3244a13c3b8"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
@@ -7354,15 +7482,15 @@ dependencies = [
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
 
 [[package]]
 name = "simd_cesu8"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+checksum = "11031e251abf8611c80f460e19dbdeb54a66db918e49c65a7065b46ac7aec520"
 dependencies = [
  "rustc_version",
  "simdutf8",
@@ -7407,15 +7535,15 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
 
 [[package]]
 name = "spin"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
+checksum = "023a211cb3138dbc438680b32560ad89f699977624c9f8dbb95a47d5b4c07dd3"
 
 [[package]]
 name = "spki"
@@ -7488,7 +7616,7 @@ dependencies = [
  "serde_json",
  "sha2 0.10.9",
  "smallvec",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -7506,7 +7634,7 @@ dependencies = [
  "quote",
  "sqlx-core",
  "sqlx-macros-core",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -7527,7 +7655,7 @@ dependencies = [
  "sha2 0.10.9",
  "sqlx-core",
  "sqlx-postgres",
- "syn 2.0.118",
+ "syn 2.0.119",
  "tokio",
  "url",
 ]
@@ -7540,7 +7668,7 @@ checksum = "db58fcd5a53cf07c184b154801ff91347e4c30d17a3562a635ff028ad5deda46"
 dependencies = [
  "atoi",
  "base64 0.22.1",
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "byteorder",
  "crc",
  "dotenvy",
@@ -7557,14 +7685,14 @@ dependencies = [
  "md-5 0.10.6",
  "memchr",
  "once_cell",
- "rand 0.8.6",
+ "rand 0.8.7",
  "serde",
  "serde_json",
  "sha2 0.10.9",
  "smallvec",
  "sqlx-core",
  "stringprep",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tracing",
  "whoami 1.6.1",
 ]
@@ -7641,7 +7769,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "structmeta-derive",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -7652,7 +7780,7 @@ checksum = "152a0b65a590ff6c3da95cabe2353ee04e6167c896b28e3b14478c2636c922fc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -7682,7 +7810,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -7694,7 +7822,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -7716,9 +7844,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.118"
+version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7727,9 +7855,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "3.0.2"
+version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a207d6d6a2b7fc470b80443726053f18a2481b7e1eee970597051596567987a3"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7753,7 +7881,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -7787,9 +7915,9 @@ checksum = "1ac9aa371f599d22256307c24a9d748c041e548cbf599f35d890f9d365361790"
 
 [[package]]
 name = "target-triple"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "591ef38edfb78ca4771ee32cf494cb8771944bee237a9b91fc9c1424ac4b777b"
+checksum = "c3a6bfce3d99adfa72d24750a61f782f3036a81e7f86d8841ee1326deaebd171"
 
 [[package]]
 name = "teams"
@@ -7830,7 +7958,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.4.3",
  "once_cell",
- "rustix 1.1.4",
+ "rustix",
  "windows-sys 0.61.2",
 ]
 
@@ -7858,9 +7986,9 @@ version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9048a889effe34a5cddee0af7f53285198b16dca3be510858d38dfdb3e62a04e"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "parking_lot 0.12.5",
- "rustix 1.1.4",
+ "rustix",
  "signal-hook",
  "windows-sys 0.61.2",
 ]
@@ -7894,7 +8022,7 @@ checksum = "4676b37242ccbd1aabf56edb093a4827dc49086c0ffd764a5705899e0f35f8f7"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "fancy-regex",
  "filedescriptor",
  "finl_unicode",
@@ -7943,7 +8071,7 @@ dependencies = [
  "etcetera 0.11.0",
  "ferroid",
  "futures",
- "http 1.4.2",
+ "http 1.5.0",
  "itertools",
  "log",
  "memchr",
@@ -7952,7 +8080,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -7979,11 +8107,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.19"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
+checksum = "ec86235f5fcc2a73650310756d2ac5b138a5780bbbdfae3eeccec992c435ba4f"
 dependencies = [
- "thiserror-impl 2.0.19",
+ "thiserror-impl 2.0.20",
 ]
 
 [[package]]
@@ -7994,34 +8122,34 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.19"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
+checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.2",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "thread_local"
-version = "1.1.9"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+checksum = "1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "time"
-version = "0.3.54"
+version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e1d5e639ff6bab73cb6885cc7e7b1de96c3f32c68ec55f3952614bec1092244"
+checksum = "cdb87b95ec50ddfa440816d227a17b2ccbdda963a316a727fda0fc4334f7d134"
 dependencies = [
  "deranged",
  "libc",
@@ -8051,9 +8179,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+checksum = "b1e27c91459209c2986af3dcf603a5a74a4368754ce37414f59acc971167f643"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -8061,9 +8189,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -8092,7 +8220,7 @@ checksum = "2d2e76690929402faae40aebdda620a2c0e25dd6d3b9afe48867dfd95991f4bd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -8107,7 +8235,7 @@ dependencies = [
  "diesel_migrations",
  "example-e2e",
  "futures",
- "http 1.4.2",
+ "http 1.5.0",
  "maud",
  "pq-sys",
  "serde",
@@ -8119,9 +8247,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.52.3"
+version = "1.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
+checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
 dependencies = [
  "bytes",
  "libc",
@@ -8152,13 +8280,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.7.0"
+version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+checksum = "78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -8184,7 +8312,7 @@ dependencies = [
  "socket2",
  "tokio",
  "tokio-util",
- "whoami 2.1.2",
+ "whoami 2.1.3",
 ]
 
 [[package]]
@@ -8214,9 +8342,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+checksum = "a3d06f0b082ba57c26b79407372e57cf2a1e28124f78e9479fe80322cf53420b"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -8266,9 +8394,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "1.1.2+spec-1.1.0"
+version = "1.1.4+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
+checksum = "3aace63f4bbcdfc2c965b059de67119c89c4017a70d633be6c104910f67056f5"
 dependencies = [
  "indexmap 2.14.0",
  "serde_core",
@@ -8276,7 +8404,7 @@ dependencies = [
  "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
  "toml_writer",
- "winnow 1.0.3",
+ "winnow 1.0.4",
 ]
 
 [[package]]
@@ -8299,31 +8427,31 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.25.12+spec-1.1.0"
+version = "0.25.13+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
+checksum = "6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b"
 dependencies = [
  "indexmap 2.14.0",
  "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
  "toml_writer",
- "winnow 1.0.3",
+ "winnow 1.0.4",
 ]
 
 [[package]]
 name = "toml_parser"
-version = "1.1.2+spec-1.1.0"
+version = "1.1.3+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
 dependencies = [
- "winnow 1.0.3",
+ "winnow 1.0.4",
 ]
 
 [[package]]
 name = "toml_writer"
-version = "1.1.1+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
+checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
 
 [[package]]
 name = "tonic"
@@ -8336,7 +8464,7 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "h2",
- "http 1.4.2",
+ "http 1.5.0",
  "http-body 1.1.0",
  "http-body-util",
  "hyper",
@@ -8403,10 +8531,10 @@ version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "bytes",
  "futures-util",
- "http 1.4.2",
+ "http 1.5.0",
  "http-body 1.1.0",
  "pin-project-lite",
  "tower",
@@ -8422,11 +8550,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b11f75e912b0c2be01b63d8cf8057b8c3f97cf34abb3d431a3a4c8675498e233"
 dependencies = [
  "async-compression",
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "bytes",
  "futures-core",
  "futures-util",
- "http 1.4.2",
+ "http 1.5.0",
  "http-body 1.1.0",
  "http-body-util",
  "http-range-header",
@@ -8474,7 +8602,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -8553,17 +8681,17 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "trybuild"
-version = "1.0.118"
+version = "1.0.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06649c6f63d86604ba0c8950d5a1829fc9a17afd70fc6629f481d75b6a624c78"
+checksum = "1e605bf6b39357663d8ba4e984f8be8da8df6bb32e81031d6889024ea8fd68e4"
 dependencies = [
  "glob",
  "serde",
  "serde_derive",
  "serde_json",
- "target-triple 1.0.0",
+ "target-triple 1.0.1",
  "termcolor",
- "toml 1.1.2+spec-1.1.0",
+ "toml 1.1.4+spec-1.1.0",
 ]
 
 [[package]]
@@ -8574,12 +8702,12 @@ checksum = "8628dcc84e5a09eb3d8423d6cb682965dea9133204e8fb3efee74c2a0c259442"
 dependencies = [
  "bytes",
  "data-encoding",
- "http 1.4.2",
+ "http 1.5.0",
  "httparse",
  "log",
- "rand 0.9.4",
+ "rand 0.9.5",
  "sha1",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "utf-8",
 ]
 
@@ -8591,12 +8719,12 @@ checksum = "6c01152af293afb9c7c2a57e4b559c5620b421f6d133261c60dd2d0cdb38e6b8"
 dependencies = [
  "bytes",
  "data-encoding",
- "http 1.4.2",
+ "http 1.5.0",
  "httparse",
  "log",
- "rand 0.9.4",
+ "rand 0.9.5",
  "sha1",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -8721,11 +8849,11 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "ureq"
-version = "3.3.0"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
+checksum = "972d7902c8735f2695410b8aed7df6ed12a47394aa1c8d7af49f0497b731a94d"
 dependencies = [
- "base64 0.22.1",
+ "base64 0.23.1",
  "log",
  "percent-encoding",
  "rustls",
@@ -8736,12 +8864,12 @@ dependencies = [
 
 [[package]]
 name = "ureq-proto"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
+checksum = "da5f78b09e6941e1a0f2e30e695e4b120377b54d5e0aec11b594bb57b3971613"
 dependencies = [
- "base64 0.22.1",
- "http 1.4.2",
+ "base64 0.23.1",
+ "http 1.5.0",
  "httparse",
  "log",
 ]
@@ -8791,9 +8919,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.24.0"
+version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf3923a6f5c4c6382e0b653c4117f48d631ea17f38ed86e2a828e6f7412f5239"
+checksum = "f053576934f05a761a402421fbbe3d425d9366f75f978806a037b3ca481abecc"
 dependencies = [
  "atomic",
  "getrandom 0.4.3",
@@ -8820,16 +8948,15 @@ dependencies = [
 
 [[package]]
 name = "validator_derive"
-version = "0.20.0"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7df16e474ef958526d1205f6dda359fdfab79d9aa6d54bafcb92dcd07673dca"
+checksum = "240e4b81c20a1d6d50d1d7265c658dfbd204e8b9ac4d80f3c931f39462196335"
 dependencies = [
- "darling 0.20.11",
- "once_cell",
- "proc-macro-error2",
+ "darling 0.23.0",
+ "proc-macro-error3",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -8934,9 +9061,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
+checksum = "1b70935747edd64d89de3efa29d73789b806c15798f8e7dca4d8ac356b50ce70"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -8948,9 +9075,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.76"
+version = "0.4.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c62df1340f32221cb9c54d6a27b030e3dba64361d4a95bed55f9aacb44da291d"
+checksum = "6b7777d5cc23d0e91404e53ce2d5e8ec7acae3026b16233dba62cd3246457950"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -8958,9 +9085,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
+checksum = "77775f8f3f7217702089053b94958f8f54061a3f663417df76e19cbdcca29bc1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -8968,22 +9095,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
+checksum = "e11d33f857dc2fb11b8bc75aee111aa9cbeb12cd9f25efd3d4c2a3dd4e235284"
 dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
+checksum = "7ef64dbcc55df09c7e5a46182d181c2cfa3e925f3da937ea764728b4bbb9dcbf"
 dependencies = [
  "unicode-ident",
 ]
@@ -9025,7 +9152,7 @@ dependencies = [
  "arrayvec",
  "multi-stash",
  "smallvec",
- "spin 0.9.8",
+ "spin 0.9.9",
  "wasmi_collections",
  "wasmi_core",
  "wasmi_ir",
@@ -9066,15 +9193,15 @@ version = "0.221.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d06bfa36ab3ac2be0dee563380147a5b81ba10dd8885d7fbbc9eb574be67d185"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "indexmap 2.14.0",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.103"
+version = "0.3.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141"
+checksum = "c435338968042f4f59a557f690a253676d47ce13ceb55d70100e7facf6620a30"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -9092,9 +9219,9 @@ dependencies = [
 
 [[package]]
 name = "web_atoms"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "075474b12bcb3d2e3d4546580e9de478eeeead668a1761e2a8860c836b7ef297"
+checksum = "ba8b815c1b593dc0baf78dd0f4fc8fdb2de53198fb1163738093e9a311c33fb3"
 dependencies = [
  "phf 0.13.1",
  "phf_codegen 0.13.1",
@@ -9143,7 +9270,7 @@ dependencies = [
  "nom 7.1.3",
  "openssl",
  "openssl-sys",
- "rand 0.9.4",
+ "rand 0.9.5",
  "rand_chacha 0.9.0",
  "serde",
  "serde_cbor_2",
@@ -9172,9 +9299,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-root-certs"
-version = "1.0.8"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d46a5a140e6f7afeccd8eae97eff335163939eac8b929834875168b29b3d267"
+checksum = "b96554aa2acc8ccdb7e1c9a58a7a68dd5d13bccc69cd124cb09406db612a1c9b"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -9277,9 +9404,9 @@ dependencies = [
 
 [[package]]
 name = "which"
-version = "8.0.4"
+version = "8.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48d7cd18d4acb58fb3cdfe9ea54e6cd96a4e7d4cc45c56338b236e82dad47248"
+checksum = "8f3ef584124b911bcc3875c2f1472e80f24361ceb789bd1c62b3e9a3df9ff43c"
 dependencies = [
  "libc",
 ]
@@ -9296,9 +9423,9 @@ dependencies = [
 
 [[package]]
 name = "whoami"
-version = "2.1.2"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "998767ef88740d1f5b0682a9c53c24431453923962269c2db68ee43788c5a40d"
+checksum = "626c4bac6755d76ffc12cb01b2eac751db1996b9e0041de9aa02c8c211ddc82c"
 dependencies = [
  "libc",
  "libredox",
@@ -9309,7 +9436,7 @@ dependencies = [
 
 [[package]]
 name = "wiki"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "autumn-web",
  "chrono",
@@ -9379,7 +9506,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -9390,7 +9517,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -9442,15 +9569,6 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
-dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
 ]
@@ -9667,9 +9785,9 @@ checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 
 [[package]]
 name = "winnow"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
 dependencies = [
  "memchr",
 ]
@@ -9682,9 +9800,9 @@ checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "writeable"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+checksum = "3ad82d2a33cdc9674dc7465672f271e096168fcdbe0f799d9e6db8c5892679dc"
 
 [[package]]
 name = "wyz"
@@ -9738,7 +9856,7 @@ dependencies = [
  "oid-registry 0.8.1",
  "ring",
  "rusticata-macros",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "time",
 ]
 
@@ -9749,7 +9867,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
 dependencies = [
  "libc",
- "rustix 1.1.4",
+ "rustix",
 ]
 
 [[package]]
@@ -9760,9 +9878,9 @@ checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
 
 [[package]]
 name = "xxhash-rust"
-version = "0.8.16"
+version = "0.8.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d93c89cdc2d3a63c3ec48ffe926931bdc069eafa8e4402fe6d8f790c9d1e576"
+checksum = "aee1b19627c7c60102ab80d3a9cbe18de90bfe03bfa6c3715447681f0e8c8af6"
 
 [[package]]
 name = "yansi"
@@ -9799,28 +9917,28 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
  "synstructure",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.8.53"
+version = "0.8.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75726053136156d419e285b9b7eddaaea9e3fea6ce32eed44a89901f0bd98de1"
+checksum = "556764e583adb45a9f8d413c2a147fa7e8d821e48e12b14fd560b607998b75eb"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.53"
+version = "0.8.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4714fd92cf900833d49538023a9b3915155210801d1c1169eba513b2addefd71"
+checksum = "f2ab42fc20575779bd240faa45f94a74256f755c0fa9e89f0ede20d91d0cdfc1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -9840,7 +9958,7 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
  "synstructure",
 ]
 
@@ -9861,14 +9979,14 @@ checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "zerotrie"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+checksum = "4ea269c3bd32f0a32c321907a2ae912ba6f4649bb0fc764a15627e99a7095a3f"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -9877,9 +9995,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.6"
+version = "0.11.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+checksum = "bb0464e17806c1d976d5cba29399c7f08e516e279e2ba493f63123b5fca67dd8"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -9888,26 +10006,26 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.3"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
+checksum = "34df6fc39dbd26ddc9c10e6a2984476e13acce22e64e4487636ef494369225da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "zmij"
-version = "1.0.21"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"
 
 [[package]]
 name = "zune-core"
-version = "0.5.1"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb8a0807f7c01457d0379ba880ba6322660448ddebc890ce29bb64da71fb40f9"
+checksum = "d56377fd46368984a170bc5aac5567e52ca5da874caa60bea39fcbca78fb658b"
 
 [[package]]
 name = "zune-jpeg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ autumn-web = { path = "autumn" }
 [workspace.package]
 edition = "2024"
 rust-version = "1.88.0"
-version = "0.6.0"
+version = "0.7.0"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/autumn-foundation/autumn"
 
@@ -64,7 +64,7 @@ pq-sys = { version = "0.7", features = ["bundled_without_openssl"] }
 diesel-async = { version = "0.9", features = ["deadpool", "postgres", "async-connection-wrapper"] }
 diesel_migrations = "2"
 http = "1"
-libsqlite3-sys = { version = "0.37", features = ["bundled"] }
+libsqlite3-sys = { version = "0.38", features = ["bundled"] }
 tokio = { version = "1", features = ["full"] }
 tokio-stream = { version = "0.1", features = ["sync"] }
 serde = { version = "1", features = ["derive"] }
@@ -101,7 +101,7 @@ testcontainers = "0.27"
 testcontainers-modules = { version = "0.15", features = ["postgres", "redis", "minio"] }
 # Keep time on the 0.3 release line for the testcontainers/bollard dependency
 # graph used by integration tests.
-time = { version = ">=0.3, <0.3.55" }
+time = { version = ">=0.3, <0.3.56" }
 
 csv = "1.3"
 rust_decimal = "1"

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ for that same "ship the app, not the plumbing" shape in Rust.
 
 ```bash
 # Install the published CLI
-cargo install autumn-cli --version 0.6.0
+cargo install autumn-cli --version 0.7.0
 
 # Local development only, from an Autumn checkout:
 # cargo install --path autumn-cli
@@ -81,7 +81,7 @@ Prefer a manual download? Grab the tarball plus its `.sha256`:
 - Latest: `https://github.com/autumn-foundation/autumn/releases/latest/download/autumn-<target>.tar.gz`
 - Pinned: `https://github.com/autumn-foundation/autumn/releases/download/<tag>/autumn-<target>.tar.gz`
 
-where `<target>` is one of `x86_64-unknown-linux-musl`, `aarch64-unknown-linux-musl`, `x86_64-apple-darwin`, or `aarch64-apple-darwin` (Linux binaries are static musl — no glibc version dependency). Binaries track tagged crate releases (e.g. `v0.6.0`); `latest` is the most recent released version — there are no rolling trunk-dev builds.
+where `<target>` is one of `x86_64-unknown-linux-musl`, `aarch64-unknown-linux-musl`, `x86_64-apple-darwin`, or `aarch64-apple-darwin` (Linux binaries are static musl — no glibc version dependency). Binaries track tagged crate releases (e.g. `v0.7.0`); `latest` is the most recent released version — there are no rolling trunk-dev builds.
 
 ### Install a prebuilt binary (Windows)
 
@@ -232,6 +232,7 @@ See [EXAMPLES.md](EXAMPLES.md) for the full catalog with personas, journeys, pre
 
 ## Documentation
 
+- [**What's new in 0.7.0**](docs/releases/0.7.0.md) — a walkthrough of the release: host-preparing deploys and fleets, deterministic simulation testing, the new model attributes, failure-capsule replay, and a request path that allocates ~59% less
 - [Getting Started Guide](docs/guide/getting-started.md)
 - [Authentication](docs/guide/authentication.md) — sessions, password policy, login/logout, `#[secured]`, lockout, and remember-me; the hub that links OAuth, step-up, and MFA
 - [Dev-Loop Latency Budget](docs/guide/dev-loop-latency.md) — p50/p95/max budgets per change class, measurement methodology, and CI gates for `autumn dev`

--- a/autumn-admin-plugin/Cargo.toml
+++ b/autumn-admin-plugin/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["web", "admin", "axum", "htmx", "fullstack"]
 categories = ["web-programming", "web-programming::http-server"]
 
 [dependencies]
-autumn-web = { version = "0.6.0", path = "../autumn", features = ["maud", "htmx", "db", "flash", "multipart"] }
+autumn-web = { version = "0.7.0", path = "../autumn", features = ["maud", "htmx", "db", "flash", "multipart"] }
 axum = { workspace = true, features = ["multipart"] }
 csv = { workspace = true }
 diesel = { workspace = true }

--- a/autumn-cache-redis/Cargo.toml
+++ b/autumn-cache-redis/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["web", "redis", "cache", "axum", "fullstack"]
 categories = ["web-programming", "web-programming::http-server"]
 
 [dependencies]
-autumn-web = { version = "0.6.0", path = "../autumn", features = ["redis"] }
+autumn-web = { version = "0.7.0", path = "../autumn", features = ["redis"] }
 redis = { workspace = true }
 # Installs the process-wide rustls `CryptoProvider` `redis`'s `tokio-rustls-comp`
 # needs for `rediss://` URLs — see the comment in `RedisCache::connect`. Pinned

--- a/autumn-cli/Cargo.toml
+++ b/autumn-cli/Cargo.toml
@@ -62,10 +62,10 @@ acme = ["tls", "autumn-web/acme"]
 sqlite = ["autumn-web/sqlite", "diesel_migrations/sqlite"]
 
 [dependencies]
-autumn-web = { version = "0.6.0", path = "../autumn", default-features = false, features = [
+autumn-web = { version = "0.7.0", path = "../autumn", default-features = false, features = [
     "db", "htmx", "maud", "storage", "i18n", "telemetry-otlp", "redis", "cache-moka", "http-client", "reporting"
 ] }
-autumn-schema-core = { version = "0.6.0", path = "../autumn-schema-core" }
+autumn-schema-core = { version = "0.7.0", path = "../autumn-schema-core" }
 base64 = "0.22"
 clap = { version = "4", features = ["derive", "env"] }
 diesel = { workspace = true }

--- a/autumn-cli/src/upgrade/migrations.rs
+++ b/autumn-cli/src/upgrade/migrations.rs
@@ -262,6 +262,20 @@ pub static APP_MIGRATIONS: &[AppMigration] = &[
     // last-value-wins, or see `Vec<(String, String)>` come back key-sorted,
     // with nothing in the build to warn it. `GuideOnly` is precisely the slot
     // for a client-dependent change no source-level rewrite can decide.
+    // The highest-consequence item in the release, and invisible in Rust: an
+    // `autumn.toml` that already sets `auto_migrate_in_production = true` under
+    // a CUSTOM profile did nothing on 0.6.x and applies migrations at startup
+    // on 0.7.0. The key did not change; the profile name-gate around it was
+    // removed. An operator who reads only the compile breaks would meet this
+    // for the first time against a live database.
+    AppMigration {
+        id: "0.7.0-migrate-profile-agnostic",
+        version: "0.7.0",
+        title: "`auto_migrate_in_production` is honoured on any non-`dev` profile",
+        confidence: Confidence::Manual,
+        guide: "docs/migrations/0.7.0.md#startup-migrations-are-now-profile-agnostic-1903",
+        rewrite: Rewrite::GuideOnly,
+    },
     AppMigration {
         id: "0.7.0-query-decoding",
         version: "0.7.0",

--- a/autumn-cli/src/upgrade/migrations.rs
+++ b/autumn-cli/src/upgrade/migrations.rs
@@ -622,13 +622,22 @@ mod tests {
 
     #[test]
     fn excludes_migrations_the_app_is_already_past() {
-        let ids: Vec<_> = migrations_between(&v(0, 6, 0), &v(0, 7, 0))
-            .iter()
-            .map(|m| m.id)
-            .collect();
+        // An app already on 0.6.0 needs none of 0.6.0's migrations — but it
+        // does need everything 0.7.0 introduced. This asserted an EMPTY result
+        // while 0.7.0 had no entries yet, which quietly conflated "excludes
+        // what the app is past" with "the target release adds nothing"; the
+        // moment 0.7.0 registered its first migration the assertion was wrong
+        // about the thing it is named for. Assert the boundary itself.
+        let selected = migrations_between(&v(0, 6, 0), &v(0, 7, 0));
+        let ids: Vec<_> = selected.iter().map(|m| m.id).collect();
         assert!(
-            ids.is_empty(),
-            "an app already on 0.6.0 needs no 0.6.0 migration, got {ids:?}"
+            selected.iter().all(|m| m.version == "0.7.0"),
+            "0.6.0 -> 0.7.0 must select only 0.7.0 migrations, got {ids:?}"
+        );
+        assert!(
+            !ids.is_empty(),
+            "0.7.0 registers migrations, so this range is not empty — if it is, \
+             the range filter dropped them"
         );
     }
 

--- a/autumn-cli/src/upgrade/migrations.rs
+++ b/autumn-cli/src/upgrade/migrations.rs
@@ -225,6 +225,36 @@ pub static APP_MIGRATIONS: &[AppMigration] = &[
             }),
         },
     },
+    // 0.7.0 ships no codemod: each of its three breaks needs a value, a wire
+    // change in a client this tool never sees, or a change of impl *shape* —
+    // none of them rename-level. They are registered as `GuideOnly` so the
+    // upgrade summary names them and links the guide section, rather than a
+    // 0.6.x app being told "nothing to change" about a release that broke
+    // three seams.
+    AppMigration {
+        id: "0.7.0-routing-route-seo-field",
+        version: "0.7.0",
+        title: "`Route` and `StaticRouteMeta` gained an `seo` field",
+        confidence: Confidence::Manual,
+        guide: "docs/migrations/0.7.0.md#routing-route-and-staticroutemeta-gained-an-seo-field",
+        rewrite: Rewrite::GuideOnly,
+    },
+    AppMigration {
+        id: "0.7.0-api-lock-version-required",
+        version: "0.7.0",
+        title: "a `lock_version` model requires the version on JSON `PUT`/`PATCH`",
+        confidence: Confidence::Manual,
+        guide: "docs/migrations/0.7.0.md#json-api-a-lock_version-model-now-requires-the-version-on-putpatch",
+        rewrite: Rewrite::GuideOnly,
+    },
+    AppMigration {
+        id: "0.7.0-app-layers-erased",
+        version: "0.7.0",
+        title: "app-wide layers are registered against the erased ingress service",
+        confidence: Confidence::Manual,
+        guide: "docs/migrations/0.7.0.md#app-wide-layers-are-now-erased",
+        rewrite: Rewrite::GuideOnly,
+    },
 ];
 
 /// The full registry.

--- a/autumn-cli/src/upgrade/migrations.rs
+++ b/autumn-cli/src/upgrade/migrations.rs
@@ -225,12 +225,12 @@ pub static APP_MIGRATIONS: &[AppMigration] = &[
             }),
         },
     },
-    // 0.7.0 ships no codemod: each of its three breaks needs a value, a wire
-    // change in a client this tool never sees, or a change of impl *shape* —
-    // none of them rename-level. They are registered as `GuideOnly` so the
-    // upgrade summary names them and links the guide section, rather than a
-    // 0.6.x app being told "nothing to change" about a release that broke
-    // three seams.
+    // 0.7.0 ships no codemod: each of its breaks needs a value, a wire change
+    // in a client this tool never sees, or a change of impl *shape* — none of
+    // them rename-level. They are registered as `GuideOnly` so the upgrade
+    // summary names them and links the guide section, rather than a 0.6.x app
+    // being told "nothing to change" about a release that broke three seams
+    // and rewrote query decoding.
     AppMigration {
         id: "0.7.0-routing-route-seo-field",
         version: "0.7.0",
@@ -253,6 +253,21 @@ pub static APP_MIGRATIONS: &[AppMigration] = &[
         title: "app-wide layers are registered against the erased ingress service",
         confidence: Confidence::Manual,
         guide: "docs/migrations/0.7.0.md#app-wide-layers-are-now-erased",
+        rewrite: Rewrite::GuideOnly,
+    },
+    // Not a compile break — this one still builds, which is exactly why it
+    // needs surfacing: `Query<T>` was rewritten, and four of its runtime
+    // behaviours changed. A 0.6.x app that uses `Query<T>` beyond unique
+    // scalar keys can start returning 400s, stop resolving map duplicates
+    // last-value-wins, or see `Vec<(String, String)>` come back key-sorted,
+    // with nothing in the build to warn it. `GuideOnly` is precisely the slot
+    // for a client-dependent change no source-level rewrite can decide.
+    AppMigration {
+        id: "0.7.0-query-decoding",
+        version: "0.7.0",
+        title: "`Query<T>` decodes structure, rejects duplicate scalar keys, and sorts pair vectors",
+        confidence: Confidence::Manual,
+        guide: "docs/migrations/0.7.0.md#queryt-decoding-1972",
         rewrite: Rewrite::GuideOnly,
     },
 ];

--- a/autumn-edge/Cargo.toml
+++ b/autumn-edge/Cargo.toml
@@ -20,7 +20,7 @@ categories = ["web-programming", "wasm"]
 # crate declares the same 0.8 release line on its own with
 # `default-features = false`. Cargo still resolves both to one `axum 0.8.x` in
 # `Cargo.lock`; only the per-target feature set differs.
-autumn-macros = { version = "0.6.0", path = "../autumn-macros" }
+autumn-macros = { version = "0.7.0", path = "../autumn-macros" }
 axum = { version = "0.8", default-features = false, features = ["json", "query"] }
 # Not pinned in `[workspace.dependencies]`; matches the `base64 = "0.22"` line
 # already used by `autumn`, `autumn-cli`, and `examples/todo-app`.

--- a/autumn-edge/README.md
+++ b/autumn-edge/README.md
@@ -10,10 +10,10 @@ compiles for **both** `x86_64` and `wasm32-wasip1`. It never links tokio, hyper,
 
 ```toml
 [dependencies]
-autumn-edge = "0.6.0"
+autumn-edge = "0.7.0"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-autumn-web = { version = "0.6.0", features = ["edge"] }
+autumn-web = { version = "0.7.0", features = ["edge"] }
 ```
 
 ## What is here

--- a/autumn-media-plugin/Cargo.toml
+++ b/autumn-media-plugin/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["web", "media", "streaming", "webrtc", "axum"]
 categories = ["web-programming", "multimedia"]
 
 [dependencies]
-autumn-web = { version = "0.6.0", path = "../autumn" }
+autumn-web = { version = "0.7.0", path = "../autumn" }
 chrono = { workspace = true }
 # Diesel is used ONLY by the optional DB-backed `RoomStore` (rooms_db).
 # Backend selection (postgres / sqlite) is inherited from autumn-web's `db`
@@ -64,7 +64,7 @@ aws-smithy-types = ">=1.4, <1.5"
 # blanket From impl; time is already in this crate's graph via the aws
 # crates, so this only bounds resolution. Lift once upstream releases
 # are compatible.
-time = { version = ">=0.3.36, <0.3.55", default-features = false }
+time = { version = ">=0.3.36, <0.3.56", default-features = false }
 # aws-smithy-async 1.3.0 bumped its rust-version to 1.94.1, above this
 # workspace's pinned toolchains (MSRV 1.88.0; CI's semver-check runner is
 # 1.92.0). This is a transitive dep pulled in via aws-config/aws-sdk-s3, not

--- a/autumn-media-plugin/README.md
+++ b/autumn-media-plugin/README.md
@@ -13,8 +13,8 @@ It packages the two primitives an interactive streaming product needs:
 
 ```toml
 [dependencies]
-autumn-web = "0.6"
-autumn-media-plugin = "0.6"
+autumn-web = "0.7"
+autumn-media-plugin = "0.7"
 ```
 
 ## `[media]` configuration

--- a/autumn-search/Cargo.toml
+++ b/autumn-search/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["web", "search", "vector", "embeddings", "axum"]
 categories = ["web-programming", "database"]
 
 [dependencies]
-autumn-web = { version = "0.6.0", path = "../autumn" }
+autumn-web = { version = "0.7.0", path = "../autumn" }
 # Diesel is used ONLY by the Postgres `SearchBackend` and the Postgres
 # `DocumentSource`. Backend selection (postgres / sqlite) is inherited from
 # autumn-web's `db` feature via cargo feature unification — this crate never

--- a/autumn-storage-s3/Cargo.toml
+++ b/autumn-storage-s3/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["web", "s3", "storage", "axum", "fullstack"]
 categories = ["web-programming", "web-programming::http-server"]
 
 [dependencies]
-autumn-web = { version = "0.6.0", path = "../autumn", features = ["storage"] }
+autumn-web = { version = "0.7.0", path = "../autumn", features = ["storage"] }
 aws-config = { version = "1", features = ["behavior-version-latest"] }
 aws-credential-types = { version = "1", features = ["hardcoded-credentials"] }
 aws-runtime = ">=1, <1.7"
@@ -28,7 +28,7 @@ aws-smithy-types = ">=1.4, <1.5"
 # blanket From impl; time is already in this crate's graph via the aws
 # crates, so this only bounds resolution. Lift once upstream releases
 # are compatible.
-time = { version = ">=0.3.36, <0.3.55", default-features = false }
+time = { version = ">=0.3.36, <0.3.56", default-features = false }
 # aws-smithy-async 1.3.0 bumped its rust-version to 1.94.1, above this
 # workspace's pinned toolchains (MSRV 1.88.0; CI's semver-check runner is
 # 1.92.0). This is a transitive dep pulled in via aws-config/aws-sdk-s3, not

--- a/autumn/Cargo.toml
+++ b/autumn/Cargo.toml
@@ -220,8 +220,8 @@ acme = ["tls", "dep:instant-acme", "dep:rcgen", "dep:socket2"]
 edge = ["dep:autumn-edge"]
 
 [dependencies]
-autumn-edge = { version = "0.6.0", path = "../autumn-edge", optional = true }
-autumn-macros = { version = "0.6.0", path = "../autumn-macros" }
+autumn-edge = { version = "0.7.0", path = "../autumn-edge", optional = true }
+autumn-macros = { version = "0.7.0", path = "../autumn-macros" }
 axum.workspace = true
 bytes = "1"
 # Best-effort ASCII folding for `slug::slugify` (issue #1260, e.g. "café" ->

--- a/benchmarks/agentic-habit-tracker/prompts/autumn.md
+++ b/benchmarks/agentic-habit-tracker/prompts/autumn.md
@@ -24,14 +24,14 @@ Diesel/`diesel-async` (Postgres), and Maud for HTML.
   `benchmarks/agentic-habit-tracker/phase2/archive_hidden_test.py` — they are
   evaluator-only. You may instead use an **absolute** path to
   this checkout's `autumn/` directory, or depend on the published crate
-  (`autumn-web = "0.6"`). In your app `Cargo.toml`:
+  (`autumn-web = "0.7"`). In your app `Cargo.toml`:
   ```toml
   [package]
   edition = "2024"
 
   [dependencies]
   # Relative path from runs/<id>/app/ to <repo-root>/autumn (five levels up).
-  # Or use an absolute path from `git rev-parse --show-toplevel`, or `autumn-web = "0.6"`.
+  # Or use an absolute path from `git rev-parse --show-toplevel`, or `autumn-web = "0.7"`.
   autumn-web = { path = "../../../../../autumn", features = ["seed"] }
   diesel = { version = "2", features = ["postgres", "chrono"] }
   diesel-async = { version = "0.9", features = ["postgres"] }

--- a/docs/guide/aggregates.md
+++ b/docs/guide/aggregates.md
@@ -27,7 +27,7 @@ Postgres/Diesel repository stack — the same setup any Autumn app with a
 
 ```toml
 [dependencies]
-autumn-web = { version = "0.6", features = ["openapi"] }
+autumn-web = { version = "0.7", features = ["openapi"] }
 ```
 
 The `DateBucket` type used for time-series roll-ups is at

--- a/docs/guide/cloud-native.md
+++ b/docs/guide/cloud-native.md
@@ -615,7 +615,7 @@ autumn_web::app()
 ```toml
 # Cargo.toml
 [dependencies]
-autumn-cache-redis = "0.4"
+autumn-cache-redis = "0.7"
 ```
 
 `CacheResponseLayer::from_app(&state)` returns `Some(layer)` wired to the

--- a/docs/guide/deployment.md
+++ b/docs/guide/deployment.md
@@ -27,7 +27,7 @@ internet connection.
 - **Rust 1.88.0+** with `cargo`
 - **Docker** (or Docker Desktop) — `docker --version`
 - **PostgreSQL** accessible at a connection string you control (local or remote)
-- The `autumn` CLI - `cargo install autumn-cli --version 0.6.0`
+- The `autumn` CLI - `cargo install autumn-cli --version 0.7.0`
 
 ---
 
@@ -1434,7 +1434,7 @@ Visit [http://localhost:3000/health](http://localhost:3000/health) — a healthy
 response looks like:
 
 ```json
-{ "status": "ok", "version": "0.6.0" }
+{ "status": "ok", "version": "0.7.0" }
 ```
 
 > **Migration failure stops the rollout.** If the primary URL is wrong or the

--- a/docs/guide/docs-smoke.md
+++ b/docs/guide/docs-smoke.md
@@ -1,14 +1,14 @@
 # Docs Smoke Procedure
 
 This docs-smoke procedure certifies the public first-run path for the published
-Autumn 0.6.x line. It must use Rust 1.88.0+ and the published `autumn-cli` and
+Autumn 0.7.x line. It must use Rust 1.88.0+ and the published `autumn-cli` and
 `autumn-web` crates unless the release is explicitly in a pre-publish rehearsal.
 
 Run it in a clean temporary directory, not inside the Autumn checkout:
 
 ```bash
 rustc --version
-cargo install autumn-cli --version 0.6.0
+cargo install autumn-cli --version 0.7.0
 
 mkdir autumn-docs-smoke
 cd autumn-docs-smoke
@@ -33,7 +33,7 @@ Passing output:
 - `/health` returns:
 
   ```json
-  { "status": "ok", "version": "0.6.0" }
+  { "status": "ok", "version": "0.7.0" }
   ```
 
 Do not add `[patch.crates-io]`, path dependencies, or `cargo install --path`
@@ -47,10 +47,10 @@ commands may be rehearsed against the workspace only if the release notes record
 why the smoke is temporary:
 
 ```text
-docs-smoke: workspace-prepublish rehearsal because autumn-cli/autumn-web 0.6.0
+docs-smoke: workspace-prepublish rehearsal because autumn-cli/autumn-web 0.7.0
 were not yet available on crates.io.
 ```
 
 That rehearsal does not certify the release. The published docs-smoke must be
-rerun with `cargo install autumn-cli --version 0.6.0` and no workspace patches
+rerun with `cargo install autumn-cli --version 0.7.0` and no workspace patches
 before announcing the release.

--- a/docs/guide/edge.md
+++ b/docs/guide/edge.md
@@ -109,10 +109,10 @@ out of the capsule:
 
 ```toml
 [dependencies]
-autumn-edge = "0.6"
+autumn-edge = "0.7"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-autumn-web = { version = "0.6", features = ["edge"] }
+autumn-web = { version = "0.7", features = ["edge"] }
 ```
 
 ### What an edge handler may use

--- a/docs/guide/failure-capsules.md
+++ b/docs/guide/failure-capsules.md
@@ -195,7 +195,7 @@ has one, which is how a capsule on disk is tied back to a log line.
   "format_version": 2,
   "id": "01JB2K7Q8N4W",
   "captured_at": "2026-08-12T10:14:13.882104Z",
-  "autumn_version": "0.6.0",
+  "autumn_version": "0.7.0",
   "app": { "name": "invoices", "profile": "production" },
   "request": {
     "method": "GET",

--- a/docs/guide/feeds.md
+++ b/docs/guide/feeds.md
@@ -32,7 +32,7 @@ pulls in `chrono`:
 
 ```toml
 [dependencies]
-autumn-web = "0.6"
+autumn-web = "0.7"
 chrono = "0.4"
 ```
 

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -11,7 +11,7 @@ endpoints, profile-aware configuration, and a project CLI behind a Spring
 Boot-style developer experience.
 
 > **Version note:** This guide tracks the published `autumn-web` and
-> `autumn-cli` **0.6.x** release line. If you are working from a source
+> `autumn-cli` **0.7.x** release line. If you are working from a source
 > checkout of the Autumn repository, the workspace may be ahead of the
 > published crates — see [local development](#local-development) below.
 
@@ -85,7 +85,7 @@ directory.
 To build it from crates.io instead:
 
 ```bash
-cargo install autumn-cli --version 0.6.0
+cargo install autumn-cli --version 0.7.0
 ```
 
 ### Local development
@@ -195,7 +195,7 @@ On a fresh project, before `autumn setup`, you will see something like:
 🍂 autumn doctor
 
 ✅ rust_toolchain — rustc 1.88.0 ≥ MSRV 1.88.0
-✅ version_compat — autumn-cli 0.6.0 matches autumn-web 0.6.0
+✅ version_compat — autumn-cli 0.7.0 matches autumn-web 0.7.0
 ✅ autumn_toml — autumn.toml and profile configurations are valid
 ✅ database_topology — database not configured
 ✅ port_bindable — port 3000 is available
@@ -277,7 +277,7 @@ routes are live immediately:
 `/health` responds with:
 
 ```json
-{ "status": "ok", "version": "0.6.0" }
+{ "status": "ok", "version": "0.7.0" }
 ```
 
 Press **Ctrl+C** to stop the server. Shutdown is graceful, draining in-flight
@@ -729,7 +729,7 @@ your code referred to Diesel's traits:
 
 ```toml
 [dependencies]
-autumn-web = "0.6"
+autumn-web = "0.7"
 chrono = { version = "0.4", features = ["serde"] }
 diesel = { version = "2", features = ["postgres", "chrono"] }
 diesel-async = { version = "0.9", features = ["postgres"] }

--- a/docs/guide/i18n.md
+++ b/docs/guide/i18n.md
@@ -27,7 +27,7 @@ around three ideas:
 ```toml
 # Cargo.toml
 [dependencies]
-autumn-web = { version = "0.5", features = ["i18n"] }
+autumn-web = { version = "0.7", features = ["i18n"] }
 ```
 
 ### 2. Configure supported locales

--- a/docs/guide/macro-transparency.md
+++ b/docs/guide/macro-transparency.md
@@ -3,7 +3,7 @@
 Autumn relies on procedural macros to eliminate boilerplate. This guide shows
 you exactly what those macros generate so there are no surprises at runtime.
 
-Examples in this guide track the Autumn 0.6.x line and Rust 1.88.0+ as of
+Examples in this guide track the Autumn 0.7.x line and Rust 1.88.0+ as of
 2026-07-10.
 
 The code snippets are **illustrative**, not compiled doctests: the "what it
@@ -38,7 +38,7 @@ When your application starts, Autumn logs every decision it makes. A typical
 startup sequence looks like this:
 
 ```
-  INFO autumn: Autumn starting version="0.6.0" profile="dev"
+  INFO autumn: Autumn starting version="0.7.0" profile="dev"
   INFO autumn: Database pool configured max_connections=10
   INFO autumn: Registered task name="db_cleanup" schedule="every 5m"
   INFO autumn: Listening addr=127.0.0.1:3000
@@ -47,7 +47,7 @@ startup sequence looks like this:
 If you omit the database:
 
 ```
-  INFO autumn: Autumn starting version="0.6.0" profile="dev"
+  INFO autumn: Autumn starting version="0.7.0" profile="dev"
   INFO autumn: Database not configured
   INFO autumn: Listening addr=127.0.0.1:3000
 ```
@@ -74,7 +74,7 @@ AUTUMN_SHOW_CONFIG=1 cargo run
 This produces output like:
 
 ```
-  INFO autumn: Autumn starting version="0.6.0" profile="dev"
+  INFO autumn: Autumn starting version="0.7.0" profile="dev"
   INFO autumn: Registered routes:
     /            GET      -> index
     /todos       GET      -> list_todos

--- a/docs/guide/mail.md
+++ b/docs/guide/mail.md
@@ -4,7 +4,7 @@ Enable the optional mail subsystem when your app needs password resets, signup
 confirmations, or transactional notifications:
 
 ```toml
-autumn-web = { version = "0.5", features = ["mail"] }
+autumn-web = { version = "0.7", features = ["mail"] }
 ```
 
 ## Configuration

--- a/docs/guide/mcp.md
+++ b/docs/guide/mcp.md
@@ -23,7 +23,7 @@ The `mcp` feature builds on the OpenAPI schema machinery, so it implies the
 ```toml
 # Cargo.toml
 [dependencies]
-autumn-web = { version = "0.5", features = ["mcp"] }
+autumn-web = { version = "0.7", features = ["mcp"] }
 ```
 
 ---

--- a/docs/guide/media.md
+++ b/docs/guide/media.md
@@ -25,8 +25,8 @@ For a runnable end-to-end demo, see [`examples/media-room`](../../examples/media
 
 ```toml
 [dependencies]
-autumn-web = "0.6"
-autumn-media-plugin = "0.6"
+autumn-web = "0.7"
+autumn-media-plugin = "0.7"
 ```
 
 ## Mounting the plugin

--- a/docs/guide/openapi.md
+++ b/docs/guide/openapi.md
@@ -23,7 +23,7 @@ The spec types and the served endpoints live behind the `openapi` feature:
 ```toml
 # Cargo.toml
 [dependencies]
-autumn-web = { version = "0.6", features = ["openapi"] }
+autumn-web = { version = "0.7", features = ["openapi"] }
 ```
 
 Then hand `AppBuilder` an `OpenApiConfig`:

--- a/docs/guide/presence.md
+++ b/docs/guide/presence.md
@@ -28,7 +28,7 @@ Presence is part of the `ws` Cargo feature (same as `Channels`):
 
 ```toml
 [dependencies]
-autumn-web = { version = "0.5", features = ["ws"] }
+autumn-web = { version = "0.7", features = ["ws"] }
 ```
 
 It is available from `autumn_web::prelude::*` automatically when `ws` is enabled.

--- a/docs/guide/realtime.md
+++ b/docs/guide/realtime.md
@@ -9,7 +9,7 @@ API to Redis pub/sub with `autumn.toml`.
 
 ```toml
 [dependencies]
-autumn-web = { version = "0.5", features = ["ws"] }
+autumn-web = { version = "0.7", features = ["ws"] }
 ```
 
 ## Publish

--- a/docs/guide/rich-text.md
+++ b/docs/guide/rich-text.md
@@ -204,7 +204,7 @@ The rendered form appears on the show page.
 All of this lives behind `autumn-web`'s `markdown` feature:
 
 ```toml
-autumn-web = { version = "0.6.0", features = ["markdown"] }
+autumn-web = { version = "0.7.0", features = ["markdown"] }
 ```
 
 A `richtext` scaffold enables it on your project automatically.

--- a/docs/guide/rich-text.md
+++ b/docs/guide/rich-text.md
@@ -204,7 +204,7 @@ The rendered form appears on the show page.
 All of this lives behind `autumn-web`'s `markdown` feature:
 
 ```toml
-autumn-web = { version = "0.7.0", features = ["markdown"] }
+autumn-web = { version = "0.7", features = ["markdown"] }
 ```
 
 A `richtext` scaffold enables it on your project automatically.

--- a/docs/guide/seeding.md
+++ b/docs/guide/seeding.md
@@ -29,7 +29,7 @@ named `seed`.
 ```toml
 # Cargo.toml
 [dependencies]
-autumn-web = { version = "0.5", features = ["seed"] }
+autumn-web = { version = "0.7", features = ["seed"] }
 
 [[bin]]
 name = "seed"

--- a/docs/guide/storage-variants.md
+++ b/docs/guide/storage-variants.md
@@ -15,7 +15,7 @@ Enable both the `storage` and `variants` features on `autumn-web`:
 
 ```toml
 [dependencies]
-autumn-web = { version = "0.5", features = ["storage", "multipart", "variants"] }
+autumn-web = { version = "0.7", features = ["storage", "multipart", "variants"] }
 ```
 
 The `variants` feature pulls in the `image` crate (JPEG, PNG, WebP codecs)

--- a/docs/guide/storage.md
+++ b/docs/guide/storage.md
@@ -30,8 +30,8 @@ Enable the `storage` feature on `autumn-web` (for the Local backend and the
 
 ```toml
 [dependencies]
-autumn-web       = { version = "0.5", features = ["storage", "multipart"] }
-autumn-storage-s3 = "0.5"   # only needed when storage.backend = "s3"
+autumn-web       = { version = "0.7", features = ["storage", "multipart"] }
+autumn-storage-s3 = "0.7"   # only needed when storage.backend = "s3"
 ```
 
 The framework gives you a working `Local` backend in `dev` out of the
@@ -214,8 +214,8 @@ Add `autumn-storage-s3` to your `Cargo.toml` and wire it up in `main`:
 
 ```toml
 [dependencies]
-autumn-web        = { version = "0.5", features = ["storage", "multipart"] }
-autumn-storage-s3 = "0.5"
+autumn-web        = { version = "0.7", features = ["storage", "multipart"] }
+autumn-storage-s3 = "0.7"
 ```
 
 ```rust,ignore

--- a/docs/guide/system-tests.md
+++ b/docs/guide/system-tests.md
@@ -45,7 +45,7 @@ In your app's `Cargo.toml`:
 
 ```toml
 [dev-dependencies]
-autumn-web = { version = "0.4", features = ["system-tests"] }
+autumn-web = { version = "0.7", features = ["system-tests"] }
 
 [features]
 system-tests = ["autumn-web/system-tests"]

--- a/docs/guide/testing.md
+++ b/docs/guide/testing.md
@@ -329,7 +329,7 @@ no one-container-per-test overhead.
 ```toml
 # Cargo.toml  — use the same version as your [dependencies] entry
 [dev-dependencies]
-autumn-web = { version = "0.5", features = ["test-support"] }
+autumn-web = { version = "0.7", features = ["test-support"] }
 serde_json = "1"
 ```
 

--- a/docs/guide/tutorial/01-project-setup.md
+++ b/docs/guide/tutorial/01-project-setup.md
@@ -11,7 +11,7 @@ Before you start, make sure you have:
 
 - **Rust 1.88.0+** (edition 2024) — install from <https://rustup.rs> if you haven't already
 - **The Autumn CLI** — install the published CLI with
-  `cargo install autumn-cli --version 0.6.0`
+  `cargo install autumn-cli --version 0.7.0`
 - A terminal and a text editor
 
 Docker is not needed until Chapter 3 (Database Setup). For now, you only need
@@ -85,7 +85,7 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-autumn-web = "0.6"
+autumn-web = "0.7"
 ```
 
 This is a standard Rust project manifest. The only dependency is `autumn-web`

--- a/docs/guide/tutorial/11-testing.md
+++ b/docs/guide/tutorial/11-testing.md
@@ -40,7 +40,7 @@ Open `Cargo.toml` and add a `[dev-dependencies]` section:
 [dev-dependencies]
 # autumn-web with test-support enables TestDb (shared Postgres testcontainer).
 # The `db` feature is already active from [dependencies]; test-support adds TestDb.
-autumn-web = { version = "0.4", features = ["test-support"] }
+autumn-web = { version = "0.7", features = ["test-support"] }
 serde_json = "1"
 ```
 

--- a/docs/guide/votable.md
+++ b/docs/guide/votable.md
@@ -42,7 +42,7 @@ already has. Nothing extra to enable:
 
 ```toml
 [dependencies]
-autumn-web = { version = "0.6", features = ["maud"] }
+autumn-web = { version = "0.7", features = ["maud"] }
 ```
 
 The `maud` feature is only needed for the widget half; the `react()` /

--- a/docs/guide/websockets.md
+++ b/docs/guide/websockets.md
@@ -32,7 +32,7 @@ async fn main() {
 Enable the feature in your `Cargo.toml`:
 
 ```toml
-autumn-web = { version = "0.6", features = ["ws"] }
+autumn-web = { version = "0.7", features = ["ws"] }
 ```
 
 ## The two-function pattern

--- a/docs/migrations/0.7.0.md
+++ b/docs/migrations/0.7.0.md
@@ -10,9 +10,12 @@ narrative tour of what is new, see the
 
 - **Old version:** `autumn-web 0.6.x`
 - **New version:** `autumn-web 0.7.0`
-- **Expected upgrade effort:** none for application code, beyond two new
-  deprecation warnings if you call `scheduler::now_unix_secs` /
-  `now_unix_duration` (see *Deprecations* below). Small for **plugins
+- **Expected upgrade effort:** none to *compile* application code, beyond two
+  new deprecation warnings if you call `scheduler::now_unix_secs` /
+  `now_unix_duration` (see *Deprecations* below). Budget a review pass if you
+  use `Query<T>` for anything beyond unique scalar keys — it was rewritten and
+  four of its runtime behaviours changed (see [Behavior
+  changes](#behavior-changes)). Small for **plugins
   and libraries** that build `autumn_web::Route` values by hand, for **JSON
   API clients** of a scaffolded model that declares a `lock_version` column,
   and for the (rare) **layer author** who implemented
@@ -26,8 +29,15 @@ narrative tour of what is new, see the
 
 ## Summary
 
-Nothing in `0.7.0` changes how an application written against 0.6.x compiles
-or behaves. There are three breaks, all narrow. The first is at
+Almost nothing in `0.7.0` changes how an application written against 0.6.x
+compiles. There are three compile- or wire-level breaks, all narrow, plus one
+set of **runtime** behaviour changes that compiles fine but can change what a
+request does: the `Query<T>` extractor was rewritten (#1972). If you use
+`Query<T>` for anything beyond unique scalar keys, read [Behavior
+changes](#behavior-changes) before upgrading — a query string of unique scalar
+keys behaves exactly as before, so most apps are unaffected.
+
+Of the three breaks, the first is at
 the *route-construction* seam: `Route` and `StaticRouteMeta` gained a field, so
 code that builds those structs with a literal — which in practice means plugins
 assembling a `Vec<Route>` rather than using `routes![]` — has to name it. The
@@ -265,6 +275,42 @@ None. Every `autumn.toml` key and `AUTUMN_*` variable that worked on
 
 ## Behavior changes
 
+These compile unchanged but can behave differently at runtime.
+
+### `Query<T>` decoding (#1972)
+
+`Query<T>` no longer delegates to `serde_urlencoded`; it decodes a **superset**
+of the flat form. A query string of unique scalar keys behaves exactly as
+before — these four changes are what to check if yours is not that.
+
+- **`[` and `]` in a key are now structure.** A target that types a parameter
+  as a plain value — `Query<HashMap<String, String>>` is the common one — used
+  to receive `?filter[a]=1` as the literal key `"filter[a]"`. It now sees a
+  nested object and returns a decode error naming the fix. Give the field a
+  nested type, or accept it as `serde_json::Value`. An unrecognised parameter
+  the target does not claim stays ignorable exactly as before.
+- **A duplicated key in a single-valued position is rejected.** `?q=a&q=b`
+  against a `String` field is a 400 — as it already was under
+  `serde_urlencoded`. What changed is **map**-typed targets, which previously
+  resolved this silently to the last value. If you were relying on
+  last-value-wins for a map, type the field as a sequence instead. A sequence
+  field still takes every occurrence.
+- **Decode errors no longer echo the submitted value.** A coercion failure
+  names the field path and expected type (`page: invalid u32 value`) but never
+  the text, because the message reaches the 400 Problem Details body and every
+  error reporter, and a query parameter can hold a secret. If you parse those
+  error strings, they no longer contain the input.
+- **`Query<Vec<(String, String)>>` yields key-sorted pairs** rather than
+  submission order; occurrences of one key keep their relative order. Anything
+  depending on submission order across *different* keys needs rechecking. The
+  `#[edge]` extractor is unaffected.
+
+Nothing here requires a code change to keep compiling, and there is no codemod:
+whether a given site is affected depends on the shape the handler asks for and
+the query strings its clients actually send, neither of which the tool can see.
+
+### Other
+
 - A `#[static_get]` route declaring `robots = "noindex"` is now left out of the
   generated `sitemap.xml`. Entries supplied by a `SitemapSource` you register
   are still passed through unfiltered.
@@ -299,13 +345,17 @@ is taken automatically by `cargo update`.
 2. `cargo test` — your suite is green.
 3. Plugins: `autumn plugin-check --plugin-name <your-plugin>` passes
    (`--plugin-name` is required).
-4. If you have a `lock_version` model with JSON clients: `PUT` a record without
+4. If any handler takes `Query<T>` with a map target, a `Vec<(String,
+   String)>`, or clients that repeat a key: exercise those endpoints and
+   confirm the responses are unchanged. A 400 where you used to get a 200 is
+   one of the four decoding changes above, not a regression.
+5. If you have a `lock_version` model with JSON clients: `PUT` a record without
    `lock_version` and confirm it is rejected, then `PUT` it with the version
    from the record's `GET` and confirm it succeeds.
-5. Serve the app (`cargo run`, default `http://127.0.0.1:3000`) and view-source
+6. Serve the app (`cargo run`, default `http://127.0.0.1:3000`) and view-source
    a page whose route declares `seo(...)` — the declared `<title>` / `<meta>`
    values render.
-6. `curl http://127.0.0.1:3000/sitemap.xml` — no `robots = "noindex"` static
+7. `curl http://127.0.0.1:3000/sitemap.xml` — no `robots = "noindex"` static
    route is listed. Substitute your own address if you changed `[server] host`
    or `[server] port`.
 

--- a/docs/migrations/0.7.0.md
+++ b/docs/migrations/0.7.0.md
@@ -376,12 +376,21 @@ Guide Gate*.
 
 - **Codemod:** `autumn upgrade` (candidate CLI, run from the probe app
   **before** the dependency bump). It read `0.6.0` from the probe's
-  `Cargo.toml`, reported `app-code migrations 0.6.0 -> 0.7.0`, listed all three
-  breaks under `manual` with their guide anchors, and correctly wrote nothing:
-  *"Nothing to change: no affected call site found in 13 scanned file(s)."*
-  0.7.0 ships no `auto`/`review` codemod, so this run is a checklist rather
-  than a rewrite — which is exactly what the registry entries exist to
+  `Cargo.toml`, reported `app-code migrations 0.6.0 -> 0.7.0`, listed every
+  registered break under `manual` with its guide anchor, and correctly wrote
+  nothing: *"Nothing to change: no affected call site found in 13 scanned
+  file(s)."* 0.7.0 ships no `auto`/`review` codemod, so this run is a checklist
+  rather than a rewrite — which is exactly what the registry entries exist to
   produce.
+
+  The registry gained a fourth entry (`0.7.0-query-decoding`) *after* that
+  walkthrough, so this step was re-run against the final registry rather than
+  left describing a state that no longer exists. It now reports
+  `Migrations in range (4)` — the three compile/wire breaks plus the
+  `Query<T>` decoding change — each with a resolving guide anchor, and still
+  writes nothing. The rest of the walkthrough below is unaffected: adding a
+  `GuideOnly` entry changes what the tool *reports*, not what it rewrites, and
+  no other step depends on the registry's contents.
 - **Status:** performed 2026-08-23
 - **From → to:** `autumn-cli 0.6.0` (installed from crates.io) app upgraded to
   `autumn-web 0.7.0`

--- a/docs/migrations/0.7.0.md
+++ b/docs/migrations/0.7.0.md
@@ -15,7 +15,9 @@ narrative tour of what is new, see the
   `now_unix_duration` (see *Deprecations* below). Budget a review pass if you
   use `Query<T>` for anything beyond unique scalar keys — it was rewritten and
   four of its runtime behaviours changed (see [Behavior
-  changes](#behavior-changes)). Small for **plugins
+  changes](#behavior-changes)). Operators on a custom profile should also read
+  [Configuration changes](#configuration-changes) before deploying — one key's
+  effect changed. Small for **plugins
   and libraries** that build `autumn_web::Route` values by hand, for **JSON
   API clients** of a scaffolded model that declares a `lock_version` column,
   and for the (rare) **layer author** who implemented
@@ -270,8 +272,53 @@ has a remaining caller inside `autumn`.
 
 ## Configuration changes
 
-None. Every `autumn.toml` key and `AUTUMN_*` variable that worked on
-0.6.x works unchanged on 0.7.0.
+Every `autumn.toml` key and `AUTUMN_*` variable that worked on 0.6.x is still
+accepted on 0.7.0 — nothing was renamed or removed. One key's **effect**
+changed, and it is the kind that matters at deploy time.
+
+### Startup migrations are now profile-agnostic (#1903)
+
+**Automation:** `manual` — no mechanical rewrite. The change is in
+`autumn.toml` and in which profile a deployment runs under, neither of which is
+Rust source this tool can read, and the right answer (apply, or pin
+`auto_migrate = false`) is an operator decision about a live database. Codemod
+id `0.7.0-migrate-profile-agnostic` reserves the slot in the registry so
+`autumn upgrade` names the change and links this section.
+
+**Read this if you run a custom profile** — anything that is not `dev`,
+`development`, `prod` or `production` (`staging`, `fly`, `preview`, …).
+
+`database.auto_migrate_in_production = true` used to be *name-gated* to
+`prod`/`production`. On a custom profile it silently fell through to
+report-only: your migrations did not run, and the app usually failed later on a
+missing table. That gate is gone. The same key is now honoured on **any**
+non-`dev` profile, which means:
+
+> An `autumn.toml` that already sets `auto_migrate_in_production = true` under a
+> custom profile did nothing on 0.6.x and **will apply migrations at startup on
+> 0.7.0.** Nothing in your config changes; its effect does.
+
+If that is what you wanted all along, you need do nothing — this is the bug
+being fixed. If you would rather migrations stayed manual, set the new
+profile-agnostic override explicitly before deploying:
+
+```toml
+[database]
+auto_migrate = false        # or AUTUMN_DATABASE__AUTO_MIGRATE=false
+```
+
+The new `database.auto_migrate` (`Option<bool>`) wins on every profile. The
+decision is otherwise convention-over-configuration: `dev`/`development`
+auto-apply by default, every other profile is opt-in. Applies still route
+through the advisory-locked runner, and an opt-in profile left in report-only
+mode now logs the profile and the key to set rather than staying silent.
+
+The framework shard-map (`control` queue) migration follows the same
+`database.auto_migrate` decision instead of force-applying, so it no longer
+fails fatally on an unreachable control target under a report-only decision.
+
+To see which way a profile will go without deploying, start the app and read
+the startup log line, or set `auto_migrate` explicitly and remove the doubt.
 
 ## Behavior changes
 
@@ -383,14 +430,15 @@ Guide Gate*.
   rather than a rewrite — which is exactly what the registry entries exist to
   produce.
 
-  The registry gained a fourth entry (`0.7.0-query-decoding`) *after* that
-  walkthrough, so this step was re-run against the final registry rather than
-  left describing a state that no longer exists. It now reports
-  `Migrations in range (4)` — the three compile/wire breaks plus the
-  `Query<T>` decoding change — each with a resolving guide anchor, and still
-  writes nothing. The rest of the walkthrough below is unaffected: adding a
-  `GuideOnly` entry changes what the tool *reports*, not what it rewrites, and
-  no other step depends on the registry's contents.
+  The registry gained two more `GuideOnly` entries after that walkthrough
+  (`0.7.0-query-decoding`, then `0.7.0-migrate-profile-agnostic`), so this step
+  has been re-run against the registry as it now stands rather than left
+  describing a state that no longer exists. It reports `Migrations in range
+  (5)` — the three compile/wire breaks, the `Query<T>` decoding change, and the
+  profile-agnostic startup-migration change — each with a resolving guide
+  anchor, and still writes nothing. The rest of the walkthrough below is
+  unaffected: adding a `GuideOnly` entry changes what the tool *reports*, not
+  what it rewrites, and no other step depends on the registry's contents.
 - **Status:** performed 2026-08-23
 - **From → to:** `autumn-cli 0.6.0` (installed from crates.io) app upgraded to
   `autumn-web 0.7.0`

--- a/docs/migrations/0.7.0.md
+++ b/docs/migrations/0.7.0.md
@@ -316,8 +316,43 @@ the previous release using **only** this guide — no changelog, no source
 reading. See [`docs/release-checklist.md`](../release-checklist.md), *Migration
 Guide Gate*.
 
-- **Status:** pending — performed and recorded during the release that ships
-  this guide, before publishing to crates.io.
+- **Codemod:** `autumn upgrade` (candidate CLI, run from the probe app
+  **before** the dependency bump). It read `0.6.0` from the probe's
+  `Cargo.toml`, reported `app-code migrations 0.6.0 -> 0.7.0`, listed all three
+  breaks under `manual` with their guide anchors, and correctly wrote nothing:
+  *"Nothing to change: no affected call site found in 13 scanned file(s)."*
+  0.7.0 ships no `auto`/`review` codemod, so this run is a checklist rather
+  than a rewrite — which is exactly what the registry entries exist to
+  produce.
+- **Status:** performed 2026-08-23
+- **From → to:** `autumn-cli 0.6.0` (installed from crates.io) app upgraded to
+  `autumn-web 0.7.0`
+- **Elapsed:** 20 minutes, dominated by compiles — the guide-directed edits
+  were zero, because none of the three breaks is reachable from a scaffolded
+  app.
+- **What was run:** `autumn new upgrade-probe`, then `autumn generate scaffold
+  Post title:String body:Text published:bool` on the published 0.6.0 CLI for a
+  green baseline (`cargo check`, `cargo test`). After `autumn upgrade` and the
+  dependency bump: `cargo check` clean with **no** `missing field `seo``
+  error and no new warnings beyond the three the 0.6.0 baseline already
+  emitted; `cargo test` green; `autumn migrate` applied; `GET /health`
+  reported `{"status":"ok","version":"0.7.0",…}`; `GET /posts` and `GET /`
+  both `200`.
+- **Steps that did not apply:** the guide's conditional verification steps —
+  `autumn plugin-check --plugin-name <your-plugin>` (no plugin), the
+  `lock_version` JSON round trip (the
+  probe declares no such column), and the `seo(...)` / `sitemap.xml` checks
+  (the probe declares no `seo(...)` route). Each is guarded by an "if you
+  have…" in *How to verify*, so none is a gap.
+- **Pre-publish caveat:** `0.7.0` was not on crates.io when this was
+  performed, so the candidate was supplied by a `[patch.crates-io]` path
+  override and the CLI was the workspace binary rather than
+  `cargo install autumn-cli --version 0.7.0`. Everything else — the scaffold,
+  the baseline, and the crates the probe resolved for 0.6.0 — came from
+  crates.io. Re-run the walk-through against the published crates if the
+  release is re-cut.
+- **Gaps found and fixed in this guide:** none. The guide's central claim —
+  that application code compiles unchanged — held on a real scaffolded app.
 
 ## Reporting problems
 

--- a/docs/migrations/0.7.0.md
+++ b/docs/migrations/0.7.0.md
@@ -279,6 +279,14 @@ These compile unchanged but can behave differently at runtime.
 
 ### `Query<T>` decoding (#1972)
 
+**Automation:** `manual` — no mechanical rewrite. Whether a given call site is
+affected depends on the shape the handler asks for *and* the query strings its
+clients actually send; neither is visible to a source-level tool, and the fix
+(retype a field, or accept the parameter as `serde_json::Value`) is a change of
+shape rather than of name. Codemod id `0.7.0-query-decoding` reserves the slot
+in the registry so `autumn upgrade` still names the change and links this
+section.
+
 `Query<T>` no longer delegates to `serde_urlencoded`; it decodes a **superset**
 of the flat form. A query string of unique scalar keys behaves exactly as
 before — these four changes are what to check if yours is not that.

--- a/docs/migrations/0.7.0.md
+++ b/docs/migrations/0.7.0.md
@@ -1,0 +1,327 @@
+# Migrating from Autumn `0.6` to `0.7`
+
+This guide covers everything an application, plugin, or library on
+`autumn-web 0.6.x` needs to move to `0.7.0`. For the full commit-level picture
+see the [`0.7.0` CHANGELOG entry](../../CHANGELOG.md#070---2026-08-23); for a
+narrative tour of what is new, see the
+[0.7.0 release walkthrough](../releases/0.7.0.md).
+
+## At a glance
+
+- **Old version:** `autumn-web 0.6.x`
+- **New version:** `autumn-web 0.7.0`
+- **Expected upgrade effort:** none for application code, beyond two new
+  deprecation warnings if you call `scheduler::now_unix_secs` /
+  `now_unix_duration` (see *Deprecations* below). Small for **plugins
+  and libraries** that build `autumn_web::Route` values by hand, for **JSON
+  API clients** of a scaffolded model that declares a `lock_version` column,
+  and for the (rare) **layer author** who implemented
+  `tower::Layer<axum::routing::Route>` for a concrete type instead of
+  generically.
+- **MSRV delta:** `1.88.0` -> `1.88.0` (unchanged)
+- **Carried dependency majors:** none that reach an app's own code.
+  `libsqlite3-sys` moves `0.37` -> `0.38`, which matters only if your app
+  depends on that crate *directly* as well — see [Upstream dependency
+  updates](#upstream-dependency-updates).
+
+## Summary
+
+Nothing in `0.7.0` changes how an application written against 0.6.x compiles
+or behaves. There are three breaks, all narrow. The first is at
+the *route-construction* seam: `Route` and `StaticRouteMeta` gained a field, so
+code that builds those structs with a literal — which in practice means plugins
+assembling a `Vec<Route>` rather than using `routes![]` — has to name it. The
+second is on the wire, not in Rust: a model declaring a `lock_version` column
+now requires JSON `PUT`/`PATCH` clients to send that version. The third is at
+the *layer-registration* seam: `AppBuilder::layer` accepts layers via a bound
+on Autumn's erased ingress service rather than `axum::routing::Route`, which
+only a layer implemented non-generically against `Route` itself can notice.
+
+## Before you start
+
+1. Pin your current dependency (`autumn-web = "=0.6.0"`) and commit.
+2. Run `cargo update` so the diff that follows is just this release.
+3. Make sure your tests are green on 0.6.x.
+4. If you maintain a plugin, have its conformance check to hand
+   (`autumn plugin-check --plugin-name <your-plugin>`).
+
+## Step-by-step
+
+1. **Run `autumn upgrade`** — *before* the dependency bump. The release it
+   migrates from is the one your `Cargo.toml` still records, so bumping first
+   leaves nothing in range and the command reports "nothing to change".
+
+   ```bash
+   cargo install autumn-cli --version 0.7.0
+   autumn upgrade            # preview; writes nothing
+   ```
+
+   `0.7.0` ships **no** `auto` or `review` codemod — all three of its breaks
+   need a human decision, and the registry says so rather than staying silent.
+   The preview therefore lists each one under `manual` with a link to its
+   section below, which is the checklist for the rest of this guide.
+
+2. **Bump the dependency.**
+
+   ```toml
+   # Cargo.toml
+   [dependencies]
+   autumn-web = "0.7"
+   ```
+
+3. **Run `cargo check`.** Application code should be clean; a plugin that
+   constructs routes literally gets `error[E0063]` (see below).
+4. **Add the missing field** to each literal.
+5. **Run the test suite** and the [verification list](#how-to-verify).
+
+## Breaking changes
+
+### Routing: `Route` and `StaticRouteMeta` gained an `seo` field
+
+**Automation:** `manual` — no mechanical rewrite. A new struct field needs a
+value, and only the author of the route knows which one; adding arguments is
+outside the rename-level scope of `autumn upgrade`. Codemod id
+`0.7.0-routing-route-seo-field` reserves the slot in the registry so
+`autumn upgrade` lists this change and links this section rather than staying
+silent about it.
+
+**Why:** route-level SEO defaults (`#[get("/about", seo(title = "..."))]`) are
+recorded on the route itself, so the router can install the request extension
+only for routes that declared something and routes without `seo(...)` pay
+nothing (#1182).
+
+`routes![]` and the route attribute macros fill the field in for you. Only a
+**literal** struct construction has to change.
+
+**Before (`0.6`):**
+
+```rust,ignore
+let route = autumn_web::Route {
+    method: Method::GET,
+    path: "/health",
+    handler,
+    // ...
+};
+```
+
+**After:**
+
+```rust,ignore
+let route = autumn_web::Route {
+    method: Method::GET,
+    path: "/health",
+    handler,
+    seo: autumn_web::seo::SeoRouteDefaults::EMPTY,
+    // ...
+};
+```
+
+The same applies to `autumn_web::static_gen::StaticRouteMeta`.
+
+`SeoRouteDefaults` is `#[non_exhaustive]` and built by chaining its `const fn
+with_*` setters from `EMPTY`, so future SEO keys are additive — this is the
+last time this particular field costs you an edit.
+
+**If you are automating the upgrade:**
+
+```bash
+rg -n 'Route \{|StaticRouteMeta \{' src/
+```
+
+### JSON API: a `lock_version` model now requires the version on `PUT`/`PATCH`
+
+**Automation:** `manual` — no mechanical rewrite. The change is on the wire,
+in clients this tool never sees, not in the app's Rust source. Codemod id
+`0.7.0-api-lock-version-required` reserves the slot in the registry so
+`autumn upgrade` still names the change and links this section.
+
+**Why:** declaring a column literally named `lock_version` opts a model into
+optimistic locking (#1318). `#[lock_version]` carries the column on
+`Update{Model}` as the *expected* version, which is what lets the repository
+reject a stale write with `RepositoryError::Conflict` instead of silently
+letting the last writer win.
+
+This affects you only if **both** are true: your model declares a non-nullable
+`i32`/`i64` column named `lock_version`, and you have JSON clients writing
+through the generated `PUT`/`PATCH /api/<plural>/{id}` endpoints. Browser
+forms on an HTML scaffold are unaffected — the generated edit form carries the
+version in a hidden field for you.
+
+**Before (`0.6`):** the field was ignored on the wire, so a client could omit
+it.
+
+```jsonc
+{ "title": "Hello" }
+```
+
+**After:** the field is required, and its value must be the version the client
+read. Omitting it fails deserialization (HTTP 422); sending a stale one is
+answered with a conflict rather than an overwrite.
+
+```jsonc
+{ "title": "Hello", "lock_version": 7 }
+```
+
+Read the current version from the same record's `GET` response (it is a plain
+column) and echo it back on the next write.
+
+**If you did not want optimistic locking**, the column name is the entire
+opt-in: rename it (e.g. to `revision`) and the behaviour goes away. `autumn
+generate` prints a warning naming this escape hatch whenever it detects the
+name.
+
+### App-wide layers are now erased
+
+**Automation:** `manual` — no mechanical rewrite. The fix is to make a layer
+impl generic, which is a change of shape rather than of name. Codemod id
+`0.7.0-app-layers-erased` reserves the slot in the registry so
+`autumn upgrade` still names the change and links this section.
+
+**Why:** `AppBuilder::layer` / `static_gate` registrations (including plugin
+layers) are type-erased at registration time and composed into a single
+`Router::layer` application, so registering app-wide middleware no longer
+deepens the framework's per-request clone cascade (#2198).
+
+`IntoAppLayer`'s sealed blanket impl is therefore bound on
+`tower::Layer<autumn_web::app::ErasedAppService>` (the new public alias for
+the composed ingress service) instead of `tower::Layer<axum::routing::Route>`.
+
+This affects you only if you wrote a layer against **one concrete inner
+service type** rather than generically. Every layer that is generic over the
+service it wraps — the shape of every tower / tower-http layer, every layer in
+this repo and its plugins, and every example in the docs — satisfies both
+bounds and compiles unchanged.
+
+**Before (`0.6`):**
+
+```rust,ignore
+impl tower::Layer<axum::routing::Route> for MyLayer { /* … */ }
+```
+
+**After** — either make it generic (preferred):
+
+```rust,ignore
+impl<S> tower::Layer<S> for MyLayer { /* … */ }
+```
+
+or retarget the one concrete impl:
+
+```rust,ignore
+impl tower::Layer<autumn_web::app::ErasedAppService> for MyLayer { /* … */ }
+```
+
+**If you are automating the upgrade:**
+
+```bash
+rg -n 'Layer<axum::routing::Route>|Layer<Route>' src/
+```
+
+## Deprecations (non-breaking)
+
+### `scheduler::now_unix_secs` / `scheduler::now_unix_duration`
+
+**Automation:** `manual` — no mechanical rewrite. The replacement takes the
+app's injected clock as a new argument, and finding the right `AppState` in
+scope is inference well beyond a rename — explicitly out of scope for
+`autumn upgrade` (issue #1629).
+
+Both read the real system clock directly, off the framework's injected-clock
+seam, so anything derived from them — a scheduled-task tick key, an expiry
+computation — is not reproducible under a `#[sim_test]` and is exposed to a
+wall-clock jump. They still work exactly as before; they now emit a
+deprecation warning.
+
+```rust
+// Before
+let secs = autumn_web::scheduler::now_unix_secs();
+let dur  = autumn_web::scheduler::now_unix_duration();
+
+// After — read the app's injected clock
+let secs = autumn_web::time::clock_unix_secs(state.clock());
+let dur  = autumn_web::time::clock_unix_duration(state.clock());
+```
+
+`state` is any `AppState` (handlers, `#[job]`/`#[scheduled]` bodies, startup
+hooks). If you hold an `Arc<dyn ClockSource>` rather than an `AppState`, pass
+`clock.as_ref()`. If you genuinely have neither in scope and cannot thread one
+in yet, `#[allow(deprecated)]` at the call site is a fine interim step — the
+functions are not scheduled for removal before the next major release (see
+[STABILITY.md](../../STABILITY.md), *Deprecation process*).
+
+The framework's own scheduler already reads the injected clock; neither function
+has a remaining caller inside `autumn`.
+
+## Compiler error cheat sheet
+
+| Error message (truncated) | Where you see it | Fix |
+|---|---|---|
+| ``error[E0063]: missing field `seo` in initializer of `Route` `` | a literal `Route { .. }` | add `seo: autumn_web::seo::SeoRouteDefaults::EMPTY` |
+| ``error[E0063]: missing field `seo` in initializer of `StaticRouteMeta` `` | a literal `StaticRouteMeta { .. }` | same |
+
+## Configuration changes
+
+None. Every `autumn.toml` key and `AUTUMN_*` variable that worked on
+0.6.x works unchanged on 0.7.0.
+
+## Behavior changes
+
+- A `#[static_get]` route declaring `robots = "noindex"` is now left out of the
+  generated `sitemap.xml`. Entries supplied by a `SitemapSource` you register
+  are still passed through unfiltered.
+- On a model with a `lock_version` column, a concurrent write no longer wins
+  silently: the HTML scaffold's edit form comes back at **409** with your input
+  intact and the record's current version, and the JSON path answers with a
+  conflict.
+
+## Upstream dependency updates
+
+`0.7.0` carries no dependency major that reaches an application's own code.
+Two bumps are worth naming because they can surface in a *lockfile* resolution
+rather than in a compiler error:
+
+- **`libsqlite3-sys` `0.37` -> `0.38`** (a semver-major for that crate). It is
+  a build-time transitive dependency of the optional `sqlite` feature and
+  Autumn does not re-export it, so nothing in Autumn's public API changes. It
+  matters only if your own `Cargo.toml` also depends on `libsqlite3-sys`
+  directly: two majors of a `-sys` crate cannot coexist in one binary, so
+  cargo will refuse to resolve until you move to `0.38` too. The bundled
+  SQLite amalgamation moves to 3.51.x with it.
+- **`diesel` `2.3.10` -> `2.3.12`** (semver-compatible). Picks up upstream's
+  Postgres (de)serialization panic fixes and the SQLite batch-insert
+  `.load()` fix; no action needed.
+
+Everything else in this release's dependency refresh is semver-compatible and
+is taken automatically by `cargo update`.
+
+## How to verify
+
+1. `cargo check` — clean, with no `missing field `seo`` error.
+2. `cargo test` — your suite is green.
+3. Plugins: `autumn plugin-check --plugin-name <your-plugin>` passes
+   (`--plugin-name` is required).
+4. If you have a `lock_version` model with JSON clients: `PUT` a record without
+   `lock_version` and confirm it is rejected, then `PUT` it with the version
+   from the record's `GET` and confirm it succeeds.
+5. Serve the app (`cargo run`, default `http://127.0.0.1:3000`) and view-source
+   a page whose route declares `seo(...)` — the declared `<title>` / `<meta>`
+   values render.
+6. `curl http://127.0.0.1:3000/sitemap.xml` — no `robots = "noindex"` static
+   route is listed. Substitute your own address if you changed `[server] host`
+   or `[server] port`.
+
+### Guide-only upgrade walkthrough
+
+The release checklist requires upgrading an app scaffolded with `autumn new` on
+the previous release using **only** this guide — no changelog, no source
+reading. See [`docs/release-checklist.md`](../release-checklist.md), *Migration
+Guide Gate*.
+
+- **Status:** pending — performed and recorded during the release that ships
+  this guide, before publishing to crates.io.
+
+## Reporting problems
+
+If you hit something this guide does not cover, that is a bug in the guide.
+Open an issue at <https://github.com/autumn-foundation/autumn/issues> with the
+error or unexpected behaviour, the version you upgraded from, and a minimal
+reproduction if you have one.

--- a/docs/migrations/README.md
+++ b/docs/migrations/README.md
@@ -15,6 +15,7 @@ request and in the publish gate. See
 - [`0.4.0.md`](0.4.0.md) — `autumn-web 0.3.x → 0.4.0`
 - [`0.5.0.md`](0.5.0.md) — `autumn-web 0.4.x → 0.5.0`
 - [`0.6.0.md`](0.6.0.md) — `autumn-web 0.5.x → 0.6.0`
+- [`0.7.0.md`](0.7.0.md) — `autumn-web 0.6.x → 0.7.0`
 - [`next.md`](next.md) — rolling draft for `## [Unreleased]`, renamed to
   `<version>.md` at release time
 

--- a/docs/migrations/next.md
+++ b/docs/migrations/next.md
@@ -8,270 +8,217 @@
 > the index in [`README.md`](README.md) is updated — see
 > [`docs/release-checklist.md`](../release-checklist.md), *Migration Guide
 > Gate*.
+>
+> The `{X.Y.Z}` placeholders below are deliberate: the gate treats `next.md` as
+> a draft and accepts them (and empty sections) here, so nothing has to be
+> invented for a release that has no changes yet.
 
 ## At a glance
 
-- **Old version:** `autumn-web 0.6.x`
-- **New version:** the next release (unreleased)
-- **Expected upgrade effort:** none for application code, beyond two new
-  deprecation warnings if you call `scheduler::now_unix_secs` /
-  `now_unix_duration` (see *Deprecations* below). Small for **plugins
-  and libraries** that build `autumn_web::Route` values by hand, for **JSON
-  API clients** of a scaffolded model that declares a `lock_version` column,
-  and for the (rare) **layer author** who implemented
-  `tower::Layer<axum::routing::Route>` for a concrete type instead of
-  generically.
-- **MSRV delta:** `1.88.0` -> `1.88.0` (unchanged so far)
-- **Carried dependency majors:** none so far
+- **Old version:** `autumn-web {X.Y.Z}`
+- **New version:** `autumn-web {X.Z.0}`
+- **Expected upgrade effort:** {S / M / L — one paragraph of context}
+- **MSRV delta:** `{old MSRV}` → `{new MSRV}` ({reason, or "unchanged"})
+- **Carried dependency majors:** {e.g. `axum 0.8 → 0.9`, `diesel 2 → 3`,
+  or "none"}
 
 ## Summary
 
-Nothing in the unreleased line changes how an application written against
-0.6.x compiles or behaves. There are three breaks, all narrow. The first is at
-the *route-construction* seam: `Route` and `StaticRouteMeta` gained a field, so
-code that builds those structs with a literal — which in practice means plugins
-assembling a `Vec<Route>` rather than using `routes![]` — has to name it. The
-second is on the wire, not in Rust: a model declaring a `lock_version` column
-now requires JSON `PUT`/`PATCH` clients to send that version. The third is at
-the *layer-registration* seam: `AppBuilder::layer` accepts layers via a bound
-on Autumn's erased ingress service rather than `axum::routing::Route`, which
-only a layer implemented non-generically against `Route` itself can notice.
+One paragraph describing *why* this release is major. Prefer "we want
+these properties, and they required breaking change `X`" over a list of
+unrelated removals.
+
+Link to the [CHANGELOG entry](../../CHANGELOG.md) for the release for the
+full commit-level picture.
 
 ## Before you start
 
-1. Pin your current dependency (`autumn-web = "=0.6.0"`) and commit.
-2. Make sure your tests are green on 0.6.x.
-3. If you maintain a plugin, have its conformance check to hand
-   (`autumn plugin-check --plugin-name <your-plugin>`).
+- Pin your existing version (`autumn-web = "={X.Y.Z}"`) and commit.
+- Run `cargo update` *before* the upgrade so the subsequent diff is just
+  the major bump.
+- Make sure your test suite is green on the old version. You will want
+  the safety net.
 
 ## Step-by-step
 
-1. **Bump the dependency.**
-2. **Run `cargo check`.** Application code should be clean; a plugin that
-   constructs routes literally gets `error[E0063]` (see below).
-3. **Add the missing field** to each literal.
-4. **Run the test suite** and the [verification list](#how-to-verify).
+1. **Run `autumn upgrade`** — *before* the dependency bump. The release it
+   migrates from is the one your `Cargo.toml` still records, so bumping first
+   leaves nothing in range. It previews every mechanical change this release
+   can apply to your own source — a per-file diff plus a count of affected
+   sites — and writes nothing; re-run with `--apply` to take them. Anything it
+   cannot safely rewrite is listed with `file:line` and a link to the guide
+   section that explains it.
+
+   ```bash
+   cargo install autumn-cli --version {X.Z.0}
+   autumn upgrade            # preview
+   autumn upgrade --apply    # take it
+   ```
+
+2. **Bump the dependency.**
+   ```toml
+   # Cargo.toml
+   [dependencies]
+   autumn-web = "{(X+1).0}"
+   ```
+
+3. **Run `cargo check`.** Work through the compiler errors section by
+   section using the cheat sheet below. Only the changes labelled `review` or
+   `manual` above should still need you.
+
+4. **Apply configuration changes** (see
+   [Configuration changes](#configuration-changes)).
+
+5. **Run the test suite.**
+
+6. **Run the application locally** and exercise each feature at least
+   once. Pay attention to the [Behavior changes](#behavior-changes)
+   section.
 
 ## Breaking changes
 
-### Routing: `Route` and `StaticRouteMeta` gained an `seo` field
+Repeat the block below for each breaking change. Keep changes grouped by
+area (routing / config / database / …) so readers can skip to what they
+care about.
 
-**Automation:** `manual` — no mechanical rewrite. A new struct field needs a
-value, and only the author of the route knows which one; adding arguments is
-outside the rename-level scope of `autumn upgrade`.
+### {Area}: {Short description}
 
-**Why:** route-level SEO defaults (`#[get("/about", seo(title = "..."))]`) are
-recorded on the route itself, so the router can install the request extension
-only for routes that declared something and routes without `seo(...)` pay
-nothing (#1182).
+**Why:** One or two sentences on the motivation.
 
-`routes![]` and the route attribute macros fill the field in for you. Only a
-**literal** struct construction has to change.
-
-**Before (`0.6`):**
-
-```rust,ignore
-let route = autumn_web::Route {
-    method: Method::GET,
-    path: "/health",
-    handler,
-    // ...
-};
-```
-
-**After:**
-
-```rust,ignore
-let route = autumn_web::Route {
-    method: Method::GET,
-    path: "/health",
-    handler,
-    seo: autumn_web::seo::SeoRouteDefaults::EMPTY,
-    // ...
-};
-```
-
-The same applies to `autumn_web::static_gen::StaticRouteMeta`.
-
-`SeoRouteDefaults` is `#[non_exhaustive]` and built by chaining its `const fn
-with_*` setters from `EMPTY`, so future SEO keys are additive — this is the
-last time this particular field costs you an edit.
-
-**If you are automating the upgrade:**
-
-```bash
-rg -n 'Route \{|StaticRouteMeta \{' src/
-```
-
-### JSON API: a `lock_version` model now requires the version on `PUT`/`PATCH`
-
-**Automation:** `manual` — no mechanical rewrite. The change is on the wire,
-in clients this tool never sees, not in the app's Rust source.
-
-**Why:** declaring a column literally named `lock_version` opts a model into
-optimistic locking (#1318). `#[lock_version]` carries the column on
-`Update{Model}` as the *expected* version, which is what lets the repository
-reject a stale write with `RepositoryError::Conflict` instead of silently
-letting the last writer win.
-
-This affects you only if **both** are true: your model declares a non-nullable
-`i32`/`i64` column named `lock_version`, and you have JSON clients writing
-through the generated `PUT`/`PATCH /api/<plural>/{id}` endpoints. Browser
-forms on an HTML scaffold are unaffected — the generated edit form carries the
-version in a hidden field for you.
-
-**Before (`0.6`):** the field was ignored on the wire, so a client could omit
-it.
-
-```jsonc
-{ "title": "Hello" }
-```
-
-**After:** the field is required, and its value must be the version the client
-read. Omitting it fails deserialization (HTTP 422); sending a stale one is
-answered with a conflict rather than an overwrite.
-
-```jsonc
-{ "title": "Hello", "lock_version": 7 }
-```
-
-Read the current version from the same record's `GET` response (it is a plain
-column) and echo it back on the next write.
-
-**If you did not want optimistic locking**, the column name is the entire
-opt-in: rename it (e.g. to `revision`) and the behaviour goes away. `autumn
-generate` prints a warning naming this escape hatch whenever it detects the
-name.
-
-### App-wide layers are now erased
-
-**Automation:** `manual` — no mechanical rewrite. The fix is to make a layer
-impl generic, which is a change of shape rather than of name.
-
-**Why:** `AppBuilder::layer` / `static_gate` registrations (including plugin
-layers) are type-erased at registration time and composed into a single
-`Router::layer` application, so registering app-wide middleware no longer
-deepens the framework's per-request clone cascade (#2198).
-
-`IntoAppLayer`'s sealed blanket impl is therefore bound on
-`tower::Layer<autumn_web::app::ErasedAppService>` (the new public alias for
-the composed ingress service) instead of `tower::Layer<axum::routing::Route>`.
-
-This affects you only if you wrote a layer against **one concrete inner
-service type** rather than generically. Every layer that is generic over the
-service it wraps — the shape of every tower / tower-http layer, every layer in
-this repo and its plugins, and every example in the docs — satisfies both
-bounds and compiles unchanged.
-
-**Before (`0.6`):**
-
-```rust,ignore
-impl tower::Layer<axum::routing::Route> for MyLayer { /* … */ }
-```
-
-**After** — either make it generic (preferred):
-
-```rust,ignore
-impl<S> tower::Layer<S> for MyLayer { /* … */ }
-```
-
-or retarget the one concrete impl:
-
-```rust,ignore
-impl tower::Layer<autumn_web::app::ErasedAppService> for MyLayer { /* … */ }
-```
-
-**If you are automating the upgrade:**
-
-```bash
-rg -n 'Layer<axum::routing::Route>|Layer<Route>' src/
-```
-
-## Deprecations (non-breaking)
-
-### `scheduler::now_unix_secs` / `scheduler::now_unix_duration`
-
-**Automation:** `manual` — no mechanical rewrite. The replacement takes the
-app's injected clock as a new argument, and finding the right `AppState` in
-scope is inference well beyond a rename — explicitly out of scope for
-`autumn upgrade` (issue #1629).
-
-Both read the real system clock directly, off the framework's injected-clock
-seam, so anything derived from them — a scheduled-task tick key, an expiry
-computation — is not reproducible under a `#[sim_test]` and is exposed to a
-wall-clock jump. They still work exactly as before; they now emit a
-deprecation warning.
+**Before (`{X.Y}`):**
 
 ```rust
-// Before
-let secs = autumn_web::scheduler::now_unix_secs();
-let dur  = autumn_web::scheduler::now_unix_duration();
-
-// After — read the app's injected clock
-let secs = autumn_web::time::clock_unix_secs(state.clock());
-let dur  = autumn_web::time::clock_unix_duration(state.clock());
+// paste a minimal, compiling example from the old version
 ```
 
-`state` is any `AppState` (handlers, `#[job]`/`#[scheduled]` bodies, startup
-hooks). If you hold an `Arc<dyn ClockSource>` rather than an `AppState`, pass
-`clock.as_ref()`. If you genuinely have neither in scope and cannot thread one
-in yet, `#[allow(deprecated)]` at the call site is a fine interim step — the
-functions are not scheduled for removal before the next major release (see
-[STABILITY.md](../../STABILITY.md), *Deprecation process*).
+**After (`{(X+1).0}`):**
 
-The framework's own scheduler already reads the injected clock; neither function
-has a remaining caller inside `autumn`.
+```rust
+// paste the equivalent on the new version
+```
+
+**Automation:** `manual` — {why no codemod applies: it needs new arguments, it
+is a configuration or behaviour change, it is only reachable inside a macro, ….
+For a change `autumn upgrade` *does* rewrite, use `auto` (safe by construction:
+renames and import moves) or `review` (rewritten, every site flagged for a
+human) instead, and name the shipped codemod id from
+`autumn-cli/src/upgrade/migrations.rs` in this paragraph.}
+
+Every breaking change carries this label — `scripts/check-migration-guides.sh`
+fails without it, and fails an `auto`/`review` label that names no shipped
+codemod, or a rename-level change left `manual` with no reason (issue #1629).
+
+---
 
 ## Compiler error cheat sheet
 
+Paste the most common errors a user will hit and the fix. This is the
+single most valuable section of the guide — keep it factual and short.
+
 | Error message (truncated) | Where you see it | Fix |
-|---|---|---|
-| ``error[E0063]: missing field `seo` in initializer of `Route` `` | a literal `Route { .. }` | add `seo: autumn_web::seo::SeoRouteDefaults::EMPTY` |
-| ``error[E0063]: missing field `seo` in initializer of `StaticRouteMeta` `` | a literal `StaticRouteMeta { .. }` | same |
+|---------------------------|------------------|-----|
+| `error[E0432]: unresolved import \`autumn_web::foo\`` | module reorganized | `use autumn_web::bar;` |
+| `error[E0061]: this function takes 2 arguments but 1 was supplied` | `App::run` added a parameter | see [Breaking changes › {Area}] |
 
 ## Configuration changes
 
-None so far.
+- `autumn.toml` keys that were renamed, removed, or have new defaults.
+- New `AUTUMN_*` environment variables.
+- Default profile changes.
+
+If nothing changed, delete this section.
 
 ## Behavior changes
 
-- A `#[static_get]` route declaring `robots = "noindex"` is now left out of the
-  generated `sitemap.xml`. Entries supplied by a `SitemapSource` you register
-  are still passed through unfiltered.
-- On a model with a `lock_version` column, a concurrent write no longer wins
-  silently: the HTML scaffold's edit form comes back at **409** with your input
-  intact and the record's current version, and the JSON path answers with a
-  conflict.
+Changes that still compile but behave differently at runtime. Examples:
+
+- Error responses adopted a new JSON shape.
+- A default middleware is now ordered differently.
+- A scheduled task now runs on a different worker.
+
+If nothing changed, delete this section.
+
+## Deprecations retained from `{X.Y}`
+
+Items that were deprecated during the `{X.Y}` line and have now been
+removed. Link each to the release where the deprecation notice first
+appeared so users can see how much warning they had.
+
+### Config-key removals
+
+Config keys removed in this major release were registered in
+`DEPRECATED_CONFIG_KEYS` (`autumn/src/config.rs`) with `remove_in = "{X+1}.0.0"`.
+Startup issued a `WARN` log entry for each deprecated key detected in the config
+(via `since = "{X.Y}"`), and `autumn doctor` surfaced them in the
+`deprecated_keys` check.
+
+For each removed config key, fill in the table below:
+
+| Removed key (TOML / env var) | Replacement | Deprecated since | References |
+|------------------------------|-------------|------------------|------------|
+| `section.old_key` / `AUTUMN_SECTION__OLD_KEY` | `section.new_key` | `{X.Y}.0` | (link to changelog) |
+
+If no config keys were removed, delete this subsection.
+
+## Upstream dependency updates
+
+For each major dependency bump carried with this release:
+
+- Link to that project's upstream migration notes.
+- Call out any of their changes that leak through Autumn's public API.
+
+If no majors were carried, delete this section.
 
 ## How to verify
 
-1. `cargo check` — clean, with no `missing field `seo`` error.
-2. `cargo test` — your suite is green.
-3. Plugins: `autumn plugin-check --plugin-name <your-plugin>` passes
-   (`--plugin-name` is required).
-4. If you have a `lock_version` model with JSON clients: `PUT` a record without
-   `lock_version` and confirm it is rejected, then `PUT` it with the version
-   from the record's `GET` and confirm it succeeds.
-5. Serve the app (`cargo run`, default `http://127.0.0.1:3000`) and view-source
-   a page whose route declares `seo(...)` — the declared `<title>` / `<meta>`
-   values render.
-6. `curl http://127.0.0.1:3000/sitemap.xml` — no `robots = "noindex"` static
-   route is listed. Substitute your own address if you changed `[server] host`
-   or `[server] port`.
+The reader's proof the upgrade landed. Keep it to concrete, checkable steps —
+commands with expected output, not "make sure everything works". Required by
+`scripts/check-migration-guides.sh`.
+
+1. `cargo check` — clean, with none of the errors in the cheat sheet above.
+2. `cargo test` — the suite is green on the new version.
+3. `autumn doctor --strict` — no findings.
+4. {one step per breaking change: the observable behaviour that proves the fix
+   was applied, e.g. "hit `/x` and confirm the response carries `Y`"}
 
 ### Guide-only upgrade walkthrough
 
-The release checklist requires upgrading an app scaffolded with `autumn new` on
-the previous release using **only** this guide — no changelog, no source
-reading. See [`docs/release-checklist.md`](../release-checklist.md), *Migration
-Guide Gate*.
+(The heading keeps its historical name; the walk-through itself is
+codemod-first.) Upgrade an app scaffolded with `autumn new` on the **previous** release
+**codemod-first** — `autumn upgrade` before any manual step — using only this
+guide for what remains, and record the result here before publishing to
+crates.io. See [`docs/release-checklist.md`](../release-checklist.md),
+*Migration Guide Gate*.
 
-- **Status:** pending — performed and recorded during the release that ships
-  this guide, before publishing to crates.io.
+- **Codemod:** {the `autumn upgrade` invocation the walk-through ran first, and
+  what it covered. Required once this release ships any `auto`/`review`
+  codemod; the remaining manual steps below must be only the `review`/`manual`
+  changes.}
+- **Status:** pending
+  {the value must *begin* with `performed YYYY-MM-DD` once the walk-through is
+  done, or `backfilled` for a guide written after its release shipped;
+  `pending` is accepted only while this file is still `next.md`}
+- **From → to:** `autumn-cli {X.Y.Z}` app upgraded to `autumn-web {X.Z.0}`
+- **Elapsed:** {minutes — the budget is under 30 for a guide-only
+  walk-through, and under 10 once `autumn upgrade` covers this release's
+  rename-level changes (issue #1629)}
+- **Gaps found and fixed in this guide:** {none, or what the walk-through
+  exposed}
+
+## Troubleshooting
+
+Known rough edges, workarounds, and known-good version combinations
+(e.g. "use `diesel 2.2.5+` — earlier `2.2.x` releases have a known
+`pq-sys` linkage issue on macOS").
 
 ## Reporting problems
 
-If you hit something this guide does not cover, that is a bug in the guide.
-Open an issue at <https://github.com/autumn-foundation/autumn/issues> with the
-error or unexpected behaviour, the version you upgraded from, and a minimal
-reproduction if you have one.
+If you hit something not covered here, please open an issue at
+<https://github.com/autumn-foundation/autumn/issues> with:
+
+- The error message or unexpected behavior.
+- The old version you upgraded from.
+- A minimal reproduction if possible.
+
+Migration guides are living documents — we update them based on user
+reports for the first few months after a major release.

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -15,12 +15,25 @@ SemVer contract.
 | Crate | Directory | Publish Order | Notes |
 |---|---|---|---|
 | `autumn-macros` | `autumn-macros/` | 1 | No Autumn runtime deps; must publish first. |
-| `autumn-web` | `autumn/` | 2 | Depends on `autumn-macros`. |
-| `autumn-cli` | `autumn-cli/` | 3 | Independent of `autumn-web` at crate level. |
-| `autumn-admin-plugin` | `autumn-admin-plugin/` | 4 | Depends on `autumn-web`. |
-| `autumn-storage-s3` | `autumn-storage-s3/` | 4 | Depends on `autumn-web`. |
-| `autumn-cache-redis` | `autumn-cache-redis/` | 4 | Depends on `autumn-web`. |
-| `autumn-search` | `autumn-search/` | 4 | Depends on `autumn-web`. |
+| `autumn-schema-core` | `autumn-schema-core/` | 2 | No Autumn runtime deps. `autumn-cli` pins it. |
+| `autumn-edge` | `autumn-edge/` | 3 | Depends on `autumn-macros`. `autumn-web` pins it — **optionally**, but cargo still requires an optional dependency to resolve on crates.io, so it must precede `autumn-web`. |
+| `autumn-web` | `autumn/` | 4 | Depends on `autumn-macros` and `autumn-edge`. |
+| `autumn-cli` | `autumn-cli/` | 5 | Depends on `autumn-schema-core`. Independent of `autumn-web` at crate level. |
+| `autumn-admin-plugin` | `autumn-admin-plugin/` | 6 | Depends on `autumn-web`. |
+| `autumn-media-plugin` | `autumn-media-plugin/` | 6 | Depends on `autumn-web`. |
+| `autumn-storage-s3` | `autumn-storage-s3/` | 6 | Depends on `autumn-web`. |
+| `autumn-cache-redis` | `autumn-cache-redis/` | 6 | Depends on `autumn-web`. |
+| `autumn-search` | `autumn-search/` | 6 | Depends on `autumn-web`. |
+
+This table is the same set, in the same order, as `CRATES` in
+[`scripts/check-publish-dry-run.sh`](../scripts/check-publish-dry-run.sh) —
+that script is the executable copy, so keep the two in step. Note that two
+other gate scripts currently carry **narrower** lists —
+`scripts/check-crate-metadata.sh` omits `autumn-schema-core` and
+`autumn-media-plugin`, and `scripts/check-semver.sh` omits all three of
+`autumn-schema-core`, `autumn-edge` and `autumn-media-plugin`. Those crates are
+therefore published without a metadata or SemVer check today; widening both
+lists is worth doing, but it does not change the publish order above.
 
 All crates share a single workspace version (`[workspace.package].version` in
 `Cargo.toml`). They are always released together at the same version.
@@ -344,11 +357,18 @@ Before pushing the release tag:
    The `publish-gate` workflow runs automatically. The `release` workflow runs
    only after `publish-gate` succeeds.
 9. **Publish to crates.io** (in dependency order, after the gate passes):
+   Order matters: each crate's Autumn dependencies must already be on
+   crates.io, or `cargo publish` fails to resolve them. In particular
+   `autumn-web` pins `autumn-edge` and `autumn-cli` pins `autumn-schema-core`,
+   so both precede them here.
    ```bash
    cargo publish -p autumn-macros
+   cargo publish -p autumn-schema-core
+   cargo publish -p autumn-edge
    cargo publish -p autumn-web
    cargo publish -p autumn-cli
    cargo publish -p autumn-admin-plugin
+   cargo publish -p autumn-media-plugin
    cargo publish -p autumn-storage-s3
    cargo publish -p autumn-cache-redis
    cargo publish -p autumn-search

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -213,7 +213,8 @@ guide** — the guide is a gate, not a courtesy (issue #1588). See
 
 ### Automated
 
-- [ ] `./scripts/check-skill-version-markers.sh` is green. The `autumn-web`
+- [ ] `./scripts/check-skill-version-markers.sh` is green (it also runs in CI,
+  in the docs-only `migration-guides` job). The `autumn-web`
   agent skill annotates each API with the release it arrived in; those markers
   are hand-maintained and drift silently across a version cut, in several
   punctuation shapes (`(0.7.0)`, `**(0.7.0)**`, `(0.7.0, #1182)`, `(feature
@@ -355,6 +356,7 @@ Before pushing the release tag:
    ./scripts/check-crate-metadata.sh
    ./scripts/check-release-notes.sh
    ./scripts/check-migration-guides.sh
+   ./scripts/check-skill-version-markers.sh
    ./scripts/check-docs.sh
    ./scripts/check-semver.sh   # requires network; skip offline
    ```

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -213,6 +213,15 @@ guide** — the guide is a gate, not a courtesy (issue #1588). See
 
 ### Automated
 
+- [ ] `./scripts/check-skill-version-markers.sh` is green. The `autumn-web`
+  agent skill annotates each API with the release it arrived in; those markers
+  are hand-maintained and drift silently across a version cut, in several
+  punctuation shapes (`(0.7.0)`, `**(0.7.0)**`, `(0.7.0, #1182)`, `(feature
+  `tls`, 0.6.0, #1603)`). A marker naming too NEW a release is the damaging
+  direction — it tells a reader an API is out of reach when it already shipped.
+  The script resolves every issue-referenced marker against the CHANGELOG
+  section that introduced it. Markers with no issue reference are counted and
+  reported, not checked: skim those by hand when a release adds them.
 - [ ] `./scripts/check-migration-guides.sh` is green. It fails on an unmarked
   breaking changelog entry, a breaking section with no guide, a breaking entry
   that does not link its guide, and a guide missing a required section or an

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -169,7 +169,7 @@ are actually there. It is therefore a **post-publish, pre-announce** gate:
 - [ ] After `cargo publish` completes for the release candidate, trigger the
   `Quickstart Gate` workflow manually (Actions → Quickstart Gate → *Run
   workflow*) with the `cli-version` input set to the candidate version
-  (e.g. `0.6.0`), or via the CLI:
+  (e.g. `0.7.0`), or via the CLI:
 
   ```bash
   gh workflow run quickstart-gate.yml -f cli-version=X.Y.Z
@@ -318,7 +318,17 @@ Before pushing the release tag:
 4. **Complete the [Migration Guide Gate](#migration-guide-gate)** — rename
    `docs/migrations/next.md`, repoint the changelog links, and perform and
    record the codemod-first upgrade walk-through.
-5. **Run all gate scripts locally** to catch problems before CI sees the tag:
+5. **Refresh the dependency floor.** Review the open Dependabot PRs and fold
+   the semver-compatible ones into the release rather than tagging on top of a
+   month-old lockfile: `cargo update`, plus any manifest bound a grouped PR
+   widens. Majors that need API work are a separate change — decide
+   deliberately whether each rides this release, and say so in the changelog.
+6. **Write the [release walkthrough](releases/README.md)** —
+   `docs/releases/X.Y.Z.md`, cut after the CHANGELOG section is final. It is
+   the narrative counterpart to the changelog: what shipped, why, and what it
+   looks like in an app. Link it from the CHANGELOG section header, from the
+   README's *Documentation* list, and from the migration guide's header.
+7. **Run all gate scripts locally** to catch problems before CI sees the tag:
    ```bash
    ./scripts/check-crate-metadata.sh
    ./scripts/check-release-notes.sh
@@ -326,14 +336,14 @@ Before pushing the release tag:
    ./scripts/check-docs.sh
    ./scripts/check-semver.sh   # requires network; skip offline
    ```
-6. **Tag and push:**
+8. **Tag and push:**
    ```bash
-   git tag v0.5.0
-   git push origin v0.5.0
+   git tag v0.7.0
+   git push origin v0.7.0
    ```
    The `publish-gate` workflow runs automatically. The `release` workflow runs
    only after `publish-gate` succeeds.
-7. **Publish to crates.io** (in dependency order, after the gate passes):
+9. **Publish to crates.io** (in dependency order, after the gate passes):
    ```bash
    cargo publish -p autumn-macros
    cargo publish -p autumn-web
@@ -343,7 +353,7 @@ Before pushing the release tag:
    cargo publish -p autumn-cache-redis
    cargo publish -p autumn-search
    ```
-8. **Gate the published quickstart** (see
+10. **Gate the published quickstart** (see
    [Published Quickstart Gate](#7--published-quickstart-gate-quickstart-gate-workflow-post-publish)):
    ```bash
    gh workflow run quickstart-gate.yml -f cli-version=X.Y.Z

--- a/docs/releases/0.7.0.md
+++ b/docs/releases/0.7.0.md
@@ -438,7 +438,15 @@ implement a layer against the concrete Axum route service (retarget the bound);
 the third break is on the wire rather than in Rust. There is also one
 deprecation, and one set of runtime behaviour changes worth a look if you use
 `Query<T>` beyond unique scalar keys — those compile fine and change what a
-request does. `autumn upgrade` names every one of them against your own
+request does.
+
+If you deploy under a **custom profile** — anything that is not `dev`,
+`development`, `prod` or `production` — read the guide's *Configuration
+changes* before you ship. `auto_migrate_in_production = true` used to be
+name-gated to `prod`/`production` and silently did nothing elsewhere; 0.7.0
+honours it on any non-`dev` profile, so a config you already have can start
+applying migrations at startup. That is the bug being fixed, but it is worth
+knowing before it happens rather than after. `autumn upgrade` names every one of them against your own
 `Cargo.toml` version, which is the reliable way to find out whether any apply
 to you.
 

--- a/docs/releases/0.7.0.md
+++ b/docs/releases/0.7.0.md
@@ -431,7 +431,9 @@ tower / tower-http layer — you are unaffected. See [§8](#8-upgrading-from-06x
 
 The full path is [`docs/migrations/0.7.0.md`](../migrations/0.7.0.md). The
 short version: **application code compiles unchanged.** There are three narrow
-breaks and one deprecation.
+breaks, one deprecation, and one set of runtime behaviour changes worth a look
+if you use `Query<T>` beyond unique scalar keys — see the guide's *Behavior
+changes*.
 
 ```bash
 cargo install autumn-cli --version 0.7.0

--- a/docs/releases/0.7.0.md
+++ b/docs/releases/0.7.0.md
@@ -430,10 +430,17 @@ tower / tower-http layer — you are unaffected. See [§8](#8-upgrading-from-06x
 ## 8. Upgrading from 0.6.x
 
 The full path is [`docs/migrations/0.7.0.md`](../migrations/0.7.0.md). The
-short version: **application code compiles unchanged.** There are three narrow
-breaks, one deprecation, and one set of runtime behaviour changes worth a look
-if you use `Query<T>` beyond unique scalar keys — see the guide's *Behavior
-changes*.
+short version: **most application code compiles unchanged** — but two of the
+three breaks below are compile errors if you touch the seams they name, so
+"unchanged" is a statement about the common case, not a guarantee. You need a
+source edit if you build `Route` / `StaticRouteMeta` literals (add `seo`) or
+implement a layer against the concrete Axum route service (retarget the bound);
+the third break is on the wire rather than in Rust. There is also one
+deprecation, and one set of runtime behaviour changes worth a look if you use
+`Query<T>` beyond unique scalar keys — those compile fine and change what a
+request does. `autumn upgrade` names every one of them against your own
+`Cargo.toml` version, which is the reliable way to find out whether any apply
+to you.
 
 ```bash
 cargo install autumn-cli --version 0.7.0

--- a/docs/releases/0.7.0.md
+++ b/docs/releases/0.7.0.md
@@ -1,0 +1,478 @@
+# Autumn 0.7.0 — Ship it, then prove it
+
+*Released 2026-08-23 · [CHANGELOG](../../CHANGELOG.md#070---2026-08-23) ·
+[Migration guide](../migrations/0.7.0.md)*
+
+0.6.0 was about making Autumn apps *complete* — auth, admin, jobs, mail, the
+things an app needs before it is real. 0.7.0 is about the two things that
+happen next: **getting it onto a server**, and **knowing it still works**.
+
+Those are the two ends of the release. In between sit a new association kind,
+per-locale model fields, a deterministic simulation harness, a request path
+that allocates less than half of what it used to, and the upgrade tooling that
+gets you here from 0.6.x.
+
+This is a walkthrough, not a list. The
+[CHANGELOG](../../CHANGELOG.md#070---2026-08-23) has all 144 entries; this has
+the story.
+
+```bash
+cargo install autumn-cli --version 0.7.0
+autumn upgrade            # preview what this release changes in your source
+```
+
+---
+
+## 1. Deploys: from "≤ 3 commands" to actually true
+
+`autumn deploy` existed in 0.6.0 with an asterisk: you had to install
+`kamal-proxy` on the target yourself, and you had to run migrations
+out-of-band before the first deploy. Both are gone.
+
+**`autumn deploy up` now prepares the host.** It probes the target read-only,
+and on a host with no working proxy installs the pinned `kamal-proxy` build at
+`/usr/local/bin/kamal-proxy` (plus `curl` and a container runtime). The image
+is pinned **by digest** — a Docker Hub tag is mutable and this binary runs as
+root — the binary is staged and moved so the supervised path is never
+half-written, and the install refuses outright if anything already exists at
+that path. A host that already has a working proxy is untouched. A proxy whose
+CLI surface has *drifted* is still never silently replaced: that stays a
+fail-closed refusal. Opt out with `[deploy] install_proxy = false`.
+
+**The first deploy migrates.** `first_deploy_ops` now runs the same blocking
+`AUTUMN_MIGRATE=1` one-shot the redeploy path does, *before* the initial
+release starts — so the app never boots against a schema that was never
+applied, and a failed migration aborts the deploy with nothing started and
+nothing routed.
+
+The target-host precondition is now genuinely "a stock Ubuntu LTS with SSH
+access", and the nightly real-VPS workflow proves it: it provisions a **stock**
+image, asserts there is no kamal-proxy on it, and proves `autumn deploy up`
+installs a working one. Its manual bootstrap step is gone — which is what makes
+the "≤ 3 commands from `autumn new`" metric honest.
+
+### Fleets
+
+```toml
+[deploy]
+hosts = ["10.0.0.11", "10.0.0.12", "10.0.0.13"]
+```
+
+List several SSH-reachable servers and the same `autumn deploy up` orchestrates
+a zero-downtime rollout across all of them. No host is touched until every host
+is graded, the single migration runs on the **first host in rollout order**
+whatever its mode, and a failure mid-rollout halts and compensates.
+
+Two read-only companions:
+
+```bash
+autumn deploy status              # one row per host: release, proxy, drift
+autumn deploy maintenance on      # fleet-wide, over SSH
+autumn deploy maintenance off
+```
+
+`deploy status` is the one to reach for first — it reports fleet state and
+drift without touching anything.
+
+### And if you'd rather not run servers
+
+`autumn release init` gained three managed-platform targets this release:
+
+```bash
+autumn release init --target azure-container-apps
+autumn release init --target aws-app-runner
+autumn release init --target gcp-cloud-run
+```
+
+---
+
+## 2. Deterministic simulation testing
+
+The headline of the release, and the hardest to summarise, because it is a
+whole testing discipline rather than a feature.
+
+```rust
+#[sim_test]
+async fn retries_do_not_stampede(sim: Sim) {
+    // virtual clock, seeded entropy, replay-on-panic
+}
+```
+
+A `#[sim_test]` runs your app against a **virtual clock** and a **seeded
+entropy source**, so a concurrency bug that needs three things to happen in one
+order reproduces on every run from the same seed instead of once a fortnight in
+CI. The harness landed across the release in slices:
+
+- **The clock.** `Sim::advance(dur)` / `advance_to(target)` step virtual time;
+  the job runtime's `enqueue_in` / `enqueue_at`, the token-bucket rate limiter,
+  and the scheduler all read the injected clock rather than `Instant::now()`.
+- **Chaos.** `sim::Chaos` gained a crash/restart primitive, `clock_skew`, and a
+  deterministic SMTP transport fault lane.
+- **Assertions.** `always!` and `sometimes!` — the Antithesis-style pair that
+  lets a test say "this invariant holds on every schedule" and "this
+  interesting state is reachable at all", the second of which is what catches a
+  test that has quietly stopped exercising anything.
+- **Search.** `sim::sweep` runs a seed sweep; `sim::op` is a property-based
+  op-driver that generates operation sequences; `sim::llm` is a seeded LLM stub
+  for apps with a model in the loop.
+- **The seams.** A **determinism seam gate** now bans direct `Utc::now()` and
+  the last raw `Instant` sources in framework code, so the harness cannot be
+  quietly bypassed by a new subsystem.
+
+It has already paid for itself. The harness caught a genuine **job-backoff
+thundering herd**: retry delay was `initial_backoff_ms * 2^(attempt-1)`, a
+function of a job's *configuration* only — so when several jobs in a queue
+failed at the same instant, every one of them retried at the same instant and
+immediately re-flooded the dependency they had just backed off from. The fix
+draws an equal-jitter spread from the injected `Entropy` seam. That is exactly
+the class of bug a real-clock integration test cannot reliably reproduce, and
+`tests/integration/sim_retry_storm.rs` is the worked example.
+
+---
+
+## 3. Models learned four new tricks
+
+### `#[translatable]` — per-locale columns, no locale argument
+
+```rust
+#[model]
+struct Post {
+    #[translatable]
+    title: String,
+}
+```
+
+`title` is now a `Translated`: an independent value per locale tag, stored as a
+JSON object in the column's own `TEXT` storage (portable across Postgres and
+SQLite). `Display` renders the **active request locale**, so this:
+
+```rust
+html! { h1 { (post.title) } }
+```
+
+serves Spanish under `Accept-Language: es` with no locale argument anywhere in
+the handler, and falls back for `fr` through
+`I18nConfig::resolved_fallback_chain` — the same chain your UI strings walk.
+When the chain is exhausted the field returns a documented sentinel (`None`
+from `resolve()`, `""` from `Display`), never a panic or a 500.
+
+Because the value *is* the whole map, `find` → `set_title("es", …)` → `update`
+changes one locale and leaves every other byte-for-byte intact. `Deserialize`
+is the exact inverse and **refuses a bare string** — otherwise
+`PUT /api/posts/1 {"title": "Hola"}` would silently delete every other
+language from a body that reads like it sets one field. Use
+`Translated::merge_from` for partial updates.
+
+Adopting it on an existing column needs **no data migration**: a stored value
+that is not a JSON object of strings reads as the default locale's
+translation. The generator knows about it too —
+`autumn generate model Post 'title:String{translatable}'` emits the attribute,
+the schema entry, and a migration `autumn migrate check` classifies as
+**safe**.
+
+### `#[commentable]` — the fifth association kind
+
+`belongs_to` / `has_many` / `has_one` / `through` all pin a child to exactly
+one parent table. That is why every app that wants comments on a *second* model
+duplicates the table, the routes, the threading query and the count
+maintenance.
+
+```rust
+#[model]
+#[commentable(by = User)]
+struct Post { /* … */ }
+```
+
+One `comments` table keyed on `(commentable_type, commentable_id)`, with a
+`parent_id` self-reference for threading, attaching to any number of models at
+once. You get `add_comment(parent_id, author_id, body, reply_to)`,
+`comment_thread(parent_id)`, `delete_comment(comment_id)`, and a generic router
+with a `CommentsConfig::on_comment` hook.
+
+### `#[votable]` — votes, likes and favourites
+
+```rust
+#[votable(by = User, aggregate = sum)]
+```
+
+Votes are the same shape every time: a `(reactor, target)`-unique edge table, a
+toggle/flip/insert on it, and a denormalised `score` on the target that must
+stay *exactly* equal to `SUM(value)`. Hand-writing it is a read-then-write race
+on the edge plus a lost-update race on the aggregate. The attribute emits the
+edge table and a `{Model}Reactions` trait that gets both right.
+
+### `position` — ordered lists without reindexing SQL
+
+```bash
+autumn generate scaffold Task 'rank:position{scope:board_id}'
+```
+
+Todo priorities, kanban columns, playlist tracks. The column is server-managed
+(excluded from `New*`/`Update*`); database **triggers** assign the next
+contiguous value on insert and compact on delete or soft-delete, so the
+`0..len-1` invariant holds on every path, not just the generated repository's.
+`#[repository(Model, position(column = "rank", scope = "board_id"))]` generates
+transaction-safe `move_to(id, n)` / `move_before(id, other)`.
+
+### Optimistic locking, by naming a column
+
+Declare a non-nullable `i32`/`i64` column literally named `lock_version` and
+the model opts into optimistic locking: a stale write is rejected with
+`RepositoryError::Conflict` instead of the last writer silently winning. The
+HTML scaffold's edit form carries the version in a hidden field and comes back
+at **409** with your input intact. **This is a wire-level break for JSON API
+clients** — see [§8](#8-upgrading-from-06x).
+
+---
+
+## 4. Data that expires, on purpose
+
+```rust
+#[repository(Session, retention(after = "30d", basis = created_at))]
+```
+
+That compiles to a batched, cursor-paginated, fleet-coordinated sweep — no
+`#[scheduled]` function, no SQL. Age-based retention soft-deletes on a
+`soft_delete` repository (never re-touching an already soft-deleted row) and
+hard-deletes otherwise. The composable `purge_deleted_after = "90d"` always
+hard-purges, re-checking `deleted_at` at delete time so a row `restore()`d
+between the sweep's SELECT and DELETE survives.
+
+Policies auto-register via `inventory` — no `tasks![…]` entry — and reuse the
+same Postgres-advisory-lock coordination `#[scheduled]` already uses, so a
+fleet sweeps once. Validate before you trust it:
+
+```bash
+autumn retention --dry-run
+```
+
+---
+
+## 5. When it breaks in production
+
+### Failure capsules: record, then replay
+
+```toml
+[failure_capture]
+enabled = true
+```
+
+Every caught panic and every 5xx writes a **capsule**: one JSON file holding
+the redacted request, the database traffic the handler produced, the clock
+readings it took, and the outcome the client received.
+
+```bash
+autumn replay ./capsules/<id>.json
+```
+
+rebuilds the application around it and re-runs it. The gap this closes is the
+one between "I have a stack trace" and "I can reproduce it" — a production 500
+that depends on the row a query returned is not reproducible from a log line,
+however structured, and the usual answer (copy the request into a test, guess
+at the data) is exactly the guess that makes a bug take a week.
+
+Database effects are captured at the **wire**, not at the query API: a pooled
+connection is established through a tee that frames PostgreSQL protocol
+messages in both directions. This release also took the capsule format to
+version `2` and closed six fidelity and redaction gaps found in review.
+
+### Metrics at the call site
+
+```rust
+metrics::counter("checkout_completed_total")
+    .with_label("status", "paid")
+    .increment(1);
+```
+
+No trait to implement, no type to define, nothing to register with
+`AppBuilder`. The instrument registers in a process-global registry on first
+use and shows up on the stock `/actuator/prometheus` scrape (and under a new
+top-level `app` key on `/actuator/metrics`). `timer(..).start()` returns a
+guard that records on **every** exit path — early `?` returns and unwinding
+panics included.
+
+It is designed to degrade rather than take an app down: hard caps (100
+*labeled* series per instrument) bound cardinality instead of leaking series,
+and histograms render as standard cumulative Prometheus histograms whose
+`le="+Inf"` bucket is structurally derived from the same slots as `_count`, so
+the two can never drift.
+
+### Clustering without a coordination service
+
+Two instances of the same binary, started with a shared secret and **no**
+external coordinator — no Redis, no Postgres, no etcd — discover each other
+over authenticated TCP gossip and expose a cluster-wide grow-only CRDT counter
+(`ClusterHandle::counter(name)`). Cells are keyed by `(node id, boot
+incarnation)` and merged by per-cell maximum, so a restarted node can never
+undercount. Membership is itself a CRDT with SWIM-style incarnation refutation;
+one periodic signed state push doubles as the heartbeat.
+
+Also here: **operator alerts**, a `health.enabled` knob, and
+`autumn routes audit` wired into every scaffolded app's CI by default — so a
+route nobody classified fails CI on day one rather than waiting for an app to
+opt in. Unclassified-route diagnostics now name the handler's `file:line`.
+
+---
+
+## 6. The request path got substantially cheaper
+
+Two independent findings, both measured with `valgrind --tool=dhat` against a
+new `request_pipeline` benchmark.
+
+**Layer composition (~59% fewer heap allocations per request).** Every
+`Router::layer` call wraps the whole downstream stack in another
+`BoxCloneSyncService`, and axum's `Route::call` **deep-clones that box on every
+invocation** — so *N* stacked layers cost `N(N+1)/2 + 2N` allocations per
+request, *quadratically*. Measured against axum 0.8.9 with no-op layers: 38
+allocations/request at N = 5, 263 at N = 20, **1388 at N = 50**. The same
+layers composed into a *single* `Router::layer` call cost a flat **16 at any
+N**. Autumn's ingress stack was ~26 sequential calls; it is now a handful of
+composed ones.
+
+**Boxed futures (19.57% of every byte allocated).** Every
+`axum::middleware::from_fn` on the always-on request path returned its future
+as `Box::pin(..)` — one heap allocation per call site per request, sized by
+everything the async block captures across its `.await`, which for an outer
+layer is the whole downstream continuation. DHAT put those boxes at 5,267,600
+of 26,918,238 bytes over 650 requests — the largest single allocation cost in
+the profile, at only 2.14% of the blocks. They are now hand-rolled
+`tower::Service` impls with **named** futures.
+
+Elsewhere in the same sweep: config reads on the request path (generated auth
+handlers, the admin surface) stopped deep-cloning; `AppState::profile` and
+`auth_session_key` no longer allocate; the Postgres job worker's claim query
+dropped an `array_position` from `ORDER BY` for single-queue apps, which lets
+the planner use the existing `(queue, run_at)` index for a plain `Index Scan +
+Limit 1` instead of a bitmap scan and sort of the entire ready backlog;
+list-mail sends batch their suppression checks; and the generated scaffold
+`index` page for a `belongs_to` model stopped issuing a query per row.
+
+**One consequence is a break:** app-wide layers are now registered against an
+erased ingress service. If you wrote a layer generically — the shape of every
+tower / tower-http layer — you are unaffected. See [§8](#8-upgrading-from-06x).
+
+---
+
+## 7. Everything else worth knowing
+
+**Web surface**
+
+- **Route-level SEO** — `#[get("/about", seo(title = "…"))]` records defaults
+  on the route itself; the router installs the request extension only for
+  routes that declared something, so routes without `seo(...)` pay nothing.
+  Handlers still decide where to emit them (`SeoMeta::render()`). A
+  `robots = "noindex"` static route is now left out of `sitemap.xml`.
+- **Locale-prefixed routing** — `/{locale}/…` nests plus a path-preserving
+  locale switcher.
+- **In-app notifications** — `autumn_web::notifications` with a read/unread
+  feed: `notify(recipient_id, kind, payload)`, paginated `list(…)` with
+  `filter[unread]`, `unread_count`, idempotent `mark_read` / `mark_all_read`.
+  Pluggable `NotificationStore` (Postgres/SQLite by default, in-memory for
+  DB-less dev), and `notify_with_push` under the `ws` feature.
+- **Rich text** — a safe first-class path for user-submitted formatted text.
+- **PDF downloads** — render server-side templates to downloadable documents.
+- **`Query<T>` decodes sequences and nested structures** — `[` and `]` in a
+  query key are now structure. Duplicated keys in a single-valued position are
+  rejected, and decode errors no longer echo the submitted value back.
+- **`autumn-search`** — the in-core search surface is now an optional plugin
+  crate (keyword + vector).
+- **Edge WASM capsules (first slice)** — mark a read-path handler `#[edge]`,
+  register with `edge_routes![]`, and one `autumn build` emits a portable
+  `wasm32-wasip1` capsule alongside the native binary. Same router, same
+  handler source, no vendor SDK. The origin stays the authority: anything the
+  edge cannot serve becomes a typed `fallthrough` forwarded upstream.
+
+**Generators and CLI**
+
+- **`autumn console`** (alias `autumn c`) — a pre-wired data playground. Rust
+  has no stable `eval`, so it follows loco.rs's edit-and-run model: the first
+  invocation scaffolds `src/bin/playground.rs` already wired with config
+  resolution, a constructed pool, a checked-out connection, and a
+  `// your code here` region.
+- **`autumn generate teams`** — organizations, a closed `Owner`/`Admin`/
+  `Member` role per membership, and email invitations, composed entirely from
+  already-stable primitives (`tenant_scoped` repositories, the session `role`
+  key, `#[mailer]`) rather than a new authorization mechanism.
+- **`autumn generate webhook <provider> <Name>`** — signed, replay-safe
+  provider intake. `autumn webhook sim` gained `--event <TYPE>` and now
+  refreshes body-carried delivery IDs.
+- **Scaffold upgrades** — `--i18n` translatable views, a working **CSV export**
+  on the list view, `--belongs-to <Parent>`, the recover-from-soft-delete flow,
+  a no-JavaScript file-upload path, and `json`/`jsonb` and `{encrypted}` field
+  types.
+
+**Upgrade tooling**
+
+- **`autumn upgrade`** applies each release's *mechanical* app-code migrations
+  to your own source. It writes nothing by default — a bare invocation prints a
+  per-file diff and an affected-site count; `--apply` is the explicit write
+  step. Rewrites match whole tokens through a token-level parse rather than
+  text substitution, so string literals, comments and same-named locals are
+  untouched, formatting survives byte-for-byte, and a second run is a no-op.
+  Anything it cannot reach is reported with `file:line` and a link to the guide
+  section.
+- **The migration guide gate** — every release with a breaking change now
+  *cannot ship* without a guide. `scripts/check-migration-guides.sh` runs on
+  every pull request and in the publish gate.
+
+**Security**
+
+- Inbound mail: `multipart/*` nesting capped at 16 levels, and MIME boundaries
+  RFC 2046 §5.1.1 does not permit are rejected.
+- `#[secured]`'s roles and scopes are no longer lost when another attribute
+  sits alongside it (plus two sibling route-metadata losses found in the same
+  review).
+- `generate admin` and `#[repository]`-with-hooks both now handle
+  `#[encrypted]` models correctly.
+
+---
+
+## 8. Upgrading from 0.6.x
+
+The full path is [`docs/migrations/0.7.0.md`](../migrations/0.7.0.md). The
+short version: **application code compiles unchanged.** There are three narrow
+breaks and one deprecation.
+
+```bash
+cargo install autumn-cli --version 0.7.0
+autumn upgrade      # run this BEFORE bumping the dependency
+```
+
+0.7.0 ships no `auto` codemod — all three breaks need a human decision — but
+`autumn upgrade` still lists each one with a link to its guide section, which
+is your checklist.
+
+1. **`Route` and `StaticRouteMeta` gained an `seo` field.** Only a *literal*
+   struct construction has to change, which in practice means a plugin
+   assembling a `Vec<Route>` by hand instead of using `routes![]`. Add
+   `seo: autumn_web::seo::SeoRouteDefaults::EMPTY`.
+2. **A `lock_version` model requires the version on JSON `PUT`/`PATCH`.** On
+   the wire, not in Rust. Browser forms on an HTML scaffold are unaffected. If
+   you did not want optimistic locking, the column *name* is the entire opt-in
+   — rename it and the behaviour goes away.
+3. **App-wide layers are erased.** `IntoAppLayer` is now bound on
+   `tower::Layer<autumn_web::app::ErasedAppService>`. Every layer generic over
+   the service it wraps compiles unchanged; only a layer written against one
+   concrete inner service type notices.
+
+**Deprecated (still working):** `scheduler::now_unix_secs` /
+`now_unix_duration` read the real system clock off the framework's injected
+clock seam, so anything derived from them is not reproducible under a
+`#[sim_test]`. Move to `autumn_web::time::clock_unix_secs(state.clock())`.
+
+MSRV is unchanged at **1.88.0**. No dependency major reaches application code;
+`libsqlite3-sys` moves `0.37 → 0.38`, which matters only if your own
+`Cargo.toml` depends on it directly.
+
+---
+
+## Where to go next
+
+- [CHANGELOG — the full 0.7.0 entry](../../CHANGELOG.md#070---2026-08-23)
+- [Migration guide: 0.6.x → 0.7.0](../migrations/0.7.0.md)
+- [Getting started](../guide/getting-started.md)
+- [Simulation testing](../guide/simulation-testing.md)
+- [Fleet deploys](../guide/fleet-deploys.md)
+- [Upgrading an app across releases](../guide/upgrading.md)
+
+Found a gap? <https://github.com/autumn-foundation/autumn/issues>

--- a/docs/releases/0.7.0.md
+++ b/docs/releases/0.7.0.md
@@ -13,7 +13,7 @@ that allocates less than half of what it used to, and the upgrade tooling that
 gets you here from 0.6.x.
 
 This is a walkthrough, not a list. The
-[CHANGELOG](../../CHANGELOG.md#070---2026-08-23) has all 144 entries; this has
+[CHANGELOG](../../CHANGELOG.md#070---2026-08-23) has all 145 entries; this has
 the story.
 
 ```bash
@@ -93,7 +93,7 @@ whole testing discipline rather than a feature.
 
 ```rust
 #[sim_test]
-async fn retries_do_not_stampede(sim: Sim) {
+async fn retries_are_not_synchronized_under_load(mut sim: Sim) {
     // virtual clock, seeded entropy, replay-on-panic
 }
 ```

--- a/docs/releases/README.md
+++ b/docs/releases/README.md
@@ -1,0 +1,27 @@
+# Release Walkthroughs
+
+A narrative tour of each release: what changed, why, and what it looks like in
+an application. These sit alongside — not instead of — the two documents that
+are gates rather than prose:
+
+- [`CHANGELOG.md`](../../CHANGELOG.md) is the complete, entry-by-entry record.
+- [`docs/migrations/`](../migrations/README.md) is the upgrade path, and is
+  enforced by `scripts/check-migration-guides.sh`.
+
+A walkthrough is neither. It is the document you send someone who asks "what's
+new in this one?" and does not want 144 changelog entries.
+
+## Index
+
+- [`0.7.0.md`](0.7.0.md) — *Ship it, then prove it*: host-preparing deploys and
+  fleets, deterministic simulation testing, `#[translatable]` /
+  `#[commentable]` / `#[votable]` / `position`, failure-capsule replay,
+  call-site metrics, and a request path that allocates ~59% less.
+
+## Writing one
+
+Cut it with the release, after the CHANGELOG section is finalised, and link it
+from the release's migration guide *At a glance* header. Keep it thematic —
+group by what a reader is trying to do, not by changelog category — and quote
+real numbers and real API spellings from the changelog rather than
+paraphrasing them.

--- a/docs/releases/README.md
+++ b/docs/releases/README.md
@@ -9,7 +9,7 @@ are gates rather than prose:
   enforced by `scripts/check-migration-guides.sh`.
 
 A walkthrough is neither. It is the document you send someone who asks "what's
-new in this one?" and does not want 144 changelog entries.
+new in this one?" and does not want 145 changelog entries.
 
 ## Index
 

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -56,9 +56,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.4"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+checksum = "c982642fa9e8606056828ee9a8505737230110bb1099153c79efe865c59d12ba"
 dependencies = [
  "memchr",
 ]
@@ -86,9 +86,9 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "android_system_properties"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+checksum = "ae221649c9976a6f6c56ae1facf410f3ddb33cc661c4b7b61020a912d4237fbc"
 dependencies = [
  "libc",
 ]
@@ -107,9 +107,9 @@ checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
 
 [[package]]
 name = "async-compression"
-version = "0.4.42"
+version = "0.4.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e79b3f8a79cccc2898f31920fc69f304859b3bd567490f75ebf51ae1c792a9ac"
+checksum = "3976abdc8fe7d1133d43d304afd42abdf5bc3e1319d263d223bde07b5efc4be8"
 dependencies = [
  "compression-codecs",
  "compression-core",
@@ -119,13 +119,13 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.89"
+version = "0.1.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+checksum = "82f6aeea286b8eb4dd3431a1be1b59d290ace00f5bfd8e2a159bc2a05e2c1667"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -150,21 +150,21 @@ dependencies = [
 
 [[package]]
 name = "autumn-macros"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "autumn-web"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "aes-gcm",
  "autumn-macros",
  "axum",
- "base64",
+ "base64 0.22.1",
  "bcrypt",
  "brotli",
  "bytes",
@@ -184,6 +184,7 @@ dependencies = [
  "http-body",
  "http-body-util",
  "indexmap",
+ "infer",
  "inventory",
  "jsonwebtoken",
  "libsqlite3-sys",
@@ -191,10 +192,13 @@ dependencies = [
  "matchit",
  "maud",
  "moka",
+ "multer",
  "nix",
  "percent-encoding",
  "pin-project-lite",
  "pq-sys",
+ "rand 0.9.5",
+ "rand_chacha 0.9.0",
  "reqwest",
  "rust_decimal",
  "rustls",
@@ -206,6 +210,7 @@ dependencies = [
  "serde_path_to_error",
  "serde_urlencoded",
  "serde_yaml",
+ "sha1",
  "sha2 0.10.9",
  "subtle",
  "thiserror",
@@ -214,11 +219,12 @@ dependencies = [
  "tokio-postgres",
  "tokio-postgres-rustls",
  "tokio-util",
- "toml 1.1.2+spec-1.1.0",
+ "toml 1.1.4+spec-1.1.0",
  "tower",
  "tower-http 0.7.0",
  "tracing",
  "tracing-subscriber",
+ "unicode-normalization",
  "url",
  "uuid",
  "validator",
@@ -233,7 +239,7 @@ checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
  "axum-core",
  "axum-macros",
- "base64",
+ "base64 0.22.1",
  "bytes",
  "form_urlencoded",
  "futures-util",
@@ -290,7 +296,7 @@ checksum = "7aa268c23bfbbd2c4363b9cd302a4f504fb2a9dfe7e3451d66f35dd392e20aca"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -306,6 +312,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
+
+[[package]]
 name = "base64ct"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -313,11 +325,11 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bcrypt"
-version = "0.19.2"
+version = "0.19.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f3c067aa24dd4ed5c79cf222a38f260c8f23d3b82a062fba3f28c6fe563b753"
+checksum = "a0cd0bd35a28836d528d2b58ad499bc3c5641d59379421b1be9eeb0c2f2b912a"
 dependencies = [
- "base64",
+ "base64 0.23.1",
  "blowfish",
  "getrandom 0.4.3",
  "subtle",
@@ -326,9 +338,9 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "2.13.0"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
 name = "bitvec"
@@ -372,9 +384,9 @@ dependencies = [
 
 [[package]]
 name = "borsh"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f3f6da4992df95bbcd9af42a6c7dcb994498fc9048230405f3b36ff7cd3f145"
+checksum = "a88b7ea17d208c4193f2c1e6de3c35fe71f98c96982d5ced308bdcc749ff6e1f"
 dependencies = [
  "borsh-derive",
  "bytes",
@@ -383,15 +395,15 @@ dependencies = [
 
 [[package]]
 name = "borsh-derive"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ae8fb4fb5740e4b2c4884ff95f5f32f5e8479db1e8fd8eb49ddbe09eb09bb7c"
+checksum = "d8f347189c62a579b8cd5f80714efa178f52e461dc2e6d701d264f5ff22e566c"
 dependencies = [
  "once_cell",
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -457,14 +469,25 @@ checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "cc"
-version = "1.2.66"
+version = "1.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5d6cac793997bd970000024b2934968efe83b382de4fdcf4fcb46b6ee4ad996"
+checksum = "0ad534f4357a5264cce5019c989cf66a4f0dc4e0d1b1d15f8aacec0ff7360273"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
  "libc",
  "shlex",
+]
+
+[[package]]
+name = "cfb"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d38f2da7a0a2c4ccf0065be06397cc26a81f4e528be095826eee9d4adbb8c60f"
+dependencies = [
+ "byteorder",
+ "fnv",
+ "uuid",
 ]
 
 [[package]]
@@ -475,9 +498,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cfg_aliases"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "chacha20"
@@ -596,9 +619,9 @@ dependencies = [
 
 [[package]]
 name = "crc32fast"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+checksum = "8498c871161e1742aaa9d52551b2d6ebdd4c3d45a3be423e3728f33b955be550"
 dependencies = [
  "cfg-if",
 ]
@@ -712,7 +735,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -736,6 +759,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core 0.23.0",
+ "darling_macro 0.23.0",
+]
+
+[[package]]
 name = "darling_core"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -746,7 +779,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -760,7 +793,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.118",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -771,7 +817,7 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core 0.20.11",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -782,14 +828,25 @@ checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
 dependencies = [
  "darling_core 0.21.3",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core 0.23.0",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "data-encoding"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+checksum = "4583a4551df46e2792f82ceeac45e850d2e2d5debba0b91f102385cda5b11f06"
 
 [[package]]
 name = "deadpool"
@@ -832,7 +889,7 @@ checksum = "8034092389675178f570469e6c3b0465d3d30b4505c294a6550db47f3c17ad18"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -859,7 +916,7 @@ dependencies = [
  "darling 0.20.11",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -869,14 +926,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
 dependencies = [
  "derive_builder_core",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "diesel"
-version = "2.3.10"
+version = "2.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29fe29a87fb84c631ffb3ba21798c4b1f3a964701ba78f0dce4bf8668562ec88"
+checksum = "715377c6e464cb44bb89bd8487584240516c8d5052bc645d6babc50bb8be46c3"
 dependencies = [
  "bitflags",
  "byteorder",
@@ -916,7 +973,7 @@ dependencies = [
  "dsl_auto_type",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -936,7 +993,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe2444076b48641147115697648dc743c2c00b61adade0f01ce67133c7babe8c"
 dependencies = [
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -965,13 +1022,13 @@ dependencies = [
 
 [[package]]
 name = "displaydoc"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
+checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -991,7 +1048,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1034,9 +1091,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.16.0"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+checksum = "252afb9ae5eaa683babdc6a068b3f5726eb19e05070c731f9b2a23a7c3e8ed34"
 
 [[package]]
 name = "elliptic-curve"
@@ -1108,9 +1165,9 @@ checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.9"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+checksum = "d45db016d36b838f563236e9193d0ee6ce38f3f68b6c94e914b4929c96bbb890"
 
 [[package]]
 name = "flagset"
@@ -1157,9 +1214,9 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+checksum = "9a31d2a3fbaaeb2af2368bbdd904aa8e812d3c04a1ee10d3171f52d556e5d0a3"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1172,9 +1229,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+checksum = "b1f9e3d69d39e4862ffed03ed071a76f9a13ba1d9109d355b0f0aa6b15e393c4"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1182,15 +1239,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+checksum = "92d699e522242e69e3003b94ecc1f960f3a5e015aa7c5d7486e65ad01dd94f5e"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+checksum = "031b47cf1a3c6cc8bc2fc76cd437f521619387907d469316e7c0bc278f1f5432"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1199,38 +1256,38 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+checksum = "53c0fa8157de1303bfffdaa1cc2a673bfffb60102f76b0ef4441659124373fed"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+checksum = "9fb9654ba8355388abeb8dcb4fc62f511300867002afc858860463bdd9fe0c44"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+checksum = "1944426bf7d03f1d14f708785e4b33efd750b36d48a157b836b3efc15ede8e1d"
 
 [[package]]
 name = "futures-task"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+checksum = "cd417de3d1d015fc3bfd2b1ea46dfc7bab72ef86f1cc7cc9c78e728b34a6d1fd"
 
 [[package]]
 name = "futures-util"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+checksum = "0d50a92467f8ba5dd6e3ee5d4bd04d73ab2e4e1c44474a0674821dfce14b79bc"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1390,9 +1447,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.4.2"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
+checksum = "918d3568bebf352712bc2ef3d46a8bcf1a75b373be6539de198e9105cbbf9ce0"
 dependencies = [
  "bytes",
  "itoa",
@@ -1400,9 +1457,9 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+checksum = "ca2a8f2913ee65f60facd6a5905613afaa448497a0230cc41ce022d93290bc2c"
 dependencies = [
  "bytes",
  "http",
@@ -1410,9 +1467,9 @@ dependencies = [
 
 [[package]]
 name = "http-body-util"
-version = "0.1.3"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+checksum = "23169fe34a5fbcdd3f3862e78fb9b6fccd5f02a6dc6f732547005d45631ce71c"
 dependencies = [
  "bytes",
  "futures-core",
@@ -1441,18 +1498,18 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
+checksum = "707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b"
 dependencies = [
  "typenum",
 ]
 
 [[package]]
 name = "hyper"
-version = "1.10.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
+checksum = "d22053281f852e11534f5198498373cbb59295120a20771d90f7ed1897490a72"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1491,7 +1548,7 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-util",
@@ -1534,9 +1591,9 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+checksum = "fa68d21081c4a05d5a901a1c62add574c77048b6a1c67be3b50ce0b60d4ca513"
 dependencies = [
  "displaydoc",
  "potential_utf",
@@ -1548,9 +1605,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+checksum = "d56e28588da92eee5c3201a6eff33fabdd49b62269c8938d4ff050ce4d900deb"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -1561,9 +1618,9 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+checksum = "12f9cf5f235641ed274641dd81c3f28d870e276763d0797aeeab72317b1c646f"
 dependencies = [
  "icu_collections",
  "icu_normalizer_data",
@@ -1575,16 +1632,17 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+checksum = "1563da1ed3e0b3bf3d74c9b85917ac9c56464d2f57242270c09c9e752f8021a0"
 
 [[package]]
 name = "icu_properties"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+checksum = "7e7ca276ad3145661a65914e6daf131ca5120cd3dcee8f8f3214b8875184a148"
 dependencies = [
+ "displaydoc",
  "icu_collections",
  "icu_locale_core",
  "icu_properties_data",
@@ -1595,15 +1653,15 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+checksum = "e590f038c1464a96894fd6d10127e90a8be4509f56ff7ecef851b15cee0b7caa"
 
 [[package]]
 name = "icu_provider"
-version = "2.2.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+checksum = "d27bbb9d3abbefac45d55f647c9de1d44aafcd1186eb91879afef17c396c3e73"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -1652,6 +1710,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "infer"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc150e5ce2330295b8616ce0e3f53250e53af31759a9dbedad1621ba29151847"
+dependencies = [
+ "cfb",
+]
+
+[[package]]
 name = "inout"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1680,9 +1747,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.12.0"
+version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+checksum = "6a756c3fac73139e83f14c2d742155dd2b78d3ee56597b419a0579b7bdd6dd78"
 
 [[package]]
 name = "itoa"
@@ -1702,9 +1769,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.103"
+version = "0.3.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
+checksum = "0e0c1080212aad755ea003d18543e8768dd432c48819efd73a7bf1e39b7a5a3a"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -1717,14 +1784,14 @@ version = "10.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eba32bfb4ffdeaca3e34431072faf01745c9b26d25504aa7a6cf5684334fc4fc"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "ed25519-dalek",
  "getrandom 0.2.17",
  "hmac 0.12.1",
  "js-sys",
  "p256",
  "p384",
- "rand 0.8.6",
+ "rand 0.8.7",
  "rsa",
  "serde",
  "serde_json",
@@ -1744,9 +1811,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.186"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "libfuzzer-sys"
@@ -1766,18 +1833,18 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
-version = "0.1.18"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c943259e342f1e06ff2da7a83eabdfe7f92ce10262688dbf1895ff0b3e6e4652"
+checksum = "28d0a00925a9f930d679b6789b721e3a7f9ed110f41b86d2497caa780c3a070a"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.37.0"
+version = "0.38.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f111c8c41e7c61a49cd34e44c7619462967221a6443b0ec299e0ac30cfb9b1"
+checksum = "f1d20bef17f513b9b3004532233187769cd072d790971f4e4da0e346eb6401e8"
 dependencies = [
  "cc",
  "pkg-config",
@@ -1786,9 +1853,9 @@ dependencies = [
 
 [[package]]
 name = "litemap"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+checksum = "47d9d19d1d6efa0109d2f65ff4c85cddd50bd572e5a00127ab10987290bcefae"
 
 [[package]]
 name = "lock_api"
@@ -1801,15 +1868,15 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.33"
+version = "0.4.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
+checksum = "f9f8bd3e56ce4dfc153cf470fffbfa98c7620958b312ca5c3a4b8d5181fd13c6"
 
 [[package]]
 name = "lru"
-version = "0.18.1"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b6180140927ee907000b0aa540091f6ea512ead4447c92b8fc35bc72788a5a6"
+checksum = "5d2f2f9b4ba7e6b24d95e7e899329d35be83bcded72c8540cdd5368932d1d90a"
 dependencies = [
  "hashbrown 0.17.1",
 ]
@@ -1856,7 +1923,7 @@ dependencies = [
  "proc-macro2",
  "proc-macro2-diagnostics",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1924,9 +1991,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
+checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
 dependencies = [
  "libc",
  "wasi 0.11.1+wasi-snapshot-preview1",
@@ -1935,9 +2002,9 @@ dependencies = [
 
 [[package]]
 name = "moka"
-version = "0.12.15"
+version = "0.12.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "957228ad12042ee839f93c8f257b62b4c0ab5eaae1d4fa60de53b27c9d7c5046"
+checksum = "4293f18e7567a1caf3c584855554377025c65e0aa445344d04171f5ad63d19b9"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-epoch",
@@ -1999,7 +2066,7 @@ dependencies = [
  "num-integer",
  "num-iter",
  "num-traits",
- "rand 0.8.6",
+ "rand 0.8.7",
  "smallvec",
  "zeroize",
 ]
@@ -2018,14 +2085,14 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "num-integer"
-version = "0.1.46"
+version = "0.1.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+checksum = "7ce2d95d4b3734dc35aa2f45e1aa22cd416814592a4f9d9205e11affd5b8e10b"
 dependencies = [
  "num-traits",
 ]
@@ -2218,9 +2285,9 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+checksum = "f6b464fbc74e149a392436b17d523f769e057cb6877f6a5c4618bc6f11800548"
 
 [[package]]
 name = "polyval"
@@ -2236,9 +2303,9 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic"
-version = "1.13.1"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+checksum = "05c8b63e8d9609db387f0324918f81d68fe27748f084ef092fb35954d0539a85"
 
 [[package]]
 name = "postgres-protocol"
@@ -2246,7 +2313,7 @@ version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08808e3c483c46e999108051c78334f473d5adb59d78bb80a1268c7e6aa6c514"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "byteorder",
  "bytes",
  "fallible-iterator",
@@ -2271,9 +2338,9 @@ dependencies = [
 
 [[package]]
 name = "potential_utf"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+checksum = "d83eb9bc6d8e5cf568e7a1101d60ee05e81ed50ea106026f3d18deeb046d7661"
 dependencies = [
  "zerovec",
 ]
@@ -2333,32 +2400,32 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-error-attr2"
-version = "2.0.0"
+name = "proc-macro-error-attr3"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
+checksum = "b0084e6206a967a2dad822180626b2f6b07a3b379325e8f1ec0438e33a469ba7"
 dependencies = [
  "proc-macro2",
  "quote",
 ]
 
 [[package]]
-name = "proc-macro-error2"
-version = "2.0.1"
+name = "proc-macro-error3"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+checksum = "0cf066225f2373bc711684792b69bdeac0356019b007e721090c24d92d5d5a50"
 dependencies = [
- "proc-macro-error-attr2",
+ "proc-macro-error-attr3",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.106"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
 ]
@@ -2371,7 +2438,7 @@ checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
  "version_check",
 ]
 
@@ -2417,9 +2484,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.16"
+version = "0.11.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
+checksum = "04759210543be93709136e28212294a659ef5001836ff4eab4d663e4529bba83"
 dependencies = [
  "bytes",
  "getrandom 0.4.3",
@@ -2453,9 +2520,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.46"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
+checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
  "proc-macro2",
 ]
@@ -2480,9 +2547,9 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -2491,9 +2558,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -2574,9 +2641,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.13.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a0e75113e14dc5acb068cd0786884f214f1312650a3d36d269f5c4f3cdee8a2"
+checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2586,9 +2653,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.15"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f388202e4b80542a0921078cc23b6333bcf1409c1e3f86404cae4766a6131db"
+checksum = "ad8553b9b26413251cbf30e620595c7a41b3887f03da04579c0e6b0d6a06b4b2"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2616,7 +2683,7 @@ version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-core",
  "http",
@@ -2741,7 +2808,7 @@ dependencies = [
  "borsh",
  "bytes",
  "num-traits",
- "rand 0.8.6",
+ "rand 0.8.7",
  "rkyv",
  "serde",
  "serde_json",
@@ -2765,9 +2832,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.41"
+version = "0.23.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b92b125634d9b795e7beca796cc790df15a7fb38323bf3196fda83292d06b1f"
+checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
 dependencies = [
  "log",
  "once_cell",
@@ -2780,9 +2847,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.15.0"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "764899a24af3980067ee14bc143654f297b22eaebfe3c7b6b211920a5a59b046"
+checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
 dependencies = [
  "web-time",
  "zeroize",
@@ -2790,9 +2857,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.13"
+version = "0.103.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+checksum = "f3c3cf1d8b1e7d4927e2d154c3fcb02979afb9939629c62cd9048d4f07b60ac2"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -2864,9 +2931,9 @@ checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
  "serde_derive",
@@ -2874,29 +2941,29 @@ dependencies = [
 
 [[package]]
 name = "serde_core"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.150"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
  "itoa",
  "memchr",
@@ -2952,9 +3019,9 @@ dependencies = [
 
 [[package]]
 name = "sha1"
-version = "0.10.6"
+version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+checksum = "a978451301f4db1d02937a4ab3ccce137717b81826e79b7d49ffe3244a13c3b8"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
@@ -3020,9 +3087,9 @@ dependencies = [
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
 
 [[package]]
 name = "simdutf8"
@@ -3050,9 +3117,9 @@ checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "socket2"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
+checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
@@ -3060,9 +3127,9 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
 
 [[package]]
 name = "spki"
@@ -3127,7 +3194,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3149,9 +3216,20 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.118"
+version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3175,7 +3253,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3192,38 +3270,38 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "thiserror"
-version = "2.0.18"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+checksum = "ec86235f5fcc2a73650310756d2ac5b138a5780bbbdfae3eeccec992c435ba4f"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.18"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "thread_local"
-version = "1.1.9"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+checksum = "1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "time"
-version = "0.3.53"
+version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18dfaaeddcb932337b5e7866ee7d0ce9b76d2fd092997146f187ec09b4558a50"
+checksum = "cdb87b95ec50ddfa440816d227a17b2ccbdda963a316a727fda0fc4334f7d134"
 dependencies = [
  "deranged",
  "num-conv",
@@ -3241,9 +3319,9 @@ checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.31"
+version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c431b87111666e491a90baa837f914fb45cd5dc3c268591b0220ff5057f2085f"
+checksum = "7e689342a48d2ea927c87ea50cabf8594854bf940e9310208848d680d668ed85"
 dependencies = [
  "num-conv",
  "time-core",
@@ -3251,9 +3329,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+checksum = "b1e27c91459209c2986af3dcf603a5a74a4368754ce37414f59acc971167f643"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -3261,9 +3339,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -3292,14 +3370,14 @@ checksum = "2d2e76690929402faae40aebdda620a2c0e25dd6d3b9afe48867dfd95991f4bd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "tokio"
-version = "1.52.3"
+version = "1.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
+checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
 dependencies = [
  "bytes",
  "libc",
@@ -3330,13 +3408,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.7.0"
+version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+checksum = "78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -3404,13 +3482,14 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.18"
+version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+checksum = "494815d09bf52b5548659851081238f0ca39ff638363907596da739561c62c52"
 dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
+ "libc",
  "pin-project-lite",
  "tokio",
 ]
@@ -3430,9 +3509,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "1.1.2+spec-1.1.0"
+version = "1.1.4+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
+checksum = "3aace63f4bbcdfc2c965b059de67119c89c4017a70d633be6c104910f67056f5"
 dependencies = [
  "indexmap",
  "serde_core",
@@ -3440,7 +3519,7 @@ dependencies = [
  "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
  "toml_writer",
- "winnow 1.0.3",
+ "winnow 1.0.4",
 ]
 
 [[package]]
@@ -3463,30 +3542,30 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.25.12+spec-1.1.0"
+version = "0.25.13+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
+checksum = "6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b"
 dependencies = [
  "indexmap",
  "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
- "winnow 1.0.3",
+ "winnow 1.0.4",
 ]
 
 [[package]]
 name = "toml_parser"
-version = "1.1.2+spec-1.1.0"
+version = "1.1.3+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
 dependencies = [
- "winnow 1.0.3",
+ "winnow 1.0.4",
 ]
 
 [[package]]
 name = "toml_writer"
-version = "1.1.1+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
+checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
 
 [[package]]
 name = "tower"
@@ -3581,7 +3660,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3653,7 +3732,7 @@ dependencies = [
  "http",
  "httparse",
  "log",
- "rand 0.9.4",
+ "rand 0.9.5",
  "sha1",
  "thiserror",
 ]
@@ -3739,9 +3818,9 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "uuid"
-version = "1.23.4"
+version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf80a72845275afea99e7f2b434723d3bc7e38470fcd1c7ed39a599c73319a53"
+checksum = "f053576934f05a761a402421fbbe3d425d9366f75f978806a037b3ca481abecc"
 dependencies = [
  "getrandom 0.4.3",
  "js-sys",
@@ -3766,16 +3845,15 @@ dependencies = [
 
 [[package]]
 name = "validator_derive"
-version = "0.20.0"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7df16e474ef958526d1205f6dda359fdfab79d9aa6d54bafcb92dcd07673dca"
+checksum = "240e4b81c20a1d6d50d1d7265c658dfbd204e8b9ac4d80f3c931f39462196335"
 dependencies = [
- "darling 0.20.11",
- "once_cell",
- "proc-macro-error2",
+ "darling 0.23.0",
+ "proc-macro-error3",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3840,9 +3918,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
+checksum = "1b70935747edd64d89de3efa29d73789b806c15798f8e7dca4d8ac356b50ce70"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -3854,9 +3932,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.76"
+version = "0.4.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c62df1340f32221cb9c54d6a27b030e3dba64361d4a95bed55f9aacb44da291d"
+checksum = "6b7777d5cc23d0e91404e53ce2d5e8ec7acae3026b16233dba62cd3246457950"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3864,9 +3942,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
+checksum = "77775f8f3f7217702089053b94958f8f54061a3f663417df76e19cbdcca29bc1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3874,31 +3952,31 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
+checksum = "e11d33f857dc2fb11b8bc75aee111aa9cbeb12cd9f25efd3d4c2a3dd4e235284"
 dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
+checksum = "7ef64dbcc55df09c7e5a46182d181c2cfa3e925f3da937ea764728b4bbb9dcbf"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.103"
+version = "0.3.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141"
+checksum = "c435338968042f4f59a557f690a253676d47ce13ceb55d70100e7facf6620a30"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3916,18 +3994,18 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.8"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf85cb06032201fa7c6f829d7db5a7e5aa45bcc0655327713065f6f0576731bf"
+checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
 dependencies = [
  "rustls-pki-types",
 ]
 
 [[package]]
 name = "whoami"
-version = "2.1.2"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "998767ef88740d1f5b0682a9c53c24431453923962269c2db68ee43788c5a40d"
+checksum = "626c4bac6755d76ffc12cb01b2eac751db1996b9e0041de9aa02c8c211ddc82c"
 dependencies = [
  "libc",
  "libredox",
@@ -3957,7 +4035,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3968,7 +4046,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4085,9 +4163,9 @@ checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 
 [[package]]
 name = "winnow"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
 dependencies = [
  "memchr",
 ]
@@ -4100,9 +4178,9 @@ checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "writeable"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+checksum = "3ad82d2a33cdc9674dc7465672f271e096168fcdbe0f799d9e6db8c5892679dc"
 
 [[package]]
 name = "wyz"
@@ -4144,28 +4222,28 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
  "synstructure",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.8.54"
+version = "0.8.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7cbbc0a705a0fd05cc3676525980d2bf5a9bc4adac6d6475209a7887cf59d19"
+checksum = "556764e583adb45a9f8d413c2a147fa7e8d821e48e12b14fd560b607998b75eb"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.54"
+version = "0.8.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2e817b7b52d0c7358d3246da9d69935ebb18116b2b102b4230dac079b4862f5"
+checksum = "f2ab42fc20575779bd240faa45f94a74256f755c0fa9e89f0ede20d91d0cdfc1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4185,7 +4263,7 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
  "synstructure",
 ]
 
@@ -4206,14 +4284,14 @@ checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "zerotrie"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+checksum = "4ea269c3bd32f0a32c321907a2ae912ba6f4649bb0fc764a15627e99a7095a3f"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -4222,9 +4300,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.6"
+version = "0.11.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+checksum = "bb0464e17806c1d976d5cba29399c7f08e516e279e2ba493f63123b5fca67dd8"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -4233,17 +4311,17 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.3"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
+checksum = "34df6fc39dbd26ddc9c10e6a2984476e13acce22e64e4487636ef494369225da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "zmij"
-version = "1.0.21"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"

--- a/scripts/check-semver.sh
+++ b/scripts/check-semver.sh
@@ -315,12 +315,26 @@ for crate in "${CRATES[@]}"; do
     fi
 
     autumn_web_semver_features="maud,htmx,tailwind,db,cache-moka,ws,flash,multipart,http-client,oauth2,openapi,mcp,redis,i18n,storage,variants,mail,seed,system-info,markdown,csv,reporting,presence,webauthn,inbound-mail,inbound-mailgun,inbound-ses,telemetry-otlp,offline-sync,embed-assets,tls,acme"
-    # The SQLite backend surface. Deliberately MINIMAL: `sqlite` already pulls
-    # `db` transitively, and every feature added alongside it is one more
-    # chance to co-enable something type-incompatible with the SQLite
-    # `RuntimeConnection` — the exact class of rustdoc failure that hard-blocks
-    # a tag push. Widen it only against a demonstrated compile.
-    autumn_web_semver_sqlite_features="sqlite"
+    # The SQLite backend surface: the SAME list plus `sqlite`.
+    #
+    # It was `sqlite` alone at first, on the theory that a minimal set is the
+    # safe one. That left a hole: an item gated on `sqlite` AND another stable
+    # feature was compiled by NEITHER pass, so a break in it would sail through
+    # this gate. `repository_commit_hooks.rs` is the concrete case — four
+    # `start_repository_commit_hook_worker` variants across the ws x sqlite
+    # matrix, of which `cfg(all(feature = "ws", feature = "sqlite"))` was
+    # invisible: the Postgres pass has `ws` but no `sqlite`, the minimal SQLite
+    # pass had `sqlite` but no `ws`.
+    #
+    # Reusing the Postgres list is safe precisely because that list already
+    # excludes `managed-pg`/`managed-pg-bundled` — the features that hard-code
+    # `AsyncPgConnection` and are therefore the ones `sqlite` cannot co-exist
+    # with. Verified by compiling it before wiring it in:
+    #   cargo check -p autumn-web --no-default-features \
+    #     --features "<this list>,sqlite"      # Finished, exit 0
+    # Keep the two lists in step: a feature added to the Postgres list belongs
+    # here too, against the same demonstrated compile.
+    autumn_web_semver_sqlite_features="${autumn_web_semver_features},sqlite"
 
     echo "  pass 1/2: Postgres surface (--features $autumn_web_semver_features)"
     pg_output="$("${SEMVER_CARGO[@]}" semver-checks check-release --package "$crate" \

--- a/scripts/check-semver.sh
+++ b/scripts/check-semver.sh
@@ -109,6 +109,78 @@ CRATES=(
 breaking_failures=0
 tool_failures=0
 
+# Classify ONE cargo-semver-checks invocation and record its verdict.
+#
+# autumn-web runs two independent passes (Postgres and SQLite surfaces), and
+# each must be classified on its OWN output. Concatenating them and running this
+# chain once lets a skip-worthy signal from one pass mask a real break in the
+# other — e.g. the SQLite pass hitting the handled upstream `time` E0119 while
+# the Postgres pass reports "checks failed" would match the E0119 SKIP branch
+# first and wave the break through. The branches below are ordered by
+# specificity, not severity, so that precedence bug is structural: the fix is to
+# never hand this function more than one pass's output.
+#
+# Args: $1 crate, $2 pass label (empty for single-pass crates), $3 exit code,
+# $4 captured output. Increments the global `breaking_failures` /
+# `tool_failures` counters.
+classify_semver_pass() {
+  local crate="$1" pass_label="$2" pass_exit_code="$3" pass_output="$4"
+  echo "$pass_output"
+
+  if [[ $pass_exit_code -eq 0 ]]; then
+    echo "  PASS: $crate$pass_label API is semver-compatible with crates.io baseline"
+  elif echo "$pass_output" | grep -q "no crates with library targets selected"; then
+    # Proc-macro or binary-only crate — no public API surface to semver-check.
+    echo "  SKIP: $crate$pass_label has no library targets (proc-macro or binary)"
+  elif echo "$pass_output" | grep -q "not found in registry"; then
+    # Crate has never been published on crates.io; nothing to compare against.
+    echo "  SKIP: $crate$pass_label not yet published on crates.io"
+  elif echo "$pass_output" | grep -qE "error\[E0282\]" && echo "$pass_output" | grep -q "aws-runtime"; then
+    # aws-runtime has a type-inference regression (E0282) on Rust 1.92.x that
+    # affects every published version of the crate.  This is an upstream bug
+    # unrelated to our public API surface; skip rather than hard-fail so the
+    # gate remains actionable for real semver breaks.
+    echo "  SKIP: $crate$pass_label — aws-runtime E0282 upstream regression on Rust $semver_toolchain (not a semver issue)"
+  elif echo "$pass_output" | grep -qE "error\[E0119\]" && echo "$pass_output" | grep -qE 'HourBase|conflicting implementation in crate `time`'; then
+    # time 0.3.48 added a blanket From<HourBase> impl that breaks trait
+    # coherence (E0119) in downstream crates with their own blanket From
+    # impls — bollard 0.20.x, aws-smithy-types 1.4.x, and ratatui-widgets
+    # are all affected. The isolated workspace used by cargo-semver-checks
+    # resolves time fresh, so it picks up the broken release even though
+    # the workspace pins time below it (<0.3.48). Upstream breakage, not a
+    # semver issue; remove once time yanks/fixes 0.3.48 or the affected
+    # crates ship releases compatible with it.
+    echo "  SKIP: $crate$pass_label — time 0.3.48 coherence regression (E0119) breaking downstream crates (not a semver issue)"
+  elif echo "$pass_output" | grep -qE "checks failed|semver requires"; then
+    # Exit 1 with semver-violation output → actual breaking API changes found.
+    # Allow them through only when BOTH conditions hold:
+    #   1. A migration guide exists (explicit acknowledgement).
+    #   2. The version bump type permits breaking changes per release policy
+    #      (post-1.0 major bump X.0.0, or pre-1.0 minor bump 0.Y.0).
+    # A patch release or a post-1.0 minor release must never break even if a
+    # migration stub is present, to prevent an accidental regression slipping
+    # through because an old migration document was lying around.
+    if [[ -f "$migration_guide" ]] && is_breaking_release_type; then
+      echo "  ADVISORY: $crate$pass_label has breaking API changes; intentional — migration guide found at $migration_guide"
+    elif [[ -f "$migration_guide" ]]; then
+      echo "  FAIL: $crate$pass_label has breaking API changes but $workspace_version is a patch/minor release." >&2
+      echo "        Breaking changes require a major bump (X.0.0, X≥1) or a pre-1.0 minor bump (0.Y.0)." >&2
+      breaking_failures=$((breaking_failures + 1))
+    else
+      echo "  FAIL: $crate$pass_label has unacknowledged breaking API changes." >&2
+      echo "        Add a migration guide at $migration_guide to acknowledge an intentional break," >&2
+      echo "        or fix the API regression before releasing." >&2
+      breaking_failures=$((breaking_failures + 1))
+    fi
+  else
+    # Exit 1 with unrecognised output → tool/invocation error (compilation
+    # failure, registry timeout, unsupported flag, etc.).  Hard-fail so the
+    # error is investigated rather than silently skipped.
+    echo "  FAIL: $crate$pass_label — cargo-semver-checks failed with an unexpected error (exit $pass_exit_code)." >&2
+    tool_failures=$((tool_failures + 1))
+  fi
+}
+
 for crate in "${CRATES[@]}"; do
   echo ""
   echo "==> semver-checks: $crate"
@@ -251,86 +323,33 @@ for crate in "${CRATES[@]}"; do
     autumn_web_semver_sqlite_features="sqlite"
 
     echo "  pass 1/2: Postgres surface (--features $autumn_web_semver_features)"
-    crate_output="$("${SEMVER_CARGO[@]}" semver-checks check-release --package "$crate" \
+    pg_output="$("${SEMVER_CARGO[@]}" semver-checks check-release --package "$crate" \
       --only-explicit-features \
       --features "$autumn_web_semver_features" 2>&1)"
-    exit_code=$?
+    pg_exit_code=$?
 
-    # Run the SQLite pass regardless, so one report names every break rather
-    # than the maintainer fixing Postgres and rediscovering SQLite on the next
-    # push. Keep the FIRST failing exit code and concatenate both outputs: the
-    # outcome-classifying branches below parse `crate_output`, so a skip-worthy
-    # signal (unpublished crate, upstream E0119/E0282) is still matched from
-    # whichever pass emitted it.
+    # Run the SQLite pass regardless of pass 1's outcome, so one report names
+    # every break rather than the maintainer fixing Postgres and rediscovering
+    # SQLite on the next push.
     echo "  pass 2/2: SQLite surface (--features $autumn_web_semver_sqlite_features)"
     sqlite_output="$("${SEMVER_CARGO[@]}" semver-checks check-release --package "$crate" \
       --only-explicit-features \
       --features "$autumn_web_semver_sqlite_features" 2>&1)"
     sqlite_exit_code=$?
-    crate_output="${crate_output}"$'\n'"${sqlite_output}"
-    if [[ $exit_code -eq 0 ]]; then
-      exit_code=$sqlite_exit_code
-    fi
-  else
-    crate_output="$("${SEMVER_CARGO[@]}" semver-checks check-release --package "$crate" 2>&1)"
-    exit_code=$?
+    set -e
+
+    # Classify each pass on its OWN output — never concatenated. See the
+    # comment on classify_semver_pass for why merging them is unsafe.
+    classify_semver_pass "$crate" " (Postgres surface)" "$pg_exit_code" "$pg_output"
+    classify_semver_pass "$crate" " (SQLite surface)" "$sqlite_exit_code" "$sqlite_output"
+    continue
   fi
+
+  crate_output="$("${SEMVER_CARGO[@]}" semver-checks check-release --package "$crate" 2>&1)"
+  exit_code=$?
   set -e
 
-  echo "$crate_output"
-
-  if [[ $exit_code -eq 0 ]]; then
-    echo "  PASS: $crate API is semver-compatible with crates.io baseline"
-  elif echo "$crate_output" | grep -q "no crates with library targets selected"; then
-    # Proc-macro or binary-only crate — no public API surface to semver-check.
-    echo "  SKIP: $crate has no library targets (proc-macro or binary)"
-  elif echo "$crate_output" | grep -q "not found in registry"; then
-    # Crate has never been published on crates.io; nothing to compare against.
-    echo "  SKIP: $crate not yet published on crates.io"
-  elif echo "$crate_output" | grep -qE "error\[E0282\]" && echo "$crate_output" | grep -q "aws-runtime"; then
-    # aws-runtime has a type-inference regression (E0282) on Rust 1.92.x that
-    # affects every published version of the crate.  This is an upstream bug
-    # unrelated to our public API surface; skip rather than hard-fail so the
-    # gate remains actionable for real semver breaks.
-    echo "  SKIP: $crate — aws-runtime E0282 upstream regression on Rust $semver_toolchain (not a semver issue)"
-  elif echo "$crate_output" | grep -qE "error\[E0119\]" && echo "$crate_output" | grep -qE 'HourBase|conflicting implementation in crate `time`'; then
-    # time 0.3.48 added a blanket From<HourBase> impl that breaks trait
-    # coherence (E0119) in downstream crates with their own blanket From
-    # impls — bollard 0.20.x, aws-smithy-types 1.4.x, and ratatui-widgets
-    # are all affected. The isolated workspace used by cargo-semver-checks
-    # resolves time fresh, so it picks up the broken release even though
-    # the workspace pins time below it (<0.3.48). Upstream breakage, not a
-    # semver issue; remove once time yanks/fixes 0.3.48 or the affected
-    # crates ship releases compatible with it.
-    echo "  SKIP: $crate — time 0.3.48 coherence regression (E0119) breaking downstream crates (not a semver issue)"
-  elif echo "$crate_output" | grep -qE "checks failed|semver requires"; then
-    # Exit 1 with semver-violation output → actual breaking API changes found.
-    # Allow them through only when BOTH conditions hold:
-    #   1. A migration guide exists (explicit acknowledgement).
-    #   2. The version bump type permits breaking changes per release policy
-    #      (post-1.0 major bump X.0.0, or pre-1.0 minor bump 0.Y.0).
-    # A patch release or a post-1.0 minor release must never break even if a
-    # migration stub is present, to prevent an accidental regression slipping
-    # through because an old migration document was lying around.
-    if [[ -f "$migration_guide" ]] && is_breaking_release_type; then
-      echo "  ADVISORY: $crate has breaking API changes; intentional — migration guide found at $migration_guide"
-    elif [[ -f "$migration_guide" ]]; then
-      echo "  FAIL: $crate has breaking API changes but $workspace_version is a patch/minor release." >&2
-      echo "        Breaking changes require a major bump (X.0.0, X≥1) or a pre-1.0 minor bump (0.Y.0)." >&2
-      breaking_failures=$((breaking_failures + 1))
-    else
-      echo "  FAIL: $crate has unacknowledged breaking API changes." >&2
-      echo "        Add a migration guide at $migration_guide to acknowledge an intentional break," >&2
-      echo "        or fix the API regression before releasing." >&2
-      breaking_failures=$((breaking_failures + 1))
-    fi
-  else
-    # Exit 1 with unrecognised output → tool/invocation error (compilation
-    # failure, registry timeout, unsupported flag, etc.).  Hard-fail so the
-    # error is investigated rather than silently skipped.
-    echo "  FAIL: $crate — cargo-semver-checks failed with an unexpected error (exit $exit_code)." >&2
-    tool_failures=$((tool_failures + 1))
-  fi
+  classify_semver_pass "$crate" "" "$exit_code" "$crate_output"
 done
 
 echo ""

--- a/scripts/check-semver.sh
+++ b/scripts/check-semver.sh
@@ -119,9 +119,12 @@ for crate in "${CRATES[@]}"; do
   # exit codes alone.
   set +e
   if [[ "$crate" == "autumn-web" ]]; then
-    # autumn-web special case: run ONE explicit-feature pass over the crate's
-    # documented Postgres public-API surface, with cargo-semver-checks'
-    # "enable (almost) all features" heuristic disabled.
+    # autumn-web special case: run TWO explicit-feature passes — one over the
+    # crate's documented Postgres public-API surface and one over the SQLite
+    # backend — with cargo-semver-checks' "enable (almost) all features"
+    # heuristic disabled. The two DB backends are mutually exclusive at the
+    # type level (see below), so neither pass alone covers the whole surface
+    # and they cannot be merged into one.
     #
     # Why: as of 0.6.0 autumn-web gained the mutually-incompatible feature pair
     # `sqlite` × `managed-pg`/`managed-pg-bundled`. `sqlite` flips the
@@ -150,8 +153,11 @@ for crate in "${CRATES[@]}"; do
     #      baseline and current builds cleanly.
     #
     # The list = the STABILITY.md stable public-API feature surface INTERSECTED
-    # with the published 0.5.0 baseline's `[features]` keys — i.e. the MAXIMAL
-    # baseline-safe coverage. This deliberately supersedes the earlier
+    # with the published 0.6.0 baseline's `[features]` keys — i.e. the MAXIMAL
+    # baseline-safe coverage. Recomputed for the 0.7.0 release: 0.6.0 is now
+    # the crates.io baseline, so `tls`, `acme`, `offline-sync` and
+    # `embed-assets` — 0.6.0-only when this list was last computed, and
+    # therefore excluded then — are intersection-eligible and have been ADDED. This deliberately supersedes the earlier
     # docs.rs-only list, which silently DROPPED feature-gated public modules that
     # already exist in the 0.5.0 baseline (e.g. `presence`, `webauthn`,
     # `inbound-mail`/`inbound-mailgun`/`inbound-ses`, `telemetry-otlp`) — so a
@@ -160,18 +166,27 @@ for crate in "${CRATES[@]}"; do
     # feature part of the public API, so all of them are restored here.
     #
     # It cannot equal either set alone: cargo-semver-checks enables `--features`
-    # symmetrically on the 0.5.0 baseline build too, so any feature the baseline
+    # symmetrically on the 0.6.0 baseline build too, so any feature the baseline
     # lacks would error there.
-    #   - EXCLUDES the 0.6.0-only features `sqlite`, `managed-pg`,
-    #     `managed-pg-bundled`, `embed-assets`, `offline-sync`, `tls`, `acme`:
-    #     all are NEW in 0.6.0 and absent from the 0.5.0 baseline, so the
-    #     symmetric enable would fail the baseline build ("v0.5.0 does not have
-    #     feature ...") and re-break the gate. This intersection also
-    #     AUTOMATICALLY drops the DB-backend type-incompatible pair
-    #     `sqlite` × `managed-pg`/`managed-pg-bundled` (co-enabling them is the
-    #     E0271 rustdoc failure this special-case originally fixed), since none
-    #     of them are baseline-present. Add each once a future baseline carries
-    #     it.
+    #   - EXCLUDES the 0.7.0-only features `sim-testing`, `pdf` and `edge`: all
+    #     are NEW in 0.7.0 and absent from the 0.6.0 baseline, so the symmetric
+    #     enable would fail the baseline build ("v0.6.0 does not have feature
+    #     ...") and re-break the gate. Add each once a future baseline carries
+    #     it — this is the same rule that gated `tls`/`acme`/`offline-sync`/
+    #     `embed-assets` out of the previous revision of this list.
+    #   - EXCLUDES `sqlite`, which IS baseline-present in 0.6.0, because it
+    #     flips `db::RuntimeConnection` to a SQLite connection and is therefore
+    #     type-incompatible with the Postgres surface this pass covers. It is
+    #     no longer dropped silently: the dedicated sqlite-vs-sqlite pass below
+    #     covers it symmetrically.
+    #   - EXCLUDES `managed-pg`/`managed-pg-bundled`, also baseline-present,
+    #     for the same STABILITY.md "Unsupported feature combinations (CI
+    #     excluded)" reason as `system-tests`/`test-support` below (they
+    #     download or embed Postgres binaries). Keeping them out ALSO keeps the
+    #     DB-backend type-incompatible pair `sqlite` × `managed-pg` from ever
+    #     being co-enabled — the E0271 rustdoc failure this special-case
+    #     originally fixed — now that the intersection no longer drops them
+    #     automatically.
     #   - EXCLUDES `system-tests` and `test-support` even though both ARE in the
     #     0.5.0 baseline: STABILITY.md's "Unsupported feature combinations (CI
     #     excluded)" table names both (alongside `managed-pg`/`managed-pg-bundled`)
@@ -197,13 +212,13 @@ for crate in "${CRATES[@]}"; do
     # is forced to recompute the intersection (and add the deferred
     # sqlite-vs-sqlite pass, see below) before the target is bumped.
     #
-    # Deferred: a genuine apples-to-apples sqlite-vs-sqlite pass
-    # (`--only-explicit-features --features sqlite`) is
-    # intentionally NOT added this release — the 0.5.x baseline has no `sqlite`
-    # feature (a symmetric enable would hard-error on the baseline), and a
-    # sqlite-vs-Postgres comparison yields false-positive breaks because
-    # `sqlite` flips `RuntimeConnection`'s type. Add that pass in a release
-    # after 0.6.0 is published (when a sqlite baseline exists).
+    # The sqlite-vs-sqlite pass, deferred at 0.6.0, is now ADDED (see
+    # `autumn_web_semver_sqlite_features` below). It was deferred because the
+    # 0.5.x baseline had no `sqlite` feature, so a symmetric enable would
+    # hard-error on the baseline, while a sqlite-vs-Postgres comparison yields
+    # false-positive breaks because `sqlite` flips `RuntimeConnection`'s type.
+    # 0.6.0 carries `sqlite`, so an apples-to-apples symmetric enable is finally
+    # possible and the SQLite public surface is no longer unchecked.
     #
     # NOTE: `telemetry-otlp` pulls prost/tonic, which need `protoc` at build
     # time. The SemVer job in .github/workflows/publish-gate.yml installs
@@ -219,22 +234,47 @@ for crate in "${CRATES[@]}"; do
     # cargo-semver-checks is exactly `workspace_package_value "version"` — parsed
     # with the SAME method used for `workspace_version` above; if it cannot be
     # parsed at all, FAIL CLOSED (a release gate must be conservative).
-    SEMVER_ALLOWLIST_TARGET_VERSION="0.6.0"
+    SEMVER_ALLOWLIST_TARGET_VERSION="0.7.0"
     autumn_web_current_version="$(workspace_package_value "version")"
     [[ -n "$autumn_web_current_version" ]] || \
       die "could not determine autumn-web version for the SemVer allowlist guard"
     if [[ "$autumn_web_current_version" != "$SEMVER_ALLOWLIST_TARGET_VERSION" ]]; then
-      die "autumn-web is now v${autumn_web_current_version} but the SemVer feature allowlist is pinned to ${SEMVER_ALLOWLIST_TARGET_VERSION} (computed as the 0.5.0-baseline ∩ 0.6.0 feature set). cargo-semver-checks now compares against a newer baseline that has tls/acme/sqlite/managed-pg/embed-assets/offline-sync — recompute the allowlist as (new-baseline ∩ current) features (and add the deferred sqlite-vs-sqlite pass) before releasing. See the comment above this block."
+      die "autumn-web is now v${autumn_web_current_version} but the SemVer feature allowlist is pinned to ${SEMVER_ALLOWLIST_TARGET_VERSION} (computed as the 0.6.0-baseline ∩ 0.7.0 feature set). cargo-semver-checks now compares against a newer baseline, which may already carry features this list still omits (currently sim-testing/pdf/edge) — recompute both allowlists as (new-baseline ∩ current) features before releasing. See the comment above this block."
     fi
 
-    autumn_web_semver_features="maud,htmx,tailwind,db,cache-moka,ws,flash,multipart,http-client,oauth2,openapi,mcp,redis,i18n,storage,variants,mail,seed,system-info,markdown,csv,reporting,presence,webauthn,inbound-mail,inbound-mailgun,inbound-ses,telemetry-otlp"
+    autumn_web_semver_features="maud,htmx,tailwind,db,cache-moka,ws,flash,multipart,http-client,oauth2,openapi,mcp,redis,i18n,storage,variants,mail,seed,system-info,markdown,csv,reporting,presence,webauthn,inbound-mail,inbound-mailgun,inbound-ses,telemetry-otlp,offline-sync,embed-assets,tls,acme"
+    # The SQLite backend surface. Deliberately MINIMAL: `sqlite` already pulls
+    # `db` transitively, and every feature added alongside it is one more
+    # chance to co-enable something type-incompatible with the SQLite
+    # `RuntimeConnection` — the exact class of rustdoc failure that hard-blocks
+    # a tag push. Widen it only against a demonstrated compile.
+    autumn_web_semver_sqlite_features="sqlite"
+
+    echo "  pass 1/2: Postgres surface (--features $autumn_web_semver_features)"
     crate_output="$("${SEMVER_CARGO[@]}" semver-checks check-release --package "$crate" \
       --only-explicit-features \
       --features "$autumn_web_semver_features" 2>&1)"
+    exit_code=$?
+
+    # Run the SQLite pass regardless, so one report names every break rather
+    # than the maintainer fixing Postgres and rediscovering SQLite on the next
+    # push. Keep the FIRST failing exit code and concatenate both outputs: the
+    # outcome-classifying branches below parse `crate_output`, so a skip-worthy
+    # signal (unpublished crate, upstream E0119/E0282) is still matched from
+    # whichever pass emitted it.
+    echo "  pass 2/2: SQLite surface (--features $autumn_web_semver_sqlite_features)"
+    sqlite_output="$("${SEMVER_CARGO[@]}" semver-checks check-release --package "$crate" \
+      --only-explicit-features \
+      --features "$autumn_web_semver_sqlite_features" 2>&1)"
+    sqlite_exit_code=$?
+    crate_output="${crate_output}"$'\n'"${sqlite_output}"
+    if [[ $exit_code -eq 0 ]]; then
+      exit_code=$sqlite_exit_code
+    fi
   else
     crate_output="$("${SEMVER_CARGO[@]}" semver-checks check-release --package "$crate" 2>&1)"
+    exit_code=$?
   fi
-  exit_code=$?
   set -e
 
   echo "$crate_output"

--- a/scripts/check-skill-version-markers.sh
+++ b/scripts/check-skill-version-markers.sh
@@ -25,6 +25,16 @@ SKILL_DIR="skills/autumn-web"
 # Lines whose issue reference is NOT the marked feature's own issue, verified by
 # hand. Keyed on line content, since line numbers move. Keep this list tiny and
 # justify every entry.
+# Issue references that legitimately do not appear in CHANGELOG.md. Each needs a
+# reason: the marker is still verified by hand, just not by this script.
+UNTRACEABLE_ISSUES=(
+  # `MarkdownRegistry::static_params_for` is recorded in the 0.7.0 section
+  # (CHANGELOG "**`MarkdownRegistry::static_params_for(param)`:**") but that
+  # entry cites no issue number, so #743 itself is unfindable. Marker verified
+  # against the API entry instead.
+  '#743'
+)
+
 ALLOW=(
   # Marks `from_shard`/`with_pool_untracked` (0.6.0); cites #1629 only for the
   # `autumn upgrade` tooling that applies its codemod, which is 0.7.0.
@@ -86,7 +96,22 @@ while IFS= read -r entry; do
   # introducing release appears nowhere on its line is drift.
   for issue in "${issues[@]}"; do
     oldest="$(grep -n -- "$issue" "$CHANGELOG" 2>/dev/null | tail -1 | cut -d: -f1 || true)"
-    [[ -z "$oldest" ]] && continue
+    if [[ -z "$oldest" ]]; then
+      # An issue the CHANGELOG has never heard of. Skipping it silently is how
+      # a typo'd or untraceable reference slips past this gate entirely, so it
+      # is reported. Legitimate cases (an API recorded without its issue
+      # number) go in UNTRACEABLE_ISSUES with a justification.
+      known=0
+      for u in "${UNTRACEABLE_ISSUES[@]}"; do [[ "$issue" == "$u" ]] && known=1 && break; done
+      if [[ $known -eq 0 ]]; then
+        echo "UNTRACEABLE $file:$lineno" >&2
+        echo "            $issue appears nowhere in $CHANGELOG — typo, or an" >&2
+        echo "            issue that predates it. Fix the reference, or add it to" >&2
+        echo "            UNTRACEABLE_ISSUES with a reason." >&2
+        fail=$((fail + 1))
+      fi
+      continue
+    fi
     truth="$(section_for_line "$oldest" || true)"
     [[ -z "$truth" ]] && continue
 

--- a/scripts/check-skill-version-markers.sh
+++ b/scripts/check-skill-version-markers.sh
@@ -94,6 +94,18 @@ while IFS= read -r entry; do
   # on that line. Positional pairing would be wrong (a line can cite an issue
   # for tooling rather than for the feature it marks), but an issue whose
   # introducing release appears nowhere on its line is drift.
+  # When the line carries as many releases as issues, they are almost certainly
+  # written as pairs — "(0.6.0; fleets 0.7.0, issues #1607/#1621)" — so pair
+  # them POSITIONALLY. The set rule ("some release on the line matches") cannot
+  # see a swap: transpose those two versions and both releases are still
+  # present, so both issues still find a match and the drift the gate exists to
+  # catch sails through. Positional pairing catches it. When the counts differ,
+  # the line is not written as pairs (a codemod id can repeat a version, an
+  # issue can be cited for tooling), so fall back to the set rule.
+  paired=0
+  [[ ${#markers[@]} -eq ${#issues[@]} ]] && paired=1
+
+  idx=0
   for issue in "${issues[@]}"; do
     oldest="$(grep -n -- "$issue" "$CHANGELOG" 2>/dev/null | tail -1 | cut -d: -f1 || true)"
     if [[ -z "$oldest" ]]; then
@@ -110,24 +122,36 @@ while IFS= read -r entry; do
         echo "            UNTRACEABLE_ISSUES with a reason." >&2
         fail=$((fail + 1))
       fi
+      idx=$((idx + 1))
       continue
     fi
     truth="$(section_for_line "$oldest" || true)"
-    [[ -z "$truth" ]] && continue
+    if [[ -z "$truth" ]]; then idx=$((idx + 1)); continue; fi
 
-    matched=0
-    for m in "${markers[@]}"; do [[ "$m" == "$truth" ]] && matched=1 && break; done
-    if [[ $matched -eq 0 ]]; then
-      echo "MISMATCH $file:$lineno" >&2
-      echo "         $issue was introduced in $truth, which appears nowhere on this line" >&2
-      echo "         line carries: ${markers[*]}" >&2
-      echo "         ${text:0:100}" >&2
-      fail=$((fail + 1))
+    if [[ $paired -eq 1 ]]; then
+      if [[ "${markers[$idx]}" != "$truth" ]]; then
+        echo "MISMATCH $file:$lineno" >&2
+        echo "         $issue was introduced in $truth, but the marker paired with it" >&2
+        echo "         on this line is ${markers[$idx]} (markers: ${markers[*]}; issues: ${issues[*]})" >&2
+        echo "         ${text:0:100}" >&2
+        fail=$((fail + 1))
+      fi
+    else
+      matched=0
+      for m in "${markers[@]}"; do [[ "$m" == "$truth" ]] && matched=1 && break; done
+      if [[ $matched -eq 0 ]]; then
+        echo "MISMATCH $file:$lineno" >&2
+        echo "         $issue was introduced in $truth, which appears nowhere on this line" >&2
+        echo "         line carries: ${markers[*]}" >&2
+        echo "         ${text:0:100}" >&2
+        fail=$((fail + 1))
+      fi
     fi
+    idx=$((idx + 1))
   done
 done < <(
-  grep -rn '0\.[0-9]\+\.0' "$SKILL_DIR" \
-    | grep -v 'migrations/0\.[0-9]\+\.0\.md\|v0\.[0-9]\+\.0\|--version 0\.[0-9]\+\.0\|"0\.[0-9]\+\.0"\|autumn-web = \|autumn-cli = \|MSRV' \
+  grep -rn '[0-9]\+\.[0-9]\+\.[0-9]\+' "$SKILL_DIR" \
+    | grep -v 'migrations/[0-9]\+\.[0-9]\+\.[0-9]\+\.md\|v[0-9]\+\.[0-9]\+\.[0-9]\+\|--version [0-9]\+\.[0-9]\+\.[0-9]\+\|"[0-9]\+\.[0-9]\+\.[0-9]\+"\|autumn-web = \|autumn-cli = \|MSRV' \
     | sed "s|^$SKILL_DIR/||"
 )
 

--- a/scripts/check-skill-version-markers.sh
+++ b/scripts/check-skill-version-markers.sh
@@ -63,31 +63,43 @@ while IFS= read -r entry; do
   [[ $skip -eq 1 ]] && continue
 
   # `|| true`: a non-matching grep exits 1, which `set -e` would treat as fatal.
-  marker=""
+  # Collect EVERY release token and EVERY issue on the line, not just the
+  # first of each. A line can annotate more than one feature — e.g.
+  # "autumn deploy (0.6.0; fleets 0.7.0, issues #1607/#1621)" — and stopping at
+  # the first pair would leave the later annotation unchecked forever.
+  markers=()
   for cand in $(grep -o '[0-9]\+\.[0-9]\+\.[0-9]\+' <<<"$text" || true); do
-    if is_release "$cand"; then marker="$cand"; break; fi
+    is_release "$cand" && markers+=("$cand")
   done
-  [[ -z "$marker" ]] && continue
-  issue="$(grep -o '#[0-9]\{3,4\}' <<<"$text" | head -1 || true)"
+  [[ ${#markers[@]} -eq 0 ]] && continue
 
-  if [[ -z "$issue" ]]; then
+  issues=()
+  for i in $(grep -o '#[0-9]\{3,4\}' <<<"$text" || true); do issues+=("$i"); done
+  if [[ ${#issues[@]} -eq 0 ]]; then
     unverifiable=$((unverifiable + 1))
     continue
   fi
 
-  # Oldest mention == introducing release (CHANGELOG is newest-first).
-  oldest="$(grep -n -- "$issue" "$CHANGELOG" 2>/dev/null | tail -1 | cut -d: -f1 || true)"
-  [[ -z "$oldest" ]] && { unverifiable=$((unverifiable + 1)); continue; }
+  # Rule: every issue on the line must be accounted for by SOME release token
+  # on that line. Positional pairing would be wrong (a line can cite an issue
+  # for tooling rather than for the feature it marks), but an issue whose
+  # introducing release appears nowhere on its line is drift.
+  for issue in "${issues[@]}"; do
+    oldest="$(grep -n -- "$issue" "$CHANGELOG" 2>/dev/null | tail -1 | cut -d: -f1 || true)"
+    [[ -z "$oldest" ]] && continue
+    truth="$(section_for_line "$oldest" || true)"
+    [[ -z "$truth" ]] && continue
 
-  truth="$(section_for_line "$oldest" || true)"
-  [[ -z "$truth" ]] && continue
-
-  if [[ "$marker" != "$truth" ]]; then
-    echo "MISMATCH $file:$lineno" >&2
-    echo "         marker says $marker but $issue was introduced in $truth" >&2
-    echo "         ${text:0:100}" >&2
-    fail=$((fail + 1))
-  fi
+    matched=0
+    for m in "${markers[@]}"; do [[ "$m" == "$truth" ]] && matched=1 && break; done
+    if [[ $matched -eq 0 ]]; then
+      echo "MISMATCH $file:$lineno" >&2
+      echo "         $issue was introduced in $truth, which appears nowhere on this line" >&2
+      echo "         line carries: ${markers[*]}" >&2
+      echo "         ${text:0:100}" >&2
+      fail=$((fail + 1))
+    fi
+  done
 done < <(
   grep -rn '0\.[0-9]\+\.0' "$SKILL_DIR" \
     | grep -v 'migrations/0\.[0-9]\+\.0\.md\|v0\.[0-9]\+\.0\|--version 0\.[0-9]\+\.0\|"0\.[0-9]\+\.0"\|autumn-web = \|autumn-cli = \|MSRV' \

--- a/scripts/check-skill-version-markers.sh
+++ b/scripts/check-skill-version-markers.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# Verify the `autumn-web` agent skill's version markers against CHANGELOG.md.
+#
+# The skill annotates APIs with the release they arrived in — "(0.6.0)",
+# "**(0.7.0)**", "(0.7.0, #1182)", "(feature `tls`, 0.6.0, #1603)", and more.
+# A marker that names too NEW a release is the damaging direction: it tells a
+# reader on that line an API is out of reach when it already shipped.
+#
+# These markers were hand-maintained and drifted badly across the 0.6.0 -> 0.7.0
+# cut, in several punctuation shapes that ad-hoc greps kept missing. This script
+# matches the version token itself rather than any surrounding punctuation, so a
+# new shape cannot hide from it.
+#
+# Method: for a marker line that also cites an issue (`#1234`), find that
+# issue's OLDEST mention in CHANGELOG.md — the file is newest-first, so the
+# oldest mention is the release that introduced it — and require the marker to
+# name that release. Lines with no issue reference are reported as unverifiable
+# and must be checked by hand.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+CHANGELOG="CHANGELOG.md"
+SKILL_DIR="skills/autumn-web"
+
+# Lines whose issue reference is NOT the marked feature's own issue, verified by
+# hand. Keyed on line content, since line numbers move. Keep this list tiny and
+# justify every entry.
+ALLOW=(
+  # Marks `from_shard`/`with_pool_untracked` (0.6.0); cites #1629 only for the
+  # `autumn upgrade` tooling that applies its codemod, which is 0.7.0.
+  'with_pool_untracked` is the 0.6.0 rename'
+)
+
+# Every released version, from the CHANGELOG's own section headings. Anything
+# not in this set is not a version marker (sample IPs, MSRVs, ports).
+mapfile -t RELEASES < <(grep -o '^## \[[0-9]\+\.[0-9]\+\.[0-9]\+\]' "$CHANGELOG" | tr -d '#[] ')
+is_release() {
+  local v="$1"
+  for r in "${RELEASES[@]}"; do [[ "$v" == "$r" ]] && return 0; done
+  return 1
+}
+
+section_for_line() {
+  local n="$1"
+  awk -v target="$n" '
+    /^## \[[0-9]+\.[0-9]+\.[0-9]+\]/ { ver=$2; gsub(/[][]/, "", ver); line=NR }
+    NR == target { print ver; found=1; exit }
+    END { if (!found) print "" }
+  ' "$CHANGELOG"
+}
+
+fail=0
+unverifiable=0
+
+while IFS= read -r entry; do
+  file="${entry%%:*}"; rest="${entry#*:}"
+  lineno="${rest%%:*}"; text="${rest#*:}"
+
+  skip=0
+  for a in "${ALLOW[@]}"; do
+    [[ "$text" == *"$a"* ]] && skip=1 && break
+  done
+  [[ $skip -eq 1 ]] && continue
+
+  # `|| true`: a non-matching grep exits 1, which `set -e` would treat as fatal.
+  marker=""
+  for cand in $(grep -o '[0-9]\+\.[0-9]\+\.[0-9]\+' <<<"$text" || true); do
+    if is_release "$cand"; then marker="$cand"; break; fi
+  done
+  [[ -z "$marker" ]] && continue
+  issue="$(grep -o '#[0-9]\{3,4\}' <<<"$text" | head -1 || true)"
+
+  if [[ -z "$issue" ]]; then
+    unverifiable=$((unverifiable + 1))
+    continue
+  fi
+
+  # Oldest mention == introducing release (CHANGELOG is newest-first).
+  oldest="$(grep -n -- "$issue" "$CHANGELOG" 2>/dev/null | tail -1 | cut -d: -f1 || true)"
+  [[ -z "$oldest" ]] && { unverifiable=$((unverifiable + 1)); continue; }
+
+  truth="$(section_for_line "$oldest" || true)"
+  [[ -z "$truth" ]] && continue
+
+  if [[ "$marker" != "$truth" ]]; then
+    echo "MISMATCH $file:$lineno" >&2
+    echo "         marker says $marker but $issue was introduced in $truth" >&2
+    echo "         ${text:0:100}" >&2
+    fail=$((fail + 1))
+  fi
+done < <(
+  grep -rn '0\.[0-9]\+\.0' "$SKILL_DIR" \
+    | grep -v 'migrations/0\.[0-9]\+\.0\.md\|v0\.[0-9]\+\.0\|--version 0\.[0-9]\+\.0\|"0\.[0-9]\+\.0"\|autumn-web = \|autumn-cli = \|MSRV' \
+    | sed "s|^$SKILL_DIR/||"
+)
+
+if [[ $fail -gt 0 ]]; then
+  echo "" >&2
+  echo "$fail skill version marker(s) disagree with CHANGELOG.md." >&2
+  echo "A marker names the release an API ARRIVED in. Resolve it from the" >&2
+  echo "CHANGELOG section containing the issue's oldest mention." >&2
+  exit 1
+fi
+
+echo "Skill version markers OK ($unverifiable marker(s) carry no issue reference and were not machine-checked)."

--- a/scripts/check-skill-version-markers.sh
+++ b/scripts/check-skill-version-markers.sh
@@ -94,9 +94,38 @@ done < <(
     | sed "s|^$SKILL_DIR/||"
 )
 
+# --- Second check: prose that asserts an availability boundary --------------
+#
+# Markers were not the only thing that went stale across the 0.6.0 -> 0.7.0 cut.
+# The skill also carried sentences meaning "not shipped yet" — "trunk-dev only",
+# "NOT in the published X", "do not suggest them to users on the published
+# release". Every one of those became false the moment the release was cut, and
+# a version-number substitution does not fix them: it leaves prose that
+# contradicts its own marker, or actively tells an agent to withhold a shipped
+# command. They are phrased too freely to verify mechanically, so this check
+# bans the specific phrasings rather than trying to interpret them. Say when a
+# feature ARRIVED ("since 0.6.0", "(0.6.0)"), never where it has not yet landed.
+STALE_PHRASES=(
+  'trunk-dev only'
+  'trunk-dev-only'
+  'not in the published'
+  'do not suggest them to users on the published release'
+  'On trunk-dev'
+  'on trunk-dev'
+)
+for phrase in "${STALE_PHRASES[@]}"; do
+  while IFS= read -r hit; do
+    [[ -z "$hit" ]] && continue
+    echo "STALE-PROSE $hit" >&2
+    echo "            \"$phrase\" dates the skill to an unreleased branch." >&2
+    echo "            State the release the feature ARRIVED in instead." >&2
+    fail=$((fail + 1))
+  done < <(grep -rn -F -- "$phrase" "$SKILL_DIR" | sed "s|^$SKILL_DIR/||" | cut -c1-120 || true)
+done
+
 if [[ $fail -gt 0 ]]; then
   echo "" >&2
-  echo "$fail skill version marker(s) disagree with CHANGELOG.md." >&2
+  echo "$fail skill version problem(s) found." >&2
   echo "A marker names the release an API ARRIVED in. Resolve it from the" >&2
   echo "CHANGELOG section containing the issue's oldest mention." >&2
   exit 1

--- a/skills/autumn-web/SKILL.md
+++ b/skills/autumn-web/SKILL.md
@@ -4,24 +4,24 @@ description: >
   Use when building, debugging, documenting, or upgrading Rust web applications
   with autumn-web, autumn-cli, or first-party Autumn crates; also use for
   Autumn route/model/repository/job/webhook/admin macros, AppBuilder setup,
-  Maud + htmx server-rendered UI, Diesel async Postgres, and Autumn 0.5.x
+  Maud + htmx server-rendered UI, Diesel async Postgres, and Autumn 0.7.x
   migration or release work.
 ---
 
 # autumn-web - Rust Web Framework
 
-**Repository**: https://github.com/madmax983/autumn
+**Repository**: https://github.com/autumn-foundation/autumn
 **Branch**: `trunk-dev`
-**Latest published release**: 0.5.0 on crates.io | **Edition**: 2024 | **MSRV**: 1.88.0
-**Author**: madmax983
+**Latest release**: 0.7.0 | **Edition**: 2024 | **MSRV**: 1.88.0
 
 **Version identity trip wire**: the workspace on `trunk-dev` is versioned
-0.6.0, but 0.6.0 is **not published** — crates.io still serves 0.5.0. Apps
-depending on the published crates (`autumn-web = "0.5"`, `cargo install
-autumn-cli --version 0.5.0`) do not have trunk-dev-only features. Anything
-below marked **(unreleased)** is merged on `trunk-dev` but absent from the
-published 0.5.0 crates — do not use it in an app built against 0.5.0.
-Unmarked features are in the published release.
+0.7.0, and `v0.7.0` is the current release line — `autumn-web = "0.7"`,
+`cargo install autumn-cli --version 0.7.0`. Features below marked **(0.7.0)**
+arrived in this release and are **absent from 0.6.x and earlier**: if an app
+pins an older line, check [`CHANGELOG.md`](../../CHANGELOG.md) before using
+them. Unmarked features predate 0.7.0. An app moving up from 0.6.x follows
+[`docs/migrations/0.7.0.md`](../../docs/migrations/0.7.0.md); run
+`autumn upgrade` first.
 
 autumn-web is a Spring Boot-style web framework for Rust, built on Axum. It
 assembles Axum, Diesel, Maud, htmx, Tailwind, Tokio, tracing, and production
@@ -34,7 +34,7 @@ when their details matter:
 
 - `references/api-reference.md` - release-line API map, proc macros,
   feature flags, AppBuilder methods, config env names, and dependency versions.
-- `references/examples.md` - official 0.5.0 example patterns for minimal apps,
+- `references/examples.md` - official 0.7.0 example patterns for minimal apps,
   CRUD, production-ish jobs, Redis channels, S3 storage plugins, and signed
   webhooks. Use this before generating full app code.
 - `docs/guide/accessibility.md` - accessible-by-construction UI. Prefer the
@@ -65,26 +65,26 @@ the framework almost certainly already generates or ships it:
 | Status-transition validation written by hand in `before_create`/`before_update` hooks or handlers (`if old == "draft" && new == "published"` match blocks) | `#[state_machine(transitions(...))]` on the model field — generated `can_transition_{field}_to` / `transition_{field}_to` enforce the graph. See "Model state machines" below and `docs/guide/state-machines.md` |
 | Raw `axum::Router` routes and handlers, manual `.route("/x", get(...))` | `#[get]`/`#[post]`/`#[put]`/`#[patch]`/`#[delete]` + `routes![...]`, `.scoped(prefix, layer, routes)` for groups. `.merge()`/`.nest()` exist for the rare escape hatch only |
 | Raw Diesel queries for CRUD, lookups, pagination, or bulk writes | `#[repository]`-generated methods: `find_by_id`, `find_all`, `save`, `update`, `delete_by_id`, derived `find_by_*`, `page(&PageRequest)`, `cursor_page(&CursorRequest)`, bulk `save_many`/`update_many`/`delete_many`/`upsert_many`. See `docs/guide/repositories.md`, `docs/guide/pagination.md` |
-| Manual per-item queries in a loop (N+1) or hand-written JOINs to fetch associations | `#[belongs_to]`/`#[has_many]`/`#[has_one]` + `repo.preload(records, Model::preload()...)` (unreleased) |
-| Hand-rolled auth, session, or token checks in handler bodies | `#[secured]` / `#[secured("role")]`, `#[authorize]`, repository `policy =`/`scope =`; `#[secured(scopes = [...])]` for service tokens (unreleased) |
-| A punishingly low global rate limit to protect one abuse-prone endpoint (login, search, export) | `#[throttle(limit = 5, per = "1m", key = "ip")]` sits alongside `#[get]`/`#[post]`; `#[throttle("login")]` reads `[security.rate_limit.named.login]` from config (unreleased — issue #1350, see `docs/guide/rate-limiting.md`) |
-| Hand-assembled `<form>` markup with manual value re-fill and error display | `autumn_web::form::form_for(&changeset, action, method)` + the `#[model]`-derived `FormModel` (unreleased — trunk-dev, not in published 0.5.0) renders the whole form — CSRF, `_method` override, one pre-filled control per column, inline errors, submit — in one call; see "Whole-form rendering" below. Compose the per-field helpers only when its escape hatches don't fit: `form_tag`, `method_input`, `text_input` (published); `number_input`, `datetime_input`, `date_input`, `checkbox_input`, `select_input` + `Changeset` 422 re-render (unreleased) |
-| `find_all()` + a loop (or raw Diesel `LIMIT`/`OFFSET` paging) to sweep a whole table in a task/job/backfill | `repo.find_in_batches(n)` / `repo.find_each(n)` (unreleased — trunk-dev) — bounded-memory primary-key keyset iteration. See "Generated repository surface" below and `docs/guide/pagination.md` |
+| Manual per-item queries in a loop (N+1) or hand-written JOINs to fetch associations | `#[belongs_to]`/`#[has_many]`/`#[has_one]` + `repo.preload(records, Model::preload()...)` (0.7.0) |
+| Hand-rolled auth, session, or token checks in handler bodies | `#[secured]` / `#[secured("role")]`, `#[authorize]`, repository `policy =`/`scope =`; `#[secured(scopes = [...])]` for service tokens (0.7.0) |
+| A punishingly low global rate limit to protect one abuse-prone endpoint (login, search, export) | `#[throttle(limit = 5, per = "1m", key = "ip")]` sits alongside `#[get]`/`#[post]`; `#[throttle("login")]` reads `[security.rate_limit.named.login]` from config (0.7.0, issue #1350, see `docs/guide/rate-limiting.md`) |
+| Hand-assembled `<form>` markup with manual value re-fill and error display | `autumn_web::form::form_for(&changeset, action, method)` + the `#[model]`-derived `FormModel` (0.7.0) renders the whole form — CSRF, `_method` override, one pre-filled control per column, inline errors, submit — in one call; see "Whole-form rendering" below. Compose the per-field helpers only when its escape hatches don't fit: `form_tag`, `method_input`, `text_input` (published); `number_input`, `datetime_input`, `date_input`, `checkbox_input`, `select_input` + `Changeset` 422 re-render (0.7.0) |
+| `find_all()` + a loop (or raw Diesel `LIMIT`/`OFFSET` paging) to sweep a whole table in a task/job/backfill | `repo.find_in_batches(n)` / `repo.find_each(n)` (0.7.0) — bounded-memory primary-key keyset iteration. See "Generated repository surface" below and `docs/guide/pagination.md` |
 | Ad-hoc `tokio::spawn` / background threads for deferred work | `#[job]` (+ retries, backends, uniqueness/concurrency caps), `#[scheduled]` for recurring, `#[task]` for operator CLI work |
-| A hand-written `#[scheduled]` fn + batched `DELETE`/`UPDATE` to expire old sessions, drafts, or one-time codes | `#[repository(Model, retention(after = "30d", basis = created_at))]` (unreleased — trunk-dev, issue #1342) — batched, soft-delete-aware, fleet-coordinated sweep with zero SQL; `autumn retention --dry-run` to validate first. See `docs/guide/retention-sweeps.md` |
-| Hand-written memoization or cache-aside code | `#[cached]` on functions; `cache::get_or_compute` / `get_or_compute_with` for stampede-safe read-through fills (unreleased) |
-| Hand-written transaction retry loops for serialization failures | `Db::tx(...)`; `Db::tx_with(TxOptions::serializable(), ...)` auto-retries 40001 (unreleased) |
+| A hand-written `#[scheduled]` fn + batched `DELETE`/`UPDATE` to expire old sessions, drafts, or one-time codes | `#[repository(Model, retention(after = "30d", basis = created_at))]` (0.7.0, issue #1342) — batched, soft-delete-aware, fleet-coordinated sweep with zero SQL; `autumn retention --dry-run` to validate first. See `docs/guide/retention-sweeps.md` |
+| Hand-written memoization or cache-aside code | `#[cached]` on functions; `cache::get_or_compute` / `get_or_compute_with` for stampede-safe read-through fills (0.7.0) |
+| Hand-written transaction retry loops for serialization failures | `Db::tx(...)`; `Db::tx_with(TxOptions::serializable(), ...)` auto-retries 40001 (0.7.0) |
 | Hand-rolled HMAC verification for Stripe/GitHub/Slack callbacks | `SignedWebhook` extractor + `[webhooks.<name>]` config |
-| Hand-rolled pager markup (page-number windows, prev/next links) | `pagination_nav(&page, &PagerOptions::new("/posts"))` / `cursor_pagination_nav` (unreleased) |
-| Hand-rolled cross-module notifications (calling every reaction inline) | `#[event]` + `#[listener]` typed event bus, `.listeners(listeners![...])` (unreleased) |
-| Hand-rolled cards, tabs, modals, delete-confirm dialogs, method-override links | `autumn_web::widgets`: `card`/`stat_card`, `tabs`, `modal`/`confirm_action`, `link_to`/`button_to` + `ui::WIDGETS_CSS_PATH` stylesheet (unreleased) |
-| Hand-built file-download responses (manual `Content-Disposition`/`Content-Type`/`Content-Length` headers, byte-buffered blob reads) | `autumn_web::download::Download` — `from_bytes` / `from_stream` / `from_async_read` / `from_blob(&store, key).await?` + `.filename(...)` / `.content_type(...)` / `.inline()`; RFC 5987 filenames, injection-safe, streams blobs without buffering (unreleased) |
-| Hand-parsed `Range` headers / manual `206 Partial Content` / `Content-Range` / `416` for seekable media or resumable downloads | `autumn_web::range` (`resolve` + `partial_bytes_response`) and `Download::into_response_ranged(&headers).await` — RFC 7233 single-range parsing, multi-range single-range collapse, `If-Range` via `.etag(..)`/`.last_modified(..)`, blob slices via `BlobStore::get_range` (no whole-object buffering) (unreleased) |
-| Shelling out to `wkhtmltopdf`/headless Chrome, or hand-rolling a PDF library, to turn a view into a downloadable invoice/receipt/report | `autumn_web::pdf::Pdf` (`pdf` Cargo feature) — `Pdf::from_markup(markup)` / `Pdf::from_html(html)` + `.filename(...)` / `.inline()`; renders headings/paragraphs/tables/lists/bold/italic with the PDF base-14 fonts, no system browser or embedded fonts required. Test with `TestResponse::assert_pdf_contains(&self, &str)`. See `docs/guide/pdf-downloads.md` (unreleased) |
-| Hand-written RSS/Atom XML strings for a `/feed.xml` or podcast/blog feed | `feed::Feed::atom(..)` / `feed::Feed::rss(..)` + `feed::FeedEntry` — builds the XML, implements `IntoResponse` with the right `application/atom+xml`/`application/rss+xml` type, XML-escapes text, and `Feed::conditional(&headers)` reuses the `etag` layer for `304`s (unreleased). See `docs/guide/conditional-get.md` |
-| A hand-rolled `AtomicU64` + a `MetricsSource` impl (or a whole second `prometheus`/`metrics` crate exporter) just to count something in a handler | `autumn_web::metrics` — `metrics::counter("checkout_completed_total").with_label("status", "paid").increment(1)`, plus `gauge`, `histogram` and `timer(..).start()` (a guard that records on drop, so early `?` returns and panics are covered) / `time` / `time_async`. Registers itself on first use and lands on the stock `/actuator/prometheus` and `/actuator/metrics` (`app` key) with zero `AppBuilder` wiring; caps cardinality (100 *labeled* series/instrument) instead of leaking series (unreleased — issue #1378). `describe_*` and `set_histogram_buckets` do not register anything, so startup calls work in either order; gauges and histograms take `usize`/`u64`/`i64` directly (`set(queue.len())`). `MetricsSource` is still the answer when a subsystem already owns the numbers. See `docs/guide/metrics.md` |
-| Reproducing a production 500 by copying the request into a test and guessing at the database state it saw | `[failure_capture] enabled = true` writes a redacted **failure capsule** (request + PostgreSQL wire traffic + clock readings + outcome, one JSON file) for every caught panic/5xx; `autumn replay <capsule>` re-runs it offline against an in-process stub DB — exit 0 reproduced / 1 mismatch / 2 refused. Capsules are production data: read the security section of `docs/guide/failure-capsules.md` before enabling (unreleased — trunk-dev, #1598) |
-| Hand-assembled `Cache-Control` header strings on a handler | `etag::cache_for(Duration)` → `CacheControl`; attach as a tuple `(cache_for(dur).public(), html!{…})` or `.wrap(resp)`. Chain `public`/`private`, `max_age`, `s_maxage`, `stale_while_revalidate`, `no_store`, `no_cache`, `must_revalidate`, `immutable`; `header_value()` renders a deterministic value. Defaults to `private` (a secured page can't be silently made public); composes with `fresh_when` — the directives ride the `200` and the preserved `304` (unreleased — issue #1344). See `docs/guide/conditional-get.md` |
+| Hand-rolled pager markup (page-number windows, prev/next links) | `pagination_nav(&page, &PagerOptions::new("/posts"))` / `cursor_pagination_nav` (0.7.0) |
+| Hand-rolled cross-module notifications (calling every reaction inline) | `#[event]` + `#[listener]` typed event bus, `.listeners(listeners![...])` (0.7.0) |
+| Hand-rolled cards, tabs, modals, delete-confirm dialogs, method-override links | `autumn_web::widgets`: `card`/`stat_card`, `tabs`, `modal`/`confirm_action`, `link_to`/`button_to` + `ui::WIDGETS_CSS_PATH` stylesheet (0.7.0) |
+| Hand-built file-download responses (manual `Content-Disposition`/`Content-Type`/`Content-Length` headers, byte-buffered blob reads) | `autumn_web::download::Download` — `from_bytes` / `from_stream` / `from_async_read` / `from_blob(&store, key).await?` + `.filename(...)` / `.content_type(...)` / `.inline()`; RFC 5987 filenames, injection-safe, streams blobs without buffering (0.7.0) |
+| Hand-parsed `Range` headers / manual `206 Partial Content` / `Content-Range` / `416` for seekable media or resumable downloads | `autumn_web::range` (`resolve` + `partial_bytes_response`) and `Download::into_response_ranged(&headers).await` — RFC 7233 single-range parsing, multi-range single-range collapse, `If-Range` via `.etag(..)`/`.last_modified(..)`, blob slices via `BlobStore::get_range` (no whole-object buffering) (0.7.0) |
+| Shelling out to `wkhtmltopdf`/headless Chrome, or hand-rolling a PDF library, to turn a view into a downloadable invoice/receipt/report | `autumn_web::pdf::Pdf` (`pdf` Cargo feature) — `Pdf::from_markup(markup)` / `Pdf::from_html(html)` + `.filename(...)` / `.inline()`; renders headings/paragraphs/tables/lists/bold/italic with the PDF base-14 fonts, no system browser or embedded fonts required. Test with `TestResponse::assert_pdf_contains(&self, &str)`. See `docs/guide/pdf-downloads.md` (0.7.0) |
+| Hand-written RSS/Atom XML strings for a `/feed.xml` or podcast/blog feed | `feed::Feed::atom(..)` / `feed::Feed::rss(..)` + `feed::FeedEntry` — builds the XML, implements `IntoResponse` with the right `application/atom+xml`/`application/rss+xml` type, XML-escapes text, and `Feed::conditional(&headers)` reuses the `etag` layer for `304`s (0.7.0). See `docs/guide/conditional-get.md` |
+| A hand-rolled `AtomicU64` + a `MetricsSource` impl (or a whole second `prometheus`/`metrics` crate exporter) just to count something in a handler | `autumn_web::metrics` — `metrics::counter("checkout_completed_total").with_label("status", "paid").increment(1)`, plus `gauge`, `histogram` and `timer(..).start()` (a guard that records on drop, so early `?` returns and panics are covered) / `time` / `time_async`. Registers itself on first use and lands on the stock `/actuator/prometheus` and `/actuator/metrics` (`app` key) with zero `AppBuilder` wiring; caps cardinality (100 *labeled* series/instrument) instead of leaking series (0.7.0, issue #1378). `describe_*` and `set_histogram_buckets` do not register anything, so startup calls work in either order; gauges and histograms take `usize`/`u64`/`i64` directly (`set(queue.len())`). `MetricsSource` is still the answer when a subsystem already owns the numbers. See `docs/guide/metrics.md` |
+| Reproducing a production 500 by copying the request into a test and guessing at the database state it saw | `[failure_capture] enabled = true` writes a redacted **failure capsule** (request + PostgreSQL wire traffic + clock readings + outcome, one JSON file) for every caught panic/5xx; `autumn replay <capsule>` re-runs it offline against an in-process stub DB — exit 0 reproduced / 1 mismatch / 2 refused. Capsules are production data: read the security section of `docs/guide/failure-capsules.md` before enabling (0.7.0, #1598) |
+| Hand-assembled `Cache-Control` header strings on a handler | `etag::cache_for(Duration)` → `CacheControl`; attach as a tuple `(cache_for(dur).public(), html!{…})` or `.wrap(resp)`. Chain `public`/`private`, `max_age`, `s_maxage`, `stale_while_revalidate`, `no_store`, `no_cache`, `must_revalidate`, `immutable`; `header_value()` renders a deterministic value. Defaults to `private` (a secured page can't be silently made public); composes with `fresh_when` — the directives ride the `200` and the preserved `304` (0.7.0, issue #1344). See `docs/guide/conditional-get.md` |
 
 When none of these fit, dropping to raw Axum (`.merge()`/`.nest()`/`.layer()`)
 or raw Diesel (`&mut *db` with `diesel_async`) is supported and fine — but only
@@ -136,7 +136,7 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-autumn-web = { version = "0.5", features = ["db", "htmx", "maud"] }
+autumn-web = { version = "0.7", features = ["db", "htmx", "maud"] }
 chrono = { version = "0.4", features = ["serde"] }
 diesel = { version = "2", features = ["postgres", "chrono"] }
 diesel-async = { version = "0.8", features = ["postgres"] }
@@ -153,7 +153,7 @@ when avoiding a system libpq install.
 
 For a reddit-clone-style app with live feeds, file uploads, and blob variants:
 ```toml
-autumn-web = { version = "0.5", features = [
+autumn-web = { version = "0.7", features = [
     "mail",       # transactional email + mailer previews
     "ws",         # WebSocket routes, SSE, broadcast channels
     "presence",   # Presence extractor for online-user tracking
@@ -186,8 +186,8 @@ Defaults: `maud`, `htmx`, `tailwind`, `db`, `cache-moka`.
 | `seed` | `SeedContext` for seed binaries |
 | `system-info` | Optional system information in actuator surfaces |
 
-For S3 storage add `autumn-storage-s3 = "0.5"`; `storage-s3` is no longer an
-`autumn-web` feature. For a shared Redis cache add `autumn-cache-redis = "0.5"`.
+For S3 storage add `autumn-storage-s3 = "0.7"`; `storage-s3` is no longer an
+`autumn-web` feature. For a shared Redis cache add `autumn-cache-redis = "0.7"`.
 For keyword + vector search with lifecycle-synced indexes add `autumn-search`.
 
 ## main.rs pattern
@@ -242,11 +242,11 @@ Use `.one_off_tasks(one_off_tasks![...])` for `#[task]` handlers invoked by
 | `.with_blob_store(store)` | Install a file storage backend |
 | `.with_cache_backend(cache)` | Install a cache backend |
 | `.with_mail_delivery_queue(queue)` | Install durable deferred mail |
-| `.with_mail_suppression_store(store)` | Install a durable bounce/complaint suppression backend (unreleased; in-memory default auto-wired otherwise) |
+| `.with_mail_suppression_store(store)` | Install a durable bounce/complaint suppression backend (0.7.0; in-memory default auto-wired otherwise) |
 | `.with_audit_sink(sink)` | Install structured audit sink |
-| `.listeners(listeners![...])` | Register `#[listener]` event listeners (unreleased) |
-| `.static_gate(layer)` | Middleware that also guards `#[static_get]` pre-render (unreleased; `has_static_gate::<L>()`, `get_static_gate_types()`, `TestApp::static_gate` mirror it) |
-| `.with_shard_router(router)` | Install a shard router for `[[database.shards]]` (unreleased) |
+| `.listeners(listeners![...])` | Register `#[listener]` event listeners (0.7.0) |
+| `.static_gate(layer)` | Middleware that also guards `#[static_get]` pre-render (0.7.0; `has_static_gate::<L>()`, `get_static_gate_types()`, `TestApp::static_gate` mirror it) |
+| `.with_shard_router(router)` | Install a shard router for `[[database.shards]]` (0.7.0) |
 | `.run()` | Launch the server |
 
 ## Route macros
@@ -290,7 +290,7 @@ async fn ws() -> impl autumn_web::ws::WsHandler {
 Route functions are collected with `routes![...]`. Static routes also need
 `static_routes![...]` so `autumn build` can pre-render them.
 
-**Route-level SEO defaults (issue #1182, unreleased — trunk-dev):** declare
+**Route-level SEO defaults (issue #1182, 0.7.0):** declare
 per-page meta tag values once on the route with a `seo(...)` argument instead of
 rebuilding a `SeoMeta` in every handler. `SeoMeta` is an extractor, so a handler
 that takes one receives a builder pre-populated with the declared values:
@@ -321,7 +321,7 @@ never fails — on a route without `seo(...)` it yields an empty builder. Note t
 attribute supplies *values*, not markup: the handler still emits them, normally
 via `seo.render()` inside the layout's `<head>`.
 
-**Locale-prefixed routing (issue #1251, unreleased — trunk-dev):** set
+**Locale-prefixed routing (issue #1251, 0.7.0):** set
 `[i18n] locale_prefix_enabled = true` in `autumn.toml` (default `false`) and
 every route registered via `routes![...]` becomes reachable under
 `/{locale}/...` for each `supported_locales` entry — zero duplicated route
@@ -337,7 +337,7 @@ the lower-level `localized_path(path, locale)`) from
 default_locale, supported_locales))` to emit `hreflang` `<link>` tags for the
 current page's localized variants.
 
-**Duplicate-route preflight (issue #1012, unreleased — trunk-dev):** two
+**Duplicate-route preflight (issue #1012, 0.7.0):** two
 handlers that resolve to the same `(method, path)` after `.scoped(...)` prefix
 resolution — including `#[repository]`-generated API routes — fail app build
 with `RouterBuildError::DuplicateUserRoute { method, path, existing, incoming }`
@@ -372,7 +372,7 @@ async fn show(Path(slug): Path<String>) -> AutumnResult<Markup> {
 
 `static_params()` keys every entry `"slug"`. If the route names its parameter
 anything else — `#[static_get("/docs/{page}", …)]` — use
-`static_params_for("page")` (unreleased — trunk-dev, issue #743); a mismatched
+`static_params_for("page")` (0.7.0, issue #743); a mismatched
 key leaves `{page}` unsubstituted and the SSG build panics on the invalid URI.
 
 `render` returns `{ html, toc }` and injects heading anchors. Anchors are
@@ -419,7 +419,7 @@ pub trait PostRepository {}
 allow_unauthorized_repository_api = true # only when intentional
 ```
 
-### Associations and preloading (unreleased — trunk-dev, not in published 0.5.0)
+### Associations and preloading (0.7.0)
 
 Declare `#[belongs_to]` / `#[has_many]` / `#[has_one]` on a `#[model]` for
 batched eager loading — no N+1, no lazy loading (un-preloaded access returns
@@ -466,8 +466,7 @@ the design.
 
 **Never hand-roll a votes/likes table.** `#[votable(by = <Reactor>)]` on a
 `#[model]` declares a `(reactor, target)`-unique edge table plus a
-denormalised aggregate column on the target **(unreleased — trunk-dev,
-#1362)**:
+denormalised aggregate column on the target **(0.7.0, #1362)**:
 
 ```rust
 #[autumn_web::model]
@@ -522,8 +521,7 @@ token so the no-JS form POST works. See `docs/guide/votable.md` and `examples/re
 (`src/routes/votes.rs`).
 
 **Never hand-roll a comments table.** `#[commentable]` on a `#[model]` is
-Autumn's fifth association kind — the **polymorphic** one **(unreleased —
-trunk-dev, #1367)**. `belongs_to`/`has_many`/`has_one`/`through` pin the child
+Autumn's fifth association kind — the **polymorphic** one **(0.7.0, #1367)**. `belongs_to`/`has_many`/`has_one`/`through` pin the child
 to one parent table; this does not:
 
 ```rust
@@ -592,7 +590,7 @@ threading the CSRF token and `return_to`. See `docs/guide/commentable.md` and
 
 **Never hand-write `count + 1` on a parent.** `counter_cache` on a child's
 `#[belongs_to]` maintains a denormalised `{child}_count` column on the parent
-**(unreleased — trunk-dev, #1325)**:
+**(0.7.0, #1325)**:
 
 ```rust
 #[autumn_web::model]
@@ -637,7 +635,7 @@ paths are **not** yet maintained: a derived `delete_by_<field>` and
 
 Deleting a parent can cascade to its children in one transaction — declare
 `dependent(...)` on the parent's `#[repository]` instead of hand-writing the
-child cleanup **(unreleased — trunk-dev)**:
+child cleanup **(0.7.0)**:
 
 ```rust
 #[autumn_web::repository(Post,
@@ -655,7 +653,7 @@ locks the parent, applies every declared action, then deletes the parent — all
 a single transaction (Part of #1369). See `docs/guide/repositories.md`.
 
 On trunk-dev the cascade is recursive and bulk-aware, and can be declared on
-the model instead of the repository **(unreleased — trunk-dev, issues #1738,
+the model instead of the repository **(0.7.0, issues #1738,
 #1739, #1740)**:
 
 - **Grandchildren cascade.** `destroy` now recurses — each destroyed child runs
@@ -768,16 +766,16 @@ raw Diesel:
 | `primary_reads` (attr) / `on_primary()` | Pin reads to primary; read-your-writes after a save |
 | `soft_delete`, `tenant_scoped` (attrs), `across_tenants()` | Soft deletion and tenant scoping |
 | `hooks = MyHooks` (attr) | `before_/after_create/update/delete` + `after_*_commit` lifecycle hooks with `MutationContext` |
-| `from_shard(&ShardedDb)`, `with_pool_untracked(pool)` | **(unreleased)** shard-scoped construction; `with_pool_untracked` is new on trunk-dev — published 0.5.0 repositories have **no** pool constructor at all. An app carrying the older `with_pool` name is migrated by `autumn upgrade --apply` (codemod `0.6.0-repository-with-pool-untracked`, issue #1629) rather than by hand |
-| `find_in_batches(batch_size)`, `find_each(batch_size)` | **(unreleased)** Bounded-memory whole-table iteration via a primary-key keyset cursor (`WHERE id > last ORDER BY id ASC LIMIT batch_size` — never `LIMIT`/`OFFSET`), generated on every repository. `find_in_batches` returns a `FindInBatches` handle — drive with `while let Some(chunk) = b.next_batch().await?`; `find_each` returns `FindEach` yielding one model per `next().await?`. Inherits soft-delete filtering, tenant scoping, and read routing like `find_all`; errors are retryable (cursor advances only on success; `Ok(None)` always means completion); `batch_size == 0` errors instead of spinning; `batch_size` is **not** clamped to `MAX_PAGE_SIZE`; sharded repos reject cross-shard `across_tenants()` iteration (iterate per shard via `from_shard`). Handle types: `autumn_web::batches::{FindInBatches, FindEach, BatchSource}` (not in the prelude). See "Batched iteration" in `docs/guide/pagination.md` |
-| `find_or_create_by_<field>[_and_<field>...](<field>, &new)` | **(unreleased)** Race-safe get-or-insert; declare `fn find_or_create_by_slug(slug: String);` (lookup fields only) to generate an inherent `find_or_create_by_slug(&self, slug: String, new: &NewModel) -> AutumnResult<(Model, bool)>`. Reads on the read path first (tenant/soft-delete aware), else inserts on the primary with `ON CONFLICT DO NOTHING` — under concurrency exactly one row is created, exactly one caller sees `created == true`, and no `23505` escapes. `before_/after_create` + commit hooks fire only on the created path; works on hooked repos (unlike `upsert_many`). **Requires a unique constraint on the lookup column(s)** (`_or_` is rejected). See "Race-safe get-or-insert" in `docs/guide/repositories.md` |
-| `retention(after = "30d", basis = created_at)` / `retention(purge_deleted_after = "90d")` (attr) | **(unreleased)** Declarative data-retention: reach for this instead of hand-writing a `#[scheduled]` cleanup fn for expiring sessions, drafts, one-time codes, or other transient rows. Compiles to a batched (`batch_size`, default 500), cursor-paginated sweep auto-registered with fleet coordination — no `tasks![...]` entry needed. On a `soft_delete` repository, `after` soft-deletes (never re-touching an already-deleted row) and `purge_deleted_after` hard-purges (re-checking `deleted_at` at delete time so a concurrent `restore()` survives); without `soft_delete`, `after` hard-deletes. Sweeps run across **all** tenants on a `tenant_scoped` repository (no per-tenant opt-out) and are not supported on `sharded` repositories (compile error). `autumn retention --dry-run [--model NAME]` reports rows-that-would-be-swept without deleting. Emits `retention_sweep_rows_total` / `retention_sweep_duration_seconds` metrics + a structured log line per run. See `docs/guide/retention-sweeps.md` |
+| `from_shard(&ShardedDb)`, `with_pool_untracked(pool)` | **(0.7.0)** shard-scoped construction. `with_pool_untracked` is the 0.6.0 rename of `with_pool`; 0.5.x repositories had **no** pool constructor at all. An app carrying the older `with_pool` name is migrated by `autumn upgrade --apply` (codemod `0.6.0-repository-with-pool-untracked`, issue #1629) rather than by hand |
+| `find_in_batches(batch_size)`, `find_each(batch_size)` | **(0.7.0)** Bounded-memory whole-table iteration via a primary-key keyset cursor (`WHERE id > last ORDER BY id ASC LIMIT batch_size` — never `LIMIT`/`OFFSET`), generated on every repository. `find_in_batches` returns a `FindInBatches` handle — drive with `while let Some(chunk) = b.next_batch().await?`; `find_each` returns `FindEach` yielding one model per `next().await?`. Inherits soft-delete filtering, tenant scoping, and read routing like `find_all`; errors are retryable (cursor advances only on success; `Ok(None)` always means completion); `batch_size == 0` errors instead of spinning; `batch_size` is **not** clamped to `MAX_PAGE_SIZE`; sharded repos reject cross-shard `across_tenants()` iteration (iterate per shard via `from_shard`). Handle types: `autumn_web::batches::{FindInBatches, FindEach, BatchSource}` (not in the prelude). See "Batched iteration" in `docs/guide/pagination.md` |
+| `find_or_create_by_<field>[_and_<field>...](<field>, &new)` | **(0.7.0)** Race-safe get-or-insert; declare `fn find_or_create_by_slug(slug: String);` (lookup fields only) to generate an inherent `find_or_create_by_slug(&self, slug: String, new: &NewModel) -> AutumnResult<(Model, bool)>`. Reads on the read path first (tenant/soft-delete aware), else inserts on the primary with `ON CONFLICT DO NOTHING` — under concurrency exactly one row is created, exactly one caller sees `created == true`, and no `23505` escapes. `before_/after_create` + commit hooks fire only on the created path; works on hooked repos (unlike `upsert_many`). **Requires a unique constraint on the lookup column(s)** (`_or_` is rejected). See "Race-safe get-or-insert" in `docs/guide/repositories.md` |
+| `retention(after = "30d", basis = created_at)` / `retention(purge_deleted_after = "90d")` (attr) | **(0.7.0)** Declarative data-retention: reach for this instead of hand-writing a `#[scheduled]` cleanup fn for expiring sessions, drafts, one-time codes, or other transient rows. Compiles to a batched (`batch_size`, default 500), cursor-paginated sweep auto-registered with fleet coordination — no `tasks![...]` entry needed. On a `soft_delete` repository, `after` soft-deletes (never re-touching an already-deleted row) and `purge_deleted_after` hard-purges (re-checking `deleted_at` at delete time so a concurrent `restore()` survives); without `soft_delete`, `after` hard-deletes. Sweeps run across **all** tenants on a `tenant_scoped` repository (no per-tenant opt-out) and are not supported on `sharded` repositories (compile error). `autumn retention --dry-run [--model NAME]` reports rows-that-would-be-swept without deleting. Emits `retention_sweep_rows_total` / `retention_sweep_duration_seconds` metrics + a structured log line per run. See `docs/guide/retention-sweeps.md` |
 
 Read routing: with `database.replica_url` set, all generated reads use the
 replica automatically; writes always hit the primary. See
 `docs/guide/repositories.md` and `docs/guide/pagination.md`.
 
-### JSON API endpoints — page envelope + write validation (unreleased — trunk-dev)
+### JSON API endpoints — page envelope + write validation (0.7.0)
 
 A `#[repository(api = "/api/posts")]` list endpoint returns a page envelope, and
 create/update handlers validate the decoded payload before touching the DB:
@@ -794,7 +792,7 @@ create/update handlers validate the decoded payload before touching the DB:
   specialization (no migration burden), and this applies to plain and
   policy-backed handlers (#1237, #1253). See `docs/guide/pagination.md`.
 
-### Partial-update validation — the effective merged model (unreleased — trunk-dev, issue #1778)
+### Partial-update validation — the effective merged model (0.7.0, issue #1778)
 
 On a repository with `hooks = ...`, a `PATCH`/`PUT` update now validates the
 **effective merged model** — the existing row ∪ the patch, after normalization —
@@ -820,7 +818,7 @@ validators (follow-up: issue #1801). The `Patch<T>` per-field impls and the
 ### Transactions
 
 `Db::tx(f)` runs a READ COMMITTED transaction. On trunk-dev
-**(unreleased)**, `Db::tx_with(opts, f)` adds isolation levels and automatic
+**(0.7.0)**, `Db::tx_with(opts, f)` adds isolation levels and automatic
 retry of serialization failures (SQLSTATE 40001) with capped exponential
 backoff:
 
@@ -871,7 +869,7 @@ async fn update_post(Path(id): Path<i64>, mut db: Db, session: Session) -> Autum
 }
 ```
 
-**(unreleased)** Scoped service tokens (trunk-dev only): mint named,
+**(0.7.0)** Scoped service tokens (trunk-dev only): mint named,
 optionally-expiring API tokens carrying flat scopes via `IssueTokenSpec` +
 `issue_scoped_api_token`; gate handlers with
 `#[secured(scopes = ["posts:write"])]` (no session required — default-deny,
@@ -879,9 +877,9 @@ optionally-expiring API tokens carrying flat scopes via `IssueTokenSpec` +
 policies with `PolicyContext::has_scope/has_any_scope/has_all_scopes`; manage
 with `autumn token issue <principal> --name ... --scope ...` / `list` /
 `rotate`. The
-published 0.5.0 `autumn token` has only `issue <principal>` / `revoke`.
+published 0.7.0 `autumn token` has only `issue <principal>` / `revoke`.
 
-Active session management ships with `autumn generate auth` (published 0.5.0):
+Active session management ships with `autumn generate auth` (0.7.0):
 a `{user}_sessions` row per login, generated `sessions()`,
 `revoke_session(id)`, `revoke_other_sessions(...)`, `revoke_all_sessions()`
 methods, an `/account/sessions` Maud + htmx page, and `[auth.sessions]`
@@ -896,7 +894,7 @@ export AUTUMN_SECURITY__SIGNING_SECRET="$(openssl rand -hex 32)"
 For rotation, set `[security.signing_secret].previous_secrets` until old
 cookies, CSRF tokens, flash state, and signed storage URLs expire.
 
-### Cookie consent (unreleased — trunk-dev, issue #1214)
+### Cookie consent (0.7.0, issue #1214)
 
 `autumn new` scaffolds a cookie-consent banner and a real consent gate by
 default — no third-party tracker, no JS. `autumn_web::consent::Consent` is an
@@ -919,7 +917,7 @@ the banner into the static file written to `dist/`. Bump the scaffolded
 banner. Strictly-necessary cookies (session, CSRF) are never routed through
 the gate.
 
-### Audit actor attribution (unreleased — trunk-dev)
+### Audit actor attribution (0.7.0)
 
 Version/audit writes are auto-attributed to the current actor — no per-call
 plumbing. The log-context middleware opens an empty actor scope per request; set
@@ -942,7 +940,7 @@ DEFAULT 'system'` and the generated code falls back to `VersionEntry::SYSTEM_ACT
 
 ## OAuth2/OIDC scaffolding
 
-OAuth2/OIDC social login is in the 0.5.0 line. Do not repeat the stale
+OAuth2/OIDC social login has shipped since the 0.5.0 line. Do not repeat the stale
 changelog claim that it was reverted; the revert was followed by a reapply and
 review fixes. Prefer the current tree and `docs/guide/oauth.md` over that old
 summary line.
@@ -994,7 +992,7 @@ url = "redis://redis:6379/0"
 key_prefix = "myapp:webhooks:replay"
 ```
 
-`autumn generate webhook <provider> <Name>` (unreleased — trunk-dev, #1366)
+`autumn generate webhook <provider> <Name>` (0.7.0, #1366)
 scaffolds the whole endpoint: the `#[post]` handler over `SignedWebhook`, an
 event-type dispatch skeleton, the `[[security.webhooks.endpoints]]` config
 (`secret_env`, replay protection on — CSRF/submit-token/CAPTCHA exemptions are
@@ -1004,7 +1002,7 @@ deliveries. Presets: `stripe`, `github`, `slack`, `generic`.
 
 Read `docs/guide/signed-webhooks.md` and `examples/signed-webhooks/`.
 
-## Mail CSS inlining — render styled in Gmail/Outlook (unreleased — trunk-dev)
+## Mail CSS inlining — render styled in Gmail/Outlook (0.7.0)
 
 Gmail strips `<style>` in many contexts and Outlook (Word engine) ignores
 `<head>`/`<style>` and most external CSS, so email authored with a stylesheet
@@ -1039,7 +1037,7 @@ time. Autumn does this for you (issue #1254).
 - `autumn generate mailer` scaffolds this end to end (a `<style>` template + a
   mailer that calls `.inline_css(true)`).
 
-## Mail suppression — stop emailing bounced addresses (unreleased — trunk-dev)
+## Mail suppression — stop emailing bounced addresses (0.7.0)
 
 Autumn *detects* delivery failure (inbound bounce/complaint webhooks) **and**
 acts on it: `Mailer::send()` consults a bounce/complaint suppression list
@@ -1125,7 +1123,7 @@ this is *provider-reported* failure.
   recipient fixed their mailbox); `store.suppress(addr, SuppressionReason::Manual)`
   adds one by hand.
 
-## In-app notifications (unreleased — trunk-dev, issue #1148)
+## In-app notifications (0.7.0, issue #1148)
 
 A first-class per-recipient notification store with read/unread state — do not
 hand-roll a notifications table, model, and unread-count queries. Scaffold with
@@ -1182,13 +1180,13 @@ Use built-in jobs and tasks before reaching for a workflow engine:
 discarding, and canceling framework jobs. `GET /actuator/jobs` exposes
 lower-level counters.
 
-Job attributes beyond `name`/`max_attempts`/`backoff_ms` (published 0.5.0):
+Job attributes beyond `name`/`max_attempts`/`backoff_ms` (0.7.0):
 `#[job(unique)]` dedupes on an args hash, `unique_by = "field"`,
 `unique_window = "running"|"pending"`, `unique_for_ms = N` (debounce),
 `concurrency = N` + `concurrency_key = "field"` caps simultaneous runs. A
 coalesced enqueue is a no-op `Ok(())`.
 
-**(unreleased)** trunk-dev jobs additions:
+**(0.7.0)** trunk-dev jobs additions:
 
 - **Named queues**: `#[job(queue = "critical")]`; drain order via
   `[jobs] queues = ["critical", "default", "low"]` (strict priority) or a
@@ -1210,7 +1208,7 @@ coalesced enqueue is a no-op `Ok(())`.
   `autumn_web::payload_version::{split_version, wrap}` (Closes #1205). See
   `docs/guide/jobs.md`.
 
-**(unreleased)** Events & listeners — a typed domain event bus so one action
+**(0.7.0)** Events & listeners — a typed domain event bus so one action
 can fan out without inline coupling: `#[event]` on a struct, publish via the
 `Events` extractor (`events.publish(UserSignedUp { .. }).await?`), react with
 `#[listener(UserSignedUp)]` (sync, in-request) or
@@ -1218,7 +1216,7 @@ can fan out without inline coupling: `#[event]` on a struct, publish via the
 register with `.listeners(listeners![...])`. Do not also list durable
 listeners in `jobs![...]`. See `docs/guide/events.md`.
 
-## Distributed locks (unreleased — trunk-dev)
+## Distributed locks (0.7.0)
 
 For "run this exactly once across replicas right now" work (nightly cleanup,
 cache warming, one-shot backfills, "send the daily digest once"), use
@@ -1254,8 +1252,8 @@ See `docs/guide/distributed-locks.md` and
 For local or pluggable file storage:
 
 ```toml
-autumn-web = { version = "0.5", features = ["storage", "multipart"] }
-autumn-storage-s3 = "0.5" # when storage.backend = "s3"
+autumn-web = { version = "0.7", features = ["storage", "multipart"] }
+autumn-storage-s3 = "0.7" # when storage.backend = "s3"
 ```
 
 ```rust
@@ -1268,7 +1266,7 @@ autumn_web::app().with_blob_store(store).run().await;
 For keyword **and** vector search with an index that stays in sync:
 
 ```toml
-autumn-search = "0.6"
+autumn-search = "0.7"
 ```
 
 ```rust
@@ -1309,8 +1307,8 @@ let hits = search.similar::<Article>("how do I add auth?", 5).await?; // k-NN
 For shared Redis cache:
 
 ```toml
-autumn-web = { version = "0.5", features = ["redis"] }
-autumn-cache-redis = "0.5"
+autumn-web = { version = "0.7", features = ["redis"] }
+autumn-cache-redis = "0.7"
 ```
 
 ```rust
@@ -1320,7 +1318,7 @@ autumn_web::app()
     .await;
 ```
 
-**(unreleased)** Cache stampede protection — do not hand-roll cache-aside
+**(0.7.0)** Cache stampede protection — do not hand-roll cache-aside
 fills: `cache::get_or_compute(cache, key, Some(ttl), fill)` runs `fill` once
 per process for concurrent callers; `get_or_compute_with` +
 `GetOrComputeOptions::new().distributed_fill_lock(true)` (Redis lock) and
@@ -1329,7 +1327,7 @@ serve-stale; `cache::jittered_ttl(base, fraction)` de-synchronizes mass
 expiry. A failed fill never poisons the key. See
 `docs/guide/cache-stampede.md`.
 
-**(unreleased)** Upload content-type validation — multipart uploads are
+**(0.7.0)** Upload content-type validation — multipart uploads are
 validated by **magic bytes**, not the spoofable client `Content-Type`. The
 `Multipart` extractor sniffs the real type (`sniff_content_type`) whenever an
 `allowed_content_types` allow-list is configured or strict mode is on. Reject
@@ -1343,7 +1341,7 @@ reject_on_content_type_mismatch = true  # declared-vs-sniffed mismatch (or an
 
 (env `AUTUMN_SECURITY__UPLOAD__REJECT_ON_CONTENT_TYPE_MISMATCH`) (#1354).
 
-## View helpers and widgets (unreleased — trunk-dev, not in published 0.5.0)
+## View helpers and widgets (0.7.0)
 
 Trunk-dev ships framework view widgets — prefer these over hand-rolled Maud
 for the common cases:
@@ -1367,7 +1365,7 @@ for the common cases:
 | `comment_thread(&cfg, &CommentView::from_thread(&nodes))` / `CommentThread::new(dom_id, action)` | The view half of `#[commentable]` (#1367): nested `<ol>` comment thread with a `<details>`-disclosed inline reply form on every node. Ordinary `<form method="post">` (works with scripting off) that also carries `hx-post`/`hx-target`/`hx-swap="outerHTML"` to swap the thread in place. Thread `.csrf_token(...)` and `.return_to(path)` for the no-JS round trip, `.max_depth(n)` so the UI never offers a reply the write path would `422`, `.read_only(Some(prompt))` for a signed-out visitor |
 | `autumn_web::ui::WIDGETS_CSS` / `WIDGETS_CSS_PATH` | One shipped stylesheet backing every `autumn-*` widget class — link `href=(WIDGETS_CSS_PATH)` instead of copying widget CSS into `input.css`. Accent now follows `var(--primary)` (violet), not the old hardcoded indigo (`docs/guide/widget-styling.md`) |
 
-### Whole-form rendering — `form_for` (unreleased — trunk-dev, not in published 0.5.0)
+### Whole-form rendering — `form_for` (0.7.0)
 
 `#[model]` derives `autumn_web::form::FormModel` (one `FormField` per
 `NewX`-editable column: humanized label, type-appropriate `FieldControl`,
@@ -1415,8 +1413,7 @@ RFC 3339 JSON bodies). Serde-renamed columns pre-fill correctly via
 keeps per-field htmx emission).
 
 For **master-detail** (has-many) forms saved atomically — an order plus its
-line items in one submit — use `autumn_web::nested_form` (unreleased —
-trunk-dev, #1915) instead of hand-wiring indexed field names: implement
+line items in one submit — use `autumn_web::nested_form` (0.7.0, #1915) instead of hand-wiring indexed field names: implement
 `NestedChild` on the child new-model, render the child rows with
 `inputs_for(&nested, &InputsForOptions, |row| …)` (add/remove rows + a
 `destroy_checkbox` for deletes) off a `NestedChangesetForm<Parent, Child>`, and
@@ -1424,7 +1421,7 @@ decode the flat submission back into parent + children with
 `decode_nested_urlencoded`, so the parent and its children validate and persist
 as one transaction.
 
-## Resumable SSE streams (unreleased — trunk-dev, issue #1356)
+## Resumable SSE streams (0.7.0, issue #1356)
 
 Don't hand-roll `Last-Event-ID` bookkeeping or a manual replay buffer for
 server-sent events. On trunk-dev the `ws`-gated channels backend keeps a
@@ -1527,7 +1524,7 @@ Use `AUTUMN_SECTION__FIELD` for env overrides, for example
 `AUTUMN_SECURITY__SIGNING_SECRET`, and
 `AUTUMN_SECURITY__WEBHOOKS__REPLAY__BACKEND`.
 
-### Process roles — web/worker split (unreleased — trunk-dev)
+### Process roles — web/worker split (0.7.0)
 
 Scale HTTP and background work independently by giving a process a **role** (no
 app-code change) via `role = "web"|"worker"|"combined"` in config or the
@@ -1546,7 +1543,7 @@ app-code change) via `role = "web"|"worker"|"combined"` in config or the
   generated **docker-compose** output and sets the web-tier role on the `app`
   service (#1613). See `docs/guide/cloud-native.md`.
 
-### Per-queue worker pools, pinning & `ProcessRole` on `AppState` (unreleased — trunk-dev)
+### Per-queue worker pools, pinning & `ProcessRole` on `AppState` (0.7.0)
 
 Carve the per-process worker pool up per queue and dedicate a worker tier to a
 subset of queues — all config-only, no app-code change:
@@ -1566,7 +1563,7 @@ subset of queues — all config-only, no app-code change:
 - **Per-queue actuator gauges** — `<actuator-prefix>/jobs` adds a `queues` key
   with per-queue `depth` and `oldest_waiting_age_ms` alongside the existing
   per-job-type gauges (per-process approximations on multi-process backends).
-- **Backend-derived queue gauges (unreleased — trunk-dev, issue #1752)** — on
+- **Backend-derived queue gauges (0.7.0, issue #1752)** — on
   the durable backends (Postgres/Redis) those `queues` gauges and the
   per-job-type `queued` counter are no longer per-process approximations: a
   periodic survey of the durable store (Redis every 2s, the interval doubling as
@@ -1581,7 +1578,7 @@ subset of queues — all config-only, no app-code change:
   self-gate to the right tier instead of re-reading `AUTUMN_ROLE` (issue #1726).
   See `docs/guide/jobs.md`.
 
-## Operator alerts (unreleased — trunk-dev, issue #1610)
+## Operator alerts (0.7.0, issue #1610)
 
 Connect Autumn's built-in failure signals to email + a signed webhook with **no
 app code** — configure a destination under `[alerts]` and every built-in
@@ -1607,7 +1604,7 @@ to look" actuator pointer:
 - **Scheduled-task failure** — a `#[scheduled]`/framework task returns an error.
   A failed `autumn db backup` offsite upload also raises this condition,
   delivered via the outbound-HTTP alert channels only (not email)
-  **(unreleased — trunk-dev, issue #1743)**.
+  **(0.7.0, issue #1743)**.
 
 Delivery is best-effort and off the request path (background tick every
 `eval_interval_secs`, default 30), reuses your existing mailer + outbound-webhook
@@ -1619,7 +1616,7 @@ Slack, …) by implementing `AlertChannel` and registering it with
 missing or unusable destination — see the `doctor` skill. See
 `docs/guide/operator-alerts.md`.
 
-### Native transports (unreleased — trunk-dev, issue #1630)
+### Native transports (0.7.0, issue #1630)
 
 PagerDuty, Slack, and Discord now ship as built-in `AlertChannel`s — no code,
 just `[alerts]` keys (each with an `AUTUMN_ALERTS__*` env override):
@@ -1660,7 +1657,7 @@ discord_severities = "all"
 
 ## Observability defaults
 
-Published 0.5.0 behavior:
+Published 0.7.0 behavior:
 
 - Structured per-request access log is **on by default**; disable with
   `log.access_log = false`, tune exclusions with `log.access_log_exclude`
@@ -1671,7 +1668,7 @@ Published 0.5.0 behavior:
 - `actuator.prometheus` exposes the Prometheus scrape endpoint independently
   of sensitive actuator mode.
 
-### Runtime log levels (unreleased — trunk-dev)
+### Runtime log levels (0.7.0)
 
 `PUT /actuator/loggers/{name}` now changes the **live** `tracing` subscriber,
 not just an in-memory map — raise/lower verbosity in production without a
@@ -1694,7 +1691,7 @@ Overrides stay ephemeral — a restart resets to the configured `log.level`.
 Invalid levels still return `400`. `GET /actuator/loggers` keeps reporting
 `current_level` + overrides, now matching real emission.
 
-### Build & git provenance on `/actuator/info` (unreleased — trunk-dev)
+### Build & git provenance on `/actuator/info` (0.7.0)
 
 `GET /actuator/info` now reports which commit/build is running, for
 deploy/rollback verification. Apps scaffolded by `autumn new` get this with
@@ -1707,7 +1704,7 @@ in a `--release` binary with the cargo env unset at runtime. Sample payload:
 ```json
 {
   "app":     { "name": "my_app", "version": "1.4.2" },
-  "autumn":  { "version": "0.6.0", "profile": "prod" },
+  "autumn":  { "version": "0.7.0", "profile": "prod" },
   "runtime": { "uptime": "3h 12m" },
   "build": {
     "version": "1.4.2",
@@ -1731,7 +1728,7 @@ and using `#[autumn_web::main]`.
 **Known limitation:** apps built from the scaffolded Dockerfile currently report
 null git provenance because the Docker build context excludes `.git` (tracked in
 #1676).
-Unreleased (trunk-dev) — `Server-Timing` response header:
+0.7.0 — `Server-Timing` response header:
 
 - Opt-in via `[observability] server_timing = true` (or
   `AUTUMN_OBSERVABILITY__SERVER_TIMING=true`). Defaults **on in `dev` /
@@ -1751,7 +1748,7 @@ Unreleased (trunk-dev) — `Server-Timing` response header:
 - Doc + browser DevTools walk-through:
   `docs/guide/observability/server-timing.md`.
 
-## Resilience: load shedding (unreleased — trunk-dev)
+## Resilience: load shedding (0.7.0)
 
 Admission control caps concurrent in-flight requests; excess is shed
 immediately with `503` + `Retry-After` before the handler runs. Disabled by
@@ -1766,7 +1763,7 @@ Probes (`/health`, `/live`, `/ready`, `/startup`, actuator) are never shed;
 sheds increment `autumn_requests_shed_total`. See `docs/guide/resilience.md`
 and `docs/adr/0009-adopt-overload-protection-load-shedding.md`.
 
-## Sharding (unreleased — trunk-dev, not in published 0.5.0)
+## Sharding (0.7.0)
 
 Framework-native horizontal sharding: declare `[[database.shards]]` (each a
 full primary/replica topology), route by key → logical slot → shard. Prelude
@@ -1780,7 +1777,7 @@ bounded `each_shard` fan-out); install custom routing with
 There are no cross-shard queries or transactions by design. See
 `docs/guide/sharding.md` and `examples/bookmarks-sharded`.
 
-## Per-tenant memory cells (unreleased — trunk-dev, issue #1766)
+## Per-tenant memory cells (0.7.0, issue #1766)
 
 Row-level tenancy scopes a tenant's *rows*; per-tenant memory cells bound a
 tenant's *in-process memory*. Each resolved tenant gets a `TenantCell` — a
@@ -1897,7 +1894,7 @@ across restarts — clear it with `autumn canary promote` once traffic has moved
 ## CLI
 
 ```bash
-cargo install autumn-cli --version 0.5.0
+cargo install autumn-cli --version 0.7.0
 
 autumn new my-app
 autumn setup
@@ -1930,7 +1927,7 @@ autumn dev-loop-bench --dry-run
 autumn plugin-check --plugin-name autumn-admin-plugin --prefix /admin
 ```
 
-**(unreleased)** trunk-dev-only CLI additions — NOT in the published 0.5.0
+**(0.7.0)** CLI additions — NOT in 0.6.x or earlier
 `autumn-cli`; do not suggest them to users on the published release:
 
 ```bash
@@ -1946,7 +1943,7 @@ autumn i18n check                # compare t!/t(...) keys vs i18n/*.ftl; --stric
 autumn test                      # provision/target an isolated *_test DB, migrate, then cargo test
 autumn test --reset -- --nocapture   # drop+recreate the test DB; forward args to the harness
 autumn db backup --keep 7        # dump control DB + shards to ./backups/<profile>/<ts>/; db restore <artifact> reverses it
-autumn db backup --upload --keep 7   # + upload each verified run offsite (S3/MinIO/R2); db offsite list; db restore offsite:<profile>/latest  # (unreleased — trunk-dev)
+autumn db backup --upload --keep 7   # + upload each verified run offsite (S3/MinIO/R2); db offsite list; db restore offsite:<profile>/latest  # (0.7.0)
 autumn seed --count 50 --model Post  # generate+insert 50 faked rows via the model's factory (both flags together)
 autumn serve --role worker       # run only workers + scheduler (web/worker split); also --role web|combined
 autumn console                   # data playground: scaffolds src/bin/playground.rs (pre-wired config+pool), then builds and runs it; alias `autumn c`
@@ -1967,7 +1964,7 @@ autumn deploy status --json --strict          # read-only per-host state + versi
 autumn deploy maintenance on --message "…"    # maintenance mode on EVERY deploy host over SSH; `off` reverses (#1621)
 ```
 
-### Upgrading an app across releases — `autumn upgrade` (unreleased — trunk-dev, issue #1629)
+### Upgrading an app across releases — `autumn upgrade` (0.7.0, issue #1629)
 
 **Reach for this before hand-editing call sites out of a migration guide.**
 For each release between the `autumn-web` version the app's `Cargo.toml`
@@ -2075,7 +2072,7 @@ legacy migrations applied before the checksum feature existed; use
 `autumn migrate baseline --force <version>` only when a deliberate edit
 is intended and the fork risk is accepted.
 
-### `autumn test` — isolated test DB (unreleased — trunk-dev, issue #1056)
+### `autumn test` — isolated test DB (0.7.0, issue #1056)
 
 `autumn test` resolves the test DB URL with the same precedence as
 `autumn migrate` (`AUTUMN_DATABASE__PRIMARY_URL` → `AUTUMN_DATABASE__URL` →
@@ -2086,7 +2083,7 @@ migrations, exports `AUTUMN_ENV=test` + the resolved `DATABASE_URL`, then runs
 first; trailing `-- <args>` forward to the harness. It refuses to run against a
 non-`_test` database.
 
-### `autumn db backup` / `db restore` (unreleased — trunk-dev, issue #1595)
+### `autumn db backup` / `db restore` (0.7.0, issue #1595)
 
 `autumn db backup [--dir DIR] [--format custom|plain] [--keep N] [--shard NAME]
 [--control-only]` dumps the control DB and every shard to
@@ -2098,7 +2095,7 @@ prunes to the newest N runs. `autumn db restore <ARTIFACT> [--shard NAME]
 same production guard as `db drop` (refuses non-dev/test without `--force`). See
 `docs/guide/deployment.md`.
 
-### Offsite S3 backups (unreleased — trunk-dev, issue #1619)
+### Offsite S3 backups (0.7.0, issue #1619)
 
 `autumn db backup --upload` (or `[backup.offsite] auto_upload = true`) uploads
 each completed local run to an S3-compatible offsite destination (AWS S3,
@@ -2150,7 +2147,7 @@ Pointing the offsite bucket at the app's
 own `[storage.s3]` bucket at the same endpoint needs `allow_shared_bucket = true`. See
 `docs/guide/daemon.md`.
 
-### VPS deploys and fleets — `autumn deploy` (unreleased — trunk-dev, issues #1607/#1621)
+### VPS deploys and fleets — `autumn deploy` (0.7.0, issues #1607/#1621)
 
 `autumn deploy {check | plan | up | rollback | status | maintenance on|off}`
 takes a project to a live, zero-downtime service on Linux servers the user owns
@@ -2334,7 +2331,7 @@ Chromium, and hands back a `Page` with htmx-aware auto-waiting assertions. Add
 let runner = SystemTest::new()
     .routes(routes![index, create_todo])
     .state(state)                                       // real pool/policies
-    .layer(axum::middleware::from_fn(scope_to_tenant))  // unreleased
+    .layer(axum::middleware::from_fn(scope_to_tenant))  // 0.7.0
     .build().await.unwrap();
 
 let page = runner.page().await.unwrap();
@@ -2344,7 +2341,7 @@ page.expect_text("Saved").await?;
 page.expect_no_console_errors().await?;
 ```
 
-- `.layer(...)` (**unreleased**) takes the same layers as `AppBuilder::layer`
+- `.layer(...)` (**0.7.0**) takes the same layers as `AppBuilder::layer`
   and puts them in the same stack position, so middleware that reads the
   request ID or session behaves as in production. Use it whenever the routes
   under test need global middleware — mapping layers onto individual handlers
@@ -2360,10 +2357,10 @@ page.expect_no_console_errors().await?;
 Full API: `skills/autumn-web/references/api-reference.md`; guide:
 `docs/guide/system-tests.md`.
 
-## 0.5.0 release traps
+## 0.7.0 release traps
 
 - `AUTUMN_SECURITY__SIGNING_SECRET` is required in `prod` / `production`.
-- Use `autumn-storage-s3 = "0.5"` and `autumn-cache-redis = "0.5"`; these
+- Use `autumn-storage-s3 = "0.7"` and `autumn-cache-redis = "0.7"`; these
   are companion crates, not `autumn-web` feature names.
 - Repository-generated APIs require a policy in production unless
   `security.allow_unauthorized_repository_api = true` is explicit.
@@ -2387,7 +2384,7 @@ Full API: `skills/autumn-web/references/api-reference.md`; guide:
 ## Release and PR workflow
 
 - Base branch is `trunk-dev`, not `trunk`.
-- Release tag for this line is `v0.5.0`.
+- Release tag for this line is `v0.7.0`.
 - Published crates are released together at the same workspace version:
   `autumn-macros`, `autumn-web`, `autumn-cli`, `autumn-admin-plugin`,
   `autumn-storage-s3`, `autumn-cache-redis`, and `autumn-search`.

--- a/skills/autumn-web/SKILL.md
+++ b/skills/autumn-web/SKILL.md
@@ -338,7 +338,7 @@ the lower-level `localized_path(path, locale)`) from
 default_locale, supported_locales))` to emit `hreflang` `<link>` tags for the
 current page's localized variants.
 
-**Duplicate-route preflight (issue #1012, 0.7.0):** two
+**Duplicate-route preflight (issue #1012, 0.6.0):** two
 handlers that resolve to the same `(method, path)` after `.scoped(...)` prefix
 resolution — including `#[repository]`-generated API routes — fail app build
 with `RouterBuildError::DuplicateUserRoute { method, path, existing, incoming }`

--- a/skills/autumn-web/SKILL.md
+++ b/skills/autumn-web/SKILL.md
@@ -68,7 +68,7 @@ the framework almost certainly already generates or ships it:
 | Raw Diesel queries for CRUD, lookups, pagination, or bulk writes | `#[repository]`-generated methods: `find_by_id`, `find_all`, `save`, `update`, `delete_by_id`, derived `find_by_*`, `page(&PageRequest)`, `cursor_page(&CursorRequest)`, bulk `save_many`/`update_many`/`delete_many`/`upsert_many`. See `docs/guide/repositories.md`, `docs/guide/pagination.md` |
 | Manual per-item queries in a loop (N+1) or hand-written JOINs to fetch associations | `#[belongs_to]`/`#[has_many]`/`#[has_one]` + `repo.preload(records, Model::preload()...)` (0.6.0) |
 | Hand-rolled auth, session, or token checks in handler bodies | `#[secured]` / `#[secured("role")]`, `#[authorize]`, repository `policy =`/`scope =`; `#[secured(scopes = [...])]` for service tokens (0.6.0) |
-| A punishingly low global rate limit to protect one abuse-prone endpoint (login, search, export) | `#[throttle(limit = 5, per = "1m", key = "ip")]` sits alongside `#[get]`/`#[post]`; `#[throttle("login")]` reads `[security.rate_limit.named.login]` from config (0.7.0, issue #1350, see `docs/guide/rate-limiting.md`) |
+| A punishingly low global rate limit to protect one abuse-prone endpoint (login, search, export) | `#[throttle(limit = 5, per = "1m", key = "ip")]` sits alongside `#[get]`/`#[post]`; `#[throttle("login")]` reads `[security.rate_limit.named.login]` from config (0.6.0, issue #1350, see `docs/guide/rate-limiting.md`) |
 | Hand-assembled `<form>` markup with manual value re-fill and error display | `autumn_web::form::form_for(&changeset, action, method)` + the `#[model]`-derived `FormModel` (0.6.0) renders the whole form — CSRF, `_method` override, one pre-filled control per column, inline errors, submit — in one call; see "Whole-form rendering" below. Compose the per-field helpers only when its escape hatches don't fit: `form_tag`, `method_input`, `text_input` (published); `number_input`, `datetime_input`, `date_input`, `checkbox_input`, `select_input` + `Changeset` 422 re-render (0.6.0) |
 | `find_all()` + a loop (or raw Diesel `LIMIT`/`OFFSET` paging) to sweep a whole table in a task/job/backfill | `repo.find_in_batches(n)` / `repo.find_each(n)` (0.6.0) — bounded-memory primary-key keyset iteration. See "Generated repository surface" below and `docs/guide/pagination.md` |
 | Ad-hoc `tokio::spawn` / background threads for deferred work | `#[job]` (+ retries, backends, uniqueness/concurrency caps), `#[scheduled]` for recurring, `#[task]` for operator CLI work |
@@ -85,7 +85,7 @@ the framework almost certainly already generates or ships it:
 | Hand-written RSS/Atom XML strings for a `/feed.xml` or podcast/blog feed | `feed::Feed::atom(..)` / `feed::Feed::rss(..)` + `feed::FeedEntry` — builds the XML, implements `IntoResponse` with the right `application/atom+xml`/`application/rss+xml` type, XML-escapes text, and `Feed::conditional(&headers)` reuses the `etag` layer for `304`s (0.6.0). See `docs/guide/conditional-get.md` |
 | A hand-rolled `AtomicU64` + a `MetricsSource` impl (or a whole second `prometheus`/`metrics` crate exporter) just to count something in a handler | `autumn_web::metrics` — `metrics::counter("checkout_completed_total").with_label("status", "paid").increment(1)`, plus `gauge`, `histogram` and `timer(..).start()` (a guard that records on drop, so early `?` returns and panics are covered) / `time` / `time_async`. Registers itself on first use and lands on the stock `/actuator/prometheus` and `/actuator/metrics` (`app` key) with zero `AppBuilder` wiring; caps cardinality (100 *labeled* series/instrument) instead of leaking series (0.7.0, issue #1378). `describe_*` and `set_histogram_buckets` do not register anything, so startup calls work in either order; gauges and histograms take `usize`/`u64`/`i64` directly (`set(queue.len())`). `MetricsSource` is still the answer when a subsystem already owns the numbers. See `docs/guide/metrics.md` |
 | Reproducing a production 500 by copying the request into a test and guessing at the database state it saw | `[failure_capture] enabled = true` writes a redacted **failure capsule** (request + PostgreSQL wire traffic + clock readings + outcome, one JSON file) for every caught panic/5xx; `autumn replay <capsule>` re-runs it offline against an in-process stub DB — exit 0 reproduced / 1 mismatch / 2 refused. Capsules are production data: read the security section of `docs/guide/failure-capsules.md` before enabling (0.7.0, #1598) |
-| Hand-assembled `Cache-Control` header strings on a handler | `etag::cache_for(Duration)` → `CacheControl`; attach as a tuple `(cache_for(dur).public(), html!{…})` or `.wrap(resp)`. Chain `public`/`private`, `max_age`, `s_maxage`, `stale_while_revalidate`, `no_store`, `no_cache`, `must_revalidate`, `immutable`; `header_value()` renders a deterministic value. Defaults to `private` (a secured page can't be silently made public); composes with `fresh_when` — the directives ride the `200` and the preserved `304` (0.7.0, issue #1344). See `docs/guide/conditional-get.md` |
+| Hand-assembled `Cache-Control` header strings on a handler | `etag::cache_for(Duration)` → `CacheControl`; attach as a tuple `(cache_for(dur).public(), html!{…})` or `.wrap(resp)`. Chain `public`/`private`, `max_age`, `s_maxage`, `stale_while_revalidate`, `no_store`, `no_cache`, `must_revalidate`, `immutable`; `header_value()` renders a deterministic value. Defaults to `private` (a secured page can't be silently made public); composes with `fresh_when` — the directives ride the `200` and the preserved `304` (0.6.0, issue #1344). See `docs/guide/conditional-get.md` |
 
 When none of these fit, dropping to raw Axum (`.merge()`/`.nest()`/`.layer()`)
 or raw Diesel (`&mut *db` with `diesel_async`) is supported and fine — but only
@@ -243,10 +243,10 @@ Use `.one_off_tasks(one_off_tasks![...])` for `#[task]` handlers invoked by
 | `.with_blob_store(store)` | Install a file storage backend |
 | `.with_cache_backend(cache)` | Install a cache backend |
 | `.with_mail_delivery_queue(queue)` | Install durable deferred mail |
-| `.with_mail_suppression_store(store)` | Install a durable bounce/complaint suppression backend (0.7.0; in-memory default auto-wired otherwise) |
+| `.with_mail_suppression_store(store)` | Install a durable bounce/complaint suppression backend (0.6.0; in-memory default auto-wired otherwise) |
 | `.with_audit_sink(sink)` | Install structured audit sink |
 | `.listeners(listeners![...])` | Register `#[listener]` event listeners (0.6.0) |
-| `.static_gate(layer)` | Middleware that also guards `#[static_get]` pre-render (0.7.0; `has_static_gate::<L>()`, `get_static_gate_types()`, `TestApp::static_gate` mirror it) |
+| `.static_gate(layer)` | Middleware that also guards `#[static_get]` pre-render (0.6.0; `has_static_gate::<L>()`, `get_static_gate_types()`, `TestApp::static_gate` mirror it) |
 | `.with_shard_router(router)` | Install a shard router for `[[database.shards]]` (0.6.0) |
 | `.run()` | Launch the server |
 
@@ -654,7 +654,7 @@ locks the parent, applies every declared action, then deletes the parent — all
 a single transaction (Part of #1369). See `docs/guide/repositories.md`.
 
 On trunk-dev the cascade is recursive and bulk-aware, and can be declared on
-the model instead of the repository **(0.7.0, issues #1738,
+the model instead of the repository **(0.6.0, issues #1738,
 #1739, #1740)**:
 
 - **Grandchildren cascade.** `destroy` now recurses — each destroyed child runs
@@ -793,7 +793,7 @@ create/update handlers validate the decoded payload before touching the DB:
   specialization (no migration burden), and this applies to plain and
   policy-backed handlers (#1237, #1253). See `docs/guide/pagination.md`.
 
-### Partial-update validation — the effective merged model (0.7.0, issue #1778)
+### Partial-update validation — the effective merged model (0.6.0, issue #1778)
 
 On a repository with `hooks = ...`, a `PATCH`/`PUT` update now validates the
 **effective merged model** — the existing row ∪ the patch, after normalization —
@@ -1414,7 +1414,7 @@ RFC 3339 JSON bodies). Serde-renamed columns pre-fill correctly via
 keeps per-field htmx emission).
 
 For **master-detail** (has-many) forms saved atomically — an order plus its
-line items in one submit — use `autumn_web::nested_form` (0.7.0, #1915) instead of hand-wiring indexed field names: implement
+line items in one submit — use `autumn_web::nested_form` (0.6.0, #1915) instead of hand-wiring indexed field names: implement
 `NestedChild` on the child new-model, render the child rows with
 `inputs_for(&nested, &InputsForOptions, |row| …)` (add/remove rows + a
 `destroy_checkbox` for deletes) off a `NestedChangesetForm<Parent, Child>`, and
@@ -1422,7 +1422,7 @@ decode the flat submission back into parent + children with
 `decode_nested_urlencoded`, so the parent and its children validate and persist
 as one transaction.
 
-## Resumable SSE streams (0.7.0, issue #1356)
+## Resumable SSE streams (0.6.0, issue #1356)
 
 Don't hand-roll `Last-Event-ID` bookkeeping or a manual replay buffer for
 server-sent events. On trunk-dev the `ws`-gated channels backend keeps a
@@ -1564,7 +1564,7 @@ subset of queues — all config-only, no app-code change:
 - **Per-queue actuator gauges** — `<actuator-prefix>/jobs` adds a `queues` key
   with per-queue `depth` and `oldest_waiting_age_ms` alongside the existing
   per-job-type gauges (per-process approximations on multi-process backends).
-- **Backend-derived queue gauges (0.7.0, issue #1752)** — on
+- **Backend-derived queue gauges (0.6.0, issue #1752)** — on
   the durable backends (Postgres/Redis) those `queues` gauges and the
   per-job-type `queued` counter are no longer per-process approximations: a
   periodic survey of the durable store (Redis every 2s, the interval doubling as
@@ -1579,7 +1579,7 @@ subset of queues — all config-only, no app-code change:
   self-gate to the right tier instead of re-reading `AUTUMN_ROLE` (issue #1726).
   See `docs/guide/jobs.md`.
 
-## Operator alerts (0.7.0, issue #1610)
+## Operator alerts (0.6.0, issue #1610)
 
 Connect Autumn's built-in failure signals to email + a signed webhook with **no
 app code** — configure a destination under `[alerts]` and every built-in
@@ -1605,7 +1605,7 @@ to look" actuator pointer:
 - **Scheduled-task failure** — a `#[scheduled]`/framework task returns an error.
   A failed `autumn db backup` offsite upload also raises this condition,
   delivered via the outbound-HTTP alert channels only (not email)
-  **(0.7.0, issue #1743)**.
+  **(0.6.0, issue #1743)**.
 
 Delivery is best-effort and off the request path (background tick every
 `eval_interval_secs`, default 30), reuses your existing mailer + outbound-webhook
@@ -1617,7 +1617,7 @@ Slack, …) by implementing `AlertChannel` and registering it with
 missing or unusable destination — see the `doctor` skill. See
 `docs/guide/operator-alerts.md`.
 
-### Native transports (0.7.0, issue #1630)
+### Native transports (0.6.0, issue #1630)
 
 PagerDuty, Slack, and Discord now ship as built-in `AlertChannel`s — no code,
 just `[alerts]` keys (each with an `AUTUMN_ALERTS__*` env override):
@@ -1778,7 +1778,7 @@ bounded `each_shard` fan-out); install custom routing with
 There are no cross-shard queries or transactions by design. See
 `docs/guide/sharding.md` and `examples/bookmarks-sharded`.
 
-## Per-tenant memory cells (0.7.0, issue #1766)
+## Per-tenant memory cells (0.6.0, issue #1766)
 
 Row-level tenancy scopes a tenant's *rows*; per-tenant memory cells bound a
 tenant's *in-process memory*. Each resolved tenant gets a `TenantCell` — a
@@ -2073,7 +2073,7 @@ legacy migrations applied before the checksum feature existed; use
 `autumn migrate baseline --force <version>` only when a deliberate edit
 is intended and the fork risk is accepted.
 
-### `autumn test` — isolated test DB (0.7.0, issue #1056)
+### `autumn test` — isolated test DB (0.6.0, issue #1056)
 
 `autumn test` resolves the test DB URL with the same precedence as
 `autumn migrate` (`AUTUMN_DATABASE__PRIMARY_URL` → `AUTUMN_DATABASE__URL` →
@@ -2084,7 +2084,7 @@ migrations, exports `AUTUMN_ENV=test` + the resolved `DATABASE_URL`, then runs
 first; trailing `-- <args>` forward to the harness. It refuses to run against a
 non-`_test` database.
 
-### `autumn db backup` / `db restore` (0.7.0, issue #1595)
+### `autumn db backup` / `db restore` (0.6.0, issue #1595)
 
 `autumn db backup [--dir DIR] [--format custom|plain] [--keep N] [--shard NAME]
 [--control-only]` dumps the control DB and every shard to
@@ -2096,7 +2096,7 @@ prunes to the newest N runs. `autumn db restore <ARTIFACT> [--shard NAME]
 same production guard as `db drop` (refuses non-dev/test without `--force`). See
 `docs/guide/deployment.md`.
 
-### Offsite S3 backups (0.7.0, issue #1619)
+### Offsite S3 backups (0.6.0, issue #1619)
 
 `autumn db backup --upload` (or `[backup.offsite] auto_upload = true`) uploads
 each completed local run to an S3-compatible offsite destination (AWS S3,
@@ -2148,7 +2148,7 @@ Pointing the offsite bucket at the app's
 own `[storage.s3]` bucket at the same endpoint needs `allow_shared_bucket = true`. See
 `docs/guide/daemon.md`.
 
-### VPS deploys and fleets — `autumn deploy` (0.7.0, issues #1607/#1621)
+### VPS deploys and fleets — `autumn deploy` (0.6.0; fleets 0.7.0, issues #1607/#1621)
 
 `autumn deploy {check | plan | up | rollback | status | maintenance on|off}`
 takes a project to a live, zero-downtime service on Linux servers the user owns

--- a/skills/autumn-web/SKILL.md
+++ b/skills/autumn-web/SKILL.md
@@ -50,7 +50,7 @@ when their details matter:
   `.aria_required()`, `.aria_invalid()`, `.described_by()`, per-type
   min/max/length) plus a `.hx(name, value)` escape hatch for arbitrary `hx-*`
   attributes. Treat `autumn a11y verify` as an advisory/best-effort CI net, not
-  a guarantee — the typed primitives are the compile-time proof (trunk-dev,
+  a guarantee — the typed primitives are the compile-time proof (0.6.0,
   #1706). See `skills/autumn-web/references/api-reference.md` for the full
   setter surface.
 
@@ -644,8 +644,8 @@ child cleanup **(0.6.0)**:
 pub trait PostRepository {}
 ```
 
-`on_delete` = `destroy` (soft-delete-aware, fires each child's hooks; on
-trunk-dev this **now recurses** into each child's own `dependent`, cascading
+`on_delete` = `destroy` (soft-delete-aware, fires each child's hooks; since
+0.6.0 this **recurses** into each child's own `dependent`, cascading
 into grandchildren — see the recursive/bulk/model-side note below) |
 `delete_all` (bulk delete, no child hooks) | `nullify` (set the FK null) |
 `restrict` (probe for referencing rows *before* mutating; errors `cannot delete:
@@ -653,7 +653,7 @@ dependent N row(s) …` if any still exist). The generated `delete_by_id` loads 
 locks the parent, applies every declared action, then deletes the parent — all in
 a single transaction (Part of #1369). See `docs/guide/repositories.md`.
 
-On trunk-dev the cascade is recursive and bulk-aware, and can be declared on
+Since 0.6.0 the cascade is recursive and bulk-aware, and can be declared on
 the model instead of the repository **(0.6.0, issues #1738,
 #1739, #1740)**:
 
@@ -818,8 +818,8 @@ validators (follow-up: issue #1801). The `Patch<T>` per-field impls and the
 
 ### Transactions
 
-`Db::tx(f)` runs a READ COMMITTED transaction. On trunk-dev
-**(0.6.0)**, `Db::tx_with(opts, f)` adds isolation levels and automatic
+`Db::tx(f)` runs a READ COMMITTED transaction. Since
+**0.6.0**, `Db::tx_with(opts, f)` adds isolation levels and automatic
 retry of serialization failures (SQLSTATE 40001) with capped exponential
 backoff:
 
@@ -870,15 +870,15 @@ async fn update_post(Path(id): Path<i64>, mut db: Db, session: Session) -> Autum
 }
 ```
 
-**(0.6.0)** Scoped service tokens (trunk-dev only): mint named,
+**(0.6.0)** Scoped service tokens: mint named,
 optionally-expiring API tokens carrying flat scopes via `IssueTokenSpec` +
 `issue_scoped_api_token`; gate handlers with
 `#[secured(scopes = ["posts:write"])]` (no session required — default-deny,
 403 when missing) or `#[secured("admin", scopes = [...])]` for both; check in
 policies with `PolicyContext::has_scope/has_any_scope/has_all_scopes`; manage
 with `autumn token issue <principal> --name ... --scope ...` / `list` /
-`rotate`. The
-published 0.7.0 `autumn token` has only `issue <principal>` / `revoke`.
+`rotate` / `revoke` — all four ship in 0.7.0. `list` and `rotate` arrived in
+0.6.0; a 0.5.x CLI has only `issue` / `revoke`.
 
 Active session management ships with `autumn generate auth` (0.6.0):
 a `{user}_sessions` row per login, generated `sessions()`,
@@ -1187,7 +1187,7 @@ Job attributes beyond `name`/`max_attempts`/`backoff_ms` (0.6.0):
 `concurrency = N` + `concurrency_key = "field"` caps simultaneous runs. A
 coalesced enqueue is a no-op `Ok(())`.
 
-**(0.6.0)** trunk-dev jobs additions:
+**(0.6.0)** jobs additions:
 
 - **Named queues**: `#[job(queue = "critical")]`; drain order via
   `[jobs] queues = ["critical", "default", "low"]` (strict priority) or a
@@ -1425,7 +1425,7 @@ as one transaction.
 ## Resumable SSE streams (0.6.0, issue #1356)
 
 Don't hand-roll `Last-Event-ID` bookkeeping or a manual replay buffer for
-server-sent events. On trunk-dev the `ws`-gated channels backend keeps a
+server-sent events. Since 0.6.0 the `ws`-gated channels backend keeps a
 **bounded per-topic replay ring buffer** and assigns every event an
 **epoch-tagged per-topic `id` automatically** (wire format `epoch.seq`, opaque
 to clients) — no manual `.id(...)` in handler code.
@@ -1658,7 +1658,7 @@ discord_severities = "all"
 
 ## Observability defaults
 
-Published 0.7.0 behavior:
+Published 0.5.0 behavior:
 
 - Structured per-request access log is **on by default**; disable with
   `log.access_log = false`, tune exclusions with `log.access_log_exclude`
@@ -1729,7 +1729,7 @@ and using `#[autumn_web::main]`.
 **Known limitation:** apps built from the scaffolded Dockerfile currently report
 null git provenance because the Docker build context excludes `.git` (tracked in
 #1676).
-0.7.0 — `Server-Timing` response header:
+0.6.0 — `Server-Timing` response header:
 
 - Opt-in via `[observability] server_timing = true` (or
   `AUTUMN_OBSERVABILITY__SERVER_TIMING=true`). Defaults **on in `dev` /
@@ -1928,8 +1928,9 @@ autumn dev-loop-bench --dry-run
 autumn plugin-check --plugin-name autumn-admin-plugin --prefix /admin
 ```
 
-**(0.6.0)** CLI additions — NOT in 0.6.x or earlier
-`autumn-cli`; do not suggest them to users on the published release:
+**(0.6.0)** CLI additions — absent from a 0.5.x `autumn-cli`, but present in
+every published release since 0.6.0, so they are safe to suggest unless the
+user pins 0.5.x:
 
 ```bash
 autumn serve --daemon            # non-watch local daemon; also: serve stop|status|restart

--- a/skills/autumn-web/SKILL.md
+++ b/skills/autumn-web/SKILL.md
@@ -880,7 +880,7 @@ with `autumn token issue <principal> --name ... --scope ...` / `list` /
 `rotate` / `revoke` — all four ship in 0.7.0. `list` and `rotate` arrived in
 0.6.0; a 0.5.x CLI has only `issue` / `revoke`.
 
-Active session management ships with `autumn generate auth` (0.6.0):
+Active session management ships with `autumn generate auth` (0.5.0):
 a `{user}_sessions` row per login, generated `sessions()`,
 `revoke_session(id)`, `revoke_other_sessions(...)`, `revoke_all_sessions()`
 methods, an `/account/sessions` Maud + htmx page, and `[auth.sessions]`
@@ -1181,7 +1181,7 @@ Use built-in jobs and tasks before reaching for a workflow engine:
 discarding, and canceling framework jobs. `GET /actuator/jobs` exposes
 lower-level counters.
 
-Job attributes beyond `name`/`max_attempts`/`backoff_ms` (0.6.0):
+Job attributes beyond `name`/`max_attempts`/`backoff_ms` (0.5.0):
 `#[job(unique)]` dedupes on an args hash, `unique_by = "field"`,
 `unique_window = "running"|"pending"`, `unique_for_ms = N` (debounce),
 `concurrency = N` + `concurrency_key = "field"` caps simultaneous runs. A

--- a/skills/autumn-web/SKILL.md
+++ b/skills/autumn-web/SKILL.md
@@ -16,10 +16,11 @@ description: >
 
 **Version identity trip wire**: the workspace on `trunk-dev` is versioned
 0.7.0, and `v0.7.0` is the current release line — `autumn-web = "0.7"`,
-`cargo install autumn-cli --version 0.7.0`. Features below marked **(0.7.0)**
-arrived in this release and are **absent from 0.6.x and earlier**: if an app
-pins an older line, check [`CHANGELOG.md`](../../CHANGELOG.md) before using
-them. Unmarked features predate 0.7.0. An app moving up from 0.6.x follows
+`cargo install autumn-cli --version 0.7.0`. Features below carry the release
+they arrived in — **(0.7.0)** is **absent from 0.6.x and earlier**, and
+**(0.6.0)** is absent from 0.5.x: if an app pins an older line, check
+[`CHANGELOG.md`](../../CHANGELOG.md) before using them. Unmarked features
+predate 0.6.0. An app moving up from 0.6.x follows
 [`docs/migrations/0.7.0.md`](../../docs/migrations/0.7.0.md); run
 `autumn upgrade` first.
 
@@ -65,23 +66,23 @@ the framework almost certainly already generates or ships it:
 | Status-transition validation written by hand in `before_create`/`before_update` hooks or handlers (`if old == "draft" && new == "published"` match blocks) | `#[state_machine(transitions(...))]` on the model field — generated `can_transition_{field}_to` / `transition_{field}_to` enforce the graph. See "Model state machines" below and `docs/guide/state-machines.md` |
 | Raw `axum::Router` routes and handlers, manual `.route("/x", get(...))` | `#[get]`/`#[post]`/`#[put]`/`#[patch]`/`#[delete]` + `routes![...]`, `.scoped(prefix, layer, routes)` for groups. `.merge()`/`.nest()` exist for the rare escape hatch only |
 | Raw Diesel queries for CRUD, lookups, pagination, or bulk writes | `#[repository]`-generated methods: `find_by_id`, `find_all`, `save`, `update`, `delete_by_id`, derived `find_by_*`, `page(&PageRequest)`, `cursor_page(&CursorRequest)`, bulk `save_many`/`update_many`/`delete_many`/`upsert_many`. See `docs/guide/repositories.md`, `docs/guide/pagination.md` |
-| Manual per-item queries in a loop (N+1) or hand-written JOINs to fetch associations | `#[belongs_to]`/`#[has_many]`/`#[has_one]` + `repo.preload(records, Model::preload()...)` (0.7.0) |
-| Hand-rolled auth, session, or token checks in handler bodies | `#[secured]` / `#[secured("role")]`, `#[authorize]`, repository `policy =`/`scope =`; `#[secured(scopes = [...])]` for service tokens (0.7.0) |
+| Manual per-item queries in a loop (N+1) or hand-written JOINs to fetch associations | `#[belongs_to]`/`#[has_many]`/`#[has_one]` + `repo.preload(records, Model::preload()...)` (0.6.0) |
+| Hand-rolled auth, session, or token checks in handler bodies | `#[secured]` / `#[secured("role")]`, `#[authorize]`, repository `policy =`/`scope =`; `#[secured(scopes = [...])]` for service tokens (0.6.0) |
 | A punishingly low global rate limit to protect one abuse-prone endpoint (login, search, export) | `#[throttle(limit = 5, per = "1m", key = "ip")]` sits alongside `#[get]`/`#[post]`; `#[throttle("login")]` reads `[security.rate_limit.named.login]` from config (0.7.0, issue #1350, see `docs/guide/rate-limiting.md`) |
-| Hand-assembled `<form>` markup with manual value re-fill and error display | `autumn_web::form::form_for(&changeset, action, method)` + the `#[model]`-derived `FormModel` (0.7.0) renders the whole form — CSRF, `_method` override, one pre-filled control per column, inline errors, submit — in one call; see "Whole-form rendering" below. Compose the per-field helpers only when its escape hatches don't fit: `form_tag`, `method_input`, `text_input` (published); `number_input`, `datetime_input`, `date_input`, `checkbox_input`, `select_input` + `Changeset` 422 re-render (0.7.0) |
-| `find_all()` + a loop (or raw Diesel `LIMIT`/`OFFSET` paging) to sweep a whole table in a task/job/backfill | `repo.find_in_batches(n)` / `repo.find_each(n)` (0.7.0) — bounded-memory primary-key keyset iteration. See "Generated repository surface" below and `docs/guide/pagination.md` |
+| Hand-assembled `<form>` markup with manual value re-fill and error display | `autumn_web::form::form_for(&changeset, action, method)` + the `#[model]`-derived `FormModel` (0.6.0) renders the whole form — CSRF, `_method` override, one pre-filled control per column, inline errors, submit — in one call; see "Whole-form rendering" below. Compose the per-field helpers only when its escape hatches don't fit: `form_tag`, `method_input`, `text_input` (published); `number_input`, `datetime_input`, `date_input`, `checkbox_input`, `select_input` + `Changeset` 422 re-render (0.6.0) |
+| `find_all()` + a loop (or raw Diesel `LIMIT`/`OFFSET` paging) to sweep a whole table in a task/job/backfill | `repo.find_in_batches(n)` / `repo.find_each(n)` (0.6.0) — bounded-memory primary-key keyset iteration. See "Generated repository surface" below and `docs/guide/pagination.md` |
 | Ad-hoc `tokio::spawn` / background threads for deferred work | `#[job]` (+ retries, backends, uniqueness/concurrency caps), `#[scheduled]` for recurring, `#[task]` for operator CLI work |
 | A hand-written `#[scheduled]` fn + batched `DELETE`/`UPDATE` to expire old sessions, drafts, or one-time codes | `#[repository(Model, retention(after = "30d", basis = created_at))]` (0.7.0, issue #1342) — batched, soft-delete-aware, fleet-coordinated sweep with zero SQL; `autumn retention --dry-run` to validate first. See `docs/guide/retention-sweeps.md` |
-| Hand-written memoization or cache-aside code | `#[cached]` on functions; `cache::get_or_compute` / `get_or_compute_with` for stampede-safe read-through fills (0.7.0) |
-| Hand-written transaction retry loops for serialization failures | `Db::tx(...)`; `Db::tx_with(TxOptions::serializable(), ...)` auto-retries 40001 (0.7.0) |
+| Hand-written memoization or cache-aside code | `#[cached]` on functions; `cache::get_or_compute` / `get_or_compute_with` for stampede-safe read-through fills (0.6.0) |
+| Hand-written transaction retry loops for serialization failures | `Db::tx(...)`; `Db::tx_with(TxOptions::serializable(), ...)` auto-retries 40001 (0.6.0) |
 | Hand-rolled HMAC verification for Stripe/GitHub/Slack callbacks | `SignedWebhook` extractor + `[webhooks.<name>]` config |
-| Hand-rolled pager markup (page-number windows, prev/next links) | `pagination_nav(&page, &PagerOptions::new("/posts"))` / `cursor_pagination_nav` (0.7.0) |
-| Hand-rolled cross-module notifications (calling every reaction inline) | `#[event]` + `#[listener]` typed event bus, `.listeners(listeners![...])` (0.7.0) |
-| Hand-rolled cards, tabs, modals, delete-confirm dialogs, method-override links | `autumn_web::widgets`: `card`/`stat_card`, `tabs`, `modal`/`confirm_action`, `link_to`/`button_to` + `ui::WIDGETS_CSS_PATH` stylesheet (0.7.0) |
-| Hand-built file-download responses (manual `Content-Disposition`/`Content-Type`/`Content-Length` headers, byte-buffered blob reads) | `autumn_web::download::Download` — `from_bytes` / `from_stream` / `from_async_read` / `from_blob(&store, key).await?` + `.filename(...)` / `.content_type(...)` / `.inline()`; RFC 5987 filenames, injection-safe, streams blobs without buffering (0.7.0) |
-| Hand-parsed `Range` headers / manual `206 Partial Content` / `Content-Range` / `416` for seekable media or resumable downloads | `autumn_web::range` (`resolve` + `partial_bytes_response`) and `Download::into_response_ranged(&headers).await` — RFC 7233 single-range parsing, multi-range single-range collapse, `If-Range` via `.etag(..)`/`.last_modified(..)`, blob slices via `BlobStore::get_range` (no whole-object buffering) (0.7.0) |
+| Hand-rolled pager markup (page-number windows, prev/next links) | `pagination_nav(&page, &PagerOptions::new("/posts"))` / `cursor_pagination_nav` (0.6.0) |
+| Hand-rolled cross-module notifications (calling every reaction inline) | `#[event]` + `#[listener]` typed event bus, `.listeners(listeners![...])` (0.6.0) |
+| Hand-rolled cards, tabs, modals, delete-confirm dialogs, method-override links | `autumn_web::widgets`: `card`/`stat_card`, `tabs`, `modal`/`confirm_action`, `link_to`/`button_to` + `ui::WIDGETS_CSS_PATH` stylesheet (0.6.0) |
+| Hand-built file-download responses (manual `Content-Disposition`/`Content-Type`/`Content-Length` headers, byte-buffered blob reads) | `autumn_web::download::Download` — `from_bytes` / `from_stream` / `from_async_read` / `from_blob(&store, key).await?` + `.filename(...)` / `.content_type(...)` / `.inline()`; RFC 5987 filenames, injection-safe, streams blobs without buffering (0.6.0) |
+| Hand-parsed `Range` headers / manual `206 Partial Content` / `Content-Range` / `416` for seekable media or resumable downloads | `autumn_web::range` (`resolve` + `partial_bytes_response`) and `Download::into_response_ranged(&headers).await` — RFC 7233 single-range parsing, multi-range single-range collapse, `If-Range` via `.etag(..)`/`.last_modified(..)`, blob slices via `BlobStore::get_range` (no whole-object buffering) (0.6.0) |
 | Shelling out to `wkhtmltopdf`/headless Chrome, or hand-rolling a PDF library, to turn a view into a downloadable invoice/receipt/report | `autumn_web::pdf::Pdf` (`pdf` Cargo feature) — `Pdf::from_markup(markup)` / `Pdf::from_html(html)` + `.filename(...)` / `.inline()`; renders headings/paragraphs/tables/lists/bold/italic with the PDF base-14 fonts, no system browser or embedded fonts required. Test with `TestResponse::assert_pdf_contains(&self, &str)`. See `docs/guide/pdf-downloads.md` (0.7.0) |
-| Hand-written RSS/Atom XML strings for a `/feed.xml` or podcast/blog feed | `feed::Feed::atom(..)` / `feed::Feed::rss(..)` + `feed::FeedEntry` — builds the XML, implements `IntoResponse` with the right `application/atom+xml`/`application/rss+xml` type, XML-escapes text, and `Feed::conditional(&headers)` reuses the `etag` layer for `304`s (0.7.0). See `docs/guide/conditional-get.md` |
+| Hand-written RSS/Atom XML strings for a `/feed.xml` or podcast/blog feed | `feed::Feed::atom(..)` / `feed::Feed::rss(..)` + `feed::FeedEntry` — builds the XML, implements `IntoResponse` with the right `application/atom+xml`/`application/rss+xml` type, XML-escapes text, and `Feed::conditional(&headers)` reuses the `etag` layer for `304`s (0.6.0). See `docs/guide/conditional-get.md` |
 | A hand-rolled `AtomicU64` + a `MetricsSource` impl (or a whole second `prometheus`/`metrics` crate exporter) just to count something in a handler | `autumn_web::metrics` — `metrics::counter("checkout_completed_total").with_label("status", "paid").increment(1)`, plus `gauge`, `histogram` and `timer(..).start()` (a guard that records on drop, so early `?` returns and panics are covered) / `time` / `time_async`. Registers itself on first use and lands on the stock `/actuator/prometheus` and `/actuator/metrics` (`app` key) with zero `AppBuilder` wiring; caps cardinality (100 *labeled* series/instrument) instead of leaking series (0.7.0, issue #1378). `describe_*` and `set_histogram_buckets` do not register anything, so startup calls work in either order; gauges and histograms take `usize`/`u64`/`i64` directly (`set(queue.len())`). `MetricsSource` is still the answer when a subsystem already owns the numbers. See `docs/guide/metrics.md` |
 | Reproducing a production 500 by copying the request into a test and guessing at the database state it saw | `[failure_capture] enabled = true` writes a redacted **failure capsule** (request + PostgreSQL wire traffic + clock readings + outcome, one JSON file) for every caught panic/5xx; `autumn replay <capsule>` re-runs it offline against an in-process stub DB — exit 0 reproduced / 1 mismatch / 2 refused. Capsules are production data: read the security section of `docs/guide/failure-capsules.md` before enabling (0.7.0, #1598) |
 | Hand-assembled `Cache-Control` header strings on a handler | `etag::cache_for(Duration)` → `CacheControl`; attach as a tuple `(cache_for(dur).public(), html!{…})` or `.wrap(resp)`. Chain `public`/`private`, `max_age`, `s_maxage`, `stale_while_revalidate`, `no_store`, `no_cache`, `must_revalidate`, `immutable`; `header_value()` renders a deterministic value. Defaults to `private` (a secured page can't be silently made public); composes with `fresh_when` — the directives ride the `200` and the preserved `304` (0.7.0, issue #1344). See `docs/guide/conditional-get.md` |
@@ -244,9 +245,9 @@ Use `.one_off_tasks(one_off_tasks![...])` for `#[task]` handlers invoked by
 | `.with_mail_delivery_queue(queue)` | Install durable deferred mail |
 | `.with_mail_suppression_store(store)` | Install a durable bounce/complaint suppression backend (0.7.0; in-memory default auto-wired otherwise) |
 | `.with_audit_sink(sink)` | Install structured audit sink |
-| `.listeners(listeners![...])` | Register `#[listener]` event listeners (0.7.0) |
+| `.listeners(listeners![...])` | Register `#[listener]` event listeners (0.6.0) |
 | `.static_gate(layer)` | Middleware that also guards `#[static_get]` pre-render (0.7.0; `has_static_gate::<L>()`, `get_static_gate_types()`, `TestApp::static_gate` mirror it) |
-| `.with_shard_router(router)` | Install a shard router for `[[database.shards]]` (0.7.0) |
+| `.with_shard_router(router)` | Install a shard router for `[[database.shards]]` (0.6.0) |
 | `.run()` | Launch the server |
 
 ## Route macros
@@ -419,7 +420,7 @@ pub trait PostRepository {}
 allow_unauthorized_repository_api = true # only when intentional
 ```
 
-### Associations and preloading (0.7.0)
+### Associations and preloading (0.6.0)
 
 Declare `#[belongs_to]` / `#[has_many]` / `#[has_one]` on a `#[model]` for
 batched eager loading — no N+1, no lazy loading (un-preloaded access returns
@@ -635,7 +636,7 @@ paths are **not** yet maintained: a derived `delete_by_<field>` and
 
 Deleting a parent can cascade to its children in one transaction — declare
 `dependent(...)` on the parent's `#[repository]` instead of hand-writing the
-child cleanup **(0.7.0)**:
+child cleanup **(0.6.0)**:
 
 ```rust
 #[autumn_web::repository(Post,
@@ -766,16 +767,16 @@ raw Diesel:
 | `primary_reads` (attr) / `on_primary()` | Pin reads to primary; read-your-writes after a save |
 | `soft_delete`, `tenant_scoped` (attrs), `across_tenants()` | Soft deletion and tenant scoping |
 | `hooks = MyHooks` (attr) | `before_/after_create/update/delete` + `after_*_commit` lifecycle hooks with `MutationContext` |
-| `from_shard(&ShardedDb)`, `with_pool_untracked(pool)` | **(0.7.0)** shard-scoped construction. `with_pool_untracked` is the 0.6.0 rename of `with_pool`; 0.5.x repositories had **no** pool constructor at all. An app carrying the older `with_pool` name is migrated by `autumn upgrade --apply` (codemod `0.6.0-repository-with-pool-untracked`, issue #1629) rather than by hand |
-| `find_in_batches(batch_size)`, `find_each(batch_size)` | **(0.7.0)** Bounded-memory whole-table iteration via a primary-key keyset cursor (`WHERE id > last ORDER BY id ASC LIMIT batch_size` — never `LIMIT`/`OFFSET`), generated on every repository. `find_in_batches` returns a `FindInBatches` handle — drive with `while let Some(chunk) = b.next_batch().await?`; `find_each` returns `FindEach` yielding one model per `next().await?`. Inherits soft-delete filtering, tenant scoping, and read routing like `find_all`; errors are retryable (cursor advances only on success; `Ok(None)` always means completion); `batch_size == 0` errors instead of spinning; `batch_size` is **not** clamped to `MAX_PAGE_SIZE`; sharded repos reject cross-shard `across_tenants()` iteration (iterate per shard via `from_shard`). Handle types: `autumn_web::batches::{FindInBatches, FindEach, BatchSource}` (not in the prelude). See "Batched iteration" in `docs/guide/pagination.md` |
-| `find_or_create_by_<field>[_and_<field>...](<field>, &new)` | **(0.7.0)** Race-safe get-or-insert; declare `fn find_or_create_by_slug(slug: String);` (lookup fields only) to generate an inherent `find_or_create_by_slug(&self, slug: String, new: &NewModel) -> AutumnResult<(Model, bool)>`. Reads on the read path first (tenant/soft-delete aware), else inserts on the primary with `ON CONFLICT DO NOTHING` — under concurrency exactly one row is created, exactly one caller sees `created == true`, and no `23505` escapes. `before_/after_create` + commit hooks fire only on the created path; works on hooked repos (unlike `upsert_many`). **Requires a unique constraint on the lookup column(s)** (`_or_` is rejected). See "Race-safe get-or-insert" in `docs/guide/repositories.md` |
+| `from_shard(&ShardedDb)`, `with_pool_untracked(pool)` | **(0.6.0)** shard-scoped construction. `with_pool_untracked` is the 0.6.0 rename of `with_pool`; 0.5.x repositories had **no** pool constructor at all. An app carrying the older `with_pool` name is migrated by `autumn upgrade --apply` (codemod `0.6.0-repository-with-pool-untracked`, issue #1629) rather than by hand |
+| `find_in_batches(batch_size)`, `find_each(batch_size)` | **(0.6.0)** Bounded-memory whole-table iteration via a primary-key keyset cursor (`WHERE id > last ORDER BY id ASC LIMIT batch_size` — never `LIMIT`/`OFFSET`), generated on every repository. `find_in_batches` returns a `FindInBatches` handle — drive with `while let Some(chunk) = b.next_batch().await?`; `find_each` returns `FindEach` yielding one model per `next().await?`. Inherits soft-delete filtering, tenant scoping, and read routing like `find_all`; errors are retryable (cursor advances only on success; `Ok(None)` always means completion); `batch_size == 0` errors instead of spinning; `batch_size` is **not** clamped to `MAX_PAGE_SIZE`; sharded repos reject cross-shard `across_tenants()` iteration (iterate per shard via `from_shard`). Handle types: `autumn_web::batches::{FindInBatches, FindEach, BatchSource}` (not in the prelude). See "Batched iteration" in `docs/guide/pagination.md` |
+| `find_or_create_by_<field>[_and_<field>...](<field>, &new)` | **(0.6.0)** Race-safe get-or-insert; declare `fn find_or_create_by_slug(slug: String);` (lookup fields only) to generate an inherent `find_or_create_by_slug(&self, slug: String, new: &NewModel) -> AutumnResult<(Model, bool)>`. Reads on the read path first (tenant/soft-delete aware), else inserts on the primary with `ON CONFLICT DO NOTHING` — under concurrency exactly one row is created, exactly one caller sees `created == true`, and no `23505` escapes. `before_/after_create` + commit hooks fire only on the created path; works on hooked repos (unlike `upsert_many`). **Requires a unique constraint on the lookup column(s)** (`_or_` is rejected). See "Race-safe get-or-insert" in `docs/guide/repositories.md` |
 | `retention(after = "30d", basis = created_at)` / `retention(purge_deleted_after = "90d")` (attr) | **(0.7.0)** Declarative data-retention: reach for this instead of hand-writing a `#[scheduled]` cleanup fn for expiring sessions, drafts, one-time codes, or other transient rows. Compiles to a batched (`batch_size`, default 500), cursor-paginated sweep auto-registered with fleet coordination — no `tasks![...]` entry needed. On a `soft_delete` repository, `after` soft-deletes (never re-touching an already-deleted row) and `purge_deleted_after` hard-purges (re-checking `deleted_at` at delete time so a concurrent `restore()` survives); without `soft_delete`, `after` hard-deletes. Sweeps run across **all** tenants on a `tenant_scoped` repository (no per-tenant opt-out) and are not supported on `sharded` repositories (compile error). `autumn retention --dry-run [--model NAME]` reports rows-that-would-be-swept without deleting. Emits `retention_sweep_rows_total` / `retention_sweep_duration_seconds` metrics + a structured log line per run. See `docs/guide/retention-sweeps.md` |
 
 Read routing: with `database.replica_url` set, all generated reads use the
 replica automatically; writes always hit the primary. See
 `docs/guide/repositories.md` and `docs/guide/pagination.md`.
 
-### JSON API endpoints — page envelope + write validation (0.7.0)
+### JSON API endpoints — page envelope + write validation (0.6.0)
 
 A `#[repository(api = "/api/posts")]` list endpoint returns a page envelope, and
 create/update handlers validate the decoded payload before touching the DB:
@@ -818,7 +819,7 @@ validators (follow-up: issue #1801). The `Patch<T>` per-field impls and the
 ### Transactions
 
 `Db::tx(f)` runs a READ COMMITTED transaction. On trunk-dev
-**(0.7.0)**, `Db::tx_with(opts, f)` adds isolation levels and automatic
+**(0.6.0)**, `Db::tx_with(opts, f)` adds isolation levels and automatic
 retry of serialization failures (SQLSTATE 40001) with capped exponential
 backoff:
 
@@ -869,7 +870,7 @@ async fn update_post(Path(id): Path<i64>, mut db: Db, session: Session) -> Autum
 }
 ```
 
-**(0.7.0)** Scoped service tokens (trunk-dev only): mint named,
+**(0.6.0)** Scoped service tokens (trunk-dev only): mint named,
 optionally-expiring API tokens carrying flat scopes via `IssueTokenSpec` +
 `issue_scoped_api_token`; gate handlers with
 `#[secured(scopes = ["posts:write"])]` (no session required — default-deny,
@@ -879,7 +880,7 @@ with `autumn token issue <principal> --name ... --scope ...` / `list` /
 `rotate`. The
 published 0.7.0 `autumn token` has only `issue <principal>` / `revoke`.
 
-Active session management ships with `autumn generate auth` (0.7.0):
+Active session management ships with `autumn generate auth` (0.6.0):
 a `{user}_sessions` row per login, generated `sessions()`,
 `revoke_session(id)`, `revoke_other_sessions(...)`, `revoke_all_sessions()`
 methods, an `/account/sessions` Maud + htmx page, and `[auth.sessions]`
@@ -917,7 +918,7 @@ the banner into the static file written to `dist/`. Bump the scaffolded
 banner. Strictly-necessary cookies (session, CSRF) are never routed through
 the gate.
 
-### Audit actor attribution (0.7.0)
+### Audit actor attribution (0.6.0)
 
 Version/audit writes are auto-attributed to the current actor — no per-call
 plumbing. The log-context middleware opens an empty actor scope per request; set
@@ -1002,7 +1003,7 @@ deliveries. Presets: `stripe`, `github`, `slack`, `generic`.
 
 Read `docs/guide/signed-webhooks.md` and `examples/signed-webhooks/`.
 
-## Mail CSS inlining — render styled in Gmail/Outlook (0.7.0)
+## Mail CSS inlining — render styled in Gmail/Outlook (0.6.0)
 
 Gmail strips `<style>` in many contexts and Outlook (Word engine) ignores
 `<head>`/`<style>` and most external CSS, so email authored with a stylesheet
@@ -1037,7 +1038,7 @@ time. Autumn does this for you (issue #1254).
 - `autumn generate mailer` scaffolds this end to end (a `<style>` template + a
   mailer that calls `.inline_css(true)`).
 
-## Mail suppression — stop emailing bounced addresses (0.7.0)
+## Mail suppression — stop emailing bounced addresses (0.6.0)
 
 Autumn *detects* delivery failure (inbound bounce/complaint webhooks) **and**
 acts on it: `Mailer::send()` consults a bounce/complaint suppression list
@@ -1180,13 +1181,13 @@ Use built-in jobs and tasks before reaching for a workflow engine:
 discarding, and canceling framework jobs. `GET /actuator/jobs` exposes
 lower-level counters.
 
-Job attributes beyond `name`/`max_attempts`/`backoff_ms` (0.7.0):
+Job attributes beyond `name`/`max_attempts`/`backoff_ms` (0.6.0):
 `#[job(unique)]` dedupes on an args hash, `unique_by = "field"`,
 `unique_window = "running"|"pending"`, `unique_for_ms = N` (debounce),
 `concurrency = N` + `concurrency_key = "field"` caps simultaneous runs. A
 coalesced enqueue is a no-op `Ok(())`.
 
-**(0.7.0)** trunk-dev jobs additions:
+**(0.6.0)** trunk-dev jobs additions:
 
 - **Named queues**: `#[job(queue = "critical")]`; drain order via
   `[jobs] queues = ["critical", "default", "low"]` (strict priority) or a
@@ -1208,7 +1209,7 @@ coalesced enqueue is a no-op `Ok(())`.
   `autumn_web::payload_version::{split_version, wrap}` (Closes #1205). See
   `docs/guide/jobs.md`.
 
-**(0.7.0)** Events & listeners — a typed domain event bus so one action
+**(0.6.0)** Events & listeners — a typed domain event bus so one action
 can fan out without inline coupling: `#[event]` on a struct, publish via the
 `Events` extractor (`events.publish(UserSignedUp { .. }).await?`), react with
 `#[listener(UserSignedUp)]` (sync, in-request) or
@@ -1216,7 +1217,7 @@ can fan out without inline coupling: `#[event]` on a struct, publish via the
 register with `.listeners(listeners![...])`. Do not also list durable
 listeners in `jobs![...]`. See `docs/guide/events.md`.
 
-## Distributed locks (0.7.0)
+## Distributed locks (0.6.0)
 
 For "run this exactly once across replicas right now" work (nightly cleanup,
 cache warming, one-shot backfills, "send the daily digest once"), use
@@ -1318,7 +1319,7 @@ autumn_web::app()
     .await;
 ```
 
-**(0.7.0)** Cache stampede protection — do not hand-roll cache-aside
+**(0.6.0)** Cache stampede protection — do not hand-roll cache-aside
 fills: `cache::get_or_compute(cache, key, Some(ttl), fill)` runs `fill` once
 per process for concurrent callers; `get_or_compute_with` +
 `GetOrComputeOptions::new().distributed_fill_lock(true)` (Redis lock) and
@@ -1327,7 +1328,7 @@ serve-stale; `cache::jittered_ttl(base, fraction)` de-synchronizes mass
 expiry. A failed fill never poisons the key. See
 `docs/guide/cache-stampede.md`.
 
-**(0.7.0)** Upload content-type validation — multipart uploads are
+**(0.6.0)** Upload content-type validation — multipart uploads are
 validated by **magic bytes**, not the spoofable client `Content-Type`. The
 `Multipart` extractor sniffs the real type (`sniff_content_type`) whenever an
 `allowed_content_types` allow-list is configured or strict mode is on. Reject
@@ -1341,7 +1342,7 @@ reject_on_content_type_mismatch = true  # declared-vs-sniffed mismatch (or an
 
 (env `AUTUMN_SECURITY__UPLOAD__REJECT_ON_CONTENT_TYPE_MISMATCH`) (#1354).
 
-## View helpers and widgets (0.7.0)
+## View helpers and widgets (0.6.0)
 
 Trunk-dev ships framework view widgets — prefer these over hand-rolled Maud
 for the common cases:
@@ -1365,7 +1366,7 @@ for the common cases:
 | `comment_thread(&cfg, &CommentView::from_thread(&nodes))` / `CommentThread::new(dom_id, action)` | The view half of `#[commentable]` (#1367): nested `<ol>` comment thread with a `<details>`-disclosed inline reply form on every node. Ordinary `<form method="post">` (works with scripting off) that also carries `hx-post`/`hx-target`/`hx-swap="outerHTML"` to swap the thread in place. Thread `.csrf_token(...)` and `.return_to(path)` for the no-JS round trip, `.max_depth(n)` so the UI never offers a reply the write path would `422`, `.read_only(Some(prompt))` for a signed-out visitor |
 | `autumn_web::ui::WIDGETS_CSS` / `WIDGETS_CSS_PATH` | One shipped stylesheet backing every `autumn-*` widget class — link `href=(WIDGETS_CSS_PATH)` instead of copying widget CSS into `input.css`. Accent now follows `var(--primary)` (violet), not the old hardcoded indigo (`docs/guide/widget-styling.md`) |
 
-### Whole-form rendering — `form_for` (0.7.0)
+### Whole-form rendering — `form_for` (0.6.0)
 
 `#[model]` derives `autumn_web::form::FormModel` (one `FormField` per
 `NewX`-editable column: humanized label, type-appropriate `FieldControl`,
@@ -1524,7 +1525,7 @@ Use `AUTUMN_SECTION__FIELD` for env overrides, for example
 `AUTUMN_SECURITY__SIGNING_SECRET`, and
 `AUTUMN_SECURITY__WEBHOOKS__REPLAY__BACKEND`.
 
-### Process roles — web/worker split (0.7.0)
+### Process roles — web/worker split (0.6.0)
 
 Scale HTTP and background work independently by giving a process a **role** (no
 app-code change) via `role = "web"|"worker"|"combined"` in config or the
@@ -1543,7 +1544,7 @@ app-code change) via `role = "web"|"worker"|"combined"` in config or the
   generated **docker-compose** output and sets the web-tier role on the `app`
   service (#1613). See `docs/guide/cloud-native.md`.
 
-### Per-queue worker pools, pinning & `ProcessRole` on `AppState` (0.7.0)
+### Per-queue worker pools, pinning & `ProcessRole` on `AppState` (0.6.0)
 
 Carve the per-process worker pool up per queue and dedicate a worker tier to a
 subset of queues — all config-only, no app-code change:
@@ -1668,7 +1669,7 @@ Published 0.7.0 behavior:
 - `actuator.prometheus` exposes the Prometheus scrape endpoint independently
   of sensitive actuator mode.
 
-### Runtime log levels (0.7.0)
+### Runtime log levels (0.6.0)
 
 `PUT /actuator/loggers/{name}` now changes the **live** `tracing` subscriber,
 not just an in-memory map — raise/lower verbosity in production without a
@@ -1691,7 +1692,7 @@ Overrides stay ephemeral — a restart resets to the configured `log.level`.
 Invalid levels still return `400`. `GET /actuator/loggers` keeps reporting
 `current_level` + overrides, now matching real emission.
 
-### Build & git provenance on `/actuator/info` (0.7.0)
+### Build & git provenance on `/actuator/info` (0.6.0)
 
 `GET /actuator/info` now reports which commit/build is running, for
 deploy/rollback verification. Apps scaffolded by `autumn new` get this with
@@ -1748,7 +1749,7 @@ null git provenance because the Docker build context excludes `.git` (tracked in
 - Doc + browser DevTools walk-through:
   `docs/guide/observability/server-timing.md`.
 
-## Resilience: load shedding (0.7.0)
+## Resilience: load shedding (0.6.0)
 
 Admission control caps concurrent in-flight requests; excess is shed
 immediately with `503` + `Retry-After` before the handler runs. Disabled by
@@ -1763,7 +1764,7 @@ Probes (`/health`, `/live`, `/ready`, `/startup`, actuator) are never shed;
 sheds increment `autumn_requests_shed_total`. See `docs/guide/resilience.md`
 and `docs/adr/0009-adopt-overload-protection-load-shedding.md`.
 
-## Sharding (0.7.0)
+## Sharding (0.6.0)
 
 Framework-native horizontal sharding: declare `[[database.shards]]` (each a
 full primary/replica topology), route by key → logical slot → shard. Prelude
@@ -1927,7 +1928,7 @@ autumn dev-loop-bench --dry-run
 autumn plugin-check --plugin-name autumn-admin-plugin --prefix /admin
 ```
 
-**(0.7.0)** CLI additions — NOT in 0.6.x or earlier
+**(0.6.0)** CLI additions — NOT in 0.6.x or earlier
 `autumn-cli`; do not suggest them to users on the published release:
 
 ```bash
@@ -1943,7 +1944,7 @@ autumn i18n check                # compare t!/t(...) keys vs i18n/*.ftl; --stric
 autumn test                      # provision/target an isolated *_test DB, migrate, then cargo test
 autumn test --reset -- --nocapture   # drop+recreate the test DB; forward args to the harness
 autumn db backup --keep 7        # dump control DB + shards to ./backups/<profile>/<ts>/; db restore <artifact> reverses it
-autumn db backup --upload --keep 7   # + upload each verified run offsite (S3/MinIO/R2); db offsite list; db restore offsite:<profile>/latest  # (0.7.0)
+autumn db backup --upload --keep 7   # + upload each verified run offsite (S3/MinIO/R2); db offsite list; db restore offsite:<profile>/latest  # (0.6.0)
 autumn seed --count 50 --model Post  # generate+insert 50 faked rows via the model's factory (both flags together)
 autumn serve --role worker       # run only workers + scheduler (web/worker split); also --role web|combined
 autumn console                   # data playground: scaffolds src/bin/playground.rs (pre-wired config+pool), then builds and runs it; alias `autumn c`

--- a/skills/autumn-web/references/api-reference.md
+++ b/skills/autumn-web/references/api-reference.md
@@ -4,8 +4,9 @@ Use this file as a quick map for public names, features, dependency versions,
 and config keys. Verify against current source when exact code matters.
 
 Version identity: this reference tracks **0.7.0**, the current release line,
-which is also the version `trunk-dev` carries. Entries marked **(0.7.0)**
-arrived in this release and are absent from 0.6.x and earlier.
+which is also the version `trunk-dev` carries. Entries carry the release they
+arrived in: **(0.6.0)** is absent from 0.5.x, and **(0.7.0)** is absent from
+0.6.x and earlier. Unmarked entries predate 0.6.0.
 
 ## Published crates
 
@@ -158,7 +159,7 @@ supported_locales)` emit `<link rel="alternate" hreflang="…">` tags (plus
 static route when the flag is on.
 
 `#[model]` also recognizes `#[belongs_to]` / `#[has_many]` / `#[has_one]`
-struct-level attributes (0.7.0)
+struct-level attributes (0.6.0)
 for declarative associations with batched eager
 preloading (`Model::preload()`, `repo.preload(records, spec)`); these are
 consumed by `#[model]` itself, not separately-registered proc macros.
@@ -176,7 +177,7 @@ from -> to: "guard", ...))]` field attribute on `String` fields, generating
 `docs/guide/state-machines.md`.
 
 `#[model]` field attributes for column privacy and canonicalization
-(0.7.0):
+(0.6.0):
 
 - `#[private]` (issue #1374) — excludes the column from the model's `Serialize`
   impl so it never appears in `Json` output, the auto-generated `--api`
@@ -190,7 +191,7 @@ from -> to: "guard", ...))]` field attribute on `String` fields, generating
   *set* it). `autumn doctor` warns (`model_private_columns`) when a
   sensitively-named column (`password`, `token`, `secret`, `*_hash`) is not
   marked `#[private]`.
-- `#[translatable]` (issue #1384, needs the `i18n` feature) — the column stores
+- **(0.7.0)** `#[translatable]` (issue #1384, needs the `i18n` feature) — the column stores
   an **independent value per locale tag** and resolves to the request's active
   locale with no locale argument in the handler. The field type becomes
   `autumn_web::i18n::Translated`, a per-locale container persisted as a JSON
@@ -249,7 +250,7 @@ Published 0.7.0: `find_by_id`, `find_all`, `count`, `exists_by_id`, `save`,
 `scope =`, `primary_reads`, `soft_delete`, `tenant_scoped`, `hooks =`,
 `mcp` / `mcp = "read"`.
 
-**(0.7.0)**: `preload(records, spec)` (declarative associations);
+**(0.6.0)**: `preload(records, spec)` (declarative associations);
 `from_shard(&ShardedDb)`; `with_pool_untracked` (new on
 the 0.6.0 rename of `with_pool`; 0.5.x repositories had no pool constructor);
 `find_in_batches(batch_size)` / `find_each(batch_size)` — bounded-memory
@@ -265,7 +266,7 @@ clamped to `MAX_PAGE_SIZE`; sharded repositories reject cross-shard
 `across_tenants()` iteration like `cursor_page`. See "Batched iteration" in
 `docs/guide/pagination.md`.
 
-**(0.7.0)** — `find_or_create_by_<field>[_and_<field>...]`: declare
+**(0.6.0)** — `find_or_create_by_<field>[_and_<field>...]`: declare
 `fn find_or_create_by_slug(slug: String);` (lookup fields only) in the
 `#[repository]` trait to generate an inherent
 `find_or_create_by_slug(&self, slug: String, new: &NewModel) ->
@@ -281,7 +282,7 @@ Requires a unique constraint covering the lookup column(s); `_or_` is rejected
 (it would span constraints). See "Race-safe get-or-insert" in
 `docs/guide/repositories.md`.
 
-**(0.7.0)** — typed grouped aggregate queries (#1364): declare
+**(0.6.0)** — typed grouped aggregate queries (#1364): declare
 `fn count_grouped_by_<col>() -> Vec<(K, i64)>` or
 `fn <sum|avg|min|max>_<num_col>_grouped_by_<col>() -> Vec<(K, Option<T>)>`
 (`avg` → `Option<f64>`) in the `#[repository]` trait — the pair return type is
@@ -400,7 +401,7 @@ join an enclosing `Db::tx`** — never hold a `Db` extractor across the call, or
 the handler needs two connections at once and deadlocks once concurrency
 reaches the pool size. See `docs/guide/votable.md`.
 
-**(0.7.0)** — `ListQuery` extractor + `SortDir` (#1126): an `Infallible`
+**(0.6.0)** — `ListQuery` extractor + `SortDir` (#1126): an `Infallible`
 query extractor parsing `?sort=<col>`, `?dir=asc|desc`, and
 `?filter[<col>]=<val>`. It **never rejects** — an empty or unknown `sort` falls
 back to the model's default order, and an invalid `dir` falls back to `asc`
@@ -474,7 +475,7 @@ delete actions remain last-write-wins.
 
 ## Db transactions
 
-- `Db::tx(f)` — READ COMMITTED, one attempt (0.7.0).
+- `Db::tx(f)` — READ COMMITTED, one attempt (0.6.0).
 - `Db::tx_with(opts: TxOptions, f) -> Result<T, AutumnError>`
   (**0.7.0**) — closure gets `&mut AsyncPgConnection`; auto-retries
   SQLSTATE 40001 with capped exponential backoff.
@@ -492,9 +493,9 @@ Free functions rendering changeset-aware, accessible inputs:
 - Published 0.7.0: `form_tag`, `method_input`, `text_input`,
   `text_input_htmx`; `Changeset`-bound methods (`form.form_tag(...)`,
   `form.text_input(...)`).
-- **(0.7.0)**: `checkbox_input`, `number_input`, `date_input`,
+- **(0.6.0)**: `checkbox_input`, `number_input`, `date_input`,
   `datetime_input`, `select_input`.
-- **(0.7.0)**: `form_for(&changeset,
+- **(0.6.0)**: `form_for(&changeset,
   action, method) -> FormFor` whole-form builder. Renders the opening
   `<form>` (audited CSRF injection + hidden `_method` override, as
   `form_tag`), one pre-filled control with inline errors per
@@ -742,13 +743,13 @@ Per-primitive setters (in addition to the shared set):
 `TextField` / `TextArea` / `Select` / `Checkbox` / `FileField` — are documented
 in **Typed accessible primitives** above.)
 
-## Cache read-through (0.7.0)
+## Cache read-through (0.6.0)
 
 `autumn_web::cache::{get_or_compute, get_or_compute_with,
 GetOrComputeOptions, CacheFillError, jittered_ttl}` — single-flight fills,
 optional `.distributed_fill_lock(true)` / `.stale_while_revalidate(grace)`.
 
-## Downloads (0.7.0)
+## Downloads (0.6.0)
 
 `autumn_web::download::Download` — a typed file-download `IntoResponse`.
 
@@ -771,7 +772,7 @@ optional `.distributed_fill_lock(true)` / `.stale_while_revalidate(grace)`.
   object's bytes; `LocalBlobStore` overrides it to stream from disk, other
   backends inherit a buffering default.
 
-### Range / 206 Partial Content (0.7.0)
+### Range / 206 Partial Content (0.6.0)
 
 `autumn_web::range` — reusable HTTP `Range` (RFC 7233) parsing + response
 building, wired into `Download` and the embedded static-asset path.
@@ -841,12 +842,12 @@ to a downloadable PDF `IntoResponse` built on `Download`.
 - Published 0.7.0 `#[job]` keys: `name`, `max_attempts`, `backoff_ms`,
   `unique`, `unique_by`, `unique_window`, `unique_for_ms`, `concurrency`,
   `concurrency_key`.
-- **(0.7.0)**: `queue = "name"` + `[jobs] queues` strict-priority list or
+- **(0.6.0)**: `queue = "name"` + `[jobs] queues` strict-priority list or
   `[jobs.queues]` weight table; tracked jobs (`job::enqueue_tracked`,
   `enqueue_tracked_for`, `TrackedJobHandle`, optional third `JobContext`
   handler arg, `GET /_autumn/jobs/{token}`, `jobs.tracking.*` config).
 
-## Distributed locks (0.7.0)
+## Distributed locks (0.6.0)
 
 - `autumn_web::lock::Lock` (prelude: `Lock`, `LockGuard`, `LockError`; `db`
   feature). Named, cluster-wide Postgres advisory lock for
@@ -894,7 +895,7 @@ to a downloadable PDF `IntoResponse` built on `Download`.
 - Published 0.7.0: `autumn generate auth` session management (`{user}_sessions`
   table, `sessions()` / `revoke_session` / `revoke_other_sessions` /
   `revoke_all_sessions`, `/account/sessions` page, `[auth.sessions]` config).
-- **(0.7.0)**: scoped service tokens — `IssueTokenSpec`,
+- **(0.6.0)**: scoped service tokens — `IssueTokenSpec`,
   `issue_scoped_api_token`, `#[secured(scopes = [...])]`,
   `PolicyContext::has_scope/has_any_scope/has_all_scopes`, `autumn token
   issue --name/--scope/--expires-at | list | rotate`, admin `TokenAdminModel`.
@@ -1251,7 +1252,7 @@ Profile selection precedence:
 3. `--profile <name>`
 4. `AUTUMN_IS_DEBUG` auto-detection from the macro
 
-`.env` auto-loading (0.7.0): a project-root `.env` file is a
+`.env` auto-loading (0.6.0): a project-root `.env` file is a
 local-dev feeder for the env-var layer (6), not a new precedence tier. On
 startup Autumn injects `.env` values into the process environment only for keys
 that are still unset, so a real environment variable of the same name always
@@ -1271,7 +1272,7 @@ Frequently used env keys:
 | `AUTUMN_SESSION__BACKEND` | `session.backend` |
 | `AUTUMN_SESSION__REDIS__URL` | `session.redis.url` |
 | `AUTUMN_CHANNELS__BACKEND` | `channels.backend` |
-| `AUTUMN_CHANNELS__REPLAY_BUFFER` | `channels.replay_buffer` (0.7.0) |
+| `AUTUMN_CHANNELS__REPLAY_BUFFER` | `channels.replay_buffer` (0.6.0) |
 | `AUTUMN_JOBS__BACKEND` | `jobs.backend` |
 | `AUTUMN_JOBS__REDIS__URL` | `jobs.redis.url` |
 | `AUTUMN_SCHEDULER__BACKEND` | `scheduler.backend` |
@@ -1282,7 +1283,7 @@ Frequently used env keys:
 | `AUTUMN_MAIL__ALLOW_IN_PROCESS_DELIVER_LATER_IN_PRODUCTION` | `mail.allow_in_process_deliver_later_in_production` |
 | `AUTUMN_STORAGE__BACKEND` | `storage.backend` |
 | `AUTUMN_CACHE__BACKEND` | `cache.backend` |
-| `AUTUMN_OBSERVABILITY__SERVER_TIMING` | `observability.server_timing` (0.7.0) — bool; `Server-Timing` response header opt-in. Defaults on in `dev`/`development`, off elsewhere. See `docs/guide/observability/server-timing.md`. |
+| `AUTUMN_OBSERVABILITY__SERVER_TIMING` | `observability.server_timing` (0.6.0) — bool; `Server-Timing` response header opt-in. Defaults on in `dev`/`development`, off elsewhere. See `docs/guide/observability/server-timing.md`. |
 
 ### `[cluster]` — embedded clustering (0.7.0, #1762)
 

--- a/skills/autumn-web/references/api-reference.md
+++ b/skills/autumn-web/references/api-reference.md
@@ -246,7 +246,7 @@ from -> to: "guard", ...))]` field attribute on `String` fields, generating
 
 ## Repository-generated methods (`#[repository]`)
 
-Published 0.7.0: `find_by_id`, `find_all`, `count`, `exists_by_id`, `save`,
+Published 0.5.0: `find_by_id`, `find_all`, `count`, `exists_by_id`, `save`,
 `update`, `delete_by_id`, derived `find_by_*`/`count_by_*`/`exists_by_*`,
 `page(&PageRequest)`, `cursor_page(&CursorRequest)` (with `cursor_key =` /
 `cursor_key_type =` attr keys), bulk `save_many` / `save_many_skip_invalid` /
@@ -495,7 +495,7 @@ delete actions remain last-write-wins.
 
 Free functions rendering changeset-aware, accessible inputs:
 
-- Published 0.7.0: `form_tag`, `method_input`, `text_input`,
+- Published 0.5.0: `form_tag`, `method_input`, `text_input`,
   `text_input_htmx`; `Changeset`-bound methods (`form.form_tag(...)`,
   `form.text_input(...)`).
 - **(0.6.0)**: `checkbox_input`, `number_input`, `date_input`,
@@ -844,7 +844,7 @@ to a downloadable PDF `IntoResponse` built on `Download`.
 
 ## Jobs additions
 
-- Published 0.7.0 `#[job]` keys: `name`, `max_attempts`, `backoff_ms`,
+- Published 0.5.0 `#[job]` keys: `name`, `max_attempts`, `backoff_ms`,
   `unique`, `unique_by`, `unique_window`, `unique_for_ms`, `concurrency`,
   `concurrency_key`.
 - **(0.6.0)**: `queue = "name"` + `[jobs] queues` strict-priority list or
@@ -897,7 +897,7 @@ to a downloadable PDF `IntoResponse` built on `Download`.
 
 ## Auth additions
 
-- Published 0.7.0: `autumn generate auth` session management (`{user}_sessions`
+- Published 0.5.0: `autumn generate auth` session management (`{user}_sessions`
   table, `sessions()` / `revoke_session` / `revoke_other_sessions` /
   `revoke_all_sessions`, `/account/sessions` page, `[auth.sessions]` config).
 - **(0.6.0)**: scoped service tokens — `IssueTokenSpec`,

--- a/skills/autumn-web/references/api-reference.md
+++ b/skills/autumn-web/references/api-reference.md
@@ -1,11 +1,11 @@
-# autumn-web API Reference (published 0.5.0 + trunk-dev)
+# autumn-web API Reference (0.7.0)
 
 Use this file as a quick map for public names, features, dependency versions,
 and config keys. Verify against current source when exact code matters.
 
-Version identity: crates.io serves **0.5.0** (the latest published release);
-the `trunk-dev` workspace is versioned **0.6.0 (unpublished)**. Entries marked
-**(unreleased)** exist on trunk-dev but NOT in the published 0.5.0 crates.
+Version identity: this reference tracks **0.7.0**, the current release line,
+which is also the version `trunk-dev` carries. Entries marked **(0.7.0)**
+arrived in this release and are absent from 0.6.x and earlier.
 
 ## Published crates
 
@@ -20,7 +20,7 @@ the `trunk-dev` workspace is versioned **0.6.0 (unpublished)**. Entries marked
 | `autumn-search` | `autumn-search/` | Keyword + vector search plugin |
 
 All publishable crates share the `[workspace.package]` version and release
-together (`0.5.0` published; `0.6.0` on trunk-dev, unpublished).
+together at `0.7.0`.
 
 ## Top-level exports
 
@@ -56,7 +56,7 @@ together (`0.5.0` published; `0.6.0` on trunk-dev, unpublished).
   `broadcasts_on(topic)` / `assert_broadcast(topic, predicate)` /
   `assert_broadcast_count(topic, n)` / `assert_no_broadcasts(topic)`
   (`RecordedBroadcast` exposes `.topic()` / `.payload()`)
-- Resumable SSE **(unreleased — trunk-dev, issue #1356)**:
+- Resumable SSE **(0.7.0, issue #1356)**:
   `sse::stream_resumable(&state, topic, last_event_id: Option<u64>)` — automatic
   monotonic per-topic event ids + `Last-Event-ID` replay from a bounded
   per-topic ring buffer, with a `gap` sentinel (`event: gap`,
@@ -109,7 +109,7 @@ together (`0.5.0` published; `0.6.0` on trunk-dev, unpublished).
 | `#[repository]` | CRUD repository and generated API (`db`); `mcp` / `mcp = "read"` expose the generated routes as MCP tools |
 | `#[service]` | Service implementation scaffolding (`db`) |
 | `#[secured]` | Session auth and role guard |
-| `#[public]` | Marks a route handler as deliberately unauthenticated for the `autumn routes audit` coverage manifest — mirrors `#[secured]`, classifying the route `public` vs `gated`/`framework`/`unclassified` (**unreleased** — trunk-dev, #1604) |
+| `#[public]` | Marks a route handler as deliberately unauthenticated for the `autumn routes audit` coverage manifest — mirrors `#[secured]`, classifying the route `public` vs `gated`/`framework`/`unclassified` (0.7.0, #1604) |
 | `#[authorize]` | Record-level policy guard |
 | `#[api_doc]` | Route OpenAPI metadata |
 | `#[oauth2_callback]` | OAuth2/OIDC callback route |
@@ -123,11 +123,11 @@ together (`0.5.0` published; `0.6.0` on trunk-dev, unpublished).
 | `#[feature_flag]` | Feature-flag definition |
 | `#[inbound_mail]` | Inbound mail handler |
 | `#[step_up]` | Step-up authentication guard |
-| `#[throttle]` | Per-route rate limit — inline (`limit`/`per`/`key`) or named (`#[throttle("login")]`) (**unreleased**) |
-| `#[event]`, `#[listener]`, `listeners![...]` | Typed domain event bus (**unreleased**) — publish via the `Events` extractor, register with `.listeners(...)` |
+| `#[throttle]` | Per-route rate limit — inline (`limit`/`per`/`key`) or named (`#[throttle("login")]`) (**0.7.0**) |
+| `#[event]`, `#[listener]`, `listeners![...]` | Typed domain event bus (**0.7.0**) — publish via the `Events` extractor, register with `.listeners(...)` |
 
 Route macros accept a `seo(...)` argument declaring per-page meta tag defaults
-(**unreleased** — trunk-dev, #1182):
+(0.7.0, #1182):
 `#[get("/about", seo(title = "About", description = "…"))]`. Keys mirror the
 `SeoMeta` builder — `title`, `description`, `canonical`, `og_title`,
 `og_description`, `og_image`, `og_type`, `og_url`, `twitter_card`,
@@ -139,7 +139,7 @@ builder), then refine them with per-request data before calling
 `seo.render()`. `#[static_get]` honours the argument too. The declared values
 are also recorded on `Route::seo` as a `SeoRouteDefaults`.
 
-**Locale-prefixed routing** (**unreleased** — trunk-dev, #1251): `[i18n]
+**Locale-prefixed routing** (0.7.0, #1251): `[i18n]
 locale_prefix_enabled = true` in `autumn.toml` (default `false`, no behavior
 change) makes every route registered via `routes(...)` also reachable under
 `/{locale}/...` for each `supported_locales` entry — no route definitions are
@@ -158,7 +158,7 @@ supported_locales)` emit `<link rel="alternate" hreflang="…">` tags (plus
 static route when the flag is on.
 
 `#[model]` also recognizes `#[belongs_to]` / `#[has_many]` / `#[has_one]`
-struct-level attributes (**unreleased** — trunk-dev, not in published 0.5.0)
+struct-level attributes (0.7.0)
 for declarative associations with batched eager
 preloading (`Model::preload()`, `repo.preload(records, spec)`); these are
 consumed by `#[model]` itself, not separately-registered proc macros.
@@ -176,7 +176,7 @@ from -> to: "guard", ...))]` field attribute on `String` fields, generating
 `docs/guide/state-machines.md`.
 
 `#[model]` field attributes for column privacy and canonicalization
-(**unreleased** — trunk-dev, not in published 0.5.0):
+(0.7.0):
 
 - `#[private]` (issue #1374) — excludes the column from the model's `Serialize`
   impl so it never appears in `Json` output, the auto-generated `--api`
@@ -240,7 +240,7 @@ from -> to: "guard", ...))]` field attribute on `String` fields, generating
 
 ## Repository-generated methods (`#[repository]`)
 
-Published 0.5.0: `find_by_id`, `find_all`, `count`, `exists_by_id`, `save`,
+Published 0.7.0: `find_by_id`, `find_all`, `count`, `exists_by_id`, `save`,
 `update`, `delete_by_id`, derived `find_by_*`/`count_by_*`/`exists_by_*`,
 `page(&PageRequest)`, `cursor_page(&CursorRequest)` (with `cursor_key =` /
 `cursor_key_type =` attr keys), bulk `save_many` / `save_many_skip_invalid` /
@@ -249,9 +249,9 @@ Published 0.5.0: `find_by_id`, `find_all`, `count`, `exists_by_id`, `save`,
 `scope =`, `primary_reads`, `soft_delete`, `tenant_scoped`, `hooks =`,
 `mcp` / `mcp = "read"`.
 
-**(unreleased)**: `preload(records, spec)` (declarative associations);
+**(0.7.0)**: `preload(records, spec)` (declarative associations);
 `from_shard(&ShardedDb)`; `with_pool_untracked` (new on
-trunk-dev — published 0.5.0 repositories have no pool constructor);
+the 0.6.0 rename of `with_pool`; 0.5.x repositories had no pool constructor);
 `find_in_batches(batch_size)` / `find_each(batch_size)` — bounded-memory
 whole-table iteration on every repository via a primary-key keyset cursor
 (`WHERE id > last ORDER BY id ASC LIMIT batch_size`, never `LIMIT`/`OFFSET`).
@@ -265,7 +265,7 @@ clamped to `MAX_PAGE_SIZE`; sharded repositories reject cross-shard
 `across_tenants()` iteration like `cursor_page`. See "Batched iteration" in
 `docs/guide/pagination.md`.
 
-**(unreleased)** — `find_or_create_by_<field>[_and_<field>...]`: declare
+**(0.7.0)** — `find_or_create_by_<field>[_and_<field>...]`: declare
 `fn find_or_create_by_slug(slug: String);` (lookup fields only) in the
 `#[repository]` trait to generate an inherent
 `find_or_create_by_slug(&self, slug: String, new: &NewModel) ->
@@ -281,7 +281,7 @@ Requires a unique constraint covering the lookup column(s); `_or_` is rejected
 (it would span constraints). See "Race-safe get-or-insert" in
 `docs/guide/repositories.md`.
 
-**(unreleased)** — typed grouped aggregate queries (#1364): declare
+**(0.7.0)** — typed grouped aggregate queries (#1364): declare
 `fn count_grouped_by_<col>() -> Vec<(K, i64)>` or
 `fn <sum|avg|min|max>_<num_col>_grouped_by_<col>() -> Vec<(K, Option<T>)>`
 (`avg` → `Option<f64>`) in the `#[repository]` trait — the pair return type is
@@ -301,7 +301,7 @@ returning a per-shard-partial answer. `DateBucket` and the `GroupedAggregate`
 builder live in `autumn_web::aggregate`. See "Grouped aggregate queries" in
 `docs/guide/repositories.md`.
 
-**(unreleased)** — `#[commentable]` polymorphic comment helpers (#1367):
+**(0.7.0)** — `#[commentable]` polymorphic comment helpers (#1367):
 declaring `#[commentable(by = User, author_name = username)]` on a `#[model]`
 emits `Model::COMMENTABLE_TYPE`, `Model::commentable_spec()`, an `inventory`
 registration, and a `{Model}Comments` trait blanket-implemented for that
@@ -345,7 +345,7 @@ private records must set `CommentsConfig::authorize(...)`. Build a host page's
 own thread with `commentable::thread_dom_id`/`thread_action` so the router's
 re-render lands on the same element. See `docs/guide/commentable.md`.
 
-**(unreleased)** — `#[votable]` reaction helpers (#1362): declaring
+**(0.7.0)** — `#[votable]` reaction helpers (#1362): declaring
 `#[votable(by = User, aggregate = sum|count)]` on a `#[model]` emits a
 `{Model}Reactions` trait blanket-implemented for that model's repository (no
 `#[repository]` attribute needed — it rides the same `M2mConnSource<Model =
@@ -400,7 +400,7 @@ join an enclosing `Db::tx`** — never hold a `Db` extractor across the call, or
 the handler needs two connections at once and deadlocks once concurrency
 reaches the pool size. See `docs/guide/votable.md`.
 
-**(unreleased)** — `ListQuery` extractor + `SortDir` (#1126): an `Infallible`
+**(0.7.0)** — `ListQuery` extractor + `SortDir` (#1126): an `Infallible`
 query extractor parsing `?sort=<col>`, `?dir=asc|desc`, and
 `?filter[<col>]=<val>`. It **never rejects** — an empty or unknown `sort` falls
 back to the model's default order, and an invalid `dir` falls back to `asc`
@@ -409,7 +409,7 @@ back to the model's default order, and an invalid `dir` falls back to `asc`
 so only real columns can reach SQL (unknown sort/filter columns are ignored, not
 injected).
 
-**(unreleased)** — `Query<T>` decodes sequences and nested structures (#1972):
+**(0.7.0)** — `Query<T>` decodes sequences and nested structures (#1972):
 the extractor no longer delegates to `serde_urlencoded`, so a query field does
 **not** have to be a scalar. A query string of unique scalar keys behaves
 exactly as before; on top of that it accepts
@@ -457,7 +457,7 @@ clients must send it), and `#[repository]`'s update raises
 `RepositoryError::Conflict` — mapped to HTTP 409 — when the stored version
 moved on. The model also gains a derived `etag()`.
 
-**(unreleased — trunk-dev, #1318)** `autumn generate model` / `generate
+**(0.7.0, #1318)** `autumn generate model` / `generate
 scaffold` wire this from the field name alone: the attribute, an
 `INTEGER/BIGINT NOT NULL DEFAULT 0` column (the INSERT never names it), a
 hidden `lock_version` input on the scaffolded edit form, an `update` handler
@@ -474,9 +474,9 @@ delete actions remain last-write-wins.
 
 ## Db transactions
 
-- `Db::tx(f)` — READ COMMITTED, one attempt (published 0.5.0).
+- `Db::tx(f)` — READ COMMITTED, one attempt (0.7.0).
 - `Db::tx_with(opts: TxOptions, f) -> Result<T, AutumnError>`
-  (**unreleased**) — closure gets `&mut AsyncPgConnection`; auto-retries
+  (**0.7.0**) — closure gets `&mut AsyncPgConnection`; auto-retries
   SQLSTATE 40001 with capped exponential backoff.
 - `autumn_web::db::IsolationLevel` {`ReadCommitted` (default),
   `RepeatableRead`, `Serializable`}; `TxOptions` builders
@@ -489,12 +489,12 @@ delete actions remain last-write-wins.
 
 Free functions rendering changeset-aware, accessible inputs:
 
-- Published 0.5.0: `form_tag`, `method_input`, `text_input`,
+- Published 0.7.0: `form_tag`, `method_input`, `text_input`,
   `text_input_htmx`; `Changeset`-bound methods (`form.form_tag(...)`,
   `form.text_input(...)`).
-- **(unreleased)**: `checkbox_input`, `number_input`, `date_input`,
+- **(0.7.0)**: `checkbox_input`, `number_input`, `date_input`,
   `datetime_input`, `select_input`.
-- **(unreleased — trunk-dev, not in published 0.5.0)**: `form_for(&changeset,
+- **(0.7.0)**: `form_for(&changeset,
   action, method) -> FormFor` whole-form builder. Renders the opening
   `<form>` (audited CSRF injection + hidden `_method` override, as
   `form_tag`), one pre-filled control with inline errors per
@@ -523,7 +523,7 @@ Free functions rendering changeset-aware, accessible inputs:
   values decode; RFC 3339 still accepted). `DateTime` columns with a zone
   other than `Utc`/`Local` render as `Text` (RFC 3339 string), not a picker.
 
-## Typed accessible primitives (`autumn_web::a11y`, feature `maud`, unreleased — trunk-dev only, #1706)
+## Typed accessible primitives (`autumn_web::a11y`, feature `maud`, 0.7.0, #1706)
 
 Render-implementing structs that make the accessible name a **type-level
 obligation** — the inaccessible form does not compile (the missing name is a
@@ -583,7 +583,7 @@ Per-primitive setters (in addition to the shared set):
 - **`FileField::new(name)`** — `.accept(s)` (MIME/extension filter),
   `.multiple()` (sets the `multiple` attribute).
 
-## View widgets and UI (all unreleased — trunk-dev only)
+## View widgets and UI (all 0.7.0)
 
 - `autumn_web::widgets`: `card(&body, &CardConfig)`,
   `stat_card(label, value, link)`, `tabs(id, &[(id, label, markup)])`,
@@ -742,13 +742,13 @@ Per-primitive setters (in addition to the shared set):
 `TextField` / `TextArea` / `Select` / `Checkbox` / `FileField` — are documented
 in **Typed accessible primitives** above.)
 
-## Cache read-through (unreleased)
+## Cache read-through (0.7.0)
 
 `autumn_web::cache::{get_or_compute, get_or_compute_with,
 GetOrComputeOptions, CacheFillError, jittered_ttl}` — single-flight fills,
 optional `.distributed_fill_lock(true)` / `.stale_while_revalidate(grace)`.
 
-## Downloads (unreleased)
+## Downloads (0.7.0)
 
 `autumn_web::download::Download` — a typed file-download `IntoResponse`.
 
@@ -771,7 +771,7 @@ optional `.distributed_fill_lock(true)` / `.stale_while_revalidate(grace)`.
   object's bytes; `LocalBlobStore` overrides it to stream from disk, other
   backends inherit a buffering default.
 
-### Range / 206 Partial Content (unreleased)
+### Range / 206 Partial Content (0.7.0)
 
 `autumn_web::range` — reusable HTTP `Range` (RFC 7233) parsing + response
 building, wired into `Download` and the embedded static-asset path.
@@ -804,7 +804,7 @@ building, wired into `Download` and the embedded static-asset path.
   (`LocalBlobStore` seeks + takes off disk; other backends inherit a buffering
   default) — a seek in a large video never buffers the whole object.
 
-## PDF generation (unreleased)
+## PDF generation (0.7.0)
 
 `autumn_web::pdf::Pdf` (`pdf` Cargo feature, off by default) — renders an
 HTML string, typically a `maud::Markup` view you already render on-screen,
@@ -838,15 +838,15 @@ to a downloadable PDF `IntoResponse` built on `Download`.
 
 ## Jobs additions
 
-- Published 0.5.0 `#[job]` keys: `name`, `max_attempts`, `backoff_ms`,
+- Published 0.7.0 `#[job]` keys: `name`, `max_attempts`, `backoff_ms`,
   `unique`, `unique_by`, `unique_window`, `unique_for_ms`, `concurrency`,
   `concurrency_key`.
-- **(unreleased)**: `queue = "name"` + `[jobs] queues` strict-priority list or
+- **(0.7.0)**: `queue = "name"` + `[jobs] queues` strict-priority list or
   `[jobs.queues]` weight table; tracked jobs (`job::enqueue_tracked`,
   `enqueue_tracked_for`, `TrackedJobHandle`, optional third `JobContext`
   handler arg, `GET /_autumn/jobs/{token}`, `jobs.tracking.*` config).
 
-## Distributed locks (unreleased — trunk-dev)
+## Distributed locks (0.7.0)
 
 - `autumn_web::lock::Lock` (prelude: `Lock`, `LockGuard`, `LockError`; `db`
   feature). Named, cluster-wide Postgres advisory lock for
@@ -864,7 +864,7 @@ to a downloadable PDF `IntoResponse` built on `Download`.
   / `Timeout` map to `503`.
 - Non-goals: not fair, not a lease, not row-level (`with_lock`), Postgres only.
 
-## Embedded clustering (unreleased — trunk-dev, #1762)
+## Embedded clustering (0.7.0, #1762)
 
 - `autumn_web::cluster` — zero-dependency two-node clustering: authenticated
   TCP gossip membership plus one shared primitive, an eventually consistent
@@ -891,15 +891,15 @@ to a downloadable PDF `IntoResponse` built on `Download`.
 
 ## Auth additions
 
-- Published 0.5.0: `autumn generate auth` session management (`{user}_sessions`
+- Published 0.7.0: `autumn generate auth` session management (`{user}_sessions`
   table, `sessions()` / `revoke_session` / `revoke_other_sessions` /
   `revoke_all_sessions`, `/account/sessions` page, `[auth.sessions]` config).
-- **(unreleased)**: scoped service tokens — `IssueTokenSpec`,
+- **(0.7.0)**: scoped service tokens — `IssueTokenSpec`,
   `issue_scoped_api_token`, `#[secured(scopes = [...])]`,
   `PolicyContext::has_scope/has_any_scope/has_all_scopes`, `autumn token
   issue --name/--scope/--expires-at | list | rotate`, admin `TokenAdminModel`.
 
-## Submit tokens (unreleased — trunk-dev, #1360)
+## Submit tokens (0.7.0, #1360)
 
 One-time, at-most-once form submission with no JS — defends against
 double-submits and replays.
@@ -927,7 +927,7 @@ double-submits and replays.
   **Note**: `#[model]` and `#[repository]` are NOT in the prelude — use
   `#[autumn_web::model]` and `#[autumn_web::repository]` (qualified paths).
 - Rendering: `asset_url`, `Markup`, `PreEscaped`, `html!`.
-- Accessibility primitives (`maud` feature, **unreleased** — trunk-dev):
+- Accessibility primitives (`maud` feature, 0.7.0):
   `Button`, `ButtonType`, `Img`, `Link`, `MenuItem`, `TextField`.
 - Extractors: `Db`, `Form`, `Json`, `Path`, `Query`, `State`, `Session`,
   `Auth`, `ApiToken`, `RequireApiToken`, `CsrfToken`, `CsrfFormField`,
@@ -974,9 +974,9 @@ double-submits and replays.
 | `with_audit_sink(sink)` | Structured audit sink |
 | `policy::<R, P>(policy)`, `scope::<R, S>(scope)` | Repository authorization |
 | `plugin(plugin)`, `plugins(tuple)` | Plugin install |
-| `listeners(listeners![...])` | Event listeners (**unreleased**) |
-| `static_gate(layer)`, `has_static_gate::<L>()`, `get_static_gate_types()` | Static pre-render gating middleware (**unreleased**) |
-| `with_shard_router(router)` | Sharding router (**unreleased**) |
+| `listeners(listeners![...])` | Event listeners (**0.7.0**) |
+| `static_gate(layer)`, `has_static_gate::<L>()`, `get_static_gate_types()` | Static pre-render gating middleware (**0.7.0**) |
+| `with_shard_router(router)` | Sharding router (**0.7.0**) |
 | `run()` | Start server |
 
 ## Deterministic time and entropy (`autumn_web::time`, `autumn_web::entropy`)
@@ -989,13 +989,13 @@ to a wall-clock jump in production.
 | API | Purpose |
 |---|---|
 | `Clock` extractor -> `.now()` | Wall-clock instant, snapshotted at request start |
-| `Clock` extractor -> `.monotonic()` | Monotonic *request-start* instant (**unreleased**) |
-| `AppState::monotonic()` | Live monotonic reading — the closing half of an elapsed measurement (**unreleased**) |
-| `MonotonicInstant::saturating_duration_since(earlier)` | Elapsed duration; never negative, never panics (**unreleased**) |
-| `MonotonicInstant::saturating_add(dur)` | Deadline arithmetic without `Instant + Duration`'s panic (**unreleased**) |
-| `time::monotonic_now()` | Real monotonic clock, for code with no `ClockSource` in scope (**unreleased**) |
+| `Clock` extractor -> `.monotonic()` | Monotonic *request-start* instant (**0.7.0**) |
+| `AppState::monotonic()` | Live monotonic reading — the closing half of an elapsed measurement (**0.7.0**) |
+| `MonotonicInstant::saturating_duration_since(earlier)` | Elapsed duration; never negative, never panics (**0.7.0**) |
+| `MonotonicInstant::saturating_add(dur)` | Deadline arithmetic without `Instant + Duration`'s panic (**0.7.0**) |
+| `time::monotonic_now()` | Real monotonic clock, for code with no `ClockSource` in scope (**0.7.0**) |
 | `time::clock_unix_secs(clock)` / `clock_unix_duration(clock)` | Unix time from the injected clock |
-| `ClockSource::now` / `ClockSource::monotonic` | The trait; `monotonic` is defaulted to real time, so a **virtual** clock must override it (**unreleased**) |
+| `ClockSource::now` / `ClockSource::monotonic` | The trait; `monotonic` is defaulted to real time, so a **virtual** clock must override it (**0.7.0**) |
 | `Rng` extractor -> `.uuid_v4()` / `.uuid_v7(ms)` / `.next_u64()` | Ids and randomness from the injected `Entropy` source |
 | `AppState::entropy()` | The same source, for framework/job code |
 | `SystemClock` / `FixedClock` / `TickingClock` | Real, pinned, and steppable `ClockSource` implementations |
@@ -1016,7 +1016,7 @@ Dev-dependency only.
 | `SystemTest::new()` | Builder; `test` profile with CSRF disabled |
 | `.routes(routes![...])` | Routes to serve; additive across calls |
 | `.state(AppState)` | Supply a pre-built state (real DB pool, policies); its embedded config wins |
-| `.layer(layer)` | App-wide Tower middleware, same `IntoAppLayer` bound and stack position as `AppBuilder::layer` — first call is outermost on ingress (**unreleased**) |
+| `.layer(layer)` | App-wide Tower middleware, same `IntoAppLayer` bound and stack position as `AppBuilder::layer` — first call is outermost on ingress (**0.7.0**) |
 | `.artifact_dir(path)` | Where failure screenshots/HTML go (default `target/system-tests/<test>/`) |
 | `.browser_timeout(d)` / `.hx_settle_timeout(d)` | Launch and htmx-settle deadlines |
 | `.build()` | Boot server + browser → `SystemTestRunner` |
@@ -1085,7 +1085,7 @@ csv = ["dep:csv"]
 system-tests = ["dep:chromiumoxide"]
 ```
 
-`storage-s3` is not a feature in 0.5.0. Use `autumn-storage-s3 = "0.5"`.
+`storage-s3` is not an `autumn-web` feature. Use `autumn-storage-s3 = "0.7"`.
 
 ## Workspace dependency versions
 
@@ -1196,7 +1196,7 @@ Endpoint builders:
 
 ## Cache-Control freshness (`etag::cache_for` / `CacheControl`)
 
-Declarative per-handler `Cache-Control` header (unreleased — issue #1344).
+Declarative per-handler `Cache-Control` header (0.7.0, issue #1344).
 While `fresh_when` handles *revalidation* (is a cached copy still valid?),
 `cache_for` handles *freshness* (how long may a copy be reused before
 revalidating?). Both are re-exported from the prelude.
@@ -1229,8 +1229,7 @@ revalidating?). Both are re-exported from the prelude.
 
 ## Config layering and env keys
 
-Reading the resolved config from handler/service code (**unreleased** —
-trunk-dev, #2198): `AppState::config_arc() -> Arc<AutumnConfig>` is the cheap
+Reading the resolved config from handler/service code (0.7.0, #2198): `AppState::config_arc() -> Arc<AutumnConfig>` is the cheap
 accessor — a refcount bump, no deep clone; reach for it on anything that runs
 per request. `AppState::config() -> AutumnConfig` is unchanged and still right
 when you need an owned, independently mutable snapshot — it deep-clones every
@@ -1252,7 +1251,7 @@ Profile selection precedence:
 3. `--profile <name>`
 4. `AUTUMN_IS_DEBUG` auto-detection from the macro
 
-`.env` auto-loading (unreleased — trunk-dev): a project-root `.env` file is a
+`.env` auto-loading (0.7.0): a project-root `.env` file is a
 local-dev feeder for the env-var layer (6), not a new precedence tier. On
 startup Autumn injects `.env` values into the process environment only for keys
 that are still unset, so a real environment variable of the same name always
@@ -1272,7 +1271,7 @@ Frequently used env keys:
 | `AUTUMN_SESSION__BACKEND` | `session.backend` |
 | `AUTUMN_SESSION__REDIS__URL` | `session.redis.url` |
 | `AUTUMN_CHANNELS__BACKEND` | `channels.backend` |
-| `AUTUMN_CHANNELS__REPLAY_BUFFER` | `channels.replay_buffer` (unreleased — trunk-dev) |
+| `AUTUMN_CHANNELS__REPLAY_BUFFER` | `channels.replay_buffer` (0.7.0) |
 | `AUTUMN_JOBS__BACKEND` | `jobs.backend` |
 | `AUTUMN_JOBS__REDIS__URL` | `jobs.redis.url` |
 | `AUTUMN_SCHEDULER__BACKEND` | `scheduler.backend` |
@@ -1283,9 +1282,9 @@ Frequently used env keys:
 | `AUTUMN_MAIL__ALLOW_IN_PROCESS_DELIVER_LATER_IN_PRODUCTION` | `mail.allow_in_process_deliver_later_in_production` |
 | `AUTUMN_STORAGE__BACKEND` | `storage.backend` |
 | `AUTUMN_CACHE__BACKEND` | `cache.backend` |
-| `AUTUMN_OBSERVABILITY__SERVER_TIMING` | `observability.server_timing` (unreleased — trunk-dev) — bool; `Server-Timing` response header opt-in. Defaults on in `dev`/`development`, off elsewhere. See `docs/guide/observability/server-timing.md`. |
+| `AUTUMN_OBSERVABILITY__SERVER_TIMING` | `observability.server_timing` (0.7.0) — bool; `Server-Timing` response header opt-in. Defaults on in `dev`/`development`, off elsewhere. See `docs/guide/observability/server-timing.md`. |
 
-### `[cluster]` — embedded clustering (unreleased — trunk-dev, #1762)
+### `[cluster]` — embedded clustering (0.7.0, #1762)
 
 Opt-in, zero-dependency two-node clustering (see "Embedded clustering" above).
 Off by default; when enabled a secret of ≥16 bytes is required (fail-fast
@@ -1307,7 +1306,7 @@ suspicion_timeout_ms = 2500       # ≥ 3× push_interval_ms enforced
 Env form `AUTUMN_CLUSTER__<KEY>`; addresses are IP literals (no hostname
 resolution).
 
-### `[failure_capture]` — failure capsules (unreleased — trunk-dev, #1598)
+### `[failure_capture]` — failure capsules (0.7.0, #1598)
 
 Opt-in deterministic replay capsules: every caught handler panic or 5xx writes
 one redacted JSON file (the request, the PostgreSQL wire traffic the handler
@@ -1347,7 +1346,7 @@ max_capsules = 50         # oldest-first prune (capsule-named files only), befor
   are not maskable; treat the directory like a database dump and read
   `docs/guide/failure-capsules.md` (security section leads) before enabling.
 
-### `[server.tls]` (feature `tls`, unreleased — trunk-dev, #1603)
+### `[server.tls]` (feature `tls`, 0.7.0, #1603)
 
 In-process HTTPS termination on the same host:port (off by default).
 
@@ -1357,7 +1356,7 @@ In-process HTTPS termination on the same host:port (off by default).
 - `handshake_timeout_secs` (default `10`).
 - Fail-fast at startup on bad / missing / mismatched / expired PEM.
 
-### `[server.tls.acme]` (feature `acme`, unreleased — trunk-dev, #1608)
+### `[server.tls.acme]` (feature `acme`, 0.7.0, #1608)
 
 Automatic ACME certificate provisioning + renewal; builds on `tls`, off by
 default. Mutually exclusive with static `cert_path` / `key_path`.

--- a/skills/autumn-web/references/api-reference.md
+++ b/skills/autumn-web/references/api-reference.md
@@ -480,7 +480,7 @@ delete actions remain last-write-wins.
 
 ## Db transactions
 
-- `Db::tx(f)` — READ COMMITTED, one attempt (0.6.0).
+- `Db::tx(f)` — READ COMMITTED, one attempt (0.5.0).
 - `Db::tx_with(opts: TxOptions, f) -> Result<T, AutumnError>`
   (**0.6.0**) — closure gets `&mut AsyncPgConnection`; auto-retries
   SQLSTATE 40001 with capped exponential backoff.

--- a/skills/autumn-web/references/api-reference.md
+++ b/skills/autumn-web/references/api-reference.md
@@ -129,8 +129,8 @@ copy of the publish order.
 | `#[feature_flag]` | Feature-flag definition |
 | `#[inbound_mail]` | Inbound mail handler |
 | `#[step_up]` | Step-up authentication guard |
-| `#[throttle]` | Per-route rate limit — inline (`limit`/`per`/`key`) or named (`#[throttle("login")]`) (**0.7.0**) |
-| `#[event]`, `#[listener]`, `listeners![...]` | Typed domain event bus (**0.7.0**) — publish via the `Events` extractor, register with `.listeners(...)` |
+| `#[throttle]` | Per-route rate limit — inline (`limit`/`per`/`key`) or named (`#[throttle("login")]`) (**0.6.0**) |
+| `#[event]`, `#[listener]`, `listeners![...]` | Typed domain event bus (**0.6.0**) — publish via the `Events` extractor, register with `.listeners(...)` |
 
 Route macros accept a `seo(...)` argument declaring per-page meta tag defaults
 (0.7.0, #1182):
@@ -482,7 +482,7 @@ delete actions remain last-write-wins.
 
 - `Db::tx(f)` — READ COMMITTED, one attempt (0.6.0).
 - `Db::tx_with(opts: TxOptions, f) -> Result<T, AutumnError>`
-  (**0.7.0**) — closure gets `&mut AsyncPgConnection`; auto-retries
+  (**0.6.0**) — closure gets `&mut AsyncPgConnection`; auto-retries
   SQLSTATE 40001 with capped exponential backoff.
 - `autumn_web::db::IsolationLevel` {`ReadCommitted` (default),
   `RepeatableRead`, `Serializable`}; `TxOptions` builders
@@ -529,7 +529,7 @@ Free functions rendering changeset-aware, accessible inputs:
   values decode; RFC 3339 still accepted). `DateTime` columns with a zone
   other than `Utc`/`Local` render as `Text` (RFC 3339 string), not a picker.
 
-## Typed accessible primitives (`autumn_web::a11y`, feature `maud`, 0.7.0, #1706)
+## Typed accessible primitives (`autumn_web::a11y`, feature `maud`, 0.6.0, #1706)
 
 Render-implementing structs that make the accessible name a **type-level
 obligation** — the inaccessible form does not compile (the missing name is a
@@ -589,7 +589,7 @@ Per-primitive setters (in addition to the shared set):
 - **`FileField::new(name)`** — `.accept(s)` (MIME/extension filter),
   `.multiple()` (sets the `multiple` attribute).
 
-## View widgets and UI (all 0.7.0)
+## View widgets and UI (all 0.6.0)
 
 - `autumn_web::widgets`: `card(&body, &CardConfig)`,
   `stat_card(label, value, link)`, `tabs(id, &[(id, label, markup)])`,
@@ -933,7 +933,7 @@ double-submits and replays.
   **Note**: `#[model]` and `#[repository]` are NOT in the prelude — use
   `#[autumn_web::model]` and `#[autumn_web::repository]` (qualified paths).
 - Rendering: `asset_url`, `Markup`, `PreEscaped`, `html!`.
-- Accessibility primitives (`maud` feature, 0.7.0):
+- Accessibility primitives (`maud` feature, 0.6.0):
   `Button`, `ButtonType`, `Img`, `Link`, `MenuItem`, `TextField`.
 - Extractors: `Db`, `Form`, `Json`, `Path`, `Query`, `State`, `Session`,
   `Auth`, `ApiToken`, `RequireApiToken`, `CsrfToken`, `CsrfFormField`,
@@ -980,9 +980,9 @@ double-submits and replays.
 | `with_audit_sink(sink)` | Structured audit sink |
 | `policy::<R, P>(policy)`, `scope::<R, S>(scope)` | Repository authorization |
 | `plugin(plugin)`, `plugins(tuple)` | Plugin install |
-| `listeners(listeners![...])` | Event listeners (**0.7.0**) |
-| `static_gate(layer)`, `has_static_gate::<L>()`, `get_static_gate_types()` | Static pre-render gating middleware (**0.7.0**) |
-| `with_shard_router(router)` | Sharding router (**0.7.0**) |
+| `listeners(listeners![...])` | Event listeners (**0.6.0**) |
+| `static_gate(layer)`, `has_static_gate::<L>()`, `get_static_gate_types()` | Static pre-render gating middleware (**0.6.0**) |
+| `with_shard_router(router)` | Sharding router (**0.6.0**) |
 | `run()` | Start server |
 
 ## Deterministic time and entropy (`autumn_web::time`, `autumn_web::entropy`)
@@ -1352,7 +1352,7 @@ max_capsules = 50         # oldest-first prune (capsule-named files only), befor
   are not maskable; treat the directory like a database dump and read
   `docs/guide/failure-capsules.md` (security section leads) before enabling.
 
-### `[server.tls]` (feature `tls`, 0.7.0, #1603)
+### `[server.tls]` (feature `tls`, 0.6.0, #1603)
 
 In-process HTTPS termination on the same host:port (off by default).
 
@@ -1362,7 +1362,7 @@ In-process HTTPS termination on the same host:port (off by default).
 - `handshake_timeout_secs` (default `10`).
 - Fail-fast at startup on bad / missing / mismatched / expired PEM.
 
-### `[server.tls.acme]` (feature `acme`, 0.7.0, #1608)
+### `[server.tls.acme]` (feature `acme`, 0.6.0, #1608)
 
 Automatic ACME certificate provisioning + renewal; builds on `tls`, off by
 default. Mutually exclusive with static `cert_path` / `key_path`.

--- a/skills/autumn-web/references/api-reference.md
+++ b/skills/autumn-web/references/api-reference.md
@@ -13,15 +13,20 @@ arrived in: **(0.6.0)** is absent from 0.5.x, and **(0.7.0)** is absent from
 | Crate | Directory | Notes |
 |---|---|---|
 | `autumn-macros` | `autumn-macros/` | Proc macros; publish first |
+| `autumn-schema-core` | `autumn-schema-core/` | Schema primitives shared by the CLI; no Autumn runtime deps |
+| `autumn-edge` | `autumn-edge/` | Edge/WASM capsule runtime; `autumn-web` pins it (optionally) so it publishes before `autumn-web` |
 | `autumn-web` | `autumn/` | Main framework crate; import path `autumn_web` |
 | `autumn-cli` | `autumn-cli/` | Binary crate; binary name `autumn` |
 | `autumn-admin-plugin` | `autumn-admin-plugin/` | First-party admin UI plugin |
+| `autumn-media-plugin` | `autumn-media-plugin/` | Live-streaming media plugin (broadcast + rooms) |
 | `autumn-storage-s3` | `autumn-storage-s3/` | S3-compatible `BlobStore` plugin |
 | `autumn-cache-redis` | `autumn-cache-redis/` | Redis cache plugin |
 | `autumn-search` | `autumn-search/` | Keyword + vector search plugin |
 
 All publishable crates share the `[workspace.package]` version and release
-together at `0.7.0`.
+together at `0.7.0`. This table lists the same crates, in the same order, as
+`CRATES` in `scripts/check-publish-dry-run.sh` — that script is the executable
+copy of the publish order.
 
 ## Top-level exports
 
@@ -57,7 +62,7 @@ together at `0.7.0`.
   `broadcasts_on(topic)` / `assert_broadcast(topic, predicate)` /
   `assert_broadcast_count(topic, n)` / `assert_no_broadcasts(topic)`
   (`RecordedBroadcast` exposes `.topic()` / `.payload()`)
-- Resumable SSE **(0.7.0, issue #1356)**:
+- Resumable SSE **(0.6.0, issue #1356)**:
   `sse::stream_resumable(&state, topic, last_event_id: Option<u64>)` — automatic
   monotonic per-topic event ids + `Last-Event-ID` replay from a bounded
   per-topic ring buffer, with a `gap` sentinel (`event: gap`,
@@ -110,7 +115,7 @@ together at `0.7.0`.
 | `#[repository]` | CRUD repository and generated API (`db`); `mcp` / `mcp = "read"` expose the generated routes as MCP tools |
 | `#[service]` | Service implementation scaffolding (`db`) |
 | `#[secured]` | Session auth and role guard |
-| `#[public]` | Marks a route handler as deliberately unauthenticated for the `autumn routes audit` coverage manifest — mirrors `#[secured]`, classifying the route `public` vs `gated`/`framework`/`unclassified` (0.7.0, #1604) |
+| `#[public]` | Marks a route handler as deliberately unauthenticated for the `autumn routes audit` coverage manifest — mirrors `#[secured]`, classifying the route `public` vs `gated`/`framework`/`unclassified` (0.6.0, #1604) |
 | `#[authorize]` | Record-level policy guard |
 | `#[api_doc]` | Route OpenAPI metadata |
 | `#[oauth2_callback]` | OAuth2/OIDC callback route |
@@ -900,7 +905,7 @@ to a downloadable PDF `IntoResponse` built on `Download`.
   `PolicyContext::has_scope/has_any_scope/has_all_scopes`, `autumn token
   issue --name/--scope/--expires-at | list | rotate`, admin `TokenAdminModel`.
 
-## Submit tokens (0.7.0, #1360)
+## Submit tokens (0.6.0, #1360)
 
 One-time, at-most-once form submission with no JS — defends against
 double-submits and replays.
@@ -1197,7 +1202,7 @@ Endpoint builders:
 
 ## Cache-Control freshness (`etag::cache_for` / `CacheControl`)
 
-Declarative per-handler `Cache-Control` header (0.7.0, issue #1344).
+Declarative per-handler `Cache-Control` header (0.6.0, issue #1344).
 While `fresh_when` handles *revalidation* (is a cached copy still valid?),
 `cache_for` handles *freshness* (how long may a copy be reused before
 revalidating?). Both are re-exported from the prelude.

--- a/skills/autumn-web/references/examples.md
+++ b/skills/autumn-web/references/examples.md
@@ -1,8 +1,8 @@
-# autumn-web Example Reference (published 0.5.0)
+# autumn-web Example Reference (0.7.0)
 
 Use these patterns when generating or reviewing Autumn apps. The official
 examples live under `examples/`; prefer current source when exact code matters.
-Everything here works on the published 0.5.0 crates unless marked otherwise.
+Everything here works on the published 0.7.0 crates unless marked otherwise.
 
 ## Status field with a state machine (replaces hand-rolled hook validation)
 
@@ -75,7 +75,7 @@ Published-user dependency:
 
 ```toml
 [dependencies]
-autumn-web = "0.5"
+autumn-web = "0.7"
 ```
 
 Workspace examples use `autumn-web = { path = "../../autumn" }` plus the root
@@ -189,7 +189,7 @@ async fn main() {
 Feature set:
 
 ```toml
-autumn-web = { version = "0.5", features = ["mail", "ws", "storage", "multipart", "redis"] }
+autumn-web = { version = "0.7", features = ["mail", "ws", "storage", "multipart", "redis"] }
 ```
 
 Keep Harvest out of core web examples. Use built-in jobs for app-local work and
@@ -372,8 +372,8 @@ backend = "postgres"
 Install the first-party admin UI:
 
 ```toml
-autumn-web = { version = "0.5", features = ["db", "flash", "htmx", "maud"] }
-autumn-admin-plugin = "0.5"
+autumn-web = { version = "0.7", features = ["db", "flash", "htmx", "maud"] }
+autumn-admin-plugin = "0.7"
 ```
 
 ```rust
@@ -390,14 +390,14 @@ async fn main() {
 ```
 
 The plugin mounts at `/admin` by default and requires the `admin` session role.
-In 0.5.0 it includes jobs, feature-flag, and experiment administration
+It includes jobs, feature-flag, and experiment administration
 surfaces.
 
 ## S3 storage plugin
 
 ```toml
-autumn-web = { version = "0.5", features = ["storage", "multipart"] }
-autumn-storage-s3 = "0.5"
+autumn-web = { version = "0.7", features = ["storage", "multipart"] }
+autumn-storage-s3 = "0.7"
 ```
 
 ```rust
@@ -462,7 +462,7 @@ read via `BlobStore::get_range` (the local backend seeks + takes off disk).
 Enable test support for integration-style app tests:
 
 ```toml
-autumn-web = { version = "0.5", features = ["test-support"] }
+autumn-web = { version = "0.7", features = ["test-support"] }
 ```
 
 Use `TestApp`, `TestClient`, `TestResponse`, and `TestDb` from


### PR DESCRIPTION
Cuts `0.7.0` from the accumulated `## [Unreleased]` line, following
`docs/release-checklist.md`.

## Version and crates

- `[workspace.package].version` → `0.7.0`, and every inter-crate pin with it
  (`autumn-web`, `autumn-macros`, `autumn-edge`, `autumn-schema-core` across
  all eight publishable crates). `scripts/check-crate-metadata.sh` confirms the
  pins are coherent.
- Generated apps need no change: `autumn new` derives its `autumn-web` pin from
  `env!("CARGO_PKG_VERSION")`, so it tracks automatically.

## Dependency refresh

Reviewed the open Dependabot PRs rather than tagging on a month-old lockfile,
and folded in the semver-compatible ones:

- **#2181 (diesel-ecosystem):** `diesel` 2.3.10 → 2.3.12, `libsqlite3-sys`
  0.37 → 0.38.
- **#2245 (rust-deps, 19 updates):** carried by `cargo update`, plus the `time`
  upper-bound widening to `<0.3.56` in the three manifests that pin it for the
  testcontainers/bollard and aws-smithy graphs.
- Also picked up: `redis` 1.4 → 1.6, `clap` 4.6.3 → 4.6.6, `tokio` 1.52.3 →
  1.53.1, `rustls` 0.23.42 → 0.23.43, and the rest of the compatible set.

**Deliberately not carried:** `rand` 0.10, `sha1` 0.11, `aes-gcm` 0.11,
`matchit` 0.9, `x509-parser` 0.18, `tokio-tungstenite` 0.30,
`tokio-postgres-rustls` 0.14. Each is an API-breaking major that has sat open
since July; folding them into a release cut is its own change with its own
risk. The GitHub-Actions bumps (#2081, #1891, #2164) and the benchmark-only
Django bump (#2179) are CI/benchmark-scoped and also left alone.

The changelog records both the bumps and the omissions.

## CHANGELOG

- 145 entries moved under `## [0.7.0] - 2026-08-23`, and the repeated per-PR
  `### Added` / `### Fixed` / … subsections consolidated into one ordered set.
  Verified byte-identical: every non-heading, non-blank line in the section is
  unchanged, only the headings moved.
- The four `docs/migrations/next.md` links repointed at
  `docs/migrations/0.7.0.md`.
- `## [Unreleased]` recreated empty.

## Migration guide

- `next.md` → `0.7.0.md`, version placeholders filled in, indexed in
  `docs/migrations/README.md`, and the rolling `next.md` draft recreated from
  `TEMPLATE.md`.
- Added the codemod-first *Step-by-step* and an *Upstream dependency updates*
  section covering the `libsqlite3-sys` major (which only reaches an app that
  depends on it directly).
- **The walk-through was performed, not asserted.** `cargo install autumn-cli
  --version 0.6.0` from crates.io → `autumn new` → `generate scaffold Post` →
  green baseline → `autumn upgrade` from the candidate CLI *before* the
  dependency bump → bump → `cargo check` clean with no ``missing field `seo` ``
  → `cargo test` green → `autumn migrate` applied → `GET /health` reporting
  `0.7.0`, `GET /posts` and `GET /` both 200. 20 minutes, zero guide-directed
  edits, no gaps found. The record notes the one pre-publish caveat: `0.7.0` is
  not on crates.io yet, so the candidate came from a `[patch.crates-io]` path
  override.

## `autumn upgrade`

`0.7.0`'s three breaks are registered as `GuideOnly` entries, so a 0.6.x app is
told about them and linked to the guide instead of hearing "nothing to change".
The release ships no `auto`/`review` codemod — each break needs a value, a wire
change in a client the tool never sees, or a change of impl shape, none of them
rename-level.

```
autumn upgrade - app-code migrations 0.6.0 -> 0.7.0
Migrations in range (3):
  manual  0.7.0-routing-route-seo-field       …
  manual  0.7.0-api-lock-version-required     …
  manual  0.7.0-app-layers-erased             …
```

## Docs

- Every install pin, dependency line, release-line note and sample runtime
  version moved to `0.7.x` — including the `"0.6"` *series* form (as in
  `autumn-web = "0.6"`) that the first sweep missed and `repo_hygiene`'s
  `first_run_docs_match_current_release_line` caught.
- **The `autumn-web` agent skill was materially stale**: it still described
  0.5.0 as the published release with trunk-dev unreleased, so all 77
  `(unreleased — trunk-dev)` markers now read `(0.7.0)`, the version-identity
  trip wire is rewritten, and the repository URL is corrected from the old
  `madmax983/autumn`.

## New: release walkthroughs (`docs/releases/`)

A narrative counterpart to the changelog — the document you send someone who
asks "what's new in this one?" and does not want 145 entries. `0.7.0.md` walks
through host-preparing deploys and fleets, deterministic simulation testing,
`#[translatable]` / `#[commentable]` / `#[votable]` / `position`,
failure-capsule replay, the call-site metrics facade, and the ~59%
allocations-per-request reduction, closing with the upgrade path. Every API
spelling and number in it is quoted from the changelog or verified against the
source.

Linked from the CHANGELOG section header, the README *Documentation* list, and
the migration guide header. `docs/release-checklist.md` gains the step that
keeps one being cut, alongside a new dependency-refresh step.

## Verification

| Check | Result |
|---|---|
| `scripts/check-crate-metadata.sh` | pass |
| `scripts/check-release-notes.sh` | pass |
| `scripts/check-migration-guides.sh` | pass |
| `cargo fmt --all -- --check` | pass |
| `cargo check --workspace --all-targets` | pass |
| `cargo test --workspace --no-run` | pass (links the consolidated `integration_tests` binary) |
| `cargo test --workspace --doc` | pass |
| `cargo test -p autumn-cli --test cli_tests repo_hygiene` | 287 passed |
| `cargo test -p autumn-cli --test cli_tests upgrade_codemod` | 91 passed |
| Upgrade walk-through, 0.6.0 → 0.7.0 | performed, green |

**`cargo clippy --workspace --all-targets -- -D warnings` could not be
validated here.** This sandbox runs rustc 1.97.0 while CI is on ≥1.98 (the root
`Cargo.toml`'s own comment dates `clippy::unused_async_trait_impl` to 1.98), so
clippy fails on two findings that are artifacts of the older toolchain, in
files this branch does not touch:

- `warning[E0602]: unknown lint: clippy::unused_async_trait_impl` — the
  workspace `[lints]` allow-entry names a lint 1.97's clippy does not know.
- `clippy::doc_markdown` on `PostgreSQL` in `autumn/src/commentable.rs:105`
  (from #2261) — `PostgreSQL` is in newer clippy's default `doc-valid-idents`.

This branch changes exactly one Rust file (`autumn-cli/src/upgrade/migrations.rs`,
+30 lines of registry data) and zero files under `autumn/`. Scoped clippy over
`autumn-cli` is clean apart from those two inherited findings. Worth a look at
the CI lint job before tagging.

## Not done

`RELEASE_NOTES.md` is left as-is. It is a stale UTF-16 `0.5.0` artifact that
the `publish-gate` workflow regenerates with git-cliff at tag time, so the
committed copy is vestigial — but the broken encoding is worth cleaning up
separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019X2bKuyBrWfeLstXy74ri3

---
_Generated by [Claude Code](https://claude.ai/code/session_019X2bKuyBrWfeLstXy74ri3)_