### PR TITLE
Address CI feedback on #2296: bound response-body collection in the edge-capsule runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   now rejects `all` (case-insensitive) at index-registration time, so the
   ambiguity can never reach a backfill.
 
+- **the edge-capsule runtime now bounds a dispatched handler's response body
+  at 16 MiB:** `EdgeHandler` accepts any axum handler return type, including
+  a streaming body whose length is unbounded or driven by request input.
+  `serve_io` collected a dispatched handler's response with no limit before
+  emitting the wire frame, so one such request could buffer without bound —
+  the wasm guest's own allocator eventually traps against the host's memory
+  budget, but only after the attempt, and `serve_io` can also run natively
+  with no wasm host in the loop at all, where nothing else bounds it.
+  Exceeding the new cap now fails closed into the same
+  `FallthroughReason::CapsuleError` fallthrough the runtime already uses for
+  every other decline, so the origin serves the request instead.
+
 ### Performance
 
 - **scaffolded form helpers no longer re-escape their own constant HTML at

--- a/autumn-edge/src/runtime.rs
+++ b/autumn-edge/src/runtime.rs
@@ -70,6 +70,24 @@ use crate::wire::{
     canonicalize_headers, from_line, strip_sensitive_headers, strip_sentinel, to_line,
 };
 
+/// Cap on a single response body collected from a dispatched handler, in
+/// bytes (16 MiB).
+///
+/// `EdgeHandler` accepts any axum handler return type, including a streaming
+/// body whose length is unbounded or driven by request input (e.g. a path or
+/// query parameter). Without a limit here, collecting one such response would
+/// buffer without bound — the wasm guest's own allocator eventually traps
+/// against [`host::MEMORY_BUDGET_BYTES`](crate::host::MEMORY_BUDGET_BYTES),
+/// but only after the attempt, and `serve_io` can also run natively with no
+/// wasm host in the loop at all (see the module docs), where nothing else
+/// bounds it. Sized to match `host::STDOUT_LINE_BUDGET_BYTES`'s own "honest
+/// frame" assumption (16 MiB pre-base64) so a body within this limit is also
+/// within that budget once framed for the wire. Exceeding it fails
+/// `to_bytes` below, which the existing error arm already turns into a
+/// [`FallthroughReason::CapsuleError`] — the origin serves the request
+/// instead of the capsule exhausting memory on it.
+const MAX_RESPONSE_BODY_BYTES: usize = 16 * 1024 * 1024;
+
 /// Serve edge requests over stdin/stdout until the host closes the stream.
 ///
 /// This is the entire body of a capsule's `main`. It returns on EOF; a
@@ -369,7 +387,7 @@ where
             );
         }
 
