### PR TITLE
Address CI feedback on #2296: CSRF cache-guard + fuzz-nightly workflow fix

### DIFF
--- a/.github/workflows/fuzz-nightly.yml
+++ b/.github/workflows/fuzz-nightly.yml
@@ -61,7 +61,7 @@ jobs:
       # to the newest prior cache for this target+ref if the exact key misses, so
       # the corpus is never silently reset to the committed seeds alone.
       - name: Restore persisted corpus
-        uses: actions/cache@v7
+        uses: actions/cache@v6
         with:
           path: fuzz/corpus/${{ matrix.target }}
           key: fuzz-corpus-${{ matrix.target }}-${{ github.ref }}-${{ github.run_id }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- **consent-banner middleware now guards the already-rendered case against
+  shared-cache CSRF token replay:** when a handler (e.g. a "manage cookie
+  preferences" page) had already rendered the consent banner itself —
+  detected via `RENDERED_BANNER_MARKER` — `splice_into_response` returned
+  that response unchanged without stamping `Cache-Control: private,
+  no-store` / `Vary: Cookie`, even though the handler's own rendering
+  embeds a live, per-visitor CSRF token (`consent_banner_markup`). A shared
+  cache sitting in front of an otherwise-cacheable handler could therefore
+  serve one visitor's token-bearing form to another, leaking the token and
+  breaking that visitor's subsequent submission. The same two headers the
+  injection path already sets are now applied on this path too.
+
 ### Performance
 
 - **scaffolded form helpers no longer re-escape their own constant HTML at

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   embeds a live, per-visitor CSRF token (`consent_banner_markup`). A shared
   cache sitting in front of an otherwise-cacheable handler could therefore
   serve one visitor's token-bearing form to another, leaking the token and
-  breaking that visitor's subsequent submission. The same two headers the
-  injection path already sets are now applied on this path too.
+  causing that visitor's subsequent submission to fail CSRF validation. The
+  same two headers the injection path already sets are now applied on this
+  path too.
 
 ### Performance
 

--- a/autumn/src/consent/banner.rs
+++ b/autumn/src/consent/banner.rs
@@ -388,6 +388,17 @@ async fn splice_into_response(response: Response<Body>, snippet: &str) -> Respon
             // not just the bare class name) rather than assuming any
             // particular route.
             if contains_ascii_case_insensitive(&bytes, RENDERED_BANNER_MARKER.as_bytes()) {
+                // The handler's own rendering already carries a live,
+                // per-visitor CSRF token (see `consent_banner_markup`) —
+                // apply the same cache guards as the injection path below so
+                // a shared cache can't replay this visitor's token to
+                // someone else.
+                parts
+                    .headers
+                    .insert(CACHE_CONTROL, HeaderValue::from_static("private, no-store"));
+                parts
+                    .headers
+                    .append(VARY, HeaderValue::from_static("Cookie"));
                 return Response::from_parts(parts, Body::from(bytes));
             }
 
@@ -1277,6 +1288,46 @@ mod tests {
             html.matches(RENDERED_BANNER_MARKER).count(),
             1,
             "must not splice a second banner when the response already contains one: {html}"
+        );
+    }
+
+    #[tokio::test]
+    async fn stamps_cache_guards_when_handler_already_rendered_the_banner() {
+        // The handler's own rendering (as in the test above) carries a live,
+        // per-visitor CSRF token. Even though this middleware doesn't splice
+        // anything into that response, it must still stamp the same
+        // no-cache guards as the injection path — otherwise a shared cache
+        // could serve one visitor's token-bearing form to another.
+        let app = Router::new()
+            .route(
+                "/",
+                get(|| async {
+                    let banner = consent_banner_markup(Some("tok"), "_csrf").into_string();
+                    Response::builder()
+                        .header(CONTENT_TYPE, "text/html; charset=utf-8")
+                        .body(Body::from(format!("<html><body>{banner}</body></html>")))
+                        .unwrap()
+                }),
+            )
+            .layer(axum::middleware::from_fn(move |req, next| async move {
+                inject_consent_banner(req, next, 1, "autumn-csrf", "_csrf").await
+            }));
+        let response = app
+            .oneshot(Request::builder().uri("/").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(
+            response
+                .headers()
+                .get(CACHE_CONTROL)
+                .and_then(|v| v.to_str().ok()),
+            Some("private, no-store"),
+            "an already-rendered banner still carries a live CSRF token and must not be cached"
+        );
+        assert_eq!(
+            response.headers().get(VARY).and_then(|v| v.to_str().ok()),
+            Some("Cookie"),
+            "a shared cache must vary on the visitor's consent/CSRF cookie"
         );
     }
 


### PR DESCRIPTION
## Summary

- Fixes a P2 finding from `chatgpt-codex-connector` on #2296: `splice_into_response`'s already-rendered-banner early return (in `autumn/src/consent/banner.rs`) skipped the `Cache-Control: private, no-store` / `Vary: Cookie` guards the injection path just below it sets — even though the handler's own rendering (`consent_banner_markup`) embeds a live, per-visitor CSRF token. A shared cache in front of an otherwise-cacheable handler (e.g. a "manage cookie preferences" page) could serve one visitor's token-bearing form to another, leaking the token and causing that visitor's subsequent submission to fail CSRF validation.
- Applies the same two header stamps the injection path already uses, and adds a regression test asserting both headers on the already-rendered path.
- Adds a `### Security` entry under `## [Unreleased]` in `CHANGELOG.md` per repo convention.
- Fixes `.github/workflows/fuzz-nightly.yml`'s `actions/cache@v7` pin — that version doesn't exist (latest is v6), so all five "Fuzz long-run" matrix legs failed identically at the corpus-restore step on #2296's scheduled nightly run, before any fuzzing ran. Not a fuzz finding — a workflow typo.

This branch was previously used for #2297 and #2299 (both merged); per the repo's branch-restart convention it was reset to the latest `trunk-dev` for this follow-up work.

## Test plan

- [x] `cargo test -p autumn-web --lib consent::banner::` — 46 passed, including the new `stamps_cache_guards_when_handler_already_rendered_the_banner` regression test
- [x] `cargo fmt --all`
- [x] `python3 -c "import yaml; yaml.safe_load(...)"` on the edited workflow file
- [x] CI (Lint, Test matrix, etc.) — green