### PR TITLE
docs(reports): bisect #2309 fix's cold-start shortfall (undetermined)

### DIFF
--- a/docs/reports/2026-09-03-prospect-cold-start-post-fix-bisect.md
+++ b/docs/reports/2026-09-03-prospect-cold-start-post-fix-bisect.md
@@ -555,8 +555,13 @@ calibrated noise floor in hand:**
 ## 🏁 Verdict
 
 **Undetermined** on the pre-registered falsifiable question specifically
-(*does a single commit explain the shortfall?* — no), but **not** for the
-reason the immediately preceding revision of this section gave. This
+(*does a single commit explain the shortfall?* — **unknown**, not "no":
+this report never disproved the specific-commit hypothesis, it only
+found that no candidate clears a confidence bar this apparatus's own
+noise floor was never rigorously established — a materially weaker,
+still-open claim, corrected here after an earlier revision of this
+sentence stated a flat "no"), but **not** for the reason the immediately
+preceding revision of this section gave. This
 report went through four revisions before landing here, each one caught
 by a different Codex review finding on PR #2477 — worth stating plainly
 rather than only keeping the final number, since the corrections mostly

--- a/docs/reports/2026-09-03-prospect-cold-start-post-fix-bisect.md
+++ b/docs/reports/2026-09-03-prospect-cold-start-post-fix-bisect.md
@@ -1,0 +1,135 @@
+# ⛏️ Prospect: which post-#2309-fix commit ate the missing cold-start savings? (TBD)
+
+## 🎯 Question
+
+The 2026-09-02 verification assay (`docs/reports/2026-09-02-prospect-cold-start-db-gate-verify.md`,
+PR #2434) confirmed PR #2360's `db`-feature-gate fix for issue #2309 is real
+at the crate level (`autumn-macros` self-compile: 54.8s → 3.34s with `db`
+off, ~94%) and at the controlled binary level (PR #2360's own same-box A/B:
+136,594ms → 90,846ms, -33%), but found the real CI trajectory only moved
+120,422ms → 105,371ms (-12.5%) across the same before/after commits
+(`d1ecb361` → `ef61ae44`). That assay explicitly left the gap unexplained
+and named it a follow-up: *"a `cargo build --timings` bisection over the
+full comparison interval... is the follow-up, not this verification."* It
+also named three commits as candidates "because they touch default
+features/deps in that window" — but that list turns out to be wrong: one of
+the three (`1fd6245`, Ledgered entities) is **not even an ancestor of
+`ef61ae44`** (`git merge-base --is-ancestor 1fd6245 ef61ae44` fails), so it
+cannot be part of this window's compile-time delta at all. This assay
+corrects that and re-derives the real commit set.
+
+**Falsifiable question:** among the commits actually in `d1ecb361..ef61ae44`
+(12 commits, verified below), does any single non-fix commit measurably add
+compile-time weight to the no-DB daemon feature set (`autumn-web
+--no-default-features --features maud,htmx,tailwind,cache-moka,http-client,reporting`,
+i.e. exactly `DAEMON_NO_DB_FEATURES` from `autumn-cli/src/new.rs`) — enough
+to plausibly account for a material share of the ~15,051ms shortfall between
+the fix's own confirmed relative saving and the real CI trajectory? Or does
+no single commit explain it, meaning the shortfall is better attributed to
+statistical/runner noise (CI's 3-sample p95 vs PR #2360's 1-sample local A/B,
+different runners, a week apart) rather than to a specific regression?
+
+**Decision:** whether issue #2309 needs a second, narrowly-scoped follow-up
+PR (revert or feature-gate whatever commit is found responsible) versus
+whether the issue can stay open purely as a "budget was never realistic for
+this dependency graph" tracking item with no further code archaeology
+warranted. **Decider:** repo maintainer (same as the parent assay — issue
+#2309 has no other owner).
+
+## ⚖️ Pre-registration
+
+Committed in this same commit, before any timed build runs.
+
+- **Actual window** (superseding the parent report's unverified guess),
+  oldest → newest, confirmed via `git log --oneline d1ecb361..ef61ae44` and
+  `git merge-base --is-ancestor`:
+  `61bdd9c` (Web Push, #2334) → `28c6fae` (scaffold reconciliation, #2340) →
+  `651929b` (**the #2309 fix itself**, #2360) → `d6aa668` (admin
+  impersonation, #2339) → `97a97be` (replay capsule seams, #2348) →
+  `d96cfab` (cached-read staleness proof, #2352) → `fec5221` (zero-downtime
+  state migration, #2345) → `8f94e60` (CI-only: clippy parallelism, #2361)
+  → `76c56b1` (docs/routing example, #2341) → `9c1ede1` (db scrub, #2365) →
+  `f15ca1b` (classified-data compile-time proof, #2367) → `ef61ae4` (Bolt
+  form-field escaping, #2376 — the post-fix CI-measured commit itself).
+- **Pursue-bisection-further line:** a single commit's isolated build delta
+  (vs. the immediately preceding checkpoint, same feature set, same warmed
+  target dir) is ≥ 5,000ms — large enough to plausibly be a real,
+  reproducible contributor to the ~15s CI shortfall rather than noise.
+  Report it as the (or a) responsible commit, with the specific dependency
+  or codegen path named from `cargo build --timings` output.
+- **Kill line (for the "specific commit" hypothesis):** no single commit's
+  isolated delta reaches 5,000ms, and the sum of all deltas across the
+  window stays within run-to-run noise of a repeated build at one fixed
+  commit (measured as a same-commit repeat at the final checkpoint). If so,
+  the verdict is that the shortfall is **not** attributable to a specific
+  commit in this window and the parent report's "far less than confirmed"
+  finding stands without a named cause — CI statistical/runner variance is
+  the better explanation, and no further bisection is warranted.
+- **Conditions:** this sandbox (4-core, 15GiB, rustc/cargo 1.94.1 — same
+  environment class as the parent assay's control). A dedicated git
+  worktree, detached at each commit in chronological order. One shared
+  `target/` directory reused across all 12 checkpoints (external
+  dependency compiles stay warm across the waterfall, matching how CI's
+  `Swatinem/rust-cache` persists across weekly runs) — but before every
+  timed build, the workspace-local crates' own fingerprints and incremental
+  artifacts are cleared (`autumn-macros`, `autumn-web`/`autumn`, and any
+  other workspace member whose Cargo.toml changed in that commit), so every
+  timed number reflects a genuine from-scratch rebuild of *this repo's own
+  code* at that commit, never reused workspace-crate object files.
+  `CARGO_INCREMENTAL=0`. Command timed:
+  `cargo build -p autumn-web --no-default-features --features maud,htmx,tailwind,cache-moka,http-client,reporting`
+  (exactly `DAEMON_NO_DB_FEATURES`, joined). One run per checkpoint (12
+  checkpoints, chronological), plus one repeat run at the final checkpoint
+  (`ef61ae4`) to give a same-commit noise floor.
+- **Time box:** same session. Target ≤ 60 minutes of cumulative build
+  wall-clock. If any single checkpoint step exceeds 10 minutes twice in a
+  row, or the cumulative budget is exhausted before reaching `ef61ae4`,
+  stop and report undetermined with the partial waterfall — that is itself
+  a finding (this class of bisection is too expensive to do cheaply on a
+  weekly cadence, which bears on whether it's worth CI ever doing this
+  automatically).
+- **Riskiest assumption tested first:** that the shortfall is explained by
+  *one* commit's dependency-graph change at all, rather than being an
+  artifact of comparing a 1-sample local A/B (PR #2360) against a 3-sample
+  CI p95 on a different runner a week apart (the parent report's own stated
+  caveat). The same-commit repeat run directly tests this: if repeat-run
+  noise at a single fixed commit is itself comparable to the per-commit
+  deltas seen across the window, the whole bisection approach is answering
+  a question noise already explains, and that finding is reported as such.
+- **Containment:** a detached, uncommitted git worktree
+  (`/tmp/prospect-coldstart-wt`) outside the repo's tracked tree; no CI
+  triggered; no changes to `trunk`/`trunk-dev`; this report is the only
+  artifact that lands in the PR.
+
+## 🔍 Prior art
+
+- `docs/reports/2026-09-02-prospect-cold-start-db-gate-verify.md` (PR
+  #2434, merged) — the parent verification assay this one follows up on;
+  confirms the fix works in isolation and names the bisection as the open
+  follow-up.
+- Issue #2309 — root cause, still open, un-recalibrated budget.
+- PR #2360 / `651929b` — the fix itself; its commit message's own A/B
+  number is the "confirmed saving" baseline this assay is trying to
+  reconcile against real CI.
+- No other report or open PR revisits this gap since the 2026-09-02 report
+  merged (checked via `search_pull_requests` for cold-start/bisect terms
+  and by re-reading issue #2309's thread — no new activity).
+
+## 🧪 Apparatus
+
+- One detached git worktree, walked chronologically through the 12 commits
+  above, each timed with the command in **Conditions**.
+- No stubs beyond what the parent assay already used: this measures a
+  library crate's feature-gated build, not a running app — no server is
+  started, no HTTP request is made. That is a deliberate, cheaper proxy for
+  the full `autumn new` cold-start journey (which also includes scaffold
+  templating and the generated app's own thin compile unit) — the parent
+  assay's control used the same proxy for `autumn-macros` alone and it
+  matched the full-journey CI numbers well in direction/magnitude, though
+  not exactly. This assay inherits that same limitation: it can name which
+  commit adds compile weight to `autumn-web`'s no-DB feature set, but a
+  match to the exact CI millisecond figure is not expected or claimed.
+
+## 📊 Assay
+
+_Filled in after runs complete — see the follow-up commit to this file._

--- a/docs/reports/2026-09-03-prospect-cold-start-post-fix-bisect.md
+++ b/docs/reports/2026-09-03-prospect-cold-start-post-fix-bisect.md
@@ -20,10 +20,15 @@ daemon feature set (`autumn-web --no-default-features --features
 maud,htmx,tailwind,cache-moka,http-client,reporting`, i.e. exactly
 `DAEMON_NO_DB_FEATURES` from `autumn-cli/src/new.rs`) — enough to plausibly
 account for a material share of the shortfall between the fix's own
-confirmed relative saving and the real CI trajectory (**corrected figure**,
-see Correction below: **~30,697ms** absolute, or **~21.0 percentage
-points** — not the ~15,051ms this question originally named, which is
-CI's own observed saving, not the gap to explain)? Or does no single
+confirmed relative saving and the real CI trajectory (**correction, see
+below: ~15,051ms is CI's own observed saving, not the gap to explain — but
+the actual gap cannot be stated as a precise millisecond or
+percentage-point figure either**, for the same reason the parent report
+gave: `45,748ms`/`-33%` came from PR #2360's local same-box A/B and
+`15,051ms`/`-12.5%` from GitHub-hosted weekly CI runs — different
+hardware, different workload distribution — so subtracting them doesn't
+produce a real, portable shortfall number, only a directional one: CI
+moved *far less* than the confirmed same-box saving)? Or does no single
 commit explain it, meaning the shortfall is better attributed to
 statistical/runner noise (CI's 3-sample p95 vs PR #2360's 1-sample local
 A/B, different runners, a week apart) rather than to a specific regression?
@@ -126,23 +131,63 @@ is supposed to prevent — so this correction reflects fixing a tooling bug
 discovered *after* results existed, not re-drawing the window to fit them.
 
 **A third, unrelated error in the pre-registration itself** (Codex P2 on
-`e5e6eb56`, independent of the shallow-clone bug above): the
-pre-registration's own "Pursue-bisection-further line" and "Kill line"
-text (blockquoted above, not edited) both call `~15,051ms` "the CI
-shortfall," and this report's Question section repeated that framing. It's
-wrong: `15,051ms` (`120,422−105,371`) is CI's own **observed saving**, not
-the gap between what was confirmed and what CI delivered. The actual gap
-is **~30,697ms** absolute (`45,748ms` confirmed same-box saving minus
-CI's `15,051ms`), or **~21.0 percentage points** (`33.49%` confirmed vs.
-`12.50%` observed) — roughly double what "~15,051ms" suggested. This does
+`e5e6eb56`, corrected further on `39ae17a1` — independent of the
+shallow-clone bug above): the pre-registration's own "Pursue-bisection-
+further line" and "Kill line" text (blockquoted above, not edited) both
+call `~15,051ms` "the CI shortfall," and this report's Question section
+repeated that framing. `15,051ms` (`120,422−105,371`) is CI's own
+**observed saving**, not the gap between what was confirmed and what CI
+delivered — that part of the finding stands. What does **not** stand is
+this report's own first attempt at a fix, which replaced it with an
+equally-precise-sounding `~30,697ms`/`~21.0 percentage points` by directly
+subtracting PR #2360's local same-box A/B from CI's weekly numbers — the
+exact kind of cross-hardware precision the parent report deliberately
+avoided, for the same reason: `45,748ms` and `15,051ms` come from
+different runners with a different workload distribution, so their
+difference isn't a real, portable "shortfall" figure any more than
+`15,051ms` alone was. Corrected a second time in the Question section to
+state this directionally, matching the parent report's own established
+caution, rather than trading one false precision for another. This does
 **not** change the pursue/kill lines themselves (the 5,000ms threshold was
-set independently as "large enough to plausibly be a material single
-contributor," not derived as a fraction of the shortfall figure), so it
-doesn't retroactively invalidate any verdict in this report. It does mean
-the Question section's framing was imprecise about the size of what this
-assay was ultimately trying to explain; corrected there, left unedited in
-the frozen pre-registration blockquote per the same policy as the other
-two corrections above.
+set independently), so it doesn't retroactively invalidate any verdict in
+this report.
+
+**A fourth, more consequential limitation** (Codex P1 on `39ae17a1`): this
+report's entire apparatus reuses one warm `target/` directory across the
+whole chronological walk, clearing only workspace-crate artifacts between
+checkpoints — a deliberate design choice (see Apparatus) to keep external
+dependency compiles warm, matching how CI's `Swatinem/rust-cache` persists
+*something* across weekly runs. But per `autumn-cli/src/cold_start_driver.rs`
+(`compile_cold`, confirmed by reading it directly) and
+`.github/workflows/cold-start-latency.yml`, what the CI gate actually
+measures is different in kind, not just in what it additionally includes:
+**every single CI sample scaffolds a brand-new temp project with its own
+empty `target/`, explicitly removes `CARGO_TARGET_DIR`, and disables
+compiler wrappers — so CI pays the full compile cost of every external
+dependency, from scratch, on every sample, forever.** This report's
+warm-target apparatus pays that cost **at most once**, on whichever
+checkpoint first introduces a given dependency — after that, it's cached
+and invisible in every later delta, even though CI keeps paying it every
+week. `git log --name-only -- Cargo.lock` over this window shows **4 of
+the 31 non-fix commits actually touched `Cargo.lock`**: `fec52215`
+(zero-downtime state migration, this report's second-largest post-fix
+delta at +4,591ms), `61bdd9c2` (Web Push, +1,995ms), `bc99a4b8` (scaffold
+DSL constraints, −733ms), and `141f36ef` (a `base64` patch-version bump,
+−2,518ms, unlikely to matter much on its own). **This report's deltas for
+those four commits cannot be trusted as representative of their true,
+CI-relevant recurring contribution** — the apparatus can only undercount,
+never overcount, a genuine per-dependency cost, since it's structurally
+incapable of showing more than a one-time compile for anything new. It
+also means the "total window effect" and "this proxy's absolute saving vs.
+CI's" comparisons throughout Assay and Verdict are weaker than stated
+there: they are not just measuring a narrower workload (library-only, no
+scaffold/server-start) as already disclosed, but a workload measured under
+a fundamentally warmer caching regime than CI ever runs under. Not
+corrected by re-running (out of this session's time box — a true
+apples-to-apples repeat would need an empty `target/` per checkpoint,
+i.e. 32+ fully cold builds, each potentially 60-120s, a materially larger
+apparatus); flagged here as a limitation this report cannot resolve, and
+carried into the Verdict.
 
 ## 🔍 Prior art
 
@@ -431,12 +476,25 @@ live report needs the map:
   draws is itself around 2.5-2.9σ even under the tight estimate. No
   commit in this dataset clears a confident attribution bar under either
   noise scale.
-- **The residual gap to CI is still unexplained.** This proxy's ≈−13,000ms
-  absolute saving sits close to, but not exactly at, CI's own observed
-  −15,051ms — and this proxy still only measures `autumn-web`'s own
-  compile time, not the full `autumn new → first HTTP 200` journey CI
-  gates on. The parent report's CI/runner-variance confound is also still
-  live and undistinguished from either explanation.
+- **This proxy's ≈−13,000ms is not directly comparable to CI's −15,051ms
+  at all, and this report previously overstated how close a match that
+  was** (Codex P1 on `39ae17a1`). Two compounding reasons, not one: this
+  proxy measures a narrower workload (`autumn-web`'s own compile time,
+  not the full `autumn new → first HTTP 200` journey), already disclosed
+  — but more fundamentally, it measures that workload under a **warm**
+  shared `target/` directory reused across the whole chronological walk,
+  while CI's `cold_start_driver.rs` scaffolds a brand-new project with an
+  **empty** `target/` and no compiler-wrapper cache on every single
+  sample (see Apparatus's fourth correction). This apparatus pays each
+  external dependency's compile cost once per introduction; CI pays it on
+  every sample, forever. Four of the 31 non-fix commits touched
+  `Cargo.lock`, so their deltas in this report specifically cannot be
+  trusted as CI-representative — and the apparatus can only *undercount*
+  that cost, never overcount it, so the true CI-relevant total for this
+  window is more likely to exceed this proxy's ≈−13,000ms-implied
+  workspace-only cost than to match it. The parent report's CI/runner-
+  variance confound (1-sample local A/B vs. 3-sample CI p95, different
+  runners) is also still live and undistinguished from any of this.
 
 **What would resolve this, as an explicit follow-up (not chartered or run
 here):**
@@ -451,8 +509,17 @@ here):**
 2. Also calibrate the fix's own delta (`651929b2`, currently n=1 in this
    report) with repeats, and extend the method to the
    scaffold+app-compile+server-start portion of the journey via the real
-   `autumn dev-loop-bench --cold-start` harness, to close the residual gap
-   between this proxy's absolute saving and CI's.
+   `autumn dev-loop-bench --cold-start` harness.
+3. **Use an empty `target/` per checkpoint, matching CI's own
+   `cold_start_driver.rs` methodology, not a warm shared one** — the
+   single biggest change needed before this proxy's numbers can be
+   compared to CI's at all. This is a materially larger apparatus (32+
+   fully cold builds instead of one warm chain; each of the confirmed
+   cold-build samples in this report took 60-120s, so a fully-cold
+   32-checkpoint pass could run 30-60+ minutes on its own) — but without
+   it, any commit touching `Cargo.lock` (4 of 31 here) cannot be trusted,
+   and neither can this proxy's total-window comparison to CI's absolute
+   saving.
 
 ## 💰 Cost to productionize
 

--- a/docs/reports/2026-09-03-prospect-cold-start-post-fix-bisect.md
+++ b/docs/reports/2026-09-03-prospect-cold-start-post-fix-bisect.md
@@ -436,9 +436,11 @@ here):**
 
 N/A — undetermined verdict, no build to productionize. Build wall-clock
 across all passes: ~11 minutes (first, shallow-clone-invalidated pass) +
-~34 minutes (corrected 32-checkpoint pass + 2 warm re-measurements) + ~7
-minutes (noise-floor calibration, 7 valid + 1 discarded cold-artifact run)
-≈ 52 minutes total, against the pre-registered ≤60-minute *per-pass* box.
+~34 minutes (main 35-build pass: 32 chronological checkpoints + 1 in-pass
+repeat + 2 warm re-measurements) + ~7 minutes (separate noise-floor pass:
+6 builds, 5 valid + 1 discarded cold-artifact, contributing 5 of the
+calibration's 7 total samples — the other 2 come from the main pass) ≈ 52
+minutes total, against the pre-registered ≤60-minute *per-pass* box.
 Two real costs stand out for anyone scoping a repeat: (1) `git fetch
 --unshallow` before any window-derivation command, always — a shallow
 clone fails silently, not loudly; (2) a single-run-per-checkpoint design

--- a/docs/reports/2026-09-03-prospect-cold-start-post-fix-bisect.md
+++ b/docs/reports/2026-09-03-prospect-cold-start-post-fix-bisect.md
@@ -496,21 +496,33 @@ for c in "${COMMITS[@]}"; do
   timed_build "$c"
 done
 
+# This same pass also includes one same-commit repeat of the final
+# checkpoint, taken immediately (still in this same warm worktree) —
+# this is the 35th build of the main pass, and one of the 7 calibration
+# samples (see the separate calibration pass below).
+timed_build "ef61ae44-repeat-in-pass"
+
 # Re-measure d1ecb361 and dc74ce43 now that target/ is fully warm from the
 # pass above — these two (and only these two) replace their earlier numbers.
+# Main pass total: 32 + 1 + 2 = 35 builds.
 for c in d1ecb361 dc74ce43; do
   git checkout --detach "$c" --quiet
   timed_build "${c}-warm"
 done
 
-# Noise-floor calibration: the COMMITS loop above already measured ef61ae44
-# once (that IS the "window end" sample in the table). Six MORE repeats here
-# gives 7 total warm-condition samples, matching this report's calibration —
-# don't add a 7th here or you'll have 8, not 7.
-git checkout --detach ef61ae44 --quiet
-for i in 1 2 3 4 5 6; do
-  timed_build "ef61ae44-repeat-${i}"
-done
+git worktree remove /tmp/prospect-coldstart-wt2 --force
 
-git worktree remove /tmp/prospect-coldstart-wt2 --force   # dismantle
+# Noise-floor calibration is a SEPARATE pass, in a fresh worktree (empty
+# target/, same cold-build artifact as the main pass's first checkpoint —
+# that's why run 1 below is expected to be an outlier and gets discarded,
+# not because anything is wrong with it). 6 builds here + the 2 ef61ae44
+# samples already produced by the main pass above (the "window end"
+# checkpoint and the in-pass repeat) = 7 total calibration samples,
+# matching this report's numbers.
+git worktree add --detach /tmp/prospect-noise-wt ef61ae44
+cd /tmp/prospect-noise-wt
+for i in 1 2 3 4 5 6; do
+  timed_build "ef61ae44-calibration-${i}"   # run 1 is the expected cold outlier — discard it
+done
+git worktree remove /tmp/prospect-noise-wt --force
 ```

--- a/docs/reports/2026-09-03-prospect-cold-start-post-fix-bisect.md
+++ b/docs/reports/2026-09-03-prospect-cold-start-post-fix-bisect.md
@@ -190,28 +190,56 @@ per-commit correction below) changes the list:
   compiled version, not a swap), and `p256 v0.13.2` — the crate Web
   Push's own commit message says gained a new `ecdh` feature flag — is in
   the tree too.
-- `bc99a4b8` (scaffold DSL constraints) is **disputed**: Codex's finding
-  characterized it as "only adds `serde_urlencoded` to `autumn-cli`,"
-  but the actual `Cargo.lock` diff (`git show bc99a4b8 -- Cargo.lock`)
-  adds `serde_urlencoded` to **`reqwest`'s own** dependency list, and
-  `cargo tree` confirms `reqwest` (via the `http-client` feature this
-  build enables) resolves `serde_urlencoded v0.7.1` into this exact tree.
-  Kept flagged, on the verified evidence, contrary to the review comment
-  that prompted this recheck — noted here rather than either accepted or
-  silently dropped.
+- `bc99a4b8` (scaffold DSL constraints) — **retracted, a second confirmed
+  false positive** (Codex P2 on `abea7490`, correcting my own prior
+  verification, which was sloppy: I saw `reqwest` and `serde_urlencoded`
+  both appear somewhere in the tree and stopped there, without checking
+  *which* `reqwest`). The exact feature set this report times resolves
+  `reqwest v0.12.28` (confirmed: `cargo tree -p autumn-web ... -i
+  "reqwest@0.12.28"`); `bc99a4b8^:Cargo.lock` (the parent commit, before
+  this change) shows `reqwest 0.12.28` **already** listed
+  `serde_urlencoded` as a dependency — it was never added by this commit.
+  What `bc99a4b8` actually adds `serde_urlencoded` to is `reqwest
+  v0.13.4`, a wholly different resolved version pulled in only by
+  `autumn-cli`'s dev-dependencies, never built by `cargo build -p
+  autumn-web`. Compounding that: `autumn/Cargo.toml` (`autumn-web`'s own
+  manifest) already lists `serde_urlencoded = "0.7"` as a **direct**
+  dependency regardless of `reqwest` at all. None of that is touched by
+  `bc99a4b8`. My first correction (`abea7490`) was itself wrong to keep
+  this flagged — reversed here.
 
-Net: 3 of the 4 originally-flagged commits (`141f36ef`, `61bdd9c2`,
-`bc99a4b8`) are confirmed relevant to this feature set's resolved graph;
-`fec52215` is not. **For the 3 confirmed commits, this report's deltas
-cannot be trusted as representative of their true, CI-relevant recurring
-contribution** — the apparatus can only undercount, never overcount, a
-genuine per-dependency cost, since it's structurally incapable of showing
-more than a one-time compile for anything new. It
+Net, after two rounds of verification: **2 of the 4** originally-flagged
+commits (`141f36ef`, `61bdd9c2`) are confirmed relevant to this feature
+set's resolved graph; `fec52215` and `bc99a4b8` are both confirmed false
+positives. **For the 2 confirmed commits, this report's deltas cannot be
+trusted as representative of their true, CI-relevant recurring
+contribution** — but not for a purely one-directional reason (see the
+next correction). It
 also means the "total window effect" and "this proxy's absolute saving vs.
 CI's" comparisons throughout Assay and Verdict are weaker than stated
 there: they are not just measuring a narrower workload (library-only, no
 scaffold/server-start) as already disclosed, but a workload measured under
-a fundamentally warmer caching regime than CI ever runs under. Not
+a fundamentally warmer caching regime than CI ever runs under.
+
+**The bias is not one-directional** (Codex P2 on `abea7490`, correcting
+the "can only undercount, never overcount" claim this section originally
+made): when a checkpoint upgrades or newly introduces a dependency, this
+apparatus's warm-target delta charges that checkpoint the *entire* fresh
+compile cost of the new/changed dependency, while the *previous*
+checkpoint paid nothing for it (it wasn't cached yet, or didn't exist).
+A true cold-vs-cold comparison — what CI actually runs — would instead
+show the much smaller *marginal* difference between compiling the old
+version and the new one, since both a fully-cold pre- and post-commit
+build pay for *some* version of that dependency. So at the introducing
+checkpoint specifically, this apparatus likely **overcounts** the
+commit's true CI-relevant marginal cost; at every checkpoint *after* it,
+the dependency is cached and the apparatus shows nothing for it, which
+**undercounts** the recurring cost CI keeps paying. Both directions are
+real, and this report cannot say which dominates for `141f36ef` or
+`61bdd9c2` specifically without a genuinely cold-per-checkpoint rerun.
+Practically, this makes individual per-commit deltas in this dataset
+*less* interpretable than the "undercount only" framing suggested, not
+more — reinforcing the undetermined verdict, not weakening it. Not
 corrected by re-running (out of this session's time box — a true
 apples-to-apples repeat would need an empty `target/` per checkpoint,
 i.e. 32+ fully cold builds, each potentially 60-120s, a materially larger
@@ -517,16 +545,20 @@ live report needs the map:
   sample (see Apparatus's fourth correction). This apparatus pays each
   external dependency's compile cost once per introduction; CI pays it on
   every sample, forever. Of the 4 non-fix commits that touched
-  `Cargo.lock`, 3 (`141f36ef`, `61bdd9c2`, `bc99a4b8`) are confirmed via
-  `cargo tree` to actually affect this feature set's resolved graph (see
-  Apparatus's fourth correction for the per-commit check and the one
-  confirmed false positive, `fec52215`) — their deltas in this report
-  specifically cannot be trusted as CI-representative, and the apparatus
-  can only *undercount* that cost, never overcount it, so the true
-  CI-relevant total for this window is more likely to exceed this proxy's
-  ≈−13,000ms-implied workspace-only cost than to match it. The parent
-  report's CI/runner-variance confound (1-sample local A/B vs. 3-sample CI
-  p95, different runners) is also still live and undistinguished from any
+  `Cargo.lock`, only **2** (`141f36ef`, `61bdd9c2`) are confirmed via
+  version-specific `cargo tree` checks to actually affect this feature
+  set's resolved graph — `fec52215` and, after a second, more careful
+  check, `bc99a4b8` too are both confirmed false positives (see
+  Apparatus's fourth and fifth corrections). Their deltas cannot be
+  trusted as CI-representative, but not in a single, simple direction:
+  the apparatus likely *overcounts* each one's cost at its own
+  introducing checkpoint (charging the full fresh-compile cost rather
+  than CI's much smaller cold-vs-cold marginal difference) and
+  *undercounts* it at every checkpoint after (nothing shown where CI pays
+  every sample). Which effect dominates for this window's total is not
+  resolvable from this data. The parent report's CI/runner-variance
+  confound (1-sample local A/B vs. 3-sample CI p95, different runners) is
+  also still live and undistinguished from any
   of this.
 
 **What would resolve this, as an explicit follow-up (not chartered or run

--- a/docs/reports/2026-09-03-prospect-cold-start-post-fix-bisect.md
+++ b/docs/reports/2026-09-03-prospect-cold-start-post-fix-bisect.md
@@ -517,24 +517,32 @@ calibrated noise floor in hand:**
   end of that range is closer to true. Resolving it needs noise
   calibration interspersed *throughout* a long chronological walk, not a
   clustered batch run separately from it — not done here. See Verdict.
-- **The total-window figure survives, even though attribution inside it
-  does not — but at a lower confidence than first stated** (Codex P2 on
-  `c38feaa9`, applying the same walk-noise inflation caveat here that the
-  kill-line discussion above already applied to the pre/post-fix spans,
-  rather than treating this claim as exempt from it). End-to-end,
+- **The total-window figure is this report's single strongest number, but
+  it is not immune from the same open noise question as everything
+  else — a claim that it was "solidly real at either end" of a 4.0-5.9σ
+  range overstated what's actually established** (Codex P2 on `1c785d56`,
+  correcting the previous revision's own correction). End-to-end,
   `d1ecb361` (55,882ms, one warm sample from the 32-checkpoint walk) →
   `ef61ae44` (42,837ms, 7-sample calibrated mean) is **−13,045ms
   (−23.4%)**, consistent with the single-sample estimate reported before
   calibration (−13,245ms, −23.7%). Using the clustered calibration's
-  σ=1,080ms at face value, that's ≈8-9σ (dominated by the single, n=1
-  `d1ecb361` sample's stdev, since the endpoint's 7-sample mean has a much
-  smaller SE of ≈408ms) — but `d1ecb361` was measured *within* the same
-  noisy 32-checkpoint walk the kill-line discussion flags as possibly
-  2-3x noisier than the clustered calibration. Applying that same 2-3x
-  range to `d1ecb361`'s stdev gives a combined uncertainty of
-  ≈2,200-3,270ms, so the honest range is **≈4.0σ-5.9σ**, not 8-9σ. Still
-  comfortably real at either end of that range — just not as
-  overwhelmingly so as the unadjusted number suggested. What calibration
+  σ=1,080ms at face value, that's ≈8-9σ. Scaling that by the 2-3x range
+  used elsewhere in this report gives ≈4.0-5.9σ — but that 2-3x figure
+  itself rests on exactly two single-run no-op deltas (`dc74ce43`,
+  `31423bfc`, ±4.6s), which can suggest a point estimate but cannot
+  establish a rigorous *upper bound* on how noisy the 32-checkpoint walk
+  really was, especially with only one `d1ecb361` sample to begin with.
+  Nothing in this report rules out the walk's true noise being higher
+  than 3x the clustered estimate — in which case even 4.0σ is not a safe
+  floor. The honest statement is not "≈4.0-5.9σ, solidly real" but: **the
+  applicable noise scale for this comparison is not established by this
+  data, the same as the pre-fix and post-fix spans** — what distinguishes
+  this number from those is only that its raw effect size (≈13,000ms) is
+  roughly 3-4x theirs, so it would take a noise level considerably higher
+  than anything this report's evidence suggests to put it in real doubt.
+  That is a qualitative reason for somewhat more confidence, not a
+  quantitative one, and this report cannot honestly produce a specific σ
+  figure for it. What calibration
   removes is
   confidence in *why*: whether that total is the fix's raw −24,333ms
   partly clawed back by real per-commit compile-time growth (this report's
@@ -587,17 +595,20 @@ live report needs the map:
 
 **What this assay establishes, and at what confidence:**
 
-- **The total window effect is real and large, though not fully immune to
-  the same noise-inflation question as the spans below** (Codex P2 on
-  `c38feaa9`, correcting an earlier claim that this comparison was exempt
-  from the walk-noise caveat; it isn't, since `d1ecb361` was measured
-  within that same noisy walk). `d1ecb361` →
-  `ef61ae44`, ≈−13,000ms (−23-24%), is ≈8-9σ against the clustered
-  calibration's tight noise estimate but ≈4.0-5.9σ against the same
-  2-3x-inflated estimate applied to the spans below (see Assay) — still
-  solidly real at either end, unlike the post-fix span, but with real
-  (if modest, given the size of the effect) uncertainty in exactly how
-  solid.
+- **The total window effect is this report's strongest single number, but
+  it is subject to the same unresolved noise-scale question as the spans
+  below, not exempt from it** (corrected twice now, most recently Codex
+  P2 on `1c785d56`: a prior revision computed a ≈4.0-5.9σ "floor" using a
+  2-3x noise-inflation range, then asserted that floor as solid — but
+  that 2-3x range itself rests on only two single-run no-op observations
+  and doesn't establish a rigorous upper bound on the walk's true noise).
+  `d1ecb361` → `ef61ae44`, ≈−13,000ms (−23-24%), is ≈8-9σ against the
+  clustered calibration's tight noise estimate; this report cannot
+  honestly state a specific σ figure beyond that, only that the effect
+  size is roughly 3-4x larger than the spans below, so it would take a
+  noise level well outside what any evidence here suggests to put it in
+  real doubt. That is qualitative grounds for more confidence than the
+  spans below warrant, not a quantitative guarantee.
 - **Whether the pre-fix and post-fix spans individually show real,
   not-noise compile-time growth is genuinely unresolved, not just
   unattributed.** Under the calibration's own tight noise estimate
@@ -614,23 +625,36 @@ live report needs the map:
   pessimistic end, but neither revision had the honest range in hand when
   it was written.
 - **What remains genuinely unresolved regardless: attribution to any
-  specific commit.** Telescoping means a sum over a contiguous span
-  carries *zero* information about which intermediate commit(s) caused
-  the change — mathematically true independent of the noise-scale
-  question above, and this is the load-bearing reason no commit can be
-  named, not the multiple-comparisons point that follows (corrected,
-  Codex P2 on `269afeb8`: a simulation of 31 standard-normal draws gives
-  an expected one-sided maximum of ≈2.06σ, ≈2.34σ for the maximum
-  absolute value — not the ≈2.5-2.9σ an earlier revision claimed, which
-  was closer to a ~95th-percentile value than an expectation). Against
-  the correct number, `6a6610c4` (+4,990ms, ≈3.3σ against the tight
-  calibration's per-delta noise) sits *above* the expected maximum of 31
-  draws, not comfortably within it — a simulated `P(max ≥ 3.3σ)` of only
-  ≈1.5%, which doesn't clear a confident attribution bar on its own but
-  is weaker cover for "just noise" than the earlier, incorrect number
-  suggested. What still rules it out is the telescoping argument above
-  and the confirmed, unrelated calibration and warm-cache-bias issues
-  elsewhere in this report — not this multiple-comparisons calculation.
+  specific commit — but telescoping is not the reason for that, and
+  claiming it was is a mistake this section made** (Codex P2 on
+  `1c785d56`, correcting the previous paragraph's own logic, not just its
+  numbers). Telescoping only nullifies information in a *sum* — it has
+  nothing to say about the individual per-checkpoint deltas already
+  sitting in the Assay table, each a standalone two-point measurement.
+  `6a6610c4` (+4,990ms) is exactly such a measurement, and its own
+  `Cargo.toml`/`Cargo.lock` diff touches nothing but `autumn/src/search.rs`
+  — no dependency-cache caveat applies to it at all. The real reason it
+  (and every other individual delta in the table) can't be confidently
+  named as a cause is the **noise/calibration problem already established
+  above**: this apparatus took one measurement per checkpoint, and the
+  true noise floor for a single such measurement is itself uncertain
+  (tight clustered calibration says σ≈1,080ms; the walk itself may run
+  noisier). Against the tight estimate, `6a6610c4`'s ≈3.3σ is a real
+  single-comparison signal, sitting *above*, not within, the expected
+  one-sided maximum of 31 independent draws (a simulation, 200k trials,
+  n=31 standard normal: E[max]≈2.06σ, E[max abs]≈2.34σ, `P(max≥3.3σ)`≈1.5%
+  — correcting an earlier, wrong ≈2.5-2.9σ claim here, which was closer to
+  a ~95th-percentile value than an expectation). That ≈1.5% tail
+  probability is suggestive, not dispositive, and — as the total-window
+  discussion below now also states plainly — this report never
+  established a reliable upper bound on the walk's true noise scale, so
+  even this single-comparison signal cannot be confidently separated from
+  noise. Telescoping is the correct, load-bearing reason the pre-fix and
+  post-fix *aggregate* sums (+7,677ms across 22 commits, +3,411ms across
+  9) carry no information about which commit(s) within each span caused
+  the shift; the noise/calibration problem is the separate, load-bearing
+  reason no *individual* delta — including `6a6610c4`'s — can be
+  confidently named either. Both apply; neither is the other.
 - **This proxy's ≈−13,000ms is not directly comparable to CI's −15,051ms
   at all, and this report previously overstated how close a match that
   was** (Codex P1 on `39ae17a1`). Two compounding reasons, not one: this

--- a/docs/reports/2026-09-03-prospect-cold-start-post-fix-bisect.md
+++ b/docs/reports/2026-09-03-prospect-cold-start-post-fix-bisect.md
@@ -19,8 +19,11 @@ any single non-fix commit measurably add compile-time weight to the no-DB
 daemon feature set (`autumn-web --no-default-features --features
 maud,htmx,tailwind,cache-moka,http-client,reporting`, i.e. exactly
 `DAEMON_NO_DB_FEATURES` from `autumn-cli/src/new.rs`) — enough to plausibly
-account for a material share of the ~15,051ms shortfall between the fix's
-own confirmed relative saving and the real CI trajectory? Or does no single
+account for a material share of the shortfall between the fix's own
+confirmed relative saving and the real CI trajectory (**corrected figure**,
+see Correction below: **~30,697ms** absolute, or **~21.0 percentage
+points** — not the ~15,051ms this question originally named, which is
+CI's own observed saving, not the gap to explain)? Or does no single
 commit explain it, meaning the shortfall is better attributed to
 statistical/runner noise (CI's 3-sample p95 vs PR #2360's 1-sample local
 A/B, different runners, a week apart) rather than to a specific regression?
@@ -121,6 +124,25 @@ window (rather than quietly patching the pre-registration's commit list to
 match what was actually measured) is what "committed before measurement"
 is supposed to prevent — so this correction reflects fixing a tooling bug
 discovered *after* results existed, not re-drawing the window to fit them.
+
+**A third, unrelated error in the pre-registration itself** (Codex P2 on
+`e5e6eb56`, independent of the shallow-clone bug above): the
+pre-registration's own "Pursue-bisection-further line" and "Kill line"
+text (blockquoted above, not edited) both call `~15,051ms` "the CI
+shortfall," and this report's Question section repeated that framing. It's
+wrong: `15,051ms` (`120,422−105,371`) is CI's own **observed saving**, not
+the gap between what was confirmed and what CI delivered. The actual gap
+is **~30,697ms** absolute (`45,748ms` confirmed same-box saving minus
+CI's `15,051ms`), or **~21.0 percentage points** (`33.49%` confirmed vs.
+`12.50%` observed) — roughly double what "~15,051ms" suggested. This does
+**not** change the pursue/kill lines themselves (the 5,000ms threshold was
+set independently as "large enough to plausibly be a material single
+contributor," not derived as a fraction of the shortfall figure), so it
+doesn't retroactively invalidate any verdict in this report. It does mean
+the Question section's framing was imprecise about the size of what this
+assay was ultimately trying to explain; corrected there, left unedited in
+the frozen pre-registration blockquote per the same policy as the other
+two corrections above.
 
 ## 🔍 Prior art
 
@@ -463,9 +485,12 @@ set -euo pipefail   # fail loudly, don't silently build the wrong commit
 # IMPORTANT: unshallow first, and treat failure as fatal. A shallow clone
 # silently truncates git log ranges and git merge-base --is-ancestor
 # results without erroring — this is exactly the bug that produced this
-# report's first, wrong revision. `|| true` here would suppress a fetch
-# failure and let the script carry on against a still-shallow repo.
-git fetch --unshallow origin
+# report's first, wrong revision. `--unshallow` itself errors (exit 128,
+# "does not make sense") on an already-complete clone, so only run it when
+# actually shallow — but still verify and fail loudly afterward either way.
+if [ "$(git rev-parse --is-shallow-repository)" = "true" ]; then
+  git fetch --unshallow origin
+fi
 if [ "$(git rev-parse --is-shallow-repository)" != "false" ]; then
   echo "FATAL: repository is still shallow after fetch --unshallow" >&2
   exit 1

--- a/docs/reports/2026-09-03-prospect-cold-start-post-fix-bisect.md
+++ b/docs/reports/2026-09-03-prospect-cold-start-post-fix-bisect.md
@@ -168,16 +168,45 @@ dependency, from scratch, on every sample, forever.** This report's
 warm-target apparatus pays that cost **at most once**, on whichever
 checkpoint first introduces a given dependency — after that, it's cached
 and invisible in every later delta, even though CI keeps paying it every
-week. `git log --name-only -- Cargo.lock` over this window shows **4 of
-the 31 non-fix commits actually touched `Cargo.lock`**: `fec52215`
-(zero-downtime state migration, this report's second-largest post-fix
-delta at +4,591ms), `61bdd9c2` (Web Push, +1,995ms), `bc99a4b8` (scaffold
-DSL constraints, −733ms), and `141f36ef` (a `base64` patch-version bump,
-−2,518ms, unlikely to matter much on its own). **This report's deltas for
-those four commits cannot be trusted as representative of their true,
-CI-relevant recurring contribution** — the apparatus can only undercount,
-never overcount, a genuine per-dependency cost, since it's structurally
-incapable of showing more than a one-time compile for anything new. It
+week. `git log --name-only -- Cargo.lock` over this window flags **4 of
+the 31 non-fix commits as touching `Cargo.lock`** — but "touches the
+file" is a crude proxy for "changes *this exact feature set's* resolved
+graph," and checking each one against `cargo tree -p autumn-web
+--no-default-features --features
+maud,htmx,tailwind,cache-moka,http-client,reporting` (Codex P2 on
+`d2a980c3`, verified independently rather than taken on trust — see the
+per-commit correction below) changes the list:
+
+- `fec52215` (zero-downtime state migration, this report's second-largest
+  post-fix delta at +4,591ms) is a **confirmed false positive**: its only
+  `Cargo.lock` change adds the unrelated `hot-upgrade` example/workspace
+  package, which is absent from this feature set's resolved tree. Its
+  delta should **not** be discounted on this basis — if it's real, the
+  cause is something else (or noise, per the significance discussion
+  above).
+- `141f36ef` (a `base64` patch-version bump) and `61bdd9c2` (Web Push)
+  are **confirmed real**: `cargo tree` shows both `base64 v0.22.1` and
+  `v0.23.1` coexisting in this exact feature set (the bump adds a second
+  compiled version, not a swap), and `p256 v0.13.2` — the crate Web
+  Push's own commit message says gained a new `ecdh` feature flag — is in
+  the tree too.
+- `bc99a4b8` (scaffold DSL constraints) is **disputed**: Codex's finding
+  characterized it as "only adds `serde_urlencoded` to `autumn-cli`,"
+  but the actual `Cargo.lock` diff (`git show bc99a4b8 -- Cargo.lock`)
+  adds `serde_urlencoded` to **`reqwest`'s own** dependency list, and
+  `cargo tree` confirms `reqwest` (via the `http-client` feature this
+  build enables) resolves `serde_urlencoded v0.7.1` into this exact tree.
+  Kept flagged, on the verified evidence, contrary to the review comment
+  that prompted this recheck — noted here rather than either accepted or
+  silently dropped.
+
+Net: 3 of the 4 originally-flagged commits (`141f36ef`, `61bdd9c2`,
+`bc99a4b8`) are confirmed relevant to this feature set's resolved graph;
+`fec52215` is not. **For the 3 confirmed commits, this report's deltas
+cannot be trusted as representative of their true, CI-relevant recurring
+contribution** — the apparatus can only undercount, never overcount, a
+genuine per-dependency cost, since it's structurally incapable of showing
+more than a one-time compile for anything new. It
 also means the "total window effect" and "this proxy's absolute saving vs.
 CI's" comparisons throughout Assay and Verdict are weaker than stated
 there: they are not just measuring a narrower workload (library-only, no
@@ -487,14 +516,18 @@ live report needs the map:
   **empty** `target/` and no compiler-wrapper cache on every single
   sample (see Apparatus's fourth correction). This apparatus pays each
   external dependency's compile cost once per introduction; CI pays it on
-  every sample, forever. Four of the 31 non-fix commits touched
-  `Cargo.lock`, so their deltas in this report specifically cannot be
-  trusted as CI-representative — and the apparatus can only *undercount*
-  that cost, never overcount it, so the true CI-relevant total for this
-  window is more likely to exceed this proxy's ≈−13,000ms-implied
-  workspace-only cost than to match it. The parent report's CI/runner-
-  variance confound (1-sample local A/B vs. 3-sample CI p95, different
-  runners) is also still live and undistinguished from any of this.
+  every sample, forever. Of the 4 non-fix commits that touched
+  `Cargo.lock`, 3 (`141f36ef`, `61bdd9c2`, `bc99a4b8`) are confirmed via
+  `cargo tree` to actually affect this feature set's resolved graph (see
+  Apparatus's fourth correction for the per-commit check and the one
+  confirmed false positive, `fec52215`) — their deltas in this report
+  specifically cannot be trusted as CI-representative, and the apparatus
+  can only *undercount* that cost, never overcount it, so the true
+  CI-relevant total for this window is more likely to exceed this proxy's
+  ≈−13,000ms-implied workspace-only cost than to match it. The parent
+  report's CI/runner-variance confound (1-sample local A/B vs. 3-sample CI
+  p95, different runners) is also still live and undistinguished from any
+  of this.
 
 **What would resolve this, as an explicit follow-up (not chartered or run
 here):**

--- a/docs/reports/2026-09-03-prospect-cold-start-post-fix-bisect.md
+++ b/docs/reports/2026-09-03-prospect-cold-start-post-fix-bisect.md
@@ -1,4 +1,4 @@
-# ⛏️ Prospect: which commit ate the missing cold-start savings? (undetermined: total window effect is real (~13,000ms), but whether the pre/post-fix spans are signal or noise depends on a noise estimate this assay can't pin down, and no single commit can be named either way)
+# ⛏️ Prospect: which commit ate the missing cold-start savings? (undetermined: the ~13,000ms total window effect is this assay's strongest evidence, but a rigorous noise floor for this apparatus was never established, so no confidence figure — total, span-level, or per-commit — can be honestly stated)
 
 ## 🎯 Question
 

--- a/docs/reports/2026-09-03-prospect-cold-start-post-fix-bisect.md
+++ b/docs/reports/2026-09-03-prospect-cold-start-post-fix-bisect.md
@@ -365,6 +365,24 @@ carried into the Verdict.
   freshly-created worktree, hit the same cold-dependency-compile artifact
   described above — 82,156ms — and is excluded for the same reason). See
   Assay for the result and its consequence for the verdict.
+- **A seventh limitation, also confirmed (Codex P2 on `269afeb8`): the
+  timed feature set isn't an exact match for what CI's own scaffold
+  builds, either.** `DAEMON_NO_DB_FEATURES` (this report's feature list)
+  omits `flash`, and `autumn-cli/src/new.rs` writes the generated app's
+  `autumn-web` dependency line with `default-features = false, features =
+  [DAEMON_NO_DB_FEATURES]` accordingly — but the generated scaffold's
+  *own* `Cargo.toml` (`autumn-cli/src/templates/Cargo.toml.tmpl`)
+  separately declares `default = ["flash"]` / `flash =
+  ["autumn-web/flash"]`, and `cold_start_driver.rs`'s `cold_build` runs a
+  bare `cargo build` with no `--no-default-features` flag of its own.
+  Cargo feature unification then turns `autumn-web/flash` on for the real
+  scaffold build regardless of the dependency line's explicit feature
+  list. This report's exact command (`--features
+  maud,htmx,tailwind,cache-moka,http-client,reporting`) never enables
+  `flash`, so it measures a library configuration close to, but not
+  identical with, what CI actually compiles. Not corrected by re-running
+  (compounds with, doesn't replace, the narrower-workload and
+  warm-vs-cold-target limitations already disclosed).
 
 ## 📊 Assay
 
@@ -599,14 +617,20 @@ live report needs the map:
   specific commit.** Telescoping means a sum over a contiguous span
   carries *zero* information about which intermediate commit(s) caused
   the change — mathematically true independent of the noise-scale
-  question above. Individually, `6a6610c4` (+4,990ms) is the largest
-  single delta at ≈3.3σ against the tight calibration's per-delta noise
-  (lower, and further from significant, under the inflated estimate) — a
-  real single-comparison signal at best, but also the largest of 31
-  candidate deltas, and the expected maximum of 31 independent noise
-  draws is itself around 2.5-2.9σ even under the tight estimate. No
-  commit in this dataset clears a confident attribution bar under either
-  noise scale.
+  question above, and this is the load-bearing reason no commit can be
+  named, not the multiple-comparisons point that follows (corrected,
+  Codex P2 on `269afeb8`: a simulation of 31 standard-normal draws gives
+  an expected one-sided maximum of ≈2.06σ, ≈2.34σ for the maximum
+  absolute value — not the ≈2.5-2.9σ an earlier revision claimed, which
+  was closer to a ~95th-percentile value than an expectation). Against
+  the correct number, `6a6610c4` (+4,990ms, ≈3.3σ against the tight
+  calibration's per-delta noise) sits *above* the expected maximum of 31
+  draws, not comfortably within it — a simulated `P(max ≥ 3.3σ)` of only
+  ≈1.5%, which doesn't clear a confident attribution bar on its own but
+  is weaker cover for "just noise" than the earlier, incorrect number
+  suggested. What still rules it out is the telescoping argument above
+  and the confirmed, unrelated calibration and warm-cache-bias issues
+  elsewhere in this report — not this multiple-comparisons calculation.
 - **This proxy's ≈−13,000ms is not directly comparable to CI's −15,051ms
   at all, and this report previously overstated how close a match that
   was** (Codex P1 on `39ae17a1`). Two compounding reasons, not one: this
@@ -666,9 +690,12 @@ here):**
    fully cold builds instead of one warm chain; each of the confirmed
    cold-build samples in this report took 60-120s, so a fully-cold
    32-checkpoint pass could run 30-60+ minutes on its own) — but without
-   it, any commit touching `Cargo.lock` (4 of 31 here) cannot be trusted,
-   and neither can this proxy's total-window comparison to CI's absolute
-   saving.
+   it, any commit that actually changes this feature set's resolved
+   dependency graph (not merely "touches `Cargo.lock`" — confirmed real
+   for only 3 of the ~13 candidates checked, `61bdd9c2`/`9d99d980`/
+   `9c1ede1e`, with several more `Cargo.toml`-touching commits unchecked;
+   see Apparatus) cannot be trusted, and neither can this proxy's
+   total-window comparison to CI's absolute saving.
 
 ## 💰 Cost to productionize
 

--- a/docs/reports/2026-09-03-prospect-cold-start-post-fix-bisect.md
+++ b/docs/reports/2026-09-03-prospect-cold-start-post-fix-bisect.md
@@ -1,4 +1,4 @@
-# ⛏️ Prospect: which post-#2309-fix commit ate the missing cold-start savings? (kill: no single commit ≥5,000ms vs the pursue line; proxy overshoots the confirmed saving, so the shortfall isn't here)
+# ⛏️ Prospect: which commits ate the missing cold-start savings? (undetermined: no single commit ≥5,000ms, but +10,655ms of diffuse creep across 31 commits closely tracks the CI shortfall in absolute terms)
 
 ## 🎯 Question
 
@@ -12,22 +12,18 @@ off, ~94%) and at the controlled binary level (PR #2360's own same-box A/B:
 and named it a follow-up: *"a `cargo build --timings` bisection over the
 full comparison interval... is the follow-up, not this verification."* It
 also named three commits as candidates "because they touch default
-features/deps in that window" — but that list turns out to be wrong: one of
-the three (`1fd6245`, Ledgered entities) is **not even an ancestor of
-`ef61ae44`** (`git merge-base --is-ancestor 1fd6245 ef61ae44` fails), so it
-cannot be part of this window's compile-time delta at all. This assay
-corrects that and re-derives the real commit set.
+features/deps in that window."
 
-**Falsifiable question:** among the commits actually in `d1ecb361..ef61ae44`
-(12 commits, verified below), does any single non-fix commit measurably add
-compile-time weight to the no-DB daemon feature set (`autumn-web
---no-default-features --features maud,htmx,tailwind,cache-moka,http-client,reporting`,
-i.e. exactly `DAEMON_NO_DB_FEATURES` from `autumn-cli/src/new.rs`) — enough
-to plausibly account for a material share of the ~15,051ms shortfall between
-the fix's own confirmed relative saving and the real CI trajectory? Or does
-no single commit explain it, meaning the shortfall is better attributed to
-statistical/runner noise (CI's 3-sample p95 vs PR #2360's 1-sample local A/B,
-different runners, a week apart) rather than to a specific regression?
+**Falsifiable question:** among the commits in `d1ecb361..ef61ae44`, does
+any single non-fix commit measurably add compile-time weight to the no-DB
+daemon feature set (`autumn-web --no-default-features --features
+maud,htmx,tailwind,cache-moka,http-client,reporting`, i.e. exactly
+`DAEMON_NO_DB_FEATURES` from `autumn-cli/src/new.rs`) — enough to plausibly
+account for a material share of the ~15,051ms shortfall between the fix's
+own confirmed relative saving and the real CI trajectory? Or does no single
+commit explain it, meaning the shortfall is better attributed to
+statistical/runner noise (CI's 3-sample p95 vs PR #2360's 1-sample local
+A/B, different runners, a week apart) rather than to a specific regression?
 
 **Decision:** whether issue #2309 needs a second, narrowly-scoped follow-up
 PR (revert or feature-gate whatever commit is found responsible) versus
@@ -38,68 +34,93 @@ warranted. **Decider:** repo maintainer (same as the parent assay — issue
 
 ## ⚖️ Pre-registration
 
-Committed in this same commit, before any timed build runs.
+Committed in commit `cf3ffdd`, before any timed build runs. Reproduced
+verbatim below — **do not edit this section**; the correction discovered
+after committing it is recorded separately, immediately after.
 
-- **Actual window** (superseding the parent report's unverified guess),
-  oldest → newest, confirmed via `git log --oneline d1ecb361..ef61ae44` and
-  `git merge-base --is-ancestor`:
-  `61bdd9c` (Web Push, #2334) → `28c6fae` (scaffold reconciliation, #2340) →
-  `651929b` (**the #2309 fix itself**, #2360) → `d6aa668` (admin
-  impersonation, #2339) → `97a97be` (replay capsule seams, #2348) →
-  `d96cfab` (cached-read staleness proof, #2352) → `fec5221` (zero-downtime
-  state migration, #2345) → `8f94e60` (CI-only: clippy parallelism, #2361)
-  → `76c56b1` (docs/routing example, #2341) → `9c1ede1` (db scrub, #2365) →
-  `f15ca1b` (classified-data compile-time proof, #2367) → `ef61ae4` (Bolt
-  form-field escaping, #2376 — the post-fix CI-measured commit itself).
-- **Pursue-bisection-further line:** a single commit's isolated build delta
-  (vs. the immediately preceding checkpoint, same feature set, same warmed
-  target dir) is ≥ 5,000ms — large enough to plausibly be a real,
-  reproducible contributor to the ~15s CI shortfall rather than noise.
-  Report it as the (or a) responsible commit, with the specific dependency
-  or codegen path named from `cargo build --timings` output.
-- **Kill line (for the "specific commit" hypothesis):** no single commit's
-  isolated delta reaches 5,000ms, and the sum of all deltas across the
-  window stays within run-to-run noise of a repeated build at one fixed
-  commit (measured as a same-commit repeat at the final checkpoint). If so,
-  the verdict is that the shortfall is **not** attributable to a specific
-  commit in this window and the parent report's "far less than confirmed"
-  finding stands without a named cause — CI statistical/runner variance is
-  the better explanation, and no further bisection is warranted.
-- **Conditions:** this sandbox (4-core, 15GiB, rustc/cargo 1.94.1 — same
-  environment class as the parent assay's control). A dedicated git
-  worktree, detached at each commit in chronological order. One shared
-  `target/` directory reused across all 12 checkpoints (external
-  dependency compiles stay warm across the waterfall, matching how CI's
-  `Swatinem/rust-cache` persists across weekly runs) — but before every
-  timed build, the workspace-local crates' own fingerprints and incremental
-  artifacts are cleared (`autumn-macros`, `autumn-web`/`autumn`, and any
-  other workspace member whose Cargo.toml changed in that commit), so every
-  timed number reflects a genuine from-scratch rebuild of *this repo's own
-  code* at that commit, never reused workspace-crate object files.
-  `CARGO_INCREMENTAL=0`. Command timed:
-  `cargo build -p autumn-web --no-default-features --features maud,htmx,tailwind,cache-moka,http-client,reporting`
-  (exactly `DAEMON_NO_DB_FEATURES`, joined). One run per checkpoint (12
-  checkpoints, chronological), plus one repeat run at the final checkpoint
-  (`ef61ae4`) to give a same-commit noise floor.
-- **Time box:** same session. Target ≤ 60 minutes of cumulative build
-  wall-clock. If any single checkpoint step exceeds 10 minutes twice in a
-  row, or the cumulative budget is exhausted before reaching `ef61ae4`,
-  stop and report undetermined with the partial waterfall — that is itself
-  a finding (this class of bisection is too expensive to do cheaply on a
-  weekly cadence, which bears on whether it's worth CI ever doing this
-  automatically).
-- **Riskiest assumption tested first:** that the shortfall is explained by
-  *one* commit's dependency-graph change at all, rather than being an
-  artifact of comparing a 1-sample local A/B (PR #2360) against a 3-sample
-  CI p95 on a different runner a week apart (the parent report's own stated
-  caveat). The same-commit repeat run directly tests this: if repeat-run
-  noise at a single fixed commit is itself comparable to the per-commit
-  deltas seen across the window, the whole bisection approach is answering
-  a question noise already explains, and that finding is reported as such.
-- **Containment:** a detached, uncommitted git worktree
-  (`/tmp/prospect-coldstart-wt`) outside the repo's tracked tree; no CI
-  triggered; no changes to `trunk`/`trunk-dev`; this report is the only
-  artifact that lands in the PR.
+> - **Actual window** (superseding the parent report's unverified guess),
+>   oldest → newest, confirmed via `git log --oneline d1ecb361..ef61ae44` and
+>   `git merge-base --is-ancestor`:
+>   `61bdd9c` (Web Push, #2334) → `28c6fae` (scaffold reconciliation, #2340) →
+>   `651929b` (**the #2309 fix itself**, #2360) → `d6aa668` (admin
+>   impersonation, #2339) → `97a97be` (replay capsule seams, #2348) →
+>   `d96cfab` (cached-read staleness proof, #2352) → `fec5221` (zero-downtime
+>   state migration, #2345) → `8f94e60` (CI-only: clippy parallelism, #2361)
+>   → `76c56b1` (docs/routing example, #2341) → `9c1ede1` (db scrub, #2365) →
+>   `f15ca1b` (classified-data compile-time proof, #2367) → `ef61ae4` (Bolt
+>   form-field escaping, #2376 — the post-fix CI-measured commit itself).
+> - **Pursue-bisection-further line:** a single commit's isolated build delta
+>   (vs. the immediately preceding checkpoint, same feature set, same warmed
+>   target dir) is ≥ 5,000ms — large enough to plausibly be a real,
+>   reproducible contributor to the ~15s CI shortfall rather than noise.
+>   Report it as the (or a) responsible commit, with the specific dependency
+>   or codegen path named from `cargo build --timings` output.
+> - **Kill line (for the "specific commit" hypothesis):** no single commit's
+>   isolated delta reaches 5,000ms, and the sum of all deltas across the
+>   window stays within run-to-run noise of a repeated build at one fixed
+>   commit (measured as a same-commit repeat at the final checkpoint). If so,
+>   the verdict is that the shortfall is **not** attributable to a specific
+>   commit in this window and the parent report's "far less than confirmed"
+>   finding stands without a named cause — CI statistical/runner variance is
+>   the better explanation, and no further bisection is warranted.
+> - **Conditions:** this sandbox (4-core, 15GiB, rustc/cargo 1.94.1 — same
+>   environment class as the parent assay's control). A dedicated git
+>   worktree, detached at each commit in chronological order. One shared
+>   `target/` directory reused across all checkpoints (external dependency
+>   compiles stay warm across the waterfall, matching how CI's
+>   `Swatinem/rust-cache` persists across weekly runs) — but before every
+>   timed build, the workspace-local crates' own fingerprints and incremental
+>   artifacts are cleared, so every timed number reflects a genuine
+>   from-scratch rebuild of *this repo's own code* at that commit, never
+>   reused workspace-crate object files. `CARGO_INCREMENTAL=0`. Command
+>   timed: `cargo build -p autumn-web --no-default-features --features
+>   maud,htmx,tailwind,cache-moka,http-client,reporting` (exactly
+>   `DAEMON_NO_DB_FEATURES`, joined). One run per checkpoint, chronological,
+>   plus one repeat run at the final checkpoint (`ef61ae4`) to give a
+>   same-commit noise floor.
+> - **Time box:** same session. Target ≤ 60 minutes of cumulative build
+>   wall-clock. If any single checkpoint step exceeds 10 minutes twice in a
+>   row, or the cumulative budget is exhausted before reaching `ef61ae4`,
+>   stop and report undetermined with the partial waterfall.
+> - **Riskiest assumption tested first:** that the shortfall is explained by
+>   *one* commit's dependency-graph change at all, rather than being an
+>   artifact of comparing a 1-sample local A/B (PR #2360) against a 3-sample
+>   CI p95 on a different runner a week apart.
+> - **Containment:** a detached, uncommitted git worktree, outside the
+>   repo's tracked tree; no CI triggered; no changes to `trunk`/`trunk-dev`;
+>   this report is the only artifact that lands in the PR.
+
+### 🛠️ Correction (found during Codex review, before merge)
+
+The first measurement pass used a **shallow clone** (`git rev-parse
+--is-shallow-repository` → `true`) without noticing it. That silently
+broke two things the pre-registration relied on:
+
+1. `git log --oneline d1ecb361..ef61ae44` returned only **12** commits
+   instead of the true **32** (`git rev-list --count`, confirmed after
+   `git fetch --unshallow`) — 20 real commits were never in the measured
+   window at all, collapsed into one invisible jump from `d1ecb361` straight
+   to `61bdd9c`.
+2. `git merge-base --is-ancestor 1fd6245 ef61ae44` reported failure inside
+   the shallow clone; after unshallowing it correctly reports success —
+   `1fd6245` (Ledgered entities, #2318) **is** an ancestor of `ef61ae44`
+   and **is** part of the real window. The claim in this report's first
+   pushed revision that it wasn't was wrong, caused by the same shallow
+   clone, not by the actual repository history.
+
+Both errors were caught by `chatgpt-codex-connector`'s review of PR #2477
+(two separate P1 findings) before this report merged. **Section "🔍 Prior
+art" below is corrected to match; the window used in the "🧪 Apparatus" and
+"📊 Assay" sections below is the full, verified 32-commit list, superseding
+the incomplete 12-commit list quoted in the pre-registration blockquote
+above.** The pre-registered *criteria, lines, conditions, and time box* are
+unchanged and still govern the verdict — only the commit list the
+pre-registration itself got wrong from tooling error, not from a change in
+the question, is corrected. Re-running against the corrected, complete
+window (rather than quietly patching the pre-registration's commit list to
+match what was actually measured) is what "committed before measurement"
+is supposed to prevent — so this correction reflects fixing a tooling bug
+discovered *after* results existed, not re-drawing the window to fit them.
 
 ## 🔍 Prior art
 
@@ -114,153 +135,217 @@ Committed in this same commit, before any timed build runs.
 - No other report or open PR revisits this gap since the 2026-09-02 report
   merged (checked via `search_pull_requests` for cold-start/bisect terms
   and by re-reading issue #2309's thread — no new activity).
+- **Correction:** the parent report's three named "candidate" commits
+  included `1fd6245`, based on the same shallow-clone-induced ancestry
+  error this report initially repeated. `1fd6245` **is** in the real
+  window (see Correction above) and is measured below (checkpoint
+  `1fd62458`, Δ +805ms — not a standout contributor).
 
 ## 🧪 Apparatus
 
-- One detached git worktree, walked chronologically through the 12 commits
-  above, each timed with the command in **Conditions**.
+- One detached git worktree, walked chronologically through the full,
+  verified 32-commit window (`d1ecb361` exclusive → `ef61ae44` inclusive),
+  each timed with the command in **Conditions**. `git fetch --unshallow`
+  run first this time.
+- Two additional checkpoints beyond the pre-registered plan, added when the
+  data required them, not to move any line: the worktree's *first* build
+  (`dc74ce43`) unavoidably paid a one-time cold dependency-compile cost
+  (103,881ms) that the rest of the chronological walk did not, because
+  external `target/` artifacts hadn't been populated yet — an apparatus
+  artifact of build *order*, not of that commit's code. Both `d1ecb361`
+  (the baseline) and `dc74ce43` (the first step) were re-measured once the
+  target directory was fully warm from the other 31 builds, under the
+  exact same clear-workspace-fingerprints-only protocol as every other
+  checkpoint, so all 33 numbers used in the Assay table below are mutually
+  comparable. The stale cold-build numbers (65,617ms for a differently-warm
+  `d1ecb361` in the first, shallow-clone run; 103,881ms for `dc74ce43`) are
+  reported here for transparency but not used in any delta.
 - No stubs beyond what the parent assay already used: this measures a
   library crate's feature-gated build, not a running app — no server is
   started, no HTTP request is made. That is a deliberate, cheaper proxy for
   the full `autumn new` cold-start journey (which also includes scaffold
   templating and the generated app's own thin compile unit) — the parent
-  assay's control used the same proxy for `autumn-macros` alone and it
-  matched the full-journey CI numbers well in direction/magnitude, though
-  not exactly. This assay inherits that same limitation: it can name which
-  commit adds compile weight to `autumn-web`'s no-DB feature set, but a
-  match to the exact CI millisecond figure is not expected or claimed.
+  assay's control used the same proxy for `autumn-macros` alone. This
+  assay inherits that same limitation, stated plainly in the Verdict.
 
 ## 📊 Assay
 
-**Environment:** detached git worktree (`/tmp/prospect-coldstart-wt`, outside
-the tracked tree), same sandbox as the parent assay (4-core, 15GiB,
-rustc/cargo 1.94.1). One shared `target/` reused across every checkpoint
-below (external deps stay warm); workspace-local crate fingerprints and
-incremental artifacts cleared before every timed build;
+**Environment:** detached git worktree (`/tmp/prospect-coldstart-wt2`,
+outside the tracked tree, unshallowed), same sandbox as the parent assay
+(4-core, 15GiB, rustc/cargo 1.94.1). One shared `target/` reused across
+every checkpoint (external deps stay warm); workspace-local crate
+fingerprints and incremental artifacts cleared before every timed build;
 `CARGO_INCREMENTAL=0`. Command: `cargo build -p autumn-web
 --no-default-features --features maud,htmx,tailwind,cache-moka,http-client,reporting`.
 One run per checkpoint, chronological order, plus a same-commit repeat at
-the end. All 13 builds exited 0 (no failures, no timeouts against the 300s
-per-step cap).
+the end. All 34 builds (32 checkpoints + 2 warm re-measurements of
+`d1ecb361`/`dc74ce43` + 1 final-checkpoint repeat) exited 0.
 
 | Checkpoint (chronological) | Elapsed | Δ vs prev | Note |
 |---|---:|---:|---|
-| `d1ecb361` (window start, CI pre-fix commit) | 65,617ms | — | baseline |
-| `61bdd9c` Web Push (#2334) | 67,653ms | +2,036ms | pre-fix |
-| `28c6fae` scaffold reconciliation (#2340) | 65,456ms | −2,197ms | pre-fix |
-| `651929b` **#2309 fix itself** (#2360) | 36,225ms | **−29,231ms** | the fix |
-| `d6aa668` admin impersonation (#2339) | 37,889ms | +1,664ms | post-fix |
-| `97a97be` replay capsule seams (#2348) | 36,835ms | −1,054ms | post-fix |
-| `d96cfab` cached-read staleness proof (#2352) | 39,371ms | +2,536ms | post-fix |
-| `fec5221` zero-downtime state migration (#2345) | 42,356ms | +2,985ms | post-fix, largest single delta |
-| `8f94e60` CI-only, clippy parallelism (#2361) | 42,773ms | +417ms | post-fix |
-| `76c56b1` docs/routing example (#2341) | 40,337ms | −2,436ms | post-fix |
-| `9c1ede1` db scrub (#2365) | 43,219ms | +2,882ms | post-fix |
-| `f15ca1b` classified-data compile-time proof (#2367) | 41,589ms | −1,630ms | post-fix |
-| `ef61ae4` Bolt form-field escaping (#2376, CI post-fix commit) | 42,378ms | +789ms | window end |
-| `ef61ae4` repeat (noise floor, identical commit/conditions) | 43,052ms | +674ms | same-commit re-run |
+| `d1ecb361` (window start, warm target) | 55,882ms | — | baseline |
+| `dc74ce43` CI-feedback fixups (#2297) | 60,527ms | +4,645ms | pre-fix |
+| `25ed48ff` Bolt: skip HTML-escaping constants (#2298) | 61,948ms | +1,421ms | pre-fix |
+| `31423bfc` CI-feedback: macro-scaling + Redis glob (#2299) | 57,326ms | −4,622ms | pre-fix |
+| `e2efa9b0` CI-feedback: CSRF cache-guard (#2303) | 57,664ms | +338ms | pre-fix |
+| `6a6610c4` Reserve "all" search index name (#2305) | 62,654ms | +4,990ms | pre-fix, closest to the pursue line |
+| `d81a4449` Bound response-body collection, edge capsule (#2307) | 60,223ms | −2,431ms | pre-fix |
+| `7dff7e07` Fix TLS migration panic; named plugin migrations (#2306) | 60,866ms | +643ms | pre-fix |
+| `c9121d5b` Bolt: defer error_id allocation (#2304) | 64,564ms | +3,698ms | pre-fix |
+| `141f36ef` chore(deps): bump base64 (#2301) | 62,046ms | −2,518ms | pre-fix |
+| `5cdb1e17` Ledger: commit hook claim/ack profile (#2300) | 61,829ms | −217ms | pre-fix |
+| `747d204b` fix(cli): Azure bootstrap scaled to zero (#2247) | 56,915ms | −4,914ms | pre-fix |
+| `bbac3304` Ledger: batch search-store upserts (#2308) | 57,589ms | +674ms | pre-fix |
+| `9d99d980` Prove a route's DB query count at compile time (#2315) | 59,179ms | +1,590ms | pre-fix |
+| `52af191d` docs: agents.md | 58,768ms | −411ms | pre-fix |
+| `bc99a4b8` Prove scaffold DSL constraints at runtime (#2317) | 58,035ms | −733ms | pre-fix |
+| `69bb9d18` docs(seo): SEO guide + reddit-clone wiring (#2325) | 59,912ms | +1,877ms | pre-fix |
+| `55febd8a` Scaffold CSV import route (#2324) | 60,156ms | +244ms | pre-fix |
+| `1fd62458` Ledgered entities (#2318) | 60,961ms | +805ms | pre-fix — corrects the "not an ancestor" error |
+| `eba7fc67` Mirror live traffic to shadow build (#2327) | 64,087ms | +3,126ms | pre-fix |
+| `24bf151c` examples: flagship 0.7.0 subsystems (#2338) | 62,793ms | −1,294ms | pre-fix |
+| `61bdd9c2` Web Push (#2334) | 64,788ms | +1,995ms | pre-fix |
+| `28c6fae8` scaffold reconciliation (#2340) | 63,559ms | −1,229ms | pre-fix |
+| `651929b2` **#2309 fix itself** (#2360) | 39,226ms | **−24,333ms** | the fix |
+| `d6aa6688` admin impersonation (#2339) | 39,720ms | +494ms | post-fix |
+| `97a97be4` replay capsule seams (#2348) | 36,970ms | −2,750ms | post-fix |
+| `d96cfab0` cached-read staleness proof (#2352) | 37,930ms | +960ms | post-fix |
+| `fec52215` zero-downtime state migration (#2345) | 42,521ms | +4,591ms | post-fix |
+| `8f94e60b` CI-only: clippy parallelism (#2361) | 42,289ms | −232ms | post-fix |
+| `76c56b1c` docs/routing example (#2341) | 40,946ms | −1,343ms | post-fix |
+| `9c1ede1e` db scrub (#2365) | 38,107ms | −2,839ms | post-fix |
+| `f15ca1bb` classified-data compile-time proof (#2367) | 42,498ms | +4,391ms | post-fix |
+| `ef61ae44` Bolt form-field escaping (#2376, window end) | 42,637ms | +139ms | window end |
+| `ef61ae44` repeat (noise floor) | 42,204ms | −433ms | same-commit re-run |
 
 **Control comparison (against the pre-registered lines):**
 
-- **Pursue line (single commit ≥5,000ms):** not reached by any of the 11
-  non-fix commits. Largest single delta is `fec5221` at +2,985ms — real but
-  well under the line, and of the same order as `28c6fae`'s −2,197ms or
-  `76c56b1`'s −2,436ms, which run the *other* direction. No commit stands
-  out as "the" culprit.
-- **Kill line (sum within same-commit noise):** not cleanly met either. The
-  noise floor from one repeat at `ef61ae4` is 674ms, but the net sum of all
-  9 post-fix deltas is **+6,153ms** (36,225ms → 42,378ms) — about 9x a
-  single noise sample, so it reads as a real, diffuse compile-time creep
-  spread across many unrelated commits (new dependencies/codegen each
-  adding a couple seconds), not pure noise. One repeat sample can't fully
-  separate signal from noise here; that's a limitation of this assay's
-  single-run-per-checkpoint design, stated rather than papered over.
-- **The question this assay actually needed to answer wasn't which specific
-  wording bucket the diffuse creep falls into — it's whether that creep
-  (real or noise) is big enough to explain the CI shortfall. It is not, by
-  a wide margin, and in the wrong direction:** end-to-end across the full
-  window (`d1ecb361` → `ef61ae4`), this `autumn-web`-only proxy moved
-  65,617ms → 42,378ms, **−23,239ms (−35.4%)**. That is *larger* than PR
-  #2360's own confirmed same-box A/B saving (−33%), and far larger than
-  the real CI trajectory (−12.5%, 120,422ms → 105,371ms). If the 9
-  post-fix commits' diffuse compile-time creep were the explanation for
-  CI's shortfall, this proxy should have shown *less* relative saving than
-  the confirmed −33%, not more.
+- **Pursue line (single commit ≥5,000ms):** not reached by any of the 31
+  non-fix commits. Closest is `6a6610c4` at +4,990ms — 10ms under the line
+  — followed by `fec52215` (+4,591ms) and `f15ca1bb` (+4,391ms). None
+  crosses it, so per the pre-registered rule, no single commit is named as
+  "the" culprit.
+- **Kill line (sum within same-commit noise):** the only valid same-run,
+  same-conditions noise sample is the `ef61ae44` repeat: 433ms. (A
+  cross-run comparison of `651929b`'s two measurements — 36,225ms in the
+  first, shallow-clone run vs. 39,226ms here — looked like a 3,001ms swing
+  at first, but the two runs reached that commit through different warm-cache
+  histories, i.e. different conditions, so it is **not** a valid noise
+  sample and is excluded rather than used as evidence either way.) Against
+  the one valid 433ms sample, the sum of all 31 non-fix deltas is
+  **+10,655ms** (+7,677ms pre-fix across 22 commits, +2,978ms post-fix
+  across 9 commits) — about 25x the noise sample. This is not noise by any
+  reasonable reading, so the kill line's second clause is **not** met
+  either.
+- **Neither pre-registered line is met.** No single commit crosses the
+  pursue threshold, but the cumulative non-fix effect is far too large to
+  call noise. The pre-registration did not provide for this outcome, and
+  per Prospect's own rule against moving the kill line after seeing the
+  data, this assay does not force one — see Verdict.
+- **What the complete data changes vs. the (wrong) partial-window read:**
+  end-to-end across the real window, `d1ecb361` (55,882ms, warm) →
+  `ef61ae44` (42,637ms) is **−13,245ms (−23.7%)**, or −13,678ms (−24.5%)
+  using the repeat. That is a real, large improvement — but it sits
+  *between* PR #2360's confirmed −33% same-box A/B and the real CI
+  trajectory's −12.5%, not above the confirmed figure as the incomplete
+  12-commit run wrongly concluded. In **absolute** terms (the number that
+  should track CI's absolute 15,051ms saving more directly than a
+  relative percentage computed against two very different baselines —
+  this proxy's ~56-65k ms vs CI's ~105-120k ms full-journey baseline), this
+  proxy's −13,245ms to −13,678ms is within ~1,373-1,806ms of CI's own
+  −15,051ms saving. The fix's own raw in-context contribution is
+  −24,333ms; **+10,655ms of that gets eaten back by the other 31 commits
+  in the same window, mostly (+7,677ms) before the fix even landed.**
 
-**Worst case / robustness check:** the same-commit repeat at `ef61ae4`
-(43,052ms vs. the first run's 42,378ms, +674ms) confirms single-run
-measurements at this scale carry a few hundred milliseconds of noise, which
-is small relative to the −23,239ms window-wide effect being measured, so
-the headline finding (proxy overshoots the confirmed saving) is not an
-artifact of one noisy run.
+**Worst case / robustness check:** the same-commit repeat at `ef61ae44`
+(42,204ms vs. the first run's 42,637ms, −433ms) shows single-run noise at
+this scale is on the order of a few hundred milliseconds — small next to
+the ±5,000ms line and tiny next to the +10,655ms cumulative effect, so
+that cumulative figure is not an artifact of one noisy run. It cannot,
+however, rule in or rule out any *individual* sub-5,000ms delta in the
+table as signal vs. noise — that needs repeated measurement per commit,
+not done here (see Verdict).
 
 ## 🏁 Verdict
 
-**Kill** — against the pre-set line, for the originally-falsifiable
-question: no single non-fix commit in `d1ecb361..ef61ae44` reaches the
-5,000ms pursue threshold in `autumn-web`'s own no-DB-feature compile time,
-so this assay does not name a single "responsible" commit, and none is
-warranted from this data.
+**Undetermined**, against the pre-set lines exactly as written — not
+"kill," which the first, incomplete-window revision of this report
+incorrectly claimed, and not "pursue," since no single commit clears the
+line either. Reporting this as a clean kill would have been moving the
+goalposts after seeing the data (exactly what Prospect's rules forbid);
+the honest reading of the pre-registration's two binary outcomes is that
+neither fired.
 
-More importantly, this assay **rules out** "a commit regressed
-`autumn-web`'s own compile weight" as *any* part of the explanation for the
-CI shortfall — the opposite of what the parent report's list of three
-candidate commits (one of which, `1fd6245`, wasn't even in this window's
-ancestry — see Question) suggested was worth checking. The library-level
-proxy measured here shows **more** relative saving (−35.4%) than PR #2360's
-own confirmed end-to-end A/B (−33%), which itself showed more saving than
-real CI observed (−12.5%). Chasing the shortfall inside `autumn-web`'s
-Cargo-feature graph is a dry pit: whatever eats the difference between
-"confirmed −33%" and "observed −12.5%" is **not** in this library's own
-compile time, and is not attributable to any of the 11 non-fix commits that
-landed in the same window.
+What this assay does establish, and why it changes the parent report's
+open question materially:
 
-That leaves two live explanations, neither tested here (out of this
-session's time box, and each needs its own pre-registration):
+- **No single commit is "the" cause.** The closest, `6a6610c4` (Reserve
+  "all" as a search index name, #2305) at +4,990ms, is a plausible
+  candidate for a follow-up single-commit re-measurement (repeated runs to
+  separate it from noise), but nothing here names it with confidence.
+- **The CI shortfall is very likely a real, diffuse effect, not
+  measurement noise or an artifact of the earlier incomplete window.**
+  +10,655ms of cumulative compile-time creep, spread across 31 unrelated
+  commits merged in the same week (22 before the fix, 9 after), nets the
+  fix's raw −24,333ms saving down to −13,245ms in this library-only proxy
+  — and that number lands within ~1.8s of CI's own observed −15,051ms
+  absolute saving. That is a materially different, and much better
+  grounded, conclusion than the incomplete-window revision's claim that
+  library compile weight could be ruled out entirely: it cannot. This
+  reverses that claim, per the two Codex review findings that caught it.
+- **This proxy still cannot close the loop on its own.** It measures
+  `autumn-web`'s own compile time, not the full `autumn new → first HTTP
+  200` journey CI actually gates on (scaffolding, the generated app's own
+  compile+link, server start, first request) — the ~1.8s residual gap
+  between this proxy's absolute saving and CI's could easily live there,
+  or in ordinary CI/runner variance (the parent report's already-flagged
+  confound: a 1-sample local A/B vs. 3-sample p95s on shared runners a
+  week apart). Nothing here distinguishes those two.
 
-1. **The rest of the cold-start journey** — this proxy only measures
-   `cargo build -p autumn-web`. The full `autumn new → first HTTP 200`
-   journey CI actually measures also includes: scaffolding the throwaway
-   project, compiling the *generated app* itself (a thin crate depending on
-   `autumn-web`, but still its own compile unit + link step), starting the
-   server process, and waiting for the first HTTP 200. Any of those stages
-   could have grown in the same window independent of `autumn-web`'s own
-   feature-gated compile time.
-2. **CI/runner statistics** — the confirmed −33% is a single run per
-   variant on PR #2360's local 4-core box; the CI numbers are 3-sample p95s
-   on GitHub-hosted shared runners, a week apart. Runner class variance
-   and small-sample p95 noise were already flagged as live confounds in the
-   parent report and are not ruled out by this assay — if anything, this
-   assay's clean library-level result (which *should* transfer to CI if
-   `autumn-web`'s compile time were the deciding factor) makes runner/CI
-   noise a more likely explanation by elimination, not less.
+**What would resolve this, as an explicit follow-up (not chartered or run
+here):**
 
-No further bisection of `autumn-web`'s Cargo-feature graph is warranted
-without new information — this pit is dry. A follow-up assay, if
-chartered, should pre-register against the scaffold+app-compile+server-start
-portion of the journey (stage 1 above) using the real `autumn new
---daemon` + `autumn dev-loop-bench --cold-start` harness (matching what PR
-#2360 itself used), ideally run twice per commit to get a per-stage noise
-floor that this single-run library proxy could not fully provide.
+1. Repeat each of the 31 non-fix checkpoints 2-3x to build real per-commit
+   noise floors and re-test `6a6610c4`, `c9121d5b` (+3,698ms), `eba7fc67`
+   (+3,126ms), `fec52215` (+4,591ms), and `f15ca1bb` (+4,391ms)
+   specifically against the pursue line with that noise floor in hand.
+2. Extend the same chronological-waterfall method to the
+   scaffold+app-compile+server-start portion of the journey, using the
+   real `autumn dev-loop-bench --cold-start` harness (matching what PR
+   #2360 itself used), to close the residual ~1.8s gap between this
+   proxy's absolute saving and CI's.
 
 ## 💰 Cost to productionize
 
-N/A — kill verdict, no build to productionize. This assay itself cost
-~11 minutes of build wall-clock in one sandbox session, comfortably inside
-the pre-registered ≤60-minute box.
+N/A — undetermined verdict, no build to productionize. This assay's build
+wall-clock: ~11 minutes for the first (shallow-clone, invalidated) pass,
+~34 minutes for the corrected 32-checkpoint pass plus the two warm
+re-measurements — about 45 minutes total across both passes, against the
+pre-registered ≤60-minute *per-pass* box. The shallow-clone bug and its
+correction cost real time; that overhead is itself a data point for anyone
+scoping a repeat of this method (`git fetch --unshallow` first, always).
 
 ## 🔬 Reproduce
 
 ```bash
-# Requires a git worktree at the repo's history (works from any clone with
-# the full commit range d1ecb361..ef61ae44 available):
-git worktree add --detach /tmp/prospect-coldstart-wt d1ecb361
+# IMPORTANT: unshallow first. A shallow clone silently truncates git log
+# ranges and git merge-base --is-ancestor results without erroring — this
+# is exactly the bug that produced this report's first, wrong revision.
+git fetch --unshallow origin 2>/dev/null || true
+git rev-parse --is-shallow-repository   # must print "false" before continuing
 
-cd /tmp/prospect-coldstart-wt
+git worktree add --detach /tmp/prospect-coldstart-wt2 d1ecb361
+cd /tmp/prospect-coldstart-wt2
 FEATURES=maud,htmx,tailwind,cache-moka,http-client,reporting
 
-for c in d1ecb361 61bdd9c 28c6fae 651929b d6aa668 97a97be d96cfab fec5221 \
-         8f94e60 76c56b1 9c1ede1 f15ca1b ef61ae4; do
+# Full, verified window (d1ecb361 exclusive .. ef61ae44 inclusive, 32 commits):
+COMMITS=(dc74ce43 25ed48ff 31423bfc e2efa9b0 6a6610c4 d81a4449 7dff7e07 c9121d5b \
+         141f36ef 5cdb1e17 747d204b bbac3304 9d99d980 52af191d bc99a4b8 69bb9d18 \
+         55febd8a 1fd62458 eba7fc67 24bf151c 61bdd9c2 28c6fae8 651929b2 d6aa6688 \
+         97a97be4 d96cfab0 fec52215 8f94e60b 76c56b1c 9c1ede1e f15ca1bb ef61ae44)
+
+# Warm baseline first (matches all other checkpoints' conditions):
+for c in d1ecb361 "${COMMITS[@]}"; do
   git checkout --detach "$c" --quiet
   rm -rf target/debug/deps/libautumn_macros* target/debug/deps/libautumn_web* \
          target/debug/deps/libautumn-* target/debug/deps/autumn_macros-* \
@@ -274,5 +359,5 @@ for c in d1ecb361 61bdd9c 28c6fae 651929b d6aa668 97a97be d96cfab fec5221 \
   echo "$c: $((END-START))ms"
 done
 
-git worktree remove /tmp/prospect-coldstart-wt --force   # dismantle
+git worktree remove /tmp/prospect-coldstart-wt2 --force   # dismantle
 ```

--- a/docs/reports/2026-09-03-prospect-cold-start-post-fix-bisect.md
+++ b/docs/reports/2026-09-03-prospect-cold-start-post-fix-bisect.md
@@ -1,4 +1,4 @@
-# ⛏️ Prospect: which commit ate the missing cold-start savings? (undetermined: the pre-fix and post-fix compile-time growth is real (≈5σ vs calibrated noise), but telescoping math means no single commit can be named)
+# ⛏️ Prospect: which commit ate the missing cold-start savings? (undetermined: total window effect is real (~13,000ms), but whether the pre/post-fix spans are signal or noise depends on a noise estimate this assay can't pin down, and no single commit can be named either way)
 
 ## 🎯 Question
 
@@ -195,9 +195,21 @@ every checkpoint (external deps stay warm); workspace-local crate
 fingerprints and incremental artifacts cleared before every timed build;
 `CARGO_INCREMENTAL=0`. Command: `cargo build -p autumn-web
 --no-default-features --features maud,htmx,tailwind,cache-moka,http-client,reporting`.
-One run per checkpoint, chronological order, plus a same-commit repeat at
-the end. All 34 builds (32 checkpoints + 2 warm re-measurements of
-`d1ecb361`/`dc74ce43` + 1 final-checkpoint repeat) exited 0.
+One run per checkpoint, chronological order, plus a same-commit repeat
+built into that same pass. **Build count, corrected (Codex P2 on
+`480f7ec5`):** this pass ran 35 builds — 32 chronological checkpoints
+(`dc74ce43` through `ef61ae44`) + 1 same-commit repeat of `ef61ae44` built
+into that same run + 2 warm re-measurements of `d1ecb361`/`dc74ce43` — not
+34 as an earlier revision stated (simple arithmetic error: 32+2+1=35). The
+dedicated noise-floor calibration below is a **separate** pass of 6 more
+builds (5 valid + 1 discarded cold-artifact), run afterward. Its reported
+"7 valid samples" are **not** 6 new plus something else — they are the 5
+valid new builds from that separate pass **plus 2 samples already produced
+by this 35-build pass** (the `ef61ae44` chronological-checkpoint value,
+42,637ms, and this pass's own built-in `ef61ae44` repeat, 42,204ms). Total
+distinct builds across both passes: 35 + 6 = 41, all exited 0 (the
+discarded cold-artifact build succeeded; it's excluded from analysis as
+non-representative, not because it failed).
 
 | Checkpoint (chronological) | Elapsed | Δ vs prev | Note |
 |---|---:|---:|---|
@@ -284,21 +296,29 @@ calibrated noise floor in hand:**
   (ef61ae44 − 651929b2)` = `(63,559−55,882) + (42,637−39,226)` =
   `+7,677ms + 3,411ms` = **+11,088ms**, with expected noise stdev
   `1,080ms·√4 = 2,160ms` — **not** `1,527ms·√31`. Against that correctly-
-  derived figure, +11,088ms is **≈5.13σ**: the pre-fix span alone
-  (+7,677ms vs. a 2-endpoint stdev of 1,080ms·√2≈1,527ms) is ≈5.03σ, the
-  post-fix span (+3,411ms) is ≈2.23σ. This is not plausibly noise, and the
-  kill line's second clause is **not met** — reversing what the
-  immediately preceding text here claimed. One caveat kept deliberately
-  visible rather than smoothed over: the σ=1,080ms calibration came from 7
-  builds run back-to-back in one short batch, while the 32-checkpoint walk
-  ran continuously for ~35 minutes with more room for thermal/scheduling
-  drift — the `dc74ce43`/`31423bfc` adjacent-delta magnitude (≈4,600ms,
-  implying a per-point σ some 2-3x the clustered calibration's, if treated
-  as representative of that longer walk) is a live reason the true z-score
-  for the segment-level effect could be smaller than 5.1σ. Even discounted
-  by that much, though, it stays solidly above the ~2σ range associated
-  with real, not-noise effects. See Verdict for what this does and does
-  not establish.
+  derived figure, +11,088ms is **≈5.13σ *if* the calibration's σ=1,080ms
+  represents the noise present throughout the whole 32-checkpoint walk**:
+  the pre-fix span alone (+7,677ms vs. a 2-endpoint stdev of
+  1,080ms·√2≈1,527ms) would be ≈5.03σ, the post-fix span (+3,411ms) ≈2.23σ.
+  **That premise doesn't hold, and carrying the correction through changes
+  the answer, not just the caveat** (Codex P1 on `480f7ec5`, correcting
+  the previous sentence here, which raised this same caveat and then
+  wrongly asserted it didn't matter): the calibration's 7 builds ran
+  back-to-back in one short batch, while the 32-checkpoint walk ran
+  continuously for ~35 minutes with more room for thermal/scheduling
+  drift, and `dc74ce43`/`31423bfc`'s adjacent-delta magnitude (≈4,600ms)
+  implies a per-point σ during that longer walk perhaps 2-3x the clustered
+  calibration's. Carrying that multiplier through, rather than gesturing
+  at it: at 2x, pre-fix drops to ≈2.51σ and post-fix to ≈1.12σ (combined
+  ≈2.57σ); at 3x, pre-fix ≈1.68σ, post-fix ≈0.74σ (combined ≈1.71σ). At
+  the upper end of the range this report's own evidence supports, **the
+  post-fix span is not distinguishable from noise, and even the combined
+  figure is only weak evidence, not the ≈5σ headline number.** The honest
+  range is ≈1.7σ-5.1σ combined, ≈0.7σ-2.2σ for the post-fix span alone —
+  and this assay has no way to determine, from the data collected, which
+  end of that range is closer to true. Resolving it needs noise
+  calibration interspersed *throughout* a long chronological walk, not a
+  clustered batch run separately from it — not done here. See Verdict.
 - **The total-window figure survives, even though attribution inside it
   does not.** End-to-end, `d1ecb361` (55,882ms, one warm sample) →
   `ef61ae44` (42,837ms, 7-sample calibrated mean) is **−13,045ms
@@ -340,38 +360,55 @@ live report needs the map:
    chronological chain, and summing two *contiguous* runs of them
    telescopes to just their four segment-boundary points, not 31
    independent measurements.
-4. **This revision:** correcting the telescoping error, the non-fix sum's
-   real expected noise stdev is `1,080ms·√4 = 2,160ms` (four independent
-   endpoint measurements, not 31), and the observed +11,088ms is **≈5.1σ**
-   — a real, not-noise, systematic compile-time increase across the
-   pre-fix span (`d1ecb361`→`28c6fae8`, ≈5.0σ) and, more weakly, the
-   post-fix span (`651929b2`→`ef61ae44`, ≈2.2σ). See Assay for the caveat
-   about the calibration's own representativeness that keeps this from
-   being stated as beyond-doubt.
+4. **Revision 4: corrected the telescoping error, claimed ≈5.1σ, "real,
+   not noise."** Half right: the telescoping correction itself
+   (`1,080ms·√4 = 2,160ms`, not `1,527ms·√31`) is sound and stands. But
+   that revision raised its own caveat about the calibration's
+   representativeness over a longer, less-controlled walk, then asserted
+   without checking that the conclusion "stays solidly above the ~2σ
+   range" regardless — it didn't verify that.
+5. **This revision:** carrying that caveat's own numbers through (Codex
+   P1 on `480f7ec5`) changes the answer. At a 2-3x noise inflation — the
+   range the `dc74ce43`/`31423bfc` evidence implies for the full walk —
+   the combined significance ranges **≈1.7σ-5.1σ**, and the post-fix span
+   alone ranges **≈0.7σ-2.2σ**, i.e. *not* reliably distinguishable from
+   noise at the pessimistic end. See Assay for the numbers at each
+   multiplier.
 
 **What this assay establishes, and at what confidence:**
 
 - **The total window effect is real and large.** `d1ecb361` → `ef61ae44`,
   ≈−13,000ms (−23-24%), roughly 8-9x the single-measurement noise floor —
-  not in serious doubt at any point across all four revisions.
-- **The pre-fix and post-fix spans each show a real (not noise) net
-  increase in compile time**, not just the total window — ≈5.0σ and
-  ≈2.2σ respectively, per the corrected math above. This is closer to
-  revision 2's original instinct than revision 3's retraction of it,
-  though revision 2 reached it through invalid reasoning (a single
-  under-representative repeat), so getting the right qualitative answer
-  there was luck, not method.
-- **What remains genuinely unresolved: attribution to any specific
-  commit.** Telescoping means a sum over a contiguous span carries *zero*
-  information about which intermediate commit(s) caused the change — that
-  is mathematically true regardless of noise. Individually, `6a6610c4`
-  (+4,990ms) is the largest single delta at ≈3.3σ against the calibrated
-  per-delta noise — a real single-comparison signal, but it was also the
-  largest of 31 candidate deltas, and the expected maximum of 31
-  independent noise draws is itself around 2.5-2.9σ, so this specific
-  value cannot be confidently distinguished from "the biggest of 31 noisy
-  draws" without a dedicated repeat measurement of that one commit. No
-  commit in this dataset clears that bar.
+  not in serious doubt at any point across all five revisions, and not
+  sensitive to the noise-inflation question above (it's a direct 2-point
+  comparison with a huge effect size, not a telescoped sum).
+- **Whether the pre-fix and post-fix spans individually show real,
+  not-noise compile-time growth is genuinely unresolved, not just
+  unattributed.** Under the calibration's own tight noise estimate
+  (σ=1,080ms from a clustered batch), both spans read as real (≈5.0σ
+  pre-fix, ≈2.2σ post-fix). Under the noise scale the report's own
+  `dc74ce43`/`31423bfc` evidence implies for a long, less-controlled walk
+  (2-3x higher), the post-fix span is not distinguishable from noise and
+  the pre-fix span's significance drops substantially too. This assay
+  cannot determine which noise estimate is closer to true — that needs
+  noise calibration interspersed *throughout* a long walk, not a
+  clustered batch run separately from it (not done here). Revision 2's
+  "very likely real" framing was closer to the optimistic end of this
+  range than revision 3's "not distinguishable from noise" was to the
+  pessimistic end, but neither revision had the honest range in hand when
+  it was written.
+- **What remains genuinely unresolved regardless: attribution to any
+  specific commit.** Telescoping means a sum over a contiguous span
+  carries *zero* information about which intermediate commit(s) caused
+  the change — mathematically true independent of the noise-scale
+  question above. Individually, `6a6610c4` (+4,990ms) is the largest
+  single delta at ≈3.3σ against the tight calibration's per-delta noise
+  (lower, and further from significant, under the inflated estimate) — a
+  real single-comparison signal at best, but also the largest of 31
+  candidate deltas, and the expected maximum of 31 independent noise
+  draws is itself around 2.5-2.9σ even under the tight estimate. No
+  commit in this dataset clears a confident attribution bar under either
+  noise scale.
 - **The residual gap to CI is still unexplained.** This proxy's ≈−13,000ms
   absolute saving sits close to, but not exactly at, CI's own observed
   −15,051ms — and this proxy still only measures `autumn-web`'s own

--- a/docs/reports/2026-09-03-prospect-cold-start-post-fix-bisect.md
+++ b/docs/reports/2026-09-03-prospect-cold-start-post-fix-bisect.md
@@ -1,4 +1,4 @@
-# ⛏️ Prospect: which commits ate the missing cold-start savings? (undetermined: no single commit ≥5,000ms, but +10,655ms of diffuse creep across 31 commits closely tracks the CI shortfall in absolute terms)
+# ⛏️ Prospect: which commits ate the missing cold-start savings? (undetermined: total window effect (−13,000ms) is real, but calibrated noise (σ≈1,080-1,527ms) is too close to every individual and cumulative per-commit figure to attribute it)
 
 ## 🎯 Question
 
@@ -167,6 +167,24 @@ discovered *after* results existed, not re-drawing the window to fit them.
   templating and the generated app's own thin compile unit) — the parent
   assay's control used the same proxy for `autumn-macros` alone. This
   assay inherits that same limitation, stated plainly in the Verdict.
+- **A third correction, also from Codex review (P1/P2, on `26e9e040`):**
+  the second revision above treated the single `ef61ae44` repeat (433ms)
+  as *the* noise floor and used it to call the cumulative non-fix sum
+  "real, not noise." Codex pointed out direct counter-evidence already
+  sitting in the table: `dc74ce43` (touches only `autumn-cli` and a
+  benchmark crate's `Cargo.toml` — confirmed via `git show --stat`, neither
+  built by the timed command) shows +4,645ms, and `31423bfc` (touches only
+  `autumn-cache-redis`, a feature this build doesn't enable, and
+  `autumn-cli` — confirmed the same way) shows −4,622ms. Both commits are
+  provable no-ops for `cargo build -p autumn-web` with this feature set,
+  yet swing by multi-second amounts — proof the true noise floor is much
+  larger than one repeat suggested, and the second revision's "very likely
+  real" claim was undersupported. In response, a dedicated noise-floor
+  calibration was run: 7 valid repeated builds of the single fixed commit
+  `ef61ae44` under matching warm-target conditions (an 8th, run first in a
+  freshly-created worktree, hit the same cold-dependency-compile artifact
+  described above — 82,156ms — and is excluded for the same reason). See
+  Assay for the result and its consequence for the verdict.
 
 ## 📊 Assay
 
@@ -216,116 +234,155 @@ the end. All 34 builds (32 checkpoints + 2 warm re-measurements of
 | `9c1ede1e` db scrub (#2365) | 38,107ms | −2,839ms | post-fix |
 | `f15ca1bb` classified-data compile-time proof (#2367) | 42,498ms | +4,391ms | post-fix |
 | `ef61ae44` Bolt form-field escaping (#2376, window end) | 42,637ms | +139ms | window end |
-| `ef61ae44` repeat (noise floor) | 42,204ms | −433ms | same-commit re-run |
 
-**Control comparison (against the pre-registered lines):**
+**Noise-floor calibration** (added after Codex review; not in the original
+pre-registration, run to test its own "433ms noise floor" claim): 7 valid
+repeated builds of the fixed commit `ef61ae44`, same warm-target protocol
+as every checkpoint above (an 8th run, first in a fresh worktree, hit the
+cold-dependency-compile artifact described in Apparatus — 82,156ms —
+and is excluded):
+
+`42,637 / 42,204 / 43,204 / 40,843 / 43,667 / 43,184 / 44,117` ms
+— mean **42,837ms**, sample stdev **1,080ms**, min/max spread **3,274ms**.
+
+**Corrected arithmetic** (Codex P2 on `26e9e040`): the previous revision's
+"+10,655ms" non-fix sum wrongly folded the `ef61ae44` repeat's −433ms into
+the post-fix total — a repeat isn't a commit delta. Removing it: post-fix
+sum across the real 9 commits is **+3,411ms** (not +2,978ms), and the
+total non-fix sum across all 31 commits is **+11,088ms** (+7,677ms
+pre-fix, +3,411ms post-fix), not +10,655ms.
+
+**Control comparison (against the pre-registered lines), with the
+calibrated noise floor in hand:**
 
 - **Pursue line (single commit ≥5,000ms):** not reached by any of the 31
-  non-fix commits. Closest is `6a6610c4` at +4,990ms — 10ms under the line
-  — followed by `fec52215` (+4,591ms) and `f15ca1bb` (+4,391ms). None
-  crosses it, so per the pre-registered rule, no single commit is named as
-  "the" culprit.
-- **Kill line (sum within same-commit noise):** the only valid same-run,
-  same-conditions noise sample is the `ef61ae44` repeat: 433ms. (A
-  cross-run comparison of `651929b`'s two measurements — 36,225ms in the
-  first, shallow-clone run vs. 39,226ms here — looked like a 3,001ms swing
-  at first, but the two runs reached that commit through different warm-cache
-  histories, i.e. different conditions, so it is **not** a valid noise
-  sample and is excluded rather than used as evidence either way.) Against
-  the one valid 433ms sample, the sum of all 31 non-fix deltas is
-  **+10,655ms** (+7,677ms pre-fix across 22 commits, +2,978ms post-fix
-  across 9 commits) — about 25x the noise sample. This is not noise by any
-  reasonable reading, so the kill line's second clause is **not** met
-  either.
-- **Neither pre-registered line is met.** No single commit crosses the
-  pursue threshold, but the cumulative non-fix effect is far too large to
-  call noise. The pre-registration did not provide for this outcome, and
-  per Prospect's own rule against moving the kill line after seeing the
-  data, this assay does not force one — see Verdict.
-- **What the complete data changes vs. the (wrong) partial-window read:**
-  end-to-end across the real window, `d1ecb361` (55,882ms, warm) →
-  `ef61ae44` (42,637ms) is **−13,245ms (−23.7%)**, or −13,678ms (−24.5%)
-  using the repeat. That is a real, large improvement — but it sits
-  *between* PR #2360's confirmed −33% same-box A/B and the real CI
-  trajectory's −12.5%, not above the confirmed figure as the incomplete
-  12-commit run wrongly concluded. In **absolute** terms (the number that
-  should track CI's absolute 15,051ms saving more directly than a
-  relative percentage computed against two very different baselines —
-  this proxy's ~56-65k ms vs CI's ~105-120k ms full-journey baseline), this
-  proxy's −13,245ms to −13,678ms is within ~1,373-1,806ms of CI's own
-  −15,051ms saving. The fix's own raw in-context contribution is
-  −24,333ms; **+10,655ms of that gets eaten back by the other 31 commits
-  in the same window, mostly (+7,677ms) before the fix even landed.**
-
-**Worst case / robustness check:** the same-commit repeat at `ef61ae44`
-(42,204ms vs. the first run's 42,637ms, −433ms) shows single-run noise at
-this scale is on the order of a few hundred milliseconds — small next to
-the ±5,000ms line and tiny next to the +10,655ms cumulative effect, so
-that cumulative figure is not an artifact of one noisy run. It cannot,
-however, rule in or rule out any *individual* sub-5,000ms delta in the
-table as signal vs. noise — that needs repeated measurement per commit,
-not done here (see Verdict).
+  non-fix commits — closest is `6a6610c4` at +4,990ms, followed by
+  `fec52215` (+4,591ms) and `f15ca1bb` (+4,391ms). With the calibration
+  above, none of these can be called real signal either: a single-delta
+  measurement combines two single-run draws, so its expected noise is
+  ≈1,080ms·√2 ≈ 1,527ms by the calibration — meaning +4,990ms is only
+  ≈3.3 calibrated-σ, and the two known-zero-effect commits (`dc74ce43`
+  +4,645ms, `31423bfc` −4,622ms — see Apparatus; both provably cannot
+  touch this build) already swing at almost exactly that same magnitude
+  purely from noise not captured by the clustered same-commit calibration.
+  The 5,000ms pursue line, chosen before any noise measurement existed,
+  turns out to sit barely above the apparatus's own demonstrated noise
+  ceiling — in hindsight, badly calibrated, not a defect in the commits
+  measured.
+- **Kill line (sum within noise):** using the calibrated per-delta
+  combined-noise estimate (≈1,527ms) and treating the 31 non-fix deltas as
+  independent, the expected stdev of their **sum** is ≈1,527ms·√31 ≈
+  8,504ms. The observed sum, +11,088ms, is ≈1.3 of that — not
+  distinguishable from a zero-mean accumulation of per-step noise at any
+  conventional confidence level. (Using the larger, `dc74ce43`/`31423bfc`-
+  implied noise scale instead would widen that expected stdev further,
+  weakening the case for a real cumulative effect even more.) The kill
+  line's second clause is **arguably met** under this analysis — but the
+  pre-registration wrote "stays within run-to-run noise of a repeated
+  build," a bar it did not define numerically, and a single calibration
+  run after the fact is thin evidence to hang a clean "kill" on. This
+  assay does not force that call — see Verdict.
+- **The total-window figure survives, even though attribution inside it
+  does not.** End-to-end, `d1ecb361` (55,882ms, one warm sample) →
+  `ef61ae44` (42,837ms, 7-sample calibrated mean) is **−13,045ms
+  (−23.4%)**, consistent with the single-sample estimate reported before
+  calibration (−13,245ms, −23.7%). At ≈13,000ms, this is roughly 8-9x the
+  calibrated single-measurement stdev (1,080-1,527ms), so the *total*
+  window effect is not plausibly noise. What calibration removes is
+  confidence in *why*: whether that total is the fix's raw −24,333ms
+  partly clawed back by real per-commit compile-time growth (this report's
+  second revision's claim), or whether the raw in-context fix effect
+  itself is simply smaller than PR #2360's isolated same-box A/B for
+  reasons this apparatus can't see (measurement-context differences,
+  since the fix's own delta, −24,333ms, was measured only once and was
+  never itself calibrated against repeats either).
 
 ## 🏁 Verdict
 
-**Undetermined**, against the pre-set lines exactly as written — not
-"kill," which the first, incomplete-window revision of this report
-incorrectly claimed, and not "pursue," since no single commit clears the
-line either. Reporting this as a clean kill would have been moving the
-goalposts after seeing the data (exactly what Prospect's rules forbid);
-the honest reading of the pre-registration's two binary outcomes is that
-neither fired.
+**Undetermined** — against the pre-set lines exactly as written, and this
+time for a directly measured, quantified reason rather than an assumption.
+This report went through three revisions before landing here, each one
+caught by a different Codex review finding on PR #2477; all three are
+worth stating plainly rather than only keeping the final number:
 
-What this assay does establish, and why it changes the parent report's
-open question materially:
+1. **First revision: "Kill."** Wrong — built on a shallow clone that
+   silently measured 12 of the real 32 commits in the window and got a
+   commit-ancestry check backwards. Corrected by unshallowing and
+   re-measuring the complete window.
+2. **Second revision: "the shortfall is very likely a real, diffuse
+   effect."** Also unsupported — it treated one repeat (433ms) as the
+   noise floor and called a +10,655ms cumulative sum "25x noise" without
+   ever testing whether 433ms was representative. It wasn't: two commits
+   in the table (`dc74ce43`, `31423bfc`) are provable no-ops for this
+   build yet swing by ±4,600ms purely from run-to-run variance —
+   caught by Codex, confirmed by a dedicated 7-sample calibration run
+   (mean 42,837ms, stdev 1,080ms) showing the true per-measurement noise
+   is roughly 2.5x what one repeat suggested.
+3. **This revision, with the calibration in hand:** neither pre-registered
+   line can be honestly triggered. No single commit reaches the 5,000ms
+   pursue line — the closest (`6a6610c4`, +4,990ms) is statistically
+   indistinguishable from the noise two known-zero-effect commits already
+   demonstrate at almost the same magnitude. The kill line's "sum stays
+   within noise" clause is arguably satisfiable under a formal
+   independent-noise model (+11,088ms observed vs. ≈8,504ms expected
+   stdev, ≈1.3σ) — but the pre-registration never defined that bar
+   numerically, one post-hoc calibration run is thin evidence to hang a
+   clean verdict on, and the fix's own −24,333ms delta was never itself
+   calibrated against repeats. Forcing either "kill" or "pursue" here
+   would be the same mistake the first two revisions made in different
+   directions.
 
-- **No single commit is "the" cause.** The closest, `6a6610c4` (Reserve
-  "all" as a search index name, #2305) at +4,990ms, is a plausible
-  candidate for a follow-up single-commit re-measurement (repeated runs to
-  separate it from noise), but nothing here names it with confidence.
-- **The CI shortfall is very likely a real, diffuse effect, not
-  measurement noise or an artifact of the earlier incomplete window.**
-  +10,655ms of cumulative compile-time creep, spread across 31 unrelated
-  commits merged in the same week (22 before the fix, 9 after), nets the
-  fix's raw −24,333ms saving down to −13,245ms in this library-only proxy
-  — and that number lands within ~1.8s of CI's own observed −15,051ms
-  absolute saving. That is a materially different, and much better
-  grounded, conclusion than the incomplete-window revision's claim that
-  library compile weight could be ruled out entirely: it cannot. This
-  reverses that claim, per the two Codex review findings that caught it.
-- **This proxy still cannot close the loop on its own.** It measures
-  `autumn-web`'s own compile time, not the full `autumn new → first HTTP
-  200` journey CI actually gates on (scaffolding, the generated app's own
-  compile+link, server start, first request) — the ~1.8s residual gap
-  between this proxy's absolute saving and CI's could easily live there,
-  or in ordinary CI/runner variance (the parent report's already-flagged
-  confound: a 1-sample local A/B vs. 3-sample p95s on shared runners a
-  week apart). Nothing here distinguishes those two.
+**What this assay does establish, robustly:** the total window effect —
+`d1ecb361` → `ef61ae44`, roughly **−13,000ms (−23-24%)** whether measured
+by single sample (−13,245ms) or calibrated mean (−13,045ms) — is real and
+large relative to the now-measured noise floor (≈1,080-1,527ms). In
+**absolute** terms it sits close to CI's own observed −15,051ms saving.
+**What it cannot establish:** whether that −13,000ms is the fix's raw
+effect (−24,333ms) genuinely clawed back by real compile-time growth in
+the other 31 commits, or whether the raw fix effect was simply smaller
+in this full-chronology context than PR #2360's isolated same-box A/B for
+reasons unrelated to any of those 31 commits. Both this proxy's per-commit
+resolution and the parent report's already-flagged CI/runner-variance
+confound remain live, undistinguished explanations.
 
 **What would resolve this, as an explicit follow-up (not chartered or run
 here):**
 
-1. Repeat each of the 31 non-fix checkpoints 2-3x to build real per-commit
-   noise floors and re-test `6a6610c4`, `c9121d5b` (+3,698ms), `eba7fc67`
-   (+3,126ms), `fec52215` (+4,591ms), and `f15ca1bb` (+4,391ms)
-   specifically against the pursue line with that noise floor in hand.
-2. Extend the same chronological-waterfall method to the
-   scaffold+app-compile+server-start portion of the journey, using the
-   real `autumn dev-loop-bench --cold-start` harness (matching what PR
-   #2360 itself used), to close the residual ~1.8s gap between this
-   proxy's absolute saving and CI's.
+1. This apparatus needs roughly 3+ repeats per checkpoint (not one) to
+   reach the resolution its own pursue/kill lines assumed — a materially
+   larger apparatus (≈3x the build wall-clock used here) than "cheap
+   bisection" originally scoped for. That cost-of-precision finding is
+   itself useful: a single-run cold-start bisection at this repo's noise
+   scale cannot resolve sub-5,000ms effects, so nobody should trust one
+   again without calibrating first.
+2. Also calibrate the fix's own delta (`651929b2`, currently n=1 in this
+   report) with repeats, and extend the method to the
+   scaffold+app-compile+server-start portion of the journey via the real
+   `autumn dev-loop-bench --cold-start` harness, to close the residual gap
+   between this proxy's absolute saving and CI's.
 
 ## 💰 Cost to productionize
 
-N/A — undetermined verdict, no build to productionize. This assay's build
-wall-clock: ~11 minutes for the first (shallow-clone, invalidated) pass,
-~34 minutes for the corrected 32-checkpoint pass plus the two warm
-re-measurements — about 45 minutes total across both passes, against the
-pre-registered ≤60-minute *per-pass* box. The shallow-clone bug and its
-correction cost real time; that overhead is itself a data point for anyone
-scoping a repeat of this method (`git fetch --unshallow` first, always).
+N/A — undetermined verdict, no build to productionize. Build wall-clock
+across all passes: ~11 minutes (first, shallow-clone-invalidated pass) +
+~34 minutes (corrected 32-checkpoint pass + 2 warm re-measurements) + ~7
+minutes (noise-floor calibration, 7 valid + 1 discarded cold-artifact run)
+≈ 52 minutes total, against the pre-registered ≤60-minute *per-pass* box.
+Two real costs stand out for anyone scoping a repeat: (1) `git fetch
+--unshallow` before any window-derivation command, always — a shallow
+clone fails silently, not loudly; (2) a single-run-per-checkpoint design
+is cheap but under-powered at this repo's demonstrated noise scale
+(σ≈1,080-1,527ms) — budget for repeats from the start rather than
+retrofitting a calibration run after the fact, as this report had to.
 
 ## 🔬 Reproduce
+
+This matches the actual procedure used (not the naive version): the first
+commit built in a fresh worktree absorbs a one-time cold dependency
+compile that is not representative of any other checkpoint, so `d1ecb361`
+and the window's first commit are measured chronologically like every
+other checkpoint, then **re-measured** once the target directory is fully
+warm, and only the warm numbers are used in the table.
 
 ```bash
 # IMPORTANT: unshallow first. A shallow clone silently truncates git log
@@ -338,25 +395,49 @@ git worktree add --detach /tmp/prospect-coldstart-wt2 d1ecb361
 cd /tmp/prospect-coldstart-wt2
 FEATURES=maud,htmx,tailwind,cache-moka,http-client,reporting
 
-# Full, verified window (d1ecb361 exclusive .. ef61ae44 inclusive, 32 commits):
-COMMITS=(dc74ce43 25ed48ff 31423bfc e2efa9b0 6a6610c4 d81a4449 7dff7e07 c9121d5b \
-         141f36ef 5cdb1e17 747d204b bbac3304 9d99d980 52af191d bc99a4b8 69bb9d18 \
-         55febd8a 1fd62458 eba7fc67 24bf151c 61bdd9c2 28c6fae8 651929b2 d6aa6688 \
-         97a97be4 d96cfab0 fec52215 8f94e60b 76c56b1c 9c1ede1e f15ca1bb ef61ae44)
-
-# Warm baseline first (matches all other checkpoints' conditions):
-for c in d1ecb361 "${COMMITS[@]}"; do
-  git checkout --detach "$c" --quiet
+clear_workspace_artifacts() {
   rm -rf target/debug/deps/libautumn_macros* target/debug/deps/libautumn_web* \
          target/debug/deps/libautumn-* target/debug/deps/autumn_macros-* \
          target/debug/deps/autumn_web-* target/debug/deps/autumn-* \
          target/debug/.fingerprint/autumn-macros-* target/debug/.fingerprint/autumn-web-* \
          target/debug/.fingerprint/autumn-* target/debug/incremental/autumn_macros-* \
          target/debug/incremental/autumn_web-* target/debug/incremental/autumn-*
+}
+
+timed_build() {
+  clear_workspace_artifacts
   START=$(date +%s%3N)
   CARGO_INCREMENTAL=0 cargo build -p autumn-web --no-default-features --features "$FEATURES"
   END=$(date +%s%3N)
-  echo "$c: $((END-START))ms"
+  echo "$1: $((END-START))ms"
+}
+
+# Full, verified window (d1ecb361 exclusive .. ef61ae44 inclusive, 32 commits).
+# The worktree starts with an EMPTY target/, so this first pass's first
+# checkpoint (dc74ce43) unavoidably pays a one-time cold dependency compile
+# — that number is discarded, not used in the table.
+COMMITS=(dc74ce43 25ed48ff 31423bfc e2efa9b0 6a6610c4 d81a4449 7dff7e07 c9121d5b \
+         141f36ef 5cdb1e17 747d204b bbac3304 9d99d980 52af191d bc99a4b8 69bb9d18 \
+         55febd8a 1fd62458 eba7fc67 24bf151c 61bdd9c2 28c6fae8 651929b2 d6aa6688 \
+         97a97be4 d96cfab0 fec52215 8f94e60b 76c56b1c 9c1ede1e f15ca1bb ef61ae44)
+for c in "${COMMITS[@]}"; do
+  git checkout --detach "$c" --quiet
+  timed_build "$c"
+done
+
+# Re-measure d1ecb361 and dc74ce43 now that target/ is fully warm from the
+# pass above — these two (and only these two) replace their earlier numbers.
+for c in d1ecb361 dc74ce43; do
+  git checkout --detach "$c" --quiet
+  timed_build "${c}-warm"
+done
+
+# Noise-floor calibration: repeat the final checkpoint under matching warm
+# conditions. Run at least 3x (this report used 7) before treating any
+# individual or cumulative delta above as signal rather than noise.
+git checkout --detach ef61ae44 --quiet
+for i in 1 2 3 4 5 6 7; do
+  timed_build "ef61ae44-repeat-${i}"
 done
 
 git worktree remove /tmp/prospect-coldstart-wt2 --force   # dismantle

--- a/docs/reports/2026-09-03-prospect-cold-start-post-fix-bisect.md
+++ b/docs/reports/2026-09-03-prospect-cold-start-post-fix-bisect.md
@@ -184,12 +184,31 @@ per-commit correction below) changes the list:
   delta should **not** be discounted on this basis — if it's real, the
   cause is something else (or noise, per the significance discussion
   above).
-- `141f36ef` (a `base64` patch-version bump) and `61bdd9c2` (Web Push)
-  are **confirmed real**: `cargo tree` shows both `base64 v0.22.1` and
-  `v0.23.1` coexisting in this exact feature set (the bump adds a second
-  compiled version, not a swap), and `p256 v0.13.2` — the crate Web
-  Push's own commit message says gained a new `ecdh` feature flag — is in
-  the tree too.
+- `141f36ef` (a `base64` patch-version bump) — **retracted, a third
+  confirmed false positive** (Codex P2 on `cc91a56d`): the coexistence of
+  `base64 v0.22.1` and `v0.23.1` I cited as evidence isn't caused by this
+  commit — checking both `141f36ef^:Cargo.lock` and `141f36ef:Cargo.lock`
+  package-by-package (which package's `dependencies` list names which
+  `base64` version) shows `bcrypt` (an unconditional, direct dependency
+  of `autumn-web` — confirmed via `cargo tree -i bcrypt`) already
+  depended on `base64 0.23.1` **before** this commit, while `axum`,
+  `reqwest`, and everything else kept depending on `0.22.1` **after** it
+  unchanged. `141f36ef` only re-points `autumn-web`'s *own* direct edge
+  from `0.22.1` to `0.23.1` — a version that was already being compiled
+  for `bcrypt`'s sake regardless. No new compiled artifact, before or
+  after.
+- `61bdd9c2` (Web Push) — **confirmed real**, the one commit that
+  survives full scrutiny: its actual `Cargo.lock` diff is a single new
+  line, `autumn-web` gaining a direct dependency edge to `p256 0.13.2` — a
+  version already resolved (and already compiled) via `jsonwebtoken`'s
+  transitive dependency on it, so the crate itself isn't new. What is new
+  is the *feature set* Cargo resolves for it: the commit's own message
+  states it adds `p256`'s `ecdh` feature flag on that new direct edge,
+  and Cargo unifies features across every path to a shared dependency
+  within one build — so `p256` is compiled once, under the union of
+  features every consumer requests, meaning this edge's new feature
+  forces a real (if likely modest) recompile of `p256` that wouldn't
+  happen otherwise.
 - `bc99a4b8` (scaffold DSL constraints) — **retracted, a second confirmed
   false positive** (Codex P2 on `abea7490`, correcting my own prior
   verification, which was sloppy: I saw `reqwest` and `serde_urlencoded`
@@ -208,13 +227,13 @@ per-commit correction below) changes the list:
   `bc99a4b8`. My first correction (`abea7490`) was itself wrong to keep
   this flagged — reversed here.
 
-Net, after two rounds of verification: **2 of the 4** originally-flagged
-commits (`141f36ef`, `61bdd9c2`) are confirmed relevant to this feature
-set's resolved graph; `fec52215` and `bc99a4b8` are both confirmed false
-positives. **For the 2 confirmed commits, this report's deltas cannot be
-trusted as representative of their true, CI-relevant recurring
-contribution** — but not for a purely one-directional reason (see the
-next correction). It
+Net, after three rounds of verification: **only 1 of the 4**
+originally-flagged commits (`61bdd9c2`) is confirmed relevant to this
+feature set's resolved graph; `fec52215`, `bc99a4b8`, and `141f36ef` are
+all confirmed false positives. **For that one confirmed commit, this
+report's delta cannot be trusted as representative of its true,
+CI-relevant recurring contribution** — but not for a purely
+one-directional reason (see the next correction). It
 also means the "total window effect" and "this proxy's absolute saving vs.
 CI's" comparisons throughout Assay and Verdict are weaker than stated
 there: they are not just measuring a narrower workload (library-only, no
@@ -545,15 +564,18 @@ live report needs the map:
   sample (see Apparatus's fourth correction). This apparatus pays each
   external dependency's compile cost once per introduction; CI pays it on
   every sample, forever. Of the 4 non-fix commits that touched
-  `Cargo.lock`, only **2** (`141f36ef`, `61bdd9c2`) are confirmed via
-  version-specific `cargo tree` checks to actually affect this feature
-  set's resolved graph — `fec52215` and, after a second, more careful
-  check, `bc99a4b8` too are both confirmed false positives (see
-  Apparatus's fourth and fifth corrections). Their deltas cannot be
-  trusted as CI-representative, but not in a single, simple direction:
-  the apparatus likely *overcounts* each one's cost at its own
-  introducing checkpoint (charging the full fresh-compile cost rather
-  than CI's much smaller cold-vs-cold marginal difference) and
+  `Cargo.lock`, only **1** (`61bdd9c2`, confirmed via a package-by-package
+  `Cargo.lock` diff: a new direct edge to `p256` carrying a new feature
+  flag, forcing a real recompile under Cargo's feature unification) is
+  confirmed to actually affect this feature set's resolved graph.
+  `fec52215`, `bc99a4b8`, and `141f36ef` are all confirmed false
+  positives on closer inspection (see Apparatus's fourth through sixth
+  corrections — three separate rounds of "touches `Cargo.lock`" turning
+  out not to mean "changes this build's resolved graph"). That one
+  commit's delta cannot be trusted as CI-representative, but not in a
+  single, simple direction: the apparatus likely *overcounts* its cost at
+  its own introducing checkpoint (charging the full fresh-compile cost
+  rather than CI's much smaller cold-vs-cold marginal difference) and
   *undercounts* it at every checkpoint after (nothing shown where CI pays
   every sample). Which effect dominates for this window's total is not
   resolvable from this data. The parent report's CI/runner-variance

--- a/docs/reports/2026-09-03-prospect-cold-start-post-fix-bisect.md
+++ b/docs/reports/2026-09-03-prospect-cold-start-post-fix-bisect.md
@@ -458,12 +458,20 @@ other checkpoint, then **re-measured** once the target directory is fully
 warm, and only the warm numbers are used in the table.
 
 ```bash
-# IMPORTANT: unshallow first. A shallow clone silently truncates git log
-# ranges and git merge-base --is-ancestor results without erroring — this
-# is exactly the bug that produced this report's first, wrong revision.
-git fetch --unshallow origin 2>/dev/null || true
-git rev-parse --is-shallow-repository   # must print "false" before continuing
+set -euo pipefail   # fail loudly, don't silently build the wrong commit
 
+# IMPORTANT: unshallow first, and treat failure as fatal. A shallow clone
+# silently truncates git log ranges and git merge-base --is-ancestor
+# results without erroring — this is exactly the bug that produced this
+# report's first, wrong revision. `|| true` here would suppress a fetch
+# failure and let the script carry on against a still-shallow repo.
+git fetch --unshallow origin
+if [ "$(git rev-parse --is-shallow-repository)" != "false" ]; then
+  echo "FATAL: repository is still shallow after fetch --unshallow" >&2
+  exit 1
+fi
+
+REPO_ROOT=$(pwd)   # so we can cd back out before removing a worktree
 git worktree add --detach /tmp/prospect-coldstart-wt2 d1ecb361
 cd /tmp/prospect-coldstart-wt2
 FEATURES=maud,htmx,tailwind,cache-moka,http-client,reporting
@@ -512,6 +520,9 @@ for c in d1ecb361 dc74ce43; do
   timed_build "${c}-warm"
 done
 
+cd "$REPO_ROOT"   # must leave the worktree before removing it, or the next
+                  # `git worktree add` fails with "Unable to read current
+                  # working directory"
 git worktree remove /tmp/prospect-coldstart-wt2 --force
 
 # Noise-floor calibration is a SEPARATE pass, in a fresh worktree (empty
@@ -526,5 +537,6 @@ cd /tmp/prospect-noise-wt
 for i in 1 2 3 4 5 6; do
   timed_build "ef61ae44-calibration-${i}"   # run 1 is the expected cold outlier — discard it
 done
+cd "$REPO_ROOT"
 git worktree remove /tmp/prospect-noise-wt --force
 ```

--- a/docs/reports/2026-09-03-prospect-cold-start-post-fix-bisect.md
+++ b/docs/reports/2026-09-03-prospect-cold-start-post-fix-bisect.md
@@ -254,9 +254,12 @@ checkpoint specifically, this apparatus likely **overcounts** the
 commit's true CI-relevant marginal cost; at every checkpoint *after* it,
 the dependency is cached and the apparatus shows nothing for it, which
 **undercounts** the recurring cost CI keeps paying. Both directions are
-real, and this report cannot say which dominates for `141f36ef` or
-`61bdd9c2` specifically without a genuinely cold-per-checkpoint rerun.
-Practically, this makes individual per-commit deltas in this dataset
+real, and this report cannot say which dominates for `61bdd9c2`
+specifically (the one commit confirmed graph-relevant above — `141f36ef`
+is a confirmed false positive with no compiled artifact change either
+way, so this caveat doesn't apply to it) without a genuinely
+cold-per-checkpoint rerun. Practically, this makes individual per-commit
+deltas in this dataset
 *less* interpretable than the "undercount only" framing suggested, not
 more — reinforcing the undetermined verdict, not weakening it. Not
 corrected by re-running (out of this session's time box — a true
@@ -463,12 +466,24 @@ calibrated noise floor in hand:**
   calibration interspersed *throughout* a long chronological walk, not a
   clustered batch run separately from it — not done here. See Verdict.
 - **The total-window figure survives, even though attribution inside it
-  does not.** End-to-end, `d1ecb361` (55,882ms, one warm sample) →
+  does not — but at a lower confidence than first stated** (Codex P2 on
+  `c38feaa9`, applying the same walk-noise inflation caveat here that the
+  kill-line discussion above already applied to the pre/post-fix spans,
+  rather than treating this claim as exempt from it). End-to-end,
+  `d1ecb361` (55,882ms, one warm sample from the 32-checkpoint walk) →
   `ef61ae44` (42,837ms, 7-sample calibrated mean) is **−13,045ms
   (−23.4%)**, consistent with the single-sample estimate reported before
-  calibration (−13,245ms, −23.7%). At ≈13,000ms, this is roughly 8-9x the
-  calibrated single-measurement stdev (1,080-1,527ms), so the *total*
-  window effect is not plausibly noise. What calibration removes is
+  calibration (−13,245ms, −23.7%). Using the clustered calibration's
+  σ=1,080ms at face value, that's ≈8-9σ (dominated by the single, n=1
+  `d1ecb361` sample's stdev, since the endpoint's 7-sample mean has a much
+  smaller SE of ≈408ms) — but `d1ecb361` was measured *within* the same
+  noisy 32-checkpoint walk the kill-line discussion flags as possibly
+  2-3x noisier than the clustered calibration. Applying that same 2-3x
+  range to `d1ecb361`'s stdev gives a combined uncertainty of
+  ≈2,200-3,270ms, so the honest range is **≈4.0σ-5.9σ**, not 8-9σ. Still
+  comfortably real at either end of that range — just not as
+  overwhelmingly so as the unadjusted number suggested. What calibration
+  removes is
   confidence in *why*: whether that total is the fix's raw −24,333ms
   partly clawed back by real per-commit compile-time growth (this report's
   second revision's claim), or whether the raw in-context fix effect
@@ -520,11 +535,17 @@ live report needs the map:
 
 **What this assay establishes, and at what confidence:**
 
-- **The total window effect is real and large.** `d1ecb361` → `ef61ae44`,
-  ≈−13,000ms (−23-24%), roughly 8-9x the single-measurement noise floor —
-  not in serious doubt at any point across all five revisions, and not
-  sensitive to the noise-inflation question above (it's a direct 2-point
-  comparison with a huge effect size, not a telescoped sum).
+- **The total window effect is real and large, though not fully immune to
+  the same noise-inflation question as the spans below** (Codex P2 on
+  `c38feaa9`, correcting an earlier claim that this comparison was exempt
+  from the walk-noise caveat; it isn't, since `d1ecb361` was measured
+  within that same noisy walk). `d1ecb361` →
+  `ef61ae44`, ≈−13,000ms (−23-24%), is ≈8-9σ against the clustered
+  calibration's tight noise estimate but ≈4.0-5.9σ against the same
+  2-3x-inflated estimate applied to the spans below (see Assay) — still
+  solidly real at either end, unlike the post-fix span, but with real
+  (if modest, given the size of the effect) uncertainty in exactly how
+  solid.
 - **Whether the pre-fix and post-fix spans individually show real,
   not-noise compile-time growth is genuinely unresolved, not just
   unattributed.** Under the calibration's own tight noise estimate

--- a/docs/reports/2026-09-03-prospect-cold-start-post-fix-bisect.md
+++ b/docs/reports/2026-09-03-prospect-cold-start-post-fix-bisect.md
@@ -1,4 +1,4 @@
-# ⛏️ Prospect: which post-#2309-fix commit ate the missing cold-start savings? (TBD)
+# ⛏️ Prospect: which post-#2309-fix commit ate the missing cold-start savings? (kill: no single commit ≥5,000ms vs the pursue line; proxy overshoots the confirmed saving, so the shortfall isn't here)
 
 ## 🎯 Question
 
@@ -132,4 +132,147 @@ Committed in this same commit, before any timed build runs.
 
 ## 📊 Assay
 
-_Filled in after runs complete — see the follow-up commit to this file._
+**Environment:** detached git worktree (`/tmp/prospect-coldstart-wt`, outside
+the tracked tree), same sandbox as the parent assay (4-core, 15GiB,
+rustc/cargo 1.94.1). One shared `target/` reused across every checkpoint
+below (external deps stay warm); workspace-local crate fingerprints and
+incremental artifacts cleared before every timed build;
+`CARGO_INCREMENTAL=0`. Command: `cargo build -p autumn-web
+--no-default-features --features maud,htmx,tailwind,cache-moka,http-client,reporting`.
+One run per checkpoint, chronological order, plus a same-commit repeat at
+the end. All 13 builds exited 0 (no failures, no timeouts against the 300s
+per-step cap).
+
+| Checkpoint (chronological) | Elapsed | Δ vs prev | Note |
+|---|---:|---:|---|
+| `d1ecb361` (window start, CI pre-fix commit) | 65,617ms | — | baseline |
+| `61bdd9c` Web Push (#2334) | 67,653ms | +2,036ms | pre-fix |
+| `28c6fae` scaffold reconciliation (#2340) | 65,456ms | −2,197ms | pre-fix |
+| `651929b` **#2309 fix itself** (#2360) | 36,225ms | **−29,231ms** | the fix |
+| `d6aa668` admin impersonation (#2339) | 37,889ms | +1,664ms | post-fix |
+| `97a97be` replay capsule seams (#2348) | 36,835ms | −1,054ms | post-fix |
+| `d96cfab` cached-read staleness proof (#2352) | 39,371ms | +2,536ms | post-fix |
+| `fec5221` zero-downtime state migration (#2345) | 42,356ms | +2,985ms | post-fix, largest single delta |
+| `8f94e60` CI-only, clippy parallelism (#2361) | 42,773ms | +417ms | post-fix |
+| `76c56b1` docs/routing example (#2341) | 40,337ms | −2,436ms | post-fix |
+| `9c1ede1` db scrub (#2365) | 43,219ms | +2,882ms | post-fix |
+| `f15ca1b` classified-data compile-time proof (#2367) | 41,589ms | −1,630ms | post-fix |
+| `ef61ae4` Bolt form-field escaping (#2376, CI post-fix commit) | 42,378ms | +789ms | window end |
+| `ef61ae4` repeat (noise floor, identical commit/conditions) | 43,052ms | +674ms | same-commit re-run |
+
+**Control comparison (against the pre-registered lines):**
+
+- **Pursue line (single commit ≥5,000ms):** not reached by any of the 11
+  non-fix commits. Largest single delta is `fec5221` at +2,985ms — real but
+  well under the line, and of the same order as `28c6fae`'s −2,197ms or
+  `76c56b1`'s −2,436ms, which run the *other* direction. No commit stands
+  out as "the" culprit.
+- **Kill line (sum within same-commit noise):** not cleanly met either. The
+  noise floor from one repeat at `ef61ae4` is 674ms, but the net sum of all
+  9 post-fix deltas is **+6,153ms** (36,225ms → 42,378ms) — about 9x a
+  single noise sample, so it reads as a real, diffuse compile-time creep
+  spread across many unrelated commits (new dependencies/codegen each
+  adding a couple seconds), not pure noise. One repeat sample can't fully
+  separate signal from noise here; that's a limitation of this assay's
+  single-run-per-checkpoint design, stated rather than papered over.
+- **The question this assay actually needed to answer wasn't which specific
+  wording bucket the diffuse creep falls into — it's whether that creep
+  (real or noise) is big enough to explain the CI shortfall. It is not, by
+  a wide margin, and in the wrong direction:** end-to-end across the full
+  window (`d1ecb361` → `ef61ae4`), this `autumn-web`-only proxy moved
+  65,617ms → 42,378ms, **−23,239ms (−35.4%)**. That is *larger* than PR
+  #2360's own confirmed same-box A/B saving (−33%), and far larger than
+  the real CI trajectory (−12.5%, 120,422ms → 105,371ms). If the 9
+  post-fix commits' diffuse compile-time creep were the explanation for
+  CI's shortfall, this proxy should have shown *less* relative saving than
+  the confirmed −33%, not more.
+
+**Worst case / robustness check:** the same-commit repeat at `ef61ae4`
+(43,052ms vs. the first run's 42,378ms, +674ms) confirms single-run
+measurements at this scale carry a few hundred milliseconds of noise, which
+is small relative to the −23,239ms window-wide effect being measured, so
+the headline finding (proxy overshoots the confirmed saving) is not an
+artifact of one noisy run.
+
+## 🏁 Verdict
+
+**Kill** — against the pre-set line, for the originally-falsifiable
+question: no single non-fix commit in `d1ecb361..ef61ae44` reaches the
+5,000ms pursue threshold in `autumn-web`'s own no-DB-feature compile time,
+so this assay does not name a single "responsible" commit, and none is
+warranted from this data.
+
+More importantly, this assay **rules out** "a commit regressed
+`autumn-web`'s own compile weight" as *any* part of the explanation for the
+CI shortfall — the opposite of what the parent report's list of three
+candidate commits (one of which, `1fd6245`, wasn't even in this window's
+ancestry — see Question) suggested was worth checking. The library-level
+proxy measured here shows **more** relative saving (−35.4%) than PR #2360's
+own confirmed end-to-end A/B (−33%), which itself showed more saving than
+real CI observed (−12.5%). Chasing the shortfall inside `autumn-web`'s
+Cargo-feature graph is a dry pit: whatever eats the difference between
+"confirmed −33%" and "observed −12.5%" is **not** in this library's own
+compile time, and is not attributable to any of the 11 non-fix commits that
+landed in the same window.
+
+That leaves two live explanations, neither tested here (out of this
+session's time box, and each needs its own pre-registration):
+
+1. **The rest of the cold-start journey** — this proxy only measures
+   `cargo build -p autumn-web`. The full `autumn new → first HTTP 200`
+   journey CI actually measures also includes: scaffolding the throwaway
+   project, compiling the *generated app* itself (a thin crate depending on
+   `autumn-web`, but still its own compile unit + link step), starting the
+   server process, and waiting for the first HTTP 200. Any of those stages
+   could have grown in the same window independent of `autumn-web`'s own
+   feature-gated compile time.
+2. **CI/runner statistics** — the confirmed −33% is a single run per
+   variant on PR #2360's local 4-core box; the CI numbers are 3-sample p95s
+   on GitHub-hosted shared runners, a week apart. Runner class variance
+   and small-sample p95 noise were already flagged as live confounds in the
+   parent report and are not ruled out by this assay — if anything, this
+   assay's clean library-level result (which *should* transfer to CI if
+   `autumn-web`'s compile time were the deciding factor) makes runner/CI
+   noise a more likely explanation by elimination, not less.
+
+No further bisection of `autumn-web`'s Cargo-feature graph is warranted
+without new information — this pit is dry. A follow-up assay, if
+chartered, should pre-register against the scaffold+app-compile+server-start
+portion of the journey (stage 1 above) using the real `autumn new
+--daemon` + `autumn dev-loop-bench --cold-start` harness (matching what PR
+#2360 itself used), ideally run twice per commit to get a per-stage noise
+floor that this single-run library proxy could not fully provide.
+
+## 💰 Cost to productionize
+
+N/A — kill verdict, no build to productionize. This assay itself cost
+~11 minutes of build wall-clock in one sandbox session, comfortably inside
+the pre-registered ≤60-minute box.
+
+## 🔬 Reproduce
+
+```bash
+# Requires a git worktree at the repo's history (works from any clone with
+# the full commit range d1ecb361..ef61ae44 available):
+git worktree add --detach /tmp/prospect-coldstart-wt d1ecb361
+
+cd /tmp/prospect-coldstart-wt
+FEATURES=maud,htmx,tailwind,cache-moka,http-client,reporting
+
+for c in d1ecb361 61bdd9c 28c6fae 651929b d6aa668 97a97be d96cfab fec5221 \
+         8f94e60 76c56b1 9c1ede1 f15ca1b ef61ae4; do
+  git checkout --detach "$c" --quiet
+  rm -rf target/debug/deps/libautumn_macros* target/debug/deps/libautumn_web* \
+         target/debug/deps/libautumn-* target/debug/deps/autumn_macros-* \
+         target/debug/deps/autumn_web-* target/debug/deps/autumn-* \
+         target/debug/.fingerprint/autumn-macros-* target/debug/.fingerprint/autumn-web-* \
+         target/debug/.fingerprint/autumn-* target/debug/incremental/autumn_macros-* \
+         target/debug/incremental/autumn_web-* target/debug/incremental/autumn-*
+  START=$(date +%s%3N)
+  CARGO_INCREMENTAL=0 cargo build -p autumn-web --no-default-features --features "$FEATURES"
+  END=$(date +%s%3N)
+  echo "$c: $((END-START))ms"
+done
+
+git worktree remove /tmp/prospect-coldstart-wt --force   # dismantle
+```

--- a/docs/reports/2026-09-03-prospect-cold-start-post-fix-bisect.md
+++ b/docs/reports/2026-09-03-prospect-cold-start-post-fix-bisect.md
@@ -227,13 +227,47 @@ per-commit correction below) changes the list:
   `bc99a4b8`. My first correction (`abea7490`) was itself wrong to keep
   this flagged — reversed here.
 
-Net, after three rounds of verification: **only 1 of the 4**
-originally-flagged commits (`61bdd9c2`) is confirmed relevant to this
+Net, after three rounds of verification against `Cargo.lock`: **1 of the
+4** originally-flagged commits (`61bdd9c2`) is confirmed relevant to this
 feature set's resolved graph; `fec52215`, `bc99a4b8`, and `141f36ef` are
-all confirmed false positives. **For that one confirmed commit, this
-report's delta cannot be trusted as representative of its true,
-CI-relevant recurring contribution** — but not for a purely
-one-directional reason (see the next correction). It
+confirmed false positives.
+
+**But the audit's scope was itself wrong** (Codex P2 on `a54423f1`,
+found not by rechecking a candidate but by pointing out an entire
+*category* of change this report never looked for): `Cargo.lock` records
+resolved *versions*, not enabled *features* — a workspace `Cargo.toml`
+edit that changes which Cargo features a dependency compiles with never
+touches `Cargo.lock` at all, yet triggers exactly the same warm-cache
+bias this section is about. Checked directly: `9d99d980` changes the
+workspace's `syn = { features = [...] }` declaration from `["full"]` to
+`["full", "visit-mut"]`, and `9c1ede1e` extends it again to `["full",
+"visit", "visit-mut"]` — confirmed via `git show <sha> -- Cargo.toml` on
+both. `autumn-macros` declares `syn.workspace = true` (confirmed:
+`autumn-macros/Cargo.toml`) and is compiled by the timed command, so both
+commits force a real `syn` recompile under a newly-expanded feature set —
+two more confirmed cases, found by a completely different method than
+the `Cargo.lock` audit above, which missed both.
+
+`git log --name-only -- '**/Cargo.toml' Cargo.toml` over the window shows
+roughly 9 of the 31 non-fix commits touch *some* `Cargo.toml` (not just
+the 4 that touched `Cargo.lock`) — but, as the `bc99a4b8` and `141f36ef`
+retractions above already demonstrated, "touches the manifest" is no more
+reliable a proxy than "touches the lockfile" was; each one needs the same
+package-by-package, before/after verification those two retractions
+required, which is not a small check. **Auditing all ~9 is out of this
+session's remaining time box.** The honest position is not "1 of 4" or
+even "3 of 31" — it is: **at least 3 non-fix commits in this window
+(`61bdd9c2`, `9d99d980`, `9c1ede1e`) are confirmed to trigger this
+apparatus's warm-cache bias, the true count is unknown and could be
+higher, and no exhaustive accounting was completed.** For every commit
+this bias touches, confirmed or not yet checked, this report's delta
+cannot be trusted as representative of its true, CI-relevant recurring
+contribution — not for a purely one-directional reason (see the next
+correction). This uncertainty compounds with, rather than replaces, the
+open noise-floor question in Assay: individual per-commit deltas in this
+dataset are less interpretable on *two* independent axes now, both
+pointing the same way — toward the undetermined verdict, not away from
+it. It
 also means the "total window effect" and "this proxy's absolute saving vs.
 CI's" comparisons throughout Assay and Verdict are weaker than stated
 there: they are not just measuring a narrower workload (library-only, no
@@ -584,19 +618,26 @@ live report needs the map:
   **empty** `target/` and no compiler-wrapper cache on every single
   sample (see Apparatus's fourth correction). This apparatus pays each
   external dependency's compile cost once per introduction; CI pays it on
-  every sample, forever. Of the 4 non-fix commits that touched
-  `Cargo.lock`, only **1** (`61bdd9c2`, confirmed via a package-by-package
-  `Cargo.lock` diff: a new direct edge to `p256` carrying a new feature
-  flag, forcing a real recompile under Cargo's feature unification) is
-  confirmed to actually affect this feature set's resolved graph.
-  `fec52215`, `bc99a4b8`, and `141f36ef` are all confirmed false
-  positives on closer inspection (see Apparatus's fourth through sixth
-  corrections — three separate rounds of "touches `Cargo.lock`" turning
-  out not to mean "changes this build's resolved graph"). That one
-  commit's delta cannot be trusted as CI-representative, but not in a
-  single, simple direction: the apparatus likely *overcounts* its cost at
-  its own introducing checkpoint (charging the full fresh-compile cost
-  rather than CI's much smaller cold-vs-cold marginal difference) and
+  every sample, forever. Auditing this by "touched `Cargo.lock`" alone
+  (the original approach) found only **1** of the 4 candidates confirmed
+  real (`61bdd9c2`; `fec52215`, `bc99a4b8`, `141f36ef` all confirmed
+  false positives after three separate rounds of package-by-package
+  verification) — but `Cargo.lock` doesn't record *enabled features*,
+  only resolved versions, so that audit was itself scoped too narrowly.
+  A workspace `Cargo.toml` feature-flag change is invisible to it and
+  triggers the identical bias: confirmed directly for `9d99d980` and
+  `9c1ede1e` (both change the workspace's `syn` feature set;
+  `autumn-macros` inherits it via `syn.workspace = true` and is compiled
+  by this build). **At least 3 non-fix commits in this window are
+  confirmed to trigger this bias** (`61bdd9c2`, `9d99d980`, `9c1ede1e`);
+  roughly 9 of the 31 touch *some* `Cargo.toml`, each needing the same
+  depth of verification the retractions above required, which a full
+  audit of all of them was not completed in this session's time box — so
+  the true count is unknown and plausibly higher. Every affected commit's
+  delta cannot be trusted as CI-representative, but not in a single,
+  simple direction: the apparatus likely *overcounts* its cost at its own
+  introducing checkpoint (charging the full fresh-compile cost rather
+  than CI's much smaller cold-vs-cold marginal difference) and
   *undercounts* it at every checkpoint after (nothing shown where CI pays
   every sample). Which effect dominates for this window's total is not
   resolvable from this data. The parent report's CI/runner-variance

--- a/docs/reports/2026-09-03-prospect-cold-start-post-fix-bisect.md
+++ b/docs/reports/2026-09-03-prospect-cold-start-post-fix-bisect.md
@@ -1,4 +1,4 @@
-# ⛏️ Prospect: which commits ate the missing cold-start savings? (undetermined: total window effect (−13,000ms) is real, but calibrated noise (σ≈1,080-1,527ms) is too close to every individual and cumulative per-commit figure to attribute it)
+# ⛏️ Prospect: which commit ate the missing cold-start savings? (undetermined: the pre-fix and post-fix compile-time growth is real (≈5σ vs calibrated noise), but telescoping math means no single commit can be named)
 
 ## 🎯 Question
 
@@ -269,19 +269,36 @@ calibrated noise floor in hand:**
   turns out to sit barely above the apparatus's own demonstrated noise
   ceiling — in hindsight, badly calibrated, not a defect in the commits
   measured.
-- **Kill line (sum within noise):** using the calibrated per-delta
-  combined-noise estimate (≈1,527ms) and treating the 31 non-fix deltas as
-  independent, the expected stdev of their **sum** is ≈1,527ms·√31 ≈
-  8,504ms. The observed sum, +11,088ms, is ≈1.3 of that — not
-  distinguishable from a zero-mean accumulation of per-step noise at any
-  conventional confidence level. (Using the larger, `dc74ce43`/`31423bfc`-
-  implied noise scale instead would widen that expected stdev further,
-  weakening the case for a real cumulative effect even more.) The kill
-  line's second clause is **arguably met** under this analysis — but the
-  pre-registration wrote "stays within run-to-run noise of a repeated
-  build," a bar it did not define numerically, and a single calibration
-  run after the fact is thin evidence to hang a clean "kill" on. This
-  assay does not force that call — see Verdict.
+- **Kill line (sum within noise) — corrected a second time (Codex P1 on
+  `9afe2a3a`):** the previous paragraph here treated the 31 non-fix deltas
+  as 31 independent noise draws (expected sum stdev ≈1,527ms·√31 ≈
+  8,504ms, observed +11,088ms ≈1.3σ, "not distinguishable from noise").
+  That model was wrong: the deltas are **not** independent — they're a
+  chronological chain, `y_i − y_{i−1}`, and summing a *contiguous* run of
+  such adjacent differences telescopes to just the segment's two
+  endpoints, regardless of how many intermediate steps it contains. The
+  non-fix sum here is two such contiguous runs (pre-fix: `dc74ce43`
+  through `28c6fae8`; post-fix: `d6aa6688` through `ef61ae44`) with the
+  fix's own delta excised from the middle, so it telescopes to exactly
+  four independent point measurements: `(28c6fae8 − d1ecb361) +
+  (ef61ae44 − 651929b2)` = `(63,559−55,882) + (42,637−39,226)` =
+  `+7,677ms + 3,411ms` = **+11,088ms**, with expected noise stdev
+  `1,080ms·√4 = 2,160ms` — **not** `1,527ms·√31`. Against that correctly-
+  derived figure, +11,088ms is **≈5.13σ**: the pre-fix span alone
+  (+7,677ms vs. a 2-endpoint stdev of 1,080ms·√2≈1,527ms) is ≈5.03σ, the
+  post-fix span (+3,411ms) is ≈2.23σ. This is not plausibly noise, and the
+  kill line's second clause is **not met** — reversing what the
+  immediately preceding text here claimed. One caveat kept deliberately
+  visible rather than smoothed over: the σ=1,080ms calibration came from 7
+  builds run back-to-back in one short batch, while the 32-checkpoint walk
+  ran continuously for ~35 minutes with more room for thermal/scheduling
+  drift — the `dc74ce43`/`31423bfc` adjacent-delta magnitude (≈4,600ms,
+  implying a per-point σ some 2-3x the clustered calibration's, if treated
+  as representative of that longer walk) is a live reason the true z-score
+  for the segment-level effect could be smaller than 5.1σ. Even discounted
+  by that much, though, it stays solidly above the ~2σ range associated
+  with real, not-noise effects. See Verdict for what this does and does
+  not establish.
 - **The total-window figure survives, even though attribution inside it
   does not.** End-to-end, `d1ecb361` (55,882ms, one warm sample) →
   `ef61ae44` (42,837ms, 7-sample calibrated mean) is **−13,045ms
@@ -299,51 +316,68 @@ calibrated noise floor in hand:**
 
 ## 🏁 Verdict
 
-**Undetermined** — against the pre-set lines exactly as written, and this
-time for a directly measured, quantified reason rather than an assumption.
-This report went through three revisions before landing here, each one
-caught by a different Codex review finding on PR #2477; all three are
-worth stating plainly rather than only keeping the final number:
+**Undetermined** on the pre-registered falsifiable question specifically
+(*does a single commit explain the shortfall?* — no), but **not** for the
+reason the immediately preceding revision of this section gave. This
+report went through four revisions before landing here, each one caught
+by a different Codex review finding on PR #2477 — worth stating plainly
+rather than only keeping the final number, since the corrections mostly
+ran in different directions and a reader comparing this PR's diff to the
+live report needs the map:
 
-1. **First revision: "Kill."** Wrong — built on a shallow clone that
-   silently measured 12 of the real 32 commits in the window and got a
-   commit-ancestry check backwards. Corrected by unshallowing and
-   re-measuring the complete window.
-2. **Second revision: "the shortfall is very likely a real, diffuse
-   effect."** Also unsupported — it treated one repeat (433ms) as the
-   noise floor and called a +10,655ms cumulative sum "25x noise" without
-   ever testing whether 433ms was representative. It wasn't: two commits
-   in the table (`dc74ce43`, `31423bfc`) are provable no-ops for this
-   build yet swing by ±4,600ms purely from run-to-run variance —
-   caught by Codex, confirmed by a dedicated 7-sample calibration run
-   (mean 42,837ms, stdev 1,080ms) showing the true per-measurement noise
-   is roughly 2.5x what one repeat suggested.
-3. **This revision, with the calibration in hand:** neither pre-registered
-   line can be honestly triggered. No single commit reaches the 5,000ms
-   pursue line — the closest (`6a6610c4`, +4,990ms) is statistically
-   indistinguishable from the noise two known-zero-effect commits already
-   demonstrate at almost the same magnitude. The kill line's "sum stays
-   within noise" clause is arguably satisfiable under a formal
-   independent-noise model (+11,088ms observed vs. ≈8,504ms expected
-   stdev, ≈1.3σ) — but the pre-registration never defined that bar
-   numerically, one post-hoc calibration run is thin evidence to hang a
-   clean verdict on, and the fix's own −24,333ms delta was never itself
-   calibrated against repeats. Forcing either "kill" or "pursue" here
-   would be the same mistake the first two revisions made in different
-   directions.
+1. **Revision 1: "Kill."** Wrong — built on a shallow clone that silently
+   measured 12 of the real 32 commits and got a commit-ancestry check
+   backwards. Fixed by unshallowing and re-measuring the complete window.
+2. **Revision 2: "very likely a real, diffuse effect."** Unsupported as
+   argued — it treated one repeat (433ms) as the noise floor without
+   testing whether it was representative. It wasn't (see below), but the
+   qualitative conclusion turns out to have been closer to right than
+   revision 3's walk-back of it.
+3. **Revision 3: "undetermined, kill line arguably satisfiable."** Also
+   wrong, on the arithmetic: it modeled the 31 non-fix deltas' sum as 31
+   *independent* noise draws (expected stdev ≈1,527ms·√31≈8,504ms,
+   observed +11,088ms ≈1.3σ). That model doesn't apply — the deltas are a
+   chronological chain, and summing two *contiguous* runs of them
+   telescopes to just their four segment-boundary points, not 31
+   independent measurements.
+4. **This revision:** correcting the telescoping error, the non-fix sum's
+   real expected noise stdev is `1,080ms·√4 = 2,160ms` (four independent
+   endpoint measurements, not 31), and the observed +11,088ms is **≈5.1σ**
+   — a real, not-noise, systematic compile-time increase across the
+   pre-fix span (`d1ecb361`→`28c6fae8`, ≈5.0σ) and, more weakly, the
+   post-fix span (`651929b2`→`ef61ae44`, ≈2.2σ). See Assay for the caveat
+   about the calibration's own representativeness that keeps this from
+   being stated as beyond-doubt.
 
-**What this assay does establish, robustly:** the total window effect —
-`d1ecb361` → `ef61ae44`, roughly **−13,000ms (−23-24%)** whether measured
-by single sample (−13,245ms) or calibrated mean (−13,045ms) — is real and
-large relative to the now-measured noise floor (≈1,080-1,527ms). In
-**absolute** terms it sits close to CI's own observed −15,051ms saving.
-**What it cannot establish:** whether that −13,000ms is the fix's raw
-effect (−24,333ms) genuinely clawed back by real compile-time growth in
-the other 31 commits, or whether the raw fix effect was simply smaller
-in this full-chronology context than PR #2360's isolated same-box A/B for
-reasons unrelated to any of those 31 commits. Both this proxy's per-commit
-resolution and the parent report's already-flagged CI/runner-variance
-confound remain live, undistinguished explanations.
+**What this assay establishes, and at what confidence:**
+
+- **The total window effect is real and large.** `d1ecb361` → `ef61ae44`,
+  ≈−13,000ms (−23-24%), roughly 8-9x the single-measurement noise floor —
+  not in serious doubt at any point across all four revisions.
+- **The pre-fix and post-fix spans each show a real (not noise) net
+  increase in compile time**, not just the total window — ≈5.0σ and
+  ≈2.2σ respectively, per the corrected math above. This is closer to
+  revision 2's original instinct than revision 3's retraction of it,
+  though revision 2 reached it through invalid reasoning (a single
+  under-representative repeat), so getting the right qualitative answer
+  there was luck, not method.
+- **What remains genuinely unresolved: attribution to any specific
+  commit.** Telescoping means a sum over a contiguous span carries *zero*
+  information about which intermediate commit(s) caused the change — that
+  is mathematically true regardless of noise. Individually, `6a6610c4`
+  (+4,990ms) is the largest single delta at ≈3.3σ against the calibrated
+  per-delta noise — a real single-comparison signal, but it was also the
+  largest of 31 candidate deltas, and the expected maximum of 31
+  independent noise draws is itself around 2.5-2.9σ, so this specific
+  value cannot be confidently distinguished from "the biggest of 31 noisy
+  draws" without a dedicated repeat measurement of that one commit. No
+  commit in this dataset clears that bar.
+- **The residual gap to CI is still unexplained.** This proxy's ≈−13,000ms
+  absolute saving sits close to, but not exactly at, CI's own observed
+  −15,051ms — and this proxy still only measures `autumn-web`'s own
+  compile time, not the full `autumn new → first HTTP 200` journey CI
+  gates on. The parent report's CI/runner-variance confound is also still
+  live and undistinguished from either explanation.
 
 **What would resolve this, as an explicit follow-up (not chartered or run
 here):**
@@ -432,11 +466,12 @@ for c in d1ecb361 dc74ce43; do
   timed_build "${c}-warm"
 done
 
-# Noise-floor calibration: repeat the final checkpoint under matching warm
-# conditions. Run at least 3x (this report used 7) before treating any
-# individual or cumulative delta above as signal rather than noise.
+# Noise-floor calibration: the COMMITS loop above already measured ef61ae44
+# once (that IS the "window end" sample in the table). Six MORE repeats here
+# gives 7 total warm-condition samples, matching this report's calibration —
+# don't add a 7th here or you'll have 8, not 7.
 git checkout --detach ef61ae44 --quiet
-for i in 1 2 3 4 5 6 7; do
+for i in 1 2 3 4 5 6; do
   timed_build "ef61ae44-repeat-${i}"
 done
 


### PR DESCRIPTION
## Summary

- The 2026-09-02 verification assay (`docs/reports/2026-09-02-prospect-cold-start-db-gate-verify.md`, PR #2434) confirmed issue #2309's fix (PR #2360) works — a confirmed same-box A/B of −33% — but found real CI only moved −12.5%, and named a `cargo build --timings` bisection over `d1ecb361..ef61ae44` as the explicit follow-up.
- **This report went through many rounds of review**, each catching a real error in the previous — the Verdict section keeps every correction visible rather than silently overwriting them, since a reader diffing this PR needs the map. Broadly, in order: (1) a shallow git clone silently truncated the comparison window from the real 32 commits to 12 and got a commit-ancestry check backwards; (2) redoing it over the full window without calibrating noise led to an unsupported "very likely real" claim; (3) a naive noise-of-sum calculation wrongly modeled 31 chronological deltas as independent; (4) correcting that (the deltas telescope to 4 endpoint measurements) gave a number that was then asserted to survive a noise-inflation caveat without actually checking; (5) carrying that caveat through properly showed the honest range was much wider than claimed; (6)-(9) the "commits that touch `Cargo.lock`" audit was re-verified three separate times against `cargo tree`, each round finding a previously-confirmed commit was actually a false positive (down to 1 of 4 originally flagged), then found the audit itself was scoped too narrowly — `Cargo.lock` doesn't track enabled *features*, only resolved versions, so two more commits confirmed relevant by checking manifests directly; (10) a stray multiple-comparisons statistic was wrong (simulated 200k trials to get the real expected-maximum value); (11) a logical conflation between "telescoping blocks attribution" and "noise blocks attribution" was untangled; (12) an asserted confidence floor for the total-window effect turned out to rest on a thin 2-sample noise estimate and was walked back to a qualitative, not quantitative, claim; (13) the Verdict's own opening line overclaimed "no" where the honest answer is "unknown."
- **Final state:** no single commit in the window reaches the pre-registered 5,000ms pursue line for `autumn-web`'s own no-DB compile time (closest: `6a6610c4` at +4,990ms, ≈3.3σ against the tight noise calibration — a real signal, but not confidently separable from noise given this report's own unresolved noise-floor question). The total window effect (`d1ecb361`→`ef61ae44`, ≈−13,000ms) is this report's strongest evidence but still not immune to that same open question. Attribution to any specific commit is separately blocked by telescoping math for the aggregate spans, and by measurement noise for individual deltas. The apparatus itself also doesn't exactly replicate CI's methodology (warm vs. cold target directory, and a `flash` feature-set mismatch), both independently confirmed and documented as limitations rather than corrected by re-running (out of session time box).
- Verdict: **undetermined**, with concrete, explicitly-scoped follow-ups (repeated measurements per checkpoint to establish a real noise floor; extending the method to the full `autumn dev-loop-bench --cold-start` harness with an empty `target/` per checkpoint) rather than a forced kill or pursue.
- Apparatus (detached git worktrees, all timed builds) dismantled after each pass, per Prospect's no-promotion-to-production rule. No code changes — this PR adds one report file, pre-registered in a separate commit (`cf3ffdd`) before any measurement ran, and never edited in place — corrections are recorded alongside it instead.

## Test plan

- [x] N/A — documentation-only change (no code paths touched)
- [x] Pre-registration (`cf3ffdd`) committed before the first timed build ran; kept verbatim in the report with corrections recorded separately, never edited in place
- [x] All builds across every pass (13 + 35 + 6 = 54 total, across three separate git worktrees) exited 0; commands are reproducible via the `## 🔬 Reproduce` section, hardened (fatal shallow-clone check, correct `--unshallow` guard, safe worktree teardown) after review
- [x] 32 review findings from `chatgpt-codex-connector` across 16 rounds, every one independently verified against primary sources (`git show`, `cargo tree`, direct simulation) rather than accepted or dismissed on trust — including two cases where I pushed back on a finding's specific claim with contrary evidence, and one where a from-scratch simulation corrected a wrong statistic in the finding I was fixing
- [x] All 33 CI checks green on the current head; no merge conflicts

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F7QyUqdyZpZGjUqMhFdYXT

---
_Generated by [Claude Code](https://claude.ai/code/session_01F7QyUqdyZpZGjUqMhFdYXT)_