### PR TITLE
🔐 ACME config: close the two doctor↔runtime validation-parity nits (#1874)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -524,6 +524,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **ACME config: `autumn doctor` and the runtime now reject the same two
+  spellings (#1874):** two low-severity parity gaps let `autumn doctor
+  --strict` bless an `autumn.toml` the server refuses to boot on, and let one
+  malformed value through both. A **string-typed `renew_before_days`**
+  (`renew_before_days = "30"`, and likewise a float, a bool, a negative, or an
+  out-of-`u32`-range integer) was read by doctor's `as_integer()` chain as
+  *absent* and silently defaulted to 30, while the runtime's typed
+  deserialization rejects it — doctor now records the value the operator
+  actually wrote and reports an `acme_config` **Fail** naming it, exactly as it
+  already did for `http_challenge_port` and `directory`. A
+  **whitespace-padded domain** (`domains = [" app.example.com "]`) passed
+  `AcmeConfig::validate()`, which trims only for its blank and wildcard checks
+  but stores the entry untrimmed — and the untrimmed string is what becomes the
+  certificate's SAN and the ACME order's `Identifier::Dns`, so the padded name
+  was requested as-is and failed mid-issuance with an opaque CA error. Both
+  `validate()` and doctor now reject it at startup with a message naming the
+  entry, its index, and the trimmed spelling to use. Neither gap was a security,
+  denial-of-service, or CA-rate-limit issue: each was already caught fail-fast
+  at boot or at first issuance, just later and less legibly than it should have
+  been.
+
 - **CI now rejects colliding migration versions:** app, framework and plugin
   migrations are applied into one shared version space — diesel keys
   `__diesel_schema_migrations` on the 14-digit version and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -526,14 +526,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **ACME config: `autumn doctor` and the runtime now reject the same two
   spellings (#1874):** two low-severity parity gaps let `autumn doctor
-  --strict` bless an `autumn.toml` the server refuses to boot on, and let one
-  malformed value through both. A **string-typed `renew_before_days`**
-  (`renew_before_days = "30"`, and likewise a float, a bool, a negative, or an
-  out-of-`u32`-range integer) was read by doctor's `as_integer()` chain as
-  *absent* and silently defaulted to 30, while the runtime's typed
-  deserialization rejects it — doctor now records the value the operator
-  actually wrote and reports an `acme_config` **Fail** naming it, exactly as it
-  already did for `http_challenge_port` and `directory`. A
+  --strict` bless an `autumn.toml` the server refuses to boot on. A
+  **non-integer `renew_before_days`** — a quoted `renew_before_days = "30"`, a
+  float, or a bool — was read by doctor's `as_integer()` chain as *absent* and
+  silently defaulted to 30, so the check passed while the runtime's typed
+  deserialization rejects the file at boot. Doctor now records the value the
+  operator actually wrote and reports an `acme_config` **Fail** naming it,
+  exactly as it already did for `http_challenge_port` and `directory`. (A
+  negative or out-of-`u32`-range integer already failed, having been clamped to
+  `u32::MAX` and caught by the `>= 90` rule; it now fails with a message about
+  the value rather than about the renewal window.) A
   **whitespace-padded domain** (`domains = [" app.example.com "]`) passed
   `AcmeConfig::validate()`, which trims only for its blank and wildcard checks
   but stores the entry untrimmed — and the untrimmed string is what becomes the

--- a/autumn-cli/src/doctor.rs
+++ b/autumn-cli/src/doctor.rs
@@ -4995,8 +4995,11 @@ pub struct AcmeDoctorConfig {
     /// PRESENT but does not deserialize as a `u32` the way the runtime's typed
     /// `AcmeConfig` does (a quoted string like `"30"`, a float, a bool, a
     /// negative, or an out-of-`u32`-range integer). Doctor's old `as_integer()`
-    /// chain treated such a value as ABSENT and silently defaulted to 30, so
-    /// `doctor --strict` passed a file the runtime refuses to boot on (#1874).
+    /// chain treated a NON-INTEGER as ABSENT and silently defaulted to 30, so
+    /// `doctor --strict` passed a file the runtime refuses to boot on (#1874);
+    /// a negative / out-of-range integer did parse, but was clamped to
+    /// `u32::MAX` and reported against the `>= 90` renewal-window rule rather
+    /// than as the malformed value it is.
     /// Mirrors the [`port_error`](Self::port_error) treatment. `None` when the
     /// value is a valid `u32` or the key is absent (absent uses the runtime
     /// default, 30).
@@ -5207,39 +5210,6 @@ fn resolve_acme_doctor_config(toml_table: Option<&toml::Table>) -> Option<AcmeDo
     })
 }
 
-/// Grade the resolved ACME config against the runtime's boot-time invariants,
-/// mirroring [`autumn_web::config::AcmeConfig::validate`] (pure; injectable for
-/// tests).
-///
-/// The runtime `TlsConfig::validate()` / `AcmeConfig::validate()` REJECTS an ACME
-/// config that (a) has a `directory` value that fails to deserialize as
-/// [`autumn_web::config::AcmeDirectory`], (b) lists no `domains`, (c) has a blank
-/// `contact_email`, or (d) includes a wildcard `*.` domain (wildcards require
-/// DNS-01, tracked in #1620) — the server exits at boot. `validate()`'s fifth
-/// rule, a blank `ca_root_path`, is graded by
-/// [`check_acme_ca_root_impl`] instead: the whole `ca_root_path` story (blank,
-/// non-string, unreadable, unusable, a bundle, or redundant against a public
-/// directory) belongs in one check with one name, rather than splitting the
-/// blank case away from its siblings. Doctor previously turned
-/// a missing/empty `domains` into an empty list and reported `acme_stored_cert`
-/// as Pass with no probes, and silently defaulted a malformed `directory` to
-/// staging, so `doctor --strict` blessed a deployment that immediately exits.
-/// This grader returns a `Fail` [`CheckResult`] for the first violated rule
-/// (messages mirror the runtime's), or `None` when the ACME config is valid.
-///
-/// The recorded deserialize errors on `config` — [`domains_error`],
-/// [`directory_error`], [`port_error`] and [`renew_before_days_error`] — are
-/// checked FIRST, because the runtime DESERIALIZES `AcmeConfig` (failing on a
-/// non-string `domains` entry, a bad `directory`, or an out-of-range /
-/// non-integer `http_challenge_port` / `renew_before_days`) before it ever runs
-/// `validate()`. Each one is a rendered invalid value the operator wrote, so the
-/// FAIL can name it.
-///
-/// [`domains_error`]: AcmeDoctorConfig::domains_error
-/// [`directory_error`]: AcmeDoctorConfig::directory_error
-/// [`port_error`]: AcmeDoctorConfig::port_error
-/// [`renew_before_days_error`]: AcmeDoctorConfig::renew_before_days_error
-#[must_use]
 /// The shared `acme_config` Fail shape: every ACME-config violation reports the
 /// same check name and status, so each rule contributes only a detail + hint.
 fn acme_config_fail(detail: String, hint: &'static str) -> Option<CheckResult> {
@@ -5316,6 +5286,39 @@ fn check_acme_deserialize_errors(config: &AcmeDoctorConfig) -> Option<CheckResul
     None
 }
 
