### PR TITLE
⚡ Bolt: skip redundant HMAC re-check in CSRF verify (instructions -10.4%)

### DIFF
--- a/autumn/Cargo.toml
+++ b/autumn/Cargo.toml
@@ -513,6 +513,14 @@ harness = false
 name = "form_render"
 harness = false
 
+# Signed-CSRF-cookie workload for profilers: drives real POST traffic through
+# `security::CsrfLayer` with HMAC signing active so the verification cost is
+# attributable in a profiler. Asserts nothing — see the file header for the
+# exact commands.
+[[bench]]
+name = "csrf_verify"
+harness = false
+
 # W6 PR3 seed-sweep runner (issue #1797): CI-facing driver for
 # `sim::sweep::sweep_proptest`. `required-features` (not a `#![cfg(...)]` file
 # guard, since a `[[bin]]` target — unlike a `[[test]]` — is simply skipped by

--- a/autumn/benches/csrf_verify.rs
+++ b/autumn/benches/csrf_verify.rs
@@ -40,6 +40,7 @@ use std::hint::black_box;
 
 use autumn_web::config::AutumnConfig;
 use autumn_web::prelude::*;
+use autumn_web::security::{CsrfConfig, SecurityConfig};
 use autumn_web::test::TestApp;
 
 #[get("/notes")]