-        let body = match axum::body::to_bytes(response.into_body(), usize::MAX).await {
+        let body = match axum::body::to_bytes(response.into_body(), MAX_RESPONSE_BODY_BYTES).await {
             Ok(body) => body.to_vec(),
             Err(err) => {
                 return EdgeOutcome::fallthrough(

--- a/autumn-edge/tests/runtime_io.rs
+++ b/autumn-edge/tests/runtime_io.rs
@@ -86,6 +86,16 @@ async fn aliased_extension(_ext: Alias) -> &'static str {
     "never reached: the capsule installs no extensions"
 }
 
+/// A handler whose body exceeds the runtime's response-body cap — the shape
+/// a streaming response, or one sized off a path/query parameter, could take.
+/// Collecting it must fail closed into a fallthrough rather than buffer
+/// without bound.
+async fn oversized_body() -> Vec<u8> {
+    // One byte past `runtime::MAX_RESPONSE_BODY_BYTES` (16 MiB); mirrored here
+    // as a literal since the constant is private to the crate.
+    vec![b'x'; 16 * 1024 * 1024 + 1]
+}
+
 /// A handler whose response header value is valid HTTP but not valid UTF-8 —
 /// it cannot cross the JSON wire byte-faithfully, so the runtime must decline
 /// rather than serve a lossily rewritten value the origin would never send.
@@ -112,6 +122,13 @@ fn routes() -> Vec<EdgeRoute> {
             path: "/latin1",
             handler: edge_get(latin1_header),
             name: "latin1_header",
+            needs: &[],
+        },
+        EdgeRoute {
+            method: http::Method::GET,
+            path: "/oversized",
+            handler: edge_get(oversized_body),
+            name: "oversized_body",
             needs: &[],
         },
         EdgeRoute {
@@ -299,6 +316,19 @@ fn a_cookie_setting_handler_is_a_fallthrough_not_a_cacheable_session_leak() {
     assert!(
         detail.contains("cookie") && detail.contains("origin-only"),
         "the decline must name the cookie hazard: {detail}"
+    );
+}
+
+#[test]
+fn an_oversized_response_body_is_a_fallthrough_not_an_unbounded_buffer() {
+    let frames = drive(&[request_line(EdgeRequest::get("/oversized"), &[])]);
+
+    assert_eq!(frames.len(), 1, "{frames:?}");
+    let (reason, detail) = expect_fallthrough(&frames[0]);
+    assert_eq!(reason, FallthroughReason::CapsuleError);
+    assert!(
+        detail.contains("/oversized"),
+        "the decline must name the request: {detail}"
     );
 }
 


### PR DESCRIPTION
## Summary

- Fixes a P2 finding from `chatgpt-codex-connector` on #2296: `EdgeHandler` accepts any axum handler return type, including a streaming body whose length is unbounded or driven by request input (a path or query parameter). `serve_io` (`autumn-edge/src/runtime.rs`) collected a dispatched handler's response body with `axum::body::to_bytes(..., usize::MAX)` before emitting the wire frame, so one such request could buffer without bound — the wasm guest's own allocator eventually traps against the host's memory budget, but only after the attempt, and `serve_io` can also run natively with no wasm host in the loop at all (per its own module docs), where nothing else bounds it.
- Caps the collected body at 16 MiB (matching `host::STDOUT_LINE_BUDGET_BYTES`'s own "honest frame" sizing assumption, documented there as ~16 MiB pre-base64). Exceeding it now fails `to_bytes`, which the existing error arm already turns into a `FallthroughReason::CapsuleError` — the origin serves the request instead of the capsule exhausting memory on it. No new branching logic was needed; the existing fallthrough path already does exactly what the finding asked for once the limit is finite.
- Adds a regression test (`an_oversized_response_body_is_a_fallthrough_not_an_unbounded_buffer`) driving `serve_io` end-to-end with a handler returning a body one byte past the cap.
- Adds a `### Security` entry under `## [Unreleased]` in `CHANGELOG.md` per repo convention.

Two other call sites of `to_bytes(..., usize::MAX)` in this crate were checked and left alone: `extract.rs`'s is `#[cfg(test)]`-only, and `router.rs`'s `needs()` probe response is a small, framework-generated capability list, not handler/request-controlled data.

This branch was previously used for #2297, #2299, #2303, and #2305 (all merged); per the repo's branch-restart convention it was reset to the latest `trunk-dev` for this follow-up fix.

## Test plan

- [x] `cargo test -p autumn-edge --test runtime_io` — 22 passed, including the new regression test
- [x] `cargo test -p autumn-edge --lib` — 49 passed
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p autumn-edge --all-targets --features host -- -D warnings` — clean (aside from a pre-existing, unrelated toolchain-version-skew warning in `autumn-macros`)
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc -p autumn-edge --no-deps --features host` — clean, confirms the new intra-doc links resolve
- [x] `./scripts/check-migration-guides.sh` — passes
- [ ] CI (Lint, Test matrix, Edge capsule conformance, etc.)

---
_Generated by [Claude Code](https://claude.ai/code/session_01La1MTD4iB4K4TWib2hK2YF)_