### PR TITLE
🛣️ Onramp: fix stale `createdb` step in the CRUD-generators fast path (docs drift ✗→✓, harness gap closed)

### DIFF
--- a/docs/guide/generators.md
+++ b/docs/guide/generators.md
@@ -35,7 +35,7 @@ cd my-app
 autumn generate scaffold Post title:String body:Text published:bool
 # Before migrating: configure the database (see the note below) and
 # create it if it does not exist yet:
-createdb my_app
+autumn db create
 autumn migrate
 autumn dev
 ```
@@ -46,8 +46,10 @@ One file edit belongs between `generate` and `migrate`: the generated
 Postgres so both `autumn migrate` and the running app can reach the
 database — without it, `autumn migrate` exits with `✗ No database URL found.`.
 `autumn migrate` runs migrations against that database but does not create
-it, hence the `createdb my_app` above (any equivalent, such as
-`CREATE DATABASE` in psql, works too):
+it, hence `autumn db create` above — it reads the same `url`/`primary_url`
+you just configured and creates that database, idempotently, with no extra
+tooling beyond what `autumn migrate` already needs (an external `createdb` or
+`CREATE DATABASE` in psql works too, if you have a Postgres client installed):
 
 ```toml
 [database]

--- a/scripts/check-quickstart.sh
+++ b/scripts/check-quickstart.sh
@@ -36,7 +36,7 @@
 #   scaffold-migrate the documented scaffold prerequisites + migrate
 #                    (docs/guide/generators.md): install the Diesel CLI if
 #                    missing, uncomment [database] in autumn.toml (using
-#                    $DATABASE_URL as the value), `createdb`, then
+#                    $DATABASE_URL as the value), `autumn db create`, then
 #                    `autumn migrate` with DB env stripped.
 #   scaffold-serve   `autumn dev` + poll `GET /posts` until 200 (DB config
 #                    comes from autumn.toml, not env).
@@ -258,37 +258,18 @@ configure_database() {
 }
 
 create_database() {
-  # The documented database-creation step (docs/guide/generators.md):
-  # `autumn migrate` runs migrations against the configured database but
-  # does not create it, and the published autumn-cli (0.5.0) has no
-  # `autumn db create` subcommand — the guide documents `createdb my_app`.
-  # Run exactly that, with connection parameters taken from the same URL
-  # written into autumn.toml (standing in for the user's local Postgres
-  # auth). The CI service container deliberately does NOT pre-create this
-  # database, so skipping this step fails the migrate phase — exactly as it
-  # fails for a fresh user.
-  local url="$DATABASE_URL" dbname rest cred hostport host port user pass
-  dbname="${url##*/}"; dbname="${dbname%%\?*}"
-  rest="${url#*://}"; rest="${rest%/*}"
-  if [[ "$rest" == *@* ]]; then
-    cred="${rest%@*}"; hostport="${rest##*@}"
-    user="${cred%%:*}"
-    if [[ "$cred" == *:* ]]; then pass="${cred#*:}"; else pass=""; fi
-  else
-    hostport="$rest"; user=""; pass=""
-  fi
-  host="${hostport%%:*}"
-  if [[ "$hostport" == *:* ]]; then port="${hostport#*:}"; else port=5432; fi
-  command -v createdb >/dev/null \
-    || fail "createdb (postgresql-client) is not on PATH — the documented database-creation step needs it"
-  if PGPASSWORD="$pass" createdb -h "$host" -p "$port" ${user:+-U "$user"} "$dbname" 2>"$state/createdb.err"; then
-    echo "created database '${dbname}' (documented 'createdb' step)"
-  elif grep -q "already exists" "$state/createdb.err"; then
-    echo "database '${dbname}' already exists — documented 'createdb' step skipped"
-  else
-    cat "$state/createdb.err" >&2 || true
-    fail "'createdb ${dbname}' (the documented database-creation step) failed — see the output above"
-  fi
+  # The documented database-creation step. autumn-cli gained a first-party
+  # `autumn db create` subcommand before the 0.7.0 release cut, and
+  # docs/guide/generators.md's "Five commands to a working CRUD app" now
+  # teaches that command (matching docs/guide/getting-started.md, which
+  # already did) instead of shelling out to the separately-installed
+  # `createdb` (postgresql-client) binary. Run it exactly as documented, in a
+  # clean shell so the database URL resolves from autumn.toml alone — the
+  # same realism `autumn migrate` gets below. The CI service container
+  # deliberately does NOT pre-create this database, so skipping this step
+  # fails the migrate phase — exactly as it fails for a fresh user.
+  (cd "$app_dir" && env "${db_env_strip[@]}" autumn db create) \
+    || fail "'autumn db create' failed with database.url configured in autumn.toml (docs/guide/generators.md scaffold path)"
 }
 
 


### PR DESCRIPTION
## 🎯 Journey

