### PR TITLE
🛡 Warden: run webhook delivery through the SSRF-safe send path (SSRF, outbound webhooks)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1102,6 +1102,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   handler ran, so a retry after such a switch still replays instead of
   re-running the mutation. See
   `docs/security/2026-09-02-idempotency-tenant-scope/`.
+- **Outbound webhook delivery now dials `target_url` through the SSRF-safe
+  path:** `WebhookSubscription::target_url` is a subscriber-chosen
+  destination — the outbound-webhooks guide describes it as "a consumer's
+  registered endpoint" — and the `autumn_webhook_delivery` background job
+  posted to it with a plain `Client::post()`, which carries none of the
+  private/loopback/link-local/CGNAT/cloud-metadata deny-list
+  `Client::get_ssrf_safe()` already enforces elsewhere in the framework. An
+  app following the documented pattern (letting its own users register a
+  webhook receiver URL) let any such user point delivery at an internal
+  service, the app's own database host, or a cloud metadata endpoint, with
+  Autumn's own backend making the request on their behalf. `get_ssrf_safe`
+  itself only ever built a `GET`; the fix adds a general
+  `RequestBuilder::ssrf_safe()` chainable on any verb (`get_ssrf_safe` is now
+  defined in terms of it, unchanged in behavior) and applies it to the
+  webhook delivery request. Delivery to a blocked destination now fails
+  closed with `SsrfBlocked` before any socket opens and is recorded/retried/
+  DLQ'd exactly like any other transport failure. **Compatibility note:** an
+  app relying on `target_url` reaching a private address (e.g. an
+  internal-only receiver during development) will see those deliveries start
+  failing after upgrade — this is the intended effect of closing the gap. See
+  `docs/security/2026-09-03-webhook-ssrf/`.
 
 ### Fixed
 

--- a/autumn/src/http_client.rs
+++ b/autumn/src/http_client.rs
@@ -1870,7 +1870,7 @@ impl RequestBuilder {
             if self.breaker_scoped {
                 return self.send_custom_breaker_guarded().await;
             }
-            return self.send_custom().await;
+            return self.send_custom(false).await;
         }
 
         // ── Resilience / Circuit Breaker ──────────────────────────────────
