### PR TITLE
🧼 Add `autumn db scrub` to anonymize data for non-production use (#1602)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -271,6 +271,19 @@ jobs:
           # above). Runs in the existing Docker-dependent Linux step rather than a
           # separate required gate.
           cargo test -p autumn-cli --test cli_tests -- --ignored offsite
+          # PII scrub round-trip (#1602): seed known PII -> `autumn db backup`
+          # -> `autumn db scrub --artifact` into a separate staging database ->
+          # assert ZERO occurrences of any original value in the result, plus
+          # the fail-closed refusals (undeclared column, renamed column,
+          # production profile). Needs Docker (testcontainers) + host
+          # pg_dump/pg_restore (installed above). autumn-cli's Docker-gated
+          # tests are NOT auto-swept the way autumn-web's are, so this line is
+          # the only thing that runs them.
+          # `scrubbed_database_migrates_clean_and_boots_the_app` is skipped
+          # here: it compiles and boots a generated app and needs the diesel
+          # CLI, so it runs in generator-conformance.yml's Postgres gate.
+          cargo test -p autumn-cli --test cli_tests -- --ignored db_scrub \
+            --skip scrubbed_database_migrates_clean_and_boots_the_app
           # Consolidated `integration_tests` binary: discover-and-run ALL the
           # Docker/testcontainer `#[ignore]`d DB tests instead of a hand-curated
           # per-feature allowlist (#1923). Enabling `test-support` (testcontainers)

--- a/.github/workflows/generator-conformance.yml
+++ b/.github/workflows/generator-conformance.yml
@@ -28,6 +28,13 @@ on:
       - "autumn-cli/tests/generate.rs"
       - "autumn-cli/tests/integration/console.rs"
       - "autumn-cli/tests/integration/scaffold_validation.rs"
+      # The `autumn db scrub` boot gate (#1602) lives in this workflow because
+      # it needs the diesel CLI and compiles a generated app. Without these
+      # paths a scrub-only change would run the ci.yml round-trip and skip the
+      # one test that proves the scrubbed database still boots an app.
+      - "autumn-cli/src/db/**"
+      - "autumn-cli/src/schema/**"
+      - "autumn-cli/tests/integration/db_scrub.rs"
       - "autumn/src/**"
       - "autumn/Cargo.toml"
       - "autumn-macros/**"
@@ -47,6 +54,13 @@ on:
       - "autumn-cli/tests/generate.rs"
       - "autumn-cli/tests/integration/console.rs"
       - "autumn-cli/tests/integration/scaffold_validation.rs"
+      # The `autumn db scrub` boot gate (#1602) lives in this workflow because
+      # it needs the diesel CLI and compiles a generated app. Without these
+      # paths a scrub-only change would run the ci.yml round-trip and skip the
+      # one test that proves the scrubbed database still boots an app.
+      - "autumn-cli/src/db/**"
+      - "autumn-cli/src/schema/**"
+      - "autumn-cli/tests/integration/db_scrub.rs"
       - "autumn/src/**"
       - "autumn/Cargo.toml"
       - "autumn-macros/**"
@@ -490,9 +504,15 @@ jobs:
       # The scrub gate below drives `autumn db backup`, which shells out to the
       # HOST pg_dump/pg_restore; ubuntu-latest does not guarantee them on PATH.
       - name: Install Postgres client tools
+        # Guarded: this job can route to the self-hosted runner, where
+        # `pg_dump` is already present and passwordless apt may not be — an
+        # unconditional install would take the four pre-existing gates in this
+        # job down with it.
         run: |
-          sudo apt-get update
-          sudo apt-get install -y postgresql-client
+          if ! command -v pg_dump >/dev/null 2>&1; then
+            sudo apt-get update
+            sudo apt-get install -y postgresql-client
+          fi
           pg_dump --version
 
       - name: generated_scaffold_serves_posts_index_and_json_api

--- a/.github/workflows/generator-conformance.yml
+++ b/.github/workflows/generator-conformance.yml
@@ -487,6 +487,14 @@ jobs:
       - name: Install diesel_cli
         run: cargo install diesel_cli --version "=2.2.0" --no-default-features --features postgres --locked
 
+      # The scrub gate below drives `autumn db backup`, which shells out to the
+      # HOST pg_dump/pg_restore; ubuntu-latest does not guarantee them on PATH.
+      - name: Install Postgres client tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y postgresql-client
+          pg_dump --version
+
       - name: generated_scaffold_serves_posts_index_and_json_api
         run: |
           cargo test -p autumn-cli --test generate \
@@ -522,4 +530,18 @@ jobs:
         run: |
           cargo test -p autumn-cli --test cli_tests \
             integration::generate_json_postgres::scaffolded_json_field_generates_compiles_inserts_and_selects \
+            -- --ignored --exact
+
+      # ── `autumn db scrub` boots the app it scrubbed (#1602) ──────────────
+      #
+      # The one AC the general Docker sweep cannot cover: after a scrub, the
+      # scrubbed database still MIGRATES CLEAN and a real generated app boots
+      # against it and answers GET /health with 200. Needs Docker + the diesel
+      # CLI + host pg_dump, and compiles a generated app — hence this job
+      # rather than ci.yml's sweep. Same `cli_tests` caveat as the blocks
+      # above: named explicitly here or it never runs anywhere.
+      - name: scrubbed_database_migrates_clean_and_boots_the_app
+        run: |
+          cargo test -p autumn-cli --test cli_tests \
+            integration::db_scrub::scrubbed_database_migrates_clean_and_boots_the_app \
             -- --ignored --exact

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   integrity survives. Writing refuses outside `dev`/`test` without `--force`,
   the same guard as `autumn db drop`, and every statement for one database runs
   in a single transaction. `--output` re-dumps the scrubbed database as a fresh
-  artifact, closing the backup → scrub → restore loop. See the new
+  artifact, closing the backup → scrub → restore loop.
+
+  The safety work is where most of the substance is. `#[encrypted]` columns are
+  **re-encrypted** under the target's own key rather than overwritten with a
+  plain string (which would make every later read of that row fail as malformed
+  ciphertext). PII is refused on either side of any foreign key — composite keys
+  included — so a natural key another table references is protected, not just
+  the referencing column; on `CHECK`-constrained columns, where no fabricated
+  value can satisfy the predicate; and on generated columns, which Postgres
+  refuses to update at all. Uniqueness is read from every unique index, partial
+  and composite included, and a unique column gets a wider `sha256` token so a
+  narrow `varchar(n)` cannot truncate into collisions. Statements are
+  `public`-qualified with a pinned `search_path` (a tenant `search_path` cannot
+  redirect a write), the planned tables are locked for the transaction, row-level
+  security and non-`public` schemas are refused rather than silently
+  under-scrubbed, materialized views are refreshed in dependency order, and the
+  framework-owned tables that keep verbatim copies of app rows — the ledger, the
+  version history, the search index, `api_tokens` — are reported and can be
+  emptied with `[framework] purge`. See the new
   [Data Scrubbing guide](docs/guide/data-scrubbing.md).
 
 - **`autumn upgrade` now reconciles framework-owned scaffold files, not just

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`autumn db scrub` turns a production copy into an anonymized one, and
+  refuses to guess (#1602):** the moment `autumn db backup` shipped, a
+  production database was one command away from a laptop or a shared staging
+  box — PII and all — and the only remedy was hand-rolled `UPDATE` scripts that
+  rot the first time someone adds an `email` column. `autumn db scrub` takes
+  either a backup artifact (`--artifact`) or the resolved database URL and
+  rewrites every PII-classified column with deterministic, constraint-valid
+  fake values. Classification comes from the schema, not from a config file
+  alone: `#[encrypted]` model columns and tables registered with the GDPR
+  anonymize strategy are classified automatically, everything else is declared
+  in a checked-in `scrub.toml` — and because the column universe is read by
+  introspecting the live database, a column that is neither PII-classified nor
+  explicitly marked safe **aborts the scrub** and is listed by name, with a
+  paste-ready declaration stanza. That makes "we think staging is clean" a
+  CI-verified invariant: `autumn db scrub --check` writes nothing and exits
+  non-zero on any unclassified column. Replacements are derived from an `md5`
+  over the row's primary key salted with the column name, so a `UNIQUE` column
+  stays unique, `NULL`s stay `NULL`, and two columns of one row never collide;
+  PII on a primary- or foreign-key column is refused outright, so referential
+  integrity survives. Writing refuses outside `dev`/`test` without `--force`,
+  the same guard as `autumn db drop`, and every statement for one database runs
+  in a single transaction. `--output` re-dumps the scrubbed database as a fresh
+  artifact, closing the backup → scrub → restore loop. See the new
+  [Data Scrubbing guide](docs/guide/data-scrubbing.md).
+
 - **`autumn upgrade` now reconciles framework-owned scaffold files, not just
   app code (#1593):** `autumn new` writes about a dozen framework-owned files
   into every project — `Dockerfile`, `.dockerignore`, `build.rs`, `autumn.toml`,

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -118,7 +118,7 @@ printpdf = { version = "0.12", default-features = false }
 image = { version = "0.25", default-features = false, features = ["jpeg", "png", "webp"] }
 
 # Proc macro
-syn = { version = "2", features = ["full", "visit-mut"] }
+syn = { version = "2", features = ["full", "visit", "visit-mut"] }
 quote = "1"
 proc-macro2 = "1"
 

--- a/README.md
+++ b/README.md
@@ -248,6 +248,7 @@ See [EXAMPLES.md](EXAMPLES.md) for the full catalog with personas, journeys, pre
 - [Multi-Replica Scheduled Tasks](docs/guide/scheduled-multi-replica.md) - `#[scheduled]` with Postgres advisory-lock coordination
 - [Fleet Deploys](docs/guide/fleet-deploys.md) — `[deploy] hosts`: `autumn deploy up` rolls a release across several VPS hosts one at a time (per-host blue/green, migrations exactly once, halt-and-roll-back on failure), plus `deploy status` drift detection, fleet maintenance, and the load-balancer contract
 - [Data-Retention Sweeps](docs/guide/retention-sweeps.md) — `retention(...)` on `#[repository(...)]`: batched, soft-delete-aware, fleet-coordinated auto-purge, plus `autumn retention --dry-run`
+- [Data Scrubbing](docs/guide/data-scrubbing.md) — `autumn db scrub`: turn a production backup into an anonymized staging copy, with fail-closed PII classification driven by `#[encrypted]` columns, GDPR anonymize registrations, and a checked-in `scrub.toml`
 - [Horizontal Sharding](docs/guide/sharding.md) — `[[database.shards]]`, slot-based routing, `ShardedDb`/`Shards` extractors, per-shard health and migrations
 - [Per-Tenant Memory Cells](docs/guide/tenant-cells.md) — `TenantCell` byte accounting with the `tenancy.quota_bytes` soft quota and deterministic per-tenant eviction
 - [Operating Background Jobs](docs/guide/operating-background-jobs.md) - admin dashboard and recovery actions for `#[job]`

--- a/autumn-cli/src/db.rs
+++ b/autumn-cli/src/db.rs
@@ -28,6 +28,11 @@ pub mod backup;
 /// Minimal synchronous S3 SigV4 client for offsite backup transfer (issue #1619).
 pub mod s3;
 
+/// `autumn db scrub` — anonymize a database (or a backup artifact) for
+/// non-production use (issue #1602). A submodule so it can reuse this module's
+/// production guard ([`guard_destructive`]) and identifier-quoting verbatim.
+pub mod scrub;
+
 /// The lifecycle subcommands of `autumn db`.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum DbCommand {

--- a/autumn-cli/src/db/backup.rs
+++ b/autumn-cli/src/db/backup.rs
@@ -325,7 +325,7 @@ pub fn run_restore(args: &RestoreArgs) {
 
 // ─── Backup ─────────────────────────────────────────────────────────────────
 
-fn backup(args: &BackupArgs) -> Result<(), BackupError> {
+pub(super) fn backup(args: &BackupArgs) -> Result<(), BackupError> {
     let targets = resolve_targets(args.profile.as_deref(), &args.target)?;
     // Include the managed cluster's bundled tools (daemon/cron path, where
     // AUTUMN_MANAGED_PG_DATA_DIR isn't inherited) so a managed backup needs zero
@@ -896,7 +896,7 @@ fn verify_plain_dump(path: &Path, db: &str) -> Result<(), BackupError> {
 
 // ─── Restore ────────────────────────────────────────────────────────────────
 
-fn restore(args: &RestoreArgs) -> Result<(), BackupError> {
+pub(super) fn restore(args: &RestoreArgs) -> Result<(), BackupError> {
     // Production guard — identical to `autumn db drop` (AC #4). This guards the
     // RESTORE-TARGET profile (`--profile`), independent of any offsite source.
     let profile = migrate::effective_profile(args.profile.as_deref());
@@ -1192,6 +1192,35 @@ where
 
 /// Resolve the databases a backup run should capture, reusing the SAME
 /// resolution `autumn migrate` uses so the set matches the running app exactly.
+/// Every database a scrub must visit under `profile` — control plus each
+/// configured shard — as `(label, url)` pairs, resolved through the **same**
+/// path `backup`/`restore` use so a scrub can never miss a database a backup
+/// captured (issue #1602).
+///
+/// # Errors
+///
+/// Returns [`BackupError::NoUrl`] when no control URL can be resolved.
+pub(super) fn resolve_all_target_urls(
+    profile: Option<&str>,
+) -> Result<Vec<(String, String)>, BackupError> {
+    Ok(resolve_targets(profile, &TargetSelector::All)?
+        .into_iter()
+        .map(|t| (t.label, t.url))
+        .collect())
+}
+
+/// The profile a backup run directory was taken under, read from its
+/// `manifest.json`. `None` for a bare single-file artifact (which carries no
+/// manifest) or an unreadable/invalid manifest — callers treat absence as
+/// "unknown provenance", never as "safe".
+pub(super) fn artifact_source_profile(artifact: &Path) -> Option<String> {
+    artifact
+        .is_dir()
+        .then(|| read_manifest(artifact).ok())
+        .flatten()
+        .map(|m| m.profile)
+}
+
 fn resolve_targets(
     profile: Option<&str>,
     selector: &TargetSelector,

--- a/autumn-cli/src/db/scrub.rs
+++ b/autumn-cli/src/db/scrub.rs
@@ -1792,9 +1792,15 @@ fn same_database(a: &str, b: &str) -> bool {
     }
 }
 
-/// Refuse to scrub the database a **config file** declares for the artifact's
-/// own (non-dev/test) profile — the "I pointed staging at the production URL"
+/// Refuse to scrub a database that a **config file** declares for a
+/// production-ish profile — the "I pointed staging at the production URL"
 /// mistake the profile guard alone cannot see.
+///
+/// Every non-dev/test profile with an `autumn-<profile>.toml` in the project is
+/// checked, not just the one an artifact's manifest names. A bare `.dump`/`.sql`
+/// artifact carries no manifest at all, so keying the guard off known provenance
+/// would silently skip it in exactly the case where the operator knows least
+/// about what they are restoring.
 ///
 /// Deliberately reads only `autumn.toml` / `autumn-<profile>.toml`, never the
 /// environment: an env-provided `DATABASE_URL` is shared by every profile
@@ -1805,29 +1811,61 @@ fn same_database(a: &str, b: &str) -> bool {
 /// not `dev`/`test`), so a guard that `--force` waived would be inert in exactly
 /// the workflow it exists for.
 fn guard_configured_source(
-    source_profile: &str,
+    artifact_profile: Option<&str>,
+    project_root: &Path,
     targets: &[(String, String)],
     allowed: bool,
 ) -> Result<(), ScrubError> {
-    if allowed || super::is_safe_destructive_profile(source_profile) {
+    if allowed {
         return Ok(());
     }
-    let table = migrate::read_autumn_toml_table_with_profile(Some(source_profile));
-    let Some(declared) = migrate::resolve_primary_database_url_from_sources(
-        |_| Err(std::env::VarError::NotPresent),
-        table.as_ref(),
-    ) else {
-        return Ok(());
-    };
-    for (_, url) in targets {
-        if same_database(&declared, url) {
-            return Err(ScrubError::OverwritesConfiguredTarget {
-                profile: source_profile.to_owned(),
-                database: parsed_db_name(url),
-            });
+    let mut candidates: Vec<String> = artifact_profile
+        .map(str::to_owned)
+        .into_iter()
+        .chain(profiles_with_config(project_root))
+        .filter(|p| !super::is_safe_destructive_profile(p))
+        .collect();
+    candidates.sort();
+    candidates.dedup();
+
+    for profile in candidates {
+        let table = migrate::read_autumn_toml_table_with_profile(Some(&profile));
+        let Some(declared) = migrate::resolve_primary_database_url_from_sources(
+            |_| Err(std::env::VarError::NotPresent),
+            table.as_ref(),
+        ) else {
+            continue;
+        };
+        for (_, url) in targets {
+            if same_database(&declared, url) {
+                return Err(ScrubError::OverwritesConfiguredTarget {
+                    profile,
+                    database: parsed_db_name(url),
+                });
+            }
         }
     }
     Ok(())
+}
+
+/// Profile names that have an `autumn-<profile>.toml` overlay in the project.
+fn profiles_with_config(project_root: &Path) -> Vec<String> {
+    let Ok(entries) = std::fs::read_dir(project_root) else {
+        return Vec::new();
+    };
+    let mut out: Vec<String> = entries
+        .filter_map(Result::ok)
+        .filter_map(|entry| {
+            let name = entry.file_name().to_string_lossy().into_owned();
+            name.strip_prefix("autumn-")
+                .and_then(|rest| rest.strip_suffix(".toml"))
+                .map(str::to_owned)
+        })
+        .filter(|p| !p.is_empty())
+        .collect();
+    out.sort();
+    out.dedup();
+    out
 }
 
 /// The database name in a connection URL, for credential-safe reporting.
@@ -1904,6 +1942,7 @@ fn scrub(args: &ScrubArgs) -> Result<(), ScrubError> {
     let targets = super::backup::resolve_all_target_urls(args.profile.as_deref())?;
 
     let restored = if let Some(artifact) = &args.artifact {
+        let artifact_profile = super::backup::artifact_source_profile(artifact);
         // `--check`/`--dry-run` promise to write nothing, and a restore is the
         // largest write there is. clap already rejects the combination; this
         // keeps the invariant true inside the function that relies on it.
@@ -1911,10 +1950,19 @@ fn scrub(args: &ScrubArgs) -> Result<(), ScrubError> {
             writes,
             "--check/--dry-run must never reach an artifact restore"
         );
-        if let Some(source_profile) = super::backup::artifact_source_profile(artifact) {
-            eprintln!("  \u{2139} Artifact was taken under the {source_profile:?} profile.");
-            guard_configured_source(&source_profile, &targets, args.allow_source_overwrite)?;
-        }
+        eprintln!(
+            "  \u{2139} Artifact provenance: {}.",
+            artifact_profile.as_deref().map_or_else(
+                || "unknown (no manifest)".to_owned(),
+                |p| format!("{p:?} profile")
+            )
+        );
+        guard_configured_source(
+            artifact_profile.as_deref(),
+            Path::new("."),
+            &targets,
+            args.allow_source_overwrite,
+        )?;
         eprintln!(
             "\u{2500}\u{2500} restoring {} \u{2500}\u{2500}",
             artifact.display()
@@ -2094,20 +2142,20 @@ fn classify_and_apply(
     let mut committed: Vec<&str> = Vec::new();
     for (label, url, plan, facts) in &plans {
         let purges = purge_statements(&facts.framework_tables, &sources.config);
-        let applied = execute(url, plan, &purges, label).inspect_err(|_| {
-            if !committed.is_empty() {
-                eprintln!(
-                    "\n\u{26A0}\u{FE0F}  Already committed before this failure: {}. \
+        let applied =
+            execute(url, plan, &purges, &facts.materialized_views, label).inspect_err(|_| {
+                if !committed.is_empty() {
+                    eprintln!(
+                        "\n\u{26A0}\u{FE0F}  Already committed before this failure: {}. \
                      Those databases ARE scrubbed; every later target is untouched and still \
                      holds real data.",
-                    committed.join(", ")
-                );
-            }
-        })?;
+                        committed.join(", ")
+                    );
+                }
+            })?;
         for (table, rows) in applied {
             eprintln!("  \u{2713} {table}: {rows} row(s) scrubbed.");
         }
-        refresh_materialized_views(url, label, &facts.materialized_views)?;
         committed.push(label);
     }
 
@@ -2647,9 +2695,10 @@ fn execute(
     url: &str,
     plan: &ScrubPlan,
     purges: &[(String, String)],
+    materialized_views: &[String],
     label: &str,
 ) -> Result<Vec<(String, usize)>, ScrubError> {
-    if plan.tables.is_empty() && purges.is_empty() {
+    if plan.tables.is_empty() && purges.is_empty() && materialized_views.is_empty() {
         return Ok(Vec::new());
     }
     let mut conn = probe_connection(url, label, "apply the scrub")?;
@@ -2668,10 +2717,19 @@ fn execute(
         // taken on another connection, and a row inserted between the two would
         // otherwise survive the scrub unnoticed. SHARE ROW EXCLUSIVE blocks
         // writers while still allowing plain reads.
-        for table in &plan.tables {
+        // Every table the transaction writes, including the ones it empties: a
+        // producer inserting into a purged job/sync/token table after that
+        // `DELETE` took its snapshot would otherwise survive a run that reports
+        // the table emptied.
+        let locked = plan
+            .tables
+            .iter()
+            .map(|t| t.table.as_str())
+            .chain(purges.iter().map(|(table, _)| table.as_str()));
+        for table in locked {
             sql_query(format!(
                 "LOCK TABLE {} IN SHARE ROW EXCLUSIVE MODE",
-                qualified_ident(&table.table)
+                qualified_ident(table)
             ))
             .execute(conn)?;
         }
@@ -2689,33 +2747,21 @@ fn execute(
             let rows = sql_query(statement).execute(conn)?;
             counts.push((format!("{table} (emptied)"), rows));
         }
+        // Inside the transaction, so a refresh the role is not allowed to run
+        // rolls the rewrites back rather than committing base tables that a
+        // stale materialized view still contradicts.
+        for view in materialized_views {
+            sql_query(format!(
+                "REFRESH MATERIALIZED VIEW {}",
+                qualified_ident(view)
+            ))
+            .execute(conn)?;
+            counts.push((format!("{view} (materialized view refreshed)"), 0));
+        }
         Ok(())
     })
     .map_err(|e| ScrubError::Sql(e.to_string()))?;
     Ok(counts)
-}
-
-/// Refresh every materialized view, sources first.
-///
-/// A materialized view holds its own copy of whatever it selected, so scrubbing
-/// the base tables leaves it holding the original values — and `pg_restore`
-/// populates them from the still-real data it just restored. They are refreshed
-/// in dependency order so a view reading another view never re-derives from
-/// stale content.
-fn refresh_materialized_views(url: &str, label: &str, views: &[String]) -> Result<(), ScrubError> {
-    if views.is_empty() {
-        return Ok(());
-    }
-    let mut conn = probe_connection(url, label, "refresh its materialized views")?;
-    for view in views {
-        conn.batch_execute(&format!(
-            "REFRESH MATERIALIZED VIEW {}",
-            qualified_ident(view)
-        ))
-        .map_err(|e| ScrubError::Sql(format!("refreshing materialized view {view:?}: {e}")))?;
-        eprintln!("  \u{2713} refreshed materialized view {view}.");
-    }
-    Ok(())
 }
 
 #[cfg(test)]
@@ -3977,6 +4023,49 @@ mod tests {
         ));
         // An unparsable URL never claims a match.
         assert!(!same_database("not a url", "not a url"));
+    }
+
+    #[test]
+    fn a_bare_artifact_with_no_manifest_still_gets_the_source_guard() {
+        // `autumn-prod.toml` declares the very database the scrub would write.
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("autumn-prod.toml"),
+            "[database]\nprimary_url = \"postgres://app:pw@db.example.com:5432/myapp\"\n",
+        )
+        .unwrap();
+        std::fs::write(dir.path().join("autumn-dev.toml"), "[database]\n").unwrap();
+
+        assert_eq!(
+            profiles_with_config(dir.path()),
+            vec!["dev".to_owned(), "prod".to_owned()],
+            "every profile overlay is a candidate, not just the one an artifact names"
+        );
+        // A bare `.dump` carries no manifest, so provenance is `None` — which
+        // must not read as permission to continue.
+        assert!(
+            !profiles_with_config(dir.path()).is_empty(),
+            "the guard has candidates to check even with unknown provenance"
+        );
+    }
+
+    #[test]
+    fn the_source_guard_waiver_is_not_force() {
+        // `--force` is mandatory in the documented staging drill, so a guard it
+        // waived would be inert in exactly the workflow it exists for.
+        let targets = vec![(
+            "control".to_owned(),
+            "postgres://app:pw@db.example.com:5432/myapp".to_owned(),
+        )];
+        let empty = tempfile::tempdir().unwrap();
+        assert!(
+            guard_configured_source(Some("prod"), empty.path(), &targets, false).is_ok(),
+            "no config overlay means nothing to compare against"
+        );
+        assert!(
+            guard_configured_source(Some("prod"), empty.path(), &targets, true).is_ok(),
+            "--allow-source-overwrite is the waiver"
+        );
     }
 
     #[test]

--- a/autumn-cli/src/db/scrub.rs
+++ b/autumn-cli/src/db/scrub.rs
@@ -24,7 +24,7 @@
 //!    PII unless explicitly declared `safe`.
 //!
 //! Everything left over is **unclassified**, and an unclassified column is a
-//! hard failure ([`ScrubError::Unclassified`]) — never a silent pass-through.
+//! hard failure (`ScrubError::Unclassified`) — never a silent pass-through.
 //! Because the column universe comes from **introspecting the live database**
 //! (not from the config file), a column added yesterday cannot be missing from
 //! that universe: adding a column without declaring it breaks the scrub, which
@@ -743,7 +743,8 @@ fn parse_config_str(src: &str) -> Result<ScrubConfig, ScrubError> {
     parse_config_at(src, Path::new(SCRUB_CONFIG_FILE))
 }
 
-/// [`parse_config_str`], attributing any error to the file it came from.
+/// Parse a `scrub.toml` document, attributing any error to the file it came
+/// from.
 fn parse_config_at(src: &str, path: &Path) -> Result<ScrubConfig, ScrubError> {
     toml::from_str(src).map_err(|e| ScrubError::Config {
         path: path.display().to_string(),

--- a/autumn-cli/src/db/scrub.rs
+++ b/autumn-cli/src/db/scrub.rs
@@ -1321,7 +1321,11 @@ fn token_expr(table: &Table, column: &str, unique: bool) -> String {
 fn token_expr_from(row_key: &str, column: &str, unique: bool) -> String {
     let seed = format!("{} || '|' || {row_key}", quote_literal(column));
     if unique {
-        format!("encode(sha256(({seed})::bytea), 'hex')")
+        // Two independently-salted `md5`s concatenated, rather than `sha256`:
+        // both halves would have to collide at once, and this needs no
+        // `text`-to-`bytea` cast (whose escape-format interpretation would
+        // mangle a row key containing a backslash) and no Postgres 11 floor.
+        format!("md5({seed}) || md5(({seed}) || '#2')")
     } else {
         format!("md5({seed})")
     }
@@ -2583,11 +2587,10 @@ fn rewrite_encrypted_column(
     use autumn_web::encryption::{Mode, encrypt_text};
 
     let ident = quote_ident(&rewrite.column);
+    let seed = format!("{} || '|' || ({row_key})", quote_literal(&rewrite.column));
     let rows: Vec<RowTokenRow> = sql_query(format!(
-        "SELECT ({row_key}) AS row_key, \
-         encode(sha256((({row_key}) || '|' || {})::bytea), 'hex') AS token \
+        "SELECT ({row_key}) AS row_key, md5({seed}) || md5(({seed}) || '#2') AS token \
          FROM {} WHERE {ident} IS NOT NULL",
-        quote_literal(&rewrite.column),
         qualified_ident(table),
     ))
     .load(conn)?;
@@ -3253,9 +3256,12 @@ mod tests {
     #[test]
     fn a_unique_column_gets_a_wider_token_and_a_higher_floor() {
         let table = users_table();
-        assert!(
-            token_expr(&table, "email", true).contains("sha256"),
-            "a unique column needs more entropy than md5's 32 hex characters"
+        let unique_token = token_expr(&table, "email", true);
+        assert_eq!(
+            unique_token.matches("md5(").count(),
+            2,
+            "a unique column needs more entropy than one md5's 32 hex characters: \
+             {unique_token}"
         );
         assert!(token_expr(&table, "bio", false).contains("md5("));
 

--- a/autumn-cli/src/db/scrub.rs
+++ b/autumn-cli/src/db/scrub.rs
@@ -1,0 +1,871 @@
+//! `autumn db scrub` — RED phase (issue #1602).
+//!
+//! Tests are written first, against the intended API. The implementation lands
+//! in the GREEN commit.
+
+#[cfg(test)]
+mod tests {
+    use std::collections::{BTreeMap, BTreeSet};
+
+    use autumn_schema_core::{Backend, Column, ColumnType, ForeignKey, Index, Table};
+
+    use super::*;
+
+    // ── Fixtures ────────────────────────────────────────────────────────────
+
+    fn text_col(name: &str) -> Column {
+        Column::new(name, ColumnType::Text)
+    }
+
+    fn pk_col(name: &str) -> Column {
+        let mut c = Column::new(name, ColumnType::Int64);
+        c.primary_key = true;
+        c
+    }
+
+    /// `users(id PK, email TEXT UNIQUE, full_name TEXT, bio TEXT NULL,
+    /// created_at TIMESTAMP)`.
+    fn users_table() -> Table {
+        let mut t = Table::new("users", Backend::Postgres);
+        t.primary_key = vec!["id".to_owned()];
+        let mut email = text_col("email");
+        email.unique = true;
+        let mut bio = text_col("bio");
+        bio.nullable = true;
+        t.columns = vec![
+            pk_col("id"),
+            email,
+            text_col("full_name"),
+            bio,
+            Column::new("created_at", ColumnType::Timestamp),
+        ];
+        t
+    }
+
+    fn empty_encrypted() -> BTreeMap<String, BTreeSet<String>> {
+        BTreeMap::new()
+    }
+
+    fn no_anonymize() -> BTreeSet<String> {
+        BTreeSet::new()
+    }
+
+    fn plan_for(
+        tables: &[Table],
+        config: &ScrubConfig,
+        encrypted: &BTreeMap<String, BTreeSet<String>>,
+        anonymize: &BTreeSet<String>,
+    ) -> Result<ScrubPlan, ScrubError> {
+        build_plan(&ClassificationInputs {
+            tables,
+            config,
+            encrypted,
+            anonymize_tables: anonymize,
+        })
+    }
+
+    // ── Config parsing ──────────────────────────────────────────────────────
+
+    #[test]
+    fn config_parses_defaults_safe_and_pii() {
+        let config = parse_config_str(
+            r#"
+            [defaults]
+            safe_columns = ["id", "created_at"]
+
+            [tables.users]
+            safe = ["role"]
+
+            [tables.users.pii]
+            email = "email"
+            full_name = "name"
+            "#,
+        )
+        .expect("config must parse");
+
+        assert_eq!(config.defaults.safe_columns, vec!["id", "created_at"]);
+        let users = config.tables.get("users").expect("users rule");
+        assert_eq!(users.safe, vec!["role"]);
+        assert_eq!(users.pii.get("email"), Some(&Strategy::Email));
+        assert_eq!(users.pii.get("full_name"), Some(&Strategy::Name));
+    }
+
+    #[test]
+    fn config_rejects_unknown_strategy() {
+        let err = parse_config_str(
+            r#"
+            [tables.users.pii]
+            email = "obfuscate"
+            "#,
+        )
+        .expect_err("unknown strategy must be rejected");
+        assert!(
+            err.to_string().contains("obfuscate"),
+            "error should name the bad strategy: {err}"
+        );
+    }
+
+    #[test]
+    fn config_rejects_unknown_keys() {
+        let err = parse_config_str(
+            r#"
+            [tables.users]
+            saf = ["role"]
+            "#,
+        )
+        .expect_err("a typo'd key must not be silently ignored");
+        assert!(err.to_string().contains("saf"), "error: {err}");
+    }
+
+    #[test]
+    fn empty_config_parses_to_default() {
+        assert_eq!(parse_config_str("").unwrap(), ScrubConfig::default());
+    }
+
+    // ── Fail-closed classification (AC #3) ──────────────────────────────────
+
+    #[test]
+    fn unclassified_columns_are_refused_and_listed() {
+        let tables = vec![users_table()];
+        let err = plan_for(
+            &tables,
+            &ScrubConfig::default(),
+            &empty_encrypted(),
+            &no_anonymize(),
+        )
+        .expect_err("an all-unclassified schema must be refused");
+
+        let ScrubError::Unclassified { columns } = &err else {
+            panic!("expected Unclassified, got {err:?}");
+        };
+        assert_eq!(
+            columns,
+            &vec![
+                "users.bio".to_owned(),
+                "users.created_at".to_owned(),
+                "users.email".to_owned(),
+                "users.full_name".to_owned(),
+                "users.id".to_owned(),
+            ]
+        );
+        // The message must be actionable: it names the columns and the file.
+        let rendered = err.to_string();
+        assert!(rendered.contains("users.email"), "{rendered}");
+        assert!(rendered.contains(SCRUB_CONFIG_FILE), "{rendered}");
+    }
+
+    #[test]
+    fn a_newly_added_column_flips_a_previously_clean_config_to_failure() {
+        let config = parse_config_str(
+            r#"
+            [defaults]
+            safe_columns = ["id", "created_at"]
+            [tables.users]
+            safe = []
+            [tables.users.pii]
+            email = "email"
+            full_name = "name"
+            bio = "redact"
+            "#,
+        )
+        .unwrap();
+        let tables = vec![users_table()];
+        plan_for(&tables, &config, &empty_encrypted(), &no_anonymize())
+            .expect("the fully-declared schema must pass");
+
+        // Someone adds `users.ssn` and forgets the declaration.
+        let mut with_new_column = users_table();
+        with_new_column.columns.push(text_col("ssn"));
+        let err = plan_for(
+            &[with_new_column],
+            &config,
+            &empty_encrypted(),
+            &no_anonymize(),
+        )
+        .expect_err("a new undeclared column must fail the scrub");
+        assert!(matches!(
+            err,
+            ScrubError::Unclassified { ref columns } if columns == &vec!["users.ssn".to_owned()]
+        ));
+    }
+
+    #[test]
+    fn stale_config_entries_are_refused() {
+        let config = parse_config_str(
+            r#"
+            [defaults]
+            safe_columns = ["id", "created_at", "email", "full_name", "bio"]
+            [tables.users.pii]
+            emial = "email"
+            "#,
+        )
+        .unwrap();
+        let err = plan_for(
+            &[users_table()],
+            &config,
+            &empty_encrypted(),
+            &no_anonymize(),
+        )
+        .expect_err("a config naming a column that no longer exists must fail");
+        assert!(
+            matches!(err, ScrubError::StaleConfig { ref entries } if entries.contains(&"users.emial".to_owned())),
+            "got {err:?}"
+        );
+    }
+
+    #[test]
+    fn stale_config_table_is_refused() {
+        let config = parse_config_str(
+            r#"
+            [defaults]
+            safe_columns = ["id", "created_at", "email", "full_name", "bio"]
+            [tables.legacy_users]
+            safe = ["x"]
+            "#,
+        )
+        .unwrap();
+        let err = plan_for(
+            &[users_table()],
+            &config,
+            &empty_encrypted(),
+            &no_anonymize(),
+        )
+        .expect_err("a config table that no longer exists must fail");
+        assert!(
+            matches!(err, ScrubError::StaleConfig { ref entries } if entries.contains(&"legacy_users".to_owned())),
+            "got {err:?}"
+        );
+    }
+
+    #[test]
+    fn a_column_cannot_be_both_safe_and_pii() {
+        let config = parse_config_str(
+            r#"
+            [defaults]
+            safe_columns = ["id", "created_at", "full_name", "bio"]
+            [tables.users]
+            safe = ["email"]
+            [tables.users.pii]
+            email = "email"
+            "#,
+        )
+        .unwrap();
+        let err = plan_for(
+            &[users_table()],
+            &config,
+            &empty_encrypted(),
+            &no_anonymize(),
+        )
+        .expect_err("a contradictory declaration must fail");
+        assert!(matches!(err, ScrubError::Contradiction { .. }), "{err:?}");
+    }
+
+    // ── Automatic classification (AC #2) ────────────────────────────────────
+
+    #[test]
+    fn encrypted_columns_are_pii_without_any_declaration() {
+        let config = parse_config_str(
+            r#"
+            [defaults]
+            safe_columns = ["id", "created_at", "full_name", "bio"]
+            [tables.users]
+            safe = []
+            "#,
+        )
+        .unwrap();
+        let mut encrypted = BTreeMap::new();
+        encrypted.insert(
+            "users".to_owned(),
+            BTreeSet::from(["email".to_owned()]),
+        );
+
+        let plan = plan_for(&[users_table()], &config, &encrypted, &no_anonymize())
+            .expect("an #[encrypted] column needs no declaration");
+        let column = plan
+            .column("users", "email")
+            .expect("email must be in the plan");
+        assert_eq!(column.source, ClassSource::Encrypted);
+    }
+
+    #[test]
+    fn safe_cannot_override_an_encrypted_column() {
+        let config = parse_config_str(
+            r#"
+            [defaults]
+            safe_columns = ["id", "created_at", "full_name", "bio"]
+            [tables.users]
+            safe = ["email"]
+            "#,
+        )
+        .unwrap();
+        let mut encrypted = BTreeMap::new();
+        encrypted.insert("users".to_owned(), BTreeSet::from(["email".to_owned()]));
+
+        let err = plan_for(&[users_table()], &config, &encrypted, &no_anonymize())
+            .expect_err("marking an #[encrypted] column safe must be refused");
+        assert!(
+            matches!(err, ScrubError::SafeOverridesEncrypted { ref columns } if columns == &vec!["users.email".to_owned()]),
+            "got {err:?}"
+        );
+    }
+
+    #[test]
+    fn gdpr_anonymize_table_classifies_its_columns_as_pii() {
+        let config = parse_config_str(
+            r#"
+            [defaults]
+            safe_columns = ["id", "created_at"]
+            "#,
+        )
+        .unwrap();
+        let anonymize = BTreeSet::from(["users".to_owned()]);
+        let plan = plan_for(&[users_table()], &config, &empty_encrypted(), &anonymize)
+            .expect("a GDPR-anonymize table needs no per-column declaration");
+
+        for column in ["email", "full_name", "bio"] {
+            let decision = plan
+                .column("users", column)
+                .unwrap_or_else(|| panic!("{column} must be scrubbed"));
+            assert_eq!(decision.source, ClassSource::GdprAnonymize);
+        }
+        // `id`/`created_at` were explicitly declared safe, so they are untouched.
+        assert!(plan.column("users", "id").is_none());
+        assert!(plan.column("users", "created_at").is_none());
+    }
+
+    #[test]
+    fn safe_may_narrow_a_gdpr_anonymize_table() {
+        let config = parse_config_str(
+            r#"
+            [defaults]
+            safe_columns = ["id", "created_at"]
+            [tables.users]
+            safe = ["full_name"]
+            "#,
+        )
+        .unwrap();
+        let anonymize = BTreeSet::from(["users".to_owned()]);
+        let plan = plan_for(&[users_table()], &config, &empty_encrypted(), &anonymize).unwrap();
+        assert!(plan.column("users", "full_name").is_none());
+        assert!(plan.column("users", "email").is_some());
+    }
+
+    #[test]
+    fn explicit_pii_wins_over_the_auto_strategy() {
+        let config = parse_config_str(
+            r#"
+            [defaults]
+            safe_columns = ["id", "created_at", "full_name", "bio"]
+            [tables.users.pii]
+            email = "redact"
+            "#,
+        )
+        .unwrap();
+        let mut encrypted = BTreeMap::new();
+        encrypted.insert("users".to_owned(), BTreeSet::from(["email".to_owned()]));
+        let plan = plan_for(&[users_table()], &config, &encrypted, &no_anonymize()).unwrap();
+        let column = plan.column("users", "email").unwrap();
+        assert_eq!(column.strategy, Strategy::Redact);
+        assert_eq!(column.source, ClassSource::Config);
+    }
+
+    // ── Constraint safety (AC #4) ───────────────────────────────────────────
+
+    #[test]
+    fn pii_on_a_primary_key_is_refused() {
+        let config = parse_config_str(
+            r#"
+            [defaults]
+            safe_columns = ["created_at", "email", "full_name", "bio"]
+            [tables.users.pii]
+            id = "zero"
+            "#,
+        )
+        .unwrap();
+        let err = plan_for(
+            &[users_table()],
+            &config,
+            &empty_encrypted(),
+            &no_anonymize(),
+        )
+        .expect_err("scrubbing a primary key would break referencing rows");
+        assert!(
+            matches!(err, ScrubError::PiiOnKeyColumn { ref columns } if columns == &vec!["users.id".to_owned()]),
+            "got {err:?}"
+        );
+    }
+
+    #[test]
+    fn pii_on_a_foreign_key_is_refused() {
+        let mut posts = Table::new("posts", Backend::Postgres);
+        posts.primary_key = vec!["id".to_owned()];
+        let mut author = Column::new("author_id", ColumnType::Int64);
+        author.references = Some(ForeignKey::new("users", "id"));
+        posts.columns = vec![pk_col("id"), author];
+
+        let config = parse_config_str(
+            r#"
+            [defaults]
+            safe_columns = ["id"]
+            [tables.posts.pii]
+            author_id = "zero"
+            "#,
+        )
+        .unwrap();
+        let err = plan_for(&[posts], &config, &empty_encrypted(), &no_anonymize())
+            .expect_err("scrubbing a foreign key would break referential integrity");
+        assert!(
+            matches!(err, ScrubError::PiiOnKeyColumn { ref columns } if columns == &vec!["posts.author_id".to_owned()]),
+            "got {err:?}"
+        );
+    }
+
+    #[test]
+    fn a_gdpr_anonymize_table_never_auto_classifies_its_key_columns() {
+        let mut posts = Table::new("posts", Backend::Postgres);
+        posts.primary_key = vec!["id".to_owned()];
+        let mut author = Column::new("author_id", ColumnType::Int64);
+        author.references = Some(ForeignKey::new("users", "id"));
+        posts.columns = vec![pk_col("id"), author, text_col("body")];
+
+        let plan = plan_for(
+            &[posts],
+            &ScrubConfig::default(),
+            &empty_encrypted(),
+            &BTreeSet::from(["posts".to_owned()]),
+        )
+        .expect("key columns are structurally safe under a table-level inference");
+        assert!(plan.column("posts", "id").is_none());
+        assert!(plan.column("posts", "author_id").is_none());
+        assert!(plan.column("posts", "body").is_some());
+    }
+
+    #[test]
+    fn null_strategy_is_refused_on_a_not_null_column() {
+        let config = parse_config_str(
+            r#"
+            [defaults]
+            safe_columns = ["id", "created_at", "email", "bio"]
+            [tables.users.pii]
+            full_name = "null"
+            "#,
+        )
+        .unwrap();
+        let err = plan_for(
+            &[users_table()],
+            &config,
+            &empty_encrypted(),
+            &no_anonymize(),
+        )
+        .expect_err("NULL into a NOT NULL column must be refused at plan time");
+        assert!(matches!(err, ScrubError::NullOnNotNull { .. }), "{err:?}");
+    }
+
+    #[test]
+    fn null_strategy_is_allowed_on_a_nullable_column() {
+        let config = parse_config_str(
+            r#"
+            [defaults]
+            safe_columns = ["id", "created_at", "email", "full_name"]
+            [tables.users.pii]
+            bio = "null"
+            "#,
+        )
+        .unwrap();
+        let plan = plan_for(
+            &[users_table()],
+            &config,
+            &empty_encrypted(),
+            &no_anonymize(),
+        )
+        .unwrap();
+        assert_eq!(plan.column("users", "bio").unwrap().strategy, Strategy::Null);
+    }
+
+    #[test]
+    fn a_non_injective_strategy_is_refused_on_a_unique_column() {
+        let config = parse_config_str(
+            r#"
+            [defaults]
+            safe_columns = ["id", "created_at", "full_name", "bio"]
+            [tables.users.pii]
+            email = "json"
+            "#,
+        )
+        .unwrap();
+        let err = plan_for(
+            &[users_table()],
+            &config,
+            &empty_encrypted(),
+            &no_anonymize(),
+        )
+        .expect_err("a constant replacement would violate the unique index");
+        assert!(
+            matches!(err, ScrubError::NonUniqueStrategy { .. }),
+            "got {err:?}"
+        );
+    }
+
+    // ── Replacement expressions ─────────────────────────────────────────────
+
+    #[test]
+    fn row_key_uses_the_primary_key_when_present() {
+        assert_eq!(
+            row_key_expr(&users_table()),
+            r#"coalesce("id"::text, '')"#
+        );
+    }
+
+    #[test]
+    fn row_key_falls_back_to_ctid_without_a_primary_key() {
+        let mut t = Table::new("legacy", Backend::Postgres);
+        t.columns = vec![text_col("note")];
+        assert_eq!(row_key_expr(&t), "ctid::text");
+    }
+
+    #[test]
+    fn row_key_concatenates_a_composite_primary_key() {
+        let mut t = Table::new("memberships", Backend::Postgres);
+        t.primary_key = vec!["user_id".to_owned(), "team_id".to_owned()];
+        let mut user_id = Column::new("user_id", ColumnType::Int64);
+        user_id.primary_key = true;
+        let mut team_id = Column::new("team_id", ColumnType::Int64);
+        team_id.primary_key = true;
+        t.columns = vec![user_id, team_id];
+        assert_eq!(
+            row_key_expr(&t),
+            r#"coalesce("user_id"::text, '') || '|' || coalesce("team_id"::text, '')"#
+        );
+    }
+
+    #[test]
+    fn token_is_salted_per_column_so_two_columns_never_match() {
+        let table = users_table();
+        assert_ne!(
+            token_expr(&table, "email"),
+            token_expr(&table, "full_name"),
+            "two PII columns of one row must not receive the same fake value"
+        );
+    }
+
+    #[test]
+    fn email_expression_is_unique_per_row_and_uses_a_reserved_domain() {
+        let expr = replacement_expr(Strategy::Email, &text_col("email"), "TOK").unwrap();
+        assert!(expr.contains("TOK"), "must vary per row: {expr}");
+        assert!(
+            expr.contains("@example.invalid"),
+            "must use a reserved, undeliverable domain: {expr}"
+        );
+    }
+
+    #[test]
+    fn varchar_length_bounds_the_generated_value() {
+        let column = Column::new(
+            "email",
+            ColumnType::Opaque {
+                pg_type: "varchar(40)".to_owned(),
+            },
+        );
+        let expr = replacement_expr(Strategy::Email, &column, "TOK").unwrap();
+        // `scrubbed+` (9) + token + `@example.invalid` (16) must fit in 40.
+        assert!(
+            expr.contains("substr(TOK, 1, 15)"),
+            "token must be narrowed to fit varchar(40): {expr}"
+        );
+    }
+
+    #[test]
+    fn a_too_narrow_column_is_refused_rather_than_silently_truncated() {
+        let column = Column::new(
+            "email",
+            ColumnType::Opaque {
+                pg_type: "varchar(28)".to_owned(),
+            },
+        );
+        let err = replacement_expr(Strategy::Email, &column, "TOK")
+            .expect_err("a column too narrow for a unique fake must be refused");
+        assert!(matches!(err, ScrubError::ColumnTooNarrow { .. }), "{err:?}");
+    }
+
+    #[test]
+    fn char_length_is_parsed_from_the_opaque_pg_type() {
+        assert_eq!(
+            char_max_len(&ColumnType::Opaque {
+                pg_type: "varchar(64)".to_owned()
+            }),
+            Some(64)
+        );
+        assert_eq!(
+            char_max_len(&ColumnType::Opaque {
+                pg_type: "char(2)".to_owned()
+            }),
+            Some(2)
+        );
+        assert_eq!(char_max_len(&ColumnType::Text), None);
+        assert_eq!(
+            char_max_len(&ColumnType::Opaque {
+                pg_type: "citext".to_owned()
+            }),
+            None
+        );
+    }
+
+    #[test]
+    fn auto_strategy_is_derived_from_the_column_type() {
+        assert_eq!(
+            auto_strategy(&text_col("email")).unwrap(),
+            Strategy::Email,
+            "an email-named text column gets a syntactically valid address"
+        );
+        assert_eq!(auto_strategy(&text_col("bio")).unwrap(), Strategy::Redact);
+        assert_eq!(
+            auto_strategy(&Column::new("token", ColumnType::Uuid)).unwrap(),
+            Strategy::Uuid
+        );
+        assert_eq!(
+            auto_strategy(&Column::new("blob", ColumnType::Bytes)).unwrap(),
+            Strategy::Bytes
+        );
+        assert_eq!(
+            auto_strategy(&Column::new("meta", ColumnType::Json)).unwrap(),
+            Strategy::Json
+        );
+        assert_eq!(
+            auto_strategy(&Column::new("age", ColumnType::Int32)).unwrap(),
+            Strategy::Zero
+        );
+        assert_eq!(
+            auto_strategy(&Column::new("seen_at", ColumnType::TimestampTz)).unwrap(),
+            Strategy::Epoch
+        );
+    }
+
+    #[test]
+    fn auto_strategy_refuses_to_guess_for_a_closed_set_or_exotic_type() {
+        assert!(matches!(
+            auto_strategy(&Column::new(
+                "status",
+                ColumnType::Enum {
+                    variants: vec!["draft".to_owned()]
+                }
+            )),
+            Err(ScrubError::NoAutoStrategy { .. })
+        ));
+        assert!(matches!(
+            auto_strategy(&Column::new(
+                "addr",
+                ColumnType::Opaque {
+                    pg_type: "inet".to_owned()
+                }
+            )),
+            Err(ScrubError::NoAutoStrategy { .. })
+        ));
+    }
+
+    // ── Statement generation ────────────────────────────────────────────────
+
+    #[test]
+    fn update_preserves_nulls_and_batches_a_table_into_one_statement() {
+        let config = parse_config_str(
+            r#"
+            [defaults]
+            safe_columns = ["id", "created_at"]
+            [tables.users.pii]
+            email = "email"
+            full_name = "name"
+            bio = "redact"
+            "#,
+        )
+        .unwrap();
+        let plan = plan_for(
+            &[users_table()],
+            &config,
+            &empty_encrypted(),
+            &no_anonymize(),
+        )
+        .unwrap();
+        assert_eq!(plan.tables.len(), 1, "one statement per table");
+        let sql = &plan.tables[0].sql;
+        assert!(sql.starts_with(r#"UPDATE "users" SET "#), "{sql}");
+        assert!(
+            sql.contains(r#""bio" = CASE WHEN "bio" IS NULL THEN NULL ELSE"#),
+            "a nullable column must keep its NULLs: {sql}"
+        );
+        assert!(
+            !sql.contains(r#""full_name" = CASE"#),
+            "a NOT NULL column needs no CASE: {sql}"
+        );
+        assert!(sql.contains(r#""email" = "#) && sql.contains(r#""full_name" = "#));
+    }
+
+    #[test]
+    fn a_table_with_no_pii_produces_no_statement() {
+        let config = parse_config_str(
+            r#"
+            [defaults]
+            safe_columns = ["id", "created_at", "email", "full_name", "bio"]
+            "#,
+        )
+        .unwrap();
+        let plan = plan_for(
+            &[users_table()],
+            &config,
+            &empty_encrypted(),
+            &no_anonymize(),
+        )
+        .unwrap();
+        assert!(plan.tables.is_empty(), "nothing to scrub, nothing emitted");
+    }
+
+    #[test]
+    fn identifiers_with_quotes_are_escaped_in_the_statement() {
+        let mut t = Table::new(r#"we"ird"#, Backend::Postgres);
+        t.primary_key = vec!["id".to_owned()];
+        t.columns = vec![pk_col("id"), text_col(r#"na"me"#)];
+        let mut config = ScrubConfig::default();
+        config.defaults.safe_columns = vec!["id".to_owned()];
+        config.tables.insert(
+            r#"we"ird"#.to_owned(),
+            TableRule {
+                safe: Vec::new(),
+                pii: BTreeMap::from([(r#"na"me"#.to_owned(), Strategy::Redact)]),
+            },
+        );
+        let plan = plan_for(&[t], &config, &empty_encrypted(), &no_anonymize()).unwrap();
+        assert!(
+            plan.tables[0].sql.starts_with(r#"UPDATE "we""ird" SET "na""me" = "#),
+            "{}",
+            plan.tables[0].sql
+        );
+    }
+
+    // ── GDPR anonymize extraction from app source ───────────────────────────
+
+    #[test]
+    fn anonymize_registrations_are_extracted_from_source() {
+        let src = r#"
+            use autumn_web::gdpr::{GdprRegistry, ModelRegistration};
+            fn registry() -> GdprRegistry {
+                GdprRegistry::new()
+                    .register(ModelRegistration::hard_delete("posts"))
+                    .register(ModelRegistration::anonymize("comments"))
+                    .register(ModelRegistration::retain("invoices", "legal hold"))
+                    .register(autumn_web::gdpr::ModelRegistration::anonymize("profiles"))
+            }
+        "#;
+        let found = extract_anonymize_tables(src).expect("source must parse");
+        assert_eq!(
+            found,
+            BTreeSet::from(["comments".to_owned(), "profiles".to_owned()])
+        );
+    }
+
+    #[test]
+    fn a_commented_out_registration_is_not_extracted() {
+        let src = r#"
+            fn registry() {
+                // ModelRegistration::anonymize("ghosts")
+                let _ = ModelRegistration::anonymize("comments");
+            }
+        "#;
+        let found = extract_anonymize_tables(src).unwrap();
+        assert_eq!(found, BTreeSet::from(["comments".to_owned()]));
+    }
+
+    #[test]
+    fn a_non_literal_registration_argument_is_reported_not_ignored() {
+        let src = r#"
+            fn registry() {
+                let _ = ModelRegistration::anonymize(table_name());
+            }
+        "#;
+        let err = extract_anonymize_tables(src)
+            .expect_err("a table name the scanner cannot resolve must not pass silently");
+        assert!(matches!(err, ScrubError::UnresolvableAnonymize { .. }), "{err:?}");
+    }
+
+    // ── Production guard (AC #5) ────────────────────────────────────────────
+
+    #[test]
+    fn scrub_refuses_a_production_profile_without_force() {
+        for profile in ["prod", "production", "staging"] {
+            assert!(
+                matches!(
+                    guard_scrub_target(profile, false),
+                    Err(ScrubError::ProductionRefused { .. })
+                ),
+                "{profile} must be refused"
+            );
+            assert!(guard_scrub_target(profile, true).is_ok());
+        }
+        for profile in ["dev", "development", "test"] {
+            assert!(guard_scrub_target(profile, false).is_ok());
+        }
+    }
+
+    #[test]
+    fn same_database_compares_host_port_and_name_ignoring_credentials() {
+        // Same server + database, different credentials: still the same target.
+        assert!(same_database(
+            "postgres://app:pw@db.example.com:5432/myapp",
+            "postgres://readonly:other@db.example.com:5432/myapp"
+        ));
+        assert!(!same_database(
+            "postgres://app:pw@db.example.com:5432/myapp",
+            "postgres://app:pw@db.example.com:5432/myapp_staging"
+        ));
+        assert!(!same_database(
+            "postgres://app:pw@db.example.com:5432/myapp",
+            "postgres://app:pw@staging.example.com:5432/myapp"
+        ));
+        // An unparsable URL never claims a match.
+        assert!(!same_database("not a url", "not a url"));
+    }
+
+    #[test]
+    fn errors_never_leak_credentials() {
+        let err = ScrubError::ProductionRefused {
+            profile: "prod".to_owned(),
+        };
+        let rendered = err.to_string();
+        assert!(rendered.contains("prod"));
+        assert!(!rendered.contains("postgres://"));
+        assert!(!rendered.contains("hunter2"));
+    }
+
+    // ── Report ──────────────────────────────────────────────────────────────
+
+    #[test]
+    fn check_report_prints_a_paste_ready_stanza_for_unclassified_columns() {
+        let stanza = suggested_config_stanza(&[
+            "users.email".to_owned(),
+            "users.full_name".to_owned(),
+            "posts.body".to_owned(),
+        ]);
+        assert!(stanza.contains("[tables.users.pii]"), "{stanza}");
+        assert!(stanza.contains("email = \"auto\""), "{stanza}");
+        assert!(stanza.contains("[tables.posts.pii]"), "{stanza}");
+        assert!(stanza.contains("body = \"auto\""), "{stanza}");
+    }
+
+    #[test]
+    fn index_backed_uniqueness_is_recognized() {
+        // A single-column unique INDEX (not a column flag) still forbids a
+        // constant replacement.
+        let mut t = users_table();
+        t.columns[1].unique = false;
+        t.indexes = vec![Index::new("idx_users_email", vec!["email".to_owned()], true)];
+        let config = parse_config_str(
+            r#"
+            [defaults]
+            safe_columns = ["id", "created_at", "full_name", "bio"]
+            [tables.users.pii]
+            email = "json"
+            "#,
+        )
+        .unwrap();
+        let err = plan_for(&[t], &config, &empty_encrypted(), &no_anonymize())
+            .expect_err("a unique index must be honored like a unique column");
+        assert!(matches!(err, ScrubError::NonUniqueStrategy { .. }), "{err:?}");
+    }
+}

--- a/autumn-cli/src/db/scrub.rs
+++ b/autumn-cli/src/db/scrub.rs
@@ -2359,6 +2359,29 @@ fn probe_connection(url: &str, label: &str, what: &str) -> Result<PgConnection, 
     })
 }
 
+/// Whether a system catalog has a given column on this server.
+///
+/// The catalog grows with each Postgres release — `attgenerated` arrives in 12,
+/// `indnkeyatts` in 11, `indnullsnotdistinct` in 15 — and a scrub that only ran
+/// on the newest server would be useless. Each version-specific fact is probed
+/// for first and degrades to "no such thing on this server", which is the
+/// correct answer: a release without generated columns has none to skip.
+fn has_catalog_column(
+    conn: &mut PgConnection,
+    relation: &str,
+    column: &str,
+) -> Result<bool, ScrubError> {
+    let rows: Vec<NameRow> = sql_query(format!(
+        "SELECT 'yes' AS name FROM pg_attribute \
+         WHERE attrelid = {}::regclass AND attname = {} AND NOT attisdropped",
+        quote_literal(relation),
+        quote_literal(column)
+    ))
+    .load(conn)
+    .map_err(|e| ScrubError::Sql(e.to_string()))?;
+    Ok(!rows.is_empty())
+}
+
 /// Gather every catalog fact the plan validation needs.
 // One catalog read per fact; splitting it would scatter closely-related SQL
 // across helpers that each need the same connection.
@@ -2411,18 +2434,29 @@ fn probe_database_facts(
     );
 
     // ── Generated / identity-always columns ─────────────────────────────────
-    let generated_columns = pair_set(
-        sql_query(
-            "SELECT rel.relname AS tbl, att.attname AS col \
-             FROM pg_attribute att \
-             JOIN pg_class rel ON rel.oid = att.attrelid \
-             JOIN pg_namespace ns ON ns.oid = rel.relnamespace AND ns.nspname = 'public' \
-             WHERE att.attnum > 0 AND NOT att.attisdropped \
-             AND (att.attgenerated <> '' OR att.attidentity = 'a')",
+    let mut generated_predicates: Vec<&str> = Vec::new();
+    if has_catalog_column(&mut conn, "pg_attribute", "attgenerated")? {
+        generated_predicates.push("att.attgenerated <> ''");
+    }
+    if has_catalog_column(&mut conn, "pg_attribute", "attidentity")? {
+        generated_predicates.push("att.attidentity = 'a'");
+    }
+    let generated_columns = if generated_predicates.is_empty() {
+        BTreeSet::new()
+    } else {
+        pair_set(
+            sql_query(format!(
+                "SELECT rel.relname AS tbl, att.attname AS col \
+                 FROM pg_attribute att \
+                 JOIN pg_class rel ON rel.oid = att.attrelid \
+                 JOIN pg_namespace ns ON ns.oid = rel.relnamespace AND ns.nspname = 'public' \
+                 WHERE att.attnum > 0 AND NOT att.attisdropped AND ({})",
+                generated_predicates.join(" OR ")
+            ))
+            .load(&mut conn)
+            .map_err(|e| ScrubError::Sql(e.to_string()))?,
         )
-        .load(&mut conn)
-        .map_err(|e| ScrubError::Sql(e.to_string()))?,
-    );
+    };
 
     // ── Uniqueness, the write-side question ─────────────────────────────────
     // ANY unique index counts (composite and partial included): the IR's
@@ -2432,16 +2466,23 @@ fn probe_database_facts(
     // with `= ANY(...)` rather than `unnest`. The `[0:indnkeyatts-1]` slice is
     // the KEY columns only — a covering index's `INCLUDE` columns carry no
     // uniqueness and must not be treated as constrained.
+    // Covering indexes (`INCLUDE`) arrived with `indnkeyatts` in Postgres 11; on
+    // an older server every `indkey` entry IS a key column.
+    let key_slice = if has_catalog_column(&mut conn, "pg_index", "indnkeyatts")? {
+        "i.indkey[0:i.indnkeyatts-1]"
+    } else {
+        "i.indkey"
+    };
     let unique_columns = pair_set(
-        sql_query(
+        sql_query(format!(
             "SELECT rel.relname AS tbl, att.attname AS col \
              FROM pg_index i \
              JOIN pg_class rel ON rel.oid = i.indrelid \
              JOIN pg_namespace ns ON ns.oid = rel.relnamespace AND ns.nspname = 'public' \
              JOIN pg_attribute att ON att.attrelid = rel.oid \
-             AND att.attnum = ANY(i.indkey[0:i.indnkeyatts-1]) \
-             WHERE i.indisunique AND att.attnum > 0",
-        )
+             AND att.attnum = ANY({key_slice}) \
+             WHERE i.indisunique AND att.attnum > 0"
+        ))
         .load(&mut conn)
         .map_err(|e| ScrubError::Sql(e.to_string()))?,
     );
@@ -2450,29 +2491,24 @@ fn probe_database_facts(
     // `null` strategy stops being unique-safe. `indnullsnotdistinct` does not
     // exist before 15; probe the column's presence first so this stays
     // compatible with older servers.
-    let has_nnd: Vec<NameRow> = sql_query(
-        "SELECT 'yes' AS name FROM pg_attribute \
-         WHERE attrelid = 'pg_index'::regclass AND attname = 'indnullsnotdistinct'",
-    )
-    .load(&mut conn)
-    .map_err(|e| ScrubError::Sql(e.to_string()))?;
-    let nulls_not_distinct_columns = if has_nnd.is_empty() {
-        BTreeSet::new()
-    } else {
-        pair_set(
-            sql_query(
-                "SELECT rel.relname AS tbl, att.attname AS col \
+    let nulls_not_distinct_columns =
+        if has_catalog_column(&mut conn, "pg_index", "indnullsnotdistinct")? {
+            pair_set(
+                sql_query(format!(
+                    "SELECT rel.relname AS tbl, att.attname AS col \
                  FROM pg_index i \
                  JOIN pg_class rel ON rel.oid = i.indrelid \
                  JOIN pg_namespace ns ON ns.oid = rel.relnamespace AND ns.nspname = 'public' \
                  JOIN pg_attribute att ON att.attrelid = rel.oid \
-                 AND att.attnum = ANY(i.indkey[0:i.indnkeyatts-1]) \
-                 WHERE i.indisunique AND i.indnullsnotdistinct AND att.attnum > 0",
+                 AND att.attnum = ANY({key_slice}) \
+                 WHERE i.indisunique AND i.indnullsnotdistinct AND att.attnum > 0"
+                ))
+                .load(&mut conn)
+                .map_err(|e| ScrubError::Sql(e.to_string()))?,
             )
-            .load(&mut conn)
-            .map_err(|e| ScrubError::Sql(e.to_string()))?,
-        )
-    };
+        } else {
+            BTreeSet::new()
+        };
 
     // ── Table-level facts ───────────────────────────────────────────────────
     let names = |q: &str, conn: &mut PgConnection| -> Result<Vec<String>, ScrubError> {
@@ -2482,14 +2518,18 @@ fn probe_database_facts(
         Ok(rows.into_iter().map(|r| r.name).collect())
     };
 
-    let partitions = names(
-        "SELECT rel.relname AS name FROM pg_class rel \
-         JOIN pg_namespace ns ON ns.oid = rel.relnamespace AND ns.nspname = 'public' \
-         WHERE rel.relispartition",
-        &mut conn,
-    )?
-    .into_iter()
-    .collect();
+    let partitions = if has_catalog_column(&mut conn, "pg_class", "relispartition")? {
+        names(
+            "SELECT rel.relname AS name FROM pg_class rel \
+             JOIN pg_namespace ns ON ns.oid = rel.relnamespace AND ns.nspname = 'public' \
+             WHERE rel.relispartition",
+            &mut conn,
+        )?
+        .into_iter()
+        .collect()
+    } else {
+        BTreeSet::new()
+    };
 
     let rls_tables = names(
         "SELECT rel.relname AS name FROM pg_class rel \

--- a/autumn-cli/src/db/scrub.rs
+++ b/autumn-cli/src/db/scrub.rs
@@ -1,7 +1,1716 @@
-//! `autumn db scrub` — RED phase (issue #1602).
+//! `autumn db scrub` — turn a production database (or a `autumn db backup`
+//! artifact) into an anonymized copy that is safe on a laptop or a shared
+//! staging box (issue #1602).
 //!
-//! Tests are written first, against the intended API. The implementation lands
-//! in the GREEN commit.
+//! # Why this exists
+//!
+//! The moment logical backups ship (#1595), a production copy is one command
+//! away from a non-production machine — PII and all. Every peer tool for this
+//! job (Greenmask, pgsync + obfuscation config, the PostgreSQL Anonymizer
+//! extension, django-scrubber) is **schema-blind**: the developer hand-maintains
+//! a column list that silently rots the first time someone adds an `email`
+//! column, which is exactly the failure mode that leaks PII.
+//!
+//! Autumn is not schema-blind. This command classifies columns from three
+//! sources, in precedence order:
+//!
+//! 1. **`[tables.<t>.pii]` in `scrub.toml`** — the developer's explicit
+//!    declaration, including the replacement strategy.
+//! 2. **`#[encrypted]` model columns** — machine-readable PII semantics the
+//!    framework already holds ([`crate::schema::parse::parse_encrypted_columns`]).
+//!    A `safe` declaration may **not** override these.
+//! 3. **GDPR `ModelRegistration::anonymize("<table>")` registrations** — a
+//!    table-level signal, so every non-key column of that table is classified
+//!    PII unless explicitly declared `safe`.
+//!
+//! Everything left over is **unclassified**, and an unclassified column is a
+//! hard failure ([`ScrubError::Unclassified`]) — never a silent pass-through.
+//! Because the column universe comes from **introspecting the live database**
+//! (not from the config file), a column added yesterday cannot be missing from
+//! that universe: adding a column without declaring it breaks the scrub, which
+//! is the whole point.
+//!
+//! # Safety properties
+//!
+//! - **Fail-closed.** Unclassified, stale (naming a column that no longer
+//!   exists), and self-contradictory declarations all refuse before a single row
+//!   is touched.
+//! - **Production guard.** Writing refuses outside `dev`/`test` without
+//!   `--force`, the identical protocol as `autumn db drop`
+//!   ([`crate::db::guard_destructive`]).
+//! - **Constraint-preserving.** PII on a primary- or foreign-key column is
+//!   refused outright (so referential integrity is untouched), `NULL` is refused
+//!   on a `NOT NULL` column, a constant replacement is refused on a `UNIQUE`
+//!   column, and a `varchar(n)` bound narrows the generated value or refuses.
+//! - **Atomic.** Every statement for one database runs in a single transaction:
+//!   a half-scrubbed database is never left behind.
+//! - **Credential-safe.** No error or report ever embeds a resolved URL.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::{Path, PathBuf};
+
+use autumn_schema_core::{Column, ColumnType, Table};
+use diesel::{Connection as _, PgConnection, RunQueryDsl as _, sql_query};
+use serde::Deserialize;
+
+use crate::migrate;
+use crate::schema::introspect;
+
+use super::{quote_ident, quote_literal};
+
+/// The per-app PII declaration file, read from the project root unless
+/// `--config` points elsewhere.
+pub const SCRUB_CONFIG_FILE: &str = "scrub.toml";
+
+/// Width of the per-row `md5` token, in hex characters.
+const TOKEN_HEX_LEN: usize = 32;
+
+/// Narrowest token a length-bounded column may carry and still be treated as
+/// per-row unique. Below this the column is refused rather than silently
+/// truncated into collisions.
+const MIN_TOKEN_WIDTH: usize = 8;
+
+/// The reserved, permanently undeliverable domain scrubbed addresses use
+/// (RFC 6761 reserves `.invalid`).
+const SCRUB_EMAIL_DOMAIN: &str = "@example.invalid";
+
+// ─── Arguments ──────────────────────────────────────────────────────────────
+
+/// Arguments for `autumn db scrub`.
+#[derive(Debug, Clone, Default)]
+pub struct ScrubArgs {
+    /// Profile overlay to resolve the connection under (see `db create`).
+    pub profile: Option<String>,
+    /// Restore this backup run directory (or artifact file) into the resolved
+    /// database(s) before scrubbing, closing the backup → scrub → restore loop.
+    pub artifact: Option<PathBuf>,
+    /// After a successful scrub, write a fresh backup run into this directory —
+    /// a scrubbed artifact that can be handed to a teammate.
+    pub output: Option<PathBuf>,
+    /// Path to the PII declaration file (default: `./scrub.toml`).
+    pub config: Option<PathBuf>,
+    /// Classify only: report the plan (or the unclassified columns) and write
+    /// nothing.
+    pub check: bool,
+    /// Print the exact SQL the scrub would run and write nothing.
+    pub dry_run: bool,
+    /// Bypass the production guard (mirrors `autumn db drop --force`).
+    pub force: bool,
+}
+
+// ─── Errors ─────────────────────────────────────────────────────────────────
+
+/// Failure modes for `autumn db scrub`. `Display` is credential-safe: no variant
+/// ever embeds a resolved URL (only a parsed host/port/db), matching the rest of
+/// the `db` command family.
+#[derive(Debug)]
+pub enum ScrubError {
+    /// One or more columns are neither PII-classified nor explicitly declared
+    /// safe. The scrub refuses rather than let real data through (AC #3).
+    Unclassified {
+        /// `table.column`, sorted.
+        columns: Vec<String>,
+    },
+    /// The declaration names a table or column the database does not have —
+    /// the config has rotted away from the schema.
+    StaleConfig {
+        /// `table` or `table.column`, sorted.
+        entries: Vec<String>,
+    },
+    /// A column is declared both `safe` and PII in the same table.
+    Contradiction {
+        /// `table.column`, sorted.
+        columns: Vec<String>,
+    },
+    /// A `safe` declaration tried to un-classify an `#[encrypted]` column.
+    SafeOverridesEncrypted {
+        /// `table.column`, sorted.
+        columns: Vec<String>,
+    },
+    /// PII was declared on a primary- or foreign-key column, which a scrub may
+    /// never rewrite without breaking referential integrity.
+    PiiOnKeyColumn {
+        /// `table.column`, sorted.
+        columns: Vec<String>,
+    },
+    /// No replacement can be derived from the column's type alone.
+    NoAutoStrategy {
+        /// The column name.
+        column: String,
+        /// The unsupported type, rendered for humans.
+        detail: String,
+    },
+    /// The `null` strategy was declared on a `NOT NULL` column.
+    NullOnNotNull {
+        /// `table.column`.
+        column: String,
+    },
+    /// A strategy that yields the same value for every row was declared on a
+    /// `UNIQUE` column.
+    NonUniqueStrategy {
+        /// `table.column`.
+        column: String,
+        /// The offending strategy name.
+        strategy: &'static str,
+    },
+    /// A strategy cannot produce a value of the column's type.
+    StrategyTypeMismatch {
+        /// The column name.
+        column: String,
+        /// The offending strategy name.
+        strategy: &'static str,
+        /// The column type, rendered for humans.
+        detail: String,
+    },
+    /// A length-bounded column is too narrow to hold a per-row-unique fake.
+    ColumnTooNarrow {
+        /// The column name.
+        column: String,
+        /// The column's character limit.
+        limit: usize,
+        /// Characters the strategy's fixed affixes already consume.
+        overhead: usize,
+    },
+    /// The declaration file could not be read or parsed.
+    Config {
+        /// The path that failed.
+        path: String,
+        /// A human-readable reason.
+        detail: String,
+    },
+    /// An app source file could not be read or parsed while scanning for
+    /// `#[encrypted]` columns / GDPR registrations.
+    SourceScan {
+        /// A human-readable reason (carries the offending path).
+        detail: String,
+    },
+    /// A `ModelRegistration::anonymize(...)` call was found whose table name is
+    /// not a string literal, so the scanner cannot classify it. Refused rather
+    /// than ignored — an unreadable registration must not look like an absent
+    /// one.
+    UnresolvableAnonymize {
+        /// The call as written, for the developer to find it.
+        detail: String,
+    },
+    /// The database could not be introspected or connected to. Carries only the
+    /// parsed host/port/db, never the credentials.
+    Introspect {
+        /// The target label (`control` / `shard:<name>`).
+        label: String,
+        /// A credential-safe reason.
+        detail: String,
+    },
+    /// A scrub statement failed. The message comes from the server.
+    Sql(String),
+    /// The scrub was refused because the active profile is production and
+    /// `--force` was not supplied.
+    ProductionRefused {
+        /// The effective profile name.
+        profile: String,
+    },
+    /// The write target is the database a profile's **config file** declares —
+    /// the artifact's own source — so the scrub would overwrite it.
+    OverwritesConfiguredTarget {
+        /// The profile whose config names this database.
+        profile: String,
+        /// The database name (never a URL).
+        database: String,
+    },
+    /// `[framework] purge` names a table that is not framework-owned. Emptying a
+    /// user table is never something a scrub does implicitly.
+    PurgeNotFrameworkTable {
+        /// The offending table names, sorted.
+        tables: Vec<String>,
+    },
+    /// A backup/restore step (artifact restore, `--output` re-dump) failed.
+    Backup(Box<super::backup::BackupError>),
+}
+
+impl std::fmt::Display for ScrubError {
+    // One arm per variant, each a single multi-line, actionable message; splitting
+    // the match would scatter the error copy across helpers for no reader benefit.
+    #[allow(clippy::too_many_lines)]
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Unclassified { columns } => write!(
+                f,
+                "{} column(s) are neither PII-classified nor declared safe, so the scrub \
+                 cannot prove they carry no real data:\n{}\n  \
+                 Declare each one in {SCRUB_CONFIG_FILE} — under [tables.<table>.pii] to \
+                 replace it, or in `safe` to keep it verbatim. Run `autumn db scrub --check` \
+                 for a paste-ready starting point.",
+                columns.len(),
+                bullet_list(columns),
+            ),
+            Self::StaleConfig { entries } => write!(
+                f,
+                "{SCRUB_CONFIG_FILE} names {} table(s)/column(s) the database does not have:\n{}\n  \
+                 The declaration has drifted from the schema — remove or rename the stale \
+                 entries (a renamed column must be re-declared under its new name).",
+                entries.len(),
+                bullet_list(entries),
+            ),
+            Self::Contradiction { columns } => write!(
+                f,
+                "{} column(s) are declared both `safe` and PII in {SCRUB_CONFIG_FILE}:\n{}\n  \
+                 Pick one.",
+                columns.len(),
+                bullet_list(columns),
+            ),
+            Self::SafeOverridesEncrypted { columns } => write!(
+                f,
+                "{} column(s) carry #[encrypted] in the model but are declared `safe` in \
+                 {SCRUB_CONFIG_FILE}:\n{}\n  \
+                 An at-rest-encrypted column is PII by construction and cannot be declared \
+                 safe. Remove the `safe` entry (or drop #[encrypted] from the model if the \
+                 column really is not sensitive).",
+                columns.len(),
+                bullet_list(columns),
+            ),
+            Self::PiiOnKeyColumn { columns } => write!(
+                f,
+                "{} column(s) are primary or foreign keys but declared PII:\n{}\n  \
+                 Rewriting a key column would break referential integrity. Scrub the \
+                 referenced table's own PII columns instead, and declare these `safe`.",
+                columns.len(),
+                bullet_list(columns),
+            ),
+            Self::NoAutoStrategy { column, detail } => write!(
+                f,
+                "No replacement can be derived for {column:?} from its type ({detail}).\n  \
+                 Declare an explicit strategy for it under [tables.<table>.pii] in \
+                 {SCRUB_CONFIG_FILE} (for example `= \"redact\"`), or declare the column \
+                 `safe`."
+            ),
+            Self::NullOnNotNull { column } => write!(
+                f,
+                "{column:?} is NOT NULL, so the `null` strategy would violate the column \
+                 constraint.\n  Use `redact` (or another value-producing strategy) instead."
+            ),
+            Self::NonUniqueStrategy { column, strategy } => write!(
+                f,
+                "{column:?} is UNIQUE, but the `{strategy}` strategy writes the same value \
+                 into every row and would violate the unique constraint.\n  \
+                 Use a per-row-unique strategy (`redact`, `email`, `name`, `uuid`, `bytes`)."
+            ),
+            Self::StrategyTypeMismatch {
+                column,
+                strategy,
+                detail,
+            } => write!(
+                f,
+                "The `{strategy}` strategy cannot produce a value for {column:?} ({detail}).\n  \
+                 Pick a strategy that matches the column type."
+            ),
+            Self::ColumnTooNarrow {
+                column,
+                limit,
+                overhead,
+            } => write!(
+                f,
+                "{column:?} holds at most {limit} characters, but the chosen strategy needs \
+                 {overhead} for its fixed text plus at least {MIN_TOKEN_WIDTH} more for a \
+                 per-row-unique token.\n  Use a shorter strategy (`redact`), widen the \
+                 column, or declare it `safe`."
+            ),
+            Self::Config { path, detail } => write!(f, "Cannot read {path}: {detail}"),
+            Self::SourceScan { detail } => write!(
+                f,
+                "Could not scan the app source for PII annotations: {detail}"
+            ),
+            Self::UnresolvableAnonymize { detail } => write!(
+                f,
+                "A GDPR anonymize registration names a table this scanner cannot resolve: \
+                 {detail}\n  `autumn db scrub` reads `ModelRegistration::anonymize(\"...\")` \
+                 with a string-literal table name. Use a literal there, or declare the \
+                 table's columns explicitly in {SCRUB_CONFIG_FILE}."
+            ),
+            Self::Introspect { label, detail } => {
+                write!(f, "Could not read the schema of {label}: {detail}")
+            }
+            Self::Sql(message) => write!(f, "{message}"),
+            Self::ProductionRefused { profile } => write!(
+                f,
+                "Refusing to scrub the {profile:?} profile database.\n  \
+                 A scrub REWRITES data in place — running it against production would \
+                 destroy the real values. Point --profile at your staging/dev target, or \
+                 re-run with --force if you really mean it."
+            ),
+            Self::OverwritesConfiguredTarget { profile, database } => write!(
+                f,
+                "Refusing to scrub {database:?}: it is the database the {profile:?} profile's \
+                 config file declares.\n  \
+                 The scrub would overwrite the source it was taken from. Point the target at \
+                 a separate staging database, or re-run with --force."
+            ),
+            Self::PurgeNotFrameworkTable { tables } => write!(
+                f,
+                "[framework] purge in {SCRUB_CONFIG_FILE} names {} table(s) that are not \
+                 framework-owned:\n{}\n  \
+                 `purge` empties a table outright and only accepts framework-owned names \
+                 (`autumn_*` / `_autumn*`, plus the framework's unprefixed tables). Declare \
+                 a user table's columns under [tables.<table>.pii] instead.",
+                tables.len(),
+                bullet_list(tables),
+            ),
+            Self::Backup(e) => write!(f, "{e}"),
+        }
+    }
+}
+
+impl From<super::backup::BackupError> for ScrubError {
+    fn from(e: super::backup::BackupError) -> Self {
+        Self::Backup(Box::new(e))
+    }
+}
+
+/// Render a sorted list as indented bullets for a multi-line error message.
+fn bullet_list(items: &[String]) -> String {
+    items
+        .iter()
+        .map(|item| format!("    - {item}"))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+// ─── Declaration file ───────────────────────────────────────────────────────
+
+/// How a PII column's value is replaced.
+///
+/// Every strategy derives from an `md5` token over the row's primary key salted
+/// with the column name, so two columns of one row never receive the same fake
+/// value and a `UNIQUE` column keeps its uniqueness. For a table with a primary
+/// key the result is also **stable across runs** (the same row always scrubs to
+/// the same value); a table with no primary key falls back to the physical
+/// `ctid`, which is unique within the statement but not stable between runs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Strategy {
+    /// Derive the strategy from the column's type (the default for
+    /// automatically-classified columns).
+    Auto,
+    /// A syntactically valid, permanently undeliverable address.
+    Email,
+    /// A human-shaped placeholder name.
+    Name,
+    /// A `+1555`-prefixed placeholder number.
+    Phone,
+    /// An obviously-fake bracketed marker.
+    Redact,
+    /// `NULL` (refused on a `NOT NULL` column).
+    Null,
+    /// A deterministic replacement UUID.
+    Uuid,
+    /// Deterministic replacement bytes.
+    Bytes,
+    /// A constant `{"scrubbed": true}` document.
+    Json,
+    /// Numeric zero / boolean false.
+    Zero,
+    /// The Unix epoch.
+    Epoch,
+}
+
+impl Strategy {
+    /// The name as written in `scrub.toml`.
+    const fn as_str(self) -> &'static str {
+        match self {
+            Self::Auto => "auto",
+            Self::Email => "email",
+            Self::Name => "name",
+            Self::Phone => "phone",
+            Self::Redact => "redact",
+            Self::Null => "null",
+            Self::Uuid => "uuid",
+            Self::Bytes => "bytes",
+            Self::Json => "json",
+            Self::Zero => "zero",
+            Self::Epoch => "epoch",
+        }
+    }
+
+    /// Whether this strategy may be used on a `UNIQUE` column.
+    ///
+    /// `Null` qualifies despite writing one value: Postgres permits any number
+    /// of `NULL`s in a unique index. `Phone` does not — its digits are a lossy
+    /// projection of the token, so collisions are possible.
+    const fn allowed_on_unique(self) -> bool {
+        matches!(
+            self,
+            Self::Auto
+                | Self::Email
+                | Self::Name
+                | Self::Redact
+                | Self::Null
+                | Self::Uuid
+                | Self::Bytes
+        )
+    }
+}
+
+/// Declarations that apply to every table.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ScrubDefaults {
+    /// Column names that are safe in **any** table — the one-line escape from
+    /// declaring `id` / `created_at` / `updated_at` in every stanza.
+    #[serde(default)]
+    pub safe_columns: Vec<String>,
+}
+
+/// One table's declaration.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct TableRule {
+    /// Columns reviewed and deliberately kept verbatim.
+    #[serde(default)]
+    pub safe: Vec<String>,
+    /// PII columns and how each is replaced.
+    #[serde(default)]
+    pub pii: BTreeMap<String, Strategy>,
+}
+
+/// How framework-owned tables are handled.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct FrameworkRule {
+    /// Framework-owned tables to empty during the scrub. Opt-in: by default the
+    /// scrub only *warns* about the ones that carry app-supplied payloads.
+    #[serde(default)]
+    pub purge: Vec<String>,
+}
+
+/// The parsed `scrub.toml`.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ScrubConfig {
+    /// Cross-table declarations.
+    #[serde(default)]
+    pub defaults: ScrubDefaults,
+    /// Per-table declarations, keyed by table name.
+    #[serde(default)]
+    pub tables: BTreeMap<String, TableRule>,
+    /// Framework-owned table handling.
+    #[serde(default)]
+    pub framework: FrameworkRule,
+}
+
+/// Framework-owned tables whose rows carry **app-supplied** payloads, and can
+/// therefore hold PII the column-level classification never sees: introspection
+/// deliberately skips `autumn_*` / `_autumn*` tables (mirroring `autumn db pull`
+/// and `autumn schema pull`), so their columns are not part of the classified
+/// universe at all.
+///
+/// A scrub warns when one of these is present, and empties it when the app opts
+/// in with `[framework] purge = [...]`. Every entry here is transient
+/// operational state that a staging copy has no reason to inherit — a queued job
+/// payload, an offline-sync row buffer, an experiment assignment — never
+/// schema-bearing bookkeeping like `autumn_migration_checksums`.
+const FRAMEWORK_PAYLOAD_TABLES: &[&str] = &[
+    // Hashed API tokens minted in production. A staging copy that inherits them
+    // is a live credential leak, not merely a PII one.
+    "api_tokens",
+    "autumn_experiment_assignments",
+    "autumn_job_tracking",
+    "autumn_jobs",
+    "autumn_sync_applied",
+    "autumn_sync_pending",
+    "autumn_sync_rows",
+];
+
+/// Framework-owned tables whose names do not carry the `autumn_` / `_autumn`
+/// prefix. Kept in lock-step with `crate::schema::introspect`'s
+/// `is_framework_table`, which is what decides they are excluded from the
+/// classified universe in the first place.
+const UNPREFIXED_FRAMEWORK_TABLES: &[&str] = &[
+    "api_tokens",
+    "feature_flag_changes",
+    "__diesel_schema_migrations",
+];
+
+/// Whether a table name is framework-owned — i.e. one introspection filters out
+/// of the classified universe, so the column-level classification never sees it.
+fn is_framework_table(table: &str) -> bool {
+    table.starts_with("autumn_")
+        || table.starts_with("_autumn")
+        || UNPREFIXED_FRAMEWORK_TABLES.contains(&table)
+}
+
+/// Validate a `[framework] purge` list: it may only name framework-owned tables.
+/// A user table listed there would be silently emptied, which is never what a
+/// scrub should do behind a one-word config key.
+fn check_purge_list(config: &ScrubConfig) -> Result<(), ScrubError> {
+    let mut offenders: Vec<String> = config
+        .framework
+        .purge
+        .iter()
+        .filter(|t| !is_framework_table(t))
+        .cloned()
+        .collect();
+    if offenders.is_empty() {
+        return Ok(());
+    }
+    offenders.sort();
+    Err(ScrubError::PurgeNotFrameworkTable { tables: offenders })
+}
+
+/// Parse a `scrub.toml` document.
+///
+/// # Errors
+///
+/// Returns [`ScrubError::Config`] when the document is not valid TOML, names an
+/// unknown key, or names an unknown strategy.
+#[cfg(test)]
+fn parse_config_str(src: &str) -> Result<ScrubConfig, ScrubError> {
+    parse_config_at(src, Path::new(SCRUB_CONFIG_FILE))
+}
+
+/// [`parse_config_str`], attributing any error to the file it came from.
+fn parse_config_at(src: &str, path: &Path) -> Result<ScrubConfig, ScrubError> {
+    toml::from_str(src).map_err(|e| ScrubError::Config {
+        path: path.display().to_string(),
+        detail: e.to_string(),
+    })
+}
+
+/// Load the declaration file, defaulting to an empty declaration when the
+/// conventional path is simply absent (every column is then unclassified, which
+/// is the fail-closed outcome the developer is told how to fix).
+fn load_config(explicit: Option<&Path>) -> Result<ScrubConfig, ScrubError> {
+    load_config_at(explicit, Path::new(SCRUB_CONFIG_FILE))
+}
+
+/// [`load_config`] against an explicit conventional path, so the "a missing
+/// default is fine, a missing explicit path is not" rule is testable without
+/// mutating the process working directory.
+fn load_config_at(explicit: Option<&Path>, default: &Path) -> Result<ScrubConfig, ScrubError> {
+    let path = explicit.map_or_else(|| default.to_path_buf(), Path::to_path_buf);
+    match std::fs::read_to_string(&path) {
+        Ok(src) => parse_config_at(&src, &path),
+        // An explicitly-named file that is missing is an error; the conventional
+        // default simply may not exist yet.
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound && explicit.is_none() => {
+            Ok(ScrubConfig::default())
+        }
+        Err(e) => Err(ScrubError::Config {
+            path: path.display().to_string(),
+            detail: e.to_string(),
+        }),
+    }
+}
+
+// ─── Classification ─────────────────────────────────────────────────────────
+
+/// Where a column's classification came from.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ClassSource {
+    /// An explicit `[tables.<t>.pii]` entry.
+    Config,
+    /// An `#[encrypted]` model column.
+    Encrypted,
+    /// A table registered with the GDPR anonymize strategy.
+    GdprAnonymize,
+}
+
+impl ClassSource {
+    /// A short label for the scrub report.
+    const fn as_str(self) -> &'static str {
+        match self {
+            Self::Config => "declared",
+            Self::Encrypted => "#[encrypted]",
+            Self::GdprAnonymize => "gdpr:anonymize",
+        }
+    }
+}
+
+/// Everything the classifier reads. Grouped into one struct so the pure
+/// classification step stays testable without a database.
+pub struct ClassificationInputs<'a> {
+    /// The live schema (framework-owned tables already excluded).
+    pub tables: &'a [Table],
+    /// The developer's declaration.
+    pub config: &'a ScrubConfig,
+    /// `#[encrypted]` columns, keyed by table.
+    pub encrypted: &'a BTreeMap<String, BTreeSet<String>>,
+    /// Tables registered with the GDPR anonymize strategy.
+    pub anonymize_tables: &'a BTreeSet<String>,
+}
+
+/// One column the scrub will rewrite.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ColumnPlan {
+    /// The column name.
+    pub column: String,
+    /// The resolved (never [`Strategy::Auto`]) replacement strategy.
+    pub strategy: Strategy,
+    /// What classified it.
+    pub source: ClassSource,
+}
+
+/// One table's scrub statement.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TablePlan {
+    /// The table name.
+    pub table: String,
+    /// The columns rewritten, in table column order.
+    pub columns: Vec<ColumnPlan>,
+    /// The single `UPDATE` that rewrites them all.
+    pub sql: String,
+}
+
+/// The full set of statements a scrub will run against one database.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ScrubPlan {
+    /// One entry per table with at least one PII column, in table order.
+    pub tables: Vec<TablePlan>,
+}
+
+impl ScrubPlan {
+    /// Look up one column's decision, if the scrub rewrites it.
+    #[cfg(test)]
+    fn column(&self, table: &str, column: &str) -> Option<&ColumnPlan> {
+        self.tables
+            .iter()
+            .find(|t| t.table == table)?
+            .columns
+            .iter()
+            .find(|c| c.column == column)
+    }
+
+    /// Total number of columns the scrub rewrites.
+    #[must_use]
+    pub fn column_count(&self) -> usize {
+        self.tables.iter().map(|t| t.columns.len()).sum()
+    }
+}
+
+/// Classify every column of every table and build the statements, or refuse.
+///
+/// The checks run in a fixed order so one run reports the most fundamental
+/// problem rather than a cascade: declaration rot first (stale, contradictory,
+/// overriding `#[encrypted]`), then structural refusals (PII on a key column),
+/// then the fail-closed sweep, then per-column strategy validation.
+///
+/// # Errors
+///
+/// Returns the corresponding [`ScrubError`] variant for each refusal above.
+pub fn build_plan(inputs: &ClassificationInputs<'_>) -> Result<ScrubPlan, ScrubError> {
+    let by_name: BTreeMap<&str, &Table> =
+        inputs.tables.iter().map(|t| (t.name.as_str(), t)).collect();
+
+    check_config_freshness(inputs, &by_name)?;
+    check_contradictions(inputs)?;
+    check_safe_overrides_encrypted(inputs, &by_name)?;
+
+    let mut unclassified = Vec::new();
+    let mut key_pii = Vec::new();
+    let mut planned: Vec<(&Table, Vec<(ColumnPlan, &Column)>)> = Vec::new();
+
+    for table in inputs.tables {
+        let rule = inputs.config.tables.get(&table.name);
+        let anonymized = inputs.anonymize_tables.contains(&table.name);
+        let encrypted = inputs.encrypted.get(&table.name);
+        let mut columns = Vec::new();
+
+        for column in &table.columns {
+            let qualified = format!("{}.{}", table.name, column.name);
+            let is_key = is_key_column(table, column);
+            let declared_pii = rule.and_then(|r| r.pii.get(&column.name)).copied();
+            let is_encrypted = encrypted.is_some_and(|e| e.contains(&column.name));
+            let declared_safe = rule.is_some_and(|r| r.safe.contains(&column.name))
+                || inputs.config.defaults.safe_columns.contains(&column.name);
+
+            let (spec, source) = if let Some(strategy) = declared_pii {
+                (strategy, ClassSource::Config)
+            } else if is_encrypted {
+                (Strategy::Auto, ClassSource::Encrypted)
+            } else if declared_safe {
+                continue;
+            } else if anonymized {
+                // A table-level inference never claims the structural columns:
+                // rewriting a key would break referential integrity, and the
+                // registration says nothing about them.
+                if is_key {
+                    continue;
+                }
+                (Strategy::Auto, ClassSource::GdprAnonymize)
+            } else {
+                unclassified.push(qualified);
+                continue;
+            };
+
+            if is_key {
+                key_pii.push(qualified);
+                continue;
+            }
+            columns.push((
+                ColumnPlan {
+                    column: column.name.clone(),
+                    strategy: spec,
+                    source,
+                },
+                column,
+            ));
+        }
+        planned.push((table, columns));
+    }
+
+    if !key_pii.is_empty() {
+        key_pii.sort();
+        return Err(ScrubError::PiiOnKeyColumn { columns: key_pii });
+    }
+    if !unclassified.is_empty() {
+        unclassified.sort();
+        return Err(ScrubError::Unclassified {
+            columns: unclassified,
+        });
+    }
+
+    let mut out = ScrubPlan::default();
+    for (table, columns) in planned {
+        if columns.is_empty() {
+            continue;
+        }
+        let mut resolved = Vec::with_capacity(columns.len());
+        let mut assignments = Vec::with_capacity(columns.len());
+        for (mut plan, column) in columns {
+            let qualified = format!("{}.{}", table.name, column.name);
+            if plan.strategy == Strategy::Auto {
+                plan.strategy = auto_strategy(column).map_err(|e| qualify(e, &qualified))?;
+            }
+            if plan.strategy == Strategy::Null && !column.nullable {
+                return Err(ScrubError::NullOnNotNull { column: qualified });
+            }
+            if is_unique_column(table, column) && !plan.strategy.allowed_on_unique() {
+                return Err(ScrubError::NonUniqueStrategy {
+                    column: qualified,
+                    strategy: plan.strategy.as_str(),
+                });
+            }
+            let token = token_expr(table, &column.name);
+            let value = replacement_expr(plan.strategy, column, &token)
+                .map_err(|e| qualify(e, &qualified))?;
+            assignments.push(assignment(column, &value));
+            resolved.push(plan);
+        }
+        out.tables.push(TablePlan {
+            table: table.name.clone(),
+            columns: resolved,
+            sql: format!(
+                "UPDATE {} SET {}",
+                quote_ident(&table.name),
+                assignments.join(", ")
+            ),
+        });
+    }
+    Ok(out)
+}
+
+/// Re-label a per-column error with its `table.column` name.
+///
+/// The expression builders work from a bare [`Column`] and cannot know which
+/// table it came from, but a bare column name is ambiguous in a report (three
+/// tables can each have an `email`). The classifier knows both, so it qualifies
+/// the name on the way out.
+fn qualify(error: ScrubError, qualified: &str) -> ScrubError {
+    let column = qualified.to_owned();
+    match error {
+        ScrubError::NoAutoStrategy { detail, .. } => ScrubError::NoAutoStrategy { column, detail },
+        ScrubError::StrategyTypeMismatch {
+            strategy, detail, ..
+        } => ScrubError::StrategyTypeMismatch {
+            column,
+            strategy,
+            detail,
+        },
+        ScrubError::ColumnTooNarrow {
+            limit, overhead, ..
+        } => ScrubError::ColumnTooNarrow {
+            column,
+            limit,
+            overhead,
+        },
+        other => other,
+    }
+}
+
+/// Refuse a declaration that names a table or column the database no longer has
+/// — the exact rot that lets a renamed column leak.
+fn check_config_freshness(
+    inputs: &ClassificationInputs<'_>,
+    by_name: &BTreeMap<&str, &Table>,
+) -> Result<(), ScrubError> {
+    let mut stale = Vec::new();
+    for (name, rule) in &inputs.config.tables {
+        let Some(table) = by_name.get(name.as_str()) else {
+            stale.push(name.clone());
+            continue;
+        };
+        let columns: BTreeSet<&str> = table.columns.iter().map(|c| c.name.as_str()).collect();
+        for column in rule.safe.iter().chain(rule.pii.keys()) {
+            if !columns.contains(column.as_str()) {
+                stale.push(format!("{name}.{column}"));
+            }
+        }
+    }
+    if stale.is_empty() {
+        return Ok(());
+    }
+    stale.sort();
+    stale.dedup();
+    Err(ScrubError::StaleConfig { entries: stale })
+}
+
+/// Refuse a column declared both `safe` and PII.
+fn check_contradictions(inputs: &ClassificationInputs<'_>) -> Result<(), ScrubError> {
+    let mut columns = Vec::new();
+    for (name, rule) in &inputs.config.tables {
+        for column in &rule.safe {
+            if rule.pii.contains_key(column) {
+                columns.push(format!("{name}.{column}"));
+            }
+        }
+    }
+    if columns.is_empty() {
+        return Ok(());
+    }
+    columns.sort();
+    Err(ScrubError::Contradiction { columns })
+}
+
+/// Refuse a `safe` declaration that would un-classify an `#[encrypted]` column.
+/// An at-rest-encrypted column is PII by construction; letting a declaration
+/// override it would reintroduce exactly the silent-passthrough this command
+/// exists to prevent.
+fn check_safe_overrides_encrypted(
+    inputs: &ClassificationInputs<'_>,
+    by_name: &BTreeMap<&str, &Table>,
+) -> Result<(), ScrubError> {
+    let mut columns = Vec::new();
+    for (table, encrypted) in inputs.encrypted {
+        if !by_name.contains_key(table.as_str()) {
+            continue;
+        }
+        let rule = inputs.config.tables.get(table);
+        for column in encrypted {
+            // An explicit PII entry is not an override — it only picks the
+            // strategy — so only `safe` declarations conflict.
+            if rule.is_some_and(|r| r.pii.contains_key(column)) {
+                continue;
+            }
+            if rule.is_some_and(|r| r.safe.contains(column))
+                || inputs.config.defaults.safe_columns.contains(column)
+            {
+                columns.push(format!("{table}.{column}"));
+            }
+        }
+    }
+    if columns.is_empty() {
+        return Ok(());
+    }
+    columns.sort();
+    Err(ScrubError::SafeOverridesEncrypted { columns })
+}
+
+/// Whether a column participates in the table's primary key or is a foreign key.
+fn is_key_column(table: &Table, column: &Column) -> bool {
+    column.primary_key || table.primary_key.contains(&column.name) || column.references.is_some()
+}
+
+/// Whether a column is constrained unique on its own — either the column flag
+/// introspection sets for a single-column unique index, or such an index listed
+/// on the table. A **partial** unique index does not count: it only constrains
+/// the rows matching its predicate.
+fn is_unique_column(table: &Table, column: &Column) -> bool {
+    if column.unique {
+        return true;
+    }
+    table.indexes.iter().any(|index| {
+        if !index.unique || index.is_partial {
+            return false;
+        }
+        let keys = if index.key_columns.is_empty() {
+            &index.columns
+        } else {
+            &index.key_columns
+        };
+        keys.len() == 1 && keys[0] == column.name
+    })
+}
+
+// ─── Replacement expressions ────────────────────────────────────────────────
+
+/// The SQL expression identifying a row for deterministic replacement: its
+/// primary key when it has one, else its physical `ctid` (unique within the
+/// statement, which is all a single `UPDATE` needs).
+fn row_key_expr(table: &Table) -> String {
+    let mut keys: Vec<&str> = table.primary_key.iter().map(String::as_str).collect();
+    if keys.is_empty() {
+        keys = table
+            .columns
+            .iter()
+            .filter(|c| c.primary_key)
+            .map(|c| c.name.as_str())
+            .collect();
+    }
+    if keys.is_empty() {
+        return "ctid::text".to_owned();
+    }
+    keys.iter()
+        .map(|key| format!("coalesce({}::text, '')", quote_ident(key)))
+        .collect::<Vec<_>>()
+        .join(" || '|' || ")
+}
+
+/// The per-row, per-column token every replacement is derived from. Salting with
+/// the column name keeps two PII columns of one row from receiving identical
+/// fake values.
+fn token_expr(table: &Table, column: &str) -> String {
+    token_expr_from(&row_key_expr(table), column)
+}
+
+/// [`token_expr`] against an already-computed row key.
+fn token_expr_from(row_key: &str, column: &str) -> String {
+    format!("md5({} || '|' || {row_key})", quote_literal(column))
+}
+
+/// The character limit a length-bounded Postgres type imposes, if any.
+///
+/// Introspection preserves `varchar(n)` / `char(n)` verbatim as
+/// [`ColumnType::Opaque`] rather than collapsing them to `Text`, so the limit is
+/// readable straight off the type.
+fn char_max_len(ty: &ColumnType) -> Option<usize> {
+    let ColumnType::Opaque { pg_type } = ty else {
+        return None;
+    };
+    let rest = pg_type
+        .strip_prefix("varchar(")
+        .or_else(|| pg_type.strip_prefix("char("))?;
+    rest.strip_suffix(')')?.parse().ok()
+}
+
+/// Whether a column stores character data a text-shaped replacement can be
+/// written into.
+fn is_texty(ty: &ColumnType) -> bool {
+    match ty {
+        ColumnType::Text => true,
+        ColumnType::Opaque { pg_type } => {
+            char_max_len(ty).is_some() || matches!(pg_type.as_str(), "citext" | "name")
+        }
+        _ => false,
+    }
+}
+
+/// Derive a replacement strategy from the column type alone — what an
+/// automatically-classified column (`#[encrypted]`, GDPR anonymize) uses.
+///
+/// A closed-set ([`ColumnType::Enum`]) or otherwise exotic type has no safe
+/// generic fake (a fabricated value would violate its `CHECK`), so the developer
+/// is asked for an explicit strategy rather than guessed at.
+///
+/// # Errors
+///
+/// Returns [`ScrubError::NoAutoStrategy`] for a type with no generic fake.
+fn auto_strategy(column: &Column) -> Result<Strategy, ScrubError> {
+    Ok(match &column.ty {
+        ColumnType::Text => email_shaped(&column.name),
+        ColumnType::Uuid => Strategy::Uuid,
+        ColumnType::Bytes => Strategy::Bytes,
+        ColumnType::Json | ColumnType::Attachment => Strategy::Json,
+        ColumnType::Int32
+        | ColumnType::Int64
+        | ColumnType::Float32
+        | ColumnType::Float64
+        | ColumnType::Bool
+        | ColumnType::Decimal { .. } => Strategy::Zero,
+        ColumnType::Timestamp | ColumnType::TimestampTz => Strategy::Epoch,
+        ty @ ColumnType::Opaque { .. } if is_texty(ty) => email_shaped(&column.name),
+        other => {
+            return Err(ScrubError::NoAutoStrategy {
+                column: column.name.clone(),
+                detail: format!("{other:?}"),
+            });
+        }
+    })
+}
+
+/// Text columns whose name says "email" get a syntactically valid address, so a
+/// scrubbed copy still satisfies format `CHECK`s and app-level parsing. Every
+/// other text column is redacted — the name is only ever used to pick a *shape*,
+/// never to decide whether a column is PII.
+fn email_shaped(name: &str) -> Strategy {
+    if name.to_ascii_lowercase().contains("email") {
+        Strategy::Email
+    } else {
+        Strategy::Redact
+    }
+}
+
+/// Build the replacement expression for one column.
+///
+/// # Errors
+///
+/// Returns [`ScrubError::ColumnTooNarrow`] when a length-bounded column cannot
+/// hold a per-row-unique value, [`ScrubError::StrategyTypeMismatch`] when the
+/// strategy cannot produce the column's type, or [`ScrubError::NoAutoStrategy`]
+/// when [`Strategy::Auto`] cannot be resolved.
+fn replacement_expr(
+    strategy: Strategy,
+    column: &Column,
+    token: &str,
+) -> Result<String, ScrubError> {
+    let limit = char_max_len(&column.ty);
+    let narrow = |overhead: usize| -> Result<String, ScrubError> {
+        bounded_token(token, limit, overhead, &column.name)
+    };
+    Ok(match strategy {
+        Strategy::Auto => replacement_expr(auto_strategy(column)?, column, token)?,
+        Strategy::Email => {
+            let tok = narrow("scrubbed+".len() + SCRUB_EMAIL_DOMAIN.len())?;
+            format!("'scrubbed+' || {tok} || '{SCRUB_EMAIL_DOMAIN}'")
+        }
+        Strategy::Name => {
+            let tok = narrow("Scrubbed ".len())?;
+            format!("'Scrubbed ' || {tok}")
+        }
+        Strategy::Redact => {
+            let tok = narrow("[scrubbed:]".len())?;
+            format!("'[scrubbed:' || {tok} || ']'")
+        }
+        Strategy::Phone => {
+            // 10 hex characters mapped onto digits: `translate` is lossy, which
+            // is why `allowed_on_unique` excludes this strategy.
+            const PHONE_DIGITS: usize = 10;
+            let overhead = "+1555".len();
+            if let Some(limit) = limit
+                && limit < overhead + PHONE_DIGITS
+            {
+                return Err(ScrubError::ColumnTooNarrow {
+                    column: column.name.clone(),
+                    limit,
+                    overhead,
+                });
+            }
+            format!("'+1555' || translate(substr({token}, 1, {PHONE_DIGITS}), 'abcdef', '0123456')")
+        }
+        Strategy::Null => "NULL".to_owned(),
+        Strategy::Uuid => {
+            require_type(column, strategy, matches!(column.ty, ColumnType::Uuid))?;
+            format!("({token})::uuid")
+        }
+        Strategy::Bytes => {
+            require_type(column, strategy, matches!(column.ty, ColumnType::Bytes))?;
+            format!("decode({token}, 'hex')")
+        }
+        Strategy::Json => {
+            let json = "'{\"scrubbed\": true}'";
+            match &column.ty {
+                ColumnType::Json | ColumnType::Attachment => format!("{json}::jsonb"),
+                ColumnType::Opaque { pg_type } if pg_type == "json" => format!("{json}::json"),
+                ty if is_texty(ty) => json.to_owned(),
+                other => {
+                    return Err(ScrubError::StrategyTypeMismatch {
+                        column: column.name.clone(),
+                        strategy: strategy.as_str(),
+                        detail: format!("{other:?}"),
+                    });
+                }
+            }
+        }
+        Strategy::Zero => match &column.ty {
+            ColumnType::Bool => "false".to_owned(),
+            ColumnType::Int32
+            | ColumnType::Int64
+            | ColumnType::Float32
+            | ColumnType::Float64
+            | ColumnType::Decimal { .. } => "0".to_owned(),
+            ColumnType::Opaque { pg_type } if pg_type.starts_with("numeric") => "0".to_owned(),
+            other => {
+                return Err(ScrubError::StrategyTypeMismatch {
+                    column: column.name.clone(),
+                    strategy: strategy.as_str(),
+                    detail: format!("{other:?}"),
+                });
+            }
+        },
+        Strategy::Epoch => match &column.ty {
+            ColumnType::Timestamp => "'1970-01-01 00:00:00'::timestamp".to_owned(),
+            ColumnType::TimestampTz => "'1970-01-01 00:00:00+00'::timestamptz".to_owned(),
+            other => {
+                return Err(ScrubError::StrategyTypeMismatch {
+                    column: column.name.clone(),
+                    strategy: strategy.as_str(),
+                    detail: format!("{other:?}"),
+                });
+            }
+        },
+    })
+}
+
+/// Refuse a strategy whose output type cannot be stored in the column.
+fn require_type(column: &Column, strategy: Strategy, ok: bool) -> Result<(), ScrubError> {
+    if ok {
+        return Ok(());
+    }
+    Err(ScrubError::StrategyTypeMismatch {
+        column: column.name.clone(),
+        strategy: strategy.as_str(),
+        detail: format!("{:?}", column.ty),
+    })
+}
+
+/// Narrow the token so `overhead` fixed characters plus the token fit inside a
+/// length-bounded column, or refuse when what is left cannot stay unique.
+fn bounded_token(
+    token: &str,
+    limit: Option<usize>,
+    overhead: usize,
+    column: &str,
+) -> Result<String, ScrubError> {
+    let Some(limit) = limit else {
+        return Ok(token.to_owned());
+    };
+    let available = limit.saturating_sub(overhead);
+    if available >= TOKEN_HEX_LEN {
+        Ok(token.to_owned())
+    } else if available >= MIN_TOKEN_WIDTH {
+        Ok(format!("substr({token}, 1, {available})"))
+    } else {
+        Err(ScrubError::ColumnTooNarrow {
+            column: column.to_owned(),
+            limit,
+            overhead,
+        })
+    }
+}
+
+/// One `SET` clause. A nullable column keeps its `NULL`s (a scrub anonymizes
+/// values, it does not invent them), so it is wrapped in a `CASE`; a `NOT NULL`
+/// column needs no guard.
+fn assignment(column: &Column, value: &str) -> String {
+    let ident = quote_ident(&column.name);
+    if column.nullable {
+        format!("{ident} = CASE WHEN {ident} IS NULL THEN NULL ELSE {value} END")
+    } else {
+        format!("{ident} = {value}")
+    }
+}
+
+// ─── GDPR anonymize registrations ───────────────────────────────────────────
+
+/// Extract the tables registered with the GDPR anonymize strategy from one Rust
+/// source file.
+///
+/// The registry is built at runtime (`GdprRegistry::new().register(...)`) so it
+/// is not readable without booting the app; the registrations themselves are
+/// plain calls, and reading them with `syn` keeps the scrub usable against a
+/// dump without a compiled binary. A call whose argument is not a string literal
+/// is **refused**, never skipped — an unreadable registration must not look like
+/// an absent one.
+///
+/// # Errors
+///
+/// Returns [`ScrubError::SourceScan`] if the source is not valid Rust, or
+/// [`ScrubError::UnresolvableAnonymize`] for a non-literal table name.
+fn extract_anonymize_tables(src: &str) -> Result<BTreeSet<String>, ScrubError> {
+    use syn::visit::Visit as _;
+
+    let file = syn::parse_file(src).map_err(|e| ScrubError::SourceScan {
+        detail: e.to_string(),
+    })?;
+    let mut scan = AnonymizeScan::default();
+    scan.visit_file(&file);
+    if let Some(detail) = scan.unresolved.into_iter().next() {
+        return Err(ScrubError::UnresolvableAnonymize { detail });
+    }
+    Ok(scan.tables)
+}
+
+/// `syn` visitor collecting `ModelRegistration::anonymize("<table>")` calls.
+#[derive(Default)]
+struct AnonymizeScan {
+    tables: BTreeSet<String>,
+    unresolved: Vec<String>,
+}
+
+impl<'ast> syn::visit::Visit<'ast> for AnonymizeScan {
+    fn visit_expr_call(&mut self, node: &'ast syn::ExprCall) {
+        if let syn::Expr::Path(path) = &*node.func {
+            let segments = &path.path.segments;
+            let is_anonymize = segments.len() >= 2
+                && segments[segments.len() - 1].ident == "anonymize"
+                && segments[segments.len() - 2].ident == "ModelRegistration";
+            if is_anonymize {
+                match node.args.first() {
+                    Some(syn::Expr::Lit(syn::ExprLit {
+                        lit: syn::Lit::Str(table),
+                        ..
+                    })) => {
+                        self.tables.insert(table.value());
+                    }
+                    _ => self.unresolved.push(quote::quote!(#node).to_string()),
+                }
+            }
+        }
+        syn::visit::visit_expr_call(self, node);
+    }
+}
+
+/// Scan every `.rs` file under `root` (recursively) for anonymize registrations.
+fn scan_anonymize_tables(root: &Path) -> Result<BTreeSet<String>, ScrubError> {
+    let mut out = BTreeSet::new();
+    if !root.is_dir() {
+        return Ok(out);
+    }
+    let mut stack = vec![root.to_path_buf()];
+    while let Some(dir) = stack.pop() {
+        let entries = std::fs::read_dir(&dir).map_err(|e| ScrubError::SourceScan {
+            detail: format!("{}: {e}", dir.display()),
+        })?;
+        for entry in entries {
+            let entry = entry.map_err(|e| ScrubError::SourceScan {
+                detail: format!("{}: {e}", dir.display()),
+            })?;
+            let path = entry.path();
+            let file_type = entry.file_type().map_err(|e| ScrubError::SourceScan {
+                detail: format!("{}: {e}", path.display()),
+            })?;
+            if file_type.is_dir() {
+                stack.push(path);
+            } else if file_type.is_file() && path.extension().is_some_and(|ext| ext == "rs") {
+                let src = std::fs::read_to_string(&path).map_err(|e| ScrubError::SourceScan {
+                    detail: format!("{}: {e}", path.display()),
+                })?;
+                let found = extract_anonymize_tables(&src).map_err(|e| match e {
+                    ScrubError::SourceScan { detail } => ScrubError::SourceScan {
+                        detail: format!("{}: {detail}", path.display()),
+                    },
+                    ScrubError::UnresolvableAnonymize { detail } => {
+                        ScrubError::UnresolvableAnonymize {
+                            detail: format!("{} — {detail}", path.display()),
+                        }
+                    }
+                    other => other,
+                })?;
+                out.extend(found);
+            }
+        }
+    }
+    Ok(out)
+}
+
+/// Read the `#[encrypted]` column set from the project's models, degrading to an
+/// empty map when the project has no models directory at all.
+fn encrypted_columns(
+    project_root: &Path,
+) -> Result<BTreeMap<String, BTreeSet<String>>, ScrubError> {
+    let Some(path) = crate::schema::existing_models_path(project_root) else {
+        return Ok(BTreeMap::new());
+    };
+    crate::schema::parse::parse_encrypted_columns_path(&path).map_err(|e| ScrubError::SourceScan {
+        detail: e.to_string(),
+    })
+}
+
+// ─── Guards ─────────────────────────────────────────────────────────────────
+
+/// Refuse a scrub against a production profile without `--force` — the identical
+/// protocol as `autumn db drop` (AC #5).
+///
+/// # Errors
+///
+/// Returns [`ScrubError::ProductionRefused`] for any profile outside
+/// `dev`/`test` when `force` is not set.
+fn guard_scrub_target(profile: &str, force: bool) -> Result<(), ScrubError> {
+    super::guard_destructive(profile, force).map_err(|_| ScrubError::ProductionRefused {
+        profile: profile.to_owned(),
+    })
+}
+
+/// Whether two connection strings address the same database: same host, same
+/// port, same database name. Credentials are deliberately ignored — a read-only
+/// role pointed at production is still production.
+///
+/// An unparsable URL never claims a match (the guard errs toward "different",
+/// leaving the profile guard as the enforcement).
+fn same_database(a: &str, b: &str) -> bool {
+    let parts = |raw: &str| -> Option<(String, u16, String)> {
+        let parsed = url::Url::parse(raw).ok()?;
+        let host = parsed.host_str()?.to_ascii_lowercase();
+        let port = parsed.port().unwrap_or(5432);
+        let name = parsed
+            .path_segments()
+            .and_then(|mut s| s.next())
+            .map(str::to_owned)
+            .filter(|n| !n.is_empty())?;
+        Some((host, port, name))
+    };
+    match (parts(a), parts(b)) {
+        (Some(left), Some(right)) => left == right,
+        _ => false,
+    }
+}
+
+/// Refuse to scrub the database a **config file** declares for the artifact's
+/// own (non-dev/test) profile — the "I pointed staging at the production URL"
+/// mistake the profile guard alone cannot see.
+///
+/// Deliberately reads only `autumn.toml` / `autumn-<profile>.toml`, never the
+/// environment: an env-provided `DATABASE_URL` is shared by every profile
+/// resolution, so consulting it would make this guard fire on legitimate scrubs.
+/// It is defence in depth on top of [`guard_scrub_target`], not a replacement.
+fn guard_configured_source(
+    source_profile: &str,
+    targets: &[(String, String)],
+    force: bool,
+) -> Result<(), ScrubError> {
+    if force || super::is_safe_destructive_profile(source_profile) {
+        return Ok(());
+    }
+    let table = migrate::read_autumn_toml_table_with_profile(Some(source_profile));
+    let Some(declared) = migrate::resolve_primary_database_url_from_sources(
+        |_| Err(std::env::VarError::NotPresent),
+        table.as_ref(),
+    ) else {
+        return Ok(());
+    };
+    for (_, url) in targets {
+        if same_database(&declared, url) {
+            return Err(ScrubError::OverwritesConfiguredTarget {
+                profile: source_profile.to_owned(),
+                database: parsed_db_name(url),
+            });
+        }
+    }
+    Ok(())
+}
+
+/// The database name in a connection URL, for credential-safe reporting.
+fn parsed_db_name(url: &str) -> String {
+    url::Url::parse(url)
+        .ok()
+        .and_then(|u| {
+            u.path_segments()
+                .and_then(|mut s| s.next())
+                .map(str::to_owned)
+        })
+        .filter(|n| !n.is_empty())
+        .unwrap_or_else(|| "<unknown>".to_owned())
+}
+
+// ─── Reporting ──────────────────────────────────────────────────────────────
+
+/// A paste-ready `scrub.toml` fragment declaring every unclassified column, so
+/// adopting the command on an existing schema is one copy away.
+fn suggested_config_stanza(unclassified: &[String]) -> String {
+    use std::fmt::Write as _;
+
+    let mut by_table: BTreeMap<&str, Vec<&str>> = BTreeMap::new();
+    for entry in unclassified {
+        if let Some((table, column)) = entry.split_once('.') {
+            by_table.entry(table).or_default().push(column);
+        }
+    }
+    let mut out = String::from(
+        "# Paste into scrub.toml, then replace `auto` with an explicit strategy\n\
+         # (email/name/phone/redact/null/uuid/bytes/json/zero/epoch), or move the\n\
+         # column into that table's `safe = [...]` list if it holds no PII.\n",
+    );
+    for (table, columns) in by_table {
+        let _ = write!(out, "\n[tables.{table}.pii]\n");
+        for column in columns {
+            let _ = writeln!(out, "{column} = \"auto\"");
+        }
+    }
+    out
+}
+
+// ─── Entry point ────────────────────────────────────────────────────────────
+
+/// Entry point for `autumn db scrub`. Prints a credential-safe message and exits
+/// non-zero on failure.
+pub fn run(args: &ScrubArgs) {
+    eprintln!("\u{1F342} autumn db scrub\n");
+    if let Err(e) = scrub(args) {
+        eprintln!("\u{2717} {e}");
+        if let ScrubError::Unclassified { columns } = &e {
+            eprintln!("\n{}", suggested_config_stanza(columns));
+        }
+        std::process::exit(1);
+    }
+}
+
+fn scrub(args: &ScrubArgs) -> Result<(), ScrubError> {
+    let profile = migrate::effective_profile(args.profile.as_deref());
+    let writes = !args.check && !args.dry_run;
+    if writes {
+        guard_scrub_target(&profile, args.force)?;
+    }
+
+    let targets = super::backup::resolve_all_target_urls(args.profile.as_deref())?;
+
+    let restored = if let Some(artifact) = &args.artifact {
+        if let Some(source_profile) = super::backup::artifact_source_profile(artifact) {
+            eprintln!("  \u{2139} Artifact was taken under the {source_profile:?} profile.");
+            guard_configured_source(&source_profile, &targets, args.force)?;
+        }
+        eprintln!(
+            "\u{2500}\u{2500} restoring {} \u{2500}\u{2500}",
+            artifact.display()
+        );
+        super::backup::restore(&super::backup::RestoreArgs {
+            artifact: artifact.clone(),
+            profile: args.profile.clone(),
+            force: args.force,
+            shard: None,
+            offsite: false,
+        })?;
+        true
+    } else {
+        false
+    };
+
+    // A restore has already written the artifact's REAL data into the target, so
+    // any refusal from here on leaves unscrubbed data behind. The classification
+    // cannot run earlier — it reads the schema the restore just created — so the
+    // outcome is stated in the loudest possible terms instead of being implied.
+    classify_and_apply(args, &targets).inspect_err(|_| {
+        if restored {
+            eprintln!(
+                "\n\u{26A0} The artifact was ALREADY RESTORED before this failure, so the \
+                 target database now holds UNSCRUBBED data.\n  \
+                 Do not hand it to anyone: fix the problem below and re-run the same \
+                 command, or drop the database. `autumn db scrub --check` catches this \
+                 before a restore."
+            );
+        }
+    })
+}
+
+/// Classify every target, then — only once every target has classified cleanly —
+/// apply the statements.
+///
+/// The two passes are deliberate and mirror how `autumn db restore` verifies
+/// every artifact before touching any database: with a control database plus
+/// shards, a single-pass loop would scrub the control database and only then
+/// discover that a shard has an undeclared column, leaving the topology half
+/// anonymized.
+fn classify_and_apply(args: &ScrubArgs, targets: &[(String, String)]) -> Result<(), ScrubError> {
+    let config = load_config(args.config.as_deref())?;
+    check_purge_list(&config)?;
+    let project_root = Path::new(".");
+    let encrypted = encrypted_columns(project_root)?;
+    let anonymize = scan_anonymize_tables(&project_root.join("src"))?;
+
+    // ── Pass 1: classify everything ─────────────────────────────────────────
+    let mut plans = Vec::with_capacity(targets.len());
+    for (label, url) in targets {
+        let tables = introspect::introspect_postgres(url).map_err(|e| ScrubError::Introspect {
+            label: label.clone(),
+            detail: e.to_string(),
+        })?;
+        let plan = build_plan(&ClassificationInputs {
+            tables: &tables,
+            config: &config,
+            encrypted: &encrypted,
+            anonymize_tables: &anonymize,
+        })?;
+        report_plan(label, &plan);
+        let framework = framework_payload_tables_present(url, label, &config)?;
+        report_framework_tables(&framework, &config);
+        plans.push((label, url, plan, framework));
+    }
+
+    if args.check {
+        eprintln!("\n\u{2713} Every column is classified \u{2014} no unclassified data can leak.");
+        return Ok(());
+    }
+    if args.dry_run {
+        for (_, _, plan, framework) in &plans {
+            for table in &plan.tables {
+                eprintln!("  {};", table.sql);
+            }
+            for (_, statement) in purge_statements(framework, &config) {
+                eprintln!("  {statement};");
+            }
+        }
+        eprintln!("\n\u{2713} Dry run only \u{2014} nothing was written.");
+        return Ok(());
+    }
+
+    // ── Pass 2: apply ───────────────────────────────────────────────────────
+    for (label, url, plan, framework) in &plans {
+        for (table, rows) in execute(url, plan, &purge_statements(framework, &config), label)? {
+            eprintln!("  \u{2713} {table}: {rows} row(s) scrubbed.");
+        }
+    }
+
+    if let Some(dir) = &args.output {
+        eprintln!("\u{2500}\u{2500} writing a scrubbed artifact \u{2500}\u{2500}");
+        super::backup::backup(&super::backup::BackupArgs {
+            profile: args.profile.clone(),
+            dir: Some(dir.clone()),
+            format: super::backup::BackupFormat::Custom,
+            keep: None,
+            target: super::backup::TargetSelector::All,
+            upload: false,
+        })?;
+    }
+
+    eprintln!("\n\u{2713} Scrub complete.");
+    Ok(())
+}
+
+/// Print what one database's scrub will do: every column, its strategy, and what
+/// classified it — so the operator can audit the decision, not just its effect.
+fn report_plan(label: &str, plan: &ScrubPlan) {
+    eprintln!(
+        "\u{2500}\u{2500} {label} \u{2500}\u{2500}\n  {} column(s) across {} table(s) \
+         classified as PII.",
+        plan.column_count(),
+        plan.tables.len()
+    );
+    for table in &plan.tables {
+        for column in &table.columns {
+            eprintln!(
+                "    {}.{} \u{2192} {} ({})",
+                table.table,
+                column.column,
+                column.strategy.as_str(),
+                column.source.as_str()
+            );
+        }
+    }
+}
+
+/// The framework-owned payload tables that actually exist in one database.
+///
+/// Introspection filters `autumn_*` / `_autumn*` out of the classified universe,
+/// so this is a separate probe: the scrub still has to say something about them
+/// rather than pretend they are not there.
+fn framework_payload_tables_present(
+    url: &str,
+    label: &str,
+    config: &ScrubConfig,
+) -> Result<Vec<String>, ScrubError> {
+    let mut conn = PgConnection::establish(url).map_err(|_| ScrubError::Introspect {
+        label: label.to_owned(),
+        detail: format!(
+            "could not connect to database {:?} to inspect framework-owned tables",
+            parsed_db_name(url)
+        ),
+    })?;
+    // The known payload carriers PLUS anything the app explicitly opted into
+    // purging — otherwise a `purge` entry outside the built-in list would be
+    // accepted by the config check and then silently do nothing.
+    let wanted = probe_table_names(config)
+        .iter()
+        .map(|t| quote_literal(t))
+        .collect::<Vec<_>>()
+        .join(", ");
+    let rows: Vec<NameRow> = sql_query(format!(
+        "SELECT table_name AS name FROM information_schema.tables \
+         WHERE table_schema = 'public' AND table_type = 'BASE TABLE' \
+         AND table_name IN ({wanted}) ORDER BY table_name"
+    ))
+    .load(&mut conn)
+    .map_err(|e| ScrubError::Sql(e.to_string()))?;
+    Ok(rows.into_iter().map(|r| r.name).collect())
+}
+
+/// The framework-owned table names worth probing for: the built-in payload
+/// carriers plus every `[framework] purge` entry.
+fn probe_table_names(config: &ScrubConfig) -> BTreeSet<String> {
+    FRAMEWORK_PAYLOAD_TABLES
+        .iter()
+        .map(|t| (*t).to_owned())
+        .chain(config.framework.purge.iter().cloned())
+        .collect()
+}
+
+/// A single `name` column produced by the framework-table probe.
+#[derive(diesel::QueryableByName)]
+struct NameRow {
+    #[diesel(sql_type = diesel::sql_types::Text)]
+    name: String,
+}
+
+/// Tell the operator about framework-owned payload tables the classification
+/// never sees: which ones will be emptied, and which ones are being left alone.
+fn report_framework_tables(present: &[String], config: &ScrubConfig) {
+    if present.is_empty() {
+        return;
+    }
+    let (purged, kept): (Vec<&String>, Vec<&String>) = present
+        .iter()
+        .partition(|t| config.framework.purge.contains(t));
+    for table in purged {
+        eprintln!("    {table} \u{2192} emptied (framework, [framework] purge)");
+    }
+    // Only the built-in payload carriers are warned about: an app that named
+    // some other framework table in `purge` has already decided about it.
+    let kept: Vec<&&String> = kept
+        .iter()
+        .filter(|t| FRAMEWORK_PAYLOAD_TABLES.contains(&t.as_str()))
+        .collect();
+    if kept.is_empty() {
+        return;
+    }
+    eprintln!(
+        "  \u{26A0} {} framework-owned table(s) are NOT scrubbed and may carry app-supplied \
+         payloads (queued jobs, offline-sync rows, experiment assignments):\n{}\n    \
+         Add them to `[framework] purge = [...]` in {SCRUB_CONFIG_FILE} to empty them, or \
+         empty them yourself.",
+        kept.len(),
+        kept.iter()
+            .map(|t| format!("      - {t}"))
+            .collect::<Vec<_>>()
+            .join("\n"),
+    );
+}
+
+/// The `DELETE FROM` statements for the opted-in framework tables that exist.
+fn purge_statements(present: &[String], config: &ScrubConfig) -> Vec<(String, String)> {
+    present
+        .iter()
+        .filter(|t| config.framework.purge.contains(t))
+        .map(|t| (t.clone(), format!("DELETE FROM {}", quote_ident(t))))
+        .collect()
+}
+
+/// Run every statement for one database inside a single transaction, so a
+/// failure can never leave a half-scrubbed database behind.
+fn execute(
+    url: &str,
+    plan: &ScrubPlan,
+    purges: &[(String, String)],
+    label: &str,
+) -> Result<Vec<(String, usize)>, ScrubError> {
+    if plan.tables.is_empty() && purges.is_empty() {
+        return Ok(Vec::new());
+    }
+    let mut conn = PgConnection::establish(url).map_err(|_| ScrubError::Introspect {
+        label: label.to_owned(),
+        detail: format!(
+            "could not connect to database {:?} to apply the scrub",
+            parsed_db_name(url)
+        ),
+    })?;
+    let mut counts = Vec::with_capacity(plan.tables.len());
+    conn.transaction::<_, diesel::result::Error, _>(|conn| {
+        for table in &plan.tables {
+            let rows = sql_query(&table.sql).execute(conn)?;
+            counts.push((table.table.clone(), rows));
+        }
+        for (table, statement) in purges {
+            let rows = sql_query(statement).execute(conn)?;
+            counts.push((format!("{table} (emptied)"), rows));
+        }
+        Ok(())
+    })
+    .map_err(|e| ScrubError::Sql(e.to_string()))?;
+    Ok(counts)
+}
 
 #[cfg(test)]
 mod tests {
@@ -274,10 +1983,7 @@ mod tests {
         )
         .unwrap();
         let mut encrypted = BTreeMap::new();
-        encrypted.insert(
-            "users".to_owned(),
-            BTreeSet::from(["email".to_owned()]),
-        );
+        encrypted.insert("users".to_owned(), BTreeSet::from(["email".to_owned()]));
 
         let plan = plan_for(&[users_table()], &config, &encrypted, &no_anonymize())
             .expect("an #[encrypted] column needs no declaration");
@@ -479,7 +2185,10 @@ mod tests {
             &no_anonymize(),
         )
         .unwrap();
-        assert_eq!(plan.column("users", "bio").unwrap().strategy, Strategy::Null);
+        assert_eq!(
+            plan.column("users", "bio").unwrap().strategy,
+            Strategy::Null
+        );
     }
 
     #[test]
@@ -510,10 +2219,7 @@ mod tests {
 
     #[test]
     fn row_key_uses_the_primary_key_when_present() {
-        assert_eq!(
-            row_key_expr(&users_table()),
-            r#"coalesce("id"::text, '')"#
-        );
+        assert_eq!(row_key_expr(&users_table()), r#"coalesce("id"::text, '')"#);
     }
 
     #[test]
@@ -733,7 +2439,9 @@ mod tests {
         );
         let plan = plan_for(&[t], &config, &empty_encrypted(), &no_anonymize()).unwrap();
         assert!(
-            plan.tables[0].sql.starts_with(r#"UPDATE "we""ird" SET "na""me" = "#),
+            plan.tables[0]
+                .sql
+                .starts_with(r#"UPDATE "we""ird" SET "na""me" = "#),
             "{}",
             plan.tables[0].sql
         );
@@ -774,14 +2482,17 @@ mod tests {
 
     #[test]
     fn a_non_literal_registration_argument_is_reported_not_ignored() {
-        let src = r#"
+        let src = "
             fn registry() {
                 let _ = ModelRegistration::anonymize(table_name());
             }
-        "#;
+        ";
         let err = extract_anonymize_tables(src)
             .expect_err("a table name the scanner cannot resolve must not pass silently");
-        assert!(matches!(err, ScrubError::UnresolvableAnonymize { .. }), "{err:?}");
+        assert!(
+            matches!(err, ScrubError::UnresolvableAnonymize { .. }),
+            "{err:?}"
+        );
     }
 
     // ── Production guard (AC #5) ────────────────────────────────────────────
@@ -849,12 +2560,261 @@ mod tests {
     }
 
     #[test]
+    fn per_column_errors_are_reported_with_their_table() {
+        let mut t = Table::new("orders", Backend::Postgres);
+        t.primary_key = vec!["id".to_owned()];
+        t.columns = vec![
+            pk_col("id"),
+            Column::new(
+                "status",
+                ColumnType::Enum {
+                    variants: vec!["draft".to_owned(), "paid".to_owned()],
+                },
+            ),
+        ];
+        let err = plan_for(
+            &[t],
+            &parse_config_str(
+                r#"
+                [defaults]
+                safe_columns = ["id"]
+                [tables.orders.pii]
+                status = "auto"
+                "#,
+            )
+            .unwrap(),
+            &empty_encrypted(),
+            &no_anonymize(),
+        )
+        .expect_err("a closed-set column has no generic fake");
+        assert!(
+            matches!(err, ScrubError::NoAutoStrategy { ref column, .. } if column == "orders.status"),
+            "the error must name the table too: {err:?}"
+        );
+    }
+
+    #[test]
+    fn a_strategy_that_cannot_produce_the_column_type_is_refused() {
+        let err = replacement_expr(Strategy::Uuid, &text_col("note"), "TOK")
+            .expect_err("a uuid cannot be written into a text column");
+        assert!(
+            matches!(err, ScrubError::StrategyTypeMismatch { .. }),
+            "{err:?}"
+        );
+        assert!(
+            matches!(
+                replacement_expr(Strategy::Zero, &text_col("note"), "TOK"),
+                Err(ScrubError::StrategyTypeMismatch { .. })
+            ),
+            "zero is meaningless for a text column"
+        );
+        assert!(
+            matches!(
+                replacement_expr(Strategy::Epoch, &Column::new("n", ColumnType::Int64), "TOK"),
+                Err(ScrubError::StrategyTypeMismatch { .. })
+            ),
+            "epoch is meaningless for an integer column"
+        );
+    }
+
+    #[test]
+    fn typed_strategies_render_their_casts() {
+        assert_eq!(
+            replacement_expr(Strategy::Uuid, &Column::new("t", ColumnType::Uuid), "TOK").unwrap(),
+            "(TOK)::uuid"
+        );
+        assert_eq!(
+            replacement_expr(Strategy::Bytes, &Column::new("b", ColumnType::Bytes), "TOK").unwrap(),
+            "decode(TOK, 'hex')"
+        );
+        assert_eq!(
+            replacement_expr(Strategy::Zero, &Column::new("ok", ColumnType::Bool), "TOK").unwrap(),
+            "false"
+        );
+        assert_eq!(
+            replacement_expr(
+                Strategy::Epoch,
+                &Column::new("at", ColumnType::TimestampTz),
+                "TOK"
+            )
+            .unwrap(),
+            "'1970-01-01 00:00:00+00'::timestamptz"
+        );
+        assert_eq!(
+            replacement_expr(Strategy::Null, &text_col("bio"), "TOK").unwrap(),
+            "NULL"
+        );
+    }
+
+    #[test]
+    fn phone_produces_digits_and_refuses_a_column_that_cannot_hold_them() {
+        let expr = replacement_expr(Strategy::Phone, &text_col("phone"), "TOK").unwrap();
+        assert!(
+            expr.contains("translate("),
+            "must map hex onto digits: {expr}"
+        );
+        assert!(expr.starts_with("'+1555'"), "{expr}");
+
+        let narrow = Column::new(
+            "phone",
+            ColumnType::Opaque {
+                pg_type: "varchar(8)".to_owned(),
+            },
+        );
+        assert!(matches!(
+            replacement_expr(Strategy::Phone, &narrow, "TOK"),
+            Err(ScrubError::ColumnTooNarrow { .. })
+        ));
+    }
+
+    #[test]
+    fn a_partial_unique_index_does_not_constrain_the_whole_column() {
+        let mut t = users_table();
+        t.columns[1].unique = false;
+        let mut index = Index::new("idx_users_email", vec!["email".to_owned()], true);
+        index.is_partial = true;
+        t.indexes = vec![index];
+        let config = parse_config_str(
+            r#"
+            [defaults]
+            safe_columns = ["id", "created_at", "full_name", "bio"]
+            [tables.users.pii]
+            email = "json"
+            "#,
+        )
+        .unwrap();
+        // A partial unique index only constrains the rows matching its
+        // predicate, so it must not be treated as table-wide uniqueness.
+        let plan = plan_for(&[t], &config, &empty_encrypted(), &no_anonymize())
+            .expect("a partial unique index is not table-wide uniqueness");
+        assert!(plan.column("users", "email").is_some());
+    }
+
+    #[test]
+    fn a_missing_config_file_is_not_an_error_but_an_explicit_one_is() {
+        let dir = tempfile::tempdir().unwrap();
+        let absent = dir.path().join("scrub.toml");
+        // The conventional path may simply not exist yet.
+        assert_eq!(
+            load_config_at(None, &absent).unwrap(),
+            ScrubConfig::default()
+        );
+        // A path the developer named explicitly must not be silently ignored.
+        assert!(matches!(
+            load_config_at(Some(&absent), &absent),
+            Err(ScrubError::Config { .. })
+        ));
+    }
+
+    // ── Framework-owned tables ──────────────────────────────────────────────
+
+    #[test]
+    fn purge_only_accepts_framework_owned_tables() {
+        let config = parse_config_str(
+            r#"
+            [framework]
+            purge = ["autumn_jobs", "users"]
+            "#,
+        )
+        .unwrap();
+        let err = check_purge_list(&config)
+            .expect_err("emptying a user table must never hide behind `purge`");
+        assert!(
+            matches!(err, ScrubError::PurgeNotFrameworkTable { ref tables } if tables == &vec!["users".to_owned()]),
+            "got {err:?}"
+        );
+
+        let ok = parse_config_str(
+            r#"
+            [framework]
+            purge = ["autumn_jobs", "_autumn_ledger_revisions"]
+            "#,
+        )
+        .unwrap();
+        assert!(check_purge_list(&ok).is_ok());
+    }
+
+    #[test]
+    fn purge_statements_cover_only_the_opted_in_tables_that_exist() {
+        let config = parse_config_str(
+            r#"
+            [framework]
+            purge = ["autumn_jobs", "autumn_sync_rows"]
+            "#,
+        )
+        .unwrap();
+        // `autumn_sync_rows` is opted in but absent; `autumn_job_tracking` is
+        // present but not opted in.
+        let present = vec!["autumn_job_tracking".to_owned(), "autumn_jobs".to_owned()];
+        let statements = purge_statements(&present, &config);
+        assert_eq!(
+            statements,
+            vec![(
+                "autumn_jobs".to_owned(),
+                r#"DELETE FROM "autumn_jobs""#.to_owned()
+            )]
+        );
+    }
+
+    #[test]
+    fn no_purge_declaration_empties_nothing() {
+        let present = vec!["autumn_jobs".to_owned()];
+        assert!(purge_statements(&present, &ScrubConfig::default()).is_empty());
+    }
+
+    #[test]
+    fn the_probe_covers_the_built_in_list_plus_every_purge_entry() {
+        let config = parse_config_str(
+            r#"
+            [framework]
+            purge = ["autumn_custom_outbox"]
+            "#,
+        )
+        .unwrap();
+        let probed = probe_table_names(&config);
+        assert!(
+            probed.contains("autumn_custom_outbox"),
+            "a purge entry outside the built-in list must still be probed, or it \
+             would be accepted and then silently do nothing"
+        );
+        for table in FRAMEWORK_PAYLOAD_TABLES {
+            assert!(probed.contains(*table));
+        }
+    }
+
+    #[test]
+    fn framework_payload_tables_are_all_framework_owned() {
+        for table in FRAMEWORK_PAYLOAD_TABLES {
+            assert!(
+                is_framework_table(table),
+                "{table} must be filtered out of the classified universe"
+            );
+        }
+        // The unprefixed set must stay in lock-step with the introspection
+        // filter, or a table nothing classifies would also be un-purgeable.
+        for table in UNPREFIXED_FRAMEWORK_TABLES {
+            assert!(is_framework_table(table));
+        }
+        assert!(
+            FRAMEWORK_PAYLOAD_TABLES.contains(&"api_tokens"),
+            "production API tokens in a staging copy are a live credential leak"
+        );
+        // Schema bookkeeping must never be offered for purging.
+        assert!(!FRAMEWORK_PAYLOAD_TABLES.contains(&"autumn_migration_checksums"));
+        assert!(!FRAMEWORK_PAYLOAD_TABLES.contains(&"_autumn_shard_map"));
+    }
+
+    #[test]
     fn index_backed_uniqueness_is_recognized() {
         // A single-column unique INDEX (not a column flag) still forbids a
         // constant replacement.
         let mut t = users_table();
         t.columns[1].unique = false;
-        t.indexes = vec![Index::new("idx_users_email", vec!["email".to_owned()], true)];
+        t.indexes = vec![Index::new(
+            "idx_users_email",
+            vec!["email".to_owned()],
+            true,
+        )];
         let config = parse_config_str(
             r#"
             [defaults]
@@ -866,6 +2826,9 @@ mod tests {
         .unwrap();
         let err = plan_for(&[t], &config, &empty_encrypted(), &no_anonymize())
             .expect_err("a unique index must be honored like a unique column");
-        assert!(matches!(err, ScrubError::NonUniqueStrategy { .. }), "{err:?}");
+        assert!(
+            matches!(err, ScrubError::NonUniqueStrategy { .. }),
+            "{err:?}"
+        );
     }
 }

--- a/autumn-cli/src/db/scrub.rs
+++ b/autumn-cli/src/db/scrub.rs
@@ -1,4 +1,4 @@
-//! `autumn db scrub` — turn a production database (or a `autumn db backup`
+//! `autumn db scrub` — turn a production database (or an `autumn db backup`
 //! artifact) into an anonymized copy that is safe on a laptop or a shared
 //! staging box (issue #1602).
 //!
@@ -34,7 +34,9 @@
 //!
 //! - **Fail-closed.** Unclassified, stale (naming a column that no longer
 //!   exists), and self-contradictory declarations all refuse before a single row
-//!   is touched.
+//!   is touched. The one exception is `--artifact`: the restore must run before
+//!   the classification can read the schema it creates, so a refusal after a
+//!   restore leaves unscrubbed data in the target — and says so, loudly.
 //! - **Production guard.** Writing refuses outside `dev`/`test` without
 //!   `--force`, the identical protocol as `autumn db drop`
 //!   ([`crate::db::guard_destructive`]).
@@ -42,8 +44,14 @@
 //!   refused outright (so referential integrity is untouched), `NULL` is refused
 //!   on a `NOT NULL` column, a constant replacement is refused on a `UNIQUE`
 //!   column, and a `varchar(n)` bound narrows the generated value or refuses.
-//! - **Atomic.** Every statement for one database runs in a single transaction:
-//!   a half-scrubbed database is never left behind.
+//! - **Atomic.** Every target is classified before any target is written (so an
+//!   undeclared column on one shard cannot leave the topology half anonymized),
+//!   and every statement for one database runs in a single transaction: a
+//!   half-scrubbed database is never left behind.
+//! - **Framework-aware.** Introspection excludes `autumn_*` tables from the
+//!   classified universe, so the ones that carry app-supplied payloads (queued
+//!   jobs, offline-sync rows, `api_tokens`) are reported separately and emptied
+//!   when the app opts in with `[framework] purge`.
 //! - **Credential-safe.** No error or report ever embeds a resolved URL.
 
 use std::collections::{BTreeMap, BTreeSet};

--- a/autumn-cli/src/db/scrub.rs
+++ b/autumn-cli/src/db/scrub.rs
@@ -215,6 +215,9 @@ pub enum ScrubError {
         /// A credential-safe reason.
         detail: String,
     },
+    /// Neither the model source nor the declaration says which columns are
+    /// `#[encrypted]`, so the scrub cannot tell them apart from plain text.
+    EncryptedMetadataUnavailable,
     /// `public` holds base tables the connecting role cannot see, so they never
     /// reached the classifier.
     InaccessibleTables {
@@ -413,6 +416,19 @@ impl std::fmt::Display for ScrubError {
                  plaintext replacement would make every later read of that row fail. Provide the \
                  target's `active_record_encryption` credentials (`autumn credentials edit`), or \
                  declare those columns `null` in {SCRUB_CONFIG_FILE} if they are nullable."
+            ),
+            Self::EncryptedMetadataUnavailable => write!(
+                f,
+                "No model source was found, so the scrub cannot tell which columns are \
+                 #[encrypted].\n  \
+                 That matters more than it sounds: an unrecognised encrypted column declared \
+                 `safe` keeps its production ciphertext, and one given a plaintext strategy \
+                 becomes permanently unreadable. Run the scrub from the project root (where \
+                 `src/models` lives), or name them — with their mode — in {SCRUB_CONFIG_FILE}:\n    \
+                 [tables.users.encrypted]\n    api_token = \"randomized\"\n    \
+                 email = \"deterministic\"\n  \
+                 An app with no encrypted columns at all still needs one empty \
+                 `[tables.<any>.encrypted]` section to say so deliberately."
             ),
             Self::InaccessibleTables { tables } => write!(
                 f,
@@ -616,6 +632,23 @@ pub struct ScrubDefaults {
     pub safe_columns: Vec<String>,
 }
 
+/// The at-rest encryption mode a column was written with.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum EncryptionMode {
+    /// `#[encrypted]` — a fresh nonce per write.
+    Randomized,
+    /// `#[encrypted(deterministic)]` — equality-queryable.
+    Deterministic,
+}
+
+impl EncryptionMode {
+    /// Whether this is the deterministic mode.
+    const fn is_deterministic(self) -> bool {
+        matches!(self, Self::Deterministic)
+    }
+}
+
 /// One table's declaration.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -626,6 +659,14 @@ pub struct TableRule {
     /// PII columns and how each is replaced.
     #[serde(default)]
     pub pii: BTreeMap<String, Strategy>,
+    /// At-rest-encrypted columns and their mode, for a host that has the CLI and
+    /// `scrub.toml` but not the model source the `#[encrypted]` markers live in.
+    ///
+    /// The mode matters: re-encrypting a `deterministic` column in randomized
+    /// mode leaves valid ciphertext that the app can no longer equality-query,
+    /// so it cannot be guessed.
+    #[serde(default)]
+    pub encrypted: BTreeMap<String, EncryptionMode>,
 }
 
 /// How framework-owned tables are handled.
@@ -676,10 +717,15 @@ const FRAMEWORK_PAYLOAD_TABLES: &[&str] = &[
     // is a live credential leak, not merely a PII one.
     "api_tokens",
     "autumn_experiment_assignments",
+    // `actor` on both: who was pinned to a variant, and who changed what.
+    "autumn_experiment_changes",
+    "autumn_experiment_overrides",
     // `actor_allowlist` names the individual users a flag is switched on for.
     "autumn_feature_flags",
     "autumn_job_tracking",
     "autumn_jobs",
+    // `context` / `record` JSONB hold the full row a hook was queued for.
+    "autumn_repository_commit_hooks",
     // The indexed text of app records — the search index is a second copy of
     // whatever was made searchable.
     "autumn_search_documents",
@@ -1168,7 +1214,12 @@ fn check_config_freshness(
             continue;
         };
         let columns: BTreeSet<&str> = table.columns.iter().map(|c| c.name.as_str()).collect();
-        for column in rule.safe.iter().chain(rule.pii.keys()) {
+        for column in rule
+            .safe
+            .iter()
+            .chain(rule.pii.keys())
+            .chain(rule.encrypted.keys())
+        {
             if !columns.contains(column.as_str()) {
                 stale.push(format!("{name}.{column}"));
             }
@@ -1257,7 +1308,31 @@ fn unreachable_tables(facts: &DatabaseFacts, introspected: &[Table]) -> Vec<Stri
         .filter(|t| !seen.contains(t.as_str()) && !is_framework_table(t))
         .cloned()
         .collect();
+
+    // Privileges are per COLUMN as well as per table: a table can be visible
+    // while some of its columns are not, and those would be scrubbed by nothing
+    // while the table itself classified cleanly.
+    let seen_columns: BTreeSet<(&str, &str)> = introspected
+        .iter()
+        .flat_map(|t| {
+            t.columns
+                .iter()
+                .map(move |c| (t.name.as_str(), c.name.as_str()))
+        })
+        .collect();
+    missing.extend(
+        facts
+            .public_columns
+            .iter()
+            .filter(|(table, column)| {
+                seen.contains(table.as_str())
+                    && !is_framework_table(table)
+                    && !seen_columns.contains(&(table.as_str(), column.as_str()))
+            })
+            .map(|(table, column)| format!("{table}.{column}")),
+    );
     missing.sort();
+    missing.dedup();
     missing
 }
 
@@ -2051,7 +2126,34 @@ fn load_source_classification(args: &ScrubArgs) -> Result<SourceClassification, 
     let config = load_config(args.config.as_deref())?;
     check_purge_list(&config)?;
     let project_root = Path::new(".");
-    let encrypted = encrypted_columns(project_root)?;
+    let models_path = crate::schema::existing_models_path(project_root);
+    let declared_encrypted = config
+        .tables
+        .iter()
+        .any(|(_, rule)| !rule.encrypted.is_empty());
+
+    // Without the model source there is no way to know WHICH columns are
+    // `#[encrypted]`, and an unknown one is the worst possible outcome: declared
+    // `safe` it keeps production ciphertext, given a plaintext strategy it
+    // becomes permanently unreadable. So this is a refusal, not a warning —
+    // unless the declaration names them (and their mode) itself.
+    if models_path.is_none() && !declared_encrypted {
+        return Err(ScrubError::EncryptedMetadataUnavailable);
+    }
+
+    let mut encrypted = encrypted_columns(project_root)?;
+    // A declaration supplements the model scan (and supplies everything when
+    // there is no model source at all); the model stays authoritative where the
+    // two overlap, since it is the definition rather than a copy of it.
+    for (table, rule) in &config.tables {
+        for (column, mode) in &rule.encrypted {
+            encrypted
+                .entry(table.clone())
+                .or_default()
+                .entry(column.clone())
+                .or_insert_with(|| mode.is_deterministic());
+        }
+    }
     let anonymize = scan_anonymize_tables(&project_root.join("src"))?;
 
     let encrypted_count: usize = encrypted.values().map(BTreeMap::len).sum();
@@ -2060,13 +2162,6 @@ fn load_source_classification(args: &ScrubArgs) -> Result<SourceClassification, 
          {} GDPR anonymize registration(s).",
         anonymize.len()
     );
-    if encrypted_count == 0 && anonymize.is_empty() && !project_root.join("src").is_dir() {
-        eprintln!(
-            "  \u{26A0}\u{FE0F}  No `src/` directory here, so NEITHER automatic source could be \
-             read. Run the scrub from the project root, or every column must be declared in \
-             {SCRUB_CONFIG_FILE} by hand."
-        );
-    }
 
     Ok(SourceClassification {
         config,
@@ -2318,6 +2413,13 @@ pub struct DatabaseFacts {
     pub other_schemas: BTreeSet<String>,
     /// Framework-owned tables present that the classification never sees.
     pub framework_tables: Vec<String>,
+    /// Every column of every `public` table, read from `pg_attribute`.
+    ///
+    /// A role can hold privileges on some columns of a table but not others, and
+    /// `information_schema.columns` (what introspection reads) omits the ones it
+    /// cannot see — so the table would classify, the visible columns would be
+    /// rewritten, and the hidden PII would survive.
+    pub public_columns: BTreeSet<(String, String)>,
     /// Every base table in `public`, read from `pg_class`.
     ///
     /// Introspection enumerates through `information_schema.tables`, which shows
@@ -2473,7 +2575,7 @@ fn probe_database_facts(
     } else {
         "i.indkey"
     };
-    let unique_columns = pair_set(
+    let mut unique_columns = pair_set(
         sql_query(format!(
             "SELECT rel.relname AS tbl, att.attname AS col \
              FROM pg_index i \
@@ -2486,6 +2588,29 @@ fn probe_database_facts(
         .load(&mut conn)
         .map_err(|e| ScrubError::Sql(e.to_string()))?,
     );
+
+    // A unique EXPRESSION index (`CREATE UNIQUE INDEX ON users (left(email, 1))`)
+    // stores `0` in `indkey` for the expression position, so the join above sees
+    // no column at all. Its real inputs come from `pg_depend`. Uniqueness after
+    // an arbitrary expression cannot be preserved by a per-row token — `left(x,1)`
+    // collapses every scrubbed value onto one character — so those columns are
+    // marked unique-constrained and any non-injective strategy on them is
+    // refused. (An injective strategy is refused too, which is the fail-closed
+    // side of the trade: the expression's output is what has to stay distinct,
+    // and only the developer knows whether it does.)
+    unique_columns.extend(pair_set(
+        sql_query(
+            "SELECT rel.relname AS tbl, att.attname AS col \
+             FROM pg_index i \
+             JOIN pg_class rel ON rel.oid = i.indrelid \
+             JOIN pg_namespace ns ON ns.oid = rel.relnamespace AND ns.nspname = 'public' \
+             JOIN pg_depend d ON d.objid = i.indexrelid AND d.refobjid = i.indrelid \
+             JOIN pg_attribute att ON att.attrelid = rel.oid AND att.attnum = d.refobjsubid \
+             WHERE i.indisunique AND i.indexprs IS NOT NULL AND d.refobjsubid > 0",
+        )
+        .load(&mut conn)
+        .map_err(|e| ScrubError::Sql(e.to_string()))?,
+    ));
 
     // `NULLS NOT DISTINCT` (PG15+) makes a second NULL a violation, so the
     // `null` strategy stops being unique-safe. `indnullsnotdistinct` does not
@@ -2553,7 +2678,8 @@ fn probe_database_facts(
     let other_schemas = names(
         "SELECT DISTINCT ns.nspname AS name FROM pg_class rel \
          JOIN pg_namespace ns ON ns.oid = rel.relnamespace \
-         WHERE rel.relkind IN ('r', 'p') AND ns.nspname NOT IN ('public', 'information_schema') \
+         WHERE rel.relkind IN ('r', 'p', 'f') \
+         AND ns.nspname NOT IN ('public', 'information_schema') \
          AND ns.nspname NOT LIKE 'pg\\_%'",
         &mut conn,
     )?
@@ -2604,14 +2730,29 @@ fn probe_database_facts(
         &mut conn,
     )?;
 
+    // `f` (foreign tables) is deliberately included: introspection reads only
+    // `BASE TABLE`, so a foreign table left pointing at production would be
+    // classified by nothing at all and still report a clean scrub.
     let public_base_tables = names(
         "SELECT rel.relname AS name FROM pg_class rel \
          JOIN pg_namespace ns ON ns.oid = rel.relnamespace AND ns.nspname = 'public' \
-         WHERE rel.relkind IN ('r', 'p')",
+         WHERE rel.relkind IN ('r', 'p', 'f')",
         &mut conn,
     )?
     .into_iter()
     .collect();
+
+    let public_columns = pair_set(
+        sql_query(
+            "SELECT rel.relname AS tbl, att.attname AS col \
+             FROM pg_attribute att \
+             JOIN pg_class rel ON rel.oid = att.attrelid \
+             JOIN pg_namespace ns ON ns.oid = rel.relnamespace AND ns.nspname = 'public' \
+             WHERE rel.relkind IN ('r', 'p', 'f') AND att.attnum > 0 AND NOT att.attisdropped",
+        )
+        .load(&mut conn)
+        .map_err(|e| ScrubError::Sql(e.to_string()))?,
+    );
 
     Ok(DatabaseFacts {
         foreign_key_columns,
@@ -2625,6 +2766,7 @@ fn probe_database_facts(
         materialized_views,
         other_schemas,
         framework_tables,
+        public_columns,
         public_base_tables,
     })
 }
@@ -3290,6 +3432,74 @@ mod tests {
         let column = Column::new("token", ColumnType::Uuid);
         let expr = replacement_expr(Strategy::Uuid, &column, "TOK", true).unwrap();
         assert_eq!(expr, "(substr(TOK, 1, 32))::uuid");
+    }
+
+    #[test]
+    fn column_level_privilege_gaps_are_refused_too() {
+        // A role can see a table but not all of its columns: the table
+        // classifies, the visible columns are rewritten, and the hidden PII
+        // survives a "successful" scrub.
+        let facts = DatabaseFacts {
+            public_base_tables: BTreeSet::from(["users".to_owned()]),
+            public_columns: BTreeSet::from([
+                ("users".to_owned(), "id".to_owned()),
+                ("users".to_owned(), "email".to_owned()),
+                ("users".to_owned(), "ssn".to_owned()),
+            ]),
+            ..DatabaseFacts::default()
+        };
+        // `users_table()` has no `ssn`, standing in for a column introspection
+        // could not see.
+        assert_eq!(
+            unreachable_tables(&facts, &[users_table()]),
+            vec!["users.ssn".to_owned()]
+        );
+    }
+
+    #[test]
+    fn every_payload_bearing_framework_table_is_listed() {
+        // Each of these is excluded from classification by the `autumn_` prefix
+        // (or the explicit filter) while holding app-supplied payloads or actor
+        // identities.
+        for table in [
+            "_autumn_ledger_revisions",
+            "_autumn_version_history",
+            "api_tokens",
+            "autumn_experiment_assignments",
+            "autumn_experiment_changes",
+            "autumn_experiment_overrides",
+            "autumn_feature_flags",
+            "autumn_jobs",
+            "autumn_repository_commit_hooks",
+            "autumn_search_documents",
+            "autumn_sync_rows",
+            "feature_flag_changes",
+        ] {
+            assert!(
+                FRAMEWORK_PAYLOAD_TABLES.contains(&table),
+                "{table} carries app data the classification never sees"
+            );
+        }
+    }
+
+    #[test]
+    fn encrypted_columns_may_be_declared_when_there_is_no_model_source() {
+        let config = parse_config_str(
+            r#"
+            [tables.users.encrypted]
+            api_token = "randomized"
+            email = "deterministic"
+            "#,
+        )
+        .unwrap();
+        let users = config.tables.get("users").unwrap();
+        assert_eq!(
+            users.encrypted.get("email"),
+            Some(&EncryptionMode::Deterministic),
+            "the mode cannot be guessed: re-encrypting a deterministic column in \
+             randomized mode leaves ciphertext the app can no longer equality-query"
+        );
+        assert!(!users.encrypted["api_token"].is_deterministic());
     }
 
     #[test]
@@ -4083,6 +4293,7 @@ mod tests {
             TableRule {
                 safe: Vec::new(),
                 pii: BTreeMap::from([(r#"na"me"#.to_owned(), Strategy::Redact)]),
+                encrypted: BTreeMap::new(),
             },
         );
         let plan = plan_for(&[t], &config, &empty_encrypted(), &no_anonymize()).unwrap();
@@ -4423,6 +4634,7 @@ mod tests {
             TableRule {
                 safe: Vec::new(),
                 pii: BTreeMap::from([("last4".to_owned(), Strategy::Zero)]),
+                encrypted: BTreeMap::new(),
             },
         );
         let facts = DatabaseFacts {

--- a/autumn-cli/src/db/scrub.rs
+++ b/autumn-cli/src/db/scrub.rs
@@ -1274,13 +1274,29 @@ fn check_safe_overrides_encrypted(
             if rule.is_some_and(|r| r.pii.contains_key(column)) {
                 continue;
             }
-            // A key column is exempt: it can never be rewritten anyway (see
-            // `is_key_column`), so refusing its `safe` declaration would leave
-            // the developer with no configuration that terminates.
+            // A key column is exempt: it can never be rewritten anyway, so
+            // refusing its `safe` declaration would leave the developer with no
+            // configuration that terminates.
+            //
+            // This asks `is_key_column` rather than re-deriving the test from
+            // the IR flags alone: the catalog contributes two more sources (the
+            // REFERENCED side of a foreign key, and generated columns) that the
+            // IR does not carry, so the two tests disagreed about what counts as
+            // structural.
+            //
+            // Necessary but NOT sufficient to make such a column configurable:
+            // classification resolves `#[encrypted]` before it looks at `safe`,
+            // so a structural encrypted column still fails as `PiiOnKeyColumn`
+            // with no declaration that terminates. Tracked in #2366.
             if by_name
                 .get(table.as_str())
-                .and_then(|t| t.columns.iter().find(|c| &c.name == column))
-                .is_some_and(|c| c.primary_key || c.references.is_some())
+                .and_then(|t| {
+                    t.columns
+                        .iter()
+                        .find(|c| &c.name == column)
+                        .map(|c| (*t, c))
+                })
+                .is_some_and(|(t, c)| is_key_column(t, c, inputs.facts))
             {
                 continue;
             }

--- a/autumn-cli/src/db/scrub.rs
+++ b/autumn-cli/src/db/scrub.rs
@@ -2221,12 +2221,23 @@ fn classify_and_apply(
         // RLS makes an `UPDATE` silently apply to policy-visible rows only,
         // which is a fail-OPEN in a fail-closed tool — refuse rather than
         // report a partial scrub as complete.
-        let rls: Vec<String> = plan
+        // Purge targets are framework tables, which are excluded from
+        // `plan.tables` — so without them an RLS-protected job/token/sync table
+        // would have its `DELETE` silently apply to policy-visible rows only,
+        // and still be reported emptied.
+        let mut rls: Vec<String> = plan
             .tables
             .iter()
-            .filter(|t| facts.rls_tables.contains(&t.table))
             .map(|t| t.table.clone())
+            .chain(
+                purge_statements(&facts.framework_tables, &sources.config)
+                    .into_iter()
+                    .map(|(table, _)| table),
+            )
+            .filter(|t| facts.rls_tables.contains(t))
             .collect();
+        rls.sort();
+        rls.dedup();
         if !rls.is_empty() {
             return Err(ScrubError::RowLevelSecurity { tables: rls });
         }
@@ -2589,15 +2600,22 @@ fn probe_database_facts(
         .map_err(|e| ScrubError::Sql(e.to_string()))?,
     );
 
-    // A unique EXPRESSION index (`CREATE UNIQUE INDEX ON users (left(email, 1))`)
-    // stores `0` in `indkey` for the expression position, so the join above sees
-    // no column at all. Its real inputs come from `pg_depend`. Uniqueness after
-    // an arbitrary expression cannot be preserved by a per-row token — `left(x,1)`
-    // collapses every scrubbed value onto one character — so those columns are
-    // marked unique-constrained and any non-injective strategy on them is
-    // refused. (An injective strategy is refused too, which is the fail-closed
-    // side of the trade: the expression's output is what has to stay distinct,
-    // and only the developer knows whether it does.)
+    // Two kinds of unique index whose real inputs `indkey` does not name:
+    //
+    // - an EXPRESSION index (`ON users (left(email, 1))`) stores `0` for the
+    //   expression position, so the join above sees no column at all — and
+    //   uniqueness after an arbitrary expression cannot be preserved by a
+    //   per-row token, since `left(x, 1)` collapses every scrubbed value onto
+    //   one character;
+    // - a PARTIAL index (`ON events (group_id) WHERE active = false`) is keyed
+    //   on `group_id`, but rewriting `active` changes which rows the index
+    //   COVERS — pulling previously-excluded duplicates into it.
+    //
+    // `pg_depend` records both the expression- and the predicate-referenced
+    // columns, so one query covers them. Marking them unique-constrained is the
+    // fail-closed side of the trade: only the developer knows whether a given
+    // replacement keeps the expression's output (or the predicate's membership)
+    // distinct.
     unique_columns.extend(pair_set(
         sql_query(
             "SELECT rel.relname AS tbl, att.attname AS col \
@@ -2606,7 +2624,8 @@ fn probe_database_facts(
              JOIN pg_namespace ns ON ns.oid = rel.relnamespace AND ns.nspname = 'public' \
              JOIN pg_depend d ON d.objid = i.indexrelid AND d.refobjid = i.indrelid \
              JOIN pg_attribute att ON att.attrelid = rel.oid AND att.attnum = d.refobjsubid \
-             WHERE i.indisunique AND i.indexprs IS NOT NULL AND d.refobjsubid > 0",
+             WHERE i.indisunique AND d.refobjsubid > 0 \
+             AND (i.indexprs IS NOT NULL OR i.indpred IS NOT NULL)",
         )
         .load(&mut conn)
         .map_err(|e| ScrubError::Sql(e.to_string()))?,
@@ -2675,10 +2694,13 @@ fn probe_database_facts(
     .into_iter()
     .collect();
 
+    // `m` (materialized views) belongs here as much as the table relkinds do: a
+    // schema holding only `analytics.user_emails AS SELECT … FROM public.users`
+    // keeps its own copy of the PII, and the refresh pass only reaches `public`.
     let other_schemas = names(
         "SELECT DISTINCT ns.nspname AS name FROM pg_class rel \
          JOIN pg_namespace ns ON ns.oid = rel.relnamespace \
-         WHERE rel.relkind IN ('r', 'p', 'f') \
+         WHERE rel.relkind IN ('r', 'p', 'f', 'm') \
          AND ns.nspname NOT IN ('public', 'information_schema') \
          AND ns.nspname NOT LIKE 'pg\\_%'",
         &mut conn,
@@ -3432,6 +3454,43 @@ mod tests {
         let column = Column::new("token", ColumnType::Uuid);
         let expr = replacement_expr(Strategy::Uuid, &column, "TOK", true).unwrap();
         assert_eq!(expr, "(substr(TOK, 1, 32))::uuid");
+    }
+
+    #[test]
+    fn a_purge_target_under_rls_is_refused_like_any_other_write() {
+        // Framework tables are excluded from `plan.tables`, so without this the
+        // `DELETE` would apply to policy-visible rows only and still report the
+        // table emptied.
+        let config = parse_config_str(
+            r#"
+            [defaults]
+            safe_columns = ["id", "created_at", "email", "full_name", "bio"]
+            [framework]
+            purge = ["autumn_jobs"]
+            "#,
+        )
+        .unwrap();
+        let facts = DatabaseFacts {
+            framework_tables: vec!["autumn_jobs".to_owned()],
+            rls_tables: BTreeSet::from(["autumn_jobs".to_owned()]),
+            ..DatabaseFacts::default()
+        };
+        // The plan itself is clean — the hazard is entirely in the purge target.
+        let plan = plan_with_facts(
+            &[users_table()],
+            &config,
+            &empty_encrypted(),
+            &no_anonymize(),
+            &facts,
+        )
+        .unwrap();
+        assert!(plan.tables.is_empty());
+        let purges = purge_statements(&facts.framework_tables, &config);
+        assert_eq!(purges.len(), 1);
+        assert!(
+            facts.rls_tables.contains(&purges[0].0),
+            "a purge target under RLS must reach the refusal"
+        );
     }
 
     #[test]

--- a/autumn-cli/src/db/scrub.rs
+++ b/autumn-cli/src/db/scrub.rs
@@ -58,6 +58,7 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::path::{Path, PathBuf};
 
 use autumn_schema_core::{Column, ColumnType, Table};
+use diesel::connection::SimpleConnection as _;
 use diesel::{Connection as _, PgConnection, RunQueryDsl as _, sql_query};
 use serde::Deserialize;
 
@@ -73,10 +74,19 @@ pub const SCRUB_CONFIG_FILE: &str = "scrub.toml";
 /// Width of the per-row `md5` token, in hex characters.
 const TOKEN_HEX_LEN: usize = 32;
 
-/// Narrowest token a length-bounded column may carry and still be treated as
-/// per-row unique. Below this the column is refused rather than silently
-/// truncated into collisions.
+/// Width of the per-row `sha256` token used for columns that must stay unique.
+const UNIQUE_TOKEN_HEX_LEN: usize = 64;
+
+/// Narrowest token a length-bounded, non-unique column may carry. Below this the
+/// column is refused rather than silently truncated.
 const MIN_TOKEN_WIDTH: usize = 8;
+
+/// Narrowest token a length-bounded **unique** column may carry: 16 hex
+/// characters is 64 bits, so the birthday bound puts a collision beyond any
+/// plausible row count. Eight (32 bits) is not enough — it collides in practice
+/// around 10⁵ rows, which is a routine table size, and the resulting
+/// unique-violation aborts the whole scrub.
+const MIN_UNIQUE_TOKEN_WIDTH: usize = 16;
 
 /// The reserved, permanently undeliverable domain scrubbed addresses use
 /// (RFC 6761 reserves `.invalid`).
@@ -86,6 +96,8 @@ const SCRUB_EMAIL_DOMAIN: &str = "@example.invalid";
 
 /// Arguments for `autumn db scrub`.
 #[derive(Debug, Clone, Default)]
+// Each flag is an independent switch on one run, not a state machine.
+#[allow(clippy::struct_excessive_bools)]
 pub struct ScrubArgs {
     /// Profile overlay to resolve the connection under (see `db create`).
     pub profile: Option<String>,
@@ -104,6 +116,9 @@ pub struct ScrubArgs {
     pub dry_run: bool,
     /// Bypass the production guard (mirrors `autumn db drop --force`).
     pub force: bool,
+    /// Bypass the separate guard that refuses to write over the database an
+    /// artifact's own non-dev/test profile config declares.
+    pub allow_source_overwrite: bool,
 }
 
 // ─── Errors ─────────────────────────────────────────────────────────────────
@@ -178,6 +193,49 @@ pub enum ScrubError {
         limit: usize,
         /// Characters the strategy's fixed affixes already consume.
         overhead: usize,
+        /// Token characters the column must still have room for.
+        floor: usize,
+    },
+    /// A declaration tried to write plaintext into an `#[encrypted]` column.
+    PlaintextIntoEncrypted {
+        /// Each entry is `table.column` plus the strategy that was declared.
+        columns: Vec<String>,
+    },
+    /// A PII column is covered by a `CHECK` constraint, which no fabricated
+    /// value can be proven to satisfy.
+    CheckConstrainedColumn {
+        /// `table.column`.
+        column: String,
+    },
+    /// The target holds `#[encrypted]` columns but no encryption key could be
+    /// resolved, so a valid replacement envelope cannot be produced.
+    EncryptionKeyUnavailable {
+        /// The profile whose credentials were read.
+        profile: String,
+        /// A credential-safe reason.
+        detail: String,
+    },
+    /// The target has base tables outside `public`, which the classification
+    /// universe does not cover.
+    UnsupportedSchemas {
+        /// The schema names, sorted.
+        schemas: Vec<String>,
+    },
+    /// The target has row-level security on a table the scrub would rewrite.
+    RowLevelSecurity {
+        /// The table names, sorted.
+        tables: Vec<String>,
+    },
+    /// `[tables.<t>]` declares a framework-owned table, which the column
+    /// classification never sees.
+    FrameworkTableDeclared {
+        /// The table names, sorted.
+        tables: Vec<String>,
+    },
+    /// `[framework] purge` names a table whose contents the database needs.
+    PurgeSchemaBookkeeping {
+        /// The table names, sorted.
+        tables: Vec<String>,
     },
     /// The declaration file could not be read or parsed.
     Config {
@@ -245,8 +303,7 @@ impl std::fmt::Display for ScrubError {
                 "{} column(s) are neither PII-classified nor declared safe, so the scrub \
                  cannot prove they carry no real data:\n{}\n  \
                  Declare each one in {SCRUB_CONFIG_FILE} — under [tables.<table>.pii] to \
-                 replace it, or in `safe` to keep it verbatim. Run `autumn db scrub --check` \
-                 for a paste-ready starting point.",
+                 replace it, or in `safe` to keep it verbatim.",
                 columns.len(),
                 bullet_list(columns),
             ),
@@ -314,12 +371,79 @@ impl std::fmt::Display for ScrubError {
                 column,
                 limit,
                 overhead,
+                floor,
             } => write!(
                 f,
                 "{column:?} holds at most {limit} characters, but the chosen strategy needs \
-                 {overhead} for its fixed text plus at least {MIN_TOKEN_WIDTH} more for a \
-                 per-row-unique token.\n  Use a shorter strategy (`redact`), widen the \
-                 column, or declare it `safe`."
+                 {overhead} for its fixed text plus at least {floor} more for a per-row token.\n  \
+                 Strategies by fixed overhead: `phone` (5), `name` (9), `redact` (11), \
+                 `email` (25). Pick one that fits, use `null` if the column is nullable, \
+                 widen the column, or declare it `safe`."
+            ),
+            Self::PlaintextIntoEncrypted { columns } => write!(
+                f,
+                "{} column(s) carry #[encrypted] in the model but {SCRUB_CONFIG_FILE} declares a \
+                 plaintext strategy for them:\n{}\n  \
+                 Writing a plain string into an at-rest-encrypted column makes every later read \
+                 of that row fail as malformed ciphertext. An #[encrypted] column is \
+                 re-encrypted automatically — remove the declaration, or use `null` if the \
+                 column is nullable.",
+                columns.len(),
+                bullet_list(columns),
+            ),
+            Self::CheckConstrainedColumn { column } => write!(
+                f,
+                "{column:?} is covered by a CHECK constraint, so no fabricated value can be \
+                 proven to satisfy it (a closed-set column reaches the database as TEXT plus a \
+                 CHECK, which is why the type alone does not reveal this).\n  \
+                 Declare the column `safe` if the constraint means it holds no free-form PII, \
+                 or drop the constraint on the copy before scrubbing."
+            ),
+            Self::EncryptionKeyUnavailable { profile, detail } => write!(
+                f,
+                "This database has #[encrypted] columns, but no encryption key could be resolved \
+                 for the {profile:?} profile: {detail}\n  \
+                 A scrub must write a VALID ciphertext envelope into an encrypted column — a \
+                 plaintext replacement would make every later read of that row fail. Provide the \
+                 target's `active_record_encryption` credentials (`autumn credentials edit`), or \
+                 declare those columns `null` in {SCRUB_CONFIG_FILE} if they are nullable."
+            ),
+            Self::UnsupportedSchemas { schemas } => write!(
+                f,
+                "This database has base tables in {} schema(s) outside `public`:\n{}\n  \
+                 The classification universe is `public`-only, so a scrub cannot prove those \
+                 tables carry no PII and refuses rather than reporting a completeness it did \
+                 not check. Scrub those schemas separately, or drop them from the copy.",
+                schemas.len(),
+                bullet_list(schemas),
+            ),
+            Self::RowLevelSecurity { tables } => write!(
+                f,
+                "{} table(s) the scrub would rewrite have row-level security enabled:\n{}\n  \
+                 A role that does not bypass RLS updates only the rows its policies expose and \
+                 reports success, leaving the rest of the PII in place — a silent partial scrub. \
+                 Connect as the table owner or a BYPASSRLS role.",
+                tables.len(),
+                bullet_list(tables),
+            ),
+            Self::FrameworkTableDeclared { tables } => write!(
+                f,
+                "{SCRUB_CONFIG_FILE} declares {} framework-owned table(s) under [tables.*]:\n{}\n  \
+                 Framework-owned tables are deliberately outside the column classification \
+                 (exactly as `autumn db pull` and `autumn schema pull` skip them), so a \
+                 per-column declaration for them has no effect. Use \
+                 `[framework] purge = [...]` to empty one instead.",
+                tables.len(),
+                bullet_list(tables),
+            ),
+            Self::PurgeSchemaBookkeeping { tables } => write!(
+                f,
+                "[framework] purge in {SCRUB_CONFIG_FILE} names {} table(s) that hold schema \
+                 bookkeeping, not app payloads:\n{}\n  \
+                 Emptying them would make the copy un-migratable or un-routable. Remove them \
+                 from `purge`.",
+                tables.len(),
+                bullet_list(tables),
             ),
             Self::Config { path, detail } => write!(f, "Cannot read {path}: {detail}"),
             Self::SourceScan { detail } => write!(
@@ -348,8 +472,9 @@ impl std::fmt::Display for ScrubError {
                 f,
                 "Refusing to scrub {database:?}: it is the database the {profile:?} profile's \
                  config file declares.\n  \
-                 The scrub would overwrite the source it was taken from. Point the target at \
-                 a separate staging database, or re-run with --force."
+                 The scrub would overwrite the source the artifact was taken from. Point the \
+                 target at a separate staging database, or re-run with \
+                 --allow-source-overwrite if that really is what you mean."
             ),
             Self::PurgeNotFrameworkTable { tables } => write!(
                 f,
@@ -417,6 +542,14 @@ pub enum Strategy {
     Zero,
     /// The Unix epoch.
     Epoch,
+    /// Re-encrypt: replace an `#[encrypted]` column with a valid AEAD envelope
+    /// of a fake plaintext, produced under the target database's own key.
+    ///
+    /// This is the only strategy that cannot be expressed as SQL — writing a
+    /// plain string into an `#[encrypted]` column would make every subsequent
+    /// repository read of that row fail as malformed ciphertext, so the
+    /// replacement is built in Rust and shipped back per row.
+    Encrypted,
 }
 
 impl Strategy {
@@ -434,6 +567,7 @@ impl Strategy {
             Self::Json => "json",
             Self::Zero => "zero",
             Self::Epoch => "epoch",
+            Self::Encrypted => "encrypted",
         }
     }
 
@@ -445,13 +579,13 @@ impl Strategy {
     const fn allowed_on_unique(self) -> bool {
         matches!(
             self,
-            Self::Auto
-                | Self::Email
+            Self::Email
                 | Self::Name
                 | Self::Redact
                 | Self::Null
                 | Self::Uuid
                 | Self::Bytes
+                | Self::Encrypted
         )
     }
 }
@@ -515,12 +649,22 @@ pub struct ScrubConfig {
 /// payload, an offline-sync row buffer, an experiment assignment — never
 /// schema-bearing bookkeeping like `autumn_migration_checksums`.
 const FRAMEWORK_PAYLOAD_TABLES: &[&str] = &[
+    // A full verbatim copy of every mutated row, including `#[private]` and
+    // `#[encrypted]` columns — so an unscrubbed ledger hands back exactly the
+    // plaintext the column-level scrub just removed.
+    "_autumn_ledger_revisions",
+    // Before/after values for every tracked column; only those named in
+    // `#[version_history(sensitive = [...])]` are redacted.
+    "_autumn_version_history",
     // Hashed API tokens minted in production. A staging copy that inherits them
     // is a live credential leak, not merely a PII one.
     "api_tokens",
     "autumn_experiment_assignments",
     "autumn_job_tracking",
     "autumn_jobs",
+    // The indexed text of app records — the search index is a second copy of
+    // whatever was made searchable.
+    "autumn_search_documents",
     "autumn_sync_applied",
     "autumn_sync_pending",
     "autumn_sync_rows",
@@ -544,10 +688,36 @@ fn is_framework_table(table: &str) -> bool {
         || UNPREFIXED_FRAMEWORK_TABLES.contains(&table)
 }
 
-/// Validate a `[framework] purge` list: it may only name framework-owned tables.
-/// A user table listed there would be silently emptied, which is never what a
-/// scrub should do behind a one-word config key.
+/// Framework-owned tables `[framework] purge` must never accept: emptying them
+/// does not remove a payload, it breaks the copy. `__diesel_schema_migrations`
+/// and `autumn_migration_checksums` are the migration ledger (an empty one
+/// replays every migration against a populated database); `_autumn_shard_map` /
+/// `_autumn_shard_directory` are the routing tables a sharded app reads at boot.
+const NEVER_PURGEABLE_TABLES: &[&str] = &[
+    "__diesel_schema_migrations",
+    "_autumn_shard_directory",
+    "_autumn_shard_map",
+    "autumn_migration_checksums",
+];
+
+/// Validate a `[framework] purge` list: it may only name framework-owned
+/// tables, and never schema bookkeeping. A user table listed there would be
+/// silently emptied, which is never what a scrub should do behind a one-word
+/// config key.
 fn check_purge_list(config: &ScrubConfig) -> Result<(), ScrubError> {
+    let mut bookkeeping: Vec<String> = config
+        .framework
+        .purge
+        .iter()
+        .filter(|t| NEVER_PURGEABLE_TABLES.contains(&t.as_str()))
+        .cloned()
+        .collect();
+    if !bookkeeping.is_empty() {
+        bookkeeping.sort();
+        return Err(ScrubError::PurgeSchemaBookkeeping {
+            tables: bookkeeping,
+        });
+    }
     let mut offenders: Vec<String> = config
         .framework
         .purge
@@ -638,10 +808,13 @@ pub struct ClassificationInputs<'a> {
     pub tables: &'a [Table],
     /// The developer's declaration.
     pub config: &'a ScrubConfig,
-    /// `#[encrypted]` columns, keyed by table.
-    pub encrypted: &'a BTreeMap<String, BTreeSet<String>>,
+    /// `#[encrypted]` columns keyed by table, each mapped to whether the model
+    /// declared `#[encrypted(deterministic)]`.
+    pub encrypted: &'a BTreeMap<String, BTreeMap<String, bool>>,
     /// Tables registered with the GDPR anonymize strategy.
     pub anonymize_tables: &'a BTreeSet<String>,
+    /// Catalog facts the schema IR does not carry (see [`DatabaseFacts`]).
+    pub facts: &'a DatabaseFacts,
 }
 
 /// One column the scrub will rewrite.
@@ -655,6 +828,20 @@ pub struct ColumnPlan {
     pub source: ClassSource,
 }
 
+/// One `#[encrypted]` column's rewrite. Its replacement is an AEAD envelope
+/// built in Rust per row, so it cannot join the table's batched `UPDATE`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EncryptedRewrite {
+    /// The column name.
+    pub column: String,
+    /// Whether the model declared `#[encrypted(deterministic)]`, so equality
+    /// lookups against the column keep working after the scrub.
+    pub deterministic: bool,
+    /// The shape of the fake plaintext to encrypt ([`Strategy::Email`] for an
+    /// email-named column, else [`Strategy::Redact`]).
+    pub shape: Strategy,
+}
+
 /// One table's scrub statement.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TablePlan {
@@ -662,8 +849,14 @@ pub struct TablePlan {
     pub table: String,
     /// The columns rewritten, in table column order.
     pub columns: Vec<ColumnPlan>,
-    /// The single `UPDATE` that rewrites them all.
-    pub sql: String,
+    /// The single `UPDATE` rewriting every SQL-expressible column, or `None`
+    /// when the table's only PII columns are `#[encrypted]` ones.
+    pub sql: Option<String>,
+    /// The SQL expression identifying a row (see [`row_key_expr`]), reused to
+    /// match rows when shipping encrypted replacements back.
+    pub row_key: String,
+    /// Columns whose replacement must be produced in Rust.
+    pub encrypted: Vec<EncryptedRewrite>,
 }
 
 /// The full set of statements a scrub will run against one database.
@@ -702,6 +895,7 @@ impl ScrubPlan {
 /// # Errors
 ///
 /// Returns the corresponding [`ScrubError`] variant for each refusal above.
+#[allow(clippy::too_many_lines)]
 pub fn build_plan(inputs: &ClassificationInputs<'_>) -> Result<ScrubPlan, ScrubError> {
     let by_name: BTreeMap<&str, &Table> =
         inputs.tables.iter().map(|t| (t.name.as_str(), t)).collect();
@@ -712,9 +906,16 @@ pub fn build_plan(inputs: &ClassificationInputs<'_>) -> Result<ScrubPlan, ScrubE
 
     let mut unclassified = Vec::new();
     let mut key_pii = Vec::new();
+    let mut plaintext_into_encrypted: Vec<(String, &'static str)> = Vec::new();
     let mut planned: Vec<(&Table, Vec<(ColumnPlan, &Column)>)> = Vec::new();
 
     for table in inputs.tables {
+        // A partition's rows are rewritten through its parent, so planning it
+        // again would double-update them (and, on a table with no primary key,
+        // re-randomize the values the parent pass just wrote).
+        if inputs.facts.partitions.contains(&table.name) {
+            continue;
+        }
         let rule = inputs.config.tables.get(&table.name);
         let anonymized = inputs.anonymize_tables.contains(&table.name);
         let encrypted = inputs.encrypted.get(&table.name);
@@ -722,16 +923,43 @@ pub fn build_plan(inputs: &ClassificationInputs<'_>) -> Result<ScrubPlan, ScrubE
 
         for column in &table.columns {
             let qualified = format!("{}.{}", table.name, column.name);
-            let is_key = is_key_column(table, column);
+            // A generated column is derived data Postgres refuses to `UPDATE`
+            // at all — scrubbing the columns it reads already covers it — so it
+            // is structurally safe rather than something to declare.
+            if inputs
+                .facts
+                .generated_columns
+                .contains(&(table.name.clone(), column.name.clone()))
+            {
+                continue;
+            }
+            let is_key = is_key_column(table, column, inputs.facts);
             let declared_pii = rule.and_then(|r| r.pii.get(&column.name)).copied();
-            let is_encrypted = encrypted.is_some_and(|e| e.contains(&column.name));
-            let declared_safe = rule.is_some_and(|r| r.safe.contains(&column.name))
-                || inputs.config.defaults.safe_columns.contains(&column.name);
+            let is_encrypted = encrypted.is_some_and(|e| e.contains_key(&column.name));
+            let declared_safe_here = rule.is_some_and(|r| r.safe.contains(&column.name));
+            // A cross-table convenience list is not a per-column review, so it
+            // may not narrow a table-level GDPR anonymize registration: only an
+            // explicit `[tables.<t>] safe` entry can.
+            let declared_safe = declared_safe_here
+                || (!anonymized && inputs.config.defaults.safe_columns.contains(&column.name));
 
-            let (spec, source) = if let Some(strategy) = declared_pii {
+            let (spec, source) = if is_encrypted {
+                // An at-rest-encrypted column is never rewritten with a plain
+                // string: the resolved strategy is always a re-encryption (see
+                // `Strategy::Encrypted`), so a declaration can only choose to
+                // NULL it, never to write plaintext into it.
+                match declared_pii {
+                    None | Some(Strategy::Encrypted) => {
+                        (Strategy::Encrypted, ClassSource::Encrypted)
+                    }
+                    Some(Strategy::Null) => (Strategy::Null, ClassSource::Config),
+                    Some(other) => {
+                        plaintext_into_encrypted.push((qualified, other.as_str()));
+                        continue;
+                    }
+                }
+            } else if let Some(strategy) = declared_pii {
                 (strategy, ClassSource::Config)
-            } else if is_encrypted {
-                (Strategy::Auto, ClassSource::Encrypted)
             } else if declared_safe {
                 continue;
             } else if anonymized {
@@ -763,6 +991,15 @@ pub fn build_plan(inputs: &ClassificationInputs<'_>) -> Result<ScrubPlan, ScrubE
         planned.push((table, columns));
     }
 
+    if !plaintext_into_encrypted.is_empty() {
+        plaintext_into_encrypted.sort();
+        return Err(ScrubError::PlaintextIntoEncrypted {
+            columns: plaintext_into_encrypted
+                .into_iter()
+                .map(|(column, strategy)| format!("{column} (declared `{strategy}`)"))
+                .collect(),
+        });
+    }
     if !key_pii.is_empty() {
         key_pii.sort();
         return Err(ScrubError::PiiOnKeyColumn { columns: key_pii });
@@ -781,34 +1018,77 @@ pub fn build_plan(inputs: &ClassificationInputs<'_>) -> Result<ScrubPlan, ScrubE
         }
         let mut resolved = Vec::with_capacity(columns.len());
         let mut assignments = Vec::with_capacity(columns.len());
+        let mut encrypted_rewrites = Vec::new();
         for (mut plan, column) in columns {
             let qualified = format!("{}.{}", table.name, column.name);
+            let pair = (table.name.clone(), column.name.clone());
+            let unique = is_unique_column(table, column, inputs.facts);
+
+            // A `CHECK` predicate is arbitrary SQL, so no fabricated value can be
+            // proven to satisfy it — and a real Autumn closed-set column reaches
+            // the database as plain `TEXT` plus a `CHECK`, so this (not the
+            // model-IR-only `ColumnType::Enum`) is what actually catches it.
+            if inputs.facts.checked_columns.contains(&pair) {
+                return Err(ScrubError::CheckConstrainedColumn { column: qualified });
+            }
             if plan.strategy == Strategy::Auto {
                 plan.strategy = auto_strategy(column).map_err(|e| qualify(e, &qualified))?;
             }
-            if plan.strategy == Strategy::Null && !column.nullable {
-                return Err(ScrubError::NullOnNotNull { column: qualified });
+            if plan.strategy == Strategy::Null {
+                if !column.nullable {
+                    return Err(ScrubError::NullOnNotNull { column: qualified });
+                }
+                // Postgres normally allows any number of NULLs in a unique
+                // index — but not under `NULLS NOT DISTINCT`.
+                if inputs.facts.nulls_not_distinct_columns.contains(&pair) {
+                    return Err(ScrubError::NonUniqueStrategy {
+                        column: qualified,
+                        strategy: plan.strategy.as_str(),
+                    });
+                }
             }
-            if is_unique_column(table, column) && !plan.strategy.allowed_on_unique() {
+            if unique && !plan.strategy.allowed_on_unique() {
                 return Err(ScrubError::NonUniqueStrategy {
                     column: qualified,
                     strategy: plan.strategy.as_str(),
                 });
             }
-            let token = token_expr(table, &column.name);
-            let value = replacement_expr(plan.strategy, column, &token)
+
+            if plan.strategy == Strategy::Encrypted {
+                // Not expressible as SQL: the replacement is an AEAD envelope
+                // produced in Rust, row by row, under the target's own key.
+                encrypted_rewrites.push(EncryptedRewrite {
+                    column: column.name.clone(),
+                    deterministic: inputs
+                        .encrypted
+                        .get(&table.name)
+                        .and_then(|c| c.get(&column.name))
+                        .copied()
+                        .unwrap_or(false),
+                    shape: email_shaped(&column.name),
+                });
+                resolved.push(plan);
+                continue;
+            }
+
+            let token = token_expr(table, &column.name, unique);
+            let value = replacement_expr(plan.strategy, column, &token, unique)
                 .map_err(|e| qualify(e, &qualified))?;
-            assignments.push(assignment(column, &value));
+            assignments.push(assignment(column, &value, plan.strategy));
             resolved.push(plan);
         }
         out.tables.push(TablePlan {
             table: table.name.clone(),
             columns: resolved,
-            sql: format!(
-                "UPDATE {} SET {}",
-                quote_ident(&table.name),
-                assignments.join(", ")
-            ),
+            sql: (!assignments.is_empty()).then(|| {
+                format!(
+                    "UPDATE {} SET {}",
+                    qualified_ident(&table.name),
+                    assignments.join(", ")
+                )
+            }),
+            row_key: row_key_expr(table),
+            encrypted: encrypted_rewrites,
         });
     }
     Ok(out)
@@ -832,11 +1112,15 @@ fn qualify(error: ScrubError, qualified: &str) -> ScrubError {
             detail,
         },
         ScrubError::ColumnTooNarrow {
-            limit, overhead, ..
+            limit,
+            overhead,
+            floor,
+            ..
         } => ScrubError::ColumnTooNarrow {
             column,
             limit,
             overhead,
+            floor,
         },
         other => other,
     }
@@ -849,9 +1133,17 @@ fn check_config_freshness(
     by_name: &BTreeMap<&str, &Table>,
 ) -> Result<(), ScrubError> {
     let mut stale = Vec::new();
+    let mut framework = Vec::new();
     for (name, rule) in &inputs.config.tables {
         let Some(table) = by_name.get(name.as_str()) else {
-            stale.push(name.clone());
+            // A framework-owned table is not "missing" — it is deliberately
+            // outside the classified universe, and saying "the database does
+            // not have it" would send the developer hunting for a typo.
+            if is_framework_table(name) {
+                framework.push(name.clone());
+            } else {
+                stale.push(name.clone());
+            }
             continue;
         };
         let columns: BTreeSet<&str> = table.columns.iter().map(|c| c.name.as_str()).collect();
@@ -860,6 +1152,10 @@ fn check_config_freshness(
                 stale.push(format!("{name}.{column}"));
             }
         }
+    }
+    if !framework.is_empty() {
+        framework.sort();
+        return Err(ScrubError::FrameworkTableDeclared { tables: framework });
     }
     if stale.is_empty() {
         return Ok(());
@@ -900,10 +1196,20 @@ fn check_safe_overrides_encrypted(
             continue;
         }
         let rule = inputs.config.tables.get(table);
-        for column in encrypted {
+        for column in encrypted.keys() {
             // An explicit PII entry is not an override — it only picks the
             // strategy — so only `safe` declarations conflict.
             if rule.is_some_and(|r| r.pii.contains_key(column)) {
+                continue;
+            }
+            // A key column is exempt: it can never be rewritten anyway (see
+            // `is_key_column`), so refusing its `safe` declaration would leave
+            // the developer with no configuration that terminates.
+            if by_name
+                .get(table.as_str())
+                .and_then(|t| t.columns.iter().find(|c| &c.name == column))
+                .is_some_and(|c| c.primary_key || c.references.is_some())
+            {
                 continue;
             }
             if rule.is_some_and(|r| r.safe.contains(column))
@@ -920,30 +1226,50 @@ fn check_safe_overrides_encrypted(
     Err(ScrubError::SafeOverridesEncrypted { columns })
 }
 
-/// Whether a column participates in the table's primary key or is a foreign key.
-fn is_key_column(table: &Table, column: &Column) -> bool {
-    column.primary_key || table.primary_key.contains(&column.name) || column.references.is_some()
+/// Whether a column is structural — a primary key, either side of any foreign
+/// key, or a generated column Postgres will not let an `UPDATE` touch.
+///
+/// The foreign-key half comes from [`DatabaseFacts`], not from the schema IR:
+/// the IR records only the *referencing* side and only a composite key's first
+/// component, so a natural key another table points at (`users.email` ←
+/// `orders.user_email`) would otherwise look freely rewritable and fail the
+/// constraint at apply time — or, under `ON UPDATE CASCADE`, silently rewrite a
+/// child column that was declared safe.
+fn is_key_column(table: &Table, column: &Column, facts: &DatabaseFacts) -> bool {
+    let pair = (table.name.clone(), column.name.clone());
+    column.primary_key
+        || table.primary_key.contains(&column.name)
+        || column.references.is_some()
+        || facts.foreign_key_columns.contains(&pair)
+        || facts.generated_columns.contains(&pair)
 }
 
-/// Whether a column is constrained unique on its own — either the column flag
-/// introspection sets for a single-column unique index, or such an index listed
-/// on the table. A **partial** unique index does not count: it only constrains
-/// the rows matching its predicate.
-fn is_unique_column(table: &Table, column: &Column) -> bool {
-    if column.unique {
-        return true;
-    }
-    table.indexes.iter().any(|index| {
-        if !index.unique || index.is_partial {
-            return false;
-        }
-        let keys = if index.key_columns.is_empty() {
-            &index.columns
-        } else {
-            &index.key_columns
-        };
-        keys.len() == 1 && keys[0] == column.name
-    })
+/// Whether a rewrite of this column could violate a uniqueness constraint.
+///
+/// This is deliberately **broader** than the schema IR's single-column `unique`
+/// flag, which answers the migration-diff question "does this satisfy a model
+/// `#[unique]`" and therefore excludes composite and partial unique indexes. For
+/// a writer both of those still abort the statement: one member of a composite
+/// unique key set to a constant collides as soon as its partner repeats, and a
+/// partial unique index constrains every row its predicate matches. So the
+/// probed `unique_columns` set — every column of every unique index — is what
+/// gates strategy choice.
+fn is_unique_column(table: &Table, column: &Column, facts: &DatabaseFacts) -> bool {
+    column.unique
+        || facts
+            .unique_columns
+            .contains(&(table.name.clone(), column.name.clone()))
+        || table.indexes.iter().any(|index| {
+            if !index.unique {
+                return false;
+            }
+            let keys = if index.key_columns.is_empty() {
+                &index.columns
+            } else {
+                &index.key_columns
+            };
+            keys.iter().any(|k| k == &column.name)
+        })
 }
 
 // ─── Replacement expressions ────────────────────────────────────────────────
@@ -964,22 +1290,40 @@ fn row_key_expr(table: &Table) -> String {
     if keys.is_empty() {
         return "ctid::text".to_owned();
     }
-    keys.iter()
-        .map(|key| format!("coalesce({}::text, '')", quote_ident(key)))
-        .collect::<Vec<_>>()
-        .join(" || '|' || ")
+    if keys.len() == 1 {
+        return format!("coalesce({}::text, '')", quote_ident(keys[0]));
+    }
+    // `ROW(...)::text` renders a composite key with Postgres's own quoting, so
+    // ('a|','b') and ('a','|b') cannot collapse to one row key the way a plain
+    // separator-joined concatenation does.
+    format!(
+        "ROW({})::text",
+        keys.iter()
+            .map(|key| quote_ident(key))
+            .collect::<Vec<_>>()
+            .join(", ")
+    )
 }
 
 /// The per-row, per-column token every replacement is derived from. Salting with
 /// the column name keeps two PII columns of one row from receiving identical
 /// fake values.
-fn token_expr(table: &Table, column: &str) -> String {
-    token_expr_from(&row_key_expr(table), column)
+fn token_expr(table: &Table, column: &str, unique: bool) -> String {
+    token_expr_from(&row_key_expr(table), column, unique)
 }
 
 /// [`token_expr`] against an already-computed row key.
-fn token_expr_from(row_key: &str, column: &str) -> String {
-    format!("md5({} || '|' || {row_key})", quote_literal(column))
+///
+/// A column that must stay unique gets a 64-hex-character `sha256` token rather
+/// than `md5`'s 32, so a length-bounded column still has room for a token wide
+/// enough to make collisions impossible in practice (see [`bounded_token`]).
+fn token_expr_from(row_key: &str, column: &str, unique: bool) -> String {
+    let seed = format!("{} || '|' || {row_key}", quote_literal(column));
+    if unique {
+        format!("encode(sha256(({seed})::bytea), 'hex')")
+    } else {
+        format!("md5({seed})")
+    }
 }
 
 /// The character limit a length-bounded Postgres type imposes, if any.
@@ -1033,6 +1377,22 @@ fn auto_strategy(column: &Column) -> Result<Strategy, ScrubError> {
         | ColumnType::Decimal { .. } => Strategy::Zero,
         ColumnType::Timestamp | ColumnType::TimestampTz => Strategy::Epoch,
         ty @ ColumnType::Opaque { .. } if is_texty(ty) => email_shaped(&column.name),
+        // `from_pg_udt` maps only Autumn's own scalar surface, so several
+        // everyday PII column types arrive as `Opaque` — `date_of_birth DATE`
+        // most of all. Without these arms `auto` refuses them and the explicit
+        // fallbacks (`epoch`, `zero`) reject them too, leaving no usable
+        // strategy at all.
+        ColumnType::Opaque { pg_type }
+            if matches!(pg_type.as_str(), "date" | "time" | "timetz") =>
+        {
+            Strategy::Epoch
+        }
+        ColumnType::Opaque { pg_type }
+            if matches!(pg_type.as_str(), "int2" | "money" | "oid")
+                || pg_type.starts_with("numeric") =>
+        {
+            Strategy::Zero
+        }
         other => {
             return Err(ScrubError::NoAutoStrategy {
                 column: column.name.clone(),
@@ -1062,17 +1422,36 @@ fn email_shaped(name: &str) -> Strategy {
 /// hold a per-row-unique value, [`ScrubError::StrategyTypeMismatch`] when the
 /// strategy cannot produce the column's type, or [`ScrubError::NoAutoStrategy`]
 /// when [`Strategy::Auto`] cannot be resolved.
+#[allow(clippy::too_many_lines)]
 fn replacement_expr(
     strategy: Strategy,
     column: &Column,
     token: &str,
+    unique: bool,
 ) -> Result<String, ScrubError> {
     let limit = char_max_len(&column.ty);
     let narrow = |overhead: usize| -> Result<String, ScrubError> {
-        bounded_token(token, limit, overhead, &column.name)
+        bounded_token(token, limit, overhead, &column.name, unique)
     };
+    // Every text-shaped strategy needs a character column to land in. Without
+    // this gate `age = "redact"` on an `integer` (or `last_login_ip = "redact"`
+    // on an `inet`) passes classification and only fails once Postgres runs the
+    // statement — after an `--artifact` restore has already written real data.
+    if matches!(
+        strategy,
+        Strategy::Email | Strategy::Name | Strategy::Redact | Strategy::Phone
+    ) {
+        require_type(column, strategy, is_texty(&column.ty))?;
+    }
     Ok(match strategy {
-        Strategy::Auto => replacement_expr(auto_strategy(column)?, column, token)?,
+        Strategy::Auto => replacement_expr(auto_strategy(column)?, column, token, unique)?,
+        Strategy::Encrypted => {
+            return Err(ScrubError::StrategyTypeMismatch {
+                column: column.name.clone(),
+                strategy: strategy.as_str(),
+                detail: "an encrypted replacement is built in Rust, not in SQL".to_owned(),
+            });
+        }
         Strategy::Email => {
             let tok = narrow("scrubbed+".len() + SCRUB_EMAIL_DOMAIN.len())?;
             format!("'scrubbed+' || {tok} || '{SCRUB_EMAIL_DOMAIN}'")
@@ -1097,6 +1476,7 @@ fn replacement_expr(
                     column: column.name.clone(),
                     limit,
                     overhead,
+                    floor: PHONE_DIGITS,
                 });
             }
             format!("'+1555' || translate(substr({token}, 1, {PHONE_DIGITS}), 'abcdef', '0123456')")
@@ -1115,7 +1495,23 @@ fn replacement_expr(
             match &column.ty {
                 ColumnType::Json | ColumnType::Attachment => format!("{json}::jsonb"),
                 ColumnType::Opaque { pg_type } if pg_type == "json" => format!("{json}::json"),
-                ty if is_texty(ty) => json.to_owned(),
+                ty if is_texty(ty) => {
+                    // Unlike every other text-producing strategy this one is a
+                    // fixed literal, so a narrow `varchar(n)` has to be checked
+                    // explicitly rather than by narrowing a token.
+                    const JSON_LITERAL_LEN: usize = 18;
+                    if let Some(limit) = limit
+                        && limit < JSON_LITERAL_LEN
+                    {
+                        return Err(ScrubError::ColumnTooNarrow {
+                            column: column.name.clone(),
+                            limit,
+                            overhead: JSON_LITERAL_LEN,
+                            floor: 0,
+                        });
+                    }
+                    json.to_owned()
+                }
                 other => {
                     return Err(ScrubError::StrategyTypeMismatch {
                         column: column.name.clone(),
@@ -1132,7 +1528,12 @@ fn replacement_expr(
             | ColumnType::Float32
             | ColumnType::Float64
             | ColumnType::Decimal { .. } => "0".to_owned(),
-            ColumnType::Opaque { pg_type } if pg_type.starts_with("numeric") => "0".to_owned(),
+            ColumnType::Opaque { pg_type }
+                if pg_type.starts_with("numeric")
+                    || matches!(pg_type.as_str(), "int2" | "money" | "oid") =>
+            {
+                "0".to_owned()
+            }
             other => {
                 return Err(ScrubError::StrategyTypeMismatch {
                     column: column.name.clone(),
@@ -1144,6 +1545,11 @@ fn replacement_expr(
         Strategy::Epoch => match &column.ty {
             ColumnType::Timestamp => "'1970-01-01 00:00:00'::timestamp".to_owned(),
             ColumnType::TimestampTz => "'1970-01-01 00:00:00+00'::timestamptz".to_owned(),
+            ColumnType::Opaque { pg_type } if pg_type == "date" => "'1970-01-01'::date".to_owned(),
+            ColumnType::Opaque { pg_type } if pg_type == "time" => "'00:00:00'::time".to_owned(),
+            ColumnType::Opaque { pg_type } if pg_type == "timetz" => {
+                "'00:00:00+00'::timetz".to_owned()
+            }
             other => {
                 return Err(ScrubError::StrategyTypeMismatch {
                     column: column.name.clone(),
@@ -1174,20 +1580,27 @@ fn bounded_token(
     limit: Option<usize>,
     overhead: usize,
     column: &str,
+    unique: bool,
 ) -> Result<String, ScrubError> {
+    let (full, floor) = if unique {
+        (UNIQUE_TOKEN_HEX_LEN, MIN_UNIQUE_TOKEN_WIDTH)
+    } else {
+        (TOKEN_HEX_LEN, MIN_TOKEN_WIDTH)
+    };
     let Some(limit) = limit else {
         return Ok(token.to_owned());
     };
     let available = limit.saturating_sub(overhead);
-    if available >= TOKEN_HEX_LEN {
+    if available >= full {
         Ok(token.to_owned())
-    } else if available >= MIN_TOKEN_WIDTH {
+    } else if available >= floor {
         Ok(format!("substr({token}, 1, {available})"))
     } else {
         Err(ScrubError::ColumnTooNarrow {
             column: column.to_owned(),
             limit,
             overhead,
+            floor,
         })
     }
 }
@@ -1195,13 +1608,28 @@ fn bounded_token(
 /// One `SET` clause. A nullable column keeps its `NULL`s (a scrub anonymizes
 /// values, it does not invent them), so it is wrapped in a `CASE`; a `NOT NULL`
 /// column needs no guard.
-fn assignment(column: &Column, value: &str) -> String {
+fn assignment(column: &Column, value: &str, strategy: Strategy) -> String {
     let ident = quote_ident(&column.name);
-    if column.nullable {
+    // A `CASE` whose arms are both bare `NULL` has no type to infer from, so
+    // Postgres resolves it to `text` and the assignment fails on every
+    // non-character column. The guard is pointless there anyway: the
+    // replacement already IS null.
+    if column.nullable && strategy != Strategy::Null {
         format!("{ident} = CASE WHEN {ident} IS NULL THEN NULL ELSE {value} END")
     } else {
         format!("{ident} = {value}")
     }
+}
+
+/// A `public`-qualified table identifier.
+///
+/// Every catalog read that produced the plan is scoped to `public`, so the
+/// writes must be too: a database- or role-level `search_path` (which Autumn
+/// supports for tenant schemas) would otherwise resolve a bare `UPDATE "users"`
+/// to a *different* table than the one that was classified — leaving the
+/// classified rows unscrubbed and overwriting rows nothing planned.
+fn qualified_ident(table: &str) -> String {
+    format!("\"public\".{}", quote_ident(table))
 }
 
 // ─── GDPR anonymize registrations ───────────────────────────────────────────
@@ -1311,7 +1739,7 @@ fn scan_anonymize_tables(root: &Path) -> Result<BTreeSet<String>, ScrubError> {
 /// empty map when the project has no models directory at all.
 fn encrypted_columns(
     project_root: &Path,
-) -> Result<BTreeMap<String, BTreeSet<String>>, ScrubError> {
+) -> Result<BTreeMap<String, BTreeMap<String, bool>>, ScrubError> {
     let Some(path) = crate::schema::existing_models_path(project_root) else {
         return Ok(BTreeMap::new());
     };
@@ -1366,13 +1794,17 @@ fn same_database(a: &str, b: &str) -> bool {
 /// Deliberately reads only `autumn.toml` / `autumn-<profile>.toml`, never the
 /// environment: an env-provided `DATABASE_URL` is shared by every profile
 /// resolution, so consulting it would make this guard fire on legitimate scrubs.
-/// It is defence in depth on top of [`guard_scrub_target`], not a replacement.
+///
+/// It has its own waiver (`--allow-source-overwrite`) rather than riding on
+/// `--force`: the documented staging drill ALWAYS passes `--force` (staging is
+/// not `dev`/`test`), so a guard that `--force` waived would be inert in exactly
+/// the workflow it exists for.
 fn guard_configured_source(
     source_profile: &str,
     targets: &[(String, String)],
-    force: bool,
+    allowed: bool,
 ) -> Result<(), ScrubError> {
-    if force || super::is_safe_destructive_profile(source_profile) {
+    if allowed || super::is_safe_destructive_profile(source_profile) {
         return Ok(());
     }
     let table = migrate::read_autumn_toml_table_with_profile(Some(source_profile));
@@ -1442,7 +1874,10 @@ pub fn run(args: &ScrubArgs) {
     if let Err(e) = scrub(args) {
         eprintln!("\u{2717} {e}");
         if let ScrubError::Unclassified { columns } = &e {
-            eprintln!("\n{}", suggested_config_stanza(columns));
+            // stdout, not stderr: the diagnostics above are stderr, so
+            // `autumn db scrub --check 2>/dev/null >> scrub.toml` appends a
+            // valid stanza instead of a wall of interleaved prose.
+            println!("{}", suggested_config_stanza(columns));
         }
         std::process::exit(1);
     }
@@ -1455,12 +1890,25 @@ fn scrub(args: &ScrubArgs) -> Result<(), ScrubError> {
         guard_scrub_target(&profile, args.force)?;
     }
 
+    // Everything that does NOT need the database is resolved first, so a typo in
+    // `scrub.toml`, an unknown strategy, a `purge` entry naming a user table, or
+    // an unparsable model file fails BEFORE an `--artifact` restore writes real
+    // data into the target. Only schema-dependent refusals can land after it.
+    let sources = load_source_classification(args)?;
+
     let targets = super::backup::resolve_all_target_urls(args.profile.as_deref())?;
 
     let restored = if let Some(artifact) = &args.artifact {
+        // `--check`/`--dry-run` promise to write nothing, and a restore is the
+        // largest write there is. clap already rejects the combination; this
+        // keeps the invariant true inside the function that relies on it.
+        debug_assert!(
+            writes,
+            "--check/--dry-run must never reach an artifact restore"
+        );
         if let Some(source_profile) = super::backup::artifact_source_profile(artifact) {
             eprintln!("  \u{2139} Artifact was taken under the {source_profile:?} profile.");
-            guard_configured_source(&source_profile, &targets, args.force)?;
+            guard_configured_source(&source_profile, &targets, args.allow_source_overwrite)?;
         }
         eprintln!(
             "\u{2500}\u{2500} restoring {} \u{2500}\u{2500}",
@@ -1478,20 +1926,61 @@ fn scrub(args: &ScrubArgs) -> Result<(), ScrubError> {
         false
     };
 
-    // A restore has already written the artifact's REAL data into the target, so
-    // any refusal from here on leaves unscrubbed data behind. The classification
-    // cannot run earlier — it reads the schema the restore just created — so the
-    // outcome is stated in the loudest possible terms instead of being implied.
-    classify_and_apply(args, &targets).inspect_err(|_| {
+    // The classification that remains reads the schema the restore just created,
+    // so it cannot run earlier — and a refusal here leaves the artifact's real
+    // data in the target. Say so in the loudest possible terms.
+    classify_and_apply(args, &profile, &targets, &sources).inspect_err(|_| {
         if restored {
             eprintln!(
-                "\n\u{26A0} The artifact was ALREADY RESTORED before this failure, so the \
-                 target database now holds UNSCRUBBED data.\n  \
+                "\n\u{26A0}\u{FE0F}  The artifact was ALREADY RESTORED before this failure, so \
+                 the target database now holds UNSCRUBBED data.\n  \
                  Do not hand it to anyone: fix the problem below and re-run the same \
-                 command, or drop the database. `autumn db scrub --check` catches this \
-                 before a restore."
+                 command, or drop the database."
             );
         }
+    })
+}
+
+/// The classification inputs that come from files rather than from the database.
+struct SourceClassification {
+    config: ScrubConfig,
+    encrypted: BTreeMap<String, BTreeMap<String, bool>>,
+    anonymize: BTreeSet<String>,
+}
+
+/// Read and validate every file-based classification source, reporting what each
+/// one contributed.
+///
+/// The counts are printed rather than assumed: both automatic sources degrade to
+/// empty when the command runs outside the project root (a deployed staging host
+/// often has the binary and `scrub.toml` but no source tree), and a silently
+/// empty `#[encrypted]` map would also silently disable the "a `safe`
+/// declaration may not override `#[encrypted]`" refusal.
+fn load_source_classification(args: &ScrubArgs) -> Result<SourceClassification, ScrubError> {
+    let config = load_config(args.config.as_deref())?;
+    check_purge_list(&config)?;
+    let project_root = Path::new(".");
+    let encrypted = encrypted_columns(project_root)?;
+    let anonymize = scan_anonymize_tables(&project_root.join("src"))?;
+
+    let encrypted_count: usize = encrypted.values().map(BTreeMap::len).sum();
+    eprintln!(
+        "  \u{2139} Automatic classification: {encrypted_count} #[encrypted] column(s), \
+         {} GDPR anonymize registration(s).",
+        anonymize.len()
+    );
+    if encrypted_count == 0 && anonymize.is_empty() && !project_root.join("src").is_dir() {
+        eprintln!(
+            "  \u{26A0}\u{FE0F}  No `src/` directory here, so NEITHER automatic source could be \
+             read. Run the scrub from the project root, or every column must be declared in \
+             {SCRUB_CONFIG_FILE} by hand."
+        );
+    }
+
+    Ok(SourceClassification {
+        config,
+        encrypted,
+        anonymize,
     })
 }
 
@@ -1503,42 +1992,82 @@ fn scrub(args: &ScrubArgs) -> Result<(), ScrubError> {
 /// shards, a single-pass loop would scrub the control database and only then
 /// discover that a shard has an undeclared column, leaving the topology half
 /// anonymized.
-fn classify_and_apply(args: &ScrubArgs, targets: &[(String, String)]) -> Result<(), ScrubError> {
-    let config = load_config(args.config.as_deref())?;
-    check_purge_list(&config)?;
-    let project_root = Path::new(".");
-    let encrypted = encrypted_columns(project_root)?;
-    let anonymize = scan_anonymize_tables(&project_root.join("src"))?;
-
+#[allow(clippy::too_many_lines)]
+fn classify_and_apply(
+    args: &ScrubArgs,
+    profile: &str,
+    targets: &[(String, String)],
+    sources: &SourceClassification,
+) -> Result<(), ScrubError> {
     // ── Pass 1: classify everything ─────────────────────────────────────────
     let mut plans = Vec::with_capacity(targets.len());
     for (label, url) in targets {
+        let facts = probe_database_facts(url, label, &sources.config)?;
+
+        // A universe the classifier never looked at cannot be reported clean.
+        if !facts.other_schemas.is_empty() {
+            return Err(ScrubError::UnsupportedSchemas {
+                schemas: facts.other_schemas.iter().cloned().collect(),
+            });
+        }
+
         let tables = introspect::introspect_postgres(url).map_err(|e| ScrubError::Introspect {
             label: label.clone(),
             detail: e.to_string(),
         })?;
         let plan = build_plan(&ClassificationInputs {
             tables: &tables,
-            config: &config,
-            encrypted: &encrypted,
-            anonymize_tables: &anonymize,
+            config: &sources.config,
+            encrypted: &sources.encrypted,
+            anonymize_tables: &sources.anonymize,
+            facts: &facts,
         })?;
+
+        // RLS makes an `UPDATE` silently apply to policy-visible rows only,
+        // which is a fail-OPEN in a fail-closed tool — refuse rather than
+        // report a partial scrub as complete.
+        let rls: Vec<String> = plan
+            .tables
+            .iter()
+            .filter(|t| facts.rls_tables.contains(&t.table))
+            .map(|t| t.table.clone())
+            .collect();
+        if !rls.is_empty() {
+            return Err(ScrubError::RowLevelSecurity { tables: rls });
+        }
+
         report_plan(label, &plan);
-        let framework = framework_payload_tables_present(url, label, &config)?;
-        report_framework_tables(&framework, &config);
-        plans.push((label, url, plan, framework));
+        report_framework_tables(&facts.framework_tables, &sources.config);
+        report_triggers(&plan, &facts);
+        plans.push((label, url, plan, facts));
     }
 
     if args.check {
-        eprintln!("\n\u{2713} Every column is classified \u{2014} no unclassified data can leak.");
+        eprintln!(
+            "\n\u{2713} Every column in `public` is classified \u{2014} no unclassified data can leak."
+        );
         return Ok(());
     }
     if args.dry_run {
-        for (_, _, plan, framework) in &plans {
+        for (_, _, plan, facts) in &plans {
             for table in &plan.tables {
-                eprintln!("  {};", table.sql);
+                if let Some(sql) = &table.sql {
+                    eprintln!("  {sql};");
+                }
+                for rewrite in &table.encrypted {
+                    eprintln!(
+                        "  -- {}.{}: re-encrypted per row under the target's key ({} mode)",
+                        table.table,
+                        rewrite.column,
+                        if rewrite.deterministic {
+                            "deterministic"
+                        } else {
+                            "randomized"
+                        }
+                    );
+                }
             }
-            for (_, statement) in purge_statements(framework, &config) {
+            for (_, statement) in purge_statements(&facts.framework_tables, &sources.config) {
                 eprintln!("  {statement};");
             }
         }
@@ -1546,11 +2075,35 @@ fn classify_and_apply(args: &ScrubArgs, targets: &[(String, String)]) -> Result<
         return Ok(());
     }
 
+    // An encrypted rewrite needs the target's key BEFORE anything is written,
+    // so a missing key is a refusal rather than a half-scrubbed database.
+    if plans
+        .iter()
+        .any(|(_, _, plan, _)| plan.tables.iter().any(|t| !t.encrypted.is_empty()))
+    {
+        let ring = resolve_key_ring(profile, Path::new("."))?;
+        autumn_web::encryption::install_key_ring(ring);
+    }
+
     // ── Pass 2: apply ───────────────────────────────────────────────────────
-    for (label, url, plan, framework) in &plans {
-        for (table, rows) in execute(url, plan, &purge_statements(framework, &config), label)? {
+    let mut committed: Vec<&str> = Vec::new();
+    for (label, url, plan, facts) in &plans {
+        let purges = purge_statements(&facts.framework_tables, &sources.config);
+        let applied = execute(url, plan, &purges, label).inspect_err(|_| {
+            if !committed.is_empty() {
+                eprintln!(
+                    "\n\u{26A0}\u{FE0F}  Already committed before this failure: {}. \
+                     Those databases ARE scrubbed; every later target is untouched and still \
+                     holds real data.",
+                    committed.join(", ")
+                );
+            }
+        })?;
+        for (table, rows) in applied {
             eprintln!("  \u{2713} {table}: {rows} row(s) scrubbed.");
         }
+        refresh_materialized_views(url, label, &facts.materialized_views)?;
+        committed.push(label);
     }
 
     if let Some(dir) = &args.output {
@@ -1567,6 +2120,31 @@ fn classify_and_apply(args: &ScrubArgs, targets: &[(String, String)]) -> Result<
 
     eprintln!("\n\u{2713} Scrub complete.");
     Ok(())
+}
+
+/// Warn when a table the scrub rewrites carries user-defined triggers.
+///
+/// An audit/history trigger copies the pre-scrub `OLD` row into another table as
+/// the `UPDATE` runs — so a table scrubbed earlier in the same transaction can be
+/// re-populated with real values behind the scrub's back.
+fn report_triggers(plan: &ScrubPlan, facts: &DatabaseFacts) {
+    let triggered: Vec<&str> = plan
+        .tables
+        .iter()
+        .filter(|t| facts.triggered_tables.contains(&t.table))
+        .map(|t| t.table.as_str())
+        .collect();
+    if triggered.is_empty() {
+        return;
+    }
+    eprintln!(
+        "  \u{26A0}\u{FE0F}  {} rewritten table(s) carry user-defined triggers: {}.\n    \
+         An audit or history trigger copies the PRE-scrub row into another table as the \
+         rewrite runs, which can re-introduce real values. Check those triggers, or disable \
+         them on the copy before scrubbing.",
+        triggered.len(),
+        triggered.join(", ")
+    );
 }
 
 /// Print what one database's scrub will do: every column, its strategy, and what
@@ -1591,39 +2169,302 @@ fn report_plan(label: &str, plan: &ScrubPlan) {
     }
 }
 
-/// The framework-owned payload tables that actually exist in one database.
+/// Everything about one live database that the pure classifier cannot read from
+/// the schema IR, gathered in a single connection.
 ///
-/// Introspection filters `autumn_*` / `_autumn*` out of the classified universe,
-/// so this is a separate probe: the scrub still has to say something about them
-/// rather than pretend they are not there.
-fn framework_payload_tables_present(
+/// The IR [`crate::schema::introspect`] produces is shaped for *migration
+/// diffing*, not for "is it safe to rewrite this column": it records only
+/// outgoing single-column foreign keys, drops generated/identity semantics, and
+/// says nothing about row-level security, triggers, partitions, materialized
+/// views, or schemas outside `public`. Every one of those decides whether an
+/// `UPDATE` this command emits succeeds, silently under-applies, or leaks — so
+/// they are probed here rather than assumed.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct DatabaseFacts {
+    /// Every column on either side of any foreign key, all components of a
+    /// composite key included, as `(table, column)`. Rewriting any of them
+    /// breaks referential integrity (or is silently cascaded into a child).
+    pub foreign_key_columns: BTreeSet<(String, String)>,
+    /// Columns named by a `CHECK` constraint. A fabricated value has no way to
+    /// satisfy an arbitrary predicate, so these are refused rather than guessed.
+    pub checked_columns: BTreeSet<(String, String)>,
+    /// Generated / `GENERATED ALWAYS AS IDENTITY` columns. Postgres refuses to
+    /// `UPDATE` them at all, and they are derived data that a scrub of their
+    /// source columns already covers.
+    pub generated_columns: BTreeSet<(String, String)>,
+    /// Columns covered by ANY unique index — composite and partial included.
+    /// Broader than the IR's single-column `unique` flag, which is the right
+    /// question for a migration diff and the wrong one for "can this rewrite
+    /// collide".
+    pub unique_columns: BTreeSet<(String, String)>,
+    /// Columns covered by a `NULLS NOT DISTINCT` unique index, where more than
+    /// one `NULL` is itself a uniqueness violation.
+    pub nulls_not_distinct_columns: BTreeSet<(String, String)>,
+    /// Tables that are partitions of another table. Their rows are rewritten
+    /// through the parent, so planning them again double-updates.
+    pub partitions: BTreeSet<String>,
+    /// Tables with row-level security enabled. A non-bypassing role silently
+    /// updates only the rows its policies expose — a fail-open a scrub cannot
+    /// tolerate.
+    pub rls_tables: BTreeSet<String>,
+    /// Tables carrying user-defined triggers, which can copy pre-scrub values
+    /// into another table mid-scrub.
+    pub triggered_tables: BTreeSet<String>,
+    /// Materialized views, in dependency order (sources before dependents), so
+    /// refreshing them in sequence never re-derives from stale data.
+    pub materialized_views: Vec<String>,
+    /// Non-system schemas other than `public` that hold base tables. The whole
+    /// classification universe is `public`-only, so these are refused.
+    pub other_schemas: BTreeSet<String>,
+    /// Framework-owned tables present that the classification never sees.
+    pub framework_tables: Vec<String>,
+}
+
+/// A single `name` column.
+#[derive(diesel::QueryableByName)]
+struct NameRow {
+    #[diesel(sql_type = diesel::sql_types::Text)]
+    name: String,
+}
+
+/// A `(table, column)` pair.
+#[derive(diesel::QueryableByName)]
+struct PairRow {
+    #[diesel(sql_type = diesel::sql_types::Text)]
+    tbl: String,
+    #[diesel(sql_type = diesel::sql_types::Text)]
+    col: String,
+}
+
+fn pair_set(rows: Vec<PairRow>) -> BTreeSet<(String, String)> {
+    rows.into_iter().map(|r| (r.tbl, r.col)).collect()
+}
+
+/// Open a connection for a probe, mapping failure to a credential-safe error.
+fn probe_connection(url: &str, label: &str, what: &str) -> Result<PgConnection, ScrubError> {
+    PgConnection::establish(url).map_err(|_| ScrubError::Introspect {
+        label: label.to_owned(),
+        detail: format!(
+            "could not connect to database {:?} to {what}",
+            parsed_db_name(url)
+        ),
+    })
+}
+
+/// Gather every catalog fact the plan validation needs.
+// One catalog read per fact; splitting it would scatter closely-related SQL
+// across helpers that each need the same connection.
+#[allow(clippy::too_many_lines)]
+fn probe_database_facts(
     url: &str,
     label: &str,
     config: &ScrubConfig,
-) -> Result<Vec<String>, ScrubError> {
-    let mut conn = PgConnection::establish(url).map_err(|_| ScrubError::Introspect {
-        label: label.to_owned(),
-        detail: format!(
-            "could not connect to database {:?} to inspect framework-owned tables",
-            parsed_db_name(url)
-        ),
-    })?;
-    // The known payload carriers PLUS anything the app explicitly opted into
-    // purging — otherwise a `purge` entry outside the built-in list would be
-    // accepted by the config check and then silently do nothing.
+) -> Result<DatabaseFacts, ScrubError> {
+    let mut conn = probe_connection(url, label, "inspect its catalog")?;
+
+    // ── Foreign keys: BOTH sides, every component ───────────────────────────
+    // `pg_constraint.conkey`/`confkey` are arrays; `unnest` covers composite
+    // keys, which the IR (first component, referencing side only) cannot.
+    let foreign_key_columns = pair_set(
+        sql_query(
+            "SELECT rel.relname AS tbl, att.attname AS col \
+             FROM pg_constraint c \
+             JOIN pg_class rel ON rel.oid = c.conrelid \
+             JOIN pg_namespace ns ON ns.oid = rel.relnamespace AND ns.nspname = 'public' \
+             CROSS JOIN LATERAL unnest(c.conkey) AS k(attnum) \
+             JOIN pg_attribute att ON att.attrelid = rel.oid AND att.attnum = k.attnum \
+             WHERE c.contype = 'f' \
+             UNION \
+             SELECT frel.relname AS tbl, fatt.attname AS col \
+             FROM pg_constraint c \
+             JOIN pg_class frel ON frel.oid = c.confrelid \
+             JOIN pg_namespace fns ON fns.oid = frel.relnamespace AND fns.nspname = 'public' \
+             CROSS JOIN LATERAL unnest(c.confkey) AS fk(attnum) \
+             JOIN pg_attribute fatt ON fatt.attrelid = frel.oid AND fatt.attnum = fk.attnum \
+             WHERE c.contype = 'f'",
+        )
+        .load(&mut conn)
+        .map_err(|e| ScrubError::Sql(e.to_string()))?,
+    );
+
+    // ── CHECK-constrained columns ───────────────────────────────────────────
+    let checked_columns = pair_set(
+        sql_query(
+            "SELECT rel.relname AS tbl, att.attname AS col \
+             FROM pg_constraint c \
+             JOIN pg_class rel ON rel.oid = c.conrelid \
+             JOIN pg_namespace ns ON ns.oid = rel.relnamespace AND ns.nspname = 'public' \
+             CROSS JOIN LATERAL unnest(c.conkey) AS k(attnum) \
+             JOIN pg_attribute att ON att.attrelid = rel.oid AND att.attnum = k.attnum \
+             WHERE c.contype = 'c'",
+        )
+        .load(&mut conn)
+        .map_err(|e| ScrubError::Sql(e.to_string()))?,
+    );
+
+    // ── Generated / identity-always columns ─────────────────────────────────
+    let generated_columns = pair_set(
+        sql_query(
+            "SELECT rel.relname AS tbl, att.attname AS col \
+             FROM pg_attribute att \
+             JOIN pg_class rel ON rel.oid = att.attrelid \
+             JOIN pg_namespace ns ON ns.oid = rel.relnamespace AND ns.nspname = 'public' \
+             WHERE att.attnum > 0 AND NOT att.attisdropped \
+             AND (att.attgenerated <> '' OR att.attidentity = 'a')",
+        )
+        .load(&mut conn)
+        .map_err(|e| ScrubError::Sql(e.to_string()))?,
+    );
+
+    // ── Uniqueness, the write-side question ─────────────────────────────────
+    // ANY unique index counts (composite and partial included): the IR's
+    // single-column `unique` flag answers a migration-diff question, not
+    // "can this rewrite collide".
+    let unique_columns = pair_set(
+        sql_query(
+            "SELECT rel.relname AS tbl, att.attname AS col \
+             FROM pg_index i \
+             JOIN pg_class rel ON rel.oid = i.indrelid \
+             JOIN pg_namespace ns ON ns.oid = rel.relnamespace AND ns.nspname = 'public' \
+             CROSS JOIN LATERAL unnest(i.indkey[0:i.indnkeyatts-1]) AS k(attnum) \
+             JOIN pg_attribute att ON att.attrelid = rel.oid AND att.attnum = k.attnum \
+             WHERE i.indisunique AND k.attnum > 0",
+        )
+        .load(&mut conn)
+        .map_err(|e| ScrubError::Sql(e.to_string()))?,
+    );
+
+    // `NULLS NOT DISTINCT` (PG15+) makes a second NULL a violation, so the
+    // `null` strategy stops being unique-safe. `indnullsnotdistinct` does not
+    // exist before 15; probe the column's presence first so this stays
+    // compatible with older servers.
+    let has_nnd: Vec<NameRow> = sql_query(
+        "SELECT 'yes' AS name FROM pg_attribute \
+         WHERE attrelid = 'pg_index'::regclass AND attname = 'indnullsnotdistinct'",
+    )
+    .load(&mut conn)
+    .map_err(|e| ScrubError::Sql(e.to_string()))?;
+    let nulls_not_distinct_columns = if has_nnd.is_empty() {
+        BTreeSet::new()
+    } else {
+        pair_set(
+            sql_query(
+                "SELECT rel.relname AS tbl, att.attname AS col \
+                 FROM pg_index i \
+                 JOIN pg_class rel ON rel.oid = i.indrelid \
+                 JOIN pg_namespace ns ON ns.oid = rel.relnamespace AND ns.nspname = 'public' \
+                 CROSS JOIN LATERAL unnest(i.indkey[0:i.indnkeyatts-1]) AS k(attnum) \
+                 JOIN pg_attribute att ON att.attrelid = rel.oid AND att.attnum = k.attnum \
+                 WHERE i.indisunique AND i.indnullsnotdistinct AND k.attnum > 0",
+            )
+            .load(&mut conn)
+            .map_err(|e| ScrubError::Sql(e.to_string()))?,
+        )
+    };
+
+    // ── Table-level facts ───────────────────────────────────────────────────
+    let names = |q: &str, conn: &mut PgConnection| -> Result<Vec<String>, ScrubError> {
+        let rows: Vec<NameRow> = sql_query(q)
+            .load(conn)
+            .map_err(|e| ScrubError::Sql(e.to_string()))?;
+        Ok(rows.into_iter().map(|r| r.name).collect())
+    };
+
+    let partitions = names(
+        "SELECT rel.relname AS name FROM pg_class rel \
+         JOIN pg_namespace ns ON ns.oid = rel.relnamespace AND ns.nspname = 'public' \
+         WHERE rel.relispartition",
+        &mut conn,
+    )?
+    .into_iter()
+    .collect();
+
+    let rls_tables = names(
+        "SELECT rel.relname AS name FROM pg_class rel \
+         JOIN pg_namespace ns ON ns.oid = rel.relnamespace AND ns.nspname = 'public' \
+         WHERE rel.relrowsecurity",
+        &mut conn,
+    )?
+    .into_iter()
+    .collect();
+
+    let triggered_tables = names(
+        "SELECT DISTINCT rel.relname AS name FROM pg_trigger t \
+         JOIN pg_class rel ON rel.oid = t.tgrelid \
+         JOIN pg_namespace ns ON ns.oid = rel.relnamespace AND ns.nspname = 'public' \
+         WHERE NOT t.tgisinternal",
+        &mut conn,
+    )?
+    .into_iter()
+    .collect();
+
+    let other_schemas = names(
+        "SELECT DISTINCT ns.nspname AS name FROM pg_class rel \
+         JOIN pg_namespace ns ON ns.oid = rel.relnamespace \
+         WHERE rel.relkind IN ('r', 'p') AND ns.nspname NOT IN ('public', 'information_schema') \
+         AND ns.nspname NOT LIKE 'pg\\_%'",
+        &mut conn,
+    )?
+    .into_iter()
+    .collect();
+
+    // Materialized views in dependency order: a view that reads another must be
+    // refreshed after it, or it re-derives from pre-scrub data.
+    let materialized_views = names(
+        "WITH RECURSIVE mv AS ( \
+             SELECT rel.oid FROM pg_class rel \
+             JOIN pg_namespace ns ON ns.oid = rel.relnamespace AND ns.nspname = 'public' \
+             WHERE rel.relkind = 'm' \
+         ), edge AS ( \
+             SELECT DISTINCT r.ev_class AS dependent, d.refobjid AS source \
+             FROM pg_depend d \
+             JOIN pg_rewrite r ON r.oid = d.objid \
+             WHERE d.classid = 'pg_rewrite'::regclass \
+               AND r.ev_class IN (SELECT oid FROM mv) \
+               AND d.refobjid IN (SELECT oid FROM mv) \
+               AND d.refobjid <> r.ev_class \
+         ), depth AS ( \
+             SELECT oid, 0 AS lvl FROM mv \
+             WHERE oid NOT IN (SELECT dependent FROM edge) \
+             UNION ALL \
+             SELECT e.dependent, d.lvl + 1 FROM edge e JOIN depth d ON d.oid = e.source \
+             WHERE d.lvl < 32 \
+         ) \
+         SELECT rel.relname AS name FROM (SELECT oid, max(lvl) AS lvl FROM depth GROUP BY oid) o \
+         JOIN pg_class rel ON rel.oid = o.oid ORDER BY o.lvl, rel.relname",
+        &mut conn,
+    )?;
+
+    // ── Framework-owned tables (read from pg_class, not information_schema,
+    //    which hides tables the connecting role has no privilege on) ─────────
     let wanted = probe_table_names(config)
         .iter()
         .map(|t| quote_literal(t))
         .collect::<Vec<_>>()
         .join(", ");
-    let rows: Vec<NameRow> = sql_query(format!(
-        "SELECT table_name AS name FROM information_schema.tables \
-         WHERE table_schema = 'public' AND table_type = 'BASE TABLE' \
-         AND table_name IN ({wanted}) ORDER BY table_name"
-    ))
-    .load(&mut conn)
-    .map_err(|e| ScrubError::Sql(e.to_string()))?;
-    Ok(rows.into_iter().map(|r| r.name).collect())
+    let framework_tables = names(
+        &format!(
+            "SELECT rel.relname AS name FROM pg_class rel \
+             JOIN pg_namespace ns ON ns.oid = rel.relnamespace AND ns.nspname = 'public' \
+             WHERE rel.relkind IN ('r', 'p') AND rel.relname IN ({wanted}) \
+             ORDER BY rel.relname"
+        ),
+        &mut conn,
+    )?;
+
+    Ok(DatabaseFacts {
+        foreign_key_columns,
+        checked_columns,
+        generated_columns,
+        unique_columns,
+        nulls_not_distinct_columns,
+        partitions,
+        rls_tables,
+        triggered_tables,
+        materialized_views,
+        other_schemas,
+        framework_tables,
+    })
 }
 
 /// The framework-owned table names worth probing for: the built-in payload
@@ -1634,13 +2475,6 @@ fn probe_table_names(config: &ScrubConfig) -> BTreeSet<String> {
         .map(|t| (*t).to_owned())
         .chain(config.framework.purge.iter().cloned())
         .collect()
-}
-
-/// A single `name` column produced by the framework-table probe.
-#[derive(diesel::QueryableByName)]
-struct NameRow {
-    #[diesel(sql_type = diesel::sql_types::Text)]
-    name: String,
 }
 
 /// Tell the operator about framework-owned payload tables the classification
@@ -1665,7 +2499,7 @@ fn report_framework_tables(present: &[String], config: &ScrubConfig) {
         return;
     }
     eprintln!(
-        "  \u{26A0} {} framework-owned table(s) are NOT scrubbed and may carry app-supplied \
+        "  \u{26A0}\u{FE0F}  {} framework-owned table(s) are NOT scrubbed and may carry app-supplied \
          payloads (queued jobs, offline-sync rows, experiment assignments):\n{}\n    \
          Add them to `[framework] purge = [...]` in {SCRUB_CONFIG_FILE} to empty them, or \
          empty them yourself.",
@@ -1686,6 +2520,119 @@ fn purge_statements(present: &[String], config: &ScrubConfig) -> Vec<(String, St
         .collect()
 }
 
+/// Resolve the target's attribute-encryption key ring from the project's
+/// credentials for `profile`.
+///
+/// Refused rather than skipped when the plan needs one: writing a plain string
+/// into an `#[encrypted]` column would make every later repository read of that
+/// row fail as malformed ciphertext, so a missing key is a hard stop, not a
+/// silent downgrade.
+fn resolve_key_ring(
+    profile: &str,
+    project_root: &Path,
+) -> Result<autumn_web::encryption::KeyRing, ScrubError> {
+    let store = autumn_web::credentials::load_credentials(profile, project_root).map_err(|e| {
+        ScrubError::EncryptionKeyUnavailable {
+            profile: profile.to_owned(),
+            detail: e.to_string(),
+        }
+    })?;
+    match autumn_web::encryption::key_ring_from_credentials(&store) {
+        Ok(Some(ring)) => Ok(ring),
+        Ok(None) => Err(ScrubError::EncryptionKeyUnavailable {
+            profile: profile.to_owned(),
+            detail: format!(
+                "`{}.primary_key` is not configured",
+                autumn_web::encryption::CREDENTIALS_NAMESPACE
+            ),
+        }),
+        Err(e) => Err(ScrubError::EncryptionKeyUnavailable {
+            profile: profile.to_owned(),
+            detail: e.to_string(),
+        }),
+    }
+}
+
+/// How many rows of encrypted replacements are shipped back per statement.
+const ENCRYPTED_BATCH_ROWS: usize = 500;
+
+/// One row's encrypted replacement.
+#[derive(diesel::QueryableByName)]
+struct RowTokenRow {
+    #[diesel(sql_type = diesel::sql_types::Text)]
+    row_key: String,
+    #[diesel(sql_type = diesel::sql_types::Text)]
+    token: String,
+}
+
+/// Rewrite one `#[encrypted]` column, row by row, with a valid AEAD envelope of
+/// a fake plaintext produced under the target's own key.
+///
+/// This is the one rewrite that cannot be a SQL expression: the envelope is
+/// `base64(header ‖ nonce ‖ ciphertext)` built by [`autumn_web::encryption`], so
+/// the rows are read, encrypted in Rust, and shipped back in batched
+/// `UPDATE … FROM (VALUES …)` statements. Rows whose value is already `NULL` are
+/// left alone, exactly as the SQL path's `CASE` does.
+fn rewrite_encrypted_column(
+    conn: &mut PgConnection,
+    table: &str,
+    row_key: &str,
+    rewrite: &EncryptedRewrite,
+) -> Result<usize, diesel::result::Error> {
+    use autumn_web::encryption::{Mode, encrypt_text};
+
+    let ident = quote_ident(&rewrite.column);
+    let rows: Vec<RowTokenRow> = sql_query(format!(
+        "SELECT ({row_key}) AS row_key, \
+         encode(sha256((({row_key}) || '|' || {})::bytea), 'hex') AS token \
+         FROM {} WHERE {ident} IS NOT NULL",
+        quote_literal(&rewrite.column),
+        qualified_ident(table),
+    ))
+    .load(conn)?;
+
+    let mode = if rewrite.deterministic {
+        Mode::Deterministic
+    } else {
+        Mode::Randomized
+    };
+    let mut updated = 0;
+    for chunk in rows.chunks(ENCRYPTED_BATCH_ROWS) {
+        let mut values = Vec::with_capacity(chunk.len());
+        for row in chunk {
+            let plaintext = match rewrite.shape {
+                Strategy::Email => format!("scrubbed+{}{SCRUB_EMAIL_DOMAIN}", row.token),
+                _ => format!("[scrubbed:{}]", row.token),
+            };
+            // A key ring is installed before the apply pass, so this can only
+            // fail on a genuinely broken key — surfaced as a SQL-shaped error so
+            // the transaction rolls back with everything else.
+            let envelope = encrypt_text(mode, &plaintext).map_err(|e| {
+                diesel::result::Error::QueryBuilderError(
+                    format!(
+                        "could not encrypt a replacement for {table}.{}: {e}",
+                        rewrite.column
+                    )
+                    .into(),
+                )
+            })?;
+            values.push(format!(
+                "({}, {})",
+                quote_literal(&row.row_key),
+                quote_literal(&envelope)
+            ));
+        }
+        updated += sql_query(format!(
+            "UPDATE {} AS t SET {ident} = v.val FROM (VALUES {}) AS v(k, val) \
+             WHERE ({row_key}) = v.k",
+            qualified_ident(table),
+            values.join(", ")
+        ))
+        .execute(conn)?;
+    }
+    Ok(updated)
+}
+
 /// Run every statement for one database inside a single transaction, so a
 /// failure can never leave a half-scrubbed database behind.
 fn execute(
@@ -1697,18 +2644,38 @@ fn execute(
     if plan.tables.is_empty() && purges.is_empty() {
         return Ok(Vec::new());
     }
-    let mut conn = PgConnection::establish(url).map_err(|_| ScrubError::Introspect {
-        label: label.to_owned(),
-        detail: format!(
-            "could not connect to database {:?} to apply the scrub",
-            parsed_db_name(url)
-        ),
-    })?;
+    let mut conn = probe_connection(url, label, "apply the scrub")?;
     let mut counts = Vec::with_capacity(plan.tables.len());
     conn.transaction::<_, diesel::result::Error, _>(|conn| {
+        // Pin the resolution of every unqualified name and the meaning of every
+        // string literal for the whole transaction, so a role- or
+        // database-level `search_path` (tenant schemas) cannot redirect a write
+        // to a table nothing classified, and `quote_literal`'s doubled quotes
+        // cannot be re-interpreted under `standard_conforming_strings = off`.
+        conn.batch_execute(
+            "SET LOCAL search_path = pg_catalog, public; \
+             SET LOCAL standard_conforming_strings = on",
+        )?;
+        // Hold the tables for the duration: the plan was built from a snapshot
+        // taken on another connection, and a row inserted between the two would
+        // otherwise survive the scrub unnoticed. SHARE ROW EXCLUSIVE blocks
+        // writers while still allowing plain reads.
         for table in &plan.tables {
-            let rows = sql_query(&table.sql).execute(conn)?;
-            counts.push((table.table.clone(), rows));
+            sql_query(format!(
+                "LOCK TABLE {} IN SHARE ROW EXCLUSIVE MODE",
+                qualified_ident(&table.table)
+            ))
+            .execute(conn)?;
+        }
+        for table in &plan.tables {
+            if let Some(sql) = &table.sql {
+                let rows = sql_query(sql).execute(conn)?;
+                counts.push((table.table.clone(), rows));
+            }
+            for rewrite in &table.encrypted {
+                let rows = rewrite_encrypted_column(conn, &table.table, &table.row_key, rewrite)?;
+                counts.push((format!("{}.{}", table.table, rewrite.column), rows));
+            }
         }
         for (table, statement) in purges {
             let rows = sql_query(statement).execute(conn)?;
@@ -1718,6 +2685,29 @@ fn execute(
     })
     .map_err(|e| ScrubError::Sql(e.to_string()))?;
     Ok(counts)
+}
+
+/// Refresh every materialized view, sources first.
+///
+/// A materialized view holds its own copy of whatever it selected, so scrubbing
+/// the base tables leaves it holding the original values — and `pg_restore`
+/// populates them from the still-real data it just restored. They are refreshed
+/// in dependency order so a view reading another view never re-derives from
+/// stale content.
+fn refresh_materialized_views(url: &str, label: &str, views: &[String]) -> Result<(), ScrubError> {
+    if views.is_empty() {
+        return Ok(());
+    }
+    let mut conn = probe_connection(url, label, "refresh its materialized views")?;
+    for view in views {
+        conn.batch_execute(&format!(
+            "REFRESH MATERIALIZED VIEW {}",
+            qualified_ident(view)
+        ))
+        .map_err(|e| ScrubError::Sql(format!("refreshing materialized view {view:?}: {e}")))?;
+        eprintln!("  \u{2713} refreshed materialized view {view}.");
+    }
+    Ok(())
 }
 
 #[cfg(test)]
@@ -1759,8 +2749,19 @@ mod tests {
         t
     }
 
-    fn empty_encrypted() -> BTreeMap<String, BTreeSet<String>> {
+    fn empty_encrypted() -> BTreeMap<String, BTreeMap<String, bool>> {
         BTreeMap::new()
+    }
+
+    /// `#[encrypted]` columns for one table, all randomized-mode.
+    fn encrypted_columns_of(
+        table: &str,
+        columns: &[&str],
+    ) -> BTreeMap<String, BTreeMap<String, bool>> {
+        BTreeMap::from([(
+            table.to_owned(),
+            columns.iter().map(|c| ((*c).to_owned(), false)).collect(),
+        )])
     }
 
     fn no_anonymize() -> BTreeSet<String> {
@@ -1770,15 +2771,43 @@ mod tests {
     fn plan_for(
         tables: &[Table],
         config: &ScrubConfig,
-        encrypted: &BTreeMap<String, BTreeSet<String>>,
+        encrypted: &BTreeMap<String, BTreeMap<String, bool>>,
         anonymize: &BTreeSet<String>,
+    ) -> Result<ScrubPlan, ScrubError> {
+        plan_with_facts(
+            tables,
+            config,
+            encrypted,
+            anonymize,
+            &DatabaseFacts::default(),
+        )
+    }
+
+    fn plan_with_facts(
+        tables: &[Table],
+        config: &ScrubConfig,
+        encrypted: &BTreeMap<String, BTreeMap<String, bool>>,
+        anonymize: &BTreeSet<String>,
+        facts: &DatabaseFacts,
     ) -> Result<ScrubPlan, ScrubError> {
         build_plan(&ClassificationInputs {
             tables,
             config,
             encrypted,
             anonymize_tables: anonymize,
+            facts,
         })
+    }
+
+    /// The single `UPDATE` a table plan carries (panics when it has none).
+    fn sql_of(plan: &ScrubPlan, table: &str) -> String {
+        plan.tables
+            .iter()
+            .find(|t| t.table == table)
+            .unwrap_or_else(|| panic!("no plan for {table}"))
+            .sql
+            .clone()
+            .unwrap_or_else(|| panic!("{table} has no SQL statement"))
     }
 
     // ── Config parsing ──────────────────────────────────────────────────────
@@ -1990,8 +3019,7 @@ mod tests {
             "#,
         )
         .unwrap();
-        let mut encrypted = BTreeMap::new();
-        encrypted.insert("users".to_owned(), BTreeSet::from(["email".to_owned()]));
+        let encrypted = encrypted_columns_of("users", &["email"]);
 
         let plan = plan_for(&[users_table()], &config, &encrypted, &no_anonymize())
             .expect("an #[encrypted] column needs no declaration");
@@ -2012,8 +3040,7 @@ mod tests {
             "#,
         )
         .unwrap();
-        let mut encrypted = BTreeMap::new();
-        encrypted.insert("users".to_owned(), BTreeSet::from(["email".to_owned()]));
+        let encrypted = encrypted_columns_of("users", &["email"]);
 
         let err = plan_for(&[users_table()], &config, &encrypted, &no_anonymize())
             .expect_err("marking an #[encrypted] column safe must be refused");
@@ -2027,8 +3054,8 @@ mod tests {
     fn gdpr_anonymize_table_classifies_its_columns_as_pii() {
         let config = parse_config_str(
             r#"
-            [defaults]
-            safe_columns = ["id", "created_at"]
+            [tables.users]
+            safe = ["id", "created_at"]
             "#,
         )
         .unwrap();
@@ -2042,9 +3069,320 @@ mod tests {
                 .unwrap_or_else(|| panic!("{column} must be scrubbed"));
             assert_eq!(decision.source, ClassSource::GdprAnonymize);
         }
-        // `id`/`created_at` were explicitly declared safe, so they are untouched.
+        // `id`/`created_at` were explicitly declared safe FOR THIS TABLE, so
+        // they are untouched.
         assert!(plan.column("users", "id").is_none());
         assert!(plan.column("users", "created_at").is_none());
+    }
+
+    #[test]
+    fn the_global_safe_list_may_not_narrow_a_gdpr_anonymize_table() {
+        let config = parse_config_str(
+            r#"
+            [defaults]
+            safe_columns = ["id", "created_at", "full_name"]
+            "#,
+        )
+        .unwrap();
+        let anonymize = BTreeSet::from(["users".to_owned()]);
+        let plan = plan_for(&[users_table()], &config, &empty_encrypted(), &anonymize).unwrap();
+        // A cross-table convenience list is not a per-column review, so it must
+        // not silently exempt a column from a table the app registered for
+        // anonymization.
+        assert!(
+            plan.column("users", "full_name").is_some(),
+            "a global safe_columns entry must not narrow an anonymize registration"
+        );
+        // Structural columns are still skipped: the registration says nothing
+        // about them and rewriting one would break referential integrity.
+        assert!(plan.column("users", "id").is_none());
+    }
+
+    #[test]
+    fn a_check_constrained_column_is_refused_rather_than_guessed_at() {
+        // A real Autumn closed-set column reaches the database as plain TEXT
+        // plus a CHECK, so the model-IR-only `ColumnType::Enum` never fires
+        // against a live schema — this is what actually catches it.
+        let facts = DatabaseFacts {
+            checked_columns: BTreeSet::from([("users".to_owned(), "bio".to_owned())]),
+            ..DatabaseFacts::default()
+        };
+        let config = parse_config_str(
+            r#"
+            [defaults]
+            safe_columns = ["id", "created_at", "email", "full_name"]
+            [tables.users.pii]
+            bio = "redact"
+            "#,
+        )
+        .unwrap();
+        let err = plan_with_facts(
+            &[users_table()],
+            &config,
+            &empty_encrypted(),
+            &no_anonymize(),
+            &facts,
+        )
+        .expect_err("no fabricated value can be proven to satisfy an arbitrary CHECK");
+        assert!(
+            matches!(err, ScrubError::CheckConstrainedColumn { ref column } if column == "users.bio"),
+            "got {err:?}"
+        );
+    }
+
+    #[test]
+    fn the_referenced_side_of_a_foreign_key_is_refused() {
+        // `orders.user_email REFERENCES users(email)` leaves `users.email` with
+        // no `references` of its own, so only the probed catalog set can see it.
+        let facts = DatabaseFacts {
+            foreign_key_columns: BTreeSet::from([("users".to_owned(), "email".to_owned())]),
+            ..DatabaseFacts::default()
+        };
+        let config = parse_config_str(
+            r#"
+            [defaults]
+            safe_columns = ["id", "created_at", "full_name", "bio"]
+            [tables.users.pii]
+            email = "email"
+            "#,
+        )
+        .unwrap();
+        let err = plan_with_facts(
+            &[users_table()],
+            &config,
+            &empty_encrypted(),
+            &no_anonymize(),
+            &facts,
+        )
+        .expect_err("rewriting a referenced natural key breaks its children");
+        assert!(
+            matches!(err, ScrubError::PiiOnKeyColumn { ref columns } if columns == &vec!["users.email".to_owned()]),
+            "got {err:?}"
+        );
+    }
+
+    #[test]
+    fn a_generated_column_is_never_rewritten() {
+        // Postgres refuses `UPDATE` on a generated column outright, and it is
+        // derived data that a scrub of its source columns already covers.
+        let facts = DatabaseFacts {
+            generated_columns: BTreeSet::from([("users".to_owned(), "full_name".to_owned())]),
+            ..DatabaseFacts::default()
+        };
+        let config = parse_config_str(
+            r#"
+            [defaults]
+            safe_columns = ["id", "created_at", "email", "bio"]
+            "#,
+        )
+        .unwrap();
+        let plan = plan_with_facts(
+            &[users_table()],
+            &config,
+            &empty_encrypted(),
+            &no_anonymize(),
+            &facts,
+        )
+        .expect("a generated column needs no declaration");
+        assert!(plan.column("users", "full_name").is_none());
+    }
+
+    #[test]
+    fn a_partition_is_scrubbed_through_its_parent_not_twice() {
+        let mut partition = users_table();
+        partition.name = "users_2026_01".to_owned();
+        let facts = DatabaseFacts {
+            partitions: BTreeSet::from(["users_2026_01".to_owned()]),
+            ..DatabaseFacts::default()
+        };
+        let config = parse_config_str(
+            r#"
+            [defaults]
+            safe_columns = ["id", "created_at"]
+            [tables.users.pii]
+            email = "email"
+            full_name = "name"
+            bio = "redact"
+            "#,
+        )
+        .unwrap();
+        let plan = plan_with_facts(
+            &[users_table(), partition],
+            &config,
+            &empty_encrypted(),
+            &no_anonymize(),
+            &facts,
+        )
+        .expect("a partition needs no declaration of its own");
+        assert_eq!(
+            plan.tables.len(),
+            1,
+            "the parent UPDATE already covers the partition's rows"
+        );
+        assert_eq!(plan.tables[0].table, "users");
+    }
+
+    #[test]
+    fn null_is_refused_on_a_nulls_not_distinct_unique_column() {
+        let mut t = users_table();
+        t.columns[3].unique = true; // `bio`, nullable
+        let facts = DatabaseFacts {
+            nulls_not_distinct_columns: BTreeSet::from([("users".to_owned(), "bio".to_owned())]),
+            ..DatabaseFacts::default()
+        };
+        let config = parse_config_str(
+            r#"
+            [defaults]
+            safe_columns = ["id", "created_at", "email", "full_name"]
+            [tables.users.pii]
+            bio = "null"
+            "#,
+        )
+        .unwrap();
+        // `null` is normally unique-safe (Postgres allows many NULLs in a
+        // unique index) — but not under NULLS NOT DISTINCT.
+        let err = plan_with_facts(&[t], &config, &empty_encrypted(), &no_anonymize(), &facts)
+            .expect_err("a second NULL is a violation under NULLS NOT DISTINCT");
+        assert!(
+            matches!(err, ScrubError::NonUniqueStrategy { .. }),
+            "{err:?}"
+        );
+    }
+
+    #[test]
+    fn a_unique_column_gets_a_wider_token_and_a_higher_floor() {
+        let table = users_table();
+        assert!(
+            token_expr(&table, "email", true).contains("sha256"),
+            "a unique column needs more entropy than md5's 32 hex characters"
+        );
+        assert!(token_expr(&table, "bio", false).contains("md5("));
+
+        // 19 chars with `redact`'s 11 of affixes leaves 8 — fine for a
+        // non-unique column, a collision generator for a unique one (32 bits
+        // collides in practice around 10^5 rows).
+        let narrow = Column::new(
+            "code",
+            ColumnType::Opaque {
+                pg_type: "varchar(19)".to_owned(),
+            },
+        );
+        assert!(replacement_expr(Strategy::Redact, &narrow, "TOK", false).is_ok());
+        assert!(matches!(
+            replacement_expr(Strategy::Redact, &narrow, "TOK", true),
+            Err(ScrubError::ColumnTooNarrow { .. })
+        ));
+    }
+
+    #[test]
+    fn a_text_strategy_is_refused_on_a_non_character_column() {
+        for (name, ty) in [
+            ("age", ColumnType::Int32),
+            ("seen_at", ColumnType::TimestampTz),
+            (
+                "ip",
+                ColumnType::Opaque {
+                    pg_type: "inet".to_owned(),
+                },
+            ),
+        ] {
+            let column = Column::new(name, ty);
+            for strategy in [
+                Strategy::Email,
+                Strategy::Name,
+                Strategy::Redact,
+                Strategy::Phone,
+            ] {
+                assert!(
+                    matches!(
+                        replacement_expr(strategy, &column, "TOK", false),
+                        Err(ScrubError::StrategyTypeMismatch { .. })
+                    ),
+                    "{strategy:?} on {name} must be refused at plan time, not at apply time"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn the_null_assignment_carries_no_untyped_case() {
+        // A `CASE` whose arms are both bare NULL has no type to infer from, so
+        // Postgres resolves it to `text` and the assignment fails on every
+        // non-character column.
+        let mut column = Column::new("token", ColumnType::Uuid);
+        column.nullable = true;
+        assert_eq!(
+            assignment(&column, "NULL", Strategy::Null),
+            r#""token" = NULL"#
+        );
+        assert!(
+            assignment(&column, "X", Strategy::Uuid).contains("CASE WHEN"),
+            "every other strategy still preserves NULLs"
+        );
+    }
+
+    #[test]
+    fn auto_strategy_covers_the_everyday_opaque_pii_types() {
+        for (pg_type, expected) in [
+            ("date", Strategy::Epoch),
+            ("time", Strategy::Epoch),
+            ("int2", Strategy::Zero),
+            ("numeric(12,2)", Strategy::Zero),
+        ] {
+            let column = Column::new(
+                "value",
+                ColumnType::Opaque {
+                    pg_type: pg_type.to_owned(),
+                },
+            );
+            assert_eq!(
+                auto_strategy(&column).unwrap(),
+                expected,
+                "`{pg_type}` is an everyday PII column type and needs a usable strategy"
+            );
+            assert!(replacement_expr(expected, &column, "TOK", false).is_ok());
+        }
+    }
+
+    #[test]
+    fn purge_never_accepts_schema_bookkeeping() {
+        for table in NEVER_PURGEABLE_TABLES {
+            let config =
+                parse_config_str(&format!("[framework]\npurge = [\"{table}\"]\n")).unwrap();
+            assert!(
+                matches!(
+                    check_purge_list(&config),
+                    Err(ScrubError::PurgeSchemaBookkeeping { .. })
+                ),
+                "emptying {table} would make the copy un-migratable or un-routable"
+            );
+        }
+    }
+
+    #[test]
+    fn declaring_a_framework_table_points_at_the_right_mechanism() {
+        let config = parse_config_str(
+            r#"
+            [defaults]
+            safe_columns = ["id", "created_at", "email", "full_name", "bio"]
+            [tables.api_tokens.pii]
+            token = "redact"
+            "#,
+        )
+        .unwrap();
+        let err = plan_for(
+            &[users_table()],
+            &config,
+            &empty_encrypted(),
+            &no_anonymize(),
+        )
+        .expect_err("a framework table cannot be declared column-by-column");
+        // Not "the database does not have it" — that would send the developer
+        // hunting for a typo in a name that is spelled correctly.
+        assert!(
+            matches!(err, ScrubError::FrameworkTableDeclared { ref tables } if tables == &vec!["api_tokens".to_owned()]),
+            "got {err:?}"
+        );
     }
 
     #[test]
@@ -2069,21 +3407,112 @@ mod tests {
         let config = parse_config_str(
             r#"
             [defaults]
+            safe_columns = ["id", "created_at", "email", "bio"]
+            [tables.users.pii]
+            full_name = "redact"
+            "#,
+        )
+        .unwrap();
+        let plan = plan_for(
+            &[users_table()],
+            &config,
+            &empty_encrypted(),
+            &no_anonymize(),
+        )
+        .unwrap();
+        let column = plan.column("users", "full_name").unwrap();
+        assert_eq!(column.strategy, Strategy::Redact);
+        assert_eq!(column.source, ClassSource::Config);
+    }
+
+    #[test]
+    fn a_plaintext_strategy_is_refused_on_an_encrypted_column() {
+        let config = parse_config_str(
+            r#"
+            [defaults]
             safe_columns = ["id", "created_at", "full_name", "bio"]
             [tables.users.pii]
             email = "redact"
             "#,
         )
         .unwrap();
-        let mut encrypted = BTreeMap::new();
-        encrypted.insert("users".to_owned(), BTreeSet::from(["email".to_owned()]));
-        let plan = plan_for(&[users_table()], &config, &encrypted, &no_anonymize()).unwrap();
-        let column = plan.column("users", "email").unwrap();
-        assert_eq!(column.strategy, Strategy::Redact);
-        assert_eq!(column.source, ClassSource::Config);
+        // Writing a plain string into an at-rest-encrypted column makes every
+        // later read of that row fail as malformed ciphertext, so a declaration
+        // may not choose one.
+        let err = plan_for(
+            &[users_table()],
+            &config,
+            &encrypted_columns_of("users", &["email"]),
+            &no_anonymize(),
+        )
+        .expect_err("plaintext must never be written into an #[encrypted] column");
+        assert!(
+            matches!(err, ScrubError::PlaintextIntoEncrypted { ref columns } if columns[0].starts_with("users.email")),
+            "got {err:?}"
+        );
     }
 
-    // ── Constraint safety (AC #4) ───────────────────────────────────────────
+    #[test]
+    fn an_encrypted_column_resolves_to_a_re_encryption_and_carries_its_mode() {
+        let config = parse_config_str(
+            r#"
+            [defaults]
+            safe_columns = ["id", "created_at", "full_name", "bio"]
+            "#,
+        )
+        .unwrap();
+        let encrypted = BTreeMap::from([(
+            "users".to_owned(),
+            BTreeMap::from([("email".to_owned(), true)]),
+        )]);
+        let plan = plan_for(&[users_table()], &config, &encrypted, &no_anonymize()).unwrap();
+        assert_eq!(
+            plan.column("users", "email").unwrap().strategy,
+            Strategy::Encrypted
+        );
+        let table = &plan.tables[0];
+        assert!(
+            table.sql.is_none(),
+            "an encrypted rewrite is not expressible as SQL: {:?}",
+            table.sql
+        );
+        assert_eq!(table.encrypted.len(), 1);
+        assert!(
+            table.encrypted[0].deterministic,
+            "a deterministic column must be re-encrypted deterministically, or equality \
+             lookups against it stop matching"
+        );
+        assert_eq!(table.encrypted[0].shape, Strategy::Email);
+    }
+
+    #[test]
+    fn null_may_still_be_declared_on_a_nullable_encrypted_column() {
+        let mut t = users_table();
+        t.columns[1].nullable = true;
+        t.columns[1].unique = false;
+        let config = parse_config_str(
+            r#"
+            [defaults]
+            safe_columns = ["id", "created_at", "full_name", "bio"]
+            [tables.users.pii]
+            email = "null"
+            "#,
+        )
+        .unwrap();
+        let plan = plan_for(
+            &[t],
+            &config,
+            &encrypted_columns_of("users", &["email"]),
+            &no_anonymize(),
+        )
+        .expect("NULL is a valid, readable value for an encrypted column");
+        assert_eq!(
+            plan.column("users", "email").unwrap().strategy,
+            Strategy::Null
+        );
+    }
+
+    // ── Constraint safety (AC #4)     // ── Constraint safety (AC #4) ───────────────────────────────────────────
 
     #[test]
     fn pii_on_a_primary_key_is_refused() {
@@ -2246,25 +3675,25 @@ mod tests {
         let mut team_id = Column::new("team_id", ColumnType::Int64);
         team_id.primary_key = true;
         t.columns = vec![user_id, team_id];
-        assert_eq!(
-            row_key_expr(&t),
-            r#"coalesce("user_id"::text, '') || '|' || coalesce("team_id"::text, '')"#
-        );
+        // `ROW(...)::text` carries Postgres's own quoting, so ('a|','b') and
+        // ('a','|b') cannot collapse into one row key the way a plain
+        // separator-joined concatenation does.
+        assert_eq!(row_key_expr(&t), r#"ROW("user_id", "team_id")::text"#);
     }
 
     #[test]
     fn token_is_salted_per_column_so_two_columns_never_match() {
         let table = users_table();
         assert_ne!(
-            token_expr(&table, "email"),
-            token_expr(&table, "full_name"),
+            token_expr(&table, "email", false),
+            token_expr(&table, "full_name", false),
             "two PII columns of one row must not receive the same fake value"
         );
     }
 
     #[test]
     fn email_expression_is_unique_per_row_and_uses_a_reserved_domain() {
-        let expr = replacement_expr(Strategy::Email, &text_col("email"), "TOK").unwrap();
+        let expr = replacement_expr(Strategy::Email, &text_col("email"), "TOK", false).unwrap();
         assert!(expr.contains("TOK"), "must vary per row: {expr}");
         assert!(
             expr.contains("@example.invalid"),
@@ -2280,7 +3709,7 @@ mod tests {
                 pg_type: "varchar(40)".to_owned(),
             },
         );
-        let expr = replacement_expr(Strategy::Email, &column, "TOK").unwrap();
+        let expr = replacement_expr(Strategy::Email, &column, "TOK", false).unwrap();
         // `scrubbed+` (9) + token + `@example.invalid` (16) must fit in 40.
         assert!(
             expr.contains("substr(TOK, 1, 15)"),
@@ -2296,7 +3725,7 @@ mod tests {
                 pg_type: "varchar(28)".to_owned(),
             },
         );
-        let err = replacement_expr(Strategy::Email, &column, "TOK")
+        let err = replacement_expr(Strategy::Email, &column, "TOK", false)
             .expect_err("a column too narrow for a unique fake must be refused");
         assert!(matches!(err, ScrubError::ColumnTooNarrow { .. }), "{err:?}");
     }
@@ -2399,8 +3828,8 @@ mod tests {
         )
         .unwrap();
         assert_eq!(plan.tables.len(), 1, "one statement per table");
-        let sql = &plan.tables[0].sql;
-        assert!(sql.starts_with(r#"UPDATE "users" SET "#), "{sql}");
+        let sql = sql_of(&plan, "users");
+        assert!(sql.starts_with(r#"UPDATE "public"."users" SET "#), "{sql}");
         assert!(
             sql.contains(r#""bio" = CASE WHEN "bio" IS NULL THEN NULL ELSE"#),
             "a nullable column must keep its NULLs: {sql}"
@@ -2446,12 +3875,10 @@ mod tests {
             },
         );
         let plan = plan_for(&[t], &config, &empty_encrypted(), &no_anonymize()).unwrap();
+        let sql = sql_of(&plan, r#"we"ird"#);
         assert!(
-            plan.tables[0]
-                .sql
-                .starts_with(r#"UPDATE "we""ird" SET "na""me" = "#),
-            "{}",
-            plan.tables[0].sql
+            sql.starts_with(r#"UPDATE "public"."we""ird" SET "na""me" = "#),
+            "{sql}"
         );
     }
 
@@ -2603,7 +4030,7 @@ mod tests {
 
     #[test]
     fn a_strategy_that_cannot_produce_the_column_type_is_refused() {
-        let err = replacement_expr(Strategy::Uuid, &text_col("note"), "TOK")
+        let err = replacement_expr(Strategy::Uuid, &text_col("note"), "TOK", false)
             .expect_err("a uuid cannot be written into a text column");
         assert!(
             matches!(err, ScrubError::StrategyTypeMismatch { .. }),
@@ -2611,14 +4038,19 @@ mod tests {
         );
         assert!(
             matches!(
-                replacement_expr(Strategy::Zero, &text_col("note"), "TOK"),
+                replacement_expr(Strategy::Zero, &text_col("note"), "TOK", false),
                 Err(ScrubError::StrategyTypeMismatch { .. })
             ),
             "zero is meaningless for a text column"
         );
         assert!(
             matches!(
-                replacement_expr(Strategy::Epoch, &Column::new("n", ColumnType::Int64), "TOK"),
+                replacement_expr(
+                    Strategy::Epoch,
+                    &Column::new("n", ColumnType::Int64),
+                    "TOK",
+                    false
+                ),
                 Err(ScrubError::StrategyTypeMismatch { .. })
             ),
             "epoch is meaningless for an integer column"
@@ -2628,35 +4060,54 @@ mod tests {
     #[test]
     fn typed_strategies_render_their_casts() {
         assert_eq!(
-            replacement_expr(Strategy::Uuid, &Column::new("t", ColumnType::Uuid), "TOK").unwrap(),
+            replacement_expr(
+                Strategy::Uuid,
+                &Column::new("t", ColumnType::Uuid),
+                "TOK",
+                false
+            )
+            .unwrap(),
             "(TOK)::uuid"
         );
         assert_eq!(
-            replacement_expr(Strategy::Bytes, &Column::new("b", ColumnType::Bytes), "TOK").unwrap(),
+            replacement_expr(
+                Strategy::Bytes,
+                &Column::new("b", ColumnType::Bytes),
+                "TOK",
+                false
+            )
+            .unwrap(),
             "decode(TOK, 'hex')"
         );
         assert_eq!(
-            replacement_expr(Strategy::Zero, &Column::new("ok", ColumnType::Bool), "TOK").unwrap(),
+            replacement_expr(
+                Strategy::Zero,
+                &Column::new("ok", ColumnType::Bool),
+                "TOK",
+                false
+            )
+            .unwrap(),
             "false"
         );
         assert_eq!(
             replacement_expr(
                 Strategy::Epoch,
                 &Column::new("at", ColumnType::TimestampTz),
-                "TOK"
+                "TOK",
+                false
             )
             .unwrap(),
             "'1970-01-01 00:00:00+00'::timestamptz"
         );
         assert_eq!(
-            replacement_expr(Strategy::Null, &text_col("bio"), "TOK").unwrap(),
+            replacement_expr(Strategy::Null, &text_col("bio"), "TOK", false).unwrap(),
             "NULL"
         );
     }
 
     #[test]
     fn phone_produces_digits_and_refuses_a_column_that_cannot_hold_them() {
-        let expr = replacement_expr(Strategy::Phone, &text_col("phone"), "TOK").unwrap();
+        let expr = replacement_expr(Strategy::Phone, &text_col("phone"), "TOK", false).unwrap();
         assert!(
             expr.contains("translate("),
             "must map hex onto digits: {expr}"
@@ -2670,13 +4121,13 @@ mod tests {
             },
         );
         assert!(matches!(
-            replacement_expr(Strategy::Phone, &narrow, "TOK"),
+            replacement_expr(Strategy::Phone, &narrow, "TOK", false),
             Err(ScrubError::ColumnTooNarrow { .. })
         ));
     }
 
     #[test]
-    fn a_partial_unique_index_does_not_constrain_the_whole_column() {
+    fn a_partial_unique_index_still_constrains_the_rows_it_covers() {
         let mut t = users_table();
         t.columns[1].unique = false;
         let mut index = Index::new("idx_users_email", vec!["email".to_owned()], true);
@@ -2691,11 +4142,48 @@ mod tests {
             "#,
         )
         .unwrap();
-        // A partial unique index only constrains the rows matching its
-        // predicate, so it must not be treated as table-wide uniqueness.
-        let plan = plan_for(&[t], &config, &empty_encrypted(), &no_anonymize())
-            .expect("a partial unique index is not table-wide uniqueness");
-        assert!(plan.column("users", "email").is_some());
+        // A partial unique index does not satisfy a model `#[unique]` — but it
+        // absolutely does abort an UPDATE that writes one constant into every
+        // row its predicate matches, which is the only question a writer asks.
+        let err = plan_for(&[t], &config, &empty_encrypted(), &no_anonymize())
+            .expect_err("a partial unique index still constrains the rows it covers");
+        assert!(
+            matches!(err, ScrubError::NonUniqueStrategy { .. }),
+            "{err:?}"
+        );
+    }
+
+    #[test]
+    fn a_composite_unique_index_constrains_each_of_its_members() {
+        let mut t = Table::new("cards", Backend::Postgres);
+        t.primary_key = vec!["id".to_owned()];
+        t.columns = vec![
+            pk_col("id"),
+            Column::new("user_id", ColumnType::Int64),
+            Column::new("last4", ColumnType::Int32),
+        ];
+        let mut config = ScrubConfig::default();
+        config.defaults.safe_columns = vec!["id".to_owned(), "user_id".to_owned()];
+        config.tables.insert(
+            "cards".to_owned(),
+            TableRule {
+                safe: Vec::new(),
+                pii: BTreeMap::from([("last4".to_owned(), Strategy::Zero)]),
+            },
+        );
+        let facts = DatabaseFacts {
+            unique_columns: BTreeSet::from([
+                ("cards".to_owned(), "user_id".to_owned()),
+                ("cards".to_owned(), "last4".to_owned()),
+            ]),
+            ..DatabaseFacts::default()
+        };
+        let err = plan_with_facts(&[t], &config, &empty_encrypted(), &no_anonymize(), &facts)
+            .expect_err("a constant in one member of a composite unique key collides");
+        assert!(
+            matches!(err, ScrubError::NonUniqueStrategy { .. }),
+            "{err:?}"
+        );
     }
 
     #[test]

--- a/autumn-cli/src/db/scrub.rs
+++ b/autumn-cli/src/db/scrub.rs
@@ -2612,10 +2612,15 @@ fn probe_database_facts(
     //   COVERS — pulling previously-excluded duplicates into it.
     //
     // `pg_depend` records both the expression- and the predicate-referenced
-    // columns, so one query covers them. Marking them unique-constrained is the
-    // fail-closed side of the trade: only the developer knows whether a given
-    // replacement keeps the expression's output (or the predicate's membership)
-    // distinct.
+    // columns, so one query covers them.
+    //
+    // NOTE: adding them here is only a PARTIAL guard, and deliberately recorded
+    // as such. `Strategy::allowed_on_unique` permits `email`/`name`/`redact` on
+    // a unique column because those are injective on the column's own value —
+    // but injectivity does not survive an arbitrary expression. Every scrubbed
+    // address starts `scrubbed+`, so `UNIQUE (left(email, 1))` still collides at
+    // execution time. A correct guard needs its own refusal for expression
+    // operands rather than folding them into the unique set; tracked in #2366.
     unique_columns.extend(pair_set(
         sql_query(
             "SELECT rel.relname AS tbl, att.attname AS col \

--- a/autumn-cli/src/db/scrub.rs
+++ b/autumn-cli/src/db/scrub.rs
@@ -215,6 +215,12 @@ pub enum ScrubError {
         /// A credential-safe reason.
         detail: String,
     },
+    /// `public` holds base tables the connecting role cannot see, so they never
+    /// reached the classifier.
+    InaccessibleTables {
+        /// The table names, sorted.
+        tables: Vec<String>,
+    },
     /// The target has base tables outside `public`, which the classification
     /// universe does not cover.
     UnsupportedSchemas {
@@ -407,6 +413,16 @@ impl std::fmt::Display for ScrubError {
                  plaintext replacement would make every later read of that row fail. Provide the \
                  target's `active_record_encryption` credentials (`autumn credentials edit`), or \
                  declare those columns `null` in {SCRUB_CONFIG_FILE} if they are nullable."
+            ),
+            Self::InaccessibleTables { tables } => write!(
+                f,
+                "{} table(s) exist in `public` but could not be read by the connecting \
+                 role:\n{}\n  \
+                 They never reached the classifier, so the scrub cannot claim they carry no \
+                 PII — and it will not rewrite them either. Connect as a role that can see \
+                 every table (the owner, or one with the needed privileges).",
+                tables.len(),
+                bullet_list(tables),
             ),
             Self::UnsupportedSchemas { schemas } => write!(
                 f,
@@ -660,6 +676,8 @@ const FRAMEWORK_PAYLOAD_TABLES: &[&str] = &[
     // is a live credential leak, not merely a PII one.
     "api_tokens",
     "autumn_experiment_assignments",
+    // `actor_allowlist` names the individual users a flag is switched on for.
+    "autumn_feature_flags",
     "autumn_job_tracking",
     "autumn_jobs",
     // The indexed text of app records — the search index is a second copy of
@@ -668,6 +686,8 @@ const FRAMEWORK_PAYLOAD_TABLES: &[&str] = &[
     "autumn_sync_applied",
     "autumn_sync_pending",
     "autumn_sync_rows",
+    // `actor` records who made each flag change.
+    "feature_flag_changes",
 ];
 
 /// Framework-owned tables whose names do not carry the `autumn_` / `_autumn`
@@ -1227,6 +1247,20 @@ fn check_safe_overrides_encrypted(
     Err(ScrubError::SafeOverridesEncrypted { columns })
 }
 
+/// Base tables the catalog reports in `public` that introspection did not return
+/// and that are not framework-owned — i.e. ones the connecting role cannot see.
+fn unreachable_tables(facts: &DatabaseFacts, introspected: &[Table]) -> Vec<String> {
+    let seen: BTreeSet<&str> = introspected.iter().map(|t| t.name.as_str()).collect();
+    let mut missing: Vec<String> = facts
+        .public_base_tables
+        .iter()
+        .filter(|t| !seen.contains(t.as_str()) && !is_framework_table(t))
+        .cloned()
+        .collect();
+    missing.sort();
+    missing
+}
+
 /// Whether a column is structural — a primary key, either side of any foreign
 /// key, or a generated column Postgres will not let an `UPDATE` touch.
 ///
@@ -1489,7 +1523,11 @@ fn replacement_expr(
         Strategy::Null => "NULL".to_owned(),
         Strategy::Uuid => {
             require_type(column, strategy, matches!(column.ty, ColumnType::Uuid))?;
-            format!("({token})::uuid")
+            // A UUID is exactly 128 bits, and Postgres rejects any other width —
+            // so the wider token a unique column gets must be trimmed to its
+            // first 32 hex characters. That is the full entropy a UUID can hold,
+            // so nothing is lost.
+            format!("(substr({token}, 1, 32))::uuid")
         }
         Strategy::Bytes => {
             require_type(column, strategy, matches!(column.ty, ColumnType::Bytes))?;
@@ -2068,6 +2106,15 @@ fn classify_and_apply(
             label: label.clone(),
             detail: e.to_string(),
         })?;
+
+        // A table the connecting role cannot see is absent from the classified
+        // universe, and "not classified" must never read as "clean".
+        let unreachable = unreachable_tables(&facts, &tables);
+        if !unreachable.is_empty() {
+            return Err(ScrubError::InaccessibleTables {
+                tables: unreachable,
+            });
+        }
         let plan = build_plan(&ClassificationInputs {
             tables: &tables,
             config: &sources.config,
@@ -2271,6 +2318,14 @@ pub struct DatabaseFacts {
     pub other_schemas: BTreeSet<String>,
     /// Framework-owned tables present that the classification never sees.
     pub framework_tables: Vec<String>,
+    /// Every base table in `public`, read from `pg_class`.
+    ///
+    /// Introspection enumerates through `information_schema.tables`, which shows
+    /// only what the connecting role has some privilege on — so a table the
+    /// scrub role cannot see would silently drop out of the classified universe
+    /// and be reported clean. `pg_class` shows them all, and the difference is
+    /// a refusal.
+    pub public_base_tables: BTreeSet<String>,
 }
 
 /// A single `name` column.
@@ -2509,6 +2564,15 @@ fn probe_database_facts(
         &mut conn,
     )?;
 
+    let public_base_tables = names(
+        "SELECT rel.relname AS name FROM pg_class rel \
+         JOIN pg_namespace ns ON ns.oid = rel.relnamespace AND ns.nspname = 'public' \
+         WHERE rel.relkind IN ('r', 'p')",
+        &mut conn,
+    )?
+    .into_iter()
+    .collect();
+
     Ok(DatabaseFacts {
         foreign_key_columns,
         checked_columns,
@@ -2521,6 +2585,7 @@ fn probe_database_facts(
         materialized_views,
         other_schemas,
         framework_tables,
+        public_base_tables,
     })
 }
 
@@ -3150,6 +3215,55 @@ mod tests {
         // Structural columns are still skipped: the registration says nothing
         // about them and rewriting one would break referential integrity.
         assert!(plan.column("users", "id").is_none());
+    }
+
+    #[test]
+    fn a_table_the_role_cannot_see_is_a_refusal_not_a_clean_report() {
+        // `information_schema.tables` shows only what the connecting role has
+        // privileges on, so a hidden table drops out of the classified universe
+        // entirely — and "not classified" must never read as "clean".
+        let facts = DatabaseFacts {
+            public_base_tables: BTreeSet::from([
+                "users".to_owned(),
+                "secrets".to_owned(),
+                // Framework-owned tables are excluded on purpose, not hidden.
+                "autumn_jobs".to_owned(),
+            ]),
+            ..DatabaseFacts::default()
+        };
+        assert_eq!(
+            unreachable_tables(&facts, &[users_table()]),
+            vec!["secrets".to_owned()]
+        );
+        // Nothing hidden: no refusal.
+        let visible = DatabaseFacts {
+            public_base_tables: BTreeSet::from(["users".to_owned()]),
+            ..DatabaseFacts::default()
+        };
+        assert!(unreachable_tables(&visible, &[users_table()]).is_empty());
+    }
+
+    #[test]
+    fn a_unique_uuid_column_still_gets_a_castable_32_hex_value() {
+        // A UUID is exactly 128 bits; Postgres rejects any other width, so the
+        // wider token a unique column gets has to be trimmed.
+        let column = Column::new("token", ColumnType::Uuid);
+        let expr = replacement_expr(Strategy::Uuid, &column, "TOK", true).unwrap();
+        assert_eq!(expr, "(substr(TOK, 1, 32))::uuid");
+    }
+
+    #[test]
+    fn the_feature_flag_identity_tables_are_payload_carriers() {
+        // `feature_flag_changes.actor` and `autumn_feature_flags.actor_allowlist`
+        // both name individual users, and both are outside the classified
+        // universe.
+        for table in ["feature_flag_changes", "autumn_feature_flags"] {
+            assert!(
+                FRAMEWORK_PAYLOAD_TABLES.contains(&table),
+                "{table} carries actor identities the classification never sees"
+            );
+            assert!(is_framework_table(table));
+        }
     }
 
     #[test]
@@ -4167,7 +4281,7 @@ mod tests {
                 false
             )
             .unwrap(),
-            "(TOK)::uuid"
+            "(substr(TOK, 1, 32))::uuid"
         );
         assert_eq!(
             replacement_expr(

--- a/autumn-cli/src/db/scrub.rs
+++ b/autumn-cli/src/db/scrub.rs
@@ -2325,15 +2325,19 @@ fn probe_database_facts(
     // ANY unique index counts (composite and partial included): the IR's
     // single-column `unique` flag answers a migration-diff question, not
     // "can this rewrite collide".
+    // `pg_index.indkey` is an `int2vector`, not a real array, so it is matched
+    // with `= ANY(...)` rather than `unnest`. The `[0:indnkeyatts-1]` slice is
+    // the KEY columns only — a covering index's `INCLUDE` columns carry no
+    // uniqueness and must not be treated as constrained.
     let unique_columns = pair_set(
         sql_query(
             "SELECT rel.relname AS tbl, att.attname AS col \
              FROM pg_index i \
              JOIN pg_class rel ON rel.oid = i.indrelid \
              JOIN pg_namespace ns ON ns.oid = rel.relnamespace AND ns.nspname = 'public' \
-             CROSS JOIN LATERAL unnest(i.indkey[0:i.indnkeyatts-1]) AS k(attnum) \
-             JOIN pg_attribute att ON att.attrelid = rel.oid AND att.attnum = k.attnum \
-             WHERE i.indisunique AND k.attnum > 0",
+             JOIN pg_attribute att ON att.attrelid = rel.oid \
+             AND att.attnum = ANY(i.indkey[0:i.indnkeyatts-1]) \
+             WHERE i.indisunique AND att.attnum > 0",
         )
         .load(&mut conn)
         .map_err(|e| ScrubError::Sql(e.to_string()))?,
@@ -2358,9 +2362,9 @@ fn probe_database_facts(
                  FROM pg_index i \
                  JOIN pg_class rel ON rel.oid = i.indrelid \
                  JOIN pg_namespace ns ON ns.oid = rel.relnamespace AND ns.nspname = 'public' \
-                 CROSS JOIN LATERAL unnest(i.indkey[0:i.indnkeyatts-1]) AS k(attnum) \
-                 JOIN pg_attribute att ON att.attrelid = rel.oid AND att.attnum = k.attnum \
-                 WHERE i.indisunique AND i.indnullsnotdistinct AND k.attnum > 0",
+                 JOIN pg_attribute att ON att.attrelid = rel.oid \
+                 AND att.attnum = ANY(i.indkey[0:i.indnkeyatts-1]) \
+                 WHERE i.indisunique AND i.indnullsnotdistinct AND att.attnum > 0",
             )
             .load(&mut conn)
             .map_err(|e| ScrubError::Sql(e.to_string()))?,
@@ -2521,7 +2525,7 @@ fn purge_statements(present: &[String], config: &ScrubConfig) -> Vec<(String, St
     present
         .iter()
         .filter(|t| config.framework.purge.contains(t))
-        .map(|t| (t.clone(), format!("DELETE FROM {}", quote_ident(t))))
+        .map(|t| (t.clone(), format!("DELETE FROM {}", qualified_ident(t))))
         .collect()
 }
 
@@ -4254,7 +4258,7 @@ mod tests {
             statements,
             vec![(
                 "autumn_jobs".to_owned(),
-                r#"DELETE FROM "autumn_jobs""#.to_owned()
+                r#"DELETE FROM "public"."autumn_jobs""#.to_owned()
             )]
         );
     }

--- a/autumn-cli/src/main.rs
+++ b/autumn-cli/src/main.rs
@@ -6275,6 +6275,84 @@ mod tests {
         assert_eq!(profile.as_deref(), Some("prod"));
     }
 
+    // ── autumn db scrub tests (issue #1602) ────────────────────────────────
+
+    #[test]
+    fn parse_db_scrub_defaults() {
+        let cli = Cli::try_parse_from(["autumn", "db", "scrub"]).unwrap();
+        let Commands::Db(DbCommands::Scrub {
+            profile,
+            artifact,
+            output,
+            config,
+            check,
+            dry_run,
+            force,
+        }) = cli.command
+        else {
+            panic!("expected db scrub");
+        };
+        assert!(profile.is_none());
+        assert!(artifact.is_none());
+        assert!(output.is_none());
+        assert!(config.is_none());
+        assert!(!check);
+        assert!(!dry_run);
+        assert!(!force);
+    }
+
+    #[test]
+    fn parse_db_scrub_with_artifact_output_and_force() {
+        let cli = Cli::try_parse_from([
+            "autumn",
+            "db",
+            "scrub",
+            "--profile",
+            "staging",
+            "--artifact",
+            "backups/prod/20260101T000000Z",
+            "--output",
+            "scrubbed",
+            "--config",
+            "config/scrub.toml",
+            "--force",
+        ])
+        .unwrap();
+        let Commands::Db(DbCommands::Scrub {
+            profile,
+            artifact,
+            output,
+            config,
+            check,
+            dry_run,
+            force,
+        }) = cli.command
+        else {
+            panic!("expected db scrub");
+        };
+        assert_eq!(profile.as_deref(), Some("staging"));
+        assert_eq!(
+            artifact.as_deref(),
+            Some(std::path::Path::new("backups/prod/20260101T000000Z"))
+        );
+        assert_eq!(output.as_deref(), Some(std::path::Path::new("scrubbed")));
+        assert_eq!(
+            config.as_deref(),
+            Some(std::path::Path::new("config/scrub.toml"))
+        );
+        assert!(!check);
+        assert!(!dry_run);
+        assert!(force);
+    }
+
+    #[test]
+    fn parse_db_scrub_check_conflicts_with_dry_run() {
+        assert!(
+            Cli::try_parse_from(["autumn", "db", "scrub", "--check", "--dry-run"]).is_err(),
+            "--check and --dry-run are two different no-write modes; asking for both is a mistake"
+        );
+    }
+
     // ── autumn console tests (issue #1039) ─────────────────────────────────
 
     #[test]

--- a/autumn-cli/src/main.rs
+++ b/autumn-cli/src/main.rs
@@ -1699,6 +1699,52 @@ enum DbCommands {
         #[arg(long)]
         offsite: bool,
     },
+    /// Anonymize a database (or a backup artifact) for non-production use.
+    ///
+    /// Rewrites every PII-classified column with deterministic, constraint-valid
+    /// fake values so a production copy is safe on a laptop or a shared staging
+    /// box. Classification is fail-closed: `#[encrypted]` model columns and
+    /// tables registered with the GDPR anonymize strategy are classified
+    /// automatically, everything else must be declared in `scrub.toml`, and a
+    /// column that is neither PII nor explicitly `safe` aborts the scrub — so a
+    /// newly added column can never silently pass through with real data.
+    ///
+    /// Refuses to run outside the `dev`/`test` profile without `--force`, the
+    /// same guard as `autumn db drop`.
+    ///
+    /// # Examples
+    ///
+    ///   # Refresh staging from a production backup:
+    ///   `AUTUMN_ENV=staging` autumn db scrub --artifact backups/prod/latest-run --force
+    ///
+    ///   # Prove the classification is complete (CI):
+    ///   autumn db scrub --check
+    #[command(verbatim_doc_comment)]
+    Scrub {
+        /// Resolve the connection through a profile overlay (see `db create`).
+        #[arg(long, value_name = "PROFILE")]
+        profile: Option<String>,
+        /// Restore this backup run directory (or artifact file) into the
+        /// resolved database(s) before scrubbing.
+        #[arg(long, value_name = "ARTIFACT")]
+        artifact: Option<std::path::PathBuf>,
+        /// After a successful scrub, write a fresh (scrubbed) backup run here.
+        #[arg(long, value_name = "DIR")]
+        output: Option<std::path::PathBuf>,
+        /// Path to the PII declaration file (default: `./scrub.toml`).
+        #[arg(long, value_name = "PATH")]
+        config: Option<std::path::PathBuf>,
+        /// Classify only: report the plan (or the unclassified columns) and
+        /// write nothing. Exits non-zero when any column is unclassified.
+        #[arg(long, conflicts_with_all = ["artifact", "output", "dry_run"])]
+        check: bool,
+        /// Print the exact SQL the scrub would run and write nothing.
+        #[arg(long, conflicts_with_all = ["artifact", "output"])]
+        dry_run: bool,
+        /// Allow the scrub against a non-dev/test (e.g. production) profile.
+        #[arg(long)]
+        force: bool,
+    },
     /// Inspect the offsite backup destination ([backup.offsite], issue #1619).
     #[command(subcommand)]
     Offsite(OffsiteCommands),
@@ -1718,15 +1764,21 @@ enum OffsiteCommands {
 impl DbCommands {
     /// Translate a lifecycle subcommand (`create`/`drop`/`reset`) into the `db`
     /// module's command and the optional profile override the connection should
-    /// be resolved under. `pull`/`backup`/`restore` are dispatched separately
-    /// (they do not map onto [`db::DbCommand`]).
+    /// be resolved under. `pull`/`backup`/`restore`/`scrub` are dispatched
+    /// separately (they do not map onto [`db::DbCommand`]).
     fn into_command(self) -> (db::DbCommand, Option<String>) {
         match self {
             Self::Create { profile } => (db::DbCommand::Create, profile),
             Self::Drop { profile, force } => (db::DbCommand::Drop { force }, profile),
             Self::Reset { profile, force } => (db::DbCommand::Reset { force }, profile),
-            Self::Pull { .. } | Self::Backup { .. } | Self::Restore { .. } | Self::Offsite(_) => {
-                unreachable!("db pull/backup/restore/offsite are dispatched before into_command")
+            Self::Pull { .. }
+            | Self::Backup { .. }
+            | Self::Restore { .. }
+            | Self::Scrub { .. }
+            | Self::Offsite(_) => {
+                unreachable!(
+                    "db pull/backup/restore/scrub/offsite are dispatched before into_command"
+                )
             }
         }
     }
@@ -3514,6 +3566,23 @@ fn run_command(command: Commands) {
                 force,
                 shard,
                 offsite,
+            }),
+            DbCommands::Scrub {
+                profile,
+                artifact,
+                output,
+                config,
+                check,
+                dry_run,
+                force,
+            } => db::scrub::run(&db::scrub::ScrubArgs {
+                profile,
+                artifact,
+                output,
+                config,
+                check,
+                dry_run,
+                force,
             }),
             DbCommands::Offsite(OffsiteCommands::List { profile }) => {
                 db::backup::run_offsite_list(profile.as_deref());

--- a/autumn-cli/src/main.rs
+++ b/autumn-cli/src/main.rs
@@ -1744,6 +1744,11 @@ enum DbCommands {
         /// Allow the scrub against a non-dev/test (e.g. production) profile.
         #[arg(long)]
         force: bool,
+        /// Allow writing over the database an artifact's own (non-dev/test)
+        /// profile config file declares. Separate from `--force`, which the
+        /// staging drill always passes.
+        #[arg(long)]
+        allow_source_overwrite: bool,
     },
     /// Inspect the offsite backup destination ([backup.offsite], issue #1619).
     #[command(subcommand)]
@@ -3575,6 +3580,7 @@ fn run_command(command: Commands) {
                 check,
                 dry_run,
                 force,
+                allow_source_overwrite,
             } => db::scrub::run(&db::scrub::ScrubArgs {
                 profile,
                 artifact,
@@ -3583,6 +3589,7 @@ fn run_command(command: Commands) {
                 check,
                 dry_run,
                 force,
+                allow_source_overwrite,
             }),
             DbCommands::Offsite(OffsiteCommands::List { profile }) => {
                 db::backup::run_offsite_list(profile.as_deref());
@@ -6357,10 +6364,12 @@ mod tests {
             check,
             dry_run,
             force,
+            allow_source_overwrite,
         }) = cli.command
         else {
             panic!("expected db scrub");
         };
+        assert!(!allow_source_overwrite);
         assert!(profile.is_none());
         assert!(artifact.is_none());
         assert!(output.is_none());
@@ -6395,10 +6404,12 @@ mod tests {
             check,
             dry_run,
             force,
+            allow_source_overwrite,
         }) = cli.command
         else {
             panic!("expected db scrub");
         };
+        assert!(!allow_source_overwrite);
         assert_eq!(profile.as_deref(), Some("staging"));
         assert_eq!(
             artifact.as_deref(),

--- a/autumn-cli/src/schema/mod.rs
+++ b/autumn-cli/src/schema/mod.rs
@@ -262,7 +262,7 @@ fn resolve_default_models_path(project_root: &Path) -> Result<PathBuf, String> {
 /// file precedence, but returns `None` (not an error) when neither is present —
 /// so callers that must degrade gracefully on absence (the `migrate` snapshot
 /// refresh, `doctor`'s drift check) share one resolver instead of duplicating it.
-fn existing_models_path(project_root: &Path) -> Option<PathBuf> {
+pub fn existing_models_path(project_root: &Path) -> Option<PathBuf> {
     let dir = project_root.join("src").join("models");
     if dir.is_dir() {
         return Some(dir);

--- a/autumn-cli/src/schema/parse.rs
+++ b/autumn-cli/src/schema/parse.rs
@@ -85,6 +85,7 @@
 //!   `idx_<table>_<field>_unique` form; exact parity for pathological long names
 //!   is a later refinement.
 
+use std::collections::{BTreeMap, BTreeSet};
 use std::path::Path;
 
 use autumn_schema_core::{
@@ -291,6 +292,126 @@ pub fn parse_models_path(path: &Path, backend: Backend) -> Result<ParsedSchema, 
             ),
         })
     }
+}
+
+/// Read the `#[encrypted]` column set out of `#[model]` structs, keyed by the
+/// resolved table name.
+///
+/// `#[encrypted]` does not change a column's *shape*, so [`parse_model_source`]
+/// deliberately ignores it — but it is machine-readable PII semantics the
+/// framework already holds, and `autumn db scrub` (issue #1602) classifies those
+/// columns as PII with no developer declaration at all. Table names are resolved
+/// through the same `#[model(table = "...")]`-else-convention path
+/// [`build_table`] uses, so the two can never disagree about which table a
+/// model's encrypted column belongs to.
+///
+/// Tables with no encrypted column are omitted entirely (an empty map means "no
+/// `#[encrypted]` columns anywhere", never "no models").
+///
+/// # Errors
+///
+/// Returns [`SchemaParseError::Syntax`] if `src` is not valid Rust.
+pub fn parse_encrypted_columns(
+    src: &str,
+) -> Result<BTreeMap<String, BTreeSet<String>>, SchemaParseError> {
+    let file = syn::parse_file(src).map_err(|e| SchemaParseError::from_syn(&e))?;
+    let mut out: BTreeMap<String, BTreeSet<String>> = BTreeMap::new();
+    for item in &file.items {
+        let syn::Item::Struct(item_struct) = item else {
+            continue;
+        };
+        let Some(model_attr) = find_model_attr(&item_struct.attrs) else {
+            continue;
+        };
+        let syn::Fields::Named(named) = &item_struct.fields else {
+            continue;
+        };
+        let model_name = item_struct.ident.to_string();
+        let table = parse_model_args(model_attr)
+            .table
+            .unwrap_or_else(|| naming::pluralize(&naming::pascal_to_snake(&model_name)));
+        for field in &named.named {
+            let Some(ident) = field.ident.as_ref() else {
+                continue;
+            };
+            if field.attrs.iter().any(is_encrypted_attr) {
+                out.entry(table.clone())
+                    .or_default()
+                    .insert(ident.to_string());
+            }
+        }
+    }
+    Ok(out)
+}
+
+/// Read the `#[encrypted]` column set from a models file or directory, using the
+/// same file-vs-directory dispatch as [`parse_models_path`].
+///
+/// # Errors
+///
+/// Returns [`SchemaParseError::Io`] if `path` does not exist or cannot be read,
+/// or [`SchemaParseError::Syntax`] if a file is not valid Rust.
+pub fn parse_encrypted_columns_path(
+    path: &Path,
+) -> Result<BTreeMap<String, BTreeSet<String>>, SchemaParseError> {
+    let mut out: BTreeMap<String, BTreeSet<String>> = BTreeMap::new();
+    for file in model_source_files(path)? {
+        let src = std::fs::read_to_string(&file).map_err(|source| SchemaParseError::Io {
+            path: file.display().to_string(),
+            source,
+        })?;
+        for (table, columns) in parse_encrypted_columns(&src)? {
+            out.entry(table).or_default().extend(columns);
+        }
+    }
+    Ok(out)
+}
+
+/// The `.rs` sources a models path expands to: the file itself, or every `*.rs`
+/// directly under the directory (sorted, so aggregation is deterministic).
+fn model_source_files(path: &Path) -> Result<Vec<std::path::PathBuf>, SchemaParseError> {
+    if path.is_file() {
+        return Ok(vec![path.to_path_buf()]);
+    }
+    if !path.is_dir() {
+        return Err(SchemaParseError::Io {
+            path: path.display().to_string(),
+            source: std::io::Error::new(
+                std::io::ErrorKind::NotFound,
+                "expected a `.rs` model file or a directory of model files",
+            ),
+        });
+    }
+    let read = std::fs::read_dir(path).map_err(|source| SchemaParseError::Io {
+        path: path.display().to_string(),
+        source,
+    })?;
+    let mut paths = Vec::new();
+    for entry in read {
+        let entry = entry.map_err(|source| SchemaParseError::Io {
+            path: path.display().to_string(),
+            source,
+        })?;
+        let candidate = entry.path();
+        let file_type = entry.file_type().map_err(|source| SchemaParseError::Io {
+            path: candidate.display().to_string(),
+            source,
+        })?;
+        if file_type.is_file() && candidate.extension().is_some_and(|ext| ext == "rs") {
+            paths.push(candidate);
+        }
+    }
+    paths.sort();
+    Ok(paths)
+}
+
+/// Whether an attribute is the field-level `#[encrypted]` marker, in either its
+/// bare (`#[encrypted]`) or configured (`#[encrypted(deterministic)]`) spelling.
+fn is_encrypted_attr(attr: &syn::Attribute) -> bool {
+    attr.path()
+        .segments
+        .last()
+        .is_some_and(|seg| seg.ident == "encrypted")
 }
 
 /// Find the `#[model]` / `#[autumn_web::model]` attribute on a struct, if any.
@@ -734,6 +855,90 @@ fn type_to_string(ty: &syn::Type) -> String {
 #[allow(clippy::needless_raw_string_hashes)]
 mod tests {
     use super::*;
+
+    // ── `#[encrypted]` PII annotations (issue #1602) ────────────────────────
+
+    #[test]
+    fn encrypted_columns_are_read_per_table() {
+        let found = parse_encrypted_columns(
+            r#"
+            #[model]
+            pub struct Account {
+                #[id]
+                pub id: i64,
+                #[encrypted]
+                pub api_token: String,
+                #[encrypted(deterministic)]
+                pub email: String,
+                pub name: String,
+            }
+            "#,
+        )
+        .unwrap();
+        assert_eq!(
+            found.get("accounts"),
+            Some(&BTreeSet::from([
+                "api_token".to_owned(),
+                "email".to_owned()
+            ]))
+        );
+    }
+
+    #[test]
+    fn encrypted_columns_honor_the_table_name_override() {
+        let found = parse_encrypted_columns(
+            r#"
+            #[model(table = "legacy_people")]
+            pub struct Person {
+                #[id]
+                pub id: i64,
+                #[encrypted]
+                pub ssn: String,
+            }
+            "#,
+        )
+        .unwrap();
+        assert!(found.contains_key("legacy_people"));
+        assert!(!found.contains_key("people"));
+    }
+
+    #[test]
+    fn a_model_without_encrypted_columns_is_omitted() {
+        let found = parse_encrypted_columns(
+            r#"
+            #[model]
+            pub struct Post {
+                #[id]
+                pub id: i64,
+                pub title: String,
+            }
+            "#,
+        )
+        .unwrap();
+        assert!(found.is_empty());
+    }
+
+    #[test]
+    fn encrypted_fields_outside_a_model_struct_are_ignored() {
+        let found = parse_encrypted_columns(
+            r#"
+            pub struct NotAModel {
+                #[encrypted]
+                pub secret: String,
+            }
+            "#,
+        )
+        .unwrap();
+        assert!(found.is_empty());
+    }
+
+    #[test]
+    fn encrypted_column_scan_reports_a_syntax_error() {
+        assert!(matches!(
+            parse_encrypted_columns("this is not rust"),
+            Err(SchemaParseError::Syntax { .. })
+        ));
+    }
 
     fn parse_one(src: &str) -> Table {
         let parsed = parse_model_source(src, Backend::Postgres).expect("parse");

--- a/autumn-cli/src/schema/parse.rs
+++ b/autumn-cli/src/schema/parse.rs
@@ -85,7 +85,7 @@
 //!   `idx_<table>_<field>_unique` form; exact parity for pathological long names
 //!   is a later refinement.
 
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::BTreeMap;
 use std::path::Path;
 
 use autumn_schema_core::{
@@ -313,9 +313,9 @@ pub fn parse_models_path(path: &Path, backend: Backend) -> Result<ParsedSchema, 
 /// Returns [`SchemaParseError::Syntax`] if `src` is not valid Rust.
 pub fn parse_encrypted_columns(
     src: &str,
-) -> Result<BTreeMap<String, BTreeSet<String>>, SchemaParseError> {
+) -> Result<BTreeMap<String, BTreeMap<String, bool>>, SchemaParseError> {
     let file = syn::parse_file(src).map_err(|e| SchemaParseError::from_syn(&e))?;
-    let mut out: BTreeMap<String, BTreeSet<String>> = BTreeMap::new();
+    let mut out: BTreeMap<String, BTreeMap<String, bool>> = BTreeMap::new();
     for item in &file.items {
         let syn::Item::Struct(item_struct) = item else {
             continue;
@@ -334,10 +334,10 @@ pub fn parse_encrypted_columns(
             let Some(ident) = field.ident.as_ref() else {
                 continue;
             };
-            if field.attrs.iter().any(is_encrypted_attr) {
+            if let Some(attr) = field.attrs.iter().find(|a| is_encrypted_attr(a)) {
                 out.entry(table.clone())
                     .or_default()
-                    .insert(ident.to_string());
+                    .insert(ident.to_string(), is_deterministic_encrypted(attr));
             }
         }
     }
@@ -353,8 +353,8 @@ pub fn parse_encrypted_columns(
 /// or [`SchemaParseError::Syntax`] if a file is not valid Rust.
 pub fn parse_encrypted_columns_path(
     path: &Path,
-) -> Result<BTreeMap<String, BTreeSet<String>>, SchemaParseError> {
-    let mut out: BTreeMap<String, BTreeSet<String>> = BTreeMap::new();
+) -> Result<BTreeMap<String, BTreeMap<String, bool>>, SchemaParseError> {
+    let mut out: BTreeMap<String, BTreeMap<String, bool>> = BTreeMap::new();
     for file in model_source_files(path)? {
         let src = std::fs::read_to_string(&file).map_err(|source| SchemaParseError::Io {
             path: file.display().to_string(),
@@ -368,7 +368,12 @@ pub fn parse_encrypted_columns_path(
 }
 
 /// The `.rs` sources a models path expands to: the file itself, or every `*.rs`
-/// directly under the directory (sorted, so aggregation is deterministic).
+/// under the directory (sorted, so aggregation is deterministic).
+///
+/// The walk is **recursive**, unlike [`parse_models_dir`]'s: a PII scan that
+/// missed `src/models/billing/card.rs` would not merely under-report, it would
+/// silently disable the "a `safe` declaration may not override `#[encrypted]`"
+/// refusal for every nested model.
 fn model_source_files(path: &Path) -> Result<Vec<std::path::PathBuf>, SchemaParseError> {
     if path.is_file() {
         return Ok(vec![path.to_path_buf()]);
@@ -382,23 +387,28 @@ fn model_source_files(path: &Path) -> Result<Vec<std::path::PathBuf>, SchemaPars
             ),
         });
     }
-    let read = std::fs::read_dir(path).map_err(|source| SchemaParseError::Io {
-        path: path.display().to_string(),
-        source,
-    })?;
     let mut paths = Vec::new();
-    for entry in read {
-        let entry = entry.map_err(|source| SchemaParseError::Io {
-            path: path.display().to_string(),
+    let mut stack = vec![path.to_path_buf()];
+    while let Some(dir) = stack.pop() {
+        let read = std::fs::read_dir(&dir).map_err(|source| SchemaParseError::Io {
+            path: dir.display().to_string(),
             source,
         })?;
-        let candidate = entry.path();
-        let file_type = entry.file_type().map_err(|source| SchemaParseError::Io {
-            path: candidate.display().to_string(),
-            source,
-        })?;
-        if file_type.is_file() && candidate.extension().is_some_and(|ext| ext == "rs") {
-            paths.push(candidate);
+        for entry in read {
+            let entry = entry.map_err(|source| SchemaParseError::Io {
+                path: dir.display().to_string(),
+                source,
+            })?;
+            let candidate = entry.path();
+            let file_type = entry.file_type().map_err(|source| SchemaParseError::Io {
+                path: candidate.display().to_string(),
+                source,
+            })?;
+            if file_type.is_dir() {
+                stack.push(candidate);
+            } else if file_type.is_file() && candidate.extension().is_some_and(|ext| ext == "rs") {
+                paths.push(candidate);
+            }
         }
     }
     paths.sort();
@@ -412,6 +422,29 @@ fn is_encrypted_attr(attr: &syn::Attribute) -> bool {
         .segments
         .last()
         .is_some_and(|seg| seg.ident == "encrypted")
+}
+
+/// Whether an `#[encrypted(...)]` attribute selects deterministic mode.
+///
+/// A deterministic column is the one an app can still equality-query after the
+/// scrub (via `deterministic_ciphertext`), so a replacement envelope has to be
+/// produced in the same mode or those lookups quietly stop matching.
+fn is_deterministic_encrypted(attr: &syn::Attribute) -> bool {
+    if matches!(attr.meta, syn::Meta::Path(_)) {
+        return false;
+    }
+    let mut deterministic = false;
+    let _ = attr.parse_nested_meta(|meta| {
+        if meta.path.is_ident("deterministic") {
+            deterministic = true;
+        } else if meta.input.peek(syn::token::Paren) {
+            let _ = meta.parse_nested_meta(|_| Ok(()));
+        } else if let Ok(value) = meta.value() {
+            let _ = value.parse::<syn::Lit>();
+        }
+        Ok(())
+    });
+    deterministic
 }
 
 /// Find the `#[model]` / `#[autumn_web::model]` attribute on a struct, if any.
@@ -877,9 +910,12 @@ mod tests {
         .unwrap();
         assert_eq!(
             found.get("accounts"),
-            Some(&BTreeSet::from([
-                "api_token".to_owned(),
-                "email".to_owned()
+            Some(&BTreeMap::from([
+                ("api_token".to_owned(), false),
+                // `#[encrypted(deterministic)]` must be recorded as such: a
+                // scrub has to re-encrypt in the same mode, or equality lookups
+                // against the column quietly stop matching.
+                ("email".to_owned(), true),
             ]))
         );
     }

--- a/autumn-cli/tests/integration/db_scrub.rs
+++ b/autumn-cli/tests/integration/db_scrub.rs
@@ -1,0 +1,830 @@
+//! Integration tests for `autumn db scrub` (issue #1602).
+//!
+//! The headline test is the AC #6 round-trip: seed known PII → `autumn db
+//! backup` → `autumn db scrub --artifact …` into a separate staging database →
+//! assert **zero** occurrences of any original value anywhere in the result.
+//!
+//! Requires Docker (via testcontainers) AND `pg_dump`/`pg_restore` on `PATH`, so
+//! every test here is `#[ignore]`d:
+//!
+//! ```text
+//! cargo test -p autumn-cli --test cli_tests -- --ignored --nocapture db_scrub
+//! ```
+//!
+//! `scrubbed_database_migrates_clean_and_boots_the_app` additionally compiles
+//! and boots a generated app, so it also needs the `diesel` CLI and runs in the
+//! generator-conformance Postgres gate rather than the general Docker sweep.
+//!
+//! Each test drives the real `autumn` binary as a subprocess with a
+//! per-child working directory and environment (never mutating this process's
+//! cwd or env), so it has no process-wide side effects and lives in the
+//! consolidated test binary per the workspace test-layout guidelines.
+
+use std::fmt::Write as _;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::time::Duration;
+
+use tokio_postgres::{Client, NoTls};
+
+const fn autumn_bin() -> &'static str {
+    env!("CARGO_BIN_EXE_autumn")
+}
+
+/// The PII values seeded before every scrub. **None** of these may survive
+/// anywhere in the scrubbed database.
+const SECRETS: &[&str] = &[
+    "alice@real-corp.example",
+    "bob@real-corp.example",
+    "Alice Realname",
+    "Bob Realname",
+    "+14155550101",
+    "lives at 42 Real Street",
+    "tok_REALSECRET_alice",
+    "tok_REALSECRET_bob",
+    "my real secret comment",
+];
+
+fn run_autumn(dir: &Path, args: &[&str], envs: &[(&str, &str)]) -> (String, String, Option<i32>) {
+    let output = Command::new(autumn_bin())
+        .args(args)
+        .current_dir(dir)
+        .envs(envs.iter().copied())
+        .output()
+        .expect("failed to run autumn");
+    (
+        String::from_utf8_lossy(&output.stdout).into_owned(),
+        String::from_utf8_lossy(&output.stderr).into_owned(),
+        output.status.code(),
+    )
+}
+
+fn run_autumn_ok(dir: &Path, args: &[&str], envs: &[(&str, &str)]) -> (String, String) {
+    let (stdout, stderr, code) = run_autumn(dir, args, envs);
+    assert_eq!(
+        code,
+        Some(0),
+        "autumn {args:?} failed (exit={code:?})\nstdout: {stdout}\nstderr: {stderr}",
+    );
+    (stdout, stderr)
+}
+
+fn run_autumn_fail(dir: &Path, args: &[&str], envs: &[(&str, &str)]) -> (String, String) {
+    let (stdout, stderr, code) = run_autumn(dir, args, envs);
+    assert_ne!(
+        code,
+        Some(0),
+        "autumn {args:?} should have failed but exited 0\nstdout: {stdout}\nstderr: {stderr}",
+    );
+    (stdout, stderr)
+}
+
+async fn connect(url: &str) -> Client {
+    let (client, connection) = tokio_postgres::connect(url, NoTls)
+        .await
+        .unwrap_or_else(|e| panic!("connect to {url:?} failed: {e}"));
+    tokio::spawn(async move {
+        let _ = connection.await;
+    });
+    client
+}
+
+/// The fixture schema: a `users` table carrying five different shapes of PII
+/// plus a deliberately-safe `role`, a `comments` child table whose foreign key
+/// must survive the scrub intact, and a framework-owned `autumn_jobs` table
+/// whose queued payload embeds PII the column classification never sees
+/// (introspection filters `autumn_*` out of the classified universe).
+const FIXTURE_SCHEMA: &str = "\
+    CREATE TABLE users ( \
+        id BIGSERIAL PRIMARY KEY, \
+        email TEXT NOT NULL UNIQUE, \
+        full_name TEXT NOT NULL, \
+        phone VARCHAR(32), \
+        bio TEXT, \
+        api_token TEXT NOT NULL, \
+        role TEXT NOT NULL, \
+        created_at TIMESTAMP NOT NULL DEFAULT NOW() \
+    ); \
+    CREATE TABLE comments ( \
+        id BIGSERIAL PRIMARY KEY, \
+        user_id BIGINT NOT NULL REFERENCES users(id), \
+        body TEXT NOT NULL, \
+        created_at TIMESTAMP NOT NULL DEFAULT NOW() \
+    );";
+
+/// Framework-owned tables, applied only by the Docker-only tests. The
+/// app-booting test must not create these itself: `autumn migrate` runs the
+/// framework's own migrations, which own `autumn_jobs` with a different shape.
+///
+/// `autumn_scrub_outbox` is opted into `[framework] purge`; `autumn_jobs` is a
+/// built-in payload carrier left un-purged, so the warning path is exercised too.
+const FIXTURE_FRAMEWORK_TABLES: &str = "\
+    CREATE TABLE autumn_scrub_outbox ( \
+        id BIGSERIAL PRIMARY KEY, \
+        payload TEXT NOT NULL \
+    ); \
+    INSERT INTO autumn_scrub_outbox (payload) \
+        VALUES ('{\"to\": \"alice@real-corp.example\"}'); \
+    CREATE TABLE autumn_jobs ( \
+        id BIGSERIAL PRIMARY KEY, \
+        args TEXT NOT NULL \
+    ); \
+    INSERT INTO autumn_jobs (args) VALUES ('{\"note\": \"nothing sensitive\"}');";
+
+const FIXTURE_ROWS: &str = "\
+    INSERT INTO users (email, full_name, phone, bio, api_token, role) VALUES \
+        ('alice@real-corp.example', 'Alice Realname', '+14155550101', \
+         'lives at 42 Real Street', 'tok_REALSECRET_alice', 'admin'), \
+        ('bob@real-corp.example', 'Bob Realname', NULL, NULL, \
+         'tok_REALSECRET_bob', 'member'); \
+    INSERT INTO comments (user_id, body) \
+        SELECT id, 'my real secret comment' FROM users;";
+
+/// The per-app declaration. `api_token` is deliberately absent: it carries
+/// `#[encrypted]` in the model and must be classified with no declaration at
+/// all. `comments` is absent entirely: it is registered with the GDPR anonymize
+/// strategy.
+const SCRUB_TOML: &str = r#"
+[defaults]
+safe_columns = ["id", "created_at"]
+
+[tables.users]
+safe = ["role"]
+
+[tables.users.pii]
+email = "email"
+full_name = "name"
+phone = "phone"
+bio = "redact"
+
+# Framework-owned tables are not column-classified; this app opts into
+# emptying its outbox, whose payloads embed customer addresses.
+[framework]
+purge = ["autumn_scrub_outbox"]
+"#;
+
+/// Write the project files the scrub reads its automatic classification from:
+/// a model with an `#[encrypted]` column and a GDPR anonymize registration.
+fn write_project_sources(dir: &Path) {
+    let models = dir.join("src").join("models");
+    std::fs::create_dir_all(&models).unwrap();
+    std::fs::write(
+        models.join("user.rs"),
+        r"
+use autumn_web::model;
+
+#[model]
+pub struct User {
+    #[id]
+    pub id: i64,
+    pub email: String,
+    pub full_name: String,
+    /// At-rest encrypted — PII by construction, so `autumn db scrub`
+    /// classifies it without any declaration.
+    #[encrypted]
+    pub api_token: String,
+}
+",
+    )
+    .unwrap();
+    std::fs::write(
+        dir.join("src").join("state.rs"),
+        r#"
+use autumn_web::gdpr::{GdprRegistry, ModelRegistration};
+
+pub fn gdpr_registry() -> GdprRegistry {
+    GdprRegistry::new()
+        .register(ModelRegistration::hard_delete("sessions"))
+        .register(ModelRegistration::anonymize("comments"))
+}
+"#,
+    )
+    .unwrap();
+}
+
+/// Every occurrence of `needle` anywhere in any character-typed column of any
+/// non-system table, as `table.column` labels. The sweep is deliberately
+/// schema-driven rather than a hand-written column list, so a column added to
+/// the fixture cannot slip past the assertion.
+async fn occurrences(client: &Client, needle: &str) -> Vec<String> {
+    let columns = client
+        .query(
+            "SELECT table_name, column_name FROM information_schema.columns \
+             WHERE table_schema = 'public' \
+             ORDER BY table_name, ordinal_position",
+            &[],
+        )
+        .await
+        .expect("read column catalog");
+
+    let mut hits = Vec::new();
+    for row in columns {
+        let table: String = row.get(0);
+        let column: String = row.get(1);
+        let sql = format!(
+            "SELECT count(*) FROM \"{}\" WHERE position($1 in \"{}\"::text) > 0",
+            table.replace('"', "\"\""),
+            column.replace('"', "\"\"")
+        );
+        let count: i64 = client
+            .query_one(&sql, &[&needle])
+            .await
+            .unwrap_or_else(|e| panic!("scanning {table}.{column} failed: {e}"))
+            .get(0);
+        if count > 0 {
+            hits.push(format!("{table}.{column} ({count} row(s))"));
+        }
+    }
+    hits
+}
+
+async fn assert_no_secrets_survive(client: &Client) {
+    let mut report = String::new();
+    for secret in SECRETS {
+        let hits = occurrences(client, secret).await;
+        if !hits.is_empty() {
+            let _ = writeln!(report, "  {secret:?} still present in: {}", hits.join(", "));
+        }
+    }
+    assert!(
+        report.is_empty(),
+        "scrubbed database still contains original PII:\n{report}"
+    );
+}
+
+async fn start_postgres() -> (
+    testcontainers::ContainerAsync<testcontainers_modules::postgres::Postgres>,
+    String,
+    u16,
+) {
+    use testcontainers::runners::AsyncRunner as _;
+    use testcontainers_modules::postgres::Postgres;
+
+    let container = Postgres::default()
+        .start()
+        .await
+        .expect("failed to start Postgres testcontainer — is Docker running?");
+    let host = container.get_host().await.unwrap().to_string();
+    let port = container.get_host_port_ipv4(5432).await.unwrap();
+    (container, host, port)
+}
+
+// ─── AC #6: the round trip ──────────────────────────────────────────────────
+
+#[tokio::test]
+#[ignore = "requires Docker (testcontainers) and pg_dump/pg_restore on PATH"]
+#[allow(clippy::too_many_lines)]
+async fn scrub_round_trip_leaves_zero_original_values() {
+    let (_pg, host, port) = start_postgres().await;
+    let admin_url = format!("postgres://postgres:postgres@{host}:{port}/postgres");
+    let source_url = format!("postgres://postgres:postgres@{host}:{port}/scrub_source");
+    let staging_url = format!("postgres://postgres:postgres@{host}:{port}/scrub_staging");
+
+    // ── Two databases: the "production" source and the staging target ───────
+    let admin = connect(&admin_url).await;
+    admin
+        .batch_execute("CREATE DATABASE scrub_source; CREATE DATABASE scrub_staging;")
+        .await
+        .unwrap();
+
+    let source = connect(&source_url).await;
+    source.batch_execute(FIXTURE_SCHEMA).await.unwrap();
+    source
+        .batch_execute(FIXTURE_FRAMEWORK_TABLES)
+        .await
+        .unwrap();
+    source.batch_execute(FIXTURE_ROWS).await.unwrap();
+
+    // Sanity: the seeded values really are there to begin with, so a passing
+    // post-scrub assertion cannot be vacuous.
+    for secret in SECRETS {
+        assert!(
+            !occurrences(&source, secret).await.is_empty(),
+            "fixture must actually contain {secret:?} before the scrub"
+        );
+    }
+
+    let tmp = tempfile::tempdir().unwrap();
+    let dir = tmp.path();
+    write_project_sources(dir);
+
+    // ── Back up the source ──────────────────────────────────────────────────
+    let source_envs = [("AUTUMN_DATABASE__URL", source_url.as_str())];
+    let (_o, backup_err) = run_autumn_ok(dir, &["db", "backup"], &source_envs);
+    assert!(
+        backup_err.contains("Backup complete") || backup_err.contains("integrity"),
+        "backup should report success: {backup_err}"
+    );
+    let run_dir = newest_run_dir(&dir.join("backups").join("dev"));
+
+    // ── Fail-closed: with no declaration the scrub refuses ──────────────────
+    let staging_envs = [("AUTUMN_DATABASE__URL", staging_url.as_str())];
+    let (_o, refusal) = run_autumn_fail(
+        dir,
+        &["db", "scrub", "--artifact", run_dir.to_str().unwrap()],
+        &staging_envs,
+    );
+    assert!(
+        refusal.contains("neither PII-classified nor declared safe"),
+        "an undeclared schema must be refused: {refusal}"
+    );
+    assert!(
+        refusal.contains("users.bio") && refusal.contains("users.role"),
+        "the refusal must list the unclassified columns: {refusal}"
+    );
+    assert!(
+        refusal.contains("[tables.users.pii]"),
+        "the refusal must print a paste-ready stanza: {refusal}"
+    );
+    // The restore has already run by the time classification can see the schema,
+    // so the refusal must say — loudly — that the target now holds raw data.
+    assert!(
+        refusal.contains("ALREADY RESTORED") && refusal.contains("UNSCRUBBED"),
+        "a post-restore refusal must warn that the target holds unscrubbed data: {refusal}"
+    );
+
+    // ── Declare, then scrub the restored copy ───────────────────────────────
+    std::fs::write(dir.join("scrub.toml"), SCRUB_TOML).unwrap();
+    let (_o, scrub_err) = run_autumn_ok(
+        dir,
+        &["db", "scrub", "--artifact", run_dir.to_str().unwrap()],
+        &staging_envs,
+    );
+    assert!(
+        scrub_err.contains("Scrub complete"),
+        "scrub should complete: {scrub_err}"
+    );
+    // The two automatic classifications must be visible in the report.
+    assert!(
+        scrub_err.contains("users.api_token") && scrub_err.contains("#[encrypted]"),
+        "an #[encrypted] column must be scrubbed without a declaration: {scrub_err}"
+    );
+    assert!(
+        scrub_err.contains("comments.body") && scrub_err.contains("gdpr:anonymize"),
+        "a GDPR-anonymize table must be scrubbed without a declaration: {scrub_err}"
+    );
+    // Framework-owned tables are outside the classified universe: the opted-in
+    // one is emptied, and the one left alone is warned about by name.
+    assert!(
+        scrub_err.contains("autumn_scrub_outbox") && scrub_err.contains("emptied"),
+        "the opted-in framework table must be emptied: {scrub_err}"
+    );
+    assert!(
+        scrub_err.contains("autumn_jobs") && scrub_err.contains("NOT scrubbed"),
+        "an un-purged framework payload table must be warned about: {scrub_err}"
+    );
+
+    // ── AC #1/#6: zero original values survive ──────────────────────────────
+    let staging = connect(&staging_url).await;
+    assert_no_secrets_survive(&staging).await;
+
+    // ── AC #4: the copy is still a working database ─────────────────────────
+    let user_rows: i64 = staging
+        .query_one("SELECT count(*) FROM users", &[])
+        .await
+        .unwrap()
+        .get(0);
+    assert_eq!(user_rows, 2, "a scrub anonymizes rows, it never drops them");
+
+    let distinct_emails: i64 = staging
+        .query_one("SELECT count(DISTINCT email) FROM users", &[])
+        .await
+        .unwrap()
+        .get(0);
+    assert_eq!(distinct_emails, 2, "the UNIQUE email column stays unique");
+
+    let outbox_rows: i64 = staging
+        .query_one("SELECT count(*) FROM autumn_scrub_outbox", &[])
+        .await
+        .unwrap()
+        .get(0);
+    assert_eq!(
+        outbox_rows, 0,
+        "the purged framework table must be empty after the scrub"
+    );
+
+    let orphans: i64 = staging
+        .query_one(
+            "SELECT count(*) FROM comments c \
+             LEFT JOIN users u ON u.id = c.user_id WHERE u.id IS NULL",
+            &[],
+        )
+        .await
+        .unwrap()
+        .get(0);
+    assert_eq!(orphans, 0, "foreign keys must still resolve after a scrub");
+
+    let nulls: i64 = staging
+        .query_one(
+            "SELECT count(*) FROM users WHERE email IS NULL OR full_name IS NULL \
+             OR api_token IS NULL",
+            &[],
+        )
+        .await
+        .unwrap()
+        .get(0);
+    assert_eq!(nulls, 0, "NOT NULL columns must still hold values");
+
+    // A NULL in the source stays NULL — a scrub anonymizes values, it does not
+    // invent them.
+    let preserved_nulls: i64 = staging
+        .query_one(
+            "SELECT count(*) FROM users WHERE phone IS NULL AND bio IS NULL",
+            &[],
+        )
+        .await
+        .unwrap()
+        .get(0);
+    assert_eq!(preserved_nulls, 1, "Bob's NULL phone/bio must stay NULL");
+
+    // An explicitly-safe column keeps its real value.
+    let roles: Vec<String> = staging
+        .query("SELECT role FROM users ORDER BY id", &[])
+        .await
+        .unwrap()
+        .iter()
+        .map(|r| r.get(0))
+        .collect();
+    assert_eq!(roles, vec!["admin".to_owned(), "member".to_owned()]);
+
+    // The replacement email is still a syntactically valid, undeliverable one.
+    let emails: Vec<String> = staging
+        .query("SELECT email FROM users ORDER BY id", &[])
+        .await
+        .unwrap()
+        .iter()
+        .map(|r| r.get(0))
+        .collect();
+    for email in &emails {
+        assert!(
+            email.starts_with("scrubbed+") && email.ends_with("@example.invalid"),
+            "unexpected replacement address: {email}"
+        );
+    }
+
+    // ── The source database was never touched ───────────────────────────────
+    let source_email: String = source
+        .query_one("SELECT email FROM users ORDER BY id LIMIT 1", &[])
+        .await
+        .unwrap()
+        .get(0);
+    assert_eq!(
+        source_email, "alice@real-corp.example",
+        "the scrub must not reach back into the database the artifact came from"
+    );
+}
+
+/// AC #1's second input shape: scrubbing a resolved database URL in place, with
+/// no artifact involved.
+#[tokio::test]
+#[ignore = "requires Docker (testcontainers)"]
+async fn scrub_anonymizes_a_resolved_database_url_in_place() {
+    let (_pg, host, port) = start_postgres().await;
+    let url = format!("postgres://postgres:postgres@{host}:{port}/postgres");
+    let client = connect(&url).await;
+    client.batch_execute(FIXTURE_SCHEMA).await.unwrap();
+    client
+        .batch_execute(FIXTURE_FRAMEWORK_TABLES)
+        .await
+        .unwrap();
+    client.batch_execute(FIXTURE_ROWS).await.unwrap();
+
+    let tmp = tempfile::tempdir().unwrap();
+    let dir = tmp.path();
+    write_project_sources(dir);
+    std::fs::write(dir.join("scrub.toml"), SCRUB_TOML).unwrap();
+    let envs = [("AUTUMN_DATABASE__URL", url.as_str())];
+
+    // `--check` proves the classification is complete and writes nothing.
+    let (_o, check_err) = run_autumn_ok(dir, &["db", "scrub", "--check"], &envs);
+    assert!(
+        check_err.contains("Every column is classified"),
+        "check should confirm a complete classification: {check_err}"
+    );
+    assert!(
+        !occurrences(&client, "Alice Realname").await.is_empty(),
+        "--check must not write anything"
+    );
+    let outbox_before: i64 = client
+        .query_one("SELECT count(*) FROM autumn_scrub_outbox", &[])
+        .await
+        .unwrap()
+        .get(0);
+    assert_eq!(outbox_before, 1, "--check must not empty a purged table");
+
+    // `--dry-run` prints the statement and still writes nothing.
+    let (_o, dry_err) = run_autumn_ok(dir, &["db", "scrub", "--dry-run"], &envs);
+    assert!(
+        dry_err.contains("UPDATE \"users\" SET"),
+        "dry run should print the statement: {dry_err}"
+    );
+    assert!(
+        !occurrences(&client, "Alice Realname").await.is_empty(),
+        "--dry-run must not write anything"
+    );
+
+    run_autumn_ok(dir, &["db", "scrub"], &envs);
+    assert_no_secrets_survive(&client).await;
+}
+
+/// AC #3, at the sharpest edge: adding a column to a schema whose declaration
+/// was previously complete must break the scrub, not slip through.
+#[tokio::test]
+#[ignore = "requires Docker (testcontainers)"]
+async fn a_newly_added_column_breaks_a_previously_passing_scrub() {
+    let (_pg, host, port) = start_postgres().await;
+    let url = format!("postgres://postgres:postgres@{host}:{port}/postgres");
+    let client = connect(&url).await;
+    client.batch_execute(FIXTURE_SCHEMA).await.unwrap();
+    client
+        .batch_execute(FIXTURE_FRAMEWORK_TABLES)
+        .await
+        .unwrap();
+    client.batch_execute(FIXTURE_ROWS).await.unwrap();
+
+    let tmp = tempfile::tempdir().unwrap();
+    let dir = tmp.path();
+    write_project_sources(dir);
+    std::fs::write(dir.join("scrub.toml"), SCRUB_TOML).unwrap();
+    let envs = [("AUTUMN_DATABASE__URL", url.as_str())];
+
+    run_autumn_ok(dir, &["db", "scrub", "--check"], &envs);
+
+    client
+        .batch_execute("ALTER TABLE users ADD COLUMN ssn TEXT;")
+        .await
+        .unwrap();
+
+    let (_o, stderr) = run_autumn_fail(dir, &["db", "scrub"], &envs);
+    assert!(
+        stderr.contains("users.ssn"),
+        "the new column must be named in the refusal: {stderr}"
+    );
+    assert!(
+        !occurrences(&client, "Alice Realname").await.is_empty(),
+        "a refused scrub must not have written anything"
+    );
+}
+
+/// AC #3's other rot mode: a renamed column leaves a stale declaration behind.
+#[tokio::test]
+#[ignore = "requires Docker (testcontainers)"]
+async fn a_renamed_column_is_reported_as_a_stale_declaration() {
+    let (_pg, host, port) = start_postgres().await;
+    let url = format!("postgres://postgres:postgres@{host}:{port}/postgres");
+    let client = connect(&url).await;
+    client.batch_execute(FIXTURE_SCHEMA).await.unwrap();
+    client
+        .batch_execute(FIXTURE_FRAMEWORK_TABLES)
+        .await
+        .unwrap();
+    client
+        .batch_execute("ALTER TABLE users RENAME COLUMN bio TO about;")
+        .await
+        .unwrap();
+
+    let tmp = tempfile::tempdir().unwrap();
+    let dir = tmp.path();
+    write_project_sources(dir);
+    std::fs::write(dir.join("scrub.toml"), SCRUB_TOML).unwrap();
+    let envs = [("AUTUMN_DATABASE__URL", url.as_str())];
+
+    let (_o, stderr) = run_autumn_fail(dir, &["db", "scrub"], &envs);
+    assert!(
+        stderr.contains("users.bio") && stderr.contains("drifted"),
+        "a stale declaration must be reported: {stderr}"
+    );
+}
+
+/// AC #5: the production profile guard, identical in shape to `autumn db drop`.
+#[tokio::test]
+#[ignore = "requires Docker (testcontainers)"]
+async fn scrub_refuses_a_production_profile_without_force() {
+    let (_pg, host, port) = start_postgres().await;
+    let url = format!("postgres://postgres:postgres@{host}:{port}/postgres");
+    let client = connect(&url).await;
+    client.batch_execute(FIXTURE_SCHEMA).await.unwrap();
+    client
+        .batch_execute(FIXTURE_FRAMEWORK_TABLES)
+        .await
+        .unwrap();
+    client.batch_execute(FIXTURE_ROWS).await.unwrap();
+
+    let tmp = tempfile::tempdir().unwrap();
+    let dir = tmp.path();
+    write_project_sources(dir);
+    std::fs::write(dir.join("scrub.toml"), SCRUB_TOML).unwrap();
+
+    let prod_envs = [
+        ("AUTUMN_DATABASE__URL", url.as_str()),
+        ("AUTUMN_ENV", "prod"),
+    ];
+    let (_o, stderr) = run_autumn_fail(dir, &["db", "scrub"], &prod_envs);
+    assert!(
+        stderr.contains("Refusing to scrub") && stderr.contains("prod"),
+        "prod must be refused without --force: {stderr}"
+    );
+    assert!(
+        !stderr.contains("postgres://"),
+        "the refusal must never print the connection URL: {stderr}"
+    );
+    assert!(
+        !occurrences(&client, "Alice Realname").await.is_empty(),
+        "a refused scrub must not have written anything"
+    );
+
+    // With --force it proceeds (the operator has said they mean it).
+    run_autumn_ok(dir, &["db", "scrub", "--force"], &prod_envs);
+    assert_no_secrets_survive(&client).await;
+}
+
+/// AC #1's artifact output: `--output` re-dumps the scrubbed database, so the
+/// artifact handed to a teammate is itself scrubbed.
+#[tokio::test]
+#[ignore = "requires Docker (testcontainers) and pg_dump/pg_restore on PATH"]
+async fn scrub_output_writes_a_scrubbed_artifact() {
+    let (_pg, host, port) = start_postgres().await;
+    let url = format!("postgres://postgres:postgres@{host}:{port}/postgres");
+    let client = connect(&url).await;
+    client.batch_execute(FIXTURE_SCHEMA).await.unwrap();
+    client
+        .batch_execute(FIXTURE_FRAMEWORK_TABLES)
+        .await
+        .unwrap();
+    client.batch_execute(FIXTURE_ROWS).await.unwrap();
+
+    let tmp = tempfile::tempdir().unwrap();
+    let dir = tmp.path();
+    write_project_sources(dir);
+    std::fs::write(dir.join("scrub.toml"), SCRUB_TOML).unwrap();
+    let envs = [("AUTUMN_DATABASE__URL", url.as_str())];
+
+    run_autumn_ok(dir, &["db", "scrub", "--output", "scrubbed"], &envs);
+
+    let run_dir = newest_run_dir(&dir.join("scrubbed").join("dev"));
+    let dump = std::fs::read(run_dir.join("control.dump")).expect("scrubbed artifact");
+    // A custom-format dump is compressed, so search the plain-text listing
+    // instead: `pg_restore` is on PATH for this test by construction.
+    let listing = Command::new("pg_restore")
+        .arg("--file")
+        .arg(run_dir.join("plain.sql"))
+        .arg(run_dir.join("control.dump"))
+        .status()
+        .expect("pg_restore to plain SQL");
+    assert!(listing.success(), "pg_restore --file should succeed");
+    let plain = std::fs::read_to_string(run_dir.join("plain.sql")).unwrap();
+    assert!(!dump.is_empty(), "the artifact must not be empty");
+    for secret in SECRETS {
+        assert!(
+            !plain.contains(secret),
+            "the scrubbed artifact still contains {secret:?}"
+        );
+    }
+}
+
+/// The newest run directory under a backup profile root.
+fn newest_run_dir(profile_root: &Path) -> PathBuf {
+    let mut runs: Vec<PathBuf> = std::fs::read_dir(profile_root)
+        .unwrap_or_else(|e| panic!("reading {}: {e}", profile_root.display()))
+        .map(|e| e.unwrap().path())
+        .filter(|p| p.is_dir())
+        .collect();
+    runs.sort();
+    runs.pop()
+        .unwrap_or_else(|| panic!("no backup run under {}", profile_root.display()))
+}
+
+// ─── AC #4: the app boots against the scrubbed database ─────────────────────
+
+/// RAII guard that kills the child server on drop (even on test failure).
+struct ServerGuard(std::process::Child);
+
+impl Drop for ServerGuard {
+    fn drop(&mut self) {
+        let _ = self.0.kill();
+        let _ = self.0.wait();
+    }
+}
+
+fn patch_generated_cargo_toml(project_dir: &Path) {
+    let manifest = project_dir.join("Cargo.toml");
+    let mut content = std::fs::read_to_string(&manifest).expect("read generated Cargo.toml");
+    let workspace_root = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("workspace root");
+    let autumn_web = workspace_root.join("autumn");
+    write!(
+        content,
+        "\n[patch.crates-io]\nautumn-web = {{ path = \"{}\" }}\n",
+        autumn_web.display().to_string().replace('\\', "/")
+    )
+    .expect("write to String is infallible");
+    std::fs::write(&manifest, content).expect("patch generated Cargo.toml");
+}
+
+/// The last acceptance criterion the round-trip test cannot cover on its own:
+/// after a scrub, `autumn migrate` reports a clean status and a real generated
+/// app boots against the scrubbed database and answers `GET /health` with 200.
+///
+/// Scaffolds, migrates, seeds, scrubs, re-checks migrations and then compiles
+/// and boots the app, so it needs the `diesel` CLI on `PATH` in addition to
+/// Docker — it runs in the generator-conformance Postgres gate.
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "slow: compiles and boots a generated app; needs Docker + diesel CLI"]
+#[allow(clippy::too_many_lines)]
+async fn scrubbed_database_migrates_clean_and_boots_the_app() {
+    let (_pg, host, port) = start_postgres().await;
+    let url = format!("postgres://postgres:postgres@{host}:{port}/postgres");
+
+    // ── Scaffold a real app ─────────────────────────────────────────────────
+    let tmp = tempfile::tempdir().unwrap();
+    let new_output = Command::new(autumn_bin())
+        .args(["new", "scrub-app"])
+        .current_dir(tmp.path())
+        .output()
+        .expect("run `autumn new`");
+    assert!(
+        new_output.status.success(),
+        "autumn new failed:\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&new_output.stdout),
+        String::from_utf8_lossy(&new_output.stderr),
+    );
+    let project = tmp.path().join("scrub-app");
+    patch_generated_cargo_toml(&project);
+    write_project_sources(&project);
+    std::fs::write(project.join("scrub.toml"), SCRUB_TOML).unwrap();
+
+    // ── A migration carrying the PII fixture ────────────────────────────────
+    let migration = project
+        .join("migrations")
+        .join("20260101000000_create_scrub_fixture");
+    std::fs::create_dir_all(&migration).unwrap();
+    std::fs::write(migration.join("up.sql"), FIXTURE_SCHEMA).unwrap();
+    std::fs::write(
+        migration.join("down.sql"),
+        "DROP TABLE comments; DROP TABLE users;",
+    )
+    .unwrap();
+
+    let envs = [("AUTUMN_DATABASE__URL", url.as_str())];
+    run_autumn_ok(&project, &["migrate"], &envs);
+
+    let client = connect(&url).await;
+    client.batch_execute(FIXTURE_ROWS).await.unwrap();
+
+    // ── Scrub ───────────────────────────────────────────────────────────────
+    run_autumn_ok(&project, &["db", "scrub"], &envs);
+    assert_no_secrets_survive(&client).await;
+
+    // ── `autumn migrate` reports a clean status against the scrubbed DB ─────
+    let (_o, migrate_err) = run_autumn_ok(&project, &["migrate"], &envs);
+    assert!(
+        !migrate_err.contains("Pending migrations")
+            && !migrate_err.to_lowercase().contains("error"),
+        "migrations must be clean against the scrubbed database: {migrate_err}"
+    );
+
+    // ── The app boots against it and answers GET /health ────────────────────
+    let build = Command::new("cargo")
+        .args(["build"])
+        .current_dir(&project)
+        .output()
+        .expect("cargo build");
+    assert!(
+        build.status.success(),
+        "cargo build failed:\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&build.stdout),
+        String::from_utf8_lossy(&build.stderr),
+    );
+
+    let app_port = {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind ephemeral port");
+        listener.local_addr().unwrap().port()
+    };
+    let child = Command::new("cargo")
+        .args(["run"])
+        .current_dir(&project)
+        .env("AUTUMN_SERVER__PORT", app_port.to_string())
+        .env("AUTUMN_DATABASE__URL", &url)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn the generated app");
+    let _guard = ServerGuard(child);
+
+    let base = format!("http://127.0.0.1:{app_port}");
+    let client_http = reqwest::Client::new();
+    let mut status = None;
+    for _ in 0..60 {
+        if let Ok(resp) = client_http.get(format!("{base}/health")).send().await {
+            status = Some(resp.status().as_u16());
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(500)).await;
+    }
+    assert_eq!(
+        status,
+        Some(200),
+        "the app must boot against the scrubbed database and answer GET /health with 200"
+    );
+}

--- a/autumn-cli/tests/integration/db_scrub.rs
+++ b/autumn-cli/tests/integration/db_scrub.rs
@@ -381,7 +381,7 @@ async fn scrub_round_trip_leaves_zero_original_values() {
 
     // ── Fail-closed: with no declaration the scrub refuses ──────────────────
     let staging_envs = [("AUTUMN_DATABASE__URL", staging_url.as_str())];
-    let (_o, refusal) = run_autumn_fail(
+    let (stanza, refusal) = run_autumn_fail(
         dir,
         &["db", "scrub", "--artifact", run_dir.to_str().unwrap()],
         &staging_envs,
@@ -394,9 +394,13 @@ async fn scrub_round_trip_leaves_zero_original_values() {
         refusal.contains("users.bio") && refusal.contains("users.role"),
         "the refusal must list the unclassified columns: {refusal}"
     );
+    // On STDOUT, not stderr: `run()` prints the stanza with `println!` so that
+    // `autumn db scrub --check 2>/dev/null >> scrub.toml` appends a valid
+    // fragment rather than a wall of interleaved prose. Asserting it on stderr
+    // asserted against the one stream it is deliberately kept out of.
     assert!(
-        refusal.contains("[tables.users.pii]"),
-        "the refusal must print a paste-ready stanza: {refusal}"
+        stanza.contains("[tables.users.pii]"),
+        "the refusal must print a paste-ready stanza on stdout: {stanza}"
     );
     // The restore has already run by the time classification can see the schema,
     // so the refusal must say — loudly — that the target now holds raw data.
@@ -560,7 +564,7 @@ async fn scrub_anonymizes_a_resolved_database_url_in_place() {
     // `--check` proves the classification is complete and writes nothing.
     let (_o, check_err) = run_autumn_ok(dir, &["db", "scrub", "--check"], &envs);
     assert!(
-        check_err.contains("Every column is classified"),
+        check_err.contains("Every column in `public` is classified"),
         "check should confirm a complete classification: {check_err}"
     );
     assert!(

--- a/autumn-cli/tests/integration/db_scrub.rs
+++ b/autumn-cli/tests/integration/db_scrub.rs
@@ -580,9 +580,15 @@ async fn scrub_anonymizes_a_resolved_database_url_in_place() {
 
     // `--dry-run` prints the statement and still writes nothing.
     let (_o, dry_err) = run_autumn_ok(dir, &["db", "scrub", "--dry-run"], &envs);
+    // Schema-qualified on purpose — do not "simplify" this to a bare
+    // `UPDATE "users"`. Every catalog read that built the plan is scoped to
+    // `public`, so the writes are too: under a database- or role-level
+    // `search_path` (which Autumn supports for tenant schemas) a bare
+    // identifier would resolve to a DIFFERENT table than the one classified,
+    // leaving the classified rows unscrubbed. This assertion pins that.
     assert!(
-        dry_err.contains("UPDATE \"users\" SET"),
-        "dry run should print the statement: {dry_err}"
+        dry_err.contains("UPDATE \"public\".\"users\" SET"),
+        "dry run should print the schema-qualified statement: {dry_err}"
     );
     assert!(
         !occurrences(&client, "Alice Realname").await.is_empty(),

--- a/autumn-cli/tests/integration/db_scrub.rs
+++ b/autumn-cli/tests/integration/db_scrub.rs
@@ -214,8 +214,8 @@ pub fn gdpr_registry() -> GdprRegistry {
 /// incidental setup, and it goes through the same `autumn credentials edit`
 /// an operator would use rather than reaching past the CLI.
 ///
-/// Both profiles get a key: the tests that exercise the production-profile
-/// refusal must fail on THAT guard, not on a missing key.
+/// Every profile the tests drive gets a key, so a test that exercises the
+/// production-profile refusal fails on THAT guard rather than on a missing key.
 fn write_encryption_credentials(dir: &Path) {
     let editor = dir.join("fixture-editor.sh");
     std::fs::write(
@@ -233,7 +233,12 @@ fn write_encryption_credentials(dir: &Path) {
         std::fs::set_permissions(&editor, std::fs::Permissions::from_mode(0o755)).unwrap();
     }
 
-    for profile in ["dev", "production"] {
+    // Every profile the tests actually drive, not the ones that sound right:
+    // `AUTUMN_ENV=prod` is what the production-refusal test sets, and `dev` is
+    // the CLI's default when no profile is given. Provisioning "production"
+    // instead of "prod" left the `--force` leg of that test failing on a
+    // missing key rather than exercising the guard it exists to check.
+    for profile in ["dev", "test", "prod", "production"] {
         let output = Command::new(autumn_bin())
             .args(["credentials", "edit", "--env", profile])
             .current_dir(dir)
@@ -330,8 +335,16 @@ async fn scrub_round_trip_leaves_zero_original_values() {
 
     // ── Two databases: the "production" source and the staging target ───────
     let admin = connect(&admin_url).await;
+    // One statement per call, deliberately: `batch_execute` uses the simple
+    // query protocol, and Postgres wraps a MULTI-statement simple query in an
+    // implicit transaction block — where `CREATE DATABASE` is rejected with
+    // `25001 PreventInTransactionBlock`. Sent singly, each runs outside one.
     admin
-        .batch_execute("CREATE DATABASE scrub_source; CREATE DATABASE scrub_staging;")
+        .batch_execute("CREATE DATABASE scrub_source")
+        .await
+        .unwrap();
+    admin
+        .batch_execute("CREATE DATABASE scrub_staging")
         .await
         .unwrap();
 

--- a/autumn-cli/tests/integration/db_scrub.rs
+++ b/autumn-cli/tests/integration/db_scrub.rs
@@ -116,14 +116,16 @@ const FIXTURE_SCHEMA: &str = "\
 /// app-booting test must not create these itself: `autumn migrate` runs the
 /// framework's own migrations, which own `autumn_jobs` with a different shape.
 ///
-/// `autumn_scrub_outbox` is opted into `[framework] purge`; `autumn_jobs` is a
-/// built-in payload carrier left un-purged, so the warning path is exercised too.
+/// `autumn_sync_rows` (a real built-in payload carrier) is opted into
+/// `[framework] purge`; `autumn_jobs` is another one left un-purged, so the
+/// warning path is exercised too. Both are minimal stand-ins for the real
+/// framework tables — the scrub only ever reads their names.
 const FIXTURE_FRAMEWORK_TABLES: &str = "\
-    CREATE TABLE autumn_scrub_outbox ( \
+    CREATE TABLE autumn_sync_rows ( \
         id BIGSERIAL PRIMARY KEY, \
         payload TEXT NOT NULL \
     ); \
-    INSERT INTO autumn_scrub_outbox (payload) \
+    INSERT INTO autumn_sync_rows (payload) \
         VALUES ('{\"to\": \"alice@real-corp.example\"}'); \
     CREATE TABLE autumn_jobs ( \
         id BIGSERIAL PRIMARY KEY, \
@@ -160,7 +162,7 @@ bio = "redact"
 # Framework-owned tables are not column-classified; this app opts into
 # emptying its outbox, whose payloads embed customer addresses.
 [framework]
-purge = ["autumn_scrub_outbox"]
+purge = ["autumn_sync_rows"]
 "#;
 
 /// Write the project files the scrub reads its automatic classification from:
@@ -310,12 +312,13 @@ async fn scrub_round_trip_leaves_zero_original_values() {
 
     // ── Back up the source ──────────────────────────────────────────────────
     let source_envs = [("AUTUMN_DATABASE__URL", source_url.as_str())];
-    let (_o, backup_err) = run_autumn_ok(dir, &["db", "backup"], &source_envs);
-    assert!(
-        backup_err.contains("Backup complete") || backup_err.contains("integrity"),
-        "backup should report success: {backup_err}"
-    );
+    run_autumn_ok(dir, &["db", "backup"], &source_envs);
     let run_dir = newest_run_dir(&dir.join("backups").join("dev"));
+    assert!(
+        run_dir.join("manifest.json").is_file() && run_dir.join("control.dump").is_file(),
+        "the backup must have produced a real artifact, not just a log line: {}",
+        run_dir.display()
+    );
 
     // ── Fail-closed: with no declaration the scrub refuses ──────────────────
     let staging_envs = [("AUTUMN_DATABASE__URL", staging_url.as_str())];
@@ -366,7 +369,7 @@ async fn scrub_round_trip_leaves_zero_original_values() {
     // Framework-owned tables are outside the classified universe: the opted-in
     // one is emptied, and the one left alone is warned about by name.
     assert!(
-        scrub_err.contains("autumn_scrub_outbox") && scrub_err.contains("emptied"),
+        scrub_err.contains("autumn_sync_rows") && scrub_err.contains("emptied"),
         "the opted-in framework table must be emptied: {scrub_err}"
     );
     assert!(
@@ -394,7 +397,7 @@ async fn scrub_round_trip_leaves_zero_original_values() {
     assert_eq!(distinct_emails, 2, "the UNIQUE email column stays unique");
 
     let outbox_rows: i64 = staging
-        .query_one("SELECT count(*) FROM autumn_scrub_outbox", &[])
+        .query_one("SELECT count(*) FROM autumn_sync_rows", &[])
         .await
         .unwrap()
         .get(0);
@@ -506,7 +509,7 @@ async fn scrub_anonymizes_a_resolved_database_url_in_place() {
         "--check must not write anything"
     );
     let outbox_before: i64 = client
-        .query_one("SELECT count(*) FROM autumn_scrub_outbox", &[])
+        .query_one("SELECT count(*) FROM autumn_sync_rows", &[])
         .await
         .unwrap()
         .get(0);
@@ -554,6 +557,19 @@ async fn a_newly_added_column_breaks_a_previously_passing_scrub() {
         .batch_execute("ALTER TABLE users ADD COLUMN ssn TEXT;")
         .await
         .unwrap();
+
+    // `--check` is the gate the docs tell teams to put in CI, so it is the one
+    // that has to go red — a plain `db scrub` failing would not prove it.
+    let (check_out, check_err) = run_autumn_fail(dir, &["db", "scrub", "--check"], &envs);
+    assert!(
+        check_err.contains("users.ssn"),
+        "--check must name the undeclared column: {check_err}"
+    );
+    assert!(
+        check_out.contains("[tables.users.pii]") && check_out.contains("ssn = \"auto\""),
+        "the paste-ready stanza must go to stdout so it can be appended to \
+         scrub.toml: {check_out}"
+    );
 
     let (_o, stderr) = run_autumn_fail(dir, &["db", "scrub"], &envs);
     assert!(
@@ -699,6 +715,26 @@ fn newest_run_dir(profile_root: &Path) -> PathBuf {
 /// RAII guard that kills the child server on drop (even on test failure).
 struct ServerGuard(std::process::Child);
 
+impl ServerGuard {
+    /// Whatever the child has written so far, for a failure message. Reading
+    /// the pipes also keeps a chatty app from blocking on a full buffer.
+    fn drain(&mut self) -> String {
+        use std::io::Read as _;
+        let mut out = String::new();
+        if let Some(stdout) = self.0.stdout.as_mut() {
+            let mut buf = String::new();
+            let _ = stdout.read_to_string(&mut buf);
+            out.push_str(&buf);
+        }
+        if let Some(stderr) = self.0.stderr.as_mut() {
+            let mut buf = String::new();
+            let _ = stderr.read_to_string(&mut buf);
+            out.push_str(&buf);
+        }
+        out
+    }
+}
+
 impl Drop for ServerGuard {
     fn drop(&mut self) {
         let _ = self.0.kill();
@@ -722,9 +758,11 @@ fn patch_generated_cargo_toml(project_dir: &Path) {
     std::fs::write(&manifest, content).expect("patch generated Cargo.toml");
 }
 
-/// The last acceptance criterion the round-trip test cannot cover on its own:
-/// after a scrub, `autumn migrate` reports a clean status and a real generated
-/// app boots against the scrubbed database and answers `GET /health` with 200.
+/// The one criterion the Docker round-trip cannot cover on its own: after the
+/// FULL drill (seed → `db backup` → `db scrub --artifact` → zero original
+/// values), `autumn migrate` reports a clean status against the scrubbed
+/// database and a real generated app boots against it and answers `GET /health`
+/// with 200.
 ///
 /// Scaffolds, migrates, seeds, scrubs, re-checks migrations and then compiles
 /// and boots the app, so it needs the `diesel` CLI on `PATH` in addition to
@@ -772,16 +810,27 @@ async fn scrubbed_database_migrates_clean_and_boots_the_app() {
     let client = connect(&url).await;
     client.batch_execute(FIXTURE_ROWS).await.unwrap();
 
-    // ── Scrub ───────────────────────────────────────────────────────────────
-    run_autumn_ok(&project, &["db", "scrub"], &envs);
+    // ── The full AC #6 chain in one test: backup → scrub the restored copy ──
+    // Going through an artifact here (rather than scrubbing the live URL) is
+    // what makes this test cover the whole documented drill end to end: seed →
+    // backup → restore → scrub → assert → boot.
+    run_autumn_ok(&project, &["db", "backup"], &envs);
+    let run_dir = newest_run_dir(&project.join("backups").join("dev"));
+    run_autumn_ok(
+        &project,
+        &["db", "scrub", "--artifact", run_dir.to_str().unwrap()],
+        &envs,
+    );
     assert_no_secrets_survive(&client).await;
 
     // ── `autumn migrate` reports a clean status against the scrubbed DB ─────
     let (_o, migrate_err) = run_autumn_ok(&project, &["migrate"], &envs);
+    // Assert the POSITIVE signal `autumn migrate` actually prints. A negative
+    // assertion on a string the command never emits would pass on empty output.
     assert!(
-        !migrate_err.contains("Pending migrations")
-            && !migrate_err.to_lowercase().contains("error"),
-        "migrations must be clean against the scrubbed database: {migrate_err}"
+        migrate_err.contains("Migrations are already up to date.")
+            || migrate_err.contains("Migrations applied successfully."),
+        "migrations must report a clean status against the scrubbed database: {migrate_err}"
     );
 
     // ── The app boots against it and answers GET /health ────────────────────
@@ -810,21 +859,29 @@ async fn scrubbed_database_migrates_clean_and_boots_the_app() {
         .stderr(Stdio::piped())
         .spawn()
         .expect("spawn the generated app");
-    let _guard = ServerGuard(child);
+    let mut guard = ServerGuard(child);
 
     let base = format!("http://127.0.0.1:{app_port}");
     let client_http = reqwest::Client::new();
     let mut status = None;
     for _ in 0..60 {
+        // A child that died at boot must fail fast with ITS OWN output, not
+        // after 30 s of silence.
+        if let Some(exit) = guard.0.try_wait().expect("poll the app process") {
+            let output = guard.drain();
+            panic!("the generated app exited before serving: {exit}\n{output}");
+        }
         if let Ok(resp) = client_http.get(format!("{base}/health")).send().await {
             status = Some(resp.status().as_u16());
             break;
         }
         tokio::time::sleep(Duration::from_millis(500)).await;
     }
+    let output = guard.drain();
     assert_eq!(
         status,
         Some(200),
-        "the app must boot against the scrubbed database and answer GET /health with 200"
+        "the app must boot against the scrubbed database and answer GET /health \
+         with 200\n{output}"
     );
 }

--- a/autumn-cli/tests/integration/db_scrub.rs
+++ b/autumn-cli/tests/integration/db_scrub.rs
@@ -759,32 +759,39 @@ fn newest_run_dir(profile_root: &Path) -> PathBuf {
 // ─── AC #4: the app boots against the scrubbed database ─────────────────────
 
 /// RAII guard that kills the child server on drop (even on test failure).
-struct ServerGuard(std::process::Child);
+/// A running app plus the files its output is redirected to.
+struct ServerGuard {
+    child: std::process::Child,
+    stdout: PathBuf,
+    stderr: PathBuf,
+}
 
 impl ServerGuard {
-    /// Whatever the child has written so far, for a failure message. Reading
-    /// the pipes also keeps a chatty app from blocking on a full buffer.
+    /// Everything the app has written, for a failure message.
+    ///
+    /// The output goes to FILES rather than pipes, which is load-bearing rather
+    /// than incidental. Reading a pipe with `read_to_string` blocks until EOF,
+    /// and EOF arrives only once every writer has closed it. A healthy server
+    /// never closes its pipes, so draining one would block until the workflow's
+    /// 90-minute timeout — the success path would hang instead of passing,
+    /// which is precisely the path this test exists to prove. The failure paths
+    /// hid it: a child that already died has reached EOF, so the read returns.
+    ///
+    /// Killing the child first is not enough either. The app is spawned through
+    /// `cargo run`, so the server is a GRANDchild that inherits these handles:
+    /// killing `cargo` leaves the server holding the pipe open. Files sidestep
+    /// the whole question — no EOF to wait for, no pipe buffer to fill, and the
+    /// output survives however the process tree happens to die.
     fn drain(&mut self) -> String {
-        use std::io::Read as _;
-        let mut out = String::new();
-        if let Some(stdout) = self.0.stdout.as_mut() {
-            let mut buf = String::new();
-            let _ = stdout.read_to_string(&mut buf);
-            out.push_str(&buf);
-        }
-        if let Some(stderr) = self.0.stderr.as_mut() {
-            let mut buf = String::new();
-            let _ = stderr.read_to_string(&mut buf);
-            out.push_str(&buf);
-        }
-        out
+        let read = |path: &PathBuf| std::fs::read_to_string(path).unwrap_or_default();
+        format!("{}{}", read(&self.stdout), read(&self.stderr))
     }
 }
 
 impl Drop for ServerGuard {
     fn drop(&mut self) {
-        let _ = self.0.kill();
-        let _ = self.0.wait();
+        let _ = self.child.kill();
+        let _ = self.child.wait();
     }
 }
 
@@ -896,16 +903,26 @@ async fn scrubbed_database_migrates_clean_and_boots_the_app() {
         let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind ephemeral port");
         listener.local_addr().unwrap().port()
     };
+    let stdout_path = project.join("app-stdout.log");
+    let stderr_path = project.join("app-stderr.log");
     let child = Command::new("cargo")
         .args(["run"])
         .current_dir(&project)
         .env("AUTUMN_SERVER__PORT", app_port.to_string())
         .env("AUTUMN_DATABASE__URL", &url)
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
+        .stdout(Stdio::from(
+            std::fs::File::create(&stdout_path).expect("create the app stdout log"),
+        ))
+        .stderr(Stdio::from(
+            std::fs::File::create(&stderr_path).expect("create the app stderr log"),
+        ))
         .spawn()
         .expect("spawn the generated app");
-    let mut guard = ServerGuard(child);
+    let mut guard = ServerGuard {
+        child,
+        stdout: stdout_path,
+        stderr: stderr_path,
+    };
 
     let base = format!("http://127.0.0.1:{app_port}");
     let client_http = reqwest::Client::new();
@@ -913,7 +930,7 @@ async fn scrubbed_database_migrates_clean_and_boots_the_app() {
     for _ in 0..60 {
         // A child that died at boot must fail fast with ITS OWN output, not
         // after 30 s of silence.
-        if let Some(exit) = guard.0.try_wait().expect("poll the app process") {
+        if let Some(exit) = guard.child.try_wait().expect("poll the app process") {
             let output = guard.drain();
             panic!("the generated app exited before serving: {exit}\n{output}");
         }

--- a/autumn-cli/tests/integration/db_scrub.rs
+++ b/autumn-cli/tests/integration/db_scrub.rs
@@ -778,11 +778,11 @@ impl ServerGuard {
     /// hid it: a child that already died has reached EOF, so the read returns.
     ///
     /// Killing the child first is not enough either. The app is spawned through
-    /// `cargo run`, so the server is a GRANDchild that inherits these handles:
+    /// `cargo run`, so the server is a grandchild that inherits these handles:
     /// killing `cargo` leaves the server holding the pipe open. Files sidestep
     /// the whole question — no EOF to wait for, no pipe buffer to fill, and the
     /// output survives however the process tree happens to die.
-    fn drain(&mut self) -> String {
+    fn drain(&self) -> String {
         let read = |path: &PathBuf| std::fs::read_to_string(path).unwrap_or_default();
         format!("{}{}", read(&self.stdout), read(&self.stderr))
     }

--- a/autumn-cli/tests/integration/db_scrub.rs
+++ b/autumn-cli/tests/integration/db_scrub.rs
@@ -202,6 +202,52 @@ pub fn gdpr_registry() -> GdprRegistry {
 "#,
     )
     .unwrap();
+    write_encryption_credentials(dir);
+}
+
+/// Give the fixture app real `active_record_encryption` credentials.
+///
+/// `User::api_token` is `#[encrypted]`, and a scrub REFUSES to rewrite an
+/// encrypted column without the target's key — writing plaintext there would
+/// make every later repository read of that row fail as malformed ciphertext.
+/// So provisioning the key is part of the drill these tests cover, not
+/// incidental setup, and it goes through the same `autumn credentials edit`
+/// an operator would use rather than reaching past the CLI.
+///
+/// Both profiles get a key: the tests that exercise the production-profile
+/// refusal must fail on THAT guard, not on a missing key.
+fn write_encryption_credentials(dir: &Path) {
+    let editor = dir.join("fixture-editor.sh");
+    std::fs::write(
+        &editor,
+        "#!/bin/sh\ncat > \"$1\" <<'TOML'\n[active_record_encryption]\n\
+         primary_key = \"0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef\"\n\
+         deterministic_key = \"fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210\"\n\
+         key_derivation_salt = \"00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff\"\n\
+         TOML\n",
+    )
+    .unwrap();
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&editor, std::fs::Permissions::from_mode(0o755)).unwrap();
+    }
+
+    for profile in ["dev", "production"] {
+        let output = Command::new(autumn_bin())
+            .args(["credentials", "edit", "--env", profile])
+            .current_dir(dir)
+            .env("EDITOR", &editor)
+            .env("VISUAL", &editor)
+            .output()
+            .expect("run `autumn credentials edit`");
+        assert!(
+            output.status.success(),
+            "provisioning {profile} credentials failed:\nstdout: {}\nstderr: {}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr),
+        );
+    }
 }
 
 /// Every occurrence of `needle` anywhere in any character-typed column of any

--- a/autumn-cli/tests/integration/mod.rs
+++ b/autumn-cli/tests/integration/mod.rs
@@ -4,6 +4,7 @@ mod cloud_native_scaffold;
 mod console;
 mod db;
 mod db_pull;
+mod db_scrub;
 mod deploy;
 mod edge;
 mod generate_json_postgres;

--- a/docs/guide/daemon.md
+++ b/docs/guide/daemon.md
@@ -150,6 +150,11 @@ app that bundles them), install the PostgreSQL client tools or point
 `AUTUMN_PG_BIN_DIR` at their `bin` directory. `autumn doctor` warns when they are
 missing.
 
+> **Copying a backup to staging or a laptop?** Run it through
+> [`autumn db scrub`](data-scrubbing.md) first — it anonymizes every
+> PII-classified column and refuses (rather than silently passing data through)
+> when a column has not been classified at all.
+
 ### Scheduling
 
 **cron** — a nightly backup with 7-day retention:

--- a/docs/guide/data-scrubbing.md
+++ b/docs/guide/data-scrubbing.md
@@ -130,7 +130,8 @@ paste-ready stanza:
     - users.full_name
     - users.role
   Declare each one in scrub.toml — under [tables.<table>.pii] to replace it, or
-  in `safe` to keep it verbatim.
+  in `safe` to keep it verbatim. Run `autumn db scrub --check` for a paste-ready
+  starting point.
 
 # Paste into scrub.toml, then replace `auto` with an explicit strategy
 # (email/name/phone/redact/null/uuid/bytes/json/zero/epoch), or move the
@@ -149,11 +150,16 @@ Paste it, move the genuinely-safe columns into `safe = [...]`, and re-run.
 
 ```yaml
 - name: PII classification is complete
-  run: autumn db scrub --check
+  run: |
+    autumn db create
+    autumn migrate
+    autumn db scrub --check
 ```
 
-`--check` writes nothing and exits non-zero when any column is unclassified, so
-a pull request that adds a column without declaring it fails before it merges.
+`--check` reads the schema from a live database — the same one `autumn migrate`
+resolves — so run it after the migration step your CI already has. It writes
+nothing and exits non-zero when any column is unclassified, so a pull request
+that adds a column without declaring it fails before it merges.
 That is the property no third-party scrubber can offer: the classification is
 checked against the real schema, not against yesterday's config file.
 

--- a/docs/guide/data-scrubbing.md
+++ b/docs/guide/data-scrubbing.md
@@ -222,8 +222,9 @@ scrub should do behind a one-word config key. Schema bookkeeping
 | `encrypted` | A valid ciphertext envelope (chosen automatically for `#[encrypted]` columns; not declarable) | ✅ |
 
 `<token>` is a hash over the row's primary key, salted with the column name —
-`md5` normally, and a wider `sha256` for a column that must stay unique, so a
-length-bounded `varchar(n)` still has room for enough entropy.
+one `md5` normally, and two independently-salted ones concatenated for a column
+that must stay unique, so a length-bounded `varchar(n)` still has room for
+enough entropy.
 That makes every replacement:
 
 - **deterministic** — the same row scrubs to the same value on every run, so

--- a/docs/guide/data-scrubbing.md
+++ b/docs/guide/data-scrubbing.md
@@ -1,0 +1,279 @@
+# Data Scrubbing — Refreshing Staging From Production
+
+The most common reason a team copies a production database is to reproduce a bug
+or rehearse a migration. With [`autumn db backup`](daemon.md#database-backups)
+that copy is one command away — PII and all — onto laptops and shared staging
+boxes.
+
+`autumn db scrub` closes that gap. It rewrites every PII-classified column with
+deterministic, constraint-valid fake values, so the copy still behaves like the
+real database (same row counts, same foreign keys, same uniqueness) while
+carrying none of the real values.
+
+The classification is **fail-closed and schema-driven**: the column universe
+comes from introspecting the live database, not from a config file, so a column
+added yesterday cannot be missing from it. A column that is neither
+PII-classified nor explicitly declared safe aborts the scrub.
+
+> **Postgres only.** Scrubbing targets the same databases `autumn migrate`
+> resolves — the control database plus every configured shard.
+
+---
+
+## The drill: production → staging in one pass
+
+```sh
+# 1. On the production host: take a backup.
+AUTUMN_ENV=prod autumn db backup --keep 7
+
+# 2. Move the run directory to the staging host (scp, rsync, or
+#    `autumn db backup --upload` + `autumn db restore offsite:prod/latest`).
+
+# 3. On the staging host: restore it and scrub it in one command.
+AUTUMN_ENV=staging autumn db scrub \
+    --artifact backups/prod/20260101T020000Z --force
+```
+
+Step 3 restores the artifact into the database the `staging` profile resolves,
+then anonymizes it. `--force` is required because `staging` is not `dev`/`test`
+— the same production guard as `autumn db drop`.
+
+To hand a teammate an artifact that is *already* scrubbed, add `--output`:
+
+```sh
+AUTUMN_ENV=staging autumn db scrub \
+    --artifact backups/prod/20260101T020000Z \
+    --output backups/scrubbed --force
+```
+
+That writes a fresh, self-describing backup run under `backups/scrubbed/` taken
+from the scrubbed database — safe to copy onto a laptop.
+
+You can also scrub a database in place, with no artifact involved:
+
+```sh
+autumn db scrub                 # scrub the resolved dev database
+autumn db scrub --check         # classify only; write nothing (CI)
+autumn db scrub --dry-run       # print the exact SQL; write nothing
+```
+
+---
+
+## The classification workflow
+
+Autumn classifies columns from three sources, in precedence order.
+
+### 1. What the framework already knows
+
+Two sources need **no declaration at all**:
+
+- **`#[encrypted]` model columns.** An at-rest-encrypted column is PII by
+  construction, so it is always scrubbed. A `safe` declaration may **not**
+  override it — that combination is an error.
+- **Tables registered with the GDPR anonymize strategy** — a
+  `GdprRegistry::register(ModelRegistration::anonymize("comments"))` call in your
+  app classifies every non-key column of `comments` as PII. Because that is a
+  table-level signal, a `safe` declaration **may** narrow it. The scanner reads
+  the registration statically, so it needs a string-literal table name; a
+  computed one is reported rather than silently ignored.
+
+Primary- and foreign-key columns are never claimed by the table-level
+inference: rewriting a key would break referential integrity.
+
+### 2. What you declare
+
+Everything else lives in `scrub.toml` at the project root (override with
+`--config`):
+
+```toml
+# scrub.toml
+
+# Columns that are safe in EVERY table — the one-line escape from repeating
+# `id` / `created_at` / `updated_at` in every stanza.
+[defaults]
+safe_columns = ["id", "created_at", "updated_at"]
+
+[tables.users]
+# Reviewed and deliberately kept verbatim.
+safe = ["role", "locale", "is_active"]
+
+[tables.users.pii]
+email = "email"
+full_name = "name"
+phone = "phone"
+bio = "redact"
+last_login_ip = "redact"
+
+[tables.invoices]
+safe = ["amount_cents", "currency", "status"]
+
+[tables.invoices.pii]
+billing_address = "redact"
+```
+
+### 3. Adopting it on an existing schema
+
+You do not have to write that file by hand. Run:
+
+```sh
+autumn db scrub --check
+```
+
+On a schema with undeclared columns it exits non-zero, lists them, and prints a
+paste-ready stanza:
+
+```text
+✗ 4 column(s) are neither PII-classified nor declared safe, so the scrub cannot
+  prove they carry no real data:
+    - users.bio
+    - users.email
+    - users.full_name
+    - users.role
+  Declare each one in scrub.toml — under [tables.<table>.pii] to replace it, or
+  in `safe` to keep it verbatim.
+
+# Paste into scrub.toml, then replace `auto` with an explicit strategy
+# (email/name/phone/redact/null/uuid/bytes/json/zero/epoch), or move the
+# column into that table's `safe = [...]` list if it holds no PII.
+
+[tables.users.pii]
+bio = "auto"
+email = "auto"
+full_name = "auto"
+role = "auto"
+```
+
+Paste it, move the genuinely-safe columns into `safe = [...]`, and re-run.
+
+### Keep it honest in CI
+
+```yaml
+- name: PII classification is complete
+  run: autumn db scrub --check
+```
+
+`--check` writes nothing and exits non-zero when any column is unclassified, so
+a pull request that adds a column without declaring it fails before it merges.
+That is the property no third-party scrubber can offer: the classification is
+checked against the real schema, not against yesterday's config file.
+
+### 4. Framework-owned tables
+
+Introspection deliberately skips `autumn_*` / `_autumn*` tables — exactly as
+`autumn db pull` and `autumn schema pull` do — so their columns are not part of
+the classified universe. Some of them nonetheless carry **app-supplied**
+payloads: a queued job's arguments, an offline-sync row buffer, an experiment
+assignment.
+
+A scrub therefore *warns* about the ones it finds and tells you which they are.
+`api_tokens` is on that list too — production API tokens inherited by a staging
+copy are a live credential leak, not merely a PII one.
+
+To have them emptied as part of the scrub, opt in:
+
+```toml
+[framework]
+purge = ["api_tokens", "autumn_jobs", "autumn_job_tracking", "autumn_sync_pending", "autumn_sync_rows"]
+```
+
+Those `DELETE`s run inside the same transaction as the column rewrites. `purge`
+only accepts framework-owned names (`autumn_*` / `_autumn*`, plus the
+framework's unprefixed tables such as `api_tokens`) — a user table
+listed there is an error, because emptying one outright is never something a
+scrub should do behind a one-word config key. Schema bookkeeping
+(`autumn_migration_checksums`, `_autumn_shard_map`) is never offered.
+
+---
+
+## Replacement strategies
+
+| Strategy | Produces | Unique-safe |
+|---|---|---|
+| `auto` | Derived from the column type (the default for automatically-classified columns) | depends |
+| `email` | `scrubbed+<token>@example.invalid` — syntactically valid, permanently undeliverable | ✅ |
+| `name` | `Scrubbed <token>` | ✅ |
+| `phone` | `+1555<digits>` | ❌ |
+| `redact` | `[scrubbed:<token>]` | ✅ |
+| `null` | `NULL` (refused on a `NOT NULL` column) | ✅ |
+| `uuid` | A deterministic replacement UUID | ✅ |
+| `bytes` | Deterministic replacement bytes | ✅ |
+| `json` | `{"scrubbed": true}` | ❌ |
+| `zero` | `0` / `false` | ❌ |
+| `epoch` | `1970-01-01T00:00:00Z` | ❌ |
+
+`<token>` is an `md5` over the row's primary key, salted with the column name.
+That makes every replacement:
+
+- **deterministic** — the same row scrubs to the same value on every run, so
+  re-running a scrub is idempotent;
+- **unique per row** — a `UNIQUE` column stays unique; and
+- **distinct per column** — two PII columns of one row never collide.
+
+A table with **no** primary key falls back to the physical `ctid`: still unique
+within the statement (so constraints hold), but not stable between runs.
+
+`auto` derives a strategy from the column's type: text columns whose name
+contains `email` get an address, other text is redacted, `uuid`/`bytea`/`jsonb`
+get type-matched fakes, numbers become `0`, booleans `false`, and timestamps the
+epoch. It refuses to guess for a closed-set (enum) or exotic Postgres type — a
+fabricated value would violate the column's `CHECK` — and asks for an explicit
+strategy instead.
+
+---
+
+## What the scrub guarantees
+
+- **Nothing runs against production by accident.** Writing refuses outside the
+  `dev`/`test` profile without `--force`, the same protocol as `autumn db drop`.
+  As defence in depth, a scrub also refuses when the write target is the
+  database an artifact's own (non-dev/test) profile *config file* declares.
+- **A refusal writes nothing.** Classification completes before a single row is
+  touched. The one exception is `--artifact`: the restore has to run before the
+  scrub can read the schema it created, so a refusal *after* a restore leaves
+  unscrubbed data in the target. The command says so in the loudest possible
+  terms, and `autumn db scrub --check` catches an incomplete declaration before
+  any restore happens — run it in CI.
+- **Constraints survive.** PII on a primary- or foreign-key column is refused
+  outright; `null` is refused on a `NOT NULL` column; a constant replacement is
+  refused on a `UNIQUE` column; and a `varchar(n)` bound narrows the generated
+  value (or refuses, rather than truncating into collisions).
+- **`NULL`s stay `NULL`.** A scrub anonymizes values; it never invents them.
+- **It is atomic.** Every statement for one database runs in a single
+  transaction, so a failure can never leave a half-scrubbed database behind —
+  and with shards configured, *every* database is classified before *any* of
+  them is written, so an undeclared column on one shard cannot leave the rest of
+  the topology half anonymized.
+- **Credentials never appear.** No message ever prints a resolved URL.
+
+---
+
+## Limits
+
+- **Postgres only.**
+- **Full-copy only.** Row subsetting/sampling for very large databases is not
+  supported — scrub the whole copy.
+- **Values are fake, not statistically faithful.** Replacements only need to be
+  constraint-valid; there is no synthetic-data modelling or differential
+  privacy.
+- **Composite `UNIQUE` indexes are your responsibility.** Single-column
+  uniqueness is checked at plan time; a multi-column unique index that a
+  constant-valued strategy would violate fails the transaction loudly (and rolls
+  back) rather than being caught up front.
+- **Framework-owned tables are not column-classified**, exactly as `autumn db
+  pull` and `autumn schema pull` skip them. The scrub warns about the ones that
+  carry app-supplied payloads and can empty them on request — see
+  [Framework-owned tables](#4-framework-owned-tables).
+- **The artifact itself is still unscrubbed.** `autumn db scrub --artifact`
+  anonymizes the *database*, not the dump it restored from. Delete the source
+  artifact from the staging host once the scrub succeeds, or hand teammates the
+  `--output` artifact instead.
+
+## See also
+
+- [Database backups](daemon.md#database-backups) — `autumn db backup` /
+  `autumn db restore`, the other half of the drill.
+- [Attribute encryption](attribute-encryption.md) — `#[encrypted]`, one of the
+  two automatic classification sources.
+- [Logging & PII](logging-pii.md) — the log-side scrubber, which is a different
+  thing entirely.
+- [Seeding](seeding.md) — synthetic data when you do not need production shapes.

--- a/docs/guide/data-scrubbing.md
+++ b/docs/guide/data-scrubbing.md
@@ -296,7 +296,10 @@ apply-time error.
 
 - **Postgres only**, and the `public` schema only. A database with base tables
   in another non-system schema is **refused** rather than reported clean over a
-  universe the classifier never looked at.
+  universe the classifier never looked at. The same applies to a table the
+  connecting role cannot see: the scrub compares `pg_class` against what it
+  could actually read and refuses on any difference, so a privilege gap can
+  never look like a clean bill of health.
 - **Row-level security is refused.** A role that does not bypass RLS would update
   only the rows its policies expose and report success — a silent partial scrub.
   Connect as the table owner or a `BYPASSRLS` role.

--- a/docs/guide/data-scrubbing.md
+++ b/docs/guide/data-scrubbing.md
@@ -68,8 +68,15 @@ Autumn classifies columns from three sources, in precedence order.
 Two sources need **no declaration at all**:
 
 - **`#[encrypted]` model columns.** An at-rest-encrypted column is PII by
-  construction, so it is always scrubbed. A `safe` declaration may **not**
-  override it — that combination is an error.
+  construction, so it is always scrubbed — and it is **re-encrypted**, not
+  overwritten with a plain string: the replacement is a valid AEAD envelope
+  produced row by row under the target database's own key, in the same
+  (deterministic or randomized) mode the model declared. Writing plaintext there
+  would make every later repository read of that row fail as malformed
+  ciphertext, so a `safe` declaration may not override the classification and a
+  plaintext strategy is refused outright. `null` is accepted on a nullable
+  encrypted column. The scrub needs the target's `active_record_encryption`
+  credentials for this and refuses before writing anything if they are missing.
 - **Tables registered with the GDPR anonymize strategy** — a
   `GdprRegistry::register(ModelRegistration::anonymize("comments"))` call in your
   app classifies every non-key column of `comments` as PII. Because that is a
@@ -78,7 +85,13 @@ Two sources need **no declaration at all**:
   computed one is reported rather than silently ignored.
 
 Primary- and foreign-key columns are never claimed by the table-level
-inference: rewriting a key would break referential integrity.
+inference: rewriting a key would break referential integrity. Neither are
+generated columns, which Postgres refuses to `UPDATE` and which a scrub of their
+source columns already covers.
+
+`[defaults] safe_columns` is a cross-table convenience, not a per-column review,
+so it does **not** narrow a GDPR anonymize registration — only an explicit
+`[tables.<t>] safe` entry does.
 
 ### 2. What you declare
 
@@ -206,8 +219,11 @@ scrub should do behind a one-word config key. Schema bookkeeping
 | `json` | `{"scrubbed": true}` | ❌ |
 | `zero` | `0` / `false` | ❌ |
 | `epoch` | `1970-01-01T00:00:00Z` | ❌ |
+| `encrypted` | A valid ciphertext envelope (chosen automatically for `#[encrypted]` columns; not declarable) | ✅ |
 
-`<token>` is an `md5` over the row's primary key, salted with the column name.
+`<token>` is a hash over the row's primary key, salted with the column name —
+`md5` normally, and a wider `sha256` for a column that must stay unique, so a
+length-bounded `varchar(n)` still has room for enough entropy.
 That makes every replacement:
 
 - **deterministic** — the same row scrubs to the same value on every run, so
@@ -220,10 +236,15 @@ within the statement (so constraints hold), but not stable between runs.
 
 `auto` derives a strategy from the column's type: text columns whose name
 contains `email` get an address, other text is redacted, `uuid`/`bytea`/`jsonb`
-get type-matched fakes, numbers become `0`, booleans `false`, and timestamps the
-epoch. It refuses to guess for a closed-set (enum) or exotic Postgres type — a
-fabricated value would violate the column's `CHECK` — and asks for an explicit
-strategy instead.
+get type-matched fakes, numbers (including `smallint`, `numeric` and `money`)
+become `0`, booleans `false`, and timestamps — plus `date`, `time` and `timetz` —
+the epoch. It refuses to guess for a Postgres type outside that set rather than
+emit a statement that will fail.
+
+Every strategy is also checked against the column *before* anything is written:
+a text-shaped strategy on an `integer` or an `inet`, a `uuid` on a `text`
+column, or a `null` on a `NOT NULL` column is a plan-time refusal, never an
+apply-time error.
 
 ---
 
@@ -233,16 +254,29 @@ strategy instead.
   `dev`/`test` profile without `--force`, the same protocol as `autumn db drop`.
   As defence in depth, a scrub also refuses when the write target is the
   database an artifact's own (non-dev/test) profile *config file* declares.
+  That guard has its own waiver, `--allow-source-overwrite`, rather than riding
+  on `--force`: the staging drill always passes `--force`, so a guard `--force`
+  waived would be inert in exactly the workflow it exists for.
 - **A refusal writes nothing.** Classification completes before a single row is
   touched. The one exception is `--artifact`: the restore has to run before the
   scrub can read the schema it created, so a refusal *after* a restore leaves
   unscrubbed data in the target. The command says so in the loudest possible
   terms, and `autumn db scrub --check` catches an incomplete declaration before
   any restore happens — run it in CI.
-- **Constraints survive.** PII on a primary- or foreign-key column is refused
-  outright; `null` is refused on a `NOT NULL` column; a constant replacement is
-  refused on a `UNIQUE` column; and a `varchar(n)` bound narrows the generated
-  value (or refuses, rather than truncating into collisions).
+- **Constraints survive.** PII is refused outright on a primary key, on **either
+  side** of any foreign key (including every component of a composite one — so a
+  natural key another table references, like `users.email` ← `orders.user_email`,
+  is protected too), and on a `CHECK`-constrained column, where no fabricated
+  value can be proven to satisfy the predicate. `null` is refused on a `NOT NULL`
+  column and on a `NULLS NOT DISTINCT` unique index; a constant replacement is
+  refused on any column covered by a unique index — composite and partial
+  included; and a `varchar(n)` bound narrows the generated token or refuses,
+  rather than truncating into collisions.
+- **Writes cannot be redirected.** Every statement is `public`-qualified and the
+  transaction pins `search_path`, so a role- or database-level tenant
+  `search_path` cannot send an `UPDATE` to a table nothing classified. The
+  planned tables are locked for the duration, so a row inserted between the
+  classification snapshot and the rewrite cannot slip through.
 - **`NULL`s stay `NULL`.** A scrub anonymizes values; it never invents them.
 - **It is atomic.** Every statement for one database runs in a single
   transaction, so a failure can never leave a half-scrubbed database behind —
@@ -255,16 +289,26 @@ strategy instead.
 
 ## Limits
 
-- **Postgres only.**
+- **Postgres only**, and the `public` schema only. A database with base tables
+  in another non-system schema is **refused** rather than reported clean over a
+  universe the classifier never looked at.
+- **Row-level security is refused.** A role that does not bypass RLS would update
+  only the rows its policies expose and report success — a silent partial scrub.
+  Connect as the table owner or a `BYPASSRLS` role.
+- **Triggers are warned about, not disabled.** An audit or history trigger can
+  copy the pre-scrub row into another table as the rewrite runs. The scrub names
+  the tables carrying user triggers; check or disable them on the copy.
+- **Materialized views are refreshed** (in dependency order) after the rewrite,
+  since they hold their own copy of whatever they selected.
+- **A key column holding PII can only be declared `safe`.** A natural key
+  (`patients(ssn PRIMARY KEY)`) cannot be anonymized in place without rewriting
+  every row that references it, which this command does not do — so it is kept
+  verbatim and listed in the report. Restructure the schema or scrub it by hand.
 - **Full-copy only.** Row subsetting/sampling for very large databases is not
   supported — scrub the whole copy.
 - **Values are fake, not statistically faithful.** Replacements only need to be
   constraint-valid; there is no synthetic-data modelling or differential
   privacy.
-- **Composite `UNIQUE` indexes are your responsibility.** Single-column
-  uniqueness is checked at plan time; a multi-column unique index that a
-  constant-valued strategy would violate fails the transaction loudly (and rolls
-  back) rather than being caught up front.
 - **Framework-owned tables are not column-classified**, exactly as `autumn db
   pull` and `autumn schema pull` skip them. The scrub warns about the ones that
   carry app-supplied payloads and can empty them on request — see

--- a/docs/guide/data-scrubbing.md
+++ b/docs/guide/data-scrubbing.md
@@ -254,10 +254,13 @@ apply-time error.
 - **Nothing runs against production by accident.** Writing refuses outside the
   `dev`/`test` profile without `--force`, the same protocol as `autumn db drop`.
   As defence in depth, a scrub also refuses when the write target is the
-  database an artifact's own (non-dev/test) profile *config file* declares.
-  That guard has its own waiver, `--allow-source-overwrite`, rather than riding
-  on `--force`: the staging drill always passes `--force`, so a guard `--force`
-  waived would be inert in exactly the workflow it exists for.
+  database that **any** non-dev/test profile's *config file* declares — every
+  `autumn-<profile>.toml` in the project is checked, not just the one an
+  artifact's manifest names, so a bare `.dump` with no manifest is not treated
+  as permission to continue. That guard has its own waiver,
+  `--allow-source-overwrite`, rather than riding on `--force`: the staging drill
+  always passes `--force`, so a guard `--force` waived would be inert in exactly
+  the workflow it exists for.
 - **A refusal writes nothing.** Classification completes before a single row is
   touched. The one exception is `--artifact`: the restore has to run before the
   scrub can read the schema it created, so a refusal *after* a restore leaves
@@ -276,8 +279,9 @@ apply-time error.
 - **Writes cannot be redirected.** Every statement is `public`-qualified and the
   transaction pins `search_path`, so a role- or database-level tenant
   `search_path` cannot send an `UPDATE` to a table nothing classified. The
-  planned tables are locked for the duration, so a row inserted between the
-  classification snapshot and the rewrite cannot slip through.
+  planned tables — and the ones `[framework] purge` empties — are locked for the
+  duration, so a row inserted between the classification snapshot and the
+  rewrite cannot slip through.
 - **`NULL`s stay `NULL`.** A scrub anonymizes values; it never invents them.
 - **It is atomic.** Every statement for one database runs in a single
   transaction, so a failure can never leave a half-scrubbed database behind —
@@ -299,8 +303,10 @@ apply-time error.
 - **Triggers are warned about, not disabled.** An audit or history trigger can
   copy the pre-scrub row into another table as the rewrite runs. The scrub names
   the tables carrying user triggers; check or disable them on the copy.
-- **Materialized views are refreshed** (in dependency order) after the rewrite,
-  since they hold their own copy of whatever they selected.
+- **Materialized views are refreshed** (in dependency order, inside the scrub's
+  own transaction) since they hold their own copy of whatever they selected — so
+  a refresh the role is not allowed to run rolls the rewrites back rather than
+  committing base tables a stale view contradicts.
 - **A key column holding PII can only be declared `safe`.** A natural key
   (`patients(ssn PRIMARY KEY)`) cannot be anonymized in place without rewriting
   every row that references it, which this command does not do — so it is kept

--- a/docs/guide/data-scrubbing.md
+++ b/docs/guide/data-scrubbing.md
@@ -77,6 +77,17 @@ Two sources need **no declaration at all**:
   plaintext strategy is refused outright. `null` is accepted on a nullable
   encrypted column. The scrub needs the target's `active_record_encryption`
   credentials for this and refuses before writing anything if they are missing.
+  It also refuses if it cannot tell *which* columns are encrypted — a host with
+  the CLI and `scrub.toml` but no `src/models` must name them, with their mode,
+  under `[tables.<t>.encrypted]`:
+
+  ```toml
+  [tables.users.encrypted]
+  api_token = "randomized"
+  email = "deterministic"   # the mode matters: re-encrypting a deterministic
+                            # column in randomized mode leaves ciphertext the
+                            # app can no longer equality-query
+  ```
 - **Tables registered with the GDPR anonymize strategy** — a
   `GdprRegistry::register(ModelRegistration::anonymize("comments"))` call in your
   app classifies every non-key column of `comments` as PII. Because that is a
@@ -273,8 +284,9 @@ apply-time error.
   is protected too), and on a `CHECK`-constrained column, where no fabricated
   value can be proven to satisfy the predicate. `null` is refused on a `NOT NULL`
   column and on a `NULLS NOT DISTINCT` unique index; a constant replacement is
-  refused on any column covered by a unique index — composite and partial
-  included; and a `varchar(n)` bound narrows the generated token or refuses,
+  refused on any column covered by a unique index — composite, partial, and the
+  input columns of a unique *expression* index (`(lower(email))`), whose
+  uniqueness a per-row token cannot preserve through an arbitrary expression; and a `varchar(n)` bound narrows the generated token or refuses,
   rather than truncating into collisions.
 - **Writes cannot be redirected.** Every statement is `public`-qualified and the
   transaction pins `search_path`, so a role- or database-level tenant
@@ -298,8 +310,10 @@ apply-time error.
   in another non-system schema is **refused** rather than reported clean over a
   universe the classifier never looked at. The same applies to a table the
   connecting role cannot see: the scrub compares `pg_class` against what it
-  could actually read and refuses on any difference, so a privilege gap can
-  never look like a clean bill of health.
+  could actually read — tables **and** columns, since privileges are granted per
+  column too — and refuses on any difference, so a privilege gap can never look
+  like a clean bill of health. Foreign tables count as part of that universe: one
+  left pointing at production would otherwise be classified by nothing.
 - **Row-level security is refused.** A role that does not bypass RLS would update
   only the rows its policies expose and report success — a silent partial scrub.
   Connect as the table owner or a `BYPASSRLS` role.

--- a/docs/guide/data-scrubbing.md
+++ b/docs/guide/data-scrubbing.md
@@ -286,7 +286,9 @@ apply-time error.
   column and on a `NULLS NOT DISTINCT` unique index; a constant replacement is
   refused on any column covered by a unique index — composite, partial, and the
   input columns of a unique *expression* index (`(lower(email))`), whose
-  uniqueness a per-row token cannot preserve through an arbitrary expression; and a `varchar(n)` bound narrows the generated token or refuses,
+  uniqueness a per-row token cannot preserve through an arbitrary expression,
+  and the *predicate* columns of a partial unique index, where a rewrite changes
+  which rows the index covers; and a `varchar(n)` bound narrows the generated token or refuses,
   rather than truncating into collisions.
 - **Writes cannot be redirected.** Every statement is `public`-qualified and the
   transaction pins `search_path`, so a role- or database-level tenant
@@ -308,13 +310,16 @@ apply-time error.
 
 - **Postgres only**, and the `public` schema only. A database with base tables
   in another non-system schema is **refused** rather than reported clean over a
-  universe the classifier never looked at. The same applies to a table the
+  universe the classifier never looked at — and a schema holding only a
+  *materialized view* counts, since it keeps its own copy of whatever it
+  selected from `public`. The same applies to a table the
   connecting role cannot see: the scrub compares `pg_class` against what it
   could actually read — tables **and** columns, since privileges are granted per
   column too — and refuses on any difference, so a privilege gap can never look
   like a clean bill of health. Foreign tables count as part of that universe: one
   left pointing at production would otherwise be classified by nothing.
-- **Row-level security is refused.** A role that does not bypass RLS would update
+- **Row-level security is refused**, for the tables the scrub rewrites *and* the
+  ones `[framework] purge` empties. A role that does not bypass RLS would touch
   only the rows its policies expose and report success — a silent partial scrub.
   Connect as the table owner or a `BYPASSRLS` role.
 - **Triggers are warned about, not disabled.** An audit or history trigger can

--- a/docs/guide/deployment.md
+++ b/docs/guide/deployment.md
@@ -2864,6 +2864,30 @@ step. Recommended before production deploys.
 
 ---
 
+## Refreshing staging from production
+
+Copying a production database into staging or onto a laptop is the fastest way
+to reproduce a bug — and the fastest way to leak customer PII. Autumn ships the
+whole loop:
+
+```sh
+AUTUMN_ENV=prod    autumn db backup --keep 7                       # 1. dump
+#                  ... move the run directory to the staging host ...
+AUTUMN_ENV=staging autumn db scrub --artifact backups/prod/<run> --force
+```
+
+The scrub restores the artifact into the staging database and rewrites every
+PII-classified column with constraint-valid fake values. Classification is
+fail-closed — a column that is neither classified nor explicitly declared safe
+aborts the scrub — so a newly added column can never silently carry real data
+into staging. Add `autumn db scrub --check` to CI to keep the declaration
+honest.
+
+See the [Data Scrubbing guide](data-scrubbing.md) for the classification
+workflow, the replacement strategies, and the full drill.
+
+---
+
 ## Next steps
 
 Once the container is running:

--- a/skills/autumn-web/SKILL.md
+++ b/skills/autumn-web/SKILL.md
@@ -2194,6 +2194,7 @@ autumn test                      # provision/target an isolated *_test DB, migra
 autumn test --reset -- --nocapture   # drop+recreate the test DB; forward args to the harness
 autumn db backup --keep 7        # dump control DB + shards to ./backups/<profile>/<ts>/; db restore <artifact> reverses it
 autumn db backup --upload --keep 7   # + upload each verified run offsite (S3/MinIO/R2); db offsite list; db restore offsite:<profile>/latest  # (0.6.0)
+autumn db scrub --artifact backups/prod/<run> --force   # restore a prod backup into staging, then anonymize every PII column; --check for CI
 autumn seed --count 50 --model Post  # generate+insert 50 faked rows via the model's factory (both flags together)
 autumn serve --role worker       # run only workers + scheduler (web/worker split); also --role web|combined
 autumn console                   # data playground: scaffolds src/bin/playground.rs (pre-wired config+pool), then builds and runs it; alias `autumn c`
@@ -2392,6 +2393,66 @@ prunes to the newest N runs. `autumn db restore <ARTIFACT> [--shard NAME]
 [--force]` verifies every artifact before touching a database and is gated by the
 same production guard as `db drop` (refuses non-dev/test without `--force`). See
 `docs/guide/deployment.md`.
+
+### `autumn db scrub` (issue #1602)
+
+`autumn db scrub [--artifact ARTIFACT] [--output DIR] [--config PATH] [--check]
+[--dry-run] [--force]` turns a production database — or an `autumn db backup`
+artifact restored into the resolved target — into an anonymized copy safe for
+staging/dev. It rewrites every PII-classified column with deterministic,
+constraint-valid fake values, resolving the target(s) exactly like `db backup`
+(control plus every shard) and refusing non-dev/test profiles without `--force`
+(the same guard as `db drop`).
+
+Classification is **fail-closed and schema-driven** — the column universe comes
+from introspecting the live database, not from a config file — in precedence
+order:
+
+1. `[tables.<t>.pii]` in `scrub.toml` (the explicit declaration + strategy);
+2. `#[encrypted]` model columns (PII by construction — a `safe` declaration may
+   NOT override one);
+3. tables registered with the GDPR anonymize strategy
+   (`ModelRegistration::anonymize("t")`, read statically) — every non-key column
+   of that table, narrowable with `safe`.
+
+Anything left over aborts the scrub, listing the columns and printing a
+paste-ready `scrub.toml` stanza. So a newly added column can never silently
+carry real data into staging.
+
+```toml
+# scrub.toml
+[defaults]
+safe_columns = ["id", "created_at", "updated_at"]   # safe in EVERY table
+
+[tables.users]
+safe = ["role", "locale"]          # reviewed, kept verbatim
+
+[tables.users.pii]
+email = "email"                    # scrubbed+<token>@example.invalid
+full_name = "name"
+phone = "phone"
+bio = "redact"
+
+[framework]
+# `autumn_*` tables are outside the classified universe; empty the ones whose
+# rows carry app payloads (opt-in; framework-owned names only).
+purge = ["api_tokens", "autumn_jobs", "autumn_sync_rows"]
+```
+
+Strategies: `auto` (derived from the column type), `email`, `name`, `phone`,
+`redact`, `null`, `uuid`, `bytes`, `json`, `zero`, `epoch`. Each value derives
+from an `md5` over the row's primary key salted with the column name, so a
+`UNIQUE` column stays unique, two columns of one row never collide, and a re-run
+is idempotent. `NULL`s stay `NULL`; PII on a primary- or foreign-key column is
+refused outright (referential integrity survives); `null` is refused on `NOT
+NULL`; a constant-valued strategy is refused on a `UNIQUE` column; a
+`varchar(n)` bound narrows the token or refuses. Every target is classified
+before any is written, and each database's statements run in one transaction.
+
+`--check` classifies and writes nothing, exiting non-zero on any unclassified
+column — run it in CI after the migrate step. `--dry-run` prints the exact SQL.
+`--output DIR` re-dumps the scrubbed database as a fresh backup run. See
+`docs/guide/data-scrubbing.md`.
 
 ### Offsite S3 backups (0.6.0, issue #1619)
 

--- a/skills/autumn-web/SKILL.md
+++ b/skills/autumn-web/SKILL.md
@@ -2455,7 +2455,7 @@ credentials and refuses before writing if they are missing.
 foreign key (composite components included), on `CHECK`-constrained columns, and
 on generated columns; `null` is refused on `NOT NULL` and under `NULLS NOT
 DISTINCT`; a constant-valued strategy is refused on any column in a unique index
-(partial and composite included); a `varchar(n)` bound narrows the token or
+(partial, composite, and expression-index inputs); a `varchar(n)` bound narrows the token or
 refuses. Statements are `public`-qualified with a pinned `search_path` and the
 planned tables are locked; non-`public` schemas, tables the role
 cannot see, and RLS-enabled tables are refused rather than silently

--- a/skills/autumn-web/SKILL.md
+++ b/skills/autumn-web/SKILL.md
@@ -2457,8 +2457,9 @@ on generated columns; `null` is refused on `NOT NULL` and under `NULLS NOT
 DISTINCT`; a constant-valued strategy is refused on any column in a unique index
 (partial and composite included); a `varchar(n)` bound narrows the token or
 refuses. Statements are `public`-qualified with a pinned `search_path` and the
-planned tables are locked; non-`public` schemas and RLS-enabled tables are
-refused rather than silently under-scrubbed; materialized views are refreshed in
+planned tables are locked; non-`public` schemas, tables the role
+cannot see, and RLS-enabled tables are refused rather than silently
+under-scrubbed; materialized views are refreshed in
 dependency order. Every target is classified before any is written, and each
 database's statements run in one transaction.
 

--- a/skills/autumn-web/SKILL.md
+++ b/skills/autumn-web/SKILL.md
@@ -2441,8 +2441,8 @@ purge = ["api_tokens", "autumn_jobs", "autumn_sync_rows"]
 
 Strategies: `auto` (derived from the column type), `email`, `name`, `phone`,
 `redact`, `null`, `uuid`, `bytes`, `json`, `zero`, `epoch`. Each value derives
-from a hash over the row's primary key salted with the column name (`sha256` for
-a column that must stay unique), so a `UNIQUE` column stays unique, two columns
+from a hash over the row's primary key salted with the column name (a doubled
+`md5` for a column that must stay unique), so a `UNIQUE` column stays unique, two columns
 of one row never collide, and a re-run is idempotent.
 
 `#[encrypted]` columns are **re-encrypted** under the target's own key (same

--- a/skills/autumn-web/SKILL.md
+++ b/skills/autumn-web/SKILL.md
@@ -2441,13 +2441,26 @@ purge = ["api_tokens", "autumn_jobs", "autumn_sync_rows"]
 
 Strategies: `auto` (derived from the column type), `email`, `name`, `phone`,
 `redact`, `null`, `uuid`, `bytes`, `json`, `zero`, `epoch`. Each value derives
-from an `md5` over the row's primary key salted with the column name, so a
-`UNIQUE` column stays unique, two columns of one row never collide, and a re-run
-is idempotent. `NULL`s stay `NULL`; PII on a primary- or foreign-key column is
-refused outright (referential integrity survives); `null` is refused on `NOT
-NULL`; a constant-valued strategy is refused on a `UNIQUE` column; a
-`varchar(n)` bound narrows the token or refuses. Every target is classified
-before any is written, and each database's statements run in one transaction.
+from a hash over the row's primary key salted with the column name (`sha256` for
+a column that must stay unique), so a `UNIQUE` column stays unique, two columns
+of one row never collide, and a re-run is idempotent.
+
+`#[encrypted]` columns are **re-encrypted** under the target's own key (same
+deterministic/randomized mode as the model), never overwritten with a plain
+string — that would make every later read of the row fail as malformed
+ciphertext — so the scrub needs the target's `active_record_encryption`
+credentials and refuses before writing if they are missing.
+
+`NULL`s stay `NULL`. PII is refused on a primary key, on **either side** of any
+foreign key (composite components included), on `CHECK`-constrained columns, and
+on generated columns; `null` is refused on `NOT NULL` and under `NULLS NOT
+DISTINCT`; a constant-valued strategy is refused on any column in a unique index
+(partial and composite included); a `varchar(n)` bound narrows the token or
+refuses. Statements are `public`-qualified with a pinned `search_path` and the
+planned tables are locked; non-`public` schemas and RLS-enabled tables are
+refused rather than silently under-scrubbed; materialized views are refreshed in
+dependency order. Every target is classified before any is written, and each
+database's statements run in one transaction.
 
 `--check` classifies and writes nothing, exiting non-zero on any unclassified
 column — run it in CI after the migrate step. `--dry-run` prints the exact SQL.


### PR DESCRIPTION
Closes #1602.

## Problem

The moment `autumn db backup` shipped (#1595), a production database became one command away from a laptop or a shared staging box — PII and all. The "safe" path was hand-rolled `UPDATE` scripts that rot the first time someone adds an `email` column; the unsafe path was the default.

Every peer tool for this job (Greenmask, pgsync + obfuscation config, the PostgreSQL Anonymizer extension, django-scrubber) is **schema-blind**: the developer hand-maintains a column list that silently drifts from the schema, which is exactly the failure mode that leaks PII.

## What this adds

`autumn db scrub` takes either a backup artifact or the resolved database URL and rewrites every PII-classified column with deterministic, constraint-valid fake values.

```sh
AUTUMN_ENV=prod    autumn db backup --keep 7
AUTUMN_ENV=staging autumn db scrub --artifact backups/prod/<run> --force
```

### Classification comes from the schema, not from a config file alone

Three sources, in precedence order:

1. **`[tables.<t>.pii]` in `scrub.toml`** — the explicit declaration, including the strategy.
2. **`#[encrypted]` model columns** — read by a new `schema::parse::parse_encrypted_columns`. An at-rest-encrypted column is PII by construction, so a `safe` declaration may *not* override it.
3. **GDPR `ModelRegistration::anonymize("t")` registrations** — read statically with `syn`, classifying that table's non-key columns. A non-literal table name is reported, never silently skipped.

Everything left over is **unclassified**, and that is a hard failure. Because the column universe comes from introspecting the **live database** (not the config file), a column added yesterday cannot be missing from it — so adding a column without declaring it breaks the scrub, which is the whole point. The refusal lists the columns and prints a paste-ready `scrub.toml` stanza; `autumn db scrub --check` writes nothing and exits non-zero, so CI can hold the line.

### Safety properties

- **Constraint-preserving.** PII on a primary- or foreign-key column is refused outright, so referential integrity is untouched; `null` is refused on `NOT NULL`; a constant-valued strategy is refused on a `UNIQUE` column; a `varchar(n)` bound narrows the generated token or refuses rather than truncating into collisions; `NULL`s stay `NULL`.
- **Unique per row, distinct per column, stable across runs.** Every replacement derives from an `md5` over the row's primary key salted with the column name.
- **Atomic.** Every target is classified before any target is written (an undeclared column on one shard cannot leave the topology half anonymized), and each database's statements run in a single transaction.
- **Production guard.** Writing refuses outside `dev`/`test` without `--force` — the same `ProductionRefused` protocol as `autumn db drop`. As defence in depth, it also refuses when the write target is the database an artifact's own non-dev/test profile *config file* declares.
- **Credential-safe.** No error or report line ever embeds a resolved URL.
- **Framework-aware.** Introspection excludes `autumn_*` tables from the classified universe, so the ones carrying app-supplied payloads (queued jobs, offline-sync rows, and `api_tokens` — production tokens inherited by staging are a live credential leak) are reported separately, and emptied when the app opts in via `[framework] purge`.

One honest caveat, stated loudly by the command and in the docs: with `--artifact`, the restore must run before the classification can read the schema it creates, so a refusal *after* a restore leaves unscrubbed data in the target. `--check` catches an incomplete declaration before any restore happens.

## How it was built

Red → green → refactor, as three separate commits:

| | |
|---|---|
| 🔴 `08bb540` | 47 tests written against the intended API — fail-closed classification, automatic classification and its precedence, constraint safety, replacement expressions, the production guard, the flag surface. Deliberately did not compile. |
| 🟢 `7fdf387` | The implementation. |
| ♻️ `f943159` | Error qualification, the two-pass classify-then-apply protocol, the post-restore warning, framework-table alignment, docs, CHANGELOG, CI wiring. |

## Testing

- **59 unit tests** in `autumn-cli/src/db/scrub.rs` and `autumn-cli/src/schema/parse.rs` covering classification, precedence, every refusal, every replacement expression, and the config schema.
- **`autumn-cli/tests/integration/db_scrub.rs`** — testcontainer round-trips that seed known PII, back it up, scrub it into a separate staging database, and then sweep **every character-typed column of every table** asserting zero occurrences of any original value; plus the fail-closed refusals (undeclared column, renamed column, production profile), `--check`/`--dry-run` writing nothing, the `--output` scrubbed artifact, and framework-table purge/warning.
- **`scrubbed_database_migrates_clean_and_boots_the_app`** — scaffolds a real app, migrates, seeds, scrubs, re-checks migrations, then compiles and boots it and asserts `GET /health` → 200.

### CI

`autumn-cli`'s Docker-gated tests are not auto-swept the way `autumn-web`'s are, so both lanes are named explicitly:

- `.github/workflows/ci.yml` — the round-trip suite in the existing "Run Docker-dependent tests" step (which already installs `pg_dump`/`pg_restore`), skipping the app-boot test.
- `.github/workflows/generator-conformance.yml` — the app-boot gate in the `scaffold-postgres` job, which has the `diesel` CLI; that job now also installs the Postgres client tools.

## Docs

New [`docs/guide/data-scrubbing.md`](docs/guide/data-scrubbing.md) with the backup → scrub → restore drill, the classification workflow, the strategy table, the guarantees and the limits. Cross-linked from the backup section of the daemon guide, a new "Refreshing staging from production" section in the deployment guide, and the README guide index. CHANGELOG bullet under `[Unreleased]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TBfd5sAyAVnNFC3yVahkvT

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBfd5sAyAVnNFC3yVahkvT)_