### PR TITLE
⚡ Bolt: build form-field id suffixes without format! (instructions -13.39%, allocs -13.5%)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1256,6 +1256,45 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `form_render_alloc_gate.rs` for the full explanation and its updated
   ceiling.
 
+- **scaffolded form helpers build their `-field`/`-error` id suffix by direct
+  string concatenation instead of `format!`:** `text_input`, `password_input`,
+  `textarea_input`, `number_input`, `checkbox_input`, `date_input` each built
+  `let wrapper_id = format!("{field_html}-field");` and (when the field has an
+  error) `format!("{field_html}-error")` — a fixed two-part concatenation of
+  already-`&str` pieces, but routed through `format!`'s `Arguments`/
+  `fmt::Write` dispatch and an unsized `String::new()` that grows via
+  reallocation as the pieces land, rather than a single up-front
+  `String::with_capacity`. Profiling the committed
+  `autumn/benches/form_render.rs` workload showed `alloc::fmt::format::format_inner`
+  and `core::fmt::write` alone at 2.46%/2.00% of the release-build
+  instruction count, plus a further ~4% in the `String`-growth machinery
+  (`RawVecInner::finish_grow`/`reserve::do_reserve_and_handle`) those two
+  calls' unsized starting buffer drove. A new private `concat_suffix(base,
+  suffix)` helper (`String::with_capacity(base.len() + suffix.len())` plus
+  two `push_str` calls) replaces all 12 call sites (2 per helper × 6
+  helpers); output is byte-for-byte unchanged (verified by the unchanged 209
+  `form`/`nested_form` lib tests).
+
+  Measured with the committed `autumn/benches/form_render.rs` harness and the
+  existing `autumn/tests/form_render_alloc_gate.rs` allocation gate (both the
+  same 12-field workload), `valgrind --tool=callgrind`, before and after on
+  the same machine:
+
+  | | before | after | delta |
+  | --- | ---: | ---: | ---: |
+  | Instructions (3,000-iteration run) | 159,827,570 | 138,424,533 | **-13.39%** |
+  | `alloc::fmt::format::format_inner` instructions | 3,928,400 (2.46%) | 0 (eliminated) | **-100%** |
+  | `core::fmt::write` instructions | 3,202,591 (2.00%) | 0 (eliminated) | **-100%** |
+  | Allocation blocks (200 renders) | 20,800 | 18,000 | **-13.5%** |
+  | Allocation bytes (200 renders) | 4,604,600 | 4,565,600 | -0.85% |
+
+  Clears the impact floor two ways independently: >=5% instruction reduction
+  on the realistic, directly-exercised bench workload, and >=10% allocation-
+  block reduction per the gate. The block-count drop is larger than the
+  12-call-site count alone would suggest — `format!`'s unsized starting
+  buffer apparently cost more than one allocation for some of these calls
+  once it had to grow, not just the final `String`.
+
 ## [0.7.0] - 2026-08-23
 
 For a narrative tour of this release, see the

--- a/autumn/src/form.rs
+++ b/autumn/src/form.rs
@@ -1100,6 +1100,23 @@ fn fast_escape(input: &str) -> std::borrow::Cow<'_, str> {
     std::borrow::Cow::Owned(out)
 }
 
+/// Build `"{base}{suffix}"` by direct, exactly-sized concatenation instead of
+/// `format!`. `format!("{base}{suffix}")` drives an unsized `String::new()`
+/// through the `Arguments`/`fmt::Write` machinery — arguments are boxed into
+/// a `[ArgumentV1]`, each piece is dispatched through `Display::fmt`, and the
+/// output `String` grows via reallocation as pieces land rather than being
+/// sized up front. For the fixed two-part `-field`/`-error` id suffixes every
+/// scaffolded input helper builds once per render, that dispatch is pure
+/// overhead: both parts are already `&str`, so one `String::with_capacity`
+/// plus two `push_str` calls produces the identical bytes.
+#[cfg(feature = "maud")]
+fn concat_suffix(base: &str, suffix: &str) -> String {
+    let mut s = String::with_capacity(base.len().saturating_add(suffix.len()));
+    s.push_str(base);
+    s.push_str(suffix);
+    s
+}
+
 /// Render a labeled `<input type="text">` tied to a changeset field.
 ///
 /// - Sets `name` and `id` to `field`
@@ -1120,8 +1137,8 @@ pub fn text_input<T: Serialize>(
     let has_errors = !errors.is_empty();
     let value = changeset.field_value(field).unwrap_or_default();
     let field_html = fast_escape(field);
-    let error_id = has_errors.then(|| format!("{field_html}-error"));
-    let wrapper_id = format!("{field_html}-field");
+    let error_id = has_errors.then(|| concat_suffix(&field_html, "-error"));
+    let wrapper_id = concat_suffix(&field_html, "-field");
     let field_pe = maud::PreEscaped(field_html.as_ref());
     let wrapper_pe = maud::PreEscaped(&wrapper_id);
     let aria_pe = maud::PreEscaped(error_id.as_deref().unwrap_or(""));
@@ -1411,8 +1428,8 @@ pub fn password_input<T: Serialize>(
     let errors = changeset.errors_for(field);
     let has_errors = !errors.is_empty();
     let field_html = fast_escape(field);
-    let error_id = has_errors.then(|| format!("{field_html}-error"));
-    let wrapper_id = format!("{field_html}-field");
+    let error_id = has_errors.then(|| concat_suffix(&field_html, "-error"));
+    let wrapper_id = concat_suffix(&field_html, "-field");
     let field_pe = maud::PreEscaped(field_html.as_ref());
     let wrapper_pe = maud::PreEscaped(&wrapper_id);
     let aria_pe = maud::PreEscaped(error_id.as_deref().unwrap_or(""));
@@ -1454,8 +1471,8 @@ pub fn textarea_input<T: Serialize>(
     let has_errors = !errors.is_empty();
     let value = changeset.field_value(field).unwrap_or_default();
     let field_html = fast_escape(field);
-    let error_id = has_errors.then(|| format!("{field_html}-error"));
-    let wrapper_id = format!("{field_html}-field");
+    let error_id = has_errors.then(|| concat_suffix(&field_html, "-error"));
+    let wrapper_id = concat_suffix(&field_html, "-field");
     let field_pe = maud::PreEscaped(field_html.as_ref());
     let wrapper_pe = maud::PreEscaped(&wrapper_id);
     let aria_pe = maud::PreEscaped(error_id.as_deref().unwrap_or(""));
@@ -1919,8 +1936,8 @@ pub fn checkbox_input<T: Serialize>(
     let has_errors = !errors.is_empty();
     let checked = changeset.field_value(field).as_deref() == Some("true");
     let field_html = fast_escape(field);
-    let error_id = has_errors.then(|| format!("{field_html}-error"));
-    let wrapper_id = format!("{field_html}-field");
+    let error_id = has_errors.then(|| concat_suffix(&field_html, "-error"));
+    let wrapper_id = concat_suffix(&field_html, "-field");
     let field_pe = maud::PreEscaped(field_html.as_ref());
     let wrapper_pe = maud::PreEscaped(&wrapper_id);
     let aria_pe = maud::PreEscaped(error_id.as_deref().unwrap_or(""));
@@ -1968,8 +1985,8 @@ pub fn number_input<T: Serialize>(
     let has_errors = !errors.is_empty();
     let value = changeset.field_value(field).unwrap_or_default();
     let field_html = fast_escape(field);
-    let error_id = has_errors.then(|| format!("{field_html}-error"));
-    let wrapper_id = format!("{field_html}-field");
+    let error_id = has_errors.then(|| concat_suffix(&field_html, "-error"));
+    let wrapper_id = concat_suffix(&field_html, "-field");
     let field_pe = maud::PreEscaped(field_html.as_ref());
     let wrapper_pe = maud::PreEscaped(&wrapper_id);
     let aria_pe = maud::PreEscaped(error_id.as_deref().unwrap_or(""));
@@ -2401,8 +2418,8 @@ pub fn date_input<T: Serialize>(
     let has_errors = !errors.is_empty();
     let value = normalize_date_value(&changeset.field_value(field).unwrap_or_default());
     let field_html = fast_escape(field);
-    let error_id = has_errors.then(|| format!("{field_html}-error"));
-    let wrapper_id = format!("{field_html}-field");
+    let error_id = has_errors.then(|| concat_suffix(&field_html, "-error"));
+    let wrapper_id = concat_suffix(&field_html, "-field");
     let field_pe = maud::PreEscaped(field_html.as_ref());
     let wrapper_pe = maud::PreEscaped(&wrapper_id);
     let aria_pe = maud::PreEscaped(error_id.as_deref().unwrap_or(""));

--- a/autumn/tests/form_render_alloc_gate.rs
+++ b/autumn/tests/form_render_alloc_gate.rs
@@ -152,17 +152,32 @@ fn scaffolded_form_render_allocations_on_a_12_field_workload() {
     // for feature-set/toolchain variance, same convention as
     // `config_alloc_gate`/`password_policy_alloc_gate`; a failure a hair over
     // the line means re-measure and re-derive, not nudge upwards.
+    //
+    // Bolt follow-up (looking at `alloc::fmt::format::format_inner`, 2.45% of
+    // a release-profile instruction count on this exact workload — see
+    // `benches/form_render.rs`): all six helpers built their `-field`/
+    // `-error` id suffix with `format!("{field_html}-error")` /
+    // `format!("{field_html}-field")`, which drives an unsized `String::new()`
+    // through the `Arguments`/`fmt::Write` machinery instead of sizing the
+    // output up front. Replaced with `autumn_web::form`'s new private
+    // `concat_suffix` (`String::with_capacity(base.len() + suffix.len())`
+    // plus two `push_str` calls) at all 6 call sites. Blocks dropped to **90**
+    // per render, 18,000 total (-13.5%): `format!`'s own internal growth
+    // apparently cost more than one allocation per call for some of these
+    // short strings, not just the final `String`. Bytes dropped slightly to
+    // **22,828** per render / **4,565,600** total (-0.85%) — exact-capacity
+    // sizing trims the same over-reservation slack the pre-escaping follow-up
+    // above added, though not by much against this workload's larger buffers.
     assert!(
-        info.count_total <= 21_500,
+        info.count_total <= 18_700,
         "scaffolded form render allocated {} blocks over {RENDERS} renders, over the \
-         21,500-block ceiling (20,800 measured; 24,800 was the pre-fix baseline)",
+         18,700-block ceiling (18,000 measured; 20,800 was the pre-fix baseline)",
         info.count_total,
     );
     assert!(
         info.bytes_total <= 4_660_000,
         "scaffolded form render allocated {} bytes over {RENDERS} renders, over the \
-         4,660,000-byte ceiling (4,604,600 measured; 4,495,800 was the pre-Bolt-follow-up \
-         baseline; 4,498,200 was the original pre-fix baseline)",
+         4,660,000-byte ceiling (4,565,600 measured; 4,604,600 was the pre-fix baseline)",
         info.bytes_total,
     );
 }


### PR DESCRIPTION
## Summary

🎯 **Workload** — the committed `autumn/benches/form_render.rs` harness: a realistic 12-field scaffolded form (`text_input`/`password_input`/`textarea_input`/`number_input`/`checkbox_input`/`date_input`), two fields carrying validation errors, matching a re-rendered failed create/update submission. Reproduce: `cargo build --release -p autumn-web --bench form_render` then `valgrind --tool=callgrind --callgrind-out-file=callgrind.out target/release/deps/form_render-* --iterations 3000`.

📈 **Profile** — post the pre-escaping fix (#2376), `alloc::fmt::format::format_inner` (2.46%) and `core::fmt::write` (2.00%) were the two largest non-libc, non-form-logic entries in the release-profile instruction count, with a further ~4% in the `String`-growth machinery (`RawVecInner::finish_grow` / `reserve::do_reserve_and_handle`) that their unsized starting buffer drove — together comfortably over the 5% floor.

💡 **Hypothesis** — all six helpers build `let wrapper_id = format!("{field_html}-field");` and (behind `has_errors`) `format!("{field_html}-error")`: a fixed two-part concatenation of already-`&str` pieces, routed through `format!`'s `Arguments`/`fmt::Write` dispatch and an unsized `String::new()` that grows via reallocation as the pieces land, instead of one up-front `String::with_capacity`.

🔧 **Change** — a new private `concat_suffix(base, suffix)` helper (`String::with_capacity(base.len() + suffix.len())` plus two `push_str` calls) replaces all 12 call sites (2 per helper × 6 helpers) in `autumn/src/form.rs`. Output is byte-for-byte identical; all 209 `form`/`nested_form` lib tests pass unchanged. The existing `autumn/tests/form_render_alloc_gate.rs` allocation-gate ceiling is lowered to the new measurement, following the same convention as the prior passes over this bench (#2295, #2298, #2304, #2376).

📊 **Measurement** — before/after, same harness, same machine:

| | before | after | delta |
| --- | ---: | ---: | ---: |
| Instructions (3,000-iteration run, `valgrind --tool=callgrind`) | 159,827,570 | 138,424,533 | **-13.39%** |
| `alloc::fmt::format::format_inner` instructions | 3,928,400 (2.46%) | 0 | **eliminated** |
| `core::fmt::write` instructions | 3,202,591 (2.00%) | 0 | **eliminated** |
| Allocation blocks (200 renders, `allocation-counter`) | 20,800 | 18,000 | **-13.5%** |
| Allocation bytes (200 renders) | 4,604,600 | 4,565,600 | -0.85% |

Clears the impact floor two independent ways: ≥5% instruction reduction on the realistic, directly-exercised bench workload, and ≥10% allocation-block reduction per the gate.

🔬 **Reproduce**:
```sh
cargo build --release -p autumn-web --bench form_render
BIN=$(find target/release/deps -maxdepth 1 -name "form_render-*" -type f ! -name "*.d")
valgrind --tool=callgrind --callgrind-out-file=callgrind.out "$BIN" --iterations 3000
callgrind_annotate --threshold=95 callgrind.out | head -40

cargo test -p autumn-web --test form_render_alloc_gate --features maud -- --nocapture
```

## Verification

- `cargo fmt --all -- --check` clean
- `cargo clippy -p autumn-web --features maud --lib --test form_render_alloc_gate -- -D warnings` clean (only the pre-existing, unrelated unknown-lint warning for `clippy::unused_async_trait_impl`, also noted in #2295/#2298/#2304)
- `cargo test -p autumn-web --lib --features maud` — all 5140 tests pass
- Checked for duplicate/overlapping work first: no open PR or issue references `form.rs`'s `error_id`/`wrapper_id` construction or `concat_suffix`

---
_Generated by [Claude Code](https://claude.ai/code/session_017M79CpMRggw6ZcM2MjX2rV)_