### PR TITLE
🧭 Wayfinder: redisplay admin form on validation failure (error-path 0/4 → 4/4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -678,6 +678,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   touches any ambient runtime, closing both failure points. Verified against
   a real TLS-enabled Postgres server, on both a `current_thread` and
   `multi_thread` tokio runtime, called directly from an async body.
+- **Admin panel: a create/edit form that fails validation no longer discards
+  everything the admin typed:** `POST /{slug}` and `POST /{slug}/{id}` — the
+  only mutation UI the framework ships, used identically by every model in
+  every admin-plugin deployment — propagated a malformed field (e.g.
+  unparsable JSON) or a model-declared `AdminError::Validation` (e.g. a
+  uniqueness check) as a bare `AutumnError`. That renders as a generic error
+  response with no reference back to the form: a full-page navigation away,
+  a "Go to homepage" link as the only recovery step, and every value the
+  admin had entered gone. Both handlers now catch just that failure class and
+  re-render the same form (HTTP 422) with every submitted value still filled
+  in and the failure shown through the existing persistent, accessible flash
+  banner — no toast, no blank form. On update, the redisplayed form is
+  merged with the stored record so `create_only` fields (rendered read-only,
+  never resubmitted) keep showing their real value instead of going blank.
+  Other failure classes (missing pool, unknown model, database outage) are
+  unchanged and still render the generic error page.
 
 ### Added
 

--- a/autumn-admin-plugin/src/routes.rs
+++ b/autumn-admin-plugin/src/routes.rs
@@ -484,24 +484,31 @@ fn invalid_form_response(
 /// through the form post. Merge the submitted edits onto the stored record so
 /// those columns keep showing their real value on redisplay instead of going
 /// blank.
+///
+/// A genuinely missing record (`Ok(None)` — e.g. deleted between the edit
+/// page loading and this submit) falls back to `submitted` alone, same as
+/// before: there is no stored record to merge with. A fetch error, though,
+/// is a real backend problem (e.g. `AdminError::Database`) unrelated to the
+/// admin's input — it must reach the caller so it renders the normal error
+/// response, not be swallowed into a 422 that quietly blanks out every
+/// `create_only` field and calls it a validation failure (Codex review,
+/// PR #2422).
 async fn merge_with_stored_record(
     model: &dyn AdminModel,
     pool: &Pool<::autumn_web::RuntimeConnection>,
     id: i64,
     submitted: &Value,
-) -> Value {
+) -> Result<Value, AdminError> {
     let mut base = model
         .get(pool, id)
-        .await
-        .ok()
-        .flatten()
+        .await?
         .unwrap_or_else(|| submitted.clone());
     if let (Some(obj), Some(sub)) = (base.as_object_mut(), submitted.as_object()) {
         for (k, v) in sub {
             obj.insert(k.clone(), v.clone());
         }
     }
-    base
+    Ok(base)
 }
 
 /// Extract the value of the `__autumn_reveal` cookie from request headers.
@@ -1102,7 +1109,10 @@ async fn model_update(
     let form_data = match coerce_form_fields(submitted, &fields) {
         Ok(v) => v,
         Err((partial, field_names, msg)) => {
-            let display = merge_with_stored_record(model, &pool, id, &partial).await;
+            let display = match merge_with_stored_record(model, &pool, id, &partial).await {
+                Ok(v) => v,
+                Err(e) => return Err(admin_err("Update failed", e)),
+            };
             return Ok(invalid_form_response(
                 &registry,
                 &slug,
@@ -1122,7 +1132,10 @@ async fn model_update(
     };
     if let Err(e) = model.update(&pool, id, form_data.clone()).await {
         if let AdminError::Validation(msg) = e {
-            let display = merge_with_stored_record(model, &pool, id, &form_data).await;
+            let display = match merge_with_stored_record(model, &pool, id, &form_data).await {
+                Ok(v) => v,
+                Err(e) => return Err(admin_err("Update failed", e)),
+            };
             return Ok(invalid_form_response(
                 &registry,
                 &slug,
@@ -1897,6 +1910,11 @@ mod tests {
                         "owner": "alice",
                         "metadata": {"a": 1},
                     })))
+                } else if id == 999 {
+                    // Sentinel id simulating a backend outage on the
+                    // refetch `merge_with_stored_record` does to redisplay
+                    // an update's `create_only` fields correctly.
+                    Err(AdminError::Database("simulated outage".into()))
                 } else {
                     Ok(None)
                 }
@@ -2130,6 +2148,30 @@ mod tests {
         // its stored value on redisplay instead of going blank.
         assert!(html.contains("alice"), "html: {html}");
         assert!(!html.contains("Go to homepage"), "html: {html}");
+    }
+
+    #[tokio::test]
+    async fn model_update_validation_error_propagates_a_refetch_backend_failure() {
+        // Codex review, PR #2422: `merge_with_stored_record`'s refetch (done
+        // purely to redisplay `create_only` fields correctly) used to turn
+        // ANY error from it — including a real backend outage — into a
+        // silent fallback, masking the outage as an ordinary 422 validation
+        // failure with blanked-out `create_only` fields. It must surface as
+        // the normal error response instead.
+        let (status, body) = post_form(
+            form_test_app(),
+            "/widgets/999",
+            &[("name", "taken"), ("metadata", "{}")],
+        )
+        .await;
+
+        assert_ne!(
+            status,
+            StatusCode::UNPROCESSABLE_ENTITY,
+            "a backend outage on the refetch must not be reported as a validation failure: {body}"
+        );
+        assert!(status.is_server_error(), "status: {status}, body: {body}");
+        assert!(body.contains("simulated outage"), "body: {body}");
     }
 
     #[tokio::test]

--- a/autumn-admin-plugin/src/routes.rs
+++ b/autumn-admin-plugin/src/routes.rs
@@ -438,6 +438,13 @@ fn invalid_form_response(
     model: &dyn AdminModel,
     fields: &[AdminField],
     submitted: &Value,
+    // Names of fields in `submitted` whose value is raw, unparsed form text
+    // (e.g. a `Json` field that failed to parse) rather than a genuinely
+    // typed value — forwarded to `model_form_page` so it skips round-tripping
+    // that one field through `Value::to_string()` and shows the raw text
+    // verbatim instead. Empty when `submitted` is fully coerced/typed (the
+    // `AdminError::Validation` case).
+    raw_fields: &[&str],
     error_message: String,
     id: Option<i64>,
     csrf: &AdminCsrf,
@@ -458,6 +465,7 @@ fn invalid_form_response(
         fields,
         Some(submitted),
         id,
+        raw_fields,
         &messages,
         csrf.token(),
         csrf.form_field(),
@@ -766,6 +774,7 @@ async fn model_new_form(
         &fields,
         None,
         None,
+        &[],
         &messages,
         csrf.token(),
         csrf.form_field(),
@@ -796,15 +805,16 @@ async fn model_create(
 
     let fields = model.fields();
     let submitted = strip_meta_fields(form_data, &fields, false);
-    let form_data = match coerce_form_fields(submitted.clone(), &fields) {
+    let form_data = match coerce_form_fields(submitted, &fields) {
         Ok(v) => v,
-        Err(msg) => {
+        Err((partial, field_name, msg)) => {
             return Ok(invalid_form_response(
                 &registry,
                 &slug,
                 model,
                 &fields,
-                &submitted,
+                &partial,
+                &[field_name],
                 msg,
                 None,
                 &csrf,
@@ -824,6 +834,7 @@ async fn model_create(
                 model,
                 &fields,
                 &form_data,
+                &[],
                 msg,
                 None,
                 &csrf,
@@ -1057,6 +1068,7 @@ async fn model_edit_form(
         &fields,
         Some(&record),
         Some(id),
+        &[],
         &messages,
         csrf.token(),
         csrf.form_field(),
@@ -1087,16 +1099,17 @@ async fn model_update(
 
     let fields = model.fields();
     let submitted = strip_meta_fields(form_data, &fields, true);
-    let form_data = match coerce_form_fields(submitted.clone(), &fields) {
+    let form_data = match coerce_form_fields(submitted, &fields) {
         Ok(v) => v,
-        Err(msg) => {
-            let display = merge_with_stored_record(model, &pool, id, &submitted).await;
+        Err((partial, field_name, msg)) => {
+            let display = merge_with_stored_record(model, &pool, id, &partial).await;
             return Ok(invalid_form_response(
                 &registry,
                 &slug,
                 model,
                 &fields,
                 &display,
+                &[field_name],
                 msg,
                 Some(id),
                 &csrf,
@@ -1116,6 +1129,7 @@ async fn model_update(
                 model,
                 &fields,
                 &display,
+                &[],
                 msg,
                 Some(id),
                 &csrf,
@@ -1664,19 +1678,34 @@ fn strip_meta_fields(mut data: Value, fields: &[AdminField], for_update: bool) -
     data
 }
 
-fn coerce_form_fields(mut data: Value, fields: &[AdminField]) -> Result<Value, String> {
-    let Some(obj) = data.as_object_mut() else {
-        return Ok(data);
-    };
-
-    for field in fields {
-        let Some(value) = obj.get_mut(field.name) else {
-            continue;
-        };
-        coerce_form_value(value, field)?;
+/// Coerce every field's raw form-string value to its declared type.
+///
+/// On the first field that fails to coerce (currently only possible for
+/// `Json`), stops and returns the partially-coerced `data` alongside the
+/// failing field's name and message — rather than discarding it — so a
+/// caller redisplaying the form after a validation failure can show every
+/// other field's value normally and single out just the one that didn't
+/// parse (see `render_form_widget`'s `raw_fields`).
+fn coerce_form_fields(
+    mut data: Value,
+    fields: &[AdminField],
+) -> Result<Value, (Value, &'static str, String)> {
+    let mut failure: Option<(&'static str, String)> = None;
+    if let Some(obj) = data.as_object_mut() {
+        for field in fields {
+            let Some(value) = obj.get_mut(field.name) else {
+                continue;
+            };
+            if let Err(msg) = coerce_form_value(value, field) {
+                failure = Some((field.name, msg));
+                break;
+            }
+        }
     }
-
-    Ok(data)
+    match failure {
+        Some((field_name, msg)) => Err((data, field_name, msg)),
+        None => Ok(data),
+    }
 }
 
 fn coerce_form_value(value: &mut Value, field: &AdminField) -> Result<(), String> {
@@ -1828,6 +1857,9 @@ mod tests {
                 AdminField::new("name", AdminFieldKind::Text),
                 AdminField::new("owner", AdminFieldKind::Text).create_only(),
                 AdminField::new("metadata", AdminFieldKind::Json),
+                AdminField::new("api_key", AdminFieldKind::Text)
+                    .optional()
+                    .encrypted(),
             ]
         }
         fn list(
@@ -1972,9 +2004,56 @@ mod tests {
         assert_eq!(status, StatusCode::UNPROCESSABLE_ENTITY, "html: {html}");
         assert!(html.contains("New Widget"), "html: {html}");
         assert!(html.contains(r#"value="Widget X""#), "html: {html}");
-        assert!(html.contains("{broken"), "html: {html}");
         assert!(html.contains("invalid JSON"), "html: {html}");
         assert!(!html.contains("Go to homepage"), "html: {html}");
+        // The malformed text must reach the textarea VERBATIM — not
+        // round-tripped through `Value::to_string()`, which would wrap it in
+        // an extra pair of quotes (`"{broken"`) and risk silently persisting
+        // that as a valid-but-wrong JSON string on a blind resubmit (Codex
+        // review, PR #2422).
+        assert!(
+            html.contains(">{broken</textarea>"),
+            "malformed JSON must render raw, unquoted: {html}"
+        );
+        assert!(
+            !html.contains(r"&quot;{broken&quot;") && !html.contains(r#">"{broken"</textarea>"#),
+            "malformed JSON must not be re-quoted: {html}"
+        );
+    }
+
+    #[tokio::test]
+    async fn model_create_malformed_json_keeps_encrypted_field_editable() {
+        // A validation failure on CREATE passes `Some(record)` to
+        // `model_form_page` (the resubmitted values) so they can be
+        // refilled — but the encrypted-field branch must still treat this
+        // as CREATE (no stored ciphertext to protect yet), not EDIT, or an
+        // encrypted field silently becomes a disabled, unsubmittable control
+        // and the admin can never get past validation for a model with a
+        // required encrypted column (Codex review, PR #2422).
+        let (status, html) = post_form(
+            form_test_app(),
+            "/widgets",
+            &[
+                ("name", "Widget X"),
+                ("metadata", "{broken"),
+                ("api_key", "sk-live-123"),
+            ],
+        )
+        .await;
+
+        assert_eq!(status, StatusCode::UNPROCESSABLE_ENTITY, "html: {html}");
+        assert!(
+            html.contains(r#"name="api_key""#),
+            "encrypted field must stay submittable on a create failure: {html}"
+        );
+        // The redacted edit-only control has no `name=` attribute at all (so
+        // it never submits and can't overwrite the stored ciphertext) — the
+        // `name="api_key"` check above already rules it out; this pins down
+        // the other half of that control's shape.
+        assert!(
+            !html.contains("••••••••"),
+            "encrypted field must not show the edit-only redaction mask on create: {html}"
+        );
     }
 
     #[tokio::test]
@@ -2235,12 +2314,17 @@ mod tests {
         // a raw string — so a malformed, non-blank submission must be rejected
         // here rather than silently persisted as a JSON string literal.
         let fields = vec![AdminField::new("settings", AdminFieldKind::Json)];
-        let err = coerce_form_fields(json!({"settings": "{broken"}), &fields)
-            .expect_err("malformed non-blank JSON must be rejected, not silently stored");
-        assert!(
-            err.contains("settings"),
-            "error should name the offending field: {err}"
+        let (partial, field_name, msg) =
+            coerce_form_fields(json!({"settings": "{broken"}), &fields)
+                .expect_err("malformed non-blank JSON must be rejected, not silently stored");
+        assert_eq!(
+            field_name, "settings",
+            "error should name the offending field"
         );
+        assert!(msg.contains("settings"), "error message: {msg}");
+        // The raw, unparsed text survives in the partial result so the caller
+        // can redisplay exactly what the admin typed.
+        assert_eq!(partial, json!({"settings": "{broken"}));
 
         // Nullable columns are rejected the same way.
         let fields = vec![AdminField::new("settings", AdminFieldKind::Json).optional()];
@@ -2251,6 +2335,23 @@ mod tests {
         let fields = vec![AdminField::new("settings", AdminFieldKind::Json)];
         let out = coerce_form_fields(json!({"settings": "\"not broken\""}), &fields).unwrap();
         assert_eq!(out, json!({"settings": "not broken"}));
+    }
+
+    #[test]
+    fn coerce_form_fields_partial_result_keeps_earlier_fields_coerced() {
+        // A field ahead of the failing one in declaration order must still
+        // come back properly typed in the partial result — only the failing
+        // field itself is left as raw text (routes.rs's redisplay path
+        // relies on this: every other widget renders normally).
+        let fields = vec![
+            AdminField::new("count", AdminFieldKind::Integer),
+            AdminField::new("settings", AdminFieldKind::Json),
+        ];
+        let (partial, field_name, _msg) =
+            coerce_form_fields(json!({"count": "42", "settings": "{broken"}), &fields)
+                .expect_err("malformed JSON must be rejected");
+        assert_eq!(field_name, "settings");
+        assert_eq!(partial, json!({"count": 42, "settings": "{broken"}));
     }
 
     #[test]

--- a/autumn-admin-plugin/src/routes.rs
+++ b/autumn-admin-plugin/src/routes.rs
@@ -807,14 +807,14 @@ async fn model_create(
     let submitted = strip_meta_fields(form_data, &fields, false);
     let form_data = match coerce_form_fields(submitted, &fields) {
         Ok(v) => v,
-        Err((partial, field_name, msg)) => {
+        Err((partial, field_names, msg)) => {
             return Ok(invalid_form_response(
                 &registry,
                 &slug,
                 model,
                 &fields,
                 &partial,
-                &[field_name],
+                &field_names,
                 msg,
                 None,
                 &csrf,
@@ -1101,7 +1101,7 @@ async fn model_update(
     let submitted = strip_meta_fields(form_data, &fields, true);
     let form_data = match coerce_form_fields(submitted, &fields) {
         Ok(v) => v,
-        Err((partial, field_name, msg)) => {
+        Err((partial, field_names, msg)) => {
             let display = merge_with_stored_record(model, &pool, id, &partial).await;
             return Ok(invalid_form_response(
                 &registry,
@@ -1109,7 +1109,7 @@ async fn model_update(
                 model,
                 &fields,
                 &display,
-                &[field_name],
+                &field_names,
                 msg,
                 Some(id),
                 &csrf,
@@ -1680,31 +1680,38 @@ fn strip_meta_fields(mut data: Value, fields: &[AdminField], for_update: bool) -
 
 /// Coerce every field's raw form-string value to its declared type.
 ///
-/// On the first field that fails to coerce (currently only possible for
-/// `Json`), stops and returns the partially-coerced `data` alongside the
-/// failing field's name and message — rather than discarding it — so a
-/// caller redisplaying the form after a validation failure can show every
-/// other field's value normally and single out just the one that didn't
-/// parse (see `render_form_widget`'s `raw_fields`).
+/// Attempts every field regardless of earlier failures (currently only
+/// possible for `Json`) — never stops at the first one — so a field
+/// declared after a malformed one still comes back properly typed rather
+/// than redisplaying with its pre-coercion raw string (e.g. a checked
+/// `Boolean` appearing unchecked, or a valid JSON object getting
+/// re-quoted). Returns the fully-attempted `data` alongside every failing
+/// field's name and a combined message on error — rather than discarding
+/// it — so a caller redisplaying the form after a validation failure can
+/// show every successfully coerced field normally and single out just the
+/// field(s) that didn't parse (see `render_form_widget`'s `raw_fields`;
+/// Codex review, PR #2422).
 fn coerce_form_fields(
     mut data: Value,
     fields: &[AdminField],
-) -> Result<Value, (Value, &'static str, String)> {
-    let mut failure: Option<(&'static str, String)> = None;
+) -> Result<Value, (Value, Vec<&'static str>, String)> {
+    let mut failed_names = Vec::new();
+    let mut messages = Vec::new();
     if let Some(obj) = data.as_object_mut() {
         for field in fields {
             let Some(value) = obj.get_mut(field.name) else {
                 continue;
             };
             if let Err(msg) = coerce_form_value(value, field) {
-                failure = Some((field.name, msg));
-                break;
+                failed_names.push(field.name);
+                messages.push(msg);
             }
         }
     }
-    match failure {
-        Some((field_name, msg)) => Err((data, field_name, msg)),
-        None => Ok(data),
+    if messages.is_empty() {
+        Ok(data)
+    } else {
+        Err((data, failed_names, messages.join("; ")))
     }
 }
 
@@ -1860,6 +1867,7 @@ mod tests {
                 AdminField::new("api_key", AdminFieldKind::Text)
                     .optional()
                     .encrypted(),
+                AdminField::new("published", AdminFieldKind::Boolean).optional(),
             ]
         }
         fn list(
@@ -2053,6 +2061,38 @@ mod tests {
         assert!(
             !html.contains("••••••••"),
             "encrypted field must not show the edit-only redaction mask on create: {html}"
+        );
+        // The admin's just-typed secret must not round-trip back into the
+        // response body (Codex review, PR #2422) — the control stays
+        // enabled and submittable, but blank, so they retype it.
+        assert!(
+            !html.contains("sk-live-123"),
+            "encrypted field's plaintext must not leak into the redisplayed HTML: {html}"
+        );
+    }
+
+    #[tokio::test]
+    async fn model_create_malformed_json_keeps_other_fields_coerced() {
+        // Codex review, PR #2422: coercion used to stop at the first
+        // failure, leaving every later field's raw form string uncoerced —
+        // a checked Boolean would redisplay unchecked. `published` is
+        // declared after `metadata` on `FormTestModel`, so this exercises
+        // exactly that ordering.
+        let (status, html) = post_form(
+            form_test_app(),
+            "/widgets",
+            &[
+                ("name", "Widget X"),
+                ("metadata", "{broken"),
+                ("published", "true"),
+            ],
+        )
+        .await;
+
+        assert_eq!(status, StatusCode::UNPROCESSABLE_ENTITY, "html: {html}");
+        assert!(
+            html.contains(r#"id="published" value="true" checked"#),
+            "a later field must still coerce and redisplay checked: {html}"
         );
     }
 
@@ -2314,11 +2354,12 @@ mod tests {
         // a raw string — so a malformed, non-blank submission must be rejected
         // here rather than silently persisted as a JSON string literal.
         let fields = vec![AdminField::new("settings", AdminFieldKind::Json)];
-        let (partial, field_name, msg) =
+        let (partial, field_names, msg) =
             coerce_form_fields(json!({"settings": "{broken"}), &fields)
                 .expect_err("malformed non-blank JSON must be rejected, not silently stored");
         assert_eq!(
-            field_name, "settings",
+            field_names,
+            vec!["settings"],
             "error should name the offending field"
         );
         assert!(msg.contains("settings"), "error message: {msg}");
@@ -2347,11 +2388,49 @@ mod tests {
             AdminField::new("count", AdminFieldKind::Integer),
             AdminField::new("settings", AdminFieldKind::Json),
         ];
-        let (partial, field_name, _msg) =
+        let (partial, field_names, _msg) =
             coerce_form_fields(json!({"count": "42", "settings": "{broken"}), &fields)
                 .expect_err("malformed JSON must be rejected");
-        assert_eq!(field_name, "settings");
+        assert_eq!(field_names, vec!["settings"]);
         assert_eq!(partial, json!({"count": 42, "settings": "{broken"}));
+    }
+
+    #[test]
+    fn coerce_form_fields_still_coerces_fields_declared_after_a_failure() {
+        // Codex review, PR #2422: stopping at the first failure left every
+        // LATER field's raw form string uncoerced too — a checked Boolean
+        // after a malformed Json field would redisplay unchecked, and if the
+        // admin didn't notice and resubmitted, that wrong value would be
+        // persisted. Coercion must keep going past a failure.
+        let fields = vec![
+            AdminField::new("settings", AdminFieldKind::Json),
+            AdminField::new("published", AdminFieldKind::Boolean),
+        ];
+        let (partial, field_names, _msg) =
+            coerce_form_fields(json!({"settings": "{broken", "published": "true"}), &fields)
+                .expect_err("malformed JSON must be rejected");
+        assert_eq!(field_names, vec!["settings"]);
+        assert_eq!(
+            partial,
+            json!({"settings": "{broken", "published": true}),
+            "a field declared after the failing one must still coerce"
+        );
+    }
+
+    #[test]
+    fn coerce_form_fields_collects_every_failing_field() {
+        // Two independently malformed Json fields must both be named and
+        // both kept as raw text — not just the first one encountered.
+        let fields = vec![
+            AdminField::new("a", AdminFieldKind::Json),
+            AdminField::new("b", AdminFieldKind::Json),
+        ];
+        let (partial, field_names, msg) =
+            coerce_form_fields(json!({"a": "{broken", "b": "[also-broken"}), &fields)
+                .expect_err("both malformed fields must be rejected");
+        assert_eq!(field_names, vec!["a", "b"]);
+        assert!(msg.contains('a') && msg.contains('b'), "message: {msg}");
+        assert_eq!(partial, json!({"a": "{broken", "b": "[also-broken"}));
     }
 
     #[test]

--- a/autumn-admin-plugin/src/routes.rs
+++ b/autumn-admin-plugin/src/routes.rs
@@ -426,6 +426,76 @@ fn render(markup: maud::Markup) -> Response {
     Html(markup.into_string()).into_response()
 }
 
+/// Re-render the create/edit form after a validation failure instead of
+/// navigating away to the generic error page. Preserves every value the
+/// admin typed (`submitted`) and surfaces `error_message` through the same
+/// persistent, accessible flash banner every other page uses — no toast, no
+/// blank form, no lost input.
+#[allow(clippy::too_many_arguments)]
+fn invalid_form_response(
+    registry: &AdminRegistry,
+    slug: &str,
+    model: &dyn AdminModel,
+    fields: &[AdminField],
+    submitted: &Value,
+    error_message: String,
+    id: Option<i64>,
+    csrf: &AdminCsrf,
+    prefix: &str,
+    actuator_prefix: &str,
+    show_config: bool,
+    imp: &AdminImpersonation,
+) -> Response {
+    let messages = [FlashMessage {
+        level: FlashLevel::Error,
+        message: error_message,
+    }];
+    let markup = templates::model_form_page(
+        registry,
+        slug,
+        model.display_name(),
+        model.display_name_plural(),
+        fields,
+        Some(submitted),
+        id,
+        &messages,
+        csrf.token(),
+        csrf.form_field(),
+        csrf.token_header(),
+        prefix,
+        actuator_prefix,
+        show_config,
+        imp.banner(prefix, csrf.token(), csrf.form_field()).as_ref(),
+    );
+    (StatusCode::UNPROCESSABLE_ENTITY, Html(markup.into_string())).into_response()
+}
+
+/// After a validation failure on update, `submitted` holds only the fields
+/// the browser actually sent — create-only columns render read-only with no
+/// `name` attribute (see `render_readonly_display`), so they never round-trip
+/// through the form post. Merge the submitted edits onto the stored record so
+/// those columns keep showing their real value on redisplay instead of going
+/// blank.
+async fn merge_with_stored_record(
+    model: &dyn AdminModel,
+    pool: &Pool<::autumn_web::RuntimeConnection>,
+    id: i64,
+    submitted: &Value,
+) -> Value {
+    let mut base = model
+        .get(pool, id)
+        .await
+        .ok()
+        .flatten()
+        .unwrap_or_else(|| submitted.clone());
+    if let (Some(obj), Some(sub)) = (base.as_object_mut(), submitted.as_object()) {
+        for (k, v) in sub {
+            obj.insert(k.clone(), v.clone());
+        }
+    }
+    base
+}
+
 /// Extract the value of the `__autumn_reveal` cookie from request headers.
 fn extract_reveal_cookie(headers: &axum::http::HeaderMap) -> Option<String> {
     let cookie_str = headers.get(axum::http::header::COOKIE)?.to_str().ok()?;
@@ -709,23 +779,62 @@ async fn model_new_form(
 }
 
 /// `POST /admin/{slug}` — Create a record.
+#[allow(clippy::too_many_arguments)]
 async fn model_create(
+    imp: AdminImpersonation,
     State(state): State<AppState>,
     axum::Extension(registry): axum::Extension<Arc<AdminRegistry>>,
     axum::Extension(AdminPrefix(prefix)): axum::Extension<AdminPrefix>,
+    axum::Extension(ActuatorPrefix(actuator_prefix)): axum::Extension<ActuatorPrefix>,
+    axum::Extension(HasRuntimeConfig(show_config)): axum::Extension<HasRuntimeConfig>,
     Path(slug): Path<String>,
+    csrf: AdminCsrf,
     flash: Flash,
     axum::extract::Form(form_data): axum::extract::Form<Value>,
 ) -> AutumnResult<Response> {
     let (pool, model) = resolve(&state, &registry, &slug)?;
 
     let fields = model.fields();
-    let form_data = coerce_form_fields(strip_meta_fields(form_data, &fields, false), &fields)
-        .map_err(AutumnError::bad_request_msg)?;
-    let record = model
-        .create(&pool, form_data)
-        .await
-        .map_err(|e| admin_err("Create failed", e))?;
+    let submitted = strip_meta_fields(form_data, &fields, false);
+    let form_data = match coerce_form_fields(submitted.clone(), &fields) {
+        Ok(v) => v,
+        Err(msg) => {
+            return Ok(invalid_form_response(
+                &registry,
+                &slug,
+                model,
+                &fields,
+                &submitted,
+                msg,
+                None,
+                &csrf,
+                &prefix,
+                &actuator_prefix,
+                show_config,
+                &imp,
+            ));
+        }
+    };
+    let record = match model.create(&pool, form_data.clone()).await {
+        Ok(record) => record,
+        Err(AdminError::Validation(msg)) => {
+            return Ok(invalid_form_response(
+                &registry,
+                &slug,
+                model,
+                &fields,
+                &form_data,
+                msg,
+                None,
+                &csrf,
+                &prefix,
+                &actuator_prefix,
+                show_config,
+                &imp,
+            ));
+        }
+        Err(e) => return Err(admin_err("Create failed", e)),
+    };
     // The post-create redirect needs a routable ID. Treat a missing or
     // non-numeric `id` as a model-impl bug rather than silently sending
     // the admin to `/{slug}/0` (which lands on the wrong row or a 404).
@@ -961,23 +1070,63 @@ async fn model_edit_form(
 }
 
 /// `POST /admin/{slug}/{id}` — Update a record.
+#[allow(clippy::too_many_arguments)]
 async fn model_update(
+    imp: AdminImpersonation,
     State(state): State<AppState>,
     axum::Extension(registry): axum::Extension<Arc<AdminRegistry>>,
     axum::Extension(AdminPrefix(prefix)): axum::Extension<AdminPrefix>,
+    axum::Extension(ActuatorPrefix(actuator_prefix)): axum::Extension<ActuatorPrefix>,
+    axum::Extension(HasRuntimeConfig(show_config)): axum::Extension<HasRuntimeConfig>,
     Path((slug, id)): Path<(String, i64)>,
+    csrf: AdminCsrf,
     flash: Flash,
     axum::extract::Form(form_data): axum::extract::Form<Value>,
 ) -> AutumnResult<Response> {
     let (pool, model) = resolve(&state, &registry, &slug)?;
 
     let fields = model.fields();
-    let form_data = coerce_form_fields(strip_meta_fields(form_data, &fields, true), &fields)
-        .map_err(AutumnError::bad_request_msg)?;
-    model
-        .update(&pool, id, form_data)
-        .await
-        .map_err(|e| admin_err("Update failed", e))?;
+    let submitted = strip_meta_fields(form_data, &fields, true);
+    let form_data = match coerce_form_fields(submitted.clone(), &fields) {
+        Ok(v) => v,
+        Err(msg) => {
+            let display = merge_with_stored_record(model, &pool, id, &submitted).await;
+            return Ok(invalid_form_response(
+                &registry,
+                &slug,
+                model,
+                &fields,
+                &display,
+                msg,
+                Some(id),
+                &csrf,
+                &prefix,
+                &actuator_prefix,
+                show_config,
+                &imp,
+            ));
+        }
+    };
+    if let Err(e) = model.update(&pool, id, form_data.clone()).await {
+        if let AdminError::Validation(msg) = e {
+            let display = merge_with_stored_record(model, &pool, id, &form_data).await;
+            return Ok(invalid_form_response(
+                &registry,
+                &slug,
+                model,
+                &fields,
+                &display,
+                msg,
+                Some(id),
+                &csrf,
+                &prefix,
+                &actuator_prefix,
+                show_config,
+                &imp,
+            ));
+        }
+        return Err(admin_err("Update failed", e));
+    }
     flash
         .success(format!("{} #{id} updated.", model.display_name()))
         .await;
@@ -1776,11 +1925,13 @@ mod tests {
         uri: &str,
         pairs: &[(&str, &str)],
     ) -> (StatusCode, String) {
-        let mut ser = form_urlencoded::Serializer::new(String::new());
-        for (k, v) in pairs {
-            ser.append_pair(k, v);
-        }
-        let body = ser.finish();
+        let body = {
+            let mut ser = form_urlencoded::Serializer::new(String::new());
+            for (k, v) in pairs {
+                ser.append_pair(k, v);
+            }
+            ser.finish()
+        };
         let response = app
             .oneshot(
                 axum::http::Request::builder()
@@ -1803,63 +1954,63 @@ mod tests {
         (status, String::from_utf8(bytes.to_vec()).expect("utf8"))
     }
 
-    // BASELINE (measured on this commit, unfixed): a `POST /{slug}` or
-    // `POST /{slug}/{id}` that fails validation propagates as a bare
-    // `AutumnError`, which turns into a `application/problem+json` body —
-    // status 400, `{"type":...,"title":"Bad Request","detail":"...",...}`.
-    // No `<form>`, no re-rendered field, none of the other values the admin
-    // typed (e.g. `name=Widget X` here). Every one of the four error-path
-    // booleans fails: not adjacent to its cause (it isn't the form at all —
-    // it's a different content type), doesn't state a recovery step beyond
-    // "something was invalid", and every submitted value is gone.
+    // FIXED: a validation failure on `POST /{slug}` or `POST /{slug}/{id}`
+    // now re-renders the same form (422, HTML) with every value the admin
+    // typed still filled in and the failure surfaced through the same
+    // persistent, accessible flash banner every other admin page uses —
+    // instead of discarding the form for a bare `application/problem+json`
+    // body. See the previous commit for the measured baseline this replaces.
     #[tokio::test]
-    async fn model_create_malformed_json_discards_the_whole_form() {
-        let (status, body) = post_form(
+    async fn model_create_malformed_json_redisplays_form_with_entered_data() {
+        let (status, html) = post_form(
             form_test_app(),
             "/widgets",
             &[("name", "Widget X"), ("metadata", "{broken")],
         )
         .await;
 
-        assert_eq!(status, StatusCode::BAD_REQUEST, "body: {body}");
-        assert!(
-            body.contains(r#""status":400"#) && body.contains("invalid JSON"),
-            "body: {body}"
-        );
-        // The admin's `name` entry never appears anywhere in the response —
-        // it's simply gone.
-        assert!(!body.contains("Widget X"), "body: {body}");
-        assert!(!body.contains("<form"), "body: {body}");
+        assert_eq!(status, StatusCode::UNPROCESSABLE_ENTITY, "html: {html}");
+        assert!(html.contains("New Widget"), "html: {html}");
+        assert!(html.contains(r#"value="Widget X""#), "html: {html}");
+        assert!(html.contains("{broken"), "html: {html}");
+        assert!(html.contains("invalid JSON"), "html: {html}");
+        assert!(!html.contains("Go to homepage"), "html: {html}");
     }
 
     #[tokio::test]
-    async fn model_create_validation_error_discards_the_whole_form() {
-        let (status, body) = post_form(
+    async fn model_create_validation_error_redisplays_form_with_entered_data() {
+        let (status, html) = post_form(
             form_test_app(),
             "/widgets",
             &[("name", "taken"), ("owner", "bob"), ("metadata", "{}")],
         )
         .await;
 
-        assert_eq!(status, StatusCode::BAD_REQUEST, "body: {body}");
-        assert!(body.contains("name already taken"), "body: {body}");
-        assert!(!body.contains("<form"), "body: {body}");
-        // The `owner` value the admin typed never appears anywhere either.
-        assert!(!body.contains("bob"), "body: {body}");
+        assert_eq!(status, StatusCode::UNPROCESSABLE_ENTITY, "html: {html}");
+        assert!(html.contains("New Widget"), "html: {html}");
+        assert!(html.contains(r#"value="taken""#), "html: {html}");
+        assert!(html.contains("name already taken"), "html: {html}");
+        assert!(!html.contains("Go to homepage"), "html: {html}");
     }
 
     #[tokio::test]
-    async fn model_update_validation_error_discards_the_whole_form() {
-        let (status, body) = post_form(
+    async fn model_update_validation_error_preserves_create_only_field_and_entered_data() {
+        let (status, html) = post_form(
             form_test_app(),
             "/widgets/1",
             &[("name", "taken"), ("metadata", "{}")],
         )
         .await;
 
-        assert_eq!(status, StatusCode::BAD_REQUEST, "body: {body}");
-        assert!(body.contains("name already taken"), "body: {body}");
-        assert!(!body.contains("<form"), "body: {body}");
+        assert_eq!(status, StatusCode::UNPROCESSABLE_ENTITY, "html: {html}");
+        assert!(html.contains("Edit Widget"), "html: {html}");
+        assert!(html.contains(r#"value="taken""#), "html: {html}");
+        assert!(html.contains("name already taken"), "html: {html}");
+        // `owner` is create_only: never submitted by the edit form (it
+        // renders read-only, with no `name=` attribute). It must still show
+        // its stored value on redisplay instead of going blank.
+        assert!(html.contains("alice"), "html: {html}");
+        assert!(!html.contains("Go to homepage"), "html: {html}");
     }
 
     #[tokio::test]

--- a/autumn-admin-plugin/src/routes.rs
+++ b/autumn-admin-plugin/src/routes.rs
@@ -1616,7 +1616,7 @@ fn parse_form_bool(raw: &str) -> Option<bool> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::traits::SelectOption;
+    use crate::traits::{AdminFuture, ListResult, SelectOption};
     use autumn_web::job::{JobAdminBackendEntry, JobAdminMemoryBackend};
     use autumn_web::session::Session;
     use axum::body::Body;
@@ -1630,6 +1630,236 @@ mod tests {
             .cloned()
             .map(|(name, kind)| AdminField::new(name, kind))
             .collect()
+    }
+
+    // ── Validation-failure redisplay (form data loss on 400) ────────────
+    //
+    // Baseline (pre-fix): a validation failure on `POST /{slug}` or
+    // `POST /{slug}/{id}` — malformed JSON in a `Json` field, or the model
+    // rejecting the payload with `AdminError::Validation` — propagated as an
+    // `AutumnError`, which the framework's `ErrorPageFilter` renders as a
+    // full generic error page (status/title/"Go to homepage" link only).
+    // The admin lost every value they had typed; the only recovery step
+    // offered was navigating away. See PR description for the audit.
+    //
+    // A lazy pool that never connects: fine here because every scenario
+    // below fails validation before any handler reaches the database.
+    fn lazy_pool() -> Pool<::autumn_web::RuntimeConnection> {
+        let config = autumn_web::config::DatabaseConfig {
+            url: Some("postgres://localhost/unused".into()),
+            pool_size: 1,
+            ..Default::default()
+        };
+        autumn_web::db::create_pool(&config)
+            .expect("pool config")
+            .expect("pool")
+    }
+
+    /// Minimal `AdminModel` for exercising the create/update
+    /// validation-failure path without a real database. `name == "taken"`
+    /// simulates a model-level validation failure (e.g. a uniqueness
+    /// check); everything else succeeds. `owner` is `create_only` so it
+    /// renders read-only (and is never submitted) on the edit form —
+    /// exactly the case that needs the stored record merged back in on
+    /// redisplay.
+    struct FormTestModel;
+
+    impl AdminModel for FormTestModel {
+        fn slug(&self) -> &'static str {
+            "widgets"
+        }
+        fn display_name(&self) -> &'static str {
+            "Widget"
+        }
+        fn display_name_plural(&self) -> &'static str {
+            "Widgets"
+        }
+        fn fields(&self) -> Vec<AdminField> {
+            vec![
+                AdminField::new("name", AdminFieldKind::Text),
+                AdminField::new("owner", AdminFieldKind::Text).create_only(),
+                AdminField::new("metadata", AdminFieldKind::Json),
+            ]
+        }
+        fn list(
+            &self,
+            _pool: &Pool<::autumn_web::RuntimeConnection>,
+            _params: ListParams,
+        ) -> AdminFuture<'_, ListResult> {
+            Box::pin(async {
+                Ok(ListResult {
+                    records: vec![],
+                    total: 0,
+                    page: 1,
+                    per_page: 25,
+                })
+            })
+        }
+        fn get(
+            &self,
+            _pool: &Pool<::autumn_web::RuntimeConnection>,
+            id: i64,
+        ) -> AdminFuture<'_, Option<Value>> {
+            Box::pin(async move {
+                if id == 1 {
+                    Ok(Some(json!({
+                        "id": 1,
+                        "name": "Widget One",
+                        "owner": "alice",
+                        "metadata": {"a": 1},
+                    })))
+                } else {
+                    Ok(None)
+                }
+            })
+        }
+        fn create(
+            &self,
+            _pool: &Pool<::autumn_web::RuntimeConnection>,
+            data: Value,
+        ) -> AdminFuture<'_, Value> {
+            Box::pin(async move {
+                if data.get("name").and_then(Value::as_str) == Some("taken") {
+                    return Err(AdminError::Validation("name already taken".into()));
+                }
+                let mut record = data;
+                if let Some(obj) = record.as_object_mut() {
+                    obj.insert("id".into(), json!(2));
+                }
+                Ok(record)
+            })
+        }
+        fn update(
+            &self,
+            _pool: &Pool<::autumn_web::RuntimeConnection>,
+            _id: i64,
+            data: Value,
+        ) -> AdminFuture<'_, Value> {
+            Box::pin(async move {
+                if data.get("name").and_then(Value::as_str) == Some("taken") {
+                    return Err(AdminError::Validation("name already taken".into()));
+                }
+                Ok(data)
+            })
+        }
+        fn delete(
+            &self,
+            _pool: &Pool<::autumn_web::RuntimeConnection>,
+            _id: i64,
+        ) -> AdminFuture<'_, ()> {
+            Box::pin(async { Ok(()) })
+        }
+    }
+
+    fn form_test_app() -> axum::Router {
+        let mut registry = AdminRegistry::new();
+        registry.register(FormTestModel);
+        let session = Session::new_for_test("sid".to_owned(), HashMap::new());
+        let state = AppState::for_test().with_pool(lazy_pool());
+        admin_router(
+            Arc::new(registry),
+            "/admin",
+            "/actuator".to_owned(),
+            "user_id".to_owned(),
+            None,
+            None,
+            false,
+            autumn_web::step_up::DEFAULT_MAX_AGE_SECS,
+            false,
+        )
+        .layer(axum::Extension(session))
+        .with_state(state)
+    }
+
+    async fn post_form(
+        app: axum::Router,
+        uri: &str,
+        pairs: &[(&str, &str)],
+    ) -> (StatusCode, String) {
+        let mut ser = form_urlencoded::Serializer::new(String::new());
+        for (k, v) in pairs {
+            ser.append_pair(k, v);
+        }
+        let body = ser.finish();
+        let response = app
+            .oneshot(
+                axum::http::Request::builder()
+                    .method("POST")
+                    .uri(uri)
+                    .header(header::CONTENT_TYPE, "application/x-www-form-urlencoded")
+                    // Real browser form-submit navigation always sends this —
+                    // exercise the same HTML error-page path a real admin hits,
+                    // not the JSON fallback an unspecified `Accept` would take.
+                    .header(header::ACCEPT, "text/html,application/xhtml+xml")
+                    .body(Body::from(body))
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+        let status = response.status();
+        let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("body");
+        (status, String::from_utf8(bytes.to_vec()).expect("utf8"))
+    }
+
+    // BASELINE (measured on this commit, unfixed): a `POST /{slug}` or
+    // `POST /{slug}/{id}` that fails validation propagates as a bare
+    // `AutumnError`, which turns into a `application/problem+json` body —
+    // status 400, `{"type":...,"title":"Bad Request","detail":"...",...}`.
+    // No `<form>`, no re-rendered field, none of the other values the admin
+    // typed (e.g. `name=Widget X` here). Every one of the four error-path
+    // booleans fails: not adjacent to its cause (it isn't the form at all —
+    // it's a different content type), doesn't state a recovery step beyond
+    // "something was invalid", and every submitted value is gone.
+    #[tokio::test]
+    async fn model_create_malformed_json_discards_the_whole_form() {
+        let (status, body) = post_form(
+            form_test_app(),
+            "/widgets",
+            &[("name", "Widget X"), ("metadata", "{broken")],
+        )
+        .await;
+
+        assert_eq!(status, StatusCode::BAD_REQUEST, "body: {body}");
+        assert!(
+            body.contains(r#""status":400"#) && body.contains("invalid JSON"),
+            "body: {body}"
+        );
+        // The admin's `name` entry never appears anywhere in the response —
+        // it's simply gone.
+        assert!(!body.contains("Widget X"), "body: {body}");
+        assert!(!body.contains("<form"), "body: {body}");
+    }
+
+    #[tokio::test]
+    async fn model_create_validation_error_discards_the_whole_form() {
+        let (status, body) = post_form(
+            form_test_app(),
+            "/widgets",
+            &[("name", "taken"), ("owner", "bob"), ("metadata", "{}")],
+        )
+        .await;
+
+        assert_eq!(status, StatusCode::BAD_REQUEST, "body: {body}");
+        assert!(body.contains("name already taken"), "body: {body}");
+        assert!(!body.contains("<form"), "body: {body}");
+        // The `owner` value the admin typed never appears anywhere either.
+        assert!(!body.contains("bob"), "body: {body}");
+    }
+
+    #[tokio::test]
+    async fn model_update_validation_error_discards_the_whole_form() {
+        let (status, body) = post_form(
+            form_test_app(),
+            "/widgets/1",
+            &[("name", "taken"), ("metadata", "{}")],
+        )
+        .await;
+
+        assert_eq!(status, StatusCode::BAD_REQUEST, "body: {body}");
+        assert!(body.contains("name already taken"), "body: {body}");
+        assert!(!body.contains("<form"), "body: {body}");
     }
 
     #[tokio::test]

--- a/autumn-admin-plugin/src/templates.rs
+++ b/autumn-admin-plugin/src/templates.rs
@@ -2318,7 +2318,15 @@ fn render_form_widget(
             // extra pair of quotes, turning `{broken` into the seemingly
             // valid JSON string `"{broken"` and risking a silent resave of
             // the wrong data — Codex review, PR #2422).
-            let json_val = if raw_fields.contains(&field.name) {
+            let json_val = if raw_fields.contains(&field.name) || field.encrypted {
+                // `field.encrypted`: this arm otherwise reads `record`
+                // directly (see the #1341 comment above) rather than the
+                // already-cleared `current_value`/`str_val`, which would
+                // still leak an encrypted JSON field's submitted plaintext
+                // on a create-failure redisplay (Codex review, PR #2422).
+                // `str_val` is `""` here in both cases: it comes from
+                // `current_value`, which is already forced to `Value::Null`
+                // for every encrypted field above.
                 str_val
             } else {
                 match record.and_then(|r| r.get(field.name)) {
@@ -2655,6 +2663,36 @@ mod tests {
             !form.contains("••••••••"),
             "create control is an empty input, not the redaction mask: {form}"
         );
+    }
+
+    #[test]
+    fn create_failure_redisplay_never_echoes_encrypted_plaintext() {
+        // Codex review, PR #2422: a create-validation-failure redisplay
+        // passes `Some(record)` holding the admin's just-typed values
+        // (`is_edit` stays `false`, so this isn't the EDIT-only redacted
+        // branch) — an encrypted field must still never echo that plaintext
+        // back into the response, in any widget kind, including `Json`
+        // (which has its own record lookup, separate from the shared
+        // `current_value` guard, for the #1341 stored-null case).
+        let record = serde_json::json!({
+            "ssn": "123-45-6789",
+            "secret_config": {"token": "sk-live-999"},
+        });
+        for field in [
+            AdminField::new("ssn", AdminFieldKind::Text).encrypted(),
+            AdminField::new("secret_config", AdminFieldKind::Json).encrypted(),
+        ] {
+            let name = field.name;
+            let form = render_form_widget(&field, Some(&record), false, &[]).into_string();
+            assert!(
+                form.contains(&format!("name=\"{name}\"")),
+                "create control must stay submittable for {name}: {form}"
+            );
+            assert!(
+                !form.contains("123-45-6789") && !form.contains("sk-live-999"),
+                "encrypted {name} must not echo the submitted plaintext on a create failure: {form}"
+            );
+        }
     }
 
     #[test]

--- a/autumn-admin-plugin/src/templates.rs
+++ b/autumn-admin-plugin/src/templates.rs
@@ -1639,6 +1639,12 @@ pub fn model_form_page(
     // Path-based ID from the handler on edit pages (`None` when rendering
     // the "new" form). Never trust the JSON payload for mutation routing.
     id: Option<i64>,
+    // Names of fields in `record` whose value is raw, unvalidated form
+    // input from a failed submission rather than a genuine stored/coerced
+    // value — see `render_form_widget`. Empty for every ordinary render
+    // (fresh "new" form, a real stored record, or a resubmission that
+    // failed for a reason unrelated to that field's own syntax).
+    raw_fields: &[&str],
     messages: &[FlashMessage],
     csrf_token: &str,
     csrf_form_field: &str,
@@ -1691,7 +1697,7 @@ pub fn model_form_page(
                                 // so the admin can see it but cannot change it.
                                 (render_readonly_display(field, record))
                             } @else {
-                                (render_form_widget(field, record))
+                                (render_form_widget(field, record, is_edit, raw_fields))
                             }
                         }
                     }
@@ -2160,16 +2166,35 @@ fn render_readonly_display(field: &AdminField, record: Option<&Value>) -> Markup
 }
 
 /// Render a form widget for a field.
-fn render_form_widget(field: &AdminField, record: Option<&Value>) -> Markup {
-    // Encrypted columns (#805). On EDIT (`record` is `Some`) we must never reveal
-    // or overwrite the stored ciphertext, so render a disabled, redacted control
-    // with no `name`: the plaintext never reaches the HTML and a save never
-    // submits (and thus never overwrites) it. On CREATE (`record` is `None`) there
-    // is no stored secret to protect and the generated `New*` DTO requires the
-    // value, so fall through to a normal editable input that captures the initial
-    // plaintext (the wrapper encrypts it on insert). The flag is per-field, so an
+///
+/// `is_edit` is the CREATE-vs-EDIT signal, taken from the caller's `id`
+/// (`None` on create) rather than inferred from `record.is_some()`: a
+/// validation-failure redisplay on CREATE passes `Some(record)` (the
+/// resubmitted values) with no `id`, which must still be treated as create
+/// for the encrypted-field branch below (Codex review, PR #2422).
+///
+/// `raw_fields` names the fields (by `AdminField::name`) whose `record`
+/// value is unvalidated form input straight from a failed submission —
+/// e.g. text that failed `Json` parsing — rather than a genuinely typed
+/// value from storage or a successful coercion. Only the `Json` branch
+/// consults it, to skip the JSON-round-trip serialization and show the raw
+/// text the admin typed instead (Codex review, PR #2422).
+#[allow(clippy::too_many_lines)]
+fn render_form_widget(
+    field: &AdminField,
+    record: Option<&Value>,
+    is_edit: bool,
+    raw_fields: &[&str],
+) -> Markup {
+    // Encrypted columns (#805). On EDIT we must never reveal or overwrite the
+    // stored ciphertext, so render a disabled, redacted control with no
+    // `name`: the plaintext never reaches the HTML and a save never submits
+    // (and thus never overwrites) it. On CREATE there is no stored secret to
+    // protect and the generated `New*` DTO requires the value, so fall
+    // through to a normal editable input that captures the initial plaintext
+    // (the wrapper encrypts it on insert). The flag is per-field, so an
     // unrelated same-named plaintext column stays editable.
-    if field.encrypted && record.is_some() {
+    if field.encrypted && is_edit {
         return html! {
             input type="text" class="form-input" value="••••••••" disabled
                 title="Encrypted at rest — managed outside the admin";
@@ -2275,10 +2300,21 @@ fn render_form_widget(field: &AdminField, record: Option<&Value>) -> Markup {
             // directly instead of reusing `current_value`, matching only a
             // genuinely nullable-and-null EDIT to blank (Codex review finding
             // on #1341).
-            let json_val = match record.and_then(|r| r.get(field.name)) {
-                None => String::new(),
-                Some(Value::Null) if !field.required => String::new(),
-                Some(v) => v.to_string(),
+            // A field named in `raw_fields` holds the exact text the admin
+            // typed, which failed to parse as JSON — show it verbatim so
+            // they can see and fix the mistake, rather than round-tripping
+            // it through `Value::to_string()` (which would wrap it in an
+            // extra pair of quotes, turning `{broken` into the seemingly
+            // valid JSON string `"{broken"` and risking a silent resave of
+            // the wrong data — Codex review, PR #2422).
+            let json_val = if raw_fields.contains(&field.name) {
+                str_val
+            } else {
+                match record.and_then(|r| r.get(field.name)) {
+                    None => String::new(),
+                    Some(Value::Null) if !field.required => String::new(),
+                    Some(v) => v.to_string(),
+                }
             };
             html! {
                 textarea class="form-input" name=(field.name) id=(field.name)
@@ -2573,7 +2609,7 @@ mod tests {
             AdminField::new("audit_note", AdminFieldKind::Text).encrypted_visible(),
         ] {
             let col = field.name;
-            let form = render_form_widget(&field, Some(&record)).into_string();
+            let form = render_form_widget(&field, Some(&record), true, &[]).into_string();
             assert!(
                 !form.contains("123-45-6789") && !form.contains("visible-note"),
                 "edit form must not pre-fill encrypted plaintext for {col}: {form}"
@@ -2595,7 +2631,7 @@ mod tests {
         // submittable, empty input — otherwise the default "New" flow can't create
         // a record with a required encrypted column (#805).
         let field = AdminField::new("ssn", AdminFieldKind::Text).encrypted();
-        let form = render_form_widget(&field, None).into_string();
+        let form = render_form_widget(&field, None, false, &[]).into_string();
         assert!(
             form.contains("name=\"ssn\""),
             "create control must submit the value: {form}"
@@ -2620,7 +2656,7 @@ mod tests {
         let field = AdminField::new("config", AdminFieldKind::Json);
 
         let record = serde_json::json!({ "config": "hello" });
-        let form = render_form_widget(&field, Some(&record)).into_string();
+        let form = render_form_widget(&field, Some(&record), true, &[]).into_string();
         assert!(
             form.contains("&quot;hello&quot;") || form.contains("\"hello\""),
             "stored JSON string must render with its quotes intact: {form}"
@@ -2629,7 +2665,7 @@ mod tests {
         // A string that looks like another JSON literal must round-trip as
         // the SAME string, not silently become that other type.
         let record = serde_json::json!({ "config": "true" });
-        let form = render_form_widget(&field, Some(&record)).into_string();
+        let form = render_form_widget(&field, Some(&record), true, &[]).into_string();
         assert!(
             form.contains("&quot;true&quot;") || form.contains("\"true\""),
             "a stored JSON string \"true\" must not render as the bare word true: {form}"
@@ -2637,7 +2673,7 @@ mod tests {
 
         // Object/array values were already correct — no regression.
         let record = serde_json::json!({ "config": {"a": 1} });
-        let form = render_form_widget(&field, Some(&record)).into_string();
+        let form = render_form_widget(&field, Some(&record), true, &[]).into_string();
         assert!(
             form.contains("{&quot;a&quot;:1}") || form.contains(r#"{"a":1}"#),
             "object values still render as JSON: {form}"
@@ -2647,7 +2683,7 @@ mod tests {
         // matching the existing "blank means no value" convention.
         let optional_field = AdminField::new("config", AdminFieldKind::Json).optional();
         let record = serde_json::json!({ "config": null });
-        let form = render_form_widget(&optional_field, Some(&record)).into_string();
+        let form = render_form_widget(&optional_field, Some(&record), true, &[]).into_string();
         assert!(
             !form.contains("null"),
             "an optional NULL json value should render blank, not the literal word null: {form}"
@@ -2662,7 +2698,7 @@ mod tests {
         // programmatic blank submission would coerce into `""` instead of
         // round-tripping back to `Value::Null` (Codex review finding on
         // #1341).
-        let form = render_form_widget(&field, Some(&record)).into_string();
+        let form = render_form_widget(&field, Some(&record), true, &[]).into_string();
         assert!(
             form.contains(">null<") || form.contains("null"),
             "a required NULL json value must render the literal `null`, not blank: {form}"
@@ -2678,7 +2714,7 @@ mod tests {
         // shared default, so the widget must distinguish "no record" from "a
         // null value in the record" directly.
         let field = AdminField::new("config", AdminFieldKind::Json);
-        let form = render_form_widget(&field, None).into_string();
+        let form = render_form_widget(&field, None, false, &[]).into_string();
         assert!(
             !form.contains("null"),
             "a brand-new required json field on the CREATE form must start blank, \
@@ -3127,6 +3163,7 @@ mod tests {
             None,
             None,
             &[],
+            &[],
             "tok-xyz",
             "authenticity_token",
             "X-CSRF-Token",
@@ -3157,6 +3194,7 @@ mod tests {
             &fields,
             Some(&record),
             Some(1),
+            &[],
             &[],
             "t",
             "_csrf",
@@ -3192,6 +3230,7 @@ mod tests {
             &fields,
             Some(&record),
             Some(42),
+            &[],
             &[],
             "t",
             "_csrf",

--- a/autumn-admin-plugin/src/templates.rs
+++ b/autumn-admin-plugin/src/templates.rs
@@ -2200,10 +2200,21 @@ fn render_form_widget(
                 title="Encrypted at rest — managed outside the admin";
         };
     }
-    let current_value = record
-        .and_then(|r| r.get(field.name))
-        .cloned()
-        .unwrap_or(Value::Null);
+    // An encrypted field that reaches here is CREATE (the EDIT branch above
+    // already returned). A create-validation-failure redisplay still passes
+    // `Some(record)` with the admin's just-typed plaintext in it — never
+    // echo that back into the response body; keep the control enabled and
+    // submittable (unlike EDIT) but blank, so the admin retypes it rather
+    // than the secret round-tripping through server-rendered HTML a second
+    // time (Codex review, PR #2422).
+    let current_value = if field.encrypted {
+        Value::Null
+    } else {
+        record
+            .and_then(|r| r.get(field.name))
+            .cloned()
+            .unwrap_or(Value::Null)
+    };
     let str_val = match &current_value {
         Value::String(s) => s.clone(),
         Value::Null => String::new(),


### PR DESCRIPTION
---
_Generated by [Claude Code](https://claude.ai/code/session_01SpxdSjA2JVFT3kaLhEsxfR)_