### PR TITLE
docs(seo): add the SEO guide and wire route-level SEO into reddit-clone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the start-up-snapshot semantics and the custom-route escape hatch for larger
   or live sitemaps), the 50,000-URL limit, `hreflang` alternates on
   locale-prefixed sites, and static builds. `examples/reddit-clone` is now the
-  runnable sample: a database-backed (and deliberately bounded) `RedditSitemapSource` whose `<lastmod>` is derived from the whole page — the later of `posts.updated_at` and the newest live comment — rather than read from one column, `[seo]` +
+  runnable sample: a database-backed (and deliberately bounded) `RedditSitemapSource` whose `<lastmod>` is derived from the whole page — the latest of `posts.updated_at`, the newest live comment, and the newest comment deletion — rather than read from one column, `[seo]` +
   `[seo.robots]` in `autumn.toml`, `seo(...)` on the front page, the community
   index, the community page, the post page, and the about page, canonical URLs
   on each of them, `robots = "noindex, nofollow"` on the submit form, and a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the start-up-snapshot semantics and the custom-route escape hatch for larger
   or live sitemaps), the 50,000-URL limit, `hreflang` alternates on
   locale-prefixed sites, and static builds. `examples/reddit-clone` is now the
-  runnable sample: a database-backed (and deliberately bounded) `RedditSitemapSource`, `[seo]` +
+  runnable sample: a database-backed (and deliberately bounded) `RedditSitemapSource` whose `<lastmod>` is derived from the whole page — the later of `posts.updated_at` and the newest live comment — rather than read from one column, `[seo]` +
   `[seo.robots]` in `autumn.toml`, `seo(...)` on the front page, the community
   index, the community page, the post page, and the about page, canonical URLs
   on each of them, `robots = "noindex, nofollow"` on the submit form, and a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the start-up-snapshot semantics and the custom-route escape hatch for larger
   or live sitemaps), the 50,000-URL limit, `hreflang` alternates on
   locale-prefixed sites, and static builds. `examples/reddit-clone` is now the
