### PR TITLE
Mirror live traffic to a shadow build and diff before cutover (#1653)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,11 +65,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   extra request rather than an exponential storm) and the seam a candidate build
   uses to refuse writes. Recorded samples pass through the same
   `[log] filter_parameters` redaction as the access log and failure capsules,
-  and an excerpt is recorded only when every scalar in the body sits under an
-  object key, since that is exactly when the key-name filter has something to
-  match — an HTML body, a bare scalar (a `text/plain` one-time code parses as a
-  JSON number) and an array of bare strings all record a digest and a length
-  instead — and the guide is explicit about what that redaction does and does
+  and an excerpt is recorded only when every scalar in the body has an object key
+  above it, since the filter replaces a matched key's whole value and that is
+  exactly when naming a key could reach it — an HTML body, a bare scalar (a
+  `text/plain` one-time code parses as a JSON number) and a top-level array of
+  strings all record a digest and a length instead — and the guide is explicit about what that redaction does and does
   not cover before you point this at a route returning personal data. Requests
   the live build itself refuses (`429`/`503` from maintenance mode, load
   shedding, or the rate limiter) are not mirrored at all, so a planned

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,8 +66,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   uses to refuse writes. Recorded samples pass through the same
   `[log] filter_parameters` redaction as the access log and failure capsules,
   and only JSON bodies are sampled — an HTML or binary body records a digest and
-  a length instead of an excerpt no redaction rule could vet. Off by default;
-  see `docs/guide/staged-deploys.md` for how it differs from canary and for the
+  a length instead of an excerpt no redaction rule could vet — and the redaction
+  is a key-name allowlist, so the guide is explicit about what it does and does
+  not cover before you point this at a route returning personal data. Requests
+  the live build itself refuses (`429`/`503` from maintenance mode, load
+  shedding, or the rate limiter) are not mirrored at all, so a planned
+  maintenance window does not read as a divergence storm. Off by default, and
+  requires the `http-client` cargo feature (on by default) — a build without it
+  says so at startup and mirrors nothing rather than pretending to. See
+  `docs/guide/staged-deploys.md` for how it differs from canary and for the
   trust boundary (the candidate receives live credentials, and its own side
   effects are yours to contain). Effect virtualization for mutating traffic, and
   gating `autumn deploy` on a clean diff, are deliberate follow-ups.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,7 +71,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   not cover before you point this at a route returning personal data. Requests
   the live build itself refuses (`429`/`503` from maintenance mode, load
   shedding, or the rate limiter) are not mirrored at all, so a planned
-  maintenance window does not read as a divergence storm. Off by default, and
+  maintenance window does not read as a divergence storm. The candidate is
+  dialed at `target` but sees the `Host` the live build accepted, so a candidate
+  cloning production's `[security.trusted_hosts]` — or a subdomain-keyed
+  multi-tenant app — does not diverge on every request; and in an SSG/ISG build
+  the mirror sits outside the static-first middleware, so pre-rendered pages are
+  compared rather than silently skipped. Off by default, and
   requires the `http-client` cargo feature (on by default) — a build without it
   says so at startup and mirrors nothing rather than pretending to. See
   `docs/guide/staged-deploys.md` for how it differs from canary and for the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,9 +72,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the live build itself refuses (`429`/`503` from maintenance mode, load
   shedding, or the rate limiter) are not mirrored at all, so a planned
   maintenance window does not read as a divergence storm. The candidate is
-  dialed at `target` but sees the `Host` the live build accepted, so a candidate
-  cloning production's `[security.trusted_hosts]` — or a subdomain-keyed
-  multi-tenant app — does not diverge on every request; and in an SSG/ISG build
+  dialed at `target` but sees the `Host` the live build accepted — behind a
+  trusted proxy, the *resolved* authority rather than the internal raw header —
+  so a candidate cloning production's `[security.trusted_hosts]`, or a
+  subdomain-keyed multi-tenant app, does not diverge on every request; and in an SSG/ISG build
   the mirror sits outside the static-first middleware, so pre-rendered pages are
   compared rather than silently skipped. Off by default, and
   requires the `http-client` cargo feature (on by default) — a build without it

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,9 +65,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   extra request rather than an exponential storm) and the seam a candidate build
   uses to refuse writes. Recorded samples pass through the same
   `[log] filter_parameters` redaction as the access log and failure capsules,
-  and only JSON bodies are sampled — an HTML or binary body records a digest and
-  a length instead of an excerpt no redaction rule could vet — and the redaction
-  is a key-name allowlist, so the guide is explicit about what it does and does
+  and an excerpt is recorded only when every scalar in the body sits under an
+  object key, since that is exactly when the key-name filter has something to
+  match — an HTML body, a bare scalar (a `text/plain` one-time code parses as a
+  JSON number) and an array of bare strings all record a digest and a length
+  instead — and the guide is explicit about what that redaction does and does
   not cover before you point this at a route returning personal data. Requests
   the live build itself refuses (`429`/`503` from maintenance mode, load
   shedding, or the rate limiter) are not mirrored at all, so a planned

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,45 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Shadow (differential) deploys — mirror live traffic to a candidate build and
+  diff its responses before cutover (#1653):** every deploy strategy Autumn
+  shipped until now — rolling, blue/green, canary — routes **real** traffic to
+  the new version and decides go/no-go from aggregate cohort metrics. That
+  catches a build that falls over; it structurally cannot catch the build that
+  returns `200 OK` with a dropped JSON field, a reordered list, or an off-by-one
+  total, because nothing ever compares two responses to the *same* request. A
+  new `[shadow]` section turns on in-process traffic mirroring: Autumn samples
+  live `GET`/`HEAD` requests, replays each against an operator-provided
+  candidate build, and diffs the two responses on status class and a normalized
+  body. Object key order is normalized away; array order is not, because a
+  reordered list is exactly the regression this exists to catch. Divergences are
+  reported at `{actuator-prefix}/shadow` (sensitive-gated, like
+  `/actuator/tasks`) and as the labelled metrics
+  `autumn_shadow_comparisons_total{route,outcome}` and
+  `autumn_shadow_divergences_total{route,kind}`; identical divergences collapse
+  onto one record by a content-addressed `fingerprint`, so a captured pair is
+  reproducible and one loud regression cannot evict every other record. The live
+  request cannot tell mirroring is on: the shadow request is dispatched on a
+  detached task and the primary response body is *teed* rather than buffered, so
+  a slow, erroring, or unreachable candidate resolves to a counter and nothing
+  else — bounded by `sample_rate`, `timeout_ms`, `max_in_flight` (excess is
+  dropped, never queued), and `max_body_bytes` (an oversize body is skipped, not
+  partially buffered). The candidate's response is read into a plain struct
+  inside that task and dropped there, so no code path exists on which it could
+  reach a user; only idempotent methods are mirrored, and the allowlist is a
+  constant rather than a config key. Every mirrored request carries
+  `X-Autumn-Shadow: 1`, which is both the recursion guard (a request carrying it
+  is never mirrored again, so pointing a shadow at the app itself costs one
+  extra request rather than an exponential storm) and the seam a candidate build
+  uses to refuse writes. Recorded samples pass through the same
+  `[log] filter_parameters` redaction as the access log and failure capsules,
+  and only JSON bodies are sampled — an HTML or binary body records a digest and
+  a length instead of an excerpt no redaction rule could vet. Off by default;
+  see `docs/guide/staged-deploys.md` for how it differs from canary and for the
+  trust boundary (the candidate receives live credentials, and its own side
+  effects are yours to contain). Effect virtualization for mutating traffic, and
+  gating `autumn deploy` on a clean diff, are deliberate follow-ups.
+
 - **`#[query_budget(N)]` — a compile-time, per-route database query budget
   (#1667):** declare a handler's query ceiling and the build fails when any
   statically reachable path can exceed it. The canonical case is the N+1 — a

--- a/autumn/src/actuator.rs
+++ b/autumn/src/actuator.rs
@@ -384,6 +384,17 @@ pub trait ProvideActuatorState {
     fn log_buffer(&self) -> Option<crate::log::capture::LogBuffer> {
         None
     }
+
+    /// Returns the shadow-mirroring handle, when this replica assembled a
+    /// mirror (`[shadow] enabled = true` with a reachable target configured).
+    ///
+    /// The default returns `None` — mirroring is off — and
+    /// `{prefix}/shadow` then reports a disabled mirror rather than 404ing, so
+    /// an operator turning the feature on can tell "not enabled here" apart
+    /// from "endpoint not mounted".
+    fn shadow(&self) -> Option<crate::shadow::ShadowHandle> {
+        None
+    }
 }
 
 // ── Shared types for AppState ──────────────────────────────────
@@ -3508,6 +3519,26 @@ pub(crate) async fn jobs_endpoint<S: ProvideActuatorState + Send + Sync + 'stati
     Json(serde_json::json!({ "jobs": jobs, "queues": queues }))
 }
 
+/// `GET <actuator-prefix>/shadow` -- shadow-mirroring counters and the most
+/// recent primary-vs-shadow divergences (issue #1653).
+///
+/// Sensitive-gated, like `/tasks` and `/jobs`: the recorded samples are
+/// redacted excerpts of real production responses, so this is not a public
+/// surface. A replica with mirroring switched off answers with
+/// `{"enabled": false, ...}` rather than `404`, so an operator can tell
+/// "mirroring is off here" apart from "this build has no such endpoint".
+pub(crate) async fn shadow_endpoint<S: ProvideActuatorState + Send + Sync + 'static>(
+    State(state): State<S>,
+) -> Json<crate::shadow::ShadowSnapshot> {
+    Json(
+        state
+            .shadow()
+            .map_or_else(crate::shadow::ShadowHandle::disabled_snapshot, |handle| {
+                handle.snapshot()
+            }),
+    )
+}
+
 #[cfg(feature = "http-client")]
 /// Request body for `POST <actuator-prefix>/webhooks/replay`.
 #[derive(Deserialize)]
@@ -3868,6 +3899,7 @@ pub(crate) fn actuator_endpoint_paths(
         paths.push(actuator_route_path(prefix, "/tasks"));
         paths.push(actuator_route_path(prefix, "/jobs"));
         paths.push(actuator_route_path(prefix, "/ui/tasks"));
+        paths.push(actuator_route_path(prefix, "/shadow"));
         #[cfg(feature = "system-info")]
         {
             paths.push(actuator_route_path(prefix, "/system"));
@@ -4012,6 +4044,10 @@ pub(crate) fn actuator_router_with_prefix<
             .route(
                 &actuator_route_path(prefix, "/ui/tasks"),
                 axum::routing::get(ui_tasks::<S>),
+            )
+            .route(
+                &actuator_route_path(prefix, "/shadow"),
+                axum::routing::get(shadow_endpoint::<S>),
             );
         #[cfg(feature = "http-client")]
         {

--- a/autumn/src/actuator.rs
+++ b/autumn/src/actuator.rs
@@ -3136,7 +3136,7 @@ fn write_builtin_shadow_metrics(
         }
         let _ = writeln!(out, "# HELP {name} {help}");
         let _ = writeln!(out, "# TYPE {name} counter");
-        for entry in series.iter() {
+        for entry in series {
             let route = escape_prometheus_label_value(&entry.route);
             let label = escape_prometheus_label_value(&entry.label);
             let _ = writeln!(

--- a/autumn/src/actuator.rs
+++ b/autumn/src/actuator.rs
@@ -2723,7 +2723,7 @@ pub(crate) const SERIES_DROPPED_FAMILY: &str = "autumn_metrics_series_dropped_to
 /// `emitted_families` set with it so a plugin [`MetricsSource`] cannot shadow a
 /// built-in family, and [`crate::metrics`] refuses to register an app metric
 /// under any of these names.
-pub(crate) const BUILTIN_METRIC_FAMILY_NAMES: [&str; 21] = [
+pub(crate) const BUILTIN_METRIC_FAMILY_NAMES: [&str; 23] = [
     "autumn_http_requests_total",
     "autumn_http_requests_active",
     "autumn_http_responses_total",
@@ -2751,6 +2751,8 @@ pub(crate) const BUILTIN_METRIC_FAMILY_NAMES: [&str; 21] = [
     "autumn_cache_read_through_stale_serves_total",
     "autumn_cache_fill_lock_acquires_total",
     "autumn_cache_fill_lock_contended_total",
+    crate::shadow::COMPARISONS_METRIC,
+    crate::shadow::DIVERGENCES_METRIC,
 ];
 
 /// Returns true if `s` is a valid Prometheus metric name (`[a-zA-Z_:][a-zA-Z0-9_:]*`).
@@ -3097,6 +3099,55 @@ fn write_builtin_cache_metrics(
     }
 }
 
+/// Render the shadow-mirroring families (issue #1653) into `out`.
+///
+/// Written as built-in families rather than through the [`crate::metrics`]
+/// facade because that facade reserves the `autumn_` namespace for exactly
+/// these — a framework family registered through it would be silently inert.
+///
+/// A replica with no mirror writes nothing at all, so the families stay absent
+/// from the scrape until an operator turns mirroring on. Route labels are
+/// bounded by the registry (see its `MAX_ROUTE_SERIES`), and both label values
+/// are escaped defensively: the route can come from an app's own route
+/// template.
+fn write_builtin_shadow_metrics(
+    out: &mut String,
+    version: &str,
+    snapshot: &crate::shadow::ShadowSnapshot,
+) {
+    use std::fmt::Write;
+
+    for (name, help, label_name, series) in [
+        (
+            crate::shadow::COMPARISONS_METRIC,
+            "Mirrored requests by route and comparison outcome",
+            "outcome",
+            &snapshot.comparisons_by_route,
+        ),
+        (
+            crate::shadow::DIVERGENCES_METRIC,
+            "Primary/shadow response divergences by route and kind",
+            "kind",
+            &snapshot.divergences_by_route,
+        ),
+    ] {
+        if series.is_empty() {
+            continue;
+        }
+        let _ = writeln!(out, "# HELP {name} {help}");
+        let _ = writeln!(out, "# TYPE {name} counter");
+        for entry in series.iter() {
+            let route = escape_prometheus_label_value(&entry.route);
+            let label = escape_prometheus_label_value(&entry.label);
+            let _ = writeln!(
+                out,
+                "{name}{{version=\"{version}\",route=\"{route}\",{label_name}=\"{label}\"}} {}",
+                entry.count
+            );
+        }
+    }
+}
+
 /// Render the app-defined [`crate::metrics`] facade instruments into `out`.
 ///
 /// Every family name written here is inserted into `emitted_families` —
@@ -3264,6 +3315,9 @@ pub(crate) async fn prometheus_endpoint<S: ProvideActuatorState + Send + Sync + 
         &version,
         &crate::cache::read_through_metrics().snapshot(),
     );
+    if let Some(handle) = state.shadow() {
+        write_builtin_shadow_metrics(&mut out, &version, &handle.snapshot());
+    }
 
     // Name ownership, in precedence order: built-in families first, then the
     // app-metrics facade, then plugin-contributed sources — so neither the

--- a/autumn/src/config.rs
+++ b/autumn/src/config.rs
@@ -4393,7 +4393,11 @@ impl AutumnConfig {
             "AUTUMN_SHADOW__SAMPLE_RATE",
             &mut self.shadow.sample_rate,
         );
-        parse_env_csv(env, "AUTUMN_SHADOW__ROUTES", &mut self.shadow.routes);
+        // `_non_empty`: an unfilled template (`AUTUMN_SHADOW__ROUTES=`) must not
+        // become a one-element allowlist containing the empty pattern, which
+        // matches no path and would silently mirror nothing (issue #1621's
+        // failure shape).
+        parse_env_csv_non_empty(env, "AUTUMN_SHADOW__ROUTES", &mut self.shadow.routes);
         parse_env(
             env,
             "AUTUMN_SHADOW__TIMEOUT_MS",
@@ -11422,6 +11426,62 @@ path = "/healthz"
         assert!(
             config.cluster.validate().is_ok(),
             "…and a cluster_name at the cap must be accepted, or the rule is vacuous"
+        );
+    }
+
+    #[test]
+    fn shadow_env_overrides_apply() {
+        let env = MockEnv::new()
+            .with("AUTUMN_SHADOW__ENABLED", "true")
+            .with("AUTUMN_SHADOW__TARGET", "http://127.0.0.1:9091")
+            .with("AUTUMN_SHADOW__SAMPLE_RATE", "0.25")
+            .with("AUTUMN_SHADOW__ROUTES", "/api/*, /status")
+            .with("AUTUMN_SHADOW__TIMEOUT_MS", "750")
+            .with("AUTUMN_SHADOW__MAX_IN_FLIGHT", "16")
+            .with("AUTUMN_SHADOW__MAX_BODY_BYTES", "4096")
+            .with("AUTUMN_SHADOW__MAX_RECORDS", "12")
+            .with("AUTUMN_SHADOW__MAX_SAMPLE_BYTES", "256");
+        let mut config = AutumnConfig::default();
+        config.apply_env_overrides_with_env(&env);
+
+        assert!(config.shadow.enabled);
+        assert_eq!(
+            config.shadow.target.as_deref(),
+            Some("http://127.0.0.1:9091")
+        );
+        assert!((config.shadow.sample_rate - 0.25).abs() < f64::EPSILON);
+        assert_eq!(config.shadow.routes, vec!["/api/*", "/status"]);
+        assert_eq!(config.shadow.timeout_ms, 750);
+        assert_eq!(config.shadow.max_in_flight, 16);
+        assert_eq!(config.shadow.max_body_bytes, 4096);
+        assert_eq!(config.shadow.max_records, 12);
+        assert_eq!(config.shadow.max_sample_bytes, 256);
+        assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn an_empty_shadow_routes_override_does_not_disable_mirroring() {
+        // An unfilled compose/CI template (`AUTUMN_SHADOW__ROUTES=`) must not
+        // become a one-element allowlist holding the empty pattern: that
+        // matches no path, so the mirror would run and mirror nothing, with no
+        // diagnostic. Same failure shape `parse_env_csv_non_empty` was added
+        // for in #1621.
+        let env = MockEnv::new().with("AUTUMN_SHADOW__ROUTES", "");
+        let mut config = AutumnConfig::default();
+        config.apply_env_overrides_with_env(&env);
+        assert!(config.shadow.routes.is_empty());
+    }
+
+    #[test]
+    fn top_level_validation_rejects_an_unusable_shadow_section() {
+        // Guards the `self.shadow.validate()?` call in `AutumnConfig::validate`:
+        // without it a replica boots with mirroring "on" and no target.
+        let mut config = AutumnConfig::default();
+        config.shadow.enabled = true;
+        let error = config.validate().expect_err("must reject");
+        assert!(
+            error.to_string().contains("shadow.target"),
+            "the boot failure must name the missing key, got: {error}"
         );
     }
 

--- a/autumn/src/config.rs
+++ b/autumn/src/config.rs
@@ -171,6 +171,15 @@
 //! | `AUTUMN_CLUSTER__NODE_ID` | `cluster.node_id` | `String` |
 //! | `AUTUMN_CLUSTER__PUSH_INTERVAL_MS` | `cluster.push_interval_ms` | `u64` |
 //! | `AUTUMN_CLUSTER__SUSPICION_TIMEOUT_MS` | `cluster.suspicion_timeout_ms` | `u64` |
+//! | `AUTUMN_SHADOW__ENABLED` | `shadow.enabled` | `bool` |
+//! | `AUTUMN_SHADOW__TARGET` | `shadow.target` | `String` |
+//! | `AUTUMN_SHADOW__SAMPLE_RATE` | `shadow.sample_rate` | `f64` |
+//! | `AUTUMN_SHADOW__ROUTES` | `shadow.routes` | comma-separated patterns |
+//! | `AUTUMN_SHADOW__TIMEOUT_MS` | `shadow.timeout_ms` | `u64` |
+//! | `AUTUMN_SHADOW__MAX_IN_FLIGHT` | `shadow.max_in_flight` | `usize` |
+//! | `AUTUMN_SHADOW__MAX_BODY_BYTES` | `shadow.max_body_bytes` | `usize` |
+//! | `AUTUMN_SHADOW__MAX_RECORDS` | `shadow.max_records` | `usize` |
+//! | `AUTUMN_SHADOW__MAX_SAMPLE_BYTES` | `shadow.max_sample_bytes` | `usize` |
 
 use std::path::{Path, PathBuf};
 
@@ -1069,6 +1078,26 @@ pub struct AutumnConfig {
     /// this ordering breaks.
     #[serde(default)]
     pub cluster: ClusterConfig,
+
+    /// Live-traffic shadow mirroring and response diffing (`[shadow]` section,
+    /// issue #1653).
+    ///
+    /// Off by default. When enabled, a sampled slice of `GET`/`HEAD` traffic is
+    /// replayed against an operator-provided candidate build and the two
+    /// responses are diffed; see [`crate::shadow::ShadowConfig`] and
+    /// `docs/guide/staged-deploys.md`.
+    ///
+    /// # Field ordering (load-bearing — do not move below `database`)
+    ///
+    /// Declared here, before [`database`](Self::database), for the same reason
+    /// [`deploy`](Self::deploy) and `cluster` are: `DatabaseConfig`'s
+    /// `deserialize_with` duration field can abort the `SchemaDeserializer`
+    /// traversal, and a section it never descends into is recorded only as an
+    /// opaque root leaf — so a typo like `[shadow] targt = "…"` would be
+    /// silently accepted and the mirror would never run. The regression guard
+    /// `shadow_child_keys_are_strictly_validated` fails if this ordering breaks.
+    #[serde(default)]
+    pub shadow: crate::shadow::ShadowConfig,
 
     /// Database connection settings (URL, pool size, timeouts).
     #[serde(default)]
@@ -4208,6 +4237,10 @@ impl AutumnConfig {
         #[cfg(feature = "mail")]
         self.mail.validate(self.profile.as_deref())?;
         self.time_zone.validate()?;
+        // A `[shadow]` block that is switched on but cannot be honoured (no
+        // target, an unusable URL, an out-of-range sample rate) must fail boot
+        // rather than start a replica that silently mirrors nothing.
+        self.shadow.validate().map_err(ConfigError::Validation)?;
         // Fail fast on an insecure or flapping [cluster] section: a node that
         // would boot without a shared secret must not boot at all.
         self.cluster.validate()?;
@@ -4297,6 +4330,15 @@ impl AutumnConfig {
     /// - `AUTUMN_CLUSTER__NODE_ID` → `cluster.node_id` (`String`)
     /// - `AUTUMN_CLUSTER__PUSH_INTERVAL_MS` → `cluster.push_interval_ms` (`u64`)
     /// - `AUTUMN_CLUSTER__SUSPICION_TIMEOUT_MS` → `cluster.suspicion_timeout_ms` (`u64`)
+    /// - `AUTUMN_SHADOW__ENABLED` → `shadow.enabled` (`bool`)
+    /// - `AUTUMN_SHADOW__TARGET` → `shadow.target` (`String`)
+    /// - `AUTUMN_SHADOW__SAMPLE_RATE` → `shadow.sample_rate` (`f64`)
+    /// - `AUTUMN_SHADOW__ROUTES` → `shadow.routes` (comma-separated patterns)
+    /// - `AUTUMN_SHADOW__TIMEOUT_MS` → `shadow.timeout_ms` (`u64`)
+    /// - `AUTUMN_SHADOW__MAX_IN_FLIGHT` → `shadow.max_in_flight` (`usize`)
+    /// - `AUTUMN_SHADOW__MAX_BODY_BYTES` → `shadow.max_body_bytes` (`usize`)
+    /// - `AUTUMN_SHADOW__MAX_RECORDS` → `shadow.max_records` (`usize`)
+    /// - `AUTUMN_SHADOW__MAX_SAMPLE_BYTES` → `shadow.max_sample_bytes` (`usize`)
     pub fn apply_env_overrides(&mut self) {
         self.apply_env_overrides_with_env(&OsEnv);
     }
@@ -4340,6 +4382,43 @@ impl AutumnConfig {
         self.apply_alerts_env_overrides_with_env(env);
         self.apply_tenancy_env_overrides_with_env(env);
         self.apply_cluster_env_overrides_with_env(env);
+        self.apply_shadow_env_overrides_with_env(env);
+    }
+
+    fn apply_shadow_env_overrides_with_env(&mut self, env: &dyn Env) {
+        parse_env_bool(env, "AUTUMN_SHADOW__ENABLED", &mut self.shadow.enabled);
+        parse_env_option_string(env, "AUTUMN_SHADOW__TARGET", &mut self.shadow.target);
+        parse_env(
+            env,
+            "AUTUMN_SHADOW__SAMPLE_RATE",
+            &mut self.shadow.sample_rate,
+        );
+        parse_env_csv(env, "AUTUMN_SHADOW__ROUTES", &mut self.shadow.routes);
+        parse_env(
+            env,
+            "AUTUMN_SHADOW__TIMEOUT_MS",
+            &mut self.shadow.timeout_ms,
+        );
+        parse_env(
+            env,
+            "AUTUMN_SHADOW__MAX_IN_FLIGHT",
+            &mut self.shadow.max_in_flight,
+        );
+        parse_env(
+            env,
+            "AUTUMN_SHADOW__MAX_BODY_BYTES",
+            &mut self.shadow.max_body_bytes,
+        );
+        parse_env(
+            env,
+            "AUTUMN_SHADOW__MAX_RECORDS",
+            &mut self.shadow.max_records,
+        );
+        parse_env(
+            env,
+            "AUTUMN_SHADOW__MAX_SAMPLE_BYTES",
+            &mut self.shadow.max_sample_bytes,
+        );
     }
 
     fn apply_cluster_env_overrides_with_env(&mut self, env: &dyn Env) {

--- a/autumn/src/lib.rs
+++ b/autumn/src/lib.rs
@@ -473,8 +473,11 @@ pub mod reporting;
 pub mod scheduler;
 pub mod security;
 pub mod session;
-/// Live-traffic shadow mirroring and primary-vs-shadow response diffing
-/// (issue #1653) — see `docs/guide/staged-deploys.md`.
+/// Live-traffic shadow mirroring and response diffing.
+///
+/// Samples `GET`/`HEAD` traffic to a candidate build and compares the two
+/// responses before cutover (issue #1653) — see
+/// `docs/guide/staged-deploys.md`.
 pub mod shadow;
 /// URL-safe slug generation (`slugify`), shared by the scaffold generator's
 /// `slug:slug{from:...}` DSL token and any hand-written app.

--- a/autumn/src/lib.rs
+++ b/autumn/src/lib.rs
@@ -473,6 +473,9 @@ pub mod reporting;
 pub mod scheduler;
 pub mod security;
 pub mod session;
+/// Live-traffic shadow mirroring and primary-vs-shadow response diffing
+/// (issue #1653) — see `docs/guide/staged-deploys.md`.
+pub mod shadow;
 /// URL-safe slug generation (`slugify`), shared by the scaffold generator's
 /// `slug:slug{from:...}` DSL token and any hand-written app.
 pub mod slug;

--- a/autumn/src/router.rs
+++ b/autumn/src/router.rs
@@ -711,6 +711,7 @@ fn build_router_pre_state(
         ctx.session_store,
         route_timeouts,
         load_shed_layer,
+        defer_security_headers,
     )?;
 
     if dev_reload_enabled {
@@ -4301,6 +4302,12 @@ fn apply_middleware(
     // `LoadShedLayer` here would give `/mcp` its own independent (always-zero)
     // counter that never sheds. See `build_load_shed_layer`.
     load_shed_layer: Option<crate::middleware::LoadShedLayer>,
+    // When true (SSG/ISG path), the shadow-mirroring layer is NOT installed
+    // here. `try_build_router_with_static_inner` installs a single one OUTSIDE
+    // the static-first middleware, so that a request served from the static
+    // cache is mirrored too — installing one here as well would double-mirror
+    // every dynamic miss against a second, unpublished registry.
+    defer_shadow: bool,
 ) -> Result<axum::Router<AppState>, RouterBuildError> {
     // 404 fallback handler for unmatched routes must be registered BEFORE global middleware
     // so that unmatched routes are still protected by rate limiting, CSRF, CORS, etc.
@@ -4749,7 +4756,13 @@ fn apply_middleware(
         // handler's own bytes, which is what the candidate build returns too.
         // Teeing a gzip-encoded body would diff against the candidate's plain
         // one and report every route as divergent.
-        tower::util::option_layer(build_shadow_layer(config, state)),
+        //
+        // `None` in the SSG/ISG path — see `defer_shadow`.
+        tower::util::option_layer(
+            (!defer_shadow)
+                .then(|| build_shadow_layer(config, state))
+                .flatten(),
+        ),
         crate::middleware::MetricsLayer::new(state.metrics.clone()),
         ExceptionFilterLayer::new(all_filters),
         crate::middleware::error_page_filter::ErrorPageContextLayer { is_dev },
@@ -5315,6 +5328,18 @@ pub fn try_build_router_with_static_inner(
     // Compression must also be applied OUTSIDE the static-first middleware so
     // that pre-rendered HTML pages (served directly by StaticFileLayer without
     // reaching inner_router) are also compressed. This mirrors the placement in
+    // Shadow mirroring (#1653) goes here — OUTSIDE the static-first middleware
+    // and inside compression — rather than in `apply_middleware` (which is why
+    // that call was made with `defer_shadow = true`). A request the static
+    // cache answers never reaches the inner router at all, so a layer installed
+    // in there would see only dynamic misses: a shadow run over an SSG/ISG app
+    // would report clean while every pre-rendered page the candidate generates
+    // differently went uncompared. Outer to the user layers and inner to
+    // compression, matching its position in the dynamic path.
+    if let Some(shadow) = build_shadow_layer(config, &state) {
+        router = router.layer(shadow);
+    }
+
     // apply_middleware for the dynamic-only path.
     router = apply_compression_middleware(router, config);
 

--- a/autumn/src/router.rs
+++ b/autumn/src/router.rs
@@ -3427,11 +3427,15 @@ fn build_shadow_layer(
     // leave the ingress stack untouched rather than pretending to mirror.
     #[cfg(not(feature = "http-client"))]
     {
-        let _ = (state, target_base);
         tracing::warn!(
             "[shadow] enabled but this build has no `http-client` feature; \
              traffic mirroring is inactive"
         );
+        // Install an inactive handle anyway, so the actuator can say "this
+        // replica has a target configured but cannot mirror" rather than
+        // reporting the same thing as a replica that never configured
+        // `[shadow]` at all.
+        state.insert_extension(crate::shadow::ShadowHandle::inactive(target_base));
         return None;
     }
 

--- a/autumn/src/router.rs
+++ b/autumn/src/router.rs
@@ -3474,11 +3474,26 @@ fn build_shadow_layer(
             &config.log.unfilter_parameters,
         ));
 
+        // Exempt the actuator's ACTUAL mounted paths as well as its prefix.
+        // With `[actuator] prefix = "/"` the endpoints mount at the root, where
+        // no prefix test can tell them from application routes — and mirroring
+        // an operator's `/metrics` poll means candidate load plus permanent
+        // false divergences from a payload that is per-replica by
+        // construction. `actuator_endpoint_paths` is the same source the
+        // startup barrier seeds its allow-list from, so this cannot drift from
+        // what is mounted.
+        let mut exempt_paths = probe_bypass_paths(config);
+        exempt_paths.extend(crate::actuator::actuator_endpoint_paths(
+            &config.actuator.prefix,
+            config.actuator.sensitive,
+            config.actuator.prometheus,
+        ));
+
         let selector = crate::shadow::MirrorSelector::new(
             config.shadow.sample_rate,
             &config.shadow.routes,
             &config.actuator.prefix,
-            &probe_bypass_paths(config),
+            &exempt_paths,
         );
 
         tracing::info!(

--- a/autumn/src/router.rs
+++ b/autumn/src/router.rs
@@ -3403,6 +3403,104 @@ fn build_load_shed_layer(
     )
 }
 
+/// Build the shadow-mirroring layer, or `None` when `[shadow]` is off.
+///
+/// Also installs the [`ShadowHandle`](crate::shadow::ShadowHandle) into the
+/// app state's runtime extension map, which is what
+/// `{actuator-prefix}/shadow` reads. A replica with mirroring off installs
+/// nothing and that endpoint reports a disabled mirror.
+///
+/// The clock and entropy source are taken from the app state rather than read
+/// ambiently, so a [`#[sim_test]`](crate::sim_test) controls both the sampling
+/// decision and the recorded timestamps.
+fn build_shadow_layer(
+    config: &AutumnConfig,
+    state: &AppState,
+) -> Option<crate::shadow::ShadowMirrorLayer> {
+    if !config.shadow.is_active() {
+        return None;
+    }
+    let target_base = config.shadow.target_base()?.to_owned();
+
+    // The real transport needs an HTTP client. Without the `http-client`
+    // feature there is nothing to dial the candidate with, so say so once and
+    // leave the ingress stack untouched rather than pretending to mirror.
+    #[cfg(not(feature = "http-client"))]
+    {
+        let _ = (state, target_base);
+        tracing::warn!(
+            "[shadow] enabled but this build has no `http-client` feature; \
+             traffic mirroring is inactive"
+        );
+        return None;
+    }
+
+    #[cfg(feature = "http-client")]
+    {
+        let timeout = std::time::Duration::from_millis(config.shadow.timeout_ms);
+        let transport = match crate::shadow::transport::HttpShadowTransport::new(
+            timeout,
+            config.shadow.max_body_bytes,
+        ) {
+            Ok(transport) => std::sync::Arc::new(transport),
+            Err(error) => {
+                tracing::warn!(
+                    %error,
+                    "[shadow] could not build the mirroring HTTP client; traffic mirroring \
+                     is inactive"
+                );
+                return None;
+            }
+        };
+
+        let registry = crate::shadow::ShadowRegistry::new(config.shadow.max_records);
+        state.insert_extension(crate::shadow::ShadowHandle {
+            registry: registry.clone(),
+            enabled: true,
+            target: Some(target_base.clone()),
+        });
+
+        // One `[log] filter_parameters` list governs the access log, error
+        // pages, failure capsules, and now the recorded divergence samples.
+        let mut filter_parameters = config.log.filter_parameters.clone();
+        filter_parameters.extend(crate::encryption::registered_encrypted_column_names());
+        let filter = Arc::new(crate::log::filter::ParameterFilter::new(
+            &filter_parameters,
+            &config.log.unfilter_parameters,
+        ));
+
+        let selector = crate::shadow::MirrorSelector::new(
+            config.shadow.sample_rate,
+            &config.shadow.routes,
+            &config.actuator.prefix,
+            &probe_bypass_paths(config),
+        );
+
+        tracing::info!(
+            target = %target_base,
+            sample_rate = config.shadow.sample_rate,
+            routes = ?config.shadow.routes,
+            "Shadow traffic mirroring enabled (GET/HEAD only)"
+        );
+
+        Some(crate::shadow::ShadowMirrorLayer::new(
+            crate::shadow::MirrorSettings {
+                target_base,
+                timeout,
+                max_in_flight: config.shadow.max_in_flight,
+                max_body_bytes: config.shadow.max_body_bytes,
+                max_sample_bytes: config.shadow.max_sample_bytes,
+            },
+            selector,
+            registry,
+            transport,
+            filter,
+            state.entropy_arc(),
+            state.clock_arc(),
+        ))
+    }
+}
+
 /// Per-route timeout lookup table, keyed by the fully-qualified route template
 /// (matching [`axum::extract::MatchedPath`]) and then by HTTP method, so an
 /// override on one handler never bleeds onto sibling methods sharing the path
@@ -4624,7 +4722,7 @@ fn apply_middleware(
     //   MCP dispatch clone, outside session and the static cache] ->
     //   [event-bus context, oauth2 interceptor] -> Inspector (dev) ->
     //   dev live-reload (dev)   (all applied in build_router_pre_state) ->
-    //   Compression -> Metrics -> ExceptionFilter -> ErrorPageContext ->
+    //   Compression -> ShadowMirror -> Metrics -> ExceptionFilter -> ErrorPageContext ->
     //   ReadYourWrites -> Session -> NormalizeBody ->
     //   RequestId -> LogContext -> ServerTiming -> AccessLog-primary ->
     //   Reporting -> Timeout -> Tenancy -> TrustedProxies ->
@@ -4642,6 +4740,12 @@ fn apply_middleware(
     //   `try_build_router_with_static_inner`.)
     // Listed OUTERMOST FIRST — see the warning at the top of this function.
     let outer_stack = (
+        // Shadow mirroring (#1653) is the outermost member of this group and
+        // therefore INNER to compression: the primary body it tees is the
+        // handler's own bytes, which is what the candidate build returns too.
+        // Teeing a gzip-encoded body would diff against the candidate's plain
+        // one and report every route as divergent.
+        tower::util::option_layer(build_shadow_layer(config, state)),
         crate::middleware::MetricsLayer::new(state.metrics.clone()),
         ExceptionFilterLayer::new(all_filters),
         crate::middleware::error_page_filter::ErrorPageContextLayer { is_dev },

--- a/autumn/src/shadow/config.rs
+++ b/autumn/src/shadow/config.rs
@@ -76,8 +76,8 @@ pub struct ShadowConfig {
     #[serde(default = "default_max_records")]
     pub max_records: usize,
 
-    /// Budget, in characters, for each recorded JSON sample before it is
-    /// truncated. Default: `2048`.
+    /// Budget, in bytes of the serialized form, for each recorded JSON sample
+    /// before it is truncated. Default: `2048`.
     #[serde(default = "default_max_sample_bytes")]
     pub max_sample_bytes: usize,
 }
@@ -130,6 +130,33 @@ impl ShadowConfig {
             return Err(format!(
                 "shadow.target must be an absolute http(s) URL, got {target:?}"
             ));
+        }
+        // Userinfo in the target would be echoed by the actuator endpoint and
+        // by the startup log line. Refuse it rather than quietly publishing a
+        // credential; the candidate should be reached without one, or behind
+        // something that adds it.
+        if target
+            .split_once("//")
+            .and_then(|(_, rest)| rest.split('/').next())
+            .is_some_and(|authority| authority.contains('@'))
+        {
+            return Err(
+                "shadow.target must not embed credentials — the value is published by the \
+                 shadow actuator endpoint and logged at startup"
+                    .to_owned(),
+            );
+        }
+
+        for route in &self.routes {
+            if route.trim().is_empty() {
+                return Err("shadow.routes must not contain a blank pattern".to_owned());
+            }
+            if !route.starts_with('/') {
+                return Err(format!(
+                    "shadow.routes patterns must start with '/', got {route:?} — a pattern that \
+                     cannot match any request path would silently disable mirroring"
+                ));
+            }
         }
 
         if !self.sample_rate.is_finite() || !(0.0..=1.0).contains(&self.sample_rate) {
@@ -320,6 +347,82 @@ mod tests {
         assert_eq!(config.routes, vec!["/api/*".to_owned()]);
         // Unspecified keys still carry their bounded defaults.
         assert_eq!(config.timeout_ms, ShadowConfig::default().timeout_ms);
+    }
+
+    #[test]
+    fn a_target_carrying_credentials_is_rejected() {
+        // The value is echoed by the shadow actuator endpoint and logged at
+        // startup, so it must not be a place to put a password.
+        let config = ShadowConfig {
+            enabled: true,
+            target: Some("http://user:pass@candidate.internal".to_owned()),
+            ..ShadowConfig::default()
+        };
+        let error = config.validate().expect_err("must reject");
+        assert!(error.contains("credentials"), "{error}");
+    }
+
+    #[test]
+    fn route_patterns_that_can_never_match_are_rejected() {
+        // A pattern without a leading slash matches no request path, so the
+        // allowlist would silently mirror nothing at all.
+        for bad in ["api/*", "  ", ""] {
+            let config = ShadowConfig {
+                enabled: true,
+                target: Some("http://127.0.0.1:9091".to_owned()),
+                routes: vec![bad.to_owned()],
+                ..ShadowConfig::default()
+            };
+            assert!(
+                config.validate().is_err(),
+                "{bad:?} must be rejected as a route pattern"
+            );
+        }
+        let config = ShadowConfig {
+            enabled: true,
+            target: Some("http://127.0.0.1:9091".to_owned()),
+            routes: vec!["/api/*".to_owned(), "/status".to_owned()],
+            ..ShadowConfig::default()
+        };
+        assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn validation_errors_name_the_key_that_is_wrong() {
+        let base = ShadowConfig {
+            enabled: true,
+            target: Some("http://127.0.0.1:9091".to_owned()),
+            ..ShadowConfig::default()
+        };
+        for (name, mutate) in [
+            (
+                "shadow.timeout_ms",
+                (|c: &mut ShadowConfig| c.timeout_ms = 0) as fn(&mut ShadowConfig),
+            ),
+            ("shadow.max_in_flight", |c: &mut ShadowConfig| {
+                c.max_in_flight = 0;
+            }),
+            ("shadow.max_body_bytes", |c: &mut ShadowConfig| {
+                c.max_body_bytes = 0;
+            }),
+            ("shadow.max_records", |c: &mut ShadowConfig| {
+                c.max_records = 0;
+            }),
+            ("shadow.max_sample_bytes", |c: &mut ShadowConfig| {
+                c.max_sample_bytes = 0;
+            }),
+            ("shadow.sample_rate", |c: &mut ShadowConfig| {
+                c.sample_rate = 2.0;
+            }),
+        ] {
+            let mut config = base.clone();
+            mutate(&mut config);
+            let error = config.validate().expect_err("must reject");
+            assert!(
+                error.contains(name),
+                "the error for {name} must name it, got: {error}"
+            );
+        }
     }
 
     #[test]

--- a/autumn/src/shadow/config.rs
+++ b/autumn/src/shadow/config.rs
@@ -126,20 +126,28 @@ impl ShadowConfig {
                     .to_owned(),
             );
         };
-        if !(target.starts_with("http://") || target.starts_with("https://")) {
+        // Parsed, not prefix-matched: `"http://"` passes a `starts_with` check
+        // but has no authority to dial, so the replica would boot reporting an
+        // enabled mirror while every selected request failed as a transport
+        // error. A target that cannot be dialed must fail boot, which is what
+        // the rest of this function promises.
+        let parsed = url::Url::parse(target)
+            .map_err(|error| format!("shadow.target is not a valid URL ({error}): {target:?}"))?;
+        if !matches!(parsed.scheme(), "http" | "https") {
             return Err(format!(
                 "shadow.target must be an absolute http(s) URL, got {target:?}"
             ));
         }
-        // Userinfo in the target would be echoed by the actuator endpoint and
-        // by the startup log line. Refuse it rather than quietly publishing a
-        // credential; the candidate should be reached without one, or behind
-        // something that adds it.
-        if target
-            .split_once("//")
-            .and_then(|(_, rest)| rest.split('/').next())
-            .is_some_and(|authority| authority.contains('@'))
-        {
+        if parsed.host_str().is_none_or(str::is_empty) {
+            return Err(format!(
+                "shadow.target must name a host to dial, got {target:?}"
+            ));
+        }
+        // Userinfo would be echoed by the actuator endpoint and by the startup
+        // log line. Refuse it rather than quietly publishing a credential; the
+        // candidate should be reached without one, or behind something that
+        // adds it.
+        if !parsed.username().is_empty() || parsed.password().is_some() {
             return Err(
                 "shadow.target must not embed credentials — the value is published by the \
                  shadow actuator endpoint and logged at startup"
@@ -347,6 +355,26 @@ mod tests {
         assert_eq!(config.routes, vec!["/api/*".to_owned()]);
         // Unspecified keys still carry their bounded defaults.
         assert_eq!(config.timeout_ms, ShadowConfig::default().timeout_ms);
+    }
+
+    #[test]
+    fn a_target_with_no_host_to_dial_is_rejected() {
+        // `"http://"` passes a `starts_with` check but has nothing to dial, so
+        // the replica would boot reporting an enabled mirror while every
+        // request failed as a transport error.
+        // NB `"http:///path"` is deliberately absent: WHATWG normalizes it to
+        // host `path`, which is dialable, so rejecting it would be wrong.
+        for bad in ["http://", "https://"] {
+            let config = ShadowConfig {
+                enabled: true,
+                target: Some(bad.to_owned()),
+                ..ShadowConfig::default()
+            };
+            let error = config
+                .validate()
+                .expect_err(&format!("{bad} must be rejected"));
+            assert!(error.contains("shadow.target"), "{error}");
+        }
     }
 
     #[test]

--- a/autumn/src/shadow/config.rs
+++ b/autumn/src/shadow/config.rs
@@ -143,6 +143,25 @@ impl ShadowConfig {
                 "shadow.target must name a host to dial, got {target:?}"
             ));
         }
+        // A query or fragment on the base is unusable: `shadow_url` appends the
+        // live request target to it, so `http://candidate/base?token=x` would
+        // produce `…/base?token=x/api/orders?page=2` — the request path folded
+        // into the query — and a fragment is never transmitted at all. Every
+        // mirrored request would reach the wrong resource on the candidate,
+        // quietly. A base *path* (`http://candidate/base`) is fine and is what
+        // an operator mounting the candidate under a prefix needs.
+        if parsed.query().is_some() {
+            return Err(format!(
+                "shadow.target must not carry a query string — the request target is \
+                 appended to it, so the mirrored path would fold into the query: {target:?}"
+            ));
+        }
+        if parsed.fragment().is_some() {
+            return Err(format!(
+                "shadow.target must not carry a fragment — a fragment is never sent over \
+                 the wire: {target:?}"
+            ));
+        }
         // Userinfo would be echoed by the actuator endpoint and by the startup
         // log line. Refuse it rather than quietly publishing a credential; the
         // candidate should be reached without one, or behind something that
@@ -375,6 +394,37 @@ mod tests {
                 .expect_err(&format!("{bad} must be rejected"));
             assert!(error.contains("shadow.target"), "{error}");
         }
+    }
+
+    #[test]
+    fn a_target_carrying_a_query_or_fragment_is_rejected() {
+        // The request target is appended to the base, so a query on the base
+        // would swallow the mirrored path (`…?token=x/api/orders`) and a
+        // fragment is never sent at all — either way every mirrored request
+        // would silently reach the wrong resource.
+        for bad in [
+            "http://candidate/base?token=x",
+            "http://candidate#fragment",
+            "http://candidate/base?a=1#f",
+        ] {
+            let config = ShadowConfig {
+                enabled: true,
+                target: Some(bad.to_owned()),
+                ..ShadowConfig::default()
+            };
+            let error = config
+                .validate()
+                .expect_err(&format!("{bad} must be rejected"));
+            assert!(error.contains("shadow.target"), "{error}");
+        }
+
+        // A base *path* is legitimate — mounting the candidate under a prefix.
+        let config = ShadowConfig {
+            enabled: true,
+            target: Some("http://candidate/base".to_owned()),
+            ..ShadowConfig::default()
+        };
+        assert!(config.validate().is_ok());
     }
 
     #[test]

--- a/autumn/src/shadow/config.rs
+++ b/autumn/src/shadow/config.rs
@@ -1,0 +1,334 @@
+//! `[shadow]` configuration — traffic mirroring and response diffing (#1653).
+//!
+//! Off by default and inert until an operator sets both `enabled = true` and a
+//! `target`. Every knob here exists to bound the blast radius: mirroring copies
+//! production traffic, so the sample rate, the per-request deadline, the
+//! in-flight ceiling, and the capture budgets are all first-class config rather
+//! than hard-coded constants.
+//!
+//! ```toml
+//! [shadow]
+//! enabled        = true
+//! target         = "http://127.0.0.1:9091"   # the candidate build
+//! sample_rate    = 0.05                      # mirror 5 % of eligible traffic
+//! routes         = ["/api/*"]                # empty = every eligible route
+//! timeout_ms     = 2000
+//! max_in_flight  = 8
+//! ```
+
+use serde::Deserialize;
+
+/// Settings for mirroring live `GET`/`HEAD` traffic to a shadow build and
+/// diffing its responses against the live ones.
+///
+/// # Why the method set is not configurable
+///
+/// This slice mirrors idempotent traffic only. Replaying a `POST` against a
+/// candidate build would let the candidate's writes land for real — the effect
+/// virtualization that makes that safe is the deliberate follow-up slice. The
+/// method allowlist is therefore a compile-time constant
+/// ([`crate::shadow::sample::MIRRORABLE_METHODS`]), not a config key an
+/// operator can widen by accident.
+#[derive(Debug, Clone, Deserialize)]
+pub struct ShadowConfig {
+    /// Master switch. Default: `false`.
+    #[serde(default)]
+    pub enabled: bool,
+
+    /// Base URL of the candidate build that receives mirrored requests, e.g.
+    /// `"http://127.0.0.1:9091"`. Required once [`Self::enabled`] is `true`.
+    #[serde(default)]
+    pub target: Option<String>,
+
+    /// Fraction of *eligible* requests to mirror, `0.0`–`1.0`. Default: `1.0`.
+    ///
+    /// Eligibility (method, loop guard, route allowlist) is decided first, so
+    /// this samples what is left rather than all traffic.
+    #[serde(default = "default_sample_rate")]
+    pub sample_rate: f64,
+
+    /// Route patterns opted into mirroring. Empty (the default) means every
+    /// eligible route. A trailing `*` matches a prefix (`"/api/*"`); anything
+    /// else is an exact path match.
+    #[serde(default)]
+    pub routes: Vec<String>,
+
+    /// Wall-clock deadline for a single shadow request, in milliseconds.
+    /// A shadow that overruns it is abandoned and counted, never awaited by the
+    /// live request. Default: `2000`.
+    #[serde(default = "default_timeout_ms")]
+    pub timeout_ms: u64,
+
+    /// Ceiling on concurrently in-flight mirrored requests. Once reached,
+    /// further candidates are dropped (and counted) rather than queued, so a
+    /// slow shadow can never accumulate work. Default: `8`.
+    #[serde(default = "default_max_in_flight")]
+    pub max_in_flight: usize,
+
+    /// Largest response body, in bytes, either side will buffer for comparison.
+    /// A larger body is not compared at all (counted as skipped) — it is never
+    /// partially buffered. Default: 256 KiB.
+    #[serde(default = "default_max_body_bytes")]
+    pub max_body_bytes: usize,
+
+    /// How many recent divergences `{actuator-prefix}/shadow` keeps.
+    /// Default: `50`.
+    #[serde(default = "default_max_records")]
+    pub max_records: usize,
+
+    /// Budget, in characters, for each recorded JSON sample before it is
+    /// truncated. Default: `2048`.
+    #[serde(default = "default_max_sample_bytes")]
+    pub max_sample_bytes: usize,
+}
+
+impl Default for ShadowConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            target: None,
+            sample_rate: default_sample_rate(),
+            routes: Vec::new(),
+            timeout_ms: default_timeout_ms(),
+            max_in_flight: default_max_in_flight(),
+            max_body_bytes: default_max_body_bytes(),
+            max_records: default_max_records(),
+            max_sample_bytes: default_max_sample_bytes(),
+        }
+    }
+}
+
+impl ShadowConfig {
+    /// Validate the section.
+    ///
+    /// Returns `Ok(())` unmodified while [`Self::enabled`] is `false`: an
+    /// operator drafting a `[shadow]` block must be able to leave it
+    /// half-finished in the file without failing boot. Every check below is
+    /// therefore about a mirror that is actually about to run.
+    ///
+    /// # Errors
+    ///
+    /// Returns the human-readable reason the section cannot be honoured.
+    pub fn validate(&self) -> Result<(), String> {
+        if !self.enabled {
+            return Ok(());
+        }
+
+        let Some(target) = self
+            .target
+            .as_deref()
+            .map(str::trim)
+            .filter(|t| !t.is_empty())
+        else {
+            return Err(
+                "shadow.target is required when shadow.enabled = true — set it to the \
+                 candidate build's base URL, e.g. \"http://127.0.0.1:9091\""
+                    .to_owned(),
+            );
+        };
+        if !(target.starts_with("http://") || target.starts_with("https://")) {
+            return Err(format!(
+                "shadow.target must be an absolute http(s) URL, got {target:?}"
+            ));
+        }
+
+        if !self.sample_rate.is_finite() || !(0.0..=1.0).contains(&self.sample_rate) {
+            return Err(format!(
+                "shadow.sample_rate must be between 0.0 and 1.0, got {}",
+                self.sample_rate
+            ));
+        }
+
+        for (name, is_zero) in [
+            ("shadow.timeout_ms", self.timeout_ms == 0),
+            ("shadow.max_in_flight", self.max_in_flight == 0),
+            ("shadow.max_body_bytes", self.max_body_bytes == 0),
+            ("shadow.max_records", self.max_records == 0),
+            ("shadow.max_sample_bytes", self.max_sample_bytes == 0),
+        ] {
+            if is_zero {
+                return Err(format!("{name} must be greater than zero"));
+            }
+        }
+
+        Ok(())
+    }
+
+    /// The target base URL with any trailing `/` removed, so joining a request
+    /// target (which always starts with `/`) cannot produce a doubled slash.
+    ///
+    /// `None` when no target is configured.
+    #[must_use]
+    pub fn target_base(&self) -> Option<&str> {
+        self.target
+            .as_deref()
+            .map(str::trim)
+            .map(|target| target.strip_suffix('/').unwrap_or(target))
+            .filter(|target| !target.is_empty())
+    }
+
+    /// Whether mirroring should actually run: switched on *and* pointed
+    /// somewhere.
+    #[must_use]
+    pub fn is_active(&self) -> bool {
+        self.enabled && self.target_base().is_some()
+    }
+}
+
+const fn default_sample_rate() -> f64 {
+    1.0
+}
+
+const fn default_timeout_ms() -> u64 {
+    2000
+}
+
+const fn default_max_in_flight() -> usize {
+    8
+}
+
+const fn default_max_body_bytes() -> usize {
+    256 * 1024
+}
+
+const fn default_max_records() -> usize {
+    50
+}
+
+const fn default_max_sample_bytes() -> usize {
+    2048
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn disabled_by_default_with_no_target() {
+        let config = ShadowConfig::default();
+        assert!(!config.enabled);
+        assert!(config.target.is_none());
+        assert!(config.routes.is_empty());
+        assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn defaults_are_bounded() {
+        let config = ShadowConfig::default();
+        assert!(config.timeout_ms > 0);
+        assert!(config.max_in_flight > 0);
+        assert!(config.max_body_bytes > 0);
+        assert!(config.max_records > 0);
+        assert!(config.max_sample_bytes > 0);
+        assert!((config.sample_rate - 1.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn enabling_without_a_target_is_rejected() {
+        let config = ShadowConfig {
+            enabled: true,
+            ..ShadowConfig::default()
+        };
+        let error = config.validate().expect_err("must reject");
+        assert!(error.contains("shadow.target"), "{error}");
+    }
+
+    #[test]
+    fn target_must_be_an_absolute_http_url() {
+        for bad in ["localhost:9091", "ftp://host", "/relative", "  "] {
+            let config = ShadowConfig {
+                enabled: true,
+                target: Some(bad.to_owned()),
+                ..ShadowConfig::default()
+            };
+            assert!(
+                config.validate().is_err(),
+                "{bad} must be rejected as a shadow target"
+            );
+        }
+        let config = ShadowConfig {
+            enabled: true,
+            target: Some("http://127.0.0.1:9091".to_owned()),
+            ..ShadowConfig::default()
+        };
+        assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn sample_rate_must_be_a_probability() {
+        for bad in [-0.1, 1.1, f64::NAN] {
+            let config = ShadowConfig {
+                enabled: true,
+                target: Some("http://127.0.0.1:9091".to_owned()),
+                sample_rate: bad,
+                ..ShadowConfig::default()
+            };
+            assert!(
+                config.validate().is_err(),
+                "sample_rate {bad} must be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn zero_bounds_are_rejected() {
+        let base = ShadowConfig {
+            enabled: true,
+            target: Some("http://127.0.0.1:9091".to_owned()),
+            ..ShadowConfig::default()
+        };
+        for mutate in [
+            (|c: &mut ShadowConfig| c.timeout_ms = 0) as fn(&mut ShadowConfig),
+            |c: &mut ShadowConfig| c.max_in_flight = 0,
+            |c: &mut ShadowConfig| c.max_body_bytes = 0,
+            |c: &mut ShadowConfig| c.max_records = 0,
+            |c: &mut ShadowConfig| c.max_sample_bytes = 0,
+        ] {
+            let mut config = base.clone();
+            mutate(&mut config);
+            assert!(config.validate().is_err(), "a zero bound must be rejected");
+        }
+    }
+
+    #[test]
+    fn validation_is_skipped_while_disabled() {
+        // An operator may leave a half-finished `[shadow]` block in the file;
+        // it must not fail boot until they actually switch it on.
+        let config = ShadowConfig {
+            enabled: false,
+            target: Some("not-a-url".to_owned()),
+            sample_rate: 9.0,
+            ..ShadowConfig::default()
+        };
+        assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn deserializes_from_toml_with_partial_tables() {
+        let config: ShadowConfig = toml::from_str(
+            r#"
+            enabled = true
+            target = "http://127.0.0.1:9091"
+            sample_rate = 0.25
+            routes = ["/api/*"]
+            "#,
+        )
+        .expect("must parse");
+        assert!(config.enabled);
+        assert_eq!(config.target.as_deref(), Some("http://127.0.0.1:9091"));
+        assert!((config.sample_rate - 0.25).abs() < f64::EPSILON);
+        assert_eq!(config.routes, vec!["/api/*".to_owned()]);
+        // Unspecified keys still carry their bounded defaults.
+        assert_eq!(config.timeout_ms, ShadowConfig::default().timeout_ms);
+    }
+
+    #[test]
+    fn target_base_trims_a_trailing_slash() {
+        let config = ShadowConfig {
+            enabled: true,
+            target: Some("http://127.0.0.1:9091/".to_owned()),
+            ..ShadowConfig::default()
+        };
+        assert_eq!(config.target_base(), Some("http://127.0.0.1:9091"));
+    }
+}

--- a/autumn/src/shadow/diff.rs
+++ b/autumn/src/shadow/diff.rs
@@ -419,10 +419,7 @@ fn sample(body: &NormalizedBody, filter: &ParameterFilter, sample_limit: usize) 
     if rendered.len() <= sample_limit {
         return Some(scrubbed);
     }
-    Some(Value::String(truncate_to_serialized_budget(
-        &rendered,
-        sample_limit,
-    )))
+    truncate_to_serialized_budget(&rendered, sample_limit).map(Value::String)
 }
 
 /// Build the truncated excerpt so that the value's own **serialized** form fits
@@ -435,15 +432,16 @@ fn sample(body: &NormalizedBody, filter: &ParameterFilter, sample_limit: usize) 
 /// number the operator actually configured. So the cost is accumulated per
 /// character as it will be *written*, with the quotes and the marker reserved
 /// up front.
-fn truncate_to_serialized_budget(rendered: &str, sample_limit: usize) -> String {
+fn truncate_to_serialized_budget(rendered: &str, sample_limit: usize) -> Option<String> {
     /// The two `"` a JSON string is written between.
     const QUOTES: usize = 2;
 
     let reserved = QUOTES.saturating_add(TRUNCATION_MARKER.len());
-    // Not even the marker fits; the marker alone is the honest answer.
-    let Some(budget) = sample_limit.checked_sub(reserved) else {
-        return TRUNCATION_MARKER.to_owned();
-    };
+    // Not even the quoted marker fits. Returning it anyway would overshoot the
+    // budget by exactly the amount this function exists to prevent, so the
+    // honest answer is no sample at all — the record still carries the digest,
+    // the length, and how the body was normalized.
+    let budget = sample_limit.checked_sub(reserved)?;
 
     let mut truncated = String::new();
     let mut cost = 0usize;
@@ -455,7 +453,7 @@ fn truncate_to_serialized_budget(rendered: &str, sample_limit: usize) -> String 
         truncated.push(character);
     }
     truncated.push_str(TRUNCATION_MARKER);
-    truncated
+    Some(truncated)
 }
 
 /// How many bytes `character` occupies once written inside a JSON string.
@@ -986,19 +984,34 @@ mod tests {
     }
 
     #[test]
-    fn an_absurdly_small_budget_still_produces_something_valid() {
+    fn a_budget_too_small_for_the_marker_records_no_sample_at_all() {
+        // The quoted marker serializes to 5 bytes, so any budget below that
+        // cannot be honoured by emitting it — returning it anyway would
+        // overshoot by exactly what the budget exists to prevent. No sample is
+        // the honest answer; the digest and length still prove the divergence.
         let filter = ParameterFilter::default();
+        for limit in 0usize..=4 {
+            let Comparison::Diverged(d) =
+                compare(&json(200, r#"{"a":1}"#), &json(200, "{}"), &filter, limit)
+            else {
+                panic!("expected divergence at limit {limit}");
+            };
+            assert!(
+                d.primary_sample.is_none(),
+                "limit {limit}: recorded {:?}",
+                d.primary_sample
+            );
+            assert!(!d.primary_digest.is_empty());
+        }
+
+        // At 5 the quoted marker fits exactly, so a sample reappears.
         let Comparison::Diverged(d) =
-            compare(&json(200, r#"{"a":1}"#), &json(200, "{}"), &filter, 1)
+            compare(&json(200, r#"{"a":1}"#), &json(200, "{}"), &filter, 5)
         else {
             panic!("expected divergence");
         };
-        // Not required to fit a budget smaller than the marker itself, but it
-        // must still be a valid, obviously-truncated value rather than a panic.
-        let Some(Value::String(sample)) = d.primary_sample else {
-            panic!("expected a truncated string");
-        };
-        assert!(sample.ends_with(TRUNCATION_MARKER), "{sample}");
+        let serialized = serde_json::to_string(&d.primary_sample).expect("serializes");
+        assert!(serialized.len() <= 5, "{serialized}");
     }
 
     #[test]

--- a/autumn/src/shadow/diff.rs
+++ b/autumn/src/shadow/diff.rs
@@ -484,19 +484,16 @@ fn percent_decode(raw: &str) -> String {
         out.extend_from_slice(first);
     }
     for part in parts {
-        match (
+        if let (Some(high), Some(low)) = (
             part.first().copied().and_then(hex_value),
             part.get(1).copied().and_then(hex_value),
         ) {
-            (Some(high), Some(low)) => {
-                out.push(high.wrapping_shl(4) | low);
-                out.extend_from_slice(part.get(2..).unwrap_or_default());
-            }
+            out.push(high.wrapping_shl(4) | low);
+            out.extend_from_slice(part.get(2..).unwrap_or_default());
+        } else {
             // Not a valid escape — keep the `%` and the rest verbatim.
-            _ => {
-                out.push(b'%');
-                out.extend_from_slice(part);
-            }
+            out.push(b'%');
+            out.extend_from_slice(part);
         }
     }
     String::from_utf8_lossy(&out).into_owned()

--- a/autumn/src/shadow/diff.rs
+++ b/autumn/src/shadow/diff.rs
@@ -281,15 +281,15 @@ pub fn normalize_body(facts: &ResponseFacts) -> NormalizedBody {
         return NormalizedBody::Empty;
     }
 
-    let content_type = facts
-        .content_type
-        .as_deref()
-        .unwrap_or_default()
-        .to_ascii_lowercase();
-
-    if looks_like_json(&content_type, &facts.body)
-        && let Ok(value) = serde_json::from_slice::<Value>(&facts.body)
-    {
+    // NB: `facts.content_type` is deliberately unread. It is recorded for the
+    // operator's benefit and never consulted here — see the two branches below.
+    // Attempted on every body, with no content-type sniff in front of it. A
+    // sniff for `{`/`[` missed scalar JSON — `null`, `true`, `1`, `"ok"` — so a
+    // body that parsed as JSON on the labelled side fell through to `Text` on
+    // the unlabelled one, and a header-only difference became a body
+    // divergence. Parsing is the only symmetric test. A non-JSON body fails on
+    // its first byte, so this costs nothing on the common path.
+    if let Ok(value) = serde_json::from_slice::<Value>(&facts.body) {
         return NormalizedBody::Json(canonicalize(&value));
     }
 
@@ -305,16 +305,6 @@ pub fn normalize_body(facts: &ResponseFacts) -> NormalizedBody {
     }
 
     NormalizedBody::Bytes(facts.body.clone())
-}
-
-/// Whether this body is worth attempting to parse as JSON.
-fn looks_like_json(content_type: &str, body: &[u8]) -> bool {
-    if content_type.contains("json") {
-        return true;
-    }
-    body.iter()
-        .find(|byte| !byte.is_ascii_whitespace())
-        .is_some_and(|byte| matches!(byte, b'{' | b'['))
 }
 
 /// Fold `\r\n` to `\n` and trim the body's outer whitespace.
@@ -653,6 +643,43 @@ mod tests {
         let other = ResponseFacts::new(200, None, Bytes::from_static(b"goodbye"));
         assert!(matches!(
             compare(&labelled, &other, &filter, 2048),
+            Comparison::Diverged(_)
+        ));
+    }
+
+    #[test]
+    fn scalar_json_is_recognised_without_a_content_type() {
+        // `{`/`[` sniffing missed these, so a labelled side became `Json` while
+        // an unlabelled one became `Text` — a header-only difference surfacing
+        // as a body divergence.
+        let filter = ParameterFilter::default();
+        for body in ["null", "true", "1", "\"ok\"", "1.5"] {
+            let labelled = ResponseFacts::new(
+                200,
+                Some("application/json".to_owned()),
+                Bytes::from(body.to_owned()),
+            );
+            let unlabelled = ResponseFacts::new(200, None, Bytes::from(body.to_owned()));
+            assert!(
+                matches!(
+                    compare(&labelled, &unlabelled, &filter, 2048),
+                    Comparison::Match
+                ),
+                "scalar JSON body {body:?} diverged on a header-only difference"
+            );
+        }
+    }
+
+    #[test]
+    fn scalar_json_still_diverges_on_a_real_difference() {
+        let filter = ParameterFilter::default();
+        let scalar = |body: &str| ResponseFacts::new(200, None, Bytes::from(body.to_owned()));
+        assert!(matches!(
+            compare(&scalar("true"), &scalar("false"), &filter, 2048),
+            Comparison::Diverged(_)
+        ));
+        assert!(matches!(
+            compare(&scalar("1"), &scalar("2"), &filter, 2048),
             Comparison::Diverged(_)
         ));
     }

--- a/autumn/src/shadow/diff.rs
+++ b/autumn/src/shadow/diff.rs
@@ -384,25 +384,51 @@ fn fingerprint(
 
 /// Build the recorded excerpt for one side, or `None` when the body is not
 /// JSON (see the module docs on why non-JSON bodies are not sampled).
+///
+/// `sample_limit` is a budget in **bytes** of the serialized form, matching the
+/// `shadow.max_sample_bytes` config key: counting characters instead would let
+/// a body of multi-byte text store up to four times the nominal budget.
 fn sample(body: &NormalizedBody, filter: &ParameterFilter, sample_limit: usize) -> Option<Value> {
     let NormalizedBody::Json(value) = body else {
         return None;
     };
     let scrubbed = filter.scrub_json(value);
     let rendered = serde_json::to_string(&scrubbed).unwrap_or_default();
-    if rendered.chars().count() <= sample_limit {
+    if rendered.len() <= sample_limit {
         return Some(scrubbed);
     }
-    let mut truncated: String = rendered.chars().take(sample_limit).collect();
+    // Cut on a character boundary at or below the budget, so the excerpt is
+    // still valid UTF-8 and never exceeds what the operator asked for.
+    let cut = rendered
+        .char_indices()
+        .map(|(index, _)| index)
+        .take_while(|index| *index <= sample_limit)
+        .last()
+        .unwrap_or(0);
+    let mut truncated = String::with_capacity(cut.saturating_add(TRUNCATION_MARKER.len()));
+    truncated.push_str(rendered.get(..cut).unwrap_or_default());
     truncated.push_str(TRUNCATION_MARKER);
     Some(Value::String(truncated))
 }
 
 /// Redact a request target (`/path?query`) for recording.
 ///
-/// The path is kept verbatim — it is a route, not user data — while each query
-/// parameter whose name the filter matches is replaced with the filter's
-/// placeholder. Parameter order is preserved so the result stays deterministic.
+/// Each query parameter whose name the filter matches is replaced with the
+/// filter's placeholder; parameter order is preserved so the result stays
+/// deterministic.
+///
+/// Matching is done on the **percent-decoded** name and on each of its
+/// structural segments, mirroring how failure capsules redact a captured URL.
+/// Both matter: `?%74oken=…` hides a filtered name behind an encoding, and
+/// `?auth[access_token]=…` / `?filter.password=…` hide it inside a nested key
+/// that whole-string matching would miss. A parameter with no `=` is treated as
+/// a bare name and redacted to the placeholder when it matches, since
+/// `?SECRETVALUE`-style targets carry the secret in the name position.
+///
+/// The path itself is kept verbatim. It is the route, which is what makes a
+/// record actionable — but a path *can* carry user data
+/// (`/password-reset/{token}`), so the recorded target is only ever published
+/// on the sensitive actuator endpoint, never in the ordinary log stream.
 #[must_use]
 pub fn redact_path_and_query(target: &str, filter: &ParameterFilter) -> String {
     let Some((path, query)) = target.split_once('?') else {
@@ -411,13 +437,66 @@ pub fn redact_path_and_query(target: &str, filter: &ParameterFilter) -> String {
     let redacted: Vec<String> = query
         .split('&')
         .map(|pair| match pair.split_once('=') {
-            Some((key, _)) if filter.matches_key(key) => {
+            Some((key, _)) if key_is_filtered(key, filter) => {
                 format!("{key}={}", crate::log::filter::FILTERED_PLACEHOLDER)
+            }
+            None if !pair.is_empty() && key_is_filtered(pair, filter) => {
+                crate::log::filter::FILTERED_PLACEHOLDER.to_owned()
             }
             _ => pair.to_owned(),
         })
         .collect();
     format!("{path}?{}", redacted.join("&"))
+}
+
+/// Whether a raw query-parameter name should be filtered.
+///
+/// Checks the name as written, its percent-decoded form, and every structural
+/// segment of that decoded form (`a[b]` and `a.b` both yield `a` and `b`).
+fn key_is_filtered(raw_key: &str, filter: &ParameterFilter) -> bool {
+    if filter.matches_key(raw_key) {
+        return true;
+    }
+    let decoded = percent_decode(raw_key);
+    if filter.matches_key(&decoded) {
+        return true;
+    }
+    decoded
+        .split(['[', ']', '.'])
+        .any(|segment| !segment.is_empty() && filter.matches_key(segment))
+}
+
+/// Percent-decode a query-parameter name, treating `+` as a space.
+///
+/// Undecodable bytes are passed through as written: this feeds a filter-name
+/// comparison, so a best-effort decode that never fails is the right shape.
+fn percent_decode(raw: &str) -> String {
+    let bytes = raw.replace('+', " ").into_bytes();
+    let mut out = Vec::with_capacity(bytes.len());
+    let mut index = 0;
+    while let Some(byte) = bytes.get(index) {
+        if *byte == b'%'
+            && let (Some(high), Some(low)) = (bytes.get(index + 1), bytes.get(index + 2))
+            && let (Some(high), Some(low)) = (hex_value(*high), hex_value(*low))
+        {
+            out.push((high << 4) | low);
+            index += 3;
+            continue;
+        }
+        out.push(*byte);
+        index += 1;
+    }
+    String::from_utf8_lossy(&out).into_owned()
+}
+
+/// The numeric value of one ASCII hex digit.
+const fn hex_value(byte: u8) -> Option<u8> {
+    match byte {
+        b'0'..=b'9' => Some(byte - b'0'),
+        b'a'..=b'f' => Some(byte - b'a' + 10),
+        b'A'..=b'F' => Some(byte - b'A' + 10),
+        _ => None,
+    }
 }
 
 #[cfg(test)]
@@ -564,18 +643,99 @@ mod tests {
     }
 
     #[test]
-    fn oversized_samples_are_truncated() {
+    fn oversized_samples_are_truncated_to_the_byte_budget() {
         let filter = ParameterFilter::default();
         let big = format!(r#"{{"blob":"{}"}}"#, "x".repeat(4096));
         let Comparison::Diverged(d) = compare(&json(200, &big), &json(200, "{}"), &filter, 64)
         else {
             panic!("expected divergence");
         };
-        let rendered = serde_json::to_string(&d.primary_sample).unwrap();
+        let Some(Value::String(sample)) = d.primary_sample else {
+            panic!("a truncated sample is recorded as a string");
+        };
+        assert!(sample.ends_with(TRUNCATION_MARKER), "{sample}");
+        let body = sample.strip_suffix(TRUNCATION_MARKER).expect("marker");
         assert!(
-            rendered.len() < 512,
-            "sample must be truncated: {}",
-            rendered.len()
+            body.len() <= 64,
+            "sample body is {} bytes, budget was 64",
+            body.len()
+        );
+    }
+
+    #[test]
+    fn the_sample_budget_is_bytes_not_characters() {
+        let filter = ParameterFilter::default();
+        // Each `€` is three UTF-8 bytes. Counting characters would let this
+        // store roughly three times the operator's nominal budget.
+        let wide = format!(r#"{{"note":"{}"}}"#, "€".repeat(200));
+        let Comparison::Diverged(d) = compare(&json(200, &wide), &json(200, "{}"), &filter, 64)
+        else {
+            panic!("expected divergence");
+        };
+        let Some(Value::String(sample)) = d.primary_sample else {
+            panic!("a truncated sample is recorded as a string");
+        };
+        let body = sample.strip_suffix(TRUNCATION_MARKER).expect("marker");
+        assert!(body.len() <= 64, "{} bytes exceeds the budget", body.len());
+    }
+
+    #[test]
+    fn both_samples_are_redacted_not_just_the_primary() {
+        let filter = ParameterFilter::default();
+        let a = json(200, r#"{"id":1,"password":"hunter2","total":1}"#);
+        let b = json(200, r#"{"id":2,"password":"hunter2"}"#);
+        let Comparison::Diverged(d) = compare(&a, &b, &filter, 2048) else {
+            panic!("expected divergence");
+        };
+        for (side, sample) in [("primary", &d.primary_sample), ("shadow", &d.shadow_sample)] {
+            let rendered = serde_json::to_string(sample).unwrap();
+            assert!(
+                !rendered.contains("hunter2"),
+                "{side} sample leaked a filtered value: {rendered}"
+            );
+        }
+    }
+
+    #[test]
+    fn redaction_sees_through_percent_encoded_parameter_names() {
+        let filter = ParameterFilter::default();
+        assert_eq!(
+            redact_path_and_query("/x?%74oken=abc123", &filter),
+            "/x?%74oken=[FILTERED]"
+        );
+    }
+
+    #[test]
+    fn redaction_sees_into_nested_parameter_names() {
+        let filter = ParameterFilter::default();
+        for (raw, expected) in [
+            (
+                "/x?auth[access_token]=s",
+                "/x?auth[access_token]=[FILTERED]",
+            ),
+            ("/x?filter.password=s", "/x?filter.password=[FILTERED]"),
+            ("/x?auth%5Bapi_key%5D=s", "/x?auth%5Bapi_key%5D=[FILTERED]"),
+        ] {
+            assert_eq!(redact_path_and_query(raw, &filter), expected, "{raw}");
+        }
+    }
+
+    #[test]
+    fn a_valueless_parameter_that_names_a_secret_is_redacted() {
+        let filter = ParameterFilter::default();
+        assert_eq!(
+            redact_path_and_query("/reset?token", &filter),
+            "/reset?[FILTERED]"
+        );
+        assert_eq!(redact_path_and_query("/list?debug", &filter), "/list?debug");
+    }
+
+    #[test]
+    fn redaction_preserves_unrelated_parameters_and_their_order() {
+        let filter = ParameterFilter::default();
+        assert_eq!(
+            redact_path_and_query("/x?a=1&token=t&b=2", &filter),
+            "/x?a=1&token=[FILTERED]&b=2"
         );
     }
 

--- a/autumn/src/shadow/diff.rs
+++ b/autumn/src/shadow/diff.rs
@@ -26,11 +26,14 @@
 //!
 //! Recorded samples pass through [`ParameterFilter`] — the same filter the
 //! access log, error pages, and failure capsules use, driven by the same
-//! `[log] filter_parameters` / `[log] unfilter_parameters` config. Only **JSON**
-//! bodies are sampled: a JSON body has named keys the filter can reason about,
-//! whereas an HTML or binary body does not, so for those only a digest, a
-//! length, and the content type are recorded. A divergence is still reported —
-//! just without a body excerpt that no redaction rule could vet.
+//! `[log] filter_parameters` / `[log] unfilter_parameters` config.
+//!
+//! That filter redacts by **key name**, so an excerpt is recorded only when
+//! every scalar in the body sits under one. An HTML or binary body has no keys;
+//! neither does a bare scalar (a `text/plain` one-time code parses as a JSON
+//! number) nor an array of bare strings. Those record a digest, a length, and
+//! how the body was normalized. A divergence is still reported — just without a
+//! body excerpt that no redaction rule could vet.
 
 // autumn-panic-gate: request-path module — production code path must be panic-free.
 // See CONTRIBUTING.md "Request-path panic gate". Justify exceptions with
@@ -378,6 +381,14 @@ fn sample(body: &NormalizedBody, filter: &ParameterFilter, sample_limit: usize) 
     let NormalizedBody::Json(value) = body else {
         return None;
     };
+    // Parsing as JSON is not on its own a licence to record. `ParameterFilter`
+    // redacts by KEY NAME, so a value only has protection if it sits under one:
+    // a `text/plain` six-digit OTP parses as a JSON number, and a bare scalar —
+    // or a scalar inside an array — offers the filter nothing to match. Those
+    // record a digest and a length like any other unsamplable body.
+    if !scalars_are_all_keyed(value) {
+        return None;
+    }
     let scrubbed = filter.scrub_json(value);
     let rendered = serde_json::to_string(&scrubbed).unwrap_or_default();
     if rendered.len() <= sample_limit {
@@ -395,6 +406,25 @@ fn sample(body: &NormalizedBody, filter: &ParameterFilter, sample_limit: usize) 
     truncated.push_str(rendered.get(..cut).unwrap_or_default());
     truncated.push_str(TRUNCATION_MARKER);
     Some(Value::String(truncated))
+}
+
+/// Whether every scalar in `value` sits under an object key, and is therefore
+/// something [`ParameterFilter`] can be asked about.
+///
+/// A scalar at the top level, or as an array element, has no key above it — no
+/// redaction rule can vet it, so a body containing one is not sampled at all.
+/// An array *of objects* is fine: each scalar inside them is keyed.
+fn scalars_are_all_keyed(value: &Value) -> bool {
+    match value {
+        // Nothing above this to name it.
+        Value::Null | Value::Bool(_) | Value::Number(_) | Value::String(_) => false,
+        Value::Array(items) => items.iter().all(scalars_are_all_keyed),
+        Value::Object(map) => map.values().all(|child| match child {
+            // Directly under a key: the filter can match it.
+            Value::Null | Value::Bool(_) | Value::Number(_) | Value::String(_) => true,
+            nested => scalars_are_all_keyed(nested),
+        }),
+    }
 }
 
 /// Redact a request target (`/path?query`) for recording.
@@ -668,6 +698,75 @@ mod tests {
                 "scalar JSON body {body:?} diverged on a header-only difference"
             );
         }
+    }
+
+    #[test]
+    fn a_scalar_body_is_never_sampled_however_it_is_labelled() {
+        // A `text/plain` six-digit OTP parses as a JSON number. Comparing it
+        // structurally is right; RECORDING it is not — `ParameterFilter`
+        // redacts by key name, and a bare scalar gives it nothing to match.
+        let filter = ParameterFilter::default();
+        for (content_type, body) in [
+            (Some("text/plain".to_owned()), "482913"),
+            (Some("application/json".to_owned()), "482913"),
+            (Some("application/json".to_owned()), "\"a-bearer-token\""),
+            (None, "482913"),
+        ] {
+            let primary = ResponseFacts::new(200, content_type.clone(), Bytes::from(body));
+            let shadow = ResponseFacts::new(200, content_type, Bytes::from_static(b"0"));
+            let Comparison::Diverged(d) = compare(&primary, &shadow, &filter, 2048) else {
+                panic!("expected divergence for {body}");
+            };
+            assert!(
+                d.primary_sample.is_none(),
+                "a scalar body must record a digest only, got a sample for {body}"
+            );
+            assert!(!d.primary_digest.is_empty());
+        }
+    }
+
+    #[test]
+    fn an_array_of_bare_scalars_is_not_sampled_either() {
+        // Array elements have no key above them, so the filter cannot vet them.
+        let filter = ParameterFilter::default();
+        let list = |body: &str| {
+            ResponseFacts::new(
+                200,
+                Some("application/json".to_owned()),
+                Bytes::from(body.to_owned()),
+            )
+        };
+        let Comparison::Diverged(d) =
+            compare(&list(r#"["a-bearer-token"]"#), &list("[]"), &filter, 2048)
+        else {
+            panic!("expected divergence");
+        };
+        assert!(d.primary_sample.is_none());
+    }
+
+    #[test]
+    fn keyed_bodies_are_still_sampled_including_arrays_of_objects() {
+        // The common shape must keep its excerpt: every scalar here sits under
+        // a key the filter can be asked about.
+        let filter = ParameterFilter::default();
+        let json_body = |body: &str| {
+            ResponseFacts::new(
+                200,
+                Some("application/json".to_owned()),
+                Bytes::from(body.to_owned()),
+            )
+        };
+        let Comparison::Diverged(d) = compare(
+            &json_body(r#"[{"id":1,"password":"hunter2"},{"id":2}]"#),
+            &json_body("[]"),
+            &filter,
+            2048,
+        ) else {
+            panic!("expected divergence");
+        };
+        let rendered = serde_json::to_string(&d.primary_sample).unwrap();
+        assert!(rendered.contains("[FILTERED]"), "{rendered}");
+        assert!(!rendered.contains("hunter2"), "{rendered}");
     }
 
     #[test]

--- a/autumn/src/shadow/diff.rs
+++ b/autumn/src/shadow/diff.rs
@@ -77,6 +77,13 @@ pub struct ResponseFacts {
     pub status: u16,
     /// `Content-Type` header value, when the build sent one.
     pub content_type: Option<String>,
+    /// `Content-Encoding` header value, when the build sent one.
+    ///
+    /// A handler may serve a precompressed representation, in which case the
+    /// bytes here are encoded — on **either** side. Both are decoded before
+    /// comparison; decoding only one would report identical builds as
+    /// divergent.
+    pub content_encoding: Option<String>,
     /// Response body bytes, already bounded by the mirror's capture budget.
     pub body: Bytes,
 }
@@ -88,6 +95,23 @@ impl ResponseFacts {
         Self {
             status,
             content_type,
+            content_encoding: None,
+            body,
+        }
+    }
+
+    /// Construct facts for a body that arrived under a `Content-Encoding`.
+    #[must_use]
+    pub const fn encoded(
+        status: u16,
+        content_type: Option<String>,
+        content_encoding: Option<String>,
+        body: Bytes,
+    ) -> Self {
+        Self {
+            status,
+            content_type,
+            content_encoding,
             body,
         }
     }
@@ -395,18 +419,54 @@ fn sample(body: &NormalizedBody, filter: &ParameterFilter, sample_limit: usize) 
     if rendered.len() <= sample_limit {
         return Some(scrubbed);
     }
-    // Cut on a character boundary at or below the budget, so the excerpt is
-    // still valid UTF-8 and never exceeds what the operator asked for.
-    let cut = rendered
-        .char_indices()
-        .map(|(index, _)| index)
-        .take_while(|index| *index <= sample_limit)
-        .last()
-        .unwrap_or(0);
-    let mut truncated = String::with_capacity(cut.saturating_add(TRUNCATION_MARKER.len()));
-    truncated.push_str(rendered.get(..cut).unwrap_or_default());
+    Some(Value::String(truncate_to_serialized_budget(
+        &rendered,
+        sample_limit,
+    )))
+}
+
+/// Build the truncated excerpt so that the value's own **serialized** form fits
+/// in `sample_limit` bytes.
+///
+/// Cutting the source string at the budget is not enough: the result is stored
+/// as a JSON string, so serializing it adds the surrounding quotes and escapes
+/// every `"`, `\` and control character already in the prefix. A prefix taken
+/// at exactly the budget can therefore serialize to well over it — which is the
+/// number the operator actually configured. So the cost is accumulated per
+/// character as it will be *written*, with the quotes and the marker reserved
+/// up front.
+fn truncate_to_serialized_budget(rendered: &str, sample_limit: usize) -> String {
+    /// The two `"` a JSON string is written between.
+    const QUOTES: usize = 2;
+
+    let reserved = QUOTES.saturating_add(TRUNCATION_MARKER.len());
+    // Not even the marker fits; the marker alone is the honest answer.
+    let Some(budget) = sample_limit.checked_sub(reserved) else {
+        return TRUNCATION_MARKER.to_owned();
+    };
+
+    let mut truncated = String::new();
+    let mut cost = 0usize;
+    for character in rendered.chars() {
+        cost = cost.saturating_add(serialized_len(character));
+        if cost > budget {
+            break;
+        }
+        truncated.push(character);
+    }
     truncated.push_str(TRUNCATION_MARKER);
-    Some(Value::String(truncated))
+    truncated
+}
+
+/// How many bytes `character` occupies once written inside a JSON string.
+const fn serialized_len(character: char) -> usize {
+    match character {
+        // Escaped as a two-character sequence.
+        '"' | '\\' | '\n' | '\r' | '\t' | '\u{8}' | '\u{c}' => 2,
+        // Every other control character becomes `\u00XX`.
+        c if (c as u32) < 0x20 => 6,
+        c => c.len_utf8(),
+    }
 }
 
 /// Whether every scalar in `value` has an object key somewhere above it, and is
@@ -545,6 +605,7 @@ mod tests {
         ResponseFacts {
             status,
             content_type: Some("application/json".to_owned()),
+            content_encoding: None,
             body: Bytes::from(body.to_owned()),
         }
     }
@@ -644,6 +705,7 @@ mod tests {
         let html = |body: &str| ResponseFacts {
             status: 200,
             content_type: Some("text/html; charset=utf-8".to_owned()),
+            content_encoding: None,
             body: Bytes::from(body.to_owned()),
         };
         let Comparison::Diverged(d) = compare(
@@ -866,6 +928,7 @@ mod tests {
         let text = |body: &str| ResponseFacts {
             status: 200,
             content_type: Some("text/plain".to_owned()),
+            content_encoding: None,
             body: Bytes::from(body.to_owned()),
         };
         assert!(matches!(
@@ -897,6 +960,45 @@ mod tests {
             "sample body is {} bytes, budget was 64",
             body.len()
         );
+    }
+
+    #[test]
+    fn a_truncated_sample_fits_its_budget_once_serialized() {
+        // The excerpt is stored as a JSON string, so serializing re-adds the
+        // quotes and escapes every quote and backslash in the prefix. Cutting
+        // the source at the budget therefore overshoots the number the operator
+        // configured.
+        let filter = ParameterFilter::default();
+        let quoted = format!(r#"{{"blob":"{}"}}"#, "a\"b\\c".repeat(400));
+        for limit in [8usize, 16, 64, 512] {
+            let Comparison::Diverged(d) =
+                compare(&json(200, &quoted), &json(200, "{}"), &filter, limit)
+            else {
+                panic!("expected divergence at limit {limit}");
+            };
+            let serialized = serde_json::to_string(&d.primary_sample).expect("sample serializes");
+            assert!(
+                serialized.len() <= limit,
+                "limit {limit}: serialized sample is {} bytes: {serialized}",
+                serialized.len()
+            );
+        }
+    }
+
+    #[test]
+    fn an_absurdly_small_budget_still_produces_something_valid() {
+        let filter = ParameterFilter::default();
+        let Comparison::Diverged(d) =
+            compare(&json(200, r#"{"a":1}"#), &json(200, "{}"), &filter, 1)
+        else {
+            panic!("expected divergence");
+        };
+        // Not required to fit a budget smaller than the marker itself, but it
+        // must still be a valid, obviously-truncated value rather than a panic.
+        let Some(Value::String(sample)) = d.primary_sample else {
+            panic!("expected a truncated string");
+        };
+        assert!(sample.ends_with(TRUNCATION_MARKER), "{sample}");
     }
 
     #[test]
@@ -982,6 +1084,7 @@ mod tests {
         let head = || ResponseFacts {
             status: 204,
             content_type: None,
+            content_encoding: None,
             body: Bytes::new(),
         };
         assert!(matches!(

--- a/autumn/src/shadow/diff.rs
+++ b/autumn/src/shadow/diff.rs
@@ -293,9 +293,14 @@ pub fn normalize_body(facts: &ResponseFacts) -> NormalizedBody {
         return NormalizedBody::Json(canonicalize(&value));
     }
 
-    if is_textual(&content_type)
-        && let Ok(text) = std::str::from_utf8(&facts.body)
-    {
+    // UTF-8 decides this, NOT the content type. Headers are explicitly outside
+    // the comparison contract, so two builds returning the identical bytes
+    // `hello` must not diverge merely because only one of them said
+    // `text/plain` — that would put a header back inside the contract through
+    // the back door, as a difference in normalized *form* rather than in
+    // content. A genuinely binary body is not valid UTF-8 and still lands in
+    // `Bytes`.
+    if let Ok(text) = std::str::from_utf8(&facts.body) {
         return NormalizedBody::Text(normalize_text(text));
     }
 
@@ -310,15 +315,6 @@ fn looks_like_json(content_type: &str, body: &[u8]) -> bool {
     body.iter()
         .find(|byte| !byte.is_ascii_whitespace())
         .is_some_and(|byte| matches!(byte, b'{' | b'['))
-}
-
-/// Whether a content type describes text whose whitespace can be normalized.
-fn is_textual(content_type: &str) -> bool {
-    content_type.starts_with("text/")
-        || content_type.contains("xml")
-        || content_type.contains("javascript")
-        || content_type.contains("csv")
-        || content_type.contains("x-www-form-urlencoded")
 }
 
 /// Fold `\r\n` to `\n` and trim the body's outer whitespace.
@@ -635,6 +631,50 @@ mod tests {
         assert!(d.primary_sample.is_none());
         assert!(d.shadow_sample.is_none());
         assert_ne!(d.primary_digest, d.shadow_digest);
+    }
+
+    #[test]
+    fn identical_bytes_do_not_diverge_because_only_one_side_named_a_content_type() {
+        // Headers are outside the comparison contract, so a header difference
+        // must not reappear as a difference in normalized *form*.
+        let filter = ParameterFilter::default();
+        let labelled = ResponseFacts::new(
+            200,
+            Some("text/plain".to_owned()),
+            Bytes::from_static(b"hello"),
+        );
+        let unlabelled = ResponseFacts::new(200, None, Bytes::from_static(b"hello"));
+        assert!(matches!(
+            compare(&labelled, &unlabelled, &filter, 2048),
+            Comparison::Match
+        ));
+
+        // ...and a genuinely different body still diverges.
+        let other = ResponseFacts::new(200, None, Bytes::from_static(b"goodbye"));
+        assert!(matches!(
+            compare(&labelled, &other, &filter, 2048),
+            Comparison::Diverged(_)
+        ));
+    }
+
+    #[test]
+    fn a_body_that_is_not_utf8_is_compared_byte_for_byte() {
+        let filter = ParameterFilter::default();
+        let png = |trailer: u8| {
+            ResponseFacts::new(
+                200,
+                Some("image/png".to_owned()),
+                Bytes::from(vec![0x89, b'P', b'N', b'G', 0xFF, trailer]),
+            )
+        };
+        assert!(matches!(
+            compare(&png(1), &png(1), &filter, 2048),
+            Comparison::Match
+        ));
+        assert!(matches!(
+            compare(&png(1), &png(2), &filter, 2048),
+            Comparison::Diverged(_)
+        ));
     }
 
     #[test]

--- a/autumn/src/shadow/diff.rs
+++ b/autumn/src/shadow/diff.rs
@@ -470,31 +470,48 @@ fn key_is_filtered(raw_key: &str, filter: &ParameterFilter) -> bool {
 ///
 /// Undecodable bytes are passed through as written: this feeds a filter-name
 /// comparison, so a best-effort decode that never fails is the right shape.
+///
+/// Written as a split over `%` rather than an index walk so it carries no
+/// cursor arithmetic at all — this module is on the request path and its panic
+/// gate denies arithmetic that could overflow.
 fn percent_decode(raw: &str) -> String {
-    let bytes = raw.replace('+', " ").into_bytes();
-    let mut out = Vec::with_capacity(bytes.len());
-    let mut index = 0;
-    while let Some(byte) = bytes.get(index) {
-        if *byte == b'%'
-            && let (Some(high), Some(low)) = (bytes.get(index + 1), bytes.get(index + 2))
-            && let (Some(high), Some(low)) = (hex_value(*high), hex_value(*low))
-        {
-            out.push((high << 4) | low);
-            index += 3;
-            continue;
+    let replaced = raw.replace('+', " ");
+    let mut out: Vec<u8> = Vec::with_capacity(replaced.len());
+    let mut parts = replaced.as_bytes().split(|byte| *byte == b'%');
+
+    // Everything before the first `%` is literal.
+    if let Some(first) = parts.next() {
+        out.extend_from_slice(first);
+    }
+    for part in parts {
+        match (
+            part.first().copied().and_then(hex_value),
+            part.get(1).copied().and_then(hex_value),
+        ) {
+            (Some(high), Some(low)) => {
+                out.push(high.wrapping_shl(4) | low);
+                out.extend_from_slice(part.get(2..).unwrap_or_default());
+            }
+            // Not a valid escape — keep the `%` and the rest verbatim.
+            _ => {
+                out.push(b'%');
+                out.extend_from_slice(part);
+            }
         }
-        out.push(*byte);
-        index += 1;
     }
     String::from_utf8_lossy(&out).into_owned()
 }
 
 /// The numeric value of one ASCII hex digit.
+///
+/// The `wrapping_*` calls cannot wrap — each arm's range guarantees the
+/// subtraction is in bounds — but they say so without arithmetic this module's
+/// panic gate has to take on faith.
 const fn hex_value(byte: u8) -> Option<u8> {
     match byte {
-        b'0'..=b'9' => Some(byte - b'0'),
-        b'a'..=b'f' => Some(byte - b'a' + 10),
-        b'A'..=b'F' => Some(byte - b'A' + 10),
+        b'0'..=b'9' => Some(byte.wrapping_sub(b'0')),
+        b'a'..=b'f' => Some(byte.wrapping_sub(b'a').wrapping_add(10)),
+        b'A'..=b'F' => Some(byte.wrapping_sub(b'A').wrapping_add(10)),
         _ => None,
     }
 }

--- a/autumn/src/shadow/diff.rs
+++ b/autumn/src/shadow/diff.rs
@@ -1,0 +1,641 @@
+//! Pure primary-vs-shadow response comparison (issue #1653).
+//!
+//! Everything in this module is a **pure function of its inputs**: no clock, no
+//! randomness, no I/O. That is what makes the acceptance criterion "divergence
+//! recording is deterministic and reproducible for a captured request" testable
+//! — feed [`compare`] the same two [`ResponseFacts`] and it yields a
+//! byte-identical [`Divergence`], fingerprint included. The registry
+//! ([`crate::shadow::ShadowRegistry`]) stamps the wall-clock time, so the
+//! comparison itself never varies.
+//!
+//! # What is compared
+//!
+//! Exactly two things, per the first slice's scope:
+//!
+//! 1. **Status class** — `2xx` vs `5xx` diverges; `200` vs `201` does not.
+//! 2. **Normalized body** — see [`normalize_body`]. JSON object key order is
+//!    normalized away (two builds serialising the same map differently are not
+//!    a regression); **array order is preserved**, because a reordered list is
+//!    precisely the kind of subtly-wrong-but-`200` response this feature
+//!    exists to catch.
+//!
+//! Headers, latency, and fuzzy/semantic JSON tolerance are deliberately out of
+//! scope.
+//!
+//! # PII
+//!
+//! Recorded samples pass through [`ParameterFilter`] — the same filter the
+//! access log, error pages, and failure capsules use, driven by the same
+//! `[log] filter_parameters` / `[log] unfilter_parameters` config. Only **JSON**
+//! bodies are sampled: a JSON body has named keys the filter can reason about,
+//! whereas an HTML or binary body does not, so for those only a digest, a
+//! length, and the content type are recorded. A divergence is still reported —
+//! just without a body excerpt that no redaction rule could vet.
+
+// autumn-panic-gate: request-path module — production code path must be panic-free.
+// See CONTRIBUTING.md "Request-path panic gate". Justify exceptions with
+// #[allow(clippy::<lint>, reason = "…")] at the narrowest scope.
+#![cfg_attr(
+    not(test),
+    deny(
+        clippy::unwrap_used,
+        clippy::expect_used,
+        clippy::panic,
+        clippy::unreachable,
+        clippy::todo,
+        clippy::unimplemented,
+        clippy::indexing_slicing,
+        clippy::string_slice,
+        clippy::arithmetic_side_effects,
+    )
+)]
+
+use bytes::Bytes;
+use serde::Serialize;
+use serde_json::{Map, Value};
+use sha2::{Digest, Sha256};
+
+use crate::log::filter::ParameterFilter;
+
+/// Placeholder appended to a sample that was cut short by the sample budget.
+pub const TRUNCATION_MARKER: &str = "…";
+
+/// The facts about one side of a comparison: what a build returned for a
+/// mirrored request.
+///
+/// Deliberately not a `http::Response` — the shadow side never becomes a
+/// response object at all (it is read out of the transport and dropped), and
+/// keeping both sides in one plain struct is what lets [`compare`] be pure and
+/// re-runnable from a recorded capture.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ResponseFacts {
+    /// HTTP status code as returned by that build.
+    pub status: u16,
+    /// `Content-Type` header value, when the build sent one.
+    pub content_type: Option<String>,
+    /// Response body bytes, already bounded by the mirror's capture budget.
+    pub body: Bytes,
+}
+
+impl ResponseFacts {
+    /// Construct facts for a body that is already in memory.
+    #[must_use]
+    pub const fn new(status: u16, content_type: Option<String>, body: Bytes) -> Self {
+        Self {
+            status,
+            content_type,
+            body,
+        }
+    }
+}
+
+/// A response body reduced to the form the comparison actually operates on.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum NormalizedBody {
+    /// No bytes at all (a `HEAD` or `204`, say).
+    Empty,
+    /// A parsed JSON document with every object's keys in sorted order.
+    Json(Value),
+    /// UTF-8 text with `\r\n` folded to `\n` and outer whitespace trimmed.
+    Text(String),
+    /// Anything else: compared byte-for-byte.
+    Bytes(Bytes),
+}
+
+impl NormalizedBody {
+    /// The canonical byte encoding this body digests to.
+    #[must_use]
+    fn canonical_bytes(&self) -> Vec<u8> {
+        match self {
+            Self::Empty => Vec::new(),
+            // Canonicalisation already sorted every object's keys, so
+            // `to_string` is stable regardless of whether `serde_json` was
+            // compiled with `preserve_order`.
+            Self::Json(value) => serde_json::to_vec(value).unwrap_or_default(),
+            Self::Text(text) => text.as_bytes().to_vec(),
+            Self::Bytes(bytes) => bytes.to_vec(),
+        }
+    }
+
+    /// The tag recorded alongside a digest so a reader can tell *how* the two
+    /// sides were compared.
+    #[must_use]
+    const fn kind_label(&self) -> &'static str {
+        match self {
+            Self::Empty => "empty",
+            Self::Json(_) => "json",
+            Self::Text(_) => "text",
+            Self::Bytes(_) => "bytes",
+        }
+    }
+}
+
+/// Which of the two compared dimensions disagreed.
+///
+/// A response can of course diverge on both; the status class is reported in
+/// that case because it is the coarser (and more actionable) signal.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DivergenceKind {
+    /// The two builds returned different status *classes* (`status / 100`).
+    StatusClass,
+    /// Same status class, different normalized body.
+    Body,
+}
+
+impl DivergenceKind {
+    /// Stable lowercase name, used as a metric label value.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::StatusClass => "status_class",
+            Self::Body => "body",
+        }
+    }
+}
+
+/// One recorded disagreement between the live build and the candidate.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+pub struct Divergence {
+    /// Which dimension disagreed.
+    pub kind: DivergenceKind,
+    /// Status the live build returned.
+    pub primary_status: u16,
+    /// Status the shadow build returned.
+    pub shadow_status: u16,
+    /// How the live body was normalized before digesting (`json`/`text`/…).
+    pub primary_body_kind: &'static str,
+    /// How the shadow body was normalized before digesting.
+    pub shadow_body_kind: &'static str,
+    /// Bytes in the live body as captured.
+    pub primary_body_bytes: usize,
+    /// Bytes in the shadow body as captured.
+    pub shadow_body_bytes: usize,
+    /// Hex SHA-256 of the live body's canonical encoding.
+    pub primary_digest: String,
+    /// Hex SHA-256 of the shadow body's canonical encoding.
+    pub shadow_digest: String,
+    /// Redacted, budget-bounded excerpt of the live body — JSON bodies only.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub primary_sample: Option<Value>,
+    /// Redacted, budget-bounded excerpt of the shadow body — JSON bodies only.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub shadow_sample: Option<Value>,
+    /// Content-addressed identity of this divergence: the same captured pair
+    /// always yields the same value, so repeat occurrences collapse and an
+    /// operator can quote one in a bug report.
+    pub fingerprint: String,
+}
+
+/// The result of comparing one mirrored request's two responses.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum Comparison {
+    /// The two builds agree on status class and normalized body.
+    Match,
+    /// They disagree; the boxed record is what gets reported.
+    Diverged(Box<Divergence>),
+}
+
+impl Comparison {
+    /// Metric-label value for this outcome.
+    #[must_use]
+    pub const fn outcome_label(&self) -> &'static str {
+        match self {
+            Self::Match => "match",
+            Self::Diverged(_) => "diverged",
+        }
+    }
+}
+
+/// Compare a primary response against its shadow.
+///
+/// `sample_limit` bounds the serialized length of each recorded JSON sample;
+/// anything longer is replaced by a truncated string ending in
+/// [`TRUNCATION_MARKER`].
+#[must_use]
+pub fn compare(
+    primary: &ResponseFacts,
+    shadow: &ResponseFacts,
+    filter: &ParameterFilter,
+    sample_limit: usize,
+) -> Comparison {
+    let primary_body = normalize_body(primary);
+    let shadow_body = normalize_body(shadow);
+
+    let status_class_differs = status_class(primary.status) != status_class(shadow.status);
+    let body_differs = primary_body != shadow_body;
+
+    if !status_class_differs && !body_differs {
+        return Comparison::Match;
+    }
+
+    let kind = if status_class_differs {
+        DivergenceKind::StatusClass
+    } else {
+        DivergenceKind::Body
+    };
+
+    let primary_digest = digest(&primary_body);
+    let shadow_digest = digest(&shadow_body);
+    let fingerprint = fingerprint(
+        kind,
+        primary.status,
+        &primary_digest,
+        shadow.status,
+        &shadow_digest,
+    );
+
+    Comparison::Diverged(Box::new(Divergence {
+        kind,
+        primary_status: primary.status,
+        shadow_status: shadow.status,
+        primary_body_kind: primary_body.kind_label(),
+        shadow_body_kind: shadow_body.kind_label(),
+        primary_body_bytes: primary.body.len(),
+        shadow_body_bytes: shadow.body.len(),
+        primary_digest,
+        shadow_digest,
+        primary_sample: sample(&primary_body, filter, sample_limit),
+        shadow_sample: sample(&shadow_body, filter, sample_limit),
+        fingerprint,
+    }))
+}
+
+/// The status *class* two responses are compared on (`2` for any `2xx`).
+#[must_use]
+pub const fn status_class(status: u16) -> u16 {
+    status.saturating_div(100)
+}
+
+/// Reduce a raw response body to its comparable form.
+///
+/// JSON is recognised either from the content type or from the body's own
+/// first non-whitespace byte, so a build that mislabels its JSON is still
+/// compared structurally rather than byte-for-byte. A body that *claims* to be
+/// JSON but does not parse falls back to a byte comparison — deliberately: two
+/// identical malformed bodies still agree, and pretending otherwise would
+/// manufacture a divergence out of a shared bug.
+#[must_use]
+pub fn normalize_body(facts: &ResponseFacts) -> NormalizedBody {
+    if facts.body.is_empty() {
+        return NormalizedBody::Empty;
+    }
+
+    let content_type = facts
+        .content_type
+        .as_deref()
+        .unwrap_or_default()
+        .to_ascii_lowercase();
+
+    if looks_like_json(&content_type, &facts.body)
+        && let Ok(value) = serde_json::from_slice::<Value>(&facts.body)
+    {
+        return NormalizedBody::Json(canonicalize(&value));
+    }
+
+    if is_textual(&content_type)
+        && let Ok(text) = std::str::from_utf8(&facts.body)
+    {
+        return NormalizedBody::Text(normalize_text(text));
+    }
+
+    NormalizedBody::Bytes(facts.body.clone())
+}
+
+/// Whether this body is worth attempting to parse as JSON.
+fn looks_like_json(content_type: &str, body: &[u8]) -> bool {
+    if content_type.contains("json") {
+        return true;
+    }
+    body.iter()
+        .find(|byte| !byte.is_ascii_whitespace())
+        .is_some_and(|byte| matches!(byte, b'{' | b'['))
+}
+
+/// Whether a content type describes text whose whitespace can be normalized.
+fn is_textual(content_type: &str) -> bool {
+    content_type.starts_with("text/")
+        || content_type.contains("xml")
+        || content_type.contains("javascript")
+        || content_type.contains("csv")
+        || content_type.contains("x-www-form-urlencoded")
+}
+
+/// Fold `\r\n` to `\n` and trim the body's outer whitespace.
+///
+/// Interior whitespace is left alone: it is load-bearing inside `<pre>`, in
+/// generated CSV, and in anything indentation-sensitive, so collapsing it would
+/// hide real divergences.
+fn normalize_text(text: &str) -> String {
+    text.replace("\r\n", "\n").trim().to_owned()
+}
+
+/// Recursively sort every JSON object's keys.
+///
+/// Arrays keep their order — see the module docs.
+fn canonicalize(value: &Value) -> Value {
+    match value {
+        Value::Object(map) => {
+            let mut keys: Vec<&String> = map.keys().collect();
+            keys.sort_unstable();
+            let mut out = Map::new();
+            for key in keys {
+                if let Some(child) = map.get(key) {
+                    out.insert(key.clone(), canonicalize(child));
+                }
+            }
+            Value::Object(out)
+        }
+        Value::Array(items) => Value::Array(items.iter().map(canonicalize).collect()),
+        other => other.clone(),
+    }
+}
+
+/// Hex SHA-256 of a normalized body's canonical encoding, prefixed by its kind
+/// so an empty JSON body and an empty text body cannot collide.
+fn digest(body: &NormalizedBody) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(body.kind_label().as_bytes());
+    hasher.update([0]);
+    hasher.update(body.canonical_bytes());
+    hex::encode(hasher.finalize())
+}
+
+/// Content-addressed identity for a divergence.
+fn fingerprint(
+    kind: DivergenceKind,
+    primary_status: u16,
+    primary_digest: &str,
+    shadow_status: u16,
+    shadow_digest: &str,
+) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(kind.as_str().as_bytes());
+    hasher.update([0]);
+    hasher.update(primary_status.to_string().as_bytes());
+    hasher.update([0]);
+    hasher.update(primary_digest.as_bytes());
+    hasher.update([0]);
+    hasher.update(shadow_status.to_string().as_bytes());
+    hasher.update([0]);
+    hasher.update(shadow_digest.as_bytes());
+    hex::encode(hasher.finalize()).chars().take(16).collect()
+}
+
+/// Build the recorded excerpt for one side, or `None` when the body is not
+/// JSON (see the module docs on why non-JSON bodies are not sampled).
+fn sample(body: &NormalizedBody, filter: &ParameterFilter, sample_limit: usize) -> Option<Value> {
+    let NormalizedBody::Json(value) = body else {
+        return None;
+    };
+    let scrubbed = filter.scrub_json(value);
+    let rendered = serde_json::to_string(&scrubbed).unwrap_or_default();
+    if rendered.chars().count() <= sample_limit {
+        return Some(scrubbed);
+    }
+    let mut truncated: String = rendered.chars().take(sample_limit).collect();
+    truncated.push_str(TRUNCATION_MARKER);
+    Some(Value::String(truncated))
+}
+
+/// Redact a request target (`/path?query`) for recording.
+///
+/// The path is kept verbatim — it is a route, not user data — while each query
+/// parameter whose name the filter matches is replaced with the filter's
+/// placeholder. Parameter order is preserved so the result stays deterministic.
+#[must_use]
+pub fn redact_path_and_query(target: &str, filter: &ParameterFilter) -> String {
+    let Some((path, query)) = target.split_once('?') else {
+        return target.to_owned();
+    };
+    let redacted: Vec<String> = query
+        .split('&')
+        .map(|pair| match pair.split_once('=') {
+            Some((key, _)) if filter.matches_key(key) => {
+                format!("{key}={}", crate::log::filter::FILTERED_PLACEHOLDER)
+            }
+            _ => pair.to_owned(),
+        })
+        .collect();
+    format!("{path}?{}", redacted.join("&"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::log::filter::ParameterFilter;
+    use bytes::Bytes;
+
+    fn json(status: u16, body: &str) -> ResponseFacts {
+        ResponseFacts {
+            status,
+            content_type: Some("application/json".to_owned()),
+            body: Bytes::from(body.to_owned()),
+        }
+    }
+
+    #[test]
+    fn identical_json_matches() {
+        let filter = ParameterFilter::default();
+        let a = json(200, r#"{"id":1,"name":"ada"}"#);
+        let b = json(200, r#"{"id":1,"name":"ada"}"#);
+        assert!(matches!(
+            compare(&a, &b, &filter, 2048),
+            Comparison::Match { .. }
+        ));
+    }
+
+    #[test]
+    fn json_object_key_order_is_normalized_away() {
+        let filter = ParameterFilter::default();
+        let a = json(200, r#"{"id":1,"name":"ada"}"#);
+        let b = json(200, r#"{"name":"ada","id":1}"#);
+        assert!(matches!(
+            compare(&a, &b, &filter, 2048),
+            Comparison::Match { .. }
+        ));
+    }
+
+    #[test]
+    fn json_array_order_is_a_divergence() {
+        let filter = ParameterFilter::default();
+        let a = json(200, r#"{"ids":[1,2,3]}"#);
+        let b = json(200, r#"{"ids":[3,2,1]}"#);
+        assert!(matches!(
+            compare(&a, &b, &filter, 2048),
+            Comparison::Diverged(_)
+        ));
+    }
+
+    #[test]
+    fn dropped_json_field_is_a_body_divergence() {
+        let filter = ParameterFilter::default();
+        let a = json(200, r#"{"id":1,"total":42}"#);
+        let b = json(200, r#"{"id":1}"#);
+        let Comparison::Diverged(d) = compare(&a, &b, &filter, 2048) else {
+            panic!("expected divergence");
+        };
+        assert_eq!(d.kind, DivergenceKind::Body);
+    }
+
+    #[test]
+    fn differing_status_class_is_a_status_divergence() {
+        let filter = ParameterFilter::default();
+        let a = json(200, r#"{"id":1}"#);
+        let b = json(500, r#"{"id":1}"#);
+        let Comparison::Diverged(d) = compare(&a, &b, &filter, 2048) else {
+            panic!("expected divergence");
+        };
+        assert_eq!(d.kind, DivergenceKind::StatusClass);
+        assert_eq!(d.primary_status, 200);
+        assert_eq!(d.shadow_status, 500);
+    }
+
+    #[test]
+    fn same_status_class_different_code_is_not_a_status_divergence() {
+        let filter = ParameterFilter::default();
+        let a = json(200, r#"{"id":1}"#);
+        let b = json(201, r#"{"id":1}"#);
+        assert!(matches!(
+            compare(&a, &b, &filter, 2048),
+            Comparison::Match { .. }
+        ));
+    }
+
+    #[test]
+    fn comparison_is_deterministic_and_reproducible() {
+        let filter = ParameterFilter::default();
+        let a = json(200, r#"{"id":1,"total":42}"#);
+        let b = json(200, r#"{"id":1}"#);
+        let first = compare(&a, &b, &filter, 2048);
+        let second = compare(&a, &b, &filter, 2048);
+        let (Comparison::Diverged(x), Comparison::Diverged(y)) = (first, second) else {
+            panic!("expected divergences");
+        };
+        assert_eq!(x, y, "the same captured pair must produce the same record");
+        assert!(!x.fingerprint.is_empty());
+    }
+
+    #[test]
+    fn samples_are_pii_redacted() {
+        let filter = ParameterFilter::default();
+        let a = json(200, r#"{"id":1,"password":"hunter2","total":1}"#);
+        let b = json(200, r#"{"id":1,"password":"hunter2"}"#);
+        let Comparison::Diverged(d) = compare(&a, &b, &filter, 2048) else {
+            panic!("expected divergence");
+        };
+        let rendered = serde_json::to_string(&d.primary_sample).unwrap();
+        assert!(
+            !rendered.contains("hunter2"),
+            "recorded sample must not carry a filtered value: {rendered}"
+        );
+        assert!(rendered.contains("[FILTERED]"));
+    }
+
+    #[test]
+    fn non_json_bodies_record_no_sample() {
+        let filter = ParameterFilter::default();
+        let html = |body: &str| ResponseFacts {
+            status: 200,
+            content_type: Some("text/html; charset=utf-8".to_owned()),
+            body: Bytes::from(body.to_owned()),
+        };
+        let Comparison::Diverged(d) = compare(
+            &html("<p>ada@example.com</p>"),
+            &html("<p>grace@example.com</p>"),
+            &filter,
+            2048,
+        ) else {
+            panic!("expected divergence");
+        };
+        assert!(d.primary_sample.is_none());
+        assert!(d.shadow_sample.is_none());
+        assert_ne!(d.primary_digest, d.shadow_digest);
+    }
+
+    #[test]
+    fn text_bodies_normalize_line_endings_and_outer_whitespace() {
+        let filter = ParameterFilter::default();
+        let text = |body: &str| ResponseFacts {
+            status: 200,
+            content_type: Some("text/plain".to_owned()),
+            body: Bytes::from(body.to_owned()),
+        };
+        assert!(matches!(
+            compare(
+                &text("hello\r\nworld"),
+                &text("  hello\nworld\n"),
+                &filter,
+                2048
+            ),
+            Comparison::Match { .. }
+        ));
+    }
+
+    #[test]
+    fn oversized_samples_are_truncated() {
+        let filter = ParameterFilter::default();
+        let big = format!(r#"{{"blob":"{}"}}"#, "x".repeat(4096));
+        let Comparison::Diverged(d) = compare(&json(200, &big), &json(200, "{}"), &filter, 64)
+        else {
+            panic!("expected divergence");
+        };
+        let rendered = serde_json::to_string(&d.primary_sample).unwrap();
+        assert!(
+            rendered.len() < 512,
+            "sample must be truncated: {}",
+            rendered.len()
+        );
+    }
+
+    #[test]
+    fn empty_bodies_on_both_sides_match() {
+        let filter = ParameterFilter::default();
+        let head = || ResponseFacts {
+            status: 204,
+            content_type: None,
+            body: Bytes::new(),
+        };
+        assert!(matches!(
+            compare(&head(), &head(), &filter, 2048),
+            Comparison::Match { .. }
+        ));
+    }
+
+    #[test]
+    fn invalid_json_falls_back_to_byte_comparison() {
+        let filter = ParameterFilter::default();
+        let a = json(200, "{not json");
+        let b = json(200, "{not json");
+        assert!(matches!(
+            compare(&a, &b, &filter, 2048),
+            Comparison::Match { .. }
+        ));
+        let c = json(200, "{not json!");
+        assert!(matches!(
+            compare(&a, &c, &filter, 2048),
+            Comparison::Diverged(_)
+        ));
+    }
+
+    #[test]
+    fn digests_are_stable_across_equivalent_encodings() {
+        let filter = ParameterFilter::default();
+        let a = json(200, r#"{"a":1,"b":2}"#);
+        let b = json(200, "{ \"b\" : 2 , \"a\" : 1 }");
+        assert!(matches!(
+            compare(&a, &b, &filter, 2048),
+            Comparison::Match { .. }
+        ));
+    }
+
+    #[test]
+    fn redact_query_filters_sensitive_parameters() {
+        let filter = ParameterFilter::default();
+        assert_eq!(
+            redact_path_and_query("/search?q=ada&token=abc123", &filter),
+            "/search?q=ada&token=[FILTERED]"
+        );
+        assert_eq!(redact_path_and_query("/plain", &filter), "/plain");
+    }
+}

--- a/autumn/src/shadow/diff.rs
+++ b/autumn/src/shadow/diff.rs
@@ -28,12 +28,13 @@
 //! access log, error pages, and failure capsules use, driven by the same
 //! `[log] filter_parameters` / `[log] unfilter_parameters` config.
 //!
-//! That filter redacts by **key name**, so an excerpt is recorded only when
-//! every scalar in the body sits under one. An HTML or binary body has no keys;
-//! neither does a bare scalar (a `text/plain` one-time code parses as a JSON
-//! number) nor an array of bare strings. Those record a digest, a length, and
-//! how the body was normalized. A divergence is still reported — just without a
-//! body excerpt that no redaction rule could vet.
+//! That filter redacts by **key name**, replacing a matched key's whole value,
+//! so an excerpt is recorded only when every scalar has some object key above
+//! it — that is exactly when naming a key could reach it. An HTML or binary
+//! body has no keys; neither does a bare scalar (a `text/plain` one-time code
+//! parses as a JSON number) nor a top-level array of strings. Those record a
+//! digest, a length, and how the body was normalized. A divergence is still
+//! reported — just without a body excerpt that no redaction rule could vet.
 
 // autumn-panic-gate: request-path module — production code path must be panic-free.
 // See CONTRIBUTING.md "Request-path panic gate". Justify exceptions with
@@ -408,22 +409,27 @@ fn sample(body: &NormalizedBody, filter: &ParameterFilter, sample_limit: usize) 
     Some(Value::String(truncated))
 }
 
-/// Whether every scalar in `value` sits under an object key, and is therefore
-/// something [`ParameterFilter`] can be asked about.
+/// Whether every scalar in `value` has an object key somewhere above it, and is
+/// therefore something [`ParameterFilter`] can be asked about.
 ///
-/// A scalar at the top level, or as an array element, has no key above it — no
-/// redaction rule can vet it, so a body containing one is not sampled at all.
-/// An array *of objects* is fine: each scalar inside them is keyed.
+/// The question is not whether a scalar is *directly* under a key — it is
+/// whether naming a key in `[log] filter_parameters` could redact it.
+/// `scrub_json` replaces a matched key's **whole value**, so everything inside
+/// an object is covered by that object's keys, however deeply nested:
+/// `{"tags": ["x"]}` is redacted entirely by listing `tags`.
+///
+/// What cannot be covered is a value with no key above it at all — a bare
+/// scalar body, or a top-level array of scalars. There is no name an operator
+/// could write down that would reach those, so a body containing one is not
+/// sampled and records only a digest and a length.
 fn scalars_are_all_keyed(value: &Value) -> bool {
     match value {
+        // Every descendant has this object's keys above it.
+        Value::Object(_) => true,
+        // Elements have no key of their own, so each must supply one.
+        Value::Array(items) => items.iter().all(scalars_are_all_keyed),
         // Nothing above this to name it.
         Value::Null | Value::Bool(_) | Value::Number(_) | Value::String(_) => false,
-        Value::Array(items) => items.iter().all(scalars_are_all_keyed),
-        Value::Object(map) => map.values().all(|child| match child {
-            // Directly under a key: the filter can match it.
-            Value::Null | Value::Bool(_) | Value::Number(_) | Value::String(_) => true,
-            nested => scalars_are_all_keyed(nested),
-        }),
     }
 }
 
@@ -742,6 +748,57 @@ mod tests {
             panic!("expected divergence");
         };
         assert!(d.primary_sample.is_none());
+    }
+
+    #[test]
+    fn a_list_of_strings_under_a_key_is_still_sampled() {
+        // Regression: an earlier form of this rule demanded that every scalar be
+        // DIRECTLY under a key, which refused `{"items": ["a", "b"]}` — an
+        // extremely ordinary shape whose array IS governed by `items`. Listing
+        // `items` in `filter_parameters` redacts the whole array, so the filter
+        // can be asked about it and the excerpt is safe to record.
+        let filter = ParameterFilter::default();
+        let body = |raw: &str| {
+            ResponseFacts::new(
+                200,
+                Some("application/json".to_owned()),
+                Bytes::from(raw.to_owned()),
+            )
+        };
+        let Comparison::Diverged(d) = compare(
+            &body(r#"{"id":7,"total":42,"items":["a","b"]}"#),
+            &body(r#"{"id":7,"items":["a","b"]}"#),
+            &filter,
+            2048,
+        ) else {
+            panic!("expected divergence");
+        };
+        let sample = d.primary_sample.expect("a keyed body must be sampled");
+        assert_eq!(sample["total"], serde_json::json!(42));
+        assert_eq!(sample["items"], serde_json::json!(["a", "b"]));
+    }
+
+    #[test]
+    fn a_list_under_a_filtered_key_is_redacted_whole() {
+        let filter = ParameterFilter::default();
+        let body = |raw: &str| {
+            ResponseFacts::new(
+                200,
+                Some("application/json".to_owned()),
+                Bytes::from(raw.to_owned()),
+            )
+        };
+        let Comparison::Diverged(d) = compare(
+            &body(r#"{"id":1,"token":["abc","def"]}"#),
+            &body(r#"{"id":2,"token":["abc","def"]}"#),
+            &filter,
+            2048,
+        ) else {
+            panic!("expected divergence");
+        };
+        let rendered = serde_json::to_string(&d.primary_sample).unwrap();
+        assert!(!rendered.contains("abc"), "{rendered}");
+        assert!(rendered.contains("[FILTERED]"), "{rendered}");
     }
 
     #[test]

--- a/autumn/src/shadow/diff.rs
+++ b/autumn/src/shadow/diff.rs
@@ -439,10 +439,7 @@ mod tests {
         let filter = ParameterFilter::default();
         let a = json(200, r#"{"id":1,"name":"ada"}"#);
         let b = json(200, r#"{"id":1,"name":"ada"}"#);
-        assert!(matches!(
-            compare(&a, &b, &filter, 2048),
-            Comparison::Match { .. }
-        ));
+        assert!(matches!(compare(&a, &b, &filter, 2048), Comparison::Match));
     }
 
     #[test]
@@ -450,10 +447,7 @@ mod tests {
         let filter = ParameterFilter::default();
         let a = json(200, r#"{"id":1,"name":"ada"}"#);
         let b = json(200, r#"{"name":"ada","id":1}"#);
-        assert!(matches!(
-            compare(&a, &b, &filter, 2048),
-            Comparison::Match { .. }
-        ));
+        assert!(matches!(compare(&a, &b, &filter, 2048), Comparison::Match));
     }
 
     #[test]
@@ -496,10 +490,7 @@ mod tests {
         let filter = ParameterFilter::default();
         let a = json(200, r#"{"id":1}"#);
         let b = json(201, r#"{"id":1}"#);
-        assert!(matches!(
-            compare(&a, &b, &filter, 2048),
-            Comparison::Match { .. }
-        ));
+        assert!(matches!(compare(&a, &b, &filter, 2048), Comparison::Match));
     }
 
     #[test]
@@ -568,7 +559,7 @@ mod tests {
                 &filter,
                 2048
             ),
-            Comparison::Match { .. }
+            Comparison::Match
         ));
     }
 
@@ -598,7 +589,7 @@ mod tests {
         };
         assert!(matches!(
             compare(&head(), &head(), &filter, 2048),
-            Comparison::Match { .. }
+            Comparison::Match
         ));
     }
 
@@ -607,10 +598,7 @@ mod tests {
         let filter = ParameterFilter::default();
         let a = json(200, "{not json");
         let b = json(200, "{not json");
-        assert!(matches!(
-            compare(&a, &b, &filter, 2048),
-            Comparison::Match { .. }
-        ));
+        assert!(matches!(compare(&a, &b, &filter, 2048), Comparison::Match));
         let c = json(200, "{not json!");
         assert!(matches!(
             compare(&a, &c, &filter, 2048),
@@ -623,10 +611,7 @@ mod tests {
         let filter = ParameterFilter::default();
         let a = json(200, r#"{"a":1,"b":2}"#);
         let b = json(200, "{ \"b\" : 2 , \"a\" : 1 }");
-        assert!(matches!(
-            compare(&a, &b, &filter, 2048),
-            Comparison::Match { .. }
-        ));
+        assert!(matches!(compare(&a, &b, &filter, 2048), Comparison::Match));
     }
 
     #[test]

--- a/autumn/src/shadow/layer.rs
+++ b/autumn/src/shadow/layer.rs
@@ -661,13 +661,10 @@ fn content_type_of(headers: &HeaderMap) -> Option<String> {
         .map(ToOwned::to_owned)
 }
 
-/// The `Content-Encoding` header value, when the response carries a readable
-/// one — a handler may serve a precompressed representation.
+/// The response's full `Content-Encoding` coding list — a handler may serve a
+/// precompressed representation, and may emit the chain as repeated fields.
 fn content_encoding_of(headers: &HeaderMap) -> Option<String> {
-    headers
-        .get(axum::http::header::CONTENT_ENCODING)
-        .and_then(|value| value.to_str().ok())
-        .map(|value| value.trim().to_ascii_lowercase())
+    crate::shadow::transport::joined_content_encoding(headers)
 }
 
 /// Wrap a response body so a copy of its bytes reaches `tx` once the client has

--- a/autumn/src/shadow/layer.rs
+++ b/autumn/src/shadow/layer.rs
@@ -397,6 +397,31 @@ async fn run_mirror(
         return;
     };
 
+    // Decode BOTH sides, here in the detached task rather than on the response
+    // path. A handler can serve a precompressed representation, so the primary
+    // tee captures encoded bytes just as the candidate's response can arrive
+    // encoded — decoding only one of them would report two identical builds as
+    // divergent on every such route.
+    let (Ok(primary_body), Ok(shadow_body)) = (
+        crate::shadow::transport::decode_body(
+            primary.content_encoding.as_deref(),
+            primary.body.clone(),
+            ctx.settings.max_body_bytes,
+        ),
+        crate::shadow::transport::decode_body(
+            shadow.content_encoding.as_deref(),
+            shadow.body.clone(),
+            ctx.settings.max_body_bytes,
+        ),
+    ) else {
+        // Undecodable or over-budget once expanded: counted, never guessed at.
+        ctx.registry.record_skipped_oversize();
+        record_outcome(&ctx.registry, &context.route, "skipped");
+        return;
+    };
+    let primary = ResponseFacts::encoded(primary.status, primary.content_type, None, primary_body);
+    let shadow = ResponseFacts::encoded(shadow.status, shadow.content_type, None, shadow_body);
+
     let comparison = compare(
         &primary,
         &shadow,
@@ -558,9 +583,10 @@ where
         };
         if head {
             let (parts, body) = response.into_parts();
-            let _ = tx.send(Some(ResponseFacts::new(
+            let _ = tx.send(Some(ResponseFacts::encoded(
                 parts.status.as_u16(),
                 content_type_of(&parts.headers),
+                content_encoding_of(&parts.headers),
                 Bytes::new(),
             )));
             return Poll::Ready(Ok(Response::from_parts(parts, body)));
@@ -582,6 +608,15 @@ fn content_type_of(headers: &HeaderMap) -> Option<String> {
         .map(ToOwned::to_owned)
 }
 
+/// The `Content-Encoding` header value, when the response carries a readable
+/// one — a handler may serve a precompressed representation.
+fn content_encoding_of(headers: &HeaderMap) -> Option<String> {
+    headers
+        .get(axum::http::header::CONTENT_ENCODING)
+        .and_then(|value| value.to_str().ok())
+        .map(|value| value.trim().to_ascii_lowercase())
+}
+
 /// Wrap a response body so a copy of its bytes reaches `tx` once the client has
 /// been served the last frame.
 fn tee_response(
@@ -591,6 +626,7 @@ fn tee_response(
 ) -> Response<Body> {
     let status = response.status().as_u16();
     let content_type = content_type_of(response.headers());
+    let content_encoding = content_encoding_of(response.headers());
 
     let (parts, body) = response.into_parts();
 
@@ -598,7 +634,12 @@ fn tee_response(
     // polled at all, so there would be no poll on which to deliver the facts.
     // Deliver them now and leave the body untouched.
     if http_body::Body::is_end_stream(&body) {
-        let _ = tx.send(Some(ResponseFacts::new(status, content_type, Bytes::new())));
+        let _ = tx.send(Some(ResponseFacts::encoded(
+            status,
+            content_type,
+            content_encoding,
+            Bytes::new(),
+        )));
         return Response::from_parts(parts, body);
     }
 
@@ -606,6 +647,7 @@ fn tee_response(
         inner: body,
         status,
         content_type,
+        content_encoding,
         captured: BytesMut::new(),
         max_body_bytes,
         overflowed: false,
@@ -622,6 +664,7 @@ struct MirrorTeeBody {
     inner: Body,
     status: u16,
     content_type: Option<String>,
+    content_encoding: Option<String>,
     captured: BytesMut,
     max_body_bytes: usize,
     overflowed: bool,
@@ -660,9 +703,10 @@ impl MirrorTeeBody {
         let facts = if self.overflowed {
             None
         } else {
-            Some(ResponseFacts::new(
+            Some(ResponseFacts::encoded(
                 self.status,
                 self.content_type.clone(),
+                self.content_encoding.clone(),
                 std::mem::take(&mut self.captured).freeze(),
             ))
         };
@@ -728,10 +772,26 @@ mod tests {
     use std::time::Duration;
     use tower::{ServiceExt, service_fn};
 
+    /// gzip-encode `plain`, for the precompressed-representation tests.
+    fn gzipped(plain: &[u8]) -> bytes::Bytes {
+        use std::io::Write as _;
+        let mut encoder = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::default());
+        encoder.write_all(plain).expect("encode");
+        bytes::Bytes::from(encoder.finish().expect("finish"))
+    }
+
     /// What a [`FakeTransport`] should do with each mirrored request.
     #[derive(Clone)]
     enum Behaviour {
-        Reply { status: u16, body: &'static str },
+        /// Answer with a gzip `Content-Encoding`, as a handler serving a
+        /// precompressed representation would.
+        ReplyGzipped {
+            body: &'static str,
+        },
+        Reply {
+            status: u16,
+            body: &'static str,
+        },
         Fail,
         Oversize,
         Stall(Duration),
@@ -772,6 +832,12 @@ mod tests {
                         status,
                         Some("application/json".to_owned()),
                         bytes::Bytes::from_static(body.as_bytes()),
+                    )),
+                    Behaviour::ReplyGzipped { body } => Ok(ResponseFacts::encoded(
+                        200,
+                        Some("application/json".to_owned()),
+                        Some("gzip".to_owned()),
+                        gzipped(body.as_bytes()),
                     )),
                     Behaviour::Fail => Err(ShadowError::Transport("refused".to_owned())),
                     Behaviour::Oversize => Err(ShadowError::Oversize),
@@ -1180,6 +1246,84 @@ mod tests {
             recent[0].target
         );
         assert!(recent[0].target.contains("page=2"));
+    }
+
+    #[tokio::test]
+    async fn a_precompressed_body_is_decoded_on_both_sides_before_comparing() {
+        // A handler may serve a precompressed representation, so the primary
+        // tee captures ENCODED bytes — exactly as the candidate's response can
+        // arrive encoded. Decoding only one side would report two identical
+        // builds as divergent on every such route.
+        let transport = FakeTransport::new(Behaviour::ReplyGzipped {
+            body: r#"{"ok":true}"#,
+        });
+        let registry = ShadowRegistry::new(10);
+        let service = layer(transport.clone(), &registry, settings()).layer(service_fn(
+            |_req: Request<Body>| async move {
+                Ok::<_, std::convert::Infallible>(
+                    Response::builder()
+                        .status(StatusCode::OK)
+                        .header("content-type", "application/json")
+                        .header("content-encoding", "gzip")
+                        .body(Body::from(gzipped(br#"{"ok":true}"#)))
+                        .expect("valid response"),
+                )
+            },
+        ));
+
+        let request = Request::builder()
+            .uri("/api/orders")
+            .body(Body::empty())
+            .expect("request");
+        let response = service.oneshot(request).await.expect("response");
+        let _ = read_body(response).await;
+
+        settle("the comparison to be recorded", || {
+            registry.stats().compared == 1
+        })
+        .await;
+        assert_eq!(
+            registry.stats().matched,
+            1,
+            "identical precompressed bodies must not diverge"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_precompressed_primary_matches_a_plain_candidate_with_the_same_content() {
+        // Only one side encoded: after decoding, the content is identical, so
+        // this is a match. An encoding difference is a header difference, and
+        // headers are outside the comparison contract.
+        let transport = FakeTransport::new(Behaviour::Reply {
+            status: 200,
+            body: r#"{"ok":true}"#,
+        });
+        let registry = ShadowRegistry::new(10);
+        let service = layer(transport.clone(), &registry, settings()).layer(service_fn(
+            |_req: Request<Body>| async move {
+                Ok::<_, std::convert::Infallible>(
+                    Response::builder()
+                        .status(StatusCode::OK)
+                        .header("content-type", "application/json")
+                        .header("content-encoding", "gzip")
+                        .body(Body::from(gzipped(br#"{"ok":true}"#)))
+                        .expect("valid response"),
+                )
+            },
+        ));
+
+        let request = Request::builder()
+            .uri("/api/orders")
+            .body(Body::empty())
+            .expect("request");
+        let response = service.oneshot(request).await.expect("response");
+        let _ = read_body(response).await;
+
+        settle("the comparison to be recorded", || {
+            registry.stats().compared == 1
+        })
+        .await;
+        assert_eq!(registry.stats().matched, 1);
     }
 
     #[tokio::test]

--- a/autumn/src/shadow/layer.rs
+++ b/autumn/src/shadow/layer.rs
@@ -365,13 +365,10 @@ async fn run_mirror(
     // silently off for the rest of the process's life. `Err` on the channel
     // means the same thing arrived sooner — the client disconnected, or the
     // response was aborted mid-stream.
-    let primary = match tokio::time::timeout(ctx.settings.timeout, primary_rx).await {
-        Ok(Ok(primary)) => primary,
-        Ok(Err(_)) | Err(_) => {
-            ctx.registry.record_primary_incomplete();
-            record_outcome(&ctx.registry, &context.route, "incomplete");
-            return;
-        }
+    let Ok(Ok(primary)) = tokio::time::timeout(ctx.settings.timeout, primary_rx).await else {
+        ctx.registry.record_primary_incomplete();
+        record_outcome(&ctx.registry, &context.route, "incomplete");
+        return;
     };
 
     // `None` means the primary body blew the capture budget; a shadow body may

--- a/autumn/src/shadow/layer.rs
+++ b/autumn/src/shadow/layer.rs
@@ -1,0 +1,999 @@
+//! The traffic-mirroring tower layer (issue #1653).
+//!
+//! # The one invariant
+//!
+//! **The live request must not be able to tell that mirroring is on.** Every
+//! design decision here follows from that:
+//!
+//! - The shadow request is dispatched on a **detached task** before the primary
+//!   handler has even finished, so the two run concurrently and the client
+//!   never waits on the candidate.
+//! - The primary response body is **teed, not buffered**: frames flow to the
+//!   client the instant they are produced and a copy accumulates on the side.
+//!   Buffering-then-forwarding would have added the handler's whole body
+//!   latency to every mirrored request.
+//! - The shadow response is read into [`ResponseFacts`] inside the detached
+//!   task and dropped there. It is never a `Response`, so no code path exists
+//!   on which it could be returned.
+//! - Every failure mode of the mirror (transport error, deadline, oversize
+//!   body, a full in-flight ceiling) resolves to *a counter and nothing else*.
+//!
+//! # What bounds it
+//!
+//! `max_in_flight` reserves a slot before dispatch and releases it when the
+//! detached task ends, so a candidate that stops answering costs at most that
+//! many outstanding requests rather than one per inbound request. `timeout`
+//! bounds each attempt. `max_body_bytes` bounds what either side may buffer —
+//! an oversize body is not partially captured, it is abandoned and counted, so
+//! a streaming endpoint cannot grow the process.
+
+// autumn-panic-gate: request-path module — production code path must be panic-free.
+// See CONTRIBUTING.md "Request-path panic gate". Justify exceptions with
+// #[allow(clippy::<lint>, reason = "…")] at the narrowest scope.
+#![cfg_attr(
+    not(test),
+    deny(
+        clippy::unwrap_used,
+        clippy::expect_used,
+        clippy::panic,
+        clippy::unreachable,
+        clippy::todo,
+        clippy::unimplemented,
+        clippy::indexing_slicing,
+        clippy::string_slice,
+        clippy::arithmetic_side_effects,
+    )
+)]
+
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::task::{Context, Poll};
+use std::time::Duration;
+
+use axum::body::Body;
+use axum::http::{HeaderMap, Method, Request, Response};
+use bytes::{Bytes, BytesMut};
+use pin_project_lite::pin_project;
+use tokio::sync::oneshot;
+use tower::{Layer, Service};
+
+use crate::entropy::Entropy;
+use crate::log::filter::ParameterFilter;
+use crate::shadow::diff::{
+    Comparison, DivergenceKind, ResponseFacts, compare, redact_path_and_query,
+};
+use crate::shadow::registry::{RequestContext, ShadowRegistry};
+use crate::shadow::sample::{MirrorDecision, MirrorSelector, roll_from};
+use crate::shadow::transport::{
+    ShadowError, ShadowRequest, ShadowTransport, forwarded_headers, shadow_url,
+};
+use crate::time::ClockSource;
+
+/// Metric recording every mirrored request's outcome, labelled by the bounded
+/// route label and one of `match` / `diverged` / `error` / `timeout` /
+/// `skipped`.
+pub const COMPARISONS_METRIC: &str = "autumn_shadow_comparisons_total";
+
+/// Metric recording divergences only, labelled by route and divergence kind.
+///
+/// Redundant with the `diverged` outcome above by design: this is the series an
+/// operator alerts on, and it stays at zero on a clean run.
+pub const DIVERGENCES_METRIC: &str = "autumn_shadow_divergences_total";
+
+/// Bounds and destination for a mirror run.
+#[derive(Clone, Debug)]
+pub struct MirrorSettings {
+    /// Base URL of the candidate build, without a trailing slash.
+    pub target_base: String,
+    /// Deadline for one shadow request.
+    pub timeout: Duration,
+    /// Ceiling on concurrently in-flight mirrored requests.
+    pub max_in_flight: usize,
+    /// Largest response body either side may buffer for comparison.
+    pub max_body_bytes: usize,
+    /// Character budget for each recorded JSON sample.
+    pub max_sample_bytes: usize,
+}
+
+/// Everything the mirror needs, resolved once at router-assembly time.
+struct MirrorContext {
+    settings: MirrorSettings,
+    selector: MirrorSelector,
+    registry: ShadowRegistry,
+    transport: Arc<dyn ShadowTransport>,
+    filter: Arc<ParameterFilter>,
+    entropy: Arc<dyn Entropy>,
+    clock: Arc<dyn ClockSource>,
+    in_flight: Arc<AtomicUsize>,
+}
+
+impl std::fmt::Debug for MirrorContext {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("MirrorContext")
+            .field("settings", &self.settings)
+            .field("in_flight", &self.in_flight.load(Ordering::Relaxed))
+            .finish_non_exhaustive()
+    }
+}
+
+/// Tower [`Layer`] that mirrors eligible traffic to a shadow build and diffs
+/// the responses.
+///
+/// Clone it freely — all state is shared through [`Arc`], including the
+/// in-flight counter, so every clone admits against the same ceiling.
+#[derive(Clone, Debug)]
+pub struct ShadowMirrorLayer {
+    ctx: Arc<MirrorContext>,
+}
+
+impl ShadowMirrorLayer {
+    /// Assemble the layer.
+    ///
+    /// `entropy` and `clock` are injected rather than read from the ambient
+    /// process so a [`#[sim_test]`](crate::sim_test) can make the sampling
+    /// decision and the recorded timestamps reproducible.
+    #[must_use]
+    pub fn new(
+        settings: MirrorSettings,
+        selector: MirrorSelector,
+        registry: ShadowRegistry,
+        transport: Arc<dyn ShadowTransport>,
+        filter: Arc<ParameterFilter>,
+        entropy: Arc<dyn Entropy>,
+        clock: Arc<dyn ClockSource>,
+    ) -> Self {
+        crate::metrics::describe_counter(
+            COMPARISONS_METRIC,
+            "Mirrored requests by route and comparison outcome",
+        );
+        crate::metrics::describe_counter(
+            DIVERGENCES_METRIC,
+            "Primary/shadow response divergences by route and kind",
+        );
+        Self {
+            ctx: Arc::new(MirrorContext {
+                settings,
+                selector,
+                registry,
+                transport,
+                filter,
+                entropy,
+                clock,
+                in_flight: Arc::new(AtomicUsize::new(0)),
+            }),
+        }
+    }
+}
+
+impl<S> Layer<S> for ShadowMirrorLayer {
+    type Service = ShadowMirrorService<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        ShadowMirrorService {
+            inner,
+            ctx: Arc::clone(&self.ctx),
+        }
+    }
+}
+
+/// The [`ShadowMirrorLayer`]'s service.
+#[derive(Clone, Debug)]
+pub struct ShadowMirrorService<S> {
+    inner: S,
+    ctx: Arc<MirrorContext>,
+}
+
+impl<S, ReqBody> Service<Request<ReqBody>> for ShadowMirrorService<S>
+where
+    S: Service<Request<ReqBody>, Response = Response<Body>>,
+{
+    type Response = Response<Body>;
+    type Error = S::Error;
+    type Future = ShadowMirrorFuture<S::Future>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, req: Request<ReqBody>) -> Self::Future {
+        let target = request_target(&req);
+        let ctx = Arc::clone(&self.ctx);
+        let decision = self
+            .ctx
+            .selector
+            .decide(req.method(), &target, req.headers(), || {
+                roll_from(ctx.entropy.as_ref())
+            });
+
+        let primary_tx = match decision {
+            MirrorDecision::Mirror => {
+                self.ctx
+                    .begin_mirror(req.method().clone(), &target, req.headers())
+            }
+            // Not mirrored: the request is forwarded with no wrapper at all, so
+            // the overwhelmingly common path costs one decision and nothing
+            // else — no body wrapper, no allocation, no metric.
+            MirrorDecision::Skip(_) => None,
+        };
+
+        ShadowMirrorFuture {
+            inner: self.inner.call(req),
+            primary_tx,
+            max_body_bytes: self.ctx.settings.max_body_bytes,
+        }
+    }
+}
+
+impl MirrorContext {
+    /// Reserve a slot, dispatch the shadow request on a detached task, and
+    /// return the sender the response tee will deliver the primary facts on.
+    ///
+    /// `None` means "do not tee": either the ceiling was reached (counted) or
+    /// there is nothing to compare against.
+    fn begin_mirror(
+        self: &Arc<Self>,
+        method: Method,
+        target: &str,
+        headers: &HeaderMap,
+    ) -> Option<oneshot::Sender<Option<ResponseFacts>>> {
+        let Some(permit) =
+            InFlightPermit::try_acquire(&self.in_flight, self.settings.max_in_flight)
+        else {
+            // The candidate is not keeping up. Drop the mirror rather than
+            // queueing it: a queue would turn a slow shadow into unbounded
+            // memory growth on the *primary*, which is the one thing this
+            // feature must never do.
+            self.registry.record_dropped_at_capacity();
+            record_outcome(self.selector.route_label(target), "dropped");
+            return None;
+        };
+
+        let request = ShadowRequest {
+            method,
+            url: shadow_url(&self.settings.target_base, target),
+            headers: forwarded_headers(headers),
+        };
+        let context = RequestContext {
+            method: request.method.to_string(),
+            target: redact_path_and_query(target, &self.filter),
+            route: self.selector.route_label(target).to_owned(),
+        };
+
+        // Mirroring needs somewhere to run the detached task. There always is
+        // one on a served request, but a caller driving the router from a
+        // non-tokio executor would otherwise make `tokio::spawn` panic on the
+        // request path — which is precisely what this module's panic gate
+        // exists to prevent. No runtime means no mirror, not a broken request.
+        let Ok(runtime) = tokio::runtime::Handle::try_current() else {
+            tracing::debug!(
+                target: "autumn::shadow",
+                "no tokio runtime on this request; skipping the mirror"
+            );
+            return None;
+        };
+
+        self.registry.record_mirrored();
+
+        let (tx, rx) = oneshot::channel();
+        let ctx = Arc::clone(self);
+        runtime.spawn(async move {
+            run_mirror(ctx, permit, context, request, rx).await;
+        });
+        Some(tx)
+    }
+}
+
+/// Dispatch one shadow request, await the primary's teed body, compare, record.
+async fn run_mirror(
+    ctx: Arc<MirrorContext>,
+    permit: InFlightPermit,
+    context: RequestContext,
+    request: ShadowRequest,
+    primary_rx: oneshot::Receiver<Option<ResponseFacts>>,
+) {
+    // The permit is released when this task ends, whatever the outcome.
+    let _permit = permit;
+
+    let shadow = match tokio::time::timeout(ctx.settings.timeout, ctx.transport.send(request)).await
+    {
+        Err(_) | Ok(Err(ShadowError::Timeout)) => {
+            ctx.registry.record_shadow_timeout();
+            record_outcome(&context.route, "timeout");
+            return;
+        }
+        Ok(Err(ShadowError::Oversize)) => {
+            ctx.registry.record_skipped_oversize();
+            record_outcome(&context.route, "skipped");
+            return;
+        }
+        Ok(Err(error)) => {
+            ctx.registry.record_shadow_error();
+            record_outcome(&context.route, "error");
+            tracing::debug!(target: "autumn::shadow", route = %context.route, %error, "shadow request failed");
+            return;
+        }
+        Ok(Ok(facts)) => facts,
+    };
+
+    // `Err` means the primary body never completed — the client disconnected or
+    // the response was aborted mid-stream. There is no primary response to
+    // compare against, so nothing is recorded.
+    let Ok(primary) = primary_rx.await else {
+        return;
+    };
+
+    // `None` means the primary body blew the capture budget; a shadow body may
+    // do the same.
+    let (Some(primary), true) = (primary, shadow.body.len() <= ctx.settings.max_body_bytes) else {
+        ctx.registry.record_skipped_oversize();
+        record_outcome(&context.route, "skipped");
+        return;
+    };
+
+    let comparison = compare(
+        &primary,
+        &shadow,
+        &ctx.filter,
+        ctx.settings.max_sample_bytes,
+    );
+    record_outcome(&context.route, comparison.outcome_label());
+    if let Comparison::Diverged(divergence) = &comparison {
+        record_divergence(&context.route, divergence.kind);
+        tracing::warn!(
+            target: "autumn::shadow",
+            route = %context.route,
+            method = %context.method,
+            request_target = %context.target,
+            kind = divergence.kind.as_str(),
+            fingerprint = %divergence.fingerprint,
+            primary_status = divergence.primary_status,
+            shadow_status = divergence.shadow_status,
+            "shadow build diverged from the live build"
+        );
+    }
+    let observed_at_ms = ctx.clock.now().timestamp_millis().unsigned_abs();
+    ctx.registry
+        .record_comparison(&context, comparison, observed_at_ms);
+}
+
+fn record_outcome(route: &str, outcome: &'static str) {
+    crate::metrics::counter(COMPARISONS_METRIC)
+        .with_label("route", route.to_owned())
+        .with_label("outcome", outcome)
+        .increment(1);
+}
+
+fn record_divergence(route: &str, kind: DivergenceKind) {
+    crate::metrics::counter(DIVERGENCES_METRIC)
+        .with_label("route", route.to_owned())
+        .with_label("kind", kind.as_str())
+        .increment(1);
+}
+
+/// The request target (`/path?query`) mirroring replays.
+fn request_target<B>(req: &Request<B>) -> String {
+    req.uri()
+        .path_and_query()
+        .map_or_else(|| req.uri().path().to_owned(), |pq| pq.as_str().to_owned())
+}
+
+/// A reserved in-flight slot, released on drop.
+#[derive(Debug)]
+struct InFlightPermit {
+    counter: Arc<AtomicUsize>,
+}
+
+impl InFlightPermit {
+    /// Reserve a slot, or `None` when the ceiling is already reached.
+    fn try_acquire(counter: &Arc<AtomicUsize>, limit: usize) -> Option<Self> {
+        let mut current = counter.load(Ordering::Acquire);
+        loop {
+            if current >= limit {
+                return None;
+            }
+            match counter.compare_exchange_weak(
+                current,
+                current.saturating_add(1),
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            ) {
+                Ok(_) => {
+                    return Some(Self {
+                        counter: Arc::clone(counter),
+                    });
+                }
+                Err(observed) => current = observed,
+            }
+        }
+    }
+}
+
+impl Drop for InFlightPermit {
+    fn drop(&mut self) {
+        let _ = self
+            .counter
+            .fetch_update(Ordering::AcqRel, Ordering::Acquire, |current| {
+                Some(current.saturating_sub(1))
+            });
+    }
+}
+
+pin_project! {
+    /// Future returned by [`ShadowMirrorService`].
+    ///
+    /// When the request was selected for mirroring it wraps the response body
+    /// in the tee; otherwise it is a transparent pass-through.
+    pub struct ShadowMirrorFuture<F> {
+        #[pin]
+        inner: F,
+        primary_tx: Option<oneshot::Sender<Option<ResponseFacts>>>,
+        max_body_bytes: usize,
+    }
+}
+
+impl<F, E> Future for ShadowMirrorFuture<F>
+where
+    F: Future<Output = Result<Response<Body>, E>>,
+{
+    type Output = Result<Response<Body>, E>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.project();
+        let response = std::task::ready!(this.inner.poll(cx))?;
+        let Some(tx) = this.primary_tx.take() else {
+            return Poll::Ready(Ok(response));
+        };
+        Poll::Ready(Ok(tee_response(response, tx, *this.max_body_bytes)))
+    }
+}
+
+/// Wrap a response body so a copy of its bytes reaches `tx` once the client has
+/// been served the last frame.
+fn tee_response(
+    response: Response<Body>,
+    tx: oneshot::Sender<Option<ResponseFacts>>,
+    max_body_bytes: usize,
+) -> Response<Body> {
+    let status = response.status().as_u16();
+    let content_type = response
+        .headers()
+        .get(axum::http::header::CONTENT_TYPE)
+        .and_then(|value| value.to_str().ok())
+        .map(ToOwned::to_owned);
+
+    let (parts, body) = response.into_parts();
+
+    // A body that is already at end-of-stream (a `HEAD`, a `204`) may never be
+    // polled at all, so there would be no poll on which to deliver the facts.
+    // Deliver them now and leave the body untouched.
+    if http_body::Body::is_end_stream(&body) {
+        let _ = tx.send(Some(ResponseFacts::new(status, content_type, Bytes::new())));
+        return Response::from_parts(parts, body);
+    }
+
+    let teed = Body::new(MirrorTeeBody {
+        inner: body,
+        status,
+        content_type,
+        captured: BytesMut::new(),
+        max_body_bytes,
+        overflowed: false,
+        tx: Some(tx),
+    });
+    Response::from_parts(parts, teed)
+}
+
+/// Response body that copies frames to the differ on their way to the client.
+///
+/// Every method delegates, so the client sees exactly the body it would have
+/// seen without mirroring — same frames, same order, same size hint.
+struct MirrorTeeBody {
+    inner: Body,
+    status: u16,
+    content_type: Option<String>,
+    captured: BytesMut,
+    max_body_bytes: usize,
+    overflowed: bool,
+    tx: Option<oneshot::Sender<Option<ResponseFacts>>>,
+}
+
+impl MirrorTeeBody {
+    fn capture(&mut self, data: &Bytes) {
+        if self.overflowed {
+            return;
+        }
+        if self.captured.len().saturating_add(data.len()) > self.max_body_bytes {
+            // Abandon rather than truncate: half a body would diff against
+            // half another body and manufacture divergences that are not real.
+            self.overflowed = true;
+            self.captured = BytesMut::new();
+            return;
+        }
+        self.captured.extend_from_slice(data);
+    }
+
+    fn finish(&mut self) {
+        let Some(tx) = self.tx.take() else {
+            return;
+        };
+        let facts = if self.overflowed {
+            None
+        } else {
+            Some(ResponseFacts::new(
+                self.status,
+                self.content_type.clone(),
+                std::mem::take(&mut self.captured).freeze(),
+            ))
+        };
+        let _ = tx.send(facts);
+    }
+}
+
+impl http_body::Body for MirrorTeeBody {
+    type Data = Bytes;
+    type Error = axum::Error;
+
+    fn poll_frame(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<Result<http_body::Frame<Self::Data>, Self::Error>>> {
+        let this = self.get_mut();
+        let polled = Pin::new(&mut this.inner).poll_frame(cx);
+        match &polled {
+            Poll::Ready(Some(Ok(frame))) => {
+                if let Some(data) = frame.data_ref() {
+                    let data = data.clone();
+                    this.capture(&data);
+                }
+                // A body that announces its end alongside its last frame is
+                // finished here; the consumer is entitled not to poll again.
+                if http_body::Body::is_end_stream(&this.inner) {
+                    this.finish();
+                }
+            }
+            Poll::Ready(None) => this.finish(),
+            // A body that errored mid-stream never reached the client whole,
+            // so there is nothing comparable. Dropping the sender cancels the
+            // waiting mirror task.
+            Poll::Ready(Some(Err(_))) => {
+                this.tx = None;
+            }
+            Poll::Pending => {}
+        }
+        polled
+    }
+
+    fn is_end_stream(&self) -> bool {
+        self.inner.is_end_stream()
+    }
+
+    fn size_hint(&self) -> http_body::SizeHint {
+        http_body::Body::size_hint(&self.inner)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::entropy::SeededEntropy;
+    use crate::log::filter::ParameterFilter;
+    use crate::shadow::registry::ShadowRegistry;
+    use crate::shadow::sample::{MirrorSelector, SHADOW_HEADER};
+    use crate::shadow::transport::{ShadowError, ShadowFuture, ShadowRequest, ShadowTransport};
+    use crate::time::FixedClock;
+    use axum::body::Body;
+    use axum::http::{Request, Response, StatusCode};
+    use std::sync::Mutex;
+    use std::time::Duration;
+    use tower::{ServiceExt, service_fn};
+
+    /// What a [`FakeTransport`] should do with each mirrored request.
+    #[derive(Clone)]
+    enum Behaviour {
+        Reply { status: u16, body: &'static str },
+        Fail,
+        Oversize,
+        Stall(Duration),
+    }
+
+    #[derive(Debug)]
+    struct FakeTransport {
+        seen: Arc<Mutex<Vec<ShadowRequest>>>,
+        behaviour: Mutex<Behaviour>,
+    }
+
+    impl FakeTransport {
+        fn new(behaviour: Behaviour) -> Arc<Self> {
+            Arc::new(Self {
+                seen: Arc::new(Mutex::new(Vec::new())),
+                behaviour: Mutex::new(behaviour),
+            })
+        }
+
+        fn seen(&self) -> Vec<ShadowRequest> {
+            self.seen.lock().expect("lock").clone()
+        }
+    }
+
+    impl std::fmt::Debug for Behaviour {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            f.write_str("Behaviour")
+        }
+    }
+
+    impl ShadowTransport for FakeTransport {
+        fn send(&self, request: ShadowRequest) -> ShadowFuture {
+            self.seen.lock().expect("lock").push(request);
+            let behaviour = self.behaviour.lock().expect("lock").clone();
+            Box::pin(async move {
+                match behaviour {
+                    Behaviour::Reply { status, body } => Ok(ResponseFacts::new(
+                        status,
+                        Some("application/json".to_owned()),
+                        bytes::Bytes::from_static(body.as_bytes()),
+                    )),
+                    Behaviour::Fail => Err(ShadowError::Transport("refused".to_owned())),
+                    Behaviour::Oversize => Err(ShadowError::Oversize),
+                    Behaviour::Stall(duration) => {
+                        tokio::time::sleep(duration).await;
+                        Ok(ResponseFacts::new(200, None, bytes::Bytes::new()))
+                    }
+                }
+            })
+        }
+    }
+
+    fn settings() -> MirrorSettings {
+        MirrorSettings {
+            target_base: "http://shadow.invalid".to_owned(),
+            timeout: Duration::from_millis(100),
+            max_in_flight: 4,
+            max_body_bytes: 1024,
+            max_sample_bytes: 512,
+        }
+    }
+
+    fn layer(
+        transport: Arc<dyn ShadowTransport>,
+        registry: &ShadowRegistry,
+        settings: MirrorSettings,
+    ) -> ShadowMirrorLayer {
+        ShadowMirrorLayer::new(
+            settings,
+            MirrorSelector::new(1.0, &[], "/actuator", &[]),
+            registry.clone(),
+            transport,
+            Arc::new(ParameterFilter::default()),
+            Arc::new(SeededEntropy::new(7)),
+            Arc::new(FixedClock::at(chrono::Utc::now())),
+        )
+    }
+
+    /// A primary handler that always answers with `body`.
+    fn primary(
+        body: &'static str,
+    ) -> impl tower::Service<
+        Request<Body>,
+        Response = Response<Body>,
+        Error = std::convert::Infallible,
+    > + Clone {
+        service_fn(move |_req: Request<Body>| async move {
+            Ok::<_, std::convert::Infallible>(
+                Response::builder()
+                    .status(StatusCode::OK)
+                    .header("content-type", "application/json")
+                    .body(Body::from(body))
+                    .expect("valid response"),
+            )
+        })
+    }
+
+    async fn read_body(response: Response<Body>) -> String {
+        let bytes = axum::body::to_bytes(response.into_body(), 64 * 1024)
+            .await
+            .expect("body");
+        String::from_utf8_lossy(&bytes).into_owned()
+    }
+
+    /// Wait until `condition` holds or ~2 s elapse. The mirror runs on a
+    /// detached task, so tests observe its effects rather than awaiting it.
+    async fn settle(mut condition: impl FnMut() -> bool) {
+        for _ in 0..200 {
+            if condition() {
+                return;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    }
+
+    #[tokio::test]
+    async fn a_mutating_request_is_never_mirrored() {
+        let transport = FakeTransport::new(Behaviour::Reply {
+            status: 200,
+            body: "{}",
+        });
+        let registry = ShadowRegistry::new(10);
+        let service =
+            layer(transport.clone(), &registry, settings()).layer(primary(r#"{"ok":true}"#));
+
+        let request = Request::builder()
+            .method("POST")
+            .uri("/api/orders")
+            .body(Body::empty())
+            .expect("request");
+        let response = service.oneshot(request).await.expect("response");
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(read_body(response).await, r#"{"ok":true}"#);
+
+        assert!(transport.seen().is_empty());
+        assert_eq!(registry.stats().mirrored, 0);
+    }
+
+    #[tokio::test]
+    async fn an_eligible_request_is_replayed_against_the_target() {
+        let transport = FakeTransport::new(Behaviour::Reply {
+            status: 200,
+            body: r#"{"ok":true}"#,
+        });
+        let registry = ShadowRegistry::new(10);
+        let service =
+            layer(transport.clone(), &registry, settings()).layer(primary(r#"{"ok":true}"#));
+
+        let request = Request::builder()
+            .uri("/api/orders?page=2")
+            .body(Body::empty())
+            .expect("request");
+        let response = service.oneshot(request).await.expect("response");
+        assert_eq!(read_body(response).await, r#"{"ok":true}"#);
+
+        settle(|| !transport.seen().is_empty()).await;
+        let seen = transport.seen();
+        assert_eq!(seen.len(), 1);
+        assert_eq!(seen[0].url, "http://shadow.invalid/api/orders?page=2");
+        assert_eq!(seen[0].method, axum::http::Method::GET);
+        assert!(seen[0].headers.contains_key(SHADOW_HEADER));
+
+        settle(|| registry.stats().compared == 1).await;
+        let stats = registry.stats();
+        assert_eq!(stats.mirrored, 1);
+        assert_eq!(stats.matched, 1);
+        assert_eq!(stats.diverged, 0);
+    }
+
+    #[tokio::test]
+    async fn a_divergent_shadow_never_reaches_the_client_but_is_recorded() {
+        let transport = FakeTransport::new(Behaviour::Reply {
+            status: 200,
+            body: r#"{"ok":true}"#,
+        });
+        let registry = ShadowRegistry::new(10);
+        let service = layer(transport.clone(), &registry, settings())
+            .layer(primary(r#"{"ok":true,"total":42}"#));
+
+        let request = Request::builder()
+            .uri("/api/orders")
+            .body(Body::empty())
+            .expect("request");
+        let response = service.oneshot(request).await.expect("response");
+        let body = read_body(response).await;
+        assert_eq!(
+            body, r#"{"ok":true,"total":42}"#,
+            "the client must receive the primary body, untouched"
+        );
+
+        settle(|| registry.stats().diverged == 1).await;
+        let recent = registry.recent();
+        assert_eq!(recent.len(), 1);
+        assert_eq!(recent[0].divergence.kind, DivergenceKind::Body);
+        assert_eq!(recent[0].target, "/api/orders");
+    }
+
+    #[tokio::test]
+    async fn a_failing_shadow_is_counted_and_leaves_the_client_alone() {
+        let transport = FakeTransport::new(Behaviour::Fail);
+        let registry = ShadowRegistry::new(10);
+        let service =
+            layer(transport.clone(), &registry, settings()).layer(primary(r#"{"ok":true}"#));
+
+        let request = Request::builder()
+            .uri("/api/orders")
+            .body(Body::empty())
+            .expect("request");
+        let response = service.oneshot(request).await.expect("response");
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(read_body(response).await, r#"{"ok":true}"#);
+
+        settle(|| registry.stats().shadow_errors == 1).await;
+        assert_eq!(registry.stats().shadow_errors, 1);
+        assert_eq!(registry.stats().compared, 0);
+    }
+
+    #[tokio::test]
+    async fn a_stalled_shadow_is_abandoned_without_delaying_the_client() {
+        let transport = FakeTransport::new(Behaviour::Stall(Duration::from_secs(30)));
+        let registry = ShadowRegistry::new(10);
+        let mut settings = settings();
+        settings.timeout = Duration::from_millis(50);
+        let service =
+            layer(transport.clone(), &registry, settings).layer(primary(r#"{"ok":true}"#));
+
+        let started = std::time::Instant::now();
+        let request = Request::builder()
+            .uri("/api/orders")
+            .body(Body::empty())
+            .expect("request");
+        let response = service.oneshot(request).await.expect("response");
+        let body = read_body(response).await;
+        let elapsed = started.elapsed();
+
+        assert_eq!(body, r#"{"ok":true}"#);
+        assert!(
+            elapsed < Duration::from_secs(5),
+            "the client waited {elapsed:?} on a stalled shadow"
+        );
+
+        settle(|| registry.stats().shadow_timeouts == 1).await;
+        assert_eq!(registry.stats().shadow_timeouts, 1);
+    }
+
+    #[tokio::test]
+    async fn the_in_flight_ceiling_drops_excess_mirrors() {
+        let transport = FakeTransport::new(Behaviour::Stall(Duration::from_secs(30)));
+        let registry = ShadowRegistry::new(10);
+        let mut settings = settings();
+        settings.max_in_flight = 1;
+        settings.timeout = Duration::from_secs(10);
+        let mirror = layer(transport.clone(), &registry, settings);
+
+        for _ in 0..4 {
+            let service = mirror.clone().layer(primary(r#"{"ok":true}"#));
+            let request = Request::builder()
+                .uri("/api/orders")
+                .body(Body::empty())
+                .expect("request");
+            let response = service.oneshot(request).await.expect("response");
+            let _ = read_body(response).await;
+        }
+
+        settle(|| registry.stats().dropped_at_capacity >= 3).await;
+        let stats = registry.stats();
+        assert_eq!(stats.mirrored, 1, "only one mirror may be in flight");
+        assert_eq!(stats.dropped_at_capacity, 3);
+    }
+
+    #[tokio::test]
+    async fn an_oversized_primary_body_is_skipped_rather_than_buffered() {
+        let transport = FakeTransport::new(Behaviour::Reply {
+            status: 200,
+            body: "{}",
+        });
+        let registry = ShadowRegistry::new(10);
+        let mut settings = settings();
+        settings.max_body_bytes = 16;
+        let service = layer(transport.clone(), &registry, settings)
+            .layer(primary(r#"{"padding":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}"#));
+
+        let request = Request::builder()
+            .uri("/api/orders")
+            .body(Body::empty())
+            .expect("request");
+        let response = service.oneshot(request).await.expect("response");
+        assert_eq!(
+            read_body(response).await,
+            r#"{"padding":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}"#,
+            "an oversized body must still stream to the client in full"
+        );
+
+        settle(|| registry.stats().skipped_oversize == 1).await;
+        assert_eq!(registry.stats().skipped_oversize, 1);
+        assert_eq!(registry.stats().compared, 0);
+    }
+
+    #[tokio::test]
+    async fn an_oversized_shadow_body_is_skipped() {
+        let transport = FakeTransport::new(Behaviour::Reply {
+            status: 200,
+            body: r#"{"padding":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}"#,
+        });
+        let registry = ShadowRegistry::new(10);
+        let mut settings = settings();
+        settings.max_body_bytes = 16;
+        let service = layer(transport.clone(), &registry, settings).layer(primary("{}"));
+
+        let request = Request::builder()
+            .uri("/api/orders")
+            .body(Body::empty())
+            .expect("request");
+        let response = service.oneshot(request).await.expect("response");
+        let _ = read_body(response).await;
+
+        settle(|| registry.stats().skipped_oversize == 1).await;
+        assert_eq!(registry.stats().skipped_oversize, 1);
+        assert_eq!(registry.stats().compared, 0);
+    }
+
+    #[tokio::test]
+    async fn a_transport_reported_oversize_body_is_skipped_not_errored() {
+        // The real transport stops reading a candidate body once it passes the
+        // budget, so the caller never sees its length — it sees this error.
+        let transport = FakeTransport::new(Behaviour::Oversize);
+        let registry = ShadowRegistry::new(10);
+        let service =
+            layer(transport.clone(), &registry, settings()).layer(primary(r#"{"ok":true}"#));
+
+        let request = Request::builder()
+            .uri("/api/orders")
+            .body(Body::empty())
+            .expect("request");
+        let response = service.oneshot(request).await.expect("response");
+        assert_eq!(read_body(response).await, r#"{"ok":true}"#);
+
+        settle(|| registry.stats().skipped_oversize == 1).await;
+        let stats = registry.stats();
+        assert_eq!(stats.skipped_oversize, 1);
+        assert_eq!(
+            stats.shadow_errors, 0,
+            "oversize is not a transport failure"
+        );
+        assert_eq!(stats.compared, 0);
+    }
+
+    #[tokio::test]
+    async fn the_recorded_target_redacts_sensitive_query_parameters() {
+        let transport = FakeTransport::new(Behaviour::Reply {
+            status: 200,
+            body: "{}",
+        });
+        let registry = ShadowRegistry::new(10);
+        let service = layer(transport.clone(), &registry, settings()).layer(primary(r#"{"a":1}"#));
+
+        let request = Request::builder()
+            .uri("/api/orders?token=supersecret&page=2")
+            .body(Body::empty())
+            .expect("request");
+        let response = service.oneshot(request).await.expect("response");
+        let _ = read_body(response).await;
+
+        settle(|| registry.stats().diverged == 1).await;
+        let recent = registry.recent();
+        assert_eq!(recent.len(), 1);
+        assert!(
+            !recent[0].target.contains("supersecret"),
+            "recorded target leaked a secret: {}",
+            recent[0].target
+        );
+        assert!(recent[0].target.contains("page=2"));
+    }
+
+    #[tokio::test]
+    async fn an_empty_primary_body_still_compares() {
+        let transport = FakeTransport::new(Behaviour::Reply {
+            status: 204,
+            body: "",
+        });
+        let registry = ShadowRegistry::new(10);
+        let service = layer(transport.clone(), &registry, settings()).layer(service_fn(
+            |_req: Request<Body>| async move {
+                Ok::<_, std::convert::Infallible>(
+                    Response::builder()
+                        .status(StatusCode::NO_CONTENT)
+                        .body(Body::empty())
+                        .expect("valid response"),
+                )
+            },
+        ));
+
+        let request = Request::builder()
+            .method("HEAD")
+            .uri("/api/orders")
+            .body(Body::empty())
+            .expect("request");
+        let response = service.oneshot(request).await.expect("response");
+        let _ = read_body(response).await;
+
+        settle(|| registry.stats().compared == 1).await;
+        assert_eq!(registry.stats().matched, 1);
+    }
+}

--- a/autumn/src/shadow/layer.rs
+++ b/autumn/src/shadow/layer.rs
@@ -211,7 +211,14 @@ where
         let pending = match decision {
             MirrorDecision::Mirror => Some(PendingMirror {
                 method: req.method().clone(),
-                headers: forwarded_headers(req.headers()),
+                // The trusted-proxy layer runs at the `axum::serve` boundary,
+                // outside this one, so its verdict is already stamped here.
+                headers: forwarded_headers(
+                    req.headers(),
+                    req.extensions()
+                        .get::<crate::security::ResolvedClientIdentity>()
+                        .and_then(|id| id.host.as_deref()),
+                ),
                 // Prefer axum's matched route template over the configured
                 // pattern: this layer is applied with `Router::layer`, which
                 // wraps each route's service, so routing — and the

--- a/autumn/src/shadow/layer.rs
+++ b/autumn/src/shadow/layer.rs
@@ -81,9 +81,8 @@ use crate::time::ClockSource;
 /// Labelled by route and one
 /// of `match`, `diverged`, `error`, `timeout`, `skipped` (a body over the
 /// capture budget), `dropped` (the in-flight ceiling was full), `refused` (the
-/// live build answered with an admission-control status — see
-/// [`ADMISSION_CONTROL_STATUSES`]), or `incomplete` (the client never finished
-/// reading the primary response).
+/// live build answered `429`/`503`, so the request never reached a handler), or
+/// `incomplete` (the client never finished reading the primary response).
 pub const COMPARISONS_METRIC: &str = "autumn_shadow_comparisons_total";
 
 /// Metric recording divergences only, labelled by route and divergence kind.

--- a/autumn/src/shadow/layer.rs
+++ b/autumn/src/shadow/layer.rs
@@ -82,7 +82,9 @@ use crate::time::ClockSource;
 /// of `match`, `diverged`, `error`, `timeout`, `skipped` (a body over the
 /// capture budget), `dropped` (the in-flight ceiling was full), `refused` (the
 /// live build answered `429`/`503`, so the request never reached a handler), or
-/// `incomplete` (the client never finished reading the primary response).
+/// `incomplete` (the client never finished reading the primary response), or
+/// `primary_error` (the LIVE build's own response could not be decoded — not a
+/// candidate failure, and counted apart from one).
 pub const COMPARISONS_METRIC: &str = "autumn_shadow_comparisons_total";
 
 /// Metric recording divergences only, labelled by route and divergence kind.
@@ -414,10 +416,10 @@ async fn run_mirror(
     // does not decode is an *error*. Folding both into `skipped_oversize` would
     // show an operator a size-budget skip for what is actually a malformed
     // encoding, and lose the reason entirely.
-    let Some(primary_body) = decode_side(&ctx, &context, "primary", &primary) else {
+    let Some(primary_body) = decode_side(&ctx, &context, PRIMARY, &primary) else {
         return;
     };
-    let Some(shadow_body) = decode_side(&ctx, &context, "shadow", &shadow) else {
+    let Some(shadow_body) = decode_side(&ctx, &context, SHADOW, &shadow) else {
         return;
     };
     let primary = ResponseFacts::encoded(primary.status, primary.content_type, None, primary_body);
@@ -464,7 +466,13 @@ async fn run_mirror(
     }
 }
 
-/// Decode one side's body, counting the two failure modes distinctly.
+/// Label for the live build in [`decode_side`].
+const PRIMARY: &str = "primary";
+
+/// Label for the candidate build in [`decode_side`].
+const SHADOW: &str = "shadow";
+
+/// Decode one side's body, counting the failure modes distinctly.
 ///
 /// `None` means the comparison cannot proceed and has already been counted.
 fn decode_side(
@@ -485,8 +493,17 @@ fn decode_side(
             None
         }
         Err(error) => {
-            ctx.registry.record_shadow_error();
-            record_outcome(&ctx.registry, &context.route, error.as_str());
+            // Attributed to the side that produced it. `shadow_errors` is
+            // documented as candidate failures, so counting the live build's
+            // own malformed response there would send an operator hunting
+            // candidate connectivity for a body their own handler emitted.
+            if side == PRIMARY {
+                ctx.registry.record_primary_error();
+                record_outcome(&ctx.registry, &context.route, "primary_error");
+            } else {
+                ctx.registry.record_shadow_error();
+                record_outcome(&ctx.registry, &context.route, error.as_str());
+            }
             tracing::debug!(
                 target: "autumn::shadow",
                 route = %context.route,
@@ -1413,6 +1430,49 @@ mod tests {
             stats.shadow_errors, 0,
             "an empty body is not a decode failure"
         );
+    }
+
+    #[tokio::test]
+    async fn a_malformed_primary_body_is_not_blamed_on_the_candidate() {
+        // `shadow_errors` is documented as CANDIDATE failures. Counting the
+        // live build's own undecodable response there sends an operator hunting
+        // candidate connectivity for a body their own handler emitted.
+        let transport = FakeTransport::new(Behaviour::Reply {
+            status: 200,
+            body: r#"{"ok":true}"#,
+        });
+        let registry = ShadowRegistry::new(10);
+        let service = layer(transport.clone(), &registry, settings()).layer(service_fn(
+            |_req: Request<Body>| async move {
+                Ok::<_, std::convert::Infallible>(
+                    Response::builder()
+                        .status(StatusCode::OK)
+                        .header("content-type", "application/json")
+                        .header("content-encoding", "gzip")
+                        .body(Body::from("this is definitely not gzip"))
+                        .expect("valid response"),
+                )
+            },
+        ));
+
+        let request = Request::builder()
+            .uri("/api/orders")
+            .body(Body::empty())
+            .expect("request");
+        let response = service.oneshot(request).await.expect("response");
+        let _ = read_body(response).await;
+
+        settle("the primary decode failure to be counted", || {
+            registry.stats().primary_errors == 1
+        })
+        .await;
+        let stats = registry.stats();
+        assert_eq!(stats.primary_errors, 1);
+        assert_eq!(
+            stats.shadow_errors, 0,
+            "the candidate answered fine; it must not be blamed"
+        );
+        assert_eq!(stats.compared, 0);
     }
 
     #[tokio::test]

--- a/autumn/src/shadow/layer.rs
+++ b/autumn/src/shadow/layer.rs
@@ -1371,6 +1371,51 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn a_head_on_a_precompressed_route_still_compares() {
+        // A `HEAD` sends no body while keeping its representation headers, so
+        // both sides arrive as zero bytes still declaring `Content-Encoding:
+        // gzip`. Handing that to a decoder fails with an unexpected EOF — which
+        // would have two identical builds counted as `shadow_errors` and never
+        // compared, on every precompressed route answering `HEAD`.
+        let transport = FakeTransport::new(Behaviour::Reply {
+            status: 200,
+            body: "",
+        });
+        let registry = ShadowRegistry::new(10);
+        let service = layer(transport.clone(), &registry, settings()).layer(service_fn(
+            |_req: Request<Body>| async move {
+                Ok::<_, std::convert::Infallible>(
+                    Response::builder()
+                        .status(StatusCode::OK)
+                        .header("content-type", "application/json")
+                        .header("content-encoding", "gzip")
+                        .body(Body::from(gzipped(br#"{"ok":true}"#)))
+                        .expect("valid response"),
+                )
+            },
+        ));
+
+        let request = Request::builder()
+            .method("HEAD")
+            .uri("/api/orders")
+            .body(Body::empty())
+            .expect("request");
+        let response = service.oneshot(request).await.expect("response");
+        assert_eq!(response.status(), StatusCode::OK);
+
+        settle("the HEAD comparison to be recorded", || {
+            registry.stats().compared == 1
+        })
+        .await;
+        let stats = registry.stats();
+        assert_eq!(stats.matched, 1, "a HEAD compares on status class alone");
+        assert_eq!(
+            stats.shadow_errors, 0,
+            "an empty body is not a decode failure"
+        );
+    }
+
+    #[tokio::test]
     async fn a_malformed_encoding_is_an_error_not_a_size_skip() {
         // An operator seeing `skipped_oversize` would go looking for a body
         // over `max_body_bytes`, when the real problem is a response whose

--- a/autumn/src/shadow/layer.rs
+++ b/autumn/src/shadow/layer.rs
@@ -336,8 +336,15 @@ async fn run_mirror(
     // The permit is released when this task ends, whatever the outcome.
     let _permit = permit;
 
-    let shadow = match tokio::time::timeout(ctx.settings.timeout, ctx.transport.send(request)).await
-    {
+    // ONE deadline for the whole mirror, stamped at dispatch and shared by both
+    // waits below. Two independent `timeout(settings.timeout, ..)` calls would
+    // let a shadow that answers just under the deadline be followed by a fresh
+    // full deadline on the primary wait — up to `2 * timeout_ms` holding a slot,
+    // which at capacity keeps every later mirror dropped for twice as long as
+    // the operator configured, against this module's stated guarantee.
+    let deadline = tokio::time::Instant::now() + ctx.settings.timeout;
+
+    let shadow = match tokio::time::timeout_at(deadline, ctx.transport.send(request)).await {
         Err(_) | Ok(Err(ShadowError::Timeout)) => {
             ctx.registry.record_shadow_timeout();
             record_outcome(&ctx.registry, &context.route, ShadowError::Timeout.as_str());
@@ -365,7 +372,7 @@ async fn run_mirror(
     // silently off for the rest of the process's life. `Err` on the channel
     // means the same thing arrived sooner — the client disconnected, or the
     // response was aborted mid-stream.
-    let Ok(Ok(primary)) = tokio::time::timeout(ctx.settings.timeout, primary_rx).await else {
+    let Ok(Ok(primary)) = tokio::time::timeout_at(deadline, primary_rx).await else {
         ctx.registry.record_primary_incomplete();
         record_outcome(&ctx.registry, &context.route, "incomplete");
         return;
@@ -983,6 +990,41 @@ mod tests {
         })
         .await;
         assert_eq!(registry.stats().shadow_timeouts, 1);
+    }
+
+    #[tokio::test]
+    async fn one_deadline_covers_both_mirror_waits() {
+        // A shadow that answers just under the deadline must not then start a
+        // fresh full deadline on the primary wait: that would hold the permit
+        // for up to 2x the configured timeout, and at capacity would keep every
+        // later mirror dropped for twice as long as the operator asked for.
+        let transport = FakeTransport::new(Behaviour::Stall(Duration::from_millis(120)));
+        let registry = ShadowRegistry::new(10);
+        let mut settings = settings();
+        settings.timeout = Duration::from_millis(200);
+        settings.max_in_flight = 1;
+        let service =
+            layer(transport.clone(), &registry, settings).layer(primary(r#"{"ok":true}"#));
+
+        // Drop the response unread, so the primary wait never resolves on its
+        // own and only the shared deadline can end the mirror.
+        let request = Request::builder()
+            .uri("/api/orders")
+            .body(Body::empty())
+            .expect("request");
+        let response = service.oneshot(request).await.expect("response");
+        let started = std::time::Instant::now();
+        drop(response);
+
+        settle("the mirror to give up", || {
+            registry.stats().primary_incomplete == 1
+        })
+        .await;
+        let elapsed = started.elapsed();
+        assert!(
+            elapsed < Duration::from_millis(360),
+            "the mirror lived {elapsed:?}, close to twice the 200ms deadline"
+        );
     }
 
     #[tokio::test]

--- a/autumn/src/shadow/layer.rs
+++ b/autumn/src/shadow/layer.rs
@@ -64,16 +64,26 @@ use crate::log::filter::ParameterFilter;
 use crate::shadow::diff::{
     Comparison, DivergenceKind, ResponseFacts, compare, redact_path_and_query,
 };
-use crate::shadow::registry::{RequestContext, ShadowRegistry};
+use crate::shadow::registry::{Recorded, RequestContext, ShadowRegistry};
 use crate::shadow::sample::{MirrorDecision, MirrorSelector, roll_from};
 use crate::shadow::transport::{
     ShadowError, ShadowRequest, ShadowTransport, forwarded_headers, shadow_url,
 };
 use crate::time::ClockSource;
 
-/// Metric recording every mirrored request's outcome, labelled by the bounded
-/// route label and one of `match` / `diverged` / `error` / `timeout` /
-/// `skipped`.
+/// Built-in metric family recording every mirrored request's outcome.
+///
+/// Rendered by the actuator's Prometheus endpoint from
+/// [`ShadowRegistry::comparisons_by_route`], not through
+/// [`crate::metrics::counter`]: the `autumn_` namespace belongs to the
+/// framework's built-in families and the public facade correctly refuses it.
+///
+/// Labelled by route and one
+/// of `match`, `diverged`, `error`, `timeout`, `skipped` (a body over the
+/// capture budget), `dropped` (the in-flight ceiling was full), `refused` (the
+/// live build answered with an admission-control status — see
+/// [`ADMISSION_CONTROL_STATUSES`]), or `incomplete` (the client never finished
+/// reading the primary response).
 pub const COMPARISONS_METRIC: &str = "autumn_shadow_comparisons_total";
 
 /// Metric recording divergences only, labelled by route and divergence kind.
@@ -144,14 +154,6 @@ impl ShadowMirrorLayer {
         entropy: Arc<dyn Entropy>,
         clock: Arc<dyn ClockSource>,
     ) -> Self {
-        crate::metrics::describe_counter(
-            COMPARISONS_METRIC,
-            "Mirrored requests by route and comparison outcome",
-        );
-        crate::metrics::describe_counter(
-            DIVERGENCES_METRIC,
-            "Primary/shadow response divergences by route and kind",
-        );
         Self {
             ctx: Arc::new(MirrorContext {
                 settings,
@@ -207,23 +209,64 @@ where
                 roll_from(ctx.entropy.as_ref())
             });
 
-        let primary_tx = match decision {
-            MirrorDecision::Mirror => {
-                self.ctx
-                    .begin_mirror(req.method().clone(), &target, req.headers())
-            }
+        let pending = match decision {
+            MirrorDecision::Mirror => Some(PendingMirror {
+                method: req.method().clone(),
+                headers: forwarded_headers(req.headers()),
+                // Prefer axum's matched route template over the configured
+                // pattern: this layer is applied with `Router::layer`, which
+                // wraps each route's service, so routing — and the
+                // `MatchedPath` insertion — has already happened. It is a
+                // bounded, genuinely informative dimension; the raw path never
+                // is, which is why it is not the fallback.
+                route: req
+                    .extensions()
+                    .get::<axum::extract::MatchedPath>()
+                    .map_or_else(
+                        || self.ctx.selector.route_label(&target).to_owned(),
+                        |matched| matched.as_str().to_owned(),
+                    ),
+                target,
+            }),
             // Not mirrored: the request is forwarded with no wrapper at all, so
             // the overwhelmingly common path costs one decision and nothing
             // else — no body wrapper, no allocation, no metric.
-            MirrorDecision::Skip(_) => None,
+            MirrorDecision::Skip(reason) => {
+                tracing::trace!(
+                    target: "autumn::shadow",
+                    reason = reason.as_str(),
+                    "request not mirrored"
+                );
+                None
+            }
         };
 
         ShadowMirrorFuture {
             inner: self.inner.call(req),
-            primary_tx,
-            max_body_bytes: self.ctx.settings.max_body_bytes,
+            ctx: Arc::clone(&self.ctx),
+            pending,
         }
     }
+}
+
+/// A request that cleared the mirroring gates, held until its primary response
+/// exists.
+///
+/// Dispatch is deliberately deferred to the response path. Mirroring is
+/// fire-and-forget, so nothing is gained by racing the handler — and this layer
+/// sits *outside* every admission-control layer (load shed, maintenance mode,
+/// rate limiting, trusted-host, CORS). Dispatching on the request path would
+/// therefore replay traffic the live build is in the middle of refusing: the
+/// candidate, under none of those pressures, answers `200`, and every mirrored
+/// request during a maintenance window or a shed becomes a `status_class`
+/// divergence. Waiting for the status lets those be skipped, and spares the
+/// candidate the amplification at exactly the moment the replica is shedding
+/// because it is over capacity.
+struct PendingMirror {
+    method: Method,
+    target: String,
+    route: String,
+    headers: HeaderMap,
 }
 
 impl MirrorContext {
@@ -234,9 +277,7 @@ impl MirrorContext {
     /// there is nothing to compare against.
     fn begin_mirror(
         self: &Arc<Self>,
-        method: Method,
-        target: &str,
-        headers: &HeaderMap,
+        pending: PendingMirror,
     ) -> Option<oneshot::Sender<Option<ResponseFacts>>> {
         let Some(permit) =
             InFlightPermit::try_acquire(&self.in_flight, self.settings.max_in_flight)
@@ -246,19 +287,19 @@ impl MirrorContext {
             // memory growth on the *primary*, which is the one thing this
             // feature must never do.
             self.registry.record_dropped_at_capacity();
-            record_outcome(self.selector.route_label(target), "dropped");
+            record_outcome(&self.registry, &pending.route, "dropped");
             return None;
         };
 
         let request = ShadowRequest {
-            method,
-            url: shadow_url(&self.settings.target_base, target),
-            headers: forwarded_headers(headers),
+            method: pending.method,
+            url: shadow_url(&self.settings.target_base, &pending.target),
+            headers: pending.headers,
         };
         let context = RequestContext {
             method: request.method.to_string(),
-            target: redact_path_and_query(target, &self.filter),
-            route: self.selector.route_label(target).to_owned(),
+            target: redact_path_and_query(&pending.target, &self.filter),
+            route: pending.route,
         };
 
         // Mirroring needs somewhere to run the detached task. There always is
@@ -300,35 +341,45 @@ async fn run_mirror(
     {
         Err(_) | Ok(Err(ShadowError::Timeout)) => {
             ctx.registry.record_shadow_timeout();
-            record_outcome(&context.route, "timeout");
+            record_outcome(&ctx.registry, &context.route, ShadowError::Timeout.as_str());
             return;
         }
         Ok(Err(ShadowError::Oversize)) => {
             ctx.registry.record_skipped_oversize();
-            record_outcome(&context.route, "skipped");
+            record_outcome(&ctx.registry, &context.route, "skipped");
             return;
         }
         Ok(Err(error)) => {
             ctx.registry.record_shadow_error();
-            record_outcome(&context.route, "error");
+            record_outcome(&ctx.registry, &context.route, error.as_str());
             tracing::debug!(target: "autumn::shadow", route = %context.route, %error, "shadow request failed");
             return;
         }
         Ok(Ok(facts)) => facts,
     };
 
-    // `Err` means the primary body never completed — the client disconnected or
-    // the response was aborted mid-stream. There is no primary response to
-    // compare against, so nothing is recorded.
-    let Ok(primary) = primary_rx.await else {
-        return;
+    // The primary's teed body is bounded by the same deadline as the shadow
+    // request. It resolves when the CLIENT finishes reading the response, which
+    // is not something this process controls: a client reading a byte a minute,
+    // or a long-lived `text/event-stream`, would otherwise pin this permit for
+    // the life of that connection. `max_in_flight` of those and mirroring is
+    // silently off for the rest of the process's life. `Err` on the channel
+    // means the same thing arrived sooner — the client disconnected, or the
+    // response was aborted mid-stream.
+    let primary = match tokio::time::timeout(ctx.settings.timeout, primary_rx).await {
+        Ok(Ok(primary)) => primary,
+        Ok(Err(_)) | Err(_) => {
+            ctx.registry.record_primary_incomplete();
+            record_outcome(&ctx.registry, &context.route, "incomplete");
+            return;
+        }
     };
 
     // `None` means the primary body blew the capture budget; a shadow body may
     // do the same.
     let (Some(primary), true) = (primary, shadow.body.len() <= ctx.settings.max_body_bytes) else {
         ctx.registry.record_skipped_oversize();
-        record_outcome(&context.route, "skipped");
+        record_outcome(&ctx.registry, &context.route, "skipped");
         return;
     };
 
@@ -338,38 +389,51 @@ async fn run_mirror(
         &ctx.filter,
         ctx.settings.max_sample_bytes,
     );
-    record_outcome(&context.route, comparison.outcome_label());
-    if let Comparison::Diverged(divergence) = &comparison {
-        record_divergence(&context.route, divergence.kind);
+    record_outcome(&ctx.registry, &context.route, comparison.outcome_label());
+    let kind = match &comparison {
+        Comparison::Match => None,
+        Comparison::Diverged(divergence) => Some(divergence.kind),
+    };
+    if let Some(kind) = kind {
+        record_divergence(&ctx.registry, &context.route, kind);
+    }
+
+    let observed_at_ms = ctx.clock.now().timestamp_millis().unsigned_abs();
+    let recorded = ctx
+        .registry
+        .record_comparison(&context, comparison, observed_at_ms);
+
+    // One WARN per distinct divergence, not per occurrence. A candidate with a
+    // systematic regression diverges on EVERY mirrored request; at production
+    // rates that is a log line per request, drowning the warnings an operator
+    // actually needs. The registry already collapses repeats by fingerprint,
+    // so this reuses that decision. The recurrence count is in the actuator
+    // payload and in `autumn_shadow_divergences_total`.
+    if let Recorded::NewDivergence(divergence) = recorded {
         tracing::warn!(
             target: "autumn::shadow",
             route = %context.route,
             method = %context.method,
-            request_target = %context.target,
             kind = divergence.kind.as_str(),
             fingerprint = %divergence.fingerprint,
             primary_status = divergence.primary_status,
             shadow_status = divergence.shadow_status,
-            "shadow build diverged from the live build"
+            "shadow build diverged from the live build; see the shadow actuator endpoint \
+             for the redacted request target and response samples"
         );
     }
-    let observed_at_ms = ctx.clock.now().timestamp_millis().unsigned_abs();
-    ctx.registry
-        .record_comparison(&context, comparison, observed_at_ms);
 }
 
-fn record_outcome(route: &str, outcome: &'static str) {
-    crate::metrics::counter(COMPARISONS_METRIC)
-        .with_label("route", route.to_owned())
-        .with_label("outcome", outcome)
-        .increment(1);
+/// Record one comparison outcome against the `{route, outcome}` series the
+/// actuator scrapes as [`COMPARISONS_METRIC`].
+fn record_outcome(registry: &ShadowRegistry, route: &str, outcome: &'static str) {
+    registry.record_outcome(route, outcome);
 }
 
-fn record_divergence(route: &str, kind: DivergenceKind) {
-    crate::metrics::counter(DIVERGENCES_METRIC)
-        .with_label("route", route.to_owned())
-        .with_label("kind", kind.as_str())
-        .increment(1);
+/// Record one divergence against the `{route, kind}` series the actuator
+/// scrapes as [`DIVERGENCES_METRIC`].
+fn record_divergence(registry: &ShadowRegistry, route: &str, kind: DivergenceKind) {
+    registry.record_divergence_kind(route, kind.as_str());
 }
 
 /// The request target (`/path?query`) mirroring replays.
@@ -420,16 +484,31 @@ impl Drop for InFlightPermit {
     }
 }
 
+/// Statuses the framework's own admission control produces for a request that
+/// never reached a handler: `503` from maintenance mode, load shedding, or the
+/// request deadline, and `429` from the rate limiter.
+///
+/// A mirrored request that ends in one of these is not compared. The candidate
+/// is a separate process under none of those pressures, so it answers normally
+/// and the pair diverges on status class every single time — a divergence storm
+/// through a planned maintenance window, filling the bounded record ring with
+/// noise and driving the metric operators alert on. The cost is that a genuine
+/// handler-produced `503`/`429` divergence is not reported either; that is the
+/// conservative side of the trade.
+const ADMISSION_CONTROL_STATUSES: [u16; 2] = [429, 503];
+
 pin_project! {
     /// Future returned by [`ShadowMirrorService`].
     ///
-    /// When the request was selected for mirroring it wraps the response body
-    /// in the tee; otherwise it is a transparent pass-through.
+    /// When the request was selected for mirroring, this is where the mirror is
+    /// actually dispatched — see [`PendingMirror`] for why that waits for the
+    /// response — and where the response body is wrapped in the tee. Otherwise
+    /// it is a transparent pass-through.
     pub struct ShadowMirrorFuture<F> {
         #[pin]
         inner: F,
-        primary_tx: Option<oneshot::Sender<Option<ResponseFacts>>>,
-        max_body_bytes: usize,
+        ctx: Arc<MirrorContext>,
+        pending: Option<PendingMirror>,
     }
 }
 
@@ -442,11 +521,51 @@ where
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let this = self.project();
         let response = std::task::ready!(this.inner.poll(cx))?;
-        let Some(tx) = this.primary_tx.take() else {
+        let Some(pending) = this.pending.take() else {
             return Poll::Ready(Ok(response));
         };
-        Poll::Ready(Ok(tee_response(response, tx, *this.max_body_bytes)))
+
+        if ADMISSION_CONTROL_STATUSES.contains(&response.status().as_u16()) {
+            this.ctx.registry.record_skipped_refused();
+            record_outcome(&this.ctx.registry, &pending.route, "refused");
+            return Poll::Ready(Ok(response));
+        }
+
+        // A `HEAD` response carries no body on the wire, so the tee would never
+        // be polled and the facts would never be delivered — the mirror would
+        // burn a slot and record nothing. Worse, an upstream layer that *does*
+        // drain the body would hand the differ the `GET` body while the
+        // candidate's `HEAD` returns none, manufacturing a divergence on every
+        // request. Deliver empty facts now and leave the body alone: for a
+        // `HEAD`, status class is the only thing there is to compare.
+        let head = pending.method == Method::HEAD;
+        let Some(tx) = this.ctx.begin_mirror(pending) else {
+            return Poll::Ready(Ok(response));
+        };
+        if head {
+            let (parts, body) = response.into_parts();
+            let _ = tx.send(Some(ResponseFacts::new(
+                parts.status.as_u16(),
+                content_type_of(&parts.headers),
+                Bytes::new(),
+            )));
+            return Poll::Ready(Ok(Response::from_parts(parts, body)));
+        }
+
+        Poll::Ready(Ok(tee_response(
+            response,
+            tx,
+            this.ctx.settings.max_body_bytes,
+        )))
     }
+}
+
+/// The `Content-Type` header value, when the response carries a readable one.
+fn content_type_of(headers: &HeaderMap) -> Option<String> {
+    headers
+        .get(axum::http::header::CONTENT_TYPE)
+        .and_then(|value| value.to_str().ok())
+        .map(ToOwned::to_owned)
 }
 
 /// Wrap a response body so a copy of its bytes reaches `tx` once the client has
@@ -457,11 +576,7 @@ fn tee_response(
     max_body_bytes: usize,
 ) -> Response<Body> {
     let status = response.status().as_u16();
-    let content_type = response
-        .headers()
-        .get(axum::http::header::CONTENT_TYPE)
-        .and_then(|value| value.to_str().ok())
-        .map(ToOwned::to_owned);
+    let content_type = content_type_of(response.headers());
 
     let (parts, body) = response.into_parts();
 
@@ -502,6 +617,16 @@ struct MirrorTeeBody {
 impl MirrorTeeBody {
     fn capture(&mut self, data: &Bytes) {
         if self.overflowed {
+            return;
+        }
+        // Nobody is waiting any more — the mirror task gave up (its deadline,
+        // a transport failure) or finished. Without this check the buffer keeps
+        // growing to `max_body_bytes` for a receiver that no longer exists, so
+        // the memory the tee holds would be bounded by *inbound concurrency*
+        // rather than by `max_in_flight` — the ceiling would stop meaning what
+        // the module docs say it means.
+        if self.tx.as_ref().is_some_and(oneshot::Sender::is_closed) {
+            self.tx = None;
             return;
         }
         if self.captured.len().saturating_add(data.len()) > self.max_body_bytes {
@@ -697,15 +822,21 @@ mod tests {
         String::from_utf8_lossy(&bytes).into_owned()
     }
 
-    /// Wait until `condition` holds or ~2 s elapse. The mirror runs on a
-    /// detached task, so tests observe its effects rather than awaiting it.
-    async fn settle(mut condition: impl FnMut() -> bool) {
-        for _ in 0..200 {
+    /// Wait until `condition` holds, or fail the test naming it.
+    ///
+    /// The mirror runs on a detached task, so tests observe its effects rather
+    /// than awaiting it. Panicking on exhaustion matters: a silent
+    /// fall-through turns "the mirror never ran" into a confusing assertion
+    /// failure three lines later, and on a loaded CI runner that is the
+    /// difference between a diagnosable failure and a mystery.
+    async fn settle(what: &str, mut condition: impl FnMut() -> bool) {
+        for _ in 0..500 {
             if condition() {
                 return;
             }
             tokio::time::sleep(Duration::from_millis(10)).await;
         }
+        panic!("timed out after 5s waiting for: {what}");
     }
 
     #[tokio::test]
@@ -748,17 +879,23 @@ mod tests {
         let response = service.oneshot(request).await.expect("response");
         assert_eq!(read_body(response).await, r#"{"ok":true}"#);
 
-        settle(|| !transport.seen().is_empty()).await;
+        settle("the shadow request to be sent", || {
+            !transport.seen().is_empty()
+        })
+        .await;
         let seen = transport.seen();
         assert_eq!(seen.len(), 1);
         assert_eq!(seen[0].url, "http://shadow.invalid/api/orders?page=2");
         assert_eq!(seen[0].method, axum::http::Method::GET);
         assert!(seen[0].headers.contains_key(SHADOW_HEADER));
 
-        settle(|| registry.stats().compared == 1).await;
+        settle("the comparison to be recorded", || {
+            registry.stats().matched == 1
+        })
+        .await;
         let stats = registry.stats();
         assert_eq!(stats.mirrored, 1);
-        assert_eq!(stats.matched, 1);
+        assert_eq!(stats.compared, 1);
         assert_eq!(stats.diverged, 0);
     }
 
@@ -783,7 +920,10 @@ mod tests {
             "the client must receive the primary body, untouched"
         );
 
-        settle(|| registry.stats().diverged == 1).await;
+        settle("the divergence record to land", || {
+            !registry.recent().is_empty()
+        })
+        .await;
         let recent = registry.recent();
         assert_eq!(recent.len(), 1);
         assert_eq!(recent[0].divergence.kind, DivergenceKind::Body);
@@ -805,7 +945,10 @@ mod tests {
         assert_eq!(response.status(), StatusCode::OK);
         assert_eq!(read_body(response).await, r#"{"ok":true}"#);
 
-        settle(|| registry.stats().shadow_errors == 1).await;
+        settle("the transport failure to be counted", || {
+            registry.stats().shadow_errors == 1
+        })
+        .await;
         assert_eq!(registry.stats().shadow_errors, 1);
         assert_eq!(registry.stats().compared, 0);
     }
@@ -829,12 +972,20 @@ mod tests {
         let elapsed = started.elapsed();
 
         assert_eq!(body, r#"{"ok":true}"#);
+        // The shadow stalls for 30 s against a 50 ms deadline. A client that
+        // waited on the mirror at all would show at least that deadline here;
+        // one that waited on the stall would show 30 s. A looser bound would
+        // pass even if the mirror were awaited inline, which is the whole
+        // property under test.
         assert!(
-            elapsed < Duration::from_secs(5),
+            elapsed < Duration::from_millis(100),
             "the client waited {elapsed:?} on a stalled shadow"
         );
 
-        settle(|| registry.stats().shadow_timeouts == 1).await;
+        settle("the shadow deadline to fire", || {
+            registry.stats().shadow_timeouts == 1
+        })
+        .await;
         assert_eq!(registry.stats().shadow_timeouts, 1);
     }
 
@@ -857,7 +1008,10 @@ mod tests {
             let _ = read_body(response).await;
         }
 
-        settle(|| registry.stats().dropped_at_capacity >= 3).await;
+        settle("the excess mirrors to be dropped", || {
+            registry.stats().dropped_at_capacity >= 3
+        })
+        .await;
         let stats = registry.stats();
         assert_eq!(stats.mirrored, 1, "only one mirror may be in flight");
         assert_eq!(stats.dropped_at_capacity, 3);
@@ -886,7 +1040,10 @@ mod tests {
             "an oversized body must still stream to the client in full"
         );
 
-        settle(|| registry.stats().skipped_oversize == 1).await;
+        settle("the oversize body to be skipped", || {
+            registry.stats().skipped_oversize == 1
+        })
+        .await;
         assert_eq!(registry.stats().skipped_oversize, 1);
         assert_eq!(registry.stats().compared, 0);
     }
@@ -909,7 +1066,10 @@ mod tests {
         let response = service.oneshot(request).await.expect("response");
         let _ = read_body(response).await;
 
-        settle(|| registry.stats().skipped_oversize == 1).await;
+        settle("the oversize body to be skipped", || {
+            registry.stats().skipped_oversize == 1
+        })
+        .await;
         assert_eq!(registry.stats().skipped_oversize, 1);
         assert_eq!(registry.stats().compared, 0);
     }
@@ -930,7 +1090,10 @@ mod tests {
         let response = service.oneshot(request).await.expect("response");
         assert_eq!(read_body(response).await, r#"{"ok":true}"#);
 
-        settle(|| registry.stats().skipped_oversize == 1).await;
+        settle("the oversize body to be skipped", || {
+            registry.stats().skipped_oversize == 1
+        })
+        .await;
         let stats = registry.stats();
         assert_eq!(stats.skipped_oversize, 1);
         assert_eq!(
@@ -956,7 +1119,10 @@ mod tests {
         let response = service.oneshot(request).await.expect("response");
         let _ = read_body(response).await;
 
-        settle(|| registry.stats().diverged == 1).await;
+        settle("the divergence record to land", || {
+            !registry.recent().is_empty()
+        })
+        .await;
         let recent = registry.recent();
         assert_eq!(recent.len(), 1);
         assert!(
@@ -965,6 +1131,188 @@ mod tests {
             recent[0].target
         );
         assert!(recent[0].target.contains("page=2"));
+    }
+
+    #[tokio::test]
+    async fn a_permit_is_released_so_mirroring_survives_the_first_batch() {
+        // The ceiling test only ever fills slots; nothing proved they come
+        // back. If `InFlightPermit::drop` were a no-op the whole suite would
+        // still pass, and production mirroring would silently stop after
+        // `max_in_flight` requests.
+        let transport = FakeTransport::new(Behaviour::Reply {
+            status: 200,
+            body: r#"{"ok":true}"#,
+        });
+        let registry = ShadowRegistry::new(10);
+        let mut settings = settings();
+        settings.max_in_flight = 1;
+        let mirror = layer(transport.clone(), &registry, settings);
+
+        for expected in 1..=3 {
+            let service = mirror.clone().layer(primary(r#"{"ok":true}"#));
+            let request = Request::builder()
+                .uri("/api/orders")
+                .body(Body::empty())
+                .expect("request");
+            let response = service.oneshot(request).await.expect("response");
+            let _ = read_body(response).await;
+            settle("the slot to be released", || {
+                registry.stats().matched == expected
+            })
+            .await;
+        }
+
+        let stats = registry.stats();
+        assert_eq!(stats.mirrored, 3, "a single slot must be reusable");
+        assert_eq!(stats.dropped_at_capacity, 0);
+    }
+
+    #[tokio::test]
+    async fn a_request_the_live_build_refused_is_not_mirrored() {
+        // This layer sits outside load shedding, maintenance mode and the rate
+        // limiter, so without this the candidate — under none of those
+        // pressures — answers 200 and every request through a maintenance
+        // window becomes a status-class divergence.
+        for status in [
+            StatusCode::TOO_MANY_REQUESTS,
+            StatusCode::SERVICE_UNAVAILABLE,
+        ] {
+            let transport = FakeTransport::new(Behaviour::Reply {
+                status: 200,
+                body: r#"{"ok":true}"#,
+            });
+            let registry = ShadowRegistry::new(10);
+            let service = layer(transport.clone(), &registry, settings()).layer(service_fn(
+                move |_req: Request<Body>| async move {
+                    Ok::<_, std::convert::Infallible>(
+                        Response::builder()
+                            .status(status)
+                            .body(Body::from("rejected"))
+                            .expect("valid response"),
+                    )
+                },
+            ));
+
+            let request = Request::builder()
+                .uri("/api/orders")
+                .body(Body::empty())
+                .expect("request");
+            let response = service.oneshot(request).await.expect("response");
+            assert_eq!(response.status(), status);
+            let _ = read_body(response).await;
+
+            settle("the refusal to be counted", || {
+                registry.stats().skipped_refused == 1
+            })
+            .await;
+            let stats = registry.stats();
+            assert_eq!(stats.mirrored, 0, "{status} must not reach the candidate");
+            assert_eq!(stats.diverged, 0);
+            assert!(transport.seen().is_empty());
+        }
+    }
+
+    #[tokio::test]
+    async fn a_head_request_compares_on_status_class_alone() {
+        // A `HEAD` response carries no body on the wire, so a tee would never
+        // be polled: the mirror would burn a slot and record nothing. The
+        // facts are delivered up front instead, and both sides compare empty.
+        let transport = FakeTransport::new(Behaviour::Reply {
+            status: 200,
+            body: "",
+        });
+        let registry = ShadowRegistry::new(10);
+        let service = layer(transport.clone(), &registry, settings())
+            .layer(primary(r#"{"ok":true,"total":42}"#));
+
+        let request = Request::builder()
+            .method("HEAD")
+            .uri("/api/orders")
+            .body(Body::empty())
+            .expect("request");
+        let response = service.oneshot(request).await.expect("response");
+        assert_eq!(response.status(), StatusCode::OK);
+
+        settle("the HEAD comparison to be recorded", || {
+            registry.stats().compared == 1
+        })
+        .await;
+        assert_eq!(
+            registry.stats().matched,
+            1,
+            "a HEAD must not diff the GET body against the candidate's empty one"
+        );
+        let seen = transport.seen();
+        assert_eq!(seen.len(), 1);
+        assert_eq!(seen[0].method, axum::http::Method::HEAD);
+    }
+
+    #[tokio::test]
+    async fn a_primary_body_the_client_never_finishes_is_counted_not_leaked() {
+        // Dropping the response without reading it stands in for a client that
+        // disconnects. Without the deadline on the primary wait this would
+        // hold its slot until the process ended; without the counter the
+        // operator would see `mirrored` exceed every other counter with
+        // nothing explaining the gap.
+        let transport = FakeTransport::new(Behaviour::Reply {
+            status: 200,
+            body: r#"{"ok":true}"#,
+        });
+        let registry = ShadowRegistry::new(10);
+        let mut settings = settings();
+        settings.timeout = Duration::from_millis(50);
+        let service =
+            layer(transport.clone(), &registry, settings).layer(primary(r#"{"ok":true}"#));
+
+        let request = Request::builder()
+            .uri("/api/orders")
+            .body(Body::empty())
+            .expect("request");
+        let response = service.oneshot(request).await.expect("response");
+        drop(response); // never read the body
+
+        settle("the abandoned primary to be counted", || {
+            registry.stats().primary_incomplete == 1
+        })
+        .await;
+        let stats = registry.stats();
+        assert_eq!(stats.mirrored, 1);
+        assert_eq!(stats.compared, 0);
+        assert_eq!(stats.primary_incomplete, 1);
+    }
+
+    #[tokio::test]
+    async fn the_route_label_prefers_the_matched_route_template() {
+        let transport = FakeTransport::new(Behaviour::Reply {
+            status: 200,
+            body: "{}",
+        });
+        let registry = ShadowRegistry::new(10);
+        // Route the request through a real axum Router so `MatchedPath` is set,
+        // exactly as it is for the framework's own ingress stack.
+        let router: axum::Router = axum::Router::new()
+            .route(
+                "/api/orders/{id}",
+                axum::routing::get(|| async { r#"{"ok":true}"# }),
+            )
+            .layer(layer(transport.clone(), &registry, settings()));
+
+        let request = Request::builder()
+            .uri("/api/orders/42")
+            .body(Body::empty())
+            .expect("request");
+        let response = router.oneshot(request).await.expect("response");
+        let _ = read_body(response).await;
+
+        settle("the divergence record to land", || {
+            !registry.recent().is_empty()
+        })
+        .await;
+        assert_eq!(
+            registry.recent()[0].route,
+            "/api/orders/{id}",
+            "the bounded route template beats both the raw path and the fallback"
+        );
     }
 
     #[tokio::test]
@@ -993,7 +1341,10 @@ mod tests {
         let response = service.oneshot(request).await.expect("response");
         let _ = read_body(response).await;
 
-        settle(|| registry.stats().compared == 1).await;
-        assert_eq!(registry.stats().matched, 1);
+        settle("the comparison to be recorded", || {
+            registry.stats().matched == 1
+        })
+        .await;
+        assert_eq!(registry.stats().compared, 1);
     }
 }

--- a/autumn/src/shadow/layer.rs
+++ b/autumn/src/shadow/layer.rs
@@ -216,8 +216,7 @@ where
                 headers: forwarded_headers(
                     req.headers(),
                     req.extensions()
-                        .get::<crate::security::ResolvedClientIdentity>()
-                        .and_then(|id| id.host.as_deref()),
+                        .get::<crate::security::ResolvedClientIdentity>(),
                 ),
                 // Prefer axum's matched route template over the configured
                 // pattern: this layer is applied with `Router::layer`, which

--- a/autumn/src/shadow/layer.rs
+++ b/autumn/src/shadow/layer.rs
@@ -342,12 +342,19 @@ async fn run_mirror(
     // The permit is released when this task ends, whatever the outcome.
     let _permit = permit;
 
-    // ONE deadline for the whole mirror, stamped at dispatch and shared by both
-    // waits below. Two independent `timeout(settings.timeout, ..)` calls would
-    // let a shadow that answers just under the deadline be followed by a fresh
-    // full deadline on the primary wait — up to `2 * timeout_ms` holding a slot,
-    // which at capacity keeps every later mirror dropped for twice as long as
-    // the operator configured, against this module's stated guarantee.
+    // ONE deadline for the mirror's WAITING, stamped at dispatch and shared by
+    // both waits below. Two independent `timeout(settings.timeout, ..)` calls
+    // would let a shadow that answers just under the deadline be followed by a
+    // fresh full deadline on the primary wait — up to `2 * timeout_ms` holding
+    // a slot, which at capacity keeps every later mirror dropped for twice as
+    // long as the operator configured.
+    //
+    // KNOWN LIMITATION: it does NOT cover the comparison that follows. Decoding,
+    // canonicalising and digesting both bodies is bounded work (`max_body_bytes`
+    // caps each side) but runs with the permit still held, so a mirror can
+    // outlive `timeout_ms` by that much. Whether `max_in_flight` should bound
+    // outstanding *requests* or outstanding *mirrors* is the open question in
+    // issue #2333.
     let now = tokio::time::Instant::now();
     // `checked_add`, not `+`: this module's panic gate denies arithmetic that
     // can panic, and `Instant + Duration` does on overflow. An absurd
@@ -402,21 +409,15 @@ async fn run_mirror(
     // tee captures encoded bytes just as the candidate's response can arrive
     // encoded — decoding only one of them would report two identical builds as
     // divergent on every such route.
-    let (Ok(primary_body), Ok(shadow_body)) = (
-        crate::shadow::transport::decode_body(
-            primary.content_encoding.as_deref(),
-            primary.body.clone(),
-            ctx.settings.max_body_bytes,
-        ),
-        crate::shadow::transport::decode_body(
-            shadow.content_encoding.as_deref(),
-            shadow.body.clone(),
-            ctx.settings.max_body_bytes,
-        ),
-    ) else {
-        // Undecodable or over-budget once expanded: counted, never guessed at.
-        ctx.registry.record_skipped_oversize();
-        record_outcome(&ctx.registry, &context.route, "skipped");
+    // Decoded separately, and their failures told apart: a body that expands
+    // past the budget is a *size* skip, while a body whose declared encoding
+    // does not decode is an *error*. Folding both into `skipped_oversize` would
+    // show an operator a size-budget skip for what is actually a malformed
+    // encoding, and lose the reason entirely.
+    let Some(primary_body) = decode_side(&ctx, &context, "primary", &primary) else {
+        return;
+    };
+    let Some(shadow_body) = decode_side(&ctx, &context, "shadow", &shadow) else {
         return;
     };
     let primary = ResponseFacts::encoded(primary.status, primary.content_type, None, primary_body);
@@ -460,6 +461,41 @@ async fn run_mirror(
             "shadow build diverged from the live build; see the shadow actuator endpoint \
              for the redacted request target and response samples"
         );
+    }
+}
+
+/// Decode one side's body, counting the two failure modes distinctly.
+///
+/// `None` means the comparison cannot proceed and has already been counted.
+fn decode_side(
+    ctx: &MirrorContext,
+    context: &RequestContext,
+    side: &'static str,
+    facts: &ResponseFacts,
+) -> Option<Bytes> {
+    match crate::shadow::transport::decode_body(
+        facts.content_encoding.as_deref(),
+        facts.body.clone(),
+        ctx.settings.max_body_bytes,
+    ) {
+        Ok(body) => Some(body),
+        Err(ShadowError::Oversize) => {
+            ctx.registry.record_skipped_oversize();
+            record_outcome(&ctx.registry, &context.route, "skipped");
+            None
+        }
+        Err(error) => {
+            ctx.registry.record_shadow_error();
+            record_outcome(&ctx.registry, &context.route, error.as_str());
+            tracing::debug!(
+                target: "autumn::shadow",
+                route = %context.route,
+                side,
+                %error,
+                "could not decode a mirrored response body"
+            );
+            None
+        }
     }
 }
 
@@ -788,6 +824,8 @@ mod tests {
         ReplyGzipped {
             body: &'static str,
         },
+        /// Answer claiming an encoding the bytes do not actually carry.
+        ReplyMisencoded,
         Reply {
             status: u16,
             body: &'static str,
@@ -838,6 +876,12 @@ mod tests {
                         Some("application/json".to_owned()),
                         Some("gzip".to_owned()),
                         gzipped(body.as_bytes()),
+                    )),
+                    Behaviour::ReplyMisencoded => Ok(ResponseFacts::encoded(
+                        200,
+                        Some("application/json".to_owned()),
+                        Some("gzip".to_owned()),
+                        bytes::Bytes::from_static(b"this is not gzip"),
                     )),
                     Behaviour::Fail => Err(ShadowError::Transport("refused".to_owned())),
                     Behaviour::Oversize => Err(ShadowError::Oversize),
@@ -1324,6 +1368,37 @@ mod tests {
         })
         .await;
         assert_eq!(registry.stats().matched, 1);
+    }
+
+    #[tokio::test]
+    async fn a_malformed_encoding_is_an_error_not_a_size_skip() {
+        // An operator seeing `skipped_oversize` would go looking for a body
+        // over `max_body_bytes`, when the real problem is a response whose
+        // declared encoding does not decode. Distinct counters, distinct
+        // outcome labels.
+        let transport = FakeTransport::new(Behaviour::ReplyMisencoded);
+        let registry = ShadowRegistry::new(10);
+        let service =
+            layer(transport.clone(), &registry, settings()).layer(primary(r#"{"ok":true}"#));
+
+        let request = Request::builder()
+            .uri("/api/orders")
+            .body(Body::empty())
+            .expect("request");
+        let response = service.oneshot(request).await.expect("response");
+        assert_eq!(read_body(response).await, r#"{"ok":true}"#);
+
+        settle("the decode failure to be counted", || {
+            registry.stats().shadow_errors == 1
+        })
+        .await;
+        let stats = registry.stats();
+        assert_eq!(stats.shadow_errors, 1);
+        assert_eq!(
+            stats.skipped_oversize, 0,
+            "a malformed encoding is not a size-budget skip"
+        );
+        assert_eq!(stats.compared, 0);
     }
 
     #[tokio::test]

--- a/autumn/src/shadow/layer.rs
+++ b/autumn/src/shadow/layer.rs
@@ -342,7 +342,12 @@ async fn run_mirror(
     // full deadline on the primary wait — up to `2 * timeout_ms` holding a slot,
     // which at capacity keeps every later mirror dropped for twice as long as
     // the operator configured, against this module's stated guarantee.
-    let deadline = tokio::time::Instant::now() + ctx.settings.timeout;
+    let now = tokio::time::Instant::now();
+    // `checked_add`, not `+`: this module's panic gate denies arithmetic that
+    // can panic, and `Instant + Duration` does on overflow. An absurd
+    // `timeout_ms` therefore degrades to an immediate deadline — the mirror
+    // gives up rather than the request path panicking.
+    let deadline = now.checked_add(ctx.settings.timeout).unwrap_or(now);
 
     let shadow = match tokio::time::timeout_at(deadline, ctx.transport.send(request)).await {
         Err(_) | Ok(Err(ShadowError::Timeout)) => {

--- a/autumn/src/shadow/mod.rs
+++ b/autumn/src/shadow/mod.rs
@@ -35,19 +35,36 @@
 //! assembled into the ingress stack by the framework router; nothing here needs
 //! to be called by hand. See `docs/guide/staged-deploys.md`.
 
-pub mod config;
-pub mod diff;
-pub mod layer;
-pub mod registry;
-pub mod sample;
+// Private modules behind a curated re-export list, matching
+// `crate::middleware`: the module split is an implementation detail, and
+// everything below is deliberate public surface. `transport` stays public
+// because a third party may want to implement [`ShadowTransport`] against a
+// non-HTTP candidate.
+pub(crate) mod config;
+pub(crate) mod diff;
+pub(crate) mod layer;
+pub(crate) mod registry;
+pub(crate) mod sample;
 pub mod transport;
 
 pub use config::ShadowConfig;
-pub use diff::{Comparison, Divergence, DivergenceKind, ResponseFacts, compare};
-pub use layer::{MirrorSettings, ShadowMirrorLayer};
-pub use registry::{DivergenceRecord, RequestContext, ShadowRegistry, ShadowSnapshot, ShadowStats};
-pub use sample::{MirrorDecision, MirrorSelector, SHADOW_HEADER, SHADOW_HEADER_VALUE, SkipReason};
-pub use transport::{ShadowError, ShadowRequest, ShadowTransport};
+pub use diff::{
+    Comparison, Divergence, DivergenceKind, NormalizedBody, ResponseFacts, compare, normalize_body,
+    redact_path_and_query, status_class,
+};
+pub use layer::{
+    COMPARISONS_METRIC, DIVERGENCES_METRIC, MirrorSettings, ShadowMirrorLayer, ShadowMirrorService,
+};
+pub use registry::{
+    DivergenceRecord, Recorded, RequestContext, ShadowRegistry, ShadowSnapshot, ShadowStats,
+};
+pub use sample::{
+    MIRRORABLE_METHODS, MirrorDecision, MirrorSelector, SHADOW_HEADER, SHADOW_HEADER_VALUE,
+    SkipReason,
+};
+#[cfg(feature = "http-client")]
+pub use transport::HttpShadowTransport;
+pub use transport::{ShadowError, ShadowFuture, ShadowRequest, ShadowTransport};
 
 /// What `{actuator-prefix}/shadow` needs to report on a mirror run: the
 /// registry plus the two facts that live in config rather than in it.
@@ -75,11 +92,22 @@ impl ShadowHandle {
     /// The payload for a replica that never assembled a mirror.
     #[must_use]
     pub fn disabled_snapshot() -> ShadowSnapshot {
-        ShadowSnapshot {
+        ShadowSnapshot::disabled()
+    }
+
+    /// A handle for a replica that configured `[shadow]` but could not assemble
+    /// a mirror — today, a build without the `http-client` feature, which has
+    /// no way to dial the candidate.
+    ///
+    /// Installed so the actuator can distinguish "configured but inert here"
+    /// from "never configured": both report `enabled: false`, but only this one
+    /// reports the target the operator asked for.
+    #[must_use]
+    pub fn inactive(target: impl Into<String>) -> Self {
+        Self {
+            registry: ShadowRegistry::new(1),
             enabled: false,
-            target: None,
-            stats: ShadowStats::default(),
-            divergences: Vec::new(),
+            target: Some(target.into()),
         }
     }
 }

--- a/autumn/src/shadow/mod.rs
+++ b/autumn/src/shadow/mod.rs
@@ -1,0 +1,85 @@
+//! Live-traffic shadow mirroring and primary-vs-shadow response diffing
+//! (issue #1653).
+//!
+//! Canary, blue/green, and rolling deploys all answer the same question — *are
+//! the aggregate metrics still healthy?* — and all of them route **real**
+//! traffic to the new build to answer it. None of them catches the regression
+//! that returns `200 OK` with a dropped field, a reordered list, or an
+//! off-by-one total, because nothing ever compares two responses to the same
+//! request. This module does.
+//!
+//! ```text
+//!                        ┌──────────────────┐
+//!   client ──request──▶  │  live build      │ ──response──▶ client
+//!                        └────────┬─────────┘        │
+//!                                 │ (copy)           │ (tee)
+//!                        ┌────────▼─────────┐   ┌────▼─────┐
+//!                        │ candidate build  │──▶│  differ  │──▶ /actuator/shadow
+//!                        └──────────────────┘   └──────────┘        + metrics
+//! ```
+//!
+//! The candidate's response reaches the differ and nothing else. It is never a
+//! `Response`, never touches the primary's state, and never delays the client.
+//!
+//! # Scope of this slice
+//!
+//! Idempotent (`GET`/`HEAD`) traffic only, against an operator-provided shadow
+//! target. Mirroring mutating methods requires virtualizing the candidate's
+//! effects — DB writes, outbound HTTP, `#[job]` enqueues — which is the
+//! deliberate follow-up slice. The method allowlist is therefore a constant,
+//! not a config key.
+//!
+//! # Wiring
+//!
+//! Configured through [`ShadowConfig`] (`[shadow]` in `autumn.toml`) and
+//! assembled into the ingress stack by the framework router; nothing here needs
+//! to be called by hand. See `docs/guide/staged-deploys.md`.
+
+pub mod config;
+pub mod diff;
+pub mod layer;
+pub mod registry;
+pub mod sample;
+pub mod transport;
+
+pub use config::ShadowConfig;
+pub use diff::{Comparison, Divergence, DivergenceKind, ResponseFacts, compare};
+pub use layer::{MirrorSettings, ShadowMirrorLayer};
+pub use registry::{DivergenceRecord, RequestContext, ShadowRegistry, ShadowSnapshot, ShadowStats};
+pub use sample::{MirrorDecision, MirrorSelector, SHADOW_HEADER, SHADOW_HEADER_VALUE, SkipReason};
+pub use transport::{ShadowError, ShadowRequest, ShadowTransport};
+
+/// What `{actuator-prefix}/shadow` needs to report on a mirror run: the
+/// registry plus the two facts that live in config rather than in it.
+///
+/// Installed into [`crate::AppState`]'s runtime extension map when the mirror
+/// layer is assembled, so a replica with mirroring switched off simply has no
+/// handle and the endpoint reports a disabled mirror.
+#[derive(Clone, Debug)]
+pub struct ShadowHandle {
+    /// Shared counters and the bounded divergence ring.
+    pub registry: ShadowRegistry,
+    /// Whether mirroring is switched on for this replica.
+    pub enabled: bool,
+    /// The configured candidate target.
+    pub target: Option<String>,
+}
+
+impl ShadowHandle {
+    /// Build the payload the actuator endpoint publishes.
+    #[must_use]
+    pub fn snapshot(&self) -> ShadowSnapshot {
+        self.registry.snapshot(self.enabled, self.target.as_deref())
+    }
+
+    /// The payload for a replica that never assembled a mirror.
+    #[must_use]
+    pub fn disabled_snapshot() -> ShadowSnapshot {
+        ShadowSnapshot {
+            enabled: false,
+            target: None,
+            stats: ShadowStats::default(),
+            divergences: Vec::new(),
+        }
+    }
+}

--- a/autumn/src/shadow/mod.rs
+++ b/autumn/src/shadow/mod.rs
@@ -31,7 +31,8 @@
 //!
 //! # Wiring
 //!
-//! Configured through [`ShadowConfig`] (`[shadow]` in `autumn.toml`) and
+//! Configured through [`ShadowConfig`](crate::shadow::ShadowConfig) (`[shadow]` in
+//! `autumn.toml`) and
 //! assembled into the ingress stack by the framework router; nothing here needs
 //! to be called by hand. See `docs/guide/staged-deploys.md`.
 
@@ -49,18 +50,19 @@ pub mod transport;
 
 pub use config::ShadowConfig;
 pub use diff::{
-    Comparison, Divergence, DivergenceKind, NormalizedBody, ResponseFacts, compare, normalize_body,
-    redact_path_and_query, status_class,
+    Comparison, Divergence, DivergenceKind, NormalizedBody, ResponseFacts, TRUNCATION_MARKER,
+    compare, normalize_body, redact_path_and_query, status_class,
 };
 pub use layer::{
     COMPARISONS_METRIC, DIVERGENCES_METRIC, MirrorSettings, ShadowMirrorLayer, ShadowMirrorService,
 };
 pub use registry::{
-    DivergenceRecord, Recorded, RequestContext, ShadowRegistry, ShadowSnapshot, ShadowStats,
+    DivergenceRecord, LabelledCount, OVERFLOW_ROUTE_LABEL, Recorded, RequestContext,
+    ShadowRegistry, ShadowSnapshot, ShadowStats,
 };
 pub use sample::{
     MIRRORABLE_METHODS, MirrorDecision, MirrorSelector, SHADOW_HEADER, SHADOW_HEADER_VALUE,
-    SkipReason,
+    SkipReason, roll_from,
 };
 #[cfg(feature = "http-client")]
 pub use transport::HttpShadowTransport;

--- a/autumn/src/shadow/registry.rs
+++ b/autumn/src/shadow/registry.rs
@@ -120,7 +120,7 @@ pub struct DivergenceRecord {
 /// the overflow is visible rather than silent.
 const MAX_ROUTE_SERIES: usize = 200;
 
-/// Route label every route past [`MAX_ROUTE_SERIES`] is folded into.
+/// Route label every route past the per-registry route ceiling is folded into.
 pub const OVERFLOW_ROUTE_LABEL: &str = "__other__";
 
 /// One `{route, outcome}` (or `{route, kind}`) counter series.
@@ -339,6 +339,7 @@ impl ShadowRegistry {
     /// The return value distinguishes a divergence seen for the first time from
     /// a repeat, so the caller can log once per distinct problem rather than
     /// once per request.
+    #[must_use = "the caller decides whether to log; ignore it with `let _ =` when not"]
     pub fn record_comparison(
         &self,
         context: &RequestContext,

--- a/autumn/src/shadow/registry.rs
+++ b/autumn/src/shadow/registry.rs
@@ -1,0 +1,420 @@
+//! In-memory shadow-run bookkeeping: counters plus a bounded ring of the most
+//! recent divergences (issue #1653).
+//!
+//! Modelled on [`crate::actuator::TaskRegistry`] — a cheaply cloneable handle
+//! over shared state that the actuator reads and the request path writes. Two
+//! properties matter more here than they do for tasks:
+//!
+//! - **Bounded.** A mirror run against a badly-regressed candidate diverges on
+//!   *every* request. The counters are unbounded (they saturate rather than
+//!   wrap), but the stored records are capped at `max_records` and identical
+//!   divergences collapse onto one record by
+//!   [`fingerprint`](crate::shadow::diff::Divergence::fingerprint) — so a
+//!   thousand copies of one regression occupy one slot, and the ring keeps
+//!   showing distinct problems rather than a thousand copies of the loudest.
+//! - **Clock-free.** The observation time is a parameter, never read from a
+//!   clock in here, so the whole recording path stays a pure function of its
+//!   inputs and a captured request replays to a byte-identical record.
+
+use std::collections::VecDeque;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, RwLock};
+
+use serde::Serialize;
+
+use crate::shadow::diff::{Comparison, Divergence};
+
+/// Aggregate counters for a shadow run.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize)]
+pub struct ShadowStats {
+    /// Requests selected for mirroring.
+    pub mirrored: u64,
+    /// Mirrored requests whose two responses were successfully compared.
+    pub compared: u64,
+    /// Comparisons where the builds agreed.
+    pub matched: u64,
+    /// Comparisons where they did not.
+    pub diverged: u64,
+    /// Shadow requests that failed at the transport (connection refused, DNS,
+    /// TLS, a malformed response).
+    pub shadow_errors: u64,
+    /// Shadow requests abandoned at the configured deadline.
+    pub shadow_timeouts: u64,
+    /// Requests dropped without being mirrored because the in-flight ceiling
+    /// was already reached.
+    pub dropped_at_capacity: u64,
+    /// Mirrored requests not compared because a response body exceeded
+    /// `shadow.max_body_bytes`.
+    pub skipped_oversize: u64,
+}
+
+/// The request a divergence was observed on.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RequestContext {
+    /// HTTP method (always `GET` or `HEAD` in this slice).
+    pub method: String,
+    /// Request target with sensitive query parameters already redacted — see
+    /// [`crate::shadow::diff::redact_path_and_query`].
+    pub target: String,
+    /// The bounded route label this request maps to (a configured pattern, or
+    /// `"*"`). Used as the metric dimension too.
+    pub route: String,
+}
+
+/// One stored divergence: the request it happened on, the comparison detail,
+/// and how often this exact divergence has recurred.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+pub struct DivergenceRecord {
+    /// HTTP method.
+    pub method: String,
+    /// Redacted request target.
+    pub target: String,
+    /// Bounded route label.
+    pub route: String,
+    /// Times this fingerprint has been seen.
+    pub occurrences: u64,
+    /// Epoch milliseconds of the first occurrence.
+    pub first_observed_at_ms: u64,
+    /// Epoch milliseconds of the most recent occurrence.
+    pub last_observed_at_ms: u64,
+    /// The comparison detail (kind, statuses, digests, redacted samples).
+    #[serde(flatten)]
+    pub divergence: Divergence,
+}
+
+/// Everything `{actuator-prefix}/shadow` publishes.
+#[derive(Clone, Debug, Serialize)]
+pub struct ShadowSnapshot {
+    /// Whether mirroring is switched on for this replica.
+    pub enabled: bool,
+    /// The configured candidate target, when there is one.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub target: Option<String>,
+    /// Aggregate counters.
+    pub stats: ShadowStats,
+    /// Most recent distinct divergences, oldest first.
+    pub divergences: Vec<DivergenceRecord>,
+}
+
+/// Shared, cheaply cloneable shadow-run state.
+#[derive(Clone, Debug)]
+pub struct ShadowRegistry {
+    counters: Arc<Counters>,
+    records: Arc<RwLock<VecDeque<DivergenceRecord>>>,
+    max_records: usize,
+}
+
+#[derive(Debug, Default)]
+struct Counters {
+    mirrored: AtomicU64,
+    compared: AtomicU64,
+    matched: AtomicU64,
+    diverged: AtomicU64,
+    shadow_errors: AtomicU64,
+    shadow_timeouts: AtomicU64,
+    dropped_at_capacity: AtomicU64,
+    skipped_oversize: AtomicU64,
+}
+
+/// Saturating increment: a long-lived replica must not wrap a counter back to
+/// zero and report a healthy mirror that has in fact diverged 2^64 times.
+fn bump(counter: &AtomicU64) {
+    let _ = counter.fetch_update(Ordering::Relaxed, Ordering::Relaxed, |current| {
+        Some(current.saturating_add(1))
+    });
+}
+
+impl ShadowRegistry {
+    /// Create a registry that keeps at most `max_records` distinct divergences.
+    ///
+    /// `max_records` of `0` is clamped to `1` so the ring can always hold the
+    /// evidence for at least one divergence; config validation rejects `0`
+    /// before this, so the clamp is belt-and-braces.
+    #[must_use]
+    pub fn new(max_records: usize) -> Self {
+        Self {
+            counters: Arc::new(Counters::default()),
+            records: Arc::new(RwLock::new(VecDeque::new())),
+            max_records: max_records.max(1),
+        }
+    }
+
+    /// Count a request selected for mirroring.
+    pub fn record_mirrored(&self) {
+        bump(&self.counters.mirrored);
+    }
+
+    /// Count a request dropped because the in-flight ceiling was reached.
+    pub fn record_dropped_at_capacity(&self) {
+        bump(&self.counters.dropped_at_capacity);
+    }
+
+    /// Count a shadow request that failed at the transport.
+    pub fn record_shadow_error(&self) {
+        bump(&self.counters.shadow_errors);
+    }
+
+    /// Count a shadow request abandoned at its deadline.
+    pub fn record_shadow_timeout(&self) {
+        bump(&self.counters.shadow_timeouts);
+    }
+
+    /// Count a mirrored request whose body was too large to compare.
+    pub fn record_skipped_oversize(&self) {
+        bump(&self.counters.skipped_oversize);
+    }
+
+    /// Record the outcome of one comparison, observed at `observed_at_ms`.
+    pub fn record_comparison(
+        &self,
+        context: &RequestContext,
+        comparison: Comparison,
+        observed_at_ms: u64,
+    ) {
+        bump(&self.counters.compared);
+        let divergence = match comparison {
+            Comparison::Match => {
+                bump(&self.counters.matched);
+                return;
+            }
+            Comparison::Diverged(divergence) => *divergence,
+        };
+        bump(&self.counters.diverged);
+
+        let Ok(mut records) = self.records.write() else {
+            // A poisoned lock means a previous writer panicked while holding
+            // it. The counters above still tell the operator divergences are
+            // happening; losing the sample is strictly better than propagating
+            // a panic into a detached mirror task.
+            return;
+        };
+        if let Some(existing) = records
+            .iter_mut()
+            .find(|record| record.divergence.fingerprint == divergence.fingerprint)
+        {
+            existing.occurrences = existing.occurrences.saturating_add(1);
+            existing.last_observed_at_ms = observed_at_ms;
+            return;
+        }
+        while records.len() >= self.max_records {
+            records.pop_front();
+        }
+        records.push_back(DivergenceRecord {
+            method: context.method.clone(),
+            target: context.target.clone(),
+            route: context.route.clone(),
+            occurrences: 1,
+            first_observed_at_ms: observed_at_ms,
+            last_observed_at_ms: observed_at_ms,
+            divergence,
+        });
+    }
+
+    /// Current counters.
+    #[must_use]
+    pub fn stats(&self) -> ShadowStats {
+        ShadowStats {
+            mirrored: self.counters.mirrored.load(Ordering::Relaxed),
+            compared: self.counters.compared.load(Ordering::Relaxed),
+            matched: self.counters.matched.load(Ordering::Relaxed),
+            diverged: self.counters.diverged.load(Ordering::Relaxed),
+            shadow_errors: self.counters.shadow_errors.load(Ordering::Relaxed),
+            shadow_timeouts: self.counters.shadow_timeouts.load(Ordering::Relaxed),
+            dropped_at_capacity: self.counters.dropped_at_capacity.load(Ordering::Relaxed),
+            skipped_oversize: self.counters.skipped_oversize.load(Ordering::Relaxed),
+        }
+    }
+
+    /// The stored divergences, oldest first.
+    #[must_use]
+    pub fn recent(&self) -> Vec<DivergenceRecord> {
+        self.records
+            .read()
+            .map(|records| records.iter().cloned().collect())
+            .unwrap_or_default()
+    }
+
+    /// Build the payload `{actuator-prefix}/shadow` returns.
+    #[must_use]
+    pub fn snapshot(&self, enabled: bool, target: Option<&str>) -> ShadowSnapshot {
+        ShadowSnapshot {
+            enabled,
+            target: target.map(ToOwned::to_owned),
+            stats: self.stats(),
+            divergences: self.recent(),
+        }
+    }
+
+    /// Drive the `mirrored` counter to its ceiling so a test can prove the next
+    /// increment saturates instead of wrapping.
+    #[cfg(test)]
+    fn pin_mirrored_at_ceiling_for_tests(&self) {
+        self.counters.mirrored.store(u64::MAX, Ordering::Relaxed);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::log::filter::ParameterFilter;
+    use crate::shadow::diff::{Comparison, ResponseFacts, compare};
+    use bytes::Bytes;
+
+    fn facts(status: u16, body: &str) -> ResponseFacts {
+        ResponseFacts::new(
+            status,
+            Some("application/json".to_owned()),
+            Bytes::from(body.to_owned()),
+        )
+    }
+
+    fn context() -> RequestContext {
+        RequestContext {
+            method: "GET".to_owned(),
+            target: "/api/orders".to_owned(),
+            route: "/api/*".to_owned(),
+        }
+    }
+
+    fn diverging(primary: &str, shadow: &str) -> Comparison {
+        compare(
+            &facts(200, primary),
+            &facts(200, shadow),
+            &ParameterFilter::default(),
+            2048,
+        )
+    }
+
+    #[test]
+    fn a_fresh_registry_is_empty() {
+        let registry = ShadowRegistry::new(10);
+        let stats = registry.stats();
+        assert_eq!(stats.mirrored, 0);
+        assert_eq!(stats.compared, 0);
+        assert_eq!(stats.diverged, 0);
+        assert!(registry.recent().is_empty());
+    }
+
+    #[test]
+    fn a_match_is_counted_but_not_recorded() {
+        let registry = ShadowRegistry::new(10);
+        registry.record_comparison(&context(), diverging("{\"a\":1}", "{\"a\":1}"), 1_000);
+        let stats = registry.stats();
+        assert_eq!(stats.compared, 1);
+        assert_eq!(stats.matched, 1);
+        assert_eq!(stats.diverged, 0);
+        assert!(registry.recent().is_empty());
+    }
+
+    #[test]
+    fn a_divergence_is_counted_and_recorded() {
+        let registry = ShadowRegistry::new(10);
+        registry.record_comparison(&context(), diverging("{\"a\":1}", "{}"), 1_000);
+        let stats = registry.stats();
+        assert_eq!(stats.compared, 1);
+        assert_eq!(stats.matched, 0);
+        assert_eq!(stats.diverged, 1);
+        let recent = registry.recent();
+        assert_eq!(recent.len(), 1);
+        assert_eq!(recent[0].method, "GET");
+        assert_eq!(recent[0].route, "/api/*");
+        assert_eq!(recent[0].occurrences, 1);
+        assert_eq!(recent[0].first_observed_at_ms, 1_000);
+        assert_eq!(recent[0].last_observed_at_ms, 1_000);
+    }
+
+    #[test]
+    fn repeat_divergences_collapse_by_fingerprint() {
+        let registry = ShadowRegistry::new(10);
+        for at in [1_000, 2_000, 3_000] {
+            registry.record_comparison(&context(), diverging("{\"a\":1}", "{}"), at);
+        }
+        let recent = registry.recent();
+        assert_eq!(
+            recent.len(),
+            1,
+            "the same divergence must not fill the ring"
+        );
+        assert_eq!(recent[0].occurrences, 3);
+        assert_eq!(recent[0].first_observed_at_ms, 1_000);
+        assert_eq!(recent[0].last_observed_at_ms, 3_000);
+        assert_eq!(registry.stats().diverged, 3);
+    }
+
+    #[test]
+    fn the_record_ring_is_bounded() {
+        let registry = ShadowRegistry::new(3);
+        for n in 0_u64..10 {
+            registry.record_comparison(
+                &context(),
+                diverging(&format!("{{\"a\":{n}}}"), "{}"),
+                1_000 + u64::from(n),
+            );
+        }
+        let recent = registry.recent();
+        assert_eq!(recent.len(), 3, "ring must be capped at max_records");
+        assert_eq!(registry.stats().diverged, 10, "counters are not capped");
+        // The newest survive; the oldest are evicted.
+        assert_eq!(recent[2].last_observed_at_ms, 1_009);
+    }
+
+    #[test]
+    fn operational_counters_move_independently() {
+        let registry = ShadowRegistry::new(10);
+        registry.record_mirrored();
+        registry.record_mirrored();
+        registry.record_dropped_at_capacity();
+        registry.record_shadow_error();
+        registry.record_shadow_timeout();
+        registry.record_skipped_oversize();
+        let stats = registry.stats();
+        assert_eq!(stats.mirrored, 2);
+        assert_eq!(stats.dropped_at_capacity, 1);
+        assert_eq!(stats.shadow_errors, 1);
+        assert_eq!(stats.shadow_timeouts, 1);
+        assert_eq!(stats.skipped_oversize, 1);
+        assert_eq!(stats.compared, 0);
+    }
+
+    #[test]
+    fn clones_share_one_registry() {
+        let registry = ShadowRegistry::new(10);
+        let clone = registry.clone();
+        clone.record_mirrored();
+        assert_eq!(registry.stats().mirrored, 1);
+    }
+
+    #[test]
+    fn the_snapshot_serializes_the_shape_the_actuator_publishes() {
+        let registry = ShadowRegistry::new(10);
+        registry.record_mirrored();
+        registry.record_comparison(&context(), diverging("{\"a\":1}", "{}"), 1_000);
+        let snapshot = registry.snapshot(true, Some("http://127.0.0.1:9091"));
+        let json = serde_json::to_value(&snapshot).expect("must serialize");
+        assert_eq!(json["enabled"], serde_json::json!(true));
+        assert_eq!(json["target"], serde_json::json!("http://127.0.0.1:9091"));
+        assert_eq!(json["stats"]["diverged"], serde_json::json!(1));
+        assert_eq!(json["divergences"][0]["route"], serde_json::json!("/api/*"));
+        assert_eq!(
+            json["divergences"][0]["kind"],
+            serde_json::json!("body"),
+            "the divergence detail must be flattened into the record"
+        );
+    }
+
+    #[test]
+    fn a_disabled_snapshot_reports_no_target() {
+        let registry = ShadowRegistry::new(10);
+        let json = serde_json::to_value(registry.snapshot(false, None)).expect("must serialize");
+        assert_eq!(json["enabled"], serde_json::json!(false));
+        assert!(json.get("target").is_none() || json["target"].is_null());
+    }
+
+    #[test]
+    fn counters_saturate_rather_than_wrapping() {
+        let registry = ShadowRegistry::new(10);
+        registry.pin_mirrored_at_ceiling_for_tests();
+        registry.record_mirrored();
+        assert_eq!(registry.stats().mirrored, u64::MAX);
+    }
+}

--- a/autumn/src/shadow/registry.rs
+++ b/autumn/src/shadow/registry.rs
@@ -16,6 +16,24 @@
 //!   clock in here, so the whole recording path stays a pure function of its
 //!   inputs and a captured request replays to a byte-identical record.
 
+// autumn-panic-gate: request-path module — production code path must be panic-free.
+// See CONTRIBUTING.md "Request-path panic gate". Justify exceptions with
+// #[allow(clippy::<lint>, reason = "…")] at the narrowest scope.
+#![cfg_attr(
+    not(test),
+    deny(
+        clippy::unwrap_used,
+        clippy::expect_used,
+        clippy::panic,
+        clippy::unreachable,
+        clippy::todo,
+        clippy::unimplemented,
+        clippy::indexing_slicing,
+        clippy::string_slice,
+        clippy::arithmetic_side_effects,
+    )
+)]
+
 use std::collections::VecDeque;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, RwLock};
@@ -46,6 +64,17 @@ pub struct ShadowStats {
     /// Mirrored requests not compared because a response body exceeded
     /// `shadow.max_body_bytes`.
     pub skipped_oversize: u64,
+    /// Mirrors not dispatched because the live build answered with an
+    /// admission-control status (`429`/`503`) — see the mirror layer's
+    /// `ADMISSION_CONTROL_STATUSES`. Diffing those against a candidate under
+    /// none of the same pressure reports a divergence every time.
+    pub skipped_refused: u64,
+    /// Mirrored requests whose primary response never completed within the
+    /// deadline — the client disconnected, stopped reading, or the response was
+    /// a long-lived stream. Counted so `mirrored` always accounts for itself:
+    /// without this an operator sees `mirrored` far exceed every other counter
+    /// with nothing explaining the gap.
+    pub primary_incomplete: u64,
 }
 
 /// The request a divergence was observed on.
@@ -82,6 +111,62 @@ pub struct DivergenceRecord {
     pub divergence: Divergence,
 }
 
+/// Ceiling on the number of distinct route labels the per-route series retain.
+///
+/// The route label is already bounded — it is a matched route template or a
+/// configured pattern, never a raw URL — but an app with thousands of route
+/// templates would still make a scrape enormous. Past this many routes, further
+/// ones fold into [`OVERFLOW_ROUTE_LABEL`] so the series set stays bounded and
+/// the overflow is visible rather than silent.
+const MAX_ROUTE_SERIES: usize = 200;
+
+/// Route label every route past [`MAX_ROUTE_SERIES`] is folded into.
+pub const OVERFLOW_ROUTE_LABEL: &str = "__other__";
+
+/// One `{route, outcome}` (or `{route, kind}`) counter series.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+pub struct LabelledCount {
+    /// The bounded route label.
+    pub route: String,
+    /// The second dimension: a comparison outcome, or a divergence kind.
+    pub label: String,
+    /// Occurrences.
+    pub count: u64,
+}
+
+/// Per-route counter series, bounded by [`MAX_ROUTE_SERIES`] distinct routes.
+#[derive(Debug, Default)]
+struct LabelledSeries {
+    counts: std::collections::BTreeMap<(String, String), u64>,
+    routes: std::collections::BTreeSet<String>,
+}
+
+impl LabelledSeries {
+    fn record(&mut self, route: &str, label: &str) {
+        let route = if self.routes.contains(route) {
+            route.to_owned()
+        } else if self.routes.len() < MAX_ROUTE_SERIES {
+            self.routes.insert(route.to_owned());
+            route.to_owned()
+        } else {
+            OVERFLOW_ROUTE_LABEL.to_owned()
+        };
+        let entry = self.counts.entry((route, label.to_owned())).or_insert(0);
+        *entry = entry.saturating_add(1);
+    }
+
+    fn snapshot(&self) -> Vec<LabelledCount> {
+        self.counts
+            .iter()
+            .map(|((route, label), count)| LabelledCount {
+                route: route.clone(),
+                label: label.clone(),
+                count: *count,
+            })
+            .collect()
+    }
+}
+
 /// Everything `{actuator-prefix}/shadow` publishes.
 #[derive(Clone, Debug, Serialize)]
 pub struct ShadowSnapshot {
@@ -92,8 +177,40 @@ pub struct ShadowSnapshot {
     pub target: Option<String>,
     /// Aggregate counters.
     pub stats: ShadowStats,
+    /// Per-`{route, outcome}` comparison counts — the series
+    /// `autumn_shadow_comparisons_total` is scraped from.
+    pub comparisons_by_route: Vec<LabelledCount>,
+    /// Per-`{route, kind}` divergence counts — the series
+    /// `autumn_shadow_divergences_total` is scraped from.
+    pub divergences_by_route: Vec<LabelledCount>,
     /// Most recent distinct divergences, oldest first.
     pub divergences: Vec<DivergenceRecord>,
+}
+
+/// What [`ShadowRegistry::record_comparison`] did with a comparison.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum Recorded {
+    /// The two builds agreed; nothing was stored.
+    Match,
+    /// A divergence not previously seen on this route, now stored.
+    NewDivergence(Box<Divergence>),
+    /// A divergence already in the ring; its occurrence count moved.
+    RepeatDivergence,
+}
+
+impl ShadowSnapshot {
+    /// The payload a replica with no mirror publishes.
+    #[must_use]
+    pub fn disabled() -> Self {
+        Self {
+            enabled: false,
+            target: None,
+            stats: ShadowStats::default(),
+            comparisons_by_route: Vec::new(),
+            divergences_by_route: Vec::new(),
+            divergences: Vec::new(),
+        }
+    }
 }
 
 /// Shared, cheaply cloneable shadow-run state.
@@ -101,6 +218,8 @@ pub struct ShadowSnapshot {
 pub struct ShadowRegistry {
     counters: Arc<Counters>,
     records: Arc<RwLock<VecDeque<DivergenceRecord>>>,
+    comparisons_by_route: Arc<RwLock<LabelledSeries>>,
+    divergences_by_route: Arc<RwLock<LabelledSeries>>,
     max_records: usize,
 }
 
@@ -114,6 +233,8 @@ struct Counters {
     shadow_timeouts: AtomicU64,
     dropped_at_capacity: AtomicU64,
     skipped_oversize: AtomicU64,
+    skipped_refused: AtomicU64,
+    primary_incomplete: AtomicU64,
 }
 
 /// Saturating increment: a long-lived replica must not wrap a counter back to
@@ -135,8 +256,47 @@ impl ShadowRegistry {
         Self {
             counters: Arc::new(Counters::default()),
             records: Arc::new(RwLock::new(VecDeque::new())),
+            comparisons_by_route: Arc::new(RwLock::new(LabelledSeries::default())),
+            divergences_by_route: Arc::new(RwLock::new(LabelledSeries::default())),
             max_records: max_records.max(1),
         }
+    }
+
+    /// Record one `{route, outcome}` comparison result.
+    ///
+    /// This is what `autumn_shadow_comparisons_total` is scraped from. It lives
+    /// here rather than going through [`crate::metrics::counter`] because that
+    /// facade — correctly — refuses the `autumn_` namespace, which belongs to
+    /// the framework's built-in families.
+    pub fn record_outcome(&self, route: &str, outcome: &str) {
+        if let Ok(mut series) = self.comparisons_by_route.write() {
+            series.record(route, outcome);
+        }
+    }
+
+    /// Record one `{route, kind}` divergence.
+    pub fn record_divergence_kind(&self, route: &str, kind: &str) {
+        if let Ok(mut series) = self.divergences_by_route.write() {
+            series.record(route, kind);
+        }
+    }
+
+    /// The per-`{route, outcome}` comparison series.
+    #[must_use]
+    pub fn comparisons_by_route(&self) -> Vec<LabelledCount> {
+        self.comparisons_by_route
+            .read()
+            .map(|series| series.snapshot())
+            .unwrap_or_default()
+    }
+
+    /// The per-`{route, kind}` divergence series.
+    #[must_use]
+    pub fn divergences_by_route(&self) -> Vec<LabelledCount> {
+        self.divergences_by_route
+            .read()
+            .map(|series| series.snapshot())
+            .unwrap_or_default()
     }
 
     /// Count a request selected for mirroring.
@@ -164,18 +324,32 @@ impl ShadowRegistry {
         bump(&self.counters.skipped_oversize);
     }
 
+    /// Count a mirror not dispatched because the live build refused the request.
+    pub fn record_skipped_refused(&self) {
+        bump(&self.counters.skipped_refused);
+    }
+
+    /// Count a mirrored request whose primary response never completed.
+    pub fn record_primary_incomplete(&self) {
+        bump(&self.counters.primary_incomplete);
+    }
+
     /// Record the outcome of one comparison, observed at `observed_at_ms`.
+    ///
+    /// The return value distinguishes a divergence seen for the first time from
+    /// a repeat, so the caller can log once per distinct problem rather than
+    /// once per request.
     pub fn record_comparison(
         &self,
         context: &RequestContext,
         comparison: Comparison,
         observed_at_ms: u64,
-    ) {
+    ) -> Recorded {
         bump(&self.counters.compared);
         let divergence = match comparison {
             Comparison::Match => {
                 bump(&self.counters.matched);
-                return;
+                return Recorded::Match;
             }
             Comparison::Diverged(divergence) => *divergence,
         };
@@ -186,15 +360,21 @@ impl ShadowRegistry {
             // it. The counters above still tell the operator divergences are
             // happening; losing the sample is strictly better than propagating
             // a panic into a detached mirror task.
-            return;
+            return Recorded::RepeatDivergence;
         };
-        if let Some(existing) = records
-            .iter_mut()
-            .find(|record| record.divergence.fingerprint == divergence.fingerprint)
-        {
+        // Keyed on (route, fingerprint), not the fingerprint alone. The
+        // fingerprint is content-addressed over the two responses only, so two
+        // DIFFERENT routes that happen to answer identically — say a candidate
+        // that 500s with one generic error body everywhere — would otherwise
+        // collapse onto a single record attributed to whichever route was seen
+        // first, and the operator would fix one route believing it was the only
+        // one broken.
+        if let Some(existing) = records.iter_mut().find(|record| {
+            record.divergence.fingerprint == divergence.fingerprint && record.route == context.route
+        }) {
             existing.occurrences = existing.occurrences.saturating_add(1);
             existing.last_observed_at_ms = observed_at_ms;
-            return;
+            return Recorded::RepeatDivergence;
         }
         while records.len() >= self.max_records {
             records.pop_front();
@@ -206,8 +386,9 @@ impl ShadowRegistry {
             occurrences: 1,
             first_observed_at_ms: observed_at_ms,
             last_observed_at_ms: observed_at_ms,
-            divergence,
+            divergence: divergence.clone(),
         });
+        Recorded::NewDivergence(Box::new(divergence))
     }
 
     /// Current counters.
@@ -222,6 +403,8 @@ impl ShadowRegistry {
             shadow_timeouts: self.counters.shadow_timeouts.load(Ordering::Relaxed),
             dropped_at_capacity: self.counters.dropped_at_capacity.load(Ordering::Relaxed),
             skipped_oversize: self.counters.skipped_oversize.load(Ordering::Relaxed),
+            skipped_refused: self.counters.skipped_refused.load(Ordering::Relaxed),
+            primary_incomplete: self.counters.primary_incomplete.load(Ordering::Relaxed),
         }
     }
 
@@ -241,6 +424,8 @@ impl ShadowRegistry {
             enabled,
             target: target.map(ToOwned::to_owned),
             stats: self.stats(),
+            comparisons_by_route: self.comparisons_by_route(),
+            divergences_by_route: self.divergences_by_route(),
             divergences: self.recent(),
         }
     }
@@ -359,6 +544,51 @@ mod tests {
     }
 
     #[test]
+    fn identical_divergences_on_different_routes_stay_separate() {
+        // The fingerprint is content-addressed over the two responses only, so
+        // a candidate that 500s with one generic body everywhere produces the
+        // same fingerprint on every route. Collapsing those would attribute one
+        // record to whichever route happened to be seen first, and the operator
+        // would fix one route believing it was the only one broken.
+        let registry = ShadowRegistry::new(10);
+        for route in ["/api/orders", "/api/users"] {
+            let context = RequestContext {
+                method: "GET".to_owned(),
+                target: route.to_owned(),
+                route: route.to_owned(),
+            };
+            registry.record_comparison(&context, diverging("{\"a\":1}", "{}"), 1_000);
+        }
+        let recent = registry.recent();
+        assert_eq!(recent.len(), 2);
+        assert_eq!(recent[0].route, "/api/orders");
+        assert_eq!(recent[1].route, "/api/users");
+        // ...and the same route still collapses.
+        assert_eq!(
+            recent[0].divergence.fingerprint,
+            recent[1].divergence.fingerprint
+        );
+    }
+
+    #[test]
+    fn recording_reports_whether_a_divergence_was_new() {
+        let registry = ShadowRegistry::new(10);
+        assert_eq!(
+            registry.record_comparison(&context(), diverging("{\"a\":1}", "{\"a\":1}"), 1_000),
+            Recorded::Match
+        );
+        let first = registry.record_comparison(&context(), diverging("{\"a\":1}", "{}"), 1_000);
+        assert!(
+            matches!(first, Recorded::NewDivergence(_)),
+            "the first sighting must be reported as new so the layer logs once"
+        );
+        assert_eq!(
+            registry.record_comparison(&context(), diverging("{\"a\":1}", "{}"), 2_000),
+            Recorded::RepeatDivergence
+        );
+    }
+
+    #[test]
     fn operational_counters_move_independently() {
         let registry = ShadowRegistry::new(10);
         registry.record_mirrored();
@@ -367,7 +597,11 @@ mod tests {
         registry.record_shadow_error();
         registry.record_shadow_timeout();
         registry.record_skipped_oversize();
+        registry.record_skipped_refused();
+        registry.record_primary_incomplete();
         let stats = registry.stats();
+        assert_eq!(stats.skipped_refused, 1);
+        assert_eq!(stats.primary_incomplete, 1);
         assert_eq!(stats.mirrored, 2);
         assert_eq!(stats.dropped_at_capacity, 1);
         assert_eq!(stats.shadow_errors, 1);

--- a/autumn/src/shadow/registry.rs
+++ b/autumn/src/shadow/registry.rs
@@ -348,7 +348,7 @@ mod tests {
             registry.record_comparison(
                 &context(),
                 diverging(&format!("{{\"a\":{n}}}"), "{}"),
-                1_000 + u64::from(n),
+                1_000 + n,
             );
         }
         let recent = registry.recent();

--- a/autumn/src/shadow/registry.rs
+++ b/autumn/src/shadow/registry.rs
@@ -484,7 +484,7 @@ mod tests {
     #[test]
     fn a_match_is_counted_but_not_recorded() {
         let registry = ShadowRegistry::new(10);
-        registry.record_comparison(&context(), diverging("{\"a\":1}", "{\"a\":1}"), 1_000);
+        let _ = registry.record_comparison(&context(), diverging("{\"a\":1}", "{\"a\":1}"), 1_000);
         let stats = registry.stats();
         assert_eq!(stats.compared, 1);
         assert_eq!(stats.matched, 1);
@@ -495,7 +495,7 @@ mod tests {
     #[test]
     fn a_divergence_is_counted_and_recorded() {
         let registry = ShadowRegistry::new(10);
-        registry.record_comparison(&context(), diverging("{\"a\":1}", "{}"), 1_000);
+        let _ = registry.record_comparison(&context(), diverging("{\"a\":1}", "{}"), 1_000);
         let stats = registry.stats();
         assert_eq!(stats.compared, 1);
         assert_eq!(stats.matched, 0);
@@ -513,7 +513,7 @@ mod tests {
     fn repeat_divergences_collapse_by_fingerprint() {
         let registry = ShadowRegistry::new(10);
         for at in [1_000, 2_000, 3_000] {
-            registry.record_comparison(&context(), diverging("{\"a\":1}", "{}"), at);
+            let _ = registry.record_comparison(&context(), diverging("{\"a\":1}", "{}"), at);
         }
         let recent = registry.recent();
         assert_eq!(
@@ -531,7 +531,7 @@ mod tests {
     fn the_record_ring_is_bounded() {
         let registry = ShadowRegistry::new(3);
         for n in 0_u64..10 {
-            registry.record_comparison(
+            let _ = registry.record_comparison(
                 &context(),
                 diverging(&format!("{{\"a\":{n}}}"), "{}"),
                 1_000 + n,
@@ -558,7 +558,7 @@ mod tests {
                 target: route.to_owned(),
                 route: route.to_owned(),
             };
-            registry.record_comparison(&context, diverging("{\"a\":1}", "{}"), 1_000);
+            let _ = registry.record_comparison(&context, diverging("{\"a\":1}", "{}"), 1_000);
         }
         let recent = registry.recent();
         assert_eq!(recent.len(), 2);
@@ -623,7 +623,7 @@ mod tests {
     fn the_snapshot_serializes_the_shape_the_actuator_publishes() {
         let registry = ShadowRegistry::new(10);
         registry.record_mirrored();
-        registry.record_comparison(&context(), diverging("{\"a\":1}", "{}"), 1_000);
+        let _ = registry.record_comparison(&context(), diverging("{\"a\":1}", "{}"), 1_000);
         let snapshot = registry.snapshot(true, Some("http://127.0.0.1:9091"));
         let json = serde_json::to_value(&snapshot).expect("must serialize");
         assert_eq!(json["enabled"], serde_json::json!(true));

--- a/autumn/src/shadow/registry.rs
+++ b/autumn/src/shadow/registry.rs
@@ -54,8 +54,14 @@ pub struct ShadowStats {
     /// Comparisons where they did not.
     pub diverged: u64,
     /// Shadow requests that failed at the transport (connection refused, DNS,
-    /// TLS, a malformed response).
+    /// TLS, a malformed response) — failures of the **candidate**.
     pub shadow_errors: u64,
+    /// Responses from the **live** build that could not be decoded, so no
+    /// comparison was possible. Counted apart from `shadow_errors` because that
+    /// series is documented as candidate transport failures: folding the two
+    /// together points an operator at candidate connectivity when the malformed
+    /// response was their own.
+    pub primary_errors: u64,
     /// Shadow requests abandoned at the configured deadline.
     pub shadow_timeouts: u64,
     /// Requests dropped without being mirrored because the in-flight ceiling
@@ -230,6 +236,7 @@ struct Counters {
     matched: AtomicU64,
     diverged: AtomicU64,
     shadow_errors: AtomicU64,
+    primary_errors: AtomicU64,
     shadow_timeouts: AtomicU64,
     dropped_at_capacity: AtomicU64,
     skipped_oversize: AtomicU64,
@@ -312,6 +319,11 @@ impl ShadowRegistry {
     /// Count a shadow request that failed at the transport.
     pub fn record_shadow_error(&self) {
         bump(&self.counters.shadow_errors);
+    }
+
+    /// Count a response from the live build that could not be decoded.
+    pub fn record_primary_error(&self) {
+        bump(&self.counters.primary_errors);
     }
 
     /// Count a shadow request abandoned at its deadline.
@@ -401,6 +413,7 @@ impl ShadowRegistry {
             matched: self.counters.matched.load(Ordering::Relaxed),
             diverged: self.counters.diverged.load(Ordering::Relaxed),
             shadow_errors: self.counters.shadow_errors.load(Ordering::Relaxed),
+            primary_errors: self.counters.primary_errors.load(Ordering::Relaxed),
             shadow_timeouts: self.counters.shadow_timeouts.load(Ordering::Relaxed),
             dropped_at_capacity: self.counters.dropped_at_capacity.load(Ordering::Relaxed),
             skipped_oversize: self.counters.skipped_oversize.load(Ordering::Relaxed),

--- a/autumn/src/shadow/sample.rs
+++ b/autumn/src/shadow/sample.rs
@@ -154,6 +154,9 @@ impl MirrorSelector {
     ///
     /// `actuator_prefix` and `probe_paths` come from the same config the
     /// load-shed layer reads, so the two agree on what platform traffic is.
+    /// `probe_paths` should also carry the actuator's mounted endpoint paths:
+    /// with `prefix = "/"` the actuator mounts at the root, where no prefix
+    /// test can distinguish it from application routes.
     #[must_use]
     pub fn new(
         sample_rate: f64,
@@ -161,7 +164,14 @@ impl MirrorSelector {
         actuator_prefix: &str,
         probe_paths: &[String],
     ) -> Self {
-        let actuator_prefix = actuator_prefix.trim_end_matches('/').to_owned();
+        // The actuator's OWN normalizer, not a hand-rolled trim. `[actuator]
+        // prefix` accepts noncanonical forms — `"ops/"` mounts at `/ops`, `"/"`
+        // mounts at the root — and a trim that disagreed with the mount would
+        // leave the real endpoints unexempt, so operator polling of
+        // `/metrics`, `/prometheus`, `/shadow` would be mirrored: candidate
+        // load, plus permanent false divergences from payloads that are
+        // per-replica by construction.
+        let actuator_prefix = crate::actuator::normalize_actuator_prefix(actuator_prefix);
         Self {
             sample_rate,
             routes: std::sync::Arc::new(routes.iter().map(|r| RoutePattern::parse(r)).collect()),

--- a/autumn/src/shadow/sample.rs
+++ b/autumn/src/shadow/sample.rs
@@ -215,7 +215,7 @@ impl MirrorSelector {
     }
 
     /// The bounded label for a path: the configured pattern it matched, or
-    /// [`ALL_ROUTES_LABEL`] when no allowlist is configured.
+    /// `"*"` when no allowlist is configured.
     ///
     /// This is the **fallback**. The mirror layer prefers
     /// [`axum::extract::MatchedPath`], which is a genuinely informative route
@@ -254,6 +254,11 @@ fn path_of(target: &str) -> &str {
 /// draws through [`Entropy`] rather than a thread RNG so a seeded source makes
 /// the whole mirroring decision reproducible.
 #[must_use]
+#[allow(
+    clippy::cast_precision_loss,
+    reason = "the shift keeps the value in 53 bits, which an f64 represents exactly — \
+              that is the point of taking the top bits rather than the whole u64"
+)]
 pub fn roll_from(entropy: &dyn Entropy) -> f64 {
     /// `2^-53`, the spacing of the representable values this maps onto.
     const SCALE: f64 = 1.0 / (1u64 << 53) as f64;

--- a/autumn/src/shadow/sample.rs
+++ b/autumn/src/shadow/sample.rs
@@ -1,0 +1,462 @@
+//! Which requests get mirrored, and why the rest do not (issue #1653).
+//!
+//! The decision is a pure function of the request and one `roll` in `[0, 1)`
+//! supplied by the caller, so it is fully testable and — when the roll comes
+//! from a [`crate::entropy::SeededEntropy`], as it does under
+//! [`#[sim_test]`](crate::sim_test) — reproducible.
+//!
+//! Four gates run before the sample rate is even consulted, cheapest first:
+//!
+//! 1. **Method.** Only [`MIRRORABLE_METHODS`] (`GET`/`HEAD`). This slice
+//!    mirrors idempotent traffic only, and the set is a constant rather than a
+//!    config key precisely so it cannot be widened by accident.
+//! 2. **Loop guard.** A request already carrying [`SHADOW_HEADER`] is itself a
+//!    mirrored request. Mirroring it again — which is what happens the moment
+//!    someone points a shadow target at the app itself, or chains two shadows —
+//!    would multiply traffic without bound.
+//! 3. **Exempt paths.** The actuator prefix and the platform probe paths. A
+//!    load balancer's health checks are the highest-rate, least-interesting
+//!    traffic an app serves; mirroring them buys nothing and drowns the
+//!    candidate.
+//! 4. **Route allowlist.** Empty means "every eligible route".
+
+// autumn-panic-gate: request-path module — production code path must be panic-free.
+// See CONTRIBUTING.md "Request-path panic gate". Justify exceptions with
+// #[allow(clippy::<lint>, reason = "…")] at the narrowest scope.
+#![cfg_attr(
+    not(test),
+    deny(
+        clippy::unwrap_used,
+        clippy::expect_used,
+        clippy::panic,
+        clippy::unreachable,
+        clippy::todo,
+        clippy::unimplemented,
+        clippy::indexing_slicing,
+        clippy::string_slice,
+        clippy::arithmetic_side_effects,
+    )
+)]
+
+use axum::http::{HeaderMap, Method};
+
+use crate::entropy::Entropy;
+
+/// The only methods this slice mirrors.
+pub const MIRRORABLE_METHODS: [Method; 2] = [Method::GET, Method::HEAD];
+
+/// Header stamped on every mirrored request.
+///
+/// Two jobs: it is the loop guard (see the module docs), and it is the seam a
+/// candidate build uses to recognise mirrored traffic and refuse to act on it —
+/// the hook the follow-up effect-virtualization slice builds on.
+pub const SHADOW_HEADER: &str = "x-autumn-shadow";
+
+/// Value sent with [`SHADOW_HEADER`].
+pub const SHADOW_HEADER_VALUE: &str = "1";
+
+/// Label used for the route dimension when no route patterns are configured.
+const ALL_ROUTES_LABEL: &str = "*";
+
+/// Why a request was not mirrored.
+///
+/// Each variant is a metric label value, so an operator can see at a glance
+/// whether their mirror is quiet because nothing matched, because the sample
+/// rate is low, or because they pointed it at itself.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SkipReason {
+    /// Not a [`MIRRORABLE_METHODS`] method.
+    Method,
+    /// The request is itself a mirrored request.
+    LoopGuard,
+    /// An actuator or probe path.
+    ExemptPath,
+    /// A route allowlist is configured and this path is not on it.
+    RouteNotOptedIn,
+    /// Eligible, but the sample rate did not select it.
+    NotSampled,
+}
+
+impl SkipReason {
+    /// Stable snake_case name for metrics and diagnostics.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Method => "method",
+            Self::LoopGuard => "loop_guard",
+            Self::ExemptPath => "exempt_path",
+            Self::RouteNotOptedIn => "route_not_opted_in",
+            Self::NotSampled => "not_sampled",
+        }
+    }
+}
+
+/// Whether to mirror one request.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum MirrorDecision {
+    /// Mirror it.
+    Mirror,
+    /// Leave it alone, for this reason.
+    Skip(SkipReason),
+}
+
+/// One entry of the configured route allowlist.
+#[derive(Clone, Debug)]
+enum RoutePattern {
+    /// `"/api/*"` — matches any path starting with `"/api/"`, and `"/api/"`.
+    Prefix { pattern: String, prefix: String },
+    /// `"/status"` — matches that path exactly.
+    Exact(String),
+}
+
+impl RoutePattern {
+    fn parse(raw: &str) -> Self {
+        raw.strip_suffix('*').map_or_else(
+            || Self::Exact(raw.to_owned()),
+            |prefix| Self::Prefix {
+                pattern: raw.to_owned(),
+                prefix: prefix.to_owned(),
+            },
+        )
+    }
+
+    fn matches(&self, path: &str) -> bool {
+        match self {
+            Self::Prefix { prefix, .. } => path.starts_with(prefix.as_str()),
+            Self::Exact(exact) => path == exact,
+        }
+    }
+
+    fn label(&self) -> &str {
+        match self {
+            Self::Prefix { pattern, .. } => pattern,
+            Self::Exact(exact) => exact,
+        }
+    }
+}
+
+/// The mirroring admission decision, resolved once at router-assembly time.
+#[derive(Clone, Debug)]
+pub struct MirrorSelector {
+    sample_rate: f64,
+    routes: std::sync::Arc<Vec<RoutePattern>>,
+    actuator_prefix: String,
+    actuator_prefix_slash: String,
+    probe_paths: std::sync::Arc<Vec<String>>,
+}
+
+impl MirrorSelector {
+    /// Build a selector.
+    ///
+    /// `actuator_prefix` and `probe_paths` come from the same config the
+    /// load-shed layer reads, so the two agree on what platform traffic is.
+    #[must_use]
+    pub fn new(
+        sample_rate: f64,
+        routes: &[String],
+        actuator_prefix: &str,
+        probe_paths: &[String],
+    ) -> Self {
+        let actuator_prefix = actuator_prefix.trim_end_matches('/').to_owned();
+        Self {
+            sample_rate,
+            routes: std::sync::Arc::new(routes.iter().map(|r| RoutePattern::parse(r)).collect()),
+            actuator_prefix_slash: format!("{actuator_prefix}/"),
+            actuator_prefix,
+            probe_paths: std::sync::Arc::new(probe_paths.to_vec()),
+        }
+    }
+
+    /// Decide whether to mirror one request.
+    ///
+    /// `roll` is a **thunk**, not a value: it is called only once the four
+    /// cheap gates above have passed. On an app with mirroring enabled this
+    /// runs on every inbound request, and the entropy source behind
+    /// [`roll_from`] takes a lock — so drawing eagerly would put a lock
+    /// acquisition on the path of every `POST`, every health check, and every
+    /// request to a route that is not even opted in. It must be in `[0, 1)`.
+    #[must_use]
+    pub fn decide(
+        &self,
+        method: &Method,
+        target: &str,
+        headers: &HeaderMap,
+        roll: impl FnOnce() -> f64,
+    ) -> MirrorDecision {
+        if !MIRRORABLE_METHODS.contains(method) {
+            return MirrorDecision::Skip(SkipReason::Method);
+        }
+        if headers.contains_key(SHADOW_HEADER) {
+            return MirrorDecision::Skip(SkipReason::LoopGuard);
+        }
+
+        let path = path_of(target);
+        if self.is_exempt(path) {
+            return MirrorDecision::Skip(SkipReason::ExemptPath);
+        }
+        if !self.routes.is_empty() && !self.routes.iter().any(|r| r.matches(path)) {
+            return MirrorDecision::Skip(SkipReason::RouteNotOptedIn);
+        }
+
+        // `roll < rate` — so `rate = 0.0` never fires (no roll is below zero)
+        // and `rate = 1.0` always does (every roll is below one).
+        if self.sample_rate <= 0.0 {
+            return MirrorDecision::Skip(SkipReason::NotSampled);
+        }
+        if roll() < self.sample_rate {
+            MirrorDecision::Mirror
+        } else {
+            MirrorDecision::Skip(SkipReason::NotSampled)
+        }
+    }
+
+    /// The bounded metric label for a path: the configured pattern it matched,
+    /// or [`ALL_ROUTES_LABEL`] when no allowlist is configured.
+    ///
+    /// Never the raw path. A global tower layer runs outside axum's route
+    /// matching, so [`axum::extract::MatchedPath`] is not available here; using
+    /// the URL itself would let an unbounded URL space become unbounded metric
+    /// cardinality.
+    #[must_use]
+    pub fn route_label(&self, target: &str) -> &str {
+        let path = path_of(target);
+        self.routes
+            .iter()
+            .find(|r| r.matches(path))
+            .map_or(ALL_ROUTES_LABEL, RoutePattern::label)
+    }
+
+    /// Platform traffic that is never mirrored.
+    fn is_exempt(&self, path: &str) -> bool {
+        if !self.actuator_prefix.is_empty()
+            && (path == self.actuator_prefix || path.starts_with(&self.actuator_prefix_slash))
+        {
+            return true;
+        }
+        self.probe_paths.iter().any(|probe| probe == path)
+    }
+}
+
+/// The path portion of a request target, with any query string removed.
+fn path_of(target: &str) -> &str {
+    target.split('?').next().unwrap_or(target)
+}
+
+/// Draw a sampling roll in `[0, 1)` from an entropy source.
+///
+/// Uses the top 53 bits so every draw is exactly representable as an `f64`, and
+/// draws through [`Entropy`] rather than a thread RNG so a seeded source makes
+/// the whole mirroring decision reproducible.
+#[must_use]
+pub fn roll_from(entropy: &dyn Entropy) -> f64 {
+    /// `2^-53`, the spacing of the representable values this maps onto.
+    const SCALE: f64 = 1.0 / (1u64 << 53) as f64;
+    ((entropy.next_u64() >> 11) as f64) * SCALE
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::http::{HeaderMap, HeaderValue, Method};
+
+    fn selector() -> MirrorSelector {
+        MirrorSelector::new(1.0, &[], "/actuator", &["/healthz".to_owned()])
+    }
+
+    #[test]
+    fn get_and_head_are_mirrored() {
+        let selector = selector();
+        for method in [Method::GET, Method::HEAD] {
+            assert_eq!(
+                selector.decide(&method, "/api/orders", &HeaderMap::new(), || 0.0),
+                MirrorDecision::Mirror
+            );
+        }
+    }
+
+    #[test]
+    fn mutating_methods_are_never_mirrored() {
+        let selector = selector();
+        for method in [
+            Method::POST,
+            Method::PUT,
+            Method::PATCH,
+            Method::DELETE,
+            Method::OPTIONS,
+        ] {
+            assert_eq!(
+                selector.decide(&method, "/api/orders", &HeaderMap::new(), || 0.0),
+                MirrorDecision::Skip(SkipReason::Method),
+                "{method} must not be mirrored"
+            );
+        }
+    }
+
+    #[test]
+    fn a_mirrored_request_is_never_mirrored_again() {
+        let selector = selector();
+        let mut headers = HeaderMap::new();
+        headers.insert(SHADOW_HEADER, HeaderValue::from_static(SHADOW_HEADER_VALUE));
+        assert_eq!(
+            selector.decide(&Method::GET, "/api/orders", &headers, || 0.0),
+            MirrorDecision::Skip(SkipReason::LoopGuard)
+        );
+    }
+
+    #[test]
+    fn actuator_and_probe_paths_are_exempt() {
+        let selector = selector();
+        for path in ["/actuator", "/actuator/health", "/healthz"] {
+            assert_eq!(
+                selector.decide(&Method::GET, path, &HeaderMap::new(), || 0.0),
+                MirrorDecision::Skip(SkipReason::ExemptPath),
+                "{path} must be exempt"
+            );
+        }
+        // A route that merely *starts with the same letters* is not exempt.
+        assert_eq!(
+            selector.decide(
+                &Method::GET,
+                "/actuatorsomething",
+                &HeaderMap::new(),
+                || 0.0
+            ),
+            MirrorDecision::Mirror
+        );
+    }
+
+    #[test]
+    fn an_empty_route_list_opts_every_route_in() {
+        let selector = selector();
+        assert_eq!(
+            selector.decide(&Method::GET, "/anything/at/all", &HeaderMap::new(), || 0.0),
+            MirrorDecision::Mirror
+        );
+    }
+
+    #[test]
+    fn route_patterns_gate_which_paths_are_mirrored() {
+        let selector = MirrorSelector::new(
+            1.0,
+            &["/api/*".to_owned(), "/status".to_owned()],
+            "/actuator",
+            &[],
+        );
+        for path in ["/api/orders", "/api/", "/status"] {
+            assert_eq!(
+                selector.decide(&Method::GET, path, &HeaderMap::new(), || 0.0),
+                MirrorDecision::Mirror,
+                "{path} must match"
+            );
+        }
+        for path in ["/apiary", "/status/detail", "/"] {
+            assert_eq!(
+                selector.decide(&Method::GET, path, &HeaderMap::new(), || 0.0),
+                MirrorDecision::Skip(SkipReason::RouteNotOptedIn),
+                "{path} must not match"
+            );
+        }
+    }
+
+    #[test]
+    fn a_query_string_does_not_defeat_route_matching() {
+        let selector = MirrorSelector::new(1.0, &["/api/*".to_owned()], "/actuator", &[]);
+        assert_eq!(
+            selector.decide(
+                &Method::GET,
+                "/api/orders?page=2",
+                &HeaderMap::new(),
+                || 0.0
+            ),
+            MirrorDecision::Mirror
+        );
+    }
+
+    #[test]
+    fn sample_rate_zero_mirrors_nothing() {
+        let selector = MirrorSelector::new(0.0, &[], "/actuator", &[]);
+        for roll in [0.0, 0.5, 0.999] {
+            assert_eq!(
+                selector.decide(&Method::GET, "/api/orders", &HeaderMap::new(), || roll),
+                MirrorDecision::Skip(SkipReason::NotSampled)
+            );
+        }
+    }
+
+    #[test]
+    fn sample_rate_is_a_deterministic_function_of_the_roll() {
+        let selector = MirrorSelector::new(0.25, &[], "/actuator", &[]);
+        assert_eq!(
+            selector.decide(&Method::GET, "/api/orders", &HeaderMap::new(), || 0.1),
+            MirrorDecision::Mirror
+        );
+        assert_eq!(
+            selector.decide(&Method::GET, "/api/orders", &HeaderMap::new(), || 0.9),
+            MirrorDecision::Skip(SkipReason::NotSampled)
+        );
+    }
+
+    #[test]
+    fn route_label_is_the_configured_pattern_not_the_raw_path() {
+        let selector = MirrorSelector::new(1.0, &["/api/*".to_owned()], "/actuator", &[]);
+        assert_eq!(selector.route_label("/api/orders/42"), "/api/*");
+        // With no patterns configured the label collapses to a single bucket so
+        // metric cardinality can never follow the URL space.
+        let all = MirrorSelector::new(1.0, &[], "/actuator", &[]);
+        assert_eq!(all.route_label("/api/orders/42"), "*");
+    }
+
+    #[test]
+    fn the_sampling_roll_is_only_drawn_once_the_cheap_gates_pass() {
+        let selector = MirrorSelector::new(1.0, &["/api/*".to_owned()], "/actuator", &[]);
+        let draws = std::cell::Cell::new(0_u32);
+        let roll = || {
+            draws.set(draws.get() + 1);
+            0.0
+        };
+
+        // Wrong method, exempt path, and un-opted-in route must all decide
+        // without touching the entropy source.
+        let _ = selector.decide(&Method::POST, "/api/orders", &HeaderMap::new(), roll);
+        assert_eq!(draws.get(), 0);
+        let _ = selector.decide(&Method::GET, "/actuator/health", &HeaderMap::new(), roll);
+        assert_eq!(draws.get(), 0);
+        let _ = selector.decide(&Method::GET, "/elsewhere", &HeaderMap::new(), roll);
+        assert_eq!(draws.get(), 0);
+
+        // An eligible request does draw.
+        let _ = selector.decide(&Method::GET, "/api/orders", &HeaderMap::new(), roll);
+        assert_eq!(draws.get(), 1);
+    }
+
+    #[test]
+    fn a_zero_sample_rate_never_draws_at_all() {
+        let selector = MirrorSelector::new(0.0, &[], "/actuator", &[]);
+        let drew = std::cell::Cell::new(false);
+        let decision = selector.decide(&Method::GET, "/api/orders", &HeaderMap::new(), || {
+            drew.set(true);
+            0.0
+        });
+        assert_eq!(decision, MirrorDecision::Skip(SkipReason::NotSampled));
+        assert!(!drew.get(), "a disabled sample rate must not draw entropy");
+    }
+
+    #[test]
+    fn skip_reasons_have_stable_metric_labels() {
+        assert_eq!(SkipReason::Method.as_str(), "method");
+        assert_eq!(SkipReason::LoopGuard.as_str(), "loop_guard");
+        assert_eq!(SkipReason::ExemptPath.as_str(), "exempt_path");
+        assert_eq!(SkipReason::RouteNotOptedIn.as_str(), "route_not_opted_in");
+        assert_eq!(SkipReason::NotSampled.as_str(), "not_sampled");
+    }
+
+    #[test]
+    fn roll_from_entropy_stays_in_range_and_is_reproducible() {
+        let seeded = crate::entropy::SeededEntropy::new(42);
+        let first: Vec<f64> = (0..8).map(|_| roll_from(&seeded)).collect();
+        assert!(first.iter().all(|r| (0.0..1.0).contains(r)), "{first:?}");
+        let replay = crate::entropy::SeededEntropy::new(42);
+        let second: Vec<f64> = (0..8).map(|_| roll_from(&replay)).collect();
+        assert_eq!(first, second, "the same seed must reproduce the same rolls");
+    }
+}

--- a/autumn/src/shadow/sample.rs
+++ b/autumn/src/shadow/sample.rs
@@ -60,9 +60,13 @@ const ALL_ROUTES_LABEL: &str = "*";
 
 /// Why a request was not mirrored.
 ///
-/// Each variant is a metric label value, so an operator can see at a glance
-/// whether their mirror is quiet because nothing matched, because the sample
-/// rate is low, or because they pointed it at itself.
+/// Emitted on the mirror layer's `TRACE` stream (target `autumn::shadow`), so
+/// an operator debugging a quiet mirror can see whether it is quiet because
+/// nothing matched, because the sample rate is low, or because they pointed it
+/// at itself. Deliberately not a metric: this fires on every inbound request
+/// while mirroring is enabled, and a labelled counter increment on the
+/// not-mirrored path is a cost every request would pay to report a
+/// configuration fact.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum SkipReason {
     /// Not a [`MIRRORABLE_METHODS`] method.
@@ -78,7 +82,7 @@ pub enum SkipReason {
 }
 
 impl SkipReason {
-    /// Stable snake_case name for metrics and diagnostics.
+    /// Stable `snake_case` name for diagnostics.
     #[must_use]
     pub const fn as_str(self) -> &'static str {
         match self {
@@ -210,13 +214,15 @@ impl MirrorSelector {
         }
     }
 
-    /// The bounded metric label for a path: the configured pattern it matched,
-    /// or [`ALL_ROUTES_LABEL`] when no allowlist is configured.
+    /// The bounded label for a path: the configured pattern it matched, or
+    /// [`ALL_ROUTES_LABEL`] when no allowlist is configured.
     ///
-    /// Never the raw path. A global tower layer runs outside axum's route
-    /// matching, so [`axum::extract::MatchedPath`] is not available here; using
-    /// the URL itself would let an unbounded URL space become unbounded metric
-    /// cardinality.
+    /// This is the **fallback**. The mirror layer prefers
+    /// [`axum::extract::MatchedPath`], which is a genuinely informative route
+    /// template and is available to it (`Router::layer` wraps each route's
+    /// service, so routing has already run); this covers the cases where no
+    /// route matched. Never the raw path either way — an unbounded URL space
+    /// must not become unbounded metric cardinality.
     #[must_use]
     pub fn route_label(&self, target: &str) -> &str {
         let path = path_of(target);

--- a/autumn/src/shadow/transport.rs
+++ b/autumn/src/shadow/transport.rs
@@ -160,17 +160,20 @@ pub trait ShadowTransport: std::fmt::Debug + Send + Sync + 'static {
 /// address and the authority are separate things, and only the address comes
 /// from the target.
 ///
-/// `resolved_host` is the authority the trusted-proxy layer accepted, when it
-/// ran. It takes precedence over the raw `Host`: behind a proxy the raw header
-/// carries the *internal* address while the public one arrives in
-/// `X-Forwarded-Host`, which is stripped here for the reasons above. Sending
-/// the internal host would have the candidate resolve the wrong tenant, or
-/// reject the request outright — so the validated authority is what travels,
-/// never the unvalidated header it came from. This mirrors
-/// `tenancy::extract_tenant_from_parts`, which prefers the same resolved value
-/// over the raw header for the same reason.
+/// `resolved` is what the trusted-proxy layer accepted, when it ran, and it is
+/// re-stamped over the stripped forwarding family: the candidate is told the
+/// *validated* host, client address, and scheme rather than the client's own
+/// claims. Behind a proxy the raw `Host` is the internal address while the
+/// public one arrives in `X-Forwarded-Host` — forwarding that header would let
+/// a client forge it, and dropping it silently would have the candidate resolve
+/// the wrong tenant or reject the request. Preferring the resolved value
+/// mirrors `tenancy::extract_tenant_from_parts`, which makes the same choice
+/// for the same reason.
 #[must_use]
-pub fn forwarded_headers(source: &HeaderMap, resolved_host: Option<&str>) -> HeaderMap {
+pub fn forwarded_headers(
+    source: &HeaderMap,
+    resolved: Option<&crate::security::ResolvedClientIdentity>,
+) -> HeaderMap {
     let connection_named = connection_named_headers(source);
     let mut out = HeaderMap::with_capacity(source.len().saturating_add(1));
     for (name, value) in source {
@@ -183,10 +186,30 @@ pub fn forwarded_headers(source: &HeaderMap, resolved_host: Option<&str>) -> Hea
         }
         out.append(name.clone(), value.clone());
     }
-    if let Some(host) = resolved_host
-        && let Ok(value) = HeaderValue::from_str(host)
-    {
-        out.insert(axum::http::header::HOST, value);
+    // Re-stamp the forwarding family from the VALIDATED identity — never from
+    // the client's raw claims, which were stripped above. Dropping them
+    // entirely left the candidate resolving this process as the client: its
+    // per-IP rate limiter would bucket every mirror together (and answer `429`,
+    // a divergence), and `ClientScheme` would fall back to `http`, diverging on
+    // any route that behaves differently under TLS. A candidate that does not
+    // trust this process as a proxy simply ignores these, which is exactly
+    // where it was before.
+    if let Some(identity) = resolved {
+        if let Some(host) = identity.host.as_deref()
+            && let Ok(value) = HeaderValue::from_str(host)
+        {
+            out.insert(axum::http::header::HOST, value);
+        }
+        if let Some(addr) = identity.addr
+            && let Ok(value) = HeaderValue::from_str(&addr.to_string())
+        {
+            out.insert("x-forwarded-for", value);
+        }
+        if let Some(scheme) = identity.scheme.as_deref()
+            && let Ok(value) = HeaderValue::from_str(scheme)
+        {
+            out.insert("x-forwarded-proto", value);
+        }
     }
     if let Ok(name) = HeaderName::from_bytes(SHADOW_HEADER.as_bytes()) {
         out.insert(name, HeaderValue::from_static(SHADOW_HEADER_VALUE));
@@ -455,27 +478,68 @@ mod tests {
         );
     }
 
+    fn identity(host: &str, addr: &str, scheme: &str) -> crate::security::ResolvedClientIdentity {
+        crate::security::ResolvedClientIdentity {
+            addr: Some(addr.parse().expect("valid ip")),
+            host: Some(host.to_owned()),
+            scheme: Some(scheme.to_owned()),
+        }
+    }
+
     #[test]
-    fn the_trusted_proxys_resolved_host_wins_over_the_raw_one() {
+    fn the_validated_identity_replaces_the_clients_own_claims() {
         // Behind a proxy the raw `Host` is the INTERNAL address and the public
-        // one arrives in `X-Forwarded-Host`, which is stripped here (a client
-        // could have forged it). The validated authority the trusted-proxy
-        // layer accepted is what travels instead — otherwise the candidate
-        // resolves the wrong tenant, or rejects the request outright.
+        // one arrives in `X-Forwarded-Host` — which is stripped here, because a
+        // client can forge it. What travels instead is what the trusted-proxy
+        // layer ACCEPTED: host, client address, and scheme. Dropping the last
+        // two left the candidate resolving this process as the client, so its
+        // per-IP limiter bucketed every mirror together and `ClientScheme` fell
+        // back to `http`.
         let forwarded = forwarded_headers(
             &headers(&[
                 ("host", "10.0.0.7:3000"),
-                ("x-forwarded-host", "app.example.com"),
+                ("x-forwarded-host", "evil.example"),
+                ("x-forwarded-for", "203.0.113.9"),
+                ("x-forwarded-proto", "http"),
             ]),
-            Some("app.example.com"),
+            Some(&identity("app.example.com", "198.51.100.4", "https")),
         );
         assert_eq!(
             forwarded.get("host").and_then(|v| v.to_str().ok()),
             Some("app.example.com")
         );
+        assert_eq!(
+            forwarded
+                .get("x-forwarded-for")
+                .and_then(|v| v.to_str().ok()),
+            Some("198.51.100.4"),
+            "the resolved client address, not the one the client claimed"
+        );
+        assert_eq!(
+            forwarded
+                .get("x-forwarded-proto")
+                .and_then(|v| v.to_str().ok()),
+            Some("https"),
+            "the resolved scheme, not the one the client claimed"
+        );
         assert!(
             !forwarded.contains_key("x-forwarded-host"),
-            "the unvalidated header itself must still not travel"
+            "the unvalidated header itself must never travel"
+        );
+    }
+
+    #[test]
+    fn no_forwarding_headers_are_synthesized_without_a_resolved_identity() {
+        // Nothing validated the client's claims, so nothing is asserted to the
+        // candidate on its behalf.
+        let forwarded = forwarded_headers(
+            &headers(&[("x-forwarded-for", "203.0.113.9"), ("host", "app.local")]),
+            None,
+        );
+        assert!(!forwarded.contains_key("x-forwarded-for"));
+        assert_eq!(
+            forwarded.get("host").and_then(|v| v.to_str().ok()),
+            Some("app.local")
         );
     }
 

--- a/autumn/src/shadow/transport.rs
+++ b/autumn/src/shadow/transport.rs
@@ -53,7 +53,7 @@ use crate::shadow::sample::{SHADOW_HEADER, SHADOW_HEADER_VALUE};
 /// candidate answers uncompressed: the primary body is teed *inside* the
 /// compression layer, so an encoded shadow body would diff against a plain
 /// primary one and every route would look divergent.
-const STRIPPED_HEADERS: [&str; 18] = [
+const STRIPPED_HEADERS: [&str; 17] = [
     // Hop-by-hop (RFC 9110 §7.6.1) plus `proxy-connection`.
     "connection",
     "proxy-connection",
@@ -64,9 +64,7 @@ const STRIPPED_HEADERS: [&str; 18] = [
     "trailer",
     "transfer-encoding",
     "upgrade",
-    // Re-derived from the shadow target, or describing a body a GET/HEAD
-    // mirror does not carry.
-    "host",
+    // Describes a body a GET/HEAD mirror does not carry.
     "content-length",
     // Dropped so the candidate answers uncompressed — see the module note on
     // why an encoded shadow body would diff against a plain primary one.
@@ -151,6 +149,16 @@ pub trait ShadowTransport: std::fmt::Debug + Send + Sync + 'static {
 /// redirect or a `401`, and the diff degenerates into noise. The consequence —
 /// the shadow target receives live credentials and must be as trusted as the
 /// primary — is stated in `docs/guide/staged-deploys.md`.
+///
+/// **So is `Host`.** The candidate is dialed at the operator's target address
+/// (`127.0.0.1:9091`, say), but the request's *logical* authority is the one
+/// the live build accepted. Letting the client re-derive `Host` from the dial
+/// address breaks any route whose behaviour depends on it: a candidate that
+/// clones production's `[security.trusted_hosts]` rejects every mirror with a
+/// `400`, and a subdomain-keyed multi-tenant app resolves the wrong tenant —
+/// either way manufacturing a divergence on every single request. The dial
+/// address and the authority are separate things, and only the address comes
+/// from the target.
 #[must_use]
 pub fn forwarded_headers(source: &HeaderMap) -> HeaderMap {
     let connection_named = connection_named_headers(source);
@@ -353,13 +361,23 @@ mod tests {
     }
 
     #[test]
-    fn host_and_framing_headers_are_stripped() {
-        let forwarded = forwarded_headers(&headers(&[
-            ("host", "app.example.com"),
-            ("content-length", "0"),
-        ]));
-        assert!(!forwarded.contains_key("host"));
+    fn framing_headers_are_stripped() {
+        let forwarded = forwarded_headers(&headers(&[("content-length", "0")]));
         assert!(!forwarded.contains_key("content-length"));
+    }
+
+    #[test]
+    fn the_accepted_host_is_preserved() {
+        // The candidate is dialed at the operator's target address, but the
+        // request's logical authority is the one the live build accepted.
+        // Re-deriving it from the dial address would make a candidate that
+        // clones production's trusted-host policy reject every mirror with a
+        // 400, and a subdomain-keyed tenant app resolve the wrong tenant.
+        let forwarded = forwarded_headers(&headers(&[("host", "app.example.com")]));
+        assert_eq!(
+            forwarded.get("host").and_then(|v| v.to_str().ok()),
+            Some("app.example.com")
+        );
     }
 
     #[test]

--- a/autumn/src/shadow/transport.rs
+++ b/autumn/src/shadow/transport.rs
@@ -1,0 +1,361 @@
+//! Sending a mirrored request to the candidate build (issue #1653).
+//!
+//! Behind a trait, for two reasons. The obvious one is testability: the layer's
+//! own tests drive a recording double instead of a socket. The load-bearing one
+//! is that the shadow response must never become a `Response` the framework can
+//! accidentally return — it is read into a [`ResponseFacts`] here and handed
+//! straight to the differ, so there is no code path on which a candidate's bytes
+//! could reach an end user.
+//!
+//! [`HttpShadowTransport`] deliberately does **not** use
+//! [`crate::http_client::Client`]. That client carries a retry policy and a
+//! process-global per-host circuit breaker, both of which are wrong here: a
+//! retry would double the amplification a mirror already represents, and a
+//! flaky candidate would trip a breaker shared with the application's own
+//! outbound calls. Mirroring is strictly one attempt, one deadline, no
+//! redirects.
+
+// autumn-panic-gate: request-path module — production code path must be panic-free.
+// See CONTRIBUTING.md "Request-path panic gate". Justify exceptions with
+// #[allow(clippy::<lint>, reason = "…")] at the narrowest scope.
+#![cfg_attr(
+    not(test),
+    deny(
+        clippy::unwrap_used,
+        clippy::expect_used,
+        clippy::panic,
+        clippy::unreachable,
+        clippy::todo,
+        clippy::unimplemented,
+        clippy::indexing_slicing,
+        clippy::string_slice,
+        clippy::arithmetic_side_effects,
+    )
+)]
+
+use std::future::Future;
+use std::pin::Pin;
+
+use axum::http::{HeaderMap, HeaderName, HeaderValue, Method};
+
+use crate::shadow::diff::ResponseFacts;
+use crate::shadow::sample::{SHADOW_HEADER, SHADOW_HEADER_VALUE};
+
+/// Headers never copied onto a mirrored request.
+///
+/// The hop-by-hop set (RFC 9110 §7.6.1) describes *this* connection, not the
+/// message, so forwarding it is meaningless at best. `host` is re-derived from
+/// the shadow target. `content-length`/`transfer-encoding` describe a body a
+/// `GET`/`HEAD` mirror does not carry. `accept-encoding` is dropped so the
+/// candidate answers uncompressed: the primary body is teed *inside* the
+/// compression layer, so an encoded shadow body would diff against a plain
+/// primary one and every route would look divergent.
+const STRIPPED_HEADERS: [&str; 10] = [
+    "connection",
+    "keep-alive",
+    "proxy-authenticate",
+    "proxy-authorization",
+    "te",
+    "trailer",
+    "transfer-encoding",
+    "upgrade",
+    "host",
+    "content-length",
+];
+
+/// A request to replay against the candidate build.
+#[derive(Clone, Debug)]
+pub struct ShadowRequest {
+    /// Method — always `GET` or `HEAD`.
+    pub method: Method,
+    /// Absolute URL on the shadow target.
+    pub url: String,
+    /// Headers to send, already sanitized by [`forwarded_headers`].
+    pub headers: HeaderMap,
+}
+
+/// Why a shadow request produced no comparable response.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ShadowError {
+    /// The configured deadline elapsed first.
+    Timeout,
+    /// The candidate's response body exceeded `shadow.max_body_bytes`.
+    ///
+    /// Reported by the transport rather than by the caller, because the caller
+    /// can only measure a body that has *already been read into memory* — which
+    /// is the very thing this bound exists to prevent. The read stops the
+    /// moment the budget is passed and the rest of the body is never buffered.
+    Oversize,
+    /// Anything else: connection refused, DNS, TLS, a malformed response.
+    Transport(String),
+}
+
+impl ShadowError {
+    /// Stable metric label for this failure.
+    #[must_use]
+    pub const fn as_str(&self) -> &'static str {
+        match self {
+            Self::Timeout => "timeout",
+            Self::Oversize => "oversize",
+            Self::Transport(_) => "error",
+        }
+    }
+}
+
+impl std::fmt::Display for ShadowError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Timeout => write!(f, "shadow request timed out"),
+            Self::Oversize => write!(f, "shadow response body exceeded the capture budget"),
+            Self::Transport(detail) => write!(f, "shadow request failed: {detail}"),
+        }
+    }
+}
+
+impl std::error::Error for ShadowError {}
+
+/// Boxed future a [`ShadowTransport`] returns.
+pub type ShadowFuture =
+    Pin<Box<dyn Future<Output = Result<ResponseFacts, ShadowError>> + Send + 'static>>;
+
+/// How a mirrored request reaches the candidate build.
+pub trait ShadowTransport: std::fmt::Debug + Send + Sync + 'static {
+    /// Send `request` and read the response into comparable facts.
+    ///
+    /// Implementations must not retry: the caller already bounds this with a
+    /// deadline, and a mirror that retries amplifies production traffic.
+    fn send(&self, request: ShadowRequest) -> ShadowFuture;
+}
+
+/// Copy the headers that should travel with a mirrored request, and stamp the
+/// loop guard.
+///
+/// **Credentials are forwarded on purpose.** A candidate build that cannot see
+/// the session cookie or bearer token answers every authenticated route with a
+/// redirect or a `401`, and the diff degenerates into noise. The consequence —
+/// the shadow target receives live credentials and must be as trusted as the
+/// primary — is stated in `docs/guide/staged-deploys.md`.
+#[must_use]
+pub fn forwarded_headers(source: &HeaderMap) -> HeaderMap {
+    let mut out = HeaderMap::with_capacity(source.len().saturating_add(1));
+    for (name, value) in source {
+        let lower = name.as_str().to_ascii_lowercase();
+        if STRIPPED_HEADERS.contains(&lower.as_str())
+            || lower == "accept-encoding"
+            || lower == SHADOW_HEADER
+        {
+            continue;
+        }
+        out.append(name.clone(), value.clone());
+    }
+    if let Ok(name) = HeaderName::from_bytes(SHADOW_HEADER.as_bytes()) {
+        out.insert(name, HeaderValue::from_static(SHADOW_HEADER_VALUE));
+    }
+    out
+}
+
+/// Join a shadow target base with a request target.
+#[must_use]
+pub fn shadow_url(target_base: &str, request_target: &str) -> String {
+    let base = target_base.trim_end_matches('/');
+    if request_target.starts_with('/') {
+        format!("{base}{request_target}")
+    } else {
+        format!("{base}/{request_target}")
+    }
+}
+
+/// The real transport: one `reqwest` request, one deadline, no retries, no
+/// redirects, no circuit breaker.
+#[cfg(feature = "http-client")]
+#[derive(Debug, Clone)]
+pub struct HttpShadowTransport {
+    client: reqwest::Client,
+    max_body_bytes: usize,
+}
+
+#[cfg(feature = "http-client")]
+impl HttpShadowTransport {
+    /// Build a transport whose requests are bounded by `timeout`.
+    ///
+    /// Redirects are not followed: a candidate that answers `302` where the
+    /// live build answers `200` is exactly the divergence this feature exists
+    /// to report, and following the hop would hide it.
+    ///
+    /// # Errors
+    ///
+    /// Returns the `reqwest` build error when the TLS backend cannot be
+    /// initialised, so a misconfigured process reports it at startup rather
+    /// than panicking on the request path.
+    pub fn new(
+        timeout: std::time::Duration,
+        max_body_bytes: usize,
+    ) -> Result<Self, reqwest::Error> {
+        Ok(Self {
+            client: reqwest::Client::builder()
+                .timeout(timeout)
+                .redirect(reqwest::redirect::Policy::none())
+                .build()?,
+            max_body_bytes,
+        })
+    }
+}
+
+#[cfg(feature = "http-client")]
+impl ShadowTransport for HttpShadowTransport {
+    fn send(&self, request: ShadowRequest) -> ShadowFuture {
+        let client = self.client.clone();
+        let max_body_bytes = self.max_body_bytes;
+        Box::pin(async move {
+            let response = client
+                .request(request.method, &request.url)
+                .headers(request.headers)
+                .send()
+                .await
+                .map_err(|error| {
+                    if error.is_timeout() {
+                        ShadowError::Timeout
+                    } else {
+                        ShadowError::Transport(error.to_string())
+                    }
+                })?;
+
+            let status = response.status().as_u16();
+            let content_type = response
+                .headers()
+                .get(axum::http::header::CONTENT_TYPE)
+                .and_then(|value| value.to_str().ok())
+                .map(ToOwned::to_owned);
+            // Streamed, not `.bytes()`: collecting the whole body first would
+            // buffer an arbitrarily large candidate response into this
+            // process's memory before anyone could check its size. A candidate
+            // that streams a gigabyte must cost this replica the budget, not
+            // the gigabyte.
+            let mut collected = bytes::BytesMut::new();
+            let mut response = response;
+            loop {
+                let chunk = response.chunk().await.map_err(|error| {
+                    if error.is_timeout() {
+                        ShadowError::Timeout
+                    } else {
+                        ShadowError::Transport(error.to_string())
+                    }
+                })?;
+                let Some(chunk) = chunk else { break };
+                if collected.len().saturating_add(chunk.len()) > max_body_bytes {
+                    // Drop the response here: the connection is closed and the
+                    // remaining bytes are never read.
+                    return Err(ShadowError::Oversize);
+                }
+                collected.extend_from_slice(&chunk);
+            }
+
+            Ok(ResponseFacts::new(status, content_type, collected.freeze()))
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::http::{HeaderMap, HeaderName, HeaderValue};
+
+    fn headers(pairs: &[(&str, &str)]) -> HeaderMap {
+        let mut map = HeaderMap::new();
+        for (name, value) in pairs {
+            map.insert(
+                HeaderName::from_bytes(name.as_bytes()).expect("valid header name"),
+                HeaderValue::from_str(value).expect("valid header value"),
+            );
+        }
+        map
+    }
+
+    #[test]
+    fn the_loop_guard_header_is_always_added() {
+        let forwarded = forwarded_headers(&HeaderMap::new());
+        assert_eq!(
+            forwarded
+                .get(crate::shadow::sample::SHADOW_HEADER)
+                .and_then(|v| v.to_str().ok()),
+            Some(crate::shadow::sample::SHADOW_HEADER_VALUE)
+        );
+    }
+
+    #[test]
+    fn hop_by_hop_headers_are_stripped() {
+        let forwarded = forwarded_headers(&headers(&[
+            ("connection", "keep-alive"),
+            ("keep-alive", "timeout=5"),
+            ("proxy-authorization", "secret"),
+            ("te", "trailers"),
+            ("trailer", "Expires"),
+            ("transfer-encoding", "chunked"),
+            ("upgrade", "websocket"),
+        ]));
+        for stripped in [
+            "connection",
+            "keep-alive",
+            "proxy-authorization",
+            "te",
+            "trailer",
+            "transfer-encoding",
+            "upgrade",
+        ] {
+            assert!(
+                !forwarded.contains_key(stripped),
+                "{stripped} must not be forwarded"
+            );
+        }
+    }
+
+    #[test]
+    fn host_and_framing_headers_are_stripped() {
+        let forwarded = forwarded_headers(&headers(&[
+            ("host", "app.example.com"),
+            ("content-length", "0"),
+        ]));
+        assert!(!forwarded.contains_key("host"));
+        assert!(!forwarded.contains_key("content-length"));
+    }
+
+    #[test]
+    fn accept_encoding_is_stripped_so_both_sides_are_compared_uncompressed() {
+        let forwarded = forwarded_headers(&headers(&[("accept-encoding", "gzip, br")]));
+        assert!(!forwarded.contains_key("accept-encoding"));
+    }
+
+    #[test]
+    fn application_headers_including_credentials_are_forwarded() {
+        // Documented trust boundary: the candidate build must see the same
+        // request the live build saw, or every authenticated route diverges.
+        let forwarded = forwarded_headers(&headers(&[
+            ("cookie", "session=abc"),
+            ("authorization", "Bearer t"),
+            ("accept", "application/json"),
+            ("x-request-id", "r-1"),
+        ]));
+        for kept in ["cookie", "authorization", "accept", "x-request-id"] {
+            assert!(forwarded.contains_key(kept), "{kept} must be forwarded");
+        }
+    }
+
+    #[test]
+    fn shadow_urls_join_without_doubling_slashes() {
+        assert_eq!(
+            shadow_url("http://127.0.0.1:9091", "/api/orders?page=2"),
+            "http://127.0.0.1:9091/api/orders?page=2"
+        );
+        assert_eq!(
+            shadow_url("http://127.0.0.1:9091", "api/orders"),
+            "http://127.0.0.1:9091/api/orders"
+        );
+    }
+
+    #[test]
+    fn shadow_errors_have_stable_metric_labels() {
+        assert_eq!(ShadowError::Timeout.as_str(), "timeout");
+        assert_eq!(ShadowError::Oversize.as_str(), "oversize");
+        assert_eq!(ShadowError::Transport(String::new()).as_str(), "error");
+    }
+}

--- a/autumn/src/shadow/transport.rs
+++ b/autumn/src/shadow/transport.rs
@@ -259,7 +259,7 @@ pub fn shadow_url(target_base: &str, request_target: &str) -> String {
 /// the compressed bytes would leave a decompression bomb able to grow this
 /// process. An unknown encoding is passed through untouched — better a
 /// byte-comparison the operator can see than a guess.
-fn decode_body(
+pub(crate) fn decode_body(
     content_encoding: Option<&str>,
     body: bytes::Bytes,
     max_body_bytes: usize,
@@ -402,16 +402,17 @@ impl ShadowTransport for HttpShadowTransport {
                 collected.extend_from_slice(&chunk);
             }
 
-            // The candidate saw the client's `Accept-Encoding`, so it may have
-            // answered encoded. Decode before comparing: the primary side was
-            // teed inside the compression layer and is plain.
-            let body = decode_body(
-                content_encoding.as_deref(),
+            // The encoding travels WITH the facts rather than being consumed
+            // here. Decoding only this side would report identical builds as
+            // divergent whenever a handler serves a precompressed
+            // representation, because the primary tee captures those encoded
+            // bytes too. Both sides are decoded together in the mirror task.
+            Ok(ResponseFacts::encoded(
+                status,
+                content_type,
+                content_encoding,
                 collected.freeze(),
-                max_body_bytes,
-            )?;
-
-            Ok(ResponseFacts::new(status, content_type, body))
+            ))
         })
     }
 }

--- a/autumn/src/shadow/transport.rs
+++ b/autumn/src/shadow/transport.rs
@@ -7,6 +7,9 @@
 //! straight to the differ, so there is no code path on which a candidate's bytes
 //! could reach an end user.
 //!
+//! [`HttpShadowTransport`] also disables proxy autodetection and follows no
+//! redirects — see [`HttpShadowTransport::new`].
+//!
 //! [`HttpShadowTransport`] deliberately does **not** use
 //! [`crate::http_client::Client`]. That client carries a retry policy and a
 //! process-global per-host circuit breaker, both of which are wrong here: a
@@ -50,8 +53,10 @@ use crate::shadow::sample::{SHADOW_HEADER, SHADOW_HEADER_VALUE};
 /// candidate answers uncompressed: the primary body is teed *inside* the
 /// compression layer, so an encoded shadow body would diff against a plain
 /// primary one and every route would look divergent.
-const STRIPPED_HEADERS: [&str; 10] = [
+const STRIPPED_HEADERS: [&str; 18] = [
+    // Hop-by-hop (RFC 9110 §7.6.1) plus `proxy-connection`.
     "connection",
+    "proxy-connection",
     "keep-alive",
     "proxy-authenticate",
     "proxy-authorization",
@@ -59,8 +64,28 @@ const STRIPPED_HEADERS: [&str; 10] = [
     "trailer",
     "transfer-encoding",
     "upgrade",
+    // Re-derived from the shadow target, or describing a body a GET/HEAD
+    // mirror does not carry.
     "host",
     "content-length",
+    // Dropped so the candidate answers uncompressed — see the module note on
+    // why an encoded shadow body would diff against a plain primary one.
+    "accept-encoding",
+    // The forwarding family. This layer runs OUTSIDE
+    // `TrustedProxiesLayer`, so these still hold whatever the client put on
+    // the wire: the primary is about to discard them (its peer is not a
+    // trusted proxy), but the candidate would receive them from *this
+    // process's* address, which a production-cloned `trusted_proxies` config
+    // very likely does trust. Forwarding them would launder a header the
+    // primary correctly rejects into one an internal build accepts — a
+    // spoofed client IP past the candidate's own IP allowlists and per-IP
+    // limits, or a poisoned absolute-URL host.
+    "x-forwarded-for",
+    "x-forwarded-host",
+    "x-forwarded-proto",
+    "x-forwarded-port",
+    "forwarded",
+    "x-real-ip",
 ];
 
 /// A request to replay against the candidate build.
@@ -75,9 +100,10 @@ pub struct ShadowRequest {
 }
 
 /// Why a shadow request produced no comparable response.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, thiserror::Error)]
 pub enum ShadowError {
     /// The configured deadline elapsed first.
+    #[error("shadow request timed out")]
     Timeout,
     /// The candidate's response body exceeded `shadow.max_body_bytes`.
     ///
@@ -85,8 +111,10 @@ pub enum ShadowError {
     /// can only measure a body that has *already been read into memory* — which
     /// is the very thing this bound exists to prevent. The read stops the
     /// moment the budget is passed and the rest of the body is never buffered.
+    #[error("shadow response body exceeded the capture budget")]
     Oversize,
     /// Anything else: connection refused, DNS, TLS, a malformed response.
+    #[error("shadow request failed: {0}")]
     Transport(String),
 }
 
@@ -101,18 +129,6 @@ impl ShadowError {
         }
     }
 }
-
-impl std::fmt::Display for ShadowError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::Timeout => write!(f, "shadow request timed out"),
-            Self::Oversize => write!(f, "shadow response body exceeded the capture budget"),
-            Self::Transport(detail) => write!(f, "shadow request failed: {detail}"),
-        }
-    }
-}
-
-impl std::error::Error for ShadowError {}
 
 /// Boxed future a [`ShadowTransport`] returns.
 pub type ShadowFuture =
@@ -137,12 +153,13 @@ pub trait ShadowTransport: std::fmt::Debug + Send + Sync + 'static {
 /// primary — is stated in `docs/guide/staged-deploys.md`.
 #[must_use]
 pub fn forwarded_headers(source: &HeaderMap) -> HeaderMap {
+    let connection_named = connection_named_headers(source);
     let mut out = HeaderMap::with_capacity(source.len().saturating_add(1));
     for (name, value) in source {
         let lower = name.as_str().to_ascii_lowercase();
         if STRIPPED_HEADERS.contains(&lower.as_str())
-            || lower == "accept-encoding"
             || lower == SHADOW_HEADER
+            || connection_named.iter().any(|named| named == &lower)
         {
             continue;
         }
@@ -152,6 +169,23 @@ pub fn forwarded_headers(source: &HeaderMap) -> HeaderMap {
         out.insert(name, HeaderValue::from_static(SHADOW_HEADER_VALUE));
     }
     out
+}
+
+/// The header names an inbound `Connection:` header declares hop-by-hop.
+///
+/// RFC 9110 lets a message nominate its own connection-scoped headers
+/// (`Connection: X-Internal-Auth`). Those describe the hop the request arrived
+/// on, so copying them onto a different hop is exactly the mistake the fixed
+/// list above avoids for the well-known names.
+fn connection_named_headers(source: &HeaderMap) -> Vec<String> {
+    source
+        .get_all(axum::http::header::CONNECTION)
+        .iter()
+        .filter_map(|value| value.to_str().ok())
+        .flat_map(|value| value.split(','))
+        .map(|name| name.trim().to_ascii_lowercase())
+        .filter(|name| !name.is_empty())
+        .collect()
 }
 
 /// Join a shadow target base with a request target.
@@ -194,6 +228,15 @@ impl HttpShadowTransport {
         Ok(Self {
             client: reqwest::Client::builder()
                 .timeout(timeout)
+                // No ambient proxy. Mirrored requests carry the end user's
+                // session cookie and `Authorization` header, and reqwest
+                // honours `HTTP_PROXY`/`HTTPS_PROXY` by default with no
+                // loopback bypass — so on a host that sets those (a corporate
+                // egress proxy, a sidecar) every mirrored request would ship
+                // live credentials to a third party the operator never chose
+                // as a shadow target. The target is an address the operator
+                // named; this client dials it directly or not at all.
+                .no_proxy()
                 .redirect(reqwest::redirect::Policy::none())
                 .build()?,
             max_body_bytes,
@@ -323,6 +366,65 @@ mod tests {
     fn accept_encoding_is_stripped_so_both_sides_are_compared_uncompressed() {
         let forwarded = forwarded_headers(&headers(&[("accept-encoding", "gzip, br")]));
         assert!(!forwarded.contains_key("accept-encoding"));
+    }
+
+    #[test]
+    fn the_forwarding_family_is_stripped() {
+        // This layer runs outside TrustedProxiesLayer, so these still carry
+        // whatever the client sent. Forwarding them would launder a spoofed
+        // client IP or host into a candidate that trusts this process's
+        // address as a proxy.
+        let forwarded = forwarded_headers(&headers(&[
+            ("x-forwarded-for", "10.0.0.1"),
+            ("x-forwarded-host", "evil.example"),
+            ("x-forwarded-proto", "https"),
+            ("x-forwarded-port", "443"),
+            ("forwarded", "for=10.0.0.1;host=evil.example"),
+            ("x-real-ip", "10.0.0.1"),
+        ]));
+        for stripped in [
+            "x-forwarded-for",
+            "x-forwarded-host",
+            "x-forwarded-proto",
+            "x-forwarded-port",
+            "forwarded",
+            "x-real-ip",
+        ] {
+            assert!(
+                !forwarded.contains_key(stripped),
+                "{stripped} must not be forwarded to the candidate"
+            );
+        }
+    }
+
+    #[test]
+    fn headers_named_by_connection_are_stripped() {
+        let forwarded = forwarded_headers(&headers(&[
+            ("connection", "X-Internal-Auth, Keep-Alive"),
+            ("x-internal-auth", "hop-scoped"),
+            ("proxy-connection", "keep-alive"),
+            ("accept", "application/json"),
+        ]));
+        assert!(!forwarded.contains_key("x-internal-auth"));
+        assert!(!forwarded.contains_key("proxy-connection"));
+        assert!(
+            forwarded.contains_key("accept"),
+            "unrelated headers survive"
+        );
+    }
+
+    #[test]
+    fn an_inbound_loop_guard_is_replaced_not_duplicated() {
+        let forwarded = forwarded_headers(&headers(&[(
+            crate::shadow::sample::SHADOW_HEADER,
+            "spoofed",
+        )]));
+        let values: Vec<_> = forwarded
+            .get_all(crate::shadow::sample::SHADOW_HEADER)
+            .iter()
+            .filter_map(|v| v.to_str().ok())
+            .collect();
+        assert_eq!(values, vec![crate::shadow::sample::SHADOW_HEADER_VALUE]);
     }
 
     #[test]

--- a/autumn/src/shadow/transport.rs
+++ b/autumn/src/shadow/transport.rs
@@ -264,14 +264,12 @@ pub(crate) fn decode_body(
     body: bytes::Bytes,
     max_body_bytes: usize,
 ) -> Result<bytes::Bytes, ShadowError> {
-    use std::io::Read as _;
-
     // Nothing to decode. A `HEAD` response carries no body while keeping its
     // representation headers, so it arrives here as zero bytes still declaring
     // `Content-Encoding: gzip` — and a decoder handed zero bytes fails with an
     // unexpected EOF. Reporting that as a transport error would have two
-    // identical builds increment `shadow_errors` and never be compared at all,
-    // on every precompressed route that answers `HEAD`.
+    // identical builds counted as errors and never compared at all, on every
+    // precompressed route that answers `HEAD`.
     if body.is_empty() {
         return Ok(body);
     }
@@ -279,10 +277,48 @@ pub(crate) fn decode_body(
     let Some(encoding) = content_encoding else {
         return Ok(body);
     };
-    // `identity` means "not encoded"; anything unrecognised is left alone.
-    if matches!(encoding, "identity" | "") {
+
+    // `Content-Encoding` is a LIST: `gzip, br` means brotli was applied to the
+    // gzip output, so it unwinds in reverse. Matching the header as a single
+    // string left a stacked value unrecognised and passed encoded bytes through
+    // to be compared against a plain body — a divergence produced by a header,
+    // which the contract says is not compared. `identity` contributes nothing
+    // and drops out of the chain.
+    let codings: Vec<&str> = encoding
+        .split(',')
+        .map(str::trim)
+        .filter(|coding| !coding.is_empty() && *coding != "identity")
+        .collect();
+    if codings.is_empty() {
         return Ok(body);
     }
+    // An unrecognised coding anywhere makes the whole chain unsafe to unwind:
+    // decoding the layers around it would produce bytes that were never a
+    // representation of anything. Pass the body through untouched — exactly
+    // what a single unknown coding does — and let the byte comparison show it.
+    if !codings.iter().all(|coding| is_known_coding(coding)) {
+        return Ok(body);
+    }
+
+    let mut current = body;
+    for coding in codings.iter().rev() {
+        current = decode_one(coding, &current, max_body_bytes)?;
+    }
+    Ok(current)
+}
+
+/// Whether this content coding can be unwound.
+fn is_known_coding(coding: &str) -> bool {
+    matches!(coding, "gzip" | "x-gzip" | "deflate" | "br")
+}
+
+/// Unwind one content coding, bounding the output at `max_body_bytes`.
+fn decode_one(
+    coding: &str,
+    body: &bytes::Bytes,
+    max_body_bytes: usize,
+) -> Result<bytes::Bytes, ShadowError> {
+    use std::io::Read as _;
 
     // One byte past the budget, so an over-budget body is detectable rather
     // than silently truncated into a false divergence.
@@ -290,7 +326,7 @@ pub(crate) fn decode_body(
         .unwrap_or(u64::MAX)
         .saturating_add(1);
     let mut decoded = Vec::new();
-    let read = match encoding {
+    let read = match coding {
         "gzip" | "x-gzip" => flate2::read::GzDecoder::new(body.as_ref())
             .take(limit)
             .read_to_end(&mut decoded),
@@ -300,12 +336,10 @@ pub(crate) fn decode_body(
         "br" => brotli::Decompressor::new(body.as_ref(), 4096)
             .take(limit)
             .read_to_end(&mut decoded),
-        _ => return Ok(body),
+        _ => return Ok(body.clone()),
     };
     read.map_err(|error| {
-        ShadowError::Transport(format!(
-            "could not decode a {encoding} shadow body: {error}"
-        ))
+        ShadowError::Transport(format!("could not decode a {coding} body: {error}"))
     })?;
     if decoded.len() > max_body_bytes {
         return Err(ShadowError::Oversize);
@@ -533,6 +567,56 @@ mod tests {
 
         let decoded = decode_body(Some("gzip"), gzipped, 4096).expect("decode");
         assert_eq!(decoded.as_ref(), plain);
+    }
+
+    #[test]
+    fn a_stacked_content_encoding_is_unwound_in_reverse() {
+        // `gzip, br` means brotli was applied to the gzip output, so it unwinds
+        // br-then-gzip. Treating the header as one opaque string left it
+        // unrecognised and passed encoded bytes through to be compared against
+        // a plain body.
+        use std::io::Write as _;
+        let plain = br#"{"ok":true}"#;
+
+        let mut gz = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::default());
+        gz.write_all(plain).expect("gzip");
+        let gzipped = gz.finish().expect("finish");
+
+        let mut brotlied = Vec::new();
+        {
+            let mut writer = brotli::CompressorWriter::new(&mut brotlied, 4096, 5, 22);
+            writer.write_all(&gzipped).expect("br");
+        }
+
+        let decoded = decode_body(Some("gzip, br"), bytes::Bytes::from(brotlied), 4096)
+            .expect("decode chain");
+        assert_eq!(decoded.as_ref(), plain);
+    }
+
+    #[test]
+    fn identity_inside_a_chain_is_ignored() {
+        use std::io::Write as _;
+        let plain = b"hello";
+        let mut gz = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::default());
+        gz.write_all(plain).expect("gzip");
+        let gzipped = bytes::Bytes::from(gz.finish().expect("finish"));
+
+        let decoded = decode_body(Some("identity, gzip"), gzipped, 4096).expect("decode");
+        assert_eq!(decoded.as_ref(), plain);
+    }
+
+    #[test]
+    fn an_unknown_coding_anywhere_leaves_the_whole_chain_alone() {
+        // Unwinding the layers around an unknown coding would produce bytes
+        // that were never a representation of anything.
+        let body = bytes::Bytes::from_static(b"opaque");
+        for encoding in ["exotic-v2", "gzip, exotic-v2", "exotic-v2, gzip"] {
+            assert_eq!(
+                decode_body(Some(encoding), body.clone(), 4096).expect("pass through"),
+                body,
+                "{encoding}"
+            );
+        }
     }
 
     #[test]

--- a/autumn/src/shadow/transport.rs
+++ b/autumn/src/shadow/transport.rs
@@ -163,9 +163,17 @@ pub trait ShadowTransport: std::fmt::Debug + Send + Sync + 'static {
 /// from the target.
 ///
 /// `resolved` is what the trusted-proxy layer accepted, when it ran, and it is
-/// re-stamped over the stripped forwarding family: the candidate is told the
-/// *validated* host, client address, and scheme rather than the client's own
-/// claims. Behind a proxy the raw `Host` is the internal address while the
+/// re-stamped over the stripped forwarding family: the candidate is *told* the
+/// validated host, client address, and scheme rather than the client's own
+/// claims.
+///
+/// Told, not guaranteed to be believed: a candidate's own `ProxyResolver`
+/// honours `X-Forwarded-*` only when its immediate peer is trusted, so one that
+/// clones production's `[security.trusted_proxies]` — listing the load
+/// balancer, not this host — ignores them and resolves the mirroring process as
+/// the client. `Host` is unaffected, since it needs no proxy trust. The
+/// operator-facing consequence and its one-line fix are in
+/// `docs/guide/staged-deploys.md`. Behind a proxy the raw `Host` is the internal address while the
 /// public one arrives in `X-Forwarded-Host` — forwarding that header would let
 /// a client forge it, and dropping it silently would have the candidate resolve
 /// the wrong tenant or reject the request. Preferring the resolved value
@@ -307,6 +315,25 @@ pub(crate) fn decode_body(
     Ok(current)
 }
 
+/// Join every `Content-Encoding` field on a response into one coding list.
+///
+/// The header may legally appear as repeated fields (`Content-Encoding: gzip`
+/// then `Content-Encoding: br`) rather than one comma-joined value, and both
+/// forms mean the same chain. Reading only the first field would hand the
+/// decoder an incomplete chain — it would fail, and two identical builds would
+/// be recorded as decode errors instead of compared.
+#[must_use]
+pub(crate) fn joined_content_encoding(headers: &HeaderMap) -> Option<String> {
+    let codings: Vec<String> = headers
+        .get_all(axum::http::header::CONTENT_ENCODING)
+        .iter()
+        .filter_map(|value| value.to_str().ok())
+        .map(|value| value.trim().to_ascii_lowercase())
+        .filter(|value| !value.is_empty())
+        .collect();
+    (!codings.is_empty()).then(|| codings.join(", "))
+}
+
 /// Whether this content coding can be unwound.
 fn is_known_coding(coding: &str) -> bool {
     matches!(coding, "gzip" | "x-gzip" | "deflate" | "br")
@@ -417,11 +444,7 @@ impl ShadowTransport for HttpShadowTransport {
                 .get(axum::http::header::CONTENT_TYPE)
                 .and_then(|value| value.to_str().ok())
                 .map(ToOwned::to_owned);
-            let content_encoding = response
-                .headers()
-                .get(axum::http::header::CONTENT_ENCODING)
-                .and_then(|value| value.to_str().ok())
-                .map(|value| value.trim().to_ascii_lowercase());
+            let content_encoding = joined_content_encoding(response.headers());
             // Streamed, not `.bytes()`: collecting the whole body first would
             // buffer an arbitrarily large candidate response into this
             // process's memory before anyone could check its size. A candidate
@@ -567,6 +590,32 @@ mod tests {
 
         let decoded = decode_body(Some("gzip"), gzipped, 4096).expect("decode");
         assert_eq!(decoded.as_ref(), plain);
+    }
+
+    #[test]
+    fn repeated_content_encoding_fields_join_into_one_chain() {
+        // `Content-Encoding: gzip` then `Content-Encoding: br` means the same
+        // chain as `gzip, br`. Reading only the first field hands the decoder an
+        // incomplete chain, which fails — recording two identical builds as
+        // decode errors instead of comparing them.
+        let mut headers = HeaderMap::new();
+        headers.append(
+            axum::http::header::CONTENT_ENCODING,
+            HeaderValue::from_static("gzip"),
+        );
+        headers.append(
+            axum::http::header::CONTENT_ENCODING,
+            HeaderValue::from_static("br"),
+        );
+        assert_eq!(
+            joined_content_encoding(&headers).as_deref(),
+            Some("gzip, br")
+        );
+    }
+
+    #[test]
+    fn no_content_encoding_field_yields_none() {
+        assert_eq!(joined_content_encoding(&HeaderMap::new()), None);
     }
 
     #[test]

--- a/autumn/src/shadow/transport.rs
+++ b/autumn/src/shadow/transport.rs
@@ -159,8 +159,18 @@ pub trait ShadowTransport: std::fmt::Debug + Send + Sync + 'static {
 /// either way manufacturing a divergence on every single request. The dial
 /// address and the authority are separate things, and only the address comes
 /// from the target.
+///
+/// `resolved_host` is the authority the trusted-proxy layer accepted, when it
+/// ran. It takes precedence over the raw `Host`: behind a proxy the raw header
+/// carries the *internal* address while the public one arrives in
+/// `X-Forwarded-Host`, which is stripped here for the reasons above. Sending
+/// the internal host would have the candidate resolve the wrong tenant, or
+/// reject the request outright — so the validated authority is what travels,
+/// never the unvalidated header it came from. This mirrors
+/// `tenancy::extract_tenant_from_parts`, which prefers the same resolved value
+/// over the raw header for the same reason.
 #[must_use]
-pub fn forwarded_headers(source: &HeaderMap) -> HeaderMap {
+pub fn forwarded_headers(source: &HeaderMap, resolved_host: Option<&str>) -> HeaderMap {
     let connection_named = connection_named_headers(source);
     let mut out = HeaderMap::with_capacity(source.len().saturating_add(1));
     for (name, value) in source {
@@ -172,6 +182,11 @@ pub fn forwarded_headers(source: &HeaderMap) -> HeaderMap {
             continue;
         }
         out.append(name.clone(), value.clone());
+    }
+    if let Some(host) = resolved_host
+        && let Ok(value) = HeaderValue::from_str(host)
+    {
+        out.insert(axum::http::header::HOST, value);
     }
     if let Ok(name) = HeaderName::from_bytes(SHADOW_HEADER.as_bytes()) {
         out.insert(name, HeaderValue::from_static(SHADOW_HEADER_VALUE));
@@ -324,7 +339,7 @@ mod tests {
 
     #[test]
     fn the_loop_guard_header_is_always_added() {
-        let forwarded = forwarded_headers(&HeaderMap::new());
+        let forwarded = forwarded_headers(&HeaderMap::new(), None);
         assert_eq!(
             forwarded
                 .get(crate::shadow::sample::SHADOW_HEADER)
@@ -335,15 +350,18 @@ mod tests {
 
     #[test]
     fn hop_by_hop_headers_are_stripped() {
-        let forwarded = forwarded_headers(&headers(&[
-            ("connection", "keep-alive"),
-            ("keep-alive", "timeout=5"),
-            ("proxy-authorization", "secret"),
-            ("te", "trailers"),
-            ("trailer", "Expires"),
-            ("transfer-encoding", "chunked"),
-            ("upgrade", "websocket"),
-        ]));
+        let forwarded = forwarded_headers(
+            &headers(&[
+                ("connection", "keep-alive"),
+                ("keep-alive", "timeout=5"),
+                ("proxy-authorization", "secret"),
+                ("te", "trailers"),
+                ("trailer", "Expires"),
+                ("transfer-encoding", "chunked"),
+                ("upgrade", "websocket"),
+            ]),
+            None,
+        );
         for stripped in [
             "connection",
             "keep-alive",
@@ -362,7 +380,7 @@ mod tests {
 
     #[test]
     fn framing_headers_are_stripped() {
-        let forwarded = forwarded_headers(&headers(&[("content-length", "0")]));
+        let forwarded = forwarded_headers(&headers(&[("content-length", "0")]), None);
         assert!(!forwarded.contains_key("content-length"));
     }
 
@@ -373,7 +391,7 @@ mod tests {
         // Re-deriving it from the dial address would make a candidate that
         // clones production's trusted-host policy reject every mirror with a
         // 400, and a subdomain-keyed tenant app resolve the wrong tenant.
-        let forwarded = forwarded_headers(&headers(&[("host", "app.example.com")]));
+        let forwarded = forwarded_headers(&headers(&[("host", "app.example.com")]), None);
         assert_eq!(
             forwarded.get("host").and_then(|v| v.to_str().ok()),
             Some("app.example.com")
@@ -382,7 +400,7 @@ mod tests {
 
     #[test]
     fn accept_encoding_is_stripped_so_both_sides_are_compared_uncompressed() {
-        let forwarded = forwarded_headers(&headers(&[("accept-encoding", "gzip, br")]));
+        let forwarded = forwarded_headers(&headers(&[("accept-encoding", "gzip, br")]), None);
         assert!(!forwarded.contains_key("accept-encoding"));
     }
 
@@ -392,14 +410,17 @@ mod tests {
         // whatever the client sent. Forwarding them would launder a spoofed
         // client IP or host into a candidate that trusts this process's
         // address as a proxy.
-        let forwarded = forwarded_headers(&headers(&[
-            ("x-forwarded-for", "10.0.0.1"),
-            ("x-forwarded-host", "evil.example"),
-            ("x-forwarded-proto", "https"),
-            ("x-forwarded-port", "443"),
-            ("forwarded", "for=10.0.0.1;host=evil.example"),
-            ("x-real-ip", "10.0.0.1"),
-        ]));
+        let forwarded = forwarded_headers(
+            &headers(&[
+                ("x-forwarded-for", "10.0.0.1"),
+                ("x-forwarded-host", "evil.example"),
+                ("x-forwarded-proto", "https"),
+                ("x-forwarded-port", "443"),
+                ("forwarded", "for=10.0.0.1;host=evil.example"),
+                ("x-real-ip", "10.0.0.1"),
+            ]),
+            None,
+        );
         for stripped in [
             "x-forwarded-for",
             "x-forwarded-host",
@@ -417,12 +438,15 @@ mod tests {
 
     #[test]
     fn headers_named_by_connection_are_stripped() {
-        let forwarded = forwarded_headers(&headers(&[
-            ("connection", "X-Internal-Auth, Keep-Alive"),
-            ("x-internal-auth", "hop-scoped"),
-            ("proxy-connection", "keep-alive"),
-            ("accept", "application/json"),
-        ]));
+        let forwarded = forwarded_headers(
+            &headers(&[
+                ("connection", "X-Internal-Auth, Keep-Alive"),
+                ("x-internal-auth", "hop-scoped"),
+                ("proxy-connection", "keep-alive"),
+                ("accept", "application/json"),
+            ]),
+            None,
+        );
         assert!(!forwarded.contains_key("x-internal-auth"));
         assert!(!forwarded.contains_key("proxy-connection"));
         assert!(
@@ -432,11 +456,44 @@ mod tests {
     }
 
     #[test]
+    fn the_trusted_proxys_resolved_host_wins_over_the_raw_one() {
+        // Behind a proxy the raw `Host` is the INTERNAL address and the public
+        // one arrives in `X-Forwarded-Host`, which is stripped here (a client
+        // could have forged it). The validated authority the trusted-proxy
+        // layer accepted is what travels instead — otherwise the candidate
+        // resolves the wrong tenant, or rejects the request outright.
+        let forwarded = forwarded_headers(
+            &headers(&[
+                ("host", "10.0.0.7:3000"),
+                ("x-forwarded-host", "app.example.com"),
+            ]),
+            Some("app.example.com"),
+        );
+        assert_eq!(
+            forwarded.get("host").and_then(|v| v.to_str().ok()),
+            Some("app.example.com")
+        );
+        assert!(
+            !forwarded.contains_key("x-forwarded-host"),
+            "the unvalidated header itself must still not travel"
+        );
+    }
+
+    #[test]
+    fn without_a_resolved_host_the_raw_one_is_used() {
+        let forwarded = forwarded_headers(&headers(&[("host", "app.example.com")]), None);
+        assert_eq!(
+            forwarded.get("host").and_then(|v| v.to_str().ok()),
+            Some("app.example.com")
+        );
+    }
+
+    #[test]
     fn an_inbound_loop_guard_is_replaced_not_duplicated() {
-        let forwarded = forwarded_headers(&headers(&[(
-            crate::shadow::sample::SHADOW_HEADER,
-            "spoofed",
-        )]));
+        let forwarded = forwarded_headers(
+            &headers(&[(crate::shadow::sample::SHADOW_HEADER, "spoofed")]),
+            None,
+        );
         let values: Vec<_> = forwarded
             .get_all(crate::shadow::sample::SHADOW_HEADER)
             .iter()
@@ -449,12 +506,15 @@ mod tests {
     fn application_headers_including_credentials_are_forwarded() {
         // Documented trust boundary: the candidate build must see the same
         // request the live build saw, or every authenticated route diverges.
-        let forwarded = forwarded_headers(&headers(&[
-            ("cookie", "session=abc"),
-            ("authorization", "Bearer t"),
-            ("accept", "application/json"),
-            ("x-request-id", "r-1"),
-        ]));
+        let forwarded = forwarded_headers(
+            &headers(&[
+                ("cookie", "session=abc"),
+                ("authorization", "Bearer t"),
+                ("accept", "application/json"),
+                ("x-request-id", "r-1"),
+            ]),
+            None,
+        );
         for kept in ["cookie", "authorization", "accept", "x-request-id"] {
             assert!(forwarded.contains_key(kept), "{kept} must be forwarded");
         }

--- a/autumn/src/shadow/transport.rs
+++ b/autumn/src/shadow/transport.rs
@@ -49,11 +49,16 @@ use crate::shadow::sample::{SHADOW_HEADER, SHADOW_HEADER_VALUE};
 /// The hop-by-hop set (RFC 9110 §7.6.1) describes *this* connection, not the
 /// message, so forwarding it is meaningless at best. `host` is re-derived from
 /// the shadow target. `content-length`/`transfer-encoding` describe a body a
-/// `GET`/`HEAD` mirror does not carry. `accept-encoding` is dropped so the
-/// candidate answers uncompressed: the primary body is teed *inside* the
-/// compression layer, so an encoded shadow body would diff against a plain
-/// primary one and every route would look divergent.
-const STRIPPED_HEADERS: [&str; 17] = [
+/// `GET`/`HEAD` mirror does not carry.
+///
+/// `accept-encoding` is deliberately **not** in this list. The primary body is
+/// teed *inside* the compression layer, so it is the handler's plain bytes —
+/// but stripping the request header is not the way to make the candidate match:
+/// a handler or user layer may vary its body on `Accept-Encoding` (serving a
+/// precompressed representation), and then the two stacks would be answering
+/// different logical requests. The header travels, and the candidate's response
+/// is decoded on arrival instead — see `decode_body`.
+const STRIPPED_HEADERS: [&str; 16] = [
     // Hop-by-hop (RFC 9110 §7.6.1) plus `proxy-connection`.
     "connection",
     "proxy-connection",
@@ -66,9 +71,6 @@ const STRIPPED_HEADERS: [&str; 17] = [
     "upgrade",
     // Describes a body a GET/HEAD mirror does not carry.
     "content-length",
-    // Dropped so the candidate answers uncompressed — see the module note on
-    // why an encoded shadow body would diff against a plain primary one.
-    "accept-encoding",
     // The forwarding family. This layer runs OUTSIDE
     // `TrustedProxiesLayer`, so these still hold whatever the client put on
     // the wire: the primary is about to discard them (its peer is not a
@@ -245,6 +247,62 @@ pub fn shadow_url(target_base: &str, request_target: &str) -> String {
     }
 }
 
+/// Decode a candidate response body according to its `Content-Encoding`.
+///
+/// The mirrored request carries the client's own `Accept-Encoding` (see
+/// [`STRIPPED_HEADERS`]), so the candidate may legitimately answer encoded
+/// while the teed primary body is plain. Comparing those directly would report
+/// every compressible route as divergent.
+///
+/// The output is capped at `max_body_bytes` just as the wire read is: a
+/// decoder turns a small body into an arbitrarily large one, so bounding only
+/// the compressed bytes would leave a decompression bomb able to grow this
+/// process. An unknown encoding is passed through untouched — better a
+/// byte-comparison the operator can see than a guess.
+fn decode_body(
+    content_encoding: Option<&str>,
+    body: bytes::Bytes,
+    max_body_bytes: usize,
+) -> Result<bytes::Bytes, ShadowError> {
+    use std::io::Read as _;
+
+    let Some(encoding) = content_encoding else {
+        return Ok(body);
+    };
+    // `identity` means "not encoded"; anything unrecognised is left alone.
+    if matches!(encoding, "identity" | "") {
+        return Ok(body);
+    }
+
+    // One byte past the budget, so an over-budget body is detectable rather
+    // than silently truncated into a false divergence.
+    let limit = u64::try_from(max_body_bytes)
+        .unwrap_or(u64::MAX)
+        .saturating_add(1);
+    let mut decoded = Vec::new();
+    let read = match encoding {
+        "gzip" | "x-gzip" => flate2::read::GzDecoder::new(body.as_ref())
+            .take(limit)
+            .read_to_end(&mut decoded),
+        "deflate" => flate2::read::ZlibDecoder::new(body.as_ref())
+            .take(limit)
+            .read_to_end(&mut decoded),
+        "br" => brotli::Decompressor::new(body.as_ref(), 4096)
+            .take(limit)
+            .read_to_end(&mut decoded),
+        _ => return Ok(body),
+    };
+    read.map_err(|error| {
+        ShadowError::Transport(format!(
+            "could not decode a {encoding} shadow body: {error}"
+        ))
+    })?;
+    if decoded.len() > max_body_bytes {
+        return Err(ShadowError::Oversize);
+    }
+    Ok(bytes::Bytes::from(decoded))
+}
+
 /// The real transport: one `reqwest` request, one deadline, no retries, no
 /// redirects, no circuit breaker.
 #[cfg(feature = "http-client")]
@@ -315,6 +373,11 @@ impl ShadowTransport for HttpShadowTransport {
                 .get(axum::http::header::CONTENT_TYPE)
                 .and_then(|value| value.to_str().ok())
                 .map(ToOwned::to_owned);
+            let content_encoding = response
+                .headers()
+                .get(axum::http::header::CONTENT_ENCODING)
+                .and_then(|value| value.to_str().ok())
+                .map(|value| value.trim().to_ascii_lowercase());
             // Streamed, not `.bytes()`: collecting the whole body first would
             // buffer an arbitrarily large candidate response into this
             // process's memory before anyone could check its size. A candidate
@@ -339,7 +402,16 @@ impl ShadowTransport for HttpShadowTransport {
                 collected.extend_from_slice(&chunk);
             }
 
-            Ok(ResponseFacts::new(status, content_type, collected.freeze()))
+            // The candidate saw the client's `Accept-Encoding`, so it may have
+            // answered encoded. Decode before comparing: the primary side was
+            // teed inside the compression layer and is plain.
+            let body = decode_body(
+                content_encoding.as_deref(),
+                collected.freeze(),
+                max_body_bytes,
+            )?;
+
+            Ok(ResponseFacts::new(status, content_type, body))
         })
     }
 }
@@ -422,9 +494,59 @@ mod tests {
     }
 
     #[test]
-    fn accept_encoding_is_stripped_so_both_sides_are_compared_uncompressed() {
+    fn accept_encoding_travels_so_both_stacks_answer_the_same_request() {
+        // A handler or user layer may vary its body on this header; stripping it
+        // would have the two stacks answering different logical requests. The
+        // candidate's response is decoded on arrival instead.
         let forwarded = forwarded_headers(&headers(&[("accept-encoding", "gzip, br")]), None);
-        assert!(!forwarded.contains_key("accept-encoding"));
+        assert_eq!(
+            forwarded
+                .get("accept-encoding")
+                .and_then(|v| v.to_str().ok()),
+            Some("gzip, br")
+        );
+    }
+
+    #[test]
+    fn an_encoded_candidate_body_is_decoded_before_comparison() {
+        use std::io::Write as _;
+        let plain = b"{\"ok\":true}";
+        let mut encoder = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::default());
+        encoder.write_all(plain).expect("encode");
+        let gzipped = bytes::Bytes::from(encoder.finish().expect("finish"));
+        assert_ne!(
+            gzipped.as_ref(),
+            plain,
+            "the fixture must really be encoded"
+        );
+
+        let decoded = decode_body(Some("gzip"), gzipped, 4096).expect("decode");
+        assert_eq!(decoded.as_ref(), plain);
+    }
+
+    #[test]
+    fn an_unencoded_or_unknown_body_passes_through() {
+        let body = bytes::Bytes::from_static(b"plain");
+        for encoding in [None, Some("identity"), Some("exotic-v2")] {
+            let out = decode_body(encoding, body.clone(), 4096).expect("pass through");
+            assert_eq!(out, body, "{encoding:?}");
+        }
+    }
+
+    #[test]
+    fn a_decompression_bomb_is_refused_by_the_output_budget() {
+        // The wire read is capped, but a decoder turns a small body into an
+        // arbitrarily large one — so the OUTPUT is capped too.
+        use std::io::Write as _;
+        let mut encoder = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::best());
+        encoder.write_all(&vec![b'a'; 512 * 1024]).expect("encode");
+        let bomb = bytes::Bytes::from(encoder.finish().expect("finish"));
+        assert!(bomb.len() < 4096, "the fixture must be small on the wire");
+
+        assert_eq!(
+            decode_body(Some("gzip"), bomb, 4096),
+            Err(ShadowError::Oversize)
+        );
     }
 
     #[test]

--- a/autumn/src/shadow/transport.rs
+++ b/autumn/src/shadow/transport.rs
@@ -266,6 +266,16 @@ pub(crate) fn decode_body(
 ) -> Result<bytes::Bytes, ShadowError> {
     use std::io::Read as _;
 
+    // Nothing to decode. A `HEAD` response carries no body while keeping its
+    // representation headers, so it arrives here as zero bytes still declaring
+    // `Content-Encoding: gzip` — and a decoder handed zero bytes fails with an
+    // unexpected EOF. Reporting that as a transport error would have two
+    // identical builds increment `shadow_errors` and never be compared at all,
+    // on every precompressed route that answers `HEAD`.
+    if body.is_empty() {
+        return Ok(body);
+    }
+
     let Some(encoding) = content_encoding else {
         return Ok(body);
     };
@@ -523,6 +533,25 @@ mod tests {
 
         let decoded = decode_body(Some("gzip"), gzipped, 4096).expect("decode");
         assert_eq!(decoded.as_ref(), plain);
+    }
+
+    #[test]
+    fn an_empty_body_needs_no_decoding_whatever_it_declares() {
+        // A `HEAD` keeps its representation headers and sends no body, so this
+        // is the shape that reaches the decoder for a precompressed route.
+        for encoding in [
+            Some("gzip"),
+            Some("br"),
+            Some("deflate"),
+            Some("identity"),
+            None,
+        ] {
+            assert_eq!(
+                decode_body(encoding, bytes::Bytes::new(), 4096),
+                Ok(bytes::Bytes::new()),
+                "{encoding:?}"
+            );
+        }
     }
 
     #[test]

--- a/autumn/src/state.rs
+++ b/autumn/src/state.rs
@@ -1091,6 +1091,18 @@ impl crate::actuator::ProvideActuatorState for AppState {
         self.health_detailed
     }
 
+    /// The shadow-mirroring handle, installed into the runtime extension map
+    /// when the framework router assembled a mirror layer for this app.
+    ///
+    /// Read from extensions rather than stored as an `AppState` field because
+    /// the mirror is built during router assembly — after the state exists —
+    /// and because an app that never enables `[shadow]` should carry no extra
+    /// bytes for it.
+    fn shadow(&self) -> Option<crate::shadow::ShadowHandle> {
+        self.extension::<crate::shadow::ShadowHandle>()
+            .map(|handle| (*handle).clone())
+    }
+
     fn deploy_version(&self) -> String {
         self.extension::<crate::canary::CanaryState>().map_or_else(
             || crate::canary::STABLE.to_owned(),

--- a/autumn/tests/fixtures/schema_keys.snapshot
+++ b/autumn/tests/fixtures/schema_keys.snapshot
@@ -372,6 +372,16 @@ session.redis.key_prefix
 session.redis.url
 session.same_site
 session.secure
+shadow
+shadow.enabled
+shadow.max_body_bytes
+shadow.max_in_flight
+shadow.max_records
+shadow.max_sample_bytes
+shadow.routes
+shadow.sample_rate
+shadow.target
+shadow.timeout_ms
 storage
 storage.allow_local_in_production
 storage.backend

--- a/autumn/tests/integration/circuit_breaker_integration.rs
+++ b/autumn/tests/integration/circuit_breaker_integration.rs
@@ -55,7 +55,6 @@ async fn unrelated() -> &'static str {
     "unrelated ok"
 }
 
-
 /// Latency budget for a request that must not be slowed by an open circuit
 /// breaker, derived from a warm baseline measured on the same app.
 ///

--- a/autumn/tests/integration/circuit_breaker_integration.rs
+++ b/autumn/tests/integration/circuit_breaker_integration.rs
@@ -55,6 +55,25 @@ async fn unrelated() -> &'static str {
     "unrelated ok"
 }
 
+
+/// Latency budget for a request that must not be slowed by an open circuit
+/// breaker, derived from a warm baseline measured on the same app.
+///
+/// Fixed wall-clock bounds make this class of assertion measure the *runner*:
+/// a single in-process request on a loaded CI box (the macOS lane routinely
+/// takes 20+ minutes for this suite) can exceed a 50 ms bound through
+/// scheduler contention alone, with nothing slow about the code under test.
+/// A multiple of a baseline taken on the same machine, in the same run, keeps
+/// the property the test actually asserts — "an open breaker adds no latency
+/// here" — while scaling with whatever the machine is doing.
+///
+/// The `20 ms` floor keeps the budget meaningful when the baseline is
+/// unrealistically fast; a genuine regression here is blocking I/O or a lock,
+/// which is orders of magnitude, not a small multiple.
+fn latency_budget(baseline: Duration) -> Duration {
+    baseline.max(Duration::from_millis(20)) * 8
+}
+
 #[tokio::test]
 #[allow(clippy::too_many_lines, clippy::await_holding_lock)]
 async fn test_circuit_breaker_downstream_outage_flow() {
@@ -131,6 +150,20 @@ async fn test_circuit_breaker_downstream_outage_flow() {
         assert_eq!(val["status"], "UP");
     });
 
+    // Baseline for `/unrelated` while the breaker is still CLOSED, taken warm
+    // (after the requests above) so connection/lazy-init costs are already
+    // paid. The assertions below compare against THIS rather than against a
+    // fixed wall-clock bound: what the test means is "an open breaker on one
+    // host adds no latency to an unrelated route", which is a relative
+    // property. A fixed bound also measures the runner — on a loaded macOS CI
+    // box a single in-process request can exceed 50 ms from scheduler
+    // contention alone, failing a test whose subject is not slow at all.
+    let unrelated_baseline = {
+        let start = std::time::Instant::now();
+        client.get("/unrelated").send().await.assert_ok();
+        start.elapsed()
+    };
+
     // ── Downstream Outage triggers ──
     is_outage.store(true, Ordering::SeqCst);
 
@@ -166,9 +199,14 @@ async fn test_circuit_breaker_downstream_outage_flow() {
     resp_open.assert_status(503);
     assert_eq!(resp_open.text(), "circuit breaker open");
     let fast_elapsed = start_fast.elapsed();
+    // An open breaker short-circuits without dialling downstream, so this must
+    // be in the same league as an ordinary in-process request — not a fixed
+    // wall-clock figure that also measures the runner's load.
+    let fast_budget = latency_budget(unrelated_baseline);
     assert!(
-        fast_elapsed < Duration::from_millis(100),
-        "Should fail fast under 100ms"
+        fast_elapsed < fast_budget,
+        "an open breaker must fail fast: took {fast_elapsed:?}, budget {fast_budget:?} \
+         (baseline {unrelated_baseline:?})"
     );
 
     // Unrelated route latency stays low
@@ -177,9 +215,11 @@ async fn test_circuit_breaker_downstream_outage_flow() {
     resp_unrelated.assert_ok();
     assert_eq!(resp_unrelated.text(), "unrelated ok");
     let unrelated_elapsed = start_unrelated.elapsed();
+    let unrelated_budget = latency_budget(unrelated_baseline);
     assert!(
-        unrelated_elapsed < Duration::from_millis(50),
-        "Unrelated latency must be very low"
+        unrelated_elapsed < unrelated_budget,
+        "an open breaker on one host must not slow an unrelated route: took \
+         {unrelated_elapsed:?}, budget {unrelated_budget:?} (baseline {unrelated_baseline:?})"
     );
 
     // /health (compatibility) stays UP!

--- a/autumn/tests/integration/mod.rs
+++ b/autumn/tests/integration/mod.rs
@@ -257,6 +257,8 @@ mod search_index_definition;
 mod security;
 mod seo;
 mod server_timing;
+#[cfg(feature = "http-client")]
+mod shadow_mirror;
 #[cfg(feature = "db")]
 mod shard_across_tenants_no_shard_set;
 #[cfg(feature = "db")]

--- a/autumn/tests/integration/schema_drift_guard.rs
+++ b/autumn/tests/integration/schema_drift_guard.rs
@@ -383,6 +383,54 @@ fn cluster_child_keys_are_strictly_validated() {
     );
 }
 
+/// Regression guard for the `[shadow]` field ordering (issue #1653).
+///
+/// Same landmine as `deploy_child_keys_are_strictly_validated` and
+/// `cluster_child_keys_are_strictly_validated`: strict unknown-key validation
+/// only descends into a section the `SchemaDeserializer` walk actually reaches.
+/// A silently-accepted typo here is a mirror that never runs (`targt`), or one
+/// that mirrors far more traffic than the operator meant (`sample_rat` leaving
+/// the 1.0 default in place against production volume). If someone moves
+/// `shadow` below `database` and the walk stops reaching it, this fails.
+#[test]
+fn shadow_child_keys_are_strictly_validated() {
+    let leaves = AutumnConfig::schema_leaf_paths();
+    for key in [
+        "shadow.enabled",
+        "shadow.target",
+        "shadow.sample_rate",
+        "shadow.routes",
+        "shadow.timeout_ms",
+        "shadow.max_in_flight",
+        "shadow.max_body_bytes",
+        "shadow.max_records",
+        "shadow.max_sample_bytes",
+    ] {
+        assert!(
+            leaves.contains(key),
+            "{key} must be a schema leaf so strict validation descends into [shadow]; \
+             if this fails, `shadow` was likely moved below `database` in AutumnConfig"
+        );
+    }
+
+    let schema = AutumnConfig::get_schema_keys();
+    let errors =
+        AutumnConfig::validate_toml("[shadow]\ntargt = \"http://127.0.0.1:9091\"\n", &schema);
+    assert!(
+        errors.iter().any(|(path, _)| path == "shadow.targt"),
+        "a bogus [shadow] child key must be rejected by strict validation, got: {errors:?}"
+    );
+
+    let ok = AutumnConfig::validate_toml(
+        "[shadow]\nenabled = true\ntarget = \"http://127.0.0.1:9091\"\nsample_rate = 0.1\n",
+        &schema,
+    );
+    assert!(
+        ok.is_empty(),
+        "a well-formed [shadow] section must be accepted, got: {ok:?}"
+    );
+}
+
 /// #1890: config.rs-internal sections declared AFTER `database` used to vanish
 /// from the derived schema because the `statement_timeout` duration field
 /// aborted the `SchemaDeserializer` walk. The tolerant `deserialize_any` probe

--- a/autumn/tests/integration/shadow_mirror.rs
+++ b/autumn/tests/integration/shadow_mirror.rs
@@ -139,8 +139,10 @@ async fn spawn_candidate() -> (SocketAddr, Arc<CandidateLog>) {
 // ── Harness ─────────────────────────────────────────────────────────────────
 
 fn mirroring_config(target: SocketAddr) -> AutumnConfig {
-    let mut config = AutumnConfig::default();
-    config.profile = Some("test".into());
+    let mut config = AutumnConfig {
+        profile: Some("test".into()),
+        ..AutumnConfig::default()
+    };
     config.security.csrf.enabled = false;
     config.actuator.sensitive = true;
     config.shadow = ShadowConfig {
@@ -363,8 +365,10 @@ async fn the_actuator_endpoint_reports_the_mirror_run() {
 
 #[tokio::test]
 async fn the_actuator_endpoint_reports_a_disabled_mirror_by_default() {
-    let mut config = AutumnConfig::default();
-    config.profile = Some("test".into());
+    let mut config = AutumnConfig {
+        profile: Some("test".into()),
+        ..AutumnConfig::default()
+    };
     config.security.csrf.enabled = false;
     config.actuator.sensitive = true;
 
@@ -600,8 +604,10 @@ async fn a_divergence_is_reported_as_a_labelled_metric() {
 async fn the_shadow_metric_families_are_absent_without_a_mirror() {
     // Nothing to say, nothing written: the families stay out of the scrape
     // until an operator turns mirroring on.
-    let mut config = AutumnConfig::default();
-    config.profile = Some("test".into());
+    let mut config = AutumnConfig {
+        profile: Some("test".into()),
+        ..AutumnConfig::default()
+    };
     config.security.csrf.enabled = false;
 
     let app = TestApp::new()

--- a/autumn/tests/integration/shadow_mirror.rs
+++ b/autumn/tests/integration/shadow_mirror.rs
@@ -145,15 +145,19 @@ fn mirroring_config(target: SocketAddr) -> AutumnConfig {
     config
 }
 
-/// Poll `condition` every 10 ms for up to ~5 s. Mirroring runs on a detached
-/// task by design, so tests observe its effects rather than awaiting it.
-async fn settle(mut condition: impl FnMut() -> bool) {
-    for _ in 0..500 {
+/// Poll `condition` every 10 ms until it holds, or fail the test naming it.
+///
+/// Mirroring runs on a detached task by design, so tests observe its effects
+/// rather than awaiting it. Failing loudly on exhaustion keeps "the mirror
+/// never ran" from surfacing as a confusing assertion three lines later.
+async fn settle(what: &str, mut condition: impl FnMut() -> bool) {
+    for _ in 0..1_000 {
         if condition() {
             return;
         }
         tokio::time::sleep(Duration::from_millis(10)).await;
     }
+    panic!("timed out after 10s waiting for: {what}");
 }
 
 fn stats(app: &TestClient) -> autumn_web::shadow::ShadowStats {
@@ -187,7 +191,11 @@ async fn a_seeded_regression_is_flagged_and_clean_routes_stay_clean() {
         app.get("/api/status").send().await.assert_status(200);
     }
 
-    settle(|| stats(&app).compared >= 10).await;
+    settle("all ten comparisons to be recorded", || {
+        let stats = stats(&app);
+        stats.matched + stats.diverged >= 10
+    })
+    .await;
     let stats = stats(&app);
     assert_eq!(stats.mirrored, 10);
     assert_eq!(stats.compared, 10, "every mirror must reach the differ");
@@ -200,6 +208,10 @@ async fn a_seeded_regression_is_flagged_and_clean_routes_stay_clean() {
 
     // One record, not five: the same divergence collapses by fingerprint.
     let handle = app.state().shadow().expect("mirror handle");
+    settle("the divergence record to land", || {
+        !handle.registry.recent().is_empty()
+    })
+    .await;
     let records = handle.registry.recent();
     assert_eq!(records.len(), 1);
     assert_eq!(records[0].target, "/api/orders");
@@ -244,8 +256,12 @@ async fn mutating_requests_are_never_replayed_against_the_candidate() {
     // not a false negative from a dead mirror.
     app.get("/api/orders").send().await.assert_status(200);
 
-    settle(|| stats(&app).compared >= 1).await;
+    settle("the comparison to be recorded", || {
+        stats(&app).compared >= 1
+    })
+    .await;
     let seen = candidate.seen();
+    assert_eq!(seen.len(), 1, "only the GET may be mirrored: {seen:?}");
     assert!(
         seen.iter().all(|(method, _, _)| method == "GET"),
         "a mutating method reached the candidate: {seen:?}"
@@ -269,7 +285,10 @@ async fn the_client_sees_identical_bytes_with_and_without_mirroring() {
 
     assert_eq!(plain_body, mirrored_body);
 
-    settle(|| stats(&mirrored).compared >= 1).await;
+    settle("the comparison to be recorded", || {
+        stats(&mirrored).compared >= 1
+    })
+    .await;
     assert_eq!(stats(&mirrored).diverged, 1, "and it still diffed");
 }
 
@@ -286,7 +305,7 @@ async fn the_primary_handler_runs_exactly_once_per_client_request() {
         .send()
         .await
         .assert_status(200);
-    settle(|| stats(&app).mirrored >= 1).await;
+    settle("the mirror to be dispatched", || stats(&app).mirrored >= 1).await;
     let after = COUNTED_ORDER_CALLS.load(Ordering::SeqCst);
 
     assert_eq!(
@@ -305,7 +324,15 @@ async fn the_actuator_endpoint_reports_the_mirror_run() {
         .build();
 
     app.get("/api/orders").send().await.assert_status(200);
-    settle(|| stats(&app).diverged >= 1).await;
+    settle("the divergence to be recorded", || {
+        !app.state()
+            .shadow()
+            .expect("mirror handle")
+            .registry
+            .recent()
+            .is_empty()
+    })
+    .await;
 
     let response = app.get("/actuator/shadow").send().await;
     response.assert_status(200);
@@ -358,7 +385,10 @@ async fn actuator_paths_that_would_amplify_the_candidate_are_never_mirrored() {
     // A real request afterwards, so we can wait on a definite signal rather
     // than on the absence of one.
     app.get("/api/orders").send().await.assert_status(200);
-    settle(|| stats(&app).compared >= 1).await;
+    settle("the comparison to be recorded", || {
+        stats(&app).compared >= 1
+    })
+    .await;
 
     let seen = candidate.seen();
     assert_eq!(
@@ -373,6 +403,205 @@ async fn actuator_paths_that_would_amplify_the_candidate_are_never_mirrored() {
 #[get("/api/huge")]
 async fn live_huge() -> String {
     "x".repeat(512 * 1024)
+}
+
+#[tokio::test]
+async fn a_compressed_response_still_diffs_clean_against_the_candidate() {
+    // The mirror layer must stay INNER to the compression layer: it tees the
+    // handler's own bytes, which is what the candidate returns too. If it ever
+    // moved outside, it would tee a gzip-encoded body, diff it against the
+    // candidate's plain one, and report every single route as divergent. This
+    // control route is byte-identical on both builds, so any divergence here is
+    // that regression. (`accept-encoding` is also stripped from the mirrored
+    // request, so the candidate answers uncompressed either way.)
+    let (addr, _candidate) = spawn_candidate().await;
+    let app = TestApp::new()
+        .config(mirroring_config(addr))
+        .routes(routes![live_status])
+        .build();
+
+    for _ in 0..3 {
+        let response = app
+            .get("/api/status")
+            .header("accept-encoding", "gzip, br")
+            .send()
+            .await;
+        response.assert_status(200);
+    }
+
+    settle("all three comparisons to be recorded", || {
+        let stats = stats(&app);
+        stats.matched + stats.diverged >= 3
+    })
+    .await;
+    let stats = stats(&app);
+    assert_eq!(stats.matched, 3);
+    assert_eq!(
+        stats.diverged, 0,
+        "a compressed response must not manufacture a divergence"
+    );
+}
+
+#[tokio::test]
+async fn a_request_carrying_the_loop_guard_is_never_mirrored_again() {
+    // This is what stops a shadow target pointed at the app itself from turning
+    // one client request into 2, then 4, then 8: a request that already carries
+    // the guard is not eligible. Driven through the whole ingress stack, not
+    // just the selector.
+    let (addr, candidate) = spawn_candidate().await;
+    let app = TestApp::new()
+        .config(mirroring_config(addr))
+        .routes(routes![live_orders])
+        .build();
+
+    for _ in 0..3 {
+        app.get("/api/orders")
+            .header(SHADOW_HEADER, "1")
+            .send()
+            .await
+            .assert_status(200);
+    }
+    // An ordinary request afterwards, so we wait on a definite signal rather
+    // than on the absence of one.
+    app.get("/api/orders").send().await.assert_status(200);
+    settle("the unguarded request to reach the candidate", || {
+        !candidate.seen().is_empty()
+    })
+    .await;
+
+    assert_eq!(
+        stats(&app).mirrored,
+        1,
+        "only the request without the guard may be mirrored"
+    );
+    assert_eq!(candidate.seen().len(), 1);
+}
+
+#[tokio::test]
+async fn the_route_allowlist_and_sample_rate_reach_the_layer() {
+    // Proves `build_shadow_layer` actually threads `shadow.routes` and
+    // `shadow.sample_rate` through, rather than hard-coding "everything".
+    let (addr, candidate) = spawn_candidate().await;
+    let mut config = mirroring_config(addr);
+    config.shadow.routes = vec!["/api/status".to_owned()];
+    let app = TestApp::new()
+        .config(config)
+        .routes(routes![live_orders, live_status])
+        .build();
+
+    app.get("/api/orders").send().await.assert_status(200);
+    app.get("/api/status").send().await.assert_status(200);
+
+    settle("the allowlisted route to reach the candidate", || {
+        !candidate.seen().is_empty()
+    })
+    .await;
+    let seen = candidate.seen();
+    assert_eq!(seen.len(), 1, "only the allowlisted route: {seen:?}");
+    assert_eq!(seen[0].1, "/api/status");
+}
+
+#[tokio::test]
+async fn a_zero_sample_rate_mirrors_nothing() {
+    let (addr, candidate) = spawn_candidate().await;
+    let mut config = mirroring_config(addr);
+    config.shadow.sample_rate = 0.0;
+    let app = TestApp::new()
+        .config(config)
+        .routes(routes![live_orders])
+        .build();
+
+    for _ in 0..5 {
+        app.get("/api/orders").send().await.assert_status(200);
+    }
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    assert_eq!(stats(&app).mirrored, 0);
+    assert!(candidate.seen().is_empty());
+}
+
+#[tokio::test]
+async fn the_shadow_endpoint_is_gated_behind_sensitive_actuator() {
+    // The payload holds redacted excerpts of real production responses, so it
+    // must not be reachable on a replica that has sensitive surfaces closed.
+    let (addr, _candidate) = spawn_candidate().await;
+    let mut config = mirroring_config(addr);
+    config.actuator.sensitive = false;
+    let app = TestApp::new()
+        .config(config)
+        .routes(routes![live_orders])
+        .build();
+
+    app.get("/api/orders").send().await.assert_status(200);
+    app.get("/actuator/shadow").send().await.assert_status(404);
+}
+
+#[tokio::test]
+async fn a_divergence_is_reported_as_a_labelled_metric() {
+    // A route pattern unique to this test keeps the assertion independent of
+    // the other tests sharing this process's global metric registry.
+    let (addr, _candidate) = spawn_candidate().await;
+    let mut config = mirroring_config(addr);
+    config.shadow.routes = vec!["/api/orders".to_owned()];
+    let app = TestApp::new()
+        .config(config)
+        .routes(routes![live_orders])
+        .build();
+
+    app.get("/api/orders").send().await.assert_status(200);
+    settle("the divergence to be recorded", || {
+        stats(&app).diverged >= 1
+    })
+    .await;
+
+    // The framework's own `autumn_*` families are rendered by the actuator's
+    // Prometheus endpoint, not by the app-metrics facade — that facade reserves
+    // the `autumn_` namespace, so a family registered through it would be
+    // silently inert.
+    let scrape = app.get("/actuator/prometheus").send().await;
+    scrape.assert_status(200);
+    let body = scrape.text();
+
+    assert!(
+        body.contains(&format!(
+            "{}{{version=\"stable\",route=\"/api/orders\",kind=\"body\"}} 1",
+            autumn_web::shadow::DIVERGENCES_METRIC
+        )),
+        "divergence series missing from the scrape:\n{body}"
+    );
+    assert!(
+        body.contains(&format!(
+            "{}{{version=\"stable\",route=\"/api/orders\",outcome=\"diverged\"}} 1",
+            autumn_web::shadow::COMPARISONS_METRIC
+        )),
+        "comparison series missing from the scrape:\n{body}"
+    );
+    assert!(
+        body.contains(&format!(
+            "# TYPE {} counter",
+            autumn_web::shadow::DIVERGENCES_METRIC
+        )),
+        "the family must be declared as a counter:\n{body}"
+    );
+}
+
+#[tokio::test]
+async fn the_shadow_metric_families_are_absent_without_a_mirror() {
+    // Nothing to say, nothing written: the families stay out of the scrape
+    // until an operator turns mirroring on.
+    let mut config = AutumnConfig::default();
+    config.profile = Some("test".into());
+    config.security.csrf.enabled = false;
+
+    let app = TestApp::new()
+        .config(config)
+        .routes(routes![live_orders])
+        .build();
+    app.get("/api/orders").send().await.assert_status(200);
+
+    let body = app.get("/actuator/prometheus").send().await.text();
+    assert!(!body.contains(autumn_web::shadow::COMPARISONS_METRIC));
+    assert!(!body.contains(autumn_web::shadow::DIVERGENCES_METRIC));
 }
 
 #[tokio::test]
@@ -393,7 +622,10 @@ async fn an_oversized_candidate_response_is_skipped_not_buffered() {
         "the client still receives the whole body"
     );
 
-    settle(|| stats(&app).skipped_oversize >= 1).await;
+    settle("the oversize body to be skipped", || {
+        stats(&app).skipped_oversize >= 1
+    })
+    .await;
     let stats = stats(&app);
     assert_eq!(stats.mirrored, 1);
     assert_eq!(stats.skipped_oversize, 1);
@@ -403,12 +635,12 @@ async fn an_oversized_candidate_response_is_skipped_not_buffered() {
 
 #[tokio::test]
 async fn an_unreachable_candidate_is_counted_and_never_affects_the_client() {
-    // Bind and immediately drop, so the port is (almost certainly) closed.
-    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
-        .await
-        .expect("bind");
-    let addr = listener.local_addr().expect("addr");
-    drop(listener);
+    // Port 1 on loopback: privileged, never handed out by an ephemeral bind, so
+    // this cannot race a `spawn_candidate()` in a test running in parallel. (An
+    // ephemeral port that was bound and dropped can be re-handed to another
+    // test in this same binary, which would make the mirror unexpectedly
+    // succeed.)
+    let addr: SocketAddr = "127.0.0.1:1".parse().expect("addr");
 
     let mut config = mirroring_config(addr);
     config.shadow.timeout_ms = 500;
@@ -424,7 +656,7 @@ async fn an_unreachable_candidate_is_counted_and_never_affects_the_client() {
         json!({ "id": 7, "total": 42, "items": ["a", "b"] })
     );
 
-    settle(|| {
+    settle("the unreachable candidate to be counted", || {
         let stats = stats(&app);
         stats.shadow_errors + stats.shadow_timeouts >= 1
     })

--- a/autumn/tests/integration/shadow_mirror.rs
+++ b/autumn/tests/integration/shadow_mirror.rs
@@ -58,12 +58,16 @@ async fn create_order() -> Json<Value> {
 #[derive(Debug, Default)]
 struct CandidateLog {
     requests: std::sync::Mutex<Vec<(String, String, bool)>>,
+    hosts: std::sync::Mutex<Vec<String>>,
 }
 
 impl CandidateLog {
-    fn record(&self, method: &str, path: &str, loop_guard: bool) {
+    fn record(&self, method: &str, path: &str, loop_guard: bool, host: Option<&str>) {
         if let Ok(mut requests) = self.requests.lock() {
             requests.push((method.to_owned(), path.to_owned(), loop_guard));
+        }
+        if let Ok(mut hosts) = self.hosts.lock() {
+            hosts.push(host.unwrap_or_default().to_owned());
         }
     }
 
@@ -72,6 +76,10 @@ impl CandidateLog {
             .lock()
             .map(|requests| requests.clone())
             .unwrap_or_default()
+    }
+
+    fn hosts(&self) -> Vec<String> {
+        self.hosts.lock().map(|h| h.clone()).unwrap_or_default()
     }
 }
 
@@ -109,6 +117,9 @@ async fn spawn_candidate() -> (SocketAddr, Arc<CandidateLog>) {
                         req.method().as_str(),
                         req.uri().path(),
                         req.headers().contains_key(SHADOW_HEADER),
+                        req.headers()
+                            .get(axum::http::header::HOST)
+                            .and_then(|v| v.to_str().ok()),
                     );
                     next.run(req).await
                 }
@@ -602,6 +613,41 @@ async fn the_shadow_metric_families_are_absent_without_a_mirror() {
     let body = app.get("/actuator/prometheus").send().await.text();
     assert!(!body.contains(autumn_web::shadow::COMPARISONS_METRIC));
     assert!(!body.contains(autumn_web::shadow::DIVERGENCES_METRIC));
+}
+
+#[tokio::test]
+async fn the_candidate_sees_the_host_the_live_build_accepted() {
+    // Not the dial address. A candidate that clones production's
+    // `[security.trusted_hosts]` would reject every mirror with a 400 if the
+    // client re-derived `Host` from the target, and a subdomain-keyed tenant
+    // app would resolve the wrong tenant — either way a divergence on every
+    // request. This also pins that the HTTP client honours an explicit `Host`
+    // rather than overwriting it with the URL's authority.
+    let (addr, candidate) = spawn_candidate().await;
+    let mut config = mirroring_config(addr);
+    // The live build accepts this host; the candidate is dialed at a loopback
+    // address that has nothing to do with it.
+    config
+        .security
+        .trusted_hosts
+        .hosts
+        .push("app.example.com".to_owned());
+    let app = TestApp::new()
+        .config(config)
+        .routes(routes![live_orders])
+        .build();
+
+    app.get("/api/orders")
+        .header("host", "app.example.com")
+        .send()
+        .await
+        .assert_status(200);
+
+    settle("the mirror to reach the candidate", || {
+        !candidate.seen().is_empty()
+    })
+    .await;
+    assert_eq!(candidate.hosts(), vec!["app.example.com".to_owned()]);
 }
 
 #[tokio::test]

--- a/autumn/tests/integration/shadow_mirror.rs
+++ b/autumn/tests/integration/shadow_mirror.rs
@@ -1,0 +1,436 @@
+//! End-to-end shadow traffic mirroring and response diffing (issue #1653).
+//!
+//! These tests stand up a real **candidate build** — a separate axum server on
+//! a loopback port — carrying one seeded response regression, mirror live
+//! traffic to it through the framework's ingress stack, and assert the
+//! acceptance criteria the issue names:
+//!
+//! * the regressed endpoint is flagged,
+//! * unchanged endpoints report **zero** divergences,
+//! * the client's bytes are identical whether mirroring is on or off,
+//! * no mutating request is ever replayed,
+//! * `/actuator/shadow` reports what happened.
+
+use std::net::SocketAddr;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::Duration;
+
+use autumn_web::actuator::ProvideActuatorState;
+use autumn_web::config::AutumnConfig;
+use autumn_web::shadow::{SHADOW_HEADER, ShadowConfig};
+use autumn_web::test::{TestApp, TestClient};
+use autumn_web::{get, post, routes};
+use axum::Json;
+use serde_json::{Value, json};
+
+// ── The live build ──────────────────────────────────────────────────────────
+
+#[get("/api/orders")]
+async fn live_orders() -> Json<Value> {
+    Json(json!({ "id": 7, "total": 42, "items": ["a", "b"] }))
+}
+
+/// How many times [`counted_orders`] ran. Its own route, touched by exactly one
+/// test, so the tests in this binary — which run in parallel — cannot disturb
+/// each other's count.
+static COUNTED_ORDER_CALLS: AtomicUsize = AtomicUsize::new(0);
+
+#[get("/api/counted-orders")]
+async fn counted_orders() -> Json<Value> {
+    COUNTED_ORDER_CALLS.fetch_add(1, Ordering::SeqCst);
+    Json(json!({ "id": 7, "total": 42, "items": ["a", "b"] }))
+}
+
+#[get("/api/status")]
+async fn live_status() -> Json<Value> {
+    Json(json!({ "status": "ok" }))
+}
+
+#[post("/api/orders")]
+async fn create_order() -> Json<Value> {
+    Json(json!({ "created": true }))
+}
+
+// ── The candidate build ─────────────────────────────────────────────────────
+
+/// What the candidate saw, so tests can assert on the mirrored traffic itself.
+#[derive(Debug, Default)]
+struct CandidateLog {
+    requests: std::sync::Mutex<Vec<(String, String, bool)>>,
+}
+
+impl CandidateLog {
+    fn record(&self, method: &str, path: &str, loop_guard: bool) {
+        if let Ok(mut requests) = self.requests.lock() {
+            requests.push((method.to_owned(), path.to_owned(), loop_guard));
+        }
+    }
+
+    fn seen(&self) -> Vec<(String, String, bool)> {
+        self.requests
+            .lock()
+            .map(|requests| requests.clone())
+            .unwrap_or_default()
+    }
+}
+
+/// Start a candidate build on a loopback port.
+///
+/// `/api/orders` carries the **seeded regression**: the `total` field is
+/// dropped. `/api/status` is byte-identical to the live build, so it is the
+/// false-positive control.
+async fn spawn_candidate() -> (SocketAddr, Arc<CandidateLog>) {
+    let log = Arc::new(CandidateLog::default());
+
+    let router = axum::Router::new()
+        .route(
+            "/api/orders",
+            axum::routing::get(|| async { Json(json!({ "id": 7, "items": ["a", "b"] })) }),
+        )
+        .route(
+            "/api/status",
+            axum::routing::get(|| async { Json(json!({ "status": "ok" })) }),
+        )
+        .route(
+            "/api/huge",
+            axum::routing::get(|| async { "x".repeat(512 * 1024) }),
+        )
+        .route(
+            "/api/orders-post",
+            axum::routing::post(|| async { Json(json!({ "created": true })) }),
+        )
+        .layer(axum::middleware::from_fn({
+            let log = Arc::clone(&log);
+            move |req: axum::extract::Request, next: axum::middleware::Next| {
+                let log = Arc::clone(&log);
+                async move {
+                    log.record(
+                        req.method().as_str(),
+                        req.uri().path(),
+                        req.headers().contains_key(SHADOW_HEADER),
+                    );
+                    next.run(req).await
+                }
+            }
+        }));
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind candidate");
+    let addr = listener.local_addr().expect("candidate addr");
+    tokio::spawn(async move {
+        let _ = axum::serve(listener, router).await;
+    });
+    (addr, log)
+}
+
+// ── Harness ─────────────────────────────────────────────────────────────────
+
+fn mirroring_config(target: SocketAddr) -> AutumnConfig {
+    let mut config = AutumnConfig::default();
+    config.profile = Some("test".into());
+    config.security.csrf.enabled = false;
+    config.actuator.sensitive = true;
+    config.shadow = ShadowConfig {
+        enabled: true,
+        target: Some(format!("http://{target}")),
+        sample_rate: 1.0,
+        // Well above anything these tests issue, so a mirror is never dropped
+        // at the ceiling and the counts below are exact. (The ceiling itself is
+        // covered by the layer's own unit tests.)
+        max_in_flight: 64,
+        ..ShadowConfig::default()
+    };
+    config
+}
+
+/// Poll `condition` every 10 ms for up to ~5 s. Mirroring runs on a detached
+/// task by design, so tests observe its effects rather than awaiting it.
+async fn settle(mut condition: impl FnMut() -> bool) {
+    for _ in 0..500 {
+        if condition() {
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+}
+
+fn stats(app: &TestClient) -> autumn_web::shadow::ShadowStats {
+    app.state()
+        .shadow()
+        .map(|handle| handle.registry.stats())
+        .unwrap_or_default()
+}
+
+// ── Tests ───────────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn a_seeded_regression_is_flagged_and_clean_routes_stay_clean() {
+    let (addr, candidate) = spawn_candidate().await;
+    let app = TestApp::new()
+        .config(mirroring_config(addr))
+        .routes(routes![live_orders, live_status])
+        .build();
+
+    // Ten mirrored requests: five to the regressed endpoint, five to the
+    // control.
+    for _ in 0..5 {
+        let response = app.get("/api/orders").send().await;
+        response.assert_status(200);
+        assert_eq!(
+            response.json::<Value>(),
+            json!({ "id": 7, "total": 42, "items": ["a", "b"] }),
+            "the client must receive the LIVE build's response, untouched"
+        );
+
+        app.get("/api/status").send().await.assert_status(200);
+    }
+
+    settle(|| stats(&app).compared >= 10).await;
+    let stats = stats(&app);
+    assert_eq!(stats.mirrored, 10);
+    assert_eq!(stats.compared, 10, "every mirror must reach the differ");
+    assert_eq!(stats.diverged, 5, "the regressed endpoint diverges");
+    assert_eq!(stats.matched, 5, "the unchanged endpoint must not");
+    assert_eq!(stats.shadow_errors, 0);
+    assert_eq!(stats.shadow_timeouts, 0);
+    assert_eq!(stats.dropped_at_capacity, 0);
+    assert_eq!(stats.skipped_oversize, 0);
+
+    // One record, not five: the same divergence collapses by fingerprint.
+    let handle = app.state().shadow().expect("mirror handle");
+    let records = handle.registry.recent();
+    assert_eq!(records.len(), 1);
+    assert_eq!(records[0].target, "/api/orders");
+    assert_eq!(records[0].occurrences, 5);
+    assert_eq!(records[0].divergence.kind.as_str(), "body");
+    // The dropped field is visible in the redacted samples.
+    let primary = records[0]
+        .divergence
+        .primary_sample
+        .as_ref()
+        .expect("json sample");
+    assert_eq!(primary["total"], json!(42));
+    let shadow = records[0]
+        .divergence
+        .shadow_sample
+        .as_ref()
+        .expect("json sample");
+    assert!(shadow.get("total").is_none());
+
+    // Every mirrored request carried the loop guard, and none of them was a
+    // mutating method.
+    let seen = candidate.seen();
+    assert_eq!(seen.len(), 10);
+    assert!(
+        seen.iter()
+            .all(|(method, _, guard)| method == "GET" && *guard)
+    );
+}
+
+#[tokio::test]
+async fn mutating_requests_are_never_replayed_against_the_candidate() {
+    let (addr, candidate) = spawn_candidate().await;
+    let app = TestApp::new()
+        .config(mirroring_config(addr))
+        .routes(routes![live_orders, create_order])
+        .build();
+
+    for _ in 0..3 {
+        app.post("/api/orders").send().await.assert_status(200);
+    }
+    // One GET afterwards proves mirroring is on at all, so the POST result is
+    // not a false negative from a dead mirror.
+    app.get("/api/orders").send().await.assert_status(200);
+
+    settle(|| stats(&app).compared >= 1).await;
+    let seen = candidate.seen();
+    assert!(
+        seen.iter().all(|(method, _, _)| method == "GET"),
+        "a mutating method reached the candidate: {seen:?}"
+    );
+    assert_eq!(stats(&app).mirrored, 1);
+}
+
+#[tokio::test]
+async fn the_client_sees_identical_bytes_with_and_without_mirroring() {
+    let (addr, _candidate) = spawn_candidate().await;
+
+    let plain = TestApp::new().routes(routes![live_orders]).build();
+    let plain_body = plain.get("/api/orders").send().await.text();
+
+    let mirrored = TestApp::new()
+        .config(mirroring_config(addr))
+        .routes(routes![live_orders])
+        .build();
+    let mirrored_response = mirrored.get("/api/orders").send().await;
+    let mirrored_body = mirrored_response.text();
+
+    assert_eq!(plain_body, mirrored_body);
+
+    settle(|| stats(&mirrored).compared >= 1).await;
+    assert_eq!(stats(&mirrored).diverged, 1, "and it still diffed");
+}
+
+#[tokio::test]
+async fn the_primary_handler_runs_exactly_once_per_client_request() {
+    let (addr, _candidate) = spawn_candidate().await;
+    let app = TestApp::new()
+        .config(mirroring_config(addr))
+        .routes(routes![counted_orders])
+        .build();
+
+    let before = COUNTED_ORDER_CALLS.load(Ordering::SeqCst);
+    app.get("/api/counted-orders")
+        .send()
+        .await
+        .assert_status(200);
+    settle(|| stats(&app).mirrored >= 1).await;
+    let after = COUNTED_ORDER_CALLS.load(Ordering::SeqCst);
+
+    assert_eq!(
+        after - before,
+        1,
+        "mirroring must not re-enter the live build"
+    );
+}
+
+#[tokio::test]
+async fn the_actuator_endpoint_reports_the_mirror_run() {
+    let (addr, _candidate) = spawn_candidate().await;
+    let app = TestApp::new()
+        .config(mirroring_config(addr))
+        .routes(routes![live_orders])
+        .build();
+
+    app.get("/api/orders").send().await.assert_status(200);
+    settle(|| stats(&app).diverged >= 1).await;
+
+    let response = app.get("/actuator/shadow").send().await;
+    response.assert_status(200);
+    let body = response.json::<Value>();
+    assert_eq!(body["enabled"], json!(true));
+    assert_eq!(body["target"], json!(format!("http://{addr}")));
+    assert_eq!(body["stats"]["diverged"], json!(1));
+    assert_eq!(body["divergences"][0]["target"], json!("/api/orders"));
+    assert_eq!(body["divergences"][0]["kind"], json!("body"));
+    assert!(
+        body["divergences"][0]["fingerprint"]
+            .as_str()
+            .is_some_and(|f| !f.is_empty()),
+        "a recorded divergence must be quotable by fingerprint"
+    );
+}
+
+#[tokio::test]
+async fn the_actuator_endpoint_reports_a_disabled_mirror_by_default() {
+    let mut config = AutumnConfig::default();
+    config.profile = Some("test".into());
+    config.security.csrf.enabled = false;
+    config.actuator.sensitive = true;
+
+    let app = TestApp::new()
+        .config(config)
+        .routes(routes![live_orders])
+        .build();
+    app.get("/api/orders").send().await.assert_status(200);
+
+    let response = app.get("/actuator/shadow").send().await;
+    response.assert_status(200);
+    let body = response.json::<Value>();
+    assert_eq!(body["enabled"], json!(false));
+    assert_eq!(body["stats"]["mirrored"], json!(0));
+    assert!(app.state().shadow().is_none());
+}
+
+#[tokio::test]
+async fn actuator_paths_that_would_amplify_the_candidate_are_never_mirrored() {
+    let (addr, candidate) = spawn_candidate().await;
+    let app = TestApp::new()
+        .config(mirroring_config(addr))
+        .routes(routes![live_orders])
+        .build();
+
+    for path in ["/actuator/health", "/actuator/shadow", "/health"] {
+        let _ = app.get(path).send().await;
+    }
+    // A real request afterwards, so we can wait on a definite signal rather
+    // than on the absence of one.
+    app.get("/api/orders").send().await.assert_status(200);
+    settle(|| stats(&app).compared >= 1).await;
+
+    let seen = candidate.seen();
+    assert_eq!(
+        seen.len(),
+        1,
+        "only the application request may be mirrored: {seen:?}"
+    );
+    assert_eq!(seen[0].1, "/api/orders");
+}
+
+/// The live build's counterpart to the candidate's `/api/huge`.
+#[get("/api/huge")]
+async fn live_huge() -> String {
+    "x".repeat(512 * 1024)
+}
+
+#[tokio::test]
+async fn an_oversized_candidate_response_is_skipped_not_buffered() {
+    let (addr, _candidate) = spawn_candidate().await;
+    let mut config = mirroring_config(addr);
+    config.shadow.max_body_bytes = 4096;
+    let app = TestApp::new()
+        .config(config)
+        .routes(routes![live_huge])
+        .build();
+
+    let response = app.get("/api/huge").send().await;
+    response.assert_status(200);
+    assert_eq!(
+        response.text().len(),
+        512 * 1024,
+        "the client still receives the whole body"
+    );
+
+    settle(|| stats(&app).skipped_oversize >= 1).await;
+    let stats = stats(&app);
+    assert_eq!(stats.mirrored, 1);
+    assert_eq!(stats.skipped_oversize, 1);
+    assert_eq!(stats.compared, 0);
+    assert_eq!(stats.shadow_errors, 0);
+}
+
+#[tokio::test]
+async fn an_unreachable_candidate_is_counted_and_never_affects_the_client() {
+    // Bind and immediately drop, so the port is (almost certainly) closed.
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind");
+    let addr = listener.local_addr().expect("addr");
+    drop(listener);
+
+    let mut config = mirroring_config(addr);
+    config.shadow.timeout_ms = 500;
+    let app = TestApp::new()
+        .config(config)
+        .routes(routes![live_orders])
+        .build();
+
+    let response = app.get("/api/orders").send().await;
+    response.assert_status(200);
+    assert_eq!(
+        response.json::<Value>(),
+        json!({ "id": 7, "total": 42, "items": ["a", "b"] })
+    );
+
+    settle(|| {
+        let stats = stats(&app);
+        stats.shadow_errors + stats.shadow_timeouts >= 1
+    })
+    .await;
+    let stats = stats(&app);
+    assert_eq!(stats.mirrored, 1);
+    assert_eq!(stats.compared, 0);
+    assert_eq!(stats.shadow_errors + stats.shadow_timeouts, 1);
+}

--- a/docs/guide/deployment.md
+++ b/docs/guide/deployment.md
@@ -2589,13 +2589,15 @@ controlled by `actuator.prometheus` (default **`true`**) and is **independent of
 `actuator.sensitive`**. That separation is the whole point: a production app can
 let Fly.io (or any scraper) collect metrics while keeping `actuator.sensitive =
 false`, so `/actuator/env`, `/actuator/configprops`, `/actuator/loggers`,
-`/actuator/tasks`, `/actuator/jobs`, and the actuator task UI stay off the
-public surface.
+`/actuator/tasks`, `/actuator/jobs`, `/actuator/shadow`, and the actuator task
+UI stay off the public surface. `/actuator/shadow` (see the [shadow deploys
+guide](staged-deploys.md#shadow-differential-deploys)) is the most sensitive of
+these: it publishes redacted excerpts of real production responses.
 
 ```toml
 # autumn.toml — metrics on, sensitive surfaces off (the safe production shape)
 [actuator]
-sensitive  = false   # env/configprops/loggers/tasks/jobs NOT mounted
+sensitive  = false   # env/configprops/loggers/tasks/jobs/shadow NOT mounted
 prometheus = true    # /actuator/prometheus still scrapeable
 ```
 

--- a/docs/guide/staged-deploys.md
+++ b/docs/guide/staged-deploys.md
@@ -475,15 +475,23 @@ prove the build holds up under real load.
 ```toml
 # autumn.toml
 [shadow]
-enabled        = true
-target         = "http://127.0.0.1:9091"  # the candidate build you started
-sample_rate    = 0.05                     # 5 % of eligible traffic
-routes         = ["/api/*"]               # empty = every eligible route
-timeout_ms     = 2000                     # per shadow request
-max_in_flight  = 8                        # concurrent mirrors; excess is dropped
-max_body_bytes = 262144                   # larger responses are not compared
-max_records    = 50                       # divergences kept for the actuator
+enabled          = true
+target           = "http://127.0.0.1:9091"  # the candidate build you started
+sample_rate      = 0.05    # fraction of ELIGIBLE traffic. Default: 1.0 — i.e.
+                           # every eligible request. Start low.
+routes           = ["/api/*"]  # empty (default) = every eligible route
+timeout_ms       = 2000    # deadline per shadow request, and per mirrored
+                           # primary response
+max_in_flight    = 8       # concurrent mirrors; excess is dropped, never queued
+max_body_bytes   = 262144  # larger responses are not compared, on either side
+max_records      = 50      # divergences kept for the actuator
+max_sample_bytes = 2048    # per recorded JSON sample, before truncation
 ```
+
+Mirroring requires the `http-client` cargo feature (on by default). A build
+without it logs a warning at startup and mirrors nothing; `/actuator/shadow`
+then reports the configured target with `enabled: false`, so the state is
+visible rather than silent.
 
 Every key has an environment override (`AUTUMN_SHADOW__ENABLED`,
 `AUTUMN_SHADOW__TARGET`, `AUTUMN_SHADOW__SAMPLE_RATE`, …), so a shadow run can
@@ -514,6 +522,24 @@ container, another port, another machine) and point `target` at it.
   refuse writes.
 - **Actuator and probe paths are never mirrored**, so load-balancer health
   checks do not drown the candidate.
+- **Requests the live build refuses are not mirrored.** A response of `429` or
+  `503` — the statuses maintenance mode, load shedding, the request deadline,
+  and the rate limiter produce — skips the mirror entirely (counted as
+  `refused`). The candidate is under none of those pressures, so it would answer
+  normally and every request through a planned maintenance window would look
+  like a status-class divergence. The trade is that a genuine handler-produced
+  `429`/`503` divergence is not reported either.
+- **A mirror cannot outlive its deadline.** `timeout_ms` bounds the shadow
+  request *and* the wait for the mirrored primary response, so a client that
+  stops reading — or a long-lived `text/event-stream` — cannot pin an
+  `max_in_flight` slot indefinitely. Those are counted as `incomplete`.
+- **Credentials never reach a proxy.** The mirroring client disables proxy
+  autodetection, so `HTTP_PROXY`/`HTTPS_PROXY` in the environment cannot divert
+  a mirrored request (carrying the end user's cookie) to a third party.
+- **Forwarding headers are not replayed.** `X-Forwarded-*`, `Forwarded`, and
+  `X-Real-IP` are stripped: this layer runs before the primary's trusted-proxy
+  policy, so forwarding them would hand the candidate a client-spoofed value
+  arriving from an address it *does* trust.
 
 ### What is compared
 
@@ -546,19 +572,33 @@ $ curl -s localhost:3000/actuator/shadow | jq
     {
       "method": "GET",
       "target": "/api/orders?page=2",
-      "route": "/api/*",
+      "route": "/api/orders",
       "occurrences": 9,
+      "first_observed_at_ms": 1756300000000,
+      "last_observed_at_ms": 1756300310000,
       "kind": "body",
       "primary_status": 200,
       "shadow_status": 200,
+      "primary_body_kind": "json", "shadow_body_kind": "json",
+      "primary_body_bytes": 118, "shadow_body_bytes": 104,
       "primary_digest": "9f2c…", "shadow_digest": "41ab…",
       "primary_sample": { "id": 7, "total": 42 },
       "shadow_sample": { "id": 7 },
       "fingerprint": "3d91a2f0c4e7b158"
     }
+  ],
+  "comparisons_by_route": [
+    { "route": "/api/orders", "label": "diverged", "count": 9 },
+    { "route": "/api/orders", "label": "match", "count": 4109 }
+  ],
+  "divergences_by_route": [
+    { "route": "/api/orders", "label": "body", "count": 9 }
   ]
 }
 ```
+
+`stats` also carries `skipped_refused` and `primary_incomplete` (see the
+outcomes below).
 
 `/actuator/shadow` is a **sensitive** endpoint (`[actuator] sensitive = true`),
 like `/actuator/tasks` — the samples are excerpts of real production responses.
@@ -573,26 +613,56 @@ record from the ring.
 
 Two labelled metrics carry the same signal into your dashboards:
 
-- `autumn_shadow_comparisons_total{route, outcome}` — `outcome` is `match`,
-  `diverged`, `error`, `timeout`, `skipped`, or `dropped`.
-- `autumn_shadow_divergences_total{route, kind}` — the series to alert on; it
-  stays at zero on a clean run.
+- `autumn_shadow_comparisons_total{version, route, outcome}` — `outcome` is
+  `match`, `diverged`, `error` (the candidate could not be reached), `timeout`,
+  `skipped` (a body over the capture budget), `dropped` (the in-flight ceiling
+  was full), `refused` (the live build answered `429`/`503`), or `incomplete`
+  (the client never finished reading the primary response).
+- `autumn_shadow_divergences_total{version, route, kind}` — the series to alert
+  on; it stays at zero on a clean run.
 
-The `route` label is the **configured pattern** the request matched (`"/api/*"`),
-or `"*"` when no `routes` allowlist is set — never the raw URL, so an unbounded
-URL space cannot become unbounded metric cardinality.
+Both are **built-in families**, rendered by `/actuator/prometheus` alongside
+`autumn_http_*`; they carry the same `version` label the canary cohort metrics
+do, so a shadow run and a canary can be read on one dashboard.
+
+The `route` label is axum's **matched route template** (`"/api/orders/{id}"`),
+falling back to the configured pattern and then to `"*"`. Never the raw URL: an
+unbounded URL space must not become unbounded metric cardinality. Past 200
+distinct routes, further ones fold into `__other__`.
 
 ### PII in recorded samples
 
 Recorded samples pass through the same `[log] filter_parameters` /
 `[log] unfilter_parameters` redaction the access log, error pages, and failure
-capsules use, and encrypted column names are always filtered. Sensitive query
-parameters in the recorded request target are redacted the same way.
+capsules use, and encrypted column names are always filtered. The recorded
+request target is redacted the same way, matching on the percent-decoded
+parameter name and on each of its structural segments — so `?token=`,
+`?%74oken=`, `?auth[access_token]=` and `?filter.password=` are all caught.
 
 Only **JSON** bodies are sampled. A JSON body has named keys the filter can
 reason about; an HTML or binary body does not, so for those Autumn records the
-digest, the byte length, and the content type — enough to prove the builds
-disagree, without an excerpt no redaction rule could vet.
+digest, the byte length, and how the body was normalized — enough to prove the
+builds disagree, without an excerpt no redaction rule could vet.
+
+**Know what that redaction is and is not.** It is a *key-name allowlist*: a JSON
+field is replaced only when its name matches `[log] filter_parameters` (whose
+defaults are `password`, `token`, `secret`, `api_key`, `ssn`, `credit_card`, and
+a handful more). Every other field of the response body is recorded verbatim —
+`email`, `phone`, `address`, `balance`, `csrf_token`, a top-level JSON string.
+This is a category of data no other Autumn surface writes down, so before
+enabling `[shadow]` on a route that returns personal data:
+
+- scope `routes` to endpoints whose bodies you are willing to see in
+  `/actuator/shadow`,
+- extend `[log] filter_parameters` with the field names those endpoints return,
+- and keep `[actuator] sensitive = false` anywhere the endpoint could be reached
+  by someone who should not read production responses.
+
+The recorded request target and the samples are published **only** on the
+sensitive actuator endpoint. The `WARN` log line for a divergence deliberately
+carries just the route, the kind, and the fingerprint — never the target or a
+sample — and is emitted once per distinct divergence rather than once per
+occurrence.
 
 ### ⚠️ Before you turn this on
 
@@ -602,9 +672,16 @@ disagree, without an excerpt no redaction rule could vet.
   the shadow target as exactly as trusted as production.
 - **The candidate's own side effects are real.** Autumn guarantees the mirror
   does not touch *primary* state. It cannot stop the candidate from writing to a
-  database you pointed it at. Run the candidate against a scratch database, a
-  read-only replica, or with writes disabled — the `X-Autumn-Shadow: 1` header
-  on every mirrored request is the hook for that.
+  database you pointed it at. Contain it by **environment** — a scratch
+  database, a read-only replica, a build with writes disabled.
+- **`X-Autumn-Shadow` is a convenience signal, not a security boundary.** It is
+  an ordinary request header, so anything that can reach your app can set it.
+  Using it inside the candidate to skip writes is fine *as a second line*; using
+  it as the only thing standing between mirrored traffic and your production
+  database is not, and on the primary it would be a client-controlled kill
+  switch for whatever you gated on it. (A client that sets it on production
+  traffic also opts that request out of being mirrored, which is the header's
+  loop guard doing its job.)
 - **Mirroring is extra load** on the candidate and on this process's outbound
   connections. Start at a low `sample_rate` and a narrow `routes` allowlist.
 - **Expect benign divergences.** Timestamps, generated ids, and CSRF tokens in a

--- a/docs/guide/staged-deploys.md
+++ b/docs/guide/staged-deploys.md
@@ -538,12 +538,15 @@ container, another port, another machine) and point `target` at it.
 - **Credentials never reach a proxy.** The mirroring client disables proxy
   autodetection, so `HTTP_PROXY`/`HTTPS_PROXY` in the environment cannot divert
   a mirrored request (carrying the end user's cookie) to a third party.
-- **`Accept-Encoding` travels, and the candidate's answer is decoded.** A
-  handler can legitimately vary its body on that header, so stripping it would
-  have the two stacks answering different logical requests. The candidate's
-  response is `gzip`/`deflate`/`br`-decoded on arrival — under the same size
-  budget as the wire read, so a decompression bomb is refused rather than
-  buffered.
+- **`Accept-Encoding` travels, and both bodies are decoded.** A handler can
+  legitimately vary its body on that header, so stripping it would have the two
+  stacks answering different logical requests. A handler can also serve a
+  *precompressed* representation, in which case the live build's captured bytes
+  are encoded too — so `gzip`/`deflate`/`br` decoding is applied to **both**
+  sides before comparison, under the same size budget as the wire read. A
+  decompression bomb is refused rather than buffered, and an encoding difference
+  between the two builds is a header difference, which the contract does not
+  compare.
 - **Forwarding headers are not replayed.** `X-Forwarded-*`, `Forwarded`, and
   `X-Real-IP` are stripped: this layer runs before the primary's trusted-proxy
   policy, so forwarding them would hand the candidate a client-spoofed value

--- a/docs/guide/staged-deploys.md
+++ b/docs/guide/staged-deploys.md
@@ -556,7 +556,8 @@ container, another port, another machine) and point `target` at it.
 - **Forwarding headers are not replayed.** `X-Forwarded-*`, `Forwarded`, and
   `X-Real-IP` are stripped: this layer runs before the primary's trusted-proxy
   policy, so forwarding them would hand the candidate a client-spoofed value
-  arriving from an address it *does* trust.
+  arriving from an address it *does* trust. What is sent instead is the
+  **validated** identity — see the configuration note below.
 - **`Host` is preserved.** The candidate is *dialed* at `target`, but it sees
   the authority the live build accepted. Those are separate things, and only the
   address comes from `target`: a candidate that clones your
@@ -569,6 +570,34 @@ container, another port, another machine) and point `target` at it.
   the static-first middleware answers matching `GET`/`HEAD` requests before the
   dynamic router runs; the mirror sits outside it, so a pre-rendered page the
   candidate generates differently is still compared.
+
+### One thing you must configure on the candidate
+
+Autumn sends the candidate the client identity its own trusted-proxy policy
+resolved — `X-Forwarded-For` and `X-Forwarded-Proto` synthesised from the
+validated values, never the client's raw claims. **The candidate only honours
+them if it trusts the mirroring process as a proxy.**
+
+`ProxyResolver` reads forwarding headers only when the *immediate peer* is
+trusted, so a candidate that clones production's `[security.trusted_proxies]` —
+which lists your load balancer, not the app host — will ignore them and resolve
+the mirror itself as the client. Handlers then see a loopback address over
+`http`, and per-IP rate limiting buckets every mirrored request together, which
+answers `429` and shows up as a divergence on every route.
+
+Add the mirroring replica's address to the **candidate's** trusted proxies:
+
+```toml
+# autumn.toml on the CANDIDATE build
+[security.trusted_proxies]
+# ...your production ranges, plus the host the mirror dials from:
+ranges = ["10.0.0.0/8", "127.0.0.1/32"]
+```
+
+If you would rather not widen that trust, leave it — the mirror still works,
+and the candidate simply resolves the mirroring process as the client. Routes
+that read `ClientAddr`/`ClientScheme`, and candidate-side per-IP rate limits,
+are the ones that will then disagree.
 
 ### What is compared
 

--- a/docs/guide/staged-deploys.md
+++ b/docs/guide/staged-deploys.md
@@ -11,6 +11,7 @@ mode fit together to give you a safe rollout in each case.
 | Rolling | Standard incremental rollout | Full — probes + drain handle it automatically |
 | Blue/green | Instant cutover with easy rollback | Full — probe drain + LB switch |
 | Canary | Gradual traffic shift with automated promotion | Framework primitives — version-labelled metrics, a canary-route extractor, and a controller-driven rollback signal (see [Canary deploys](#canary-deploys)) |
+| Shadow / differential | Proving the candidate answers identically before cutover | Full — in-process traffic mirroring, response differ, and `/actuator/shadow` (see [Shadow deploys](#shadow-differential-deploys)) |
 | Rolling across your own VPS fleet | Several app servers you own, behind your own load balancer, with no orchestrator | Full — `autumn deploy up` with `[deploy] hosts` rolls the hosts one at a time (per-host blue/green, migrations exactly once, halt-and-roll-back on failure); see the [fleet deploys guide](fleet-deploys.md) |
 
 ---
@@ -433,6 +434,186 @@ the controller triggers.
 
 ---
 
+## Shadow (differential) deploys
+
+Every strategy above decides go/no-go from **aggregate cohort metrics** — error
+rate, p99 — after routing **real** traffic to the new build. That catches a
+build that falls over. It does not catch the build that returns `200 OK` with a
+dropped JSON field, a reordered list, or an off-by-one total, because nothing
+ever compares two responses to the same request.
+
+Shadow mirroring does exactly that. Autumn samples live `GET`/`HEAD` traffic,
+replays each sampled request against a candidate build you run alongside
+production, and diffs the two responses. The candidate's output is consumed by
+the differ and nothing else.
+
+```text
+                       ┌──────────────────┐
+  client ──request──▶  │  live build      │ ──response──▶ client
+                       └────────┬─────────┘        │
+                                │ (copy)           │ (tee)
+                       ┌────────▼─────────┐   ┌────▼─────┐
+                       │ candidate build  │──▶│  differ  │──▶ /actuator/shadow
+                       └──────────────────┘   └──────────┘        + metrics
+```
+
+### How it differs from canary
+
+|  | Canary | Shadow |
+|---|---|---|
+| Does the new build serve real users? | **Yes** — a slice of live traffic | **No** — not one byte reaches a client |
+| What is the signal? | Cohort metrics (error rate, p99) over a population | A per-request diff: *did these two builds answer the same?* |
+| Catches a subtly-wrong `200`? | No — it is a `200` in both cohorts | **Yes** — that is the whole point |
+| Blast radius of a bad candidate | Real users see it | None on the response path; the candidate's own side effects are yours to contain (see the warning below) |
+| Needs a traffic split? | Yes, at the load balancer | No — the mirror is in-process |
+
+The two compose. Run a shadow to prove behaviour equivalence, *then* canary to
+prove the build holds up under real load.
+
+### Turning it on
+
+```toml
+# autumn.toml
+[shadow]
+enabled        = true
+target         = "http://127.0.0.1:9091"  # the candidate build you started
+sample_rate    = 0.05                     # 5 % of eligible traffic
+routes         = ["/api/*"]               # empty = every eligible route
+timeout_ms     = 2000                     # per shadow request
+max_in_flight  = 8                        # concurrent mirrors; excess is dropped
+max_body_bytes = 262144                   # larger responses are not compared
+max_records    = 50                       # divergences kept for the actuator
+```
+
+Every key has an environment override (`AUTUMN_SHADOW__ENABLED`,
+`AUTUMN_SHADOW__TARGET`, `AUTUMN_SHADOW__SAMPLE_RATE`, …), so a shadow run can
+be switched on for one replica without redeploying the config.
+
+Autumn does not build, start, or orchestrate the candidate — you run it (another
+container, another port, another machine) and point `target` at it.
+
+### What is guaranteed
+
+- **The live request never waits on the mirror.** The shadow request is
+  dispatched on a detached task before the primary handler finishes, and the
+  primary response body is *teed* — frames reach the client as they are
+  produced, with a copy accumulating on the side. A slow, erroring, or
+  unreachable candidate resolves to a counter and nothing else.
+- **Only idempotent methods are mirrored.** `GET` and `HEAD`, and the set is not
+  configurable. Mirroring a `POST` would let the candidate's writes land for
+  real; that needs effect virtualization, which is a follow-up.
+- **Mirrored requests never touch primary state.** The mirror path performs no
+  database, cache, mail, or job work of its own — it copies request bytes and
+  compares response bytes.
+- **The candidate's response never reaches a user.** It is read into a plain
+  struct inside the detached task and dropped there; it is never a `Response`.
+- **Mirroring cannot recurse.** Every mirrored request carries
+  `X-Autumn-Shadow: 1`, and a request carrying that header is never mirrored
+  again — so pointing a shadow target at the app itself costs one extra request,
+  not an exponential storm. Your candidate build can read the same header to
+  refuse writes.
+- **Actuator and probe paths are never mirrored**, so load-balancer health
+  checks do not drown the candidate.
+
+### What is compared
+
+Two things, and deliberately only two:
+
+1. **Status class.** `2xx` vs `5xx` diverges. `200` vs `201` does not.
+2. **Normalized body.** JSON is parsed and object keys sorted, so two builds
+   serialising the same map in a different order agree. **Array order is
+   preserved** — a reordered list *is* a divergence, because that is exactly the
+   class of regression this exists to catch. Text bodies have `\r\n` folded to
+   `\n` and outer whitespace trimmed. Anything else is compared byte-for-byte.
+
+Headers, latency, and fuzzy JSON tolerance are **not** compared. A response
+whose body is larger than `max_body_bytes` is not compared at all (counted as
+`skipped_oversize`) rather than partially buffered.
+
+### Reading the results
+
+```console
+$ curl -s localhost:3000/actuator/shadow | jq
+{
+  "enabled": true,
+  "target": "http://127.0.0.1:9091",
+  "stats": {
+    "mirrored": 4120, "compared": 4118, "matched": 4109, "diverged": 9,
+    "shadow_errors": 2, "shadow_timeouts": 0,
+    "dropped_at_capacity": 0, "skipped_oversize": 0
+  },
+  "divergences": [
+    {
+      "method": "GET",
+      "target": "/api/orders?page=2",
+      "route": "/api/*",
+      "occurrences": 9,
+      "kind": "body",
+      "primary_status": 200,
+      "shadow_status": 200,
+      "primary_digest": "9f2c…", "shadow_digest": "41ab…",
+      "primary_sample": { "id": 7, "total": 42 },
+      "shadow_sample": { "id": 7 },
+      "fingerprint": "3d91a2f0c4e7b158"
+    }
+  ]
+}
+```
+
+`/actuator/shadow` is a **sensitive** endpoint (`[actuator] sensitive = true`),
+like `/actuator/tasks` — the samples are excerpts of real production responses.
+A replica with mirroring off answers `{"enabled": false, …}` rather than `404`,
+so you can tell "off here" from "not in this build".
+
+Identical divergences collapse onto one record by `fingerprint`, a
+content-addressed id derived only from the two responses. The same captured pair
+always produces the same fingerprint, so a divergence is reproducible and
+quotable in a bug report, and one loud regression cannot evict every other
+record from the ring.
+
+Two labelled metrics carry the same signal into your dashboards:
+
+- `autumn_shadow_comparisons_total{route, outcome}` — `outcome` is `match`,
+  `diverged`, `error`, `timeout`, `skipped`, or `dropped`.
+- `autumn_shadow_divergences_total{route, kind}` — the series to alert on; it
+  stays at zero on a clean run.
+
+The `route` label is the **configured pattern** the request matched (`"/api/*"`),
+or `"*"` when no `routes` allowlist is set — never the raw URL, so an unbounded
+URL space cannot become unbounded metric cardinality.
+
+### PII in recorded samples
+
+Recorded samples pass through the same `[log] filter_parameters` /
+`[log] unfilter_parameters` redaction the access log, error pages, and failure
+capsules use, and encrypted column names are always filtered. Sensitive query
+parameters in the recorded request target are redacted the same way.
+
+Only **JSON** bodies are sampled. A JSON body has named keys the filter can
+reason about; an HTML or binary body does not, so for those Autumn records the
+digest, the byte length, and the content type — enough to prove the builds
+disagree, without an excerpt no redaction rule could vet.
+
+### ⚠️ Before you turn this on
+
+- **The candidate receives live credentials.** Cookies and `Authorization`
+  headers are forwarded, because a candidate that cannot authenticate answers
+  every protected route with a `401` and the diff degenerates into noise. Treat
+  the shadow target as exactly as trusted as production.
+- **The candidate's own side effects are real.** Autumn guarantees the mirror
+  does not touch *primary* state. It cannot stop the candidate from writing to a
+  database you pointed it at. Run the candidate against a scratch database, a
+  read-only replica, or with writes disabled — the `X-Autumn-Shadow: 1` header
+  on every mirrored request is the hook for that.
+- **Mirroring is extra load** on the candidate and on this process's outbound
+  connections. Start at a low `sample_rate` and a narrow `routes` allowlist.
+- **Expect benign divergences.** Timestamps, generated ids, and CSRF tokens in a
+  response body differ between two builds by construction. This slice has no
+  fuzzy-tolerance knob (deliberately); scope `routes` to the endpoints whose
+  bodies are deterministic.
+
+---
+
 ## Choosing a strategy
 
 | Situation | Recommended strategy |
@@ -442,6 +623,7 @@ the controller triggers.
 | High-risk release requiring fast rollback | Blue/green |
 | Incident response — stop traffic immediately | [Maintenance mode](maintenance-mode.md) |
 | Gradual rollout with automated promotion | [Canary](#canary-deploys) — platform traffic weights gated on Autumn's version-labelled metrics, with `autumn canary rollback` for a clean drain |
+| Prove a build is behaviour-equivalent before it serves anyone | [Shadow](#shadow-differential-deploys) — mirror real `GET`/`HEAD` traffic to a candidate and diff responses request-for-request |
 | Several VPS hosts you own, no orchestrator | [`autumn deploy up` with `[deploy] hosts`](fleet-deploys.md) — serial rolling deploy driven by the CLI, per-host blue/green, one migration per fleet |
 | A whole fleet must pause writes at once | [`autumn deploy maintenance on`](fleet-deploys.md#runbook-a-fleet-wide-maintenance-window) — note it gates traffic, it does not drain hosts from the load balancer |
 
@@ -456,5 +638,8 @@ the controller triggers.
 - **Monitor drains**: the `autumn_shutdown_aborted_requests_total` metric
   increments when a request is abandoned during shutdown. Alert on it to catch
   an undersized `shutdown_timeout_secs`.
+- **Prove equivalence, not just health**: a [shadow run](#shadow-differential-deploys)
+  answers "does the candidate return the same bytes?" — the question cohort
+  metrics structurally cannot.
 - **Full cloud-native setup**: Kubernetes readiness probes, OTLP tracing, and
   structured logging are covered in the [Cloud-Native Guide](cloud-native.md).

--- a/docs/guide/staged-deploys.md
+++ b/docs/guide/staged-deploys.md
@@ -544,7 +544,10 @@ container, another port, another machine) and point `target` at it.
   the authority the live build accepted. Those are separate things, and only the
   address comes from `target`: a candidate that clones your
   `[security.trusted_hosts]` would otherwise reject every mirror with a `400`,
-  and a subdomain-keyed multi-tenant app would resolve the wrong tenant.
+  and a subdomain-keyed multi-tenant app would resolve the wrong tenant. Behind
+  a trusted proxy it is the **resolved** authority that travels — the one your
+  `[security.trusted_proxies]` policy accepted — not the internal address in the
+  raw `Host` header, and not the unvalidated `X-Forwarded-Host` itself.
 - **Pages served from the static cache are mirrored too.** In an SSG/ISG build
   the static-first middleware answers matching `GET`/`HEAD` requests before the
   dynamic router runs; the mirror sits outside it, so a pre-rendered page the

--- a/docs/guide/staged-deploys.md
+++ b/docs/guide/staged-deploys.md
@@ -558,8 +558,14 @@ Two things, and deliberately only two:
 2. **Normalized body.** JSON is parsed and object keys sorted, so two builds
    serialising the same map in a different order agree. **Array order is
    preserved** — a reordered list *is* a divergence, because that is exactly the
-   class of regression this exists to catch. Text bodies have `\r\n` folded to
-   `\n` and outer whitespace trimmed. Anything else is compared byte-for-byte.
+   class of regression this exists to catch. Any other UTF-8 body has `\r\n`
+   folded to `\n` and outer whitespace trimmed; anything that is not valid UTF-8
+   is compared byte-for-byte.
+
+   Which of those applies is decided by the **bytes**, never by `Content-Type`.
+   Headers are outside the contract, so two builds returning an identical body
+   must not diverge merely because one of them labelled it and the other did
+   not.
 
 Headers, latency, and fuzzy JSON tolerance are **not** compared. A response
 whose body is larger than `max_body_bytes` is not compared at all (counted as

--- a/docs/guide/staged-deploys.md
+++ b/docs/guide/staged-deploys.md
@@ -531,10 +531,14 @@ container, another port, another machine) and point `target` at it.
   normally and every request through a planned maintenance window would look
   like a status-class divergence. The trade is that a genuine handler-produced
   `429`/`503` divergence is not reported either.
-- **A mirror cannot outlive its deadline.** `timeout_ms` bounds the shadow
-  request *and* the wait for the mirrored primary response, so a client that
-  stops reading — or a long-lived `text/event-stream` — cannot pin an
-  `max_in_flight` slot indefinitely. Those are counted as `incomplete`.
+- **A mirror's waiting is bounded.** One deadline, stamped at dispatch, covers
+  both the shadow request and the wait for the mirrored primary response, so a
+  client that stops reading — or a long-lived `text/event-stream` — cannot pin
+  an `max_in_flight` slot indefinitely. Those are counted as `incomplete`.
+  (Comparing the two responses once both are in hand is bounded CPU work on
+  bodies already capped by `max_body_bytes`, but it is not itself covered by
+  that deadline — see
+  [#2333](https://github.com/autumn-foundation/autumn/issues/2333).)
 - **Credentials never reach a proxy.** The mirroring client disables proxy
   autodetection, so `HTTP_PROXY`/`HTTPS_PROXY` in the environment cannot divert
   a mirrored request (carrying the end user's cookie) to a third party.

--- a/docs/guide/staged-deploys.md
+++ b/docs/guide/staged-deploys.md
@@ -521,7 +521,9 @@ container, another port, another machine) and point `target` at it.
   not an exponential storm. Your candidate build can read the same header to
   refuse writes.
 - **Actuator and probe paths are never mirrored**, so load-balancer health
-  checks do not drown the candidate.
+  checks do not drown the candidate. The exemption is derived from the actuator's
+  own mounted paths, so it holds for any `[actuator] prefix` — including `"/"`,
+  where the endpoints sit at the root.
 - **Requests the live build refuses are not mirrored.** A response of `429` or
   `503` — the statuses maintenance mode, load shedding, the request deadline,
   and the rate limiter produce — skips the mirror entirely (counted as
@@ -536,6 +538,12 @@ container, another port, another machine) and point `target` at it.
 - **Credentials never reach a proxy.** The mirroring client disables proxy
   autodetection, so `HTTP_PROXY`/`HTTPS_PROXY` in the environment cannot divert
   a mirrored request (carrying the end user's cookie) to a third party.
+- **`Accept-Encoding` travels, and the candidate's answer is decoded.** A
+  handler can legitimately vary its body on that header, so stripping it would
+  have the two stacks answering different logical requests. The candidate's
+  response is `gzip`/`deflate`/`br`-decoded on arrival — under the same size
+  budget as the wire read, so a decompression bomb is refused rather than
+  buffered.
 - **Forwarding headers are not replayed.** `X-Forwarded-*`, `Forwarded`, and
   `X-Real-IP` are stripped: this layer runs before the primary's trusted-proxy
   policy, so forwarding them would hand the candidate a client-spoofed value

--- a/docs/guide/staged-deploys.md
+++ b/docs/guide/staged-deploys.md
@@ -657,10 +657,14 @@ request target is redacted the same way, matching on the percent-decoded
 parameter name and on each of its structural segments — so `?token=`,
 `?%74oken=`, `?auth[access_token]=` and `?filter.password=` are all caught.
 
-Only **JSON** bodies are sampled. A JSON body has named keys the filter can
-reason about; an HTML or binary body does not, so for those Autumn records the
-digest, the byte length, and how the body was normalized — enough to prove the
-builds disagree, without an excerpt no redaction rule could vet.
+An excerpt is recorded only when **every scalar in the body sits under an
+object key** — because that is exactly when the filter has a name to match
+against. An HTML or binary body has no keys; so does a bare scalar (a
+`text/plain` one-time code parses as a JSON number) and so does an array of
+bare strings. All of those record the digest, the byte length, and how the body
+was normalized — enough to prove the builds disagree, without an excerpt no
+redaction rule could vet. An object, or an array of objects, is sampled
+normally.
 
 **Know what that redaction is and is not.** It is a *key-name allowlist*: a JSON
 field is replaced only when its name matches `[log] filter_parameters` (whose

--- a/docs/guide/staged-deploys.md
+++ b/docs/guide/staged-deploys.md
@@ -657,14 +657,15 @@ request target is redacted the same way, matching on the percent-decoded
 parameter name and on each of its structural segments — so `?token=`,
 `?%74oken=`, `?auth[access_token]=` and `?filter.password=` are all caught.
 
-An excerpt is recorded only when **every scalar in the body sits under an
-object key** — because that is exactly when the filter has a name to match
-against. An HTML or binary body has no keys; so does a bare scalar (a
-`text/plain` one-time code parses as a JSON number) and so does an array of
-bare strings. All of those record the digest, the byte length, and how the body
-was normalized — enough to prove the builds disagree, without an excerpt no
-redaction rule could vet. An object, or an array of objects, is sampled
-normally.
+An excerpt is recorded only when **every scalar in the body has an object key
+above it** — because the filter replaces a matched key's whole value, so that
+is exactly when naming a key could reach it. `{"tags": ["x"]}` qualifies:
+listing `tags` redacts the array entire. What does not qualify is a value with
+no key anywhere above it — an HTML or binary body, a bare scalar (a
+`text/plain` one-time code parses as a JSON number), or a top-level array of
+strings. Those record the digest, the byte length, and how the body was
+normalized — enough to prove the builds disagree, without an excerpt no
+redaction rule could vet.
 
 **Know what that redaction is and is not.** It is a *key-name allowlist*: a JSON
 field is replaced only when its name matches `[log] filter_parameters` (whose

--- a/docs/guide/staged-deploys.md
+++ b/docs/guide/staged-deploys.md
@@ -548,6 +548,8 @@ container, another port, another machine) and point `target` at it.
   *precompressed* representation, in which case the live build's captured bytes
   are encoded too — so `gzip`/`deflate`/`br` decoding is applied to **both**
   sides before comparison, under the same size budget as the wire read. A
+  stacked `Content-Encoding` (`gzip, br`) unwinds in reverse; an unrecognised
+  coding anywhere leaves the body untouched rather than guessing. A
   decompression bomb is refused rather than buffered, and an encoding difference
   between the two builds is a header difference, which the contract does not
   compare.
@@ -647,10 +649,13 @@ record from the ring.
 Two labelled metrics carry the same signal into your dashboards:
 
 - `autumn_shadow_comparisons_total{version, route, outcome}` — `outcome` is
-  `match`, `diverged`, `error` (the candidate could not be reached), `timeout`,
-  `skipped` (a body over the capture budget), `dropped` (the in-flight ceiling
-  was full), `refused` (the live build answered `429`/`503`), or `incomplete`
-  (the client never finished reading the primary response).
+  `match`, `diverged`, `error` (the candidate could not be reached, or its
+  response could not be decoded), `timeout`, `skipped` (a body over the capture
+  budget), `dropped` (the in-flight ceiling was full), `refused` (the live build
+  answered `429`/`503`), `incomplete` (the client never finished reading the
+  primary response), or `primary_error` (the **live** build's own response could
+  not be decoded — counted apart, so a malformed response of your own never
+  reads as a candidate connectivity problem).
 - `autumn_shadow_divergences_total{version, route, kind}` — the series to alert
   on; it stays at zero on a clean run.
 

--- a/docs/guide/staged-deploys.md
+++ b/docs/guide/staged-deploys.md
@@ -540,6 +540,15 @@ container, another port, another machine) and point `target` at it.
   `X-Real-IP` are stripped: this layer runs before the primary's trusted-proxy
   policy, so forwarding them would hand the candidate a client-spoofed value
   arriving from an address it *does* trust.
+- **`Host` is preserved.** The candidate is *dialed* at `target`, but it sees
+  the authority the live build accepted. Those are separate things, and only the
+  address comes from `target`: a candidate that clones your
+  `[security.trusted_hosts]` would otherwise reject every mirror with a `400`,
+  and a subdomain-keyed multi-tenant app would resolve the wrong tenant.
+- **Pages served from the static cache are mirrored too.** In an SSG/ISG build
+  the static-first middleware answers matching `GET`/`HEAD` requests before the
+  dynamic router runs; the mirror sits outside it, so a pre-rendered page the
+  candidate generates differently is still compared.
 
 ### What is compared
 

--- a/scripts/check-panic-gate.sh
+++ b/scripts/check-panic-gate.sh
@@ -130,6 +130,10 @@ REQUEST_PATH_MODULES=(
   autumn/src/cluster/wire.rs:default
   autumn/src/cluster/transport.rs:default
   autumn/src/cluster/node.rs:default
+  autumn/src/shadow/diff.rs:default
+  autumn/src/shadow/sample.rs:default
+  autumn/src/shadow/transport.rs:default
+  autumn/src/shadow/layer.rs:default
   autumn-search/src/lib.rs:default
 )
 
@@ -138,7 +142,7 @@ REQUEST_PATH_MODULES=(
 # cannot quietly shrink the gate's surface. It tracks the manifest's length, so
 # it moves with every addition too — otherwise a one-entry revert would shrink
 # the manifest back under the floor while the gate still passed.
-MODULE_COUNT_FLOOR=45
+MODULE_COUNT_FLOOR=49
 
 # Gated modules whose feature is KNOWINGLY not enabled by any enforcing CI clippy
 # lane, as `<path>:<feature>`. Their headers are real but unenforced: the deny

--- a/scripts/check-panic-gate.sh
+++ b/scripts/check-panic-gate.sh
@@ -134,6 +134,7 @@ REQUEST_PATH_MODULES=(
   autumn/src/shadow/sample.rs:default
   autumn/src/shadow/transport.rs:default
   autumn/src/shadow/layer.rs:default
+  autumn/src/shadow/registry.rs:default
   autumn-search/src/lib.rs:default
 )
 
@@ -142,7 +143,7 @@ REQUEST_PATH_MODULES=(
 # cannot quietly shrink the gate's surface. It tracks the manifest's length, so
 # it moves with every addition too — otherwise a one-entry revert would shrink
 # the manifest back under the floor while the gate still passed.
-MODULE_COUNT_FLOOR=49
+MODULE_COUNT_FLOOR=50
 
 # Gated modules whose feature is KNOWINGLY not enabled by any enforcing CI clippy
 # lane, as `<path>:<feature>`. Their headers are real but unenforced: the deny

--- a/skills/autumn-web/SKILL.md
+++ b/skills/autumn-web/SKILL.md
@@ -1893,6 +1893,72 @@ The rollback flag file lives at `tmp/autumn-canary-rollback.json`. A controller
 that cannot exec into the replica can write it directly. The flag is sticky
 across restarts — clear it with `autumn canary promote` once traffic has moved.
 
+## Shadow (differential) deploys
+
+Canary decides from **cohort metrics** over traffic the new build really serves.
+Shadow decides from a **per-request diff** and serves nobody: Autumn mirrors
+sampled `GET`/`HEAD` traffic to a candidate build you run alongside production
+and compares the two responses. Use it to catch the subtly-wrong-but-`200`
+regression — a dropped JSON field, a reordered list, an off-by-one total — that
+cohort metrics cannot see. It composes with canary; it does not replace it.
+
+Off by default. Requires the `http-client` feature (on by default).
+
+```toml
+# autumn.toml
+[shadow]
+enabled          = true
+target           = "http://127.0.0.1:9091"  # the candidate build (you run it)
+sample_rate      = 0.05    # of ELIGIBLE traffic. Default 1.0 — start low.
+routes           = ["/api/*"]  # empty (default) = every eligible route
+timeout_ms       = 2000    # bounds the shadow request AND the primary wait
+max_in_flight    = 8       # excess mirrors are dropped, never queued
+max_body_bytes   = 262144  # larger responses are not compared, either side
+max_records      = 50      # divergences kept for the actuator
+max_sample_bytes = 2048    # per recorded JSON sample, before truncation
+```
+
+Every key has an env override (`AUTUMN_SHADOW__ENABLED`,
+`AUTUMN_SHADOW__TARGET`, `AUTUMN_SHADOW__SAMPLE_RATE`, …).
+
+**What it guarantees.** The client never waits on the mirror (detached task; the
+primary body is teed, not buffered) and never receives a candidate byte. Only
+`GET`/`HEAD` are mirrored, and that is a constant, not a config key — replaying
+a `POST` needs effect virtualization, which does not exist yet. Requests the
+live build refuses (`429`/`503`) are not mirrored. Actuator and probe paths are
+never mirrored. Every mirrored request carries `X-Autumn-Shadow: 1`, so
+mirroring cannot recurse.
+
+**What it compares.** Status class (`200` vs `201` is not a divergence; `200` vs
+`500` is) and a normalized body: JSON object key order is normalized away,
+**array order is not**. Headers, latency, and fuzzy JSON tolerance are out of
+scope.
+
+**Reading the results** — `{actuator-prefix}/shadow`, sensitive-gated like
+`/actuator/tasks`:
+
+```bash
+curl -s localhost:3000/actuator/shadow | jq '.stats, .divergences[0]'
+```
+
+Plus two built-in metric families on `/actuator/prometheus`:
+
+```
+autumn_shadow_comparisons_total{version,route,outcome}  # match|diverged|error|
+                                                        # timeout|skipped|dropped|
+                                                        # refused|incomplete
+autumn_shadow_divergences_total{version,route,kind}     # the series to alert on
+```
+
+**Tell the user before they enable it**: the candidate receives live cookies and
+`Authorization` headers (a candidate that cannot authenticate makes every diff
+noise), its own side effects are real so it must be contained by environment
+(scratch database / writes disabled), and recorded samples are redacted by a
+**key-name allowlist** (`[log] filter_parameters`) — not a PII classifier — so
+any other field of a response body is stored verbatim on that actuator endpoint.
+
+See `docs/guide/staged-deploys.md`.
+
 ## CLI
 
 ```bash

--- a/skills/autumn-web/SKILL.md
+++ b/skills/autumn-web/SKILL.md
@@ -1922,7 +1922,9 @@ Every key has an env override (`AUTUMN_SHADOW__ENABLED`,
 `AUTUMN_SHADOW__TARGET`, `AUTUMN_SHADOW__SAMPLE_RATE`, …).
 
 **What it guarantees.** The client never waits on the mirror (detached task; the
-primary body is teed, not buffered) and never receives a candidate byte. Only
+primary body is teed, not buffered) and never receives a candidate byte. The
+candidate is dialed at `target` but sees the `Host` the live build accepted, and
+pages served from an SSG/ISG static cache are mirrored too. Only
 `GET`/`HEAD` are mirrored, and that is a constant, not a config key — replaying
 a `POST` needs effect virtualization, which does not exist yet. Requests the
 live build refuses (`429`/`503`) are not mirrored. Actuator and probe paths are

--- a/skills/autumn-web/SKILL.md
+++ b/skills/autumn-web/SKILL.md
@@ -1995,6 +1995,12 @@ noise), its own side effects are real so it must be contained by environment
 any other *keyed* field of a response body is stored verbatim on that actuator
 endpoint. (Bodies with unkeyed scalars record only a digest.)
 
+**One configuration step is easy to miss**: the candidate honours the forwarded
+client identity only if it trusts the mirroring host as a proxy. Add that host
+to the *candidate's* `[security.trusted_proxies] ranges`, or accept that routes
+reading `ClientAddr`/`ClientScheme` — and candidate-side per-IP rate limits —
+will see the mirror rather than the real client.
+
 See `docs/guide/staged-deploys.md`.
 
 ## CLI

--- a/skills/autumn-web/SKILL.md
+++ b/skills/autumn-web/SKILL.md
@@ -1957,7 +1957,8 @@ autumn_shadow_divergences_total{version,route,kind}     # the series to alert on
 noise), its own side effects are real so it must be contained by environment
 (scratch database / writes disabled), and recorded samples are redacted by a
 **key-name allowlist** (`[log] filter_parameters`) — not a PII classifier — so
-any other field of a response body is stored verbatim on that actuator endpoint.
+any other *keyed* field of a response body is stored verbatim on that actuator
+endpoint. (Bodies with unkeyed scalars record only a digest.)
 
 See `docs/guide/staged-deploys.md`.
 


### PR DESCRIPTION
Closes #1653.

## Why

Rolling, blue/green, and canary all route **real** traffic to the new build and decide go/no-go from aggregate cohort metrics. That catches a build that falls over. It structurally cannot catch the build that returns `200 OK` with a dropped JSON field, a reordered list, or an off-by-one total — because nothing ever compares two responses to the *same* request.

```text
                       ┌──────────────────┐
  client ──request──▶  │  live build      │ ──response──▶ client
                       └────────┬─────────┘        │
                                │ (copy)           │ (tee)
                       ┌────────▼─────────┐   ┌────▼─────┐
                       │ candidate build  │──▶│  differ  │──▶ /actuator/shadow
                       └──────────────────┘   └──────────┘        + metrics
```

## What

A new `[shadow]` section mirrors a sampled slice of `GET`/`HEAD` traffic to an operator-provided candidate build and diffs the two responses on **status class** and a **normalized body**. Object key order is normalized away; array order is not, because a reordered list is exactly the regression this exists to catch. Which normalization applies is decided by the **bytes**, never by `Content-Type` — headers are outside the contract, so a header difference must not reappear as a difference in normalized form.

Divergences surface at `{actuator-prefix}/shadow` (sensitive-gated, like `/actuator/tasks`) and as two built-in metric families, `autumn_shadow_comparisons_total{version,route,outcome}` and `autumn_shadow_divergences_total{version,route,kind}`.

### The one invariant: the live request cannot tell mirroring is on

- The shadow request is dispatched on a **detached task**; the client never waits on the candidate.
- The primary response body is **teed, not buffered** — frames reach the client as they are produced, with a copy accumulating on the side.
- Every failure mode resolves to a counter: transport error, blown deadline, full in-flight ceiling (dropped, never queued), an oversize body on either side, a malformed encoding, and a primary the client never finished reading.
- **One deadline**, stamped at dispatch, bounds both waits — the shadow request and the wait for the teed primary body. (It does not bound the comparison that follows; see [#2333](https://github.com/autumn-foundation/autumn/issues/2333).)
- The candidate&#39;s response is read into a plain struct inside that task and dropped there. It is never a `Response`, so no code path exists on which it could reach a user.
- Only idempotent methods are mirrored, and the allowlist is a **constant, not a config key**.
- Every mirrored request carries `X-Autumn-Shadow: 1`: the recursion guard, and the seam a candidate uses to refuse writes.
- Requests the live build itself refuses (`429`/`503`) are not mirrored.
- The candidate is *dialed* at `target` and is **told** the validated identity the live build accepted — host, client address and scheme from `ResolvedClientIdentity`, never the client&#39;s raw `X-Forwarded-*` claims. Whether it *believes* the forwarded pair is its own `[security.trusted_proxies]` decision, which the guide now spells out as a required operator step.
- `Accept-Encoding` travels, and **both** bodies are decoded before comparison (a handler may serve a precompressed representation on either side), bounded by the same budget as the wire read.
- In an SSG/ISG build the mirror sits **outside the static-first middleware**, so pre-rendered pages are compared rather than silently skipped.
- Actuator and probe paths are exempt via the actuator&#39;s own mounted-path list, so the exemption holds for any `[actuator] prefix` including `&#34;/&#34;`.

`compare` is a pure function of its two inputs — no clock, no randomness, no I/O — so a captured pair always yields a byte-identical record and a stable content-addressed `fingerprint`.

## How it was built

Strict red → green → refactor, component by component. Planning used brainstorming, reverse brainstorming, and six-hats before any code. The acceptance-criteria evidence table is in the first review comment.

## Review history

**Four independent reviews** (security, concurrency/correctness, API design, test coverage) ran against the finished branch, then **eleven Codex rounds**. Every round is answered in a thread; the load-bearing findings:

| | Finding | Fix |
|---|---|---|
| Agents | Slow client could permanently disable mirroring (unbounded wait holding a permit) | `359f8b8` |
| Agents | **Metrics were silently inert** — `crate::metrics::counter` reserves the `autumn_` namespace, so the families recorded nothing | `359f8b8` |
| Agents | `HEAD` mirror recorded nothing and could manufacture divergences | `359f8b8` |
| Agents | Credentials could reach an ambient `HTTP_PROXY`; `X-Forwarded-*` replayed to the candidate | `359f8b8` |
| 1 | Preserve the accepted `Host`; mirror static-cache hits; parse the target | `9da77c0` |
| 2 | Reject query/fragment targets; one shared deadline; normalization independent of `Content-Type` | `b7029d9` |
| 3 | Replay the *resolved* host; recognise scalar JSON without a content type | `9d72211` |
| 4 | Scalar text could be sampled verbatim; replay the full validated identity | `0b3483e`, `4afd994` |
| 5 | Actuator prefix normalization; `Accept-Encoding` semantics | `aead575` |
| 6 | Decode **both** sides; truncated samples exceeded their serialized budget | `e75f0dd` |
| 7 | Decode failure misreported as a size skip; sub-marker sample budgets | `a415779` |
| 8 | An empty body still tried to decode its declared encoding (`HEAD` on a precompressed route) | `e9e00e8` |
| 9 | A *stacked* `Content-Encoding` never unwound; a malformed primary blamed on the candidate | `08487c5` |
| 10 | Repeated `Content-Encoding` **fields** read only the first; the forwarded identity was over-claimed | `c58de73` |
| 11 | Conditional requests replay the primary's validator | deferred → [#2335](https://github.com/autumn-foundation/autumn/issues/2335) |

Two patterns are worth naming, because neither is visible from any single round.

**Rounds 2–10 mostly found that my *previous* fix was incomplete rather than new ground.** The fixes that stuck were structural — deleting `is_textual`, making `normalize_body` read `content_type` nowhere at all, routing both sides of the decode through one shared helper — rather than adjusting a condition at whichever layer I happened to be looking at. Asymmetry between the two sides caused rounds 6, 7 and 9 in a row, and it is the reason round 11 is deferred rather than patched: the tempting three-line fix there (strip the conditional headers) desynchronises the two sides and makes the divergence fire *deterministically*.

**Three findings were defects in the prose, not the code:** the deadline guarantee (round 7), the sampling promise (round 4), and the forwarded identity (round 10). In each case the code did exactly what I wrote it to do and the *claim above it* described the intent instead of the mechanism. No test suite catches that class — a test asserts what the code does — which is a good argument for the review having been worth the rounds.

## Deferred, with issues

- **[#2332](https://github.com/autumn-foundation/autumn/issues/2332)** — a `GET` carrying a request body is replayed without it. Needs request-body teeing, which is the same machinery the mutating-traffic follow-up needs.
- **[#2333](https://github.com/autumn-foundation/autumn/issues/2333)** — post-processing runs outside the mirror deadline while holding a permit. Turns on what `max_in_flight` is meant to bound. The docs no longer claim the deadline covers the comparison.
- **[#2335](https://github.com/autumn-foundation/autumn/issues/2335)** — conditional requests (`If-None-Match`/`If-Modified-Since`/`If-Range`) replay the primary's validator, so a candidate whose validator differs for identical content answers `200` against the primary's `304`. The larger half is the reverse: when both sides revalidate successfully, two empty `304` bodies compare as a **match**, so that traffic is compared vacuously.

## Testing

- **139 new tests**: 122 unit (`cargo test -p autumn-web --lib -- shadow`) and 17 end-to-end against a real candidate server on a loopback port — including the issue&#39;s success metric: a seeded dropped-field regression flagged, **zero** false positives on the unchanged control route (and none under `Accept-Encoding: gzip`), zero mutating requests replayed, byte-identical client output with mirroring on vs off.
- `cargo test -p autumn-web --lib`: 4767 passed. `./scripts/check-docs.sh`: clean. Clippy clean across every shadow file including tests.

`circuit_breaker_integration.rs` is in this diff because its two wall-clock latency assertions failed on the macOS lane and could not distinguish &#34;the breaker is blocking unrelated routes&#34; from &#34;the runner is busy&#34;. They are now relative to a warm baseline measured in the same run — see the [comment](https://github.com/autumn-foundation/autumn/pull/2327#issuecomment-5434874703).

## Notable trade-offs

- **The candidate receives live credentials.** Cookies and `Authorization` are forwarded, because a candidate that cannot authenticate answers every protected route with a `401` and the diff degenerates into noise. The guide states the trust boundary plainly.
- **The candidate needs one config line.** It must list the mirroring host in `[security.trusted_proxies]` or it will ignore the forwarded identity and resolve every mirror as a loopback client. Nothing in this process can make it trust us, so this is documented as a required operator step rather than patched around.
- **Sample redaction is a key-name allowlist**, not a PII classifier. An excerpt is recorded only when every scalar has an object key above it — that is exactly when naming a key could redact it.
- **`429`/`503` divergences are not reported**, the conservative side of the admission-control trade.
- **Conditional traffic is compared as-is** pending #2335, which is the one known source of both false positives and vacuous matches in this slice.
- **The static-first path has no test.** A `dist` manifest fixture is a bigger lift than the one-line layer application it would cover; flagged rather than left implied.

## Out of scope (per the issue)

Effect virtualization for mutating traffic, auto-gating `autumn deploy` / fleet cutover on a clean diff, orchestrating the candidate, and fuzzy/semantic diffing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XZsMMcw6tFB6ZV5SAG3jxr