### PR TITLE
Address CI feedback on #2296: env-var leaks + benchmark version skew

### DIFF
--- a/autumn-cli/src/replay.rs
+++ b/autumn-cli/src/replay.rs
@@ -9,6 +9,29 @@ pub const REPLAY_CAPSULE_ENV: &str = "AUTUMN_REPLAY_CAPSULE";
 /// Exit code used for a capsule that is never replayed at all.
 const EXIT_REFUSED: i32 = 2;
 
+/// Clear the other internal one-shot mode env vars `AppBuilder::run` checks
+/// *before* `AUTUMN_REPLAY_CAPSULE` in its dispatch chain.
+///
+/// `Command` inherits the parent process's environment by default, so any of
+/// these left over in the CLI's own environment (e.g. from a wrapping script,
+/// or a previous `autumn migrate`/`autumn task run ...` invocation in the same
+/// shell) would silently hijack a replay into a completely different — and
+/// potentially mutating — mode, since every one of them is dispatched earlier
+/// than `AUTUMN_REPLAY_CAPSULE` in `AppBuilder::run`.
+fn clear_competing_one_shot_env(command: &mut Command) {
+    for var in [
+        "AUTUMN_BUILD_STATIC",
+        "AUTUMN_DUMP_ROUTES",
+        "AUTUMN_DUMP_JOBS",
+        "AUTUMN_LIST_TASKS",
+        "AUTUMN_RUN_TASK",
+        "AUTUMN_MIGRATE",
+        "AUTUMN_RETENTION_DRY_RUN",
+    ] {
+        command.env_remove(var);
+    }
+}
+
 /// Options controlling `autumn replay`.
 pub struct ReplayOptions<'a> {
     pub capsule: &'a str,
@@ -60,6 +83,7 @@ pub fn run(opts: &ReplayOptions<'_>) {
     }
 
     let mut command = Command::new(&binary);
+    clear_competing_one_shot_env(&mut command);
     command
         .env(REPLAY_CAPSULE_ENV, &capsule)
         .env("AUTUMN_ENV", &profile)
@@ -330,6 +354,41 @@ mod tests {
         assert!(
             error.contains("directory"),
             "the error must say what is wrong: {error}"
+        );
+    }
+
+    #[test]
+    fn clear_competing_one_shot_env_removes_every_var_checked_before_replay() {
+        // AppBuilder::run checks build, route/job dumps, tasks, migration, and
+        // retention dry-run modes *before* AUTUMN_REPLAY_CAPSULE in its
+        // dispatch chain — any of them left over in the CLI's own environment
+        // would hijack a replay into a completely different (potentially
+        // mutating) mode via Command's default environment inheritance.
+        let competing_vars = [
+            "AUTUMN_BUILD_STATIC",
+            "AUTUMN_DUMP_ROUTES",
+            "AUTUMN_DUMP_JOBS",
+            "AUTUMN_LIST_TASKS",
+            "AUTUMN_RUN_TASK",
+            "AUTUMN_MIGRATE",
+            "AUTUMN_RETENTION_DRY_RUN",
+        ];
+        let mut command = Command::new("true");
+        for var in competing_vars {
+            command.env(var, "1");
+        }
+        clear_competing_one_shot_env(&mut command);
+        let remaining: Vec<&str> = command
+            .get_envs()
+            .filter_map(|(key, value)| {
+                value
+                    .and(key.to_str())
+                    .filter(|k| competing_vars.contains(k))
+            })
+            .collect();
+        assert!(
+            remaining.is_empty(),
+            "these competing one-shot vars survived: {remaining:?}"
         );
     }
 

