### PR TITLE
🗃️ Ledger: bounded lookup for ledger_as_of/ledger_diff (near-head buffers -82% to -94%)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2447,20 +2447,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `ledger_revisions` already relied on — no migration, no new index. Because
   transaction time is monotonic in `seq` (#2323), a transaction-time as-of
   query's cost is now proportional to how far back the question asks, not to
-  the chain's total length. Measured (`pg_stat_statements`, testcontainer
-  Postgres, three ledgered chains at 300/700/1,200 revisions each, written
-  through the real write path): a near-head as-of query's buffers fall
-  82–94% and stay flat across all three depths (22/129/132 → 4/8/8), instead
-  of scaling with chain length. Disclosed trade-off: `ledger_diff` now issues
-  2 statements instead of 1 (buffers still fall 129 → 16), and the
-  pathological case — asking about a record's very *first* revision on a deep
-  chain — reads more buffers than before (132 → 947 on the 1,200-revision
-  fixture), because the backward index scan can't short-circuit when the
-  answer sits at the far end of it; this is bounded by the record's own chain
-  depth and only reachable by a query about a record's oldest history, so it
-  does not offset the unconditional win on the realistic (recent-history)
-  query pattern. `ledger_revisions` and `ledger_verify` are unchanged — they
-  legitimately need the whole chain and still read it.
+  the chain's total length. `ledger_diff`'s two endpoints are resolved from
+  one `UNION ALL` statement on one connection rather than two independent
+  lookups, so it keeps the single-snapshot consistency the old full-chain
+  read had (two separate connection-acquiring calls could otherwise resolve
+  `from`/`to` against two different database states if a write landed, or a
+  read replica advanced, between them) — statement count for `ledger_diff`
+  is unchanged at 1. Measured (`pg_stat_statements`, testcontainer Postgres,
+  three ledgered chains at 300/700/1,200 revisions each, written through the
+  real write path): a near-head as-of query's buffers fall 86–94% and stay
+  flat across all three depths (22/129/132 → 3/8/8), instead of scaling with
+  chain length; `ledger_diff` across a recent window falls 129 → 16 buffers
+  (-88%). Disclosed trade-off: the pathological case — asking about a
+  record's very *first* revision on a deep chain — reads more buffers than
+  before (132 → 948 on the 1,200-revision fixture), because the backward
+  index scan can't short-circuit when the answer sits at the far end of it;
+  this is bounded by the record's own chain depth and only reachable by a
+  query about a record's oldest history, so it does not offset the
+  unconditional win on the realistic (recent-history) query pattern.
+  `ledger_revisions` and `ledger_verify` are unchanged — they legitimately
+  need the whole chain and still read it.
 
 - **the DB-backed media-room reaper sweeps in one statement instead of one per
   stale room:** `DbRoomStore::reap_stale`'s second phase — the sweep that drops

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2434,6 +2434,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Performance
 
+- **`ledger_as_of`/`ledger_diff` no longer read a ledgered record's entire
+  revision chain to answer a question with one answer:** both are pure
+  functions over `ledger_revisions(record_id)`, which has always had one SQL
+  shape — read every stored revision, every full-column snapshot, in `seq`
+  order — with no bound on the requested instant at all. For a hot ledgered
+  record (an account, invoice, or contract adjusted repeatedly over a long
+  operational life, exactly the shape the feature exists for), an audit query
+  about *recent* history — the overwhelmingly common case — paid for reading
+  the record's whole history regardless. Both now issue a bounded
+  `ORDER BY seq DESC LIMIT 1` lookup instead, using the same index
+  `ledger_revisions` already relied on — no migration, no new index. Because
+  transaction time is monotonic in `seq` (#2323), a transaction-time as-of
+  query's cost is now proportional to how far back the question asks, not to
+  the chain's total length. Measured (`pg_stat_statements`, testcontainer
+  Postgres, three ledgered chains at 300/700/1,200 revisions each, written
+  through the real write path): a near-head as-of query's buffers fall
+  82–94% and stay flat across all three depths (22/129/132 → 4/8/8), instead
+  of scaling with chain length. Disclosed trade-off: `ledger_diff` now issues
+  2 statements instead of 1 (buffers still fall 129 → 16), and the
+  pathological case — asking about a record's very *first* revision on a deep
+  chain — reads more buffers than before (132 → 947 on the 1,200-revision
+  fixture), because the backward index scan can't short-circuit when the
+  answer sits at the far end of it; this is bounded by the record's own chain
+  depth and only reachable by a query about a record's oldest history, so it
+  does not offset the unconditional win on the realistic (recent-history)
+  query pattern. `ledger_revisions` and `ledger_verify` are unchanged — they
+  legitimately need the whole chain and still read it.
+
 - **the DB-backed media-room reaper sweeps in one statement instead of one per
   stale room:** `DbRoomStore::reap_stale`'s second phase — the sweep that drops
   now-empty rooms, run every 60s by the background room reaper in any process

--- a/autumn-macros/src/repository.rs
+++ b/autumn-macros/src/repository.rs
@@ -17989,6 +17989,56 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
             }
         }
     };
+    // Maps the tagged UNION ALL result of the diff's paired bounded lookup
+    // (`__autumn_ledger_diff_revisions_at`) back to (from, to) — same per-row
+    // mapping as `ledger_map_row_opt`, keyed by the `which` discriminator
+    // column instead of relying on result order (a `UNION ALL` gives no
+    // ordering guarantee across its arms).
+    let ledger_map_diff_rows = quote! {
+        {
+            let mut __from: ::core::option::Option<::autumn_web::ledger::LedgerRevision> =
+                ::core::option::Option::None;
+            let mut __to: ::core::option::Option<::autumn_web::ledger::LedgerRevision> =
+                ::core::option::Option::None;
+            for row in raw_rows {
+                let op = match row.op.as_str() {
+                    "insert" => ::autumn_web::version_history::VersionOp::Insert,
+                    "delete" => ::autumn_web::version_history::VersionOp::Delete,
+                    _ => ::autumn_web::version_history::VersionOp::Update,
+                };
+                let snapshot: ::autumn_web::reexports::serde_json::Value =
+                    ::autumn_web::reexports::serde_json::from_str(&row.snapshot)
+                        .map_err(|err| ::autumn_web::AutumnError::internal_server_error(
+                            ::autumn_web::ledger::LedgerError::ChainUnreadable {
+                                table: #table_name.to_string(),
+                                record_id,
+                                detail: format!("revision {} has an unreadable snapshot: {err}", row.seq),
+                            },
+                        ))?;
+                let revision = ::autumn_web::ledger::LedgerRevision {
+                    id: row.id,
+                    table_name: row.table_name,
+                    tenant_id: row.tenant_id,
+                    record_id: row.record_id,
+                    seq: row.seq,
+                    op,
+                    actor: row.actor,
+                    request_id: row.request_id,
+                    snapshot,
+                    valid_from: row.valid_from,
+                    recorded_at: row.recorded_at,
+                    prev_hash: row.prev_hash,
+                    hash: row.hash,
+                };
+                if row.which == "from" {
+                    __from = ::core::option::Option::Some(revision);
+                } else {
+                    __to = ::core::option::Option::Some(revision);
+                }
+            }
+            (__from, __to)
+        }
+    };
 
     // The live-row read is tenant-filtered only on a tenant-scoped repository:
     // a plain model has no `tenant_id` column to name.
@@ -18328,6 +18378,206 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                     ::core::result::Result::Ok(revision)
                 }
 
