### PR TITLE
🔐 Redact Redis URL credentials, and close the review gaps in #2401 (#2172)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -228,6 +228,39 @@ jobs:
         run: |
           cargo test -p autumn-web --features i18n --lib i18n::
           cargo test -p autumn-web --features "i18n,test-support" --test integration_tests translatable
+      - name: Run redis-TLS-gated tests (rediss:// CryptoProvider guard)
+        # `redis` and `ws` are not `autumn-web` default features. The
+        # workspace `cargo test` above happens to compile this suite anyway,
+        # because resolver-3 feature unification pulls `redis` in from
+        # `autumn-cache-redis`/`autumn-cli` and `ws` from the `reddit-clone`
+        # example — a coincidence of what other members want, not anything
+        # this suite asks for. Drop `ws` from that example and the channels
+        # scenario silently stops existing; drop `redis` and the whole module
+        # does, with `cargo test --workspace` still green and zero coverage of
+        # the guard.
+        #
+        # That guard is the only thing standing between a `rediss://` URL and
+        # a startup panic (#2172), and the azure-container-apps target hands
+        # apps nothing else. So it gets its own explicitly-featured run, with
+        # the same non-zero-pass-count check the TLS/ACME lanes use: `cargo
+        # test` exits 0 when a filter matches nothing.
+        #
+        # Linux only: the assertions are about process-global state and fork
+        # isolation, neither of which is platform-specific, and `rusty_fork`
+        # re-execs the test binary — cheapest on the fast runner.
+        if: runner.os == 'Linux'
+        run: |
+          set -euo pipefail
+          assert_ran() {
+            grep -qE 'test result: ok\. [1-9][0-9]* passed' "$1" \
+              || { echo "::error::no tests ran for $2 — the suite is no longer compiled in"; exit 1; }
+          }
+          cargo test -p autumn-web --features "redis,ws" --lib redis_tls:: \
+            | tee "${RUNNER_TEMP}/redis-tls.log"
+          assert_ran "${RUNNER_TEMP}/redis-tls.log" "autumn-web redis_tls unit tests"
+          cargo test -p autumn-cache-redis --lib \
+            | tee "${RUNNER_TEMP}/cache-redis.log"
+          assert_ran "${RUNNER_TEMP}/cache-redis.log" "autumn-cache-redis unit tests"
       - name: Run direct-TLS (HTTPS) tests
         # `tls` is not a default feature, so the workspace `cargo test` above
         # compiles neither `tls`'s in-module suite nor the `[server.tls]`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -472,6 +472,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   report a divergence against unchanged code; and outbound request and response
   headers are charged against `max_capsule_bytes`, which they had escaped.
 
+- **`autumn_web::redis_tls` (new public module):** `open_client` is the
+  Redis client constructor every Autumn subsystem now uses — it installs the
+  rustls `CryptoProvider` a `rediss://` URL needs before rustls can be asked
+  to resolve one. `ensure_tls_crypto_provider` exposes just that step for code
+  that builds a client another way, and `redact_url` masks the password in a
+  Redis URL before it is logged. `redis` is re-exported as
+  `autumn_web::reexports::redis` so callers can name the returned
+  `redis::Client` without adding their own dependency. Issue #2172.
+
 ### Fixed
 
 - **`rediss://` no longer panics at startup, in any Redis-backed subsystem
@@ -492,15 +501,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `autumn_web::redis_tls::open_client`, which installs `ring` once,
   idempotently, and only when the URL is a TLS one — decided by asking the
   `redis` crate to parse it and checking whether it resolved to a TLS address,
-  so `rediss://`, Valkey's `valkeys://` and any case variant the URL parser
-  accepts are all covered without a scheme list to keep in sync. (The previous
-  `starts_with("rediss://")` check had already missed both.) A plaintext
+  rather than by keeping a second copy of that crate's scheme table. So
+  `rediss://`, Valkey's `valkeys://` and every case variant the URL parser
+  accepts are covered with nothing to re-check on a dependency bump, and
+  prefix lookalikes (`redisstore://`), `unix://` sockets and unparseable input
+  are classified exactly as the connector will classify them. A plaintext
   `redis://` URL deliberately does **not** claim the process-wide default, so
   it cannot pre-empt an application that installs `aws-lc-rs` for something
   else, and an already-installed provider is always kept rather than replaced.
   `autumn-cache-redis` now delegates to the same guard instead of carrying its
-  own copy, and a source scan in each crate keeps a future subsystem from
-  re-opening the hole with a bare `redis::Client::open`.
+  own copy, the `reddit-clone` example is wired through it too (examples get
+  copied), and a source scan in each of the three crates keeps a future
+  subsystem from re-opening the hole with a bare `redis::Client::open`.
+
+  Redis URLs are no longer logged verbatim. A managed Redis carries its access
+  key *inside* the URL, and the rate-limit backend echoed the configured URL
+  into a `WARN` on both of its fallback-to-memory paths — writing that key to
+  whatever log sink the app ships to. `autumn_web::redis_tls::redact_url`
+  masks the password, and deliberately over-redacts rather than under-redacts:
+  an Azure access key is base64, whose alphabet includes `/`, and an
+  un-encoded `/` is exactly what makes such a URL fail to parse and reach that
+  log line in the first place.
 
 - **A container that terminates TLS itself is no longer permanently
   `unhealthy`:** the Dockerfile `autumn release init` generates hardcoded its

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -518,10 +518,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   key *inside* the URL, and the rate-limit backend echoed the configured URL
   into a `WARN` on both of its fallback-to-memory paths — writing that key to
   whatever log sink the app ships to. `autumn_web::redis_tls::redact_url`
-  masks the password, and deliberately over-redacts rather than under-redacts:
-  an Azure access key is base64, whose alphabet includes `/`, and an
-  un-encoded `/` is exactly what makes such a URL fail to parse and reach that
-  log line in the first place.
+  masks the password, and deliberately over-redacts rather than under-redacts.
+  Every input it sees on that path is malformed by definition, and malformed
+  is exactly where a redactor gives up: an Azure access key is base64, whose
+  alphabet includes `/`, and an un-encoded `/` ends the URL's authority early
+  — which is both why the URL fails to parse and why the log line is reached.
+  A mistyped scheme delimiter (`rediss:/:key@host`) leaves nothing to split
+  on at all. Neither returns the input untouched. The invalid-URL branch now
+  also logs no URL whatsoever, redacted or not: the `redis` error names the
+  problem without echoing the value.
 
 - **A container that terminates TLS itself is no longer permanently
   `unhealthy`:** the Dockerfile `autumn release init` generates hardcoded its

--- a/autumn-cache-redis/src/lib.rs
+++ b/autumn-cache-redis/src/lib.rs
@@ -501,38 +501,66 @@ mod tests {
         assert_eq!(ttl_millis_for_redis(std::time::Duration::ZERO), 1);
     }
 
-    /// This crate must not open its own Redis client: `RedisCache::connect`
+    /// This crate must not build its own Redis client: `RedisCache::connect`
     /// goes through `autumn_web::redis_tls::open_client`, which installs the
     /// process-level rustls `CryptoProvider` a `rediss://` URL needs before
-    /// rustls is asked to resolve one (#2172). Mirrors the identical scan in
-    /// `autumn_web::redis_tls` so the two crates cannot drift — a second,
-    /// hand-rolled install here is exactly how the `valkeys://` and
-    /// case-insensitivity gaps got fixed in one place and missed in another.
+    /// rustls is asked to resolve one (#2172). A second, hand-rolled install
+    /// here is exactly how one copy of this logic drifts from the other.
+    ///
+    /// Walks `src/` rather than scanning `lib.rs` alone: the crate is a
+    /// single file today, and a scan that silently stops covering the crate
+    /// the day a second module appears is the drift it exists to prevent.
     #[test]
-    fn the_cache_never_opens_a_redis_client_outside_the_shared_tls_guard() {
-        // Split so the needle does not match this test's own source line.
-        let needle = concat!("Client::", "open(");
-        let source = include_str!("lib.rs");
-        let offenders: Vec<_> = source
-            .lines()
-            .enumerate()
-            .filter(|(_, line)| {
+    fn the_cache_never_builds_a_redis_client_outside_the_shared_tls_guard() {
+        // Split so the needles do not match this declaration.
+        let needles = [concat!("Client::", "open("), concat!("build_with", "_tls(")];
+        let src = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
+        let mut files = Vec::new();
+        collect_rust_sources(&src, &mut files);
+        assert!(!files.is_empty(), "no sources under {}", src.display());
+        files.sort();
+
+        let mut offenders = Vec::new();
+        for file in files {
+            let source = std::fs::read_to_string(&file).expect("read source");
+            for (index, line) in source.lines().enumerate() {
                 let trimmed = line.trim_start();
-                !trimmed.starts_with("//") && !trimmed.starts_with('*') && line.contains(needle)
-            })
-            .map(|(index, line)| format!("lib.rs:{}: {}", index + 1, line.trim()))
-            .collect();
+                if trimmed.starts_with("//") || trimmed.starts_with('*') {
+                    continue;
+                }
+                if needles.iter().any(|needle| line.contains(needle)) {
+                    offenders.push(format!(
+                        "{}:{}: {}",
+                        file.strip_prefix(&src).unwrap_or(&file).display(),
+                        index + 1,
+                        line.trim()
+                    ));
+                }
+            }
+        }
         assert!(
             offenders.is_empty(),
-            "open Redis clients through `autumn_web::redis_tls::open_client`, \
+            "build Redis clients through `autumn_web::redis_tls::open_client`, \
              not directly — a `rediss://` URL otherwise reaches rustls with no \
              process-level CryptoProvider installed and panics (#2172):\n{}",
             offenders.join("\n")
         );
     }
 
-    /// The TLS scheme classification itself is `autumn_web::redis_tls`'s
-    /// contract; this only pins that this crate is wired to the same one.
+    /// Recursively collect every `.rs` file under `dir`.
+    fn collect_rust_sources(dir: &std::path::Path, out: &mut Vec<std::path::PathBuf>) {
+        for entry in std::fs::read_dir(dir).expect("read_dir") {
+            let path = entry.expect("dir entry").path();
+            if path.is_dir() {
+                collect_rust_sources(&path, out);
+            } else if path.extension().is_some_and(|ext| ext == "rs") {
+                out.push(path);
+            }
+        }
+    }
+
+    /// The TLS classification itself is `autumn_web::redis_tls`'s contract;
+    /// this only pins that this crate is wired to the same one.
     #[test]
     fn the_shared_guard_classifies_the_tls_schemes_this_cache_is_deployed_on() {
         assert!(autumn_web::redis_tls::url_needs_tls_crypto_provider(

--- a/autumn/src/lib.rs
+++ b/autumn/src/lib.rs
@@ -1767,6 +1767,7 @@ pub use axum::extract::State;
 /// | `axum` | `autumn_web::reexports::axum` | Custom routers, middleware, extractors |
 /// | `diesel` | `autumn_web::reexports::diesel` | Raw Diesel queries, schema types |
 /// | `http` | `autumn_web::reexports::http` | HTTP types (`StatusCode`, `Method`, headers) |
+/// | `redis` | `autumn_web::reexports::redis` | Naming the `redis::Client` [`redis_tls::open_client`] returns (`redis` feature) |
 /// | `serde_json` | `autumn_web::reexports::serde_json` | JSON values and conversion helpers |
 /// | `tokio` | `autumn_web::reexports::tokio` | Async runtime, spawn, timers |
 pub mod reexports {
@@ -1780,6 +1781,12 @@ pub mod reexports {
     pub use inventory;
     #[cfg(feature = "mail")]
     pub use lettre;
+    /// Re-exported because [`crate::redis_tls::open_client`] returns a
+    /// `redis::Client`: without this, an app calling it cannot name the
+    /// returned type without adding its own `redis` dependency at a
+    /// compatible major.
+    #[cfg(feature = "redis")]
+    pub use redis;
     pub use rust_decimal;
     #[cfg(feature = "db")]
     pub use scoped_futures;

--- a/autumn/src/redis_tls.rs
+++ b/autumn/src/redis_tls.rs
@@ -27,11 +27,15 @@
 ///
 /// Answered by asking the `redis` crate to parse the URL and reporting
 /// whether it resolved to a TLS address, rather than by matching schemes
-/// here. That distinction matters: the first cut of this check lived in
-/// `autumn-cache-redis` as `starts_with("rediss://")`, which silently missed
-/// Valkey's `valkeys://` and any case variant the URL parser accepts. Reusing
-/// `redis`'s own scheme table means a scheme it learns to treat as TLS is
-/// covered the day the dependency is bumped, with nothing to keep in sync.
+/// here. The check this replaces (in `autumn-cache-redis`) matched
+/// `rediss`/`valkeys` case-insensitively by hand — correct for the schemes
+/// `redis` treats as TLS *today*, but a second copy of a table owned by a
+/// dependency, which only stays correct for as long as someone remembers to
+/// re-check it on every bump. Reusing `redis`'s own parser means there is
+/// nothing to keep in sync, and it settles the surrounding cases for free: a
+/// prefix lookalike (`redisstore://`), a `unix://` socket, and input `redis`
+/// cannot parse at all are each classified the same way the connector will
+/// classify them, because it is the same code.
 ///
 /// A plain `redis://`/`valkey://` URL never touches TLS, so it must **not**
 /// claim the process-wide default: doing so could pre-empt a later, unrelated
@@ -66,12 +70,63 @@ pub fn ensure_tls_crypto_provider(url: &str) {
     }
 }
 
+/// A copy of `url` with any password in its userinfo replaced by `***`,
+/// for logging.
+///
+/// A managed Redis hands out its credential *inside* the URL — the
+/// `azure-container-apps` target's generated
+/// `rediss://:<access-key>@<name>.redis.cache.windows.net:6380` is the shape
+/// this framework's own docs tell operators to configure — so a diagnostic
+/// that echoes the configured URL verbatim writes that key into whatever log
+/// sink the app ships to. Anything that logs a Redis URL must log this
+/// instead.
+///
+/// Deliberately textual rather than a re-parse: this also runs on the failure
+/// path for URLs `redis` has just refused to parse, and a redaction that
+/// returns nothing for malformed input is worse than one that leaves a
+/// malformed string alone.
+///
+/// It over-redacts rather than under-redacts, which is the whole point on that
+/// failure path. An Azure access key is 44 characters of base64 whose alphabet
+/// includes `/`; pasted into a URL without percent-encoding, that `/` ends the
+/// authority early, which is *why* the URL failed to parse — and an
+/// authority-scoped search for the userinfo would then find no `@`, and hand
+/// the untouched key straight to the log. So when the authority holds no `@`,
+/// the search widens to the whole remainder: mistaking a path segment for a
+/// credential costs an ugly log line, missing a credential costs the
+/// credential.
+#[must_use]
+pub fn redact_url(url: &str) -> String {
+    let Some((scheme, rest)) = url.split_once("://") else {
+        return url.to_owned();
+    };
+    // Userinfo is everything before the LAST `@` in the authority, since a
+    // password may itself contain one. The authority runs to the first `/`,
+    // `?` or `#` — but for a URL that failed to parse, that terminator may
+    // itself be an un-encoded character *inside* the password, so fall back to
+    // the last `@` anywhere in the remainder rather than concluding there is
+    // no credential to hide.
+    let authority_end = rest.find(['/', '?', '#']).unwrap_or(rest.len());
+    let Some(at) = rest[..authority_end].rfind('@').or_else(|| rest.rfind('@')) else {
+        return url.to_owned();
+    };
+    // `rest_from_at` keeps the `@` and everything after it (host, port, path).
+    let (userinfo, rest_from_at) = rest.split_at(at);
+    let userinfo = match userinfo.split_once(':') {
+        Some((user, _)) => format!("{user}:***"),
+        // A bare username carries no secret; inventing a `:***` would imply
+        // a password that is not there.
+        None => userinfo.to_owned(),
+    };
+    format!("{scheme}://{userinfo}{rest_from_at}")
+}
+
 /// Open a Redis client, installing the rustls `CryptoProvider` first when
 /// `url` is a TLS (`rediss://` / `valkeys://`) endpoint.
 ///
-/// The only sanctioned way to build a [`redis::Client`] in this crate — a
-/// unit test scans `src/` to keep it that way. See the module docs for why a
-/// bare `redis::Client::open` is a latent startup panic (#2172).
+/// The only sanctioned way to build a [`redis::Client`] in this crate's
+/// `src/`, which a unit test scans to keep it that way. See the module docs
+/// for why a bare `redis::Client::open` is a latent startup panic (#2172).
 ///
 /// # Errors
 ///
@@ -86,7 +141,9 @@ pub fn open_client(url: &str) -> redis::RedisResult<redis::Client> {
 mod tests {
     use std::path::{Path, PathBuf};
 
-    use super::{open_client, url_needs_tls_crypto_provider};
+    use super::{
+        ensure_tls_crypto_provider, open_client, redact_url, url_needs_tls_crypto_provider,
+    };
 
     use rusty_fork::rusty_fork_test;
 
@@ -152,6 +209,95 @@ mod tests {
         assert!(open_client("not a redis url").is_err());
     }
 
+    #[test]
+    fn redact_url_hides_the_password_but_keeps_the_endpoint_readable() {
+        // The shape `autumn release init --target azure-container-apps`
+        // generates: no username, the access key as the password.
+        assert_eq!(
+            redact_url("rediss://:s3cr3t-key@cache.redis.cache.windows.net:6380"),
+            "rediss://:***@cache.redis.cache.windows.net:6380"
+        );
+        assert_eq!(
+            redact_url("redis://user:s3cr3t@host:6379/0"),
+            "redis://user:***@host:6379/0"
+        );
+    }
+
+    #[test]
+    fn redact_url_leaves_urls_without_a_password_alone() {
+        assert_eq!(
+            redact_url("redis://127.0.0.1:6379/"),
+            "redis://127.0.0.1:6379/"
+        );
+        // A bare username is not a secret.
+        assert_eq!(
+            redact_url("redis://user@host:6379"),
+            "redis://user@host:6379"
+        );
+        assert_eq!(
+            redact_url("unix:///run/redis.sock"),
+            "unix:///run/redis.sock"
+        );
+        assert_eq!(redact_url("garbage"), "garbage");
+        assert_eq!(redact_url(""), "");
+    }
+
+    #[test]
+    fn redact_url_is_not_fooled_by_an_at_sign_in_the_password() {
+        // The LAST `@` in the authority separates userinfo from host, so a
+        // password containing one still redacts whole.
+        assert_eq!(
+            redact_url("rediss://user:p@ss@host:6380/0"),
+            "rediss://user:***@host:6380/0"
+        );
+    }
+
+    #[test]
+    fn redact_url_hides_a_key_whose_own_slash_broke_the_url() {
+        // The regression this helper exists for. An Azure access key is
+        // base64, whose alphabet includes `/`. Pasted un-encoded, that `/`
+        // terminates the authority early — which is exactly why `redis`
+        // rejects the URL and why the log line that leaks it gets reached.
+        // An authority-scoped search would find no `@` here and hand the key
+        // to the log verbatim; widening to the last `@` in the remainder
+        // hides it.
+        let leaked = "rediss://:8kQz+Ab/CdEfGh=@my-cache.redis.cache.windows.net:6380";
+        let redacted = redact_url(leaked);
+        assert!(
+            !redacted.contains("8kQz+Ab") && !redacted.contains("CdEfGh"),
+            "the access key survived redaction: {redacted}"
+        );
+        assert!(redacted.contains("my-cache.redis.cache.windows.net"));
+    }
+
+    #[test]
+    fn redact_url_handles_query_and_fragment_authority_terminators() {
+        assert_eq!(
+            redact_url("rediss://user:secret@host:6380/0?foo=bar"),
+            "rediss://user:***@host:6380/0?foo=bar"
+        );
+        assert_eq!(
+            redact_url("rediss://user:secret@host:6380/0#insecure"),
+            "rediss://user:***@host:6380/0#insecure"
+        );
+    }
+
+    #[test]
+    fn redact_url_over_redacts_rather_than_leaking() {
+        // An `@` in the path of a credential-free URL makes the widened
+        // search treat the text before it as userinfo. Over-redaction is the
+        // deliberate trade: an ugly log line beats a leaked key. Nothing is
+        // rewritten when there is no colon to hide a password behind.
+        assert_eq!(redact_url("redis://host/a@b"), "redis://host/a@b");
+        assert_eq!(redact_url("redis://host:6379/db@1"), "redis://host:***@1");
+    }
+
+    /// The `redis::Client` constructors that can reach rustls. `open` is the
+    /// one every subsystem uses; `build_with_tls` is a second, equally
+    /// panic-prone door into `ClientConfig::builder()`. Split so the needles
+    /// do not match this declaration.
+    const NEEDLES: [&str; 2] = [concat!("Client::", "open("), concat!("build_with", "_tls(")];
+
     /// Recursively collect every `.rs` file under `dir`.
     fn rust_sources(dir: &Path, out: &mut Vec<PathBuf>) {
         for entry in std::fs::read_dir(dir).expect("read_dir") {
@@ -172,9 +318,13 @@ mod tests {
     /// because the failure mode is a *missing* call: a new Redis-backed
     /// subsystem that opens its own client is exactly the regression #2172
     /// describes, and no runtime test of the subsystems that exist today can
-    /// see it. It also covers the two sites a runtime test cannot reach
-    /// cheaply — `job::start_redis_runtime` (needs a live `AppState`) and
-    /// `session::resolve_backend_plan`'s URL validation.
+    /// see it. It is also the only coverage for the two sites a runtime test
+    /// cannot reach cheaply — `job::start_redis_runtime` (needs a live
+    /// `AppState`) and `webhook::validate_redis_replay_config` (private).
+    ///
+    /// A substring scan cannot see through an alias (`use redis::Client as
+    /// C; C::open(..)`); it catches the shapes anyone actually writes, and
+    /// the forked scenarios below cover the constructors that exist.
     #[test]
     fn no_redis_client_is_opened_outside_the_tls_guard() {
         let src = Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
@@ -201,7 +351,7 @@ mod tests {
                 if trimmed.starts_with("//") || trimmed.starts_with('*') {
                     continue;
                 }
-                if line.contains("Client::open(") {
+                if NEEDLES.iter().any(|needle| line.contains(needle)) {
                     offenders.push(format!(
                         "{}:{}: {}",
                         file.strip_prefix(&src).unwrap_or(&file).display(),
@@ -214,7 +364,7 @@ mod tests {
 
         assert!(
             offenders.is_empty(),
-            "these sites open a Redis client directly instead of through \
+            "these sites build a Redis client directly instead of through \
              `crate::redis_tls::open_client`, so a `rediss://` URL reaches \
              rustls with no process-level CryptoProvider installed and panics \
              at startup (#2172):\n{}",
@@ -339,6 +489,48 @@ mod tests {
                 let _ = crate::security::rate_limit::RateLimitLayer::from_config(&config);
             });
             assert_provider_installed("the Redis rate-limit backend");
+        }
+
+        /// Config validation touches the `rediss://` URL *before* any store
+        /// is built — `AppBuilder` calls this at startup — so it is the
+        /// earliest place the panic can land, and the one a store-level test
+        /// would never reach.
+        #[test]
+        fn session_config_validation_installs_the_tls_provider() {
+            assert_no_provider_yet();
+            let mut config = crate::session::SessionConfig {
+                backend: crate::session::SessionBackend::Redis,
+                ..Default::default()
+            };
+            config.redis.url = Some(TLS_URL.to_owned());
+            let _ = config.backend_plan(None);
+            assert_provider_installed("session config validation");
+        }
+
+        /// The documented promise that an application's own provider is
+        /// never replaced. Installs a deliberately crippled `ring` (one
+        /// cipher suite), then asserts the guard leaves it alone — a
+        /// refactor to an unconditional install, or to
+        /// `install_default().expect(..)`, fails here.
+        #[test]
+        fn an_application_installed_provider_is_never_replaced() {
+            assert_no_provider_yet();
+            let mut provider = rustls::crypto::ring::default_provider();
+            provider.cipher_suites.truncate(1);
+            provider
+                .install_default()
+                .expect("fresh process: nothing installed yet");
+
+            ensure_tls_crypto_provider(TLS_URL);
+
+            let installed = rustls::crypto::CryptoProvider::get_default()
+                .expect("a provider is installed");
+            assert_eq!(
+                installed.cipher_suites.len(),
+                1,
+                "the guard replaced the application's own CryptoProvider \
+                 instead of keeping it"
+            );
         }
 
         /// The negative half of the guarantee: a plaintext `redis://` URL

--- a/autumn/src/redis_tls.rs
+++ b/autumn/src/redis_tls.rs
@@ -86,20 +86,28 @@ pub fn ensure_tls_crypto_provider(url: &str) {
 /// returns nothing for malformed input is worse than one that leaves a
 /// malformed string alone.
 ///
-/// It over-redacts rather than under-redacts, which is the whole point on that
-/// failure path. An Azure access key is 44 characters of base64 whose alphabet
-/// includes `/`; pasted into a URL without percent-encoding, that `/` ends the
-/// authority early, which is *why* the URL failed to parse — and an
-/// authority-scoped search for the userinfo would then find no `@`, and hand
-/// the untouched key straight to the log. So when the authority holds no `@`,
-/// the search widens to the whole remainder: mistaking a path segment for a
-/// credential costs an ugly log line, missing a credential costs the
-/// credential.
+/// It over-redacts rather than under-redacts, and every early return is
+/// chosen on that basis, because each one is reached by *malformed* input —
+/// which is the only input this ever sees on the failure path.
+///
+/// Two shapes make that concrete. An Azure access key is 44 characters of
+/// base64 whose alphabet includes `/`; pasted without percent-encoding, that
+/// `/` ends the authority early, which is *why* the URL failed to parse — so
+/// an authority-scoped search for the userinfo finds no `@` and would hand
+/// the untouched key to the log. And a mistyped scheme delimiter
+/// (`rediss:/:key@host`) means there is no `://` to split on at all. Neither
+/// may return the input untouched: the search widens to the last `@` anywhere
+/// in the string, and a missing delimiter just means the whole string is
+/// treated as the part that might carry userinfo. Mistaking a path segment
+/// for a credential costs an ugly log line; missing one costs the credential.
 #[must_use]
 pub fn redact_url(url: &str) -> String {
-    let Some((scheme, rest)) = url.split_once("://") else {
-        return url.to_owned();
-    };
+    // A well-formed delimiter splits scheme from the rest; a malformed or
+    // absent one is not grounds to give up — the credential is still in
+    // there, so treat the whole string as potentially carrying userinfo.
+    let (scheme_prefix, rest) = url
+        .split_once("://")
+        .map_or(("", url), |(scheme, rest)| (&url[..scheme.len() + 3], rest));
     // Userinfo is everything before the LAST `@` in the authority, since a
     // password may itself contain one. The authority runs to the first `/`,
     // `?` or `#` — but for a URL that failed to parse, that terminator may
@@ -108,17 +116,20 @@ pub fn redact_url(url: &str) -> String {
     // no credential to hide.
     let authority_end = rest.find(['/', '?', '#']).unwrap_or(rest.len());
     let Some(at) = rest[..authority_end].rfind('@').or_else(|| rest.rfind('@')) else {
+        // No `@` at all: nothing shaped like a credential to hide.
         return url.to_owned();
     };
     // `rest_from_at` keeps the `@` and everything after it (host, port, path).
     let (userinfo, rest_from_at) = rest.split_at(at);
     let userinfo = match userinfo.split_once(':') {
+        // Split on the FIRST colon, not the last: a password may contain one,
+        // and cutting at the last would leave part of it in the clear.
         Some((user, _)) => format!("{user}:***"),
         // A bare username carries no secret; inventing a `:***` would imply
         // a password that is not there.
         None => userinfo.to_owned(),
     };
-    format!("{scheme}://{userinfo}{rest_from_at}")
+    format!("{scheme_prefix}{userinfo}{rest_from_at}")
 }
 
 /// Open a Redis client, installing the rustls `CryptoProvider` first when
@@ -268,6 +279,26 @@ mod tests {
             "the access key survived redaction: {redacted}"
         );
         assert!(redacted.contains("my-cache.redis.cache.windows.net"));
+    }
+
+    #[test]
+    fn redact_url_hides_a_key_behind_a_mistyped_scheme_delimiter() {
+        // Regression (Codex P1 on #2410): a value missing or mistyping `://`
+        // is rejected by `open_client` and therefore lands on the very log
+        // line this helper guards — so bailing out on a missing delimiter
+        // reproduced the whole secret verbatim.
+        for malformed in [
+            "rediss:/:8kQz-secret@cache.redis.cache.windows.net:6380",
+            "rediss:8kQz-secret@cache",
+            "redis:/user:8kQz-secret@host",
+            ":8kQz-secret@host:6380",
+        ] {
+            let redacted = redact_url(malformed);
+            assert!(
+                !redacted.contains("8kQz-secret"),
+                "the secret survived redaction of {malformed:?}: {redacted}"
+            );
+        }
     }
 
     #[test]

--- a/autumn/src/security/rate_limit.rs
+++ b/autumn/src/security/rate_limit.rs
@@ -595,11 +595,14 @@ impl Limiter {
                         }
                     }
                     Err(err) => {
+                        // No `url` field here, redacted or otherwise: this arm
+                        // fires when the URL failed to PARSE, so its shape is
+                        // exactly what a redactor has least purchase on, and
+                        // the `redis` error text names the problem without
+                        // echoing the value. The key is not worth the
+                        // diagnostic (#2172).
                         tracing::warn!(
                             error = %err,
-                            // Redacted: a managed Redis carries its access key
-                            // in the URL (#2172).
-                            url = %crate::redis_tls::redact_url(url),
                             "rate-limit Redis backend: invalid Redis URL; \
                              falling back to memory"
                         );

--- a/autumn/src/security/rate_limit.rs
+++ b/autumn/src/security/rate_limit.rs
@@ -585,7 +585,9 @@ impl Limiter {
                             Err(err) => {
                                 tracing::warn!(
                                     error = %err,
-                                    url = %url,
+                                    // Redacted: a managed Redis carries its
+                                    // access key in the URL (#2172).
+                                    url = %crate::redis_tls::redact_url(url),
                                     "rate-limit Redis backend: failed to create \
                                      connection manager; falling back to memory"
                                 );
@@ -595,7 +597,9 @@ impl Limiter {
                     Err(err) => {
                         tracing::warn!(
                             error = %err,
-                            url = %url,
+                            // Redacted: a managed Redis carries its access key
+                            // in the URL (#2172).
+                            url = %crate::redis_tls::redact_url(url),
                             "rate-limit Redis backend: invalid Redis URL; \
                              falling back to memory"
                         );

--- a/autumn/tests/integration/job_tracking_stores_integration.rs
+++ b/autumn/tests/integration/job_tracking_stores_integration.rs
@@ -85,7 +85,11 @@ async fn redis_backend_persists_tracked_job_and_expires_it() {
     // Query Redis directly, bypassing the JobTrackingStore abstraction, to
     // prove the config-selected backend really is Redis — not the in-memory
     // fallback, which would leave nothing here to find.
-    let client = redis::Client::open(redis_url.clone()).expect("open redis client");
+    // Through the guard, not `redis::Client::open`: this file is outside the
+    // `src/` scan in `autumn_web::redis_tls`, and a bare call left here is a
+    // copy-paste source for the very pattern that scan exists to eradicate
+    // (#2172).
+    let client = autumn_web::redis_tls::open_client(&redis_url).expect("open redis client");
     let mut conn = client
         .get_multiplexed_async_connection()
         .await

--- a/docs/guide/cloud-native.md
+++ b/docs/guide/cloud-native.md
@@ -652,11 +652,22 @@ url = "rediss://:<access-key>@my-cache.redis.cache.windows.net:6380"
 Valkey's `valkeys://` scheme works the same way. No extra Cargo feature is
 needed; TLS support is compiled in.
 
+Certificates are validated against the public CA store. A managed Redis that
+presents a private or provider-internal CA — Google Memorystore, for instance
+— will not validate, which is why `autumn release init --target
+gcp-cloud-run` provisions Memorystore with `transit_encryption_mode =
+"DISABLED"` and keeps the connection inside the VPC instead.
+
 Autumn installs the process-wide rustls `CryptoProvider` (`ring`) that the
 `redis` crate's TLS transport requires, once and only for TLS URLs. If your
 application installs its own provider — for example `aws-lc-rs` — install it
-before serving starts and Autumn keeps yours. A plaintext `redis://` URL never
-claims the default, so it cannot pre-empt that choice.
+at the top of `main`, before the app builder runs: Autumn keeps whatever is
+already installed, and it may reach for one as early as config validation. A
+plaintext `redis://` URL never claims the default, so it cannot pre-empt that
+choice.
+
+Redis URLs carry credentials, so Autumn redacts the password from any URL it
+logs. Do the same in your own code — `autumn_web::redis_tls::redact_url`.
 
 ## Concurrent Writes
 

--- a/docs/guide/deployment.md
+++ b/docs/guide/deployment.md
@@ -1762,6 +1762,11 @@ must *also* depend on the `autumn-cache-redis` crate and register
 silently never read — you'd pay for a Redis instance the app never talks to.
 See [Shared Cache](cloud-native.md#shared-cache) for the three steps.
 
+The generated cache sets `non_ssl_port_enabled = false`, so the URL it hands
+the app is always `rediss://`. That works out of the box — see [Redis over
+TLS](cloud-native.md#redis-over-tls-rediss) — and applies to any other
+subsystem you point at the same instance.
+
 **Resource names are sanitized, not verbatim.** A Cargo package name may
 contain underscores or uppercase letters (both invalid in Container App
 names), so every Container Apps-family resource name (the app, its
@@ -2237,6 +2242,10 @@ crate and register `.plugin(RedisCachePlugin::new())` in `main.rs`, or
 you'd pay for a Redis instance the app never talks to. See
 [Shared Cache](cloud-native.md#shared-cache) for the three steps.
 
+ElastiCache is provisioned with transit encryption on, so the URL is a
+`rediss://` one — see [Redis over
+TLS](cloud-native.md#redis-over-tls-rediss).
+
 **Resource names are sanitized, not verbatim** — the same scheme as Azure
 and App Runner, capped at 20 characters here so the longest suffixed name
 (the `-migrate-tg`-style target group name, if it existed) would still fit
@@ -2455,6 +2464,13 @@ vars alone does nothing: your application must *also* depend on the
 in `main.rs`, or the config is parsed and silently never read — you'd pay
 for a Redis instance the app never talks to. See
 [Shared Cache](cloud-native.md#shared-cache) for the three steps.
+
+Unlike the Azure and AWS targets, this one sets
+`transit_encryption_mode = "DISABLED"` and emits a plaintext `redis://` URL.
+That is deliberate: Memorystore presents a Google-internal CA that Autumn's
+Redis TLS — which trusts the public CA store — will not validate, so
+`SERVER_AUTHENTICATION` would hand the app a URL it can never connect to.
+The connection stays inside your VPC.
 
 **Secret access is scoped per secret, not project-wide.** The runtime
 service account is granted `roles/secretmanager.secretAccessor` on exactly

--- a/examples/reddit-clone/src/live_events.rs
+++ b/examples/reddit-clone/src/live_events.rs
@@ -1257,23 +1257,53 @@ mod tests {
     /// Examples get copied, so the wrong pattern must not survive here.
     #[test]
     fn redis_clients_are_opened_through_the_shared_tls_guard() {
-        // Split so the needle does not match this test's own source line.
-        let needle = concat!("redis::Client::", "open(");
-        let offenders: Vec<_> = include_str!("live_events.rs")
-            .lines()
-            .enumerate()
-            .filter(|(_, line)| {
+        // Split so the needles do not match this declaration. Deliberately
+        // unqualified: `redis` is a direct dependency of this example, so
+        // `use redis::Client;` + `Client::open(..)` is a one-line edit away
+        // and a `redis::`-qualified needle would not see it.
+        let needles = [concat!("Client::", "open("), concat!("build_with", "_tls(")];
+        let src = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
+        let mut files = Vec::new();
+        collect_rust_sources(&src, &mut files);
+        assert!(!files.is_empty(), "no sources under {}", src.display());
+        files.sort();
+
+        let mut offenders = Vec::new();
+        for file in files {
+            let source = std::fs::read_to_string(&file).expect("read source");
+            for (index, line) in source.lines().enumerate() {
                 let trimmed = line.trim_start();
-                !trimmed.starts_with("//") && line.contains(needle)
-            })
-            .map(|(index, line)| format!("live_events.rs:{}: {}", index + 1, line.trim()))
-            .collect();
+                if trimmed.starts_with("//") || trimmed.starts_with('*') {
+                    continue;
+                }
+                if needles.iter().any(|needle| line.contains(needle)) {
+                    offenders.push(format!(
+                        "{}:{}: {}",
+                        file.strip_prefix(&src).unwrap_or(&file).display(),
+                        index + 1,
+                        line.trim()
+                    ));
+                }
+            }
+        }
         assert!(
             offenders.is_empty(),
             "use `autumn_web::redis_tls::open_client` so a `rediss://` URL \
              cannot panic inside rustls (#2172):\n{}",
             offenders.join("\n")
         );
+    }
+
+    /// Recursively collect every `.rs` file under `dir`.
+    fn collect_rust_sources(dir: &std::path::Path, out: &mut Vec<std::path::PathBuf>) {
+        for entry in std::fs::read_dir(dir).expect("read_dir") {
+            let path = entry.expect("dir entry").path();
+            if path.is_dir() {
+                collect_rust_sources(&path, out);
+            } else if path.extension().is_some_and(|ext| ext == "rs") {
+                out.push(path);
+            }
+        }
     }
 
     use std::collections::VecDeque;

--- a/skills/autumn-web/references/api-reference.md
+++ b/skills/autumn-web/references/api-reference.md
@@ -1163,7 +1163,7 @@ telemetry-otlp = [
     "dep:opentelemetry-otlp",
     "dep:tracing-opentelemetry",
 ]
-redis = ["dep:redis"]
+redis = ["dep:redis", "dep:rustls"]
 i18n = []
 storage = ["diesel?/serde_json"]
 mail = ["dep:lettre", "maud"]
@@ -1203,7 +1203,7 @@ tracing-opentelemetry = "0.32.1"
 opentelemetry = { version = "0.31.0", default-features = false, features = ["trace"] }
 opentelemetry_sdk = { version = "0.31.0", default-features = false, features = ["trace"] }
 opentelemetry-otlp = { version = "0.31.0", default-features = false, features = ["trace", "grpc-tonic", "http-proto", "reqwest-client"] }
-redis = { version = "1.2.0", default-features = false, features = ["aio", "tokio-comp", "connection-manager", "script"] }
+redis = { version = "1.2.0", default-features = false, features = ["aio", "tokio-comp", "connection-manager", "script", "tokio-rustls-comp"] }
 tokio-cron-scheduler = { version = "0.15", features = ["signal"] }
 chrono-tz = "0.10"
 validator = { version = "0.20", features = ["derive"] }


### PR DESCRIPTION
Follow-up to #2401, which merged before these changes were ready. Same issue (#2172), new PR — a merged PR cannot take further commits.

## The substantive fix: a Redis access key was being written to logs

A managed Redis carries its credential *inside* the URL. That is the exact shape #2401's own new documentation tells operators to configure:

```toml
url = "rediss://:ACCESS-KEY@my-cache.redis.cache.windows.net:6380"
```

The rate-limit backend echoed the configured URL into a `WARN` on both of its fallback-to-memory paths (`security/rate_limit.rs:588,598`), so a typo or an unreachable cache wrote that key into whatever log sink the app ships to. The logging predates #2401; what #2401 changed is the likelihood the URL carries a secret at all.

`redis_tls::redact_url` masks the password. The interesting part is that it **deliberately over-redacts**, and that this took two passes to get right — both failures being the same mistake:

This helper only ever runs on the failure path, so *every* input it sees is malformed by definition. Yet the first two cuts each bailed out whenever the input looked malformed, which is precisely backwards.

- An Azure access key is 44 characters of base64, and that alphabet includes `/`. Pasted without percent-encoding, that `/` terminates the URL's authority early — simultaneously *why* `redis` rejects the URL and *why* the logging branch is reached. An authority-scoped search for the userinfo therefore found no `@` on exactly the inputs that get logged.
- A mistyped scheme delimiter (`rediss:/:key@host`) left `split_once("://")` with nothing to split on, and the early return reproduced the whole secret. (Caught by Codex as a P1 on the first commit here; fixed in `73f29ad`.)

Neither now returns the input untouched: the search for the `@` widens to the whole string, and a missing delimiter just means the entire value is treated as potentially carrying userinfo. Mistaking a path segment for a credential costs an ugly log line; the other direction costs the key. Belt and braces, the invalid-URL branch now logs **no** URL at all — a value malformed enough to fail parsing is where a redactor has least purchase, and the `redis` error names the problem without echoing it. The connection-manager branch keeps the redacted URL, since a URL that got that far did parse.

`redact_url_hides_a_key_whose_own_slash_broke_the_url` and `redact_url_hides_a_key_behind_a_mistyped_scheme_delimiter` pin both classes.

## A correction to #2401

Its changelog and module docs claimed the check being replaced was `starts_with("rediss://")`, which "had already missed" `valkeys://` and case variants.

That is false, and I wrote it. `trunk-dev` carried:

```rust
let scheme = url.split_once("://").map_or("", |(scheme, _)| scheme);
scheme.eq_ignore_ascii_case("rediss") || scheme.eq_ignore_ascii_case("valkeys")
```

— already case-insensitive, already covering `valkeys://`. `starts_with` was only ever the strawman named in a removed test's comment; it was never live code. The prose promoted that hypothetical into repo history and then credited the rewrite with fixing gaps that were never open. Anyone grepping the history would conclude the changelog invents bugs.

The real argument stands without it: parsing via `redis`'s own `IntoConnectionInfo` means there is no second copy of a table the dependency owns, and prefix lookalikes, `unix://` sockets and unparseable input are all classified exactly as the connector will classify them. Both sites now say that.

## Test gaps closed

- **The suite ran in CI only by coincidence.** Nothing asked for `redis` or `ws` on `autumn-web`; resolver-3 unification happened to supply them from `autumn-cache-redis` and the `reddit-clone` example. Drop `ws` from that example and the channels scenario silently ceases to exist, with `cargo test --workspace` still green. It now has an explicitly-featured lane using the repo's existing `assert_ran` non-zero-pass-count idiom (the one `ci.yml` already applies to `tls`, `acme`, `markdown`, `i18n`, `inbound-mail`).
- **`SessionConfig::backend_plan` was scan-only** — and it is the *earliest* site to touch a `rediss://` URL, before any store is built. It is `pub` and needs no runtime. The scan's doc comment also named `session::resolve_backend_plan`, which does not exist. Fixed and covered.
- **"Autumn keeps your provider" was documented but untested.** A forked scenario installs a deliberately crippled `ring` (one cipher suite) and asserts it survives — a refactor to an unconditional install, or to `install_default().expect(..)`, now fails.
- **All three scans missed `Client::build_with_tls`**, a second door into the same panicking `ClientConfig::builder()`. Added to the needle set.
- **The reddit-clone scan was the weakest, in the crate most likely to be copied.** Its needle was `redis::`-qualified (one `use redis::Client;` defeated it) and it read 1 of 33 source files. The cache-crate scan claimed to "mirror the identical scan" while reading a single file via `include_str!`. Both now walk `src/`.
- The last bare `Client::open`, in a test file outside the scan's reach, goes through the guard so it stops being a copy-paste source.

## API hygiene

`open_client` returns a `redis::Client`, making `redis` a public-API dependency (`STABILITY.md`'s second bullet) — but it was not re-exported, so an external caller could not name the returned type without adding its own `redis` at a compatible major. Now `autumn_web::reexports::redis`.

## Docs

- The install deadline was "before serving starts"; it is actually before *config validation*, which runs earlier. An app installing `aws-lc-rs` from an `on_startup` hook would have followed the old advice and lost the race.
- Redis TLS validates against the public CA store. That is why the GCP target keeps Memorystore on `transit_encryption_mode = "DISABLED"` inside the VPC — previously a reader would have taken "every subsystem accepts `rediss://`" as licence to enable `SERVER_AUTHENTICATION` and get a handshake failure.
- Azure and AWS ECS deployment callouts cross-reference the TLS section; the stale `redis = ["dep:redis"]` and missing `tokio-rustls-comp` mirrors in the skills reference are corrected.

## Verification

On `73f29ad`:

```
cargo test -p autumn-web --features "redis,ws" --lib redis_tls
    23 passed; 0 failed          (was 14 in #2401)

cargo test -p autumn-cache-redis --lib
    7 passed; 0 failed; 10 ignored (Docker)

cargo test -p reddit-clone --lib live_events::tests::redis_clients
    1 passed; 0 failed

cargo clippy --workspace --all-targets -- -D warnings
    clean

cargo fmt --all
    clean
```

Not addressed, deliberately: the `^0.7.0` caret pin in `autumn-cache-redis` (a repo-wide gap `check-crate-metadata.sh` closes at release time, already acknowledged in `check-publish-dry-run.sh`'s header) and pre-existing `check-docs.sh` feature-list drift — both outside this change.