-  runnable sample: a database-backed `RedditSitemapSource`, `[seo]` +
+  runnable sample: a database-backed (and deliberately bounded) `RedditSitemapSource`, `[seo]` +
   `[seo.robots]` in `autumn.toml`, `seo(...)` on the front page, the community
   index, the community page, the post page, and the about page, canonical URLs
   on each of them, `robots = "noindex, nofollow"` on the submit form, and a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **SEO guide and a runnable SEO example (#2320, T1 Gap 1):** `seo.rs` was
+  rustdoc-only and `docs/guide/` had zero `sitemap`/`robots` mentions, even
+  though the `seo(...)` route attribute shipped in 0.7.0. The new
+  [`docs/guide/seo.md`](docs/guide/seo.md) covers the `seo(...)` argument and
+  its keys, the `SeoMeta` extractor and its Open Graph/Twitter fallbacks,
+  canonical URLs, `robots = "noindex"` and exactly which sitemap entries it
+  filters, `[seo]`/`[seo.robots]` configuration, `SitemapSource` (including
+  the start-up-snapshot semantics and the custom-route escape hatch for larger
+  or live sitemaps), the 50,000-URL limit, `hreflang` alternates on
+  locale-prefixed sites, and static builds. `examples/reddit-clone` is now the
+  runnable sample: a database-backed `RedditSitemapSource`, `[seo]` +
+  `[seo.robots]` in `autumn.toml`, `seo(...)` on the front page, the community
+  index, the community page, the post page, and the about page, canonical URLs
+  on each of them, `robots = "noindex, nofollow"` on the submit form, and a
+  single `SeoMeta::render()` call in the shared layout. Covered by unit tests
+  in `routes/layout.rs`/`seo.rs` and a Postgres integration suite in
+  `tests/seo_pg_integration.rs`.
+
 - **`#[query_budget(N)]` — a compile-time, per-route database query budget
   (#1667):** declare a handler's query ceiling and the build fails when any
   statically reachable path can exceed it. The canonical case is the N+1 — a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the start-up-snapshot semantics and the custom-route escape hatch for larger
   or live sitemaps), the 50,000-URL limit, `hreflang` alternates on
   locale-prefixed sites, and static builds. `examples/reddit-clone` is now the
-  runnable sample: a database-backed (and deliberately bounded) `RedditSitemapSource` whose `<lastmod>` is derived from the whole page — the latest of `posts.updated_at`, the newest live comment, and the newest comment deletion — rather than read from one column, `[seo]` +
+  runnable sample: a database-backed `RedditSitemapSource` (entry-capped, with the cap's cost characteristics documented) whose `<lastmod>` is derived from the whole page — the latest of `posts.updated_at`, the newest live comment, and the newest comment deletion — rather than read from one column, `[seo]` +
   `[seo.robots]` in `autumn.toml`, `seo(...)` on the front page, the community
   index, the community page, the post page, and the about page, canonical URLs
   on each of them, `robots = "noindex, nofollow"` on the submit form, and a

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -156,7 +156,7 @@ The island crate that produces the wasm lives in `examples/island-flock`
 | **Key capabilities** | `#[secured]`, CSRF, sessions, `#[job]`, `#[ws]` channels, Redis fan-out, `#[scheduled]`, transactional email, htmx voting (`#[votable]`), threaded polymorphic comments on *two* models (`#[commentable]`, zero comment routes), route-level SEO (`seo(...)` + `SeoMeta`, a DB-backed `SitemapSource`, `/robots.txt` + `/sitemap.xml`), `ExperimentService`, `SignedWebhook`, `Client` extractor with SSRF guard, `ErrorReporter`, `RuntimeConfigService` |
 | **Prerequisites** | Rust 1.88.0+, PostgreSQL, Redis (optional for local run; required for multi-replica fan-out) |
 | **Run command** | `cargo run -p reddit-clone` |
-| **Success proof** | `curl http://localhost:3000/` returns the front-page HTML; `curl http://localhost:3000/sitemap.xml` returns a `<urlset>` listing every community and post |
+| **Success proof** | `curl http://localhost:3000/` returns the front-page HTML; `curl http://localhost:3000/sitemap.xml` returns a `<urlset>` listing the site's communities and posts |
 
 ---
 

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -153,10 +153,10 @@ The island crate that produces the wasm lives in `examples/island-flock`
 |-------|-------|
 | **Persona** | Developer building a production-shaped Autumn application and exploring the full feature set |
 | **Journey** | Full-stack Reddit clone: registration, sessions, posts, voting, live feeds, background jobs, transactional email, A/B experiments, signed webhook intake, outbound HTTP with SSRF protection, structured error reporting, and live-tunable runtime config |
-| **Key capabilities** | `#[secured]`, CSRF, sessions, `#[job]`, `#[ws]` channels, Redis fan-out, `#[scheduled]`, transactional email, htmx voting (`#[votable]`), threaded polymorphic comments on *two* models (`#[commentable]`, zero comment routes), `ExperimentService`, `SignedWebhook`, `Client` extractor with SSRF guard, `ErrorReporter`, `RuntimeConfigService` |
+| **Key capabilities** | `#[secured]`, CSRF, sessions, `#[job]`, `#[ws]` channels, Redis fan-out, `#[scheduled]`, transactional email, htmx voting (`#[votable]`), threaded polymorphic comments on *two* models (`#[commentable]`, zero comment routes), route-level SEO (`seo(...)` + `SeoMeta`, a DB-backed `SitemapSource`, `/robots.txt` + `/sitemap.xml`), `ExperimentService`, `SignedWebhook`, `Client` extractor with SSRF guard, `ErrorReporter`, `RuntimeConfigService` |
 | **Prerequisites** | Rust 1.88.0+, PostgreSQL, Redis (optional for local run; required for multi-replica fan-out) |
 | **Run command** | `cargo run -p reddit-clone` |
-| **Success proof** | `curl http://localhost:3000/` returns the front-page HTML |
+| **Success proof** | `curl http://localhost:3000/` returns the front-page HTML; `curl http://localhost:3000/sitemap.xml` returns a `<urlset>` listing every community and post |
 
 ---
 
@@ -300,7 +300,7 @@ can pick the closest starting point without overlap.
 | Horizontal sharding | `bookmarks-sharded` | Tenant → slot → shard routing, control DB, cross-shard fan-out, Docker Compose |
 | Hooks / revisions | `wiki` | Before/after-save hooks, slug lifecycle, full revision trail |
 | Markdown docs + SSG | `wiki` | `markdown` feature: embedded `.md` with frontmatter, TOC, heading anchors, rendered live at `/docs/{slug}` and pre-rendered via `#[static_get]` |
-| Full-stack showcase | `reddit-clone` | Auth, sessions, jobs, channels, email, A/B experiments, signed webhooks, outbound HTTP, error reporting — the complete feature showcase |
+| Full-stack showcase | `reddit-clone` | Auth, sessions, jobs, channels, email, A/B experiments, signed webhooks, outbound HTTP, error reporting, route-level SEO — the complete feature showcase |
 | Multi-tenant SaaS starter | `saas` | Session auth + row-level tenancy + tenant-scoped dashboard — the flagship `autumn new --starter saas` archetype |
 | Live mesh rooms | `media-room` | Installs `autumn-media-plugin` with rooms and creates/lists mesh-call rooms through the mounted `RoomService` |
 | PDF downloads | `invoice` | Renders one Maud view as both an on-screen page and a downloadable PDF via `autumn_web::pdf::Pdf` |

--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ See [EXAMPLES.md](EXAMPLES.md) for the full catalog with personas, journeys, pre
 | [`examples/bookmarks-distributed`](examples/bookmarks-distributed) | Primary/replica Postgres, multi-replica web tier behind nginx, advisory-lock scheduling, and Docker Compose deployment |
 | [`examples/bookmarks-sharded`](examples/bookmarks-sharded) | Framework-native horizontal sharding: tenant → slot → shard routing, control database, cross-shard fan-out, and Docker Compose deployment |
 | [`examples/wiki`](examples/wiki) | Mutation hooks, revision history, generated REST API, and slug lifecycle management |
-| [`examples/reddit-clone`](examples/reddit-clone) | Canonical feature showcase: auth, sessions, CSRF, `#[secured]`, transactional email, `#[job]`, `#[ws]` channels, Redis fan-out, htmx voting, A/B experiments, signed webhook intake, outbound HTTP with SSRF protection, structured error reporting, and live-tunable config |
+| [`examples/reddit-clone`](examples/reddit-clone) | Canonical feature showcase: auth, sessions, CSRF, `#[secured]`, transactional email, `#[job]`, `#[ws]` channels, Redis fan-out, htmx voting, A/B experiments, signed webhook intake, outbound HTTP with SSRF protection, structured error reporting, route-level SEO (`seo(...)`, `sitemap.xml`, `robots.txt`), and live-tunable config |
 | [`examples/saas`](examples/saas) | Multi-tenant SaaS starter: session auth + row-level tenancy + tenant-scoped dashboard — the flagship `autumn new --starter saas` archetype (see the [starters guide](docs/guide/starters.md)) |
 | [`examples/teams`](examples/teams) | Organization membership, roles, and email invitations: multi-org `Membership`, a `require_role` guard, `#[mailer]` invite emails, idempotent accept, and role-gated member management |
 | [`examples/media-room`](examples/media-room) | Live-media plugin: installs `autumn-media-plugin` with the rooms primitive and creates/lists mesh-call rooms through the mounted `RoomService` (see the [media guide](docs/guide/media.md)) |
@@ -268,6 +268,7 @@ See [EXAMPLES.md](EXAMPLES.md) for the full catalog with personas, journeys, pre
 - [Transition effects](docs/guide/transition-effects.md) — per-edge `on` / `on_commit` side effects on `#[state_machine]` transitions.
 - [Counter Caches](docs/guide/counter-cache.md) — `#[belongs_to(Post, counter_cache)]` keeps `posts.comment_count` current atomically, in the same transaction, with an idempotent `recompute` for drift
 - [Votes, Likes and Reactions](docs/guide/votable.md) — `#[votable(by = ..., aggregate = sum|count)]`, the race-safe `react()` / `reaction_of()` helpers, and the no-JS `reaction_controls` widget
+- [SEO](docs/guide/seo.md) — `seo(...)` on any route macro plus the `SeoMeta` extractor, canonical URLs, `robots = "noindex"` and its sitemap exclusion, `SitemapSource`, and the auto-mounted `/sitemap.xml` + `/robots.txt`
 - [Threaded Comments on Anything](docs/guide/commentable.md) — `#[commentable]`, the polymorphic `(commentable_type, commentable_id)` association, `add_comment()` / `comment_thread()` / `delete_comment()`, the registry-driven comment router, and the no-JS `comment_thread` widget
 
 ## Stability

--- a/docs/guide/seo.md
+++ b/docs/guide/seo.md
@@ -251,6 +251,13 @@ Autumn reads `noindex` as a comma-separated directive, so `"noindex"`,
 `"noindex, nofollow"`, and `"nofollow, noindex"` all count. An unrelated value
 such as `"noarchive"` does not.
 
+Choose the second half of the directive on purpose. `noindex, follow` keeps the
+page out of the index but lets crawlers walk its links, which is what a thin
+profile page wants. `noindex, nofollow` stops both.
+
+Do not also add the URL to `robots.txt`. See
+[Do not use `Disallow` and `noindex` on the same URL](#do-not-use-disallow-and-noindex-on-the-same-url).
+
 ### The sitemap-exclusion rule
 
 The framework filters only the paths it derives on its own. Those are the
@@ -284,9 +291,10 @@ Override the default and add your own rules under `[seo.robots]`:
 allow_all = false
 
 # Extra lines. Autumn appends them after the User-agent block.
+# Machine endpoints only. Read the next section before you add a page here.
 additional_rules = [
-  "Disallow: /submit",
   "Disallow: /actuator/",
+  "Disallow: /api/",
   "Crawl-delay: 5",
 ]
 
@@ -294,13 +302,29 @@ additional_rules = [
 sitemap_url = "https://cdn.example.com/sitemap.xml"
 ```
 
-`robots.txt` and a `noindex` tag do different jobs. Use both:
+### Do not use `Disallow` and `noindex` on the same URL
+
+The two rules do different jobs, and they cancel each other out:
 
 - `robots.txt` stops the **crawl**.
 - `noindex` stops the **indexing**.
 
-A page that another site links to can enter the index without a crawl. Only the
-`noindex` tag keeps it out, and a crawler must fetch the page to read that tag.
+A crawler must fetch a page to read its `noindex` tag. A `Disallow` line stops
+that fetch, so the crawler never reads the tag. The damage goes further. A page
+that another site links to can still enter the index without a crawl. The URL
+then appears as a bare result, and you have no way to remove it.
+
+Pick one tool for each URL:
+
+| Goal | Use |
+|---|---|
+| Keep the URL out of the index | Allow the crawl. Serve `seo(robots = "noindex")`. |
+| Keep crawlers off a machine endpoint | `Disallow` it. Accept that URL-only indexing stays possible. |
+
+A `noindex` tag also has to be reachable. A page behind `#[secured]` answers an
+anonymous crawler with a redirect to the login form. The crawler never sees the
+tag on the page itself. Put the directive where a crawler can read it, or send
+an `X-Robots-Tag: noindex` header on the redirect.
 
 ---
 
@@ -371,9 +395,16 @@ let source = PostSitemapSource { pool };
 `examples/reddit-clone/src/seo.rs` does this. It lists the communities and the
 posts.
 
-Bound the query. It runs at boot, so a row count you did not choose must not
-decide how long it takes. Log a warning when the bound bites, so a partial
+Cap the number of entries, and log a warning when the cap bites, so a partial
 sitemap is never a silent one.
+
+Know what a `LIMIT` bounds. It bounds the size of the document. It does not
+bound the work: a database must read every candidate row before it can know
+which rows are newest. Boot time therefore grows with the table. That is
+acceptable while the table is small. Past that point, stop building the sitemap
+at boot and serve `/sitemap.xml` from your own route, as
+[The entries are a start-up snapshot](#the-entries-are-a-start-up-snapshot)
+describes.
 
 ### Give `lastmod` the page, not one column
 
@@ -569,7 +600,8 @@ fn post_page_declares_its_canonical_url() {
 2. Put `(seo.render())` in the `<head>` of your layout.
 3. Declare a `title` and a `description` on each public route.
 4. Add a canonical URL on each page that answers at more than one address.
-5. Mark each private page `robots = "noindex, nofollow"`.
+5. Mark each page you want out of the index `robots = "noindex"`, and leave
+   that URL out of `robots.txt`.
 6. Register a `SitemapSource` for the pages the framework cannot derive.
 7. Read `/robots.txt` and `/sitemap.xml` before you deploy.
 

--- a/docs/guide/seo.md
+++ b/docs/guide/seo.md
@@ -395,12 +395,28 @@ Prefer the second. One query then owns the definition, and no write path has
 to remember to take part:
 
 ```sql
-SELECT GREATEST(p.updated_at, COALESCE(MAX(c.created_at), p.updated_at)) AS last_modified
+SELECT GREATEST(
+           p.updated_at,
+           COALESCE(MAX(c.created_at) FILTER (WHERE c.deleted_at IS NULL), p.updated_at),
+           COALESCE(MAX(c.deleted_at), p.updated_at)
+       ) AS last_modified
   FROM posts p
-  LEFT JOIN comments c ON c.commentable_id = p.id AND c.deleted_at IS NULL
+  LEFT JOIN comments c
+         ON c.commentable_type = 'Post'
+        AND c.commentable_id = p.id
  GROUP BY p.id
  ORDER BY last_modified DESC
 ```
+
+Two details in that query earn their place:
+
+- **Match the discriminator.** A `#[commentable]` table is polymorphic, so
+  `commentable_id` is unique only with `commentable_type`. Without the type,
+  a comment on community 7 moves post 7's date.
+- **Count a deletion too.** A removed comment changes the page as much as a
+  new one. Filter the deleted rows out of the *aggregate*, not out of the
+  *join*: drop them in the join and the date can move backward when somebody
+  deletes the newest reply.
 
 Order on the derived value, not on the column. Your entry cap cuts the list,
 and it must cut the pages that really are the oldest.

--- a/docs/guide/seo.md
+++ b/docs/guide/seo.md
@@ -368,8 +368,12 @@ let pool = autumn_web::db::create_pool(&config.database)?;
 let source = PostSitemapSource { pool };
 ```
 
-`examples/reddit-clone/src/seo.rs` does this. It lists each community and each
-post, and it puts `posts.updated_at` in `lastmod`.
+`examples/reddit-clone/src/seo.rs` does this. It lists the communities and the
+posts, and it puts `posts.updated_at` in `lastmod`.
+
+Bound the query. It runs at boot, so a row count you did not choose must not
+decide how long it takes. Log a warning when the bound bites, so a partial
+sitemap is never a silent one.
 
 Handle a query failure inside the source. Log the failure and return the
 entries you have. A short sitemap is better than a failed boot.

--- a/docs/guide/seo.md
+++ b/docs/guide/seo.md
@@ -369,11 +369,45 @@ let source = PostSitemapSource { pool };
 ```
 
 `examples/reddit-clone/src/seo.rs` does this. It lists the communities and the
-posts, and it puts `posts.updated_at` in `lastmod`.
+posts.
 
 Bound the query. It runs at boot, so a row count you did not choose must not
 decide how long it takes. Log a warning when the bound bites, so a partial
 sitemap is never a silent one.
+
+### Give `lastmod` the page, not one column
+
+`lastmod` tells a crawler whether it must fetch the page again. It must
+therefore describe the whole page. One timestamp column rarely does.
+
+A post page is its body plus its comment thread. An edit advances
+`posts.updated_at`. A new comment does not: it writes a different table
+through a different route. A `lastmod` read straight from `posts.updated_at`
+therefore tells the crawler nothing changed, and the new comments stay out of
+the index.
+
+You have two ways to fix that:
+
+1. **Write** the timestamp from each subsystem that changes the page.
+2. **Derive** it in the sitemap query.
+
+Prefer the second. One query then owns the definition, and no write path has
+to remember to take part:
+
+```sql
+SELECT GREATEST(p.updated_at, COALESCE(MAX(c.created_at), p.updated_at)) AS last_modified
+  FROM posts p
+  LEFT JOIN comments c ON c.commentable_id = p.id AND c.deleted_at IS NULL
+ GROUP BY p.id
+ ORDER BY last_modified DESC
+```
+
+Order on the derived value, not on the column. Your entry cap cuts the list,
+and it must cut the pages that really are the oldest.
+
+Leave out the changes a reader does not come for. A vote count is one of them.
+Search engines ask you not to advertise a trivial change. A sitemap that moves
+every date on every vote also teaches crawlers to distrust all of its dates.
 
 Handle a query failure inside the source. Log the failure and return the
 entries you have. A short sitemap is better than a failed boot.

--- a/docs/guide/seo.md
+++ b/docs/guide/seo.md
@@ -1,0 +1,551 @@
+# SEO — `seo(...)`, `sitemap.xml`, and `robots.txt`
+
+A public web page needs three things before a search engine can index it well:
+
+1. **Meta tags** in the `<head>` that give the page a title, a summary, and a
+   preview card.
+2. A **`sitemap.xml`** that lists every URL the crawler must visit.
+3. A **`robots.txt`** that tells the crawler where it can go.
+
+Autumn builds all three. You do three things:
+
+- Declare the values that never change on the route attribute.
+- Refine the values that change in the handler.
+- Set the site base URL in `autumn.toml`.
+
+The framework then mounts `/robots.txt` and `/sitemap.xml` for you.
+
+> **Runnable example:** [`examples/reddit-clone`](../../examples/reddit-clone)
+> wires the full feature. Its `src/seo.rs` holds the sitemap source and the
+> canonical-URL helpers. Its `autumn.toml` holds the `[seo]` block. Its routes
+> in `src/routes/` carry the `seo(...)` arguments.
+> [`examples/blog`](../../examples/blog) shows the same feature on a
+> locale-prefixed site.
+
+---
+
+## Turn the feature on
+
+Set one value in `autumn.toml`:
+
+```toml
+[seo]
+base_url = "https://example.com"
+```
+
+`base_url` does three jobs:
+
+- It mounts `GET /robots.txt` and `GET /sitemap.xml`.
+- It makes the absolute URLs that both documents need.
+- It adds the `Sitemap:` line to `robots.txt`.
+
+Set it to the real public host. A wrong `base_url` sends crawlers to URLs that
+do not exist.
+
+The routes also appear when you register a sitemap source (see
+[Sitemap](#sitemapxml)). You do not need both.
+
+---
+
+## Meta tags on the route
+
+Declare the values that never change on the route attribute. Add a `seo(...)`
+argument, then take a `SeoMeta` parameter. The parameter arrives with the
+declared values already in it.
+
+```rust,ignore
+use autumn_web::prelude::*;
+
+#[get(
+    "/about",
+    seo(
+        title = "About • Autumn Reddit",
+        description = "Why this site exists and what it demonstrates.",
+        og_type = "website"
+    )
+)]
+pub async fn about(seo: SeoMeta) -> Markup {
+    layout_with_seo(seo, html! { h1 { "About" } })
+}
+```
+
+Two rules govern the argument:
+
+- Each value must be a string literal. The macro reads it at compile time.
+- An unknown key or a repeated key is a compile error.
+
+The argument gives the handler **values, not markup**. The handler still
+chooses where to write them. A route that declares `seo(...)` but never takes a
+`SeoMeta` parameter renders nothing.
+
+The extractor never fails. A route without a `seo(...)` argument gives the
+handler an empty builder, so you can add the parameter to any route.
+
+### Where the argument works
+
+| Macro | Accepts `seo(...)` |
+|---|---|
+| `#[get]`, `#[post]`, `#[put]`, `#[patch]`, `#[delete]` | yes |
+| `#[static_get]` | yes — the pre-rendered HTML carries the tags |
+| `#[ws]` | no — a WebSocket upgrade serves no crawlable page |
+
+### The keys
+
+Each key matches one `SeoMeta` builder method.
+
+| Key | Tag it renders |
+|---|---|
+| `title` | `<title>` |
+| `description` | `<meta name="description">` |
+| `canonical` | `<link rel="canonical">` |
+| `robots` | `<meta name="robots">` |
+| `og_title`, `og_description`, `og_image`, `og_type`, `og_url` | `<meta property="og:…">` |
+| `twitter_card`, `twitter_title`, `twitter_description`, `twitter_image` | `<meta name="twitter:…">` |
+
+`SeoMeta::render` writes only the tags you set. It also fills three gaps for
+you:
+
+- `og:title` falls back to `title`.
+- `og:description` falls back to `description`.
+- `og:url` falls back to `canonical`.
+
+The Twitter title and description fall back in the same way, but only when you
+set `twitter_card`. Set each value one time and let the fallbacks do the rest.
+
+Match the card type to what you have. Use `summary` until the page can supply
+an `og_image`. A `summary_large_image` card with no image renders as a plain
+link.
+
+---
+
+## Refine the values in the handler
+
+A detail page cannot put its title on the attribute, because the title comes
+from the database. Declare the fixed part on the attribute. Add the changing
+part in the handler.
+
+```rust,ignore
+#[get(
+    "/r/{sub_slug}/posts/{post_slug}",
+    seo(og_type = "article", twitter_card = "summary")
+)]
+pub async fn show(
+    Path((sub_slug, post_slug)): Path<(String, String)>,
+    seo: SeoMeta,
+    mut db: Db,
+) -> AutumnResult<Markup> {
+    let post = load_post(&mut db, &sub_slug, &post_slug).await?;
+
+    let seo = seo
+        .title(format!("{} • Autumn Reddit", post.title))
+        .description(summarize(&post.body, 155));
+
+    Ok(layout_with_seo(seo, html! { h1 { (post.title) } }))
+}
+```
+
+`SeoMeta` is a normal builder. Each method takes the builder and returns it, so
+you can chain the calls.
+
+---
+
+## Render the tags in your layout
+
+`SeoMeta::render` returns Maud `Markup`. Put one call in the `<head>` of your
+layout. Every page then gets the same treatment.
+
+```rust,ignore
+pub fn layout_with_seo(seo: SeoMeta, content: Markup) -> Markup {
+    html! {
+        (PreEscaped("<!DOCTYPE html>"))
+        html lang="en" {
+            head {
+                meta charset="utf-8";
+                meta name="viewport" content="width=device-width, initial-scale=1";
+                (seo.render())
+                link rel="stylesheet" href="/static/css/app.css";
+            }
+            body { main { (content) } }
+        }
+    }
+}
+```
+
+`render` writes the `<title>` tag, so the layout must not write its own. Give
+each page a title, or the page gets no title at all.
+
+Keep the old plain-title entry point if your application has many pages. Let it
+build a `SeoMeta` and call the new function:
+
+```rust,ignore
+pub fn layout(title: &str, content: Markup) -> Markup {
+    layout_with_seo(SeoMeta::new().title(format!("{title} — Autumn Reddit")), content)
+}
+```
+
+`examples/reddit-clone` uses this pattern in `src/routes/layout.rs`. Most of its
+pages still call `layout`. Only the pages that need more tags call
+`layout_with_seo`.
+
+---
+
+## Canonical URLs
+
+A canonical tag names the one true address of a page. Add it when the same
+content answers at more than one URL. Three common causes are:
+
+- a second route that redirects to the first, such as `/posts/{id}`;
+- a tracking parameter in the query string;
+- a page that appears under both `/` and `/index`.
+
+The tag must hold an absolute URL, so the handler needs `base_url` at run time.
+Read it one time at start-up and keep it in a `OnceLock`:
+
+```rust,ignore
+static BASE_URL: OnceLock<Option<String>> = OnceLock::new();
+
+pub fn init_base_url(config: &AutumnConfig) {
+    let base = config.seo.base_url.as_deref()
+        .map(|url| url.trim_end_matches('/').to_owned());
+    let _ = BASE_URL.set(base);
+}
+
+#[must_use]
+pub fn with_canonical(seo: SeoMeta, path: &str) -> SeoMeta {
+    match BASE_URL.get().and_then(Option::as_deref) {
+        Some(base) => seo.canonical(format!("{base}{path}")),
+        None => seo,
+    }
+}
+```
+
+Call `init_base_url` in `main` before the application starts. Then wrap the
+builder in each handler:
+
+```rust,ignore
+let seo = with_canonical(seo.title(post.title.clone()), &post_path);
+```
+
+The `AutumnConfig` extractor also reads the value, but it clones the whole
+configuration on each request. The `OnceLock` costs one pointer read.
+
+---
+
+## Keep a page out of the index
+
+Set `robots` on the route:
+
+```rust,ignore
+#[secured]
+#[get("/submit", seo(title = "Submit a post", robots = "noindex, nofollow"))]
+pub async fn submit_form(seo: SeoMeta) -> AutumnResult<Markup> { /* … */ }
+```
+
+The directive has two effects:
+
+1. The page renders `<meta name="robots" content="noindex, nofollow">`.
+2. The framework drops the page from `sitemap.xml`, but only for a
+   `#[static_get]` route. See the next rule for why.
+
+Autumn reads `noindex` as a comma-separated directive, so `"noindex"`,
+`"noindex, nofollow"`, and `"nofollow, noindex"` all count. An unrelated value
+such as `"noarchive"` does not.
+
+### The sitemap-exclusion rule
+
+The framework filters only the paths it derives on its own. Those are the
+concrete `#[static_get]` paths. It never filters the entries a sitemap source
+supplies.
+
+The reason is that a `SitemapEntry` carries only a URL string. Nothing ties the
+entry back to a route, so the framework cannot match your URLs against your
+route templates. It also must not drop a URL you asked for.
+
+The practical result is one rule: **when you add a URL to a sitemap source, do
+not also mark its route `noindex`.** Remove the URL from the source instead.
+
+---
+
+## `robots.txt`
+
+The active profile sets the default:
+
+| Profile | Body |
+|---|---|
+| `dev`, `test` | `User-agent: *` and `Disallow: /` |
+| `prod`, `production` | `User-agent: *` and `Allow: /` |
+
+Override the default and add your own rules under `[seo.robots]`:
+
+```toml
+[seo.robots]
+# Force the answer, whatever the profile says. Use `false` on a staging host
+# that runs the `prod` profile.
+allow_all = false
+
+# Extra lines. Autumn appends them after the User-agent block.
+additional_rules = [
+  "Disallow: /submit",
+  "Disallow: /actuator/",
+  "Crawl-delay: 5",
+]
+
+# An explicit Sitemap: URL. Autumn computes it from `base_url` when you omit it.
+sitemap_url = "https://cdn.example.com/sitemap.xml"
+```
+
+`robots.txt` and a `noindex` tag do different jobs. Use both:
+
+- `robots.txt` stops the **crawl**.
+- `noindex` stops the **indexing**.
+
+A page that another site links to can enter the index without a crawl. Only the
+`noindex` tag keeps it out, and a crawler must fetch the page to read that tag.
+
+---
+
+## `sitemap.xml`
+
+Autumn builds the document from two sources.
+
+### 1. Static routes, derived for you
+
+The framework adds one entry for each `#[static_get]` path when `base_url` is
+set. It skips a path that holds a `{` placeholder, because a template is not a
+URL.
+
+### 2. A `SitemapSource` you register
+
+Every other URL comes from your application. Implement `SitemapSource` and
+register it on the builder:
+
+```rust,ignore
+use autumn_web::seo::{SitemapChangefreq, SitemapEntry, SitemapSource};
+use std::future::Future;
+use std::pin::Pin;
+
+struct PostSitemapSource {
+    pool: Option<Pool<RuntimeConnection>>,
+}
+
+impl SitemapSource for PostSitemapSource {
+    fn entries(&self) -> Pin<Box<dyn Future<Output = Vec<SitemapEntry>> + Send + '_>> {
+        Box::pin(async {
+            vec![
+                SitemapEntry::new("https://example.com/posts/hello")
+                    .lastmod("2026-05-01")
+                    .changefreq(SitemapChangefreq::Weekly)
+                    .priority(0.6),
+            ]
+        })
+    }
+}
+
+// In main():
+autumn_web::app()
+    .seo_source(PostSitemapSource { pool })
+    .run()
+    .await;
+```
+
+Each entry holds one URL and three optional hints:
+
+| Field | Meaning |
+|---|---|
+| `loc` | The absolute URL. Autumn escapes the XML characters for you. |
+| `lastmod` | The last change date, as `YYYY-MM-DD`. |
+| `changefreq` | `Always`, `Hourly`, `Daily`, `Weekly`, `Monthly`, `Yearly`, or `Never`. |
+| `priority` | A number from 0.0 to 1.0. Autumn clamps it. |
+
+### Read the database in a source
+
+The application state does not exist when the framework collects the entries,
+so a source cannot use the `Db` extractor. Build a pool of its own from the
+configuration:
+
+```rust,ignore
+let pool = autumn_web::db::create_pool(&config.database)?;
+let source = PostSitemapSource { pool };
+```
+
+`examples/reddit-clone/src/seo.rs` does this. It lists each community and each
+post, and it puts `posts.updated_at` in `lastmod`.
+
+Handle a query failure inside the source. Log the failure and return the
+entries you have. A short sitemap is better than a failed boot.
+
+### The entries are a start-up snapshot
+
+Autumn calls `entries()` one time, while it builds the router. It renders the
+result into a fixed response body. Two things follow:
+
+- The route costs nothing to serve. It writes one cached string.
+- The sitemap does not change until the next deploy or restart.
+
+That trade suits most sites, because a crawler reads the file hours after a
+deploy. When your site must list new content at once, register your own route
+instead:
+
+```rust,ignore
+#[get("/sitemap.xml")]
+async fn sitemap(mut db: Db) -> impl IntoResponse {
+    let entries = load_entries(&mut db).await;
+    (
+        [("Content-Type", "application/xml; charset=utf-8")],
+        autumn_web::seo::sitemap_xml(&entries, Some("https://example.com")),
+    )
+}
+```
+
+Autumn sees the collision, logs a warning, and mounts neither of its own SEO
+routes. Your route wins. Serve `/robots.txt` yourself as well in that case, or
+build its body with `autumn_web::seo::robots_txt`.
+
+### The 50,000-URL limit
+
+The sitemap protocol allows 50,000 URLs in one file. `sitemap_xml` serves the
+first 50,000 entries and logs a warning for the rest. A larger site needs a
+sitemap index, which is a file that points at several sitemap files. Build the
+index in your own `/sitemap.xml` route.
+
+---
+
+## Locale-prefixed sites
+
+Turn on locale-prefixed routing in `autumn.toml`:
+
+```toml
+[i18n]
+locale_prefix_enabled = true
+supported_locales = ["en", "es"]
+```
+
+Autumn then writes one sitemap entry per locale for each derived static path.
+`/about` becomes `https://example.com/en/about` and
+`https://example.com/es/about`.
+
+Tell the crawler which URLs are translations of each other with `hreflang`
+links. `locale_alternates` builds the pairs, and `hreflang_alternates` renders
+them:
+
+```rust,ignore
+use autumn_web::seo::{SeoMeta, locale_alternates};
+
+#[get("/posts", seo(title = "Posts"))]
+async fn index(locale: Locale, seo: SeoMeta) -> Markup {
+    let seo = seo.hreflang_alternates(locale_alternates(
+        "https://example.com",
+        "/posts",
+        "en",
+        &["en".to_owned(), "es".to_owned()],
+    ));
+    html! { head { (seo.render()) } }
+}
+```
+
+The function adds an `x-default` pair that points at the default locale. Pass
+the locale-stripped path, which is what the `Uri` extractor gives you inside a
+locale-prefixed nest.
+
+Two exclusions apply, and both keep the sitemap in step with the router:
+
+- Autumn excludes `#[static_get]` routes from locale prefixing, because
+  pre-rendering requests one unprefixed path. Such a route stays one entry.
+- Autumn lists a path from `[i18n] locale_prefix_exclude` without a prefix.
+
+A `SitemapSource` entry is your own text. Autumn never rewrites it, so add the
+locale prefix yourself. `examples/blog` shows both halves.
+
+---
+
+## Static builds
+
+`autumn build` writes `robots.txt` and `sitemap.xml` into the output directory
+next to the pre-rendered pages. It uses the same configuration and the same
+sources as the server, so the two agree.
+
+The build never overwrites a file your own routes already produced. A
+`#[static_get("/robots.txt")]` route therefore wins, and the build prints a
+line that says it skipped the file.
+
+---
+
+## Test it
+
+Start the application and read the two documents:
+
+```bash
+curl http://localhost:3000/robots.txt
+curl http://localhost:3000/sitemap.xml
+curl -s http://localhost:3000/ | grep -E '<title>|og:|canonical'
+```
+
+In a test, assert on the rendered markup:
+
+```rust,ignore
+#[test]
+fn post_page_declares_its_canonical_url() {
+    let seo = SeoMeta::new()
+        .title("hello • Autumn Reddit")
+        .canonical("https://example.com/r/rust/posts/hello")
+        .og_type("article");
+
+    let html = layout_with_seo(seo, html! {}).into_string();
+
+    assert!(html.contains(r#"<link rel="canonical" href="https://example.com/r/rust/posts/hello">"#));
+    assert!(html.contains(r#"<meta property="og:type" content="article">"#));
+}
+```
+
+`examples/reddit-clone` carries two suites:
+
+- `src/routes/layout.rs` asserts the rendered tags. It needs no database.
+- `tests/seo_pg_integration.rs` seeds a Postgres, runs the sitemap source, and
+  asserts the URLs and the `lastmod` values. Run it with:
+
+  ```bash
+  cargo test -p reddit-clone --test seo_pg_integration -- --ignored
+  ```
+
+---
+
+## Checklist
+
+1. Set `[seo] base_url` to the real public host.
+2. Put `(seo.render())` in the `<head>` of your layout.
+3. Declare a `title` and a `description` on each public route.
+4. Add a canonical URL on each page that answers at more than one address.
+5. Mark each private page `robots = "noindex, nofollow"`.
+6. Register a `SitemapSource` for the pages the framework cannot derive.
+7. Read `/robots.txt` and `/sitemap.xml` before you deploy.
+
+---
+
+## Reference
+
+| Item | Where |
+|---|---|
+| `seo(...)` route argument | `#[get]`, `#[post]`, `#[put]`, `#[patch]`, `#[delete]`, `#[static_get]` |
+| `SeoMeta` builder and extractor | `autumn_web::seo::SeoMeta` |
+| `locale_alternates` | `autumn_web::seo::locale_alternates` |
+| `SitemapSource`, `SitemapEntry`, `SitemapChangefreq` | `autumn_web::seo` |
+| `sitemap_xml`, `robots_txt` | `autumn_web::seo` |
+| `AppBuilder::seo_source` | `autumn_web::app::AppBuilder` |
+| `[seo]`, `[seo.robots]` | `autumn.toml` |
+
+## Related guides
+
+- [Internationalization](i18n.md) — locale-prefixed routing and the locale
+  switcher that the `hreflang` links pair with.
+- [Atom and RSS Feeds](feeds.md) — the other document a content site publishes
+  for machines.
+- [Getting Started](getting-started.md) — `#[static_get]`, the route kind whose
+  paths Autumn puts in the sitemap for you.
+- [Deployment](deployment.md) — profiles, which decide the `robots.txt`
+  default.
+
+---
+
+*This guide follows [ASD-STE100](https://www.asd-ste100.org/) Simplified
+Technical English: short sentences, active voice, simple tenses, and one
+meaning per word. Keep that style when you edit it.*

--- a/examples/reddit-clone/README.md
+++ b/examples/reddit-clone/README.md
@@ -144,8 +144,9 @@ websocat ws://localhost:3000/ws/r/rustlang
 `[seo] base_url` in `autumn.toml` mounts `/robots.txt` and `/sitemap.xml`. The
 sitemap source in `src/seo.rs` reads the database at start-up and lists the
 front page, the community index, the communities, and the posts (capped at
-1,000 and 5,000 entries respectively — a bounded boot query, with a logged
-warning when a cap bites).
+1,000 and 5,000 entries respectively, with a logged warning when a cap bites).
+The caps bound the number of URLs, not the work the query does — see
+`src/seo.rs` for when to stop building the sitemap at boot.
 
 ```bash
 # The crawl rules. The dev profile disallows every crawler; prod allows them.

--- a/examples/reddit-clone/README.md
+++ b/examples/reddit-clone/README.md
@@ -30,6 +30,7 @@ showcasing the framework's major features in a single cohesive application.
 | Tailwind CSS styling | All templates |
 | Static asset serving (`/static/css/`, `/static/js/htmx.min.js`) | Auto-mounted |
 | Audit logging (`AuditLogger` + `TracingAuditSink`, actor auto-attribution via `Current::actor()`) | `main.rs`, `routes/posts.rs` (`delete_post`) |
+| **Route-level SEO** (`seo(...)` + `SeoMeta` extractor, canonical URLs, `robots = "noindex"`, DB-backed `SitemapSource`, auto-mounted `/robots.txt` + `/sitemap.xml`) | `seo.rs`, `autumn.toml`, `routes/posts.rs`, `routes/subreddits.rs`, `routes/about.rs`, `routes/layout.rs` |
 
 ## Prerequisites
 
@@ -138,6 +139,38 @@ websocat ws://localhost:3000/ws/feed
 websocat ws://localhost:3000/ws/r/rustlang
 ```
 
+## SEO
+
+`[seo] base_url` in `autumn.toml` mounts `/robots.txt` and `/sitemap.xml`. The
+sitemap source in `src/seo.rs` reads the database at start-up and lists the
+front page, the community index, every community, and every post.
+
+```bash
+# The crawl rules. The dev profile disallows every crawler; prod allows them.
+curl http://localhost:3000/robots.txt
+
+# One <url> per public page, with <lastmod> from posts.updated_at.
+curl http://localhost:3000/sitemap.xml
+
+# The per-page meta tags the route attributes declare.
+curl -s http://localhost:3000/ | grep -E '<title>|og:|canonical'
+curl -s http://localhost:3000/about | grep -E '<title>|og:'
+```
+
+Where each part lives:
+
+| Part | File |
+|------|------|
+| `[seo]` and `[seo.robots]` settings | `autumn.toml` |
+| `SitemapSource`, canonical helpers, `summarize` | `src/seo.rs` |
+| Attribute-only meta tags on a static page | `src/routes/about.rs` |
+| Attribute defaults refined from a database row | `src/routes/posts.rs` (`show`) |
+| `robots = "noindex, nofollow"` on a private page | `src/routes/posts.rs` (`submit_form`) |
+| `SeoMeta::render()` in the shared `<head>` | `src/routes/layout.rs` |
+
+Change `base_url` to the real host before you deploy. See
+[`docs/guide/seo.md`](../../docs/guide/seo.md) for the full guide.
+
 ## API Endpoints
 
 The `#[repository]` macro auto-generates read-only REST endpoints:
@@ -165,6 +198,7 @@ src/
   jobs.rs           # #[job] onboarding + post-publication side effects
   live_bus.rs       # Live-feed bus config and backend selection
   live_events.rs    # Durable app-db live-feed relay with Postgres/Redis wakeups
+  seo.rs            # SitemapSource (DB-backed), canonical-URL helpers, summarize()
   tasks.rs          # Scheduled hot-rank + live-feed retention tasks
   slugify.rs        # URL slug generation utility
   routes/

--- a/examples/reddit-clone/README.md
+++ b/examples/reddit-clone/README.md
@@ -143,7 +143,9 @@ websocat ws://localhost:3000/ws/r/rustlang
 
 `[seo] base_url` in `autumn.toml` mounts `/robots.txt` and `/sitemap.xml`. The
 sitemap source in `src/seo.rs` reads the database at start-up and lists the
-front page, the community index, every community, and every post.
+front page, the community index, the communities, and the posts (capped at
+1,000 and 5,000 entries respectively — a bounded boot query, with a logged
+warning when a cap bites).
 
 ```bash
 # The crawl rules. The dev profile disallows every crawler; prod allows them.

--- a/examples/reddit-clone/autumn.toml
+++ b/examples/reddit-clone/autumn.toml
@@ -38,14 +38,19 @@ base_url = "https://autumn-reddit.example.com"
 # allows every crawler. Set `allow_all = false` here to keep a staging
 # deployment out of search results even when it runs the `prod` profile.
 #
-# These rules are a second line of defence for the pages that must stay out of
-# the index. `robots.txt` stops the crawl; the `seo(robots = "noindex")`
-# argument on a route stops the indexing. Use both: a page that another site
-# links to can still be indexed without ever being crawled.
+# `Disallow` and `noindex` are ALTERNATIVES for one URL, not layers. A
+# `Disallow` line stops the fetch, so a crawler never reads the page's
+# `noindex` tag -- and the URL can still be indexed from an inbound link, as a
+# bare result nobody can remove. Pick one tool per URL:
+#
+#   * "I do not want this URL in the index"  -> allow the crawl, serve
+#     `seo(robots = "noindex")`. That is why `/submit` and `/u/` are NOT
+#     listed below even though both declare the directive.
+#   * "I do not want crawlers here at all"   -> `Disallow`, and accept that
+#     URL-only indexing stays possible. That is the right trade for the
+#     machine endpoints below: they serve JSON or HTML fragments, so there is
+#     no page anyone could usefully index anyway.
 additional_rules = [
-  "Disallow: /submit",
-  "Disallow: /login",
-  "Disallow: /register",
   "Disallow: /_partials/",
   "Disallow: /actuator/",
   "Disallow: /api/",

--- a/examples/reddit-clone/autumn.toml
+++ b/examples/reddit-clone/autumn.toml
@@ -22,6 +22,35 @@ path = "/health"
 [security.csrf]
 enabled = true
 
+# Route-level SEO (docs/guide/seo.md).
+#
+# `base_url` turns on /robots.txt and /sitemap.xml. The framework needs it
+# because both files hold absolute URLs. It also lets the handlers build a
+# canonical URL for each page (see src/seo.rs).
+#
+# Change this to the real host before you deploy. The value below is the demo
+# host, and a wrong `base_url` sends crawlers to URLs that do not exist.
+[seo]
+base_url = "https://autumn-reddit.example.com"
+
+[seo.robots]
+# The profile sets the default: `dev` and `test` disallow every crawler, `prod`
+# allows every crawler. Set `allow_all = false` here to keep a staging
+# deployment out of search results even when it runs the `prod` profile.
+#
+# These rules are a second line of defence for the pages that must stay out of
+# the index. `robots.txt` stops the crawl; the `seo(robots = "noindex")`
+# argument on a route stops the indexing. Use both: a page that another site
+# links to can still be indexed without ever being crawled.
+additional_rules = [
+  "Disallow: /submit",
+  "Disallow: /login",
+  "Disallow: /register",
+  "Disallow: /_partials/",
+  "Disallow: /actuator/",
+  "Disallow: /api/",
+]
+
 [security.webhooks.replay]
 allow_memory_in_production = true
 

--- a/examples/reddit-clone/src/hooks.rs
+++ b/examples/reddit-clone/src/hooks.rs
@@ -29,7 +29,7 @@ impl MutationHooks for PostHooks {
 
     async fn before_update(
         &self,
-        _ctx: &mut MutationContext,
+        ctx: &mut MutationContext,
         draft: &mut UpdateDraft<Post>,
     ) -> AutumnResult<()> {
         // Re-slug if title changed and slug was not manually set in the changes
@@ -41,6 +41,116 @@ impl MutationHooks for PostHooks {
                 "Re-slugged post after title change"
             );
         }
+
+        // Advance the modification timestamp on every update path -- the edit
+        // form, the generated API routes, a bulk update. `posts.updated_at`
+        // carries a `DEFAULT NOW()` that only fires on INSERT, so without this
+        // line an edited post keeps reporting its creation date forever. That
+        // matters beyond the column itself: `/sitemap.xml` publishes it as each
+        // post's `<lastmod>` (see `crate::seo`), which is how a crawler decides
+        // whether to fetch the page again. A stale `<lastmod>` tells it not to.
+        //
+        // `ctx.now` is the framework's injected mutation timestamp, so this
+        // stays deterministic under `#[sim_test]`; `chrono::Utc::now()` would
+        // not (see the determinism seam gate in `clippy.toml`).
+        draft.after.updated_at = ctx.now.naive_utc();
+
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use autumn_web::hooks::MutationOp;
+    use chrono::TimeZone as _;
+
+    use super::*;
+
+    /// A post created a year ago and never touched since.
+    fn stale_post() -> Post {
+        let created = chrono::NaiveDate::from_ymd_opt(2025, 5, 1)
+            .expect("valid date")
+            .and_hms_opt(12, 0, 0)
+            .expect("valid time");
+        Post {
+            id: 1,
+            title: "Original title".to_owned(),
+            slug: "original-title".to_owned(),
+            body: "Body".to_owned(),
+            url: None,
+            author_id: 1,
+            subreddit_id: 1,
+            score: 0,
+            hot_rank: 0.0,
+            comment_count: 0,
+            created_at: created,
+            updated_at: created,
+        }
+    }
+
+    /// A context whose `now` is fixed, so the assertion below is exact.
+    fn context_at(year: i32, month: u32, day: u32) -> MutationContext {
+        let mut ctx = MutationContext::new(MutationOp::Update);
+        ctx.now = chrono::Utc
+            .with_ymd_and_hms(year, month, day, 9, 30, 0)
+            .single()
+            .expect("valid timestamp");
+        ctx
+    }
+
+    #[tokio::test]
+    async fn before_update_advances_updated_at() {
+        let mut ctx = context_at(2026, 6, 2);
+        let mut draft = UpdateDraft::new(stale_post());
+        draft.after.body = "Edited body".to_owned();
+
+        PostHooks
+            .before_update(&mut ctx, &mut draft)
+            .await
+            .expect("hook succeeds");
+
+        assert_eq!(
+            draft.after.updated_at,
+            ctx.now.naive_utc(),
+            "an edit must advance posts.updated_at -- /sitemap.xml publishes it as <lastmod>",
+        );
+        assert_ne!(
+            draft.after.updated_at, draft.before.updated_at,
+            "the timestamp must move off the creation date",
+        );
+        assert_eq!(
+            draft.after.created_at, draft.before.created_at,
+            "created_at must not move",
+        );
+    }
+
+    #[tokio::test]
+    async fn before_update_advances_updated_at_even_without_a_field_change() {
+        // A no-op save still counts as a modification for `<lastmod>`: the
+        // hook must not make the timestamp conditional on a diff it cannot
+        // see (tags, votes and comments all change the rendered page).
+        let mut ctx = context_at(2026, 7, 4);
+        let mut draft = UpdateDraft::new(stale_post());
+
+        PostHooks
+            .before_update(&mut ctx, &mut draft)
+            .await
+            .expect("hook succeeds");
+
+        assert_eq!(draft.after.updated_at, ctx.now.naive_utc());
+    }
+
+    #[tokio::test]
+    async fn before_update_still_reslugs_on_a_title_change() {
+        let mut ctx = context_at(2026, 6, 2);
+        let mut draft = UpdateDraft::new(stale_post());
+        draft.after.title = "A brand new title".to_owned();
+
+        PostHooks
+            .before_update(&mut ctx, &mut draft)
+            .await
+            .expect("hook succeeds");
+
+        assert_eq!(draft.after.slug, "a-brand-new-title");
     }
 }

--- a/examples/reddit-clone/src/hooks.rs
+++ b/examples/reddit-clone/src/hooks.rs
@@ -46,9 +46,14 @@ impl MutationHooks for PostHooks {
         // form, the generated API routes, a bulk update. `posts.updated_at`
         // carries a `DEFAULT NOW()` that only fires on INSERT, so without this
         // line an edited post keeps reporting its creation date forever. That
-        // matters beyond the column itself: `/sitemap.xml` publishes it as each
+        // matters beyond the column itself: `/sitemap.xml` feeds it into each
         // post's `<lastmod>` (see `crate::seo`), which is how a crawler decides
         // whether to fetch the page again. A stale `<lastmod>` tells it not to.
+        //
+        // This covers edits only. A comment changes the page without touching
+        // the `posts` row at all, so `crate::seo` derives the final
+        // `<lastmod>` as the later of this column and the newest live comment
+        // rather than expecting every subsystem to write a timestamp here.
         //
         // `ctx.now` is the framework's injected mutation timestamp, so this
         // stays deterministic under `#[sim_test]`; `chrono::Utc::now()` would
@@ -126,9 +131,14 @@ mod tests {
 
     #[tokio::test]
     async fn before_update_advances_updated_at_even_without_a_field_change() {
-        // A no-op save still counts as a modification for `<lastmod>`: the
-        // hook must not make the timestamp conditional on a diff it cannot
-        // see (tags, votes and comments all change the rendered page).
+        // A no-op save still counts as a modification: the hook cannot see
+        // every reason a caller saved (a normalizer may have rewritten a
+        // field, or the caller may be re-persisting a value it recomputed),
+        // so it must not make the timestamp conditional on a column diff.
+        //
+        // This hook covers the `PgPostRepository::update` path only. Comments
+        // never touch the `posts` row -- `crate::seo` derives their effect on
+        // `<lastmod>` at read time instead.
         let mut ctx = context_at(2026, 7, 4);
         let mut draft = UpdateDraft::new(stale_post());
 

--- a/examples/reddit-clone/src/lib.rs
+++ b/examples/reddit-clone/src/lib.rs
@@ -13,6 +13,7 @@ pub mod policies;
 pub mod repositories;
 pub mod routes;
 pub mod schema;
+pub mod seo;
 pub mod tasks;
 
 use std::sync::{Arc, OnceLock};

--- a/examples/reddit-clone/src/main.rs
+++ b/examples/reddit-clone/src/main.rs
@@ -33,6 +33,9 @@
 //                          (see routes/webhooks.rs, [[security.webhooks.endpoints]] in autumn.toml)
 //   Outbound HTTP       -> autumn_web::http::Client extractor for traced, retried outbound calls
 //                          (link-preview deferred: tracked in #1238 + #1239 for 0.5.0)
+//   Route-level SEO     -> seo(...) on the route attributes + the SeoMeta extractor, a
+//                          database-backed SitemapSource, /robots.txt and /sitemap.xml
+//                          (see src/seo.rs, [seo] in autumn.toml, docs/guide/seo.md)
 //
 // Run with:   cargo run -p reddit-clone   (first dev boot applies reddit migrations and
 //                                          starts the job runtime + durable live-feed relay)
@@ -40,6 +43,9 @@
 // WebSocket:  ws://localhost:3000/ws/feed
 // API test:   curl http://localhost:3000/api/posts
 //             curl http://localhost:3000/api/subreddits
+// SEO test:   curl http://localhost:3000/robots.txt
+//             curl http://localhost:3000/sitemap.xml
+//             curl -s http://localhost:3000/ | grep -E '<title>|og:|canonical'
 
 use autumn_web::actuator::{HealthCheckOutput, HealthIndicator, HealthStatus};
 use autumn_web::config::AutumnConfig;
@@ -95,11 +101,22 @@ async fn main() {
     // assignments survive restarts and you can conclude experiments from the DB.
     let experiment_svc = experiments::setup();
 
+    // Route-level SEO (docs/guide/seo.md). Two steps:
+    //
+    //   1. Record `[seo] base_url` so the handlers can build canonical URLs
+    //      without cloning the whole config on each request.
+    //   2. Register the sitemap source. This ALSO mounts /robots.txt and
+    //      /sitemap.xml — `[seo] base_url` alone is enough to mount them, and
+    //      the source only adds the dynamic URLs.
+    reddit_clone::seo::init_base_url(&app_config);
+    let sitemap_source = reddit_clone::seo::RedditSitemapSource::from_config(&app_config);
+
     let app = autumn_web::app()
         .migrations(autumn_web::migrate::FRAMEWORK_MIGRATIONS)
         .migrations(MIGRATIONS)
         .with_flag_store(flag_store)
         .with_error_reporter(StructuredReporter)
+        .seo_source(sitemap_source)
         .state_initializer(move |state| {
             state.insert_extension(experiment_svc);
             // Audit sink: an append-only security-event log, kept separate from

--- a/examples/reddit-clone/src/routes/about.rs
+++ b/examples/reddit-clone/src/routes/about.rs
@@ -34,7 +34,11 @@ use super::layout::layout_with_seo;
 )]
 pub async fn about(seo: SeoMeta) -> Markup {
     layout_with_seo(
-        seo,
+        // The canonical URL is the one value the attribute cannot hold: it
+        // needs `[seo] base_url` from `autumn.toml`, which is a run-time
+        // value. `main` records it before the app starts, and `autumn build`
+        // runs that same `main`, so the pre-rendered HTML carries the tag too.
+        crate::seo::with_canonical(seo, "/about"),
         None,
         None,
         html! {
@@ -190,4 +194,58 @@ pub async fn about(seo: SeoMeta) -> Markup {
             }
         },
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use autumn_web::config::{AutumnConfig, SeoConfig};
+
+    use super::*;
+
+    /// `crate::seo::BASE_URL` is a process-wide `OnceLock`, so this test sets
+    /// it for the whole lib-test binary. That is safe today because no other
+    /// test in this binary reads it: the two `crate::seo` tests exercise the
+    /// pure `with_canonical_in` instead. Keep it that way — a test that
+    /// asserts the *unset* path through `with_canonical` would become
+    /// order-dependent.
+    fn configure_base_url() {
+        crate::seo::init_base_url(&AutumnConfig {
+            seo: SeoConfig {
+                base_url: Some("https://autumn-reddit.example.com".to_owned()),
+                ..Default::default()
+            },
+            ..Default::default()
+        });
+    }
+
+    #[tokio::test]
+    async fn about_page_renders_its_attribute_tags_and_a_canonical_url() {
+        configure_base_url();
+
+        // The route attribute normally feeds these values in through the
+        // `SeoMeta` extractor. This test calls the handler directly, so it
+        // stands in for the router and passes the same values.
+        let seo = SeoMeta::new()
+            .title("About \u{2022} Autumn Reddit")
+            .description("Autumn Reddit is a demo link-sharing site.")
+            .og_type("website")
+            .twitter_card("summary");
+
+        let html = about(seo).await.into_string();
+
+        assert!(
+            html.contains("<title>About \u{2022} Autumn Reddit</title>"),
+            "html: {html}"
+        );
+        assert!(
+            html.contains(r#"<meta property="og:type" content="website">"#),
+            "html: {html}"
+        );
+        assert!(
+            html.contains(
+                r#"<link rel="canonical" href="https://autumn-reddit.example.com/about">"#
+            ),
+            "the static page must carry a canonical URL too; html: {html}"
+        );
+    }
 }

--- a/examples/reddit-clone/src/routes/about.rs
+++ b/examples/reddit-clone/src/routes/about.rs
@@ -4,15 +4,37 @@
 //! static HTML — zero compute per request. It showcases all the Autumn
 //! features used in this Reddit clone example.
 
+use autumn_web::seo::SeoMeta;
 use autumn_web::{Markup, html, static_get};
 
-use super::layout::layout;
+use super::layout::layout_with_seo;
 
+/// The about page, pre-rendered at build time.
+///
+/// The `seo(...)` argument on the attribute holds every meta value this page
+/// needs, and the `SeoMeta` parameter receives them. The handler adds nothing:
+/// a page whose text never changes needs no per-request builder.
+///
+/// `#[static_get]` honours `seo(...)` in the same way as `#[get]`, so the
+/// pre-rendered HTML carries the tags too.
+///
+/// This route also puts `/about` in `/sitemap.xml`. The framework derives a
+/// sitemap entry for each `#[static_get]` path when `[seo] base_url` is set,
+/// so `RedditSitemapSource` does not list this page. See `docs/guide/seo.md`.
 #[allow(clippy::too_many_lines)] // Template-heavy function
-#[static_get("/about")]
-pub async fn about() -> Markup {
-    layout(
-        "About",
+#[static_get(
+    "/about",
+    seo(
+        title = "About \u{2022} Autumn Reddit",
+        description = "Autumn Reddit is a demo link-sharing site. It shows every major feature of \
+                       the Autumn web framework for Rust in one application.",
+        og_type = "website",
+        twitter_card = "summary"
+    )
+)]
+pub async fn about(seo: SeoMeta) -> Markup {
+    layout_with_seo(
+        seo,
         None,
         None,
         html! {

--- a/examples/reddit-clone/src/routes/auth.rs
+++ b/examples/reddit-clone/src/routes/auth.rs
@@ -19,7 +19,7 @@ use crate::jobs::{UserOnboardingArgs, UserOnboardingJob};
 use crate::models::{NewUser, User};
 use crate::schema::users;
 
-use super::layout::layout;
+use super::layout::{layout, layout_with_seo};
 
 struct AccountMailer;
 
@@ -404,8 +404,28 @@ pub async fn logout(
 
 // ── Profile ────────────────────────────────────────────────────
 
-#[get("/u/{username}")]
+/// A user's public profile.
+///
+/// This is the route where `robots = "noindex"` actually does its job, and it
+/// is worth understanding why. The directive only works if a crawler FETCHES
+/// the page and reads the tag. Two things have to be true for that:
+///
+///   1. `robots.txt` must not block the URL. A `Disallow` line stops the
+///      fetch, so the crawler never sees the tag -- and the URL can still be
+///      indexed from an inbound link, with no content and no way to remove it.
+///      `autumn.toml` deliberately does not list `/u/`.
+///   2. The page must be reachable without a session. This route is public;
+///      `submit_form` is `#[secured]`, so an anonymous crawler gets the login
+///      redirect there rather than the tag.
+///
+/// Profiles are the natural thing to keep out of an index: thin, near-duplicate
+/// pages whose content lives on the posts they link to.
+///
+/// See `docs/guide/seo.md`, "Keep a page out of the index".
+#[allow(clippy::too_many_arguments)]
+#[get("/u/{username}", seo(og_type = "profile", robots = "noindex, follow"))]
 pub async fn profile(
+    seo: SeoMeta,
     State(state): State<AppState>,
     Path(name): Path<String>,
     session: Session,
@@ -449,8 +469,19 @@ pub async fn profile(
     };
     let is_self = current_user.as_deref() == Some(user.username.as_str());
 
-    Ok(layout(
-        &format!("u/{}", user.username),
+    // `follow` and not `nofollow`: keep this page out of the index, but let
+    // crawlers walk the links to the user's posts, which DO belong there.
+    let seo = crate::seo::with_canonical(
+        seo.title(format!("u/{} \u{2022} Autumn Reddit", user.username))
+            .description(format!(
+                "The profile of u/{} on Autumn Reddit.",
+                user.username
+            )),
+        &__autumn_path_profile(&user.username),
+    );
+
+    Ok(layout_with_seo(
+        seo,
         current_user.as_deref(),
         Some(csrf.token()),
         html! {

--- a/examples/reddit-clone/src/routes/layout.rs
+++ b/examples/reddit-clone/src/routes/layout.rs
@@ -374,6 +374,28 @@ mod tests {
         );
     }
 
+    /// `noindex, follow` is the directive a thin-but-linking page wants: keep
+    /// this page out of the index, but let crawlers walk through to the pages
+    /// that belong in it. `routes::auth::profile` declares exactly this.
+    #[test]
+    fn layout_with_seo_renders_noindex_follow_for_a_profile_page() {
+        let seo = SeoMeta::new()
+            .title("u/ferris \u{2022} Autumn Reddit")
+            .robots("noindex, follow")
+            .og_type("profile");
+
+        let rendered = layout_with_seo(seo, None, None, html! {}).into_string();
+
+        assert!(
+            rendered.contains(r#"<meta name="robots" content="noindex, follow">"#),
+            "rendered: {rendered}"
+        );
+        assert!(
+            !rendered.contains("nofollow"),
+            "`follow` must not be rendered as `nofollow`; rendered: {rendered}"
+        );
+    }
+
     #[test]
     fn layout_with_seo_renders_a_noindex_directive() {
         let seo = SeoMeta::new()

--- a/examples/reddit-clone/src/routes/layout.rs
+++ b/examples/reddit-clone/src/routes/layout.rs
@@ -2,6 +2,7 @@
 
 use autumn_web::reexports::axum::response::{IntoResponse, Response};
 use autumn_web::reexports::http;
+use autumn_web::seo::SeoMeta;
 use autumn_web::widgets::{ReactionControls, reaction_controls};
 use autumn_web::{HTMX_CSRF_JS_PATH, HTMX_JS_PATH, HTMX_SSE_JS_PATH, Markup, PreEscaped, html};
 
@@ -83,9 +84,43 @@ pub fn nav_auth_markup(username: Option<&str>) -> Markup {
 /// Base HTML layout wrapping page content.
 ///
 /// Accepts an optional `username` to show login/logout state in the nav.
+///
+/// This is the plain-title entry point, and most pages use it. It builds a
+/// [`SeoMeta`] that holds only the title and calls [`layout_with_seo`]. Pages
+/// that want more meta tags — a description, a canonical URL, Open Graph
+/// values, a `robots` directive — call [`layout_with_seo`] directly with the
+/// builder the `SeoMeta` extractor gave them.
 #[allow(clippy::needless_pass_by_value)] // Maud Markup is idiomatically passed by value
 pub fn layout(
     title: &str,
+    username: Option<&str>,
+    csrf_token: Option<&str>,
+    content: Markup,
+) -> Markup {
+    layout_with_seo(
+        SeoMeta::new().title(format!("{title} \u{2014} Autumn Reddit")),
+        username,
+        csrf_token,
+        content,
+    )
+}
+
+/// Base HTML layout that takes an explicit [`SeoMeta`] builder.
+///
+/// [`SeoMeta::render`] writes the `<title>` tag, so `seo` must carry a title.
+/// The route attribute usually supplies it:
+///
+/// ```rust,ignore
+/// #[get("/about", seo(title = "About \u{2022} Autumn Reddit"))]
+/// pub async fn about(seo: SeoMeta) -> Markup {
+///     layout_with_seo(seo, None, None, html! { /* ... */ })
+/// }
+/// ```
+///
+/// See `docs/guide/seo.md`.
+#[allow(clippy::needless_pass_by_value)] // Maud Markup is idiomatically passed by value
+pub fn layout_with_seo(
+    seo: SeoMeta,
     username: Option<&str>,
     csrf_token: Option<&str>,
     content: Markup,
@@ -96,7 +131,10 @@ pub fn layout(
             head {
                 meta charset="utf-8";
                 meta name="viewport" content="width=device-width, initial-scale=1";
-                title { (title) " — Autumn Reddit" }
+                // One call writes <title>, the description, the canonical
+                // link, the Open Graph tags, and the Twitter card tags — but
+                // only the ones this page actually set (see docs/guide/seo.md).
+                (seo.render())
                 // Embed CSRF token in a meta tag so htmx JS can read it
                 // (the autumn-csrf cookie is HttpOnly and inaccessible to JS)
                 @if let Some(token) = csrf_token {
@@ -255,8 +293,100 @@ pub fn time_ago(dt: &chrono::NaiveDateTime) -> String {
 #[cfg(test)]
 mod tests {
     use autumn_web::html;
+    use autumn_web::seo::SeoMeta;
 
-    use super::layout;
+    use super::{layout, layout_with_seo};
+
+    #[test]
+    fn layout_still_renders_the_site_title_suffix() {
+        let rendered = layout("Front Page", None, None, html! {}).into_string();
+
+        assert!(
+            rendered.contains("<title>Front Page \u{2014} Autumn Reddit</title>"),
+            "rendered: {rendered}"
+        );
+    }
+
+    #[test]
+    fn layout_with_seo_renders_every_declared_tag() {
+        let seo = SeoMeta::new()
+            .title("hello \u{2022} r/rust \u{2022} Autumn Reddit")
+            .description("A post about Rust.")
+            .canonical("https://autumn-reddit.example.com/r/rust/posts/hello")
+            .og_type("article")
+            .twitter_card("summary_large_image");
+
+        let rendered = layout_with_seo(seo, None, None, html! {}).into_string();
+
+        assert!(
+            rendered.contains("<title>hello \u{2022} r/rust \u{2022} Autumn Reddit</title>"),
+            "rendered: {rendered}"
+        );
+        assert!(
+            rendered.contains(r#"<meta name="description" content="A post about Rust.">"#),
+            "rendered: {rendered}"
+        );
+        assert!(
+            rendered.contains(
+                r#"<link rel="canonical" href="https://autumn-reddit.example.com/r/rust/posts/hello">"#
+            ),
+            "rendered: {rendered}"
+        );
+        assert!(
+            rendered.contains(r#"<meta property="og:type" content="article">"#),
+            "rendered: {rendered}"
+        );
+        // og:title and og:description fall back to the page title and
+        // description, so the app sets each value one time.
+        assert!(
+            rendered.contains(r#"<meta property="og:title" content="hello"#),
+            "rendered: {rendered}"
+        );
+        assert!(
+            rendered.contains(r#"<meta name="twitter:card" content="summary_large_image">"#),
+            "rendered: {rendered}"
+        );
+        // og:url falls back to the canonical URL.
+        assert!(
+            rendered.contains(
+                r#"<meta property="og:url" content="https://autumn-reddit.example.com/r/rust/posts/hello">"#
+            ),
+            "rendered: {rendered}"
+        );
+    }
+
+    #[test]
+    fn layout_with_seo_emits_only_the_tags_a_page_sets() {
+        let rendered =
+            layout_with_seo(SeoMeta::new().title("Plain"), None, None, html! {}).into_string();
+
+        assert!(
+            rendered.contains("<title>Plain</title>"),
+            "rendered: {rendered}"
+        );
+        assert!(
+            !rendered.contains("og:type"),
+            "an unset value must emit no tag; rendered: {rendered}"
+        );
+        assert!(
+            !rendered.contains("rel=\"canonical\""),
+            "an unset value must emit no tag; rendered: {rendered}"
+        );
+    }
+
+    #[test]
+    fn layout_with_seo_renders_a_noindex_directive() {
+        let seo = SeoMeta::new()
+            .title("Submit a post \u{2022} Autumn Reddit")
+            .robots("noindex, nofollow");
+
+        let rendered = layout_with_seo(seo, Some("ferris"), None, html! {}).into_string();
+
+        assert!(
+            rendered.contains(r#"<meta name="robots" content="noindex, nofollow">"#),
+            "rendered: {rendered}"
+        );
+    }
 
     #[test]
     fn layout_loads_framework_csrf_script_from_same_origin() {

--- a/examples/reddit-clone/src/routes/posts.rs
+++ b/examples/reddit-clone/src/routes/posts.rs
@@ -327,14 +327,22 @@ pub async fn front_page(
 
 /// The submit form.
 ///
-/// `robots = "noindex, nofollow"` keeps this page out of search results. The
-/// page is behind `#[secured]`, so a crawler only ever sees the login
-/// redirect, and an indexed "Submit a post" result would help nobody.
+/// `robots = "noindex, nofollow"` declares the intent, but note what actually
+/// reaches a crawler here: the page is behind `#[secured]`, so an anonymous
+/// request gets the login redirect, not this HTML. The directive is therefore
+/// belt-and-braces for signed-in states rather than the thing keeping the URL
+/// out of an index. `routes::auth::profile` is the route where the same
+/// directive genuinely does the work, on a page a crawler can fetch.
 ///
-/// The directive also has a second effect on `#[static_get]` routes: the
-/// framework drops such a route from `/sitemap.xml`, so the application never
-/// advertises a URL and asks crawlers to skip it at the same time. This route
-/// is a `#[get]` route, so no derived entry exists to drop.
+/// What the app must NOT do is also add `/submit` to `[seo.robots]
+/// additional_rules`. A `Disallow` line stops the fetch, so no crawler could
+/// ever read this tag — the two are alternatives for one URL, not layers.
+/// See the comment in `autumn.toml` and `docs/guide/seo.md`.
+///
+/// The directive has a second effect on `#[static_get]` routes: the framework
+/// drops such a route from `/sitemap.xml`, so the application never advertises
+/// a URL and asks crawlers to skip it at the same time. This route is a
+/// `#[get]` route, so no derived entry exists to drop.
 #[secured]
 #[get(
     "/submit",

--- a/examples/reddit-clone/src/routes/posts.rs
+++ b/examples/reddit-clone/src/routes/posts.rs
@@ -34,13 +34,33 @@ fn posts_per_page() -> i64 {
         .unwrap_or(25)
 }
 
-use super::layout::{layout, time_ago, vote_controls};
+use super::layout::{layout, layout_with_seo, time_ago, vote_controls};
 
 // ── Front page — hot posts across all subreddits ───────────────
 
-#[get("/")]
+/// The front page.
+///
+/// Route-level SEO (#1182): the `seo(...)` argument declares the values that
+/// never change, and the `SeoMeta` parameter delivers them to the handler.
+/// The handler adds the one value the attribute cannot hold — the canonical
+/// URL, which needs `[seo] base_url` from `autumn.toml` at run time.
+///
+/// See `docs/guide/seo.md`.
+#[get(
+    "/",
+    seo(
+        title = "Autumn Reddit \u{2022} Front page",
+        description = "The hottest posts across every community on Autumn Reddit, a demo \
+                       link-sharing site built with the Autumn web framework for Rust.",
+        og_type = "website",
+        // `summary` and not `summary_large_image`: this app ships no share
+        // image. Set `og_image` first, then change the card type.
+        twitter_card = "summary"
+    )
+)]
 #[allow(clippy::too_many_arguments)]
 pub async fn front_page(
+    seo: SeoMeta,
     session: Session,
     csrf: CsrfToken,
     mut db: Db,
@@ -139,8 +159,8 @@ pub async fn front_page(
     // Consume the flash only after all fallible work, so a mid-handler error
     // doesn't drop the one-shot message before it is shown.
     let flash_html = flash.render().await;
-    Ok(layout(
-        "Front Page",
+    Ok(layout_with_seo(
+        crate::seo::with_canonical(seo, "/"),
         current_user.as_deref(),
         Some(csrf.token()),
         html! {
@@ -305,9 +325,30 @@ pub async fn front_page(
 
 // ── Submit form (global — pick subreddit) ──────────────────────
 
+/// The submit form.
+///
+/// `robots = "noindex, nofollow"` keeps this page out of search results. The
+/// page is behind `#[secured]`, so a crawler only ever sees the login
+/// redirect, and an indexed "Submit a post" result would help nobody.
+///
+/// The directive also has a second effect on `#[static_get]` routes: the
+/// framework drops such a route from `/sitemap.xml`, so the application never
+/// advertises a URL and asks crawlers to skip it at the same time. This route
+/// is a `#[get]` route, so no derived entry exists to drop.
 #[secured]
-#[get("/submit")]
-pub async fn submit_form(session: Session, csrf: CsrfToken, mut db: Db) -> AutumnResult<Markup> {
+#[get(
+    "/submit",
+    seo(
+        title = "Submit a post \u{2022} Autumn Reddit",
+        robots = "noindex, nofollow"
+    )
+)]
+pub async fn submit_form(
+    seo: SeoMeta,
+    session: Session,
+    csrf: CsrfToken,
+    mut db: Db,
+) -> AutumnResult<Markup> {
     let current_user = session.get("username").await;
 
     let subs: Vec<Subreddit> = subreddits::table
@@ -316,8 +357,8 @@ pub async fn submit_form(session: Session, csrf: CsrfToken, mut db: Db) -> Autum
         .load(&mut *db)
         .await?;
 
-    Ok(layout(
-        "Submit Post",
+    Ok(layout_with_seo(
+        seo,
         current_user.as_deref(),
         Some(csrf.token()),
         html! {
@@ -629,8 +670,25 @@ pub async fn show_by_id(Path(post_id): Path<i64>, mut db: Db) -> AutumnResult<Re
 
 // ── View single post with comments ─────────────────────────────
 
+/// A post's detail page.
+///
+/// This is the SEO case the attribute alone cannot serve. `og_type` and the
+/// Twitter card type are the same for every post, so they sit on the
+/// attribute. The title, the description, and the canonical URL come from the
+/// row, so the handler refines the builder after it reads the post.
+///
+/// The canonical URL matters here more than on any other page. `/posts/{id}`
+/// redirects to this route, and htmx and share links add query strings, so one
+/// post has many addresses. The canonical tag names the one true address.
+///
+/// See `docs/guide/seo.md`.
 #[allow(clippy::too_many_lines)] // Template-heavy function
-#[get("/r/{sub_slug}/posts/{post_slug}")]
+#[get(
+    "/r/{sub_slug}/posts/{post_slug}",
+    // `og_type = "article"` is the right Open Graph type for a post. The card
+    // stays `summary` until the app has a share image to point `og_image` at.
+    seo(og_type = "article", twitter_card = "summary")
+)]
 // Every argument is a distinct extractor -- path, session, CSRF token, CSRF
 // field name, connection, repository, flags, flash. An axum handler's arguments
 // ARE its request-state declaration; bundling them into a struct would only
@@ -638,6 +696,7 @@ pub async fn show_by_id(Path(post_id): Path<i64>, mut db: Db) -> AutumnResult<Re
 #[allow(clippy::too_many_arguments)]
 pub async fn show(
     Path((sub_slug, post_slug)): Path<(String, String)>,
+    seo: SeoMeta,
     session: Session,
     csrf: CsrfToken,
     // The widget's hidden input has to carry the field name `CsrfLayer` will
@@ -742,10 +801,27 @@ pub async fn show(
         None => None,
     };
 
+    // Refine the attribute defaults with this post's own values. `og_type`
+    // and the Twitter card type stay as the attribute declared them.
+    // `og:title` and `og:description` fall back to `title` and `description`,
+    // so this app sets each value one time.
+    let seo = crate::seo::with_canonical(
+        seo.title(format!(
+            "{} \u{2022} r/{} \u{2022} Autumn Reddit",
+            post.title, sub.name
+        ))
+        .description(
+            crate::seo::summarize(&post.body, 155)
+                .or_else(|| post.url.clone())
+                .unwrap_or_else(|| format!("A post in r/{}.", sub.name)),
+        ),
+        &post_path,
+    );
+
     // Consume the flash only after all fallible work above.
     let flash_html = flash.render().await;
-    Ok(layout(
-        &post.title,
+    Ok(layout_with_seo(
+        seo,
         current_user.as_deref(),
         Some(csrf.token()),
         html! {

--- a/examples/reddit-clone/src/routes/subreddits.rs
+++ b/examples/reddit-clone/src/routes/subreddits.rs
@@ -14,17 +14,32 @@ use crate::schema::users;
 use autumn_web::slugify;
 use autumn_web::widgets::{CommentThread, CommentView, comment_thread};
 
-use super::layout::{layout, time_ago};
+use super::layout::{layout, layout_with_seo, time_ago};
 
 // ── List all communities ───────────────────────────────────────
 
-#[get("/r")]
-pub async fn list(session: Session, repo: PgSubredditRepository) -> AutumnResult<Markup> {
+/// The community index.
+///
+/// Every meta value is fixed text, so the `seo(...)` argument carries all of
+/// them and the handler only adds the canonical URL. See `docs/guide/seo.md`.
+#[get(
+    "/r",
+    seo(
+        title = "Communities \u{2022} Autumn Reddit",
+        description = "Every community on Autumn Reddit. Each one collects posts on one topic.",
+        og_type = "website"
+    )
+)]
+pub async fn list(
+    seo: SeoMeta,
+    session: Session,
+    repo: PgSubredditRepository,
+) -> AutumnResult<Markup> {
     let current_user = session.get("username").await;
     let all = repo.find_all().await?;
 
-    Ok(layout(
-        "Communities",
+    Ok(layout_with_seo(
+        crate::seo::with_canonical(seo, "/r"),
         current_user.as_deref(),
         None,
         html! {
@@ -179,9 +194,17 @@ pub async fn create(
 
 // ── Show subreddit with posts ──────────────────────────────────
 
-#[get("/r/{slug}")]
+/// A community's page.
+///
+/// The name and the description come from the row, so the handler refines the
+/// attribute defaults after it reads the community.
+#[get("/r/{slug}", seo(og_type = "website"))]
+// Every argument is a distinct extractor: path, SEO defaults, session, CSRF
+// token, CSRF field name, repository, connection, flash.
+#[allow(clippy::too_many_arguments)]
 pub async fn show(
     Path(slug): Path<String>,
+    seo: SeoMeta,
     session: Session,
     csrf: CsrfToken,
     // Same as the post detail page: the widget's hidden input must be named
@@ -256,10 +279,19 @@ pub async fn show(
             .sign_in_prompt("Log in to join the discussion.");
     }
 
+    let seo = crate::seo::with_canonical(
+        seo.title(format!("r/{} \u{2022} Autumn Reddit", sub.name))
+            .description(
+                crate::seo::summarize(&sub.description, 155)
+                    .unwrap_or_else(|| format!("The r/{} community on Autumn Reddit.", sub.name)),
+            ),
+        &__autumn_path_show(&sub.slug),
+    );
+
     // Consume the flash only after all fallible work above.
     let flash_html = flash.render().await;
-    Ok(layout(
-        &format!("r/{}", sub.name),
+    Ok(layout_with_seo(
+        seo,
         current_user.as_deref(),
         Some(csrf.token()),
         html! {

--- a/examples/reddit-clone/src/seo.rs
+++ b/examples/reddit-clone/src/seo.rs
@@ -25,7 +25,22 @@ use diesel::prelude::*;
 use diesel_async::RunQueryDsl;
 use diesel_async::pooled_connection::deadpool::Pool;
 
-use crate::schema::{posts, subreddits};
+use crate::models::Post;
+use crate::schema::subreddits;
+
+/// One post's sitemap row, as the derived-`lastmod` query returns it.
+///
+/// `last_modified` is not a column: it is `GREATEST(posts.updated_at, the
+/// newest live comment)`. See the query in [`RedditSitemapSource::collect`].
+#[derive(diesel::QueryableByName)]
+struct PostSitemapRow {
+    #[diesel(sql_type = diesel::sql_types::Text)]
+    sub_slug: String,
+    #[diesel(sql_type = diesel::sql_types::Text)]
+    post_slug: String,
+    #[diesel(sql_type = diesel::sql_types::Timestamp)]
+    last_modified: chrono::NaiveDateTime,
+}
 
 /// The maximum number of posts in `/sitemap.xml`.
 ///
@@ -36,8 +51,9 @@ use crate::schema::{posts, subreddits};
 /// table holds.
 ///
 /// The consequence is real and this example accepts it: past this many posts
-/// the sitemap is **partial**, and it drops the least recently updated posts
-/// first. `collect` logs a warning when it hits the cap, so the truncation is
+/// the sitemap is **partial**, and it drops the least recently changed posts
+/// first -- "changed" by the derived `<lastmod>`, so a busy comment thread
+/// keeps its place even when nobody has edited the post itself. `collect` logs a warning when it hits the cap, so the truncation is
 /// never silent. A site that outgrows one file needs a sitemap index served
 /// from its own `/sitemap.xml` route — see `docs/guide/seo.md`.
 const MAX_POST_ENTRIES: i64 = 5_000;
@@ -141,6 +157,11 @@ pub fn summarize(text: &str, max_chars: usize) -> Option<String> {
 /// posts. Both caps log a warning when they bite; read their doc comments for
 /// why the example bounds a boot-time query.
 ///
+/// Each post's `<lastmod>` is **derived**, not read from one column: it is the
+/// later of `posts.updated_at` and the post's newest live comment, because a
+/// comment changes the page without touching the `posts` row. See the query in
+/// [`Self::collect`] for the two changes deliberately left out.
+///
 /// The framework calls [`SitemapSource::entries`] one time, while it builds
 /// the router. It renders the result into a static `/sitemap.xml` body. The
 /// sitemap is therefore a snapshot of the database at start-up. That is the
@@ -234,19 +255,53 @@ impl RedditSitemapSource {
             );
         }
 
-        // `updated_at` becomes each post's `<lastmod>`, which tells a crawler
-        // whether it must fetch the page again. `PostHooks::before_update`
-        // advances that column on every update path, so the date is a real
-        // modification date and not the row's creation date.
+        // `<lastmod>` tells a crawler whether it must fetch the page again, so
+        // it has to describe the *page*, not one row. A post page is its body
+        // plus its comment thread, and the two change through different write
+        // paths:
         //
-        // The `ORDER BY updated_at DESC` pairs with the cap below: when the
-        // table outgrows `MAX_POST_ENTRIES`, the posts that survive into the
-        // sitemap are the ones that changed most recently.
-        let rows: Vec<(String, String, chrono::NaiveDateTime)> = match posts::table
-            .inner_join(subreddits::table)
-            .order(posts::updated_at.desc())
-            .limit(MAX_POST_ENTRIES)
-            .select((subreddits::slug, posts::slug, posts::updated_at))
+        //   * an edit goes through `PgPostRepository::update`, and
+        //     `PostHooks::before_update` advances `posts.updated_at`;
+        //   * a comment goes through the framework's comment router, which
+        //     never touches the `posts` row at all.
+        //
+        // So the modification time is derived here, at read time, rather than
+        // written by every subsystem that can change the page: `GREATEST` of
+        // the post's own timestamp and its newest live comment. Deriving beats
+        // fanning timestamp writes out across the comment router, the vote
+        // path and the tag path -- one query owns the definition, and no write
+        // path has to remember to participate.
+        //
+        // Two deliberate exclusions. **Votes** do not count: a score tick is
+        // exactly the trivial change search engines ask you not to advertise,
+        // and bumping every post on every vote would make the whole sitemap
+        // churn and teach crawlers to distrust its dates. **Tags** do not
+        // count either -- they are page chrome, not the content someone
+        // arrives to read.
+        //
+        // Raw SQL here on purpose: the cap below has to keep the genuinely
+        // freshest pages, so the ORDER BY must run on the same derived
+        // expression the SELECT returns. Ordering on `posts.updated_at` and
+        // computing the real date afterwards in Rust would cut a busy but
+        // rarely-edited thread before its freshness was ever known.
+        let post_sql = r#"
+            SELECT s.slug AS sub_slug,
+                   p.slug AS post_slug,
+                   GREATEST(p.updated_at, COALESCE(MAX(c.created_at), p.updated_at))
+                       AS last_modified
+              FROM posts p
+              JOIN subreddits s ON s.id = p.subreddit_id
+              LEFT JOIN comments c
+                     ON c.commentable_type = $1
+                    AND c.commentable_id = p.id
+                    AND c.deleted_at IS NULL
+             GROUP BY p.id, s.id
+             ORDER BY last_modified DESC
+             LIMIT $2
+        "#;
+        let rows: Vec<PostSitemapRow> = match diesel::sql_query(post_sql)
+            .bind::<diesel::sql_types::Text, _>(Post::COMMENTABLE_TYPE)
+            .bind::<diesel::sql_types::BigInt, _>(MAX_POST_ENTRIES)
             .load(&mut conn)
             .await
         {
@@ -260,13 +315,13 @@ impl RedditSitemapSource {
             tracing::warn!(
                 limit = MAX_POST_ENTRIES,
                 "sitemap: post cap reached; the sitemap is partial and omits the least \
-                 recently updated posts"
+                 recently changed posts"
             );
         }
-        for (sub_slug, post_slug, updated_at) in rows {
+        for row in rows {
             entries.push(
-                SitemapEntry::new(format!("{base}/r/{sub_slug}/posts/{post_slug}"))
-                    .lastmod(updated_at.format("%Y-%m-%d").to_string())
+                SitemapEntry::new(format!("{base}/r/{}/posts/{}", row.sub_slug, row.post_slug))
+                    .lastmod(row.last_modified.format("%Y-%m-%d").to_string())
                     .changefreq(SitemapChangefreq::Weekly)
                     .priority(0.6),
             );

--- a/examples/reddit-clone/src/seo.rs
+++ b/examples/reddit-clone/src/seo.rs
@@ -30,8 +30,9 @@ use crate::schema::subreddits;
 
 /// One post's sitemap row, as the derived-`lastmod` query returns it.
 ///
-/// `last_modified` is not a column: it is `GREATEST(posts.updated_at, the
-/// newest live comment)`. See the query in [`RedditSitemapSource::collect`].
+/// `last_modified` is not a column: it is the latest of the post's own
+/// `updated_at`, its newest live comment, and its newest comment *deletion*.
+/// See the query in [`RedditSitemapSource::collect`].
 #[derive(diesel::QueryableByName)]
 struct PostSitemapRow {
     #[diesel(sql_type = diesel::sql_types::Text)]
@@ -158,9 +159,10 @@ pub fn summarize(text: &str, max_chars: usize) -> Option<String> {
 /// why the example bounds a boot-time query.
 ///
 /// Each post's `<lastmod>` is **derived**, not read from one column: it is the
-/// later of `posts.updated_at` and the post's newest live comment, because a
-/// comment changes the page without touching the `posts` row. See the query in
-/// [`Self::collect`] for the two changes deliberately left out.
+/// latest of `posts.updated_at`, the post's newest live comment, and its
+/// newest comment deletion, because all three change the page without
+/// necessarily touching the `posts` row. See the query in [`Self::collect`]
+/// for the two changes deliberately left out.
 ///
 /// The framework calls [`SitemapSource::entries`] one time, while it builds
 /// the router. It renders the result into a static `/sitemap.xml` body. The
@@ -262,8 +264,8 @@ impl RedditSitemapSource {
         //
         //   * an edit goes through `PgPostRepository::update`, and
         //     `PostHooks::before_update` advances `posts.updated_at`;
-        //   * a comment goes through the framework's comment router, which
-        //     never touches the `posts` row at all.
+        //   * a comment -- added or removed -- goes through the framework's
+        //     comment router, which never touches the `posts` row at all.
         //
         // So the modification time is derived here, at read time, rather than
         // written by every subsystem that can change the page: `GREATEST` of
@@ -284,17 +286,42 @@ impl RedditSitemapSource {
         // expression the SELECT returns. Ordering on `posts.updated_at` and
         // computing the real date afterwards in Rust would cut a busy but
         // rarely-edited thread before its freshness was ever known.
+        // Three things can be the newest change to a post page, so the
+        // expression takes the latest of all three:
+        //
+        //   1. `p.updated_at`      -- somebody edited the post.
+        //   2. the newest LIVE comment's `created_at` -- somebody replied.
+        //   3. the newest `deleted_at` -- somebody removed a comment, which
+        //      changes the page just as much as adding one.
+        //
+        // (3) is why the join does not filter `deleted_at IS NULL`. Filtering
+        // there would drop the deleted rows before the aggregate could read
+        // their deletion time, and `<lastmod>` could then move BACKWARD across
+        // a restart: a July comment deleted in August would leave June's live
+        // comment as the newest date. The `FILTER` clause on (2) keeps a
+        // deleted comment's own `created_at` out while its `deleted_at` still
+        // counts.
+        //
+        // `c.commentable_type = $1` is load-bearing, not decoration. The
+        // comments table is polymorphic, so `commentable_id` is unique only
+        // together with the discriminator: without it, a comment on
+        // subreddit 7 would advance post 7's date.
         let post_sql = r#"
             SELECT s.slug AS sub_slug,
                    p.slug AS post_slug,
-                   GREATEST(p.updated_at, COALESCE(MAX(c.created_at), p.updated_at))
-                       AS last_modified
+                   GREATEST(
+                       p.updated_at,
+                       COALESCE(
+                           MAX(c.created_at) FILTER (WHERE c.deleted_at IS NULL),
+                           p.updated_at
+                       ),
+                       COALESCE(MAX(c.deleted_at), p.updated_at)
+                   ) AS last_modified
               FROM posts p
               JOIN subreddits s ON s.id = p.subreddit_id
               LEFT JOIN comments c
                      ON c.commentable_type = $1
                     AND c.commentable_id = p.id
-                    AND c.deleted_at IS NULL
              GROUP BY p.id, s.id
              ORDER BY last_modified DESC
              LIMIT $2

--- a/examples/reddit-clone/src/seo.rs
+++ b/examples/reddit-clone/src/seo.rs
@@ -29,12 +29,23 @@ use crate::schema::{posts, subreddits};
 
 /// The maximum number of posts in `/sitemap.xml`.
 ///
-/// The sitemap protocol permits 50,000 URLs in one file. This example stops
-/// well below that limit. A larger site must serve a sitemap index instead.
-/// See `docs/guide/seo.md`.
+/// The sitemap protocol permits 50,000 URLs in one file, and this example
+/// stops well below that. The cap is deliberate, not an oversight: the query
+/// below runs at boot, before the application serves anything, so it must be
+/// bounded by a number the author chose rather than by however many rows the
+/// table holds.
+///
+/// The consequence is real and this example accepts it: past this many posts
+/// the sitemap is **partial**, and it drops the least recently updated posts
+/// first. `collect` logs a warning when it hits the cap, so the truncation is
+/// never silent. A site that outgrows one file needs a sitemap index served
+/// from its own `/sitemap.xml` route — see `docs/guide/seo.md`.
 const MAX_POST_ENTRIES: i64 = 5_000;
 
 /// The maximum number of communities in `/sitemap.xml`.
+///
+/// Same contract as [`MAX_POST_ENTRIES`]: a bounded boot query, a logged
+/// warning at the cap, and a partial sitemap past it.
 const MAX_SUBREDDIT_ENTRIES: i64 = 1_000;
 
 /// The site base URL, without a trailing slash.
@@ -125,6 +136,11 @@ pub fn summarize(text: &str, max_chars: usize) -> Option<String> {
 
 /// The application's sitemap source.
 ///
+/// It lists the front page, the community index, up to
+/// [`MAX_SUBREDDIT_ENTRIES`] communities, and up to [`MAX_POST_ENTRIES`]
+/// posts. Both caps log a warning when they bite; read their doc comments for
+/// why the example bounds a boot-time query.
+///
 /// The framework calls [`SitemapSource::entries`] one time, while it builds
 /// the router. It renders the result into a static `/sitemap.xml` body. The
 /// sitemap is therefore a snapshot of the database at start-up. That is the
@@ -204,6 +220,12 @@ impl RedditSitemapSource {
                 Vec::new()
             }
         };
+        if i64::try_from(subs.len()).is_ok_and(|n| n >= MAX_SUBREDDIT_ENTRIES) {
+            tracing::warn!(
+                limit = MAX_SUBREDDIT_ENTRIES,
+                "sitemap: community cap reached; the sitemap is partial and omits the rest"
+            );
+        }
         for slug in subs {
             entries.push(
                 SitemapEntry::new(format!("{base}/r/{slug}"))
@@ -213,7 +235,13 @@ impl RedditSitemapSource {
         }
 
         // `updated_at` becomes each post's `<lastmod>`, which tells a crawler
-        // whether it must fetch the page again.
+        // whether it must fetch the page again. `PostHooks::before_update`
+        // advances that column on every update path, so the date is a real
+        // modification date and not the row's creation date.
+        //
+        // The `ORDER BY updated_at DESC` pairs with the cap below: when the
+        // table outgrows `MAX_POST_ENTRIES`, the posts that survive into the
+        // sitemap are the ones that changed most recently.
         let rows: Vec<(String, String, chrono::NaiveDateTime)> = match posts::table
             .inner_join(subreddits::table)
             .order(posts::updated_at.desc())
@@ -228,6 +256,13 @@ impl RedditSitemapSource {
                 Vec::new()
             }
         };
+        if i64::try_from(rows.len()).is_ok_and(|n| n >= MAX_POST_ENTRIES) {
+            tracing::warn!(
+                limit = MAX_POST_ENTRIES,
+                "sitemap: post cap reached; the sitemap is partial and omits the least \
+                 recently updated posts"
+            );
+        }
         for (sub_slug, post_slug, updated_at) in rows {
             entries.push(
                 SitemapEntry::new(format!("{base}/r/{sub_slug}/posts/{post_slug}"))

--- a/examples/reddit-clone/src/seo.rs
+++ b/examples/reddit-clone/src/seo.rs
@@ -46,23 +46,33 @@ struct PostSitemapRow {
 /// The maximum number of posts in `/sitemap.xml`.
 ///
 /// The sitemap protocol permits 50,000 URLs in one file, and this example
-/// stops well below that. The cap is deliberate, not an oversight: the query
-/// below runs at boot, before the application serves anything, so it must be
-/// bounded by a number the author chose rather than by however many rows the
-/// table holds.
+/// stops well below that.
 ///
-/// The consequence is real and this example accepts it: past this many posts
-/// the sitemap is **partial**, and it drops the least recently changed posts
-/// first -- "changed" by the derived `<lastmod>`, so a busy comment thread
-/// keeps its place even when nobody has edited the post itself. `collect` logs a warning when it hits the cap, so the truncation is
-/// never silent. A site that outgrows one file needs a sitemap index served
-/// from its own `/sitemap.xml` route — see `docs/guide/seo.md`.
+/// **What this cap does and does not bound.** It bounds the number of URLs in
+/// the document. It does **not** bound the work the query does: `ORDER BY
+/// last_modified DESC LIMIT n` still makes Postgres join and aggregate every
+/// matching post and comment before it can know which `n` are newest, so
+/// boot-time cost grows with the table rather than with this constant. That
+/// is inherent to deriving the sort key at read time (see
+/// [`RedditSitemapSource::collect`]), and it is the right trade at this
+/// example's scale. It stops being the right trade well before 5,000 posts on
+/// a busy site: at that point move off the start-up snapshot entirely and
+/// serve `/sitemap.xml` from your own route, which `docs/guide/seo.md`
+/// describes.
+///
+/// Past this many posts the sitemap is **partial**, and it drops the least
+/// recently changed posts first -- "changed" by the derived `<lastmod>`, so a
+/// busy comment thread keeps its place even when nobody has edited the post
+/// itself. `collect` logs a warning when it hits the cap, so the truncation is
+/// never silent.
 const MAX_POST_ENTRIES: i64 = 5_000;
 
 /// The maximum number of communities in `/sitemap.xml`.
 ///
-/// Same contract as [`MAX_POST_ENTRIES`]: a bounded boot query, a logged
-/// warning at the cap, and a partial sitemap past it.
+/// Same contract as [`MAX_POST_ENTRIES`]: it bounds the number of URLs, not
+/// the work, with a logged warning at the cap and a partial sitemap past it.
+/// This is the cheap query of the two -- an indexed scan of a small table,
+/// with no join and no aggregate.
 const MAX_SUBREDDIT_ENTRIES: i64 = 1_000;
 
 /// The site base URL, without a trailing slash.

--- a/examples/reddit-clone/src/seo.rs
+++ b/examples/reddit-clone/src/seo.rs
@@ -1,0 +1,311 @@
+//! Route-level SEO for reddit-clone: canonical URLs and a database-backed
+//! sitemap.
+//!
+//! This module holds the two parts of SEO that are not route attributes:
+//!
+//! 1. [`RedditSitemapSource`] — the [`SitemapSource`] that lists every
+//!    community and every post in `/sitemap.xml`.
+//! 2. [`base_url`] and [`with_canonical`] — the helpers that make an absolute
+//!    canonical URL from a request path.
+//!
+//! The per-page meta tags live on the route attributes themselves. See
+//! `routes::posts::front_page`, `routes::posts::show`,
+//! `routes::subreddits::show`, and `routes::about::about`.
+//!
+//! The guide for this module is `docs/guide/seo.md`.
+
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::OnceLock;
+
+use autumn_web::config::AutumnConfig;
+use autumn_web::db::RuntimeConnection;
+use autumn_web::seo::{SeoMeta, SitemapChangefreq, SitemapEntry, SitemapSource};
+use diesel::prelude::*;
+use diesel_async::RunQueryDsl;
+use diesel_async::pooled_connection::deadpool::Pool;
+
+use crate::schema::{posts, subreddits};
+
+/// The maximum number of posts in `/sitemap.xml`.
+///
+/// The sitemap protocol permits 50,000 URLs in one file. This example stops
+/// well below that limit. A larger site must serve a sitemap index instead.
+/// See `docs/guide/seo.md`.
+const MAX_POST_ENTRIES: i64 = 5_000;
+
+/// The maximum number of communities in `/sitemap.xml`.
+const MAX_SUBREDDIT_ENTRIES: i64 = 1_000;
+
+/// The site base URL, without a trailing slash.
+///
+/// `main` writes this value once at start-up. The handlers read it on each
+/// request. A `OnceLock` keeps the read cheap: the alternative is the
+/// `AutumnConfig` extractor, which clones the full configuration for every
+/// request that wants one string.
+static BASE_URL: OnceLock<Option<String>> = OnceLock::new();
+
+/// Record the `[seo] base_url` value from `autumn.toml`.
+///
+/// Call this one time, before the application starts. Later calls do nothing.
+pub fn init_base_url(config: &AutumnConfig) {
+    let base = config
+        .seo
+        .base_url
+        .as_deref()
+        .map(|url| url.trim_end_matches('/').to_owned());
+    let _ = BASE_URL.set(base);
+}
+
+/// Return the configured base URL, or `None` when `autumn.toml` sets none.
+#[must_use]
+pub fn base_url() -> Option<&'static str> {
+    BASE_URL.get().and_then(Option::as_deref)
+}
+
+/// Make an absolute URL from an application path.
+///
+/// Returns `None` when no base URL is configured. A canonical tag must be an
+/// absolute URL, so the caller omits the tag in that case.
+#[must_use]
+pub fn absolute_url(path: &str) -> Option<String> {
+    base_url().map(|base| format!("{base}{path}"))
+}
+
+/// The pure half of [`with_canonical`], with the base URL passed in.
+///
+/// [`BASE_URL`] is process-wide, so the tests exercise this function instead.
+#[must_use]
+fn with_canonical_in(seo: SeoMeta, base: Option<&str>, path: &str) -> SeoMeta {
+    match base {
+        Some(base) => seo.canonical(format!("{base}{path}")),
+        None => seo,
+    }
+}
+
+/// Add a canonical URL to `seo` for the given application path.
+///
+/// The tag tells a crawler which URL is the true address of the page. This
+/// application shows the same post at two paths — `/posts/{id}` redirects to
+/// `/r/{sub}/posts/{slug}` — and a query string makes more variants. The
+/// canonical tag makes all of them collapse to one URL.
+///
+/// If no base URL is configured, `seo` comes back unchanged.
+#[must_use]
+pub fn with_canonical(seo: SeoMeta, path: &str) -> SeoMeta {
+    with_canonical_in(seo, base_url(), path)
+}
+
+/// Cut `text` down to a one-line page description.
+///
+/// A description tag is a short summary. Search engines show approximately 155
+/// characters, so this function stops at `max_chars` and adds an ellipsis. It
+/// also replaces each run of whitespace with one space, because the source
+/// text is a multi-line post body.
+///
+/// Returns `None` for text that has no words, for example a link-only post.
+#[must_use]
+pub fn summarize(text: &str, max_chars: usize) -> Option<String> {
+    let flat = text.split_whitespace().collect::<Vec<_>>().join(" ");
+    if flat.is_empty() {
+        return None;
+    }
+    if flat.chars().count() <= max_chars {
+        return Some(flat);
+    }
+    // Cut on a character boundary, then back off to the last word break so the
+    // description does not end in the middle of a word.
+    let head: String = flat.chars().take(max_chars).collect();
+    let trimmed = match head.rfind(' ') {
+        Some(idx) if idx > 0 => &head[..idx],
+        _ => head.as_str(),
+    };
+    Some(format!("{}\u{2026}", trimmed.trim_end()))
+}
+
+/// The application's sitemap source.
+///
+/// The framework calls [`SitemapSource::entries`] one time, while it builds
+/// the router. It renders the result into a static `/sitemap.xml` body. The
+/// sitemap is therefore a snapshot of the database at start-up. That is the
+/// correct trade for this application: the body costs nothing to serve, and a
+/// crawler reads it minutes or hours after a deploy. An application that must
+/// list new content immediately serves its own `/sitemap.xml` route instead;
+/// see `docs/guide/seo.md`.
+pub struct RedditSitemapSource {
+    /// A pool of this source's own. The application state does not exist yet
+    /// when the framework collects sitemap entries, so the source cannot use
+    /// the `Db` extractor.
+    pool: Option<Pool<RuntimeConnection>>,
+}
+
+impl RedditSitemapSource {
+    /// Build the source from the loaded configuration.
+    ///
+    /// The source stays quiet when the application runs without a database:
+    /// it then contributes no entries, and `/sitemap.xml` still lists the
+    /// static routes the framework derives on its own.
+    #[must_use]
+    pub fn from_config(config: &AutumnConfig) -> Self {
+        let pool = match autumn_web::db::create_pool(&config.database) {
+            Ok(pool) => pool,
+            Err(err) => {
+                tracing::warn!(error = %err, "sitemap: cannot build a pool; sitemap will list static routes only");
+                None
+            }
+        };
+        Self { pool }
+    }
+
+    /// Read the database and build one entry for each public page.
+    ///
+    /// A failure here is not fatal. The function logs the failure and returns
+    /// the entries it has. A short sitemap is better than a failed boot.
+    async fn collect(&self) -> Vec<SitemapEntry> {
+        let Some(base) = base_url() else {
+            tracing::warn!(
+                "sitemap: [seo] base_url is not set; the sitemap needs absolute URLs, so it stays empty"
+            );
+            return Vec::new();
+        };
+        let Some(pool) = self.pool.as_ref() else {
+            return Vec::new();
+        };
+        let mut conn = match pool.get().await {
+            Ok(conn) => conn,
+            Err(err) => {
+                tracing::warn!(error = %err, "sitemap: cannot get a connection; skipping dynamic entries");
+                return Vec::new();
+            }
+        };
+
+        // The two hub pages. `/` and `/r` are `#[get]` routes, so the
+        // framework cannot derive them: it derives only `#[static_get]` paths.
+        // `/about` is a `#[static_get]` route and arrives automatically.
+        let mut entries = vec![
+            SitemapEntry::new(format!("{base}/"))
+                .changefreq(SitemapChangefreq::Hourly)
+                .priority(1.0),
+            SitemapEntry::new(format!("{base}/r"))
+                .changefreq(SitemapChangefreq::Daily)
+                .priority(0.8),
+        ];
+
+        let subs: Vec<String> = match subreddits::table
+            .order(subreddits::name.asc())
+            .limit(MAX_SUBREDDIT_ENTRIES)
+            .select(subreddits::slug)
+            .load(&mut conn)
+            .await
+        {
+            Ok(rows) => rows,
+            Err(err) => {
+                tracing::warn!(error = %err, "sitemap: community query failed");
+                Vec::new()
+            }
+        };
+        for slug in subs {
+            entries.push(
+                SitemapEntry::new(format!("{base}/r/{slug}"))
+                    .changefreq(SitemapChangefreq::Daily)
+                    .priority(0.7),
+            );
+        }
+
+        // `updated_at` becomes each post's `<lastmod>`, which tells a crawler
+        // whether it must fetch the page again.
+        let rows: Vec<(String, String, chrono::NaiveDateTime)> = match posts::table
+            .inner_join(subreddits::table)
+            .order(posts::updated_at.desc())
+            .limit(MAX_POST_ENTRIES)
+            .select((subreddits::slug, posts::slug, posts::updated_at))
+            .load(&mut conn)
+            .await
+        {
+            Ok(rows) => rows,
+            Err(err) => {
+                tracing::warn!(error = %err, "sitemap: post query failed");
+                Vec::new()
+            }
+        };
+        for (sub_slug, post_slug, updated_at) in rows {
+            entries.push(
+                SitemapEntry::new(format!("{base}/r/{sub_slug}/posts/{post_slug}"))
+                    .lastmod(updated_at.format("%Y-%m-%d").to_string())
+                    .changefreq(SitemapChangefreq::Weekly)
+                    .priority(0.6),
+            );
+        }
+
+        tracing::info!(count = entries.len(), "sitemap: collected entries");
+        entries
+    }
+}
+
+impl SitemapSource for RedditSitemapSource {
+    fn entries(&self) -> Pin<Box<dyn Future<Output = Vec<SitemapEntry>> + Send + '_>> {
+        Box::pin(self.collect())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn summarize_keeps_short_text_unchanged() {
+        assert_eq!(
+            summarize("A short body.", 155).as_deref(),
+            Some("A short body.")
+        );
+    }
+
+    #[test]
+    fn summarize_collapses_whitespace() {
+        assert_eq!(
+            summarize("first line\n\n  second line", 155).as_deref(),
+            Some("first line second line")
+        );
+    }
+
+    #[test]
+    fn summarize_cuts_on_a_word_break() {
+        let out = summarize("alpha bravo charlie delta", 14).expect("some text");
+        assert_eq!(out, "alpha bravo\u{2026}");
+    }
+
+    #[test]
+    fn summarize_returns_none_for_blank_text() {
+        assert!(summarize("   \n\t ", 155).is_none());
+        assert!(summarize("", 155).is_none());
+    }
+
+    #[test]
+    fn summarize_handles_multibyte_text() {
+        // The cut must land on a character boundary, not a byte boundary.
+        let out = summarize("\u{e9}\u{e9}\u{e9}\u{e9}\u{e9}\u{e9}", 3).expect("some text");
+        assert_eq!(out, "\u{e9}\u{e9}\u{e9}\u{2026}");
+    }
+
+    #[test]
+    fn with_canonical_adds_an_absolute_url() {
+        let seo = with_canonical_in(
+            SeoMeta::new().title("t"),
+            Some("https://example.com"),
+            "/r/rust/posts/hello",
+        );
+        assert!(
+            seo.render().into_string().contains(
+                r#"<link rel="canonical" href="https://example.com/r/rust/posts/hello">"#
+            ),
+            "canonical tag missing: {}",
+            seo.render().into_string()
+        );
+    }
+
+    #[test]
+    fn with_canonical_is_a_no_op_without_a_base_url() {
+        let seo = with_canonical_in(SeoMeta::new().title("t"), None, "/r/rust");
+        assert_eq!(seo, SeoMeta::new().title("t"));
+    }
+}

--- a/examples/reddit-clone/tests/seo_pg_integration.rs
+++ b/examples/reddit-clone/tests/seo_pg_integration.rs
@@ -2,17 +2,26 @@
 //! Postgres.
 //!
 //! The guide for this feature is `docs/guide/seo.md`. These tests prove the
-//! three parts the guide describes:
+//! parts the guide describes:
 //!
 //! 1. `sitemap_lists_every_public_page` — `RedditSitemapSource` reads the
 //!    database and produces one absolute URL for each community and each post,
-//!    plus the two hub pages. It also proves the `<lastmod>` value comes from
-//!    `posts.updated_at`.
-//! 2. `sitemap_and_robots_render_the_expected_documents` — the entries and the
+//!    plus the two hub pages, and leaves `#[static_get]` paths to the
+//!    framework.
+//! 2. `lastmod_follows_comment_activity_not_just_post_edits` — `<lastmod>` is
+//!    **derived**, not read from `posts.updated_at`: it is the latest of that
+//!    column, the newest live comment, and the newest comment deletion. Also
+//!    covers the ordering that derivation drives, and the polymorphic
+//!    discriminator that keeps a community's comment off a post with the same
+//!    id.
+//! 3. `sitemap_and_robots_render_the_expected_documents` — the entries and the
 //!    `[seo.robots]` rules become a valid `sitemap.xml` and a `robots.txt`
 //!    that points back at the sitemap.
-//! 3. `sitemap_is_empty_without_a_database` — a source with no database does
+//! 4. `sitemap_is_empty_without_a_database` — a source with no database does
 //!    not fail the boot. It contributes no entries.
+//! 5. `robots_txt_never_blocks_a_url_that_relies_on_a_noindex_tag` — the
+//!    committed `autumn.toml` keeps `Disallow` and `noindex` off the same URL.
+//!    Needs no database, so it runs unignored.
 //!
 //! The Docker-backed tests are `#[ignore]` (like the other PG integration
 //! tests here) and run through testcontainers by default. When Docker is not

--- a/examples/reddit-clone/tests/seo_pg_integration.rs
+++ b/examples/reddit-clone/tests/seo_pg_integration.rs
@@ -1,0 +1,331 @@
+//! Integration tests: route-level SEO in the example app, against a real
+//! Postgres.
+//!
+//! The guide for this feature is `docs/guide/seo.md`. These tests prove the
+//! three parts the guide describes:
+//!
+//! 1. `sitemap_lists_every_public_page` — `RedditSitemapSource` reads the
+//!    database and produces one absolute URL for each community and each post,
+//!    plus the two hub pages. It also proves the `<lastmod>` value comes from
+//!    `posts.updated_at`.
+//! 2. `sitemap_and_robots_render_the_expected_documents` — the entries and the
+//!    `[seo.robots]` rules become a valid `sitemap.xml` and a `robots.txt`
+//!    that points back at the sitemap.
+//! 3. `sitemap_is_empty_without_a_database` — a source with no database does
+//!    not fail the boot. It contributes no entries.
+//!
+//! The Docker-backed tests are `#[ignore]` (like the other PG integration
+//! tests here) and run through testcontainers by default. When Docker is not
+//! available, point them at a Postgres that already runs:
+//!
+//! ```text
+//! AUTUMN_TEST_PG_URL=postgres://autumn:autumn@127.0.0.1:5432/reddit \
+//!   cargo test -p reddit-clone --test seo_pg_integration -- --ignored --test-threads=1
+//! ```
+
+use autumn_web::config::{AutumnConfig, DatabaseConfig, RobotsConfig, SeoConfig};
+use autumn_web::seo::{SitemapSource as _, robots_txt, sitemap_xml};
+use diesel::sql_types::{BigInt, Text};
+use diesel_async::pooled_connection::AsyncDieselConnectionManager;
+use diesel_async::pooled_connection::deadpool::Pool;
+use diesel_async::{AsyncPgConnection, RunQueryDsl, SimpleAsyncConnection};
+use reddit_clone::seo::RedditSitemapSource;
+use testcontainers::ContainerAsync;
+use testcontainers::runners::AsyncRunner;
+use testcontainers_modules::postgres::Postgres;
+
+const CREATE_SCHEMA: &str = include_str!("../migrations/20260419000000_create_reddit/up.sql");
+const ADD_AVATAR: &str = include_str!("../migrations/20260427000000_add_user_avatar/up.sql");
+const CREATE_TAGS: &str = include_str!("../migrations/20260702000001_create_tags/up.sql");
+const POLYMORPHIC_COMMENTS: &str =
+    include_str!("../migrations/20260820000000_polymorphic_comments/up.sql");
+
+/// The base URL these tests configure. It must match `[seo] base_url` in shape
+/// (absolute, no trailing slash), not in value.
+const BASE_URL: &str = "https://autumn-reddit.example.com";
+
+#[derive(diesel::QueryableByName)]
+struct IdRow {
+    #[diesel(sql_type = BigInt)]
+    id: i64,
+}
+
+/// Keeps whichever backing Postgres alive for the duration of the test.
+enum PgHandle {
+    Container(#[allow(dead_code)] Box<ContainerAsync<Postgres>>),
+    External,
+}
+
+async fn start_postgres() -> (PgHandle, String, Pool<AsyncPgConnection>) {
+    if let Ok(url) = std::env::var("AUTUMN_TEST_PG_URL") {
+        let manager = AsyncDieselConnectionManager::<AsyncPgConnection>::new(url.clone());
+        let pool = Pool::builder(manager)
+            .max_size(8)
+            .build()
+            .expect("build pool");
+        return (PgHandle::External, url, pool);
+    }
+    let container = Postgres::default()
+        .start()
+        .await
+        .expect("start Postgres container");
+    let port = container
+        .get_host_port_ipv4(5432)
+        .await
+        .expect("Postgres port");
+    let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
+    let manager = AsyncDieselConnectionManager::<AsyncPgConnection>::new(url.clone());
+    let pool = Pool::builder(manager)
+        .max_size(8)
+        .build()
+        .expect("build pool");
+    (PgHandle::Container(Box::new(container)), url, pool)
+}
+
+async fn setup_schema(conn: &mut AsyncPgConnection) {
+    if std::env::var("AUTUMN_TEST_PG_URL").is_ok() {
+        conn.batch_execute(
+            "DROP TABLE IF EXISTS post_tags, tags, comments, votes, \
+             live_feed_events, posts, subreddits, users CASCADE;",
+        )
+        .await
+        .expect("reset reddit-clone tables");
+    }
+    // The migration files hold many semicolon-separated statements. Postgres
+    // rejects multiple commands in one prepared statement, so use the simple
+    // (unprepared) batch protocol.
+    conn.batch_execute(CREATE_SCHEMA)
+        .await
+        .expect("create reddit schema");
+    conn.batch_execute(ADD_AVATAR)
+        .await
+        .expect("add users.avatar column");
+    conn.batch_execute(CREATE_TAGS)
+        .await
+        .expect("create tag tables");
+    conn.batch_execute(POLYMORPHIC_COMMENTS)
+        .await
+        .expect("make comments polymorphic");
+}
+
+async fn seed_user(conn: &mut AsyncPgConnection, username: &str) -> i64 {
+    diesel::sql_query("INSERT INTO users (username, password_hash) VALUES ($1, 'h') RETURNING id")
+        .bind::<Text, _>(username)
+        .get_result::<IdRow>(conn)
+        .await
+        .expect("seed user")
+        .id
+}
+
+async fn seed_subreddit(conn: &mut AsyncPgConnection, creator_id: i64, slug: &str) -> i64 {
+    diesel::sql_query(
+        "INSERT INTO subreddits (name, slug, description, creator_id) \
+         VALUES ($1, $1, 'a community', $2) RETURNING id",
+    )
+    .bind::<Text, _>(slug)
+    .bind::<BigInt, _>(creator_id)
+    .get_result::<IdRow>(conn)
+    .await
+    .expect("seed subreddit")
+    .id
+}
+
+async fn seed_post(
+    conn: &mut AsyncPgConnection,
+    author_id: i64,
+    subreddit_id: i64,
+    slug: &str,
+    updated_at: &str,
+) -> i64 {
+    diesel::sql_query(
+        "INSERT INTO posts (title, slug, body, author_id, subreddit_id, updated_at) \
+         VALUES ($1, $1, 'body text', $2, $3, $4::timestamp) RETURNING id",
+    )
+    .bind::<Text, _>(slug)
+    .bind::<BigInt, _>(author_id)
+    .bind::<BigInt, _>(subreddit_id)
+    .bind::<Text, _>(updated_at)
+    .get_result::<IdRow>(conn)
+    .await
+    .expect("seed post")
+    .id
+}
+
+/// Build the configuration the example builds from `autumn.toml`, but pointed
+/// at this test's database.
+fn test_config(database_url: Option<&str>) -> AutumnConfig {
+    AutumnConfig {
+        database: DatabaseConfig {
+            primary_url: database_url.map(str::to_owned),
+            ..Default::default()
+        },
+        seo: SeoConfig {
+            base_url: Some(BASE_URL.to_owned()),
+            robots: RobotsConfig {
+                additional_rules: vec!["Disallow: /submit".to_owned()],
+                ..Default::default()
+            },
+        },
+        ..Default::default()
+    }
+}
+
+#[tokio::test]
+#[ignore = "requires Docker (testcontainers)"]
+async fn sitemap_lists_every_public_page() {
+    let (_handle, url, pool) = start_postgres().await;
+    let mut conn = pool.get().await.expect("checkout");
+    setup_schema(&mut conn).await;
+
+    let author = seed_user(&mut conn, "ferris").await;
+    let rust = seed_subreddit(&mut conn, author, "rust").await;
+    let gardening = seed_subreddit(&mut conn, author, "gardening").await;
+    seed_post(
+        &mut conn,
+        author,
+        rust,
+        "hello-world",
+        "2026-05-01 12:00:00",
+    )
+    .await;
+    seed_post(
+        &mut conn,
+        author,
+        gardening,
+        "tomatoes",
+        "2026-06-02 09:30:00",
+    )
+    .await;
+    drop(conn);
+
+    let config = test_config(Some(&url));
+    reddit_clone::seo::init_base_url(&config);
+    let source = RedditSitemapSource::from_config(&config);
+    let entries = source.entries().await;
+    let locs: Vec<&str> = entries.iter().map(|e| e.loc.as_str()).collect();
+
+    // The two hub pages. Both are `#[get]` routes, so the framework cannot
+    // derive them and the source must list them.
+    assert!(
+        locs.contains(&format!("{BASE_URL}/").as_str()),
+        "front page missing: {locs:?}"
+    );
+    assert!(
+        locs.contains(&format!("{BASE_URL}/r").as_str()),
+        "community index missing: {locs:?}"
+    );
+
+    // One entry for each community.
+    assert!(
+        locs.contains(&format!("{BASE_URL}/r/rust").as_str()),
+        "r/rust missing: {locs:?}"
+    );
+    assert!(
+        locs.contains(&format!("{BASE_URL}/r/gardening").as_str()),
+        "r/gardening missing: {locs:?}"
+    );
+
+    // One entry for each post, at the same path the `show` route serves.
+    assert!(
+        locs.contains(&format!("{BASE_URL}/r/rust/posts/hello-world").as_str()),
+        "post URL missing: {locs:?}"
+    );
+    assert!(
+        locs.contains(&format!("{BASE_URL}/r/gardening/posts/tomatoes").as_str()),
+        "post URL missing: {locs:?}"
+    );
+
+    // `<lastmod>` comes from `posts.updated_at`, not from the crawl time.
+    let hello = entries
+        .iter()
+        .find(|e| e.loc.ends_with("/posts/hello-world"))
+        .expect("hello-world entry");
+    assert_eq!(hello.lastmod.as_deref(), Some("2026-05-01"));
+
+    // Every URL is absolute. A relative URL in a sitemap is invalid.
+    for loc in &locs {
+        assert!(loc.starts_with(BASE_URL), "relative URL in sitemap: {loc}");
+    }
+
+    // `/about` is a `#[static_get]` route. The framework derives its entry
+    // from the static-route table, so the source must NOT list it too.
+    assert!(
+        !locs.contains(&format!("{BASE_URL}/about").as_str()),
+        "the source must leave static routes to the framework: {locs:?}"
+    );
+}
+
+#[tokio::test]
+#[ignore = "requires Docker (testcontainers)"]
+async fn sitemap_and_robots_render_the_expected_documents() {
+    let (_handle, url, pool) = start_postgres().await;
+    let mut conn = pool.get().await.expect("checkout");
+    setup_schema(&mut conn).await;
+
+    let author = seed_user(&mut conn, "ferris").await;
+    let rust = seed_subreddit(&mut conn, author, "rust").await;
+    seed_post(
+        &mut conn,
+        author,
+        rust,
+        "hello-world",
+        "2026-05-01 12:00:00",
+    )
+    .await;
+    drop(conn);
+
+    let config = test_config(Some(&url));
+    reddit_clone::seo::init_base_url(&config);
+    let entries = RedditSitemapSource::from_config(&config).entries().await;
+
+    // This is what the framework serves at GET /sitemap.xml.
+    let xml = sitemap_xml(&entries, Some(BASE_URL));
+    assert!(
+        xml.contains(r#"<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">"#),
+        "sitemap must declare the sitemap namespace:\n{xml}"
+    );
+    assert!(
+        xml.contains(&format!("<loc>{BASE_URL}/r/rust/posts/hello-world</loc>")),
+        "post URL missing from the rendered sitemap:\n{xml}"
+    );
+    assert!(
+        xml.contains("<lastmod>2026-05-01</lastmod>"),
+        "lastmod missing from the rendered sitemap:\n{xml}"
+    );
+
+    // This is what the framework serves at GET /robots.txt under the `prod`
+    // profile. The `Sitemap:` line is derived from `[seo] base_url`.
+    let robots = robots_txt(
+        "prod",
+        Some(&format!("{BASE_URL}/sitemap.xml")),
+        &config.seo.robots.additional_rules,
+    );
+    assert!(robots.contains("User-agent: *"), "robots:\n{robots}");
+    assert!(robots.contains("Allow: /"), "robots:\n{robots}");
+    assert!(robots.contains("Disallow: /submit"), "robots:\n{robots}");
+    assert!(
+        robots.contains(&format!("Sitemap: {BASE_URL}/sitemap.xml")),
+        "robots must point at the sitemap:\n{robots}"
+    );
+
+    // The `dev` profile keeps a local run out of the index.
+    let dev_robots = robots_txt("dev", None, &[]);
+    assert!(
+        dev_robots.contains("Disallow: /"),
+        "dev must disallow every crawler:\n{dev_robots}"
+    );
+}
+
+#[tokio::test]
+async fn sitemap_is_empty_without_a_database() {
+    // No `primary_url`, so `create_pool` returns no pool. The source must stay
+    // quiet rather than fail the boot: `/sitemap.xml` then lists only the
+    // static routes the framework derives.
+    let config = test_config(None);
+    let entries = RedditSitemapSource::from_config(&config).entries().await;
+    assert!(
+        entries.is_empty(),
+        "a source with no database must contribute no entries; got {} entries",
+        entries.len()
+    );
+}

--- a/examples/reddit-clone/tests/seo_pg_integration.rs
+++ b/examples/reddit-clone/tests/seo_pg_integration.rs
@@ -130,6 +130,30 @@ async fn seed_subreddit(conn: &mut AsyncPgConnection, creator_id: i64, slug: &st
     .id
 }
 
+/// Insert a live comment on a post, at an explicit `created_at`.
+///
+/// The comments table is polymorphic, so the parent is
+/// `(commentable_type, commentable_id)` and carries no foreign key.
+async fn seed_comment(
+    conn: &mut AsyncPgConnection,
+    author_id: i64,
+    post_id: i64,
+    created_at: &str,
+) -> i64 {
+    diesel::sql_query(
+        "INSERT INTO comments (body, author_id, commentable_type, commentable_id, created_at) \
+         VALUES ('a reply', $1, $2, $3, $4::timestamp) RETURNING id",
+    )
+    .bind::<BigInt, _>(author_id)
+    .bind::<Text, _>(reddit_clone::models::Post::COMMENTABLE_TYPE)
+    .bind::<BigInt, _>(post_id)
+    .bind::<Text, _>(created_at)
+    .get_result::<IdRow>(conn)
+    .await
+    .expect("seed comment")
+    .id
+}
+
 async fn seed_post(
     conn: &mut AsyncPgConnection,
     author_id: i64,
@@ -252,6 +276,88 @@ async fn sitemap_lists_every_public_page() {
     assert!(
         !locs.contains(&format!("{BASE_URL}/about").as_str()),
         "the source must leave static routes to the framework: {locs:?}"
+    );
+}
+
+/// `<lastmod>` must describe the *page*, not the `posts` row.
+///
+/// A comment changes what a visitor reads but never touches `posts.updated_at`
+/// (the comment router writes only the polymorphic `comments` table), so the
+/// source derives the date as `GREATEST(posts.updated_at, newest live
+/// comment)`. This is the regression test for that derivation, including the
+/// ordering it drives: a busy thread must outrank a recently edited but quiet
+/// post, or the entry cap would drop the wrong pages first.
+#[tokio::test]
+#[ignore = "requires Docker (testcontainers)"]
+async fn lastmod_follows_comment_activity_not_just_post_edits() {
+    let (_handle, url, pool) = start_postgres().await;
+    let mut conn = pool.get().await.expect("checkout");
+    setup_schema(&mut conn).await;
+
+    let author = seed_user(&mut conn, "ferris").await;
+    let rust = seed_subreddit(&mut conn, author, "rust").await;
+
+    // Edited long ago, but the discussion is alive.
+    let busy = seed_post(
+        &mut conn,
+        author,
+        rust,
+        "busy-thread",
+        "2026-01-10 08:00:00",
+    )
+    .await;
+    seed_comment(&mut conn, author, busy, "2026-06-20 17:45:00").await;
+    // A deleted comment must not count: it is not on the page any more.
+    let deleted = seed_comment(&mut conn, author, busy, "2026-07-30 10:00:00").await;
+    diesel::sql_query("UPDATE comments SET deleted_at = NOW() WHERE id = $1")
+        .bind::<BigInt, _>(deleted)
+        .execute(&mut conn)
+        .await
+        .expect("soft-delete the comment");
+
+    // Edited more recently than `busy`, but nobody has replied.
+    seed_post(&mut conn, author, rust, "quiet-post", "2026-03-15 09:00:00").await;
+    drop(conn);
+
+    let config = test_config(Some(&url));
+    reddit_clone::seo::init_base_url(&config);
+    let entries = RedditSitemapSource::from_config(&config).entries().await;
+
+    let busy_entry = entries
+        .iter()
+        .find(|e| e.loc.ends_with("/posts/busy-thread"))
+        .expect("busy-thread entry");
+    let quiet_entry = entries
+        .iter()
+        .find(|e| e.loc.ends_with("/posts/quiet-post"))
+        .expect("quiet-post entry");
+
+    assert_eq!(
+        busy_entry.lastmod.as_deref(),
+        Some("2026-06-20"),
+        "lastmod must follow the newest LIVE comment, not posts.updated_at \
+         and not the soft-deleted reply",
+    );
+    assert_eq!(
+        quiet_entry.lastmod.as_deref(),
+        Some("2026-03-15"),
+        "a post with no comments keeps its own updated_at",
+    );
+
+    // Ordering drives which posts survive the entry cap, so the busy thread
+    // must come first despite its older `posts.updated_at`.
+    let busy_pos = entries
+        .iter()
+        .position(|e| e.loc.ends_with("/posts/busy-thread"))
+        .expect("busy-thread position");
+    let quiet_pos = entries
+        .iter()
+        .position(|e| e.loc.ends_with("/posts/quiet-post"))
+        .expect("quiet-post position");
+    assert!(
+        busy_pos < quiet_pos,
+        "the busy thread must outrank the quiet post; entries: {:?}",
+        entries.iter().map(|e| &e.loc).collect::<Vec<_>>(),
     );
 }
 

--- a/examples/reddit-clone/tests/seo_pg_integration.rs
+++ b/examples/reddit-clone/tests/seo_pg_integration.rs
@@ -279,14 +279,25 @@ async fn sitemap_lists_every_public_page() {
     );
 }
 
+/// Soft-delete a comment at an explicit time, so the assertions are exact.
+async fn soft_delete_comment(conn: &mut AsyncPgConnection, comment_id: i64, deleted_at: &str) {
+    diesel::sql_query("UPDATE comments SET deleted_at = $1::timestamp WHERE id = $2")
+        .bind::<Text, _>(deleted_at)
+        .bind::<BigInt, _>(comment_id)
+        .execute(conn)
+        .await
+        .expect("soft-delete the comment");
+}
+
 /// `<lastmod>` must describe the *page*, not the `posts` row.
 ///
-/// A comment changes what a visitor reads but never touches `posts.updated_at`
-/// (the comment router writes only the polymorphic `comments` table), so the
-/// source derives the date as `GREATEST(posts.updated_at, newest live
-/// comment)`. This is the regression test for that derivation, including the
-/// ordering it drives: a busy thread must outrank a recently edited but quiet
-/// post, or the entry cap would drop the wrong pages first.
+/// The comment router writes only the polymorphic `comments` table, so three
+/// separate things change a post page without necessarily touching
+/// `posts.updated_at`: an edit, a new reply, and the removal of a reply. The
+/// source takes the latest of all three. This is the regression test for that
+/// derivation, and for the ordering it drives -- a busy thread must outrank a
+/// recently edited but quiet post, or the entry cap would drop the wrong pages
+/// first.
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn lastmod_follows_comment_activity_not_just_post_edits() {
@@ -297,67 +308,100 @@ async fn lastmod_follows_comment_activity_not_just_post_edits() {
     let author = seed_user(&mut conn, "ferris").await;
     let rust = seed_subreddit(&mut conn, author, "rust").await;
 
-    // Edited long ago, but the discussion is alive.
-    let busy = seed_post(
+    // (a) Edited long ago, but the discussion is alive.
+    let replied = seed_post(&mut conn, author, rust, "replied-to", "2026-01-10 08:00:00").await;
+    seed_comment(&mut conn, author, replied, "2026-06-20 17:45:00").await;
+
+    // (b) The deletion case. The newest reply was removed in August, which
+    // changed the page then -- so August is the answer, NOT June. Filtering
+    // deleted rows out of the join would give June, and the date would move
+    // backward across a restart.
+    let pruned = seed_post(
         &mut conn,
         author,
         rust,
-        "busy-thread",
-        "2026-01-10 08:00:00",
+        "pruned-thread",
+        "2026-01-11 08:00:00",
     )
     .await;
-    seed_comment(&mut conn, author, busy, "2026-06-20 17:45:00").await;
-    // A deleted comment must not count: it is not on the page any more.
-    let deleted = seed_comment(&mut conn, author, busy, "2026-07-30 10:00:00").await;
-    diesel::sql_query("UPDATE comments SET deleted_at = NOW() WHERE id = $1")
-        .bind::<BigInt, _>(deleted)
-        .execute(&mut conn)
-        .await
-        .expect("soft-delete the comment");
+    seed_comment(&mut conn, author, pruned, "2026-06-01 09:00:00").await;
+    let removed = seed_comment(&mut conn, author, pruned, "2026-07-30 10:00:00").await;
+    soft_delete_comment(&mut conn, removed, "2026-08-05 14:00:00").await;
 
-    // Edited more recently than `busy`, but nobody has replied.
+    // (c) Edited more recently than (a) and (b), but nobody has replied.
     seed_post(&mut conn, author, rust, "quiet-post", "2026-03-15 09:00:00").await;
+
+    // (d) The polymorphic trap: a comment on the COMMUNITY whose
+    // `commentable_id` equals a post id. Ids come from independent sequences,
+    // so line them up deliberately. It must not move that post's date.
+    let twin = seed_post(&mut conn, author, rust, "id-twin", "2026-02-01 08:00:00").await;
+    diesel::sql_query(
+        "INSERT INTO comments (body, author_id, commentable_type, commentable_id, created_at) \
+         VALUES ('community talk', $1, 'Subreddit', $2, '2026-09-09 12:00:00'::timestamp)",
+    )
+    .bind::<BigInt, _>(author)
+    .bind::<BigInt, _>(twin)
+    .execute(&mut conn)
+    .await
+    .expect("seed a Subreddit-typed comment sharing a post id");
     drop(conn);
 
     let config = test_config(Some(&url));
     reddit_clone::seo::init_base_url(&config);
     let entries = RedditSitemapSource::from_config(&config).entries().await;
 
-    let busy_entry = entries
-        .iter()
-        .find(|e| e.loc.ends_with("/posts/busy-thread"))
-        .expect("busy-thread entry");
-    let quiet_entry = entries
-        .iter()
-        .find(|e| e.loc.ends_with("/posts/quiet-post"))
-        .expect("quiet-post entry");
+    let lastmod_of = |suffix: &str| -> Option<String> {
+        entries
+            .iter()
+            .find(|e| e.loc.ends_with(suffix))
+            .unwrap_or_else(|| panic!("no entry ending in {suffix}"))
+            .lastmod
+            .clone()
+    };
 
     assert_eq!(
-        busy_entry.lastmod.as_deref(),
+        lastmod_of("/posts/replied-to").as_deref(),
         Some("2026-06-20"),
-        "lastmod must follow the newest LIVE comment, not posts.updated_at \
-         and not the soft-deleted reply",
+        "a live reply must advance lastmod past the post's own updated_at",
     );
     assert_eq!(
-        quiet_entry.lastmod.as_deref(),
+        lastmod_of("/posts/pruned-thread").as_deref(),
+        Some("2026-08-05"),
+        "removing a comment changes the page, so the DELETION time wins -- \
+         never a fallback to an older live comment",
+    );
+    assert_eq!(
+        lastmod_of("/posts/quiet-post").as_deref(),
         Some("2026-03-15"),
         "a post with no comments keeps its own updated_at",
     );
+    assert_eq!(
+        lastmod_of("/posts/id-twin").as_deref(),
+        Some("2026-02-01"),
+        "a comment on a Subreddit whose id equals this post's id must not \
+         touch it -- the join has to match commentable_type as well",
+    );
 
-    // Ordering drives which posts survive the entry cap, so the busy thread
-    // must come first despite its older `posts.updated_at`.
-    let busy_pos = entries
-        .iter()
-        .position(|e| e.loc.ends_with("/posts/busy-thread"))
-        .expect("busy-thread position");
-    let quiet_pos = entries
-        .iter()
-        .position(|e| e.loc.ends_with("/posts/quiet-post"))
-        .expect("quiet-post position");
+    // Ordering drives which posts survive the entry cap, so the active
+    // threads must outrank the quiet post despite their older `updated_at`.
+    let position = |suffix: &str| {
+        entries
+            .iter()
+            .position(|e| e.loc.ends_with(suffix))
+            .unwrap_or_else(|| panic!("no entry ending in {suffix}"))
+    };
+    let locs: Vec<&String> = entries.iter().map(|e| &e.loc).collect();
     assert!(
-        busy_pos < quiet_pos,
-        "the busy thread must outrank the quiet post; entries: {:?}",
-        entries.iter().map(|e| &e.loc).collect::<Vec<_>>(),
+        position("/posts/pruned-thread") < position("/posts/replied-to"),
+        "August (a deletion) must outrank June (a reply); entries: {locs:?}",
+    );
+    assert!(
+        position("/posts/replied-to") < position("/posts/quiet-post"),
+        "an active thread must outrank a quiet post; entries: {locs:?}",
+    );
+    assert!(
+        position("/posts/quiet-post") < position("/posts/id-twin"),
+        "March must outrank February; entries: {locs:?}",
     );
 }
 

--- a/examples/reddit-clone/tests/seo_pg_integration.rs
+++ b/examples/reddit-clone/tests/seo_pg_integration.rs
@@ -479,3 +479,51 @@ async fn sitemap_is_empty_without_a_database() {
         entries.len()
     );
 }
+
+/// `robots.txt` must not block a URL whose exclusion depends on a meta tag.
+///
+/// A `Disallow` line stops the fetch, so a crawler never reads that page's
+/// `noindex` — and the URL can still be indexed from an inbound link, as a
+/// bare result nobody can remove. The two are alternatives for one URL, not
+/// layers. This asserts the example's `autumn.toml` keeps them apart: the
+/// machine endpoints are blocked, and the two routes that declare `noindex`
+/// (`/submit` and `/u/{username}`) are left crawlable.
+#[test]
+fn robots_txt_never_blocks_a_url_that_relies_on_a_noindex_tag() {
+    let manifest = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("autumn.toml");
+    let raw = std::fs::read_to_string(&manifest).expect("read autumn.toml");
+    let parsed: toml::Value = toml::from_str(&raw).expect("parse autumn.toml");
+
+    let rules: Vec<String> = parsed
+        .get("seo")
+        .and_then(|seo| seo.get("robots"))
+        .and_then(|robots| robots.get("additional_rules"))
+        .and_then(toml::Value::as_array)
+        .expect("[seo.robots] additional_rules")
+        .iter()
+        .map(|v| v.as_str().expect("rule is a string").to_owned())
+        .collect();
+
+    // The routes that declare `seo(robots = "noindex", ...)` must stay
+    // crawlable, or the directive can never be read.
+    for noindex_path in ["/submit", "/u/"] {
+        assert!(
+            !rules
+                .iter()
+                .any(|rule| rule.starts_with("Disallow:") && rule.contains(noindex_path)),
+            "{noindex_path} declares a noindex tag, so robots.txt must not Disallow it; \
+             rules: {rules:?}",
+        );
+    }
+
+    // The machine endpoints have no page worth indexing, so blocking the crawl
+    // is the right tool there. Keep that half of the contract asserted too.
+    for machine_path in ["/api/", "/actuator/", "/_partials/"] {
+        assert!(
+            rules
+                .iter()
+                .any(|rule| rule == &format!("Disallow: {machine_path}")),
+            "expected a Disallow for the machine endpoint {machine_path}; rules: {rules:?}",
+        );
+    }
+}

--- a/skills/autumn-web/SKILL.md
+++ b/skills/autumn-web/SKILL.md
@@ -249,6 +249,7 @@ Use `.one_off_tasks(one_off_tasks![...])` for `#[task]` handlers invoked by
 | `.listeners(listeners![...])` | Register `#[listener]` event listeners (0.6.0) |
 | `.static_gate(layer)` | Middleware that also guards `#[static_get]` pre-render (0.6.0; `has_static_gate::<L>()`, `get_static_gate_types()`, `TestApp::static_gate` mirror it) |
 | `.with_shard_router(router)` | Install a shard router for `[[database.shards]]` (0.6.0) |
+| `.seo_source(source)` | Register a `SitemapSource` for dynamic `/sitemap.xml` entries (0.7.0) |
 | `.run()` | Launch the server |
 
 ## Route macros
@@ -322,6 +323,40 @@ accepts the same argument, so pre-rendered pages carry the tags. The extractor
 never fails — on a route without `seo(...)` it yields an empty builder. Note the
 attribute supplies *values*, not markup: the handler still emits them, normally
 via `seo.render()` inside the layout's `<head>`.
+
+**`sitemap.xml` and `robots.txt` (0.7.0):** set `[seo] base_url =
+"https://example.com"` in `autumn.toml` and the framework mounts `GET
+/robots.txt` and `GET /sitemap.xml`. `robots.txt` defaults by profile
+(`dev`/`test` → `Disallow: /`, `prod` → `Allow: /`); override with `[seo.robots]
+allow_all`, add lines with `additional_rules`, and pin the `Sitemap:` URL with
+`sitemap_url` (otherwise derived from `base_url`). The sitemap gets one entry
+per concrete `#[static_get]` path for free; every other URL comes from a
+`SitemapSource` registered with `.seo_source(...)`:
+
+```rust
+use autumn_web::seo::{SitemapEntry, SitemapSource};
+
+impl SitemapSource for PostSitemap {
+    fn entries(&self) -> Pin<Box<dyn Future<Output = Vec<SitemapEntry>> + Send + '_>> {
+        Box::pin(async {
+            vec![SitemapEntry::new("https://example.com/posts/hello")
+                .lastmod("2026-05-01")
+                .changefreq(autumn_web::seo::SitemapChangefreq::Weekly)]
+        })
+    }
+}
+```
+
+Traps: `entries()` is awaited **once**, while the router builds, and the body is
+cached — the sitemap is a start-up snapshot, so an app needing live entries must
+register its own `/sitemap.xml` route (the framework detects the collision, warns,
+and mounts neither of its own SEO routes). A source cannot use the `Db` extractor
+(no `AppState` yet) — build a pool with `autumn_web::db::create_pool(&config.database)`.
+`seo(robots = "noindex")` drops a route from the sitemap only for `#[static_get]`
+paths the framework derived itself; `SitemapSource` entries are never filtered, so
+omit the URL from the source instead. `sitemap_xml` truncates past 50,000 URLs.
+`autumn build` writes both files into `dist/`. Guide: `docs/guide/seo.md`; runnable
+example: `examples/reddit-clone` (`src/seo.rs`, `autumn.toml`).
 
 **Locale-prefixed routing (issue #1251, 0.7.0):** set
 `[i18n] locale_prefix_enabled = true` in `autumn.toml` (default `false`) and
@@ -2466,6 +2501,7 @@ touched crate so examples compile from an external-consumer perspective.
 - `docs/guide/daemon.md`
 - `docs/guide/resilience.md`
 - `docs/guide/generators.md`
+- `docs/guide/seo.md`
 - `docs/guide/widget-styling.md`
 - `docs/guide/tabs.md`
 - `docs/guide/maintenance-mode.md`

--- a/skills/autumn-web/references/api-reference.md
+++ b/skills/autumn-web/references/api-reference.md
@@ -146,6 +146,22 @@ builder), then refine them with per-request data before calling
 `seo.render()`. `#[static_get]` honours the argument too. The declared values
 are also recorded on `Route::seo` as a `SeoRouteDefaults`.
 
+**`sitemap.xml` / `robots.txt`** (0.7.0): `[seo] base_url` in `autumn.toml`
+mounts `GET /robots.txt` and `GET /sitemap.xml`.
+`[seo.robots]` takes `allow_all` (override the `dev`→`Disallow: /` /
+`prod`→`Allow: /` profile default), `additional_rules`, and `sitemap_url`.
+`AppBuilder::seo_source(source)` registers an
+`autumn_web::seo::SitemapSource` supplying `SitemapEntry` values
+(`loc` + optional `lastmod` / `changefreq` / `priority`); concrete
+`#[static_get]` paths are derived automatically. `entries()` is awaited once at
+router build, so the served body is a start-up snapshot — register your own
+`/sitemap.xml` route for live entries (Autumn detects the collision, warns, and
+mounts neither of its own SEO routes). `seo(robots = "noindex")` excludes a
+route from the sitemap only for derived `#[static_get]` paths, never for
+`SitemapSource` entries. Helpers: `seo::sitemap_xml` (truncates past 50,000
+URLs), `seo::robots_txt`, `seo::write_seo_files` (used by `autumn build`).
+Guide: `docs/guide/seo.md`.
+
 **Locale-prefixed routing** (0.7.0, #1251): `[i18n]
 locale_prefix_enabled = true` in `autumn.toml` (default `false`, no behavior
 change) makes every route registered via `routes(...)` also reachable under


### PR DESCRIPTION
Closes the **T1 gap** from the 0.7.0 docs & examples coverage audit ([#2320](https://github.com/autumn-foundation/autumn/issues/2320)): route-level SEO was the only new-in-0.7.0 feature with no guide. `autumn/src/seo.rs` was rustdoc-only and `docs/guide/` had **zero** `sitemap`/`robots` mentions, even though the `seo(...)` route attribute shipped in 0.7.0 and `examples/blog` already wired `SitemapSource` + `[seo] base_url`.

## `docs/guide/seo.md` (new)

Covers, in this order:

- turning the feature on with `[seo] base_url` (and what it actually mounts)
- the `seo(...)` route argument: every key, which macros accept it, string-literal-only, compile errors on unknown/repeated keys
- the `SeoMeta` extractor (infallible), its Open Graph / Twitter fallbacks, and the "values, not markup" contract
- refining attribute defaults from a database row in the handler
- where to render — one `(seo.render())` call in the layout `<head>`
- canonical URLs, and reading `base_url` once instead of cloning `AutumnConfig` per request
- `robots = "noindex"`, which half of the directive to pick (`follow` vs `nofollow`), and **exactly** which sitemap entries it filters: derived `#[static_get]` paths only, never `SitemapSource` entries, with the reason
- **why `Disallow` and `noindex` must not share a URL** — they cancel out, and a `noindex` behind `#[secured]` is unreachable for the same reason
- `[seo.robots]`: profile defaults, `allow_all`, `additional_rules`, `sitemap_url`
- `SitemapSource`: entry fields, reading a database from one (no `Db` extractor at router-build time), the **start-up-snapshot** semantics, the custom-`/sitemap.xml`-route escape hatch and its collision behaviour, what a `LIMIT` does and does not bound, and the 50,000-URL limit
- **giving `lastmod` the page, not one column** — the write-vs-derive tradeoff, with the query
- `hreflang` alternates and locale-prefixed sitemaps, including the two exclusions that keep the sitemap in step with the router
- static builds (`autumn build`), including that it never overwrites a file your own routes produced
- a test recipe, a deploy checklist, and a reference table

The guide is written in **ASD-STE100** Simplified Technical English as requested: short sentences, active voice, simple tenses, one instruction per sentence, one meaning per word. A note at the foot asks editors to keep that style.

## `examples/reddit-clone` — the runnable sample

| Part | File |
|------|------|
| DB-backed `RedditSitemapSource`, base-URL/canonical helpers, `summarize` | `src/seo.rs` (new) |
| `[seo]` + `[seo.robots]`, documented inline | `autumn.toml` |
| Attribute-only tags + canonical on a `#[static_get]` page | `src/routes/about.rs` |
| Attribute defaults refined from a row + canonical URL | `src/routes/posts.rs` (`show`), `src/routes/subreddits.rs` (`show`) |
| Attribute-only tags + canonical on index pages | `src/routes/posts.rs` (`front_page`), `src/routes/subreddits.rs` (`list`) |
| `noindex, follow` on a public, crawlable page — where the directive actually works | `src/routes/auth.rs` (`profile`) |
| `noindex, nofollow` on a `#[secured]` page, with a note on why the tag is belt-and-braces there | `src/routes/posts.rs` (`submit_form`) |
| One `SeoMeta::render()` in the shared `<head>` | `src/routes/layout.rs` |
| `posts.updated_at` advanced on every update path | `src/hooks.rs` |

**The sitemap.** Lists the front page, the community index, the communities and the posts. Each post's `<lastmod>` is *derived* rather than read from a column — `GREATEST` of `posts.updated_at`, the newest live comment, and the newest comment deletion — because a comment changes the page without touching the `posts` row. Ordering runs on that same derived value, so the entry cap keeps the genuinely freshest pages. Entry caps of 1,000 communities and 5,000 posts bound the number of URLs, **not** the work the query does; the constants say so and say when to stop building the sitemap at boot. The source builds its own pool from the config (no `AppState` exists yet when the framework collects entries) and degrades to an empty list rather than failing the boot.

`routes/layout.rs` gains `layout_with_seo(seo, …)`; the existing `layout(title, …)` now delegates to it, so every untouched page keeps its `<title>` and its `— Autumn Reddit` suffix.

Verify a running app:

```bash
curl http://localhost:3000/robots.txt
curl http://localhost:3000/sitemap.xml
curl -s http://localhost:3000/ | grep -E '<title>|og:|canonical'
```

## Tests

- `src/routes/layout.rs` — rendered-tag assertions: every declared tag, the OG/Twitter fallbacks, "unset value emits no tag", `noindex, nofollow` and `noindex, follow`, and the preserved plain-title path.
- `src/routes/about.rs` — the pre-rendered page carries its attribute tags and a canonical URL.
- `src/hooks.rs` — `before_update` advances `posts.updated_at` (on an edit, and with no field diff) and still re-slugs on a title change.
- `src/seo.rs` — `summarize` (whitespace collapse, word-break cut, multibyte boundary, blank input) and the canonical helper with and without a base URL.
- `tests/seo_pg_integration.rs` — `robots_txt_never_blocks_a_url_that_relies_on_a_noindex_tag` parses the committed `autumn.toml` and asserts both halves of the crawl/index contract (runs unignored). Behind `#[ignore]` (testcontainers): the URL set and absolute-URL invariant, the rendered `sitemap.xml`/`robots.txt`, and `lastmod_follows_comment_activity_not_just_post_edits`, which covers a live reply, a deletion, a no-comment post, and a `Subreddit`-typed comment sharing a post's id.

## Also updated

`skills/autumn-web/` (SKILL.md + `references/api-reference.md`) — the plugin documented the `seo(...)` attribute but nothing of the `sitemap.xml` / `robots.txt` half. `README.md`, `EXAMPLES.md`, `examples/reddit-clone/README.md`, and `CHANGELOG.md` under `## [Unreleased]`.

## Review rounds

Four rounds of Codex findings, all verified against the code before acting:

1. **`<lastmod>` reported the creation date forever** — nothing advanced `posts.updated_at`. Fixed in `PostHooks::before_update` using `ctx.now` (the determinism seam bans `chrono::Utc::now()`).
2. **`/about` had no canonical URL** despite the changelog claiming otherwise.
3. **Silent sitemap truncation** while docs claimed "every community and post" — caps kept, now logged and honestly documented.
4. **The hook covered only `repo.update`** — votes, comments and tags bypass it. Moved to deriving `lastmod` at read time rather than fanning timestamp writes across every subsystem.
5. **The guide's copyable query dropped the polymorphic discriminator**, and **comment deletions were invisible** (and could move `lastmod` *backward*). Both fixed; the live filter moved from the join to the aggregate.
6. **`Disallow` + `noindex` on the same URL** — the guide advised a combination that cannot work, and the example implemented it. Rewritten, and `profile` added as a demonstration that actually functions.

One suggestion was declined with reasoning on [its thread](https://github.com/autumn-foundation/autumn/pull/2325#discussion_r3867711671): pre-filtering the sitemap query's candidate set. The false claim it rested on is gone, but a denormalised page-modification column is the write-fan-out this PR deliberately moved away from, and a three-way candidate `UNION` is a query-optimisation lesson in a file whose job is SEO wiring.

## Checks run locally

`cargo check --workspace --all-targets`, `cargo test -p reddit-clone --lib` (54), `cargo test -p reddit-clone --test seo_pg_integration` (2 unignored; 3 testcontainer tests compile but **do not execute** — no Docker in this environment), `cargo clippy -p reddit-clone --all-targets -- -D warnings`, `cargo fmt --all`, and `check-plugin-freshness.sh`, `check-skill-version-markers.sh`, `check-release-notes.sh`, `check-docs.sh`, `check-examples.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XnVwd4ffd6npS4obEMrjQe