### PR TITLE
🪞 Echo: single lockstep_contract() for first-party plugins (instances 5→1, mass -144 tokens)

### DIFF
--- a/autumn-admin-plugin/src/lib.rs
+++ b/autumn-admin-plugin/src/lib.rs
@@ -490,6 +490,24 @@ pub(crate) fn admin_route_infos(
         .collect()
 }
 
+#[cfg(test)]
+mod contract_tests {
+    use super::AdminPlugin;
+    use autumn_web::plugin::Plugin;
+
+    #[test]
+    fn contract_declares_lockstep_with_own_crate() {
+        let contract = AdminPlugin::new().contract().expect("a contract");
+        assert_eq!(contract.plugin, env!("CARGO_PKG_NAME"));
+        assert_eq!(contract.plugin_version.as_deref(), Some(env!("CARGO_PKG_VERSION")));
+        assert_eq!(
+            contract.autumn_web.as_deref(),
+            Some(autumn_web::plugin_contract::lockstep_range(env!("CARGO_PKG_VERSION")).as_str())
+        );
+        assert!(contract.experimental_surfaces.is_empty());
+    }
+}
+
 // ── Conformance reference tests ────────────────────────────────────────────
 //
 // These tests are the reference example for the Autumn plugin conformance

--- a/autumn-admin-plugin/src/lib.rs
+++ b/autumn-admin-plugin/src/lib.rs
@@ -276,24 +276,13 @@ impl Default for AdminPlugin {
 }
 
 impl Plugin for AdminPlugin {
-    /// The compatibility contract this plugin declares (issue #1601).
-    ///
-    /// First-party plugins ship in lockstep with `autumn-web`, so the declared
-    /// range is this crate's own minor series — the two versions are the same
-    /// number by construction. Below `1.0` a minor bump is breaking (see
-    /// `STABILITY.md`), which is exactly what the `MAJOR.MINOR` requirement
-    /// says.
-    ///
-    /// Nothing experimental is declared: this plugin is built entirely on the
-    /// stable plugin surface.
+    /// This plugin ships in lockstep with `autumn-web` — see
+    /// [`lockstep_contract`](autumn_web::plugin_contract::lockstep_contract).
     fn contract(&self) -> Option<autumn_web::plugin_contract::PluginContract> {
-        Some(
-            autumn_web::plugin_contract::PluginContract::new(env!("CARGO_PKG_NAME"))
-                .plugin_version(env!("CARGO_PKG_VERSION"))
-                .autumn_web(autumn_web::plugin_contract::lockstep_range(env!(
-                    "CARGO_PKG_VERSION"
-                ))),
-        )
+        Some(autumn_web::plugin_contract::lockstep_contract(
+            env!("CARGO_PKG_NAME"),
+            env!("CARGO_PKG_VERSION"),
+        ))
     }
 
     fn name(&self) -> Cow<'static, str> {
@@ -499,7 +488,10 @@ mod contract_tests {
     fn contract_declares_lockstep_with_own_crate() {
         let contract = AdminPlugin::new().contract().expect("a contract");
         assert_eq!(contract.plugin, env!("CARGO_PKG_NAME"));
-        assert_eq!(contract.plugin_version.as_deref(), Some(env!("CARGO_PKG_VERSION")));
+        assert_eq!(
+            contract.plugin_version.as_deref(),
+            Some(env!("CARGO_PKG_VERSION"))
+        );
         assert_eq!(
             contract.autumn_web.as_deref(),
             Some(autumn_web::plugin_contract::lockstep_range(env!("CARGO_PKG_VERSION")).as_str())

--- a/autumn-cache-redis/src/lib.rs
+++ b/autumn-cache-redis/src/lib.rs
@@ -505,6 +505,20 @@ mod tests {
     use testcontainers_modules::redis::Redis as RedisImage;
 
     #[test]
+    fn contract_declares_lockstep_with_own_crate() {
+        use autumn_web::plugin::Plugin;
+
+        let contract = RedisCachePlugin::new().contract().expect("a contract");
+        assert_eq!(contract.plugin, env!("CARGO_PKG_NAME"));
+        assert_eq!(contract.plugin_version.as_deref(), Some(env!("CARGO_PKG_VERSION")));
+        assert_eq!(
+            contract.autumn_web.as_deref(),
+            Some(autumn_web::plugin_contract::lockstep_range(env!("CARGO_PKG_VERSION")).as_str())
+        );
+        assert!(contract.experimental_surfaces.is_empty());
+    }
+
+    #[test]
     fn redis_ttl_millis_preserves_subsecond_precision() {
         assert_eq!(
             ttl_millis_for_redis(std::time::Duration::from_millis(100)),

--- a/autumn-cache-redis/src/lib.rs
+++ b/autumn-cache-redis/src/lib.rs
@@ -451,24 +451,13 @@ impl Default for RedisCachePlugin {
 }
 
 impl autumn_web::plugin::Plugin for RedisCachePlugin {
-    /// The compatibility contract this plugin declares (issue #1601).
-    ///
-    /// First-party plugins ship in lockstep with `autumn-web`, so the declared
-    /// range is this crate's own minor series — the two versions are the same
-    /// number by construction. Below `1.0` a minor bump is breaking (see
-    /// `STABILITY.md`), which is exactly what the `MAJOR.MINOR` requirement
-    /// says.
-    ///
-    /// Nothing experimental is declared: this plugin is built entirely on the
-    /// stable plugin surface.
+    /// This plugin ships in lockstep with `autumn-web` — see
+    /// [`lockstep_contract`](autumn_web::plugin_contract::lockstep_contract).
     fn contract(&self) -> Option<autumn_web::plugin_contract::PluginContract> {
-        Some(
-            autumn_web::plugin_contract::PluginContract::new(env!("CARGO_PKG_NAME"))
-                .plugin_version(env!("CARGO_PKG_VERSION"))
-                .autumn_web(autumn_web::plugin_contract::lockstep_range(env!(
-                    "CARGO_PKG_VERSION"
-                ))),
-        )
+        Some(autumn_web::plugin_contract::lockstep_contract(
+            env!("CARGO_PKG_NAME"),
+            env!("CARGO_PKG_VERSION"),
+        ))
     }
 
     fn build(self, app: autumn_web::app::AppBuilder) -> autumn_web::app::AppBuilder {
@@ -510,7 +499,10 @@ mod tests {
 
         let contract = RedisCachePlugin::new().contract().expect("a contract");
         assert_eq!(contract.plugin, env!("CARGO_PKG_NAME"));
-        assert_eq!(contract.plugin_version.as_deref(), Some(env!("CARGO_PKG_VERSION")));
+        assert_eq!(
+            contract.plugin_version.as_deref(),
+            Some(env!("CARGO_PKG_VERSION"))
+        );
         assert_eq!(
             contract.autumn_web.as_deref(),
             Some(autumn_web::plugin_contract::lockstep_range(env!("CARGO_PKG_VERSION")).as_str())

--- a/autumn-media-plugin/src/lib.rs
+++ b/autumn-media-plugin/src/lib.rs
@@ -716,6 +716,24 @@ fn arroyo_recordings_root(env: &HashMap<String, String>) -> PathBuf {
         )
 }
 
+#[cfg(test)]
+mod contract_tests {
+    use super::MediaPlugin;
+    use autumn_web::plugin::Plugin;
+
+    #[test]
+    fn contract_declares_lockstep_with_own_crate() {
+        let contract = MediaPlugin::new().contract().expect("a contract");
+        assert_eq!(contract.plugin, env!("CARGO_PKG_NAME"));
+        assert_eq!(contract.plugin_version.as_deref(), Some(env!("CARGO_PKG_VERSION")));
+        assert_eq!(
+            contract.autumn_web.as_deref(),
+            Some(autumn_web::plugin_contract::lockstep_range(env!("CARGO_PKG_VERSION")).as_str())
+        );
+        assert!(contract.experimental_surfaces.is_empty());
+    }
+}
+
 // ── Arroyo migration shim (slice 5) ─────────────────────────────────────────
 
 #[cfg(test)]

--- a/autumn-media-plugin/src/lib.rs
+++ b/autumn-media-plugin/src/lib.rs
@@ -361,24 +361,13 @@ impl Default for MediaPlugin {
 }
 
 impl Plugin for MediaPlugin {
-    /// The compatibility contract this plugin declares (issue #1601).
-    ///
-    /// First-party plugins ship in lockstep with `autumn-web`, so the declared
-    /// range is this crate's own minor series — the two versions are the same
-    /// number by construction. Below `1.0` a minor bump is breaking (see
-    /// `STABILITY.md`), which is exactly what the `MAJOR.MINOR` requirement
-    /// says.
-    ///
-    /// Nothing experimental is declared: this plugin is built entirely on the
-    /// stable plugin surface.
+    /// This plugin ships in lockstep with `autumn-web` — see
+    /// [`lockstep_contract`](autumn_web::plugin_contract::lockstep_contract).
     fn contract(&self) -> Option<autumn_web::plugin_contract::PluginContract> {
-        Some(
-            autumn_web::plugin_contract::PluginContract::new(env!("CARGO_PKG_NAME"))
-                .plugin_version(env!("CARGO_PKG_VERSION"))
-                .autumn_web(autumn_web::plugin_contract::lockstep_range(env!(
-                    "CARGO_PKG_VERSION"
-                ))),
-        )
+        Some(autumn_web::plugin_contract::lockstep_contract(
+            env!("CARGO_PKG_NAME"),
+            env!("CARGO_PKG_VERSION"),
+        ))
     }
 
     fn name(&self) -> Cow<'static, str> {
@@ -725,7 +714,10 @@ mod contract_tests {
     fn contract_declares_lockstep_with_own_crate() {
         let contract = MediaPlugin::new().contract().expect("a contract");
         assert_eq!(contract.plugin, env!("CARGO_PKG_NAME"));
-        assert_eq!(contract.plugin_version.as_deref(), Some(env!("CARGO_PKG_VERSION")));
+        assert_eq!(
+            contract.plugin_version.as_deref(),
+            Some(env!("CARGO_PKG_VERSION"))
+        );
         assert_eq!(
             contract.autumn_web.as_deref(),
             Some(autumn_web::plugin_contract::lockstep_range(env!("CARGO_PKG_VERSION")).as_str())

--- a/autumn-plugin-reference/src/lib.rs
+++ b/autumn-plugin-reference/src/lib.rs
@@ -79,11 +79,10 @@ impl Plugin for ReferencePlugin {
 
     // surface: Plugin::contract
     fn contract(&self) -> Option<PluginContract> {
-        Some(
-            PluginContract::new(env!("CARGO_PKG_NAME"))
-                .plugin_version(env!("CARGO_PKG_VERSION"))
-                .autumn_web(declared_autumn_web_range()),
-        )
+        Some(autumn_web::plugin_contract::lockstep_contract(
+            env!("CARGO_PKG_NAME"),
+            env!("CARGO_PKG_VERSION"),
+        ))
     }
 
     // surface: Plugin::build

--- a/autumn-search/src/plugin.rs
+++ b/autumn-search/src/plugin.rs
@@ -410,24 +410,13 @@ fn parse_purge_flag(raw: Option<&str>) -> bool {
 }
 
 impl Plugin for SearchPlugin {
-    /// The compatibility contract this plugin declares (issue #1601).
-    ///
-    /// First-party plugins ship in lockstep with `autumn-web`, so the declared
-    /// range is this crate's own minor series — the two versions are the same
-    /// number by construction. Below `1.0` a minor bump is breaking (see
-    /// `STABILITY.md`), which is exactly what the `MAJOR.MINOR` requirement
-    /// says.
-    ///
-    /// Nothing experimental is declared: this plugin is built entirely on the
-    /// stable plugin surface.
+    /// This plugin ships in lockstep with `autumn-web` — see
+    /// [`lockstep_contract`](autumn_web::plugin_contract::lockstep_contract).
     fn contract(&self) -> Option<autumn_web::plugin_contract::PluginContract> {
-        Some(
-            autumn_web::plugin_contract::PluginContract::new(env!("CARGO_PKG_NAME"))
-                .plugin_version(env!("CARGO_PKG_VERSION"))
-                .autumn_web(autumn_web::plugin_contract::lockstep_range(env!(
-                    "CARGO_PKG_VERSION"
-                ))),
-        )
+        Some(autumn_web::plugin_contract::lockstep_contract(
+            env!("CARGO_PKG_NAME"),
+            env!("CARGO_PKG_VERSION"),
+        ))
     }
 
     fn name(&self) -> Cow<'static, str> {
@@ -638,7 +627,10 @@ mod tests {
     fn contract_declares_lockstep_with_own_crate() {
         let contract = SearchPlugin::new().contract().expect("a contract");
         assert_eq!(contract.plugin, env!("CARGO_PKG_NAME"));
-        assert_eq!(contract.plugin_version.as_deref(), Some(env!("CARGO_PKG_VERSION")));
+        assert_eq!(
+            contract.plugin_version.as_deref(),
+            Some(env!("CARGO_PKG_VERSION"))
+        );
         assert_eq!(
             contract.autumn_web.as_deref(),
             Some(autumn_web::plugin_contract::lockstep_range(env!("CARGO_PKG_VERSION")).as_str())

--- a/autumn-search/src/plugin.rs
+++ b/autumn-search/src/plugin.rs
@@ -635,6 +635,18 @@ mod tests {
     }
 
     #[test]
+    fn contract_declares_lockstep_with_own_crate() {
+        let contract = SearchPlugin::new().contract().expect("a contract");
+        assert_eq!(contract.plugin, env!("CARGO_PKG_NAME"));
+        assert_eq!(contract.plugin_version.as_deref(), Some(env!("CARGO_PKG_VERSION")));
+        assert_eq!(
+            contract.autumn_web.as_deref(),
+            Some(autumn_web::plugin_contract::lockstep_range(env!("CARGO_PKG_VERSION")).as_str())
+        );
+        assert!(contract.experimental_surfaces.is_empty());
+    }
+
+    #[test]
     fn the_queue_override_reaches_the_registered_jobs() {
         let plugin = SearchPlugin::new().queue("indexing");
         assert_eq!(plugin.search_config().queue, "indexing");

--- a/autumn/src/plugin_contract.rs
+++ b/autumn/src/plugin_contract.rs
@@ -424,6 +424,47 @@ pub fn lockstep_range(version: &str) -> String {
     }
 }
 
+/// Builds the compatibility contract a first-party plugin declares from
+/// [`Plugin::contract`](crate::plugin::Plugin::contract) (issue #1601).
+///
+/// First-party plugins ship in lockstep with `autumn-web`, so the declared
+/// range is this crate's own minor series — the two versions are the same
+/// number by construction. Below `1.0` a minor bump is breaking (see
+/// `STABILITY.md`), which is exactly what the `MAJOR.MINOR` requirement says.
+///
+/// Pass `env!("CARGO_PKG_NAME")` / `env!("CARGO_PKG_VERSION")` so both fields
+/// describe the calling crate, not this one:
+///
+/// ```rust
+/// use autumn_web::app::AppBuilder;
+/// use autumn_web::plugin::Plugin;
+/// use autumn_web::plugin_contract::{PluginContract, lockstep_contract};
+///
+/// struct MyFirstPartyPlugin;
+///
+/// impl Plugin for MyFirstPartyPlugin {
+///     fn contract(&self) -> Option<PluginContract> {
+///         Some(lockstep_contract(env!("CARGO_PKG_NAME"), env!("CARGO_PKG_VERSION")))
+///     }
+///
+///     fn build(self, app: AppBuilder) -> AppBuilder {
+///         app
+///     }
+/// }
+/// ```
+///
+/// # This is for lockstep crates only
+///
+/// Same restriction as [`lockstep_range`]: a plugin that versions
+/// independently of `autumn-web` must declare its own literal range instead
+/// (see that function's docs for why).
+#[must_use]
+pub fn lockstep_contract(name: &str, version: &str) -> PluginContract {
+    PluginContract::new(name)
+        .plugin_version(version)
+        .autumn_web(lockstep_range(version))
+}
+
 // ── Evaluation ─────────────────────────────────────────────────────────────
 
 /// The outcome of checking a [`PluginContract`] against a framework version.
@@ -615,6 +656,15 @@ mod tests {
         for odd in ["", "1", "not.a.version", "x.y.z", ".7.0"] {
             assert_eq!(lockstep_range(odd), odd, "input {odd:?}");
         }
+    }
+
+    #[test]
+    fn lockstep_contract_combines_name_version_and_lockstep_range() {
+        let contract = lockstep_contract("my-plugin", "0.7.3");
+        assert_eq!(contract.plugin, "my-plugin");
+        assert_eq!(contract.plugin_version.as_deref(), Some("0.7.3"));
+        assert_eq!(contract.autumn_web.as_deref(), Some("0.7"));
+        assert!(contract.experimental_surfaces.is_empty());
     }
 
     #[test]

--- a/docs/migrations/next.md
+++ b/docs/migrations/next.md
@@ -550,7 +550,7 @@ for the policy.
   - `Plugin::contract` — declare the `autumn-web` range your plugin supports.
     Defaults to `None`, so implementing it is optional.
   - `autumn_web::plugin_contract` — `PluginContract`, `PLUGIN_SURFACES`,
-    `SurfaceTier`, `evaluate`, `lockstep_range`, and the
+    `SurfaceTier`, `evaluate`, `lockstep_range`, `lockstep_contract`, and the
     `PLUGIN_CONTRACT_MARKER` dump protocol.
   - `AppBuilder::plugin_contracts()` — the contracts declared by the plugins
     mounted on a builder.
@@ -568,7 +568,11 @@ for the policy.
   `autumn plugin-check --plugin-name <your-plugin>`. A plugin that releases in
   lockstep with the framework can write
   `.autumn_web(lockstep_range(env!("CARGO_PKG_VERSION")))` instead and never
-  touch the literal again.
+  touch the literal again — or write the whole `Plugin::contract` body in one
+  call with the new `lockstep_contract(env!("CARGO_PKG_NAME"),
+  env!("CARGO_PKG_VERSION"))`, which every first-party plugin in this
+  repository now does (previously each wrote out the three-call construction
+  by hand).
 
 **Breaking for the `plugin-check` command, and only for it.** Two checks join
 the report. `plugin-contract` **fails** when the plugin under check declares no


### PR DESCRIPTION
## Summary

🎯 **Clone class** — 5 instances of `Plugin::contract()` declaring the "first-party plugin ships in lockstep with `autumn-web`" compatibility contract (issue #1601): `autumn-admin-plugin/src/lib.rs`, `autumn-media-plugin/src/lib.rs`, `autumn-cache-redis/src/lib.rs`, `autumn-search/src/plugin.rs` (byte-identical: same 8-line doc comment + `PluginContract::new(env!("CARGO_PKG_NAME")).plugin_version(env!("CARGO_PKG_VERSION")).autumn_web(lockstep_range(env!("CARGO_PKG_VERSION")))`), plus `autumn-plugin-reference/src/lib.rs` (semantically identical — same three calls, routed through its own private `declared_autumn_web_range()` wrapper). Detector: `jscpd` (`cpd 5.1.2`), `--pattern "**/*.rs" --ignore "**/target/**,fuzz/**,examples/**,example-e2e/**,benchmarks/**,**/vendor/**,**/node_modules/**" --min-tokens 50 --min-lines 10`, run whole-repo and ranked by mass × instances (not pointed at a pre-picked file). The 4 byte-identical sites formed a clique: 3 reported pairs, 270 duplicated tokens, 22–23 lines each.

This was the largest clone class in the repo touching **production** code across ≥3 files after excluding two categories that don't clear the bar: (1) the `autumn-panic-gate`/`autumn-determinism-gate` module-header `#[cfg_attr(...)]` boilerplate, duplicated near-verbatim across ~54 files — already governed by `scripts/check-panic-gate.sh`, and Rust has no way to share a module inner-attribute without a proc macro, so it's the wrong target; (2) the `syn`-parse-or-`compile_error!` idiom repeated in `autumn-macros/src/{cached,listener,one_off_task,scheduled}.rs` — a language idiom (guard clause / error mapping), inadmissible per this task's own rules.

📜 **History** — All 5 sites were added in a single commit, `0227dc6` "🔌 Define a versioned stability contract for the plugin API (issue #1601) (#2449)", and none has been touched since (`git log --oneline -- <file>` shows `0227dc6` as the most recent commit on each). So there is no ≥2-occasion co-change and no missed-fix defect here — the qualifying evidence is the **named domain rule**: `STABILITY.md` §"The plugin API surface (issue #1601)" states as one policy, "Separately, a plugin declares the `autumn-web` range it supports through `Plugin::contract`," and every duplicated doc comment itself cites the same rule ("First-party plugins ship in lockstep with `autumn-web` … Below `1.0` a minor bump is breaking (see `STABILITY.md`)"). `autumn-plugin-reference/src/lib.rs`'s own (untouched) doc comment on `declared_autumn_web_range()` says explicitly: "if it too releases in lockstep, calls this same helper" — the duplication was already recognized as one decision, just never given a shared home.

💡 **Hypothesis** — All 5 `contract()` bodies encode exactly one decision: "this is a first-party plugin, so its declared `autumn-web` compatibility range is derived from its own version, not chosen independently" — the lockstep policy `STABILITY.md` documents once. The three-call construction (`PluginContract::new` → `.plugin_version` → `.autumn_web(lockstep_range(..))`) is that decision's *shape*; nothing about it varies per plugin except the two `env!()` values every crate already had to supply itself.

🔧 **Change** — Added `autumn_web::plugin_contract::lockstep_contract(name: &str, version: &str) -> PluginContract` next to the existing `lockstep_range` helper it wraps, carrying the (previously five-times-duplicated) doc comment once. Each of the 5 sites now reads:
```rust
fn contract(&self) -> Option<autumn_web::plugin_contract::PluginContract> {
    Some(autumn_web::plugin_contract::lockstep_contract(
        env!("CARGO_PKG_NAME"),
        env!("CARGO_PKG_VERSION"),
    ))
}
```
`name`/`version` are data every caller already had to provide (via its own `env!()`, which must be invoked in the calling crate to resolve correctly — a plain function takes them as parameters rather than a macro, so no new macro/codegen is introduced). No mode/boolean/`is_`/`kind` parameter, no caller-identity branch, no wrapper shim: every call site is a plain call. `autumn-plugin-reference`'s local `declared_autumn_web_range()` is left as-is (unrelated concern: it still backs its own `declared_range_is_the_series_below_one_zero` test), just no longer used by `contract()`.

**Characterization tests, committed first** (`test: characterize first-party plugin contract() before Echo merge`, previous commit): a `contract_declares_lockstep_with_own_crate` test per crate lacking coverage (admin-plugin, media-plugin, cache-redis, search — `autumn-plugin-reference` already had equivalent tests), pinning `plugin`, `plugin_version`, `autumn_web`, and `experimental_surfaces`. Verified passing against the **unmerged** code before the merge commit; unchanged and still passing after.

📊 **Measurement**
- Instances: 5 → 1 (+5 one-line call sites)
- jscpd mass for the 4 byte-identical sites (contract()-region pairs only): 3 pairs / 270 tokens (22–23 lines each) → 2 pairs / 126 tokens (12 lines each); the residual is the now-unavoidable per-crate trait-method override (signature + one-line delegating call), which two of the four sites (cache-redis, and semantically `plugin-reference`) no longer even clone-match on
- Diff: `+152 / -73` across 6 files (`git diff origin/trunk-dev...HEAD --stat`), split into a tests-first commit (+62/-0) and the merge commit (+94/-77, net -17 within the merge itself since the shared helper's doc comment is written once instead of 5 times)
- Concept count: zero new caller-identity branches, zero mode/boolean parameters added (`name`/`version` are the same per-crate data every site already supplied); every call site is a call, not an adaptation
- API surface: additive only — new `pub fn lockstep_contract` in `autumn_web::plugin_contract` (not part of the tracked `PLUGIN_SURFACES` registry — that registry names plugin-*author*-facing extension points like `Plugin::build`/`AppBuilder::routes`, not framework-side helpers like the pre-existing `lockstep_range`, so `scripts/check-plugin-surface.sh`'s ratchet is unaffected); no existing signature changed

🔬 **Reproduce**
```sh
npx --yes jscpd --pattern "**/*.rs" \
  --ignore "**/target/**,fuzz/**,examples/**,example-e2e/**,benchmarks/**,**/vendor/**,**/node_modules/**" \
  --min-tokens 50 --min-lines 10 --reporters console --silent .

git log --oneline --all -- autumn-search/src/plugin.rs autumn-media-plugin/src/lib.rs \
  autumn-admin-plugin/src/lib.rs autumn-cache-redis/src/lib.rs autumn-plugin-reference/src/lib.rs
git show --stat 0227dc6
grep -n "plugin declares the \`autumn-web\` range" STABILITY.md
```

## Verification

- `cargo fmt --all -- --check` — clean
- `cargo clippy -p autumn-web --lib --features "test-support,offline-sync,ws,mail,redis,i18n" -- -D warnings` — clean (only a pre-existing, unrelated `unknown_lints` warning on `clippy::unused_async_trait_impl`)
- `cargo clippy -p autumn-admin-plugin -p autumn-media-plugin -p autumn-search -p autumn-cache-redis -p autumn-plugin-reference --lib --tests -- -D warnings` — clean (same pre-existing warning)
- `cargo test` — the 4 new characterization tests + `autumn-plugin-reference`'s existing 7 tests (including `every_stable_surface_is_exercised_here`, confirming the `// surface: Plugin::contract` marker still tracks correctly) + the new `lockstep_contract` unit test + its doctest — all pass, all unchanged assertions

Every characterization test's expectation is byte-for-byte the same before and after; only the construction moved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Grz5mPwhY8QqwcWCL2Z2mG

---
_Generated by [Claude Code](https://claude.ai/code/session_01Grz5mPwhY8QqwcWCL2Z2mG)_