### PR TITLE
Address CI feedback on #2296: macro-scaling sweep + Redis clear() glob escaping

### DIFF
--- a/autumn-cache-redis/src/lib.rs
+++ b/autumn-cache-redis/src/lib.rs
@@ -98,6 +98,26 @@ fn ttl_millis_for_redis(ttl: std::time::Duration) -> u64 {
     u64::try_from(millis).unwrap_or(u64::MAX)
 }
 
+/// Escape Redis GLOB pattern metacharacters (`\`, `*`, `?`, `[`) in `s` so it
+/// matches only literally when used inside a `SCAN`/`KEYS` `MATCH` pattern.
+///
+/// `key_prefix` is an operator-supplied config value (`cache.redis.key_prefix`
+/// in `autumn.toml`), not attacker-controlled request input, but an operator
+/// prefix that happens to contain one of these characters (e.g. `tenant:*`)
+/// would otherwise be interpreted as a glob by [`RedisCache::clear`]'s `SCAN
+/// MATCH {prefix}:*`, letting `clear()` match — and delete — keys outside the
+/// namespace the prefix was meant to scope it to.
+fn escape_redis_glob(s: &str) -> String {
+    let mut escaped = String::with_capacity(s.len());
+    for ch in s.chars() {
+        if matches!(ch, '\\' | '*' | '?' | '[') {
+            escaped.push('\\');
+        }
+        escaped.push(ch);
+    }
+    escaped
+}
+
 /// Whether `url` needs the `rustls` `CryptoProvider` installed to connect —
 /// true only for the two TLS schemes `redis::Client::open` itself
 /// recognizes (`rediss://` and Valkey's `valkeys://`), matched
