### PR TITLE
Cap workspace clippy parallelism so the Lint job stops being OOM-killed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,20 @@ jobs:
       - name: Check formatting
         run: cargo fmt --all -- --check
       - name: Clippy
-        run: cargo clippy --workspace --all-targets -- -D warnings
+        # `-j 2` caps codegen parallelism. This step checks the whole workspace
+        # with `--all-targets`, and at cargo's default (one job per core, 4 on
+        # ubuntu-latest) its peak memory exceeds the runner's 16 GB while
+        # `Checking autumn-web` — the largest crate. The runner is then
+        # reclaimed mid-step and the job reports `exit code 143` with
+        # "The runner has received a shutdown signal" and no clippy diagnostic
+        # at all, which reads like infrastructure flake rather than what it is.
+        #
+        # It is marginal rather than deterministic — the same command succeeds
+        # on some runs — so it surfaced as an intermittent red that re-running
+        # sometimes cleared, on trunk-dev and on every branch cut from it.
+        # Reproduced locally on a 15 GB box: `--workspace --all-targets` is
+        # OOM-killed at `-j 4` and completes clean at `-j 2`.
+        run: cargo clippy -j 2 --workspace --all-targets -- -D warnings
       - name: Clippy (autumn-web, gated request-path features — panic gate)
         # The default-feature Clippy above does not compile the feature-gated
         # request-path modules (channels→ws, mail→mail, sync/*→offline-sync,


### PR DESCRIPTION
## The failure

`Lint`'s first step, `cargo clippy --workspace --all-targets`, is intermittently killed on `ubuntu-latest`:

```
    Checking autumn-web v0.7.0 (/home/runner/work/autumn/autumn/autumn)
    Checking bench-runtime-gate v0.1.0 (…/benchmarks/runtime/gate)
##[error]Process completed with exit code 143.
##[error]The runner has received a shutdown signal. This can happen when the
runner service is stopped, or a manually started runner is canceled.
```

Always while `Checking autumn-web`, 60–90 s after the last compile line, **with no clippy diagnostic in the log**. With nothing to point at, it reads as infrastructure flake, so it has been re-run rather than fixed.

Four consecutive `trunk-dev` runs failed this way:

| Run | Commit | Last log line | Outcome |
|---|---|---|---|
| [33129145297](https://github.com/autumn-foundation/autumn/actions/runs/33129145297) | `61bdd9c` Web Push | `Checking autumn-web` 00:17:53 | exit 143 at 00:19:08 |
| [33123617901](https://github.com/autumn-foundation/autumn/actions/runs/33123617901) | `24bf151` examples | `Checking autumn-web` 22:46:05 | exit 143 at 22:47:32 |
| [33091693589](https://github.com/autumn-foundation/autumn/actions/runs/33091693589) | `eba7fc6` shadow build | — | failure |
| [33014697098](https://github.com/autumn-foundation/autumn/actions/runs/33014697098) | scaffold DSL | — | failure |

## The cause

Memory, not infrastructure. `lint` is `runs-on: ubuntu-latest` — 4 cores, 16 GB — and cargo defaults to one job per core. Checking the whole workspace with `--all-targets` peaks past 16 GB while `autumn-web`, the largest crate, is in flight; the runner is reclaimed and the step reports 143.

Reproduced on a 15 GB box, same toolchain CI pins (1.98.0):

| Command | Result |
|---|---|
| `cargo clippy --workspace --all-targets -- -D warnings` (default `-j 4`) | OOM-killed, no diagnostic |
| `cargo clippy -j 2 --workspace --all-targets -- -D warnings` | **exit 0**, clean |

That it is marginal rather than deterministic explains the shape of the failure: the same command succeeds on some runs (for instance [#2345](https://github.com/autumn-foundation/autumn/pull/2345)'s `Lint` passed at 02:33–02:53 while another branch's was dying), which is exactly why it looked like a flake worth re-running.

## The fix

`-j 2` on that one step. It trades some wall-clock for a step that currently fails outright.

Scoped deliberately to the workspace step — the one with evidence behind it. The two `-p autumn-web` clippy steps check a single crate, and because the job dies before reaching them they have never been observed to fail; capping them too would be speculation.

## Why it is worth fixing rather than waiting out

`test` declares `needs: [lint, meta]`, so while `Lint` is red the entire `test` matrix — **`ubuntu-latest`, `windows-latest` and `macos-latest`** — never runs. Every branch cut from `trunk-dev` inherits both the red check and the missing cross-platform coverage.

## Verification

- `cargo clippy -j 2 --workspace --all-targets -- -D warnings` — exit 0 on 1.98.0, the toolchain this job pins.
- Workflow parses: `yaml.safe_load` on `.github/workflows/ci.yml` succeeds.
- No change to what is checked — same command, same `-D warnings`, same crates and targets. Only the codegen job count differs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HUZJFJRqZvf4GQUbwdNd9x

---
_Generated by [Claude Code](https://claude.ai/code/session_01HUZJFJRqZvf4GQUbwdNd9x)_