### PR TITLE
⚡ Bolt: skip HTML-escaping constant form attributes (instructions -7.58%)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-Nothing yet.
+### Performance
+
+- **scaffolded form helpers no longer re-escape their own constant HTML at
+  render time:** `text_input`, `password_input`, `textarea_input`,
+  `number_input`, `checkbox_input`, `date_input`/`datetime_input` (and their
+  `required_*`/`*_htmx` variants) build their `class`/`aria-invalid`
+  attributes from an `if has_errors { A } else { B }` expression where `A`
+  and `B` are always one of a small, fixed set of compile-time string
+  literals (`"autumn-field__input"`, `"true"`/`"false"`, etc.). Passed to
+  `maud::html!`'s `(...)` splice as plain `&str`, each of those literals ran
+  through `maud::escape_to_string`'s byte-by-byte HTML-escaping scan on
+  every render even though the value can never contain a character that
+  needs escaping. Wrapping the literals in `maud::PreEscaped(...)` — the
+  same mechanism the form helpers already use elsewhere for known-safe
+  content — skips the scan entirely; behavior and output are unchanged.
+
+  Measured with the committed `autumn/benches/form_render.rs` harness (a
+  realistic 12-field scaffolded form, two fields carrying validation errors,
+  3,000 iterations = 3,050 renders), `valgrind --tool=callgrind`, before and
+  after on the same machine:
+
+  | | before | after | delta |
+  | --- | ---: | ---: | ---: |
+  | Instructions (3,000-iteration run) | 220,034,852 | 203,355,183 | **-7.58%** |
+  | `maud::escape_to_string` instructions | 65,998,950 (30.0%) | 48,339,450 (23.8%) | **-26.8%** |
+
+  Allocation counts are unchanged (`escape_to_string` writes into an
+  already-allocated buffer; the win is pure CPU, not allocations) — all 203
+  `form`/`nested_form` lib tests pass unchanged.
 
 ## [0.7.0] - 2026-08-23
 

