### PR TITLE
🛣️ Onramp: autumn setup retries a dropped Tailwind download (quickstart setup: flaky→robust)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1490,6 +1490,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **🛣️ Onramp: `autumn setup` retries a dropped Tailwind CSS download instead
+  of failing the whole quickstart [no-plugin]:** `autumn setup` — the second
+  documented command in the README quickstart, right after `autumn new` — did
+  a single unretried `GET` for both the Tailwind CSS checksums manifest and
+  the ~10MB platform binary (`autumn-cli/src/http.rs`); any transient
+  transport hiccup (a truncated body, a dropped connection) aborted the whole
+  command with a bare `Error: download failed: error decoding response body`
+  and no second chance. This is not hypothetical: 2 of the last 3
+  `quickstart-gate.yml` runs against published crates.io on 2026-09-03 (runs
+  33784307158 at 17:23 UTC and 33805758766 at 21:02 UTC) failed at exactly
+  this step with exactly this error, with the passing run in between
+  (33797353571, 19:35 UTC) at the same commit — confirming the failure is
+  transient CDN flakiness, not a real break, and that a real fraction of
+  fresh `autumn setup` runs hit it. `fetch_bytes` and the new `fetch_text`
+  (both in `autumn-cli/src/http.rs`, shared by `autumn setup` and `autumn
+  assets`) now retry up to 3 times with a 2s backoff on any non-HTTP-status
+  error (a definitive 404/5xx is not retried — retrying it would just waste
+  the user's time); the retry/backoff bookkeeping is exercised by 4 unit
+  tests against fake failing/succeeding closures, no real networking
+  involved. No public API changed — `fetch_bytes`'s signature and error type
+  are unchanged, `fetch_text` is a new addition. No plugin-facing surface;
+  this is a CLI robustness fix, not new framework surface.
+
 - **`--counter-cache` scaffolds compiled clean now (#2431):** `autumn generate
   scaffold Comment ... --belongs-to Post --counter-cache` — the documented,
   only way to use the flag — generated a child model that failed `cargo check`

--- a/autumn-cli/src/http.rs
+++ b/autumn-cli/src/http.rs
@@ -1,13 +1,52 @@
-//! Shared HTTP download helper used by `autumn setup` and `autumn assets`.
+//! Shared HTTP download helpers used by `autumn setup` and `autumn assets`.
+
+use std::fmt;
+use std::thread::sleep;
+use std::time::Duration;
 
 use indicatif::{ProgressBar, ProgressStyle};
 
+/// Retry budget for transient network failures during `autumn setup` /
+/// `autumn assets`.
+///
+/// A single dropped byte mid-transfer from a release CDN used to abort the
+/// whole documented quickstart with a bare `download failed: error decoding
+/// response body` and no second chance — 2 of 3 `quickstart-gate.yml` runs on
+/// 2026-09-03 hit exactly this on the `autumn setup` step
+/// (runs 33784307158, 33805758766; run 33797353571 in between passed with no
+/// code change in between, confirming it's transient, not a real break).
+/// Three attempts with a short backoff resolve almost all of them before the
+/// user ever sees an error.
+const MAX_ATTEMPTS: u32 = 3;
+const RETRY_DELAY: Duration = Duration::from_secs(2);
+
 /// Download `url` with a progress bar and return the response body as bytes.
+/// Retries transient failures (see [`MAX_ATTEMPTS`]) before giving up.
 ///
 /// Returns `Err(reqwest::Error)` so callers can convert with `?` into their
 /// own error type (both [`crate::setup::SetupError`] and
 /// [`crate::assets::AssetsError`] wrap `reqwest::Error` via `#[from]`).
 pub fn fetch_bytes(url: &str) -> Result<Vec<u8>, reqwest::Error> {
+    retry_transient(
+        MAX_ATTEMPTS,
+        RETRY_DELAY,
+        |e: &reqwest::Error| !e.is_status(),
+        || fetch_bytes_once(url),
+    )
+}
+
+/// Fetch `url` as UTF-8 text (used for the small Tailwind checksums
+/// manifest). Retries transient failures the same as [`fetch_bytes`].
+pub fn fetch_text(url: &str) -> Result<String, reqwest::Error> {
+    retry_transient(
+        MAX_ATTEMPTS,
+        RETRY_DELAY,
+        |e: &reqwest::Error| !e.is_status(),
+        || fetch_text_once(url),
+    )
+}
+
+fn fetch_bytes_once(url: &str) -> Result<Vec<u8>, reqwest::Error> {
     let response = reqwest::blocking::Client::builder()
         .timeout(std::time::Duration::from_secs(30))
         .build()?
@@ -27,4 +66,120 @@ pub fn fetch_bytes(url: &str) -> Result<Vec<u8>, reqwest::Error> {
     pb.set_length(bytes.len() as u64);
     pb.finish_and_clear();
     Ok(bytes.to_vec())
+}
+
+fn fetch_text_once(url: &str) -> Result<String, reqwest::Error> {
+    reqwest::blocking::Client::builder()
+        .timeout(std::time::Duration::from_secs(30))
+        .build()?
+        .get(url)
+        .send()?
+        .error_for_status()?
+        .text()
+}
+
+/// Retry `attempt` up to `max_attempts` times, waiting `delay` between tries,
+/// as long as `is_retryable` says the error is worth retrying. Returns the
+/// last error once attempts (or retryability) are exhausted.
+///
+/// Generic over the error type and injected purely so the retry/backoff
+/// bookkeeping can be exercised in tests without any real networking.
+fn retry_transient<T, E: fmt::Display>(
+    max_attempts: u32,
+    delay: Duration,
+    is_retryable: impl Fn(&E) -> bool,
+    mut attempt: impl FnMut() -> Result<T, E>,
+) -> Result<T, E> {
+    let mut last_err = None;
+    for n in 1..=max_attempts {
+        match attempt() {
+            Ok(v) => return Ok(v),
+            Err(e) => {
+                let will_retry = n < max_attempts && is_retryable(&e);
+                if will_retry {
+                    eprintln!("  download attempt {n}/{max_attempts} failed ({e}), retrying...");
+                    sleep(delay);
+                }
+                last_err = Some(e);
+                if !will_retry {
+                    break;
+                }
+            }
+        }
+    }
+    Err(last_err.expect("max_attempts >= 1, so the loop runs at least once"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::cell::Cell;
+
+    #[test]
+    fn retry_transient_recovers_after_transient_failures() {
+        let calls = Cell::new(0);
+        let result: Result<i32, &str> = retry_transient(
+            3,
+            Duration::from_millis(1),
+            |_| true,
+            || {
+                calls.set(calls.get() + 1);
+                if calls.get() < 3 {
+                    Err("transient")
+                } else {
+                    Ok(42)
+                }
+            },
+        );
+        assert_eq!(result, Ok(42));
+        assert_eq!(calls.get(), 3);
+    }
+
+    #[test]
+    fn retry_transient_gives_up_after_max_attempts() {
+        let calls = Cell::new(0);
+        let result: Result<i32, &str> = retry_transient(
+            3,
+            Duration::from_millis(1),
+            |_| true,
+            || {
+                calls.set(calls.get() + 1);
+                Err("still failing")
+            },
+        );
+        assert_eq!(result, Err("still failing"));
+        assert_eq!(calls.get(), 3);
+    }
+
+    #[test]
+    fn retry_transient_does_not_retry_non_retryable_errors() {
+        let calls = Cell::new(0);
+        let result: Result<i32, &str> = retry_transient(
+            3,
+            Duration::from_millis(1),
+            |_| false,
+            || {
+                calls.set(calls.get() + 1);
+                Err("404 not found")
+            },
+        );
+        assert_eq!(result, Err("404 not found"));
+        assert_eq!(calls.get(), 1, "a non-retryable error must not be retried");
+    }
+
+    #[test]
+    fn retry_transient_succeeds_on_first_try_without_delay() {
+        let calls = Cell::new(0);
+        let result: Result<i32, &str> = retry_transient(
+            3,
+            Duration::from_secs(60),
+            |_| true,
+            || {
+                calls.set(calls.get() + 1);
+                Ok(7)
+            },
+        );
+        assert_eq!(result, Ok(7));
+        assert_eq!(calls.get(), 1);
+    }
 }

--- a/autumn-cli/src/setup.rs
+++ b/autumn-cli/src/setup.rs
@@ -124,7 +124,7 @@ fn install_path(dir: &Path) -> PathBuf {
 }
 
 fn fetch_expected_checksum(url: &str, binary_name: &str) -> Result<String, SetupError> {
-    let body = reqwest::blocking::get(url)?.error_for_status()?.text()?;
+    let body = crate::http::fetch_text(url)?;
     parse_checksum_file(&body, binary_name)
 }
 


### PR DESCRIPTION
## 🎯 Journey

**First run** — the README quickstart. `autumn setup` is the *second*
documented command, immediately after `autumn new`:

```bash
cargo install autumn-cli --version 0.7.0
autumn new my-app
cd my-app
autumn setup   # <- fails here, intermittently
autumn dev
```

Weight: this exact sequence is gated by its own dedicated CI workflow,
`.github/workflows/quickstart-gate.yml`, which runs the README's commands
verbatim against **published crates.io** (not the in-tree `[patch.crates-io]`
override every other CI job uses) on every `trunk-dev` push and a daily
schedule. It is, by design, the literal front door.

Reproduce: `scripts/check-quickstart.sh install && scripts/check-quickstart.sh new && scripts/check-quickstart.sh setup` from a clean checkout outside this repo (`QUICKSTART_STATE_DIR` set outside the workspace so the patch override can't leak in), or just watch the next few scheduled runs of `quickstart-gate.yml`.

## 📈 Evidence

**Tier 1, from the existing harness — no new harness needed.** 2 of the last
3 `quickstart-gate.yml` runs on 2026-09-03 failed at the `setup` step:

| Run | Time (UTC) | `setup` step |
|---|---|---|
| [33784307158](https://github.com/autumn-foundation/autumn/actions/runs/33784307158) | 17:23 | ❌ `Error: download failed: error decoding response body` |
| [33797353571](https://github.com/autumn-foundation/autumn/actions/runs/33797353571) | 19:35 | ✅ passed |
| [33805758766](https://github.com/autumn-foundation/autumn/actions/runs/33805758766) | 21:02 | ❌ `Error: download failed: error decoding response body` |

Same commit range, no code change between the pass and the two failures —
this rules out a real regression and confirms transient CDN flakiness on the
Tailwind CSS release download. A hard failure on the documented path, ~2/3
of observed runs, clears the impact floor on its own.

## 💡 Hypothesis

`autumn-cli/src/http.rs::fetch_bytes` (the ~10MB platform Tailwind binary)
and `setup.rs`'s inline `reqwest::blocking::get` (the small checksums
manifest) each make **exactly one** HTTP request, no retry. Any transient
transport hiccup — a truncated body, a dropped connection — aborts the whole
`autumn setup` command with a bare, non-actionable error and zero recovery,
even though (per the passing run above) a retry a few seconds later usually
just works.

## 🔧 Change

**Layer: the default.** A good default (retry transient failures) deletes
the failure for affected users without adding a step, a flag, or a config
option. `autumn-cli/src/http.rs` gains a small generic `retry_transient`
helper (3 attempts, 2s backoff, skips retrying a definitive HTTP status —
retrying a real 404/5xx wastes the user's time instead of helping them) and
a new `fetch_text` alongside the existing `fetch_bytes`. `setup.rs`'s
checksum fetch now goes through `fetch_text` instead of its own bare
`reqwest::blocking::get`, so both network calls on the setup path get the
same protection.

**Compatibility:** `fetch_bytes`'s signature and error type (`reqwest::Error`)
are unchanged; `fetch_text` is a pure addition. Nothing public in
`autumn-web`/`autumn-macros` touched — this is CLI-internal.

## 📊 Measurement

The retry/backoff bookkeeping is unit-tested in isolation — 4 new tests in
`http.rs` against fake failing/succeeding closures, no real networking,
deterministic:

- recovers once a transient failure clears within the attempt budget
- still reports the error once the budget is exhausted (no infinite retry)
- never retries a non-retryable (HTTP-status) error
- costs zero delay on a first-try success

```
running 4 tests
test http::tests::retry_transient_does_not_retry_non_retryable_errors ... ok
test http::tests::retry_transient_succeeds_on_first_try_without_delay ... ok
test http::tests::retry_transient_gives_up_after_max_attempts ... ok
test http::tests::retry_transient_recovers_after_transient_failures ... ok
```

`cargo test -p autumn-cli --bin autumn` (both `http::` and `setup::`, 19
tests) and `cargo clippy -p autumn-cli --all-targets -- -D warnings` pass
clean.

`quickstart-gate.yml`'s main job installs `autumn-cli` from crates.io, so —
like any `autumn-cli` fix — this only changes that gate's *observed*
behavior after the next release ships. That's the gate's own documented,
expected latency (see its header comment), not a gap in this change.

## 🔬 Reproduce

```bash
git clone https://github.com/autumn-foundation/autumn && cd autumn
QUICKSTART_STATE_DIR=/tmp/qs-repro scripts/check-quickstart.sh install
QUICKSTART_STATE_DIR=/tmp/qs-repro scripts/check-quickstart.sh new
QUICKSTART_STATE_DIR=/tmp/qs-repro scripts/check-quickstart.sh setup
```

Or re-run the retry unit tests directly: `cargo test -p autumn-cli --bin autumn http::`

---

CHANGELOG entry tagged `[no-plugin]`: CLI network-robustness, not new
agent-facing framework surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XcWP37myiazmfJ6uBZDXwb

---
_Generated by [Claude Code](https://claude.ai/code/session_01XcWP37myiazmfJ6uBZDXwb)_