@@ -289,7 +309,7 @@ impl Cache for RedisCache {
     fn clear(&self) {
         // Use SCAN instead of KEYS to avoid blocking the Redis server on large
         // keyspaces. SCAN is O(1) per call and processes the keyspace in batches.
-        let pattern = format!("{}:*", self.key_prefix);
+        let pattern = format!("{}:*", escape_redis_glob(&self.key_prefix));
         let mut conn = self.manager.clone();
         tokio::task::block_in_place(|| {
             tokio::runtime::Handle::current().block_on(async move {
@@ -471,6 +491,24 @@ mod tests {
         // installed (if nothing else in the process had installed one
         // first) and panic instead of returning a connection error.
         assert!(needs_tls_crypto_provider("valkeys://127.0.0.1:6380/"));
+    }
+
+    #[test]
+    fn escape_redis_glob_leaves_plain_prefixes_unchanged() {
+        assert_eq!(escape_redis_glob("myapp:cache"), "myapp:cache");
+    }
+
+    #[test]
+    fn escape_redis_glob_escapes_scan_match_metacharacters() {
+        // Regression: `clear()` builds a SCAN MATCH pattern as
+        // "{key_prefix}:*". An unescaped operator-supplied prefix containing
+        // a glob metacharacter (e.g. "tenant:*") would let SCAN MATCH match
+        // — and clear() then delete — keys well outside that prefix's
+        // intended namespace.
+        assert_eq!(escape_redis_glob("tenant:*"), r"tenant:\*");
+        assert_eq!(escape_redis_glob("a?b"), r"a\?b");
+        assert_eq!(escape_redis_glob("[ab]"), r"\[ab]");
+        assert_eq!(escape_redis_glob(r"back\slash"), r"back\\slash");
     }
 
     #[test]

--- a/autumn-cli/src/dev_loop_scaling.rs
+++ b/autumn-cli/src/dev_loop_scaling.rs
@@ -126,11 +126,13 @@ pub struct ScalingReport {
 /// The generated app:
 /// - Is a **standalone workspace root** (contains `[workspace]`) so that the
 ///   `[patch.crates-io]` section appended by the live driver is valid.
-/// - Depends only on `autumn-web` at default features (which include `db`,
-///   bringing in diesel and diesel-async).
-/// - Uses `autumn_web::reexports::diesel::table!` (no separate diesel dep)
-///   and `#[autumn_web::model]` / `#[autumn_web::repository]`, exactly
-///   mirroring `autumn/tests/compile-pass/repository_no_hooks.rs`.
+/// - Depends on `autumn-web` at default features (which include `db`,
+///   bringing in diesel and diesel-async), plus direct `diesel`/`serde`/
+///   `serde_json` dependencies the generated macro expansions need at the
+///   bare crate path (see the comment on `cargo_toml` below).
+/// - Declares schema through `autumn_web::reexports::diesel::table!` and uses
+///   `#[autumn_web::model]` / `#[autumn_web::repository]`, mirroring
+///   `autumn/tests/compile-pass/repository_no_hooks.rs`.
 /// - Is **compile-only** — no Postgres is required because we never boot the
 ///   binary, only `cargo build` it.
 ///
@@ -143,6 +145,18 @@ pub fn generate_synthetic_app(n: usize) -> GeneratedApp {
     // the resolved version is whatever the repo currently is. A wildcard avoids
     // a hardcoded version that would silently break `[patch]` resolution after a
     // workspace version bump; `publish = false` makes the wildcard valid.
+    //
+    // `diesel`, `serde`, and `serde_json` are also DIRECT dependencies here even
+    // though `autumn-web` re-exports all three (`autumn_web::reexports::diesel`
+    // etc.) and pulls them in transitively: `diesel::table!` and the
+    // `#[autumn_web::model]`/`#[autumn_web::repository]` derives expand to code
+    // that references the bare `diesel`/`serde`/`serde_json` crate paths (not
+    // `$crate`-hygienic re-export paths), which only resolve when those crates
+    // are direct dependencies of the compiling crate — a transitive dependency
+    // is invisible at that path. Omitting them fails every generated model and
+    // repository with "no external crate `diesel`" / "could not find `serde`"
+    // before a single size point can even compile, mirroring the same class of
+    // gap `benchmarks/runtime/autumn` had (issue: diesel-async version skew).
     let cargo_toml = "[package]\n\
          name = \"scaling_bench_app\"\n\
          version = \"0.1.0\"\n\
@@ -152,7 +166,10 @@ pub fn generate_synthetic_app(n: usize) -> GeneratedApp {
          [workspace]\n\
          \n\
          [dependencies]\n\
-         autumn-web = \"*\"\n"
+         autumn-web = \"*\"\n\
+         diesel = { version = \"2\", features = [\"postgres\"] }\n\
+         serde = { version = \"1\", features = [\"derive\"] }\n\
+         serde_json = \"1\"\n"
         .to_string();
 
     let files = vec![
@@ -206,7 +223,7 @@ fn generate_repositories(n: usize) -> String {
     for k in 0..n {
         writeln!(
             out,
-            "#[autumn_web::repository(Entity{k})]\npub trait Entity{k}Repository {{\n\
+            "#[autumn_web::repository(Entity{k}, table = \"entity_{k}\")]\npub trait Entity{k}Repository {{\n\
              \tfn find_by_content(content: String) -> Vec<Entity{k}>;\n\
              }}\n"
         )
@@ -753,15 +770,65 @@ mod tests {
 
     #[test]
     fn generate_app_schema_uses_reexport_path() {
-        // The generated app only depends on autumn-web, not a separate diesel
-        // dep. It must use autumn_web::reexports::diesel::table! to declare
-        // schema, mirroring the compile-pass test pattern.
+        // Schema declarations go through autumn_web::reexports::diesel::table!
+        // (mirroring the compile-pass test pattern) even though the generated
+        // Cargo.toml also carries a *direct* diesel dependency — diesel's own
+        // table! macro expands to code that references the bare `diesel` path,
+        // which only resolves when diesel is a direct dependency of the
+        // compiling crate (see generate_app_cargo_toml_has_direct_macro_deps).
         let app = generate_synthetic_app(1);
         let schema = file_content(&app, "src/schema.rs");
         assert!(
             schema.contains("autumn_web::reexports::diesel::table!"),
-            "schema must use autumn_web::reexports::diesel::table! (no direct diesel dep)"
+            "schema must use autumn_web::reexports::diesel::table!"
         );
+    }
+
+    #[test]
+    fn generate_app_cargo_toml_has_direct_macro_deps() {
+        // Regression: `diesel::table!` and the `#[model]`/`#[repository]`
+        // derives expand to code referencing the bare `diesel`/`serde`/
+        // `serde_json` crate paths, not `autumn_web::reexports::...` — these
+        // only resolve when the crates are DIRECT dependencies of the
+        // compiling crate, since a transitive dependency (pulled in only via
+        // autumn-web) is invisible at that path. Omitting them fails the
+        // scaffolded app with "no external crate `diesel`" / "could not find
+        // `serde`" before a single size point can compile.
+        let app = generate_synthetic_app(1);
+        assert!(
+            app.cargo_toml.contains("diesel"),
+            "Cargo.toml must declare a direct diesel dependency"
+        );
+        assert!(
+            app.cargo_toml.contains("serde_json"),
+            "Cargo.toml must declare a direct serde_json dependency"
+        );
+        assert!(
+            app.cargo_toml.contains("serde"),
+            "Cargo.toml must declare a direct serde dependency"
+        );
+    }
+
+    #[test]
+    fn generate_app_repository_table_attr_matches_model_table_attr() {
+        // Regression: the repository macro has no way to see the model's own
+        // #[model(table = "...")] override — each macro independently infers
+        // (or is told) its table name. Since these generated models use an
+        // explicit non-default table name (entity_{k}, not the default
+        // pluralized entity{k}s), the repository attribute must carry the
+        // SAME explicit table = "entity_{k}" override, or diesel resolves it
+        // against a schema module that was never declared.
+        let n = 3;
+        let app = generate_synthetic_app(n);
+        let repos = file_content(&app, "src/repositories.rs");
+        for k in 0..n {
+            assert!(
+                repos.contains(&format!("Entity{k}, table = \"entity_{k}\"")),
+                "repository(Entity{k}) must carry the same table override as \
+                 #[model(table = \"entity_{k}\")], or it falls back to \
+                 inferring `entity{k}s`, which the schema never declares"
+            );
+        }
     }
 
     // ── apply_handler_edit ────────────────────────────────────────────────

--- a/autumn-cli/src/dev_loop_scaling.rs
+++ b/autumn-cli/src/dev_loop_scaling.rs
@@ -795,16 +795,20 @@ mod tests {
         // scaffolded app with "no external crate `diesel`" / "could not find
         // `serde`" before a single size point can compile.
         let app = generate_synthetic_app(1);
+        // Match complete manifest keys, not bare substrings: "serde" is a
+        // substring of "serde_json", so a `.contains("serde")` check alone
+        // would still pass even if the direct `serde =` entry were removed
+        // and only `serde_json` remained.
         assert!(
-            app.cargo_toml.contains("diesel"),
+            app.cargo_toml.contains("diesel ="),
             "Cargo.toml must declare a direct diesel dependency"
         );
         assert!(
-            app.cargo_toml.contains("serde_json"),
+            app.cargo_toml.contains("serde_json ="),
             "Cargo.toml must declare a direct serde_json dependency"
         );
         assert!(
-            app.cargo_toml.contains("serde"),
+            app.cargo_toml.contains("serde ="),
             "Cargo.toml must declare a direct serde dependency"
         );
     }


### PR DESCRIPTION
## Summary
Follow-up to #2297, addressing more CI failures and review feedback from PR #2296.

### 1. Macro-scaling sweep failure (1700 compile errors)
Root-caused the "Measure macro-scaling sweep" CI failure from the weekly Runtime Latency Gate sweep on `trunk-dev`. Two independent bugs in `autumn-cli/src/dev_loop_scaling.rs`'s `generate_synthetic_app` made every scaffolded scaling-benchmark app fail to compile across all sweep sizes `[1,25,50,100]`:

1. **Missing direct dependencies.** The generated `Cargo.toml` depended only on `autumn-web`. `diesel::table!` and the `#[model]`/`#[repository]` derive macros expand to code that references the bare `diesel`/`serde`/`serde_json` crate paths (not `autumn_web::reexports::...`), which only resolve when those crates are **direct** dependencies of the compiling crate — a transitive dependency pulled in only via `autumn-web` is invisible at that path. This is the same class of gap as the `diesel-async` version skew fixed in `benchmarks/runtime/autumn` in #2297.
2. **Table-name mismatch.** `generate_repositories` emitted `#[autumn_web::repository(Entity{k})]` without the `table = "entity_{k}"` override that `generate_models` pairs with the model. The `repository` macro has no way to see the model's own attribute, so it independently inferred the wrong table name (`entity{k}s`, which the schema never declares).

Verified by scaffolding the real `generate_synthetic_app` output (n=3 and n=25, matching actual generator code, not hand-transcribed) and compiling it standalone against local `autumn-web` via `[patch.crates-io]`, reproducing the original failure and confirming both fixes are independently required and jointly sufficient for a clean build.

### 2. Redis cache `clear()` glob-pattern escaping (review feedback, P2)
Addresses automated review feedback (chatgpt-codex-connector) on #2296: `RedisCache::clear()` builds its `SCAN MATCH` pattern as `"{key_prefix}:*"` without escaping `key_prefix`. An operator-configured prefix (`cache.redis.key_prefix` in `autumn.toml`) containing a Redis glob metacharacter (`*`, `?`, `[`, `\`) — e.g. `"tenant:*"` — is interpreted as part of the glob rather than a literal prefix, so `clear()` could match and delete keys well outside the namespace the prefix was meant to scope it to. Added `escape_redis_glob` and applied it before building the pattern.

## Test plan
- [x] `cargo test -p autumn-cli --bin autumn dev_loop_scaling::` — 59/59 pass, including two new regression tests
- [x] `cargo test -p autumn-cache-redis --lib` — 9/9 non-Docker tests pass, including two new regression tests for `escape_redis_glob`
- [x] `cargo fmt --all`
- [x] Manually scaffolded and compiled the scaling generator's real output at n=3 and n=25 against local `autumn-web` — clean build, 0 errors (previously 115+ errors at n=3)
- [x] Confirmed each scaling-sweep fix is independently necessary via targeted reverts

---
_Generated by [Claude Code](https://claude.ai/code/session_01La1MTD4iB4K4TWib2hK2YF)_