### PR TITLE
⚡ Bolt: version-history diff moves owned columns instead of cloning them (#2429)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1964,6 +1964,62 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   buffer apparently cost more than one allocation for some of these calls
   once it had to grow, not just the final `String`.
 
+- **the versioned-repository audit write path stops cloning every column
+  (#2429):** `compute_diff` / `compute_insert_changes` /
+  `compute_delete_changes` take `&serde_json::Value`, so each one had to clone
+  every retained column name and value into the `ColumnChange` it returns. The
+  only production caller — the `#[repository(versioned = true)]` codegen, which
+  every insert, update and delete of a versioned model funnels through — builds
+  those `Value`s fresh from `version_column_values()` per mutation and drops
+  them the moment the diff returns. Every retained field was therefore allocated
+  twice and dropped twice, for a value nobody would look at again.
+
+  Three owned-value siblings — `compute_diff_owned`,
+  `compute_insert_changes_owned`, `compute_delete_changes_owned` — take the
+  `Value` by value and move each key and value straight into its
+  `ColumnChange` (`Map::into_iter` / `Map::remove` instead of `.get().cloned()`
+  / `.clone()`). The codegen now calls those. The borrowed functions are
+  unchanged and stay public, for callers whose `Value` outlives the call.
+
+  Allocation blocks per mutation on a realistic 7-column record, measured by the
+  new `version_history_alloc_gate` (`allocation-counter`, deterministic across
+  runs). Each figure includes the throwaway `Value` materialization both paths
+  are charged for, so the delta is only what each does with the value it is
+  handed:
+
+  | Entry point | Borrowed | Owned | Delta |
+  |---|---|---|---|
+  | `compute_insert_changes` | 26 blocks | 14 blocks | **-46.2%** |
+  | `compute_delete_changes` | 26 blocks | 14 blocks | **-46.2%** |
+  | `compute_diff` | 34 blocks | 27 blocks | **-20.6%** |
+
+  Whole-process totals over the committed `autumn/benches/version_history.rs`
+  harness, one variant per process (`BIN borrowed` / `BIN owned`):
+
+  | Metric | Borrowed | Owned | Delta |
+  |---|---|---|---|
+  | Instructions (`valgrind --tool=callgrind`) | 2,275,350,133 | 1,547,245,235 | **-32.0%** |
+  | Allocation blocks (`valgrind --tool=dhat`) | 6,901,045 | 4,441,045 | **-35.6%** |
+  | Allocation bytes (same) | 422,257,918 | 393,179,915 | -6.9% |
+
+  Wall clock on the same harness moves with it — insert and delete land around
+  -33% (roughly 650 -> 420 ns/op), and the harness now reports median and
+  spread across alternating rounds so a figure inside the noise says so. The
+  `compute_diff` row is the small one either way: it only ever retained the
+  *changed* columns (3 of 7 in this workload), so it had the fewest clones to
+  drop.
+
+  This is an audit surface, so the changeset itself is held byte-identical
+  rather than eyeballed: each owned function is asserted equal to its borrowed
+  twin — as a `Vec<ColumnChange>` *and* as the serialized JSON that reaches the
+  `_autumn_version_history` row — over shared case matrices (25 diff cases, 10
+  insert/delete cases) covering sensitive-column redaction, columns present in
+  `after` but not `before`, columns dropped from the changeset, `null`-vs-
+  missing, non-object inputs, and key ordering. Separate tests assert pointer
+  identity between the input buffers and the emitted ones, so an `_owned`
+  function that quietly delegated to its borrowed twin would fail even though
+  its output is correct.
+
 ## [0.7.0] - 2026-08-23
 
 For a narrative tour of this release, see the

--- a/autumn-macros/src/repository.rs
+++ b/autumn-macros/src/repository.rs
@@ -1991,12 +1991,21 @@ fn vh_insert_ts(
         quote! { ::core::option::Option::None::<&str> }
     };
 
+    // #2429: the `__vh_json` / `__vh_before_json` / `__vh_after_json` bindings
+    // are freshly serialized per mutation and used for nothing but the diff, so
+    // they are handed to the `*_owned` entry points **by value**. Those move
+    // each retained column name and value straight into the `ColumnChange`,
+    // where the `&Value` variants had to clone every one of them and then drop
+    // the original — two allocations and two drops per retained field on the
+    // audit-trail write path of every versioned repository. Output is identical
+    // (`autumn/src/version_history.rs` holds the owned and borrowed functions to
+    // an exact parity matrix); do not reintroduce a borrow here.
     let changes_ts = match op {
         "insert" => quote! {
             {
                 use ::autumn_web::version_history::VersionedRecord as _;
                 let __vh_json = (#record_expr).version_column_values();
-                let __vh_changes = ::autumn_web::version_history::compute_insert_changes(&__vh_json, <#model_ident as ::autumn_web::version_history::VersionedRecord>::version_sensitive_columns());
+                let __vh_changes = ::autumn_web::version_history::compute_insert_changes_owned(__vh_json, <#model_ident as ::autumn_web::version_history::VersionedRecord>::version_sensitive_columns());
                 ::autumn_web::reexports::serde_json::to_string(&__vh_changes)
                     .unwrap_or_else(|_| "[]".to_string())
             }
@@ -2005,7 +2014,7 @@ fn vh_insert_ts(
             {
                 use ::autumn_web::version_history::VersionedRecord as _;
                 let __vh_json = (#record_expr).version_column_values();
-                let __vh_changes = ::autumn_web::version_history::compute_delete_changes(&__vh_json, <#model_ident as ::autumn_web::version_history::VersionedRecord>::version_sensitive_columns());
+                let __vh_changes = ::autumn_web::version_history::compute_delete_changes_owned(__vh_json, <#model_ident as ::autumn_web::version_history::VersionedRecord>::version_sensitive_columns());
                 ::autumn_web::reexports::serde_json::to_string(&__vh_changes)
                     .unwrap_or_else(|_| "[]".to_string())
             }
@@ -2018,7 +2027,7 @@ fn vh_insert_ts(
                     use ::autumn_web::version_history::VersionedRecord as _;
                     let __vh_before_json = (#before).version_column_values();
                     let __vh_after_json = (#record_expr).version_column_values();
-                    let __vh_changes = ::autumn_web::version_history::compute_diff(&__vh_before_json, &__vh_after_json, <#model_ident as ::autumn_web::version_history::VersionedRecord>::version_sensitive_columns());
+                    let __vh_changes = ::autumn_web::version_history::compute_diff_owned(__vh_before_json, __vh_after_json, <#model_ident as ::autumn_web::version_history::VersionedRecord>::version_sensitive_columns());
                     ::autumn_web::reexports::serde_json::to_string(&__vh_changes)
                         .unwrap_or_else(|_| "[]".to_string())
                 }
@@ -20442,6 +20451,85 @@ mod tests {
             rendered,
             vec!["crate::views::recent_posts", "home::sidebar"]
         );
+    }
+
+    // ── #2429: version-history codegen hands over owned values ───────
+
+    /// Render `vh_insert_ts` for one op with a whitespace-normalized body, so
+    /// the assertions below read like the code they are checking.
+    fn vh_tokens(op: &str) -> String {
+        let record_expr = quote! { __rec };
+        let before_expr = quote! { __before };
+        let conn_ident = quote! { conn };
+        let model_ident: proc_macro2::Ident = syn::parse_quote!(Post);
+        vh_insert_ts(
+            "posts",
+            op,
+            false,
+            &record_expr,
+            Some(&before_expr),
+            &conn_ident,
+            &model_ident,
+            false,
+        )
+        .to_string()
+        .replace(' ', "")
+    }
+
+    #[test]
+    fn vh_codegen_moves_the_disposable_value_into_compute_insert_changes() {
+        let ts = vh_tokens("insert");
+        assert!(
+            ts.contains("compute_insert_changes_owned(__vh_json,"),
+            "insert codegen must move `__vh_json` into the owned entry point: {ts}"
+        );
+        assert!(
+            !ts.contains("compute_insert_changes(&__vh_json"),
+            "insert codegen must not keep borrowing `__vh_json`: {ts}"
+        );
+    }
+
+    #[test]
+    fn vh_codegen_moves_the_disposable_value_into_compute_delete_changes() {
+        let ts = vh_tokens("delete");
+        assert!(
+            ts.contains("compute_delete_changes_owned(__vh_json,"),
+            "delete codegen must move `__vh_json` into the owned entry point: {ts}"
+        );
+        assert!(
+            !ts.contains("compute_delete_changes(&__vh_json"),
+            "delete codegen must not keep borrowing `__vh_json`: {ts}"
+        );
+    }
+
+    #[test]
+    fn vh_codegen_moves_both_disposable_values_into_compute_diff() {
+        let ts = vh_tokens("update");
+        assert!(
+            ts.contains("compute_diff_owned(__vh_before_json,__vh_after_json,"),
+            "update codegen must move both values into the owned entry point: {ts}"
+        );
+        assert!(
+            !ts.contains("compute_diff(&__vh_before_json"),
+            "update codegen must not keep borrowing the before/after values: {ts}"
+        );
+    }
+
+    #[test]
+    fn vh_codegen_still_serializes_each_record_exactly_once() {
+        // Moving the value into the diff must not tempt a second
+        // `version_column_values()` call: that would double the serialization
+        // cost the change is meant to reduce, and — for a model whose
+        // serialization is not pure — could record a different snapshot than
+        // the one that was written.
+        for (op, expected) in [("insert", 1), ("delete", 1), ("update", 2)] {
+            let ts = vh_tokens(op);
+            assert_eq!(
+                ts.matches("version_column_values()").count(),
+                expected,
+                "{op} codegen must call version_column_values() {expected}x: {ts}"
+            );
+        }
     }
 
     #[test]

--- a/autumn/Cargo.toml
+++ b/autumn/Cargo.toml
@@ -507,6 +507,15 @@ path = "tests/password_policy_alloc_gate.rs"
 name = "form_render_alloc_gate"
 path = "tests/form_render_alloc_gate.rs"
 
+# Allocation gate for the version-history diff entry points on the same
+# 7-column record as `benches/version_history.rs` (#2429, proving the owned
+# entry points the versioned-repository codegen calls move column names and
+# values instead of cloning them). Own binary for the same `allocation-counter`
+# global-allocator reason as `config_alloc_gate` above.
+[[test]]
+name = "version_history_alloc_gate"
+path = "tests/version_history_alloc_gate.rs"
+
 # SQLite runtime-lane boot+serve proof (issue #1614, PR2). Only meaningful under
 # `--features sqlite`; the file is `#![cfg(feature = "sqlite")]` so a default
 # `cargo test` compiles it to an empty (passing) binary. Run explicitly:

--- a/autumn/benches/version_history.rs
+++ b/autumn/benches/version_history.rs
@@ -2,7 +2,8 @@
 //!
 //! Measures the performance cost of `compute_diff`, `compute_insert_changes`,
 //! and `compute_delete_changes` — the hot paths executed on every versioned
-//! repository write.
+//! repository write — against their owned-value siblings (`*_owned`, #2429),
+//! which the `#[repository(versioned = true)]` codegen now calls.
 //!
 //! # Budget
 //!
@@ -15,11 +16,166 @@
 //! query, which runs in the same transaction as the mutating statement. Profile
 //! with `cargo bench --bench version_history` before shipping.
 //!
+//! # Borrowed vs owned
+//!
+//! Both variants are timed on identical work, and both pay for it inside the
+//! timer: every iteration materializes a throwaway `Value` — exactly what the
+//! generated code hands over, one fresh `version_column_values()` result per
+//! mutation — and destroys it. The only difference measured is what each entry
+//! point does with that input: `&Value` clones every retained column name and
+//! value out of it and then drops the original, while the owned variant moves
+//! them straight through.
+//!
+//! Two deliberate choices, both because an earlier revision of this harness got
+//! them wrong:
+//!
+//! * **Setup is inside the timer, not hoisted.** Pre-building the inputs was
+//!   tried first and abandoned: a 10 000-element batch of `Value` pairs left the
+//!   heap in such a different state between the two loops that whichever
+//!   variant ran second measured ~2x slower, in *both* orders.
+//! * **The two variants alternate**, and each measurement reports median plus
+//!   min/max rather than a bare point estimate. Timing one variant to
+//!   completion before starting the other lets process warm-up land entirely on
+//!   whichever went first.
+//!
+//! Wall-clock figures here are indicative. The load-bearing, deterministic
+//! measurement of the same change is the allocation gate,
+//! `autumn/tests/version_history_alloc_gate.rs`.
+//!
+//! # Profiling one side at a time
+//!
+//! Both variants in one process are useless to `callgrind`/`dhat`, which
+//! report whole-process totals. Pass a mode argument to run only one side:
+//!
+//! ```sh
+//! cargo build --release -p autumn-web --bench version_history
+//! BIN=$(find target/release/deps -maxdepth 1 -name "version_history-*" -type f ! -name "*.d" | head -1)
+//! valgrind --tool=dhat --dhat-out-file=borrowed.json "$BIN" borrowed
+//! valgrind --tool=dhat --dhat-out-file=owned.json    "$BIN" owned
+//! ```
+//!
 //! Run with: `cargo bench -p autumn-web --bench version_history`
 
 use std::hint::black_box;
 
-use autumn_web::version_history::{compute_delete_changes, compute_diff, compute_insert_changes};
+use autumn_web::version_history::{
+    compute_delete_changes, compute_delete_changes_owned, compute_diff, compute_diff_owned,
+    compute_insert_changes, compute_insert_changes_owned,
+};
+
+const ITERATIONS: u32 = 10_000;
+const WARMUP: u32 = 1_000;
+/// Timed rounds per variant. Each round runs both variants, alternating which
+/// goes first, so neither absorbs the other's warm-up.
+const ROUNDS: u32 = 8;
+
+/// ns/op across [`ROUNDS`] rounds, summarized.
+#[derive(Debug, Clone, Copy)]
+struct Timing {
+    median: u128,
+    min: u128,
+    max: u128,
+}
+
+impl Timing {
+    fn from_samples(mut samples: Vec<u128>) -> Self {
+        samples.sort_unstable();
+        Self {
+            median: samples[samples.len() / 2],
+            min: samples[0],
+            max: samples[samples.len() - 1],
+        }
+    }
+
+    fn report(self, label: &str) {
+        let Self { median, min, max } = self;
+        println!("{label:<32} {median} ns/op (median of {ROUNDS}; {min}-{max})");
+    }
+}
+
+/// Time both variants against each other, alternating which runs first in each
+/// round. Whatever setup an iteration needs belongs *inside* each body, so the
+/// two are charged for it equally.
+fn bench_pair(
+    borrowed_label: &str,
+    mut borrowed: impl FnMut(),
+    owned_label: &str,
+    mut owned: impl FnMut(),
+    enabled: (bool, bool),
+) -> (Option<Timing>, Option<Timing>) {
+    let (run_borrowed, run_owned) = enabled;
+    let mut borrowed_samples = Vec::new();
+    let mut owned_samples = Vec::new();
+
+    let time = |body: &mut dyn FnMut()| -> u128 {
+        let start = std::time::Instant::now();
+        for _ in 0..ITERATIONS {
+            body();
+        }
+        start.elapsed().as_nanos() / u128::from(ITERATIONS)
+    };
+
+    for round in 0..ROUNDS {
+        // Alternate the order so process/cache warm-up is shared evenly.
+        if round % 2 == 0 {
+            if run_borrowed {
+                borrowed_samples.push(time(&mut borrowed));
+            }
+            if run_owned {
+                owned_samples.push(time(&mut owned));
+            }
+        } else {
+            if run_owned {
+                owned_samples.push(time(&mut owned));
+            }
+            if run_borrowed {
+                borrowed_samples.push(time(&mut borrowed));
+            }
+        }
+    }
+
+    let borrowed_timing = (!borrowed_samples.is_empty()).then(|| {
+        let t = Timing::from_samples(borrowed_samples);
+        t.report(borrowed_label);
+        t
+    });
+    let owned_timing = (!owned_samples.is_empty()).then(|| {
+        let t = Timing::from_samples(owned_samples);
+        t.report(owned_label);
+        t
+    });
+    (borrowed_timing, owned_timing)
+}
+
+/// Print the signed median-to-median delta. Signed deliberately: clamping at
+/// zero would render a regression as "no difference" in the one artifact whose
+/// job is to show whether the owned path is cheaper.
+fn report_delta(name: &str, borrowed: Option<Timing>, owned: Option<Timing>) {
+    let (Some(borrowed), Some(owned)) = (borrowed, owned) else {
+        return; // One side was not run.
+    };
+    if borrowed.median == 0 {
+        println!("  {name}: too fast to measure at this resolution");
+        return;
+    }
+    #[allow(clippy::cast_precision_loss)]
+    let pct = ((owned.median as f64 - borrowed.median as f64) / borrowed.median as f64) * 100.0;
+    let verdict = if owned.median <= borrowed.median {
+        "faster"
+    } else {
+        "SLOWER"
+    };
+    println!(
+        "  {name}: {} -> {} ns/op ({pct:+.1}%, owned is {verdict})",
+        borrowed.median, owned.median
+    );
+    if owned.max > borrowed.min {
+        println!(
+            "    note: the two ranges overlap ({}-{} vs {}-{}); treat this row as indicative",
+            borrowed.min, borrowed.max, owned.min, owned.max
+        );
+    }
+}
 
 fn main() {
     let before = serde_json::json!({
@@ -44,54 +200,86 @@ fn main() {
 
     let sensitive: &[&str] = &[];
 
-    // Warmup
-    for _ in 0..1000 {
-        let _ = black_box(compute_diff(&before, &after, sensitive));
-    }
-
-    // Timed run: 10 000 iterations
-    let start = std::time::Instant::now();
-    let iterations = 10_000u32;
-    for _ in 0..iterations {
-        let _ = black_box(compute_diff(
-            black_box(&before),
-            black_box(&after),
-            black_box(sensitive),
-        ));
-    }
-    let elapsed = start.elapsed();
-    let per_op_ns = elapsed.as_nanos() / u128::from(iterations);
-    println!(
-        "compute_diff:            {per_op_ns} ns/op  ({iterations} iterations in {elapsed:?})"
+    // `borrowed` / `owned` restrict the run to one side so a profiler's
+    // whole-process totals are attributable; no argument runs both and prints
+    // the comparison.
+    let mode = std::env::args().nth(1);
+    let enabled = (
+        mode.as_deref() != Some("owned"),
+        mode.as_deref() != Some("borrowed"),
     );
 
-    let start = std::time::Instant::now();
-    for _ in 0..iterations {
-        let _ = black_box(compute_insert_changes(
-            black_box(&after),
-            black_box(sensitive),
-        ));
+    // Warmup, so neither side pays a first-touch cost inside a round. Gated by
+    // mode too: under `borrowed`/`owned` a profiler is attributing the whole
+    // process, so warming the other side would pollute the totals.
+    for _ in 0..WARMUP {
+        if enabled.0 {
+            let _ = black_box(compute_diff(&before, &after, sensitive));
+            let _ = black_box(compute_insert_changes(&after, sensitive));
+        }
+        if enabled.1 {
+            let _ = black_box(compute_diff_owned(before.clone(), after.clone(), sensitive));
+            let _ = black_box(compute_insert_changes_owned(after.clone(), sensitive));
+        }
     }
-    let elapsed = start.elapsed();
-    let per_op_ns = elapsed.as_nanos() / u128::from(iterations);
-    println!(
-        "compute_insert_changes:  {per_op_ns} ns/op  ({iterations} iterations in {elapsed:?})"
+
+    let (diff_borrowed, diff_owned) = bench_pair(
+        "compute_diff:",
+        || {
+            let (b, a) = (before.clone(), after.clone());
+            let _ = black_box(compute_diff(black_box(&b), black_box(&a), sensitive));
+        },
+        "compute_diff_owned:",
+        || {
+            let (b, a) = (before.clone(), after.clone());
+            let _ = black_box(compute_diff_owned(black_box(b), black_box(a), sensitive));
+        },
+        enabled,
     );
 
-    let start = std::time::Instant::now();
-    for _ in 0..iterations {
-        let _ = black_box(compute_delete_changes(
-            black_box(&before),
-            black_box(sensitive),
-        ));
-    }
-    let elapsed = start.elapsed();
-    let per_op_ns = elapsed.as_nanos() / u128::from(iterations);
-    println!(
-        "compute_delete_changes:  {per_op_ns} ns/op  ({iterations} iterations in {elapsed:?})"
+    let (insert_borrowed, insert_owned) = bench_pair(
+        "compute_insert_changes:",
+        || {
+            let r = after.clone();
+            let _ = black_box(compute_insert_changes(black_box(&r), sensitive));
+        },
+        "compute_insert_changes_owned:",
+        || {
+            let r = after.clone();
+            let _ = black_box(compute_insert_changes_owned(black_box(r), sensitive));
+        },
+        enabled,
+    );
+
+    let (delete_borrowed, delete_owned) = bench_pair(
+        "compute_delete_changes:",
+        || {
+            let r = before.clone();
+            let _ = black_box(compute_delete_changes(black_box(&r), sensitive));
+        },
+        "compute_delete_changes_owned:",
+        || {
+            let r = before.clone();
+            let _ = black_box(compute_delete_changes_owned(black_box(r), sensitive));
+        },
+        enabled,
     );
 
     println!();
+    if enabled == (true, true) {
+        println!("Owned-value entry points (#2429) — what the versioned codegen calls.");
+        println!("Each figure includes the per-iteration `Value` materialization both pay for:");
+        report_delta("compute_diff", diff_borrowed, diff_owned);
+        report_delta("compute_insert_changes", insert_borrowed, insert_owned);
+        report_delta("compute_delete_changes", delete_borrowed, delete_owned);
+        println!();
+        println!(
+            "Allocation blocks, deterministic, are gated in \
+             autumn/tests/version_history_alloc_gate.rs."
+        );
+        println!();
+    }
+
     println!("Budget: ≤ 5 ms p99 write latency overhead (pure Rust component only).");
     println!("Each operation above runs in single-digit microseconds — well within budget.");
 }

--- a/autumn/benches/version_history.rs
+++ b/autumn/benches/version_history.rs
@@ -169,7 +169,10 @@ fn report_delta(name: &str, borrowed: Option<Timing>, owned: Option<Timing>) {
         "  {name}: {} -> {} ns/op ({pct:+.1}%, owned is {verdict})",
         borrowed.median, owned.median
     );
-    if owned.max > borrowed.min {
+    // Interval overlap needs *both* bounds: `owned.max > borrowed.min` alone is
+    // also true when owned is uniformly slower (borrowed 400-450, owned
+    // 600-650), which would file a conclusive regression as mere noise.
+    if owned.min <= borrowed.max && borrowed.min <= owned.max {
         println!(
             "    note: the two ranges overlap ({}-{} vs {}-{}); treat this row as indicative",
             borrowed.min, borrowed.max, owned.min, owned.max

--- a/autumn/src/lib.rs
+++ b/autumn/src/lib.rs
@@ -384,7 +384,8 @@ pub use ledger::{
 pub mod version_history;
 pub use version_history::{
     ColumnChange, VersionEntry, VersionFilter, VersionOp, VersionPage, VersionedRecord,
-    compute_delete_changes, compute_diff, compute_insert_changes,
+    compute_delete_changes, compute_delete_changes_owned, compute_diff, compute_diff_owned,
+    compute_insert_changes, compute_insert_changes_owned,
 };
 
 /// Router construction and integration with Axum.

--- a/autumn/src/version_history.rs
+++ b/autumn/src/version_history.rs
@@ -387,6 +387,108 @@ pub fn compute_delete_changes(record: &serde_json::Value, sensitive: &[&str]) ->
         .collect()
 }
 
+/// Owned-value twin of [`compute_diff`].
+///
+/// Produces the identical changeset — same entries, same order, same
+/// sensitive-column redaction. The only difference is ownership: taking
+/// `before`/`after` by value lets every retained column name and value be
+/// **moved** into its [`ColumnChange`] instead of cloned, so each retained
+/// field is allocated once and dropped once rather than twice.
+///
+/// Prefer this whenever the caller has a `Value` it will not use again. The
+/// `#[repository(versioned = true)]` codegen does exactly that: it builds a
+/// throwaway `Value` from [`VersionedRecord::version_column_values`] per
+/// mutation and drops it immediately after the diff (#2429).
+///
+/// Use [`compute_diff`] when the `Value` must outlive the call.
+#[must_use]
+pub fn compute_diff_owned(
+    before: serde_json::Value,
+    after: serde_json::Value,
+    sensitive: &[&str],
+) -> Vec<ColumnChange> {
+    let serde_json::Value::Object(after_obj) = after else {
+        return vec![];
+    };
+    // A non-object `before` (JSON `null` from a missing prior row, a scalar
+    // from a hand-rolled `VersionedRecord`) is treated as "no prior values",
+    // matching `compute_diff`, which resolves `before.as_object()` to `None`.
+    let mut before_obj = match before {
+        serde_json::Value::Object(obj) => Some(obj),
+        _ => None,
+    };
+
+    let mut changes = Vec::new();
+    for (col, after_val) in after_obj {
+        // `remove` both reads the prior value and takes ownership of it. Only
+        // the `after` map is being iterated, so mutating `before` here is
+        // sound, and a JSON object cannot repeat a key — each column is
+        // removed at most once.
+        let before_val = before_obj.as_mut().and_then(|obj| obj.remove(&col));
+        let did_change = before_val.as_ref() != Some(&after_val);
+        if !did_change {
+            continue;
+        }
+        // `remove` above already moved the prior value into `before_val`, so
+        // this decides only where it goes next: a redacted column's secret is
+        // never cloned and never reaches the entry — it is dropped when
+        // `before_val` falls out of scope at the end of this iteration, along
+        // with the `after` value beside it.
+        if sensitive.contains(&col.as_str()) {
+            changes.push(ColumnChange::sensitive(col));
+        } else {
+            changes.push(ColumnChange::new(col, before_val, Some(after_val)));
+        }
+    }
+    changes
+}
+
+/// Owned-value twin of [`compute_insert_changes`].
+///
+/// Same output; moves each column name and value into its [`ColumnChange`]
+/// instead of cloning it. See [`compute_diff_owned`] for when to prefer this.
+#[must_use]
+pub fn compute_insert_changes_owned(
+    record: serde_json::Value,
+    sensitive: &[&str],
+) -> Vec<ColumnChange> {
+    let serde_json::Value::Object(obj) = record else {
+        return vec![];
+    };
+    obj.into_iter()
+        .map(|(col, val)| {
+            if sensitive.contains(&col.as_str()) {
+                ColumnChange::sensitive(col)
+            } else {
+                ColumnChange::new(col, None, Some(val))
+            }
+        })
+        .collect()
+}
+
+/// Owned-value twin of [`compute_delete_changes`].
+///
+/// Same output; moves each column name and value into its [`ColumnChange`]
+/// instead of cloning it. See [`compute_diff_owned`] for when to prefer this.
+#[must_use]
+pub fn compute_delete_changes_owned(
+    record: serde_json::Value,
+    sensitive: &[&str],
+) -> Vec<ColumnChange> {
+    let serde_json::Value::Object(obj) = record else {
+        return vec![];
+    };
+    obj.into_iter()
+        .map(|(col, val)| {
+            if sensitive.contains(&col.as_str()) {
+                ColumnChange::sensitive(col)
+            } else {
+                ColumnChange::new(col, Some(val), None)
+            }
+        })
+        .collect()
+}
+
 // ── VersionedRecord trait ────────────────────────────────────────────
 
 /// Implemented by models that opt into automatic version history.
@@ -854,6 +956,481 @@ mod tests {
         assert!(secret.sensitive);
         assert!(secret.before.is_none());
         assert!(secret.after.is_none());
+    }
+
+    // ── owned-value siblings (#2429) ─────────────────────────────────
+    //
+    // The macro call site (`autumn-macros/src/repository.rs`, `vh_insert_ts`)
+    // builds each `Value` fresh and throws it away immediately, so the
+    // borrowed entry points clone every retained key and value for nothing.
+    // The `*_owned` siblings move those keys/values straight into the
+    // `ColumnChange`. Because this is the audit-trail write path, every
+    // owned function is held to **exact** output parity with its borrowed
+    // twin, over a case matrix the two share, rather than to hand-written
+    // expectations: any future divergence — a dropped sensitive redaction, a
+    // mishandled "present in `after` but not `before`" column, a reordered
+    // changeset — fails here.
+
+    /// `(label, before, after, sensitive)` cases exercised by both the
+    /// borrowed and the owned diff path.
+    fn diff_parity_cases() -> Vec<(
+        &'static str,
+        serde_json::Value,
+        serde_json::Value,
+        &'static [&'static str],
+    )> {
+        vec![
+            (
+                "typical update",
+                serde_json::json!({"id": 1, "title": "old", "body": "same", "published": false}),
+                serde_json::json!({"id": 1, "title": "new", "body": "same", "published": true}),
+                &[],
+            ),
+            (
+                "no changes",
+                serde_json::json!({"title": "same"}),
+                serde_json::json!({"title": "same"}),
+                &[],
+            ),
+            (
+                "sensitive column changed",
+                serde_json::json!({"title": "old", "password_digest": "hash1"}),
+                serde_json::json!({"title": "new", "password_digest": "hash2"}),
+                &["password_digest"],
+            ),
+            (
+                "sensitive column unchanged",
+                serde_json::json!({"title": "new", "password_digest": "same"}),
+                serde_json::json!({"title": "new", "password_digest": "same"}),
+                &["password_digest"],
+            ),
+            (
+                "multiple sensitive columns",
+                serde_json::json!({"a": 1, "password_digest": "h1", "reset_token": "t1"}),
+                serde_json::json!({"a": 2, "password_digest": "h2", "reset_token": "t2"}),
+                &["password_digest", "reset_token"],
+            ),
+            (
+                "sensitive column listed but absent",
+                serde_json::json!({"title": "old"}),
+                serde_json::json!({"title": "new"}),
+                &["password_digest"],
+            ),
+            (
+                "sensitive column present only in after",
+                serde_json::json!({"title": "old"}),
+                serde_json::json!({"title": "new", "password_digest": "h"}),
+                &["password_digest"],
+            ),
+            (
+                "sensitive column present only in before",
+                serde_json::json!({"title": "old", "password_digest": "h"}),
+                serde_json::json!({"title": "new"}),
+                &["password_digest"],
+            ),
+            (
+                "before and after share no keys",
+                serde_json::json!({"old_a": 1, "old_b": 2}),
+                serde_json::json!({"new_a": 3, "new_b": 4}),
+                &[],
+            ),
+            (
+                "before is JSON null",
+                serde_json::json!(null),
+                serde_json::json!({"title": "Hello"}),
+                &[],
+            ),
+            (
+                "before is a scalar",
+                serde_json::json!(42),
+                serde_json::json!({"title": "Hello"}),
+                &[],
+            ),
+            (
+                "before is an array",
+                serde_json::json!([1, 2, 3]),
+                serde_json::json!({"title": "Hello"}),
+                &[],
+            ),
+            (
+                "after is not an object",
+                serde_json::json!({"title": "Hello"}),
+                serde_json::json!(null),
+                &[],
+            ),
+            (
+                "after is an array",
+                serde_json::json!({"title": "Hello"}),
+                serde_json::json!(["title"]),
+                &[],
+            ),
+            (
+                "column only in after",
+                serde_json::json!({"title": "old"}),
+                serde_json::json!({"title": "old", "slug": "new-col"}),
+                &[],
+            ),
+            (
+                "column only in before is dropped from the changeset",
+                serde_json::json!({"title": "old", "legacy": "gone"}),
+                serde_json::json!({"title": "new"}),
+                &[],
+            ),
+            (
+                "null equals null",
+                serde_json::json!({"a": null}),
+                serde_json::json!({"a": null}),
+                &[],
+            ),
+            (
+                "missing before vs explicit null after",
+                serde_json::json!({}),
+                serde_json::json!({"a": null}),
+                &[],
+            ),
+            (
+                "null before to value after",
+                serde_json::json!({"a": null}),
+                serde_json::json!({"a": 1}),
+                &[],
+            ),
+            (
+                "value before to null after",
+                serde_json::json!({"a": 1}),
+                serde_json::json!({"a": null}),
+                &[],
+            ),
+            (
+                "empty after object",
+                serde_json::json!({"a": 1}),
+                serde_json::json!({}),
+                &[],
+            ),
+            (
+                "empty before object",
+                serde_json::json!({}),
+                serde_json::json!({"a": 1}),
+                &[],
+            ),
+            (
+                "nested object and array values",
+                serde_json::json!({"meta": {"k": [1, 2]}, "tags": ["a"]}),
+                serde_json::json!({"meta": {"k": [1, 3]}, "tags": ["a"]}),
+                &[],
+            ),
+            (
+                "numeric type change with equal display",
+                serde_json::json!({"n": 1}),
+                serde_json::json!({"n": 1.0}),
+                &[],
+            ),
+            (
+                "unicode and ordering",
+                serde_json::json!({"zeta": 1, "Alpha": 2, "émile": 3}),
+                serde_json::json!({"zeta": 9, "Alpha": 2, "émile": 8}),
+                &[],
+            ),
+        ]
+    }
+
+    /// `(label, record, sensitive)` cases exercised by both the borrowed and
+    /// the owned insert/delete paths.
+    fn record_parity_cases() -> Vec<(&'static str, serde_json::Value, &'static [&'static str])> {
+        vec![
+            (
+                "typical record",
+                serde_json::json!({"id": 1, "title": "Hello", "body": "World"}),
+                &[],
+            ),
+            (
+                "sensitive column",
+                serde_json::json!({"id": 1, "password_digest": "hashed"}),
+                &["password_digest"],
+            ),
+            (
+                "every column sensitive",
+                serde_json::json!({"password_digest": "h", "reset_token": "t"}),
+                &["password_digest", "reset_token"],
+            ),
+            (
+                "sensitive listed but absent",
+                serde_json::json!({"id": 1}),
+                &["password_digest"],
+            ),
+            ("empty object", serde_json::json!({}), &[]),
+            ("not an object", serde_json::json!(null), &[]),
+            ("scalar", serde_json::json!(7), &[]),
+            ("array", serde_json::json!([1, 2]), &[]),
+            (
+                "null and nested values",
+                serde_json::json!({"a": null, "meta": {"k": [1, 2]}}),
+                &[],
+            ),
+            (
+                "unicode and ordering",
+                serde_json::json!({"zeta": 1, "Alpha": 2, "émile": 3}),
+                &[],
+            ),
+        ]
+    }
+
+    #[test]
+    fn compute_diff_owned_matches_borrowed_exactly() {
+        for (label, before, after, sensitive) in diff_parity_cases() {
+            let borrowed = compute_diff(&before, &after, sensitive);
+            let owned = compute_diff_owned(before.clone(), after.clone(), sensitive);
+            assert_eq!(owned, borrowed, "compute_diff_owned diverged for {label:?}");
+        }
+    }
+
+    #[test]
+    fn compute_insert_changes_owned_matches_borrowed_exactly() {
+        for (label, record, sensitive) in record_parity_cases() {
+            let borrowed = compute_insert_changes(&record, sensitive);
+            let owned = compute_insert_changes_owned(record.clone(), sensitive);
+            assert_eq!(
+                owned, borrowed,
+                "compute_insert_changes_owned diverged for {label:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn compute_delete_changes_owned_matches_borrowed_exactly() {
+        for (label, record, sensitive) in record_parity_cases() {
+            let borrowed = compute_delete_changes(&record, sensitive);
+            let owned = compute_delete_changes_owned(record.clone(), sensitive);
+            assert_eq!(
+                owned, borrowed,
+                "compute_delete_changes_owned diverged for {label:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn owned_changesets_serialize_identically_to_borrowed() {
+        // The generated code serializes the changeset to a string before it
+        // reaches the `_autumn_version_history` row, so parity has to hold at
+        // the JSON level too — including key order inside each entry.
+        for (label, before, after, sensitive) in diff_parity_cases() {
+            let borrowed =
+                serde_json::to_string(&compute_diff(&before, &after, sensitive)).unwrap();
+            let owned =
+                serde_json::to_string(&compute_diff_owned(before, after, sensitive)).unwrap();
+            assert_eq!(owned, borrowed, "serialized diff diverged for {label:?}");
+        }
+        for (label, record, sensitive) in record_parity_cases() {
+            let borrowed =
+                serde_json::to_string(&compute_insert_changes(&record, sensitive)).unwrap();
+            let owned =
+                serde_json::to_string(&compute_insert_changes_owned(record.clone(), sensitive))
+                    .unwrap();
+            assert_eq!(owned, borrowed, "serialized insert diverged for {label:?}");
+
+            let borrowed =
+                serde_json::to_string(&compute_delete_changes(&record, sensitive)).unwrap();
+            let owned =
+                serde_json::to_string(&compute_delete_changes_owned(record, sensitive)).unwrap();
+            assert_eq!(owned, borrowed, "serialized delete diverged for {label:?}");
+        }
+    }
+
+    /// Assert the redaction contract on one changeset: the column still
+    /// appears (the timeline must stay complete, per [`ColumnChange`]), it is
+    /// flagged `sensitive`, both values are omitted, and no secret survives
+    /// into the serialized row that reaches the audit table.
+    ///
+    /// Both halves matter: without the first, an implementation that dropped
+    /// the entry entirely — or returned `vec![]` — would "pass" a leak test.
+    fn assert_redacted(changes: &[ColumnChange], secrets: &[&str]) {
+        let entry = changes
+            .iter()
+            .find(|c| c.column == "password_digest")
+            .expect("a changed sensitive column must still appear in the changeset");
+        assert!(entry.sensitive, "the entry must be flagged sensitive");
+        assert!(entry.before.is_none(), "sensitive before must be omitted");
+        assert!(entry.after.is_none(), "sensitive after must be omitted");
+
+        let json = serde_json::to_string(changes).unwrap();
+        for secret in secrets {
+            assert!(
+                !json.contains(secret),
+                "sensitive value {secret} leaked into the changeset: {json}"
+            );
+        }
+    }
+
+    #[test]
+    fn compute_diff_owned_never_leaks_a_sensitive_value() {
+        // Adversarial: a `.remove()`-based implementation that forgot the
+        // sensitive check would move the secret into the entry instead of
+        // dropping it.
+        let before = serde_json::json!({"password_digest": "OLD_SECRET", "title": "t"});
+        let after = serde_json::json!({"password_digest": "NEW_SECRET", "title": "t2"});
+        assert_redacted(
+            &compute_diff_owned(before, after, &["password_digest"]),
+            &["OLD_SECRET", "NEW_SECRET"],
+        );
+
+        let record = serde_json::json!({"password_digest": "INSERT_SECRET"});
+        assert_redacted(
+            &compute_insert_changes_owned(record, &["password_digest"]),
+            &["INSERT_SECRET"],
+        );
+
+        let record = serde_json::json!({"password_digest": "DELETE_SECRET"});
+        assert_redacted(
+            &compute_delete_changes_owned(record, &["password_digest"]),
+            &["DELETE_SECRET"],
+        );
+    }
+
+    // The parity tests above prove the owned path is *correct*. These prove it
+    // is actually cheaper, by the strictest statement available: the heap
+    // buffer that comes out of the owned entry point is the same allocation
+    // that went in. An `_owned` function implemented by delegating to its
+    // borrowed twin would still pass every parity test above, and fails here.
+    //
+    // The aggregate, whole-record version of the same claim — allocation blocks
+    // per mutation, against a pinned ceiling — lives in
+    // `autumn/tests/version_history_alloc_gate.rs`, which needs its own binary
+    // because `allocation-counter` installs a process-wide global allocator.
+    // These stay here because they are exact rather than statistical: they name
+    // *which* buffer, and cost nothing to run in the consolidated suite.
+
+    /// Heap address of a column name inside a JSON object.
+    fn key_ptr(v: &serde_json::Value, col: &str) -> *const u8 {
+        v.as_object()
+            .unwrap()
+            .get_key_value(col)
+            .unwrap()
+            .0
+            .as_ptr()
+    }
+
+    /// Heap address of a string column's value inside a JSON object.
+    fn val_ptr(v: &serde_json::Value, col: &str) -> *const u8 {
+        v.as_object().unwrap()[col].as_str().unwrap().as_ptr()
+    }
+
+    #[test]
+    fn compute_diff_owned_moves_buffers_instead_of_cloning_them() {
+        let before = serde_json::json!({
+            "body": "the previous body text, long enough to be heap allocated"
+        });
+        let after = serde_json::json!({
+            "body": "the current body text, long enough to be heap allocated"
+        });
+
+        let col = key_ptr(&after, "body");
+        let old = val_ptr(&before, "body");
+        let new = val_ptr(&after, "body");
+
+        // Contrast: the borrowed entry point copies all three. `before`/`after`
+        // are still alive here, so the copies cannot reuse their addresses.
+        let borrowed = compute_diff(&before, &after, &[]);
+        assert_eq!(borrowed.len(), 1);
+        assert_ne!(borrowed[0].column.as_ptr(), col);
+        assert_ne!(
+            borrowed[0]
+                .before
+                .as_ref()
+                .unwrap()
+                .as_str()
+                .unwrap()
+                .as_ptr(),
+            old
+        );
+        assert_ne!(
+            borrowed[0]
+                .after
+                .as_ref()
+                .unwrap()
+                .as_str()
+                .unwrap()
+                .as_ptr(),
+            new
+        );
+
+        let owned = compute_diff_owned(before, after, &[]);
+        assert_eq!(owned, borrowed);
+        assert_eq!(
+            owned[0].column.as_ptr(),
+            col,
+            "the column name must be moved out of the `after` map, not cloned"
+        );
+        assert_eq!(
+            owned[0].before.as_ref().unwrap().as_str().unwrap().as_ptr(),
+            old,
+            "the before value must be moved out of the `before` map, not cloned"
+        );
+        assert_eq!(
+            owned[0].after.as_ref().unwrap().as_str().unwrap().as_ptr(),
+            new,
+            "the after value must be moved out of the `after` map, not cloned"
+        );
+    }
+
+    #[test]
+    fn compute_insert_changes_owned_moves_buffers_instead_of_cloning_them() {
+        let record = serde_json::json!({
+            "body": "an inserted body long enough to be heap allocated"
+        });
+        let col = key_ptr(&record, "body");
+        let val = val_ptr(&record, "body");
+
+        let borrowed = compute_insert_changes(&record, &[]);
+        assert_eq!(borrowed.len(), 1);
+        assert_ne!(borrowed[0].column.as_ptr(), col);
+        assert_ne!(
+            borrowed[0]
+                .after
+                .as_ref()
+                .unwrap()
+                .as_str()
+                .unwrap()
+                .as_ptr(),
+            val
+        );
+
+        let owned = compute_insert_changes_owned(record, &[]);
+        assert_eq!(owned, borrowed);
+        assert_eq!(owned[0].column.as_ptr(), col);
+        assert_eq!(
+            owned[0].after.as_ref().unwrap().as_str().unwrap().as_ptr(),
+            val
+        );
+    }
+
+    #[test]
+    fn compute_delete_changes_owned_moves_buffers_instead_of_cloning_them() {
+        let record = serde_json::json!({
+            "body": "a deleted body long enough to be heap allocated"
+        });
+        let col = key_ptr(&record, "body");
+        let val = val_ptr(&record, "body");
+
+        let borrowed = compute_delete_changes(&record, &[]);
+        assert_eq!(borrowed.len(), 1);
+        assert_ne!(borrowed[0].column.as_ptr(), col);
+        assert_ne!(
+            borrowed[0]
+                .before
+                .as_ref()
+                .unwrap()
+                .as_str()
+                .unwrap()
+                .as_ptr(),
+            val
+        );
+
+        let owned = compute_delete_changes_owned(record, &[]);
+        assert_eq!(owned, borrowed);
+        assert_eq!(owned[0].column.as_ptr(), col);
+        assert_eq!(
+            owned[0].before.as_ref().unwrap().as_str().unwrap().as_ptr(),
+            val
+        );
     }
 
     // ── VersionedRecord trait ────────────────────────────────────────

--- a/autumn/src/version_history.rs
+++ b/autumn/src/version_history.rs
@@ -973,6 +973,7 @@ mod tests {
 
     /// `(label, before, after, sensitive)` cases exercised by both the
     /// borrowed and the owned diff path.
+    #[allow(clippy::too_many_lines)] // a case table; splitting it would only hide cases
     fn diff_parity_cases() -> Vec<(
         &'static str,
         serde_json::Value,

--- a/autumn/tests/version_history_alloc_gate.rs
+++ b/autumn/tests/version_history_alloc_gate.rs
@@ -1,0 +1,183 @@
+//! Isolated integration test: allocation gate for the version-history diff
+//! entry points on the workload the `#[repository(versioned = true)]` codegen
+//! actually runs (#2429).
+//!
+//! Its own binary for the same reason `config_alloc_gate` and
+//! `password_policy_alloc_gate` are: `allocation-counter` installs a
+//! process-wide counting `#[global_allocator]`, a process-wide side effect per
+//! CLAUDE.md's isolated-test rules, and taxing every allocation in the
+//! consolidated suite to measure a handful here is not a trade worth making.
+//!
+//! # What is measured
+//!
+//! One *mutation* as the generated code performs it: materialize a throwaway
+//! `serde_json::Value` (standing in for `VersionedRecord::version_column_values`,
+//! which serializes the record fresh on every write) and hand it to the diff.
+//! Both the borrowed and the owned entry point are charged for that
+//! materialization, so the delta between them is exactly what each does with
+//! the value it is given — `&Value` clones every retained column name and value
+//! out of it, the owned variant moves them.
+//!
+//! The pointer-identity tests in `autumn/src/version_history.rs` prove *that*
+//! the owned path moves rather than clones, for one column. This gate is the
+//! aggregate: it pins the whole-record cost so a future refactor back toward
+//! cloning fails a test instead of only showing up in a profiler.
+
+use std::hint::black_box;
+
+use autumn_web::version_history::{
+    compute_delete_changes, compute_delete_changes_owned, compute_diff, compute_diff_owned,
+    compute_insert_changes, compute_insert_changes_owned,
+};
+
+/// Enough repetitions that a per-mutation allocation cannot hide in noise,
+/// and enough that the ceilings below are legible per-mutation figures.
+const MUTATIONS: u64 = 100;
+
+// Measured on this 7-column record, deterministic across runs, blocks per
+// `MUTATIONS`-run window (each figure includes the throwaway `Value` both the
+// borrowed and the owned path are charged for):
+//
+// | entry point              | borrowed | owned | delta   |
+// |--------------------------|----------|-------|---------|
+// | `compute_diff`           |    3,400 | 2,700 | -20.6%  |
+// | `compute_insert_changes` |    2,600 | 1,400 | -46.2%  |
+// | `compute_delete_changes` |    2,600 | 1,400 | -46.2%  |
+//
+// `compute_diff` gains least because it only ever retained the *changed*
+// columns (3 of 7 here), so it had the fewest clones to drop.
+//
+// Ceilings sit a little above the measurement, same convention as
+// `config_alloc_gate`'s. A failure a hair over the line means re-measure and
+// re-derive, not nudge upwards.
+const DIFF_OWNED_CEILING: u64 = 2_800;
+const INSERT_OWNED_CEILING: u64 = 1_500;
+const DELETE_OWNED_CEILING: u64 = 1_500;
+
+/// A realistic 7-column record (title/body/published/author/timestamps),
+/// matching `autumn/benches/version_history.rs`.
+fn before_record() -> serde_json::Value {
+    serde_json::json!({
+        "id": 1,
+        "title": "Old title",
+        "body": "Some body text that is reasonably long to be realistic",
+        "published": false,
+        "author": "alice",
+        "created_at": "2026-01-01T00:00:00Z",
+        "updated_at": "2026-01-01T00:00:00Z"
+    })
+}
+
+fn after_record() -> serde_json::Value {
+    serde_json::json!({
+        "id": 1,
+        "title": "New title",
+        "body": "Some body text that is reasonably long to be realistic",
+        "published": true,
+        "author": "alice",
+        "created_at": "2026-01-01T00:00:00Z",
+        "updated_at": "2026-05-26T12:00:00Z"
+    })
+}
+
+/// Blocks and bytes charged to `MUTATIONS` runs of `body`.
+fn measure(label: &str, body: impl Fn()) -> (u64, u64) {
+    // Warm-up outside the measured window, so nothing one-time is charged.
+    body();
+    let info = allocation_counter::measure(|| {
+        for _ in 0..MUTATIONS {
+            body();
+        }
+    });
+    let per_mutation_blocks = info.count_total / MUTATIONS;
+    let per_mutation_bytes = info.bytes_total / MUTATIONS;
+    println!(
+        "{label}: {per_mutation_blocks} blocks / {per_mutation_bytes} bytes per mutation \
+         ({MUTATIONS} mutations, {} blocks / {} bytes total)",
+        info.count_total, info.bytes_total
+    );
+    (info.count_total, info.bytes_total)
+}
+
+#[test]
+fn owned_entry_points_allocate_less_than_borrowed_on_a_versioned_write() {
+    let before = before_record();
+    let after = after_record();
+    let sensitive: &[&str] = &[];
+
+    let (diff_borrowed, diff_borrowed_bytes) = measure("compute_diff", || {
+        let (b, a) = (before.clone(), after.clone());
+        black_box(compute_diff(black_box(&b), black_box(&a), sensitive));
+    });
+    let (diff_owned, diff_owned_bytes) = measure("compute_diff_owned", || {
+        let (b, a) = (before.clone(), after.clone());
+        black_box(compute_diff_owned(black_box(b), black_box(a), sensitive));
+    });
+
+    let (insert_borrowed, insert_borrowed_bytes) = measure("compute_insert_changes", || {
+        let r = after.clone();
+        black_box(compute_insert_changes(black_box(&r), sensitive));
+    });
+    let (insert_owned, insert_owned_bytes) = measure("compute_insert_changes_owned", || {
+        let r = after.clone();
+        black_box(compute_insert_changes_owned(black_box(r), sensitive));
+    });
+
+    let (delete_borrowed, delete_borrowed_bytes) = measure("compute_delete_changes", || {
+        let r = before.clone();
+        black_box(compute_delete_changes(black_box(&r), sensitive));
+    });
+    let (delete_owned, delete_owned_bytes) = measure("compute_delete_changes_owned", || {
+        let r = before.clone();
+        black_box(compute_delete_changes_owned(black_box(r), sensitive));
+    });
+
+    // ── Relative: the whole point of the owned entry points ──────────
+    //
+    // Stated as strict inequalities rather than fixed ratios so the gate
+    // survives an unrelated change to how `serde_json::json!` allocates, while
+    // still failing outright if an `_owned` function is ever reimplemented as a
+    // delegate to its borrowed twin (which allocates identically).
+    assert!(
+        diff_owned < diff_borrowed,
+        "compute_diff_owned allocated {diff_owned} blocks vs compute_diff's {diff_borrowed} \
+         over {MUTATIONS} mutations — the owned path must allocate strictly less"
+    );
+    assert!(
+        insert_owned < insert_borrowed,
+        "compute_insert_changes_owned allocated {insert_owned} blocks vs \
+         compute_insert_changes's {insert_borrowed} over {MUTATIONS} mutations"
+    );
+    assert!(
+        delete_owned < delete_borrowed,
+        "compute_delete_changes_owned allocated {delete_owned} blocks vs \
+         compute_delete_changes's {delete_borrowed} over {MUTATIONS} mutations"
+    );
+    assert!(
+        diff_owned_bytes < diff_borrowed_bytes
+            && insert_owned_bytes < insert_borrowed_bytes
+            && delete_owned_bytes < delete_borrowed_bytes,
+        "every owned entry point must also allocate fewer bytes: diff {diff_owned_bytes} vs \
+         {diff_borrowed_bytes}, insert {insert_owned_bytes} vs {insert_borrowed_bytes}, \
+         delete {delete_owned_bytes} vs {delete_borrowed_bytes}"
+    );
+
+    // ── Absolute: pin the measured cost ──────────────────────────────
+    //
+    // See the table beside the ceiling constants for the measured baselines.
+    assert!(
+        insert_owned <= INSERT_OWNED_CEILING,
+        "compute_insert_changes_owned allocated {insert_owned} blocks over {MUTATIONS} \
+         mutations, over the {INSERT_OWNED_CEILING}-block ceiling"
+    );
+    assert!(
+        delete_owned <= DELETE_OWNED_CEILING,
+        "compute_delete_changes_owned allocated {delete_owned} blocks over {MUTATIONS} \
+         mutations, over the {DELETE_OWNED_CEILING}-block ceiling"
+    );
+    assert!(
+        diff_owned <= DIFF_OWNED_CEILING,
+        "compute_diff_owned allocated {diff_owned} blocks over {MUTATIONS} mutations, \
+         over the {DIFF_OWNED_CEILING}-block ceiling"
+    );
+}

--- a/docs/guide/version-history.md
+++ b/docs/guide/version-history.md
@@ -151,6 +151,29 @@ transaction, so it does not add a full network RTT. The in-process overhead
 **Budget**: the feature must not regress p99 write latency by more than 5 ms
 relative to the same repository with version history off.
 
+## Computing a diff yourself
+
+Step 2 of the write path above is available directly, in two shapes:
+
+| What you have                        | What to call |
+|--------------------------------------|--------------|
+| a `Value` you still need afterwards  | `compute_diff`, `compute_insert_changes`, `compute_delete_changes` |
+| a `Value` you are done with          | `compute_diff_owned`, `compute_insert_changes_owned`, `compute_delete_changes_owned` |
+
+Both shapes produce the identical changeset. The `_owned` variants take the
+`serde_json::Value` by value so every retained column name and value is *moved*
+into its `ColumnChange` rather than cloned, which is why the generated write
+path uses them: it serializes a throwaway `Value` per mutation and drops it
+immediately after the diff.
+
+```rust,ignore
+use autumn_web::version_history::compute_diff_owned;
+
+let changes = compute_diff_owned(before_json, after_json, &["password_digest"]);
+```
+
+Reach for the borrowed variants when the `Value` has to outlive the call.
+
 ## Storage growth
 
 Each row in `_autumn_version_history` is roughly proportional to the number of


### PR DESCRIPTION
Closes #2429.

## What

`compute_diff` / `compute_insert_changes` / `compute_delete_changes` take `&serde_json::Value`, so each one had to clone every retained column name and value into the `ColumnChange` it returns. The only production caller — the `#[repository(versioned = true)]` codegen (`vh_insert_ts`), which every insert, update and delete of a versioned model funnels through — builds those `Value`s fresh from `version_column_values()` per mutation and drops them the moment the diff returns. Every retained field was allocated twice and dropped twice, for a value nobody would look at again.

This adds three owned-value siblings that take the `Value` by value and move each key and value straight into its `ColumnChange` (`Map::into_iter` / `Map::remove` instead of `.get().cloned()` / `.clone()`), and switches the codegen to call them:

- `compute_diff_owned`
- `compute_insert_changes_owned`
- `compute_delete_changes_owned`

The borrowed functions are unchanged and stay public, for callers whose `Value` outlives the call. Purely additive — no existing signature moves.

## Measurements

Allocation blocks per mutation on a realistic 7-column record, from the new `version_history_alloc_gate` (`allocation-counter`, deterministic across runs). Each figure includes the throwaway `Value` materialization both paths are charged for, so the delta is only what each does with the value it is handed:

| Entry point | Borrowed | Owned | Delta |
|---|---|---|---|
| `compute_insert_changes` | 26 blocks | 14 blocks | **-46.2%** |
| `compute_delete_changes` | 26 blocks | 14 blocks | **-46.2%** |
| `compute_diff` | 34 blocks | 27 blocks | **-20.6%** |

Whole-process totals over the committed `autumn/benches/version_history.rs` harness, one variant per process (`BIN borrowed` / `BIN owned`):

| Metric | Borrowed | Owned | Delta |
|---|---|---|---|
| Instructions (`valgrind --tool=callgrind`) | 2,275,350,133 | 1,547,245,235 | **-32.0%** |
| Allocation blocks (`valgrind --tool=dhat`) | 6,901,045 | 4,441,045 | **-35.6%** |
| Allocation bytes (same) | 422,257,918 | 393,179,915 | -6.9% |

Wall clock moves with it — insert and delete land around -33% (roughly 650 → 420 ns/op). `compute_diff` is the small row either way: it only ever retained the *changed* columns (3 of 7 in this workload), so it had the fewest clones to drop.

## Why this is safe to land on an audit surface

`_autumn_version_history` is a compliance surface, so the changeset is held byte-identical rather than eyeballed:

- **Parity matrices.** Each owned function is asserted equal to its borrowed twin — as a `Vec<ColumnChange>` *and* as the serialized JSON that reaches the history row — over shared case matrices (25 diff cases, 10 insert/delete cases): sensitive-column redaction, columns present in `after` but not `before`, columns present only in `before` (dropped from the changeset), disjoint key sets, `null`-vs-missing, non-object inputs on either side, nested values, and key ordering.
- **Redaction.** The sensitive check runs before either value can reach a `ColumnChange`; a dedicated test asserts the column still appears, is flagged `sensitive`, has both values omitted, and that no secret survives into the serialized row.
- **Pointer identity.** Separate tests assert the emitted heap buffers *are* the input buffers, so an `_owned` function that quietly delegated to its borrowed twin would fail even though its output is correct. Mutation-checked: replacing the body with such a delegate keeps the parity tests green and fails these.
- **Codegen.** Four token assertions pin that `vh_insert_ts` hands the value over by move for all three ops, and that it still calls `version_column_values()` exactly once per record (twice for update).
- **End to end.** `sqlite_version_history` (3/3) drives a real `versioned = true` repository through create + update + delete against SQLite and reads the rows back, including the time-range filter and fail-closed tenant isolation.
- **Regression gate.** `version_history_alloc_gate` asserts each owned entry point allocates strictly fewer blocks *and* bytes than its borrowed twin, plus a pinned absolute ceiling — so the win cannot silently regress. Own binary, per CLAUDE.md, because `allocation-counter` installs a process-wide global allocator; follows the existing `config_alloc_gate` / `password_policy_alloc_gate` / `form_render_alloc_gate` house pattern.

Independent review also ran a 400,000-case differential fuzz across both `serde_json` configurations (default, and `preserve_order` + `arbitrary_precision` forced on): zero divergence. The `Map::remove` → `IndexMap::swap_remove` reordering hazard is inert here — `before` is only ever keyed-looked-up, never iterated, and output order is fixed by the untouched `after` map.

## Also in this PR

- The benchmark now alternates the two variants per round and reports median plus min/max with a **signed** delta, flagging when two ranges overlap — an earlier revision hoisted setup out of the timer and made whichever variant ran second look ~2x slower in *both* orders. It also takes a `borrowed` / `owned` mode argument so `callgrind`/`dhat` whole-process totals are attributable.
- `docs/guide/version-history.md` documents which shape to reach for.
- `CHANGELOG.md` bullet under the existing `## [Unreleased]` → `### Performance`. No version bump.

## Verification

```
cargo test -p autumn-web --lib version_history            51 passed
cargo test -p autumn-macros --lib vh_codegen              4 passed
cargo test -p autumn-web --test version_history_alloc_gate 1 passed
cargo test -p autumn-web --features "sqlite,test-support" \
  --test sqlite_version_history                           3 passed
cargo clippy -p autumn-web -p autumn-macros --all-targets exit 0
cargo fmt --all                                           clean
```

(The one clippy warning emitted, `E0602: unknown lint: clippy::unused_async_trait_impl`, is pre-existing — it comes from the workspace lint grandfather at `Cargo.toml:155` and reproduces on a stashed tree.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NmAoYKJFWw1HKJNnEoXH3u

---
_Generated by [Claude Code](https://claude.ai/code/session_01NmAoYKJFWw1HKJNnEoXH3u)_