--- a/autumn-cli/src/replay.rs
+++ b/autumn-cli/src/replay.rs
@@ -382,7 +382,7 @@ mod tests {
             .get_envs()
             .filter_map(|(key, value)| {
                 value
-                    .and(key.to_str())
+                    .and_then(|_| key.to_str())
                     .filter(|k| competing_vars.contains(k))
             })
             .collect();

--- a/autumn-cli/src/search.rs
+++ b/autumn-cli/src/search.rs
@@ -80,6 +80,75 @@ pub fn is_started_marker(line: &str) -> bool {
     line.starts_with(BACKFILL_STARTED_MARKER)
 }
 
+/// Clear the internal one-shot mode env vars `AppBuilder::run` dispatches
+/// *before* it falls through to normal server startup, where `SearchPlugin`
+/// consumes [`BACKFILL_ENV`].
+///
+/// `Command` inherits the parent process's environment by default, so any of
+/// these left over in the CLI's own environment (e.g. from a wrapping script,
+/// or a previous `autumn migrate`/`autumn task run ...`/`autumn replay ...`
+/// invocation in the same shell) would silently hijack `autumn search
+/// reindex` into a completely different — and potentially mutating — mode,
+/// since every one of them is dispatched earlier than server startup in
+/// `AppBuilder::run`.
+fn clear_competing_one_shot_env(command: &mut Command) {
+    for var in [
+        "AUTUMN_BUILD_STATIC",
+        "AUTUMN_DUMP_ROUTES",
+        "AUTUMN_DUMP_JOBS",
+        "AUTUMN_LIST_TASKS",
+        "AUTUMN_RUN_TASK",
+        "AUTUMN_MIGRATE",
+        "AUTUMN_RETENTION_DRY_RUN",
+        "AUTUMN_REPLAY_CAPSULE",
+    ] {
+        command.env_remove(var);
+    }
+}
+
+/// Set or clear [`BACKFILL_PURGE_ENV`] on `command` from `purge`.
+///
+/// `Command` inherits the parent process's environment by default, so
+/// without an explicit removal when `purge` is `false`, an
+/// `AUTUMN_SEARCH_BACKFILL_PURGE=1` the CLI's own environment already
+/// happens to carry (e.g. exported by a wrapping script, or left over from a
+/// previous `--purge` invocation) would silently leak into a purge-less
+/// reindex, clearing every selected index before rebuilding it — the exact
+/// search outage `--purge` being opt-in is meant to guard against.
+///
+/// A free function (rather than inlined into [`run`]) so this is
+/// unit-testable via [`Command::get_envs`] without actually spawning a
+/// process.
+fn apply_purge_env(command: &mut Command, purge: bool) {
+    if purge {
+        command.env(BACKFILL_PURGE_ENV, "1");
+    } else {
+        command.env_remove(BACKFILL_PURGE_ENV);
+    }
+}
+
+/// Set or clear the profile selector on `command` from `profile`.
+///
+/// `Command` inherits the parent process's environment by default, so
+/// without an explicit removal when `profile` is `None`, an inherited
+/// `AUTUMN_ENV`/`AUTUMN_PROFILE` would outrank the debug-build inference
+/// this CLI just announced (`AUTUMN_ENV` is the configuration resolver's
+/// highest-priority selector), silently reindexing — and, with `--purge`,
+/// temporarily emptying — that other profile's index while claiming to
+/// operate on `dev`.
+///
+/// A free function (rather than inlined into [`run`]) so this is
+/// unit-testable via [`Command::get_envs`] without actually spawning a
+/// process.
+fn apply_profile_env(command: &mut Command, profile: Option<&str>) {
+    if let Some(profile) = profile {
+        command.env("AUTUMN_ENV", profile);
+    } else {
+        command.env_remove("AUTUMN_ENV");
+        command.env_remove("AUTUMN_PROFILE");
+    }
+}
+
 /// Run `autumn search reindex`.
 pub fn run(opts: &ReindexOptions<'_>) {
     eprintln!("\u{1F342} autumn search reindex\n");
@@ -103,16 +172,10 @@ pub fn run(opts: &ReindexOptions<'_>) {
     let binary = find_binary(opts.package, opts.bin);
 
     let mut command = Command::new(&binary);
+    clear_competing_one_shot_env(&mut command);
     command.env(BACKFILL_ENV, backfill_target(opts.index));
-    if opts.purge {
-        command.env(BACKFILL_PURGE_ENV, "1");
-    }
-    // Forwarded as `AUTUMN_ENV`, the highest-priority selector, so the child
-    // resolves `[profile.<name>.search]` for the profile the operator meant
-    // rather than the one implied by this CLI's debug build.
-    if let Some(profile) = opts.profile {
-        command.env("AUTUMN_ENV", profile);
-    }
+    apply_purge_env(&mut command, opts.purge);
+    apply_profile_env(&mut command, opts.profile);
 
     // stdout is piped so the CLI can watch for the plugin's start marker; it is
     // forwarded line by line so the app's own output still reaches the user.
@@ -207,6 +270,92 @@ mod tests {
             Some("prod"),
             "the forwarded value must be one core recognizes"
         );
+    }
+
+    fn set_envs(command: &mut Command, keys: impl IntoIterator<Item = &'static str>) {
+        for key in keys {
+            command.env(key, "1");
+        }
+    }
+
+    /// Vars still explicitly set (present with a value, i.e. not
+    /// `env_remove`d) on `command`, restricted to `keys`.
+    fn still_set(command: &Command, keys: &[&str]) -> Vec<String> {
+        command
+            .get_envs()
+            .filter_map(|(key, value)| value.map(|_| key))
+            .filter_map(|key| key.to_str().map(str::to_owned))
+            .filter(|key| keys.contains(&key.as_str()))
+            .collect()
+    }
+
+    #[test]
+    fn clear_competing_one_shot_env_removes_every_var_checked_before_server_startup() {
+        // AppBuilder::run dispatches build, route/job dumps, tasks, migration,
+        // retention dry-run, and capsule replay *before* falling through to
+        // normal server startup, where SearchPlugin consumes
+        // AUTUMN_SEARCH_BACKFILL — any of them left over in the CLI's own
+        // environment would hijack `autumn search reindex` into a completely
+        // different (potentially mutating) mode via Command's default
+        // environment inheritance.
+        let competing_vars = [
+            "AUTUMN_BUILD_STATIC",
+            "AUTUMN_DUMP_ROUTES",
+            "AUTUMN_DUMP_JOBS",
+            "AUTUMN_LIST_TASKS",
+            "AUTUMN_RUN_TASK",
+            "AUTUMN_MIGRATE",
+            "AUTUMN_RETENTION_DRY_RUN",
+            "AUTUMN_REPLAY_CAPSULE",
+        ];
+        let mut command = Command::new("true");
+        set_envs(&mut command, competing_vars);
+        clear_competing_one_shot_env(&mut command);
+        let remaining = still_set(&command, &competing_vars);
+        assert!(
+            remaining.is_empty(),
+            "these competing one-shot vars survived: {remaining:?}"
+        );
+    }
+
+    #[test]
+    fn apply_purge_env_clears_an_inherited_purge_flag_when_purge_is_not_requested() {
+        let mut command = Command::new("true");
+        command.env(BACKFILL_PURGE_ENV, "1");
+        apply_purge_env(&mut command, false);
+        assert!(
+            still_set(&command, &[BACKFILL_PURGE_ENV]).is_empty(),
+            "an inherited purge flag must not survive a purge-less reindex"
+        );
+    }
+
+    #[test]
+    fn apply_purge_env_sets_the_flag_when_purge_is_requested() {
+        let mut command = Command::new("true");
+        apply_purge_env(&mut command, true);
+        assert_eq!(
+            still_set(&command, &[BACKFILL_PURGE_ENV]),
+            [BACKFILL_PURGE_ENV]
+        );
+    }
+
+    #[test]
+    fn apply_profile_env_clears_inherited_profile_selectors_for_default_reindex() {
+        let mut command = Command::new("true");
+        command.env("AUTUMN_ENV", "prod");
+        command.env("AUTUMN_PROFILE", "prod");
+        apply_profile_env(&mut command, None);
+        assert!(
+            still_set(&command, &["AUTUMN_ENV", "AUTUMN_PROFILE"]).is_empty(),
+            "an inherited profile selector must not survive an unset --profile"
+        );
+    }
+
+    #[test]
+    fn apply_profile_env_forwards_an_explicit_profile_as_autumn_env() {
+        let mut command = Command::new("true");
+        apply_profile_env(&mut command, Some("prod"));
+        assert_eq!(still_set(&command, &["AUTUMN_ENV"]), ["AUTUMN_ENV"]);
     }
 
     #[test]

--- a/benchmarks/runtime/autumn/Cargo.toml
+++ b/benchmarks/runtime/autumn/Cargo.toml
@@ -18,7 +18,7 @@ path = "src/bin/seed.rs"
 autumn-web = { path = "../../../autumn" }
 chrono = { version = "0.4", features = ["serde"] }
 diesel = { version = "2", features = ["postgres", "chrono"] }
-diesel-async = { version = "0.8", features = ["postgres"] }
+diesel-async = { version = "0.9", features = ["postgres"] }
 pq-sys = { version = "0.7", features = ["bundled_without_openssl"] }
 diesel_migrations = "2"
 maud = { version = "0.27", features = ["axum"] }


### PR DESCRIPTION
## Summary
Addresses CI failures and automated review feedback found on #2296.

### Automated review feedback (chatgpt-codex-connector) — 4 P1 findings
`Command` inherits the parent process's environment by default. A one-shot mode selector left over in the CLI's own environment — from a wrapping script, or a previous `autumn migrate`/`autumn task run ...`/`autumn replay ...` invocation in the same shell — could silently hijack `autumn replay` or `autumn search reindex` into a completely different, potentially mutating mode against a live database, since `AppBuilder::run` checks all of those modes earlier in its dispatch chain.

- `autumn-cli/src/replay.rs`: clear every one-shot mode env var (`AUTUMN_BUILD_STATIC`, `AUTUMN_DUMP_ROUTES`, `AUTUMN_DUMP_JOBS`, `AUTUMN_LIST_TASKS`, `AUTUMN_RUN_TASK`, `AUTUMN_MIGRATE`, `AUTUMN_RETENTION_DRY_RUN`) that `AppBuilder::run` dispatches before `AUTUMN_REPLAY_CAPSULE`.
- `autumn-cli/src/search.rs`:
  - clear every one-shot mode env var dispatched before normal server startup (where `SearchPlugin` consumes the backfill env), including `AUTUMN_REPLAY_CAPSULE` since reindex startup happens after all of them;
  - explicitly `env_remove` the purge flag (`AUTUMN_SEARCH_BACKFILL_PURGE`) when `--purge` is not passed, so an inherited purge flag can no longer clear indexes the operator didn't ask to clear;
  - explicitly `env_remove` `AUTUMN_ENV`/`AUTUMN_PROFILE` when `--profile` is not passed, so an inherited profile selector can no longer outrank the debug-build `dev` default this CLI announces.

Each fix is a straightforward `Command::env_remove` following the existing pattern already used in `autumn-cli/src/retention.rs`'s `clear_competing_one_shot_env`.

### CI failure: `benchmarks/runtime/autumn` diesel-async version skew
The weekly "Runtime Latency Gate" scheduled job (`measure` / "Measure Autumn request latency") failed to compile on `trunk-dev`: `benchmarks/runtime/autumn/Cargo.toml` pinned `diesel-async = "0.8"` directly while `autumn-web` (a path dependency) pulls the workspace's `diesel-async = "0.9"`, producing two distinct `AsyncPgConnection` types in the dependency graph. Every route handler using autumn-web's `Db` extractor then failed to type-check against this crate's own diesel-async APIs (`E0308`/`E0277`). Bumped the pin to `0.9` to match the workspace.

## Test plan
- [x] `cargo build --workspace` / `cargo check -p autumn-cli`
- [x] `cargo fmt --all`
- [x] `cargo test -p autumn-cli --bin autumn replay::` / `search::` — all pass, including new regression tests for `clear_competing_one_shot_env`, `apply_purge_env`, `apply_profile_env`
- [x] `cargo clippy -p autumn-cli --all-targets -- -D warnings` — clean (CI confirmed)
- [x] `cargo check --bin bench-autumn --bin seed` in `benchmarks/runtime/autumn` — reproduced the version-skew compile failure locally and confirmed the fix resolves it
- [x] `cargo clippy --bin bench-autumn --bin seed -- -D warnings` in `benchmarks/runtime/autumn` — clean

---
_Generated by [Claude Code](https://claude.ai/code/session_01La1MTD4iB4K4TWib2hK2YF)_