**First real integration** — "hello world → my use case", specifically the CRUD-scaffold fast path. This is not a side doc: README's own Quickstart points readers straight at it (`# Optional: scaffold a CRUD resource (see docs/guide/generators.md)`), and `scripts/check-quickstart.sh`'s `scaffold-migrate`/`scaffold-serve` phases are explicitly "mirrored from README.md ... and, for the scaffold migrate/serve phases, docs/guide/generators.md" (the script's own header comment).

Reproduce the journey as documented, from a clean shell:
```bash
cargo install autumn-cli --version 0.7.0   # or: cargo install --path autumn-cli
autumn new my-app && cd my-app
autumn generate scaffold Post title:String body:Text published:bool
# uncomment [database] in autumn.toml, point url at a reachable Postgres
autumn db create   # was: createdb my_app
autumn migrate
autumn dev
```

## 📈 Evidence

**Tier 1 — doc/harness cross-check + hand verification.**

- `docs/guide/generators.md` ("Five commands to a working CRUD app") taught `createdb my_app` — a `postgresql-client` binary never listed as a prerequisite anywhere in that guide (its prereqs are "Rust and Postgres installed", full stop).
- `docs/guide/getting-started.md` (the other official first-run guide, more prominently linked) already teaches `autumn db create` for the exact same step, on the exact same 0.7.x release line.
- `scripts/check-quickstart.sh` — the committed clean-room CI gate that runs the documented journey against the *published* crate on every push and daily — carried a comment explaining the `createdb` workaround: *"the published autumn-cli (0.5.0) has no `autumn db create` subcommand."* Git history shows this is stale: `autumn db create` (`autumn-cli/src/db.rs`, commit `65d87a9`) landed hours *before* the 0.7.0 release-prep commit (`f96c867`), both on 2026-08-23 — the version the gate installs today has had the subcommand all along.
- Hand-verified end to end in this session (fresh `autumn new` + `autumn generate scaffold` app, real local Postgres 16, in-tree CLI build): `autumn db create` creates the database and, on rerun, reports `Database "my_app" already exists — nothing to do.` — matching getting-started.md's own description, with zero tooling beyond what `autumn migrate` already needs.

## 💡 Hypothesis

`generators.md` was written when `autumn db create` genuinely didn't exist; the subcommand shipped later and `getting-started.md` adopted it, but nobody circled back to update `generators.md` or the CI harness's workaround comment to match. The result: two official guides answer "how do I create the database" differently for the same framework version, and the one the README's own Quickstart points to for the scaffold path is the stale one — silently requiring a separately-installed system binary (`createdb`, part of `postgresql-client`) that the guide never tells you to install. A developer on a minimal toolchain (Rust + `libpq` + Diesel CLI, exactly what the guide's prerequisites list) who reaches this step via a Docker-only or managed-Postgres setup — the path `getting-started.md`'s own Docker one-liner invites — has no guarantee `createdb` is on `PATH`, and hits a bare `command not found` the doc never warns about. The CI gate's own `command -v createdb || fail ...` guard is itself evidence this was a real, anticipated failure mode, not a hypothetical.

## 🔧 Change

**Docs layer** (cheapest effective layer, per the fix-order: error message → default → docs → API shape): swap the `createdb my_app` snippet and its surrounding prose in `docs/guide/generators.md` for `autumn db create`, matching `getting-started.md`. **Harness layer**: `scripts/check-quickstart.sh`'s `create_database` now runs `autumn db create` (in the same DB-env-stripped clean shell `autumn migrate` already gets, so it resolves purely from `autumn.toml` like a real user) instead of hand-parsing the URL and shelling out to `createdb`. No public API surface touched — pure docs + CI-script change, additive, nothing removed from the CLI or `autumn-web`.

## 📊 Measurement

| | Before | After |
|---|---|---|
| `generators.md` database-creation step | `createdb my_app` (undocumented external prerequisite) | `autumn db create` (zero extra tooling; same config resolution as `autumn migrate`) |
| Docs agreement | `generators.md` and `getting-started.md` disagree on the same step, same release line | Both guides teach the same command |
| Clean-room gate coverage | `scaffold-migrate` phase proves a workaround the docs no longer teach | `scaffold-migrate` phase proves the exact documented command against the published crate |
| Hand verification | — | `autumn db create` on a fresh scaffolded app: creates the DB, reports "already exists" idempotently on rerun — matches getting-started.md's description |

Compatibility check: no public API changed (docs + CI script only); `cargo build -p autumn-cli` and the modified script's `bash -n` syntax check both pass.

## 🔬 Reproduce

```bash
# From a clean checkout, with a reachable local Postgres:
cargo build -p autumn-cli
export PATH="$PWD/target/debug:$PATH"
cd /tmp && autumn new my-app && cd my-app
autumn generate scaffold Post title:String body:Text published:bool
# uncomment [database], set url = "postgres://<user>:<pass>@127.0.0.1:5432/my_app"
autumn db create   # → "Created database \"my_app\"."
autumn db create   # → "Database \"my_app\" already exists — nothing to do."
```

The full harness (against the published crate, matrix `stable` + MSRV) runs via `.github/workflows/quickstart-gate.yml`, which now exercises this exact fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VUhC6TNN4RyrtvxuEfk6uw

---
_Generated by [Claude Code](https://claude.ai/code/session_01VUhC6TNN4RyrtvxuEfk6uw)_