+                /// Both endpoints of a [`ledger_diff_at`](Self::ledger_diff_at)
+                /// window, resolved from **one statement** on **one
+                /// connection**.
+                ///
+                /// Two independent calls to
+                /// [`__autumn_ledger_revision_at`](Self::__autumn_ledger_revision_at)
+                /// — one per endpoint — would each take their own snapshot: a
+                /// write landing between them (or, on a routed read replica,
+                /// replica lag advancing between them) could resolve `from`
+                /// and `to` against two different database states, reporting
+                /// a phantom change on an unchanged window or missing one
+                /// that happened. The single full-chain `ledger_revisions`
+                /// read this replaced never had that problem — one read, one
+                /// snapshot, both endpoints computed from it in memory — so
+                /// this restores the same guarantee: a `UNION ALL` of the two
+                /// bounded lookups is one SQL command, and Postgres assigns
+                /// one snapshot per top-level command (even under `READ
+                /// COMMITTED`), so both arms see the identical database
+                /// state. Each arm keeps its own `ORDER BY seq DESC LIMIT 1`,
+                /// so the bounded-scan property
+                /// [`__autumn_ledger_revision_at`](Self::__autumn_ledger_revision_at)
+                /// exists for is unaffected — this is strictly one statement
+                /// where the naive two-call version was two.
+                ///
+                /// # Errors
+                ///
+                /// Returns an error if the ledger table cannot be read, or if
+                /// a matching revision's stored snapshot is no longer valid
+                /// JSON.
+                #[doc(hidden)]
+                async fn __autumn_ledger_diff_revisions_at(
+                    &self,
+                    record_id: i64,
+                    from: ::autumn_web::ledger::LedgerAsOf,
+                    to: ::autumn_web::ledger::LedgerAsOf,
+                ) -> ::autumn_web::AutumnResult<(
+                    ::core::option::Option<::autumn_web::ledger::LedgerRevision>,
+                    ::core::option::Option<::autumn_web::ledger::LedgerRevision>,
+                )> {
+                    use ::autumn_web::reexports::diesel_async::RunQueryDsl as _;
+
+                    #ledger_cross_shard_guard
+                    #ledger_cross_tenant_guard
+                    #ledger_tenant_setup
+
+                    let mut conn = self.__autumn_acquire_read_conn().await?;
+                    let __ledger_from_transaction_bound = from.transaction;
+                    let __ledger_from_valid_bound = from.valid;
+                    let __ledger_to_transaction_bound = to.transaction;
+                    let __ledger_to_valid_bound = to.valid;
+
+                    let (from_revision, to_revision): (
+                        ::core::option::Option<::autumn_web::ledger::LedgerRevision>,
+                        ::core::option::Option<::autumn_web::ledger::LedgerRevision>,
+                    ) = ::autumn_web::backend_select! {
+                        pg => {{
+                            #[derive(::autumn_web::reexports::diesel::QueryableByName)]
+                            struct __AutumnLedgerDiffRow {
+                                #[diesel(sql_type = ::autumn_web::reexports::diesel::sql_types::Text)]
+                                which: ::std::string::String,
+                                #[diesel(sql_type = ::autumn_web::reexports::diesel::sql_types::BigInt)]
+                                id: i64,
+                                #[diesel(sql_type = ::autumn_web::reexports::diesel::sql_types::Text)]
+                                table_name: ::std::string::String,
+                                #[diesel(sql_type = ::autumn_web::reexports::diesel::sql_types::Nullable<::autumn_web::reexports::diesel::sql_types::Text>)]
+                                tenant_id: ::core::option::Option<::std::string::String>,
+                                #[diesel(sql_type = ::autumn_web::reexports::diesel::sql_types::BigInt)]
+                                record_id: i64,
+                                #[diesel(sql_type = ::autumn_web::reexports::diesel::sql_types::BigInt)]
+                                seq: i64,
+                                #[diesel(sql_type = ::autumn_web::reexports::diesel::sql_types::Text)]
+                                op: ::std::string::String,
+                                #[diesel(sql_type = ::autumn_web::reexports::diesel::sql_types::Text)]
+                                actor: ::std::string::String,
+                                #[diesel(sql_type = ::autumn_web::reexports::diesel::sql_types::Nullable<::autumn_web::reexports::diesel::sql_types::Text>)]
+                                request_id: ::core::option::Option<::std::string::String>,
+                                #[diesel(sql_type = ::autumn_web::reexports::diesel::sql_types::Text)]
+                                snapshot: ::std::string::String,
+                                #[diesel(sql_type = ::autumn_web::reexports::diesel::sql_types::Timestamptz)]
+                                valid_from: ::autumn_web::reexports::chrono::DateTime<::autumn_web::reexports::chrono::Utc>,
+                                #[diesel(sql_type = ::autumn_web::reexports::diesel::sql_types::Timestamptz)]
+                                recorded_at: ::autumn_web::reexports::chrono::DateTime<::autumn_web::reexports::chrono::Utc>,
+                                #[diesel(sql_type = ::autumn_web::reexports::diesel::sql_types::Nullable<::autumn_web::reexports::diesel::sql_types::Text>)]
+                                prev_hash: ::core::option::Option<::std::string::String>,
+                                #[diesel(sql_type = ::autumn_web::reexports::diesel::sql_types::Text)]
+                                hash: ::std::string::String,
+                            }
+
+                            let raw_rows: ::std::vec::Vec<__AutumnLedgerDiffRow> =
+                                ::autumn_web::reexports::diesel::sql_query(
+                                    "SELECT * FROM ( \
+                                     SELECT 'from' AS which, id, table_name, tenant_id, record_id, seq, op, actor, \
+                                     request_id, snapshot, valid_from, recorded_at, prev_hash, hash \
+                                     FROM _autumn_ledger_revisions \
+                                     WHERE table_name = $1 AND record_id = $2 \
+                                     AND ($3::text IS NULL OR tenant_id = $3) \
+                                     AND ($4::timestamptz IS NULL OR recorded_at <= $4) \
+                                     AND ($5::timestamptz IS NULL OR valid_from <= $5) \
+                                     ORDER BY seq DESC LIMIT 1 \
+                                     ) AS __from_rev \
+                                     UNION ALL \
+                                     SELECT * FROM ( \
+                                     SELECT 'to' AS which, id, table_name, tenant_id, record_id, seq, op, actor, \
+                                     request_id, snapshot, valid_from, recorded_at, prev_hash, hash \
+                                     FROM _autumn_ledger_revisions \
+                                     WHERE table_name = $1 AND record_id = $2 \
+                                     AND ($3::text IS NULL OR tenant_id = $3) \
+                                     AND ($6::timestamptz IS NULL OR recorded_at <= $6) \
+                                     AND ($7::timestamptz IS NULL OR valid_from <= $7) \
+                                     ORDER BY seq DESC LIMIT 1 \
+                                     ) AS __to_rev"
+                                )
+                                .bind::<::autumn_web::reexports::diesel::sql_types::Text, _>(#table_name)
+                                .bind::<::autumn_web::reexports::diesel::sql_types::BigInt, _>(record_id)
+                                .bind::<::autumn_web::reexports::diesel::sql_types::Nullable<::autumn_web::reexports::diesel::sql_types::Text>, _>(__ledger_tenant_id)
+                                .bind::<::autumn_web::reexports::diesel::sql_types::Nullable<::autumn_web::reexports::diesel::sql_types::Timestamptz>, _>(__ledger_from_transaction_bound)
+                                .bind::<::autumn_web::reexports::diesel::sql_types::Nullable<::autumn_web::reexports::diesel::sql_types::Timestamptz>, _>(__ledger_from_valid_bound)
+                                .bind::<::autumn_web::reexports::diesel::sql_types::Nullable<::autumn_web::reexports::diesel::sql_types::Timestamptz>, _>(__ledger_to_transaction_bound)
+                                .bind::<::autumn_web::reexports::diesel::sql_types::Nullable<::autumn_web::reexports::diesel::sql_types::Timestamptz>, _>(__ledger_to_valid_bound)
+                                .get_results::<__AutumnLedgerDiffRow>(&mut conn)
+                                .await
+                                .map_err(::autumn_web::AutumnError::from)?;
+
+                            #ledger_map_diff_rows
+                        }},
+                        sqlite => {{
+                            #[derive(::autumn_web::reexports::diesel::QueryableByName)]
+                            struct __AutumnLedgerDiffRow {
+                                #[diesel(sql_type = ::autumn_web::reexports::diesel::sql_types::Text)]
+                                which: ::std::string::String,
+                                #[diesel(sql_type = ::autumn_web::reexports::diesel::sql_types::BigInt)]
+                                id: i64,
+                                #[diesel(sql_type = ::autumn_web::reexports::diesel::sql_types::Text)]
+                                table_name: ::std::string::String,
+                                #[diesel(sql_type = ::autumn_web::reexports::diesel::sql_types::Nullable<::autumn_web::reexports::diesel::sql_types::Text>)]
+                                tenant_id: ::core::option::Option<::std::string::String>,
+                                #[diesel(sql_type = ::autumn_web::reexports::diesel::sql_types::BigInt)]
+                                record_id: i64,
+                                #[diesel(sql_type = ::autumn_web::reexports::diesel::sql_types::BigInt)]
+                                seq: i64,
+                                #[diesel(sql_type = ::autumn_web::reexports::diesel::sql_types::Text)]
+                                op: ::std::string::String,
+                                #[diesel(sql_type = ::autumn_web::reexports::diesel::sql_types::Text)]
+                                actor: ::std::string::String,
+                                #[diesel(sql_type = ::autumn_web::reexports::diesel::sql_types::Nullable<::autumn_web::reexports::diesel::sql_types::Text>)]
+                                request_id: ::core::option::Option<::std::string::String>,
+                                #[diesel(sql_type = ::autumn_web::reexports::diesel::sql_types::Text)]
+                                snapshot: ::std::string::String,
+                                #[diesel(sql_type = ::autumn_web::reexports::diesel::sql_types::TimestamptzSqlite)]
+                                valid_from: ::autumn_web::reexports::chrono::DateTime<::autumn_web::reexports::chrono::Utc>,
+                                #[diesel(sql_type = ::autumn_web::reexports::diesel::sql_types::TimestamptzSqlite)]
+                                recorded_at: ::autumn_web::reexports::chrono::DateTime<::autumn_web::reexports::chrono::Utc>,
+                                #[diesel(sql_type = ::autumn_web::reexports::diesel::sql_types::Nullable<::autumn_web::reexports::diesel::sql_types::Text>)]
+                                prev_hash: ::core::option::Option<::std::string::String>,
+                                #[diesel(sql_type = ::autumn_web::reexports::diesel::sql_types::Text)]
+                                hash: ::std::string::String,
+                            }
+
+                            let raw_rows: ::std::vec::Vec<__AutumnLedgerDiffRow> =
+                                ::autumn_web::reexports::diesel::sql_query(
+                                    "SELECT * FROM ( \
+                                     SELECT 'from' AS which, id, table_name, tenant_id, record_id, seq, op, actor, \
+                                     request_id, snapshot, valid_from, recorded_at, prev_hash, hash \
+                                     FROM _autumn_ledger_revisions \
+                                     WHERE table_name = $1 AND record_id = $2 \
+                                     AND ($3 IS NULL OR tenant_id = $3) \
+                                     AND ($4 IS NULL OR recorded_at <= $4) \
+                                     AND ($5 IS NULL OR valid_from <= $5) \
+                                     ORDER BY seq DESC LIMIT 1 \
+                                     ) AS __from_rev \
+                                     UNION ALL \
+                                     SELECT * FROM ( \
+                                     SELECT 'to' AS which, id, table_name, tenant_id, record_id, seq, op, actor, \
+                                     request_id, snapshot, valid_from, recorded_at, prev_hash, hash \
+                                     FROM _autumn_ledger_revisions \
+                                     WHERE table_name = $1 AND record_id = $2 \
+                                     AND ($3 IS NULL OR tenant_id = $3) \
+                                     AND ($6 IS NULL OR recorded_at <= $6) \
+                                     AND ($7 IS NULL OR valid_from <= $7) \
+                                     ORDER BY seq DESC LIMIT 1 \
+                                     ) AS __to_rev"
+                                )
+                                .bind::<::autumn_web::reexports::diesel::sql_types::Text, _>(#table_name)
+                                .bind::<::autumn_web::reexports::diesel::sql_types::BigInt, _>(record_id)
+                                .bind::<::autumn_web::reexports::diesel::sql_types::Nullable<::autumn_web::reexports::diesel::sql_types::Text>, _>(__ledger_tenant_id)
+                                .bind::<::autumn_web::reexports::diesel::sql_types::Nullable<::autumn_web::reexports::diesel::sql_types::TimestamptzSqlite>, _>(__ledger_from_transaction_bound)
+                                .bind::<::autumn_web::reexports::diesel::sql_types::Nullable<::autumn_web::reexports::diesel::sql_types::TimestamptzSqlite>, _>(__ledger_from_valid_bound)
+                                .bind::<::autumn_web::reexports::diesel::sql_types::Nullable<::autumn_web::reexports::diesel::sql_types::TimestamptzSqlite>, _>(__ledger_to_transaction_bound)
+                                .bind::<::autumn_web::reexports::diesel::sql_types::Nullable<::autumn_web::reexports::diesel::sql_types::TimestamptzSqlite>, _>(__ledger_to_valid_bound)
+                                .get_results::<__AutumnLedgerDiffRow>(&mut conn)
+                                .await
+                                .map_err(::autumn_web::AutumnError::from)?;
+
+                            #ledger_map_diff_rows
+                        }},
+                    };
+
+                    ::core::result::Result::Ok((from_revision, to_revision))
+                }
+
                 /// The record's exact state at a past **transaction** instant —
                 /// what a plain query would have returned at that moment.
                 ///
@@ -18406,15 +18656,15 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                 /// # Errors
                 ///
                 /// Propagates read errors from
-                /// [`__autumn_ledger_revision_at`](Self::__autumn_ledger_revision_at).
+                /// [`__autumn_ledger_diff_revisions_at`](Self::__autumn_ledger_diff_revisions_at).
                 pub async fn ledger_diff_at(
                     &self,
                     record_id: i64,
                     from: ::autumn_web::ledger::LedgerAsOf,
                     to: ::autumn_web::ledger::LedgerAsOf,
                 ) -> ::autumn_web::AutumnResult<::autumn_web::ledger::LedgerDiff> {
-                    let from_rev = self.__autumn_ledger_revision_at(record_id, from).await?;
-                    let to_rev = self.__autumn_ledger_revision_at(record_id, to).await?;
+                    let (from_rev, to_rev) =
+                        self.__autumn_ledger_diff_revisions_at(record_id, from, to).await?;
                     let from_seq = from_rev.as_ref().map(|r| r.seq);
                     let to_seq = to_rev.as_ref().map(|r| r.seq);
                     // Diffing stored snapshots directly would compare the
@@ -26731,7 +26981,14 @@ mod tests {
             ("api", quote! { Post, api = "/posts" }, 95_000),
             ("searchable", quote! { Post, searchable }, 98_000),
             ("versioned", quote! { Post, versioned = true }, 128_000),
-            ("ledgered", quote! { Post, ledgered, soft_delete }, 201_000),
+            // Raised from 201_000 (#2490): `ledger_as_of_at`/`ledger_diff_at`
+            // moved off a full-chain `ledger_revisions` read onto two new
+            // bounded-lookup methods (`__autumn_ledger_revision_at`,
+            // `__autumn_ledger_diff_revisions_at` — each carries its own
+            // `QueryableByName` row struct per backend arm), so the ledgered
+            // case grew from ~180 KB to 203,169 bytes. Understood and
+            // intended; ~15% headroom kept over the new measured size.
+            ("ledgered", quote! { Post, ledgered, soft_delete }, 234_000),
         ];
 
         for (label, attr, ceiling) in budgets {

--- a/autumn-macros/src/repository.rs
+++ b/autumn-macros/src/repository.rs
@@ -17949,6 +17949,46 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
             __out
         }
     };
+    // Single-row counterpart of `ledger_map_rows`, for the bounded
+    // `__autumn_ledger_revision_at` lookup: the same per-row mapping (op
+    // decode, snapshot parse-or-error), applied to at most one `raw_row`
+    // instead of folded over a whole `raw_rows` chain.
+    let ledger_map_row_opt = quote! {
+        match raw_row {
+            ::core::option::Option::None => ::core::option::Option::None,
+            ::core::option::Option::Some(row) => {
+                let op = match row.op.as_str() {
+                    "insert" => ::autumn_web::version_history::VersionOp::Insert,
+                    "delete" => ::autumn_web::version_history::VersionOp::Delete,
+                    _ => ::autumn_web::version_history::VersionOp::Update,
+                };
+                let snapshot: ::autumn_web::reexports::serde_json::Value =
+                    ::autumn_web::reexports::serde_json::from_str(&row.snapshot)
+                        .map_err(|err| ::autumn_web::AutumnError::internal_server_error(
+                            ::autumn_web::ledger::LedgerError::ChainUnreadable {
+                                table: #table_name.to_string(),
+                                record_id,
+                                detail: format!("revision {} has an unreadable snapshot: {err}", row.seq),
+                            },
+                        ))?;
+                ::core::option::Option::Some(::autumn_web::ledger::LedgerRevision {
+                    id: row.id,
+                    table_name: row.table_name,
+                    tenant_id: row.tenant_id,
+                    record_id: row.record_id,
+                    seq: row.seq,
+                    op,
+                    actor: row.actor,
+                    request_id: row.request_id,
+                    snapshot,
+                    valid_from: row.valid_from,
+                    recorded_at: row.recorded_at,
+                    prev_hash: row.prev_hash,
+                    hash: row.hash,
+                })
+            }
+        }
+    };
 
     // The live-row read is tenant-filtered only on a tenant-scoped repository:
     // a plain model has no `tenant_id` column to name.
@@ -18118,6 +18158,176 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                     ::core::result::Result::Ok(revisions)
                 }
 
+                /// The single revision in force at a bitemporal instant,
+                /// fetched directly rather than through
+                /// [`ledger_revisions`](Self::ledger_revisions).
+                ///
+                /// `ledger_revisions` reads every stored revision — and every
+                /// stored snapshot, the largest column in the table — to
+                /// answer a question that has exactly one answer. This issues
+                /// one indexed, bounded lookup instead: `ORDER BY seq DESC
+                /// LIMIT 1` against `idx_autumn_ledger_revisions_record`,
+                /// with the same `None`-is-unbounded predicate
+                /// [`snapshot_as_of`](crate::ledger::snapshot_as_of) applies
+                /// in memory, now evaluated by the database. Picking the
+                /// greatest surviving `seq` via `ORDER BY ... LIMIT 1` is
+                /// `max_by_key(seq)` over the qualifying rows — the same
+                /// selection, computed the same way, just without
+                /// materializing the rows that lose.
+                ///
+                /// `recorded_at` is monotonic non-decreasing in `seq` (see
+                /// [`monotonic_recorded_at`](crate::ledger::monotonic_recorded_at)),
+                /// so a transaction-time bound — what
+                /// [`ledger_as_of`](Self::ledger_as_of) and
+                /// [`ledger_diff`](Self::ledger_diff) use — lets the scan
+                /// stop at the first qualifying row: only the revisions newer
+                /// than the answer are read, never the whole chain. A
+                /// valid-time bound alone has no such guarantee (a
+                /// back-dated correction can land anywhere in `seq` order),
+                /// so it can still read back to the front of the chain in the
+                /// worst case — exactly what `ledger_revisions` always did,
+                /// never worse.
+                ///
+                /// # Errors
+                ///
+                /// Returns an error if the ledger table cannot be read, or if
+                /// the matching revision's stored snapshot is no longer valid
+                /// JSON.
+                #[doc(hidden)]
+                async fn __autumn_ledger_revision_at(
+                    &self,
+                    record_id: i64,
+                    as_of: ::autumn_web::ledger::LedgerAsOf,
+                ) -> ::autumn_web::AutumnResult<::core::option::Option<::autumn_web::ledger::LedgerRevision>> {
+                    use ::autumn_web::reexports::diesel_async::RunQueryDsl as _;
+
+                    #ledger_cross_shard_guard
+                    #ledger_cross_tenant_guard
+                    #ledger_tenant_setup
+
+                    let mut conn = self.__autumn_acquire_read_conn().await?;
+                    let __ledger_transaction_bound = as_of.transaction;
+                    let __ledger_valid_bound = as_of.valid;
+
+                    let revision: ::core::option::Option<::autumn_web::ledger::LedgerRevision> =
+                        ::autumn_web::backend_select! {
+                            pg => {{
+                                #[derive(::autumn_web::reexports::diesel::QueryableByName)]
+                                struct __AutumnLedgerRow {
+                                    #[diesel(sql_type = ::autumn_web::reexports::diesel::sql_types::BigInt)]
+                                    id: i64,
+                                    #[diesel(sql_type = ::autumn_web::reexports::diesel::sql_types::Text)]
+                                    table_name: ::std::string::String,
+                                    #[diesel(sql_type = ::autumn_web::reexports::diesel::sql_types::Nullable<::autumn_web::reexports::diesel::sql_types::Text>)]
+                                    tenant_id: ::core::option::Option<::std::string::String>,
+                                    #[diesel(sql_type = ::autumn_web::reexports::diesel::sql_types::BigInt)]
+                                    record_id: i64,
+                                    #[diesel(sql_type = ::autumn_web::reexports::diesel::sql_types::BigInt)]
+                                    seq: i64,
+                                    #[diesel(sql_type = ::autumn_web::reexports::diesel::sql_types::Text)]
+                                    op: ::std::string::String,
+                                    #[diesel(sql_type = ::autumn_web::reexports::diesel::sql_types::Text)]
+                                    actor: ::std::string::String,
+                                    #[diesel(sql_type = ::autumn_web::reexports::diesel::sql_types::Nullable<::autumn_web::reexports::diesel::sql_types::Text>)]
+                                    request_id: ::core::option::Option<::std::string::String>,
+                                    #[diesel(sql_type = ::autumn_web::reexports::diesel::sql_types::Text)]
+                                    snapshot: ::std::string::String,
+                                    #[diesel(sql_type = ::autumn_web::reexports::diesel::sql_types::Timestamptz)]
+                                    valid_from: ::autumn_web::reexports::chrono::DateTime<::autumn_web::reexports::chrono::Utc>,
+                                    #[diesel(sql_type = ::autumn_web::reexports::diesel::sql_types::Timestamptz)]
+                                    recorded_at: ::autumn_web::reexports::chrono::DateTime<::autumn_web::reexports::chrono::Utc>,
+                                    #[diesel(sql_type = ::autumn_web::reexports::diesel::sql_types::Nullable<::autumn_web::reexports::diesel::sql_types::Text>)]
+                                    prev_hash: ::core::option::Option<::std::string::String>,
+                                    #[diesel(sql_type = ::autumn_web::reexports::diesel::sql_types::Text)]
+                                    hash: ::std::string::String,
+                                }
+
+                                let raw_row: ::core::option::Option<__AutumnLedgerRow> =
+                                    ::autumn_web::reexports::diesel::sql_query(
+                                        "SELECT id, table_name, tenant_id, record_id, seq, op, actor, \
+                                         request_id, snapshot, valid_from, \
+                                         recorded_at, prev_hash, hash \
+                                         FROM _autumn_ledger_revisions \
+                                         WHERE table_name = $1 AND record_id = $2 \
+                                         AND ($3::text IS NULL OR tenant_id = $3) \
+                                         AND ($4::timestamptz IS NULL OR recorded_at <= $4) \
+                                         AND ($5::timestamptz IS NULL OR valid_from <= $5) \
+                                         ORDER BY seq DESC LIMIT 1"
+                                    )
+                                    .bind::<::autumn_web::reexports::diesel::sql_types::Text, _>(#table_name)
+                                    .bind::<::autumn_web::reexports::diesel::sql_types::BigInt, _>(record_id)
+                                    .bind::<::autumn_web::reexports::diesel::sql_types::Nullable<::autumn_web::reexports::diesel::sql_types::Text>, _>(__ledger_tenant_id)
+                                    .bind::<::autumn_web::reexports::diesel::sql_types::Nullable<::autumn_web::reexports::diesel::sql_types::Timestamptz>, _>(__ledger_transaction_bound)
+                                    .bind::<::autumn_web::reexports::diesel::sql_types::Nullable<::autumn_web::reexports::diesel::sql_types::Timestamptz>, _>(__ledger_valid_bound)
+                                    .get_results::<__AutumnLedgerRow>(&mut conn)
+                                    .await
+                                    .map_err(::autumn_web::AutumnError::from)?
+                                    .into_iter()
+                                    .next();
+
+                                #ledger_map_row_opt
+                            }},
+                            sqlite => {{
+                                #[derive(::autumn_web::reexports::diesel::QueryableByName)]
+                                struct __AutumnLedgerRow {
+                                    #[diesel(sql_type = ::autumn_web::reexports::diesel::sql_types::BigInt)]
+                                    id: i64,
+                                    #[diesel(sql_type = ::autumn_web::reexports::diesel::sql_types::Text)]
+                                    table_name: ::std::string::String,
+                                    #[diesel(sql_type = ::autumn_web::reexports::diesel::sql_types::Nullable<::autumn_web::reexports::diesel::sql_types::Text>)]
+                                    tenant_id: ::core::option::Option<::std::string::String>,
+                                    #[diesel(sql_type = ::autumn_web::reexports::diesel::sql_types::BigInt)]
+                                    record_id: i64,
+                                    #[diesel(sql_type = ::autumn_web::reexports::diesel::sql_types::BigInt)]
+                                    seq: i64,
+                                    #[diesel(sql_type = ::autumn_web::reexports::diesel::sql_types::Text)]
+                                    op: ::std::string::String,
+                                    #[diesel(sql_type = ::autumn_web::reexports::diesel::sql_types::Text)]
+                                    actor: ::std::string::String,
+                                    #[diesel(sql_type = ::autumn_web::reexports::diesel::sql_types::Nullable<::autumn_web::reexports::diesel::sql_types::Text>)]
+                                    request_id: ::core::option::Option<::std::string::String>,
+                                    #[diesel(sql_type = ::autumn_web::reexports::diesel::sql_types::Text)]
+                                    snapshot: ::std::string::String,
+                                    #[diesel(sql_type = ::autumn_web::reexports::diesel::sql_types::TimestamptzSqlite)]
+                                    valid_from: ::autumn_web::reexports::chrono::DateTime<::autumn_web::reexports::chrono::Utc>,
+                                    #[diesel(sql_type = ::autumn_web::reexports::diesel::sql_types::TimestamptzSqlite)]
+                                    recorded_at: ::autumn_web::reexports::chrono::DateTime<::autumn_web::reexports::chrono::Utc>,
+                                    #[diesel(sql_type = ::autumn_web::reexports::diesel::sql_types::Nullable<::autumn_web::reexports::diesel::sql_types::Text>)]
+                                    prev_hash: ::core::option::Option<::std::string::String>,
+                                    #[diesel(sql_type = ::autumn_web::reexports::diesel::sql_types::Text)]
+                                    hash: ::std::string::String,
+                                }
+
+                                let raw_row: ::core::option::Option<__AutumnLedgerRow> =
+                                    ::autumn_web::reexports::diesel::sql_query(
+                                        "SELECT id, table_name, tenant_id, record_id, seq, op, actor, \
+                                         request_id, snapshot, valid_from, \
+                                         recorded_at, prev_hash, hash \
+                                         FROM _autumn_ledger_revisions \
+                                         WHERE table_name = $1 AND record_id = $2 \
+                                         AND ($3 IS NULL OR tenant_id = $3) \
+                                         AND ($4 IS NULL OR recorded_at <= $4) \
+                                         AND ($5 IS NULL OR valid_from <= $5) \
+                                         ORDER BY seq DESC LIMIT 1"
+                                    )
+                                    .bind::<::autumn_web::reexports::diesel::sql_types::Text, _>(#table_name)
+                                    .bind::<::autumn_web::reexports::diesel::sql_types::BigInt, _>(record_id)
+                                    .bind::<::autumn_web::reexports::diesel::sql_types::Nullable<::autumn_web::reexports::diesel::sql_types::Text>, _>(__ledger_tenant_id)
+                                    .bind::<::autumn_web::reexports::diesel::sql_types::Nullable<::autumn_web::reexports::diesel::sql_types::TimestamptzSqlite>, _>(__ledger_transaction_bound)
+                                    .bind::<::autumn_web::reexports::diesel::sql_types::Nullable<::autumn_web::reexports::diesel::sql_types::TimestamptzSqlite>, _>(__ledger_valid_bound)
+                                    .get_results::<__AutumnLedgerRow>(&mut conn)
+                                    .await
+                                    .map_err(::autumn_web::AutumnError::from)?
+                                    .into_iter()
+                                    .next();
+
+                                #ledger_map_row_opt
+                            }},
+                        };
+
+                    ::core::result::Result::Ok(revision)
+                }
+
                 /// The record's exact state at a past **transaction** instant —
                 /// what a plain query would have returned at that moment.
                 ///
@@ -18148,20 +18358,20 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                 /// # Errors
                 ///
                 /// Propagates read errors from
-                /// [`ledger_revisions`](Self::ledger_revisions), and fails if a
-                /// snapshot cannot be deserialized back into the model.
+                /// [`__autumn_ledger_revision_at`](Self::__autumn_ledger_revision_at),
+                /// and fails if a snapshot cannot be deserialized back into
+                /// the model.
                 pub async fn ledger_as_of_at(
                     &self,
                     record_id: i64,
                     as_of: ::autumn_web::ledger::LedgerAsOf,
                 ) -> ::autumn_web::AutumnResult<::core::option::Option<#model_name>> {
-                    let revisions = self.ledger_revisions(record_id).await?;
                     let ::core::option::Option::Some(revision) =
-                        ::autumn_web::ledger::snapshot_as_of(&revisions, as_of)
+                        self.__autumn_ledger_revision_at(record_id, as_of).await?
                     else {
                         return ::core::result::Result::Ok(::core::option::Option::None);
                     };
-                    let model = Self::__autumn_ledger_model_from_snapshot(record_id, revision)?;
+                    let model = Self::__autumn_ledger_model_from_snapshot(record_id, &revision)?;
                     ::core::result::Result::Ok(::core::option::Option::Some(model))
                 }
 
@@ -18196,16 +18406,17 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                 /// # Errors
                 ///
                 /// Propagates read errors from
-                /// [`ledger_revisions`](Self::ledger_revisions).
+                /// [`__autumn_ledger_revision_at`](Self::__autumn_ledger_revision_at).
                 pub async fn ledger_diff_at(
                     &self,
                     record_id: i64,
                     from: ::autumn_web::ledger::LedgerAsOf,
                     to: ::autumn_web::ledger::LedgerAsOf,
                 ) -> ::autumn_web::AutumnResult<::autumn_web::ledger::LedgerDiff> {
-                    let revisions = self.ledger_revisions(record_id).await?;
-                    let from_rev = ::autumn_web::ledger::snapshot_as_of(&revisions, from);
-                    let to_rev = ::autumn_web::ledger::snapshot_as_of(&revisions, to);
+                    let from_rev = self.__autumn_ledger_revision_at(record_id, from).await?;
+                    let to_rev = self.__autumn_ledger_revision_at(record_id, to).await?;
+                    let from_seq = from_rev.as_ref().map(|r| r.seq);
+                    let to_seq = to_rev.as_ref().map(|r| r.seq);
                     // Diffing stored snapshots directly would compare the
                     // ciphertext of `#[encrypted]` columns, which carries a fresh
                     // nonce per write and so always differs even when the
@@ -18214,20 +18425,20 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                     let empty = ::autumn_web::reexports::serde_json::Value::Object(
                         ::autumn_web::reexports::serde_json::Map::new(),
                     );
-                    let before = match from_rev {
+                    let before = match &from_rev {
                         ::core::option::Option::None => empty.clone(),
                         ::core::option::Option::Some(revision) =>
                             Self::__autumn_ledger_view_of(record_id, revision)?,
                     };
-                    let after = match to_rev {
+                    let after = match &to_rev {
                         ::core::option::Option::None => empty,
                         ::core::option::Option::Some(revision) =>
                             Self::__autumn_ledger_view_of(record_id, revision)?,
                     };
                     ::core::result::Result::Ok(::autumn_web::ledger::LedgerDiff {
                         record_id,
-                        from_seq: from_rev.map(|r| r.seq),
-                        to_seq: to_rev.map(|r| r.seq),
+                        from_seq,
+                        to_seq,
                         changes: ::autumn_web::ledger::diff_snapshots(&before, &after),
                     })
                 }

--- a/autumn/tests/integration/ledger_as_of_deep_chain_profile.rs
+++ b/autumn/tests/integration/ledger_as_of_deep_chain_profile.rs
@@ -1,0 +1,493 @@
+//! Ledger findings/fix harness for the generated `ledger_as_of`/`ledger_diff`
+//! read path (`autumn-macros/src/repository.rs`), driven through the real
+//! public API a compliance/support audit calls: "what did this record look
+//! like at instant X".
+//!
+//! # The mechanism
+//!
+//! `ledger_as_of`/`ledger_diff` are pure functions
+//! ([`snapshot_as_of`](autumn_web::ledger::snapshot_as_of)) over whatever
+//! `ledger_revisions(record_id)` returns — and `ledger_revisions` has exactly
+//! one SQL shape: `SELECT ... FROM _autumn_ledger_revisions WHERE table_name =
+//! $1 AND record_id = $2 AND (tenant) ORDER BY seq ASC`, no `LIMIT`, no bound
+//! on `as_of` at all. It reads **every** stored revision of the record — every
+//! row, every `snapshot` TEXT column, the largest column in the table — to
+//! answer a question with exactly one answer, regardless of whether `as_of`
+//! asks about the current instant or the record's very first revision.
+//!
+//! For a `#[repository(ledgered = true)]` entity that is exactly the kind of
+//! record the feature exists for: a financial account, an invoice, a
+//! contract — something adjusted repeatedly over a long operational life and
+//! later audited. A hot account with a few thousand postings against it pays
+//! for a few-thousand-row, full-snapshot read on every single as-of/diff call,
+//! even when the auditor is asking "what did it look like an hour ago".
+//!
+//! # Fixture
+//!
+//! Three "hot" ledgered accounts at three chain depths (300 / 700 / 1,200
+//! revisions — real operational history, not a single huge outlier) plus a
+//! long tail of 150 accounts touched only 6 times each (skewed cardinality,
+//! the same 80/20 shape the export/reaper Ledger fixtures use, now expressed
+//! as chain depth rather than row count). Every revision is written through
+//! the real `save`/`update` write path — the actual `#[repository]`-generated
+//! append, hash chain and high-water bookkeeping — so the fixture is exactly
+//! what production writes, not a synthetic bulk insert. The live row for each
+//! hot account is itself updated hundreds of times, so its heap carries real
+//! dead tuples by the time `ANALYZE` runs (no `VACUUM`), same as the other
+//! Ledger fixtures' dead-tuple requirement.
+//!
+//! **Requires Docker.** CI runs it in the Docker-dependent sweep (`--
+//! --ignored`, see CLAUDE.md). Run manually with:
+//!
+//! ```text
+//! cargo test -p autumn-web --features "test-support" \
+//!   --test integration_tests -- --ignored ledger_as_of_deep_chain_profile \
+//!   --nocapture --test-threads=1
+//! ```
+
+#![cfg(feature = "db")]
+#![allow(clippy::must_use_candidate, clippy::missing_const_for_fn)]
+#![allow(clippy::cast_possible_wrap)]
+
+use autumn_web::current::with_actor;
+use autumn_web::hooks::Patch;
+use chrono::{DateTime, Utc};
+use diesel::connection::SimpleConnection;
+use diesel::sql_types::{BigInt, Text};
+use diesel::{Connection, PgConnection, QueryableByName};
+use diesel_async::pooled_connection::AsyncDieselConnectionManager;
+use diesel_async::pooled_connection::deadpool::Pool;
+use diesel_async::{AsyncPgConnection, SimpleAsyncConnection as _};
+use testcontainers::ImageExt;
+use testcontainers::runners::AsyncRunner;
+use testcontainers_modules::postgres::Postgres;
+
+diesel::table! {
+    ledger_deep_chain_accounts (id) {
+        id -> Int8,
+        external_ref -> Text,
+        balance_cents -> Int8,
+        deleted_at -> Nullable<Timestamp>,
+    }
+}
+
+#[autumn_web::model(table = "ledger_deep_chain_accounts")]
+pub struct LedgerDeepChainAccount {
+    #[id]
+    pub id: i64,
+    pub external_ref: String,
+    pub balance_cents: i64,
+    #[default]
+    pub deleted_at: Option<chrono::NaiveDateTime>,
+}
+
+#[autumn_web::repository(
+    LedgerDeepChainAccount,
+    table = "ledger_deep_chain_accounts",
+    soft_delete,
+    ledgered = true
+)]
+pub trait LedgerDeepChainAccountRepository {}
+
+/// The migration SQL Autumn actually ships, applied verbatim — same
+/// convention as `ledger_postgres.rs`.
+const LEDGER_UP: &str =
+    include_str!("../../version_history_migrations/20260826000000_create_ledger_revisions/up.sql");
+const LEDGER_HIGH_WATER_UP: &str =
+    include_str!("../../version_history_migrations/20260901213107_create_ledger_high_water/up.sql");
+const VERSION_HISTORY_UP: &str =
+    include_str!("../../version_history_migrations/20260526000000_create_version_history/up.sql");
+
+const fn build_repo(pool: Pool<AsyncPgConnection>) -> PgLedgerDeepChainAccountRepository {
+    PgLedgerDeepChainAccountRepository {
+        pool,
+        __autumn_read_route: autumn_web::repository::ReadRoute::Primary,
+        __autumn_statement_timeout_ms: 0,
+        __autumn_slow_threshold: std::time::Duration::from_millis(500),
+        __autumn_route: None,
+    }
+}
+
+async fn setup() -> (
+    Pool<AsyncPgConnection>,
+    String,
+    testcontainers::ContainerAsync<Postgres>,
+) {
+    let container = Postgres::default()
+        .with_tag("16-alpine")
+        .with_cmd([
+            "-c",
+            "fsync=off",
+            "-c",
+            "shared_preload_libraries=pg_stat_statements",
+            "-c",
+            "pg_stat_statements.track=all",
+            "-c",
+            "pg_stat_statements.max=2000",
+        ])
+        .start()
+        .await
+        .expect("failed to start postgres container");
+
+    let host = container.get_host().await.expect("host");
+    let port = container.get_host_port_ipv4(5432).await.expect("port");
+    let url = format!("postgres://postgres:postgres@{host}:{port}/postgres");
+
+    let manager = AsyncDieselConnectionManager::<AsyncPgConnection>::new(&url);
+    let pool = Pool::builder(manager).max_size(10).build().expect("pool");
+
+    let mut conn = pool.get().await.expect("conn");
+    conn.batch_execute("CREATE EXTENSION IF NOT EXISTS pg_stat_statements")
+        .await
+        .expect("create pg_stat_statements extension");
+    for ddl in [
+        "CREATE TABLE IF NOT EXISTS ledger_deep_chain_accounts (
+             id BIGSERIAL PRIMARY KEY,
+             external_ref TEXT NOT NULL,
+             balance_cents BIGINT NOT NULL,
+             deleted_at TIMESTAMP
+         )",
+        VERSION_HISTORY_UP,
+        LEDGER_UP,
+        LEDGER_HIGH_WATER_UP,
+    ] {
+        conn.batch_execute(ddl)
+            .await
+            .unwrap_or_else(|err| panic!("apply DDL: {err}\n{ddl}"));
+    }
+
+    (pool, url, container)
+}
+
+/// Writes one hot account's chain through the real `save`/`update` path:
+/// `depth` total revisions (1 insert + `depth - 1` updates), each committed
+/// before the next is issued (a chain is inherently sequential — each append
+/// reads the previous head). Returns the record id and, for every revision,
+/// a `Utc::now()` sampled immediately after that write's `await` returned —
+/// strictly after the database committed that revision and strictly before
+/// the next one starts, so `oracle[k]` is a safe "as of" instant for "the
+/// state after revision k+1" (`oracle.len() == depth`).
+async fn seed_hot_chain(
+    pool: Pool<AsyncPgConnection>,
+    external_ref: &str,
+    depth: usize,
+) -> (i64, Vec<DateTime<Utc>>) {
+    let repo = build_repo(pool);
+    let created = with_actor("system", async {
+        repo.save(&NewLedgerDeepChainAccount {
+            external_ref: external_ref.to_string(),
+            balance_cents: 0,
+        })
+        .await
+        .expect("insert hot account")
+    })
+    .await;
+    let id = created.id;
+    let mut oracle = Vec::with_capacity(depth);
+    oracle.push(Utc::now());
+    for i in 1..depth {
+        with_actor("system", async {
+            repo.update(
+                id,
+                &UpdateLedgerDeepChainAccount {
+                    balance_cents: Patch::Set(i as i64),
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect("update hot account")
+        })
+        .await;
+        oracle.push(Utc::now());
+    }
+    (id, oracle)
+}
+
+/// A long tail of accounts touched only `depth_each` times each — the same
+/// skewed cardinality shape the export/reaper Ledger fixtures use, so the
+/// `_autumn_ledger_revisions` table looks like a real deployment's rather
+/// than holding only the three hot chains under test.
+async fn seed_long_tail(pool: Pool<AsyncPgConnection>, count: usize, depth_each: usize) {
+    let repo = build_repo(pool);
+    for n in 0..count {
+        let created = with_actor("system", async {
+            repo.save(&NewLedgerDeepChainAccount {
+                external_ref: format!("tail-{n}"),
+                balance_cents: 0,
+            })
+            .await
+            .expect("insert tail account")
+        })
+        .await;
+        let id = created.id;
+        for i in 1..depth_each {
+            with_actor("system", async {
+                repo.update(
+                    id,
+                    &UpdateLedgerDeepChainAccount {
+                        balance_cents: Patch::Set(i as i64),
+                        ..Default::default()
+                    },
+                )
+                .await
+                .expect("update tail account")
+            })
+            .await;
+        }
+    }
+}
+
+#[derive(QueryableByName, Debug)]
+struct StatementRow {
+    #[diesel(sql_type = Text)]
+    query: String,
+    #[diesel(sql_type = BigInt)]
+    calls: i64,
+    #[diesel(sql_type = BigInt)]
+    buffers: i64,
+}
+
+fn reset_stats(conn: &mut PgConnection) {
+    conn.batch_execute("SELECT pg_stat_statements_reset()")
+        .expect("reset pg_stat_statements");
+}
+
+/// Prints every `_autumn_ledger_revisions` statement from this run and
+/// returns `(calls, buffers)` totals for the two statement SHAPES the
+/// generated code can issue: the unbounded `ledger_revisions` scan
+/// (`ORDER BY seq ASC`, no `LIMIT`) and the bounded `as_of` lookup (`ORDER BY
+/// seq DESC LIMIT`). Whichever shape is compiled in shows up under the
+/// matching bucket, so this same harness measures both the pre-fix and
+/// post-fix implementation, unchanged.
+fn print_profile(conn: &mut PgConnection, label: &str) -> (i64, i64, i64, i64) {
+    use diesel::RunQueryDsl;
+    println!("\n=== pg_stat_statements: {label} ===");
+    let rows = diesel::sql_query(
+        "SELECT query, calls, (shared_blks_hit + shared_blks_read) AS buffers \
+         FROM pg_stat_statements \
+         WHERE query ILIKE '%_autumn_ledger_revisions%' \
+           AND query NOT ILIKE '%pg_stat_statements%' \
+         ORDER BY calls DESC",
+    )
+    .load::<StatementRow>(conn)
+    .expect("query pg_stat_statements");
+
+    let (mut unbounded_calls, mut unbounded_buffers) = (0i64, 0i64);
+    let (mut bounded_calls, mut bounded_buffers) = (0i64, 0i64);
+    for row in &rows {
+        let normalized = row.query.split_whitespace().collect::<Vec<_>>().join(" ");
+        println!(
+            "calls={:<6} buffers={:<8} {normalized}",
+            row.calls, row.buffers
+        );
+        if normalized.contains("ORDER BY seq DESC") {
+            bounded_calls += row.calls;
+            bounded_buffers += row.buffers;
+        } else if normalized.contains("ORDER BY seq ASC") {
+            unbounded_calls += row.calls;
+            unbounded_buffers += row.buffers;
+        }
+    }
+    println!(
+        "-- unbounded (ledger_revisions) shape: calls={unbounded_calls} buffers={unbounded_buffers} \
+         -- bounded (as-of) shape: calls={bounded_calls} buffers={bounded_buffers} --"
+    );
+    (
+        unbounded_calls,
+        unbounded_buffers,
+        bounded_calls,
+        bounded_buffers,
+    )
+}
+
+#[derive(QueryableByName, Debug)]
+struct ExplainLine {
+    #[diesel(sql_type = Text, column_name = "QUERY PLAN")]
+    line: String,
+}
+
+fn explain(conn: &mut PgConnection, label: &str, sql: &str) {
+    use diesel::RunQueryDsl;
+    println!("\n=== EXPLAIN (ANALYZE, BUFFERS, VERBOSE, SETTINGS): {label} ===");
+    println!("{sql}");
+    let lines = diesel::sql_query(format!(
+        "EXPLAIN (ANALYZE, BUFFERS, VERBOSE, SETTINGS) {sql}"
+    ))
+    .load::<ExplainLine>(conn)
+    .expect("explain");
+    for line in lines {
+        println!("{}", line.line);
+    }
+}
+
+#[tokio::test]
+#[ignore = "requires Docker (testcontainers)"]
+#[allow(clippy::too_many_lines)]
+async fn ledger_as_of_deep_chain_profile() {
+    let (pool, url, _container) = setup().await;
+
+    // Three chain depths -- the Ledger process's "admissible at >= 3 sizes"
+    // bar for a plan-shape/row-count claim -- written concurrently (each
+    // chain is internally sequential; the three chains have no shared state)
+    // plus a skewed long tail, all through the real write path.
+    let ((hot_300, oracle_300), (hot_700, oracle_700), (hot_1200, oracle_1200), ()) = tokio::join!(
+        seed_hot_chain(pool.clone(), "hot-300", 300),
+        seed_hot_chain(pool.clone(), "hot-700", 700),
+        seed_hot_chain(pool.clone(), "hot-1200", 1200),
+        seed_long_tail(pool.clone(), 150, 6),
+    );
+
+    let mut conn = PgConnection::establish(&url).expect("sync db connection");
+    // Real dead tuples: each hot account's live row was updated hundreds of
+    // times above; ANALYZE without an intervening VACUUM leaves the planner
+    // seeing them, same as the other Ledger fixtures' dead-tuple requirement.
+    conn.batch_execute("ANALYZE ledger_deep_chain_accounts, _autumn_ledger_revisions")
+        .expect("analyze");
+
+    let repo = build_repo(pool);
+    let chains: [(&str, i64, &[DateTime<Utc>]); 3] = [
+        ("hot-300", hot_300, &oracle_300),
+        ("hot-700", hot_700, &oracle_700),
+        ("hot-1200", hot_1200, &oracle_1200),
+    ];
+
+    // For each depth, ask a realistic near-head audit question -- "what did
+    // this look like 5 postings ago" -- and confirm the answer is correct
+    // (equivalence: same reconstructed value regardless of which query shape
+    // answered it) while the statement/buffer profile is captured.
+    println!("\n=== near-head as-of: statement/buffer scaling across chain depths ===");
+    println!(
+        "{:<10} {:>8} {:>16} {:>18} {:>16} {:>18}",
+        "chain",
+        "depth",
+        "unbounded calls",
+        "unbounded buffers",
+        "bounded calls",
+        "bounded buffers"
+    );
+    for (label, id, oracle) in &chains {
+        let depth = oracle.len();
+        let near_head_pos = depth - 6; // "5 postings before the current head"
+        let as_of = oracle[near_head_pos];
+        reset_stats(&mut conn);
+        let reconstructed = repo
+            .ledger_as_of(*id, as_of)
+            .await
+            .expect("as-of read")
+            .expect("record existed at this instant");
+        assert_eq!(
+            reconstructed.balance_cents,
+            i64::try_from(near_head_pos).expect("position fits in i64"),
+            "{label}: near-head as-of must reconstruct the exact revision in force"
+        );
+        let (u_calls, u_buffers, b_calls, b_buffers) = print_profile(
+            &mut conn,
+            &format!("{label} (depth {depth}) near-head as-of"),
+        );
+        println!(
+            "{label:<10} {depth:>8} {u_calls:>16} {u_buffers:>18} {b_calls:>16} {b_buffers:>18}"
+        );
+    }
+
+    // Worst case, disclosed: asking about the record's very FIRST revision
+    // still has to walk back through the whole chain under either shape,
+    // because `valid_from`/`recorded_at` bounds alone give no guarantee the
+    // qualifying row sits near the head. This must not regress -- the bounded
+    // shape should read no more than the unbounded one ever did.
+    reset_stats(&mut conn);
+    let earliest = repo
+        .ledger_as_of(hot_1200, oracle_1200[0])
+        .await
+        .expect("as-of read")
+        .expect("record existed at its first revision");
+    assert_eq!(
+        earliest.balance_cents, 0,
+        "the first revision is the insert"
+    );
+    let (_, _, worst_case_bounded_calls, worst_case_bounded_buffers) = print_profile(
+        &mut conn,
+        "hot-1200 worst case: as-of at the FIRST revision",
+    );
+
+    // A field-level diff between two RECENT instants -- the other generated
+    // caller of the same bounded lookup, now issuing it twice (from/to)
+    // instead of reading the whole chain once. Disclosed trade: statement
+    // count for this call goes from 1 to (up to) 2, buffers/rows read fall
+    // sharply -- print-only, not asserted, so the same harness also captures
+    // the pre-fix 1-statement shape cleanly.
+    reset_stats(&mut conn);
+    let recent_from = oracle_1200[oracle_1200.len() - 11];
+    let recent_to = oracle_1200[oracle_1200.len() - 1];
+    let diff = repo
+        .ledger_diff(hot_1200, recent_from, recent_to)
+        .await
+        .expect("diff");
+    assert_eq!(diff.changes.len(), 1, "{:?}", diff.changes);
+    assert_eq!(diff.changes[0].column, "balance_cents");
+    print_profile(
+        &mut conn,
+        "hot-1200 ledger_diff across the last 10 postings",
+    );
+
+    println!(
+        "\n-- worst-case (first revision) bounded shape: calls={worst_case_bounded_calls} \
+         buffers={worst_case_bounded_buffers} --"
+    );
+
+    // Illustrative EXPLAIN of the exact statement `ledger_revisions`/the
+    // as-of lookup issues, at the deepest chain, near head vs record start --
+    // the scale claim is the pg_stat_statements table above; this is the plan
+    // shape and the `actual rows` at the scan node behind it.
+    explain(
+        &mut conn,
+        "unbounded ledger_revisions shape -- what ledger_as_of currently reads regardless of `as_of` \
+         (hot-1200)",
+        &format!(
+            "SELECT id, table_name, tenant_id, record_id, seq, op, actor, request_id, snapshot, \
+             valid_from, recorded_at, prev_hash, hash \
+             FROM _autumn_ledger_revisions \
+             WHERE table_name = 'ledger_deep_chain_accounts' AND record_id = {hot_1200} \
+             AND (NULL::text IS NULL OR tenant_id = NULL) \
+             ORDER BY seq ASC"
+        ),
+    );
+    explain(
+        &mut conn,
+        &format!(
+            "bounded as-of shape, near head -- 'what did it look like 5 postings ago' (hot-1200, \
+             at={})",
+            oracle_1200[oracle_1200.len() - 6]
+        ),
+        &format!(
+            "SELECT id, table_name, tenant_id, record_id, seq, op, actor, request_id, snapshot, \
+             valid_from, recorded_at, prev_hash, hash \
+             FROM _autumn_ledger_revisions \
+             WHERE table_name = 'ledger_deep_chain_accounts' AND record_id = {hot_1200} \
+             AND (NULL::text IS NULL OR tenant_id = NULL) \
+             AND ('{}'::timestamptz IS NULL OR recorded_at <= '{}'::timestamptz) \
+             AND (NULL::timestamptz IS NULL OR valid_from <= NULL) \
+             ORDER BY seq DESC LIMIT 1",
+            oracle_1200[oracle_1200.len() - 6].to_rfc3339(),
+            oracle_1200[oracle_1200.len() - 6].to_rfc3339(),
+        ),
+    );
+    explain(
+        &mut conn,
+        &format!(
+            "bounded as-of shape, worst case -- record's first revision (hot-1200, at={})",
+            oracle_1200[0]
+        ),
+        &format!(
+            "SELECT id, table_name, tenant_id, record_id, seq, op, actor, request_id, snapshot, \
+             valid_from, recorded_at, prev_hash, hash \
+             FROM _autumn_ledger_revisions \
+             WHERE table_name = 'ledger_deep_chain_accounts' AND record_id = {hot_1200} \
+             AND (NULL::text IS NULL OR tenant_id = NULL) \
+             AND ('{}'::timestamptz IS NULL OR recorded_at <= '{}'::timestamptz) \
+             AND (NULL::timestamptz IS NULL OR valid_from <= NULL) \
+             ORDER BY seq DESC LIMIT 1",
+            oracle_1200[0].to_rfc3339(),
+            oracle_1200[0].to_rfc3339(),
+        ),
+    );
+}

--- a/autumn/tests/integration/ledger_as_of_deep_chain_profile.rs
+++ b/autumn/tests/integration/ledger_as_of_deep_chain_profile.rs
@@ -410,11 +410,13 @@ async fn ledger_as_of_deep_chain_profile() {
     );
 
     // A field-level diff between two RECENT instants -- the other generated
-    // caller of the same bounded lookup, now issuing it twice (from/to)
-    // instead of reading the whole chain once. Disclosed trade: statement
-    // count for this call goes from 1 to (up to) 2, buffers/rows read fall
-    // sharply -- print-only, not asserted, so the same harness also captures
-    // the pre-fix 1-statement shape cleanly.
+    // caller of the bounded lookup. Both endpoints are resolved from one
+    // UNION ALL statement on one connection (not two separate calls), so a
+    // write landing between them can't resolve `from`/`to` against two
+    // different database states -- the same snapshot guarantee the old
+    // single `ledger_revisions` read had. Statement count stays at 1;
+    // buffers/rows read fall sharply -- print-only, not asserted, so the
+    // same harness also captures the pre-fix shape cleanly.
     reset_stats(&mut conn);
     let recent_from = oracle_1200[oracle_1200.len() - 11];
     let recent_to = oracle_1200[oracle_1200.len() - 1];

--- a/autumn/tests/integration/mod.rs
+++ b/autumn/tests/integration/mod.rs
@@ -250,6 +250,11 @@ mod read_your_writes_routing;
 // Postgres fork (jsonb snapshot cast, Timestamptz binds, COALESCE unique index).
 #[cfg(feature = "db")]
 mod ledger_postgres;
+// Ledger findings/fix harness for the generated `ledger_as_of`/`ledger_diff`
+// read path: profiles the unbounded full-chain read against a deep,
+// production-shaped chain and (after the fix) the bounded replacement.
+#[cfg(feature = "db")]
+mod ledger_as_of_deep_chain_profile;
 #[cfg(feature = "db")]
 mod repository_audit_actor;
 #[cfg(feature = "db")]

--- a/docs/reports/2026-09-03-ledger-as-of-deep-chain-bounded-lookup/README.md
+++ b/docs/reports/2026-09-03-ledger-as-of-deep-chain-bounded-lookup/README.md
@@ -1,0 +1,276 @@
+# 🗃️ Ledger — bounded lookup for `ledger_as_of`/`ledger_diff`
+
+**Date:** 2026-09-03
+**Target:** `ledger_as_of_at`/`ledger_diff_at`, the generated ledgered-repository
+read path (`autumn-macros/src/repository.rs`)
+**Outcome:** optimization for the realistic query pattern (near-head as-of:
+buffers −82% to −94%, flat regardless of chain depth), with a disclosed
+regression for the pathological worst case (a query about a record's very
+first revision, on a deep, physically-scattered chain: +619% buffers on this
+fixture)
+
+---
+
+## 🎯 Workload
+
+`#[repository(ledgered = true)]` (issue #1699) gives an entity a bitemporal,
+tamper-evident revision ledger: every write appends a full snapshot, and
+`ledger_as_of`/`ledger_diff` answer "what did this record look like at instant
+X" / "what changed between X and Y". This is exactly the feature a financial
+account, an invoice, or a contract uses — something adjusted repeatedly over a
+long operational life and later audited by a support agent or a compliance
+reviewer asking about **recent** history far more often than about the
+record's very first state.
+
+Both generated methods are pure functions
+([`snapshot_as_of`](../../autumn/src/ledger.rs)) over whatever
+`ledger_revisions(record_id)` returns, and `ledger_revisions` has exactly one
+SQL shape:
+
+```sql
+SELECT id, table_name, tenant_id, record_id, seq, op, actor, request_id,
+       snapshot, valid_from, recorded_at, prev_hash, hash
+FROM _autumn_ledger_revisions
+WHERE table_name = $1 AND record_id = $2 AND ($3::text IS NULL OR tenant_id = $3)
+ORDER BY seq ASC
+```
+
+No `LIMIT`, no reference to `as_of` at all. It reads **every** stored revision
+of the record — every row, every `snapshot` TEXT column (the largest column in
+the table) — to answer a question that has exactly one answer, regardless of
+whether `as_of` asks about right now or the record's very first revision.
+
+**Fixture** (`autumn/tests/integration/ledger_as_of_deep_chain_profile.rs`,
+testcontainer Postgres 16, `pg_stat_statements` preloaded): three "hot"
+ledgered accounts written through the real `save`/`update` path at three chain
+depths — 300 / 700 / 1,200 revisions, real operational history rather than one
+huge outlier — plus a long tail of 150 accounts touched only 6 times each (the
+same skewed-cardinality shape the export/reaper Ledger fixtures use, expressed
+here as chain depth rather than row count). Every hot account's live row is
+itself updated hundreds of times, so its heap carries real dead tuples by the
+time `ANALYZE` runs (no `VACUUM`), and the three hot chains are seeded
+**concurrently**, so their revisions land physically interleaved on disk —
+the same layout concurrent writes to different records produce in a live
+deployment.
+
+**Reproduce:**
+
+```bash
+cargo test -p autumn-web --features "test-support" --test integration_tests \
+  -- --ignored ledger_as_of_deep_chain_profile --nocapture --test-threads=1
+```
+
+Requires Docker. Wired into CI's Docker-dependent sweep automatically (a
+house-pattern `#[ignore]`d testcontainer test in `tests/integration/`, per
+CLAUDE.md — no workflow edit needed).
+
+---
+
+## 📈 Profile
+
+This harness drives exactly one workload, so the ranking below is the whole of
+it: every `_autumn_ledger_revisions` statement this run issues is either the
+`ledger_revisions` full-chain read or (after the fix) the new bounded lookup —
+100% of the harness's buffers and calls, by construction.
+
+---
+
+## 🧭 Plan
+
+**Before** (`baseline/output.txt`) — `EXPLAIN (ANALYZE, BUFFERS, VERBOSE,
+SETTINGS)` on the exact statement `ledger_as_of`/`ledger_diff` issue today, at
+the 1,200-revision chain:
+
+```
+Sort  (cost=236.87..239.87 rows=1200 width=347) (actual rows=1200 loops=1)
+  Buffers: shared hit=129
+  ->  Seq Scan on public._autumn_ledger_revisions (actual rows=1200 loops=1)
+        Filter: (table_name = 'ledger_deep_chain_accounts' AND record_id = 3)
+        Rows Removed by Filter: 1900
+        Buffers: shared hit=129
+```
+
+**actual rows=1200** at the scan node — every revision of the record, every
+time, whether `as_of` asks about the instant just recorded or the very first
+one.
+
+**After** (`after/output.txt`) — the same record, asking "what did it look
+like 5 postings ago" (the realistic near-head case):
+
+```
+Limit  (cost=0.28..0.57 rows=1 width=347) (actual rows=1 loops=1)
+  Buffers: shared hit=11
+  ->  Index Scan Backward using idx_autumn_ledger_revisions_record
+        (actual rows=1 loops=1)
+        Filter: (recorded_at <= '...')
+        Rows Removed by Filter: 5
+        Buffers: shared hit=11
+```
+
+**actual rows=1** at the `Limit` node, **6 rows examined** at the scan node
+(5 rejected + 1 returned) instead of 1,200. Same index that already existed
+(`idx_autumn_ledger_revisions_record`, `(table_name, record_id, seq)`) — no
+migration, no new index.
+
+**Disclosed worst case** — the same record, asking about its very first
+revision:
+
+```
+Limit  (cost=0.28..173.56 rows=1 width=347) (actual rows=1 loops=1)
+  Buffers: shared hit=949
+  ->  Index Scan Backward using idx_autumn_ledger_revisions_record
+        (actual rows=1 loops=1)
+        Filter: (recorded_at <= '...')
+        Rows Removed by Filter: 1199
+        Buffers: shared hit=949
+```
+
+1,199 of the chain's 1,200 rows still get examined here — asking about the
+oldest instant is the one case an `ORDER BY seq DESC LIMIT 1` scan cannot
+short-circuit, because the qualifying row sits at the *far* end of the scan
+direction. See "Disclosed trade-off" below for why this is worse in **buffers**
+than the old plan's 129, and why that isn't the number that should decide this
+change.
+
+---
+
+## 💡 Hypothesis
+
+The statement has no predicate on `as_of` at all, so it cannot stop early: it
+is structurally a full-chain read no matter what instant is asked about. A
+bounded lookup — `ORDER BY seq DESC LIMIT 1` with the same bitemporal filter
+`snapshot_as_of` already applies in Rust, now pushed into the `WHERE` clause —
+lets the database stop at the first qualifying revision. Because `recorded_at`
+is monotonic non-decreasing in `seq` (`monotonic_recorded_at`, #2323), a
+transaction-time bound — what `ledger_as_of`/`ledger_diff` use — means the scan
+only has to walk back past revisions *newer* than the answer, i.e. its cost is
+proportional to **how far back the question asks**, not to the chain's total
+length. Recent-history questions, the overwhelmingly common audit pattern,
+become cheap; only "what was true right at the start" stays expensive — a
+much better distribution of cost than "always expensive."
+
+## 🔧 Change
+
+`autumn-macros/src/repository.rs`: adds `__autumn_ledger_revision_at`, a new
+generated method that issues the bounded lookup (same guard blocks —
+cross-shard, cross-tenant, tenant setup — as every other ledger query; same
+row shape as `ledger_revisions`, mapped through a new single-row counterpart of
+its row mapper). `ledger_as_of_at` and `ledger_diff_at` now call it instead of
+`ledger_revisions` + `snapshot_as_of`. `ledger_revisions` and `ledger_verify`
+are untouched — they legitimately need the whole chain (verification walks
+every link) and still do.
+
+No migration: the index this query uses
+(`idx_autumn_ledger_revisions_record`) already existed for `ledger_revisions`
+itself. No schema change, no lock beyond the `SELECT`'s own.
+
+---
+
+## 📊 Measurement
+
+`pg_stat_statements`, one run each, reset before the measured call:
+
+| query | depth | before: calls | before: buffers | after: calls | after: buffers | Δ buffers |
+|---|---:|---:|---:|---:|---:|---:|
+| near-head as-of ("5 postings ago") | 300 | 1 | 22 | 1 | 4 | **−82%** |
+| near-head as-of ("5 postings ago") | 700 | 1 | 129 | 1 | 8 | **−94%** |
+| near-head as-of ("5 postings ago") | 1,200 | 1 | 132 | 1 | 8 | **−94%** |
+| worst case: as-of at the FIRST revision | 1,200 | 1 | 132 | 1 | 947 | **+618%** (disclosed) |
+| `ledger_diff` across the last 10 postings | 1,200 | 1 | 129 | 2 | 16 | **−88%** (statements 1→2, disclosed) |
+
+The before column is flat at ~130 buffers regardless of *which* instant is
+asked about — direct evidence the old query ignores `as_of` entirely. The
+after column for the near-head case stays flat at 4–8 buffers **across all
+three chain depths** (300/700/1,200) — the "admissible at ≥3 sizes" bar for a
+plan-shape claim — instead of scaling with depth the way the old plan does
+(22 → 129 → 132).
+
+Temp blocks: zero on every statement, either side (no spill). WAL bytes: N/A
+— this is a read-only change, no write path touched, no index added.
+
+### Disclosed trade-off
+
+Two costs go up, both disclosed rather than hidden:
+
+- **`ledger_diff` issues 2 statements instead of 1** (one bounded lookup per
+  instant, `from` and `to`, instead of one full-chain read shared between
+  them). Buffers still fall sharply (129 → 16) because each lookup is now
+  short — this is a straightforward win, not a wash.
+- **The worst case — asking about a record's very first revision — reads more
+  buffers than before on this fixture (949 vs 132)**, not fewer. Mechanism:
+  `ORDER BY seq DESC LIMIT 1` can only short-circuit when the qualifying row is
+  near the *scan's* end (recent history for a transaction-time bound); asking
+  about the oldest instant forces the backward index scan to walk almost the
+  whole chain, and — because this fixture seeds three chains **concurrently**,
+  so their revisions interleave physically on disk, the same layout concurrent
+  writes to different records produce in a live deployment — each step is a
+  non-contiguous heap fetch. Postgres counts a buffer hit per access, not per
+  distinct page, so revisiting an already-cached page still adds to the count;
+  the old plan's sequential `Seq Scan` touches each page in the (here, small)
+  table exactly once no matter how many distinct records' rows live on it.
+  Note the planner's own **cost** estimate for this query (`0.28..173.56`) is
+  *lower* than the near-head query's is high in the old plan's terms and
+  nowhere close to predicting the 949-buffer actual — another instance of
+  "cost estimates are not evidence."
+
+  This is a real cost, not a rounding artifact, and it does not clear the
+  impact floor on its own. It is accepted here because (a) it is bounded by
+  the record's own chain depth, never larger, and only reachable by a query
+  about a record's *oldest* history; (b) the near-head case — asking about
+  recent state, which is what an as-of audit query does in practice — improves
+  unconditionally at every depth tested; and (c) for the long-tail majority of
+  ledgered records (a handful of revisions, not thousands), there is no
+  meaningful "old vs. recent" distinction to begin with — the bounded query is
+  strictly better there regardless of position. A workload that specifically
+  and frequently queries ancient instants on very deep chains would want a
+  covering index (`INCLUDE`) to eliminate the heap fetches entirely; that is a
+  schema change (`CREATE INDEX`, write cost, migration lock) out of scope for
+  this change and flagged here as a follow-up rather than folded in.
+
+---
+
+## ✅ Equivalence
+
+- **Existing tests pass unchanged.** `tests/sqlite_ledger.rs` (39 tests,
+  including the bitemporal `valid_time` axis, tenant fail-closed reads, the
+  never-returns-a-revision-recorded-after-the-instant invariant, and the
+  golden as-of/diff/verify walk) and `tests/integration/ledger_postgres.rs`
+  (byte-for-byte as-of reconstruction against a live oracle, diff, verify,
+  restore) needed no edits.
+- **This harness self-checks equivalence**: at every depth, the near-head
+  as-of reconstructs `balance_cents` equal to the exact expected revision
+  position; the worst-case as-of reconstructs the insert (`balance_cents ==
+  0`); `ledger_diff` reports exactly the one column that actually changed.
+  These are hard-asserted, not printed.
+- **`ledger_verify`/`ledger_revisions` untouched** — the hash-chain walk and
+  the raw chain listing still read every revision, unconditionally, exactly as
+  before. Only the two callers that only ever needed one revision changed how
+  they fetch it.
+- The SQL predicate change is exactly `snapshot_as_of`'s own selection rule
+  (discard revisions that fail the transaction/valid-time bound, keep the
+  greatest surviving `seq`) moved into the `WHERE`/`ORDER BY`/`LIMIT` clause —
+  `ORDER BY seq DESC LIMIT 1` over a filtered set *is* `max_by_key(seq)` over
+  that set, not an approximation of it.
+
+---
+
+## 🔬 Reproduce
+
+```bash
+# Requires Docker.
+cargo test -p autumn-web --features "test-support" --test integration_tests \
+  -- --ignored ledger_as_of_deep_chain_profile --nocapture --test-threads=1
+
+# Full existing correctness suites, unchanged:
+cargo test -p autumn-web --test sqlite_ledger --features "test-support,sqlite"
+cargo test -p autumn-web --features "test-support" --test integration_tests \
+  -- --ignored ledger_records_chains_and_reconstructs_on_postgres \
+     restore_records_a_revision_on_postgres \
+     verify_detects_a_truncated_tail_on_postgres \
+  --nocapture --test-threads=1
+```
+
+`baseline/output.txt` was captured with the fix's macro change stashed
+(`git stash push -- autumn-macros/src/repository.rs`) and the harness rebuilt;
+`after/output.txt` with it restored — same harness, same fixture-generation
+code, same session.

--- a/docs/reports/2026-09-03-ledger-as-of-deep-chain-bounded-lookup/README.md
+++ b/docs/reports/2026-09-03-ledger-as-of-deep-chain-bounded-lookup/README.md
@@ -23,7 +23,7 @@ reviewer asking about **recent** history far more often than about the
 record's very first state.
 
 Both generated methods are pure functions
-([`snapshot_as_of`](../../autumn/src/ledger.rs)) over whatever
+([`snapshot_as_of`](../../../autumn/src/ledger.rs)) over whatever
 `ledger_revisions(record_id)` returns, and `ledger_revisions` has exactly one
 SQL shape:
 

--- a/docs/reports/2026-09-03-ledger-as-of-deep-chain-bounded-lookup/README.md
+++ b/docs/reports/2026-09-03-ledger-as-of-deep-chain-bounded-lookup/README.md
@@ -4,10 +4,10 @@
 **Target:** `ledger_as_of_at`/`ledger_diff_at`, the generated ledgered-repository
 read path (`autumn-macros/src/repository.rs`)
 **Outcome:** optimization for the realistic query pattern (near-head as-of:
-buffers −82% to −94%, flat regardless of chain depth), with a disclosed
-regression for the pathological worst case (a query about a record's very
-first revision, on a deep, physically-scattered chain: +619% buffers on this
-fixture)
+buffers −82% to −94%, flat regardless of chain depth; `ledger_diff` stays at
+1 statement, buffers −88%), with a disclosed regression for the pathological
+worst case (a query about a record's very first revision, on a deep,
+physically-scattered chain: +618% buffers on this fixture)
 
 ---
 
@@ -117,12 +117,12 @@ revision:
 
 ```
 Limit  (cost=0.28..173.56 rows=1 width=347) (actual rows=1 loops=1)
-  Buffers: shared hit=949
+  Buffers: shared hit=948
   ->  Index Scan Backward using idx_autumn_ledger_revisions_record
         (actual rows=1 loops=1)
         Filter: (recorded_at <= '...')
         Rows Removed by Filter: 1199
-        Buffers: shared hit=949
+        Buffers: shared hit=948
 ```
 
 1,199 of the chain's 1,200 rows still get examined here — asking about the
@@ -151,14 +151,29 @@ much better distribution of cost than "always expensive."
 
 ## 🔧 Change
 
-`autumn-macros/src/repository.rs`: adds `__autumn_ledger_revision_at`, a new
-generated method that issues the bounded lookup (same guard blocks —
-cross-shard, cross-tenant, tenant setup — as every other ledger query; same
-row shape as `ledger_revisions`, mapped through a new single-row counterpart of
-its row mapper). `ledger_as_of_at` and `ledger_diff_at` now call it instead of
-`ledger_revisions` + `snapshot_as_of`. `ledger_revisions` and `ledger_verify`
-are untouched — they legitimately need the whole chain (verification walks
-every link) and still do.
+`autumn-macros/src/repository.rs` adds two new generated methods (same guard
+blocks — cross-shard, cross-tenant, tenant setup — as every other ledger
+query; same row shape as `ledger_revisions`, mapped through new row-mapper
+counterparts):
+
+- `__autumn_ledger_revision_at` issues the bounded lookup for a single
+  instant. `ledger_as_of_at` calls it instead of `ledger_revisions` +
+  `snapshot_as_of`.
+- `__autumn_ledger_diff_revisions_at` resolves **both** endpoints of a diff
+  window from **one** `UNION ALL` statement on **one** connection, rather
+  than two independent bounded lookups. Two separate calls would each take
+  their own snapshot: a write landing between them (or, on a routed read
+  replica, lag advancing between them) could resolve `from` and `to` against
+  two different database states — exactly the class of bug an initial version
+  of this change had, caught in review (see "Equivalence" below). Postgres
+  assigns one snapshot per top-level SQL command even under `READ COMMITTED`,
+  so wrapping both bounded arms in one `UNION ALL` restores the single-snapshot
+  guarantee the old full-chain `ledger_revisions` read had, while keeping each
+  arm's own `ORDER BY seq DESC LIMIT 1`. `ledger_diff_at` calls it instead of
+  `ledger_revisions` + `snapshot_as_of` twice.
+
+`ledger_revisions` and `ledger_verify` are untouched — they legitimately need
+the whole chain (verification walks every link) and still do.
 
 No migration: the index this query uses
 (`idx_autumn_ledger_revisions_record`) already existed for `ledger_revisions`
@@ -172,11 +187,11 @@ itself. No schema change, no lock beyond the `SELECT`'s own.
 
 | query | depth | before: calls | before: buffers | after: calls | after: buffers | Δ buffers |
 |---|---:|---:|---:|---:|---:|---:|
-| near-head as-of ("5 postings ago") | 300 | 1 | 22 | 1 | 4 | **−82%** |
+| near-head as-of ("5 postings ago") | 300 | 1 | 22 | 1 | 3 | **−86%** |
 | near-head as-of ("5 postings ago") | 700 | 1 | 129 | 1 | 8 | **−94%** |
 | near-head as-of ("5 postings ago") | 1,200 | 1 | 132 | 1 | 8 | **−94%** |
-| worst case: as-of at the FIRST revision | 1,200 | 1 | 132 | 1 | 947 | **+618%** (disclosed) |
-| `ledger_diff` across the last 10 postings | 1,200 | 1 | 129 | 2 | 16 | **−88%** (statements 1→2, disclosed) |
+| worst case: as-of at the FIRST revision | 1,200 | 1 | 132 | 1 | 948 | **+618%** (disclosed) |
+| `ledger_diff` across the last 10 postings | 1,200 | 1 | 129 | 1 | 16 | **−88%** |
 
 The before column is flat at ~130 buffers regardless of *which* instant is
 asked about — direct evidence the old query ignores `as_of` entirely. The
@@ -190,14 +205,10 @@ Temp blocks: zero on every statement, either side (no spill). WAL bytes: N/A
 
 ### Disclosed trade-off
 
-Two costs go up, both disclosed rather than hidden:
+One cost goes up, disclosed rather than hidden:
 
-- **`ledger_diff` issues 2 statements instead of 1** (one bounded lookup per
-  instant, `from` and `to`, instead of one full-chain read shared between
-  them). Buffers still fall sharply (129 → 16) because each lookup is now
-  short — this is a straightforward win, not a wash.
 - **The worst case — asking about a record's very first revision — reads more
-  buffers than before on this fixture (949 vs 132)**, not fewer. Mechanism:
+  buffers than before on this fixture (948 vs 132)**, not fewer. Mechanism:
   `ORDER BY seq DESC LIMIT 1` can only short-circuit when the qualifying row is
   near the *scan's* end (recent history for a transaction-time bound); asking
   about the oldest instant forces the backward index scan to walk almost the
@@ -210,7 +221,7 @@ Two costs go up, both disclosed rather than hidden:
   table exactly once no matter how many distinct records' rows live on it.
   Note the planner's own **cost** estimate for this query (`0.28..173.56`) is
   *lower* than the near-head query's is high in the old plan's terms and
-  nowhere close to predicting the 949-buffer actual — another instance of
+  nowhere close to predicting the 948-buffer actual — another instance of
   "cost estimates are not evidence."
 
   This is a real cost, not a rounding artifact, and it does not clear the
@@ -251,6 +262,18 @@ Two costs go up, both disclosed rather than hidden:
   greatest surviving `seq`) moved into the `WHERE`/`ORDER BY`/`LIMIT` clause —
   `ORDER BY seq DESC LIMIT 1` over a filtered set *is* `max_by_key(seq)` over
   that set, not an approximation of it.
+- **Single-snapshot consistency for `ledger_diff_at`.** An initial version of
+  this change gave `ledger_diff_at` two independent bounded-lookup calls (one
+  per endpoint), each on its own connection acquisition — caught in review
+  (Codex, autumn-foundation/autumn#2490) as a correctness regression: a write
+  landing between the two calls, or replica lag advancing between them, could
+  resolve `from` and `to` against two different database states, something the
+  old single `ledger_revisions` read could never do. Fixed by resolving both
+  endpoints from one `UNION ALL` statement on one connection instead
+  (`__autumn_ledger_diff_revisions_at`) — one top-level SQL command takes one
+  snapshot even under `READ COMMITTED`, so both arms see the same state. This
+  also dropped `ledger_diff`'s statement count back to 1 (matching the old
+  behavior exactly, not the 2 an earlier draft of this PR reported).
 
 ---
 

--- a/docs/reports/2026-09-03-ledger-as-of-deep-chain-bounded-lookup/after/output.txt
+++ b/docs/reports/2026-09-03-ledger-as-of-deep-chain-bounded-lookup/after/output.txt
@@ -4,9 +4,9 @@ test integration::ledger_as_of_deep_chain_profile::ledger_as_of_deep_chain_profi
 chain         depth  unbounded calls  unbounded buffers    bounded calls    bounded buffers
 
 === pg_stat_statements: hot-300 (depth 300) near-head as-of ===
-calls=1      buffers=4        SELECT id, table_name, tenant_id, record_id, seq, op, actor, request_id, snapshot, valid_from, recorded_at, prev_hash, hash FROM _autumn_ledger_revisions WHERE table_name = $1 AND record_id = $2 AND ($3::text IS NULL OR tenant_id = $3) AND ($4::timestamptz IS NULL OR recorded_at <= $4) AND ($5::timestamptz IS NULL OR valid_from <= $5) ORDER BY seq DESC LIMIT $6
--- unbounded (ledger_revisions) shape: calls=0 buffers=0 -- bounded (as-of) shape: calls=1 buffers=4 --
-hot-300         300                0                  0                1                  4
+calls=1      buffers=3        SELECT id, table_name, tenant_id, record_id, seq, op, actor, request_id, snapshot, valid_from, recorded_at, prev_hash, hash FROM _autumn_ledger_revisions WHERE table_name = $1 AND record_id = $2 AND ($3::text IS NULL OR tenant_id = $3) AND ($4::timestamptz IS NULL OR recorded_at <= $4) AND ($5::timestamptz IS NULL OR valid_from <= $5) ORDER BY seq DESC LIMIT $6
+-- unbounded (ledger_revisions) shape: calls=0 buffers=0 -- bounded (as-of) shape: calls=1 buffers=3 --
+hot-300         300                0                  0                1                  3
 
 === pg_stat_statements: hot-700 (depth 700) near-head as-of ===
 calls=1      buffers=8        SELECT id, table_name, tenant_id, record_id, seq, op, actor, request_id, snapshot, valid_from, recorded_at, prev_hash, hash FROM _autumn_ledger_revisions WHERE table_name = $1 AND record_id = $2 AND ($3::text IS NULL OR tenant_id = $3) AND ($4::timestamptz IS NULL OR recorded_at <= $4) AND ($5::timestamptz IS NULL OR valid_from <= $5) ORDER BY seq DESC LIMIT $6
@@ -19,23 +19,23 @@ calls=1      buffers=8        SELECT id, table_name, tenant_id, record_id, seq, 
 hot-1200       1200                0                  0                1                  8
 
 === pg_stat_statements: hot-1200 worst case: as-of at the FIRST revision ===
-calls=1      buffers=947      SELECT id, table_name, tenant_id, record_id, seq, op, actor, request_id, snapshot, valid_from, recorded_at, prev_hash, hash FROM _autumn_ledger_revisions WHERE table_name = $1 AND record_id = $2 AND ($3::text IS NULL OR tenant_id = $3) AND ($4::timestamptz IS NULL OR recorded_at <= $4) AND ($5::timestamptz IS NULL OR valid_from <= $5) ORDER BY seq DESC LIMIT $6
--- unbounded (ledger_revisions) shape: calls=0 buffers=0 -- bounded (as-of) shape: calls=1 buffers=947 --
+calls=1      buffers=948      SELECT id, table_name, tenant_id, record_id, seq, op, actor, request_id, snapshot, valid_from, recorded_at, prev_hash, hash FROM _autumn_ledger_revisions WHERE table_name = $1 AND record_id = $2 AND ($3::text IS NULL OR tenant_id = $3) AND ($4::timestamptz IS NULL OR recorded_at <= $4) AND ($5::timestamptz IS NULL OR valid_from <= $5) ORDER BY seq DESC LIMIT $6
+-- unbounded (ledger_revisions) shape: calls=0 buffers=0 -- bounded (as-of) shape: calls=1 buffers=948 --
 
 === pg_stat_statements: hot-1200 ledger_diff across the last 10 postings ===
-calls=2      buffers=16       SELECT id, table_name, tenant_id, record_id, seq, op, actor, request_id, snapshot, valid_from, recorded_at, prev_hash, hash FROM _autumn_ledger_revisions WHERE table_name = $1 AND record_id = $2 AND ($3::text IS NULL OR tenant_id = $3) AND ($4::timestamptz IS NULL OR recorded_at <= $4) AND ($5::timestamptz IS NULL OR valid_from <= $5) ORDER BY seq DESC LIMIT $6
--- unbounded (ledger_revisions) shape: calls=0 buffers=0 -- bounded (as-of) shape: calls=2 buffers=16 --
+calls=1      buffers=16       SELECT * FROM ( SELECT $8 AS which, id, table_name, tenant_id, record_id, seq, op, actor, request_id, snapshot, valid_from, recorded_at, prev_hash, hash FROM _autumn_ledger_revisions WHERE table_name = $1 AND record_id = $2 AND ($3::text IS NULL OR tenant_id = $3) AND ($4::timestamptz IS NULL OR recorded_at <= $4) AND ($5::timestamptz IS NULL OR valid_from <= $5) ORDER BY seq DESC LIMIT $9 ) AS __from_rev UNION ALL SELECT * FROM ( SELECT $10 AS which, id, table_name, tenant_id, record_id, seq, op, actor, request_id, snapshot, valid_from, recorded_at, prev_hash, hash FROM _autumn_ledger_revisions WHERE table_name = $1 AND record_id = $2 AND ($3::text IS NULL OR tenant_id = $3) AND ($6::timestamptz IS NULL OR recorded_at <= $6) AND ($7::timestamptz IS NULL OR valid_from <= $7) ORDER BY seq DESC LIMIT $11 ) AS __to_rev
+-- unbounded (ledger_revisions) shape: calls=0 buffers=0 -- bounded (as-of) shape: calls=1 buffers=16 --
 
--- worst-case (first revision) bounded shape: calls=1 buffers=947 --
+-- worst-case (first revision) bounded shape: calls=1 buffers=948 --
 
 === EXPLAIN (ANALYZE, BUFFERS, VERBOSE, SETTINGS): unbounded ledger_revisions shape -- what ledger_as_of currently reads regardless of `as_of` (hot-1200) ===
 SELECT id, table_name, tenant_id, record_id, seq, op, actor, request_id, snapshot, valid_from, recorded_at, prev_hash, hash FROM _autumn_ledger_revisions WHERE table_name = 'ledger_deep_chain_accounts' AND record_id = 2 AND (NULL::text IS NULL OR tenant_id = NULL) ORDER BY seq ASC
-Sort  (cost=238.87..241.87 rows=1200 width=347) (actual time=0.895..0.967 rows=1200 loops=1)
+Sort  (cost=238.87..241.87 rows=1200 width=347) (actual time=0.822..0.883 rows=1200 loops=1)
   Output: id, table_name, tenant_id, record_id, seq, op, actor, request_id, snapshot, valid_from, recorded_at, prev_hash, hash
   Sort Key: _autumn_ledger_revisions.seq
   Sort Method: quicksort  Memory: 433kB
   Buffers: shared hit=131
-  ->  Seq Scan on public._autumn_ledger_revisions  (cost=0.00..177.50 rows=1200 width=347) (actual time=0.007..0.502 rows=1200 loops=1)
+  ->  Seq Scan on public._autumn_ledger_revisions  (cost=0.00..177.50 rows=1200 width=347) (actual time=0.006..0.502 rows=1200 loops=1)
         Output: id, table_name, tenant_id, record_id, seq, op, actor, request_id, snapshot, valid_from, recorded_at, prev_hash, hash
         Filter: ((_autumn_ledger_revisions.table_name = 'ledger_deep_chain_accounts'::text) AND (_autumn_ledger_revisions.record_id = 2))
         Rows Removed by Filter: 1900
@@ -43,41 +43,41 @@ Sort  (cost=238.87..241.87 rows=1200 width=347) (actual time=0.895..0.967 rows=1
 Query Identifier: -1101199879689280044
 Planning:
   Buffers: shared hit=83
-Planning Time: 0.543 ms
-Execution Time: 1.088 ms
+Planning Time: 0.487 ms
+Execution Time: 0.995 ms
 
-=== EXPLAIN (ANALYZE, BUFFERS, VERBOSE, SETTINGS): bounded as-of shape, near head -- 'what did it look like 5 postings ago' (hot-1200, at=2026-09-03 18:14:13.850509933 UTC) ===
-SELECT id, table_name, tenant_id, record_id, seq, op, actor, request_id, snapshot, valid_from, recorded_at, prev_hash, hash FROM _autumn_ledger_revisions WHERE table_name = 'ledger_deep_chain_accounts' AND record_id = 2 AND (NULL::text IS NULL OR tenant_id = NULL) AND ('2026-09-03T18:14:13.850509933+00:00'::timestamptz IS NULL OR recorded_at <= '2026-09-03T18:14:13.850509933+00:00'::timestamptz) AND (NULL::timestamptz IS NULL OR valid_from <= NULL) ORDER BY seq DESC LIMIT 1
+=== EXPLAIN (ANALYZE, BUFFERS, VERBOSE, SETTINGS): bounded as-of shape, near head -- 'what did it look like 5 postings ago' (hot-1200, at=2026-09-03 20:23:11.129125222 UTC) ===
+SELECT id, table_name, tenant_id, record_id, seq, op, actor, request_id, snapshot, valid_from, recorded_at, prev_hash, hash FROM _autumn_ledger_revisions WHERE table_name = 'ledger_deep_chain_accounts' AND record_id = 2 AND (NULL::text IS NULL OR tenant_id = NULL) AND ('2026-09-03T20:23:11.129125222+00:00'::timestamptz IS NULL OR recorded_at <= '2026-09-03T20:23:11.129125222+00:00'::timestamptz) AND (NULL::timestamptz IS NULL OR valid_from <= NULL) ORDER BY seq DESC LIMIT 1
 Limit  (cost=0.28..0.57 rows=1 width=347) (actual time=0.041..0.041 rows=1 loops=1)
   Output: id, table_name, tenant_id, record_id, seq, op, actor, request_id, snapshot, valid_from, recorded_at, prev_hash, hash
   Buffers: shared hit=11
   ->  Index Scan Backward using idx_autumn_ledger_revisions_record on public._autumn_ledger_revisions  (cost=0.28..350.90 rows=1198 width=347) (actual time=0.040..0.040 rows=1 loops=1)
         Output: id, table_name, tenant_id, record_id, seq, op, actor, request_id, snapshot, valid_from, recorded_at, prev_hash, hash
         Index Cond: ((_autumn_ledger_revisions.table_name = 'ledger_deep_chain_accounts'::text) AND (_autumn_ledger_revisions.record_id = 2))
-        Filter: (_autumn_ledger_revisions.recorded_at <= '2026-09-03 18:14:13.85051+00'::timestamp with time zone)
+        Filter: (_autumn_ledger_revisions.recorded_at <= '2026-09-03 20:23:11.129125+00'::timestamp with time zone)
         Rows Removed by Filter: 5
         Buffers: shared hit=11
 Query Identifier: -7230372579415535019
 Planning:
   Buffers: shared hit=3
-Planning Time: 0.096 ms
+Planning Time: 0.099 ms
 Execution Time: 0.060 ms
 
-=== EXPLAIN (ANALYZE, BUFFERS, VERBOSE, SETTINGS): bounded as-of shape, worst case -- record's first revision (hot-1200, at=2026-09-03 18:14:04.444982494 UTC) ===
-SELECT id, table_name, tenant_id, record_id, seq, op, actor, request_id, snapshot, valid_from, recorded_at, prev_hash, hash FROM _autumn_ledger_revisions WHERE table_name = 'ledger_deep_chain_accounts' AND record_id = 2 AND (NULL::text IS NULL OR tenant_id = NULL) AND ('2026-09-03T18:14:04.444982494+00:00'::timestamptz IS NULL OR recorded_at <= '2026-09-03T18:14:04.444982494+00:00'::timestamptz) AND (NULL::timestamptz IS NULL OR valid_from <= NULL) ORDER BY seq DESC LIMIT 1
-Limit  (cost=0.28..175.59 rows=1 width=347) (actual time=0.372..0.373 rows=1 loops=1)
+=== EXPLAIN (ANALYZE, BUFFERS, VERBOSE, SETTINGS): bounded as-of shape, worst case -- record's first revision (hot-1200, at=2026-09-03 20:23:02.284836344 UTC) ===
+SELECT id, table_name, tenant_id, record_id, seq, op, actor, request_id, snapshot, valid_from, recorded_at, prev_hash, hash FROM _autumn_ledger_revisions WHERE table_name = 'ledger_deep_chain_accounts' AND record_id = 2 AND (NULL::text IS NULL OR tenant_id = NULL) AND ('2026-09-03T20:23:02.284836344+00:00'::timestamptz IS NULL OR recorded_at <= '2026-09-03T20:23:02.284836344+00:00'::timestamptz) AND (NULL::timestamptz IS NULL OR valid_from <= NULL) ORDER BY seq DESC LIMIT 1
+Limit  (cost=0.28..175.59 rows=1 width=347) (actual time=0.430..0.430 rows=1 loops=1)
   Output: id, table_name, tenant_id, record_id, seq, op, actor, request_id, snapshot, valid_from, recorded_at, prev_hash, hash
-  Buffers: shared hit=947
-  ->  Index Scan Backward using idx_autumn_ledger_revisions_record on public._autumn_ledger_revisions  (cost=0.28..350.90 rows=2 width=347) (actual time=0.372..0.372 rows=1 loops=1)
+  Buffers: shared hit=948
+  ->  Index Scan Backward using idx_autumn_ledger_revisions_record on public._autumn_ledger_revisions  (cost=0.28..350.90 rows=2 width=347) (actual time=0.429..0.430 rows=1 loops=1)
         Output: id, table_name, tenant_id, record_id, seq, op, actor, request_id, snapshot, valid_from, recorded_at, prev_hash, hash
         Index Cond: ((_autumn_ledger_revisions.table_name = 'ledger_deep_chain_accounts'::text) AND (_autumn_ledger_revisions.record_id = 2))
-        Filter: (_autumn_ledger_revisions.recorded_at <= '2026-09-03 18:14:04.444982+00'::timestamp with time zone)
+        Filter: (_autumn_ledger_revisions.recorded_at <= '2026-09-03 20:23:02.284836+00'::timestamp with time zone)
         Rows Removed by Filter: 1199
-        Buffers: shared hit=947
+        Buffers: shared hit=948
 Query Identifier: -7230372579415535019
 Planning Time: 0.075 ms
-Execution Time: 0.394 ms
+Execution Time: 0.457 ms
 ok
 
-test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 1924 filtered out; finished in 11.86s
+test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 1924 filtered out; finished in 11.12s
 

--- a/docs/reports/2026-09-03-ledger-as-of-deep-chain-bounded-lookup/after/output.txt
+++ b/docs/reports/2026-09-03-ledger-as-of-deep-chain-bounded-lookup/after/output.txt
@@ -1,0 +1,83 @@
+running 1 test
+test integration::ledger_as_of_deep_chain_profile::ledger_as_of_deep_chain_profile ... 
+=== near-head as-of: statement/buffer scaling across chain depths ===
+chain         depth  unbounded calls  unbounded buffers    bounded calls    bounded buffers
+
+=== pg_stat_statements: hot-300 (depth 300) near-head as-of ===
+calls=1      buffers=4        SELECT id, table_name, tenant_id, record_id, seq, op, actor, request_id, snapshot, valid_from, recorded_at, prev_hash, hash FROM _autumn_ledger_revisions WHERE table_name = $1 AND record_id = $2 AND ($3::text IS NULL OR tenant_id = $3) AND ($4::timestamptz IS NULL OR recorded_at <= $4) AND ($5::timestamptz IS NULL OR valid_from <= $5) ORDER BY seq DESC LIMIT $6
+-- unbounded (ledger_revisions) shape: calls=0 buffers=0 -- bounded (as-of) shape: calls=1 buffers=4 --
+hot-300         300                0                  0                1                  4
+
+=== pg_stat_statements: hot-700 (depth 700) near-head as-of ===
+calls=1      buffers=8        SELECT id, table_name, tenant_id, record_id, seq, op, actor, request_id, snapshot, valid_from, recorded_at, prev_hash, hash FROM _autumn_ledger_revisions WHERE table_name = $1 AND record_id = $2 AND ($3::text IS NULL OR tenant_id = $3) AND ($4::timestamptz IS NULL OR recorded_at <= $4) AND ($5::timestamptz IS NULL OR valid_from <= $5) ORDER BY seq DESC LIMIT $6
+-- unbounded (ledger_revisions) shape: calls=0 buffers=0 -- bounded (as-of) shape: calls=1 buffers=8 --
+hot-700         700                0                  0                1                  8
+
+=== pg_stat_statements: hot-1200 (depth 1200) near-head as-of ===
+calls=1      buffers=8        SELECT id, table_name, tenant_id, record_id, seq, op, actor, request_id, snapshot, valid_from, recorded_at, prev_hash, hash FROM _autumn_ledger_revisions WHERE table_name = $1 AND record_id = $2 AND ($3::text IS NULL OR tenant_id = $3) AND ($4::timestamptz IS NULL OR recorded_at <= $4) AND ($5::timestamptz IS NULL OR valid_from <= $5) ORDER BY seq DESC LIMIT $6
+-- unbounded (ledger_revisions) shape: calls=0 buffers=0 -- bounded (as-of) shape: calls=1 buffers=8 --
+hot-1200       1200                0                  0                1                  8
+
+=== pg_stat_statements: hot-1200 worst case: as-of at the FIRST revision ===
+calls=1      buffers=947      SELECT id, table_name, tenant_id, record_id, seq, op, actor, request_id, snapshot, valid_from, recorded_at, prev_hash, hash FROM _autumn_ledger_revisions WHERE table_name = $1 AND record_id = $2 AND ($3::text IS NULL OR tenant_id = $3) AND ($4::timestamptz IS NULL OR recorded_at <= $4) AND ($5::timestamptz IS NULL OR valid_from <= $5) ORDER BY seq DESC LIMIT $6
+-- unbounded (ledger_revisions) shape: calls=0 buffers=0 -- bounded (as-of) shape: calls=1 buffers=947 --
+
+=== pg_stat_statements: hot-1200 ledger_diff across the last 10 postings ===
+calls=2      buffers=16       SELECT id, table_name, tenant_id, record_id, seq, op, actor, request_id, snapshot, valid_from, recorded_at, prev_hash, hash FROM _autumn_ledger_revisions WHERE table_name = $1 AND record_id = $2 AND ($3::text IS NULL OR tenant_id = $3) AND ($4::timestamptz IS NULL OR recorded_at <= $4) AND ($5::timestamptz IS NULL OR valid_from <= $5) ORDER BY seq DESC LIMIT $6
+-- unbounded (ledger_revisions) shape: calls=0 buffers=0 -- bounded (as-of) shape: calls=2 buffers=16 --
+
+-- worst-case (first revision) bounded shape: calls=1 buffers=947 --
+
+=== EXPLAIN (ANALYZE, BUFFERS, VERBOSE, SETTINGS): unbounded ledger_revisions shape -- what ledger_as_of currently reads regardless of `as_of` (hot-1200) ===
+SELECT id, table_name, tenant_id, record_id, seq, op, actor, request_id, snapshot, valid_from, recorded_at, prev_hash, hash FROM _autumn_ledger_revisions WHERE table_name = 'ledger_deep_chain_accounts' AND record_id = 2 AND (NULL::text IS NULL OR tenant_id = NULL) ORDER BY seq ASC
+Sort  (cost=238.87..241.87 rows=1200 width=347) (actual time=0.895..0.967 rows=1200 loops=1)
+  Output: id, table_name, tenant_id, record_id, seq, op, actor, request_id, snapshot, valid_from, recorded_at, prev_hash, hash
+  Sort Key: _autumn_ledger_revisions.seq
+  Sort Method: quicksort  Memory: 433kB
+  Buffers: shared hit=131
+  ->  Seq Scan on public._autumn_ledger_revisions  (cost=0.00..177.50 rows=1200 width=347) (actual time=0.007..0.502 rows=1200 loops=1)
+        Output: id, table_name, tenant_id, record_id, seq, op, actor, request_id, snapshot, valid_from, recorded_at, prev_hash, hash
+        Filter: ((_autumn_ledger_revisions.table_name = 'ledger_deep_chain_accounts'::text) AND (_autumn_ledger_revisions.record_id = 2))
+        Rows Removed by Filter: 1900
+        Buffers: shared hit=131
+Query Identifier: -1101199879689280044
+Planning:
+  Buffers: shared hit=83
+Planning Time: 0.543 ms
+Execution Time: 1.088 ms
+
+=== EXPLAIN (ANALYZE, BUFFERS, VERBOSE, SETTINGS): bounded as-of shape, near head -- 'what did it look like 5 postings ago' (hot-1200, at=2026-09-03 18:14:13.850509933 UTC) ===
+SELECT id, table_name, tenant_id, record_id, seq, op, actor, request_id, snapshot, valid_from, recorded_at, prev_hash, hash FROM _autumn_ledger_revisions WHERE table_name = 'ledger_deep_chain_accounts' AND record_id = 2 AND (NULL::text IS NULL OR tenant_id = NULL) AND ('2026-09-03T18:14:13.850509933+00:00'::timestamptz IS NULL OR recorded_at <= '2026-09-03T18:14:13.850509933+00:00'::timestamptz) AND (NULL::timestamptz IS NULL OR valid_from <= NULL) ORDER BY seq DESC LIMIT 1
+Limit  (cost=0.28..0.57 rows=1 width=347) (actual time=0.041..0.041 rows=1 loops=1)
+  Output: id, table_name, tenant_id, record_id, seq, op, actor, request_id, snapshot, valid_from, recorded_at, prev_hash, hash
+  Buffers: shared hit=11
+  ->  Index Scan Backward using idx_autumn_ledger_revisions_record on public._autumn_ledger_revisions  (cost=0.28..350.90 rows=1198 width=347) (actual time=0.040..0.040 rows=1 loops=1)
+        Output: id, table_name, tenant_id, record_id, seq, op, actor, request_id, snapshot, valid_from, recorded_at, prev_hash, hash
+        Index Cond: ((_autumn_ledger_revisions.table_name = 'ledger_deep_chain_accounts'::text) AND (_autumn_ledger_revisions.record_id = 2))
+        Filter: (_autumn_ledger_revisions.recorded_at <= '2026-09-03 18:14:13.85051+00'::timestamp with time zone)
+        Rows Removed by Filter: 5
+        Buffers: shared hit=11
+Query Identifier: -7230372579415535019
+Planning:
+  Buffers: shared hit=3
+Planning Time: 0.096 ms
+Execution Time: 0.060 ms
+
+=== EXPLAIN (ANALYZE, BUFFERS, VERBOSE, SETTINGS): bounded as-of shape, worst case -- record's first revision (hot-1200, at=2026-09-03 18:14:04.444982494 UTC) ===
+SELECT id, table_name, tenant_id, record_id, seq, op, actor, request_id, snapshot, valid_from, recorded_at, prev_hash, hash FROM _autumn_ledger_revisions WHERE table_name = 'ledger_deep_chain_accounts' AND record_id = 2 AND (NULL::text IS NULL OR tenant_id = NULL) AND ('2026-09-03T18:14:04.444982494+00:00'::timestamptz IS NULL OR recorded_at <= '2026-09-03T18:14:04.444982494+00:00'::timestamptz) AND (NULL::timestamptz IS NULL OR valid_from <= NULL) ORDER BY seq DESC LIMIT 1
+Limit  (cost=0.28..175.59 rows=1 width=347) (actual time=0.372..0.373 rows=1 loops=1)
+  Output: id, table_name, tenant_id, record_id, seq, op, actor, request_id, snapshot, valid_from, recorded_at, prev_hash, hash
+  Buffers: shared hit=947
+  ->  Index Scan Backward using idx_autumn_ledger_revisions_record on public._autumn_ledger_revisions  (cost=0.28..350.90 rows=2 width=347) (actual time=0.372..0.372 rows=1 loops=1)
+        Output: id, table_name, tenant_id, record_id, seq, op, actor, request_id, snapshot, valid_from, recorded_at, prev_hash, hash
+        Index Cond: ((_autumn_ledger_revisions.table_name = 'ledger_deep_chain_accounts'::text) AND (_autumn_ledger_revisions.record_id = 2))
+        Filter: (_autumn_ledger_revisions.recorded_at <= '2026-09-03 18:14:04.444982+00'::timestamp with time zone)
+        Rows Removed by Filter: 1199
+        Buffers: shared hit=947
+Query Identifier: -7230372579415535019
+Planning Time: 0.075 ms
+Execution Time: 0.394 ms
+ok
+
+test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 1924 filtered out; finished in 11.86s
+

--- a/docs/reports/2026-09-03-ledger-as-of-deep-chain-bounded-lookup/baseline/output.txt
+++ b/docs/reports/2026-09-03-ledger-as-of-deep-chain-bounded-lookup/baseline/output.txt
@@ -1,0 +1,83 @@
+running 1 test
+test integration::ledger_as_of_deep_chain_profile::ledger_as_of_deep_chain_profile ... 
+=== near-head as-of: statement/buffer scaling across chain depths ===
+chain         depth  unbounded calls  unbounded buffers    bounded calls    bounded buffers
+
+=== pg_stat_statements: hot-300 (depth 300) near-head as-of ===
+calls=1      buffers=22       SELECT id, table_name, tenant_id, record_id, seq, op, actor, request_id, snapshot, valid_from, recorded_at, prev_hash, hash FROM _autumn_ledger_revisions WHERE table_name = $1 AND record_id = $2 AND ($3::text IS NULL OR tenant_id = $3) ORDER BY seq ASC
+-- unbounded (ledger_revisions) shape: calls=1 buffers=22 -- bounded (as-of) shape: calls=0 buffers=0 --
+hot-300         300                1                 22                0                  0
+
+=== pg_stat_statements: hot-700 (depth 700) near-head as-of ===
+calls=1      buffers=129      SELECT id, table_name, tenant_id, record_id, seq, op, actor, request_id, snapshot, valid_from, recorded_at, prev_hash, hash FROM _autumn_ledger_revisions WHERE table_name = $1 AND record_id = $2 AND ($3::text IS NULL OR tenant_id = $3) ORDER BY seq ASC
+-- unbounded (ledger_revisions) shape: calls=1 buffers=129 -- bounded (as-of) shape: calls=0 buffers=0 --
+hot-700         700                1                129                0                  0
+
+=== pg_stat_statements: hot-1200 (depth 1200) near-head as-of ===
+calls=1      buffers=132      SELECT id, table_name, tenant_id, record_id, seq, op, actor, request_id, snapshot, valid_from, recorded_at, prev_hash, hash FROM _autumn_ledger_revisions WHERE table_name = $1 AND record_id = $2 AND ($3::text IS NULL OR tenant_id = $3) ORDER BY seq ASC
+-- unbounded (ledger_revisions) shape: calls=1 buffers=132 -- bounded (as-of) shape: calls=0 buffers=0 --
+hot-1200       1200                1                132                0                  0
+
+=== pg_stat_statements: hot-1200 worst case: as-of at the FIRST revision ===
+calls=1      buffers=132      SELECT id, table_name, tenant_id, record_id, seq, op, actor, request_id, snapshot, valid_from, recorded_at, prev_hash, hash FROM _autumn_ledger_revisions WHERE table_name = $1 AND record_id = $2 AND ($3::text IS NULL OR tenant_id = $3) ORDER BY seq ASC
+-- unbounded (ledger_revisions) shape: calls=1 buffers=132 -- bounded (as-of) shape: calls=0 buffers=0 --
+
+=== pg_stat_statements: hot-1200 ledger_diff across the last 10 postings ===
+calls=1      buffers=129      SELECT id, table_name, tenant_id, record_id, seq, op, actor, request_id, snapshot, valid_from, recorded_at, prev_hash, hash FROM _autumn_ledger_revisions WHERE table_name = $1 AND record_id = $2 AND ($3::text IS NULL OR tenant_id = $3) ORDER BY seq ASC
+-- unbounded (ledger_revisions) shape: calls=1 buffers=129 -- bounded (as-of) shape: calls=0 buffers=0 --
+
+-- worst-case (first revision) bounded shape: calls=0 buffers=0 --
+
+=== EXPLAIN (ANALYZE, BUFFERS, VERBOSE, SETTINGS): unbounded ledger_revisions shape -- what ledger_as_of currently reads regardless of `as_of` (hot-1200) ===
+SELECT id, table_name, tenant_id, record_id, seq, op, actor, request_id, snapshot, valid_from, recorded_at, prev_hash, hash FROM _autumn_ledger_revisions WHERE table_name = 'ledger_deep_chain_accounts' AND record_id = 3 AND (NULL::text IS NULL OR tenant_id = NULL) ORDER BY seq ASC
+Sort  (cost=236.87..239.87 rows=1200 width=347) (actual time=0.825..0.889 rows=1200 loops=1)
+  Output: id, table_name, tenant_id, record_id, seq, op, actor, request_id, snapshot, valid_from, recorded_at, prev_hash, hash
+  Sort Key: _autumn_ledger_revisions.seq
+  Sort Method: quicksort  Memory: 433kB
+  Buffers: shared hit=129
+  ->  Seq Scan on public._autumn_ledger_revisions  (cost=0.00..175.50 rows=1200 width=347) (actual time=0.007..0.474 rows=1200 loops=1)
+        Output: id, table_name, tenant_id, record_id, seq, op, actor, request_id, snapshot, valid_from, recorded_at, prev_hash, hash
+        Filter: ((_autumn_ledger_revisions.table_name = 'ledger_deep_chain_accounts'::text) AND (_autumn_ledger_revisions.record_id = 3))
+        Rows Removed by Filter: 1900
+        Buffers: shared hit=129
+Query Identifier: -1101199879689280044
+Planning:
+  Buffers: shared hit=83
+Planning Time: 0.560 ms
+Execution Time: 1.011 ms
+
+=== EXPLAIN (ANALYZE, BUFFERS, VERBOSE, SETTINGS): bounded as-of shape, near head -- 'what did it look like 5 postings ago' (hot-1200, at=2026-09-03 17:46:44.426947605 UTC) ===
+SELECT id, table_name, tenant_id, record_id, seq, op, actor, request_id, snapshot, valid_from, recorded_at, prev_hash, hash FROM _autumn_ledger_revisions WHERE table_name = 'ledger_deep_chain_accounts' AND record_id = 3 AND (NULL::text IS NULL OR tenant_id = NULL) AND ('2026-09-03T17:46:44.426947605+00:00'::timestamptz IS NULL OR recorded_at <= '2026-09-03T17:46:44.426947605+00:00'::timestamptz) AND (NULL::timestamptz IS NULL OR valid_from <= NULL) ORDER BY seq DESC LIMIT 1
+Limit  (cost=0.28..0.57 rows=1 width=347) (actual time=0.047..0.047 rows=1 loops=1)
+  Output: id, table_name, tenant_id, record_id, seq, op, actor, request_id, snapshot, valid_from, recorded_at, prev_hash, hash
+  Buffers: shared hit=11
+  ->  Index Scan Backward using idx_autumn_ledger_revisions_record on public._autumn_ledger_revisions  (cost=0.28..346.84 rows=1198 width=347) (actual time=0.046..0.046 rows=1 loops=1)
+        Output: id, table_name, tenant_id, record_id, seq, op, actor, request_id, snapshot, valid_from, recorded_at, prev_hash, hash
+        Index Cond: ((_autumn_ledger_revisions.table_name = 'ledger_deep_chain_accounts'::text) AND (_autumn_ledger_revisions.record_id = 3))
+        Filter: (_autumn_ledger_revisions.recorded_at <= '2026-09-03 17:46:44.426948+00'::timestamp with time zone)
+        Rows Removed by Filter: 5
+        Buffers: shared hit=11
+Query Identifier: -7230372579415535019
+Planning:
+  Buffers: shared hit=3
+Planning Time: 0.114 ms
+Execution Time: 0.069 ms
+
+=== EXPLAIN (ANALYZE, BUFFERS, VERBOSE, SETTINGS): bounded as-of shape, worst case -- record's first revision (hot-1200, at=2026-09-03 17:46:35.434022670 UTC) ===
+SELECT id, table_name, tenant_id, record_id, seq, op, actor, request_id, snapshot, valid_from, recorded_at, prev_hash, hash FROM _autumn_ledger_revisions WHERE table_name = 'ledger_deep_chain_accounts' AND record_id = 3 AND (NULL::text IS NULL OR tenant_id = NULL) AND ('2026-09-03T17:46:35.434022670+00:00'::timestamptz IS NULL OR recorded_at <= '2026-09-03T17:46:35.434022670+00:00'::timestamptz) AND (NULL::timestamptz IS NULL OR valid_from <= NULL) ORDER BY seq DESC LIMIT 1
+Limit  (cost=0.28..173.56 rows=1 width=347) (actual time=0.389..0.389 rows=1 loops=1)
+  Output: id, table_name, tenant_id, record_id, seq, op, actor, request_id, snapshot, valid_from, recorded_at, prev_hash, hash
+  Buffers: shared hit=949
+  ->  Index Scan Backward using idx_autumn_ledger_revisions_record on public._autumn_ledger_revisions  (cost=0.28..346.84 rows=2 width=347) (actual time=0.388..0.388 rows=1 loops=1)
+        Output: id, table_name, tenant_id, record_id, seq, op, actor, request_id, snapshot, valid_from, recorded_at, prev_hash, hash
+        Index Cond: ((_autumn_ledger_revisions.table_name = 'ledger_deep_chain_accounts'::text) AND (_autumn_ledger_revisions.record_id = 3))
+        Filter: (_autumn_ledger_revisions.recorded_at <= '2026-09-03 17:46:35.434023+00'::timestamp with time zone)
+        Rows Removed by Filter: 1199
+        Buffers: shared hit=949
+Query Identifier: -7230372579415535019
+Planning Time: 0.137 ms
+Execution Time: 0.421 ms
+ok
+
+test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 1924 filtered out; finished in 11.72s
+


### PR DESCRIPTION
## Summary

`ledger_as_of`/`ledger_diff` — the generated read path for a
`#[repository(ledgered = true)]` entity's bitemporal, tamper-evident revision
ledger (issue #1699) — answered "what did this record look like at instant X"
by reading **every** stored revision of the record (full snapshot column
included) via `ledger_revisions`, regardless of which instant was asked about.
For a hot ledgered record (an account, invoice, or contract — exactly the
shape the feature exists for), a compliance/audit query about *recent* history
paid for reading the record's entire history.

Both now issue a bounded `ORDER BY seq DESC LIMIT 1` lookup instead, using the
same index `ledger_revisions` already relied on
(`idx_autumn_ledger_revisions_record`) — no migration, no new index, no schema
change. Because transaction time is monotonic in `seq` (#2323), the new
query's cost is proportional to how far back the question asks, not to the
chain's total length. `ledger_revisions`/`ledger_verify` are untouched — they
legitimately need the whole chain and still read it.

## 🎯 Workload / 📈 Profile / 🧭 Plan / 💡 Hypothesis / 🔧 Change / 📊 Measurement / ✅ Equivalence / 🔬 Reproduce

Full report, with `EXPLAIN (ANALYZE, BUFFERS, VERBOSE, SETTINGS)` plans and
the complete measurement table:
[`docs/reports/2026-09-03-ledger-as-of-deep-chain-bounded-lookup/README.md`](docs/reports/2026-09-03-ledger-as-of-deep-chain-bounded-lookup/README.md)

Headline numbers (`pg_stat_statements`, testcontainer Postgres, three ledgered
chains written through the real `save`/`update` path at 300/700/1,200
revisions, seeded concurrently so their revisions interleave physically —
same layout concurrent writes to different records produce live — plus a
150-account/6-revision-each long tail):

| query | depth | before buffers | after buffers | Δ |
|---|---:|---:|---:|---:|
| near-head as-of ("5 postings ago") | 300 | 22 | 4 | **-82%** |
| near-head as-of ("5 postings ago") | 700 | 129 | 8 | **-94%** |
| near-head as-of ("5 postings ago") | 1,200 | 132 | 8 | **-94%** |
| `ledger_diff` (last 10 postings) | 1,200 | 129 (1 stmt) | 16 (2 stmts) | **-88%** |
| worst case: as-of at the FIRST revision | 1,200 | 132 | 947 | **+618%** (disclosed) |

The before column is flat (~130 buffers) regardless of *which* instant is
asked about — direct evidence the old query ignores `as_of` entirely. The
after column for the realistic near-head case stays flat (4–8 buffers)
**across all three chain depths tested**, instead of scaling with depth.

### Disclosed trade-off

Two costs go up, on purpose, not hidden:

- `ledger_diff` now issues 2 statements instead of 1 (one bounded lookup per
  instant). Buffers still fall sharply (129 → 16).
- **The pathological worst case — asking about a record's very first
  revision on a deep chain — reads *more* buffers than before** (947 vs 132 on
  this fixture). `ORDER BY seq DESC LIMIT 1` can only short-circuit when the
  qualifying row sits near the scan's own end; asking about the oldest instant
  forces a near-full backward index scan, and because this fixture's chains
  are seeded concurrently (the same physical interleaving concurrent writes to
  different records produce live), each step is a non-contiguous heap fetch —
  Postgres counts a buffer hit per access, not per distinct page, unlike the
  old plan's single sequential `Seq Scan`.

  Accepted because it's bounded by the record's own chain depth, only
  reachable by a query about a record's *oldest* history, and the realistic
  audit pattern (recent history) improves unconditionally at every depth
  tested. A workload that specifically needs fast "oldest revision" lookups on
  very deep chains would want a covering index — a separate, write-cost-bearing
  decision, flagged here as a follow-up rather than folded in.

## Equivalence

- `tests/sqlite_ledger.rs` (39 tests — bitemporal `valid_time` axis, tenant
  fail-closed reads, the never-returns-a-revision-recorded-after-the-instant
  invariant, golden as-of/diff/verify walk) and
  `tests/integration/ledger_postgres.rs` (10 tests — byte-for-byte as-of
  reconstruction against a live oracle, diff, verify, restore) pass
  **unchanged**, no edits.
- The new harness (`autumn/tests/integration/ledger_as_of_deep_chain_profile.rs`)
  hard-asserts the exact reconstructed value at every sampled instant and the
  diff's single changed column.
- `ORDER BY seq DESC LIMIT 1` over the SQL predicate mirroring
  `snapshot_as_of`'s own in-memory filter *is* `max_by_key(seq)` over the
  qualifying rows — not an approximation of it.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p autumn-macros --all-targets -- -D warnings` (clean; the
      one `unknown_lints` warning is the pre-existing, unrelated
      `clippy::unused_async_trait_impl` noted in #2295/#2298/#2304)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` (clean, run with
      reduced parallelism due to sandbox memory limits — same result)
- [x] `cargo clippy -p autumn-web --features "ws,mail,offline-sync,redis,markdown,inbound-mail,inbound-mailgun,inbound-ses,storage,tls,acme" --lib -- -D warnings` (clean)
- [x] `cargo test -p autumn-web --test sqlite_ledger --features "test-support,sqlite"` — 39/39 pass
- [x] `cargo test -p autumn-web --test integration_tests --features test-support -- --ignored ledger_postgres --nocapture --test-threads=1` — 10/10 pass
- [x] `cargo test -p autumn-web --test integration_tests --features test-support -- --ignored ledger_as_of_deep_chain_profile --nocapture --test-threads=1` — new harness passes
- [x] `cargo test -p autumn-macros --lib` — 1044/1044 pass (macro codegen unit tests, incl. `repository_macro_ledgered_generates_the_query_surface`)
- [ ] `cargo test --workspace --no-run` (full workspace compile-only sweep) —
      **not completed**: this sandbox's disk allowance was exhausted partway
      through (examples + trybuild-adjacent targets), independent of this
      change's content. CI's `test` job runs on a properly-provisioned runner
      and will catch anything this couldn't.

Requires Docker for the ledger integration tests above (testcontainers,
Postgres 16 + `pg_stat_statements`); CI picks up
`ledger_as_of_deep_chain_profile` automatically via its Docker-dependent
`--ignored` sweep, no workflow edit needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S2TWKSiEjrJkkDgTriTZ63

---
_Generated by [Claude Code](https://claude.ai/code/session_01S2TWKSiEjrJkkDgTriTZ63)_