+/// Grade the resolved ACME config against the runtime's boot-time invariants,
+/// mirroring [`autumn_web::config::AcmeConfig::validate`] (pure; injectable for
+/// tests).
+///
+/// The runtime `TlsConfig::validate()` / `AcmeConfig::validate()` REJECTS an ACME
+/// config that (a) has a `directory` value that fails to deserialize as
+/// [`autumn_web::config::AcmeDirectory`], (b) lists no `domains`, (c) has a blank
+/// `contact_email`, or (d) includes a wildcard `*.` domain (wildcards require
+/// DNS-01, tracked in #1620) — the server exits at boot. `validate()`'s fifth
+/// rule, a blank `ca_root_path`, is graded by
+/// [`check_acme_ca_root_impl`] instead: the whole `ca_root_path` story (blank,
+/// non-string, unreadable, unusable, a bundle, or redundant against a public
+/// directory) belongs in one check with one name, rather than splitting the
+/// blank case away from its siblings. Doctor previously turned
+/// a missing/empty `domains` into an empty list and reported `acme_stored_cert`
+/// as Pass with no probes, and silently defaulted a malformed `directory` to
+/// staging, so `doctor --strict` blessed a deployment that immediately exits.
+/// This grader returns a `Fail` [`CheckResult`] for the first violated rule
+/// (messages mirror the runtime's), or `None` when the ACME config is valid.
+///
+/// The recorded deserialize errors on `config` — [`domains_error`],
+/// [`directory_error`], [`port_error`] and [`renew_before_days_error`] — are
+/// checked FIRST, because the runtime DESERIALIZES `AcmeConfig` (failing on a
+/// non-string `domains` entry, a bad `directory`, or an out-of-range /
+/// non-integer `http_challenge_port` / `renew_before_days`) before it ever runs
+/// `validate()`. Each one is a rendered invalid value the operator wrote, so the
+/// FAIL can name it.
+///
+/// [`domains_error`]: AcmeDoctorConfig::domains_error
+/// [`directory_error`]: AcmeDoctorConfig::directory_error
+/// [`port_error`]: AcmeDoctorConfig::port_error
+/// [`renew_before_days_error`]: AcmeDoctorConfig::renew_before_days_error
+#[must_use]
 pub fn check_acme_config_impl(config: &AcmeDoctorConfig) -> Option<CheckResult> {
     let AcmeDoctorConfig {
         domains,
@@ -10892,7 +10895,9 @@ renew_before_days = 30
     #[test]
     fn acme_config_fail_when_renew_before_days_malformed() {
         for (bad_line, needle) in [
-            ("renew_before_days = \"30\"", "30"),
+            // The QUOTING is the bug here, so the FAIL must echo it: a wrong fix
+            // that reused the `>= 90` detail would still contain a bare `30`.
+            ("renew_before_days = \"30\"", "\"30\""),
             ("renew_before_days = 30.5", "30.5"),
             ("renew_before_days = true", "true"),
             ("renew_before_days = -1", "-1"),
@@ -10920,6 +10925,13 @@ contact_email = \"ops@example.com\"
             assert!(
                 detail.contains("renew_before_days") && detail.contains(needle),
                 "detail must name the bad renew_before_days value: {detail}"
+            );
+            // The deserialize tier, not the `>= 90` renewal-window rule: the
+            // runtime never gets far enough to compare this against 90.
+            assert!(
+                detail.contains("is not a valid renewal window"),
+                "`{bad_line}` must FAIL as a malformed value, not as a >= 90 \
+                 renewal window: {detail}"
             );
         }
     }
@@ -10980,8 +10992,54 @@ contact_email = \"ops@example.com\"
         assert_eq!(r.name, "acme_config");
         let detail = r.detail.as_deref().unwrap_or_default();
         assert!(
-            detail.contains("whitespace") && detail.contains("app.example.com"),
-            "detail must name the problem and the entry: {detail}"
+            detail.contains("whitespace") && detail.contains("` app.example.com `"),
+            "detail must name the problem and echo the RAW padded entry (not just \
+             the trimmed spelling it suggests): {detail}"
+        );
+
+        // Leading-only, trailing-only and tab/newline padding are rejected too.
+        for line in [
+            "domains = [\" app.example.com\"]",
+            "domains = [\"app.example.com \"]",
+            "domains = [\"\\tapp.example.com\\n\"]",
+        ] {
+            let raw: toml::Table = toml::from_str(&format!(
+                "\
+[server.tls.acme]
+{line}
+contact_email = \"ops@example.com\"
+"
+            ))
+            .unwrap();
+            let acme = resolve_acme_doctor_config(Some(&raw)).expect("[server.tls.acme] present");
+            let r = check_acme_config_impl(&acme)
+                .unwrap_or_else(|| panic!("`{line}` must be an acme_config FAIL"));
+            assert!(
+                r.detail
+                    .as_deref()
+                    .unwrap_or_default()
+                    .contains("whitespace"),
+                "`{line}` must FAIL on whitespace: {:?}",
+                r.detail
+            );
+        }
+
+        // A padded entry is caught behind a well-formed one, and the FAIL names
+        // the right index.
+        let raw: toml::Table = toml::from_str(
+            "\
+[server.tls.acme]
+domains = [\"app.example.com\", \" www.example.com\"]
+contact_email = \"ops@example.com\"
+",
+        )
+        .unwrap();
+        let acme = resolve_acme_doctor_config(Some(&raw)).expect("[server.tls.acme] present");
+        let r = check_acme_config_impl(&acme).expect("a padded entry at index 1 must FAIL");
+        assert!(
+            r.detail.as_deref().unwrap_or_default().contains("index 1"),
+            "detail must name the offending index: {:?}",
+            r.detail
         );
 
         // And, as in the runtime, the padded rule does not shadow the blank or
@@ -11004,6 +11062,76 @@ contact_email = \"ops@example.com\"
             assert!(
                 detail.contains(needle),
                 "`{line}` should report `{needle}`, got: {detail}"
+            );
+        }
+    }
+
+    // The doctor grader is a HAND-COPY of `AcmeConfig::validate()`, and the two
+    // have now drifted three times (#1608, and both items of #1874). Every other
+    // test here pins one side against a hard-coded expectation; this one pins the
+    // two sides against EACH OTHER, so the next divergence fails a test instead of
+    // shipping. Verdicts only — the messages deliberately differ in shape (doctor
+    // splits the runtime's closing advice into a separate `hint`).
+    //
+    // `ca_root_path` is excluded on purpose: `validate()` grades a blank one, but
+    // doctor routes the whole `ca_root_path` story through `check_acme_ca_root_impl`
+    // instead (see `check_acme_config_impl`'s docs).
+    #[test]
+    fn acme_config_grader_agrees_with_runtime_validate() {
+        let cases: &[(&[&str], &str, u16, u32)] = &[
+            (&["app.example.com"], "ops@example.com", 80, 30),
+            (
+                &["app.example.com", "www.example.com"],
+                "ops@example.com",
+                8080,
+                89,
+            ),
+            // Item 2 (#1874) and its neighbours: padded, wildcard, blank.
+            (&[" app.example.com "], "ops@example.com", 80, 30),
+            (&["app.example.com\t"], "ops@example.com", 80, 30),
+            (&["\u{a0}app.example.com"], "ops@example.com", 80, 30),
+            (&[" *.example.com "], "ops@example.com", 80, 30),
+            (&["   "], "ops@example.com", 80, 30),
+            (
+                &["app.example.com", " www.example.com"],
+                "ops@example.com",
+                80,
+                30,
+            ),
+            // The pre-existing invariants.
+            (&[], "ops@example.com", 80, 30),
+            (&["app.example.com"], "  ", 80, 30),
+            (&["app.example.com"], "ops@example.com", 0, 30),
+            (&["app.example.com"], "ops@example.com", 80, 0),
+            (&["app.example.com"], "ops@example.com", 80, 90),
+            (&["app.example.com"], "ops@example.com", 80, 100),
+            // Whitespace INSIDE a name is out of scope for both sides today; this
+            // row records that they agree about it rather than that it is allowed.
+            (&["app .example.com"], "ops@example.com", 80, 30),
+        ];
+
+        for (domains, contact_email, http_challenge_port, renew_before_days) in cases {
+            let mut doctor_cfg = acme_doctor_cfg(domains, contact_email);
+            doctor_cfg.http_challenge_port = *http_challenge_port;
+            doctor_cfg.renew_before_days = *renew_before_days;
+
+            let runtime_cfg = autumn_web::config::AcmeConfig {
+                domains: domains.iter().map(|d| (*d).to_owned()).collect(),
+                contact_email: (*contact_email).to_owned(),
+                directory: autumn_web::config::AcmeDirectory::Staging,
+                cache_dir: std::path::PathBuf::from("config/acme"),
+                http_challenge_port: *http_challenge_port,
+                renew_before_days: *renew_before_days,
+                ca_root_path: None,
+            };
+
+            assert_eq!(
+                check_acme_config_impl(&doctor_cfg).is_some(),
+                runtime_cfg.validate().is_err(),
+                "doctor and AcmeConfig::validate disagree on domains={domains:?} \
+                 contact_email={contact_email:?} port={http_challenge_port} \
+                 renew_before_days={renew_before_days} (runtime said {:?})",
+                runtime_cfg.validate()
             );
         }
     }
@@ -11429,20 +11557,8 @@ directory = \"production\"
     // unprobed domain. A 2-domain config must yield a port + DNS check per domain.
     #[test]
     fn online_probes_every_configured_domain() {
-        let config = AcmeDoctorConfig {
-            domains: vec!["ok.example.com".to_owned(), "bad.example.com".to_owned()],
-            contact_email: "ops@example.com".to_owned(),
-            http_challenge_port: 80,
-            renew_before_days: 30,
-            cache_dir: std::path::PathBuf::from("config/acme"),
-            directory_label: "production".to_owned(),
-            directory_error: None,
-            port_error: None,
-            ca_root_path: None,
-            ca_root_error: None,
-            domains_error: None,
-            renew_before_days_error: None,
-        };
+        let mut config = acme_doctor_cfg(&["ok.example.com", "bad.example.com"], "ops@example.com");
+        config.directory_label = "production".to_owned();
 
         // Every configured domain is scheduled for probing, not just the first.
         let domains = acme_online_probe_domains(&config);

--- a/autumn-cli/src/doctor.rs
+++ b/autumn-cli/src/doctor.rs
@@ -5212,13 +5212,18 @@ fn resolve_acme_doctor_config(toml_table: Option<&toml::Table>) -> Option<AcmeDo
 
 /// The shared `acme_config` Fail shape: every ACME-config violation reports the
 /// same check name and status, so each rule contributes only a detail + hint.
-fn acme_config_fail(detail: String, hint: &'static str) -> Option<CheckResult> {
-    Some(CheckResult {
+///
+/// Returns the bare [`CheckResult`] rather than a `Some(..)`; the graders that
+/// call it return `Option<CheckResult>` (`None` meaning "this rule is satisfied")
+/// and wrap it themselves, so the "always Some" is theirs to state, not this
+/// constructor's.
+const fn acme_config_fail(detail: String, hint: &'static str) -> CheckResult {
+    CheckResult {
         name: "acme_config",
         status: CheckStatus::Fail,
         detail: Some(detail),
         hint: Some(hint),
-    })
+    }
 }
 
 /// Grade the `[server.tls.acme]` values that the runtime rejects while
@@ -5240,17 +5245,17 @@ fn check_acme_deserialize_errors(config: &AcmeDoctorConfig) -> Option<CheckResul
     } = config;
 
     if let Some(bad_value) = domains_error {
-        return acme_config_fail(
+        return Some(acme_config_fail(
             format!(
                 "[server.tls.acme] domains {bad_value}: every entry must be a string hostname. \
                  The runtime deserializes domains as a list of strings and fails to boot on a \
                  non-string entry"
             ),
             "List only string hostnames in [server.tls.acme] domains",
-        );
+        ));
     }
     if let Some(bad_value) = directory_error {
-        return acme_config_fail(
+        return Some(acme_config_fail(
             format!(
                 "[server.tls.acme] directory value {bad_value} is not a valid ACME directory: use \
                  \"staging\", \"production\", or a custom directory URL. The runtime fails to boot \
@@ -5258,10 +5263,10 @@ fn check_acme_deserialize_errors(config: &AcmeDoctorConfig) -> Option<CheckResul
             ),
             "Set [server.tls.acme] directory to \"staging\", \"production\", or a custom directory \
              URL",
-        );
+        ));
     }
     if let Some(bad_value) = port_error {
-        return acme_config_fail(
+        return Some(acme_config_fail(
             format!(
                 "[server.tls.acme] http_challenge_port value {bad_value} is not a valid port: it \
                  must be an integer in the range 0-65535 (the runtime fails to boot on an \
@@ -5269,10 +5274,10 @@ fn check_acme_deserialize_errors(config: &AcmeDoctorConfig) -> Option<CheckResul
             ),
             "Set [server.tls.acme] http_challenge_port to a valid port number (80, or the port a \
              front-end forwards `:80` to)",
-        );
+        ));
     }
     if let Some(bad_value) = renew_before_days_error {
-        return acme_config_fail(
+        return Some(acme_config_fail(
             format!(
                 "[server.tls.acme] renew_before_days value {bad_value} is not a valid renewal \
                  window: it must be a whole number of days in the range 0-4294967295 (the runtime \
@@ -5281,7 +5286,7 @@ fn check_acme_deserialize_errors(config: &AcmeDoctorConfig) -> Option<CheckResul
             ),
             "Set [server.tls.acme] renew_before_days to a whole number of days below 90 (default \
              30), unquoted",
-        );
+        ));
     }
     None
 }
@@ -5335,32 +5340,32 @@ pub fn check_acme_config_impl(config: &AcmeDoctorConfig) -> Option<CheckResult> 
     }
 
     if domains.is_empty() {
-        return acme_config_fail(
+        return Some(acme_config_fail(
             "[server.tls.acme] domains must list at least one domain to request a certificate for"
                 .to_owned(),
             "Add at least one domain to [server.tls.acme] domains",
-        );
+        ));
     }
     if contact_email.trim().is_empty() {
-        return acme_config_fail(
+        return Some(acme_config_fail(
             "[server.tls.acme] contact_email must be set (the ACME CA requires an account contact \
              for expiry notifications)"
                 .to_owned(),
             "Set [server.tls.acme] contact_email",
-        );
+        ));
     }
     if *http_challenge_port == 0 {
-        return acme_config_fail(
+        return Some(acme_config_fail(
             "[server.tls.acme] http_challenge_port must not be 0: port 0 binds an ephemeral \
              OS-assigned port that the ACME HTTP-01 validator (which always connects on port 80) \
              can never reach, so every issuance fails. Use 80, or the port a front-end forwards \
              `:80` to"
                 .to_owned(),
             "Set [server.tls.acme] http_challenge_port to 80 (or the port `:80` forwards to)",
-        );
+        ));
     }
     if *renew_before_days >= 90 {
-        return acme_config_fail(
+        return Some(acme_config_fail(
             format!(
                 "[server.tls.acme] renew_before_days ({renew_before_days}) must be less than 90: \
                  it is compared against the issued certificate's remaining validity, and \
@@ -5370,7 +5375,7 @@ pub fn check_acme_config_impl(config: &AcmeDoctorConfig) -> Option<CheckResult> 
                  every hour and burn the CA's rate limits"
             ),
             "Set [server.tls.acme] renew_before_days below 90 (default 30)",
-        );
+        ));
     }
     check_acme_domain_entries(domains)
 }