@@ -1912,8 +1912,17 @@ impl RequestBuilder {
         if breaker.before_call().is_err() {
             return Err(ClientError::CircuitBreakerOpen);
         }
+        // Read before the breaker moves into the guard below. Mirrors the
+        // plain-path breaker block's own `is_half_open` (passed to
+        // `send_inner` to force a single attempt): a half-open probe is a
+        // budgeted, limited trial (`half_open_trial_count`), and letting
+        // `send_one`'s own retry loop turn one trial into several real
+        // network attempts spends that budget on one logical delivery
+        // instead of testing recovery with independent probes (#2480
+        // review, round 10).
+        let is_half_open = breaker.state() == crate::circuit_breaker::CircuitState::HalfOpen;
         let guard = crate::circuit_breaker::CircuitBreakerGuard::new(breaker);
-        let res = self.send_custom().await;
+        let res = self.send_custom(is_half_open).await;
         match &res {
             Ok(resp) if resp.status().as_u16() < 500 => guard.success(),
             _ => guard.failure(),
@@ -2057,7 +2066,14 @@ impl RequestBuilder {
     }
 
     /// Dispatch to the appropriate custom send path. Consumes `self`.
-    async fn send_custom(self) -> Result<Response, ClientError> {
+    ///
+    /// `is_half_open`: `true` when this call is a circuit-breaker half-open
+    /// probe (only ever passed by [`Self::send_custom_breaker_guarded`]);
+    /// forces every `send_one` this dispatch reaches down to a single
+    /// attempt, exactly like the plain-path breaker block's own
+    /// `send_inner(is_half_open)` already does — see
+    /// `send_custom_breaker_guarded`'s doc comment.
+    async fn send_custom(self, is_half_open: bool) -> Result<Response, ClientError> {
         // Reject the incompatible `get_ssrf_safe` + `pin_to` combination up
         // front — deterministically, before any network I/O. `get_ssrf_safe`
         // routes through `send_ssrf_safe`, which runs its OWN per-hop
@@ -2115,7 +2131,7 @@ impl RequestBuilder {
             .unwrap_or_else(|| Duration::from_secs(30));
 
         if self.ssrf_safe {
-            return self.send_ssrf_safe(timeout).await;
+            return self.send_ssrf_safe(timeout, is_half_open).await;
         }
 
         // Extract the follow parameters (ending the borrow) before moving `self`.
@@ -2124,7 +2140,9 @@ impl RequestBuilder {
             RedirectMode::None | RedirectMode::Default => None,
         };
         if let Some((max, validator)) = follow {
-            return self.follow_loop(max, validator, timeout).await;
+            return self
+                .follow_loop(max, validator, timeout, is_half_open)
+                .await;
         }
 
         // Only `RedirectMode::None` (explicit `no_redirect`) and the pin-only
@@ -2147,6 +2165,7 @@ impl RequestBuilder {
             &self.retry_policy,
             self.discard_response_body,
             None,
+            is_half_open,
         )
         .await
     }
@@ -2167,6 +2186,7 @@ impl RequestBuilder {
         max: usize,
         validator: RedirectValidator,
         timeout: Duration,
+        is_half_open: bool,
     ) -> Result<Response, ClientError> {
         let original =
             url::Url::parse(&self.url).map_err(|e| ClientError::InvalidUrl(e.to_string()))?;
@@ -2201,6 +2221,7 @@ impl RequestBuilder {
                 &self.retry_policy,
                 self.discard_response_body,
                 None,
+                is_half_open,
             )
             .await?;
 
@@ -2276,7 +2297,11 @@ impl RequestBuilder {
     /// to preserve, because it had no timeout at all before this fix —
     /// surfaces as `InvalidUrl`, consistent with the DNS-failure case
     /// immediately below reusing the same variant.
-    async fn send_ssrf_safe(self, timeout: Duration) -> Result<Response, ClientError> {
+    async fn send_ssrf_safe(
+        self,
+        timeout: Duration,
+        is_half_open: bool,
+    ) -> Result<Response, ClientError> {
         let deadline = std::time::Instant::now() + timeout;
         let (follow, max) = self.ssrf_redirect_plan();
         let original =
@@ -2322,6 +2347,7 @@ impl RequestBuilder {
                 &self.retry_policy,
                 self.discard_response_body,
                 Some(deadline),
+                is_half_open,
             )
             .await?;
 
@@ -2493,12 +2519,34 @@ fn build_oneshot_client(
 /// round 7's `ClientError::Request`/`.is_timeout()` regression) — the first
 /// attempt's error shape is always preserved unchanged. Other callers pass
 /// `None`, so their behavior is exactly as before this parameter existed.
+///
+/// Two more `deadline` seams round 9 found `send_ssrf_safe`'s own deadline
+/// fix had missed: `client`'s own reqwest-level timeout is fixed at
+/// build-hop-start, so a retry within the same hop still got the *original*
+/// per-attempt budget rather than what's actually left; and the 429
+/// `Retry-After` sleep is a second sleep, separate from the backoff sleep
+/// above, that the deadline check never covered at all. Both are fixed here:
+/// every attempt sends with an explicit per-request `.timeout()` recomputed
+/// from `deadline` (overriding `client`'s built-in one only when `deadline`
+/// is set, so non-SSRF-safe callers passing `None` are unaffected), and the
+/// `Retry-After` sleep is capped by the remaining budget and followed by the
+/// same deadline check the backoff sleep already has — falling through to
+/// return the 429 response as final, exactly like running out of
+/// `max_attempts` already does, rather than sleeping past the deadline first.
+///
+/// `suppress_retries`, when `true`, forces a single attempt regardless of
+/// `retry_policy` — the same thing [`RequestBuilder::send_inner`]'s own
+/// `suppress_retries` parameter does for the plain (non-custom) breaker path
+/// during a circuit-breaker half-open probe (#2480 review, round 10): a
+/// probe is a budgeted, limited trial, and letting this retry loop turn one
+/// trial into several real network attempts spends that budget on one
+/// logical delivery rather than testing recovery with independent probes.
 #[allow(
     clippy::too_many_arguments,
     reason = "one seam shared by three call sites (plain custom path, follow_loop, send_ssrf_safe); \
               splitting the request-shape fields into their own struct would still leave the \
-              retry/discard/deadline knobs alongside it, for no reduction in what a caller reasons \
-              about"
+              retry/discard/deadline/half-open knobs alongside it, for no reduction in what a \
+              caller reasons about"
 )]
 async fn send_one(
     client: &reqwest::Client,
@@ -2509,9 +2557,12 @@ async fn send_one(
     retry_policy: &RetryPolicy,
     discard_response_body: bool,
     deadline: Option<Instant>,
+    suppress_retries: bool,
 ) -> Result<Response, ClientError> {
     let start = Instant::now();
-    let max_attempts = if is_idempotent_method(method) || !retry_policy.retry_idempotent_only {
+    let max_attempts = if suppress_retries {
+        1
+    } else if is_idempotent_method(method) || !retry_policy.retry_idempotent_only {
         retry_policy.max_retries.saturating_add(1)
     } else {
         1
@@ -2528,6 +2579,14 @@ async fn send_one(
         }
 
         let mut req = client.request(method.clone(), url);
+        // Recomputed fresh every attempt (not just retries) rather than
+        // relying solely on `client`'s own timeout, which was fixed when the
+        // caller built it at hop-start: without this override, a retry deep
+        // into a hop's budget would still get the full original per-attempt
+        // timeout rather than what's actually left before `deadline`.
+        if let Some(d) = deadline {
+            req = req.timeout(d.saturating_duration_since(Instant::now()));
+        }
         req = inject_trace_context(req);
         for (name, value) in extra_headers {
             req = req.header(name.clone(), value.clone());
@@ -2549,10 +2608,23 @@ async fn send_one(
                     if let Some(req_timeout) = retry_policy.request_timeout {
                         sleep_delay = sleep_delay.min(req_timeout);
                     }
+                    if let Some(d) = deadline {
+                        sleep_delay = sleep_delay.min(d.saturating_duration_since(Instant::now()));
+                    }
                     tokio::time::sleep(sleep_delay).await;
-                    continue;
+                    if deadline.is_none_or(|d| Instant::now() < d) {
+                        continue;
+                    }
+                    // Deadline exceeded during (or because of) the
+                    // Retry-After wait — fall through and return this 429
+                    // response as the final outcome, exactly as running out
+                    // of max_attempts already does, instead of sleeping past
+                    // the deadline and only then giving up.
                 }
-                if is_retryable_status(status.as_u16()) && attempt + 1 < max_attempts {
+                if is_retryable_status(status.as_u16())
+                    && attempt + 1 < max_attempts
+                    && deadline.is_none_or(|d| Instant::now() < d)
+                {
                     continue;
                 }
 

--- a/autumn/src/http_client.rs
+++ b/autumn/src/http_client.rs
@@ -2244,30 +2244,38 @@ impl RequestBuilder {
     /// default cap while every per-hop safety step (resolve→validate→pin,
     /// https→http downgrade block, sensitive-header stripping, method/body
     /// rewrite) still applies.
-    /// Runs the whole resolve→validate→pin→redirect operation under one
-    /// outer deadline, so it cannot exceed `timeout` in total.
+    /// Runs the whole resolve→validate→pin→redirect operation against one
+    /// deadline `timeout` from now, rather than handing every phase of every
+    /// hop a fresh `timeout`-length budget.
     ///
     /// Without this, `timeout` only bounded each hop's own connect/response
-    /// wait *inside* [`Self::send_ssrf_safe_inner`] — the DNS lookup in
-    /// [`resolve_and_validate`] has no timeout of its own, and a fresh
-    /// `timeout`-length budget is handed to *every* redirect hop rather than
-    /// the operation as a whole. A subscriber-controlled destination (the
-    /// motivating case: outbound webhook delivery, #2480 code review) with
-    /// stalled DNS or a slow multi-hop redirect chain could therefore occupy
-    /// a job worker for `timeout × (hops + 1)` plus unbounded DNS wait,
-    /// rather than the single `timeout` every other outbound call is bounded
-    /// by.
+    /// wait — the DNS lookup in [`resolve_and_validate`] had no timeout of
+    /// its own, and every redirect hop got a full fresh `timeout` regardless
+    /// of how long earlier hops already took. A subscriber-controlled
+    /// destination (the motivating case: outbound webhook delivery, #2480
+    /// code review) with stalled DNS or a slow multi-hop redirect chain
+    /// could therefore occupy a job worker for `timeout × (hops + 1)` plus
+    /// unbounded DNS wait, rather than the single `timeout` every other
+    /// outbound call is bounded by.
+    ///
+    /// The budget shrinks across two seams per hop — the DNS lookup, then
+    /// the connect/response reqwest performs — rather than being enforced by
+    /// one coarse outer `tokio::time::timeout` wrapping the whole call: a
+    /// coarse wrap would race the *same* duration against both this
+    /// operation's start and each hop's own reqwest-level timeout, and since
+    /// the outer clock always starts first it would almost always fire
+    /// first, silently reclassifying an ordinary single-hop stall from
+    /// `ClientError::Request` (a `reqwest::Error` callers can query with
+    /// `.is_timeout()`) into `ClientError::InvalidUrl` (#2480 review, round
+    /// 7). Shrinking the *reqwest* timeout instead means a connect/response
+    /// stall in the common (no-redirect) case still times out inside
+    /// reqwest itself and keeps that exact, already-documented error shape;
+    /// only a stall in the DNS lookup — which had no error shape of its own
+    /// to preserve, because it had no timeout at all before this fix —
+    /// surfaces as `InvalidUrl`, consistent with the DNS-failure case
+    /// immediately below reusing the same variant.
     async fn send_ssrf_safe(self, timeout: Duration) -> Result<Response, ClientError> {
-        tokio::time::timeout(timeout, self.send_ssrf_safe_inner(timeout))
-            .await
-            .unwrap_or_else(|_| {
-                Err(ClientError::InvalidUrl(format!(
-                    "SSRF-safe resolve/redirect operation exceeded the {timeout:?} deadline"
-                )))
-            })
-    }
-
-    async fn send_ssrf_safe_inner(self, timeout: Duration) -> Result<Response, ClientError> {
+        let deadline = std::time::Instant::now() + timeout;
         let (follow, max) = self.ssrf_redirect_plan();
         let original =
             url::Url::parse(&self.url).map_err(|e| ClientError::InvalidUrl(e.to_string()))?;
@@ -2278,15 +2286,25 @@ impl RequestBuilder {
         let mut headers = self.extra_headers.clone();
         let mut body = self.body.clone();
         for hop in 0.. {
+            let remaining_for_lookup = deadline_remaining_or_timeout(deadline, &current)?;
             // Resolve host → ALL validated addresses (rejects if ANY resolved IP
             // is blocked), then pin the full set so reqwest cannot re-resolve but
             // can still fall back across the validated addresses in order.
-            let addrs = resolve_and_validate(&current).await?;
+            // Wrapped in the *remaining* budget, not the full per-request
+            // `timeout`: resolve_and_validate's DNS lookup previously had no
+            // timeout of its own at all.
+            let addrs = tokio::time::timeout(remaining_for_lookup, resolve_and_validate(&current))
+                .await
+                .map_err(|_| ssrf_safe_deadline_error(&current))??;
             let host = host_of(&current)?;
+            // Re-measured after the lookup, so a slow DNS response shrinks
+            // what's left for the connect/response phase below rather than
+            // that phase getting a fresh full `timeout` regardless.
+            let remaining_for_connect = deadline_remaining_or_timeout(deadline, &current)?;
             let client = build_oneshot_client(
                 Some((host, addrs)),
                 reqwest::redirect::Policy::none(),
-                timeout,
+                remaining_for_connect,
             )?;
             // On any post-origin hop, drop credential-bearing headers if the
             // current target is cross-origin (stays stripped once stripped).
@@ -2356,6 +2374,32 @@ const fn is_idempotent_method(method: &Method) -> bool {
 
 const fn is_retryable_status(status: u16) -> bool {
     matches!(status, 502..=504)
+}
+
+/// Time left until `deadline`, or the deadline error if it has already
+/// passed before this hop's next phase (DNS lookup or connect) even began.
+/// Used by [`RequestBuilder::send_ssrf_safe`] to shrink the budget handed to
+/// each successive phase rather than resetting it every hop.
+fn deadline_remaining_or_timeout(
+    deadline: std::time::Instant,
+    current: &str,
+) -> Result<Duration, ClientError> {
+    let now = std::time::Instant::now();
+    if now >= deadline {
+        return Err(ssrf_safe_deadline_error(current));
+    }
+    Ok(deadline - now)
+}
+
+/// The error [`RequestBuilder::send_ssrf_safe`] returns when its overall
+/// deadline is exhausted — reusing [`ClientError::InvalidUrl`] rather than a
+/// new variant (see that call site's doc comment for why), consistent with
+/// the adjacent DNS-lookup-failure case in [`resolve_and_validate`] already
+/// using the same variant for the same phase.
+fn ssrf_safe_deadline_error(current: &str) -> ClientError {
+    ClientError::InvalidUrl(format!(
+        "SSRF-safe resolve/redirect operation exceeded its deadline resolving {current}"
+    ))
 }
 
 /// Resolve (or create) the circuit breaker for `url`'s host, honouring a

--- a/autumn/src/http_client.rs
+++ b/autumn/src/http_client.rs
@@ -2567,11 +2567,19 @@ async fn send_one(
     } else {
         1
     };
+    let mut last_transient_err: Option<reqwest::Error> = None;
 
     for attempt in 0..max_attempts {
         if attempt > 0 {
             if deadline.is_some_and(|d| Instant::now() >= d) {
-                return Err(ssrf_safe_deadline_error(url));
+                // A prior attempt's own connect/timeout error may be why the
+                // deadline is already gone — surface that error (preserving
+                // `ClientError::Request(e).is_timeout()` for callers) instead
+                // of masking it as an unrelated `InvalidUrl`.
+                return Err(last_transient_err.take().map_or_else(
+                    || ssrf_safe_deadline_error(url),
+                    |e| ClientError::Request(e.without_url()),
+                ));
             }
             let exp = (attempt - 1).min(10);
             let delay = Duration::from_millis(100 * (1_u64 << exp));
@@ -2650,7 +2658,9 @@ async fn send_one(
                     url: Some(url_used),
                 });
             }
-            Err(e) if (e.is_connect() || e.is_timeout()) && attempt + 1 < max_attempts => {}
+            Err(e) if (e.is_connect() || e.is_timeout()) && attempt + 1 < max_attempts => {
+                last_transient_err = Some(e);
+            }
             Err(e) => return Err(ClientError::Request(e.without_url())),
         }
     }

--- a/autumn/src/http_client.rs
+++ b/autumn/src/http_client.rs
@@ -2146,6 +2146,7 @@ impl RequestBuilder {
             self.body.as_ref(),
             &self.retry_policy,
             self.discard_response_body,
+            None,
         )
         .await
     }
@@ -2199,6 +2200,7 @@ impl RequestBuilder {
                 body.as_ref(),
                 &self.retry_policy,
                 self.discard_response_body,
+                None,
             )
             .await?;
 
@@ -2319,6 +2321,7 @@ impl RequestBuilder {
                 body.as_ref(),
                 &self.retry_policy,
                 self.discard_response_body,
+                Some(deadline),
             )
             .await?;
 
@@ -2471,6 +2474,32 @@ fn build_oneshot_client(
 /// Send a single request through `client` (no manual redirect following — the
 /// client's redirect policy governs that) with the same transient-error and
 /// 429/5xx retry behaviour as the shared path, and collect the [`Response`].
+///
+/// `deadline`, when set, bounds the *retry loop* — checked before each
+/// backoff sleep, so a retry that would start after the deadline is skipped
+/// in favour of failing the call immediately with a deadline error, rather
+/// than a stale response/error from an attempt that already ran. This exists
+/// for
+/// [`RequestBuilder::send_ssrf_safe`] (#2480 review, round 8): passing a
+/// shrunk per-hop `timeout` into `client`'s own reqwest-level timeout, as
+/// every other caller here already does, bounds one attempt's connect/
+/// response wait, but `client` is reused across every retry `send_one`
+/// itself performs — each gets that same per-attempt timeout again, and the
+/// backoff/`Retry-After` sleeps between attempts are outside it entirely, so
+/// a retried, timing-out SSRF-safe hop could still run well past the overall
+/// deadline the caller computed. Checked only before sleeping (never wrapped
+/// around an in-flight attempt), so it cannot race an attempt's own
+/// reqwest-level timeout the way an outer `tokio::time::timeout` would (see
+/// round 7's `ClientError::Request`/`.is_timeout()` regression) — the first
+/// attempt's error shape is always preserved unchanged. Other callers pass
+/// `None`, so their behavior is exactly as before this parameter existed.
+#[allow(
+    clippy::too_many_arguments,
+    reason = "one seam shared by three call sites (plain custom path, follow_loop, send_ssrf_safe); \
+              splitting the request-shape fields into their own struct would still leave the \
+              retry/discard/deadline knobs alongside it, for no reduction in what a caller reasons \
+              about"
+)]
 async fn send_one(
     client: &reqwest::Client,
     method: &Method,
@@ -2479,6 +2508,7 @@ async fn send_one(
     body: Option<&Bytes>,
     retry_policy: &RetryPolicy,
     discard_response_body: bool,
+    deadline: Option<Instant>,
 ) -> Result<Response, ClientError> {
     let start = Instant::now();
     let max_attempts = if is_idempotent_method(method) || !retry_policy.retry_idempotent_only {
@@ -2489,6 +2519,9 @@ async fn send_one(
 
     for attempt in 0..max_attempts {
         if attempt > 0 {
+            if deadline.is_some_and(|d| Instant::now() >= d) {
+                return Err(ssrf_safe_deadline_error(url));
+            }
             let exp = (attempt - 1).min(10);
             let delay = Duration::from_millis(100 * (1_u64 << exp));
             tokio::time::sleep(delay).await;

--- a/autumn/src/http_client.rs
+++ b/autumn/src/http_client.rs
@@ -2279,6 +2279,21 @@ const fn is_retryable_status(status: u16) -> bool {
     matches!(status, 502..=504)
 }
 
+/// Whether this task is replaying a failure capsule — the same check
+/// [`RequestBuilder::send`] makes before anything else, mirrored here for
+/// [`BreakerGuardedCall::begin`]. No-op twin for builds without `reporting`,
+/// the feature the whole `capsule` module (and therefore `current_tape`) is
+/// gated behind.
+#[cfg(feature = "reporting")]
+fn replay_tape_active() -> bool {
+    crate::capsule::effects::current_tape().is_some()
+}
+
+#[cfg(not(feature = "reporting"))]
+const fn replay_tape_active() -> bool {
+    false
+}
+
 /// Resolve (or create) the circuit breaker for `url`'s host, honouring a
 /// per-client `resilience_config` override exactly as [`RequestBuilder::send_recorded`]'s
 /// own breaker path does. Shared with [`BreakerGuardedCall`] so the two paths
@@ -2339,16 +2354,30 @@ fn breaker_for_url(
 /// eventually wedging the breaker in `HalfOpen` forever.
 pub(crate) struct BreakerGuardedCall {
     /// `None` when the client this call was `begin`-ed against has a mock
-    /// registry attached: `record` is then a no-op, matching the bypass
-    /// above.
+    /// registry attached, or a capsule replay is in progress on this task:
+    /// `record` is then a no-op, matching the bypasses above.
     guard: Option<crate::circuit_breaker::CircuitBreakerGuard>,
 }
 
 impl BreakerGuardedCall {
     /// Returns `Err(ClientError::CircuitBreakerOpen)` immediately, without
     /// touching the network, when the breaker for `url`'s host is open.
+    ///
+    /// Also bypassed — exactly like the mock case — when this task is
+    /// replaying a failure capsule: [`RequestBuilder::send`] answers such a
+    /// call from the capsule's recorded effect tape before it ever reaches
+    /// `send_recorded`'s breaker block (`#[cfg(feature = "reporting")] if let
+    /// Some(tape) = current_tape() { return replayed_response(...) }`, ahead
+    /// of everything else in `send`). A caller wrapping that call in
+    /// `BreakerGuardedCall` sits *outside* `send` and knows nothing about the
+    /// tape, so without this check it would gate the replay on live global
+    /// breaker state unrelated to the recorded run (an open breaker turns a
+    /// capsule that actually succeeded into a spurious `CircuitBreakerOpen`,
+    /// never consulting the tape at all) and, on a closed breaker, feed the
+    /// *replayed* outcome back into that same live state — historical replay
+    /// traffic contaminating a production breaker (#2480 review, round 3).
     pub(crate) fn begin(client: &Client, url: &str) -> Result<Self, ClientError> {
-        if client.mock.is_some() {
+        if client.mock.is_some() || replay_tape_active() {
             return Ok(Self { guard: None });
         }
         let breaker = breaker_for_url(client.resilience_config.as_ref(), url);
@@ -3238,6 +3267,32 @@ mod tests {
         // record() on the no-op guard must not panic and must not fabricate a
         // breaker entry for the host.
         call.record(&Err(ClientError::CircuitBreakerOpen));
+    }
+
+    // PR #2480 review, round 3 (P2): `BreakerGuardedCall` must also bypass the
+    // real breaker while this task is replaying a failure capsule — the same
+    // check `RequestBuilder::send` makes (`current_tape()`) before it ever
+    // reaches `send_recorded`'s breaker block, so a caller wrapping the call
+    // externally has to make the identical check or it gates/contaminates the
+    // live breaker with a replay that `send` itself never routed through it.
+    #[cfg(feature = "reporting")]
+    #[tokio::test]
+    async fn breaker_guarded_call_is_a_noop_during_capsule_replay() {
+        let tape = crate::capsule::effects::ReplayEffects::new(
+            crate::capsule::schema::CapsuleEffects::default(),
+        );
+        let client = Client::new();
+
+        crate::capsule::effects::with_effect_tape(std::sync::Arc::new(tape), async {
+            let call = BreakerGuardedCall::begin(&client, "http://replay-target/hook")
+                .expect("a capsule replay must never see CircuitBreakerOpen from live state");
+            assert!(
+                call.guard.is_none(),
+                "begin() must not touch the real breaker during capsule replay"
+            );
+            call.record(&Err(ClientError::CircuitBreakerOpen));
+        })
+        .await;
     }
 
     // TEST 26: from_request_parts uses AutumnConfig.http when no HttpConfig extension.

--- a/autumn/src/http_client.rs
+++ b/autumn/src/http_client.rs
@@ -2326,27 +2326,48 @@ fn breaker_for_url(
 /// [`BreakerGuardedCall::begin`] before `send()` and
 /// [`BreakerGuardedCall::record`] after, mirroring exactly what
 /// `send_recorded`'s own breaker-guarded path does (`before_call` gate,
-/// `< 500` success threshold).
+/// `< 500` success threshold) — including its `self.mock.is_some()` bypass
+/// (#2480 review, round 2): a client with a mock registry attached must never
+/// touch the real breaker, or a mocked failure in one test could open the
+/// shared global breaker for a host name reused by an unrelated later test.
+///
+/// The [`crate::circuit_breaker::CircuitBreakerGuard`] is created inside
+/// `begin`, not deferred to `record` — its `Drop` releases the
+/// `half_open_in_flight` slot `before_call` reserved if the caller's future
+/// is cancelled or panics before `record` runs (#2480 review, round 2);
+/// deferring construction would leak that slot on every such interruption,
+/// eventually wedging the breaker in `HalfOpen` forever.
 pub(crate) struct BreakerGuardedCall {
-    breaker: crate::circuit_breaker::CircuitBreaker,
+    /// `None` when the client this call was `begin`-ed against has a mock
+    /// registry attached: `record` is then a no-op, matching the bypass
+    /// above.
+    guard: Option<crate::circuit_breaker::CircuitBreakerGuard>,
 }
 
 impl BreakerGuardedCall {
     /// Returns `Err(ClientError::CircuitBreakerOpen)` immediately, without
     /// touching the network, when the breaker for `url`'s host is open.
     pub(crate) fn begin(client: &Client, url: &str) -> Result<Self, ClientError> {
+        if client.mock.is_some() {
+            return Ok(Self { guard: None });
+        }
         let breaker = breaker_for_url(client.resilience_config.as_ref(), url);
         if breaker.before_call().is_err() {
             return Err(ClientError::CircuitBreakerOpen);
         }
-        Ok(Self { breaker })
+        Ok(Self {
+            guard: Some(crate::circuit_breaker::CircuitBreakerGuard::new(breaker)),
+        })
     }
 
     /// Record the outcome against the breaker: any transport error or `>=
     /// 500` response counts as a failure, exactly like `send_recorded`'s own
-    /// breaker path.
+    /// breaker path. A no-op when `begin` bypassed the breaker (mocked
+    /// client).
     pub(crate) fn record(self, result: &Result<Response, ClientError>) {
-        let guard = crate::circuit_breaker::CircuitBreakerGuard::new(self.breaker);
+        let Some(guard) = self.guard else {
+            return;
+        };
         match result {
             Ok(resp) if resp.status().as_u16() < 500 => guard.success(),
             _ => guard.failure(),
@@ -3192,6 +3213,31 @@ mod tests {
         assert!(url::Url::parse("hook-service").is_err());
         let breaker = super::breaker_for_url(None, req.url());
         assert_eq!(breaker.name(), "mock-receiver");
+    }
+
+    // PR #2480 review, round 2 (P2): `BreakerGuardedCall` must never touch the
+    // real shared breaker for a client with a mock registry attached —
+    // `send_recorded` itself bypasses the breaker whenever `self.mock.is_some()`
+    // (checked before it ever reaches the breaker block), and a caller that
+    // wraps a mocked send in `BreakerGuardedCall` without honouring the same
+    // bypass would let a deliberately-mocked failure in one test mutate global
+    // breaker state a later, unrelated test reusing the same host name would
+    // then trip over.
+    #[test]
+    fn breaker_guarded_call_is_a_noop_for_a_mocked_client() {
+        let registry = Arc::new(MockRegistry::new());
+        let client = Client::new().with_mock(registry);
+
+        let call = BreakerGuardedCall::begin(&client, "http://mock-receiver/hook")
+            .expect("a mocked client must never see CircuitBreakerOpen");
+        assert!(
+            call.guard.is_none(),
+            "begin() must not touch the real breaker for a mocked client"
+        );
+
+        // record() on the no-op guard must not panic and must not fabricate a
+        // breaker entry for the host.
+        call.record(&Err(ClientError::CircuitBreakerOpen));
     }
 
     // TEST 26: from_request_parts uses AutumnConfig.http when no HttpConfig extension.

--- a/autumn/src/http_client.rs
+++ b/autumn/src/http_client.rs
@@ -1828,27 +1828,7 @@ impl RequestBuilder {
         }
 
         // ── Resilience / Circuit Breaker ──────────────────────────────────
-        let host = url::Url::parse(&self.url).ok().map_or_else(
-            || "unknown".to_owned(),
-            |u| {
-                let h = u.host_str().unwrap_or("unknown");
-                u.port()
-                    .map_or_else(|| h.to_owned(), |port| format!("{h}:{port}"))
-            },
-        );
-
-        let breaker = self.resilience_config.as_ref().map_or_else(
-            || {
-                crate::circuit_breaker::global_registry().get_or_create(
-                    &host,
-                    crate::circuit_breaker::CircuitBreakerPolicy::default(),
-                )
-            },
-            |rc| {
-                let policy = crate::circuit_breaker::CircuitBreakerPolicy::from_config(rc, &host);
-                crate::circuit_breaker::global_registry().get_or_create_with_config(&host, policy)
-            },
-        );
+        let breaker = breaker_for_url(self.resilience_config.as_ref(), &self.url);
 
         // Check if circuit breaker is open
         if breaker.before_call().is_err() {
@@ -2286,6 +2266,81 @@ const fn is_idempotent_method(method: &Method) -> bool {
 
 const fn is_retryable_status(status: u16) -> bool {
     matches!(status, 502..=504)
+}
+
+/// Resolve (or create) the circuit breaker for `url`'s host, honouring a
+/// per-client `resilience_config` override exactly as [`RequestBuilder::send_recorded`]'s
+/// own breaker path does. Shared with [`BreakerGuardedCall`] so the two paths
+/// cannot drift on how a host name is derived from the URL.
+fn breaker_for_url(
+    resilience_config: Option<&Arc<crate::config::ResilienceConfig>>,
+    url: &str,
+) -> crate::circuit_breaker::CircuitBreaker {
+    let host = url::Url::parse(url).ok().map_or_else(
+        || "unknown".to_owned(),
+        |u| {
+            let h = u.host_str().unwrap_or("unknown");
+            u.port()
+                .map_or_else(|| h.to_owned(), |port| format!("{h}:{port}"))
+        },
+    );
+
+    resilience_config.map_or_else(
+        || {
+            crate::circuit_breaker::global_registry().get_or_create(
+                &host,
+                crate::circuit_breaker::CircuitBreakerPolicy::default(),
+            )
+        },
+        |rc| {
+            let policy = crate::circuit_breaker::CircuitBreakerPolicy::from_config(rc, &host);
+            crate::circuit_breaker::global_registry().get_or_create_with_config(&host, policy)
+        },
+    )
+}
+
+/// Circuit-breaker accounting for a caller that must route through the
+/// SSRF-safe (or otherwise custom) send path — which, like the mock path,
+/// deliberately bypasses [`RequestBuilder::send_recorded`]'s own breaker
+/// block, because that path exists for one-off, per-request fetches of an
+/// arbitrary caller-chosen URL where per-host breaker state would mostly be
+/// noise.
+///
+/// A caller that instead makes *repeated* calls to a small, durable set of
+/// hosts — outbound webhook delivery is the motivating case (#2480 code
+/// review) — still wants the breaker: without it, a webhook receiver that is
+/// down does not fail fast, and every queued delivery pays a full
+/// DNS-resolve-and-connect timeout instead of the open-breaker short-circuit
+/// every other outbound call gets. Wrap such a call with
+/// [`BreakerGuardedCall::begin`] before `send()` and
+/// [`BreakerGuardedCall::record`] after, mirroring exactly what
+/// `send_recorded`'s own breaker-guarded path does (`before_call` gate,
+/// `< 500` success threshold).
+pub(crate) struct BreakerGuardedCall {
+    breaker: crate::circuit_breaker::CircuitBreaker,
+}
+
+impl BreakerGuardedCall {
+    /// Returns `Err(ClientError::CircuitBreakerOpen)` immediately, without
+    /// touching the network, when the breaker for `url`'s host is open.
+    pub(crate) fn begin(client: &Client, url: &str) -> Result<Self, ClientError> {
+        let breaker = breaker_for_url(client.resilience_config.as_ref(), url);
+        if breaker.before_call().is_err() {
+            return Err(ClientError::CircuitBreakerOpen);
+        }
+        Ok(Self { breaker })
+    }
+
+    /// Record the outcome against the breaker: any transport error or `>=
+    /// 500` response counts as a failure, exactly like `send_recorded`'s own
+    /// breaker path.
+    pub(crate) fn record(self, result: &Result<Response, ClientError>) {
+        let guard = crate::circuit_breaker::CircuitBreakerGuard::new(self.breaker);
+        match result {
+            Ok(resp) if resp.status().as_u16() < 500 => guard.success(),
+            _ => guard.failure(),
+        }
+    }
 }
 
 // ── Custom send-path helpers (redirect / pin / SSRF-safe) ─────────────────────

--- a/autumn/src/http_client.rs
+++ b/autumn/src/http_client.rs
@@ -2569,21 +2569,31 @@ async fn send_one(
     };
     let mut last_transient_err: Option<reqwest::Error> = None;
 
+    // A prior attempt's own connect/timeout error may be why the deadline is
+    // already gone — surface that error (preserving
+    // `ClientError::Request(e).is_timeout()` for callers) instead of masking
+    // it as an unrelated `InvalidUrl`.
+    let deadline_exceeded_err = |last_transient_err: &mut Option<reqwest::Error>| {
+        last_transient_err.take().map_or_else(
+            || ssrf_safe_deadline_error(url),
+            |e| ClientError::Request(e.without_url()),
+        )
+    };
+
     for attempt in 0..max_attempts {
         if attempt > 0 {
             if deadline.is_some_and(|d| Instant::now() >= d) {
-                // A prior attempt's own connect/timeout error may be why the
-                // deadline is already gone — surface that error (preserving
-                // `ClientError::Request(e).is_timeout()` for callers) instead
-                // of masking it as an unrelated `InvalidUrl`.
-                return Err(last_transient_err.take().map_or_else(
-                    || ssrf_safe_deadline_error(url),
-                    |e| ClientError::Request(e.without_url()),
-                ));
+                return Err(deadline_exceeded_err(&mut last_transient_err));
             }
             let exp = (attempt - 1).min(10);
-            let delay = Duration::from_millis(100 * (1_u64 << exp));
+            let mut delay = Duration::from_millis(100 * (1_u64 << exp));
+            if let Some(d) = deadline {
+                delay = delay.min(d.saturating_duration_since(Instant::now()));
+            }
             tokio::time::sleep(delay).await;
+            if deadline.is_some_and(|d| Instant::now() >= d) {
+                return Err(deadline_exceeded_err(&mut last_transient_err));
+            }
         }
 
         let mut req = client.request(method.clone(), url);

--- a/autumn/src/http_client.rs
+++ b/autumn/src/http_client.rs
@@ -1351,6 +1351,7 @@ impl Client {
             pin_addr: None,
             ssrf_safe: false,
             discard_response_body: false,
+            breaker_scoped: false,
         }
     }
 
@@ -1506,6 +1507,10 @@ pub struct RequestBuilder {
     /// When `true`, the response body is dropped unread. See
     /// [`RequestBuilder::discard_response_body`].
     discard_response_body: bool,
+    /// When `true`, `send_recorded` keeps circuit-breaker accounting even on
+    /// the custom send path (`needs_custom_path()`). See
+    /// [`RequestBuilder::breaker_scoped`].
+    breaker_scoped: bool,
 }
 
 impl RequestBuilder {
@@ -1738,15 +1743,40 @@ impl RequestBuilder {
         self
     }
 
-    /// The fully-resolved URL this request will dial: an alias passed to
-    /// [`Client::post`]/etc. (e.g. `"hook-service"`) is already expanded
-    /// against `[http.client.base_urls]` by [`Client::build_request`] before
-    /// this builder exists, so this is never the bare alias. A caller that
-    /// needs to key something (a circuit breaker, a log line) by destination
-    /// host must read it from here rather than from whatever string it
-    /// originally passed to `post`/`get`/etc. — see [`BreakerGuardedCall::begin`].
-    pub(crate) fn url(&self) -> &str {
-        &self.url
+    /// Keep circuit-breaker accounting even when this request also needs the
+    /// custom send path (`ssrf_safe()`, `pin_to()`, `no_redirect()`,
+    /// `follow_redirects()`).
+    ///
+    /// That custom path otherwise bypasses `send_recorded`'s breaker block
+    /// entirely — right for its usual case, a one-off fetch of an arbitrary
+    /// caller-chosen URL, where per-host breaker state is mostly noise. A
+    /// caller instead making *repeated* calls to a small, durable set of
+    /// hosts — outbound webhook delivery is the motivating case (#2480 code
+    /// review) — still wants the breaker: without it, a down receiver never
+    /// fails fast, and every queued delivery pays a full
+    /// DNS-resolve-and-connect timeout instead of the open-breaker
+    /// short-circuit every other outbound call gets.
+    ///
+    /// This flag is read from *inside* `send_recorded`, not layered on
+    /// externally, which is what makes it free to get right on every other
+    /// axis `send` already handles correctly: a mocked client's `self.mock.is_some()`
+    /// check runs first regardless (mock behavior is unaffected); a capsule
+    /// replay's `current_tape()` check happens even earlier, in `send` itself,
+    /// before `send_recorded` is ever reached (an open-breaker attempt is
+    /// therefore never gated on live state during replay, and — because it
+    /// stays behind `send`'s own capture tee — an open-breaker attempt made
+    /// *while capturing* is recorded into the capsule exactly like any other
+    /// outcome, so a later replay of that exact run reproduces
+    /// `CircuitBreakerOpen` instead of diverging).
+    ///
+    /// Breaker keying always uses this request's *resolved* URL (`self.url`
+    /// — already expanded past any `[http.client.base_urls]` alias by
+    /// `Client::build_request`), so an alias-targeted destination keys the
+    /// same breaker bucket a literal-URL request to the same host would.
+    #[must_use]
+    pub(crate) const fn breaker_scoped(mut self) -> Self {
+        self.breaker_scoped = true;
+        self
     }
 
     /// Send the request, applying retries and returning a [`Response`].
@@ -1833,8 +1863,13 @@ impl RequestBuilder {
         // (+ optional .resolve()) and does manual redirect handling. Like the
         // mock path it deliberately BYPASSES the process-global circuit breaker
         // to avoid entangling these one-off, per-URL requests with the shared
-        // per-host breaker registry.
+        // per-host breaker registry — unless the caller opted in via
+        // `breaker_scoped()` (repeated calls to a small, durable host set; see
+        // its doc comment).
         if self.needs_custom_path() {
+            if self.breaker_scoped {
+                return self.send_custom_breaker_guarded().await;
+            }
             return self.send_custom().await;
         }
 
@@ -1861,6 +1896,27 @@ impl RequestBuilder {
             Err(_) => {
                 guard.failure();
             }
+        }
+        res
+    }
+
+    /// The custom send path (`send_custom`), with breaker accounting exactly
+    /// like the plain-path breaker block above: `before_call` gate,
+    /// `CircuitBreakerGuard` covering the call (its `Drop` releases a
+    /// half-open slot if this future is cancelled or panics before finishing),
+    /// `< 500` success threshold. Only reached when `breaker_scoped()` was
+    /// set — see its doc comment for why this has to live here rather than in
+    /// an external wrapper around `send()`.
+    async fn send_custom_breaker_guarded(self) -> Result<Response, ClientError> {
+        let breaker = breaker_for_url(self.resilience_config.as_ref(), &self.url);
+        if breaker.before_call().is_err() {
+            return Err(ClientError::CircuitBreakerOpen);
+        }
+        let guard = crate::circuit_breaker::CircuitBreakerGuard::new(breaker);
+        let res = self.send_custom().await;
+        match &res {
+            Ok(resp) if resp.status().as_u16() < 500 => guard.success(),
+            _ => guard.failure(),
         }
         res
     }
@@ -2279,25 +2335,11 @@ const fn is_retryable_status(status: u16) -> bool {
     matches!(status, 502..=504)
 }
 
-/// Whether this task is replaying a failure capsule — the same check
-/// [`RequestBuilder::send`] makes before anything else, mirrored here for
-/// [`BreakerGuardedCall::begin`]. No-op twin for builds without `reporting`,
-/// the feature the whole `capsule` module (and therefore `current_tape`) is
-/// gated behind.
-#[cfg(feature = "reporting")]
-fn replay_tape_active() -> bool {
-    crate::capsule::effects::current_tape().is_some()
-}
-
-#[cfg(not(feature = "reporting"))]
-const fn replay_tape_active() -> bool {
-    false
-}
-
 /// Resolve (or create) the circuit breaker for `url`'s host, honouring a
 /// per-client `resilience_config` override exactly as [`RequestBuilder::send_recorded`]'s
-/// own breaker path does. Shared with [`BreakerGuardedCall`] so the two paths
-/// cannot drift on how a host name is derived from the URL.
+/// own breaker path does. Shared by both the plain-path breaker block and
+/// [`RequestBuilder::send_custom_breaker_guarded`] so the two cannot drift on
+/// how a host name is derived from the URL.
 fn breaker_for_url(
     resilience_config: Option<&Arc<crate::config::ResilienceConfig>>,
     url: &str,
@@ -2323,85 +2365,6 @@ fn breaker_for_url(
             crate::circuit_breaker::global_registry().get_or_create_with_config(&host, policy)
         },
     )
-}
-
-/// Circuit-breaker accounting for a caller that must route through the
-/// SSRF-safe (or otherwise custom) send path — which, like the mock path,
-/// deliberately bypasses [`RequestBuilder::send_recorded`]'s own breaker
-/// block, because that path exists for one-off, per-request fetches of an
-/// arbitrary caller-chosen URL where per-host breaker state would mostly be
-/// noise.
-///
-/// A caller that instead makes *repeated* calls to a small, durable set of
-/// hosts — outbound webhook delivery is the motivating case (#2480 code
-/// review) — still wants the breaker: without it, a webhook receiver that is
-/// down does not fail fast, and every queued delivery pays a full
-/// DNS-resolve-and-connect timeout instead of the open-breaker short-circuit
-/// every other outbound call gets. Wrap such a call with
-/// [`BreakerGuardedCall::begin`] before `send()` and
-/// [`BreakerGuardedCall::record`] after, mirroring exactly what
-/// `send_recorded`'s own breaker-guarded path does (`before_call` gate,
-/// `< 500` success threshold) — including its `self.mock.is_some()` bypass
-/// (#2480 review, round 2): a client with a mock registry attached must never
-/// touch the real breaker, or a mocked failure in one test could open the
-/// shared global breaker for a host name reused by an unrelated later test.
-///
-/// The [`crate::circuit_breaker::CircuitBreakerGuard`] is created inside
-/// `begin`, not deferred to `record` — its `Drop` releases the
-/// `half_open_in_flight` slot `before_call` reserved if the caller's future
-/// is cancelled or panics before `record` runs (#2480 review, round 2);
-/// deferring construction would leak that slot on every such interruption,
-/// eventually wedging the breaker in `HalfOpen` forever.
-pub(crate) struct BreakerGuardedCall {
-    /// `None` when the client this call was `begin`-ed against has a mock
-    /// registry attached, or a capsule replay is in progress on this task:
-    /// `record` is then a no-op, matching the bypasses above.
-    guard: Option<crate::circuit_breaker::CircuitBreakerGuard>,
-}
-
-impl BreakerGuardedCall {
-    /// Returns `Err(ClientError::CircuitBreakerOpen)` immediately, without
-    /// touching the network, when the breaker for `url`'s host is open.
-    ///
-    /// Also bypassed — exactly like the mock case — when this task is
-    /// replaying a failure capsule: [`RequestBuilder::send`] answers such a
-    /// call from the capsule's recorded effect tape before it ever reaches
-    /// `send_recorded`'s breaker block (`#[cfg(feature = "reporting")] if let
-    /// Some(tape) = current_tape() { return replayed_response(...) }`, ahead
-    /// of everything else in `send`). A caller wrapping that call in
-    /// `BreakerGuardedCall` sits *outside* `send` and knows nothing about the
-    /// tape, so without this check it would gate the replay on live global
-    /// breaker state unrelated to the recorded run (an open breaker turns a
-    /// capsule that actually succeeded into a spurious `CircuitBreakerOpen`,
-    /// never consulting the tape at all) and, on a closed breaker, feed the
-    /// *replayed* outcome back into that same live state — historical replay
-    /// traffic contaminating a production breaker (#2480 review, round 3).
-    pub(crate) fn begin(client: &Client, url: &str) -> Result<Self, ClientError> {
-        if client.mock.is_some() || replay_tape_active() {
-            return Ok(Self { guard: None });
-        }
-        let breaker = breaker_for_url(client.resilience_config.as_ref(), url);
-        if breaker.before_call().is_err() {
-            return Err(ClientError::CircuitBreakerOpen);
-        }
-        Ok(Self {
-            guard: Some(crate::circuit_breaker::CircuitBreakerGuard::new(breaker)),
-        })
-    }
-
-    /// Record the outcome against the breaker: any transport error or `>=
-    /// 500` response counts as a failure, exactly like `send_recorded`'s own
-    /// breaker path. A no-op when `begin` bypassed the breaker (mocked
-    /// client).
-    pub(crate) fn record(self, result: &Result<Response, ClientError>) {
-        let Some(guard) = self.guard else {
-            return;
-        };
-        match result {
-            Ok(resp) if resp.status().as_u16() < 500 => guard.success(),
-            _ => guard.failure(),
-        }
-    }
 }
 
 // ── Custom send-path helpers (redirect / pin / SSRF-safe) ─────────────────────
@@ -3214,13 +3177,31 @@ mod tests {
         assert!(other.base_url.is_none());
     }
 
-    // PR #2480 review (P1): a `RequestBuilder`'s `.url()` must be the
-    // *expanded* destination when built through an alias, not the bare alias
-    // string — a caller keying a circuit breaker (or anything else) by
-    // destination host has to read it from here, never from what it
-    // originally passed to `post`/`get`/etc.
+    // PR #2480 review, round 4 (redesign): `breaker_scoped()` moved breaker
+    // accounting for the custom send path from an external wrapper
+    // (`BreakerGuardedCall`, now removed) to a flag `send_recorded` itself
+    // reads — which is what makes the mock bypass, the capsule-replay bypass,
+    // and correct capsule *recording* of an open-breaker attempt all free:
+    // they were already correctly ordered around `send_recorded` before this
+    // flag existed, for every other caller.
+    //
+    // This test locks in the one thing the external wrapper got wrong (P1,
+    // round 1): keying the breaker by the alias a caller passed to
+    // `post`/`get`/etc. rather than the expanded destination. `self.url` is
+    // set once, by `Client::build_request`, before any `breaker_scoped()` /
+    // `ssrf_safe()` flag is even read — so there is no separate "pass the
+    // right URL" step left to get wrong.
     #[test]
-    fn request_builder_url_is_expanded_not_the_alias() {
+    fn breaker_scoped_keys_by_resolved_url_not_alias() {
+        // breaker_for_url really does get_or_create against the shared global
+        // registry, so this needs the same isolation as every other test that
+        // touches it directly — otherwise a concurrently-running test's "no
+        // breaker entry for this host" assertion can observe the entry this
+        // test creates (and never cleans up otherwise).
+        let _lock = crate::circuit_breaker::TEST_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+
         let mut base_urls = std::collections::HashMap::new();
         base_urls.insert(
             "hook-service".to_owned(),
@@ -3234,65 +3215,122 @@ mod tests {
         };
         let client = Client::from_config(&config);
 
-        let req = client.named("hook-service").post("hook-service");
-        assert_eq!(req.url(), "http://mock-receiver/base/hook-service");
+        let req = client
+            .named("hook-service")
+            .post("hook-service")
+            .ssrf_safe()
+            .breaker_scoped();
+        assert_eq!(req.url, "http://mock-receiver/base/hook-service");
+        assert!(req.breaker_scoped);
 
         // The bare alias would neither parse as a URL nor name the real
         // destination host — exactly the bug the P1 finding caught.
         assert!(url::Url::parse("hook-service").is_err());
-        let breaker = super::breaker_for_url(None, req.url());
+        let breaker = super::breaker_for_url(None, &req.url);
         assert_eq!(breaker.name(), "mock-receiver");
+
+        crate::circuit_breaker::global_registry().clear();
     }
 
-    // PR #2480 review, round 2 (P2): `BreakerGuardedCall` must never touch the
-    // real shared breaker for a client with a mock registry attached —
-    // `send_recorded` itself bypasses the breaker whenever `self.mock.is_some()`
-    // (checked before it ever reaches the breaker block), and a caller that
-    // wraps a mocked send in `BreakerGuardedCall` without honouring the same
-    // bypass would let a deliberately-mocked failure in one test mutate global
-    // breaker state a later, unrelated test reusing the same host name would
-    // then trip over.
-    #[test]
-    fn breaker_guarded_call_is_a_noop_for_a_mocked_client() {
+    // PR #2480 review, round 4: `breaker_scoped()` on the custom send path
+    // must trip and fail fast exactly like the plain-path breaker already
+    // does (`test_http_client_circuit_breaker_integration`), and must key on
+    // the same host a non-custom-path request to the same URL would.
+    //
+    // No listener needed: `send_ssrf_safe` refuses a loopback destination
+    // (`SsrfBlocked`) before ever dialing, and that refusal is exactly the
+    // kind of failure the breaker must count — a subscriber pointing
+    // `target_url` at a blocked destination repeatedly must trip the breaker
+    // on those refusals just as it would on real 5xxs, not bypass accounting
+    // entirely.
+    #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
+    async fn breaker_scoped_custom_path_trips_and_fails_fast() {
+        let _lock = crate::circuit_breaker::TEST_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        crate::circuit_breaker::global_registry().clear();
+
+        let mut rc = crate::config::ResilienceConfig::default();
+        rc.circuit_breaker.defaults.failure_ratio_threshold = Some(0.5);
+        rc.circuit_breaker.defaults.minimum_sample_count = Some(3);
+        rc.circuit_breaker.defaults.open_duration_secs = Some(10);
+        let client = Client {
+            resilience_config: Some(Arc::new(rc)),
+            ..Client::new()
+        };
+
+        let url = "http://127.0.0.1:1/blocked";
+
+        for _ in 0..3 {
+            let res = client.post(url).ssrf_safe().breaker_scoped().send().await;
+            assert!(
+                matches!(res, Err(ClientError::SsrfBlocked(_))),
+                "expected SsrfBlocked, got {res:?}"
+            );
+        }
+
+        // The breaker for 127.0.0.1 should now be OPEN — the next attempt
+        // must fail fast with CircuitBreakerOpen rather than SsrfBlocked,
+        // proving it never re-entered send_custom (no re-resolution, no
+        // reqwest client built).
+        let res = client.post(url).ssrf_safe().breaker_scoped().send().await;
+        assert!(matches!(res, Err(ClientError::CircuitBreakerOpen)));
+
+        crate::circuit_breaker::global_registry().clear();
+    }
+
+    // PR #2480 review, round 4: a client with a mock registry attached must
+    // never touch the real breaker even with `breaker_scoped()` set —
+    // `send_recorded` checks `self.mock.is_some()` before it ever reads
+    // `breaker_scoped`, so a deliberately-mocked failure in one test cannot
+    // open the shared global breaker for a host name reused by an unrelated
+    // later test.
+    #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
+    async fn breaker_scoped_bypassed_for_mocked_client() {
+        let _lock = crate::circuit_breaker::TEST_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        crate::circuit_breaker::global_registry().clear();
+
         let registry = Arc::new(MockRegistry::new());
+        let mock = MockSetupBuilder {
+            registry: registry.clone(),
+            alias: "http://mock-receiver/hook".to_owned(),
+            method: None,
+            path: None,
+        }
+        .post("/hook")
+        .respond_with(500, serde_json::json!({ "error": "down" }));
         let client = Client::new().with_mock(registry);
 
-        let call = BreakerGuardedCall::begin(&client, "http://mock-receiver/hook")
-            .expect("a mocked client must never see CircuitBreakerOpen");
+        // More attempts than minimum_sample_count would need to trip a real
+        // breaker at default thresholds — every one must still reach the
+        // mock rather than short-circuiting on CircuitBreakerOpen.
+        for _ in 0..12 {
+            let res = client
+                .named("http://mock-receiver/hook")
+                .post("http://mock-receiver/hook")
+                .ssrf_safe()
+                .breaker_scoped()
+                .send()
+                .await;
+            let res = res.expect("a mocked client must never see CircuitBreakerOpen");
+            assert_eq!(res.status().as_u16(), 500);
+        }
+        mock.expect_called(12);
+
+        // No breaker entry should exist for the mocked host at all.
         assert!(
-            call.guard.is_none(),
-            "begin() must not touch the real breaker for a mocked client"
+            crate::circuit_breaker::global_registry()
+                .all_breakers()
+                .iter()
+                .all(|b| b.name() != "mock-receiver"),
+            "a mocked send must never create a real breaker entry"
         );
 
-        // record() on the no-op guard must not panic and must not fabricate a
-        // breaker entry for the host.
-        call.record(&Err(ClientError::CircuitBreakerOpen));
-    }
-
-    // PR #2480 review, round 3 (P2): `BreakerGuardedCall` must also bypass the
-    // real breaker while this task is replaying a failure capsule — the same
-    // check `RequestBuilder::send` makes (`current_tape()`) before it ever
-    // reaches `send_recorded`'s breaker block, so a caller wrapping the call
-    // externally has to make the identical check or it gates/contaminates the
-    // live breaker with a replay that `send` itself never routed through it.
-    #[cfg(feature = "reporting")]
-    #[tokio::test]
-    async fn breaker_guarded_call_is_a_noop_during_capsule_replay() {
-        let tape = crate::capsule::effects::ReplayEffects::new(
-            crate::capsule::schema::CapsuleEffects::default(),
-        );
-        let client = Client::new();
-
-        crate::capsule::effects::with_effect_tape(std::sync::Arc::new(tape), async {
-            let call = BreakerGuardedCall::begin(&client, "http://replay-target/hook")
-                .expect("a capsule replay must never see CircuitBreakerOpen from live state");
-            assert!(
-                call.guard.is_none(),
-                "begin() must not touch the real breaker during capsule replay"
-            );
-            call.record(&Err(ClientError::CircuitBreakerOpen));
-        })
-        .await;
+        crate::circuit_breaker::global_registry().clear();
     }
 
     // TEST 26: from_request_parts uses AutumnConfig.http when no HttpConfig extension.

--- a/autumn/src/http_client.rs
+++ b/autumn/src/http_client.rs
@@ -2244,7 +2244,30 @@ impl RequestBuilder {
     /// default cap while every per-hop safety step (resolve→validate→pin,
     /// https→http downgrade block, sensitive-header stripping, method/body
     /// rewrite) still applies.
+    /// Runs the whole resolve→validate→pin→redirect operation under one
+    /// outer deadline, so it cannot exceed `timeout` in total.
+    ///
+    /// Without this, `timeout` only bounded each hop's own connect/response
+    /// wait *inside* [`Self::send_ssrf_safe_inner`] — the DNS lookup in
+    /// [`resolve_and_validate`] has no timeout of its own, and a fresh
+    /// `timeout`-length budget is handed to *every* redirect hop rather than
+    /// the operation as a whole. A subscriber-controlled destination (the
+    /// motivating case: outbound webhook delivery, #2480 code review) with
+    /// stalled DNS or a slow multi-hop redirect chain could therefore occupy
+    /// a job worker for `timeout × (hops + 1)` plus unbounded DNS wait,
+    /// rather than the single `timeout` every other outbound call is bounded
+    /// by.
     async fn send_ssrf_safe(self, timeout: Duration) -> Result<Response, ClientError> {
+        tokio::time::timeout(timeout, self.send_ssrf_safe_inner(timeout))
+            .await
+            .unwrap_or_else(|_| {
+                Err(ClientError::InvalidUrl(format!(
+                    "SSRF-safe resolve/redirect operation exceeded the {timeout:?} deadline"
+                )))
+            })
+    }
+
+    async fn send_ssrf_safe_inner(self, timeout: Duration) -> Result<Response, ClientError> {
         let (follow, max) = self.ssrf_redirect_plan();
         let original =
             url::Url::parse(&self.url).map_err(|e| ClientError::InvalidUrl(e.to_string()))?;

--- a/autumn/src/http_client.rs
+++ b/autumn/src/http_client.rs
@@ -1433,9 +1433,7 @@ impl Client {
     /// automatic per-hop pinning.
     #[must_use]
     pub fn get_ssrf_safe(&self, url: impl Into<String>) -> RequestBuilder {
-        let mut builder = self.build_request(Method::GET, url.into());
-        builder.ssrf_safe = true;
-        builder
+        self.build_request(Method::GET, url.into()).ssrf_safe()
     }
 }
 
@@ -1710,6 +1708,33 @@ impl RequestBuilder {
     #[must_use]
     pub const fn pin_to(mut self, addr: SocketAddr) -> Self {
         self.pin_addr = Some(addr);
+        self
+    }
+
+    /// Route this request through the SSRF-safe resolve→validate→pin send path
+    /// documented on [`Client::get_ssrf_safe`], for any HTTP method.
+    ///
+    /// [`Client::get_ssrf_safe`] only builds `GET` requests, but the guarantee
+    /// it describes — reject a resolved address on the built-in SSRF deny-list,
+    /// pin the connection to the validated set, re-validate on every redirect
+    /// hop — is implemented by [`Self::send`] purely from this flag and is not
+    /// GET-specific. Any outbound call whose destination is not a value the
+    /// app itself chose — a webhook subscriber's `target_url`, a user-supplied
+    /// callback, an OAuth discovery endpoint — needs this on **every** verb it
+    /// uses, not only reads. Chain it after [`Client::post`], [`Client::put`],
+    /// etc.:
+    ///
+    /// ```rust,ignore
+    /// client.post(target_url).ssrf_safe().json(&payload).send().await?;
+    /// ```
+    ///
+    /// Same incompatibility with [`pin_to`](Self::pin_to) as `get_ssrf_safe`:
+    /// this path performs its own per-hop resolve→validate→pin, so chaining an
+    /// explicit pin is rejected at send time with
+    /// [`ClientError::PinNotAllowedWithSsrfSafe`].
+    #[must_use]
+    pub const fn ssrf_safe(mut self) -> Self {
+        self.ssrf_safe = true;
         self
     }
 

--- a/autumn/src/http_client.rs
+++ b/autumn/src/http_client.rs
@@ -1738,6 +1738,17 @@ impl RequestBuilder {
         self
     }
 
+    /// The fully-resolved URL this request will dial: an alias passed to
+    /// [`Client::post`]/etc. (e.g. `"hook-service"`) is already expanded
+    /// against `[http.client.base_urls]` by [`Client::build_request`] before
+    /// this builder exists, so this is never the bare alias. A caller that
+    /// needs to key something (a circuit breaker, a log line) by destination
+    /// host must read it from here rather than from whatever string it
+    /// originally passed to `post`/`get`/etc. — see [`BreakerGuardedCall::begin`].
+    pub(crate) fn url(&self) -> &str {
+        &self.url
+    }
+
     /// Send the request, applying retries and returning a [`Response`].
     ///
     /// # Errors
@@ -3151,6 +3162,36 @@ mod tests {
         // Unknown alias falls back to client-level base_url (None in this case).
         let other = client.named("sendgrid");
         assert!(other.base_url.is_none());
+    }
+
+    // PR #2480 review (P1): a `RequestBuilder`'s `.url()` must be the
+    // *expanded* destination when built through an alias, not the bare alias
+    // string — a caller keying a circuit breaker (or anything else) by
+    // destination host has to read it from here, never from what it
+    // originally passed to `post`/`get`/etc.
+    #[test]
+    fn request_builder_url_is_expanded_not_the_alias() {
+        let mut base_urls = std::collections::HashMap::new();
+        base_urls.insert(
+            "hook-service".to_owned(),
+            "http://mock-receiver/base".to_owned(),
+        );
+        let config = HttpClientConfig {
+            timeout_secs: 30,
+            max_retries: 3,
+            max_retry_after_secs: 10,
+            base_urls,
+        };
+        let client = Client::from_config(&config);
+
+        let req = client.named("hook-service").post("hook-service");
+        assert_eq!(req.url(), "http://mock-receiver/base/hook-service");
+
+        // The bare alias would neither parse as a URL nor name the real
+        // destination host — exactly the bug the P1 finding caught.
+        assert!(url::Url::parse("hook-service").is_err());
+        let breaker = super::breaker_for_url(None, req.url());
+        assert_eq!(breaker.name(), "mock-receiver");
     }
 
     // TEST 26: from_request_parts uses AutumnConfig.http when no HttpConfig extension.

--- a/autumn/src/webhook_outbound.rs
+++ b/autumn/src/webhook_outbound.rs
@@ -621,6 +621,14 @@ pub fn deliver_webhook_job(
         // it this POST carries none of the private/link-local/loopback/cloud-
         // metadata deny-list `Client::get_ssrf_safe` documents. See
         // docs/security/2026-09-03-webhook-ssrf/README.md.
+        //
+        // `ssrf_safe()` routes through the custom send path, which (like the
+        // mock path) bypasses `RequestBuilder::send_recorded`'s own circuit
+        // breaker — that bypass is meant for one-off fetches of an arbitrary
+        // caller-chosen URL, not for repeated deliveries to the same
+        // subscriber host. Wrap the call with `BreakerGuardedCall` to keep
+        // the fail-fast-on-a-down-receiver behavior every other outbound call
+        // gets (PR #2480 review).
         let req = manager
             .client
             .named(&sub.target_url)
@@ -630,7 +638,16 @@ pub fn deliver_webhook_job(
             .header("Autumn-Signature", signature_header)
             .text_body(log.payload.clone());
 
-        let response = req.send().await;
+        let breaker_call =
+            crate::http_client::BreakerGuardedCall::begin(&manager.client, &sub.target_url);
+        let response = match breaker_call {
+            Ok(guarded) => {
+                let result = req.send().await;
+                guarded.record(&result);
+                result
+            }
+            Err(open) => Err(open),
+        };
         let elapsed = u64::try_from(start.elapsed().as_millis()).unwrap_or(u64::MAX);
 
         tracing::debug!(

--- a/autumn/src/webhook_outbound.rs
+++ b/autumn/src/webhook_outbound.rs
@@ -616,10 +616,16 @@ pub fn deliver_webhook_job(
         request_headers.insert("Autumn-Signature".to_owned(), signature_header.clone());
 
         let start = std::time::Instant::now();
+        // `target_url` is a subscriber-chosen destination, not one the app
+        // itself picked — exactly the case `ssrf_safe()` exists for. Without
+        // it this POST carries none of the private/link-local/loopback/cloud-
+        // metadata deny-list `Client::get_ssrf_safe` documents. See
+        // docs/security/2026-09-03-webhook-ssrf/README.md.
         let req = manager
             .client
             .named(&sub.target_url)
             .post(&sub.target_url)
+            .ssrf_safe()
             .header("Content-Type", "application/json")
             .header("Autumn-Signature", signature_header)
             .text_body(log.payload.clone());
@@ -985,10 +991,7 @@ mod tests {
             .await
             .unwrap();
 
-        let accept = tokio::time::timeout(
-            std::time::Duration::from_millis(500),
-            listener.accept(),
-        );
+        let accept = tokio::time::timeout(std::time::Duration::from_millis(500), listener.accept());
 
         let job_result =
             deliver_webhook_job(state, serde_json::json!({ "log_id": "log_ssrf" })).await;
@@ -1009,7 +1012,9 @@ mod tests {
             .unwrap()
             .expect("log should remain stored");
         assert!(
-            log.last_error.as_deref().is_some_and(|e| e.contains("SSRF")),
+            log.last_error
+                .as_deref()
+                .is_some_and(|e| e.contains("SSRF")),
             "delivery log should record the SSRF block, got: {:?}",
             log.last_error
         );

--- a/autumn/src/webhook_outbound.rs
+++ b/autumn/src/webhook_outbound.rs
@@ -638,8 +638,16 @@ pub fn deliver_webhook_job(
             .header("Autumn-Signature", signature_header)
             .text_body(log.payload.clone());
 
+        // Key the breaker by the request's *resolved* URL, not `target_url`
+        // as the caller wrote it: when `target_url` is a
+        // `[http.client.base_urls]` alias (e.g. `"hook-service"`), `req.url()`
+        // is already expanded to the real destination, while the alias
+        // string itself doesn't parse as a URL at all — every alias-based
+        // subscription would otherwise fall into one shared "unknown"
+        // breaker bucket, letting failures from one receiver reject
+        // deliveries to unrelated healthy ones (PR #2480 review).
         let breaker_call =
-            crate::http_client::BreakerGuardedCall::begin(&manager.client, &sub.target_url);
+            crate::http_client::BreakerGuardedCall::begin(&manager.client, req.url());
         let response = match breaker_call {
             Ok(guarded) => {
                 let result = req.send().await;

--- a/autumn/src/webhook_outbound.rs
+++ b/autumn/src/webhook_outbound.rs
@@ -619,43 +619,27 @@ pub fn deliver_webhook_job(
         // `target_url` is a subscriber-chosen destination, not one the app
         // itself picked — exactly the case `ssrf_safe()` exists for. Without
         // it this POST carries none of the private/link-local/loopback/cloud-
-        // metadata deny-list `Client::get_ssrf_safe` documents. See
-        // docs/security/2026-09-03-webhook-ssrf/README.md.
-        //
-        // `ssrf_safe()` routes through the custom send path, which (like the
-        // mock path) bypasses `RequestBuilder::send_recorded`'s own circuit
-        // breaker — that bypass is meant for one-off fetches of an arbitrary
-        // caller-chosen URL, not for repeated deliveries to the same
-        // subscriber host. Wrap the call with `BreakerGuardedCall` to keep
+        // metadata deny-list `Client::get_ssrf_safe` documents. `ssrf_safe()`
+        // alone would route through the custom send path, which (like the
+        // mock path) bypasses `send_recorded`'s circuit breaker by default —
+        // right for a one-off fetch of an arbitrary URL, wrong for repeated
+        // deliveries to the same subscriber host. `breaker_scoped()` keeps
         // the fail-fast-on-a-down-receiver behavior every other outbound call
-        // gets (PR #2480 review).
+        // gets, correctly ordered with the mock bypass, capsule replay, and
+        // capsule *recording* of the attempt — all handled inside
+        // `send_recorded` itself, not layered on here. See
+        // docs/security/2026-09-03-webhook-ssrf/README.md.
         let req = manager
             .client
             .named(&sub.target_url)
             .post(&sub.target_url)
             .ssrf_safe()
+            .breaker_scoped()
             .header("Content-Type", "application/json")
             .header("Autumn-Signature", signature_header)
             .text_body(log.payload.clone());
 
-        // Key the breaker by the request's *resolved* URL, not `target_url`
-        // as the caller wrote it: when `target_url` is a
-        // `[http.client.base_urls]` alias (e.g. `"hook-service"`), `req.url()`
-        // is already expanded to the real destination, while the alias
-        // string itself doesn't parse as a URL at all — every alias-based
-        // subscription would otherwise fall into one shared "unknown"
-        // breaker bucket, letting failures from one receiver reject
-        // deliveries to unrelated healthy ones (PR #2480 review).
-        let breaker_call =
-            crate::http_client::BreakerGuardedCall::begin(&manager.client, req.url());
-        let response = match breaker_call {
-            Ok(guarded) => {
-                let result = req.send().await;
-                guarded.record(&result);
-                result
-            }
-            Err(open) => Err(open),
-        };
+        let response = req.send().await;
         let elapsed = u64::try_from(start.elapsed().as_millis()).unwrap_or(u64::MAX);
 
         tracing::debug!(

--- a/autumn/src/webhook_outbound.rs
+++ b/autumn/src/webhook_outbound.rs
@@ -942,6 +942,80 @@ mod tests {
         assert_eq!(log.response_status, None);
     }
 
+    /// 🛡 Warden — SSRF via subscriber-chosen `target_url` (2026-09-03).
+    ///
+    /// `WebhookSubscription::target_url` is exactly the kind of destination
+    /// `docs/guide/outbound-webhooks.md` describes as "a consumer's registered
+    /// endpoint" — supplied by whoever registers the subscription, not chosen
+    /// by the app. An attacker who can register (or edit) a subscription can
+    /// point it at an internal service, the app's own DB host, or a cloud
+    /// metadata endpoint (169.254.169.254); Autumn's own background job then
+    /// makes the outbound call from inside the app's network. No app code in
+    /// this path is doing anything the guide warns against — the guide's only
+    /// stated security mechanism is the outbound HMAC signature, which says
+    /// nothing about where the request is allowed to go.
+    ///
+    /// `127.0.0.1` stands in for that internal destination: it is on the
+    /// framework's own SSRF deny-list ([`crate::http_client::is_blocked_ip`]),
+    /// so a real local listener lets the test observe, without touching the
+    /// network beyond loopback, whether the connection was ever attempted.
+    #[tokio::test]
+    async fn deliver_webhook_job_refuses_ssrf_target_url() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind loopback listener");
+        let port = listener
+            .local_addr()
+            .expect("listener has a local address")
+            .port();
+        let target_url = format!("http://127.0.0.1:{port}/hook");
+
+        let state = AppState::for_test();
+        let store = Arc::new(InMemoryOutboundWebhookHandler::new());
+        // Deliberately NOT registering an `HttpMockRegistryExt` — the mock
+        // path short-circuits before the SSRF check runs (`send_recorded`
+        // checks `self.mock.is_some()` first), so this test needs the real
+        // send path to observe whether the connection was actually blocked.
+        install_outbound_webhook_manager(&state, store.clone(), 1);
+
+        let sub = sample_subscription("sub_ssrf", &target_url, WebhookSubscriptionStatus::Active);
+        store.create_subscription(sub).await.unwrap();
+        store
+            .replace_delivery_log(sample_log("log_ssrf", "sub_ssrf"))
+            .await
+            .unwrap();
+
+        let accept = tokio::time::timeout(
+            std::time::Duration::from_millis(500),
+            listener.accept(),
+        );
+
+        let job_result =
+            deliver_webhook_job(state, serde_json::json!({ "log_id": "log_ssrf" })).await;
+
+        assert!(
+            accept.await.is_err(),
+            "the listener standing in for an internal service must never see a \
+             connection — a blocked destination has to be rejected before dial"
+        );
+        assert!(
+            job_result.is_err(),
+            "delivery to a blocked destination must not report success"
+        );
+
+        let log = store
+            .get_delivery_log("log_ssrf")
+            .await
+            .unwrap()
+            .expect("log should remain stored");
+        assert!(
+            log.last_error.as_deref().is_some_and(|e| e.contains("SSRF")),
+            "delivery log should record the SSRF block, got: {:?}",
+            log.last_error
+        );
+        assert_eq!(log.response_status, None);
+    }
+
     #[tokio::test]
     async fn self_contained_delivery_uses_latest_subscription_state() {
         let state = AppState::for_test();

--- a/docs/security/2026-09-03-webhook-ssrf/README.md
+++ b/docs/security/2026-09-03-webhook-ssrf/README.md
@@ -1,0 +1,163 @@
+# SSRF via subscriber-chosen `target_url` in outbound webhook delivery (2026-09-03)
+
+**Class:** SSRF reaching the internal network / cloud metadata, through a
+documented, first-class feature
+**Surface:** `autumn_web::webhook_outbound` — `deliver_webhook_job` (the
+`autumn_webhook_delivery` background job)
+**Entry point:** `WebhookOutboundManager::dispatch()` → `autumn_webhook_delivery`
+job → `deliver_webhook_job`, the framework's own delivery of a
+`WebhookSubscription::target_url`
+**Affected:** `autumn-web` 0.7.0 and every earlier release that shipped
+`webhook_outbound`
+**Status:** fixed — `autumn/src/webhook_outbound.rs`, `autumn/src/http_client.rs`
+
+## 🕵️ Threat model
+
+> Against an app that follows Autumn's documented outbound-webhook guide
+> (`docs/guide/outbound-webhooks.md`) — lets its own users/customers register a
+> `WebhookSubscription` naming a `target_url` ("a consumer's registered
+> endpoint", per the guide) and calls `WebhookOutboundManager::dispatch()` on
+> domain events — an attacker who is an ordinary authenticated user of that
+> app, exactly the principal the feature is built to serve, can set
+> `target_url` to an address on the app's own network (an internal admin
+> service, the database host, a message queue) or a cloud metadata endpoint
+> (`http://169.254.169.254/latest/meta-data/iam/security-credentials/...`).
+> Autumn's own background job then makes the outbound HTTP POST from inside
+> the app's network/cloud environment, on the attacker's behalf, and (via the
+> stored delivery log / DLQ, and the `/actuator/webhooks/dlq` actuator route
+> the guide documents) the attacker can read back the response body — the
+> credentials the metadata service returned, or the internal service's
+> reply. The app author did nothing the documentation told them not to do:
+> the guide's only stated security mechanism is the outbound HMAC-SHA256
+> payload signature (§3), which says nothing about, and does nothing to
+> constrain, where the request is allowed to go.
+
+This is exactly the SSRF-via-webhook shape well known from Stripe/GitHub/
+Shopify-style "notify my server" integrations — the reason those platforms all
+validate or restrict the destination before dialing it.
+
+## 🔎 Root cause
+
+Autumn ships a real SSRF-safe outbound path: `Client::get_ssrf_safe`
+(`autumn/src/http_client.rs`) resolves the destination host, rejects the
+request if *any* resolved address is on the built-in
+private/loopback/link-local/CGNAT/cloud-metadata deny-list
+(`is_blocked_ip`), and pins the connection to the validated address set so a
+DNS-rebinding race cannot swap in a blocked address after the check.
+
+`deliver_webhook_job` — the one place in the framework that dials a
+completely attacker/subscriber-chosen URL — did not use it:
+
+```rust
+let req = manager
+    .client
+    .named(&sub.target_url)
+    .post(&sub.target_url)          // plain POST — no SSRF policy applied
+    .header("Content-Type", "application/json")
+    .header("Autumn-Signature", signature_header)
+    .text_body(log.payload.clone());
+```
+
+`get_ssrf_safe` could not have been used as-is even if someone had reached for
+it: it is hard-coded to `Method::GET`
+
+```rust
+pub fn get_ssrf_safe(&self, url: impl Into<String>) -> RequestBuilder {
+    let mut builder = self.build_request(Method::GET, url.into());
+    builder.ssrf_safe = true;
+    builder
+}
+```
+
+even though the `ssrf_safe` flag it sets, and the whole resolve→validate→pin
+path it enables in `RequestBuilder::send`, are method-agnostic — `send_ssrf_safe`
+reads `self.method` and works for any verb. The one outbound call that most
+needed the guarantee (a POST to a value the app did not choose) was also the
+one call the public API had no way to opt into it for.
+
+## 🧪 Reproduction
+
+`autumn/src/webhook_outbound.rs::tests::deliver_webhook_job_refuses_ssrf_target_url`
+
+```bash
+cargo test -p autumn-web --lib webhook_outbound::tests::deliver_webhook_job_refuses_ssrf_target_url
+```
+
+The test binds a real loopback `TcpListener` (standing in for an internal
+service / cloud metadata endpoint — `127.0.0.1` is on the framework's own
+deny-list) as `target_url`, runs `deliver_webhook_job` with no HTTP mock
+registered (the mock path would short-circuit before the SSRF check ever
+runs), and asserts the listener never receives a connection.
+
+On trunk (`trunk-failure.txt`): the listener **does** receive the POST — the
+assertion that it must not fails, proving the framework dialed the
+SSRF-blocked destination.
+
+## 🩹 Fix
+
+Two changes, both additive:
+
+1. **`autumn/src/http_client.rs`** — `RequestBuilder::ssrf_safe()`: a new
+   public chainable builder method that sets the same `ssrf_safe` flag
+   `get_ssrf_safe` sets, usable after `Client::post`/`put`/`patch`/`delete`,
+   not just `get`. `Client::get_ssrf_safe` is refactored to call it
+   (`self.build_request(Method::GET, url.into()).ssrf_safe()`) — byte-identical
+   behavior, no signature change.
+2. **`autumn/src/webhook_outbound.rs`** — `deliver_webhook_job`'s delivery
+   request chains `.ssrf_safe()` before `.send()`.
+
+Delivery to a blocked destination now fails closed with
+`ClientError::SsrfBlocked` before any socket is opened, is recorded on the
+delivery log exactly like any other transport failure (`last_error`, retried
+up to `max_attempts`, DLQ'd on exhaustion), and reaches the same operator-only
+`/actuator/webhooks/dlq` surface the guide already documents — nothing new is
+exposed to the attacker beyond "delivery failed."
+
+## ✅ Verification
+
+* `cargo test -p autumn-web --lib webhook_outbound::tests::deliver_webhook_job_refuses_ssrf_target_url` — red before, green after (see `trunk-failure.txt` / `after.txt`).
+* `cargo test -p autumn-web --lib webhook_outbound::` — full module, all existing tests still pass unchanged (mock-backed tests are unaffected: `send_recorded` checks `self.mock.is_some()` before the SSRF branch, so a registered mock still short-circuits exactly as before).
+* `cargo test -p autumn-web --lib http_client::` — full module, all existing `get_ssrf_safe` tests still pass unchanged after the refactor.
+* `cargo fmt --all`
+* `cargo clippy --workspace --all-targets -- -D warnings`
+* `./scripts/pre-push-check.sh`
+
+## 📡 Blast radius
+
+Swept every other framework call site that dials a URL the app did not
+choose, grepping for `.post(`/`.put(`/`.patch(`/`.delete(` against a value
+sourced from stored/request data rather than a literal or a `[http.client]`
+config alias:
+
+* **`webhook_outbound.rs::deliver_webhook_job`** — fixed above (the finding).
+* **OAuth2 / OIDC token & userinfo endpoints** (`oauth2.rs` and friends) —
+  checked: the authorization/token/userinfo/JWKS URLs come from the app's own
+  `[oauth.providers.*]` config, not from request/subscriber data, so they are
+  not attacker-controlled the way `target_url` is; out of scope for this
+  finding (a compromised config is a different threat model).
+* **`http_client.rs` `follow_redirects`/`pin_to`/plain `get`/`post`/etc.
+  call sites inside `autumn/src`** — none dial a subscriber/request-supplied
+  URL directly; every other in-framework caller either targets a
+  `[http.client.base_urls]` alias or an app-configured upstream.
+* **MCP outbound tool calls** — `mcp.rs` dispatches back into the app's own
+  router (loopback, in-process), not an outbound `Client` call; not this
+  shape.
+* Feature-gated call sites: none of `redis`, `ws`, `mail`, `i18n` touch
+  `http_client`'s outbound path.
+
+No sibling gap found; this was the one call site.
+
+## 📜 Compatibility
+
+Both changes are pure additions — `RequestBuilder::ssrf_safe()` is new,
+`Client::get_ssrf_safe`'s signature and behavior are unchanged, and
+`deliver_webhook_job`'s request now fails a class of destination
+(private/loopback/link-local/CGNAT/cloud-metadata) it previously reached.
+That is the security fix, and per CLAUDE.md and the "Ask before" gate below,
+worth flagging explicitly: **an app that was relying on `target_url` pointing
+at a private address (e.g. an internal-only receiver during development)
+will see those deliveries start failing with `SsrfBlocked` after upgrade.**
+That is the correct behavior for the documented, subscriber-facing feature,
+matching what `get_ssrf_safe` already enforces elsewhere in the framework, but
+it is a behavior change for any app relying on the previous unrestricted
+delivery. Recorded under `## [Unreleased] → Security` in `CHANGELOG.md`.

--- a/docs/security/2026-09-03-webhook-ssrf/README.md
+++ b/docs/security/2026-09-03-webhook-ssrf/README.md
@@ -161,3 +161,34 @@ That is the correct behavior for the documented, subscriber-facing feature,
 matching what `get_ssrf_safe` already enforces elsewhere in the framework, but
 it is a behavior change for any app relying on the previous unrestricted
 delivery. Recorded under `## [Unreleased] → Security` in `CHANGELOG.md`.
+
+## Follow-up: circuit breaker bypass on the fixed path (same day, pre-merge)
+
+Codex's automated review on PR #2480 caught a correctness gap in the fix
+itself: `.ssrf_safe()` routes the request through `RequestBuilder::send_custom`,
+which — like the mock path — deliberately bypasses `send_recorded`'s
+circuit-breaker block. That bypass is right for `get_ssrf_safe`'s usual case
+(a one-off fetch of an arbitrary caller-chosen URL, where per-host breaker
+state is mostly noise), but wrong for `deliver_webhook_job`, which makes
+*repeated* calls to the same subscriber host: without the breaker, a down
+receiver no longer fails fast, and every queued delivery pays a full
+DNS-resolve-and-connect timeout instead of the open-breaker short-circuit
+every other outbound call gets — amplifying exactly the thundering-herd load
+the job's own jitter/backoff exists to avoid. Not a security regression (no
+tenant boundary or SSRF protection is affected), but a resilience regression
+introduced by the security fix.
+
+**Fix:** scoped to the one call site rather than widening `get_ssrf_safe`'s
+global bypass semantics, which other one-off SSRF-safe fetches elsewhere may
+be relying on. `http_client.rs` extracts the existing host-derivation +
+`resilience_config` lookup into `breaker_for_url` (shared by both
+`send_recorded` and the new path, so they cannot drift) and adds
+`pub(crate) BreakerGuardedCall`: `begin()` gates on the breaker exactly like
+`send_recorded`'s own `before_call` check, `record()` applies the same
+`< 500` success threshold. `deliver_webhook_job` wraps its `.ssrf_safe()` send
+with it.
+
+**Verification:** `cargo test -p autumn-web --lib webhook_outbound:: http_client::`
+— 87/87 passed, including `test_http_client_circuit_breaker_integration` and
+`deliver_webhook_job_refuses_ssrf_target_url`; `cargo fmt --all --check`;
+`cargo clippy -p autumn-web --all-targets -- -D warnings` — clean.

--- a/docs/security/2026-09-03-webhook-ssrf/after.txt
+++ b/docs/security/2026-09-03-webhook-ssrf/after.txt
@@ -1,0 +1,23 @@
+$ cargo test -p autumn-web --lib webhook_outbound:: -- --nocapture
+# with the fix applied (RequestBuilder::ssrf_safe() + deliver_webhook_job using it)
+
+   Compiling autumn-web v0.7.0 (/home/user/autumn/autumn)
+    Finished `test` profile [unoptimized + debuginfo] target(s) in 1m 55s
+     Running unittests src/lib.rs (target/debug/deps/autumn_web-ab97033ae7ae3be3)
+
+running 10 tests
+test webhook_outbound::tests::outbound_webhook_plugin_installs_manager_without_startup_hook ... ok
+test webhook_outbound::tests::replace_delivery_log_is_not_a_delivery_outcome ... ok
+test webhook_outbound::tests::replay_job_keeps_disabled_subscription_log_in_dlq ... ok
+test webhook_outbound::tests::replay_job_sends_failed_subscription_instead_of_skipping ... ok
+test webhook_outbound::tests::delivery_log_response_body_is_capped ... ok
+test webhook_outbound::tests::self_contained_delivery_uses_latest_subscription_state ... ok
+test webhook_outbound::tests::dispatch_marks_log_dlq_when_fallback_enqueue_fails ... ok
+test webhook_outbound::tests::successful_delivery_does_not_retry_when_failure_reset_fails ... ok
+test webhook_outbound::tests::webhook_manager_uses_http_client_config_base_urls ... ok
+test webhook_outbound::tests::deliver_webhook_job_refuses_ssrf_target_url ... ok
+
+test result: ok. 10 passed; 0 failed; 0 ignored; 0 measured; 5448 filtered out; finished in 0.50s
+
+
+[exited with code 0]

--- a/docs/security/2026-09-03-webhook-ssrf/trunk-failure.txt
+++ b/docs/security/2026-09-03-webhook-ssrf/trunk-failure.txt
@@ -1,0 +1,85 @@
+$ cargo test -p autumn-web --lib webhook_outbound::tests::deliver_webhook_job_refuses_ssrf_target_url -- --nocapture
+# on trunk, before the fix (RequestBuilder::ssrf_safe() not yet applied to deliver_webhook_job)
+
+   Compiling filetime v0.2.29
+   Compiling scoped-futures v0.1.4
+   Compiling allocation-counter v0.8.1
+   Compiling inventory v0.3.24
+   Compiling autumn-web v0.7.0 (/home/user/autumn/autumn)
+    Finished `test` profile [unoptimized + debuginfo] target(s) in 4m 29s
+     Running unittests src/lib.rs (target/debug/deps/autumn_web-ab97033ae7ae3be3)
+
+running 1 test
+
+thread 'webhook_outbound::tests::deliver_webhook_job_refuses_ssrf_target_url' (8591) panicked at autumn/src/webhook_outbound.rs:1001:9:
+the listener standing in for an internal service must never see a connection — a blocked destination has to be rejected before dial
+stack backtrace:
+   0: __rustc::rust_begin_unwind
+             at /rustc/e408947bfd200af42db322daf0fadfe7e26d3bd1/library/std/src/panicking.rs:689:5
+   1: core::panicking::panic_fmt
+             at /rustc/e408947bfd200af42db322daf0fadfe7e26d3bd1/library/core/src/panicking.rs:80:14
+   2: {async_block#0}
+             at ./src/webhook_outbound.rs:1001:9
+   3: poll<&mut dyn core::future::future::Future<Output=()>>
+             at /rustc/e408947bfd200af42db322daf0fadfe7e26d3bd1/library/core/src/future/future.rs:133:9
+   4: poll<&mut core::pin::Pin<&mut dyn core::future::future::Future<Output=()>>>
+             at /rustc/e408947bfd200af42db322daf0fadfe7e26d3bd1/library/core/src/future/future.rs:133:9
+   5: {closure#0}<core::pin::Pin<&mut core::pin::Pin<&mut dyn core::future::future::Future<Output=()>>>>
+             at /root/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.53.1/src/runtime/scheduler/current_thread/mod.rs:830:70
+   6: with_budget<core::task::poll::Poll<()>, tokio::runtime::scheduler::current_thread::{impl#9}::block_on::{closure#0}::{closure#0}::{closure_env#0}<core::pin::Pin<&mut core::pin::Pin<&mut dyn core::future::future::Future<Output=()>>>>>
+             at /root/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.53.1/src/task/coop/mod.rs:167:5
+   7: budget<core::task::poll::Poll<()>, tokio::runtime::scheduler::current_thread::{impl#9}::block_on::{closure#0}::{closure#0}::{closure_env#0}<core::pin::Pin<&mut core::pin::Pin<&mut dyn core::future::future::Future<Output=()>>>>>
+             at /root/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.53.1/src/task/coop/mod.rs:133:5
+   8: {closure#0}<core::pin::Pin<&mut core::pin::Pin<&mut dyn core::future::future::Future<Output=()>>>>
+             at /root/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.53.1/src/runtime/scheduler/current_thread/mod.rs:830:25
+   9: tokio::runtime::scheduler::current_thread::Context::enter
+             at /root/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.53.1/src/runtime/scheduler/current_thread/mod.rs:488:19
+  10: {closure#0}<core::pin::Pin<&mut core::pin::Pin<&mut dyn core::future::future::Future<Output=()>>>>
+             at /root/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.53.1/src/runtime/scheduler/current_thread/mod.rs:829:44
+  11: tokio::runtime::scheduler::current_thread::CoreGuard::enter::{{closure}}
+             at /root/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.53.1/src/runtime/scheduler/current_thread/mod.rs:906:68
+  12: tokio::runtime::context::scoped::Scoped<T>::set
+             at /root/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.53.1/src/runtime/context/scoped.rs:40:9
+  13: tokio::runtime::context::set_scheduler::{{closure}}
+             at /root/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.53.1/src/runtime/context.rs:187:38
+  14: try_with<tokio::runtime::context::Context, tokio::runtime::context::set_scheduler::{closure_env#0}<(alloc::boxed::Box<tokio::runtime::scheduler::current_thread::Core, alloc::alloc::Global>, core::option::Option<()>), tokio::runtime::scheduler::current_thread::{impl#9}::enter::{closure_env#0}<tokio::runtime::scheduler::current_thread::{impl#9}::block_on::{closure_env#0}<core::pin::Pin<&mut core::pin::Pin<&mut dyn core::future::future::Future<Output=()>>>>, core::option::Option<()>>>, (alloc::boxed::Box<tokio::runtime::scheduler::current_thread::Core, alloc::alloc::Global>, core::option::Option<()>)>
+             at /rustc/e408947bfd200af42db322daf0fadfe7e26d3bd1/library/std/src/thread/local.rs:513:12
+  15: std::thread::local::LocalKey<T>::with
+             at /rustc/e408947bfd200af42db322daf0fadfe7e26d3bd1/library/std/src/thread/local.rs:477:20
+  16: tokio::runtime::context::set_scheduler
+             at /root/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.53.1/src/runtime/context.rs:187:17
+  17: tokio::runtime::scheduler::current_thread::CoreGuard::enter
+             at /root/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.53.1/src/runtime/scheduler/current_thread/mod.rs:906:27
+  18: tokio::runtime::scheduler::current_thread::CoreGuard::block_on
+             at /root/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.53.1/src/runtime/scheduler/current_thread/mod.rs:817:24
+  19: {closure#0}<core::pin::Pin<&mut dyn core::future::future::Future<Output=()>>>
+             at /root/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.53.1/src/runtime/scheduler/current_thread/mod.rs:218:33
+  20: tokio::runtime::context::runtime::enter_runtime
+             at /root/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.53.1/src/runtime/context/runtime.rs:65:16
+  21: block_on<core::pin::Pin<&mut dyn core::future::future::Future<Output=()>>>
+             at /root/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.53.1/src/runtime/scheduler/current_thread/mod.rs:206:9
+  22: tokio::runtime::runtime::Runtime::block_on_inner
+             at /root/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.53.1/src/runtime/runtime.rs:374:52
+  23: block_on<core::pin::Pin<&mut dyn core::future::future::Future<Output=()>>>
+             at /root/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.53.1/src/runtime/runtime.rs:343:18
+  24: deliver_webhook_job_refuses_ssrf_target_url
+             at ./src/webhook_outbound.rs:1021:46
+  25: autumn_web::webhook_outbound::tests::deliver_webhook_job_refuses_ssrf_target_url::{{closure}}
+             at ./src/webhook_outbound.rs:968:59
+  26: core::ops::function::FnOnce::call_once
+             at /rustc/e408947bfd200af42db322daf0fadfe7e26d3bd1/library/core/src/ops/function.rs:250:5
+  27: core::ops::function::FnOnce::call_once
+             at /rustc/e408947bfd200af42db322daf0fadfe7e26d3bd1/library/core/src/ops/function.rs:250:5
+note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
+test webhook_outbound::tests::deliver_webhook_job_refuses_ssrf_target_url ... FAILED
+
+failures:
+
+failures:
+    webhook_outbound::tests::deliver_webhook_job_refuses_ssrf_target_url
+
+test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 5457 filtered out; finished in 30.52s
+
+error: test failed, to rerun pass `-p autumn-web --lib`
+
+[exited with code 0]


### PR DESCRIPTION
## 🎯 Surface

`autumn_web::webhook_outbound` — `deliver_webhook_job`, the `autumn_webhook_delivery` background job that Autumn's own `WebhookOutboundManager::dispatch()` enqueues for every active `WebhookSubscription`. This is the framework's implementation of the documented outbound-webhooks feature (`docs/guide/outbound-webhooks.md`), not app code.

## 🕵️ Threat model

Against an app that follows Autumn's documented outbound-webhook guide — lets its own users/customers register a `WebhookSubscription` naming a `target_url` (the guide's own words: "a consumer's registered endpoint") and calls `WebhookOutboundManager::dispatch()` on domain events — an attacker who is an ordinary authenticated user of that app, exactly the principal the feature is built to serve, can set `target_url` to an address on the app's own network (an internal admin service, the database host, a message queue) or a cloud metadata endpoint (`http://169.254.169.254/latest/meta-data/...`). Autumn's own background job then makes the outbound HTTP POST from inside the app's network/cloud environment on the attacker's behalf, and the response is readable back through the delivery log / DLQ and the guide's own `/actuator/webhooks/dlq` route.

The app author did nothing the documentation told them not to do — the guide's only stated security mechanism is the outbound HMAC-SHA256 payload signature (§3), which says nothing about, and does nothing to constrain, where the request is allowed to go. This is the same SSRF-via-webhook shape well known from Stripe/GitHub/Shopify-style "notify my server" integrations.

## 🧪 Reproduction

`autumn/src/webhook_outbound.rs::tests::deliver_webhook_job_refuses_ssrf_target_url`

```
cargo test -p autumn-web --lib webhook_outbound::tests::deliver_webhook_job_refuses_ssrf_target_url
```

The test binds a real loopback `TcpListener` (`127.0.0.1` is on the framework's own SSRF deny-list — a stand-in for an internal service / cloud metadata endpoint), registers it as `target_url` with no HTTP mock configured (the mock path would short-circuit before the SSRF check ever runs), and asserts the listener never receives a connection.

On trunk (first commit, `docs/security/2026-09-03-webhook-ssrf/trunk-failure.txt`):

```
thread 'webhook_outbound::tests::deliver_webhook_job_refuses_ssrf_target_url' panicked:
the listener standing in for an internal service must never see a connection —
a blocked destination has to be rejected before dial
test result: FAILED. 0 passed; 1 failed
```

## 🔎 Root cause

Autumn ships a real SSRF-safe outbound path, `Client::get_ssrf_safe` (`autumn/src/http_client.rs`): it resolves the destination host, rejects the request if *any* resolved address is on the built-in private/loopback/link-local/CGNAT/cloud-metadata deny-list (`is_blocked_ip`), and pins the connection to the validated address set against DNS-rebinding.

`deliver_webhook_job` — the one place in the framework that dials a completely subscriber-chosen URL — never used it:

```rust
let req = manager.client.named(&sub.target_url).post(&sub.target_url) // plain POST
    .header("Content-Type", "application/json")
    .header("Autumn-Signature", signature_header)
    .text_body(log.payload.clone());
```

It couldn't have been, as shipped: `get_ssrf_safe` is hard-coded to `Method::GET`, even though the `ssrf_safe` flag it sets and the resolve→validate→pin path it enables in `RequestBuilder::send` are method-agnostic (`send_ssrf_safe` reads `self.method` generically). The one outbound call that most needed the guarantee — a POST to a value the app didn't choose — was also the one call with no way to opt into it.

## 🩹 Fix

Two additive changes:

1. **`autumn/src/http_client.rs`** — new public chainable `RequestBuilder::ssrf_safe()`, usable after `post`/`put`/`patch`/`delete`, not just `get`. `Client::get_ssrf_safe` is refactored to call it (`self.build_request(Method::GET, url.into()).ssrf_safe()`) — byte-identical behavior, confirmed by the unchanged `http_client::` test module (77/77 passed).
2. **`autumn/src/webhook_outbound.rs`** — `deliver_webhook_job`'s delivery request chains `.ssrf_safe()`.

Delivery to a blocked destination now fails closed with `ClientError::SsrfBlocked` before any socket opens, and is recorded/retried/DLQ'd exactly like any other transport failure — nothing new is exposed to the attacker beyond "delivery failed."

## ✅ Verification

- `deliver_webhook_job_refuses_ssrf_target_url`: red on trunk → green after the fix (`docs/security/2026-09-03-webhook-ssrf/{trunk-failure,after}.txt`).
- `cargo test -p autumn-web --lib webhook_outbound::` — 10/10 passed, no existing test's behavior changed (mock-backed tests short-circuit before the SSRF branch, unaffected).
- `cargo test -p autumn-web --lib http_client::` — 77/77 passed, `get_ssrf_safe` refactor is behavior-preserving.
- `cargo fmt --all` — clean.
- `cargo clippy -p autumn-web --all-targets -- -D warnings` — clean.
- `./scripts/check-panic-gate.sh` — 52 request-path modules gated, unaffected (no new `unwrap`/`expect`/`panic` in production code; the test's own `.unwrap()`s are inside `#[cfg(test)] mod tests`, exempt).
- `cargo check --workspace` and `cargo check -p autumn-web --all-targets` (reduced parallelism) — both clean; `./scripts/pre-push-check.sh`'s full run hit a SIGKILL on an unrelated crate under this sandbox's default parallelism (memory pressure from full-workspace clippy across every example/plugin), reproduced as an OOM rather than a real break — `autumn-macros` (the crate it died on) compiles clean standalone and is untouched by this diff.

## 📡 Blast radius

Swept every other framework call site that dials a URL the app did not choose:

- **`webhook_outbound.rs::deliver_webhook_job`** — fixed above (the finding).
- **OAuth2/OIDC endpoints** — sourced from the app's own `[oauth.providers.*]` config, not request/subscriber data; out of scope for this finding.
- **Every other in-framework `Client` call site** — targets a `[http.client.base_urls]` alias or an app-configured upstream, never a subscriber-supplied URL.
- **MCP dispatch** — loopback, in-process router dispatch, not an outbound `Client` call.
- Feature-gated call sites (`redis`, `ws`, `mail`, `i18n`) — none touch `http_client`'s outbound path.

No sibling gap found; this was the one call site.

## 📜 Compatibility

Both code changes are pure additions (`RequestBuilder::ssrf_safe()` is new; `get_ssrf_safe`'s signature and behavior are unchanged). The **behavioral** change is the point of the fix: an app relying on `target_url` reaching a private address (e.g. an internal-only receiver during development) will see those deliveries start failing with `SsrfBlocked` after upgrade — the same guarantee `get_ssrf_safe` already enforces elsewhere in the framework. Recorded under `## [Unreleased] → Security` in `CHANGELOG.md`. No workspace version bump.

## 🗂 Ledger

`docs/security/2026-09-03-webhook-ssrf/` (README, trunk-failure.txt, after.txt)


---
_Generated by [Claude Code](https://claude.ai/code/session_012fA5FohcWFrEFMUY5PsW7a)_