### PR TITLE
🔐 Stop `rediss://` panicking at startup in every Redis-backed subsystem (#2172)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -474,6 +474,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`rediss://` no longer panics at startup, in any Redis-backed subsystem
+  (#2172):** `redis`'s `tokio-rustls-comp` builds its TLS `ClientConfig`
+  through `rustls::ClientConfig::builder()`, which *panics* rather than
+  erroring when no process-level `CryptoProvider` is installed — and rustls
+  can only resolve one implicitly while exactly one of its `ring`/`aws-lc-rs`
+  features is on, which Cargo's whole-graph feature unification can break from
+  any dependency (`telemetry-otlp` alone is enough). Only `autumn-cache-redis`
+  guarded against this; sessions, channels, the Redis job queue, job tracking,
+  idempotency, webhook replay and Redis rate limiting each opened their own
+  unguarded client. Since the `azure-container-apps` release target provisions
+  a Redis Cache with `non_ssl_port_enabled = false` — it can only ever hand the
+  app a `rediss://` URL — pointing any of those subsystems at it crashed the
+  app on boot.
+
+  Every Redis client the framework opens now goes through
+  `autumn_web::redis_tls::open_client`, which installs `ring` once,
+  idempotently, and only when the URL is a TLS one — decided by asking the
+  `redis` crate to parse it and checking whether it resolved to a TLS address,
+  so `rediss://`, Valkey's `valkeys://` and any case variant the URL parser
+  accepts are all covered without a scheme list to keep in sync. (The previous
+  `starts_with("rediss://")` check had already missed both.) A plaintext
+  `redis://` URL deliberately does **not** claim the process-wide default, so
+  it cannot pre-empt an application that installs `aws-lc-rs` for something
+  else, and an already-installed provider is always kept rather than replaced.
+  `autumn-cache-redis` now delegates to the same guard instead of carrying its
+  own copy, and a source scan in each crate keeps a future subsystem from
+  re-opening the hole with a bare `redis::Client::open`.
+
 - **A container that terminates TLS itself is no longer permanently
   `unhealthy`:** the Dockerfile `autumn release init` generates hardcoded its
   `HEALTHCHECK` to `curl -f http://localhost:3000/health`, so an image whose app

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -453,7 +453,6 @@ version = "0.7.0"
 dependencies = [
  "autumn-web",
  "redis",
- "rustls",
  "serde",
  "serde_json",
  "testcontainers",

--- a/autumn-cache-redis/Cargo.toml
+++ b/autumn-cache-redis/Cargo.toml
@@ -14,10 +14,6 @@ categories = ["web-programming", "web-programming::http-server"]
 [dependencies]
 autumn-web = { version = "0.7.0", path = "../autumn", features = ["redis"] }
 redis = { workspace = true }
-# Installs the process-wide rustls `CryptoProvider` `redis`'s `tokio-rustls-comp`
-# needs for `rediss://` URLs — see the comment in `RedisCache::connect`. Pinned
-# to the same version/feature set `autumn`'s own rustls call sites use.
-rustls = { version = "0.23", default-features = false, features = ["ring", "logging", "std", "tls12"] }
 thiserror = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }

--- a/autumn-cache-redis/src/lib.rs
+++ b/autumn-cache-redis/src/lib.rs
@@ -118,20 +118,6 @@ fn escape_redis_glob(s: &str) -> String {
     escaped
 }
 
-/// Whether `url` needs the `rustls` `CryptoProvider` installed to connect —
-/// true only for the two TLS schemes `redis::Client::open` itself
-/// recognizes (`rediss://` and Valkey's `valkeys://`), matched
-/// case-insensitively the same way `redis`'s own URL parsing (via the
-/// `url` crate, which lowercases the scheme while parsing) does. A plain
-/// `redis://`/`valkey://` URL never touches TLS, so it must not claim the
-/// process-wide default: doing so could pre-empt a later, unrelated
-/// attempt elsewhere in the process to install a different provider (e.g.
-/// `aws-lc-rs`) for something that actually needs one.
-fn needs_tls_crypto_provider(url: &str) -> bool {
-    let scheme = url.split_once("://").map_or("", |(scheme, _)| scheme);
-    scheme.eq_ignore_ascii_case("rediss") || scheme.eq_ignore_ascii_case("valkeys")
-}
-
 impl RedisCache {
     /// Connect using an explicit URL and key prefix.
     ///
@@ -142,26 +128,13 @@ impl RedisCache {
         url: &str,
         key_prefix: impl Into<String>,
     ) -> Result<Self, RedisCacheError> {
-        // The workspace links both `ring` and `aws-lc-rs` (via other rustls
-        // consumers, e.g. opentelemetry-otlp's `tls-aws-lc`), so rustls can no
-        // longer auto-select a process-wide default `CryptoProvider` — and
-        // `redis`'s `tokio-rustls-comp` builds its `ClientConfig` via the
-        // short-form `rustls::ClientConfig::builder()`, which panics instead
-        // of erroring when that default is missing. Installing `ring` here
-        // (matching the backend already used by this workspace's other rustls
-        // call sites) makes a `rediss://` URL usable regardless of init
-        // order; `.ok()` makes it idempotent since a concurrent/earlier call
-        // may have already installed one. Scoped to `rediss://` URLs only —
-        // a plain `redis://` connection never touches TLS, so claiming the
-        // process-wide default here would be able to pre-empt a later,
-        // unrelated attempt elsewhere in the process to install a different
-        // provider (e.g. `aws-lc-rs`) for something that actually needs it.
-        if needs_tls_crypto_provider(url) {
-            rustls::crypto::ring::default_provider()
-                .install_default()
-                .ok();
-        }
-        let client = redis::Client::open(url)?;
+        // `open_client`, not `redis::Client::open`: it installs the
+        // process-wide rustls `CryptoProvider` that `redis`'s
+        // `tokio-rustls-comp` needs before a `rediss://` URL can be dialled,
+        // and it is the same guard every Redis client inside `autumn-web`
+        // goes through. Scoped to TLS schemes there, so a plain `redis://`
+        // connection never claims the process-wide default. See #2172.
+        let client = autumn_web::redis_tls::open_client(url)?;
         let manager = ConnectionManager::new(client).await?;
         Ok(Self {
             manager,
@@ -528,28 +501,46 @@ mod tests {
         assert_eq!(ttl_millis_for_redis(std::time::Duration::ZERO), 1);
     }
 
+    /// This crate must not open its own Redis client: `RedisCache::connect`
+    /// goes through `autumn_web::redis_tls::open_client`, which installs the
+    /// process-level rustls `CryptoProvider` a `rediss://` URL needs before
+    /// rustls is asked to resolve one (#2172). Mirrors the identical scan in
+    /// `autumn_web::redis_tls` so the two crates cannot drift — a second,
+    /// hand-rolled install here is exactly how the `valkeys://` and
+    /// case-insensitivity gaps got fixed in one place and missed in another.
     #[test]
-    fn plain_redis_urls_do_not_claim_the_process_wide_tls_provider() {
-        assert!(!needs_tls_crypto_provider("redis://127.0.0.1:6379/"));
-        assert!(!needs_tls_crypto_provider("redis://user:pass@host:6379/0"));
-        assert!(!needs_tls_crypto_provider("valkey://127.0.0.1:6379/"));
+    fn the_cache_never_opens_a_redis_client_outside_the_shared_tls_guard() {
+        // Split so the needle does not match this test's own source line.
+        let needle = concat!("Client::", "open(");
+        let source = include_str!("lib.rs");
+        let offenders: Vec<_> = source
+            .lines()
+            .enumerate()
+            .filter(|(_, line)| {
+                let trimmed = line.trim_start();
+                !trimmed.starts_with("//") && !trimmed.starts_with('*') && line.contains(needle)
+            })
+            .map(|(index, line)| format!("lib.rs:{}: {}", index + 1, line.trim()))
+            .collect();
+        assert!(
+            offenders.is_empty(),
+            "open Redis clients through `autumn_web::redis_tls::open_client`, \
+             not directly — a `rediss://` URL otherwise reaches rustls with no \
+             process-level CryptoProvider installed and panics (#2172):\n{}",
+            offenders.join("\n")
+        );
     }
 
+    /// The TLS scheme classification itself is `autumn_web::redis_tls`'s
+    /// contract; this only pins that this crate is wired to the same one.
     #[test]
-    fn rediss_urls_still_claim_the_tls_provider() {
-        assert!(needs_tls_crypto_provider("rediss://127.0.0.1:6380/"));
-    }
-
-    #[test]
-    fn valkeys_urls_also_claim_the_tls_provider() {
-        // Regression: `redis::Client::open` (via the `url` crate, which
-        // lowercases the scheme while parsing) treats both `rediss://` and
-        // Valkey's `valkeys://` as TLS — a literal `starts_with("rediss://")`
-        // check missed `valkeys://` entirely, so a `valkeys://` connection
-        // could reach `ClientConfig::builder()` with no provider ever
-        // installed (if nothing else in the process had installed one
-        // first) and panic instead of returning a connection error.
-        assert!(needs_tls_crypto_provider("valkeys://127.0.0.1:6380/"));
+    fn the_shared_guard_classifies_the_tls_schemes_this_cache_is_deployed_on() {
+        assert!(autumn_web::redis_tls::url_needs_tls_crypto_provider(
+            "rediss://cache.redis.cache.windows.net:6380/"
+        ));
+        assert!(!autumn_web::redis_tls::url_needs_tls_crypto_provider(
+            "redis://127.0.0.1:6379/"
+        ));
     }
 
     #[test]
@@ -568,17 +559,6 @@ mod tests {
         assert_eq!(escape_redis_glob("a?b"), r"a\?b");
         assert_eq!(escape_redis_glob("[ab]"), r"\[ab]");
         assert_eq!(escape_redis_glob(r"back\slash"), r"back\\slash");
-    }
-
-    #[test]
-    fn tls_scheme_matching_is_case_insensitive() {
-        // Regression: a literal `starts_with("rediss://")` also missed a
-        // case-variant scheme such as `REDISS://` — valid per URL parsing
-        // (schemes are normalized to lowercase), and accepted the same way
-        // by `redis::Client::open`, but invisible to a case-sensitive
-        // prefix check.
-        assert!(needs_tls_crypto_provider("REDISS://127.0.0.1:6380/"));
-        assert!(needs_tls_crypto_provider("Valkeys://127.0.0.1:6380/"));
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/autumn/Cargo.toml
+++ b/autumn/Cargo.toml
@@ -122,7 +122,12 @@ telemetry-otlp = [
 # `[[bin]]` (W6 PR3), which is a binary and therefore cannot use dev-deps, can
 # depend on it too. `proptest` itself stays out of default builds.
 sim-testing = ["dep:proptest"]
-redis = ["dep:redis"]
+# `dep:rustls` is not optional flavouring: `redis`'s `tokio-rustls-comp`
+# feature makes `rediss://` URLs reachable, and those panic inside
+# `rustls::ClientConfig::builder()` unless a process-level
+# `CryptoProvider` is installed first. `redis_tls` installs one — see
+# that module and issue #2172.
+redis = ["dep:redis", "dep:rustls"]
 i18n = []
 # Embed the app's `static/` tree (incl. the fingerprint manifest) and i18n
 # `locales`/`i18n` bundles into the release binary at compile time, so a single

--- a/autumn/src/channels.rs
+++ b/autumn/src/channels.rs
@@ -994,7 +994,7 @@ impl RedisChannelsBackend {
             .clone()
             .filter(|url| !url.trim().is_empty())
             .ok_or(ChannelBackendConfigError::MissingRedisUrl)?;
-        let client = redis::Client::open(url)
+        let client = crate::redis_tls::open_client(&url)
             .map_err(|error| ChannelBackendConfigError::InvalidRedisUrl(error.to_string()))?;
         let local =
             LocalChannelsBackend::with_replay_capacity(config.capacity, config.replay_buffer);

--- a/autumn/src/idempotency.rs
+++ b/autumn/src/idempotency.rs
@@ -583,7 +583,7 @@ mod redis_store {
         IdempotencyEntry, IdempotencyRecord, IdempotencyStore, IdempotencyStoreError,
         saturating_deadline,
     };
-    use redis::{AsyncCommands, Client, aio::ConnectionManager, aio::ConnectionManagerConfig};
+    use redis::{AsyncCommands, aio::ConnectionManager, aio::ConnectionManagerConfig};
     use serde::{Deserialize, Serialize};
     use std::time::Duration;
 
@@ -624,7 +624,7 @@ mod redis_store {
                      [idempotency.redis] url in autumn.toml."
                         .to_owned()
                 })?;
-            let client = Client::open(url).map_err(|e| e.to_string())?;
+            let client = crate::redis_tls::open_client(url).map_err(|e| e.to_string())?;
             let connection =
                 ConnectionManager::new_lazy_with_config(client, ConnectionManagerConfig::new())
                     .map_err(|e| e.to_string())?;

--- a/autumn/src/job.rs
+++ b/autumn/src/job.rs
@@ -7648,7 +7648,7 @@ fn start_redis_runtime(
             ))
         })?;
 
-    let client = redis::Client::open(url).map_err(|e| {
+    let client = crate::redis_tls::open_client(&url).map_err(|e| {
         AutumnError::internal_server_error(std::io::Error::other(format!(
             "invalid jobs redis url: {e}"
         )))
@@ -12064,7 +12064,7 @@ mod tests {
         let container = RedisImage::default().start().await.unwrap();
         let port = container.get_host_port_ipv4(6379).await.unwrap();
         let url = format!("redis://127.0.0.1:{port}");
-        (container, redis::Client::open(url).unwrap())
+        (container, crate::redis_tls::open_client(&url).unwrap())
     }
 
     #[cfg(feature = "redis")]

--- a/autumn/src/job_tracking.rs
+++ b/autumn/src/job_tracking.rs
@@ -1384,13 +1384,15 @@ impl JobTrackingStore for RedisJobTrackingStore {
 /// `None` when no URL is configured or it fails to parse; the connection
 /// manager itself connects lazily, so this never blocks on Redis being up.
 #[cfg(feature = "redis")]
-pub(crate) fn build_redis_tracking_store(config: &crate::config::JobConfig) -> Option<RedisJobTrackingStore> {
+pub(crate) fn build_redis_tracking_store(
+    config: &crate::config::JobConfig,
+) -> Option<RedisJobTrackingStore> {
     let url = config
         .redis
         .url
         .clone()
         .filter(|url| !url.trim().is_empty())?;
-    let client = redis::Client::open(url).ok()?;
+    let client = crate::redis_tls::open_client(&url).ok()?;
     let connection = redis::aio::ConnectionManager::new_lazy_with_config(
         client,
         redis::aio::ConnectionManagerConfig::new(),

--- a/autumn/src/job_tracking.rs
+++ b/autumn/src/job_tracking.rs
@@ -1384,7 +1384,7 @@ impl JobTrackingStore for RedisJobTrackingStore {
 /// `None` when no URL is configured or it fails to parse; the connection
 /// manager itself connects lazily, so this never blocks on Redis being up.
 #[cfg(feature = "redis")]
-fn build_redis_tracking_store(config: &crate::config::JobConfig) -> Option<RedisJobTrackingStore> {
+pub(crate) fn build_redis_tracking_store(config: &crate::config::JobConfig) -> Option<RedisJobTrackingStore> {
     let url = config
         .redis
         .url

--- a/autumn/src/lib.rs
+++ b/autumn/src/lib.rs
@@ -504,6 +504,10 @@ pub mod markdown;
 /// Enabled by the `reporting` Cargo feature (on by default).
 #[cfg(feature = "reporting")]
 pub mod reporting;
+/// Process-wide rustls `CryptoProvider` guard for TLS Redis (`rediss://`)
+/// URLs — see [`redis_tls::open_client`] (issue #2172).
+#[cfg(feature = "redis")]
+pub mod redis_tls;
 pub mod scheduler;
 pub mod security;
 pub mod session;

--- a/autumn/src/lib.rs
+++ b/autumn/src/lib.rs
@@ -498,16 +498,16 @@ pub use seo::SeoRouteDefaults;
 /// Enable with the Cargo feature `markdown`.
 #[cfg(feature = "markdown")]
 pub mod markdown;
+/// Process-wide rustls `CryptoProvider` guard for TLS Redis (`rediss://`)
+/// URLs — see [`redis_tls::open_client`] (issue #2172).
+#[cfg(feature = "redis")]
+pub mod redis_tls;
 /// Pluggable error reporting: catch handler panics and route panics + 5xx
 /// responses to configured [`ErrorReporter`](reporting::ErrorReporter)s.
 ///
 /// Enabled by the `reporting` Cargo feature (on by default).
 #[cfg(feature = "reporting")]
 pub mod reporting;
-/// Process-wide rustls `CryptoProvider` guard for TLS Redis (`rediss://`)
-/// URLs — see [`redis_tls::open_client`] (issue #2172).
-#[cfg(feature = "redis")]
-pub mod redis_tls;
 pub mod scheduler;
 pub mod security;
 pub mod session;

--- a/autumn/src/redis_tls.rs
+++ b/autumn/src/redis_tls.rs
@@ -1,0 +1,242 @@
+//! Process-wide rustls `CryptoProvider` guard for TLS Redis URLs.
+//!
+//! `redis`'s `tokio-rustls-comp` feature builds its TLS `ClientConfig` through
+//! the short-form `rustls::ClientConfig::builder()`, which resolves its crypto
+//! provider from process-global state. That call does **not** return an error
+//! when it cannot resolve one — it *panics*:
+//!
+//! ```text
+//! Could not automatically determine the process-level CryptoProvider from
+//! Rustls crate features. Call CryptoProvider::install_default() before this
+//! point ...
+//! ```
+//!
+//! rustls resolves implicitly only while exactly ONE of its `ring` /
+//! `aws-lc-rs` features is enabled. Autumn pins `ring` everywhere, but Cargo
+//! unifies features across the whole dependency graph, so any dependency that
+//! turns on `aws-lc-rs` (`telemetry-otlp` alone is enough) makes the choice
+//! ambiguous — and then every `rediss://` connection panics. Not a test
+//! artifact: the `azure-container-apps` release target provisions a Redis
+//! Cache with `non_ssl_port_enabled = false`, so it only ever hands the app a
+//! `rediss://` URL, and the panic lands at startup on a real deployment.
+//!
+//! See issue #2172.
+
+#[cfg(test)]
+mod tests {
+    use std::path::{Path, PathBuf};
+
+    use rusty_fork::rusty_fork_test;
+
+    /// A TLS Redis URL pointed at a port nothing listens on. None of the
+    /// scenarios below dial: every constructor under test builds a *lazy*
+    /// connection manager, so the URL is only ever parsed and classified.
+    const TLS_URL: &str = "rediss://127.0.0.1:16380/";
+    /// The plaintext counterpart, for the negative scenario.
+    const PLAIN_URL: &str = "redis://127.0.0.1:16379/";
+
+    /// Recursively collect every `.rs` file under `dir`.
+    fn rust_sources(dir: &Path, out: &mut Vec<PathBuf>) {
+        for entry in std::fs::read_dir(dir).expect("read_dir") {
+            let path = entry.expect("dir entry").path();
+            if path.is_dir() {
+                rust_sources(&path, out);
+            } else if path.extension().is_some_and(|ext| ext == "rs") {
+                out.push(path);
+            }
+        }
+    }
+
+    /// Every Redis client in this crate must be built through this module's
+    /// guarded constructor, so a `rediss://` URL can never reach rustls with
+    /// no process-level `CryptoProvider` installed.
+    ///
+    /// A source scan rather than only per-call-site runtime assertions,
+    /// because the failure mode is a *missing* call: a new Redis-backed
+    /// subsystem that opens its own client is exactly the regression #2172
+    /// describes, and no runtime test of the subsystems that exist today can
+    /// see it. It also covers the two sites a runtime test cannot reach
+    /// cheaply — `job::start_redis_runtime` (needs a live `AppState`) and
+    /// `session::resolve_backend_plan`'s URL validation.
+    #[test]
+    fn no_redis_client_is_opened_outside_the_tls_guard() {
+        let src = Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
+        let mut files = Vec::new();
+        rust_sources(&src, &mut files);
+        assert!(!files.is_empty(), "no sources found under {}", src.display());
+        files.sort();
+
+        let mut offenders = Vec::new();
+        for file in files {
+            // This module *is* the guard: the one place allowed to call it.
+            if file.file_name().is_some_and(|name| name == "redis_tls.rs") {
+                continue;
+            }
+            let source = std::fs::read_to_string(&file).expect("read source");
+            for (index, line) in source.lines().enumerate() {
+                let trimmed = line.trim_start();
+                // Prose (doc comments, block-comment continuations) may quote
+                // the banned call while explaining it.
+                if trimmed.starts_with("//") || trimmed.starts_with('*') {
+                    continue;
+                }
+                if line.contains("Client::open(") {
+                    offenders.push(format!(
+                        "{}:{}: {}",
+                        file.strip_prefix(&src).unwrap_or(&file).display(),
+                        index + 1,
+                        line.trim()
+                    ));
+                }
+            }
+        }
+
+        assert!(
+            offenders.is_empty(),
+            "these sites open a Redis client directly instead of through \
+             `crate::redis_tls::open_client`, so a `rediss://` URL reaches \
+             rustls with no process-level CryptoProvider installed and panics \
+             at startup (#2172):\n{}",
+            offenders.join("\n")
+        );
+    }
+
+    /// Run `body` inside a Tokio runtime: the lazy `ConnectionManager`s these
+    /// constructors build need a reactor context to spawn their background
+    /// reconnect task onto, even though they never dial.
+    #[cfg(feature = "redis")]
+    fn in_runtime(body: impl FnOnce()) {
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("tokio runtime")
+            .block_on(async { body() });
+    }
+
+    /// Assert that a fresh process starts with no provider — otherwise every
+    /// assertion below would pass vacuously.
+    #[cfg(feature = "redis")]
+    fn assert_no_provider_yet() {
+        assert!(
+            rustls::crypto::CryptoProvider::get_default().is_none(),
+            "this scenario must run in a fresh process (rusty_fork), or the \
+             assertions below prove nothing"
+        );
+    }
+
+    /// The `#[must_use]`-shaped assertion each TLS scenario ends on.
+    #[cfg(feature = "redis")]
+    fn assert_provider_installed(subsystem: &str) {
+        assert!(
+            rustls::crypto::CryptoProvider::get_default().is_some(),
+            "{subsystem} built a Redis client for a `rediss://` URL without \
+             installing a process-level rustls CryptoProvider first; the next \
+             rustls `ClientConfig::builder()` call panics instead of \
+             connecting (#2172)"
+        );
+    }
+
+    // Each scenario runs in its own forked process: installing a
+    // `CryptoProvider` is a one-shot process-global side effect, so a second
+    // in-process assertion would pass no matter which subsystem installed it.
+    #[cfg(feature = "redis")]
+    rusty_fork_test! {
+        #[test]
+        fn session_store_installs_the_tls_provider() {
+            assert_no_provider_yet();
+            in_runtime(|| {
+                let mut config = crate::session::SessionConfig::default();
+                config.backend = crate::session::SessionBackend::Redis;
+                config.redis.url = Some(TLS_URL.to_owned());
+                let _ = crate::session_redis::RedisStore::from_config(&config);
+            });
+            assert_provider_installed("the Redis session store");
+        }
+
+        // `channels` is `ws`-gated, so this scenario only exists in builds
+        // that compile the Redis pub/sub backend at all.
+        #[cfg(feature = "ws")]
+        #[test]
+        fn channels_backend_installs_the_tls_provider() {
+            assert_no_provider_yet();
+            in_runtime(|| {
+                let mut config = crate::config::ChannelConfig::default();
+                config.backend = crate::config::ChannelBackend::Redis;
+                config.redis.url = Some(TLS_URL.to_owned());
+                let _ = crate::channels::Channels::from_config(
+                    &config,
+                    tokio_util::sync::CancellationToken::new(),
+                );
+            });
+            assert_provider_installed("the Redis channels backend");
+        }
+
+        #[test]
+        fn idempotency_store_installs_the_tls_provider() {
+            assert_no_provider_yet();
+            in_runtime(|| {
+                let mut config = crate::config::IdempotencyConfig::default();
+                config.redis.url = Some(TLS_URL.to_owned());
+                let _ = crate::idempotency::RedisIdempotencyStore::from_config(&config);
+            });
+            assert_provider_installed("the Redis idempotency store");
+        }
+
+        #[test]
+        fn webhook_replay_store_installs_the_tls_provider() {
+            assert_no_provider_yet();
+            in_runtime(|| {
+                let config = crate::webhook::WebhookReplayRedisConfig {
+                    url: Some(TLS_URL.to_owned()),
+                    ..Default::default()
+                };
+                let _ = crate::webhook::RedisWebhookReplayStore::from_config(&config);
+            });
+            assert_provider_installed("the Redis webhook replay store");
+        }
+
+        #[test]
+        fn job_tracking_store_installs_the_tls_provider() {
+            assert_no_provider_yet();
+            in_runtime(|| {
+                let mut config = crate::config::JobConfig::default();
+                config.redis.url = Some(TLS_URL.to_owned());
+                let _ = crate::job_tracking::build_redis_tracking_store(&config);
+            });
+            assert_provider_installed("the Redis job tracking store");
+        }
+
+        #[test]
+        fn rate_limit_backend_installs_the_tls_provider() {
+            assert_no_provider_yet();
+            in_runtime(|| {
+                let mut config = crate::security::RateLimitConfig::default();
+                config.backend = crate::security::RateLimitBackend::Redis;
+                config.redis.url = Some(TLS_URL.to_owned());
+                let _ = crate::security::rate_limit::RateLimitLayer::from_config(&config);
+            });
+            assert_provider_installed("the Redis rate-limit backend");
+        }
+
+        /// The negative half of the guarantee: a plaintext `redis://` URL
+        /// never touches TLS, so claiming the process-wide default for it
+        /// could pre-empt a later, unrelated attempt elsewhere in the process
+        /// to install a *different* provider (e.g. `aws-lc-rs`) for something
+        /// that actually needs one.
+        #[test]
+        fn a_plaintext_redis_url_leaves_the_process_provider_unset() {
+            assert_no_provider_yet();
+            in_runtime(|| {
+                let mut config = crate::session::SessionConfig::default();
+                config.backend = crate::session::SessionBackend::Redis;
+                config.redis.url = Some(PLAIN_URL.to_owned());
+                let _ = crate::session_redis::RedisStore::from_config(&config);
+            });
+            assert!(
+                rustls::crypto::CryptoProvider::get_default().is_none(),
+                "a plaintext `redis://` connection must not claim the \
+                 process-wide rustls default provider"
+            );
+        }
+    }
+}

--- a/autumn/src/redis_tls.rs
+++ b/autumn/src/redis_tls.rs
@@ -22,9 +22,71 @@
 //!
 //! See issue #2172.
 
+/// Whether `url` needs the rustls `CryptoProvider` installed before a client
+/// built from it can connect.
+///
+/// Answered by asking the `redis` crate to parse the URL and reporting
+/// whether it resolved to a TLS address, rather than by matching schemes
+/// here. That distinction matters: the first cut of this check lived in
+/// `autumn-cache-redis` as `starts_with("rediss://")`, which silently missed
+/// Valkey's `valkeys://` and any case variant the URL parser accepts. Reusing
+/// `redis`'s own scheme table means a scheme it learns to treat as TLS is
+/// covered the day the dependency is bumped, with nothing to keep in sync.
+///
+/// A plain `redis://`/`valkey://` URL never touches TLS, so it must **not**
+/// claim the process-wide default: doing so could pre-empt a later, unrelated
+/// attempt elsewhere in the process to install a different provider (e.g.
+/// `aws-lc-rs`) for something that actually needs one. A URL `redis` cannot
+/// parse at all is likewise not TLS — [`open_client`] is about to reject it
+/// with that same parse error.
+#[must_use]
+pub fn url_needs_tls_crypto_provider(url: &str) -> bool {
+    use redis::IntoConnectionInfo as _;
+
+    url.into_connection_info()
+        .is_ok_and(|info| matches!(info.addr(), redis::ConnectionAddr::TcpTls { .. }))
+}
+
+/// Install `ring` as the process-wide default `CryptoProvider` if `url` is a
+/// TLS Redis URL and nothing has installed one yet.
+///
+/// Call this before handing a URL to any Redis client constructor this module
+/// does not own — [`open_client`] already does it for you. Idempotent and
+/// safe to race: an existing provider is always kept, because the requirement
+/// is only that *a* default exists before rustls looks for one, and silently
+/// replacing an application's deliberate choice would be worse than the panic
+/// this prevents.
+pub fn ensure_tls_crypto_provider(url: &str) {
+    if url_needs_tls_crypto_provider(url) && rustls::crypto::CryptoProvider::get_default().is_none()
+    {
+        // Errors only if another thread won the race to install one, which
+        // satisfies the requirement just as well. `ring` matches the backend
+        // every other rustls call site in this workspace already pins.
+        let _ = rustls::crypto::ring::default_provider().install_default();
+    }
+}
+
+/// Open a Redis client, installing the rustls `CryptoProvider` first when
+/// `url` is a TLS (`rediss://` / `valkeys://`) endpoint.
+///
+/// The only sanctioned way to build a [`redis::Client`] in this crate — a
+/// unit test scans `src/` to keep it that way. See the module docs for why a
+/// bare `redis::Client::open` is a latent startup panic (#2172).
+///
+/// # Errors
+///
+/// Returns the `redis` crate's parse error when `url` is not a valid Redis
+/// connection URL. No connection is attempted here.
+pub fn open_client(url: &str) -> redis::RedisResult<redis::Client> {
+    ensure_tls_crypto_provider(url);
+    redis::Client::open(url)
+}
+
 #[cfg(test)]
 mod tests {
     use std::path::{Path, PathBuf};
+
+    use super::{open_client, url_needs_tls_crypto_provider};
 
     use rusty_fork::rusty_fork_test;
 
@@ -34,6 +96,61 @@ mod tests {
     const TLS_URL: &str = "rediss://127.0.0.1:16380/";
     /// The plaintext counterpart, for the negative scenario.
     const PLAIN_URL: &str = "redis://127.0.0.1:16379/";
+
+    #[test]
+    fn plain_redis_urls_do_not_claim_the_process_wide_tls_provider() {
+        assert!(!url_needs_tls_crypto_provider("redis://127.0.0.1:6379/"));
+        assert!(!url_needs_tls_crypto_provider(
+            "redis://user:pass@host:6379/0"
+        ));
+        assert!(!url_needs_tls_crypto_provider("valkey://127.0.0.1:6379/"));
+        assert!(!url_needs_tls_crypto_provider("unix:///run/redis.sock"));
+        // Unparseable input is not TLS: `open_client` is about to reject it.
+        assert!(!url_needs_tls_crypto_provider(""));
+        assert!(!url_needs_tls_crypto_provider("not a redis url"));
+        assert!(!url_needs_tls_crypto_provider("https://example.com"));
+    }
+
+    #[test]
+    fn rediss_urls_claim_the_tls_provider() {
+        assert!(url_needs_tls_crypto_provider("rediss://127.0.0.1:6380/"));
+        assert!(url_needs_tls_crypto_provider(
+            "rediss://user:pass@cache.redis.cache.windows.net:6380/0"
+        ));
+    }
+
+    #[test]
+    fn valkeys_urls_also_claim_the_tls_provider() {
+        // Regression: `redis::Client::open` (via the `url` crate, which
+        // lowercases the scheme while parsing) treats both `rediss://` and
+        // Valkey's `valkeys://` as TLS — a literal `starts_with("rediss://")`
+        // check missed `valkeys://` entirely, so such a connection could
+        // reach `ClientConfig::builder()` with no provider installed.
+        assert!(url_needs_tls_crypto_provider("valkeys://127.0.0.1:6380/"));
+    }
+
+    #[test]
+    fn tls_scheme_matching_is_case_insensitive() {
+        // Regression: a literal `starts_with("rediss://")` also missed a
+        // case-variant scheme such as `REDISS://` — valid per URL parsing
+        // (schemes are normalized to lowercase) and accepted the same way by
+        // `redis::Client::open`, but invisible to a case-sensitive check.
+        assert!(url_needs_tls_crypto_provider("REDISS://127.0.0.1:6380/"));
+        assert!(url_needs_tls_crypto_provider("Valkeys://127.0.0.1:6380/"));
+    }
+
+    #[test]
+    fn a_scheme_that_merely_starts_with_a_tls_scheme_is_not_tls() {
+        // `redisstore://` shares the `rediss` prefix but is not a Redis
+        // scheme at all; a prefix match would have claimed the provider for
+        // it. `redis`'s parser rejects it outright, so it is not TLS.
+        assert!(!url_needs_tls_crypto_provider("redisstore://host:6379/"));
+    }
+
+    #[test]
+    fn open_client_rejects_a_malformed_url_without_panicking() {
+        assert!(open_client("not a redis url").is_err());
+    }
 
     /// Recursively collect every `.rs` file under `dir`.
     fn rust_sources(dir: &Path, out: &mut Vec<PathBuf>) {
@@ -63,7 +180,11 @@ mod tests {
         let src = Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
         let mut files = Vec::new();
         rust_sources(&src, &mut files);
-        assert!(!files.is_empty(), "no sources found under {}", src.display());
+        assert!(
+            !files.is_empty(),
+            "no sources found under {}",
+            src.display()
+        );
         files.sort();
 
         let mut offenders = Vec::new();
@@ -104,7 +225,6 @@ mod tests {
     /// Run `body` inside a Tokio runtime: the lazy `ConnectionManager`s these
     /// constructors build need a reactor context to spawn their background
     /// reconnect task onto, even though they never dial.
-    #[cfg(feature = "redis")]
     fn in_runtime(body: impl FnOnce()) {
         tokio::runtime::Builder::new_current_thread()
             .enable_all()
@@ -115,7 +235,6 @@ mod tests {
 
     /// Assert that a fresh process starts with no provider — otherwise every
     /// assertion below would pass vacuously.
-    #[cfg(feature = "redis")]
     fn assert_no_provider_yet() {
         assert!(
             rustls::crypto::CryptoProvider::get_default().is_none(),
@@ -124,8 +243,7 @@ mod tests {
         );
     }
 
-    /// The `#[must_use]`-shaped assertion each TLS scenario ends on.
-    #[cfg(feature = "redis")]
+    /// The assertion every TLS scenario ends on.
     fn assert_provider_installed(subsystem: &str) {
         assert!(
             rustls::crypto::CryptoProvider::get_default().is_some(),
@@ -139,14 +257,15 @@ mod tests {
     // Each scenario runs in its own forked process: installing a
     // `CryptoProvider` is a one-shot process-global side effect, so a second
     // in-process assertion would pass no matter which subsystem installed it.
-    #[cfg(feature = "redis")]
     rusty_fork_test! {
         #[test]
         fn session_store_installs_the_tls_provider() {
             assert_no_provider_yet();
             in_runtime(|| {
-                let mut config = crate::session::SessionConfig::default();
-                config.backend = crate::session::SessionBackend::Redis;
+                let mut config = crate::session::SessionConfig {
+                    backend: crate::session::SessionBackend::Redis,
+                    ..Default::default()
+                };
                 config.redis.url = Some(TLS_URL.to_owned());
                 let _ = crate::session_redis::RedisStore::from_config(&config);
             });
@@ -160,8 +279,10 @@ mod tests {
         fn channels_backend_installs_the_tls_provider() {
             assert_no_provider_yet();
             in_runtime(|| {
-                let mut config = crate::config::ChannelConfig::default();
-                config.backend = crate::config::ChannelBackend::Redis;
+                let mut config = crate::config::ChannelConfig {
+                    backend: crate::config::ChannelBackend::Redis,
+                    ..Default::default()
+                };
                 config.redis.url = Some(TLS_URL.to_owned());
                 let _ = crate::channels::Channels::from_config(
                     &config,
@@ -210,8 +331,10 @@ mod tests {
         fn rate_limit_backend_installs_the_tls_provider() {
             assert_no_provider_yet();
             in_runtime(|| {
-                let mut config = crate::security::RateLimitConfig::default();
-                config.backend = crate::security::RateLimitBackend::Redis;
+                let mut config = crate::security::RateLimitConfig {
+                    backend: crate::security::RateLimitBackend::Redis,
+                    ..Default::default()
+                };
                 config.redis.url = Some(TLS_URL.to_owned());
                 let _ = crate::security::rate_limit::RateLimitLayer::from_config(&config);
             });
@@ -227,8 +350,10 @@ mod tests {
         fn a_plaintext_redis_url_leaves_the_process_provider_unset() {
             assert_no_provider_yet();
             in_runtime(|| {
-                let mut config = crate::session::SessionConfig::default();
-                config.backend = crate::session::SessionBackend::Redis;
+                let mut config = crate::session::SessionConfig {
+                    backend: crate::session::SessionBackend::Redis,
+                    ..Default::default()
+                };
                 config.redis.url = Some(PLAIN_URL.to_owned());
                 let _ = crate::session_redis::RedisStore::from_config(&config);
             });

--- a/autumn/src/security/rate_limit.rs
+++ b/autumn/src/security/rate_limit.rs
@@ -568,7 +568,7 @@ impl Limiter {
         #[cfg(feature = "redis")]
         if config.backend == RateLimitBackend::Redis {
             if let Some(url) = config.redis.url.as_deref().filter(|u| !u.trim().is_empty()) {
-                match redis::Client::open(url) {
+                match crate::redis_tls::open_client(url) {
                     Ok(client) => {
                         match redis::aio::ConnectionManager::new_lazy_with_config(
                             client,
@@ -2448,7 +2448,7 @@ mod tests {
     #[tokio::test]
     async fn redis_store_debug_format() {
         use super::super::config::RateLimitBackendFailure;
-        let client = redis::Client::open("redis://127.0.0.1/").unwrap();
+        let client = crate::redis_tls::open_client("redis://127.0.0.1/").unwrap();
         let connection = redis::aio::ConnectionManager::new_lazy_with_config(
             client,
             redis::aio::ConnectionManagerConfig::new(),

--- a/autumn/src/session.rs
+++ b/autumn/src/session.rs
@@ -615,7 +615,7 @@ impl SessionConfig {
 
                 #[cfg(feature = "redis")]
                 {
-                    if let Err(error) = redis::Client::open(url.clone()) {
+                    if let Err(error) = crate::redis_tls::open_client(&url) {
                         return Err(SessionBackendConfigError::InvalidRedisUrl(
                             error.to_string(),
                         ));

--- a/autumn/src/session_redis.rs
+++ b/autumn/src/session_redis.rs
@@ -43,7 +43,7 @@ impl RedisStore {
             .clone()
             .filter(|url| !url.trim().is_empty())
             .ok_or(SessionBackendConfigError::MissingRedisUrl)?;
-        let client = redis::Client::open(url)
+        let client = crate::redis_tls::open_client(&url)
             .map_err(|error| SessionBackendConfigError::InvalidRedisUrl(error.to_string()))?;
         let connection =
             ConnectionManager::new_lazy_with_config(client, ConnectionManagerConfig::new())
@@ -167,7 +167,7 @@ mod tests {
     async fn redis_store_key_for() {
         let store = RedisStore {
             connection: ConnectionManager::new_lazy_with_config(
-                redis::Client::open("redis://127.0.0.1/").unwrap(),
+                crate::redis_tls::open_client("redis://127.0.0.1/").unwrap(),
                 ConnectionManagerConfig::new(),
             )
             .unwrap(),

--- a/autumn/src/webhook.rs
+++ b/autumn/src/webhook.rs
@@ -826,7 +826,7 @@ impl RedisWebhookReplayStore {
             .as_deref()
             .filter(|url| !url.trim().is_empty())
             .ok_or(WebhookConfigError::RedisReplayMissingUrl)?;
-        let client = redis::Client::open(url)
+        let client = crate::redis_tls::open_client(url)
             .map_err(|error| WebhookConfigError::RedisReplayInvalidUrl(error.to_string()))?;
         let connection = redis::aio::ConnectionManager::new_lazy_with_config(
             client,
@@ -1617,7 +1617,7 @@ fn validate_redis_replay_config(
 
     #[cfg(feature = "redis")]
     {
-        redis::Client::open(url)
+        crate::redis_tls::open_client(url)
             .map_err(|error| WebhookConfigError::RedisReplayInvalidUrl(error.to_string()))?;
         Ok(())
     }

--- a/docs/guide/cloud-native.md
+++ b/docs/guide/cloud-native.md
@@ -200,6 +200,9 @@ key_prefix = "my-app:sessions"
 The `prod` profile warns when you keep `backend = "memory"` without explicitly
 acknowledging it via `session.allow_memory_in_production = true`.
 
+A managed Redis that only exposes a TLS port takes a `rediss://` URL here —
+see [Redis over TLS](#redis-over-tls-rediss).
+
 ## Mail
 
 The `mail` cargo feature gives apps a `Mailer` extractor and log/file/SMTP
@@ -629,6 +632,31 @@ For read-through fills that coalesce concurrent misses into a single
 recompute (in-process single-flight, plus an opt-in distributed fill lock and
 stale-while-revalidate on the Redis backend), see [Cache Stampede
 Protection](cache-stampede.md).
+
+## Redis over TLS (`rediss://`)
+
+Managed Redis usually speaks TLS and often speaks *only* TLS. Azure Cache for
+Redis provisioned by `autumn release init --target azure-container-apps` sets
+`non_ssl_port_enabled = false`, and ElastiCache with transit encryption on
+behaves the same way, so the only URL you get is a `rediss://` one.
+
+Every Redis-backed subsystem accepts it — sessions, channels, jobs, job
+tracking, idempotency, webhook replay, rate limiting, and the
+`autumn-cache-redis` cache:
+
+```toml
+[session.redis]
+url = "rediss://:<access-key>@my-cache.redis.cache.windows.net:6380"
+```
+
+Valkey's `valkeys://` scheme works the same way. No extra Cargo feature is
+needed; TLS support is compiled in.
+
+Autumn installs the process-wide rustls `CryptoProvider` (`ring`) that the
+`redis` crate's TLS transport requires, once and only for TLS URLs. If your
+application installs its own provider — for example `aws-lc-rs` — install it
+before serving starts and Autumn keeps yours. A plaintext `redis://` URL never
+claims the default, so it cannot pre-empt that choice.
 
 ## Concurrent Writes
 

--- a/examples/reddit-clone/src/live_events.rs
+++ b/examples/reddit-clone/src/live_events.rs
@@ -414,7 +414,11 @@ impl LiveEventBusPublisher {
                         "distributed.live_feed_bus.redis_url is required when kind = redis_pubsub",
                     )
                 })?;
-                let client = redis::Client::open(redis_url)
+                // `open_client`, not `redis::Client::open`: a `rediss://` URL
+                // (Azure Redis Cache only offers TLS) panics inside rustls
+                // unless a process-level CryptoProvider is installed first.
+                // See `autumn_web::redis_tls` and issue #2172.
+                let client = autumn_web::redis_tls::open_client(redis_url)
                     .map_err(|error| AutumnError::service_unavailable_msg(error.to_string()))?;
                 LiveEventBusPublisherInner::RedisPubSub {
                     channel: config.channel.clone(),
@@ -719,7 +723,7 @@ async fn connect_redis_live_event_listener(
         warn!("distributed.live_feed_bus.redis_url is missing; falling back to polling");
         return None;
     };
-    match redis::Client::open(redis_url) {
+    match autumn_web::redis_tls::open_client(redis_url) {
         Ok(client) => setup_redis_pubsub(client, channel).await,
         Err(error) => {
             warn!(
@@ -1245,6 +1249,33 @@ fn rebroadcast_row(state: &AppState, row: &LiveFeedEventRow) {
 
 #[cfg(test)]
 mod tests {
+    /// The live-feed bus must open its Redis clients through
+    /// `autumn_web::redis_tls::open_client`. A managed Redis (Azure Redis
+    /// Cache, ElastiCache with transit encryption) only offers `rediss://`,
+    /// and a bare `redis::Client::open` on that scheme panics inside rustls
+    /// unless a process-level `CryptoProvider` was installed first (#2172).
+    /// Examples get copied, so the wrong pattern must not survive here.
+    #[test]
+    fn redis_clients_are_opened_through_the_shared_tls_guard() {
+        // Split so the needle does not match this test's own source line.
+        let needle = concat!("redis::Client::", "open(");
+        let offenders: Vec<_> = include_str!("live_events.rs")
+            .lines()
+            .enumerate()
+            .filter(|(_, line)| {
+                let trimmed = line.trim_start();
+                !trimmed.starts_with("//") && line.contains(needle)
+            })
+            .map(|(index, line)| format!("live_events.rs:{}: {}", index + 1, line.trim()))
+            .collect();
+        assert!(
+            offenders.is_empty(),
+            "use `autumn_web::redis_tls::open_client` so a `rediss://` URL \
+             cannot panic inside rustls (#2172):\n{}",
+            offenders.join("\n")
+        );
+    }
+
     use std::collections::VecDeque;
     use std::sync::Arc;
     use std::sync::Mutex;


### PR DESCRIPTION
Closes #2172.

## The gap the issue actually names

#2172's title points at `autumn-cache-redis`, and a fix landed there. But the issue's body makes the broader claim:

> If no `CryptoProvider` is ever installed elsewhere in the process before this runs, a real `azure-container-apps` deployment would hit the same panic on startup, not just this unit test.

That hazard was still live in **seven other places**. `redis`'s `tokio-rustls-comp` builds its TLS `ClientConfig` through the short-form `rustls::ClientConfig::builder()`, which *panics* rather than erroring when it cannot resolve a process-level `CryptoProvider` — and rustls only resolves one implicitly while exactly one of its `ring`/`aws-lc-rs` features is enabled, which Cargo's whole-graph feature unification can break from any dependency (`telemetry-otlp` alone is enough).

Only the cache crate guarded against it. Every other Redis client in the framework opened its own:

| Subsystem | Site |
|---|---|
| Channels / pub-sub | `autumn/src/channels.rs:997` |
| Job queue | `autumn/src/job.rs:7651` |
| Job tracking | `autumn/src/job_tracking.rs:1393` |
| Idempotency | `autumn/src/idempotency.rs:627` |
| Sessions | `autumn/src/session_redis.rs:46` |
| Webhook replay | `autumn/src/webhook.rs:829` |
| Rate limiting | `autumn/src/security/rate_limit.rs:571` |

…plus session-config URL validation (`session.rs:618`) and the reddit-clone live-feed bus. `autumn`'s `redis` feature did not even pull `rustls`, so there was nothing there to install one.

This is not theoretical. The `azure-container-apps` release target provisions a Redis Cache with `non_ssl_port_enabled = false` — it can only ever hand the app a `rediss://` URL. An operator pointing `AUTUMN_SESSION__REDIS__URL` at that same instance crashed the app on boot.

## The fix

A single seam, `autumn_web::redis_tls`:

- **`url_needs_tls_crypto_provider`** asks the `redis` crate to parse the URL and reports whether it resolved to a `ConnectionAddr::TcpTls`, rather than matching schemes by hand. The hand-rolled predicate this replaces (`starts_with("rediss://")`) is *how this bug class recurs* — it had already shipped once missing Valkey's `valkeys://` and every case variant. Deriving the answer from the dependency's own scheme table leaves nothing to keep in sync.
- **`ensure_tls_crypto_provider`** installs `ring` once, only for TLS URLs, and never replaces a provider the application installed itself. A plaintext `redis://` URL deliberately does **not** claim the process-wide default, so it cannot pre-empt an app that installs `aws-lc-rs` for something else.
- **`open_client`** is the sanctioned `redis::Client` constructor. Every site above now goes through it.

`autumn-cache-redis` delegates to the same seam and drops its own `rustls` dependency and duplicate scheme check. The `redis` feature now pulls `dep:rustls`, so a `redis`-only build (no `db`/`tls`) has a provider to install.

## TDD

Developed red → green → refactor, one commit per phase boundary.

**Red** (`d706d38`) — 7 failing, 1 passing:

- A **source scan** asserting no `Client::open(` outside the guard. This is the only thing that can see a *missing* call at a future subsystem's call site — which is exactly the regression the issue describes — and the only coverage for `job::start_redis_runtime` (needs a live `AppState`) and session-config URL validation. It named all 12 unguarded sites.
- Six **`rusty_fork_test!` scenarios**, one forked process each, driving the real constructors with a `rediss://` URL and asserting a provider is left installed. Forked because installing one is a one-shot process global: a second in-process assertion would pass no matter which subsystem installed it. Each scenario first asserts the fresh process starts with *no* provider, so it cannot pass vacuously.
- A **negative scenario** pinning that a plaintext `redis://` URL leaves the global unset. This one passed in the red phase and had to keep passing — it is what stops the fix from over-reaching.

**Green + refactor** (`22df189`) — 14 passing.

## Verification

```
cargo test -p autumn-web --features "redis,ws" --lib redis_tls
    14 passed; 0 failed

cargo test -p autumn-cache-redis --lib
    7 passed; 0 failed; 10 ignored (Docker)

cargo clippy -p autumn-web --features "redis,ws" --all-targets -- -D warnings
    clean

cargo check -p autumn-web --no-default-features --features redis
    clean

./scripts/check-docs.sh
    clean
```

`./scripts/pre-push-check.sh` was still running when this PR was opened; CI is the authority and I'll act on anything it reports.

## Docs

New "Redis over TLS (`rediss://`)" section in `docs/guide/cloud-native.md`, cross-referenced from Sessions, plus a `CHANGELOG.md` entry under the existing `## [Unreleased]` → `### Fixed`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TtdpVBMaio7TcPQRWZkbcG)_