@@ -5382,30 +5387,30 @@ fn check_acme_domain_entries(domains: &[String]) -> Option<CheckResult> {
     for (index, domain) in domains.iter().enumerate() {
         let trimmed = domain.trim();
         if trimmed.is_empty() {
-            return acme_config_fail(
+            return Some(acme_config_fail(
                 format!(
                     "[server.tls.acme] domains must not contain blank entries (entry at index \
                      {index} is empty or whitespace-only)"
                 ),
                 "Remove blank/whitespace-only entries from [server.tls.acme] domains",
-            );
+            ));
         }
         if trimmed.starts_with("*.") {
-            return acme_config_fail(
+            return Some(acme_config_fail(
                 format!(
                     "[server.tls.acme] wildcard domain `{trimmed}` is not supported: wildcards \
                      require the DNS-01 challenge, which is out of scope here (tracked in #1620). \
                      List explicit hostnames instead"
                 ),
                 "Remove wildcard domains; list explicit hostnames (DNS-01 tracked in #1620)",
-            );
+            ));
         }
         // The two rules above read `trimmed`, but the runtime stores and uses the
         // entry UNTRIMMED — as the certificate's SAN and as the ACME order's DNS
         // identifier — so `AcmeConfig::validate()` rejects a padded entry. Mirror
         // that here, or `doctor --strict` passes a file the server won't boot on.
         if domain != trimmed {
-            return acme_config_fail(
+            return Some(acme_config_fail(
                 format!(
                     "[server.tls.acme] domain `{domain}` (entry at index {index}) has leading or \
                      trailing whitespace: the entry is used verbatim as the certificate's SAN and \
@@ -5413,7 +5418,7 @@ fn check_acme_domain_entries(domains: &[String]) -> Option<CheckResult> {
                      as-is. Write it as `{trimmed}`"
                 ),
                 "Remove the leading/trailing whitespace from the [server.tls.acme] domains entry",
-            );
+            ));
         }
     }
     None

--- a/autumn-cli/src/doctor.rs
+++ b/autumn-cli/src/doctor.rs
@@ -4991,6 +4991,16 @@ pub struct AcmeDoctorConfig {
     /// config. Recorded here so the grader surfaces it as an `acme_config` FAIL.
     /// `None` when every entry is a string (or `domains` is absent).
     pub domains_error: Option<String>,
+    /// The rendered invalid `acme.renew_before_days` value when the key is
+    /// PRESENT but does not deserialize as a `u32` the way the runtime's typed
+    /// `AcmeConfig` does (a quoted string like `"30"`, a float, a bool, a
+    /// negative, or an out-of-`u32`-range integer). Doctor's old `as_integer()`
+    /// chain treated such a value as ABSENT and silently defaulted to 30, so
+    /// `doctor --strict` passed a file the runtime refuses to boot on (#1874).
+    /// Mirrors the [`port_error`](Self::port_error) treatment. `None` when the
+    /// value is a valid `u32` or the key is absent (absent uses the runtime
+    /// default, 30).
+    pub renew_before_days_error: Option<String>,
 }
 
 /// Deserialize `[server.tls.acme] directory` exactly as the runtime does.
@@ -5014,6 +5024,32 @@ fn parse_acme_directory(acme: &toml::Table) -> Result<autumn_web::config::AcmeDi
     )
 }
 
+/// Deserialize one scalar `[server.tls.acme]` key exactly as the runtime's typed
+/// `AcmeConfig` does, keeping the offending value on failure.
+///
+/// Returns `default` when the key is absent (matching the runtime's `#[serde(default
+/// = ...)]`), the deserialized `T` when the value is one the runtime accepts, and
+/// otherwise the RENDERED invalid value — so the caller can surface it as an
+/// `acme_config` FAIL naming what the operator actually wrote, instead of
+/// silently falling back to the default and blessing a config the server refuses
+/// to boot on.
+fn parse_acme_scalar<T: serde::de::DeserializeOwned>(
+    acme: &toml::Table,
+    key: &str,
+    default: T,
+) -> Result<T, String> {
+    acme.get(key).cloned().map_or_else(
+        || Ok(default),
+        |value| {
+            // Render the value BEFORE `try_into` consumes it, for the FAIL message.
+            let rendered = value.to_string();
+            value
+                .try_into::<T>()
+                .map_err(|_| rendered.trim().to_owned())
+        },
+    )
+}
+
 /// Deserialize `[server.tls.acme] http_challenge_port` exactly as the runtime's
 /// typed `AcmeConfig` does.
 ///
