### PR TITLE
🔌 One-command plugin install: `autumn plugin add` / `autumn plugin list` (#1606)

### DIFF
--- a/.github/workflows/generator-conformance.yml
+++ b/.github/workflows/generator-conformance.yml
@@ -19,6 +19,8 @@ on:
       - ".github/workflows/generator-conformance.yml"
       - "autumn-cli/src/generate/**"
       - "autumn-cli/src/plugin/**"
+      # The comment-aware scanner `autumn plugin add` anchors its mount on.
+      - "autumn-cli/src/rust_source.rs"
       - "autumn-cli/src/templates/**"
       - "autumn-cli/src/new.rs"
       - "autumn-cli/src/console.rs"
@@ -54,6 +56,8 @@ on:
       - ".github/workflows/generator-conformance.yml"
       - "autumn-cli/src/generate/**"
       - "autumn-cli/src/plugin/**"
+      # The comment-aware scanner `autumn plugin add` anchors its mount on.
+      - "autumn-cli/src/rust_source.rs"
       - "autumn-cli/src/templates/**"
       - "autumn-cli/src/new.rs"
       - "autumn-cli/src/console.rs"

--- a/.github/workflows/generator-conformance.yml
+++ b/.github/workflows/generator-conformance.yml
@@ -18,6 +18,7 @@ on:
     paths:
       - ".github/workflows/generator-conformance.yml"
       - "autumn-cli/src/generate/**"
+      - "autumn-cli/src/plugin/**"
       - "autumn-cli/src/templates/**"
       - "autumn-cli/src/new.rs"
       - "autumn-cli/src/console.rs"
@@ -38,12 +39,21 @@ on:
       - "autumn/src/**"
       - "autumn/Cargo.toml"
       - "autumn-macros/**"
+      # The `autumn plugin add` install gate (#1606) compiles each
+      # first-party plugin into a fresh scaffold, so a change to any of
+      # them can break the mount this workflow is the only proof of.
+      - "autumn-admin-plugin/**"
+      - "autumn-cache-redis/**"
+      - "autumn-media-plugin/**"
+      - "autumn-search/**"
+      - "autumn-storage-s3/**"
       - "Cargo.toml"
   pull_request:
     branches: [trunk, trunk-dev]
     paths:
       - ".github/workflows/generator-conformance.yml"
       - "autumn-cli/src/generate/**"
+      - "autumn-cli/src/plugin/**"
       - "autumn-cli/src/templates/**"
       - "autumn-cli/src/new.rs"
       - "autumn-cli/src/console.rs"
@@ -64,6 +74,14 @@ on:
       - "autumn/src/**"
       - "autumn/Cargo.toml"
       - "autumn-macros/**"
+      # The `autumn plugin add` install gate (#1606) compiles each
+      # first-party plugin into a fresh scaffold, so a change to any of
+      # them can break the mount this workflow is the only proof of.
+      - "autumn-admin-plugin/**"
+      - "autumn-cache-redis/**"
+      - "autumn-media-plugin/**"
+      - "autumn-search/**"
+      - "autumn-storage-s3/**"
       - "Cargo.toml"
   schedule:
     # Weekly on Monday at 04:00 UTC — catches rot from transitive dep updates
@@ -565,3 +583,41 @@ jobs:
           cargo test -p autumn-cli --test cli_tests \
             integration::db_scrub::scrubbed_database_migrates_clean_and_boots_the_app \
             -- --ignored --exact
+
+  # ── `autumn plugin add` install gate (#1606) ────────────────────────────────
+  #
+  # The Success Metric for issue #1606: installing every first-party plugin
+  # into a fresh `autumn new` scaffold must produce a project that compiles on
+  # the first try. `plugin_add_first_party_scaffolds_cargo_check` runs
+  # `autumn plugin add` for each of the five plugin crates against its own
+  # scaffold, asserts the second `add` is a no-op, and then `cargo check`s the
+  # result — the only place the generated mount snippets are compiled against
+  # the real crates.
+  #
+  # It lives in its own job (not the compile-and-serve matrix) because it
+  # builds the aws-sdk-s3 / redis / media dependency graphs, which nothing else
+  # in this workflow pulls in. The five projects share one CARGO_TARGET_DIR
+  # inside the test, so the framework is compiled once.
+  plugin-install:
+    name: autumn plugin add install gate
+    needs: meta
+    runs-on: ${{ fromJSON(needs.meta.outputs.heavy_runs_on) }}
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Free disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android \
+                      /opt/ghc /opt/hostedtoolcache/CodeQL
+          df -h
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2.7.8
+        continue-on-error: true
+
+      - name: plugin_add_first_party_scaffolds_cargo_check
+        run: |
+          cargo test -p autumn-cli --test generate \
+            plugin_add_first_party_scaffolds_cargo_check -- --ignored --exact

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **One-command plugin install — `autumn plugin add` / `autumn plugin list`
+  (#1606):** Autumn had a real plugin seam (the `Plugin` trait, first-party
+  plugin crates, a crates.io naming convention, an author-facing
+  `autumn plugin-check`) and no consumer-facing tooling at all: using a shipped
+  capability meant finding the crate, hand-editing `Cargo.toml`, hand-writing
+  the `.plugin(...)` mount, and reading config docs — four places to pick an
+  incompatible version or misconfigure the mount. `autumn plugin list` now shows
+  every installable plugin with a one-line description and the version
+  compatible with the app's `autumn-web` — the five first-party crates plus
+  community crates discovered on crates.io through the documented
+  `autumn-plugin-<name>` convention (`--json` for machine-readable output,
+  `--offline` to skip the lookup). `autumn plugin add <name>` performs the whole
+  install: the dependency at a compatible version, the mount spliced into the
+  `autumn_web::app()` builder chain, and the post-install steps (config keys,
+  follow-up generators like `autumn generate admin`) printed.
+
+  Every refusal is total rather than partial. The version gate runs before a
+  single filesystem action exists, so installing a plugin whose supported
+  `autumn-web` range excludes the app fails naming both versions with the app
+  byte-identical. A second `add` of the same plugin reports it as already
+  installed and changes nothing — no duplicate dependency, no duplicate mount.
+  And when the builder chain cannot be edited confidently (a heavily customized
+  `main.rs`, or a one-line chain with nowhere to splice a call) the command
+  writes **nothing** and prints the exact dependency line and mount snippet to
+  apply by hand, so it can never leave an app in a non-compiling state. Community
+  crates get their dependency written but never an automatic mount: the
+  `<Name>Plugin` is derived from the naming convention and printed, because
+  nothing outside that crate can verify it. A CI gate installs every first-party
+  plugin into a fresh `autumn new` scaffold and requires a green `cargo check`.
+
 - **Personal data that cannot reach a JSON response by accident (#1654):**
   Autumn's protections for sensitive data were all *name*-based and ran at
   runtime — `log/filter.rs` scrubbed a key denylist, `http_client.rs` redacted

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,6 +67,7 @@ code that **compiles, boots, and serves**. The tests that prove this live in
 | `encrypted_nested_scaffold_cargo_checks` | `integration/scaffold_encrypted.rs` | `{encrypted}` + `--belongs-to` → `cargo check --tests` |
 | `encrypted_admin_scaffold_cargo_checks` | `integration/scaffold_encrypted.rs` | `{encrypted}` + `generate admin` (wired in) → `cargo check --tests` |
 | `constrained_scaffold_cargo_checks` | `integration/scaffold_validation.rs` | `{min,max}`/`{email}`/`{url}`/nullable-bound scaffold → `cargo check --tests` (#1388) |
+| `plugin_add_first_party_scaffolds_cargo_check` | `generate.rs` | `autumn plugin add` for every first-party plugin into its own fresh scaffold → `cargo check --all-targets` (#1606) |
 
 The `console.rs`, `scaffold_encrypted.rs`, and `scaffold_validation.rs` entries
 compile into the consolidated `cli_tests` binary, whose only other CI
@@ -86,10 +87,14 @@ tests explicitly via `-- --ignored --exact`. It fires on every PR or push
 that touches:
 
 - `autumn-cli/src/generate/**` (generator logic)
+- `autumn-cli/src/plugin/**` (`autumn plugin add` catalog, mounts, install planning)
 - `autumn-cli/src/templates/**` (scaffold/model/auth templates)
 - `autumn-cli/src/new.rs` (project scaffolding)
 - `autumn/src/lib.rs` or `autumn/src/prelude.rs` (public API surface)
 - `autumn-macros/**` (proc-macro API surface)
+- `autumn-admin-plugin/**`, `autumn-cache-redis/**`, `autumn-media-plugin/**`,
+  `autumn-search/**`, `autumn-storage-s3/**` (the crates whose mount snippets
+  the `plugin add` gate compiles)
 
 A weekly scheduled run also catches breakage that arrives through transitive
 dependency updates rather than direct file edits.

--- a/autumn-admin-plugin/README.md
+++ b/autumn-admin-plugin/README.md
@@ -24,7 +24,7 @@ One command adds the dependency at a version compatible with your app's
 `autumn-web`, mounts the plugin in your `autumn_web::app()` builder chain, and
 prints any configuration still needed. It is safe to re-run, and it refuses —
 before touching any file — to install into an app on an incompatible
-`autumn-web` version. See [docs/plugins.md](../docs/plugins.md#installing-a-plugin).
+`autumn-web` version. See [docs/plugins.md](https://github.com/autumn-foundation/autumn/blob/main/docs/plugins.md#installing-a-plugin).
 
 ### Manual install
 
@@ -33,8 +33,8 @@ builder chain and printed these lines for you):
 
 ```toml
 [dependencies]
-autumn-web = { version = "0.4", features = ["db", "flash", "htmx", "maud"] }
-autumn-admin-plugin = "0.4"
+autumn-web = { version = "0.7", features = ["db", "flash", "htmx", "maud"] }
+autumn-admin-plugin = "0.7"
 ```
 
 `autumn-admin-plugin` expects a configured Autumn database pool for registered

--- a/autumn-admin-plugin/README.md
+++ b/autumn-admin-plugin/README.md
@@ -16,7 +16,20 @@
 
 ## Installation
 
-Add the plugin alongside `autumn-web`:
+```bash
+autumn plugin add autumn-admin-plugin
+```
+
+One command adds the dependency at a version compatible with your app's
+`autumn-web`, mounts the plugin in your `autumn_web::app()` builder chain, and
+prints any configuration still needed. It is safe to re-run, and it refuses —
+before touching any file — to install into an app on an incompatible
+`autumn-web` version. See [docs/plugins.md](../docs/plugins.md#installing-a-plugin).
+
+### Manual install
+
+If you would rather wire it yourself (or `autumn plugin add` could not find your
+builder chain and printed these lines for you):
 
 ```toml
 [dependencies]

--- a/autumn-cache-redis/README.md
+++ b/autumn-cache-redis/README.md
@@ -8,6 +8,21 @@ cache instead of the default in-process Moka store.
 
 ## Installation
 
+```bash
+autumn plugin add autumn-cache-redis
+```
+
+One command adds the dependency at a version compatible with your app's
+`autumn-web`, mounts the plugin in your `autumn_web::app()` builder chain, and
+prints any configuration still needed. It is safe to re-run, and it refuses —
+before touching any file — to install into an app on an incompatible
+`autumn-web` version. See [docs/plugins.md](../docs/plugins.md#installing-a-plugin).
+
+### Manual install
+
+If you would rather wire it yourself (or `autumn plugin add` could not find your
+builder chain and printed these lines for you):
+
 ```toml
 [dependencies]
 autumn-web        = { version = "0.4", features = ["redis"] }

--- a/autumn-cache-redis/README.md
+++ b/autumn-cache-redis/README.md
@@ -16,7 +16,7 @@ One command adds the dependency at a version compatible with your app's
 `autumn-web`, mounts the plugin in your `autumn_web::app()` builder chain, and
 prints any configuration still needed. It is safe to re-run, and it refuses —
 before touching any file — to install into an app on an incompatible
-`autumn-web` version. See [docs/plugins.md](../docs/plugins.md#installing-a-plugin).
+`autumn-web` version. See [docs/plugins.md](https://github.com/autumn-foundation/autumn/blob/main/docs/plugins.md#installing-a-plugin).
 
 ### Manual install
 
@@ -25,23 +25,42 @@ builder chain and printed these lines for you):
 
 ```toml
 [dependencies]
-autumn-web        = { version = "0.4", features = ["redis"] }
-autumn-cache-redis = "0.4"
+autumn-web        = { version = "0.7", features = ["redis"] }
+autumn-cache-redis = "0.7"
 ```
 
 ## Quick Start
+
+`autumn plugin add autumn-cache-redis` writes this mount for you. It reads
+`[cache]` at startup and installs the Redis cache only when
+`backend = "redis"`, so it is inert until you configure it:
+
+```rust,ignore
+use autumn_cache_redis::RedisCachePlugin;
+
+#[autumn_web::main]
+async fn main() {
+    autumn_web::app()
+        .plugin(RedisCachePlugin::new())
+        .run()
+        .await;
+}
+```
+
+To build the store yourself instead — bypassing the `[cache] backend` switch —
+construct it and install it on the builder:
 
 ```rust,ignore
 use autumn_cache_redis::RedisCache;
 
 #[autumn_web::main]
 async fn main() {
-    let cache = RedisCache::from_config(&config.redis)
+    let cache = RedisCache::from_config(&config.cache.redis)
         .await
         .expect("Redis connection established");
 
     autumn_web::app()
-        .with_cache(cache)
+        .with_cache_backend(cache)
         .run()
         .await;
 }
@@ -49,12 +68,18 @@ async fn main() {
 
 ## Configuration
 
-Add a `[redis]` section to `config/default.toml`:
+Select the Redis backend and point it at your server in `autumn.toml`:
 
 ```toml
-[redis]
+[cache]
+backend = "redis"
+
+[cache.redis]
 url = "redis://127.0.0.1:6379"
 ```
+
+`RedisCachePlugin` reads `[cache]` at startup: until `backend = "redis"` is set
+it is a no-op and the default in-process Moka cache stays in use.
 
 The URL follows the standard Redis URL format and is passed directly to the `redis` crate's
 connection manager.

--- a/autumn-cli/src/generate/model.rs
+++ b/autumn-cli/src/generate/model.rs
@@ -1143,7 +1143,7 @@ pub(super) const TEMPLATE_SHIPPED_CARGO_DEPS: &[&str] =
 /// section, skipping entries already present. Pure string transformation —
 /// preserves the rest of the file as-is. If the file has no `[dependencies]`
 /// section yet, appends a new one with the requested entries.
-pub(super) fn ensure_cargo_dependencies(existing: &str, deps: &[(&str, &str)]) -> String {
+pub fn ensure_cargo_dependencies(existing: &str, deps: &[(&str, &str)]) -> String {
     let lines: Vec<&str> = existing.lines().collect();
 
     // Locate the `[dependencies]` table header. Tolerate trailing whitespace

--- a/autumn-cli/src/generate/pwa.rs
+++ b/autumn-cli/src/generate/pwa.rs
@@ -982,7 +982,7 @@ fn inject_push_router(source: &str) -> String {
 /// nothing pointing at the cause. So the scan ignores comments, exactly as
 /// [`push_router_anchor`] does.
 fn push_router_already_mounted(source: &str) -> bool {
-    for_each_code_line(source, |line, _offset| {
+    crate::rust_source::for_each_code_line(source, |line, _offset| {
         line.contains("autumn_web::push::router()").then_some(())
     })
     .is_some()
@@ -994,7 +994,7 @@ fn push_router_already_mounted(source: &str) -> bool {
 /// See [`inject_push_router`]'s "Anchor selection" for why each rule is here.
 fn push_router_anchor(source: &str) -> Option<usize> {
     let mut seen_main = false;
-    for_each_code_line(source, |line, offset| {
+    crate::rust_source::for_each_code_line(source, |line, offset| {
         if line.trim().contains("async fn main") {
             seen_main = true;
         }
@@ -1005,51 +1005,6 @@ fn push_router_anchor(source: &str) -> Option<usize> {
         (seen_main && line.trim_end().ends_with("autumn_web::app()"))
             .then(|| offset + line.trim_end().len())
     })
-}
-
-/// Walk `source`'s lines that are **code**, skipping comments, and return the
-/// first non-`None` result of `f`.
-///
-/// `f` receives the raw line and its byte offset in `source`. The offset is
-/// tracked as the walk proceeds rather than recovered afterwards with
-/// `source.find(line)`, which would re-locate an identical earlier line and
-/// splice at the wrong place.
-///
-/// Shared by [`push_router_anchor`] and [`push_router_already_mounted`] so the
-/// two can never disagree about what counts as a comment — a disagreement
-/// there is what lets a doc-comment mention suppress both the injection and
-/// the warning about it.
-fn for_each_code_line<T>(source: &str, mut f: impl FnMut(&str, usize) -> Option<T>) -> Option<T> {
-    let mut offset = 0_usize;
-    let mut in_block_comment = false;
-
-    for line in source.split_inclusive('\n') {
-        let trimmed = line.trim();
-        let line_start = offset;
-        offset += line.len();
-
-        if in_block_comment {
-            if trimmed.contains("*/") {
-                in_block_comment = false;
-            }
-            continue;
-        }
-        if trimmed.starts_with("/*") {
-            if !trimmed.contains("*/") {
-                in_block_comment = true;
-            }
-            continue;
-        }
-        // `//`, `///`, `//!`, and continuation lines of a block comment.
-        if trimmed.starts_with("//") || trimmed.starts_with('*') {
-            continue;
-        }
-
-        if let Some(found) = f(line, line_start) {
-            return Some(found);
-        }
-    }
-    None
 }
 
 /// Inverse of [`inject_push_router`]: remove exactly the line it inserted.

--- a/autumn-cli/src/main.rs
+++ b/autumn-cli/src/main.rs
@@ -334,7 +334,6 @@ pub enum SearchSubcommands {
     },
 }
 
-/// Subcommands for `autumn jobs`.
 /// `autumn plugin ...` — consumer-facing plugin discovery and install
 /// (issue #1606). The author-facing conformance gate stays at
 /// `autumn plugin-check`.
@@ -348,7 +347,7 @@ pub enum PluginSubcommands {
         /// Emit JSON instead of a table.
         #[arg(long)]
         json: bool,
-        /// Skip the crates.io lookup (first-party plugins only).
+        /// Do not query crates.io; list the first-party catalog only.
         #[arg(long)]
         offline: bool,
     },
@@ -359,12 +358,14 @@ pub enum PluginSubcommands {
         /// Print what would change without writing anything.
         #[arg(long)]
         dry_run: bool,
-        /// Skip the crates.io lookup (first-party plugins only).
+        /// Do not query crates.io. First-party plugins install normally;
+        /// a community crate cannot have its version resolved and is refused.
         #[arg(long)]
         offline: bool,
     },
 }
 
+/// Subcommands for `autumn jobs`.
 #[derive(Subcommand, Clone, Debug, PartialEq, Eq)]
 pub enum JobsSubcommands {
     /// Emit the effective drained-queue manifest the running app declares.
@@ -1275,8 +1276,12 @@ enum Commands {
     /// Discover and install Autumn plugins.
     ///
     /// `list` shows every installable plugin with the version compatible with
-    /// this app; `add` writes the dependency, mounts the plugin in the
+    /// this app (querying crates.io for community crates unless `--offline`);
+    /// `add` writes the dependency, mounts the plugin in the
     /// `autumn_web::app()` builder chain, and prints the post-install steps.
+    ///
+    /// Writing a plugin instead? `autumn generate plugin`. Auditing one you
+    /// wrote? `autumn plugin-check`.
     ///
     /// # Examples
     ///
@@ -1297,6 +1302,9 @@ enum Commands {
     /// and verifies that the named plugin satisfies five checks: installability,
     /// route attribution, route prefix, route collision, and sensitive-surface
     /// gating.  Exits 0 on pass, 1 on failure.
+    ///
+    /// This is the AUTHOR-facing gate. To discover and install a plugin as a
+    /// consumer, use `autumn plugin list` / `autumn plugin add`.
     ///
     /// # Examples
     ///

--- a/autumn-cli/src/main.rs
+++ b/autumn-cli/src/main.rs
@@ -37,6 +37,7 @@ mod new;
 mod overload_driver;
 mod paths;
 mod pg;
+mod plugin;
 mod plugin_check;
 mod process;
 mod release;
@@ -44,6 +45,7 @@ mod replay;
 mod retention;
 mod routes;
 mod routes_audit;
+mod rust_source;
 mod scaling_driver;
 mod schema;
 mod search;
@@ -333,6 +335,36 @@ pub enum SearchSubcommands {
 }
 
 /// Subcommands for `autumn jobs`.
+/// `autumn plugin ...` — consumer-facing plugin discovery and install
+/// (issue #1606). The author-facing conformance gate stays at
+/// `autumn plugin-check`.
+#[derive(Subcommand, Clone, Debug, PartialEq, Eq)]
+pub enum PluginSubcommands {
+    /// List installable plugins with the version compatible with this app.
+    ///
+    /// Covers every first-party plugin plus community crates discoverable on
+    /// crates.io through the documented `autumn-plugin-<name>` convention.
+    List {
+        /// Emit JSON instead of a table.
+        #[arg(long)]
+        json: bool,
+        /// Skip the crates.io lookup (first-party plugins only).
+        #[arg(long)]
+        offline: bool,
+    },
+    /// Add a plugin: dependency, builder-chain mount, and post-install steps.
+    Add {
+        /// Plugin crate name, e.g. `autumn-admin-plugin`.
+        name: String,
+        /// Print what would change without writing anything.
+        #[arg(long)]
+        dry_run: bool,
+        /// Skip the crates.io lookup (first-party plugins only).
+        #[arg(long)]
+        offline: bool,
+    },
+}
+
 #[derive(Subcommand, Clone, Debug, PartialEq, Eq)]
 pub enum JobsSubcommands {
     /// Emit the effective drained-queue manifest the running app declares.
@@ -1238,6 +1270,25 @@ enum Commands {
     Search {
         #[command(subcommand)]
         action: SearchSubcommands,
+    },
+
+    /// Discover and install Autumn plugins.
+    ///
+    /// `list` shows every installable plugin with the version compatible with
+    /// this app; `add` writes the dependency, mounts the plugin in the
+    /// `autumn_web::app()` builder chain, and prints the post-install steps.
+    ///
+    /// # Examples
+    ///
+    ///   autumn plugin list
+    ///   autumn plugin list --json --offline
+    ///   autumn plugin add autumn-admin-plugin
+    ///   autumn plugin add autumn-cache-redis --dry-run
+    #[command(verbatim_doc_comment)]
+    Plugin {
+        /// The plugin subcommand to run.
+        #[command(subcommand)]
+        action: PluginSubcommands,
     },
 
     /// Run conformance checks against a plugin's route contributions.
@@ -4181,6 +4232,31 @@ fn run_command(command: Commands) {
                 });
             }
         },
+        Commands::Plugin { action } => {
+            let root = std::path::Path::new(".");
+            let code = match action {
+                PluginSubcommands::List { json, offline } => {
+                    plugin::run_list(&plugin::ListOptions {
+                        root,
+                        json,
+                        offline,
+                    })
+                }
+                PluginSubcommands::Add {
+                    name,
+                    dry_run,
+                    offline,
+                } => plugin::run_add(&plugin::AddOptions {
+                    root,
+                    name: &name,
+                    dry_run,
+                    offline,
+                }),
+            };
+            if code != 0 {
+                std::process::exit(code);
+            }
+        }
         Commands::PluginCheck {
             package,
             bin,
@@ -7607,6 +7683,71 @@ mod tests {
     #[test]
     fn parse_token_revoke_without_token_is_error() {
         assert!(Cli::try_parse_from(["autumn", "token", "revoke"]).is_err());
+    }
+
+    // ── autumn plugin (list/add) tests ─────────────────────────────────────
+
+    #[test]
+    fn parse_plugin_list_defaults() {
+        let cli = Cli::try_parse_from(["autumn", "plugin", "list"]).unwrap();
+        match cli.command {
+            Commands::Plugin {
+                action: PluginSubcommands::List { json, offline },
+            } => {
+                assert!(!json);
+                assert!(!offline);
+            }
+            _ => panic!("expected plugin list"),
+        }
+    }
+
+    #[test]
+    fn parse_plugin_list_json_and_offline() {
+        let cli = Cli::try_parse_from(["autumn", "plugin", "list", "--json", "--offline"]).unwrap();
+        match cli.command {
+            Commands::Plugin {
+                action: PluginSubcommands::List { json, offline },
+            } => {
+                assert!(json);
+                assert!(offline);
+            }
+            _ => panic!("expected plugin list"),
+        }
+    }
+
+    #[test]
+    fn parse_plugin_add_requires_a_name() {
+        assert!(Cli::try_parse_from(["autumn", "plugin", "add"]).is_err());
+    }
+
+    #[test]
+    fn parse_plugin_add_with_dry_run() {
+        let cli = Cli::try_parse_from([
+            "autumn",
+            "plugin",
+            "add",
+            "autumn-admin-plugin",
+            "--dry-run",
+        ])
+        .unwrap();
+        match cli.command {
+            Commands::Plugin {
+                action: PluginSubcommands::Add { name, dry_run, .. },
+            } => {
+                assert_eq!(name, "autumn-admin-plugin");
+                assert!(dry_run);
+            }
+            _ => panic!("expected plugin add"),
+        }
+    }
+
+    /// `autumn plugin-check` predates `autumn plugin` and must keep working
+    /// as its own top-level command.
+    #[test]
+    fn plugin_and_plugin_check_are_distinct_commands() {
+        let check =
+            Cli::try_parse_from(["autumn", "plugin-check", "--plugin-name", "myplugin"]).unwrap();
+        assert!(matches!(check.command, Commands::PluginCheck { .. }));
     }
 
     // ── autumn plugin-check tests ──────────────────────────────────────────

--- a/autumn-cli/src/plugin/catalog.rs
+++ b/autumn-cli/src/plugin/catalog.rs
@@ -28,13 +28,20 @@ pub struct CatalogEntry {
     /// under the builder-opening `autumn_web::app()` line. Its first line is
     /// the `// added by ...` marker.
     pub mount: &'static str,
-    /// The fully-qualified path this command's own mount writes. Matched
-    /// against *code* lines only, so a mention in a comment never counts.
-    pub probe: &'static str,
-    /// The same mount as a hand-written call after a `use` import
-    /// (`AdminPlugin::new(`). Detected too, so `add` never splices a second,
-    /// default-constructed mount over a user's configured one.
-    pub probe_bare: &'static str,
+    /// The builder call this plugin mounts through: `.plugin(` for a
+    /// `Plugin`, `.with_blob_store(` for `autumn-storage-s3`.
+    pub mount_call: &'static str,
+    /// The fully-qualified path this command's own mount writes. Trusted only
+    /// *inside* a [`Self::mount_call`] argument: on its own it is just a type
+    /// name, so `fn configure(_: autumn_admin_plugin::AdminPlugin) {}` would
+    /// otherwise read as a mount and suppress the real one.
+    pub mount_arg: &'static str,
+    /// The constructor call a mount must contain (`AdminPlugin::new(`).
+    /// Trusted anywhere in code, because a plugin built into a variable and
+    /// mounted as `.plugin(configured)` is still a mount — and splicing a
+    /// second, default-constructed one over it would win the duplicate check
+    /// and silently discard the user's configuration.
+    pub constructor: &'static str,
     /// Config keys the plugin needs before the app can serve it.
     pub config_keys: &'static [&'static str],
     /// Follow-up steps printed after a successful install.
@@ -65,8 +72,9 @@ pub const FIRST_PARTY: &[CatalogEntry] = &[
             "        // added by `autumn plugin add autumn-admin-plugin`\n",
             "        .plugin(autumn_admin_plugin::AdminPlugin::new())\n",
         ),
-        probe: "autumn_admin_plugin::AdminPlugin",
-        probe_bare: "AdminPlugin::new(",
+        mount_call: ".plugin(",
+        mount_arg: "autumn_admin_plugin::AdminPlugin",
+        constructor: "AdminPlugin::new(",
         config_keys: &["[database]\nprimary_url = \"postgres://localhost/my_app\""],
         post_install: &[
             "Register a model with `autumn generate admin <Model>` — the panel mounts at /admin but starts with no models.",
@@ -81,8 +89,9 @@ pub const FIRST_PARTY: &[CatalogEntry] = &[
             "        // added by `autumn plugin add autumn-cache-redis`\n",
             "        .plugin(autumn_cache_redis::RedisCachePlugin::new())\n",
         ),
-        probe: "autumn_cache_redis::RedisCachePlugin",
-        probe_bare: "RedisCachePlugin::new(",
+        mount_call: ".plugin(",
+        mount_arg: "autumn_cache_redis::RedisCachePlugin",
+        constructor: "RedisCachePlugin::new(",
         config_keys: &[
             "[cache]\nbackend = \"redis\"\n\n[cache.redis]\nurl = \"redis://127.0.0.1:6379\"",
         ],
@@ -97,8 +106,9 @@ pub const FIRST_PARTY: &[CatalogEntry] = &[
             "        // added by `autumn plugin add autumn-media-plugin`\n",
             "        .plugin(autumn_media_plugin::MediaPlugin::new())\n",
         ),
-        probe: "autumn_media_plugin::MediaPlugin",
-        probe_bare: "MediaPlugin::new(",
+        mount_call: ".plugin(",
+        mount_arg: "autumn_media_plugin::MediaPlugin",
+        constructor: "MediaPlugin::new(",
         config_keys: &[
             "[media]\nroom_max_participants = 6\n\n[media.mediamtx]\napi_base = \"http://127.0.0.1:9997\"",
         ],
@@ -114,8 +124,9 @@ pub const FIRST_PARTY: &[CatalogEntry] = &[
             "        // added by `autumn plugin add autumn-search`\n",
             "        .plugin(autumn_search::SearchPlugin::new())\n",
         ),
-        probe: "autumn_search::SearchPlugin",
-        probe_bare: "SearchPlugin::new(",
+        mount_call: ".plugin(",
+        mount_arg: "autumn_search::SearchPlugin",
+        constructor: "SearchPlugin::new(",
         config_keys: &["[search]\nengine = \"postgres\""],
         post_install: &[
             "Mark a model with `#[searchable]`, then register it: `SearchPlugin::new().postgres().index::<Model>()`.",
@@ -139,8 +150,9 @@ pub const FIRST_PARTY: &[CatalogEntry] = &[
             "                .expect(\"`[storage.s3]` must set `bucket` and `region`\")\n",
             "        })\n",
         ),
-        probe: "autumn_storage_s3::S3BlobStore",
-        probe_bare: "S3BlobStore::from_config(",
+        mount_call: ".with_blob_store(",
+        mount_arg: "autumn_storage_s3::S3BlobStore",
+        constructor: "S3BlobStore::from_config(",
         config_keys: &[
             "[storage]\nbackend = \"s3\"\n\n[storage.s3]\nbucket = \"my-bucket\"\nregion = \"us-east-1\"",
         ],
@@ -150,15 +162,6 @@ pub const FIRST_PARTY: &[CatalogEntry] = &[
         ],
     },
 ];
-
-impl CatalogEntry {
-    /// Both spellings a mount of this plugin can take, for
-    /// [`crate::plugin::install::mount_present`].
-    #[must_use]
-    pub const fn probes(&self) -> [&'static str; 2] {
-        [self.probe, self.probe_bare]
-    }
-}
 
 /// The first-party entry named `name`, if there is one.
 #[must_use]
@@ -316,18 +319,23 @@ mod tests {
         }
     }
 
-    /// Idempotency (AC #4) is decided by the probe, so a probe that does not
-    /// occur in its own mount snippet could never detect the mount it just
-    /// wrote. Every mount must also carry the `added by` marker.
+    /// Idempotency (AC #4) is decided by these three fields, so a mount that
+    /// does not contain its own call, type path and constructor could never
+    /// detect the mount it just wrote.
     #[test]
-    fn every_mount_contains_its_probe_and_marker() {
+    fn every_mount_contains_its_own_detection_markers() {
         for entry in FIRST_PARTY {
-            assert!(
-                entry.mount.contains(entry.probe),
-                "{}: probe {:?} not in its own mount",
-                entry.crate_name,
-                entry.probe
-            );
+            for (label, needle) in [
+                ("mount_call", entry.mount_call),
+                ("mount_arg", entry.mount_arg),
+                ("constructor", entry.constructor),
+            ] {
+                assert!(
+                    entry.mount.contains(needle),
+                    "{}: {label} {needle:?} not in its own mount",
+                    entry.crate_name
+                );
+            }
             assert!(
                 entry
                     .mount
@@ -338,18 +346,26 @@ mod tests {
         }
     }
 
-    /// The probe must be a *code* substring: matching on a comment would let a
-    /// pasted README snippet suppress a real install.
+    /// The type path is only trusted inside a mount call, and the constructor
+    /// anywhere — so each must be the shape the other is not.
     #[test]
-    fn every_probe_is_a_module_path_not_a_comment() {
+    fn detection_markers_have_the_right_shapes() {
         for entry in FIRST_PARTY {
             assert!(
-                entry.probe.contains("::"),
-                "{}: probe {:?} should be a module path",
-                entry.crate_name,
-                entry.probe
+                entry.mount_arg.contains("::") && !entry.mount_arg.contains('('),
+                "{}: mount_arg should be a bare type path",
+                entry.crate_name
             );
-            assert!(!entry.probe.contains("//"), "{}", entry.crate_name);
+            assert!(
+                entry.constructor.ends_with('('),
+                "{}: constructor should be a call",
+                entry.crate_name
+            );
+            assert!(
+                entry.mount_call.starts_with('.') && entry.mount_call.ends_with('('),
+                "{}: mount_call should be a builder call",
+                entry.crate_name
+            );
         }
     }
 

--- a/autumn-cli/src/plugin/catalog.rs
+++ b/autumn-cli/src/plugin/catalog.rs
@@ -1,0 +1,341 @@
+//! The install catalog: what `autumn plugin list` shows and what
+//! `autumn plugin add` knows how to mount.
+//!
+//! Two sources feed the catalog, exactly as issue #1606 scopes discovery
+//! ("crates.io plus the existing naming convention"):
+//!
+//! - **First-party** plugins ship as a static table compiled into the CLI.
+//!   They are released in lockstep with `autumn-web`, so the CLI's own version
+//!   *is* the version to install, and the mount snippet can be written down
+//!   once and compile-gated in CI.
+//! - **Community** plugins are discovered on crates.io through the documented
+//!   `autumn-plugin-<name>` naming convention (see `docs/plugins.md`). Their
+//!   mount is *derived* from the same convention and printed for the user to
+//!   apply, never spliced in: nothing here can verify a third-party crate
+//!   really exposes `<Name>Plugin`, and a wrong guess would leave the app not
+//!   compiling.
+
+/// One installable first-party plugin.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CatalogEntry {
+    /// crates.io name, e.g. `autumn-admin-plugin`.
+    pub crate_name: &'static str,
+    /// One-line description shown by `autumn plugin list`. Kept byte-identical
+    /// to the crate's own `Cargo.toml` `description` (pinned by a unit test)
+    /// so the listing can never quietly drift from what crates.io shows.
+    pub summary: &'static str,
+    /// Snippet spliced into the `AppBuilder` chain, already indented to sit
+    /// under the builder-opening `autumn_web::app()` line. Its first line is
+    /// the `// added by ...` marker.
+    pub mount: &'static str,
+    /// A code substring that proves this plugin is already mounted. Matched
+    /// against *code* lines only, so a mention in a comment never counts.
+    pub probe: &'static str,
+    /// Config keys the plugin needs before the app can serve it.
+    pub config_keys: &'static [&'static str],
+    /// Follow-up steps printed after a successful install.
+    pub post_install: &'static [&'static str],
+}
+
+/// Every first-party plugin in this workspace, in `plugin list` order.
+///
+/// Four of the five implement `Plugin` and mount with `.plugin(...)`.
+/// `autumn-storage-s3` is the exception: it exposes a `BlobStore`, not a
+/// `Plugin`, and `S3BlobStore::from_config` is `async` — but `.await` is legal
+/// inside a method-call argument in an `async fn`, so its mount is still one
+/// splice into the same builder chain, with no second anchor and no statement
+/// rewriting.
+pub const FIRST_PARTY: &[CatalogEntry] = &[
+    CatalogEntry {
+        crate_name: "autumn-admin-plugin",
+        summary: "Out-of-the-box admin panel plugin for autumn-web applications",
+        mount: concat!(
+            "        // added by `autumn plugin add autumn-admin-plugin`\n",
+            "        .plugin(autumn_admin_plugin::AdminPlugin::new())\n",
+        ),
+        probe: "autumn_admin_plugin::AdminPlugin",
+        config_keys: &["[database]\nprimary_url = \"postgres://localhost/my_app\""],
+        post_install: &[
+            "Register a model with `autumn generate admin <Model>` — the panel mounts at /admin but starts with no models.",
+            "Sign in with a session carrying the `admin` role; override with `AdminPlugin::new().require_role(...)`.",
+            "The jobs dashboard at /admin/jobs works without a database; model screens need a configured pool.",
+        ],
+    },
+    CatalogEntry {
+        crate_name: "autumn-cache-redis",
+        summary: "Redis-backed shared cache plugin for autumn-web applications",
+        mount: concat!(
+            "        // added by `autumn plugin add autumn-cache-redis`\n",
+            "        .plugin(autumn_cache_redis::RedisCachePlugin::new())\n",
+        ),
+        probe: "autumn_cache_redis::RedisCachePlugin",
+        config_keys: &[
+            "[cache]\nbackend = \"redis\"\n\n[cache.redis]\nurl = \"redis://127.0.0.1:6379\"",
+        ],
+        post_install: &[
+            "Until `[cache] backend = \"redis\"` is set the plugin is a no-op and the in-process Moka cache stays in use.",
+        ],
+    },
+    CatalogEntry {
+        crate_name: "autumn-media-plugin",
+        summary: "Live-streaming media plugin (broadcast + rooms) for autumn-web applications",
+        mount: concat!(
+            "        // added by `autumn plugin add autumn-media-plugin`\n",
+            "        .plugin(autumn_media_plugin::MediaPlugin::new())\n",
+        ),
+        probe: "autumn_media_plugin::MediaPlugin",
+        config_keys: &[
+            "[media]\nroom_max_participants = 6\n\n[media.mediamtx]\napi_base = \"http://127.0.0.1:9997\"",
+        ],
+        post_install: &[
+            "Both primitives are off by default — chain `.with_broadcast()` and/or `.with_rooms()` to enable them.",
+            "Broadcast needs a reachable MediaMTX origin and an ffmpeg binary; see autumn-media-plugin/README.md.",
+        ],
+    },
+    CatalogEntry {
+        crate_name: "autumn-search",
+        summary: "Keyword and vector search plugin for autumn-web applications: mark a model searchable, get an index that stays in sync",
+        mount: concat!(
+            "        // added by `autumn plugin add autumn-search`\n",
+            "        .plugin(autumn_search::SearchPlugin::new())\n",
+        ),
+        probe: "autumn_search::SearchPlugin",
+        config_keys: &["[search]\nengine = \"postgres\""],
+        post_install: &[
+            "Mark a model with `#[searchable]`, then register it: `SearchPlugin::new().postgres().index::<Model>()`.",
+            "Keep the index in sync by giving the model's `#[repository]` a `SearchSyncHooks` alias.",
+            "Backfill an existing table with `autumn search reindex`.",
+        ],
+    },
+    CatalogEntry {
+        crate_name: "autumn-storage-s3",
+        summary: "S3-compatible blob storage plugin for autumn-web applications",
+        mount: concat!(
+            "        // added by `autumn plugin add autumn-storage-s3`\n",
+            "        .with_blob_store({\n",
+            "            let config = autumn_web::config::AutumnConfig::load()\n",
+            "                .expect(\"autumn.toml must load before the S3 blob store can be built\");\n",
+            "            autumn_storage_s3::S3BlobStore::from_config(&config.storage.s3)\n",
+            "                .await\n",
+            "                .expect(\"`[storage.s3]` must set `bucket` and `region`\")\n",
+            "        })\n",
+        ),
+        probe: "autumn_storage_s3::S3BlobStore",
+        config_keys: &[
+            "[storage]\nbackend = \"s3\"\n\n[storage.s3]\nbucket = \"my-bucket\"\nregion = \"us-east-1\"",
+        ],
+        post_install: &[
+            "Set `[storage.s3] bucket` and `region` before starting the app — the mount panics with that message until you do.",
+            "Credentials come from the standard AWS chain, or name env vars with `access_key_id_env` / `secret_access_key_env`.",
+        ],
+    },
+];
+
+/// The first-party entry named `name`, if there is one.
+#[must_use]
+pub fn lookup(name: &str) -> Option<&'static CatalogEntry> {
+    FIRST_PARTY.iter().find(|entry| entry.crate_name == name)
+}
+
+/// The documented third-party crate-name prefix (`docs/plugins.md`).
+pub const COMMUNITY_PREFIX: &str = "autumn-plugin-";
+
+/// Whether `name` follows the documented third-party naming convention.
+///
+/// The bare prefix with nothing after it is not a crate name, so it does not
+/// count — otherwise `plugin add autumn-plugin-` would resolve to a crate that
+/// cannot exist.
+#[must_use]
+pub fn is_community_name(name: &str) -> bool {
+    name.strip_prefix(COMMUNITY_PREFIX)
+        .is_some_and(|rest| !rest.is_empty())
+}
+
+/// The `<Name>Plugin` struct a community crate is expected to expose, derived
+/// from the documented convention (`autumn-plugin-live-feed` →
+/// `LiveFeedPlugin`). `None` when `name` does not follow the convention.
+#[must_use]
+pub fn community_struct_name(name: &str) -> Option<String> {
+    if !is_community_name(name) {
+        return None;
+    }
+    let rest = name.strip_prefix(COMMUNITY_PREFIX)?;
+    let mut out = String::with_capacity(rest.len() + "Plugin".len());
+    for segment in rest.split('-').filter(|s| !s.is_empty()) {
+        let mut chars = segment.chars();
+        if let Some(first) = chars.next() {
+            out.extend(first.to_uppercase());
+            out.push_str(chars.as_str());
+        }
+    }
+    if out.is_empty() {
+        return None;
+    }
+    out.push_str("Plugin");
+    Some(out)
+}
+
+/// The Rust module path for a crate name (`autumn-plugin-live-feed` →
+/// `autumn_plugin_live_feed`).
+#[must_use]
+pub fn module_path_for(crate_name: &str) -> String {
+    crate_name.replace('-', "_")
+}
+
+/// The `.plugin(...)` line a community crate is expected to mount with.
+/// `None` when the struct name cannot be derived.
+///
+/// Printed, never spliced: nothing here can check that a third-party crate
+/// really follows the convention, and a wrong guess would leave the app not
+/// compiling — the one outcome issue #1606 rules out.
+#[must_use]
+pub fn community_mount_snippet(crate_name: &str) -> Option<String> {
+    let struct_name = community_struct_name(crate_name)?;
+    Some(format!(
+        "        .plugin({}::{struct_name}::new())",
+        module_path_for(crate_name)
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// AC #1: the listing covers **all** first-party plugins in this
+    /// workspace, not just the three `plugin add` is spelled out for.
+    #[test]
+    fn catalog_covers_every_first_party_plugin_in_the_workspace() {
+        let names: Vec<&str> = FIRST_PARTY.iter().map(|e| e.crate_name).collect();
+        for expected in [
+            "autumn-admin-plugin",
+            "autumn-cache-redis",
+            "autumn-media-plugin",
+            "autumn-search",
+            "autumn-storage-s3",
+        ] {
+            assert!(names.contains(&expected), "catalog is missing {expected}");
+        }
+    }
+
+    /// The catalog is a hand-written table, so it can drift from the crates it
+    /// describes. Pin it to the manifests: every entry must name a crate that
+    /// exists in this workspace, and carry that crate's own description.
+    #[test]
+    fn catalog_entries_match_their_crate_manifests() {
+        let workspace = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .expect("workspace root");
+        for entry in FIRST_PARTY {
+            let manifest = workspace.join(entry.crate_name).join("Cargo.toml");
+            let content = std::fs::read_to_string(&manifest)
+                .unwrap_or_else(|e| panic!("{}: {e}", manifest.display()));
+            let table: toml::Table = toml::from_str(&content).expect("parse manifest");
+            let description = table["package"]["description"]
+                .as_str()
+                .expect("description")
+                .to_owned();
+            assert_eq!(
+                entry.summary, description,
+                "{} summary drifted from its Cargo.toml description",
+                entry.crate_name
+            );
+        }
+    }
+
+    /// Idempotency (AC #4) is decided by the probe, so a probe that does not
+    /// occur in its own mount snippet could never detect the mount it just
+    /// wrote. Every mount must also carry the `added by` marker.
+    #[test]
+    fn every_mount_contains_its_probe_and_marker() {
+        for entry in FIRST_PARTY {
+            assert!(
+                entry.mount.contains(entry.probe),
+                "{}: probe {:?} not in its own mount",
+                entry.crate_name,
+                entry.probe
+            );
+            assert!(
+                entry
+                    .mount
+                    .contains(&format!("autumn plugin add {}", entry.crate_name)),
+                "{}: mount is missing its marker comment",
+                entry.crate_name
+            );
+        }
+    }
+
+    /// The probe must be a *code* substring: matching on a comment would let a
+    /// pasted README snippet suppress a real install.
+    #[test]
+    fn every_probe_is_a_module_path_not_a_comment() {
+        for entry in FIRST_PARTY {
+            assert!(
+                entry.probe.contains("::"),
+                "{}: probe {:?} should be a module path",
+                entry.crate_name,
+                entry.probe
+            );
+            assert!(!entry.probe.contains("//"), "{}", entry.crate_name);
+        }
+    }
+
+    #[test]
+    fn lookup_finds_first_party_entries() {
+        assert_eq!(
+            lookup("autumn-admin-plugin").map(|e| e.crate_name),
+            Some("autumn-admin-plugin")
+        );
+    }
+
+    #[test]
+    fn lookup_rejects_unknown_names() {
+        assert!(lookup("autumn-plugin-nope").is_none());
+        assert!(lookup("serde").is_none());
+    }
+
+    #[test]
+    fn community_names_follow_the_documented_prefix() {
+        assert!(is_community_name("autumn-plugin-live-feed"));
+        assert!(!is_community_name("autumn-admin-plugin"));
+        assert!(!is_community_name("autumn-plugin-"));
+        assert!(!is_community_name("serde"));
+    }
+
+    /// `docs/plugins.md`: third-party crates are `autumn-plugin-<name>` and
+    /// expose `<Name>Plugin`.
+    #[test]
+    fn community_struct_name_follows_the_documented_convention() {
+        assert_eq!(
+            community_struct_name("autumn-plugin-live-feed").as_deref(),
+            Some("LiveFeedPlugin")
+        );
+        assert_eq!(
+            community_struct_name("autumn-plugin-audit").as_deref(),
+            Some("AuditPlugin")
+        );
+        assert_eq!(community_struct_name("autumn-plugin-").as_deref(), None);
+        assert_eq!(community_struct_name("autumn-admin-plugin"), None);
+    }
+
+    #[test]
+    fn module_path_replaces_hyphens_with_underscores() {
+        assert_eq!(
+            module_path_for("autumn-plugin-live-feed"),
+            "autumn_plugin_live_feed"
+        );
+        assert_eq!(
+            module_path_for("autumn-admin-plugin"),
+            "autumn_admin_plugin"
+        );
+    }
+
+    #[test]
+    fn community_mount_snippet_is_a_plugin_call() {
+        let snippet = community_mount_snippet("autumn-plugin-live-feed").expect("snippet");
+        assert!(
+            snippet.contains(".plugin(autumn_plugin_live_feed::LiveFeedPlugin::new())"),
+            "{snippet}"
+        );
+        assert!(community_mount_snippet("autumn-plugin-").is_none());
+    }
+}

--- a/autumn-cli/src/plugin/catalog.rs
+++ b/autumn-cli/src/plugin/catalog.rs
@@ -43,6 +43,14 @@ pub struct CatalogEntry {
 
 /// Every first-party plugin in this workspace, in `plugin list` order.
 ///
+/// No entry adds `features = [...]` to the app's own `autumn-web` dependency.
+/// Each plugin crate already depends on `autumn-web` with the features its
+/// mount needs, and Cargo unifies features across the graph — so one dependency
+/// line is genuinely enough, and writing features into the user's manifest
+/// would duplicate a fact the plugin crate already owns. The `plugin-install`
+/// CI gate compiles every one of these mounts into a fresh scaffold, so if a
+/// plugin ever drops a feature its mount needs, that gate is what fails.
+///
 /// Four of the five implement `Plugin` and mount with `.plugin(...)`.
 /// `autumn-storage-s3` is the exception: it exposes a `BlobStore`, not a
 /// `Plugin`, and `S3BlobStore::from_config` is `async` — but `.await` is legal

--- a/autumn-cli/src/plugin/catalog.rs
+++ b/autumn-cli/src/plugin/catalog.rs
@@ -28,9 +28,13 @@ pub struct CatalogEntry {
     /// under the builder-opening `autumn_web::app()` line. Its first line is
     /// the `// added by ...` marker.
     pub mount: &'static str,
-    /// A code substring that proves this plugin is already mounted. Matched
+    /// The fully-qualified path this command's own mount writes. Matched
     /// against *code* lines only, so a mention in a comment never counts.
     pub probe: &'static str,
+    /// The same mount as a hand-written call after a `use` import
+    /// (`AdminPlugin::new(`). Detected too, so `add` never splices a second,
+    /// default-constructed mount over a user's configured one.
+    pub probe_bare: &'static str,
     /// Config keys the plugin needs before the app can serve it.
     pub config_keys: &'static [&'static str],
     /// Follow-up steps printed after a successful install.
@@ -54,6 +58,7 @@ pub const FIRST_PARTY: &[CatalogEntry] = &[
             "        .plugin(autumn_admin_plugin::AdminPlugin::new())\n",
         ),
         probe: "autumn_admin_plugin::AdminPlugin",
+        probe_bare: "AdminPlugin::new(",
         config_keys: &["[database]\nprimary_url = \"postgres://localhost/my_app\""],
         post_install: &[
             "Register a model with `autumn generate admin <Model>` — the panel mounts at /admin but starts with no models.",
@@ -69,6 +74,7 @@ pub const FIRST_PARTY: &[CatalogEntry] = &[
             "        .plugin(autumn_cache_redis::RedisCachePlugin::new())\n",
         ),
         probe: "autumn_cache_redis::RedisCachePlugin",
+        probe_bare: "RedisCachePlugin::new(",
         config_keys: &[
             "[cache]\nbackend = \"redis\"\n\n[cache.redis]\nurl = \"redis://127.0.0.1:6379\"",
         ],
@@ -84,6 +90,7 @@ pub const FIRST_PARTY: &[CatalogEntry] = &[
             "        .plugin(autumn_media_plugin::MediaPlugin::new())\n",
         ),
         probe: "autumn_media_plugin::MediaPlugin",
+        probe_bare: "MediaPlugin::new(",
         config_keys: &[
             "[media]\nroom_max_participants = 6\n\n[media.mediamtx]\napi_base = \"http://127.0.0.1:9997\"",
         ],
@@ -100,6 +107,7 @@ pub const FIRST_PARTY: &[CatalogEntry] = &[
             "        .plugin(autumn_search::SearchPlugin::new())\n",
         ),
         probe: "autumn_search::SearchPlugin",
+        probe_bare: "SearchPlugin::new(",
         config_keys: &["[search]\nengine = \"postgres\""],
         post_install: &[
             "Mark a model with `#[searchable]`, then register it: `SearchPlugin::new().postgres().index::<Model>()`.",
@@ -113,7 +121,10 @@ pub const FIRST_PARTY: &[CatalogEntry] = &[
         mount: concat!(
             "        // added by `autumn plugin add autumn-storage-s3`\n",
             "        .with_blob_store({\n",
-            "            let config = autumn_web::config::AutumnConfig::load()\n",
+            "            // `load_lenient_unknown_roots` (not `load`) so a config section\n",
+            "            // belonging to another plugin — `[media]`, `[search]` — is a warning\n",
+            "            // here rather than a hard failure: this load only needs `[storage]`.\n",
+            "            let config = autumn_web::config::AutumnConfig::load_lenient_unknown_roots()\n",
             "                .expect(\"autumn.toml must load before the S3 blob store can be built\");\n",
             "            autumn_storage_s3::S3BlobStore::from_config(&config.storage.s3)\n",
             "                .await\n",
@@ -121,6 +132,7 @@ pub const FIRST_PARTY: &[CatalogEntry] = &[
             "        })\n",
         ),
         probe: "autumn_storage_s3::S3BlobStore",
+        probe_bare: "S3BlobStore::from_config(",
         config_keys: &[
             "[storage]\nbackend = \"s3\"\n\n[storage.s3]\nbucket = \"my-bucket\"\nregion = \"us-east-1\"",
         ],
@@ -131,6 +143,15 @@ pub const FIRST_PARTY: &[CatalogEntry] = &[
     },
 ];
 
+impl CatalogEntry {
+    /// Both spellings a mount of this plugin can take, for
+    /// [`crate::plugin::install::mount_present`].
+    #[must_use]
+    pub const fn probes(&self) -> [&'static str; 2] {
+        [self.probe, self.probe_bare]
+    }
+}
+
 /// The first-party entry named `name`, if there is one.
 #[must_use]
 pub fn lookup(name: &str) -> Option<&'static CatalogEntry> {
@@ -140,15 +161,25 @@ pub fn lookup(name: &str) -> Option<&'static CatalogEntry> {
 /// The documented third-party crate-name prefix (`docs/plugins.md`).
 pub const COMMUNITY_PREFIX: &str = "autumn-plugin-";
 
-/// Whether `name` follows the documented third-party naming convention.
+/// Whether `name` follows the documented third-party naming convention **and**
+/// is a legal crates.io crate name.
 ///
-/// The bare prefix with nothing after it is not a crate name, so it does not
-/// count — otherwise `plugin add autumn-plugin-` would resolve to a crate that
-/// cannot exist.
+/// The charset check is load-bearing, not cosmetic: this predicate is the only
+/// gate on a name that is then interpolated into a crates.io URL *and* written
+/// as a bare TOML key. `autumn-plugin-x/../../crates/serde` would otherwise be
+/// URL-normalised into a request for a different crate and then written as a
+/// key containing `/` and `.`, which no longer parses — the one outcome
+/// `plugin add` promises is impossible.
+///
+/// The bare prefix with nothing after it is not a crate name either.
 #[must_use]
 pub fn is_community_name(name: &str) -> bool {
-    name.strip_prefix(COMMUNITY_PREFIX)
-        .is_some_and(|rest| !rest.is_empty())
+    name.strip_prefix(COMMUNITY_PREFIX).is_some_and(|rest| {
+        !rest.is_empty()
+            && rest
+                .chars()
+                .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+    })
 }
 
 /// The `<Name>Plugin` struct a community crate is expected to expose, derived
@@ -201,19 +232,54 @@ pub fn community_mount_snippet(crate_name: &str) -> Option<String> {
 mod tests {
     use super::*;
 
+    /// Workspace members that are not plugin crates: the framework itself,
+    /// its macros, this CLI, the schema core, and the edge runtime (none of
+    /// which appear in `docs/plugins.md`'s first-party plugin table).
+    const NON_PLUGIN_MEMBERS: &[&str] = &[
+        "autumn",
+        "autumn-macros",
+        "autumn-cli",
+        "autumn-schema-core",
+        "autumn-edge",
+    ];
+
     /// AC #1: the listing covers **all** first-party plugins in this
     /// workspace, not just the three `plugin add` is spelled out for.
+    ///
+    /// The expected set is ENUMERATED from the workspace manifest rather than
+    /// hardcoded, so a sixth first-party plugin crate added later fails this
+    /// test instead of quietly never appearing in `autumn plugin list`.
     #[test]
     fn catalog_covers_every_first_party_plugin_in_the_workspace() {
+        let workspace = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .expect("workspace root");
+        let manifest = std::fs::read_to_string(workspace.join("Cargo.toml")).expect("manifest");
+        let table: toml::Table = toml::from_str(&manifest).expect("parse workspace manifest");
+        let members = table["workspace"]["members"]
+            .as_array()
+            .expect("members array");
+
+        let expected: Vec<String> = members
+            .iter()
+            .filter_map(toml::Value::as_str)
+            // Top-level crates only: `examples/*`, `benchmarks/*` and
+            // `example-e2e` are apps, not plugin crates.
+            .filter(|member| !member.contains('/') && *member != "example-e2e")
+            .filter(|member| !NON_PLUGIN_MEMBERS.contains(member))
+            .map(std::borrow::ToOwned::to_owned)
+            .collect();
+        assert!(
+            expected.len() >= 5,
+            "the workspace enumeration found too few plugin crates: {expected:?}"
+        );
+
         let names: Vec<&str> = FIRST_PARTY.iter().map(|e| e.crate_name).collect();
-        for expected in [
-            "autumn-admin-plugin",
-            "autumn-cache-redis",
-            "autumn-media-plugin",
-            "autumn-search",
-            "autumn-storage-s3",
-        ] {
-            assert!(names.contains(&expected), "catalog is missing {expected}");
+        for member in &expected {
+            assert!(
+                names.contains(&member.as_str()),
+                "catalog is missing the first-party plugin crate {member}"
+            );
         }
     }
 
@@ -296,9 +362,29 @@ mod tests {
     #[test]
     fn community_names_follow_the_documented_prefix() {
         assert!(is_community_name("autumn-plugin-live-feed"));
+        assert!(is_community_name("autumn-plugin-audit_log2"));
         assert!(!is_community_name("autumn-admin-plugin"));
         assert!(!is_community_name("autumn-plugin-"));
         assert!(!is_community_name("serde"));
+    }
+
+    /// The prefix check is the ONLY gate on a name that is interpolated into
+    /// a crates.io URL and written as a bare TOML key, so it must also reject
+    /// anything that is not a legal crate name. `autumn-plugin-x/../../crates/
+    /// serde` would otherwise be URL-normalised into a request for a
+    /// different crate and then written as a key that no longer parses.
+    #[test]
+    fn community_names_reject_anything_that_is_not_a_crate_name() {
+        for hostile in [
+            "autumn-plugin-x/../../crates/serde",
+            "autumn-plugin-x?q=1",
+            "autumn-plugin-x y",
+            "autumn-plugin-x\"\n[dependencies]\nevil = \"1",
+            "autumn-plugin-../serde",
+        ] {
+            assert!(!is_community_name(hostile), "{hostile:?} must be rejected");
+            assert!(community_mount_snippet(hostile).is_none(), "{hostile:?}");
+        }
     }
 
     /// `docs/plugins.md`: third-party crates are `autumn-plugin-<name>` and

--- a/autumn-cli/src/plugin/install.rs
+++ b/autumn-cli/src/plugin/install.rs
@@ -1,0 +1,757 @@
+//! Install planning for `autumn plugin add` — pure functions plus one
+//! [`emit::Plan`] builder, so `--dry-run` and the Created/Modified output match
+//! every other code-touching Autumn command.
+//!
+//! Every decision that can refuse the install (version gate, missing project,
+//! unreadable builder chain) is made *before* a single [`emit::Action`] is
+//! queued, which is what makes issue #1606's "fails before any file is
+//! modified" and "never leaves the app in a non-compiling state" true by
+//! construction rather than by careful ordering.
+
+use std::path::{Path, PathBuf};
+
+use crate::generate::emit::Plan;
+
+use super::catalog::CatalogEntry;
+
+/// Why an install could not proceed.
+#[derive(Debug, thiserror::Error)]
+pub enum PluginError {
+    /// The working directory is not an Autumn project root.
+    #[error("not inside an Autumn project (no Cargo.toml found in current directory)")]
+    NotInProject,
+
+    /// The project's `Cargo.toml` does not depend on `autumn-web`.
+    #[error(
+        "this project does not depend on `autumn-web`, so there is no plugin-compatible version to resolve"
+    )]
+    NoAutumnWeb,
+
+    /// The plugin's supported `autumn-web` range excludes the app's version.
+    #[error(
+        "`{crate_name} {plugin_version}` supports autumn-web {supported}, but this app uses autumn-web {app_version} — no files were modified.\nUpgrade the app with `autumn upgrade`, or install a `{crate_name}` release built for autumn-web {app_version}."
+    )]
+    Incompatible {
+        /// The plugin crate being installed.
+        crate_name: String,
+        /// The plugin version that would have been installed.
+        plugin_version: String,
+        /// The `autumn-web` range that plugin version supports.
+        supported: String,
+        /// The `autumn-web` version this app declares.
+        app_version: String,
+    },
+
+    /// The name is neither a first-party plugin nor a `autumn-plugin-` crate.
+    #[error(
+        "unknown plugin `{0}` — run `autumn plugin list` to see installable plugins. Community plugins follow the `autumn-plugin-<name>` convention documented in docs/plugins.md."
+    )]
+    UnknownPlugin(String),
+
+    /// Filesystem error while reading the project.
+    #[error("{0}")]
+    Io(#[from] std::io::Error),
+}
+
+/// How the app declares `autumn-web`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AppAutumnWeb {
+    /// A readable version requirement.
+    Version(String),
+    /// Declared through a `path`/`git`/workspace entry with no version here.
+    Unversioned,
+}
+
+/// The verdict of the version gate.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Compat {
+    /// The plugin supports the app's `autumn-web` version.
+    Compatible,
+    /// The plugin does not support the app's `autumn-web` version.
+    Incompatible,
+    /// One of the two versions could not be parsed.
+    Unknown,
+}
+
+/// What `plugin add` decided to do.
+#[derive(Debug)]
+pub enum AddOutcome {
+    /// The install can be applied.
+    Installed {
+        /// Filesystem actions to execute.
+        plan: Box<Plan>,
+        /// Post-install steps to print.
+        steps: Vec<String>,
+    },
+    /// Dependency and mount are both already present.
+    AlreadyInstalled,
+    /// The dependency was added but the mount was left to the user — a
+    /// community crate, whose `<Name>Plugin` the CLI can derive from the
+    /// naming convention but cannot verify.
+    DependencyOnly {
+        /// Filesystem actions to execute (the manifest edit).
+        plan: Box<Plan>,
+        /// The `[dependencies]` line that was added.
+        dependency_line: String,
+        /// The convention-derived builder-chain snippet to paste.
+        mount_snippet: String,
+    },
+    /// Nothing was changed; the user applies the printed lines by hand.
+    Manual {
+        /// Why the automatic edit was declined.
+        reason: String,
+        /// The `[dependencies]` line to add.
+        dependency_line: String,
+        /// The builder-chain snippet to paste.
+        mount_snippet: String,
+        /// Post-install steps to print.
+        steps: Vec<String>,
+    },
+}
+
+/// Compare the app's `autumn-web` requirement against the version of a plugin
+/// release.
+///
+/// First-party plugins are published in lockstep with `autumn-web`, so the
+/// plugin's version *is* the `autumn-web` version it was built against. The
+/// comparison follows Cargo's compatibility rule, which is also
+/// `STABILITY.md`'s pre-1.0 contract: below 1.0 every minor bump is breaking,
+/// so the minor has to match; from 1.0 on only the major does.
+#[must_use]
+pub fn check_compat(app_version: &str, plugin_supports: &str) -> Compat {
+    let (Some(app), Some(plugin)) = (parse_version(app_version), parse_version(plugin_supports))
+    else {
+        return Compat::Unknown;
+    };
+    let compatible = if app.0 == 0 || plugin.0 == 0 {
+        app.0 == plugin.0 && app.1 == plugin.1
+    } else {
+        app.0 == plugin.0
+    };
+    if compatible {
+        Compat::Compatible
+    } else {
+        Compat::Incompatible
+    }
+}
+
+/// The `autumn-web` range a first-party plugin at `version` supports, as it is
+/// printed in the incompatibility diagnostic: `0.7` below 1.0 (where the minor
+/// is part of the compatibility key), `2` from 1.0 on.
+#[must_use]
+pub fn supported_range(version: &str) -> String {
+    match parse_version(version) {
+        Some((0, minor, _)) => format!("0.{minor}"),
+        Some((major, _, _)) => major.to_string(),
+        None => version.to_owned(),
+    }
+}
+
+/// Parse `MAJOR.MINOR[.PATCH]`, tolerating a leading requirement operator and
+/// a pre-release/build suffix. Mirrors `doctor::check_version_compat`'s parser
+/// so the two commands can never disagree about what a version means.
+fn parse_version(version: &str) -> Option<(u64, u64, u64)> {
+    let version = version
+        .trim()
+        .trim_start_matches(['=', '^', '~', '>', '<', ' ']);
+    let mut parts = version.split('.');
+    let major: u64 = parts.next()?.trim().parse().ok()?;
+    let minor: u64 = parts.next()?.trim().parse().ok()?;
+    let patch: u64 = parts.next().map_or(0, |p| {
+        p.split(|c: char| !c.is_ascii_digit())
+            .next()
+            .unwrap_or("0")
+            .parse()
+            .unwrap_or(0)
+    });
+    Some((major, minor, patch))
+}
+
+/// Read how the project at `root` declares `autumn-web`.
+///
+/// # Errors
+///
+/// [`PluginError::NotInProject`] when there is no `Cargo.toml`, and
+/// [`PluginError::NoAutumnWeb`] when it does not mention `autumn-web`.
+pub fn app_autumn_web(root: &Path) -> Result<AppAutumnWeb, PluginError> {
+    if !manifest_path(root).is_file() {
+        return Err(PluginError::NotInProject);
+    }
+    let declarations = crate::doctor::autumn_web_declarations_at(root);
+    let mut declared = false;
+    for declaration in &declarations {
+        match declaration {
+            crate::doctor::AutumnWebDependency::Version(version) => {
+                return Ok(AppAutumnWeb::Version(version.clone()));
+            }
+            crate::doctor::AutumnWebDependency::WithoutVersion => declared = true,
+            // `Inherited` comes back for ANY `{ workspace = true }` entry, not
+            // just this crate's — the scan cannot tell them apart by itself —
+            // so only the entry actually keyed `autumn-web` counts here.
+            crate::doctor::AutumnWebDependency::Inherited(key) => {
+                declared |= key == "autumn-web";
+            }
+            crate::doctor::AutumnWebDependency::Absent
+            | crate::doctor::AutumnWebDependency::Unreadable => {}
+        }
+    }
+    if declared {
+        Ok(AppAutumnWeb::Unversioned)
+    } else {
+        Err(PluginError::NoAutumnWeb)
+    }
+}
+
+/// The `[dependencies]` line `plugin add` writes (and prints).
+#[must_use]
+pub fn dependency_line(crate_name: &str, version: &str) -> String {
+    format!("{crate_name} = \"{version}\"")
+}
+
+/// Whether `manifest` already declares `crate_name` in any dependency table.
+///
+/// Parsed rather than substring-matched: a commented-out line or a mention in
+/// a `description` must not make an install look done.
+#[must_use]
+pub fn dependency_present(manifest: &str, crate_name: &str) -> bool {
+    let Ok(table) = toml::from_str::<toml::Table>(manifest) else {
+        return false;
+    };
+    ["dependencies", "dev-dependencies", "build-dependencies"]
+        .iter()
+        .filter_map(|kind| table.get(*kind))
+        .filter_map(toml::Value::as_table)
+        .any(|deps| deps.contains_key(crate_name))
+}
+
+/// Whether `main_rs` already mounts the plugin **in code** — a mention inside
+/// a comment (a README snippet pasted into the file) does not count.
+///
+/// Sharing [`crate::rust_source::for_each_code_line`] with the anchor scan is
+/// deliberate: if the two disagreed about what a comment is, a doc-comment
+/// mention could suppress both the mount and the warning about it.
+#[must_use]
+pub fn mount_present(main_rs: &str, probe: &str) -> bool {
+    crate::rust_source::for_each_code_line(main_rs, |line, _offset| {
+        line.contains(probe).then_some(())
+    })
+    .is_some()
+}
+
+/// Byte offset just past the builder-opening `autumn_web::app()` inside
+/// `main()`, or `None` when there is no unambiguous anchor.
+///
+/// Only a line that *ends* with the opener is an anchor. A one-line chain
+/// (`autumn_web::app().routes(…).run().await;`) has no place to splice a call
+/// into, and a mention inside a comment is not code at all — in both cases the
+/// caller degrades to printed instructions rather than guessing (AC #5).
+fn builder_anchor(main_rs: &str) -> Option<usize> {
+    let mut seen_main = false;
+    crate::rust_source::for_each_code_line(main_rs, |line, offset| {
+        if line.trim().contains("async fn main") {
+            seen_main = true;
+        }
+        (seen_main && line.trim_end().ends_with("autumn_web::app()"))
+            .then(|| offset + line.trim_end().len())
+    })
+}
+
+/// Splice `mount` into the `AppBuilder` chain, or `None` when the chain has no
+/// unambiguous anchor (a heavily customized `main.rs`).
+#[must_use]
+pub fn insert_mount(main_rs: &str, mount: &str) -> Option<String> {
+    let anchor_end = builder_anchor(main_rs)?;
+    let snippet = mount.trim_end_matches('\n');
+    let mut out = String::with_capacity(main_rs.len() + snippet.len() + 1);
+    out.push_str(&main_rs[..anchor_end]);
+    out.push('\n');
+    out.push_str(snippet);
+    out.push_str(&main_rs[anchor_end..]);
+    Some(out)
+}
+
+/// The post-install steps printed for `entry`: its config keys first (nothing
+/// else can be done until the app is configured), then its follow-ups.
+#[must_use]
+pub fn steps_for(entry: &CatalogEntry) -> Vec<String> {
+    let mut steps = Vec::with_capacity(entry.config_keys.len() + entry.post_install.len());
+    for keys in entry.config_keys {
+        steps.push(format!(
+            "Add to `autumn.toml`:\n\n{}\n",
+            indent(keys, "         ")
+        ));
+    }
+    steps.extend(entry.post_install.iter().map(|step| (*step).to_owned()));
+    steps
+}
+
+/// Indent every non-empty line of `text` by `prefix`.
+fn indent(text: &str, prefix: &str) -> String {
+    text.lines()
+        .map(|line| {
+            if line.is_empty() {
+                String::new()
+            } else {
+                format!("{prefix}{line}")
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+/// Plan the install of `entry` at `version` into the project at `root`.
+///
+/// Ordering is the contract: the project check and the version gate run before
+/// a single [`crate::generate::emit::Action`] exists, and the builder-chain
+/// edit is computed (not applied) before the manifest edit is queued — so
+/// every refusal leaves the app byte-identical, and no outcome can add a
+/// dependency whose mount never landed.
+///
+/// # Errors
+///
+/// [`PluginError::NotInProject`], [`PluginError::NoAutumnWeb`],
+/// [`PluginError::Incompatible`], or an I/O error reading the manifest.
+pub fn plan_add(
+    root: &Path,
+    entry: &CatalogEntry,
+    version: &str,
+) -> Result<AddOutcome, PluginError> {
+    if let AppAutumnWeb::Version(app_version) = app_autumn_web(root)?
+        && check_compat(&app_version, version) == Compat::Incompatible
+    {
+        return Err(PluginError::Incompatible {
+            crate_name: entry.crate_name.to_owned(),
+            plugin_version: version.to_owned(),
+            supported: supported_range(version),
+            app_version,
+        });
+    }
+
+    let manifest = manifest_path(root);
+    let manifest_src = std::fs::read_to_string(&manifest)?;
+    let main_path = root.join("src").join("main.rs");
+    let main_src = std::fs::read_to_string(&main_path).unwrap_or_default();
+
+    let dependency_installed = dependency_present(&manifest_src, entry.crate_name);
+    let already_mounted = mount_present(&main_src, entry.probe);
+    if dependency_installed && already_mounted {
+        return Ok(AddOutcome::AlreadyInstalled);
+    }
+
+    let mounted_src = if already_mounted {
+        None
+    } else {
+        match insert_mount(&main_src, entry.mount) {
+            Some(updated) => Some(updated),
+            None => {
+                return Ok(AddOutcome::Manual {
+                    reason: format!(
+                        "could not find the `autumn_web::app()` builder chain in {} — nothing was changed",
+                        main_path.display().to_string().replace('\\', "/")
+                    ),
+                    dependency_line: dependency_line(entry.crate_name, version),
+                    mount_snippet: entry.mount.trim_end_matches('\n').to_owned(),
+                    steps: steps_for(entry),
+                });
+            }
+        }
+    };
+
+    let mut plan = Plan::new(root);
+    let spec = format!("\"{version}\"");
+    let updated_manifest = crate::generate::model::ensure_cargo_dependencies(
+        &manifest_src,
+        &[(entry.crate_name, spec.as_str())],
+    );
+    if updated_manifest != manifest_src {
+        plan.modify(manifest, updated_manifest);
+    }
+    if let Some(updated_main) = mounted_src {
+        plan.modify(main_path, updated_main);
+    }
+    Ok(AddOutcome::Installed {
+        plan: Box::new(plan),
+        steps: steps_for(entry),
+    })
+}
+
+/// Plan the dependency-only install of a community crate.
+///
+/// The mount is derived from the naming convention and *printed*, never
+/// spliced: nothing here can verify a third-party crate exposes
+/// `<Name>Plugin`, and an unused dependency always compiles while a wrong
+/// mount does not.
+///
+/// # Errors
+///
+/// [`PluginError::NotInProject`], [`PluginError::NoAutumnWeb`], or an I/O
+/// error reading the manifest.
+pub fn plan_add_community(
+    root: &Path,
+    crate_name: &str,
+    version: &str,
+) -> Result<AddOutcome, PluginError> {
+    app_autumn_web(root)?;
+    let manifest = manifest_path(root);
+    let manifest_src = std::fs::read_to_string(&manifest)?;
+    let snippet = super::catalog::community_mount_snippet(crate_name)
+        .unwrap_or_else(|| "        .plugin(/* see the crate's README */)".to_owned());
+
+    if dependency_present(&manifest_src, crate_name) {
+        return Ok(AddOutcome::AlreadyInstalled);
+    }
+    let mut plan = Plan::new(root);
+    let spec = format!("\"{version}\"");
+    let updated = crate::generate::model::ensure_cargo_dependencies(
+        &manifest_src,
+        &[(crate_name, spec.as_str())],
+    );
+    if updated != manifest_src {
+        plan.modify(manifest, updated);
+    }
+    Ok(AddOutcome::DependencyOnly {
+        plan: Box::new(plan),
+        dependency_line: dependency_line(crate_name, version),
+        mount_snippet: snippet,
+    })
+}
+
+/// `root`'s `Cargo.toml`.
+#[must_use]
+pub fn manifest_path(root: &Path) -> PathBuf {
+    root.join("Cargo.toml")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::plugin::catalog;
+
+    /// The `main.rs` an `autumn new` app ships with, reduced to the shape that
+    /// matters here: a builder chain opened by `autumn_web::app()`.
+    const SCAFFOLD_MAIN: &str = r"use autumn_web::prelude::*;
+
+#[autumn_web::main]
+async fn main() {
+    let app = autumn_web::app()
+        .routes(routes![index])
+        .migrations(MIGRATIONS);
+
+    app
+        .run()
+        .await;
+}
+";
+
+    const SCAFFOLD_CARGO: &str = r#"[package]
+name = "demo"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+autumn-web = "0.7.0"
+maud = { version = "0.27", features = ["axum"] }
+"#;
+
+    fn fake_project(main_rs: &str, cargo: &str) -> tempfile::TempDir {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(tmp.path().join("Cargo.toml"), cargo).unwrap();
+        std::fs::create_dir_all(tmp.path().join("src")).unwrap();
+        std::fs::write(tmp.path().join("src/main.rs"), main_rs).unwrap();
+        tmp
+    }
+
+    fn admin() -> &'static catalog::CatalogEntry {
+        catalog::lookup("autumn-admin-plugin").expect("admin entry")
+    }
+
+    // ── AC #3: version safety ────────────────────────────────────────────────
+
+    #[test]
+    fn same_minor_series_is_compatible() {
+        assert_eq!(check_compat("0.7.0", "0.7.0"), Compat::Compatible);
+        assert_eq!(check_compat("0.7.3", "0.7.0"), Compat::Compatible);
+        assert_eq!(check_compat("^0.7", "0.7.0"), Compat::Compatible);
+    }
+
+    /// Pre-1.0, Cargo treats every minor bump as breaking — the STABILITY.md
+    /// contract this composes with.
+    #[test]
+    fn different_minor_series_is_incompatible_pre_1_0() {
+        assert_eq!(check_compat("0.6.0", "0.7.0"), Compat::Incompatible);
+        assert_eq!(check_compat("0.8.0", "0.7.0"), Compat::Incompatible);
+    }
+
+    #[test]
+    fn post_1_0_only_the_major_has_to_match() {
+        assert_eq!(check_compat("1.2.0", "1.5.0"), Compat::Compatible);
+        assert_eq!(check_compat("2.0.0", "1.5.0"), Compat::Incompatible);
+    }
+
+    #[test]
+    fn unparseable_versions_are_unknown_not_incompatible() {
+        assert_eq!(check_compat("wat", "0.7.0"), Compat::Unknown);
+        assert_eq!(check_compat("0.7.0", "wat"), Compat::Unknown);
+    }
+
+    #[test]
+    fn supported_range_names_the_minor_series_pre_1_0() {
+        assert_eq!(supported_range("0.7.0"), "0.7");
+        assert_eq!(supported_range("1.4.2"), "1");
+    }
+
+    #[test]
+    fn app_autumn_web_reads_the_declared_version() {
+        let tmp = fake_project(SCAFFOLD_MAIN, SCAFFOLD_CARGO);
+        assert_eq!(
+            app_autumn_web(tmp.path()).unwrap(),
+            AppAutumnWeb::Version("0.7.0".to_owned())
+        );
+    }
+
+    #[test]
+    fn app_autumn_web_tolerates_a_path_dependency() {
+        let tmp = fake_project(
+            SCAFFOLD_MAIN,
+            "[package]\nname = \"demo\"\n\n[dependencies]\nautumn-web = { path = \"../autumn\" }\n",
+        );
+        assert_eq!(
+            app_autumn_web(tmp.path()).unwrap(),
+            AppAutumnWeb::Unversioned
+        );
+    }
+
+    #[test]
+    fn app_autumn_web_rejects_a_non_autumn_project() {
+        let tmp = fake_project(
+            SCAFFOLD_MAIN,
+            "[package]\nname = \"demo\"\n\n[dependencies]\nserde = \"1\"\n",
+        );
+        assert!(matches!(
+            app_autumn_web(tmp.path()).unwrap_err(),
+            PluginError::NoAutumnWeb
+        ));
+        let empty = tempfile::tempdir().unwrap();
+        assert!(matches!(
+            app_autumn_web(empty.path()).unwrap_err(),
+            PluginError::NotInProject
+        ));
+    }
+
+    /// AC #3: the refusal happens **before any file is modified**, and names
+    /// both versions.
+    #[test]
+    fn incompatible_app_version_fails_without_touching_any_file() {
+        let cargo = SCAFFOLD_CARGO.replace("autumn-web = \"0.7.0\"", "autumn-web = \"0.5.0\"");
+        let tmp = fake_project(SCAFFOLD_MAIN, &cargo);
+        let before_cargo = std::fs::read_to_string(tmp.path().join("Cargo.toml")).unwrap();
+        let before_main = std::fs::read_to_string(tmp.path().join("src/main.rs")).unwrap();
+
+        let err = plan_add(tmp.path(), admin(), "0.7.0").unwrap_err();
+        let message = err.to_string();
+        assert!(message.contains("0.5.0"), "{message}");
+        assert!(message.contains("0.7"), "{message}");
+        assert!(message.contains("autumn-admin-plugin"), "{message}");
+
+        assert_eq!(
+            std::fs::read_to_string(tmp.path().join("Cargo.toml")).unwrap(),
+            before_cargo
+        );
+        assert_eq!(
+            std::fs::read_to_string(tmp.path().join("src/main.rs")).unwrap(),
+            before_main
+        );
+    }
+
+    // ── AC #2: dependency + mount ────────────────────────────────────────────
+
+    #[test]
+    fn dependency_line_is_the_shorthand_form() {
+        assert_eq!(
+            dependency_line("autumn-admin-plugin", "0.7.0"),
+            "autumn-admin-plugin = \"0.7.0\""
+        );
+    }
+
+    #[test]
+    fn plan_add_writes_the_dependency_and_the_mount() {
+        let tmp = fake_project(SCAFFOLD_MAIN, SCAFFOLD_CARGO);
+        let outcome = plan_add(tmp.path(), admin(), "0.7.0").unwrap();
+        let AddOutcome::Installed { plan, steps } = outcome else {
+            panic!("expected an installable plan");
+        };
+        plan.execute(crate::generate::Flags::default()).unwrap();
+
+        let cargo = std::fs::read_to_string(tmp.path().join("Cargo.toml")).unwrap();
+        assert!(cargo.contains("autumn-admin-plugin = \"0.7.0\""), "{cargo}");
+
+        let main_rs = std::fs::read_to_string(tmp.path().join("src/main.rs")).unwrap();
+        assert!(
+            main_rs.contains(".plugin(autumn_admin_plugin::AdminPlugin::new())"),
+            "{main_rs}"
+        );
+        assert!(main_rs.contains(".routes(routes![index])"), "{main_rs}");
+        assert!(
+            steps.iter().any(|s| s.contains("autumn generate admin")),
+            "{steps:?}"
+        );
+    }
+
+    /// The mount must land inside the builder chain, i.e. between
+    /// `autumn_web::app()` and the first existing call.
+    #[test]
+    fn mount_lands_inside_the_builder_chain() {
+        let updated = insert_mount(SCAFFOLD_MAIN, admin().mount).expect("anchor");
+        let app_at = updated.find("autumn_web::app()").unwrap();
+        let mount_at = updated.find(admin().probe).unwrap();
+        let routes_at = updated.find(".routes(").unwrap();
+        assert!(app_at < mount_at && mount_at < routes_at, "{updated}");
+    }
+
+    #[test]
+    fn insert_mount_preserves_everything_else() {
+        let updated = insert_mount(SCAFFOLD_MAIN, admin().mount).expect("anchor");
+        for line in SCAFFOLD_MAIN.lines() {
+            assert!(updated.contains(line), "lost line {line:?}");
+        }
+    }
+
+    // ── AC #4: idempotency ───────────────────────────────────────────────────
+
+    #[test]
+    fn mount_present_ignores_comment_mentions() {
+        let commented = "// autumn_admin_plugin::AdminPlugin::new()\nfn main() {}\n";
+        assert!(!mount_present(commented, admin().probe));
+        let block = "/*\nautumn_admin_plugin::AdminPlugin::new()\n*/\nfn main() {}\n";
+        assert!(!mount_present(block, admin().probe));
+        let real = "fn main() { app.plugin(autumn_admin_plugin::AdminPlugin::new()); }\n";
+        assert!(mount_present(real, admin().probe));
+    }
+
+    #[test]
+    fn second_add_changes_nothing_and_says_so() {
+        let tmp = fake_project(SCAFFOLD_MAIN, SCAFFOLD_CARGO);
+        let AddOutcome::Installed { plan, .. } = plan_add(tmp.path(), admin(), "0.7.0").unwrap()
+        else {
+            panic!("expected an installable plan");
+        };
+        plan.execute(crate::generate::Flags::default()).unwrap();
+
+        let cargo_after = std::fs::read_to_string(tmp.path().join("Cargo.toml")).unwrap();
+        let main_after = std::fs::read_to_string(tmp.path().join("src/main.rs")).unwrap();
+
+        let second = plan_add(tmp.path(), admin(), "0.7.0").unwrap();
+        assert!(matches!(second, AddOutcome::AlreadyInstalled), "{second:?}");
+
+        assert_eq!(
+            std::fs::read_to_string(tmp.path().join("Cargo.toml")).unwrap(),
+            cargo_after
+        );
+        assert_eq!(
+            std::fs::read_to_string(tmp.path().join("src/main.rs")).unwrap(),
+            main_after
+        );
+        assert_eq!(
+            main_after.matches("AdminPlugin::new()").count(),
+            1,
+            "duplicate mount: {main_after}"
+        );
+    }
+
+    /// A half-installed app (dependency by hand, no mount) must still get the
+    /// mount rather than being reported as already installed.
+    #[test]
+    fn a_dependency_without_a_mount_is_completed() {
+        let cargo = format!("{SCAFFOLD_CARGO}autumn-admin-plugin = \"0.7.0\"\n");
+        let tmp = fake_project(SCAFFOLD_MAIN, &cargo);
+        let AddOutcome::Installed { plan, .. } = plan_add(tmp.path(), admin(), "0.7.0").unwrap()
+        else {
+            panic!("expected an installable plan");
+        };
+        plan.execute(crate::generate::Flags::default()).unwrap();
+        let main_rs = std::fs::read_to_string(tmp.path().join("src/main.rs")).unwrap();
+        assert!(main_rs.contains(admin().probe), "{main_rs}");
+        let cargo_after = std::fs::read_to_string(tmp.path().join("Cargo.toml")).unwrap();
+        assert_eq!(
+            cargo_after.matches("autumn-admin-plugin =").count(),
+            1,
+            "duplicate dependency: {cargo_after}"
+        );
+    }
+
+    // ── AC #5: safe degradation ──────────────────────────────────────────────
+
+    /// A single-line chain has nowhere to splice a call, so the command must
+    /// decline rather than guess.
+    #[test]
+    fn a_single_line_builder_chain_has_no_anchor() {
+        let src = "#[autumn_web::main]\nasync fn main() {\n    autumn_web::app().routes(routes![]).run().await;\n}\n";
+        assert!(insert_mount(src, admin().mount).is_none());
+    }
+
+    /// A `main.rs` that only mentions the builder inside a doc comment must
+    /// not be spliced into the comment.
+    #[test]
+    fn a_commented_builder_is_not_an_anchor() {
+        let src = "//! Quick start:\n//!\n//!     autumn_web::app()\n//!         .run()\n\nfn main() {}\n";
+        assert!(insert_mount(src, admin().mount).is_none());
+    }
+
+    #[test]
+    fn a_customized_main_degrades_to_printed_instructions() {
+        let custom = "#[autumn_web::main]\nasync fn main() {\n    bootstrap().await;\n}\n";
+        let tmp = fake_project(custom, SCAFFOLD_CARGO);
+        let before_cargo = std::fs::read_to_string(tmp.path().join("Cargo.toml")).unwrap();
+
+        let outcome = plan_add(tmp.path(), admin(), "0.7.0").unwrap();
+        let AddOutcome::Manual {
+            dependency_line: dep,
+            mount_snippet,
+            reason,
+            ..
+        } = outcome
+        else {
+            panic!("expected the manual fallback");
+        };
+        assert_eq!(dep, "autumn-admin-plugin = \"0.7.0\"");
+        assert!(
+            mount_snippet.contains("AdminPlugin::new()"),
+            "{mount_snippet}"
+        );
+        assert!(!reason.is_empty());
+
+        // Nothing was written.
+        assert_eq!(
+            std::fs::read_to_string(tmp.path().join("Cargo.toml")).unwrap(),
+            before_cargo
+        );
+        assert_eq!(
+            std::fs::read_to_string(tmp.path().join("src/main.rs")).unwrap(),
+            custom
+        );
+    }
+
+    #[test]
+    fn plan_add_outside_a_project_is_an_error() {
+        let tmp = tempfile::tempdir().unwrap();
+        assert!(matches!(
+            plan_add(tmp.path(), admin(), "0.7.0").unwrap_err(),
+            PluginError::NotInProject
+        ));
+    }
+
+    /// Every first-party mount must find the scaffold's anchor — otherwise
+    /// `autumn plugin add` degrades on the very app `autumn new` produces.
+    #[test]
+    fn every_first_party_mount_applies_to_a_fresh_scaffold() {
+        for entry in catalog::FIRST_PARTY {
+            let updated = insert_mount(SCAFFOLD_MAIN, entry.mount)
+                .unwrap_or_else(|| panic!("{}: no anchor", entry.crate_name));
+            assert!(
+                mount_present(&updated, entry.probe),
+                "{}: mount not detected after insertion",
+                entry.crate_name
+            );
+        }
+    }
+}

--- a/autumn-cli/src/plugin/install.rs
+++ b/autumn-cli/src/plugin/install.rs
@@ -270,59 +270,70 @@ pub fn dependency_line(crate_name: &str, version: &str) -> String {
     format!("{crate_name} = \"{version}\"")
 }
 
-/// Whether `manifest` already declares `crate_name` as a **normal** dependency
-/// of the application target.
+/// Whether `manifest` already declares `crate_name` as an unconditional
+/// `[dependencies]` entry.
 ///
 /// Parsed rather than substring-matched: a commented-out line or a mention in
 /// a `description` must not make an install look done.
+///
+/// `[dependencies]` **only** — not `[dev-dependencies]`, not
+/// `[build-dependencies]`, and not `[target.'cfg(…)'.dependencies]`. The mount
+/// this command writes is unconditional, so anything that does not make the
+/// crate available to every application build cannot count as installed:
+/// a dev-dependency is invisible to the binary, and a `cfg(windows)`
+/// dependency is absent on the Linux build. Counting either would report a
+/// complete install for an app that does not compile, *and* would stop the
+/// command adding the entry that fixes it.
 #[must_use]
 pub fn dependency_present(manifest: &str, crate_name: &str) -> bool {
     let Ok(table) = toml::from_str::<toml::Table>(manifest) else {
         return false;
     };
-    // `[dependencies]` and the per-target normal tables ONLY. A crate declared
-    // under `[dev-dependencies]` or `[build-dependencies]` is not available to
-    // the application target, so counting one as installed would report a
-    // complete install for an app that cannot compile — and would stop the
-    // command adding the `[dependencies]` entry that fixes it.
-    let targets = table.get("target").and_then(toml::Value::as_table);
     table
         .get("dependencies")
-        .into_iter()
-        .chain(targets.into_iter().flat_map(|targets| {
-            targets
-                .values()
-                .filter_map(|target| target.get("dependencies"))
-        }))
-        .filter_map(toml::Value::as_table)
-        .any(|deps| deps.contains_key(crate_name))
+        .and_then(toml::Value::as_table)
+        .is_some_and(|deps| deps.contains_key(crate_name))
 }
 
-/// Whether `main_rs` already mounts the plugin **in code**.
+/// Whether `main_rs` already mounts `entry` **in code**.
 ///
-/// `probes` are the spellings a mount can take: the fully-qualified path this
-/// command writes (`autumn_search::SearchPlugin`) and the bare call a
-/// hand-written mount uses after a `use` import (`SearchPlugin::new(`). Both
-/// are needed, in both directions: without the bare form a hand-configured
-/// `.plugin(SearchPlugin::new().index::<Post>())` is not detected and `add`
-/// splices a *second*, default-constructed mount — which `AppBuilder::plugin`
-/// then keeps in preference to the user's, silently discarding their
-/// configuration.
+/// Two independent kinds of evidence, because a single substring test is wrong
+/// in both directions:
 ///
-/// `use` lines are excluded for the mirror-image reason: a bare
-/// `use autumn_search::SearchPlugin;` import is not a mount, and treating it
-/// as one made `add` report "already installed" for an app that mounts
-/// nothing.
+/// - The plugin's **type path** inside a [`CatalogEntry::mount_call`]
+///   argument (`.plugin(…)` / `.with_blob_store(…)`), located by a
+///   balanced-paren scan so a mount split across lines still matches. The type
+///   path is only trusted *there*: on its own it is just a name, and
+///   `fn configure(_: autumn_admin_plugin::AdminPlugin) {}` would otherwise
+///   read as a mount and suppress the real one.
+/// - The plugin's **constructor call** (`AdminPlugin::new(`) anywhere in code.
+///   A plugin built into a variable and mounted as `.plugin(configured)` is
+///   still a mount, and the mount call alone cannot see that. Splicing a
+///   second, default-constructed mount over it would take priority in
+///   `AppBuilder::plugin`'s duplicate check and silently discard the user's
+///   configuration — the worse of the two failures.
 ///
-/// Sharing [`crate::rust_source::code_lines`] with the anchor scan is
-/// deliberate: if the two disagreed about what a comment is, a doc-comment
-/// mention could suppress both the mount and the warning about it.
+/// Both run against [`crate::rust_source::mask_non_code`] output, so neither a
+/// comment nor a string literal can spoof either one.
 #[must_use]
-pub fn mount_present(main_rs: &str, probes: &[&str]) -> bool {
-    crate::rust_source::code_lines(main_rs)
-        .into_iter()
-        .filter(|(line, _)| !line.trim_start().starts_with("use "))
-        .any(|(line, _)| probes.iter().any(|probe| line.contains(probe)))
+pub fn mount_present(main_rs: &str, entry: &CatalogEntry) -> bool {
+    let masked = crate::rust_source::mask_non_code(main_rs);
+    if masked.contains(entry.constructor) {
+        return true;
+    }
+    let mut from = 0usize;
+    while let Some(found) = masked[from..].find(entry.mount_call) {
+        // The `(` the call opens with is the last byte of `mount_call`.
+        let open = from + found + entry.mount_call.len() - 1;
+        let Some(close) = crate::rust_source::balanced_close_paren(&masked, open) else {
+            return false;
+        };
+        if masked[open + 1..close].contains(entry.mount_arg) {
+            return true;
+        }
+        from = close;
+    }
+    false
 }
 
 /// Byte offset just past the builder-opening `autumn_web::app()` **inside the
@@ -351,7 +362,7 @@ fn builder_anchor(main_rs: &str) -> Option<usize> {
     let lines = crate::rust_source::code_lines(main_rs);
     let main_at = lines
         .iter()
-        .position(|(line, _)| line.trim().contains("async fn main"))?;
+        .position(|(line, _)| crate::rust_source::declares_async_main(line))?;
     // The body ends at the first code line that closes a brace at column 0 —
     // the closing brace of a top-level `async fn main`.
     let body_end = lines
@@ -450,7 +461,7 @@ pub fn plan_add(
     let main_src = std::fs::read_to_string(&main_path).unwrap_or_default();
 
     let dependency_installed = dependency_present(&manifest_src, entry.crate_name);
-    let already_mounted = mount_present(&main_src, &entry.probes());
+    let already_mounted = mount_present(&main_src, entry);
     if dependency_installed && already_mounted {
         return Ok(AddOutcome::AlreadyInstalled);
     }
@@ -737,7 +748,7 @@ maud = { version = "0.27", features = ["axum"] }
     fn mount_lands_inside_the_builder_chain() {
         let updated = insert_mount(SCAFFOLD_MAIN, admin().mount).expect("anchor");
         let app_at = updated.find("autumn_web::app()").unwrap();
-        let mount_at = updated.find(admin().probe).unwrap();
+        let mount_at = updated.find(admin().mount_arg).unwrap();
         let routes_at = updated.find(".routes(").unwrap();
         assert!(app_at < mount_at && mount_at < routes_at, "{updated}");
     }
@@ -755,11 +766,11 @@ maud = { version = "0.27", features = ["axum"] }
     #[test]
     fn mount_present_ignores_comment_mentions() {
         let commented = "// autumn_admin_plugin::AdminPlugin::new()\nfn main() {}\n";
-        assert!(!mount_present(commented, &admin().probes()));
+        assert!(!mount_present(commented, admin()));
         let block = "/*\nautumn_admin_plugin::AdminPlugin::new()\n*/\nfn main() {}\n";
-        assert!(!mount_present(block, &admin().probes()));
+        assert!(!mount_present(block, admin()));
         let real = "fn main() { app.plugin(autumn_admin_plugin::AdminPlugin::new()); }\n";
-        assert!(mount_present(real, &admin().probes()));
+        assert!(mount_present(real, admin()));
     }
 
     /// A bare `use` import is not a mount. Counting it as one made `add`
@@ -768,7 +779,7 @@ maud = { version = "0.27", features = ["axum"] }
     #[test]
     fn an_import_alone_is_not_a_mount() {
         let imported = "use autumn_admin_plugin::AdminPlugin;\n\nfn main() {}\n";
-        assert!(!mount_present(imported, &admin().probes()));
+        assert!(!mount_present(imported, admin()));
     }
 
     /// A hand-written mount through an import carries only the bare call, so
@@ -779,7 +790,7 @@ maud = { version = "0.27", features = ["axum"] }
     fn a_hand_written_mount_behind_an_import_is_detected() {
         let src = "use autumn_admin_plugin::AdminPlugin;\n\nfn main() {\n    \
                    app.plugin(AdminPlugin::new().require_role(\"staff\"));\n}\n";
-        assert!(mount_present(src, &admin().probes()));
+        assert!(mount_present(src, admin()));
     }
 
     #[test]
@@ -824,7 +835,7 @@ maud = { version = "0.27", features = ["axum"] }
         };
         plan.execute(crate::generate::Flags::default()).unwrap();
         let main_rs = std::fs::read_to_string(tmp.path().join("src/main.rs")).unwrap();
-        assert!(main_rs.contains(admin().probe), "{main_rs}");
+        assert!(main_rs.contains(admin().mount_arg), "{main_rs}");
         let cargo_after = std::fs::read_to_string(tmp.path().join("Cargo.toml")).unwrap();
         assert_eq!(
             cargo_after.matches("autumn-admin-plugin =").count(),
@@ -841,7 +852,7 @@ maud = { version = "0.27", features = ["axum"] }
         let src = "#[autumn_web::main]\nasync fn main() {\n    \
                    let help = \"paste AdminPlugin::new( into your builder\";\n    \
                    let app = autumn_web::app()\n        .routes(routes![index]);\n}\n";
-        assert!(!mount_present(src, &admin().probes()));
+        assert!(!mount_present(src, admin()));
 
         let tmp = fake_project(src, SCAFFOLD_CARGO);
         let AddOutcome::Installed { plan, .. } = plan_add(tmp.path(), admin(), "0.7.0").unwrap()
@@ -885,12 +896,61 @@ maud = { version = "0.27", features = ["axum"] }
         );
     }
 
+    /// A target-gated dependency cannot back the unconditional mount this
+    /// command writes: on any build where the predicate is false the crate is
+    /// absent, so counting it as installed would report success for an app
+    /// that does not compile — and would decline to add the entry that fixes
+    /// it.
     #[test]
-    fn a_target_specific_normal_dependency_counts_as_installed() {
+    fn a_target_gated_dependency_does_not_count_as_installed() {
         let cargo = format!(
-            "{SCAFFOLD_CARGO}\n[target.'cfg(unix)'.dependencies]\nautumn-admin-plugin = \"0.7.0\"\n"
+            "{SCAFFOLD_CARGO}\n[target.'cfg(windows)'.dependencies]\nautumn-admin-plugin = \"0.7.0\"\n"
         );
-        assert!(dependency_present(&cargo, "autumn-admin-plugin"));
+        assert!(!dependency_present(&cargo, "autumn-admin-plugin"));
+    }
+
+    /// A plugin type in a signature is not a mount. Reading one as a mount
+    /// suppressed the real insertion while the command reported success.
+    #[test]
+    fn a_type_annotation_is_not_a_mount() {
+        let src = "fn configure(_: autumn_admin_plugin::AdminPlugin) {}\n\
+                   #[autumn_web::main]\nasync fn main() {\n    \
+                   let app = autumn_web::app()\n        .routes(routes![index]);\n}\n";
+        assert!(!mount_present(src, admin()));
+    }
+
+    /// …but a plugin built into a variable and mounted through it IS a mount:
+    /// splicing a second, default-constructed one would win the duplicate
+    /// check and discard the user's configuration.
+    #[test]
+    fn a_constructor_bound_to_a_variable_is_a_mount() {
+        let src = "#[autumn_web::main]\nasync fn main() {\n    \
+                   let configured = AdminPlugin::new().require_role(\"staff\");\n    \
+                   let app = autumn_web::app().plugin(configured);\n}\n";
+        assert!(mount_present(src, admin()));
+    }
+
+    /// A mount split across lines — the shape rustfmt produces, and the shape
+    /// this command writes for `autumn-storage-s3` — must still be detected.
+    #[test]
+    fn a_multi_line_mount_is_detected() {
+        let src = "#[autumn_web::main]\nasync fn main() {\n    \
+                   let app = autumn_web::app()\n        .plugin(\n            \
+                   autumn_search::SearchPlugin::new()\n                \
+                   .postgres(),\n        );\n}\n";
+        let search = catalog::lookup("autumn-search").expect("search entry");
+        assert!(mount_present(src, search));
+    }
+
+    /// A helper whose name merely starts with `main` is not the entry point:
+    /// splicing into it mounts the plugin where the binary never runs it.
+    #[test]
+    fn a_helper_named_like_main_is_not_the_entry_point() {
+        let src = "async fn main_loop() {\n    let a = autumn_web::app()\n        \
+                   .routes(routes![index]);\n}\n\n\
+                   #[autumn_web::main]\nasync fn main() {\n    \
+                   main_loop().await;\n}\n";
+        assert!(insert_mount(src, admin().mount).is_none());
     }
 
     /// A community crate never gets its mount written, so a re-run stays
@@ -1021,7 +1081,7 @@ maud = { version = "0.27", features = ["axum"] }
         let updated = insert_mount(src, admin().mount).expect("the real chain");
         // Spliced after the REAL builder line, not the one in the string.
         let doc_at = updated.find("let doc").unwrap();
-        let mount_at = updated.find(admin().probe).unwrap();
+        let mount_at = updated.find(admin().mount_arg).unwrap();
         let real_at = updated.find("let app = autumn_web::app()").unwrap();
         assert!(doc_at < real_at, "{updated}");
         assert!(real_at < mount_at, "{updated}");
@@ -1144,7 +1204,7 @@ maud = { version = "0.27", features = ["axum"] }
             let updated = insert_mount(SCAFFOLD_MAIN, entry.mount)
                 .unwrap_or_else(|| panic!("{}: no anchor", entry.crate_name));
             assert!(
-                mount_present(&updated, &entry.probes()),
+                mount_present(&updated, entry),
                 "{}: mount not detected after insertion",
                 entry.crate_name
             );

--- a/autumn-cli/src/plugin/install.rs
+++ b/autumn-cli/src/plugin/install.rs
@@ -49,6 +49,29 @@ pub enum PluginError {
     )]
     UnknownPlugin(String),
 
+    /// The app already declares this plugin at an incompatible version.
+    #[error(
+        "`{crate_name}` is already declared as `{declared}`, which is not compatible with the `{installing}` this CLI installs — no files were changed.\nUpdate that line to `{crate_name} = \"{installing}\"` (or run `autumn upgrade`) and try again: leaving it would mount a {declared}-series plugin into a {installing}-series builder, which does not compile."
+    )]
+    DependencyVersionMismatch {
+        /// The plugin crate.
+        crate_name: String,
+        /// The requirement the manifest already carries.
+        declared: String,
+        /// The version this CLI would install.
+        installing: String,
+    },
+
+    /// `autumn-web` comes from a path/git checkout that no `[patch.crates-io]`
+    /// redirects, so a registry plugin would link a *second* framework copy.
+    #[error(
+        "this app depends on `autumn-web` from a local path or git checkout with no `[patch.crates-io]` entry redirecting it — no files were changed.\nA plugin installed from crates.io would pull its own copy of `autumn-web`, so Cargo would build two different framework crates and the mount would not satisfy the local `AppBuilder`'s traits.\nAdd to your workspace Cargo.toml:\n\n    [patch.crates-io]\n    autumn-web = {{ path = \"<your autumn-web checkout>\" }}\n\nor depend on `{crate_name}` by path from the same checkout."
+    )]
+    UnpatchedLocalFramework {
+        /// The plugin that could not be installed.
+        crate_name: String,
+    },
+
     /// crates.io returned something that is not a usable version string.
     #[error(
         "crates.io reported version `{version}` for `{crate_name}`, which is not a usable version requirement — no files were changed"
@@ -295,6 +318,74 @@ pub fn dependency_present(manifest: &str, crate_name: &str) -> bool {
         .is_some_and(|deps| deps.contains_key(crate_name))
 }
 
+/// The version requirement `manifest` already declares for `crate_name` under
+/// `[dependencies]`, if any.
+///
+/// A path/git entry has no requirement to compare, so it reads as `None`.
+#[must_use]
+pub fn declared_dependency_version(manifest: &str, crate_name: &str) -> Option<String> {
+    let table = toml::from_str::<toml::Table>(manifest).ok()?;
+    let entry = table.get("dependencies")?.as_table()?.get(crate_name)?;
+    match entry {
+        toml::Value::String(version) => Some(version.clone()),
+        toml::Value::Table(table) => table
+            .get("version")
+            .and_then(toml::Value::as_str)
+            .map(std::borrow::ToOwned::to_owned),
+        _ => None,
+    }
+}
+
+/// Whether the app's `autumn-web` comes from a path or git checkout that no
+/// `[patch.crates-io]` entry redirects.
+///
+/// This is fatal for an install from crates.io: the plugin would depend on the
+/// *registry* `autumn-web`, Cargo would build two distinct framework crates,
+/// and the generated mount would not satisfy the local `AppBuilder`'s traits.
+/// A `[patch.crates-io] autumn-web` entry collapses the two back into one,
+/// which is exactly what this repo's own conformance gate does — so the check
+/// is for a local source that is *not* patched, not for a local source.
+///
+/// Manifests are read from `root` upward, because both the dependency and the
+/// patch table commonly live in an enclosing workspace manifest.
+#[must_use]
+pub fn unpatched_local_framework(root: &Path) -> bool {
+    let mut local = false;
+    let mut patched = false;
+    let mut dir = Some(root);
+    while let Some(current) = dir {
+        if let Ok(content) = std::fs::read_to_string(current.join("Cargo.toml"))
+            && let Ok(table) = toml::from_str::<toml::Table>(&content)
+        {
+            for kind in ["dependencies", "workspace"] {
+                let deps = if kind == "workspace" {
+                    table.get(kind).and_then(|w| w.get("dependencies"))
+                } else {
+                    table.get(kind)
+                };
+                if let Some(entry) = deps
+                    .and_then(toml::Value::as_table)
+                    .and_then(|deps| deps.get("autumn-web"))
+                    .and_then(toml::Value::as_table)
+                    && (entry.contains_key("path") || entry.contains_key("git"))
+                {
+                    local = true;
+                }
+            }
+            if table
+                .get("patch")
+                .and_then(|patch| patch.get("crates-io"))
+                .and_then(toml::Value::as_table)
+                .is_some_and(|patched_crates| patched_crates.contains_key("autumn-web"))
+            {
+                patched = true;
+            }
+        }
+        dir = current.parent();
+    }
+    local && !patched
+}
+
 /// Whether `main_rs` already mounts `entry` **in code**.
 ///
 /// Two independent kinds of evidence, because a single substring test is wrong
@@ -455,10 +546,29 @@ pub fn plan_add(
         });
     }
 
+    if unpatched_local_framework(root) {
+        return Err(PluginError::UnpatchedLocalFramework {
+            crate_name: entry.crate_name.to_owned(),
+        });
+    }
+
     let manifest = manifest_path(root);
     let manifest_src = std::fs::read_to_string(&manifest)?;
     let main_path = root.join("src").join("main.rs");
     let main_src = std::fs::read_to_string(&main_path).unwrap_or_default();
+
+    // An existing entry at another series is not "already installed": the key
+    // is there, so `ensure_cargo_dependencies` would leave the old pin in
+    // place while the mount written below is this series' shape.
+    if let Some(declared) = declared_dependency_version(&manifest_src, entry.crate_name)
+        && check_compat(&declared, version) == Compat::Incompatible
+    {
+        return Err(PluginError::DependencyVersionMismatch {
+            crate_name: entry.crate_name.to_owned(),
+            declared,
+            installing: version.to_owned(),
+        });
+    }
 
     let dependency_installed = dependency_present(&manifest_src, entry.crate_name);
     let already_mounted = mount_present(&main_src, entry);
@@ -706,6 +816,100 @@ maud = { version = "0.27", features = ["axum"] }
             std::fs::read_to_string(tmp.path().join("src/main.rs")).unwrap(),
             before_main
         );
+    }
+
+    /// A plugin already pinned to another framework series is not "already
+    /// installed": `ensure_cargo_dependencies` leaves an existing key alone,
+    /// so the old pin would stay while this series' mount was written in.
+    #[test]
+    fn an_incompatible_existing_pin_is_refused_without_editing() {
+        let cargo = format!("{SCAFFOLD_CARGO}autumn-admin-plugin = \"0.6.0\"\n");
+        let tmp = fake_project(SCAFFOLD_MAIN, &cargo);
+        let before = std::fs::read_to_string(tmp.path().join("src/main.rs")).unwrap();
+
+        let err = plan_add(tmp.path(), admin(), "0.7.0").unwrap_err();
+        let message = err.to_string();
+        assert!(message.contains("0.6.0"), "{message}");
+        assert!(message.contains("0.7.0"), "{message}");
+
+        assert_eq!(
+            std::fs::read_to_string(tmp.path().join("Cargo.toml")).unwrap(),
+            cargo
+        );
+        assert_eq!(
+            std::fs::read_to_string(tmp.path().join("src/main.rs")).unwrap(),
+            before
+        );
+    }
+
+    #[test]
+    fn a_matching_existing_pin_is_not_refused() {
+        let cargo = format!("{SCAFFOLD_CARGO}autumn-admin-plugin = \"0.7.0\"\n");
+        let tmp = fake_project(SCAFFOLD_MAIN, &cargo);
+        assert!(plan_add(tmp.path(), admin(), "0.7.0").is_ok());
+    }
+
+    #[test]
+    fn declared_dependency_version_reads_both_spellings() {
+        assert_eq!(
+            declared_dependency_version("[dependencies]\nfoo = \"1.2\"\n", "foo").as_deref(),
+            Some("1.2")
+        );
+        assert_eq!(
+            declared_dependency_version(
+                "[dependencies]\nfoo = { version = \"1.2\", features = [] }\n",
+                "foo"
+            )
+            .as_deref(),
+            Some("1.2")
+        );
+        assert_eq!(
+            declared_dependency_version("[dependencies]\nfoo = { path = \"../foo\" }\n", "foo"),
+            None
+        );
+        assert_eq!(declared_dependency_version("[dependencies]\n", "foo"), None);
+    }
+
+    /// A crates.io plugin against an unpatched local `autumn-web` links a
+    /// SECOND framework copy, so the mount cannot satisfy the local
+    /// `AppBuilder`'s traits. Refuse, and say how to fix it.
+    #[test]
+    fn an_unpatched_local_framework_is_refused() {
+        let cargo = "[package]\nname = \"demo\"\n\n\
+                     [dependencies]\nautumn-web = { path = \"../autumn\" }\n";
+        let tmp = fake_project(SCAFFOLD_MAIN, cargo);
+        assert!(unpatched_local_framework(tmp.path()));
+
+        let err = plan_add(tmp.path(), admin(), "0.7.0").unwrap_err();
+        assert!(
+            matches!(err, PluginError::UnpatchedLocalFramework { .. }),
+            "{err}"
+        );
+        assert!(err.to_string().contains("patch.crates-io"), "{err}");
+
+        assert_eq!(
+            std::fs::read_to_string(tmp.path().join("Cargo.toml")).unwrap(),
+            cargo
+        );
+    }
+
+    /// …but a `[patch.crates-io]` entry collapses the two copies back into
+    /// one, which is exactly what this repo's own conformance gate does.
+    #[test]
+    fn a_patched_local_framework_is_allowed() {
+        let cargo = "[package]\nname = \"demo\"\n\n\
+                     [dependencies]\nautumn-web = { path = \"../autumn\" }\n\n\
+                     [patch.crates-io]\nautumn-web = { path = \"../autumn\" }\n";
+        let tmp = fake_project(SCAFFOLD_MAIN, cargo);
+        assert!(!unpatched_local_framework(tmp.path()));
+        assert!(plan_add(tmp.path(), admin(), "0.7.0").is_ok());
+    }
+
+    /// A plain registry dependency is not a local checkout.
+    #[test]
+    fn a_registry_framework_is_not_a_local_checkout() {
+        let tmp = fake_project(SCAFFOLD_MAIN, SCAFFOLD_CARGO);
+        assert!(!unpatched_local_framework(tmp.path()));
     }
 
     // ── AC #2: dependency + mount ────────────────────────────────────────────

--- a/autumn-cli/src/plugin/install.rs
+++ b/autumn-cli/src/plugin/install.rs
@@ -102,6 +102,9 @@ pub enum AddOutcome {
     DependencyOnly {
         /// Filesystem actions to execute (the manifest edit).
         plan: Box<Plan>,
+        /// Whether this run actually added the dependency. `false` on a
+        /// re-run, where the mount snippet still needs showing.
+        dependency_added: bool,
         /// The `[dependencies]` line that was added.
         dependency_line: String,
         /// The convention-derived builder-chain snippet to paste.
@@ -266,7 +269,8 @@ pub fn dependency_line(crate_name: &str, version: &str) -> String {
     format!("{crate_name} = \"{version}\"")
 }
 
-/// Whether `manifest` already declares `crate_name` in any dependency table.
+/// Whether `manifest` already declares `crate_name` as a **normal** dependency
+/// of the application target.
 ///
 /// Parsed rather than substring-matched: a commented-out line or a mention in
 /// a `description` must not make an install look done.
@@ -275,9 +279,21 @@ pub fn dependency_present(manifest: &str, crate_name: &str) -> bool {
     let Ok(table) = toml::from_str::<toml::Table>(manifest) else {
         return false;
     };
-    ["dependencies", "dev-dependencies", "build-dependencies"]
-        .iter()
-        .filter_map(|kind| table.get(*kind))
+    // `[dependencies]` and the per-target normal tables ONLY. A crate declared
+    // under `[dev-dependencies]` or `[build-dependencies]` is not available to
+    // the application target, so counting one as installed would report a
+    // complete install for an app that cannot compile — and would stop the
+    // command adding the `[dependencies]` entry that fixes it.
+    let mut tables: Vec<&toml::Value> = table.get("dependencies").into_iter().collect();
+    if let Some(targets) = table.get("target").and_then(toml::Value::as_table) {
+        tables.extend(
+            targets
+                .values()
+                .filter_map(|target| target.get("dependencies")),
+        );
+    }
+    tables
+        .into_iter()
         .filter_map(toml::Value::as_table)
         .any(|deps| deps.contains_key(crate_name))
 }
@@ -509,20 +525,26 @@ pub fn plan_add_community(
     let snippet = super::catalog::community_mount_snippet(crate_name)
         .unwrap_or_else(|| "        .plugin(/* see the crate's README */)".to_owned());
 
-    if dependency_present(&manifest_src, crate_name) {
-        return Ok(AddOutcome::AlreadyInstalled);
-    }
+    // NOT `AlreadyInstalled`: that outcome reports the dependency *and* the
+    // mount as in place, and a community mount is never written — so a re-run
+    // would claim a complete install and stop showing the snippet the user
+    // still has to paste. The outcome stays dependency-only; only the wording
+    // changes.
+    let dependency_added = !dependency_present(&manifest_src, crate_name);
     let mut plan = Plan::new(root);
-    let spec = format!("\"{version}\"");
-    let updated = crate::generate::model::ensure_cargo_dependencies(
-        &manifest_src,
-        &[(crate_name, spec.as_str())],
-    );
-    if updated != manifest_src {
-        plan.modify(manifest, updated);
+    if dependency_added {
+        let spec = format!("\"{version}\"");
+        let updated = crate::generate::model::ensure_cargo_dependencies(
+            &manifest_src,
+            &[(crate_name, spec.as_str())],
+        );
+        if updated != manifest_src {
+            plan.modify(manifest, updated);
+        }
     }
     Ok(AddOutcome::DependencyOnly {
         plan: Box::new(plan),
+        dependency_added,
         dependency_line: dependency_line(crate_name, version),
         mount_snippet: snippet,
     })
@@ -811,6 +833,106 @@ maud = { version = "0.27", features = ["axum"] }
         );
     }
 
+    /// A probe hidden in a string literal is not a mount. Reading one as a
+    /// mount made `add` skip the insertion and still report success, leaving
+    /// the app running without the plugin it said it installed.
+    #[test]
+    fn a_probe_inside_a_string_literal_is_not_a_mount() {
+        let src = "#[autumn_web::main]\nasync fn main() {\n    \
+                   let help = \"paste AdminPlugin::new( into your builder\";\n    \
+                   let app = autumn_web::app()\n        .routes(routes![index]);\n}\n";
+        assert!(!mount_present(src, &admin().probes()));
+
+        let tmp = fake_project(src, SCAFFOLD_CARGO);
+        let AddOutcome::Installed { plan, .. } = plan_add(tmp.path(), admin(), "0.7.0").unwrap()
+        else {
+            panic!("expected an installable plan");
+        };
+        plan.execute(crate::generate::Flags::default()).unwrap();
+        let main_rs = std::fs::read_to_string(tmp.path().join("src/main.rs")).unwrap();
+        assert!(
+            main_rs.contains(".plugin(autumn_admin_plugin::AdminPlugin::new())"),
+            "{main_rs}"
+        );
+    }
+
+    /// A dev- or build-dependency is not available to the application target,
+    /// so it cannot count as installed: reporting one as complete leaves the
+    /// app uncompilable AND declines to add the entry that would fix it.
+    #[test]
+    fn only_a_normal_dependency_counts_as_installed() {
+        let cargo =
+            format!("{SCAFFOLD_CARGO}\n[dev-dependencies]\nautumn-admin-plugin = \"0.7.0\"\n");
+        assert!(!dependency_present(&cargo, "autumn-admin-plugin"));
+
+        // Mount already present + dev-dependency only ⇒ still an install, not
+        // "already installed".
+        let mounted = SCAFFOLD_MAIN.replace(
+            ".routes(routes![index])",
+            ".plugin(autumn_admin_plugin::AdminPlugin::new())\n        .routes(routes![index])",
+        );
+        let tmp = fake_project(&mounted, &cargo);
+        let AddOutcome::Installed { plan, .. } = plan_add(tmp.path(), admin(), "0.7.0").unwrap()
+        else {
+            panic!("expected an installable plan, not AlreadyInstalled");
+        };
+        plan.execute(crate::generate::Flags::default()).unwrap();
+        let after = std::fs::read_to_string(tmp.path().join("Cargo.toml")).unwrap();
+        let deps_section = after.split("[dev-dependencies]").next().unwrap();
+        assert!(
+            deps_section.contains("autumn-admin-plugin ="),
+            "the normal dependency must be added: {after}"
+        );
+    }
+
+    #[test]
+    fn a_target_specific_normal_dependency_counts_as_installed() {
+        let cargo = format!(
+            "{SCAFFOLD_CARGO}\n[target.'cfg(unix)'.dependencies]\nautumn-admin-plugin = \"0.7.0\"\n"
+        );
+        assert!(dependency_present(&cargo, "autumn-admin-plugin"));
+    }
+
+    /// A community crate never gets its mount written, so a re-run stays
+    /// dependency-only rather than claiming a complete install.
+    #[test]
+    fn a_repeated_community_add_stays_dependency_only() {
+        let tmp = fake_project(SCAFFOLD_MAIN, SCAFFOLD_CARGO);
+        let AddOutcome::DependencyOnly {
+            plan,
+            dependency_added,
+            ..
+        } = plan_add_community(tmp.path(), "autumn-plugin-live-feed", "0.3.1").unwrap()
+        else {
+            panic!("expected a dependency-only outcome");
+        };
+        assert!(dependency_added);
+        plan.execute(crate::generate::Flags::default()).unwrap();
+        let after = std::fs::read_to_string(tmp.path().join("Cargo.toml")).unwrap();
+
+        let second = plan_add_community(tmp.path(), "autumn-plugin-live-feed", "0.3.1").unwrap();
+        let AddOutcome::DependencyOnly {
+            plan,
+            dependency_added,
+            mount_snippet,
+            ..
+        } = second
+        else {
+            panic!("a re-run must stay dependency-only, got {second:?}");
+        };
+        assert!(!dependency_added);
+        assert!(
+            mount_snippet.contains("LiveFeedPlugin::new()"),
+            "{mount_snippet}"
+        );
+        plan.execute(crate::generate::Flags::default()).unwrap();
+        assert_eq!(
+            std::fs::read_to_string(tmp.path().join("Cargo.toml")).unwrap(),
+            after,
+            "a re-run must change nothing"
+        );
+    }
+
     // ── AC #5: safe degradation ──────────────────────────────────────────────
 
     /// A single-line chain has nowhere to splice a call, so the command must
@@ -887,15 +1009,32 @@ maud = { version = "0.27", features = ["axum"] }
         assert!(insert_mount(src, admin().mount).is_none());
     }
 
-    /// The scanner skips comments but not string literals, so a quick-start
-    /// snippet in a raw string inside `main` looks like an anchor. Two
-    /// candidates must mean "no anchor", not "pick the first".
+    /// A quick-start snippet inside a raw string in `main` is not a candidate
+    /// at all — the scanner masks string contents — so the real chain below it
+    /// is still found and spliced.
     #[test]
-    fn an_ambiguous_builder_is_not_an_anchor() {
+    fn a_builder_inside_a_string_literal_is_not_a_candidate() {
         let src = "#[autumn_web::main]\nasync fn main() {\n    let doc = r\"\n    \
                    autumn_web::app()\n        .run()\n\";\n    \
                    let app = autumn_web::app()\n        .routes(routes![index]);\n    \
                    app.run().await;\n}\n";
+        let updated = insert_mount(src, admin().mount).expect("the real chain");
+        // Spliced after the REAL builder line, not the one in the string.
+        let doc_at = updated.find("let doc").unwrap();
+        let mount_at = updated.find(admin().probe).unwrap();
+        let real_at = updated.find("let app = autumn_web::app()").unwrap();
+        assert!(doc_at < real_at, "{updated}");
+        assert!(real_at < mount_at, "{updated}");
+    }
+
+    /// Two REAL builder chains in `main` are genuinely ambiguous: refuse
+    /// rather than pick one.
+    #[test]
+    fn two_real_builders_are_not_an_anchor() {
+        let src = "#[autumn_web::main]\nasync fn main() {\n    \
+                   let a = autumn_web::app()\n        .routes(routes![index]);\n    \
+                   let b = autumn_web::app()\n        .routes(routes![other]);\n    \
+                   pick(a, b).run().await;\n}\n";
         assert!(insert_mount(src, admin().mount).is_none());
     }
 

--- a/autumn-cli/src/plugin/install.rs
+++ b/autumn-cli/src/plugin/install.rs
@@ -1,9 +1,10 @@
 //! Install planning for `autumn plugin add` — pure functions plus one
-//! [`emit::Plan`] builder, so `--dry-run` and the Created/Modified output match
+//! [`crate::generate::emit::Plan`] builder, so `--dry-run` and the Created/Modified output match
 //! every other code-touching Autumn command.
 //!
 //! Every decision that can refuse the install (version gate, missing project,
-//! unreadable builder chain) is made *before* a single [`emit::Action`] is
+//! unreadable builder chain) is made *before* a single
+//! [`crate::generate::emit::Action`] is
 //! queued, which is what makes issue #1606's "fails before any file is
 //! modified" and "never leaves the app in a non-compiling state" true by
 //! construction rather than by careful ordering.

--- a/autumn-cli/src/plugin/install.rs
+++ b/autumn-cli/src/plugin/install.rs
@@ -48,6 +48,17 @@ pub enum PluginError {
     )]
     UnknownPlugin(String),
 
+    /// crates.io returned something that is not a usable version string.
+    #[error(
+        "crates.io reported version `{version}` for `{crate_name}`, which is not a usable version requirement — no files were changed"
+    )]
+    ImplausibleVersion {
+        /// The crate whose version could not be used.
+        crate_name: String,
+        /// The rejected version string.
+        version: String,
+    },
+
     /// Filesystem error while reading the project.
     #[error("{0}")]
     Io(#[from] std::io::Error),
@@ -147,13 +158,26 @@ pub fn supported_range(version: &str) -> String {
     }
 }
 
-/// Parse `MAJOR.MINOR[.PATCH]`, tolerating a leading requirement operator and
-/// a pre-release/build suffix. Mirrors `doctor::check_version_compat`'s parser
-/// so the two commands can never disagree about what a version means.
+/// Parse `MAJOR.MINOR[.PATCH]` from a Cargo version requirement, or `None`
+/// when the requirement does not pin one.
+///
+/// `=`, `^` and `~` are stripped: all three name a single version whose
+/// compatibility is the version's own. Comparison and range requirements
+/// (`>=0.6`, `>=0.7, <0.9`, `*`, `0.6 || 0.7`) are deliberately **not**
+/// parsed — stripping their operator would read `>=0.6` as *exactly* 0.6 and
+/// refuse an install into an app that resolves to 0.7 perfectly well. `None`
+/// becomes [`Compat::Unknown`], which lets the install proceed rather than
+/// refusing on a version this code cannot actually evaluate.
+///
+/// (`doctor::check_version_compat` strips operators instead. It is comparing
+/// two *concrete* versions for a diagnostic, where a false warning costs
+/// nothing; here a false negative blocks a command outright.)
 fn parse_version(version: &str) -> Option<(u64, u64, u64)> {
-    let version = version
-        .trim()
-        .trim_start_matches(['=', '^', '~', '>', '<', ' ']);
+    let version = version.trim();
+    if version.contains(['<', '>', ',', '*', '|']) {
+        return None;
+    }
+    let version = version.trim_start_matches(['=', '^', '~', ' ']);
     let mut parts = version.split('.');
     let major: u64 = parts.next()?.trim().parse().ok()?;
     let minor: u64 = parts.next()?.trim().parse().ok()?;
@@ -165,6 +189,20 @@ fn parse_version(version: &str) -> Option<(u64, u64, u64)> {
             .unwrap_or(0)
     });
     Some((major, minor, patch))
+}
+
+/// Whether `version` is safe to write into a `Cargo.toml` dependency line.
+///
+/// Belt-and-braces on the crates.io response: a version string is written
+/// verbatim into the manifest, so anything that is not plausibly a semver
+/// version is refused rather than emitted into a file the user then has to
+/// repair.
+#[must_use]
+pub fn is_plausible_version(version: &str) -> bool {
+    version.starts_with(|c: char| c.is_ascii_digit())
+        && version
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '-' | '+'))
 }
 
 /// Read how the project at `root` declares `autumn-web`.
@@ -187,9 +225,14 @@ pub fn app_autumn_web(root: &Path) -> Result<AppAutumnWeb, PluginError> {
             crate::doctor::AutumnWebDependency::WithoutVersion => declared = true,
             // `Inherited` comes back for ANY `{ workspace = true }` entry, not
             // just this crate's — the scan cannot tell them apart by itself —
-            // so only the entry actually keyed `autumn-web` counts here.
+            // so resolve it against the enclosing workspace, exactly as
+            // `autumn upgrade` does. Without this a member crate's version gate
+            // silently never runs, which is the whole guarantee of AC #3.
             crate::doctor::AutumnWebDependency::Inherited(key) => {
-                declared |= key == "autumn-web";
+                match workspace_version_for(root, key) {
+                    Some(version) => return Ok(AppAutumnWeb::Version(version)),
+                    None => declared |= key == "autumn-web",
+                }
             }
             crate::doctor::AutumnWebDependency::Absent
             | crate::doctor::AutumnWebDependency::Unreadable => {}
@@ -200,6 +243,21 @@ pub fn app_autumn_web(root: &Path) -> Result<AppAutumnWeb, PluginError> {
     } else {
         Err(PluginError::NoAutumnWeb)
     }
+}
+
+/// The version a `{ workspace = true }` entry named `key` resolves to, found
+/// by walking up from `root` the way Cargo does.
+fn workspace_version_for(root: &Path, key: &str) -> Option<String> {
+    let mut dir = Some(root);
+    while let Some(current) = dir {
+        if let Some(crate::doctor::AutumnWebDependency::Version(version)) =
+            crate::doctor::workspace_dependency_for(current, key)
+        {
+            return Some(version);
+        }
+        dir = current.parent();
+    }
+    None
 }
 
 /// The `[dependencies]` line `plugin add` writes (and prints).
@@ -224,36 +282,77 @@ pub fn dependency_present(manifest: &str, crate_name: &str) -> bool {
         .any(|deps| deps.contains_key(crate_name))
 }
 
-/// Whether `main_rs` already mounts the plugin **in code** — a mention inside
-/// a comment (a README snippet pasted into the file) does not count.
+/// Whether `main_rs` already mounts the plugin **in code**.
 ///
-/// Sharing [`crate::rust_source::for_each_code_line`] with the anchor scan is
+/// `probes` are the spellings a mount can take: the fully-qualified path this
+/// command writes (`autumn_search::SearchPlugin`) and the bare call a
+/// hand-written mount uses after a `use` import (`SearchPlugin::new(`). Both
+/// are needed, in both directions: without the bare form a hand-configured
+/// `.plugin(SearchPlugin::new().index::<Post>())` is not detected and `add`
+/// splices a *second*, default-constructed mount — which `AppBuilder::plugin`
+/// then keeps in preference to the user's, silently discarding their
+/// configuration.
+///
+/// `use` lines are excluded for the mirror-image reason: a bare
+/// `use autumn_search::SearchPlugin;` import is not a mount, and treating it
+/// as one made `add` report "already installed" for an app that mounts
+/// nothing.
+///
+/// Sharing [`crate::rust_source::code_lines`] with the anchor scan is
 /// deliberate: if the two disagreed about what a comment is, a doc-comment
 /// mention could suppress both the mount and the warning about it.
 #[must_use]
-pub fn mount_present(main_rs: &str, probe: &str) -> bool {
-    crate::rust_source::for_each_code_line(main_rs, |line, _offset| {
-        line.contains(probe).then_some(())
-    })
-    .is_some()
+pub fn mount_present(main_rs: &str, probes: &[&str]) -> bool {
+    crate::rust_source::code_lines(main_rs)
+        .into_iter()
+        .filter(|(line, _)| !line.trim_start().starts_with("use "))
+        .any(|(line, _)| probes.iter().any(|probe| line.contains(probe)))
 }
 
-/// Byte offset just past the builder-opening `autumn_web::app()` inside
-/// `main()`, or `None` when there is no unambiguous anchor.
+/// Byte offset just past the builder-opening `autumn_web::app()` **inside the
+/// body of `async fn main`**, or `None` when there is no unambiguous anchor.
 ///
-/// Only a line that *ends* with the opener is an anchor. A one-line chain
-/// (`autumn_web::app().routes(…).run().await;`) has no place to splice a call
-/// into, and a mention inside a comment is not code at all — in both cases the
-/// caller degrades to printed instructions rather than guessing (AC #5).
+/// Three rules, each of which exists because breaking it produces a wrong
+/// edit rather than no edit:
+///
+/// 1. **Scoped to `main`'s body.** A sticky "have I seen `async fn main` yet"
+///    flag is not enough: an app that factors its builder into a helper
+///    (`fn build_app() -> AppBuilder { autumn_web::app()… }`) or that keeps a
+///    `#[cfg(test)] mod tests` harness would otherwise be spliced *there* —
+///    mounting the plugin into a function the binary never calls, or (for the
+///    `autumn-storage-s3` mount, which awaits) into a synchronous fn, which
+///    does not compile. The body runs from the `async fn main` line to the
+///    first line that closes a brace at column 0.
+/// 2. **Exactly one candidate.** [`crate::rust_source::code_lines`] skips
+///    comments but not string literals, so a quick-start snippet inside a raw
+///    string can look like an anchor. Refusing when there is more than one
+///    candidate turns that from a silent mis-splice into the documented
+///    manual fallback.
+/// 3. **The line must END with the opener.** A one-line chain
+///    (`autumn_web::app().routes(…).run().await;`) has nowhere to splice a
+///    call into.
 fn builder_anchor(main_rs: &str) -> Option<usize> {
-    let mut seen_main = false;
-    crate::rust_source::for_each_code_line(main_rs, |line, offset| {
-        if line.trim().contains("async fn main") {
-            seen_main = true;
-        }
-        (seen_main && line.trim_end().ends_with("autumn_web::app()"))
-            .then(|| offset + line.trim_end().len())
-    })
+    let lines = crate::rust_source::code_lines(main_rs);
+    let main_at = lines
+        .iter()
+        .position(|(line, _)| line.trim().contains("async fn main"))?;
+    // The body ends at the first code line that closes a brace at column 0 —
+    // the closing brace of a top-level `async fn main`.
+    let body_end = lines
+        .iter()
+        .skip(main_at + 1)
+        .position(|(line, _)| line.starts_with('}'))
+        .map_or(lines.len(), |offset| main_at + 1 + offset);
+
+    let mut candidates = lines[main_at..body_end]
+        .iter()
+        .filter(|(line, _)| line.trim_end().ends_with("autumn_web::app()"));
+    let (line, offset) = candidates.next()?;
+    if candidates.next().is_some() {
+        // Ambiguous: refuse rather than guess (rule 2).
+        return None;
+    }
+    Some(offset + line.trim_end().len())
 }
 
 /// Splice `mount` into the `AppBuilder` chain, or `None` when the chain has no
@@ -301,11 +400,13 @@ fn indent(text: &str, prefix: &str) -> String {
 
 /// Plan the install of `entry` at `version` into the project at `root`.
 ///
-/// Ordering is the contract: the project check and the version gate run before
-/// a single [`crate::generate::emit::Action`] exists, and the builder-chain
-/// edit is computed (not applied) before the manifest edit is queued — so
-/// every refusal leaves the app byte-identical, and no outcome can add a
-/// dependency whose mount never landed.
+/// Ordering is the contract. The project check and the version gate run before
+/// a single [`crate::generate::emit::Action`] exists, so every refusal leaves
+/// the app byte-identical. The builder-chain edit is computed (not applied)
+/// before the manifest edit is queued, so no outcome can add a dependency whose
+/// mount was never even computed — and the two writes are queued mount-first,
+/// so a mid-execute I/O failure fails loudly at `rustc` instead of looking like
+/// a completed install.
 ///
 /// # Errors
 ///
@@ -333,7 +434,7 @@ pub fn plan_add(
     let main_src = std::fs::read_to_string(&main_path).unwrap_or_default();
 
     let dependency_installed = dependency_present(&manifest_src, entry.crate_name);
-    let already_mounted = mount_present(&main_src, entry.probe);
+    let already_mounted = mount_present(&main_src, &entry.probes());
     if dependency_installed && already_mounted {
         return Ok(AddOutcome::AlreadyInstalled);
     }
@@ -357,7 +458,15 @@ pub fn plan_add(
         }
     };
 
+    // `src/main.rs` is queued BEFORE `Cargo.toml`. `Plan::execute` writes
+    // actions in order with no rollback, so if the second write fails (a
+    // read-only file, ENOSPC) this ordering leaves a mount with no dependency
+    // — which rustc rejects immediately — rather than a dependency with no
+    // mount, which looks exactly like a completed install.
     let mut plan = Plan::new(root);
+    if let Some(updated_main) = mounted_src {
+        plan.modify(main_path, updated_main);
+    }
     let spec = format!("\"{version}\"");
     let updated_manifest = crate::generate::model::ensure_cargo_dependencies(
         &manifest_src,
@@ -365,9 +474,6 @@ pub fn plan_add(
     );
     if updated_manifest != manifest_src {
         plan.modify(manifest, updated_manifest);
-    }
-    if let Some(updated_main) = mounted_src {
-        plan.modify(main_path, updated_main);
     }
     Ok(AddOutcome::Installed {
         plan: Box::new(plan),
@@ -384,14 +490,20 @@ pub fn plan_add(
 ///
 /// # Errors
 ///
-/// [`PluginError::NotInProject`], [`PluginError::NoAutumnWeb`], or an I/O
-/// error reading the manifest.
+/// [`PluginError::NotInProject`], [`PluginError::NoAutumnWeb`],
+/// [`PluginError::ImplausibleVersion`], or an I/O error reading the manifest.
 pub fn plan_add_community(
     root: &Path,
     crate_name: &str,
     version: &str,
 ) -> Result<AddOutcome, PluginError> {
     app_autumn_web(root)?;
+    if !is_plausible_version(version) {
+        return Err(PluginError::ImplausibleVersion {
+            crate_name: crate_name.to_owned(),
+            version: version.to_owned(),
+        });
+    }
     let manifest = manifest_path(root);
     let manifest_src = std::fs::read_to_string(&manifest)?;
     let snippet = super::catalog::community_mount_snippet(crate_name)
@@ -621,11 +733,31 @@ maud = { version = "0.27", features = ["axum"] }
     #[test]
     fn mount_present_ignores_comment_mentions() {
         let commented = "// autumn_admin_plugin::AdminPlugin::new()\nfn main() {}\n";
-        assert!(!mount_present(commented, admin().probe));
+        assert!(!mount_present(commented, &admin().probes()));
         let block = "/*\nautumn_admin_plugin::AdminPlugin::new()\n*/\nfn main() {}\n";
-        assert!(!mount_present(block, admin().probe));
+        assert!(!mount_present(block, &admin().probes()));
         let real = "fn main() { app.plugin(autumn_admin_plugin::AdminPlugin::new()); }\n";
-        assert!(mount_present(real, admin().probe));
+        assert!(mount_present(real, &admin().probes()));
+    }
+
+    /// A bare `use` import is not a mount. Counting it as one made `add`
+    /// report "already installed" for an app that mounts nothing, with no way
+    /// for the user to make the command work.
+    #[test]
+    fn an_import_alone_is_not_a_mount() {
+        let imported = "use autumn_admin_plugin::AdminPlugin;\n\nfn main() {}\n";
+        assert!(!mount_present(imported, &admin().probes()));
+    }
+
+    /// A hand-written mount through an import carries only the bare call, so
+    /// the bare probe has to catch it — otherwise `add` splices a SECOND,
+    /// default-constructed mount, and `AppBuilder::plugin` keeps that one in
+    /// preference to the user's configured instance.
+    #[test]
+    fn a_hand_written_mount_behind_an_import_is_detected() {
+        let src = "use autumn_admin_plugin::AdminPlugin;\n\nfn main() {\n    \
+                   app.plugin(AdminPlugin::new().require_role(\"staff\"));\n}\n";
+        assert!(mount_present(src, &admin().probes()));
     }
 
     #[test]
@@ -731,6 +863,131 @@ maud = { version = "0.27", features = ["axum"] }
         );
     }
 
+    /// The builder must be found inside `main`'s own body. A `main.rs` that
+    /// factors the builder into a helper would otherwise be spliced there —
+    /// and for the `autumn-storage-s3` mount, which awaits, splicing into a
+    /// synchronous fn does not compile at all.
+    #[test]
+    fn a_builder_in_a_helper_function_is_not_an_anchor() {
+        let src = "#[autumn_web::main]\nasync fn main() {\n    build_app().run().await;\n}\n\n\
+                   fn build_app() -> autumn_web::app::AppBuilder {\n    autumn_web::app()\n        \
+                   .routes(routes![index])\n}\n";
+        assert!(insert_mount(src, admin().mount).is_none());
+    }
+
+    /// Same rule, the test-harness shape: splicing into `#[cfg(test)] mod
+    /// tests` compiles but never mounts anything in the real binary, and the
+    /// probe it leaves behind makes the next `add` report "already installed".
+    #[test]
+    fn a_builder_in_a_test_module_is_not_an_anchor() {
+        let src = "#[autumn_web::main]\nasync fn main() {\n    \
+                   autumn_web::app().routes(routes![]).run().await;\n}\n\n\
+                   #[cfg(test)]\nmod tests {\n    fn harness() {\n        \
+                   let b = autumn_web::app()\n            .routes(routes![]);\n    }\n}\n";
+        assert!(insert_mount(src, admin().mount).is_none());
+    }
+
+    /// The scanner skips comments but not string literals, so a quick-start
+    /// snippet in a raw string inside `main` looks like an anchor. Two
+    /// candidates must mean "no anchor", not "pick the first".
+    #[test]
+    fn an_ambiguous_builder_is_not_an_anchor() {
+        let src = "#[autumn_web::main]\nasync fn main() {\n    let doc = r\"\n    \
+                   autumn_web::app()\n        .run()\n\";\n    \
+                   let app = autumn_web::app()\n        .routes(routes![index]);\n    \
+                   app.run().await;\n}\n";
+        assert!(insert_mount(src, admin().mount).is_none());
+    }
+
+    /// A comparison or range requirement pins no single version, so it must
+    /// not be read as an exact one: `>=0.6` resolves to 0.7 perfectly well and
+    /// refusing the install would be a false negative.
+    #[test]
+    fn range_requirements_are_unknown_not_incompatible() {
+        for requirement in [">=0.6", ">=0.7, <0.9", "*", "0.6 || 0.7", "<0.8"] {
+            assert_eq!(
+                check_compat(requirement, "0.7.0"),
+                Compat::Unknown,
+                "{requirement}"
+            );
+        }
+    }
+
+    #[test]
+    fn exact_and_caret_requirements_still_compare() {
+        assert_eq!(check_compat("=0.7.1", "0.7.0"), Compat::Compatible);
+        assert_eq!(check_compat("~0.6.0", "0.7.0"), Compat::Incompatible);
+    }
+
+    /// AC #3 must hold for a workspace member too: `{ workspace = true }`
+    /// resolves against the enclosing workspace rather than silently skipping
+    /// the gate.
+    #[test]
+    fn a_workspace_inherited_dependency_still_gates() {
+        let workspace = tempfile::tempdir().unwrap();
+        std::fs::write(
+            workspace.path().join("Cargo.toml"),
+            "[workspace]\nmembers = [\"app\"]\n\n\
+             [workspace.dependencies]\nautumn-web = \"0.5.0\"\n",
+        )
+        .unwrap();
+        let member = workspace.path().join("app");
+        std::fs::create_dir_all(member.join("src")).unwrap();
+        std::fs::write(
+            member.join("Cargo.toml"),
+            "[package]\nname = \"app\"\n\n[dependencies]\nautumn-web = { workspace = true }\n",
+        )
+        .unwrap();
+        std::fs::write(member.join("src/main.rs"), SCAFFOLD_MAIN).unwrap();
+
+        assert_eq!(
+            app_autumn_web(&member).unwrap(),
+            AppAutumnWeb::Version("0.5.0".to_owned())
+        );
+        let err = plan_add(&member, admin(), "0.7.0").unwrap_err();
+        assert!(err.to_string().contains("0.5.0"), "{err}");
+    }
+
+    #[test]
+    fn implausible_versions_are_never_written_to_a_manifest() {
+        assert!(is_plausible_version("0.7.0"));
+        assert!(is_plausible_version("1.0.0-rc.1+build.5"));
+        assert!(!is_plausible_version("\" }\n[dependencies]\nevil = \"1"));
+        assert!(!is_plausible_version(""));
+        assert!(!is_plausible_version("latest"));
+
+        let tmp = fake_project(SCAFFOLD_MAIN, SCAFFOLD_CARGO);
+        let before = std::fs::read_to_string(tmp.path().join("Cargo.toml")).unwrap();
+        let err = plan_add_community(tmp.path(), "autumn-plugin-x", "not a version").unwrap_err();
+        assert!(
+            matches!(err, PluginError::ImplausibleVersion { .. }),
+            "{err}"
+        );
+        assert_eq!(
+            std::fs::read_to_string(tmp.path().join("Cargo.toml")).unwrap(),
+            before
+        );
+    }
+
+    /// The mount is queued before the manifest edit, so a mid-execute I/O
+    /// failure cannot leave a dependency whose mount never landed.
+    #[test]
+    fn the_mount_is_queued_before_the_manifest() {
+        let tmp = fake_project(SCAFFOLD_MAIN, SCAFFOLD_CARGO);
+        let AddOutcome::Installed { plan, .. } = plan_add(tmp.path(), admin(), "0.7.0").unwrap()
+        else {
+            panic!("expected an installable plan");
+        };
+        let paths: Vec<_> = plan
+            .actions
+            .iter()
+            .map(|action| action.path().to_path_buf())
+            .collect();
+        assert_eq!(paths.len(), 2, "{paths:?}");
+        assert!(paths[0].ends_with("main.rs"), "{paths:?}");
+        assert!(paths[1].ends_with("Cargo.toml"), "{paths:?}");
+    }
+
     #[test]
     fn plan_add_outside_a_project_is_an_error() {
         let tmp = tempfile::tempdir().unwrap();
@@ -748,7 +1005,7 @@ maud = { version = "0.27", features = ["axum"] }
             let updated = insert_mount(SCAFFOLD_MAIN, entry.mount)
                 .unwrap_or_else(|| panic!("{}: no anchor", entry.crate_name));
             assert!(
-                mount_present(&updated, entry.probe),
+                mount_present(&updated, &entry.probes()),
                 "{}: mount not detected after insertion",
                 entry.crate_name
             );

--- a/autumn-cli/src/plugin/install.rs
+++ b/autumn-cli/src/plugin/install.rs
@@ -285,16 +285,15 @@ pub fn dependency_present(manifest: &str, crate_name: &str) -> bool {
     // the application target, so counting one as installed would report a
     // complete install for an app that cannot compile — and would stop the
     // command adding the `[dependencies]` entry that fixes it.
-    let mut tables: Vec<&toml::Value> = table.get("dependencies").into_iter().collect();
-    if let Some(targets) = table.get("target").and_then(toml::Value::as_table) {
-        tables.extend(
+    let targets = table.get("target").and_then(toml::Value::as_table);
+    table
+        .get("dependencies")
+        .into_iter()
+        .chain(targets.into_iter().flat_map(|targets| {
             targets
                 .values()
-                .filter_map(|target| target.get("dependencies")),
-        );
-    }
-    tables
-        .into_iter()
+                .filter_map(|target| target.get("dependencies"))
+        }))
         .filter_map(toml::Value::as_table)
         .any(|deps| deps.contains_key(crate_name))
 }

--- a/autumn-cli/src/plugin/mod.rs
+++ b/autumn-cli/src/plugin/mod.rs
@@ -263,6 +263,7 @@ pub fn render_add(entry_name: &str, outcome: &AddOutcome, dry_run: bool) -> Stri
             );
         }
         AddOutcome::DependencyOnly {
+            dependency_added,
             dependency_line,
             mount_snippet,
             ..
@@ -272,8 +273,13 @@ pub fn render_add(entry_name: &str, outcome: &AddOutcome, dry_run: bool) -> Stri
                     out,
                     "\nDry run: nothing was written. `autumn plugin add {entry_name}` would add {dependency_line}."
                 );
-            } else {
+            } else if *dependency_added {
                 let _ = writeln!(out, "\nAdded {dependency_line}.");
+            } else {
+                let _ = writeln!(
+                    out,
+                    "\n{dependency_line} is already declared — nothing to change."
+                );
             }
             let _ = writeln!(
                 out,
@@ -625,6 +631,7 @@ mod tests {
             "autumn-plugin-live-feed",
             &AddOutcome::DependencyOnly {
                 plan: Box::new(crate::generate::emit::Plan::new(".")),
+                dependency_added: true,
                 dependency_line: "autumn-plugin-live-feed = \"0.3.1\"".to_owned(),
                 mount_snippet: "        .plugin(autumn_plugin_live_feed::LiveFeedPlugin::new())"
                     .to_owned(),
@@ -634,6 +641,27 @@ mod tests {
         assert!(out.contains("autumn-plugin-live-feed = \"0.3.1\""), "{out}");
         assert!(out.contains("LiveFeedPlugin::new()"), "{out}");
         assert!(out.contains("community crate"), "{out}");
+    }
+
+    /// A community crate's mount is never written, so a re-run is still
+    /// dependency-only: it must not claim the mount is in place, and it must
+    /// keep showing the snippet the user has yet to paste.
+    #[test]
+    fn a_repeated_community_add_still_shows_the_mount() {
+        let out = render_add(
+            "autumn-plugin-live-feed",
+            &AddOutcome::DependencyOnly {
+                plan: Box::new(crate::generate::emit::Plan::new(".")),
+                dependency_added: false,
+                dependency_line: "autumn-plugin-live-feed = \"0.3.1\"".to_owned(),
+                mount_snippet: "        .plugin(autumn_plugin_live_feed::LiveFeedPlugin::new())"
+                    .to_owned(),
+            },
+            false,
+        );
+        assert!(out.contains("already declared"), "{out}");
+        assert!(out.contains("LiveFeedPlugin::new()"), "{out}");
+        assert!(!out.contains("already installed"), "{out}");
     }
 
     #[test]

--- a/autumn-cli/src/plugin/mod.rs
+++ b/autumn-cli/src/plugin/mod.rs
@@ -74,6 +74,10 @@ pub enum Resolved {
     Community(String),
 }
 
+/// Exit code for the manual-fallback outcome: nothing was written, and the
+/// dependency line plus mount snippet were printed for the user to apply.
+pub const MANUAL_FALLBACK_EXIT_CODE: i32 = 2;
+
 /// The version of every first-party plugin: they are released in lockstep
 /// with `autumn-web` and with this CLI, so the CLI's own version is the one to
 /// install.
@@ -169,10 +173,16 @@ pub fn render_list(rows: &[ListRow], app_version: Option<&str>, note: Option<&st
                 version = row.version,
                 summary = elide(&row.summary, SUMMARY_WIDTH),
                 compat = match row.compat {
-                    Compat::Incompatible => "  [incompatible with this app]",
+                    // Name the series that WOULD work, rather than only saying
+                    // this one will not: on an older app the bare word
+                    // "incompatible" leaves the reader with no next step.
+                    Compat::Incompatible => format!(
+                        "  [needs autumn-web {}]",
+                        install::supported_range(&row.version)
+                    ),
                     Compat::Unknown if row.origin == Origin::FirstParty =>
-                        "  [compatibility unknown]",
-                    Compat::Compatible | Compat::Unknown => "",
+                        "  [compatibility unknown]".to_owned(),
+                    Compat::Compatible | Compat::Unknown => String::new(),
                 },
             );
         }
@@ -412,7 +422,17 @@ pub fn run_add(opts: &AddOptions<'_>) -> i32 {
         }
         AddOutcome::AlreadyInstalled | AddOutcome::Manual { .. } => {}
     }
-    println!("{}", render_add(opts.name, &outcome, opts.dry_run));
+
+    let report = render_add(opts.name, &outcome, opts.dry_run);
+    if matches!(outcome, AddOutcome::Manual { .. }) {
+        // A refusal, not a result: it goes to stderr and exits non-zero so
+        // `autumn plugin add … && cargo build` cannot read "I changed nothing,
+        // do it yourself" as a successful install. `2` rather than `1` so a
+        // script can tell "apply this by hand" apart from a hard error.
+        eprintln!("{report}");
+        return MANUAL_FALLBACK_EXIT_CODE;
+    }
+    println!("{report}");
     0
 }
 
@@ -536,7 +556,8 @@ mod tests {
     #[test]
     fn the_table_flags_incompatible_rows() {
         let out = render_list(&list_rows(Some("0.5.0"), &[]), Some("0.5.0"), None);
-        assert!(out.contains("incompatible"), "{out}");
+        // Naming the series that would work is the actionable half.
+        assert!(out.contains("needs autumn-web 0.7"), "{out}");
     }
 
     #[test]

--- a/autumn-cli/src/plugin/mod.rs
+++ b/autumn-cli/src/plugin/mod.rs
@@ -1,0 +1,634 @@
+//! `autumn plugin list` / `autumn plugin add` — one-command plugin discovery
+//! and install (issue #1606).
+//!
+//! The CLI already knew how to *author* a plugin (`autumn generate plugin`) and
+//! how to *audit* one (`autumn plugin-check`); this module is the consumer
+//! half. `list` answers "what can I install into this app, at what version",
+//! and `add` performs the four hand edits — find the crate, add the
+//! dependency, mount it in the builder chain, read the config docs — as one
+//! command.
+
+pub mod catalog;
+pub mod install;
+pub mod registry;
+
+use std::path::Path;
+
+use catalog::CatalogEntry;
+use install::{AddOutcome, Compat, PluginError};
+
+/// Where a listed plugin came from.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Origin {
+    /// Shipped in this workspace, released in lockstep with `autumn-web`.
+    FirstParty,
+    /// Found on crates.io through the `autumn-plugin-` naming convention.
+    Community,
+}
+
+/// One row of `autumn plugin list`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ListRow {
+    /// crates.io name.
+    pub crate_name: String,
+    /// The version that would be installed.
+    pub version: String,
+    /// One-line description.
+    pub summary: String,
+    /// Where the row came from.
+    pub origin: Origin,
+    /// Whether that version works with this app's `autumn-web`.
+    pub compat: Compat,
+}
+
+/// Options for `autumn plugin list`.
+#[derive(Debug, Clone, Copy)]
+pub struct ListOptions<'a> {
+    /// Project root to resolve the app's `autumn-web` version from.
+    pub root: &'a Path,
+    /// Emit JSON instead of a table.
+    pub json: bool,
+    /// Skip the crates.io lookup entirely.
+    pub offline: bool,
+}
+
+/// Options for `autumn plugin add`.
+#[derive(Debug, Clone, Copy)]
+pub struct AddOptions<'a> {
+    /// Project root to install into.
+    pub root: &'a Path,
+    /// Plugin crate name.
+    pub name: &'a str,
+    /// Print the plan without touching the filesystem.
+    pub dry_run: bool,
+    /// Skip the crates.io lookup (community crates only).
+    pub offline: bool,
+}
+
+/// What [`resolve`] found for a plugin name.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Resolved {
+    /// A first-party plugin the CLI knows how to mount.
+    FirstParty(&'static CatalogEntry),
+    /// A community crate following the `autumn-plugin-` convention.
+    Community(String),
+}
+
+/// The version of every first-party plugin: they are released in lockstep
+/// with `autumn-web` and with this CLI, so the CLI's own version is the one to
+/// install.
+#[must_use]
+pub const fn first_party_version() -> &'static str {
+    env!("CARGO_PKG_VERSION")
+}
+
+/// Build the rows `autumn plugin list` renders.
+///
+/// `app_version` is the app's `autumn-web` requirement, or `None` when the
+/// command is run outside a project — in which case nothing can be said about
+/// compatibility, so every row is [`Compat::Unknown`] rather than optimistically
+/// compatible.
+#[must_use]
+pub fn list_rows(
+    app_version: Option<&str>,
+    community: &[registry::CommunityPlugin],
+) -> Vec<ListRow> {
+    let version = first_party_version();
+    let compat = app_version.map_or(Compat::Unknown, |app| install::check_compat(app, version));
+    let mut rows: Vec<ListRow> = catalog::FIRST_PARTY
+        .iter()
+        .map(|entry| ListRow {
+            crate_name: entry.crate_name.to_owned(),
+            version: version.to_owned(),
+            summary: entry.summary.to_owned(),
+            origin: Origin::FirstParty,
+            compat,
+        })
+        .collect();
+    rows.extend(community.iter().map(|found| ListRow {
+        crate_name: found.crate_name.clone(),
+        version: found.version.clone(),
+        summary: found.summary.clone(),
+        origin: Origin::Community,
+        // A community crate's supported `autumn-web` range is not in the
+        // crates.io search response, and issue #1606 rules out a registry that
+        // would carry it. Reported unknown rather than guessed.
+        compat: Compat::Unknown,
+    }));
+    rows
+}
+
+/// Longest single-line summary rendered in the table before it is elided.
+const SUMMARY_WIDTH: usize = 68;
+
+/// Render `rows` as the human-readable table.
+#[must_use]
+pub fn render_list(rows: &[ListRow], app_version: Option<&str>, note: Option<&str>) -> String {
+    use std::fmt::Write as _;
+
+    let mut out = String::new();
+    match app_version {
+        Some(version) => {
+            let _ = writeln!(
+                out,
+                "Installable plugins (this app uses autumn-web {version})\n"
+            );
+        }
+        None => {
+            out.push_str(
+                "Installable plugins (run inside an Autumn project to check version compatibility)\n\n",
+            );
+        }
+    }
+
+    let name_width = rows
+        .iter()
+        .map(|row| crate::text_width::display_width(&row.crate_name))
+        .max()
+        .unwrap_or(0);
+    let version_width = rows
+        .iter()
+        .map(|row| crate::text_width::display_width(&row.version))
+        .max()
+        .unwrap_or(0);
+
+    for (origin, heading) in [
+        (Origin::FirstParty, "First-party"),
+        (Origin::Community, "Community (crates.io `autumn-plugin-*`)"),
+    ] {
+        let group: Vec<&ListRow> = rows.iter().filter(|row| row.origin == origin).collect();
+        if group.is_empty() {
+            continue;
+        }
+        let _ = writeln!(out, "{heading}:");
+        for row in group {
+            let _ = writeln!(
+                out,
+                "  {name:<name_width$}  {version:<version_width$}  {summary}{compat}",
+                name = row.crate_name,
+                version = row.version,
+                summary = elide(&row.summary, SUMMARY_WIDTH),
+                compat = match row.compat {
+                    Compat::Incompatible => "  [incompatible with this app]",
+                    Compat::Unknown if row.origin == Origin::FirstParty =>
+                        "  [compatibility unknown]",
+                    Compat::Compatible | Compat::Unknown => "",
+                },
+            );
+        }
+        out.push('\n');
+    }
+
+    if let Some(note) = note {
+        let _ = writeln!(out, "Note: {note}");
+    }
+    let _ = write!(out, "Install one with `autumn plugin add <name>`.");
+    out
+}
+
+/// Shorten `text` to `width` display columns, marking the cut with `…`.
+fn elide(text: &str, width: usize) -> String {
+    if crate::text_width::display_width(text) <= width {
+        return text.to_owned();
+    }
+    let mut out: String = text.chars().take(width.saturating_sub(1)).collect();
+    out.push('…');
+    out
+}
+
+/// Render `rows` as JSON.
+#[must_use]
+pub fn render_list_json(rows: &[ListRow], app_version: Option<&str>) -> String {
+    let plugins: Vec<serde_json::Value> = rows
+        .iter()
+        .map(|row| {
+            serde_json::json!({
+                "name": row.crate_name,
+                "version": row.version,
+                "description": row.summary,
+                "origin": match row.origin {
+                    Origin::FirstParty => "first-party",
+                    Origin::Community => "community",
+                },
+                "compatible": match row.compat {
+                    Compat::Compatible => serde_json::Value::Bool(true),
+                    Compat::Incompatible => serde_json::Value::Bool(false),
+                    Compat::Unknown => serde_json::Value::Null,
+                },
+            })
+        })
+        .collect();
+    let document = serde_json::json!({
+        "autumn_web": app_version,
+        "plugins": plugins,
+    });
+    serde_json::to_string_pretty(&document).unwrap_or_else(|_| "{}".to_owned())
+}
+
+/// Render the report `plugin add` prints for `outcome`.
+///
+/// `dry_run` only changes the wording: a dry run has printed the edits it
+/// *would* make, so claiming the plugin was installed would be a lie.
+#[must_use]
+pub fn render_add(entry_name: &str, outcome: &AddOutcome, dry_run: bool) -> String {
+    use std::fmt::Write as _;
+
+    let mut out = String::new();
+    match outcome {
+        AddOutcome::Installed { steps, .. } => {
+            if dry_run {
+                let _ = writeln!(
+                    out,
+                    "\nDry run: nothing was written. `autumn plugin add {entry_name}` would make the edits above."
+                );
+            } else {
+                let _ = writeln!(out, "\nInstalled {entry_name}.");
+            }
+            append_steps(&mut out, steps);
+        }
+        AddOutcome::AlreadyInstalled => {
+            let _ = write!(
+                out,
+                "\n{entry_name} is already installed — nothing to do (the dependency and the mount are both in place)."
+            );
+        }
+        AddOutcome::DependencyOnly {
+            dependency_line,
+            mount_snippet,
+            ..
+        } => {
+            if dry_run {
+                let _ = writeln!(
+                    out,
+                    "\nDry run: nothing was written. `autumn plugin add {entry_name}` would add {dependency_line}."
+                );
+            } else {
+                let _ = writeln!(out, "\nAdded {dependency_line}.");
+            }
+            let _ = writeln!(
+                out,
+                "\n{entry_name} is a community crate, so the mount is not written for you — the\n\
+                 `<Name>Plugin` below is derived from the naming convention in docs/plugins.md and\n\
+                 cannot be verified from here. Check the crate's README, then add to your builder chain:\n"
+            );
+            let _ = writeln!(out, "{mount_snippet}");
+        }
+        AddOutcome::Manual {
+            reason,
+            dependency_line,
+            mount_snippet,
+            steps,
+        } => {
+            let _ = writeln!(out, "\nNo files were changed: {reason}.");
+            let _ = writeln!(out, "\nAdd to `[dependencies]` in Cargo.toml:\n");
+            let _ = writeln!(out, "  {dependency_line}");
+            let _ = writeln!(out, "\nAdd to your `autumn_web::app()` builder chain:\n");
+            let _ = writeln!(out, "{mount_snippet}");
+            append_steps(&mut out, steps);
+        }
+    }
+    out
+}
+
+/// Append a numbered "Next steps" block, if there is anything to say.
+fn append_steps(out: &mut String, steps: &[String]) {
+    use std::fmt::Write as _;
+
+    if steps.is_empty() {
+        return;
+    }
+    out.push_str("\nNext steps:\n");
+    for (index, step) in steps.iter().enumerate() {
+        let _ = writeln!(out, "  {}. {step}", index + 1);
+    }
+}
+
+/// Resolve `name` to a first-party catalog entry, or report it as a community
+/// crate that follows the documented convention.
+///
+/// # Errors
+///
+/// [`PluginError::UnknownPlugin`] when the name is neither.
+pub fn resolve(name: &str) -> Result<Resolved, PluginError> {
+    if let Some(entry) = catalog::lookup(name) {
+        return Ok(Resolved::FirstParty(entry));
+    }
+    if catalog::is_community_name(name) {
+        return Ok(Resolved::Community(name.to_owned()));
+    }
+    Err(PluginError::UnknownPlugin(name.to_owned()))
+}
+
+/// The app's `autumn-web` version, or `None` when it cannot be determined.
+fn app_version(root: &Path) -> Option<String> {
+    match install::app_autumn_web(root) {
+        Ok(install::AppAutumnWeb::Version(version)) => Some(version),
+        Ok(install::AppAutumnWeb::Unversioned) | Err(_) => None,
+    }
+}
+
+/// Run `autumn plugin list`. Returns the process exit code.
+#[must_use]
+pub fn run_list(opts: &ListOptions<'_>) -> i32 {
+    let app = app_version(opts.root);
+    let (community, note) = if opts.offline {
+        (
+            Vec::new(),
+            Some(
+                "--offline: crates.io was not queried, so no community plugins are listed."
+                    .to_owned(),
+            ),
+        )
+    } else {
+        registry::search().map_or_else(
+            || {
+                (
+                    Vec::new(),
+                    Some(
+                        "could not reach crates.io, so no community plugins are listed.".to_owned(),
+                    ),
+                )
+            },
+            |found| (found, None),
+        )
+    };
+    let rows = list_rows(app.as_deref(), &community);
+    if opts.json {
+        println!("{}", render_list_json(&rows, app.as_deref()));
+    } else {
+        println!("{}", render_list(&rows, app.as_deref(), note.as_deref()));
+    }
+    0
+}
+
+/// Run `autumn plugin add`. Returns the process exit code.
+#[must_use]
+pub fn run_add(opts: &AddOptions<'_>) -> i32 {
+    let resolved = match resolve(opts.name) {
+        Ok(resolved) => resolved,
+        Err(err) => {
+            eprintln!("autumn plugin add: {err}");
+            return 1;
+        }
+    };
+
+    let outcome = match &resolved {
+        Resolved::FirstParty(entry) => install::plan_add(opts.root, entry, first_party_version()),
+        Resolved::Community(crate_name) => {
+            if opts.offline {
+                eprintln!(
+                    "autumn plugin add: --offline cannot resolve a version for the community crate `{crate_name}`; drop --offline or add the dependency by hand."
+                );
+                return 1;
+            }
+            let Some(version) = registry::latest_version(crate_name) else {
+                eprintln!(
+                    "autumn plugin add: could not find `{crate_name}` on crates.io (or crates.io is unreachable); no files were changed."
+                );
+                return 1;
+            };
+            install::plan_add_community(opts.root, crate_name, &version)
+        }
+    };
+
+    let outcome = match outcome {
+        Ok(outcome) => outcome,
+        Err(err) => {
+            eprintln!("autumn plugin add: {err}");
+            return 1;
+        }
+    };
+
+    let flags = crate::generate::Flags {
+        dry_run: opts.dry_run,
+        force: false,
+    };
+    match &outcome {
+        AddOutcome::Installed { plan, .. } | AddOutcome::DependencyOnly { plan, .. } => {
+            if let Err(err) = plan.execute(flags) {
+                eprintln!("autumn plugin add: {err}");
+                return 1;
+            }
+        }
+        AddOutcome::AlreadyInstalled | AddOutcome::Manual { .. } => {}
+    }
+    println!("{}", render_add(opts.name, &outcome, opts.dry_run));
+    0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use registry::CommunityPlugin;
+
+    fn community() -> Vec<CommunityPlugin> {
+        vec![CommunityPlugin {
+            crate_name: "autumn-plugin-live-feed".to_owned(),
+            version: "0.3.1".to_owned(),
+            summary: "Live feeds for autumn-web".to_owned(),
+        }]
+    }
+
+    #[test]
+    fn resolve_finds_first_party_plugins() {
+        assert!(matches!(
+            resolve("autumn-admin-plugin").unwrap(),
+            Resolved::FirstParty(_)
+        ));
+    }
+
+    #[test]
+    fn resolve_accepts_convention_named_community_crates() {
+        assert_eq!(
+            resolve("autumn-plugin-live-feed").unwrap(),
+            Resolved::Community("autumn-plugin-live-feed".to_owned())
+        );
+    }
+
+    #[test]
+    fn resolve_rejects_anything_else() {
+        let err = resolve("tokio").unwrap_err();
+        assert!(matches!(err, PluginError::UnknownPlugin(_)));
+        assert!(err.to_string().contains("autumn plugin list"), "{err}");
+    }
+
+    /// AC #1: name, one-line description, and the version compatible with the
+    /// app's `autumn-web` — for first-party *and* community crates.
+    #[test]
+    fn rows_cover_first_party_and_community() {
+        let rows = list_rows(Some("0.7.0"), &community());
+        assert!(
+            rows.iter()
+                .filter(|r| r.origin == Origin::FirstParty)
+                .count()
+                >= 5
+        );
+        let feed = rows
+            .iter()
+            .find(|r| r.crate_name == "autumn-plugin-live-feed")
+            .expect("community row");
+        assert_eq!(feed.origin, Origin::Community);
+        assert_eq!(feed.version, "0.3.1");
+        assert_eq!(feed.summary, "Live feeds for autumn-web");
+    }
+
+    #[test]
+    fn first_party_rows_carry_a_summary_and_a_version() {
+        for row in list_rows(Some("0.7.0"), &[])
+            .iter()
+            .filter(|r| r.origin == Origin::FirstParty)
+        {
+            assert!(!row.summary.is_empty(), "{row:?}");
+            assert!(!row.version.is_empty(), "{row:?}");
+            assert_eq!(row.compat, Compat::Compatible, "{row:?}");
+        }
+    }
+
+    /// A first-party plugin cannot be installed into an app on a different
+    /// `autumn-web` minor series — the listing has to say so rather than
+    /// offering a version that will be refused at `add` time.
+    #[test]
+    fn rows_mark_incompatibility_against_an_older_app() {
+        let rows = list_rows(Some("0.5.0"), &[]);
+        assert!(
+            rows.iter()
+                .filter(|r| r.origin == Origin::FirstParty)
+                .all(|r| r.compat == Compat::Incompatible),
+            "{rows:?}"
+        );
+    }
+
+    /// Outside a project there is no app version to compare against; the
+    /// listing still renders, marked unknown.
+    #[test]
+    fn rows_outside_a_project_are_unknown_not_incompatible() {
+        let rows = list_rows(None, &[]);
+        assert!(
+            rows.iter()
+                .filter(|r| r.origin == Origin::FirstParty)
+                .all(|r| r.compat == Compat::Unknown),
+            "{rows:?}"
+        );
+    }
+
+    /// A community crate's `autumn-web` range is not knowable from the search
+    /// API, so it is reported as unknown rather than guessed.
+    #[test]
+    fn community_rows_have_unknown_compatibility() {
+        let rows = list_rows(Some("0.7.0"), &community());
+        let feed = rows
+            .iter()
+            .find(|r| r.crate_name == "autumn-plugin-live-feed")
+            .unwrap();
+        assert_eq!(feed.compat, Compat::Unknown);
+    }
+
+    #[test]
+    fn the_table_shows_name_version_and_description() {
+        let out = render_list(&list_rows(Some("0.7.0"), &community()), Some("0.7.0"), None);
+        assert!(out.contains("autumn-admin-plugin"), "{out}");
+        assert!(out.contains("autumn-plugin-live-feed"), "{out}");
+        assert!(out.contains("Live feeds for autumn-web"), "{out}");
+        assert!(out.contains("0.3.1"), "{out}");
+        assert!(out.contains("0.7.0"), "{out}");
+    }
+
+    #[test]
+    fn the_table_flags_incompatible_rows() {
+        let out = render_list(&list_rows(Some("0.5.0"), &[]), Some("0.5.0"), None);
+        assert!(out.contains("incompatible"), "{out}");
+    }
+
+    #[test]
+    fn a_note_is_rendered_when_crates_io_could_not_be_reached() {
+        let out = render_list(
+            &list_rows(Some("0.7.0"), &[]),
+            Some("0.7.0"),
+            Some("offline"),
+        );
+        assert!(out.contains("offline"), "{out}");
+    }
+
+    #[test]
+    fn json_output_is_machine_readable() {
+        let json = render_list_json(&list_rows(Some("0.7.0"), &community()), Some("0.7.0"));
+        let value: serde_json::Value = serde_json::from_str(&json).expect("valid JSON");
+        assert_eq!(value["autumn_web"], "0.7.0");
+        let plugins = value["plugins"].as_array().expect("plugins array");
+        let admin = plugins
+            .iter()
+            .find(|p| p["name"] == "autumn-admin-plugin")
+            .expect("admin row");
+        assert_eq!(admin["origin"], "first-party");
+        assert_eq!(admin["compatible"], true);
+        assert!(admin["description"].as_str().is_some_and(|d| !d.is_empty()));
+    }
+
+    #[test]
+    fn the_add_report_lists_post_install_steps() {
+        let entry = catalog::lookup("autumn-cache-redis").unwrap();
+        let outcome = AddOutcome::Installed {
+            plan: Box::new(crate::generate::emit::Plan::new(".")),
+            steps: entry.post_install.iter().map(|s| (*s).to_owned()).collect(),
+        };
+        let out = render_add("autumn-cache-redis", &outcome, false);
+        for step in entry.post_install {
+            assert!(out.contains(step), "{out}");
+        }
+    }
+
+    /// A dry run must not claim the plugin was installed.
+    #[test]
+    fn the_dry_run_report_does_not_claim_an_install() {
+        let outcome = AddOutcome::Installed {
+            plan: Box::new(crate::generate::emit::Plan::new(".")),
+            steps: Vec::new(),
+        };
+        let out = render_add("autumn-admin-plugin", &outcome, true);
+        assert!(out.contains("Dry run"), "{out}");
+        assert!(!out.contains("Installed autumn-admin-plugin"), "{out}");
+    }
+
+    #[test]
+    fn the_already_installed_report_says_nothing_changed() {
+        let out = render_add("autumn-admin-plugin", &AddOutcome::AlreadyInstalled, false);
+        assert!(out.contains("already installed"), "{out}");
+        assert!(out.contains("autumn-admin-plugin"), "{out}");
+    }
+
+    /// A community crate gets its dependency written but never an automatic
+    /// mount — the report has to say so, and show the derived snippet.
+    #[test]
+    fn the_dependency_only_report_shows_the_derived_mount() {
+        let out = render_add(
+            "autumn-plugin-live-feed",
+            &AddOutcome::DependencyOnly {
+                plan: Box::new(crate::generate::emit::Plan::new(".")),
+                dependency_line: "autumn-plugin-live-feed = \"0.3.1\"".to_owned(),
+                mount_snippet: "        .plugin(autumn_plugin_live_feed::LiveFeedPlugin::new())"
+                    .to_owned(),
+            },
+            false,
+        );
+        assert!(out.contains("autumn-plugin-live-feed = \"0.3.1\""), "{out}");
+        assert!(out.contains("LiveFeedPlugin::new()"), "{out}");
+        assert!(out.contains("community crate"), "{out}");
+    }
+
+    #[test]
+    fn the_manual_report_prints_both_the_dependency_and_the_mount() {
+        let out = render_add(
+            "autumn-admin-plugin",
+            &AddOutcome::Manual {
+                reason: "could not find the builder chain".to_owned(),
+                dependency_line: "autumn-admin-plugin = \"0.7.0\"".to_owned(),
+                mount_snippet: ".plugin(autumn_admin_plugin::AdminPlugin::new())".to_owned(),
+                steps: vec!["run `autumn generate admin Post`".to_owned()],
+            },
+            false,
+        );
+        assert!(out.contains("autumn-admin-plugin = \"0.7.0\""), "{out}");
+        assert!(out.contains("AdminPlugin::new()"), "{out}");
+        assert!(out.contains("could not find the builder chain"), "{out}");
+    }
+}

