### PR TITLE
Add Web Push so notifications reach devices when the site is closed (#1392)

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,18 @@
+# Workspace-wide Cargo configuration.
+
+[env]
+# `cargo test` on the `autumn-cli` binary aborts with a stack overflow without
+# this, in the very first test that calls `Cli::try_parse_from`.
+#
+# The cause is not the tests: clap's derive macro expands the whole `Commands`
+# tree — every subcommand, every argument — into a single `augment_args`
+# function, and this CLI has a lot of both. Unoptimized, that one frame is
+# larger than the 2 MiB stack libtest gives a test thread, so building the
+# command tree overflows before any assertion runs. Release builds inline it
+# away and never hit it, which is why only `cargo test` is affected.
+#
+# `[env]` (rather than exporting the variable in CI) keeps the fix with the
+# code: every `cargo test` invocation picks it up — local, CI, and the
+# pre-push gate alike — so the suite cannot pass on one machine and abort on
+# another. Raise it further if the CLI grows enough to overflow 16 MiB again.
+RUST_MIN_STACK = "16777216"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   generated snippet, which is what keeps push opt-in working under the
   production defaults without exempting the push routes from CSRF.
 
+  Because every endpoint is client-chosen, the delivery path is written for a
+  hostile one: a principal's devices are dispatched to concurrently (bounded),
+  so a device that accepts a connection and never answers cannot hold up its
+  live siblings; the transport reads only the status code and discards the
+  response body unread, so a registered endpoint cannot stream unbounded memory
+  into the process; and the generated snippet unsubscribes on sign-out, so a
+  subscription never outlives the session that created it.
+
   Failure posture is deliberate: a `[push] private_key` that is present but
   unusable fails the **boot** rather than leaving push silently dead, and
   sending with no key configured is an error raised before any dispatch, never

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`cargo test` on the workspace no longer aborts with a stack overflow:**
+  clap's derive macro expands the whole `autumn` CLI — every subcommand, every
+  argument — into a single `augment_args` function, and unoptimized that one
+  frame is larger than the 2 MiB stack libtest gives a test thread. The first
+  test to call `Cli::try_parse_from` therefore overflowed and took the process
+  down with `SIGABRT`, stopping the suite before ~5,600 other `autumn-cli`
+  tests ran. Release builds inline the frame away, which is why only `cargo
+  test` was affected. A workspace `.cargo/config.toml` now sets
+  `RUST_MIN_STACK`, so the fix travels with the code instead of living in a CI
+  environment variable — the suite cannot pass on one machine and abort on
+  another.
+
 - **TLS-enabled migrations no longer panic when applied from an app's own
   async `on_startup` hook:** the sync migration/wait-check path bridges to
   Postgres through diesel-async's `AsyncConnectionWrapper` whenever the
@@ -32,6 +44,63 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `multi_thread` tokio runtime, called directly from an async body.
 
 ### Added
+
+- **Web Push — notifications that reach a device with the tab closed
+  (#1392):** Autumn already generated an installable PWA (#1149) and stored an
+  in-app notification feed (#1148), but a notification could only ever arrive
+  while the user already had the app open. The new `autumn_web::push` module
+  closes that loop, and a developer writes **zero** lines of crypto: the
+  framework mints/loads the VAPID key pair, signs the ES256 identity JWT
+  (RFC 8292), performs the ECDH + HKDF + AES-128-GCM payload encryption
+  (RFC 8291), and dispatches to the push service. Configure `[push]
+  private_key`, mount `autumn_web::push::router()` (which `autumn generate pwa`
+  now does for you), and call `push.send(user_id, &PushMessage::new(title,
+  body).url(target))`.
+
+  `autumn generate pwa` now also emits a service worker with `push` and
+  `notificationclick` handlers, a client subscribe snippet wired to the
+  framework's own public-key endpoint, and a `push_subscriptions` migration —
+  all idempotent, `--dry-run`-honoring, and fully reversed by
+  `autumn destroy pwa`.
+
+  Subscription storage is hardened against the fact that an endpoint URL is a
+  *capability*: the subscribe boundary normalizes the endpoint (so one browser
+  can never become several rows), caps subscriptions per principal, and allows
+  an endpoint to move between accounts only when the request presents the
+  stored `p256dh` — which keeps the shared-device case working (the browser
+  returns the same endpoint **and** keys) while refusing a takeover by anyone
+  who merely learned the URL. The outbound transport resolves the endpoint host
+  and refuses any address on the framework's SSRF deny-list, pins the connection
+  to the checked address, and declines redirects, so neither a DNS record
+  pointing at `169.254.169.254` nor a `307` can steer the POST at an internal
+  host.
+
+  Failure posture is deliberate: a `[push] private_key` that is present but
+  unusable fails the **boot** rather than leaving push silently dead, and
+  sending with no key configured is an error raised before any dispatch, never
+  an `Ok` report of zero deliveries. A `404`/`410` from the push service prunes
+  the subscription so a dead endpoint is never re-sent to, while a `5xx` or
+  rate limit leaves it in place — pruning on a transient failure would silently
+  unsubscribe every user during an outage. Because the subscribe endpoint takes
+  a client-supplied URL the framework later POSTs to, it requires `https` and
+  refuses IP-literal and loopback hosts, closing the SSRF shape at the
+  boundary.
+
+  The encryption is pinned to RFC 8291 §5's own published test vector — fed the
+  RFC's inputs it must reproduce the RFC's output byte-for-byte — and the
+  end-to-end test decrypts a dispatched body back with the receiving user
+  agent's private key and verifies the VAPID signature, so what is asserted is
+  what a real browser would receive. Ships `RecordingPushTransport` so
+  applications can assert their own push behaviour the same way.
+
+  Adds **no new crate** to the dependency graph: `p256` was already resolved
+  for `jsonwebtoken`'s ES256 backend, and `aes-gcm`/`hmac`/`sha2`/`base64` were
+  already non-optional dependencies. All additions are additive — a new
+  `[push]` config block, a new `push_subscriptions` table, and new public API;
+  no existing `autumn-web` surface changed. Guide:
+  `docs/guide/web-push.md`. Out of scope by design: native mobile push
+  (APNs/FCM device tokens), notification actions/images/badges, and per-user
+  preferences or quiet hours.
 
 - **`#[query_budget(N)]` — a compile-time, per-route database query budget
   (#1667):** declare a handler's query ceiling and the build fails when any

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,7 +76,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   host.
 
   `[push]` honors the usual environment overrides
-  (`AUTUMN_PUSH__PRIVATE_KEY` and friends), and `subject` is validated at boot
+  (`AUTUMN_PUSH__PRIVATE_KEY` and friends) — with one deliberate divergence: a
+  *blank* private-key override is preserved and refused at boot rather than
+  clearing the setting the way other `AUTUMN_*` overrides do, because the
+  commonest cause is a secret that failed to interpolate, and clearing it would
+  silently disable delivery (and erase a good key from `autumn.toml`). The
+  `subject` is validated at boot
   against what RFC 8292 permits — a bare email address instead of a `mailto:`
   URI otherwise boots cleanly and has every delivery refused remotely. Because
   Autumn's CSRF layer rejects an unaccompanied POST and its cookie is

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   pointing at `169.254.169.254` nor a `307` can steer the POST at an internal
   host.
 
+  `[push]` honors the usual environment overrides
+  (`AUTUMN_PUSH__PRIVATE_KEY` and friends), and `subject` is validated at boot
+  against what RFC 8292 permits — a bare email address instead of a `mailto:`
+  URI otherwise boots cleanly and has every delivery refused remotely. Because
+  Autumn's CSRF layer rejects an unaccompanied POST and its cookie is
+  `HttpOnly`, the public-key response carries the caller's CSRF token for the
+  generated snippet, which is what keeps push opt-in working under the
+  production defaults without exempting the push routes from CSRF.
+
   Failure posture is deliberate: a `[push] private_key` that is present but
   unusable fails the **boot** rather than leaving push silently dead, and
   sending with no key configured is an error raised before any dispatch, never

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -665,6 +665,7 @@ dependencies = [
  "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry_sdk",
+ "p256 0.13.2",
  "percent-encoding",
  "pin-project-lite",
  "postgresql_embedded",

--- a/autumn-cli/src/generate/commentable.rs
+++ b/autumn-cli/src/generate/commentable.rs
@@ -232,7 +232,7 @@ fn comments_table_state(project_root: &Path) -> (bool, bool) {
 /// `UNLOGGED` is a durability setting, not a different kind of object: the
 /// relation is still permanent and still occupies the name, so a later
 /// `CREATE TABLE comments` fails with "already exists" — confirmed against
-/// PostgreSQL, not assumed. Missing it made the scan report no table and emit a
+/// `PostgreSQL`, not assumed. Missing it made the scan report no table and emit a
 /// duplicate migration.
 ///
 /// `TEMPORARY`/`TEMP` is deliberately NOT here, and that is the more
@@ -247,7 +247,7 @@ const CREATE_VERBS: &[&str] = &["create table", "create unlogged table"];
 /// `DROP TABLE [ IF EXISTS ] name [, ...] [ CASCADE | RESTRICT ]` — the LIST is
 /// the point. Requiring `comments` immediately after the verb missed
 /// `DROP TABLE audit_log, comments;`, which really does drop it (confirmed
-/// against PostgreSQL). The replay then kept a table the database no longer
+/// against `PostgreSQL`). The replay then kept a table the database no longer
 /// has, the next scaffold skipped creating it, and every generated helper
 /// queried a missing relation — silently, until the first request.
 fn comments_drops(lowered: &str) -> Vec<usize> {
@@ -559,7 +559,7 @@ fn comments_creations(sql: &str) -> Vec<(usize, &str)> {
 ///
 /// Ordering is why. Diesel keys on the version prefix, and the shared table's
 /// version is `{timestamp}2` while a parent scaffolded in the same second is
-/// `{timestamp}` — so the parent migration runs FIRST, and PostgreSQL refuses
+/// `{timestamp}` — so the parent migration runs FIRST, and `PostgreSQL` refuses
 /// `CREATE TRIGGER` when its function does not yet exist. A parent that carries
 /// its own function cannot be ordered wrongly. The body may safely reference
 /// `comments` before that table exists: plpgsql resolves it at execution.
@@ -637,8 +637,8 @@ pub fn parent_cleanup_sql(
 
 /// The `DROP TRIGGER` undoing [`parent_cleanup_sql`].
 ///
-/// Backend-split because the syntax differs: PostgreSQL names the table
-/// (`DROP TRIGGER … ON <table>`), SQLite does not — triggers are global there.
+/// Backend-split because the syntax differs: `PostgreSQL` names the table
+/// (`DROP TRIGGER … ON <table>`), `SQLite` does not — triggers are global there.
 #[must_use]
 pub fn parent_cleanup_down_sql(
     backend: autumn_web::config::DatabaseBackend,
@@ -743,7 +743,7 @@ fn migration_up_sql(project_root: &Path) -> Vec<String> {
 /// comments (commentable_type …)` in a migration's header, which is exactly the
 /// kind of thing a header explaining the shared table would contain — would
 /// otherwise read as the real table and make the generator emit nothing.
-/// Whether the quote at `quote` opens a PostgreSQL escape string (`E'…'`).
+/// Whether the quote at `quote` opens a `PostgreSQL` escape string (`E'…'`).
 ///
 /// Only these honour backslash escapes; an ordinary literal treats `\` as data
 /// under the default `standard_conforming_strings = on`. The `E` must be the
@@ -765,12 +765,12 @@ fn is_escape_string_prefix(sql: &str, quote: usize) -> bool {
 
 /// Length of the `$tag$` opening a dollar-quoted literal, if `text` starts one.
 ///
-/// `$$…$$` and `$tag$…$tag$` are PostgreSQL's quote-free string syntax. The tag
+/// `$$…$$` and `$tag$…$tag$` are `PostgreSQL`'s quote-free string syntax. The tag
 /// is an identifier: letters, digits and underscores, but it may NOT begin with
 /// a digit — `$1abc$x$1abc$` is rejected as "trailing junk after parameter",
 /// which is exactly why `$1` and `$2` placeholders must pass through untouched
 /// rather than being read as the start of a literal. Verified against
-/// PostgreSQL rather than recalled.
+/// `PostgreSQL` rather than recalled.
 fn dollar_tag_len(text: &str) -> Option<usize> {
     let bytes = text.as_bytes();
     if bytes.first() != Some(&b'$') {
@@ -2114,7 +2114,7 @@ mod tests {
         }
     }
 
-    /// PostgreSQL makes `COLUMN` optional in a column rename, so both spellings
+    /// `PostgreSQL` makes `COLUMN` optional in a column rename, so both spellings
     /// have to be read the same way — in both directions.
     #[test]
     fn a_column_rename_is_recognised_with_or_without_the_column_keyword() {
@@ -2165,7 +2165,7 @@ mod tests {
     }
 
     /// Backslash escapes belong to `E'…'` and to nothing else. Both halves
-    /// were checked against a real PostgreSQL.
+    /// were checked against a real `PostgreSQL`.
     #[test]
     fn backslash_escapes_are_honoured_only_in_escape_strings() {
         let tmp = tempfile::tempdir().expect("tempdir");
@@ -2229,7 +2229,7 @@ mod tests {
     }
 
     /// `$tag$…$tag$` is a string, not DDL. Every case here was checked
-    /// against a real PostgreSQL before being encoded.
+    /// against a real `PostgreSQL` before being encoded.
     #[test]
     fn dollar_quoted_literals_are_not_read_as_ddl() {
         let tmp = tempfile::tempdir().expect("tempdir");
@@ -2322,7 +2322,7 @@ mod tests {
     }
 
     /// `UNLOGGED` still occupies the name; `TEMPORARY` does not. Both halves
-    /// were checked against a real PostgreSQL before being encoded here.
+    /// were checked against a real `PostgreSQL` before being encoded here.
     #[test]
     fn an_unlogged_comments_table_counts_and_a_temporary_one_does_not() {
         let tmp = tempfile::tempdir().expect("tempdir");
@@ -2512,7 +2512,7 @@ mod tests {
         assert!(!conflicting_comments_table(empty.path()));
     }
 
-    /// Quoting makes an identifier case-SENSITIVE: PostgreSQL treats
+    /// Quoting makes an identifier case-SENSITIVE: `PostgreSQL` treats
     /// `"Comments"` and `comments` as different relations, so folding the whole
     /// file would report a table the runtime cannot find.
     #[test]

--- a/autumn-cli/src/generate/pwa.rs
+++ b/autumn-cli/src/generate/pwa.rs
@@ -595,6 +595,11 @@ function autumnDecodeVapidKey(base64url) {{
 /// `window.autumnPushSubscribe` / `window.autumnPushUnsubscribe`, plus the
 /// declarative `data-autumn-push-subscribe` wiring.
 fn render_push_entry_points() -> String {
+    format!("{}{}", render_push_subscribe(), render_push_teardown())
+}
+
+/// `window.autumnPushSubscribe` — the opt-in half.
+fn render_push_subscribe() -> String {
     format!(
         r"// Opt the current visitor in to Web Push. Call it from a click handler — it
 // prompts for notification permission, so it needs a user gesture.
@@ -651,7 +656,19 @@ window.autumnPushSubscribe = async function autumnPushSubscribe() {{
 }};
 
 // Undo the above: forget this browser's subscription, server-side and locally.
-window.autumnPushUnsubscribe = async function autumnPushUnsubscribe() {{
+// Drop this browser's subscription SERVER-SIDE, leaving the browser's own
+// subscription intact.
+//
+// This is what sign-out wants, and revoking the browser subscription there
+// would be actively wrong: an origin has ONE `PushSubscription` shared by
+// every tab, so with two accounts open the row belongs to whichever signed in
+// last. A stale tab signing out gets a `204` from the scoped delete whether or
+// not it owned the row — the route is deliberately indistinguishable, so it
+// cannot be used to probe who owns an endpoint — and revoking on the strength
+// of that `204` would invalidate the OTHER account's endpoint. Its next push
+// would `410`, be pruned, and that account would silently stop receiving
+// notifications until it opted in again.
+window.autumnPushForget = async function autumnPushForget() {{
   if (!('serviceWorker' in navigator) || !('PushManager' in window)) {{
     return false;
   }}
@@ -660,20 +677,47 @@ window.autumnPushUnsubscribe = async function autumnPushUnsubscribe() {{
   if (!subscription) {{
     return true;
   }}
-  // Unsubscribe can be the first call of the page, before anything primed the
-  // token; one cheap GET is enough to obtain it.
+  // This can be the first call of the page, before anything primed the token;
+  // one cheap GET is enough to obtain it.
   if (!autumnPushCsrf) {{
     autumnPushCaptureCsrf(
       await fetch('{key_path}', {{ credentials: 'same-origin' }})
     );
   }}
-  await fetch('{unsubscribe_path}', {{
+  const response = await fetch('{unsubscribe_path}', {{
     method: 'POST',
     headers: autumnPushHeaders(),
     credentials: 'same-origin',
     body: JSON.stringify({{ endpoint: subscription.endpoint }}),
   }});
-  return subscription.unsubscribe();
+  return response.ok;
+}};
+
+",
+        key_path = autumn_web::push::VAPID_PUBLIC_KEY_PATH,
+        subscribe_path = autumn_web::push::SUBSCRIBE_PATH,
+        unsubscribe_path = autumn_web::push::UNSUBSCRIBE_PATH,
+    )
+}
+
+/// `window.autumnPushForget` / `window.autumnPushUnsubscribe`, the sign-out
+/// hook, and the declarative `data-autumn-push-subscribe` wiring.
+fn render_push_teardown() -> String {
+    format!(
+        r"// Fully opt this browser out: forget the row server-side AND revoke the
+// browser's subscription.
+//
+// Revoking is correct HERE and only here — the visitor is explicitly asking to
+// stop receiving on this device, so taking the shared subscription down with
+// them is the intent, not a side effect.
+window.autumnPushUnsubscribe = async function autumnPushUnsubscribe() {{
+  if (!('serviceWorker' in navigator) || !('PushManager' in window)) {{
+    return false;
+  }}
+  await window.autumnPushForget();
+  const registration = await navigator.serviceWorker.ready;
+  const subscription = await registration.pushManager.getSubscription();
+  return subscription ? subscription.unsubscribe() : true;
 }};
 
 // Unsubscribe on the way out of a session.
@@ -712,8 +756,11 @@ document.addEventListener('submit', (event) => {{
   // called `preventDefault()`, the user cannot log out at all. Blocking a
   // sign-out is far worse than leaving a subscription behind, which the push
   // service prunes with a `410` soon enough anyway.
-  const cleanup = window.autumnPushUnsubscribe().catch(console.error);
-  const deadline = new Promise((resolve) => setTimeout(resolve, {logout_timeout_ms}));
+  // `autumnPushForget`, NOT `autumnPushUnsubscribe`: see that function's
+  // comment — revoking the shared browser subscription on sign-out would take
+  // another still-signed-in account's notifications down with it.
+  const cleanup = window.autumnPushForget().catch(console.error);
+  const deadline = new Promise((resolve) => setTimeout(resolve, {LOGOUT_UNSUBSCRIBE_TIMEOUT_MS}));
   Promise.race([cleanup, deadline]).then(() => form.submit());
 }});
 
@@ -731,10 +778,6 @@ document.addEventListener('click', (event) => {{
     window.autumnPushSubscribe().catch(console.error);
   }}
 }});",
-        key_path = autumn_web::push::VAPID_PUBLIC_KEY_PATH,
-        subscribe_path = autumn_web::push::SUBSCRIBE_PATH,
-        unsubscribe_path = autumn_web::push::UNSUBSCRIBE_PATH,
-        logout_timeout_ms = LOGOUT_UNSUBSCRIBE_TIMEOUT_MS,
     )
 }
 
@@ -2416,6 +2459,49 @@ async fn main() {
     }
 
     #[test]
+    fn signing_out_forgets_the_row_without_revoking_a_shared_subscription() {
+        // An origin has ONE `PushSubscription` shared by every tab. With two
+        // accounts open, the row belongs to whichever signed in last, and the
+        // scoped unsubscribe route returns `204` either way (deliberately, so
+        // it cannot be used to probe who owns an endpoint). Revoking the
+        // browser subscription on the strength of that `204` would invalidate
+        // the OTHER account's endpoint — its next push `410`s, gets pruned,
+        // and it silently stops receiving until it opts in again.
+        let js = render_push_opt_in();
+        assert!(
+            js.contains("window.autumnPushForget = "),
+            "sign-out needs a server-side-only path:\n{js}"
+        );
+        assert!(
+            js.contains("window.autumnPushForget().catch"),
+            "…and the sign-out hook must use it:\n{js}"
+        );
+
+        // The full opt-out keeps revoking — there the visitor is explicitly
+        // asking to stop receiving on this device.
+        let opt_out = js
+            .split_once("window.autumnPushUnsubscribe = ")
+            .expect("the full opt-out exists")
+            .1;
+        assert!(
+            opt_out.contains("subscription.unsubscribe()"),
+            "an explicit opt-out must still revoke the browser subscription:\n{opt_out}"
+        );
+        // And `autumnPushForget` must NOT revoke.
+        let forget = js
+            .split_once("window.autumnPushForget = ")
+            .expect("forget exists")
+            .1
+            .split_once("window.autumnPushUnsubscribe = ")
+            .expect("…and ends where the opt-out begins")
+            .0;
+        assert!(
+            !forget.contains("unsubscribe()"),
+            "the sign-out path must never revoke the shared subscription:\n{forget}"
+        );
+    }
+
+    #[test]
     fn client_snippet_unsubscribes_when_the_user_signs_out() {
         // A subscription outliving its session is a privacy leak: the row
         // stays bound to the user who logged out, so the app keeps pushing
@@ -2435,8 +2521,8 @@ async fn main() {
             "…plus an opt-in attribute for a differently-shaped sign-out:\n{js}"
         );
         assert!(
-            js.contains("autumnPushUnsubscribe()"),
-            "…and it must actually unsubscribe:\n{js}"
+            js.contains("autumnPushForget()"),
+            "…and it must actually drop the server-side row:\n{js}"
         );
     }
 

--- a/autumn-cli/src/generate/pwa.rs
+++ b/autumn-cli/src/generate/pwa.rs
@@ -452,37 +452,72 @@ fn render_maskable_icon_svg() -> String {
     .to_owned()
 }
 
+/// The `static/pwa-register.js` the generator emits.
+///
+/// Served as a same-origin script to avoid CSP `script-src 'self'` blocking
+/// inline scripts that the default `SecurityHeadersLayer` enforces.
+///
+/// Two halves, split across two functions so each stays readable: unconditional
+/// service-worker registration, and the Web Push opt-in (issue #1392).
 fn render_pwa_register_js() -> String {
-    // Served as a same-origin script to avoid CSP `script-src 'self'` blocking
-    // inline scripts that the default SecurityHeadersLayer enforces.
-    //
-    // Two halves: service-worker registration (unconditional), and Web Push
-    // opt-in (issue #1392), which is deliberately NOT run on load — a
-    // permission prompt fired without a user gesture is the fastest way to get
-    // permanently blocked, and both Chrome and Firefox penalise it. Instead the
-    // subscribe flow is exposed as `window.autumnPushSubscribe()` and wired to
-    // any element carrying `data-autumn-push-subscribe`, so an app gets an
-    // opt-in button with no JavaScript of its own:
-    //
-    //     <button data-autumn-push-subscribe>Enable notifications</button>
-    //
-    // The paths below come from `autumn_web::push::router`'s own constants, so
-    // the snippet and the mounted routes can never drift apart.
     format!(
-        r"if ('serviceWorker' in navigator) {{
-  navigator.serviceWorker
-    .register('/service-worker.js', {{ scope: '/' }})
-    .then(() => {{ document.documentElement.dataset.swRegistered = 'true'; }})
-    .catch(console.error);
-}}
+        "{}\n{}",
+        render_service_worker_registration(),
+        render_push_opt_in()
+    )
+}
 
-// Autumn's CSRF layer rejects an unaccompanied mutating request, so read the
-// token the layout publishes and send it on both POSTs below. Without this the
-// subscribe/unsubscribe calls 403 the moment `[security.csrf] enabled = true`
-// — and the tempting workaround (exempting `/push/`) would strip CSRF from a
-// route whose entire body is client-chosen.
+/// The service-worker registration half of `pwa-register.js`.
+///
+/// Sets `data-sw-registered="true"` on `<html>` once registration resolves;
+/// the generated system test polls for that attribute.
+fn render_service_worker_registration() -> String {
+    r"if ('serviceWorker' in navigator) {
+  navigator.serviceWorker
+    .register('/service-worker.js', { scope: '/' })
+    .then(() => { document.documentElement.dataset.swRegistered = 'true'; })
+    .catch(console.error);
+}
+"
+    .to_owned()
+}
+
+/// The Web Push opt-in half of `pwa-register.js` (issue #1392).
+///
+/// Deliberately NOT run on load: a permission prompt fired without a user
+/// gesture is the fastest way to get permanently blocked, and both Chrome and
+/// Firefox penalise it. The subscribe flow is exposed as
+/// `window.autumnPushSubscribe()` and wired to any element carrying
+/// `data-autumn-push-subscribe`, so an app gets an opt-in button with no
+/// JavaScript of its own:
+///
+/// ```html
+/// <button data-autumn-push-subscribe>Enable notifications</button>
+/// ```
+///
+/// Every path and header name below comes from `autumn_web::push::router`'s own
+/// constants, so the snippet and the mounted routes can never drift apart.
+fn render_push_opt_in() -> String {
+    format!(
+        r"// Autumn's CSRF layer rejects an unaccompanied mutating request, so both POSTs
+// below must carry a token. Without one they 403 the moment
+// `[security.csrf] enabled = true` — which the production smart defaults do —
+// and the tempting workaround (exempting `/push/`) would be far worse than the
+// bug it hides: a forced subscribe would register an ATTACKER's keys under the
+// victim's session, letting them decrypt every notification sent to that user.
+//
+// The CSRF cookie is HttpOnly, so this cannot read it. Two sources, in order:
+// the public-key response (which the subscribe flow fetches anyway, and which
+// carries the token for exactly this purpose), then `<meta name=csrf-token>`
+// for an app that already publishes it the way `autumn generate auth` does.
+let autumnPushCsrf = null;
+
 function autumnPushHeaders() {{
   const headers = {{ 'content-type': 'application/json' }};
+  if (autumnPushCsrf && autumnPushCsrf.token) {{
+    headers[autumnPushCsrf.header || 'X-CSRF-Token'] = autumnPushCsrf.token;
+    return headers;
+  }}
   // Unquoted attribute values (both are valid CSS identifiers) so this stays
   // inside a Rust raw string that cannot contain a double quote.
   const token = document.querySelector('meta[name=csrf-token]');
@@ -491,6 +526,19 @@ function autumnPushHeaders() {{
     headers[(header && header.content) || 'X-CSRF-Token'] = token.content;
   }}
   return headers;
+}}
+
+// Read the CSRF token off a public-key response. Same-origin only: a
+// cross-origin reader cannot see these headers without the app opting in via
+// CORS, which is the property double-submit CSRF already depends on.
+function autumnPushCaptureCsrf(response) {{
+  const token = response.headers.get('{csrf_token_header}');
+  if (token) {{
+    autumnPushCsrf = {{
+      token: token,
+      header: response.headers.get('{csrf_header_name_header}'),
+    }};
+  }}
 }}
 
 // `applicationServerKey` takes a BufferSource, not the base64url string the
@@ -518,12 +566,13 @@ window.autumnPushSubscribe = async function autumnPushSubscribe() {{
   if ((await Notification.requestPermission()) !== 'granted') {{
     return false;
   }}
-  const response = await fetch('{key_path}');
+  const response = await fetch('{key_path}', {{ credentials: 'same-origin' }});
   if (!response.ok) {{
     // 503 means the app has not configured `[push] private_key` yet.
     console.error('web push is not configured on this server');
     return false;
   }}
+  autumnPushCaptureCsrf(response);
   const registration = await navigator.serviceWorker.ready;
   const subscription = await registration.pushManager.subscribe({{
     // Chrome refuses a subscription without this, and it is also the honest
@@ -550,6 +599,13 @@ window.autumnPushUnsubscribe = async function autumnPushUnsubscribe() {{
   const subscription = await registration.pushManager.getSubscription();
   if (!subscription) {{
     return true;
+  }}
+  // Unsubscribe can be the first call of the page, before anything primed the
+  // token; one cheap GET is enough to obtain it.
+  if (!autumnPushCsrf) {{
+    autumnPushCaptureCsrf(
+      await fetch('{key_path}', {{ credentials: 'same-origin' }})
+    );
   }}
   await fetch('{unsubscribe_path}', {{
     method: 'POST',
@@ -578,6 +634,8 @@ document.addEventListener('click', (event) => {{
         key_path = autumn_web::push::router::VAPID_PUBLIC_KEY_PATH,
         subscribe_path = autumn_web::push::router::SUBSCRIBE_PATH,
         unsubscribe_path = autumn_web::push::router::UNSUBSCRIBE_PATH,
+        csrf_token_header = autumn_web::push::router::CSRF_TOKEN_HEADER,
+        csrf_header_name_header = autumn_web::push::router::CSRF_TOKEN_HEADER_NAME_HEADER,
     )
 }
 
@@ -2095,6 +2153,58 @@ async fn main() {
             js.contains("data-autumn-push-subscribe"),
             "…and wire it to a declarative opt-in attribute so an app needs no JS \
              of its own:\n{js}"
+        );
+    }
+
+    #[test]
+    fn client_snippet_sends_a_csrf_token_with_both_push_posts() {
+        // Autumn's production smart defaults turn CSRF on, and the CSRF cookie
+        // is HttpOnly — so without this the generated subscribe/unsubscribe
+        // POSTs 403 and push opt-in is unusable in exactly the environment it
+        // is meant for.
+        let js = render_pwa_register_js();
+        assert!(
+            js.contains(autumn_web::push::router::CSRF_TOKEN_HEADER),
+            "the snippet must read the token the public-key response serves:\n{js}"
+        );
+        assert!(
+            js.contains(autumn_web::push::router::CSRF_TOKEN_HEADER_NAME_HEADER),
+            "…and the configured header name to send it back in:\n{js}"
+        );
+        // Every POST must go through the helper that attaches it — a `fetch`
+        // with a hand-written `content-type` header would silently skip it.
+        let posts = js.matches("method: 'POST'").count();
+        assert_eq!(
+            posts, 2,
+            "expected exactly the subscribe and unsubscribe POSTs"
+        );
+        assert_eq!(
+            js.matches("headers: autumnPushHeaders()").count(),
+            posts,
+            "every push POST must attach the CSRF token:\n{js}"
+        );
+    }
+
+    #[test]
+    fn client_snippet_still_falls_back_to_the_csrf_meta_tag() {
+        // An app that already publishes the token the way `autumn generate
+        // auth` does must keep working.
+        let js = render_pwa_register_js();
+        assert!(
+            js.contains("meta[name=csrf-token]"),
+            "the meta-tag fallback must remain:\n{js}"
+        );
+    }
+
+    #[test]
+    fn client_snippet_sends_credentials_on_every_push_request() {
+        // The server resolves the subscriber from the session; without the
+        // cookie every call is an anonymous 401.
+        let js = render_pwa_register_js();
+        assert_eq!(
+            js.matches("credentials: 'same-origin'").count(),
+            4,
+            "two POSTs plus the two public-key GETs must all carry the session:\n{js}"
         );
     }
 

--- a/autumn-cli/src/generate/pwa.rs
+++ b/autumn-cli/src/generate/pwa.rs
@@ -160,7 +160,7 @@ pub fn plan_pwa(project_root: &Path) -> Result<Plan, GenerateError> {
     // A silently unmounted router is the worst outcome here: the command exits
     // 0, the client snippet ships, and every `fetch` it makes 404s with
     // nothing pointing at the cause. Say so instead.
-    if !updated_main.contains("autumn_web::push::router()") {
+    if !push_router_already_mounted(&updated_main) {
         plan.warn(
             "could not find the app builder in src/main.rs, so the Web Push routes were not \
              mounted. Add this line to your builder chain by hand:\n    \
@@ -498,6 +498,13 @@ fn render_service_worker_registration() -> String {
 /// Every path and header name below comes from `autumn_web::push::router`'s own
 /// constants, so the snippet and the mounted routes can never drift apart.
 fn render_push_opt_in() -> String {
+    format!("{}{}", render_push_helpers(), render_push_entry_points())
+}
+
+/// The shared helpers the push entry points below build on: CSRF header
+/// assembly, the base64url→`Uint8Array` key decode, the rotated-key check, and
+/// the CSRF capture.
+fn render_push_helpers() -> String {
     format!(
         r"// Autumn's CSRF layer rejects an unaccompanied mutating request, so both POSTs
 // below must carry a token. Without one they 403 the moment
@@ -528,6 +535,30 @@ function autumnPushHeaders() {{
   return headers;
 }}
 
+// Whether an existing subscription was created with `key`.
+//
+// `options.applicationServerKey` is the ArrayBuffer the browser recorded at
+// subscribe time; comparing bytes is the only way to notice a server-side key
+// rotation before `subscribe()` throws over it.
+function autumnPushKeyMatches(subscription, key) {{
+  const recorded = subscription.options && subscription.options.applicationServerKey;
+  if (!recorded) {{
+    // The browser does not expose it (older Safari): assume it still matches
+    // rather than churning a working subscription on every page load.
+    return true;
+  }}
+  const bytes = new Uint8Array(recorded);
+  if (bytes.length !== key.length) {{
+    return false;
+  }}
+  for (let i = 0; i < bytes.length; i += 1) {{
+    if (bytes[i] !== key[i]) {{
+      return false;
+    }}
+  }}
+  return true;
+}}
+
 // Read the CSRF token off a public-key response. Same-origin only: a
 // cross-origin reader cannot see these headers without the app opting in via
 // CORS, which is the property double-submit CSRF already depends on.
@@ -555,7 +586,17 @@ function autumnDecodeVapidKey(base64url) {{
   return bytes;
 }}
 
-// Opt the current visitor in to Web Push. Call it from a click handler — it
+",
+        csrf_token_header = autumn_web::push::CSRF_TOKEN_HEADER,
+        csrf_header_name_header = autumn_web::push::CSRF_TOKEN_HEADER_NAME_HEADER,
+    )
+}
+
+/// `window.autumnPushSubscribe` / `window.autumnPushUnsubscribe`, plus the
+/// declarative `data-autumn-push-subscribe` wiring.
+fn render_push_entry_points() -> String {
+    format!(
+        r"// Opt the current visitor in to Web Push. Call it from a click handler — it
 // prompts for notification permission, so it needs a user gesture.
 // Resolves `true` once the subscription has been recorded server-side.
 window.autumnPushSubscribe = async function autumnPushSubscribe() {{
@@ -574,11 +615,30 @@ window.autumnPushSubscribe = async function autumnPushSubscribe() {{
   }}
   autumnPushCaptureCsrf(response);
   const registration = await navigator.serviceWorker.ready;
+  const applicationServerKey = autumnDecodeVapidKey((await response.text()).trim());
+
+  // A browser keeps its subscription across deployments. If this deployment
+  // rotated `[push] private_key`, that stored subscription was created with
+  // the OLD applicationServerKey, and `subscribe()` then REJECTS rather than
+  // replacing it — leaving the user unable to opt back in through the button
+  // without manually clearing site data. Drop a subscription whose key no
+  // longer matches and subscribe afresh.
+  const existing = await registration.pushManager.getSubscription();
+  if (existing && !autumnPushKeyMatches(existing, applicationServerKey)) {{
+    await fetch('{unsubscribe_path}', {{
+      method: 'POST',
+      headers: autumnPushHeaders(),
+      credentials: 'same-origin',
+      body: JSON.stringify({{ endpoint: existing.endpoint }}),
+    }}).catch(() => {{}});
+    await existing.unsubscribe();
+  }}
+
   const subscription = await registration.pushManager.subscribe({{
     // Chrome refuses a subscription without this, and it is also the honest
     // contract: every push this app sends raises a visible notification.
     userVisibleOnly: true,
-    applicationServerKey: autumnDecodeVapidKey((await response.text()).trim()),
+    applicationServerKey,
   }});
   const recorded = await fetch('{subscribe_path}', {{
     method: 'POST',
@@ -629,13 +689,10 @@ document.addEventListener('click', (event) => {{
     event.preventDefault();
     window.autumnPushSubscribe().catch(console.error);
   }}
-}});
-",
-        key_path = autumn_web::push::router::VAPID_PUBLIC_KEY_PATH,
-        subscribe_path = autumn_web::push::router::SUBSCRIBE_PATH,
-        unsubscribe_path = autumn_web::push::router::UNSUBSCRIBE_PATH,
-        csrf_token_header = autumn_web::push::router::CSRF_TOKEN_HEADER,
-        csrf_header_name_header = autumn_web::push::router::CSRF_TOKEN_HEADER_NAME_HEADER,
+}});",
+        key_path = autumn_web::push::VAPID_PUBLIC_KEY_PATH,
+        subscribe_path = autumn_web::push::SUBSCRIBE_PATH,
+        unsubscribe_path = autumn_web::push::UNSUBSCRIBE_PATH,
     )
 }
 
@@ -806,7 +863,7 @@ const PUSH_ROUTER_LINE: &str =
 /// by text, which could land on an earlier occurrence), skips anything inside
 /// a comment, and only accepts an anchor at or after `async fn main`.
 fn inject_push_router(source: &str) -> String {
-    if source.contains("autumn_web::push::router()") {
+    if push_router_already_mounted(source) {
         return source.to_owned();
     }
     let Some(anchor_end) = push_router_anchor(source) else {
@@ -820,21 +877,62 @@ fn inject_push_router(source: &str) -> String {
     result
 }
 
+/// Whether `main.rs` already mounts the push router **in code**.
+///
+/// A plain substring test is not enough: this project's own documentation (and
+/// `autumn_web::push::routes`' doc comment) shows a quick-start snippet
+/// containing that exact call, so a `main.rs` that pasted it into a comment
+/// would look mounted, skip injection, *and* skip the warning the caller emits
+/// off this same predicate — leaving every generated `fetch` to 404 with
+/// nothing pointing at the cause. So the scan ignores comments, exactly as
+/// [`push_router_anchor`] does.
+fn push_router_already_mounted(source: &str) -> bool {
+    for_each_code_line(source, |line, _offset| {
+        line.contains("autumn_web::push::router()").then_some(())
+    })
+    .is_some()
+}
+
 /// Byte offset just past the builder-opening `autumn_web::app()` inside
 /// `main()`, or `None` when there is no unambiguous anchor.
 ///
 /// See [`inject_push_router`]'s "Anchor selection" for why each rule is here.
 fn push_router_anchor(source: &str) -> Option<usize> {
+    let mut seen_main = false;
+    for_each_code_line(source, |line, offset| {
+        if line.trim().contains("async fn main") {
+            seen_main = true;
+        }
+        // Only a line that ENDS with the builder opener is an anchor: a
+        // single-line chain (`autumn_web::app().routes(…).run().await;`) has
+        // no place to insert a `.merge(…)` line, so it is deliberately left
+        // alone and reported instead of being spliced mid-expression.
+        (seen_main && line.trim_end().ends_with("autumn_web::app()"))
+            .then(|| offset + line.trim_end().len())
+    })
+}
+
+/// Walk `source`'s lines that are **code**, skipping comments, and return the
+/// first non-`None` result of `f`.
+///
+/// `f` receives the raw line and its byte offset in `source`. The offset is
+/// tracked as the walk proceeds rather than recovered afterwards with
+/// `source.find(line)`, which would re-locate an identical earlier line and
+/// splice at the wrong place.
+///
+/// Shared by [`push_router_anchor`] and [`push_router_already_mounted`] so the
+/// two can never disagree about what counts as a comment — a disagreement
+/// there is what lets a doc-comment mention suppress both the injection and
+/// the warning about it.
+fn for_each_code_line<T>(source: &str, mut f: impl FnMut(&str, usize) -> Option<T>) -> Option<T> {
     let mut offset = 0_usize;
     let mut in_block_comment = false;
-    let mut seen_main = false;
 
     for line in source.split_inclusive('\n') {
         let trimmed = line.trim();
         let line_start = offset;
         offset += line.len();
 
-        // Track block comments so a commented-out builder never anchors.
         if in_block_comment {
             if trimmed.contains("*/") {
                 in_block_comment = false;
@@ -852,15 +950,8 @@ fn push_router_anchor(source: &str) -> Option<usize> {
             continue;
         }
 
-        if trimmed.contains("async fn main") {
-            seen_main = true;
-        }
-        // Only a line that ENDS with the builder opener is an anchor: a
-        // single-line chain (`autumn_web::app().routes(…).run().await;`) has
-        // no place to insert a `.merge(…)` line, so it is deliberately left
-        // alone and reported instead of being spliced mid-expression.
-        if seen_main && line.trim_end().ends_with("autumn_web::app()") {
-            return Some(line_start + line.trim_end().len());
+        if let Some(found) = f(line, line_start) {
+            return Some(found);
         }
     }
     None
@@ -2084,12 +2175,12 @@ async fn main() {
     fn client_snippet_subscribes_against_the_frameworks_public_key_endpoint() {
         let js = render_pwa_register_js();
         assert!(
-            js.contains(autumn_web::push::router::VAPID_PUBLIC_KEY_PATH),
+            js.contains(autumn_web::push::VAPID_PUBLIC_KEY_PATH),
             "the snippet must fetch the key from the built-in endpoint so the two \
              can never drift:\n{js}"
         );
         assert!(
-            js.contains(autumn_web::push::router::SUBSCRIBE_PATH),
+            js.contains(autumn_web::push::SUBSCRIBE_PATH),
             "the snippet must POST the subscription to the built-in endpoint:\n{js}"
         );
         assert!(
@@ -2162,26 +2253,113 @@ async fn main() {
         // is HttpOnly — so without this the generated subscribe/unsubscribe
         // POSTs 403 and push opt-in is unusable in exactly the environment it
         // is meant for.
-        let js = render_pwa_register_js();
+        let js = render_push_opt_in();
         assert!(
-            js.contains(autumn_web::push::router::CSRF_TOKEN_HEADER),
+            js.contains(autumn_web::push::CSRF_TOKEN_HEADER),
             "the snippet must read the token the public-key response serves:\n{js}"
         );
         assert!(
-            js.contains(autumn_web::push::router::CSRF_TOKEN_HEADER_NAME_HEADER),
+            js.contains(autumn_web::push::CSRF_TOKEN_HEADER_NAME_HEADER),
             "…and the configured header name to send it back in:\n{js}"
         );
         // Every POST must go through the helper that attaches it — a `fetch`
         // with a hand-written `content-type` header would silently skip it.
+        // Counted, not fixed at a number: adding a POST later must not be able
+        // to quietly ship one without a token.
         let posts = js.matches("method: 'POST'").count();
-        assert_eq!(
-            posts, 2,
-            "expected exactly the subscribe and unsubscribe POSTs"
+        assert!(
+            posts >= 2,
+            "expected at least the subscribe and unsubscribe POSTs:\n{js}"
         );
         assert_eq!(
             js.matches("headers: autumnPushHeaders()").count(),
             posts,
             "every push POST must attach the CSRF token:\n{js}"
+        );
+    }
+
+    #[test]
+    fn client_snippet_replaces_a_subscription_made_with_a_rotated_key() {
+        // A browser keeps its subscription across deployments. After a
+        // `[push] private_key` rotation `subscribe()` REJECTS rather than
+        // replacing one made with the old applicationServerKey, so without
+        // this the affected users cannot opt back in through the generated
+        // button at all.
+        let js = render_push_opt_in();
+        assert!(
+            js.contains("autumnPushKeyMatches"),
+            "the snippet must compare the stored key against the current one:\n{js}"
+        );
+        assert!(
+            js.contains("applicationServerKey"),
+            "…by reading `options.applicationServerKey`:\n{js}"
+        );
+        assert!(
+            js.contains("existing.unsubscribe()"),
+            "…and drop the stale subscription before re-subscribing:\n{js}"
+        );
+        // The server-side row must go too, or it lingers until the push
+        // service reports it gone.
+        assert!(
+            js.contains("existing.endpoint"),
+            "…telling the server to forget the old endpoint as well:\n{js}"
+        );
+    }
+
+    #[test]
+    fn a_browser_that_hides_the_recorded_key_is_left_alone() {
+        // Older Safari does not expose `options.applicationServerKey`.
+        // Churning a working subscription on every page load would be worse
+        // than the rotation case this guards.
+        let js = render_push_opt_in();
+        assert!(
+            js.contains("return true;"),
+            "an unavailable recorded key must be treated as matching:\n{js}"
+        );
+    }
+
+    #[test]
+    fn the_registration_half_stays_free_of_push_concerns() {
+        // Registration must work on a build that never configures push.
+        let js = render_service_worker_registration();
+        assert!(js.contains("serviceWorker"), "{js}");
+        assert!(
+            !js.contains("pushManager") && !js.contains("autumnPush"),
+            "service-worker registration must not depend on the push half:\n{js}"
+        );
+    }
+
+    #[test]
+    fn a_router_mount_inside_a_comment_does_not_count_as_mounted() {
+        // This project's own docs show a quick-start snippet containing the
+        // mount call, so a `main.rs` that pasted it into a comment would look
+        // mounted, skip injection AND skip the warning — leaving every
+        // generated `fetch` to 404 with nothing pointing at the cause.
+        let commented = DEFAULT_MAIN.replace(
+            "#[autumn_web::main]",
+            "// Example from the guide:\n             //     .merge(autumn_web::push::router())\n             #[autumn_web::main]",
+        );
+        assert!(
+            !push_router_already_mounted(&commented),
+            "a commented-out mount must not count as mounted"
+        );
+        let injected = inject_pwa_into_main(&commented);
+        assert!(
+            push_router_already_mounted(&injected),
+            "…so injection must still happen:\n{injected}"
+        );
+    }
+
+    #[test]
+    fn a_real_router_mount_does_count_as_mounted() {
+        let injected = inject_pwa_into_main(DEFAULT_MAIN);
+        assert!(push_router_already_mounted(&injected));
+        assert_eq!(
+            inject_pwa_into_main(&injected)
+                .matches("autumn_web::push::router()")
+                .count(),
+            1,
+            "and a second run must not add another"
         );
     }
 
@@ -2200,11 +2378,16 @@ async fn main() {
     fn client_snippet_sends_credentials_on_every_push_request() {
         // The server resolves the subscriber from the session; without the
         // cookie every call is an anonymous 401.
-        let js = render_pwa_register_js();
+        //
+        // Compared against the number of `fetch` calls rather than a fixed
+        // count: every request the push half makes either authenticates or
+        // reads a per-visitor token, so a new one without credentials is a bug
+        // whatever the total happens to be.
+        let js = render_push_opt_in();
         assert_eq!(
             js.matches("credentials: 'same-origin'").count(),
-            4,
-            "two POSTs plus the two public-key GETs must all carry the session:\n{js}"
+            js.matches("fetch(").count(),
+            "every push request must carry the session cookie:\n{js}"
         );
     }
 

--- a/autumn-cli/src/generate/pwa.rs
+++ b/autumn-cli/src/generate/pwa.rs
@@ -703,12 +703,18 @@ document.addEventListener('submit', (event) => {{
   // Re-entrancy guard: `form.submit()` below does not re-fire this handler in
   // any current browser, but the flag makes that independent of that detail.
   form.dataset.autumnPushHandled = 'true';
-  // `finally`, not `then`: a failed unsubscribe must never trap the user in a
-  // session they asked to leave.
-  window
-    .autumnPushUnsubscribe()
-    .catch(console.error)
-    .finally(() => form.submit());
+  // Raced against a deadline — `catch` alone is not enough here.
+  //
+  // `autumnPushUnsubscribe` awaits `navigator.serviceWorker.ready`, which by
+  // specification NEVER REJECTS: it stays pending until a worker becomes
+  // active. So if the service worker fails to install, a bare
+  // `.catch().finally()` never runs — and since this handler has already
+  // called `preventDefault()`, the user cannot log out at all. Blocking a
+  // sign-out is far worse than leaving a subscription behind, which the push
+  // service prunes with a `410` soon enough anyway.
+  const cleanup = window.autumnPushUnsubscribe().catch(console.error);
+  const deadline = new Promise((resolve) => setTimeout(resolve, {logout_timeout_ms}));
+  Promise.race([cleanup, deadline]).then(() => form.submit());
 }});
 
 // Declarative opt-in: no application JavaScript required.
@@ -728,6 +734,7 @@ document.addEventListener('click', (event) => {{
         key_path = autumn_web::push::VAPID_PUBLIC_KEY_PATH,
         subscribe_path = autumn_web::push::SUBSCRIBE_PATH,
         unsubscribe_path = autumn_web::push::UNSUBSCRIBE_PATH,
+        logout_timeout_ms = LOGOUT_UNSUBSCRIBE_TIMEOUT_MS,
     )
 }
 
@@ -869,6 +876,16 @@ pub fn inject_pwa_into_main(source: &str) -> String {
 /// developer had written themselves before ever running the generator — which
 /// `Plan::revert` documents it never does.
 const PUSH_ROUTER_MARKER: &str = "// added by `autumn generate pwa`";
+
+/// How long the generated sign-out waits for the push unsubscribe before
+/// submitting the form regardless.
+///
+/// `navigator.serviceWorker.ready` never rejects — it stays pending until a
+/// worker activates — so a worker that failed to install would otherwise hang
+/// the logout forever. Two seconds is generous for a local
+/// `getSubscription()` plus one same-origin POST, and short enough that a user
+/// who hits the broken case barely notices.
+const LOGOUT_UNSUBSCRIBE_TIMEOUT_MS: u32 = 2_000;
 
 /// The line [`inject_push_router`] inserts, and [`remove_push_router`] removes.
 ///
@@ -2424,13 +2441,34 @@ async fn main() {
     }
 
     #[test]
-    fn a_failed_unsubscribe_never_traps_the_user_in_their_session() {
-        // The logout POST is preventDefault'd, so if the unsubscribe promise
-        // is not always followed by a submit the user cannot sign out at all.
+    fn a_stalled_unsubscribe_never_traps_the_user_in_their_session() {
+        // The logout POST is preventDefault'd, so the form MUST submit
+        // regardless of what the unsubscribe promise does.
+        //
+        // `.catch(…).finally(…)` looks sufficient and is not:
+        // `autumnPushUnsubscribe` awaits `navigator.serviceWorker.ready`,
+        // which by specification never rejects — it stays pending until a
+        // worker activates. A worker that fails to install therefore leaves
+        // `finally` unreached and the user unable to log out. Only a race
+        // against a deadline actually secures the invariant this test names,
+        // so that is what is asserted.
         let js = render_push_opt_in();
         assert!(
-            js.contains(".finally(() => form.submit())"),
-            "the form must submit whether or not the unsubscribe succeeded:\n{js}"
+            js.contains("Promise.race("),
+            "the submit must be raced against a deadline, not chained off a \
+             promise that may never settle:\n{js}"
+        );
+        assert!(
+            js.contains("setTimeout(resolve"),
+            "…with an actual timer as the other racer:\n{js}"
+        );
+        assert!(
+            js.contains(&format!("{LOGOUT_UNSUBSCRIBE_TIMEOUT_MS}")),
+            "…bounded by the documented timeout:\n{js}"
+        );
+        assert!(
+            js.contains("form.submit()"),
+            "…and the form must actually be submitted:\n{js}"
         );
         assert!(
             js.contains("autumnPushHandled"),

--- a/autumn-cli/src/generate/pwa.rs
+++ b/autumn-cli/src/generate/pwa.rs
@@ -676,6 +676,41 @@ window.autumnPushUnsubscribe = async function autumnPushUnsubscribe() {{
   return subscription.unsubscribe();
 }};
 
+// Unsubscribe on the way out of a session.
+//
+// A subscription outliving the session that created it is a privacy leak, not
+// just untidiness: the row stays bound to the user who logged out, so the app
+// keeps pushing their notifications to that browser — in front of whoever uses
+// the device next. Nothing in a logout flow knows about push, so this hooks
+// the submit instead, while the session is still valid enough for the
+// server-side unsubscribe to authorize.
+//
+// Matches any form posting to `/logout` (what `autumn generate auth` emits) and
+// anything explicitly marked `data-autumn-push-unsubscribe`, for an app whose
+// sign-out is shaped differently.
+document.addEventListener('submit', (event) => {{
+  const form = event.target;
+  if (!(form instanceof HTMLFormElement) || form.dataset.autumnPushHandled) {{
+    return;
+  }}
+  const action = form.getAttribute('action') || '';
+  const isSignOut =
+    form.hasAttribute('data-autumn-push-unsubscribe') || /\/logout\/?$/.test(action);
+  if (!isSignOut) {{
+    return;
+  }}
+  event.preventDefault();
+  // Re-entrancy guard: `form.submit()` below does not re-fire this handler in
+  // any current browser, but the flag makes that independent of that detail.
+  form.dataset.autumnPushHandled = 'true';
+  // `finally`, not `then`: a failed unsubscribe must never trap the user in a
+  // session they asked to leave.
+  window
+    .autumnPushUnsubscribe()
+    .catch(console.error)
+    .finally(() => form.submit());
+}});
+
 // Declarative opt-in: no application JavaScript required.
 document.addEventListener('click', (event) => {{
   // A synthetic `document.dispatchEvent(new MouseEvent('click'))` — the common
@@ -2360,6 +2395,46 @@ async fn main() {
                 .count(),
             1,
             "and a second run must not add another"
+        );
+    }
+
+    #[test]
+    fn client_snippet_unsubscribes_when_the_user_signs_out() {
+        // A subscription outliving its session is a privacy leak: the row
+        // stays bound to the user who logged out, so the app keeps pushing
+        // their notifications to that browser — in front of whoever uses the
+        // device next.
+        let js = render_push_opt_in();
+        assert!(
+            js.contains("addEventListener('submit'"),
+            "sign-out must be hooked; nothing in a logout flow knows about push:\n{js}"
+        );
+        assert!(
+            js.contains("/logout"),
+            "…matching what `autumn generate auth` emits:\n{js}"
+        );
+        assert!(
+            js.contains("data-autumn-push-unsubscribe"),
+            "…plus an opt-in attribute for a differently-shaped sign-out:\n{js}"
+        );
+        assert!(
+            js.contains("autumnPushUnsubscribe()"),
+            "…and it must actually unsubscribe:\n{js}"
+        );
+    }
+
+    #[test]
+    fn a_failed_unsubscribe_never_traps_the_user_in_their_session() {
+        // The logout POST is preventDefault'd, so if the unsubscribe promise
+        // is not always followed by a submit the user cannot sign out at all.
+        let js = render_push_opt_in();
+        assert!(
+            js.contains(".finally(() => form.submit())"),
+            "the form must submit whether or not the unsubscribe succeeded:\n{js}"
+        );
+        assert!(
+            js.contains("autumnPushHandled"),
+            "…guarded against re-entering the handler:\n{js}"
         );
     }
 

--- a/autumn-cli/src/generate/pwa.rs
+++ b/autumn-cli/src/generate/pwa.rs
@@ -12,12 +12,19 @@
 //!   - `tests/system/pwa_smoke.rs`     — Smoke test (manifest content-type + SW registration)
 //!   - `Cargo.toml`                    — `system-tests` feature added if absent
 
-use std::path::Path;
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::{Path, PathBuf};
 
+use autumn_web::config::DatabaseBackend;
+use autumn_web::push::PUSH_SUBSCRIPTIONS_TABLE;
+
+use super::dsl::{Field, FieldConstraints, FieldKind, IdType};
 use super::emit::Plan;
-use super::schema_edit::update_main_rs;
+use super::schema_edit::{
+    create_table_sql_with_metadata_and_id_for, drop_table_sql, update_main_rs,
+};
 use super::system_test::patch_cargo_toml as patch_system_test_cargo_toml;
-use super::{GenerateError, ensure_project_root};
+use super::{GenerateError, detect_backend, ensure_project_root, timestamp_now};
 
 // ── Public API ────────────────────────────────────────────────────────────────
 
@@ -70,6 +77,32 @@ fn plan_pwa_shared(project_root: &Path) -> Plan {
             "pwa_offline".to_owned(),
         ],
     });
+
+    // migrations/<ts>_create_push_subscriptions/{up,down}.sql — the table the
+    // framework's `DbPushSubscriptionStore` reads (issue #1392).
+    //
+    // Like the notifications feed, push subscriptions are a singleton scaffold:
+    // re-running (especially with `--force`) must not mint a SECOND
+    // `*_create_push_subscriptions` directory, since two `CREATE TABLE
+    // push_subscriptions` migrations would fail the next `autumn migrate` on
+    // the duplicate table and make destroy's suffix match ambiguous. So reuse
+    // an existing directory when one is present, minting a fresh timestamped
+    // one only on a clean project.
+    let backend = detect_backend(project_root);
+    let migration_dir = existing_push_migration_dir(project_root).unwrap_or_else(|| {
+        project_root.join("migrations").join(format!(
+            "{}_create_{PUSH_SUBSCRIPTIONS_TABLE}",
+            timestamp_now()
+        ))
+    });
+    plan.create(
+        migration_dir.join("up.sql"),
+        push_subscriptions_up_sql(backend),
+    );
+    plan.create(
+        migration_dir.join("down.sql"),
+        drop_table_sql(PUSH_SUBSCRIPTIONS_TABLE),
+    );
 
     // System test
     let system_test_path = project_root
@@ -124,6 +157,18 @@ pub fn plan_pwa(project_root: &Path) -> Result<Plan, GenerateError> {
 
     // src/main.rs: inject PWA meta tags + route handlers (idempotent)
     let updated_main = inject_pwa_into_main(&main_existing);
+    // A silently unmounted router is the worst outcome here: the command exits
+    // 0, the client snippet ships, and every `fetch` it makes 404s with
+    // nothing pointing at the cause. Say so instead.
+    if !updated_main.contains("autumn_web::push::router()") {
+        plan.warn(
+            "could not find the app builder in src/main.rs, so the Web Push routes were not \
+             mounted. Add this line to your builder chain by hand:\n    \
+             .merge(autumn_web::push::router())\n  \
+             Without it the generated subscribe snippet will 404. See \
+             docs/guide/web-push.md.",
+        );
+    }
     if updated_main != main_existing {
         plan.modify(main_path, updated_main);
     }
@@ -156,6 +201,88 @@ pub fn plan_pwa_destroy_fallback(project_root: &Path) -> Result<Plan, GenerateEr
 }
 
 // ── Content renderers ─────────────────────────────────────────────────────────
+
+/// The existing `migrations/<ts>_create_push_subscriptions/` directory, if the
+/// project already has one — so a re-run reuses it in place rather than
+/// minting a second singleton migration. Matched by the same
+/// `_create_push_subscriptions` suffix destroy uses, so the two stay in
+/// agreement. If more than one somehow exists (a hand-added duplicate), the
+/// lexicographically-smallest is chosen deterministically.
+fn existing_push_migration_dir(project_root: &Path) -> Option<PathBuf> {
+    let suffix = format!("_create_{PUSH_SUBSCRIPTIONS_TABLE}");
+    let mut matches: Vec<PathBuf> = std::fs::read_dir(project_root.join("migrations"))
+        .ok()?
+        .filter_map(Result::ok)
+        .map(|entry| entry.path())
+        .filter(|path| {
+            path.is_dir()
+                && path
+                    .file_name()
+                    .and_then(|n| n.to_str())
+                    .is_some_and(|n| n.ends_with(&suffix))
+        })
+        .collect();
+    matches.sort();
+    matches.into_iter().next()
+}
+
+/// The four non-`id` columns of the `push_subscriptions` table, expressed in
+/// the migration DSL so the DDL comes out of the same shared helper every
+/// other generator uses (`id` and `created_at` come from the helper itself).
+///
+/// The column types must match the framework store's diesel `table!` in
+/// `autumn_web::push::store` (`Text` throughout; `Timestamptz` on Postgres,
+/// `TimestamptzSqlite` — RFC 3339 `TEXT` — on SQLite): that store, not any
+/// generated model, is what reads this table. The two key columns hold the
+/// browser's own base64url strings rather than raw bytes, which keeps one
+/// `table!` definition working on both backends.
+fn push_subscription_fields() -> Vec<Field> {
+    let field = |name: &str, unique: bool| Field {
+        name: name.to_owned(),
+        kind: FieldKind::String,
+        nullable: false,
+        variants: Vec::new(),
+        unique,
+        constraints: FieldConstraints::default(),
+        state_machine: None,
+    };
+    vec![
+        field("principal_id", false),
+        // UNIQUE is load-bearing, not decoration: it is what makes the store's
+        // `ON CONFLICT (endpoint) DO UPDATE` upsert atomic rather than a racy
+        // select-then-insert, and what stops one browser accumulating a row
+        // per page load.
+        field("endpoint", true),
+        field("p256dh", false),
+        field("auth", false),
+    ]
+}
+
+/// Build the `push_subscriptions` `up.sql` for the target `backend`.
+///
+/// The shared helper's stock `created_at` is `TIMESTAMP`; the Postgres output
+/// rewrites that one column to `TIMESTAMPTZ` to stay in lockstep with the
+/// framework store's `Timestamptz` mapping — the same adjustment the
+/// notifications generator makes, for the same reason. The `SQLite` output
+/// already matches and is left exactly as the helper emits it.
+fn push_subscriptions_up_sql(backend: DatabaseBackend) -> String {
+    let indexes: BTreeSet<String> = std::iter::once("principal_id".to_owned()).collect();
+    let sql = create_table_sql_with_metadata_and_id_for(
+        backend,
+        PUSH_SUBSCRIPTIONS_TABLE,
+        &push_subscription_fields(),
+        &indexes,
+        &BTreeMap::new(),
+        IdType::BigSerial,
+    );
+    match backend {
+        DatabaseBackend::Postgres => sql.replace(
+            "created_at TIMESTAMP NOT NULL DEFAULT NOW()",
+            "created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()",
+        ),
+        DatabaseBackend::Sqlite => sql,
+    }
+}
 
 fn render_manifest() -> String {
     concat!(
@@ -236,6 +363,67 @@ self.addEventListener('fetch', (event) => {
     );
   }
 });
+
+// ── Web Push ────────────────────────────────────────────────────────────────
+// Fired by the browser even when every tab of this site is closed. The payload
+// is what `autumn_web::push::PushMessage` serializes: {title, body, url?, icon?}.
+
+self.addEventListener('push', (event) => {
+  // A push can legitimately arrive with no payload, and a payload from any
+  // other sender need not be JSON. Throwing here makes the browser show a
+  // generic 'site updated in the background' notice instead, so always fall
+  // back to something readable.
+  let payload = {};
+  if (event.data) {
+    try {
+      payload = event.data.json();
+    } catch (e) {
+      payload = { body: event.data.text() };
+    }
+  }
+  const title = payload.title || 'Notification';
+  const options = {
+    body: payload.body || '',
+    icon: payload.icon || '/static/icons/icon.svg',
+    // Carried through to `notificationclick` below.
+    data: { url: payload.url || '/' },
+  };
+  event.waitUntil(self.registration.showNotification(title, options));
+});
+
+self.addEventListener('notificationclick', (event) => {
+  event.notification.close();
+  const target = new URL(
+    (event.notification.data && event.notification.data.url) || '/',
+    self.location.origin
+  );
+  // Cross-origin targets are dropped: the payload travels through a third-party
+  // push service, so a notification must never be able to navigate this app's
+  // users off-origin.
+  const url = target.origin === self.location.origin ? target.href : self.location.origin + '/';
+  event.waitUntil(
+    self.clients.matchAll({ type: 'window', includeUncontrolled: true }).then((windows) => {
+      // Prefer focusing a tab that is already on the target rather than
+      // opening a duplicate one.
+      for (const client of windows) {
+        if (client.url === url && 'focus' in client) {
+          return client.focus();
+        }
+      }
+      if (windows.length > 0 && 'navigate' in windows[0] && 'focus' in windows[0]) {
+        // `navigate()` REJECTS for a client this service worker does not
+        // control — and `includeUncontrolled: true` above is exactly how such
+        // clients get into this list. An unhandled rejection inside
+        // `waitUntil` means the click does nothing at all, so fall back.
+        return windows[0]
+          .navigate(url)
+          .then((client) => (client ? client.focus() : undefined))
+          .catch(() => self.clients.openWindow(url));
+      }
+      return self.clients.openWindow(url);
+    })
+  );
+});
 "
     .to_owned()
 }
@@ -267,12 +455,130 @@ fn render_maskable_icon_svg() -> String {
 fn render_pwa_register_js() -> String {
     // Served as a same-origin script to avoid CSP `script-src 'self'` blocking
     // inline scripts that the default SecurityHeadersLayer enforces.
-    "if('serviceWorker'in navigator)\
-     navigator.serviceWorker\
-     .register('/service-worker.js',{scope:'/'})\
-     .then(()=>document.documentElement.dataset.swRegistered='true')\
-     .catch(console.error);\n"
-        .to_owned()
+    //
+    // Two halves: service-worker registration (unconditional), and Web Push
+    // opt-in (issue #1392), which is deliberately NOT run on load — a
+    // permission prompt fired without a user gesture is the fastest way to get
+    // permanently blocked, and both Chrome and Firefox penalise it. Instead the
+    // subscribe flow is exposed as `window.autumnPushSubscribe()` and wired to
+    // any element carrying `data-autumn-push-subscribe`, so an app gets an
+    // opt-in button with no JavaScript of its own:
+    //
+    //     <button data-autumn-push-subscribe>Enable notifications</button>
+    //
+    // The paths below come from `autumn_web::push::router`'s own constants, so
+    // the snippet and the mounted routes can never drift apart.
+    format!(
+        r"if ('serviceWorker' in navigator) {{
+  navigator.serviceWorker
+    .register('/service-worker.js', {{ scope: '/' }})
+    .then(() => {{ document.documentElement.dataset.swRegistered = 'true'; }})
+    .catch(console.error);
+}}
+
+// Autumn's CSRF layer rejects an unaccompanied mutating request, so read the
+// token the layout publishes and send it on both POSTs below. Without this the
+// subscribe/unsubscribe calls 403 the moment `[security.csrf] enabled = true`
+// — and the tempting workaround (exempting `/push/`) would strip CSRF from a
+// route whose entire body is client-chosen.
+function autumnPushHeaders() {{
+  const headers = {{ 'content-type': 'application/json' }};
+  // Unquoted attribute values (both are valid CSS identifiers) so this stays
+  // inside a Rust raw string that cannot contain a double quote.
+  const token = document.querySelector('meta[name=csrf-token]');
+  if (token && token.content) {{
+    const header = document.querySelector('meta[name=csrf-token-header]');
+    headers[(header && header.content) || 'X-CSRF-Token'] = token.content;
+  }}
+  return headers;
+}}
+
+// `applicationServerKey` takes a BufferSource, not the base64url string the
+// endpoint serves, and `atob` only understands standard base64 — so translate
+// base64url's `-` and `_` back to `+` and `/` and re-pad before decoding.
+function autumnDecodeVapidKey(base64url) {{
+  const padding = '='.repeat((4 - (base64url.length % 4)) % 4);
+  const base64 = (base64url + padding).replace(/-/g, '+').replace(/_/g, '/');
+  const raw = atob(base64);
+  const bytes = new Uint8Array(raw.length);
+  for (let i = 0; i < raw.length; i += 1) {{
+    bytes[i] = raw.charCodeAt(i);
+  }}
+  return bytes;
+}}
+
+// Opt the current visitor in to Web Push. Call it from a click handler — it
+// prompts for notification permission, so it needs a user gesture.
+// Resolves `true` once the subscription has been recorded server-side.
+window.autumnPushSubscribe = async function autumnPushSubscribe() {{
+  // Safari on older iOS has service workers but no Push API at all.
+  if (!('serviceWorker' in navigator) || !('PushManager' in window)) {{
+    return false;
+  }}
+  if ((await Notification.requestPermission()) !== 'granted') {{
+    return false;
+  }}
+  const response = await fetch('{key_path}');
+  if (!response.ok) {{
+    // 503 means the app has not configured `[push] private_key` yet.
+    console.error('web push is not configured on this server');
+    return false;
+  }}
+  const registration = await navigator.serviceWorker.ready;
+  const subscription = await registration.pushManager.subscribe({{
+    // Chrome refuses a subscription without this, and it is also the honest
+    // contract: every push this app sends raises a visible notification.
+    userVisibleOnly: true,
+    applicationServerKey: autumnDecodeVapidKey((await response.text()).trim()),
+  }});
+  const recorded = await fetch('{subscribe_path}', {{
+    method: 'POST',
+    headers: autumnPushHeaders(),
+    // Send the session cookie so the server knows whose subscription this is.
+    credentials: 'same-origin',
+    body: JSON.stringify(subscription),
+  }});
+  return recorded.ok;
+}};
+
+// Undo the above: forget this browser's subscription, server-side and locally.
+window.autumnPushUnsubscribe = async function autumnPushUnsubscribe() {{
+  if (!('serviceWorker' in navigator) || !('PushManager' in window)) {{
+    return false;
+  }}
+  const registration = await navigator.serviceWorker.ready;
+  const subscription = await registration.pushManager.getSubscription();
+  if (!subscription) {{
+    return true;
+  }}
+  await fetch('{unsubscribe_path}', {{
+    method: 'POST',
+    headers: autumnPushHeaders(),
+    credentials: 'same-origin',
+    body: JSON.stringify({{ endpoint: subscription.endpoint }}),
+  }});
+  return subscription.unsubscribe();
+}};
+
+// Declarative opt-in: no application JavaScript required.
+document.addEventListener('click', (event) => {{
+  // A synthetic `document.dispatchEvent(new MouseEvent('click'))` — the common
+  // close-the-open-dropdown idiom — has `document` as its target, which has no
+  // `closest`. Guard rather than throw on every such click.
+  if (!(event.target instanceof Element)) {{
+    return;
+  }}
+  const trigger = event.target.closest('[data-autumn-push-subscribe]');
+  if (trigger) {{
+    event.preventDefault();
+    window.autumnPushSubscribe().catch(console.error);
+  }}
+}});
+",
+        key_path = autumn_web::push::router::VAPID_PUBLIC_KEY_PATH,
+        subscribe_path = autumn_web::push::router::SUBSCRIBE_PATH,
+        unsubscribe_path = autumn_web::push::router::UNSUBSCRIBE_PATH,
+    )
 }
 
 fn render_pwa_system_test() -> String {
@@ -396,13 +702,131 @@ fn render_pwa_system_test() -> String {
 pub fn inject_pwa_into_main(source: &str) -> String {
     let with_meta = inject_pwa_meta_into_head(source);
     let with_handlers = inject_pwa_handlers(&with_meta);
+    let with_push_router = inject_push_router(&with_handlers);
     let route_entries = vec![
         "pwa_manifest".to_owned(),
         "pwa_service_worker".to_owned(),
         "pwa_register_js".to_owned(),
         "pwa_offline".to_owned(),
     ];
-    update_main_rs(&with_handlers, &[], &route_entries)
+    update_main_rs(&with_push_router, &[], &route_entries)
+}
+
+/// The trailing marker on the mount line [`inject_push_router`] inserts.
+///
+/// Load-bearing for [`remove_push_router`]: destroy must remove only the line
+/// *this generator* wrote. Without a marker it would also delete a mount the
+/// developer had written themselves before ever running the generator — which
+/// `Plan::revert` documents it never does.
+const PUSH_ROUTER_MARKER: &str = "// added by `autumn generate pwa`";
+
+/// The line [`inject_push_router`] inserts, and [`remove_push_router`] removes.
+///
+/// Mounting the framework's built-in push routes is what makes the generated
+/// client snippet work: without it every `fetch` in `pwa-register.js` 404s.
+const PUSH_ROUTER_LINE: &str =
+    "        .merge(autumn_web::push::router()) // added by `autumn generate pwa`";
+
+/// Mount `autumn_web::push::router()` on the app builder in `main()`.
+///
+/// Anchored on the `autumn_web::app()` line that every scaffolded `main.rs`
+/// opens its builder chain with. Idempotent, and — like
+/// [`inject_pwa_meta_into_head`] — a **no-op** when no usable anchor is found,
+/// rather than a guess: an app whose `main.rs` has been restructured keeps
+/// compiling and mounts the router itself with the one line the guide shows.
+/// The caller reports that no-op as a warning; a silently unmounted router
+/// would look like success and 404 on every call from the generated snippet.
+///
+/// # Anchor selection
+///
+/// Matching `autumn_web::app()` by text alone is not safe: this project's own
+/// documentation (and `autumn_web::push::router`'s doc comment) shows a
+/// quick-start snippet containing that exact line, so a `main.rs` that pasted
+/// it into a comment would get the mount spliced **into the comment** —
+/// producing a file that does not compile *and* a `main()` that never mounts
+/// the router. So the scan walks lines with a byte cursor (never re-locating
+/// by text, which could land on an earlier occurrence), skips anything inside
+/// a comment, and only accepts an anchor at or after `async fn main`.
+fn inject_push_router(source: &str) -> String {
+    if source.contains("autumn_web::push::router()") {
+        return source.to_owned();
+    }
+    let Some(anchor_end) = push_router_anchor(source) else {
+        return source.to_owned();
+    };
+    let mut result = String::with_capacity(source.len() + PUSH_ROUTER_LINE.len() + 1);
+    result.push_str(&source[..anchor_end]);
+    result.push('\n');
+    result.push_str(PUSH_ROUTER_LINE);
+    result.push_str(&source[anchor_end..]);
+    result
+}
+
+/// Byte offset just past the builder-opening `autumn_web::app()` inside
+/// `main()`, or `None` when there is no unambiguous anchor.
+///
+/// See [`inject_push_router`]'s "Anchor selection" for why each rule is here.
+fn push_router_anchor(source: &str) -> Option<usize> {
+    let mut offset = 0_usize;
+    let mut in_block_comment = false;
+    let mut seen_main = false;
+
+    for line in source.split_inclusive('\n') {
+        let trimmed = line.trim();
+        let line_start = offset;
+        offset += line.len();
+
+        // Track block comments so a commented-out builder never anchors.
+        if in_block_comment {
+            if trimmed.contains("*/") {
+                in_block_comment = false;
+            }
+            continue;
+        }
+        if trimmed.starts_with("/*") {
+            if !trimmed.contains("*/") {
+                in_block_comment = true;
+            }
+            continue;
+        }
+        // `//`, `///`, `//!`, and continuation lines of a block comment.
+        if trimmed.starts_with("//") || trimmed.starts_with('*') {
+            continue;
+        }
+
+        if trimmed.contains("async fn main") {
+            seen_main = true;
+        }
+        // Only a line that ENDS with the builder opener is an anchor: a
+        // single-line chain (`autumn_web::app().routes(…).run().await;`) has
+        // no place to insert a `.merge(…)` line, so it is deliberately left
+        // alone and reported instead of being spliced mid-expression.
+        if seen_main && line.trim_end().ends_with("autumn_web::app()") {
+            return Some(line_start + line.trim_end().len());
+        }
+    }
+    None
+}
+
+/// Inverse of [`inject_push_router`]: remove exactly the line it inserted.
+///
+/// Matched on the [`PUSH_ROUTER_MARKER`] this generator writes, so a mount the
+/// developer added themselves is left untouched — `Plan::revert`'s contract is
+/// that it never removes content the plan did not itself add. A no-op when the
+/// marked line is absent (already destroyed, or hand-edited away).
+fn remove_push_router(existing: &str) -> String {
+    if !existing.contains(PUSH_ROUTER_MARKER) {
+        return existing.to_owned();
+    }
+    let mut out = String::with_capacity(existing.len());
+    for line in existing.split_inclusive('\n') {
+        let trimmed = line.trim();
+        if trimmed.contains("autumn_web::push::router()") && trimmed.ends_with(PUSH_ROUTER_MARKER) {
+            continue;
+        }
+        out.push_str(line);
+    }
+    out
 }
 
 /// Insert PWA `<link>` / `<meta>` tags into the `head {}` block of the
@@ -644,7 +1068,8 @@ fn indent_count(line: &str) -> usize {
 /// handler functions this generator injected. A no-op wherever its target
 /// isn't present (already destroyed, or hand-edited away).
 pub(super) fn remove_pwa_injection(existing: &str) -> String {
-    let without_handlers = remove_pwa_handlers(existing);
+    let without_router = remove_push_router(existing);
+    let without_handlers = remove_pwa_handlers(&without_router);
     remove_pwa_meta_from_head(&without_handlers)
 }
 
@@ -1520,5 +1945,400 @@ async fn main() {
         );
         let after = fs::read_to_string(tmp.path().join("src/main.rs")).unwrap();
         assert_eq!(original_main, after, "dry-run must not modify main.rs");
+    }
+
+    // ── Web Push (issue #1392) ──────────────────────────────────────────────
+
+    /// The text an emitted action would write.
+    fn action_contents(action: &crate::generate::emit::Action) -> String {
+        match action {
+            crate::generate::emit::Action::Create { contents, .. }
+            | crate::generate::emit::Action::Modify { contents, .. }
+            | crate::generate::emit::Action::CreateIfAbsent { contents, .. } => contents.clone(),
+            crate::generate::emit::Action::CreateBytes { bytes, .. } => {
+                String::from_utf8_lossy(bytes).into_owned()
+            }
+        }
+    }
+
+    #[test]
+    fn service_worker_has_a_push_handler() {
+        let sw = render_service_worker();
+        assert!(
+            sw.contains("addEventListener('push'"),
+            "without a `push` handler the browser shows nothing when the tab is closed — \
+             the entire point of Web Push:\n{sw}"
+        );
+        assert!(
+            sw.contains("showNotification"),
+            "the push handler must actually raise a notification:\n{sw}"
+        );
+    }
+
+    #[test]
+    fn push_handler_reads_the_frameworks_json_payload() {
+        let sw = render_service_worker();
+        // The framework sends `{title, body, url?, icon?}` — the SW must read
+        // those exact keys or every notification renders blank.
+        for key in ["title", "body", "icon"] {
+            assert!(
+                sw.contains(key),
+                "the push handler must read `{key}` from the payload:\n{sw}"
+            );
+        }
+    }
+
+    #[test]
+    fn push_handler_survives_a_payload_that_is_not_json() {
+        // A push with no payload (or a non-JSON one from another sender) must
+        // still show *something* rather than throwing inside the SW, which
+        // browsers surface as a generic "site updated in the background".
+        let sw = render_service_worker();
+        assert!(
+            sw.contains("catch"),
+            "the push handler must guard payload parsing:\n{sw}"
+        );
+    }
+
+    #[test]
+    fn service_worker_has_a_notificationclick_handler_that_focuses_or_opens() {
+        let sw = render_service_worker();
+        assert!(
+            sw.contains("addEventListener('notificationclick'"),
+            "clicking a notification must do something:\n{sw}"
+        );
+        assert!(
+            sw.contains("clients.matchAll"),
+            "clicking must FOCUS an already-open tab rather than always opening \
+             a duplicate one:\n{sw}"
+        );
+        assert!(
+            sw.contains("openWindow"),
+            "…and open a new window when none is focusable:\n{sw}"
+        );
+        assert!(
+            sw.contains("notification.close()"),
+            "the notification must be dismissed on click:\n{sw}"
+        );
+    }
+
+    #[test]
+    fn client_snippet_subscribes_against_the_frameworks_public_key_endpoint() {
+        let js = render_pwa_register_js();
+        assert!(
+            js.contains(autumn_web::push::router::VAPID_PUBLIC_KEY_PATH),
+            "the snippet must fetch the key from the built-in endpoint so the two \
+             can never drift:\n{js}"
+        );
+        assert!(
+            js.contains(autumn_web::push::router::SUBSCRIBE_PATH),
+            "the snippet must POST the subscription to the built-in endpoint:\n{js}"
+        );
+        assert!(
+            js.contains("pushManager.subscribe"),
+            "the snippet must actually subscribe:\n{js}"
+        );
+        assert!(
+            js.contains("userVisibleOnly"),
+            "Chrome refuses a subscription without `userVisibleOnly: true`:\n{js}"
+        );
+    }
+
+    #[test]
+    fn client_snippet_converts_the_key_to_the_uint8array_the_api_requires() {
+        // `applicationServerKey` takes a BufferSource, not the base64url
+        // string the endpoint serves; passing the string fails at runtime.
+        let js = render_pwa_register_js();
+        assert!(
+            js.contains("Uint8Array"),
+            "the base64url key must be decoded to a Uint8Array:\n{js}"
+        );
+        assert!(js.contains("atob"), "…via base64 decoding:\n{js}");
+        assert!(
+            js.contains("replace"),
+            "…after translating base64url's -/_ back to +/ for atob:\n{js}"
+        );
+    }
+
+    #[test]
+    fn client_snippet_never_prompts_for_permission_on_page_load() {
+        // A permission prompt fired on load is the single fastest way to get
+        // permanently blocked, and Chrome/Firefox both penalise it. The
+        // snippet must expose an explicit opt-in instead.
+        //
+        // The check has to be positional, not a substring test: `contains`
+        // cannot tell a call INSIDE `autumnPushSubscribe` from one at top
+        // level, which is exactly the failure being guarded against. So find
+        // every `requestPermission` and require each to sit inside a function
+        // body — i.e. on an indented line.
+        let js = render_pwa_register_js();
+        let prompts: Vec<&str> = js
+            .lines()
+            .filter(|line| line.contains("requestPermission"))
+            .collect();
+        assert!(
+            !prompts.is_empty(),
+            "the snippet must request permission somewhere:\n{js}"
+        );
+        for line in prompts {
+            assert!(
+                line.starts_with(' '),
+                "`requestPermission` must be called inside the opt-in function, never at \
+                 top level where it would run on page load:\n{line}"
+            );
+        }
+        assert!(
+            js.contains("window.autumnPushSubscribe = "),
+            "the snippet must expose a callable opt-in entry point:\n{js}"
+        );
+        assert!(
+            js.contains("data-autumn-push-subscribe"),
+            "…and wire it to a declarative opt-in attribute so an app needs no JS \
+             of its own:\n{js}"
+        );
+    }
+
+    #[test]
+    fn client_snippet_skips_push_entirely_when_the_browser_lacks_support() {
+        let js = render_pwa_register_js();
+        assert!(
+            js.contains("PushManager"),
+            "the snippet must feature-detect before touching the Push API — Safari \
+             on older iOS has service workers but no PushManager:\n{js}"
+        );
+    }
+
+    #[test]
+    fn plan_creates_the_push_subscriptions_migration() {
+        let tmp = project_with_main(DEFAULT_MAIN);
+        let plan = plan_pwa(tmp.path()).unwrap();
+        let up = plan
+            .actions
+            .iter()
+            .find(|a| {
+                a.path()
+                    .to_string_lossy()
+                    .contains("create_push_subscriptions")
+                    && a.path().ends_with("up.sql")
+            })
+            .expect("the pwa generator must scaffold the push_subscriptions table");
+        let sql = action_contents(up);
+        assert!(sql.contains("CREATE TABLE"), "{sql}");
+        for column in ["principal_id", "endpoint", "p256dh", "auth"] {
+            assert!(
+                sql.contains(column),
+                "the DDL must match the framework store's columns; missing `{column}`:\n{sql}"
+            );
+        }
+        assert!(
+            sql.to_uppercase().contains("UNIQUE"),
+            "`endpoint` must be UNIQUE — it is what makes the store's upsert atomic \
+             rather than a racy select-then-insert:\n{sql}"
+        );
+    }
+
+    /// Pins the generated Postgres DDL against the exact schema the framework
+    /// store is tested on.
+    ///
+    /// The two live in different crates — `autumn-web`'s tests cannot depend
+    /// on `autumn-cli` — so this assertion and the `CREATE_PUSH_SUBSCRIPTIONS_SQL`
+    /// constant in `autumn/tests/integration/push_end_to_end.rs` are the only
+    /// thing binding them. A column renamed, retyped, or dropped on either
+    /// side fails here.
+    #[test]
+    fn generated_push_ddl_matches_the_ddl_the_framework_store_is_tested_against() {
+        let sql = push_subscriptions_up_sql(DatabaseBackend::Postgres);
+
+        for column in [
+            "principal_id TEXT NOT NULL",
+            "endpoint TEXT NOT NULL",
+            "p256dh TEXT NOT NULL",
+            "auth TEXT NOT NULL",
+        ] {
+            assert!(
+                sql.contains(column),
+                "the store's diesel `table!` expects `{column}`:\n{sql}"
+            );
+        }
+        assert!(
+            sql.contains("id BIGSERIAL PRIMARY KEY"),
+            "the store selects `id` as BigInt:\n{sql}"
+        );
+        // The store maps `created_at` as `Timestamptz`. The shared helper emits
+        // a plain `TIMESTAMP`, so this generator rewrites that one column — if
+        // the helper's spacing ever changes, the rewrite silently no-ops and
+        // this is what catches it.
+        assert!(
+            sql.contains("created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()"),
+            "`created_at` must be TIMESTAMPTZ to match the store's mapping:\n{sql}"
+        );
+        assert!(
+            !sql.contains("created_at TIMESTAMP NOT NULL"),
+            "the TIMESTAMP → TIMESTAMPTZ rewrite did not apply:\n{sql}"
+        );
+    }
+
+    #[test]
+    fn push_migration_makes_endpoint_unique_specifically() {
+        // `contains("UNIQUE")` alone would pass with the constraint on the
+        // wrong column — and `endpoint` being unique is what makes the store's
+        // `ON CONFLICT (endpoint) DO UPDATE` atomic rather than a racy
+        // select-then-insert.
+        let sql = push_subscriptions_up_sql(DatabaseBackend::Postgres);
+        let unique_line = sql
+            .lines()
+            .find(|line| line.to_uppercase().contains("UNIQUE"))
+            .unwrap_or_else(|| panic!("no UNIQUE constraint in:\n{sql}"));
+        assert!(
+            unique_line.contains("(endpoint)"),
+            "UNIQUE must be on `endpoint`, not another column: {unique_line}"
+        );
+    }
+
+    #[test]
+    fn push_migration_indexes_principal_id_for_the_send_path() {
+        // Every send does `WHERE principal_id = …`; without the index that is
+        // a sequential scan of every subscription in the system.
+        let sql = push_subscriptions_up_sql(DatabaseBackend::Postgres);
+        assert!(
+            sql.contains("(principal_id)"),
+            "`principal_id` must be indexed:\n{sql}"
+        );
+    }
+
+    #[test]
+    fn push_migration_is_emitted_for_sqlite_too() {
+        let sql = push_subscriptions_up_sql(DatabaseBackend::Sqlite);
+        assert!(sql.contains("CREATE TABLE"), "{sql}");
+        assert!(
+            !sql.contains("BIGSERIAL"),
+            "SQLite has no BIGSERIAL:\n{sql}"
+        );
+        assert!(
+            !sql.contains("TIMESTAMPTZ"),
+            "the SQLite lane stores RFC 3339 TEXT, matching TimestamptzSqlite:\n{sql}"
+        );
+    }
+
+    #[test]
+    fn push_migration_has_a_matching_down() {
+        let tmp = project_with_main(DEFAULT_MAIN);
+        let plan = plan_pwa(tmp.path()).unwrap();
+        let down = plan
+            .actions
+            .iter()
+            .find(|a| {
+                a.path()
+                    .to_string_lossy()
+                    .contains("create_push_subscriptions")
+                    && a.path().ends_with("down.sql")
+            })
+            .expect("every migration needs a down");
+        let sql = action_contents(down);
+        assert!(sql.contains("DROP TABLE"), "{sql}");
+    }
+
+    #[test]
+    fn re_running_reuses_the_existing_push_migration_directory() {
+        // Two `*_create_push_subscriptions` directories would fail the next
+        // `autumn migrate` on the duplicate table — the same singleton rule
+        // the notifications generator follows.
+        let tmp = project_with_main(DEFAULT_MAIN);
+        plan_pwa(tmp.path())
+            .unwrap()
+            .execute(Flags::default())
+            .unwrap();
+        plan_pwa(tmp.path())
+            .unwrap()
+            .execute(Flags {
+                force: true,
+                ..Flags::default()
+            })
+            .unwrap();
+
+        let dirs: Vec<_> = fs::read_dir(tmp.path().join("migrations"))
+            .unwrap()
+            .filter_map(Result::ok)
+            .filter(|e| {
+                e.file_name()
+                    .to_string_lossy()
+                    .ends_with("_create_push_subscriptions")
+            })
+            .collect();
+        assert_eq!(
+            dirs.len(),
+            1,
+            "re-running must reuse the existing migration directory, not mint a second"
+        );
+    }
+
+    #[test]
+    fn inject_mounts_the_built_in_push_router() {
+        let injected = inject_pwa_into_main(DEFAULT_MAIN);
+        assert!(
+            injected.contains("autumn_web::push::router()"),
+            "without the router mounted the generated client snippet 404s on every \
+             call:\n{injected}"
+        );
+    }
+
+    #[test]
+    fn inject_push_router_is_idempotent() {
+        let once = inject_pwa_into_main(DEFAULT_MAIN);
+        let twice = inject_pwa_into_main(&once);
+        assert_eq!(once, twice);
+        assert_eq!(
+            twice.matches("autumn_web::push::router()").count(),
+            1,
+            "a second run must not mount the router twice:\n{twice}"
+        );
+    }
+
+    #[test]
+    fn generate_then_destroy_removes_the_push_router_mount_too() {
+        let tmp = project_with_main(DEFAULT_MAIN);
+        let main_path = tmp.path().join("src/main.rs");
+        let original_main = fs::read_to_string(&main_path).unwrap();
+
+        plan_pwa(tmp.path())
+            .unwrap()
+            .execute(Flags::default())
+            .unwrap();
+        assert!(
+            fs::read_to_string(&main_path)
+                .unwrap()
+                .contains("autumn_web::push::router()")
+        );
+
+        plan_pwa(tmp.path())
+            .unwrap()
+            .revert(Flags::default())
+            .unwrap();
+        assert_eq!(
+            fs::read_to_string(&main_path).unwrap(),
+            original_main,
+            "destroy must restore main.rs byte-for-byte, router mount included"
+        );
+    }
+
+    #[test]
+    fn dry_run_writes_no_push_files() {
+        let tmp = project_with_main(DEFAULT_MAIN);
+        plan_pwa(tmp.path())
+            .unwrap()
+            .execute(Flags {
+                dry_run: true,
+                ..Flags::default()
+            })
+            .unwrap();
+        assert!(
+            !tmp.path().join("migrations").exists(),
+            "--dry-run must write nothing"
+        );
+        assert!(
+            !fs::read_to_string(tmp.path().join("src/main.rs"))
+                .unwrap()
+                .contains("autumn_web::push::router()")
+        );
     }
 }

--- a/autumn/Cargo.toml
+++ b/autumn/Cargo.toml
@@ -350,6 +350,13 @@ infer = { version = "0.16", optional = true }
 sha1 = { version = "0.10", optional = true }
 rsa = { version = "0.9", default-features = false, features = ["std", "pem"], optional = true }
 aes-gcm = "0.10"
+# NIST P-256 (prime256v1) for Web Push (issue #1392): ES256 VAPID JWT signing
+# (RFC 8292) and the ECDH half of RFC 8291 payload encryption. Adds NO new
+# crate to the graph — `jsonwebtoken` (a non-optional dependency above) already
+# resolves p256 0.13 for its `rust_crypto` ES256 backend; this only adds the
+# direct edge plus the `ecdh` feature, which is a feature flag on the
+# already-compiled `elliptic-curve`, not a new dependency.
+p256 = { version = "0.13", default-features = false, features = ["ecdh", "ecdsa", "std"] }
 getrandom = "0.2"
 hex = "0.4"
 include_dir = { version = "0.7", optional = true }

--- a/autumn/src/app.rs
+++ b/autumn/src/app.rs
@@ -2255,6 +2255,77 @@ impl AppBuilder {
         })
     }
 
+    /// Register a push subscription store, overriding the default resolution
+    /// used by the [`WebPush`] extractor.
+    ///
+    /// Without this call the extractor resolves its store automatically: the
+    /// database-backed
+    /// [`DbPushSubscriptionStore`](crate::push::DbPushSubscriptionStore) when a
+    /// pool is configured (the `push_subscriptions` table is scaffolded by
+    /// `autumn generate pwa`), the process-local
+    /// [`MemoryPushSubscriptionStore`](crate::push::MemoryPushSubscriptionStore)
+    /// otherwise.
+    ///
+    /// # Example
+    ///
+    /// ```rust,ignore
+    /// use autumn_web::push::MemoryPushSubscriptionStore;
+    ///
+    /// autumn_web::app()
+    ///     .with_push_subscription_store(MemoryPushSubscriptionStore::new())
+    ///     .merge(autumn_web::push::router())
+    ///     .run()
+    ///     .await;
+    /// ```
+    ///
+    /// [`WebPush`]: crate::push::WebPush
+    #[must_use]
+    pub fn with_push_subscription_store<S>(self, store: S) -> Self
+    where
+        S: crate::push::PushSubscriptionStore,
+    {
+        self.state_initializer(move |state| {
+            state.insert_extension(crate::push::WebPush::from_state_with_store(state, store));
+        })
+    }
+
+    /// Register a fully-built [`WebPush`] service, overriding key, store,
+    /// transport, TTL and clock at once.
+    ///
+    /// This is the registration path for a **custom
+    /// [`PushTransport`]** — routing push traffic through your own HTTP stack
+    /// or a queue rather than the built-in one — and for supplying a VAPID key
+    /// from somewhere `[push] private_key` cannot reach, such as a secrets
+    /// manager fetched at boot.
+    ///
+    /// # Example
+    ///
+    /// ```rust,ignore
+    /// use autumn_web::push::{MemoryPushSubscriptionStore, VapidKey, WebPush};
+    ///
+    /// let push = WebPush::new(
+    ///     MemoryPushSubscriptionStore::new(),
+    ///     VapidKey::from_base64url(&fetch_key_from_vault().await?)?,
+    ///     "mailto:ops@example.com",
+    ///     MyQueueTransport::new(),
+    /// );
+    ///
+    /// autumn_web::app()
+    ///     .with_web_push(push)
+    ///     .merge(autumn_web::push::router())
+    ///     .run()
+    ///     .await;
+    /// ```
+    ///
+    /// [`WebPush`]: crate::push::WebPush
+    /// [`PushTransport`]: crate::push::PushTransport
+    #[must_use]
+    pub fn with_web_push(self, push: crate::push::WebPush) -> Self {
+        self.state_initializer(move |state| {
+            state.insert_extension(push);
+        })
+    }
+
     /// Register an experiment store with a custom [`ExposureSink`].
     ///
     /// Use when you want to forward exposure events to an analytics pipeline
@@ -3817,6 +3888,20 @@ impl AppBuilder {
         // `unix_socket_cleanup` is the socket to unlink on clean exit (axum does
         // not remove it for us), as `(path, dev, inode)` so cleanup can confirm
         // the file is still the one *this* process bound before removing it.
+        // Load the `[push]` VAPID key once, before binding. A key that is
+        // present but unusable (a typo, an env var that failed to interpolate,
+        // a public/private pair that does not match) is a hard boot failure
+        // rather than a quiet fallback to "push disabled": the failure this
+        // guards against is an app that starts cleanly, records subscriptions,
+        // and silently never delivers anything (issue #1392). An app with no
+        // `[push]` block at all is unaffected.
+        if let Err(e) = config.validate_push() {
+            tracing::error!("Invalid [push] configuration: {e}");
+            #[cfg(feature = "managed-pg")]
+            crate::managed_pg::emergency_stop_async().await;
+            std::process::exit(1);
+        }
+
         // Validate `[server.tls]` wiring before we bind anything, so a
         // misconfiguration is a clear pre-bind failure. Two cases fail fast:
         // (1) the section is present but this binary was built without the

--- a/autumn/src/commentable.rs
+++ b/autumn/src/commentable.rs
@@ -102,7 +102,7 @@ const FOR_NO_KEY_UPDATE: &str = "";
 /// against a bound `BIGINT`.
 ///
 /// `i32` is admitted alongside `i64`: those ids widen losslessly, they parse,
-/// and PostgreSQL compares `INTEGER` to `BIGINT` without complaint, so an
+/// and `PostgreSQL` compares `INTEGER` to `BIGINT` without complaint, so an
 /// `i32`-keyed author model works today and must keep working.
 ///
 /// Sealed, because implementing it for a wider type would re-open exactly the

--- a/autumn/src/config.rs
+++ b/autumn/src/config.rs
@@ -4365,6 +4365,23 @@ impl AutumnConfig {
         self.apply_alerts_env_overrides_with_env(env);
         self.apply_tenancy_env_overrides_with_env(env);
         self.apply_cluster_env_overrides_with_env(env);
+        self.apply_push_env_overrides_with_env(env);
+    }
+
+    /// Web Push (`[push]`) environment overrides.
+    ///
+    /// The private key is the reason this exists: it is a credential, so the
+    /// guide and `PushConfig`'s own docs tell operators to supply it through
+    /// `AUTUMN_PUSH__PRIVATE_KEY` rather than commit it. Overrides are applied
+    /// only through the explicit per-section methods above, so without this one
+    /// that documented deployment path silently leaves push unconfigured —
+    /// every send failing `NotConfigured` and the public-key endpoint serving
+    /// `503`, with the operator looking at a variable they did set.
+    fn apply_push_env_overrides_with_env(&mut self, env: &dyn Env) {
+        parse_env_option_secret(env, "AUTUMN_PUSH__PRIVATE_KEY", &mut self.push.private_key);
+        parse_env_option_string(env, "AUTUMN_PUSH__PUBLIC_KEY", &mut self.push.public_key);
+        parse_env_option_string(env, "AUTUMN_PUSH__SUBJECT", &mut self.push.subject);
+        parse_env_option(env, "AUTUMN_PUSH__TTL_SECS", &mut self.push.ttl_secs);
     }
 
     fn apply_cluster_env_overrides_with_env(&mut self, env: &dyn Env) {

--- a/autumn/src/config.rs
+++ b/autumn/src/config.rs
@@ -4378,7 +4378,21 @@ impl AutumnConfig {
     /// every send failing `NotConfigured` and the public-key endpoint serving
     /// `503`, with the operator looking at a variable they did set.
     fn apply_push_env_overrides_with_env(&mut self, env: &dyn Env) {
-        parse_env_option_secret(env, "AUTUMN_PUSH__PRIVATE_KEY", &mut self.push.private_key);
+        // NOT `parse_env_option_secret`. That helper treats a blank value as
+        // "clear this setting", which is right for a section where unsetting
+        // via env is meaningful — but wrong here, and dangerously so: the
+        // commonest way `AUTUMN_PUSH__PRIVATE_KEY` ends up blank is a secret
+        // that failed to interpolate, and clearing it would silently disable
+        // push, sail through `validate_push`, and surface much later as a
+        // `503` and `NotConfigured` on every send. Worse, it would erase a
+        // perfectly good key from `autumn.toml`.
+        //
+        // So a blank value is PRESERVED, precisely so `load_vapid_key` can
+        // reject it at boot with a message naming the environment variable —
+        // the fail-fast contract this whole subsystem is built on.
+        if let Ok(value) = env.var("AUTUMN_PUSH__PRIVATE_KEY") {
+            self.push.private_key = Some(secrecy::SecretString::from(value));
+        }
         parse_env_option_string(env, "AUTUMN_PUSH__PUBLIC_KEY", &mut self.push.public_key);
         parse_env_option_string(env, "AUTUMN_PUSH__SUBJECT", &mut self.push.subject);
         parse_env_option(env, "AUTUMN_PUSH__TTL_SECS", &mut self.push.ttl_secs);

--- a/autumn/src/config.rs
+++ b/autumn/src/config.rs
@@ -1106,6 +1106,15 @@ pub struct AutumnConfig {
     #[serde(default)]
     pub tenancy: TenancyConfig,
 
+    /// Web Push settings (`[push]` section, issue #1392).
+    ///
+    /// Absent by default. The VAPID key it names is loaded and validated once
+    /// at boot — a key that is present but unusable fails the boot rather than
+    /// leaving the app running with push silently dead. See
+    /// [`crate::push::PushConfig`] and `docs/guide/web-push.md`.
+    #[serde(default)]
+    pub push: crate::push::PushConfig,
+
     /// HTTP idempotency-key middleware settings.
     #[serde(default)]
     pub idempotency: IdempotencyConfig,
@@ -3268,6 +3277,22 @@ const MANUAL_SCHEMA_SECTIONS: &[(&str, &[&str])] = &[
     // `crate::time_zone::TimeZoneConfig` — untagged Scalar|Table.
     ("time_zone", &["identifier", "sources"]),
 ];
+
+impl AutumnConfig {
+    /// Validate the `[push]` block, as `AppBuilder::run` does before binding.
+    ///
+    /// Factored out of the boot path so the rule it enforces — a VAPID key
+    /// that is present but unusable is a hard failure, never a quiet fallback
+    /// to "push disabled" — is reachable from a test. `run` calls exactly this
+    /// and exits on `Err`.
+    ///
+    /// # Errors
+    ///
+    /// See [`crate::push::PushConfig::load_vapid_key`].
+    pub fn validate_push(&self) -> Result<(), crate::push::PushError> {
+        self.push.load_vapid_key().map(|_| ())
+    }
+}
 
 impl AutumnConfig {
     /// Recursively extracts all valid configuration schema keys and nested fields.

--- a/autumn/src/current.rs
+++ b/autumn/src/current.rs
@@ -110,6 +110,20 @@ impl Current {
         }
     }
 
+    /// The actor published on the **current scope**, with no process-wide
+    /// default fallback.
+    ///
+    /// [`actor`](Self::actor) reads the configured default when no scope is in
+    /// effect, which is right for attributing background writes but wrong for
+    /// authorizing a request: a route that resolves "who is calling" from the
+    /// ambient actor must see `None` for an unauthenticated caller, never a
+    /// job runner's identity. Used by the Web Push subscribe/unsubscribe
+    /// routes for exactly that reason.
+    #[must_use]
+    pub(crate) fn scoped_actor() -> Option<String> {
+        CURRENT_ACTOR.try_with(ActorScope::get).ok().flatten()
+    }
+
     /// Publish the authenticated principal onto the current request scope.
     ///
     /// Called by the auth layer right after it resolves the user id (next to

--- a/autumn/src/error.rs
+++ b/autumn/src/error.rs
@@ -185,6 +185,15 @@ where
             }
         }
 
+        // Web Push (#1392) distinguishes client-fault failures (a malformed
+        // browser subscription, an endpoint already claimed) from server-fault
+        // ones, so an app calling `push.subscribe(…).await?` from its own
+        // handler gets the same status the built-in push router would return
+        // rather than a blanket 500.
+        if let Some(push_err) = any_err.downcast_ref::<crate::push::PushError>() {
+            status = push_err.status();
+        }
+
         if matches!(
             any_err.downcast_ref::<crate::lock::LockError>(),
             Some(

--- a/autumn/src/http_client.rs
+++ b/autumn/src/http_client.rs
@@ -1024,6 +1024,7 @@ impl Client {
             redirect_mode: RedirectMode::Default,
             pin_addr: None,
             ssrf_safe: false,
+            discard_response_body: false,
         }
     }
 
@@ -1178,6 +1179,9 @@ pub struct RequestBuilder {
     /// When `true`, use the composed SSRF-safe send path (resolve→validate→pin
     /// with per-hop redirect validation). Set by [`Client::get_ssrf_safe`].
     ssrf_safe: bool,
+    /// When `true`, the response body is dropped unread. See
+    /// [`RequestBuilder::discard_response_body`].
+    discard_response_body: bool,
 }
 
 impl RequestBuilder {
@@ -1278,6 +1282,25 @@ impl RequestBuilder {
     #[must_use]
     pub fn no_redirect(mut self) -> Self {
         self.redirect_mode = RedirectMode::None;
+        self
+    }
+
+    /// Return the status and headers without reading the response body.
+    ///
+    /// Every other path collects the whole body into memory with no ceiling,
+    /// which is the right default for an API call whose payload the caller
+    /// wants. It is the wrong default when the *remote host* is untrusted and
+    /// the caller needs only the status: a server that streams indefinitely
+    /// then costs one unbounded allocation per request until the timeout
+    /// fires.
+    ///
+    /// Web Push is exactly that shape — the endpoint URL is chosen by the
+    /// client, and the transport only ever reads the status code — so it sets
+    /// this. [`Response::bytes`] then returns empty; dropping the underlying
+    /// response closes the connection without draining it.
+    #[must_use]
+    pub const fn discard_response_body(mut self) -> Self {
+        self.discard_response_body = true;
         self
     }
 
@@ -1552,10 +1575,14 @@ impl RequestBuilder {
                         continue;
                     }
 
-                    let body = resp
-                        .bytes()
-                        .await
-                        .map_err(|e| ClientError::Request(e.without_url()))?;
+                    let body = if self.discard_response_body {
+                        // Dropped unread — see `discard_response_body`.
+                        Bytes::new()
+                    } else {
+                        resp.bytes()
+                            .await
+                            .map_err(|e| ClientError::Request(e.without_url()))?
+                    };
                     let elapsed = start.elapsed();
                     log_request(
                         self.method.as_str(),
@@ -1679,6 +1706,7 @@ impl RequestBuilder {
             &self.extra_headers,
             self.body.as_ref(),
             &self.retry_policy,
+            self.discard_response_body,
         )
         .await
     }
@@ -1731,6 +1759,7 @@ impl RequestBuilder {
                 &headers,
                 body.as_ref(),
                 &self.retry_policy,
+                self.discard_response_body,
             )
             .await?;
 
@@ -1809,6 +1838,7 @@ impl RequestBuilder {
                 &headers,
                 body.as_ref(),
                 &self.retry_policy,
+                self.discard_response_body,
             )
             .await?;
 
@@ -1910,6 +1940,7 @@ async fn send_one(
     extra_headers: &HeaderMap,
     body: Option<&Bytes>,
     retry_policy: &RetryPolicy,
+    discard_response_body: bool,
 ) -> Result<Response, ClientError> {
     let start = Instant::now();
     let max_attempts = if is_idempotent_method(method) || !retry_policy.retry_idempotent_only {
@@ -1954,10 +1985,14 @@ async fn send_one(
                     continue;
                 }
 
-                let body = resp
-                    .bytes()
-                    .await
-                    .map_err(|e| ClientError::Request(e.without_url()))?;
+                let body = if discard_response_body {
+                    // Dropped unread — see `RequestBuilder::discard_response_body`.
+                    Bytes::new()
+                } else {
+                    resp.bytes()
+                        .await
+                        .map_err(|e| ClientError::Request(e.without_url()))?
+                };
                 log_request(
                     method.as_str(),
                     &url_used,

--- a/autumn/src/http_client.rs
+++ b/autumn/src/http_client.rs
@@ -1232,6 +1232,18 @@ impl RequestBuilder {
         self
     }
 
+    /// Set a raw byte body, without assuming any content type.
+    ///
+    /// Use this for binary payloads — [`text_body`](Self::text_body) takes a
+    /// `String` and so cannot carry bytes that are not valid UTF-8. Set the
+    /// content type yourself with [`header`](Self::header). The Web Push
+    /// transport uses this for RFC 8291-encrypted bodies.
+    #[must_use]
+    pub fn bytes_body(mut self, body: impl Into<Bytes>) -> Self {
+        self.body = Some(body.into());
+        self
+    }
+
     /// Override the maximum retry count for this request.
     ///
     /// Also clears the idempotent-only flag so non-idempotent methods such as

--- a/autumn/src/lib.rs
+++ b/autumn/src/lib.rs
@@ -435,6 +435,12 @@ pub mod pdf;
 /// [`preload::Preloadable`] trait that generated code implements.
 pub mod preload;
 pub mod prelude;
+/// Web Push: VAPID key handling, RFC 8291 payload encryption, subscription
+/// storage, and a built-in subscribe/unsubscribe router (#1392).
+///
+/// See [`push::WebPush`] for the send API and [`push::router`] for the
+/// built-in endpoints.
+pub mod push;
 /// Compile-time per-route database query budgets (#1667).
 ///
 /// See [`query_budget::StaticQueryBudget`] and the

--- a/autumn/src/lib.rs
+++ b/autumn/src/lib.rs
@@ -435,11 +435,11 @@ pub mod pdf;
 /// [`preload::Preloadable`] trait that generated code implements.
 pub mod preload;
 pub mod prelude;
-/// Web Push: VAPID key handling, RFC 8291 payload encryption, subscription
-/// storage, and a built-in subscribe/unsubscribe router (#1392).
-///
-/// See [`push::WebPush`] for the send API and [`push::router`] for the
-/// built-in endpoints.
+// Declared bare, like `notifications`: the module carries its own `//!` docs,
+// and an outer doc comment here would make rustdoc resolve that whole
+// combined block in the CRATE-ROOT scope — where `WebPush`, `PushError` and
+// friends are not in scope, breaking every intra-doc link in the module and
+// failing the `-D rustdoc::broken_intra_doc_links` docs gate.
 pub mod push;
 /// Compile-time per-route database query budgets (#1667).
 ///

--- a/autumn/src/pagination.rs
+++ b/autumn/src/pagination.rs
@@ -759,6 +759,13 @@ const BASE64URL_ALPHABET: &[u8; 64] =
 // exact MSRV — CI builds a `1.88.0` lane, so adopting it leaves zero margin for
 // an MSRV the project may want to hold. Not a trade worth making for an
 // incidental cleanup; revisit when the MSRV moves past 1.88.
+//
+// `unknown_lints` is allowed alongside it because the lint below does NOT exist
+// on every toolchain the workspace is built with (it was added in 1.98, and the
+// MSRV lane is 1.88). Without this, naming it is itself a `-D warnings` failure
+// on any older toolchain — the allow has to be forward- *and* backward-
+// compatible to be useful.
+#[allow(unknown_lints)]
 #[allow(clippy::chunks_exact_to_as_chunks)]
 fn base64url_encode(input: &[u8]) -> String {
     let mut out = String::with_capacity(input.len().div_ceil(3) * 4);

--- a/autumn/src/prelude.rs
+++ b/autumn/src/prelude.rs
@@ -267,6 +267,10 @@ pub use crate::log::context::with_log_field;
 /// In-app notifications service/extractor (persistent per-recipient feed
 /// with read/unread state). See [`crate::notifications`] for the full surface.
 pub use crate::notifications::Notifications;
+/// Web Push service/extractor (deliver a notification to a subscribed browser
+/// even when the app's tab is closed). See [`crate::push`] for the full
+/// surface.
+pub use crate::push::{PushMessage, WebPush};
 /// Session extractor for accessing per-user session data.
 pub use crate::session::Session;
 /// Tenant extractor and context helpers.

--- a/autumn/src/push/config.rs
+++ b/autumn/src/push/config.rs
@@ -1,0 +1,281 @@
+//! The `[push]` configuration block.
+//!
+//! ```toml
+//! [push]
+//! # Mint one offline with `VapidKey::generate()`; keep it secret.
+//! private_key = "…"
+//! # Optional: declare the matching public half so a mismatched pair is
+//! # caught at boot instead of at the first (silently rejected) send.
+//! public_key  = "…"
+//! # RFC 8292 `sub` claim: how a push service operator reaches you.
+//! subject     = "mailto:ops@example.com"
+//! # Optional: how long a push service may hold an undelivered message.
+//! ttl_secs    = 2419200
+//! ```
+//!
+//! The key is loaded **once, at boot**. A key that is present but unusable is
+//! a hard error rather than a quiet fallback to "push disabled": the whole
+//! failure mode this guards against is an app that starts cleanly, accepts
+//! subscriptions, and never delivers anything.
+
+use secrecy::{ExposeSecret as _, SecretString};
+use serde::Deserialize;
+
+use super::{PushError, VapidKey};
+
+/// The default VAPID `sub` claim when none is configured.
+///
+/// RFC 8292 requires a `mailto:` or `https:` URL — a push service may reject
+/// the message outright otherwise — so the default is a syntactically valid
+/// placeholder rather than an empty string. Set `[push] subject` to something
+/// an operator can actually reach you at.
+pub const DEFAULT_VAPID_SUBJECT: &str = "mailto:admin@localhost";
+
+/// Web Push settings (`[push]` section in `autumn.toml`).
+///
+/// Absent by default, so an app that never sends a push is unaffected.
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct PushConfig {
+    /// The VAPID private key: a base64url-encoded 32-byte P-256 scalar.
+    ///
+    /// Supply it from an environment variable (`AUTUMN_PUSH__PRIVATE_KEY`) or
+    /// the encrypted credentials store rather than committing it.
+    ///
+    /// Held as a [`SecretString`] for the same reason `cluster.secret` and
+    /// `tenancy.jwt_secret` are: `AutumnConfig` derives `Debug` and is
+    /// reachable from every handler, so one `tracing::debug!(?config)` or one
+    /// panic message would otherwise put the signing key into the log
+    /// pipeline.
+    #[serde(default)]
+    pub private_key: Option<SecretString>,
+
+    /// The matching public key, base64url-encoded.
+    ///
+    /// Optional and purely a **safety check**: the public half is always
+    /// derived from the private one, so declaring it only serves to catch a
+    /// mismatched pair at boot. That is worth catching, because a mismatch
+    /// otherwise surfaces as every send being rejected by the push service
+    /// with no local symptom at all.
+    #[serde(default)]
+    pub public_key: Option<String>,
+
+    /// The VAPID `sub` claim: a `mailto:` or `https:` URL a push service
+    /// operator can use to contact you about your traffic. Defaults to
+    /// [`DEFAULT_VAPID_SUBJECT`].
+    #[serde(default)]
+    pub subject: Option<String>,
+
+    /// How long (seconds) a push service may hold an undelivered message.
+    /// Defaults to [`DEFAULT_TTL_SECS`](super::service::DEFAULT_TTL_SECS).
+    #[serde(default)]
+    pub ttl_secs: Option<u32>,
+}
+
+impl PushConfig {
+    /// Load and validate the configured VAPID key.
+    ///
+    /// Returns `Ok(None)` only when **nothing** is configured. Anything that
+    /// looks like an attempt to configure push and cannot work is an error.
+    ///
+    /// # Errors
+    ///
+    /// - [`PushError::InvalidVapidKey`] when `private_key` is present but not
+    ///   a valid P-256 scalar — including when it is empty, which almost
+    ///   always means an environment variable failed to interpolate.
+    /// - [`PushError::InvalidConfig`] when `public_key` is set without a
+    ///   `private_key`, or does not match the key derived from it.
+    pub fn load_vapid_key(&self) -> Result<Option<VapidKey>, PushError> {
+        let private = self
+            .private_key
+            .as_ref()
+            .map(|key| key.expose_secret().trim());
+        let declared_public = self.public_key.as_deref().map(str::trim);
+
+        let Some(private) = private else {
+            if declared_public.is_some_and(|key| !key.is_empty()) {
+                return Err(PushError::InvalidConfig(
+                    "`[push] public_key` is set without a `private_key`. The public half is \
+                     derived from the private one, so a public key alone can never send \
+                     anything — set `private_key` too, or drop both."
+                        .to_owned(),
+                ));
+            }
+            return Ok(None);
+        };
+
+        // Deliberately NOT treated as absent: an empty value is a set value
+        // that failed to interpolate, and silently disabling push there is the
+        // exact failure this whole path exists to prevent.
+        if private.is_empty() {
+            return Err(PushError::InvalidVapidKey(
+                "`[push] private_key` is empty. If it comes from an environment variable, \
+                 that variable is unset or blank in this environment."
+                    .to_owned(),
+            ));
+        }
+
+        let key = VapidKey::from_base64url(private)?;
+
+        if let Some(declared) = declared_public.filter(|key| !key.is_empty()) {
+            let derived = key.public_key_base64url();
+            if declared != derived {
+                return Err(PushError::InvalidConfig(format!(
+                    "`[push] public_key` does not match the key derived from `private_key` \
+                     (configured `{declared}`, derived `{derived}`). Browsers subscribe with \
+                     the public key and the push service validates against the private one, \
+                     so a mismatched pair means every send is rejected. Update `public_key` \
+                     to the derived value, or remove it."
+                )));
+            }
+        }
+
+        Ok(Some(key))
+    }
+
+    /// The configured `sub` claim, or [`DEFAULT_VAPID_SUBJECT`].
+    #[must_use]
+    pub fn subject_or_default(&self) -> String {
+        self.subject
+            .as_deref()
+            .map(str::trim)
+            .filter(|subject| !subject.is_empty())
+            .unwrap_or(DEFAULT_VAPID_SUBJECT)
+            .to_owned()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn config(toml: &str) -> PushConfig {
+        toml::from_str(toml).expect("config parses")
+    }
+
+    #[test]
+    fn an_absent_block_configures_no_key() {
+        let key = config("")
+            .load_vapid_key()
+            .expect("an absent [push] is fine");
+        assert!(
+            key.is_none(),
+            "an app that never configured push must still boot"
+        );
+    }
+
+    #[test]
+    fn a_valid_private_key_is_loaded() {
+        let generated = VapidKey::generate();
+        let loaded = config(&format!(
+            "private_key = \"{}\"",
+            generated.private_key_base64url()
+        ))
+        .load_vapid_key()
+        .expect("valid key loads")
+        .expect("a key is present");
+        assert_eq!(
+            loaded.public_key_base64url(),
+            generated.public_key_base64url()
+        );
+    }
+
+    #[test]
+    fn an_invalid_private_key_fails_fast_rather_than_silently_disabling_push() {
+        // The whole point: a typo'd key must stop the boot, not leave the app
+        // running with push quietly dead.
+        let err = config("private_key = \"obviously-not-a-key\"")
+            .load_vapid_key()
+            .expect_err("an invalid key is a hard error");
+        assert!(matches!(err, PushError::InvalidVapidKey(_)), "{err:?}");
+    }
+
+    #[test]
+    fn an_empty_private_key_is_rejected_not_treated_as_absent() {
+        // `private_key = ""` reads as "I meant to set this" — most often an
+        // env var that failed to interpolate. Treating it as absent would
+        // silently disable push in exactly the deployment that needed it.
+        let err = config("private_key = \"\"")
+            .load_vapid_key()
+            .expect_err("an empty key is an error, not an absent one");
+        assert!(matches!(err, PushError::InvalidVapidKey(_)), "{err:?}");
+    }
+
+    #[test]
+    fn a_declared_public_key_must_match_the_private_one() {
+        // A mismatched pair is the nastiest possible failure: the browser
+        // subscribes under one key, the server signs with another, and every
+        // send is rejected by the push service with no clue why.
+        let generated = VapidKey::generate();
+        let other = VapidKey::generate();
+        let err = config(&format!(
+            "private_key = \"{}\"\npublic_key = \"{}\"",
+            generated.private_key_base64url(),
+            other.public_key_base64url()
+        ))
+        .load_vapid_key()
+        .expect_err("a mismatched pair is refused");
+        assert!(matches!(err, PushError::InvalidConfig(_)), "{err:?}");
+        assert!(
+            err.to_string().contains("public_key"),
+            "the error must name the offending key: {err}"
+        );
+    }
+
+    #[test]
+    fn a_matching_public_key_is_accepted() {
+        let generated = VapidKey::generate();
+        config(&format!(
+            "private_key = \"{}\"\npublic_key = \"{}\"",
+            generated.private_key_base64url(),
+            generated.public_key_base64url()
+        ))
+        .load_vapid_key()
+        .expect("a matching declared pair is fine");
+    }
+
+    #[test]
+    fn a_public_key_without_a_private_one_is_rejected() {
+        // Public-key-only would mean the browser can subscribe but nothing can
+        // ever be sent — a configuration that cannot work.
+        let err = config(&format!(
+            "public_key = \"{}\"",
+            VapidKey::generate().public_key_base64url()
+        ))
+        .load_vapid_key()
+        .expect_err("public-only is refused");
+        assert!(matches!(err, PushError::InvalidConfig(_)), "{err:?}");
+    }
+
+    #[test]
+    fn surrounding_whitespace_in_a_key_is_tolerated() {
+        // Keys arrive via env vars and shell here-docs; a trailing newline is
+        // not a configuration error.
+        let generated = VapidKey::generate();
+        config(&format!(
+            "private_key = \"  {}\\n\"",
+            generated.private_key_base64url()
+        ))
+        .load_vapid_key()
+        .expect("whitespace is trimmed")
+        .expect("key present");
+    }
+
+    #[test]
+    fn subject_defaults_to_a_valid_vapid_sub_claim() {
+        // RFC 8292 requires `sub` to be a mailto: or https: URL; a push
+        // service may reject anything else.
+        let subject = PushConfig::default().subject_or_default();
+        assert!(
+            subject.starts_with("mailto:") || subject.starts_with("https://"),
+            "the default sub must be a valid VAPID subject, got {subject}"
+        );
+    }
+
+    #[test]
+    fn a_configured_subject_wins() {
+        assert_eq!(
+            config("subject = \"mailto:ops@example.com\"").subject_or_default(),
+            "mailto:ops@example.com"
+        );
+    }
+}

--- a/autumn/src/push/config.rs
+++ b/autumn/src/push/config.rs
@@ -71,6 +71,20 @@ pub struct PushConfig {
     pub ttl_secs: Option<u32>,
 }
 
+/// Whether `subject` is a VAPID `sub` claim a push service will accept.
+///
+/// RFC 8292 §2.1 requires a `mailto:` or `https:` URI — it is how a push
+/// service operator reaches you about your traffic, so a bare email address or
+/// a name is not enough.
+fn is_valid_vapid_subject(subject: &str) -> bool {
+    let subject = subject.trim();
+    if let Some(rest) = subject.strip_prefix("mailto:") {
+        // `mailto:` with nothing after it names nobody.
+        return rest.contains('@') && !rest.starts_with('@') && !rest.ends_with('@');
+    }
+    url::Url::parse(subject).is_ok_and(|parsed| parsed.scheme() == "https" && parsed.has_host())
+}
+
 impl PushConfig {
     /// Load and validate the configured VAPID key.
     ///
@@ -129,7 +143,31 @@ impl PushConfig {
             }
         }
 
+        // A `sub` the push services will reject is just as fatal as a bad key,
+        // and just as invisible: the app boots, signs happily, and every
+        // delivery is refused remotely. Validate it here so it fails the boot
+        // alongside the key rather than in production.
+        self.validated_subject()?;
+
         Ok(Some(key))
+    }
+
+    /// The configured `sub` claim, checked against what RFC 8292 permits.
+    ///
+    /// # Errors
+    ///
+    /// [`PushError::InvalidConfig`] when `subject` is set to something that is
+    /// neither a `mailto:` nor an `https:` URI.
+    pub fn validated_subject(&self) -> Result<String, PushError> {
+        let subject = self.subject_or_default();
+        if !is_valid_vapid_subject(&subject) {
+            return Err(PushError::InvalidConfig(format!(
+                "`[push] subject` must be a `mailto:` or `https:` URI (RFC 8292 §2.1), got \
+                 `{subject}`. A push service may reject every message signed with anything \
+                 else, so this is refused at boot rather than in production."
+            )));
+        }
+        Ok(subject)
     }
 
     /// The configured `sub` claim, or [`DEFAULT_VAPID_SUBJECT`].
@@ -277,5 +315,82 @@ mod tests {
             config("subject = \"mailto:ops@example.com\"").subject_or_default(),
             "mailto:ops@example.com"
         );
+    }
+    // ── Subject validation (RFC 8292 §2.1) ──────────────────────────────────
+
+    #[test]
+    fn a_bare_email_address_is_not_a_valid_subject() {
+        // The commonest mistake, and the most invisible: the app boots, signs
+        // happily, and every push service refuses the delivery.
+        let err = config("subject = \"ops@example.com\"")
+            .validated_subject()
+            .expect_err("a bare address is not a `mailto:` URI");
+        assert!(matches!(err, PushError::InvalidConfig(_)), "{err:?}");
+        assert!(
+            err.to_string().contains("mailto:"),
+            "the error must say what a valid subject looks like: {err}"
+        );
+    }
+
+    #[test]
+    fn mailto_and_https_subjects_are_accepted() {
+        for subject in [
+            "mailto:ops@example.com",
+            "https://example.com/contact",
+            "  mailto:ops@example.com  ",
+        ] {
+            config(&format!("subject = \"{}\"", subject.replace('"', "")))
+                .validated_subject()
+                .unwrap_or_else(|e| panic!("{subject} must be accepted, got {e}"));
+        }
+    }
+
+    #[test]
+    fn a_subject_with_a_wrong_scheme_is_rejected() {
+        // `http://` in particular: the point of the `sub` claim is that a push
+        // service operator can reach the sender, and RFC 8292 names only
+        // `mailto:` and `https:`.
+        for subject in ["http://example.com", "tel:+15550100", "example.com"] {
+            let err = config(&format!("subject = \"{subject}\""))
+                .validated_subject()
+                .expect_err("this subject must be refused");
+            assert!(
+                matches!(err, PushError::InvalidConfig(_)),
+                "{subject}: {err:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_malformed_mailto_is_rejected() {
+        for subject in ["mailto:", "mailto:@example.com", "mailto:ops@"] {
+            assert!(
+                config(&format!("subject = \"{subject}\""))
+                    .validated_subject()
+                    .is_err(),
+                "{subject} must be refused"
+            );
+        }
+    }
+
+    #[test]
+    fn the_default_subject_passes_its_own_validation() {
+        PushConfig::default()
+            .validated_subject()
+            .expect("the shipped default must itself be a valid VAPID subject");
+    }
+
+    #[test]
+    fn an_invalid_subject_fails_the_boot_alongside_the_key() {
+        // `load_vapid_key` is what `AutumnConfig::validate_push` calls, so the
+        // subject has to be checked there or a bad one boots cleanly.
+        let key = VapidKey::generate();
+        let err = config(&format!(
+            "private_key = \"{}\"\nsubject = \"nonsense\"",
+            key.private_key_base64url()
+        ))
+        .load_vapid_key()
+        .expect_err("an invalid subject is a boot failure");
+        assert!(matches!(err, PushError::InvalidConfig(_)), "{err:?}");
     }
 }

--- a/autumn/src/push/config.rs
+++ b/autumn/src/push/config.rs
@@ -76,7 +76,7 @@ pub struct PushConfig {
 /// RFC 8292 §2.1 requires a `mailto:` or `https:` URI — it is how a push
 /// service operator reaches you about your traffic, so a bare email address or
 /// a name is not enough.
-fn is_valid_vapid_subject(subject: &str) -> bool {
+pub(super) fn is_valid_vapid_subject(subject: &str) -> bool {
     let subject = subject.trim();
     if let Some(rest) = subject.strip_prefix("mailto:") {
         // `mailto:` with nothing after it names nobody.
@@ -122,8 +122,11 @@ impl PushConfig {
         // exact failure this whole path exists to prevent.
         if private.is_empty() {
             return Err(PushError::InvalidVapidKey(
-                "`[push] private_key` is empty. If it comes from an environment variable, \
-                 that variable is unset or blank in this environment."
+                "`[push] private_key` is empty. The commonest cause is \
+                 `AUTUMN_PUSH__PRIVATE_KEY` being set to a secret that failed to \
+                 interpolate in this environment — a blank value is refused rather than \
+                 treated as \"push disabled\", because silently disabling delivery is \
+                 exactly the failure this check exists to prevent."
                     .to_owned(),
             ));
         }

--- a/autumn/src/push/encryption.rs
+++ b/autumn/src/push/encryption.rs
@@ -52,7 +52,7 @@ const LAST_RECORD_DELIMITER: u8 = 0x02;
 /// Everything Autumn sends is a single record, so this only needs to exceed
 /// the record's own length; 4096 is the value RFC 8291's example uses and the
 /// one every push service is required to accept.
-pub(crate) const RECORD_SIZE: u32 = 4096;
+pub const RECORD_SIZE: u32 = 4096;
 
 /// The largest plaintext that still fits an encrypted body of [`RECORD_SIZE`].
 ///
@@ -60,8 +60,7 @@ pub(crate) const RECORD_SIZE: u32 = 4096;
 /// required to accept 4096 octets, so exceeding this is refused up front with
 /// [`PushError::PayloadTooLarge`] rather than dispatched and rejected
 /// remotely.
-pub(crate) const MAX_PLAINTEXT_LEN: usize =
-    RECORD_SIZE as usize - HEADER_LEN - 1 - TAG_LEN;
+pub const MAX_PLAINTEXT_LEN: usize = RECORD_SIZE as usize - HEADER_LEN - 1 - TAG_LEN;
 
 /// Encrypt `plaintext` for a subscription, minting a fresh salt and ephemeral
 /// key pair.
@@ -71,7 +70,7 @@ pub(crate) const MAX_PLAINTEXT_LEN: usize =
 /// [`PushError::InvalidSubscriptionKey`] for a malformed `p256dh`/`auth`,
 /// [`PushError::PayloadTooLarge`] past [`MAX_PLAINTEXT_LEN`], and
 /// [`PushError::Encryption`] if AES-GCM itself fails.
-pub(crate) fn encrypt(
+pub fn encrypt(
     plaintext: &[u8],
     ua_public: &[u8],
     auth_secret: &[u8],
@@ -83,7 +82,7 @@ pub(crate) fn encrypt(
     rand::TryRngCore::try_fill_bytes(&mut rand::rngs::OsRng, &mut salt)
         .map_err(|e| PushError::Encryption(format!("could not draw a random salt: {e}")))?;
     let ephemeral = p256::SecretKey::random(&mut p256::elliptic_curve::rand_core::OsRng);
-    encrypt_with(plaintext, ua_public, auth_secret, salt, ephemeral)
+    encrypt_with(plaintext, ua_public, auth_secret, salt, &ephemeral)
 }
 
 /// [`encrypt`] with the salt and ephemeral key supplied by the caller.
@@ -95,12 +94,12 @@ pub(crate) fn encrypt(
 /// # Errors
 ///
 /// See [`encrypt`].
-pub(crate) fn encrypt_with(
+pub fn encrypt_with(
     plaintext: &[u8],
     ua_public: &[u8],
     auth_secret: &[u8],
     salt: [u8; 16],
-    ephemeral: p256::SecretKey,
+    ephemeral: &p256::SecretKey,
 ) -> Result<Vec<u8>, PushError> {
     if plaintext.len() > MAX_PLAINTEXT_LEN {
         return Err(PushError::PayloadTooLarge {
@@ -163,10 +162,7 @@ pub(crate) fn encrypt_with(
     body.extend_from_slice(&salt);
     body.extend_from_slice(&RECORD_SIZE.to_be_bytes());
     // The key id length is a single octet; a P-256 point is always 65 bytes.
-    body.push(
-        u8::try_from(P256_UNCOMPRESSED_LEN)
-            .expect("65 fits in a u8"),
-    );
+    body.push(u8::try_from(P256_UNCOMPRESSED_LEN).expect("65 fits in a u8"));
     body.extend_from_slice(as_public);
     body.extend_from_slice(&ciphertext);
     Ok(body)
@@ -179,11 +175,12 @@ pub(crate) fn encrypt_with(
 /// than adding the `hkdf` crate for ~15 lines. Every output Web Push needs is
 /// at most 32 bytes, i.e. a single expansion block, but the loop is written
 /// generally so the RFC 5869 test vectors (which go to 42 bytes) exercise it.
-pub(crate) fn hkdf_sha256(salt: &[u8], ikm: &[u8], info: &[u8], len: usize) -> Vec<u8> {
+pub fn hkdf_sha256(salt: &[u8], ikm: &[u8], info: &[u8], len: usize) -> Vec<u8> {
     type HmacSha256 = Hmac<Sha256>;
 
     // Extract: PRK = HMAC(salt, IKM). `new_from_slice` accepts any key length.
-    let mut extract = <HmacSha256 as Mac>::new_from_slice(salt).expect("HMAC accepts any key length");
+    let mut extract =
+        <HmacSha256 as Mac>::new_from_slice(salt).expect("HMAC accepts any key length");
     extract.update(ikm);
     let prk = extract.finalize().into_bytes();
 
@@ -192,7 +189,8 @@ pub(crate) fn hkdf_sha256(salt: &[u8], ikm: &[u8], info: &[u8], len: usize) -> V
     let mut previous: Vec<u8> = Vec::new();
     let mut counter: u8 = 1;
     while okm.len() < len {
-        let mut expand = <HmacSha256 as Mac>::new_from_slice(&prk).expect("HMAC accepts any key length");
+        let mut expand =
+            <HmacSha256 as Mac>::new_from_slice(&prk).expect("HMAC accepts any key length");
         expand.update(&previous);
         expand.update(info);
         expand.update(&[counter]);
@@ -256,7 +254,7 @@ mod tests {
             &b64(RFC_UA_PUBLIC),
             &b64(RFC_AUTH_SECRET),
             rfc_salt(),
-            rfc_ephemeral(),
+            &rfc_ephemeral(),
         )
         .expect("encrypting the RFC vector succeeds");
 
@@ -275,7 +273,7 @@ mod tests {
             &b64(RFC_UA_PUBLIC),
             &b64(RFC_AUTH_SECRET),
             rfc_salt(),
-            rfc_ephemeral(),
+            &rfc_ephemeral(),
         )
         .expect("encrypt");
 
@@ -363,8 +361,8 @@ mod tests {
 
     #[test]
     fn rejects_a_wrong_length_auth_secret() {
-        let err = encrypt(b"hi", &b64(RFC_UA_PUBLIC), &[0_u8; 8])
-            .expect_err("auth is exactly 16 bytes");
+        let err =
+            encrypt(b"hi", &b64(RFC_UA_PUBLIC), &[0_u8; 8]).expect_err("auth is exactly 16 bytes");
         assert!(
             matches!(err, PushError::InvalidSubscriptionKey(_)),
             "{err:?}"
@@ -377,10 +375,7 @@ mod tests {
         let too_big = vec![b'x'; MAX_PLAINTEXT_LEN + 1];
         let err = encrypt(&too_big, &b64(RFC_UA_PUBLIC), &b64(RFC_AUTH_SECRET))
             .expect_err("oversize payloads are refused, not silently truncated");
-        assert!(
-            matches!(err, PushError::PayloadTooLarge { .. }),
-            "{err:?}"
-        );
+        assert!(matches!(err, PushError::PayloadTooLarge { .. }), "{err:?}");
     }
 
     #[test]

--- a/autumn/src/push/encryption.rs
+++ b/autumn/src/push/encryption.rs
@@ -1,0 +1,404 @@
+//! RFC 8291 "Message Encryption for Web Push" over the RFC 8188 `aes128gcm`
+//! content coding.
+//!
+//! A Web Push payload is encrypted *for the browser*, not for the push
+//! service: the push service is an untrusted relay that only ever sees
+//! ciphertext. The receiving user agent publishes two values in its
+//! `PushSubscription` — a P-256 public key (`p256dh`) and a 16-byte
+//! authentication secret (`auth`) — and RFC 8291 combines them with a
+//! per-message ephemeral key pair to derive the content encryption key.
+//!
+//! Per message:
+//!
+//! 1. Mint a fresh ephemeral P-256 key pair (the "application server" key).
+//! 2. ECDH it against the subscription's `p256dh` to get a shared secret.
+//! 3. `IKM = HKDF(salt = auth, ikm = ecdh, info = "WebPush: info\0" ‖ ua ‖ as, 32)`
+//! 4. Mint a fresh random 16-byte `salt`, then derive from `HKDF(salt, IKM, …)`
+//!    the 16-byte content encryption key (`"Content-Encoding: aes128gcm\0"`)
+//!    and the 12-byte nonce (`"Content-Encoding: nonce\0"`).
+//! 5. AES-128-GCM the plaintext with a trailing `0x02` record delimiter.
+//! 6. Frame it: `salt(16) ‖ rs(4, BE) ‖ idlen(1) ‖ as_public(65) ‖ ciphertext`.
+//!
+//! Both the salt and the ephemeral key MUST be fresh per message — reuse
+//! would repeat the AES-GCM (key, nonce) pair across messages, which destroys
+//! confidentiality. [`encrypt`] is the only entry point application code
+//! reaches; [`encrypt_with`] exists so the RFC's published test vector can be
+//! reproduced exactly.
+
+use aes_gcm::aead::{Aead, KeyInit, Payload};
+use aes_gcm::{Aes128Gcm, Key, Nonce};
+use hmac::{Hmac, Mac};
+use p256::elliptic_curve::sec1::ToEncodedPoint;
+use sha2::Sha256;
+
+use super::PushError;
+use super::vapid::P256_UNCOMPRESSED_LEN;
+
+/// Length of the `auth` secret a browser publishes (RFC 8291 §3.2).
+const AUTH_SECRET_LEN: usize = 16;
+/// Length of the per-message content encryption key (AES-128).
+const CEK_LEN: usize = 16;
+/// Length of the AES-GCM nonce.
+const NONCE_LEN: usize = 12;
+/// Length of the AES-GCM authentication tag.
+const TAG_LEN: usize = 16;
+/// Bytes of framing before the ciphertext: salt ‖ rs ‖ idlen ‖ key.
+const HEADER_LEN: usize = 16 + 4 + 1 + P256_UNCOMPRESSED_LEN;
+/// RFC 8188 delimiter marking the final record.
+const LAST_RECORD_DELIMITER: u8 = 0x02;
+
+/// The `rs` (record size) written into the header.
+///
+/// Everything Autumn sends is a single record, so this only needs to exceed
+/// the record's own length; 4096 is the value RFC 8291's example uses and the
+/// one every push service is required to accept.
+pub(crate) const RECORD_SIZE: u32 = 4096;
+
+/// The largest plaintext that still fits an encrypted body of [`RECORD_SIZE`].
+///
+/// `4096 - header(86) - delimiter(1) - GCM tag(16)`. Push services are only
+/// required to accept 4096 octets, so exceeding this is refused up front with
+/// [`PushError::PayloadTooLarge`] rather than dispatched and rejected
+/// remotely.
+pub(crate) const MAX_PLAINTEXT_LEN: usize =
+    RECORD_SIZE as usize - HEADER_LEN - 1 - TAG_LEN;
+
+/// Encrypt `plaintext` for a subscription, minting a fresh salt and ephemeral
+/// key pair.
+///
+/// # Errors
+///
+/// [`PushError::InvalidSubscriptionKey`] for a malformed `p256dh`/`auth`,
+/// [`PushError::PayloadTooLarge`] past [`MAX_PLAINTEXT_LEN`], and
+/// [`PushError::Encryption`] if AES-GCM itself fails.
+pub(crate) fn encrypt(
+    plaintext: &[u8],
+    ua_public: &[u8],
+    auth_secret: &[u8],
+) -> Result<Vec<u8>, PushError> {
+    let mut salt = [0_u8; 16];
+    // `OsRng` is the operating system CSPRNG — the same source `SigningKey::
+    // random` draws from. A non-cryptographic RNG here would be a real break,
+    // not a style choice.
+    rand::TryRngCore::try_fill_bytes(&mut rand::rngs::OsRng, &mut salt)
+        .map_err(|e| PushError::Encryption(format!("could not draw a random salt: {e}")))?;
+    let ephemeral = p256::SecretKey::random(&mut p256::elliptic_curve::rand_core::OsRng);
+    encrypt_with(plaintext, ua_public, auth_secret, salt, ephemeral)
+}
+
+/// [`encrypt`] with the salt and ephemeral key supplied by the caller.
+///
+/// Deterministic, so RFC 8291 §5's published vector can be reproduced exactly.
+/// Application code always goes through [`encrypt`]: passing a salt or key
+/// that has been used before repeats an AES-GCM (key, nonce) pair.
+///
+/// # Errors
+///
+/// See [`encrypt`].
+pub(crate) fn encrypt_with(
+    plaintext: &[u8],
+    ua_public: &[u8],
+    auth_secret: &[u8],
+    salt: [u8; 16],
+    ephemeral: p256::SecretKey,
+) -> Result<Vec<u8>, PushError> {
+    if plaintext.len() > MAX_PLAINTEXT_LEN {
+        return Err(PushError::PayloadTooLarge {
+            len: plaintext.len(),
+            max: MAX_PLAINTEXT_LEN,
+        });
+    }
+    if auth_secret.len() != AUTH_SECRET_LEN {
+        return Err(PushError::InvalidSubscriptionKey(format!(
+            "`auth` must be exactly {AUTH_SECRET_LEN} bytes, got {}",
+            auth_secret.len()
+        )));
+    }
+    // `from_sec1_bytes` rejects both a wrong length and a point that is not on
+    // the curve, so a hostile `p256dh` cannot steer the ECDH onto a weak curve.
+    let ua_key = p256::PublicKey::from_sec1_bytes(ua_public).map_err(|_| {
+        PushError::InvalidSubscriptionKey(
+            "`p256dh` is not an uncompressed P-256 public key on the curve".to_owned(),
+        )
+    })?;
+
+    let as_public_point = ephemeral.public_key().to_encoded_point(false);
+    let as_public = as_public_point.as_bytes();
+    debug_assert_eq!(as_public.len(), P256_UNCOMPRESSED_LEN);
+
+    // ── Step 1: ECDH ────────────────────────────────────────────────────────
+    let shared = p256::ecdh::diffie_hellman(ephemeral.to_nonzero_scalar(), ua_key.as_affine());
+
+    // ── Step 2: the RFC 8291 §3.3 combined IKM ──────────────────────────────
+    // info = "WebPush: info" ‖ 0x00 ‖ ua_public ‖ as_public
+    let mut key_info = Vec::with_capacity(14 + P256_UNCOMPRESSED_LEN * 2);
+    key_info.extend_from_slice(b"WebPush: info\0");
+    key_info.extend_from_slice(ua_key.to_encoded_point(false).as_bytes());
+    key_info.extend_from_slice(as_public);
+    let ikm = hkdf_sha256(auth_secret, shared.raw_secret_bytes(), &key_info, 32);
+
+    // ── Step 3: the RFC 8188 content key and nonce ──────────────────────────
+    let cek = hkdf_sha256(&salt, &ikm, b"Content-Encoding: aes128gcm\0", CEK_LEN);
+    let nonce = hkdf_sha256(&salt, &ikm, b"Content-Encoding: nonce\0", NONCE_LEN);
+
+    // ── Step 4: AES-128-GCM over `plaintext ‖ 0x02` ─────────────────────────
+    let mut record = Vec::with_capacity(plaintext.len() + 1);
+    record.extend_from_slice(plaintext);
+    record.push(LAST_RECORD_DELIMITER);
+    let cipher = Aes128Gcm::new(Key::<Aes128Gcm>::from_slice(&cek));
+    let ciphertext = cipher
+        .encrypt(
+            Nonce::from_slice(&nonce),
+            Payload {
+                msg: &record,
+                // `aes128gcm` binds the header through the key derivation, not
+                // through AEAD associated data (RFC 8188 §2).
+                aad: b"",
+            },
+        )
+        .map_err(|e| PushError::Encryption(format!("AES-128-GCM: {e}")))?;
+
+    // ── Step 5: RFC 8188 framing ────────────────────────────────────────────
+    let mut body = Vec::with_capacity(HEADER_LEN + ciphertext.len());
+    body.extend_from_slice(&salt);
+    body.extend_from_slice(&RECORD_SIZE.to_be_bytes());
+    // The key id length is a single octet; a P-256 point is always 65 bytes.
+    body.push(
+        u8::try_from(P256_UNCOMPRESSED_LEN)
+            .expect("65 fits in a u8"),
+    );
+    body.extend_from_slice(as_public);
+    body.extend_from_slice(&ciphertext);
+    Ok(body)
+}
+
+/// HKDF-SHA256 (RFC 5869): extract with `salt`, then expand `info` to `len`
+/// bytes.
+///
+/// Hand-rolled over the `hmac` crate already in the dependency graph rather
+/// than adding the `hkdf` crate for ~15 lines. Every output Web Push needs is
+/// at most 32 bytes, i.e. a single expansion block, but the loop is written
+/// generally so the RFC 5869 test vectors (which go to 42 bytes) exercise it.
+pub(crate) fn hkdf_sha256(salt: &[u8], ikm: &[u8], info: &[u8], len: usize) -> Vec<u8> {
+    type HmacSha256 = Hmac<Sha256>;
+
+    // Extract: PRK = HMAC(salt, IKM). `new_from_slice` accepts any key length.
+    let mut extract = <HmacSha256 as Mac>::new_from_slice(salt).expect("HMAC accepts any key length");
+    extract.update(ikm);
+    let prk = extract.finalize().into_bytes();
+
+    // Expand: T(n) = HMAC(PRK, T(n-1) ‖ info ‖ n).
+    let mut okm = Vec::with_capacity(len);
+    let mut previous: Vec<u8> = Vec::new();
+    let mut counter: u8 = 1;
+    while okm.len() < len {
+        let mut expand = <HmacSha256 as Mac>::new_from_slice(&prk).expect("HMAC accepts any key length");
+        expand.update(&previous);
+        expand.update(info);
+        expand.update(&[counter]);
+        previous = expand.finalize().into_bytes().to_vec();
+        okm.extend_from_slice(&previous);
+        counter += 1;
+    }
+    okm.truncate(len);
+    okm
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::push::vapid::decode_base64url;
+    use base64::Engine as _;
+    use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+
+    // ── RFC 8291 §5 published test vector ───────────────────────────────────
+    //
+    // Every value below is copied verbatim from RFC 8291 Section 5 ("Push
+    // Message Encryption Example"). Pinning the RFC's own vector — not a
+    // round-trip against our own code — is what proves this implementation
+    // interoperates with real push services and real browsers.
+
+    const RFC_PLAINTEXT: &str = "When I grow up, I want to be a watermelon";
+    /// The user agent's public key (`p256dh`).
+    const RFC_UA_PUBLIC: &str =
+        "BCVxsr7N_eNgVRqvHtD0zTZsEc6-VV-JvLexhqUzORcxaOzi6-AYWXvTBHm4bjyPjs7Vd8pZGH6SRpkNtoIAiw4";
+    /// The user agent's authentication secret (`auth`).
+    const RFC_AUTH_SECRET: &str = "BTBZMqHH6r4Tts7J_aSIgg";
+    /// The application server's ephemeral private key for this message.
+    const RFC_AS_PRIVATE: &str = "yfWPiYE-n46HLnH0KqZOF1fJJU3MYrct3AELtAQ-oRw";
+    /// The application server's ephemeral public key for this message.
+    const RFC_AS_PUBLIC: &str =
+        "BP4z9KsN6nGRTbVYI_c7VJSPQTBtkgcy27mlmlMoZIIgDll6e3vCYLocInmYWAmS6TlzAC8wEqKK6PBru3jl7A8";
+    const RFC_SALT: &str = "DGv6ra1nlYgDCS1FRnbzlw";
+    /// The complete `aes128gcm` body the RFC's inputs must produce.
+    const RFC_BODY: &str = "DGv6ra1nlYgDCS1FRnbzlwAAEABBBP4z9KsN6nGRTbVYI_c7VJSPQTBtkgcy27ml\
+         mlMoZIIgDll6e3vCYLocInmYWAmS6TlzAC8wEqKK6PBru3jl7A_yl95bQpu6cVPT\
+         pK4Mqgkf1CXztLVBSt2Ks3oZwbuwXPXLWyouBWLVWGNWQexSgSxsj_Qulcy4a-fN";
+
+    fn b64(value: &str) -> Vec<u8> {
+        decode_base64url(value).expect("test vector is base64url")
+    }
+
+    fn rfc_salt() -> [u8; 16] {
+        let mut salt = [0_u8; 16];
+        salt.copy_from_slice(&b64(RFC_SALT));
+        salt
+    }
+
+    fn rfc_ephemeral() -> p256::SecretKey {
+        p256::SecretKey::from_slice(&b64(RFC_AS_PRIVATE)).expect("RFC private key parses")
+    }
+
+    #[test]
+    fn matches_the_rfc_8291_published_vector() {
+        let body = encrypt_with(
+            RFC_PLAINTEXT.as_bytes(),
+            &b64(RFC_UA_PUBLIC),
+            &b64(RFC_AUTH_SECRET),
+            rfc_salt(),
+            rfc_ephemeral(),
+        )
+        .expect("encrypting the RFC vector succeeds");
+
+        assert_eq!(
+            URL_SAFE_NO_PAD.encode(&body),
+            RFC_BODY.replace([' ', '\n'], ""),
+            "the aes128gcm body must match RFC 8291 §5 byte-for-byte — anything \
+             else will not decrypt in a real browser"
+        );
+    }
+
+    #[test]
+    fn body_is_framed_as_rfc_8188_requires() {
+        let body = encrypt_with(
+            RFC_PLAINTEXT.as_bytes(),
+            &b64(RFC_UA_PUBLIC),
+            &b64(RFC_AUTH_SECRET),
+            rfc_salt(),
+            rfc_ephemeral(),
+        )
+        .expect("encrypt");
+
+        assert_eq!(&body[..16], &rfc_salt()[..], "bytes 0..16 are the salt");
+        assert_eq!(
+            u32::from_be_bytes([body[16], body[17], body[18], body[19]]),
+            RECORD_SIZE,
+            "bytes 16..20 are the big-endian record size"
+        );
+        assert_eq!(body[20], 65, "byte 20 is the key id length (65 for P-256)");
+        assert_eq!(
+            URL_SAFE_NO_PAD.encode(&body[21..86]),
+            RFC_AS_PUBLIC,
+            "bytes 21..86 are the application server's ephemeral public key"
+        );
+        assert_eq!(
+            body.len(),
+            21 + 65 + RFC_PLAINTEXT.len() + 1 + 16,
+            "header + key + (plaintext ‖ 0x02 delimiter) + GCM tag"
+        );
+    }
+
+    #[test]
+    fn hkdf_matches_rfc_5869_test_case_1() {
+        // RFC 5869 Appendix A.1 — an independent check that the HKDF-SHA256
+        // used for every derived key here is correct, separate from the
+        // Web Push framing.
+        let ikm = [0x0b_u8; 22];
+        let salt: Vec<u8> = (0x00..=0x0c).collect();
+        let info: Vec<u8> = (0xf0..=0xf9).collect();
+        let okm = hkdf_sha256(&salt, &ikm, &info, 42);
+        assert_eq!(
+            hex::encode(okm),
+            "3cb25f25faacd57a90434f64d0362f2a2d2d0a90cf1a5a4c5db02d56ecc4c5bf34007208d5b887185865"
+        );
+    }
+
+    #[test]
+    fn each_message_uses_a_fresh_salt_and_ephemeral_key() {
+        // Reusing either across messages would leak plaintext relationships;
+        // the random entry point must never produce the same body twice.
+        let first = encrypt(
+            RFC_PLAINTEXT.as_bytes(),
+            &b64(RFC_UA_PUBLIC),
+            &b64(RFC_AUTH_SECRET),
+        )
+        .expect("encrypt");
+        let second = encrypt(
+            RFC_PLAINTEXT.as_bytes(),
+            &b64(RFC_UA_PUBLIC),
+            &b64(RFC_AUTH_SECRET),
+        )
+        .expect("encrypt");
+        assert_ne!(&first[..16], &second[..16], "salt must be freshly random");
+        assert_ne!(
+            &first[21..86],
+            &second[21..86],
+            "the ephemeral key must be freshly random"
+        );
+    }
+
+    #[test]
+    fn rejects_a_malformed_p256dh_key() {
+        let err = encrypt(b"hi", &[0x04, 0x01, 0x02], &b64(RFC_AUTH_SECRET))
+            .expect_err("a 3-byte p256dh is not a P-256 point");
+        assert!(
+            matches!(err, PushError::InvalidSubscriptionKey(_)),
+            "{err:?}"
+        );
+    }
+
+    #[test]
+    fn rejects_a_p256dh_that_is_not_on_the_curve() {
+        // Right length and right prefix, but not a curve point: accepting it
+        // would be an invalid-curve attack surface.
+        let mut bogus = b64(RFC_UA_PUBLIC);
+        bogus[64] ^= 0x01;
+        let err = encrypt(b"hi", &bogus, &b64(RFC_AUTH_SECRET))
+            .expect_err("an off-curve point is rejected");
+        assert!(
+            matches!(err, PushError::InvalidSubscriptionKey(_)),
+            "{err:?}"
+        );
+    }
+
+    #[test]
+    fn rejects_a_wrong_length_auth_secret() {
+        let err = encrypt(b"hi", &b64(RFC_UA_PUBLIC), &[0_u8; 8])
+            .expect_err("auth is exactly 16 bytes");
+        assert!(
+            matches!(err, PushError::InvalidSubscriptionKey(_)),
+            "{err:?}"
+        );
+        assert!(err.to_string().contains("16"), "{err}");
+    }
+
+    #[test]
+    fn rejects_a_payload_that_would_not_fit_a_single_record() {
+        let too_big = vec![b'x'; MAX_PLAINTEXT_LEN + 1];
+        let err = encrypt(&too_big, &b64(RFC_UA_PUBLIC), &b64(RFC_AUTH_SECRET))
+            .expect_err("oversize payloads are refused, not silently truncated");
+        assert!(
+            matches!(err, PushError::PayloadTooLarge { .. }),
+            "{err:?}"
+        );
+    }
+
+    #[test]
+    fn accepts_a_payload_exactly_at_the_limit() {
+        let at_limit = vec![b'x'; MAX_PLAINTEXT_LEN];
+        let body = encrypt(&at_limit, &b64(RFC_UA_PUBLIC), &b64(RFC_AUTH_SECRET))
+            .expect("the documented maximum must actually be sendable");
+        assert!(
+            body.len() <= 4096,
+            "the encrypted body must fit the 4096-byte floor every push service \
+             is required to accept, got {}",
+            body.len()
+        );
+    }
+
+    #[test]
+    fn empty_payload_still_produces_a_valid_record() {
+        let body = encrypt(b"", &b64(RFC_UA_PUBLIC), &b64(RFC_AUTH_SECRET)).expect("encrypt");
+        assert_eq!(body.len(), 21 + 65 + 1 + 16, "delimiter + tag only");
+    }
+}

--- a/autumn/src/push/mod.rs
+++ b/autumn/src/push/mod.rs
@@ -1,17 +1,140 @@
-//! Web Push (issue #1392).
+//! Web Push: deliver a notification to a subscribed browser **even when the
+//! app's tab is closed** (issue #1392).
+//!
+//! Autumn already generates an installable PWA (`autumn generate pwa`) and
+//! stores an in-app notification feed
+//! ([`notifications`](crate::notifications)). This module closes the loop
+//! between them: the browser subscribes, the app calls
+//! [`WebPush::send`], and the service worker raises a notification on the
+//! user's device. The developer writes **zero** lines of crypto — VAPID
+//! signing (RFC 8292) and payload encryption (RFC 8291) both happen here.
+//!
+//! # Quick start
+//!
+//! 1. Mint a key pair once, offline, and record the private half:
+//!
+//!    ```rust,ignore
+//!    let key = autumn_web::push::VapidKey::generate();
+//!    println!("private_key = \"{}\"", key.private_key_base64url());
+//!    ```
+//!
+//! 2. Configure it (see [`PushConfig`]):
+//!
+//!    ```toml
+//!    [push]
+//!    private_key = "…"                    # from step 1; keep it secret
+//!    subject     = "mailto:ops@example.com"
+//!    ```
+//!
+//! 3. Mount the built-in routes — `autumn generate pwa` does this for you:
+//!
+//!    ```rust,ignore
+//!    autumn_web::app()
+//!        .merge(autumn_web::push::router())
+//!        .run()
+//!        .await;
+//!    ```
+//!
+//! 4. Send:
+//!
+//!    ```rust,ignore
+//!    use autumn_web::prelude::*;
+//!
+//!    #[post("/builds/{id}/fail")]
+//!    async fn build_failed(push: WebPush, id: Path<i64>) -> AutumnResult<&'static str> {
+//!        push.send(
+//!            owner_id,
+//!            &PushMessage::new("Build failed", "main is red")
+//!                .url(format!("/builds/{}", *id)),
+//!        )
+//!        .await?;
+//!        Ok("ok")
+//!    }
+//!    ```
+//!
+//! # Composing with the in-app notification feed (#1148)
+//!
+//! Push is a *delivery leg*, not a replacement for the feed: the feed is the
+//! durable record the user can come back to, and the push is the nudge that
+//! brings them back. Write the notification first, then push best-effort —
+//! mirroring how [`Notifications::notify_with_push`] treats its `channels`
+//! broadcast:
+//!
+//! ```rust,ignore
+//! use autumn_web::prelude::*;
+//! use autumn_web::push::PushMessage;
+//!
+//! #[post("/posts/{id}/comments")]
+//! async fn comment(
+//!     notifications: Notifications,
+//!     push: WebPush,
+//!     id: Path<i64>,
+//! ) -> AutumnResult<&'static str> {
+//!     // 1. The durable record. A failure here IS a failure of the request.
+//!     notifications
+//!         .notify(author_id, "comment.created", serde_json::json!({ "post": *id }))
+//!         .await?;
+//!
+//!     // 2. The nudge. Best-effort: a push service outage, a revoked
+//!     //    permission, or an app with no `[push]` key configured must never
+//!     //    fail the comment that was already written. `PushPrincipal` accepts
+//!     //    the same `i64` recipient the feed uses, so there is no conversion.
+//!     if let Err(e) = push
+//!         .send(
+//!             author_id,
+//!             &PushMessage::new("New comment", "Someone replied to your post")
+//!                 .url(format!("/posts/{}", *id)),
+//!         )
+//!         .await
+//!     {
+//!         tracing::warn!(error = %e, "web push failed; the in-app notification still stands");
+//!     }
+//!
+//!     Ok("ok")
+//! }
+//! ```
+//!
+//! The ordering is the point: the feed write is awaited and propagated, the
+//! push is awaited and *logged*. A user whose browser has never subscribed
+//! gets an empty [`PushDeliveryReport`] rather than an error, so the branch
+//! above only fires on a genuine problem.
+//!
+//! # What is stored, and where
+//!
+//! A browser subscription is an endpoint URL plus two keys, bound to a
+//! principal — see [`PushSubscriptionStore`]. The default backend is the
+//! `push_subscriptions` table scaffolded by `autumn generate pwa`, falling
+//! back to an in-memory store when no database is configured.
+//!
+//! # Failure posture
+//!
+//! - **Never a silent no-op.** Sending with no key configured is
+//!   [`PushError::NotConfigured`], raised before anything is dispatched, and a
+//!   key that is present but unusable fails the boot outright.
+//! - **A dead device never blocks a live one.** Per-device outcomes are
+//!   reported through [`PushDeliveryReport`], not raised.
+//! - **Stale subscriptions are pruned, transient failures are not.** A
+//!   `404`/`410` removes the subscription; a `5xx` or a rate limit leaves it
+//!   in place to retry, because pruning on those would silently unsubscribe
+//!   every user during an incident.
 
+pub mod config;
 pub(crate) mod encryption;
+pub mod router;
 pub mod service;
 pub mod store;
 pub mod transport;
 pub mod vapid;
 
+pub use config::PushConfig;
+pub use router::router;
 pub use service::{PushDeliveryReport, PushMessage, WebPush};
 #[cfg(feature = "db")]
 pub use store::DbPushSubscriptionStore;
 pub use store::{
-    BrowserSubscription, MemoryPushSubscriptionStore, PUSH_SUBSCRIPTIONS_TABLE, PushPrincipal,
-    PushSubscriptionStore, StoredSubscription, SubscriptionKeys,
+    BrowserSubscription, MAX_SUBSCRIPTIONS_PER_PRINCIPAL, MemoryPushSubscriptionStore,
+    PUSH_SUBSCRIPTIONS_TABLE, PushPrincipal, PushSubscriptionStore, StoredSubscription,
+    SubscriptionKeys,
 };
 pub use transport::{PushRequest, PushTransport, RecordingPushTransport};
 pub use vapid::VapidKey;
@@ -39,20 +162,78 @@ pub enum PushError {
         /// Maximum permitted plaintext length.
         max: usize,
     },
+    /// The message could not be serialized to JSON.
+    #[error("could not serialize the push payload: {0}")]
+    Serialization(String),
     /// Payload encryption failed.
     #[error("push payload encryption failed: {0}")]
     Encryption(String),
+    /// The endpoint is already registered to a different principal, and the
+    /// request did not present the key material that would prove it is the
+    /// same user agent re-subscribing.
+    #[error(
+        "this push endpoint is already registered to a different account. Unsubscribe in the \
+         browser first (`pushManager.getSubscription()` then `.unsubscribe()`), then subscribe \
+         again."
+    )]
+    EndpointClaimed,
+    /// The principal already holds the maximum number of subscriptions.
+    #[error(
+        "this account already has the maximum of {max} push subscriptions. Unsubscribe an \
+         unused device before adding another."
+    )]
+    TooManySubscriptions {
+        /// The per-principal ceiling.
+        max: usize,
+    },
     /// The subscription store failed.
     #[error("push subscription store error: {0}")]
     Store(String),
     /// No VAPID key is configured, so nothing can be signed or sent.
     #[error(
         "Web Push is not configured: no VAPID key. Set `[push] private_key = \"…\"` in \
-         autumn.toml (mint one with `VapidKey::generate()`), or register a key with \
-         `AppBuilder::with_vapid_key(...)`"
+         autumn.toml (mint one with `VapidKey::generate()`), or register a service carrying \
+         one with `AppBuilder::with_web_push(...)`"
     )]
     NotConfigured,
+    /// The `[push]` configuration block is internally inconsistent.
+    #[error("invalid `[push]` configuration: {0}")]
+    InvalidConfig(String),
     /// The transport could not reach the push service at all.
     #[error("push transport failed: {0}")]
     Transport(String),
+}
+
+impl PushError {
+    /// The HTTP status this failure should surface as.
+    ///
+    /// Consulted by [`AutumnError`](crate::error::AutumnError)'s blanket
+    /// conversion, so `push.subscribe(…).await?` in an application's own
+    /// handler answers a malformed *browser* payload with the same `400` the
+    /// built-in [`router`] does, instead of reporting a client mistake as a
+    /// server fault.
+    #[must_use]
+    pub const fn status(&self) -> http::StatusCode {
+        match self {
+            // The caller sent something unusable.
+            Self::InvalidEndpoint(_)
+            | Self::InvalidSubscriptionKey(_)
+            | Self::PayloadTooLarge { .. } => http::StatusCode::BAD_REQUEST,
+            // Well-formed, but it conflicts with existing state…
+            Self::EndpointClaimed => http::StatusCode::CONFLICT,
+            // …or exceeds the caller's quota.
+            Self::TooManySubscriptions { .. } => http::StatusCode::UNPROCESSABLE_ENTITY,
+            // Push is not set up on this deployment: the request was fine, the
+            // capability is absent. `503` invites a retry once it is
+            // configured, where `500` would not.
+            Self::NotConfigured => http::StatusCode::SERVICE_UNAVAILABLE,
+            // Genuinely ours.
+            Self::InvalidVapidKey(_)
+            | Self::InvalidConfig(_)
+            | Self::Serialization(_)
+            | Self::Encryption(_)
+            | Self::Store(_)
+            | Self::Transport(_) => http::StatusCode::INTERNAL_SERVER_ERROR,
+        }
+    }
 }

--- a/autumn/src/push/mod.rs
+++ b/autumn/src/push/mod.rs
@@ -1,0 +1,34 @@
+//! Web Push (issue #1392).
+
+pub(crate) mod encryption;
+pub mod vapid;
+
+pub use vapid::VapidKey;
+
+/// Errors produced by the Web Push subsystem.
+#[derive(Debug, Clone, thiserror::Error, PartialEq, Eq)]
+pub enum PushError {
+    /// The configured VAPID key could not be loaded.
+    #[error("invalid VAPID key: {0}")]
+    InvalidVapidKey(String),
+    /// A subscription endpoint URL is unusable.
+    #[error("invalid push endpoint: {0}")]
+    InvalidEndpoint(String),
+    /// A browser-supplied subscription key (`p256dh` / `auth`) is malformed.
+    #[error("invalid subscription key: {0}")]
+    InvalidSubscriptionKey(String),
+    /// The payload exceeds what push services are required to accept.
+    #[error(
+        "push payload is {len} bytes after JSON encoding, but the maximum a push service must \
+         accept leaves room for only {max}; shorten the title/body or move detail behind the url"
+    )]
+    PayloadTooLarge {
+        /// Actual plaintext length.
+        len: usize,
+        /// Maximum permitted plaintext length.
+        max: usize,
+    },
+    /// Payload encryption failed.
+    #[error("push payload encryption failed: {0}")]
+    Encryption(String),
+}

--- a/autumn/src/push/mod.rs
+++ b/autumn/src/push/mod.rs
@@ -1,8 +1,19 @@
 //! Web Push (issue #1392).
 
 pub(crate) mod encryption;
+pub mod service;
+pub mod store;
+pub mod transport;
 pub mod vapid;
 
+pub use service::{PushDeliveryReport, PushMessage, WebPush};
+#[cfg(feature = "db")]
+pub use store::DbPushSubscriptionStore;
+pub use store::{
+    BrowserSubscription, MemoryPushSubscriptionStore, PUSH_SUBSCRIPTIONS_TABLE, PushPrincipal,
+    PushSubscriptionStore, StoredSubscription, SubscriptionKeys,
+};
+pub use transport::{PushRequest, PushTransport, RecordingPushTransport};
 pub use vapid::VapidKey;
 
 /// Errors produced by the Web Push subsystem.
@@ -31,4 +42,17 @@ pub enum PushError {
     /// Payload encryption failed.
     #[error("push payload encryption failed: {0}")]
     Encryption(String),
+    /// The subscription store failed.
+    #[error("push subscription store error: {0}")]
+    Store(String),
+    /// No VAPID key is configured, so nothing can be signed or sent.
+    #[error(
+        "Web Push is not configured: no VAPID key. Set `[push] private_key = \"…\"` in \
+         autumn.toml (mint one with `VapidKey::generate()`), or register a key with \
+         `AppBuilder::with_vapid_key(...)`"
+    )]
+    NotConfigured,
+    /// The transport could not reach the push service at all.
+    #[error("push transport failed: {0}")]
+    Transport(String),
 }

--- a/autumn/src/push/mod.rs
+++ b/autumn/src/push/mod.rs
@@ -57,7 +57,7 @@
 //! Push is a *delivery leg*, not a replacement for the feed: the feed is the
 //! durable record the user can come back to, and the push is the nudge that
 //! brings them back. Write the notification first, then push best-effort —
-//! mirroring how [`Notifications::notify_with_push`] treats its `channels`
+//! mirroring how [`Notifications::notify_with_push`](crate::notifications::Notifications::notify_with_push) treats its `channels`
 //! broadcast:
 //!
 //! ```rust,ignore
@@ -120,14 +120,17 @@
 
 pub mod config;
 pub(crate) mod encryption;
-pub mod router;
+pub mod routes;
 pub mod service;
 pub mod store;
 pub mod transport;
 pub mod vapid;
 
 pub use config::PushConfig;
-pub use router::router;
+pub use routes::{
+    CSRF_TOKEN_HEADER, CSRF_TOKEN_HEADER_NAME_HEADER, SUBSCRIBE_PATH, UNSUBSCRIBE_PATH,
+    VAPID_PUBLIC_KEY_PATH, router,
+};
 pub use service::{PushDeliveryReport, PushMessage, WebPush};
 #[cfg(feature = "db")]
 pub use store::DbPushSubscriptionStore;
@@ -210,7 +213,7 @@ impl PushError {
     /// Consulted by [`AutumnError`](crate::error::AutumnError)'s blanket
     /// conversion, so `push.subscribe(…).await?` in an application's own
     /// handler answers a malformed *browser* payload with the same `400` the
-    /// built-in [`router`] does, instead of reporting a client mistake as a
+    /// built-in [`router()`] does, instead of reporting a client mistake as a
     /// server fault.
     #[must_use]
     pub const fn status(&self) -> http::StatusCode {

--- a/autumn/src/push/router.rs
+++ b/autumn/src/push/router.rs
@@ -1,0 +1,181 @@
+//! The built-in Web Push endpoints.
+//!
+//! Mount them once and the browser side of the subscription dance needs no
+//! application code:
+//!
+//! | Method | Path | Does |
+//! |---|---|---|
+//! | `GET`  | `/push/vapid-public-key` | serve the `applicationServerKey` the browser subscribes with |
+//! | `POST` | `/push/subscribe`        | record the caller's browser `PushSubscription` |
+//! | `POST` | `/push/unsubscribe`      | remove one of the caller's subscriptions |
+//!
+//! ```rust,ignore
+//! autumn_web::app()
+//!     .merge(autumn_web::push::router())
+//!     .run()
+//!     .await;
+//! ```
+//!
+//! `autumn generate pwa` wires this in for you, along with the client snippet
+//! that calls it.
+//!
+//! # Authentication
+//!
+//! A subscription is meaningless without an owner, so both mutating routes
+//! resolve the caller server-side and `401` when they cannot — they never take
+//! a principal from the request body, which would let anyone subscribe *as*
+//! anyone. Resolution reads, in order:
+//!
+//! 1. [`Current::actor`](crate::current::Current::actor) — set by the
+//!    framework's auth layers, so bearer-token and session auth both work; then
+//! 2. the session value named by `[auth] session_key` (default `user_id`), so
+//!    an app whose push routes are not themselves behind `#[secured]` still
+//!    resolves the signed-in user.
+//!
+//! Until an app has authentication, these routes are simply dormant: every
+//! call 401s and nothing is stored. `GET /push/vapid-public-key` is
+//! deliberately **public** — the subscribe snippet fetches it before the user
+//! has done anything, and it is public key material.
+
+use axum::Json;
+use axum::extract::State;
+use axum::http::StatusCode;
+use axum::response::IntoResponse;
+use axum::routing::{get, post};
+use axum::{Router, extract::FromRequestParts};
+use serde::Deserialize;
+
+use super::WebPush;
+use super::store::BrowserSubscription;
+use crate::error::{AutumnError, AutumnResult};
+use crate::state::AppState;
+
+/// The path `GET`ting the VAPID public key. Kept as a constant so the
+/// generated client snippet and the router can never drift apart.
+pub const VAPID_PUBLIC_KEY_PATH: &str = "/push/vapid-public-key";
+/// The path a browser `POST`s its `PushSubscription` to.
+pub const SUBSCRIBE_PATH: &str = "/push/subscribe";
+/// The path a browser `POST`s an endpoint to in order to unsubscribe.
+pub const UNSUBSCRIBE_PATH: &str = "/push/unsubscribe";
+
+/// Mount the built-in push routes. See the [module docs](self).
+pub fn router() -> Router<AppState> {
+    Router::new()
+        .route(VAPID_PUBLIC_KEY_PATH, get(vapid_public_key))
+        .route(SUBSCRIBE_PATH, post(subscribe))
+        .route(UNSUBSCRIBE_PATH, post(unsubscribe))
+}
+
+/// Body of `POST /push/unsubscribe`.
+#[derive(Debug, Deserialize)]
+struct UnsubscribeBody {
+    /// The endpoint to forget. Browsers have this on the `PushSubscription`
+    /// they are about to discard.
+    endpoint: String,
+}
+
+/// `GET /push/vapid-public-key`
+async fn vapid_public_key(push: WebPush) -> impl IntoResponse {
+    match push.vapid_public_key() {
+        Ok(key) => (
+            StatusCode::OK,
+            [
+                ("content-type", "text/plain; charset=utf-8"),
+                // Per-deployment, not per-user, and stable — but never worth
+                // a shared cache holding it across a key rotation.
+                ("cache-control", "no-store"),
+            ],
+            key,
+        )
+            .into_response(),
+        // 503, not 200-with-empty-body: the client must be able to tell "push
+        // is not configured here" from "here is your key", and a
+        // `NotConfigured` app is expected to start working once configured.
+        Err(e) => (
+            StatusCode::SERVICE_UNAVAILABLE,
+            [("cache-control", "no-store")],
+            e.to_string(),
+        )
+            .into_response(),
+    }
+}
+
+/// `POST /push/subscribe`
+async fn subscribe(
+    State(state): State<AppState>,
+    push: WebPush,
+    parts: RequestPrincipal,
+    Json(subscription): Json<BrowserSubscription>,
+) -> AutumnResult<StatusCode> {
+    let principal = parts.resolve(&state).await?;
+    // `From<PushError>` carries the status mapping, so this route and an
+    // application's own handler answer a malformed payload identically.
+    push.subscribe(principal, &subscription).await?;
+    Ok(StatusCode::NO_CONTENT)
+}
+
+/// `POST /push/unsubscribe`
+async fn unsubscribe(
+    State(state): State<AppState>,
+    push: WebPush,
+    parts: RequestPrincipal,
+    Json(body): Json<UnsubscribeBody>,
+) -> AutumnResult<StatusCode> {
+    let principal = parts.resolve(&state).await?;
+    // The result is deliberately discarded: an endpoint that was already gone
+    // (or belongs to someone else) is still a successful unsubscribe from the
+    // caller's point of view, and reporting the difference would tell one user
+    // whether an endpoint belongs to another.
+    push.unsubscribe(principal, &body.endpoint).await?;
+    Ok(StatusCode::NO_CONTENT)
+}
+
+/// The request parts needed to resolve who is calling.
+///
+/// Held as an extractor rather than resolved inline so the session lookup —
+/// which is async and needs the session store — happens in the handler body,
+/// where a failure is a clean `401` instead of an extractor rejection.
+struct RequestPrincipal(axum::http::request::Parts);
+
+impl FromRequestParts<AppState> for RequestPrincipal {
+    type Rejection = std::convert::Infallible;
+
+    async fn from_request_parts(
+        parts: &mut axum::http::request::Parts,
+        _state: &AppState,
+    ) -> Result<Self, Self::Rejection> {
+        Ok(Self(parts.clone()))
+    }
+}
+
+impl RequestPrincipal {
+    /// Resolve the calling principal, or `401`.
+    async fn resolve(mut self, state: &AppState) -> AutumnResult<String> {
+        // 1. Whatever the framework's auth layers published (bearer tokens and
+        //    `#[secured]` session auth both land here).
+        //
+        //    `scoped_actor`, not `actor`: the latter falls back to the
+        //    PROCESS-WIDE default actor when no request scope is in effect,
+        //    which an app sets for its job runner (`set_default_actor`). This
+        //    router is a mergeable `Router<AppState>` that can be mounted on a
+        //    trimmed stack, and a route whose whole security model is "resolve
+        //    the caller server-side" must never resolve an *unauthenticated*
+        //    request to some ambient global identity.
+        if let Some(actor) = crate::current::Current::scoped_actor() {
+            return Ok(actor);
+        }
+
+        // 2. The signed-in user on the session, for an app whose push routes
+        //    are not themselves behind an auth layer.
+        let session_key = state.config().auth.session_key.clone();
+        if let Ok(session) = crate::session::Session::from_request_parts(&mut self.0, state).await
+            && let Some(user_id) = session.get(&session_key).await
+        {
+            return Ok(user_id);
+        }
+
+        Err(AutumnError::unauthorized_msg(
+            "a push subscription must belong to a signed-in user",
+        ))
+    }
+}

--- a/autumn/src/push/router.rs
+++ b/autumn/src/push/router.rs
@@ -74,20 +74,73 @@ struct UnsubscribeBody {
     endpoint: String,
 }
 
+/// Response header carrying the caller's CSRF token on the public-key
+/// response. See [`vapid_public_key`].
+pub const CSRF_TOKEN_HEADER: &str = "x-autumn-push-csrf-token";
+/// Response header naming the header the CSRF token must be sent back in.
+pub const CSRF_TOKEN_HEADER_NAME_HEADER: &str = "x-autumn-push-csrf-header";
+
 /// `GET /push/vapid-public-key`
-async fn vapid_public_key(push: WebPush) -> impl IntoResponse {
+///
+/// Also carries the caller's CSRF token, in [`CSRF_TOKEN_HEADER`].
+///
+/// # Why the token rides on this response
+///
+/// Both mutating push routes are `POST`s that Autumn's CSRF layer rejects
+/// without a token, and the CSRF cookie is `HttpOnly`, so the subscribe
+/// snippet cannot read it. The framework's usual answer — a handler takes
+/// `CsrfToken` and its template emits `<meta name="csrf-token">` — does not
+/// reach here: the generated snippet runs on the *app's own* pages, rendered
+/// by a `layout()` the PWA generator does not (and should not) change the
+/// signature of.
+///
+/// So the token travels on the one request the snippet already makes before
+/// subscribing. That is safe because reading it requires a **same-origin**
+/// fetch: a cross-origin attacker cannot read response headers without the
+/// app explicitly allowing it via CORS, which is exactly the property
+/// double-submit CSRF already relies on. Same-origin script could obtain a
+/// token from any rendered form anyway, so this exposes nothing new.
+///
+/// Exempting the push routes from CSRF instead would be the wrong trade: a
+/// forced subscribe registers the *attacker's* keys under the victim's
+/// session, letting them decrypt every notification the app sends that user.
+async fn vapid_public_key(
+    push: WebPush,
+    csrf: Option<crate::security::CsrfToken>,
+    csrf_header: Option<axum::Extension<crate::security::CsrfTokenHeader>>,
+) -> impl IntoResponse {
+    let csrf_headers = csrf.map(|token| {
+        let header_name =
+            csrf_header.map_or_else(|| "X-CSRF-Token".to_owned(), |axum::Extension(name)| name.0);
+        (token.token().to_owned(), header_name)
+    });
+
     match push.vapid_public_key() {
-        Ok(key) => (
-            StatusCode::OK,
-            [
-                ("content-type", "text/plain; charset=utf-8"),
-                // Per-deployment, not per-user, and stable — but never worth
-                // a shared cache holding it across a key rotation.
-                ("cache-control", "no-store"),
-            ],
-            key,
-        )
-            .into_response(),
+        Ok(key) => {
+            let mut response = (
+                StatusCode::OK,
+                [
+                    ("content-type", "text/plain; charset=utf-8"),
+                    // Per-deployment, not per-user, and stable — but never
+                    // worth a shared cache holding it across a key rotation.
+                    // The CSRF token below makes it per-visitor besides.
+                    ("cache-control", "no-store"),
+                ],
+                key,
+            )
+                .into_response();
+            if let Some((token, header_name)) = csrf_headers {
+                let headers = response.headers_mut();
+                if let (Ok(token), Ok(name)) = (
+                    axum::http::HeaderValue::from_str(&token),
+                    axum::http::HeaderValue::from_str(&header_name),
+                ) {
+                    headers.insert(CSRF_TOKEN_HEADER, token);
+                    headers.insert(CSRF_TOKEN_HEADER_NAME_HEADER, name);
+                }
+            }
+            response
+        }
         // 503, not 200-with-empty-body: the client must be able to tell "push
         // is not configured here" from "here is your key", and a
         // `NotConfigured` app is expected to start working once configured.

--- a/autumn/src/push/routes.rs
+++ b/autumn/src/push/routes.rs
@@ -74,8 +74,12 @@ struct UnsubscribeBody {
     endpoint: String,
 }
 
-/// Response header carrying the caller's CSRF token on the public-key
-/// response. See [`vapid_public_key`].
+/// Response header carrying the caller's CSRF token on the
+/// `GET /push/vapid-public-key` response.
+///
+/// The subscribe snippet reads it and sends the token back in the header named
+/// by [`CSRF_TOKEN_HEADER_NAME_HEADER`]; see the [module docs](self) for why
+/// the token travels this way.
 pub const CSRF_TOKEN_HEADER: &str = "x-autumn-push-csrf-token";
 /// Response header naming the header the CSRF token must be sent back in.
 pub const CSRF_TOKEN_HEADER_NAME_HEADER: &str = "x-autumn-push-csrf-header";

--- a/autumn/src/push/routes.rs
+++ b/autumn/src/push/routes.rs
@@ -119,32 +119,19 @@ async fn vapid_public_key(
         (token.token().to_owned(), header_name)
     });
 
-    match push.vapid_public_key() {
-        Ok(key) => {
-            let mut response = (
-                StatusCode::OK,
-                [
-                    ("content-type", "text/plain; charset=utf-8"),
-                    // Per-deployment, not per-user, and stable — but never
-                    // worth a shared cache holding it across a key rotation.
-                    // The CSRF token below makes it per-visitor besides.
-                    ("cache-control", "no-store"),
-                ],
-                key,
-            )
-                .into_response();
-            if let Some((token, header_name)) = csrf_headers {
-                let headers = response.headers_mut();
-                if let (Ok(token), Ok(name)) = (
-                    axum::http::HeaderValue::from_str(&token),
-                    axum::http::HeaderValue::from_str(&header_name),
-                ) {
-                    headers.insert(CSRF_TOKEN_HEADER, token);
-                    headers.insert(CSRF_TOKEN_HEADER_NAME_HEADER, name);
-                }
-            }
-            response
-        }
+    let mut response = match push.vapid_public_key() {
+        Ok(key) => (
+            StatusCode::OK,
+            [
+                ("content-type", "text/plain; charset=utf-8"),
+                // Per-deployment, not per-user, and stable — but never
+                // worth a shared cache holding it across a key rotation.
+                // The CSRF token below makes it per-visitor besides.
+                ("cache-control", "no-store"),
+            ],
+            key,
+        )
+            .into_response(),
         // 503, not 200-with-empty-body: the client must be able to tell "push
         // is not configured here" from "here is your key", and a
         // `NotConfigured` app is expected to start working once configured.
@@ -154,7 +141,27 @@ async fn vapid_public_key(
             e.to_string(),
         )
             .into_response(),
+    };
+
+    // Attached AFTER the match, so both branches carry it.
+    //
+    // The `503` needs it just as much as the `200`: a deployment that removes
+    // its VAPID key still has browsers holding subscriptions, and the
+    // unsubscribe flow primes its token from exactly this endpoint. Without a
+    // token there, the follow-up `POST /push/unsubscribe` is rejected while
+    // the client still drops its local subscription — stranding the server row
+    // forever, since nothing will ever push to it again to earn a `410`.
+    if let Some((token, header_name)) = csrf_headers {
+        let headers = response.headers_mut();
+        if let (Ok(token), Ok(name)) = (
+            axum::http::HeaderValue::from_str(&token),
+            axum::http::HeaderValue::from_str(&header_name),
+        ) {
+            headers.insert(CSRF_TOKEN_HEADER, token);
+            headers.insert(CSRF_TOKEN_HEADER_NAME_HEADER, name);
+        }
     }
+    response
 }
 
 /// `POST /push/subscribe`

--- a/autumn/src/push/service.rs
+++ b/autumn/src/push/service.rs
@@ -21,6 +21,7 @@
 
 use std::sync::Arc;
 
+use futures::StreamExt as _;
 use serde::{Deserialize, Serialize};
 
 use super::PushError;
@@ -40,6 +41,15 @@ use crate::state::AppState;
 /// the re-engagement case this exists for — a notification is still worth
 /// delivering when the user's laptop comes back online tomorrow.
 pub const DEFAULT_TTL_SECS: u32 = 4 * 7 * 24 * 60 * 60;
+
+/// How many of one principal's devices are dispatched to at once.
+///
+/// Push endpoints are client-chosen, so a device that accepts a connection and
+/// never answers is a case to design for, not an accident: delivered serially
+/// it would hold the whole send for the transport's timeout. Concurrency keeps
+/// a stalled device from blocking its live siblings, and the bound keeps a
+/// fan-out from opening one connection per subscription at once.
+const MAX_CONCURRENT_DELIVERIES: usize = 8;
 
 // ── Message ─────────────────────────────────────────────────────────────────
 
@@ -322,10 +332,31 @@ impl WebPush {
             );
         }
 
+        // Dispatched concurrently, with a bound.
+        //
+        // Serially, one device that accepts the connection and then never
+        // answers holds the whole send for the transport's full timeout, and
+        // `send_many` queues every later recipient behind it — a principal at
+        // the subscription cap could stall one notification for minutes.
+        // Since every endpoint is client-chosen, that is reachable on purpose.
+        //
+        // Bounded rather than unbounded: a fan-out is still someone's
+        // connection pool, and `MAX_CONCURRENT_DELIVERIES` at a time is plenty
+        // to keep a stalled device from blocking its live siblings.
         let mut report = PushDeliveryReport::default();
-        for subscription in subscriptions {
-            report.merge(self.deliver_one(vapid, &subscription, &payload).await?);
+        let mut deliveries = futures::stream::iter(
+            subscriptions
+                .iter()
+                .map(|subscription| self.deliver_one(vapid, subscription, &payload)),
+        )
+        .buffer_unordered(MAX_CONCURRENT_DELIVERIES);
+        while let Some(outcome) = futures::StreamExt::next(&mut deliveries).await {
+            report.merge(outcome?);
         }
+        drop(deliveries);
+        // Deterministic order regardless of which device answered first, so a
+        // caller (and a test) can compare reports.
+        report.pruned.sort();
         Ok(report)
     }
 
@@ -1162,6 +1193,116 @@ mod tests {
             "the error must say how to fix it: {err}"
         );
         assert!(transport.requests().is_empty());
+    }
+
+    #[tokio::test]
+    async fn a_stalled_device_does_not_hold_up_its_live_siblings() {
+        // Serially, one endpoint that accepts the connection and never answers
+        // holds the whole send for the transport's full timeout. Every
+        // endpoint is client-chosen, so this is reachable on purpose.
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        /// Blocks on the endpoint named `stall` until the others are done.
+        #[derive(Debug)]
+        struct StallingTransport {
+            in_flight: Arc<AtomicUsize>,
+        }
+
+        impl PushTransport for StallingTransport {
+            fn deliver<'a>(
+                &'a self,
+                request: &'a crate::push::PushRequest,
+            ) -> crate::push::transport::PushTransportFuture<'a> {
+                Box::pin(async move {
+                    if request.endpoint.contains("stall") {
+                        // Resolves only once every other device has been
+                        // dispatched — impossible unless they run
+                        // concurrently with this one.
+                        for _ in 0..1_000 {
+                            if self.in_flight.load(Ordering::SeqCst) >= 2 {
+                                break;
+                            }
+                            tokio::task::yield_now().await;
+                        }
+                        return Ok(201);
+                    }
+                    self.in_flight.fetch_add(1, Ordering::SeqCst);
+                    Ok(201)
+                })
+            }
+        }
+
+        let in_flight = Arc::new(AtomicUsize::new(0));
+        let push = WebPush::new(
+            MemoryPushSubscriptionStore::new(),
+            VapidKey::generate(),
+            "mailto:ops@example.com",
+            StallingTransport {
+                in_flight: in_flight.clone(),
+            },
+        );
+        for endpoint in [
+            "https://push.example.com/stall",
+            "https://push.example.com/live-a",
+            "https://push.example.com/live-b",
+        ] {
+            push.subscribe(7_i64, &browser_subscription(endpoint))
+                .await
+                .expect("subscribe");
+        }
+
+        // Serial dispatch would deadlock here: the stalled device is first and
+        // would wait forever for siblings that never start.
+        let report = tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            push.send(7_i64, &PushMessage::new("Hi", "There")),
+        )
+        .await
+        .expect("a stalled device must not block the others")
+        .expect("send");
+        assert_eq!(report.delivered, 3);
+    }
+
+    #[tokio::test]
+    async fn concurrent_delivery_still_prunes_and_reports_deterministically() {
+        // Concurrency must not change what a send reports, only how fast it
+        // gets there — including the order of `pruned`, which callers compare.
+        let transport = RecordingPushTransport::new()
+            .responding_with("https://push.example.com/dead-a", 410)
+            .responding_with("https://push.example.com/dead-b", 404);
+        let (push, _) = web_push_with(transport.clone());
+        for endpoint in [
+            "https://push.example.com/dead-b",
+            "https://push.example.com/live",
+            "https://push.example.com/dead-a",
+        ] {
+            push.subscribe(7_i64, &browser_subscription(endpoint))
+                .await
+                .expect("subscribe");
+        }
+
+        let report = push
+            .send(7_i64, &PushMessage::new("Hi", "There"))
+            .await
+            .expect("send");
+        assert_eq!(report.delivered, 1);
+        assert_eq!(
+            report.pruned,
+            vec![
+                "https://push.example.com/dead-a".to_owned(),
+                "https://push.example.com/dead-b".to_owned(),
+            ],
+            "pruned must be stably ordered whichever device answered first"
+        );
+        // And the pruning really happened.
+        assert_eq!(
+            push.send(7_i64, &PushMessage::new("Hi", "again"))
+                .await
+                .expect("send")
+                .delivered,
+            1
+        );
     }
 
     #[tokio::test]

--- a/autumn/src/push/service.rs
+++ b/autumn/src/push/service.rs
@@ -31,6 +31,7 @@ use super::store::{
 };
 use super::transport::{PushRequest, PushTransport};
 use super::vapid::VapidKey;
+use crate::state::AppState;
 
 /// Default `TTL` (RFC 8030 §5.2) on a dispatched message: how long the push
 /// service may hold it for a device that is currently offline.
@@ -302,6 +303,18 @@ impl WebPush {
             .boxed_list_for(principal.as_str().to_owned())
             .await?;
 
+        if subscriptions.is_empty() {
+            // Usually benign (the user never granted permission), but it is
+            // also what a principal-namespace mismatch looks like — the
+            // subscribe route recorded `user:42` while the send asked for
+            // `42`. Naming the id that was looked up is the quickest way to
+            // spot that, and there is no other symptom.
+            tracing::debug!(
+                principal = %principal,
+                "no push subscriptions for this principal; nothing dispatched"
+            );
+        }
+
         let mut report = PushDeliveryReport::default();
         for subscription in subscriptions {
             report.merge(self.deliver_one(vapid, &subscription, &payload).await?);
@@ -334,8 +347,8 @@ impl WebPush {
 
     /// Serialize a message and check it against the payload ceiling.
     fn encode(message: &PushMessage) -> Result<Vec<u8>, PushError> {
-        let payload = serde_json::to_vec(message)
-            .map_err(|e| PushError::Encryption(format!("payload serialization: {e}")))?;
+        let payload =
+            serde_json::to_vec(message).map_err(|e| PushError::Serialization(e.to_string()))?;
         if payload.len() > encryption::MAX_PLAINTEXT_LEN {
             return Err(PushError::PayloadTooLarge {
                 len: payload.len(),
@@ -360,7 +373,7 @@ impl WebPush {
                 // succeed, but it must not abort delivery to this principal's
                 // other devices either.
                 tracing::warn!(
-                    endpoint = %subscription.endpoint,
+                    endpoint.origin = %endpoint_origin(subscription.endpoint()),
                     error = %e,
                     "skipping a push subscription that could not be encoded"
                 );
@@ -375,7 +388,7 @@ impl WebPush {
             Ok(status) => status,
             Err(e) => {
                 tracing::warn!(
-                    endpoint = %subscription.endpoint,
+                    endpoint.origin = %endpoint_origin(subscription.endpoint()),
                     error = %e,
                     "push transport failed"
                 );
@@ -398,22 +411,46 @@ impl WebPush {
             }),
             404 | 410 => {
                 // Unscoped: the endpoint is dead for whoever owns it.
-                self.store
-                    .boxed_remove(subscription.endpoint.clone(), None)
-                    .await?;
-                tracing::debug!(
-                    endpoint = %subscription.endpoint,
-                    status,
-                    "pruned a stale push subscription"
-                );
-                Ok(PushDeliveryReport {
-                    pruned: vec![subscription.endpoint.clone()],
-                    ..Default::default()
-                })
+                //
+                // A store failure here is NOT propagated. The message has
+                // already been dispatched and answered; failing the whole send
+                // now would discard the deliveries that already succeeded to
+                // this principal's other devices and abort the ones still to
+                // come — the exact opposite of "a dead device never blocks a
+                // live one". The row simply survives to be pruned on the next
+                // send.
+                match self
+                    .store
+                    .boxed_remove(subscription.endpoint().to_owned(), None)
+                    .await
+                {
+                    Ok(_) => {
+                        tracing::debug!(
+                            endpoint.origin = %endpoint_origin(subscription.endpoint()),
+                            status,
+                            "pruned a stale push subscription"
+                        );
+                        Ok(PushDeliveryReport {
+                            pruned: vec![subscription.endpoint().to_owned()],
+                            ..Default::default()
+                        })
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            endpoint.origin = %endpoint_origin(subscription.endpoint()),
+                            error = %e,
+                            "could not prune a stale push subscription; it will be retried"
+                        );
+                        Ok(PushDeliveryReport {
+                            failed: 1,
+                            ..Default::default()
+                        })
+                    }
+                }
             }
             other => {
                 tracing::warn!(
-                    endpoint = %subscription.endpoint,
+                    endpoint.origin = %endpoint_origin(subscription.endpoint()),
                     status = other,
                     "push service rejected a message; leaving the subscription in place"
                 );
@@ -432,12 +469,12 @@ impl WebPush {
         subscription: &StoredSubscription,
         payload: &[u8],
     ) -> Result<PushRequest, PushError> {
-        let body = encryption::encrypt(payload, &subscription.p256dh, &subscription.auth)?;
+        let body = encryption::encrypt(payload, subscription.p256dh(), subscription.auth())?;
         let issued_at = u64::try_from(self.clock.now().timestamp()).unwrap_or(0);
         let authorization =
-            vapid.authorization_header(&subscription.endpoint, &self.subject, issued_at)?;
+            vapid.authorization_header(subscription.endpoint(), &self.subject, issued_at)?;
         Ok(PushRequest {
-            endpoint: subscription.endpoint.clone(),
+            endpoint: subscription.endpoint().to_owned(),
             headers: vec![
                 ("authorization".to_owned(), authorization),
                 ("content-encoding".to_owned(), "aes128gcm".to_owned()),
@@ -450,6 +487,136 @@ impl WebPush {
             body,
         })
     }
+}
+
+// ── Extractor ───────────────────────────────────────────────────────────────
+
+impl WebPush {
+    /// The service an app that registered nothing gets.
+    ///
+    /// Resolution mirrors [`Notifications`](crate::notifications::Notifications):
+    /// the database-backed store when a pool is configured, the in-memory one
+    /// otherwise. The VAPID key and subject come from the validated `[push]`
+    /// config block.
+    fn default_for(state: &AppState) -> Self {
+        let config = state.config();
+        // Already validated at boot by `AppBuilder`, so a key that fails to
+        // load here means the config was replaced at runtime. Treating that as
+        // "unconfigured" is the safe reading: sends then fail loudly with
+        // `NotConfigured` rather than silently signing with a stale key.
+        let vapid = config.push.load_vapid_key().unwrap_or_else(|e| {
+            tracing::error!(error = %e, "the `[push]` VAPID key failed to load; sends will fail");
+            None
+        });
+        let subject = config.push.subject_or_default();
+        let ttl_secs = config.push.ttl_secs.unwrap_or(DEFAULT_TTL_SECS);
+
+        let transport = Self::default_transport(state);
+
+        #[cfg(feature = "db")]
+        let store: Arc<dyn BoxedPushSubscriptionStore> =
+            if let Some(pool) = crate::db::DbState::pool(state) {
+                Arc::new(super::store::DbPushSubscriptionStore::new(pool.clone()))
+            } else {
+                Arc::new(super::store::MemoryPushSubscriptionStore::new())
+            };
+        #[cfg(not(feature = "db"))]
+        let store: Arc<dyn BoxedPushSubscriptionStore> =
+            Arc::new(super::store::MemoryPushSubscriptionStore::new());
+
+        Self {
+            store,
+            vapid: vapid.map(Arc::new),
+            subject: subject.into(),
+            transport,
+            ttl_secs,
+            clock: state.clock_arc(),
+        }
+    }
+
+    /// [`default_for`](Self::default_for) with an explicitly registered store.
+    ///
+    /// Used by
+    /// [`AppBuilder::with_push_subscription_store`](crate::app::AppBuilder::with_push_subscription_store),
+    /// so a custom store still picks up the app's configured key, subject,
+    /// TTL, transport and clock.
+    pub(crate) fn from_state_with_store(
+        state: &AppState,
+        store: impl PushSubscriptionStore,
+    ) -> Self {
+        Self {
+            store: Arc::new(store),
+            ..Self::default_for(state)
+        }
+    }
+
+    /// The transport a resolved service uses: a real HTTP client when one can
+    /// be built, otherwise a transport that reports the failure rather than
+    /// pretending to deliver.
+    fn default_transport(state: &AppState) -> Arc<dyn PushTransport> {
+        #[cfg(feature = "http-client")]
+        {
+            Arc::new(super::transport::HttpPushTransport::new(
+                crate::http_client::Client::from_state(state),
+            ))
+        }
+        #[cfg(not(feature = "http-client"))]
+        {
+            let _ = state;
+            Arc::new(super::transport::UnavailablePushTransport)
+        }
+    }
+}
+
+impl axum::extract::FromRequestParts<AppState> for WebPush {
+    // Resolution always succeeds (a store fallback always exists, and a
+    // missing key surfaces from `send`, not extraction) — the same contract
+    // `Notifications` and `Session` have.
+    type Rejection = std::convert::Infallible;
+
+    async fn from_request_parts(
+        _parts: &mut axum::http::request::Parts,
+        state: &AppState,
+    ) -> Result<Self, Self::Rejection> {
+        // Fast path: a service registered by `AppBuilder::with_web_push` /
+        // `with_push_subscription_store`, or resolved by an earlier request.
+        if let Some(existing) = state.extension::<Self>() {
+            return Ok((*existing).clone());
+        }
+
+        // Resolve OUTSIDE `extension_or_insert_with`.
+        //
+        // That helper holds the extensions **write** lock while it calls its
+        // closure, and `default_for` reads other extensions off the same state
+        // (the shared outbound HTTP client, and the mock registry under test).
+        // A `std::sync::RwLock` is not reentrant, so resolving inside the
+        // closure takes a read lock on a lock this thread already holds for
+        // writing — and the request hangs forever. `Notifications` can resolve
+        // inline only because its closure touches nothing but the database
+        // pool.
+        //
+        // Building before the lock costs at most a redundant construction when
+        // two requests race; `extension_or_insert_with` re-checks under the
+        // lock, so exactly one is stored and the loser is dropped.
+        let resolved = Self::default_for(state);
+        // `extension_or_insert_with` keeps the resolved service (and thus the
+        // memory store's contents) stable across requests.
+        Ok((*state.extension_or_insert_with::<Self>(|| resolved)).clone())
+    }
+}
+
+/// The origin of an endpoint URL, for logging.
+///
+/// A full push endpoint URL is a **capability**: anyone holding one can send
+/// to that device. Logs are copied, shipped, and retained far more widely than
+/// the subscription table, so framework logs record only the origin — enough
+/// to tell FCM apart from Mozilla autopush when diagnosing a delivery problem,
+/// and useless to anyone who reads the log.
+fn endpoint_origin(endpoint: &str) -> String {
+    url::Url::parse(endpoint).map_or_else(
+        |_| "<unparseable>".to_owned(),
+        |parsed| parsed.origin().ascii_serialization(),
+    )
 }
 
 impl std::fmt::Debug for WebPush {
@@ -535,7 +702,7 @@ mod tests {
         plaintext
     }
 
-    async fn web_push_with(transport: RecordingPushTransport) -> (WebPush, VapidKey) {
+    fn web_push_with(transport: RecordingPushTransport) -> (WebPush, VapidKey) {
         let vapid = VapidKey::generate();
         let push = WebPush::new(
             MemoryPushSubscriptionStore::new(),
@@ -572,12 +739,12 @@ mod tests {
 
     #[tokio::test]
     async fn subscribe_records_the_subscription_for_the_principal() {
-        let (push, _) = web_push_with(RecordingPushTransport::new()).await;
+        let (push, _) = web_push_with(RecordingPushTransport::new());
         let stored = push
             .subscribe(7_i64, &browser_subscription("https://push.example.com/a"))
             .await
             .expect("subscribe");
-        assert_eq!(stored.principal_id, "7");
+        assert_eq!(stored.principal_id(), "7");
         let report = push
             .send(7_i64, &PushMessage::new("Hi", "There"))
             .await
@@ -590,7 +757,7 @@ mod tests {
 
     #[tokio::test]
     async fn subscribe_rejects_a_malformed_payload_rather_than_storing_it() {
-        let (push, _) = web_push_with(RecordingPushTransport::new()).await;
+        let (push, _) = web_push_with(RecordingPushTransport::new());
         let mut bad = browser_subscription("https://push.example.com/a");
         bad.keys.auth = URL_SAFE_NO_PAD.encode([0_u8; 4]);
         let err = push.subscribe(7_i64, &bad).await.expect_err("rejected");
@@ -602,7 +769,7 @@ mod tests {
 
     #[tokio::test]
     async fn unsubscribe_removes_only_the_callers_own_endpoint() {
-        let (push, _) = web_push_with(RecordingPushTransport::new()).await;
+        let (push, _) = web_push_with(RecordingPushTransport::new());
         push.subscribe(7_i64, &browser_subscription("https://push.example.com/a"))
             .await
             .expect("subscribe");
@@ -631,7 +798,7 @@ mod tests {
 
     #[tokio::test]
     async fn unsubscribing_an_unknown_endpoint_reports_false_not_an_error() {
-        let (push, _) = web_push_with(RecordingPushTransport::new()).await;
+        let (push, _) = web_push_with(RecordingPushTransport::new());
         assert!(
             !push
                 .unsubscribe(7_i64, "https://push.example.com/never")
@@ -645,7 +812,7 @@ mod tests {
     #[tokio::test]
     async fn send_dispatches_to_the_recorded_endpoint() {
         let transport = RecordingPushTransport::new();
-        let (push, _) = web_push_with(transport.clone()).await;
+        let (push, _) = web_push_with(transport.clone());
         push.subscribe(7_i64, &browser_subscription("https://push.example.com/abc"))
             .await
             .expect("subscribe");
@@ -669,7 +836,7 @@ mod tests {
         use p256::ecdsa::signature::Verifier;
 
         let transport = RecordingPushTransport::new();
-        let (push, vapid) = web_push_with(transport.clone()).await;
+        let (push, vapid) = web_push_with(transport.clone());
         push.subscribe(7_i64, &browser_subscription("https://push.example.com/abc"))
             .await
             .expect("subscribe");
@@ -713,7 +880,7 @@ mod tests {
     #[tokio::test]
     async fn dispatched_request_carries_the_aes128gcm_content_headers() {
         let transport = RecordingPushTransport::new();
-        let (push, _) = web_push_with(transport.clone()).await;
+        let (push, _) = web_push_with(transport.clone());
         push.subscribe(7_i64, &browser_subscription("https://push.example.com/abc"))
             .await
             .expect("subscribe");
@@ -739,7 +906,7 @@ mod tests {
     #[tokio::test]
     async fn dispatched_body_decrypts_to_the_message_in_the_browser() {
         let transport = RecordingPushTransport::new();
-        let (push, _) = web_push_with(transport.clone()).await;
+        let (push, _) = web_push_with(transport.clone());
         push.subscribe(7_i64, &browser_subscription("https://push.example.com/abc"))
             .await
             .expect("subscribe");
@@ -762,7 +929,7 @@ mod tests {
     #[tokio::test]
     async fn each_device_gets_its_own_request() {
         let transport = RecordingPushTransport::new();
-        let (push, _) = web_push_with(transport.clone()).await;
+        let (push, _) = web_push_with(transport.clone());
         push.subscribe(
             7_i64,
             &browser_subscription("https://push.example.com/laptop"),
@@ -799,7 +966,7 @@ mod tests {
     #[tokio::test]
     async fn every_message_gets_fresh_encryption_material() {
         let transport = RecordingPushTransport::new();
-        let (push, _) = web_push_with(transport.clone()).await;
+        let (push, _) = web_push_with(transport.clone());
         push.subscribe(7_i64, &browser_subscription("https://push.example.com/abc"))
             .await
             .expect("subscribe");
@@ -822,7 +989,7 @@ mod tests {
     async fn a_410_gone_prunes_the_subscription() {
         let transport =
             RecordingPushTransport::new().responding_with("https://push.example.com/dead", 410);
-        let (push, _) = web_push_with(transport.clone()).await;
+        let (push, _) = web_push_with(transport.clone());
         push.subscribe(
             7_i64,
             &browser_subscription("https://push.example.com/dead"),
@@ -858,7 +1025,7 @@ mod tests {
     async fn a_404_not_found_also_prunes() {
         let transport =
             RecordingPushTransport::new().responding_with("https://push.example.com/gone", 404);
-        let (push, _) = web_push_with(transport.clone()).await;
+        let (push, _) = web_push_with(transport.clone());
         push.subscribe(
             7_i64,
             &browser_subscription("https://push.example.com/gone"),
@@ -882,7 +1049,7 @@ mod tests {
         // permission.
         let transport =
             RecordingPushTransport::new().responding_with("https://push.example.com/a", 503);
-        let (push, _) = web_push_with(transport.clone()).await;
+        let (push, _) = web_push_with(transport.clone());
         push.subscribe(7_i64, &browser_subscription("https://push.example.com/a"))
             .await
             .expect("subscribe");
@@ -910,7 +1077,7 @@ mod tests {
     async fn one_dead_device_does_not_stop_delivery_to_the_others() {
         let transport =
             RecordingPushTransport::new().responding_with("https://push.example.com/dead", 410);
-        let (push, _) = web_push_with(transport.clone()).await;
+        let (push, _) = web_push_with(transport.clone());
         push.subscribe(
             7_i64,
             &browser_subscription("https://push.example.com/dead"),
@@ -935,7 +1102,7 @@ mod tests {
     #[tokio::test]
     async fn sending_to_a_principal_with_no_subscriptions_is_a_no_op() {
         let transport = RecordingPushTransport::new();
-        let (push, _) = web_push_with(transport.clone()).await;
+        let (push, _) = web_push_with(transport.clone());
         let report = push
             .send(99_i64, &PushMessage::new("Hi", "There"))
             .await
@@ -970,7 +1137,7 @@ mod tests {
 
     #[tokio::test]
     async fn vapid_public_key_is_the_browsers_application_server_key() {
-        let (push, vapid) = web_push_with(RecordingPushTransport::new()).await;
+        let (push, vapid) = web_push_with(RecordingPushTransport::new());
         assert_eq!(
             push.vapid_public_key().expect("configured"),
             vapid.public_key_base64url()
@@ -993,7 +1160,7 @@ mod tests {
     #[tokio::test]
     async fn an_oversize_message_is_refused_before_any_dispatch() {
         let transport = RecordingPushTransport::new();
-        let (push, _) = web_push_with(transport.clone()).await;
+        let (push, _) = web_push_with(transport.clone());
         push.subscribe(7_i64, &browser_subscription("https://push.example.com/a"))
             .await
             .expect("subscribe");
@@ -1014,7 +1181,7 @@ mod tests {
     #[tokio::test]
     async fn send_many_fans_out_across_principals() {
         let transport = RecordingPushTransport::new();
-        let (push, _) = web_push_with(transport.clone()).await;
+        let (push, _) = web_push_with(transport.clone());
         push.subscribe(1_i64, &browser_subscription("https://push.example.com/one"))
             .await
             .expect("subscribe");
@@ -1040,7 +1207,7 @@ mod tests {
     async fn send_many_aggregates_pruning_across_principals() {
         let transport =
             RecordingPushTransport::new().responding_with("https://push.example.com/dead", 410);
-        let (push, _) = web_push_with(transport.clone()).await;
+        let (push, _) = web_push_with(transport.clone());
         push.subscribe(
             1_i64,
             &browser_subscription("https://push.example.com/dead"),
@@ -1068,7 +1235,7 @@ mod tests {
     #[tokio::test]
     async fn send_many_accepts_string_principals_too() {
         let transport = RecordingPushTransport::new();
-        let (push, _) = web_push_with(transport.clone()).await;
+        let (push, _) = web_push_with(transport.clone());
         push.subscribe(
             "service:ci",
             &browser_subscription("https://push.example.com/ci"),
@@ -1081,6 +1248,254 @@ mod tests {
                 .expect("send_many")
                 .delivered,
             1
+        );
+    }
+
+    // ── TTL and clock ───────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn ttl_defaults_to_the_documented_value() {
+        // `ttl.parse().is_ok()` would pass for `0`, which means
+        // deliver-now-or-drop — a real behavioural difference for the offline
+        // device this feature exists to reach.
+        let transport = RecordingPushTransport::new();
+        let (push, _) = web_push_with(transport.clone());
+        push.subscribe(7_i64, &browser_subscription("https://push.example.com/a"))
+            .await
+            .expect("subscribe");
+        push.send(7_i64, &PushMessage::new("Hi", "There"))
+            .await
+            .expect("send");
+        assert_eq!(
+            transport.requests()[0].header("ttl"),
+            Some(DEFAULT_TTL_SECS.to_string().as_str())
+        );
+    }
+
+    #[tokio::test]
+    async fn a_configured_ttl_reaches_the_dispatched_header() {
+        let transport = RecordingPushTransport::new();
+        let (push, _) = web_push_with(transport.clone());
+        let push = push.with_ttl_secs(60);
+        push.subscribe(7_i64, &browser_subscription("https://push.example.com/a"))
+            .await
+            .expect("subscribe");
+        push.send(7_i64, &PushMessage::new("Hi", "There"))
+            .await
+            .expect("send");
+        assert_eq!(transport.requests()[0].header("ttl"), Some("60"));
+    }
+
+    #[tokio::test]
+    async fn the_jwt_exp_is_anchored_to_the_frameworks_clock() {
+        // A broken clock (or the `unwrap_or(0)` in `build_request` firing)
+        // would put `exp` in 1970 and make every real send be rejected by the
+        // push service — with signature verification still passing, so no
+        // other test would notice.
+        use chrono::{TimeZone as _, Utc};
+
+        let issued = Utc.timestamp_opt(1_800_000_000, 0).single().expect("time");
+        let transport = RecordingPushTransport::new();
+        let (push, _) = web_push_with(transport.clone());
+        let push = push.with_clock(std::sync::Arc::new(crate::time::FixedClock::at(issued)));
+        push.subscribe(7_i64, &browser_subscription("https://push.example.com/a"))
+            .await
+            .expect("subscribe");
+        push.send(7_i64, &PushMessage::new("Hi", "There"))
+            .await
+            .expect("send");
+
+        let authorization = transport.requests()[0]
+            .header("authorization")
+            .expect("header")
+            .to_owned();
+        let jwt = authorization
+            .strip_prefix("vapid t=")
+            .and_then(|rest| rest.split_once(", k="))
+            .expect("vapid header")
+            .0
+            .to_owned();
+        let claims = URL_SAFE_NO_PAD
+            .decode(jwt.split('.').nth(1).expect("claims"))
+            .expect("base64url");
+        let claims: serde_json::Value = serde_json::from_slice(&claims).expect("json");
+        assert_eq!(
+            claims["exp"].as_u64().expect("exp"),
+            1_800_000_000 + crate::push::vapid::VAPID_TOKEN_TTL_SECS,
+            "exp must be derived from the injected clock, not wall time or zero"
+        );
+    }
+
+    // ── Store failures ──────────────────────────────────────────────────────
+
+    /// A store whose every operation fails, for the paths
+    /// [`MemoryPushSubscriptionStore`] can never reach.
+    #[derive(Debug, Default)]
+    struct BrokenStore;
+
+    impl PushSubscriptionStore for BrokenStore {
+        async fn save(&self, _subscription: StoredSubscription) -> Result<(), PushError> {
+            Err(PushError::Store("save exploded".to_owned()))
+        }
+        async fn list_for(
+            &self,
+            _principal_id: &str,
+        ) -> Result<Vec<StoredSubscription>, PushError> {
+            Err(PushError::Store("list exploded".to_owned()))
+        }
+        async fn remove(
+            &self,
+            _endpoint: &str,
+            _principal_id: Option<&str>,
+        ) -> Result<u64, PushError> {
+            Err(PushError::Store("remove exploded".to_owned()))
+        }
+    }
+
+    /// A store that reads fine but cannot delete — the shape that makes a
+    /// prune fail after the message has already been dispatched.
+    #[derive(Debug)]
+    struct UnprunableStore(MemoryPushSubscriptionStore);
+
+    impl PushSubscriptionStore for UnprunableStore {
+        async fn save(&self, subscription: StoredSubscription) -> Result<(), PushError> {
+            self.0.save(subscription).await
+        }
+        async fn list_for(&self, principal_id: &str) -> Result<Vec<StoredSubscription>, PushError> {
+            self.0.list_for(principal_id).await
+        }
+        async fn remove(
+            &self,
+            _endpoint: &str,
+            _principal_id: Option<&str>,
+        ) -> Result<u64, PushError> {
+            Err(PushError::Store("remove exploded".to_owned()))
+        }
+    }
+
+    #[tokio::test]
+    async fn a_store_failure_on_read_surfaces_rather_than_reporting_zero_deliveries() {
+        let push = WebPush::new(
+            BrokenStore,
+            VapidKey::generate(),
+            "mailto:ops@example.com",
+            RecordingPushTransport::new(),
+        );
+        let err = push
+            .send(7_i64, &PushMessage::new("Hi", "There"))
+            .await
+            .expect_err("a broken store must not look like `no subscriptions`");
+        assert!(matches!(err, PushError::Store(_)), "{err:?}");
+    }
+
+    #[tokio::test]
+    async fn a_failed_prune_does_not_abort_delivery_to_the_other_devices() {
+        // The prune happens AFTER dispatch. Propagating a store failure there
+        // would discard the deliveries that already succeeded and skip the
+        // ones still to come — the opposite of "a dead device never blocks a
+        // live one".
+        let transport =
+            RecordingPushTransport::new().responding_with("https://push.example.com/dead", 410);
+        let push = WebPush::new(
+            UnprunableStore(MemoryPushSubscriptionStore::new()),
+            VapidKey::generate(),
+            "mailto:ops@example.com",
+            transport.clone(),
+        );
+        push.subscribe(
+            7_i64,
+            &browser_subscription("https://push.example.com/dead"),
+        )
+        .await
+        .expect("subscribe");
+        push.subscribe(
+            7_i64,
+            &browser_subscription("https://push.example.com/live"),
+        )
+        .await
+        .expect("subscribe");
+
+        let report = push
+            .send(7_i64, &PushMessage::new("Hi", "There"))
+            .await
+            .expect("a prune failure must not fail the send");
+        assert_eq!(
+            report.delivered, 1,
+            "the live device must still be reported as delivered"
+        );
+        assert!(
+            report.pruned.is_empty(),
+            "nothing was actually pruned, so nothing may be reported as pruned"
+        );
+        assert_eq!(report.failed, 1);
+        assert_eq!(transport.requests().len(), 2, "both devices were attempted");
+    }
+
+    // ── Cross-origin fan-out ────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn each_endpoint_gets_a_jwt_audienced_to_its_own_push_service() {
+        // Real deployments mix FCM, Mozilla autopush and WNS. A bug that
+        // computed `aud` once — or reused one Authorization header across
+        // devices — would pass every single-origin test and then be rejected
+        // by every push service but the first.
+        let transport = RecordingPushTransport::new();
+        let (push, _) = web_push_with(transport.clone());
+        for endpoint in [
+            "https://fcm.googleapis.com/fcm/send/abc",
+            "https://updates.push.services.mozilla.com/wpush/v2/xyz",
+        ] {
+            push.subscribe(7_i64, &browser_subscription(endpoint))
+                .await
+                .expect("subscribe");
+        }
+        push.send(7_i64, &PushMessage::new("Hi", "There"))
+            .await
+            .expect("send");
+
+        for request in transport.requests() {
+            let authorization = request.header("authorization").expect("header");
+            let jwt = authorization
+                .strip_prefix("vapid t=")
+                .and_then(|rest| rest.split_once(", k="))
+                .expect("vapid header")
+                .0;
+            let claims = URL_SAFE_NO_PAD
+                .decode(jwt.split('.').nth(1).expect("claims"))
+                .expect("base64url");
+            let claims: serde_json::Value = serde_json::from_slice(&claims).expect("json");
+            let expected = url::Url::parse(&request.endpoint)
+                .expect("endpoint parses")
+                .origin()
+                .ascii_serialization();
+            assert_eq!(
+                claims["aud"], expected,
+                "each request's aud must be ITS OWN endpoint's origin"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn every_device_gets_its_own_encryption_material() {
+        // One ephemeral key or salt reused across two subscriptions in the
+        // same send would be an actual cryptographic break.
+        let transport = RecordingPushTransport::new();
+        let (push, _) = web_push_with(transport.clone());
+        for endpoint in ["https://push.example.com/a", "https://push.example.com/b"] {
+            push.subscribe(7_i64, &browser_subscription(endpoint))
+                .await
+                .expect("subscribe");
+        }
+        push.send(7_i64, &PushMessage::new("Hi", "There"))
+            .await
+            .expect("send");
+
+        let requests = transport.requests();
+        assert_ne!(requests[0].body[..16], requests[1].body[..16], "salt");
+        assert_ne!(
+            requests[0].body[21..86],
+            requests[1].body[21..86],
+            "ephemeral key"
         );
     }
 }

--- a/autumn/src/push/service.rs
+++ b/autumn/src/push/service.rs
@@ -28,7 +28,7 @@ use super::PushError;
 use super::encryption;
 use super::store::{
     BoxedPushSubscriptionStore, BrowserSubscription, PushPrincipal, PushSubscriptionStore,
-    StoredSubscription,
+    StoredSubscription, endpoint_origin,
 };
 use super::transport::{PushRequest, PushTransport};
 use super::vapid::VapidKey;
@@ -663,20 +663,6 @@ impl axum::extract::FromRequestParts<AppState> for WebPush {
         // memory store's contents) stable across requests.
         Ok((*state.extension_or_insert_with::<Self>(|| resolved)).clone())
     }
-}
-
-/// The origin of an endpoint URL, for logging.
-///
-/// A full push endpoint URL is a **capability**: anyone holding one can send
-/// to that device. Logs are copied, shipped, and retained far more widely than
-/// the subscription table, so framework logs record only the origin — enough
-/// to tell FCM apart from Mozilla autopush when diagnosing a delivery problem,
-/// and useless to anyone who reads the log.
-fn endpoint_origin(endpoint: &str) -> String {
-    url::Url::parse(endpoint).map_or_else(
-        |_| "<unparseable>".to_owned(),
-        |parsed| parsed.origin().ascii_serialization(),
-    )
 }
 
 impl std::fmt::Debug for WebPush {

--- a/autumn/src/push/service.rs
+++ b/autumn/src/push/service.rs
@@ -1,0 +1,1086 @@
+//! The Web Push send API: [`WebPush`].
+//!
+//! This is the surface an application actually touches. Everything
+//! cryptographic — minting the VAPID JWT, deriving keys, encrypting the
+//! payload — happens below it, so sending a notification is one call:
+//!
+//! ```rust,ignore
+//! use autumn_web::push::{PushMessage, WebPush};
+//! use autumn_web::prelude::*;
+//!
+//! #[post("/builds/{id}/fail")]
+//! async fn build_failed(push: WebPush, id: Path<i64>) -> AutumnResult<&'static str> {
+//!     push.send(
+//!         owner_id,
+//!         &PushMessage::new("Build failed", "main is red").url(format!("/builds/{}", *id)),
+//!     )
+//!     .await?;
+//!     Ok("ok")
+//! }
+//! ```
+
+use std::sync::Arc;
+
+use serde::{Deserialize, Serialize};
+
+use super::PushError;
+use super::encryption;
+use super::store::{
+    BoxedPushSubscriptionStore, BrowserSubscription, PushPrincipal, PushSubscriptionStore,
+    StoredSubscription,
+};
+use super::transport::{PushRequest, PushTransport};
+use super::vapid::VapidKey;
+
+/// Default `TTL` (RFC 8030 §5.2) on a dispatched message: how long the push
+/// service may hold it for a device that is currently offline.
+///
+/// Four weeks matches what push services accept as an upper bound and suits
+/// the re-engagement case this exists for — a notification is still worth
+/// delivering when the user's laptop comes back online tomorrow.
+pub const DEFAULT_TTL_SECS: u32 = 4 * 7 * 24 * 60 * 60;
+
+// ── Message ─────────────────────────────────────────────────────────────────
+
+/// What the user sees: the payload delivered to the service worker's `push`
+/// event.
+///
+/// Serialized as JSON, so the generated service worker can read
+/// `event.data.json()` and hand `title`/`body`/`icon` straight to
+/// `showNotification`, with `url` driving the `notificationclick` handler.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PushMessage {
+    /// The notification's title line.
+    pub title: String,
+    /// The notification's body text.
+    pub body: String,
+    /// Where clicking the notification takes the user. Omitted when unset, so
+    /// the service worker's `notificationclick` handler can fall back to the
+    /// app root.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub url: Option<String>,
+    /// Icon URL shown alongside the notification. Omitted when unset.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub icon: Option<String>,
+}
+
+impl PushMessage {
+    /// A message with just a title and body.
+    #[must_use]
+    pub fn new(title: impl Into<String>, body: impl Into<String>) -> Self {
+        Self {
+            title: title.into(),
+            body: body.into(),
+            url: None,
+            icon: None,
+        }
+    }
+
+    /// Set where clicking the notification navigates.
+    #[must_use]
+    pub fn url(mut self, url: impl Into<String>) -> Self {
+        self.url = Some(url.into());
+        self
+    }
+
+    /// Set the notification's icon URL.
+    #[must_use]
+    pub fn icon(mut self, icon: impl Into<String>) -> Self {
+        self.icon = Some(icon.into());
+        self
+    }
+}
+
+// ── Delivery report ─────────────────────────────────────────────────────────
+
+/// What one [`WebPush::send`] (or [`send_many`](WebPush::send_many)) actually
+/// achieved.
+///
+/// A send never fails because one device is unreachable — a user with three
+/// devices, one of which has revoked permission, still gets the notification
+/// on the other two. This report is how that partial outcome is surfaced
+/// rather than swallowed.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct PushDeliveryReport {
+    /// Subscriptions the push service accepted the message for.
+    pub delivered: usize,
+    /// Endpoints the push service reported as gone (`404`/`410`); these have
+    /// been removed from the store and will not be tried again.
+    pub pruned: Vec<String>,
+    /// Subscriptions that failed for a reason that is **not** staleness (a
+    /// push service outage, a rate limit, a transport error). These are left
+    /// in the store to be retried.
+    pub failed: usize,
+}
+
+impl PushDeliveryReport {
+    /// Fold `other` into this report.
+    fn merge(&mut self, other: Self) {
+        self.delivered += other.delivered;
+        self.failed += other.failed;
+        self.pruned.extend(other.pruned);
+    }
+}
+
+// ── Service ─────────────────────────────────────────────────────────────────
+
+/// The Web Push service.
+///
+/// Declare it as a handler parameter (it implements `FromRequestParts`, like
+/// [`Notifications`](crate::notifications::Notifications)) or construct one
+/// directly with [`WebPush::new`] in tests and background jobs.
+///
+/// # Store and key resolution
+///
+/// As a handler extractor the store resolves the same way the notification
+/// feed's does — an explicitly registered store, else the database-backed
+/// store when a pool is configured, else the in-memory one — and the VAPID key
+/// comes from the `[push]` config block, validated once at boot.
+#[derive(Clone)]
+pub struct WebPush {
+    store: Arc<dyn BoxedPushSubscriptionStore>,
+    /// `None` when no VAPID key is configured. Sending then fails with
+    /// [`PushError::NotConfigured`] — never silently succeeds.
+    vapid: Option<Arc<VapidKey>>,
+    subject: Arc<str>,
+    transport: Arc<dyn PushTransport>,
+    ttl_secs: u32,
+    clock: Arc<dyn crate::time::ClockSource>,
+}
+
+impl WebPush {
+    /// Build a service over an explicit store, key, and transport.
+    ///
+    /// `subject` is the VAPID `sub` claim: a `mailto:` or `https:` URL a push
+    /// service operator can use to reach you about your traffic.
+    #[must_use]
+    pub fn new(
+        store: impl PushSubscriptionStore,
+        vapid: VapidKey,
+        subject: impl Into<String>,
+        transport: impl PushTransport,
+    ) -> Self {
+        Self {
+            store: Arc::new(store),
+            vapid: Some(Arc::new(vapid)),
+            subject: subject.into().into(),
+            transport: Arc::new(transport),
+            ttl_secs: DEFAULT_TTL_SECS,
+            clock: Arc::new(crate::time::SystemClock),
+        }
+    }
+
+    /// A service with **no** VAPID key: subscriptions can still be recorded,
+    /// but every send fails with [`PushError::NotConfigured`].
+    ///
+    /// This is what an app that has generated a PWA but not yet configured
+    /// `[push]` gets. Recording subscriptions early is harmless and means the
+    /// app starts delivering the moment a key is configured; sending, by
+    /// contrast, must never look like it worked.
+    #[must_use]
+    pub fn without_vapid_key(
+        store: impl PushSubscriptionStore,
+        subject: impl Into<String>,
+        transport: impl PushTransport,
+    ) -> Self {
+        Self {
+            store: Arc::new(store),
+            vapid: None,
+            subject: subject.into().into(),
+            transport: Arc::new(transport),
+            ttl_secs: DEFAULT_TTL_SECS,
+            clock: Arc::new(crate::time::SystemClock),
+        }
+    }
+
+    /// Override the `TTL` sent to the push service (default
+    /// [`DEFAULT_TTL_SECS`]).
+    #[must_use]
+    pub const fn with_ttl_secs(mut self, ttl_secs: u32) -> Self {
+        self.ttl_secs = ttl_secs;
+        self
+    }
+
+    /// Override the clock used for the VAPID JWT's `exp`.
+    #[must_use]
+    pub fn with_clock(mut self, clock: Arc<dyn crate::time::ClockSource>) -> Self {
+        self.clock = clock;
+        self
+    }
+
+    /// The `applicationServerKey` a browser needs to subscribe.
+    ///
+    /// Serve this to the client (the built-in [`router`](super::router) does,
+    /// at `/push/vapid-public-key`). It is public key material — safe to
+    /// expose to any visitor.
+    ///
+    /// # Errors
+    ///
+    /// [`PushError::NotConfigured`] when no VAPID key is configured.
+    pub fn vapid_public_key(&self) -> Result<String, PushError> {
+        self.vapid
+            .as_ref()
+            .map(|key| key.public_key_base64url())
+            .ok_or(PushError::NotConfigured)
+    }
+
+    /// Validate a browser `PushSubscription` and record it for `principal`.
+    ///
+    /// Re-subscribing the same endpoint updates the existing row rather than
+    /// creating a second one, so a browser that re-subscribes on every page
+    /// load (which is the recommended client pattern) never accumulates
+    /// duplicates.
+    ///
+    /// # Errors
+    ///
+    /// [`PushError::InvalidEndpoint`] / [`PushError::InvalidSubscriptionKey`]
+    /// for a payload that fails validation, or [`PushError::Store`] when the
+    /// store fails.
+    pub async fn subscribe(
+        &self,
+        principal: impl Into<PushPrincipal> + Send,
+        subscription: &BrowserSubscription,
+    ) -> Result<StoredSubscription, PushError> {
+        let stored = subscription.decode(&principal.into())?;
+        self.store.boxed_save(stored.clone()).await?;
+        Ok(stored)
+    }
+
+    /// Remove `principal`'s subscription for `endpoint`.
+    ///
+    /// Scoped to the caller: an endpoint belonging to a different principal is
+    /// left untouched and reported as `false`, so a signed-in user can never
+    /// unsubscribe someone else's device. Idempotent — an endpoint that was
+    /// never subscribed is `Ok(false)`, not an error.
+    ///
+    /// # Errors
+    ///
+    /// [`PushError::Store`] when the store fails.
+    pub async fn unsubscribe(
+        &self,
+        principal: impl Into<PushPrincipal> + Send,
+        endpoint: &str,
+    ) -> Result<bool, PushError> {
+        let principal = principal.into();
+        let removed = self
+            .store
+            .boxed_remove(endpoint.to_owned(), Some(principal.as_str().to_owned()))
+            .await?;
+        Ok(removed > 0)
+    }
+
+    /// Deliver `message` to every device `principal` has subscribed.
+    ///
+    /// A principal with no subscriptions is not an error — it just means the
+    /// user never granted notification permission — and returns an empty
+    /// report. Per-device failures are reported, not raised: see
+    /// [`PushDeliveryReport`].
+    ///
+    /// # Errors
+    ///
+    /// - [`PushError::NotConfigured`] when no VAPID key is configured. This is
+    ///   raised **before** anything is dispatched, so an unconfigured app
+    ///   fails loudly rather than appearing to send.
+    /// - [`PushError::PayloadTooLarge`] when the encoded message exceeds what
+    ///   push services are required to accept — also raised before dispatch,
+    ///   since it would fail identically for every device.
+    /// - [`PushError::Store`] when the subscription store itself fails.
+    pub async fn send(
+        &self,
+        principal: impl Into<PushPrincipal> + Send,
+        message: &PushMessage,
+    ) -> Result<PushDeliveryReport, PushError> {
+        let principal = principal.into();
+        // Fail fast, before touching the store: a missing key or an oversize
+        // payload fails identically for every device, so discovering it
+        // per-device would just be N copies of the same error.
+        let vapid = self.vapid.as_ref().ok_or(PushError::NotConfigured)?;
+        let payload = Self::encode(message)?;
+
+        let subscriptions = self
+            .store
+            .boxed_list_for(principal.as_str().to_owned())
+            .await?;
+
+        let mut report = PushDeliveryReport::default();
+        for subscription in subscriptions {
+            report.merge(self.deliver_one(vapid, &subscription, &payload).await?);
+        }
+        Ok(report)
+    }
+
+    /// [`send`](Self::send) to many principals, aggregating one report.
+    ///
+    /// Deduplication is *not* performed: passing the same principal twice
+    /// sends twice. Principals with no subscriptions contribute nothing.
+    ///
+    /// # Errors
+    ///
+    /// As [`send`](Self::send).
+    pub async fn send_many<P>(
+        &self,
+        principals: impl IntoIterator<Item = P> + Send,
+        message: &PushMessage,
+    ) -> Result<PushDeliveryReport, PushError>
+    where
+        P: Into<PushPrincipal> + Send,
+    {
+        let mut report = PushDeliveryReport::default();
+        for principal in principals {
+            report.merge(self.send(principal, message).await?);
+        }
+        Ok(report)
+    }
+
+    /// Serialize a message and check it against the payload ceiling.
+    fn encode(message: &PushMessage) -> Result<Vec<u8>, PushError> {
+        let payload = serde_json::to_vec(message)
+            .map_err(|e| PushError::Encryption(format!("payload serialization: {e}")))?;
+        if payload.len() > encryption::MAX_PLAINTEXT_LEN {
+            return Err(PushError::PayloadTooLarge {
+                len: payload.len(),
+                max: encryption::MAX_PLAINTEXT_LEN,
+            });
+        }
+        Ok(payload)
+    }
+
+    /// Encrypt, sign, dispatch, and interpret the result for one subscription.
+    async fn deliver_one(
+        &self,
+        vapid: &VapidKey,
+        subscription: &StoredSubscription,
+        payload: &[u8],
+    ) -> Result<PushDeliveryReport, PushError> {
+        let request = match self.build_request(vapid, subscription, payload) {
+            Ok(request) => request,
+            Err(e) => {
+                // A row that no longer encrypts (a key corrupted in storage,
+                // an endpoint that is no longer a valid URL) can never
+                // succeed, but it must not abort delivery to this principal's
+                // other devices either.
+                tracing::warn!(
+                    endpoint = %subscription.endpoint,
+                    error = %e,
+                    "skipping a push subscription that could not be encoded"
+                );
+                return Ok(PushDeliveryReport {
+                    failed: 1,
+                    ..Default::default()
+                });
+            }
+        };
+
+        let status = match self.transport.deliver(&request).await {
+            Ok(status) => status,
+            Err(e) => {
+                tracing::warn!(
+                    endpoint = %subscription.endpoint,
+                    error = %e,
+                    "push transport failed"
+                );
+                return Ok(PushDeliveryReport {
+                    failed: 1,
+                    ..Default::default()
+                });
+            }
+        };
+
+        // RFC 8030 §7.3: `404 Not Found` and `410 Gone` are the push service
+        // saying this subscription no longer exists. Every OTHER failure —
+        // including a 5xx outage or a 429 rate limit — is transient, and
+        // pruning on those would silently unsubscribe every user during an
+        // incident, unrecoverable without them re-granting permission.
+        match status {
+            200..=299 => Ok(PushDeliveryReport {
+                delivered: 1,
+                ..Default::default()
+            }),
+            404 | 410 => {
+                // Unscoped: the endpoint is dead for whoever owns it.
+                self.store
+                    .boxed_remove(subscription.endpoint.clone(), None)
+                    .await?;
+                tracing::debug!(
+                    endpoint = %subscription.endpoint,
+                    status,
+                    "pruned a stale push subscription"
+                );
+                Ok(PushDeliveryReport {
+                    pruned: vec![subscription.endpoint.clone()],
+                    ..Default::default()
+                })
+            }
+            other => {
+                tracing::warn!(
+                    endpoint = %subscription.endpoint,
+                    status = other,
+                    "push service rejected a message; leaving the subscription in place"
+                );
+                Ok(PushDeliveryReport {
+                    failed: 1,
+                    ..Default::default()
+                })
+            }
+        }
+    }
+
+    /// Build the encrypted, VAPID-signed request for one subscription.
+    fn build_request(
+        &self,
+        vapid: &VapidKey,
+        subscription: &StoredSubscription,
+        payload: &[u8],
+    ) -> Result<PushRequest, PushError> {
+        let body = encryption::encrypt(payload, &subscription.p256dh, &subscription.auth)?;
+        let issued_at = u64::try_from(self.clock.now().timestamp()).unwrap_or(0);
+        let authorization =
+            vapid.authorization_header(&subscription.endpoint, &self.subject, issued_at)?;
+        Ok(PushRequest {
+            endpoint: subscription.endpoint.clone(),
+            headers: vec![
+                ("authorization".to_owned(), authorization),
+                ("content-encoding".to_owned(), "aes128gcm".to_owned()),
+                (
+                    "content-type".to_owned(),
+                    "application/octet-stream".to_owned(),
+                ),
+                ("ttl".to_owned(), self.ttl_secs.to_string()),
+            ],
+            body,
+        })
+    }
+}
+
+impl std::fmt::Debug for WebPush {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("WebPush")
+            .field("configured", &self.vapid.is_some())
+            .field("subject", &self.subject)
+            .field("ttl_secs", &self.ttl_secs)
+            .finish_non_exhaustive()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::push::encryption::hkdf_sha256;
+    use crate::push::store::{MemoryPushSubscriptionStore, SubscriptionKeys};
+    use crate::push::transport::RecordingPushTransport;
+    use crate::push::vapid::decode_base64url;
+    use aes_gcm::aead::{Aead, KeyInit, Payload};
+    use aes_gcm::{Aes128Gcm, Key, Nonce};
+    use base64::Engine as _;
+    use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+    use p256::elliptic_curve::sec1::ToEncodedPoint;
+
+    // The RFC 8291 §5 user agent, whose PRIVATE key lets these tests decrypt
+    // what the framework produced — proving the browser would really be able
+    // to read it, not just that some bytes were sent.
+    const UA_PRIVATE: &str = "q1dXpw3UpT5VOmu_cf_v6ih07Aems3njxI-JWgLcM94";
+    const UA_PUBLIC: &str =
+        "BCVxsr7N_eNgVRqvHtD0zTZsEc6-VV-JvLexhqUzORcxaOzi6-AYWXvTBHm4bjyPjs7Vd8pZGH6SRpkNtoIAiw4";
+    const UA_AUTH: &str = "BTBZMqHH6r4Tts7J_aSIgg";
+
+    fn browser_subscription(endpoint: &str) -> BrowserSubscription {
+        BrowserSubscription {
+            endpoint: endpoint.to_owned(),
+            keys: SubscriptionKeys {
+                p256dh: UA_PUBLIC.to_owned(),
+                auth: UA_AUTH.to_owned(),
+            },
+        }
+    }
+
+    /// The receiving half of RFC 8291 — what a browser does with the body.
+    ///
+    /// Written out longhand (rather than reusing any of the sending code) so
+    /// it is an independent check: if the two ever disagree, this fails.
+    fn decrypt_as_the_browser_would(body: &[u8]) -> Vec<u8> {
+        let salt = &body[..16];
+        let id_len = body[20] as usize;
+        let as_public = &body[21..21 + id_len];
+        let ciphertext = &body[21 + id_len..];
+
+        let ua_private =
+            p256::SecretKey::from_slice(&decode_base64url(UA_PRIVATE).expect("ua private"))
+                .expect("parses");
+        let as_key = p256::PublicKey::from_sec1_bytes(as_public).expect("as public parses");
+        let shared = p256::ecdh::diffie_hellman(ua_private.to_nonzero_scalar(), as_key.as_affine());
+
+        let ua_public_bytes = ua_private.public_key().to_encoded_point(false);
+        let mut key_info = Vec::new();
+        key_info.extend_from_slice(b"WebPush: info\0");
+        key_info.extend_from_slice(ua_public_bytes.as_bytes());
+        key_info.extend_from_slice(as_public);
+
+        let auth = decode_base64url(UA_AUTH).expect("auth");
+        let ikm = hkdf_sha256(&auth, shared.raw_secret_bytes(), &key_info, 32);
+        let cek = hkdf_sha256(salt, &ikm, b"Content-Encoding: aes128gcm\0", 16);
+        let nonce = hkdf_sha256(salt, &ikm, b"Content-Encoding: nonce\0", 12);
+
+        let cipher = Aes128Gcm::new(Key::<Aes128Gcm>::from_slice(&cek));
+        let mut plaintext = cipher
+            .decrypt(
+                Nonce::from_slice(&nonce),
+                Payload {
+                    msg: ciphertext,
+                    aad: b"",
+                },
+            )
+            .expect("the browser must be able to decrypt what we sent");
+        // Strip the RFC 8188 last-record delimiter.
+        assert_eq!(plaintext.pop(), Some(0x02));
+        plaintext
+    }
+
+    async fn web_push_with(transport: RecordingPushTransport) -> (WebPush, VapidKey) {
+        let vapid = VapidKey::generate();
+        let push = WebPush::new(
+            MemoryPushSubscriptionStore::new(),
+            vapid.clone(),
+            "mailto:ops@example.com",
+            transport,
+        );
+        (push, vapid)
+    }
+
+    // ── PushMessage ─────────────────────────────────────────────────────────
+
+    #[test]
+    fn message_serializes_only_the_fields_that_are_set() {
+        let json = serde_json::to_value(PushMessage::new("Hi", "There")).expect("serialize");
+        assert_eq!(json["title"], "Hi");
+        assert_eq!(json["body"], "There");
+        assert!(
+            json.get("url").is_none() && json.get("icon").is_none(),
+            "absent options must not appear as nulls the service worker has to guard: {json}"
+        );
+    }
+
+    #[test]
+    fn message_builder_sets_url_and_icon() {
+        let message = PushMessage::new("Hi", "There")
+            .url("/inbox/42")
+            .icon("/static/icons/icon.svg");
+        assert_eq!(message.url.as_deref(), Some("/inbox/42"));
+        assert_eq!(message.icon.as_deref(), Some("/static/icons/icon.svg"));
+    }
+
+    // ── Subscribe / unsubscribe ─────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn subscribe_records_the_subscription_for_the_principal() {
+        let (push, _) = web_push_with(RecordingPushTransport::new()).await;
+        let stored = push
+            .subscribe(7_i64, &browser_subscription("https://push.example.com/a"))
+            .await
+            .expect("subscribe");
+        assert_eq!(stored.principal_id, "7");
+        let report = push
+            .send(7_i64, &PushMessage::new("Hi", "There"))
+            .await
+            .expect("send");
+        assert_eq!(
+            report.delivered, 1,
+            "the recorded subscription must receive"
+        );
+    }
+
+    #[tokio::test]
+    async fn subscribe_rejects_a_malformed_payload_rather_than_storing_it() {
+        let (push, _) = web_push_with(RecordingPushTransport::new()).await;
+        let mut bad = browser_subscription("https://push.example.com/a");
+        bad.keys.auth = URL_SAFE_NO_PAD.encode([0_u8; 4]);
+        let err = push.subscribe(7_i64, &bad).await.expect_err("rejected");
+        assert!(
+            matches!(err, PushError::InvalidSubscriptionKey(_)),
+            "{err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn unsubscribe_removes_only_the_callers_own_endpoint() {
+        let (push, _) = web_push_with(RecordingPushTransport::new()).await;
+        push.subscribe(7_i64, &browser_subscription("https://push.example.com/a"))
+            .await
+            .expect("subscribe");
+
+        assert!(
+            !push
+                .unsubscribe(8_i64, "https://push.example.com/a")
+                .await
+                .expect("unsubscribe"),
+            "another principal must not be able to unsubscribe this device"
+        );
+        assert!(
+            push.unsubscribe(7_i64, "https://push.example.com/a")
+                .await
+                .expect("unsubscribe"),
+            "the owner unsubscribes successfully"
+        );
+        assert_eq!(
+            push.send(7_i64, &PushMessage::new("Hi", "There"))
+                .await
+                .expect("send")
+                .delivered,
+            0
+        );
+    }
+
+    #[tokio::test]
+    async fn unsubscribing_an_unknown_endpoint_reports_false_not_an_error() {
+        let (push, _) = web_push_with(RecordingPushTransport::new()).await;
+        assert!(
+            !push
+                .unsubscribe(7_i64, "https://push.example.com/never")
+                .await
+                .expect("unsubscribe is idempotent")
+        );
+    }
+
+    // ── Send: the dispatched request ────────────────────────────────────────
+
+    #[tokio::test]
+    async fn send_dispatches_to_the_recorded_endpoint() {
+        let transport = RecordingPushTransport::new();
+        let (push, _) = web_push_with(transport.clone()).await;
+        push.subscribe(7_i64, &browser_subscription("https://push.example.com/abc"))
+            .await
+            .expect("subscribe");
+
+        let report = push
+            .send(7_i64, &PushMessage::new("Hi", "There"))
+            .await
+            .expect("send");
+
+        assert_eq!(report.delivered, 1);
+        assert!(report.pruned.is_empty());
+        assert_eq!(report.failed, 0);
+        let requests = transport.requests();
+        assert_eq!(requests.len(), 1);
+        assert_eq!(requests[0].endpoint, "https://push.example.com/abc");
+    }
+
+    #[tokio::test]
+    async fn dispatched_request_carries_a_verifiable_vapid_authorization_header() {
+        use p256::ecdsa::VerifyingKey;
+        use p256::ecdsa::signature::Verifier;
+
+        let transport = RecordingPushTransport::new();
+        let (push, vapid) = web_push_with(transport.clone()).await;
+        push.subscribe(7_i64, &browser_subscription("https://push.example.com/abc"))
+            .await
+            .expect("subscribe");
+        push.send(7_i64, &PushMessage::new("Hi", "There"))
+            .await
+            .expect("send");
+
+        let requests = transport.requests();
+        let authorization = requests[0]
+            .header("authorization")
+            .expect("every push request carries an Authorization header");
+        assert!(authorization.starts_with("vapid t="), "{authorization}");
+
+        let jwt = authorization
+            .strip_prefix("vapid t=")
+            .and_then(|rest| rest.split_once(", k="))
+            .expect("`vapid t=…, k=…`")
+            .0;
+        let (signing_input, signature) = jwt.rsplit_once('.').expect("compact JWS");
+        let signature = p256::ecdsa::Signature::from_slice(
+            &URL_SAFE_NO_PAD
+                .decode(signature)
+                .expect("signature base64url"),
+        )
+        .expect("signature parses");
+        VerifyingKey::from_sec1_bytes(&vapid.public_key_bytes())
+            .expect("public key parses")
+            .verify(signing_input.as_bytes(), &signature)
+            .expect("the push service must be able to verify the signature");
+
+        // The audience must be this endpoint's origin — a JWT minted for a
+        // different push service is rejected by the real one.
+        let claims = URL_SAFE_NO_PAD
+            .decode(signing_input.split('.').nth(1).expect("claims"))
+            .expect("claims base64url");
+        let claims: serde_json::Value = serde_json::from_slice(&claims).expect("claims JSON");
+        assert_eq!(claims["aud"], "https://push.example.com");
+        assert_eq!(claims["sub"], "mailto:ops@example.com");
+    }
+
+    #[tokio::test]
+    async fn dispatched_request_carries_the_aes128gcm_content_headers() {
+        let transport = RecordingPushTransport::new();
+        let (push, _) = web_push_with(transport.clone()).await;
+        push.subscribe(7_i64, &browser_subscription("https://push.example.com/abc"))
+            .await
+            .expect("subscribe");
+        push.send(7_i64, &PushMessage::new("Hi", "There"))
+            .await
+            .expect("send");
+
+        let requests = transport.requests();
+        assert_eq!(requests[0].header("content-encoding"), Some("aes128gcm"));
+        assert_eq!(
+            requests[0].header("content-type"),
+            Some("application/octet-stream")
+        );
+        let ttl = requests[0]
+            .header("ttl")
+            .expect("TTL is required by RFC 8030 §5.2");
+        assert!(
+            ttl.parse::<u32>().is_ok(),
+            "TTL must be a plain number of seconds, got {ttl}"
+        );
+    }
+
+    #[tokio::test]
+    async fn dispatched_body_decrypts_to_the_message_in_the_browser() {
+        let transport = RecordingPushTransport::new();
+        let (push, _) = web_push_with(transport.clone()).await;
+        push.subscribe(7_i64, &browser_subscription("https://push.example.com/abc"))
+            .await
+            .expect("subscribe");
+        push.send(
+            7_i64,
+            &PushMessage::new("Build failed", "main is red").url("/builds/42"),
+        )
+        .await
+        .expect("send");
+
+        let requests = transport.requests();
+        let plaintext = decrypt_as_the_browser_would(&requests[0].body);
+        let message: serde_json::Value =
+            serde_json::from_slice(&plaintext).expect("the payload is JSON the SW can read");
+        assert_eq!(message["title"], "Build failed");
+        assert_eq!(message["body"], "main is red");
+        assert_eq!(message["url"], "/builds/42");
+    }
+
+    #[tokio::test]
+    async fn each_device_gets_its_own_request() {
+        let transport = RecordingPushTransport::new();
+        let (push, _) = web_push_with(transport.clone()).await;
+        push.subscribe(
+            7_i64,
+            &browser_subscription("https://push.example.com/laptop"),
+        )
+        .await
+        .expect("subscribe");
+        push.subscribe(
+            7_i64,
+            &browser_subscription("https://push.example.com/phone"),
+        )
+        .await
+        .expect("subscribe");
+
+        let report = push
+            .send(7_i64, &PushMessage::new("Hi", "There"))
+            .await
+            .expect("send");
+        assert_eq!(report.delivered, 2);
+        let mut endpoints: Vec<String> = transport
+            .requests()
+            .into_iter()
+            .map(|r| r.endpoint)
+            .collect();
+        endpoints.sort();
+        assert_eq!(
+            endpoints,
+            vec![
+                "https://push.example.com/laptop".to_owned(),
+                "https://push.example.com/phone".to_owned()
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn every_message_gets_fresh_encryption_material() {
+        let transport = RecordingPushTransport::new();
+        let (push, _) = web_push_with(transport.clone()).await;
+        push.subscribe(7_i64, &browser_subscription("https://push.example.com/abc"))
+            .await
+            .expect("subscribe");
+        for _ in 0..2 {
+            push.send(7_i64, &PushMessage::new("Hi", "There"))
+                .await
+                .expect("send");
+        }
+        let requests = transport.requests();
+        assert_ne!(
+            requests[0].body[..16],
+            requests[1].body[..16],
+            "reusing a salt across messages repeats an AES-GCM (key, nonce) pair"
+        );
+    }
+
+    // ── Send: failure handling ──────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn a_410_gone_prunes_the_subscription() {
+        let transport =
+            RecordingPushTransport::new().responding_with("https://push.example.com/dead", 410);
+        let (push, _) = web_push_with(transport.clone()).await;
+        push.subscribe(
+            7_i64,
+            &browser_subscription("https://push.example.com/dead"),
+        )
+        .await
+        .expect("subscribe");
+
+        let report = push
+            .send(7_i64, &PushMessage::new("Hi", "There"))
+            .await
+            .expect("a stale endpoint is not an error for the caller");
+        assert_eq!(report.delivered, 0);
+        assert_eq!(
+            report.pruned,
+            vec!["https://push.example.com/dead".to_owned()]
+        );
+
+        // The whole point of pruning: the next send must not dispatch again.
+        let second = push
+            .send(7_i64, &PushMessage::new("Hi", "again"))
+            .await
+            .expect("send");
+        assert_eq!(second.delivered, 0);
+        assert!(second.pruned.is_empty());
+        assert_eq!(
+            transport.requests().len(),
+            1,
+            "a pruned endpoint must never be re-sent to"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_404_not_found_also_prunes() {
+        let transport =
+            RecordingPushTransport::new().responding_with("https://push.example.com/gone", 404);
+        let (push, _) = web_push_with(transport.clone()).await;
+        push.subscribe(
+            7_i64,
+            &browser_subscription("https://push.example.com/gone"),
+        )
+        .await
+        .expect("subscribe");
+        let report = push
+            .send(7_i64, &PushMessage::new("Hi", "There"))
+            .await
+            .expect("send");
+        assert_eq!(
+            report.pruned,
+            vec!["https://push.example.com/gone".to_owned()]
+        );
+    }
+
+    #[tokio::test]
+    async fn a_transient_5xx_is_counted_but_never_prunes() {
+        // Pruning on a 500 would silently unsubscribe every user during a push
+        // service outage — unrecoverable without the user re-granting
+        // permission.
+        let transport =
+            RecordingPushTransport::new().responding_with("https://push.example.com/a", 503);
+        let (push, _) = web_push_with(transport.clone()).await;
+        push.subscribe(7_i64, &browser_subscription("https://push.example.com/a"))
+            .await
+            .expect("subscribe");
+
+        let report = push
+            .send(7_i64, &PushMessage::new("Hi", "There"))
+            .await
+            .expect("send");
+        assert_eq!(report.failed, 1);
+        assert!(
+            report.pruned.is_empty(),
+            "a transient failure must never unsubscribe a live device"
+        );
+        assert_eq!(
+            push.send(7_i64, &PushMessage::new("Hi", "again"))
+                .await
+                .expect("send")
+                .failed,
+            1,
+            "the subscription must still be there to retry"
+        );
+    }
+
+    #[tokio::test]
+    async fn one_dead_device_does_not_stop_delivery_to_the_others() {
+        let transport =
+            RecordingPushTransport::new().responding_with("https://push.example.com/dead", 410);
+        let (push, _) = web_push_with(transport.clone()).await;
+        push.subscribe(
+            7_i64,
+            &browser_subscription("https://push.example.com/dead"),
+        )
+        .await
+        .expect("subscribe");
+        push.subscribe(
+            7_i64,
+            &browser_subscription("https://push.example.com/live"),
+        )
+        .await
+        .expect("subscribe");
+
+        let report = push
+            .send(7_i64, &PushMessage::new("Hi", "There"))
+            .await
+            .expect("send");
+        assert_eq!(report.delivered, 1);
+        assert_eq!(report.pruned.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn sending_to_a_principal_with_no_subscriptions_is_a_no_op() {
+        let transport = RecordingPushTransport::new();
+        let (push, _) = web_push_with(transport.clone()).await;
+        let report = push
+            .send(99_i64, &PushMessage::new("Hi", "There"))
+            .await
+            .expect("not an error — the user simply never granted permission");
+        assert_eq!(report, PushDeliveryReport::default());
+        assert!(transport.requests().is_empty());
+    }
+
+    #[tokio::test]
+    async fn sending_without_a_vapid_key_fails_loudly_and_never_silently_succeeds() {
+        let transport = RecordingPushTransport::new();
+        let push = WebPush::without_vapid_key(
+            MemoryPushSubscriptionStore::new(),
+            "mailto:ops@example.com",
+            transport.clone(),
+        );
+        push.subscribe(7_i64, &browser_subscription("https://push.example.com/a"))
+            .await
+            .expect("subscribe still works without a key");
+
+        let err = push
+            .send(7_i64, &PushMessage::new("Hi", "There"))
+            .await
+            .expect_err("an unconfigured push must be an error, never a silent no-op");
+        assert!(matches!(err, PushError::NotConfigured), "{err:?}");
+        assert!(
+            err.to_string().contains("private_key"),
+            "the error must say how to fix it: {err}"
+        );
+        assert!(transport.requests().is_empty());
+    }
+
+    #[tokio::test]
+    async fn vapid_public_key_is_the_browsers_application_server_key() {
+        let (push, vapid) = web_push_with(RecordingPushTransport::new()).await;
+        assert_eq!(
+            push.vapid_public_key().expect("configured"),
+            vapid.public_key_base64url()
+        );
+    }
+
+    #[tokio::test]
+    async fn vapid_public_key_is_an_error_when_unconfigured() {
+        let push = WebPush::without_vapid_key(
+            MemoryPushSubscriptionStore::new(),
+            "mailto:ops@example.com",
+            RecordingPushTransport::new(),
+        );
+        assert!(matches!(
+            push.vapid_public_key().expect_err("unconfigured"),
+            PushError::NotConfigured
+        ));
+    }
+
+    #[tokio::test]
+    async fn an_oversize_message_is_refused_before_any_dispatch() {
+        let transport = RecordingPushTransport::new();
+        let (push, _) = web_push_with(transport.clone()).await;
+        push.subscribe(7_i64, &browser_subscription("https://push.example.com/a"))
+            .await
+            .expect("subscribe");
+
+        let err = push
+            .send(7_i64, &PushMessage::new("Hi", "x".repeat(5000)))
+            .await
+            .expect_err("an oversize payload is refused");
+        assert!(matches!(err, PushError::PayloadTooLarge { .. }), "{err:?}");
+        assert!(
+            transport.requests().is_empty(),
+            "nothing may be dispatched when the payload cannot fit"
+        );
+    }
+
+    // ── Fan-out ─────────────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn send_many_fans_out_across_principals() {
+        let transport = RecordingPushTransport::new();
+        let (push, _) = web_push_with(transport.clone()).await;
+        push.subscribe(1_i64, &browser_subscription("https://push.example.com/one"))
+            .await
+            .expect("subscribe");
+        push.subscribe(2_i64, &browser_subscription("https://push.example.com/two"))
+            .await
+            .expect("subscribe");
+        push.subscribe(
+            2_i64,
+            &browser_subscription("https://push.example.com/two-b"),
+        )
+        .await
+        .expect("subscribe");
+
+        let report = push
+            .send_many([1_i64, 2, 3], &PushMessage::new("Deploy", "shipped"))
+            .await
+            .expect("send_many");
+        assert_eq!(report.delivered, 3, "3 has no subscription and is skipped");
+        assert_eq!(transport.requests().len(), 3);
+    }
+
+    #[tokio::test]
+    async fn send_many_aggregates_pruning_across_principals() {
+        let transport =
+            RecordingPushTransport::new().responding_with("https://push.example.com/dead", 410);
+        let (push, _) = web_push_with(transport.clone()).await;
+        push.subscribe(
+            1_i64,
+            &browser_subscription("https://push.example.com/dead"),
+        )
+        .await
+        .expect("subscribe");
+        push.subscribe(
+            2_i64,
+            &browser_subscription("https://push.example.com/live"),
+        )
+        .await
+        .expect("subscribe");
+
+        let report = push
+            .send_many([1_i64, 2], &PushMessage::new("Deploy", "shipped"))
+            .await
+            .expect("send_many");
+        assert_eq!(report.delivered, 1);
+        assert_eq!(
+            report.pruned,
+            vec!["https://push.example.com/dead".to_owned()]
+        );
+    }
+
+    #[tokio::test]
+    async fn send_many_accepts_string_principals_too() {
+        let transport = RecordingPushTransport::new();
+        let (push, _) = web_push_with(transport.clone()).await;
+        push.subscribe(
+            "service:ci",
+            &browser_subscription("https://push.example.com/ci"),
+        )
+        .await
+        .expect("subscribe");
+        assert_eq!(
+            push.send_many(["service:ci"], &PushMessage::new("CI", "green"))
+                .await
+                .expect("send_many")
+                .delivered,
+            1
+        );
+    }
+}

--- a/autumn/src/push/service.rs
+++ b/autumn/src/push/service.rs
@@ -292,10 +292,17 @@ impl WebPush {
         message: &PushMessage,
     ) -> Result<PushDeliveryReport, PushError> {
         let principal = principal.into();
-        // Fail fast, before touching the store: a missing key or an oversize
-        // payload fails identically for every device, so discovering it
-        // per-device would just be N copies of the same error.
+        // Fail fast, before touching the store: a missing key, an unusable
+        // `sub`, or an oversize payload fails identically for every device, so
+        // discovering it per-device would just be N copies of the same error.
         let vapid = self.vapid.as_ref().ok_or(PushError::NotConfigured)?;
+        // Checked here, not in `new`: the constructor is infallible (and takes
+        // `impl Into<String>`), so a service built by
+        // `AppBuilder::with_web_push` — from a secrets manager, say — never
+        // passes through the boot-time `[push]` validation. Without this an
+        // invalid `sub` would sign every request and every push service would
+        // refuse it, showing up only as `report.failed` with no cause named.
+        self.validate_subject()?;
         let payload = Self::encode(message)?;
 
         let subscriptions = self
@@ -343,6 +350,23 @@ impl WebPush {
             report.merge(self.send(principal, message).await?);
         }
         Ok(report)
+    }
+
+    /// Check the `sub` claim against what RFC 8292 permits.
+    ///
+    /// # Errors
+    ///
+    /// [`PushError::InvalidConfig`] when the subject is neither a `mailto:`
+    /// nor an `https:` URI.
+    fn validate_subject(&self) -> Result<(), PushError> {
+        if super::config::is_valid_vapid_subject(&self.subject) {
+            return Ok(());
+        }
+        Err(PushError::InvalidConfig(format!(
+            "the VAPID `sub` claim must be a `mailto:` or `https:` URI (RFC 8292 §2.1), got \
+             `{}`. A push service may refuse every message signed with anything else.",
+            self.subject
+        )))
     }
 
     /// Serialize a message and check it against the payload ceiling.
@@ -1138,6 +1162,59 @@ mod tests {
             "the error must say how to fix it: {err}"
         );
         assert!(transport.requests().is_empty());
+    }
+
+    #[tokio::test]
+    async fn an_invalid_subject_is_refused_before_any_dispatch() {
+        // `WebPush::new` is infallible and takes `impl Into<String>`, so a
+        // service registered through `AppBuilder::with_web_push` never passes
+        // through the boot-time `[push]` validation. Without this check an
+        // invalid `sub` would sign every request and every push service would
+        // refuse it, showing up only as `report.failed` with no cause named.
+        let transport = RecordingPushTransport::new();
+        let push = WebPush::new(
+            MemoryPushSubscriptionStore::new(),
+            VapidKey::generate(),
+            // A bare address, not a `mailto:` URI — the common mistake.
+            "ops@example.com",
+            transport.clone(),
+        );
+        push.subscribe(7_i64, &browser_subscription("https://push.example.com/a"))
+            .await
+            .expect("subscribe");
+
+        let err = push
+            .send(7_i64, &PushMessage::new("Hi", "There"))
+            .await
+            .expect_err("an unusable sub must be refused");
+        assert!(matches!(err, PushError::InvalidConfig(_)), "{err:?}");
+        assert!(
+            transport.requests().is_empty(),
+            "nothing may be dispatched with a sub every push service will refuse"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_valid_subject_still_sends() {
+        for subject in ["mailto:ops@example.com", "https://example.com/contact"] {
+            let transport = RecordingPushTransport::new();
+            let push = WebPush::new(
+                MemoryPushSubscriptionStore::new(),
+                VapidKey::generate(),
+                subject,
+                transport.clone(),
+            );
+            push.subscribe(7_i64, &browser_subscription("https://push.example.com/a"))
+                .await
+                .expect("subscribe");
+            assert_eq!(
+                push.send(7_i64, &PushMessage::new("Hi", "There"))
+                    .await
+                    .unwrap_or_else(|e| panic!("{subject} must send, got {e}"))
+                    .delivered,
+                1
+            );
+        }
     }
 
     #[tokio::test]

--- a/autumn/src/push/service.rs
+++ b/autumn/src/push/service.rs
@@ -508,7 +508,12 @@ impl WebPush {
             tracing::error!(error = %e, "the `[push]` VAPID key failed to load; sends will fail");
             None
         });
-        let subject = config.push.subject_or_default();
+        // Validated at boot; if it somehow fails here the configuration was
+        // replaced at runtime, and the documented default is the safe reading.
+        let subject = config
+            .push
+            .validated_subject()
+            .unwrap_or_else(|_| super::config::DEFAULT_VAPID_SUBJECT.to_owned());
         let ttl_secs = config.push.ttl_secs.unwrap_or(DEFAULT_TTL_SECS);
 
         let transport = Self::default_transport(state);

--- a/autumn/src/push/service.rs
+++ b/autumn/src/push/service.rs
@@ -211,7 +211,7 @@ impl WebPush {
 
     /// The `applicationServerKey` a browser needs to subscribe.
     ///
-    /// Serve this to the client (the built-in [`router`](super::router) does,
+    /// Serve this to the client (the built-in [`router()`](super::router) does,
     /// at `/push/vapid-public-key`). It is public key material — safe to
     /// expose to any visitor.
     ///

--- a/autumn/src/push/store.rs
+++ b/autumn/src/push/store.rs
@@ -1,0 +1,856 @@
+//! Push subscription storage: the browser payload, its validated form, and
+//! the pluggable [`PushSubscriptionStore`] backends.
+//!
+//! A browser hands the application a `PushSubscription` — an endpoint URL plus
+//! two base64url keys — which the app must persist against whoever is signed
+//! in. [`BrowserSubscription::decode`] is the validating boundary: it is the
+//! single place a browser-supplied (and therefore attacker-influenceable)
+//! payload is turned into a [`StoredSubscription`], so a row that reaches a
+//! store is always one the send path can actually use.
+//!
+//! # Backends
+//!
+//! Resolution mirrors [`Notifications`](crate::notifications::Notifications):
+//!
+//! 1. A store registered via `AppBuilder::with_push_subscription_store(...)`.
+//! 2. [`DbPushSubscriptionStore`] when a database pool is configured (the
+//!    `push_subscriptions` table is scaffolded by `autumn generate pwa`).
+//! 3. [`MemoryPushSubscriptionStore`] otherwise — process-local, for tests
+//!    and DB-less development.
+
+use std::future::Future;
+use std::pin::Pin;
+
+use base64::Engine as _;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use serde::{Deserialize, Serialize};
+
+use super::PushError;
+use super::vapid::decode_base64url;
+
+/// The `push_subscriptions` table name shared by [`DbPushSubscriptionStore`]
+/// and the `autumn generate pwa` scaffolding.
+pub const PUSH_SUBSCRIPTIONS_TABLE: &str = "push_subscriptions";
+
+/// Length of the `auth` secret a browser publishes (RFC 8291 §3.2).
+const AUTH_SECRET_LEN: usize = 16;
+
+// ── Principal ───────────────────────────────────────────────────────────────
+
+/// Whoever a subscription belongs to.
+///
+/// Stored as text so it fits both shapes Autumn apps use: the `i64` user id
+/// the [`notifications`](crate::notifications) feed keys on, and the string
+/// principal (`user:42`, `service:ci`) that
+/// [`auth`](crate::auth) tokens carry. `PushPrincipal::from(42_i64)` and
+/// `PushPrincipal::from("42")` are the same principal, so composing a push
+/// with an in-app notification needs no conversion at the call site.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct PushPrincipal(String);
+
+impl PushPrincipal {
+    /// The principal as it is stored.
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl From<i64> for PushPrincipal {
+    fn from(value: i64) -> Self {
+        Self(value.to_string())
+    }
+}
+
+impl From<&str> for PushPrincipal {
+    fn from(value: &str) -> Self {
+        Self(value.to_owned())
+    }
+}
+
+impl From<String> for PushPrincipal {
+    fn from(value: String) -> Self {
+        Self(value)
+    }
+}
+
+impl std::fmt::Display for PushPrincipal {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+// ── Browser payload ─────────────────────────────────────────────────────────
+
+/// A browser `PushSubscription`, exactly as `JSON.stringify(subscription)`
+/// serializes it.
+///
+/// This is the request body the built-in subscribe endpoint accepts. Fields
+/// the browser adds and Autumn does not use (`expirationTime`) are ignored.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BrowserSubscription {
+    /// The push service URL this user agent listens on.
+    pub endpoint: String,
+    /// The subscription's key material.
+    pub keys: SubscriptionKeys,
+}
+
+/// The `keys` object of a browser `PushSubscription`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SubscriptionKeys {
+    /// The user agent's P-256 public key, base64url-encoded.
+    pub p256dh: String,
+    /// The user agent's 16-byte authentication secret, base64url-encoded.
+    pub auth: String,
+}
+
+/// A subscription that has been validated and bound to a principal.
+///
+/// Only [`BrowserSubscription::decode`] produces one, so every value of this
+/// type carries an https endpoint, a `p256dh` that is a real point on P-256,
+/// and a 16-byte `auth` secret.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StoredSubscription {
+    /// Who this subscription delivers to.
+    pub principal_id: String,
+    /// The push service URL. Unique across the store: an endpoint identifies
+    /// exactly one user agent installation.
+    pub endpoint: String,
+    /// The user agent's P-256 public key, raw (65 bytes, uncompressed).
+    pub p256dh: Vec<u8>,
+    /// The user agent's authentication secret, raw (16 bytes).
+    pub auth: Vec<u8>,
+}
+
+impl StoredSubscription {
+    /// The `p256dh` key as the browser sent it.
+    #[must_use]
+    pub fn p256dh_base64url(&self) -> String {
+        URL_SAFE_NO_PAD.encode(&self.p256dh)
+    }
+
+    /// The `auth` secret as the browser sent it.
+    #[must_use]
+    pub fn auth_base64url(&self) -> String {
+        URL_SAFE_NO_PAD.encode(&self.auth)
+    }
+}
+
+impl BrowserSubscription {
+    /// Validate this payload and bind it to `principal`.
+    ///
+    /// # Errors
+    ///
+    /// - [`PushError::InvalidEndpoint`] — the endpoint is not an `https` URL,
+    ///   or its host is one the framework refuses to make outbound requests to
+    ///   (see the endpoint-safety note below).
+    /// - [`PushError::InvalidSubscriptionKey`] — `p256dh` is not an
+    ///   uncompressed P-256 point on the curve, or `auth` is not 16 bytes.
+    ///
+    /// # Endpoint safety
+    ///
+    /// The endpoint is a URL supplied by the client that the framework will
+    /// later `POST` to, which makes an unchecked subscribe endpoint a
+    /// server-side request forgery (SSRF) gadget. Two rules close it here, at
+    /// the boundary, so a hostile row can never even be persisted:
+    ///
+    /// - the scheme must be `https`, so neither the encrypted body nor the
+    ///   VAPID JWT that authenticates this application server ever crosses a
+    ///   plaintext hop; and
+    /// - the host must be a **domain name** that is not `localhost`. Every
+    ///   real push service (FCM, Mozilla autopush, WNS) publishes a hostname,
+    ///   so refusing IP literals outright is both stricter and simpler than
+    ///   enumerating private ranges — `https://169.254.169.254/…`,
+    ///   `https://10.0.0.1/…` and `https://[::1]/…` are all rejected by the
+    ///   same rule, with no dependence on which Cargo features are enabled.
+    ///
+    /// A hostname that *resolves* to a private address is the remaining case;
+    /// that one is caught at dispatch time by the SSRF-checked outbound client
+    /// the default transport uses (see [`super::transport`]).
+    pub fn decode(&self, principal: &PushPrincipal) -> Result<StoredSubscription, PushError> {
+        let endpoint = validate_endpoint(&self.endpoint)?;
+
+        let p256dh = decode_base64url(self.keys.p256dh.trim()).ok_or_else(|| {
+            PushError::InvalidSubscriptionKey("`p256dh` is not valid base64url".to_owned())
+        })?;
+        // Parsing as a curve point rejects both a wrong length and a value
+        // that merely looks like one, so no off-curve key reaches the ECDH.
+        p256::PublicKey::from_sec1_bytes(&p256dh).map_err(|_| {
+            PushError::InvalidSubscriptionKey(
+                "`p256dh` is not an uncompressed P-256 public key on the curve".to_owned(),
+            )
+        })?;
+
+        let auth = decode_base64url(self.keys.auth.trim()).ok_or_else(|| {
+            PushError::InvalidSubscriptionKey("`auth` is not valid base64url".to_owned())
+        })?;
+        if auth.len() != AUTH_SECRET_LEN {
+            return Err(PushError::InvalidSubscriptionKey(format!(
+                "`auth` must be exactly {AUTH_SECRET_LEN} bytes, got {}",
+                auth.len()
+            )));
+        }
+
+        Ok(StoredSubscription {
+            principal_id: principal.0.clone(),
+            endpoint,
+            p256dh,
+            auth,
+        })
+    }
+}
+
+/// Check an endpoint URL and return it in normalized form.
+///
+/// See [`BrowserSubscription::decode`]'s "Endpoint safety" section for why
+/// each rule is here.
+fn validate_endpoint(endpoint: &str) -> Result<String, PushError> {
+    let endpoint = endpoint.trim();
+    let parsed = url::Url::parse(endpoint)
+        .map_err(|e| PushError::InvalidEndpoint(format!("{endpoint}: {e}")))?;
+    if parsed.scheme() != "https" {
+        return Err(PushError::InvalidEndpoint(format!(
+            "{endpoint}: push endpoints must use https, got `{}`",
+            parsed.scheme()
+        )));
+    }
+    match parsed.host() {
+        Some(url::Host::Domain(host)) => {
+            let host = host.to_ascii_lowercase();
+            if host == "localhost" || host.ends_with(".localhost") {
+                return Err(PushError::InvalidEndpoint(format!(
+                    "{endpoint}: refusing a loopback push endpoint"
+                )));
+            }
+        }
+        Some(url::Host::Ipv4(_) | url::Host::Ipv6(_)) => {
+            return Err(PushError::InvalidEndpoint(format!(
+                "{endpoint}: push endpoints must name a host, not an IP literal"
+            )));
+        }
+        None => {
+            return Err(PushError::InvalidEndpoint(format!("{endpoint}: no host")));
+        }
+    }
+    Ok(endpoint.to_owned())
+}
+
+// ── Store trait ─────────────────────────────────────────────────────────────
+
+/// Pluggable storage for push subscriptions.
+///
+/// Implement this to persist subscriptions somewhere other than the built-in
+/// backends. Two contracts every backend must honor:
+///
+/// - **`endpoint` is the primary identity.** [`save`](Self::save) upserts on
+///   it: re-saving an endpoint updates the existing row (including moving it
+///   to a different principal, which is what happens when a second user signs
+///   in on a shared device) and never creates a second row.
+/// - **Removal is idempotent.** [`remove`](Self::remove) returns how many rows
+///   it deleted; a missing endpoint is `Ok(0)`, not an error.
+pub trait PushSubscriptionStore: Send + Sync + 'static {
+    /// Persist a subscription, replacing any existing row for the same
+    /// endpoint.
+    fn save(
+        &self,
+        subscription: StoredSubscription,
+    ) -> impl Future<Output = Result<(), PushError>> + Send;
+
+    /// Every subscription belonging to `principal_id` (empty when none do).
+    fn list_for(
+        &self,
+        principal_id: &str,
+    ) -> impl Future<Output = Result<Vec<StoredSubscription>, PushError>> + Send;
+
+    /// Delete the row for `endpoint`, returning how many rows were deleted.
+    ///
+    /// `principal_id` scopes the delete: `Some(id)` only removes the row when
+    /// it belongs to that principal (the user-facing unsubscribe path, so one
+    /// signed-in user can never drop another's device), while `None` removes
+    /// it regardless of owner (the `404`/`410` pruning path, where the
+    /// endpoint is dead for everyone).
+    fn remove(
+        &self,
+        endpoint: &str,
+        principal_id: Option<&str>,
+    ) -> impl Future<Output = Result<u64, PushError>> + Send;
+}
+
+// ── Erasure bridge (same shape as notifications::BoxedNotificationStore) ─────
+//
+// `PushSubscriptionStore` uses RPIT futures and is not dyn-compatible, so the
+// service holds a pub(crate) shadow trait with a blanket impl. Users only ever
+// see `PushSubscriptionStore`.
+
+type BoxedFuture<'a, T> = Pin<Box<dyn Future<Output = Result<T, PushError>> + Send + 'a>>;
+
+pub(crate) trait BoxedPushSubscriptionStore: Send + Sync + 'static {
+    fn boxed_save(&self, subscription: StoredSubscription) -> BoxedFuture<'_, ()>;
+    fn boxed_list_for(&self, principal_id: String) -> BoxedFuture<'_, Vec<StoredSubscription>>;
+    fn boxed_remove(&self, endpoint: String, principal_id: Option<String>) -> BoxedFuture<'_, u64>;
+}
+
+impl<S: PushSubscriptionStore> BoxedPushSubscriptionStore for S {
+    fn boxed_save(&self, subscription: StoredSubscription) -> BoxedFuture<'_, ()> {
+        Box::pin(PushSubscriptionStore::save(self, subscription))
+    }
+
+    fn boxed_list_for(&self, principal_id: String) -> BoxedFuture<'_, Vec<StoredSubscription>> {
+        Box::pin(async move { PushSubscriptionStore::list_for(self, &principal_id).await })
+    }
+
+    fn boxed_remove(&self, endpoint: String, principal_id: Option<String>) -> BoxedFuture<'_, u64> {
+        Box::pin(async move {
+            PushSubscriptionStore::remove(self, &endpoint, principal_id.as_deref()).await
+        })
+    }
+}
+
+// ── In-memory store ─────────────────────────────────────────────────────────
+
+/// Process-local [`PushSubscriptionStore`] used by default when no database is
+/// configured.
+///
+/// Suitable for tests and DB-less development; contents are lost on restart
+/// and it grows without bound (no eviction), so it is not a production store.
+#[derive(Debug, Default)]
+pub struct MemoryPushSubscriptionStore {
+    rows: std::sync::Mutex<Vec<StoredSubscription>>,
+}
+
+impl MemoryPushSubscriptionStore {
+    /// Create an empty store.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    fn lock(&self) -> Result<std::sync::MutexGuard<'_, Vec<StoredSubscription>>, PushError> {
+        self.rows
+            .lock()
+            .map_err(|_| PushError::Store("memory store mutex poisoned".to_owned()))
+    }
+}
+
+impl PushSubscriptionStore for MemoryPushSubscriptionStore {
+    async fn save(&self, subscription: StoredSubscription) -> Result<(), PushError> {
+        let mut rows = self.lock()?;
+        // Endpoint identity, not (principal, endpoint): re-subscribing on a
+        // shared device must MOVE the row, never leave the previous owner
+        // still receiving on it.
+        rows.retain(|row| row.endpoint != subscription.endpoint);
+        rows.push(subscription);
+        drop(rows);
+        Ok(())
+    }
+
+    async fn list_for(&self, principal_id: &str) -> Result<Vec<StoredSubscription>, PushError> {
+        let rows = self.lock()?;
+        Ok(rows
+            .iter()
+            .filter(|row| row.principal_id == principal_id)
+            .cloned()
+            .collect())
+    }
+
+    async fn remove(&self, endpoint: &str, principal_id: Option<&str>) -> Result<u64, PushError> {
+        let mut rows = self.lock()?;
+        let before = rows.len();
+        rows.retain(|row| {
+            row.endpoint != endpoint || principal_id.is_some_and(|id| row.principal_id != id)
+        });
+        Ok((before - rows.len()) as u64)
+    }
+}
+
+// ── Database-backed store ───────────────────────────────────────────────────
+
+#[cfg(feature = "db")]
+pub use self::db_store::DbPushSubscriptionStore;
+
+#[cfg(feature = "db")]
+mod db_store {
+    use super::{PUSH_SUBSCRIPTIONS_TABLE, PushError, PushSubscriptionStore, StoredSubscription};
+    use crate::db::RuntimeConnection;
+    use base64::Engine as _;
+    use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+    use chrono::{DateTime, Utc};
+    use diesel::prelude::*;
+    use diesel_async::RunQueryDsl;
+    use diesel_async::pooled_connection::deadpool::Pool;
+
+    // The `push_subscriptions` table as scaffolded by `autumn generate pwa`.
+    // The two key columns are TEXT holding the browser's own base64url form
+    // rather than BYTEA/BLOB: that keeps one `table!` definition working on
+    // both backends (diesel's `Binary` maps to different SQL types per
+    // backend) and makes the rows readable when debugging a delivery problem.
+    #[cfg(not(feature = "sqlite"))]
+    mod schema {
+        diesel::table! {
+            push_subscriptions (id) {
+                id -> BigInt,
+                principal_id -> Text,
+                endpoint -> Text,
+                p256dh -> Text,
+                auth -> Text,
+                created_at -> Timestamptz,
+            }
+        }
+    }
+    #[cfg(feature = "sqlite")]
+    mod schema {
+        diesel::table! {
+            push_subscriptions (id) {
+                id -> BigInt,
+                principal_id -> Text,
+                endpoint -> Text,
+                p256dh -> Text,
+                auth -> Text,
+                created_at -> TimestamptzSqlite,
+            }
+        }
+    }
+
+    use schema::push_subscriptions;
+
+    #[derive(Queryable, Selectable)]
+    #[diesel(table_name = push_subscriptions)]
+    struct SubscriptionRow {
+        principal_id: String,
+        endpoint: String,
+        p256dh: String,
+        auth: String,
+    }
+
+    #[derive(Insertable)]
+    #[diesel(table_name = push_subscriptions)]
+    struct NewSubscriptionRow {
+        principal_id: String,
+        endpoint: String,
+        p256dh: String,
+        auth: String,
+        created_at: DateTime<Utc>,
+    }
+
+    impl TryFrom<SubscriptionRow> for StoredSubscription {
+        type Error = PushError;
+
+        fn try_from(row: SubscriptionRow) -> Result<Self, PushError> {
+            let decode = |label: &str, value: &str| {
+                URL_SAFE_NO_PAD.decode(value).map_err(|e| {
+                    PushError::Store(format!(
+                        "stored `{label}` for {} is not base64url: {e}",
+                        row.endpoint
+                    ))
+                })
+            };
+            Ok(Self {
+                p256dh: decode("p256dh", &row.p256dh)?,
+                auth: decode("auth", &row.auth)?,
+                principal_id: row.principal_id,
+                endpoint: row.endpoint,
+            })
+        }
+    }
+
+    /// [`PushSubscriptionStore`] backed by the app's database pool.
+    ///
+    /// Expects the `push_subscriptions` table scaffolded by
+    /// `autumn generate pwa`, whose `endpoint` column carries a UNIQUE
+    /// constraint — that constraint is what makes [`save`](Self::save)'s
+    /// upsert atomic rather than a racy select-then-insert.
+    #[derive(Clone)]
+    pub struct DbPushSubscriptionStore {
+        pool: Pool<RuntimeConnection>,
+    }
+
+    impl DbPushSubscriptionStore {
+        /// Build a store over the given pool.
+        #[must_use]
+        pub const fn new(pool: Pool<RuntimeConnection>) -> Self {
+            Self { pool }
+        }
+
+        async fn conn(
+            &self,
+        ) -> Result<diesel_async::pooled_connection::deadpool::Object<RuntimeConnection>, PushError>
+        {
+            self.pool
+                .get()
+                .await
+                .map_err(|e| PushError::Store(format!("checkout failed: {e}")))
+        }
+    }
+
+    fn store_err(e: &diesel::result::Error) -> PushError {
+        let message = e.to_string();
+        // A missing table means the app has a database but never scaffolded
+        // the push tables — turn the bare SQL error into an actionable one.
+        if message.contains("does not exist") || message.contains("no such table") {
+            return PushError::Store(format!(
+                "query failed: {e}. The `{PUSH_SUBSCRIPTIONS_TABLE}` table is missing — \
+                 scaffold it with `autumn generate pwa`, then apply it with `autumn migrate`"
+            ));
+        }
+        PushError::Store(format!("query failed: {e}"))
+    }
+
+    impl PushSubscriptionStore for DbPushSubscriptionStore {
+        async fn save(&self, subscription: StoredSubscription) -> Result<(), PushError> {
+            let mut conn = self.conn().await?;
+            let principal_id = subscription.principal_id.clone();
+            let p256dh = subscription.p256dh_base64url();
+            let auth = subscription.auth_base64url();
+            diesel::insert_into(push_subscriptions::table)
+                .values(NewSubscriptionRow {
+                    principal_id: principal_id.clone(),
+                    endpoint: subscription.endpoint.clone(),
+                    p256dh: p256dh.clone(),
+                    auth: auth.clone(),
+                    created_at: Utc::now(),
+                })
+                // Endpoint identity: re-subscribing the same user agent MOVES
+                // the row to whoever is signed in now (a shared device where a
+                // second user signs in) instead of leaving the previous owner
+                // still receiving on it.
+                .on_conflict(push_subscriptions::endpoint)
+                .do_update()
+                .set((
+                    push_subscriptions::principal_id.eq(principal_id),
+                    push_subscriptions::p256dh.eq(p256dh),
+                    push_subscriptions::auth.eq(auth),
+                ))
+                .execute(&mut conn)
+                .await
+                .map_err(|e| store_err(&e))?;
+            Ok(())
+        }
+
+        async fn list_for(&self, principal_id: &str) -> Result<Vec<StoredSubscription>, PushError> {
+            use push_subscriptions::dsl;
+            let mut conn = self.conn().await?;
+            let rows: Vec<SubscriptionRow> = dsl::push_subscriptions
+                .filter(dsl::principal_id.eq(principal_id))
+                .order(dsl::id.asc())
+                .select(SubscriptionRow::as_select())
+                .load(&mut conn)
+                .await
+                .map_err(|e| store_err(&e))?;
+            rows.into_iter().map(StoredSubscription::try_from).collect()
+        }
+
+        async fn remove(
+            &self,
+            endpoint: &str,
+            principal_id: Option<&str>,
+        ) -> Result<u64, PushError> {
+            use push_subscriptions::dsl;
+            let mut conn = self.conn().await?;
+            let affected = match principal_id {
+                Some(id) => {
+                    diesel::delete(
+                        dsl::push_subscriptions
+                            .filter(dsl::endpoint.eq(endpoint))
+                            .filter(dsl::principal_id.eq(id)),
+                    )
+                    .execute(&mut conn)
+                    .await
+                }
+                None => {
+                    diesel::delete(dsl::push_subscriptions.filter(dsl::endpoint.eq(endpoint)))
+                        .execute(&mut conn)
+                        .await
+                }
+            }
+            .map_err(|e| store_err(&e))?;
+            Ok(affected as u64)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+
+    const P256DH: &str =
+        "BCVxsr7N_eNgVRqvHtD0zTZsEc6-VV-JvLexhqUzORcxaOzi6-AYWXvTBHm4bjyPjs7Vd8pZGH6SRpkNtoIAiw4";
+    const AUTH: &str = "BTBZMqHH6r4Tts7J_aSIgg";
+
+    fn browser_subscription(endpoint: &str) -> BrowserSubscription {
+        BrowserSubscription {
+            endpoint: endpoint.to_owned(),
+            keys: SubscriptionKeys {
+                p256dh: P256DH.to_owned(),
+                auth: AUTH.to_owned(),
+            },
+        }
+    }
+
+    fn stored(principal: impl Into<PushPrincipal>, endpoint: &str) -> StoredSubscription {
+        browser_subscription(endpoint)
+            .decode(&principal.into())
+            .expect("valid subscription")
+    }
+
+    // ── PushPrincipal ───────────────────────────────────────────────────────
+
+    #[test]
+    fn principal_accepts_an_integer_user_id() {
+        // Composing with the #1148 notification feed means reaching for the
+        // same `recipient_id: i64` the feed uses, with no manual conversion.
+        assert_eq!(PushPrincipal::from(42_i64).as_str(), "42");
+    }
+
+    #[test]
+    fn principal_accepts_string_shaped_ids() {
+        assert_eq!(PushPrincipal::from("user:42").as_str(), "user:42");
+        assert_eq!(
+            PushPrincipal::from("service:ci".to_owned()).as_str(),
+            "service:ci"
+        );
+    }
+
+    #[test]
+    fn principal_for_the_same_user_id_is_stable_across_both_forms() {
+        assert_eq!(PushPrincipal::from(7_i64), PushPrincipal::from("7"));
+    }
+
+    // ── Decoding the browser payload ────────────────────────────────────────
+
+    #[test]
+    fn decode_turns_base64url_keys_into_raw_bytes() {
+        let subscription = stored(1_i64, "https://push.example.com/a");
+        assert_eq!(subscription.principal_id, "1");
+        assert_eq!(subscription.endpoint, "https://push.example.com/a");
+        assert_eq!(
+            subscription.p256dh,
+            URL_SAFE_NO_PAD.decode(P256DH).expect("decode")
+        );
+        assert_eq!(
+            subscription.auth,
+            URL_SAFE_NO_PAD.decode(AUTH).expect("decode")
+        );
+        assert_eq!(subscription.p256dh.len(), 65);
+        assert_eq!(subscription.auth.len(), 16);
+    }
+
+    #[test]
+    fn decode_rejects_a_p256dh_that_is_not_a_curve_point() {
+        // Validating at the STORE boundary means a hostile subscribe request
+        // can never persist a row that only fails later, at send time.
+        let mut sub = browser_subscription("https://push.example.com/a");
+        let mut bytes = URL_SAFE_NO_PAD.decode(P256DH).expect("decode");
+        bytes[64] ^= 0x01;
+        sub.keys.p256dh = URL_SAFE_NO_PAD.encode(bytes);
+        let err = sub
+            .decode(&1_i64.into())
+            .expect_err("an off-curve p256dh is rejected");
+        assert!(
+            matches!(err, PushError::InvalidSubscriptionKey(_)),
+            "{err:?}"
+        );
+    }
+
+    #[test]
+    fn decode_rejects_a_wrong_length_auth_secret() {
+        let mut sub = browser_subscription("https://push.example.com/a");
+        sub.keys.auth = URL_SAFE_NO_PAD.encode([0_u8; 8]);
+        let err = sub.decode(&1_i64.into()).expect_err("auth is 16 bytes");
+        assert!(
+            matches!(err, PushError::InvalidSubscriptionKey(_)),
+            "{err:?}"
+        );
+    }
+
+    #[test]
+    fn decode_rejects_non_base64url_keys() {
+        let mut sub = browser_subscription("https://push.example.com/a");
+        sub.keys.p256dh = "not base64!!!".to_owned();
+        let err = sub.decode(&1_i64.into()).expect_err("garbage is rejected");
+        assert!(
+            matches!(err, PushError::InvalidSubscriptionKey(_)),
+            "{err:?}"
+        );
+    }
+
+    #[test]
+    fn decode_rejects_a_non_https_endpoint() {
+        // A plaintext endpoint would ship the encrypted body — and the VAPID
+        // JWT that authenticates us — over an interceptable channel.
+        let err = browser_subscription("http://push.example.com/a")
+            .decode(&1_i64.into())
+            .expect_err("http:// endpoints are refused");
+        assert!(matches!(err, PushError::InvalidEndpoint(_)), "{err:?}");
+    }
+
+    #[test]
+    fn decode_rejects_an_endpoint_pointing_at_a_private_address() {
+        // The endpoint is attacker-controlled input that the framework later
+        // makes an outbound POST to: unchecked, subscribe is an SSRF gadget.
+        for endpoint in [
+            "https://127.0.0.1/push",
+            "https://localhost/push",
+            "https://10.0.0.1/push",
+            "https://169.254.169.254/latest/meta-data",
+            "https://[::1]/push",
+        ] {
+            let err = browser_subscription(endpoint)
+                .decode(&1_i64.into())
+                .expect_err(&format!("{endpoint} must be refused"));
+            assert!(
+                matches!(err, PushError::InvalidEndpoint(_)),
+                "{endpoint}: expected InvalidEndpoint, got {err:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn decode_accepts_a_real_push_service_endpoint() {
+        for endpoint in [
+            "https://fcm.googleapis.com/fcm/send/abc123",
+            "https://updates.push.services.mozilla.com/wpush/v2/gAAAA",
+            "https://wns2-par02p.notify.windows.com/w/?token=xyz",
+        ] {
+            browser_subscription(endpoint)
+                .decode(&1_i64.into())
+                .unwrap_or_else(|e| panic!("{endpoint} must be accepted, got {e}"));
+        }
+    }
+
+    // ── MemoryPushSubscriptionStore ─────────────────────────────────────────
+
+    #[tokio::test]
+    async fn save_then_list_round_trips() {
+        let store = MemoryPushSubscriptionStore::new();
+        let subscription = stored(1_i64, "https://push.example.com/a");
+        store.save(subscription.clone()).await.expect("save");
+        assert_eq!(store.list_for("1").await.expect("list"), vec![subscription]);
+    }
+
+    #[tokio::test]
+    async fn saving_the_same_endpoint_twice_upserts_rather_than_duplicates() {
+        let store = MemoryPushSubscriptionStore::new();
+        store
+            .save(stored(1_i64, "https://push.example.com/a"))
+            .await
+            .expect("save");
+        store
+            .save(stored(1_i64, "https://push.example.com/a"))
+            .await
+            .expect("re-save");
+        assert_eq!(
+            store.list_for("1").await.expect("list").len(),
+            1,
+            "re-subscribing the same endpoint must update, not duplicate"
+        );
+    }
+
+    #[tokio::test]
+    async fn re_saving_an_endpoint_under_a_new_principal_moves_it() {
+        // A shared device where a second user signs in re-subscribes the SAME
+        // endpoint. Leaving the old row would deliver the first user's
+        // notifications to the second.
+        let store = MemoryPushSubscriptionStore::new();
+        store
+            .save(stored(1_i64, "https://push.example.com/a"))
+            .await
+            .expect("save");
+        store
+            .save(stored(2_i64, "https://push.example.com/a"))
+            .await
+            .expect("re-save under a new principal");
+        assert!(
+            store.list_for("1").await.expect("list").is_empty(),
+            "the previous owner must no longer receive on this endpoint"
+        );
+        assert_eq!(store.list_for("2").await.expect("list").len(), 1);
+    }
+
+    #[tokio::test]
+    async fn list_is_scoped_to_one_principal() {
+        let store = MemoryPushSubscriptionStore::new();
+        store
+            .save(stored(1_i64, "https://push.example.com/a"))
+            .await
+            .expect("save");
+        store
+            .save(stored(2_i64, "https://push.example.com/b"))
+            .await
+            .expect("save");
+        let rows = store.list_for("1").await.expect("list");
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].endpoint, "https://push.example.com/a");
+    }
+
+    #[tokio::test]
+    async fn list_for_an_unknown_principal_is_empty_not_an_error() {
+        let store = MemoryPushSubscriptionStore::new();
+        assert!(store.list_for("nobody").await.expect("list").is_empty());
+    }
+
+    #[tokio::test]
+    async fn one_principal_may_hold_several_devices() {
+        let store = MemoryPushSubscriptionStore::new();
+        store
+            .save(stored(1_i64, "https://push.example.com/laptop"))
+            .await
+            .expect("save");
+        store
+            .save(stored(1_i64, "https://push.example.com/phone"))
+            .await
+            .expect("save");
+        assert_eq!(store.list_for("1").await.expect("list").len(), 2);
+    }
+
+    #[tokio::test]
+    async fn unscoped_remove_prunes_by_endpoint() {
+        // This is the path a `410 Gone` from the push service takes: the
+        // endpoint is dead for everyone, so no principal scope applies.
+        let store = MemoryPushSubscriptionStore::new();
+        store
+            .save(stored(1_i64, "https://push.example.com/a"))
+            .await
+            .expect("save");
+        assert_eq!(
+            store
+                .remove("https://push.example.com/a", None)
+                .await
+                .expect("remove"),
+            1
+        );
+        assert!(store.list_for("1").await.expect("list").is_empty());
+    }
+
+    #[tokio::test]
+    async fn scoped_remove_refuses_another_principals_endpoint() {
+        // The unsubscribe route passes the caller's own principal, so one
+        // signed-in user can never unsubscribe another user's device.
+        let store = MemoryPushSubscriptionStore::new();
+        store
+            .save(stored(1_i64, "https://push.example.com/a"))
+            .await
+            .expect("save");
+        assert_eq!(
+            store
+                .remove("https://push.example.com/a", Some("2"))
+                .await
+                .expect("remove"),
+            0,
+            "a different principal must not be able to delete this row"
+        );
+        assert_eq!(store.list_for("1").await.expect("list").len(), 1);
+    }
+
+    #[tokio::test]
+    async fn removing_a_missing_endpoint_is_a_no_op_not_an_error() {
+        let store = MemoryPushSubscriptionStore::new();
+        assert_eq!(
+            store
+                .remove("https://push.example.com/gone", None)
+                .await
+                .expect("remove"),
+            0
+        );
+    }
+}

--- a/autumn/src/push/store.rs
+++ b/autumn/src/push/store.rs
@@ -106,23 +106,50 @@ pub struct SubscriptionKeys {
 
 /// A subscription that has been validated and bound to a principal.
 ///
-/// Only [`BrowserSubscription::decode`] produces one, so every value of this
-/// type carries an https endpoint, a `p256dh` that is a real point on P-256,
-/// and a 16-byte `auth` secret.
+/// The fields are private and [`BrowserSubscription::decode`] is the only way
+/// to build one, so every value of this type is *known* to carry a validated,
+/// normalized https endpoint, a `p256dh` that is a real point on P-256, and a
+/// 16-byte `auth` secret. A custom [`PushSubscriptionStore`] therefore never
+/// has to re-validate what it is handed — and cannot be handed anything a
+/// hostile client shaped.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct StoredSubscription {
     /// Who this subscription delivers to.
-    pub principal_id: String,
-    /// The push service URL. Unique across the store: an endpoint identifies
-    /// exactly one user agent installation.
-    pub endpoint: String,
+    principal_id: String,
+    /// The push service URL, normalized. Unique across the store: an endpoint
+    /// identifies exactly one user agent installation.
+    endpoint: String,
     /// The user agent's P-256 public key, raw (65 bytes, uncompressed).
-    pub p256dh: Vec<u8>,
+    p256dh: Vec<u8>,
     /// The user agent's authentication secret, raw (16 bytes).
-    pub auth: Vec<u8>,
+    auth: Vec<u8>,
 }
 
 impl StoredSubscription {
+    /// Who this subscription delivers to.
+    #[must_use]
+    pub fn principal_id(&self) -> &str {
+        &self.principal_id
+    }
+
+    /// The push service URL, in the normalized form the store keys on.
+    #[must_use]
+    pub fn endpoint(&self) -> &str {
+        &self.endpoint
+    }
+
+    /// The user agent's P-256 public key, raw (65 bytes, uncompressed).
+    #[must_use]
+    pub fn p256dh(&self) -> &[u8] {
+        &self.p256dh
+    }
+
+    /// The user agent's authentication secret, raw (16 bytes).
+    #[must_use]
+    pub fn auth(&self) -> &[u8] {
+        &self.auth
+    }
+
     /// The `p256dh` key as the browser sent it.
     #[must_use]
     pub fn p256dh_base64url(&self) -> String {
@@ -204,53 +231,116 @@ impl BrowserSubscription {
 ///
 /// See [`BrowserSubscription::decode`]'s "Endpoint safety" section for why
 /// each rule is here.
+/// The longest endpoint URL that will be stored.
+///
+/// Real push service endpoints are a few hundred bytes. A generous ceiling
+/// stops a client filling the table — and every later `Vec<String>` of pruned
+/// endpoints — with maximum-size rows.
+pub(crate) const MAX_ENDPOINT_LEN: usize = 2048;
+
+/// Check an endpoint URL and return it in **normalized** form.
+///
+/// See [`BrowserSubscription::decode`]'s "Endpoint safety" section for why
+/// each rule is here.
+///
+/// Normalization is load-bearing, not cosmetic: `endpoint` is the store's
+/// unique identity, so returning the raw client string would let
+/// `https://x.example/p`, `https://x.example:443/p`, `https://X.example/p` and
+/// `https://u:p@x.example/p` become four rows that all dispatch to the same
+/// real endpoint — defeating both the upsert and the "re-subscribing never
+/// duplicates" guarantee. `Url`'s own serialization lowercases the host, drops
+/// the scheme's default port, and resolves dot segments; userinfo and fragment
+/// are stripped here because neither is part of the endpoint's identity and a
+/// push service never uses them.
 fn validate_endpoint(endpoint: &str) -> Result<String, PushError> {
     let endpoint = endpoint.trim();
-    let parsed = url::Url::parse(endpoint)
-        .map_err(|e| PushError::InvalidEndpoint(format!("{endpoint}: {e}")))?;
+    if endpoint.len() > MAX_ENDPOINT_LEN {
+        return Err(PushError::InvalidEndpoint(format!(
+            "push endpoints must be at most {MAX_ENDPOINT_LEN} bytes, got {}",
+            endpoint.len()
+        )));
+    }
+    // The submitted URL is deliberately NOT echoed in these messages: the
+    // built-in subscribe route surfaces them to the caller, and an endpoint
+    // URL is a capability — anyone holding one can push to that device.
+    let mut parsed = url::Url::parse(endpoint)
+        .map_err(|e| PushError::InvalidEndpoint(format!("not a valid URL: {e}")))?;
     if parsed.scheme() != "https" {
         return Err(PushError::InvalidEndpoint(format!(
-            "{endpoint}: push endpoints must use https, got `{}`",
+            "push endpoints must use https, got `{}`",
             parsed.scheme()
         )));
     }
     match parsed.host() {
         Some(url::Host::Domain(host)) => {
-            let host = host.to_ascii_lowercase();
-            if host == "localhost" || host.ends_with(".localhost") {
-                return Err(PushError::InvalidEndpoint(format!(
-                    "{endpoint}: refusing a loopback push endpoint"
-                )));
+            // `Url` lowercases the host but PRESERVES a trailing dot, and
+            // `localhost.` is the fully-qualified form every resolver maps to
+            // 127.0.0.1 — so the comparison has to strip it, or the loopback
+            // rule is one character away from being bypassed.
+            let host = host.trim_end_matches('.').to_ascii_lowercase();
+            if host.is_empty() || host == "localhost" || host.ends_with(".localhost") {
+                return Err(PushError::InvalidEndpoint(
+                    "refusing a loopback push endpoint".to_owned(),
+                ));
             }
         }
         Some(url::Host::Ipv4(_) | url::Host::Ipv6(_)) => {
-            return Err(PushError::InvalidEndpoint(format!(
-                "{endpoint}: push endpoints must name a host, not an IP literal"
-            )));
+            return Err(PushError::InvalidEndpoint(
+                "push endpoints must name a host, not an IP literal".to_owned(),
+            ));
         }
         None => {
-            return Err(PushError::InvalidEndpoint(format!("{endpoint}: no host")));
+            return Err(PushError::InvalidEndpoint("no host".to_owned()));
         }
     }
-    Ok(endpoint.to_owned())
+    // Credentials and fragments are not part of the endpoint's identity, and a
+    // push service never uses them; leaving them in would make one endpoint
+    // several rows.
+    let _ = parsed.set_username("");
+    let _ = parsed.set_password(None);
+    parsed.set_fragment(None);
+    Ok(parsed.to_string())
 }
 
 // ── Store trait ─────────────────────────────────────────────────────────────
 
+/// The most subscriptions one principal may hold.
+///
+/// Every device (and every browser profile) a user has is one subscription, so
+/// the ceiling is generous — but it must exist: without it any authenticated
+/// caller can register unbounded rows, and since a send dispatches to each in
+/// turn, that turns one account into an unbounded amount of work per
+/// notification.
+pub const MAX_SUBSCRIPTIONS_PER_PRINCIPAL: usize = 20;
+
 /// Pluggable storage for push subscriptions.
 ///
 /// Implement this to persist subscriptions somewhere other than the built-in
-/// backends. Two contracts every backend must honor:
+/// backends. Three contracts every backend must honor:
 ///
 /// - **`endpoint` is the primary identity.** [`save`](Self::save) upserts on
-///   it: re-saving an endpoint updates the existing row (including moving it
-///   to a different principal, which is what happens when a second user signs
-///   in on a shared device) and never creates a second row.
+///   it: re-saving an endpoint updates the existing row and never creates a
+///   second one.
+/// - **A cross-principal move requires proof of possession.** Re-saving an
+///   endpoint that currently belongs to a *different* principal is allowed
+///   only when the incoming `p256dh` matches the stored one; otherwise it is
+///   [`PushError::EndpointClaimed`]. This keeps the legitimate case working —
+///   a shared device where a second user signs in re-subscribes and the
+///   browser returns the *same* endpoint **and the same keys**, so the row
+///   moves — while refusing the attack it otherwise enables: an endpoint URL
+///   is only a capability to *send*, and without this rule anyone who obtained
+///   one could re-register it under their own account with their own keys,
+///   silently cutting the victim off and redirecting their notifications.
 /// - **Removal is idempotent.** [`remove`](Self::remove) returns how many rows
 ///   it deleted; a missing endpoint is `Ok(0)`, not an error.
 pub trait PushSubscriptionStore: Send + Sync + 'static {
     /// Persist a subscription, replacing any existing row for the same
     /// endpoint.
+    ///
+    /// Must return [`PushError::EndpointClaimed`] when the endpoint belongs to
+    /// a different principal and the incoming `p256dh` does not match the
+    /// stored one, and [`PushError::TooManySubscriptions`] when the principal
+    /// is already at [`MAX_SUBSCRIPTIONS_PER_PRINCIPAL`]. See the trait docs.
     fn save(
         &self,
         subscription: StoredSubscription,
@@ -335,9 +425,35 @@ impl MemoryPushSubscriptionStore {
 impl PushSubscriptionStore for MemoryPushSubscriptionStore {
     async fn save(&self, subscription: StoredSubscription) -> Result<(), PushError> {
         let mut rows = self.lock()?;
+
         // Endpoint identity, not (principal, endpoint): re-subscribing on a
         // shared device must MOVE the row, never leave the previous owner
-        // still receiving on it.
+        // still receiving on it. But a move across principals is only honored
+        // when the caller presents the SAME `p256dh` the stored row has —
+        // otherwise merely knowing an endpoint URL would be enough to take a
+        // victim's device over. See the trait docs.
+        if let Some(existing) = rows
+            .iter()
+            .find(|row| row.endpoint == subscription.endpoint)
+            && existing.principal_id != subscription.principal_id
+            && existing.p256dh != subscription.p256dh
+        {
+            return Err(PushError::EndpointClaimed);
+        }
+
+        let is_new = !rows.iter().any(|row| row.endpoint == subscription.endpoint);
+        if is_new
+            && rows
+                .iter()
+                .filter(|row| row.principal_id == subscription.principal_id)
+                .count()
+                >= MAX_SUBSCRIPTIONS_PER_PRINCIPAL
+        {
+            return Err(PushError::TooManySubscriptions {
+                max: MAX_SUBSCRIPTIONS_PER_PRINCIPAL,
+            });
+        }
+
         rows.retain(|row| row.endpoint != subscription.endpoint);
         rows.push(subscription);
         drop(rows);
@@ -497,32 +613,84 @@ mod db_store {
 
     impl PushSubscriptionStore for DbPushSubscriptionStore {
         async fn save(&self, subscription: StoredSubscription) -> Result<(), PushError> {
+            // `filter` on an `ON CONFLICT … DO UPDATE` (the proof-of-possession
+            // predicate below) comes from `FilterDsl`, which the prelude does
+            // not re-export for insert statements. Imported inside this fn
+            // rather than at module scope so it cannot shadow `QueryDsl::filter`
+            // on the ordinary selects in `list_for`/`remove`.
+            use diesel::query_dsl::methods::FilterDsl as _;
+            use push_subscriptions::dsl;
+
             let mut conn = self.conn().await?;
             let principal_id = subscription.principal_id.clone();
+            let endpoint = subscription.endpoint.clone();
             let p256dh = subscription.p256dh_base64url();
             let auth = subscription.auth_base64url();
-            diesel::insert_into(push_subscriptions::table)
+
+            // Cap the principal's device count. Checked before the insert
+            // rather than enforced in SQL because the ceiling is a per-owner
+            // count, not a constraint any single row can express; the upsert
+            // below is what stays atomic. A pre-existing endpoint is an
+            // update, so it is never blocked by the cap.
+            // Fully qualified: `FilterDsl` is imported above for the upsert's
+            // `DO UPDATE … WHERE`, which would otherwise make this ambiguous.
+            let counted = diesel::QueryDsl::filter(
+                diesel::QueryDsl::filter(
+                    dsl::push_subscriptions,
+                    dsl::principal_id.eq(&principal_id),
+                ),
+                dsl::endpoint.ne(&endpoint),
+            );
+            let existing: i64 = counted
+                .count()
+                .get_result(&mut conn)
+                .await
+                .map_err(|e| store_err(&e))?;
+            if usize::try_from(existing).unwrap_or(usize::MAX)
+                >= super::MAX_SUBSCRIPTIONS_PER_PRINCIPAL
+            {
+                return Err(PushError::TooManySubscriptions {
+                    max: super::MAX_SUBSCRIPTIONS_PER_PRINCIPAL,
+                });
+            }
+
+            let affected = diesel::insert_into(push_subscriptions::table)
                 .values(NewSubscriptionRow {
                     principal_id: principal_id.clone(),
-                    endpoint: subscription.endpoint.clone(),
+                    endpoint: endpoint.clone(),
                     p256dh: p256dh.clone(),
                     auth: auth.clone(),
                     created_at: Utc::now(),
                 })
-                // Endpoint identity: re-subscribing the same user agent MOVES
-                // the row to whoever is signed in now (a shared device where a
-                // second user signs in) instead of leaving the previous owner
-                // still receiving on it.
-                .on_conflict(push_subscriptions::endpoint)
+                // Endpoint identity: re-subscribing the same user agent
+                // updates its row in place rather than adding a second.
+                .on_conflict(dsl::endpoint)
                 .do_update()
                 .set((
-                    push_subscriptions::principal_id.eq(principal_id),
-                    push_subscriptions::p256dh.eq(p256dh),
-                    push_subscriptions::auth.eq(auth),
+                    dsl::principal_id.eq(&principal_id),
+                    dsl::p256dh.eq(&p256dh),
+                    dsl::auth.eq(&auth),
                 ))
+                // Proof of possession for a CROSS-principal move, enforced in
+                // the same statement so it cannot race a concurrent subscribe:
+                // the update only applies when the row already belongs to this
+                // principal (an ordinary re-subscribe or key rotation), or when
+                // the caller presents the stored `p256dh` (the shared-device
+                // case, where the browser returns the same endpoint AND the
+                // same keys). Anyone who merely learned the endpoint URL fails
+                // both and the statement touches zero rows.
+                .filter(
+                    dsl::principal_id
+                        .eq(principal_id.clone())
+                        .or(dsl::p256dh.eq(p256dh.clone())),
+                )
                 .execute(&mut conn)
                 .await
                 .map_err(|e| store_err(&e))?;
+
+            if affected == 0 {
+                return Err(PushError::EndpointClaimed);
+            }
             Ok(())
         }
 
@@ -576,6 +744,10 @@ mod tests {
     const P256DH: &str =
         "BCVxsr7N_eNgVRqvHtD0zTZsEc6-VV-JvLexhqUzORcxaOzi6-AYWXvTBHm4bjyPjs7Vd8pZGH6SRpkNtoIAiw4";
     const AUTH: &str = "BTBZMqHH6r4Tts7J_aSIgg";
+    /// A second, unrelated valid P-256 point — what an attacker (or a key
+    /// rotation) would present.
+    const OTHER_P256DH: &str =
+        "BP4z9KsN6nGRTbVYI_c7VJSPQTBtkgcy27mlmlMoZIIgDll6e3vCYLocInmYWAmS6TlzAC8wEqKK6PBru3jl7A8";
 
     fn browser_subscription(endpoint: &str) -> BrowserSubscription {
         BrowserSubscription {
@@ -621,18 +793,18 @@ mod tests {
     #[test]
     fn decode_turns_base64url_keys_into_raw_bytes() {
         let subscription = stored(1_i64, "https://push.example.com/a");
-        assert_eq!(subscription.principal_id, "1");
-        assert_eq!(subscription.endpoint, "https://push.example.com/a");
+        assert_eq!(subscription.principal_id(), "1");
+        assert_eq!(subscription.endpoint(), "https://push.example.com/a");
         assert_eq!(
-            subscription.p256dh,
+            subscription.p256dh(),
             URL_SAFE_NO_PAD.decode(P256DH).expect("decode")
         );
         assert_eq!(
-            subscription.auth,
+            subscription.auth(),
             URL_SAFE_NO_PAD.decode(AUTH).expect("decode")
         );
-        assert_eq!(subscription.p256dh.len(), 65);
-        assert_eq!(subscription.auth.len(), 16);
+        assert_eq!(subscription.p256dh().len(), 65);
+        assert_eq!(subscription.auth().len(), 16);
     }
 
     #[test]
@@ -780,7 +952,7 @@ mod tests {
             .expect("save");
         let rows = store.list_for("1").await.expect("list");
         assert_eq!(rows.len(), 1);
-        assert_eq!(rows[0].endpoint, "https://push.example.com/a");
+        assert_eq!(rows[0].endpoint(), "https://push.example.com/a");
     }
 
     #[tokio::test]
@@ -852,5 +1024,183 @@ mod tests {
                 .expect("remove"),
             0
         );
+    }
+    // ── Endpoint hardening ──────────────────────────────────────────────────
+
+    #[test]
+    fn decode_rejects_a_trailing_dot_loopback_endpoint() {
+        // `localhost.` is the fully-qualified form every resolver maps to
+        // 127.0.0.1, and `Url` preserves the dot — so a check that compares
+        // against `localhost` alone is one character from being bypassed.
+        for endpoint in [
+            "https://localhost./push",
+            "https://LOCALHOST./push",
+            "https://foo.localhost./push",
+        ] {
+            let err = browser_subscription(endpoint)
+                .decode(&1_i64.into())
+                .expect_err(&format!("{endpoint} must be refused"));
+            assert!(
+                matches!(err, PushError::InvalidEndpoint(_)),
+                "{endpoint}: {err:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn decode_normalizes_the_endpoint_so_variants_are_one_row() {
+        // `endpoint` is the store's unique identity. If these normalized to
+        // different strings, one browser would become several rows dispatching
+        // to the same real endpoint — several duplicate notifications, and the
+        // upsert defeated.
+        let canonical = stored(1_i64, "https://push.example.com/abc")
+            .endpoint()
+            .to_owned();
+        for variant in [
+            "https://push.example.com:443/abc",
+            "https://PUSH.example.com/abc",
+            "https://user:secret@push.example.com/abc",
+            "https://push.example.com/abc#fragment",
+            "  https://push.example.com/abc  ",
+        ] {
+            assert_eq!(
+                stored(1_i64, variant).endpoint(),
+                canonical,
+                "{variant} must normalize to the same endpoint"
+            );
+        }
+    }
+
+    #[test]
+    fn decode_does_not_echo_the_submitted_url_in_its_error() {
+        // The built-in subscribe route surfaces these messages to the caller,
+        // and an endpoint URL is a capability: anyone holding one can push to
+        // that device.
+        let secret = "https://push.example.com/SECRET-DEVICE-TOKEN";
+        let mut sub = browser_subscription(secret);
+        sub.endpoint = secret.replace("https", "http");
+        let err = sub.decode(&1_i64.into()).expect_err("http is refused");
+        assert!(
+            !err.to_string().contains("SECRET-DEVICE-TOKEN"),
+            "the error must not reflect the endpoint back: {err}"
+        );
+    }
+
+    #[test]
+    fn decode_rejects_an_absurdly_long_endpoint() {
+        let long = format!("https://push.example.com/{}", "x".repeat(MAX_ENDPOINT_LEN));
+        let err = browser_subscription(&long)
+            .decode(&1_i64.into())
+            .expect_err("oversize endpoints are refused");
+        assert!(matches!(err, PushError::InvalidEndpoint(_)), "{err:?}");
+    }
+
+    // ── Takeover and capacity ───────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn a_different_principal_cannot_claim_an_endpoint_with_its_own_keys() {
+        // Knowing an endpoint URL must not be enough to take a device over:
+        // that would silently cut the victim off AND redirect their
+        // notifications to the attacker, who supplied the keys.
+        let store = MemoryPushSubscriptionStore::new();
+        store
+            .save(stored(1_i64, "https://push.example.com/a"))
+            .await
+            .expect("save");
+
+        let mut hostile = browser_subscription("https://push.example.com/a");
+        hostile.keys.p256dh = OTHER_P256DH.to_owned();
+        let hostile = hostile.decode(&2_i64.into()).expect("valid shape");
+
+        assert!(
+            matches!(store.save(hostile).await, Err(PushError::EndpointClaimed)),
+            "an endpoint URL alone must not transfer a subscription"
+        );
+        assert_eq!(
+            store.list_for("1").await.expect("list").len(),
+            1,
+            "the original owner keeps receiving"
+        );
+        assert!(store.list_for("2").await.expect("list").is_empty());
+    }
+
+    #[tokio::test]
+    async fn the_same_browser_re_subscribing_under_a_new_user_still_moves() {
+        // The legitimate shared-device case: `pushManager.subscribe()` on an
+        // unchanged registration returns the SAME endpoint and the SAME keys,
+        // so possession is proved and the row moves.
+        let store = MemoryPushSubscriptionStore::new();
+        store
+            .save(stored(1_i64, "https://push.example.com/a"))
+            .await
+            .expect("save");
+        store
+            .save(stored(2_i64, "https://push.example.com/a"))
+            .await
+            .expect("a genuine re-subscribe is honored");
+        assert!(store.list_for("1").await.expect("list").is_empty());
+        assert_eq!(store.list_for("2").await.expect("list").len(), 1);
+    }
+
+    #[tokio::test]
+    async fn one_principal_may_rotate_its_own_keys_freely() {
+        let store = MemoryPushSubscriptionStore::new();
+        store
+            .save(stored(1_i64, "https://push.example.com/a"))
+            .await
+            .expect("save");
+        let mut rotated = browser_subscription("https://push.example.com/a");
+        rotated.keys.p256dh = OTHER_P256DH.to_owned();
+        store
+            .save(rotated.decode(&1_i64.into()).expect("valid"))
+            .await
+            .expect("the owner may rotate its own keys");
+        assert_eq!(store.list_for("1").await.expect("list").len(), 1);
+    }
+
+    #[tokio::test]
+    async fn a_principal_cannot_register_unbounded_subscriptions() {
+        // Every send dispatches to each subscription in turn, so an uncapped
+        // principal turns one notification into unbounded work.
+        let store = MemoryPushSubscriptionStore::new();
+        for i in 0..MAX_SUBSCRIPTIONS_PER_PRINCIPAL {
+            store
+                .save(stored(1_i64, &format!("https://push.example.com/d{i}")))
+                .await
+                .expect("save up to the cap");
+        }
+        assert!(
+            matches!(
+                store
+                    .save(stored(1_i64, "https://push.example.com/one-too-many"))
+                    .await,
+                Err(PushError::TooManySubscriptions { .. })
+            ),
+            "the cap must be enforced"
+        );
+        // An existing endpoint is an update, so it is never capped.
+        store
+            .save(stored(1_i64, "https://push.example.com/d0"))
+            .await
+            .expect("re-saving an existing endpoint is not capped");
+        assert_eq!(
+            store.list_for("1").await.expect("list").len(),
+            MAX_SUBSCRIPTIONS_PER_PRINCIPAL
+        );
+    }
+
+    #[tokio::test]
+    async fn the_cap_is_per_principal_not_global() {
+        let store = MemoryPushSubscriptionStore::new();
+        for i in 0..MAX_SUBSCRIPTIONS_PER_PRINCIPAL {
+            store
+                .save(stored(1_i64, &format!("https://push.example.com/d{i}")))
+                .await
+                .expect("save");
+        }
+        store
+            .save(stored(2_i64, "https://push.example.com/other-user"))
+            .await
+            .expect("one user at their cap must not block everyone else");
     }
 }

--- a/autumn/src/push/store.rs
+++ b/autumn/src/push/store.rs
@@ -342,7 +342,8 @@ pub const MAX_SUBSCRIPTIONS_PER_PRINCIPAL: usize = 20;
 ///   second one.
 /// - **A cross-principal move requires proof of possession.** Re-saving an
 ///   endpoint that currently belongs to a *different* principal is allowed
-///   only when the incoming `p256dh` matches the stored one; otherwise it is
+///   only when the incoming `p256dh` **and** `auth` both match the stored ones;
+///   otherwise it is
 ///   [`PushError::EndpointClaimed`]. This keeps the legitimate case working —
 ///   a shared device where a second user signs in re-subscribes and the
 ///   browser returns the *same* endpoint **and the same keys**, so the row
@@ -394,8 +395,8 @@ pub trait PushSubscriptionStore: Send + Sync + 'static {
     /// endpoint.
     ///
     /// Must return [`PushError::EndpointClaimed`] when the endpoint belongs to
-    /// a different principal and the incoming `p256dh` does not match the
-    /// stored one, and [`PushError::TooManySubscriptions`] when the principal
+    /// a different principal and the incoming `p256dh`/`auth` do not both
+    /// match the stored ones, and [`PushError::TooManySubscriptions`] when the principal
     /// is already at [`MAX_SUBSCRIPTIONS_PER_PRINCIPAL`]. See the trait docs.
     fn save(
         &self,
@@ -490,14 +491,15 @@ impl PushSubscriptionStore for MemoryPushSubscriptionStore {
         // Endpoint identity, not (principal, endpoint): re-subscribing on a
         // shared device must MOVE the row, never leave the previous owner
         // still receiving on it. But a move across principals is only honored
-        // when the caller presents the SAME `p256dh` the stored row has —
-        // otherwise merely knowing an endpoint URL would be enough to take a
-        // victim's device over. See the trait docs.
+        // when the caller presents BOTH stored keys — otherwise knowing an
+        // endpoint URL and its (public) `p256dh` would be enough to take a
+        // victim's device over, replacing `auth` in the process so the
+        // victim's browser can no longer decrypt anything. See the trait docs.
         if let Some(existing) = rows
             .iter()
             .find(|row| row.endpoint == subscription.endpoint)
             && existing.principal_id != subscription.principal_id
-            && existing.p256dh != subscription.p256dh
+            && (existing.p256dh != subscription.p256dh || existing.auth != subscription.auth)
         {
             return Err(PushError::EndpointClaimed);
         }
@@ -741,14 +743,18 @@ mod db_store {
                 // the same statement so it cannot race a concurrent subscribe:
                 // the update only applies when the row already belongs to this
                 // principal (an ordinary re-subscribe or key rotation), or when
-                // the caller presents the stored `p256dh` (the shared-device
-                // case, where the browser returns the same endpoint AND the
-                // same keys). Anyone who merely learned the endpoint URL fails
-                // both and the statement touches zero rows.
+                // the caller presents BOTH stored keys (the shared-device case,
+                // where the browser returns the same endpoint AND the same
+                // keys). `p256dh` alone is not enough: it is a *public* key, so
+                // requiring `auth` too means learning the endpoint and its
+                // public half still cannot take the row — which would cut the
+                // victim off AND replace `auth`, leaving their browser unable
+                // to decrypt. Anyone short of both fails and the statement
+                // touches zero rows.
                 .filter(
-                    dsl::principal_id
-                        .eq(principal_id.clone())
-                        .or(dsl::p256dh.eq(p256dh.clone())),
+                    dsl::principal_id.eq(principal_id.clone()).or(dsl::p256dh
+                        .eq(p256dh.clone())
+                        .and(dsl::auth.eq(auth.clone()))),
                 )
                 .execute(&mut conn)
                 .await
@@ -1207,6 +1213,36 @@ mod tests {
             "the original owner keeps receiving"
         );
         assert!(store.list_for("2").await.expect("list").is_empty());
+    }
+
+    #[tokio::test]
+    async fn a_matching_p256dh_alone_does_not_transfer_an_endpoint() {
+        // `p256dh` is a PUBLIC key. Accepting it alone as proof of possession
+        // would let anyone who learned the endpoint and its public half take
+        // the row — cutting the victim off AND replacing `auth`, so their
+        // browser could no longer decrypt anything sent to it.
+        let store = MemoryPushSubscriptionStore::new();
+        store
+            .save(stored(1_i64, "https://push.example.com/a"))
+            .await
+            .expect("save");
+
+        let mut hostile = browser_subscription("https://push.example.com/a");
+        // Correct public key, attacker's own auth secret.
+        hostile.keys.auth = URL_SAFE_NO_PAD.encode([7_u8; 16]);
+        let hostile = hostile.decode(&2_i64.into()).expect("valid shape");
+
+        assert!(
+            matches!(store.save(hostile).await, Err(PushError::EndpointClaimed)),
+            "both keys must match for a cross-principal move"
+        );
+        let rows = store.list_for("1").await.expect("list");
+        assert_eq!(rows.len(), 1, "the original owner keeps the subscription");
+        assert_eq!(
+            rows[0].auth(),
+            URL_SAFE_NO_PAD.decode(AUTH).expect("decode").as_slice(),
+            "and its auth secret is untouched, so it can still decrypt"
+        );
     }
 
     #[tokio::test]

--- a/autumn/src/push/store.rs
+++ b/autumn/src/push/store.rs
@@ -87,7 +87,7 @@ impl std::fmt::Display for PushPrincipal {
 ///
 /// This is the request body the built-in subscribe endpoint accepts. Fields
 /// the browser adds and Autumn does not use (`expirationTime`) are ignored.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct BrowserSubscription {
     /// The push service URL this user agent listens on.
     pub endpoint: String,
@@ -96,7 +96,7 @@ pub struct BrowserSubscription {
 }
 
 /// The `keys` object of a browser `PushSubscription`.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct SubscriptionKeys {
     /// The user agent's P-256 public key, base64url-encoded.
     pub p256dh: String,
@@ -112,7 +112,7 @@ pub struct SubscriptionKeys {
 /// 16-byte `auth` secret. A custom [`PushSubscriptionStore`] therefore never
 /// has to re-validate what it is handed — and cannot be handed anything a
 /// hostile client shaped.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct StoredSubscription {
     /// Who this subscription delivers to.
     principal_id: String,
@@ -160,6 +160,43 @@ impl StoredSubscription {
     #[must_use]
     pub fn auth_base64url(&self) -> String {
         URL_SAFE_NO_PAD.encode(&self.auth)
+    }
+}
+
+/// Redacted: a derived `Debug` would print the endpoint, `p256dh` and `auth`
+/// together — which is everything needed to send arbitrary notifications to
+/// that device. One `tracing::debug!(?subscription)` in an application's own
+/// subscribe handler would put a working send capability into its log
+/// pipeline, which is exactly what the send path already avoids by logging
+/// origins only.
+impl std::fmt::Debug for BrowserSubscription {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("BrowserSubscription")
+            .field("endpoint.origin", &endpoint_origin(&self.endpoint))
+            .field("keys", &self.keys)
+            .finish_non_exhaustive()
+    }
+}
+
+/// Redacted for the same reason as [`BrowserSubscription`]'s.
+impl std::fmt::Debug for SubscriptionKeys {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SubscriptionKeys")
+            .field("p256dh", &"<redacted>")
+            .field("auth", &"<redacted>")
+            .finish()
+    }
+}
+
+/// Redacted for the same reason as [`BrowserSubscription`]'s.
+impl std::fmt::Debug for StoredSubscription {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("StoredSubscription")
+            .field("principal_id", &self.principal_id)
+            .field("endpoint.origin", &endpoint_origin(&self.endpoint))
+            .field("p256dh", &"<redacted>")
+            .field("auth", &"<redacted>")
+            .finish_non_exhaustive()
     }
 }
 
@@ -231,6 +268,19 @@ impl BrowserSubscription {
 ///
 /// See [`BrowserSubscription::decode`]'s "Endpoint safety" section for why
 /// each rule is here.
+/// The origin of an endpoint URL, for logging and `Debug`.
+///
+/// A full push endpoint URL is a **capability**: anyone holding it — with the
+/// subscription's keys — can send to that device. Logs are copied, shipped and
+/// retained far more widely than the subscription table, so nothing in this
+/// module ever renders more than the origin.
+pub(crate) fn endpoint_origin(endpoint: &str) -> String {
+    url::Url::parse(endpoint).map_or_else(
+        |_| "<unparseable>".to_owned(),
+        |parsed| parsed.origin().ascii_serialization(),
+    )
+}
+
 /// The longest endpoint URL that will be stored.
 ///
 /// Real push service endpoints are a few hundred bytes. A generous ceiling
@@ -1116,6 +1166,42 @@ mod tests {
             0
         );
     }
+    // ── Credential redaction ────────────────────────────────────────────────
+
+    #[test]
+    fn debug_never_prints_a_working_send_capability() {
+        // endpoint + p256dh + auth together are everything needed to send
+        // arbitrary notifications to that device. The send path already logs
+        // origins only; the types themselves must not undo that the moment an
+        // app writes `tracing::debug!(?subscription)`.
+        let secret_path = "SECRET-DEVICE-TOKEN";
+        let browser = browser_subscription(&format!("https://push.example.com/{secret_path}"));
+        let stored = browser.decode(&7_i64.into()).expect("valid");
+
+        for rendered in [format!("{browser:?}"), format!("{stored:?}")] {
+            assert!(
+                !rendered.contains(secret_path),
+                "the endpoint path is a capability and must not be printed: {rendered}"
+            );
+            assert!(
+                !rendered.contains(AUTH),
+                "the auth secret must not be printed: {rendered}"
+            );
+            assert!(
+                !rendered.contains(P256DH),
+                "the subscription key must not be printed: {rendered}"
+            );
+            assert!(
+                rendered.contains("push.example.com"),
+                "…but the origin stays, so a delivery problem is still diagnosable: {rendered}"
+            );
+        }
+
+        // The nested keys struct is just as reachable on its own.
+        let keys = format!("{:?}", browser.keys);
+        assert!(!keys.contains(AUTH) && !keys.contains(P256DH), "{keys}");
+    }
+
     // ── Endpoint hardening ──────────────────────────────────────────────────
 
     #[test]

--- a/autumn/src/push/store.rs
+++ b/autumn/src/push/store.rs
@@ -333,6 +333,43 @@ pub const MAX_SUBSCRIPTIONS_PER_PRINCIPAL: usize = 20;
 ///   silently cutting the victim off and redirecting their notifications.
 /// - **Removal is idempotent.** [`remove`](Self::remove) returns how many rows
 ///   it deleted; a missing endpoint is `Ok(0)`, not an error.
+///
+/// # Example
+///
+/// A store is registered once and then never mentioned again — the `WebPush`
+/// extractor picks it up:
+///
+/// ```rust,ignore
+/// use autumn_web::push::{PushError, PushSubscriptionStore, StoredSubscription};
+///
+/// struct RedisPushStore { /* … */ }
+///
+/// impl PushSubscriptionStore for RedisPushStore {
+///     async fn save(&self, subscription: StoredSubscription) -> Result<(), PushError> {
+///         // `subscription` is already validated: an https endpoint, a real
+///         // P-256 point, a 16-byte auth secret. Key on `endpoint()`.
+///         self.upsert(subscription.endpoint(), &subscription).await
+///     }
+///
+///     async fn list_for(&self, principal_id: &str) -> Result<Vec<StoredSubscription>, PushError> {
+///         self.by_principal(principal_id).await
+///     }
+///
+///     async fn remove(
+///         &self,
+///         endpoint: &str,
+///         principal_id: Option<&str>,
+///     ) -> Result<u64, PushError> {
+///         self.delete(endpoint, principal_id).await
+///     }
+/// }
+///
+/// autumn_web::app()
+///     .with_push_subscription_store(RedisPushStore::new())
+///     .merge(autumn_web::push::router())
+///     .run()
+///     .await;
+/// ```
 pub trait PushSubscriptionStore: Send + Sync + 'static {
     /// Persist a subscription, replacing any existing row for the same
     /// endpoint.

--- a/autumn/src/push/store.rs
+++ b/autumn/src/push/store.rs
@@ -311,6 +311,25 @@ fn validate_endpoint(endpoint: &str) -> Result<String, PushError> {
 /// caller can register unbounded rows, and since a send dispatches to each in
 /// turn, that turns one account into an unbounded amount of work per
 /// notification.
+///
+/// # How the bound is actually guaranteed
+///
+/// Enforced in two places, deliberately, because they guarantee different
+/// things:
+///
+/// - [`save`](PushSubscriptionStore::save) refuses a *new* endpoint past the
+///   cap. This is a check-then-insert, so a burst of concurrent subscribes for
+///   one principal can overshoot it by up to the number of requests in flight.
+///   Serializing every subscribe per principal (an advisory lock, or
+///   `SERIALIZABLE`) would close that window at a cost out of all proportion
+///   to what it buys, because —
+/// - [`list_for`](PushSubscriptionStore::list_for) returns **at most** this
+///   many rows. That is the bound that matters: it caps the work a single
+///   notification can cause no matter how many rows a race, a restored backup,
+///   or a hand-written `INSERT` managed to leave in the table.
+///
+/// So the row count is approximately capped and the *per-notification work* is
+/// strictly capped.
 pub const MAX_SUBSCRIPTIONS_PER_PRINCIPAL: usize = 20;
 
 /// Pluggable storage for push subscriptions.
@@ -384,6 +403,11 @@ pub trait PushSubscriptionStore: Send + Sync + 'static {
     ) -> impl Future<Output = Result<(), PushError>> + Send;
 
     /// Every subscription belonging to `principal_id` (empty when none do).
+    ///
+    /// Must return at most [`MAX_SUBSCRIPTIONS_PER_PRINCIPAL`] rows. This is
+    /// the hard bound on how much work one notification can cause — see that
+    /// constant — so a backend must apply it even when the table somehow holds
+    /// more.
     fn list_for(
         &self,
         principal_id: &str,
@@ -502,6 +526,9 @@ impl PushSubscriptionStore for MemoryPushSubscriptionStore {
         Ok(rows
             .iter()
             .filter(|row| row.principal_id == principal_id)
+            // The bound that actually caps per-notification work; see
+            // `MAX_SUBSCRIPTIONS_PER_PRINCIPAL`.
+            .take(MAX_SUBSCRIPTIONS_PER_PRINCIPAL)
             .cloned()
             .collect())
     }
@@ -664,11 +691,13 @@ mod db_store {
             let p256dh = subscription.p256dh_base64url();
             let auth = subscription.auth_base64url();
 
-            // Cap the principal's device count. Checked before the insert
-            // rather than enforced in SQL because the ceiling is a per-owner
-            // count, not a constraint any single row can express; the upsert
-            // below is what stays atomic. A pre-existing endpoint is an
-            // update, so it is never blocked by the cap.
+            // Cap the principal's device count. A per-owner count is not a
+            // constraint any single row can express, so this is a
+            // check-then-insert and a concurrent burst can overshoot it — see
+            // `MAX_SUBSCRIPTIONS_PER_PRINCIPAL` for why that is accepted
+            // rather than serialized away (`list_for`'s LIMIT is the bound
+            // that has to hold, and it does unconditionally). A pre-existing
+            // endpoint is an update, so it is never blocked by the cap.
             // Fully qualified: `FilterDsl` is imported above for the upsert's
             // `DO UPDATE … WHERE`, which would otherwise make this ambiguous.
             let counted = diesel::QueryDsl::filter(
@@ -737,6 +766,10 @@ mod db_store {
             let rows: Vec<SubscriptionRow> = dsl::push_subscriptions
                 .filter(dsl::principal_id.eq(principal_id))
                 .order(dsl::id.asc())
+                // The bound that actually caps per-notification work — applied
+                // in SQL so it holds however many rows the table contains. See
+                // `MAX_SUBSCRIPTIONS_PER_PRINCIPAL`.
+                .limit(i64::try_from(super::MAX_SUBSCRIPTIONS_PER_PRINCIPAL).unwrap_or(i64::MAX))
                 .select(SubscriptionRow::as_select())
                 .load(&mut conn)
                 .await
@@ -794,6 +827,21 @@ mod tests {
                 auth: AUTH.to_owned(),
             },
         }
+    }
+
+    /// Put more rows in the store than [`MAX_SUBSCRIPTIONS_PER_PRINCIPAL`]
+    /// allows, bypassing `save`'s cap the way a restored backup or a
+    /// hand-written `INSERT` would.
+    ///
+    /// Deliberately not `async`: holding the guard inside an async fn would
+    /// keep a `MutexGuard` alive across an await point.
+    fn stuff_past_the_cap(store: &MemoryPushSubscriptionStore) {
+        let extra: Vec<StoredSubscription> = (0..(MAX_SUBSCRIPTIONS_PER_PRINCIPAL * 3))
+            .map(|i| stored(1_i64, &format!("https://push.example.com/raw{i}")))
+            .collect();
+        let mut rows = store.rows.lock().expect("memory store lock");
+        rows.extend(extra);
+        drop(rows);
     }
 
     fn stored(principal: impl Into<PushPrincipal>, endpoint: &str) -> StoredSubscription {
@@ -1223,6 +1271,22 @@ mod tests {
         assert_eq!(
             store.list_for("1").await.expect("list").len(),
             MAX_SUBSCRIPTIONS_PER_PRINCIPAL
+        );
+    }
+
+    #[tokio::test]
+    async fn list_for_is_bounded_even_when_the_table_holds_more() {
+        // This is the bound that actually caps per-notification work. The
+        // insert-time cap is a check-then-insert and can be overshot by a
+        // concurrent burst (or by a restored backup, or a hand-written
+        // INSERT); this must hold regardless, so it is asserted against a
+        // store deliberately stuffed past the cap.
+        let store = MemoryPushSubscriptionStore::new();
+        stuff_past_the_cap(&store);
+        assert_eq!(
+            store.list_for("1").await.expect("list").len(),
+            MAX_SUBSCRIPTIONS_PER_PRINCIPAL,
+            "one notification must never fan out past the cap"
         );
     }
 

--- a/autumn/src/push/transport.rs
+++ b/autumn/src/push/transport.rs
@@ -166,13 +166,28 @@ impl PushTransport for RecordingPushTransport {
 
 /// The default [`PushTransport`]: a real `POST` to the push service.
 ///
-/// Uses the framework's outbound [`Client`](crate::http_client::Client), so
-/// push traffic inherits its tracing context propagation, timeouts, and — the
-/// reason it matters here — its SSRF address policy. The subscribe boundary
-/// already refuses IP-literal and loopback endpoints
-/// ([`BrowserSubscription::decode`](super::store::BrowserSubscription::decode));
-/// this covers the remaining case of a *hostname* that resolves to a private
-/// address.
+/// Uses the framework's outbound [`Client`](crate::http_client::Client) for
+/// tracing context propagation and timeouts, and adds the SSRF protection a
+/// push endpoint specifically needs.
+///
+/// # Why this does its own address validation
+///
+/// The endpoint is a URL the *client* chose, and this is the code that
+/// connects to it. [`BrowserSubscription::decode`](super::store::BrowserSubscription::decode)
+/// already refuses IP-literal and loopback endpoints at the subscribe
+/// boundary, but that check cannot see where a *hostname* resolves — an
+/// attacker who controls a DNS record can point `push.attacker.example` at
+/// `169.254.169.254` and pass it. `Client`'s own address deny-list only runs
+/// on the `get_ssrf_safe` path, which is GET-only, so this transport applies
+/// the equivalent to its `POST`:
+///
+/// 1. resolve the host and refuse the request unless **every** resolved
+///    address passes [`is_blocked_ip`](crate::http_client::is_blocked_ip);
+/// 2. pin the connection to the validated address, so the socket cannot be
+///    re-pointed between the check and the connect (DNS rebinding); and
+/// 3. refuse to follow redirects, so a real-looking public endpoint cannot
+///    `307` the body onto an internal address — reqwest's default policy
+///    would replay the POST with no re-validation of the new hop.
 #[cfg(feature = "http-client")]
 #[derive(Clone)]
 pub struct HttpPushTransport {
@@ -199,7 +214,16 @@ impl HttpPushTransport {
 impl PushTransport for HttpPushTransport {
     fn deliver<'a>(&'a self, request: &'a PushRequest) -> PushTransportFuture<'a> {
         Box::pin(async move {
-            let mut builder = self.client.post(&request.endpoint);
+            let pin = resolve_and_validate_endpoint(&request.endpoint).await?;
+
+            let mut builder = self
+                .client
+                .post(&request.endpoint)
+                // See the type docs: pin the checked address and refuse to
+                // follow a redirect, so neither DNS rebinding nor a `307` can
+                // steer this POST at an internal host.
+                .pin_to(pin)
+                .no_redirect();
             for (name, value) in &request.headers {
                 builder = builder.header(name, value);
             }
@@ -211,5 +235,193 @@ impl PushTransport for HttpPushTransport {
                 Err(e) => Err(PushError::Transport(e.to_string())),
             }
         })
+    }
+}
+
+/// Resolve `endpoint`'s host and return one address that is safe to connect to.
+///
+/// Every resolved address must pass the outbound client's SSRF deny-list: a
+/// host that resolves to *any* blocked address is refused outright rather than
+/// filtered down to its public addresses, since a resolver returning both is
+/// exactly the shape a rebinding attack produces.
+#[cfg(feature = "http-client")]
+async fn resolve_and_validate_endpoint(endpoint: &str) -> Result<std::net::SocketAddr, PushError> {
+    let parsed = url::Url::parse(endpoint)
+        .map_err(|e| PushError::InvalidEndpoint(format!("{endpoint}: {e}")))?;
+    let host = parsed
+        .host_str()
+        .ok_or_else(|| PushError::InvalidEndpoint(format!("{endpoint}: no host")))?
+        .to_owned();
+    // `port_or_known_default` gives 443 for https, the only scheme
+    // `validate_endpoint` lets through.
+    let port = parsed.port_or_known_default().unwrap_or(443);
+
+    let addrs: Vec<std::net::SocketAddr> = tokio::net::lookup_host((host.as_str(), port))
+        .await
+        .map_err(|e| PushError::Transport(format!("could not resolve the push endpoint: {e}")))?
+        .collect();
+
+    if let Some(blocked) = addrs
+        .iter()
+        .find(|addr| crate::http_client::is_blocked_ip(addr.ip()))
+    {
+        return Err(PushError::InvalidEndpoint(format!(
+            "the push endpoint host resolves to a blocked address ({}); refusing to connect",
+            blocked.ip()
+        )));
+    }
+    addrs.first().copied().ok_or_else(|| {
+        PushError::Transport("the push endpoint host resolved to no addresses".to_owned())
+    })
+}
+
+/// A transport for a build with no HTTP client compiled in.
+///
+/// Reports the failure instead of pretending to deliver: a push that cannot
+/// possibly go out must never look like it did.
+#[cfg(not(feature = "http-client"))]
+#[derive(Debug, Clone, Copy)]
+pub struct UnavailablePushTransport;
+
+#[cfg(not(feature = "http-client"))]
+impl PushTransport for UnavailablePushTransport {
+    fn deliver<'a>(&'a self, _request: &'a PushRequest) -> PushTransportFuture<'a> {
+        Box::pin(async {
+            Err(PushError::Transport(
+                "no outbound HTTP client is available: autumn-web was built without the \
+                 `http-client` feature. Enable it, or register your own transport."
+                    .to_owned(),
+            ))
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn request(endpoint: &str) -> PushRequest {
+        PushRequest {
+            endpoint: endpoint.to_owned(),
+            headers: vec![
+                ("authorization".to_owned(), "vapid t=x, k=y".to_owned()),
+                ("content-encoding".to_owned(), "aes128gcm".to_owned()),
+            ],
+            body: vec![1, 2, 3],
+        }
+    }
+
+    #[test]
+    fn header_lookup_is_case_insensitive() {
+        // Header names are case-insensitive on the wire, and a test asserting
+        // on `Authorization` must not fail because the sender wrote it lower.
+        let request = request("https://push.example.com/a");
+        assert_eq!(request.header("Authorization"), Some("vapid t=x, k=y"));
+        assert_eq!(request.header("AUTHORIZATION"), Some("vapid t=x, k=y"));
+        assert_eq!(request.header("missing"), None);
+    }
+
+    #[tokio::test]
+    async fn recording_transport_defaults_to_created() {
+        // `201 Created` is what a push service returns on acceptance; a
+        // default that fell outside 2xx would make every unscripted test look
+        // like a failed delivery.
+        let transport = RecordingPushTransport::new();
+        assert_eq!(
+            transport
+                .deliver(&request("https://push.example.com/a"))
+                .await
+                .expect("deliver"),
+            201
+        );
+    }
+
+    #[tokio::test]
+    async fn recording_transport_applies_a_scripted_status_by_endpoint() {
+        let transport = RecordingPushTransport::new()
+            .responding_with("https://push.example.com/dead", 410)
+            .responding_with("https://push.example.com/busy", 429);
+
+        for (endpoint, expected) in [
+            ("https://push.example.com/dead", 410),
+            ("https://push.example.com/busy", 429),
+            ("https://push.example.com/other", 201),
+        ] {
+            assert_eq!(
+                transport
+                    .deliver(&request(endpoint))
+                    .await
+                    .expect("deliver"),
+                expected,
+                "{endpoint}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn recording_transport_uses_the_first_matching_script() {
+        // Deterministic precedence: a test that scripts an endpoint twice must
+        // not get whichever entry the iteration order happened to reach.
+        let transport = RecordingPushTransport::new()
+            .responding_with("https://push.example.com/a", 410)
+            .responding_with("https://push.example.com/a", 500);
+        assert_eq!(
+            transport
+                .deliver(&request("https://push.example.com/a"))
+                .await
+                .expect("deliver"),
+            410
+        );
+    }
+
+    #[tokio::test]
+    async fn recording_transport_records_in_dispatch_order_and_shares_across_clones() {
+        let transport = RecordingPushTransport::new();
+        let clone = transport.clone();
+        for endpoint in ["https://push.example.com/1", "https://push.example.com/2"] {
+            clone.deliver(&request(endpoint)).await.expect("deliver");
+        }
+        let recorded = transport.requests();
+        assert_eq!(recorded.len(), 2, "a clone must share the recording");
+        assert_eq!(recorded[0].endpoint, "https://push.example.com/1");
+        assert_eq!(recorded[1].endpoint, "https://push.example.com/2");
+        assert_eq!(recorded[0].body, vec![1, 2, 3]);
+    }
+
+    #[cfg(feature = "http-client")]
+    #[tokio::test]
+    async fn the_http_transport_refuses_an_endpoint_resolving_to_a_blocked_address() {
+        // `localhost` is a hostname, so the subscribe-time IP-literal rule
+        // cannot catch it — this is the layer that must.
+        let err = resolve_and_validate_endpoint("https://localhost/push")
+            .await
+            .expect_err("a loopback-resolving host is refused");
+        assert!(matches!(err, PushError::InvalidEndpoint(_)), "{err:?}");
+        assert!(
+            err.to_string().contains("blocked address"),
+            "the error must say why: {err}"
+        );
+    }
+
+    #[cfg(feature = "http-client")]
+    #[tokio::test]
+    async fn the_http_transport_reports_an_unresolvable_host_as_a_transport_error() {
+        // `.invalid` is reserved by RFC 2606 and never resolves. A DNS failure
+        // is transient, not a reason to prune the subscription, so it must be
+        // a Transport error rather than an InvalidEndpoint one.
+        let err = resolve_and_validate_endpoint("https://nothing.invalid/push")
+            .await
+            .expect_err("an unresolvable host fails");
+        assert!(matches!(err, PushError::Transport(_)), "{err:?}");
+    }
+
+    #[cfg(not(feature = "http-client"))]
+    #[tokio::test]
+    async fn the_unavailable_transport_errors_rather_than_pretending_to_deliver() {
+        let err = UnavailablePushTransport
+            .deliver(&request("https://push.example.com/a"))
+            .await
+            .expect_err("a push that cannot go out must never look like it did");
+        assert!(matches!(err, PushError::Transport(_)), "{err:?}");
     }
 }

--- a/autumn/src/push/transport.rs
+++ b/autumn/src/push/transport.rs
@@ -214,38 +214,57 @@ impl HttpPushTransport {
 impl PushTransport for HttpPushTransport {
     fn deliver<'a>(&'a self, request: &'a PushRequest) -> PushTransportFuture<'a> {
         Box::pin(async move {
-            let pin = resolve_and_validate_endpoint(&request.endpoint).await?;
+            // Every address the host resolves to, all of them already checked
+            // against the SSRF deny-list. Keeping the whole set matters: a
+            // dual-stack push service on a host with no working IPv6 route —
+            // or a CDN whose first answer is momentarily unreachable — would
+            // otherwise fail every push despite the endpoint being perfectly
+            // reachable on another address.
+            let addrs = resolve_and_validate_endpoint(&request.endpoint).await?;
 
-            let mut builder = self
-                .client
-                .post(&request.endpoint)
-                // See the type docs: pin the checked address and refuse to
-                // follow a redirect, so neither DNS rebinding nor a `307` can
-                // steer this POST at an internal host.
-                .pin_to(pin)
-                .no_redirect();
-            for (name, value) in &request.headers {
-                builder = builder.header(name, value);
+            let mut last_error = None;
+            for addr in addrs {
+                let mut builder = self
+                    .client
+                    .post(&request.endpoint)
+                    // See the type docs: pin the checked address and refuse to
+                    // follow a redirect, so neither DNS rebinding nor a `307`
+                    // can steer this POST at an internal host.
+                    .pin_to(addr)
+                    .no_redirect();
+                for (name, value) in &request.headers {
+                    builder = builder.header(name, value);
+                }
+                // A `410 Gone` is a normal, expected answer that must reach
+                // the pruning logic, so a status code is never an error here
+                // — and never a reason to try another address either. Only a
+                // genuine transport failure falls through to the next one.
+                match builder.bytes_body(request.body.clone()).send().await {
+                    Ok(response) => return Ok(response.status().as_u16()),
+                    Err(e) => last_error = Some(e.to_string()),
+                }
             }
-            // A `410 Gone` is a normal, expected answer that must reach the
-            // pruning logic, so status codes are never turned into errors
-            // here — only a genuine transport failure is.
-            match builder.bytes_body(request.body.clone()).send().await {
-                Ok(response) => Ok(response.status().as_u16()),
-                Err(e) => Err(PushError::Transport(e.to_string())),
-            }
+            Err(PushError::Transport(last_error.unwrap_or_else(|| {
+                "the push endpoint host resolved to no usable address".to_owned()
+            })))
         })
     }
 }
 
-/// Resolve `endpoint`'s host and return one address that is safe to connect to.
+/// Resolve `endpoint`'s host and return **every** address that is safe to
+/// connect to, in the resolver's order.
 ///
 /// Every resolved address must pass the outbound client's SSRF deny-list: a
 /// host that resolves to *any* blocked address is refused outright rather than
 /// filtered down to its public addresses, since a resolver returning both is
 /// exactly the shape a rebinding attack produces.
+///
+/// All of them are returned, not just the first, so the caller can fall back
+/// to the next when one is unreachable — see [`HttpPushTransport`].
 #[cfg(feature = "http-client")]
-async fn resolve_and_validate_endpoint(endpoint: &str) -> Result<std::net::SocketAddr, PushError> {
+async fn resolve_and_validate_endpoint(
+    endpoint: &str,
+) -> Result<Vec<std::net::SocketAddr>, PushError> {
     let parsed = url::Url::parse(endpoint)
         .map_err(|e| PushError::InvalidEndpoint(format!("{endpoint}: {e}")))?;
     let host = parsed
@@ -270,9 +289,12 @@ async fn resolve_and_validate_endpoint(endpoint: &str) -> Result<std::net::Socke
             blocked.ip()
         )));
     }
-    addrs.first().copied().ok_or_else(|| {
-        PushError::Transport("the push endpoint host resolved to no addresses".to_owned())
-    })
+    if addrs.is_empty() {
+        return Err(PushError::Transport(
+            "the push endpoint host resolved to no addresses".to_owned(),
+        ));
+    }
+    Ok(addrs)
 }
 
 /// A transport for a build with no HTTP client compiled in.

--- a/autumn/src/push/transport.rs
+++ b/autumn/src/push/transport.rs
@@ -231,7 +231,12 @@ impl PushTransport for HttpPushTransport {
                     // follow a redirect, so neither DNS rebinding nor a `307`
                     // can steer this POST at an internal host.
                     .pin_to(addr)
-                    .no_redirect();
+                    .no_redirect()
+                    // The endpoint host is client-chosen and this transport
+                    // reads only the status. Without this, a registered
+                    // endpoint that streams indefinitely costs one unbounded
+                    // allocation per notification until the timeout fires.
+                    .discard_response_body();
                 for (name, value) in &request.headers {
                     builder = builder.header(name, value);
                 }

--- a/autumn/src/push/transport.rs
+++ b/autumn/src/push/transport.rs
@@ -1,0 +1,215 @@
+//! The seam between the framework's push encoder and the network.
+//!
+//! Everything above this module is deterministic: given a message and a
+//! subscription it produces one fully-formed [`PushRequest`] — endpoint,
+//! headers (including the VAPID `Authorization`), and the RFC 8291-encrypted
+//! body. A [`PushTransport`] is the only thing that touches the network.
+//!
+//! Splitting it out this way is what makes Web Push testable without a browser
+//! or a live push service: [`RecordingPushTransport`] captures every request
+//! and lets a test choose the status each endpoint answers with, so a test can
+//! assert the exact bytes and headers that would have gone out, and drive the
+//! `410 Gone` pruning path deterministically.
+
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::{Arc, Mutex};
+
+use super::PushError;
+
+/// One fully-formed, encrypted push request, ready to be `POST`ed.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PushRequest {
+    /// The push service URL to `POST` to.
+    pub endpoint: String,
+    /// Request headers, with lowercase names.
+    pub headers: Vec<(String, String)>,
+    /// The RFC 8291 `aes128gcm` body.
+    pub body: Vec<u8>,
+}
+
+impl PushRequest {
+    /// The value of `name` (compared case-insensitively), if present.
+    #[must_use]
+    pub fn header(&self, name: &str) -> Option<&str> {
+        self.headers
+            .iter()
+            .find(|(key, _)| key.eq_ignore_ascii_case(name))
+            .map(|(_, value)| value.as_str())
+    }
+}
+
+/// Future returned by [`PushTransport::deliver`], resolving to the push
+/// service's HTTP status code.
+pub type PushTransportFuture<'a> =
+    Pin<Box<dyn Future<Output = Result<u16, PushError>> + Send + 'a>>;
+
+/// Delivers an encrypted push request to a push service.
+///
+/// Implement this to route push traffic through your own HTTP stack, a queue,
+/// or a fake. A transport reports the push service's **status code**; deciding
+/// what a status means (notably that `404`/`410` prune the subscription) is
+/// the framework's job, not the transport's, so every transport behaves
+/// identically. Return [`PushError::Transport`] only when no status was
+/// obtained at all.
+pub trait PushTransport: Send + Sync + 'static {
+    /// Deliver `request`, resolving to the push service's status code.
+    fn deliver<'a>(&'a self, request: &'a PushRequest) -> PushTransportFuture<'a>;
+}
+
+impl<T: PushTransport + ?Sized> PushTransport for Arc<T> {
+    fn deliver<'a>(&'a self, request: &'a PushRequest) -> PushTransportFuture<'a> {
+        (**self).deliver(request)
+    }
+}
+
+// ── Recording transport ─────────────────────────────────────────────────────
+
+/// A [`PushTransport`] that records every request instead of sending it.
+///
+/// Shipped (not test-only) so applications can assert their own push
+/// behaviour the same way the framework asserts its own.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// use autumn_web::push::{PushMessage, RecordingPushTransport};
+///
+/// let transport = RecordingPushTransport::new()
+///     // Drive the stale-subscription path deterministically.
+///     .responding_with("https://push.example.com/dead", 410);
+///
+/// // … build a `WebPush` over `transport.clone()` and send …
+///
+/// let sent = transport.requests();
+/// assert_eq!(sent[0].endpoint, "https://push.example.com/dead");
+/// ```
+///
+/// Cloning shares the recorded requests, so a clone handed to the service
+/// still observes what the original sees.
+#[derive(Debug, Clone)]
+pub struct RecordingPushTransport {
+    requests: Arc<Mutex<Vec<PushRequest>>>,
+    /// Per-endpoint status overrides, in insertion order.
+    statuses: Arc<Mutex<Vec<(String, u16)>>>,
+}
+
+impl Default for RecordingPushTransport {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl RecordingPushTransport {
+    /// A transport that records everything and answers `201 Created` — what a
+    /// push service returns when it has accepted a message.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            requests: Arc::new(Mutex::new(Vec::new())),
+            statuses: Arc::new(Mutex::new(Vec::new())),
+        }
+    }
+
+    /// Answer `status` for requests to `endpoint`.
+    ///
+    /// Chain it to script a specific endpoint's behaviour — most usefully
+    /// `410` (the push service reporting the subscription is gone) so the
+    /// pruning path can be tested without waiting for a real expiry.
+    ///
+    /// # Panics
+    ///
+    /// If another thread panicked while holding this transport's lock.
+    #[must_use]
+    pub fn responding_with(self, endpoint: &str, status: u16) -> Self {
+        self.statuses
+            .lock()
+            .expect("recording transport mutex poisoned")
+            .push((endpoint.to_owned(), status));
+        self
+    }
+
+    /// Every request delivered so far, in dispatch order.
+    ///
+    /// # Panics
+    ///
+    /// If another thread panicked while holding this transport's lock.
+    #[must_use]
+    pub fn requests(&self) -> Vec<PushRequest> {
+        self.requests
+            .lock()
+            .expect("recording transport mutex poisoned")
+            .clone()
+    }
+}
+
+impl PushTransport for RecordingPushTransport {
+    fn deliver<'a>(&'a self, request: &'a PushRequest) -> PushTransportFuture<'a> {
+        Box::pin(async move {
+            self.requests
+                .lock()
+                .expect("recording transport mutex poisoned")
+                .push(request.clone());
+            let status = self
+                .statuses
+                .lock()
+                .expect("recording transport mutex poisoned")
+                .iter()
+                .find(|(endpoint, _)| *endpoint == request.endpoint)
+                .map_or(201, |(_, status)| *status);
+            Ok(status)
+        })
+    }
+}
+
+// ── HTTP transport ──────────────────────────────────────────────────────────
+
+/// The default [`PushTransport`]: a real `POST` to the push service.
+///
+/// Uses the framework's outbound [`Client`](crate::http_client::Client), so
+/// push traffic inherits its tracing context propagation, timeouts, and — the
+/// reason it matters here — its SSRF address policy. The subscribe boundary
+/// already refuses IP-literal and loopback endpoints
+/// ([`BrowserSubscription::decode`](super::store::BrowserSubscription::decode));
+/// this covers the remaining case of a *hostname* that resolves to a private
+/// address.
+#[cfg(feature = "http-client")]
+#[derive(Clone)]
+pub struct HttpPushTransport {
+    client: crate::http_client::Client,
+}
+
+#[cfg(feature = "http-client")]
+impl std::fmt::Debug for HttpPushTransport {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("HttpPushTransport").finish_non_exhaustive()
+    }
+}
+
+#[cfg(feature = "http-client")]
+impl HttpPushTransport {
+    /// Build a transport over an existing outbound client.
+    #[must_use]
+    pub const fn new(client: crate::http_client::Client) -> Self {
+        Self { client }
+    }
+}
+
+#[cfg(feature = "http-client")]
+impl PushTransport for HttpPushTransport {
+    fn deliver<'a>(&'a self, request: &'a PushRequest) -> PushTransportFuture<'a> {
+        Box::pin(async move {
+            let mut builder = self.client.post(&request.endpoint);
+            for (name, value) in &request.headers {
+                builder = builder.header(name, value);
+            }
+            // A `410 Gone` is a normal, expected answer that must reach the
+            // pruning logic, so status codes are never turned into errors
+            // here — only a genuine transport failure is.
+            match builder.bytes_body(request.body.clone()).send().await {
+                Ok(response) => Ok(response.status().as_u16()),
+                Err(e) => Err(PushError::Transport(e.to_string())),
+            }
+        })
+    }
+}

--- a/autumn/src/push/vapid.rs
+++ b/autumn/src/push/vapid.rs
@@ -177,10 +177,10 @@ pub(crate) fn audience_for(endpoint: &str) -> Result<String, PushError> {
     let scheme = parsed.scheme();
     // `Url::port` is `None` for the scheme's default port, which is exactly
     // the origin form the push services expect (no `:443` on https).
-    match parsed.port() {
-        Some(port) => Ok(format!("{scheme}://{host}:{port}")),
-        None => Ok(format!("{scheme}://{host}")),
-    }
+    Ok(parsed.port().map_or_else(
+        || format!("{scheme}://{host}"),
+        |port| format!("{scheme}://{host}:{port}"),
+    ))
 }
 
 /// Decode base64url with or without padding (browsers emit both).
@@ -201,7 +201,10 @@ fn escape_json(value: &str) -> String {
             '\n' => out.push_str("\\n"),
             '\r' => out.push_str("\\r"),
             '\t' => out.push_str("\\t"),
-            c if (c as u32) < 0x20 => out.push_str(&format!("\\u{:04x}", c as u32)),
+            c if (c as u32) < 0x20 => {
+                use std::fmt::Write as _;
+                write!(out, "\\u{:04x}", c as u32).expect("writing to a String cannot fail");
+            }
             c => out.push(c),
         }
     }
@@ -219,7 +222,9 @@ mod tests {
         (
             URL_SAFE_NO_PAD.decode(parts[0]).expect("header base64url"),
             URL_SAFE_NO_PAD.decode(parts[1]).expect("claims base64url"),
-            URL_SAFE_NO_PAD.decode(parts[2]).expect("signature base64url"),
+            URL_SAFE_NO_PAD
+                .decode(parts[2])
+                .expect("signature base64url"),
         )
     }
 
@@ -258,11 +263,11 @@ mod tests {
         // `atob`-based snippets and `applicationServerKey` conversion break on
         // `=` padding.
         let encoded = key.public_key_base64url();
-        assert!(!encoded.contains('='), "public key must be unpadded: {encoded}");
-        assert_eq!(
-            URL_SAFE_NO_PAD.decode(&encoded).expect("decodes").len(),
-            65
+        assert!(
+            !encoded.contains('='),
+            "public key must be unpadded: {encoded}"
         );
+        assert_eq!(URL_SAFE_NO_PAD.decode(&encoded).expect("decodes").len(), 65);
     }
 
     #[test]
@@ -416,9 +421,12 @@ mod tests {
             .expect("header");
         let jwt = jwt_from_header(&header);
         let (signing_input, signature_b64) = jwt.rsplit_once('.').expect("compact JWS");
-        let signature =
-            Signature::from_slice(&URL_SAFE_NO_PAD.decode(signature_b64).expect("sig base64url"))
-                .expect("64-byte r‖s parses as a P-256 signature");
+        let signature = Signature::from_slice(
+            &URL_SAFE_NO_PAD
+                .decode(signature_b64)
+                .expect("sig base64url"),
+        )
+        .expect("64-byte r‖s parses as a P-256 signature");
 
         // Verify with a key reconstructed from the PUBLIC bytes we hand the
         // browser — the same path the push service takes.

--- a/autumn/src/push/vapid.rs
+++ b/autumn/src/push/vapid.rs
@@ -1,0 +1,464 @@
+//! VAPID — Voluntary Application Server Identification for Web Push (RFC 8292).
+//!
+//! A VAPID key pair is a NIST P-256 (prime256v1) ECDSA key. The **public**
+//! half, serialized uncompressed (SEC1, 65 bytes) and base64url-encoded
+//! without padding, is the `applicationServerKey` a browser passes to
+//! `pushManager.subscribe()`. The **private** half signs a short-lived
+//! ES256 JWT that the push service validates before accepting a message,
+//! proving the sender is the same application server the user subscribed to.
+
+use std::fmt;
+
+use base64::Engine as _;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use p256::ecdsa::{Signature, SigningKey, signature::Signer};
+
+use super::PushError;
+
+/// How long a minted VAPID JWT stays valid.
+///
+/// RFC 8292 §2 caps `exp` at 24 hours from issue; 12 hours leaves generous
+/// room for clock skew on both ends while staying well inside that ceiling.
+pub(crate) const VAPID_TOKEN_TTL_SECS: u64 = 12 * 60 * 60;
+
+/// Length of an uncompressed SEC1 P-256 public key: `0x04 || X(32) || Y(32)`.
+pub(crate) const P256_UNCOMPRESSED_LEN: usize = 65;
+
+/// Length of a P-256 private scalar.
+const P256_SCALAR_LEN: usize = 32;
+
+/// An application-server (VAPID) key pair.
+///
+/// Mint one with [`VapidKey::generate`], persist the value returned by
+/// [`private_key_base64url`](Self::private_key_base64url), and load it back
+/// with [`VapidKey::from_base64url`].
+///
+/// # Example
+///
+/// ```rust,ignore
+/// use autumn_web::push::VapidKey;
+///
+/// // One-time, offline: mint and record the private half.
+/// let key = VapidKey::generate();
+/// println!("private: {}", key.private_key_base64url());
+/// println!("public:  {}", key.public_key_base64url());
+///
+/// // At boot: load it back from configuration.
+/// let key = VapidKey::from_base64url("…")?;
+/// # Ok::<(), autumn_web::push::PushError>(())
+/// ```
+#[derive(Clone)]
+pub struct VapidKey {
+    signing: SigningKey,
+}
+
+impl VapidKey {
+    /// Mint a fresh random key pair.
+    #[must_use]
+    pub fn generate() -> Self {
+        Self {
+            signing: SigningKey::random(&mut p256::elliptic_curve::rand_core::OsRng),
+        }
+    }
+
+    /// Load a key pair from a base64url-encoded (padded or unpadded) 32-byte
+    /// P-256 private scalar — the conventional VAPID private-key format.
+    ///
+    /// # Errors
+    ///
+    /// [`PushError::InvalidVapidKey`] when the value is not base64url, is not
+    /// exactly 32 bytes, or is not a valid P-256 scalar.
+    pub fn from_base64url(encoded: &str) -> Result<Self, PushError> {
+        let bytes = decode_base64url(encoded.trim())
+            .ok_or_else(|| PushError::InvalidVapidKey("not valid base64url".to_owned()))?;
+        if bytes.len() != P256_SCALAR_LEN {
+            return Err(PushError::InvalidVapidKey(format!(
+                "expected a {P256_SCALAR_LEN}-byte P-256 private scalar, got {} bytes",
+                bytes.len()
+            )));
+        }
+        let signing = SigningKey::from_slice(&bytes).map_err(|_| {
+            PushError::InvalidVapidKey(
+                "not a valid P-256 private scalar (zero or >= curve order)".to_owned(),
+            )
+        })?;
+        Ok(Self { signing })
+    }
+
+    /// The private scalar, base64url-encoded without padding. **Secret** —
+    /// store it the way you store any other credential.
+    #[must_use]
+    pub fn private_key_base64url(&self) -> String {
+        URL_SAFE_NO_PAD.encode(self.signing.to_bytes())
+    }
+
+    /// The uncompressed public key, base64url-encoded without padding. This
+    /// is the `applicationServerKey` value the browser needs; it is public
+    /// and safe to serve to any client.
+    #[must_use]
+    pub fn public_key_base64url(&self) -> String {
+        URL_SAFE_NO_PAD.encode(self.public_key_bytes())
+    }
+
+    /// The uncompressed (SEC1, 65-byte) public key.
+    #[must_use]
+    pub fn public_key_bytes(&self) -> [u8; P256_UNCOMPRESSED_LEN] {
+        let encoded = self.signing.verifying_key().to_encoded_point(false);
+        let mut out = [0_u8; P256_UNCOMPRESSED_LEN];
+        out.copy_from_slice(encoded.as_bytes());
+        out
+    }
+
+    /// Mint the `Authorization` header value for a message sent to
+    /// `endpoint`, valid from `issued_at_unix`.
+    ///
+    /// The header follows RFC 8292 §3.1's single-header form:
+    /// `vapid t=<jwt>, k=<base64url public key>`.
+    ///
+    /// # Errors
+    ///
+    /// [`PushError::InvalidEndpoint`] when `endpoint` has no derivable
+    /// origin (missing scheme or host).
+    pub fn authorization_header(
+        &self,
+        endpoint: &str,
+        subject: &str,
+        issued_at_unix: u64,
+    ) -> Result<String, PushError> {
+        let jwt = self.sign_jwt(&audience_for(endpoint)?, subject, issued_at_unix);
+        Ok(format!("vapid t={jwt}, k={}", self.public_key_base64url()))
+    }
+
+    /// Sign a VAPID JWT (ES256) for `audience`.
+    fn sign_jwt(&self, audience: &str, subject: &str, issued_at_unix: u64) -> String {
+        // Fixed header — the only algorithm RFC 8292 permits.
+        let header = URL_SAFE_NO_PAD.encode(br#"{"typ":"JWT","alg":"ES256"}"#);
+        let exp = issued_at_unix.saturating_add(VAPID_TOKEN_TTL_SECS);
+        // Hand-rolled rather than `serde_json` so the claim ORDER is fixed and
+        // the signing input is byte-reproducible across serde versions — the
+        // unit tests below verify the exact signing input.
+        let claims = format!(
+            r#"{{"aud":"{}","exp":{exp},"sub":"{}"}}"#,
+            escape_json(audience),
+            escape_json(subject),
+        );
+        let claims = URL_SAFE_NO_PAD.encode(claims);
+        let signing_input = format!("{header}.{claims}");
+        let signature: Signature = self.signing.sign(signing_input.as_bytes());
+        // JWS ES256 signatures are the raw fixed-width r‖s pair (64 bytes),
+        // NOT the ASN.1 DER encoding `Signature::to_der` would produce.
+        let signature = URL_SAFE_NO_PAD.encode(signature.to_bytes());
+        format!("{signing_input}.{signature}")
+    }
+}
+
+impl fmt::Debug for VapidKey {
+    /// Never prints the private scalar: a `VapidKey` ends up inside the push
+    /// service, which is itself `Debug`-printed by handler-error paths.
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("VapidKey")
+            .field("public_key", &self.public_key_base64url())
+            .field("private_key", &"<redacted>")
+            .finish()
+    }
+}
+
+/// The JWT `aud` claim for `endpoint`: its origin (`scheme://host[:port]`).
+///
+/// # Errors
+///
+/// [`PushError::InvalidEndpoint`] when the URL cannot be parsed or has no host.
+pub(crate) fn audience_for(endpoint: &str) -> Result<String, PushError> {
+    let parsed = url::Url::parse(endpoint)
+        .map_err(|e| PushError::InvalidEndpoint(format!("{endpoint}: {e}")))?;
+    let host = parsed
+        .host_str()
+        .ok_or_else(|| PushError::InvalidEndpoint(format!("{endpoint}: no host")))?;
+    let scheme = parsed.scheme();
+    // `Url::port` is `None` for the scheme's default port, which is exactly
+    // the origin form the push services expect (no `:443` on https).
+    match parsed.port() {
+        Some(port) => Ok(format!("{scheme}://{host}:{port}")),
+        None => Ok(format!("{scheme}://{host}")),
+    }
+}
+
+/// Decode base64url with or without padding (browsers emit both).
+pub(crate) fn decode_base64url(value: &str) -> Option<Vec<u8>> {
+    URL_SAFE_NO_PAD.decode(value).map_or_else(
+        |_| base64::engine::general_purpose::URL_SAFE.decode(value).ok(),
+        Some,
+    )
+}
+
+/// Minimal JSON string escaping for the two claim values we interpolate.
+fn escape_json(value: &str) -> String {
+    let mut out = String::with_capacity(value.len());
+    for ch in value.chars() {
+        match ch {
+            '"' => out.push_str("\\\""),
+            '\\' => out.push_str("\\\\"),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            c if (c as u32) < 0x20 => out.push_str(&format!("\\u{:04x}", c as u32)),
+            c => out.push(c),
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Split a compact JWS into its three base64url parts.
+    fn jwt_parts(jwt: &str) -> (Vec<u8>, Vec<u8>, Vec<u8>) {
+        let parts: Vec<&str> = jwt.split('.').collect();
+        assert_eq!(parts.len(), 3, "a JWS has exactly three parts: {jwt}");
+        (
+            URL_SAFE_NO_PAD.decode(parts[0]).expect("header base64url"),
+            URL_SAFE_NO_PAD.decode(parts[1]).expect("claims base64url"),
+            URL_SAFE_NO_PAD.decode(parts[2]).expect("signature base64url"),
+        )
+    }
+
+    fn jwt_from_header(header: &str) -> String {
+        let rest = header
+            .strip_prefix("vapid t=")
+            .expect("header starts with `vapid t=`");
+        rest.split_once(", k=")
+            .expect("header carries a `, k=` public key")
+            .0
+            .to_owned()
+    }
+
+    #[test]
+    fn generate_round_trips_through_base64url() {
+        let key = VapidKey::generate();
+        let reloaded =
+            VapidKey::from_base64url(&key.private_key_base64url()).expect("reload the private key");
+        assert_eq!(
+            reloaded.public_key_base64url(),
+            key.public_key_base64url(),
+            "a reloaded key must derive the same public half"
+        );
+    }
+
+    #[test]
+    fn public_key_is_65_uncompressed_bytes() {
+        let key = VapidKey::generate();
+        let bytes = key.public_key_bytes();
+        assert_eq!(bytes.len(), 65);
+        assert_eq!(
+            bytes[0], 0x04,
+            "the browser's applicationServerKey must be UNCOMPRESSED SEC1 (0x04 prefix)"
+        );
+        // The base64url form the client actually receives must be unpadded:
+        // `atob`-based snippets and `applicationServerKey` conversion break on
+        // `=` padding.
+        let encoded = key.public_key_base64url();
+        assert!(!encoded.contains('='), "public key must be unpadded: {encoded}");
+        assert_eq!(
+            URL_SAFE_NO_PAD.decode(&encoded).expect("decodes").len(),
+            65
+        );
+    }
+
+    #[test]
+    fn from_base64url_accepts_padded_input() {
+        let key = VapidKey::generate();
+        let padded = base64::engine::general_purpose::URL_SAFE.encode(
+            URL_SAFE_NO_PAD
+                .decode(key.private_key_base64url())
+                .expect("decode"),
+        );
+        let reloaded = VapidKey::from_base64url(&padded).expect("padded base64url is accepted");
+        assert_eq!(reloaded.public_key_base64url(), key.public_key_base64url());
+    }
+
+    #[test]
+    fn from_base64url_rejects_garbage_with_a_clear_error() {
+        let err = VapidKey::from_base64url("not base64!!!").expect_err("garbage is rejected");
+        assert!(
+            matches!(err, PushError::InvalidVapidKey(_)),
+            "expected InvalidVapidKey, got {err:?}"
+        );
+        assert!(
+            err.to_string().contains("base64url"),
+            "the error must say what is wrong: {err}"
+        );
+    }
+
+    #[test]
+    fn from_base64url_rejects_a_wrong_length_key() {
+        let short = URL_SAFE_NO_PAD.encode([1_u8; 16]);
+        let err = VapidKey::from_base64url(&short).expect_err("16 bytes is not a P-256 scalar");
+        assert!(
+            err.to_string().contains("32-byte"),
+            "the error must name the expected length: {err}"
+        );
+    }
+
+    #[test]
+    fn from_base64url_rejects_an_all_zero_scalar() {
+        // Zero is a syntactically well-formed 32 bytes but not a valid P-256
+        // private key — a length check alone would let it through and produce
+        // signatures no push service accepts.
+        let zero = URL_SAFE_NO_PAD.encode([0_u8; 32]);
+        let err = VapidKey::from_base64url(&zero).expect_err("the zero scalar is rejected");
+        assert!(matches!(err, PushError::InvalidVapidKey(_)), "{err:?}");
+    }
+
+    #[test]
+    fn audience_is_the_endpoint_origin() {
+        assert_eq!(
+            audience_for("https://fcm.googleapis.com/fcm/send/abc123").expect("origin"),
+            "https://fcm.googleapis.com",
+            "the aud claim is the ORIGIN, never the full endpoint path"
+        );
+    }
+
+    #[test]
+    fn audience_keeps_a_non_default_port_and_drops_the_default_one() {
+        assert_eq!(
+            audience_for("https://push.example.com:8443/x").expect("origin"),
+            "https://push.example.com:8443"
+        );
+        assert_eq!(
+            audience_for("https://push.example.com:443/x").expect("origin"),
+            "https://push.example.com",
+            "the default port must not appear in aud — push services compare it literally"
+        );
+    }
+
+    #[test]
+    fn audience_rejects_a_hostless_url() {
+        let err = audience_for("not a url").expect_err("garbage endpoint is rejected");
+        assert!(matches!(err, PushError::InvalidEndpoint(_)), "{err:?}");
+    }
+
+    #[test]
+    fn authorization_header_carries_the_public_key_and_a_jwt() {
+        let key = VapidKey::generate();
+        let header = key
+            .authorization_header(
+                "https://fcm.googleapis.com/fcm/send/abc",
+                "mailto:ops@example.com",
+                1_700_000_000,
+            )
+            .expect("header");
+        assert!(header.starts_with("vapid t="), "{header}");
+        assert!(
+            header.contains(&format!(", k={}", key.public_key_base64url())),
+            "the `k=` parameter must be the application server's public key: {header}"
+        );
+    }
+
+    #[test]
+    fn jwt_header_declares_es256() {
+        let key = VapidKey::generate();
+        let header = key
+            .authorization_header("https://push.example.com/x", "mailto:a@b.c", 1_700_000_000)
+            .expect("header");
+        let (jose, _, _) = jwt_parts(&jwt_from_header(&header));
+        let jose: serde_json::Value = serde_json::from_slice(&jose).expect("JOSE header is JSON");
+        assert_eq!(jose["alg"], "ES256", "RFC 8292 permits only ES256");
+        assert_eq!(jose["typ"], "JWT");
+    }
+
+    #[test]
+    fn jwt_claims_carry_aud_sub_and_a_bounded_exp() {
+        let key = VapidKey::generate();
+        let issued_at = 1_700_000_000_u64;
+        let header = key
+            .authorization_header(
+                "https://push.example.com:8443/send/x",
+                "mailto:ops@example.com",
+                issued_at,
+            )
+            .expect("header");
+        let (_, claims, _) = jwt_parts(&jwt_from_header(&header));
+        let claims: serde_json::Value = serde_json::from_slice(&claims).expect("claims are JSON");
+        assert_eq!(claims["aud"], "https://push.example.com:8443");
+        assert_eq!(claims["sub"], "mailto:ops@example.com");
+        let exp = claims["exp"].as_u64().expect("exp is a number");
+        assert!(exp > issued_at, "exp must be in the future");
+        assert!(
+            exp - issued_at <= 24 * 60 * 60,
+            "RFC 8292 caps exp at 24h from issue; got {}s",
+            exp - issued_at
+        );
+    }
+
+    #[test]
+    fn jwt_signature_is_a_raw_64_byte_r_s_pair() {
+        let key = VapidKey::generate();
+        let header = key
+            .authorization_header("https://push.example.com/x", "mailto:a@b.c", 1_700_000_000)
+            .expect("header");
+        let (_, _, signature) = jwt_parts(&jwt_from_header(&header));
+        assert_eq!(
+            signature.len(),
+            64,
+            "JWS ES256 uses the fixed-width r‖s pair, not ASN.1 DER (which is ~70-72 bytes)"
+        );
+    }
+
+    #[test]
+    fn jwt_signature_verifies_against_the_public_key() {
+        use p256::ecdsa::VerifyingKey;
+        use p256::ecdsa::signature::Verifier;
+
+        let key = VapidKey::generate();
+        let header = key
+            .authorization_header("https://push.example.com/x", "mailto:a@b.c", 1_700_000_000)
+            .expect("header");
+        let jwt = jwt_from_header(&header);
+        let (signing_input, signature_b64) = jwt.rsplit_once('.').expect("compact JWS");
+        let signature =
+            Signature::from_slice(&URL_SAFE_NO_PAD.decode(signature_b64).expect("sig base64url"))
+                .expect("64-byte r‖s parses as a P-256 signature");
+
+        // Verify with a key reconstructed from the PUBLIC bytes we hand the
+        // browser — the same path the push service takes.
+        let verifying = VerifyingKey::from_sec1_bytes(&key.public_key_bytes())
+            .expect("public bytes parse as a P-256 point");
+        verifying
+            .verify(signing_input.as_bytes(), &signature)
+            .expect("the push service must be able to verify this signature");
+    }
+
+    #[test]
+    fn subject_with_a_quote_cannot_break_out_of_the_claims_json() {
+        // A `sub` read from configuration must never be able to inject claims.
+        let key = VapidKey::generate();
+        let header = key
+            .authorization_header(
+                "https://push.example.com/x",
+                r#"mailto:a@b.c","exp":9999999999,"x":"#,
+                1_700_000_000,
+            )
+            .expect("header");
+        let (_, claims, _) = jwt_parts(&jwt_from_header(&header));
+        let claims: serde_json::Value =
+            serde_json::from_slice(&claims).expect("claims stay valid JSON");
+        assert_eq!(
+            claims["exp"].as_u64().expect("exp"),
+            1_700_000_000 + VAPID_TOKEN_TTL_SECS,
+            "an injected exp must not win over the computed one"
+        );
+        assert!(claims.get("x").is_none(), "no injected claim may appear");
+    }
+
+    #[test]
+    fn debug_never_prints_the_private_scalar() {
+        let key = VapidKey::generate();
+        let rendered = format!("{key:?}");
+        assert!(
+            !rendered.contains(&key.private_key_base64url()),
+            "Debug must redact the private key: {rendered}"
+        );
+        assert!(rendered.contains("<redacted>"), "{rendered}");
+    }
+}

--- a/autumn/src/test.rs
+++ b/autumn/src/test.rs
@@ -1199,6 +1199,33 @@ impl TestApp {
         self
     }
 
+    /// Mirrors
+    /// [`crate::app::AppBuilder::with_push_subscription_store`].
+    #[must_use]
+    pub fn with_push_subscription_store<S>(mut self, store: S) -> Self
+    where
+        S: crate::push::PushSubscriptionStore,
+    {
+        self.state_initializers.push(Box::new(move |state| {
+            state.insert_extension(crate::push::WebPush::from_state_with_store(state, store));
+        }));
+        self
+    }
+
+    /// Register an explicit [`WebPush`](crate::push::WebPush) service,
+    /// overriding key, store and transport at once.
+    ///
+    /// The usual reason is a
+    /// [`RecordingPushTransport`](crate::push::RecordingPushTransport), so a
+    /// test can assert exactly what would have gone to the push service.
+    #[must_use]
+    pub fn with_web_push(mut self, push: crate::push::WebPush) -> Self {
+        self.state_initializers.push(Box::new(move |state| {
+            state.insert_extension(push);
+        }));
+        self
+    }
+
     /// Apply a plugin directly to the test app.
     #[must_use]
     pub fn plugin<P: crate::plugin::Plugin>(mut self, plugin: P) -> Self {

--- a/autumn/tests/fixtures/schema_keys.snapshot
+++ b/autumn/tests/fixtures/schema_keys.snapshot
@@ -230,6 +230,11 @@ observability.server_timing
 openapi
 openapi.enabled
 openapi.path
+push
+push.private_key
+push.public_key
+push.subject
+push.ttl_secs
 reporting
 reporting.enabled
 reporting.sample_rate

--- a/autumn/tests/integration/mod.rs
+++ b/autumn/tests/integration/mod.rs
@@ -204,6 +204,8 @@ mod preload_scoping;
 mod problem_details;
 #[cfg(feature = "redis")]
 mod process_role_worker_gating;
+mod push_end_to_end;
+mod push_router;
 mod query_count_asserts;
 mod query_structured;
 #[cfg(feature = "redis")]

--- a/autumn/tests/integration/push_end_to_end.rs
+++ b/autumn/tests/integration/push_end_to_end.rs
@@ -1,0 +1,574 @@
+//! End-to-end Web Push (issue #1392): a browser subscribes over HTTP, the app
+//! sends, and the exact bytes that would reach the push service are asserted —
+//! then a `410 Gone` prunes the dead subscription.
+//!
+//! Everything here goes through the real, mounted routes and the real crypto.
+//! The only substitution is the transport, which records requests instead of
+//! putting them on the network; that is what makes it possible to assert the
+//! VAPID `Authorization` header and the encrypted body at all.
+
+use autumn_web::push::{
+    MemoryPushSubscriptionStore, PushMessage, RecordingPushTransport, VapidKey, WebPush,
+};
+use autumn_web::test::TestApp;
+use base64::Engine as _;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use serde_json::json;
+
+/// The RFC 8291 §5 user agent — its private key lets this test decrypt what
+/// the framework produced, proving a real browser could read it.
+const UA_PRIVATE: &str = "q1dXpw3UpT5VOmu_cf_v6ih07Aems3njxI-JWgLcM94";
+const UA_PUBLIC: &str =
+    "BCVxsr7N_eNgVRqvHtD0zTZsEc6-VV-JvLexhqUzORcxaOzi6-AYWXvTBHm4bjyPjs7Vd8pZGH6SRpkNtoIAiw4";
+const UA_AUTH: &str = "BTBZMqHH6r4Tts7J_aSIgg";
+
+const DEAD_ENDPOINT: &str = "https://push.example.com/dead";
+const LIVE_ENDPOINT: &str = "https://push.example.com/live";
+
+fn subscription_json(endpoint: &str) -> serde_json::Value {
+    json!({
+        "endpoint": endpoint,
+        "expirationTime": serde_json::Value::Null,
+        "keys": { "p256dh": UA_PUBLIC, "auth": UA_AUTH },
+    })
+}
+
+/// Decrypt an `aes128gcm` body the way the receiving browser does.
+///
+/// Deliberately written out longhand rather than reusing any framework code:
+/// if the two ever disagree, this fails.
+fn decrypt_as_the_browser_would(body: &[u8]) -> Vec<u8> {
+    use aes_gcm::aead::{Aead, KeyInit, Payload};
+    use aes_gcm::{Aes128Gcm, Key, Nonce};
+    use hmac::{Hmac, Mac};
+    use p256::elliptic_curve::sec1::ToEncodedPoint;
+    use sha2::Sha256;
+
+    fn hkdf(salt: &[u8], ikm: &[u8], info: &[u8], len: usize) -> Vec<u8> {
+        type H = Hmac<Sha256>;
+        let mut extract = <H as Mac>::new_from_slice(salt).expect("any key length");
+        extract.update(ikm);
+        let prk = extract.finalize().into_bytes();
+        let mut expand = <H as Mac>::new_from_slice(&prk).expect("any key length");
+        expand.update(info);
+        expand.update(&[1_u8]);
+        let mut okm = expand.finalize().into_bytes().to_vec();
+        okm.truncate(len);
+        okm
+    }
+
+    let salt = &body[..16];
+    let id_len = body[20] as usize;
+    let as_public = &body[21..21 + id_len];
+    let ciphertext = &body[21 + id_len..];
+
+    let ua_private =
+        p256::SecretKey::from_slice(&URL_SAFE_NO_PAD.decode(UA_PRIVATE).expect("ua private key"))
+            .expect("parses");
+    let as_key = p256::PublicKey::from_sec1_bytes(as_public).expect("as public key parses");
+    let shared = p256::ecdh::diffie_hellman(ua_private.to_nonzero_scalar(), as_key.as_affine());
+
+    let ua_public_point = ua_private.public_key().to_encoded_point(false);
+    let mut key_info = Vec::new();
+    key_info.extend_from_slice(b"WebPush: info\0");
+    key_info.extend_from_slice(ua_public_point.as_bytes());
+    key_info.extend_from_slice(as_public);
+
+    let auth = URL_SAFE_NO_PAD.decode(UA_AUTH).expect("auth");
+    let ikm = hkdf(&auth, shared.raw_secret_bytes(), &key_info, 32);
+    let cek = hkdf(salt, &ikm, b"Content-Encoding: aes128gcm\0", 16);
+    let nonce = hkdf(salt, &ikm, b"Content-Encoding: nonce\0", 12);
+
+    let mut plaintext = Aes128Gcm::new(Key::<Aes128Gcm>::from_slice(&cek))
+        .decrypt(
+            Nonce::from_slice(&nonce),
+            Payload {
+                msg: ciphertext,
+                aad: b"",
+            },
+        )
+        .expect("the browser must be able to decrypt what the framework sent");
+    assert_eq!(
+        plaintext.pop(),
+        Some(0x02),
+        "the last record carries the RFC 8188 delimiter"
+    );
+    plaintext
+}
+
+/// Verify a `vapid t=…, k=…` header the way a push service does, and return
+/// the JWT's claims.
+fn verify_vapid_header(header: &str, expected_key: &VapidKey) -> serde_json::Value {
+    use p256::ecdsa::VerifyingKey;
+    use p256::ecdsa::signature::Verifier;
+
+    let (jwt, declared_key) = header
+        .strip_prefix("vapid t=")
+        .expect("RFC 8292 §3.1 single-header form")
+        .split_once(", k=")
+        .expect("`vapid t=…, k=…`");
+    assert_eq!(
+        declared_key,
+        expected_key.public_key_base64url(),
+        "`k=` must be the application server key the browser subscribed with"
+    );
+
+    let (signing_input, signature) = jwt.rsplit_once('.').expect("compact JWS");
+    let signature = p256::ecdsa::Signature::from_slice(
+        &URL_SAFE_NO_PAD
+            .decode(signature)
+            .expect("signature base64url"),
+    )
+    .expect("64-byte r‖s parses");
+    VerifyingKey::from_sec1_bytes(&expected_key.public_key_bytes())
+        .expect("public key parses")
+        .verify(signing_input.as_bytes(), &signature)
+        .expect("the push service must be able to verify this signature");
+
+    let claims = URL_SAFE_NO_PAD
+        .decode(signing_input.split('.').nth(1).expect("claims segment"))
+        .expect("claims base64url");
+    serde_json::from_slice(&claims).expect("claims are JSON")
+}
+
+/// The whole loop: subscribe over HTTP, send, and assert exactly what would
+/// have gone to the push service.
+#[tokio::test]
+async fn subscribe_over_http_then_send_dispatches_a_signed_encrypted_request() {
+    let transport = RecordingPushTransport::new();
+    let vapid = VapidKey::generate();
+    let push = WebPush::new(
+        MemoryPushSubscriptionStore::new(),
+        vapid.clone(),
+        "mailto:ops@example.com",
+        transport.clone(),
+    );
+
+    let client = TestApp::new()
+        .merge(autumn_web::push::router())
+        .with_web_push(push.clone())
+        .build();
+    client.acting_as(7).await;
+
+    // ── Write path: the browser records its subscription ────────────────────
+    client
+        .post("/push/subscribe")
+        .json(&subscription_json(LIVE_ENDPOINT))
+        .send()
+        .await
+        .assert_status(204);
+
+    // ── Read path: the app sends to that principal ──────────────────────────
+    let report = push
+        .send(
+            7_i64,
+            &PushMessage::new("Build failed", "main is red").url("/builds/42"),
+        )
+        .await
+        .expect("send");
+    assert_eq!(report.delivered, 1);
+    assert!(report.pruned.is_empty());
+
+    // ── Assert the dispatched request ───────────────────────────────────────
+    let requests = transport.requests();
+    assert_eq!(requests.len(), 1, "exactly one device is subscribed");
+    let request = &requests[0];
+
+    assert_eq!(
+        request.endpoint, LIVE_ENDPOINT,
+        "the message must go to the endpoint the browser recorded"
+    );
+
+    let claims = verify_vapid_header(
+        request
+            .header("authorization")
+            .expect("a VAPID Authorization header"),
+        &vapid,
+    );
+    assert_eq!(
+        claims["aud"], "https://push.example.com",
+        "aud must be the endpoint's origin"
+    );
+    assert_eq!(claims["sub"], "mailto:ops@example.com");
+
+    assert_eq!(request.header("content-encoding"), Some("aes128gcm"));
+    assert_eq!(
+        request.header("content-type"),
+        Some("application/octet-stream")
+    );
+    assert!(
+        request.header("ttl").is_some(),
+        "RFC 8030 §5.2 requires TTL"
+    );
+
+    // The body is genuinely encrypted for this subscription…
+    assert!(
+        !request
+            .body
+            .windows(b"Build failed".len())
+            .any(|window| window == b"Build failed"),
+        "the plaintext must never appear in the dispatched body"
+    );
+    // …and decrypts, in the browser, to what was sent.
+    let message: serde_json::Value =
+        serde_json::from_slice(&decrypt_as_the_browser_would(&request.body))
+            .expect("the decrypted payload is the JSON the service worker reads");
+    assert_eq!(message["title"], "Build failed");
+    assert_eq!(message["body"], "main is red");
+    assert_eq!(message["url"], "/builds/42");
+}
+
+/// A push service reporting `410 Gone` must remove the subscription — and the
+/// next send must not dispatch to it again.
+#[tokio::test]
+async fn a_stale_endpoint_is_pruned_and_never_re_sent_to() {
+    let transport = RecordingPushTransport::new().responding_with(DEAD_ENDPOINT, 410);
+    let vapid = VapidKey::generate();
+    let push = WebPush::new(
+        MemoryPushSubscriptionStore::new(),
+        vapid,
+        "mailto:ops@example.com",
+        transport.clone(),
+    );
+
+    let client = TestApp::new()
+        .merge(autumn_web::push::router())
+        .with_web_push(push.clone())
+        .build();
+    client.acting_as(7).await;
+
+    for endpoint in [DEAD_ENDPOINT, LIVE_ENDPOINT] {
+        client
+            .post("/push/subscribe")
+            .json(&subscription_json(endpoint))
+            .send()
+            .await
+            .assert_status(204);
+    }
+
+    let first = push
+        .send(7_i64, &PushMessage::new("Hi", "There"))
+        .await
+        .expect("send");
+    assert_eq!(
+        first.delivered, 1,
+        "the live device still receives even though the other is dead"
+    );
+    assert_eq!(first.pruned, vec![DEAD_ENDPOINT.to_owned()]);
+
+    let second = push
+        .send(7_i64, &PushMessage::new("Hi", "again"))
+        .await
+        .expect("send");
+    assert_eq!(second.delivered, 1);
+    assert!(
+        second.pruned.is_empty(),
+        "the dead endpoint is already gone"
+    );
+
+    let dispatched_to_dead = transport
+        .requests()
+        .iter()
+        .filter(|r| r.endpoint == DEAD_ENDPOINT)
+        .count();
+    assert_eq!(
+        dispatched_to_dead, 1,
+        "a pruned endpoint must never be re-sent to — that is the whole point"
+    );
+}
+
+/// The composition documented for #1148: the in-app notification is the
+/// durable record and is awaited; the push is the nudge and is best-effort.
+#[tokio::test]
+async fn a_push_failure_never_fails_the_in_app_notification_write() {
+    use autumn_web::notifications::{MemoryNotificationStore, Notifications};
+    use autumn_web::pagination::{ListQuery, PageRequest};
+
+    let notifications = Notifications::new(MemoryNotificationStore::new());
+    // No VAPID key configured: every send fails, which is the harshest version
+    // of "push is broken".
+    let push = WebPush::without_vapid_key(
+        MemoryPushSubscriptionStore::new(),
+        "mailto:ops@example.com",
+        RecordingPushTransport::new(),
+    );
+
+    let notification = notifications
+        .notify(7, "comment.created", json!({ "post": 42 }))
+        .await
+        .expect("the durable write must succeed");
+
+    // Best-effort, exactly as the module docs show.
+    let push_result = push
+        .send(7_i64, &PushMessage::new("New comment", "Someone replied"))
+        .await;
+    assert!(push_result.is_err(), "push is genuinely broken here");
+
+    let feed = notifications
+        .list(7, &ListQuery::default(), &PageRequest::default())
+        .await
+        .expect("list");
+    assert_eq!(
+        feed.content.len(),
+        1,
+        "the in-app notification must survive a failed push"
+    );
+    assert_eq!(feed.content[0].id, notification.id);
+    assert_eq!(
+        notifications.unread_count(7).await.expect("unread"),
+        1,
+        "…and still count as unread, so the user sees it when they return"
+    );
+}
+
+// ── Postgres-backed store (testcontainers, requires Docker) ─────────────────
+
+/// `not(feature = "sqlite")`: under the app-only `sqlite` feature (which
+/// implies `db`) the runtime connection is `SQLite`, so this Postgres pool would
+/// no longer type-check against `DbPushSubscriptionStore::new`.
+#[cfg(all(feature = "db", not(feature = "sqlite")))]
+mod pg {
+    use super::*;
+    use autumn_web::push::{DbPushSubscriptionStore, PushSubscriptionStore};
+    use diesel_async::AsyncPgConnection;
+    use diesel_async::RunQueryDsl;
+    use diesel_async::pooled_connection::AsyncDieselConnectionManager;
+    use diesel_async::pooled_connection::deadpool::Pool;
+    use testcontainers::runners::AsyncRunner;
+    use testcontainers_modules::postgres::Postgres;
+
+    /// The DDL `autumn generate pwa` emits for the Postgres backend.
+    ///
+    /// This is a **copy** of the generator's output, and copying it is the
+    /// point: the generator lives in `autumn-cli`, which `autumn-web`'s tests
+    /// cannot depend on, so the contract that binds them — the store's diesel
+    /// `table!` must match the scaffolded table — is otherwise proved nowhere.
+    /// Running the store against this DDL is what catches a column that was
+    /// renamed on one side only, or a `TIMESTAMP` that should have been
+    /// `TIMESTAMPTZ`. The `autumn-cli` test
+    /// `generated_push_ddl_matches_the_ddl_the_framework_store_is_tested_against`
+    /// pins the other direction, so the two cannot drift apart silently.
+    const CREATE_PUSH_SUBSCRIPTIONS_SQL: &str = "CREATE TABLE push_subscriptions (\
+         id BIGSERIAL PRIMARY KEY, \
+         principal_id TEXT NOT NULL, \
+         endpoint TEXT NOT NULL, \
+         p256dh TEXT NOT NULL, \
+         auth TEXT NOT NULL, \
+         created_at TIMESTAMPTZ NOT NULL DEFAULT NOW())";
+    const CREATE_PUSH_ENDPOINT_INDEX_SQL: &str = "CREATE UNIQUE INDEX idx_push_subscriptions_endpoint_unique \
+         ON push_subscriptions (endpoint)";
+
+    async fn setup() -> (
+        DbPushSubscriptionStore,
+        Pool<AsyncPgConnection>,
+        testcontainers::ContainerAsync<Postgres>,
+    ) {
+        let container = Postgres::default()
+            .start()
+            .await
+            .expect("failed to start postgres container");
+        let host = container.get_host().await.expect("host");
+        let port = container.get_host_port_ipv4(5432).await.expect("port");
+        let url = format!("postgres://postgres:postgres@{host}:{port}/postgres");
+
+        let manager = AsyncDieselConnectionManager::<AsyncPgConnection>::new(&url);
+        let pool = Pool::builder(manager).max_size(4).build().expect("pool");
+        let mut conn = pool.get().await.expect("conn");
+        for ddl in [
+            CREATE_PUSH_SUBSCRIPTIONS_SQL,
+            CREATE_PUSH_ENDPOINT_INDEX_SQL,
+        ] {
+            diesel::sql_query(ddl)
+                .execute(&mut conn)
+                .await
+                .expect("apply the generated push DDL");
+        }
+        drop(conn);
+
+        (DbPushSubscriptionStore::new(pool.clone()), pool, container)
+    }
+
+    /// Build a validated subscription without going through HTTP.
+    fn stored(principal: i64, endpoint: &str) -> autumn_web::push::StoredSubscription {
+        let payload: autumn_web::push::BrowserSubscription =
+            serde_json::from_value(subscription_json(endpoint)).expect("payload");
+        payload.decode(&principal.into()).expect("valid")
+    }
+
+    #[tokio::test]
+    #[ignore = "requires Docker (testcontainers)"]
+    async fn db_store_round_trips_through_the_generated_schema() {
+        let (store, _pool, _container) = setup().await;
+
+        store
+            .save(stored(7, LIVE_ENDPOINT))
+            .await
+            .expect("the store must work against the DDL the generator emits");
+
+        let rows = store.list_for("7").await.expect("list");
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].endpoint(), LIVE_ENDPOINT);
+        assert_eq!(rows[0].principal_id(), "7");
+        // The keys must survive the TEXT round trip byte-for-byte, or nothing
+        // this store hands back will encrypt correctly.
+        assert_eq!(
+            rows[0].p256dh(),
+            URL_SAFE_NO_PAD
+                .decode(UA_PUBLIC)
+                .expect("decode")
+                .as_slice()
+        );
+        assert_eq!(
+            rows[0].auth(),
+            URL_SAFE_NO_PAD.decode(UA_AUTH).expect("decode").as_slice()
+        );
+    }
+
+    #[tokio::test]
+    #[ignore = "requires Docker (testcontainers)"]
+    async fn db_store_upserts_on_endpoint_rather_than_duplicating() {
+        let (store, _pool, _container) = setup().await;
+
+        for _ in 0..3 {
+            store.save(stored(7, LIVE_ENDPOINT)).await.expect("save");
+        }
+        assert_eq!(
+            store.list_for("7").await.expect("list").len(),
+            1,
+            "the UNIQUE index on `endpoint` is what makes the upsert atomic; without \
+             it this is three rows and three duplicate notifications"
+        );
+    }
+
+    #[tokio::test]
+    #[ignore = "requires Docker (testcontainers)"]
+    async fn db_store_updates_the_keys_of_an_existing_endpoint() {
+        // The `DO UPDATE SET` clause exists for key rotation. Re-saving an
+        // identical row proves only "no second row"; this proves the columns
+        // are actually refreshed.
+        let (store, _pool, _container) = setup().await;
+        store.save(stored(7, LIVE_ENDPOINT)).await.expect("save");
+
+        let rotated_key = VapidKey::generate().public_key_base64url();
+        let mut payload: autumn_web::push::BrowserSubscription =
+            serde_json::from_value(subscription_json(LIVE_ENDPOINT)).expect("payload");
+        payload.keys.p256dh = rotated_key.clone();
+        let rotated = payload.decode(&7_i64.into()).expect("valid");
+        store.save(rotated).await.expect("re-save with new keys");
+
+        let rows = store.list_for("7").await.expect("list");
+        assert_eq!(rows.len(), 1);
+        assert_eq!(
+            rows[0].p256dh_base64url(),
+            rotated_key,
+            "the stored key must be the rotated one, not the original"
+        );
+    }
+
+    #[tokio::test]
+    #[ignore = "requires Docker (testcontainers)"]
+    async fn db_store_moves_an_endpoint_between_principals_only_with_matching_keys() {
+        let (store, _pool, _container) = setup().await;
+        store.save(stored(7, LIVE_ENDPOINT)).await.expect("save");
+
+        // A different principal presenting DIFFERENT keys is an attempted
+        // takeover: it must be refused, not silently honored.
+        let mut payload: autumn_web::push::BrowserSubscription =
+            serde_json::from_value(subscription_json(LIVE_ENDPOINT)).expect("payload");
+        payload.keys.p256dh = VapidKey::generate().public_key_base64url();
+        let hostile = payload.decode(&9_i64.into()).expect("valid shape");
+        assert!(
+            matches!(
+                store.save(hostile).await,
+                Err(autumn_web::push::PushError::EndpointClaimed)
+            ),
+            "knowing an endpoint URL must not be enough to take a device over"
+        );
+        assert_eq!(
+            store.list_for("7").await.expect("list").len(),
+            1,
+            "the original owner keeps the subscription"
+        );
+        assert!(store.list_for("9").await.expect("list").is_empty());
+
+        // The shared-device case: the SAME browser re-subscribes under a new
+        // signed-in user, so it presents the same endpoint AND the same keys.
+        store
+            .save(stored(9, LIVE_ENDPOINT))
+            .await
+            .expect("a genuine shared-device re-subscribe is honored");
+        assert!(store.list_for("7").await.expect("list").is_empty());
+        assert_eq!(store.list_for("9").await.expect("list").len(), 1);
+    }
+
+    #[tokio::test]
+    #[ignore = "requires Docker (testcontainers)"]
+    async fn db_store_scopes_removal_by_principal() {
+        let (store, _pool, _container) = setup().await;
+        store.save(stored(7, LIVE_ENDPOINT)).await.expect("save");
+
+        assert_eq!(
+            store
+                .remove(LIVE_ENDPOINT, Some("9"))
+                .await
+                .expect("remove"),
+            0,
+            "a different principal must not be able to delete this row"
+        );
+        assert_eq!(store.list_for("7").await.expect("list").len(), 1);
+
+        // The unscoped path is what a `410 Gone` takes.
+        assert_eq!(store.remove(LIVE_ENDPOINT, None).await.expect("remove"), 1);
+        assert!(store.list_for("7").await.expect("list").is_empty());
+    }
+
+    #[tokio::test]
+    #[ignore = "requires Docker (testcontainers)"]
+    async fn db_store_caps_subscriptions_per_principal() {
+        let (store, _pool, _container) = setup().await;
+        let max = autumn_web::push::MAX_SUBSCRIPTIONS_PER_PRINCIPAL;
+
+        for i in 0..max {
+            store
+                .save(stored(7, &format!("https://push.example.com/device-{i}")))
+                .await
+                .expect("save up to the cap");
+        }
+        assert!(
+            matches!(
+                store
+                    .save(stored(7, "https://push.example.com/one-too-many"))
+                    .await,
+                Err(autumn_web::push::PushError::TooManySubscriptions { .. })
+            ),
+            "without a cap, one account can make every send unbounded work"
+        );
+        // An existing endpoint is an update, so the cap must not block it.
+        store
+            .save(stored(7, "https://push.example.com/device-0"))
+            .await
+            .expect("re-saving an existing endpoint is never capped");
+        assert_eq!(store.list_for("7").await.expect("list").len(), max);
+    }
+
+    #[tokio::test]
+    #[ignore = "requires Docker (testcontainers)"]
+    async fn a_missing_table_reports_how_to_create_it() {
+        let (store, pool, _container) = setup().await;
+        let mut conn = pool.get().await.expect("conn");
+        diesel::sql_query("DROP TABLE push_subscriptions")
+            .execute(&mut conn)
+            .await
+            .expect("drop");
+        drop(conn);
+
+        let err = store
+            .save(stored(7, LIVE_ENDPOINT))
+            .await
+            .expect_err("a missing table is an error");
+        assert!(
+            err.to_string().contains("autumn generate pwa"),
+            "the error must say how to scaffold the table: {err}"
+        );
+    }
+}

--- a/autumn/tests/integration/push_router.rs
+++ b/autumn/tests/integration/push_router.rs
@@ -446,3 +446,135 @@ async fn the_vapid_public_key_response_is_not_cacheable() {
         "a key rotation must not be masked by a cached response"
     );
 }
+
+/// `AUTUMN_PUSH__PRIVATE_KEY` is the deployment path the guide documents, so
+/// it has to actually reach the config.
+///
+/// Overrides are applied only through the explicit per-section methods
+/// `apply_env_overrides_with_env` calls; a new section that forgets to add one
+/// leaves every documented variable inert, and the operator is left looking at
+/// a variable they did set while every send reports "not configured".
+#[test]
+fn push_settings_can_be_supplied_through_the_environment() {
+    use autumn_web::config::AutumnConfig;
+    use secrecy::ExposeSecret as _;
+
+    let key = VapidKey::generate();
+    let vars = [
+        ("AUTUMN_PUSH__PRIVATE_KEY", key.private_key_base64url()),
+        ("AUTUMN_PUSH__PUBLIC_KEY", key.public_key_base64url()),
+        ("AUTUMN_PUSH__SUBJECT", "mailto:ops@example.com".to_owned()),
+        ("AUTUMN_PUSH__TTL_SECS", "600".to_owned()),
+    ];
+
+    temp_env::with_vars(
+        vars.iter()
+            .map(|(k, v)| (*k, Some(v.as_str())))
+            .collect::<Vec<_>>(),
+        || {
+            let mut config = AutumnConfig::default();
+            config.apply_env_overrides();
+
+            assert_eq!(
+                config
+                    .push
+                    .private_key
+                    .as_ref()
+                    .map(|k| k.expose_secret().to_owned()),
+                Some(key.private_key_base64url()),
+                "the documented private-key variable must reach the config"
+            );
+            assert_eq!(
+                config.push.public_key.as_deref(),
+                Some(key.public_key_base64url().as_str())
+            );
+            assert_eq!(
+                config.push.subject.as_deref(),
+                Some("mailto:ops@example.com")
+            );
+            assert_eq!(config.push.ttl_secs, Some(600));
+
+            // And the whole point: it produces a working, bootable key.
+            config.validate_push().expect("boots");
+            assert_eq!(
+                config
+                    .push
+                    .load_vapid_key()
+                    .expect("load")
+                    .expect("present")
+                    .public_key_base64url(),
+                key.public_key_base64url()
+            );
+        },
+    );
+}
+
+/// The public-key response carries the caller's CSRF token, because the
+/// subscribe snippet has no other way to get one: the CSRF cookie is
+/// `HttpOnly`, and the generated snippet runs on pages rendered by a
+/// `layout()` the PWA generator does not change the signature of.
+#[tokio::test]
+async fn the_public_key_response_carries_a_csrf_token_for_the_snippet() {
+    let vapid = VapidKey::generate();
+    let mut config = autumn_web::config::AutumnConfig::default();
+    config.push.private_key = Some(vapid.private_key_base64url().into());
+    config.security.csrf.enabled = true;
+
+    let client = TestApp::new()
+        .merge(autumn_web::push::router())
+        .config(config)
+        .build();
+
+    let response = client.get("/push/vapid-public-key").send().await;
+    response.assert_status(200);
+
+    let token = response
+        .header(autumn_web::push::router::CSRF_TOKEN_HEADER)
+        .expect("the response must carry a CSRF token when CSRF is enabled");
+    assert!(!token.is_empty(), "an empty token is no token");
+    // Compared case-insensitively: the framework normalizes the configured
+    // name to lowercase (`x-csrf-token`), and HTTP header names are
+    // case-insensitive anyway — what matters is that the snippet is told which
+    // name to use rather than guessing.
+    assert_eq!(
+        response
+            .header(autumn_web::push::router::CSRF_TOKEN_HEADER_NAME_HEADER)
+            .map(str::to_ascii_lowercase),
+        Some("x-csrf-token".to_owned()),
+        "the snippet needs the configured header name, not a guess"
+    );
+}
+
+/// Subscribing with that token succeeds where an unaccompanied POST is
+/// rejected — the end-to-end shape of the fix.
+#[tokio::test]
+async fn subscribe_succeeds_with_the_token_from_the_public_key_response() {
+    let vapid = VapidKey::generate();
+    let mut config = autumn_web::config::AutumnConfig::default();
+    config.push.private_key = Some(vapid.private_key_base64url().into());
+    config.security.csrf.enabled = true;
+
+    let client = TestApp::new()
+        .merge(autumn_web::push::router())
+        .config(config)
+        .build();
+    client.acting_as(7).await;
+
+    let key_response = client.get("/push/vapid-public-key").send().await;
+    let token = key_response
+        .header(autumn_web::push::router::CSRF_TOKEN_HEADER)
+        .expect("token")
+        .to_owned();
+    let header_name = key_response
+        .header(autumn_web::push::router::CSRF_TOKEN_HEADER_NAME_HEADER)
+        .expect("header name")
+        .to_owned();
+
+    client
+        .post("/push/subscribe")
+        .header(&header_name, &token)
+        .json(&subscription_json("https://push.example.com/csrf"))
+        .send()
+        .await
+        .assert_status(204);
+}

--- a/autumn/tests/integration/push_router.rs
+++ b/autumn/tests/integration/push_router.rs
@@ -509,6 +509,50 @@ fn push_settings_can_be_supplied_through_the_environment() {
     );
 }
 
+/// A blank `AUTUMN_PUSH__PRIVATE_KEY` must fail the boot, not disable push.
+///
+/// The shared env helpers treat a blank value as "clear this setting", which
+/// is right where unsetting via env is meaningful. It is wrong here: the
+/// commonest way this variable ends up blank is a secret that failed to
+/// interpolate, and clearing it would silently disable delivery, sail through
+/// `validate_push()`, and surface much later as `503`/`NotConfigured`.
+#[test]
+fn a_blank_push_key_override_fails_the_boot_rather_than_disabling_push() {
+    use autumn_web::config::AutumnConfig;
+
+    for blank in ["", "   ", "\n"] {
+        temp_env::with_var("AUTUMN_PUSH__PRIVATE_KEY", Some(blank), || {
+            let mut config = AutumnConfig::default();
+            config.apply_env_overrides();
+            let err = config
+                .validate_push()
+                .expect_err("a blank key must fail the boot");
+            assert!(
+                err.to_string().contains("AUTUMN_PUSH__PRIVATE_KEY"),
+                "the error must name the variable to look at: {err}"
+            );
+        });
+    }
+}
+
+/// …and it must not erase a good key that `autumn.toml` already supplied.
+#[test]
+fn a_blank_push_key_override_does_not_silently_erase_a_configured_key() {
+    use autumn_web::config::AutumnConfig;
+
+    let key = VapidKey::generate();
+    temp_env::with_var("AUTUMN_PUSH__PRIVATE_KEY", Some(""), || {
+        let mut config = AutumnConfig::default();
+        config.push.private_key = Some(key.private_key_base64url().into());
+        config.apply_env_overrides();
+        // Loudly refused — never quietly reverted to "no key configured".
+        assert!(
+            config.validate_push().is_err(),
+            "a blank override must not be mistaken for `push disabled`"
+        );
+    });
+}
+
 /// The public-key response carries the caller's CSRF token, because the
 /// subscribe snippet has no other way to get one: the CSRF cookie is
 /// `HttpOnly`, and the generated snippet runs on pages rendered by a

--- a/autumn/tests/integration/push_router.rs
+++ b/autumn/tests/integration/push_router.rs
@@ -529,7 +529,7 @@ async fn the_public_key_response_carries_a_csrf_token_for_the_snippet() {
     response.assert_status(200);
 
     let token = response
-        .header(autumn_web::push::router::CSRF_TOKEN_HEADER)
+        .header(autumn_web::push::CSRF_TOKEN_HEADER)
         .expect("the response must carry a CSRF token when CSRF is enabled");
     assert!(!token.is_empty(), "an empty token is no token");
     // Compared case-insensitively: the framework normalizes the configured
@@ -538,7 +538,7 @@ async fn the_public_key_response_carries_a_csrf_token_for_the_snippet() {
     // name to use rather than guessing.
     assert_eq!(
         response
-            .header(autumn_web::push::router::CSRF_TOKEN_HEADER_NAME_HEADER)
+            .header(autumn_web::push::CSRF_TOKEN_HEADER_NAME_HEADER)
             .map(str::to_ascii_lowercase),
         Some("x-csrf-token".to_owned()),
         "the snippet needs the configured header name, not a guess"
@@ -562,11 +562,11 @@ async fn subscribe_succeeds_with_the_token_from_the_public_key_response() {
 
     let key_response = client.get("/push/vapid-public-key").send().await;
     let token = key_response
-        .header(autumn_web::push::router::CSRF_TOKEN_HEADER)
+        .header(autumn_web::push::CSRF_TOKEN_HEADER)
         .expect("token")
         .to_owned();
     let header_name = key_response
-        .header(autumn_web::push::router::CSRF_TOKEN_HEADER_NAME_HEADER)
+        .header(autumn_web::push::CSRF_TOKEN_HEADER_NAME_HEADER)
         .expect("header name")
         .to_owned();
 

--- a/autumn/tests/integration/push_router.rs
+++ b/autumn/tests/integration/push_router.rs
@@ -589,6 +589,72 @@ async fn the_public_key_response_carries_a_csrf_token_for_the_snippet() {
     );
 }
 
+/// The `503` (push unconfigured) response must carry the CSRF token too.
+///
+/// A deployment that removes its VAPID key still has browsers holding
+/// subscriptions, and the unsubscribe flow primes its token from this very
+/// endpoint. Without a token on the `503`, the follow-up unsubscribe is
+/// rejected while the client still drops its local subscription — stranding
+/// the server row forever, since nothing will push to it again to earn a
+/// `410`.
+#[tokio::test]
+async fn the_unconfigured_response_still_carries_a_csrf_token() {
+    let mut config = autumn_web::config::AutumnConfig::default();
+    config.security.csrf.enabled = true;
+    // No `[push] private_key` — the unconfigured case.
+
+    let client = TestApp::new()
+        .merge(autumn_web::push::router())
+        .config(config)
+        .build();
+
+    let response = client.get("/push/vapid-public-key").send().await;
+    response.assert_status(503);
+    let token = response
+        .header(autumn_web::push::CSRF_TOKEN_HEADER)
+        .expect("a 503 must still let the client unsubscribe");
+    assert!(!token.is_empty());
+    assert!(
+        response
+            .header(autumn_web::push::CSRF_TOKEN_HEADER_NAME_HEADER)
+            .is_some(),
+        "…including which header to send it back in"
+    );
+}
+
+/// …and that token actually works, so a stranded subscription can be cleaned
+/// up while push is unconfigured.
+#[tokio::test]
+async fn unsubscribe_works_while_push_is_unconfigured() {
+    let mut config = autumn_web::config::AutumnConfig::default();
+    config.security.csrf.enabled = true;
+
+    let client = TestApp::new()
+        .merge(autumn_web::push::router())
+        .config(config)
+        .build();
+    client.acting_as(7).await;
+
+    let key_response = client.get("/push/vapid-public-key").send().await;
+    key_response.assert_status(503);
+    let token = key_response
+        .header(autumn_web::push::CSRF_TOKEN_HEADER)
+        .expect("token")
+        .to_owned();
+    let header_name = key_response
+        .header(autumn_web::push::CSRF_TOKEN_HEADER_NAME_HEADER)
+        .expect("header name")
+        .to_owned();
+
+    client
+        .post("/push/unsubscribe")
+        .header(&header_name, &token)
+        .json(&serde_json::json!({ "endpoint": "https://push.example.com/stranded" }))
+        .send()
+        .await
+        .assert_status(204);
+}
+
 /// Subscribing with that token succeeds where an unaccompanied POST is
 /// rejected — the end-to-end shape of the fix.
 #[tokio::test]

--- a/autumn/tests/integration/push_router.rs
+++ b/autumn/tests/integration/push_router.rs
@@ -1,0 +1,448 @@
+//! The built-in Web Push routes (`autumn_web::push::router`) — issue #1392.
+//!
+//! These exercise the routes end to end through `TestApp`: the browser's
+//! `PushSubscription` JSON goes in over HTTP, and the resulting subscription
+//! is proven by sending to it and inspecting what the transport received.
+
+use autumn_web::push::{
+    MemoryPushSubscriptionStore, PushMessage, RecordingPushTransport, VapidKey, WebPush,
+};
+use autumn_web::test::TestApp;
+use serde_json::json;
+
+const P256DH: &str =
+    "BCVxsr7N_eNgVRqvHtD0zTZsEc6-VV-JvLexhqUzORcxaOzi6-AYWXvTBHm4bjyPjs7Vd8pZGH6SRpkNtoIAiw4";
+const AUTH: &str = "BTBZMqHH6r4Tts7J_aSIgg";
+
+fn subscription_json(endpoint: &str) -> serde_json::Value {
+    json!({
+        "endpoint": endpoint,
+        // Browsers include this; the framework must ignore it rather than
+        // reject the payload.
+        "expirationTime": serde_json::Value::Null,
+        "keys": { "p256dh": P256DH, "auth": AUTH },
+    })
+}
+
+/// A `TestApp` mounting the built-in router over a `WebPush` whose transport
+/// records everything, plus a test-only route that signs a caller in.
+fn app_with_push(
+    transport: RecordingPushTransport,
+    vapid: VapidKey,
+) -> (TestApp, autumn_web::push::WebPush) {
+    let push = WebPush::new(
+        MemoryPushSubscriptionStore::new(),
+        vapid,
+        "mailto:ops@example.com",
+        transport,
+    );
+    let app = TestApp::new()
+        .merge(autumn_web::push::router())
+        .with_web_push(push.clone());
+    (app, push)
+}
+
+/// The built-in router over a recording transport, with the client already
+/// signed in as user 7 via the framework's own test sign-in seam.
+async fn signed_in_client(
+    transport: RecordingPushTransport,
+    vapid: VapidKey,
+) -> (autumn_web::test::TestClient, autumn_web::push::WebPush) {
+    let (app, push) = app_with_push(transport, vapid);
+    let client = app.build();
+    client.acting_as(7).await;
+    (client, push)
+}
+
+#[tokio::test]
+async fn vapid_public_key_endpoint_serves_the_application_server_key() {
+    let vapid = VapidKey::generate();
+    let (app, _) = app_with_push(RecordingPushTransport::new(), vapid.clone());
+    let client = app.build();
+
+    let response = client.get("/push/vapid-public-key").send().await;
+    response.assert_status(200);
+    let body = response.text();
+    assert_eq!(
+        body.trim(),
+        vapid.public_key_base64url(),
+        "the client needs exactly this string for `applicationServerKey`"
+    );
+}
+
+#[tokio::test]
+async fn vapid_public_key_endpoint_is_public() {
+    // The subscribe snippet fetches this before the user has done anything;
+    // requiring auth would break the first-visit subscribe flow. The value is
+    // public key material, so serving it to anyone is correct.
+    let (app, _) = app_with_push(RecordingPushTransport::new(), VapidKey::generate());
+    app.build()
+        .get("/push/vapid-public-key")
+        .send()
+        .await
+        .assert_status(200);
+}
+
+#[tokio::test]
+async fn vapid_public_key_endpoint_is_503_when_push_is_unconfigured() {
+    // Not a 200 with an empty body: the client must be able to tell "no key
+    // configured" apart from "here is your key".
+    let push = WebPush::without_vapid_key(
+        MemoryPushSubscriptionStore::new(),
+        "mailto:ops@example.com",
+        RecordingPushTransport::new(),
+    );
+    let client = TestApp::new()
+        .merge(autumn_web::push::router())
+        .with_web_push(push)
+        .build();
+    client
+        .get("/push/vapid-public-key")
+        .send()
+        .await
+        .assert_status(503);
+}
+
+#[tokio::test]
+async fn subscribe_records_the_subscription_for_the_signed_in_principal() {
+    let transport = RecordingPushTransport::new();
+    let (client, push) = signed_in_client(transport.clone(), VapidKey::generate()).await;
+
+    client
+        .post("/push/subscribe")
+        .json(&subscription_json("https://push.example.com/abc"))
+        .send()
+        .await
+        .assert_status(204);
+
+    let report = push
+        .send(7_i64, &PushMessage::new("Hi", "There"))
+        .await
+        .expect("send");
+    assert_eq!(report.delivered, 1);
+    assert_eq!(
+        transport.requests()[0].endpoint,
+        "https://push.example.com/abc"
+    );
+}
+
+#[tokio::test]
+async fn subscribe_requires_a_signed_in_caller() {
+    // Without a principal there is nobody to bind the subscription to, and
+    // guessing (e.g. by IP) would let an anonymous visitor receive another
+    // user's notifications.
+    let (app, _) = app_with_push(RecordingPushTransport::new(), VapidKey::generate());
+    app.build()
+        .post("/push/subscribe")
+        .json(&subscription_json("https://push.example.com/abc"))
+        .send()
+        .await
+        .assert_status(401);
+}
+
+#[tokio::test]
+async fn subscribe_rejects_a_malformed_payload_with_a_400() {
+    let (client, _) = signed_in_client(RecordingPushTransport::new(), VapidKey::generate()).await;
+    client
+        .post("/push/subscribe")
+        .json(&json!({
+            "endpoint": "https://push.example.com/abc",
+            "keys": { "p256dh": "not-a-key", "auth": AUTH },
+        }))
+        .send()
+        .await
+        .assert_status(400);
+}
+
+#[tokio::test]
+async fn subscribe_rejects_an_ssrf_shaped_endpoint_with_a_400() {
+    // The endpoint is client-supplied and the framework later POSTs to it.
+    let (client, _) = signed_in_client(RecordingPushTransport::new(), VapidKey::generate()).await;
+    client
+        .post("/push/subscribe")
+        .json(&subscription_json(
+            "https://169.254.169.254/latest/meta-data",
+        ))
+        .send()
+        .await
+        .assert_status(400);
+}
+
+#[tokio::test]
+async fn subscribing_twice_is_idempotent() {
+    // The recommended client pattern re-subscribes on every page load.
+    let transport = RecordingPushTransport::new();
+    let (client, push) = signed_in_client(transport.clone(), VapidKey::generate()).await;
+
+    for _ in 0..3 {
+        client
+            .post("/push/subscribe")
+            .json(&subscription_json("https://push.example.com/abc"))
+            .send()
+            .await
+            .assert_status(204);
+    }
+
+    assert_eq!(
+        push.send(7_i64, &PushMessage::new("Hi", "There"))
+            .await
+            .expect("send")
+            .delivered,
+        1,
+        "re-subscribing must not create a second row (and a duplicate notification)"
+    );
+}
+
+#[tokio::test]
+async fn unsubscribe_removes_the_callers_subscription() {
+    let transport = RecordingPushTransport::new();
+    let (client, push) = signed_in_client(transport.clone(), VapidKey::generate()).await;
+
+    client
+        .post("/push/subscribe")
+        .json(&subscription_json("https://push.example.com/abc"))
+        .send()
+        .await
+        .assert_status(204);
+    client
+        .post("/push/unsubscribe")
+        .json(&json!({ "endpoint": "https://push.example.com/abc" }))
+        .send()
+        .await
+        .assert_status(204);
+
+    assert_eq!(
+        push.send(7_i64, &PushMessage::new("Hi", "There"))
+            .await
+            .expect("send")
+            .delivered,
+        0
+    );
+}
+
+#[tokio::test]
+async fn unsubscribe_requires_a_signed_in_caller() {
+    let (app, _) = app_with_push(RecordingPushTransport::new(), VapidKey::generate());
+    app.build()
+        .post("/push/unsubscribe")
+        .json(&json!({ "endpoint": "https://push.example.com/abc" }))
+        .send()
+        .await
+        .assert_status(401);
+}
+
+#[tokio::test]
+async fn unsubscribing_something_never_subscribed_is_still_204() {
+    // Idempotent: a client that unsubscribes on sign-out must not see an error
+    // just because permission had already been revoked in the browser.
+    let (client, _) = signed_in_client(RecordingPushTransport::new(), VapidKey::generate()).await;
+    client
+        .post("/push/unsubscribe")
+        .json(&json!({ "endpoint": "https://push.example.com/never" }))
+        .send()
+        .await
+        .assert_status(204);
+}
+
+#[tokio::test]
+async fn one_user_cannot_unsubscribe_anothers_device() {
+    let transport = RecordingPushTransport::new();
+    let (app, push) = app_with_push(transport.clone(), VapidKey::generate());
+
+    push.subscribe(
+        7_i64,
+        &serde_json::from_value(subscription_json("https://push.example.com/victim"))
+            .expect("payload"),
+    )
+    .await
+    .expect("subscribe");
+
+    // A *different* user asks to unsubscribe user 7's endpoint.
+    let client = app.build();
+    client.acting_as(9).await;
+    client
+        .post("/push/unsubscribe")
+        .json(&json!({ "endpoint": "https://push.example.com/victim" }))
+        .send()
+        .await
+        .assert_status(204);
+
+    assert_eq!(
+        push.send(7_i64, &PushMessage::new("Hi", "There"))
+            .await
+            .expect("send")
+            .delivered,
+        1,
+        "user 9 must not have been able to remove user 7's device"
+    );
+}
+
+// ── Configuration wiring ────────────────────────────────────────────────────
+
+/// A `[push]` block with a valid key resolves a working service with no
+/// application wiring at all — the extractor path a real app takes.
+///
+/// This is also the regression guard for a deadlock: resolving the service
+/// *inside* `AppState::extension_or_insert_with`'s closure takes a read lock
+/// on the extensions map that the helper already holds for writing, and the
+/// request hangs forever. Every other test in this file registers a service
+/// explicitly and so never reaches that path — only a test that lets the
+/// extractor resolve on its own can catch it.
+#[tokio::test]
+async fn a_configured_push_block_resolves_a_working_service() {
+    let vapid = VapidKey::generate();
+    let mut config = autumn_web::config::AutumnConfig::default();
+    config.push.private_key = Some(vapid.private_key_base64url().into());
+    config.push.subject = Some("mailto:ops@example.com".to_owned());
+
+    let client = TestApp::new()
+        .merge(autumn_web::push::router())
+        .config(config)
+        .build();
+
+    let response = client.get("/push/vapid-public-key").send().await;
+    response.assert_status(200);
+    assert_eq!(
+        response.text().trim(),
+        vapid.public_key_base64url(),
+        "the key served to the browser must be the one from `[push] private_key`"
+    );
+}
+
+/// With no `[push]` block the app still boots and the routes still exist —
+/// they just report that push is unconfigured.
+#[tokio::test]
+async fn an_unconfigured_app_still_boots_and_reports_unconfigured() {
+    let client = TestApp::new().merge(autumn_web::push::router()).build();
+    let response = client.get("/push/vapid-public-key").send().await;
+    response.assert_status(503);
+    assert!(
+        response.text().contains("private_key"),
+        "the response must say how to configure push: {}",
+        response.text()
+    );
+}
+
+/// The boot-time guard `AppBuilder::run` applies before binding.
+///
+/// `run` exits the process on failure, which no in-process test can observe —
+/// so the rule itself lives in `AutumnConfig::validate_push`, and `run` calls
+/// exactly that. This pins the rule; the one-line call in `app.rs` is what
+/// connects it to the boot.
+#[test]
+fn boot_validation_refuses_a_push_block_that_cannot_work() {
+    let good = VapidKey::generate();
+
+    let mut valid = autumn_web::config::AutumnConfig::default();
+    valid.push.private_key = Some(good.private_key_base64url().into());
+    valid.validate_push().expect("a valid key boots");
+
+    let mut absent = autumn_web::config::AutumnConfig::default();
+    absent.push.private_key = None;
+    absent
+        .validate_push()
+        .expect("an app with no [push] block must still boot");
+
+    // Each of these would otherwise start cleanly, accept subscriptions, and
+    // silently never deliver anything.
+    let mut typo = autumn_web::config::AutumnConfig::default();
+    typo.push.private_key = Some("obviously-not-a-key".to_owned().into());
+    typo.validate_push()
+        .expect_err("an invalid key fails the boot");
+
+    let mut blank = autumn_web::config::AutumnConfig::default();
+    blank.push.private_key = Some(String::new().into());
+    blank
+        .validate_push()
+        .expect_err("an env var that failed to interpolate fails the boot");
+
+    let mut mismatched = autumn_web::config::AutumnConfig::default();
+    mismatched.push.private_key = Some(good.private_key_base64url().into());
+    mismatched.push.public_key = Some(VapidKey::generate().public_key_base64url());
+    mismatched
+        .validate_push()
+        .expect_err("a mismatched key pair fails the boot");
+}
+
+/// A store registered through the builder pre-empts the default resolution.
+#[tokio::test]
+async fn a_registered_subscription_store_is_the_one_the_extractor_uses() {
+    let vapid = VapidKey::generate();
+    let mut config = autumn_web::config::AutumnConfig::default();
+    config.push.private_key = Some(vapid.private_key_base64url().into());
+
+    let client = TestApp::new()
+        .merge(autumn_web::push::router())
+        .config(config)
+        // The resolved service must pick this store up rather than falling
+        // back to a fresh in-memory one.
+        .with_push_subscription_store(MemoryPushSubscriptionStore::new())
+        .build();
+    client.acting_as(7).await;
+
+    client
+        .post("/push/subscribe")
+        .json(&subscription_json("https://push.example.com/registered"))
+        .send()
+        .await
+        .assert_status(204);
+
+    // The configured key still reaches the service, so registering a store
+    // does not discard the rest of the resolved configuration.
+    let response = client.get("/push/vapid-public-key").send().await;
+    response.assert_status(200);
+    assert_eq!(response.text().trim(), vapid.public_key_base64url());
+}
+
+/// Re-subscribing an endpoint another user owns, with different keys, is a
+/// refusal — not a silent takeover.
+#[tokio::test]
+async fn one_user_cannot_claim_anothers_endpoint_over_http() {
+    let transport = RecordingPushTransport::new();
+    let (app, push) = app_with_push(transport, VapidKey::generate());
+    let client = app.build();
+
+    client.acting_as(7).await;
+    client
+        .post("/push/subscribe")
+        .json(&subscription_json("https://push.example.com/victim"))
+        .send()
+        .await
+        .assert_status(204);
+
+    // A different user submits the same endpoint with keys they control.
+    client.acting_as(9).await;
+    let mut hostile = subscription_json("https://push.example.com/victim");
+    hostile["keys"]["p256dh"] = serde_json::Value::String(
+        "BP4z9KsN6nGRTbVYI_c7VJSPQTBtkgcy27mlmlMoZIIgDll6e3vCYLocInmYWAmS6TlzAC8wEqKK6PBru3jl7A8"
+            .to_owned(),
+    );
+    client
+        .post("/push/subscribe")
+        .json(&hostile)
+        .send()
+        .await
+        .assert_status(409);
+
+    assert_eq!(
+        push.send(7_i64, &PushMessage::new("Hi", "There"))
+            .await
+            .expect("send")
+            .delivered,
+        1,
+        "the original owner must still receive"
+    );
+}
+
+/// The public-key response must never be held by a shared cache.
+#[tokio::test]
+async fn the_vapid_public_key_response_is_not_cacheable() {
+    let (app, _) = app_with_push(RecordingPushTransport::new(), VapidKey::generate());
+    let response = app.build().get("/push/vapid-public-key").send().await;
+    response.assert_status(200);
+    assert_eq!(
+        response.header("cache-control"),
+        Some("no-store"),
+        "a key rotation must not be masked by a cached response"
+    );
+}

--- a/docs/guide/web-push.md
+++ b/docs/guide/web-push.md
@@ -1,0 +1,370 @@
+# Web Push
+
+A notification only re-engages a user if it reaches them when they are *not*
+looking at your app. The [in-app feed](notifications.md) is durable but only
+visible once they come back, and `channels` needs a live connection — both go
+quiet the moment the tab closes.
+
+Web Push is the leg that closes that gap: the browser holds a subscription with
+its push service (FCM, Mozilla autopush, WNS), and your app hands that service
+an encrypted payload to deliver whenever the device next comes online. Autumn
+ships the whole loop — key handling, subscription storage, the browser-facing
+routes, the service-worker handlers, and the cryptography — so **you write zero
+lines of crypto**.
+
+> **Scope.** This is browser Web Push (VAPID / Push API). Native mobile push
+> (APNs/FCM device tokens) is out of scope, as are notification actions,
+> images, badge counts, and per-user quiet hours.
+
+## Quick start
+
+### 1. Mint a VAPID key pair
+
+A VAPID key pair identifies your application server to push services. Mint one
+**once**, offline, and keep the private half secret:
+
+```rust
+let key = autumn_web::push::VapidKey::generate();
+println!("private_key = \"{}\"", key.private_key_base64url());
+println!("public_key  = \"{}\"", key.public_key_base64url());
+```
+
+### 2. Configure it
+
+```toml
+[push]
+private_key = "…"                     # from step 1 — secret
+public_key  = "…"                     # optional; see "Fail fast" below
+subject     = "mailto:ops@example.com"
+```
+
+Supply `private_key` from an environment variable
+(`AUTUMN_PUSH__PRIVATE_KEY`) or the [encrypted credentials
+store](credentials.md) rather than committing it.
+
+### 3. Generate the PWA
+
+```bash
+autumn generate pwa
+autumn migrate
+```
+
+That emits (or updates):
+
+- `static/service-worker.js` — with `push` and `notificationclick` handlers.
+- `static/pwa-register.js` — the client subscribe snippet.
+- `migrations/<ts>_create_push_subscriptions/` — the subscription table.
+- `src/main.rs` — mounts `autumn_web::push::router()`.
+
+`--dry-run` is honored, and `autumn destroy pwa` reverses every part of it. A
+re-run needs `--force` (as every Autumn generator does — a plain re-run refuses
+rather than overwriting files you may have edited); with it, the result is
+idempotent: the migration directory is reused rather than duplicated, and the
+handlers, tags, and router mount are not added twice.
+
+If your `src/main.rs` no longer has a recognizable builder chain, the generator
+says so and skips the mount rather than guessing. Add it yourself:
+
+```rust
+.merge(autumn_web::push::router())
+```
+
+### 4. Let a user opt in
+
+The generated snippet exposes a declarative opt-in, so a button is all the
+markup you need:
+
+```html
+<button data-autumn-push-subscribe>Enable notifications</button>
+```
+
+It is deliberately **not** wired to page load: a permission prompt fired
+without a user gesture is the fastest way to get permanently blocked, and both
+Chrome and Firefox penalise it. Call `window.autumnPushSubscribe()` yourself if
+you want your own trigger; `window.autumnPushUnsubscribe()` is the inverse.
+
+### 5. Send
+
+```rust
+use autumn_web::prelude::*;
+
+#[post("/builds/{id}/fail")]
+async fn build_failed(push: WebPush, id: Path<i64>) -> AutumnResult<&'static str> {
+    push.send(
+        owner_id,
+        &PushMessage::new("Build failed", "main is red")
+            .url(format!("/builds/{}", *id)),
+    )
+    .await?;
+    Ok("ok")
+}
+```
+
+That is the whole glue budget: configure the key, mount the router, call
+`send`. Everything below the line — the ES256 VAPID JWT (RFC 8292), the ECDH
+key agreement, HKDF derivation, and AES-128-GCM payload encryption (RFC 8291) —
+is the framework's.
+
+## The API
+
+`WebPush` is an extractor, surfaced like `Session`, `Db`, and `Notifications`.
+
+| Method | Behavior |
+|---|---|
+| `send(principal, &message)` | Deliver to every device that principal has subscribed |
+| `send_many(principals, &message)` | Fan out across principals, aggregating one report |
+| `subscribe(principal, &browser_subscription)` | Validate and record a browser subscription |
+| `unsubscribe(principal, endpoint)` | Remove one of that principal's subscriptions |
+| `vapid_public_key()` | The `applicationServerKey` the browser subscribes with |
+
+`PushMessage::new(title, body)` optionally takes `.url(…)` (where a click
+navigates) and `.icon(…)`.
+
+### Principals
+
+`send` takes anything convertible into a `PushPrincipal`, which covers both id
+shapes Autumn apps use:
+
+```rust
+push.send(user.id, &message).await?;        // i64, as the notification feed uses
+push.send("service:ci", &message).await?;   // a string principal, as auth tokens carry
+```
+
+`PushPrincipal::from(42_i64)` and `PushPrincipal::from("42")` are the same
+principal, so composing with the in-app feed needs no conversion.
+
+### The delivery report
+
+`send` returns a `PushDeliveryReport`, because one unreachable device must not
+fail the whole call — a user with three devices, one of which has revoked
+permission, still gets the notification on the other two:
+
+```rust
+let report = push.send(user.id, &message).await?;
+report.delivered;  // accepted by the push service
+report.pruned;     // endpoints reported gone (404/410) and now removed
+report.failed;     // failed for a transient reason; still in the store
+```
+
+A principal who never subscribed yields an empty report, not an error.
+
+## Built-in routes
+
+`autumn_web::push::router()` mounts three routes:
+
+| Method | Path | Auth |
+|---|---|---|
+| `GET` | `/push/vapid-public-key` | public — it is public key material |
+| `POST` | `/push/subscribe` | signed in |
+| `POST` | `/push/unsubscribe` | signed in |
+
+The mutating routes resolve the caller **server-side** — from the framework's
+current actor (set by session and bearer-token auth alike), falling back to the
+`[auth] session_key` session value. They never take a principal from the
+request body, which would let anyone subscribe *as* anyone. Until an app has
+authentication these routes are simply dormant: every call 401s and nothing is
+stored.
+
+Unsubscribe is scoped to the caller, so one signed-in user cannot drop another
+user's device.
+
+### The principal must be the same id you send to
+
+> **This is the one thing to get right.** The router binds a subscription to
+> whatever the request's authenticated principal is; `send` looks a principal
+> up by the id *you* pass. If those two disagree — the router records
+> `"user:42"` because a bearer token published that, while you call
+> `push.send(42_i64, …)` — the send finds nothing and returns an empty report:
+> zero delivered, **no error**.
+
+With ordinary session auth the session value *is* the user id, so
+`push.send(user.id, …)` matches and there is nothing to do. If your app
+authenticates with API tokens whose `principal_id` is namespaced, either send
+with the same string (`push.send("user:42", …)`) or mount your own subscribe
+handler that calls `push.subscribe(user.id, …)` with the id you send to. A send
+that finds no subscriptions logs at `debug` with the principal it looked up,
+which is the quickest way to spot a mismatch.
+
+Both `PushPrincipal::from(42_i64)` and `PushPrincipal::from("42")` produce the
+same principal, so the `i64` and string spellings of one id are
+interchangeable — but two *different* namespaces are not.
+
+## Composing with the in-app feed (#1148)
+
+Push is a *delivery leg*, not a replacement for the feed. The feed is the
+durable record the user can come back to; the push is the nudge that brings
+them back. Write the record first and await it, then push best-effort:
+
+```rust
+use autumn_web::prelude::*;
+use autumn_web::push::PushMessage;
+
+#[post("/posts/{id}/comments")]
+async fn comment(
+    notifications: Notifications,
+    push: WebPush,
+    id: Path<i64>,
+) -> AutumnResult<&'static str> {
+    // The durable record. A failure here IS a failure of the request.
+    notifications
+        .notify(author_id, "comment.created", serde_json::json!({ "post": *id }))
+        .await?;
+
+    // The nudge. A push service outage, a revoked permission, or an app with
+    // no key configured must never fail the comment that was already written.
+    if let Err(e) = push
+        .send(
+            author_id,
+            &PushMessage::new("New comment", "Someone replied to your post")
+                .url(format!("/posts/{}", *id)),
+        )
+        .await
+    {
+        tracing::warn!(error = %e, "web push failed; the in-app notification still stands");
+    }
+
+    Ok("ok")
+}
+```
+
+This mirrors how `Notifications::notify_with_push` treats its `channels`
+broadcast: the durable write is propagated, the delivery attempt is logged.
+
+## Storage
+
+A subscription is an endpoint URL plus two keys, bound to a principal. The
+store resolves exactly like the notification feed's:
+
+1. A store registered via `AppBuilder::with_push_subscription_store(...)`.
+2. `DbPushSubscriptionStore` when a database pool is configured — the
+   `push_subscriptions` table `autumn generate pwa` scaffolds.
+3. `MemoryPushSubscriptionStore` otherwise (process-local; what `TestApp`
+   without a database uses).
+
+`endpoint` is the primary identity and carries a UNIQUE constraint, which is
+what makes the upsert atomic. Two consequences worth knowing:
+
+- Re-subscribing the same browser **updates** the row, and the endpoint is
+  normalized first, so `https://x/p` and `https://x:443/p` can never become two
+  rows for one device.
+- Re-subscribing under a *different* principal **moves** the row, but only when
+  the request presents the same `p256dh` the stored row has. That is exactly
+  the shared-device case — a second user signs in, the browser returns the same
+  endpoint *and* the same keys — while refusing the attack it would otherwise
+  allow: an endpoint URL is only a capability to *send*, so anyone who obtained
+  one could otherwise re-register it under their own account with their own
+  keys, cutting the victim off and redirecting their notifications. A refused
+  move is `PushError::EndpointClaimed` (`409`).
+- One principal may hold at most `MAX_SUBSCRIPTIONS_PER_PRINCIPAL` (20)
+  subscriptions. Past that, `subscribe` is
+  `PushError::TooManySubscriptions` (`422`). Without a ceiling, one account
+  could make every send unbounded work.
+
+## Fail fast, never silently
+
+The failure this subsystem is built to prevent is an app that starts cleanly,
+happily records subscriptions, and silently never delivers anything.
+
+- A `[push] private_key` that is present but unusable — a typo, an env var that
+  failed to interpolate, an empty string — **fails the boot** with a named
+  error. An app with no `[push]` block at all is unaffected.
+- Declaring `public_key` is optional and exists purely as a safety check: a
+  mismatched pair is caught at boot rather than surfacing as every send being
+  rejected by the push service with no local symptom.
+- Calling `send` with no key configured is a `PushError::NotConfigured`, raised
+  before anything is dispatched. It is never an `Ok` report of zero deliveries.
+- `GET /push/vapid-public-key` answers `503` when push is unconfigured, so the
+  client can tell that apart from "here is your key".
+
+### Pruning
+
+RFC 8030 gives push services `404 Not Found` and `410 Gone` to say a
+subscription no longer exists. Autumn removes those rows and reports them in
+`report.pruned`, so a dead endpoint is never re-sent to.
+
+Every *other* failure — a `5xx` outage, a `429` rate limit, a transport error —
+is counted in `report.failed` and the subscription is **left in place**.
+Pruning on a transient failure would silently unsubscribe every user during an
+incident, unrecoverable without each of them re-granting permission.
+
+## Endpoint safety
+
+The endpoint is a URL supplied by the client that the framework later `POST`s
+to, which makes an unvalidated subscribe route a server-side request forgery
+(SSRF) gadget. Two rules close it at the boundary, before anything is stored:
+
+- The scheme must be `https`, so neither the encrypted body nor the VAPID JWT
+  that authenticates your server crosses a plaintext hop.
+- The host must be a domain name that is not `localhost`. Every real push
+  service publishes a hostname, so refusing IP literals outright is stricter
+  and simpler than enumerating private ranges — `https://169.254.169.254/…`,
+  `https://10.0.0.1/…` and `https://[::1]/…` all fail the same rule.
+
+A hostname that *resolves* to a private address is caught at dispatch time by
+the outbound client's own SSRF address policy.
+
+## Testing
+
+`RecordingPushTransport` records requests instead of sending them, so you can
+assert exactly what would have gone to the push service — and drive the stale
+subscription path without waiting for a real expiry:
+
+```rust
+use autumn_web::push::{
+    MemoryPushSubscriptionStore, PushMessage, RecordingPushTransport, VapidKey, WebPush,
+};
+
+#[tokio::test]
+async fn build_failure_pushes_the_owner() {
+    let transport = RecordingPushTransport::new()
+        // Optional: make one endpoint report itself gone.
+        .responding_with("https://push.example.com/dead", 410);
+
+    let push = WebPush::new(
+        MemoryPushSubscriptionStore::new(),
+        VapidKey::generate(),
+        "mailto:ops@example.com",
+        transport.clone(),
+    );
+
+    let client = TestApp::new()
+        .merge(autumn_web::push::router())
+        .with_web_push(push.clone())
+        .build();
+    client.acting_as(7).await;
+
+    // … subscribe over HTTP, then send …
+
+    let sent = transport.requests();
+    assert_eq!(sent[0].endpoint, "https://push.example.com/live");
+    assert!(sent[0].header("authorization").unwrap().starts_with("vapid t="));
+}
+```
+
+## Payload limits
+
+Push services are only required to accept a 4096-byte encrypted body, which
+leaves 3993 bytes for the JSON payload. Exceeding it is a
+`PushError::PayloadTooLarge` raised **before** any dispatch, rather than N
+identical rejections from the push service. Keep the notification short and put
+the detail behind `.url(…)`.
+
+## What's under the hood
+
+You do not need any of this to use the feature, but for the record:
+
+| Concern | Standard | Where |
+|---|---|---|
+| Application server identity | RFC 8292 (VAPID) | ES256 JWT, `Authorization: vapid t=…, k=…` |
+| Payload encryption | RFC 8291 | ECDH P-256 + HKDF-SHA256 + AES-128-GCM |
+| Body framing | RFC 8188 | `aes128gcm` content coding |
+| Protocol | RFC 8030 | `TTL` header, `404`/`410` semantics |
+
+The encryption is pinned to RFC 8291 §5's own published test vector: fed the
+RFC's inputs, Autumn must reproduce the RFC's output byte-for-byte. That is
+what guarantees the payload actually decrypts in a real browser rather than
+merely round-tripping against Autumn's own code.
+
+Adding Web Push introduced **no new crate** into the dependency graph: `p256`
+was already resolved for `jsonwebtoken`'s ES256 backend, and
+`aes-gcm`/`hmac`/`sha2`/`base64` were already non-optional dependencies.

--- a/docs/guide/web-push.md
+++ b/docs/guide/web-push.md
@@ -275,6 +275,15 @@ happily records subscriptions, and silently never delivers anything.
 - A `[push] private_key` that is present but unusable — a typo, an env var that
   failed to interpolate, an empty string — **fails the boot** with a named
   error. An app with no `[push]` block at all is unaffected.
+- A **blank** `AUTUMN_PUSH__PRIVATE_KEY` is treated as "this secret failed to
+  interpolate", not as "push disabled". Most `AUTUMN_*` overrides clear their
+  setting when set to an empty string; this one deliberately does not, because
+  clearing it would silently disable delivery — and would erase a good key from
+  `autumn.toml` besides.
+- `subject` is validated wherever it comes from. The `[push]` block is checked
+  at boot; a service built by hand and registered with
+  `AppBuilder::with_web_push` is checked on the first `send`, before anything
+  is dispatched, since it never passes through boot validation.
 - Declaring `public_key` is optional and exists purely as a safety check: a
   mismatched pair is caught at boot rather than surfacing as every send being
   rejected by the push service with no local symptom.

--- a/docs/guide/web-push.md
+++ b/docs/guide/web-push.md
@@ -40,7 +40,14 @@ subject     = "mailto:ops@example.com"
 
 Supply `private_key` from an environment variable
 (`AUTUMN_PUSH__PRIVATE_KEY`) or the [encrypted credentials
-store](credentials.md) rather than committing it.
+store](credentials.md) rather than committing it. Every field has an
+environment override: `AUTUMN_PUSH__PUBLIC_KEY`, `AUTUMN_PUSH__SUBJECT`,
+`AUTUMN_PUSH__TTL_SECS`.
+
+`subject` must be a `mailto:` or `https:` URI — RFC 8292 requires it, and it is
+how a push service operator reaches you about your traffic. A bare email
+address is the common mistake and is refused at boot, because otherwise the app
+starts fine and every delivery is rejected remotely.
 
 ### 3. Generate the PWA
 
@@ -302,6 +309,31 @@ to, which makes an unvalidated subscribe route a server-side request forgery
 
 A hostname that *resolves* to a private address is caught at dispatch time by
 the outbound client's own SSRF address policy.
+
+## CSRF
+
+Autumn's CSRF layer rejects an unaccompanied `POST`, and its cookie is
+`HttpOnly` — so the subscribe snippet cannot read a token the usual way. The
+public-key response carries one for it:
+
+| Response header | Carries |
+|---|---|
+| `x-autumn-push-csrf-token` | the caller's CSRF token |
+| `x-autumn-push-csrf-header` | the header name to send it back in |
+
+The generated snippet fetches that endpoint before subscribing anyway, so this
+costs no extra request. Reading the headers requires a **same-origin** fetch —
+a cross-origin attacker cannot see response headers without the app opting in
+via CORS, which is the same property double-submit CSRF already relies on, and
+same-origin script could take a token from any rendered form regardless.
+
+If your app already publishes `<meta name="csrf-token">` (as
+`autumn generate auth` does), the snippet uses that as a fallback.
+
+**Do not exempt `/push/*` from CSRF.** It looks like the easy fix and it is the
+worst one available: a forced subscribe registers the *attacker's* keys under
+the victim's session, letting them decrypt every notification you send that
+user.
 
 ## Testing
 

--- a/docs/guide/web-push.md
+++ b/docs/guide/web-push.md
@@ -382,6 +382,23 @@ async fn build_failure_pushes_the_owner() {
 }
 ```
 
+## Signing out
+
+A subscription that outlives the session that created it is a privacy leak: the
+row stays bound to the user who signed out, so the app keeps pushing their
+notifications to that browser — in front of whoever uses the device next.
+
+The generated snippet handles it. It intercepts any form posting to `/logout`
+(what `autumn generate auth` emits) and unsubscribes first, while the session
+is still valid enough for the server to authorize it. If your sign-out is
+shaped differently, mark it:
+
+```html
+<form action="/session/end" method="post" data-autumn-push-unsubscribe>
+```
+
+A failed unsubscribe never blocks the sign-out itself.
+
 ## Payload limits
 
 Push services are only required to accept a 4096-byte encrypted body, which

--- a/docs/guide/web-push.md
+++ b/docs/guide/web-push.md
@@ -255,7 +255,7 @@ what makes the upsert atomic. Two consequences worth knowing:
   normalized first, so `https://x/p` and `https://x:443/p` can never become two
   rows for one device.
 - Re-subscribing under a *different* principal **moves** the row, but only when
-  the request presents the same `p256dh` the stored row has. That is exactly
+  the request presents **both** stored keys — `p256dh` *and* `auth`. That is exactly
   the shared-device case — a second user signs in, the browser returns the same
   endpoint *and* the same keys — while refusing the attack it would otherwise
   allow: an endpoint URL is only a capability to *send*, so anyone who obtained

--- a/skills/autumn-web/SKILL.md
+++ b/skills/autumn-web/SKILL.md
@@ -1167,6 +1167,49 @@ async fn create_comment(notifications: Notifications) -> AutumnResult<&'static s
 - Guide: `docs/guide/notifications.md`. Out of scope by design: bell widget,
   email/SMS channels, preferences/digests, cross-recipient fan-out.
 
+### Web Push (tab closed)
+
+`autumn_web::push` delivers to a subscribed browser even when the app is
+closed — the leg neither the in-app feed nor `channels` can cover. The
+developer writes **zero** crypto: VAPID signing (RFC 8292) and payload
+encryption (RFC 8291) are the framework's.
+
+- **Setup is three steps:** `VapidKey::generate()` once (offline) → `[push]
+  private_key`/`subject` in `autumn.toml` → `autumn generate pwa` (which mounts
+  `autumn_web::push::router()`, emits the SW `push`/`notificationclick`
+  handlers and the client subscribe snippet, and scaffolds the
+  `push_subscriptions` migration). Then `push.send(user_id,
+  &PushMessage::new(title, body).url(target))`.
+- **`WebPush` is an extractor** (like `Session`/`Db`/`Notifications`):
+  `send`, `send_many`, `subscribe`, `unsubscribe`, `vapid_public_key`.
+- **`PushPrincipal` accepts both id shapes** — `i64` (as the notification feed
+  uses) and `&str`/`String` (as auth tokens carry) — so composing with #1148
+  needs no conversion.
+- **Storage resolution** mirrors the feed's: `with_push_subscription_store(...)`
+  → `DbPushSubscriptionStore` (the generated `push_subscriptions` table) →
+  `MemoryPushSubscriptionStore`. `endpoint` is UNIQUE and the identity: a
+  re-subscribe updates the row, and a re-subscribe under a different principal
+  MOVES it (shared device, second user signs in).
+- **Composing with #1148:** await the `notify(...)` write (durable record),
+  then `push.send(...)` best-effort and log a failure — the same posture
+  `notify_with_push` takes with its channel broadcast. Never let a push failure
+  fail the notification write.
+- **Never a silent no-op:** an unusable `[push] private_key` fails the BOOT;
+  `send` with no key is `PushError::NotConfigured` raised before dispatch;
+  `GET /push/vapid-public-key` answers 503 when unconfigured.
+- **Pruning:** 404/410 removes the subscription (`report.pruned`); 5xx/429/
+  transport errors are counted in `report.failed` and LEFT in place — pruning
+  on a transient failure would unsubscribe everyone during an outage.
+- **Subscribe is an SSRF boundary:** the endpoint is client-supplied and later
+  POSTed to, so it must be `https` with a non-loopback domain host (IP literals
+  refused). The built-in routes resolve the principal server-side and 401 when
+  they cannot; unsubscribe is scoped to the caller.
+- **Testing:** `RecordingPushTransport` captures requests (assert endpoint,
+  headers, encrypted body) and `.responding_with(endpoint, 410)` drives the
+  pruning path. Wire it with `TestApp::with_web_push(...)`.
+- Guide: `docs/guide/web-push.md`. Out of scope by design: native mobile push
+  (APNs/FCM), notification actions/images/badges, preferences/quiet hours.
+
 ## Background work
 
 Use built-in jobs and tasks before reaching for a workflow engine:


### PR DESCRIPTION
Closes #1392.

Autumn already generated an installable PWA (#1149) and stored an in-app notification feed (#1148), but a notification could only ever arrive while the user already had the tab open. This adds the missing leg: the browser subscribes, the app calls `push.send(...)`, and the service worker raises a notification on the device — **with the tab fully closed**. The developer writes **zero** lines of crypto.

```toml
[push]
private_key = "…"                     # mint offline with `VapidKey::generate()`
subject     = "mailto:ops@example.com"
```

```rust
push.send(user.id, &PushMessage::new("Build failed", "main is red").url("/builds/42")).await?;
```

`autumn generate pwa` emits the service worker handlers, the client subscribe snippet, the `push_subscriptions` migration, and the router mount — so that config block plus the `send` call is the entire glue budget.

## What's in it

- **`autumn_web::push`** — VAPID key handling and ES256 JWT signing (RFC 8292), `aes128gcm` payload encryption (RFC 8291), a pluggable `PushSubscriptionStore` (in-memory + Postgres/SQLite), a `PushTransport` seam, and the `WebPush` send API with fan-out.
- **`push::router()`** — built-in `vapid-public-key` / `subscribe` / `unsubscribe` routes that resolve the caller server-side and `401` when they cannot.
- **`autumn generate pwa`** — service worker `push` + `notificationclick` handlers, a client subscribe snippet wired to the framework's own key endpoint, the `push_subscriptions` migration, and the router mount. Idempotent (with `--force`, as every generator), `--dry-run` honored, fully reversed by `autumn destroy pwa`.
- **Docs** — `docs/guide/web-push.md`, including the #1148 composition where the feed write is awaited and the push is best-effort.

**No new crate enters the dependency graph.** `p256` was already resolved for `jsonwebtoken`'s ES256 backend; `aes-gcm`/`hmac`/`sha2`/`base64` were already non-optional. Only a direct edge and p256's `ecdh` feature flag are new.

## The load-bearing test

`matches_the_rfc_8291_published_vector` feeds RFC 8291 §5's own inputs in and requires RFC 8291 §5's own output back, byte for byte. That is what proves the payload actually decrypts in a real browser rather than merely round-tripping against our own code. HKDF is separately pinned to RFC 5869 A.1, and the end-to-end test decrypts a dispatched body back with the receiving user agent's private key — written longhand, not by reusing the sending code — and verifies the VAPID signature against the public half.

## Failure posture

Deliberate, and tested:

- An unusable `[push] private_key` fails the **boot** — including a *blank* `AUTUMN_PUSH__PRIVATE_KEY`, which is preserved and refused rather than clearing the setting, because the commonest cause is a secret that failed to interpolate. Sending with no key is an error raised before any dispatch, never an `Ok` report of zero deliveries.
- `404`/`410` prunes the subscription so a dead endpoint is never re-sent to; a `5xx` or rate limit leaves it in place, because pruning on a transient failure would silently unsubscribe every user during an outage.
- One dead device never blocks a live one — devices are dispatched to concurrently (bounded), and per-device outcomes are reported through `PushDeliveryReport` rather than raised.

## Security

The endpoint is a client-supplied URL the framework later `POST`s to, so it is treated as one:

- The transport resolves the host, refuses any address on the SSRF deny-list, pins the connection to a checked address (closing DNS rebinding), declines redirects (closing `307`-to-internal), and **discards the response body unread** — it needs only the status, so a registered endpoint cannot stream unbounded memory into the process.
- Subscribe-time validation requires `https`, refuses IP-literal and loopback hosts (including the `localhost.` trailing-dot form), normalizes the URL so one device cannot become several rows, and caps its length.
- Moving an endpoint between accounts requires the request to present **both** stored keys — `p256dh` *and* `auth` — enforced in the same SQL statement so it cannot race. `p256dh` alone would not do: it is a public key, so requiring `auth` too means learning an endpoint and its public half still cannot take the row.
- Endpoint URLs are logged by origin only, never echoed back in an error, and the subscription types carry redacting `Debug` impls so a `tracing::debug!(?subscription)` cannot copy a send capability into an app's logs.

## Review history

Nine automated review rounds were answered on this branch, on top of four independent pre-PR review passes (security/crypto, API design, generator, test coverage). The most serious findings, all fixed here:

- A **deadlock in the `WebPush` extractor** — `extension_or_insert_with` holds the extensions write lock while calling its closure, and resolving the service reads other extensions off the same state, so any app declaring `WebPush` without registering one would have hung the request. Two integration tests take that default path specifically to guard it.
- Unbounded outbound response buffering, a blank env override silently disabling push, a sign-out hook that left the logout button dead, and a sign-out hook that revoked a `PushSubscription` shared with another signed-in account.

The review budget agreed for this PR (3 rounds, extended to 5 for genuine P1s) is spent. Seven remaining findings are tracked in **#2336** rather than pushed here, so the PR stops moving under the reviewer; the exceptions I continued to fix are argued individually in the comments.

## Also fixed

`cargo test --workspace` aborted with a stack overflow before ~5,600 `autumn-cli` tests could run: clap's derive macro expands the whole CLI into one `augment_args` frame that, unoptimized, exceeds the 2 MiB stack libtest gives a test thread. A workspace `.cargo/config.toml` sets `RUST_MIN_STACK`, so the fix travels with the code rather than living in a CI environment variable.

## Verification

- `cargo clippy --workspace --all-targets -- -D warnings` — clean, exit 0.
- `./scripts/check-docs.sh` — clean (it reproduces the CI `Documentation build` job exactly).
- `cargo test --workspace --doc` — clean.
- 115 push unit tests, 28 push integration tests, 78 pwa generator tests, plus the 78 existing `http_client` tests to confirm the new `discard_response_body` builder flag leaves the shared client untouched. Seven Postgres testcontainer tests are `#[ignore]`d in the house pattern and are swept automatically by CI's Docker step.

Additive throughout: a new `[push]` block, a new `push_subscriptions` table, new public API. No existing `autumn-web` surface changed, and the version is deliberately left at `0.7.0` with a `## [Unreleased]` entry per `CLAUDE.md`.

## Out of scope (by design)

Native mobile push (APNs/FCM device tokens), notification actions/images/badges, and per-user preferences or quiet hours.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XNrTdqNn4zh2iW1aJZubZc

---
_Generated by [Claude Code](https://claude.ai/code/session_01XNrTdqNn4zh2iW1aJZubZc)_