### PR TITLE
🪝 Reject a NUL byte in a form field instead of 500ing at Postgres (#2423)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -847,6 +847,46 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A NUL byte in a form field is a validation error, not a 500 (#2423):** a
+  Postgres `TEXT`/`VARCHAR` column cannot hold `0x00`, but nothing between the
+  form body and the `INSERT` could say so. An embedded NUL — which a real user
+  can produce by pasting from a binary source or through an input-method glitch,
+  not only deliberately — decoded cleanly, satisfied every `#[validate(...)]`
+  rule (the value is a perfectly good Rust `String`), and failed only when the
+  driver handed the byte to the server: `invalid byte sequence for encoding
+  "UTF8": 0x00`, surfacing as an uncaught `AutumnError` and a `500`. By the
+  framework's own error-class convention that reads as a server bug, when it is
+  malformed client input.
+
+  `ChangesetForm` and `NestedChangesetForm` now sweep every submitted **text**
+  value before it is deserialized — the only point where the offending field is
+  still identifiable by name — and record
+  `autumn_web::form::NUL_CHARACTER_FIELD_ERROR` ("Cannot contain the NUL
+  character (0x00)") against the field or child subfield that carried one.
+  Handlers need no change: it is an ordinary field error, so the form
+  re-renders inline through the existing `ChangesetForm` round-trip. The
+  retained value is the author's text minus the byte, so the re-rendered form
+  keeps their work, never echoes a raw `0x00` into the HTML, and their next
+  submission succeeds. The CSRF and submit tokens are exempt (no template
+  renders them, so an error there would leave the form invalid with nothing on
+  screen); file parts of a multipart body are untouched.
+
+  For the paths no form extractor sees — a JSON API body, a hand-written query,
+  a background job — the Postgres rejection is now classified instead of
+  blanket-500'd: the `AutumnError` carries `422 Unprocessable Entity`, and
+  `autumn_web::error::is_nul_byte_violation` recognizes it (walking the
+  `source()` chain) for handlers that want to fold it back into a form the way
+  `unique_violation_field` is used for a uniqueness clash. Classification is by
+  server message rather than SQLSTATE because `diesel-async` maps `22021` to
+  `DatabaseErrorKind::Unknown` and diesel's `DatabaseErrorInformation` exposes
+  no code; the match requires both the byte literal and the encoding name, so a
+  message that merely mentions `0x00` keeps its 500.
+
+  New: `Changeset::add_error`, for folding a post-decode failure back into a
+  form round-trip; `autumn_web::normalize::strip_nul` and
+  `#[normalize(strip_nul)]`, for columns where dropping the byte silently beats
+  refusing the write. See `docs/guide/forms.md` — "Unstorable bytes: NUL".
+
 - **ACME config: `autumn doctor` and the runtime now reject the same two
   spellings (#1874):** two low-severity parity gaps let `autumn doctor
   --strict` bless an `autumn.toml` the server refuses to boot on. A

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -867,25 +867,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   re-renders inline through the existing `ChangesetForm` round-trip. The
   retained value is the author's text minus the byte, so the re-rendered form
   keeps their work, never echoes a raw `0x00` into the HTML, and their next
-  submission succeeds. The CSRF and submit tokens are exempt (no template
-  renders them, so an error there would leave the form invalid with nothing on
-  screen); file parts of a multipart body are untouched.
+  submission succeeds. Framework plumbing fields are exempt under both their
+  default and configured names — `_csrf`, `_submit_token`, `_method`, and a
+  nested row's `_destroy` — because no template renders an error against one,
+  and cleaning `_destroy` would flip a falsy marker truthy. File parts of a
+  multipart body are untouched.
 
-  For the paths no form extractor sees — a JSON API body, a hand-written query,
-  a background job — the Postgres rejection is now classified instead of
+  For the paths neither round-trip extractor sees — a JSON API body, a
+  hand-written query, a background job, an `extract::Form` or `Valid<T>`
+  extraction — the Postgres rejection is now classified instead of
   blanket-500'd: the `AutumnError` carries `422 Unprocessable Entity`, and
   `autumn_web::error::is_nul_byte_violation` recognizes it (walking the
   `source()` chain) for handlers that want to fold it back into a form the way
   `unique_violation_field` is used for a uniqueness clash. Classification is by
   server message rather than SQLSTATE because `diesel-async` maps `22021` to
   `DatabaseErrorKind::Unknown` and diesel's `DatabaseErrorInformation` exposes
-  no code; the match requires both the byte literal and the encoding name, so a
-  message that merely mentions `0x00` keeps its 500.
+  no code; the match is anchored on the trailing `: 0x00` and the encoding name,
+  so a message that merely *contains* `0x00` — including one echoing text a
+  client submitted — keeps its 500 rather than being relabelled as the client's
+  fault. The classified error is also re-wrapped rather than merely restatused,
+  because the 422 error page renders the message where the 500 page redacts it:
+  the client sees a fixed sentence and the raw server message stays in the
+  `source()` chain for logs.
 
   New: `Changeset::add_error`, for folding a post-decode failure back into a
   form round-trip; `autumn_web::normalize::strip_nul` and
   `#[normalize(strip_nul)]`, for columns where dropping the byte silently beats
-  refusing the write. See `docs/guide/forms.md` — "Unstorable bytes: NUL".
+  refusing the write (insert and hooked-update paths only — the documented
+  normalize-vs-persist asymmetry still applies). See `docs/guide/forms.md` —
+  "Unstorable bytes: NUL", which also records what the backstop does not cover:
+  a 422 with no field name, and `JSONB`'s different SQLSTATE (`22P05`).
 
 - **ACME config: `autumn doctor` and the runtime now reject the same two
   spellings (#1874):** two low-severity parity gaps let `autumn doctor

--- a/autumn-macros/src/model.rs
+++ b/autumn-macros/src/model.rs
@@ -3664,11 +3664,15 @@ enum Normalizer {
     Upcase,
     /// `squish` — trim and collapse internal whitespace runs to one space.
     Squish,
+    /// `strip_nul` — remove every NUL (`U+0000`), which a Postgres
+    /// `TEXT`/`VARCHAR` column cannot store (#2423).
+    StripNul,
     /// `with = path::to::fn` — user escape hatch (`fn(&str) -> String`).
     With(syn::Path),
 }
 
-/// Parse a field's `#[normalize(trim, downcase, upcase, squish, with = path)]`
+/// Parse a field's
+/// `#[normalize(trim, downcase, upcase, squish, strip_nul, with = path)]`
 /// attribute into an ordered list of normalizers. Returns an empty list when
 /// the field has no `#[normalize]` attribute.
 fn parse_field_normalize(field: &syn::Field) -> syn::Result<Vec<Normalizer>> {
@@ -3700,13 +3704,16 @@ fn parse_field_normalize(field: &syn::Field) -> syn::Result<Vec<Normalizer>> {
                 ops.push(Normalizer::Upcase);
             } else if meta.path.is_ident("squish") {
                 ops.push(Normalizer::Squish);
+            } else if meta.path.is_ident("strip_nul") {
+                ops.push(Normalizer::StripNul);
             } else if meta.path.is_ident("with") {
                 let path: syn::Path = meta.value()?.parse()?;
                 ops.push(Normalizer::With(path));
             } else {
                 return Err(meta.error(
                     "unsupported `#[normalize]` option; expected one of \
-                     `trim`, `downcase`, `upcase`, `squish`, or `with = path`",
+                     `trim`, `downcase`, `upcase`, `squish`, `strip_nul`, or \
+                     `with = path`",
                 ));
             }
             Ok(())
@@ -3756,6 +3763,9 @@ fn emit_normalize_expr(ops: &[Normalizer], value_expr: &TokenStream) -> TokenStr
         }
         Normalizer::Squish => {
             quote! { __autumn_n = ::autumn_web::normalize::squish(&__autumn_n); }
+        }
+        Normalizer::StripNul => {
+            quote! { __autumn_n = ::autumn_web::normalize::strip_nul(&__autumn_n); }
         }
         Normalizer::With(path) => quote! { __autumn_n = #path(&__autumn_n); },
     });

--- a/autumn/src/error.rs
+++ b/autumn/src/error.rs
@@ -213,6 +213,27 @@ where
             }
         }
 
+        // #2423: Postgres refuses an embedded NUL byte in a TEXT/VARCHAR
+        // column (SQLSTATE 22021). That is malformed client input reaching the
+        // database, not a server bug, so it takes the 422 that a
+        // `#[validate(...)]` rejection would have produced had a validator been
+        // able to see it. The `source()` walk mirrors `downcast_chain_ref`, so a
+        // repository or service error wrapping the diesel error classifies too.
+        #[cfg(feature = "db")]
+        {
+            let mut current: Option<&(dyn std::error::Error + 'static)> = Some(&err);
+            while let Some(cause) = current {
+                if cause
+                    .downcast_ref::<diesel::result::Error>()
+                    .is_some_and(is_pg_nul_byte_error)
+                {
+                    status = StatusCode::UNPROCESSABLE_ENTITY;
+                    break;
+                }
+                current = cause.source();
+            }
+        }
+
         // A per-tenant memory quota breach is a soft, retryable resource limit,
         // so it maps to 503 Service Unavailable rather than a 500.
         if any_err
@@ -762,6 +783,68 @@ impl AutumnError {
 /// let err = AutumnError::internal_server_error_msg("not a db error");
 /// assert_eq!(unique_violation_field(&err, &[("idx_users_email_unique", "email", "taken")]), None);
 /// ```
+/// Whether `err` carries a Postgres rejection of an embedded NUL byte
+/// (SQLSTATE `22021`, issue #2423) — malformed *client* input rather than a
+/// server bug.
+///
+/// A `TEXT`/`VARCHAR` column cannot hold `0x00`, so a value carrying one is
+/// refused at `INSERT`/`UPDATE` time no matter how it arrived. The blanket
+/// [`From`] impl already downgrades such an error to
+/// `422 Unprocessable Entity`; this predicate is for handlers that want to go
+/// further and fold it back into a form as a field error, the way
+/// [`unique_violation_field`] is used for a uniqueness clash.
+///
+/// Walks the `source()` chain, so it still recognizes the rejection when a
+/// repository or service wraps the diesel error in its own type.
+///
+/// Prefer preventing it: [`crate::form::ChangesetForm`] already rejects a NUL
+/// at the form boundary with [`crate::form::NUL_CHARACTER_FIELD_ERROR`], so
+/// this only fires for the paths no form extractor sees — a JSON API body, a
+/// hand-written query, a background job.
+///
+/// # Examples
+///
+/// ```rust
+/// use autumn_web::error::{AutumnError, is_nul_byte_violation};
+///
+/// let err = AutumnError::internal_server_error_msg("not a db error");
+/// assert!(!is_nul_byte_violation(&err));
+/// ```
+#[cfg(feature = "db")]
+#[must_use]
+pub fn is_nul_byte_violation(err: &AutumnError) -> bool {
+    err.downcast_chain_ref::<diesel::result::Error>()
+        .is_some_and(is_pg_nul_byte_error)
+}
+
+/// Whether a raw diesel error is Postgres refusing an embedded NUL byte.
+#[cfg(feature = "db")]
+fn is_pg_nul_byte_error(err: &diesel::result::Error) -> bool {
+    let diesel::result::Error::DatabaseError(_, info) = err else {
+        return false;
+    };
+    pg_message_is_nul_rejection(info.message())
+}
+
+/// Classify a Postgres server message as the `22021` NUL rejection.
+///
+/// Message matching, not SQLSTATE matching, because the code is unavailable:
+/// `diesel-async`'s `pg/error_helper.rs` maps every SQLSTATE it does not
+/// special-case (`22021` among them) to `DatabaseErrorKind::Unknown` and keeps
+/// no copy of the code, and diesel's `DatabaseErrorInformation` trait exposes
+/// no accessor for it.
+///
+/// The match is deliberately narrow, and deliberately avoids the prose:
+/// `lc_messages` translates "invalid byte sequence for encoding", but never the
+/// byte literal or the encoding name. Requiring **both** keeps a message that
+/// merely mentions a `0x00` byte (`invalid input syntax for type bytea: 0x00`)
+/// on the blanket 500 path — misclassifying a server bug as the client's fault
+/// is the worse error of the two.
+#[cfg(feature = "db")]
+fn pg_message_is_nul_rejection(message: &str) -> bool {
+    message.contains("0x00") && (message.contains("UTF") || message.contains("encoding"))
+}
+
 #[cfg(feature = "db")]
 #[must_use]
 pub fn unique_violation_field<'a>(
@@ -1323,6 +1406,104 @@ mod tests {
             .expect("HX-Trigger header present");
         assert_eq!(hx_trigger, r#"{"autumn:conflict":true}"#);
         Ok(())
+    }
+
+    // ── #2423: Postgres rejects NUL in TEXT — that is client input ──────────
+
+    #[cfg(feature = "db")]
+    mod nul_byte_violation_tests {
+        use super::*;
+        use crate::error::is_nul_byte_violation;
+
+        /// A `DatabaseErrorInformation` carrying only a server message —
+        /// SQLSTATE is not exposed by diesel's trait (see
+        /// `diesel-async`'s `pg/error_helper.rs`, which maps `22021` to
+        /// `DatabaseErrorKind::Unknown` and drops the code), so the message is
+        /// all the classifier has to go on.
+        #[derive(Debug)]
+        struct FakeMessageInfo(&'static str);
+
+        impl diesel::result::DatabaseErrorInformation for FakeMessageInfo {
+            fn message(&self) -> &str {
+                self.0
+            }
+            fn details(&self) -> Option<&str> {
+                None
+            }
+            fn hint(&self) -> Option<&str> {
+                None
+            }
+            fn table_name(&self) -> Option<&str> {
+                None
+            }
+            fn column_name(&self) -> Option<&str> {
+                None
+            }
+            fn constraint_name(&self) -> Option<&str> {
+                None
+            }
+            fn statement_position(&self) -> Option<i32> {
+                None
+            }
+        }
+
+        fn unknown_db_error(message: &'static str) -> diesel::result::Error {
+            diesel::result::Error::DatabaseError(
+                diesel::result::DatabaseErrorKind::Unknown,
+                Box::new(FakeMessageInfo(message)),
+            )
+        }
+
+        /// The exact message Postgres 16 returns for SQLSTATE `22021`.
+        const PG_NUL_MESSAGE: &str = r#"invalid byte sequence for encoding "UTF8": 0x00"#;
+
+        #[test]
+        fn pg_nul_byte_error_maps_to_422_not_500() {
+            let err: AutumnError = unknown_db_error(PG_NUL_MESSAGE).into();
+            assert_eq!(err.status(), StatusCode::UNPROCESSABLE_ENTITY);
+        }
+
+        #[test]
+        fn predicate_recognizes_the_pg_nul_byte_error() {
+            let err: AutumnError = unknown_db_error(PG_NUL_MESSAGE).into();
+            assert!(is_nul_byte_violation(&err));
+        }
+
+        /// `lc_messages` translates the prose but leaves the encoding name and
+        /// the byte literal alone, so a non-English server still classifies.
+        #[test]
+        fn localized_pg_nul_byte_message_is_still_recognized() {
+            let err: AutumnError =
+                unknown_db_error("ungueltige Byte-Sequenz fuer Kodierung \u{ab}UTF8\u{bb}: 0x00")
+                    .into();
+            assert_eq!(err.status(), StatusCode::UNPROCESSABLE_ENTITY);
+        }
+
+        /// Narrow by construction: any other database error keeps its 500, so
+        /// a genuine server bug is never relabelled as the client's fault.
+        #[test]
+        fn other_db_errors_still_map_to_500() {
+            for message in [
+                "division by zero",
+                "relation \"posts\" does not exist",
+                // Mentions a byte literal but is not the encoding rejection.
+                "invalid input syntax for type bytea: 0x00",
+            ] {
+                let err: AutumnError = unknown_db_error(message).into();
+                assert_eq!(
+                    err.status(),
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "unexpectedly reclassified: {message}"
+                );
+                assert!(!is_nul_byte_violation(&err), "false positive: {message}");
+            }
+        }
+
+        #[test]
+        fn predicate_is_false_for_non_db_errors() {
+            let err = AutumnError::internal_server_error_msg(PG_NUL_MESSAGE);
+            assert!(!is_nul_byte_violation(&err));
+        }
     }
 
     // ── unique_violation_field (issue #1032) ────────────────────────────────

--- a/autumn/src/error.rs
+++ b/autumn/src/error.rs
@@ -166,6 +166,31 @@ where
     E: std::error::Error + Send + Sync + 'static,
 {
     fn from(err: E) -> Self {
+        // #2423: Postgres refuses an embedded NUL byte in a TEXT/VARCHAR column
+        // (SQLSTATE 22021). That is malformed client input reaching the
+        // database, not a server bug, so it takes the 422 a `#[validate(...)]`
+        // rejection would have produced had a validator been able to see the
+        // byte. Handled first and by returning, so this classification has one
+        // unambiguous precedence rather than depending on where it sits among
+        // the status overrides below.
+        //
+        // The error is re-wrapped rather than merely restatused: the 422 page
+        // renders the message verbatim where the 500 page redacts it, so
+        // downgrading alone would put a raw Postgres message on screen. The
+        // original stays reachable as `source()`.
+        #[cfg(feature = "db")]
+        if error_chain_is_pg_nul_rejection(&err) {
+            return Self {
+                inner: Box::new(NulByteRejected(err)),
+                status: StatusCode::UNPROCESSABLE_ENTITY,
+                details: None,
+                problem_type: None,
+                cache_idempotency_response: false,
+                #[cfg(debug_assertions)]
+                backtrace_string: Some(format!("{}", std::backtrace::Backtrace::force_capture())),
+            };
+        }
+
         let mut status = StatusCode::INTERNAL_SERVER_ERROR;
         let any_err: &dyn std::any::Any = &err;
 
@@ -210,27 +235,6 @@ where
                 && msg.contains("circuit breaker is open")
             {
                 status = StatusCode::SERVICE_UNAVAILABLE;
-            }
-        }
-
-        // #2423: Postgres refuses an embedded NUL byte in a TEXT/VARCHAR
-        // column (SQLSTATE 22021). That is malformed client input reaching the
-        // database, not a server bug, so it takes the 422 that a
-        // `#[validate(...)]` rejection would have produced had a validator been
-        // able to see it. The `source()` walk mirrors `downcast_chain_ref`, so a
-        // repository or service error wrapping the diesel error classifies too.
-        #[cfg(feature = "db")]
-        {
-            let mut current: Option<&(dyn std::error::Error + 'static)> = Some(&err);
-            while let Some(cause) = current {
-                if cause
-                    .downcast_ref::<diesel::result::Error>()
-                    .is_some_and(is_pg_nul_byte_error)
-                {
-                    status = StatusCode::UNPROCESSABLE_ENTITY;
-                    break;
-                }
-                current = cause.source();
             }
         }
 
@@ -783,68 +787,6 @@ impl AutumnError {
 /// let err = AutumnError::internal_server_error_msg("not a db error");
 /// assert_eq!(unique_violation_field(&err, &[("idx_users_email_unique", "email", "taken")]), None);
 /// ```
-/// Whether `err` carries a Postgres rejection of an embedded NUL byte
-/// (SQLSTATE `22021`, issue #2423) — malformed *client* input rather than a
-/// server bug.
-///
-/// A `TEXT`/`VARCHAR` column cannot hold `0x00`, so a value carrying one is
-/// refused at `INSERT`/`UPDATE` time no matter how it arrived. The blanket
-/// [`From`] impl already downgrades such an error to
-/// `422 Unprocessable Entity`; this predicate is for handlers that want to go
-/// further and fold it back into a form as a field error, the way
-/// [`unique_violation_field`] is used for a uniqueness clash.
-///
-/// Walks the `source()` chain, so it still recognizes the rejection when a
-/// repository or service wraps the diesel error in its own type.
-///
-/// Prefer preventing it: [`crate::form::ChangesetForm`] already rejects a NUL
-/// at the form boundary with [`crate::form::NUL_CHARACTER_FIELD_ERROR`], so
-/// this only fires for the paths no form extractor sees — a JSON API body, a
-/// hand-written query, a background job.
-///
-/// # Examples
-///
-/// ```rust
-/// use autumn_web::error::{AutumnError, is_nul_byte_violation};
-///
-/// let err = AutumnError::internal_server_error_msg("not a db error");
-/// assert!(!is_nul_byte_violation(&err));
-/// ```
-#[cfg(feature = "db")]
-#[must_use]
-pub fn is_nul_byte_violation(err: &AutumnError) -> bool {
-    err.downcast_chain_ref::<diesel::result::Error>()
-        .is_some_and(is_pg_nul_byte_error)
-}
-
-/// Whether a raw diesel error is Postgres refusing an embedded NUL byte.
-#[cfg(feature = "db")]
-fn is_pg_nul_byte_error(err: &diesel::result::Error) -> bool {
-    let diesel::result::Error::DatabaseError(_, info) = err else {
-        return false;
-    };
-    pg_message_is_nul_rejection(info.message())
-}
-
-/// Classify a Postgres server message as the `22021` NUL rejection.
-///
-/// Message matching, not SQLSTATE matching, because the code is unavailable:
-/// `diesel-async`'s `pg/error_helper.rs` maps every SQLSTATE it does not
-/// special-case (`22021` among them) to `DatabaseErrorKind::Unknown` and keeps
-/// no copy of the code, and diesel's `DatabaseErrorInformation` trait exposes
-/// no accessor for it.
-///
-/// The match is deliberately narrow, and deliberately avoids the prose:
-/// `lc_messages` translates "invalid byte sequence for encoding", but never the
-/// byte literal or the encoding name. Requiring **both** keeps a message that
-/// merely mentions a `0x00` byte (`invalid input syntax for type bytea: 0x00`)
-/// on the blanket 500 path — misclassifying a server bug as the client's fault
-/// is the worse error of the two.
-#[cfg(feature = "db")]
-fn pg_message_is_nul_rejection(message: &str) -> bool {
-    message.contains("0x00") && (message.contains("UTF") || message.contains("encoding"))
-}
-
 #[cfg(feature = "db")]
 #[must_use]
 pub fn unique_violation_field<'a>(
@@ -863,6 +805,135 @@ pub fn unique_violation_field<'a>(
         .iter()
         .find(|(c, _, _)| *c == constraint)
         .map(|(_, field, message)| (*field, *message))
+}
+
+// ── #2423: Postgres refuses a NUL byte in TEXT — that is client input ──────
+
+/// The client-facing message substituted for a Postgres NUL-byte rejection.
+///
+/// The raw server message (`invalid byte sequence for encoding "UTF8": 0x00`)
+/// is a database internal. It must not become the visible message, because the
+/// `422` error page renders `message` verbatim where the `500` page
+/// deliberately does not — see `error_pages::defaults`' `render_422` and
+/// `render_500`. Downgrading the status alone would therefore move a database
+/// message onto a page that shows it.
+pub const NUL_BYTE_REJECTED_MESSAGE: &str =
+    "The submitted text contains a NUL character (0x00), which cannot be stored.";
+
+/// Wrapper that gives a classified NUL rejection [`NUL_BYTE_REJECTED_MESSAGE`]
+/// as its `Display` while keeping the original error as its `source()`, so
+/// logs, error reporting and [`AutumnError::downcast_chain_ref`] still reach
+/// the underlying diesel error.
+#[cfg(feature = "db")]
+#[derive(Debug)]
+pub(crate) struct NulByteRejected<E>(E);
+
+#[cfg(feature = "db")]
+impl<E> std::fmt::Display for NulByteRejected<E> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(NUL_BYTE_REJECTED_MESSAGE)
+    }
+}
+
+#[cfg(feature = "db")]
+impl<E: std::error::Error + 'static> std::error::Error for NulByteRejected<E> {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(&self.0)
+    }
+}
+
+/// Whether `err` carries a Postgres rejection of an embedded NUL byte
+/// (SQLSTATE `22021`, issue #2423) — malformed *client* input rather than a
+/// server bug.
+///
+/// A `TEXT`/`VARCHAR` column cannot hold `0x00`, so a value carrying one is
+/// refused at `INSERT`/`UPDATE` time no matter how it arrived. The blanket
+/// [`From`] impl already downgrades such an error to
+/// `422 Unprocessable Entity`; this predicate is for handlers that want to go
+/// further and fold it back into a form as a field error, the way
+/// [`unique_violation_field`] is used for a uniqueness clash.
+///
+/// Walks the whole `source()` chain — the same walk the [`From`] impl makes,
+/// through the one shared helper, so the two can never disagree about whether
+/// a given error is this one.
+///
+/// Prefer preventing it: [`crate::form::ChangesetForm`] already rejects a NUL
+/// at the form boundary with [`crate::form::NUL_CHARACTER_FIELD_ERROR`], so
+/// this only fires for the paths no form extractor sees — a JSON API body, a
+/// hand-written query, a background job.
+///
+/// # Examples
+///
+/// ```rust
+/// use autumn_web::error::{AutumnError, is_nul_byte_violation};
+///
+/// let err = AutumnError::internal_server_error_msg("not a db error");
+/// assert!(!is_nul_byte_violation(&err));
+/// ```
+#[cfg(feature = "db")]
+#[must_use]
+pub fn is_nul_byte_violation(err: &AutumnError) -> bool {
+    error_chain_is_pg_nul_rejection(err.inner.as_ref())
+}
+
+/// Whether `err`, or anything in its `source()` chain, is Postgres refusing an
+/// embedded NUL byte.
+///
+/// The single definition of "this was the client's byte, not our bug", shared
+/// by [`is_nul_byte_violation`] and the blanket [`From`] impl. The chain walk
+/// matters because a repository or service may wrap the diesel error in its own
+/// type, and it continues past a non-matching diesel error rather than stopping
+/// at the first one found.
+#[cfg(feature = "db")]
+pub(crate) fn error_chain_is_pg_nul_rejection(err: &(dyn std::error::Error + 'static)) -> bool {
+    let mut current = Some(err);
+    while let Some(cause) = current {
+        if cause
+            .downcast_ref::<diesel::result::Error>()
+            .is_some_and(is_pg_nul_byte_error)
+        {
+            return true;
+        }
+        current = cause.source();
+    }
+    false
+}
+
+/// Whether a raw diesel error is Postgres refusing an embedded NUL byte.
+#[cfg(feature = "db")]
+fn is_pg_nul_byte_error(err: &diesel::result::Error) -> bool {
+    let diesel::result::Error::DatabaseError(_, info) = err else {
+        return false;
+    };
+    pg_message_is_nul_rejection(info.message())
+}
+
+/// Classify a Postgres server message as the `22021` NUL rejection.
+///
+/// Message matching, not SQLSTATE matching, because the code is unavailable:
+/// `diesel-async`'s `pg/error_helper.rs` maps every SQLSTATE it does not
+/// special-case (`22021` among them) to `DatabaseErrorKind::Unknown` and keeps
+/// no copy of the code, and diesel's `DatabaseErrorInformation` trait exposes no
+/// accessor for it.
+///
+/// **Anchored on purpose.** Postgres echoes submitted text into the primary
+/// message of other errors (`invalid input syntax for type integer: "…"`,
+/// `column "…" does not exist`), so a substring search for `0x00` is
+/// attacker-satisfiable: a client that submits the right literal could get a
+/// genuine server fault relabelled as its own fault — hidden from 5xx alerting
+/// and rendered on the 422 page. Requiring the message to *end* with `: 0x00`
+/// defeats that, because an echoed value is always followed by a closing quote
+/// or trailing prose. `UTF` must appear too, and always does: `tokio-postgres`
+/// fixes `client_encoding` to `UTF8`, so the encoding the server names in this
+/// message is `UTF8` on every connection this framework opens.
+///
+/// The failure this leaves is a locale whose translation moves the byte literal
+/// off the end of the message — the error then keeps its `500`, which is
+/// exactly the pre-#2423 behavior. Failing back to "server bug" is the safe
+/// direction; failing forward to "client's fault" is not.
+#[cfg(feature = "db")]
+fn pg_message_is_nul_rejection(message: &str) -> bool {
+    message.ends_with(": 0x00") && message.contains("UTF")
 }
 
 impl std::fmt::Display for AutumnError {
@@ -1479,6 +1550,28 @@ mod tests {
             assert_eq!(err.status(), StatusCode::UNPROCESSABLE_ENTITY);
         }
 
+        /// The raw server message must not reach the client: the 422 error page
+        /// renders `message` verbatim where the 500 page redacts it, so
+        /// downgrading the status without re-wrapping would newly expose a
+        /// database internal on a user-facing page.
+        #[test]
+        fn the_raw_postgres_message_is_not_the_client_facing_message() {
+            let err: AutumnError = unknown_db_error(PG_NUL_MESSAGE).into();
+            assert_eq!(err.to_string(), crate::error::NUL_BYTE_REJECTED_MESSAGE);
+            assert!(!err.to_string().contains("UTF8"));
+        }
+
+        /// ...but the original is still reachable for logs, error reporting and
+        /// handler-side classification.
+        #[test]
+        fn the_original_diesel_error_survives_as_a_source() {
+            let err: AutumnError = unknown_db_error(PG_NUL_MESSAGE).into();
+            let inner = err
+                .downcast_chain_ref::<diesel::result::Error>()
+                .expect("the diesel error must stay reachable through the chain");
+            assert!(inner.to_string().contains("0x00"));
+        }
+
         /// Narrow by construction: any other database error keeps its 500, so
         /// a genuine server bug is never relabelled as the client's fault.
         #[test]
@@ -1497,6 +1590,55 @@ mod tests {
                 );
                 assert!(!is_nul_byte_violation(&err), "false positive: {message}");
             }
+        }
+
+        /// Postgres echoes submitted text into the primary message of other
+        /// errors. A client must not be able to spell the classifier's pattern
+        /// inside its own input and so relabel a real server fault as its own
+        /// fault — which would hide it from 5xx alerting and put the message on
+        /// the 422 page. The end-anchor is what defeats this.
+        #[test]
+        fn attacker_supplied_text_echoed_into_a_message_does_not_classify() {
+            for message in [
+                // The value the client submitted, echoed and quoted.
+                "invalid input syntax for type integer: \"UTF: 0x00\"",
+                "invalid input syntax for type uuid: \"0x00 UTF8\"",
+                // A dynamic identifier built from client input.
+                "column \"0x00 UTF8 encoding\" does not exist",
+            ] {
+                let err: AutumnError = unknown_db_error(message).into();
+                assert_eq!(
+                    err.status(),
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "client-spellable message was reclassified: {message}"
+                );
+            }
+        }
+
+        /// The chain walk continues past a non-matching diesel error rather
+        /// than stopping at the first one, and the predicate agrees with the
+        /// status the `From` impl assigned.
+        #[test]
+        fn predicate_and_status_agree_through_a_wrapping_error() {
+            #[derive(Debug)]
+            struct Wrapper(diesel::result::Error);
+            impl std::fmt::Display for Wrapper {
+                fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                    write!(f, "repository failed")
+                }
+            }
+            impl std::error::Error for Wrapper {
+                fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+                    Some(&self.0)
+                }
+            }
+
+            let err: AutumnError = Wrapper(unknown_db_error(PG_NUL_MESSAGE)).into();
+            assert_eq!(err.status(), StatusCode::UNPROCESSABLE_ENTITY);
+            assert!(
+                is_nul_byte_violation(&err),
+                "the predicate must agree with the status the From impl chose"
+            );
         }
 
         #[test]

--- a/autumn/src/form.rs
+++ b/autumn/src/form.rs
@@ -364,15 +364,18 @@ pub const NUL_CHARACTER_FIELD_ERROR: &str = "Cannot contain the NUL character (0
 ///
 /// No template renders an error against one of these, so a
 /// [`NUL_CHARACTER_FIELD_ERROR`] keyed under one would leave the form invalid
-/// with nothing on screen to explain why. Each is already rejected on its own
-/// terms when malformed — a mangled `_method` simply fails to name a known
-/// verb — and none is ever written to a column.
+/// with nothing on screen to explain why — the failure the exemption exists to
+/// prevent. None is ever written to a column, so nothing is lost by cleaning
+/// one silently.
 ///
-/// Only the fixed names live here. The CSRF and submit-token field names are
-/// configurable, so the extractors pass those in from request extensions.
-const PLUMBING_FIELDS: &[&str] = &["_method"];
+/// These are the *default* names. Both token fields are configurable, so the
+/// extractors additionally exempt whatever name request extensions carry; the
+/// defaults are listed here as well so a direct caller of the public
+/// [`crate::nested_form::decode_nested_urlencoded`], which never sees those
+/// extensions, is covered for the common case.
+const PLUMBING_FIELDS: &[&str] = &["_method", "_csrf", "_submit_token"];
 
-/// Whether `name` is one of the fixed [`PLUMBING_FIELDS`].
+/// Whether `name` is one of the default [`PLUMBING_FIELDS`].
 pub(crate) fn is_plumbing_field(name: &str) -> bool {
     PLUMBING_FIELDS.contains(&name)
 }
@@ -397,17 +400,24 @@ pub(crate) fn is_plumbing_field(name: &str) -> bool {
 ///
 /// The returned names are deduplicated, so a repeated key (a multi-value
 /// field) contributes at most one message.
+///
+/// Deduplication goes through a `BTreeSet` rather than a linear scan of the
+/// names collected so far. That scan is O(n²) in the number of *distinct*
+/// offending keys, and the key count is bounded only by `DefaultBodyLimit` — a
+/// 32 MiB body of `k1=%00&k2=%00&…` is millions of distinct keys, which is
+/// minutes of CPU burned synchronously on a runtime worker thread. The set also
+/// gives the names a deterministic order.
 pub(crate) fn strip_nul_from_pairs(pairs: &mut [(String, String)]) -> Vec<String> {
-    let mut offenders: Vec<String> = Vec::new();
+    let mut offenders: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
     for (key, value) in pairs {
         if value.as_bytes().contains(&0) {
             *value = crate::normalize::strip_nul(value);
-            if !offenders.iter().any(|name| name == key) {
-                offenders.push(key.clone());
+            if !offenders.contains(key.as_str()) {
+                offenders.insert(key.clone());
             }
         }
     }
-    offenders
+    offenders.into_iter().collect()
 }
 
 // ── IntoChangeset ──────────────────────────────────────────────────
@@ -697,18 +707,31 @@ where
             .extensions()
             .get::<crate::security::csrf::CsrfFormField>()
             .map_or_else(|| "_csrf".to_owned(), |f| f.0.clone());
+        // Read for the #2423 exemption only. `ChangesetForm` does not otherwise
+        // use the submit token — `SubmitTokenLayer` consumes it from the raw
+        // body upstream — but a scaffolded flat form does post the hidden
+        // field, so its name has to be exempt here exactly as the nested
+        // extractor exempts it.
+        let submit_field = req
+            .extensions()
+            .get::<crate::security::SubmitFormField>()
+            .map_or_else(|| "_submit_token".to_owned(), |f| f.0.clone());
 
         let (data, nul_fields) = decode_form_body::<T, S>(req, state).await?;
 
         let mut changeset = data.into_changeset();
         for field in nul_fields {
-            // The CSRF token and the method override are transport plumbing,
-            // not form fields: no template renders either, so an error keyed
-            // under one would make the form permanently invalid with nothing
-            // on screen to explain why. Each is rejected on its own terms when
-            // malformed — `CsrfLayer` for the token, "not a known verb" for
-            // the override — and neither is ever written to a column.
-            if field == csrf_field || PLUMBING_FIELDS.contains(&field.as_str()) {
+            // The two tokens and the method override are transport plumbing,
+            // not form fields: no template renders any of them, so an error
+            // keyed under one would make the form permanently invalid with
+            // nothing on screen to explain why, and none is ever written to a
+            // column. The configurable names come from request extensions; the
+            // defaults are in `PLUMBING_FIELDS` too, because `CsrfService`
+            // accepts the literal `_csrf` even when another name is configured.
+            if field == csrf_field
+                || field == submit_field
+                || PLUMBING_FIELDS.contains(&field.as_str())
+            {
                 continue;
             }
             changeset.add_error(field, NUL_CHARACTER_FIELD_ERROR);
@@ -6758,6 +6781,106 @@ mod tests {
             assert_body(resp, "valid=true errors=0").await;
         }
 
+        /// A scaffolded flat form posts the submit token as a hidden field, so
+        /// its name has to be exempt here too — the nested extractor already
+        /// exempted it, and the flat one must not diverge.
+        #[tokio::test]
+        async fn nul_byte_in_the_submit_token_is_not_a_form_error() {
+            async fn handler(form: ChangesetForm<NulTestForm>) -> String {
+                format!("valid={} errors={}", form.is_valid(), form.errors().len())
+            }
+            let resp = Router::new()
+                .route("/test", post(handler))
+                .oneshot(urlencoded_req(
+                    "/test",
+                    "_submit_token=to%00ken&name=Alice&body=ok",
+                ))
+                .await
+                .unwrap();
+            assert_body(resp, "valid=true errors=0").await;
+        }
+
+        /// The exemption follows the *configured* field name, not just the
+        /// default, so renaming `security.csrf.form_field` does not reintroduce
+        /// an unrenderable error.
+        #[tokio::test]
+        async fn nul_byte_in_a_renamed_csrf_field_is_not_a_form_error() {
+            let mut req = urlencoded_req("/test", "authenticity=to%00ken&name=Alice&body=ok");
+            req.extensions_mut()
+                .insert(crate::security::csrf::CsrfFormField(
+                    "authenticity".to_owned(),
+                ));
+
+            let form = ChangesetForm::<NulTestForm>::from_request(req, &())
+                .await
+                .expect("extraction should succeed");
+            assert!(form.is_valid(), "errors: {:?}", form.errors());
+        }
+
+        /// A submitted name that is not a field of `T` is normally ignored, but
+        /// a NUL in one is still reported — under that name. Documented in
+        /// `docs/guide/forms.md`; pinned here so the choice is deliberate
+        /// rather than incidental.
+        #[tokio::test]
+        async fn nul_byte_in_an_unknown_key_is_reported_under_that_key() {
+            async fn handler(form: ChangesetForm<NulTestForm>) -> String {
+                format!(
+                    "valid={} unknown={}",
+                    form.is_valid(),
+                    form.errors_for("return_to").len()
+                )
+            }
+            let resp = Router::new()
+                .route("/test", post(handler))
+                .oneshot(urlencoded_req(
+                    "/test",
+                    "return_to=a%00b&name=Alice&body=ok",
+                ))
+                .await
+                .unwrap();
+            assert_body(resp, "valid=false unknown=1").await;
+        }
+
+        /// A key submitted more than once contributes one message, not one per
+        /// occurrence. Repeating a key that *is* a field of `T` is a hard
+        /// `duplicate field` decode failure in `serde_urlencoded` (a 400 before
+        /// any of this runs), so the case that actually reaches the sweep is a
+        /// repeated key `T` does not declare — which is also the shape that
+        /// makes the dedupe load-bearing, since an unbounded body can repeat a
+        /// key arbitrarily many times.
+        #[tokio::test]
+        async fn a_repeated_key_reports_once() {
+            async fn handler(form: ChangesetForm<NulTestForm>) -> String {
+                format!("errors={}", form.errors_for("return_to").len())
+            }
+            let resp = Router::new()
+                .route("/test", post(handler))
+                .oneshot(urlencoded_req(
+                    "/test",
+                    "name=Alice&body=ok&return_to=a%00a&return_to=b%00b&return_to=c%00c",
+                ))
+                .await
+                .unwrap();
+            assert_body(resp, "errors=1").await;
+        }
+
+        /// Keys are deliberately never cleaned. Stripping a NUL out of a key
+        /// would rename it — potentially onto a real field of `T` — inventing a
+        /// submission the client never made.
+        #[tokio::test]
+        async fn a_nul_in_a_key_never_renames_it_onto_a_real_field() {
+            async fn handler(form: ChangesetForm<NulTestForm>) -> String {
+                format!("valid={} body={:?}", form.is_valid(), form.data().body)
+            }
+            // `bod y` must NOT become `body`.
+            let resp = Router::new()
+                .route("/test", post(handler))
+                .oneshot(urlencoded_req("/test", "name=Alice&bod%00y=injected"))
+                .await
+                .unwrap();
+            assert_body(resp, r#"valid=true body="""#).await;
+        }
+
         /// A NUL in a *rule-violating* field adds to that field's messages
         /// rather than replacing the validator's own.
         #[tokio::test]
@@ -6792,6 +6915,69 @@ mod tests {
             let resp = Router::new()
                 .route("/test", post(handler))
                 .oneshot(urlencoded_req("/test", "_csrf=to%00ken&name=Alice&body=ok"))
+                .await
+                .unwrap();
+            assert_body(resp, "valid=true errors=0").await;
+        }
+
+        /// The multipart blank-optional retry re-deserializes from a filtered
+        /// pair set; the NUL report must survive that second attempt rather
+        /// than being dropped with the blank field.
+        #[cfg(feature = "multipart")]
+        #[tokio::test]
+        async fn multipart_nul_report_survives_the_blank_optional_retry() {
+            async fn handler(form: ChangesetForm<OptionalNumericForm>) -> String {
+                format!(
+                    "age={:?} name_errors={}",
+                    form.data().age,
+                    form.errors_for("name").len()
+                )
+            }
+            let resp = Router::new()
+                .route("/test", post(handler))
+                .oneshot(multipart_req_multi(
+                    "/test",
+                    // The blank `age` forces the retry path; the NUL is on
+                    // `name`, which the retry keeps.
+                    &[("name", "Ali\u{0}ce"), ("age", "")],
+                ))
+                .await
+                .unwrap();
+            assert_body(resp, "age=None name_errors=1").await;
+        }
+
+        /// A file part is binary by definition, so it is never swept and never
+        /// blocks the submission.
+        #[cfg(feature = "multipart")]
+        #[tokio::test]
+        async fn multipart_file_part_carrying_a_nul_is_untouched() {
+            async fn handler(form: ChangesetForm<NulTestForm>) -> String {
+                format!("valid={} errors={}", form.is_valid(), form.errors().len())
+            }
+            let boundary = "----FormBoundary7MA4YWxkTrZu0gW";
+            let body = format!(
+                "--{boundary}\r\n\
+                 Content-Disposition: form-data; name=\"name\"\r\n\r\n\
+                 Alice\r\n\
+                 --{boundary}\r\n\
+                 Content-Disposition: form-data; name=\"avatar\"; filename=\"a.bin\"\r\n\
+                 Content-Type: application/octet-stream\r\n\r\n\
+                 bin\u{0}ary\r\n\
+                 --{boundary}--\r\n"
+            );
+            let req = axum::http::Request::builder()
+                .method("POST")
+                .uri("/test")
+                .header(
+                    "Content-Type",
+                    format!("multipart/form-data; boundary={boundary}"),
+                )
+                .body(Body::from(body))
+                .unwrap();
+
+            let resp = Router::new()
+                .route("/test", post(handler))
+                .oneshot(req)
                 .await
                 .unwrap();
             assert_body(resp, "valid=true errors=0").await;

--- a/autumn/src/form.rs
+++ b/autumn/src/form.rs
@@ -298,6 +298,24 @@ impl<T> Changeset<T> {
     pub const fn errors(&self) -> &HashMap<String, Vec<String>> {
         &self.errors
     }
+
+    /// Record one more error message against `field`, keeping any already
+    /// there.
+    ///
+    /// Appends rather than replaces, so a field that failed a
+    /// `#[validate(...)]` rule *and* carried unstorable input shows both
+    /// messages. Adding any error makes the changeset invalid.
+    ///
+    /// Used by [`ChangesetForm`] to attach the
+    /// [`NUL_CHARACTER_FIELD_ERROR`] a validator cannot see, and available to
+    /// handlers that need to fold a post-decode failure (a uniqueness check
+    /// that only the database can answer, say) back into the form round-trip.
+    pub fn add_error(&mut self, field: impl Into<String>, message: impl Into<String>) {
+        self.errors
+            .entry(field.into())
+            .or_default()
+            .push(message.into());
+    }
 }
 
 impl<T: Serialize> Changeset<T> {
@@ -323,6 +341,73 @@ impl<T: Serialize> Changeset<T> {
             _ => None,
         }
     }
+}
+
+// ── #2423: NUL bytes in submitted text ─────────────────────────────
+
+/// The message recorded against a field whose submitted value carried an
+/// embedded NUL (`U+0000`) character (issue #2423).
+///
+/// A Postgres `TEXT`/`VARCHAR` column cannot hold `0x00`, so such a value used
+/// to sail past every `#[validate(...)]` rule and fail only at the
+/// Diesel→Postgres boundary, surfacing as an unhandled `500`. [`ChangesetForm`]
+/// now records this message against the offending field instead, so the
+/// submission is rejected the same way any other invalid input is — inline, on
+/// the field, with the author's remaining text intact.
+///
+/// A real user can produce a NUL without meaning to (a paste from a binary
+/// source, an input-method glitch), so the wording names the character rather
+/// than accusing the author of anything.
+pub const NUL_CHARACTER_FIELD_ERROR: &str = "Cannot contain the NUL character (0x00)";
+
+/// Submitted names that carry framework plumbing rather than form data.
+///
+/// No template renders an error against one of these, so a
+/// [`NUL_CHARACTER_FIELD_ERROR`] keyed under one would leave the form invalid
+/// with nothing on screen to explain why. Each is already rejected on its own
+/// terms when malformed — a mangled `_method` simply fails to name a known
+/// verb — and none is ever written to a column.
+///
+/// Only the fixed names live here. The CSRF and submit-token field names are
+/// configurable, so the extractors pass those in from request extensions.
+const PLUMBING_FIELDS: &[&str] = &["_method"];
+
+/// Whether `name` is one of the fixed [`PLUMBING_FIELDS`].
+pub(crate) fn is_plumbing_field(name: &str) -> bool {
+    PLUMBING_FIELDS.contains(&name)
+}
+
+/// Remove every NUL from each submitted value, returning the names of the
+/// fields that carried one (issue #2423).
+///
+/// Runs on the decoded key/value pairs, *before* deserialization, which is the
+/// only point where the offending field is still identifiable by name — after
+/// `serde` has built `T` the bytes are just some `String` field among others.
+///
+/// Values are cleaned rather than left as submitted for two reasons: the
+/// rejected form is re-rendered from this data, and neither the author's
+/// browser nor any downstream consumer should be handed back a raw `0x00`; and
+/// the cleaned text is what the author most likely meant, so the resubmission
+/// they make after reading the error succeeds.
+///
+/// Keys are deliberately left alone. Stripping a NUL out of a *key* would
+/// rename it — potentially onto a real field of `T` — inventing a submission
+/// the client never made. A mangled key simply fails to match any field and is
+/// ignored, exactly as any other unknown key is.
+///
+/// The returned names are deduplicated, so a repeated key (a multi-value
+/// field) contributes at most one message.
+pub(crate) fn strip_nul_from_pairs(pairs: &mut [(String, String)]) -> Vec<String> {
+    let mut offenders: Vec<String> = Vec::new();
+    for (key, value) in pairs {
+        if value.as_bytes().contains(&0) {
+            *value = crate::normalize::strip_nul(value);
+            if !offenders.iter().any(|name| name == key) {
+                offenders.push(key.clone());
+            }
+        }
+    }
+    offenders
 }
 
 // ── IntoChangeset ──────────────────────────────────────────────────
@@ -356,6 +441,18 @@ impl<T: validator::Validate> IntoChangeset for T {
 /// 422 — errors live in the [`Changeset`] and the handler decides how to
 /// respond.  Fails with 400 only when the body cannot be decoded into `T` at
 /// all.
+///
+/// # Unstorable bytes
+///
+/// Submitted text values are swept for NUL (`U+0000`) before deserialization
+/// (issue #2423). A Postgres `TEXT`/`VARCHAR` column cannot hold `0x00`, and no
+/// `#[validate(...)]` rule can express that — the value is a perfectly good
+/// Rust `String` — so such a field used to fail only at the database, as an
+/// unhandled 500. A field that carried one now gets
+/// [`NUL_CHARACTER_FIELD_ERROR`] like any other field error, and the value kept
+/// for re-render is the author's text with the byte removed. The CSRF token is
+/// exempt (no template renders it); file parts of a multipart body are
+/// untouched.
 ///
 /// # CSRF — no extra developer action in POST handlers
 ///
@@ -601,10 +698,24 @@ where
             .get::<crate::security::csrf::CsrfFormField>()
             .map_or_else(|| "_csrf".to_owned(), |f| f.0.clone());
 
-        let data: T = decode_form_body(req, state).await?;
+        let (data, nul_fields) = decode_form_body::<T, S>(req, state).await?;
+
+        let mut changeset = data.into_changeset();
+        for field in nul_fields {
+            // The CSRF token and the method override are transport plumbing,
+            // not form fields: no template renders either, so an error keyed
+            // under one would make the form permanently invalid with nothing
+            // on screen to explain why. Each is rejected on its own terms when
+            // malformed — `CsrfLayer` for the token, "not a known verb" for
+            // the override — and neither is ever written to a column.
+            if field == csrf_field || PLUMBING_FIELDS.contains(&field.as_str()) {
+                continue;
+            }
+            changeset.add_error(field, NUL_CHARACTER_FIELD_ERROR);
+        }
 
         Ok(Self {
-            changeset: data.into_changeset(),
+            changeset,
             csrf_token,
             csrf_field,
         })
@@ -612,6 +723,10 @@ where
 }
 
 /// Decode a form body — URL-encoded always, multipart when that feature is on.
+///
+/// Returns the decoded `T` alongside the names of the fields whose submitted
+/// value carried a NUL byte (#2423); those values are cleaned before `T` is
+/// built, so the caller only has to decide what to say about them.
 // `clippy::result_large_err` (armed by rustc 1.98) measures the `Err` variant at
 // 128 bytes — that is `axum::response::Response`'s own size, not something this
 // crate chose. Returning a ready-made rejection response IS the idiom here, and
@@ -619,7 +734,10 @@ where
 // heuristic. Allowed at the site rather than workspace-wide so the lint stays
 // armed for error types we do control.
 #[allow(clippy::result_large_err)]
-async fn decode_form_body<T, S>(req: Request, state: &S) -> Result<T, axum::response::Response>
+async fn decode_form_body<T, S>(
+    req: Request,
+    state: &S,
+) -> Result<(T, Vec<String>), axum::response::Response>
 where
     T: serde::de::DeserializeOwned + validator::Validate + Send,
     S: Send + Sync,
@@ -659,8 +777,11 @@ where
         .await
         .map_err(IntoResponse::into_response)?;
 
-    decode_urlencoded_dropping_blank_optional_fields::<T>(&bytes)
-        .map_err(|e| (axum::http::StatusCode::BAD_REQUEST, e.to_string()).into_response())
+    let mut pairs = parse_urlencoded_pairs(&bytes);
+    let nul_fields = strip_nul_from_pairs(&mut pairs);
+    let data = decode_pairs_dropping_blank_optional_fields::<T>(pairs)
+        .map_err(|e| (axum::http::StatusCode::BAD_REQUEST, e.to_string()).into_response())?;
+    Ok((data, nul_fields))
 }
 
 /// Deserialize `T` from `application/x-www-form-urlencoded` bytes, tolerating
@@ -699,10 +820,26 @@ where
 pub(crate) fn decode_urlencoded_dropping_blank_optional_fields<T: serde::de::DeserializeOwned>(
     bytes: &[u8],
 ) -> Result<T, serde_path_to_error::Error<serde_urlencoded::de::Error>> {
-    let mut pairs: Vec<(String, String)> = url::form_urlencoded::parse(bytes)
-        .map(|(k, v)| (k.into_owned(), v.into_owned()))
-        .collect();
+    decode_pairs_dropping_blank_optional_fields(parse_urlencoded_pairs(bytes))
+}
 
+/// Parse an `application/x-www-form-urlencoded` body into owned key/value
+/// pairs — the form in which the #2423 NUL sweep can still name the offending
+/// field.
+pub(crate) fn parse_urlencoded_pairs(bytes: &[u8]) -> Vec<(String, String)> {
+    url::form_urlencoded::parse(bytes)
+        .map(|(k, v)| (k.into_owned(), v.into_owned()))
+        .collect()
+}
+
+/// The blank-optional-dropping retry loop itself, over already-parsed pairs.
+///
+/// See [`decode_urlencoded_dropping_blank_optional_fields`] for the contract;
+/// this is the same function with the parse step hoisted out so callers can
+/// inspect and clean the pairs first.
+pub(crate) fn decode_pairs_dropping_blank_optional_fields<T: serde::de::DeserializeOwned>(
+    mut pairs: Vec<(String, String)>,
+) -> Result<T, serde_path_to_error::Error<serde_urlencoded::de::Error>> {
     loop {
         let encoded = url::form_urlencoded::Serializer::new(String::new())
             .extend_pairs(pairs.iter().map(|(k, v)| (k.as_str(), v.as_str())))
@@ -746,7 +883,10 @@ pub fn __fuzz_decode_urlencoded(bytes: &[u8]) {
 // `axum::response::Response`, which IS the rejection, and boxing it would cost
 // an allocation on every rejection to satisfy a size heuristic.
 #[allow(clippy::result_large_err)]
-async fn decode_multipart<T, S>(req: Request, state: &S) -> Result<T, axum::response::Response>
+async fn decode_multipart<T, S>(
+    req: Request,
+    state: &S,
+) -> Result<(T, Vec<String>), axum::response::Response>
 where
     T: serde::de::DeserializeOwned,
     S: Send + Sync,
@@ -783,6 +923,11 @@ where
         pairs.push((name, value));
     }
 
+    // #2423: the same NUL sweep the URL-encoded path runs, applied to the
+    // text fields only — file parts were skipped above and their bytes are
+    // never text to begin with.
+    let nul_fields = strip_nul_from_pairs(&mut pairs);
+
     // Re-encode as URL-encoded so serde_urlencoded handles type coercions
     // ("30" → u32, "true" → bool, etc.) consistently with the Form extractor.
     let encoded = url::form_urlencoded::Serializer::new(String::new())
@@ -790,7 +935,7 @@ where
         .finish();
 
     match serde_urlencoded::from_str::<T>(&encoded) {
-        Ok(data) => Ok(data),
+        Ok(data) => Ok((data, nul_fields)),
         Err(first_err) => {
             // Same blank-optional-field accommodation as `decode_form_body`:
             // a number/date/uuid field left empty submits an empty text
@@ -807,9 +952,11 @@ where
             let filtered = url::form_urlencoded::Serializer::new(String::new())
                 .extend_pairs(non_blank.iter().map(|(k, v)| (k.as_str(), v.as_str())))
                 .finish();
-            serde_urlencoded::from_str::<T>(&filtered).map_err(|_| {
-                (axum::http::StatusCode::BAD_REQUEST, first_err.to_string()).into_response()
-            })
+            serde_urlencoded::from_str::<T>(&filtered)
+                .map(|data| (data, nul_fields))
+                .map_err(|_| {
+                    (axum::http::StatusCode::BAD_REQUEST, first_err.to_string()).into_response()
+                })
         }
     }
 }
@@ -6505,6 +6652,171 @@ mod tests {
                 .await
                 .unwrap();
             assert_eq!(resp.status(), axum::http::StatusCode::OK);
+        }
+
+        // ── #2423: an embedded NUL byte is a field error, not a 500 ───
+
+        #[derive(serde::Deserialize, serde::Serialize, validator::Validate)]
+        struct NulTestForm {
+            #[validate(length(min = 3))]
+            name: String,
+            #[serde(default)]
+            body: String,
+        }
+
+        /// The shape from issue #2423: a free-text field carrying `%00`
+        /// decodes cleanly and satisfies every `#[validate(...)]` rule, so it
+        /// used to reach Postgres raw and come back as an unhandled 500. It is
+        /// now one ordinary field error on the changeset, which the handler
+        /// re-renders inline like any other rejected submission.
+        #[tokio::test]
+        async fn nul_byte_in_text_field_is_a_field_error() {
+            async fn handler(form: ChangesetForm<NulTestForm>) -> String {
+                format!(
+                    "valid={} body_errors={}",
+                    form.is_valid(),
+                    form.errors_for("body").join("|")
+                )
+            }
+            let resp = Router::new()
+                .route("/test", post(handler))
+                .oneshot(urlencoded_req("/test", "name=Alice&body=before%00after"))
+                .await
+                .unwrap();
+            assert_body(
+                resp,
+                &format!("valid=false body_errors={NUL_CHARACTER_FIELD_ERROR}"),
+            )
+            .await;
+        }
+
+        /// The retained value is the author's text minus the NUL: the
+        /// re-rendered form keeps their work (the `ChangesetForm` round-trip
+        /// contract) without echoing a raw `0x00` back into the HTML.
+        #[tokio::test]
+        async fn nul_byte_is_stripped_from_the_redisplayed_value() {
+            async fn handler(form: ChangesetForm<NulTestForm>) -> String {
+                form.into_changeset()
+                    .field_value("body")
+                    .unwrap_or_default()
+            }
+            let resp = Router::new()
+                .route("/test", post(handler))
+                .oneshot(urlencoded_req("/test", "name=Alice&body=before%00after"))
+                .await
+                .unwrap();
+            assert_body(resp, "beforeafter").await;
+        }
+
+        /// Only the field that actually carried the byte is flagged.
+        #[tokio::test]
+        async fn nul_byte_flags_only_the_offending_field() {
+            async fn handler(form: ChangesetForm<NulTestForm>) -> String {
+                format!(
+                    "name={} body={}",
+                    form.errors_for("name").len(),
+                    form.errors_for("body").len()
+                )
+            }
+            let resp = Router::new()
+                .route("/test", post(handler))
+                .oneshot(urlencoded_req("/test", "name=Alice&body=a%00b"))
+                .await
+                .unwrap();
+            assert_body(resp, "name=0 body=1").await;
+        }
+
+        /// No false positives: an ordinary submission is untouched.
+        #[tokio::test]
+        async fn form_without_nul_is_unaffected() {
+            async fn handler(form: ChangesetForm<NulTestForm>) -> String {
+                format!("valid={} body={}", form.is_valid(), form.data().body)
+            }
+            let resp = Router::new()
+                .route("/test", post(handler))
+                .oneshot(urlencoded_req("/test", "name=Alice&body=plain"))
+                .await
+                .unwrap();
+            assert_body(resp, "valid=true body=plain").await;
+        }
+
+        /// Framework plumbing fields carry no renderable error key, so a NUL
+        /// in one is cleaned but not reported — same reasoning as `_csrf`.
+        #[tokio::test]
+        async fn nul_byte_in_the_method_override_is_not_a_form_error() {
+            async fn handler(form: ChangesetForm<NulTestForm>) -> String {
+                format!("valid={} errors={}", form.is_valid(), form.errors().len())
+            }
+            let resp = Router::new()
+                .route("/test", post(handler))
+                .oneshot(urlencoded_req(
+                    "/test",
+                    "_method=PA%00TCH&name=Alice&body=ok",
+                ))
+                .await
+                .unwrap();
+            assert_body(resp, "valid=true errors=0").await;
+        }
+
+        /// A NUL in a *rule-violating* field adds to that field's messages
+        /// rather than replacing the validator's own.
+        #[tokio::test]
+        async fn nul_byte_error_is_appended_to_existing_field_errors() {
+            async fn handler(form: ChangesetForm<NulTestForm>) -> String {
+                let errs = form.errors_for("name");
+                format!(
+                    "count={} has_nul={}",
+                    errs.len(),
+                    errs.iter().any(|e| e == NUL_CHARACTER_FIELD_ERROR)
+                )
+            }
+            // "a\0b" is 2 characters after stripping, so `length(min = 3)`
+            // fails as well.
+            let resp = Router::new()
+                .route("/test", post(handler))
+                .oneshot(urlencoded_req("/test", "name=a%00b&body="))
+                .await
+                .unwrap();
+            assert_body(resp, "count=2 has_nul=true").await;
+        }
+
+        /// The CSRF token is transport plumbing, not a form field: a NUL there
+        /// must not surface as a validation error on a name no template
+        /// renders (which would make the form permanently, invisibly invalid).
+        /// CSRF verification itself still rejects the mangled token upstream.
+        #[tokio::test]
+        async fn nul_byte_in_the_csrf_field_is_not_a_form_error() {
+            async fn handler(form: ChangesetForm<NulTestForm>) -> String {
+                format!("valid={} errors={}", form.is_valid(), form.errors().len())
+            }
+            let resp = Router::new()
+                .route("/test", post(handler))
+                .oneshot(urlencoded_req("/test", "_csrf=to%00ken&name=Alice&body=ok"))
+                .await
+                .unwrap();
+            assert_body(resp, "valid=true errors=0").await;
+        }
+
+        #[cfg(feature = "multipart")]
+        #[tokio::test]
+        async fn multipart_nul_byte_in_text_field_is_a_field_error() {
+            async fn handler(form: ChangesetForm<NulTestForm>) -> String {
+                format!(
+                    "valid={} body_errors={} body={}",
+                    form.is_valid(),
+                    form.errors_for("body").len(),
+                    form.data().body
+                )
+            }
+            let resp = Router::new()
+                .route("/test", post(handler))
+                .oneshot(multipart_req_multi(
+                    "/test",
+                    &[("name", "Alice"), ("body", "before\u{0}after")],
+                ))
+                .await
+                .unwrap();
+            assert_body(resp, "valid=false body_errors=1 body=beforeafter").await;
         }
 
         // ── Helpers ────────────────────────────────────────────────

--- a/autumn/src/nested_form.rs
+++ b/autumn/src/nested_form.rs
@@ -486,6 +486,17 @@ impl<P, C: NestedChild + serde::Serialize> NestedChangeset<P, C> {
 /// [`ChangesetForm`](crate::form::ChangesetForm) uses, so string→typed
 /// coercion (`quantity=5` → `i32`) comes for free.
 ///
+/// # Unstorable bytes
+///
+/// Submitted text values are swept for NUL (`U+0000`) before anything decodes
+/// them (issue #2423), and a parent field or child subfield that carried one
+/// gets [`NUL_CHARACTER_FIELD_ERROR`](crate::form::NUL_CHARACTER_FIELD_ERROR)
+/// alongside whatever the validators said. `_destroy` is excluded from the
+/// sweep — cleaning a marker read only for truthiness would change it — and so
+/// are the *default* names of the framework's plumbing fields, since this
+/// function takes raw pairs and never sees the request extensions that carry
+/// their configured names. [`NestedChangesetForm`] additionally exempts those.
+///
 /// # Errors
 ///
 /// Returns `Err(message)` when the **parent** fails to decode (a malformed,
@@ -524,10 +535,34 @@ where
     // and fails only at the database with an unhandled 500. Parent fields and
     // each row's subfields are swept separately because they are keyed
     // separately in the rendered form.
-    let parent_nul_fields = crate::form::strip_nul_from_pairs(&mut parent_pairs);
+    // `_destroy` is excluded from the sweep, not merely from the reporting.
+    // Cleaning it would rewrite the marker itself: `is_truthy` trims only
+    // whitespace, so `"1\u{0}"` reads as false today and would read as *true*
+    // after stripping — silently destroying a row the author submitted to keep.
+    // It is never written to a column, so leaving the byte in it costs nothing.
+    let parent_nul_fields: Vec<String> = crate::form::strip_nul_from_pairs(&mut parent_pairs)
+        .into_iter()
+        // A direct caller of this public function passes the raw pairs, tokens
+        // and all, and never sees the request extensions that carry the
+        // configurable field names — so exempt the defaults here. The
+        // extractor additionally exempts the configured names.
+        .filter(|field| !crate::form::is_plumbing_field(field))
+        .collect();
     let child_nul_fields: BTreeMap<usize, Vec<String>> = child_groups
         .iter_mut()
-        .map(|(idx, subfields)| (*idx, crate::form::strip_nul_from_pairs(subfields)))
+        .map(|(idx, subfields)| {
+            let swept: Vec<String> = subfields
+                .iter_mut()
+                .filter(|(sub, _)| sub != DESTROY_SUBFIELD)
+                .filter_map(|(sub, value)| {
+                    value.as_bytes().contains(&0).then(|| {
+                        *value = crate::normalize::strip_nul(value);
+                        sub.clone()
+                    })
+                })
+                .collect();
+            (*idx, swept)
+        })
         .collect();
 
     // Decode the parent through the shared blank-optional-dropping path.
@@ -611,7 +646,7 @@ fn decode_child_row<C: NestedChild>(
     let mut decode_pairs: Vec<(String, String)> = Vec::new();
     for (sub, val) in subfields {
         values.insert(sub.clone(), val.clone());
-        if sub == "_destroy" {
+        if sub == DESTROY_SUBFIELD {
             if is_truthy(val) {
                 destroyed = true;
             }
@@ -633,16 +668,30 @@ fn decode_child_row<C: NestedChild>(
     // same outcome as the destroy path.)
     //
     // #2423: values were cleaned before this check, so a subfield whose only
-    // content was a NUL now reads as blank. A row of nothing but NULs is
-    // therefore dropped like any other blank template row — nothing is written
-    // either way.
+    // content was a NUL now reads as blank. That must not make the row *vanish*
+    // — the author did submit something, it just could not be stored — so a row
+    // that carried a NUL is reported even when nothing legible is left of it.
+    // A genuinely blank template row still drops, exactly as before.
     if decode_pairs.iter().all(|(_, val)| val.trim().is_empty()) {
-        return ChildRow::Dropped;
+        if nul_fields.is_empty() {
+            return ChildRow::Dropped;
+        }
+        let mut errors: HashMap<String, Vec<String>> = HashMap::new();
+        for field in nul_fields {
+            errors
+                .entry(field.clone())
+                .or_default()
+                .push(crate::form::NUL_CHARACTER_FIELD_ERROR.to_owned());
+        }
+        return ChildRow::Rejected(NestedRow {
+            values,
+            errors,
+            destroyed,
+        });
     }
 
     // #2423: a destroyed row is never written, so there is nothing to reject
-    // there — `_destroy` itself is a marker read only for truthiness, never a
-    // stored column.
+    // there — the cleaned values are retained only so the row re-renders.
     if destroyed {
         return ChildRow::Bound {
             row: NestedRow {
@@ -688,9 +737,8 @@ fn decode_child_row<C: NestedChild>(
     }
 
     // #2423: a NUL byte in this row's text is a rejection in its own right,
-    // recorded alongside whatever the validators said. `_destroy` is skipped:
-    // it is a marker, not a stored column.
-    for field in nul_fields.iter().filter(|field| *field != "_destroy") {
+    // recorded alongside whatever the validators said.
+    for field in nul_fields {
         errors
             .entry(field.clone())
             .or_default()
@@ -854,6 +902,12 @@ fn recover_child_error_field<C: serde::de::DeserializeOwned>(
 }
 
 /// Whether a `_destroy` marker value counts as "destroy this row".
+/// The subfield name that marks a submitted child row for destruction.
+///
+/// Not a column: its value is only ever read for truthiness, so it is left out
+/// of the #2423 NUL sweep entirely (see `decode_nested_urlencoded`).
+const DESTROY_SUBFIELD: &str = "_destroy";
+
 fn is_truthy(value: &str) -> bool {
     let trimmed = value.trim();
     trimmed == "1" || trimmed.eq_ignore_ascii_case("true") || trimmed.eq_ignore_ascii_case("on")
@@ -1835,6 +1889,114 @@ mod tests {
         ];
         let cs = decode_nested_urlencoded::<Order, LineItem>(&pairs).expect("parent decodes");
         assert!(cs.into_valid().is_err());
+    }
+
+    /// `_destroy` is a marker read only for truthiness, never a stored column,
+    /// and `is_truthy` trims whitespace but not NUL. Cleaning it would rewrite
+    /// the marker: `"1\u{0}"` reads as *false* today and would read as true
+    /// after stripping, silently destroying a row the author submitted to keep.
+    /// So the sweep leaves it alone entirely.
+    #[test]
+    fn a_nul_in_the_destroy_marker_does_not_flip_it_truthy() {
+        let pairs = vec![
+            p("name", "Order 1"),
+            p("items[0][sku]", "A-1"),
+            p("items[0][quantity]", "2"),
+            p("items[0][_destroy]", "1\u{0}"),
+        ];
+        let cs = decode_nested_urlencoded::<Order, LineItem>(&pairs).expect("parent decodes");
+        assert_eq!(cs.rows().len(), 1);
+        assert!(
+            !cs.rows()[0].is_destroyed(),
+            "a NUL-mangled marker must stay falsy, not become a destroy"
+        );
+        assert!(cs.is_valid(), "and it is not an error either");
+    }
+
+    /// A row whose every legible subfield was nothing but NUL bytes must not
+    /// silently vanish the way a genuinely blank template row does — the author
+    /// submitted something, it just could not be stored.
+    #[test]
+    fn a_row_of_only_nul_bytes_is_reported_rather_than_dropped() {
+        let pairs = vec![
+            p("name", "Order 1"),
+            p("items[0][sku]", "\u{0}"),
+            p("items[0][quantity]", ""),
+        ];
+        let cs = decode_nested_urlencoded::<Order, LineItem>(&pairs).expect("parent decodes");
+        assert_eq!(cs.rows().len(), 1, "the row must survive for re-render");
+        assert_eq!(cs.rows()[0].errors_for("sku"), [NUL_CHARACTER_FIELD_ERROR]);
+        assert!(!cs.is_valid());
+    }
+
+    /// A genuinely blank template row still drops, unchanged.
+    #[test]
+    fn a_blank_template_row_still_drops() {
+        let pairs = vec![
+            p("name", "Order 1"),
+            p("items[0][sku]", ""),
+            p("items[0][quantity]", ""),
+        ];
+        let cs = decode_nested_urlencoded::<Order, LineItem>(&pairs).expect("parent decodes");
+        assert!(cs.rows().is_empty());
+        assert!(cs.is_valid());
+    }
+
+    /// `decode_nested_urlencoded` is public and takes the raw pairs — tokens
+    /// and all — so it applies the default plumbing exemption itself. A direct
+    /// caller must not get a parent error keyed `_csrf`, which no template
+    /// renders.
+    #[test]
+    fn default_plumbing_fields_are_exempt_for_direct_callers() {
+        for field in ["_csrf", "_submit_token", "_method"] {
+            let pairs = vec![
+                p("name", "Order 1"),
+                p(field, "to%00ken".replace("%00", "\u{0}").as_str()),
+                p("items[0][sku]", "A-1"),
+                p("items[0][quantity]", "2"),
+            ];
+            let cs = decode_nested_urlencoded::<Order, LineItem>(&pairs).expect("parent decodes");
+            assert!(
+                cs.is_valid(),
+                "`{field}` must not produce an unrenderable error: {:?}",
+                cs.errors_for(field)
+            );
+        }
+    }
+
+    /// The extractor is where the *configured* token field names are known, so
+    /// that is where they have to be exempted. `decode_nested_urlencoded`
+    /// covers only the defaults.
+    #[tokio::test]
+    async fn nested_extractor_exempts_the_configured_token_field_names() {
+        use axum::body::Body;
+        use axum::extract::FromRequest as _;
+
+        let mut req = axum::http::Request::builder()
+            .method("POST")
+            .uri("/orders")
+            .header("Content-Type", "application/x-www-form-urlencoded")
+            .body(Body::from(
+                "authenticity=to%00ken&stamp=st%00amp&name=Order+1\
+                 &items%5B0%5D%5Bsku%5D=A-1&items%5B0%5D%5Bquantity%5D=2",
+            ))
+            .expect("build request");
+        req.extensions_mut()
+            .insert(crate::security::csrf::CsrfFormField(
+                "authenticity".to_owned(),
+            ));
+        req.extensions_mut()
+            .insert(crate::security::SubmitFormField("stamp".to_owned()));
+
+        let form = NestedChangesetForm::<Order, LineItem>::from_request(req, &())
+            .await
+            .expect("body decodes");
+
+        assert!(
+            form.changeset.is_valid(),
+            "renamed token fields must not produce unrenderable errors: {:?}",
+            form.changeset.parent.errors()
+        );
     }
 
     /// No false positives on the nested path either.

--- a/autumn/src/nested_form.rs
+++ b/autumn/src/nested_form.rs
@@ -188,7 +188,7 @@
     )
 )]
 
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 
 use axum::extract::{FromRequest, Request};
 use axum::response::IntoResponse;
@@ -551,17 +551,20 @@ where
     let child_nul_fields: BTreeMap<usize, Vec<String>> = child_groups
         .iter_mut()
         .map(|(idx, subfields)| {
-            let swept: Vec<String> = subfields
-                .iter_mut()
-                .filter(|(sub, _)| sub != DESTROY_SUBFIELD)
-                .filter_map(|(sub, value)| {
-                    value.as_bytes().contains(&0).then(|| {
-                        *value = crate::normalize::strip_nul(value);
-                        sub.clone()
-                    })
-                })
-                .collect();
-            (*idx, swept)
+            // Deduplicated for the same reason `strip_nul_from_pairs` is: a
+            // subfield may be submitted any number of times, and one message
+            // per *pair* would let a crafted body inflate a single row's error
+            // list without bound. One message per offending subfield.
+            let mut swept: BTreeSet<String> = BTreeSet::new();
+            for (sub, value) in subfields.iter_mut() {
+                if sub != DESTROY_SUBFIELD && value.as_bytes().contains(&0) {
+                    *value = crate::normalize::strip_nul(value);
+                    if !swept.contains(sub.as_str()) {
+                        swept.insert(sub.clone());
+                    }
+                }
+            }
+            (*idx, swept.into_iter().collect::<Vec<String>>())
         })
         .collect();
 
@@ -667,15 +670,36 @@ fn decode_child_row<C: NestedChild>(
     // all-blank row that also carries `_destroy` is dropped here too — the
     // same outcome as the destroy path.)
     //
-    // #2423: values were cleaned before this check, so a subfield whose only
-    // content was a NUL now reads as blank. That must not make the row *vanish*
-    // — the author did submit something, it just could not be stored — so a row
-    // that carried a NUL is reported even when nothing legible is left of it.
-    // A genuinely blank template row still drops, exactly as before.
-    if decode_pairs.iter().all(|(_, val)| val.trim().is_empty()) {
-        if nul_fields.is_empty() {
-            return ChildRow::Dropped;
-        }
+    let all_blank = decode_pairs.iter().all(|(_, val)| val.trim().is_empty());
+
+    // A genuinely blank template row drops, destroyed or not — unchanged.
+    if all_blank && nul_fields.is_empty() {
+        return ChildRow::Dropped;
+    }
+
+    // #2423: a destroyed row is never written, so there is nothing to reject
+    // there — the cleaned values are retained only so the row re-renders. This
+    // has to be decided *before* the NUL rejection below: a row whose only
+    // remaining content was an unstorable byte is still a row the author asked
+    // to delete, and rejecting it would block `into_valid` and leave them
+    // unable to remove it.
+    if destroyed {
+        return ChildRow::Bound {
+            row: NestedRow {
+                values,
+                errors: HashMap::new(),
+                destroyed,
+            },
+            child: None,
+        };
+    }
+
+    // #2423: values were cleaned before the blank check, so a subfield whose
+    // only content was a NUL now reads as blank. That must not make the row
+    // *vanish* — the author did submit something, it just could not be stored
+    // — so a row that carried a NUL is reported even when nothing legible is
+    // left of it.
+    if all_blank {
         let mut errors: HashMap<String, Vec<String>> = HashMap::new();
         for field in nul_fields {
             errors
@@ -688,19 +712,6 @@ fn decode_child_row<C: NestedChild>(
             errors,
             destroyed,
         });
-    }
-
-    // #2423: a destroyed row is never written, so there is nothing to reject
-    // there — the cleaned values are retained only so the row re-renders.
-    if destroyed {
-        return ChildRow::Bound {
-            row: NestedRow {
-                values,
-                errors: HashMap::new(),
-                destroyed,
-            },
-            child: None,
-        };
     }
 
     let mut errors: HashMap<String, Vec<String>> = HashMap::new();
@@ -1996,6 +2007,51 @@ mod tests {
             form.changeset.is_valid(),
             "renamed token fields must not produce unrenderable errors: {:?}",
             form.changeset.parent.errors()
+        );
+    }
+
+    /// A destroyed row is never written, so it must never be *rejected* —
+    /// otherwise the author cannot delete a row whose only remaining content
+    /// was an unstorable byte. The blank-and-NUL rejection must not run ahead
+    /// of the destroy check.
+    #[test]
+    fn a_destroyed_row_of_only_nul_bytes_is_not_rejected() {
+        let pairs = vec![
+            p("name", "Order 1"),
+            p("items[0][sku]", "\u{0}"),
+            p("items[0][quantity]", ""),
+            p("items[0][_destroy]", "1"),
+        ];
+        let cs = decode_nested_urlencoded::<Order, LineItem>(&pairs).expect("parent decodes");
+        assert!(
+            cs.is_valid(),
+            "a row the author asked to destroy must not block the submission"
+        );
+        assert!(
+            cs.into_valid().is_ok(),
+            "the parent must still be bindable so the destroy can be applied"
+        );
+    }
+
+    /// A repeated subfield carrying NULs contributes one message, not one per
+    /// occurrence — the same guarantee the flat sweep already makes. Without
+    /// it a crafted body inflates a single row's error list without bound.
+    #[test]
+    fn a_repeated_nul_subfield_in_a_row_reports_once() {
+        let pairs = vec![
+            p("name", "Order 1"),
+            p("items[0][sku]", "A-1"),
+            p("items[0][quantity]", "2"),
+            p("items[0][unknown]", "a\u{0}a"),
+            p("items[0][unknown]", "b\u{0}b"),
+            p("items[0][unknown]", "c\u{0}c"),
+        ];
+        let cs = decode_nested_urlencoded::<Order, LineItem>(&pairs).expect("parent decodes");
+        assert_eq!(cs.rows().len(), 1);
+        assert_eq!(
+            cs.rows()[0].errors_for("unknown").len(),
+            1,
+            "one message per offending subfield, not one per submitted pair"
         );
     }
 

--- a/autumn/src/nested_form.rs
+++ b/autumn/src/nested_form.rs
@@ -517,100 +517,50 @@ where
         }
     }
 
+    // #2423: sweep NUL bytes out of the submitted values before anything
+    // decodes them, remembering which names carried one so the byte lands as
+    // an ordinary error on the field or subfield that held it. Postgres cannot
+    // store `0x00` in a TEXT column, so without this the row parses, validates,
+    // and fails only at the database with an unhandled 500. Parent fields and
+    // each row's subfields are swept separately because they are keyed
+    // separately in the rendered form.
+    let parent_nul_fields = crate::form::strip_nul_from_pairs(&mut parent_pairs);
+    let child_nul_fields: BTreeMap<usize, Vec<String>> = child_groups
+        .iter_mut()
+        .map(|(idx, subfields)| (*idx, crate::form::strip_nul_from_pairs(subfields)))
+        .collect();
+
     // Decode the parent through the shared blank-optional-dropping path.
     let parent_encoded = encode_pairs(&parent_pairs);
     let parent_data: P =
         decode_urlencoded_dropping_blank_optional_fields::<P>(parent_encoded.as_bytes())
             .map_err(|e| e.to_string())?;
-    let parent = parent_data.into_changeset();
+    let mut parent = parent_data.into_changeset();
+    for field in parent_nul_fields {
+        parent.add_error(field, crate::form::NUL_CHARACTER_FIELD_ERROR);
+    }
 
     let mut rows: Vec<NestedRow> = Vec::new();
     let mut children: Vec<C> = Vec::new();
     let mut all_children_ok = true;
 
-    for subfields in child_groups.into_values() {
-        let mut values: HashMap<String, String> = HashMap::new();
-        let mut destroyed = false;
-        // Subfields decoded into `C`, excluding the `_destroy` marker (not a
-        // field of `C`).
-        let mut decode_pairs: Vec<(String, String)> = Vec::new();
-        for (sub, val) in &subfields {
-            values.insert(sub.clone(), val.clone());
-            if sub == "_destroy" {
-                if is_truthy(val) {
-                    destroyed = true;
+    for (idx, subfields) in child_groups {
+        match decode_child_row::<C>(
+            &subfields,
+            child_nul_fields.get(&idx).map_or(&[], Vec::as_slice),
+        ) {
+            ChildRow::Dropped => {}
+            ChildRow::Bound { row, child } => {
+                if let Some(child) = child {
+                    children.push(child);
                 }
-            } else {
-                decode_pairs.push((sub.clone(), val.clone()));
+                rows.push(row);
             }
-        }
-
-        // Rails `reject_if: :all_blank`: if every non-`_destroy` subfield value
-        // is blank (empty or whitespace-only after trimming), drop the row
-        // entirely. This is the auto-rendered blank template row `inputs_for`
-        // emits for the no-JS "add a child" path, not a real submitted child —
-        // treat it as if the index was never submitted: do not decode, do not
-        // validate, do not retain it, and do not count it toward the children.
-        // A row with at least one non-blank non-`_destroy` value is kept and
-        // validated as usual, so a partially filled row still surfaces its
-        // per-field errors. (`decode_pairs` already excludes `_destroy`, so an
-        // all-blank row that also carries `_destroy` is dropped here too — the
-        // same outcome as the destroy path.)
-        let all_blank = decode_pairs.iter().all(|(_, val)| val.trim().is_empty());
-        if all_blank {
-            continue;
-        }
-
-        let mut errors: HashMap<String, Vec<String>> = HashMap::new();
-
-        if destroyed {
-            rows.push(NestedRow {
-                values,
-                errors,
-                destroyed,
-            });
-            continue;
-        }
-
-        let encoded = encode_pairs(&decode_pairs);
-        match decode_urlencoded_dropping_blank_optional_fields::<C>(encoded.as_bytes()) {
-            Ok(child) => match validator::Validate::validate(&child) {
-                Ok(()) => children.push(child),
-                Err(ve) => {
-                    errors = validation_errors_to_map(&ve);
-                    all_children_ok = false;
-                }
-            },
-            Err(e) => {
-                // Row parse failure (deserialization failed before validation,
-                // e.g. `sku` filled but the required numeric `quantity` is
-                // malformed or present-but-blank). Key the message under the
-                // offending subfield so it surfaces as `items[i].{field}`,
-                // rendered by `errors_for("{field}")` next to the offending
-                // input rather than only under the row-level "" key.
-                //
-                // The blank-optional retry inside
-                // `decode_urlencoded_dropping_blank_optional_fields` can DROP a
-                // present-but-blank typed field (`quantity=`) before serde sees
-                // it, so the primary error is then `missing field \`quantity\``
-                // reported at the ROW ROOT with an empty path — losing the field
-                // name the row helpers need. `recover_child_error_field` recovers
-                // it by preferring the primary error's `missing field \`X\``
-                // message (with a raw non-dropping re-decode only as a last
-                // resort); see that helper. Only if all layers fail does it fall
-                // back to the row-level "" key, so the error is never silently
-                // dropped.
-                let field = recover_child_error_field::<C>(&e, &decode_pairs);
-                errors.entry(field).or_default().push(e.to_string());
+            ChildRow::Rejected(row) => {
                 all_children_ok = false;
+                rows.push(row);
             }
         }
-
-        rows.push(NestedRow {
-            values,
-            errors,
-            destroyed,
-        });
     }
 
     let valid_children = if parent.is_valid() && all_children_ok {
@@ -624,6 +574,142 @@ where
         rows,
         valid_children,
     })
+}
+
+/// The outcome of decoding one submitted child row.
+enum ChildRow<C> {
+    /// A blank template row (Rails `reject_if: :all_blank`) — dropped
+    /// entirely, exactly as if that index had never been submitted.
+    Dropped,
+    /// Retained for re-render and contributing `child` to the bound children:
+    /// `Some` when the row parsed and validated, `None` when it is marked
+    /// destroyed and so has nothing to write. Neither blocks `into_valid`.
+    Bound {
+        /// The row as re-rendered.
+        row: NestedRow,
+        /// The bound child, absent for a destroyed row.
+        child: Option<C>,
+    },
+    /// Retained for re-render carrying per-subfield errors; blocks
+    /// `into_valid`.
+    Rejected(NestedRow),
+}
+
+/// Decode one submitted child row from its grouped subfields.
+///
+/// `nul_fields` names the subfields of this row whose submitted value carried
+/// a NUL byte (#2423); the values in `subfields` have already been cleaned, so
+/// this only decides what to say about them.
+fn decode_child_row<C: NestedChild>(
+    subfields: &[(String, String)],
+    nul_fields: &[String],
+) -> ChildRow<C> {
+    let mut values: HashMap<String, String> = HashMap::new();
+    let mut destroyed = false;
+    // Subfields decoded into `C`, excluding the `_destroy` marker (not a
+    // field of `C`).
+    let mut decode_pairs: Vec<(String, String)> = Vec::new();
+    for (sub, val) in subfields {
+        values.insert(sub.clone(), val.clone());
+        if sub == "_destroy" {
+            if is_truthy(val) {
+                destroyed = true;
+            }
+        } else {
+            decode_pairs.push((sub.clone(), val.clone()));
+        }
+    }
+
+    // Rails `reject_if: :all_blank`: if every non-`_destroy` subfield value
+    // is blank (empty or whitespace-only after trimming), drop the row
+    // entirely. This is the auto-rendered blank template row `inputs_for`
+    // emits for the no-JS "add a child" path, not a real submitted child —
+    // treat it as if the index was never submitted: do not decode, do not
+    // validate, do not retain it, and do not count it toward the children.
+    // A row with at least one non-blank non-`_destroy` value is kept and
+    // validated as usual, so a partially filled row still surfaces its
+    // per-field errors. (`decode_pairs` already excludes `_destroy`, so an
+    // all-blank row that also carries `_destroy` is dropped here too — the
+    // same outcome as the destroy path.)
+    //
+    // #2423: values were cleaned before this check, so a subfield whose only
+    // content was a NUL now reads as blank. A row of nothing but NULs is
+    // therefore dropped like any other blank template row — nothing is written
+    // either way.
+    if decode_pairs.iter().all(|(_, val)| val.trim().is_empty()) {
+        return ChildRow::Dropped;
+    }
+
+    // #2423: a destroyed row is never written, so there is nothing to reject
+    // there — `_destroy` itself is a marker read only for truthiness, never a
+    // stored column.
+    if destroyed {
+        return ChildRow::Bound {
+            row: NestedRow {
+                values,
+                errors: HashMap::new(),
+                destroyed,
+            },
+            child: None,
+        };
+    }
+
+    let mut errors: HashMap<String, Vec<String>> = HashMap::new();
+    let mut child: Option<C> = None;
+
+    let encoded = encode_pairs(&decode_pairs);
+    match decode_urlencoded_dropping_blank_optional_fields::<C>(encoded.as_bytes()) {
+        Ok(decoded) => match validator::Validate::validate(&decoded) {
+            Ok(()) => child = Some(decoded),
+            Err(ve) => errors = validation_errors_to_map(&ve),
+        },
+        Err(e) => {
+            // Row parse failure (deserialization failed before validation,
+            // e.g. `sku` filled but the required numeric `quantity` is
+            // malformed or present-but-blank). Key the message under the
+            // offending subfield so it surfaces as `items[i].{field}`,
+            // rendered by `errors_for("{field}")` next to the offending
+            // input rather than only under the row-level "" key.
+            //
+            // The blank-optional retry inside
+            // `decode_urlencoded_dropping_blank_optional_fields` can DROP a
+            // present-but-blank typed field (`quantity=`) before serde sees
+            // it, so the primary error is then `missing field \`quantity\``
+            // reported at the ROW ROOT with an empty path — losing the field
+            // name the row helpers need. `recover_child_error_field` recovers
+            // it by preferring the primary error's `missing field \`X\``
+            // message (with a raw non-dropping re-decode only as a last
+            // resort); see that helper. Only if all layers fail does it fall
+            // back to the row-level "" key, so the error is never silently
+            // dropped.
+            let field = recover_child_error_field::<C>(&e, &decode_pairs);
+            errors.entry(field).or_default().push(e.to_string());
+        }
+    }
+
+    // #2423: a NUL byte in this row's text is a rejection in its own right,
+    // recorded alongside whatever the validators said. `_destroy` is skipped:
+    // it is a marker, not a stored column.
+    for field in nul_fields.iter().filter(|field| *field != "_destroy") {
+        errors
+            .entry(field.clone())
+            .or_default()
+            .push(crate::form::NUL_CHARACTER_FIELD_ERROR.to_owned());
+        child = None;
+    }
+
+    let row = NestedRow {
+        values,
+        errors,
+        destroyed,
+    };
+    match child {
+        Some(child) => ChildRow::Bound {
+            row,
+            child: Some(child),
+        },
+        None => ChildRow::Rejected(row),
+    }
 }
 
 /// Parse `key` as a child subfield reference `COLLECTION[<idx>][<sub>]`,
@@ -1122,9 +1208,22 @@ where
             .await
             .map_err(IntoResponse::into_response)?;
 
-        let pairs: Vec<(String, String)> = url::form_urlencoded::parse(&bytes)
+        let mut pairs: Vec<(String, String)> = url::form_urlencoded::parse(&bytes)
             .map(|(k, v)| (k.into_owned(), v.into_owned()))
             .collect();
+
+        // #2423: the CSRF token, the submit token and the method override are
+        // transport plumbing, not form fields — no template renders them, so an
+        // error keyed under one would make the form permanently invalid with
+        // nothing on screen to explain why. Clean them here so
+        // `decode_nested_urlencoded`'s sweep, which knows nothing about the two
+        // configurable names, never sees a NUL in one. Each is still rejected on
+        // its own terms when malformed.
+        for (key, value) in &mut pairs {
+            if *key == csrf_field || *key == submit_field || crate::form::is_plumbing_field(key) {
+                *value = crate::normalize::strip_nul(value);
+            }
+        }
 
         let changeset = decode_nested_urlencoded::<P, C>(&pairs)
             .map_err(|e| (axum::http::StatusCode::BAD_REQUEST, e).into_response())?;
@@ -1648,6 +1747,7 @@ pub fn nested_row_fragment<C: NestedChild>(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::form::NUL_CHARACTER_FIELD_ERROR;
 
     #[derive(serde::Serialize, serde::Deserialize, validator::Validate)]
     struct Order {
@@ -1683,6 +1783,70 @@ mod tests {
 
     fn p(k: &str, v: &str) -> (String, String) {
         (k.to_owned(), v.to_owned())
+    }
+
+    // ── #2423: NUL bytes on the nested path ───────────────────────────
+
+    /// The parent behaves exactly like a flat [`ChangesetForm`] field: the
+    /// byte is stripped from the retained value and recorded as one error on
+    /// the field that carried it.
+    #[test]
+    fn nul_byte_in_a_parent_field_is_a_parent_error() {
+        let pairs = vec![
+            p("name", "Order\u{0}1"),
+            p("items[0][sku]", "A-1"),
+            p("items[0][quantity]", "2"),
+        ];
+        let cs = decode_nested_urlencoded::<Order, LineItem>(&pairs).expect("parent decodes");
+        assert!(!cs.is_valid());
+        assert_eq!(cs.errors_for("name"), [NUL_CHARACTER_FIELD_ERROR]);
+        assert_eq!(cs.parent.data().name, "Order1");
+    }
+
+    /// A child subfield is keyed under that subfield on that row, so it
+    /// renders next to the offending input rather than at the row root.
+    #[test]
+    fn nul_byte_in_a_child_subfield_is_a_row_error() {
+        let pairs = vec![
+            p("name", "Order 1"),
+            p("items[0][sku]", "A\u{0}-1"),
+            p("items[0][quantity]", "2"),
+        ];
+        let cs = decode_nested_urlencoded::<Order, LineItem>(&pairs).expect("parent decodes");
+        assert!(!cs.is_valid());
+        assert_eq!(cs.rows().len(), 1);
+        assert_eq!(cs.rows()[0].errors_for("sku"), [NUL_CHARACTER_FIELD_ERROR]);
+        // The retained value the row re-renders is the cleaned text.
+        assert_eq!(cs.rows()[0].value("sku"), Some("A-1"));
+        assert!(
+            cs.rows()[0].errors_for("quantity").is_empty(),
+            "only the offending subfield is flagged"
+        );
+    }
+
+    /// A NUL anywhere in the submission blocks the whole write, so
+    /// `into_valid` cannot hand back children built from unstorable text.
+    #[test]
+    fn nul_byte_in_a_child_subfield_blocks_into_valid() {
+        let pairs = vec![
+            p("name", "Order 1"),
+            p("items[0][sku]", "A\u{0}-1"),
+            p("items[0][quantity]", "2"),
+        ];
+        let cs = decode_nested_urlencoded::<Order, LineItem>(&pairs).expect("parent decodes");
+        assert!(cs.into_valid().is_err());
+    }
+
+    /// No false positives on the nested path either.
+    #[test]
+    fn clean_nested_submission_is_unaffected() {
+        let pairs = vec![
+            p("name", "Order 1"),
+            p("items[0][sku]", "A-1"),
+            p("items[0][quantity]", "2"),
+        ];
+        let cs = decode_nested_urlencoded::<Order, LineItem>(&pairs).expect("parent decodes");
+        assert!(cs.is_valid());
     }
 
     #[test]

--- a/autumn/src/normalize.rs
+++ b/autumn/src/normalize.rs
@@ -72,6 +72,12 @@ pub fn upcase(s: &str) -> String {
     s.to_uppercase()
 }
 
+/// Trim and collapse every internal run of whitespace to a single ASCII space.
+#[must_use]
+pub fn squish(s: &str) -> String {
+    s.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
 /// Remove every NUL (`U+0000`) character (issue #2423).
 ///
 /// A Postgres `TEXT`/`VARCHAR` column cannot hold `0x00`, so a value carrying
@@ -88,17 +94,7 @@ pub fn upcase(s: &str) -> String {
 /// error without any attribute.
 #[must_use]
 pub fn strip_nul(s: &str) -> String {
-    if s.as_bytes().contains(&0) {
-        s.replace('\u{0}', "")
-    } else {
-        s.to_owned()
-    }
-}
-
-/// Trim and collapse every internal run of whitespace to a single ASCII space.
-#[must_use]
-pub fn squish(s: &str) -> String {
-    s.split_whitespace().collect::<Vec<_>>().join(" ")
+    s.replace('\u{0}', "")
 }
 
 /// A type whose `#[normalize]` columns can be canonicalized in place.

--- a/autumn/src/normalize.rs
+++ b/autumn/src/normalize.rs
@@ -16,6 +16,8 @@
 //! - [`upcase`] — uppercase (str casing).
 //! - [`squish`] — trim **and** collapse internal runs of whitespace to a single
 //!   space.
+//! - [`strip_nul`] — remove every NUL (`U+0000`), which a Postgres
+//!   `TEXT`/`VARCHAR` column cannot store (#2423).
 //!
 //! All built-ins are idempotent: normalizing an already-normalized value is a
 //! no-op, so applying them on both the write path and on lookups converges on
@@ -68,6 +70,29 @@ pub fn downcase(s: &str) -> String {
 #[must_use]
 pub fn upcase(s: &str) -> String {
     s.to_uppercase()
+}
+
+/// Remove every NUL (`U+0000`) character (issue #2423).
+///
+/// A Postgres `TEXT`/`VARCHAR` column cannot hold `0x00`, so a value carrying
+/// one is rejected by the server at `INSERT`/`UPDATE` time. Reach for this on
+/// a column fed by input that may legitimately arrive dirty (a paste from a
+/// binary source, a misbehaving input method) and where silently dropping the
+/// byte is preferable to rejecting the write.
+///
+/// Only NUL is removed: every other control character is storable and is left
+/// exactly as written.
+///
+/// Prefer rejecting over cleaning where the author can see and fix the value —
+/// [`crate::form::ChangesetForm`] already surfaces a NUL as an inline field
+/// error without any attribute.
+#[must_use]
+pub fn strip_nul(s: &str) -> String {
+    if s.as_bytes().contains(&0) {
+        s.replace('\u{0}', "")
+    } else {
+        s.to_owned()
+    }
 }
 
 /// Trim and collapse every internal run of whitespace to a single ASCII space.
@@ -220,6 +245,26 @@ mod tests {
     fn trim_strips_edges() {
         assert_eq!(trim("  hi  "), "hi");
         assert_eq!(trim("hi"), "hi");
+    }
+
+    #[test]
+    fn strip_nul_removes_embedded_nuls() {
+        assert_eq!(strip_nul("before\u{0}after"), "beforeafter");
+        assert_eq!(strip_nul("\u{0}\u{0}a\u{0}"), "a");
+    }
+
+    #[test]
+    fn strip_nul_leaves_clean_text_untouched() {
+        assert_eq!(strip_nul("plain text"), "plain text");
+        // Other control characters are storable in a Postgres TEXT column and
+        // are deliberately left alone.
+        assert_eq!(strip_nul("tab\there"), "tab\there");
+    }
+
+    #[test]
+    fn strip_nul_is_idempotent() {
+        let once = strip_nul("a\u{0}b");
+        assert_eq!(strip_nul(&once), once);
     }
 
     #[test]

--- a/autumn/tests/integration/mod.rs
+++ b/autumn/tests/integration/mod.rs
@@ -192,6 +192,7 @@ mod nested_form_atomic_save;
 #[cfg(feature = "maud")]
 mod nested_form_order_example;
 mod notifications;
+mod nul_byte_input;
 #[cfg(feature = "offline-sync")]
 mod offline_sync_conformance;
 #[cfg(feature = "offline-sync")]

--- a/autumn/tests/integration/model_field_attrs.rs
+++ b/autumn/tests/integration/model_field_attrs.rs
@@ -153,6 +153,8 @@ fn normalize_is_idempotent() {
         n.normalize();
         n
     };
+    assert_eq!(once.bio, twice.bio, "strip_nul is idempotent (#2423)");
+    assert_eq!(once.bio, "xy");
     assert_eq!(once.email, twice.email);
     assert_eq!(once.display_name, twice.display_name);
     assert_eq!(twice.email, "foo@x.com");

--- a/autumn/tests/integration/model_field_attrs.rs
+++ b/autumn/tests/integration/model_field_attrs.rs
@@ -20,6 +20,7 @@ diesel::table! {
         email -> Text,
         password_hash -> Text,
         display_name -> Text,
+        bio -> Text,
     }
 }
 
@@ -33,6 +34,11 @@ pub struct Account {
     pub password_hash: String,
     #[normalize(squish)]
     pub display_name: String,
+    // #2423: a free-text column fed by paste-prone input. Postgres cannot
+    // store `0x00` in a TEXT column, so the byte is dropped on the way in
+    // rather than failing the write.
+    #[normalize(strip_nul)]
+    pub bio: String,
 }
 
 // ── #1374: `#[private]` hides a column from JSON ─────────────────────────
@@ -44,6 +50,7 @@ fn private_column_is_absent_from_json() {
         email: "user@example.com".into(),
         password_hash: "argon2-super-secret".into(),
         display_name: "Ada".into(),
+        bio: "Countess of Lovelace".into(),
     };
     let value = serde_json::to_value(&account).unwrap();
     let obj = value.as_object().unwrap();
@@ -72,9 +79,10 @@ fn private_column_still_deserializes_and_writes() {
         email: "x@y.com".into(),
         password_hash: "hash-to-store".into(),
         display_name: "Grace".into(),
+        bio: "Rear Admiral".into(),
     };
     // Deserialize round-trip into the query struct still accepts the field.
-    let json = r#"{"id":1,"email":"x@y.com","password_hash":"h","display_name":"g"}"#;
+    let json = r#"{"id":1,"email":"x@y.com","password_hash":"h","display_name":"g","bio":"b"}"#;
     let decoded: Account = serde_json::from_str(json).unwrap();
     assert_eq!(decoded.password_hash, "h");
     assert_eq!(new.password_hash, "hash-to-store");
@@ -104,10 +112,12 @@ fn normalize_runs_on_the_write_struct() {
         email: "  Foo@X.COM ".into(),
         password_hash: "h".into(),
         display_name: "  Grace   Hopper  ".into(),
+        bio: "before\u{0}after".into(),
     };
     new.normalize();
     assert_eq!(new.email, "foo@x.com", "trim+downcase on write");
     assert_eq!(new.display_name, "Grace Hopper", "squish on write");
+    assert_eq!(new.bio, "beforeafter", "strip_nul on write (#2423)");
 }
 
 #[test]
@@ -133,6 +143,7 @@ fn normalize_is_idempotent() {
             email: "  Foo@X.COM ".into(),
             password_hash: "h".into(),
             display_name: "  a   b ".into(),
+            bio: "x\u{0}y".into(),
         };
         n.normalize();
         n

--- a/autumn/tests/integration/nul_byte_input.rs
+++ b/autumn/tests/integration/nul_byte_input.rs
@@ -111,7 +111,7 @@ async fn clean_post_body_is_still_accepted() {
 /// Everything the form extractor never sees — a JSON API body, a hand-written
 /// query, a background job — still reaches Postgres raw. There the rejection
 /// is classified rather than blanket-500'd.
-#[cfg(all(feature = "db", any(feature = "test-support", test)))]
+#[cfg(feature = "db")]
 mod docker {
     use autumn_web::error::{AutumnError, is_nul_byte_violation};
     use autumn_web::reexports::axum::http::StatusCode;
@@ -143,6 +143,16 @@ mod docker {
         (container, pool)
     }
 
+    /// Insert `body` the way an ordinary handler would — `?` on the diesel
+    /// result, so the conversion under test is the blanket `From` impl.
+    async fn insert(conn: &mut AsyncPgConnection, body: &str) -> Result<(), AutumnError> {
+        diesel::sql_query("INSERT INTO nul_test (body) VALUES ($1)")
+            .bind::<diesel::sql_types::Text, _>(body)
+            .execute(conn)
+            .await?;
+        Ok(())
+    }
+
     /// A real `INSERT` of a NUL-bearing `String` into a `TEXT` column: the
     /// server raises SQLSTATE `22021`, and the `?`-converted `AutumnError`
     /// carries `422`, not the `500` reported in #2423.
@@ -158,17 +168,6 @@ mod docker {
         .execute(&mut *conn)
         .await
         .expect("create table");
-
-        async fn insert(
-            conn: &mut AsyncPgConnection,
-            body: &str,
-        ) -> Result<(), autumn_web::error::AutumnError> {
-            diesel::sql_query("INSERT INTO nul_test (body) VALUES ($1)")
-                .bind::<diesel::sql_types::Text, _>(body)
-                .execute(conn)
-                .await?;
-            Ok(())
-        }
 
         // Sanity: the same statement with clean text succeeds, so the failure
         // below is the byte and not the fixture.
@@ -188,6 +187,13 @@ mod docker {
             err.status(),
             StatusCode::UNPROCESSABLE_ENTITY,
             "an embedded NUL is malformed client input, not a server bug"
+        );
+        // ...and the raw server message is not what the client would see: the
+        // 422 error page renders `message` where the 500 page redacts it.
+        assert_eq!(
+            err.to_string(),
+            autumn_web::error::NUL_BYTE_REJECTED_MESSAGE,
+            "the raw Postgres message must not become the client-facing one"
         );
     }
 }

--- a/autumn/tests/integration/nul_byte_input.rs
+++ b/autumn/tests/integration/nul_byte_input.rs
@@ -1,0 +1,193 @@
+//! #2423 — an embedded NUL byte in a form field is client input, not a 500.
+//!
+//! A Postgres `TEXT`/`VARCHAR` column cannot hold `0x00`. Before this suite,
+//! a `%00` in a free-text field decoded cleanly, satisfied every
+//! `#[validate(...)]` rule, and only failed at the Diesel→Postgres boundary —
+//! surfacing as an uncaught `AutumnError` and a `500`, which by the
+//! framework's own error-class convention means "server bug" rather than
+//! "malformed client input".
+//!
+//! Two layers are covered here, from the outside in:
+//!
+//! 1. **The form boundary** (no Docker) — `ChangesetForm` records the NUL as
+//!    an ordinary per-field error, so the handler re-renders the form inline
+//!    with a 4xx exactly as it does for a failed `#[validate(...)]` rule.
+//!    This mirrors the issue's `/submit` shape from `examples/reddit-clone`.
+//! 2. **The database boundary** (Docker) — for the paths no form extractor
+//!    sees (JSON APIs, hand-written queries), a real Postgres rejection is
+//!    classified as `422 Unprocessable Entity` instead of `500`.
+//!
+//! ```text
+//! cargo test -p autumn-web --test integration_tests nul_byte_input
+//! cargo test -p autumn-web --test integration_tests nul_byte_input -- --ignored
+//! ```
+
+use autumn_web::form::{ChangesetForm, NUL_CHARACTER_FIELD_ERROR};
+use autumn_web::reexports::axum::body::Body;
+use autumn_web::reexports::axum::http::{Request, StatusCode};
+use autumn_web::reexports::axum::response::IntoResponse;
+use autumn_web::reexports::axum::routing::post;
+use autumn_web::reexports::axum::{Router, response::Response};
+use tower::ServiceExt as _;
+
+/// The issue's form, reduced to the fields that matter: a validated `title`
+/// and a free-text Markdown `body` with no rules of its own — the exact shape
+/// that let a NUL through untouched.
+#[derive(serde::Deserialize, serde::Serialize, validator::Validate)]
+struct SubmitPostForm {
+    #[validate(length(min = 1, max = 300, message = "Title must be 1-300 characters"))]
+    title: String,
+    #[serde(default)]
+    body: String,
+}
+
+/// Stands in for `examples/reddit-clone`'s `submit`: valid input is written,
+/// a rejected changeset is re-rendered with a 422 and the author's text.
+async fn submit(form: ChangesetForm<SubmitPostForm>) -> Response {
+    match form.into_valid() {
+        Ok(valid) => (StatusCode::OK, format!("stored:{}", valid.body)).into_response(),
+        Err(rejected) => (
+            StatusCode::UNPROCESSABLE_ENTITY,
+            format!(
+                "rejected:{}:{}",
+                rejected.errors_for("body").join("|"),
+                rejected.field_value("body").unwrap_or_default()
+            ),
+        )
+            .into_response(),
+    }
+}
+
+fn urlencoded(body: &'static str) -> Request<Body> {
+    Request::builder()
+        .method("POST")
+        .uri("/submit")
+        .header("Content-Type", "application/x-www-form-urlencoded")
+        .body(Body::from(body))
+        .expect("build request")
+}
+
+async fn body_text(resp: Response) -> String {
+    let bytes = autumn_web::reexports::axum::body::to_bytes(resp.into_body(), usize::MAX)
+        .await
+        .expect("read body");
+    String::from_utf8(bytes.to_vec()).expect("utf-8 body")
+}
+
+/// The reported repro, end to end at the HTTP boundary: `body=before%00after`
+/// used to be a 500; it is now the documented `ChangesetForm` round-trip —
+/// a 422 carrying one inline message and the author's surviving text.
+#[tokio::test]
+async fn nul_byte_in_post_body_is_a_422_round_trip_not_a_500() {
+    let resp = Router::new()
+        .route("/submit", post(submit))
+        .oneshot(urlencoded("title=nul-test&body=before%00after"))
+        .await
+        .expect("router response");
+
+    assert_eq!(resp.status(), StatusCode::UNPROCESSABLE_ENTITY);
+    assert_eq!(
+        body_text(resp).await,
+        format!("rejected:{NUL_CHARACTER_FIELD_ERROR}:beforeafter")
+    );
+}
+
+/// The same request without the NUL still succeeds — the guard adds no
+/// false positives to an ordinary submission.
+#[tokio::test]
+async fn clean_post_body_is_still_accepted() {
+    let resp = Router::new()
+        .route("/submit", post(submit))
+        .oneshot(urlencoded("title=nul-test&body=beforeafter"))
+        .await
+        .expect("router response");
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    assert_eq!(body_text(resp).await, "stored:beforeafter");
+}
+
+// ── The database backstop (requires Docker) ─────────────────────────────────
+
+/// Everything the form extractor never sees — a JSON API body, a hand-written
+/// query, a background job — still reaches Postgres raw. There the rejection
+/// is classified rather than blanket-500'd.
+#[cfg(all(feature = "db", any(feature = "test-support", test)))]
+mod docker {
+    use autumn_web::error::{AutumnError, is_nul_byte_violation};
+    use autumn_web::reexports::axum::http::StatusCode;
+    use diesel_async::pooled_connection::AsyncDieselConnectionManager;
+    use diesel_async::pooled_connection::deadpool::Pool;
+    use diesel_async::{AsyncPgConnection, RunQueryDsl};
+    use testcontainers::runners::AsyncRunner;
+    use testcontainers_modules::postgres::Postgres;
+
+    async fn start_postgres() -> (
+        testcontainers::ContainerAsync<Postgres>,
+        Pool<AsyncPgConnection>,
+    ) {
+        let container = Postgres::default()
+            .start()
+            .await
+            .expect("start Postgres container");
+        let host = container.get_host().await.expect("container host");
+        let port = container
+            .get_host_port_ipv4(5432)
+            .await
+            .expect("container port");
+        let url = format!("postgres://postgres:postgres@{host}:{port}/postgres");
+        let manager = AsyncDieselConnectionManager::<AsyncPgConnection>::new(url);
+        let pool = Pool::builder(manager)
+            .max_size(2)
+            .build()
+            .expect("build pool");
+        (container, pool)
+    }
+
+    /// A real `INSERT` of a NUL-bearing `String` into a `TEXT` column: the
+    /// server raises SQLSTATE `22021`, and the `?`-converted `AutumnError`
+    /// carries `422`, not the `500` reported in #2423.
+    #[tokio::test]
+    #[ignore = "requires Docker (testcontainers)"]
+    async fn real_pg_nul_byte_insert_is_422_not_500() {
+        let (_container, pool) = start_postgres().await;
+        let mut conn = pool.get().await.expect("get connection");
+
+        diesel::sql_query(
+            "CREATE TABLE IF NOT EXISTS nul_test (id BIGSERIAL PRIMARY KEY, body TEXT NOT NULL)",
+        )
+        .execute(&mut *conn)
+        .await
+        .expect("create table");
+
+        async fn insert(
+            conn: &mut AsyncPgConnection,
+            body: &str,
+        ) -> Result<(), autumn_web::error::AutumnError> {
+            diesel::sql_query("INSERT INTO nul_test (body) VALUES ($1)")
+                .bind::<diesel::sql_types::Text, _>(body)
+                .execute(conn)
+                .await?;
+            Ok(())
+        }
+
+        // Sanity: the same statement with clean text succeeds, so the failure
+        // below is the byte and not the fixture.
+        insert(&mut conn, "beforeafter")
+            .await
+            .expect("clean insert should succeed");
+
+        let err: AutumnError = insert(&mut conn, "before\u{0}after")
+            .await
+            .expect_err("Postgres must reject an embedded NUL in a TEXT column");
+
+        assert!(
+            is_nul_byte_violation(&err),
+            "expected the NUL-byte classification, got: {err}"
+        );
+        assert_eq!(
+            err.status(),
+            StatusCode::UNPROCESSABLE_ENTITY,
+            "an embedded NUL is malformed client input, not a server bug"
+        );
+    }
+}

--- a/docs/guide/forms.md
+++ b/docs/guide/forms.md
@@ -331,6 +331,7 @@ Built-in normalizers, applied **left to right in the order you write them**:
 | `downcase` | lowercase |
 | `upcase` | uppercase |
 | `squish` | trim, and collapse every internal run of whitespace to one space |
+| `strip_nul` | remove every NUL (`U+0000`) — see [Unstorable bytes](#unstorable-bytes-nul) |
 | `with = path::to::fn` | your own `fn(&str) -> String` |
 
 All the built-ins are **idempotent** — normalizing an already-normal value
@@ -413,6 +414,92 @@ this attribute exists to remove.
   they cannot see inside a per-locale column set.
 - **It does not rewrite history.** Adding `#[normalize]` to an existing column
   canonicalizes future writes only. Backfill existing rows with a migration.
+
+---
+
+## Unstorable bytes: NUL
+
+A Postgres `TEXT` or `VARCHAR` column cannot hold a NUL byte (`0x00`). This is
+not a length or a format rule that `#[validate(...)]` could express — the value
+is a perfectly good Rust `String`, and every validator you can write on it
+passes. It fails much later, when the driver hands the byte to the server, which
+answers `invalid byte sequence for encoding "UTF8": 0x00`.
+
+A real user can produce one without trying: a paste from a binary source, a
+misbehaving input method, a clipboard glitch. So this is a robustness question,
+not only an adversarial one.
+
+The framework handles it at the form boundary. `ChangesetForm` and
+`NestedChangesetForm` sweep every submitted **text** value before it is
+deserialized, and a field that carried a NUL gets an ordinary error:
+
+```text
+Cannot contain the NUL character (0x00)
+```
+
+The message is available as `autumn_web::form::NUL_CHARACTER_FIELD_ERROR`.
+Nothing in your handler changes — it is a field error like any other, so the
+form re-renders inline with your existing `errors_for(...)` markup and whatever
+4xx you already return for a rejected changeset. The retained value is the
+author's text with the byte removed, so the re-rendered form keeps their work
+(and never echoes a raw `0x00` back into the HTML), and their next submission
+succeeds.
+
+Framework plumbing fields are deliberately exempt — the CSRF token, the submit
+token, and the `_method` override. None is a form field any template renders, so
+an error keyed under one would leave the form invalid with nothing on screen to
+explain why, and none is ever written to a column. Each is still rejected on its
+own terms when malformed: `CsrfLayer` and the submit-token guard for the tokens,
+"not a known verb" for the override.
+
+An *unknown* key is not exempt. A submitted name that is not a field of your
+form type is normally ignored, but if it carries a NUL it is still reported —
+under that name. `error_summary` renders it; a hand-written `errors_for("...")`
+per field will not, so a form built that way rejects the submission with no
+visible message. In practice that takes a hand-crafted request: the values your
+own templates emit for non-form fields are server-generated, not pasted.
+
+File parts of a `multipart/form-data` body are untouched — binary uploads are
+supposed to contain arbitrary bytes.
+
+### The paths no form extractor sees
+
+A JSON API body, a hand-written query, a background job argument: these reach
+the database without passing a form extractor, so the byte still gets there. It
+is classified rather than blanket-500'd — the resulting `AutumnError` carries
+`422 Unprocessable Entity`, matching the status a validator would have produced,
+and `autumn_web::error::is_nul_byte_violation` recognizes it if you want to fold
+it back into a form:
+
+```rust,ignore
+if let Err(err) = repo.save(&new_post).await
+    && is_nul_byte_violation(&err)
+{
+    changeset.add_error("body", NUL_CHARACTER_FIELD_ERROR);
+    return Ok(render_rejected(changeset));
+}
+```
+
+This is a backstop, not the mechanism: rejecting at the form boundary is what
+gives the author something actionable.
+
+### When you would rather clean than reject
+
+On a column fed by paste-prone input, where dropping the byte silently is
+better than refusing the write, use the normalizer:
+
+```rust,ignore
+#[model]
+pub struct Profile {
+    #[normalize(strip_nul)]
+    pub bio: String,
+}
+```
+
+Prefer rejecting wherever the author can see and fix the value — they get told
+what happened instead of having their input quietly altered. `strip_nul` removes
+only NUL; every other control character is storable and is left exactly as
+written.
 
 ---
 

--- a/docs/guide/forms.md
+++ b/docs/guide/forms.md
@@ -429,9 +429,10 @@ A real user can produce one without trying: a paste from a binary source, a
 misbehaving input method, a clipboard glitch. So this is a robustness question,
 not only an adversarial one.
 
-The framework handles it at the form boundary. `ChangesetForm` and
-`NestedChangesetForm` sweep every submitted **text** value before it is
-deserialized, and a field that carried a NUL gets an ordinary error:
+The framework handles it at the form boundary. The two extractors built for
+form round-trips — `ChangesetForm` and `NestedChangesetForm` — sweep every
+submitted **text** value before it is deserialized, and a field that carried a
+NUL gets an ordinary error:
 
 ```text
 Cannot contain the NUL character (0x00)
@@ -446,30 +447,40 @@ author's text with the byte removed, so the re-rendered form keeps their work
 succeeds.
 
 Framework plumbing fields are deliberately exempt — the CSRF token, the submit
-token, and the `_method` override. None is a form field any template renders, so
-an error keyed under one would leave the form invalid with nothing on screen to
-explain why, and none is ever written to a column. Each is still rejected on its
-own terms when malformed: `CsrfLayer` and the submit-token guard for the tokens,
-"not a known verb" for the override.
+token, and the `_method` override, under both their default names and whatever
+name you configured. None is a form field any template renders, so an error
+keyed under one would leave the form invalid with nothing on screen to explain
+why, and none is ever written to a column. Nothing about their own handling
+changes either: each is read from the raw body by its middleware, before any
+extractor runs, so a NUL-mangled `_csrf` is still a 403 and a NUL-mangled
+`_method` is still a 400. (A mangled `_submit_token` is not rejected — it simply
+matches no stored token and loses its at-most-once protection, exactly as it
+would have before.)
+
+`_destroy` on a nested child row is exempt for a different reason: it is read
+only for truthiness, and cleaning it would *change* it — `1\0` is falsy today
+and would become truthy — so the sweep leaves it alone entirely.
 
 An *unknown* key is not exempt. A submitted name that is not a field of your
 form type is normally ignored, but if it carries a NUL it is still reported —
-under that name. `error_summary` renders it; a hand-written `errors_for("...")`
-per field will not, so a form built that way rejects the submission with no
-visible message. In practice that takes a hand-crafted request: the values your
-own templates emit for non-form fields are server-generated, not pasted.
+under that name. Since no template renders that name, the submission is
+rejected with no message next to any input; `error_summary` will show the
+message, but without saying which input it belongs to. In practice that takes a
+hand-crafted request: the values your own templates emit for non-form fields
+are server-generated, not pasted.
 
 File parts of a `multipart/form-data` body are untouched — binary uploads are
 supposed to contain arbitrary bytes.
 
 ### The paths no form extractor sees
 
-A JSON API body, a hand-written query, a background job argument: these reach
-the database without passing a form extractor, so the byte still gets there. It
-is classified rather than blanket-500'd — the resulting `AutumnError` carries
-`422 Unprocessable Entity`, matching the status a validator would have produced,
-and `autumn_web::error::is_nul_byte_violation` recognizes it if you want to fold
-it back into a form:
+A JSON API body, a hand-written query, a background job argument, an
+`autumn_web::extract::Form` or `Valid<T>` extraction: these reach the database
+without passing one of the two round-trip extractors, so the byte still gets
+there. It is classified rather than blanket-500'd — the resulting `AutumnError`
+carries `422 Unprocessable Entity`, matching the status a validator would have
+produced, and `autumn_web::error::is_nul_byte_violation` recognizes it if you
+want to fold it back into a form:
 
 ```rust,ignore
 if let Err(err) = repo.save(&new_post).await
@@ -481,7 +492,12 @@ if let Err(err) = repo.save(&new_post).await
 ```
 
 This is a backstop, not the mechanism: rejecting at the form boundary is what
-gives the author something actionable.
+gives the author something actionable. Two limits come with that. The 422 names
+no field — nothing at the database boundary knows which one the byte came from,
+so `errors` is empty unless you fold it in yourself as above. And classification
+is by server message, anchored on the `: 0x00` the encoding rejection ends with;
+a NUL smuggled into a `JSONB` column fails with a different message entirely
+(`unsupported Unicode escape sequence`, SQLSTATE `22P05`) and is not classified.
 
 ### When you would rather clean than reject
 
@@ -500,6 +516,18 @@ Prefer rejecting wherever the author can see and fix the value — they get told
 what happened instead of having their input quietly altered. `strip_nul` removes
 only NUL; every other control character is storable and is left exactly as
 written.
+
+**It covers inserts and hooked updates only.** Per [Updates are not the same as
+inserts](#updates-are-not-the-same-as-inserts), a repository with no hooks, or
+one using `validate_on_update = fetch`, persists the raw patch and throws the
+normalized draft away — so an `update` through either of those still sends the
+NUL to Postgres and still fails the write, now as a 422 rather than a 500.
+
+The message is a fixed English string. Unlike a scaffold's `common.error.taken`,
+it is recorded inside the extractor, before any handler holds a `Locale`, so
+there is nowhere to look up a translation. A localized app that needs a
+localized message can rewrite it from the handler by matching
+`NUL_CHARACTER_FIELD_ERROR` in `changeset.errors()`.
 
 ---
 

--- a/docs/guide/macro-transparency.md
+++ b/docs/guide/macro-transparency.md
@@ -605,10 +605,10 @@ saying why. A `#[repository]` recording version history or a ledger serializes
 the whole model, which a classified model cannot do; gating those sinks is a
 follow-up slice. See [Data Classification](./data-classification.md).
 
-#### `#[normalize(trim, downcase, upcase, squish, with = path)]`
+#### `#[normalize(trim, downcase, upcase, squish, strip_nul, with = path)]`
 
 Runs an ordered normalizer chain over the owned `String` before every insert
-and update. Built-ins (`trim`, `downcase`, `upcase`, `squish`) are
+and update. Built-ins (`trim`, `downcase`, `upcase`, `squish`, `strip_nul`) are
 `fn(&str) -> String` in `autumn_web::normalize`; `with = path` calls your own
 function with the same signature. Normalizers apply left-to-right.
 

--- a/examples/reddit-clone/src/routes/posts.rs
+++ b/examples/reddit-clone/src/routes/posts.rs
@@ -1625,6 +1625,55 @@ mod tests {
         );
     }
 
+    // ── #2423: a NUL byte is an inline field error, not a 500 ──────
+
+    /// The reported repro, on the reported form: `body=before%00after` used to
+    /// decode cleanly, pass every `#[validate(...)]` rule on `SubmitPostForm`,
+    /// and fail only when Diesel handed the byte to Postgres — an unhandled
+    /// 500. It is now an ordinary field error, so `submit` takes its existing
+    /// 422 re-render branch with no change to this route.
+    #[tokio::test]
+    async fn a_nul_byte_in_the_body_is_an_inline_field_error() {
+        use autumn_web::form::NUL_CHARACTER_FIELD_ERROR;
+        use autumn_web::reexports::axum::body::Body;
+        use autumn_web::reexports::axum::extract::FromRequest as _;
+
+        let req = http::Request::builder()
+            .method("POST")
+            .uri(paths::submit())
+            .header("Content-Type", "application/x-www-form-urlencoded")
+            .body(Body::from(
+                "title=nul-test&url=&subreddit_id=1&body=before%00after",
+            ))
+            .expect("build request");
+
+        let form = ChangesetForm::<SubmitPostForm>::from_request(req, &())
+            .await
+            .expect("the body still decodes — this is a validation failure, not a 400");
+
+        // Rejected, so `submit`'s `form.into_valid()` takes the 422 branch...
+        assert!(!form.is_valid());
+        assert_eq!(form.errors_for("body"), [NUL_CHARACTER_FIELD_ERROR]);
+        // ...and only the field that carried the byte is flagged.
+        assert!(form.errors_for("title").is_empty());
+
+        // The re-rendered form carries the message inline and keeps the
+        // author's text, minus the byte it could never have stored.
+        let rendered = submit_form_markup(&form, &[], None).into_string();
+        assert!(
+            rendered.contains("Cannot contain the NUL character"),
+            "the message must render next to the field; rendered: {rendered}"
+        );
+        assert!(
+            rendered.contains("beforeafter"),
+            "the author's text must survive the round-trip; rendered: {rendered}"
+        );
+        assert!(
+            !rendered.contains('\u{0}'),
+            "a raw NUL must never be echoed back into the HTML"
+        );
+    }
+
     // ── Typed a11y form primitives (#1706) ─────────────────────────
 
     fn blank_submit_form() -> ChangesetForm<SubmitPostForm> {

--- a/skills/autumn-web/references/api-reference.md
+++ b/skills/autumn-web/references/api-reference.md
@@ -289,10 +289,10 @@ from -> to: "guard", ...))]` field attribute on `String` fields, generating
   `classify::manifest::ClassifiedFieldDescriptor` inventory registration, and
   `Model::__AUTUMN_CLASSIFIED_COLUMNS`. `autumn data-flow` emits the manifest.
   See `docs/guide/data-classification.md`.
-- `#[normalize(trim, downcase, upcase, squish, with = path::to::fn)]` (issue
+- `#[normalize(trim, downcase, upcase, squish, strip_nul, with = path::to::fn)]` (issue
   #1379) — canonicalizes a `String` column, composing normalizers
   left-to-right. Built-ins live in `autumn_web::normalize`
-  (`trim`/`downcase`/`upcase`/`squish`); `with = path` calls a user
+  (`trim`/`downcase`/`upcase`/`squish`/`strip_nul`); `with = path` calls a user
   `fn(&str) -> String`. Runs on the **write** path (`save`/`save_many` insert;
   `update` via `UpdateDraft::from_patch`) *before* the `before_create` /
   `before_update` hooks and the DB write, and on derived `#[repository]`


### PR DESCRIPTION
Fixes #2423.

> **Note on the base branch:** this PR was originally opened against `trunk` by mistake — the branch is cut from `trunk-dev`, so GitHub was computing the diff from the wrong merge base and showing 46 commits / 468 files. Retargeted to `trunk-dev`; the diff below is the real one. Any review from before that point was reading the inflated diff.

## The bug

A Postgres `TEXT`/`VARCHAR` column cannot hold `0x00`, but nothing between the form body and the `INSERT` could say so. An embedded NUL decoded cleanly, satisfied every `#[validate(...)]` rule — the value is a perfectly good Rust `String` — and failed only when the driver handed the byte to the server:

```
invalid byte sequence for encoding "UTF8": 0x00
```

That surfaced as an uncaught `AutumnError` and a `500`. By the framework's own error-class convention a `5xx` means a server bug, when this is malformed client input a real user can produce by pasting from a binary source.

## The fix

**Catch it at the form boundary**, which is the only point where the offending field is still identifiable by name — after `serde` has built `T` the bytes are just some `String` field among others.

`ChangesetForm` and `NestedChangesetForm` sweep every submitted **text** value before deserialization and record `NUL_CHARACTER_FIELD_ERROR` against the field (or child subfield) that carried one. Handlers need no change — it is an ordinary field error, so the form re-renders inline through the existing round-trip, and `examples/reddit-clone`'s `/submit` needed no edit at all. The retained value is the author's text minus the byte, so their work survives, no raw `0x00` is echoed into the HTML, and the next submission succeeds.

Framework plumbing fields are exempt under both their default and configured names — `_csrf`, `_submit_token`, `_method`, and a nested row's `_destroy`. No template renders an error against one, and cleaning `_destroy` would flip a falsy marker truthy. A row the author marked for destruction is never rejected, since it is never written. File parts of a multipart body are untouched.

**Back it at the database boundary** for the paths no form extractor sees — a JSON API body, a hand-written query, a job. The Postgres rejection now yields `422` rather than `500`, and `error::is_nul_byte_violation` recognizes it through the `source()` chain for handlers that want to fold it into a form the way `unique_violation_field` is used for a uniqueness clash.

Two details that matter there:

- Classification is by **server message**, not SQLSTATE, because `diesel-async`'s `pg/error_helper.rs` maps `22021` to `DatabaseErrorKind::Unknown` and keeps no copy of the code. The match is **anchored** on the trailing `: 0x00` plus the encoding name — Postgres echoes submitted text into the primary message of *other* errors, so an unanchored substring search would let a client spell the pattern in its own input and relabel a genuine server fault as its own, hiding it from 5xx alerting.
- The error is **re-wrapped**, not merely re-statused: `render_422` renders `message` verbatim where `render_500` deliberately redacts it, so downgrading alone would put a raw database message on a user-facing page. The client sees a fixed sentence; the original stays in the `source()` chain for logs.

Also new: `Changeset::add_error`, `normalize::strip_nul` and `#[normalize(strip_nul)]` for columns where dropping the byte silently beats refusing the write.

## How it was built

Red → green → refactor throughout. Every behavioural test was written first and observed failing on assertions (not just on compilation) before the corresponding production code existed — the symbols were stubbed in deliberately so the tests would discriminate rather than merely fail to build.

Then four reviewers went over it from different angles (security, correctness, API design, test quality). Their findings are fixed in the second commit and are worth reading in its message: a quadratic sweep reachable from any form POST, the raw-message disclosure above, the client-spellable classifier, `_submit_token` documented exempt but not exempt on the flat path, `_destroy` truthiness, a silently-vanishing row, a displaced rustdoc block, and a predicate that could disagree with the status the `From` impl chose.

Codex then reviewed three times. Round 2 found two further P2s in the nested path, both real and both fixed in `5a9e7ba` — a destroyed row that could no longer be destroyed (the NUL rejection ran ahead of the `destroy` check, so `into_valid()` failed on a row the author had asked to delete and could not edit into validity), and per-row offenders collected without deduplication, unlike the flat sweep, so a repeated subfield inflated one row's error list per submitted pair. Round 3 came back clean.

## Acceptance criteria

The issue is a bug report rather than a spec, so these are drawn from its **Oracle** and **Impact** sections.

| # | Criterion (from the issue) | Evidence |
|---|---|---|
| 1 | The repro (`body=before%00after`) no longer returns `500` | `nul_byte_in_post_body_is_a_422_round_trip_not_a_500` asserts `422` at the HTTP boundary |
| 2 | It is caught by the framework and re-rendered as an **inline** `4xx` validation error, per `docs/guide/forms.md`'s `ChangesetForm` round-trip | `a_nul_byte_in_the_body_is_an_inline_field_error` drives the real `SubmitPostForm` through the real extractor and asserts the message renders inline in the real `submit_form_markup`, the author's text survives, and no raw `0x00` is echoed |
| 3 | The NUL is caught **before** the Diesel→Postgres boundary, where the issue says `#[validate(...)]` had already passed | The sweep runs in `decode_form_body` before deserialization; `nul_byte_in_text_field_is_a_field_error` and the nested-path equivalents pin it |
| 4 | The framework does not silently mutate the submission | The byte is stripped only for redisplay and the write is refused — `nul_byte_is_stripped_from_the_redisplayed_value` plus `nul_byte_in_a_child_subfield_blocks_into_valid` |
| 5 | Generalizes beyond the one example route ("plausible this reaches beyond… I only verified it here") | Fixed in the framework, not the example: flat + nested extractors, urlencoded + multipart, plus the DB backstop for JSON/query/job paths. `real_pg_nul_byte_insert_is_422_not_500` proves the backstop against a real Postgres container |
| 6 | Production behavior stays non-disclosing (the issue notes the raw message is dev-only today) | `the_raw_postgres_message_is_not_the_client_facing_message` — the 422 would otherwise have *started* showing it, since `render_422` renders `message` where `render_500` redacts |
| 7 | No process crash; `/health` unaffected | Unchanged — no panic path added; the change is confined to decode-time classification. Already true in the report and preserved |

Gaps found while doing this and **not** closed here are filed as #2439 rather than left silent, and are written into `docs/guide/forms.md` so nobody discovers them the hard way: the generated API `422` names no field, `JSONB` fails with a different SQLSTATE (`22P05`), and the message is not localizable. #2445 is a separate pre-existing bug the Codex review surfaced in the capacity-contract workflow, outside this diff.

## Verification

Run on `5a9e7ba`, the current head:

- `cargo test -p autumn-web --lib --features multipart -- nul strip_nul` → 44 passed
- `cargo test -p autumn-web --test integration_tests -- nul_byte_input model_field_attrs` → 8 passed, 1 ignored (the Docker test, which CI's `--ignored` sweep picks up with no workflow edit)
- `cargo test -p reddit-clone --lib -- a_nul_byte` → 1 passed
- `cargo clippy --all-targets -- -D warnings` clean on `autumn-web`, `reddit-clone`, `autumn-macros`; `cargo fmt --all -- --check` clean; `cargo test -p autumn-web --doc` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B8RQZ9mPq1BBtbCeFnbnLd