### PR TITLE
perf(macros): feature-gate the database codegen behind `db` (#2309)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -527,9 +527,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   compiling them and throwing them away. Measured on a 4-core box, a debug build
   of `autumn-macros` drops from 31.1s to 2.7s (-91%) with `db` off; the crate sits
   on the serial critical path of a first build (nothing else starts until it
-  finishes), so that time comes straight off cold-start onboarding
-  (issue #2309). A DB-backed app enables `db` and is unaffected — same macros,
-  same expansions. The serde / JSON-schema field helpers shared with
+  finishes), so that time comes straight off cold-start onboarding. End to end,
+  `autumn dev-loop-bench --cold-start` — `autumn new` to the first HTTP 200 for
+  the no-DB starter — drops from 136.6s to 90.8s (-33%) on the same box. That
+  does not on its own bring the gate's p95 60s / max 90s budget green, so the
+  budget question issue #2309 raises stays open (issue #2309). A DB-backed app
+  enables `db` and is unaffected — same macros, same expansions. The serde /
+  JSON-schema field helpers shared with
   `#[derive(OpenApiSchema)]` moved out of `model.rs` into a new always-compiled
   `schema` module, so the derive keeps working (and keeps its tests) with `db`
   off. Direct dependants of `autumn-macros` see no change: `db` is on by default

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -516,6 +516,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Performance
 
+- **a no-database app no longer compiles the framework's database codegen:**
+  `autumn-macros` had no `[features]` section at all, so `model.rs` and
+  `repository.rs` — together ~40k of the crate's ~60k lines, and the bulk of its
+  compile time — were built in full for every consuming app, including one that
+  can reach neither macro (`autumn-web` already gates both re-exports on its own
+  `db` feature). `autumn-macros` now has a default-on `db` feature covering that
+  codegen, and `autumn-web` takes the crate with `default-features = false` and
+  forwards its own `db` to it, so a DB-free app skips the modules instead of
+  compiling them and throwing them away. Measured on a 4-core box, a debug build
+  of `autumn-macros` drops from 31.1s to 2.7s (-91%) with `db` off; the crate sits
+  on the serial critical path of a first build (nothing else starts until it
+  finishes), so that time comes straight off cold-start onboarding
+  (issue #2309). A DB-backed app enables `db` and is unaffected — same macros,
+  same expansions. The serde / JSON-schema field helpers shared with
+  `#[derive(OpenApiSchema)]` moved out of `model.rs` into a new always-compiled
+  `schema` module, so the derive keeps working (and keeps its tests) with `db`
+  off. Direct dependants of `autumn-macros` see no change: `db` is on by default
+  there.
+
 - **`autumn-search`'s Postgres backend now batches a document write into one
   statement instead of one per document:** `PostgresSearchStore::write_documents`
   — the single write path behind both `SearchBackend::index` and

--- a/autumn-edge/Cargo.toml
+++ b/autumn-edge/Cargo.toml
@@ -20,7 +20,10 @@ categories = ["web-programming", "wasm"]
 # crate declares the same 0.8 release line on its own with
 # `default-features = false`. Cargo still resolves both to one `axum 0.8.x` in
 # `Cargo.lock`; only the per-target feature set differs.
-autumn-macros = { version = "0.7.0", path = "../autumn-macros" }
+# Only the `#[edge]` / `edge_routes!` codegen is needed here, so the macro
+# crate's database codegen stays off (issue #2309). Leaving it on would also
+# feature-unify `autumn-macros/db` back on for every app that enables `edge`.
+autumn-macros = { version = "0.7.0", path = "../autumn-macros", default-features = false }
 axum = { version = "0.8", default-features = false, features = ["json", "query"] }
 # Not pinned in `[workspace.dependencies]`; matches the `base64 = "0.22"` line
 # already used by `autumn`, `autumn-cli`, and `examples/todo-app`.

--- a/autumn-macros/Cargo.toml
+++ b/autumn-macros/Cargo.toml
@@ -14,6 +14,18 @@ categories = ["web-programming", "web-programming::http-server"]
 [lib]
 proc-macro = true
 
+[features]
+# `db` is on by default so a direct dependant (and `cargo test -p
+# autumn-macros`) keeps the full macro surface. `autumn-web` takes this crate
+# with `default-features = false` and forwards its own `db` feature, so a
+# no-database app never compiles the database codegen at all.
+default = ["db"]
+# Database-layer codegen: the `#[model]` and `#[repository]` attribute macros.
+# These two modules are ~40k of the crate's ~60k lines and dominate its compile
+# time, yet a no-database app can reach neither macro — `autumn-web` already
+# gates both re-exports on its own `db` feature (issue #2309).
+db = []
+
 [dependencies]
 syn.workspace = true
 quote.workspace = true

--- a/autumn-macros/src/lib.rs
+++ b/autumn-macros/src/lib.rs
@@ -16,6 +16,7 @@ mod api_doc;
 mod authorize;
 mod cached;
 mod collect;
+#[cfg(feature = "db")]
 mod commentable;
 mod edge;
 mod edge_routes_macro;
@@ -33,6 +34,7 @@ mod mail_previews_macro;
 mod mailer;
 mod mailer_preview;
 mod main_macro;
+#[cfg(feature = "db")]
 mod model;
 mod oauth2_callback;
 mod one_off_task;
@@ -43,10 +45,12 @@ mod parse;
 mod paths_macro;
 mod public;
 mod query_budget;
+#[cfg(feature = "db")]
 mod repository;
 mod route;
 mod routes_macro;
 mod scheduled;
+mod schema;
 mod secured;
 mod service;
 mod sim_test;
@@ -646,6 +650,7 @@ pub fn story(input: TokenStream) -> TokenStream {
 /// `react()` acquires its **own** pooled connection and does not join an
 /// enclosing `Db::tx` — do not hold a `Db` extractor across the call on a small
 /// connection pool.
+#[cfg(feature = "db")]
 #[proc_macro_attribute]
 pub fn model(attr: TokenStream, item: TokenStream) -> TokenStream {
     model::model_macro(attr.into(), item.into()).into()
@@ -712,6 +717,7 @@ pub fn derive_openapi_schema(input: TokenStream) -> TokenStream {
 /// #[repository(LedgerEntry, primary_reads)]
 /// trait LedgerEntryRepository {}
 /// ```
+#[cfg(feature = "db")]
 #[proc_macro_attribute]
 pub fn repository(attr: TokenStream, item: TokenStream) -> TokenStream {
     repository::repository_macro(attr.into(), item.into()).into()

--- a/autumn-macros/src/model.rs
+++ b/autumn-macros/src/model.rs
@@ -18,6 +18,11 @@ use syn::parse::Parser as _;
 use syn::{DeriveInput, Field, LitStr};
 
 use crate::commentable::{emit_commentable_items, is_commentable_attr, resolve_commentable};
+use crate::schema::{
+    apply_serde_rename_all_rule, emit_schema_fn_body, emit_schema_fn_body_ext,
+    field_is_translatable, field_serde_serialize_rename, has_attr, is_option_type,
+    serde_rename_all_serialize_rule, type_name_str,
+};
 
 /// Parsed `#[model(...)]` attribute arguments.
 ///
@@ -68,11 +73,6 @@ fn parse_attr_args(attr: TokenStream) -> syn::Result<ModelArgs> {
     .parse2(attr)?;
 
     Ok(args)
-}
-
-/// Check if a field has the `#[id]` attribute.
-fn has_attr(field: &Field, name: &str) -> bool {
-    field.attrs.iter().any(|a| a.path().is_ident(name))
 }
 
 /// Validate the declarative-schema field markers `#[unique]` and
@@ -3184,13 +3184,6 @@ fn validate_encrypted_field(field: &syn::Field) -> syn::Result<()> {
 
 // ── #1384: `#[translatable]` field attribute ─────────────────────────────────
 
-/// Whether a field is declared `#[translatable]` (issue #1384): its column
-/// holds an `autumn_web::i18n::Translated` container — an independent value
-/// per locale tag — instead of a single monolingual string.
-fn field_is_translatable(field: &syn::Field) -> bool {
-    has_attr(field, "translatable")
-}
-
 /// Validate a `#[translatable]` field.
 ///
 /// The attribute is a marker: the *type* carries the behaviour, so the type
@@ -3601,146 +3594,6 @@ fn field_has_serde_rename(field: &syn::Field) -> bool {
         });
     }
     renamed
-}
-
-/// The struct-level `#[serde(rename_all = "...")]` casing rule that applies
-/// to *serialization*, if any. Handles both the plain form and the split
-/// `rename_all(serialize = "...", deserialize = "...")` form (taking the
-/// `serialize` side — that is what `Changeset::field_value` indexes by).
-///
-/// Same parsing convention as `field_has_serde_rename`: a `#[serde(...)]`
-/// list this parser can't fully walk simply yields no rule (the real serde
-/// derive still validates the attribute itself).
-pub fn serde_rename_all_serialize_rule(attrs: &[syn::Attribute]) -> Option<String> {
-    let mut rule = None;
-    for attr in attrs.iter().filter(|a| a.path().is_ident("serde")) {
-        let _ = attr.parse_nested_meta(|meta| {
-            if meta.path.is_ident("rename_all") {
-                if let Ok(value) = meta.value() {
-                    // rename_all = "camelCase"
-                    if let Ok(syn::Lit::Str(s)) = value.parse::<syn::Lit>() {
-                        rule = Some(s.value());
-                    }
-                } else {
-                    // rename_all(serialize = "...", deserialize = "...")
-                    let _ = meta.parse_nested_meta(|inner| {
-                        if let Ok(value) = inner.value()
-                            && let Ok(syn::Lit::Str(s)) = value.parse::<syn::Lit>()
-                            && inner.path.is_ident("serialize")
-                        {
-                            rule = Some(s.value());
-                        }
-                        Ok(())
-                    });
-                }
-            } else if let Ok(value) = meta.value() {
-                // Consume any `= value` so sibling metas keep parsing.
-                let _: syn::Result<syn::Lit> = value.parse();
-            }
-            Ok(())
-        });
-    }
-    rule
-}
-
-/// The field-level `#[serde(rename = "...")]` name that applies to
-/// *serialization*, if any. Handles both the plain form and the split
-/// `rename(serialize = "...", deserialize = "...")` form (taking the
-/// `serialize` side). Field-level `rename` overrides a struct-level
-/// `rename_all`, mirroring serde's own precedence.
-fn field_serde_serialize_rename(field: &syn::Field) -> Option<String> {
-    let mut renamed = None;
-    for attr in field.attrs.iter().filter(|a| a.path().is_ident("serde")) {
-        let _ = attr.parse_nested_meta(|meta| {
-            if meta.path.is_ident("rename") {
-                if let Ok(value) = meta.value() {
-                    // rename = "headline"
-                    if let Ok(syn::Lit::Str(s)) = value.parse::<syn::Lit>() {
-                        renamed = Some(s.value());
-                    }
-                } else {
-                    // rename(serialize = "...", deserialize = "...")
-                    let _ = meta.parse_nested_meta(|inner| {
-                        if let Ok(value) = inner.value()
-                            && let Ok(syn::Lit::Str(s)) = value.parse::<syn::Lit>()
-                            && inner.path.is_ident("serialize")
-                        {
-                            renamed = Some(s.value());
-                        }
-                        Ok(())
-                    });
-                }
-            } else if let Ok(value) = meta.value() {
-                // Consume any `= value` so sibling metas keep parsing.
-                let _: syn::Result<syn::Lit> = value.parse();
-            }
-            Ok(())
-        });
-    }
-    renamed
-}
-
-/// Apply a struct-level `#[serde(rename_all = "...")]` casing rule to a
-/// (`snake_case`) field identifier, mirroring `serde_derive`'s
-/// `RenameRule::apply_to_field`. Returns `None` for a rule string serde
-/// itself would reject (the `Serialize` derive on the emitted struct then
-/// reports the error — no point duplicating it here).
-fn apply_serde_rename_all_rule(rule: &str, field: &str) -> Option<String> {
-    fn pascal(field: &str) -> String {
-        field
-            .split('_')
-            .map(|word| {
-                let mut chars = word.chars();
-                chars.next().map_or_else(String::new, |first| {
-                    first.to_uppercase().collect::<String>() + chars.as_str()
-                })
-            })
-            .collect()
-    }
-    match rule {
-        // serde treats fields as already snake_case/lowercase.
-        "lowercase" | "snake_case" => Some(field.to_owned()),
-        "UPPERCASE" | "SCREAMING_SNAKE_CASE" => Some(field.to_ascii_uppercase()),
-        "PascalCase" => Some(pascal(field)),
-        "camelCase" => {
-            let pascal = pascal(field);
-            let mut chars = pascal.chars();
-            chars
-                .next()
-                .map(|first| first.to_lowercase().collect::<String>() + chars.as_str())
-        }
-        "kebab-case" => Some(field.replace('_', "-")),
-        "SCREAMING-KEBAB-CASE" => Some(field.to_ascii_uppercase().replace('_', "-")),
-        _ => None,
-    }
-}
-
-/// The JSON-schema property name a field serializes to, honoring serde attrs.
-///
-/// Precedence mirrors serde: a field-level `#[serde(rename = "...")]` wins over
-/// a container `#[serde(rename_all = "...")]`, which in turn overrides the raw
-/// identifier. The raw-ident prefix (`r#`) is stripped first, so a field
-/// `r#type` advertises the property name `"type"` (what the handler actually
-/// deserializes), never the literal `"r#type"`.
-///
-/// KNOWN LIMITATION: this uses the *serialize* side of a split
-/// `#[serde(rename(serialize = ..., deserialize = ...))]` /
-/// `#[serde(rename_all(serialize = ..., deserialize = ...))]`. For the common
-/// symmetric `rename` / `rename_all` (which apply to both sides) this is exact;
-/// only the rare split-form input struct could differ between the advertised
-/// schema and the deserialized wire name. This is deliberate: it keeps the
-/// `#[derive(OpenApiSchema)]`, `#[model]`, and `FormModel` code paths in
-/// lockstep on the same serde helpers rather than duplicating a
-/// deserialize-side variant.
-fn schema_property_name(field: &syn::Field, rename_all_rule: Option<&str>) -> Option<String> {
-    let ident = field.ident.as_ref()?;
-    let raw = ident.to_string();
-    let raw = raw.strip_prefix("r#").unwrap_or(&raw).to_owned();
-    Some(
-        field_serde_serialize_rename(field)
-            .or_else(|| rename_all_rule.and_then(|rule| apply_serde_rename_all_rule(rule, &raw)))
-            .unwrap_or(raw),
-    )
 }
 
 /// Parse the struct-level language dictionary configuration from `#[searchable(language = "...")]`
@@ -4223,23 +4076,6 @@ fn pascal_case(s: &str) -> String {
         .collect()
 }
 
-/// Check whether a type is `Option<...>`.
-fn is_option_type(ty: &syn::Type) -> bool {
-    if let syn::Type::Path(tp) = ty {
-        tp.path
-            .segments
-            .last()
-            .is_some_and(|seg| seg.ident == "Option")
-    } else {
-        false
-    }
-}
-
-/// Return the final path segment name of a type (e.g. `foo::Bar` → `"Bar"`).
-fn type_name_str(ty: &syn::Type) -> String {
-    crate::api_doc::last_segment_name(ty).unwrap_or_else(|| "unknown".to_owned())
-}
-
 /// Humanize a `snake_case` field name into a `<label>`-friendly title
 /// (e.g. `published_at` -> `"Published At"`). Mirrors the scaffold's
 /// `humanize_label` so a derived form and a hand-written one read alike.
@@ -4437,159 +4273,6 @@ fn emit_form_model_impl(
                 ]
             }
         }
-    }
-}
-
-/// Emit the JSON-Schema `TokenStream` for one model field.
-///
-/// Identical to [`emit_json_schema_tokens`] except that a `#[translatable]`
-/// field (issue #1384) is described inline as a locale-tag→string map, which is
-/// exactly what its lossless `Serialize` emits. Without that, the field would
-/// fall through to the `$ref` branch and `autumn openapi` would ship a spec
-/// referencing a component nothing registers.
-///
-/// Keyed on the **attribute**, never on the type's name: an application type
-/// that merely happens to be called `Translated` (`domain::Translated`) keeps
-/// its ordinary `$ref`, so the advertised contract cannot silently disagree
-/// with what that type actually serializes to.
-fn emit_json_schema_tokens_for_field(field: &Field) -> TokenStream {
-    if field_is_translatable(field) {
-        return quote! {
-            ::autumn_web::reexports::serde_json::json!({
-                "type": "object",
-                "description": "Per-locale content, keyed by locale tag (issue #1384).",
-                "additionalProperties": { "type": "string" }
-            })
-        };
-    }
-    emit_json_schema_tokens(&field.ty)
-}
-
-/// Emit a `TokenStream` that evaluates (at runtime) to a `serde_json::Value`
-/// representing the JSON Schema for the given Rust type.
-///
-/// Handles `Option<T>` (nullable), `Vec<T>` (array), primitives (`String`,
-/// `i64`, etc.), and everything else as a `$ref` to a component schema.
-fn emit_json_schema_tokens(ty: &syn::Type) -> TokenStream {
-    // Option<T> → OpenAPI 3.1 nullable: oneOf [{T-schema}, {type:null}]
-    if let Some(inner) = crate::api_doc::unwrap_single_generic(ty, "Option") {
-        let inner_tokens = emit_json_schema_tokens(&inner);
-        return quote! {{
-            let __inner = #inner_tokens;
-            ::autumn_web::reexports::serde_json::json!({ "oneOf": [__inner, { "type": "null" }] })
-        }};
-    }
-
-    // Vec<T> → {"type": "array", "items": <T-schema>}
-    if let Some(inner) = crate::api_doc::unwrap_single_generic(ty, "Vec") {
-        let inner_tokens = emit_json_schema_tokens(&inner);
-        return quote! {{
-            let __items = #inner_tokens;
-            ::autumn_web::reexports::serde_json::json!({ "type": "array", "items": __items })
-        }};
-    }
-
-    let name = type_name_str(ty);
-    crate::api_doc::primitive_json_type(&name).map_or_else(
-        || {
-            // Emit the `$ref` against the field type's FULL `type_name` identity
-            // (built at runtime), NOT its short last segment, so the finalize
-            // collision index can match this nested ref to the exact producing
-            // type and rewrite it to the same display key the top-level route
-            // refs use — even when two types share a last segment (issue #1972).
-            quote! {{
-                let __ref_path = ::std::format!(
-                    "#/components/schemas/{}",
-                    ::core::any::type_name::<#ty>()
-                );
-                ::autumn_web::reexports::serde_json::json!({ "$ref": __ref_path })
-            }}
-        },
-        |json_type| {
-            quote! { ::autumn_web::reexports::serde_json::json!({ "type": #json_type }) }
-        },
-    )
-}
-
-/// Emit the body of `OpenApiSchema::schema()` for a list of fields.
-///
-/// `all_optional` is `true` for `UpdateX` structs where every field is
-/// conceptually optional (backed by `Patch<T>`).
-pub fn emit_schema_fn_body(
-    fields: &[&&Field],
-    all_optional: bool,
-    rename_all_rule: Option<&str>,
-) -> TokenStream {
-    emit_schema_fn_body_ext(fields, all_optional, &[], rename_all_rule)
-}
-
-fn emit_schema_fn_body_ext(
-    fields: &[&&Field],
-    all_optional: bool,
-    extra_required: &[&&Field],
-    rename_all_rule: Option<&str>,
-) -> TokenStream {
-    // Resolve each field's advertised property name once — through the shared
-    // serde helpers so the schema honors `#[serde(rename)]` /
-    // `#[serde(rename_all)]` and strips raw-ident `r#` prefixes — and reuse the
-    // same resolved name for BOTH the property key and the `required` entry, so
-    // the two can never drift.
-    let insertions: Vec<TokenStream> = fields
-        .iter()
-        .chain(extra_required.iter())
-        .map(|f| {
-            let field_name = schema_property_name(f, rename_all_rule)
-                .unwrap_or_else(|| f.ident.as_ref().unwrap().to_string());
-            let schema_expr = emit_json_schema_tokens_for_field(f);
-            quote! {
-                __props.insert(#field_name.to_owned(), #schema_expr);
-            }
-        })
-        .collect();
-
-    let mut required_names: Vec<String> = if all_optional {
-        Vec::new()
-    } else {
-        fields
-            .iter()
-            .filter(|f| !is_option_type(&f.ty))
-            .filter_map(|f| schema_property_name(f, rename_all_rule))
-            .collect()
-    };
-    for f in extra_required {
-        if let Some(name) = schema_property_name(f, rename_all_rule) {
-            required_names.push(name);
-        }
-    }
-
-    let required_tokens: Vec<TokenStream> = required_names
-        .iter()
-        .map(|name| {
-            quote! { ::autumn_web::reexports::serde_json::json!(#name) }
-        })
-        .collect();
-
-    quote! {
-        let mut __props = ::autumn_web::reexports::serde_json::Map::new();
-        #(#insertions)*
-        let mut __schema = ::autumn_web::reexports::serde_json::Map::new();
-        __schema.insert(
-            "type".to_owned(),
-            ::autumn_web::reexports::serde_json::json!("object"),
-        );
-        __schema.insert(
-            "properties".to_owned(),
-            ::autumn_web::reexports::serde_json::Value::Object(__props),
-        );
-        let __required: ::std::vec::Vec<::autumn_web::reexports::serde_json::Value> =
-            ::std::vec![#(#required_tokens),*];
-        if !__required.is_empty() {
-            __schema.insert(
-                "required".to_owned(),
-                ::autumn_web::reexports::serde_json::Value::Array(__required),
-            );
-        }
-        ::autumn_web::reexports::serde_json::Value::Object(__schema)
     }
 }
 
@@ -8338,116 +8021,6 @@ mod tests {
             u128_expr.contains("as u128"),
             "u128 must be matched: {u128_expr}"
         );
-    }
-
-    // ── Serde-rename resolution for FormField::value_name (#1135) ─────────
-
-    #[test]
-    fn field_serde_serialize_rename_parses_plain_and_split_forms() {
-        let field: syn::Field = syn::Field::parse_named
-            .parse2(quote! { #[serde(rename = "headline")] pub title: String })
-            .unwrap();
-        assert_eq!(
-            field_serde_serialize_rename(&field).as_deref(),
-            Some("headline")
-        );
-
-        let field: syn::Field = syn::Field::parse_named
-            .parse2(quote! {
-                #[serde(rename(serialize = "out", deserialize = "in"))]
-                pub title: String
-            })
-            .unwrap();
-        assert_eq!(field_serde_serialize_rename(&field).as_deref(), Some("out"));
-
-        // Deserialize-only rename leaves the serialized key alone.
-        let field: syn::Field = syn::Field::parse_named
-            .parse2(quote! { #[serde(rename(deserialize = "in"))] pub title: String })
-            .unwrap();
-        assert_eq!(field_serde_serialize_rename(&field), None);
-
-        let field: syn::Field = syn::Field::parse_named
-            .parse2(quote! { #[serde(default)] pub title: String })
-            .unwrap();
-        assert_eq!(field_serde_serialize_rename(&field), None);
-    }
-
-    #[test]
-    fn schema_property_name_resolves_renames_and_strips_raw_idents() {
-        // field rename wins over rename_all.
-        let field: syn::Field = syn::Field::parse_named
-            .parse2(quote! { #[serde(rename = "kind")] pub category: String })
-            .unwrap();
-        assert_eq!(
-            schema_property_name(&field, Some("camelCase")).as_deref(),
-            Some("kind")
-        );
-
-        // container rename_all applies when there is no field rename.
-        let field: syn::Field = syn::Field::parse_named
-            .parse2(quote! { pub word_count: i64 })
-            .unwrap();
-        assert_eq!(
-            schema_property_name(&field, Some("camelCase")).as_deref(),
-            Some("wordCount")
-        );
-
-        // raw-ident prefix is stripped (advertise the wire name).
-        let field: syn::Field = syn::Field::parse_named
-            .parse2(quote! { pub r#type: String })
-            .unwrap();
-        assert_eq!(schema_property_name(&field, None).as_deref(), Some("type"));
-
-        // no rule, plain field → the identifier verbatim.
-        let field: syn::Field = syn::Field::parse_named
-            .parse2(quote! { pub title: String })
-            .unwrap();
-        assert_eq!(schema_property_name(&field, None).as_deref(), Some("title"));
-    }
-
-    #[test]
-    fn serde_rename_all_serialize_rule_parses_plain_and_split_forms() {
-        let attrs: Vec<syn::Attribute> =
-            vec![syn::parse_quote!(#[serde(rename_all = "camelCase")])];
-        assert_eq!(
-            serde_rename_all_serialize_rule(&attrs).as_deref(),
-            Some("camelCase")
-        );
-
-        let attrs: Vec<syn::Attribute> = vec![syn::parse_quote!(
-            #[serde(rename_all(serialize = "kebab-case", deserialize = "camelCase"))]
-        )];
-        assert_eq!(
-            serde_rename_all_serialize_rule(&attrs).as_deref(),
-            Some("kebab-case")
-        );
-
-        let attrs: Vec<syn::Attribute> = vec![syn::parse_quote!(#[serde(deny_unknown_fields)])];
-        assert_eq!(serde_rename_all_serialize_rule(&attrs), None);
-    }
-
-    #[test]
-    fn apply_serde_rename_all_rule_mirrors_serde_field_casings() {
-        let cases = [
-            ("lowercase", "word_count", "word_count"),
-            ("snake_case", "word_count", "word_count"),
-            ("UPPERCASE", "word_count", "WORD_COUNT"),
-            ("SCREAMING_SNAKE_CASE", "word_count", "WORD_COUNT"),
-            ("PascalCase", "word_count", "WordCount"),
-            ("camelCase", "word_count", "wordCount"),
-            ("camelCase", "title", "title"),
-            ("kebab-case", "word_count", "word-count"),
-            ("SCREAMING-KEBAB-CASE", "word_count", "WORD-COUNT"),
-        ];
-        for (rule, field, expected) in cases {
-            assert_eq!(
-                apply_serde_rename_all_rule(rule, field).as_deref(),
-                Some(expected),
-                "rule {rule} on {field}"
-            );
-        }
-        // A rule serde itself rejects resolves to no rename here.
-        assert_eq!(apply_serde_rename_all_rule("bogusCase", "word_count"), None);
     }
 
     // ── RED: #[lock_version] detection ────────────────────────────────────

--- a/autumn-macros/src/openapi_schema.rs
+++ b/autumn-macros/src/openapi_schema.rs
@@ -9,7 +9,7 @@
 //! `{"type":"object","title":"X"}` placeholder.
 //!
 //! This derive mirrors the schema `#[model]` already generates
-//! (`crate::model::emit_schema_fn_body`): each field becomes a JSON-schema
+//! (`crate::schema::emit_schema_fn_body`): each field becomes a JSON-schema
 //! property and every non-`Option` field is `required`. It additionally submits
 //! the schema into the compile-time `DerivedSchemaDescriptor` inventory that the
 //! spec/MCP back-fill loops consult, so a referenced struct resolves to its real
@@ -66,9 +66,9 @@ pub fn derive_openapi_schema(input: TokenStream) -> TokenStream {
     // Honor a container `#[serde(rename_all = "...")]` on the derived struct so
     // the advertised property names + `required` entries match the serialized
     // wire names — same helper/precedence `#[model]` and `FormModel` use.
-    let rename_all_rule = crate::model::serde_rename_all_serialize_rule(&input.attrs);
+    let rename_all_rule = crate::schema::serde_rename_all_serialize_rule(&input.attrs);
     let schema_body =
-        crate::model::emit_schema_fn_body(&field_ref_refs, false, rename_all_rule.as_deref());
+        crate::schema::emit_schema_fn_body(&field_ref_refs, false, rename_all_rule.as_deref());
 
     quote! {
         impl ::autumn_web::openapi::OpenApiSchema for #name {

--- a/autumn-macros/src/schema.rs
+++ b/autumn-macros/src/schema.rs
@@ -1,0 +1,454 @@
+//! Field-level serde / JSON-schema helpers shared by the `#[model]` macro and
+//! the `#[derive(OpenApiSchema)]` derive.
+//!
+//! These live in their own module (rather than inside [`crate::model`]) so the
+//! always-compiled `OpenApiSchema` derive does not drag the database-oriented
+//! `#[model]` codegen — which is gated behind the crate's `db` feature — into
+//! a no-database build. See `openapi_schema.rs` for the derive and `model.rs`
+//! for the macro; both go through the helpers here so a schema advertised by
+//! one matches the schema advertised by the other.
+
+use proc_macro2::TokenStream;
+use quote::quote;
+use syn::Field;
+
+/// Whether a field carries the named marker attribute (e.g. `#[id]`).
+pub fn has_attr(field: &Field, name: &str) -> bool {
+    field.attrs.iter().any(|a| a.path().is_ident(name))
+}
+
+/// Whether a field is declared `#[translatable]` (issue #1384): its column
+/// holds an `autumn_web::i18n::Translated` container — an independent value
+/// per locale tag — instead of a single monolingual string.
+pub fn field_is_translatable(field: &syn::Field) -> bool {
+    has_attr(field, "translatable")
+}
+
+/// The struct-level `#[serde(rename_all = "...")]` casing rule that applies
+/// to *serialization*, if any. Handles both the plain form and the split
+/// `rename_all(serialize = "...", deserialize = "...")` form (taking the
+/// `serialize` side — that is what `Changeset::field_value` indexes by).
+///
+/// Same parsing convention as `field_has_serde_rename`: a `#[serde(...)]`
+/// list this parser can't fully walk simply yields no rule (the real serde
+/// derive still validates the attribute itself).
+pub fn serde_rename_all_serialize_rule(attrs: &[syn::Attribute]) -> Option<String> {
+    let mut rule = None;
+    for attr in attrs.iter().filter(|a| a.path().is_ident("serde")) {
+        let _ = attr.parse_nested_meta(|meta| {
+            if meta.path.is_ident("rename_all") {
+                if let Ok(value) = meta.value() {
+                    // rename_all = "camelCase"
+                    if let Ok(syn::Lit::Str(s)) = value.parse::<syn::Lit>() {
+                        rule = Some(s.value());
+                    }
+                } else {
+                    // rename_all(serialize = "...", deserialize = "...")
+                    let _ = meta.parse_nested_meta(|inner| {
+                        if let Ok(value) = inner.value()
+                            && let Ok(syn::Lit::Str(s)) = value.parse::<syn::Lit>()
+                            && inner.path.is_ident("serialize")
+                        {
+                            rule = Some(s.value());
+                        }
+                        Ok(())
+                    });
+                }
+            } else if let Ok(value) = meta.value() {
+                // Consume any `= value` so sibling metas keep parsing.
+                let _: syn::Result<syn::Lit> = value.parse();
+            }
+            Ok(())
+        });
+    }
+    rule
+}
+
+/// The field-level `#[serde(rename = "...")]` name that applies to
+/// *serialization*, if any. Handles both the plain form and the split
+/// `rename(serialize = "...", deserialize = "...")` form (taking the
+/// `serialize` side). Field-level `rename` overrides a struct-level
+/// `rename_all`, mirroring serde's own precedence.
+pub fn field_serde_serialize_rename(field: &syn::Field) -> Option<String> {
+    let mut renamed = None;
+    for attr in field.attrs.iter().filter(|a| a.path().is_ident("serde")) {
+        let _ = attr.parse_nested_meta(|meta| {
+            if meta.path.is_ident("rename") {
+                if let Ok(value) = meta.value() {
+                    // rename = "headline"
+                    if let Ok(syn::Lit::Str(s)) = value.parse::<syn::Lit>() {
+                        renamed = Some(s.value());
+                    }
+                } else {
+                    // rename(serialize = "...", deserialize = "...")
+                    let _ = meta.parse_nested_meta(|inner| {
+                        if let Ok(value) = inner.value()
+                            && let Ok(syn::Lit::Str(s)) = value.parse::<syn::Lit>()
+                            && inner.path.is_ident("serialize")
+                        {
+                            renamed = Some(s.value());
+                        }
+                        Ok(())
+                    });
+                }
+            } else if let Ok(value) = meta.value() {
+                // Consume any `= value` so sibling metas keep parsing.
+                let _: syn::Result<syn::Lit> = value.parse();
+            }
+            Ok(())
+        });
+    }
+    renamed
+}
+
+/// Apply a struct-level `#[serde(rename_all = "...")]` casing rule to a
+/// (`snake_case`) field identifier, mirroring `serde_derive`'s
+/// `RenameRule::apply_to_field`. Returns `None` for a rule string serde
+/// itself would reject (the `Serialize` derive on the emitted struct then
+/// reports the error — no point duplicating it here).
+pub fn apply_serde_rename_all_rule(rule: &str, field: &str) -> Option<String> {
+    fn pascal(field: &str) -> String {
+        field
+            .split('_')
+            .map(|word| {
+                let mut chars = word.chars();
+                chars.next().map_or_else(String::new, |first| {
+                    first.to_uppercase().collect::<String>() + chars.as_str()
+                })
+            })
+            .collect()
+    }
+    match rule {
+        // serde treats fields as already snake_case/lowercase.
+        "lowercase" | "snake_case" => Some(field.to_owned()),
+        "UPPERCASE" | "SCREAMING_SNAKE_CASE" => Some(field.to_ascii_uppercase()),
+        "PascalCase" => Some(pascal(field)),
+        "camelCase" => {
+            let pascal = pascal(field);
+            let mut chars = pascal.chars();
+            chars
+                .next()
+                .map(|first| first.to_lowercase().collect::<String>() + chars.as_str())
+        }
+        "kebab-case" => Some(field.replace('_', "-")),
+        "SCREAMING-KEBAB-CASE" => Some(field.to_ascii_uppercase().replace('_', "-")),
+        _ => None,
+    }
+}
+
+/// The JSON-schema property name a field serializes to, honoring serde attrs.
+///
+/// Precedence mirrors serde: a field-level `#[serde(rename = "...")]` wins over
+/// a container `#[serde(rename_all = "...")]`, which in turn overrides the raw
+/// identifier. The raw-ident prefix (`r#`) is stripped first, so a field
+/// `r#type` advertises the property name `"type"` (what the handler actually
+/// deserializes), never the literal `"r#type"`.
+///
+/// KNOWN LIMITATION: this uses the *serialize* side of a split
+/// `#[serde(rename(serialize = ..., deserialize = ...))]` /
+/// `#[serde(rename_all(serialize = ..., deserialize = ...))]`. For the common
+/// symmetric `rename` / `rename_all` (which apply to both sides) this is exact;
+/// only the rare split-form input struct could differ between the advertised
+/// schema and the deserialized wire name. This is deliberate: it keeps the
+/// `#[derive(OpenApiSchema)]`, `#[model]`, and `FormModel` code paths in
+/// lockstep on the same serde helpers rather than duplicating a
+/// deserialize-side variant.
+pub fn schema_property_name(
+    field: &syn::Field,
+    rename_all_rule: Option<&str>,
+) -> Option<String> {
+    let ident = field.ident.as_ref()?;
+    let raw = ident.to_string();
+    let raw = raw.strip_prefix("r#").unwrap_or(&raw).to_owned();
+    Some(
+        field_serde_serialize_rename(field)
+            .or_else(|| rename_all_rule.and_then(|rule| apply_serde_rename_all_rule(rule, &raw)))
+            .unwrap_or(raw),
+    )
+}
+
+/// Check whether a type is `Option<...>`.
+pub fn is_option_type(ty: &syn::Type) -> bool {
+    if let syn::Type::Path(tp) = ty {
+        tp.path
+            .segments
+            .last()
+            .is_some_and(|seg| seg.ident == "Option")
+    } else {
+        false
+    }
+}
+
+/// Return the final path segment name of a type (e.g. `foo::Bar` → `"Bar"`).
+pub fn type_name_str(ty: &syn::Type) -> String {
+    crate::api_doc::last_segment_name(ty).unwrap_or_else(|| "unknown".to_owned())
+}
+
+/// Emit the JSON-Schema `TokenStream` for one model field.
+///
+/// Identical to [`emit_json_schema_tokens`] except that a `#[translatable]`
+/// field (issue #1384) is described inline as a locale-tag→string map, which is
+/// exactly what its lossless `Serialize` emits. Without that, the field would
+/// fall through to the `$ref` branch and `autumn openapi` would ship a spec
+/// referencing a component nothing registers.
+///
+/// Keyed on the **attribute**, never on the type's name: an application type
+/// that merely happens to be called `Translated` (`domain::Translated`) keeps
+/// its ordinary `$ref`, so the advertised contract cannot silently disagree
+/// with what that type actually serializes to.
+pub fn emit_json_schema_tokens_for_field(field: &Field) -> TokenStream {
+    if field_is_translatable(field) {
+        return quote! {
+            ::autumn_web::reexports::serde_json::json!({
+                "type": "object",
+                "description": "Per-locale content, keyed by locale tag (issue #1384).",
+                "additionalProperties": { "type": "string" }
+            })
+        };
+    }
+    emit_json_schema_tokens(&field.ty)
+}
+
+/// Emit a `TokenStream` that evaluates (at runtime) to a `serde_json::Value`
+/// representing the JSON Schema for the given Rust type.
+///
+/// Handles `Option<T>` (nullable), `Vec<T>` (array), primitives (`String`,
+/// `i64`, etc.), and everything else as a `$ref` to a component schema.
+pub fn emit_json_schema_tokens(ty: &syn::Type) -> TokenStream {
+    // Option<T> → OpenAPI 3.1 nullable: oneOf [{T-schema}, {type:null}]
+    if let Some(inner) = crate::api_doc::unwrap_single_generic(ty, "Option") {
+        let inner_tokens = emit_json_schema_tokens(&inner);
+        return quote! {{
+            let __inner = #inner_tokens;
+            ::autumn_web::reexports::serde_json::json!({ "oneOf": [__inner, { "type": "null" }] })
+        }};
+    }
+
+    // Vec<T> → {"type": "array", "items": <T-schema>}
+    if let Some(inner) = crate::api_doc::unwrap_single_generic(ty, "Vec") {
+        let inner_tokens = emit_json_schema_tokens(&inner);
+        return quote! {{
+            let __items = #inner_tokens;
+            ::autumn_web::reexports::serde_json::json!({ "type": "array", "items": __items })
+        }};
+    }
+
+    let name = type_name_str(ty);
+    crate::api_doc::primitive_json_type(&name).map_or_else(
+        || {
+            // Emit the `$ref` against the field type's FULL `type_name` identity
+            // (built at runtime), NOT its short last segment, so the finalize
+            // collision index can match this nested ref to the exact producing
+            // type and rewrite it to the same display key the top-level route
+            // refs use — even when two types share a last segment (issue #1972).
+            quote! {{
+                let __ref_path = ::std::format!(
+                    "#/components/schemas/{}",
+                    ::core::any::type_name::<#ty>()
+                );
+                ::autumn_web::reexports::serde_json::json!({ "$ref": __ref_path })
+            }}
+        },
+        |json_type| {
+            quote! { ::autumn_web::reexports::serde_json::json!({ "type": #json_type }) }
+        },
+    )
+}
+
+/// Emit the body of `OpenApiSchema::schema()` for a list of fields.
+///
+/// `all_optional` is `true` for `UpdateX` structs where every field is
+/// conceptually optional (backed by `Patch<T>`).
+pub fn emit_schema_fn_body(
+    fields: &[&&Field],
+    all_optional: bool,
+    rename_all_rule: Option<&str>,
+) -> TokenStream {
+    emit_schema_fn_body_ext(fields, all_optional, &[], rename_all_rule)
+}
+
+pub fn emit_schema_fn_body_ext(
+    fields: &[&&Field],
+    all_optional: bool,
+    extra_required: &[&&Field],
+    rename_all_rule: Option<&str>,
+) -> TokenStream {
+    // Resolve each field's advertised property name once — through the shared
+    // serde helpers so the schema honors `#[serde(rename)]` /
+    // `#[serde(rename_all)]` and strips raw-ident `r#` prefixes — and reuse the
+    // same resolved name for BOTH the property key and the `required` entry, so
+    // the two can never drift.
+    let insertions: Vec<TokenStream> = fields
+        .iter()
+        .chain(extra_required.iter())
+        .map(|f| {
+            let field_name = schema_property_name(f, rename_all_rule)
+                .unwrap_or_else(|| f.ident.as_ref().unwrap().to_string());
+            let schema_expr = emit_json_schema_tokens_for_field(f);
+            quote! {
+                __props.insert(#field_name.to_owned(), #schema_expr);
+            }
+        })
+        .collect();
+
+    let mut required_names: Vec<String> = if all_optional {
+        Vec::new()
+    } else {
+        fields
+            .iter()
+            .filter(|f| !is_option_type(&f.ty))
+            .filter_map(|f| schema_property_name(f, rename_all_rule))
+            .collect()
+    };
+    for f in extra_required {
+        if let Some(name) = schema_property_name(f, rename_all_rule) {
+            required_names.push(name);
+        }
+    }
+
+    let required_tokens: Vec<TokenStream> = required_names
+        .iter()
+        .map(|name| {
+            quote! { ::autumn_web::reexports::serde_json::json!(#name) }
+        })
+        .collect();
+
+    quote! {
+        let mut __props = ::autumn_web::reexports::serde_json::Map::new();
+        #(#insertions)*
+        let mut __schema = ::autumn_web::reexports::serde_json::Map::new();
+        __schema.insert(
+            "type".to_owned(),
+            ::autumn_web::reexports::serde_json::json!("object"),
+        );
+        __schema.insert(
+            "properties".to_owned(),
+            ::autumn_web::reexports::serde_json::Value::Object(__props),
+        );
+        let __required: ::std::vec::Vec<::autumn_web::reexports::serde_json::Value> =
+            ::std::vec![#(#required_tokens),*];
+        if !__required.is_empty() {
+            __schema.insert(
+                "required".to_owned(),
+                ::autumn_web::reexports::serde_json::Value::Array(__required),
+            );
+        }
+        ::autumn_web::reexports::serde_json::Value::Object(__schema)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use quote::quote;
+    use syn::parse::Parser as _;
+
+    use super::*;
+
+    #[test]
+    fn field_serde_serialize_rename_parses_plain_and_split_forms() {
+        let field: syn::Field = syn::Field::parse_named
+            .parse2(quote! { #[serde(rename = "headline")] pub title: String })
+            .unwrap();
+        assert_eq!(
+            field_serde_serialize_rename(&field).as_deref(),
+            Some("headline")
+        );
+
+        let field: syn::Field = syn::Field::parse_named
+            .parse2(quote! {
+                #[serde(rename(serialize = "out", deserialize = "in"))]
+                pub title: String
+            })
+            .unwrap();
+        assert_eq!(field_serde_serialize_rename(&field).as_deref(), Some("out"));
+
+        // Deserialize-only rename leaves the serialized key alone.
+        let field: syn::Field = syn::Field::parse_named
+            .parse2(quote! { #[serde(rename(deserialize = "in"))] pub title: String })
+            .unwrap();
+        assert_eq!(field_serde_serialize_rename(&field), None);
+
+        let field: syn::Field = syn::Field::parse_named
+            .parse2(quote! { #[serde(default)] pub title: String })
+            .unwrap();
+        assert_eq!(field_serde_serialize_rename(&field), None);
+    }
+
+    #[test]
+    fn schema_property_name_resolves_renames_and_strips_raw_idents() {
+        // field rename wins over rename_all.
+        let field: syn::Field = syn::Field::parse_named
+            .parse2(quote! { #[serde(rename = "kind")] pub category: String })
+            .unwrap();
+        assert_eq!(
+            schema_property_name(&field, Some("camelCase")).as_deref(),
+            Some("kind")
+        );
+
+        // container rename_all applies when there is no field rename.
+        let field: syn::Field = syn::Field::parse_named
+            .parse2(quote! { pub word_count: i64 })
+            .unwrap();
+        assert_eq!(
+            schema_property_name(&field, Some("camelCase")).as_deref(),
+            Some("wordCount")
+        );
+
+        // raw-ident prefix is stripped (advertise the wire name).
+        let field: syn::Field = syn::Field::parse_named
+            .parse2(quote! { pub r#type: String })
+            .unwrap();
+        assert_eq!(schema_property_name(&field, None).as_deref(), Some("type"));
+
+        // no rule, plain field → the identifier verbatim.
+        let field: syn::Field = syn::Field::parse_named
+            .parse2(quote! { pub title: String })
+            .unwrap();
+        assert_eq!(schema_property_name(&field, None).as_deref(), Some("title"));
+    }
+
+    #[test]
+    fn serde_rename_all_serialize_rule_parses_plain_and_split_forms() {
+        let attrs: Vec<syn::Attribute> =
+            vec![syn::parse_quote!(#[serde(rename_all = "camelCase")])];
+        assert_eq!(
+            serde_rename_all_serialize_rule(&attrs).as_deref(),
+            Some("camelCase")
+        );
+
+        let attrs: Vec<syn::Attribute> = vec![syn::parse_quote!(
+            #[serde(rename_all(serialize = "kebab-case", deserialize = "camelCase"))]
+        )];
+        assert_eq!(
+            serde_rename_all_serialize_rule(&attrs).as_deref(),
+            Some("kebab-case")
+        );
+
+        let attrs: Vec<syn::Attribute> = vec![syn::parse_quote!(#[serde(deny_unknown_fields)])];
+        assert_eq!(serde_rename_all_serialize_rule(&attrs), None);
+    }
+
+    #[test]
+    fn apply_serde_rename_all_rule_mirrors_serde_field_casings() {
+        let cases = [
+            ("lowercase", "word_count", "word_count"),
+            ("snake_case", "word_count", "word_count"),
+            ("UPPERCASE", "word_count", "WORD_COUNT"),
+            ("SCREAMING_SNAKE_CASE", "word_count", "WORD_COUNT"),
+            ("PascalCase", "word_count", "WordCount"),
+            ("camelCase", "word_count", "wordCount"),
+            ("camelCase", "title", "title"),
+            ("kebab-case", "word_count", "word-count"),
+            ("SCREAMING-KEBAB-CASE", "word_count", "WORD-COUNT"),
+        ];
+        for (rule, field, expected) in cases {
+            assert_eq!(
+                apply_serde_rename_all_rule(rule, field).as_deref(),
+                Some(expected),
+                "rule {rule} on {field}"
+            );
+        }
+        // A rule serde itself rejects resolves to no rename here.
+        assert_eq!(apply_serde_rename_all_rule("bogusCase", "word_count"), None);
+    }
+}

--- a/autumn-macros/src/schema.rs
+++ b/autumn-macros/src/schema.rs
@@ -153,10 +153,7 @@ pub fn apply_serde_rename_all_rule(rule: &str, field: &str) -> Option<String> {
 /// `#[derive(OpenApiSchema)]`, `#[model]`, and `FormModel` code paths in
 /// lockstep on the same serde helpers rather than duplicating a
 /// deserialize-side variant.
-pub fn schema_property_name(
-    field: &syn::Field,
-    rename_all_rule: Option<&str>,
-) -> Option<String> {
+pub fn schema_property_name(field: &syn::Field, rename_all_rule: Option<&str>) -> Option<String> {
     let ident = field.ident.as_ref()?;
     let raw = ident.to_string();
     let raw = raw.strip_prefix("r#").unwrap_or(&raw).to_owned();

--- a/autumn/Cargo.toml
+++ b/autumn/Cargo.toml
@@ -39,6 +39,7 @@ mcp = ["openapi"]
 # through, so a content app can accept user Markdown without stored XSS.
 markdown = ["dep:pulldown-cmark", "dep:ammonia"]
 db = [
+    "autumn-macros/db",
     "dep:deadpool",
     "dep:diesel",
     "dep:diesel-async",
@@ -221,7 +222,12 @@ edge = ["dep:autumn-edge"]
 
 [dependencies]
 autumn-edge = { version = "0.7.0", path = "../autumn-edge", optional = true }
-autumn-macros = { version = "0.7.0", path = "../autumn-macros" }
+# `default-features = false` drops the `#[model]` / `#[repository]` codegen from
+# the macro crate; the `db` feature above forwards it back on. A no-database app
+# could never reach either macro anyway (both re-exports are `#[cfg(feature =
+# "db")]` in `src/lib.rs`), and skipping them cuts the macro crate's own compile
+# time by ~90% on the no-DB onboarding path (issue #2309).
+autumn-macros = { version = "0.7.0", path = "../autumn-macros", default-features = false }
 axum.workspace = true
 bytes = "1"
 # Best-effort ASCII folding for `slug::slugify` (issue #1260, e.g. "café" ->


### PR DESCRIPTION
Addresses the root cause named in #2309: `autumn-macros` is the single largest compile unit on the cold-start critical path, and a no-database app pays for all of it.

## The problem

`autumn-macros` had **no `[features]` section at all**, so `model.rs` and `repository.rs` — together ~40k of the crate's ~60k lines — were compiled in full for every consuming app. A no-DB app can reach neither macro: `autumn-web` already gates `pub use autumn_macros::model` and `pub use autumn_macros::repository` on its own `db` feature. It compiled that codegen and threw it away.

## Measurement first

Debug builds, `CARGO_INCREMENTAL=0`, 4-core box, modules cfg'd out one at a time to attribute the cost:

| build | time |
| --- | --- |
| `autumn-macros` as on `trunk-dev` | 31.2s |
| minus `repository.rs` | 5.4s |
| minus `repository.rs` + `model.rs` + `commentable.rs` | 2.5s |

`repository.rs` alone is ~83% of the crate's compile time. The crate sits on the *serial* critical path of a first build — nothing else starts until it finishes — so this time lands directly on the `autumn new` → first-200 journey the gate measures.

## The change

- **`autumn-macros` gains `default = ["db"]`**, with `db` gating the `model`, `repository`, and `commentable` modules and the two proc-macro entry points. Default-on means a direct dependant and `cargo test -p autumn-macros` keep the full surface — this is not a semver break for anyone depending on the crate directly.
- **The serde / JSON-schema field helpers move to a new always-compiled `schema` module.** `#[derive(OpenApiSchema)]` shared `emit_schema_fn_body` and `serde_rename_all_serialize_rule` (and their closure — 12 functions, ~310 lines) with `#[model]`, and the derive is *not* db-gated. They now live in `autumn-macros/src/schema.rs`, which both go through, so the schema the derive advertises still cannot drift from the one `#[model]` advertises. Their four unit tests moved with them, so they now run in a no-DB build too.
- **`autumn-web` takes the macro crate with `default-features = false`** and forwards `db → autumn-macros/db`.
- **`autumn-edge` takes it `default-features = false` too.** Without this, enabling `edge` would feature-unify `autumn-macros/db` back on for an app that never asked for a database.

## Result

Macro crate, debug:

| `autumn-macros` build | time |
| --- | --- |
| with `db` (a DB-backed app) | 31.07s |
| without `db` (the no-DB onboarding path) | 2.67s |

**-91%** on the no-DB path, off the serial critical path of a first build. A database-backed app enables `db` and is entirely unaffected — same macros, same expansions, same compile time.

End to end — `autumn dev-loop-bench --cold-start`, one run each, same box, same CLI binary, `AUTUMN_BENCH_AUTUMN_WEB_PATH` pointed at each tree's `autumn-web`:

| `autumn new` → first HTTP 200 (no-DB) | p95 | vs 60s budget |
| --- | --- | --- |
| `trunk-dev` | 136,594 ms | 127% over — `FAIL` |
| this branch | 90,846 ms | 51% over — `FAIL` |

**-45.7s, -33%** on the full onboarding journey.

## What this does not do

**It does not bring the gate green.** The overrun is halved, not eliminated — on this 4-core box the journey still misses both the p95 60s and the max 90s budget. CI's runner is faster (its `trunk-dev` baseline is ~108–120s, not 136s), so the real number will differ, but nobody should read this PR as closing #2309's gate failure. The budget-recalibration question that issue raises as a third option stays open, and is better answered against a real scheduled run carrying this change than guessed at here.

It also does not make a *database-backed* app's build faster — `repository.rs` still costs what it costs when you actually use it. The issue's second suggested direction (reducing the codegen-heavy patterns inside `repository.rs` itself) is untouched and still worth its own pass; at ~26s for one file it is now, by a wide margin, the largest remaining item.

## Verification

- `cargo test -p autumn-macros`: 921 unit tests pass. `--no-default-features`: 432 pass.
- `cargo check -p autumn-web` (default) and `cargo check -p autumn-web --no-default-features --features "maud,htmx,tailwind,cache-moka,http-client,reporting"` — the exact feature set `autumn new --daemon` scaffolds, i.e. what the cold-start benchmark builds — both clean.
- `cargo clippy -p autumn-macros --all-targets -- -D warnings`, with and without `db`.
- `./scripts/pre-push-check.sh` green: panic gate, determinism gate, fmt, workspace clippy `--all-targets`, the gated request-path clippy leg, workspace test-target compile, workspace doctests.