### PR TITLE
Address CI feedback on #2296: reserve "all" as a search index name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   same two headers the injection path already sets are now applied on this
   path too.
 
+- **`"all"` is now a reserved search index name:** `AUTUMN_SEARCH_BACKFILL`
+  and `autumn search reindex --index` use the literal value `all`
+  (case-insensitive) as a sentinel meaning "every registered index." Nothing
+  previously stopped an app from registering a real index actually named
+  `all` (a valid identifier, so `IndexDefinition::validate` accepted it) —
+  requesting a rebuild of that specific index instead reindexed, or with
+  `--purge`, emptied, every index in the app. `IndexDefinition::validate`
+  now rejects `all` (case-insensitive) at index-registration time, so the
+  ambiguity can never reach a backfill.
+
 ### Performance
 
 - **scaffolded form helpers no longer re-escape their own constant HTML at

--- a/autumn/src/search.rs
+++ b/autumn/src/search.rs
@@ -294,6 +294,19 @@ impl IndexDefinition {
                 self.name
             ));
         }
+        // "all" is the magic value `AUTUMN_SEARCH_BACKFILL=all` (and `autumn
+        // search reindex --index all`) use to mean "every registered index".
+        // An index actually named `all` would make that request ambiguous —
+        // and, resolved as "every index", silently reindex (or with
+        // `--purge`, empty) every index instead of the one requested. Reject
+        // it at registration so the ambiguity can never reach a backfill.
+        if self.name.eq_ignore_ascii_case("all") {
+            return invalid(format!(
+                "search index name {:?} is reserved: \"all\" selects every index in \
+                 AUTUMN_SEARCH_BACKFILL / `autumn search reindex --index`",
+                self.name
+            ));
+        }
         if !is_valid_index_identifier(self.language) {
             return invalid(format!(
                 "search language {:?} on index {:?} is not an identifier",
@@ -599,6 +612,18 @@ mod tests {
         let mut d = def();
         d.name = "arti cles";
         assert!(d.validate().is_err());
+    }
+
+    #[test]
+    fn definition_rejects_the_reserved_all_name() {
+        // "all" is the AUTUMN_SEARCH_BACKFILL / `--index` sentinel for "every
+        // index" — an index actually named `all` would make a request for it
+        // ambiguous with a request to rebuild (or purge) everything.
+        for name in ["all", "All", "ALL"] {
+            let mut d = def();
+            d.name = name;
+            assert!(d.validate().is_err(), "{name:?} must be rejected");
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Fixes a P2 finding from `chatgpt-codex-connector` on #2296: `AUTUMN_SEARCH_BACKFILL` and `autumn search reindex --index` treat the literal value `all` (case-insensitive) as a sentinel meaning "every registered index." Nothing stopped an app from registering a real index actually named `all` — a valid identifier, so `IndexDefinition::validate` accepted it — making a request for that specific index ambiguous with a request to rebuild (or with `--purge`, empty) every index in the app instead.
- `IndexDefinition::validate` (in `autumn/src/search.rs`) now rejects `all` (case-insensitive) at index-registration time — enforced for every backend, since both the Postgres and in-memory backends call `.validate()` on every registered index during `ensure_indexes()` at boot — so the ambiguity can never reach a backfill.
- Adds a regression test (`definition_rejects_the_reserved_all_name`) covering `"all"`, `"All"`, `"ALL"`.
- Adds a `### Security` entry under `## [Unreleased]` in `CHANGELOG.md` per repo convention.

This branch was previously used for #2297, #2299, and #2303 (all merged); per the repo's branch-restart convention it was reset to the latest `trunk-dev` for this follow-up fix.

## Test plan

- [x] `cargo test -p autumn-web --lib search::` — 17 passed, including the new regression test
- [x] `cargo test -p autumn-search --lib` — 121 passed (both backends' `.validate()` call sites exercised)
- [x] `cargo fmt --all -- --check`
- [x] `./scripts/check-migration-guides.sh` — passes
- [ ] CI (Lint, Test matrix, etc.)

---
_Generated by [Claude Code](https://claude.ai/code/session_01La1MTD4iB4K4TWib2hK2YF)_