--- a/autumn/src/form.rs
+++ b/autumn/src/form.rs
@@ -1015,8 +1015,8 @@ pub fn text_input<T: Serialize>(
                 id=(field)
                 name=(field)
                 value=(value)
-                class=(if has_errors { "autumn-field__input autumn-field__input--invalid" } else { "autumn-field__input" })
-                aria-invalid=(if has_errors { "true" } else { "false" })
+                class=(if has_errors { maud::PreEscaped("autumn-field__input autumn-field__input--invalid") } else { maud::PreEscaped("autumn-field__input") })
+                aria-invalid=(if has_errors { maud::PreEscaped("true") } else { maud::PreEscaped("false") })
                 aria-describedby=(if has_errors { error_id.as_str() } else { "" });
             @if has_errors {
                 div id=(error_id) role="alert" class="autumn-field__errors" {
@@ -1154,8 +1154,8 @@ pub fn text_input_htmx_with_token_field<T: Serialize>(
                 id=(field)
                 name=(field)
                 value=(value)
-                class=(if has_errors { "autumn-field__input autumn-field__input--invalid" } else { "autumn-field__input" })
-                aria-invalid=(if has_errors { "true" } else { "false" })
+                class=(if has_errors { maud::PreEscaped("autumn-field__input autumn-field__input--invalid") } else { maud::PreEscaped("autumn-field__input") })
+                aria-invalid=(if has_errors { maud::PreEscaped("true") } else { maud::PreEscaped("false") })
                 aria-describedby=(if has_errors { error_id.as_str() } else { "" })
                 hx-post=(validate_url)
                 hx-trigger="change"
@@ -1244,8 +1244,8 @@ pub fn required_text_input_htmx_with_token_field<T: Serialize>(
                 value=(value)
                 required
                 aria-required="true"
-                class=(if has_errors { "autumn-field__input autumn-field__input--invalid" } else { "autumn-field__input" })
-                aria-invalid=(if has_errors { "true" } else { "false" })
+                class=(if has_errors { maud::PreEscaped("autumn-field__input autumn-field__input--invalid") } else { maud::PreEscaped("autumn-field__input") })
+                aria-invalid=(if has_errors { maud::PreEscaped("true") } else { maud::PreEscaped("false") })
                 aria-describedby=(if has_errors { error_id.as_str() } else { "" })
                 hx-post=(validate_url)
                 hx-trigger="change"
@@ -1301,8 +1301,8 @@ pub fn password_input<T: Serialize>(
                 type="password"
                 id=(field)
                 name=(field)
-                class=(if has_errors { "autumn-field__input autumn-field__input--invalid" } else { "autumn-field__input" })
-                aria-invalid=(if has_errors { "true" } else { "false" })
+                class=(if has_errors { maud::PreEscaped("autumn-field__input autumn-field__input--invalid") } else { maud::PreEscaped("autumn-field__input") })
+                aria-invalid=(if has_errors { maud::PreEscaped("true") } else { maud::PreEscaped("false") })
                 aria-describedby=(if has_errors { error_id.as_str() } else { "" });
             @if has_errors {
                 div id=(error_id) role="alert" class="autumn-field__errors" {
@@ -1339,8 +1339,8 @@ pub fn textarea_input<T: Serialize>(
             textarea
                 id=(field)
                 name=(field)
-                class=(if has_errors { "autumn-field__input autumn-field__input--invalid" } else { "autumn-field__input" })
-                aria-invalid=(if has_errors { "true" } else { "false" })
+                class=(if has_errors { maud::PreEscaped("autumn-field__input autumn-field__input--invalid") } else { maud::PreEscaped("autumn-field__input") })
+                aria-invalid=(if has_errors { maud::PreEscaped("true") } else { maud::PreEscaped("false") })
                 aria-describedby=(if has_errors { error_id.as_str() } else { "" })
                 { (value) }
             @if has_errors {
@@ -1646,8 +1646,8 @@ fn rich_text_area_inner<T: Serialize>(
                 id=(field)
                 name=(field)
                 rows="12"
-                class=(if has_errors { "autumn-field__input autumn-rich-text__editor autumn-field__input--invalid" } else { "autumn-field__input autumn-rich-text__editor" })
-                aria-invalid=(if has_errors { "true" } else { "false" })
+                class=(if has_errors { maud::PreEscaped("autumn-field__input autumn-rich-text__editor autumn-field__input--invalid") } else { maud::PreEscaped("autumn-field__input autumn-rich-text__editor") })
+                aria-invalid=(if has_errors { maud::PreEscaped("true") } else { maud::PreEscaped("false") })
                 aria-describedby=(described_by)
                 required[required]
                 aria-required=[required.then_some("true")]
@@ -1735,7 +1735,7 @@ pub fn required_text_input<T: Serialize>(
                 value=(value)
                 required
                 aria-required="true"
-                aria-invalid=(if has_errors { "true" } else { "false" })
+                aria-invalid=(if has_errors { maud::PreEscaped("true") } else { maud::PreEscaped("false") })
                 aria-describedby=(if has_errors { error_id.as_str() } else { "" });
             @if has_errors {
                 div id=(error_id) role="alert" {
@@ -1803,8 +1803,8 @@ pub fn checkbox_input<T: Serialize>(
                 name=(field)
                 value="true"
                 checked[checked]
-                class=(if has_errors { "autumn-field__input autumn-field__input--invalid" } else { "autumn-field__input" })
-                aria-invalid=(if has_errors { "true" } else { "false" })
+                class=(if has_errors { maud::PreEscaped("autumn-field__input autumn-field__input--invalid") } else { maud::PreEscaped("autumn-field__input") })
+                aria-invalid=(if has_errors { maud::PreEscaped("true") } else { maud::PreEscaped("false") })
                 aria-describedby=(if has_errors { error_id.as_str() } else { "" });
             @if has_errors {
                 div id=(error_id) role="alert" class="autumn-field__errors" {
@@ -1848,8 +1848,8 @@ pub fn number_input<T: Serialize>(
                 name=(field)
                 value=(value)
                 step=[step]
-                class=(if has_errors { "autumn-field__input autumn-field__input--invalid" } else { "autumn-field__input" })
-                aria-invalid=(if has_errors { "true" } else { "false" })
+                class=(if has_errors { maud::PreEscaped("autumn-field__input autumn-field__input--invalid") } else { maud::PreEscaped("autumn-field__input") })
+                aria-invalid=(if has_errors { maud::PreEscaped("true") } else { maud::PreEscaped("false") })
                 aria-describedby=(if has_errors { error_id.as_str() } else { "" });
             @if has_errors {
                 div id=(error_id) role="alert" class="autumn-field__errors" {
@@ -1892,8 +1892,8 @@ pub fn required_number_input<T: Serialize>(
                 step=[step]
                 required
                 aria-required="true"
-                class=(if has_errors { "autumn-field__input autumn-field__input--invalid" } else { "autumn-field__input" })
-                aria-invalid=(if has_errors { "true" } else { "false" })
+                class=(if has_errors { maud::PreEscaped("autumn-field__input autumn-field__input--invalid") } else { maud::PreEscaped("autumn-field__input") })
+                aria-invalid=(if has_errors { maud::PreEscaped("true") } else { maud::PreEscaped("false") })
                 aria-describedby=(if has_errors { error_id.as_str() } else { "" });
             @if has_errors {
                 div id=(error_id) role="alert" class="autumn-field__errors" {
@@ -2276,8 +2276,8 @@ pub fn date_input<T: Serialize>(
                 id=(field)
                 name=(field)
                 value=(value)
-                class=(if has_errors { "autumn-field__input autumn-field__input--invalid" } else { "autumn-field__input" })
-                aria-invalid=(if has_errors { "true" } else { "false" })
+                class=(if has_errors { maud::PreEscaped("autumn-field__input autumn-field__input--invalid") } else { maud::PreEscaped("autumn-field__input") })
+                aria-invalid=(if has_errors { maud::PreEscaped("true") } else { maud::PreEscaped("false") })
                 aria-describedby=(if has_errors { error_id.as_str() } else { "" });
             @if has_errors {
                 div id=(error_id) role="alert" class="autumn-field__errors" {
@@ -2318,8 +2318,8 @@ pub fn required_date_input<T: Serialize>(
                 value=(value)
                 required
                 aria-required="true"
-                class=(if has_errors { "autumn-field__input autumn-field__input--invalid" } else { "autumn-field__input" })
-                aria-invalid=(if has_errors { "true" } else { "false" })
+                class=(if has_errors { maud::PreEscaped("autumn-field__input autumn-field__input--invalid") } else { maud::PreEscaped("autumn-field__input") })
+                aria-invalid=(if has_errors { maud::PreEscaped("true") } else { maud::PreEscaped("false") })
                 aria-describedby=(if has_errors { error_id.as_str() } else { "" });
             @if has_errors {
                 div id=(error_id) role="alert" class="autumn-field__errors" {
@@ -2390,8 +2390,8 @@ pub fn datetime_input<T: Serialize>(
                 name=(field)
                 value=(value)
                 step="any"
-                class=(if has_errors { "autumn-field__input autumn-field__input--invalid" } else { "autumn-field__input" })
-                aria-invalid=(if has_errors { "true" } else { "false" })
+                class=(if has_errors { maud::PreEscaped("autumn-field__input autumn-field__input--invalid") } else { maud::PreEscaped("autumn-field__input") })
+                aria-invalid=(if has_errors { maud::PreEscaped("true") } else { maud::PreEscaped("false") })
                 aria-describedby=(if has_errors { error_id.as_str() } else { "" });
             @if has_errors {
                 div id=(error_id) role="alert" class="autumn-field__errors" {
@@ -2433,8 +2433,8 @@ pub fn required_datetime_input<T: Serialize>(
                 step="any"
                 required
                 aria-required="true"
-                class=(if has_errors { "autumn-field__input autumn-field__input--invalid" } else { "autumn-field__input" })
-                aria-invalid=(if has_errors { "true" } else { "false" })
+                class=(if has_errors { maud::PreEscaped("autumn-field__input autumn-field__input--invalid") } else { maud::PreEscaped("autumn-field__input") })
+                aria-invalid=(if has_errors { maud::PreEscaped("true") } else { maud::PreEscaped("false") })
                 aria-describedby=(if has_errors { error_id.as_str() } else { "" });
             @if has_errors {
                 div id=(error_id) role="alert" class="autumn-field__errors" {
@@ -2480,8 +2480,8 @@ pub fn select_input<T: Serialize>(
             select
                 id=(field)
                 name=(field)
-                class=(if has_errors { "autumn-field__input autumn-field__input--invalid" } else { "autumn-field__input" })
-                aria-invalid=(if has_errors { "true" } else { "false" })
+                class=(if has_errors { maud::PreEscaped("autumn-field__input autumn-field__input--invalid") } else { maud::PreEscaped("autumn-field__input") })
+                aria-invalid=(if has_errors { maud::PreEscaped("true") } else { maud::PreEscaped("false") })
                 aria-describedby=(if has_errors { error_id.as_str() } else { "" }) {
                 @for (option_value, option_label) in options {
                     option value=(option_value) selected[*option_value == current] { (option_label) }
@@ -2527,8 +2527,8 @@ pub fn required_select_input<T: Serialize>(
                 name=(field)
                 required
                 aria-required="true"
-                class=(if has_errors { "autumn-field__input autumn-field__input--invalid" } else { "autumn-field__input" })
-                aria-invalid=(if has_errors { "true" } else { "false" })
+                class=(if has_errors { maud::PreEscaped("autumn-field__input autumn-field__input--invalid") } else { maud::PreEscaped("autumn-field__input") })
+                aria-invalid=(if has_errors { maud::PreEscaped("true") } else { maud::PreEscaped("false") })
                 aria-describedby=(if has_errors { error_id.as_str() } else { "" }) {
                 @for (option_value, option_label) in options {
                     option value=(option_value) selected[*option_value == current] { (option_label) }


### PR DESCRIPTION
🎯 **Workload**

The committed `autumn/benches/form_render.rs` harness (`harness = false`): a realistic 12-field scaffolded form (mixed text/password/textarea/number/checkbox/date inputs, two fields carrying validation errors, matching a re-rendered failed submission), rendered through the real `autumn_web::form` helpers.

```sh
cargo build --release -p autumn-web --bench form_render
BIN=$(find target/release/deps -maxdepth 1 -name "form_render-*" -type f ! -name "*.d")
valgrind --tool=callgrind --callgrind-out-file=callgrind.out "$BIN" --iterations 3000
callgrind_annotate --threshold=85 callgrind.out | head -30
```

📈 **Profile**

Profiled at current `trunk-dev` HEAD (post-#2295, which fixed `Changeset::field_value`'s redundant JSON re-serialization). With that cost gone, `maud::escape::escape_to_string` is now the single largest line item:

```
65,998,950 (30.0%)  maud::escape::escape_to_string
18,627,043 ( 8.5%)  _int_free
12,764,969 ( 5.8%)  malloc
...
```

Walking its callers: 17.40% of total instructions come through `<str as maud::Render>::render_to` and 12.60% through `<String as maud::Render>::render_to` — i.e. genuine runtime `(...)` splices in `maud::html!`.

💡 **Hypothesis**

Every scaffolded form helper (`text_input`, `password_input`, `textarea_input`, `number_input`, `checkbox_input`, `date_input`/`datetime_input`, and their `required_*`/`*_htmx` variants) builds its `class`/`aria-invalid` attributes with `(if has_errors { "A" } else { "B" })`, where `A`/`B` are always one of a small, fixed set of compile-time string literals (`"autumn-field__input"`, `"true"`/`"false"`, etc.). Passed to `maud::html!`'s `(...)` splice as a plain `&str`, maud treats it as untrusted runtime content and re-scans it byte-by-byte in `escape_to_string` on every render — even though none of these literals can ever contain a character that needs escaping.

🔧 **Change**

Wrapped the literal branches in `maud::PreEscaped(...)` — the same mechanism these helpers already use elsewhere for known-safe content — so maud emits them directly, skipping the escape scan. 16 `aria-invalid` call sites and 15 `class` call sites across `autumn/src/form.rs`. The genuinely dynamic `value`/`label`/error-text/`field`-name splices are untouched and still escaped normally.

📊 **Measurement**

Same harness, same machine, before/after (`valgrind --tool=callgrind`, 3,000 iterations = 3,050 renders):

| | before | after | delta |
| --- | ---: | ---: | ---: |
| Instructions | 220,034,852 | 203,355,183 | **-7.58%** |
| `escape_to_string` instructions | 65,998,950 (30.0%) | 48,339,450 (23.8%) | **-26.8%** |

Clears the impact floor (≥5% instruction reduction on a benchmark exercising the real render path `autumn generate scaffold` wires into every create/edit view). Allocation counts are unchanged as expected — `escape_to_string` writes into an already-allocated buffer, so this is a pure-CPU win, not an allocation one.

All 203 `form`/`nested_form` lib tests and all 30 `a11y` integration tests (which assert on the literal rendered HTML, e.g. `aria-invalid="true"`, `class="autumn-field__input autumn-field__input--invalid"`) pass unchanged, confirming byte-identical output. `cargo fmt` clean. `cargo clippy -p autumn-web --all-targets --features maud -- -D warnings` has the same two pre-existing, unrelated toolchain-drift failures noted in #2295 (`autumn/src/pagination.rs:762` unknown lint, `autumn/src/commentable.rs:105` doc markdown) — neither touches this change.

Checked for duplicate/overlapping work first: no open PR or issue covers `form.rs` escaping or `PreEscaped` usage. The closest history is #2295 (the serialization-caching fix that surfaced this as the new #1 cost) and the unrelated, already-resolved #2193/#2198/#2199 ingress-middleware box-cascade findings.

🔬 **Reproduce**

```sh
cargo build --release -p autumn-web --bench form_render
BIN=$(find target/release/deps -maxdepth 1 -name "form_render-*" -type f ! -name "*.d")
valgrind --tool=callgrind --callgrind-out-file=callgrind.out "$BIN" --iterations 3000
callgrind_annotate --threshold=85 callgrind.out | head -30
```

---
_Generated by [Claude Code](https://claude.ai/code/session_01CPTfZ8oFPDZKdAtQwpEXT5)_