### PR TITLE
⚓ Ballast: repair stale RUSTSEC-2026-0173 ignore, resolve yanked chacha20 (advisories ignore 4→3, yanked 1→0)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1760,9 +1760,9 @@ checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "chacha20"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",

--- a/deny-sqlite.toml
+++ b/deny-sqlite.toml
@@ -26,7 +26,7 @@ features = ["autumn-web/sqlite"]
 # always denied, and unmaintained + unsound are set explicitly to "all" rather
 # than relying on cargo-deny's version-dependent default scope, so no advisory
 # anywhere in the tree can slip past this gate. Yanked crates stay at the
-# default `warn` (currently spin 0.9.8 / 0.10.0, transitive) — tracked but
+# default `warn` (currently chacha20 0.10.1, transitive) — tracked but
 # non-blocking.
 # The RUSTSEC-2024-0384 (instant) ignore enters only via managed-pg-bundled,
 # which is not in the sqlite graph, so it is legitimately unused here — don't
@@ -43,11 +43,6 @@ ignore = [
     # RSA private-key decryption oracle, so real exposure is limited. Tracked by
     # issue #1600. Review-by: 2026-10-01 (or when a fixed rsa ships).
     { id = "RUSTSEC-2023-0071", reason = "no fixed rsa release; RSA-JWT path only via jsonwebtoken; tracked in #1600; review-by 2026-10-01" },
-    # RUSTSEC-2026-0173 — proc-macro-error2 unmaintained. Build-time proc-macro
-    # only, pulled transitively by validator_derive -> validator 0.20. Not a
-    # runtime vulnerability and no safe upgrade. Review-by: 2026-10-01 (drop when
-    # validator ships a release that migrates off proc-macro-error2).
-    { id = "RUSTSEC-2026-0173", reason = "unmaintained build-time proc-macro via validator 0.20; no safe upgrade; review-by 2026-10-01" },
     # RUSTSEC-2024-0384 — instant unmaintained. Build-time, transitive, and only
     # pulled in by the managed-pg-bundled feature scanned above:
     # instant -> parking_lot -> reqwest-retry -> postgresql_archive ->

--- a/deny.toml
+++ b/deny.toml
@@ -43,7 +43,7 @@ features = ["autumn-web/ws", "autumn-web/presence", "autumn-web/flash", "autumn-
 # always denied, and unmaintained + unsound are set explicitly to "all" rather
 # than relying on cargo-deny's version-dependent default scope, so no advisory
 # anywhere in the tree can slip past this gate. Yanked crates stay at the
-# default `warn` (currently spin 0.9.8 / 0.10.0, transitive) — tracked but
+# default `warn` (currently chacha20 0.10.1, transitive) — tracked but
 # non-blocking.
 unmaintained = "all"
 unsound = "all"
@@ -56,11 +56,6 @@ ignore = [
     # RSA private-key decryption oracle, so real exposure is limited. Tracked by
     # issue #1600. Review-by: 2026-10-01 (or when a fixed rsa ships).
     { id = "RUSTSEC-2023-0071", reason = "no fixed rsa release; RSA-JWT path only via jsonwebtoken; tracked in #1600; review-by 2026-10-01" },
-    # RUSTSEC-2026-0173 — proc-macro-error2 unmaintained. Build-time proc-macro
-    # only, pulled transitively by validator_derive -> validator 0.20. Not a
-    # runtime vulnerability and no safe upgrade. Review-by: 2026-10-01 (drop when
-    # validator ships a release that migrates off proc-macro-error2).
-    { id = "RUSTSEC-2026-0173", reason = "unmaintained build-time proc-macro via validator 0.20; no safe upgrade; review-by 2026-10-01" },
     # RUSTSEC-2024-0384 — instant unmaintained. Build-time, transitive, and only
     # pulled in by the managed-pg-bundled feature scanned above:
     # instant -> parking_lot -> reqwest-retry -> postgresql_archive ->


### PR DESCRIPTION
## 🎯 Class

**Policy** — lockfile discipline / stale advisory-ignore cleanup. Targets: `deny.toml`, `deny-sqlite.toml`, `chacha20` (dev-only transitive).

## 📈 Evidence

Running the exact CI `supply-chain` job commands (`cargo deny check advisories licenses sources` and the `deny-sqlite.toml` companion) against the committed `Cargo.lock` surfaced two warnings that CI's `warning`-level checks don't fail on, but that are real ledger rot:

1. **`warning[advisory-not-detected]`** on the `RUSTSEC-2026-0173` ignore entry in **both** `deny.toml` and `deny-sqlite.toml`. That entry's own comment says to drop it "when validator ships a release that migrates off proc-macro-error2." The committed lockfile already resolves `validator_derive` to **0.20.1** (still satisfying the workspace's `validator = "0.20"` pin — no `Cargo.toml` change needed), and 0.20.1 depends on `proc-macro-error3`, not `proc-macro-error2`:
   ```
   [[package]]
   name = "validator_derive"
   version = "0.20.1"
   dependencies = [ "darling 0.23.0", "proc-macro-error3", "proc-macro2", "quote", "syn 2.0.119" ]
   ```
   `deny-sqlite.toml` sets `unused-ignored-advisory = "allow"` (deliberately, for the *unrelated* `RUSTSEC-2024-0384` entry which is legitimately sqlite-graph-inert) — that flag was silently masking this same staleness for `RUSTSEC-2026-0173` too. Removed from both files, keeping them in sync per the file's own header comment.
2. **`warning[yanked]`**: `chacha20 0.10.1` (dev-only: `rand 0.10.2` → `ferroid` → `testcontainers`/`testcontainers-modules`) is a yanked release. `cargo update -p chacha20 --dry-run` showed `0.10.1 -> 0.10.2` as the latest Rust-1.88.0-compatible, non-yanked version, with `--verbose` confirming zero other packages move. Both `deny.toml` and `deny-sqlite.toml` had a stale comment naming `spin 0.9.8 / 0.10.0` as "currently" yanked — that pair is no longer flagged by either graph scan; the comment now names the crate actually yanked today (`chacha20 0.10.1`) so the next person doesn't chase a ghost.

Ledger position: this shrinks the tracked-ignore list from 4 → 3 RUSTSEC entries (the remaining three — `RUSTSEC-2023-0071` rsa, `RUSTSEC-2024-0384` instant, `RUSTSEC-2026-0253` lru — all keep their `review-by 2026-10-01` triggers, not due yet) and the yanked-crate count from 1 → 0 in both scanned graphs.

## 💡 Mechanism / forcing fact

Not a scheduled batch and not a reachable vulnerability — this is dead-ignore + yanked-dependency cleanup a routine ledger audit turned up: an ignore rule that no longer matches anything is exactly the "pin without a revisit trigger firing" case the deny.toml header warns about, and a yanked dev-dependency is a one-line, zero-Cargo.toml-change fix sitting right there once noticed.

## 🔧 Change

- `deny.toml`, `deny-sqlite.toml`: drop the `RUSTSEC-2026-0173` ignore entry + its comment (4 lines each); update the "currently spin..." yanked-crate comment to name `chacha20 0.10.1`.
- `Cargo.lock`: `cargo update -p chacha20` → `0.10.1` → `0.10.2` (1 package, dev-dependency-only path, no `Cargo.toml` edit).

**Rehearsal actually run**, on this branch, against the resulting tree:
- `cargo deny check advisories licenses sources` → **`advisories ok, licenses ok, sources ok`**, zero warnings (was: 1× `advisory-not-detected` + 1× `yanked`).
- `cargo deny --config deny-sqlite.toml check advisories licenses sources` → **`advisories ok, licenses ok, sources ok`**, zero warnings (was: 1× `yanked`; the stale ignore was already silent here under `unused-ignored-advisory = "allow"`, now genuinely absent rather than merely suppressed).
- `./scripts/pre-push-check.sh` (the repo's compile-only mirror of CI's `lint` + `test` jobs — fmt, clippy `-D warnings` workspace-wide, full test-target compile, then doctests actually run) on this branch: **`pre-push-check: OK — workspace test targets compile clean, doctests pass.`** (A first attempt hit a container-memory OOM `SIGKILL` on `autumn-macros` — a crate this diff doesn't touch — caused by another `cargo check` left running concurrently in this session; killed the stray process and re-ran clean. Full log has zero `error`/`FAILED` lines; the one doctest crate with real tests reports `310 passed; 0 failed`.)

## 📊 Measurement

| | Before | After |
|---|---|---|
| `deny.toml` tracked advisory ignores | 4 | 3 |
| `deny-sqlite.toml` tracked advisory ignores | 4 | 3 |
| `cargo deny` warnings (default graph) | 2 (`advisory-not-detected`, `yanked`) | 0 |
| `cargo deny` warnings (sqlite graph) | 1 (`yanked`) | 0 |
| `chacha20` resolved version | 0.10.1 (yanked) | 0.10.2 |
| Direct/transitive dep counts, license set, sources | unchanged | unchanged |

No API-surface, feature, or `Cargo.toml` changes — nothing for a downstream consumer to notice, so no changelog entry.

## 🔬 Reproduce

```bash
cargo install cargo-deny --locked   # 0.20.2, matching ci.yml's pinned version
cargo deny check advisories licenses sources
cargo deny --config deny-sqlite.toml check advisories licenses sources
cargo update -p chacha20 --dry-run   # confirms 0.10.1 -> 0.10.2, 0 other packages move
./scripts/pre-push-check.sh
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BgDFjCQavpmsVHgubUTeJT