### PR TITLE
Reconcile framework-owned scaffold files across releases (#1593)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,7 +59,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and exits `3` when anything has drifted, so CI can gate on scaffold freshness
   (`1` still means the apply step died partway, and a deliberately deleted file
   does not hold the gate red forever). It prints verdicts without the per-file
-  diffs, so a CI log does not accumulate the working contents of `autumn.toml`. Every report ends with a link to that
+  diffs, so a CI log does not accumulate the working contents of `autumn.toml`.
+  `autumn upgrade --accept <path>` records a file as yours for good, so a team
+  whose `Dockerfile` is deliberately theirs can still hold a green gate rather
+  than deleting it. A crate inside a Cargo workspace is not offered the files
+  that workspace owns at its root — a crate-local `clippy.toml` shadows the
+  workspace's rather than adding to it. Every report ends with a link to that
   release's migration guide, so file reconciliation and API migration are one
   workflow. `--json` carries the whole thing under a `scaffold` key.
   [`docs/guide/upgrading.md`](docs/guide/upgrading.md) covers the workflow end

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,10 +43,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   reconciler render from one shared function, so what the scaffold writes and
   what the upgrade considers current cannot drift apart.
 
+  Nothing that cannot be read is ever written: a framework-owned path that is a
+  symlink, a directory, or not UTF-8 is reported as a conflict and left exactly
+  as it is, rather than being mistaken for a missing file and truncated —
+  which matters most for the projects with no manifest, where nothing else
+  vouches for the file. Writes go through a temporary file in the same
+  directory and are renamed into place, keeping the original's permissions, so
+  an interrupted apply cannot leave a half-written `Dockerfile`. The project
+  name is read from `[package] name` and validated, never guessed from the
+  directory: it is interpolated into `autumn.toml`, the CI workflow and the
+  `Dockerfile`'s `CMD`, so a guessed name would render a different scaffold and
+  rewrite files that had not actually drifted.
+
   New: `autumn upgrade --check` reconciles the scaffold files, writes nothing,
   and exits `3` when anything has drifted, so CI can gate on scaffold freshness
   (`1` still means the apply step died partway, and a deliberately deleted file
-  does not hold the gate red forever). Every report ends with a link to that
+  does not hold the gate red forever). It prints verdicts without the per-file
+  diffs, so a CI log does not accumulate the working contents of `autumn.toml`. Every report ends with a link to that
   release's migration guide, so file reconciliation and API migration are one
   workflow. `--json` carries the whole thing under a `scaffold` key.
   [`docs/guide/upgrading.md`](docs/guide/upgrading.md) covers the workflow end

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,51 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`autumn upgrade` now reconciles framework-owned scaffold files, not just
+  app code (#1593):** `autumn new` writes about a dozen framework-owned files
+  into every project — `Dockerfile`, `.dockerignore`, `build.rs`, `autumn.toml`,
+  `tailwind.config.js`, `rust-toolchain.toml`, `clippy.toml`, `rustfmt.toml`,
+  the CI workflow, `static/css/input.css` — and those templates keep evolving,
+  but bumping `autumn-web` in `Cargo.toml` updates the library, not the project
+  skeleton. An app scaffolded on 0.5 therefore kept 0.5-vintage project files
+  forever, and the only remedy was diffing a freshly generated throwaway project
+  by hand. `autumn upgrade` now renders the current release's scaffold in memory
+  and reports a per-file verdict alongside the existing codemod report: `add`
+  for a file a later release introduced (a pre-#1492 app is offered
+  `rust-toolchain.toml`), `update` for one whose template moved while your copy
+  stayed untouched, `conflict` for one you edited, and `removed` for one you
+  deleted on purpose. Preview stays the default; `--apply` writes the additions
+  and updates and never a conflict.
+
+  Knowing which files you edited needs a baseline, so `autumn new` now records
+  one: `.autumn/scaffold.toml` holds the release that scaffolded the project,
+  the flags it was created with, and a digest of every framework-owned file as
+  Autumn wrote it. Commit it — its value is being the baseline a later checkout
+  compares against. Projects created before this feature have no manifest and
+  are handled best-effort rather than refused: missing files are still offered,
+  and everything that differs is a conflict for review, because "untouched"
+  cannot be proven. Digests are taken over LF-normalised text, so a
+  `core.autocrlf` checkout on Windows is not mistaken for a rewrite of every
+  file.
+
+  Application source is out of bounds throughout: the command never reads,
+  writes, or names a path under `src/`, and `Cargo.toml`, `README.md`,
+  `tests/`, `migrations/`, `i18n/`, `config/credentials/` and the vendored
+  `static/js/` assets are not framework-owned either. `autumn new` and the
+  reconciler render from one shared function, so what the scaffold writes and
+  what the upgrade considers current cannot drift apart.
+
+  New: `autumn upgrade --check` reconciles the scaffold files, writes nothing,
+  and exits `3` when anything has drifted, so CI can gate on scaffold freshness
+  (`1` still means the apply step died partway, and a deliberately deleted file
+  does not hold the gate red forever). Every report ends with a link to that
+  release's migration guide, so file reconciliation and API migration are one
+  workflow. `--json` carries the whole thing under a `scaffold` key.
+  [`docs/guide/upgrading.md`](docs/guide/upgrading.md) covers the workflow end
+  to end, including the `git diff` / `git checkout --` revert path.
+
 ### Fixed
 
 - **CSV import row numbers are now the same for CRLF and LF files:**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,9 +47,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   symlink, a directory, or not UTF-8 is reported as a conflict and left exactly
   as it is, rather than being mistaken for a missing file and truncated —
   which matters most for the projects with no manifest, where nothing else
-  vouches for the file. Writes go through a temporary file in the same
-  directory and are renamed into place, keeping the original's permissions, so
-  an interrupted apply cannot leave a half-written `Dockerfile`. The project
+  vouches for the file. Every write is staged in the same directory and
+  renamed into place, so an interrupted apply cannot leave a half-written
+  `Dockerfile` or a truncated new file — which would be permanent, since a file
+  with no recorded baseline is a conflict the command then refuses to repair.
+  An updated file keeps its permissions; an added one lands with the mode
+  `autumn new` would have given it. The project
   name is read from `[package] name` and validated, never guessed from the
   directory: it is interpolated into `autumn.toml`, the CI workflow and the
   `Dockerfile`'s `CMD`, so a guessed name would render a different scaffold and

--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ See [EXAMPLES.md](EXAMPLES.md) for the full catalog with personas, journeys, pre
 - [API Reference](https://docs.rs/autumn-web)
 - [Pre-rendering Design Notes](docs/design/hybrid-rendering.md)
 - [Stability Policy](STABILITY.md) — SemVer, MSRV, and migration commitments
-- [Upgrading](docs/guide/upgrading.md) — `autumn upgrade` applies each release's mechanical API migrations to your own code after showing you the diff; everything it cannot safely rewrite is listed with `file:line` and a guide link
+- [Upgrading](docs/guide/upgrading.md) — `autumn upgrade` applies each release's mechanical API migrations to your own code **and** reconciles your project's framework-owned scaffold files (`Dockerfile`, `build.rs`, CI workflow, toolchain configs) against the current release, after showing you the diff; files you edited are flagged as conflicts rather than overwritten, `--check` exits nonzero on drift for CI, and everything it cannot safely rewrite is listed with `file:line` and a guide link
 - [Transition effects](docs/guide/transition-effects.md) — per-edge `on` / `on_commit` side effects on `#[state_machine]` transitions.
 - [Counter Caches](docs/guide/counter-cache.md) — `#[belongs_to(Post, counter_cache)]` keeps `posts.comment_count` current atomically, in the same transaction, with an idempotent `recompute` for drift
 - [Votes, Likes and Reactions](docs/guide/votable.md) — `#[votable(by = ..., aggregate = sum|count)]`, the race-safe `react()` / `reaction_of()` helpers, and the no-JS `reaction_controls` widget

--- a/autumn-cli/src/main.rs
+++ b/autumn-cli/src/main.rs
@@ -267,6 +267,7 @@ struct Cli {
 /// that a codegen difference between two rustc builds decides whether the
 /// argument-parsing tests overflow. An `Args` struct moves this command's share
 /// into `UpgradeArgs::augment_args`, which gets its own frame and pops.
+#[allow(clippy::struct_excessive_bools)]
 #[derive(clap::Args, Debug)]
 struct UpgradeArgs {
     /// Project directory to migrate (defaults to the current directory).
@@ -288,6 +289,10 @@ struct UpgradeArgs {
     /// List the shipped app-code migrations and exit without scanning.
     #[arg(long = "list-migrations")]
     list_migrations: bool,
+    /// Report framework-owned scaffold files that have drifted from this
+    /// release and exit 3 if any have. Writes nothing; for CI.
+    #[arg(long, conflicts_with = "apply")]
+    check: bool,
 }
 
 /// Available subcommands.
@@ -414,17 +419,23 @@ enum Commands {
         #[command(subcommand)]
         action: AssetsCommands,
     },
-    /// Apply a release's mechanical app-code migrations to your own source.
+    /// Bring an app up to a release: its own code, and its scaffold files.
     ///
     /// For each release between the `autumn-web` version this app records and
     /// the target, `autumn upgrade` applies that release's machine-applyable
-    /// migrations -- today, API renames -- to the app's own Rust code.
+    /// migrations -- today, API renames -- to the app's own Rust code. In the
+    /// same run it reconciles the project's framework-owned files (Dockerfile,
+    /// build.rs, autumn.toml, the toolchain/style configs, the CI workflow)
+    /// against the current release's scaffold. Application source under src/ is
+    /// out of bounds for that half.
     ///
     /// It writes nothing by default: a bare `autumn upgrade` prints a per-file
     /// diff plus a count of affected sites, and `--apply` is the explicit write
     /// step. Anything it cannot safely rewrite (a call site inside a macro
     /// invocation, or a change with no mechanical form) is listed with its
-    /// location and a link to the guide section, never guessed at.
+    /// location and a link to the guide section, never guessed at. A scaffold
+    /// file you have edited since it was generated is reported as a conflict
+    /// with its diff, never overwritten.
     ///
     /// Run it BEFORE bumping the `autumn-web` dependency: the release it
     /// migrates *from* is the one the project manifest records. If the bump
@@ -432,6 +443,7 @@ enum Commands {
     ///
     ///   autumn upgrade                     # preview
     ///   autumn upgrade --apply             # write the rewrites
+    ///   autumn upgrade --check             # CI gate: exit 3 on scaffold drift
     ///   autumn upgrade --list-migrations   # what ships today
     #[allow(clippy::doc_markdown)]
     #[command(verbatim_doc_comment)]
@@ -3711,6 +3723,7 @@ fn run_command(command: Commands) {
             apply,
             json,
             list_migrations,
+            check,
         }) => {
             let code = upgrade::run_in(
                 std::path::Path::new(&path),
@@ -3720,6 +3733,7 @@ fn run_command(command: Commands) {
                     apply,
                     json,
                     list: list_migrations,
+                    check,
                 },
             );
             std::process::exit(code);

--- a/autumn-cli/src/main.rs
+++ b/autumn-cli/src/main.rs
@@ -293,6 +293,10 @@ struct UpgradeArgs {
     /// release and exit 3 if any have. Writes nothing; for CI.
     #[arg(long, conflicts_with = "apply")]
     check: bool,
+    /// Record a framework-owned file as yours, so reconciliation leaves it
+    /// alone from now on. Repeatable. Writes only the provenance manifest.
+    #[arg(long, value_name = "PATH", conflicts_with_all = ["apply", "check"])]
+    accept: Vec<String>,
 }
 
 /// Available subcommands.
@@ -444,6 +448,7 @@ enum Commands {
     ///   autumn upgrade                     # preview
     ///   autumn upgrade --apply             # write the rewrites
     ///   autumn upgrade --check             # CI gate: exit 3 on scaffold drift
+    ///   autumn upgrade --accept Dockerfile # this file is mine; stop offering it
     ///   autumn upgrade --list-migrations   # what ships today
     #[allow(clippy::doc_markdown)]
     #[command(verbatim_doc_comment)]
@@ -3724,6 +3729,7 @@ fn run_command(command: Commands) {
             json,
             list_migrations,
             check,
+            accept,
         }) => {
             let code = upgrade::run_in(
                 std::path::Path::new(&path),
@@ -3734,6 +3740,7 @@ fn run_command(command: Commands) {
                     json,
                     list: list_migrations,
                     check,
+                    accept,
                 },
             );
             std::process::exit(code);

--- a/autumn-cli/src/new.rs
+++ b/autumn-cli/src/new.rs
@@ -140,7 +140,7 @@ pub fn generate(name: &str, parent_dir: &Path) -> Result<(), NewError> {
 }
 
 /// Reject unsupported flag combinations before any files are written.
-fn check_option_combination(opts: GenerateOptions) -> Result<(), NewError> {
+pub fn check_option_combination(opts: GenerateOptions) -> Result<(), NewError> {
     // The API flavor and the daemon flavors are different app shapes with
     // conflicting `autumn-web` feature sets: `--api` drops the view stack
     // (maud/htmx/tailwind) for a pure-JSON app, while `--daemon`/`--bundled-pg`

--- a/autumn-cli/src/new.rs
+++ b/autumn-cli/src/new.rs
@@ -542,6 +542,10 @@ fn print_scaffold_summary(name: &str, opts: GenerateOptions) {
     println!("  Created {name}/tests/integration_test.rs");
     println!("  Created {name}/config/master.key (keep secret — never commit)");
     println!("  Created {name}/config/credentials/development.toml.enc");
+    // Named with its purpose attached: it is the only generated file whose
+    // value depends entirely on being committed, and the only one a developer
+    // would otherwise be tempted to gitignore as machine bookkeeping.
+    println!("  Created {name}/.autumn/scaffold.toml (commit it — `autumn upgrade` reads it)");
     if opts.with_i18n {
         println!("  Created {name}/i18n/en.ftl");
     }

--- a/autumn-cli/src/new.rs
+++ b/autumn-cli/src/new.rs
@@ -2850,7 +2850,7 @@ mod tests {
 
         assert!(root.join(MANIFEST_PATH).is_file(), "no scaffold manifest");
         let manifest = Manifest::load(&root).expect("manifest parses");
-        assert_eq!(manifest.version, env!("CARGO_PKG_VERSION"));
+        assert_eq!(manifest.version.as_deref(), Some(env!("CARGO_PKG_VERSION")));
         assert_eq!(manifest.options, GenerateOptions::default());
         // Every framework-owned file it just wrote has a baseline digest.
         for path in framework_owned_files(

--- a/autumn-cli/src/new.rs
+++ b/autumn-cli/src/new.rs
@@ -2,13 +2,14 @@
 //!
 //! Generates a complete Autumn project directory from embedded templates.
 
+use std::collections::BTreeMap;
 use std::fs;
 use std::io::Write;
 use std::path::Path;
 
 use autumn_web::credentials::{MasterKey, encrypt};
 
-mod templates {
+pub mod templates {
     pub const CARGO_TOML: &str = include_str!("templates/Cargo.toml.tmpl");
     /// JSON-first API flavor (`autumn new --api`): drops the HTML/CSS view
     /// stack (`maud`) and disables `autumn-web`'s default view features.
@@ -279,6 +280,79 @@ fn generate_inner(
     }
     fs::write(project_dir.join("src/main.rs"), main_rs)?;
 
+    // Every framework-owned file comes from one renderer, shared with `autumn
+    // upgrade`'s scaffold reconciliation (issue #1593). Writing them from a
+    // second, parallel code path here is how the two would silently disagree —
+    // and a byte of disagreement reads to the reconciler as a permanent
+    // conflict in every project ever generated.
+    let owned = framework_owned_files(&vars, opts);
+    for (relative, contents) in &owned {
+        fs::write(project_dir.join(relative), contents)?;
+    }
+    // Record what this release wrote, so a later `autumn upgrade` can tell a
+    // template that moved from a file the developer edited (issue #1593). Best
+    // effort by design: the manifest only ever *sharpens* a later upgrade, and
+    // failing a scaffold over bookkeeping would be a worse trade than losing
+    // conflict precision.
+    let _ = crate::upgrade::scaffold::Manifest::for_files(autumn_version, opts, &owned)
+        .save(&project_dir);
+    fs::write(project_dir.join("migrations/.gitkeep"), "")?;
+
+    // The API flavor serves no HTML, so it needs no vendored htmx/SSE JS or the
+    // static asset manifest — skip the whole `static/` vendoring step.
+    if !opts.with_api {
+        scaffold_vendor_assets(&project_dir)?;
+    }
+    scaffold_credentials(&project_dir, name)?;
+    fs::write(
+        project_dir.join("tests/integration_test.rs"),
+        render(templates::INTEGRATION_TEST),
+    )?;
+
+    write_optional_scaffold_files(&project_dir, name, opts, &render)?;
+
+    if !quiet {
+        print_scaffold_summary(name, opts);
+    }
+
+    Ok(())
+}
+
+/// Every framework-owned file `autumn new` writes outside the application's own
+/// source, rendered for `opts`.
+///
+/// This is the single definition of "what the current release's scaffold looks
+/// like". [`generate_inner`] writes these files, and `autumn upgrade`'s
+/// scaffold reconciliation (issue #1593) compares an existing project against
+/// exactly the same rendering — so the two cannot drift apart, which is the one
+/// bug that would make the reconciler report a conflict in every project on
+/// earth.
+///
+/// # What is *not* here
+///
+/// The set is an allowlist, not "everything `autumn new` writes", and two
+/// exclusions are load bearing:
+///
+/// - **`src/**`.** Application source is out of bounds for the reconciler
+///   (issue #1593); `src/main.rs` and the optional seed binary are the app's,
+///   not the framework's, the moment the project exists. Enforced by the
+///   assertion below, not just by convention.
+/// - **Files the framework generates but does not own thereafter**:
+///   `Cargo.toml` (the app's dependencies), `README.md` (the app's prose),
+///   `tests/`, `migrations/`, `i18n/`, `config/credentials/` (secrets), and the
+///   vendored `static/js/` assets, which `autumn assets` — not this — keeps
+///   current.
+///
+/// Keys are project-relative and always `/`-separated, so they are equally
+/// valid as `Path` joins and as the keys of the provenance manifest on every
+/// host.
+#[must_use]
+pub fn framework_owned_files(
+    vars: &TemplateVars<'_>,
+    opts: GenerateOptions,
+) -> BTreeMap<&'static str, String> {
+    let render = |template: &str| -> String { render_template(template, vars) };
+
     let mut autumn_toml = if opts.with_i18n {
         let mut s = render(templates::AUTUMN_TOML);
         s.push_str("\n[i18n]\ndefault_locale = \"en\"\nsupported_locales = [\"en\"]\n");
@@ -307,7 +381,7 @@ fn generate_inner(
              auto_migrate_in_production = true\n",
         );
     }
-    fs::write(project_dir.join("autumn.toml"), autumn_toml)?;
+
     let dockerfile = if opts.with_api {
         // The `--api` Dockerfile carries i18n `COPY` anchors resolved by flag:
         // ship the `i18n/` sidecar into the image for `--with-i18n`, or strip
@@ -321,69 +395,42 @@ fn generate_inner(
         // still builds.
         inject_i18n_dockerfile(&render(templates::DOCKERFILE), opts.with_i18n)
     };
-    fs::write(project_dir.join("Dockerfile"), dockerfile)?;
-    fs::write(
-        project_dir.join(".dockerignore"),
-        render(templates::DOCKERIGNORE),
-    )?;
-    let build_rs_template = if opts.with_api {
-        templates::BUILD_API_RS
-    } else {
-        templates::BUILD_RS
-    };
-    fs::write(project_dir.join("build.rs"), render(build_rs_template))?;
-    // The API flavor has no Tailwind/CSS pipeline, so skip the CSS input and
-    // Tailwind config entirely (there is no `static/css` directory either).
-    if !opts.with_api {
-        fs::write(
-            project_dir.join("static/css/input.css"),
-            render(templates::INPUT_CSS),
-        )?;
-        fs::write(
-            project_dir.join("tailwind.config.js"),
-            render(templates::TAILWIND_CONFIG),
-        )?;
-    }
-    fs::write(project_dir.join(".gitignore"), render(templates::GITIGNORE))?;
-    fs::write(
-        project_dir.join(".env.example"),
-        render(templates::ENV_EXAMPLE),
-    )?;
-    fs::write(project_dir.join("migrations/.gitkeep"), "")?;
 
-    // The API flavor serves no HTML, so it needs no vendored htmx/SSE JS or the
-    // static asset manifest — skip the whole `static/` vendoring step.
-    if !opts.with_api {
-        scaffold_vendor_assets(&project_dir)?;
-    }
-    scaffold_credentials(&project_dir, name)?;
-    fs::write(
-        project_dir.join("tests/integration_test.rs"),
-        render(templates::INTEGRATION_TEST),
-    )?;
-    // Bind the path so the write fits on one line: a multi-line
-    // `fs::write(...)?` leaves the `?` error-propagation region on a bare
-    // `)?;` line that passing tests never hit, which llvm-cov reports as an
-    // uncovered line (as it does for the multi-line writes above).
-    let ci_workflow = project_dir.join(".github/workflows/ci.yml");
+    let build_rs = if opts.with_api {
+        render(templates::BUILD_API_RS)
+    } else {
+        render(templates::BUILD_RS)
+    };
+
     let ci_yml = if opts.with_api {
         strip_ci_tailwind_note(&render(templates::CI_WORKFLOW))
     } else {
         render(templates::CI_WORKFLOW)
     };
-    fs::write(ci_workflow, ci_yml)?;
-    let rust_toolchain = project_dir.join("rust-toolchain.toml");
-    fs::write(rust_toolchain, render(templates::RUST_TOOLCHAIN))?;
-    fs::write(project_dir.join("rustfmt.toml"), render(templates::RUSTFMT))?;
-    fs::write(project_dir.join("clippy.toml"), render(templates::CLIPPY))?;
 
-    write_optional_scaffold_files(&project_dir, name, opts, &render)?;
-
-    if !quiet {
-        print_scaffold_summary(name, opts);
+    let mut files = BTreeMap::new();
+    files.insert("autumn.toml", autumn_toml);
+    files.insert("Dockerfile", dockerfile);
+    files.insert(".dockerignore", render(templates::DOCKERIGNORE));
+    files.insert("build.rs", build_rs);
+    files.insert(".gitignore", render(templates::GITIGNORE));
+    files.insert(".env.example", render(templates::ENV_EXAMPLE));
+    files.insert(".github/workflows/ci.yml", ci_yml);
+    files.insert("rust-toolchain.toml", render(templates::RUST_TOOLCHAIN));
+    files.insert("rustfmt.toml", render(templates::RUSTFMT));
+    files.insert("clippy.toml", render(templates::CLIPPY));
+    // The API flavor has no Tailwind/CSS pipeline, so it owns no CSS input and
+    // no Tailwind config (there is no `static/css` directory either).
+    if !opts.with_api {
+        files.insert("tailwind.config.js", render(templates::TAILWIND_CONFIG));
+        files.insert("static/css/input.css", render(templates::INPUT_CSS));
     }
 
-    Ok(())
+    debug_assert!(
+        files.keys().all(|path| !path.starts_with("src/")),
+        "application source is out of bounds for scaffold reconciliation"
+    );
+    files
 }
 
 fn scaffold_vendor_assets(project_dir: &Path) -> Result<(), NewError> {
@@ -2641,5 +2688,223 @@ mod tests {
             !content.contains("/static/js/htmx.min.js"),
             "generated main.rs must not hardcode /static/js/htmx.min.js, got:\n{content}"
         );
+    }
+
+    // --- issue #1593: the framework-owned file set `autumn upgrade` reconciles ---
+
+    fn owned(opts: GenerateOptions) -> std::collections::BTreeMap<&'static str, String> {
+        let vars = TemplateVars {
+            project_name: "demo",
+            crate_name: "demo",
+            autumn_version: "0.7.0",
+            rust_version: "1.88.0",
+        };
+        framework_owned_files(&vars, opts)
+    }
+
+    #[test]
+    fn framework_owned_set_covers_the_fullstack_scaffold() {
+        let files = owned(GenerateOptions::default());
+        for expected in [
+            "autumn.toml",
+            "Dockerfile",
+            ".dockerignore",
+            "build.rs",
+            ".gitignore",
+            ".env.example",
+            ".github/workflows/ci.yml",
+            "rust-toolchain.toml",
+            "rustfmt.toml",
+            "clippy.toml",
+            "tailwind.config.js",
+            "static/css/input.css",
+        ] {
+            assert!(
+                files.contains_key(expected),
+                "missing {expected}: {:?}",
+                files.keys()
+            );
+        }
+    }
+
+    #[test]
+    fn framework_owned_set_never_reaches_into_src() {
+        for opts in [
+            GenerateOptions::default(),
+            GenerateOptions {
+                with_api: true,
+                ..GenerateOptions::default()
+            },
+            GenerateOptions {
+                with_i18n: true,
+                with_seed: true,
+                ..GenerateOptions::default()
+            },
+        ] {
+            for path in owned(opts).keys() {
+                assert!(
+                    !path.starts_with("src/"),
+                    "application source is out of bounds, got {path}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn api_flavor_owns_no_css_or_tailwind() {
+        let files = owned(GenerateOptions {
+            with_api: true,
+            ..GenerateOptions::default()
+        });
+        assert!(
+            !files.contains_key("tailwind.config.js"),
+            "{:?}",
+            files.keys()
+        );
+        assert!(
+            !files.contains_key("static/css/input.css"),
+            "{:?}",
+            files.keys()
+        );
+        // ...but it still owns the common set.
+        assert!(files.contains_key("Dockerfile"));
+        assert!(files.contains_key("build.rs"));
+    }
+
+    #[test]
+    fn api_and_fullstack_render_different_dockerfiles_and_build_scripts() {
+        let full = owned(GenerateOptions::default());
+        let api = owned(GenerateOptions {
+            with_api: true,
+            ..GenerateOptions::default()
+        });
+        assert_ne!(full["Dockerfile"], api["Dockerfile"]);
+        assert_ne!(full["build.rs"], api["build.rs"]);
+    }
+
+    #[test]
+    fn i18n_option_is_reflected_in_the_owned_autumn_toml_and_dockerfile() {
+        let plain = owned(GenerateOptions::default());
+        let i18n = owned(GenerateOptions {
+            with_i18n: true,
+            ..GenerateOptions::default()
+        });
+        assert!(!plain["autumn.toml"].contains("[i18n]"));
+        assert!(i18n["autumn.toml"].contains("[i18n]"));
+        assert_ne!(plain["Dockerfile"], i18n["Dockerfile"]);
+        // The unresolved anchors never survive into a generated file.
+        assert!(!i18n["Dockerfile"].contains("__AUTUMN_I18N_BUILDER_COPY__"));
+        assert!(!plain["Dockerfile"].contains("__AUTUMN_I18N_BUILDER_COPY__"));
+    }
+
+    #[test]
+    fn daemon_and_bundled_pg_options_reach_the_owned_autumn_toml() {
+        let daemon = owned(GenerateOptions {
+            with_daemon: true,
+            ..GenerateOptions::default()
+        });
+        assert!(
+            daemon["autumn.toml"].contains("uses no database"),
+            "{}",
+            daemon["autumn.toml"]
+        );
+        let bundled = owned(GenerateOptions {
+            with_daemon: true,
+            with_bundled_pg: true,
+            ..GenerateOptions::default()
+        });
+        assert!(
+            bundled["autumn.toml"].contains("auto_migrate_in_production = true"),
+            "{}",
+            bundled["autumn.toml"]
+        );
+    }
+
+    #[test]
+    fn generated_project_files_match_the_framework_owned_rendering() {
+        // The reconciler compares a project against `framework_owned_files`, so
+        // a byte that `autumn new` writes differently is a permanent phantom
+        // conflict. One renderer, one truth.
+        let tmp = TempDir::new().unwrap();
+        generate("owned-app", tmp.path()).unwrap();
+        let vars = TemplateVars {
+            project_name: "owned-app",
+            crate_name: "owned_app",
+            autumn_version: env!("CARGO_PKG_VERSION"),
+            rust_version: option_env!("CARGO_PKG_RUST_VERSION").unwrap_or("1.88.0"),
+        };
+        for (path, expected) in framework_owned_files(&vars, GenerateOptions::default()) {
+            let actual = fs::read_to_string(tmp.path().join("owned-app").join(path))
+                .unwrap_or_else(|e| panic!("{path} was not scaffolded: {e}"));
+            assert_eq!(actual, expected, "{path} drifted from its rendering");
+        }
+    }
+
+    #[test]
+    fn a_new_project_records_the_release_that_scaffolded_it() {
+        use crate::upgrade::scaffold::{MANIFEST_PATH, Manifest};
+
+        let tmp = TempDir::new().unwrap();
+        generate("provenance-app", tmp.path()).unwrap();
+        let root = tmp.path().join("provenance-app");
+
+        assert!(root.join(MANIFEST_PATH).is_file(), "no scaffold manifest");
+        let manifest = Manifest::load(&root).expect("manifest parses");
+        assert_eq!(manifest.version, env!("CARGO_PKG_VERSION"));
+        assert_eq!(manifest.options, GenerateOptions::default());
+        // Every framework-owned file it just wrote has a baseline digest.
+        for path in framework_owned_files(
+            &TemplateVars {
+                project_name: "provenance-app",
+                crate_name: "provenance_app",
+                autumn_version: env!("CARGO_PKG_VERSION"),
+                rust_version: option_env!("CARGO_PKG_RUST_VERSION").unwrap_or("1.88.0"),
+            },
+            GenerateOptions::default(),
+        )
+        .keys()
+        {
+            assert!(
+                manifest.digests.contains_key(*path),
+                "no baseline recorded for {path}"
+            );
+        }
+    }
+
+    #[test]
+    fn the_recorded_manifest_records_the_options_the_project_was_made_with() {
+        use crate::upgrade::scaffold::Manifest;
+
+        let tmp = TempDir::new().unwrap();
+        let opts = GenerateOptions {
+            with_api: true,
+            with_i18n: true,
+            ..GenerateOptions::default()
+        };
+        generate_with("api-provenance", tmp.path(), opts).unwrap();
+        let manifest = Manifest::load(&tmp.path().join("api-provenance")).unwrap();
+        assert_eq!(manifest.options, opts);
+    }
+
+    #[test]
+    fn a_new_project_reports_no_scaffold_drift() {
+        // The tightest guarantee available: what `autumn new` writes today is
+        // exactly what `autumn upgrade` calls current.
+        use crate::upgrade::scaffold;
+
+        let tmp = TempDir::new().unwrap();
+        generate("fresh-app", tmp.path()).unwrap();
+        let report = scaffold::plan(&tmp.path().join("fresh-app"), env!("CARGO_PKG_VERSION"));
+        assert!(!report.drifted(), "{}", scaffold::render_text(&report));
+    }
+
+    #[test]
+    fn the_scaffold_manifest_is_committed_not_ignored() {
+        // A manifest that git ignores is a manifest that never reaches the
+        // next checkout, which is the only place it has any value.
+        let tmp = TempDir::new().unwrap();
+        generate("committed-app", tmp.path()).unwrap();
+        let gitignore = fs::read_to_string(tmp.path().join("committed-app/.gitignore")).unwrap();
+        assert!(!gitignore.contains(".autumn"), "{gitignore}");
     }
 }

--- a/autumn-cli/src/upgrade/mod.rs
+++ b/autumn-cli/src/upgrade/mod.rs
@@ -1498,10 +1498,22 @@ fn check_scaffold(root: &Path, target: &str, json: bool) -> i32 {
     } else {
         print!("{}", scaffold::render_summary(&report));
     }
-    // A refusal to answer is not an all-clear. Without a usable `[package]
-    // name` the scaffold cannot be rendered, so there is no verdict — and a
+    // A refusal to answer is not an all-clear, whatever the reason for it — a
     // gate that goes green because the tool could not look is worse than no
-    // gate at all.
+    // gate at all. This project's files were written by a release newer than
+    // this CLI, so reconciling them would mean downgrading them.
+    if let Some(newer) = &report.scaffolded_by_newer {
+        eprintln!(
+            "autumn upgrade: `{}` was scaffolded by autumn-cli {newer}, newer than this one \
+             ({}).\n\
+             Nothing was checked: reconciling would downgrade its files. Install {newer} or later.",
+            root.display(),
+            env!("CARGO_PKG_VERSION")
+        );
+        return 2;
+    }
+    // Without a usable `[package] name` the scaffold cannot be rendered, so
+    // there is no verdict either.
     if !report.named {
         eprintln!(
             "autumn upgrade: `{}` has no usable `[package] name` in Cargo.toml, and the\n\

--- a/autumn-cli/src/upgrade/mod.rs
+++ b/autumn-cli/src/upgrade/mod.rs
@@ -1395,6 +1395,18 @@ fn check_scaffold(root: &Path, target: &str, json: bool) -> i32 {
     } else {
         print!("{}", scaffold::render_summary(&report));
     }
+    // A refusal to answer is not an all-clear. Without a usable `[package]
+    // name` the scaffold cannot be rendered, so there is no verdict — and a
+    // gate that goes green because the tool could not look is worse than no
+    // gate at all.
+    if !report.named {
+        eprintln!(
+            "autumn upgrade: `{}` has no usable `[package] name` in Cargo.toml, and the\n\
+             scaffold interpolates it. Nothing was checked.",
+            root.display()
+        );
+        return 2;
+    }
     if report.drifted() { DRIFT_EXIT_CODE } else { 0 }
 }
 

--- a/autumn-cli/src/upgrade/mod.rs
+++ b/autumn-cli/src/upgrade/mod.rs
@@ -1393,7 +1393,7 @@ fn check_scaffold(root: &Path, target: &str, json: bool) -> i32 {
                 .unwrap_or_else(|_| "{}".to_owned())
         );
     } else {
-        print!("{}", scaffold::render_text(&report));
+        print!("{}", scaffold::render_summary(&report));
     }
     if report.drifted() { DRIFT_EXIT_CODE } else { 0 }
 }

--- a/autumn-cli/src/upgrade/mod.rs
+++ b/autumn-cli/src/upgrade/mod.rs
@@ -1402,7 +1402,7 @@ fn reject_bad_combination(opts: &UpgradeOptions) -> Option<i32> {
 }
 
 /// Record framework-owned paths as the developer's own (issue #1593).
-fn accept_scaffold(root: &Path, paths: &[String]) -> i32 {
+fn accept_scaffold(root: &Path, paths: &[String], json: bool) -> i32 {
     if !scaffold::is_project(root) {
         eprintln!(
             "autumn upgrade: `{}` is not an Autumn project (no `autumn.toml`).",
@@ -1412,6 +1412,21 @@ fn accept_scaffold(root: &Path, paths: &[String]) -> i32 {
     }
     match scaffold::accept(root, paths) {
         Ok(manifest) => {
+            // `--json` is the machine-readable mode for the whole command, so
+            // this branch cannot be the one that prints prose onto a stdout a
+            // caller is parsing.
+            if json {
+                println!(
+                    "{}",
+                    serde_json::to_string_pretty(&serde_json::json!({
+                        "accepted": paths,
+                        "pinned": manifest.pinned,
+                        "manifest": scaffold::MANIFEST_PATH,
+                    }))
+                    .unwrap_or_else(|_| "{}".to_owned())
+                );
+                return 0;
+            }
             println!(
                 "Accepted as yours; `autumn upgrade` will leave {} alone:",
                 if paths.len() == 1 { "it" } else { "them" }
@@ -1424,7 +1439,6 @@ fn accept_scaffold(root: &Path, paths: &[String]) -> i32 {
                  under reconciliation.",
                 scaffold::MANIFEST_PATH
             );
-            let _ = manifest;
             0
         }
         Err(error) => {
@@ -1568,7 +1582,7 @@ pub fn run_in(root: &Path, opts: &UpgradeOptions) -> i32 {
     // against the `autumn-web` requirement, so a project whose manifest Cargo
     // cannot give a single floor for can still be gated on scaffold freshness.
     if !opts.accept.is_empty() {
-        return accept_scaffold(root, &opts.accept);
+        return accept_scaffold(root, &opts.accept, opts.json);
     }
 
     if opts.check {

--- a/autumn-cli/src/upgrade/mod.rs
+++ b/autumn-cli/src/upgrade/mod.rs
@@ -1,18 +1,23 @@
-//! `autumn upgrade` — apply each release's mechanical app-code migrations
-//! (issue #1629).
+//! `autumn upgrade` — bring an app up to a release: its own code, and its
+//! framework-owned project files (issues #1629 and #1593).
 //!
 //! Autumn ships every 2-4 weeks and, pre-1.0, most releases can break existing
-//! apps. Issue #1588 made a written migration guide a release gate, and #1593
-//! reconciles framework-owned scaffold files — but both leave the user's own
-//! Rust code out of bounds, so a purely mechanical rename like 0.6.0's
-//! `with_pool` -> `with_pool_untracked` still had to be hand-applied call site
-//! by call site from prose.
+//! apps. Issue #1588 made a written migration guide a release gate, but prose
+//! left both halves of the actual work by hand: a purely mechanical rename like
+//! 0.6.0's `with_pool` -> `with_pool_untracked` had to be applied call site by
+//! call site, and the project skeleton `autumn new` wrote — `Dockerfile`,
+//! `build.rs`, `autumn.toml`, the toolchain configs — stayed frozen at whatever
+//! release scaffolded it, because bumping `autumn-web` updates the library, not
+//! the project.
 //!
-//! This command closes that half. For each release between the app's recorded
+//! This command closes both. For each release between the app's recorded
 //! `autumn-web` version and the target, it applies that release's
 //! machine-applyable migrations (see [`migrations`]) to the app's own source,
 //! and reports everything it could not safely rewrite with `file:line` and a
-//! guide link rather than guessing.
+//! guide link rather than guessing. In the same run it reconciles the
+//! framework-owned project files against the current release's scaffold (see
+//! [`scaffold`]), which never touches `src/` and never overwrites a file the
+//! developer edited.
 //!
 //! # Safety posture
 //!
@@ -28,12 +33,14 @@
 //! - **Nothing silent.** A site the engine declines to rewrite (inside a macro
 //!   invocation or an attribute) is listed under `manual` with its location.
 //!
-//! `autumn upgrade` is also where #1593's scaffold reconciliation lands when it
-//! ships; this slice is the app-code step only.
+//! The same posture governs the scaffold half, one step further: a file whose
+//! bytes no longer match the digest [`crate::new`] recorded when it wrote them
+//! is a *conflict*, reported with its diff and never written.
 
 pub mod diff;
 pub mod engine;
 pub mod migrations;
+pub mod scaffold;
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::path::{Path, PathBuf};
@@ -41,6 +48,11 @@ use std::path::{Path, PathBuf};
 use migrations::{AppMigration, Version};
 
 /// Options for `autumn upgrade`.
+///
+/// One bool per flag, deliberately: they are independent switches the CLI layer
+/// passes straight through, and grouping them into modes would put the flag
+/// combinations' meaning somewhere other than where they are validated.
+#[allow(clippy::struct_excessive_bools)]
 #[derive(Debug, Clone, Default)]
 pub struct UpgradeOptions {
     /// Override the detected `autumn-web` version the app is upgrading *from*.
@@ -54,6 +66,10 @@ pub struct UpgradeOptions {
     pub json: bool,
     /// List the registry and exit, without scanning any source.
     pub list: bool,
+    /// Report scaffold-file drift and exit nonzero if there is any, without
+    /// scanning app code and without writing. The CI gate for scaffold
+    /// freshness (issue #1593).
+    pub check: bool,
 }
 
 /// A site the user has to handle themselves, with where to read about it.
@@ -169,6 +185,14 @@ impl Report {
 /// work and at worst a corrupted dependency.
 /// Skipped only where a crate begins — a directory holding a `Cargo.toml`.
 /// Beneath that, these are ordinary module names.
+/// Exit code for `--check` when a project's framework-owned files have drifted
+/// from the current release's scaffold (issue #1593).
+///
+/// Its own code rather than the generic `1`: within this command one exit code
+/// means one thing, and `1` already means "the apply step died partway", which
+/// is a materially different thing for a CI job to react to.
+pub const DRIFT_EXIT_CODE: i32 = 3;
+
 const SKIPPED_DIRS: &[&str] = &["target", "vendor", "node_modules", "dist", "tmp"];
 
 /// Hidden directories that hold tool or VCS metadata rather than app code.
@@ -442,7 +466,20 @@ fn manual_json(entries: &[ManualEntry]) -> serde_json::Value {
 }
 
 /// Render the machine-readable report.
+///
+/// The scaffold section (issue #1593) is merged in by the caller, which is why
+/// [`json_value`] exists separately: `autumn upgrade --json` emits one document,
+/// and building it by re-parsing this function's own output would be a parser
+/// round trip over data the caller already has.
+#[must_use]
 pub fn render_json(report: &Report) -> String {
+    serde_json::to_string_pretty(&json_value(report)).unwrap_or_else(|_| "{}".to_owned())
+}
+
+/// The machine-readable report as a value, so a caller can extend it (the
+/// scaffold section) without re-parsing its own output.
+#[must_use]
+pub fn json_value(report: &Report) -> serde_json::Value {
     let files: Vec<serde_json::Value> = report
         .files
         .iter()
@@ -485,7 +522,7 @@ pub fn render_json(report: &Report) -> String {
             "reason": reason,
         })).collect::<Vec<_>>(),
     });
-    serde_json::to_string_pretty(&value).unwrap_or_else(|_| "{}".to_owned())
+    value
 }
 
 /// Read the `autumn-web` requirement recorded by the app at `root`.
@@ -1313,37 +1350,98 @@ mod write_guard_tests {
     }
 }
 
+/// Print one run's reports — app code, and the scaffold section when there is
+/// one.
+///
+/// A directory that is not an Autumn project produces byte-for-byte the report
+/// it always did: the scaffold section is an addition to this command, not a
+/// change to it.
+fn emit(report: &Report, scaffold_report: Option<&scaffold::ScaffoldReport>, json: bool) {
+    match (json, scaffold_report) {
+        (true, None) => println!("{}", render_json(report)),
+        (true, Some(scaffold_report)) => {
+            let mut value = json_value(report);
+            value["scaffold"] = scaffold::json(scaffold_report);
+            println!(
+                "{}",
+                serde_json::to_string_pretty(&value).unwrap_or_else(|_| "{}".to_owned())
+            );
+        }
+        (false, scaffold_report) => {
+            print!("{}", render_text(report));
+            if let Some(scaffold_report) = scaffold_report {
+                print!("{}", scaffold::render_text(scaffold_report));
+            }
+        }
+    }
+}
+
+fn check_scaffold(root: &Path, target: &str, json: bool) -> i32 {
+    if !scaffold::is_project(root) {
+        eprintln!(
+            "autumn upgrade: `{}` is not an Autumn project (no `autumn.toml`).\n\
+             `--check` gates a project's framework-owned files against the current scaffold.",
+            root.display()
+        );
+        return 2;
+    }
+    let report = scaffold::plan(root, target);
+    if json {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&scaffold::json(&report))
+                .unwrap_or_else(|_| "{}".to_owned())
+        );
+    } else {
+        print!("{}", scaffold::render_text(&report));
+    }
+    if report.drifted() { DRIFT_EXIT_CODE } else { 0 }
+}
+
+/// Print the shipped codemod registry, for `--list-migrations`.
+fn list_migrations(json: bool) {
+    let all: Vec<&'static AppMigration> = migrations::app_migrations().iter().collect();
+    if json {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(
+                &serde_json::json!({ "migrations": migrations_json(&all) })
+            )
+            .unwrap_or_else(|_| "{}".to_owned())
+        );
+        return;
+    }
+    println!("Shipped app-code migrations ({}):", all.len());
+    for migration in &all {
+        println!(
+            "  {:<6}  {}  {}",
+            migration.confidence.label(),
+            migration.id,
+            migration.title
+        );
+        println!("          {}", migrations::guide_url(migration.guide));
+    }
+}
+
 /// Run `autumn upgrade` against `root`, returning the process exit code.
 ///
 /// `0` on any completed scan — including one that found sites only a human can
 /// take, or files it could not parse, both of which the report names. `1` when
 /// the apply step failed partway through, `2` for a bad argument or an
-/// unreadable scan root.
+/// unreadable scan root, and [`DRIFT_EXIT_CODE`] when `--check` found scaffold
+/// drift.
 #[must_use]
 pub fn run_in(root: &Path, opts: &UpgradeOptions) -> i32 {
     if opts.list {
-        let all: Vec<&'static AppMigration> = migrations::app_migrations().iter().collect();
-        if opts.json {
-            println!(
-                "{}",
-                serde_json::to_string_pretty(
-                    &serde_json::json!({ "migrations": migrations_json(&all) })
-                )
-                .unwrap_or_else(|_| "{}".to_owned())
-            );
-        } else {
-            println!("Shipped app-code migrations ({}):", all.len());
-            for migration in &all {
-                println!(
-                    "  {:<6}  {}  {}",
-                    migration.confidence.label(),
-                    migration.id,
-                    migration.title
-                );
-                println!("          {}", migrations::guide_url(migration.guide));
-            }
-        }
+        list_migrations(opts.json);
         return 0;
+    }
+
+    if opts.check && opts.apply {
+        eprintln!(
+            "autumn upgrade: `--check` reports drift and writes nothing; it cannot be combined with `--apply`."
+        );
+        return 2;
     }
 
     let target = opts
@@ -1368,6 +1466,14 @@ pub fn run_in(root: &Path, opts: &UpgradeOptions) -> i32 {
         return 2;
     }
 
+    // The CI gate (issue #1593). Deliberately ahead of the version resolution:
+    // scaffold drift is measured against the recorded provenance manifest, not
+    // against the `autumn-web` requirement, so a project whose manifest Cargo
+    // cannot give a single floor for can still be gated on scaffold freshness.
+    if opts.check {
+        return check_scaffold(root, &target, opts.json);
+    }
+
     let recorded = opts.from.clone().or_else(|| recorded_version(root));
     let Some(recorded) = recorded else {
         eprintln!(
@@ -1386,6 +1492,7 @@ pub fn run_in(root: &Path, opts: &UpgradeOptions) -> i32 {
 
     let mut report = plan(root, from, to);
     let mut failure = None;
+    let mut scaffold_failure = None;
     if opts.apply {
         match write_plan(&report) {
             Ok(()) => report.outcome = Outcome::Applied,
@@ -1403,16 +1510,44 @@ pub fn run_in(root: &Path, opts: &UpgradeOptions) -> i32 {
         }
     }
 
-    if opts.json {
-        println!("{}", render_json(&report));
-    } else {
-        print!("{}", render_text(&report));
+    // Framework-owned scaffold files are reconciled in the same run as the app
+    // code (issue #1593), so "bring me up to this release" is one command
+    // rather than two. Only in an actual Autumn project: `autumn upgrade` also
+    // runs over plain crates that merely depend on autumn-web, and offering to
+    // seed a Dockerfile into one of those would be nonsense.
+    //
+    // Planned *after* the app-code step, not alongside it: `build.rs` is both a
+    // framework-owned file and a `.rs` file the codemods scan, so a plan made
+    // before the rewrites could be a plan about bytes that no longer exist.
+    let mut scaffold_report = scaffold::is_project(root).then(|| scaffold::plan(root, &target));
+    // Only when the app-code step completed. A half-migrated tree is not a tree
+    // to start rewriting project files in.
+    if opts.apply
+        && failure.is_none()
+        && let Some(scaffold_report) = scaffold_report.as_mut()
+    {
+        scaffold_failure = scaffold::apply(scaffold_report).err();
     }
+
+    emit(&report, scaffold_report.as_ref(), opts.json);
 
     if let Some(WriteFailure { path, error, .. }) = failure {
         eprintln!(
             "autumn upgrade: failed while writing {path}: {error}\n\
              Files listed before it in the report above were already written; \
+             `git diff` shows exactly what changed."
+        );
+        return 1;
+    }
+    if let Some(scaffold::WriteFailure {
+        path,
+        error,
+        written,
+    }) = scaffold_failure
+    {
+        eprintln!(
+            "autumn upgrade: failed while writing the scaffold file {path}: {error}\n\
+             {written} scaffold file(s) were written before it; \
              `git diff` shows exactly what changed."
         );
         return 1;

--- a/autumn-cli/src/upgrade/mod.rs
+++ b/autumn-cli/src/upgrade/mod.rs
@@ -1363,20 +1363,17 @@ mod write_guard_tests {
 ///
 /// Planned *after* the app-code step, not alongside it: `build.rs` is both a
 /// framework-owned file and a `.rs` file the codemods scan, so a plan made
-/// before the rewrites would be a plan about bytes that no longer exist — and
-/// `rewrote` names the files this run touched, so the report attributes them to
-/// this command rather than to the developer.
-fn plan_scaffold(
-    root: &Path,
-    target: &str,
-    report: &Report,
-    rewrote: bool,
-) -> Option<scaffold::ScaffoldReport> {
-    let migrated: BTreeSet<String> = if rewrote {
-        report.files.iter().map(|file| file.path.clone()).collect()
-    } else {
-        BTreeSet::new()
-    };
+/// before the rewrites would be a plan about bytes that no longer exist.
+///
+/// The codemods' *plan* is what the scaffold half is told about, not what the
+/// apply step happened to write. The two are the same set — `--apply` writes
+/// the plan — and using the narrower one would make the preview disagree with
+/// the run it is previewing: a bare `autumn upgrade` would offer `build.rs` as
+/// a writable `update` that `--apply` then refuses. A preview that does not
+/// predict its own apply is worse than no preview, and this is the one file
+/// that can be in both halves at once.
+fn plan_scaffold(root: &Path, target: &str, report: &Report) -> Option<scaffold::ScaffoldReport> {
+    let migrated: BTreeSet<String> = report.files.iter().map(|file| file.path.clone()).collect();
     scaffold::is_project(root).then(|| scaffold::plan_after(root, target, &migrated))
 }
 
@@ -1614,8 +1611,7 @@ pub fn run_in(root: &Path, opts: &UpgradeOptions) -> i32 {
         }
     }
 
-    let mut scaffold_report =
-        plan_scaffold(root, &target, &report, opts.apply && failure.is_none());
+    let mut scaffold_report = plan_scaffold(root, &target, &report);
     // Only when the app-code step completed. A half-migrated tree is not a tree
     // to start rewriting project files in.
     if opts.apply

--- a/autumn-cli/src/upgrade/mod.rs
+++ b/autumn-cli/src/upgrade/mod.rs
@@ -70,6 +70,9 @@ pub struct UpgradeOptions {
     /// scanning app code and without writing. The CI gate for scaffold
     /// freshness (issue #1593).
     pub check: bool,
+    /// Framework-owned paths to record as the developer's own, so
+    /// reconciliation leaves them alone from now on. Writes only the manifest.
+    pub accept: Vec<String>,
 }
 
 /// A site the user has to handle themselves, with where to read about it.
@@ -1350,6 +1353,90 @@ mod write_guard_tests {
     }
 }
 
+/// Plan the scaffold half of the run, when the root is an Autumn project.
+///
+/// Framework-owned scaffold files are reconciled in the same run as the app
+/// code (issue #1593), so "bring me up to this release" is one command rather
+/// than two. Only in an actual Autumn project: `autumn upgrade` also runs over
+/// plain crates that merely depend on autumn-web, and offering to seed a
+/// Dockerfile into one of those would be nonsense.
+///
+/// Planned *after* the app-code step, not alongside it: `build.rs` is both a
+/// framework-owned file and a `.rs` file the codemods scan, so a plan made
+/// before the rewrites would be a plan about bytes that no longer exist — and
+/// `rewrote` names the files this run touched, so the report attributes them to
+/// this command rather than to the developer.
+fn plan_scaffold(
+    root: &Path,
+    target: &str,
+    report: &Report,
+    rewrote: bool,
+) -> Option<scaffold::ScaffoldReport> {
+    let migrated: BTreeSet<String> = if rewrote {
+        report.files.iter().map(|file| file.path.clone()).collect()
+    } else {
+        BTreeSet::new()
+    };
+    scaffold::is_project(root).then(|| scaffold::plan_after(root, target, &migrated))
+}
+
+/// Reject flag combinations whose meanings contradict each other.
+///
+/// Each of these would otherwise "work" while doing something other than what
+/// was asked — the worst kind of CLI behaviour, because nothing reports it.
+fn reject_bad_combination(opts: &UpgradeOptions) -> Option<i32> {
+    if opts.check && opts.apply {
+        eprintln!(
+            "autumn upgrade: `--check` reports drift and writes nothing; it cannot be combined with `--apply`."
+        );
+        return Some(2);
+    }
+    // `--list-migrations` short-circuits everything below it, so accepting it
+    // alongside `--check` would print the registry, exit 0, and gate nothing —
+    // a CI job silently not doing its job.
+    if opts.list && (opts.check || !opts.accept.is_empty()) {
+        eprintln!(
+            "autumn upgrade: `--list-migrations` prints the registry and exits; it cannot be \
+             combined with `--check` or `--accept`."
+        );
+        return Some(2);
+    }
+    None
+}
+
+/// Record framework-owned paths as the developer's own (issue #1593).
+fn accept_scaffold(root: &Path, paths: &[String]) -> i32 {
+    if !scaffold::is_project(root) {
+        eprintln!(
+            "autumn upgrade: `{}` is not an Autumn project (no `autumn.toml`).",
+            root.display()
+        );
+        return 2;
+    }
+    match scaffold::accept(root, paths) {
+        Ok(manifest) => {
+            println!(
+                "Accepted as yours; `autumn upgrade` will leave {} alone:",
+                if paths.len() == 1 { "it" } else { "them" }
+            );
+            for path in paths {
+                println!("  {path}");
+            }
+            println!(
+                "Recorded in {}. Delete a line from its `pinned` list to bring a file back\n\
+                 under reconciliation.",
+                scaffold::MANIFEST_PATH
+            );
+            let _ = manifest;
+            0
+        }
+        Err(error) => {
+            eprintln!("autumn upgrade: {error}");
+            2
+        }
+    }
+}
+
 /// Print one run's reports — app code, and the scaffold section when there is
 /// one.
 ///
@@ -1387,10 +1474,15 @@ fn check_scaffold(root: &Path, target: &str, json: bool) -> i32 {
     }
     let report = scaffold::plan(root, target);
     if json {
+        // The same shape a normal `--json` run emits, so one `jq
+        // '.scaffold.drift'` works against both. Two shapes for one field is
+        // how a CI gate ends up reading `null` and passing.
         println!(
             "{}",
-            serde_json::to_string_pretty(&scaffold::json(&report))
-                .unwrap_or_else(|_| "{}".to_owned())
+            serde_json::to_string_pretty(
+                &serde_json::json!({ "scaffold": scaffold::json(&report) })
+            )
+            .unwrap_or_else(|_| "{}".to_owned())
         );
     } else {
         print!("{}", scaffold::render_summary(&report));
@@ -1444,16 +1536,12 @@ fn list_migrations(json: bool) {
 /// drift.
 #[must_use]
 pub fn run_in(root: &Path, opts: &UpgradeOptions) -> i32 {
+    if let Some(code) = reject_bad_combination(opts) {
+        return code;
+    }
     if opts.list {
         list_migrations(opts.json);
         return 0;
-    }
-
-    if opts.check && opts.apply {
-        eprintln!(
-            "autumn upgrade: `--check` reports drift and writes nothing; it cannot be combined with `--apply`."
-        );
-        return 2;
     }
 
     let target = opts
@@ -1482,6 +1570,10 @@ pub fn run_in(root: &Path, opts: &UpgradeOptions) -> i32 {
     // scaffold drift is measured against the recorded provenance manifest, not
     // against the `autumn-web` requirement, so a project whose manifest Cargo
     // cannot give a single floor for can still be gated on scaffold freshness.
+    if !opts.accept.is_empty() {
+        return accept_scaffold(root, &opts.accept);
+    }
+
     if opts.check {
         return check_scaffold(root, &target, opts.json);
     }
@@ -1522,16 +1614,8 @@ pub fn run_in(root: &Path, opts: &UpgradeOptions) -> i32 {
         }
     }
 
-    // Framework-owned scaffold files are reconciled in the same run as the app
-    // code (issue #1593), so "bring me up to this release" is one command
-    // rather than two. Only in an actual Autumn project: `autumn upgrade` also
-    // runs over plain crates that merely depend on autumn-web, and offering to
-    // seed a Dockerfile into one of those would be nonsense.
-    //
-    // Planned *after* the app-code step, not alongside it: `build.rs` is both a
-    // framework-owned file and a `.rs` file the codemods scan, so a plan made
-    // before the rewrites could be a plan about bytes that no longer exist.
-    let mut scaffold_report = scaffold::is_project(root).then(|| scaffold::plan(root, &target));
+    let mut scaffold_report =
+        plan_scaffold(root, &target, &report, opts.apply && failure.is_none());
     // Only when the app-code step completed. A half-migrated tree is not a tree
     // to start rewriting project files in.
     if opts.apply
@@ -1542,6 +1626,22 @@ pub fn run_in(root: &Path, opts: &UpgradeOptions) -> i32 {
     }
 
     emit(&report, scaffold_report.as_ref(), opts.json);
+
+    // `--to` selects codemods; the scaffold half can only ever reconcile to the
+    // release this CLI ships templates for. Silently ignoring the flag would
+    // leave a reader believing the whole run targeted what they asked for.
+    if scaffold_report.is_some()
+        && opts
+            .to
+            .as_deref()
+            .is_some_and(|to| to != env!("CARGO_PKG_VERSION"))
+    {
+        eprintln!(
+            "autumn upgrade: `--to` selects which app-code migrations run. The scaffold\n\
+             files were reconciled against {}, the only scaffold this CLI ships.",
+            env!("CARGO_PKG_VERSION")
+        );
+    }
 
     if let Some(WriteFailure { path, error, .. }) = failure {
         eprintln!(

--- a/autumn-cli/src/upgrade/scaffold.rs
+++ b/autumn-cli/src/upgrade/scaffold.rs
@@ -1057,11 +1057,15 @@ fn write_one(entry: &Entry) -> Result<(), String> {
 }
 
 /// Whether a publish may take a destination that already exists.
+///
+/// A statement about what the caller has *established*, not about what is on
+/// disk right now — the gap between those two is the race this exists to catch.
+/// Permissions are decided separately, from the destination itself.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum Publish {
     /// The path was empty when the plan was made and must still be empty.
     Create,
-    /// The path holds the contents the plan was computed from.
+    /// The caller may take whatever is there.
     Replace,
 }
 
@@ -1129,14 +1133,17 @@ fn publish(absolute: &Path, contents: &str, mode: Publish) -> Result<(), String>
         .tempfile_in(directory)
         .map_err(|error| error.to_string())?;
 
-    // Replacing a file keeps the mode it already had; a genuinely new one takes
-    // the mode the directory implies.
-    let permissions = match mode {
-        Publish::Replace => std::fs::metadata(absolute)
-            .ok()
-            .map(|metadata| metadata.permissions()),
-        Publish::Create => permissions_for_new_file(directory),
-    };
+    // A file that is really there keeps the mode it already has; anything else
+    // is genuinely new and takes the mode the directory implies. Keyed on what
+    // is on disk rather than on `mode`, which says whether replacing is
+    // *allowed*, not whether there is anything to replace: a `Publish::Replace`
+    // of an absent path — the manifest on every `autumn new` — would otherwise
+    // keep `tempfile`'s 0600, and a manifest another uid cannot read is
+    // discarded as unreadable, throwing away every baseline in it.
+    let permissions = std::fs::metadata(absolute)
+        .ok()
+        .map(|metadata| metadata.permissions())
+        .or_else(|| permissions_for_new_file(directory));
     if let Some(permissions) = permissions {
         let _ = temp.as_file().set_permissions(permissions);
     }
@@ -2553,6 +2560,33 @@ mod tests {
         assert_eq!(
             status_of(&entries, "clippy.toml"),
             &Status::Conflict(ConflictReason::NoBaseline)
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn a_newly_created_manifest_is_as_readable_as_the_files_it_describes() {
+        // The manifest is created, not replaced, on every `autumn new` and on a
+        // legacy project's first `--accept`. Publishing it as a replacement
+        // finds no destination permissions to copy, so `tempfile`'s 0600 would
+        // stick — and a manifest another uid cannot read is discarded as
+        // unreadable, which throws away every baseline it holds and turns the
+        // next upgrade into a wall of conflicts.
+        use std::os::unix::fs::PermissionsExt as _;
+
+        let tmp = scaffolded(GenerateOptions::default());
+        let manifest = fs::metadata(tmp.path().join(MANIFEST_PATH))
+            .unwrap()
+            .permissions()
+            .mode();
+        let ordinary = fs::metadata(tmp.path().join("clippy.toml"))
+            .unwrap()
+            .permissions()
+            .mode();
+        assert_eq!(
+            manifest & 0o777,
+            ordinary & 0o777,
+            "the manifest must be as readable as the files it describes"
         );
     }
 }

--- a/autumn-cli/src/upgrade/scaffold.rs
+++ b/autumn-cli/src/upgrade/scaffold.rs
@@ -235,6 +235,18 @@ impl Manifest {
         // `autumn new`'s own rule, so the two can never disagree about what is
         // possible.
         .filter(|manifest: &Self| crate::new::check_option_combination(manifest.options).is_ok())
+        // A release string that cannot be read cannot be compared, so it cannot
+        // be refused either — and a manifest left *trusted* with digests some
+        // newer renderer wrote is the downgrade path all over again. Unknown
+        // has to mean no baseline. Absent still does not: a project whose first
+        // upgrade left conflicts standing has no `version` line at all, and its
+        // digests are perfectly good.
+        .filter(|manifest: &Self| {
+            [manifest.version.as_deref(), manifest.written_by.as_deref()]
+                .into_iter()
+                .flatten()
+                .all(|recorded| super::migrations::parse_version_req(recorded).is_some())
+        })
     }
 
     /// Load the manifest under `root`, or `None` when there is not a readable
@@ -978,10 +990,12 @@ fn newest(previous: Option<&str>, candidate: &str) -> String {
 
 /// Whether `recorded` names a release newer than the one this CLI ships.
 ///
-/// An unparsable version is *not* newer: it is simply unknown, and the
-/// conservative answer there is the one the rest of the module already gives an
-/// unreadable manifest — no baseline, everything a conflict — rather than a
-/// refusal that a typo could trigger.
+/// Only ever reached with a value [`Manifest::parse`] has already proven
+/// readable: an unreadable one makes the whole manifest no baseline, so this
+/// never has to decide what "unknown" means. It answers `false` for one anyway,
+/// because a comparison that cannot be made is not evidence of anything — but
+/// that answer must never again be the *only* thing standing between a corrupt
+/// version string and a trusted set of digests, which is exactly what it was.
 fn is_newer_than_this_cli(recorded: &str) -> bool {
     let (Some(recorded), Some(ours)) = (
         super::migrations::parse_version_req(recorded),
@@ -2934,5 +2948,65 @@ mod tests {
             Manifest::load(tmp.path()).unwrap().written_by.as_deref(),
             Some("0.7.0")
         );
+    }
+
+    #[test]
+    fn an_unparsable_recorded_version_is_no_baseline() {
+        // A version that cannot be read cannot be compared, so it cannot be
+        // refused either — and a manifest left trusted with digests a newer
+        // renderer wrote is the downgrade path all over again. Unknown must
+        // mean no baseline, which is what the doc comment on the comparison
+        // already claimed and nothing implemented.
+        for field in ["version", "written_by"] {
+            let tmp = scaffolded(GenerateOptions::default());
+            let text = fs::read_to_string(tmp.path().join(MANIFEST_PATH)).unwrap();
+            fs::write(
+                tmp.path().join(MANIFEST_PATH),
+                text.replace(
+                    &format!("{field} = \"0.7.0\""),
+                    &format!("{field} = \"not-a-version\""),
+                ),
+            )
+            .unwrap();
+
+            assert!(
+                Manifest::load(tmp.path()).is_none(),
+                "{field}: an unreadable version vouches for nothing"
+            );
+
+            // ...so a file a newer renderer wrote is a conflict, never an
+            // update, and survives `--apply`.
+            let newer = "# written by a newer release\n";
+            write(tmp.path(), "clippy.toml", newer);
+            let entries = plan_in(tmp.path()).entries;
+            assert_eq!(
+                status_of(&entries, "clippy.toml"),
+                &Status::Conflict(ConflictReason::NoBaseline),
+                "{field}"
+            );
+
+            let mut report = plan_in(tmp.path());
+            apply(&mut report).expect("apply");
+            assert_eq!(
+                fs::read_to_string(tmp.path().join("clippy.toml")).unwrap(),
+                newer,
+                "{field}"
+            );
+        }
+    }
+
+    #[test]
+    fn an_absent_version_is_still_a_usable_baseline() {
+        // Absent is not the same as unreadable: a project whose first upgrade
+        // left conflicts standing has no `version` line at all, and its digests
+        // are still good.
+        let tmp = scaffolded(GenerateOptions::default());
+        let mut manifest = Manifest::load(tmp.path()).unwrap();
+        manifest.version = None;
+        manifest.save(tmp.path()).unwrap();
+
+        let loaded = Manifest::load(tmp.path()).expect("still a baseline");
+        assert!(loaded.version.is_none());
+        assert!(!loaded.digests.is_empty());
     }
 }

--- a/autumn-cli/src/upgrade/scaffold.rs
+++ b/autumn-cli/src/upgrade/scaffold.rs
@@ -704,14 +704,35 @@ pub fn apply(report: &mut ScaffoldReport) -> Result<(), WriteFailure> {
         }
     }
 
-    // The manifest is bookkeeping, so a failure to write it must not read as a
-    // failure to upgrade: the files are already correct and the next run simply
-    // has a staler baseline.
-    let previous = Manifest::load(&report.root);
-    let _ = report.next_manifest(previous.as_ref()).save(&report.root);
-
+    record_baseline(report);
     report.outcome = super::Outcome::Applied;
     Ok(())
+}
+
+/// Refresh the provenance manifest after a completed apply.
+///
+/// Best effort by design: the manifest is bookkeeping, so failing to write it
+/// must not read as a failure to upgrade — the files on disk are already
+/// correct and the next run simply has a staler baseline.
+fn record_baseline(report: &ScaffoldReport) {
+    // A report with no entries reconciled nothing, and rebuilding the manifest
+    // from no entries would prune every digest in it. That is the baseline the
+    // whole feature rests on, destroyed by a run that did not even look at the
+    // files. The only report shaped like this is one whose project name could
+    // not be read, which is a refusal to answer, not an answer.
+    if !report.named {
+        return;
+    }
+    let previous = Manifest::load(&report.root);
+    let next = report.next_manifest(previous.as_ref());
+    // Rewriting an identical file would touch its mtime and show up in every
+    // `--apply` as a modified file with no diff.
+    let rendered = next.render();
+    let path = report.root.join(MANIFEST_PATH);
+    if std::fs::read_to_string(&path).is_ok_and(|current| current == rendered) {
+        return;
+    }
+    let _ = next.save(&report.root);
 }
 
 /// Write one entry, refusing to clobber anything that moved since the plan.
@@ -1592,5 +1613,65 @@ mod tests {
             status_of(&entries, "static/css/input.css"),
             &Status::UpToDate
         );
+    }
+
+    #[test]
+    fn a_project_whose_name_cannot_be_read_keeps_its_baseline() {
+        // With no name there are no entries, and a manifest rebuilt from no
+        // entries would prune every digest in it — destroying the baseline that
+        // is the whole point of the file, in a run that reconciled nothing.
+        let tmp = scaffolded(GenerateOptions::default());
+        let before = fs::read_to_string(tmp.path().join(MANIFEST_PATH)).unwrap();
+        fs::write(tmp.path().join("Cargo.toml"), "[workspace]\nmembers = []\n").unwrap();
+
+        let mut report = plan_in(tmp.path());
+        assert!(!report.named);
+        assert!(report.entries.is_empty());
+        apply(&mut report).expect("apply");
+
+        assert_eq!(
+            fs::read_to_string(tmp.path().join(MANIFEST_PATH)).unwrap(),
+            before,
+            "the baseline must survive a run that could not read the project name"
+        );
+    }
+
+    #[test]
+    fn a_run_that_changes_nothing_does_not_rewrite_the_manifest() {
+        // `--apply` on an already-current project should leave the working tree
+        // alone; rewriting an identical file is git noise on every run.
+        let tmp = scaffolded(GenerateOptions::default());
+        let before = fs::read_to_string(tmp.path().join(MANIFEST_PATH)).unwrap();
+        let mtime = fs::metadata(tmp.path().join(MANIFEST_PATH))
+            .unwrap()
+            .modified()
+            .unwrap();
+
+        let mut report = plan_in(tmp.path());
+        apply(&mut report).expect("apply");
+
+        assert_eq!(
+            fs::read_to_string(tmp.path().join(MANIFEST_PATH)).unwrap(),
+            before
+        );
+        assert_eq!(
+            fs::metadata(tmp.path().join(MANIFEST_PATH))
+                .unwrap()
+                .modified()
+                .unwrap(),
+            mtime,
+            "an unchanged manifest must not be rewritten"
+        );
+    }
+
+    #[test]
+    fn an_unnamed_project_is_not_reported_as_drift_free() {
+        // The refusal must not read as an all-clear: a CI gate that passes
+        // because the tool could not look is worse than no gate.
+        let tmp = scaffolded(GenerateOptions::default());
+        fs::write(tmp.path().join("Cargo.toml"), "[workspace]\nmembers = []\n").unwrap();
+        let report = plan_in(tmp.path());
+        assert!(!report.named);
+        assert!(render_summary(&report).contains("Skipped"));
     }
 }

--- a/autumn-cli/src/upgrade/scaffold.rs
+++ b/autumn-cli/src/upgrade/scaffold.rs
@@ -1,0 +1,1302 @@
+//! Framework-owned scaffold-file reconciliation for `autumn upgrade`
+//! (issue #1593).
+//!
+//! `autumn new` writes a dozen framework-owned files into every project —
+//! `Dockerfile`, `build.rs`, `autumn.toml`, the toolchain and style configs, the
+//! CI workflow — and those templates keep evolving. Bumping `autumn-web` in
+//! `Cargo.toml` updates the library, not the project skeleton, so an app
+//! scaffolded on 0.5 keeps 0.5-vintage project files forever. This module is
+//! the reconciler: it renders the *current* release's scaffold in memory,
+//! compares it against what is on disk, and classifies every difference.
+//!
+//! # The question that decides everything
+//!
+//! "May I overwrite this file?" is really "did the developer touch it?", and
+//! neither the file's contents nor its timestamp can answer that. So
+//! [`autumn new`](crate::new) records a digest of every framework-owned file as
+//! it writes it — the manifest at [`MANIFEST_PATH`] — and this module treats
+//! that digest as the merge base:
+//!
+//! - on-disk bytes still match the recorded digest → the framework wrote them
+//!   and nobody has since, so the new template may replace them ([`Status::Update`]);
+//! - they do not match, or nothing was recorded → the developer may have edited
+//!   the file, so it is a [`Status::Conflict`] and is never written.
+//!
+//! An app scaffolded before this feature existed has no manifest and therefore
+//! no baseline. That is deliberately not an error: files it is missing entirely
+//! are still offered ([`Status::Add`]), and everything else is a conflict for
+//! review. Best effort, never a silent overwrite.
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+use crate::new::{GenerateOptions, TemplateVars, framework_owned_files};
+
+/// Project-relative location of the scaffold provenance manifest.
+///
+/// Under `.autumn/` rather than at the project root: it is machine-written
+/// bookkeeping, and the root is the one directory whose listing a developer
+/// reads. It is meant to be committed — its whole value is being the baseline a
+/// *later* checkout compares against.
+pub const MANIFEST_PATH: &str = ".autumn/scaffold.toml";
+
+/// Line endings normalised, so a CRLF checkout is not mistaken for an edit.
+///
+/// `git config core.autocrlf true` rewrites every text file on checkout. Hashing
+/// the bytes as they sit on disk would then report that the developer had
+/// personally rewritten all twelve framework-owned files — turning the one
+/// upgrade path into a wall of conflicts on exactly the platform least able to
+/// diagnose it. The template renderer normalises the same way, so both sides of
+/// every comparison are LF.
+fn normalize(contents: &str) -> String {
+    contents.replace("\r\n", "\n")
+}
+
+/// The digest recorded for one framework-owned file.
+///
+/// SHA-256 over the LF-normalised text, hex encoded. Not a cryptographic
+/// commitment to anything — it only has to distinguish "these are the bytes
+/// Autumn wrote" from "these are not", and it must be stable across hosts.
+#[must_use]
+pub fn digest(contents: &str) -> String {
+    use sha2::{Digest as _, Sha256};
+    hex::encode(Sha256::digest(normalize(contents).as_bytes()))
+}
+
+/// The on-disk shape of [`MANIFEST_PATH`].
+///
+/// A flat DTO rather than [`Manifest`] itself: [`GenerateOptions`] is the CLI's
+/// argument struct and should stay free to grow fields that mean nothing to a
+/// file on disk.
+///
+/// One bool per scaffold flag, mirroring [`GenerateOptions`]: they are
+/// independent switches with no useful grouping, and naming them individually
+/// is what makes the file readable to the human whose project it describes.
+#[allow(clippy::struct_excessive_bools)]
+#[derive(Serialize, Deserialize)]
+struct ManifestFile {
+    version: String,
+    flavor: String,
+    #[serde(default)]
+    i18n: bool,
+    #[serde(default)]
+    seed: bool,
+    #[serde(default)]
+    daemon: bool,
+    #[serde(default)]
+    bundled_pg: bool,
+    #[serde(default)]
+    files: BTreeMap<String, String>,
+}
+
+const FLAVOR_API: &str = "api";
+const FLAVOR_FULLSTACK: &str = "fullstack";
+
+/// What `autumn new` recorded about the scaffold it wrote.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Manifest {
+    /// The `autumn-cli` release whose scaffold produced these files.
+    pub version: String,
+    /// The flags that release was invoked with, insofar as they change which
+    /// framework-owned files exist and what they contain.
+    pub options: GenerateOptions,
+    /// Project-relative path → digest of the file as Autumn wrote it.
+    pub digests: BTreeMap<String, String>,
+}
+
+impl Manifest {
+    /// The manifest describing `files` as just written.
+    #[must_use]
+    pub fn for_files(
+        version: &str,
+        options: GenerateOptions,
+        files: &BTreeMap<&'static str, String>,
+    ) -> Self {
+        Self {
+            version: version.to_owned(),
+            options,
+            digests: files
+                .iter()
+                .map(|(path, contents)| ((*path).to_owned(), digest(contents)))
+                .collect(),
+        }
+    }
+
+    /// The manifest text, header comment included.
+    #[must_use]
+    pub fn render(&self) -> String {
+        let file = ManifestFile {
+            version: self.version.clone(),
+            flavor: if self.options.with_api {
+                FLAVOR_API
+            } else {
+                FLAVOR_FULLSTACK
+            }
+            .to_owned(),
+            i18n: self.options.with_i18n,
+            seed: self.options.with_seed,
+            daemon: self.options.with_daemon,
+            bundled_pg: self.options.with_bundled_pg,
+            files: self.digests.clone(),
+        };
+        // Serialization cannot fail for this shape (plain strings, bools, and a
+        // string map), but a panic here would abort a scaffold over
+        // bookkeeping, so the failure degrades to a manifest-free project —
+        // which the reconciler already handles as "no baseline".
+        let body = toml::to_string(&file).unwrap_or_default();
+        format!(
+            "# Scaffold provenance for `autumn upgrade` (issue #1593).\n\
+             #\n\
+             # Written by `autumn new` and refreshed by `autumn upgrade --apply`.\n\
+             # Commit it: it records which release's scaffold produced this project's\n\
+             # framework-owned files, and a digest of each file as Autumn wrote it, so a\n\
+             # later upgrade can tell \"you edited this\" apart from \"the template moved\"\n\
+             # and never overwrite your work.\n\
+             #\n\
+             # Deleting or hand-editing this file costs precision, not correctness: an\n\
+             # upgrade with no baseline treats every changed file as a conflict to review.\n\
+             \n{body}"
+        )
+    }
+
+    /// Parse manifest text, or `None` if it is not a manifest.
+    #[must_use]
+    pub fn parse(text: &str) -> Option<Self> {
+        let file: ManifestFile = toml::from_str(text).ok()?;
+        Some(Self {
+            version: file.version,
+            options: GenerateOptions {
+                with_api: file.flavor == FLAVOR_API,
+                with_i18n: file.i18n,
+                with_seed: file.seed,
+                with_daemon: file.daemon,
+                with_bundled_pg: file.bundled_pg,
+            },
+            digests: file.files,
+        })
+    }
+
+    /// Load the manifest under `root`, or `None` when there is not a readable
+    /// one.
+    ///
+    /// Absent and unreadable collapse into the same answer on purpose. Both mean
+    /// "no baseline", and the reconciler's response to no baseline — conflict
+    /// everything that differs — is already the safe one; failing the whole
+    /// command over a corrupt bookkeeping file would be strictly worse than
+    /// upgrading conservatively.
+    #[must_use]
+    pub fn load(root: &Path) -> Option<Self> {
+        Self::parse(&std::fs::read_to_string(root.join(MANIFEST_PATH)).ok()?)
+    }
+
+    /// Write the manifest under `root`, creating `.autumn/` if needed.
+    pub fn save(&self, root: &Path) -> std::io::Result<()> {
+        let path = root.join(MANIFEST_PATH);
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        std::fs::write(path, self.render())
+    }
+}
+
+/// Why a file cannot be written without a human looking at it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ConflictReason {
+    /// The file differs from the digest Autumn recorded when it wrote it.
+    Edited,
+    /// Nothing was recorded for this file, so "untouched" cannot be proven.
+    /// Every file in a project scaffolded before the manifest existed is here.
+    NoBaseline,
+}
+
+impl ConflictReason {
+    /// The one-line explanation printed next to the file.
+    #[must_use]
+    pub const fn describe(self) -> &'static str {
+        match self {
+            Self::Edited => "you changed this since it was scaffolded",
+            Self::NoBaseline => "no recorded baseline, so an edit cannot be ruled out",
+        }
+    }
+}
+
+/// What reconciling one framework-owned file would do.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Status {
+    /// Already identical to the current release's scaffold.
+    UpToDate,
+    /// The current scaffold has this file and the project does not — including
+    /// every file introduced by a release later than the one that scaffolded
+    /// the project.
+    Add,
+    /// The template moved and the project's copy is provably untouched.
+    Update,
+    /// The template moved and the project's copy may not be Autumn's any more.
+    Conflict(ConflictReason),
+    /// Autumn wrote this file once and the developer removed it. Reported so
+    /// the drift is visible, never written back: deleting it was a decision.
+    Removed,
+}
+
+impl Status {
+    /// Whether `--apply` writes this file.
+    #[must_use]
+    pub const fn is_applied(self) -> bool {
+        matches!(self, Self::Add | Self::Update)
+    }
+
+    /// Whether this counts as drift for `--check`.
+    ///
+    /// [`Status::Removed`] does not. A CI gate that can never go green again
+    /// because someone deliberately deleted `.env.example` teaches people to
+    /// delete the gate.
+    #[must_use]
+    pub const fn is_drift(self) -> bool {
+        matches!(self, Self::Add | Self::Update | Self::Conflict(_))
+    }
+
+    /// The column label in the human report.
+    #[must_use]
+    pub const fn label(self) -> &'static str {
+        match self {
+            Self::UpToDate => "current",
+            Self::Add => "add",
+            Self::Update => "update",
+            Self::Conflict(_) => "conflict",
+            Self::Removed => "removed",
+        }
+    }
+
+    /// The short reason printed beside the label.
+    #[must_use]
+    pub const fn describe(self) -> &'static str {
+        match self {
+            Self::UpToDate => "matches the current scaffold",
+            Self::Add => "this release's scaffold has it; your project does not",
+            Self::Update => "the template changed and your copy is untouched",
+            Self::Conflict(reason) => reason.describe(),
+            Self::Removed => "you deleted this; it is not restored",
+        }
+    }
+}
+
+/// One framework-owned file, reconciled.
+#[derive(Debug, Clone)]
+pub struct Entry {
+    /// Project-relative, `/`-separated.
+    pub path: String,
+    pub status: Status,
+    /// What the current release's scaffold renders for this file.
+    pub template: String,
+    /// The on-disk text this classification was computed from, LF-normalised.
+    /// `None` when the file is absent. Kept so the apply step can prove the
+    /// file has not changed since the plan was made.
+    pub current: Option<String>,
+    /// Rendered preview diff; empty when there is nothing to show.
+    pub diff: String,
+    /// Where the file would be written.
+    pub absolute: PathBuf,
+}
+
+/// The name to interpolate into the rendered scaffold.
+///
+/// Read from `Cargo.toml`, not from the directory name: `autumn.toml` carries
+/// the project name in its telemetry and database examples, and a checkout in a
+/// differently-named directory (a CI workspace, a `git worktree`, a rename)
+/// would otherwise report the file as edited on every run.
+fn project_name(root: &Path) -> String {
+    std::fs::read_to_string(root.join("Cargo.toml"))
+        .ok()
+        .and_then(|text| text.parse::<toml::Table>().ok())
+        .and_then(|table| {
+            table
+                .get("package")?
+                .get("name")?
+                .as_str()
+                .map(str::to_owned)
+        })
+        .or_else(|| {
+            root.canonicalize()
+                .ok()?
+                .file_name()?
+                .to_str()
+                .map(str::to_owned)
+        })
+        .unwrap_or_else(|| "app".to_owned())
+}
+
+/// The scaffold options to render against, recorded if possible and inferred if
+/// not.
+///
+/// Inference only has to be good enough to pick the right *file set* and the
+/// right conditional blocks; when it is wrong the file shows up as a conflict,
+/// which is the outcome a project without a manifest gets anyway.
+#[must_use]
+pub fn resolve_options(root: &Path, manifest: Option<&Manifest>) -> GenerateOptions {
+    if let Some(manifest) = manifest {
+        return manifest.options;
+    }
+    let autumn_toml = std::fs::read_to_string(root.join("autumn.toml")).unwrap_or_default();
+    let bundled_pg = autumn_toml.contains("Managed local Postgres");
+    GenerateOptions {
+        // The API scaffold creates neither, and the fullstack one always
+        // creates both, so their joint absence is the signal. Requiring both to
+        // be missing keeps a fullstack project that merely deleted its Tailwind
+        // config from being misread as an API project and losing `input.css`.
+        with_api: !root.join("static").is_dir() && !root.join("tailwind.config.js").exists(),
+        with_i18n: root.join("i18n").is_dir(),
+        // Never affects a framework-owned file (the seed binary lives under
+        // `src/`, which is out of bounds), so there is nothing to infer.
+        with_seed: false,
+        with_daemon: bundled_pg || autumn_toml.contains("this app uses no database"),
+        with_bundled_pg: bundled_pg,
+    }
+}
+
+/// The current release's framework-owned files, rendered for the project at
+/// `root`.
+#[must_use]
+pub fn current_files(root: &Path, options: GenerateOptions) -> BTreeMap<&'static str, String> {
+    let name = project_name(root);
+    let crate_name = name.replace('-', "_");
+    let vars = TemplateVars {
+        project_name: &name,
+        crate_name: &crate_name,
+        autumn_version: env!("CARGO_PKG_VERSION"),
+        rust_version: option_env!("CARGO_PKG_RUST_VERSION").unwrap_or("1.88.0"),
+    };
+    framework_owned_files(&vars, options)
+}
+
+/// Reconcile `files` against what is on disk under `root`.
+#[must_use]
+pub fn classify(
+    root: &Path,
+    files: &BTreeMap<&'static str, String>,
+    manifest: Option<&Manifest>,
+) -> Vec<Entry> {
+    let recorded = |path: &str| manifest.and_then(|manifest| manifest.digests.get(path));
+
+    let mut entries: Vec<Entry> = files
+        .iter()
+        .map(|(path, template)| {
+            let absolute = root.join(path);
+            let current = std::fs::read_to_string(&absolute)
+                .ok()
+                .map(|c| normalize(&c));
+            let (status, diff) = match &current {
+                // Absent. Autumn wrote it once and it is gone → a deliberate
+                // deletion. Never wrote it → this release added it.
+                None if recorded(path).is_some() => (Status::Removed, String::new()),
+                None => (Status::Add, super::diff::render("", template)),
+                Some(current) if *current == normalize(template) => {
+                    (Status::UpToDate, String::new())
+                }
+                Some(current) => {
+                    let status = match recorded(path) {
+                        Some(baseline) if *baseline == digest(current) => Status::Update,
+                        Some(_) => Status::Conflict(ConflictReason::Edited),
+                        None => Status::Conflict(ConflictReason::NoBaseline),
+                    };
+                    (status, super::diff::render(current, template))
+                }
+            };
+            Entry {
+                path: (*path).to_owned(),
+                status,
+                template: normalize(template),
+                current,
+                diff,
+                absolute,
+            }
+        })
+        .collect();
+
+    entries.sort_by(|a, b| a.path.cmp(&b.path));
+    entries
+}
+
+/// Whether `root` looks like an Autumn project at all.
+///
+/// `autumn.toml` is the framework's own config file and every scaffold writes
+/// one; the manifest alone also counts, so a project that deleted its
+/// `autumn.toml` can still be reconciled. Outside such a directory the
+/// reconciler stays silent rather than offering to seed twelve files into
+/// whatever the developer happens to be standing in.
+#[must_use]
+pub fn is_project(root: &Path) -> bool {
+    root.join("autumn.toml").is_file() || root.join(MANIFEST_PATH).is_file()
+}
+
+/// The upgrade guide for the release being upgraded to.
+///
+/// Resolved against the shipped migration registry rather than composed from
+/// the version blindly: a release with no breaking change ships no guide, and a
+/// summary that links a 404 at the exact moment it tells you to go read
+/// something is worse than one that links the index.
+#[must_use]
+pub fn release_guide(target: &str) -> String {
+    let release = super::migrations::parse_version_req(target);
+    let file =
+        release.map(|version| format!("docs/migrations/{}.{}.0.md", version.major, version.minor));
+    let known = file.as_ref().is_some_and(|file| {
+        super::migrations::app_migrations()
+            .iter()
+            .any(|migration| migration.guide.starts_with(file.as_str()))
+    });
+    match file {
+        Some(file) if known => super::migrations::guide_url(&file),
+        _ => super::migrations::guide_url("docs/migrations/README.md"),
+    }
+}
+
+/// Everything one scaffold reconciliation found.
+#[derive(Debug, Clone)]
+pub struct ScaffoldReport {
+    /// The project this report is about.
+    pub root: PathBuf,
+    /// The release recorded as having scaffolded this project, when one was.
+    pub baseline: Option<String>,
+    /// The release being reconciled to.
+    pub target: String,
+    /// Whether a provenance manifest was found. Without one every changed file
+    /// is a conflict, and the report says why.
+    pub has_manifest: bool,
+    /// The scaffold options this project was reconciled against — recorded, or
+    /// inferred when there is no manifest.
+    pub options: GenerateOptions,
+    /// Every framework-owned file, up-to-date ones included.
+    pub entries: Vec<Entry>,
+    /// What the apply step actually did.
+    pub outcome: super::Outcome,
+    /// The release's upgrade guide.
+    pub guide: String,
+}
+
+impl ScaffoldReport {
+    /// Whether anything a developer can act on has drifted.
+    #[must_use]
+    pub fn drifted(&self) -> bool {
+        drifted(&self.entries)
+    }
+
+    /// Entries `--apply` would write, in the order it writes them.
+    #[must_use]
+    pub fn applicable(&self) -> Vec<&Entry> {
+        self.entries
+            .iter()
+            .filter(|entry| entry.status.is_applied())
+            .collect()
+    }
+
+    /// Entries needing a human.
+    #[must_use]
+    pub fn conflicts(&self) -> Vec<&Entry> {
+        self.entries
+            .iter()
+            .filter(|entry| matches!(entry.status, Status::Conflict(_)))
+            .collect()
+    }
+
+    /// Every entry that is not already current, in report order.
+    #[must_use]
+    pub fn changed(&self) -> Vec<&Entry> {
+        self.entries
+            .iter()
+            .filter(|entry| entry.status != Status::UpToDate)
+            .collect()
+    }
+
+    /// The manifest to record after an apply.
+    ///
+    /// Digests are refreshed for every file that is now the current scaffold,
+    /// and left untouched for the ones that are not: a conflict keeps its old
+    /// baseline so the next run still knows the developer edited it, and a
+    /// deleted file keeps its entry so it is still reported as *removed*
+    /// rather than silently re-offered.
+    fn next_manifest(&self, previous: Option<&Manifest>) -> Manifest {
+        let mut digests = previous.map(|m| m.digests.clone()).unwrap_or_default();
+        for entry in &self.entries {
+            if entry.status.is_applied() || entry.status == Status::UpToDate {
+                digests.insert(entry.path.clone(), digest(&entry.template));
+            }
+        }
+        // The baseline moves only once nothing is left to reconcile. Recording
+        // the target while conflicts stand would tell the next run — and the
+        // developer reading it — that this upgrade is finished.
+        let version = if self.conflicts().is_empty() {
+            self.target.clone()
+        } else {
+            previous.map_or_else(|| self.target.clone(), |m| m.version.clone())
+        };
+        Manifest {
+            version,
+            options: self.options,
+            digests,
+        }
+    }
+}
+
+/// A file the apply step refused or could not write.
+#[derive(Debug, Clone)]
+pub struct WriteFailure {
+    /// Project-relative path of the file that stopped the run.
+    pub path: String,
+    /// What went wrong, ready to print.
+    pub error: String,
+    /// How many files were written before it.
+    pub written: usize,
+}
+
+/// Plan a reconciliation of the project at `root` against release `target`.
+#[must_use]
+pub fn plan(root: &Path, target: &str) -> ScaffoldReport {
+    let manifest = Manifest::load(root);
+    let options = resolve_options(root, manifest.as_ref());
+    ScaffoldReport {
+        root: root.to_path_buf(),
+        options,
+        baseline: manifest.as_ref().map(|m| m.version.clone()),
+        target: target.to_owned(),
+        has_manifest: manifest.is_some(),
+        entries: classify(root, &current_files(root, options), manifest.as_ref()),
+        outcome: super::Outcome::Preview,
+        guide: release_guide(target),
+    }
+}
+
+/// Write the additions and updates in `report`, then refresh the manifest.
+///
+/// Each file is re-read immediately before it is written and compared against
+/// what the plan was computed from. A file something else changed in between —
+/// a formatter, a code generator, an editor saving — is refused rather than
+/// overwritten with a decision made about different bytes. `report.outcome` is
+/// updated either way, so a caller that ignores the error still reports the
+/// truth about what reached disk.
+///
+/// # Errors
+///
+/// Returns the file that stopped the run and how many were written before it.
+pub fn apply(report: &mut ScaffoldReport) -> Result<(), WriteFailure> {
+    for (written, entry) in report
+        .entries
+        .iter()
+        .filter(|entry| entry.status.is_applied())
+        .enumerate()
+    {
+        if let Err(error) = write_one(entry) {
+            report.outcome = super::Outcome::Partial { written };
+            return Err(WriteFailure {
+                path: entry.path.clone(),
+                error,
+                written,
+            });
+        }
+    }
+
+    // The manifest is bookkeeping, so a failure to write it must not read as a
+    // failure to upgrade: the files are already correct and the next run simply
+    // has a staler baseline.
+    let previous = Manifest::load(&report.root);
+    let _ = report.next_manifest(previous.as_ref()).save(&report.root);
+
+    report.outcome = super::Outcome::Applied;
+    Ok(())
+}
+
+/// Write one entry, refusing to clobber anything that moved since the plan.
+fn write_one(entry: &Entry) -> Result<(), String> {
+    let on_disk = std::fs::read_to_string(&entry.absolute)
+        .ok()
+        .map(|text| normalize(&text));
+    if on_disk != entry.current {
+        return Err(match entry.current {
+            None => "a file appeared here after the preview was computed; \
+                     it was left exactly as it is"
+                .to_owned(),
+            Some(_) => "this file changed after the preview was computed; \
+                        it was left exactly as it is"
+                .to_owned(),
+        });
+    }
+    if let Some(parent) = entry.absolute.parent() {
+        std::fs::create_dir_all(parent).map_err(|error| error.to_string())?;
+    }
+    std::fs::write(&entry.absolute, &entry.template).map_err(|error| error.to_string())
+}
+
+/// The human report.
+#[must_use]
+pub fn render_text(report: &ScaffoldReport) -> String {
+    use std::fmt::Write as _;
+
+    let mut out = String::new();
+    let from = report
+        .baseline
+        .clone()
+        .unwrap_or_else(|| "unknown".to_owned());
+    let _ = writeln!(
+        out,
+        "\nScaffold files ({from} -> {target})",
+        target = report.target
+    );
+
+    let changed = report.changed();
+    if changed.is_empty() {
+        let _ = writeln!(
+            out,
+            "  Your framework-owned files are up to date with this release."
+        );
+        let _ = writeln!(out, "  Upgrade guide: {}", report.guide);
+        return out;
+    }
+
+    if !report.has_manifest {
+        let _ = writeln!(
+            out,
+            "  This project predates scaffold provenance, so there is no record of\n  \
+             what Autumn originally wrote. Files it is missing are offered; every\n  \
+             file that differs is a conflict for you to review."
+        );
+    }
+
+    let width = changed.iter().map(|e| e.path.len()).max().unwrap_or(0);
+    let _ = writeln!(out, "\n  {} file(s) differ:", changed.len());
+    for entry in &changed {
+        let _ = writeln!(
+            out,
+            "  {:<9} {:<width$}  {}",
+            entry.status.label(),
+            entry.path,
+            entry.status.describe(),
+        );
+    }
+
+    for entry in &changed {
+        if entry.diff.is_empty() {
+            continue;
+        }
+        let _ = writeln!(out, "\n{} ({})", entry.path, entry.status.label());
+        out.push_str(&entry.diff);
+    }
+
+    let applicable = report.applicable().len();
+    let conflicts = report.conflicts().len();
+    let _ = writeln!(out);
+    match report.outcome {
+        // Nothing to apply is its own message. Pointing someone at `--apply`
+        // when every remaining difference is a conflict sends them to run a
+        // command that would do nothing at all.
+        super::Outcome::Preview if applicable == 0 => {
+            let _ = writeln!(
+                out,
+                "{conflicts} conflict(s) need review; nothing here can be written for you."
+            );
+            let _ = writeln!(
+                out,
+                "Take what you want from the diffs above; `git diff` shows your edits and\n\
+                 `git checkout -- <path>` puts any one file back."
+            );
+        }
+        super::Outcome::Preview => {
+            let _ = writeln!(
+                out,
+                "{applicable} file(s) would be written; {conflicts} conflict(s) need review."
+            );
+            let _ = writeln!(
+                out,
+                "Nothing was written. Re-run with `--apply` to take the writable ones, then\n\
+                 review with `git diff` -- `git checkout -- <path>` puts any one file back."
+            );
+        }
+        super::Outcome::Applied => {
+            let _ = writeln!(
+                out,
+                "{applicable} file(s) written; {conflicts} conflict(s) left for you."
+            );
+            let _ = writeln!(
+                out,
+                "Review with `git diff`; undo any single file with `git checkout -- <path>`."
+            );
+        }
+        super::Outcome::Partial { written } => {
+            let _ = writeln!(
+                out,
+                "{written} of {applicable} file(s) written before the run stopped."
+            );
+            let _ = writeln!(
+                out,
+                "Review with `git diff`; undo any single file with `git checkout -- <path>`."
+            );
+        }
+    }
+    if conflicts > 0 {
+        let _ = writeln!(
+            out,
+            "Conflicts are never overwritten. Compare each against this release's\n\
+             scaffold above, take what you want, and re-run to confirm."
+        );
+    }
+    let _ = writeln!(out, "Upgrade guide: {}", report.guide);
+    out
+}
+
+/// The machine-readable report, for CI.
+#[must_use]
+pub fn json(report: &ScaffoldReport) -> serde_json::Value {
+    serde_json::json!({
+        "baseline": report.baseline,
+        "target": report.target,
+        "has_manifest": report.has_manifest,
+        "outcome": report.outcome.label(),
+        "drift": report.drifted(),
+        "written": report.applicable().len(),
+        "conflicts": report.conflicts().len(),
+        "guide": report.guide,
+        "files": report
+            .entries
+            .iter()
+            .map(|entry| serde_json::json!({
+                "path": entry.path,
+                "status": entry.status.label(),
+                "reason": entry.status.describe(),
+                "applied": entry.status.is_applied(),
+            }))
+            .collect::<Vec<_>>(),
+    })
+}
+
+/// Whether any entry is drift a developer can act on.
+#[must_use]
+pub fn drifted(entries: &[Entry]) -> bool {
+    entries.iter().any(|entry| entry.status.is_drift())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    use crate::new::GenerateOptions;
+    use crate::upgrade::Outcome;
+
+    fn write(root: &std::path::Path, rel: &str, contents: &str) {
+        let path = root.join(rel);
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).unwrap();
+        }
+        fs::write(path, contents).unwrap();
+    }
+
+    // --- provenance manifest ---
+
+    #[test]
+    fn manifest_round_trips_through_toml() {
+        let mut digests = BTreeMap::new();
+        digests.insert("clippy.toml".to_owned(), digest("a\n"));
+        digests.insert(".github/workflows/ci.yml".to_owned(), digest("b\n"));
+        let manifest = Manifest {
+            version: "0.7.0".to_owned(),
+            options: GenerateOptions {
+                with_api: true,
+                with_i18n: true,
+                ..GenerateOptions::default()
+            },
+            digests,
+        };
+
+        let parsed = Manifest::parse(&manifest.render()).expect("round trip");
+        assert_eq!(parsed.version, manifest.version);
+        assert_eq!(parsed.options, manifest.options);
+        assert_eq!(parsed.digests, manifest.digests);
+    }
+
+    #[test]
+    fn manifest_keys_with_dots_and_slashes_survive_the_round_trip() {
+        // `.github/workflows/ci.yml` is a TOML *key* here; quoted wrong it
+        // becomes a nested table and the digest is lost — which silently
+        // downgrades that file to "no baseline" forever.
+        let mut digests = BTreeMap::new();
+        digests.insert(".github/workflows/ci.yml".to_owned(), digest("x"));
+        digests.insert(".env.example".to_owned(), digest("y"));
+        digests.insert("static/css/input.css".to_owned(), digest("z"));
+        let manifest = Manifest {
+            version: "0.7.0".to_owned(),
+            options: GenerateOptions::default(),
+            digests: digests.clone(),
+        };
+        assert_eq!(
+            Manifest::parse(&manifest.render()).unwrap().digests,
+            digests
+        );
+    }
+
+    #[test]
+    fn digest_ignores_line_ending_style() {
+        // A Windows checkout (git autocrlf) must not read as "the developer
+        // rewrote every framework file".
+        assert_eq!(digest("a\r\nb\r\n"), digest("a\nb\n"));
+        assert_ne!(digest("a\n"), digest("b\n"));
+    }
+
+    #[test]
+    fn a_missing_or_unparsable_manifest_is_absent_not_an_error() {
+        let tmp = TempDir::new().unwrap();
+        assert!(Manifest::load(tmp.path()).is_none());
+        write(tmp.path(), MANIFEST_PATH, "this is not : toml [[[");
+        assert!(Manifest::load(tmp.path()).is_none());
+    }
+
+    #[test]
+    fn manifest_is_written_and_read_back_from_disk() {
+        let tmp = TempDir::new().unwrap();
+        let mut digests = BTreeMap::new();
+        digests.insert("clippy.toml".to_owned(), digest("a\n"));
+        let manifest = Manifest {
+            version: "0.7.0".to_owned(),
+            options: GenerateOptions::default(),
+            digests,
+        };
+        manifest.save(tmp.path()).unwrap();
+        let loaded = Manifest::load(tmp.path()).expect("written manifest loads");
+        assert_eq!(loaded.digests, manifest.digests);
+        assert_eq!(loaded.version, "0.7.0");
+    }
+
+    // --- classification ---
+
+    /// A project whose framework-owned files are exactly the current scaffold.
+    fn scaffolded(opts: GenerateOptions) -> TempDir {
+        let tmp = TempDir::new().unwrap();
+        write(
+            tmp.path(),
+            "Cargo.toml",
+            "[package]\nname = \"demo\"\nversion = \"0.1.0\"\n\n[dependencies]\nautumn-web = \"0.7.0\"\n",
+        );
+        let files = current_files(tmp.path(), opts);
+        for (path, contents) in &files {
+            write(tmp.path(), path, contents);
+        }
+        Manifest::for_files("0.7.0", opts, &files)
+            .save(tmp.path())
+            .unwrap();
+        tmp
+    }
+
+    fn status_of<'a>(entries: &'a [Entry], path: &str) -> &'a Status {
+        &entries
+            .iter()
+            .find(|entry| entry.path == path)
+            .unwrap_or_else(|| {
+                panic!(
+                    "no entry for {path}: {:?}",
+                    entries.iter().map(|e| &e.path).collect::<Vec<_>>()
+                )
+            })
+            .status
+    }
+
+    #[test]
+    fn a_freshly_scaffolded_project_has_no_drift() {
+        let tmp = scaffolded(GenerateOptions::default());
+        let entries = plan_in(tmp.path()).entries;
+        assert!(
+            entries.iter().all(|entry| entry.status == Status::UpToDate),
+            "{:?}",
+            entries
+                .iter()
+                .filter(|e| e.status != Status::UpToDate)
+                .map(|e| (&e.path, &e.status))
+                .collect::<Vec<_>>()
+        );
+        assert!(!drifted(&entries));
+    }
+
+    #[test]
+    fn a_file_the_old_release_never_generated_is_offered_as_an_addition() {
+        let tmp = scaffolded(GenerateOptions::default());
+        fs::remove_file(tmp.path().join("rust-toolchain.toml")).unwrap();
+        // The manifest is the *old* release's: it never knew this file.
+        let mut manifest = Manifest::load(tmp.path()).unwrap();
+        manifest.digests.remove("rust-toolchain.toml");
+        manifest.version = "0.5.0".to_owned();
+        manifest.save(tmp.path()).unwrap();
+
+        let entries = plan_in(tmp.path()).entries;
+        assert_eq!(status_of(&entries, "rust-toolchain.toml"), &Status::Add);
+        assert!(drifted(&entries));
+    }
+
+    #[test]
+    fn an_untouched_file_whose_template_moved_is_an_update() {
+        let tmp = scaffolded(GenerateOptions::default());
+        // Simulate "the template moved": record the digest of what is on disk,
+        // then change the on-disk file to something the *old* template said
+        // while keeping its recorded digest consistent with it.
+        let old = "# an older release's clippy.toml\n";
+        write(tmp.path(), "clippy.toml", old);
+        let mut manifest = Manifest::load(tmp.path()).unwrap();
+        manifest
+            .digests
+            .insert("clippy.toml".to_owned(), digest(old));
+        manifest.save(tmp.path()).unwrap();
+
+        let entries = plan_in(tmp.path()).entries;
+        assert_eq!(status_of(&entries, "clippy.toml"), &Status::Update);
+    }
+
+    #[test]
+    fn a_file_the_developer_edited_is_a_conflict_never_an_update() {
+        let tmp = scaffolded(GenerateOptions::default());
+        write(tmp.path(), "Dockerfile", "FROM scratch\n# my own build\n");
+
+        let entries = plan_in(tmp.path()).entries;
+        assert_eq!(
+            status_of(&entries, "Dockerfile"),
+            &Status::Conflict(ConflictReason::Edited)
+        );
+    }
+
+    #[test]
+    fn a_project_with_no_manifest_gets_conflicts_not_silent_overwrites() {
+        let tmp = scaffolded(GenerateOptions::default());
+        fs::remove_file(tmp.path().join(MANIFEST_PATH)).unwrap();
+        write(tmp.path(), "clippy.toml", "# pre-manifest project\n");
+
+        let entries = plan_in(tmp.path()).entries;
+        assert_eq!(
+            status_of(&entries, "clippy.toml"),
+            &Status::Conflict(ConflictReason::NoBaseline)
+        );
+        // ...but a file it simply never had is still offered.
+        fs::remove_file(tmp.path().join("rustfmt.toml")).unwrap();
+        let entries = plan_in(tmp.path()).entries;
+        assert_eq!(status_of(&entries, "rustfmt.toml"), &Status::Add);
+    }
+
+    #[test]
+    fn a_file_the_developer_deleted_is_reported_but_not_restored() {
+        let tmp = scaffolded(GenerateOptions::default());
+        fs::remove_file(tmp.path().join(".env.example")).unwrap();
+
+        let entries = plan_in(tmp.path()).entries;
+        assert_eq!(status_of(&entries, ".env.example"), &Status::Removed);
+        assert!(
+            !entries
+                .iter()
+                .any(|entry| entry.path == ".env.example" && entry.status.is_applied()),
+            "a deliberate deletion must never be written back"
+        );
+    }
+
+    #[test]
+    fn classification_never_names_a_path_under_src() {
+        let tmp = scaffolded(GenerateOptions::default());
+        write(tmp.path(), "src/main.rs", "fn main() {}\n");
+        for entry in plan_in(tmp.path()).entries {
+            assert!(!entry.path.starts_with("src/"), "{}", entry.path);
+        }
+    }
+
+    #[test]
+    fn api_projects_are_detected_without_a_manifest() {
+        let tmp = scaffolded(GenerateOptions {
+            with_api: true,
+            ..GenerateOptions::default()
+        });
+        fs::remove_file(tmp.path().join(MANIFEST_PATH)).unwrap();
+        let entries = plan_in(tmp.path()).entries;
+        assert!(
+            !entries
+                .iter()
+                .any(|entry| entry.path == "tailwind.config.js"),
+            "an API project must not be offered the Tailwind config"
+        );
+    }
+
+    #[test]
+    fn i18n_projects_are_detected_without_a_manifest() {
+        let tmp = scaffolded(GenerateOptions {
+            with_i18n: true,
+            ..GenerateOptions::default()
+        });
+        fs::remove_file(tmp.path().join(MANIFEST_PATH)).unwrap();
+        write(tmp.path(), "i18n/en.ftl", "welcome = hi\n");
+        let entries = plan_in(tmp.path()).entries;
+        assert_eq!(status_of(&entries, "autumn.toml"), &Status::UpToDate);
+    }
+
+    #[test]
+    fn the_project_name_is_read_from_cargo_toml_not_the_directory() {
+        // `autumn.toml` interpolates the project name; reading it from the
+        // temp directory's random name would make it a conflict in every run.
+        let tmp = scaffolded(GenerateOptions::default());
+        let entries = plan_in(tmp.path()).entries;
+        assert_eq!(status_of(&entries, "autumn.toml"), &Status::UpToDate);
+    }
+
+    // --- report, apply, rendering ---
+
+    fn plan_in(root: &std::path::Path) -> ScaffoldReport {
+        plan(root, "0.7.0")
+    }
+
+    #[test]
+    fn a_directory_without_autumn_files_is_not_a_project() {
+        let tmp = TempDir::new().unwrap();
+        assert!(!is_project(tmp.path()));
+        write(tmp.path(), "autumn.toml", "[server]\n");
+        assert!(is_project(tmp.path()));
+    }
+
+    #[test]
+    fn a_project_known_only_by_its_manifest_is_still_a_project() {
+        let tmp = TempDir::new().unwrap();
+        write(
+            tmp.path(),
+            MANIFEST_PATH,
+            "version = \"0.7.0\"\nflavor = \"api\"\n",
+        );
+        assert!(is_project(tmp.path()));
+    }
+
+    #[test]
+    fn the_report_records_the_recorded_baseline_and_the_target() {
+        let tmp = scaffolded(GenerateOptions::default());
+        let mut manifest = Manifest::load(tmp.path()).unwrap();
+        manifest.version = "0.5.0".to_owned();
+        manifest.save(tmp.path()).unwrap();
+
+        let report = plan_in(tmp.path());
+        assert_eq!(report.baseline.as_deref(), Some("0.5.0"));
+        assert_eq!(report.target, "0.7.0");
+    }
+
+    #[test]
+    fn the_summary_links_the_release_upgrade_guide() {
+        let tmp = scaffolded(GenerateOptions::default());
+        let report = plan_in(tmp.path());
+        assert!(
+            report.guide.contains("docs/migrations/0.7.0.md"),
+            "{}",
+            report.guide
+        );
+        assert!(render_text(&report).contains(&report.guide));
+    }
+
+    #[test]
+    fn a_target_with_no_release_guide_links_the_guide_index() {
+        let tmp = scaffolded(GenerateOptions::default());
+        let report = plan(tmp.path(), "9.9.0");
+        assert!(
+            report.guide.ends_with("docs/migrations/README.md"),
+            "{}",
+            report.guide
+        );
+    }
+
+    #[test]
+    fn preview_writes_nothing() {
+        let tmp = scaffolded(GenerateOptions::default());
+        fs::remove_file(tmp.path().join("rustfmt.toml")).unwrap();
+        let mut manifest = Manifest::load(tmp.path()).unwrap();
+        manifest.digests.remove("rustfmt.toml");
+        manifest.save(tmp.path()).unwrap();
+
+        let report = plan_in(tmp.path());
+        assert_eq!(report.outcome, Outcome::Preview);
+        assert!(!tmp.path().join("rustfmt.toml").exists());
+        assert!(render_text(&report).contains("--apply"));
+    }
+
+    #[test]
+    fn apply_writes_additions_and_updates_but_never_conflicts() {
+        let tmp = scaffolded(GenerateOptions::default());
+
+        // An addition: a file this release introduced.
+        fs::remove_file(tmp.path().join("rustfmt.toml")).unwrap();
+        // An update: untouched by the developer, template moved.
+        let stale = "# an older release's clippy.toml\n";
+        write(tmp.path(), "clippy.toml", stale);
+        // A conflict: the developer's own Dockerfile.
+        let mine = "FROM scratch\n# mine\n";
+        write(tmp.path(), "Dockerfile", mine);
+
+        let mut manifest = Manifest::load(tmp.path()).unwrap();
+        manifest.digests.remove("rustfmt.toml");
+        manifest
+            .digests
+            .insert("clippy.toml".to_owned(), digest(stale));
+        manifest.save(tmp.path()).unwrap();
+
+        let mut report = plan_in(tmp.path());
+        apply(&mut report).expect("apply");
+        assert_eq!(report.outcome, Outcome::Applied);
+
+        let files = current_files(tmp.path(), GenerateOptions::default());
+        assert_eq!(
+            fs::read_to_string(tmp.path().join("rustfmt.toml")).unwrap(),
+            files["rustfmt.toml"]
+        );
+        assert_eq!(
+            fs::read_to_string(tmp.path().join("clippy.toml")).unwrap(),
+            files["clippy.toml"]
+        );
+        assert_eq!(
+            fs::read_to_string(tmp.path().join("Dockerfile")).unwrap(),
+            mine,
+            "a conflict must survive --apply byte for byte"
+        );
+    }
+
+    #[test]
+    fn apply_creates_missing_parent_directories() {
+        let tmp = scaffolded(GenerateOptions::default());
+        fs::remove_dir_all(tmp.path().join(".github")).unwrap();
+        let mut manifest = Manifest::load(tmp.path()).unwrap();
+        manifest.digests.remove(".github/workflows/ci.yml");
+        manifest.save(tmp.path()).unwrap();
+
+        let mut report = plan_in(tmp.path());
+        apply(&mut report).expect("apply");
+        assert!(tmp.path().join(".github/workflows/ci.yml").is_file());
+    }
+
+    #[test]
+    fn apply_refreshes_the_manifest_so_a_second_run_is_clean() {
+        let tmp = scaffolded(GenerateOptions::default());
+        fs::remove_file(tmp.path().join("rustfmt.toml")).unwrap();
+        let mut manifest = Manifest::load(tmp.path()).unwrap();
+        manifest.digests.remove("rustfmt.toml");
+        manifest.version = "0.5.0".to_owned();
+        manifest.save(tmp.path()).unwrap();
+
+        let mut report = plan_in(tmp.path());
+        apply(&mut report).expect("apply");
+
+        let second = plan_in(tmp.path());
+        assert!(!second.drifted(), "{}", render_text(&second));
+        assert_eq!(second.baseline.as_deref(), Some("0.7.0"));
+    }
+
+    #[test]
+    fn apply_leaves_the_baseline_version_alone_while_conflicts_remain() {
+        // Recording "you are on 0.7.0" while files are still unreconciled would
+        // make the next run's report say the upgrade already happened.
+        let tmp = scaffolded(GenerateOptions::default());
+        write(tmp.path(), "Dockerfile", "FROM scratch\n");
+        let mut manifest = Manifest::load(tmp.path()).unwrap();
+        manifest.version = "0.5.0".to_owned();
+        manifest.save(tmp.path()).unwrap();
+
+        let mut report = plan_in(tmp.path());
+        apply(&mut report).expect("apply");
+        assert_eq!(Manifest::load(tmp.path()).unwrap().version, "0.5.0");
+    }
+
+    #[test]
+    fn apply_refuses_a_file_that_changed_after_the_plan_was_made() {
+        let tmp = scaffolded(GenerateOptions::default());
+        let stale = "# older\n";
+        write(tmp.path(), "clippy.toml", stale);
+        let mut manifest = Manifest::load(tmp.path()).unwrap();
+        manifest
+            .digests
+            .insert("clippy.toml".to_owned(), digest(stale));
+        manifest.save(tmp.path()).unwrap();
+
+        let mut report = plan_in(tmp.path());
+        // Something else (a formatter, an editor) writes between plan and apply.
+        write(tmp.path(), "clippy.toml", "# touched by someone else\n");
+
+        let failure = apply(&mut report).expect_err("must refuse a changed file");
+        assert_eq!(failure.path, "clippy.toml");
+        assert_eq!(
+            fs::read_to_string(tmp.path().join("clippy.toml")).unwrap(),
+            "# touched by someone else\n"
+        );
+        assert!(matches!(report.outcome, Outcome::Partial { .. }));
+    }
+
+    #[test]
+    fn apply_refuses_an_addition_that_appeared_after_the_plan_was_made() {
+        let tmp = scaffolded(GenerateOptions::default());
+        fs::remove_file(tmp.path().join("rustfmt.toml")).unwrap();
+        let mut manifest = Manifest::load(tmp.path()).unwrap();
+        manifest.digests.remove("rustfmt.toml");
+        manifest.save(tmp.path()).unwrap();
+
+        let mut report = plan_in(tmp.path());
+        write(tmp.path(), "rustfmt.toml", "# mine, written just now\n");
+
+        let failure = apply(&mut report).expect_err("must refuse to clobber");
+        assert_eq!(failure.path, "rustfmt.toml");
+        assert_eq!(
+            fs::read_to_string(tmp.path().join("rustfmt.toml")).unwrap(),
+            "# mine, written just now\n"
+        );
+    }
+
+    #[test]
+    fn the_text_report_names_every_drifted_file_with_its_status() {
+        let tmp = scaffolded(GenerateOptions::default());
+        fs::remove_file(tmp.path().join("rustfmt.toml")).unwrap();
+        write(tmp.path(), "Dockerfile", "FROM scratch\n");
+        let mut manifest = Manifest::load(tmp.path()).unwrap();
+        manifest.digests.remove("rustfmt.toml");
+        manifest.save(tmp.path()).unwrap();
+
+        let text = render_text(&plan_in(tmp.path()));
+        assert!(text.contains("rustfmt.toml"), "{text}");
+        assert!(text.contains("add"), "{text}");
+        assert!(text.contains("Dockerfile"), "{text}");
+        assert!(text.contains("conflict"), "{text}");
+        // The revert path is documented in the report itself, not only in prose.
+        assert!(text.contains("git diff"), "{text}");
+        // Up-to-date files are not listed one by one.
+        assert!(!text.contains("clippy.toml"), "{text}");
+    }
+
+    #[test]
+    fn a_project_with_no_drift_says_so_without_listing_files() {
+        let tmp = scaffolded(GenerateOptions::default());
+        let text = render_text(&plan_in(tmp.path()));
+        assert!(text.contains("up to date"), "{text}");
+    }
+
+    #[test]
+    fn the_json_report_carries_a_status_per_file() {
+        let tmp = scaffolded(GenerateOptions::default());
+        fs::remove_file(tmp.path().join("rustfmt.toml")).unwrap();
+        let mut manifest = Manifest::load(tmp.path()).unwrap();
+        manifest.digests.remove("rustfmt.toml");
+        manifest.save(tmp.path()).unwrap();
+
+        let value = json(&plan_in(tmp.path()));
+        assert_eq!(value["target"], "0.7.0");
+        assert_eq!(value["drift"], true);
+        let files = value["files"].as_array().unwrap();
+        let entry = files
+            .iter()
+            .find(|file| file["path"] == "rustfmt.toml")
+            .expect("rustfmt.toml in the json report");
+        assert_eq!(entry["status"], "add");
+        assert!(value["guide"].as_str().unwrap().contains("docs/migrations"));
+    }
+
+    #[test]
+    fn a_report_with_only_conflicts_does_not_advertise_apply() {
+        // `--apply` would write nothing here, and telling someone to run a
+        // command that cannot help them is how a tool loses their attention.
+        let tmp = scaffolded(GenerateOptions::default());
+        write(tmp.path(), "Dockerfile", "FROM scratch\n");
+
+        let text = render_text(&plan_in(tmp.path()));
+        assert!(text.contains("conflict"), "{text}");
+        assert!(!text.contains("--apply"), "{text}");
+        assert!(text.contains("git diff"), "{text}");
+    }
+}

--- a/autumn-cli/src/upgrade/scaffold.rs
+++ b/autumn-cli/src/upgrade/scaffold.rs
@@ -208,6 +208,15 @@ impl Manifest {
             digests: file.files,
             pinned: file.pinned,
         })
+        // A combination `autumn new` would have refused cannot have produced
+        // this project, so the manifest is corrupt however well-formed it
+        // parses. `--api` with `--daemon`, for instance, are different app
+        // shapes with conflicting feature sets: trusting it would render the
+        // API templates against a fullstack daemon's digests and make its
+        // `Dockerfile` and `build.rs` look like safe updates. Validated with
+        // `autumn new`'s own rule, so the two can never disagree about what is
+        // possible.
+        .filter(|manifest: &Self| crate::new::check_option_combination(manifest.options).is_ok())
     }
 
     /// Load the manifest under `root`, or `None` when there is not a readable
@@ -732,6 +741,14 @@ pub struct ScaffoldReport {
     /// not, the scaffold cannot be rendered for comparison and [`Self::entries`]
     /// is empty — which is a refusal to answer, not an "all clear".
     pub named: bool,
+    /// The recorded baseline, when it names a release newer than this CLI.
+    ///
+    /// Reconciling then means rendering *older* templates against digests a
+    /// newer release wrote — so every untouched file matches its digest,
+    /// classifies as a writable `update`, and `--apply` silently downgrades the
+    /// `Dockerfile`, the build script and the CI workflow. Downgrades are out
+    /// of scope, so the run refuses instead and [`Self::entries`] is empty.
+    pub scaffolded_by_newer: Option<String>,
     /// Whether this project is a crate inside an enclosing Cargo workspace, in
     /// which case the files that workspace owns at its root are out of scope.
     pub workspace_member: bool,
@@ -881,12 +898,24 @@ pub fn plan_after(root: &Path, _target: &str, migrated: &BTreeSet<String>) -> Sc
     let target = env!("CARGO_PKG_VERSION").to_owned();
     let manifest = Manifest::load(root);
     let options = resolve_options(root, manifest.as_ref());
-    let files = current_files(root, options);
+    // A baseline from a release newer than this CLI cannot be reconciled: the
+    // templates here are older than the files those digests describe, so every
+    // untouched file would classify as a writable `update` and `--apply` would
+    // downgrade it. Nothing is rendered and nothing is classified.
+    let scaffolded_by_newer = manifest
+        .as_ref()
+        .and_then(|manifest| manifest.version.clone())
+        .filter(|recorded| is_newer_than_this_cli(recorded));
+    let files = scaffolded_by_newer
+        .is_none()
+        .then(|| current_files(root, options))
+        .flatten();
     ScaffoldReport {
         root: root.to_path_buf(),
         options,
         baseline: manifest.as_ref().and_then(|m| m.version.clone()),
-        named: files.is_some(),
+        named: scaffolded_by_newer.is_some() || files.is_some(),
+        scaffolded_by_newer,
         workspace_member: workspace_root_above(root).is_some(),
         entries: files
             .map(|files| classify(root, &files, manifest.as_ref(), migrated))
@@ -896,6 +925,22 @@ pub fn plan_after(root: &Path, _target: &str, migrated: &BTreeSet<String>) -> Sc
         has_manifest: manifest.is_some(),
         outcome: super::Outcome::Preview,
     }
+}
+
+/// Whether `recorded` names a release newer than the one this CLI ships.
+///
+/// An unparsable version is *not* newer: it is simply unknown, and the
+/// conservative answer there is the one the rest of the module already gives an
+/// unreadable manifest — no baseline, everything a conflict — rather than a
+/// refusal that a typo could trigger.
+fn is_newer_than_this_cli(recorded: &str) -> bool {
+    let (Some(recorded), Some(ours)) = (
+        super::migrations::parse_version_req(recorded),
+        super::migrations::parse_version_req(env!("CARGO_PKG_VERSION")),
+    ) else {
+        return false;
+    };
+    recorded > ours
 }
 
 /// Record `paths` as the developer's own, so reconciliation leaves them alone.
@@ -1224,6 +1269,19 @@ fn render(report: &ScaffoldReport, diffs: bool) -> String {
     use std::fmt::Write as _;
 
     let mut out = String::new();
+    if let Some(newer) = &report.scaffolded_by_newer {
+        let _ = writeln!(out, "\nScaffold files");
+        let _ = writeln!(
+            out,
+            "  Skipped: this project was scaffolded by autumn-cli {newer}, which is newer\n  \
+             than this one ({}). Reconciling would render older templates over newer\n  \
+             files — a downgrade, which this command does not do. Install {newer} or\n  \
+             later and run it again.",
+            report.target
+        );
+        let _ = writeln!(out, "  Upgrade guide: {}", report.guide);
+        return out;
+    }
     if !report.named {
         let _ = writeln!(out, "\nScaffold files");
         let _ = writeln!(
@@ -1388,6 +1446,7 @@ pub fn json(report: &ScaffoldReport) -> serde_json::Value {
         "baseline": report.baseline,
         "target": report.target,
         "named": report.named,
+        "scaffolded_by_newer": report.scaffolded_by_newer,
         "has_manifest": report.has_manifest,
         "outcome": report.outcome.label(),
         "drift": report.drifted(),
@@ -2635,5 +2694,70 @@ mod tests {
         );
         assert_eq!(failure.written, report.applicable().len());
         assert_eq!(fs::read_to_string(&outside).unwrap(), "not mine\n");
+    }
+
+    #[test]
+    fn a_project_scaffolded_by_a_newer_release_is_refused_not_downgraded() {
+        // The recorded digests still match, so every untouched file looks like
+        // a writable `update` against this older CLI's templates — and applying
+        // them would DOWNGRADE the Dockerfile, build script and CI workflow.
+        // Downgrades are out of scope; silently performing one is worse still.
+        let tmp = scaffolded(GenerateOptions::default());
+        let mut manifest = Manifest::load(tmp.path()).unwrap();
+        manifest.version = Some("99.0.0".to_owned());
+        manifest.save(tmp.path()).unwrap();
+        // An older template on disk, matching its recorded digest exactly as a
+        // newer CLI's output would.
+        let newer = "# written by a newer release\n";
+        write(tmp.path(), "clippy.toml", newer);
+        let mut manifest = Manifest::load(tmp.path()).unwrap();
+        manifest
+            .digests
+            .insert("clippy.toml".to_owned(), digest(newer));
+        manifest.save(tmp.path()).unwrap();
+
+        let report = plan_in(tmp.path());
+        assert!(report.entries.is_empty(), "nothing may be reconciled");
+        assert!(!report.drifted());
+        let text = render_text(&report);
+        assert!(text.contains("newer"), "{text}");
+
+        let mut report = plan_in(tmp.path());
+        apply(&mut report).expect("apply");
+        assert_eq!(
+            fs::read_to_string(tmp.path().join("clippy.toml")).unwrap(),
+            newer,
+            "a newer release's file must never be downgraded"
+        );
+    }
+
+    #[test]
+    fn an_impossible_option_combination_is_no_baseline() {
+        // `--api` with `--daemon` is a combination `autumn new` refuses: they
+        // are different app shapes with conflicting feature sets. A manifest
+        // claiming both is corrupt, and trusting it renders the API templates
+        // against a fullstack daemon's digests — making its `Dockerfile` and
+        // `build.rs` look like safe updates.
+        let tmp = scaffolded(GenerateOptions::default());
+        let text = fs::read_to_string(tmp.path().join(MANIFEST_PATH)).unwrap();
+        fs::write(
+            tmp.path().join(MANIFEST_PATH),
+            text.replace("flavor = \"fullstack\"", "flavor = \"api\"")
+                .replace("daemon = false", "daemon = true"),
+        )
+        .unwrap();
+
+        assert!(
+            Manifest::load(tmp.path()).is_none(),
+            "an incoherent option set vouches for nothing"
+        );
+
+        let before = fs::read_to_string(tmp.path().join("Dockerfile")).unwrap();
+        let mut report = plan_in(tmp.path());
+        apply(&mut report).expect("apply");
+        assert_eq!(
+            fs::read_to_string(tmp.path().join("Dockerfile")).unwrap(),
+            before
+        );
     }
 }

--- a/autumn-cli/src/upgrade/scaffold.rs
+++ b/autumn-cli/src/upgrade/scaffold.rs
@@ -186,7 +186,20 @@ impl Manifest {
         Some(Self {
             version: file.version,
             options: GenerateOptions {
-                with_api: file.flavor == FLAVOR_API,
+                // Anything but the two flavours this CLI knows is treated as no
+                // manifest at all. Falling back to `fullstack` would keep
+                // trusting the recorded *digests* while rendering the wrong
+                // templates against them — so an API project's `Dockerfile`,
+                // untouched and matching its baseline, would classify as
+                // `update` and be replaced with the fullstack one while its
+                // `Cargo.toml` stayed API-shaped. A value written by a newer
+                // release, or a typo, is exactly when the conservative
+                // no-baseline path is wanted.
+                with_api: match file.flavor.as_str() {
+                    FLAVOR_API => true,
+                    FLAVOR_FULLSTACK => false,
+                    _ => return None,
+                },
                 with_i18n: file.i18n,
                 with_seed: file.seed,
                 with_daemon: file.daemon,
@@ -211,12 +224,26 @@ impl Manifest {
     }
 
     /// Write the manifest under `root`, creating `.autumn/` if needed.
+    ///
+    /// # Errors
+    ///
+    /// Fails if the path cannot be written — including when `.autumn` or the
+    /// manifest itself is a symbolic link. The manifest is written by a
+    /// different code path than the scaffold files and would otherwise have had
+    /// none of their protection: following the link would truncate a file
+    /// outside the project, invisibly to that project's own `git diff`.
     pub fn save(&self, root: &Path) -> std::io::Result<()> {
+        if matches!(read_current(root, MANIFEST_PATH), OnDisk::Linked(_)) {
+            return Err(std::io::Error::other(format!(
+                "{MANIFEST_PATH} (or a directory on the way to it) is a symlink; \
+                 writing through it could write outside the project"
+            )));
+        }
         let path = root.join(MANIFEST_PATH);
         if let Some(parent) = path.parent() {
             std::fs::create_dir_all(parent)?;
         }
-        std::fs::write(path, self.render())
+        publish(&path, &self.render()).map_err(std::io::Error::other)
     }
 }
 
@@ -994,10 +1021,7 @@ fn write_one(entry: &Entry) -> Result<(), String> {
         .ok_or_else(|| "no parent directory".to_owned())?;
     std::fs::create_dir_all(directory).map_err(|error| error.to_string())?;
 
-    if entry.current == OnDisk::Absent {
-        return create_atomically(entry);
-    }
-    replace_in_place(entry, directory)
+    publish(&entry.absolute, &entry.template)
 }
 
 /// Where an in-progress write to `absolute` is staged.
@@ -1013,24 +1037,25 @@ fn scratch_path(absolute: &Path) -> PathBuf {
     absolute.with_file_name(format!(".autumn-upgrade-{}.tmp", name.to_string_lossy()))
 }
 
-/// Publish a file at a path nothing occupies yet.
+/// Publish `contents` at `absolute`, atomically.
 ///
-/// Staged and renamed, not written in place. A plain `fs::write` interrupted by
-/// Ctrl-C or a full disk leaves a truncated file at the destination — and that
-/// file has no recorded baseline, so the *next* run classifies it as a conflict
-/// and refuses to touch it. The crash would be permanent: a corrupted file this
-/// command can never repair.
+/// Staged beside the destination and renamed into place, never written in
+/// place. A plain `fs::write` interrupted by Ctrl-C or a full disk leaves a
+/// truncated file — and for a file this command *added*, that is permanent: the
+/// truncated file has no recorded baseline, so the next run classifies it as a
+/// conflict and refuses to touch it.
 ///
 /// Staged by hand rather than through `tempfile`, which deliberately creates
 /// its temporaries 0600. Renaming one of those into place would leave an added
 /// `ci.yml` or `input.css` unreadable to every other uid — fatal to a Docker
 /// stage that drops privileges, and invisible in `git diff`, which tracks only
-/// the executable bit. `OpenOptions` honours the process umask, so the file
-/// lands with exactly the mode `autumn new` would have given it.
-fn create_atomically(entry: &Entry) -> Result<(), String> {
+/// the executable bit. `OpenOptions` honours the process umask, so a new file
+/// lands with exactly the mode `autumn new` would have given it; an existing
+/// one keeps the mode it already had.
+fn publish(absolute: &Path, contents: &str) -> Result<(), String> {
     use std::io::Write as _;
 
-    let scratch = scratch_path(&entry.absolute);
+    let scratch = scratch_path(absolute);
     // Debris from a killed run, cleared so a crash is not permanent. Only ever
     // this function's own scratch name, and never the destination.
     let _ = std::fs::remove_file(&scratch);
@@ -1042,49 +1067,26 @@ fn create_atomically(entry: &Entry) -> Result<(), String> {
         .create_new(true)
         .open(&scratch)
         .map_err(|error| format!("{}: {error}", scratch.display()))?;
+    // Replacing a file keeps its mode; the umask default the scratch was
+    // created with is only right for a file that is genuinely new.
+    if let Ok(metadata) = std::fs::metadata(absolute) {
+        let _ = file.set_permissions(metadata.permissions());
+    }
 
     let staged = file
-        .write_all(entry.template.as_bytes())
+        .write_all(contents.as_bytes())
         .and_then(|()| file.flush())
         // The rename is atomic, but only against a crash if the bytes reached
         // the disk first: otherwise the rename can land before the data and
         // publish an empty file.
         .and_then(|()| file.sync_all());
     drop(file);
-    let published = staged.and_then(|()| std::fs::rename(&scratch, &entry.absolute));
+    let published = staged.and_then(|()| std::fs::rename(&scratch, absolute));
     if published.is_err() {
         // Nothing half-written survives, at the destination or beside it.
         let _ = std::fs::remove_file(&scratch);
     }
     published.map_err(|error| error.to_string())
-}
-
-/// Replace an existing file's contents atomically, keeping its mode.
-fn replace_in_place(entry: &Entry, directory: &Path) -> Result<(), String> {
-    use std::io::Write as _;
-
-    let mut temp = tempfile::Builder::new()
-        .prefix(".autumn-upgrade-")
-        .suffix(".tmp")
-        .tempfile_in(directory)
-        .map_err(|error| error.to_string())?;
-    temp.write_all(entry.template.as_bytes())
-        .map_err(|error| error.to_string())?;
-    temp.flush().map_err(|error| error.to_string())?;
-    // The rename is atomic, but only against a crash if the bytes reached the
-    // disk first: otherwise the rename can land before the data and leave an
-    // empty file where a working one used to be.
-    temp.as_file()
-        .sync_all()
-        .map_err(|error| error.to_string())?;
-    // A fresh temporary is created 0600; renaming it over an existing file
-    // would otherwise silently tighten that file's mode.
-    if let Ok(metadata) = std::fs::metadata(&entry.absolute) {
-        let _ = temp.as_file().set_permissions(metadata.permissions());
-    }
-    temp.persist(&entry.absolute)
-        .map_err(|error| error.to_string())?;
-    Ok(())
 }
 
 /// Re-read what an entry's path holds now, by the same rules the plan used —
@@ -2271,5 +2273,80 @@ mod tests {
             fs::read_to_string(tmp.path().join("rustfmt.toml")).unwrap(),
             files["rustfmt.toml"]
         );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn a_symlinked_manifest_is_never_written_through() {
+        // The manifest is written by a different path than the scaffold files,
+        // and had none of their symlink protection: a symlinked
+        // `.autumn/scaffold.toml` would have been followed and its target
+        // outside the project truncated, invisibly to the project's own
+        // `git diff`.
+        let tmp = scaffolded(GenerateOptions::default());
+        let outside = tmp.path().join("outside.toml");
+        fs::write(&outside, "not mine to touch\n").unwrap();
+        fs::remove_file(tmp.path().join(MANIFEST_PATH)).unwrap();
+        std::os::unix::fs::symlink(&outside, tmp.path().join(MANIFEST_PATH)).unwrap();
+
+        fs::remove_file(tmp.path().join("rustfmt.toml")).unwrap();
+        let mut report = plan_in(tmp.path());
+        apply(&mut report).expect("the scaffold files still reconcile");
+
+        assert_eq!(
+            fs::read_to_string(&outside).unwrap(),
+            "not mine to touch\n",
+            "the link target must never be written through"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn a_symlinked_autumn_directory_is_never_written_through() {
+        let tmp = scaffolded(GenerateOptions::default());
+        let outside = tmp.path().join("outside-dir");
+        fs::create_dir_all(&outside).unwrap();
+        fs::remove_dir_all(tmp.path().join(".autumn")).unwrap();
+        std::os::unix::fs::symlink(&outside, tmp.path().join(".autumn")).unwrap();
+
+        fs::remove_file(tmp.path().join("rustfmt.toml")).unwrap();
+        let mut report = plan_in(tmp.path());
+        apply(&mut report).expect("the scaffold files still reconcile");
+
+        assert!(
+            !outside.join("scaffold.toml").exists(),
+            "nothing may be written through a symlinked parent"
+        );
+    }
+
+    #[test]
+    fn an_unrecognised_flavor_is_no_baseline_rather_than_a_guess() {
+        // A `flavor` this CLI does not know — a typo, corruption, or a value a
+        // newer release writes — must not silently read as `fullstack`. The
+        // digests would still be trusted, so an API project's `Dockerfile`
+        // would be classified `update` and replaced with the fullstack one
+        // while its `Cargo.toml` stayed API-shaped.
+        let tmp = scaffolded(GenerateOptions {
+            with_api: true,
+            ..GenerateOptions::default()
+        });
+        let text = fs::read_to_string(tmp.path().join(MANIFEST_PATH)).unwrap();
+        fs::write(
+            tmp.path().join(MANIFEST_PATH),
+            text.replace("flavor = \"api\"", "flavor = \"fullstack-v2\""),
+        )
+        .unwrap();
+
+        assert!(Manifest::load(tmp.path()).is_none());
+
+        let before = fs::read_to_string(tmp.path().join("Dockerfile")).unwrap();
+        let mut report = plan_in(tmp.path());
+        apply(&mut report).expect("apply");
+        assert_eq!(
+            fs::read_to_string(tmp.path().join("Dockerfile")).unwrap(),
+            before,
+            "an unreadable flavor must fall back to the conservative no-baseline path"
+        );
+        assert!(!tmp.path().join("tailwind.config.js").exists());
     }
 }

--- a/autumn-cli/src/upgrade/scaffold.rs
+++ b/autumn-cli/src/upgrade/scaffold.rs
@@ -977,13 +977,10 @@ pub fn plan_after(root: &Path, _target: &str, migrated: &BTreeSet<String>) -> Sc
 /// The newer of two release strings, preferring `candidate` when neither
 /// parses as a version.
 fn newest(previous: Option<&str>, candidate: &str) -> String {
-    let parse = super::migrations::parse_version_req;
-    match (previous.and_then(parse), parse(candidate)) {
-        (Some(previous_version), Some(candidate_version))
-            if previous_version > candidate_version =>
-        {
-            previous.unwrap_or(candidate).to_owned()
-        }
+    match previous {
+        // The same precedence the refusal uses. A high-water mark compared any
+        // other way could move backwards across two prereleases of one triple.
+        Some(previous) if is_newer(previous, candidate) => previous.to_owned(),
         _ => candidate.to_owned(),
     }
 }
@@ -992,18 +989,77 @@ fn newest(previous: Option<&str>, candidate: &str) -> String {
 ///
 /// Only ever reached with a value [`Manifest::parse`] has already proven
 /// readable: an unreadable one makes the whole manifest no baseline, so this
-/// never has to decide what "unknown" means. It answers `false` for one anyway,
-/// because a comparison that cannot be made is not evidence of anything — but
-/// that answer must never again be the *only* thing standing between a corrupt
-/// version string and a trusted set of digests, which is exactly what it was.
+/// never has to decide what "unknown" means.
 fn is_newer_than_this_cli(recorded: &str) -> bool {
-    let (Some(recorded), Some(ours)) = (
-        super::migrations::parse_version_req(recorded),
-        super::migrations::parse_version_req(env!("CARGO_PKG_VERSION")),
-    ) else {
+    is_newer(recorded, env!("CARGO_PKG_VERSION"))
+}
+
+/// Whether `recorded` has strictly higher SemVer precedence than `ours`.
+///
+/// Deliberately **not** [`Version`](super::migrations::Version)'s own [`Ord`],
+/// which distinguishes only prerelease-from-stable and treats every prerelease
+/// of one triple as interchangeable. That is right for what it exists for — an
+/// app on `0.8.0-rc.1` needs the same codemods as one on `0.8.0-rc.2`, so
+/// selection must not split them, and a test in that module pins it — and
+/// wrong here, where the question is which renderer wrote a file. Borrowing it
+/// made `0.8.0-rc.2` and `0.8.0-rc.1` compare equal, so an rc.1 CLI did not
+/// refuse an rc.2 project and downgraded every file it rendered.
+fn is_newer(recorded: &str, ours: &str) -> bool {
+    let parse = super::migrations::parse_version_req;
+    let (Some(recorded), Some(ours)) = (parse(recorded), parse(ours)) else {
         return false;
     };
-    recorded > ours
+    precedence(&recorded, &ours) == std::cmp::Ordering::Greater
+}
+
+/// Full SemVer precedence, prerelease identifiers included.
+fn precedence(
+    left: &super::migrations::Version,
+    right: &super::migrations::Version,
+) -> std::cmp::Ordering {
+    use std::cmp::Ordering;
+
+    (left.major, left.minor, left.patch)
+        .cmp(&(right.major, right.minor, right.patch))
+        .then_with(
+            || match (left.prerelease.as_deref(), right.prerelease.as_deref()) {
+                (None, None) => Ordering::Equal,
+                // A stable release outranks any prerelease of its own triple.
+                (None, Some(_)) => Ordering::Greater,
+                (Some(_), None) => Ordering::Less,
+                (Some(left), Some(right)) => prerelease_precedence(left, right),
+            },
+        )
+}
+
+/// SemVer §11.4 precedence between two prerelease identifier sets.
+fn prerelease_precedence(left: &str, right: &str) -> std::cmp::Ordering {
+    use std::cmp::Ordering;
+
+    let mut left = left.split('.');
+    let mut right = right.split('.');
+    loop {
+        let ordering = match (left.next(), right.next()) {
+            (None, None) => return Ordering::Equal,
+            // "A larger set of pre-release fields has a higher precedence than
+            // a smaller set, if all of the preceding identifiers are equal."
+            (None, Some(_)) => return Ordering::Less,
+            (Some(_), None) => return Ordering::Greater,
+            (Some(left), Some(right)) => match (left.parse::<u64>(), right.parse::<u64>()) {
+                // Numeric identifiers are compared numerically, so `rc.10`
+                // outranks `rc.9` — which a text comparison gets backwards.
+                (Ok(left), Ok(right)) => left.cmp(&right),
+                // "Numeric identifiers always have lower precedence than
+                // non-numeric identifiers."
+                (Ok(_), Err(_)) => Ordering::Less,
+                (Err(_), Ok(_)) => Ordering::Greater,
+                (Err(_), Err(_)) => left.cmp(right),
+            },
+        };
+        if ordering != Ordering::Equal {
+            return ordering;
+        }
+    }
 }
 
 /// Record `paths` as the developer's own, so reconciliation leaves them alone.
@@ -3008,5 +3064,38 @@ mod tests {
         let loaded = Manifest::load(tmp.path()).expect("still a baseline");
         assert!(loaded.version.is_none());
         assert!(!loaded.digests.is_empty());
+    }
+
+    fn newer(recorded: &str) -> bool {
+        is_newer(recorded, "0.8.0-rc.1")
+    }
+
+    #[test]
+    fn provenance_compares_prereleases_by_full_semver_precedence() {
+        // `Version`'s own ordering distinguishes only prerelease-vs-stable,
+        // deliberately: codemod selection treats every prerelease of a triple
+        // as interchangeable. Provenance cannot. Reusing that comparator makes
+        // `0.8.0-rc.2` and `0.8.0-rc.1` equal, so an rc.1 CLI does not refuse
+        // an rc.2 project and downgrades every file it renders.
+        assert!(newer("0.8.0-rc.2"), "rc.2 is newer than rc.1");
+        assert!(!newer("0.8.0-rc.1"), "the same release is not newer");
+        assert!(!newer("0.8.0-rc.0"), "rc.0 is older");
+
+        // A stable release outranks any prerelease of its own triple.
+        assert!(newer("0.8.0"));
+        assert!(!is_newer("0.8.0-rc.9", "0.8.0"));
+
+        // Numeric identifiers compare numerically, not as text.
+        assert!(is_newer("0.8.0-rc.10", "0.8.0-rc.9"));
+        assert!(!is_newer("0.8.0-rc.9", "0.8.0-rc.10"));
+
+        // Numeric identifiers rank below alphanumeric ones, and a longer set of
+        // fields outranks a shorter one that is otherwise equal (SemVer 11.4).
+        assert!(is_newer("0.8.0-alpha", "0.8.0-1"));
+        assert!(is_newer("0.8.0-rc.1", "0.8.0-rc"));
+
+        // The triple still dominates everything.
+        assert!(is_newer("0.9.0-rc.1", "0.8.0"));
+        assert!(!is_newer("0.8.0", "0.9.0-rc.1"));
     }
 }

--- a/autumn-cli/src/upgrade/scaffold.rs
+++ b/autumn-cli/src/upgrade/scaffold.rs
@@ -994,7 +994,7 @@ fn is_newer_than_this_cli(recorded: &str) -> bool {
     is_newer(recorded, env!("CARGO_PKG_VERSION"))
 }
 
-/// Whether `recorded` has strictly higher SemVer precedence than `ours`.
+/// Whether `recorded` has strictly higher `SemVer` precedence than `ours`.
 ///
 /// Deliberately **not** [`Version`](super::migrations::Version)'s own [`Ord`],
 /// which distinguishes only prerelease-from-stable and treats every prerelease
@@ -1012,7 +1012,7 @@ fn is_newer(recorded: &str, ours: &str) -> bool {
     precedence(&recorded, &ours) == std::cmp::Ordering::Greater
 }
 
-/// Full SemVer precedence, prerelease identifiers included.
+/// Full `SemVer` precedence, prerelease identifiers included.
 fn precedence(
     left: &super::migrations::Version,
     right: &super::migrations::Version,
@@ -1032,7 +1032,7 @@ fn precedence(
         )
 }
 
-/// SemVer §11.4 precedence between two prerelease identifier sets.
+/// `SemVer` §11.4 precedence between two prerelease identifier sets.
 fn prerelease_precedence(left: &str, right: &str) -> std::cmp::Ordering {
     use std::cmp::Ordering;
 

--- a/autumn-cli/src/upgrade/scaffold.rs
+++ b/autumn-cli/src/upgrade/scaffold.rs
@@ -1041,11 +1041,17 @@ pub fn apply(report: &mut ScaffoldReport) -> Result<(), WriteFailure> {
 /// success would tell a CI script otherwise.
 fn record_baseline(report: &ScaffoldReport) -> Result<(), String> {
     // A report with no entries reconciled nothing, and rebuilding the manifest
-    // from no entries would prune every digest in it. That is the baseline the
-    // whole feature rests on, destroyed by a run that did not even look at the
-    // files. The only report shaped like this is one whose project name could
-    // not be read, which is a refusal to answer, not an answer.
-    if !report.named {
+    // from no entries prunes every digest in it and stamps this CLI's version
+    // over whatever was recorded. That is the baseline the whole feature rests
+    // on, destroyed by a run that did not even look at the files.
+    //
+    // Keyed on the entries themselves rather than on *why* they are empty. That
+    // distinction has already cost once: this guard was written as `!named` for
+    // the unreadable-package-name case, and the newer-scaffold refusal then
+    // arrived with entries empty and `named` true, walking straight past it.
+    // Every reason to refuse produces an empty plan, so that is the thing to
+    // check.
+    if report.entries.is_empty() {
         return Ok(());
     }
     let previous = Manifest::load(&report.root);
@@ -1130,32 +1136,6 @@ enum Publish {
     Replace,
 }
 
-/// The mode a file newly created in `directory` should carry.
-///
-/// Derived from the directory's own mode rather than by reading the process
-/// umask, which has no race-free getter — the only way to read it is to set it
-/// and set it back. Masking the directory's mode down to the file permission
-/// bits reproduces the umask-derived answer in every ordinary case (`0755` ->
-/// `0644`, `0700` -> `0600`, `0775` -> `0664`), which is what matters: a file
-/// this command adds must be exactly as readable as the one `autumn new` would
-/// have written beside it. `tempfile` creates its temporaries `0600`, and
-/// publishing one of those unchanged would leave an added `ci.yml` or
-/// `input.css` unreadable to every other uid — fatal to a Docker stage that
-/// drops privileges, and invisible in `git diff`, which tracks only the
-/// executable bit.
-#[cfg(unix)]
-fn permissions_for_new_file(directory: &Path) -> Option<std::fs::Permissions> {
-    use std::os::unix::fs::PermissionsExt as _;
-
-    let mode = std::fs::metadata(directory).ok()?.permissions().mode();
-    Some(std::fs::Permissions::from_mode(mode & 0o666))
-}
-
-#[cfg(not(unix))]
-fn permissions_for_new_file(_directory: &Path) -> Option<std::fs::Permissions> {
-    None
-}
-
 /// Publish `contents` at `absolute`, atomically.
 ///
 /// Staged beside the destination and published by a single link operation,
@@ -1188,25 +1168,33 @@ fn publish(absolute: &Path, contents: &str, mode: Publish) -> Result<(), String>
     let directory = absolute
         .parent()
         .ok_or_else(|| "no parent directory".to_owned())?;
+    // Created through ordinary `0o666` open semantics so the process umask
+    // applies, exactly as it does to the `fs::write` that `autumn new` uses.
+    // `tempfile`'s own constructor deliberately creates `0600`, and deriving a
+    // mode from the directory does not reproduce the umask either: a `0775`
+    // checkout under umask `022` yields `0664` that way and `0644` from a real
+    // write, quietly granting group write. `make_in` still supplies the unique
+    // name and the delete-on-drop, so nothing this function did not create is
+    // ever removed.
     let mut temp = tempfile::Builder::new()
         .prefix(".autumn-upgrade-")
         .suffix(".tmp")
-        .tempfile_in(directory)
+        .make_in(directory, |path| {
+            std::fs::OpenOptions::new()
+                .write(true)
+                .create_new(true)
+                .open(path)
+        })
         .map_err(|error| error.to_string())?;
 
     // A file that is really there keeps the mode it already has; anything else
-    // is genuinely new and takes the mode the directory implies. Keyed on what
-    // is on disk rather than on `mode`, which says whether replacing is
-    // *allowed*, not whether there is anything to replace: a `Publish::Replace`
-    // of an absent path — the manifest on every `autumn new` — would otherwise
-    // keep `tempfile`'s 0600, and a manifest another uid cannot read is
-    // discarded as unreadable, throwing away every baseline in it.
-    let permissions = std::fs::metadata(absolute)
-        .ok()
-        .map(|metadata| metadata.permissions())
-        .or_else(|| permissions_for_new_file(directory));
-    if let Some(permissions) = permissions {
-        let _ = temp.as_file().set_permissions(permissions);
+    // is genuinely new and keeps the umask-derived mode it was just created
+    // with. Keyed on what is on disk rather than on `mode`, which says whether
+    // replacing is *allowed*, not whether there is anything to replace — a
+    // `Publish::Replace` of an absent path is the manifest on every
+    // `autumn new`.
+    if let Ok(metadata) = std::fs::metadata(absolute) {
+        let _ = temp.as_file().set_permissions(metadata.permissions());
     }
 
     temp.write_all(contents.as_bytes())
@@ -2758,6 +2746,66 @@ mod tests {
         assert_eq!(
             fs::read_to_string(tmp.path().join("Dockerfile")).unwrap(),
             before
+        );
+    }
+
+    #[test]
+    fn refusing_a_newer_scaffold_leaves_its_manifest_untouched() {
+        // The refusal protects the files; it must protect their provenance too.
+        // A report with no entries rebuilds the manifest from nothing, pruning
+        // every digest and stamping this older CLI's version over the newer
+        // one — destroying the very record that triggered the refusal.
+        let tmp = scaffolded(GenerateOptions::default());
+        let mut manifest = Manifest::load(tmp.path()).unwrap();
+        manifest.version = Some("99.0.0".to_owned());
+        manifest.save(tmp.path()).unwrap();
+        let before = fs::read_to_string(tmp.path().join(MANIFEST_PATH)).unwrap();
+
+        let mut report = plan_in(tmp.path());
+        assert!(report.scaffolded_by_newer.is_some());
+        apply(&mut report).expect("apply");
+
+        assert_eq!(
+            fs::read_to_string(tmp.path().join(MANIFEST_PATH)).unwrap(),
+            before,
+            "a refused run must not rewrite the baseline it refused over"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn an_added_file_gets_the_mode_an_ordinary_write_would_give_it() {
+        // A directory's access bits do not encode the umask: under umask 022 a
+        // `0775` checkout yields `0664` from `mode & 0o666` but `0644` from an
+        // ordinary write, quietly granting group write. The only way to get
+        // this right is to create the file with normal 0666 semantics and let
+        // the umask apply.
+        use std::os::unix::fs::PermissionsExt as _;
+
+        let tmp = scaffolded(GenerateOptions::default());
+        fs::set_permissions(tmp.path(), std::fs::Permissions::from_mode(0o775)).unwrap();
+        fs::remove_file(tmp.path().join("rustfmt.toml")).unwrap();
+        let mut manifest = Manifest::load(tmp.path()).unwrap();
+        manifest.digests.remove("rustfmt.toml");
+        manifest.save(tmp.path()).unwrap();
+
+        // What an ordinary write produces in this very directory, whatever the
+        // umask happens to be.
+        let probe = tmp.path().join("probe.txt");
+        fs::write(&probe, "x").unwrap();
+        let expected = fs::metadata(&probe).unwrap().permissions().mode() & 0o777;
+
+        let mut report = plan_in(tmp.path());
+        apply(&mut report).expect("apply");
+
+        let added = fs::metadata(tmp.path().join("rustfmt.toml"))
+            .unwrap()
+            .permissions()
+            .mode()
+            & 0o777;
+        assert_eq!(
+            added, expected,
+            "an added file must carry the mode an ordinary write would give it"
         );
     }
 }

--- a/autumn-cli/src/upgrade/scaffold.rs
+++ b/autumn-cli/src/upgrade/scaffold.rs
@@ -994,16 +994,69 @@ fn write_one(entry: &Entry) -> Result<(), String> {
         .ok_or_else(|| "no parent directory".to_owned())?;
     std::fs::create_dir_all(directory).map_err(|error| error.to_string())?;
 
-    // Nothing is here, so there is nothing an interrupted write could destroy
-    // — and a plain write is what gives the new file the same mode `autumn new`
-    // would have given it. `tempfile` deliberately creates 0600, and renaming
-    // that into place would leave an added `ci.yml` or `input.css` unreadable
-    // to every other uid: fatal to a Docker stage that drops privileges, and
-    // invisible in `git diff`, which tracks only the executable bit.
     if entry.current == OnDisk::Absent {
-        return std::fs::write(&entry.absolute, &entry.template).map_err(|error| error.to_string());
+        return create_atomically(entry);
     }
     replace_in_place(entry, directory)
+}
+
+/// Where an in-progress write to `absolute` is staged.
+///
+/// A deterministic name, in the same directory so the publishing rename never
+/// crosses a filesystem. Deterministic rather than random because a leftover
+/// then has an owner: this function names it, so the next run recognises its
+/// own scratch and clears it instead of failing forever on a crash's debris.
+fn scratch_path(absolute: &Path) -> PathBuf {
+    let name = absolute
+        .file_name()
+        .map_or_else(|| "scaffold".into(), std::ffi::OsStr::to_os_string);
+    absolute.with_file_name(format!(".autumn-upgrade-{}.tmp", name.to_string_lossy()))
+}
+
+/// Publish a file at a path nothing occupies yet.
+///
+/// Staged and renamed, not written in place. A plain `fs::write` interrupted by
+/// Ctrl-C or a full disk leaves a truncated file at the destination — and that
+/// file has no recorded baseline, so the *next* run classifies it as a conflict
+/// and refuses to touch it. The crash would be permanent: a corrupted file this
+/// command can never repair.
+///
+/// Staged by hand rather than through `tempfile`, which deliberately creates
+/// its temporaries 0600. Renaming one of those into place would leave an added
+/// `ci.yml` or `input.css` unreadable to every other uid — fatal to a Docker
+/// stage that drops privileges, and invisible in `git diff`, which tracks only
+/// the executable bit. `OpenOptions` honours the process umask, so the file
+/// lands with exactly the mode `autumn new` would have given it.
+fn create_atomically(entry: &Entry) -> Result<(), String> {
+    use std::io::Write as _;
+
+    let scratch = scratch_path(&entry.absolute);
+    // Debris from a killed run, cleared so a crash is not permanent. Only ever
+    // this function's own scratch name, and never the destination.
+    let _ = std::fs::remove_file(&scratch);
+    let mut file = std::fs::OpenOptions::new()
+        .write(true)
+        // Refuses to clobber, so a second `autumn upgrade --apply` racing this
+        // one is a loud error rather than two writers interleaving into one
+        // file.
+        .create_new(true)
+        .open(&scratch)
+        .map_err(|error| format!("{}: {error}", scratch.display()))?;
+
+    let staged = file
+        .write_all(entry.template.as_bytes())
+        .and_then(|()| file.flush())
+        // The rename is atomic, but only against a crash if the bytes reached
+        // the disk first: otherwise the rename can land before the data and
+        // publish an empty file.
+        .and_then(|()| file.sync_all());
+    drop(file);
+    let published = staged.and_then(|()| std::fs::rename(&scratch, &entry.absolute));
+    if published.is_err() {
+        // Nothing half-written survives, at the destination or beside it.
+        let _ = std::fs::remove_file(&scratch);
+    }
+    published.map_err(|error| error.to_string())
 }
 
 /// Replace an existing file's contents atomically, keeping its mode.
@@ -2143,5 +2196,80 @@ mod tests {
         let error = accept(tmp.path(), &["src/main.rs".to_owned()]).expect_err("must refuse");
         assert!(error.contains("src/main.rs"), "{error}");
         assert!(Manifest::load(tmp.path()).unwrap().pinned.is_empty());
+    }
+
+    #[test]
+    fn an_added_file_is_published_only_once_it_is_complete() {
+        // An addition interrupted partway — Ctrl-C, a full disk — must not
+        // leave a truncated file at the destination. That file would have no
+        // recorded baseline, so the next run would call it a conflict and
+        // refuse to touch it: a corrupted file the tool can never repair.
+        let tmp = scaffolded(GenerateOptions::default());
+        fs::remove_file(tmp.path().join("rustfmt.toml")).unwrap();
+        let mut manifest = Manifest::load(tmp.path()).unwrap();
+        manifest.digests.remove("rustfmt.toml");
+        manifest.save(tmp.path()).unwrap();
+
+        // Occupy the scratch path with a directory, so publishing fails after
+        // the plan is made but before anything reaches the destination.
+        let scratch = scratch_path(&tmp.path().join("rustfmt.toml"));
+        fs::create_dir_all(&scratch).unwrap();
+
+        let mut report = plan_in(tmp.path());
+        let failure = apply(&mut report).expect_err("the write must fail");
+        assert_eq!(failure.path, "rustfmt.toml");
+        assert!(
+            !tmp.path().join("rustfmt.toml").exists(),
+            "a failed addition must leave nothing at the destination"
+        );
+    }
+
+    #[test]
+    fn a_completed_apply_leaves_no_scratch_files_behind() {
+        let tmp = scaffolded(GenerateOptions::default());
+        fs::remove_file(tmp.path().join("rustfmt.toml")).unwrap();
+        let stale = "# older\n";
+        write(tmp.path(), "clippy.toml", stale);
+        let mut manifest = Manifest::load(tmp.path()).unwrap();
+        manifest.digests.remove("rustfmt.toml");
+        manifest
+            .digests
+            .insert("clippy.toml".to_owned(), digest(stale));
+        manifest.save(tmp.path()).unwrap();
+
+        let mut report = plan_in(tmp.path());
+        apply(&mut report).expect("apply");
+
+        let strays: Vec<String> = fs::read_dir(tmp.path())
+            .unwrap()
+            .filter_map(Result::ok)
+            .map(|entry| entry.file_name().to_string_lossy().into_owned())
+            .filter(|name| name.starts_with(".autumn-upgrade-"))
+            .collect();
+        assert!(strays.is_empty(), "scratch files left behind: {strays:?}");
+    }
+
+    #[test]
+    fn a_stale_scratch_file_does_not_block_a_later_run() {
+        // A run killed mid-write leaves its scratch file behind. If that
+        // blocked every future addition, the crash would be permanent.
+        let tmp = scaffolded(GenerateOptions::default());
+        fs::remove_file(tmp.path().join("rustfmt.toml")).unwrap();
+        let mut manifest = Manifest::load(tmp.path()).unwrap();
+        manifest.digests.remove("rustfmt.toml");
+        manifest.save(tmp.path()).unwrap();
+        fs::write(
+            scratch_path(&tmp.path().join("rustfmt.toml")),
+            "half-written leftovers",
+        )
+        .unwrap();
+
+        let mut report = plan_in(tmp.path());
+        apply(&mut report).expect("a stale scratch file is not a blocker");
+        let files = current_files(tmp.path(), GenerateOptions::default()).unwrap();
+        assert_eq!(
+            fs::read_to_string(tmp.path().join("rustfmt.toml")).unwrap(),
+            files["rustfmt.toml"]
+        );
     }
 }

--- a/autumn-cli/src/upgrade/scaffold.rs
+++ b/autumn-cli/src/upgrade/scaffold.rs
@@ -27,7 +27,7 @@
 //! are still offered ([`Status::Add`]), and everything else is a conflict for
 //! review. Best effort, never a silent overwrite.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
@@ -77,7 +77,8 @@ pub fn digest(contents: &str) -> String {
 #[allow(clippy::struct_excessive_bools)]
 #[derive(Serialize, Deserialize)]
 struct ManifestFile {
-    version: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    version: Option<String>,
     flavor: String,
     #[serde(default)]
     i18n: bool,
@@ -97,8 +98,14 @@ const FLAVOR_FULLSTACK: &str = "fullstack";
 /// What `autumn new` recorded about the scaffold it wrote.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Manifest {
-    /// The `autumn-cli` release whose scaffold produced these files.
-    pub version: String,
+    /// The release this project's framework-owned files were last *fully*
+    /// reconciled to — what `autumn new` wrote, or what the last conflict-free
+    /// `autumn upgrade --apply` brought them to.
+    ///
+    /// Absent when there is no such release: an upgrade that left conflicts
+    /// standing has not finished, and recording the target anyway would tell
+    /// the next run — and the developer reading the file — that it had.
+    pub version: Option<String>,
     /// The flags that release was invoked with, insofar as they change which
     /// framework-owned files exist and what they contain.
     pub options: GenerateOptions,
@@ -115,7 +122,7 @@ impl Manifest {
         files: &BTreeMap<&'static str, String>,
     ) -> Self {
         Self {
-            version: version.to_owned(),
+            version: Some(version.to_owned()),
             options,
             digests: files
                 .iter()
@@ -209,6 +216,13 @@ pub enum ConflictReason {
     /// Nothing was recorded for this file, so "untouched" cannot be proven.
     /// Every file in a project scaffolded before the manifest existed is here.
     NoBaseline,
+    /// The file is there but could not be read as text — it is not UTF-8, or
+    /// the process cannot open it. What it holds is unknown, so it is
+    /// untouchable.
+    Unreadable,
+    /// The path is a symbolic link. Writing through it would write wherever it
+    /// points, which need not be inside the project at all.
+    Symlink,
 }
 
 impl ConflictReason {
@@ -218,6 +232,8 @@ impl ConflictReason {
         match self {
             Self::Edited => "you changed this since it was scaffolded",
             Self::NoBaseline => "no recorded baseline, so an edit cannot be ruled out",
+            Self::Unreadable => "on disk but unreadable as text, so its contents are unknown",
+            Self::Symlink => "a symlink; writing through it could write outside the project",
         }
     }
 }
@@ -290,41 +306,48 @@ pub struct Entry {
     pub status: Status,
     /// What the current release's scaffold renders for this file.
     pub template: String,
-    /// The on-disk text this classification was computed from, LF-normalised.
-    /// `None` when the file is absent. Kept so the apply step can prove the
-    /// file has not changed since the plan was made.
-    pub current: Option<String>,
+    /// What was at this path when the plan was made. Kept so the apply step
+    /// can prove nothing has changed since.
+    current: OnDisk,
     /// Rendered preview diff; empty when there is nothing to show.
     pub diff: String,
     /// Where the file would be written.
     pub absolute: PathBuf,
 }
 
-/// The name to interpolate into the rendered scaffold.
+/// The name to interpolate into the rendered scaffold, or `None` when the
+/// project does not say.
 ///
-/// Read from `Cargo.toml`, not from the directory name: `autumn.toml` carries
-/// the project name in its telemetry and database examples, and a checkout in a
-/// differently-named directory (a CI workspace, a `git worktree`, a rename)
-/// would otherwise report the file as edited on every run.
-fn project_name(root: &Path) -> String {
-    std::fs::read_to_string(root.join("Cargo.toml"))
-        .ok()
-        .and_then(|text| text.parse::<toml::Table>().ok())
-        .and_then(|table| {
-            table
-                .get("package")?
-                .get("name")?
-                .as_str()
-                .map(str::to_owned)
-        })
-        .or_else(|| {
-            root.canonicalize()
-                .ok()?
-                .file_name()?
-                .to_str()
-                .map(str::to_owned)
-        })
-        .unwrap_or_else(|| "app".to_owned())
+/// Read from `Cargo.toml`'s `[package] name` and from nowhere else. Two
+/// temptations are deliberately refused:
+///
+/// - **The directory name.** `autumn.toml`, `.env.example`, the CI workflow and
+///   the `Dockerfile`'s `CMD` all interpolate the project name, so guessing it
+///   wrong does not merely mislabel a report — it renders a *different*
+///   scaffold, and a file whose recorded digest still matches then classifies
+///   as `update` and gets written. A checkout in a renamed directory would
+///   quietly rewrite `COPY --from=builder /app/target/release/<name>` into an
+///   image that cannot start.
+/// - **A name Cargo would not accept.** The name is substituted into a YAML
+///   workflow and a Dockerfile as raw text, so a `[package] name` carrying
+///   newlines is a content-injection vector into files this command then
+///   *writes*. [`crate::new::validate_name`] is the same rule `autumn new`
+///   applies when it creates the project, so anything it rejects cannot have
+///   produced the scaffold being compared against.
+///
+/// Without a usable name the scaffold cannot be rendered faithfully, and the
+/// reconciler says so instead of comparing against a fiction.
+fn project_name(root: &Path) -> Option<String> {
+    let name = std::fs::read_to_string(root.join("Cargo.toml"))
+        .ok()?
+        .parse::<toml::Table>()
+        .ok()?
+        .get("package")?
+        .get("name")?
+        .as_str()?
+        .to_owned();
+    crate::new::validate_name(&name).ok()?;
+    Some(name)
 }
 
 /// The scaffold options to render against, recorded if possible and inferred if
@@ -340,12 +363,18 @@ pub fn resolve_options(root: &Path, manifest: Option<&Manifest>) -> GenerateOpti
     }
     let autumn_toml = std::fs::read_to_string(root.join("autumn.toml")).unwrap_or_default();
     let bundled_pg = autumn_toml.contains("Managed local Postgres");
+    // Positive evidence of the fullstack CSS pipeline, any one of which the
+    // API scaffold never writes. Deliberately not "a `static/` directory
+    // exists": a JSON API serves its `openapi.json` or a favicon from one, and
+    // `add` is the one verdict that writes with no baseline behind it — so a
+    // flavour guessed from a weak signal does not mislabel a report, it seeds
+    // Tailwind into an app that has no use for it. Any one of these is enough,
+    // so deleting a single file cannot reclassify a fullstack project either.
+    let fullstack = root.join("tailwind.config.js").exists()
+        || root.join("static/css").is_dir()
+        || root.join("static/js/htmx.min.js").exists();
     GenerateOptions {
-        // The API scaffold creates neither, and the fullstack one always
-        // creates both, so their joint absence is the signal. Requiring both to
-        // be missing keeps a fullstack project that merely deleted its Tailwind
-        // config from being misread as an API project and losing `input.css`.
-        with_api: !root.join("static").is_dir() && !root.join("tailwind.config.js").exists(),
+        with_api: !fullstack,
         with_i18n: root.join("i18n").is_dir(),
         // Never affects a framework-owned file (the seed binary lives under
         // `src/`, which is out of bounds), so there is nothing to infer.
@@ -356,10 +385,13 @@ pub fn resolve_options(root: &Path, manifest: Option<&Manifest>) -> GenerateOpti
 }
 
 /// The current release's framework-owned files, rendered for the project at
-/// `root`.
+/// `root`, or `None` when the project's name cannot be established.
 #[must_use]
-pub fn current_files(root: &Path, options: GenerateOptions) -> BTreeMap<&'static str, String> {
-    let name = project_name(root);
+pub fn current_files(
+    root: &Path,
+    options: GenerateOptions,
+) -> Option<BTreeMap<&'static str, String>> {
+    let name = project_name(root)?;
     let crate_name = name.replace('-', "_");
     let vars = TemplateVars {
         project_name: &name,
@@ -367,7 +399,45 @@ pub fn current_files(root: &Path, options: GenerateOptions) -> BTreeMap<&'static
         autumn_version: env!("CARGO_PKG_VERSION"),
         rust_version: option_env!("CARGO_PKG_RUST_VERSION").unwrap_or("1.88.0"),
     };
-    framework_owned_files(&vars, options)
+    Some(framework_owned_files(&vars, options))
+}
+
+/// What is at a framework-owned path right now.
+///
+/// Three states, not two. Collapsing "there but unreadable" into "absent" — the
+/// shape `read_to_string(..).ok()` gives you — is the bug that turns a
+/// latin-1 `input.css` or a root-owned `.gitignore` into an `add`, and then
+/// truncates it. A file whose contents cannot be read is the *last* thing that
+/// may be overwritten, not the first.
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum OnDisk {
+    /// Nothing at this path.
+    Absent,
+    /// Readable text, line endings normalised.
+    Text(String),
+    /// Present, and untouchable for this reason.
+    Opaque(ConflictReason),
+}
+
+fn read_current(absolute: &Path) -> OnDisk {
+    // `symlink_metadata` does not follow, which is the point: a link's own
+    // metadata is what says it is a link. `metadata` would report the target
+    // and a dangling link would read as absent — the exact combination that
+    // lets `--apply` create a file outside the project.
+    match std::fs::symlink_metadata(absolute) {
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => OnDisk::Absent,
+        Err(_) => OnDisk::Opaque(ConflictReason::Unreadable),
+        Ok(metadata) if metadata.file_type().is_symlink() => {
+            OnDisk::Opaque(ConflictReason::Symlink)
+        }
+        // It exists. Reading it can still fail — a directory, a device,
+        // non-UTF-8 bytes, a permission the process does not have — and every
+        // one of those is untouchable rather than absent.
+        Ok(_) => std::fs::read_to_string(absolute)
+            .map_or(OnDisk::Opaque(ConflictReason::Unreadable), |text| {
+                OnDisk::Text(normalize(&text))
+            }),
+    }
 }
 
 /// Reconcile `files` against what is on disk under `root`.
@@ -383,24 +453,26 @@ pub fn classify(
         .iter()
         .map(|(path, template)| {
             let absolute = root.join(path);
-            let current = std::fs::read_to_string(&absolute)
-                .ok()
-                .map(|c| normalize(&c));
+            let current = read_current(&absolute);
             let (status, diff) = match &current {
-                // Absent. Autumn wrote it once and it is gone → a deliberate
-                // deletion. Never wrote it → this release added it.
-                None if recorded(path).is_some() => (Status::Removed, String::new()),
-                None => (Status::Add, super::diff::render("", template)),
-                Some(current) if *current == normalize(template) => {
+                // Not there at all. Autumn wrote it once and it is gone → a
+                // deliberate deletion. Never wrote it → this release added it.
+                OnDisk::Absent if recorded(path).is_some() => (Status::Removed, String::new()),
+                OnDisk::Absent => (Status::Add, super::diff::render("", template)),
+                // There, but nothing can be said about it. Never an `add`: the
+                // whole reason to look is that writing would destroy whatever
+                // is really in the file.
+                OnDisk::Opaque(reason) => (Status::Conflict(*reason), String::new()),
+                OnDisk::Text(text) if *text == normalize(template) => {
                     (Status::UpToDate, String::new())
                 }
-                Some(current) => {
+                OnDisk::Text(text) => {
                     let status = match recorded(path) {
-                        Some(baseline) if *baseline == digest(current) => Status::Update,
+                        Some(baseline) if *baseline == digest(text) => Status::Update,
                         Some(_) => Status::Conflict(ConflictReason::Edited),
                         None => Status::Conflict(ConflictReason::NoBaseline),
                     };
-                    (status, super::diff::render(current, template))
+                    (status, super::diff::render(text, template))
                 }
             };
             Entry {
@@ -467,6 +539,10 @@ pub struct ScaffoldReport {
     /// The scaffold options this project was reconciled against — recorded, or
     /// inferred when there is no manifest.
     pub options: GenerateOptions,
+    /// Whether the project's package name could be established. When it could
+    /// not, the scaffold cannot be rendered for comparison and [`Self::entries`]
+    /// is empty — which is a refusal to answer, not an "all clear".
+    pub named: bool,
     /// Every framework-owned file, up-to-date ones included.
     pub entries: Vec<Entry>,
     /// What the apply step actually did.
@@ -517,7 +593,25 @@ impl ScaffoldReport {
     /// deleted file keeps its entry so it is still reported as *removed*
     /// rather than silently re-offered.
     fn next_manifest(&self, previous: Option<&Manifest>) -> Manifest {
-        let mut digests = previous.map(|m| m.digests.clone()).unwrap_or_default();
+        // Carried forward, but only for paths this release still owns. A key
+        // for a file the framework no longer generates is dead weight — and a
+        // hand-edited or hostile manifest should not be able to accumulate
+        // entries in a file Autumn rewrites.
+        let owned: BTreeSet<&str> = self
+            .entries
+            .iter()
+            .map(|entry| entry.path.as_str())
+            .collect();
+        let mut digests: BTreeMap<String, String> = previous
+            .map(|manifest| {
+                manifest
+                    .digests
+                    .iter()
+                    .filter(|(path, _)| owned.contains(path.as_str()))
+                    .map(|(path, digest)| (path.clone(), digest.clone()))
+                    .collect()
+            })
+            .unwrap_or_default();
         for entry in &self.entries {
             if entry.status.is_applied() || entry.status == Status::UpToDate {
                 digests.insert(entry.path.clone(), digest(&entry.template));
@@ -525,11 +619,13 @@ impl ScaffoldReport {
         }
         // The baseline moves only once nothing is left to reconcile. Recording
         // the target while conflicts stand would tell the next run — and the
-        // developer reading it — that this upgrade is finished.
+        // developer reading it — that this upgrade is finished. With nothing
+        // previously recorded there is simply no such release yet, and the
+        // field is left out rather than filled with a guess.
         let version = if self.conflicts().is_empty() {
-            self.target.clone()
+            Some(self.target.clone())
         } else {
-            previous.map_or_else(|| self.target.clone(), |m| m.version.clone())
+            previous.and_then(|manifest| manifest.version.clone())
         };
         Manifest {
             version,
@@ -550,20 +646,32 @@ pub struct WriteFailure {
     pub written: usize,
 }
 
-/// Plan a reconciliation of the project at `root` against release `target`.
+/// Plan a reconciliation of the project at `root`.
+///
+/// `_target` is accepted and ignored for the scaffold half, deliberately. This
+/// CLI ships exactly one set of scaffold templates — its own — so "bring me to
+/// the current release" is the only reconciliation it can honestly perform, and
+/// downgrades and arbitrary historical scaffolds are out of scope. `--to`
+/// selects which *codemods* run; a scaffold report claiming to reconcile to
+/// 0.6.0 while rendering 0.7.0's files would simply be false.
 #[must_use]
-pub fn plan(root: &Path, target: &str) -> ScaffoldReport {
+pub fn plan(root: &Path, _target: &str) -> ScaffoldReport {
+    let target = env!("CARGO_PKG_VERSION").to_owned();
     let manifest = Manifest::load(root);
     let options = resolve_options(root, manifest.as_ref());
+    let files = current_files(root, options);
     ScaffoldReport {
         root: root.to_path_buf(),
         options,
-        baseline: manifest.as_ref().map(|m| m.version.clone()),
-        target: target.to_owned(),
+        baseline: manifest.as_ref().and_then(|m| m.version.clone()),
+        named: files.is_some(),
+        entries: files
+            .map(|files| classify(root, &files, manifest.as_ref()))
+            .unwrap_or_default(),
+        guide: release_guide(&target),
+        target,
         has_manifest: manifest.is_some(),
-        entries: classify(root, &current_files(root, options), manifest.as_ref()),
         outcome: super::Outcome::Preview,
-        guide: release_guide(target),
     }
 }
 
@@ -607,32 +715,98 @@ pub fn apply(report: &mut ScaffoldReport) -> Result<(), WriteFailure> {
 }
 
 /// Write one entry, refusing to clobber anything that moved since the plan.
+///
+/// The re-read is not belt-and-braces. The plan is a decision made about bytes
+/// read earlier, and between then and now a formatter, a code generator, an
+/// editor autosave, or a second `autumn upgrade` can have replaced them. Writing
+/// anyway would silently revert whatever landed in that window.
+///
+/// Written through a temporary file in the same directory and renamed into
+/// place, the way the app-code half of this command writes: a truncate-in-place
+/// interrupted by Ctrl-C or ENOSPC leaves a half-written `Dockerfile` and no
+/// copy of the original anywhere.
 fn write_one(entry: &Entry) -> Result<(), String> {
-    let on_disk = std::fs::read_to_string(&entry.absolute)
-        .ok()
-        .map(|text| normalize(&text));
+    use std::io::Write as _;
+
+    let on_disk = read_current(&entry.absolute);
     if on_disk != entry.current {
         return Err(match entry.current {
-            None => "a file appeared here after the preview was computed; \
-                     it was left exactly as it is"
+            OnDisk::Absent => "something appeared at this path after the preview was \
+                               computed; it was left exactly as it is"
                 .to_owned(),
-            Some(_) => "this file changed after the preview was computed; \
-                        it was left exactly as it is"
+            _ => "this file changed after the preview was computed; \
+                  it was left exactly as it is"
                 .to_owned(),
         });
     }
-    if let Some(parent) = entry.absolute.parent() {
-        std::fs::create_dir_all(parent).map_err(|error| error.to_string())?;
+    // A plan is only ever built for `add` and `update`, and `read_current`
+    // classifies a symlink as a conflict, so reaching this with a link would be
+    // a bug rather than a race. Checked anyway: this is the last line before a
+    // write, and the cost of being wrong here is a file outside the project.
+    if matches!(on_disk, OnDisk::Opaque(_)) {
+        return Err(
+            "this path is a symlink or is unreadable; it was left exactly as it is".to_owned(),
+        );
     }
-    std::fs::write(&entry.absolute, &entry.template).map_err(|error| error.to_string())
+
+    let directory = entry
+        .absolute
+        .parent()
+        .ok_or_else(|| "no parent directory".to_owned())?;
+    std::fs::create_dir_all(directory).map_err(|error| error.to_string())?;
+    let mut temp = tempfile::Builder::new()
+        .prefix(".autumn-upgrade-")
+        .suffix(".tmp")
+        .tempfile_in(directory)
+        .map_err(|error| error.to_string())?;
+    temp.write_all(entry.template.as_bytes())
+        .map_err(|error| error.to_string())?;
+    temp.flush().map_err(|error| error.to_string())?;
+    // The rename is atomic, but only against a crash if the bytes reached the
+    // disk first: otherwise the rename can land before the data and leave an
+    // empty file where a working one used to be.
+    temp.as_file()
+        .sync_all()
+        .map_err(|error| error.to_string())?;
+    // A fresh temporary is created 0600; renaming it over an existing file
+    // would otherwise silently tighten that file's mode.
+    if let Ok(metadata) = std::fs::metadata(&entry.absolute) {
+        let _ = temp.as_file().set_permissions(metadata.permissions());
+    }
+    temp.persist(&entry.absolute)
+        .map_err(|error| error.to_string())?;
+    Ok(())
 }
 
-/// The human report.
+/// The human report, with a diff for every file that differs.
 #[must_use]
 pub fn render_text(report: &ScaffoldReport) -> String {
+    render(report, true)
+}
+
+/// The human report without the per-file diffs.
+///
+/// What `--check` prints. A CI gate wants the verdict and the file names; the
+/// diffs would put the working contents of `autumn.toml` and `.env.example` —
+/// the two files people most often paste a connection string into — into a
+/// build log that outlives the run.
+#[must_use]
+pub fn render_summary(report: &ScaffoldReport) -> String {
+    render(report, false)
+}
+
+fn render(report: &ScaffoldReport, diffs: bool) -> String {
     use std::fmt::Write as _;
 
     let mut out = String::new();
+    if !report.named {
+        let _ = writeln!(out, "\nScaffold files");
+        let _ = writeln!(
+            out,
+            "  Skipped: this project's `Cargo.toml` does not give a usable `[package] name`,\n               and the scaffold interpolates it. Comparing against a guessed name would\n               report files as changed that are not — or worse, rewrite them."
+        );
+        return out;
+    }
     let from = report
         .baseline
         .clone()
@@ -674,13 +848,24 @@ pub fn render_text(report: &ScaffoldReport) -> String {
         );
     }
 
-    for entry in &changed {
-        if entry.diff.is_empty() {
-            continue;
+    if diffs {
+        for entry in &changed {
+            if entry.diff.is_empty() {
+                continue;
+            }
+            let _ = writeln!(out, "\n{} ({})", entry.path, entry.status.label());
+            out.push_str(&entry.diff);
         }
-        let _ = writeln!(out, "\n{} ({})", entry.path, entry.status.label());
-        out.push_str(&entry.diff);
     }
+
+    render_outcome(&mut out, report);
+    let _ = writeln!(out, "Upgrade guide: {}", report.guide);
+    out
+}
+
+/// The closing paragraph: what happened, or what would, and how to undo it.
+fn render_outcome(out: &mut String, report: &ScaffoldReport) {
+    use std::fmt::Write as _;
 
     let applicable = report.applicable().len();
     let conflicts = report.conflicts().len();
@@ -739,8 +924,6 @@ pub fn render_text(report: &ScaffoldReport) -> String {
              scaffold above, take what you want, and re-run to confirm."
         );
     }
-    let _ = writeln!(out, "Upgrade guide: {}", report.guide);
-    out
 }
 
 /// The machine-readable report, for CI.
@@ -749,6 +932,7 @@ pub fn json(report: &ScaffoldReport) -> serde_json::Value {
     serde_json::json!({
         "baseline": report.baseline,
         "target": report.target,
+        "named": report.named,
         "has_manifest": report.has_manifest,
         "outcome": report.outcome.label(),
         "drift": report.drifted(),
@@ -799,7 +983,7 @@ mod tests {
         digests.insert("clippy.toml".to_owned(), digest("a\n"));
         digests.insert(".github/workflows/ci.yml".to_owned(), digest("b\n"));
         let manifest = Manifest {
-            version: "0.7.0".to_owned(),
+            version: Some("0.7.0".to_owned()),
             options: GenerateOptions {
                 with_api: true,
                 with_i18n: true,
@@ -824,7 +1008,7 @@ mod tests {
         digests.insert(".env.example".to_owned(), digest("y"));
         digests.insert("static/css/input.css".to_owned(), digest("z"));
         let manifest = Manifest {
-            version: "0.7.0".to_owned(),
+            version: Some("0.7.0".to_owned()),
             options: GenerateOptions::default(),
             digests: digests.clone(),
         };
@@ -856,14 +1040,14 @@ mod tests {
         let mut digests = BTreeMap::new();
         digests.insert("clippy.toml".to_owned(), digest("a\n"));
         let manifest = Manifest {
-            version: "0.7.0".to_owned(),
+            version: Some("0.7.0".to_owned()),
             options: GenerateOptions::default(),
             digests,
         };
         manifest.save(tmp.path()).unwrap();
         let loaded = Manifest::load(tmp.path()).expect("written manifest loads");
         assert_eq!(loaded.digests, manifest.digests);
-        assert_eq!(loaded.version, "0.7.0");
+        assert_eq!(loaded.version.as_deref(), Some("0.7.0"));
     }
 
     // --- classification ---
@@ -876,7 +1060,7 @@ mod tests {
             "Cargo.toml",
             "[package]\nname = \"demo\"\nversion = \"0.1.0\"\n\n[dependencies]\nautumn-web = \"0.7.0\"\n",
         );
-        let files = current_files(tmp.path(), opts);
+        let files = current_files(tmp.path(), opts).expect("named project");
         for (path, contents) in &files {
             write(tmp.path(), path, contents);
         }
@@ -922,7 +1106,7 @@ mod tests {
         // The manifest is the *old* release's: it never knew this file.
         let mut manifest = Manifest::load(tmp.path()).unwrap();
         manifest.digests.remove("rust-toolchain.toml");
-        manifest.version = "0.5.0".to_owned();
+        manifest.version = Some("0.5.0".to_owned());
         manifest.save(tmp.path()).unwrap();
 
         let entries = plan_in(tmp.path()).entries;
@@ -1067,7 +1251,7 @@ mod tests {
     fn the_report_records_the_recorded_baseline_and_the_target() {
         let tmp = scaffolded(GenerateOptions::default());
         let mut manifest = Manifest::load(tmp.path()).unwrap();
-        manifest.version = "0.5.0".to_owned();
+        manifest.version = Some("0.5.0".to_owned());
         manifest.save(tmp.path()).unwrap();
 
         let report = plan_in(tmp.path());
@@ -1088,14 +1272,17 @@ mod tests {
     }
 
     #[test]
-    fn a_target_with_no_release_guide_links_the_guide_index() {
-        let tmp = scaffolded(GenerateOptions::default());
-        let report = plan(tmp.path(), "9.9.0");
-        assert!(
-            report.guide.ends_with("docs/migrations/README.md"),
-            "{}",
-            report.guide
-        );
+    fn a_release_with_no_guide_links_the_guide_index() {
+        // Not every release ships a migration guide, and a summary that links a
+        // 404 at the moment it says "go read this" is worse than one that links
+        // the index.
+        let index = release_guide("9.9.0");
+        assert!(index.ends_with("docs/migrations/README.md"), "{index}");
+        let known = release_guide("0.7.0");
+        assert!(known.ends_with("docs/migrations/0.7.0.md"), "{known}");
+        // An unparsable version still resolves to something that opens.
+        let junk = release_guide("not-a-version");
+        assert!(junk.ends_with("docs/migrations/README.md"), "{junk}");
     }
 
     #[test]
@@ -1136,7 +1323,7 @@ mod tests {
         apply(&mut report).expect("apply");
         assert_eq!(report.outcome, Outcome::Applied);
 
-        let files = current_files(tmp.path(), GenerateOptions::default());
+        let files = current_files(tmp.path(), GenerateOptions::default()).expect("named project");
         assert_eq!(
             fs::read_to_string(tmp.path().join("rustfmt.toml")).unwrap(),
             files["rustfmt.toml"]
@@ -1171,7 +1358,7 @@ mod tests {
         fs::remove_file(tmp.path().join("rustfmt.toml")).unwrap();
         let mut manifest = Manifest::load(tmp.path()).unwrap();
         manifest.digests.remove("rustfmt.toml");
-        manifest.version = "0.5.0".to_owned();
+        manifest.version = Some("0.5.0".to_owned());
         manifest.save(tmp.path()).unwrap();
 
         let mut report = plan_in(tmp.path());
@@ -1189,12 +1376,15 @@ mod tests {
         let tmp = scaffolded(GenerateOptions::default());
         write(tmp.path(), "Dockerfile", "FROM scratch\n");
         let mut manifest = Manifest::load(tmp.path()).unwrap();
-        manifest.version = "0.5.0".to_owned();
+        manifest.version = Some("0.5.0".to_owned());
         manifest.save(tmp.path()).unwrap();
 
         let mut report = plan_in(tmp.path());
         apply(&mut report).expect("apply");
-        assert_eq!(Manifest::load(tmp.path()).unwrap().version, "0.5.0");
+        assert_eq!(
+            Manifest::load(tmp.path()).unwrap().version.as_deref(),
+            Some("0.5.0")
+        );
     }
 
     #[test]
@@ -1298,5 +1488,109 @@ mod tests {
         assert!(text.contains("conflict"), "{text}");
         assert!(!text.contains("--apply"), "{text}");
         assert!(text.contains("git diff"), "{text}");
+    }
+
+    #[test]
+    fn a_file_that_is_not_readable_text_is_a_conflict_not_an_addition() {
+        // `read_to_string` fails for a file that exists but is not UTF-8, and
+        // conflating that with "absent" would classify it `add` and then
+        // happily overwrite whatever is really in there.
+        let tmp = scaffolded(GenerateOptions::default());
+        fs::write(tmp.path().join(".env.example"), [0xff_u8, 0xfe, 0x00, 0x01]).unwrap();
+
+        let entries = plan_in(tmp.path()).entries;
+        assert_eq!(
+            status_of(&entries, ".env.example"),
+            &Status::Conflict(ConflictReason::Unreadable)
+        );
+
+        let mut report = plan_in(tmp.path());
+        apply(&mut report).expect("apply");
+        assert_eq!(
+            fs::read(tmp.path().join(".env.example")).unwrap(),
+            vec![0xff_u8, 0xfe, 0x00, 0x01],
+            "an unreadable file must survive --apply byte for byte"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn a_symlinked_scaffold_file_is_a_conflict_and_is_never_written_through() {
+        // Writing through a link can leave the project entirely, which is the
+        // same reason the app-code codemods refuse to follow one.
+        let tmp = scaffolded(GenerateOptions::default());
+        let outside = tmp.path().join("outside.txt");
+        fs::write(&outside, "not mine to touch\n").unwrap();
+        let link = tmp.path().join("clippy.toml");
+        fs::remove_file(&link).unwrap();
+        std::os::unix::fs::symlink(&outside, &link).unwrap();
+
+        let entries = plan_in(tmp.path()).entries;
+        assert_eq!(
+            status_of(&entries, "clippy.toml"),
+            &Status::Conflict(ConflictReason::Symlink)
+        );
+
+        let mut report = plan_in(tmp.path());
+        apply(&mut report).expect("apply");
+        assert_eq!(
+            fs::read_to_string(&outside).unwrap(),
+            "not mine to touch\n",
+            "the link target must never be written through"
+        );
+    }
+
+    #[test]
+    fn the_scaffold_is_always_this_release_not_an_arbitrary_to_version() {
+        // The CLI ships one set of templates: its own. `--to` selects which
+        // codemods run; it cannot conjure a historical scaffold, and a report
+        // claiming to reconcile to 0.6.0 while rendering 0.7.0's files would be
+        // a lie. Downgrades are explicitly out of scope for this command.
+        let tmp = scaffolded(GenerateOptions::default());
+        let report = plan(tmp.path(), "0.6.0");
+        assert_eq!(report.target, env!("CARGO_PKG_VERSION"));
+    }
+
+    #[test]
+    fn an_api_project_that_serves_something_from_static_is_still_an_api_project() {
+        // `add` is the one verdict that writes with no baseline behind it, so a
+        // wrong flavour guess does not merely mislabel a report — it seeds
+        // Tailwind into a JSON API. A `static/` directory alone is not evidence
+        // of a fullstack app: an API serves its `openapi.json` from one.
+        let tmp = scaffolded(GenerateOptions {
+            with_api: true,
+            ..GenerateOptions::default()
+        });
+        fs::remove_dir_all(tmp.path().join(".autumn")).unwrap();
+        write(tmp.path(), "static/openapi.json", "{}\n");
+
+        let mut report = plan_in(tmp.path());
+        assert!(
+            !report
+                .entries
+                .iter()
+                .any(|e| e.path == "tailwind.config.js"),
+            "{:?}",
+            report.changed().iter().map(|e| &e.path).collect::<Vec<_>>()
+        );
+        apply(&mut report).expect("apply");
+        assert!(!tmp.path().join("tailwind.config.js").exists());
+        assert!(!tmp.path().join("static/css/input.css").exists());
+    }
+
+    #[test]
+    fn a_fullstack_project_missing_its_tailwind_config_is_still_fullstack() {
+        // The mirror image: deleting one file must not silently reclassify the
+        // project and take the rest of its CSS pipeline out of scope.
+        let tmp = scaffolded(GenerateOptions::default());
+        fs::remove_dir_all(tmp.path().join(".autumn")).unwrap();
+        fs::remove_file(tmp.path().join("tailwind.config.js")).unwrap();
+
+        let entries = plan_in(tmp.path()).entries;
+        assert_eq!(status_of(&entries, "tailwind.config.js"), &Status::Add);
+        assert_eq!(
+            status_of(&entries, "static/css/input.css"),
+            &Status::UpToDate
+        );
     }
 }

--- a/autumn-cli/src/upgrade/scaffold.rs
+++ b/autumn-cli/src/upgrade/scaffold.rs
@@ -243,7 +243,7 @@ impl Manifest {
         if let Some(parent) = path.parent() {
             std::fs::create_dir_all(parent)?;
         }
-        publish(&path, &self.render()).map_err(std::io::Error::other)
+        publish(&path, &self.render(), Publish::Replace).map_err(std::io::Error::other)
     }
 }
 
@@ -263,10 +263,13 @@ pub enum ConflictReason {
     /// through it would write wherever it points, which need not be inside the
     /// project at all.
     Symlink,
-    /// This same run's app-code migrations rewrote the file. `build.rs` is both
-    /// a framework-owned file and a `.rs` file the codemods scan, so the two
+    /// This same run's app-code migrations cover the file. `build.rs` is both a
+    /// framework-owned file and a `.rs` file the codemods scan, so the two
     /// halves can land on it in one run — and blaming the developer for an edit
-    /// the tool made four lines earlier would be simply false.
+    /// the tool itself makes four lines earlier would be simply false.
+    ///
+    /// Set from the codemods' *plan*, so a preview says the same thing the
+    /// apply it is previewing will.
     MigratedThisRun,
 }
 
@@ -1021,7 +1024,15 @@ fn write_one(entry: &Entry) -> Result<(), String> {
         .ok_or_else(|| "no parent directory".to_owned())?;
     std::fs::create_dir_all(directory).map_err(|error| error.to_string())?;
 
-    publish(&entry.absolute, &entry.template)
+    publish(
+        &entry.absolute,
+        &entry.template,
+        if entry.current == OnDisk::Absent {
+            Publish::Create
+        } else {
+            Publish::Replace
+        },
+    )
 }
 
 /// Where an in-progress write to `absolute` is staged.
@@ -1037,13 +1048,22 @@ fn scratch_path(absolute: &Path) -> PathBuf {
     absolute.with_file_name(format!(".autumn-upgrade-{}.tmp", name.to_string_lossy()))
 }
 
+/// Whether a publish may take a destination that already exists.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Publish {
+    /// The path was empty when the plan was made and must still be empty.
+    Create,
+    /// The path holds the contents the plan was computed from.
+    Replace,
+}
+
 /// Publish `contents` at `absolute`, atomically.
 ///
-/// Staged beside the destination and renamed into place, never written in
-/// place. A plain `fs::write` interrupted by Ctrl-C or a full disk leaves a
-/// truncated file — and for a file this command *added*, that is permanent: the
-/// truncated file has no recorded baseline, so the next run classifies it as a
-/// conflict and refuses to touch it.
+/// Staged beside the destination and published by a link operation, never
+/// written in place. A plain `fs::write` interrupted by Ctrl-C or a full disk
+/// leaves a truncated file — and for a file this command *added*, that is
+/// permanent: the truncated file has no recorded baseline, so the next run
+/// classifies it as a conflict and refuses to touch it.
 ///
 /// Staged by hand rather than through `tempfile`, which deliberately creates
 /// its temporaries 0600. Renaming one of those into place would leave an added
@@ -1052,7 +1072,20 @@ fn scratch_path(absolute: &Path) -> PathBuf {
 /// the executable bit. `OpenOptions` honours the process umask, so a new file
 /// lands with exactly the mode `autumn new` would have given it; an existing
 /// one keeps the mode it already had.
-fn publish(absolute: &Path, contents: &str) -> Result<(), String> {
+///
+/// [`Publish::Create`] publishes with a hard link rather than a rename, because
+/// `rename` *replaces* its destination on Unix. The plan's re-read happens
+/// before the bytes are written and synced, so a file another process creates
+/// inside that window would be silently clobbered by the very step that
+/// advertises it will not. `hard_link` fails instead, and the caller reports it
+/// like any other refusal.
+///
+/// [`Publish::Replace`] is a rename, since replacing is the point there. Its
+/// window is narrowed by the re-read, not closed: a writer that replaces the
+/// file between the re-read and the rename loses. Closing that needs an
+/// exchange primitive no portable API offers, and it is the same window every
+/// rename-based updater lives with.
+fn publish(absolute: &Path, contents: &str, mode: Publish) -> Result<(), String> {
     use std::io::Write as _;
 
     let scratch = scratch_path(absolute);
@@ -1069,24 +1102,39 @@ fn publish(absolute: &Path, contents: &str) -> Result<(), String> {
         .map_err(|error| format!("{}: {error}", scratch.display()))?;
     // Replacing a file keeps its mode; the umask default the scratch was
     // created with is only right for a file that is genuinely new.
-    if let Ok(metadata) = std::fs::metadata(absolute) {
+    if mode == Publish::Replace
+        && let Ok(metadata) = std::fs::metadata(absolute)
+    {
         let _ = file.set_permissions(metadata.permissions());
     }
 
     let staged = file
         .write_all(contents.as_bytes())
         .and_then(|()| file.flush())
-        // The rename is atomic, but only against a crash if the bytes reached
-        // the disk first: otherwise the rename can land before the data and
-        // publish an empty file.
+        // The link is atomic, but only against a crash if the bytes reached the
+        // disk first: otherwise it can land before the data and publish an
+        // empty file.
         .and_then(|()| file.sync_all());
     drop(file);
-    let published = staged.and_then(|()| std::fs::rename(&scratch, absolute));
-    if published.is_err() {
-        // Nothing half-written survives, at the destination or beside it.
-        let _ = std::fs::remove_file(&scratch);
-    }
-    published.map_err(|error| error.to_string())
+
+    let published = staged.and_then(|()| match mode {
+        Publish::Create => std::fs::hard_link(&scratch, absolute),
+        Publish::Replace => std::fs::rename(&scratch, absolute),
+    });
+    // The link leaves the scratch behind by design (it is the same inode); the
+    // rename consumes it. Either way nothing half-written survives, at the
+    // destination or beside it.
+    let _ = std::fs::remove_file(&scratch);
+
+    published.map_err(|error| {
+        if mode == Publish::Create && error.kind() == std::io::ErrorKind::AlreadyExists {
+            "something appeared at this path while it was being written; \
+             it was left exactly as it is"
+                .to_owned()
+        } else {
+            error.to_string()
+        }
+    })
 }
 
 /// Re-read what an entry's path holds now, by the same rules the plan used —
@@ -2348,5 +2396,71 @@ mod tests {
             "an unreadable flavor must fall back to the conservative no-baseline path"
         );
         assert!(!tmp.path().join("tailwind.config.js").exists());
+    }
+
+    #[test]
+    fn publishing_an_addition_never_replaces_a_destination_that_appeared() {
+        // `rename` replaces the destination on Unix, so a file another process
+        // creates during the staging window — after the plan's re-read, while
+        // the bytes are being synced — would be silently clobbered by the very
+        // step that advertises it will not.
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("arrived.toml");
+        fs::write(&path, "someone else got here first\n").unwrap();
+
+        let error = publish(&path, "ours\n", Publish::Create).expect_err("must refuse");
+        assert!(error.contains("appeared"), "{error}");
+        assert_eq!(
+            fs::read_to_string(&path).unwrap(),
+            "someone else got here first\n"
+        );
+        assert!(!scratch_path(&path).exists(), "no scratch left behind");
+    }
+
+    #[test]
+    fn publishing_a_replacement_takes_the_destination() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("existing.toml");
+        fs::write(&path, "old\n").unwrap();
+
+        publish(&path, "new\n", Publish::Replace).expect("replace");
+        assert_eq!(fs::read_to_string(&path).unwrap(), "new\n");
+        assert!(!scratch_path(&path).exists(), "no scratch left behind");
+    }
+
+    #[test]
+    fn a_preview_and_an_apply_agree_about_build_rs() {
+        // `build.rs` is the one framework-owned file the codemods also scan, so
+        // it is exactly the file whose preview must not disagree with what
+        // `--apply` then does. Classifying the preview against the old contents
+        // reported a writable `update` for a file the apply would refuse.
+        let tmp = scaffolded(GenerateOptions::default());
+        // Stale but provably untouched: without the codemods in the picture
+        // this is a writable `update`.
+        let stale = "fn main() { /* an older release's build.rs */ }\n";
+        write(tmp.path(), "build.rs", stale);
+        let mut manifest = Manifest::load(tmp.path()).unwrap();
+        manifest
+            .digests
+            .insert("build.rs".to_owned(), digest(stale));
+        manifest.save(tmp.path()).unwrap();
+        assert_eq!(
+            status_of(&plan_in(tmp.path()).entries, "build.rs"),
+            &Status::Update
+        );
+
+        let migrated: BTreeSet<String> = std::iter::once("build.rs".to_owned()).collect();
+        let previewed = plan_after(tmp.path(), "0.7.0", &migrated);
+        assert_eq!(
+            status_of(&previewed.entries, "build.rs"),
+            &Status::Conflict(ConflictReason::MigratedThisRun)
+        );
+        assert!(
+            !previewed
+                .applicable()
+                .iter()
+                .any(|entry| entry.path == "build.rs"),
+            "a file the codemods rewrite is never a writable scaffold update"
+        );
     }
 }

--- a/autumn-cli/src/upgrade/scaffold.rs
+++ b/autumn-cli/src/upgrade/scaffold.rs
@@ -1035,19 +1035,6 @@ fn write_one(entry: &Entry) -> Result<(), String> {
     )
 }
 
-/// Where an in-progress write to `absolute` is staged.
-///
-/// A deterministic name, in the same directory so the publishing rename never
-/// crosses a filesystem. Deterministic rather than random because a leftover
-/// then has an owner: this function names it, so the next run recognises its
-/// own scratch and clears it instead of failing forever on a crash's debris.
-fn scratch_path(absolute: &Path) -> PathBuf {
-    let name = absolute
-        .file_name()
-        .map_or_else(|| "scaffold".into(), std::ffi::OsStr::to_os_string);
-    absolute.with_file_name(format!(".autumn-upgrade-{}.tmp", name.to_string_lossy()))
-}
-
 /// Whether a publish may take a destination that already exists.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum Publish {
@@ -1057,84 +1044,107 @@ enum Publish {
     Replace,
 }
 
+/// The mode a file newly created in `directory` should carry.
+///
+/// Derived from the directory's own mode rather than by reading the process
+/// umask, which has no race-free getter — the only way to read it is to set it
+/// and set it back. Masking the directory's mode down to the file permission
+/// bits reproduces the umask-derived answer in every ordinary case (`0755` ->
+/// `0644`, `0700` -> `0600`, `0775` -> `0664`), which is what matters: a file
+/// this command adds must be exactly as readable as the one `autumn new` would
+/// have written beside it. `tempfile` creates its temporaries `0600`, and
+/// publishing one of those unchanged would leave an added `ci.yml` or
+/// `input.css` unreadable to every other uid — fatal to a Docker stage that
+/// drops privileges, and invisible in `git diff`, which tracks only the
+/// executable bit.
+#[cfg(unix)]
+fn permissions_for_new_file(directory: &Path) -> Option<std::fs::Permissions> {
+    use std::os::unix::fs::PermissionsExt as _;
+
+    let mode = std::fs::metadata(directory).ok()?.permissions().mode();
+    Some(std::fs::Permissions::from_mode(mode & 0o666))
+}
+
+#[cfg(not(unix))]
+fn permissions_for_new_file(_directory: &Path) -> Option<std::fs::Permissions> {
+    None
+}
+
 /// Publish `contents` at `absolute`, atomically.
 ///
-/// Staged beside the destination and published by a link operation, never
-/// written in place. A plain `fs::write` interrupted by Ctrl-C or a full disk
-/// leaves a truncated file — and for a file this command *added*, that is
+/// Staged beside the destination and published by a single link operation,
+/// never written in place. A plain `fs::write` interrupted by Ctrl-C or a full
+/// disk leaves a truncated file — and for a file this command *added*, that is
 /// permanent: the truncated file has no recorded baseline, so the next run
 /// classifies it as a conflict and refuses to touch it.
 ///
-/// Staged by hand rather than through `tempfile`, which deliberately creates
-/// its temporaries 0600. Renaming one of those into place would leave an added
-/// `ci.yml` or `input.css` unreadable to every other uid — fatal to a Docker
-/// stage that drops privileges, and invisible in `git diff`, which tracks only
-/// the executable bit. `OpenOptions` honours the process umask, so a new file
-/// lands with exactly the mode `autumn new` would have given it; an existing
-/// one keeps the mode it already had.
+/// The staging file is uniquely named and deletes itself when dropped, so this
+/// function never removes a path it did not create. A predictable name would
+/// have to be *reclaimed* before use, and reclaiming means deleting a file
+/// whose provenance cannot be checked: someone else's, or the staging file of a
+/// concurrent `autumn upgrade --apply` — defeating the very race protection
+/// staging exists for. The cost is that a hard crash can leave one
+/// `.autumn-upgrade-*.tmp` behind; it is inert, and never blocks a later run.
 ///
-/// [`Publish::Create`] publishes with a hard link rather than a rename, because
-/// `rename` *replaces* its destination on Unix. The plan's re-read happens
-/// before the bytes are written and synced, so a file another process creates
-/// inside that window would be silently clobbered by the very step that
-/// advertises it will not. `hard_link` fails instead, and the caller reports it
-/// like any other refusal.
+/// [`Publish::Create`] publishes without replacing, because `rename` *does*
+/// replace its destination on Unix. The plan's re-read happens before the bytes
+/// are written and synced, so a file another process creates inside that window
+/// would be silently clobbered by the very step that advertises it will not.
 ///
-/// [`Publish::Replace`] is a rename, since replacing is the point there. Its
-/// window is narrowed by the re-read, not closed: a writer that replaces the
-/// file between the re-read and the rename loses. Closing that needs an
-/// exchange primitive no portable API offers, and it is the same window every
+/// [`Publish::Replace`] does replace, since that is the point there. Its window
+/// is narrowed by the re-read, not closed: a writer that replaces the file
+/// between the re-read and the publish loses. Closing that needs an exchange
+/// primitive no portable API offers, and it is the same window every
 /// rename-based updater lives with.
 fn publish(absolute: &Path, contents: &str, mode: Publish) -> Result<(), String> {
     use std::io::Write as _;
 
-    let scratch = scratch_path(absolute);
-    // Debris from a killed run, cleared so a crash is not permanent. Only ever
-    // this function's own scratch name, and never the destination.
-    let _ = std::fs::remove_file(&scratch);
-    let mut file = std::fs::OpenOptions::new()
-        .write(true)
-        // Refuses to clobber, so a second `autumn upgrade --apply` racing this
-        // one is a loud error rather than two writers interleaving into one
-        // file.
-        .create_new(true)
-        .open(&scratch)
-        .map_err(|error| format!("{}: {error}", scratch.display()))?;
-    // Replacing a file keeps its mode; the umask default the scratch was
-    // created with is only right for a file that is genuinely new.
-    if mode == Publish::Replace
-        && let Ok(metadata) = std::fs::metadata(absolute)
-    {
-        let _ = file.set_permissions(metadata.permissions());
+    let directory = absolute
+        .parent()
+        .ok_or_else(|| "no parent directory".to_owned())?;
+    let mut temp = tempfile::Builder::new()
+        .prefix(".autumn-upgrade-")
+        .suffix(".tmp")
+        .tempfile_in(directory)
+        .map_err(|error| error.to_string())?;
+
+    // Replacing a file keeps the mode it already had; a genuinely new one takes
+    // the mode the directory implies.
+    let permissions = match mode {
+        Publish::Replace => std::fs::metadata(absolute)
+            .ok()
+            .map(|metadata| metadata.permissions()),
+        Publish::Create => permissions_for_new_file(directory),
+    };
+    if let Some(permissions) = permissions {
+        let _ = temp.as_file().set_permissions(permissions);
     }
 
-    let staged = file
-        .write_all(contents.as_bytes())
-        .and_then(|()| file.flush())
-        // The link is atomic, but only against a crash if the bytes reached the
-        // disk first: otherwise it can land before the data and publish an
-        // empty file.
-        .and_then(|()| file.sync_all());
-    drop(file);
+    temp.write_all(contents.as_bytes())
+        .map_err(|error| error.to_string())?;
+    temp.flush().map_err(|error| error.to_string())?;
+    // The publish is atomic, but only against a crash if the bytes reached the
+    // disk first: otherwise it can land before the data and publish an empty
+    // file.
+    temp.as_file()
+        .sync_all()
+        .map_err(|error| error.to_string())?;
 
-    let published = staged.and_then(|()| match mode {
-        Publish::Create => std::fs::hard_link(&scratch, absolute),
-        Publish::Replace => std::fs::rename(&scratch, absolute),
-    });
-    // The link leaves the scratch behind by design (it is the same inode); the
-    // rename consumes it. Either way nothing half-written survives, at the
-    // destination or beside it.
-    let _ = std::fs::remove_file(&scratch);
-
-    published.map_err(|error| {
-        if mode == Publish::Create && error.kind() == std::io::ErrorKind::AlreadyExists {
-            "something appeared at this path while it was being written; \
-             it was left exactly as it is"
-                .to_owned()
-        } else {
-            error.to_string()
-        }
-    })
+    match mode {
+        Publish::Create => temp.persist_noclobber(absolute).map_err(|error| {
+            if error.error.kind() == std::io::ErrorKind::AlreadyExists {
+                "something appeared at this path while it was being written; \
+                 it was left exactly as it is"
+                    .to_owned()
+            } else {
+                error.error.to_string()
+            }
+        })?,
+        Publish::Replace => temp
+            .persist(absolute)
+            .map_err(|error| error.error.to_string())?,
+    };
+    Ok(())
 }
 
 /// Re-read what an entry's path holds now, by the same rules the plan used —
@@ -2249,32 +2259,6 @@ mod tests {
     }
 
     #[test]
-    fn an_added_file_is_published_only_once_it_is_complete() {
-        // An addition interrupted partway — Ctrl-C, a full disk — must not
-        // leave a truncated file at the destination. That file would have no
-        // recorded baseline, so the next run would call it a conflict and
-        // refuse to touch it: a corrupted file the tool can never repair.
-        let tmp = scaffolded(GenerateOptions::default());
-        fs::remove_file(tmp.path().join("rustfmt.toml")).unwrap();
-        let mut manifest = Manifest::load(tmp.path()).unwrap();
-        manifest.digests.remove("rustfmt.toml");
-        manifest.save(tmp.path()).unwrap();
-
-        // Occupy the scratch path with a directory, so publishing fails after
-        // the plan is made but before anything reaches the destination.
-        let scratch = scratch_path(&tmp.path().join("rustfmt.toml"));
-        fs::create_dir_all(&scratch).unwrap();
-
-        let mut report = plan_in(tmp.path());
-        let failure = apply(&mut report).expect_err("the write must fail");
-        assert_eq!(failure.path, "rustfmt.toml");
-        assert!(
-            !tmp.path().join("rustfmt.toml").exists(),
-            "a failed addition must leave nothing at the destination"
-        );
-    }
-
-    #[test]
     fn a_completed_apply_leaves_no_scratch_files_behind() {
         let tmp = scaffolded(GenerateOptions::default());
         fs::remove_file(tmp.path().join("rustfmt.toml")).unwrap();
@@ -2300,26 +2284,32 @@ mod tests {
     }
 
     #[test]
-    fn a_stale_scratch_file_does_not_block_a_later_run() {
-        // A run killed mid-write leaves its scratch file behind. If that
-        // blocked every future addition, the crash would be permanent.
+    fn a_file_that_merely_looks_like_scratch_is_neither_deleted_nor_a_blocker() {
+        // Nothing outside the framework-owned set may be touched, and that
+        // includes a path that happens to resemble this command's own staging
+        // file — someone else's, or a concurrent `--apply`'s, whose deletion
+        // would defeat the very race protection staging exists for.
         let tmp = scaffolded(GenerateOptions::default());
         fs::remove_file(tmp.path().join("rustfmt.toml")).unwrap();
         let mut manifest = Manifest::load(tmp.path()).unwrap();
         manifest.digests.remove("rustfmt.toml");
         manifest.save(tmp.path()).unwrap();
-        fs::write(
-            scratch_path(&tmp.path().join("rustfmt.toml")),
-            "half-written leftovers",
-        )
-        .unwrap();
+        let lookalike = tmp.path().join(".autumn-upgrade-rustfmt.toml.tmp");
+        fs::write(&lookalike, "not this command's to delete\n").unwrap();
 
         let mut report = plan_in(tmp.path());
-        apply(&mut report).expect("a stale scratch file is not a blocker");
+        apply(&mut report).expect("a lookalike is not a blocker");
+
         let files = current_files(tmp.path(), GenerateOptions::default()).unwrap();
         assert_eq!(
             fs::read_to_string(tmp.path().join("rustfmt.toml")).unwrap(),
-            files["rustfmt.toml"]
+            files["rustfmt.toml"],
+            "the addition still lands"
+        );
+        assert_eq!(
+            fs::read_to_string(&lookalike).unwrap(),
+            "not this command's to delete\n",
+            "an unowned file must survive untouched"
         );
     }
 
@@ -2414,7 +2404,7 @@ mod tests {
             fs::read_to_string(&path).unwrap(),
             "someone else got here first\n"
         );
-        assert!(!scratch_path(&path).exists(), "no scratch left behind");
+        assert!(no_scratch_beside(&path), "no scratch left behind");
     }
 
     #[test]
@@ -2425,7 +2415,20 @@ mod tests {
 
         publish(&path, "new\n", Publish::Replace).expect("replace");
         assert_eq!(fs::read_to_string(&path).unwrap(), "new\n");
-        assert!(!scratch_path(&path).exists(), "no scratch left behind");
+        assert!(no_scratch_beside(&path), "no scratch left behind");
+    }
+
+    /// Whether the directory holding `path` is free of staging files.
+    fn no_scratch_beside(path: &std::path::Path) -> bool {
+        !fs::read_dir(path.parent().unwrap())
+            .unwrap()
+            .filter_map(Result::ok)
+            .any(|entry| {
+                entry
+                    .file_name()
+                    .to_string_lossy()
+                    .starts_with(".autumn-upgrade-")
+            })
     }
 
     #[test]

--- a/autumn-cli/src/upgrade/scaffold.rs
+++ b/autumn-cli/src/upgrade/scaffold.rs
@@ -974,24 +974,34 @@ pub fn apply(report: &mut ScaffoldReport) -> Result<(), WriteFailure> {
         }
     }
 
-    record_baseline(report);
+    // The files are all written, so the outcome is `Applied` whatever happens
+    // next — but recording the baseline is part of the job, not a courtesy.
+    let written = report.applicable().len();
     report.outcome = super::Outcome::Applied;
-    Ok(())
+    record_baseline(report).map_err(|error| WriteFailure {
+        path: MANIFEST_PATH.to_owned(),
+        error,
+        written,
+    })
 }
 
 /// Refresh the provenance manifest after a completed apply.
 ///
-/// Best effort by design: the manifest is bookkeeping, so failing to write it
-/// must not read as a failure to upgrade — the files on disk are already
-/// correct and the next run simply has a staler baseline.
-fn record_baseline(report: &ScaffoldReport) {
+/// # Errors
+///
+/// Fails when the manifest cannot be written. Deliberately *not* best effort:
+/// the files on disk are correct, but without their new digests the very next
+/// `autumn upgrade --check` reports them as conflicts and exits 3. An apply
+/// that guarantees a red gate afterwards has not succeeded, and returning
+/// success would tell a CI script otherwise.
+fn record_baseline(report: &ScaffoldReport) -> Result<(), String> {
     // A report with no entries reconciled nothing, and rebuilding the manifest
     // from no entries would prune every digest in it. That is the baseline the
     // whole feature rests on, destroyed by a run that did not even look at the
     // files. The only report shaped like this is one whose project name could
     // not be read, which is a refusal to answer, not an answer.
     if !report.named {
-        return;
+        return Ok(());
     }
     let previous = Manifest::load(&report.root);
     let next = report.next_manifest(previous.as_ref());
@@ -1000,9 +1010,15 @@ fn record_baseline(report: &ScaffoldReport) {
     let rendered = next.render();
     let path = report.root.join(MANIFEST_PATH);
     if std::fs::read_to_string(&path).is_ok_and(|current| current == rendered) {
-        return;
+        return Ok(());
     }
-    let _ = next.save(&report.root);
+    next.save(&report.root).map_err(|error| {
+        format!(
+            "the scaffold files were written, but the baseline could not be recorded: \
+             {error}. Until it is, every file this run updated will be reported as a \
+             conflict and `--check` will not go green."
+        )
+    })
 }
 
 /// Write one entry, refusing to clobber anything that moved since the plan.
@@ -2357,7 +2373,8 @@ mod tests {
 
         fs::remove_file(tmp.path().join("rustfmt.toml")).unwrap();
         let mut report = plan_in(tmp.path());
-        apply(&mut report).expect("the scaffold files still reconcile");
+        let failure = apply(&mut report).expect_err("the baseline cannot be recorded");
+        assert_eq!(failure.path, MANIFEST_PATH);
 
         assert_eq!(
             fs::read_to_string(&outside).unwrap(),
@@ -2377,7 +2394,8 @@ mod tests {
 
         fs::remove_file(tmp.path().join("rustfmt.toml")).unwrap();
         let mut report = plan_in(tmp.path());
-        apply(&mut report).expect("the scaffold files still reconcile");
+        let failure = apply(&mut report).expect_err("the baseline cannot be recorded");
+        assert_eq!(failure.path, MANIFEST_PATH);
 
         assert!(
             !outside.join("scaffold.toml").exists(),
@@ -2588,5 +2606,34 @@ mod tests {
             ordinary & 0o777,
             "the manifest must be as readable as the files it describes"
         );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn an_apply_that_cannot_record_its_baseline_is_not_a_success() {
+        // The scaffold files are written correctly, but without the baseline
+        // the very next `--check` reports them as conflicts and exits 3. An
+        // apply that guarantees a red gate afterwards has not succeeded, and
+        // reporting exit 0 tells a CI script otherwise.
+        let tmp = scaffolded(GenerateOptions::default());
+        let outside = tmp.path().join("outside.toml");
+        fs::write(&outside, "not mine\n").unwrap();
+        fs::remove_file(tmp.path().join(MANIFEST_PATH)).unwrap();
+        std::os::unix::fs::symlink(&outside, tmp.path().join(MANIFEST_PATH)).unwrap();
+        fs::remove_file(tmp.path().join("rustfmt.toml")).unwrap();
+
+        let mut report = plan_in(tmp.path());
+        let failure = apply(&mut report).expect_err("must not report success");
+        assert_eq!(failure.path, MANIFEST_PATH);
+        assert!(failure.error.contains("baseline"), "{}", failure.error);
+
+        // The files it did write are still correct, and the run says how many.
+        let files = current_files(tmp.path(), GenerateOptions::default()).unwrap();
+        assert_eq!(
+            fs::read_to_string(tmp.path().join("rustfmt.toml")).unwrap(),
+            files["rustfmt.toml"]
+        );
+        assert_eq!(failure.written, report.applicable().len());
+        assert_eq!(fs::read_to_string(&outside).unwrap(), "not mine\n");
     }
 }

--- a/autumn-cli/src/upgrade/scaffold.rs
+++ b/autumn-cli/src/upgrade/scaffold.rs
@@ -79,6 +79,10 @@ pub fn digest(contents: &str) -> String {
 struct ManifestFile {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     version: Option<String>,
+    /// The newest release that has written digests here. Distinct from
+    /// `version`, which is held back while conflicts stand.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    written_by: Option<String>,
     flavor: String,
     #[serde(default)]
     i18n: bool,
@@ -113,6 +117,17 @@ pub struct Manifest {
     /// standing has not finished, and recording the target anyway would tell
     /// the next run — and the developer reading the file — that it had.
     pub version: Option<String>,
+    /// The newest release that has written any digest in this manifest — a
+    /// high-water mark, never moving backwards.
+    ///
+    /// Deliberately separate from [`Self::version`], which answers a different
+    /// question and cannot answer this one. A conflict holds `version` back
+    /// while the digests still advance to the newer templates, so an older CLI
+    /// reading `version` alone sees nothing newer than itself, trusts those
+    /// digests against its own older templates, and downgrades every file they
+    /// describe. Which release *reconciled* the project and which release
+    /// *wrote* these digests are not the same fact.
+    pub written_by: Option<String>,
     /// The flags that release was invoked with, insofar as they change which
     /// framework-owned files exist and what they contain.
     pub options: GenerateOptions,
@@ -132,6 +147,7 @@ impl Manifest {
     ) -> Self {
         Self {
             version: Some(version.to_owned()),
+            written_by: Some(version.to_owned()),
             options,
             digests: files
                 .iter()
@@ -146,6 +162,7 @@ impl Manifest {
     pub fn render(&self) -> String {
         let file = ManifestFile {
             version: self.version.clone(),
+            written_by: self.written_by.clone(),
             flavor: if self.options.with_api {
                 FLAVOR_API
             } else {
@@ -185,6 +202,7 @@ impl Manifest {
         let file: ManifestFile = toml::from_str(text).ok()?;
         Some(Self {
             version: file.version,
+            written_by: file.written_by,
             options: GenerateOptions {
                 // Anything but the two flavours this CLI knows is treated as no
                 // manifest at all. Falling back to `fullstack` would keep
@@ -851,8 +869,16 @@ impl ScaffoldReport {
         } else {
             previous.and_then(|manifest| manifest.version.clone())
         };
+        // The renderer mark moves forward on every write, conflicts or not:
+        // these digests describe *this* release's templates, and an older CLI
+        // must be able to see that even when the baseline could not advance.
+        let written_by = Some(newest(
+            previous.and_then(|m| m.written_by.as_deref()),
+            &self.target,
+        ));
         Manifest {
             version,
+            written_by,
             options: self.options,
             digests,
             pinned: previous
@@ -902,9 +928,18 @@ pub fn plan_after(root: &Path, _target: &str, migrated: &BTreeSet<String>) -> Sc
     // templates here are older than the files those digests describe, so every
     // untouched file would classify as a writable `update` and `--apply` would
     // downgrade it. Nothing is rendered and nothing is classified.
+    // The newest release either field names. `written_by` is the one that
+    // matters — a conflict holds `version` back while the digests advance, so
+    // `version` alone would let an older CLI trust newer digests — but taking
+    // the newer of the two costs nothing, covers a manifest written before the
+    // mark existed, and refuses an incoherent manifest whose `version` somehow
+    // exceeds it rather than reasoning about which field to believe.
     let scaffolded_by_newer = manifest
         .as_ref()
-        .and_then(|manifest| manifest.version.clone())
+        .and_then(|manifest| match (&manifest.written_by, &manifest.version) {
+            (Some(written_by), Some(version)) => Some(newest(Some(version), written_by)),
+            (recorded, None) | (None, recorded) => recorded.clone(),
+        })
         .filter(|recorded| is_newer_than_this_cli(recorded));
     let files = scaffolded_by_newer
         .is_none()
@@ -924,6 +959,20 @@ pub fn plan_after(root: &Path, _target: &str, migrated: &BTreeSet<String>) -> Sc
         target,
         has_manifest: manifest.is_some(),
         outcome: super::Outcome::Preview,
+    }
+}
+
+/// The newer of two release strings, preferring `candidate` when neither
+/// parses as a version.
+fn newest(previous: Option<&str>, candidate: &str) -> String {
+    let parse = super::migrations::parse_version_req;
+    match (previous.and_then(parse), parse(candidate)) {
+        (Some(previous_version), Some(candidate_version))
+            if previous_version > candidate_version =>
+        {
+            previous.unwrap_or(candidate).to_owned()
+        }
+        _ => candidate.to_owned(),
     }
 }
 
@@ -978,6 +1027,7 @@ pub fn accept(root: &Path, paths: &[String]) -> Result<Manifest, String> {
 
     let mut manifest = manifest.unwrap_or_else(|| Manifest {
         version: None,
+        written_by: None,
         options,
         digests: BTreeMap::new(),
         pinned: BTreeSet::new(),
@@ -1501,6 +1551,7 @@ mod tests {
         digests.insert(".github/workflows/ci.yml".to_owned(), digest("b\n"));
         let manifest = Manifest {
             version: Some("0.7.0".to_owned()),
+            written_by: Some("0.7.0".to_owned()),
             options: GenerateOptions {
                 with_api: true,
                 with_i18n: true,
@@ -1527,6 +1578,7 @@ mod tests {
         digests.insert("static/css/input.css".to_owned(), digest("z"));
         let manifest = Manifest {
             version: Some("0.7.0".to_owned()),
+            written_by: Some("0.7.0".to_owned()),
             options: GenerateOptions::default(),
             digests: digests.clone(),
             pinned: BTreeSet::new(),
@@ -1560,6 +1612,7 @@ mod tests {
         digests.insert("clippy.toml".to_owned(), digest("a\n"));
         let manifest = Manifest {
             version: Some("0.7.0".to_owned()),
+            written_by: Some("0.7.0".to_owned()),
             options: GenerateOptions::default(),
             digests,
             pinned: BTreeSet::new(),
@@ -2806,6 +2859,80 @@ mod tests {
         assert_eq!(
             added, expected,
             "an added file must carry the mode an ordinary write would give it"
+        );
+    }
+
+    #[test]
+    fn a_partial_upgrade_by_a_newer_release_still_refuses_an_older_cli() {
+        // `version` is held back while conflicts stand (so a half-finished
+        // upgrade never reads as finished), but the digests advance to the
+        // newer templates regardless. One field cannot mean both "the release
+        // fully reconciled to" and "the newest renderer that wrote here" — and
+        // reading the first as the second lets an older CLI trust newer digests
+        // and downgrade the files they describe.
+        let tmp = scaffolded(GenerateOptions::default());
+        let newer = "# written by a newer release\n";
+        write(tmp.path(), "clippy.toml", newer);
+        let mut manifest = Manifest::load(tmp.path()).unwrap();
+        manifest.version = Some("0.5.0".to_owned()); // held back by a conflict
+        manifest.written_by = Some("99.0.0".to_owned()); // but 99.0.0 wrote these digests
+        manifest
+            .digests
+            .insert("clippy.toml".to_owned(), digest(newer));
+        manifest.save(tmp.path()).unwrap();
+
+        let report = plan_in(tmp.path());
+        assert_eq!(report.scaffolded_by_newer.as_deref(), Some("99.0.0"));
+        assert!(report.entries.is_empty());
+
+        let mut report = plan_in(tmp.path());
+        apply(&mut report).expect("apply");
+        assert_eq!(
+            fs::read_to_string(tmp.path().join("clippy.toml")).unwrap(),
+            newer,
+            "a newer release's file must never be downgraded"
+        );
+    }
+
+    #[test]
+    fn the_renderer_high_water_mark_advances_even_when_the_baseline_cannot() {
+        // A conflict holds `version` back; it must not hold back the record of
+        // which renderer produced the digests, or the next older CLI to run
+        // here has nothing to refuse on.
+        let tmp = scaffolded(GenerateOptions::default());
+        write(tmp.path(), "Dockerfile", "FROM scratch\n");
+        let stale = "# older\n";
+        write(tmp.path(), "clippy.toml", stale);
+        let mut manifest = Manifest::load(tmp.path()).unwrap();
+        manifest.version = Some("0.5.0".to_owned());
+        manifest.written_by = Some("0.5.0".to_owned());
+        manifest
+            .digests
+            .insert("clippy.toml".to_owned(), digest(stale));
+        manifest.save(tmp.path()).unwrap();
+
+        let mut report = plan_in(tmp.path());
+        apply(&mut report).expect("apply");
+
+        let after = Manifest::load(tmp.path()).unwrap();
+        assert_eq!(
+            after.version.as_deref(),
+            Some("0.5.0"),
+            "the baseline still waits on the conflict"
+        );
+        assert_eq!(
+            after.written_by.as_deref(),
+            Some(env!("CARGO_PKG_VERSION")),
+            "but this renderer wrote these digests"
+        );
+    }
+
+    #[test]
+    fn a_new_project_records_which_renderer_wrote_it() {
+        let tmp = scaffolded(GenerateOptions::default());
+        assert_eq!(
+            Manifest::load(tmp.path()).unwrap().written_by.as_deref(),
+            Some("0.7.0")
         );
     }
 }

--- a/autumn-cli/src/upgrade/scaffold.rs
+++ b/autumn-cli/src/upgrade/scaffold.rs
@@ -220,6 +220,16 @@ impl Manifest {
     /// upgrading conservatively.
     #[must_use]
     pub fn load(root: &Path) -> Option<Self> {
+        // Refusing to *write* through a linked manifest was only half of it.
+        // Read through one and whoever controls the target supplies the
+        // digests — and a digest matching a project's current scaffold file
+        // turns that file into an `update`, so the next `--apply` overwrites
+        // something nobody vouched for. A manifest reachable only through a
+        // link is treated as absent, which is the same conservative answer a
+        // project that never had one gets.
+        if matches!(read_current(root, MANIFEST_PATH), OnDisk::Linked(_)) {
+            return None;
+        }
         Self::parse(&std::fs::read_to_string(root.join(MANIFEST_PATH)).ok()?)
     }
 
@@ -475,17 +485,28 @@ const WORKSPACE_ROOT_OWNED: &[&str] = &[
 /// the same way.
 #[must_use]
 pub fn workspace_root_above(root: &Path) -> Option<PathBuf> {
+    // A manifest carrying `[workspace]` alongside its `[package]` is the
+    // standard way for a crate below another workspace to form its own — and a
+    // workspace root owns the toolchain, lint, formatting and CI files no
+    // matter what sits above it. Answering "member" here would take exactly
+    // those out of scope and let drift in them go unreported.
+    if declares_workspace(root) {
+        return None;
+    }
     let absolute = root.canonicalize().ok()?;
     absolute
         .ancestors()
         .skip(1)
-        .find(|ancestor| {
-            std::fs::read_to_string(ancestor.join("Cargo.toml"))
-                .ok()
-                .and_then(|text| text.parse::<toml::Table>().ok())
-                .is_some_and(|table| table.contains_key("workspace"))
-        })
+        .find(|ancestor| declares_workspace(ancestor))
         .map(Path::to_path_buf)
+}
+
+/// Whether the `Cargo.toml` in `directory` declares a workspace.
+fn declares_workspace(directory: &Path) -> bool {
+    std::fs::read_to_string(directory.join("Cargo.toml"))
+        .ok()
+        .and_then(|text| text.parse::<toml::Table>().ok())
+        .is_some_and(|table| table.contains_key("workspace"))
 }
 
 /// The current release's framework-owned files, rendered for the project at
@@ -2464,6 +2485,74 @@ mod tests {
                 .iter()
                 .any(|entry| entry.path == "build.rs"),
             "a file the codemods rewrite is never a writable scaffold update"
+        );
+    }
+
+    #[test]
+    fn a_nested_workspace_root_is_a_root_not_a_member() {
+        // `[package]` and `[workspace]` in one manifest is the standard way for
+        // a crate below another workspace to form its own. It owns its
+        // toolchain, lint, formatting and CI files — treating it as a member
+        // drops exactly those out of scope, so drift in them goes unreported.
+        let outer = TempDir::new().unwrap();
+        fs::write(
+            outer.path().join("Cargo.toml"),
+            "[workspace]\nmembers = [\"app\"]\nresolver = \"3\"\n",
+        )
+        .unwrap();
+        let root = outer.path().join("app");
+        fs::create_dir_all(&root).unwrap();
+        write(
+            &root,
+            "Cargo.toml",
+            "[package]\nname = \"demo\"\nversion = \"0.1.0\"\n\n[workspace]\n",
+        );
+        write(&root, "autumn.toml", "[server]\n");
+
+        let report = plan(&root, "0.7.0");
+        assert!(
+            !report.workspace_member,
+            "its own `[workspace]` makes it a root"
+        );
+        let offered: Vec<&str> = report.entries.iter().map(|e| e.path.as_str()).collect();
+        for owned in ["clippy.toml", "rustfmt.toml", "rust-toolchain.toml"] {
+            assert!(offered.contains(&owned), "{owned} missing from {offered:?}");
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn a_symlinked_manifest_is_not_a_baseline_to_trust() {
+        // Refusing to WRITE through a linked manifest was only half of it: read
+        // through one, and whoever controls the target supplies the digests.
+        // A digest matching the project's current file turns it into an
+        // `update`, and the next `--apply` overwrites a file nobody vouched
+        // for.
+        let tmp = scaffolded(GenerateOptions::default());
+        let outside = tmp.path().join("outside-manifest.toml");
+        let real = fs::read_to_string(tmp.path().join(MANIFEST_PATH)).unwrap();
+        fs::write(&outside, &real).unwrap();
+        fs::remove_file(tmp.path().join(MANIFEST_PATH)).unwrap();
+        std::os::unix::fs::symlink(&outside, tmp.path().join(MANIFEST_PATH)).unwrap();
+
+        assert!(
+            Manifest::load(tmp.path()).is_none(),
+            "a linked manifest vouches for nothing"
+        );
+
+        // A file it would otherwise have called `update` is a conflict instead.
+        let stale = "# older\n";
+        write(tmp.path(), "clippy.toml", stale);
+        let mut linked = Manifest::parse(&real).unwrap();
+        linked
+            .digests
+            .insert("clippy.toml".to_owned(), digest(stale));
+        fs::write(&outside, linked.render()).unwrap();
+
+        let entries = plan_in(tmp.path()).entries;
+        assert_eq!(
+            status_of(&entries, "clippy.toml"),
+            &Status::Conflict(ConflictReason::NoBaseline)
         );
     }
 }

--- a/autumn-cli/src/upgrade/scaffold.rs
+++ b/autumn-cli/src/upgrade/scaffold.rs
@@ -88,6 +88,13 @@ struct ManifestFile {
     daemon: bool,
     #[serde(default)]
     bundled_pg: bool,
+    /// Paths the developer has claimed as theirs. A plain list of names, on
+    /// purpose: unlike the digests it is meant to be hand-editable — removing a
+    /// line is how a file comes back under reconciliation.
+    #[serde(default, skip_serializing_if = "BTreeSet::is_empty")]
+    pinned: BTreeSet<String>,
+    // Last: TOML serialises a table's scalars before its sub-tables, so a
+    // field declared after `files` would be emitted inside it.
     #[serde(default)]
     files: BTreeMap<String, String>,
 }
@@ -111,6 +118,8 @@ pub struct Manifest {
     pub options: GenerateOptions,
     /// Project-relative path → digest of the file as Autumn wrote it.
     pub digests: BTreeMap<String, String>,
+    /// Paths the developer has accepted as their own; never reconciled.
+    pub pinned: BTreeSet<String>,
 }
 
 impl Manifest {
@@ -128,6 +137,7 @@ impl Manifest {
                 .iter()
                 .map(|(path, contents)| ((*path).to_owned(), digest(contents)))
                 .collect(),
+            pinned: BTreeSet::new(),
         }
     }
 
@@ -147,6 +157,7 @@ impl Manifest {
             daemon: self.options.with_daemon,
             bundled_pg: self.options.with_bundled_pg,
             files: self.digests.clone(),
+            pinned: self.pinned.clone(),
         };
         // Serialization cannot fail for this shape (plain strings, bools, and a
         // string map), but a panic here would abort a scaffold over
@@ -182,6 +193,7 @@ impl Manifest {
                 with_bundled_pg: file.bundled_pg,
             },
             digests: file.files,
+            pinned: file.pinned,
         })
     }
 
@@ -220,9 +232,15 @@ pub enum ConflictReason {
     /// the process cannot open it. What it holds is unknown, so it is
     /// untouchable.
     Unreadable,
-    /// The path is a symbolic link. Writing through it would write wherever it
-    /// points, which need not be inside the project at all.
+    /// The path, or a directory on the way to it, is a symbolic link. Writing
+    /// through it would write wherever it points, which need not be inside the
+    /// project at all.
     Symlink,
+    /// This same run's app-code migrations rewrote the file. `build.rs` is both
+    /// a framework-owned file and a `.rs` file the codemods scan, so the two
+    /// halves can land on it in one run — and blaming the developer for an edit
+    /// the tool made four lines earlier would be simply false.
+    MigratedThisRun,
 }
 
 impl ConflictReason {
@@ -234,6 +252,9 @@ impl ConflictReason {
             Self::NoBaseline => "no recorded baseline, so an edit cannot be ruled out",
             Self::Unreadable => "on disk but unreadable as text, so its contents are unknown",
             Self::Symlink => "a symlink; writing through it could write outside the project",
+            Self::MigratedThisRun => {
+                "this run's app-code migrations rewrote it; reconcile it by hand"
+            }
         }
     }
 }
@@ -254,6 +275,10 @@ pub enum Status {
     /// Autumn wrote this file once and the developer removed it. Reported so
     /// the drift is visible, never written back: deleting it was a decision.
     Removed,
+    /// The developer has said this file is theirs (`autumn upgrade --accept`).
+    /// Reported, never written, and not drift — so a team that customises its
+    /// `Dockerfile` can still hold a green `--check`.
+    Pinned,
 }
 
 impl Status {
@@ -265,9 +290,10 @@ impl Status {
 
     /// Whether this counts as drift for `--check`.
     ///
-    /// [`Status::Removed`] does not. A CI gate that can never go green again
-    /// because someone deliberately deleted `.env.example` teaches people to
-    /// delete the gate.
+    /// [`Status::Removed`] and [`Status::Pinned`] do not. A CI gate that can
+    /// never go green again — because someone deliberately deleted
+    /// `.env.example`, or because the team's `Dockerfile` is theirs on purpose
+    /// — teaches people to delete the gate.
     #[must_use]
     pub const fn is_drift(self) -> bool {
         matches!(self, Self::Add | Self::Update | Self::Conflict(_))
@@ -282,6 +308,7 @@ impl Status {
             Self::Update => "update",
             Self::Conflict(_) => "conflict",
             Self::Removed => "removed",
+            Self::Pinned => "pinned",
         }
     }
 
@@ -293,7 +320,10 @@ impl Status {
             Self::Add => "this release's scaffold has it; your project does not",
             Self::Update => "the template changed and your copy is untouched",
             Self::Conflict(reason) => reason.describe(),
-            Self::Removed => "you deleted this; it is not restored",
+            Self::Removed => {
+                "you deleted this; it is not restored (drop its line from the manifest to be offered it again)"
+            }
+            Self::Pinned => "you accepted this file as yours; it is left alone",
         }
     }
 }
@@ -370,8 +400,15 @@ pub fn resolve_options(root: &Path, manifest: Option<&Manifest>) -> GenerateOpti
     // flavour guessed from a weak signal does not mislabel a report, it seeds
     // Tailwind into an app that has no use for it. Any one of these is enough,
     // so deleting a single file cannot reclassify a fullstack project either.
+    // Each of these is a file the fullstack scaffold writes and the API
+    // scaffold never does. A `static/` directory — or even a `static/css/` one
+    // — is not evidence: a JSON API serves its `openapi.json`, its favicon, or
+    // a stylesheet for a docs page out of exactly those. Getting this wrong is
+    // not a mislabelled report: `add` writes with no baseline behind it, so a
+    // weak signal seeds Tailwind into an app with no view stack, and the first
+    // `--apply` then records the guess as fact.
     let fullstack = root.join("tailwind.config.js").exists()
-        || root.join("static/css").is_dir()
+        || root.join("static/css/input.css").exists()
         || root.join("static/js/htmx.min.js").exists();
     GenerateOptions {
         with_api: !fullstack,
@@ -382,6 +419,43 @@ pub fn resolve_options(root: &Path, manifest: Option<&Manifest>) -> GenerateOpti
         with_daemon: bundled_pg || autumn_toml.contains("this app uses no database"),
         with_bundled_pg: bundled_pg,
     }
+}
+
+/// Files that a Cargo workspace owns at its root, not per crate.
+///
+/// `clippy.toml`, `rustfmt.toml` and `rust-toolchain.toml` are all resolved
+/// from the *nearest ancestor* of the crate being built, so a crate-local copy
+/// does not add to the workspace's — it **shadows** it, silently dropping its
+/// lints and its MSRV pin with no diagnostic. GitHub only runs workflows from
+/// the repository root, so a member's `.github/workflows/ci.yml` never runs at
+/// all. Seeding any of them into a workspace member is not an upgrade; it is a
+/// regression that looks like one.
+const WORKSPACE_ROOT_OWNED: &[&str] = &[
+    "clippy.toml",
+    "rustfmt.toml",
+    "rust-toolchain.toml",
+    ".github/workflows/ci.yml",
+];
+
+/// Whether `root` is a crate inside an enclosing Cargo workspace.
+///
+/// Answered from the `[workspace]` table of an ancestor manifest rather than
+/// from its `members` list: a path dependency, an `exclude`d fixture and a
+/// listed member all sit under the same root config, and all three shadow it
+/// the same way.
+#[must_use]
+pub fn workspace_root_above(root: &Path) -> Option<PathBuf> {
+    let absolute = root.canonicalize().ok()?;
+    absolute
+        .ancestors()
+        .skip(1)
+        .find(|ancestor| {
+            std::fs::read_to_string(ancestor.join("Cargo.toml"))
+                .ok()
+                .and_then(|text| text.parse::<toml::Table>().ok())
+                .is_some_and(|table| table.contains_key("workspace"))
+        })
+        .map(Path::to_path_buf)
 }
 
 /// The current release's framework-owned files, rendered for the project at
@@ -399,45 +473,85 @@ pub fn current_files(
         autumn_version: env!("CARGO_PKG_VERSION"),
         rust_version: option_env!("CARGO_PKG_RUST_VERSION").unwrap_or("1.88.0"),
     };
-    Some(framework_owned_files(&vars, options))
+    let mut files = framework_owned_files(&vars, options);
+    if workspace_root_above(root).is_some() {
+        for path in WORKSPACE_ROOT_OWNED {
+            files.remove(path);
+        }
+    }
+    Some(files)
 }
 
 /// What is at a framework-owned path right now.
 ///
-/// Three states, not two. Collapsing "there but unreadable" into "absent" — the
-/// shape `read_to_string(..).ok()` gives you — is the bug that turns a
-/// latin-1 `input.css` or a root-owned `.gitignore` into an `add`, and then
-/// truncates it. A file whose contents cannot be read is the *last* thing that
-/// may be overwritten, not the first.
+/// Four states, not two. Collapsing "there but unreadable" into "absent" — the
+/// shape `read_to_string(..).ok()` gives you — is the bug that turns a latin-1
+/// `input.css` or a root-owned `.gitignore` into an `add`, and then truncates
+/// it. A file whose contents cannot be read is the *last* thing that may be
+/// overwritten, not the first.
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum OnDisk {
     /// Nothing at this path.
     Absent,
     /// Readable text, line endings normalised.
     Text(String),
+    /// Reached through a symbolic link. The contents are known — so a link
+    /// whose target already matches the scaffold is simply current — but the
+    /// path is never written, because the write would land wherever the link
+    /// points, which need not be inside the project.
+    Linked(Option<String>),
     /// Present, and untouchable for this reason.
     Opaque(ConflictReason),
 }
 
-fn read_current(absolute: &Path) -> OnDisk {
+/// Read the path `relative` under `root`, refusing to resolve through a link.
+///
+/// The whole chain is checked, not just the leaf. A project whose `.github` is
+/// a symlink to a shared workflows tree would otherwise have
+/// `.github/workflows/ci.yml` classified as an ordinary missing file — and
+/// `--apply` would then create it outside the project, somewhere the project's
+/// own `git status` can never show.
+fn read_current(root: &Path, relative: &str) -> OnDisk {
+    let mut cursor = root.to_path_buf();
+    let components: Vec<&str> = relative.split('/').collect();
+    let (_leaf, parents) = components
+        .split_last()
+        .expect("a framework-owned path always has at least one component");
+    for directory in parents {
+        cursor.push(directory);
+        match std::fs::symlink_metadata(&cursor) {
+            // A directory that is not there yet is not a link, and creating it
+            // is exactly what an `add` of a nested file does.
+            Err(_) => break,
+            Ok(metadata) if metadata.file_type().is_symlink() => {
+                return OnDisk::Linked(read_text(&root.join(relative)));
+            }
+            Ok(_) => {}
+        }
+    }
+
+    let absolute = root.join(relative);
     // `symlink_metadata` does not follow, which is the point: a link's own
-    // metadata is what says it is a link. `metadata` would report the target
+    // metadata is what says it is a link. `metadata` would report the target,
     // and a dangling link would read as absent — the exact combination that
     // lets `--apply` create a file outside the project.
-    match std::fs::symlink_metadata(absolute) {
+    match std::fs::symlink_metadata(&absolute) {
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => OnDisk::Absent,
         Err(_) => OnDisk::Opaque(ConflictReason::Unreadable),
-        Ok(metadata) if metadata.file_type().is_symlink() => {
-            OnDisk::Opaque(ConflictReason::Symlink)
-        }
+        Ok(metadata) if metadata.file_type().is_symlink() => OnDisk::Linked(read_text(&absolute)),
         // It exists. Reading it can still fail — a directory, a device,
         // non-UTF-8 bytes, a permission the process does not have — and every
         // one of those is untouchable rather than absent.
-        Ok(_) => std::fs::read_to_string(absolute)
-            .map_or(OnDisk::Opaque(ConflictReason::Unreadable), |text| {
-                OnDisk::Text(normalize(&text))
-            }),
+        Ok(_) => {
+            read_text(&absolute).map_or(OnDisk::Opaque(ConflictReason::Unreadable), OnDisk::Text)
+        }
     }
+}
+
+fn read_text(absolute: &Path) -> Option<String> {
+    std::fs::read_to_string(absolute)
+        .ok()
+        .map(|text| normalize(&text))
 }
 
 /// Reconcile `files` against what is on disk under `root`.
@@ -446,15 +560,30 @@ pub fn classify(
     root: &Path,
     files: &BTreeMap<&'static str, String>,
     manifest: Option<&Manifest>,
+    migrated: &BTreeSet<String>,
 ) -> Vec<Entry> {
     let recorded = |path: &str| manifest.and_then(|manifest| manifest.digests.get(path));
+    let pinned = |path: &str| manifest.is_some_and(|manifest| manifest.pinned.contains(path));
 
     let mut entries: Vec<Entry> = files
         .iter()
         .map(|(path, template)| {
             let absolute = root.join(path);
-            let current = read_current(&absolute);
+            let current = read_current(root, path);
+            let normalized = normalize(template);
+            let differs = |text: &str| {
+                let diff = super::diff::render(text, template);
+                (text != normalized, diff)
+            };
             let (status, diff) = match &current {
+                // Already what this release writes. Checked before anything
+                // else, including the pin: a pinned file that happens to match
+                // is current, not an exception.
+                OnDisk::Text(text) | OnDisk::Linked(Some(text)) if *text == normalized => {
+                    (Status::UpToDate, String::new())
+                }
+                // The developer has said this one is theirs.
+                _ if pinned(path) => (Status::Pinned, String::new()),
                 // Not there at all. Autumn wrote it once and it is gone → a
                 // deliberate deletion. Never wrote it → this release added it.
                 OnDisk::Absent if recorded(path).is_some() => (Status::Removed, String::new()),
@@ -463,16 +592,25 @@ pub fn classify(
                 // whole reason to look is that writing would destroy whatever
                 // is really in the file.
                 OnDisk::Opaque(reason) => (Status::Conflict(*reason), String::new()),
-                OnDisk::Text(text) if *text == normalize(template) => {
-                    (Status::UpToDate, String::new())
-                }
+                // Reachable, but only through a link. Readable or not, it is
+                // never written.
+                OnDisk::Linked(text) => (
+                    Status::Conflict(ConflictReason::Symlink),
+                    text.as_ref()
+                        .map(|text| differs(text).1)
+                        .unwrap_or_default(),
+                ),
                 OnDisk::Text(text) => {
-                    let status = match recorded(path) {
-                        Some(baseline) if *baseline == digest(text) => Status::Update,
-                        Some(_) => Status::Conflict(ConflictReason::Edited),
-                        None => Status::Conflict(ConflictReason::NoBaseline),
+                    let status = if migrated.contains(*path) {
+                        Status::Conflict(ConflictReason::MigratedThisRun)
+                    } else {
+                        match recorded(path) {
+                            Some(baseline) if *baseline == digest(text) => Status::Update,
+                            Some(_) => Status::Conflict(ConflictReason::Edited),
+                            None => Status::Conflict(ConflictReason::NoBaseline),
+                        }
                     };
-                    (status, super::diff::render(text, template))
+                    (status, differs(text).1)
                 }
             };
             Entry {
@@ -543,6 +681,9 @@ pub struct ScaffoldReport {
     /// not, the scaffold cannot be rendered for comparison and [`Self::entries`]
     /// is empty — which is a refusal to answer, not an "all clear".
     pub named: bool,
+    /// Whether this project is a crate inside an enclosing Cargo workspace, in
+    /// which case the files that workspace owns at its root are out of scope.
+    pub workspace_member: bool,
     /// Every framework-owned file, up-to-date ones included.
     pub entries: Vec<Entry>,
     /// What the apply step actually did.
@@ -574,6 +715,21 @@ impl ScaffoldReport {
             .iter()
             .filter(|entry| matches!(entry.status, Status::Conflict(_)))
             .collect()
+    }
+
+    /// Whether the report should explain that this project has no baseline.
+    ///
+    /// True while any file still has none — not merely on the first run. A
+    /// legacy project's first `--apply` writes a manifest covering only the
+    /// files it wrote, so "a manifest exists" would drop the explanation while
+    /// every remaining file was still reported as having no baseline.
+    #[must_use]
+    pub fn needs_baseline_note(&self) -> bool {
+        !self.has_manifest
+            || self
+                .entries
+                .iter()
+                .any(|entry| entry.status == Status::Conflict(ConflictReason::NoBaseline))
     }
 
     /// Every entry that is not already current, in report order.
@@ -631,6 +787,9 @@ impl ScaffoldReport {
             version,
             options: self.options,
             digests,
+            pinned: previous
+                .map(|manifest| manifest.pinned.clone())
+                .unwrap_or_default(),
         }
     }
 }
@@ -655,7 +814,19 @@ pub struct WriteFailure {
 /// selects which *codemods* run; a scaffold report claiming to reconcile to
 /// 0.6.0 while rendering 0.7.0's files would simply be false.
 #[must_use]
-pub fn plan(root: &Path, _target: &str) -> ScaffoldReport {
+pub fn plan(root: &Path, target: &str) -> ScaffoldReport {
+    plan_after(root, target, &BTreeSet::new())
+}
+
+/// Plan a reconciliation, knowing which paths this run's app-code migrations
+/// have already rewritten.
+///
+/// `build.rs` is both a framework-owned file and a `.rs` file the codemods
+/// scan, so one `--apply` can land on it twice. Told which files the first half
+/// touched, the second half reports them honestly instead of accusing the
+/// developer of an edit this command made moments earlier.
+#[must_use]
+pub fn plan_after(root: &Path, _target: &str, migrated: &BTreeSet<String>) -> ScaffoldReport {
     let target = env!("CARGO_PKG_VERSION").to_owned();
     let manifest = Manifest::load(root);
     let options = resolve_options(root, manifest.as_ref());
@@ -665,14 +836,62 @@ pub fn plan(root: &Path, _target: &str) -> ScaffoldReport {
         options,
         baseline: manifest.as_ref().and_then(|m| m.version.clone()),
         named: files.is_some(),
+        workspace_member: workspace_root_above(root).is_some(),
         entries: files
-            .map(|files| classify(root, &files, manifest.as_ref()))
+            .map(|files| classify(root, &files, manifest.as_ref(), migrated))
             .unwrap_or_default(),
         guide: release_guide(&target),
         target,
         has_manifest: manifest.is_some(),
         outcome: super::Outcome::Preview,
     }
+}
+
+/// Record `paths` as the developer's own, so reconciliation leaves them alone.
+///
+/// This is what lets a conflict *conclude*. Without it a team whose `Dockerfile`
+/// is deliberately theirs can never make `autumn upgrade --check` green again —
+/// and a gate that is permanently red is a gate that gets deleted.
+///
+/// Only the manifest is written; no project file is touched.
+///
+/// # Errors
+///
+/// Returns a message naming any path the current scaffold does not own, and
+/// changes nothing. Accepting a path is a promise that reconciliation will skip
+/// it, and a promise about a file this command never touches is meaningless.
+pub fn accept(root: &Path, paths: &[String]) -> Result<Manifest, String> {
+    let manifest = Manifest::load(root);
+    let options = resolve_options(root, manifest.as_ref());
+    let owned = current_files(root, options).ok_or_else(|| {
+        "this project's `Cargo.toml` gives no usable `[package] name`, so the scaffold \
+         cannot be rendered and there is nothing to accept against"
+            .to_owned()
+    })?;
+    let unknown: Vec<&str> = paths
+        .iter()
+        .map(String::as_str)
+        .filter(|path| !owned.contains_key(path))
+        .collect();
+    if !unknown.is_empty() {
+        return Err(format!(
+            "not framework-owned in this project, so there is nothing to accept: {}",
+            unknown.join(", ")
+        ));
+    }
+
+    let mut manifest = manifest.unwrap_or_else(|| Manifest {
+        version: None,
+        options,
+        digests: BTreeMap::new(),
+        pinned: BTreeSet::new(),
+    });
+    manifest.options = options;
+    manifest.pinned.extend(paths.iter().cloned());
+    manifest
+        .save(root)
+        .map_err(|error| format!("could not write {MANIFEST_PATH}: {error}"))?;
+    Ok(manifest)
 }
 
 /// Write the additions and updates in `report`, then refresh the manifest.
@@ -747,9 +966,7 @@ fn record_baseline(report: &ScaffoldReport) {
 /// interrupted by Ctrl-C or ENOSPC leaves a half-written `Dockerfile` and no
 /// copy of the original anywhere.
 fn write_one(entry: &Entry) -> Result<(), String> {
-    use std::io::Write as _;
-
-    let on_disk = read_current(&entry.absolute);
+    let on_disk = read_current_absolute(entry);
     if on_disk != entry.current {
         return Err(match entry.current {
             OnDisk::Absent => "something appeared at this path after the preview was \
@@ -761,10 +978,11 @@ fn write_one(entry: &Entry) -> Result<(), String> {
         });
     }
     // A plan is only ever built for `add` and `update`, and `read_current`
-    // classifies a symlink as a conflict, so reaching this with a link would be
-    // a bug rather than a race. Checked anyway: this is the last line before a
-    // write, and the cost of being wrong here is a file outside the project.
-    if matches!(on_disk, OnDisk::Opaque(_)) {
+    // classifies a link or an unreadable file as a conflict, so reaching this
+    // with either would be a bug rather than a race. Checked anyway: this is
+    // the last line before a write, and the cost of being wrong is a file
+    // outside the project.
+    if matches!(on_disk, OnDisk::Opaque(_) | OnDisk::Linked(_)) {
         return Err(
             "this path is a symlink or is unreadable; it was left exactly as it is".to_owned(),
         );
@@ -775,6 +993,23 @@ fn write_one(entry: &Entry) -> Result<(), String> {
         .parent()
         .ok_or_else(|| "no parent directory".to_owned())?;
     std::fs::create_dir_all(directory).map_err(|error| error.to_string())?;
+
+    // Nothing is here, so there is nothing an interrupted write could destroy
+    // — and a plain write is what gives the new file the same mode `autumn new`
+    // would have given it. `tempfile` deliberately creates 0600, and renaming
+    // that into place would leave an added `ci.yml` or `input.css` unreadable
+    // to every other uid: fatal to a Docker stage that drops privileges, and
+    // invisible in `git diff`, which tracks only the executable bit.
+    if entry.current == OnDisk::Absent {
+        return std::fs::write(&entry.absolute, &entry.template).map_err(|error| error.to_string());
+    }
+    replace_in_place(entry, directory)
+}
+
+/// Replace an existing file's contents atomically, keeping its mode.
+fn replace_in_place(entry: &Entry, directory: &Path) -> Result<(), String> {
+    use std::io::Write as _;
+
     let mut temp = tempfile::Builder::new()
         .prefix(".autumn-upgrade-")
         .suffix(".tmp")
@@ -797,6 +1032,18 @@ fn write_one(entry: &Entry) -> Result<(), String> {
     temp.persist(&entry.absolute)
         .map_err(|error| error.to_string())?;
     Ok(())
+}
+
+/// Re-read what an entry's path holds now, by the same rules the plan used —
+/// the parent-link check included.
+fn read_current_absolute(entry: &Entry) -> OnDisk {
+    // The entry's own root is its absolute path with its relative path removed,
+    // so the chain checked here is exactly the chain checked at plan time.
+    let mut root = entry.absolute.clone();
+    for _ in 0..=entry.path.matches('/').count() {
+        root.pop();
+    }
+    read_current(&root, &entry.path)
 }
 
 /// The human report, with a diff for every file that differs.
@@ -838,6 +1085,28 @@ fn render(report: &ScaffoldReport, diffs: bool) -> String {
         target = report.target
     );
 
+    // Said up front, and on every run that still has an unbaselined file — not
+    // only on the first. A project's first `--apply` writes a partial manifest,
+    // and gating this on "a manifest exists" made the explanation vanish while
+    // every remaining file was still reported as having no baseline.
+    if report.needs_baseline_note() {
+        let _ = writeln!(
+            out,
+            "  This project predates scaffold provenance, so there is no record of\n  \
+             what Autumn originally wrote. Files it is missing are offered; every\n  \
+             file that differs is a conflict for you to review."
+        );
+    }
+    if report.workspace_member {
+        let _ = writeln!(
+            out,
+            "  This crate sits inside a Cargo workspace, so the files that workspace owns\n  \
+             at its root — clippy.toml, rustfmt.toml, rust-toolchain.toml and the CI\n  \
+             workflow — are out of scope here: a crate-local copy would shadow the\n  \
+             workspace's, not add to it. Reconcile those at the workspace root."
+        );
+    }
+
     let changed = report.changed();
     if changed.is_empty() {
         let _ = writeln!(
@@ -846,15 +1115,6 @@ fn render(report: &ScaffoldReport, diffs: bool) -> String {
         );
         let _ = writeln!(out, "  Upgrade guide: {}", report.guide);
         return out;
-    }
-
-    if !report.has_manifest {
-        let _ = writeln!(
-            out,
-            "  This project predates scaffold provenance, so there is no record of\n  \
-             what Autumn originally wrote. Files it is missing are offered; every\n  \
-             file that differs is a conflict for you to review."
-        );
     }
 
     let width = changed.iter().map(|e| e.path.len()).max().unwrap_or(0);
@@ -879,32 +1139,36 @@ fn render(report: &ScaffoldReport, diffs: bool) -> String {
         }
     }
 
-    render_outcome(&mut out, report);
+    render_outcome(&mut out, report, diffs);
     let _ = writeln!(out, "Upgrade guide: {}", report.guide);
     out
 }
 
 /// The closing paragraph: what happened, or what would, and how to undo it.
-fn render_outcome(out: &mut String, report: &ScaffoldReport) {
+fn render_outcome(out: &mut String, report: &ScaffoldReport, diffs: bool) {
     use std::fmt::Write as _;
 
     let applicable = report.applicable().len();
     let conflicts = report.conflicts().len();
     let _ = writeln!(out);
     match report.outcome {
-        // Nothing to apply is its own message. Pointing someone at `--apply`
-        // when every remaining difference is a conflict sends them to run a
-        // command that would do nothing at all.
+        // Nothing to write and nothing to resolve: everything listed is a file
+        // the developer removed or accepted. "0 conflict(s) need review" as the
+        // headline of a report that just listed findings reads as a bug.
+        super::Outcome::Preview if applicable == 0 && conflicts == 0 => {
+            let _ = writeln!(
+                out,
+                "Nothing to do: everything above is a file you removed or accepted as your own."
+            );
+        }
+        // Pointing someone at `--apply` when every remaining difference is a
+        // conflict sends them to run a command that would do nothing at all.
         super::Outcome::Preview if applicable == 0 => {
             let _ = writeln!(
                 out,
                 "{conflicts} conflict(s) need review; nothing here can be written for you."
             );
-            let _ = writeln!(
-                out,
-                "Take what you want from the diffs above; `git diff` shows your edits and\n\
-                 `git checkout -- <path>` puts any one file back."
-            );
+            let _ = writeln!(out, "{}", review_advice(diffs));
         }
         super::Outcome::Preview => {
             let _ = writeln!(
@@ -913,37 +1177,50 @@ fn render_outcome(out: &mut String, report: &ScaffoldReport) {
             );
             let _ = writeln!(
                 out,
-                "Nothing was written. Re-run with `--apply` to take the writable ones, then\n\
-                 review with `git diff` -- `git checkout -- <path>` puts any one file back."
+                "Nothing was written. Re-run with `--apply` to take the writable ones."
             );
+            let _ = writeln!(out, "{}", review_advice(diffs));
         }
         super::Outcome::Applied => {
             let _ = writeln!(
                 out,
                 "{applicable} file(s) written; {conflicts} conflict(s) left for you."
             );
-            let _ = writeln!(
-                out,
-                "Review with `git diff`; undo any single file with `git checkout -- <path>`."
-            );
+            let _ = writeln!(out, "{REVERT_ADVICE}");
         }
         super::Outcome::Partial { written } => {
             let _ = writeln!(
                 out,
                 "{written} of {applicable} file(s) written before the run stopped."
             );
-            let _ = writeln!(
-                out,
-                "Review with `git diff`; undo any single file with `git checkout -- <path>`."
-            );
+            let _ = writeln!(out, "{REVERT_ADVICE}");
         }
     }
     if conflicts > 0 {
         let _ = writeln!(
             out,
-            "Conflicts are never overwritten. Compare each against this release's\n\
-             scaffold above, take what you want, and re-run to confirm."
+            "Conflicts are never overwritten. Take what you want from this release's\n\
+             version, or `autumn upgrade --accept <path>` to keep yours for good."
         );
+    }
+}
+
+/// How to undo an apply.
+///
+/// `git checkout --` restores a file that was *updated*; it does nothing for
+/// one that was *added*, because git has never heard of it. Naming only the
+/// first leaves the majority case — an aged project is mostly additions — with
+/// advice that fails at the prompt.
+const REVERT_ADVICE: &str = "`git status` and `git diff` show everything this touched: \
+                             `git checkout -- <path>`\nrestores an updated file, `rm <path>` \
+                             removes an added one.";
+
+/// What to read next, given whether this report carried its diffs.
+const fn review_advice(diffs: bool) -> &'static str {
+    if diffs {
+        "Each file's diff is above; `git status` and `git diff` show what is yours."
+    } else {
+        "Re-run without `--check` to see each file's diff."
     }
 }
 
@@ -957,8 +1234,23 @@ pub fn json(report: &ScaffoldReport) -> serde_json::Value {
         "has_manifest": report.has_manifest,
         "outcome": report.outcome.label(),
         "drift": report.drifted(),
-        "written": report.applicable().len(),
+        "workspace_member": report.workspace_member,
+        // The plan, and the part of it that reached disk — the same split the
+        // app-code report draws, for the same reason: "what would this do" and
+        // "what is on disk now" are different questions, and a gate that reads
+        // the wrong one calls a preview a completed upgrade.
+        "writable": report.applicable().len(),
+        "written": match report.outcome {
+            super::Outcome::Preview => 0,
+            super::Outcome::Applied => report.applicable().len(),
+            super::Outcome::Partial { written } => written,
+        },
         "conflicts": report.conflicts().len(),
+        "pinned": report
+            .entries
+            .iter()
+            .filter(|entry| entry.status == Status::Pinned)
+            .count(),
         "guide": report.guide,
         "files": report
             .entries
@@ -1011,6 +1303,7 @@ mod tests {
                 ..GenerateOptions::default()
             },
             digests,
+            pinned: BTreeSet::new(),
         };
 
         let parsed = Manifest::parse(&manifest.render()).expect("round trip");
@@ -1032,6 +1325,7 @@ mod tests {
             version: Some("0.7.0".to_owned()),
             options: GenerateOptions::default(),
             digests: digests.clone(),
+            pinned: BTreeSet::new(),
         };
         assert_eq!(
             Manifest::parse(&manifest.render()).unwrap().digests,
@@ -1064,6 +1358,7 @@ mod tests {
             version: Some("0.7.0".to_owned()),
             options: GenerateOptions::default(),
             digests,
+            pinned: BTreeSet::new(),
         };
         manifest.save(tmp.path()).unwrap();
         let loaded = Manifest::load(tmp.path()).expect("written manifest loads");
@@ -1673,5 +1968,180 @@ mod tests {
         let report = plan_in(tmp.path());
         assert!(!report.named);
         assert!(render_summary(&report).contains("Skipped"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn a_symlinked_parent_directory_is_a_conflict_too() {
+        // Checking only the leaf is not enough: `.github` symlinked to a shared
+        // workflows tree lets `--apply` create a file outside the project
+        // entirely, which the project's own `git status` would never show.
+        let tmp = scaffolded(GenerateOptions::default());
+        let outside = tmp.path().join("outside-workflows");
+        fs::create_dir_all(&outside).unwrap();
+        fs::remove_dir_all(tmp.path().join(".github")).unwrap();
+        std::os::unix::fs::symlink(&outside, tmp.path().join(".github")).unwrap();
+
+        let mut report = plan_in(tmp.path());
+        assert_eq!(
+            status_of(&report.entries, ".github/workflows/ci.yml"),
+            &Status::Conflict(ConflictReason::Symlink)
+        );
+        apply(&mut report).expect("apply");
+        assert!(
+            !outside.join("workflows/ci.yml").exists(),
+            "nothing may be written through a symlinked parent"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn a_symlink_whose_content_is_already_current_is_not_drift() {
+        // Refusing to *write* through a link is right. Calling it drift when the
+        // bytes already match makes `--check` red forever with no remedy.
+        use std::os::unix::fs::PermissionsExt as _;
+
+        let tmp = scaffolded(GenerateOptions::default());
+        let shared = tmp.path().join("shared-clippy.toml");
+        let current = current_files(tmp.path(), GenerateOptions::default()).unwrap();
+        fs::write(&shared, &current["clippy.toml"]).unwrap();
+        fs::remove_file(tmp.path().join("clippy.toml")).unwrap();
+        std::os::unix::fs::symlink(&shared, tmp.path().join("clippy.toml")).unwrap();
+        let _ = fs::metadata(&shared).map(|m| m.permissions().mode());
+
+        let entries = plan_in(tmp.path()).entries;
+        assert_eq!(status_of(&entries, "clippy.toml"), &Status::UpToDate);
+        assert!(!drifted(&entries));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn an_added_file_is_as_readable_as_one_the_scaffold_writes() {
+        // `tempfile` creates 0600 by design. Renaming that into place gives an
+        // added `ci.yml` or `input.css` a mode no other uid can read — invisible
+        // in `git diff`, and fatal to a Docker stage that drops privileges.
+        use std::os::unix::fs::PermissionsExt as _;
+
+        let tmp = scaffolded(GenerateOptions::default());
+        fs::remove_file(tmp.path().join("rustfmt.toml")).unwrap();
+        let mut manifest = Manifest::load(tmp.path()).unwrap();
+        manifest.digests.remove("rustfmt.toml");
+        manifest.save(tmp.path()).unwrap();
+
+        let mut report = plan_in(tmp.path());
+        apply(&mut report).expect("apply");
+
+        let added = fs::metadata(tmp.path().join("rustfmt.toml"))
+            .unwrap()
+            .permissions()
+            .mode();
+        let scaffolded_by_new = fs::metadata(tmp.path().join("clippy.toml"))
+            .unwrap()
+            .permissions()
+            .mode();
+        assert_eq!(
+            added & 0o777,
+            scaffolded_by_new & 0o777,
+            "an added file must be as readable as one `autumn new` writes"
+        );
+    }
+
+    #[test]
+    fn an_api_project_serving_its_own_stylesheet_is_still_an_api_project() {
+        // `static/css/` existing is not evidence of the fullstack scaffold —
+        // `static/css/input.css` is. Getting this wrong writes Tailwind into a
+        // JSON API and then freezes the guess in the manifest.
+        let tmp = scaffolded(GenerateOptions {
+            with_api: true,
+            ..GenerateOptions::default()
+        });
+        fs::remove_dir_all(tmp.path().join(".autumn")).unwrap();
+        write(tmp.path(), "static/css/site.css", "body{}\n");
+
+        let mut report = plan_in(tmp.path());
+        apply(&mut report).expect("apply");
+        assert!(!tmp.path().join("tailwind.config.js").exists());
+        assert!(!tmp.path().join("static/css/input.css").exists());
+        assert!(Manifest::load(tmp.path()).unwrap().options.with_api);
+    }
+
+    #[test]
+    fn a_workspace_member_is_not_given_the_files_a_workspace_root_owns() {
+        // `clippy.toml`, `rustfmt.toml` and `rust-toolchain.toml` resolve from
+        // the nearest ancestor, so a crate-local copy SHADOWS the workspace's —
+        // silently dropping its lints and MSRV pin. `.github/` only runs from
+        // the repository root. Seeding those into a member is not an upgrade.
+        let outer = TempDir::new().unwrap();
+        fs::write(
+            outer.path().join("Cargo.toml"),
+            "[workspace]\nmembers = [\"app\"]\nresolver = \"3\"\n",
+        )
+        .unwrap();
+        let root = outer.path().join("app");
+        fs::create_dir_all(&root).unwrap();
+        write(
+            &root,
+            "Cargo.toml",
+            "[package]\nname = \"demo\"\nversion = \"0.1.0\"\n",
+        );
+        write(&root, "autumn.toml", "[server]\n");
+
+        let report = plan(&root, "0.7.0");
+        let offered: Vec<&str> = report.entries.iter().map(|e| e.path.as_str()).collect();
+        for root_owned in [
+            "clippy.toml",
+            "rustfmt.toml",
+            "rust-toolchain.toml",
+            ".github/workflows/ci.yml",
+        ] {
+            assert!(
+                !offered.contains(&root_owned),
+                "{root_owned} in {offered:?}"
+            );
+        }
+        // ...but the per-crate files are still reconciled.
+        assert!(offered.contains(&"Dockerfile"), "{offered:?}");
+        assert!(offered.contains(&"build.rs"), "{offered:?}");
+        assert!(
+            render_text(&report).contains("workspace"),
+            "{}",
+            render_text(&report)
+        );
+    }
+
+    #[test]
+    fn an_accepted_conflict_stops_holding_the_gate_red() {
+        // A team that customises its Dockerfile must be able to finish the
+        // review. Without this, `--check` is red forever and gets deleted.
+        let tmp = scaffolded(GenerateOptions::default());
+        write(tmp.path(), "Dockerfile", "FROM scratch\n# ours\n");
+        assert!(plan_in(tmp.path()).drifted());
+
+        accept(tmp.path(), &["Dockerfile".to_owned()]).expect("accept");
+
+        let report = plan_in(tmp.path());
+        assert_eq!(status_of(&report.entries, "Dockerfile"), &Status::Pinned);
+        assert!(!report.drifted());
+        // ...and it is still never written.
+        let mut report = plan_in(tmp.path());
+        apply(&mut report).expect("apply");
+        assert_eq!(
+            fs::read_to_string(tmp.path().join("Dockerfile")).unwrap(),
+            "FROM scratch\n# ours\n"
+        );
+        assert!(
+            Manifest::load(tmp.path())
+                .unwrap()
+                .pinned
+                .contains("Dockerfile")
+        );
+    }
+
+    #[test]
+    fn accepting_a_path_the_scaffold_does_not_own_is_refused() {
+        let tmp = scaffolded(GenerateOptions::default());
+        let error = accept(tmp.path(), &["src/main.rs".to_owned()]).expect_err("must refuse");
+        assert!(error.contains("src/main.rs"), "{error}");
+        assert!(Manifest::load(tmp.path()).unwrap().pinned.is_empty());
     }
 }

--- a/autumn-cli/tests/integration/mod.rs
+++ b/autumn-cli/tests/integration/mod.rs
@@ -48,4 +48,5 @@ mod serve;
 mod tauri_mobile_thin_client;
 mod test_command;
 mod upgrade_codemod;
+mod upgrade_scaffold;
 mod webhook_sim;

--- a/autumn-cli/tests/integration/upgrade_scaffold.rs
+++ b/autumn-cli/tests/integration/upgrade_scaffold.rs
@@ -419,3 +419,24 @@ fn check_mode_does_not_print_file_contents_into_the_build_log() {
     let full = stdout_of(&run(&root, &[]));
     assert!(full.contains("hunter2"), "{full}");
 }
+
+#[test]
+fn check_does_not_pass_a_project_whose_scaffold_it_could_not_render() {
+    // A gate that goes green because the tool could not look is worse than no
+    // gate. Without a usable `[package] name` the scaffold cannot be rendered,
+    // so there is no verdict to report — and "no verdict" is not "clean".
+    let (_tmp, root) = new_project("nameless", &[]);
+    fs::write(root.join("Cargo.toml"), "[workspace]\nmembers = []\n").unwrap();
+
+    let output = run(&root, &["--check"]);
+    assert_eq!(output.status.code(), Some(2), "{}", report(&output));
+    let combined = format!(
+        "{}{}",
+        stdout_of(&output),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(combined.contains("package"), "{combined}");
+
+    // ...and the manifest it could not use is still intact afterwards.
+    assert!(root.join(".autumn/scaffold.toml").is_file());
+}

--- a/autumn-cli/tests/integration/upgrade_scaffold.rs
+++ b/autumn-cli/tests/integration/upgrade_scaffold.rs
@@ -320,3 +320,102 @@ fn an_api_project_is_never_offered_fullstack_files() {
     assert!(!root.join("tailwind.config.js").exists(), "{out}");
     assert!(!root.join("static/css/input.css").exists(), "{out}");
 }
+
+#[test]
+fn a_file_that_is_not_utf8_is_never_treated_as_missing_and_overwritten() {
+    // The population this protects is every project that exists today: without
+    // a provenance manifest there is no baseline, so a file misread as absent
+    // would be classified `add` and truncated. `read_to_string` fails on
+    // non-UTF-8 exactly as it does on a missing file, and those two must not
+    // reach the classifier as the same answer.
+    let (_tmp, root) = new_project("binary", &[]);
+    fs::remove_dir_all(root.join(".autumn")).unwrap();
+    let mine: &[u8] = &[0xff, 0xfe, b'A', 0x00, b'B', 0x00];
+    fs::write(root.join(".env.example"), mine).unwrap();
+
+    let output = run(&root, &["--apply"]);
+    assert!(output.status.success(), "{}", report(&output));
+    let out = stdout_of(&output);
+    assert!(out.contains(".env.example"), "{out}");
+    assert!(out.contains("conflict"), "{out}");
+    assert_eq!(
+        fs::read(root.join(".env.example")).unwrap(),
+        mine,
+        "an unreadable file must survive --apply byte for byte"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn a_symlinked_scaffold_file_is_never_written_through() {
+    // A monorepo hoists shared config and symlinks it back into each crate.
+    // Writing through the link edits a file outside the project, which
+    // `git diff` inside the project would not even show.
+    let (tmp, root) = new_project("linked", &[]);
+    let shared = tmp.path().join("shared-rustfmt.toml");
+    fs::write(&shared, "edition = \"2015\"\n").unwrap();
+    fs::remove_file(root.join("rustfmt.toml")).unwrap();
+    std::os::unix::fs::symlink(&shared, root.join("rustfmt.toml")).unwrap();
+
+    let output = run(&root, &["--apply"]);
+    assert!(output.status.success(), "{}", report(&output));
+    let out = stdout_of(&output);
+    assert!(out.contains("rustfmt.toml"), "{out}");
+    assert!(out.contains("symlink"), "{out}");
+    assert_eq!(
+        fs::read_to_string(&shared).unwrap(),
+        "edition = \"2015\"\n",
+        "the link target lives outside the project and must never be written"
+    );
+    assert!(
+        root.join("rustfmt.toml")
+            .symlink_metadata()
+            .unwrap()
+            .file_type()
+            .is_symlink(),
+        "the link itself must be left in place"
+    );
+}
+
+#[test]
+fn a_to_version_does_not_pretend_to_reconcile_a_historical_scaffold() {
+    // This CLI ships one set of scaffold templates: its own. `--to` selects
+    // which codemods run; downgrades and historical scaffolds are out of scope,
+    // and a report claiming otherwise would be false.
+    let (_tmp, root) = new_project("pinned", &[]);
+    let output = run(&root, &["--to", "0.6.0"]);
+    assert!(output.status.success(), "{}", report(&output));
+    let out = stdout_of(&output);
+    let scaffold_line = out
+        .lines()
+        .find(|line| line.starts_with("Scaffold files"))
+        .unwrap_or_else(|| panic!("no scaffold header in:\n{out}"));
+    assert!(
+        scaffold_line.contains(env!("CARGO_PKG_VERSION")),
+        "{scaffold_line}"
+    );
+    assert!(!scaffold_line.contains("0.6.0"), "{scaffold_line}");
+}
+
+#[test]
+fn check_mode_does_not_print_file_contents_into_the_build_log() {
+    // `--check` is documented as a CI gate, and `autumn.toml` / `.env.example`
+    // are where people put connection strings. The gate needs the verdict and
+    // the file names, not the working contents.
+    let (_tmp, root) = new_project("quiet", &[]);
+    fs::write(
+        root.join(".env.example"),
+        "DATABASE_URL=postgres://user:hunter2@db.internal/prod\n",
+    )
+    .unwrap();
+
+    let output = run(&root, &["--check"]);
+    assert_eq!(output.status.code(), Some(3), "{}", report(&output));
+    let out = stdout_of(&output);
+    assert!(out.contains(".env.example"), "{out}");
+    assert!(out.contains("conflict"), "{out}");
+    assert!(!out.contains("hunter2"), "{out}");
+    // ...while the full report, which a human asked for, still shows the diff.
+    let full = stdout_of(&run(&root, &[]));
+    assert!(full.contains("hunter2"), "{full}");
+}

--- a/autumn-cli/tests/integration/upgrade_scaffold.rs
+++ b/autumn-cli/tests/integration/upgrade_scaffold.rs
@@ -608,3 +608,26 @@ fn accept_honours_json_mode() {
         serde_json::from_str(&stdout_of(&output)).expect("stdout must be JSON");
     assert_eq!(value["accepted"][0], "Dockerfile", "{value}");
 }
+
+#[cfg(unix)]
+#[test]
+fn an_apply_that_cannot_record_its_baseline_exits_nonzero() {
+    // Exit 0 here would tell a CI script the upgrade succeeded, when in fact
+    // the very next `--check` is guaranteed to exit 3 on the files this run
+    // just wrote correctly.
+    let (tmp, root) = new_project("baseline", &[]);
+    let outside = tmp.path().join("outside.toml");
+    fs::write(&outside, "not mine\n").unwrap();
+    fs::remove_file(root.join(MANIFEST)).unwrap();
+    std::os::unix::fs::symlink(&outside, root.join(MANIFEST)).unwrap();
+    fs::remove_file(root.join("rustfmt.toml")).unwrap();
+
+    let output = run(&root, &["--apply"]);
+    assert_eq!(output.status.code(), Some(1), "{}", report(&output));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("baseline"), "{}", report(&output));
+
+    // The file it did write is still correct, and the link target is untouched.
+    assert!(root.join("rustfmt.toml").is_file());
+    assert_eq!(fs::read_to_string(&outside).unwrap(), "not mine\n");
+}

--- a/autumn-cli/tests/integration/upgrade_scaffold.rs
+++ b/autumn-cli/tests/integration/upgrade_scaffold.rs
@@ -518,6 +518,15 @@ fn a_workspace_member_is_not_seeded_with_files_the_workspace_root_owns() {
         "[workspace]\nmembers = [\"member\"]\nresolver = \"3\"\n",
     )
     .unwrap();
+    // `autumn new` writes a bare `[workspace]` table so a generated project is
+    // its own root wherever it is dropped. Adopting one INTO a workspace means
+    // deleting that table — which is what makes this crate a member at all.
+    let manifest = fs::read_to_string(root.join("Cargo.toml")).unwrap();
+    fs::write(
+        root.join("Cargo.toml"),
+        manifest.replace("[workspace]\n", ""),
+    )
+    .unwrap();
     for path in ["clippy.toml", "rustfmt.toml", "rust-toolchain.toml"] {
         fs::remove_file(root.join(path)).unwrap();
     }
@@ -584,4 +593,18 @@ fn a_removed_only_report_does_not_talk_about_conflicts_that_do_not_exist() {
     assert!(!out.contains("conflict(s) need review"), "{out}");
     // ...and `--check` never points at diffs it deliberately suppressed.
     assert!(!out.contains("diffs above"), "{out}");
+}
+
+#[test]
+fn accept_honours_json_mode() {
+    // `--json` is documented as the machine-readable mode; a caller that
+    // combines it with `--accept` gets prose on stdout and a parse error.
+    let (_tmp, root) = new_project("acceptjson", &[]);
+    fs::write(root.join("Dockerfile"), "FROM scratch\n").unwrap();
+
+    let output = run(&root, &["--accept", "Dockerfile", "--json"]);
+    assert!(output.status.success(), "{}", report(&output));
+    let value: serde_json::Value =
+        serde_json::from_str(&stdout_of(&output)).expect("stdout must be JSON");
+    assert_eq!(value["accepted"][0], "Dockerfile", "{value}");
 }

--- a/autumn-cli/tests/integration/upgrade_scaffold.rs
+++ b/autumn-cli/tests/integration/upgrade_scaffold.rs
@@ -1,0 +1,322 @@
+//! Integration tests for `autumn upgrade`'s scaffold-file reconciliation
+//! (issue #1593).
+//!
+//! Each test scaffolds a real project with the real `autumn` binary, ages it —
+//! deleting a file the old release did not have, editing one, rewinding the
+//! recorded baseline — and then runs the real binary against it. Nothing is
+//! mocked: the whole point of the feature is that what `autumn new` writes and
+//! what `autumn upgrade` considers current are the same bytes.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+use tempfile::TempDir;
+
+const fn autumn_bin() -> &'static str {
+    env!("CARGO_BIN_EXE_autumn")
+}
+
+const MANIFEST: &str = ".autumn/scaffold.toml";
+
+fn report(output: &Output) -> String {
+    format!(
+        "status: {}\nstdout:\n{}\nstderr:\n{}",
+        output.status,
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    )
+}
+
+fn stdout_of(output: &Output) -> String {
+    String::from_utf8_lossy(&output.stdout).into_owned()
+}
+
+fn run(root: &Path, args: &[&str]) -> Output {
+    Command::new(autumn_bin())
+        .arg("upgrade")
+        .args(args)
+        .current_dir(root)
+        .output()
+        .expect("failed to run autumn upgrade")
+}
+
+/// A freshly scaffolded project, plus its root.
+fn new_project(name: &str, extra: &[&str]) -> (TempDir, PathBuf) {
+    let tmp = TempDir::new().expect("tempdir");
+    let output = Command::new(autumn_bin())
+        .arg("new")
+        .arg(name)
+        .args(extra)
+        .current_dir(tmp.path())
+        .output()
+        .expect("failed to run autumn new");
+    assert!(output.status.success(), "{}", report(&output));
+    let root = tmp.path().join(name);
+    (tmp, root)
+}
+
+/// Rewind the recorded baseline to `version` and forget `paths`, so the project
+/// looks like one scaffolded by a release that never generated them.
+fn age_to(root: &Path, version: &str, paths: &[&str]) {
+    use std::fmt::Write as _;
+
+    let text = fs::read_to_string(root.join(MANIFEST)).expect("manifest");
+    let mut out = String::new();
+    for line in text.lines() {
+        if line.starts_with("version = ") {
+            let _ = writeln!(out, "version = \"{version}\"");
+            continue;
+        }
+        if paths
+            .iter()
+            .any(|path| line.starts_with(&format!("\"{path}\" =")))
+        {
+            continue;
+        }
+        out.push_str(line);
+        out.push('\n');
+    }
+    fs::write(root.join(MANIFEST), out).unwrap();
+    for path in paths {
+        let _ = fs::remove_file(root.join(path));
+    }
+}
+
+#[test]
+fn a_fresh_project_reports_no_scaffold_drift() {
+    let (_tmp, root) = new_project("fresh", &[]);
+    let output = run(&root, &[]);
+    assert!(output.status.success(), "{}", report(&output));
+    let out = stdout_of(&output);
+    assert!(out.contains("Scaffold files"), "{out}");
+    assert!(out.contains("up to date"), "{out}");
+}
+
+#[test]
+fn an_older_project_is_offered_the_files_this_release_added() {
+    let (_tmp, root) = new_project("aged", &[]);
+    age_to(&root, "0.5.0", &["rust-toolchain.toml", "clippy.toml"]);
+
+    let output = run(&root, &[]);
+    assert!(output.status.success(), "{}", report(&output));
+    let out = stdout_of(&output);
+    assert!(out.contains("rust-toolchain.toml"), "{out}");
+    assert!(out.contains("clippy.toml"), "{out}");
+    assert!(out.contains("add"), "{out}");
+    // Preview only: nothing on disk changed.
+    assert!(!root.join("rust-toolchain.toml").exists(), "{out}");
+    assert!(!root.join("clippy.toml").exists(), "{out}");
+    assert!(out.contains("--apply"), "{out}");
+}
+
+#[test]
+fn apply_writes_the_offered_files() {
+    let (_tmp, root) = new_project("applied", &[]);
+    age_to(&root, "0.5.0", &["rust-toolchain.toml"]);
+
+    let output = run(&root, &["--apply"]);
+    assert!(output.status.success(), "{}", report(&output));
+    assert!(
+        root.join("rust-toolchain.toml").is_file(),
+        "{}",
+        report(&output)
+    );
+
+    // ...and the project is clean afterwards.
+    let after = run(&root, &["--check"]);
+    assert!(after.status.success(), "{}", report(&after));
+}
+
+#[test]
+fn an_edited_file_is_a_conflict_and_survives_apply_byte_for_byte() {
+    let (_tmp, root) = new_project("edited", &[]);
+    let mine = "FROM scratch\n# hand-tuned, do not touch\n";
+    fs::write(root.join("Dockerfile"), mine).unwrap();
+    age_to(&root, "0.5.0", &[]);
+
+    let output = run(&root, &["--apply"]);
+    assert!(output.status.success(), "{}", report(&output));
+    let out = stdout_of(&output);
+    assert!(out.contains("conflict"), "{out}");
+    assert!(out.contains("Dockerfile"), "{out}");
+    assert_eq!(
+        fs::read_to_string(root.join("Dockerfile")).unwrap(),
+        mine,
+        "an edited file must never be overwritten"
+    );
+    // The report tells the reader how to undo whatever it *did* write.
+    assert!(out.contains("git diff"), "{out}");
+}
+
+#[test]
+fn application_source_is_never_touched() {
+    let (_tmp, root) = new_project("untouched", &[]);
+    age_to(&root, "0.5.0", &["rust-toolchain.toml"]);
+    let main_rs = fs::read_to_string(root.join("src/main.rs")).unwrap();
+    let tests_rs = fs::read_to_string(root.join("tests/integration_test.rs")).unwrap();
+    let cargo = fs::read_to_string(root.join("Cargo.toml")).unwrap();
+    let readme = fs::read_to_string(root.join("README.md")).unwrap();
+
+    let output = run(&root, &["--apply"]);
+    assert!(output.status.success(), "{}", report(&output));
+
+    assert_eq!(
+        fs::read_to_string(root.join("src/main.rs")).unwrap(),
+        main_rs
+    );
+    assert_eq!(
+        fs::read_to_string(root.join("tests/integration_test.rs")).unwrap(),
+        tests_rs
+    );
+    assert_eq!(fs::read_to_string(root.join("Cargo.toml")).unwrap(), cargo);
+    assert_eq!(fs::read_to_string(root.join("README.md")).unwrap(), readme);
+    assert!(!stdout_of(&output).contains("src/main.rs"));
+}
+
+#[test]
+fn check_exits_nonzero_on_drift_and_zero_when_clean() {
+    let (_tmp, root) = new_project("gated", &[]);
+    let clean = run(&root, &["--check"]);
+    assert!(clean.status.success(), "{}", report(&clean));
+
+    age_to(&root, "0.5.0", &["rustfmt.toml"]);
+    let dirty = run(&root, &["--check"]);
+    assert!(!dirty.status.success(), "{}", report(&dirty));
+    assert_eq!(dirty.status.code(), Some(3), "{}", report(&dirty));
+    assert!(
+        stdout_of(&dirty).contains("rustfmt.toml"),
+        "{}",
+        report(&dirty)
+    );
+    // A check never writes.
+    assert!(!root.join("rustfmt.toml").exists());
+}
+
+#[test]
+fn check_and_apply_together_are_a_usage_error() {
+    let (_tmp, root) = new_project("both", &[]);
+    let output = run(&root, &["--check", "--apply"]);
+    assert_eq!(output.status.code(), Some(2), "{}", report(&output));
+}
+
+#[test]
+fn check_outside_an_autumn_project_says_so() {
+    let tmp = TempDir::new().unwrap();
+    let output = run(tmp.path(), &["--check"]);
+    assert_eq!(output.status.code(), Some(2), "{}", report(&output));
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("Autumn project"),
+        "{}",
+        report(&output)
+    );
+}
+
+#[test]
+fn a_project_predating_provenance_still_upgrades_best_effort() {
+    let (_tmp, root) = new_project("legacy", &[]);
+    // A pre-#1593 app: no manifest at all, missing a file a later release
+    // added, and carrying its own edit to another.
+    fs::remove_dir_all(root.join(".autumn")).unwrap();
+    fs::remove_file(root.join("rust-toolchain.toml")).unwrap();
+    fs::write(root.join("clippy.toml"), "# mine\n").unwrap();
+
+    let output = run(&root, &["--apply"]);
+    assert!(output.status.success(), "{}", report(&output));
+    let out = stdout_of(&output);
+    // Best effort: the missing file is added...
+    assert!(root.join("rust-toolchain.toml").is_file(), "{out}");
+    // ...and the one that differs is a conflict, not an overwrite.
+    assert_eq!(
+        fs::read_to_string(root.join("clippy.toml")).unwrap(),
+        "# mine\n"
+    );
+    assert!(out.contains("conflict"), "{out}");
+    assert!(out.contains("no recorded baseline"), "{out}");
+}
+
+#[test]
+fn the_summary_links_this_release_upgrade_guide() {
+    let (_tmp, root) = new_project("guided", &[]);
+    let out = stdout_of(&run(&root, &[]));
+    assert!(out.contains("Upgrade guide:"), "{out}");
+    assert!(
+        out.contains("https://github.com/autumn-foundation/autumn/blob/trunk-dev/docs/migrations/"),
+        "{out}"
+    );
+}
+
+#[test]
+fn the_json_report_carries_the_scaffold_section() {
+    let (_tmp, root) = new_project("machine", &[]);
+    age_to(&root, "0.5.0", &["rustfmt.toml"]);
+
+    let output = run(&root, &["--json"]);
+    assert!(output.status.success(), "{}", report(&output));
+    let value: serde_json::Value =
+        serde_json::from_str(&stdout_of(&output)).expect("json report parses");
+    let scaffold = &value["scaffold"];
+    assert_eq!(scaffold["drift"], true, "{value}");
+    assert_eq!(scaffold["baseline"], "0.5.0", "{value}");
+    let files = scaffold["files"].as_array().expect("files array");
+    assert!(
+        files
+            .iter()
+            .any(|file| file["path"] == "rustfmt.toml" && file["status"] == "add"),
+        "{value}"
+    );
+    // The app-code report is still there and untouched by this addition.
+    assert!(value["migrations"].is_array(), "{value}");
+}
+
+#[test]
+fn a_directory_that_is_not_an_autumn_project_gets_no_scaffold_section() {
+    // `autumn upgrade` also runs over plain Rust crates that merely depend on
+    // autumn-web. Offering to seed a Dockerfile into one would be nonsense.
+    let tmp = TempDir::new().unwrap();
+    fs::write(
+        tmp.path().join("Cargo.toml"),
+        "[package]\nname = \"plain\"\nversion = \"0.1.0\"\nedition = \"2024\"\n\n\
+         [dependencies]\nautumn-web = \"0.6.0\"\n",
+    )
+    .unwrap();
+    fs::create_dir_all(tmp.path().join("src")).unwrap();
+    fs::write(tmp.path().join("src/main.rs"), "fn main() {}\n").unwrap();
+
+    let output = run(tmp.path(), &[]);
+    assert!(output.status.success(), "{}", report(&output));
+    assert!(
+        !stdout_of(&output).contains("Scaffold files"),
+        "{}",
+        report(&output)
+    );
+}
+
+#[test]
+fn a_deliberately_deleted_file_is_reported_but_not_restored() {
+    let (_tmp, root) = new_project("deleted", &[]);
+    fs::remove_file(root.join(".env.example")).unwrap();
+
+    let output = run(&root, &["--apply"]);
+    assert!(output.status.success(), "{}", report(&output));
+    let out = stdout_of(&output);
+    assert!(out.contains(".env.example"), "{out}");
+    assert!(out.contains("removed"), "{out}");
+    assert!(
+        !root.join(".env.example").exists(),
+        "a deliberate deletion must not be undone: {out}"
+    );
+    // ...and it does not hold a CI gate red forever.
+    let check = run(&root, &["--check"]);
+    assert!(check.status.success(), "{}", report(&check));
+}
+
+#[test]
+fn an_api_project_is_never_offered_fullstack_files() {
+    let (_tmp, root) = new_project("apiapp", &["--api"]);
+    age_to(&root, "0.5.0", &[]);
+    let out = stdout_of(&run(&root, &["--apply"]));
+    assert!(!out.contains("tailwind.config.js"), "{out}");
+    assert!(!root.join("tailwind.config.js").exists(), "{out}");
+    assert!(!root.join("static/css/input.css").exists(), "{out}");
+}

--- a/autumn-cli/tests/integration/upgrade_scaffold.rs
+++ b/autumn-cli/tests/integration/upgrade_scaffold.rs
@@ -631,3 +631,36 @@ fn an_apply_that_cannot_record_its_baseline_exits_nonzero() {
     assert!(root.join("rustfmt.toml").is_file());
     assert_eq!(fs::read_to_string(&outside).unwrap(), "not mine\n");
 }
+
+#[test]
+fn check_does_not_pass_a_project_scaffolded_by_a_newer_release() {
+    // Refusing to look is not an all-clear — the same rule as an unreadable
+    // package name. A gate that goes green because the CLI is too old to
+    // reconcile the project is worse than no gate.
+    let (_tmp, root) = new_project("fromfuture", &[]);
+    let manifest = fs::read_to_string(root.join(MANIFEST)).unwrap();
+    fs::write(
+        root.join(MANIFEST),
+        manifest
+            .lines()
+            .map(|line| {
+                if line.starts_with("version = ") {
+                    "version = \"99.0.0\"".to_owned()
+                } else {
+                    line.to_owned()
+                }
+            })
+            .collect::<Vec<_>>()
+            .join("\n"),
+    )
+    .unwrap();
+
+    let output = run(&root, &["--check"]);
+    assert_eq!(output.status.code(), Some(2), "{}", report(&output));
+    let combined = format!(
+        "{}{}",
+        stdout_of(&output),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(combined.contains("99.0.0"), "{combined}");
+}

--- a/autumn-cli/tests/integration/upgrade_scaffold.rs
+++ b/autumn-cli/tests/integration/upgrade_scaffold.rs
@@ -440,3 +440,148 @@ fn check_does_not_pass_a_project_whose_scaffold_it_could_not_render() {
     // ...and the manifest it could not use is still intact afterwards.
     assert!(root.join(".autumn/scaffold.toml").is_file());
 }
+
+#[test]
+fn new_announces_the_scaffold_manifest_and_says_to_commit_it() {
+    // `autumn new` lists every file it creates, and this is one of them. It
+    // also only has value once it is committed — a manifest that never reaches
+    // the next checkout is a manifest that never becomes a baseline — so the
+    // summary is where a developer finds that out.
+    let tmp = TempDir::new().expect("tempdir");
+    let output = Command::new(autumn_bin())
+        .arg("new")
+        .arg("announced")
+        .current_dir(tmp.path())
+        .output()
+        .expect("failed to run autumn new");
+    assert!(output.status.success(), "{}", report(&output));
+
+    let out = stdout_of(&output);
+    assert!(out.contains(".autumn/scaffold.toml"), "{out}");
+    assert!(out.contains("commit"), "{out}");
+}
+
+#[test]
+fn accepting_a_conflict_lets_the_ci_gate_go_green_again() {
+    // Without this, a team whose Dockerfile is deliberately theirs can never
+    // make `--check` pass — and a permanently red gate is a deleted gate.
+    let (_tmp, root) = new_project("accepted", &[]);
+    let mine = "FROM scratch\n# ours, on purpose\n";
+    fs::write(root.join("Dockerfile"), mine).unwrap();
+    assert_eq!(run(&root, &["--check"]).status.code(), Some(3));
+
+    let accept = run(&root, &["--accept", "Dockerfile"]);
+    assert!(accept.status.success(), "{}", report(&accept));
+    assert!(
+        stdout_of(&accept).contains("Dockerfile"),
+        "{}",
+        report(&accept)
+    );
+
+    let check = run(&root, &["--check"]);
+    assert!(check.status.success(), "{}", report(&check));
+    assert!(stdout_of(&check).contains("pinned") || !stdout_of(&check).contains("conflict"));
+
+    // ...and it is still never written.
+    let applied = run(&root, &["--apply"]);
+    assert!(applied.status.success(), "{}", report(&applied));
+    assert_eq!(fs::read_to_string(root.join("Dockerfile")).unwrap(), mine);
+    assert!(
+        fs::read_to_string(root.join(MANIFEST))
+            .unwrap()
+            .contains("pinned"),
+        "the pin must be recorded where a later checkout can read it"
+    );
+}
+
+#[test]
+fn accept_refuses_a_path_the_scaffold_does_not_own() {
+    let (_tmp, root) = new_project("refused", &[]);
+    let output = run(&root, &["--accept", "src/main.rs"]);
+    assert_eq!(output.status.code(), Some(2), "{}", report(&output));
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("src/main.rs"),
+        "{}",
+        report(&output)
+    );
+}
+
+#[test]
+fn a_workspace_member_is_not_seeded_with_files_the_workspace_root_owns() {
+    // A crate-local `clippy.toml` SHADOWS the workspace's rather than adding to
+    // it, silently dropping its lints and MSRV pin; `.github/` only runs from
+    // the repository root. Seeding those into a member is a regression that
+    // looks like an upgrade.
+    let (tmp, root) = new_project("member", &[]);
+    fs::write(
+        tmp.path().join("Cargo.toml"),
+        "[workspace]\nmembers = [\"member\"]\nresolver = \"3\"\n",
+    )
+    .unwrap();
+    for path in ["clippy.toml", "rustfmt.toml", "rust-toolchain.toml"] {
+        fs::remove_file(root.join(path)).unwrap();
+    }
+    fs::remove_dir_all(root.join(".github")).unwrap();
+    fs::remove_dir_all(root.join(".autumn")).unwrap();
+
+    let output = run(&root, &["--apply"]);
+    assert!(output.status.success(), "{}", report(&output));
+    for path in [
+        "clippy.toml",
+        "rustfmt.toml",
+        "rust-toolchain.toml",
+        ".github/workflows/ci.yml",
+    ] {
+        assert!(
+            !root.join(path).exists(),
+            "{path} was seeded into a workspace member:\n{}",
+            stdout_of(&output)
+        );
+    }
+    assert!(
+        stdout_of(&output).contains("workspace"),
+        "{}",
+        stdout_of(&output)
+    );
+    // ...and the per-crate files are still reconciled.
+    assert!(root.join("Dockerfile").is_file());
+}
+
+#[test]
+fn check_and_list_migrations_together_are_a_usage_error() {
+    // `--list-migrations` exits before anything is checked, so accepting the
+    // pair would give CI a gate that silently gates nothing.
+    let (_tmp, root) = new_project("bothflags", &[]);
+    let output = run(&root, &["--check", "--list-migrations"]);
+    assert_eq!(output.status.code(), Some(2), "{}", report(&output));
+}
+
+#[test]
+fn the_check_json_report_has_the_same_shape_as_a_normal_run() {
+    // One `jq '.scaffold.drift'` has to work against both, or a CI author
+    // following the documented example reads null and passes.
+    let (_tmp, root) = new_project("shape", &[]);
+    age_to(&root, "0.5.0", &["rustfmt.toml"]);
+
+    let checked: serde_json::Value =
+        serde_json::from_str(&stdout_of(&run(&root, &["--check", "--json"]))).unwrap();
+    let normal: serde_json::Value =
+        serde_json::from_str(&stdout_of(&run(&root, &["--json"]))).unwrap();
+    assert_eq!(checked["scaffold"]["drift"], true, "{checked}");
+    assert_eq!(normal["scaffold"]["drift"], true, "{normal}");
+    // A preview plans writes but performs none, and the two counts say so.
+    assert_eq!(checked["scaffold"]["writable"], 1, "{checked}");
+    assert_eq!(checked["scaffold"]["written"], 0, "{checked}");
+}
+
+#[test]
+fn a_removed_only_report_does_not_talk_about_conflicts_that_do_not_exist() {
+    let (_tmp, root) = new_project("removedonly", &[]);
+    fs::remove_file(root.join(".env.example")).unwrap();
+
+    let out = stdout_of(&run(&root, &["--check"]));
+    assert!(out.contains("removed"), "{out}");
+    assert!(!out.contains("conflict(s) need review"), "{out}");
+    // ...and `--check` never points at diffs it deliberately suppressed.
+    assert!(!out.contains("diffs above"), "{out}");
+}

--- a/docs/guide/docs-smoke.md
+++ b/docs/guide/docs-smoke.md
@@ -40,6 +40,47 @@ Do not add `[patch.crates-io]`, path dependencies, or `cargo install --path`
 when certifying the published-user path. Those are contributor-mode shortcuts,
 not first-run documentation proof.
 
+## Scaffold Reconciliation
+
+The [upgrading guide](upgrading.md) documents `autumn upgrade` end to end.
+Certify its scaffold half in the same smoke directory, on the app just
+generated:
+
+```bash
+autumn upgrade --check
+```
+
+Passing output: exit status `0`, and a report ending
+
+```text
+  Your framework-owned files are up to date with this release.
+```
+
+A freshly generated app is, by construction, current. Then prove the drift path
+by aging the app: delete a framework-owned file and remove its line from
+`.autumn/scaffold.toml`, so the project looks like one scaffolded before that
+file existed.
+
+```bash
+rm rust-toolchain.toml
+grep -v '^"rust-toolchain.toml"' .autumn/scaffold.toml > /tmp/m && mv /tmp/m .autumn/scaffold.toml
+
+autumn upgrade --check ; echo "exit=$?"
+autumn upgrade
+autumn upgrade --apply
+autumn upgrade --check ; echo "exit=$?"
+```
+
+Passing output:
+
+- the first `--check` prints `add  rust-toolchain.toml` and `exit=3`;
+- the bare `autumn upgrade` prints the same file under `Scaffold files`, ends
+  with `Nothing was written`, and leaves `rust-toolchain.toml` absent;
+- `--apply` recreates `rust-toolchain.toml`;
+- the second `--check` prints `up to date` and `exit=0`.
+
+The trailing `Upgrade guide:` line of every report must be a URL that resolves.
+
 ## Pre-Publish Rehearsal
 
 Before the `autumn-cli` or `autumn-web` release has reached crates.io, the same

--- a/docs/guide/docs-smoke.md
+++ b/docs/guide/docs-smoke.md
@@ -74,8 +74,8 @@ autumn upgrade --check ; echo "exit=$?"
 Passing output:
 
 - the first `--check` prints `add  rust-toolchain.toml` and `exit=3`;
-- the bare `autumn upgrade` prints the same file under `Scaffold files`, ends
-  with `Nothing was written`, and leaves `rust-toolchain.toml` absent;
+- the bare `autumn upgrade` prints the same file under `Scaffold files`, prints
+  `Nothing was written`, and leaves `rust-toolchain.toml` absent;
 - `--apply` recreates `rust-toolchain.toml`;
 - the second `--check` prints `up to date` and `exit=0`.
 

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -148,6 +148,8 @@ my-app/
   rust-toolchain.toml
   rustfmt.toml
   clippy.toml
+  tailwind.config.js        # Tailwind content globs
+  .autumn/scaffold.toml     # which release scaffolded this — commit it
   src/
     main.rs                 # your application entry point
   static/
@@ -163,6 +165,11 @@ my-app/
     credentials/development.toml.enc
   .github/workflows/ci.yml  # fmt, clippy, test, and a11y checks
 ```
+
+`.autumn/scaffold.toml` is bookkeeping, but commit it: it records which
+release's scaffold produced the framework-owned files above, so a later
+[`autumn upgrade`](upgrading.md#scaffold-files) can tell a template that moved
+from a file you edited, and never overwrite your work.
 
 The files that matter right now:
 

--- a/docs/guide/upgrading.md
+++ b/docs/guide/upgrading.md
@@ -500,7 +500,7 @@ Only steps 3 and 6 write anything, and step 4 shows you everything step 3 did.
 | Code | Meaning |
 |------|---------|
 | `0` | The scan completed. This includes a run that reported `manual` sites or skipped an unparsable file — both are in the report, and neither is a failure of the command. |
-| `1` | The apply step failed partway through. The report names the file it died on; the ones listed before it were already written. |
+| `1` | The apply step failed partway through, or it wrote the files but could not record their new baseline in `.autumn/scaffold.toml` — in which case the files are correct and the next run will report them as conflicts until the manifest can be written. The report names the file it died on; the ones listed before it were already written. |
 | `2` | A bad argument, a `PATH` that is not a readable directory, a version this command cannot parse, or `--check` outside an Autumn project (or in one whose `Cargo.toml` gives no usable `[package] name`). Nothing was scanned. |
 | `3` | `--check` found scaffold drift. Its own code rather than `1`, so a CI job can tell "your skeleton is stale" from "the apply step died partway". |
 

--- a/docs/guide/upgrading.md
+++ b/docs/guide/upgrading.md
@@ -341,8 +341,9 @@ hatch.
 
 ### Inside a Cargo workspace
 
-If the project is a crate inside an enclosing workspace, the files that
-workspace owns at *its* root are out of scope here, and the report says so:
+If the project is a crate inside an enclosing workspace — meaning its own
+`Cargo.toml` has no `[workspace]` table of its own — the files that workspace
+owns at *its* root are out of scope here, and the report says so:
 
 - `clippy.toml`, `rustfmt.toml` and `rust-toolchain.toml` are resolved from the
   nearest ancestor of the crate being built, so a crate-local copy does not add
@@ -355,6 +356,12 @@ Everything genuinely per-crate — `autumn.toml`, `Dockerfile`, `.dockerignore`,
 `build.rs`, `.gitignore`, `.env.example`, and the CSS pipeline — is reconciled as
 usual. Reconcile the workspace-level files by running the command at the
 workspace root, if that root is itself an Autumn project.
+
+`autumn new` writes a bare `[workspace]` table into every generated
+`Cargo.toml`, so a scaffolded project is its own workspace root wherever you
+drop it, and nothing changes. This applies only once you adopt the app *into* a
+workspace by deleting that table — which is exactly when Cargo starts resolving
+its lint, format and toolchain config from the root instead.
 
 ### Gating CI on scaffold freshness
 

--- a/docs/guide/upgrading.md
+++ b/docs/guide/upgrading.md
@@ -8,7 +8,18 @@ upgrade, a codemod you can run instead of hand-editing call sites out of prose.
 ```bash
 autumn upgrade            # preview: per-file diff, nothing written
 autumn upgrade --apply    # take the rewrites
+autumn upgrade --check    # CI gate: exit 3 if scaffold files have drifted
 ```
+
+One run covers both halves of an upgrade:
+
+1. **Your own Rust code** — each release's machine-applyable API migrations,
+   applied to `src/`, `tests/`, `examples/`, `benches/` and every workspace
+   member.
+2. **Your project's framework-owned files** — `Dockerfile`, `build.rs`,
+   `autumn.toml`, the toolchain and style configs, the CI workflow —
+   reconciled against the current release's scaffold. See
+   [Scaffold files](#scaffold-files) below.
 
 ## What it does
 
@@ -19,9 +30,9 @@ machine-applyable migrations to **your own Rust source** — `src/`, `tests/`,
 and vendored sources are never touched.
 
 It is deliberately narrow. Today the shipped rewrites are API **renames**:
-`0.6.0`'s `with_pool` → `with_pool_untracked`, for instance. Configuration
-files, dependency versions, and framework-owned scaffold files are out of
-scope — `autumn doctor` and the migration guides cover those.
+`0.6.0`'s `with_pool` → `with_pool_untracked`, for instance. Dependency
+versions are out of scope, and so is anything under `src/` that is not a call
+site a shipped codemod names.
 
 ## Preview first, always
 
@@ -114,6 +125,217 @@ not:
   call unconditionally; under the other configuration the same name may be an
   unrelated import. Calls to such a type are reported for a human.
 
+## Scaffold files
+
+`autumn new` writes about a dozen framework-owned files into every project, and
+those templates keep evolving: the widget CSS restructure, the `nav_bar`
+helper, the toolchain and style configs that did not exist before `0.5`.
+Bumping `autumn-web` in `Cargo.toml` updates the *library*; it does not touch
+your project skeleton. So an app scaffolded on `0.5` keeps `0.5`-vintage
+project files forever unless something reconciles them.
+
+That something is the second half of `autumn upgrade`. It renders the current
+release's scaffold in memory, compares it against what is on disk, and prints a
+per-file verdict:
+
+```text
+Scaffold files (0.5.0 -> 0.7.0)
+
+  3 file(s) differ:
+  conflict  Dockerfile           you changed this since it was scaffolded
+  add       clippy.toml          this release's scaffold has it; your project does not
+  add       rust-toolchain.toml  this release's scaffold has it; your project does not
+
+Dockerfile (conflict)
+@@ lines 65-66 @@
+-
+-# my own tweak
+
+clippy.toml (add)
+@@ line 1 @@
++msrv = "1.88.0"
+
+rust-toolchain.toml (add)
+@@ lines 1-3 @@
++[toolchain]
++channel = "1.88.0"
++components = ["rustfmt", "clippy"]
+
+2 file(s) would be written; 1 conflict(s) need review.
+Nothing was written. Re-run with `--apply` to take the writable ones, then
+review with `git diff` -- `git checkout -- <path>` puts any one file back.
+Conflicts are never overwritten. Compare each against this release's
+scaffold above, take what you want, and re-run to confirm.
+Upgrade guide: https://github.com/autumn-foundation/autumn/blob/trunk-dev/docs/migrations/0.7.0.md
+```
+
+In every diff, `-` is what your project has now and `+` is what this release's
+scaffold writes. For a `conflict` that is a description of the difference, not
+of an impending write — a conflict is never applied.
+
+### Which files it owns
+
+| Owned — reconciled | Not owned — never touched |
+|---|---|
+| `autumn.toml` | `src/**` (all of your application code, including `src/bin/seed.rs`) |
+| `Dockerfile`, `.dockerignore` | `Cargo.toml` (your dependencies) |
+| `build.rs` | `README.md` (your prose) |
+| `.gitignore`, `.env.example` | `tests/**`, `migrations/**`, `i18n/**` |
+| `.github/workflows/ci.yml` | `config/credentials/**` (your secrets) |
+| `rust-toolchain.toml`, `rustfmt.toml`, `clippy.toml` | `static/js/**` (vendored — `autumn assets` owns these) |
+| `tailwind.config.js`, `static/css/input.css` (fullstack only) | |
+
+**Application source is out of bounds.** The command never reads, writes, or
+names a path under `src/`. API migration to your own code is the *first* half
+of `autumn upgrade` (above), and anything it cannot rewrite mechanically is
+your release's [migration guide](../migrations/README.md) to work through.
+
+### The five verdicts
+
+| Verdict | What it means | Written by `--apply`? |
+|---|---|---|
+| `current` | Identical to this release's scaffold. Not listed. | – |
+| `add` | This release's scaffold has the file and your project does not — including every file a release *after* yours introduced. | yes |
+| `update` | The template changed and your copy is provably untouched since Autumn wrote it. | yes |
+| `conflict` | The template changed and your copy may be yours now. | **no** |
+| `removed` | Autumn wrote this file once and you deleted it. | **no** |
+
+### How it knows you edited a file
+
+"May I overwrite this?" is really "did you touch it?", and neither the file's
+contents nor its timestamp can answer that. So `autumn new` records a digest of
+every framework-owned file as it writes it, in `.autumn/scaffold.toml`:
+
+```toml
+version = "0.7.0"
+flavor = "fullstack"
+i18n = false
+seed = false
+daemon = false
+bundled_pg = false
+
+[files]
+"clippy.toml" = "5e884898da280471…"
+```
+
+**Commit that file.** Its entire value is being the baseline a *later* checkout
+compares against. It holds a release, the flags the project was created with,
+and one digest per file — no paths outside the project, and nothing secret.
+`autumn upgrade --apply` refreshes it, and it moves its recorded `version`
+forward only once no conflicts are left, so a half-finished upgrade never reads
+as a finished one.
+
+Line endings are normalised before hashing, so a `core.autocrlf` checkout on
+Windows is not mistaken for you having personally rewritten all twelve files.
+
+### Projects older than this feature
+
+An app scaffolded before `.autumn/scaffold.toml` existed has no baseline, and
+that is **not** an error — it just means "untouched" cannot be proven. The
+upgrade is best effort:
+
+- files your project is missing entirely are still offered as `add` — there is
+  no content to lose;
+- every file that differs is a `conflict` for you to review, never an
+  overwrite.
+
+The report says so up front. Once you have run `--apply` once, the manifest
+exists and every later upgrade gets the sharper answer.
+
+Flavor is inferred the same way when there is no manifest: a project with no
+`static/` directory and no `tailwind.config.js` is treated as an `--api` app
+and is never offered Tailwind files; an `i18n/` directory means the project was
+made with `--with-i18n`.
+
+### Reverting
+
+`--apply` edits files in place, and your VCS is the undo:
+
+```bash
+git status                       # what changed
+git diff                         # exactly what changed, line by line
+git checkout -- rust-toolchain.toml   # put one file back
+git checkout -- .                # put everything back
+```
+
+Commit or stash before you apply, the same as for the codemods. The preview is
+the review step, `git diff` is the proof, and `git checkout --` is the escape
+hatch.
+
+### Gating CI on scaffold freshness
+
+```bash
+autumn upgrade --check
+```
+
+`--check` reconciles the scaffold files, writes nothing, and exits **3** when
+anything has drifted — so a CI job can fail the build on a stale skeleton:
+
+```yaml
+- name: Scaffold is current
+  run: autumn upgrade --check
+```
+
+It exits `0` on a clean project. A file you deliberately deleted is reported as
+`removed` but does **not** hold the gate red — deleting it was a decision, and
+a gate that can never go green again is a gate people delete.
+
+`--check` cannot be combined with `--apply`; that is a usage error (exit `2`).
+Run it outside an Autumn project — a directory with no `autumn.toml` — and it
+says so and exits `2` rather than reporting a spurious pass.
+
+`--json` works with `--check` too, and with a normal run the scaffold report is
+a `scaffold` key alongside the app-code report:
+
+```json
+{
+  "scaffold": {
+    "baseline": "0.5.0",
+    "target": "0.7.0",
+    "has_manifest": true,
+    "drift": true,
+    "written": 2,
+    "conflicts": 1,
+    "guide": "https://github.com/autumn-foundation/autumn/blob/trunk-dev/docs/migrations/0.7.0.md",
+    "files": [
+      { "path": "clippy.toml", "status": "add", "applied": true }
+    ]
+  }
+}
+```
+
+### A whole upgrade, end to end
+
+```bash
+# 1. Start clean, so `git diff` means something.
+git status
+
+# 2. Preview both halves: code rewrites and scaffold drift.
+autumn upgrade
+
+# 3. Take them.
+autumn upgrade --apply
+
+# 4. Read what it did.
+git diff
+
+# 5. Work the conflicts it refused to touch, one file at a time.
+#    Each one's diff is in the report above.
+
+# 6. Confirm the skeleton is current.
+autumn upgrade --check
+
+# 7. Now bump the library and build.
+#    (The codemods migrate FROM the version Cargo.toml records, so this is last.)
+cargo add autumn-web@0.7.0
+cargo check
+
+# 8. Read the release's migration guide for anything mechanical rewriting
+#    could not do — the link is at the bottom of every report.
+```
+
+Only step 3 writes anything, and step 4 shows you all of it.
+
 ## Flags
 
 | Flag | Effect |
@@ -124,6 +346,7 @@ not:
 | `--to VERSION` | Upgrade to this release instead of the CLI's own version. |
 | `--json` | Machine-readable report — the same content, for CI. |
 | `--list-migrations` | Print the shipped codemods and exit, without scanning. |
+| `--check` | Reconcile the scaffold files only, write nothing, and exit `3` if any have drifted. For CI. Cannot be combined with `--apply`. |
 
 ## Exit codes
 
@@ -131,7 +354,8 @@ not:
 |------|---------|
 | `0` | The scan completed. This includes a run that reported `manual` sites or skipped an unparsable file — both are in the report, and neither is a failure of the command. |
 | `1` | The apply step failed partway through. The report names the file it died on; the ones listed before it were already written. |
-| `2` | A bad argument, a `PATH` that is not a readable directory, or a version this command cannot parse. Nothing was scanned. |
+| `2` | A bad argument, a `PATH` that is not a readable directory, a version this command cannot parse, or `--check` outside an Autumn project. Nothing was scanned. |
+| `3` | `--check` found scaffold drift. Its own code rather than `1`, so a CI job can tell "your skeleton is stale" from "the apply step died partway". |
 
 There is no "found something" exit code: a preview that finds work is the
 command working. Gate on the `--json` report's `manual`, `skipped`, and site

--- a/docs/guide/upgrading.md
+++ b/docs/guide/upgrading.md
@@ -173,6 +173,11 @@ In every diff, `-` is what your project has now and `+` is what this release's
 scaffold writes. For a `conflict` that is a description of the difference, not
 of an impending write — a conflict is never applied.
 
+The scaffold half always reconciles to **this CLI's own release**. `--to`
+selects which codemods run against your Rust code; it cannot conjure a
+historical scaffold, because the CLI ships exactly one set of templates — its
+own. Downgrades and arbitrary historical scaffold versions are out of scope.
+
 ### Which files it owns
 
 | Owned — reconciled | Not owned — never touched |
@@ -200,6 +205,15 @@ your release's [migration guide](../migrations/README.md) to work through.
 | `conflict` | The template changed and your copy may be yours now. | **no** |
 | `removed` | Autumn wrote this file once and you deleted it. | **no** |
 
+A `conflict` says which of four things it is:
+
+| Reason | When |
+|---|---|
+| `you changed this since it was scaffolded` | The file no longer matches the digest Autumn recorded for it. |
+| `no recorded baseline, so an edit cannot be ruled out` | Nothing was recorded for this file — see [Projects older than this feature](#projects-older-than-this-feature). |
+| `on disk but unreadable as text, so its contents are unknown` | It is not UTF-8, it is a directory, or the process cannot open it. What it holds is unknown, so it is untouchable. |
+| `a symlink; writing through it could write outside the project` | The path is a symbolic link. Writing through it would write wherever it points, which need not be inside the project — so the link is reported and left exactly as it is. |
+
 ### How it knows you edited a file
 
 "May I overwrite this?" is really "did you touch it?", and neither the file's
@@ -220,10 +234,18 @@ bundled_pg = false
 
 **Commit that file.** Its entire value is being the baseline a *later* checkout
 compares against. It holds a release, the flags the project was created with,
-and one digest per file — no paths outside the project, and nothing secret.
-`autumn upgrade --apply` refreshes it, and it moves its recorded `version`
-forward only once no conflicts are left, so a half-finished upgrade never reads
-as a finished one.
+and one digest per file — no paths outside the project, and nothing secret (the
+digests are of Autumn's own template text, never of your content).
+
+`version` means "the release these files were last *fully* reconciled to".
+`autumn upgrade --apply` refreshes the file, and moves `version` forward only
+once no conflicts are left — so a half-finished upgrade never reads as a
+finished one, and a project that has never been fully reconciled simply has no
+`version` line rather than a flattering guess.
+
+Writes go through a temporary file in the same directory and are renamed into
+place, keeping the original's permissions, so an interrupted `--apply` cannot
+leave you with a half-written `Dockerfile`.
 
 Line endings are normalised before hashing, so a `core.autocrlf` checkout on
 Windows is not mistaken for you having personally rewritten all twelve files.
@@ -242,10 +264,22 @@ upgrade is best effort:
 The report says so up front. Once you have run `--apply` once, the manifest
 exists and every later upgrade gets the sharper answer.
 
-Flavor is inferred the same way when there is no manifest: a project with no
-`static/` directory and no `tailwind.config.js` is treated as an `--api` app
-and is never offered Tailwind files; an `i18n/` directory means the project was
-made with `--with-i18n`.
+Flavor is inferred the same way when there is no manifest, and deliberately
+needs *positive* evidence of the fullstack CSS pipeline: a `tailwind.config.js`,
+a `static/css/` directory, or the vendored `static/js/htmx.min.js`. Any one is
+enough, so deleting a single file cannot reclassify your project — and a JSON
+API that happens to serve its `openapi.json` out of `static/` is not handed a
+Tailwind config it has no use for. An `i18n/` directory means the project was
+made with `--with-i18n`, and `autumn.toml`'s own daemon markers identify the
+daemon flavors.
+
+The project's name comes from `[package] name` in `Cargo.toml` and from nowhere
+else — never the directory name. `autumn.toml`, `.env.example`, the CI workflow
+and the `Dockerfile`'s `CMD` all interpolate it, so a guessed name would render
+a *different* scaffold and could rewrite `COPY --from=builder
+/app/target/release/<name>` into an image that cannot start. If your manifest
+gives no usable package name, the scaffold half says so and reconciles nothing
+rather than comparing against a fiction.
 
 ### Reverting
 
@@ -268,8 +302,9 @@ hatch.
 autumn upgrade --check
 ```
 
-`--check` reconciles the scaffold files, writes nothing, and exits **3** when
-anything has drifted — so a CI job can fail the build on a stale skeleton:
+`--check` reconciles the scaffold files, writes nothing, prints the verdicts
+without the per-file diffs (a build log is a poor place for the working
+contents of `autumn.toml`), and exits **3** when anything has drifted — so a CI job can fail the build on a stale skeleton:
 
 ```yaml
 - name: Scaffold is current
@@ -346,7 +381,7 @@ Only step 3 writes anything, and step 4 shows you all of it.
 | `--to VERSION` | Upgrade to this release instead of the CLI's own version. |
 | `--json` | Machine-readable report — the same content, for CI. |
 | `--list-migrations` | Print the shipped codemods and exit, without scanning. |
-| `--check` | Reconcile the scaffold files only, write nothing, and exit `3` if any have drifted. For CI. Cannot be combined with `--apply`. |
+| `--check` | Reconcile the scaffold files only, write nothing, print verdicts without diffs, and exit `3` if any have drifted. For CI. Cannot be combined with `--apply`. |
 
 ## Exit codes
 

--- a/docs/guide/upgrading.md
+++ b/docs/guide/upgrading.md
@@ -136,20 +136,24 @@ project files forever unless something reconciles them.
 
 That something is the second half of `autumn upgrade`. It renders the current
 release's scaffold in memory, compares it against what is on disk, and prints a
-per-file verdict:
+per-file verdict. Here is a real run in an app scaffolded before this feature
+existed — which is every app that exists today:
 
 ```text
-Scaffold files (0.5.0 -> 0.7.0)
+Scaffold files (unknown -> 0.7.0)
+  This project predates scaffold provenance, so there is no record of
+  what Autumn originally wrote. Files it is missing are offered; every
+  file that differs is a conflict for you to review.
 
   3 file(s) differ:
-  conflict  Dockerfile           you changed this since it was scaffolded
+  conflict  Dockerfile           no recorded baseline, so an edit cannot be ruled out
   add       clippy.toml          this release's scaffold has it; your project does not
   add       rust-toolchain.toml  this release's scaffold has it; your project does not
 
 Dockerfile (conflict)
 @@ lines 65-66 @@
 -
--# my own tweak
+-# our own base image pin
 
 clippy.toml (add)
 @@ line 1 @@
@@ -162,12 +166,18 @@ rust-toolchain.toml (add)
 +components = ["rustfmt", "clippy"]
 
 2 file(s) would be written; 1 conflict(s) need review.
-Nothing was written. Re-run with `--apply` to take the writable ones, then
-review with `git diff` -- `git checkout -- <path>` puts any one file back.
-Conflicts are never overwritten. Compare each against this release's
-scaffold above, take what you want, and re-run to confirm.
+Nothing was written. Re-run with `--apply` to take the writable ones.
+Each file's diff is above; `git status` and `git diff` show what is yours.
+Conflicts are never overwritten. Take what you want from this release's
+version, or `autumn upgrade --accept <path>` to keep yours for good.
 Upgrade guide: https://github.com/autumn-foundation/autumn/blob/trunk-dev/docs/migrations/0.7.0.md
 ```
+
+Once the project has a baseline — see [How it knows you edited a
+file](#how-it-knows-you-edited-a-file) — the header names the release it was
+last reconciled to (`Scaffold files (0.7.0 -> 0.8.0)`), the banner goes away,
+and an edited file is reported as `you changed this since it was scaffolded`
+rather than as an unprovable one.
 
 In every diff, `-` is what your project has now and `+` is what this release's
 scaffold writes. For a `conflict` that is a description of the difference, not
@@ -203,7 +213,8 @@ your release's [migration guide](../migrations/README.md) to work through.
 | `add` | This release's scaffold has the file and your project does not — including every file a release *after* yours introduced. | yes |
 | `update` | The template changed and your copy is provably untouched since Autumn wrote it. | yes |
 | `conflict` | The template changed and your copy may be yours now. | **no** |
-| `removed` | Autumn wrote this file once and you deleted it. | **no** |
+| `removed` | Autumn wrote this file once and you deleted it. Delete its line from the manifest's `[files]` to be offered it again. | **no** |
+| `pinned` | You ran `autumn upgrade --accept <path>` on it. It is yours. | **no** |
 
 A `conflict` says which of four things it is:
 
@@ -213,6 +224,28 @@ A `conflict` says which of four things it is:
 | `no recorded baseline, so an edit cannot be ruled out` | Nothing was recorded for this file — see [Projects older than this feature](#projects-older-than-this-feature). |
 | `on disk but unreadable as text, so its contents are unknown` | It is not UTF-8, it is a directory, or the process cannot open it. What it holds is unknown, so it is untouchable. |
 | `a symlink; writing through it could write outside the project` | The path is a symbolic link. Writing through it would write wherever it points, which need not be inside the project — so the link is reported and left exactly as it is. |
+
+### Finishing a conflict
+
+Reviewing a conflict has to be able to *conclude*. Sometimes you take this
+release's version; sometimes the file is deliberately yours and always will be —
+a `Dockerfile` with your own base image, a CI workflow with your own jobs. For
+that second case:
+
+```bash
+autumn upgrade --accept Dockerfile
+```
+
+That records the path in the manifest's `pinned` list and writes nothing else.
+From then on the file reports as `pinned`, is never offered or written, and does
+not count as drift — so `--check` can go green again. Without it a team that
+customises one file has a CI gate that is red forever, which is a gate that gets
+deleted.
+
+`pinned` is a plain list of paths, not digests, precisely so you can undo it:
+delete a line from `.autumn/scaffold.toml` and the file comes back under
+reconciliation. `--accept` refuses a path the current scaffold does not own —
+promising to skip a file this command never touches would mean nothing.
 
 ### How it knows you edited a file
 
@@ -228,8 +261,10 @@ seed = false
 daemon = false
 bundled_pg = false
 
+pinned = ["Dockerfile"]
+
 [files]
-"clippy.toml" = "5e884898da280471…"
+"clippy.toml" = "<64 hex characters of SHA-256>"
 ```
 
 **Commit that file.** Its entire value is being the baseline a *later* checkout
@@ -248,7 +283,7 @@ place, keeping the original's permissions, so an interrupted `--apply` cannot
 leave you with a half-written `Dockerfile`.
 
 Line endings are normalised before hashing, so a `core.autocrlf` checkout on
-Windows is not mistaken for you having personally rewritten all twelve files.
+Windows is not mistaken for you having personally rewritten every one of them.
 
 ### Projects older than this feature
 
@@ -277,25 +312,48 @@ The project's name comes from `[package] name` in `Cargo.toml` and from nowhere
 else — never the directory name. `autumn.toml`, `.env.example`, the CI workflow
 and the `Dockerfile`'s `CMD` all interpolate it, so a guessed name would render
 a *different* scaffold and could rewrite `COPY --from=builder
-/app/target/release/<name>` into an image that cannot start. If your manifest
-gives no usable package name, the scaffold half says so and reconciles nothing
-rather than comparing against a fiction — and `--check` exits `2` there, because
-"we could not look" is not "clean".
+/app/target/release/<name>` into an image that cannot start. If your
+`Cargo.toml` gives no usable package name, the scaffold half says so and
+reconciles nothing rather than comparing against a fiction — and `--check` exits
+`2` there, because "we could not look" is not "clean".
 
 ### Reverting
 
 `--apply` edits files in place, and your VCS is the undo:
 
 ```bash
-git status                       # what changed
-git diff                         # exactly what changed, line by line
-git checkout -- rust-toolchain.toml   # put one file back
-git checkout -- .                # put everything back
+git status                            # what changed, added files included
+git diff                              # exactly what changed, line by line
+git checkout -- Dockerfile            # put back a file it UPDATED
+rm rust-toolchain.toml                # remove a file it ADDED
 ```
+
+The distinction matters: `git checkout --` restores a tracked file's contents,
+and does nothing at all for a file that was just created — git has never heard
+of it. An aged project is mostly `add`s, so `git status` (which lists untracked
+files) is the one to start from. A legacy project's first `--apply` also creates
+`.autumn/scaffold.toml`; it is new too.
 
 Commit or stash before you apply, the same as for the codemods. The preview is
 the review step, `git diff` is the proof, and `git checkout --` is the escape
 hatch.
+
+### Inside a Cargo workspace
+
+If the project is a crate inside an enclosing workspace, the files that
+workspace owns at *its* root are out of scope here, and the report says so:
+
+- `clippy.toml`, `rustfmt.toml` and `rust-toolchain.toml` are resolved from the
+  nearest ancestor of the crate being built, so a crate-local copy does not add
+  to the workspace's — it **shadows** it, silently dropping its lints and its
+  MSRV pin with no diagnostic.
+- GitHub only runs workflows from the repository root, so a member's
+  `.github/workflows/ci.yml` never runs at all.
+
+Everything genuinely per-crate — `autumn.toml`, `Dockerfile`, `.dockerignore`,
+`build.rs`, `.gitignore`, `.env.example`, and the CSS pipeline — is reconciled as
+usual. Reconcile the workspace-level files by running the command at the
+workspace root, if that root is itself an Autumn project.
 
 ### Gating CI on scaffold freshness
 
@@ -317,28 +375,54 @@ It exits `0` on a clean project. A file you deliberately deleted is reported as
 a gate that can never go green again is a gate people delete.
 
 `--check` cannot be combined with `--apply`; that is a usage error (exit `2`).
-Run it outside an Autumn project — a directory with no `autumn.toml` — and it
-says so and exits `2` rather than reporting a spurious pass.
+Run it outside an Autumn project — a directory with neither an `autumn.toml` nor
+a `.autumn/scaffold.toml` — and it says so and exits `2` rather than reporting a
+spurious pass.
 
-`--json` works with `--check` too, and with a normal run the scaffold report is
-a `scaffold` key alongside the app-code report:
+`--json` works with `--check` too, and both emit the scaffold report under the
+same `scaffold` key, so one `jq '.scaffold.drift'` works against either:
 
 ```json
 {
   "scaffold": {
-    "baseline": "0.5.0",
+    "baseline": "0.7.0",
     "target": "0.7.0",
+    "named": true,
     "has_manifest": true,
+    "workspace_member": false,
+    "outcome": "preview",
     "drift": true,
-    "written": 2,
+    "writable": 2,
+    "written": 0,
     "conflicts": 1,
+    "pinned": 0,
     "guide": "https://github.com/autumn-foundation/autumn/blob/trunk-dev/docs/migrations/0.7.0.md",
     "files": [
-      { "path": "clippy.toml", "status": "add", "applied": true }
+      { "path": "clippy.toml", "status": "add", "reason": "…", "applied": true }
     ]
   }
 }
 ```
+
+`writable` and `written` are different questions, the same split the app-code
+report draws. `writable` is the plan — how many files `--apply` *would* write,
+and `applied` on each file means the same thing. `written` is what actually
+reached disk: `0` for a preview or a `--check`, the whole plan after a complete
+apply, and only the prefix that landed after an interrupted one. Gate on
+`written` when you care about the state of the working tree, and on `drift` when
+you care whether there is work to do.
+
+A run that could not render the scaffold at all reports `"named": false`, and
+`--check` exits `2` rather than reporting `"drift": false` as though it had
+looked.
+
+### What it does not report
+
+A file an *older* release generated and the current one no longer does is not
+listed. The reconciler compares against the current scaffold, so a retired file
+simply falls out of scope and stays on disk untouched. Retiring a scaffold file
+is rare; when it happens the release's migration guide is where it is called
+out.
 
 ### A whole upgrade, end to end
 
@@ -352,11 +436,15 @@ autumn upgrade
 # 3. Take them.
 autumn upgrade --apply
 
-# 4. Read what it did.
+# 4. Read what it did. `git checkout -- <path>` puts back a file it updated;
+#    `rm <path>` removes one it added (git has never heard of that one).
+git status
 git diff
 
-# 5. Work the conflicts it refused to touch, one file at a time.
-#    Each one's diff is in the report above.
+# 5. Work the conflicts it refused to touch, one file at a time. Each one's
+#    diff is in the report above. Take this release's version where you want
+#    it; where the file is deliberately yours, say so once and for all:
+#      autumn upgrade --accept Dockerfile
 
 # 6. Confirm the skeleton is current.
 autumn upgrade --check
@@ -383,6 +471,7 @@ Only step 3 writes anything, and step 4 shows you all of it.
 | `--json` | Machine-readable report — the same content, for CI. |
 | `--list-migrations` | Print the shipped codemods and exit, without scanning. |
 | `--check` | Reconcile the scaffold files only, write nothing, print verdicts without diffs, and exit `3` if any have drifted. For CI. Cannot be combined with `--apply`. |
+| `--accept PATH` | Record a framework-owned file as yours, so reconciliation leaves it alone. Repeatable. Writes only `.autumn/scaffold.toml`. |
 
 ## Exit codes
 

--- a/docs/guide/upgrading.md
+++ b/docs/guide/upgrading.md
@@ -247,6 +247,14 @@ delete a line from `.autumn/scaffold.toml` and the file comes back under
 reconciliation. `--accept` refuses a path the current scaffold does not own —
 promising to skip a file this command never touches would mean nothing.
 
+**When you resolve a conflict by taking this release's version by hand, run
+`autumn upgrade --apply` once more afterwards.** The file is now identical to
+the scaffold, so nothing gets written — but the run records its digest, and
+that baseline is what lets the *next* release update the file for you instead
+of raising it as a conflict again. `--check` deliberately writes nothing, so it
+cannot do this for you: it will report the file as current while leaving it
+without a baseline.
+
 ### How it knows you edited a file
 
 "May I overwrite this?" is really "did you touch it?", and neither the file's
@@ -454,19 +462,25 @@ git diff
 #    it; where the file is deliberately yours, say so once and for all:
 #      autumn upgrade --accept Dockerfile
 
-# 6. Confirm the skeleton is current.
+# 6. Record what you resolved by hand. This writes no file content — the
+#    conflicts you settled are now identical to the scaffold, so there is
+#    nothing left to write — but it does add them to your baseline, which is
+#    what makes the NEXT release able to update them for you automatically.
+autumn upgrade --apply
+
+# 7. Confirm the skeleton is current.
 autumn upgrade --check
 
-# 7. Now bump the library and build.
+# 8. Now bump the library and build.
 #    (The codemods migrate FROM the version Cargo.toml records, so this is last.)
 cargo add autumn-web@0.7.0
 cargo check
 
-# 8. Read the release's migration guide for anything mechanical rewriting
+# 9. Read the release's migration guide for anything mechanical rewriting
 #    could not do — the link is at the bottom of every report.
 ```
 
-Only step 3 writes anything, and step 4 shows you all of it.
+Only steps 3 and 6 write anything, and step 4 shows you everything step 3 did.
 
 ## Flags
 

--- a/docs/guide/upgrading.md
+++ b/docs/guide/upgrading.md
@@ -278,9 +278,10 @@ once no conflicts are left — so a half-finished upgrade never reads as a
 finished one, and a project that has never been fully reconciled simply has no
 `version` line rather than a flattering guess.
 
-Writes go through a temporary file in the same directory and are renamed into
-place, keeping the original's permissions, so an interrupted `--apply` cannot
-leave you with a half-written `Dockerfile`.
+Every write is staged in the same directory and renamed into place, so an
+interrupted `--apply` cannot leave you with a half-written `Dockerfile` or a
+truncated new file. An updated file keeps its original permissions; an added
+one lands with exactly the mode `autumn new` would have given it.
 
 Line endings are normalised before hashing, so a `core.autocrlf` checkout on
 Windows is not mistaken for you having personally rewritten every one of them.

--- a/docs/guide/upgrading.md
+++ b/docs/guide/upgrading.md
@@ -279,7 +279,8 @@ and the `Dockerfile`'s `CMD` all interpolate it, so a guessed name would render
 a *different* scaffold and could rewrite `COPY --from=builder
 /app/target/release/<name>` into an image that cannot start. If your manifest
 gives no usable package name, the scaffold half says so and reconciles nothing
-rather than comparing against a fiction.
+rather than comparing against a fiction — and `--check` exits `2` there, because
+"we could not look" is not "clean".
 
 ### Reverting
 
@@ -389,7 +390,7 @@ Only step 3 writes anything, and step 4 shows you all of it.
 |------|---------|
 | `0` | The scan completed. This includes a run that reported `manual` sites or skipped an unparsable file — both are in the report, and neither is a failure of the command. |
 | `1` | The apply step failed partway through. The report names the file it died on; the ones listed before it were already written. |
-| `2` | A bad argument, a `PATH` that is not a readable directory, a version this command cannot parse, or `--check` outside an Autumn project. Nothing was scanned. |
+| `2` | A bad argument, a `PATH` that is not a readable directory, a version this command cannot parse, or `--check` outside an Autumn project (or in one whose `Cargo.toml` gives no usable `[package] name`). Nothing was scanned. |
 | `3` | `--check` found scaffold drift. Its own code rather than `1`, so a CI job can tell "your skeleton is stale" from "the apply step died partway". |
 
 There is no "found something" exit code: a preview that finds work is the

--- a/docs/guide/upgrading.md
+++ b/docs/guide/upgrading.md
@@ -188,6 +188,14 @@ selects which codemods run against your Rust code; it cannot conjure a
 historical scaffold, because the CLI ships exactly one set of templates — its
 own. Downgrades and arbitrary historical scaffold versions are out of scope.
 
+That cuts both ways. If the project's manifest records a release **newer** than
+the CLI you are running, the scaffold half refuses outright and says so: its
+files came from templates this CLI does not have, so every one of them would
+look like a stale file to update, and applying that would downgrade your
+`Dockerfile`, build script and CI workflow. Install a CLI at least as new as the
+recorded release and run it again. `--check` exits `2` there rather than
+reporting a clean project it never looked at.
+
 ### Which files it owns
 
 | Owned — reconciled | Not owned — never touched |
@@ -501,7 +509,7 @@ Only steps 3 and 6 write anything, and step 4 shows you everything step 3 did.
 |------|---------|
 | `0` | The scan completed. This includes a run that reported `manual` sites or skipped an unparsable file — both are in the report, and neither is a failure of the command. |
 | `1` | The apply step failed partway through, or it wrote the files but could not record their new baseline in `.autumn/scaffold.toml` — in which case the files are correct and the next run will report them as conflicts until the manifest can be written. The report names the file it died on; the ones listed before it were already written. |
-| `2` | A bad argument, a `PATH` that is not a readable directory, a version this command cannot parse, or `--check` outside an Autumn project (or in one whose `Cargo.toml` gives no usable `[package] name`). Nothing was scanned. |
+| `2` | A bad argument, a `PATH` that is not a readable directory, a version this command cannot parse, or a `--check` that could not look: outside an Autumn project, in one whose `Cargo.toml` gives no usable `[package] name`, or in one scaffolded by a release newer than this CLI. Nothing was scanned. |
 | `3` | `--check` found scaffold drift. Its own code rather than `1`, so a CI job can tell "your skeleton is stale" from "the apply step died partway". |
 
 There is no "found something" exit code: a preview that finds work is the

--- a/docs/guide/upgrading.md
+++ b/docs/guide/upgrading.md
@@ -271,6 +271,7 @@ every framework-owned file as it writes it, in `.autumn/scaffold.toml`:
 
 ```toml
 version = "0.7.0"
+written_by = "0.7.0"
 flavor = "fullstack"
 i18n = false
 seed = false
@@ -293,6 +294,13 @@ digests are of Autumn's own template text, never of your content).
 once no conflicts are left — so a half-finished upgrade never reads as a
 finished one, and a project that has never been fully reconciled simply has no
 `version` line rather than a flattering guess.
+
+`written_by` answers a different question: which is the newest release that has
+written any digest here. It moves forward on every apply, conflicts or not.
+The two come apart exactly when an upgrade leaves a conflict standing — the
+digests advance to the new templates while `version` waits — and that gap is
+what an older CLI has to see. Without it, rolling back to the older CLI would
+find digests it trusts, matching files it cannot render, and downgrade them.
 
 Every write is staged in the same directory and renamed into place, so an
 interrupted `--apply` cannot leave you with a half-written `Dockerfile` or a

--- a/docs/plans/2026-08-27-scaffold-reconciliation.md
+++ b/docs/plans/2026-08-27-scaffold-reconciliation.md
@@ -1,0 +1,171 @@
+# `autumn upgrade` scaffold reconciliation (issue #1593)
+
+Plan for reconciling framework-owned project files across releases. Written
+before any code, in the order the thinking actually happened: divergent
+options, then a deliberate hunt for failure modes, then Six Hats to settle the
+trade-offs, then the design and the TDD slices.
+
+---
+
+## 1. Brainstorming — how could this work at all?
+
+Options generated, no filtering:
+
+1. **Regenerate a throwaway project and diff it.** Shell out to `autumn new` in
+   a temp dir, diff the tree. Zero new template plumbing.
+2. **Render the current templates in memory and compare.** Same idea without
+   the temp dir; needs `new.rs` to expose per-file rendering.
+3. **Ship every historical scaffold inside the CLI**, reconstruct the app's
+   original files from its recorded version, and do a real three-way merge.
+4. **Record a digest per scaffolded file at `autumn new` time** and use it as
+   the merge base: unchanged digest ⇒ safe to overwrite, changed ⇒ conflict.
+5. **Git-native**: require a clean tree, write everything, let `git diff` be the
+   conflict UI.
+6. **Interactive per-file prompt** like `rails app:update` (`Y/n/d/q`).
+7. **Emit a patch file** the user applies with `git apply --3way`.
+8. **`.autumn/scaffold.toml` manifest** carrying version + flavor + per-file
+   digests, committed to the repo.
+9. **Marker comments** in generated files (`# autumn:managed`) so edited
+   regions are detectable inline.
+10. **A `--check` CI gate** that exits nonzero on drift.
+11. **Fold it into the existing `autumn upgrade`** so file reconciliation and
+    codemods are one run.
+12. **A separate `autumn scaffold sync` command.**
+
+Combining: **2 + 4 + 8 + 10 + 11** is the shortest path to every acceptance
+criterion. (3) is the only option that gives true three-way merges, but the CLI
+does not carry historical templates and adding them means a permanently growing
+binary; (4)'s digest baseline answers the only question that actually matters —
+"did the developer touch this?" — for a fraction of the cost. (5) and (6) are
+rejected below.
+
+## 2. Reverse brainstorming — how do we make this a disaster?
+
+Deliberately listing the ways this feature could hurt someone, then the
+mitigation that goes into the design.
+
+| How to ruin it | Mitigation in the design |
+|---|---|
+| Silently clobber a hand-tuned `Dockerfile` | Overwrite only when the on-disk bytes still match the digest Autumn recorded. Anything else is a **conflict**: reported, never written. |
+| Clobber files in a project that predates the manifest | No baseline ⇒ cannot prove "untouched" ⇒ every differing file is a conflict. Best-effort still adds files that are simply missing. |
+| Rewrite the developer's application code | The framework-owned set is a fixed allowlist with **no `src/` entry**, enforced by an assertion and a test. |
+| Write on a bare invocation | Preview is the default; `--apply` is the only writer. |
+| Half-write the tree and die | Plan everything in memory first; re-read and compare each file immediately before writing so a file changed underneath us is refused, not overwritten. |
+| Restore a file the developer deleted on purpose | A path recorded in the manifest but absent on disk is **removed**, reported and skipped, not re-added. |
+| Two sources of truth for "what the scaffold is" | `autumn new` and `autumn upgrade` render from **one** function. If they could disagree, they eventually would. |
+| Manifest becomes a liability (merge conflicts, drift, secrets) | Deterministic key order, digests only, no paths outside the project, and the file is optional — deleting it degrades precision, never correctness. |
+| Silent success in CI | `--check` exits `3` on drift, with the drift listed. |
+| Break the existing `autumn upgrade` | Scaffold reconciliation activates only in a directory that is actually an Autumn project (`autumn.toml` or `.autumn/scaffold.toml`); existing codemod behaviour and exit codes are unchanged. |
+| Dead-end the user after the report | Summary links the release's migration guide and states the revert path (`git diff`, `git checkout --`). |
+| An interactive prompt in CI | No prompts at all: preview → review → `--apply`. The terminal is not the conflict-resolution UI; the VCS is. |
+
+## 3. Six Thinking Hats
+
+**White (facts).** `autumn new` writes ~12 framework-owned files outside `src/`
+plus user-owned ones (`Cargo.toml`, `README.md`, `src/**`, tests, credentials,
+vendored JS). Template selection depends on exactly two flags for this file
+set: `--api` (drops `tailwind.config.js` + `static/css/input.css`, swaps
+`Dockerfile`/`build.rs`/CI) and `--with-i18n` (injects into `autumn.toml` and
+the `Dockerfile`); `--daemon`/`--bundled-pg` append to `autumn.toml`. `autumn
+upgrade` already exists for codemods, already resolves from/to versions from
+`Cargo.toml`, and its module doc already reserves this slot for #1593.
+
+**Red (gut).** The scary part is the write. A tool that touches `Dockerfile`
+must feel *conservative*; a single unexpected overwrite ends its adoption. The
+"conflict" outcome should feel like the normal one, not a failure.
+
+**Black (risks).** Digests are a weak baseline: reformatting on save, CRLF
+checkouts, or an `.editorconfig` trailing-newline rule flip every digest and
+turn a clean upgrade into an all-conflict wall. Mitigated by normalising CRLF
+before hashing (the renderer already normalises), and by the fact that a
+conflict is only ever *more* work, never data loss. `autumn.toml` will be a
+perpetual conflict for most real apps because it is a config file people edit —
+acceptable and honest. Flavor inference for legacy projects can be wrong; since
+legacy projects can never reach the `update` state, a wrong guess costs an
+unwanted `add` offer, which the preview shows before anything is written.
+
+**Yellow (upside).** The reconciler and the generator share one renderer, so
+this is also a de-duplication of `new.rs`. `--check` makes scaffold freshness a
+CI-gateable property — nothing in the Rust web ecosystem has that. The manifest
+is a foundation later work can build on (per-file opt-out, three-way merge).
+
+**Green (creative).** The manifest can be updated on a successful apply so the
+next upgrade's baseline is exact. Diff rendering is already written
+(`upgrade::diff`), and unlike the codemods these diffs *do* change line counts —
+so the existing "line counts differ" branch finally earns its keep, and the
+renderer becomes worth extracting properly.
+
+**Blue (process).** Ship it in TDD slices, each red → green: file set, manifest,
+classification, reporting, CLI wiring, docs. Then a multi-angle review, then
+the AC evidence table.
+
+---
+
+## 4. Design
+
+### Command surface
+
+```
+autumn upgrade                 # preview: codemods + scaffold drift
+autumn upgrade --apply         # write both
+autumn upgrade --check         # scaffold drift only; exit 3 if any
+autumn upgrade --json          # both reports, machine-readable
+```
+
+Scaffold reconciliation runs only when the root is an Autumn project — it has
+`autumn.toml` or `.autumn/scaffold.toml`. Elsewhere `autumn upgrade` behaves
+exactly as it did.
+
+### Framework-owned set (the allowlist)
+
+Common: `autumn.toml`, `Dockerfile`, `.dockerignore`, `build.rs`, `.gitignore`,
+`.env.example`, `.github/workflows/ci.yml`, `rust-toolchain.toml`,
+`rustfmt.toml`, `clippy.toml`.
+Fullstack only: `tailwind.config.js`, `static/css/input.css`.
+
+Deliberately **not** owned: `src/**` (out of bounds per the issue),
+`Cargo.toml`, `README.md`, `tests/**`, `migrations/**`, `i18n/**`,
+`config/credentials/**`, vendored `static/js/**`.
+
+### Provenance — `.autumn/scaffold.toml`
+
+```toml
+version = "0.7.0"
+flavor = "fullstack"
+i18n = false
+daemon = false
+bundled_pg = false
+
+[files]
+"clippy.toml" = "sha256 hex"
+```
+
+Written by `autumn new`, refreshed by `autumn upgrade --apply`.
+
+### Classification
+
+| Status | Condition | Applied? |
+|---|---|---|
+| `up-to-date` | on disk, bytes equal the current template | – |
+| `add` | not on disk | yes |
+| `update` | differs, and bytes still match the recorded digest | yes |
+| `conflict` (edited) | differs, and the recorded digest does not match | **no** |
+| `conflict` (no baseline) | differs, and nothing was recorded | **no** |
+| `removed` | recorded, absent on disk | **no** |
+
+### Exit codes
+
+`0` fine · `1` apply failed partway · `2` bad usage · `3` `--check` found drift.
+
+## 5. TDD slices
+
+1. **Red:** `new::framework_owned_files` unit tests (per-flavor sets, no `src/`
+   path, injections applied). **Green:** extract from `generate_inner`.
+2. **Red:** manifest round-trip + digest tests. **Green:** `Provenance`.
+3. **Red:** classification matrix. **Green:** `classify`.
+4. **Red:** report rendering + JSON. **Green:** renderers.
+5. **Red:** end-to-end integration tests against the real binary (preview,
+   apply, conflict, legacy project, `--check`, `src/` untouched).
+   **Green:** CLI wiring.
+6. **Refactor:** de-duplicate, tighten names, document.
+7. Docs guide + docs-smoke step + CHANGELOG + README.

--- a/skills/autumn-web/SKILL.md
+++ b/skills/autumn-web/SKILL.md
@@ -2114,8 +2114,10 @@ autumn release init --target azure-container-apps   # Terraform scaffold: main.t
 autumn release init --target aws-app-runner      # Fast/minimal AWS path: main.tf/variables.tf/outputs.tf/terraform.tfvars.example (ECR, App Runner behind a VPC connector, RDS Postgres, Secrets Manager). No CI workflow (#1279); see docs/guide/deployment.md.
 autumn release init --target aws-ecs             # Production AWS path: main.tf/variables.tf/outputs.tf/terraform.tfvars.example (VPC, ALB+ACM DNS-validated HTTPS, ECS Fargate w/ circuit-breaker rollback, Application Auto Scaling, RDS, opt-in Redis) + .github/workflows/aws-deploy.yml (#1279); see docs/guide/deployment.md.
 autumn release init --target gcp-cloud-run       # GCP path: main.tf/variables.tf/outputs.tf/terraform.tfvars.example (Artifact Registry, Cloud Run, Cloud SQL Postgres behind a VPC connector, Secret Manager, opt-in Memorystore Redis) + .github/workflows/gcp-deploy.yml (#1280); see docs/guide/deployment.md.
-autumn upgrade                   # preview each release's mechanical app-code migrations (renames) as a per-file diff; writes nothing
-autumn upgrade --apply           # take them; --from/--to override the range, --list-migrations shows what ships (#1629)
+autumn upgrade                   # preview BOTH halves as per-file diffs, writing nothing: each release's mechanical app-code migrations (renames), and drift between the project's framework-owned files and this release's scaffold (#1629, #1593)
+autumn upgrade --apply           # take them; --from/--to override the codemod range, --list-migrations shows what ships
+autumn upgrade --check           # scaffold files only, writes nothing, exit 3 on drift — the CI gate for scaffold freshness (#1593)
+autumn upgrade --accept <PATH>   # record a framework-owned file as the developer's own: never offered or written again, and not drift (#1593)
 autumn deploy check              # SSH/secret/DB/migrate-safety preflight per configured host; `doctor --online` runs the same graders
 autumn deploy plan               # dry-run: representative unit + ordered steps (+ fleet rollout order when `[deploy] hosts` is set)
 autumn deploy up                 # real deploy over SSH; with `[deploy] hosts` a serial rolling deploy across the fleet (#1621)
@@ -2125,13 +2127,25 @@ autumn deploy status --json --strict          # read-only per-host state + versi
 autumn deploy maintenance on --message "…"    # maintenance mode on EVERY deploy host over SSH; `off` reverses (#1621)
 ```
 
-### Upgrading an app across releases — `autumn upgrade` (0.7.0, issue #1629)
+### Upgrading an app across releases — `autumn upgrade` (0.7.0, issues #1629 and #1593)
 
-**Reach for this before hand-editing call sites out of a migration guide.**
-For each release between the `autumn-web` version the app's `Cargo.toml`
-records and the target, it applies that release's *mechanical* migrations —
-API renames — to the app's own Rust source. First shipped: 0.6.0's
-`with_pool` → `with_pool_untracked`.
+**Reach for this before hand-editing call sites out of a migration guide, or
+hand-diffing a throwaway `autumn new` project.** One run covers both halves of
+an upgrade:
+
+1. **The app's own Rust source.** For each release between the `autumn-web`
+   version `Cargo.toml` records and the target, it applies that release's
+   *mechanical* migrations — API renames — to `src/`, `tests/`, `examples/`,
+   `benches/` and every workspace member. First shipped: 0.6.0's `with_pool`
+   → `with_pool_untracked`.
+2. **The project's framework-owned files.** `Dockerfile`, `.dockerignore`,
+   `build.rs`, `autumn.toml`, `.gitignore`, `.env.example`,
+   `.github/workflows/ci.yml`, `rust-toolchain.toml`, `rustfmt.toml`,
+   `clippy.toml`, and (fullstack only) `tailwind.config.js` +
+   `static/css/input.css`, reconciled against this release's scaffold.
+   Bumping `autumn-web` updates the library, not the project skeleton, so
+   without this an app scaffolded on 0.5 keeps 0.5-vintage project files
+   forever.
 
 Three things to get right when advising on it:
 
@@ -2152,6 +2166,40 @@ Three things to get right when advising on it:
 Every breaking change in `docs/migrations/*.md` carries an `**Automation:**`
 label — `auto` (the codemod does it), `review` (it rewrites, and flags each
 site), or `manual` (read the guide section). See `docs/guide/upgrading.md`.
+
+For the scaffold half, five more things (issue #1593):
+
+- **`src/` is out of bounds.** The set is a fixed allowlist with no `src/`
+  entry, and `Cargo.toml`, `README.md`, `tests/`, `migrations/`, `i18n/`,
+  `config/credentials/` and the vendored `static/js/` assets are not
+  framework-owned either. Application code is the *first* half's business.
+- **`.autumn/scaffold.toml` is the baseline, and must be committed.**
+  `autumn new` records the scaffolding release, the flags the project was made
+  with, and a digest of every framework-owned file as Autumn wrote it. That
+  digest is the only thing that can distinguish "the template moved" from "the
+  developer edited this". Verdicts: `add` (this release's scaffold has it and
+  the project does not — including files a later release introduced),
+  `update` (template moved, the copy is provably untouched), `conflict`
+  (never written), `removed` (deleted on purpose, never restored), `pinned`
+  (accepted as the developer's).
+- **A project with no manifest still upgrades, best-effort.** Every app
+  predating this feature is in that state: missing files are still offered,
+  and everything that differs is a conflict, because "untouched" cannot be
+  proven. Never an error.
+- **A conflict has to be able to conclude.** Where a file is deliberately the
+  team's — a `Dockerfile` with their own base image — `autumn upgrade --accept
+  <path>` records it in the manifest's `pinned` list so `--check` can go green
+  again. Removing a line from that list brings the file back.
+- **Inside a Cargo workspace, member crates are not offered `clippy.toml`,
+  `rustfmt.toml`, `rust-toolchain.toml` or a CI workflow.** Those resolve from
+  the nearest ancestor, so a crate-local copy *shadows* the workspace's rather
+  than adding to it, and GitHub never runs a workflow from a subdirectory.
+
+`--to` selects which codemods run; the scaffold half always reconciles to the
+release the CLI itself ships templates for — downgrades and historical
+scaffolds are out of scope. `--json` carries the scaffold report under a
+`scaffold` key in both modes, splitting `writable` (the plan) from `written`
+(what reached disk).
 
 `autumn console` is Autumn's `rails console` equivalent. Rust has no stable
 `eval`, so it follows loco.rs's edit-and-run model instead of shipping a REPL:

--- a/skills/new/SKILL.md
+++ b/skills/new/SKILL.md
@@ -90,6 +90,7 @@ First-run checklist:
 | `src/main.rs` | AppBuilder setup — register routes, tasks, jobs, migrations here |
 | `migrations/` | Diesel migrations — one directory per migration |
 | `static/` | Static assets served at `/static/` |
+| `.autumn/scaffold.toml` | **Commit it.** Records which release's scaffold produced this project's framework-owned files (`Dockerfile`, `build.rs`, `autumn.toml`, the toolchain/style configs, the CI workflow) and a digest of each as Autumn wrote it, so a later `autumn upgrade` can tell a template that moved from a file the developer edited — and never overwrite their work. Machine-written; hand-editing it only costs conflict precision (issue #1593). |
 
 ## If autumn-cli is not installed
 


### PR DESCRIPTION
Closes #1593.

`autumn new` writes about a dozen framework-owned files into every project — `Dockerfile`, `.dockerignore`, `build.rs`, `autumn.toml`, `tailwind.config.js`, `rust-toolchain.toml`, `clippy.toml`, `rustfmt.toml`, the CI workflow, `static/css/input.css` — and those templates keep evolving. Bumping `autumn-web` in `Cargo.toml` updates the *library*, not the project skeleton, so an app scaffolded on 0.5 keeps 0.5-vintage project files forever and the only remedy was diffing a freshly generated throwaway project by hand.

`autumn upgrade` now reconciles them in the same run as the existing app-code codemods, so "bring me up to this release" is one command.

```bash
autumn upgrade            # preview: codemods + scaffold drift, nothing written
autumn upgrade --apply    # write both
autumn upgrade --check    # CI gate: exit 3 on scaffold drift
autumn upgrade --accept Dockerfile   # this file is mine; stop offering it
```

## How it works

The reconciler renders the current release's scaffold in memory and compares it against what is on disk. `autumn new` and the reconciler render from **one** shared `framework_owned_files`, so the scaffold and the upgrade cannot drift apart — a byte of disagreement would read as a permanent conflict in every project ever generated.

"May I overwrite this?" is really "did you touch it?", which neither contents nor timestamps can answer. So `autumn new` now records a baseline in `.autumn/scaffold.toml`: the scaffolding release, the flags the project was made with, and a digest of every framework-owned file as Autumn wrote it. Digests are taken over LF-normalised text, so a `core.autocrlf` checkout is not mistaken for a rewrite of every file.

| Verdict | Meaning | Written by `--apply`? |
|---|---|---|
| `add` | This release's scaffold has it, your project does not — including every file a later release introduced | yes |
| `update` | The template moved and your copy is provably untouched | yes |
| `conflict` | The template moved and your copy may be yours now | **no** |
| `removed` | Autumn wrote it once and you deleted it | **no** |
| `pinned` | You ran `--accept` on it | **no** |

Projects created before this feature have no manifest and are handled best-effort rather than refused: missing files are still offered, everything that differs is a conflict, because "untouched" cannot be proven.

Application source is out of bounds throughout — the command never reads, writes, or names a path under `src/` — and `Cargo.toml`, `README.md`, `tests/`, `migrations/`, `i18n/`, `config/credentials/` and the vendored `static/js/` assets are not framework-owned either.

## Safety posture

The command's whole contract is "never a silent overwrite", so the write path is deliberately conservative. Every byte it writes goes through **one** `publish` — one writer, one posture, because two writers with two postures is how the manifest write drifted out from under the symlink guard mid-review:

- **Nothing unreadable is ever written.** A path that is a symlink (checked along the whole chain from the project root, not just the leaf), a directory, or not UTF-8 is a conflict, not a missing file. Collapsing those into "absent" is what would classify a latin-1 `input.css` as an `add` and truncate it — and with no manifest, `add` writes with nothing vouching for it.
- **Nothing is written or read through a link.** Writing through a symlinked parent would edit a shared file the project's own `git status` can never show; *reading* a linked manifest would let whoever controls the target hand over digests that turn a file into a writable `update`.
- **Every write is staged and published by a link operation.** An addition uses a no-replace publish, so a file that appears during the staging window is never clobbered. New files land with the mode an ordinary write would give them (the umask applies, as it does in `autumn new`); replaced files keep the mode they had.
- **The plan is re-verified immediately before each write**, so a file a formatter changed in between is refused rather than reverted.
- **A manifest this CLI cannot vouch for is no baseline at all** — an unknown `flavor`, an option combination `autumn new` would refuse, or a release string that will not parse. Each drops the run onto the conservative path where every difference is a conflict.
- **A project scaffolded by a newer release is refused, not downgraded.** The manifest records `written_by` — a high-water renderer mark that advances on every write — separately from `version`, which is held back while conflicts stand. Comparing only `version` would let an older CLI trust newer digests and overwrite the files they describe. Provenance compares by full SemVer precedence, prereleases included.
- **A crate inside a Cargo workspace** — one whose own `Cargo.toml` has no `[workspace]` table — is not offered `clippy.toml`, `rustfmt.toml`, `rust-toolchain.toml` or a CI workflow: those resolve from the nearest ancestor, so a crate-local copy *shadows* the workspace's rather than adding to it, and GitHub never runs a workflow from a subdirectory.

## Acceptance criteria

| # | Criterion | Evidence |
|---|---|---|
| 1 | Lists every drifted framework-owned file, including ones the old release never generated | `classify` in `upgrade/scaffold.rs`; `a_file_the_old_release_never_generated_is_offered_as_an_addition`, integration `an_older_project_is_offered_the_files_this_release_added`. Verified: an aged app is offered `rust-toolchain.toml` |
| 2 | Default is preview-only | `plan()` never writes; `apply()` only reachable under `--apply`. `preview_writes_nothing`, `an_older_project_is_offered_the_files_this_release_added` asserts absence on disk |
| 3 | Never silently overwrites; revert path documented | `is_applied()` excludes every conflict; `an_edited_file_is_a_conflict_and_survives_apply_byte_for_byte`, `a_file_that_is_not_utf8_is_never_treated_as_missing_and_overwritten`, `a_symlinked_scaffold_file_is_never_written_through`. Revert (`git status` / `git checkout --` for updates, `rm` for adds) is in the report itself and in the guide |
| 4 | `src/` out of bounds | Static allowlist with a `debug_assert!`; `framework_owned_set_never_reaches_into_src`, `classification_never_names_a_path_under_src`, integration `application_source_is_never_touched`. Verified: `src/`, `Cargo.toml`, `README.md`, `tests/`, `config/` byte-identical after `--apply` |
| 5 | New projects record their baseline; older ones still upgrade | `autumn new` writes `.autumn/scaffold.toml`; `a_new_project_records_the_release_that_scaffolded_it`, `a_project_predating_provenance_still_upgrades_best_effort` |
| 6 | Check mode exits nonzero on drift | `--check` → exit `3`; `check_exits_nonzero_on_drift_and_zero_when_clean` and five sibling tests. A deliberately deleted or accepted file does not hold the gate red; a run that could not look exits `2` rather than reporting a clean project |
| 7 | Summary links the release's upgrade guide | `release_guide` resolves against the shipped migration registry, falling back to the index so the link always opens; on every path including `--check`. Verified HTTP 200 |
| 8 | Docs guide covers it end to end and passes docs-smoke | New "Scaffold files" section in `docs/guide/upgrading.md`; `docs/guide/docs-smoke.md` gained a Scaffold Reconciliation block, run verbatim and passing |

Out of scope per the issue and honoured: no codemods added, no dependency bumps, no runtime deprecation warnings, and no downgrades — `--to` selects codemods only, and the scaffold half always targets the one release this CLI ships templates for.

## Testing

- 68 unit tests in `upgrade::scaffold`, 29 integration tests in `tests/integration/upgrade_scaffold.rs` driving the real binary
- `cargo test -p autumn-cli`: 5717 unit + 812 integration passing
- `cargo test --workspace --no-run`: clean
- `cargo clippy -p autumn-cli --all-targets -- -D warnings`: no new findings
- The docs-smoke procedure and the guide's end-to-end walkthrough both run verbatim

Built red → green → refactor throughout; every behaviour here has a test that failed before its implementation landed. Reviewed from security/data-loss, correctness, documentation, and acceptance-criteria angles before opening, and then across fifteen rounds of automated review — the fixes from all of that are the eighteen commits after the first.

## A known flaky check (not this PR's)

`Test (macos-latest)` failed once on this commit, on `integration::rich_text::deeply_nested_blocks_render_in_linear_time` — a 5s wall-clock ceiling in `autumn-web`'s rich-text renderer that took 13.8s. **It passed on re-run and CI is green.** Recorded here because the flake will recur on other PRs.

Four facts place it outside this PR, detailed in [this comment](https://github.com/autumn-foundation/autumn/pull/2340#issuecomment-5445702482) and [its follow-up](https://github.com/autumn-foundation/autumn/pull/2340#issuecomment-5446122427):

1. `trunk-dev` at `eba7fc6` — this PR's exact merge base — fails the identical test at the same line, as its only failed job.
2. This PR touches **zero** files under `autumn/`.
3. `Test (ubuntu-latest)` passed on this exact commit, same test, in the same run.
4. The same commit, unchanged, passed on the second attempt — a quadratic regression would fail deterministically.

So the renderer has not regressed to super-linear behaviour; the ceiling is simply too tight for the macOS runner class, whose `Run tests` step takes 45+ minutes. Worth fixing on its own, but not from here, and the test was deliberately not loosened or skipped.

## Deferred follow-ups

Four findings from the later review rounds are tracked separately rather than extending this PR further. All are real; none can cause a wrong write:

- [#2342](https://github.com/autumn-foundation/autumn/issues/2342) — `publish` needs compare-and-swap. Covers both the scaffold-file replacement race and concurrent manifest writes, which are one missing mechanism in one function. Fails safe: a lost pin means a file is reported as a `conflict` again, never written.
- [#2343](https://github.com/autumn-foundation/autumn/issues/2343) — a preview diffs `build.rs` against pre-codemod bytes. The *verdict* is already correct in both modes (a conflict either way, so the file is never written); the advisory diff beside it is what differs.
- [#2344](https://github.com/autumn-foundation/autumn/issues/2344) — `.github/workflows/ci.yml` ownership should follow the git root, not the Cargo workspace root. Comes apart only for a nested repo or submodule inside a workspace, and errs safe: the file is declined rather than wrongly written.
- [#2346](https://github.com/autumn-foundation/autumn/issues/2346) — **a design question, not a defect**: should a symlink whose target matches the template count as `current` (today) or as a `conflict`? A symlink is never written either way; the disagreement is what `--check` reports. Worth a deliberate call rather than a late edit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017RgcJLiHdKYQa1VPAK7ksN