--- a/autumn-cli/src/plugin/registry.rs
+++ b/autumn-cli/src/plugin/registry.rs
@@ -135,12 +135,10 @@ pub fn search() -> Option<Vec<CommunityPlugin>> {
 pub fn latest_version(crate_name: &str) -> Option<String> {
     let body = get(&format!("https://crates.io/api/v1/crates/{crate_name}"))?;
     let value = serde_json::from_str::<serde_json::Value>(&body).ok()?;
-    let krate = value.get("crate")?;
-    krate
-        .get("newest_version")
-        .or_else(|| krate.get("max_version"))
-        .and_then(serde_json::Value::as_str)
-        .map(std::borrow::ToOwned::to_owned)
+    // The SAME field preference as the search path. Diverging here let
+    // `plugin add` pin a back-ported or pre-release version while
+    // `plugin list` had shown the stable one the user picked.
+    pick_version(value.get("crate")?)
 }
 
 /// Largest response body this module will read into memory.

--- a/autumn-cli/src/plugin/registry.rs
+++ b/autumn-cli/src/plugin/registry.rs
@@ -66,14 +66,7 @@ pub fn parse_search_response(body: &str) -> Vec<CommunityPlugin> {
             if !super::catalog::is_community_name(name) {
                 return None;
             }
-            // `newest_version` is today's field; `max_version` is the older
-            // spelling still returned by some mirrors.
-            let version = entry
-                .get("newest_version")
-                .or_else(|| entry.get("max_version"))
-                .and_then(serde_json::Value::as_str)
-                .unwrap_or_default()
-                .to_owned();
+            let version = pick_version(entry).unwrap_or_default();
             Some(CommunityPlugin {
                 crate_name: name.to_owned(),
                 version,
@@ -90,9 +83,38 @@ pub fn parse_search_response(body: &str) -> Vec<CommunityPlugin> {
     found
 }
 
+/// The version to install for a crates.io crate object.
+///
+/// `max_stable_version` first: these three fields are not spellings of one
+/// value. `newest_version` is the most *recently published* version, so a
+/// back-ported `1.4.3` released after `2.0.0` — or a trailing pre-release —
+/// would be picked over the newest release. `max_version` is the highest
+/// version including pre-releases. Only `max_stable_version` is what a user
+/// asking for "the current version" means; the other two are fallbacks for
+/// mirrors that omit it.
+fn pick_version(entry: &serde_json::Value) -> Option<String> {
+    ["max_stable_version", "max_version", "newest_version"]
+        .into_iter()
+        .find_map(|field| entry.get(field).and_then(serde_json::Value::as_str))
+        .map(std::borrow::ToOwned::to_owned)
+}
+
 /// Collapse a crates.io description to a single line for table rendering.
+///
+/// Control characters are replaced, not just collapsed: a description is
+/// attacker-supplied text (anyone can publish `autumn-plugin-<x>`) that
+/// `plugin list` prints straight to a terminal, and `char::is_whitespace` is
+/// false for `ESC`. Without this an `\x1b[…` sequence in a description could
+/// clear the victim's screen, spoof output, retitle the window, or reach the
+/// clipboard through OSC 52 — from a bare `autumn plugin list`, with nothing
+/// installed.
 fn one_line(text: &str) -> String {
-    text.split_whitespace().collect::<Vec<_>>().join(" ")
+    text.chars()
+        .map(|c| if c.is_control() { ' ' } else { c })
+        .collect::<String>()
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
 }
 
 /// Query crates.io for community plugins. `None` when the lookup could not be
@@ -121,10 +143,25 @@ pub fn latest_version(crate_name: &str) -> Option<String> {
         .map(std::borrow::ToOwned::to_owned)
 }
 
+/// Largest response body this module will read into memory.
+///
+/// `SEARCH_TIMEOUT` bounds time, not bytes, and `per_page=50` bounds the
+/// result count, not the payload — so without a cap a hostile or broken
+/// endpoint could OOM the CLI. 4 MiB is two orders of magnitude above a real
+/// 50-result crates.io page.
+const MAX_RESPONSE_BYTES: u64 = 4 * 1024 * 1024;
+
 /// One blocking GET, or `None` for any failure at all.
+///
+/// Redirects are capped (there is no crates.io API endpoint that needs them,
+/// and an uncapped chain is what would let the size cap be applied to a body
+/// from some other host), and the body is read through a byte limit.
 fn get(url: &str) -> Option<String> {
+    use std::io::Read as _;
+
     let client = reqwest::blocking::Client::builder()
         .timeout(SEARCH_TIMEOUT)
+        .redirect(reqwest::redirect::Policy::limited(2))
         .user_agent(user_agent())
         .build()
         .ok()?;
@@ -132,7 +169,12 @@ fn get(url: &str) -> Option<String> {
     if !response.status().is_success() {
         return None;
     }
-    response.text().ok()
+    let mut body = Vec::new();
+    response
+        .take(MAX_RESPONSE_BYTES)
+        .read_to_end(&mut body)
+        .ok()?;
+    String::from_utf8(body).ok()
 }
 
 #[cfg(test)]
@@ -168,8 +210,7 @@ mod tests {
         assert_eq!(feed.summary, "Live feeds for autumn-web");
     }
 
-    /// `newest_version` is the field crates.io actually returns today;
-    /// `max_version` is the older spelling. Both must work.
+    /// `newest_version` is a fallback for mirrors that omit the others.
     #[test]
     fn either_version_field_is_accepted() {
         let found = parse_search_response(SAMPLE);
@@ -178,6 +219,37 @@ mod tests {
             .find(|c| c.crate_name == "autumn-plugin-audit")
             .expect("audit");
         assert_eq!(audit.version, "1.0.0");
+    }
+
+    /// The three version fields are not spellings of one value:
+    /// `newest_version` is the most recently PUBLISHED version, so a
+    /// back-ported release or a trailing pre-release would win over the
+    /// current one. `max_stable_version` is what a user means.
+    #[test]
+    fn the_max_stable_version_wins_over_the_newest_publish() {
+        let body = r#"{"crates":[{"name":"autumn-plugin-x","max_stable_version":"2.0.0",
+            "max_version":"2.1.0-rc.1","newest_version":"1.4.3","description":"back-ported"}]}"#;
+        let found = parse_search_response(body);
+        assert_eq!(found[0].version, "2.0.0");
+    }
+
+    /// A crates.io description is attacker-supplied text printed straight to a
+    /// terminal. `ESC` is not Unicode whitespace, so collapsing whitespace
+    /// alone leaves an ANSI sequence intact.
+    #[test]
+    fn control_characters_never_survive_into_the_summary() {
+        let body = "{\"crates\":[{\"name\":\"autumn-plugin-x\",\"max_version\":\"0.1.0\",\
+                    \"description\":\"safe\\u001b[2J\\u0007evil\"}]}";
+        let found = parse_search_response(body);
+        assert_eq!(found.len(), 1);
+        assert!(
+            !found[0].summary.chars().any(char::is_control),
+            "{:?}",
+            found[0].summary
+        );
+        // The ESC and BEL are gone; what remains is inert printable text, which
+        // is the point — the sequence can no longer drive the terminal.
+        assert_eq!(found[0].summary, "safe [2J evil");
     }
 
     #[test]

--- a/autumn-cli/src/plugin/registry.rs
+++ b/autumn-cli/src/plugin/registry.rs
@@ -1,0 +1,210 @@
+//! Community-plugin discovery over crates.io.
+//!
+//! Issue #1606 scopes discovery to "crates.io plus the existing naming
+//! convention" — no hosted registry. So this is one search call against the
+//! public crates.io API for the documented `autumn-plugin-` prefix, filtered
+//! to names that actually carry it (the API's relevance search happily returns
+//! neighbours).
+//!
+//! Network failure is **not** an error: `autumn plugin list` still has the
+//! whole first-party catalog to show, so a failed or skipped lookup becomes a
+//! note in the output rather than a non-zero exit.
+
+use std::time::Duration;
+
+/// A community plugin crate found on crates.io.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CommunityPlugin {
+    /// crates.io name, e.g. `autumn-plugin-live-feed`.
+    pub crate_name: String,
+    /// Newest published version.
+    pub version: String,
+    /// crates.io description, trimmed to one line.
+    pub summary: String,
+}
+
+/// How long to wait on crates.io before giving up and rendering the
+/// first-party catalog alone.
+pub const SEARCH_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// The crates.io search endpoint for the documented naming convention.
+#[must_use]
+pub fn search_url() -> String {
+    format!(
+        "https://crates.io/api/v1/crates?q={}&per_page=50",
+        super::catalog::COMMUNITY_PREFIX
+    )
+}
+
+/// The `User-Agent` crates.io asks API clients to identify themselves with.
+fn user_agent() -> String {
+    format!(
+        "autumn-cli/{} (https://github.com/autumn-foundation/autumn)",
+        env!("CARGO_PKG_VERSION")
+    )
+}
+
+/// Parse a crates.io search response body into community plugins.
+///
+/// Split from the HTTP call so the filtering rules are unit-testable without
+/// a network. crates.io ranks by relevance, so the response also carries
+/// neighbours (`autumn-web` itself, unrelated crates): only names that
+/// actually carry the documented prefix are plugins. Results come back sorted
+/// by name so the listing is stable across runs.
+#[must_use]
+pub fn parse_search_response(body: &str) -> Vec<CommunityPlugin> {
+    let Ok(value) = serde_json::from_str::<serde_json::Value>(body) else {
+        return Vec::new();
+    };
+    let Some(crates) = value.get("crates").and_then(serde_json::Value::as_array) else {
+        return Vec::new();
+    };
+    let mut found: Vec<CommunityPlugin> = crates
+        .iter()
+        .filter_map(|entry| {
+            let name = entry.get("name")?.as_str()?;
+            if !super::catalog::is_community_name(name) {
+                return None;
+            }
+            // `newest_version` is today's field; `max_version` is the older
+            // spelling still returned by some mirrors.
+            let version = entry
+                .get("newest_version")
+                .or_else(|| entry.get("max_version"))
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or_default()
+                .to_owned();
+            Some(CommunityPlugin {
+                crate_name: name.to_owned(),
+                version,
+                summary: one_line(
+                    entry
+                        .get("description")
+                        .and_then(serde_json::Value::as_str)
+                        .unwrap_or_default(),
+                ),
+            })
+        })
+        .collect();
+    found.sort_by(|a, b| a.crate_name.cmp(&b.crate_name));
+    found
+}
+
+/// Collapse a crates.io description to a single line for table rendering.
+fn one_line(text: &str) -> String {
+    text.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+/// Query crates.io for community plugins. `None` when the lookup could not be
+/// completed (offline, timeout, non-200, unparseable body).
+///
+/// Deliberately `None` rather than `Err`: `autumn plugin list` still has the
+/// whole first-party catalog to render, so an unreachable crates.io is a note
+/// in the output, not a failed command.
+#[must_use]
+pub fn search() -> Option<Vec<CommunityPlugin>> {
+    let body = get(&search_url())?;
+    Some(parse_search_response(&body))
+}
+
+/// Look up one crate's newest version. `None` when the lookup fails or the
+/// crate does not exist.
+#[must_use]
+pub fn latest_version(crate_name: &str) -> Option<String> {
+    let body = get(&format!("https://crates.io/api/v1/crates/{crate_name}"))?;
+    let value = serde_json::from_str::<serde_json::Value>(&body).ok()?;
+    let krate = value.get("crate")?;
+    krate
+        .get("newest_version")
+        .or_else(|| krate.get("max_version"))
+        .and_then(serde_json::Value::as_str)
+        .map(std::borrow::ToOwned::to_owned)
+}
+
+/// One blocking GET, or `None` for any failure at all.
+fn get(url: &str) -> Option<String> {
+    let client = reqwest::blocking::Client::builder()
+        .timeout(SEARCH_TIMEOUT)
+        .user_agent(user_agent())
+        .build()
+        .ok()?;
+    let response = client.get(url).send().ok()?;
+    if !response.status().is_success() {
+        return None;
+    }
+    response.text().ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SAMPLE: &str = r#"{
+      "crates": [
+        {"name": "autumn-plugin-live-feed", "max_version": "0.3.1", "description": "Live feeds for autumn-web"},
+        {"name": "autumn-plugin-audit", "newest_version": "1.0.0", "description": "Audit trail"},
+        {"name": "autumn-web", "max_version": "0.7.0", "description": "The framework itself"},
+        {"name": "some-other-crate", "max_version": "2.0.0", "description": "unrelated"}
+      ]
+    }"#;
+
+    /// crates.io relevance search returns neighbours; only names that actually
+    /// carry the documented prefix are community plugins.
+    #[test]
+    fn only_convention_named_crates_are_kept() {
+        let found = parse_search_response(SAMPLE);
+        let names: Vec<&str> = found.iter().map(|c| c.crate_name.as_str()).collect();
+        assert_eq!(names, ["autumn-plugin-audit", "autumn-plugin-live-feed"]);
+    }
+
+    #[test]
+    fn version_and_summary_come_from_the_response() {
+        let found = parse_search_response(SAMPLE);
+        let feed = found
+            .iter()
+            .find(|c| c.crate_name == "autumn-plugin-live-feed")
+            .expect("live-feed");
+        assert_eq!(feed.version, "0.3.1");
+        assert_eq!(feed.summary, "Live feeds for autumn-web");
+    }
+
+    /// `newest_version` is the field crates.io actually returns today;
+    /// `max_version` is the older spelling. Both must work.
+    #[test]
+    fn either_version_field_is_accepted() {
+        let found = parse_search_response(SAMPLE);
+        let audit = found
+            .iter()
+            .find(|c| c.crate_name == "autumn-plugin-audit")
+            .expect("audit");
+        assert_eq!(audit.version, "1.0.0");
+    }
+
+    #[test]
+    fn a_missing_description_becomes_an_empty_summary() {
+        let body = r#"{"crates":[{"name":"autumn-plugin-x","max_version":"0.1.0"}]}"#;
+        let found = parse_search_response(body);
+        assert_eq!(found.len(), 1);
+        assert_eq!(found[0].summary, "");
+    }
+
+    #[test]
+    fn a_multi_line_description_is_flattened_to_one_line() {
+        let body = r#"{"crates":[{"name":"autumn-plugin-x","max_version":"0.1.0","description":"first\nsecond"}]}"#;
+        let found = parse_search_response(body);
+        assert_eq!(found[0].summary, "first second");
+    }
+
+    #[test]
+    fn a_garbage_body_yields_no_plugins() {
+        assert!(parse_search_response("not json").is_empty());
+        assert!(parse_search_response("{}").is_empty());
+    }
+
+    #[test]
+    fn the_search_url_asks_crates_io_for_the_documented_prefix() {
+        let url = search_url();
+        assert!(url.starts_with("https://crates.io/api/v1/crates"), "{url}");
+        assert!(url.contains("autumn-plugin-"), "{url}");
+    }
+}

--- a/autumn-cli/src/rust_source.rs
+++ b/autumn-cli/src/rust_source.rs
@@ -11,23 +11,20 @@
 //! One scanner, shared, so an anchor scan and its "is it already there?"
 //! companion can never disagree about what a comment is.
 
-/// Walk `source`'s lines that are **code**, skipping comments, and return the
-/// first non-`None` result of `f`.
+/// Every line of `source` that is **code**, paired with its byte offset.
 ///
-/// `f` receives the raw line and its byte offset in `source`. The offset is
-/// tracked as the walk proceeds rather than recovered afterwards with
-/// `source.find(line)`, which would re-locate an identical earlier line and
-/// splice at the wrong place.
+/// `//`, `///`, `//!` and `/* … */` are skipped. The offset is tracked as the
+/// walk proceeds rather than recovered afterwards with `source.find(line)`,
+/// which would re-locate an identical earlier line and hand back the wrong
+/// splice point.
 ///
-/// Every caller that edits a user-owned `main.rs` shares this one scanner so
-/// they can never disagree about what counts as a comment — a disagreement
-/// there is exactly what lets a doc-comment mention both suppress an edit and
-/// suppress the warning about it. Callers today: `autumn generate pwa`'s push-
-/// router injection and `autumn plugin add`'s builder-chain scan.
-pub fn for_each_code_line<T>(
-    source: &str,
-    mut f: impl FnMut(&str, usize) -> Option<T>,
-) -> Option<T> {
+/// String literals are **not** tracked: a line inside a raw string still reads
+/// as code here. Callers that splice must therefore treat an ambiguous match
+/// (more than one candidate) as "no anchor" rather than picking one — see
+/// `plugin::install::builder_anchor`.
+#[must_use]
+pub fn code_lines(source: &str) -> Vec<(&str, usize)> {
+    let mut out = Vec::new();
     let mut offset = 0_usize;
     let mut in_block_comment = false;
 
@@ -53,11 +50,25 @@ pub fn for_each_code_line<T>(
             continue;
         }
 
-        if let Some(found) = f(line, line_start) {
-            return Some(found);
-        }
+        out.push((line, line_start));
     }
-    None
+    out
+}
+
+/// Walk `source`'s code lines and return the first non-`None` result of `f`.
+///
+/// Every caller that edits a user-owned `main.rs` shares this one scanner so
+/// they can never disagree about what counts as a comment — a disagreement
+/// there is exactly what lets a doc-comment mention both suppress an edit and
+/// suppress the warning about it. Callers today: `autumn generate pwa`'s push-
+/// router injection and `autumn plugin add`'s builder-chain scan.
+pub fn for_each_code_line<T>(
+    source: &str,
+    mut f: impl FnMut(&str, usize) -> Option<T>,
+) -> Option<T> {
+    code_lines(source)
+        .into_iter()
+        .find_map(|(line, offset)| f(line, offset))
 }
 
 #[cfg(test)]

--- a/autumn-cli/src/rust_source.rs
+++ b/autumn-cli/src/rust_source.rs
@@ -1,56 +1,245 @@
-//! Comment-aware scanning of user-owned Rust source.
+//! Comment- and string-aware scanning of user-owned Rust source.
 //!
 //! Commands that edit an application's `src/main.rs` — `autumn generate pwa`,
-//! `autumn plugin add` — must never splice code into a comment. Autumn's own
-//! documentation ships quick-start snippets containing the exact lines those
-//! commands anchor on (`autumn_web::app()`, `autumn_web::push::router()`), so a
-//! `main.rs` that pasted one into a doc comment would otherwise be edited
-//! *inside* the comment: a file that does not compile, and a mount that never
-//! happened.
+//! `autumn plugin add` — must never splice code into a comment, and must never
+//! mistake text inside a string literal for code. Autumn's own documentation
+//! ships quick-start snippets containing the exact lines those commands anchor
+//! on (`autumn_web::app()`, `autumn_web::push::router()`,
+//! `AdminPlugin::new()`), so a `main.rs` that pasted one into a doc comment or
+//! into embedded help text would otherwise be edited *inside* it — or, worse,
+//! be read as "already wired" and skipped, leaving the app without the mount
+//! the command reported installing.
 //!
-//! One scanner, shared, so an anchor scan and its "is it already there?"
-//! companion can never disagree about what a comment is.
+//! [`mask_non_code`] answers both by blanking comment bodies and string-literal
+//! contents to spaces **in place**, preserving every byte offset and line
+//! break. Callers scan the mask and splice into the original at the offsets it
+//! reports, so one scanner serves both the anchor search and its "is it already
+//! there?" companion — they can never disagree about what counts as code.
 
-/// Every line of `source` that is **code**, paired with its byte offset.
+/// Lexer state while walking Rust source.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Scan {
+    /// Ordinary code.
+    Code,
+    /// Inside a `//` line comment, until the newline.
+    LineComment,
+    /// Inside `/* … */`, which nests in Rust; carries the open depth.
+    BlockComment(usize),
+    /// Inside a `"…"` string literal.
+    Str,
+    /// Inside a `r"…"` / `r#"…"#` raw string; carries the hash count.
+    RawStr(usize),
+    /// Inside a `'…'` character literal.
+    CharLit,
+}
+
+/// Return `source` with every comment body and string-literal content replaced
+/// by spaces.
 ///
-/// `//`, `///`, `//!` and `/* … */` are skipped. The offset is tracked as the
-/// walk proceeds rather than recovered afterwards with `source.find(line)`,
-/// which would re-locate an identical earlier line and hand back the wrong
-/// splice point.
+/// The result has **exactly** the same length as the input and the same
+/// newlines, so a byte offset into the mask is a byte offset into the original.
+/// Delimiters are blanked along with their contents, so a trailing `// note`
+/// no longer hides the code before it from a `trim_end()` match.
 ///
-/// String literals are **not** tracked: a line inside a raw string still reads
-/// as code here. Callers that splice must therefore treat an ambiguous match
-/// (more than one candidate) as "no anchor" rather than picking one — see
-/// `plugin::install::builder_anchor`.
+/// Handles the literal forms that can hide a probe or an anchor: line and
+/// (nesting) block comments, escaped strings, raw strings of any hash count,
+/// and character literals — with lifetimes (`'a`) correctly *not* treated as
+/// the start of one.
 #[must_use]
-pub fn code_lines(source: &str) -> Vec<(&str, usize)> {
+pub fn mask_non_code(source: &str) -> String {
+    let bytes = source.as_bytes();
+    let mut out = bytes.to_vec();
+    let mut state = Scan::Code;
+    let mut i = 0usize;
+
+    while i < bytes.len() {
+        let (next, advance) = match state {
+            Scan::Code => step_code(bytes, i, &mut out),
+            Scan::LineComment => step_line_comment(bytes, i, &mut out),
+            Scan::BlockComment(depth) => step_block_comment(bytes, i, depth, &mut out),
+            Scan::Str | Scan::CharLit => {
+                let terminator = if state == Scan::Str { b'"' } else { b'\'' };
+                step_quoted(bytes, i, terminator, state, &mut out)
+            }
+            Scan::RawStr(hashes) => step_raw_string(bytes, i, hashes, &mut out),
+        };
+        state = next;
+        i += advance;
+    }
+
+    // Only whole ASCII bytes were replaced with ASCII spaces, so the result is
+    // still the valid UTF-8 it started as.
+    String::from_utf8(out).unwrap_or_else(|_| source.to_owned())
+}
+
+/// Blank one byte unless it is the newline that keeps lines aligned.
+fn blank(out: &mut [u8], at: usize) {
+    if out[at] != b'\n' {
+        out[at] = b' ';
+    }
+}
+
+/// Blank `count` bytes from `at`.
+fn blank_run(out: &mut [u8], at: usize, count: usize) {
+    for offset in 0..count {
+        blank(out, at + offset);
+    }
+}
+
+/// One step in ordinary code: enter a comment or literal, or move on.
+fn step_code(bytes: &[u8], i: usize, out: &mut [u8]) -> (Scan, usize) {
+    if bytes[i] == b'/' && bytes.get(i + 1) == Some(&b'/') {
+        blank_run(out, i, 2);
+        (Scan::LineComment, 2)
+    } else if bytes[i] == b'/' && bytes.get(i + 1) == Some(&b'*') {
+        blank_run(out, i, 2);
+        (Scan::BlockComment(1), 2)
+    } else if bytes[i] == b'"' {
+        blank(out, i);
+        (Scan::Str, 1)
+    } else if let Some(after) = raw_string_start(bytes, i) {
+        // `after` is just past the opening quote; the hashes sit between the
+        // `r` and it.
+        let hashes = after - i - 2;
+        blank_run(out, i, after - i);
+        (Scan::RawStr(hashes), after - i)
+    } else if bytes[i] == b'\'' && is_char_literal(bytes, i) {
+        blank(out, i);
+        (Scan::CharLit, 1)
+    } else {
+        (Scan::Code, 1)
+    }
+}
+
+/// One step inside a `//` comment: it ends at the newline.
+fn step_line_comment(bytes: &[u8], i: usize, out: &mut [u8]) -> (Scan, usize) {
+    if bytes[i] == b'\n' {
+        (Scan::Code, 1)
+    } else {
+        blank(out, i);
+        (Scan::LineComment, 1)
+    }
+}
+
+/// One step inside a `/* … */` comment, which nests in Rust.
+fn step_block_comment(bytes: &[u8], i: usize, depth: usize, out: &mut [u8]) -> (Scan, usize) {
+    if bytes[i] == b'/' && bytes.get(i + 1) == Some(&b'*') {
+        blank_run(out, i, 2);
+        (Scan::BlockComment(depth + 1), 2)
+    } else if bytes[i] == b'*' && bytes.get(i + 1) == Some(&b'/') {
+        blank_run(out, i, 2);
+        let next = if depth == 1 {
+            Scan::Code
+        } else {
+            Scan::BlockComment(depth - 1)
+        };
+        (next, 2)
+    } else {
+        blank(out, i);
+        (Scan::BlockComment(depth), 1)
+    }
+}
+
+/// One step inside a `"…"` string or `'…'` character literal, honouring
+/// backslash escapes so `"\""` does not terminate early.
+fn step_quoted(
+    bytes: &[u8],
+    i: usize,
+    terminator: u8,
+    state: Scan,
+    out: &mut [u8],
+) -> (Scan, usize) {
+    if bytes[i] == b'\\' {
+        let span = if i + 1 < bytes.len() { 2 } else { 1 };
+        blank_run(out, i, span);
+        (state, span)
+    } else if bytes[i] == terminator {
+        blank(out, i);
+        (Scan::Code, 1)
+    } else {
+        blank(out, i);
+        (state, 1)
+    }
+}
+
+/// One step inside a raw string, which ends only at a quote followed by the
+/// same number of hashes it opened with.
+fn step_raw_string(bytes: &[u8], i: usize, hashes: usize, out: &mut [u8]) -> (Scan, usize) {
+    if bytes[i] == b'"' && closes_raw_string(bytes, i, hashes) {
+        blank_run(out, i, hashes + 1);
+        (Scan::Code, hashes + 1)
+    } else {
+        blank(out, i);
+        (Scan::RawStr(hashes), 1)
+    }
+}
+
+/// If a raw-string literal opens at `i` (`r"`, `r#"`, `r##"`, …), the offset
+/// just past its opening quote.
+fn raw_string_start(bytes: &[u8], i: usize) -> Option<usize> {
+    if bytes[i] != b'r' {
+        return None;
+    }
+    // A `r` that continues an identifier (`for`, `var`) is not a literal.
+    if i > 0 && (bytes[i - 1].is_ascii_alphanumeric() || bytes[i - 1] == b'_') {
+        return None;
+    }
+    let mut at = i + 1;
+    while bytes.get(at) == Some(&b'#') {
+        at += 1;
+    }
+    (bytes.get(at) == Some(&b'"')).then_some(at + 1)
+}
+
+/// Whether the `"` at `i` closes a raw string opened with `hashes` hashes.
+fn closes_raw_string(bytes: &[u8], i: usize, hashes: usize) -> bool {
+    (1..=hashes).all(|offset| bytes.get(i + offset) == Some(&b'#'))
+}
+
+/// Whether the `'` at `i` opens a character literal rather than a lifetime.
+///
+/// `'a` in `&'a str` or `Cow<'static, str>` is a lifetime; `'a'` and `'\n'`
+/// are literals. Treating a lifetime as an opening quote would blank the rest
+/// of the file.
+fn is_char_literal(bytes: &[u8], i: usize) -> bool {
+    match bytes.get(i + 1) {
+        // `'\n'`, `'\''`, `'\\'` — an escape is always a literal.
+        Some(b'\\') => true,
+        Some(_) => {
+            // A literal closes within a few bytes; a lifetime never does.
+            // Scan past one (possibly multi-byte) character.
+            let mut at = i + 2;
+            while at < bytes.len() && at <= i + 5 {
+                if bytes[at] == b'\'' {
+                    return true;
+                }
+                // Only a multi-byte UTF-8 continuation can legitimately extend
+                // the character; anything else means this was a lifetime.
+                if bytes[at] & 0b1100_0000 != 0b1000_0000 {
+                    return false;
+                }
+                at += 1;
+            }
+            false
+        }
+        None => false,
+    }
+}
+
+/// Every line of `source` with comments and string contents blanked, paired
+/// with its byte offset in the **original** source.
+///
+/// The offset is tracked as the walk proceeds rather than recovered afterwards
+/// with `source.find(line)`, which would re-locate an identical earlier line
+/// and hand back the wrong splice point.
+#[must_use]
+pub fn code_lines(source: &str) -> Vec<(String, usize)> {
+    let masked = mask_non_code(source);
     let mut out = Vec::new();
-    let mut offset = 0_usize;
-    let mut in_block_comment = false;
-
-    for line in source.split_inclusive('\n') {
-        let trimmed = line.trim();
-        let line_start = offset;
+    let mut offset = 0usize;
+    for line in masked.split_inclusive('\n') {
+        out.push((line.to_owned(), offset));
         offset += line.len();
-
-        if in_block_comment {
-            if trimmed.contains("*/") {
-                in_block_comment = false;
-            }
-            continue;
-        }
-        if trimmed.starts_with("/*") {
-            if !trimmed.contains("*/") {
-                in_block_comment = true;
-            }
-            continue;
-        }
-        // `//`, `///`, `//!`, and continuation lines of a block comment.
-        if trimmed.starts_with("//") || trimmed.starts_with('*') {
-            continue;
-        }
-
-        out.push((line, line_start));
     }
     out
 }
@@ -58,22 +247,142 @@ pub fn code_lines(source: &str) -> Vec<(&str, usize)> {
 /// Walk `source`'s code lines and return the first non-`None` result of `f`.
 ///
 /// Every caller that edits a user-owned `main.rs` shares this one scanner so
-/// they can never disagree about what counts as a comment — a disagreement
-/// there is exactly what lets a doc-comment mention both suppress an edit and
-/// suppress the warning about it. Callers today: `autumn generate pwa`'s push-
-/// router injection and `autumn plugin add`'s builder-chain scan.
+/// they can never disagree about what counts as code. Callers today:
+/// `autumn generate pwa`'s push-router injection and `autumn plugin add`'s
+/// builder-chain scan and mount probe.
 pub fn for_each_code_line<T>(
     source: &str,
     mut f: impl FnMut(&str, usize) -> Option<T>,
 ) -> Option<T> {
     code_lines(source)
         .into_iter()
-        .find_map(|(line, offset)| f(line, offset))
+        .find_map(|(line, offset)| f(&line, offset))
 }
 
 #[cfg(test)]
 mod tests {
-    use super::for_each_code_line;
+    use super::{code_lines, for_each_code_line, mask_non_code};
+
+    /// The mask must be a byte-for-byte overlay: offsets computed on it index
+    /// the original exactly.
+    #[test]
+    fn masking_preserves_length_and_newlines() {
+        for source in [
+            "let x = \"hello\";\n",
+            "// comment\nlet y = 2;\n",
+            "/* a\n   b */\nlet z = 3;\n",
+            "let r = r#\"raw \" string\"#;\n",
+            "let c = 'x'; let s: &'a str;\n",
+        ] {
+            let masked = mask_non_code(source);
+            assert_eq!(masked.len(), source.len(), "{source:?}");
+            assert_eq!(
+                masked.matches('\n').count(),
+                source.matches('\n').count(),
+                "{source:?}"
+            );
+        }
+    }
+
+    /// The finding this scanner exists for: a probe hidden in a string literal
+    /// must not read as code.
+    #[test]
+    fn string_contents_are_not_code() {
+        let source = "fn main() {\n    let help = \"run AdminPlugin::new() yourself\";\n}\n";
+        assert!(
+            for_each_code_line(source, |line, _| line
+                .contains("AdminPlugin::new(")
+                .then_some(()))
+            .is_none()
+        );
+    }
+
+    #[test]
+    fn raw_string_contents_are_not_code() {
+        let source = "fn main() {\n    let doc = r#\"\n    autumn_web::app()\n\"#;\n}\n";
+        assert!(
+            for_each_code_line(source, |line, _| line
+                .contains("autumn_web::app()")
+                .then_some(()))
+            .is_none()
+        );
+    }
+
+    /// A raw string with more hashes must not be closed by a shorter run.
+    #[test]
+    fn raw_strings_respect_their_hash_count() {
+        let source = "let d = r##\"a \"# b autumn_web::app()\"##;\nlet real = autumn_web::app();\n";
+        let found = for_each_code_line(source, |line, offset| {
+            line.contains("autumn_web::app()").then_some(offset)
+        })
+        .expect("the real call");
+        assert!(source[found..].starts_with("let real"), "{found}");
+    }
+
+    #[test]
+    fn line_and_block_comments_are_not_code() {
+        for source in [
+            "// let x = 1;\n",
+            "/// let x = 1;\n",
+            "//! let x = 1;\n",
+            "   // let x = 1;\n",
+            "/*\nlet x = 1;\n*/\n",
+            "/* /* nested */ let x = 1; */\n",
+        ] {
+            assert!(
+                for_each_code_line(source, |line, _| line.contains("let x").then_some(()))
+                    .is_none(),
+                "{source:?}"
+            );
+        }
+    }
+
+    /// A `//` inside a string is not a comment, and a quote inside a comment
+    /// does not open a string — the two states have to be tracked together.
+    #[test]
+    fn comment_and_string_states_do_not_leak_into_each_other() {
+        let source = "let url = \"https://example.com\";\nlet real = autumn_web::app();\n";
+        assert!(
+            for_each_code_line(source, |line, _| line
+                .contains("autumn_web::app()")
+                .then_some(()))
+            .is_some()
+        );
+
+        let source = "// he said \"hi\n let real = autumn_web::app();\n";
+        assert!(
+            for_each_code_line(source, |line, _| line
+                .contains("autumn_web::app()")
+                .then_some(()))
+            .is_some(),
+            "an unbalanced quote in a comment must not swallow the rest of the file"
+        );
+    }
+
+    /// A lifetime is not a character literal; reading `'a` as an opening quote
+    /// would blank everything after it.
+    #[test]
+    fn lifetimes_do_not_open_a_character_literal() {
+        let source = "fn f<'a>(s: &'a str) {}\nlet real = autumn_web::app();\n";
+        assert!(
+            for_each_code_line(source, |line, _| line
+                .contains("autumn_web::app()")
+                .then_some(()))
+            .is_some()
+        );
+    }
+
+    #[test]
+    fn character_literals_are_still_masked() {
+        let source = "let q = '\"'; let real = autumn_web::app();\n";
+        assert!(
+            for_each_code_line(source, |line, _| line
+                .contains("autumn_web::app()")
+                .then_some(()))
+            .is_some(),
+            "a quote inside a char literal must not open a string"
+        );
+    }
 
     /// The offset handed to the callback must point at the line the callback
     /// actually saw — recovering it afterwards with `find` would land on an
@@ -89,38 +398,13 @@ mod tests {
     }
 
     #[test]
-    fn line_comments_are_skipped() {
-        for source in [
-            "// let x = 1;\n",
-            "/// let x = 1;\n",
-            "//! let x = 1;\n",
-            "   // let x = 1;\n",
-        ] {
-            assert!(
-                for_each_code_line(source, |line, _| line.contains("let x").then_some(()))
-                    .is_none(),
-                "{source:?}"
-            );
-        }
-    }
-
-    #[test]
-    fn block_comments_are_skipped_across_lines() {
-        let source = "/*\nlet x = 1;\n*/\nlet y = 2;\n";
-        assert!(
-            for_each_code_line(source, |line, _| line.contains("let x").then_some(())).is_none()
-        );
-        assert!(
-            for_each_code_line(source, |line, _| line.contains("let y").then_some(())).is_some()
-        );
-    }
-
-    #[test]
-    fn a_one_line_block_comment_does_not_open_a_block() {
-        let source = "/* noise */\nlet y = 2;\n";
-        assert!(
-            for_each_code_line(source, |line, _| line.contains("let y").then_some(())).is_some()
-        );
+    fn every_line_is_reported_with_a_stable_offset() {
+        let source = "a\nbb\nccc\n";
+        let lines = code_lines(source);
+        assert_eq!(lines.len(), 3);
+        assert_eq!(lines[0].1, 0);
+        assert_eq!(lines[1].1, 2);
+        assert_eq!(lines[2].1, 5);
     }
 
     #[test]

--- a/autumn-cli/src/rust_source.rs
+++ b/autumn-cli/src/rust_source.rs
@@ -226,6 +226,33 @@ fn is_char_literal(bytes: &[u8], i: usize) -> bool {
     }
 }
 
+/// The index of the `)` that closes the `(` at `open`, or `None` if the
+/// source ends first.
+///
+/// Only meaningful on a masked source: a paren inside a string or comment
+/// would otherwise unbalance the count.
+#[must_use]
+pub fn balanced_close_paren(masked: &str, open: usize) -> Option<usize> {
+    let bytes = masked.as_bytes();
+    if bytes.get(open) != Some(&b'(') {
+        return None;
+    }
+    let mut depth = 0usize;
+    for (offset, byte) in bytes.iter().enumerate().skip(open) {
+        match byte {
+            b'(' => depth += 1,
+            b')' => {
+                depth -= 1;
+                if depth == 0 {
+                    return Some(offset);
+                }
+            }
+            _ => {}
+        }
+    }
+    None
+}
+
 /// Every line of `source` with comments and string contents blanked, paired
 /// with its byte offset in the **original** source.
 ///
@@ -259,9 +286,31 @@ pub fn for_each_code_line<T>(
         .find_map(|(line, offset)| f(&line, offset))
 }
 
+/// Whether `line` declares `async fn main` — the entry point, not a helper
+/// whose name merely starts with it (`async fn main_loop`).
+#[must_use]
+pub fn declares_async_main(line: &str) -> bool {
+    const NEEDLE: &str = "async fn main";
+    let mut rest = line;
+    while let Some(at) = rest.find(NEEDLE) {
+        let after = &rest[at + NEEDLE.len()..];
+        if after
+            .chars()
+            .next()
+            .is_none_or(|c| !c.is_alphanumeric() && c != '_')
+        {
+            return true;
+        }
+        rest = after;
+    }
+    false
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{code_lines, for_each_code_line, mask_non_code};
+    use super::{
+        balanced_close_paren, code_lines, declares_async_main, for_each_code_line, mask_non_code,
+    };
 
     /// The mask must be a byte-for-byte overlay: offsets computed on it index
     /// the original exactly.
@@ -405,6 +454,23 @@ mod tests {
         assert_eq!(lines[0].1, 0);
         assert_eq!(lines[1].1, 2);
         assert_eq!(lines[2].1, 5);
+    }
+
+    #[test]
+    fn a_helper_whose_name_starts_with_main_is_not_the_entry_point() {
+        assert!(declares_async_main("async fn main() {"));
+        assert!(declares_async_main("pub async fn main() {"));
+        assert!(!declares_async_main("async fn main_loop() {"));
+        assert!(!declares_async_main("async fn mainly() {"));
+        assert!(!declares_async_main("fn main() {"));
+    }
+
+    #[test]
+    fn balanced_close_paren_spans_nested_calls() {
+        let src = "f(a, g(b, c), d) tail";
+        assert_eq!(balanced_close_paren(src, 1), Some(15));
+        assert_eq!(balanced_close_paren(src, 0), None, "index 0 is not a paren");
+        assert_eq!(balanced_close_paren("f(a", 1), None, "unterminated");
     }
 
     #[test]

--- a/autumn-cli/src/rust_source.rs
+++ b/autumn-cli/src/rust_source.rs
@@ -73,7 +73,7 @@ pub fn mask_non_code(source: &str) -> String {
 }
 
 /// Blank one byte unless it is the newline that keeps lines aligned.
-fn blank(out: &mut [u8], at: usize) {
+const fn blank(out: &mut [u8], at: usize) {
     if out[at] != b'\n' {
         out[at] = b' ';
     }
@@ -112,7 +112,7 @@ fn step_code(bytes: &[u8], i: usize, out: &mut [u8]) -> (Scan, usize) {
 }
 
 /// One step inside a `//` comment: it ends at the newline.
-fn step_line_comment(bytes: &[u8], i: usize, out: &mut [u8]) -> (Scan, usize) {
+const fn step_line_comment(bytes: &[u8], i: usize, out: &mut [u8]) -> (Scan, usize) {
     if bytes[i] == b'\n' {
         (Scan::Code, 1)
     } else {

--- a/autumn-cli/src/rust_source.rs
+++ b/autumn-cli/src/rust_source.rs
@@ -1,0 +1,124 @@
+//! Comment-aware scanning of user-owned Rust source.
+//!
+//! Commands that edit an application's `src/main.rs` — `autumn generate pwa`,
+//! `autumn plugin add` — must never splice code into a comment. Autumn's own
+//! documentation ships quick-start snippets containing the exact lines those
+//! commands anchor on (`autumn_web::app()`, `autumn_web::push::router()`), so a
+//! `main.rs` that pasted one into a doc comment would otherwise be edited
+//! *inside* the comment: a file that does not compile, and a mount that never
+//! happened.
+//!
+//! One scanner, shared, so an anchor scan and its "is it already there?"
+//! companion can never disagree about what a comment is.
+
+/// Walk `source`'s lines that are **code**, skipping comments, and return the
+/// first non-`None` result of `f`.
+///
+/// `f` receives the raw line and its byte offset in `source`. The offset is
+/// tracked as the walk proceeds rather than recovered afterwards with
+/// `source.find(line)`, which would re-locate an identical earlier line and
+/// splice at the wrong place.
+///
+/// Every caller that edits a user-owned `main.rs` shares this one scanner so
+/// they can never disagree about what counts as a comment — a disagreement
+/// there is exactly what lets a doc-comment mention both suppress an edit and
+/// suppress the warning about it. Callers today: `autumn generate pwa`'s push-
+/// router injection and `autumn plugin add`'s builder-chain scan.
+pub fn for_each_code_line<T>(
+    source: &str,
+    mut f: impl FnMut(&str, usize) -> Option<T>,
+) -> Option<T> {
+    let mut offset = 0_usize;
+    let mut in_block_comment = false;
+
+    for line in source.split_inclusive('\n') {
+        let trimmed = line.trim();
+        let line_start = offset;
+        offset += line.len();
+
+        if in_block_comment {
+            if trimmed.contains("*/") {
+                in_block_comment = false;
+            }
+            continue;
+        }
+        if trimmed.starts_with("/*") {
+            if !trimmed.contains("*/") {
+                in_block_comment = true;
+            }
+            continue;
+        }
+        // `//`, `///`, `//!`, and continuation lines of a block comment.
+        if trimmed.starts_with("//") || trimmed.starts_with('*') {
+            continue;
+        }
+
+        if let Some(found) = f(line, line_start) {
+            return Some(found);
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::for_each_code_line;
+
+    /// The offset handed to the callback must point at the line the callback
+    /// actually saw — recovering it afterwards with `find` would land on an
+    /// identical earlier line and splice at the wrong place.
+    #[test]
+    fn the_offset_locates_the_matching_line() {
+        let source = "let x = 1;\nlet x = 1;\nlet y = 2;\n";
+        let offset = for_each_code_line(source, |line, offset| {
+            line.contains("y = 2").then_some(offset)
+        })
+        .expect("found");
+        assert_eq!(&source[offset..offset + 9], "let y = 2");
+    }
+
+    #[test]
+    fn line_comments_are_skipped() {
+        for source in [
+            "// let x = 1;\n",
+            "/// let x = 1;\n",
+            "//! let x = 1;\n",
+            "   // let x = 1;\n",
+        ] {
+            assert!(
+                for_each_code_line(source, |line, _| line.contains("let x").then_some(()))
+                    .is_none(),
+                "{source:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn block_comments_are_skipped_across_lines() {
+        let source = "/*\nlet x = 1;\n*/\nlet y = 2;\n";
+        assert!(
+            for_each_code_line(source, |line, _| line.contains("let x").then_some(())).is_none()
+        );
+        assert!(
+            for_each_code_line(source, |line, _| line.contains("let y").then_some(())).is_some()
+        );
+    }
+
+    #[test]
+    fn a_one_line_block_comment_does_not_open_a_block() {
+        let source = "/* noise */\nlet y = 2;\n";
+        assert!(
+            for_each_code_line(source, |line, _| line.contains("let y").then_some(())).is_some()
+        );
+    }
+
+    #[test]
+    fn the_first_match_wins() {
+        let source = "let a = 1;\nlet a = 2;\n";
+        let offset = for_each_code_line(source, |line, offset| {
+            line.contains("let a").then_some(offset)
+        })
+        .expect("found");
+        assert_eq!(offset, 0);
+    }
+}

--- a/autumn-cli/tests/generate.rs
+++ b/autumn-cli/tests/generate.rs
@@ -8676,3 +8676,237 @@ fn controller_api_generates_json() {
         );
     }
 }
+
+// ── `autumn plugin add` / `autumn plugin list` (issue #1606) ────────────────
+
+/// Every first-party plugin the install catalog ships, in `plugin list` order.
+const FIRST_PARTY_PLUGINS: [&str; 5] = [
+    "autumn-admin-plugin",
+    "autumn-cache-redis",
+    "autumn-media-plugin",
+    "autumn-search",
+    "autumn-storage-s3",
+];
+
+/// Repoint every first-party plugin crate — and `autumn-web` itself — at this
+/// workspace, so a generated project resolves the versions under test rather
+/// than whatever is published on crates.io.
+fn patch_generated_cargo_toml_for_plugins(project_dir: &Path) {
+    let cargo_toml_path = project_dir.join("Cargo.toml");
+    let mut content = fs::read_to_string(&cargo_toml_path).unwrap();
+    let workspace_root = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("workspace root");
+    content.push_str("\n[patch.crates-io]\n");
+    for crate_name in std::iter::once("autumn-web").chain(FIRST_PARTY_PLUGINS) {
+        // `autumn-web` lives in `autumn/`; the plugin crates are named after
+        // their own directories.
+        let dir = if crate_name == "autumn-web" {
+            "autumn"
+        } else {
+            crate_name
+        };
+        writeln!(
+            content,
+            "{crate_name} = {{ path = \"{}\" }}",
+            workspace_root
+                .join(dir)
+                .display()
+                .to_string()
+                .replace('\\', "/")
+        )
+        .unwrap();
+    }
+    fs::write(&cargo_toml_path, content).unwrap();
+}
+
+/// AC #1: the listing names every first-party plugin, with a description and
+/// the version compatible with the app's `autumn-web`.
+#[test]
+fn plugin_list_shows_every_first_party_plugin() {
+    let (_tmp, project) = fresh_project("plugin-list");
+    let (stdout, _) = run_autumn(&project, &["plugin", "list", "--offline"]);
+    for plugin in FIRST_PARTY_PLUGINS {
+        assert!(stdout.contains(plugin), "{plugin} missing from:\n{stdout}");
+    }
+    assert!(stdout.contains(env!("CARGO_PKG_VERSION")), "{stdout}");
+    assert!(stdout.contains("autumn plugin add"), "{stdout}");
+}
+
+/// The same listing, machine-readable.
+#[test]
+fn plugin_list_json_is_parseable() {
+    let (_tmp, project) = fresh_project("plugin-list-json");
+    let (stdout, _) = run_autumn(&project, &["plugin", "list", "--json", "--offline"]);
+    let value: serde_json::Value = serde_json::from_str(&stdout).expect("valid JSON");
+    let plugins = value["plugins"].as_array().expect("plugins array");
+    for plugin in FIRST_PARTY_PLUGINS {
+        assert!(
+            plugins.iter().any(|p| p["name"] == plugin),
+            "{plugin} missing from {stdout}"
+        );
+    }
+}
+
+/// AC #2 (edits) + AC #4 (idempotency), without paying for a compile.
+#[test]
+fn plugin_add_writes_the_dependency_and_the_mount_then_is_idempotent() {
+    let (_tmp, project) = fresh_project("plugin-add");
+    let (stdout, _) = run_autumn(
+        &project,
+        &["plugin", "add", "autumn-admin-plugin", "--offline"],
+    );
+    assert!(stdout.contains("Installed autumn-admin-plugin"), "{stdout}");
+    assert!(stdout.contains("autumn generate admin"), "{stdout}");
+
+    let cargo = fs::read_to_string(project.join("Cargo.toml")).unwrap();
+    assert!(cargo.contains("autumn-admin-plugin ="), "{cargo}");
+    let main_rs = fs::read_to_string(project.join("src/main.rs")).unwrap();
+    assert!(
+        main_rs.contains(".plugin(autumn_admin_plugin::AdminPlugin::new())"),
+        "{main_rs}"
+    );
+
+    let (stdout, _) = run_autumn(
+        &project,
+        &["plugin", "add", "autumn-admin-plugin", "--offline"],
+    );
+    assert!(stdout.contains("already installed"), "{stdout}");
+    assert_eq!(
+        fs::read_to_string(project.join("Cargo.toml")).unwrap(),
+        cargo
+    );
+    assert_eq!(
+        fs::read_to_string(project.join("src/main.rs")).unwrap(),
+        main_rs
+    );
+}
+
+/// AC #2: `--dry-run` reports the same edits without applying any of them.
+#[test]
+fn plugin_add_dry_run_changes_nothing() {
+    let (_tmp, project) = fresh_project("plugin-add-dry");
+    let cargo_before = fs::read_to_string(project.join("Cargo.toml")).unwrap();
+    let main_before = fs::read_to_string(project.join("src/main.rs")).unwrap();
+    run_autumn(
+        &project,
+        &[
+            "plugin",
+            "add",
+            "autumn-cache-redis",
+            "--dry-run",
+            "--offline",
+        ],
+    );
+    assert_eq!(
+        fs::read_to_string(project.join("Cargo.toml")).unwrap(),
+        cargo_before
+    );
+    assert_eq!(
+        fs::read_to_string(project.join("src/main.rs")).unwrap(),
+        main_before
+    );
+}
+
+/// AC #3: an incompatible `autumn-web` fails before any file is modified, and
+/// the diagnostic names both versions.
+#[test]
+fn plugin_add_refuses_an_incompatible_autumn_web_without_editing() {
+    let (_tmp, project) = fresh_project("plugin-add-incompat");
+    let cargo_path = project.join("Cargo.toml");
+    let cargo = fs::read_to_string(&cargo_path).unwrap().replace(
+        &format!("autumn-web = \"{}\"", env!("CARGO_PKG_VERSION")),
+        "autumn-web = \"0.1.0\"",
+    );
+    fs::write(&cargo_path, &cargo).unwrap();
+    let main_before = fs::read_to_string(project.join("src/main.rs")).unwrap();
+
+    let (_stdout, stderr, code) = run_autumn_failing(
+        &project,
+        &["plugin", "add", "autumn-admin-plugin", "--offline"],
+    );
+    assert_eq!(code, Some(1), "{stderr}");
+    assert!(stderr.contains("0.1.0"), "{stderr}");
+    assert!(stderr.contains(env!("CARGO_PKG_VERSION")), "{stderr}");
+
+    assert_eq!(fs::read_to_string(&cargo_path).unwrap(), cargo);
+    assert_eq!(
+        fs::read_to_string(project.join("src/main.rs")).unwrap(),
+        main_before
+    );
+}
+
+/// AC #5: a `main.rs` whose builder chain cannot be found is left completely
+/// alone, and the command prints what to apply by hand.
+#[test]
+fn plugin_add_degrades_on_a_customized_main() {
+    let (_tmp, project) = fresh_project("plugin-add-custom");
+    let main_path = project.join("src/main.rs");
+    let custom = "#[autumn_web::main]\nasync fn main() {\n    my_bootstrap().await;\n}\n";
+    fs::write(&main_path, custom).unwrap();
+    let cargo_before = fs::read_to_string(project.join("Cargo.toml")).unwrap();
+
+    let (stdout, _) = run_autumn(
+        &project,
+        &["plugin", "add", "autumn-admin-plugin", "--offline"],
+    );
+    assert!(stdout.contains("No files were changed"), "{stdout}");
+    assert!(stdout.contains("autumn-admin-plugin = \""), "{stdout}");
+    assert!(stdout.contains("AdminPlugin::new()"), "{stdout}");
+
+    assert_eq!(fs::read_to_string(&main_path).unwrap(), custom);
+    assert_eq!(
+        fs::read_to_string(project.join("Cargo.toml")).unwrap(),
+        cargo_before
+    );
+}
+
+/// An unknown name is refused with a pointer at `plugin list`.
+#[test]
+fn plugin_add_rejects_an_unknown_crate() {
+    let (_tmp, project) = fresh_project("plugin-add-unknown");
+    let (_stdout, stderr, code) =
+        run_autumn_failing(&project, &["plugin", "add", "tokio", "--offline"]);
+    assert_eq!(code, Some(1), "{stderr}");
+    assert!(stderr.contains("autumn plugin list"), "{stderr}");
+}
+
+/// The Success Metric for issue #1606: `autumn plugin add` for **every**
+/// first-party plugin against a fresh `autumn new` scaffold, each of which
+/// must then `cargo check` green — the machine proof that the generated mount
+/// compiles on the first try.
+///
+/// Ignored by default (it compiles five generated projects); run in CI by the
+/// `plugin-install` job in `.github/workflows/generator-conformance.yml`. The
+/// five projects share one `CARGO_TARGET_DIR` so the framework is built once
+/// rather than five times.
+#[test]
+#[ignore = "compiles generated projects against the local workspace (slow)"]
+fn plugin_add_first_party_scaffolds_cargo_check() {
+    let shared_target = tempfile::tempdir().expect("shared target dir");
+    for plugin in FIRST_PARTY_PLUGINS {
+        let (_tmp, project) = fresh_project(&plugin.replace('-', "_"));
+        patch_generated_cargo_toml_for_plugins(&project);
+
+        let (stdout, _) = run_autumn(&project, &["plugin", "add", plugin, "--offline"]);
+        assert!(stdout.contains(&format!("Installed {plugin}")), "{stdout}");
+
+        // Re-running must be a no-op, so the compile below is of a
+        // singly-installed project (AC #4).
+        let (stdout, _) = run_autumn(&project, &["plugin", "add", plugin, "--offline"]);
+        assert!(stdout.contains("already installed"), "{stdout}");
+
+        let check = Command::new("cargo")
+            .args(["check", "--all-targets"])
+            .current_dir(&project)
+            .env("CARGO_TARGET_DIR", shared_target.path())
+            .output()
+            .expect("failed to run cargo check");
+        assert!(
+            check.status.success(),
+            "`autumn plugin add {plugin}` produced a project that does not compile:\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&check.stdout),
+            String::from_utf8_lossy(&check.stderr),
+        );
+    }
+}

--- a/autumn-cli/tests/generate.rs
+++ b/autumn-cli/tests/generate.rs
@@ -8846,19 +8846,43 @@ fn plugin_add_degrades_on_a_customized_main() {
     fs::write(&main_path, custom).unwrap();
     let cargo_before = fs::read_to_string(project.join("Cargo.toml")).unwrap();
 
-    let (stdout, _) = run_autumn(
+    // A refusal, not a result: it goes to stderr and exits 2 so a script
+    // cannot read "I changed nothing" as a successful install.
+    let (_stdout, stderr, code) = run_autumn_failing(
         &project,
         &["plugin", "add", "autumn-admin-plugin", "--offline"],
     );
-    assert!(stdout.contains("No files were changed"), "{stdout}");
-    assert!(stdout.contains("autumn-admin-plugin = \""), "{stdout}");
-    assert!(stdout.contains("AdminPlugin::new()"), "{stdout}");
+    assert_eq!(code, Some(2), "{stderr}");
+    assert!(stderr.contains("No files were changed"), "{stderr}");
+    assert!(stderr.contains("autumn-admin-plugin = \""), "{stderr}");
+    assert!(stderr.contains("AdminPlugin::new()"), "{stderr}");
 
     assert_eq!(fs::read_to_string(&main_path).unwrap(), custom);
     assert_eq!(
         fs::read_to_string(project.join("Cargo.toml")).unwrap(),
         cargo_before
     );
+}
+
+/// AC #5, the shape that used to slip through: a `main.rs` that factors its
+/// builder into a helper. Splicing there mounts the plugin into a function the
+/// binary never calls — and for `autumn-storage-s3`, whose mount awaits, into a
+/// synchronous fn, which does not compile.
+#[test]
+fn plugin_add_degrades_when_the_builder_lives_in_a_helper() {
+    let (_tmp, project) = fresh_project("plugin-add-helper");
+    let main_path = project.join("src/main.rs");
+    let custom = "#[autumn_web::main]\nasync fn main() {\n    build_app().run().await;\n}\n\n\
+                  fn build_app() -> autumn_web::app::AppBuilder {\n    autumn_web::app()\n        \
+                  .routes(routes![index])\n}\n";
+    fs::write(&main_path, custom).unwrap();
+
+    let (_stdout, stderr, code) = run_autumn_failing(
+        &project,
+        &["plugin", "add", "autumn-storage-s3", "--offline"],
+    );
+    assert_eq!(code, Some(2), "{stderr}");
+    assert_eq!(fs::read_to_string(&main_path).unwrap(), custom);
 }
 
 /// An unknown name is refused with a pointer at `plugin list`.

--- a/autumn-media-plugin/README.md
+++ b/autumn-media-plugin/README.md
@@ -11,6 +11,21 @@ It packages the two primitives an interactive streaming product needs:
 
 ## Installation
 
+```bash
+autumn plugin add autumn-media-plugin
+```
+
+One command adds the dependency at a version compatible with your app's
+`autumn-web`, mounts the plugin in your `autumn_web::app()` builder chain, and
+prints any configuration still needed. It is safe to re-run, and it refuses —
+before touching any file — to install into an app on an incompatible
+`autumn-web` version. See [docs/plugins.md](../docs/plugins.md#installing-a-plugin).
+
+### Manual install
+
+If you would rather wire it yourself (or `autumn plugin add` could not find your
+builder chain and printed these lines for you):
+
 ```toml
 [dependencies]
 autumn-web = "0.7"

--- a/autumn-media-plugin/README.md
+++ b/autumn-media-plugin/README.md
@@ -19,7 +19,7 @@ One command adds the dependency at a version compatible with your app's
 `autumn-web`, mounts the plugin in your `autumn_web::app()` builder chain, and
 prints any configuration still needed. It is safe to re-run, and it refuses —
 before touching any file — to install into an app on an incompatible
-`autumn-web` version. See [docs/plugins.md](../docs/plugins.md#installing-a-plugin).
+`autumn-web` version. See [docs/plugins.md](https://github.com/autumn-foundation/autumn/blob/main/docs/plugins.md#installing-a-plugin).
 
 ### Manual install
 

--- a/autumn-search/README.md
+++ b/autumn-search/README.md
@@ -19,9 +19,12 @@ One command adds the dependency at a version compatible with your app's
 and prints the follow-up steps (mark a model `#[searchable]`, register the
 index, backfill). It is safe to re-run, and it refuses — before touching any
 file — to install into an app on an incompatible `autumn-web` version. See
-[docs/plugins.md](../docs/plugins.md#installing-a-plugin).
+[docs/plugins.md](https://github.com/autumn-foundation/autumn/blob/main/docs/plugins.md#installing-a-plugin).
 
 ### Manual install
+
+If you would rather wire it yourself (or `autumn plugin add` could not find your
+builder chain and printed these lines for you):
 
 ```toml
 [dependencies]

--- a/autumn-search/README.md
+++ b/autumn-search/README.md
@@ -8,6 +8,27 @@ one engine-agnostic API.
 The autumn-shaped answer to Laravel Scout, with vectors first-class rather than
 bolted on.
 
+## Installation
+
+```bash
+autumn plugin add autumn-search
+```
+
+One command adds the dependency at a version compatible with your app's
+`autumn-web`, mounts `SearchPlugin` in your `autumn_web::app()` builder chain,
+and prints the follow-up steps (mark a model `#[searchable]`, register the
+index, backfill). It is safe to re-run, and it refuses — before touching any
+file — to install into an app on an incompatible `autumn-web` version. See
+[docs/plugins.md](../docs/plugins.md#installing-a-plugin).
+
+### Manual install
+
+```toml
+[dependencies]
+autumn-web = "0.7"
+autumn-search = "0.7"
+```
+
 ## What you write
 
 ```rust

--- a/autumn-storage-s3/README.md
+++ b/autumn-storage-s3/README.md
@@ -7,6 +7,21 @@ by any S3-compatible object storage service (AWS S3, MinIO, Tigris, Cloudflare R
 
 ## Installation
 
+```bash
+autumn plugin add autumn-storage-s3
+```
+
+One command adds the dependency at a version compatible with your app's
+`autumn-web`, mounts the plugin in your `autumn_web::app()` builder chain, and
+prints any configuration still needed. It is safe to re-run, and it refuses —
+before touching any file — to install into an app on an incompatible
+`autumn-web` version. See [docs/plugins.md](../docs/plugins.md#installing-a-plugin).
+
+### Manual install
+
+If you would rather wire it yourself (or `autumn plugin add` could not find your
+builder chain and printed these lines for you):
+
 ```toml
 [dependencies]
 autumn-web        = { version = "0.4", features = ["storage"] }

--- a/autumn-storage-s3/README.md
+++ b/autumn-storage-s3/README.md
@@ -12,10 +12,11 @@ autumn plugin add autumn-storage-s3
 ```
 
 One command adds the dependency at a version compatible with your app's
-`autumn-web`, mounts the plugin in your `autumn_web::app()` builder chain, and
+`autumn-web`, wires the S3 blob store into your `autumn_web::app()` builder chain
+with `.with_blob_store(...)`, and
 prints any configuration still needed. It is safe to re-run, and it refuses —
 before touching any file — to install into an app on an incompatible
-`autumn-web` version. See [docs/plugins.md](../docs/plugins.md#installing-a-plugin).
+`autumn-web` version. See [docs/plugins.md](https://github.com/autumn-foundation/autumn/blob/main/docs/plugins.md#installing-a-plugin).
 
 ### Manual install
 
@@ -24,8 +25,8 @@ builder chain and printed these lines for you):
 
 ```toml
 [dependencies]
-autumn-web        = { version = "0.4", features = ["storage"] }
-autumn-storage-s3 = "0.4"
+autumn-web        = { version = "0.7", features = ["storage"] }
+autumn-storage-s3 = "0.7"
 ```
 
 ## Quick Start

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -27,6 +27,57 @@ autumn_web::app()
     .await;
 ```
 
+## Installing a plugin
+
+One command adds the dependency, mounts the plugin in your `autumn_web::app()`
+builder chain, and prints whatever configuration the plugin still needs:
+
+```bash
+autumn plugin list                      # what can I install, at what version?
+autumn plugin add autumn-admin-plugin   # dependency + mount + next steps
+```
+
+`autumn plugin list` shows every first-party plugin with the version compatible
+with your app's `autumn-web`, plus community crates it finds on crates.io under
+the `autumn-plugin-` naming convention below. Add `--json` for machine-readable
+output, or `--offline` to skip the crates.io lookup.
+
+`autumn plugin add` is safe to re-run: a second `add` of the same plugin
+reports that it is already installed and changes nothing. It refuses — before
+touching any file — to install a plugin whose supported `autumn-web` range
+excludes your app's version, naming both versions. Pass `--dry-run` to see the
+edits without applying them.
+
+### Community plugins
+
+A crate following the third-party `autumn-plugin-<name>` convention gets its
+dependency written for you, but **not** its mount: nothing outside that crate
+can verify it really exposes `<Name>Plugin`, and a wrong guess would leave your
+app not compiling. The command prints the convention-derived
+`.plugin(...)` line to paste into your builder chain — check the crate's README
+first.
+
+### The manual path
+
+`autumn plugin add` never leaves an app in a non-compiling state. If it cannot
+find your `autumn_web::app()` builder chain — a heavily customized `main.rs`, or
+a one-line chain with nowhere to splice a call — it changes **nothing** and
+prints the exact dependency line and mount snippet to apply by hand instead.
+That is also the path to follow when you would rather wire a plugin yourself:
+
+```toml
+# Cargo.toml
+[dependencies]
+autumn-admin-plugin = "0.7.0"
+```
+
+```rust,ignore
+autumn_web::app()
+    .plugin(autumn_admin_plugin::AdminPlugin::new())
+    .run()
+    .await;
+```
+
 ## First-party plugin crates
 
 | Crate | What it adds | Guide |

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -48,6 +48,25 @@ touching any file — to install a plugin whose supported `autumn-web` range
 excludes your app's version, naming both versions. Pass `--dry-run` to see the
 edits without applying them.
 
+### Versions
+
+First-party plugins are released in lockstep with `autumn-web` and with the
+CLI, so the version `autumn plugin add` installs is the CLI's own. That makes
+the version gate a statement about your toolchain: if your app is on an older
+`autumn-web`, the listing marks each first-party plugin `[needs autumn-web
+<series>]` and `add` refuses rather than writing a dependency that will not
+resolve. Install the matching CLI for that series
+(`cargo install autumn-cli --version <series>`), or bring the app forward with
+`autumn upgrade`.
+
+The command does **not** add feature flags to your `autumn-web` dependency.
+Each plugin crate already depends on `autumn-web` with the features it needs
+(`autumn-storage-s3` on `storage`, `autumn-cache-redis` on `redis`,
+`autumn-admin-plugin` on `db`/`maud`/`htmx`/`flash`/`multipart`), and Cargo
+unifies features across the graph — so the mount compiles without touching your
+manifest beyond the one dependency line. The manual path below spells the
+features out because a hand-written install may want them stated explicitly.
+
 ### Community plugins
 
 A crate following the third-party `autumn-plugin-<name>` convention gets its

--- a/skills/autumn-web/SKILL.md
+++ b/skills/autumn-web/SKILL.md
@@ -1421,6 +1421,49 @@ that already gates migrations, `#[scheduled]` leader election, and ISR.
 See `docs/guide/distributed-locks.md` and
 `docs/adr/0010-app-facing-distributed-lock.md`.
 
+## Installing a plugin — `autumn plugin add` (unreleased, issue #1606)
+
+**Reach for this instead of hand-editing `Cargo.toml` and the builder chain.**
+One command adds the dependency at a version compatible with the app's
+`autumn-web`, mounts the plugin in the `autumn_web::app()` chain, and prints
+the post-install steps (config keys, follow-up generators):
+
+```bash
+autumn plugin list                      # name, description, compatible version
+autumn plugin list --json --offline     # machine-readable; skip the crates.io lookup
+autumn plugin add autumn-admin-plugin   # dependency + mount + next steps
+autumn plugin add autumn-cache-redis --dry-run
+```
+
+`list` covers the five first-party crates (`autumn-admin-plugin`,
+`autumn-cache-redis`, `autumn-media-plugin`, `autumn-search`,
+`autumn-storage-s3`) plus community crates found on crates.io under the
+documented `autumn-plugin-<name>` convention.
+
+Four behaviours worth knowing before advising on it:
+
+- **Idempotent.** A second `add` reports "already installed" and changes
+  nothing. It also detects a mount written by hand behind a `use` import, so
+  it will not splice a second, default-constructed mount over a configured one.
+- **Version-gated before any write.** Installing into an app on an
+  incompatible `autumn-web` fails naming both versions, with the app
+  byte-identical. First-party plugins ship in lockstep with `autumn-web` and
+  the CLI, so the version installed is the CLI's — an app on an older line
+  needs the matching CLI, or `autumn upgrade`.
+- **It degrades rather than guessing.** If the `autumn_web::app()` chain
+  cannot be found unambiguously inside `async fn main` — a builder factored
+  into a helper, a one-line chain, two candidate lines — it writes *nothing*
+  and prints the dependency line and mount snippet on stderr, exiting 2. It
+  never leaves an app that does not compile.
+- **Community crates get the dependency only.** The `<Name>Plugin` mount is
+  derived from the naming convention and printed, not spliced: nothing outside
+  that crate can verify it exposes one.
+
+It writes no `features = [...]` onto the app's `autumn-web` dependency — each
+plugin crate already carries the features its mount needs and Cargo unifies
+them. `autumn plugin-check` is the separate, author-facing conformance gate;
+`autumn generate plugin` scaffolds a new plugin crate.
+
 ## File storage and cache plugins
 
 For local or pluggable file storage:
@@ -2174,6 +2217,8 @@ autumn canary promote
 autumn webhook sim generic http://localhost:3000/webhooks/test --secret mysecret --payload '{"ok":true}'
 autumn dev-loop-bench --dry-run
 autumn plugin-check --plugin-name autumn-admin-plugin --prefix /admin
+autumn plugin list
+autumn plugin add autumn-admin-plugin
 ```
 
 **(0.6.0)** CLI additions — absent from a 0.5.x `autumn-cli`, but present in
@@ -2215,6 +2260,8 @@ autumn deploy up --only web-2 --no-rollback   # narrow to a subset (repair lever
 autumn deploy rollback           # previous release; with `[deploy] hosts` the whole fleet, newest first (`--only <HOST>` for one)
 autumn deploy status --json --strict          # read-only per-host state + version/state drift; --strict exits non-zero on drift (#1621)
 autumn deploy maintenance on --message "…"    # maintenance mode on EVERY deploy host over SSH; `off` reverses (#1621)
+autumn plugin list               # installable plugins + the version compatible with this app's autumn-web; --json, --offline (#1606)
+autumn plugin add autumn-admin-plugin   # dependency + builder-chain mount + post-install steps; idempotent, version-gated, --dry-run (#1606)
 autumn data-flow                 # classified-data flow manifest: one row per `#[classified]` column and every sink a declared declassification boundary releases it to; empty reachable set = the column cannot leave the process (#1654)
 autumn data-flow --manifest data-flow-manifest.json --check data-flow-manifest.json   # write it, and fail on drift from the committed copy so a new release edge is reviewed
 autumn data-flow --release --check data-flow-manifest.json   # audit the profile you deploy: a boundary behind `#[cfg(not(debug_assertions))]` exists only in the release build, so a debug-built manifest would certify edges the shipped binary does not have (and miss the ones it does)

--- a/skills/autumn-web/references/api-reference.md
+++ b/skills/autumn-web/references/api-reference.md
@@ -1063,7 +1063,7 @@ double-submits and replays.
 | `mail_previews(...)` | Dev mail previews |
 | `with_audit_sink(sink)` | Structured audit sink |
 | `policy::<R, P>(policy)`, `scope::<R, S>(scope)` | Repository authorization |
-| `plugin(plugin)`, `plugins(tuple)` | Plugin install |
+| `plugin(plugin)`, `plugins(tuple)` | Plugin install (`autumn plugin add <crate>` writes the call for first-party plugins, #1606) |
 | `listeners(listeners![...])` | Event listeners (**0.6.0**) |
 | `static_gate(layer)`, `has_static_gate::<L>()`, `get_static_gate_types()` | Static pre-render gating middleware (**0.6.0**) |
 | `with_shard_router(router)` | Sharding router (**0.6.0**) |


### PR DESCRIPTION
Closes #1606.

## The problem

Autumn has a real plugin seam — the `Plugin` trait, five first-party plugin crates, a crates.io naming convention, an author-facing `autumn plugin-check` — and no consumer-facing tooling at all. Using a shipped capability meant finding the crate, hand-editing `Cargo.toml`, hand-writing the `.plugin(...)` mount, and reading config docs. Four places to pick an incompatible version or misconfigure the mount.

## What this adds

```bash
autumn plugin list                      # what can I install, at what version?
autumn plugin add autumn-admin-plugin   # dependency + mount + next steps
```

`plugin list` shows every installable plugin with a one-line description and the version compatible with the app's `autumn-web` — the five first-party crates, plus community crates found on crates.io through the documented `autumn-plugin-<name>` convention. `--json` for machine-readable output, `--offline` to skip the lookup.

`plugin add <name>` performs the whole install: the dependency at a compatible version, the mount spliced into the `autumn_web::app()` builder chain, and the post-install steps printed (config keys, follow-up generators like `autumn generate admin`). `--dry-run` shows the edits without applying them.

## Every refusal is total, never partial

- **Version gate runs before a single filesystem action exists**, so installing a plugin whose supported `autumn-web` range excludes the app fails naming both versions with the app byte-identical. It resolves `{ workspace = true }` by walking up, so a workspace member is gated too, and treats range requirements (`>=0.6`) as unknown rather than misreading them as exact versions.
- **Idempotent**: a second `add` reports "already installed" and changes nothing. Mount detection accepts both the qualified path this command writes and the bare call a hand-written mount uses after a `use` import — so `add` never splices a second, default-constructed mount over a user's configured one, and never mistakes a bare import for a mount.
- **Safe degradation**: when the builder chain cannot be edited confidently the command writes *nothing* and prints the exact dependency line and mount snippet to apply by hand, on stderr with exit 2 so a script cannot read it as success. The anchor is scoped to `main`'s own body and refuses on ambiguity, so a builder factored into a helper, a `#[cfg(test)]` harness, or a quick-start snippet inside a raw string all degrade rather than getting mis-spliced.
- **Community crates** get their dependency written but never an automatic mount: the `<Name>Plugin` is derived from the convention and printed, because nothing outside that crate can verify it.

## One mount mechanism, including S3

Four of the five plugins implement `Plugin` and mount with `.plugin(...)`. `autumn-storage-s3` exposes a `BlobStore`, not a `Plugin`, and `S3BlobStore::from_config` is `async` — but `.await` is legal inside a method-call argument in an `async fn`, so its mount is still one splice into the same chain: one anchor, one probe, one degradation path, no statement rewriting.

## Hardening

The crates.io path is a trust boundary — anyone can publish `autumn-plugin-<x>`. Descriptions have control characters neutralised before reaching a terminal (`ESC` is not Unicode whitespace, so collapsing whitespace left ANSI sequences intact); crate names must be legal crate names before being interpolated into a URL or written as a bare TOML key; the client caps redirects and reads bodies through a 4 MiB limit; and an implausible version is refused rather than written into `Cargo.toml`.

## Verification

- `plugin_add_first_party_scaffolds_cargo_check` — the issue's Success Metric — installs **every** first-party plugin into its own fresh `autumn new` scaffold, asserts the second `add` is a no-op, and requires a green `cargo check`. Run locally: green (285s). Wired into `generator-conformance.yml` as a new `plugin-install` job, triggered by the CLI plugin module, the shared source scanner, and every plugin crate.
- 73 unit tests + 9 e2e tests, built red-first.
- `cargo clippy -p autumn-cli --all-targets -- -D warnings` clean; `./scripts/pre-push-check.sh` green.

Reviewed from four angles before opening (correctness, AC compliance, repo conventions/UX, security); the second commit is the fixes.

## Scope

No file under `autumn/` is touched — the `Plugin` trait and runtime semantics are untouched, as the issue requires. No `plugin remove`, no registry, no `autumn new` flags. `autumn plugin-check` is preserved as a distinct command with a regression test. The comment-aware source scanner `generate/pwa.rs` used moves to `autumn-cli/src/rust_source.rs` and is now shared, so the anchor scan and the "already mounted?" check cannot disagree about what a comment is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014fBXU86FX8zKwqS8XZwKfC

---
_Generated by [Claude Code](https://claude.ai/code/session_014fBXU86FX8zKwqS8XZwKfC)_