### PR TITLE
⚡ Bolt: defer error_id allocation to fields that actually have errors (instructions -8.65%, allocs -16.1%)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   already-allocated buffer; the win is pure CPU, not allocations) — all 203
   `form`/`nested_form` lib tests pass unchanged.
 
+- **scaffolded form helpers no longer allocate a validation-error id string
+  on fields that have no error:** `text_input`, `password_input`,
+  `textarea_input`, `number_input`, `checkbox_input`,
+  `date_input`/`datetime_input` (and their `required_*`/`*_htmx` variants),
+  plus the newer `a11y`-routed `wrap_field_control`, unconditionally built
+  `format!("{field}-error")` up front, even though the string is read only
+  when that field actually carries a validation error. On a realistic
+  scaffolded form most fields don't — the committed 12-field
+  `autumn/benches/form_render.rs` workload has errors on 2 of 12. The fix
+  defers the `format!` behind `has_errors.then(...)`, allocating only when
+  the id is actually needed; output is byte-for-byte unchanged (verified by
+  the unchanged 203 form/nested_form lib tests).
+
+  Measured with a new allocation gate
+  (`autumn/tests/form_render_alloc_gate.rs`, `allocation-counter`, same
+  12-field workload) and `valgrind --tool=callgrind` on the existing
+  `form_render` bench (3,000 iterations = 3,050 renders), before and after
+  on the same machine:
+
+  | | before | after | delta |
+  | --- | ---: | ---: | ---: |
+  | Instructions (3,000-iteration run) | 203,331,276 | 185,748,259 | **-8.65%** |
+  | `alloc::fmt::format::format_inner` instructions | 6,734,400 (3.31%) | 3,928,400 (2.11%) | **-41.7%** |
+  | Allocation blocks (200 renders) | 24,800 | 20,800 | **-16.1%** |
+  | Allocation bytes (200 renders) | 4,498,200 | 4,495,800 | -0.05% |
+
+  Bytes barely move — each wasted allocation is a handful of bytes against a
+  ~22KB/render budget dominated by larger buffers — but the block-count and
+  instruction-count deltas both clear the impact floor on their own.
+
 ## [0.7.0] - 2026-08-23
 
 For a narrative tour of this release, see the

--- a/autumn/Cargo.toml
+++ b/autumn/Cargo.toml
@@ -476,6 +476,14 @@ path = "tests/config_alloc_gate.rs"
 name = "password_policy_alloc_gate"
 path = "tests/password_policy_alloc_gate.rs"
 
+# Allocation gate for the scaffolded form-render helpers on the same 12-field
+# workload as `benches/form_render.rs` (Bolt follow-up to #2295/#2298, looking
+# at the per-field `error_id` allocation). Own binary for the same
+# `allocation-counter` global-allocator reason as `config_alloc_gate` above.
+[[test]]
+name = "form_render_alloc_gate"
+path = "tests/form_render_alloc_gate.rs"
+
 # SQLite runtime-lane boot+serve proof (issue #1614, PR2). Only meaningful under
 # `--features sqlite`; the file is `#![cfg(feature = "sqlite")]` so a default
 # `cargo test` compiles it to an empty (passing) binary. Run explicitly:

--- a/autumn/src/form.rs
+++ b/autumn/src/form.rs
@@ -1004,7 +1004,7 @@ pub fn text_input<T: Serialize>(
     let errors = changeset.errors_for(field);
     let has_errors = !errors.is_empty();
     let value = changeset.field_value(field).unwrap_or_default();
-    let error_id = format!("{field}-error");
+    let error_id = has_errors.then(|| format!("{field}-error"));
     let wrapper_id = format!("{field}-field");
 
     maud::html! {
@@ -1017,9 +1017,9 @@ pub fn text_input<T: Serialize>(
                 value=(value)
                 class=(if has_errors { maud::PreEscaped("autumn-field__input autumn-field__input--invalid") } else { maud::PreEscaped("autumn-field__input") })
                 aria-invalid=(if has_errors { maud::PreEscaped("true") } else { maud::PreEscaped("false") })
-                aria-describedby=(if has_errors { error_id.as_str() } else { "" });
+                aria-describedby=(error_id.as_deref().unwrap_or(""));
             @if has_errors {
-                div id=(error_id) role="alert" class="autumn-field__errors" {
+                div id=(error_id.as_deref().unwrap_or_default()) role="alert" class="autumn-field__errors" {
                     @for error in errors {
                         p class="autumn-field__error" { (error) }
                     }
@@ -1141,7 +1141,7 @@ pub fn text_input_htmx_with_token_field<T: Serialize>(
     let errors = changeset.errors_for(field);
     let has_errors = !errors.is_empty();
     let value = changeset.field_value(field).unwrap_or_default();
-    let error_id = format!("{field}-error");
+    let error_id = has_errors.then(|| format!("{field}-error"));
     let wrapper_id = format!("{field}-field");
     let target = "closest [data-autumn-field-wrapper]";
     let hx_params = format!("not {token_field}");
@@ -1156,7 +1156,7 @@ pub fn text_input_htmx_with_token_field<T: Serialize>(
                 value=(value)
                 class=(if has_errors { maud::PreEscaped("autumn-field__input autumn-field__input--invalid") } else { maud::PreEscaped("autumn-field__input") })
                 aria-invalid=(if has_errors { maud::PreEscaped("true") } else { maud::PreEscaped("false") })
-                aria-describedby=(if has_errors { error_id.as_str() } else { "" })
+                aria-describedby=(error_id.as_deref().unwrap_or(""))
                 hx-post=(validate_url)
                 hx-trigger="change"
                 hx-target=(target)
@@ -1164,7 +1164,7 @@ pub fn text_input_htmx_with_token_field<T: Serialize>(
                 hx-include="closest form"
                 hx-params=(hx_params);
             @if has_errors {
-                div id=(error_id) role="alert" class="autumn-field__errors" {
+                div id=(error_id.as_deref().unwrap_or_default()) role="alert" class="autumn-field__errors" {
                     @for error in errors {
                         p class="autumn-field__error" { (error) }
                     }
@@ -1229,7 +1229,7 @@ pub fn required_text_input_htmx_with_token_field<T: Serialize>(
     let errors = changeset.errors_for(field);
     let has_errors = !errors.is_empty();
     let value = changeset.field_value(field).unwrap_or_default();
-    let error_id = format!("{field}-error");
+    let error_id = has_errors.then(|| format!("{field}-error"));
     let wrapper_id = format!("{field}-field");
     let target = "closest [data-autumn-field-wrapper]";
     let hx_params = format!("not {token_field}");
@@ -1246,7 +1246,7 @@ pub fn required_text_input_htmx_with_token_field<T: Serialize>(
                 aria-required="true"
                 class=(if has_errors { maud::PreEscaped("autumn-field__input autumn-field__input--invalid") } else { maud::PreEscaped("autumn-field__input") })
                 aria-invalid=(if has_errors { maud::PreEscaped("true") } else { maud::PreEscaped("false") })
-                aria-describedby=(if has_errors { error_id.as_str() } else { "" })
+                aria-describedby=(error_id.as_deref().unwrap_or(""))
                 hx-post=(validate_url)
                 hx-trigger="change"
                 hx-target=(target)
@@ -1254,7 +1254,7 @@ pub fn required_text_input_htmx_with_token_field<T: Serialize>(
                 hx-include="closest form"
                 hx-params=(hx_params);
             @if has_errors {
-                div id=(error_id) role="alert" class="autumn-field__errors" {
+                div id=(error_id.as_deref().unwrap_or_default()) role="alert" class="autumn-field__errors" {
                     @for error in errors {
                         p class="autumn-field__error" { (error) }
                     }
@@ -1291,7 +1291,7 @@ pub fn password_input<T: Serialize>(
 ) -> maud::Markup {
     let errors = changeset.errors_for(field);
     let has_errors = !errors.is_empty();
-    let error_id = format!("{field}-error");
+    let error_id = has_errors.then(|| format!("{field}-error"));
     let wrapper_id = format!("{field}-field");
 
     maud::html! {
@@ -1303,9 +1303,9 @@ pub fn password_input<T: Serialize>(
                 name=(field)
                 class=(if has_errors { maud::PreEscaped("autumn-field__input autumn-field__input--invalid") } else { maud::PreEscaped("autumn-field__input") })
                 aria-invalid=(if has_errors { maud::PreEscaped("true") } else { maud::PreEscaped("false") })
-                aria-describedby=(if has_errors { error_id.as_str() } else { "" });
+                aria-describedby=(error_id.as_deref().unwrap_or(""));
             @if has_errors {
-                div id=(error_id) role="alert" class="autumn-field__errors" {
+                div id=(error_id.as_deref().unwrap_or_default()) role="alert" class="autumn-field__errors" {
                     @for error in errors {
                         p class="autumn-field__error" { (error) }
                     }
@@ -1330,7 +1330,7 @@ pub fn textarea_input<T: Serialize>(
     let errors = changeset.errors_for(field);
     let has_errors = !errors.is_empty();
     let value = changeset.field_value(field).unwrap_or_default();
-    let error_id = format!("{field}-error");
+    let error_id = has_errors.then(|| format!("{field}-error"));
     let wrapper_id = format!("{field}-field");
 
     maud::html! {
@@ -1341,10 +1341,10 @@ pub fn textarea_input<T: Serialize>(
                 name=(field)
                 class=(if has_errors { maud::PreEscaped("autumn-field__input autumn-field__input--invalid") } else { maud::PreEscaped("autumn-field__input") })
                 aria-invalid=(if has_errors { maud::PreEscaped("true") } else { maud::PreEscaped("false") })
-                aria-describedby=(if has_errors { error_id.as_str() } else { "" })
+                aria-describedby=(error_id.as_deref().unwrap_or(""))
                 { (value) }
             @if has_errors {
-                div id=(error_id) role="alert" class="autumn-field__errors" {
+                div id=(error_id.as_deref().unwrap_or_default()) role="alert" class="autumn-field__errors" {
                     @for error in errors {
                         p class="autumn-field__error" { (error) }
                     }
@@ -1617,14 +1617,14 @@ fn rich_text_area_inner<T: Serialize>(
     let errors = changeset.errors_for(field);
     let has_errors = !errors.is_empty();
     let value = changeset.field_value(field).unwrap_or_default();
-    let error_id = format!("{field}-error");
+    let error_id = has_errors.then(|| format!("{field}-error"));
     let hint_id = format!("{field}-hint");
     let wrapper_id = format!("{field}-field");
     let preview_id = format!("{field}-preview");
     // The hint is always present, so `aria-describedby` is never empty and
     // never names an element that isn't in the DOM.
     let described_by = if has_errors {
-        format!("{hint_id} {error_id}")
+        format!("{hint_id} {}", error_id.as_deref().unwrap_or_default())
     } else {
         hint_id.clone()
     };
@@ -1660,7 +1660,7 @@ fn rich_text_area_inner<T: Serialize>(
                 { (value) }
             p id=(hint_id) class="autumn-rich-text__hint" { (RICH_TEXT_HINT) }
             @if has_errors {
-                div id=(error_id) role="alert" class="autumn-field__errors" {
+                div id=(error_id.as_deref().unwrap_or_default()) role="alert" class="autumn-field__errors" {
                     @for error in errors {
                         p class="autumn-field__error" { (error) }
                     }
@@ -1722,7 +1722,7 @@ pub fn required_text_input<T: Serialize>(
     let errors = changeset.errors_for(field);
     let has_errors = !errors.is_empty();
     let value = changeset.field_value(field).unwrap_or_default();
-    let error_id = format!("{field}-error");
+    let error_id = has_errors.then(|| format!("{field}-error"));
     let wrapper_id = format!("{field}-field");
 
     maud::html! {
@@ -1736,9 +1736,9 @@ pub fn required_text_input<T: Serialize>(
                 required
                 aria-required="true"
                 aria-invalid=(if has_errors { maud::PreEscaped("true") } else { maud::PreEscaped("false") })
-                aria-describedby=(if has_errors { error_id.as_str() } else { "" });
+                aria-describedby=(error_id.as_deref().unwrap_or(""));
             @if has_errors {
-                div id=(error_id) role="alert" {
+                div id=(error_id.as_deref().unwrap_or_default()) role="alert" {
                     @for error in errors {
                         p { (error) }
                     }
@@ -1791,7 +1791,7 @@ pub fn checkbox_input<T: Serialize>(
     let errors = changeset.errors_for(field);
     let has_errors = !errors.is_empty();
     let checked = changeset.field_value(field).as_deref() == Some("true");
-    let error_id = format!("{field}-error");
+    let error_id = has_errors.then(|| format!("{field}-error"));
     let wrapper_id = format!("{field}-field");
 
     maud::html! {
@@ -1805,9 +1805,9 @@ pub fn checkbox_input<T: Serialize>(
                 checked[checked]
                 class=(if has_errors { maud::PreEscaped("autumn-field__input autumn-field__input--invalid") } else { maud::PreEscaped("autumn-field__input") })
                 aria-invalid=(if has_errors { maud::PreEscaped("true") } else { maud::PreEscaped("false") })
-                aria-describedby=(if has_errors { error_id.as_str() } else { "" });
+                aria-describedby=(error_id.as_deref().unwrap_or(""));
             @if has_errors {
-                div id=(error_id) role="alert" class="autumn-field__errors" {
+                div id=(error_id.as_deref().unwrap_or_default()) role="alert" class="autumn-field__errors" {
                     @for error in errors {
                         p class="autumn-field__error" { (error) }
                     }
@@ -1836,7 +1836,7 @@ pub fn number_input<T: Serialize>(
     let errors = changeset.errors_for(field);
     let has_errors = !errors.is_empty();
     let value = changeset.field_value(field).unwrap_or_default();
-    let error_id = format!("{field}-error");
+    let error_id = has_errors.then(|| format!("{field}-error"));
     let wrapper_id = format!("{field}-field");
 
     maud::html! {
@@ -1850,9 +1850,9 @@ pub fn number_input<T: Serialize>(
                 step=[step]
                 class=(if has_errors { maud::PreEscaped("autumn-field__input autumn-field__input--invalid") } else { maud::PreEscaped("autumn-field__input") })
                 aria-invalid=(if has_errors { maud::PreEscaped("true") } else { maud::PreEscaped("false") })
-                aria-describedby=(if has_errors { error_id.as_str() } else { "" });
+                aria-describedby=(error_id.as_deref().unwrap_or(""));
             @if has_errors {
-                div id=(error_id) role="alert" class="autumn-field__errors" {
+                div id=(error_id.as_deref().unwrap_or_default()) role="alert" class="autumn-field__errors" {
                     @for error in errors {
                         p class="autumn-field__error" { (error) }
                     }
@@ -1878,7 +1878,7 @@ pub fn required_number_input<T: Serialize>(
     let errors = changeset.errors_for(field);
     let has_errors = !errors.is_empty();
     let value = changeset.field_value(field).unwrap_or_default();
-    let error_id = format!("{field}-error");
+    let error_id = has_errors.then(|| format!("{field}-error"));
     let wrapper_id = format!("{field}-field");
 
     maud::html! {
@@ -1894,9 +1894,9 @@ pub fn required_number_input<T: Serialize>(
                 aria-required="true"
                 class=(if has_errors { maud::PreEscaped("autumn-field__input autumn-field__input--invalid") } else { maud::PreEscaped("autumn-field__input") })
                 aria-invalid=(if has_errors { maud::PreEscaped("true") } else { maud::PreEscaped("false") })
-                aria-describedby=(if has_errors { error_id.as_str() } else { "" });
+                aria-describedby=(error_id.as_deref().unwrap_or(""));
             @if has_errors {
-                div id=(error_id) role="alert" class="autumn-field__errors" {
+                div id=(error_id.as_deref().unwrap_or_default()) role="alert" class="autumn-field__errors" {
                     @for error in errors {
                         p class="autumn-field__error" { (error) }
                     }
@@ -2265,7 +2265,7 @@ pub fn date_input<T: Serialize>(
     let errors = changeset.errors_for(field);
     let has_errors = !errors.is_empty();
     let value = normalize_date_value(&changeset.field_value(field).unwrap_or_default());
-    let error_id = format!("{field}-error");
+    let error_id = has_errors.then(|| format!("{field}-error"));
     let wrapper_id = format!("{field}-field");
 
     maud::html! {
@@ -2278,9 +2278,9 @@ pub fn date_input<T: Serialize>(
                 value=(value)
                 class=(if has_errors { maud::PreEscaped("autumn-field__input autumn-field__input--invalid") } else { maud::PreEscaped("autumn-field__input") })
                 aria-invalid=(if has_errors { maud::PreEscaped("true") } else { maud::PreEscaped("false") })
-                aria-describedby=(if has_errors { error_id.as_str() } else { "" });
+                aria-describedby=(error_id.as_deref().unwrap_or(""));
             @if has_errors {
-                div id=(error_id) role="alert" class="autumn-field__errors" {
+                div id=(error_id.as_deref().unwrap_or_default()) role="alert" class="autumn-field__errors" {
                     @for error in errors {
                         p class="autumn-field__error" { (error) }
                     }
@@ -2305,7 +2305,7 @@ pub fn required_date_input<T: Serialize>(
     let errors = changeset.errors_for(field);
     let has_errors = !errors.is_empty();
     let value = normalize_date_value(&changeset.field_value(field).unwrap_or_default());
-    let error_id = format!("{field}-error");
+    let error_id = has_errors.then(|| format!("{field}-error"));
     let wrapper_id = format!("{field}-field");
 
     maud::html! {
@@ -2320,9 +2320,9 @@ pub fn required_date_input<T: Serialize>(
                 aria-required="true"
                 class=(if has_errors { maud::PreEscaped("autumn-field__input autumn-field__input--invalid") } else { maud::PreEscaped("autumn-field__input") })
                 aria-invalid=(if has_errors { maud::PreEscaped("true") } else { maud::PreEscaped("false") })
-                aria-describedby=(if has_errors { error_id.as_str() } else { "" });
+                aria-describedby=(error_id.as_deref().unwrap_or(""));
             @if has_errors {
-                div id=(error_id) role="alert" class="autumn-field__errors" {
+                div id=(error_id.as_deref().unwrap_or_default()) role="alert" class="autumn-field__errors" {
                     @for error in errors {
                         p class="autumn-field__error" { (error) }
                     }
@@ -2378,7 +2378,7 @@ pub fn datetime_input<T: Serialize>(
     let errors = changeset.errors_for(field);
     let has_errors = !errors.is_empty();
     let value = normalize_datetime_local_value(&changeset.field_value(field).unwrap_or_default());
-    let error_id = format!("{field}-error");
+    let error_id = has_errors.then(|| format!("{field}-error"));
     let wrapper_id = format!("{field}-field");
 
     maud::html! {
@@ -2392,9 +2392,9 @@ pub fn datetime_input<T: Serialize>(
                 step="any"
                 class=(if has_errors { maud::PreEscaped("autumn-field__input autumn-field__input--invalid") } else { maud::PreEscaped("autumn-field__input") })
                 aria-invalid=(if has_errors { maud::PreEscaped("true") } else { maud::PreEscaped("false") })
-                aria-describedby=(if has_errors { error_id.as_str() } else { "" });
+                aria-describedby=(error_id.as_deref().unwrap_or(""));
             @if has_errors {
-                div id=(error_id) role="alert" class="autumn-field__errors" {
+                div id=(error_id.as_deref().unwrap_or_default()) role="alert" class="autumn-field__errors" {
                     @for error in errors {
                         p class="autumn-field__error" { (error) }
                     }
@@ -2419,7 +2419,7 @@ pub fn required_datetime_input<T: Serialize>(
     let errors = changeset.errors_for(field);
     let has_errors = !errors.is_empty();
     let value = normalize_datetime_local_value(&changeset.field_value(field).unwrap_or_default());
-    let error_id = format!("{field}-error");
+    let error_id = has_errors.then(|| format!("{field}-error"));
     let wrapper_id = format!("{field}-field");
 
     maud::html! {
@@ -2435,9 +2435,9 @@ pub fn required_datetime_input<T: Serialize>(
                 aria-required="true"
                 class=(if has_errors { maud::PreEscaped("autumn-field__input autumn-field__input--invalid") } else { maud::PreEscaped("autumn-field__input") })
                 aria-invalid=(if has_errors { maud::PreEscaped("true") } else { maud::PreEscaped("false") })
-                aria-describedby=(if has_errors { error_id.as_str() } else { "" });
+                aria-describedby=(error_id.as_deref().unwrap_or(""));
             @if has_errors {
-                div id=(error_id) role="alert" class="autumn-field__errors" {
+                div id=(error_id.as_deref().unwrap_or_default()) role="alert" class="autumn-field__errors" {
                     @for error in errors {
                         p class="autumn-field__error" { (error) }
                     }
@@ -2471,7 +2471,7 @@ pub fn select_input<T: Serialize>(
     let errors = changeset.errors_for(field);
     let has_errors = !errors.is_empty();
     let current = changeset.field_value(field).unwrap_or_default();
-    let error_id = format!("{field}-error");
+    let error_id = has_errors.then(|| format!("{field}-error"));
     let wrapper_id = format!("{field}-field");
 
     maud::html! {
@@ -2482,13 +2482,13 @@ pub fn select_input<T: Serialize>(
                 name=(field)
                 class=(if has_errors { maud::PreEscaped("autumn-field__input autumn-field__input--invalid") } else { maud::PreEscaped("autumn-field__input") })
                 aria-invalid=(if has_errors { maud::PreEscaped("true") } else { maud::PreEscaped("false") })
-                aria-describedby=(if has_errors { error_id.as_str() } else { "" }) {
+                aria-describedby=(error_id.as_deref().unwrap_or("")) {
                 @for (option_value, option_label) in options {
                     option value=(option_value) selected[*option_value == current] { (option_label) }
                 }
             }
             @if has_errors {
-                div id=(error_id) role="alert" class="autumn-field__errors" {
+                div id=(error_id.as_deref().unwrap_or_default()) role="alert" class="autumn-field__errors" {
                     @for error in errors {
                         p class="autumn-field__error" { (error) }
                     }
@@ -2516,7 +2516,7 @@ pub fn required_select_input<T: Serialize>(
     let errors = changeset.errors_for(field);
     let has_errors = !errors.is_empty();
     let current = changeset.field_value(field).unwrap_or_default();
-    let error_id = format!("{field}-error");
+    let error_id = has_errors.then(|| format!("{field}-error"));
     let wrapper_id = format!("{field}-field");
 
     maud::html! {
@@ -2529,13 +2529,13 @@ pub fn required_select_input<T: Serialize>(
                 aria-required="true"
                 class=(if has_errors { maud::PreEscaped("autumn-field__input autumn-field__input--invalid") } else { maud::PreEscaped("autumn-field__input") })
                 aria-invalid=(if has_errors { maud::PreEscaped("true") } else { maud::PreEscaped("false") })
-                aria-describedby=(if has_errors { error_id.as_str() } else { "" }) {
+                aria-describedby=(error_id.as_deref().unwrap_or("")) {
                 @for (option_value, option_label) in options {
                     option value=(option_value) selected[*option_value == current] { (option_label) }
                 }
             }
             @if has_errors {
-                div id=(error_id) role="alert" class="autumn-field__errors" {
+                div id=(error_id.as_deref().unwrap_or_default()) role="alert" class="autumn-field__errors" {
                     @for error in errors {
                         p class="autumn-field__error" { (error) }
                     }
@@ -3085,13 +3085,13 @@ fn wrap_field_control(
     control: impl maud::Render,
     errors: &[String],
 ) -> maud::Markup {
-    let error_id = format!("{field_name}-error");
+    let error_id = (!errors.is_empty()).then(|| format!("{field_name}-error"));
     let wrapper_id = format!("{field_name}-field");
     maud::html! {
         div id=(wrapper_id) class="autumn-field" {
             (control)
             @if !errors.is_empty() {
-                div id=(error_id) role="alert" class="autumn-field__errors" {
+                div id=(error_id.as_deref().unwrap_or_default()) role="alert" class="autumn-field__errors" {
                     @for error in errors {
                         p class="autumn-field__error" { (error) }
                     }

--- a/autumn/tests/form_render_alloc_gate.rs
+++ b/autumn/tests/form_render_alloc_gate.rs
@@ -1,0 +1,145 @@
+//! Isolated integration test: allocation gate for the scaffolded form-render
+//! helpers (`text_input`, `password_input`, `textarea_input`, `number_input`,
+//! `checkbox_input`, `date_input`) on the same 12-field realistic workload as
+//! the committed `autumn/benches/form_render.rs` profiling harness (title,
+//! slug, password, summary, body, price, quantity, rating, published,
+//! published_at, sku, notes — two fields, title and price, carrying
+//! validation errors, matching a re-rendered failed submission).
+//!
+//! Its own binary for the same `allocation-counter` global-allocator reason
+//! as `config_alloc_gate`/`password_policy_alloc_gate`: a process-wide
+//! counting `#[global_allocator]`, not worth taxing onto the consolidated
+//! suite to measure a handful of calls here.
+
+use std::collections::HashMap;
+
+use autumn_web::form::{
+    Changeset, checkbox_input, date_input, number_input, password_input, text_input, textarea_input,
+};
+use serde::Serialize;
+
+/// Shape of a typical scaffolded model — identical to `benches/form_render.rs`'s
+/// `Article`, kept in sync deliberately so this gate measures the same
+/// workload the profiler points at.
+#[derive(Serialize)]
+struct Article {
+    title: String,
+    slug: String,
+    author_password: String,
+    summary: String,
+    body: String,
+    price: String,
+    quantity: String,
+    rating: String,
+    published: String,
+    published_at: String,
+    sku: String,
+    notes: String,
+}
+
+fn sample_article() -> Article {
+    Article {
+        title: "Autumn Ships Named Futures".to_owned(),
+        slug: "autumn-ships-named-futures".to_owned(),
+        author_password: String::new(),
+        summary: "A short summary of the release, long enough to be realistic.".to_owned(),
+        body: "A much longer body field with several sentences of prose, the kind of \
+               content a real article body would carry when re-rendered after a \
+               failed validation submission."
+            .to_owned(),
+        price: "19.99".to_owned(),
+        quantity: "3".to_owned(),
+        rating: "4.5".to_owned(),
+        published: "true".to_owned(),
+        published_at: "2026-08-01".to_owned(),
+        sku: "ART-1042".to_owned(),
+        notes: "Internal editorial notes field.".to_owned(),
+    }
+}
+
+/// A changeset with two fields carrying validation errors, matching a
+/// realistic re-render of a failed create/update submission.
+fn sample_changeset() -> Changeset<Article> {
+    let mut errors = HashMap::new();
+    errors.insert(
+        "title".to_owned(),
+        vec!["can't be blank".to_owned(), "is too short".to_owned()],
+    );
+    errors.insert("price".to_owned(), vec!["must be a number".to_owned()]);
+    Changeset::from_errors(sample_article(), errors)
+}
+
+fn render_form(changeset: &Changeset<Article>) -> maud::Markup {
+    maud::html! {
+        form method="post" {
+            (text_input(changeset, "title", "Title"))
+            (text_input(changeset, "slug", "Slug"))
+            (password_input(changeset, "author_password", "Author password"))
+            (textarea_input(changeset, "summary", "Summary"))
+            (textarea_input(changeset, "body", "Body"))
+            (number_input(changeset, "price", "Price", Some("0.01")))
+            (number_input(changeset, "quantity", "Quantity", Some("1")))
+            (number_input(changeset, "rating", "Rating", Some("0.1")))
+            (checkbox_input(changeset, "published", "Published"))
+            (date_input(changeset, "published_at", "Published at"))
+            (text_input(changeset, "sku", "SKU"))
+            (textarea_input(changeset, "notes", "Notes"))
+        }
+    }
+}
+
+/// Enough repetitions that a per-render allocation cannot hide inside noise.
+const RENDERS: u64 = 200;
+
+#[test]
+fn scaffolded_form_render_allocations_on_a_12_field_workload() {
+    // Warm-up outside the measured window: a fresh Changeset per render (not
+    // one reused across the whole run), same reasoning as the committed bench
+    // — a real request builds a new Changeset and renders it once, so
+    // `field_value`'s internal cache fills on the render's first field access
+    // and is reused only for the rest of *that* render.
+    for _ in 0..50 {
+        let changeset = sample_changeset();
+        let _ = std::hint::black_box(render_form(&changeset).into_string());
+    }
+
+    let info = allocation_counter::measure(|| {
+        for _ in 0..RENDERS {
+            let changeset = sample_changeset();
+            let s = render_form(&changeset).into_string();
+            std::hint::black_box(&s);
+        }
+    });
+
+    let per_render_blocks = info.count_total / RENDERS;
+    let per_render_bytes = info.bytes_total / RENDERS;
+    println!(
+        "scaffolded form render: {per_render_blocks} blocks / {per_render_bytes} bytes per \
+         render ({RENDERS} renders, {} blocks / {} bytes total)",
+        info.count_total, info.bytes_total
+    );
+
+    // Baseline (debug profile, default features, deterministic across runs):
+    // 124 blocks / 22,491 bytes per render, 24,800 blocks / 4,498,200 bytes
+    // total for 200 renders. Every text/password/textarea/number/checkbox/date
+    // helper unconditionally builds `format!("{field}-error")` even on the 10
+    // of 12 fields with no validation error, where the string is never read —
+    // a fix is coming in `autumn/src/form.rs` (defer the allocation until
+    // `has_errors` is confirmed true). Ceiling sits at the current measurement
+    // plus a little headroom for feature-set/toolchain variance, same
+    // convention as `config_alloc_gate`/`password_policy_alloc_gate`; a
+    // failure a hair over the line means re-measure and re-derive, not nudge
+    // upwards.
+    assert!(
+        info.count_total <= 25_000,
+        "scaffolded form render allocated {} blocks over {RENDERS} renders, over the \
+         25,000-block ceiling (24,800 measured baseline)",
+        info.count_total,
+    );
+    assert!(
+        info.bytes_total <= 4_550_000,
+        "scaffolded form render allocated {} bytes over {RENDERS} renders, over the \
+         4,550,000-byte ceiling (4,498,200 measured baseline)",
+        info.bytes_total,
+    );
+}

--- a/autumn/tests/form_render_alloc_gate.rs
+++ b/autumn/tests/form_render_alloc_gate.rs
@@ -119,27 +119,30 @@ fn scaffolded_form_render_allocations_on_a_12_field_workload() {
         info.count_total, info.bytes_total
     );
 
-    // Baseline (debug profile, default features, deterministic across runs):
-    // 124 blocks / 22,491 bytes per render, 24,800 blocks / 4,498,200 bytes
-    // total for 200 renders. Every text/password/textarea/number/checkbox/date
-    // helper unconditionally builds `format!("{field}-error")` even on the 10
-    // of 12 fields with no validation error, where the string is never read —
-    // a fix is coming in `autumn/src/form.rs` (defer the allocation until
-    // `has_errors` is confirmed true). Ceiling sits at the current measurement
-    // plus a little headroom for feature-set/toolchain variance, same
-    // convention as `config_alloc_gate`/`password_policy_alloc_gate`; a
-    // failure a hair over the line means re-measure and re-derive, not nudge
-    // upwards.
+    // Debug profile, default features, deterministic across runs. Before the
+    // fix, every text/password/textarea/number/checkbox/date helper
+    // unconditionally built `format!("{field}-error")` even on the 10 of 12
+    // fields with no validation error, where the string is never read: 124
+    // blocks / 22,491 bytes per render, 24,800 blocks / 4,498,200 bytes total
+    // for 200 renders. See `autumn/src/form.rs`'s helpers for the fix (defers
+    // the allocation until `has_errors` is confirmed true). After: **104
+    // blocks** / 22,479 bytes per render, 20,800 / 4,495,800 total (-16.1%
+    // blocks; bytes barely move — each wasted allocation is a handful of
+    // bytes against a ~22KB/render budget dominated by larger buffers). Ceiling
+    // sits at the current measurement plus a little headroom for
+    // feature-set/toolchain variance, same convention as
+    // `config_alloc_gate`/`password_policy_alloc_gate`; a failure a hair over
+    // the line means re-measure and re-derive, not nudge upwards.
     assert!(
-        info.count_total <= 25_000,
+        info.count_total <= 21_500,
         "scaffolded form render allocated {} blocks over {RENDERS} renders, over the \
-         25,000-block ceiling (24,800 measured baseline)",
+         21,500-block ceiling (20,800 measured; 24,800 was the pre-fix baseline)",
         info.count_total,
     );
     assert!(
         info.bytes_total <= 4_550_000,
         "scaffolded form render allocated {} bytes over {RENDERS} renders, over the \
-         4,550,000-byte ceiling (4,498,200 measured baseline)",
+         4,550,000-byte ceiling (4,495,800 measured; 4,498,200 was the pre-fix baseline)",
         info.bytes_total,
     );
 }

--- a/autumn/tests/form_render_alloc_gate.rs
+++ b/autumn/tests/form_render_alloc_gate.rs
@@ -3,7 +3,7 @@
 //! `checkbox_input`, `date_input`) on the same 12-field realistic workload as
 //! the committed `autumn/benches/form_render.rs` profiling harness (title,
 //! slug, password, summary, body, price, quantity, rating, published,
-//! published_at, sku, notes — two fields, title and price, carrying
+//! `published_at`, sku, notes — two fields, title and price, carrying
 //! validation errors, matching a re-rendered failed submission).
 //!
 //! Its own binary for the same `allocation-counter` global-allocator reason


### PR DESCRIPTION
🎯 **Workload**

The committed `autumn/benches/form_render.rs` harness (`harness = false`, a realistic 12-field scaffolded form — title, slug, password, summary, body, price, quantity, rating, published, published_at, sku, notes — with two fields, `title` and `price`, carrying validation errors, matching a re-rendered failed submission). Already exists on trunk-dev; no new bench file added.

```sh
cargo build --release -p autumn-web --bench form_render
BIN=$(find target/release/deps -maxdepth 1 -name "form_render-*" -type f ! -name "*.d")
valgrind --tool=callgrind --callgrind-out-file=callgrind.out "$BIN" --iterations 3000
callgrind_annotate --threshold=90 callgrind.out | head -30
```

📈 **Profile**

Post the two prior passes over this bench (#2295 field_value caching, #2298 PreEscaped literals), `valgrind --tool=callgrind` at 3,000 iterations (3,050 renders) showed `alloc::fmt::format::format_inner` at 6,734,400 of 203,331,276 instructions (3.31%) — the single largest `autumn_web`-attributable line item after `escape_to_string`.

💡 **Hypothesis**

Every `text_input`/`password_input`/`textarea_input`/`number_input`/`checkbox_input`/`date_input` helper (and their `required_*`/`*_htmx` variants, plus the newer `a11y`-routed `wrap_field_control`) unconditionally builds `let error_id = format!("{field}-error");` up front, but the value is only ever read inside `@if has_errors { ... }`. 11 of the 22 `format!` calls per render in this bench are for `error_id`; 9 of those 11 are wasted, since only `title` and `price` carry errors. On a realistic scaffolded form most fields don't have validation errors on any given render, so this is waste on the common path, not the exceptional one.

🔧 **Change**

`let error_id = format!("{field}-error");` → `let error_id = has_errors.then(|| format!("{field}-error"));`, with the two read sites (`aria-describedby` and the `@if has_errors { div id=(error_id) ... }` block) updated to `error_id.as_deref().unwrap_or(...)`. Applied uniformly across all 17 call sites in `autumn/src/form.rs` that follow this shape, including `rich_text_area_inner`'s `described_by` string (now built via `.as_deref().unwrap_or_default()`) and `wrap_field_control`. Behavior and rendered HTML are byte-for-byte identical — verified by the unchanged 203 `form`/`nested_form` lib tests.

Also added `autumn/tests/form_render_alloc_gate.rs` — a deterministic, CI-checkable `allocation-counter` gate on the same 12-field workload, its own test binary for the same global-allocator reason as `config_alloc_gate`/`password_policy_alloc_gate`. Committed first with the pre-fix baseline ceiling (RED), then lowered to the post-fix measurement (GREEN) in the fix commit.

📊 **Measurement**

| Metric | Before | After | Delta | Tool |
|---|---:|---:|---:|---|
| Instructions (3,000 iter = 3,050 renders) | 203,331,276 | 185,748,259 | **-8.65%** | `valgrind --tool=callgrind` |
| `format_inner` instructions | 6,734,400 (3.31%) | 3,928,400 (2.11%) | **-41.7%** | same |
| Allocation blocks (200 renders) | 24,800 | 20,800 | **-16.1%** | `allocation-counter` (new gate) |
| Allocation bytes (200 renders) | 4,498,200 | 4,495,800 | -0.05% | same |

Bytes barely move — each wasted allocation is a handful of bytes (`"sku-error"` etc.) against a ~22KB/render budget dominated by larger buffers — but the instruction-count and allocation-block deltas both independently clear the impact floor (≥5% instructions on a realistic, directly-exercised workload; ≥10% allocation-block reduction).

`cargo fmt --all` clean. `cargo clippy -p autumn-web --lib --tests -- -D warnings` has the same two pre-existing, unrelated toolchain-drift failures noted in #2295/#2298 (`autumn/src/pagination.rs:762` unknown lint, `autumn/src/commentable.rs:105` doc markdown) — neither touches `form.rs` or this change. (`--all-features` clippy/build additionally fails in this sandbox on `postgresql_embedded`'s build script — a network-restricted-environment issue, unrelated to this change.) All 203 `form`/`nested_form` lib tests pass unchanged.

Checked for duplicate/overlapping work first: no open PR references `form.rs`, `error_id`, or the scaffolded field helpers. Closest history is #2295/#2298 (the two prior passes over this same bench) and the unrelated, already-closed #2232 ingress-middleware finding.

🔬 **Reproduce**

```sh
# Allocation gate (fast, deterministic, no valgrind needed)
cargo test -p autumn-web --test form_render_alloc_gate -- --nocapture

# Instruction profile
cargo build --release -p autumn-web --bench form_render
BIN=$(find target/release/deps -maxdepth 1 -name "form_render-*" -type f ! -name "*.d")
valgrind --tool=callgrind --callgrind-out-file=callgrind.out "$BIN" --iterations 3000
callgrind_annotate --threshold=90 callgrind.out | head -30
```

---
_Generated by [Claude Code](https://claude.ai/code/session_01XJCD4UTtWg5UaiDxjf9DUp)_