@@ -5023,16 +5059,20 @@ fn parse_acme_directory(acme: &toml::Table) -> Result<autumn_web::config::AcmeDi
 /// an `acme_config` FAIL instead of silently falling back to the default `80`.
 /// An absent `http_challenge_port` key uses the runtime default (`80`).
 fn parse_acme_http_challenge_port(acme: &toml::Table) -> Result<u16, String> {
-    acme.get("http_challenge_port").cloned().map_or_else(
-        || Ok(80),
-        |value| {
-            // Render the value BEFORE `try_into` consumes it, for the FAIL message.
-            let rendered = value.to_string();
-            value
-                .try_into::<u16>()
-                .map_err(|_| rendered.trim().to_owned())
-        },
-    )
+    parse_acme_scalar(acme, "http_challenge_port", 80)
+}
+
+/// Deserialize `[server.tls.acme] renew_before_days` exactly as the runtime's
+/// typed `AcmeConfig` does.
+///
+/// Returns the parsed `u32`, or — on a value the runtime would fail to
+/// deserialize (negative, out of `u32` range, or a non-integer such as a quoted
+/// string, a float, or a bool) — the rendered invalid value, so the caller can
+/// surface it as an `acme_config` FAIL instead of silently falling back to the
+/// default `30`. An absent `renew_before_days` key uses the runtime default
+/// (`30`).
+fn parse_acme_renew_before_days(acme: &toml::Table) -> Result<u32, String> {
+    parse_acme_scalar(acme, "renew_before_days", 30)
 }
 
 /// The `FsAcmeStore` subdirectory label for a parsed `acme.directory`.
@@ -5120,12 +5160,13 @@ fn resolve_acme_doctor_config(toml_table: Option<&toml::Table>) -> Option<AcmeDo
     // does: an absent key defaults to 30, a valid in-range integer is preserved
     // (including a >= 90 value, so the acme-config grader FAILs it exactly as
     // `AcmeConfig::validate()` does), and a value the runtime would reject
-    // pre-boot (negative or out of `u32` range) is clamped to `u32::MAX` so it too
-    // trips the `>= 90` FAIL rather than silently falling back to the default.
-    let renew_before_days = acme
-        .get("renew_before_days")
-        .and_then(toml::Value::as_integer)
-        .map_or(30, |v| u32::try_from(v).unwrap_or(u32::MAX));
+    // pre-boot (negative, out of `u32` range, or a non-integer such as a quoted
+    // string) records the bad value so the grader FAILs rather than silently
+    // defaulting to 30.
+    let (renew_before_days, renew_before_days_error) = match parse_acme_renew_before_days(acme) {
+        Ok(days) => (days, None),
+        Err(bad_value) => (30, Some(bad_value)),
+    };
 
     let cache_dir = acme
         .get("cache_dir")
@@ -5162,6 +5203,7 @@ fn resolve_acme_doctor_config(toml_table: Option<&toml::Table>) -> Option<AcmeDo
         ca_root_path,
         ca_root_error,
         domains_error,
+        renew_before_days_error,
     })
 }
 
@@ -5185,34 +5227,50 @@ fn resolve_acme_doctor_config(toml_table: Option<&toml::Table>) -> Option<AcmeDo
 /// This grader returns a `Fail` [`CheckResult`] for the first violated rule
 /// (messages mirror the runtime's), or `None` when the ACME config is valid.
 ///
-/// `directory_error` and `port_error` are the rendered invalid `directory` /
-/// `http_challenge_port` values (see [`AcmeDoctorConfig::directory_error`] /
-/// [`AcmeDoctorConfig::port_error`]); they are checked first because the runtime
-/// DESERIALIZES `AcmeConfig` — failing on a bad `directory` or an out-of-range /
-/// non-integer `http_challenge_port` — before it runs `validate()`.
+/// The recorded deserialize errors on `config` — [`domains_error`],
+/// [`directory_error`], [`port_error`] and [`renew_before_days_error`] — are
+/// checked FIRST, because the runtime DESERIALIZES `AcmeConfig` (failing on a
+/// non-string `domains` entry, a bad `directory`, or an out-of-range /
+/// non-integer `http_challenge_port` / `renew_before_days`) before it ever runs
+/// `validate()`. Each one is a rendered invalid value the operator wrote, so the
+/// FAIL can name it.
+///
+/// [`domains_error`]: AcmeDoctorConfig::domains_error
+/// [`directory_error`]: AcmeDoctorConfig::directory_error
+/// [`port_error`]: AcmeDoctorConfig::port_error
+/// [`renew_before_days_error`]: AcmeDoctorConfig::renew_before_days_error
 #[must_use]