@@ -64,9 +65,21 @@ fn main() {
         .build()
         .expect("failed to build tokio runtime");
 
-    let mut config = AutumnConfig::default();
-    config.profile = Some("test".into());
-    config.security.csrf.enabled = true;
+    let mut config = AutumnConfig {
+        profile: Some("test".into()),
+        security: SecurityConfig {
+            csrf: CsrfConfig {
+                enabled: true,
+                ..CsrfConfig::default()
+            },
+            ..SecurityConfig::default()
+        },
+        ..AutumnConfig::default()
+    };
+    // `SigningSecretConfig` isn't part of the public API surface (only
+    // `AutumnConfig`/`SecurityConfig`/`CsrfConfig` are re-exported), so its
+    // one field reachable through `SecurityConfig::signing_secret` has to be
+    // set by assignment rather than struct-literal syntax.
     config.security.signing_secret.secret =
         Some("bolt-csrf-bench-signing-secret-0123456789abcdef0123456789abcdef".into());
 
@@ -97,10 +110,14 @@ fn main() {
                 .header("x-csrf-token", &token)
                 .send()
                 .await;
-            assert_eq!(response.status, StatusCode::CREATED, "warm-up POST must pass CSRF");
+            assert_eq!(
+                response.status,
+                StatusCode::CREATED,
+                "warm-up POST must pass CSRF"
+            );
         }
 
-        for i in 0..iterations {
+        for _ in 0..iterations {
             black_box(client.get("/notes").send().await.status);
             black_box(
                 client
@@ -118,7 +135,6 @@ fn main() {
                     .await
                     .status,
             );
-            let _ = i;
         }
     });
 

--- a/autumn/benches/csrf_verify.rs
+++ b/autumn/benches/csrf_verify.rs
@@ -1,0 +1,126 @@
+//! Drives real requests through the production **CSRF** middleware
+//! (`autumn_web::security::CsrfLayer`) with HMAC signing active, so the
+//! per-request cost of signed-token verification can be profiled.
+//!
+//! Signed CSRF tokens (`security.csrf.enabled = true` +
+//! `security.signing_secret.secret`) are only reachable through the real
+//! config → router build path (`ResolvedSigningKeys` has no public
+//! constructor), so — like `request_pipeline.rs` — this goes through
+//! `TestApp::build()` rather than constructing `CsrfLayer` directly. Unlike
+//! `request_pipeline.rs` (which leaves CSRF and session signing off), this
+//! bench turns signing on: a `GET` mints a `{uuid}.{hmac_hex}` cookie the way
+//! a first page load would, then repeated `POST`s echo it back via the
+//! `X-CSRF-Token` header the way an authenticated SPA/JS client does — the
+//! shape scaffolded forms and `htmx` submissions also produce (cookie +
+//! matching token on every mutating request).
+//!
+//! Like the other benches in this crate it is `harness = false` and asserts
+//! nothing beyond a sanity check that the traffic isn't silently being
+//! rejected: it is a workload to point a profiler at.
+//!
+//! ```sh
+//! cargo build --release -p autumn-web --bench csrf_verify
+//! BIN=$(find target/release/deps -maxdepth 1 -name "csrf_verify-*" -type f ! -name "*.d")
+//!
+//! # Instruction profile
+//! valgrind --tool=callgrind --callgrind-out-file=callgrind.out "$BIN" --iterations 1000
+//! callgrind_annotate --threshold=80 callgrind.out | head -40
+//!
+//! # Allocation profile (valgrind's built-in dhat tool — no crate dependency).
+//! # Two runs, subtracted, isolate the marginal per-request cost from the
+//! # one-time mint + warm-up (see `request_pipeline.rs` for why).
+//! valgrind --tool=dhat --dhat-out-file=dhat-base.json "$BIN" --iterations 0
+//! valgrind --tool=dhat --dhat-out-file=dhat-run.json  "$BIN" --iterations 200
+//! ```
+//!
+//! `--iterations N` issues one `GET` + two `POST`s per round after a fixed
+//! 50-round warm-up (plus the one-time mint request).
+
+use std::hint::black_box;
+
+use autumn_web::config::AutumnConfig;
+use autumn_web::prelude::*;
+use autumn_web::test::TestApp;
+
+#[get("/notes")]
+async fn list_notes() -> &'static str {
+    "[]"
+}
+
+#[post("/notes")]
+async fn create_note() -> (StatusCode, &'static str) {
+    (StatusCode::CREATED, "created")
+}
+
+fn main() {
+    let iterations: u32 = std::env::args()
+        .position(|a| a == "--iterations")
+        .and_then(|i| std::env::args().nth(i + 1))
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(2_000);
+
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("failed to build tokio runtime");
+
+    let mut config = AutumnConfig::default();
+    config.profile = Some("test".into());
+    config.security.csrf.enabled = true;
+    config.security.signing_secret.secret =
+        Some("bolt-csrf-bench-signing-secret-0123456789abcdef0123456789abcdef".into());
+
+    let client = TestApp::new()
+        .config(config)
+        .routes(routes![list_notes, create_note])
+        .build();
+
+    rt.block_on(async {
+        // One-time mint: a first page load with no cookie yet. Signs and sets
+        // the `{uuid}.{hmac_hex}` cookie every subsequent request reuses, the
+        // same way a browser keeps one CSRF cookie for the life of a session.
+        let mint = client.get("/notes").send().await;
+        assert_eq!(mint.status, StatusCode::OK, "mint request must succeed");
+        let set_cookie = mint
+            .header("set-cookie")
+            .expect("csrf layer must set a cookie on first request");
+        let token = set_cookie
+            .split(';')
+            .next()
+            .and_then(|kv| kv.split_once('='))
+            .map(|(_, v)| v.to_owned())
+            .expect("set-cookie must be `name=value; ...`");
+
+        for _ in 0..50 {
+            let response = client
+                .post("/notes")
+                .header("x-csrf-token", &token)
+                .send()
+                .await;
+            assert_eq!(response.status, StatusCode::CREATED, "warm-up POST must pass CSRF");
+        }
+
+        for i in 0..iterations {
+            black_box(client.get("/notes").send().await.status);
+            black_box(
+                client
+                    .post("/notes")
+                    .header("x-csrf-token", &token)
+                    .send()
+                    .await
+                    .status,
+            );
+            black_box(
+                client
+                    .post("/notes")
+                    .header("x-csrf-token", &token)
+                    .send()
+                    .await
+                    .status,
+            );
+            let _ = i;
+        }
+    });
+
+    println!("completed {} requests", iterations * 3 + 51);
+}

