### PR TITLE
Gate #[secured]/#[step_up]/#[throttle] before body extraction (#1668)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1386,6 +1386,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- **`#[secured]`, `#[step_up]`, and `#[throttle]` now reject a request before
+  its body is ever parsed (#1668):** all three guard checks used to run as
+  statements inside the generated handler body, which Axum only invokes after
+  every extractor — including the body extractor (`Json`/`Form`/`Multipart`)
+  — has already succeeded. An over-limit or unauthenticated request with a
+  malformed body got the extractor's `400`/`422` instead of the guard's
+  intended `429`/`401`/`403`, masking the guard's outcome, and the server paid
+  the cost of parsing and buffering the body (worst for uploads) before a
+  `#[throttle]`-gated route ever got to shed the load. Each macro now emits a
+  `FromRequestParts` gate — a small generated type inserted as the handler's
+  first parameter — so the check runs and can reject the request before
+  Axum's extractor pipeline ever reaches the body extractor, relying on
+  Axum's guarantee that every `FromRequestParts` extractor resolves,
+  left-to-right, strictly before the trailing `FromRequest` one. The macro
+  invocation syntax and handler signatures at call sites are unchanged; a
+  route's role/scope markers still surface in the generated OpenAPI document
+  exactly as before. Fixing this also surfaced a related idempotency-replay
+  gap: when `#[authorize]` is written above one of these guards, a stale scan
+  could let the guard's new pre-body gate wrongly claim replay-serving for
+  itself, which — now that the gate runs before the body — would have let a
+  retried mutation replay its cached response without `#[authorize]`'s policy
+  check ever re-running. That gap is closed in the same change.
+
 - **The idempotency cache is now partitioned by the resolved tenant:** an app
   that turned on Autumn's multi-tenancy (`[tenancy] enabled = true`) *and*
   `AppBuilder::idempotent()` shared one cache slot between tenants. The storage

--- a/autumn-macros/src/api_doc.rs
+++ b/autumn-macros/src/api_doc.rs
@@ -1479,8 +1479,7 @@ mod tests {
         );
         let throttled =
             crate::throttle::throttle_macro(quote::quote! { limit = 5, per = "1m" }, public);
-        let parsed: syn::ItemFn =
-            syn::parse2(throttled).expect("#[throttle] over #[public] output must parse");
+        let parsed = crate::param_helpers::extract_fn_item(throttled, "h");
         assert!(
             is_public(&parsed),
             "the public marker must survive a #[throttle] wrapper"

--- a/autumn-macros/src/edge.rs
+++ b/autumn-macros/src/edge.rs
@@ -497,8 +497,9 @@ mod tests {
         // `(async move { … }).await`, burying the marker one level down.
         let edged = edge_macro(quote! {}, quote! { async fn h() -> &'static str { "ok" } });
         let secured = crate::secured::secured_macro(quote! { "admin" }, edged);
+        let secured_fn = crate::param_helpers::extract_fn_item(secured, "h");
         assert!(
-            detect(&parse_fn(secured)).is_some(),
+            detect(&secured_fn).is_some(),
             "a buried #[edge] marker must still be detected"
         );
     }

--- a/autumn-macros/src/idempotency_guard.rs
+++ b/autumn-macros/src/idempotency_guard.rs
@@ -51,7 +51,10 @@ fn block_has_generated_replay_guard(block: &Block) -> bool {
             return true;
         }
 
-        if stmt_is_generated_auth_prologue(stmt) || stmt_is_generated_throttle_prologue(stmt) {
+        if stmt_is_generated_auth_prologue(stmt)
+            || stmt_is_generated_throttle_prologue(stmt)
+            || stmt_is_generated_sunset_check_prologue(stmt)
+        {
             index += 1;
             continue;
         }
@@ -127,6 +130,85 @@ fn stmt_is_generated_throttle_prologue(stmt: &Stmt) -> bool {
     };
 
     if_let_throttle_check_returns(expr_if)
+}
+
+/// Skips the version-sunset check `#[authorize]` emits between its policy
+/// check and its replay stop:
+/// `if let Some(Extension(meta)) = &__autumn_route_version { if let
+/// Some(resp) = check_sunset(&state, meta) { return resp; } }`. It carries
+/// real behaviour (an old route version can still reject a request), but
+/// nothing downstream of it depends on that outcome the way replay-serving
+/// does, so the scan must step over it to reach the replay guard that
+/// follows: an unrecognized statement here stops the walk, the replay guard
+/// reads as absent, and a gate macro stacked above `#[authorize]` would then
+/// claim replay ownership for a `FromRequestParts` extractor that runs
+/// BEFORE authorize's policy re-check ever does.
+fn stmt_is_generated_sunset_check_prologue(stmt: &Stmt) -> bool {
+    let Stmt::Expr(Expr::If(expr_if), _) = stmt else {
+        return false;
+    };
+
+    if_let_sunset_check(expr_if)
+}
+
+fn if_let_sunset_check(expr_if: &ExprIf) -> bool {
+    let Expr::Let(expr_let) = expr_if.cond.as_ref() else {
+        return false;
+    };
+
+    expr_if.else_branch.is_none()
+        && pat_is_some_route_version_extension(&expr_let.pat)
+        && expr_is_ref_to_ident(&expr_let.expr, "__autumn_route_version")
+        && block_is_sunset_check_body(&expr_if.then_branch)
+}
+
+fn pat_is_some_route_version_extension(pat: &Pat) -> bool {
+    let Pat::TupleStruct(tuple) = pat else {
+        return false;
+    };
+
+    path_matches(&tuple.path, &["core", "option", "Option", "Some"])
+        && tuple.elems.len() == 1
+        && pat_is_extension_binding(&tuple.elems[0], "__autumn_meta")
+}
+
+fn pat_is_extension_binding(pat: &Pat, expected: &str) -> bool {
+    let Pat::TupleStruct(tuple) = pat else {
+        return false;
+    };
+
+    path_ends_with(&tuple.path, "Extension")
+        && tuple.elems.len() == 1
+        && pat_binds_ident(&tuple.elems[0], expected)
+}
+
+fn block_is_sunset_check_body(block: &Block) -> bool {
+    match block.stmts.as_slice() {
+        [Stmt::Expr(Expr::If(inner_if), _)] => if_let_sunset_response_returns(inner_if),
+        _ => false,
+    }
+}
+
+fn if_let_sunset_response_returns(expr_if: &ExprIf) -> bool {
+    let Expr::Let(expr_let) = expr_if.cond.as_ref() else {
+        return false;
+    };
+
+    expr_if.else_branch.is_none()
+        && pat_is_some_replay_response(&expr_let.pat)
+        && expr_is_check_sunset_call(&expr_let.expr)
+        && block_returns_ident(&expr_if.then_branch, "__autumn_response")
+}
+
+fn expr_is_check_sunset_call(expr: &Expr) -> bool {
+    match expr {
+        Expr::Call(call) => {
+            path_expr_matches(&call.func, &["autumn_web", "__private", "check_sunset"])
+        }
+        Expr::Group(group) => expr_is_check_sunset_call(&group.expr),
+        Expr::Paren(paren) => expr_is_check_sunset_call(&paren.expr),
+        _ => false,
+    }
 }
 
 fn if_let_throttle_check_returns(expr_if: &ExprIf) -> bool {
@@ -587,7 +669,7 @@ fn path_ends_with(path: &syn::Path, expected: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::block_has_replay_guard;
+    use super::{block_has_replay_guard, should_own_replay};
 
     #[test]
     fn string_literal_does_not_count_as_replay_guard() {
@@ -992,13 +1074,9 @@ mod tests {
         //
         // Scope of this test: it pins the SKIP-LIST behavior on the
         // marker-plus-policy-check prologue prefix, via a reduced hand-written
-        // block. It deliberately does NOT run the walk over full real
-        // `#[authorize]` output: the walk already fails there on the
-        // unrecognized sunset-check statement the guard emits between the
-        // policy check and the replay stop — a pre-existing gap that predates
-        // the marker (and equally affects `#[secured]`'s UNAUTHORIZED-wrapped
-        // failure branch), tracked as its own follow-up because recognizing
-        // those statements changes replay-layer composition at runtime.
+        // block that stops short of the sunset-check statement `#[authorize]`
+        // emits next. `should_own_replay_defers_to_authorize_across_the_sunset_check`
+        // below exercises the real full expansion, sunset check included.
         let generated = crate::authorize::authorize_macro(
             quote::quote! { "update", resource = Post },
             quote::quote! {
@@ -1042,5 +1120,43 @@ mod tests {
         });
 
         assert!(block_has_replay_guard(&block));
+    }
+
+    #[test]
+    fn should_own_replay_defers_to_authorize_across_the_sunset_check() {
+        // Real stacking order `#[authorize("update", resource = Post)]` above
+        // `#[secured]`/`#[step_up]`/`#[throttle]`: authorize expands FIRST
+        // (it's topmost) and already owns replay-serving via its own in-body
+        // check. Between that check and its replay stop it also emits a
+        // sunset-version check — a statement the scan must see past, or it
+        // stops early, reports no replay guard, and lets the about-to-attach
+        // gate claim replay ownership for itself.
+        //
+        // That would no longer be the harmless redundancy it was pre-#1668:
+        // the gate is a `FromRequestParts` extractor that runs BEFORE the
+        // handler body — i.e. before `#[authorize]`'s policy re-check, which
+        // lives entirely inside the body. A gate that wrongly owns replay
+        // would serve a cached success response for a retried mutation
+        // without ever re-running that policy check, even after the
+        // requester's authorization has since been revoked.
+        let generated = crate::authorize::authorize_macro(
+            quote::quote! { "update", resource = Post },
+            quote::quote! {
+                async fn update_post(post: Post) -> &'static str { "ok" }
+            },
+        );
+        let generated_fn: syn::ItemFn =
+            syn::parse2(generated).expect("#[authorize] must emit a parseable function");
+
+        assert!(
+            block_has_replay_guard(&generated_fn.block),
+            "the real #[authorize] expansion already owns replay-serving; the scan must \
+             see past the sunset-check statement to find it"
+        );
+        assert!(
+            !should_own_replay(&generated_fn),
+            "a gate macro stacking on top of real #[authorize] output must defer replay \
+             ownership to authorize, not claim it for a pre-body gate"
+        );
     }
 }

--- a/autumn-macros/src/idempotency_guard.rs
+++ b/autumn-macros/src/idempotency_guard.rs
@@ -6,6 +6,39 @@ pub fn block_has_replay_guard(block: &Block) -> bool {
     block_has_generated_replay_guard(block)
 }
 
+/// Whether a pre-body `FromRequestParts` gate macro (`#[secured]`,
+/// `#[step_up]`, `#[throttle]` — issue #1668) about to attach its own gate to
+/// `input_fn` should also make that gate responsible for serving a cached
+/// idempotency replay.
+///
+/// Exactly one guard may own replay-serving, and it must be the one every
+/// OTHER stacked guard's check is already guaranteed to have passed by the
+/// time it runs. That is never true when:
+///
+/// - another guard's gate parameter is already present — [`has_any_guard_gate_param`];
+/// - an earlier-expanded in-body guard (`#[authorize]`, or a gate that
+///   deferred for one of these same reasons) already owns replay —
+///   [`block_has_replay_guard`];
+/// - `#[authorize]` is still an unexpanded attribute and will run AFTER this
+///   gate: its policy check lives inside the handler body, which only runs
+///   once every extractor — including this gate — has already succeeded, so
+///   a gate that served a cached replay itself would return before
+///   `#[authorize]`'s check ever ran.
+pub fn should_own_replay(input_fn: &syn::ItemFn) -> bool {
+    !crate::param_helpers::has_any_guard_gate_param(input_fn)
+        && !block_has_replay_guard(&input_fn.block)
+        && !has_pending_authorize_attr(input_fn)
+}
+
+fn has_pending_authorize_attr(input_fn: &syn::ItemFn) -> bool {
+    input_fn.attrs.iter().any(|attr| {
+        attr.path()
+            .segments
+            .last()
+            .is_some_and(|segment| segment.ident == "authorize")
+    })
+}
+
 fn block_has_generated_replay_guard(block: &Block) -> bool {
     let mut index = 0;
     while let Some(stmt) = block.stmts.get(index) {

--- a/autumn-macros/src/param_helpers.rs
+++ b/autumn-macros/src/param_helpers.rs
@@ -43,6 +43,83 @@ fn pat_binds_name(pat: &syn::Pat, name: &str) -> bool {
     }
 }
 
+/// Type-name prefixes of the pre-body `FromRequestParts` gate parameter each
+/// body-guard macro inserts (issue #1668): `#[secured]`, `#[step_up]`, and
+/// `#[throttle]` each mint a handler-unique gate type named
+/// `__Autumn{Kind}Gate_{fn_name}` and insert it as a new leading parameter, so
+/// its check runs — and can reject — before Axum's body extractor ever runs.
+const GUARD_GATE_TYPE_PREFIXES: &[&str] = &[
+    "__AutumnSecuredGate_",
+    "__AutumnStepUpGate_",
+    "__AutumnThrottleGate_",
+];
+
+/// Whether `func` already carries another guard's pre-body gate parameter.
+///
+/// Used by each of `#[secured]`/`#[step_up]`/`#[throttle]` to decide whether
+/// ITS OWN gate should own idempotency-replay serving: whichever gate is
+/// applied to a still-unguarded function (no earlier gate parameter, and per
+/// [`crate::idempotency_guard::block_has_replay_guard`] no earlier in-body
+/// guard either) is the one whose check every other stacked guard's check is
+/// guaranteed to have already passed by the time it runs, so it — and only
+/// it — may serve a cached replay.
+pub fn has_any_guard_gate_param(func: &ItemFn) -> bool {
+    GUARD_GATE_TYPE_PREFIXES
+        .iter()
+        .any(|prefix| has_guard_gate_param_with_prefix(func, prefix))
+}
+
+/// Whether `func` has a parameter whose type name starts with `prefix` — one
+/// of the [`GUARD_GATE_TYPE_PREFIXES`]. Exposed separately from
+/// [`has_any_guard_gate_param`] so a caller that only cares about ONE guard
+/// kind (e.g. the route macro distinguishing `#[step_up]` from `#[throttle]`
+/// for its own diagnostics) doesn't have to re-derive the naming convention.
+pub fn has_guard_gate_param_with_prefix(func: &ItemFn, prefix: &str) -> bool {
+    func.sig.inputs.iter().any(|arg| {
+        let syn::FnArg::Typed(pat_type) = arg else {
+            return false;
+        };
+        type_name_starts_with(&pat_type.ty, prefix)
+    })
+}
+
+fn type_name_starts_with(ty: &syn::Type, prefix: &str) -> bool {
+    let syn::Type::Path(type_path) = ty else {
+        return false;
+    };
+    let Some(segment) = type_path.path.segments.last() else {
+        return false;
+    };
+    segment.ident.to_string().starts_with(prefix)
+}
+
+/// Test-only helper: pull the `fn` named `name` out of a macro's generated
+/// output.
+///
+/// Since issue #1668, `#[secured]`/`#[step_up]`/`#[throttle]` each emit a
+/// SIBLING gate item (a marker struct plus its `FromRequestParts` impl)
+/// alongside the transformed handler `fn`, rather than a single transformed
+/// item. That mirrors how the real compiler feeds stacked attribute macros:
+/// each attribute macro is invoked with the tokens of the ONE item it is
+/// still attached to, never a bundle of sibling items another macro emitted
+/// alongside it — a still-pending attribute (e.g. `#[get]` written above one
+/// of these guards) travels along on that single `fn` item, and the compiler
+/// re-invokes it with just that item's tokens. A test that hand-simulates
+/// stacking by feeding one macro's raw output into another must reproduce
+/// that same single-item slice, or it exercises a shape the compiler would
+/// never actually produce.
+#[cfg(test)]
+pub fn extract_fn_item(tokens: proc_macro2::TokenStream, name: &str) -> ItemFn {
+    let file: syn::File = syn::parse2(tokens).expect("generated tokens must parse as a file");
+    file.items
+        .into_iter()
+        .find_map(|item| match item {
+            syn::Item::Fn(f) if f.sig.ident == name => Some(f),
+            _ => None,
+        })
+        .unwrap_or_else(|| panic!("fn `{name}` not found among the generated items"))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -78,5 +155,29 @@ mod tests {
             async fn h(other: i32, __autumn_session: Session) {}
         };
         assert!(has_input_named(&f, "__autumn_session"));
+    }
+
+    #[test]
+    fn has_any_guard_gate_param_detects_each_kind() {
+        let secured: ItemFn = parse_quote! {
+            async fn h(_g: __AutumnSecuredGate_h) {}
+        };
+        let step_up: ItemFn = parse_quote! {
+            async fn h(_g: __AutumnStepUpGate_h) {}
+        };
+        let throttle: ItemFn = parse_quote! {
+            async fn h(_g: __AutumnThrottleGate_h) {}
+        };
+        assert!(has_any_guard_gate_param(&secured));
+        assert!(has_any_guard_gate_param(&step_up));
+        assert!(has_any_guard_gate_param(&throttle));
+    }
+
+    #[test]
+    fn has_any_guard_gate_param_false_without_one() {
+        let f: ItemFn = parse_quote! {
+            async fn h(Json(body): Json<T>) {}
+        };
+        assert!(!has_any_guard_gate_param(&f));
     }
 }

--- a/autumn-macros/src/route.rs
+++ b/autumn-macros/src/route.rs
@@ -598,22 +598,33 @@ fn has_authorize_guard(input_fn: &syn::ItemFn) -> bool {
         || crate::api_doc::has_policy_check_in_stmts(&input_fn.block.stmts)
 }
 
+/// Whether `#[step_up]` applies to `input_fn`, in either attribute order: a
+/// still-unexpanded `#[step_up]` attribute, or (issue #1668) the
+/// `__AutumnStepUpGate_*` pre-body `FromRequestParts` gate parameter it
+/// expands into. The gate parameter check matters because `#[step_up]` no
+/// longer leaves any recognizable shape in the handler *body* — its check now
+/// runs in a sibling gate, before the body ever executes — so `body_guarded_replay`
+/// (which must stay true whenever a gate owns replay-serving, to keep the
+/// standalone `IdempotencyReplayLayer` from serving a cached response ahead of
+/// the gate's check) can no longer rely on a body-shape scan alone.
 fn has_step_up_guard(input_fn: &syn::ItemFn) -> bool {
     input_fn.attrs.iter().any(|attr| {
         attr.path()
             .segments
             .last()
             .is_some_and(|segment| segment.ident == "step_up")
-    })
+    }) || crate::param_helpers::has_guard_gate_param_with_prefix(input_fn, "__AutumnStepUpGate_")
 }
 
+/// Whether `#[throttle]` applies to `input_fn`. See [`has_step_up_guard`] for
+/// why the pre-body gate parameter is checked alongside the attribute.
 fn has_throttle_guard(input_fn: &syn::ItemFn) -> bool {
     input_fn.attrs.iter().any(|attr| {
         attr.path()
             .segments
             .last()
             .is_some_and(|segment| segment.ident == "throttle")
-    })
+    }) || crate::param_helpers::has_guard_gate_param_with_prefix(input_fn, "__AutumnThrottleGate_")
 }
 
 /// Whether a `#[secured]` attribute is still present on the handler (i.e. it has
@@ -1435,7 +1446,14 @@ mod tests {
             },
         );
         let secured = crate::secured::secured_macro(quote! { "admin" }, authorized);
-        let generated = route_macro("POST", "post", quote! { "/notes/{id}" }, secured).to_string();
+        let secured_fn = crate::param_helpers::extract_fn_item(secured, "update_note");
+        let generated = route_macro(
+            "POST",
+            "post",
+            quote! { "/notes/{id}" },
+            quote! { #secured_fn },
+        )
+        .to_string();
 
         assert!(
             generated.contains(r#"AuthorizeBinding { action : "update" , resource : "Note" }"#),
@@ -1489,8 +1507,11 @@ mod tests {
                 async fn update_note(note: Note) -> &'static str { "ok" }
             },
         );
-        let authorized =
-            crate::authorize::authorize_macro(quote! { "update", resource = Note }, secured);
+        let secured_fn = crate::param_helpers::extract_fn_item(secured, "update_note");
+        let authorized = crate::authorize::authorize_macro(
+            quote! { "update", resource = Note },
+            quote! { #secured_fn },
+        );
         let generated =
             route_macro("POST", "post", quote! { "/notes/{id}" }, authorized).to_string();
 
@@ -1521,7 +1542,14 @@ mod tests {
                 async fn update_note(note: Note) -> &'static str { "ok" }
             },
         );
-        let generated = route_macro("POST", "post", quote! { "/notes/{id}" }, secured).to_string();
+        let secured_fn = crate::param_helpers::extract_fn_item(secured, "update_note");
+        let generated = route_macro(
+            "POST",
+            "post",
+            quote! { "/notes/{id}" },
+            quote! { #secured_fn },
+        )
+        .to_string();
 
         assert!(
             generated.contains(r#"required_roles : & ["admin"]"#),

--- a/autumn-macros/src/route.rs
+++ b/autumn-macros/src/route.rs
@@ -340,15 +340,18 @@ const EDGE_AGENT_OPERABLE_ERROR: &str = "`#[edge]` cannot be combined with `#[ag
      route from the origin.\n\nServe the route from the origin, or drop \
      `#[agent_operable]`. See docs/guide/agent-authority.md.";
 
-/// Marker consts the auth/rate guards inject into a handler body. A guard that
-/// expanded *before* this route macro left one of these behind instead of an
-/// attribute, and missing it would ship a guarded route to the unauthenticated
-/// edge lane.
+/// Marker consts a guard that expanded *before* this route macro left behind
+/// in the handler body instead of an attribute, and missing it would ship a
+/// guarded route to the unauthenticated edge lane.
+///
+/// `#[step_up]`/`#[throttle]` don't appear here: their check moved into a
+/// pre-body `FromRequestParts` gate (#1668) and they never left an
+/// OpenAPI-readable body marker to begin with, so `has_auth_or_rate_guard`
+/// recognizes them via `has_step_up_guard`/`has_throttle_guard`'s own
+/// gate-param check instead of this body scan.
 const GUARD_MARKERS: &[&str] = &[
     "__AUTUMN_SECURED_ROLES",
     "__AUTUMN_SECURED_SCOPES",
-    "__AUTUMN_STEP_UP_MAX_AGE",
-    "__AUTUMN_THROTTLE_ROUTE_ID",
     "__AUTUMN_AUTHORIZE_BINDINGS",
     "__AUTUMN_AGENT_OPERABLE",
 ];

--- a/autumn-macros/src/secured.rs
+++ b/autumn-macros/src/secured.rs
@@ -1,8 +1,13 @@
 //! `#[secured]` proc macro implementation.
 //!
-//! Generates an authentication/authorization guard that runs before
-//! the handler body. Injects hidden `Session` and `AppState` extractors
-//! and prepends a call to the runtime check function.
+//! Generates an authentication/authorization guard that runs as a
+//! `FromRequestParts` gate — a hidden, handler-unique parameter inserted
+//! ahead of the handler's own parameters — instead of a statement inside the
+//! handler body (issue #1668). Axum resolves every `FromRequestParts`
+//! extractor, left to right, *before* it ever reaches a `FromRequest` body
+//! extractor (`Json` / `Form` / `Multipart`) and short-circuits on the first
+//! rejection, so an unauthenticated/unauthorized request is rejected with
+//! `401`/`403` before the request body is parsed, rather than after.
 //!
 //! ## Forms
 //!
@@ -17,12 +22,11 @@
 //!   role (via the session) **and** the scope (AND semantics).
 
 use proc_macro2::TokenStream;
-use quote::quote;
+use quote::{format_ident, quote};
 use syn::parse::Parser as _;
 use syn::{Expr, ExprLit, ItemFn, Lit, LitStr, Meta, Token, parse_quote};
 
-use crate::idempotency_guard::block_has_replay_guard;
-use crate::param_helpers::has_input_named;
+use crate::idempotency_guard::should_own_replay;
 
 /// Parsed `#[secured(...)]` arguments: positional role literals plus an
 /// optional `scopes = [...]` list of token abilities.
@@ -130,29 +134,60 @@ pub fn secured_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
     // The session/role check is emitted for the classic forms (`#[secured]`,
     // `#[secured("admin")]`) and whenever a role is required. It is OMITTED for
     // a scopes-ONLY gate so a pure service token with no session authorizes on
-    // its scopes alone (injecting the Session extractor would otherwise require
-    // a SessionLayer and reject token-only requests).
+    // its scopes alone (extracting a real `Session` would otherwise require a
+    // `SessionLayer` and reject token-only requests).
     let emit_session_check = !roles.is_empty() || scopes.is_empty();
     let emit_scope_check = !scopes.is_empty();
 
     let role_literals = roles.iter().map(|role| quote! { #role });
     let scope_literals = scopes.iter().map(|scope| quote! { #scope });
+    // A single `TokenStream` (cheaply `Clone`) so the role/scope consts can be
+    // emitted twice — once in the handler body for OpenAPI extraction (where
+    // nothing in the body reads them any more, hence `allow(dead_code)`), once
+    // inside the gate for the actual runtime check — without moving the
+    // (single-use) role/scope literal iterators twice.
+    let role_scope_consts = quote! {
+        #[allow(dead_code)]
+        const __AUTUMN_SECURED_ROLES: &[&str] = &[#(#role_literals),*];
+        #[allow(dead_code)]
+        const __AUTUMN_SECURED_SCOPES: &[&str] = &[#(#scope_literals),*];
+    };
+    let fn_name = input_fn.sig.ident.clone();
+    let gate_ident = format_ident!("__AutumnSecuredGate_{}", fn_name);
 
     let session_check = if emit_session_check {
         quote! {
+            // A real `Session` extraction (not a raw extensions lookup) so a
+            // missing `SessionLayer` still fails loudly, exactly as the
+            // hidden `__autumn_session: Session` handler parameter this
+            // replaces did.
+            let __autumn_session: ::autumn_web::session::Session = match
+                <::autumn_web::session::Session as ::autumn_web::reexports::axum::extract::FromRequestParts<::autumn_web::AppState>>
+                    ::from_request_parts(parts, state).await
+            {
+                ::core::result::Result::Ok(__session) => __session,
+                ::core::result::Result::Err(__never) => match __never {},
+            };
             if let ::core::result::Result::Err(__autumn_error) = ::autumn_web::auth::__check_secured_with_key(
                 &__autumn_session,
-                __autumn_state.auth_session_key(),
+                state.auth_session_key(),
                 __AUTUMN_SECURED_ROLES,
             ).await {
                 if __autumn_error.status() == ::autumn_web::reexports::http::StatusCode::UNAUTHORIZED {
+                    let __autumn_idempotency_replay = parts
+                        .extensions
+                        .get::<::autumn_web::idempotency::IdempotencyReplayResponse>()
+                        .cloned()
+                        .map(::autumn_web::reexports::axum::extract::Extension);
                     if let ::core::option::Option::Some(__autumn_response) =
                         ::autumn_web::idempotency::__replay_finalized_session_response(&__autumn_idempotency_replay)
                     {
-                        return __autumn_response;
+                        return ::core::result::Result::Err(__autumn_response);
                     }
                 }
-                return ::autumn_web::reexports::axum::response::IntoResponse::into_response(__autumn_error);
+                return ::core::result::Result::Err(
+                    ::autumn_web::reexports::axum::response::IntoResponse::into_response(__autumn_error),
+                );
             }
         }
     } else {
@@ -161,24 +196,84 @@ pub fn secured_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
 
     let scope_check = if emit_scope_check {
         quote! {
+            let __autumn_token_scopes = parts
+                .extensions
+                .get::<::autumn_web::auth::ApiTokenScopes>()
+                .cloned();
             if let ::core::result::Result::Err(__autumn_error) = ::autumn_web::auth::__check_secured_scopes(
-                __autumn_token_scopes.as_ref().map(|__e| &__e.0),
+                __autumn_token_scopes.as_ref(),
                 __AUTUMN_SECURED_SCOPES,
             ).await {
-                return ::autumn_web::reexports::axum::response::IntoResponse::into_response(__autumn_error);
+                return ::core::result::Result::Err(
+                    ::autumn_web::reexports::axum::response::IntoResponse::into_response(__autumn_error),
+                );
             }
         }
     } else {
         quote! {}
     };
 
-    let check_call = quote! {
-        // Route macros read these markers when #[secured] expands before #[get]/#[post]/etc.
-        const __AUTUMN_SECURED_ROLES: &[&str] = &[#(#role_literals),*];
-        const __AUTUMN_SECURED_SCOPES: &[&str] = &[#(#scope_literals),*];
-        #session_check
-        #scope_check
+    // Whether THIS gate should also serve a cached idempotency replay: see
+    // `should_own_replay` for the full ordering rationale (issue #1668's
+    // pre-body gates and `#[authorize]`'s in-body check must never both skip
+    // replay-ownership, nor both claim it).
+    let owns_replay = should_own_replay(&input_fn);
+    let replay_check = if owns_replay {
+        quote! {
+            let __autumn_idempotency_replay = parts
+                .extensions
+                .get::<::autumn_web::idempotency::IdempotencyReplayResponse>()
+                .cloned()
+                .map(::autumn_web::reexports::axum::extract::Extension);
+            if let ::core::option::Option::Some(__autumn_response) =
+                ::autumn_web::idempotency::__replay_response(&__autumn_idempotency_replay)
+            {
+                return ::core::result::Result::Err(__autumn_response);
+            }
+        }
+    } else {
+        quote! {}
     };
+
+    // The marker consts stay in the handler body (not just the gate below) so
+    // `api_doc::extract_secured_info` can still recover the role/scope values
+    // for OpenAPI when `#[secured]` expands before the route macro.
+    let markers = role_scope_consts.clone();
+
+    // Both checks — and any replay lookup this gate owns — run inside a
+    // `FromRequestParts` gate: a hidden parameter inserted ahead of the
+    // handler's own parameters, rather than as a statement inside the handler
+    // body. Axum resolves every `FromRequestParts` extractor before it ever
+    // reaches a `FromRequest` body extractor (`Json` / `Form` / `Multipart`)
+    // and short-circuits on the first rejection, so an unauthenticated /
+    // unauthorized / replayed request never causes the body to be parsed.
+    let gate_item = quote! {
+        #[doc(hidden)]
+        #[allow(non_camel_case_types)]
+        pub struct #gate_ident;
+
+        #[doc(hidden)]
+        impl ::autumn_web::reexports::axum::extract::FromRequestParts<::autumn_web::AppState>
+            for #gate_ident
+        {
+            type Rejection = ::autumn_web::reexports::axum::response::Response;
+
+            fn from_request_parts(
+                parts: &mut ::autumn_web::reexports::axum::http::request::Parts,
+                state: &::autumn_web::AppState,
+            ) -> impl ::core::future::Future<Output = ::core::result::Result<Self, Self::Rejection>>
+                + Send {
+                async move {
+                    #role_scope_consts
+                    #session_check
+                    #scope_check
+                    #replay_check
+                    ::core::result::Result::Ok(#gate_ident)
+                }
+            }
+        }
+    };
+
     let original_body = &input_fn.block;
     let original_response = match &input_fn.sig.output {
         syn::ReturnType::Default => quote! {
@@ -195,64 +290,12 @@ pub fn secured_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
             ::autumn_web::reexports::axum::response::IntoResponse::into_response(__autumn_inner)
         },
     };
-    let body_already_has_replay_guard = block_has_replay_guard(original_body);
-    let replay_stop = if body_already_has_replay_guard {
-        quote! {}
-    } else {
-        quote! {
-            const __AUTUMN_IDEMPOTENCY_REPLAY_GUARD: () = ();
-            if let ::core::option::Option::Some(__autumn_response) =
-                ::autumn_web::idempotency::__replay_response(&__autumn_idempotency_replay)
-            {
-                return __autumn_response;
-            }
-        }
-    };
 
-    // Inject hidden State<AppState> and Session parameters at the start of
-    // the parameter list, but only if no other macro (typically `#[authorize]`) has
-    // already injected them. Without these guards, stacking
-    // `#[authorize]` + `#[secured]` in either attribute order would
-    // produce duplicate hidden parameters and fail to
-    // compile.
-    //
-    // For a scopes-ONLY gate the session/role check is not emitted, so we skip
-    // injecting the Session extractor — a token-only route has no SessionLayer
-    // and the extractor would otherwise reject the request.
-    if emit_session_check && !has_input_named(&input_fn, "__autumn_state") {
-        let state_param: syn::FnArg = syn::parse_quote! {
-            ::autumn_web::reexports::axum::extract::State(__autumn_state):
-                ::autumn_web::reexports::axum::extract::State<::autumn_web::AppState>
-        };
-        input_fn.sig.inputs.insert(0, state_param);
-    }
-    if emit_session_check && !has_input_named(&input_fn, "__autumn_session") {
-        let session_param: syn::FnArg = syn::parse_quote! {
-            __autumn_session: ::autumn_web::session::Session
-        };
-        input_fn.sig.inputs.insert(0, session_param);
-    }
-    // Inject the granted-scopes extension when a scope gate is present.
-    if emit_scope_check && !has_input_named(&input_fn, "__autumn_token_scopes") {
-        let scopes_param: syn::FnArg = syn::parse_quote! {
-            __autumn_token_scopes: ::core::option::Option<
-                ::autumn_web::reexports::axum::extract::Extension<
-                    ::autumn_web::auth::ApiTokenScopes
-                >
-            >
-        };
-        input_fn.sig.inputs.insert(0, scopes_param);
-    }
-    if !has_input_named(&input_fn, "__autumn_idempotency_replay") {
-        let idempotency_param: syn::FnArg = syn::parse_quote! {
-            __autumn_idempotency_replay: ::core::option::Option<
-                ::autumn_web::reexports::axum::extract::Extension<
-                    ::autumn_web::idempotency::IdempotencyReplayResponse
-                >
-            >
-        };
-        input_fn.sig.inputs.insert(0, idempotency_param);
-    }
+    // Insert the gate as the FIRST parameter — ahead of every other
+    // extractor, including any earlier-inserted guard gate (which then
+    // correctly runs AFTER this one; see `should_own_replay`'s doc comment).
+    let gate_param: syn::FnArg = parse_quote! { _: #gate_ident };
+    input_fn.sig.inputs.insert(0, gate_param);
 
     input_fn
         .attrs
@@ -263,13 +306,15 @@ pub fn secured_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
 
     input_fn.block = syn::parse_quote! {
         {
-            #check_call
-            #replay_stop
+            #markers
             #original_response
         }
     };
 
-    quote! { #input_fn }
+    quote! {
+        #gate_item
+        #input_fn
+    }
 }
 
 #[cfg(test)]
@@ -380,5 +425,117 @@ mod tests {
         // Both markers always emitted for OpenAPI extraction.
         assert!(generated.contains("__AUTUMN_SECURED_ROLES"));
         assert!(generated.contains("__AUTUMN_SECURED_SCOPES"));
+    }
+
+    // ── Pre-body FromRequestParts gate (#1668) ──────────────────────────────
+
+    #[test]
+    fn check_runs_in_a_from_request_parts_gate() {
+        let generated = secured_macro(
+            quote! { "admin" },
+            quote! { async fn h() -> &'static str { "ok" } },
+        )
+        .to_string();
+        assert!(
+            generated.contains("FromRequestParts"),
+            "the check must run in a FromRequestParts gate, not a body statement:\n{generated}"
+        );
+        assert!(
+            generated.contains("struct __AutumnSecuredGate_h"),
+            "should emit a handler-unique gate marker struct:\n{generated}"
+        );
+    }
+
+    #[test]
+    fn inserts_gate_as_first_parameter() {
+        let generated_fn = {
+            let generated = secured_macro(
+                quote! { "admin" },
+                quote! {
+                    async fn h(::autumn_web::reexports::axum::extract::Json(_body): ::autumn_web::reexports::axum::extract::Json<String>) -> &'static str { "ok" }
+                },
+            );
+            let items: syn::File = syn::parse2(generated).expect("generated tokens must parse");
+            items
+                .items
+                .into_iter()
+                .find_map(|item| match item {
+                    syn::Item::Fn(f) if f.sig.ident == "h" => Some(f),
+                    _ => None,
+                })
+                .expect("handler fn must be present in the expansion")
+        };
+        let first_param = generated_fn
+            .sig
+            .inputs
+            .first()
+            .expect("handler must have at least the gate parameter");
+        let syn::FnArg::Typed(pat_type) = first_param else {
+            panic!("first parameter must be a typed gate parameter");
+        };
+        let syn::Type::Path(type_path) = pat_type.ty.as_ref() else {
+            panic!("gate parameter must be a named type");
+        };
+        assert_eq!(
+            type_path.path.segments.last().unwrap().ident,
+            "__AutumnSecuredGate_h",
+            "the gate must be the FIRST parameter — ahead of the body extractor — so Axum \
+             resolves (and can reject on) it before ever reaching the body"
+        );
+    }
+
+    #[test]
+    fn handler_body_no_longer_contains_the_session_check() {
+        let generated_fn = {
+            let generated = secured_macro(
+                quote! { "admin" },
+                quote! { async fn h() -> &'static str { "ok" } },
+            );
+            let items: syn::File = syn::parse2(generated).expect("generated tokens must parse");
+            items
+                .items
+                .into_iter()
+                .find_map(|item| match item {
+                    syn::Item::Fn(f) if f.sig.ident == "h" => Some(f),
+                    _ => None,
+                })
+                .expect("handler fn must be present in the expansion")
+        };
+        let body = quote! { #generated_fn }.to_string();
+        assert!(
+            !body.contains("__check_secured_with_key"),
+            "the handler body must not call the runtime check directly:\n{body}"
+        );
+    }
+
+    #[test]
+    fn defers_replay_to_an_earlier_gate_when_stacked() {
+        let generated = secured_macro(
+            quote! { "admin" },
+            quote! {
+                async fn h(_g: __AutumnThrottleGate_h) -> &'static str { "ok" }
+            },
+        )
+        .to_string();
+        assert!(
+            !generated.contains("__replay_response"),
+            "must defer replay-ownership to the earlier-inserted gate:\n{generated}"
+        );
+    }
+
+    #[test]
+    fn defers_replay_when_authorize_still_pending() {
+        let generated = secured_macro(
+            quote! { "admin" },
+            quote! {
+                #[authorize("update", resource = Post)]
+                async fn h() -> &'static str { "ok" }
+            },
+        )
+        .to_string();
+        assert!(
+            !generated.contains("__replay_response"),
+            "must defer replay-ownership while #[authorize] is still pending:\n{generated}"
+        );
     }
 }

--- a/autumn-macros/src/step_up.rs
+++ b/autumn-macros/src/step_up.rs
@@ -1,8 +1,13 @@
 //! `#[step_up]` proc macro implementation.
 //!
-//! Generates a step-up authentication guard that runs before the handler
-//! body. Injects hidden extractors and prepends a call to the runtime
-//! check function.
+//! Generates a step-up authentication guard that runs as a
+//! `FromRequestParts` gate — a hidden, handler-unique parameter inserted
+//! ahead of the handler's own parameters — instead of a statement inside the
+//! handler body (issue #1668). Axum resolves every `FromRequestParts`
+//! extractor, left to right, *before* it ever reaches a `FromRequest` body
+//! extractor (`Json` / `Form` / `Multipart`) and short-circuits on the first
+//! rejection, so a stale/missing step-up session is rejected before the
+//! request body is parsed, rather than after.
 //!
 //! ## Forms
 //!
@@ -11,11 +16,10 @@
 //! - `#[step_up(max_age = "1h")]` -- require fresh auth within 1 hour
 
 use proc_macro2::TokenStream;
-use quote::quote;
+use quote::{format_ident, quote};
 use syn::{ItemFn, LitStr, parse_quote};
 
-use crate::idempotency_guard::block_has_replay_guard;
-use crate::param_helpers::has_input_named;
+use crate::idempotency_guard::should_own_replay;
 
 /// Parse the `#[step_up(max_age = "…")]` attribute arguments.
 ///
@@ -82,31 +86,33 @@ fn parse_max_age_str_at_compile_time(lit: &LitStr) -> Result<u64, String> {
         .map_err(|_| format!("invalid max_age: '{s}' (expected seconds or e.g. \"5m\")"))
 }
 
-/// Build the runtime freshness-check token stream injected at the top of
-/// the handler body.
+/// Build the runtime freshness-check token stream that runs inside the gate's
+/// `from_request_parts`, after the extractor prelude has bound `state`,
+/// `__autumn_session`, `__autumn_step_up_headers`, `__autumn_step_up_uri`,
+/// `__autumn_step_up_method`, and `__autumn_idempotency_replay`.
 fn build_check_call(max_age_tokens: &TokenStream) -> TokenStream {
     quote! {
         const __AUTUMN_STEP_UP_MAX_AGE: ::core::option::Option<u64> = #max_age_tokens;
         // Resolve max_age before the check so the response can advertise the
         // exact value actually enforced (not the compile-time default).
         let __max_age_secs: u64 =
-            ::autumn_web::step_up::__resolve_step_up_max_age(&__autumn_state, __AUTUMN_STEP_UP_MAX_AGE);
+            ::autumn_web::step_up::__resolve_step_up_max_age(state, __AUTUMN_STEP_UP_MAX_AGE);
         if let ::core::result::Result::Err(__autumn_step_up_error) =
             ::autumn_web::step_up::__check_step_up_with_config(
                 &__autumn_session,
-                &__autumn_state,
+                state,
                 __AUTUMN_STEP_UP_MAX_AGE,
             ).await
         {
             if let ::core::option::Option::Some(__autumn_response) =
                 ::autumn_web::idempotency::__replay_finalized_session_response_for_anonymous(
                     &__autumn_session,
-                    __autumn_state.auth_session_key(),
+                    state.auth_session_key(),
                     &__autumn_idempotency_replay,
                 )
                 .await
             {
-                return __autumn_response;
+                return ::core::result::Result::Err(__autumn_response);
             }
             let __wants_json: bool = __autumn_step_up_headers
                 .get(::autumn_web::reexports::axum::http::header::ACCEPT)
@@ -114,7 +120,9 @@ fn build_check_call(max_age_tokens: &TokenStream) -> TokenStream {
                 .map(|s| s.contains("application/json") || s.contains("+json"))
                 .unwrap_or(false);
             if __wants_json {
-                return ::autumn_web::step_up::__step_up_json_response(__max_age_secs);
+                return ::core::result::Result::Err(
+                    ::autumn_web::step_up::__step_up_json_response(__max_age_secs),
+                );
             } else {
                 // For non-GET requests: prefer Referer so the user returns to
                 // the page with the form after reauth rather than a POST/DELETE
@@ -142,59 +150,15 @@ fn build_check_call(max_age_tokens: &TokenStream) -> TokenStream {
                             .unwrap_or_else(|| __autumn_step_up_uri.path()),
                     )
                 };
-                return ::autumn_web::reexports::axum::response::IntoResponse::into_response(
-                    ::autumn_web::reexports::axum::response::Redirect::to(
-                        &::std::format!("/reauth?return_to={__return_to}")
-                    )
+                return ::core::result::Result::Err(
+                    ::autumn_web::reexports::axum::response::IntoResponse::into_response(
+                        ::autumn_web::reexports::axum::response::Redirect::to(
+                            &::std::format!("/reauth?return_to={__return_to}")
+                        )
+                    ),
                 );
             }
         }
-    }
-}
-
-/// Inject the four hidden extractors required by the step-up check, guarding
-/// against duplication when `#[step_up]` is stacked with `#[secured]`.
-fn inject_step_up_params(input_fn: &mut ItemFn) {
-    if !has_input_named(input_fn, "__autumn_state") {
-        let p: syn::FnArg = parse_quote! {
-            ::autumn_web::reexports::axum::extract::State(__autumn_state):
-                ::autumn_web::reexports::axum::extract::State<::autumn_web::AppState>
-        };
-        input_fn.sig.inputs.insert(0, p);
-    }
-    if !has_input_named(input_fn, "__autumn_session") {
-        let p: syn::FnArg = parse_quote! {
-            __autumn_session: ::autumn_web::session::Session
-        };
-        input_fn.sig.inputs.insert(0, p);
-    }
-    if !has_input_named(input_fn, "__autumn_step_up_headers") {
-        let p: syn::FnArg = parse_quote! {
-            __autumn_step_up_headers: ::autumn_web::reexports::axum::http::HeaderMap
-        };
-        input_fn.sig.inputs.insert(0, p);
-    }
-    if !has_input_named(input_fn, "__autumn_step_up_uri") {
-        let p: syn::FnArg = parse_quote! {
-            __autumn_step_up_uri: ::autumn_web::reexports::axum::http::Uri
-        };
-        input_fn.sig.inputs.insert(0, p);
-    }
-    if !has_input_named(input_fn, "__autumn_step_up_method") {
-        let p: syn::FnArg = parse_quote! {
-            __autumn_step_up_method: ::autumn_web::reexports::axum::http::Method
-        };
-        input_fn.sig.inputs.insert(0, p);
-    }
-    if !has_input_named(input_fn, "__autumn_idempotency_replay") {
-        let p: syn::FnArg = parse_quote! {
-            __autumn_idempotency_replay: ::core::option::Option<
-                ::autumn_web::reexports::axum::extract::Extension<
-                    ::autumn_web::idempotency::IdempotencyReplayResponse
-                >
-            >
-        };
-        input_fn.sig.inputs.insert(0, p);
     }
 }
 
@@ -226,6 +190,7 @@ fn type_contains_impl_trait(ty: &syn::Type) -> bool {
 }
 
 /// Expand the `#[step_up]` / `#[step_up(max_age = "Nm")]` attribute.
+#[allow(clippy::too_many_lines)]
 pub fn step_up_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
     let max_age_opt = match parse_step_up_args(attr) {
         Ok(v) => v,
@@ -251,6 +216,86 @@ pub fn step_up_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
         },
     );
     let check_call = build_check_call(&max_age_tokens);
+    let fn_name = input_fn.sig.ident.clone();
+    let gate_ident = format_ident!("__AutumnStepUpGate_{}", fn_name);
+
+    // Whether THIS gate should also serve a cached idempotency replay: see
+    // `should_own_replay` for the full ordering rationale (issue #1668's
+    // pre-body gates and `#[authorize]`'s in-body check must never both skip
+    // replay-ownership, nor both claim it). Replay is checked BEFORE the
+    // step-up freshness check (unchanged from before this gate existed): a
+    // cached response for an already-completed mutation needs no fresh
+    // step-up to replay, since replaying serves the exact stored bytes rather
+    // than re-executing the handler.
+    let owns_replay = should_own_replay(&input_fn);
+    let replay_check = if owns_replay {
+        quote! {
+            let __autumn_idempotency_replay = parts
+                .extensions
+                .get::<::autumn_web::idempotency::IdempotencyReplayResponse>()
+                .cloned()
+                .map(::autumn_web::reexports::axum::extract::Extension);
+            if let ::core::option::Option::Some(__autumn_response) =
+                ::autumn_web::idempotency::__replay_response(&__autumn_idempotency_replay)
+            {
+                return ::core::result::Result::Err(__autumn_response);
+            }
+        }
+    } else {
+        quote! {
+            let __autumn_idempotency_replay = parts
+                .extensions
+                .get::<::autumn_web::idempotency::IdempotencyReplayResponse>()
+                .cloned()
+                .map(::autumn_web::reexports::axum::extract::Extension);
+        }
+    };
+
+    // Both the freshness check and the replay lookup run inside a
+    // `FromRequestParts` gate: a hidden parameter inserted ahead of the
+    // handler's own parameters, rather than as a statement inside the handler
+    // body. Axum resolves every `FromRequestParts` extractor before it ever
+    // reaches a `FromRequest` body extractor (`Json` / `Form` / `Multipart`)
+    // and short-circuits on the first rejection, so a stale/missing step-up
+    // session never causes the body to be parsed.
+    let gate_item = quote! {
+        #[doc(hidden)]
+        #[allow(non_camel_case_types)]
+        pub struct #gate_ident;
+
+        #[doc(hidden)]
+        impl ::autumn_web::reexports::axum::extract::FromRequestParts<::autumn_web::AppState>
+            for #gate_ident
+        {
+            type Rejection = ::autumn_web::reexports::axum::response::Response;
+
+            fn from_request_parts(
+                parts: &mut ::autumn_web::reexports::axum::http::request::Parts,
+                state: &::autumn_web::AppState,
+            ) -> impl ::core::future::Future<Output = ::core::result::Result<Self, Self::Rejection>>
+                + Send {
+                async move {
+                    // A real `Session` extraction (not a raw extensions
+                    // lookup) so a missing `SessionLayer` still fails loudly,
+                    // exactly as the hidden `__autumn_session: Session`
+                    // handler parameter this replaces did.
+                    let __autumn_session: ::autumn_web::session::Session = match
+                        <::autumn_web::session::Session as ::autumn_web::reexports::axum::extract::FromRequestParts<::autumn_web::AppState>>
+                            ::from_request_parts(parts, state).await
+                    {
+                        ::core::result::Result::Ok(__session) => __session,
+                        ::core::result::Result::Err(__never) => match __never {},
+                    };
+                    let __autumn_step_up_headers = parts.headers.clone();
+                    let __autumn_step_up_uri = parts.uri.clone();
+                    let __autumn_step_up_method = parts.method.clone();
+                    #replay_check
+                    #check_call
+                    ::core::result::Result::Ok(#gate_ident)
+                }
+            }
+        }
+    };
 
     let original_body = input_fn.block.clone();
     let original_response = match &input_fn.sig.output {
@@ -272,35 +317,28 @@ pub fn step_up_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
         },
     };
 
-    inject_step_up_params(&mut input_fn);
+    // Insert the gate as the FIRST parameter — ahead of every other
+    // extractor, including any earlier-inserted guard gate (which then
+    // correctly runs AFTER this one; see `should_own_replay`'s doc comment).
+    let gate_param: syn::FnArg = parse_quote! { _: #gate_ident };
+    input_fn.sig.inputs.insert(0, gate_param);
+
     input_fn
         .attrs
         .push(parse_quote!(#[allow(clippy::too_many_arguments)]));
     input_fn.sig.output = parse_quote! {
         -> ::autumn_web::reexports::axum::response::Response
     };
-    let body_already_has_replay_guard = block_has_replay_guard(&original_body);
-    let replay_stop = if body_already_has_replay_guard {
-        quote! {}
-    } else {
-        quote! {
-            const __AUTUMN_IDEMPOTENCY_REPLAY_GUARD: () = ();
-            if let ::core::option::Option::Some(__autumn_response) =
-                ::autumn_web::idempotency::__replay_response(&__autumn_idempotency_replay)
-            {
-                return __autumn_response;
-            }
-        }
-    };
     input_fn.block = syn::parse_quote! {
         {
-            #replay_stop
-            #check_call
             #original_response
         }
     };
 
-    quote! { #input_fn }
+    quote! {
+        #gate_item
+        #input_fn
+    }
 }
 
 // ── Tests ────────────────────────────────────────────────────────────────────
@@ -395,7 +433,7 @@ mod tests {
     }
 
     #[test]
-    fn step_up_injects_state_parameter() {
+    fn check_runs_in_a_from_request_parts_gate() {
         let generated = step_up_macro(
             quote! {},
             quote! {
@@ -404,8 +442,17 @@ mod tests {
         )
         .to_string();
         assert!(
-            generated.contains("__autumn_state"),
-            "should inject state parameter:\n{generated}"
+            generated.contains("FromRequestParts"),
+            "the check must run in a FromRequestParts gate, not a body statement:\n{generated}"
+        );
+        assert!(
+            generated.contains("struct __AutumnStepUpGate_handler"),
+            "should emit a handler-unique gate marker struct:\n{generated}"
+        );
+        assert!(
+            !generated.contains("__autumn_state"),
+            "the old hidden State<AppState> handler parameter should be gone — the gate reads \
+             state from its own `from_request_parts` argument instead:\n{generated}"
         );
     }
 
@@ -502,30 +549,63 @@ mod tests {
     }
 
     #[test]
-    fn step_up_does_not_duplicate_session_when_stacked_with_secured() {
-        // Simulate what happens when both #[secured] and #[step_up] are applied:
-        // both macros try to inject __autumn_session. The has_input_named guard
-        // should prevent duplicates.
-        let after_secured = step_up_macro(
+    fn inserts_gate_as_first_parameter_when_stacked_with_secured() {
+        // Simulate `#[secured]` having already expanded and inserted its own
+        // gate parameter ahead of `#[step_up]`'s. Each gate is now an
+        // independent `FromRequestParts` parameter (issue #1668) rather than a
+        // shared hidden `Session`/`State` pair, so there is no more
+        // duplicate-parameter risk to guard against — but `#[step_up]`'s own
+        // gate must still land as the new FIRST parameter, ahead of
+        // `#[secured]`'s (which then correctly runs second; see
+        // `should_own_replay`'s doc comment).
+        let generated_fn = {
+            let generated = step_up_macro(
+                quote! {},
+                quote! {
+                    async fn handler(_g: __AutumnSecuredGate_handler) -> &'static str { "ok" }
+                },
+            );
+            let items: syn::File = syn::parse2(generated).expect("generated tokens must parse");
+            items
+                .items
+                .into_iter()
+                .find_map(|item| match item {
+                    syn::Item::Fn(f) if f.sig.ident == "handler" => Some(f),
+                    _ => None,
+                })
+                .expect("handler fn must be present in the expansion")
+        };
+        let first_param = generated_fn
+            .sig
+            .inputs
+            .first()
+            .expect("handler must have at least the gate parameter");
+        let syn::FnArg::Typed(pat_type) = first_param else {
+            panic!("first parameter must be a typed gate parameter");
+        };
+        let syn::Type::Path(type_path) = pat_type.ty.as_ref() else {
+            panic!("gate parameter must be a named type");
+        };
+        assert_eq!(
+            type_path.path.segments.last().unwrap().ident,
+            "__AutumnStepUpGate_handler",
+            "the newly-inserted gate must be the FIRST parameter"
+        );
+    }
+
+    #[test]
+    fn defers_replay_when_authorize_still_pending() {
+        let generated = step_up_macro(
             quote! {},
-            // Function already has __autumn_session (as if #[secured] ran first)
             quote! {
-                async fn handler(
-                    __autumn_session: ::autumn_web::session::Session,
-                    __autumn_state: ::autumn_web::reexports::axum::extract::State<::autumn_web::AppState>,
-                ) -> &'static str { "ok" }
+                #[authorize("update", resource = Post)]
+                async fn handler() -> &'static str { "ok" }
             },
         )
         .to_string();
-        // Count occurrences of "__autumn_session" — should appear multiple times
-        // in generated code (parameter, call site) but the *parameter declaration*
-        // should only appear once.
-        let session_decl_count = after_secured
-            .matches("__autumn_session : :: autumn_web :: session :: Session")
-            .count();
-        assert_eq!(
-            session_decl_count, 1,
-            "should not duplicate __autumn_session parameter:\n{after_secured}"
+        assert!(
+            !generated.contains("__replay_response"),
+            "must defer replay-ownership while #[authorize] is still pending:\n{generated}"
         );
     }
 

--- a/autumn-macros/src/throttle.rs
+++ b/autumn-macros/src/throttle.rs
@@ -1,8 +1,13 @@
 //! `#[throttle]` proc macro implementation.
 //!
-//! Generates a per-route rate-limit guard that runs before the handler
-//! body. Injects hidden extractors and prepends a call to the runtime
-//! check function.
+//! Generates a per-route rate-limit guard that runs as a `FromRequestParts`
+//! gate — a hidden, handler-unique parameter inserted ahead of the handler's
+//! own parameters — instead of a statement inside the handler body (issue
+//! #1668). Axum resolves every `FromRequestParts` extractor, left to right,
+//! *before* it ever reaches a `FromRequest` body extractor (`Json` / `Form` /
+//! `Multipart`) and short-circuits on the first rejection, so an over-limit
+//! request is rejected with `429` before the request body is parsed or
+//! buffered, rather than after.
 //!
 //! ## Forms
 //!
@@ -14,12 +19,11 @@
 //!   `[security.rate_limit.named.login]`
 
 use proc_macro2::TokenStream;
-use quote::quote;
+use quote::{format_ident, quote};
 use syn::parse::Parser as _;
 use syn::{Expr, ItemFn, Lit, LitInt, LitStr, parse_quote};
 
-use crate::idempotency_guard::block_has_replay_guard;
-use crate::param_helpers::has_input_named;
+use crate::idempotency_guard::should_own_replay;
 
 /// Parsed `#[throttle(...)]` attribute arguments.
 enum ThrottleAttrs {
@@ -172,98 +176,6 @@ fn parse_throttle_args(attr: TokenStream) -> syn::Result<ThrottleAttrs> {
     })
 }
 
-/// Inject the hidden extractors the runtime check needs. Guards against
-/// duplication when stacking with `#[secured]`, `#[step_up]`, etc.
-fn inject_throttle_params(input_fn: &mut ItemFn) {
-    if !has_input_named(input_fn, "__autumn_state") {
-        let p: syn::FnArg = parse_quote! {
-            ::autumn_web::reexports::axum::extract::State(__autumn_state):
-                ::autumn_web::reexports::axum::extract::State<::autumn_web::AppState>
-        };
-        input_fn.sig.inputs.insert(0, p);
-    }
-    if !has_input_named(input_fn, "__autumn_throttle_headers") {
-        let p: syn::FnArg = parse_quote! {
-            __autumn_throttle_headers: ::autumn_web::reexports::axum::http::HeaderMap
-        };
-        input_fn.sig.inputs.insert(0, p);
-    }
-    if !has_input_named(input_fn, "__autumn_throttle_matched_path") {
-        // Optional because `MatchedPath` is absent for some routes (fallbacks,
-        // unnested handlers). When present, the runtime matched route pattern
-        // isolates an INLINE throttle's bucket per mounted path — a handler
-        // reused under two `scoped` prefixes maps to the same compile-time
-        // `route_id`, so folding the matched path in gives each mount its own
-        // bucket. `__check_throttle` consults it only for inline throttles.
-        let p: syn::FnArg = parse_quote! {
-            __autumn_throttle_matched_path: ::core::option::Option<
-                ::autumn_web::reexports::axum::extract::MatchedPath
-            >
-        };
-        input_fn.sig.inputs.insert(0, p);
-    }
-    if !has_input_named(input_fn, "__autumn_throttle_peer") {
-        // Wrap ConnectInfo in Extension so `Option<...>` is a valid extractor
-        // even in tests that don't call `into_make_service_with_connect_info`.
-        let p: syn::FnArg = parse_quote! {
-            __autumn_throttle_peer: ::core::option::Option<
-                ::autumn_web::reexports::axum::extract::Extension<
-                    ::autumn_web::reexports::axum::extract::ConnectInfo<
-                        ::std::net::SocketAddr
-                    >
-                >
-            >
-        };
-        input_fn.sig.inputs.insert(0, p);
-    }
-    if !has_input_named(input_fn, "__autumn_throttle_principal") {
-        let p: syn::FnArg = parse_quote! {
-            __autumn_throttle_principal: ::core::option::Option<
-                ::autumn_web::reexports::axum::extract::Extension<
-                    ::autumn_web::security::RateLimitPrincipal
-                >
-            >
-        };
-        input_fn.sig.inputs.insert(0, p);
-    }
-    if !has_input_named(input_fn, "__autumn_throttle_session") {
-        // Optional so throttled routes without session middleware (or a
-        // per-route throttle that doesn't key on the principal) still compile
-        // and run. `__check_throttle` only consults it for `key = "principal"`
-        // when no `RateLimitPrincipal` extension was installed, deriving the
-        // principal from the same verified session `populate_rate_limit_principal`
-        // reads.
-        let p: syn::FnArg = parse_quote! {
-            __autumn_throttle_session: ::core::option::Option<
-                ::autumn_web::reexports::axum::extract::Extension<
-                    ::autumn_web::session::Session
-                >
-            >
-        };
-        input_fn.sig.inputs.insert(0, p);
-    }
-    if !has_input_named(input_fn, "__autumn_throttle_exempt") {
-        let p: syn::FnArg = parse_quote! {
-            __autumn_throttle_exempt: ::core::option::Option<
-                ::autumn_web::reexports::axum::extract::Extension<
-                    ::autumn_web::security::RateLimitExempt
-                >
-            >
-        };
-        input_fn.sig.inputs.insert(0, p);
-    }
-    if !has_input_named(input_fn, "__autumn_idempotency_replay") {
-        let p: syn::FnArg = parse_quote! {
-            __autumn_idempotency_replay: ::core::option::Option<
-                ::autumn_web::reexports::axum::extract::Extension<
-                    ::autumn_web::idempotency::IdempotencyReplayResponse
-                >
-            >
-        };
-        input_fn.sig.inputs.insert(0, p);
-    }
-}
-
 /// Returns `true` if `ty` contains an `impl Trait` anywhere in its tree.
 ///
 /// Rust rejects `impl Trait` in local variable type annotations, so the
@@ -332,6 +244,7 @@ fn build_spec_tokens(attrs: &ThrottleAttrs) -> TokenStream {
 }
 
 /// Expand the `#[throttle(...)]` attribute.
+#[allow(clippy::too_many_lines)]
 pub fn throttle_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
     let attrs = match parse_throttle_args(attr) {
         Ok(a) => a,
@@ -351,32 +264,128 @@ pub fn throttle_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
         .to_compile_error();
     }
 
-    let fn_name_str = input_fn.sig.ident.to_string();
+    let fn_name = input_fn.sig.ident.clone();
+    let fn_name_str = fn_name.to_string();
     let spec_tokens = build_spec_tokens(&attrs);
+    let gate_ident = format_ident!("__AutumnThrottleGate_{}", fn_name);
 
-    let check_call = quote! {
-        // Stable per-handler bucket namespace. Two routes pointing at the same
-        // named limiter share their bucket via the runtime registry — the
-        // route_id here is only used for inline limiters and for uniqueness
-        // when a named entry is missing from config.
-        const __AUTUMN_THROTTLE_ROUTE_ID: &str =
-            ::core::concat!(::core::module_path!(), "::", #fn_name_str);
-        if let ::core::result::Result::Err(__autumn_throttle_response) =
-            ::autumn_web::security::__check_throttle(
-                &__autumn_state,
-                __AUTUMN_THROTTLE_ROUTE_ID,
-                __autumn_throttle_matched_path.as_ref().map(|__mp| __mp.as_str()),
-                #spec_tokens,
-                &__autumn_throttle_headers,
-                __autumn_throttle_peer
-                    .as_ref()
-                    .map(|ext| ext.0.0),
-                __autumn_throttle_principal.as_ref().map(|e| &e.0),
-                __autumn_throttle_session.as_ref().map(|e| &e.0),
-                __autumn_throttle_exempt.is_some(),
-            ).await
+    // Whether THIS gate should also serve a cached idempotency replay: see
+    // `should_own_replay` for the full ordering rationale (issue #1668's
+    // pre-body gates and `#[authorize]`'s in-body check must never both skip
+    // replay-ownership, nor both claim it).
+    let owns_replay = should_own_replay(&input_fn);
+    let replay_check = if owns_replay {
+        quote! {
+            let __autumn_idempotency_replay = parts
+                .extensions
+                .get::<::autumn_web::idempotency::IdempotencyReplayResponse>()
+                .cloned()
+                .map(::autumn_web::reexports::axum::extract::Extension);
+            if let ::core::option::Option::Some(__autumn_response) =
+                ::autumn_web::idempotency::__replay_response(&__autumn_idempotency_replay)
+            {
+                return ::core::result::Result::Err(__autumn_response);
+            }
+        }
+    } else {
+        quote! {}
+    };
+
+    // The throttle check must run BEFORE the idempotency-replay lookup.
+    // Returning a cached response ahead of `__check_throttle` would let repeat
+    // requests reusing the same `Idempotency-Key` bypass the per-route bucket
+    // forever. Running the throttle check first ensures replays still consume
+    // the bucket and can 429 once the route limit is exhausted; only if the
+    // throttle check passes do we replay any cached response.
+    //
+    // Both the check and the replay lookup run inside a `FromRequestParts`
+    // gate — a hidden parameter inserted ahead of the handler's own
+    // parameters — rather than as a statement inside the handler body. Axum
+    // resolves every `FromRequestParts` extractor before it ever reaches a
+    // `FromRequest` body extractor (`Json` / `Form` / `Multipart`) and
+    // short-circuits on the first rejection, so an over-limit or replayed
+    // request never causes the body to be parsed or buffered.
+    let gate_item = quote! {
+        #[doc(hidden)]
+        #[allow(non_camel_case_types)]
+        pub struct #gate_ident;
+
+        #[doc(hidden)]
+        impl ::autumn_web::reexports::axum::extract::FromRequestParts<::autumn_web::AppState>
+            for #gate_ident
         {
-            return __autumn_throttle_response;
+            type Rejection = ::autumn_web::reexports::axum::response::Response;
+
+            fn from_request_parts(
+                parts: &mut ::autumn_web::reexports::axum::http::request::Parts,
+                state: &::autumn_web::AppState,
+            ) -> impl ::core::future::Future<Output = ::core::result::Result<Self, Self::Rejection>>
+                + Send {
+                async move {
+                    // Stable per-handler bucket namespace. Two routes pointing
+                    // at the same named limiter share their bucket via the
+                    // runtime registry — the route_id here is only used for
+                    // inline limiters and for uniqueness when a named entry is
+                    // missing from config.
+                    const __AUTUMN_THROTTLE_ROUTE_ID: &str =
+                        ::core::concat!(::core::module_path!(), "::", #fn_name_str);
+                    let __autumn_throttle_headers = parts.headers.clone();
+                    // Optional because `MatchedPath` is absent for some routes
+                    // (fallbacks, unnested handlers). When present, the
+                    // runtime matched route pattern isolates an INLINE
+                    // throttle's bucket per mounted path — a handler reused
+                    // under two `scoped` prefixes maps to the same
+                    // compile-time `route_id`, so folding the matched path in
+                    // gives each mount its own bucket. `__check_throttle`
+                    // consults it only for inline throttles.
+                    let __autumn_throttle_matched_path = parts
+                        .extensions
+                        .get::<::autumn_web::reexports::axum::extract::MatchedPath>()
+                        .cloned();
+                    let __autumn_throttle_peer = parts
+                        .extensions
+                        .get::<::autumn_web::reexports::axum::extract::ConnectInfo<::std::net::SocketAddr>>()
+                        .copied();
+                    let __autumn_throttle_principal = parts
+                        .extensions
+                        .get::<::autumn_web::security::RateLimitPrincipal>()
+                        .cloned();
+                    // Optional so throttled routes without session middleware
+                    // (or a per-route throttle that doesn't key on the
+                    // principal) still compile and run. `__check_throttle`
+                    // only consults it for `key = "principal"` when no
+                    // `RateLimitPrincipal` extension was installed, deriving
+                    // the principal from the same verified session
+                    // `populate_rate_limit_principal` reads. Read directly
+                    // from extensions (not the `Session` extractor) so a
+                    // route with no `SessionLayer` installed does not panic.
+                    let __autumn_throttle_session = parts
+                        .extensions
+                        .get::<::autumn_web::session::Session>()
+                        .cloned();
+                    let __autumn_throttle_exempt = parts
+                        .extensions
+                        .get::<::autumn_web::security::RateLimitExempt>()
+                        .is_some();
+                    if let ::core::result::Result::Err(__autumn_throttle_response) =
+                        ::autumn_web::security::__check_throttle(
+                            state,
+                            __AUTUMN_THROTTLE_ROUTE_ID,
+                            __autumn_throttle_matched_path.as_ref().map(|__mp| __mp.as_str()),
+                            #spec_tokens,
+                            &__autumn_throttle_headers,
+                            __autumn_throttle_peer.map(|c| c.0),
+                            __autumn_throttle_principal.as_ref(),
+                            __autumn_throttle_session.as_ref(),
+                            __autumn_throttle_exempt,
+                        ).await
+                    {
+                        return ::core::result::Result::Err(__autumn_throttle_response);
+                    }
+                    #replay_check
+                    ::core::result::Result::Ok(#gate_ident)
+                }
+            }
         }
     };
 
@@ -412,43 +421,32 @@ pub fn throttle_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
         },
     };
 
-    inject_throttle_params(&mut input_fn);
+    // Insert the gate as the FIRST parameter. Axum evaluates `FromRequestParts`
+    // extractors left to right, so this must sit ahead of every other
+    // extractor — including any earlier-inserted guard gate, which then
+    // correctly runs AFTER (see `should_own_replay`'s doc comment: whichever
+    // guard is applied to a still-unguarded function owns replay, and
+    // "unguarded" is judged at each macro's OWN expansion time, before later
+    // macros insert their gates further left).
+    let gate_param: syn::FnArg = parse_quote! { _: #gate_ident };
+    input_fn.sig.inputs.insert(0, gate_param);
+
     input_fn
         .attrs
         .push(parse_quote!(#[allow(clippy::too_many_arguments)]));
     input_fn.sig.output = parse_quote! {
         -> ::autumn_web::reexports::axum::response::Response
     };
-    let body_already_has_replay_guard = block_has_replay_guard(&original_body);
-    let replay_stop = if body_already_has_replay_guard {
-        quote! {}
-    } else {
-        quote! {
-            const __AUTUMN_IDEMPOTENCY_REPLAY_GUARD: () = ();
-            if let ::core::option::Option::Some(__autumn_response) =
-                ::autumn_web::idempotency::__replay_response(&__autumn_idempotency_replay)
-            {
-                return __autumn_response;
-            }
-        }
-    };
-    // The throttle check must run BEFORE the idempotency-replay lookup. Because
-    // the route macro disables the outer `IdempotencyReplayLayer` for throttled
-    // routes (replay handling moves into this body), returning a cached response
-    // ahead of `__check_throttle` would let repeat requests reusing the same
-    // `Idempotency-Key` bypass the per-route bucket forever. Running the throttle
-    // check first ensures replays still consume the bucket and can 429 once the
-    // route limit is exhausted; only if the throttle check passes do we replay
-    // any cached response, then fall through to the user body.
     input_fn.block = syn::parse_quote! {
         {
-            #check_call
-            #replay_stop
             #original_response
         }
     };
 
-    quote! { #input_fn }
+    quote! {
+        #gate_item
+        #input_fn
+    }
 }
 
 // ── Tests ────────────────────────────────────────────────────────────────────
@@ -626,7 +624,7 @@ mod tests {
     }
 
     #[test]
-    fn injects_state_extractor() {
+    fn gate_reads_state_from_from_request_parts() {
         let generated = throttle_macro(
             quote! { limit = 5, per = "1m" },
             quote! {
@@ -635,8 +633,17 @@ mod tests {
         )
         .to_string();
         assert!(
-            generated.contains("__autumn_state"),
-            "should inject state extractor:\n{generated}"
+            generated.contains("FromRequestParts"),
+            "check should run in a FromRequestParts gate, not a body statement:\n{generated}"
+        );
+        assert!(
+            generated.contains("__check_throttle"),
+            "should still emit the runtime check call:\n{generated}"
+        );
+        assert!(
+            !generated.contains("__autumn_state"),
+            "the old hidden State<AppState> handler parameter should be gone — the gate reads \
+             state from its own `from_request_parts` argument instead:\n{generated}"
         );
     }
 
@@ -651,11 +658,11 @@ mod tests {
         .to_string();
         assert!(
             generated.contains("__autumn_throttle_headers"),
-            "should inject headers extractor:\n{generated}"
+            "should read headers from request parts:\n{generated}"
         );
         assert!(
-            generated.contains("__autumn_throttle_peer"),
-            "should inject ConnectInfo extractor:\n{generated}"
+            generated.contains("ConnectInfo"),
+            "should read ConnectInfo from request parts:\n{generated}"
         );
     }
 
@@ -670,11 +677,151 @@ mod tests {
         .to_string();
         assert!(
             generated.contains("__autumn_throttle_matched_path"),
-            "should inject MatchedPath extractor:\n{generated}"
+            "should read MatchedPath from request parts:\n{generated}"
         );
         assert!(
             generated.contains("MatchedPath"),
             "should reference axum MatchedPath:\n{generated}"
+        );
+    }
+
+    #[test]
+    fn emits_gate_struct_and_impl_as_sibling_items() {
+        let generated = throttle_macro(
+            quote! { limit = 5, per = "1m" },
+            quote! {
+                async fn handler() -> &'static str { "ok" }
+            },
+        )
+        .to_string();
+        assert!(
+            generated.contains("struct __AutumnThrottleGate_handler"),
+            "should emit a handler-unique gate marker struct:\n{generated}"
+        );
+        assert!(
+            generated
+                .contains("impl :: autumn_web :: reexports :: axum :: extract :: FromRequestParts"),
+            "gate must implement FromRequestParts so Axum resolves it before the body extractor:\n{generated}"
+        );
+    }
+
+    #[test]
+    fn inserts_gate_as_first_parameter() {
+        let generated_fn = {
+            let generated = throttle_macro(
+                quote! { limit = 5, per = "1m" },
+                quote! {
+                    async fn handler(::autumn_web::reexports::axum::extract::Json(_body): ::autumn_web::reexports::axum::extract::Json<String>) -> &'static str { "ok" }
+                },
+            );
+            let items: syn::File = syn::parse2(generated).expect("generated tokens must parse");
+            items
+                .items
+                .into_iter()
+                .find_map(|item| match item {
+                    syn::Item::Fn(f) if f.sig.ident == "handler" => Some(f),
+                    _ => None,
+                })
+                .expect("handler fn must be present in the expansion")
+        };
+        let first_param = generated_fn
+            .sig
+            .inputs
+            .first()
+            .expect("handler must have at least the gate parameter");
+        let syn::FnArg::Typed(pat_type) = first_param else {
+            panic!("first parameter must be a typed gate parameter");
+        };
+        let syn::Type::Path(type_path) = pat_type.ty.as_ref() else {
+            panic!("gate parameter must be a named type");
+        };
+        assert_eq!(
+            type_path.path.segments.last().unwrap().ident,
+            "__AutumnThrottleGate_handler",
+            "the gate must be the FIRST parameter — ahead of the body extractor — so Axum \
+             resolves (and can reject on) it before ever reaching the body"
+        );
+    }
+
+    #[test]
+    fn handler_body_no_longer_contains_the_throttle_check() {
+        // The whole point of issue #1668: the runtime check must live in the
+        // gate's `FromRequestParts` impl, not in a statement inside the
+        // handler body (which only runs after every extractor — including a
+        // body extractor — has already succeeded).
+        let generated_fn = {
+            let generated = throttle_macro(
+                quote! { limit = 5, per = "1m" },
+                quote! {
+                    async fn handler() -> &'static str { "ok" }
+                },
+            );
+            let items: syn::File = syn::parse2(generated).expect("generated tokens must parse");
+            items
+                .items
+                .into_iter()
+                .find_map(|item| match item {
+                    syn::Item::Fn(f) if f.sig.ident == "handler" => Some(f),
+                    _ => None,
+                })
+                .expect("handler fn must be present in the expansion")
+        };
+        let body = quote! { #generated_fn }.to_string();
+        assert!(
+            !body.contains("__check_throttle"),
+            "the handler body must not call the runtime check directly:\n{body}"
+        );
+    }
+
+    #[test]
+    fn owns_replay_when_unguarded() {
+        let generated = throttle_macro(
+            quote! { limit = 5, per = "1m" },
+            quote! {
+                async fn handler() -> &'static str { "ok" }
+            },
+        )
+        .to_string();
+        assert!(
+            generated.contains("__replay_response"),
+            "an otherwise-unguarded throttled handler's gate must own replay-serving:\n{generated}"
+        );
+    }
+
+    #[test]
+    fn defers_replay_to_an_earlier_gate_when_stacked() {
+        // Simulate `#[secured]` having already expanded and inserted its own
+        // gate parameter ahead of `#[throttle]`'s.
+        let generated = throttle_macro(
+            quote! { limit = 5, per = "1m" },
+            quote! {
+                async fn handler(_g: __AutumnSecuredGate_handler) -> &'static str { "ok" }
+            },
+        )
+        .to_string();
+        assert!(
+            !generated.contains("__replay_response"),
+            "must defer replay-ownership to the earlier-inserted gate:\n{generated}"
+        );
+    }
+
+    #[test]
+    fn defers_replay_when_authorize_still_pending() {
+        // `#[authorize]` written below `#[throttle]` hasn't expanded yet, so
+        // its in-body policy check will only run once the handler body is
+        // invoked — strictly after this gate. If this gate served a cached
+        // replay itself, `#[authorize]`'s check would never run for a replay.
+        let generated = throttle_macro(
+            quote! { limit = 5, per = "1m" },
+            quote! {
+                #[authorize("update", resource = Post)]
+                async fn handler() -> &'static str { "ok" }
+            },
+        )
+        .to_string();
+        assert!(
+            !generated.contains("__replay_response"),
+            "must defer replay-ownership while #[authorize] is still pending:\n{generated}"
         );
     }
 

--- a/autumn/tests/integration/authorization_integration.rs
+++ b/autumn/tests/integration/authorization_integration.rs
@@ -747,6 +747,72 @@ async fn reversed_attribute_order_owner_passes_both() {
     assert_eq!(response.status, StatusCode::OK);
 }
 
+// ── Reversed order + idempotency replay (#1668 follow-up) ────
+//
+// `#[secured]` (and `#[step_up]`/`#[throttle]`) now run their check in a
+// pre-body `FromRequestParts` gate, which executes BEFORE `#[authorize]`'s
+// policy check when `#[authorize]` is written above them — that check still
+// lives entirely inside the handler body. A stale idempotency-guard body
+// scan once let the gate believe it should own replay-serving in this
+// ordering, which would let a retried mutation replay its cached response
+// without ever re-running `#[authorize]`'s policy check.
+
+#[autumn_web::post("/notes-reversed-idempotent/{id}")]
+#[autumn_web::authorize("update", resource = Note)]
+#[autumn_web::secured]
+async fn update_note_reversed_attribute_order_idempotent(
+    autumn_web::extract::Path(id): autumn_web::extract::Path<i64>,
+    LoadedNote(note): LoadedNote,
+) -> AutumnResult<&'static str> {
+    let _ = id;
+    let _ = note;
+    Ok("ok")
+}
+
+fn build_idempotent_reversed_app(
+    store: MemoryStore,
+    forbidden_response: ForbiddenResponse,
+) -> autumn_web::test::TestClient {
+    TestApp::new()
+        .routes(routes![update_note_reversed_attribute_order_idempotent])
+        .policy::<Note, _>(AdminOrOwnerPolicy)
+        .forbidden_response(forbidden_response)
+        .layer(SessionLayer::new(store, SessionConfig::default()))
+        .idempotent()
+        .build()
+}
+
+#[tokio::test]
+async fn idempotent_replay_does_not_bypass_authorize_policy_check_when_secured_gate_runs_first() {
+    let store = MemoryStore::new();
+    seed_session(&store, "sess-reversed-policy", "999", Some("admin")).await;
+    let client = build_idempotent_reversed_app(store.clone(), ForbiddenResponse::Forbidden403);
+
+    let first = client
+        .post("/notes-reversed-idempotent/1")
+        .header("Cookie", "autumn.sid=sess-reversed-policy")
+        .header("idempotency-key", "reversed-policy-recheck-key")
+        .send()
+        .await;
+    assert_eq!(first.status, StatusCode::OK);
+
+    seed_session(&store, "sess-reversed-policy", "999", None).await;
+
+    let retry = client
+        .post("/notes-reversed-idempotent/1")
+        .header("Cookie", "autumn.sid=sess-reversed-policy")
+        .header("idempotency-key", "reversed-policy-recheck-key")
+        .send()
+        .await;
+    assert_eq!(
+        retry.status,
+        StatusCode::FORBIDDEN,
+        "a #[secured] gate stacked below #[authorize] must not claim idempotency-replay \
+         ownership and bypass #[authorize]'s policy re-check"
+    );
+    assert_eq!(retry.header("x-idempotent-replayed"), None);
+}
+
 // ── #[authorize] bindings recorded in route metadata (#1627) ──
 //
 // The route macros record every `#[authorize("action", resource = Type)]` on a

--- a/autumn/tests/integration/mod.rs
+++ b/autumn/tests/integration/mod.rs
@@ -288,6 +288,7 @@ mod schema_drift_guard;
 mod scoped_tokens;
 #[cfg(feature = "db")]
 mod search_index_definition;
+mod secured_route;
 mod security;
 mod seo;
 mod server_timing;
@@ -326,6 +327,7 @@ mod sqlite_replication_wal;
 #[cfg(feature = "ws")]
 mod sse_replay;
 mod static_serving;
+mod step_up_route;
 #[cfg(feature = "storage")]
 mod storage_local_integration;
 #[cfg(feature = "maud")]

--- a/autumn/tests/integration/secured_route.rs
+++ b/autumn/tests/integration/secured_route.rs
@@ -1,0 +1,38 @@
+//! Integration tests for the `#[secured]` attribute's extraction ordering
+//! relative to Axum's body extractors (issue #1668).
+//!
+//! `#[secured]`'s role/session check historically ran as a statement *inside*
+//! the handler body, which only executes after every extractor — including a
+//! body extractor like `Json`/`Form`/`Multipart` — has already succeeded. That
+//! meant an unauthenticated request with a malformed body was rejected with a
+//! body-extraction error (`400`/`422`) instead of `#[secured]`'s own `401`,
+//! masking the guard's outcome behind whatever the body extractor did first.
+
+use autumn_web::reexports::axum::Json;
+use autumn_web::secured;
+use autumn_web::test::TestApp;
+use autumn_web::{post, routes};
+
+#[post("/secured-body")]
+#[secured]
+async fn secured_body(Json(_): Json<serde_json::Value>) -> &'static str {
+    "secured-body-ok"
+}
+
+/// An unauthenticated client sending a malformed body must see `#[secured]`'s
+/// `401`, not a body-extraction error. If the session/role check still ran
+/// inside the handler body (after the `Json` extractor), the malformed body
+/// would fail extraction first and the client would never see the guard's
+/// intended response.
+#[tokio::test]
+async fn secured_route_401s_before_parsing_malformed_body() {
+    let client = TestApp::new().routes(routes![secured_body]).build();
+
+    let response = client
+        .post("/secured-body")
+        .header("content-type", "application/json")
+        .body("this is not valid json")
+        .send()
+        .await;
+    response.assert_status(401);
+}

--- a/autumn/tests/integration/step_up_route.rs
+++ b/autumn/tests/integration/step_up_route.rs
@@ -1,0 +1,39 @@
+//! Integration tests for the `#[step_up]` attribute's extraction ordering
+//! relative to Axum's body extractors (issue #1668).
+//!
+//! Like `#[secured]`, `#[step_up]`'s freshness check historically ran as a
+//! statement *inside* the handler body, so it only executed after every
+//! extractor — including a body extractor like `Json` — had already
+//! succeeded. A client with no fresh step-up session sending a malformed body
+//! was rejected with a body-extraction error (`400`/`422`) instead of
+//! `#[step_up]`'s own `401`, masking the guard's outcome.
+
+use autumn_web::reexports::axum::Json;
+use autumn_web::step_up;
+use autumn_web::test::TestApp;
+use autumn_web::{post, routes};
+
+#[post("/step-up-body")]
+#[step_up]
+async fn step_up_body(Json(_): Json<serde_json::Value>) -> &'static str {
+    "step-up-body-ok"
+}
+
+/// A client with no fresh step-up session sending a malformed body must see
+/// `#[step_up]`'s own `401` (JSON clients get a `WWW-Authenticate: StepUp`
+/// problem-details response), not a body-extraction error. If the freshness
+/// check still ran inside the handler body (after the `Json` extractor), the
+/// malformed body would fail extraction first.
+#[tokio::test]
+async fn step_up_route_401s_before_parsing_malformed_body() {
+    let client = TestApp::new().routes(routes![step_up_body]).build();
+
+    let response = client
+        .post("/step-up-body")
+        .header("accept", "application/json")
+        .header("content-type", "application/json")
+        .body("this is not valid json")
+        .send()
+        .await;
+    response.assert_status(401);
+}

--- a/autumn/tests/integration/throttle_route.rs
+++ b/autumn/tests/integration/throttle_route.rs
@@ -6,6 +6,7 @@
 //! affecting sibling routes.
 
 use autumn_web::config::AutumnConfig;
+use autumn_web::reexports::axum::Json;
 use autumn_web::security::{
     KeyStrategy, RateLimitEnvelopeCounted, RateLimitExempt, RateLimitNamedConfig,
     RateLimitPrincipal,
@@ -182,6 +183,18 @@ async fn impl_throttled() -> impl axum::response::IntoResponse {
 #[throttle(limit = 1, per = "1s", key = "ip")]
 async fn response_throttled() -> axum::response::Response {
     axum::response::IntoResponse::into_response("response-throttled-ok")
+}
+
+// A throttled route whose handler extracts a JSON body. Used to prove
+// (issue #1668) that an over-limit request is rejected with 429 WITHOUT ever
+// invoking Axum's `Json` body extractor — the throttle check must run as a
+// `FromRequestParts` gate, before the body is read, not as a statement inside
+// the handler body (which only runs after every extractor, including the body
+// extractor, has already succeeded).
+#[post("/throttled-body")]
+#[throttle(limit = 1, per = "60s", key = "ip")]
+async fn throttled_body(Json(_): Json<serde_json::Value>) -> &'static str {
+    "throttled-body-ok"
 }
 
 // A throttled MUTATING route that also participates in idempotency. Repeat
@@ -1261,4 +1274,51 @@ async fn named_limiter_is_shared_across_two_routes() {
         .send()
         .await
         .assert_status(200);
+}
+
+/// Issue #1668: an over-limit client must be rejected with 429 WITHOUT the
+/// server ever parsing the request body. Proven indirectly: the second
+/// request carries a body that is NOT valid JSON, even though the handler
+/// declares `Json<serde_json::Value>`. If the throttle check ran (as it does
+/// today) *inside* the handler body — i.e. after Axum's `Json` extractor has
+/// already run — the malformed body would fail extraction first and the
+/// client would see a `400`/`422` JSON-parse error instead of the throttle's
+/// `429`. A pre-body throttle gate must reject before the body extractor ever
+/// gets a chance to look at (and reject) the malformed bytes.
+#[tokio::test]
+#[allow(clippy::await_holding_lock)]
+async fn throttled_route_429s_before_parsing_malformed_body() {
+    let _throttle_lock = autumn_web::security::TEST_LOCK
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    autumn_web::security::__throttle_registry_reset();
+
+    let client = TestApp::new()
+        .routes(routes![throttled_body])
+        .config(base_config())
+        .build();
+
+    let ip = "203.0.113.201";
+
+    // First request consumes the single token (limit = 1).
+    client
+        .post("/throttled-body")
+        .header("X-Forwarded-For", ip)
+        .json(&serde_json::json!({}))
+        .send()
+        .await
+        .assert_status(200);
+
+    // Second request: over the limit AND carries a malformed body. The
+    // throttle rejection must win — a body-extraction error would mean the
+    // guard ran too late (after body parsing), which is exactly the ordering
+    // bug this issue tracks.
+    let response = client
+        .post("/throttled-body")
+        .header("X-Forwarded-For", ip)
+        .header("content-type", "application/json")
+        .body("this is not valid json")
+        .send()
+        .await;
+    response.assert_status(429);
 }


### PR DESCRIPTION
## Summary

Closes #1668.

`#[secured]`, `#[step_up]`, and `#[throttle]` used to run their guard checks as statements inside the generated handler body. Axum only calls the handler body after **every** extractor — including the body extractor (`Json`/`Form`/`Multipart`) — has already succeeded, so:

- an over-limit or unauthenticated request with a malformed body got the extractor's `400`/`422` instead of the guard's intended `429`/`401`/`403`, masking the guard's outcome, and
- the server paid the cost of parsing/buffering the body before a `#[throttle]`-gated route ever got to shed the load (a DoS-shaped cost).

Each of the three macros now emits a `FromRequestParts` **gate** — a small generated type (e.g. `__AutumnSecuredGate_<fn>`) inserted as the handler's first parameter. Axum resolves every `FromRequestParts` extractor left-to-right, strictly before the trailing `FromRequest` body extractor, so the guard's check (and any idempotency-replay it owns) now runs and can reject the request before the body is ever parsed.

While fixing this, review also surfaced and this PR closes a related idempotency-replay gap: when `#[authorize]` sits **above** one of these guards (authorize expands first), a pre-existing scanner gap could let the guard's new pre-body gate wrongly claim replay-serving for itself. That was harmless before this change (both checks ran as sequential body statements), but became a real bypass once the guard's check moved into a pre-body gate — a replayed mutation could serve a cached response without `#[authorize]`'s policy check ever re-running. See commit `227ba8f4` and its new tests.

## Approach (TDD)

1. **Red**: added integration tests sending a request that is both guard-rejectable (over throttle limit / unauthenticated) *and* has a malformed body, asserting the guard's status code — confirmed these failed with `400`/`422` against the old body-embedded checks.
2. **Green**: converted all three macros to emit a `FromRequestParts` gate inserted as the handler's first parameter; added a shared `should_own_replay` helper (`autumn-macros/src/idempotency_guard.rs`) so exactly one guard in a stack owns idempotency-replay serving, deferring correctly to `#[authorize]` and to other stacked gates.
3. **Refactor**: multi-angle code review (security, correctness/macro-hygiene, efficiency) surfaced and fixed a genuine P1 (the `#[authorize]`-above-guard replay bypass above) plus a small dead-code cleanup in `route.rs`'s `GUARD_MARKERS`.

## Acceptance criteria (from #1668)

- [x] **Guards run before the body extractor, as a `FromRequestParts` gate.** `autumn-macros/src/secured.rs`, `step_up.rs`, `throttle.rs` each emit `pub struct __Autumn*Gate_<fn>;` + `impl FromRequestParts<AppState> for` it, inserted as parameter 0.
- [x] **Framework-wide, consistent across all three macros — not a throttle-only fix.** All three converted in the same pattern in one commit (`4edaed79`), sharing `has_any_guard_gate_param`/`should_own_replay` helpers.
- [x] **Axum's extractor-ordering guarantee holds for our generated code.** Proven empirically, not just assumed: `throttled_route_429s_before_parsing_malformed_body`, `secured_route_401s_before_parsing_malformed_body`, `step_up_route_401s_before_parsing_malformed_body` each send an over-limit/unauthenticated request with a malformed JSON body and assert the guard's status wins over the would-be body-parse error.
- [x] **Malformed body no longer masks the guard's outcome.** Same three tests above are the direct fix for the issue's "Correctness wrinkle."
- [x] **DoS-shaped cost eliminated.** Architecturally guaranteed by gate-before-body ordering; the malformed-body tests are the proof (a parsed-first body would 400 before the gate mattered).
- [x] **Composes cleanly with idempotency-replay body buffering (`body_guarded_replay`).** `route.rs`'s `has_step_up_guard`/`has_throttle_guard` recognize the new gate param so `body_guarded_replay` still correctly suppresses the standalone `IdempotencyReplayLayer` for gated routes; 80/80 pre-existing idempotency tests and 30/30 `#[authorize]` integration tests pass unmodified. A genuine gap in this exact composition (`#[authorize]`-above-guard letting a gate wrongly claim replay ownership) was found during review and fixed, with a new unit test (`should_own_replay_defers_to_authorize_across_the_sunset_check`) and a new end-to-end test (`idempotent_replay_does_not_bypass_authorize_policy_check_when_secured_gate_runs_first`) pinning the fix.
- [x] **Macro ergonomics / signature stability — non-breaking.** `#[secured]`, `#[secured(roles = [...])]`, `#[secured(scopes = [...])]`, `#[step_up]`, `#[step_up(max_age = ...)]`, and `#[throttle(limit = ..., per = ..., key = ...)]` invocation syntax is unchanged. The gate parameter is inserted internally by the macro — nothing an app author writes changes. OpenAPI role/scope markers still surface correctly (60/60 `openapi`-feature tests pass, including `secured_route_with_role_has_required_roles`).
- [x] **Scope: framework-wide (`autumn-macros` + runtime), non-breaking.** Only compile-time codegen in `autumn-macros` changed; the runtime check functions (`__check_secured_with_key`, `__check_step_up_with_config`, `__check_throttle`) are unchanged — only *where* they're called from moved.

## Testing

- `cargo test -p autumn-macros --lib`: 1059/1059 passed
- `cargo test -p autumn-web --test integration_tests` (targeted filters): `openapi` 60/60, `authoriz` 30/30, `secured`/`step_up`/`throttle` route tests, `idempotency` 80/80 — all passed
- `cargo fmt --all -- --check`: clean
- `cargo clippy -p autumn-macros --all-targets -- -D warnings`: clean
- `cargo clippy -p autumn-web --test integration_tests -- -D warnings`: clean
- Full `./scripts/pre-push-check.sh`-equivalent sweep (panic gate, determinism gate, plugin-surface gate, fmt, workspace clippy, gated-feature clippy, compile-only test build, doctests): green

## Review

Multi-angle agent review (security, correctness/macro-hygiene, efficiency/simplification) was run against the diff. The one P1 finding (the `#[authorize]`-above-guard idempotency-replay bypass described above) is fixed and covered by new tests. A few P3 nits (stale `GUARD_MARKERS` entries) were also cleaned up. No outstanding findings.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0191q2nbYuKG22FHbgJhuSCg

---
_Generated by [Claude Code](https://claude.ai/code/session_0191q2nbYuKG22FHbgJhuSCg)_