-pub fn check_acme_config_impl(
-    domains: &[String],
-    contact_email: &str,
-    http_challenge_port: u16,
-    renew_before_days: u32,
-    directory_error: Option<&str>,
-    port_error: Option<&str>,
-    domains_error: Option<&str>,
-) -> Option<CheckResult> {
-    // All ACME-config violations share the same `acme_config` Fail shape; this
-    // collapses each branch to a detail + hint pair.
-    let fail = |detail: String, hint: &'static str| {
-        Some(CheckResult {
-            name: "acme_config",
-            status: CheckStatus::Fail,
-            detail: Some(detail),
-            hint: Some(hint),
-        })
-    };
+/// The shared `acme_config` Fail shape: every ACME-config violation reports the
+/// same check name and status, so each rule contributes only a detail + hint.
+fn acme_config_fail(detail: String, hint: &'static str) -> Option<CheckResult> {
+    Some(CheckResult {
+        name: "acme_config",
+        status: CheckStatus::Fail,
+        detail: Some(detail),
+        hint: Some(hint),
+    })
+}
+
+/// Grade the `[server.tls.acme]` values that the runtime rejects while
+/// DESERIALIZING `AcmeConfig` — before `validate()` ever runs.
+///
+/// Each field here holds the rendered value the operator actually wrote (see
+/// [`AcmeDoctorConfig::port_error`] and siblings), recorded because the doctor's
+/// own lenient parse would otherwise substitute a default and bless a config the
+/// server refuses to boot on. Extracted from [`check_acme_config_impl`] so that
+/// grader stays within the line budget, and so this "the runtime cannot even
+/// parse this" tier reads as one unit.
+fn check_acme_deserialize_errors(config: &AcmeDoctorConfig) -> Option<CheckResult> {
+    let AcmeDoctorConfig {
+        directory_error,
+        port_error,
+        domains_error,
+        renew_before_days_error,
+        ..
+    } = config;
 
     if let Some(bad_value) = domains_error {
-        return fail(
+        return acme_config_fail(
             format!(
                 "[server.tls.acme] domains {bad_value}: every entry must be a string hostname. \
                  The runtime deserializes domains as a list of strings and fails to boot on a \
@@ -5222,7 +5280,7 @@ pub fn check_acme_config_impl(
         );
     }
     if let Some(bad_value) = directory_error {
-        return fail(
+        return acme_config_fail(
             format!(
                 "[server.tls.acme] directory value {bad_value} is not a valid ACME directory: use \
                  \"staging\", \"production\", or a custom directory URL. The runtime fails to boot \
@@ -5233,7 +5291,7 @@ pub fn check_acme_config_impl(
         );
     }
     if let Some(bad_value) = port_error {
-        return fail(
+        return acme_config_fail(
             format!(
                 "[server.tls.acme] http_challenge_port value {bad_value} is not a valid port: it \
                  must be an integer in the range 0-65535 (the runtime fails to boot on an \
@@ -5243,23 +5301,53 @@ pub fn check_acme_config_impl(
              front-end forwards `:80` to)",
         );
     }
+    if let Some(bad_value) = renew_before_days_error {
+        return acme_config_fail(
+            format!(
+                "[server.tls.acme] renew_before_days value {bad_value} is not a valid renewal \
+                 window: it must be a whole number of days in the range 0-4294967295 (the runtime \
+                 fails to boot on a negative, out-of-range, or non-integer value such as a quoted \
+                 string)"
+            ),
+            "Set [server.tls.acme] renew_before_days to a whole number of days below 90 (default \
+             30), unquoted",
+        );
+    }
+    None
+}
+
+pub fn check_acme_config_impl(config: &AcmeDoctorConfig) -> Option<CheckResult> {
+    let AcmeDoctorConfig {
+        domains,
+        contact_email,
+        http_challenge_port,
+        renew_before_days,
+        ..
+    } = config;
+
+    // The runtime deserializes `AcmeConfig` before it validates it, so a value it
+    // cannot even parse is graded first.
+    if let Some(deserialize_fail) = check_acme_deserialize_errors(config) {
+        return Some(deserialize_fail);
+    }
+
     if domains.is_empty() {
-        return fail(
+        return acme_config_fail(
             "[server.tls.acme] domains must list at least one domain to request a certificate for"
                 .to_owned(),
             "Add at least one domain to [server.tls.acme] domains",
         );
     }
     if contact_email.trim().is_empty() {
-        return fail(
+        return acme_config_fail(
             "[server.tls.acme] contact_email must be set (the ACME CA requires an account contact \
              for expiry notifications)"
                 .to_owned(),
             "Set [server.tls.acme] contact_email",
         );
     }
-    if http_challenge_port == 0 {
-        return fail(
+    if *http_challenge_port == 0 {
+        return acme_config_fail(
             "[server.tls.acme] http_challenge_port must not be 0: port 0 binds an ephemeral \
              OS-assigned port that the ACME HTTP-01 validator (which always connects on port 80) \
              can never reach, so every issuance fails. Use 80, or the port a front-end forwards \
@@ -5268,8 +5356,8 @@ pub fn check_acme_config_impl(
             "Set [server.tls.acme] http_challenge_port to 80 (or the port `:80` forwards to)",
         );
     }
-    if renew_before_days >= 90 {
-        return fail(
+    if *renew_before_days >= 90 {
+        return acme_config_fail(
             format!(
                 "[server.tls.acme] renew_before_days ({renew_before_days}) must be less than 90: \
                  it is compared against the issued certificate's remaining validity, and \
@@ -5288,18 +5376,10 @@ pub fn check_acme_config_impl(
 /// mirroring `AcmeConfig::validate`'s per-entry rules. Extracted from
 /// [`check_acme_config_impl`] to keep that grader within the line budget.
 fn check_acme_domain_entries(domains: &[String]) -> Option<CheckResult> {
-    let fail = |detail: String, hint: &'static str| {
-        Some(CheckResult {
-            name: "acme_config",
-            status: CheckStatus::Fail,
-            detail: Some(detail),
-            hint: Some(hint),
-        })
-    };
     for (index, domain) in domains.iter().enumerate() {
         let trimmed = domain.trim();
         if trimmed.is_empty() {
-            return fail(
+            return acme_config_fail(
                 format!(
                     "[server.tls.acme] domains must not contain blank entries (entry at index \
                      {index} is empty or whitespace-only)"
@@ -5308,13 +5388,28 @@ fn check_acme_domain_entries(domains: &[String]) -> Option<CheckResult> {
             );
         }
         if trimmed.starts_with("*.") {
-            return fail(
+            return acme_config_fail(
                 format!(
                     "[server.tls.acme] wildcard domain `{trimmed}` is not supported: wildcards \
                      require the DNS-01 challenge, which is out of scope here (tracked in #1620). \
                      List explicit hostnames instead"
                 ),
                 "Remove wildcard domains; list explicit hostnames (DNS-01 tracked in #1620)",
+            );
+        }
+        // The two rules above read `trimmed`, but the runtime stores and uses the
+        // entry UNTRIMMED — as the certificate's SAN and as the ACME order's DNS
+        // identifier — so `AcmeConfig::validate()` rejects a padded entry. Mirror
+        // that here, or `doctor --strict` passes a file the server won't boot on.
+        if domain != trimmed {
+            return acme_config_fail(
+                format!(
+                    "[server.tls.acme] domain `{domain}` (entry at index {index}) has leading or \
+                     trailing whitespace: the entry is used verbatim as the certificate's SAN and \
+                     as the ACME order's DNS identifier, so the padded value would be requested \
+                     as-is. Write it as `{trimmed}`"
+                ),
+                "Remove the leading/trailing whitespace from the [server.tls.acme] domains entry",
             );
         }
     }
@@ -7243,15 +7338,7 @@ pub fn run(opts: DoctorOptions) {
         // `acme_stored_cert` as Pass with no probes, blessing a config that exits
         // at boot. Emit the FAIL and SKIP the misleading stored-cert / online
         // probes when the config is invalid (there is nothing valid to inspect).
-        if let Some(config_fail) = check_acme_config_impl(
-            &acme.domains,
-            &acme.contact_email,
-            acme.http_challenge_port,
-            acme.renew_before_days,
-            acme.directory_error.as_deref(),
-            acme.port_error.as_deref(),
-            acme.domains_error.as_deref(),
-        ) {
+        if let Some(config_fail) = check_acme_config_impl(&acme) {
             tasks.push(Box::new(move || config_fail));
         } else {
             // Offline: stored certificate expiry (reuses the #1603 inspect path).
@@ -10573,12 +10660,33 @@ pub struct Vault {
         assert!(matches!(r.status, CheckStatus::Pass));
     }
 
+    /// A minimal, valid [`AcmeDoctorConfig`] for the pure `check_acme_config_impl`
+    /// tests, so each case names only the field it exercises. Mirrors the runtime
+    /// defaults an absent key resolves to (port 80, renew-before 30 days,
+    /// `config/acme`, staging) with no recorded deserialize errors.
+    fn acme_doctor_cfg(domains: &[&str], contact_email: &str) -> AcmeDoctorConfig {
+        AcmeDoctorConfig {
+            domains: domains.iter().map(|d| (*d).to_owned()).collect(),
+            contact_email: contact_email.to_owned(),
+            http_challenge_port: 80,
+            renew_before_days: 30,
+            cache_dir: std::path::PathBuf::from("config/acme"),
+            directory_label: "staging".to_owned(),
+            directory_error: None,
+            port_error: None,
+            ca_root_path: None,
+            ca_root_error: None,
+            domains_error: None,
+            renew_before_days_error: None,
+        }
+    }
+
     // Regression (#1608, Codex): doctor must mirror AcmeConfig::validate(). An
     // ACME config with no/empty `domains` is REJECTED by the runtime at boot, so
     // doctor must FAIL it rather than silently pass acme_stored_cert.
     #[test]
     fn acme_config_fail_when_domains_empty() {
-        let r = check_acme_config_impl(&[], "ops@example.com", 80, 30, None, None, None)
+        let r = check_acme_config_impl(&acme_doctor_cfg(&[], "ops@example.com"))
             .expect("empty domains must be a FAIL, not Pass");
         assert!(matches!(r.status, CheckStatus::Fail));
         assert_eq!(r.name, "acme_config");
@@ -10586,31 +10694,15 @@ pub struct Vault {
 
     #[test]
     fn acme_config_fail_when_contact_email_blank() {
-        let r = check_acme_config_impl(
-            &["app.example.com".to_owned()],
-            "   ",
-            80,
-            30,
-            None,
-            None,
-            None,
-        )
-        .expect("blank contact_email must be a FAIL");
+        let r = check_acme_config_impl(&acme_doctor_cfg(&["app.example.com"], "   "))
+            .expect("blank contact_email must be a FAIL");
         assert!(matches!(r.status, CheckStatus::Fail));
     }
 
     #[test]
     fn acme_config_fail_when_wildcard_domain() {
-        let r = check_acme_config_impl(
-            &["*.example.com".to_owned()],
-            "ops@example.com",
-            80,
-            30,
-            None,
-            None,
-            None,
-        )
-        .expect("wildcard domain must be a FAIL");
+        let r = check_acme_config_impl(&acme_doctor_cfg(&["*.example.com"], "ops@example.com"))
+            .expect("wildcard domain must be a FAIL");
         assert!(matches!(r.status, CheckStatus::Fail));
         // Points the operator at the DNS-01 tracking issue, mirroring
         // AcmeConfig::validate().
@@ -10621,16 +10713,8 @@ pub struct Vault {
     fn acme_config_ok_when_valid() {
         // A valid ACME config produces no acme_config failure.
         assert!(
-            check_acme_config_impl(
-                &["app.example.com".to_owned()],
-                "ops@example.com",
-                80,
-                30,
-                None,
-                None,
-                None
-            )
-            .is_none(),
+            check_acme_config_impl(&acme_doctor_cfg(&["app.example.com"], "ops@example.com"))
+                .is_none(),
             "a valid ACME config must not raise an acme_config failure"
         );
     }
@@ -10641,16 +10725,8 @@ pub struct Vault {
     // identifier, so doctor must FAIL it rather than pass acme_stored_cert.
     #[test]
     fn acme_config_fail_when_domain_entry_blank() {
-        let r = check_acme_config_impl(
-            &[String::new()],
-            "ops@example.com",
-            80,
-            30,
-            None,
-            None,
-            None,
-        )
-        .expect("a blank domain entry must be a FAIL");
+        let r = check_acme_config_impl(&acme_doctor_cfg(&[""], "ops@example.com"))
+            .expect("a blank domain entry must be a FAIL");
         assert!(matches!(r.status, CheckStatus::Fail));
         assert_eq!(r.name, "acme_config");
         assert!(
@@ -10660,16 +10736,8 @@ pub struct Vault {
         );
 
         // Whitespace-only is rejected the same way.
-        let r = check_acme_config_impl(
-            &["   ".to_owned()],
-            "ops@example.com",
-            80,
-            30,
-            None,
-            None,
-            None,
-        )
-        .expect("a whitespace-only domain entry must be a FAIL");
+        let r = check_acme_config_impl(&acme_doctor_cfg(&["   "], "ops@example.com"))
+            .expect("a whitespace-only domain entry must be a FAIL");
         assert!(matches!(r.status, CheckStatus::Fail));
     }
 
@@ -10679,16 +10747,9 @@ pub struct Vault {
     // the process stays up — doctor must FAIL it.
     #[test]
     fn acme_config_fail_when_http_challenge_port_zero() {
-        let r = check_acme_config_impl(
-            &["app.example.com".to_owned()],
-            "ops@example.com",
-            0,
-            30,
-            None,
-            None,
-            None,
-        )
-        .expect("http_challenge_port = 0 must be a FAIL");
+        let mut cfg = acme_doctor_cfg(&["app.example.com"], "ops@example.com");
+        cfg.http_challenge_port = 0;
+        let r = check_acme_config_impl(&cfg).expect("http_challenge_port = 0 must be a FAIL");
         assert!(matches!(r.status, CheckStatus::Fail));
         assert_eq!(r.name, "acme_config");
         assert!(
@@ -10725,16 +10786,8 @@ http_challenge_port = 70000
             acme.port_error.is_some(),
             "an out-of-range http_challenge_port must be recorded, not defaulted to 80"
         );
-        let r = check_acme_config_impl(
-            &acme.domains,
-            &acme.contact_email,
-            acme.http_challenge_port,
-            acme.renew_before_days,
-            acme.directory_error.as_deref(),
-            acme.port_error.as_deref(),
-            acme.domains_error.as_deref(),
-        )
-        .expect("an out-of-range http_challenge_port must be a FAIL, not silently 80");
+        let r = check_acme_config_impl(&acme)
+            .expect("an out-of-range http_challenge_port must be a FAIL, not silently 80");
         assert!(matches!(r.status, CheckStatus::Fail));
         assert_eq!(r.name, "acme_config");
         let detail = r.detail.as_deref().unwrap_or_default();
@@ -10758,16 +10811,8 @@ http_challenge_port = \"80\"
             acme.port_error.is_some(),
             "a quoted-string http_challenge_port must be recorded, not defaulted to 80"
         );
-        let r = check_acme_config_impl(
-            &acme.domains,
-            &acme.contact_email,
-            acme.http_challenge_port,
-            acme.renew_before_days,
-            acme.directory_error.as_deref(),
-            acme.port_error.as_deref(),
-            acme.domains_error.as_deref(),
-        )
-        .expect("a non-integer http_challenge_port must be a FAIL");
+        let r = check_acme_config_impl(&acme)
+            .expect("a non-integer http_challenge_port must be a FAIL");
         assert!(matches!(r.status, CheckStatus::Fail));
         assert_eq!(r.name, "acme_config");
     }
@@ -10788,16 +10833,7 @@ http_challenge_port = 8080
         assert!(acme.port_error.is_none());
         assert_eq!(acme.http_challenge_port, 8080);
         assert!(
-            check_acme_config_impl(
-                &acme.domains,
-                &acme.contact_email,
-                acme.http_challenge_port,
-                acme.renew_before_days,
-                acme.directory_error.as_deref(),
-                acme.port_error.as_deref(),
-                acme.domains_error.as_deref(),
-            )
-            .is_none(),
+            check_acme_config_impl(&acme).is_none(),
             "a valid http_challenge_port must not raise an acme_config FAIL"
         );
     }
@@ -10820,16 +10856,7 @@ renew_before_days = 100
         .unwrap();
         let acme = resolve_acme_doctor_config(Some(&raw)).expect("[server.tls.acme] present");
         assert_eq!(acme.renew_before_days, 100);
-        let r = check_acme_config_impl(
-            &acme.domains,
-            &acme.contact_email,
-            acme.http_challenge_port,
-            acme.renew_before_days,
-            acme.directory_error.as_deref(),
-            acme.port_error.as_deref(),
-            acme.domains_error.as_deref(),
-        )
-        .expect("renew_before_days >= 90 must be a FAIL");
+        let r = check_acme_config_impl(&acme).expect("renew_before_days >= 90 must be a FAIL");
         assert!(matches!(r.status, CheckStatus::Fail));
         assert_eq!(r.name, "acme_config");
         let detail = r.detail.as_deref().unwrap_or_default();
@@ -10851,18 +10878,134 @@ renew_before_days = 30
         let acme = resolve_acme_doctor_config(Some(&raw)).expect("[server.tls.acme] present");
         assert_eq!(acme.renew_before_days, 30);
         assert!(
-            check_acme_config_impl(
-                &acme.domains,
-                &acme.contact_email,
-                acme.http_challenge_port,
-                acme.renew_before_days,
-                acme.directory_error.as_deref(),
-                acme.port_error.as_deref(),
-                acme.domains_error.as_deref(),
-            )
-            .is_none(),
+            check_acme_config_impl(&acme).is_none(),
             "a valid renew_before_days must not raise an acme_config FAIL"
         );
+    }
+
+    // Regression (#1874, item 1): a `renew_before_days` the runtime's typed
+    // `AcmeConfig` cannot deserialize as a `u32` — a quoted string, a float, a
+    // bool, a negative, or an out-of-`u32`-range integer — must FAIL, not silently
+    // default to 30. Doctor's `as_integer()` chain treated a non-integer as
+    // ABSENT, so `renew_before_days = "30"` graded Pass while the server exits at
+    // boot on the same file.
+    #[test]
+    fn acme_config_fail_when_renew_before_days_malformed() {
+        for (bad_line, needle) in [
+            ("renew_before_days = \"30\"", "30"),
+            ("renew_before_days = 30.5", "30.5"),
+            ("renew_before_days = true", "true"),
+            ("renew_before_days = -1", "-1"),
+            ("renew_before_days = 4294967296", "4294967296"),
+        ] {
+            let raw: toml::Table = toml::from_str(&format!(
+                "\
+[server.tls.acme]
+domains = [\"app.example.com\"]
+contact_email = \"ops@example.com\"
+{bad_line}
+"
+            ))
+            .unwrap();
+            let acme = resolve_acme_doctor_config(Some(&raw)).expect("[server.tls.acme] present");
+            assert!(
+                acme.renew_before_days_error.is_some(),
+                "`{bad_line}` must be recorded, not silently defaulted to 30"
+            );
+            let r = check_acme_config_impl(&acme)
+                .unwrap_or_else(|| panic!("`{bad_line}` must be an acme_config FAIL"));
+            assert!(matches!(r.status, CheckStatus::Fail));
+            assert_eq!(r.name, "acme_config");
+            let detail = r.detail.as_deref().unwrap_or_default();
+            assert!(
+                detail.contains("renew_before_days") && detail.contains(needle),
+                "detail must name the bad renew_before_days value: {detail}"
+            );
+        }
+    }
+
+    // Companion: a valid explicit `renew_before_days` records no error, and an
+    // absent key still falls back to the runtime default (30) with no FAIL.
+    #[test]
+    fn acme_config_ok_when_renew_before_days_valid_or_absent() {
+        let raw: toml::Table = toml::from_str(
+            "\
+[server.tls.acme]
+domains = [\"app.example.com\"]
+contact_email = \"ops@example.com\"
+renew_before_days = 45
+",
+        )
+        .unwrap();
+        let acme = resolve_acme_doctor_config(Some(&raw)).expect("[server.tls.acme] present");
+        assert!(acme.renew_before_days_error.is_none());
+        assert_eq!(acme.renew_before_days, 45);
+        assert!(check_acme_config_impl(&acme).is_none());
+
+        let raw: toml::Table = toml::from_str(
+            "\
+[server.tls.acme]
+domains = [\"app.example.com\"]
+contact_email = \"ops@example.com\"
+",
+        )
+        .unwrap();
+        let acme = resolve_acme_doctor_config(Some(&raw)).expect("[server.tls.acme] present");
+        assert!(acme.renew_before_days_error.is_none());
+        assert_eq!(
+            acme.renew_before_days, 30,
+            "absent key uses the runtime default"
+        );
+        assert!(check_acme_config_impl(&acme).is_none());
+    }
+
+    // Regression (#1874, item 2): doctor must mirror `AcmeConfig::validate()`'s
+    // rejection of a whitespace-padded domain. Without this, `doctor --strict`
+    // passes a config the runtime refuses to boot on — the same parity gap in the
+    // opposite direction.
+    #[test]
+    fn acme_config_fail_when_domain_entry_whitespace_padded() {
+        let raw: toml::Table = toml::from_str(
+            "\
+[server.tls.acme]
+domains = [\" app.example.com \"]
+contact_email = \"ops@example.com\"
+",
+        )
+        .unwrap();
+        let acme = resolve_acme_doctor_config(Some(&raw)).expect("[server.tls.acme] present");
+        let r = check_acme_config_impl(&acme)
+            .expect("a whitespace-padded domain must be an acme_config FAIL");
+        assert!(matches!(r.status, CheckStatus::Fail));
+        assert_eq!(r.name, "acme_config");
+        let detail = r.detail.as_deref().unwrap_or_default();
+        assert!(
+            detail.contains("whitespace") && detail.contains("app.example.com"),
+            "detail must name the problem and the entry: {detail}"
+        );
+
+        // And, as in the runtime, the padded rule does not shadow the blank or
+        // wildcard rules.
+        for (line, needle) in [
+            ("domains = [\"   \"]", "blank entries"),
+            ("domains = [\" *.example.com \"]", "wildcard"),
+        ] {
+            let raw: toml::Table = toml::from_str(&format!(
+                "\
+[server.tls.acme]
+{line}
+contact_email = \"ops@example.com\"
+"
+            ))
+            .unwrap();
+            let acme = resolve_acme_doctor_config(Some(&raw)).expect("[server.tls.acme] present");
+            let r = check_acme_config_impl(&acme).expect("must FAIL");
+            let detail = r.detail.as_deref().unwrap_or_default();
+            assert!(
+                detail.contains(needle),
+                "`{line}` should report `{needle}`, got: {detail}"
+            );
+        }
     }
 
     // Regression (#1608, Codex P2): a NON-STRING entry in the `domains` array
@@ -10885,16 +11028,8 @@ contact_email = \"ops@example.com\"
             acme.domains_error.is_some(),
             "a non-string domain entry must be recorded, not silently dropped"
         );
-        let r = check_acme_config_impl(
-            &acme.domains,
-            &acme.contact_email,
-            acme.http_challenge_port,
-            acme.renew_before_days,
-            acme.directory_error.as_deref(),
-            acme.port_error.as_deref(),
-            acme.domains_error.as_deref(),
-        )
-        .expect("a non-string domain entry must be a FAIL, not silently dropped");
+        let r = check_acme_config_impl(&acme)
+            .expect("a non-string domain entry must be a FAIL, not silently dropped");
         assert!(matches!(r.status, CheckStatus::Fail));
         assert_eq!(r.name, "acme_config");
         let detail = r.detail.as_deref().unwrap_or_default();
@@ -10928,16 +11063,8 @@ directory = \"prod\"
             acme.directory_error.is_some(),
             "a malformed `directory` must be recorded as an error, not defaulted"
         );
-        let r = check_acme_config_impl(
-            &acme.domains,
-            &acme.contact_email,
-            acme.http_challenge_port,
-            acme.renew_before_days,
-            acme.directory_error.as_deref(),
-            acme.port_error.as_deref(),
-            acme.domains_error.as_deref(),
-        )
-        .expect("an invalid `directory` must be a FAIL, not silently staging");
+        let r = check_acme_config_impl(&acme)
+            .expect("an invalid `directory` must be a FAIL, not silently staging");
         assert!(matches!(r.status, CheckStatus::Fail));
         assert_eq!(r.name, "acme_config");
         // The FAIL names the offending value so the operator can fix it.
@@ -10986,16 +11113,7 @@ contact_email = \"ops@example.com\"
                 acme.directory_label
             );
             assert!(
-                check_acme_config_impl(
-                    &acme.domains,
-                    &acme.contact_email,
-                    acme.http_challenge_port,
-                    acme.renew_before_days,
-                    acme.directory_error.as_deref(),
-                    acme.port_error.as_deref(),
-                    acme.domains_error.as_deref(),
-                )
-                .is_none(),
+                check_acme_config_impl(&acme).is_none(),
                 "valid directory `{line}` must not raise an acme_config FAIL"
             );
         }
@@ -11323,6 +11441,7 @@ directory = \"production\"
             ca_root_path: None,
             ca_root_error: None,
             domains_error: None,
+            renew_before_days_error: None,
         };
 
         // Every configured domain is scheduled for probing, not just the first.

--- a/autumn/src/config.rs
+++ b/autumn/src/config.rs
@@ -6855,6 +6855,22 @@ impl AcmeConfig {
                      List explicit hostnames instead"
                 ));
             }
+            // The checks above read `trimmed`, but the entry is stored — and used —
+            // UNTRIMMED: it becomes the certificate's SAN via `CertificateParams`,
+            // the placeholder key's `CertId`, and the ACME order's
+            // `Identifier::Dns`. A padded ` app.example.com ` is therefore a
+            // different identifier than the hostname the operator meant, and the
+            // failure surfaces as an opaque CA rejection mid-issuance. Reject the
+            // padding here instead of silently trimming, so the config file says
+            // exactly what will be requested.
+            if domain != trimmed {
+                return Err(format!(
+                    "[server.tls.acme] domain `{domain}` (entry at index {index}) has leading or \
+                     trailing whitespace: the entry is used verbatim as the certificate's SAN and \
+                     as the ACME order's DNS identifier, so the padded value would be requested \
+                     as-is. Write it as `{trimmed}`"
+                ));
+            }
         }
         Ok(())
     }
@@ -14461,6 +14477,71 @@ path = "/healthz"
         cfg.acme = Some(acme_cfg(&["   "], "ops@example.com"));
         let err = cfg.validate().unwrap_err();
         assert!(err.contains("blank entries"), "got: {err}");
+    }
+
+    // Regression (#1874): a whitespace-padded domain (`" app.example.com "`)
+    // passed `validate()` — the blank and wildcard checks look at `domain.trim()`
+    // but the UNTRIMMED value is what is stored, so the padded string reached the
+    // placeholder/CSR builder and the ACME `Identifier::Dns` order. The CA then
+    // rejects (or mis-issues) an identifier that is not the hostname the operator
+    // meant, with a far less actionable error than a boot-time rejection.
+    #[test]
+    fn validate_acme_whitespace_padded_domain_rejected() {
+        for padded in [
+            " app.example.com",
+            "app.example.com ",
+            "\tapp.example.com\n",
+        ] {
+            let mut cfg = tls_static(None, None);
+            cfg.acme = Some(acme_cfg(&[padded], "ops@example.com"));
+            let err = cfg
+                .validate()
+                .expect_err("a whitespace-padded domain must be rejected");
+            assert!(
+                err.contains("whitespace"),
+                "message must name the problem: {err}"
+            );
+            assert!(
+                err.contains("app.example.com"),
+                "message must name the offending entry: {err}"
+            );
+        }
+
+        // A padded entry is rejected even when a well-formed one precedes it, and
+        // the message points at the right index.
+        let mut cfg = tls_static(None, None);
+        cfg.acme = Some(acme_cfg(
+            &["app.example.com", " www.example.com "],
+            "ops@example.com",
+        ));
+        let err = cfg.validate().unwrap_err();
+        assert!(
+            err.contains("index 1"),
+            "message must name the index: {err}"
+        );
+
+        // The already-trimmed spelling of the same name still passes.
+        let mut cfg = tls_static(None, None);
+        cfg.acme = Some(acme_cfg(&["app.example.com"], "ops@example.com"));
+        assert!(cfg.validate().is_ok(), "got: {:?}", cfg.validate());
+    }
+
+    // The padded-domain rule must not shadow the two more specific per-entry
+    // rules: a whitespace-only entry is still reported as blank, and a padded
+    // wildcard is still reported as a wildcard (the deeper problem, and the
+    // message operators already get today).
+    #[test]
+    fn validate_acme_padded_domain_rule_does_not_shadow_blank_or_wildcard() {
+        let mut cfg = tls_static(None, None);
+        cfg.acme = Some(acme_cfg(&["   "], "ops@example.com"));
+        let err = cfg.validate().unwrap_err();
+        assert!(err.contains("blank entries"), "got: {err}");
+
+        let mut cfg = tls_static(None, None);
+        cfg.acme = Some(acme_cfg(&[" *.example.com "], "ops@example.com"));
+        let err = cfg.validate().unwrap_err();
+        assert!(err.contains("wildcard"), "got: {err}");
+        assert!(err.contains("#1620"), "got: {err}");
     }
 
     // Regression (#1608, Codex P2): `http_challenge_port = 0` binds an ephemeral

--- a/autumn/src/config.rs
+++ b/autumn/src/config.rs
@@ -14479,6 +14479,38 @@ path = "/healthz"
         assert!(err.contains("blank entries"), "got: {err}");
     }
 
+    // The `autumn doctor` grader FAILs a malformed `http_challenge_port` /
+    // `renew_before_days` (#1608, #1874) on the premise that the runtime's TYPED
+    // deserialization rejects the same spellings before boot. Pin that premise
+    // here: if a future lenient `deserialize_with` ever made the runtime accept
+    // `"30"`, doctor would start FAILing a file that boots fine — the same parity
+    // bug in the opposite direction, and today nothing would catch it.
+    #[test]
+    fn acme_numeric_fields_reject_non_integer_toml_values() {
+        for key in ["http_challenge_port", "renew_before_days"] {
+            for bad in ["\"30\"", "30.5", "true", "-1", "4294967296"] {
+                let src = format!(
+                    "[server.tls.acme]\ndomains = [\"app.example.com\"]\n\
+                     contact_email = \"ops@example.com\"\n{key} = {bad}\n"
+                );
+                assert!(
+                    toml::from_str::<AutumnConfig>(&src).is_err(),
+                    "{key} = {bad} must fail to deserialize"
+                );
+            }
+            // ... while the plain unquoted integer the doctor grader treats as
+            // valid really is accepted.
+            let src = format!(
+                "[server.tls.acme]\ndomains = [\"app.example.com\"]\n\
+                 contact_email = \"ops@example.com\"\n{key} = 45\n"
+            );
+            assert!(
+                toml::from_str::<AutumnConfig>(&src).is_ok(),
+                "{key} = 45 must deserialize"
+            );
+        }
+    }
+
     // Regression (#1874): a whitespace-padded domain (`" app.example.com "`)
     // passed `validate()` — the blank and wildcard checks look at `domain.trim()`
     // but the UNTRIMMED value is what is stored, so the padded string reached the
@@ -14502,8 +14534,13 @@ path = "/healthz"
                 "message must name the problem: {err}"
             );
             assert!(
-                err.contains("app.example.com"),
-                "message must name the offending entry: {err}"
+                err.contains(&format!("`{padded}`")),
+                "message must echo the RAW padded entry, not only the trimmed \
+                 spelling it suggests: {err}"
+            );
+            assert!(
+                err.contains("`app.example.com`"),
+                "message must name the trimmed spelling to use: {err}"
             );
         }
 

--- a/docs/guide/tls.md
+++ b/docs/guide/tls.md
@@ -345,12 +345,12 @@ Fields:
 
 | Field | Default | Meaning |
 |---|---|---|
-| `domains` | required | One or more non-wildcard domains to issue for. |
+| `domains` | required | One or more non-wildcard domains to issue for. Each entry is used **verbatim** as the certificate's SAN and as the ACME order's DNS identifier, so an entry with leading or trailing whitespace is rejected at startup rather than requested as-is. |
 | `contact_email` | required | Contact address registered with the ACME account. |
 | `directory` | Let's Encrypt **staging** | ACME directory. Built-in endpoints are the bare strings `"staging"` (default) and `"production"`. A private CA / Pebble uses the inline table `{ custom = { url = "https://your-ca.example/dir" } }` — a bare URL string is **not** accepted (see below). |
 | `cache_dir` | `config/acme` | Where the account key and issued certificate are cached. |
 | `http_challenge_port` | `80` | Port the HTTP-01 challenge (and HTTP→HTTPS redirect) listens on. |
-| `renew_before_days` | `30` | Renew this many days before expiry (must be `< 90`). |
+| `renew_before_days` | `30` | Renew this many days before expiry (a whole number, unquoted, and `< 90`). |
 | `ca_root_path` | unset | PEM root that signs the **ACME directory's own HTTPS certificate**. Only needed for a private CA / Pebble; see below. |
 
 > **Staging is the default — switch to production deliberately.** When

--- a/skills/autumn-web/references/api-reference.md
+++ b/skills/autumn-web/references/api-reference.md
@@ -1466,11 +1466,13 @@ In-process HTTPS termination on the same host:port (off by default).
 Automatic ACME certificate provisioning + renewal; builds on `tls`, off by
 default. Mutually exclusive with static `cert_path` / `key_path`.
 
-- `domains` (required, non-wildcard), `contact_email` (required).
+- `domains` (required, non-wildcard), `contact_email` (required). Each domain is
+  used verbatim as the certificate's SAN and the ACME order's DNS identifier, so
+  an entry with leading/trailing whitespace is rejected at startup (#1874).
 - `directory` — Let's Encrypt staging by default; `production` or a custom URL.
 - `cache_dir` (default `config/acme`).
 - `http_challenge_port` (default `80`).
-- `renew_before_days` (default `30`, must be `< 90`).
+- `renew_before_days` (default `30`, an unquoted whole number, must be `< 90`).
 - `ca_root_path` (unset) — PEM root that signs the ACME **directory's own HTTPS
   certificate**. Needed only for a private CA / Pebble reached through a custom
   `directory`: by default the client verifies the directory against the platform


### PR DESCRIPTION
Closes #1874.

Two low-severity parity gaps between `autumn doctor` / `AcmeConfig::validate()` and the runtime's typed deserialization. Built red → green → refactor, then reviewed by three agents from different angles (correctness/parity, test quality, scope/docs) with every confirmed finding fixed.

## Item 1 — doctor: a non-integer `renew_before_days` silently defaulted

`resolve_acme_doctor_config`'s `as_integer()` chain collapsed "present but not an integer" into "absent", so `renew_before_days = "30"` (and a float or a bool) silently became 30 and `acme_config` reported **Pass** — while the runtime's typed `AcmeConfig` refuses to deserialize the same file and the server exits at boot.

Doctor now records the rendered value the operator actually wrote in a new `renew_before_days_error` and reports an `acme_config` **Fail** naming it, exactly as it already did for `http_challenge_port` and `directory`.

One correction to the issue's framing: a *negative* or out-of-`u32`-range integer was **not** a `--strict` false pass. Those did parse, were clamped to `u32::MAX`, and already failed via the `>= 90` rule — for them this change improves only the message (it now describes the malformed value rather than the renewal window). The changelog and field docs say so rather than overclaiming.

## Item 2 — `validate()`: a whitespace-padded domain passed, then was used untrimmed

`AcmeConfig::validate()` trims only for its blank and wildcard checks but **stores** the entry untrimmed — and the untrimmed string is what `CertificateParams::new` turns into the certificate's SAN (`autumn/src/acme/renewal.rs:679`) and what becomes the ACME order's `Identifier::Dns` (`renewal.rs:598`). So `domains = [" app.example.com "]` was requested verbatim and failed mid-issuance with an opaque CA error.

`validate()` now rejects `domain != domain.trim()`, naming the entry, its index, and the trimmed spelling to use. Rejecting rather than silently normalising is deliberate: quietly trimming would issue a certificate for a name the operator did not literally write.

The **doctor grader mirrors the same rule** — the issue is about parity, and leaving doctor lenient would just re-open the gap in the other direction.

Per-entry rule order is blank → wildcard → untrimmed on both sides, so `" *.example.com "` still reports the wildcard (the deeper problem, and the message operators get today) rather than the padding.

## Tests

TDD, with each red observed before its green:

| Phase | Evidence |
|---|---|
| 🔴 | `validate_acme_whitespace_padded_domain_rejected` failed — `validate()` returned `Ok(())` for every padded form |
| 🟢 | Rule added; all 10 `validate_acme_*` pass |
| 🔴 | `acme_config_fail_when_renew_before_days_malformed` and `..._domain_entry_whitespace_padded` failed at assertion level (the parse recorded the bad value, the grader still passed it) |
| 🟢 | Grader branches added; all 41 `doctor::tests::acme_*` pass |

New coverage beyond the issue's "a doctor/validate test each":

- **`acme_config_grader_agrees_with_runtime_validate`** — the doctor grader is a hand-copy of `AcmeConfig::validate()` and the two have now drifted three times (#1608, plus both items here). Every other test pins one side against a hardcoded expectation; nothing pinned the two sides against *each other*. This asserts equal verdicts across 15 configs, and a new `AcmeConfig` field breaks its compile.
- **`acme_numeric_fields_reject_non_integer_toml_values`** — pins the premise the entire doctor fix rests on: that runtime serde really does reject these spellings. Without it, a future lenient `deserialize_with` would make doctor fail a file that boots fine, with nothing to catch it.
- Assertions strengthened where a wrong-but-plausible fix would have passed: the malformed-`renew_before_days` detail must carry the **quoted** `"30"` and the deserialize-tier wording (not the `>= 90` wording), and the padded-domain message must echo the operator's **raw** entry, not only the trimmed spelling it suggests.

## Refactor (no behavior change)

`check_acme_config_impl` takes `&AcmeDoctorConfig` instead of 7 positional args — an 8th would trip `clippy::too_many_arguments` — and its "the runtime cannot even parse this" tier moved into `check_acme_deserialize_errors`, clearing a real `too_many_lines` (102/100). The two near-identical scalar parsers collapse onto a generic `parse_acme_scalar`, and the thrice-duplicated `fail` closure onto one `const acme_config_fail`.

## Known gap, deliberately out of scope

`cache_dir` still uses the same lenient `and_then(as_str)` pattern one binding below the one fixed here, so `cache_dir = 42` passes `doctor --strict` while the runtime refuses to boot (and doctor then inspects an invented directory). Same bug class, and now nearly a one-liner with `parse_acme_scalar` — but it is not in this issue's scope, which was explicitly batched to these two items. Filed as a follow-up rather than widening this PR.

## Verification

- `cargo test -p autumn-web --lib config::tests::{acme,validate_acme}` — 15 pass
- `cargo test -p autumn-cli --bin autumn doctor::tests::acme_` — 41 pass
- `cargo clippy -p autumn-cli --all-targets -- -D warnings` — clean
- `./scripts/pre-push-check.sh` — an earlier run caught `missing_const_for_fn` + `unnecessary_wraps` on the new helper under `-D warnings` (a scoped clippy run without `-D warnings` reports them as warnings, which is how they were missed); both fixed, full gate re-running.
- No example, starter, fixture, doc, or deploy script in the repo uses a padded `domains` entry, so the new startup rejection breaks nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fzuq1humVRgrY8xqK23sG5

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fzuq1humVRgrY8xqK23sG5)_