### PR TITLE
🧭 Wayfinder: text-safe warning/success tokens in the admin plugin (contrast 3.19:1 / 3.77:1 → 4.5:1+)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -847,6 +847,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **🧭 Wayfinder: text-safe warning/success colors in the admin plugin
+  (WCAG contrast 3.19:1 / 3.77:1 → 4.5:1+):** the Runtime Config page's
+  "overridden" status badge (`--warning` #d97706 on `--surface`, every
+  deployment's config page) and every model list page's boolean-field ✓
+  checkmark (`--success` #059669 on `--surface`, rendered for every boolean
+  column in every row) used their raw semantic color token directly as
+  small/normal foreground text — tokens calibrated for the 3:1 large-text/
+  border/icon uses they already had, not WCAG AA's 4.5:1 normal-text
+  threshold. New `--warning-text` (#92400e) and `--success-text` (#065f46)
+  tokens, matching the framework's existing flash-message foreground shades,
+  fix both sites without introducing a new color.
+
 - **ACME config: `autumn doctor` and the runtime now reject the same two
   spellings (#1874):** two low-severity parity gaps let `autumn doctor
   --strict` bless an `autumn.toml` the server refuses to boot on. A

--- a/autumn-admin-plugin/src/templates.rs
+++ b/autumn-admin-plugin/src/templates.rs
@@ -1803,7 +1803,7 @@ pub fn config_page(
                                 }
                                 td {
                                     @if entry.is_overridden {
-                                        span style="color: var(--warning); font-size: 0.8125rem; font-weight: 500;" {
+                                        span style="color: var(--warning-text); font-size: 0.8125rem; font-weight: 500;" {
                                             "overridden"
                                         }
                                     } @else {
@@ -1990,7 +1990,7 @@ fn render_cell_value(record: &Value, field: &AdminField) -> Markup {
         },
         Some(Value::Bool(b)) => html! {
             @if *b {
-                span style="color: var(--success);" { "✓" }
+                span style="color: var(--success-text);" { "✓" }
             } @else {
                 span style="color: var(--text-muted);" { "✗" }
             }
@@ -2580,6 +2580,128 @@ pub fn model_history_page(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // WCAG 1.4.3 (contrast minimum) relative-luminance / contrast-ratio
+    // formulas, applied to the admin plugin's own `tokens.css` color pairs.
+    // `#RRGGBB` only — every color literal in `tokens.css` is that shape.
+    fn hex_channel(hex: &str, i: usize) -> f64 {
+        f64::from(u8::from_str_radix(&hex[1 + i * 2..3 + i * 2], 16).unwrap()) / 255.0
+    }
+
+    fn relative_luminance(hex: &str) -> f64 {
+        let f = |c: f64| {
+            if c <= 0.039_28 {
+                c / 12.92
+            } else {
+                ((c + 0.055) / 1.055).powf(2.4)
+            }
+        };
+        0.0722f64.mul_add(
+            f(hex_channel(hex, 2)),
+            0.2126f64.mul_add(f(hex_channel(hex, 0)), 0.7152 * f(hex_channel(hex, 1))),
+        )
+    }
+
+    fn contrast_ratio(a: &str, b: &str) -> f64 {
+        let (la, lb) = (relative_luminance(a), relative_luminance(b));
+        let (lighter, darker) = if la >= lb { (la, lb) } else { (lb, la) };
+        (lighter + 0.05) / (darker + 0.05)
+    }
+
+    // Audited 2026-09-02 (Wayfinder). Config page (100% of admin-plugin
+    // deployments that register runtime-config keys) and every model list
+    // page's boolean columns both rendered their status text straight from
+    // `--warning`/`--success` on `--surface`: 3.19:1 and 3.77:1, both below
+    // WCAG AA's 4.5:1 normal-text threshold (the raw tokens are calibrated
+    // for the 3:1 large-text/border/icon uses they already had, not small
+    // foreground text). `--warning-text`/`--success-text` are the same hue
+    // darkened to the framework's existing flash-message foreground shade,
+    // reused here rather than inventing a new color.
+    const SURFACE: &str = "#ffffff";
+    const WARNING: &str = "#d97706";
+    const WARNING_TEXT: &str = "#92400e";
+    const SUCCESS: &str = "#059669";
+    const SUCCESS_TEXT: &str = "#065f46";
+
+    #[test]
+    fn raw_warning_and_success_tokens_fail_wcag_aa_text_contrast_on_surface() {
+        // Documents why `--warning`/`--success` may not be used directly as
+        // small/normal foreground text — the defect `-text` variants fix.
+        assert!(
+            contrast_ratio(WARNING, SURFACE) < 4.5,
+            "if this now passes, --warning's hex changed and the -text variant may be redundant"
+        );
+        assert!(
+            contrast_ratio(SUCCESS, SURFACE) < 4.5,
+            "if this now passes, --success's hex changed and the -text variant may be redundant"
+        );
+    }
+
+    #[test]
+    fn text_safe_warning_and_success_tokens_meet_wcag_aa_contrast_on_surface() {
+        assert!(
+            contrast_ratio(WARNING_TEXT, SURFACE) >= 4.5,
+            "--warning-text on --surface must clear WCAG AA 4.5:1"
+        );
+        assert!(
+            contrast_ratio(SUCCESS_TEXT, SURFACE) >= 4.5,
+            "--success-text on --surface must clear WCAG AA 4.5:1"
+        );
+        // tokens.css is the source of truth; keep these hex literals honest.
+        let css = include_str!("tokens.css");
+        assert!(
+            css.contains(&format!("--warning-text: {WARNING_TEXT}")),
+            "{css}"
+        );
+        assert!(
+            css.contains(&format!("--success-text: {SUCCESS_TEXT}")),
+            "{css}"
+        );
+    }
+
+    #[test]
+    fn config_page_overridden_status_uses_text_safe_warning_token() {
+        use autumn_web::runtime_config::{ConfigEntry, ConfigValue, ConfigValueType};
+
+        let r = dummy_registry();
+        let entries = vec![ConfigEntry {
+            name: "rate_limit".to_owned(),
+            value_type: ConfigValueType::Int,
+            current: ConfigValue::Int(200),
+            default: ConfigValue::Int(100),
+            is_overridden: true,
+            description: None,
+        }];
+        let html = config_page(
+            &r,
+            &entries,
+            &[],
+            "tok",
+            "_csrf",
+            "X-CSRF-Token",
+            "/admin",
+            "/actuator",
+            None,
+        )
+        .into_string();
+        assert!(
+            html.contains("color: var(--warning-text)"),
+            "overridden status must use the text-safe warning token, not raw --warning: {html}"
+        );
+        assert!(!html.contains("color: var(--warning);"), "{html}");
+    }
+
+    #[test]
+    fn boolean_true_cell_uses_text_safe_success_token() {
+        let record = serde_json::json!({ "active": true });
+        let field = AdminField::new("active", AdminFieldKind::Boolean);
+        let cell = render_cell_value(&record, &field).into_string();
+        assert!(
+            cell.contains("color: var(--success-text)"),
+            "boolean-true cell must use the text-safe success token, not raw --success: {cell}"
+        );
+        assert!(!cell.contains("color: var(--success);"), "{cell}");
+    }
 
     // A model with at-rest encrypted columns (#805): `ssn` is redacted by default;
     // `audit_note` opts into `admin_visible` (shown in read views). The per-field

--- a/autumn-admin-plugin/src/tokens.css
+++ b/autumn-admin-plugin/src/tokens.css
@@ -17,8 +17,18 @@
     --autumn-danger-hover: var(--danger-hover);
     --success: #059669;
     --success-light: #ecfdf5;
+    /* Darker text-safe variant: --success (#059669) on --surface is 3.77:1,
+       below WCAG AA's 4.5:1 normal-text threshold — it was calibrated for the
+       3:1 large-text/border/icon uses it already has (the success-count
+       digits, --success-light backgrounds), not for small foreground text.
+       #065f46 is the same hue used by the framework's own flash-success
+       foreground and clears 4.5:1 against both --surface and --bg. */
+    --success-text: #065f46;
     --warning: #d97706;
     --warning-light: #fffbeb;
+    /* Same rationale as --success-text: --warning on --surface is 3.19:1.
+       #92400e matches the framework's flash-warning foreground. */
+    --warning-text: #92400e;
     --radius: 0.5rem;
     --shadow: 0 1px 3px rgba(0,0,0,0.1), 0 1px 2px rgba(0,0,0,0.06);
     --font-family: system-ui, -apple-system, sans-serif;


### PR DESCRIPTION
## 🎯 Flow

The admin plugin's shipped UI — the framework's only mutation/read UI, rendered identically in every deployment that mounts `autumn-admin-plugin`. Two specific surfaces:

- **Runtime Config page** (`/admin/config`) — every registered config key's row, in every deployment that uses `AdminPlugin::with_runtime_config`.
- **Model list pages** — the boolean-field ✓/✗ column, rendered once per boolean field per row, on every model's list page (the highest-traffic admin surface).

Reproduce: `cargo test -p autumn-admin-plugin --lib templates::tests::` (see the new tests below), or visually via the `run-autumn` workflow against any app with `autumn-admin-plugin` mounted and a boolean-field model registered.

## 📈 Evidence (Tier 1 — computed contrast ratios)

Neither of the repo's two static a11y tools (`autumn a11y verify`, `autumn check --a11y`) checks color contrast, so this gap wasn't caught by existing CI gates. I computed WCAG 1.4.3 contrast ratios by hand for every `--warning`/`--success`/`--danger` token pair the admin plugin's CSS actually uses as text:

| Site | Colors | Ratio | WCAG AA (normal text, 4.5:1) |
|---|---|---|---|
| Config page "overridden" badge (13px/500-weight) | `--warning` #d97706 on `--surface` #fff | **3.19:1** | ❌ FAIL |
| List-page boolean ✓ checkmark (normal text) | `--success` #059669 on `--surface` #fff | **3.77:1** | ❌ FAIL |
| (for comparison, already-compliant) `.required` asterisk | `--danger` #dc2626 on `--surface` | 4.83:1 | ✅ pass |
| (for comparison, correctly large/bold, 3:1 threshold applies) CSV-import success/error counts | `--success`/`--danger` on their `-light` bg, 24px/700 | 3.58–3.95:1 | ✅ pass (large text) |

Both failing sites use the raw semantic token directly as small/normal foreground text — the tokens were calibrated for the 3:1 large-text/border/icon uses they already have elsewhere on the same pages, not for text at this size/weight.

## 💡 Hypothesis

An operator scanning the Runtime Config page for which knobs have been overridden — the exact information that matters most during an incident — or scanning a list page's boolean columns, gets a status indicator whose color contrast falls below the threshold most low-vision/color-deficient users need to distinguish it reliably from surrounding text. The mechanism is a token-reuse gap: `--warning`/`--success` serve double duty as both "component/icon color" (3:1 is fine) and "text color" (needs 4.5:1), and nothing enforces the stricter threshold at the text call sites.

## 🔧 Change

One variable: added two new tokens, `--warning-text` (#92400e) and `--success-text` (#065f46) — the same hue darkened to clear 4.5:1, **reusing** the exact shades the framework's own flash-message component (`autumn/src/flash.rs`) already established for warning/success text on a light background, rather than inventing new colors. Swapped the two failing call sites over. No other styling, layout, or copy touched; no visual-identity/brand change (same semantic color family).

## 📊 Measurement

Before/after, computed via the WCAG relative-luminance formula (also encoded as a permanent regression test, see below):

| | Before | After |
|---|---|---|
| Config "overridden" badge on `--surface` | 3.19:1 ❌ | **7.09:1** ✅ |
| List-page boolean ✓ on `--surface` | 3.77:1 ❌ | **7.68:1** ✅ |

Both now clear WCAG AAA (7:1), not just AA. This is a deterministic, re-runnable audit (not a behavioral claim), so there's no review-date prediction — the fix is proven by the tests in this PR and re-provable by anyone checking out this commit.

## 🔬 Reproduce

```
cargo test -p autumn-admin-plugin --lib templates::tests::raw_warning_and_success_tokens_fail_wcag_aa_text_contrast_on_surface
cargo test -p autumn-admin-plugin --lib templates::tests::text_safe_warning_and_success_tokens_meet_wcag_aa_contrast_on_surface
cargo test -p autumn-admin-plugin --lib templates::tests::config_page_overridden_status_uses_text_safe_warning_token
cargo test -p autumn-admin-plugin --lib templates::tests::boolean_true_cell_uses_text_safe_success_token
cargo clippy -p autumn-admin-plugin --all-targets -- -D warnings
cargo run -p autumn-cli --bin autumn -- a11y verify .
```

All green. `cargo fmt --all` applied. Full `autumn-admin-plugin` test suite (258 tests) passes.

## Impact floor

Clears: *"Brings a lab vital / audit metric across its WCAG threshold"* — two WCAG 1.4.3 (Serious-severity-equivalent) contrast failures fully resolved (3.19:1→7.09:1, 3.77:1→7.68:1), on live, shipped, every-deployment admin UI.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PH3Xnq3QJm8D6eQtXBEiA8

---
_Generated by [Claude Code](https://claude.ai/code/session_01PH3Xnq3QJm8D6eQtXBEiA8)_