--- a/autumn/src/security/csrf.rs
+++ b/autumn/src/security/csrf.rs
@@ -644,6 +644,14 @@ fn scan_multipart_field<'a>(bytes: &'a [u8], boundary: &str, field_name: &str) -
     None
 }
 
+/// Verify the submitted token against `cookie_token`.
+///
+/// `cookie_token` is already known HMAC-valid by the time it gets here:
+/// `CsrfService::call` only ever passes `Some` after `validate_cookie_token_hmac`
+/// confirmed it (or signing is inactive, where that check is trivially `true`).
+/// The candidate-location checks below must not re-run
+/// `validate_cookie_token_hmac` on it — that would recompute the same
+/// HMAC-SHA256 the caller already paid for, on every mutating request.
 async fn verify_csrf_token(
     req: &mut Request<axum::body::Body>,
     settings: &CsrfSettings,
@@ -660,7 +668,6 @@ async fn verify_csrf_token(
     if let (Some(c), Some(h)) = (cookie_token, header_token)
         && !c.is_empty()
         && !h.is_empty()
-        && validate_cookie_token_hmac(c, settings)
         && constant_time_eq(c, h)
     {
         token_found = true;
@@ -680,7 +687,6 @@ async fn verify_csrf_token(
     if let (Some(c), Some(q)) = (cookie_token, &query_token)
         && !c.is_empty()
         && !q.is_empty()
-        && validate_cookie_token_hmac(c, settings)
         && constant_time_eq(c, q)
     {
         token_found = true;
@@ -751,7 +757,6 @@ async fn verify_csrf_token(
                 if let Some(c) = cookie_token
                     && !c.is_empty()
                     && !value.is_empty()
-                    && validate_cookie_token_hmac(c, settings)
                     && constant_time_eq(c, value.as_ref())
                 {
                     token_found = true;
@@ -765,7 +770,6 @@ async fn verify_csrf_token(
             if let Some(c) = cookie_token
                 && !c.is_empty()
                 && !value.is_empty()
-                && validate_cookie_token_hmac(c, settings)
                 && constant_time_eq(c, value)
             {
                 token_found = true;


### PR DESCRIPTION
## Summary

🎯 **Workload** — new harness `autumn/benches/csrf_verify.rs`: drives real POST traffic through `security::CsrfLayer` with HMAC signing active (`security.csrf.enabled` + `security.signing_secret.secret`), via `TestApp::build()` since `ResolvedSigningKeys` has no public constructor. A `GET` mints a `{uuid}.{hmac_hex}` cookie the way a first page load would, then repeated rounds of `GET` + 2×`POST` echo it back via `X-CSRF-Token` — the shape an authenticated SPA/htmx client produces on every mutating request. No other committed bench touches the CSRF/signing path (`request_pipeline.rs` deliberately leaves CSRF and session signing off).

```sh
cargo build --release -p autumn-web --bench csrf_verify
BIN=$(find target/release/deps -maxdepth 1 -name "csrf_verify-*" -type f ! -name "*.d")
valgrind --tool=callgrind --callgrind-out-file=callgrind.out "$BIN" --iterations 2000
callgrind_annotate --threshold=90 callgrind.out | head -40
```

📈 **Profile** (`valgrind --tool=callgrind`, `--iterations 500`, top self-cost entries):

| Function | % of instructions |
|---|---:|
| `sha2::sha256::compress256` | 15.50% |
| `memmove` (glibc) | 13.13% |
| malloc/free family | ~19.7% |
| `core::fmt::write` + `Formatter::pad_integral` + `String::write_str` + `LowerHex<u8>::fmt` (hex-encoding the digest) | 7.55% |
| `hmac_sha256_hex` (self) | 1.02% |
| `ResolvedSigningKeys::verify` | 0.70% |
| `constant_time_eq` | 0.84% |

The HMAC sign/verify/hex-encode pipeline accounts for **~25% of instructions** in this workload — well clear of the 5% bar.

💡 **Hypothesis** — `CsrfService::call()` runs `validate_cookie_token_hmac(tok, settings)` on the incoming cookie *before* deciding whether to keep it as `cookie_token` (an invalid HMAC clears it to `None`). `verify_csrf_token`'s four candidate-location branches (header, query param, urlencoded form field, multipart form field) each re-ran `validate_cookie_token_hmac` on that *same already-validated* `cookie_token` before comparing it. Since `cookie_token` is only ever `Some` when signing is inactive (where the check is trivially `true`) or when it already passed, every one of those four checks is provably redundant — a full HMAC-SHA256 + hex-encode computing a result that's always `true`. Only one branch actually fires per request in the common case (token in exactly one location), so this is one full redundant HMAC-SHA256 verification per mutating CSRF-protected request.

🔧 **Change** — removed the four redundant `validate_cookie_token_hmac(c, settings)` calls inside `verify_csrf_token`, with a doc comment recording the invariant the caller now owns exclusively. `verify_csrf_token` is a private function with a single call site (`CsrfService::call`), so the invariant is easy to keep sound. Behavior is unchanged — all 42 `security::csrf` unit tests and all 26 CSRF-touching integration tests pass unchanged, including the timing-attack and cookie-tossing suites.

📊 **Measurement** (release build, this machine, `benches/csrf_verify.rs`):

| Metric | Before | After | Delta | Tool |
|---|---:|---:|---:|---|
| Instructions, 2000 iterations (6,051 requests) | 896,891,652 / 894,405,963 (2 runs, same bench file) | 803,152,348 / 798,473,992 (2 runs) | **-10.4% to -10.5%** | `valgrind --tool=callgrind` |
| Allocation bytes/request (marginal, 300 iterations) | 32,755.7 | 32,713.5 | -0.13% (noise floor) | `valgrind --tool=dhat` |
| Allocation blocks/request (marginal, 300 iterations) | 175.33 | 174.67 | -0.38% (noise floor) | `valgrind --tool=dhat` |

The instruction delta alone clears the 5% impact floor; the allocation deltas are negligible as expected (removing one ~64-byte `String` per request is small next to the per-request box-cascade already reported in #2193/#2198/#2371) and aren't the basis for this PR.

🔬 **Reproduce**

```sh
cargo build --release -p autumn-web --bench csrf_verify
BIN=$(find target/release/deps -maxdepth 1 -name "csrf_verify-*" -type f ! -name "*.d")
valgrind --tool=callgrind --callgrind-out-file=callgrind.out "$BIN" --iterations 2000
# Ir shown by valgrind's own summary output, or callgrind_annotate callgrind.out
```

Checked for duplicate/overlapping work first: no open issue or PR references `verify_csrf_token`, `validate_cookie_token_hmac`, or redundant CSRF HMAC checks. (Open PR #2486 / issue #2485 cover an unrelated redundant-round-trip finding in the DB connection-checkout path.)

## Test plan

- [x] `cargo build --release -p autumn-web --bench csrf_verify`
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p autumn-web --lib -- -D warnings` (clean; the one `unknown_lints` warning is the pre-existing, unrelated `clippy::unused_async_trait_impl` noted in #2295/#2298/#2304)
- [x] `cargo clippy -p autumn-web --bench csrf_verify -- -D warnings` (clean, same pre-existing warning)
- [x] `cargo test -p autumn-web --lib` — 5,556 passed, 0 failed, 19 ignored
- [x] `cargo test -p autumn-web --test integration_tests csrf` — 26 passed, 0 failed (includes timing-attack, cookie-tossing, path-traversal, htmx-bypass PoC suites)
- [x] `cargo test -p autumn-web --lib security::csrf` — 42 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KT9CchTKArWQV7tsLVt9dH

---
_Generated by [Claude Code](https://claude.ai/code/session_01KT9CchTKArWQV7tsLVt9dH)_