### PR TITLE
🚦 Semaphore: CI health census — PR-run failure clustering (9/19 verdicted runs red, macOS-only timing cluster)

### DIFF
--- a/docs/reports/2026-09-04-semaphore-ci-health-census.md
+++ b/docs/reports/2026-09-04-semaphore-ci-health-census.md
@@ -119,6 +119,17 @@ something this census fabricated a rate for).
      known executions" supports *at most* 21.4%, not "≥21%". A rate in the
      17.6%-21.4% range against 0% is still the strongest repeat signature
      in the sample, just not the number either earlier revision gave.
+     One more caveat the range doesn't resolve: `cargo test --workspace`
+     (CI's own "Run tests" command, no `--no-fail-fast`) stops at the
+     *first* failing test binary and never runs the rest — confirmed
+     empirically, not assumed — so each of those 3 unresolved runs is
+     either a confirmed `live_upgrade` pass (if its binary ran before
+     whichever binary's failure stopped the invocation) or a
+     `live_upgrade` non-execution (if not), never an executed-but-unknown
+     outcome. Which of those two it is for each of the 3 depends on
+     cargo's workspace test-binary ordering, which this census did not
+     determine; either way the failure count stays at 3 and the range
+     above still bounds it correctly.
   2. **`integration::cache_stampede::swr_serves_stale_and_refreshes_in_
      background`** — the background refresh never published within its
      1,000×25ms (~25s) poll budget (run 8190, macOS). This assertion was
@@ -229,22 +240,52 @@ That leaves two tiers, and they are not substitutes for each other:
    needs)**: rerun the exact CI command, unfiltered, and grep each run's
    output for the target test's own result line. This is expensive — the
    `Run tests` step itself took 1,501-1,607s (25-27 minutes) in the census
-   sample — so even N=10 here is a ~4-5 hour campaign, not a quick check.
-   It must run on an actual GitHub-hosted `macos-latest` runner (a
-   `workflow_dispatch` job on `ci.yml`'s own matrix leg is the simplest way
-   to get one): the hypothesis under test is contention specific to that
-   *shared, GitHub-hosted* runner class, so a clean result on a personal
-   or otherwise-provisioned Mac tests a different, less contended
-   environment and cannot stand in as evidence against it either way.
+   sample — so even N=10 here is real spend, not a quick check. Two things
+   an earlier revision of this section got wrong, both load-bearing for
+   what the campaign can actually prove:
+   - It must run on an actual GitHub-hosted `macos-latest` runner, not
+     just "macOS hardware": the hypothesis is contention specific to that
+     *shared, hosted* runner class, and a personal or otherwise-provisioned
+     Mac tests a different, less contended environment.
+   - Each of the 10 samples needs its own **fresh runner and checkout**,
+     not 10 loop iterations inside one job: a shared VM and `target/`
+     directory means samples 2-10 inherit sample 1's warm build cache and
+     host state instead of each reproducing the cold, ~25-minute build-up
+     the `live_upgrade` comparison specifically depends on.
 
-   ```
-   # Must run on macos-latest itself (see above) -- not just "any macOS
-   # box". Mirrors the actual failing step; do not add a name filter or
-   # you're back to the isolated case Codex flagged.
-   for i in $(seq 1 10); do
-     cargo test --workspace 2>&1 | tee "run-$i.log"
-     grep -E "upgrades_in_place_under_load_without_dropping|cache_stampede::swr_serves_stale_and_refreshes_in_background|sim_fault_plan::same_seed_replays_a_byte_identical_outcome_100_times" "run-$i.log"
-   done
+   A `strategy.matrix` dispatch is the natural fit — 10 independent
+   `macos-latest` jobs, each a fresh VM:
+
+   ```yaml
+   # .github/workflows/manual-contention-check.yml (throwaway, not for ci.yml)
+   on: workflow_dispatch
+   jobs:
+     sample:
+       strategy:
+         fail-fast: false
+         matrix: { n: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10] }
+       runs-on: macos-latest
+       steps:
+         - uses: actions/checkout@v7
+         - uses: dtolnay/rust-toolchain@stable
+         # Deliberately NO cache action here: a warm Swatinem/rust-cache
+         # restore is exactly the shortcut around the cold build-up this
+         # campaign needs to reproduce.
+         - name: Run the exact CI command, but keep going past a failure
+           # --no-fail-fast matters: plain `cargo test --workspace` stops
+           # at the FIRST failing test binary and never runs the rest
+           # (confirmed empirically: a two-target repro where target A
+           # fails never even started target B). Without it, one sample's
+           # results for the other two tests go silently missing instead
+           # of recording a clean pass -- the same ambiguity that already
+           # left 3 of the census's own 17 macOS runs unresolved for
+           # `live_upgrade`'s outcome specifically.
+           run: cargo test --workspace --no-fail-fast 2>&1 | tee run.log
+         - name: Classify this sample's result for each target test
+           if: always()
+           run: |
+             grep -E "upgrades_in_place_under_load_without_dropping|cache_stampede::swr_serves_stale_and_refreshes_in_background|sim_fault_plan::same_seed_replays_a_byte_identical_outcome_100_times" run.log \
+               || echo "none of the three target tests produced a result line -- treat as missing, not passing, for this sample"
    ```
 
 2. **The isolated rerun (Tier 3, a narrower, cheaper, and strictly weaker

--- a/docs/reports/2026-09-04-semaphore-ci-health-census.md
+++ b/docs/reports/2026-09-04-semaphore-ci-health-census.md
@@ -3,12 +3,15 @@
 ## 🎯 Verdict path
 
 Merging into `trunk-dev` waits on `.github/workflows/ci.yml`'s `pull_request`
-run: `meta` → `lint` (+ `migration-guides`, `plugin-contract`, `supply-chain`
-in parallel) → `test` (matrix: ubuntu/macos/windows-latest) → `coverage` /
-`loom`, plus `lint` → `windows-tier1` (`ci.yml:965-967`, the Windows Tier 1
-journey job — this census's failure sample includes one hit against it)
-and the standalone `msrv`, `sqlite-runtime`, `sim-sweep`, and
-`edge-conformance` jobs. Correction to an earlier revision of this report:
+run: `meta` and `lint` (+ `migration-guides`, `plugin-contract`,
+`supply-chain`) run in parallel with no dependency between them — `lint`
+has no `needs:` at all — and both gate `test` (`needs: [lint, meta]`,
+matrix: ubuntu/macos/windows-latest), which gates `coverage` / `loom`.
+Separately, `lint` alone gates `windows-tier1` (`ci.yml:965-967`, the
+Windows Tier 1 journey job — this census's failure sample includes one hit
+against it), and the standalone `msrv`, `sqlite-runtime`, `sim-sweep`, and
+`edge-conformance` jobs round out the workflow. Correction to an earlier
+revision of this report:
 `coverage` is not "non-blocking, Codecov only" — only its final upload
 step tolerates failure (`fail_ci_if_error: false`, `ci.yml:767`); the many
 `cargo llvm-cov` invocations in its "Generate coverage" step
@@ -259,6 +262,15 @@ That leaves two tiers, and they are not substitutes for each other:
    ```yaml
    # .github/workflows/manual-contention-check.yml (throwaway, not for ci.yml)
    on: workflow_dispatch
+   env:
+     # Copied from ci.yml:13-22, not reinvented: RUST_MIN_STACK in
+     # particular changes how close a deep call frame (clap's derive
+     # macros were the trigger there) sits to overflowing the default
+     # thread stack, which is exactly the kind of platform-dependent
+     # resource-margin difference this campaign needs to hold constant.
+     CARGO_TERM_COLOR: always
+     RUST_BACKTRACE: 1
+     RUST_MIN_STACK: 8388608
    jobs:
      sample:
        strategy:

--- a/docs/reports/2026-09-04-semaphore-ci-health-census.md
+++ b/docs/reports/2026-09-04-semaphore-ci-health-census.md
@@ -261,7 +261,12 @@ That leaves two tiers, and they are not substitutes for each other:
 
    ```yaml
    # .github/workflows/manual-contention-check.yml (throwaway, not for ci.yml)
-   on: workflow_dispatch
+   on:
+     workflow_dispatch:
+       inputs:
+         sha:
+           description: "Commit to reproduce (same-commit baseline -- do not leave this to whatever the dispatch branch's tip happens to be)"
+           required: true
    env:
      # Copied from ci.yml:13-22, not reinvented: RUST_MIN_STACK in
      # particular changes how close a deep call frame (clap's derive
@@ -278,18 +283,32 @@ That leaves two tiers, and they are not substitutes for each other:
          matrix: { n: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10] }
        runs-on: macos-latest
        steps:
+         # Pinned to the dispatch input, not the branch tip: a
+         # `workflow_dispatch` run with no `ref` checks out whatever the
+         # dispatch branch currently points to, and PR branches in this
+         # sample moved commit-to-commit routinely -- without pinning, the
+         # ten samples could each run different product/test code, which
+         # is a different campaign than the same-commit baseline this
+         # report's own hard gate calls for.
          - uses: actions/checkout@v7
+           with:
+             ref: ${{ inputs.sha }}
          - uses: dtolnay/rust-toolchain@stable
-         # Restore the cache, matching ci.yml:345 exactly. An earlier
-         # revision of this section omitted it on the theory that a warm
-         # cache would shortcut the cold build-up under test -- wrong: the
+         # Restore the cache, matching ci.yml:345-346 exactly -- including
+         # `continue-on-error: true`. An earlier revision of this section
+         # omitted the action entirely on the theory that a warm cache
+         # would shortcut the cold build-up under test -- wrong: the
          # fresh-VM-per-sample structure above already guarantees a cold
          # *runner*, and the sampled CI runs themselves all restored this
          # same cache before "Run tests". Skipping it would make every
          # sample recompile the entire dependency graph from scratch,
          # which is slower AND less faithful to the thing being measured,
-         # not more.
+         # not more; dropping the `continue-on-error` would instead let a
+         # transient cache-service failure abort a sample outright, which
+         # production tolerates by falling through to a cold-cache build
+         # rather than losing the sample.
          - uses: Swatinem/rust-cache@v2.7.8
+           continue-on-error: true
          - name: Run the exact CI command, but keep going past a failure
            # --no-fail-fast matters: plain `cargo test --workspace` stops
            # at the FIRST failing test binary and never runs the rest

--- a/docs/reports/2026-09-04-semaphore-ci-health-census.md
+++ b/docs/reports/2026-09-04-semaphore-ci-health-census.md
@@ -197,41 +197,70 @@ after-measurement — no change shipped this pass.
 
 ## 🔬 Reproduce
 
-The next legitimate step is Tier 1, not Tier 3: same-commit rerun statistics
-on `examples/hot-upgrade` and the `cache_stampede`/`sim_fault_plan` suites,
-specifically on a macOS runner (or macOS-class local hardware), at N≥20:
+An earlier revision of this section proposed reruns filtered to just the
+named test (`cargo test ... -- <test name>`). Codex review correctly
+rejected that: all three tests live in the consolidated `integration_tests`
+binary (or, for `live_upgrade`, its own binary), and every CI failure this
+census found happened while that binary ran as part of the full `Run
+tests` step (`cargo test --workspace`) — thousands of tests, much of it
+concurrent, on a runner that had already been building and testing for a
+while. A filtered single-test rerun strips out exactly the load the
+runner-contention hypothesis in Diagnosis depends on: a clean result from
+it would show the test has no bug *in isolation*, not that macOS isn't
+contended. It answers a real but different, narrower question than the one
+this report is asking.
 
-```
-# live_upgrade, the strongest repeat signature (3/3 identical failures observed
-# on macOS in the census; run this on macOS hardware/runner to match)
-for i in $(seq 1 20); do
-  cargo test -p hot-upgrade --test live_upgrade -- --test-threads=1 \
-    || echo "FAIL run $i"
-done
+That leaves two tiers, and they are not substitutes for each other:
 
-# cache_stampede's publish-visibility poll
-for i in $(seq 1 20); do
-  cargo test -p autumn-web --test integration_tests -- \
-    cache_stampede::swr_serves_stale_and_refreshes_in_background \
-    || echo "FAIL run $i"
-done
+1. **The load-faithful rerun (Tier 1, the one this diagnosis actually
+   needs)**: rerun the exact CI command, unfiltered, and grep each run's
+   output for the target test's own result line. This is expensive — the
+   `Run tests` step itself took 1,501-1,607s (25-27 minutes) in the census
+   sample — so N=20 here is a multi-hour campaign, not a quick check:
 
-# sim_fault_plan's job-runtime-not-initialized panic. Plain #[test], not
-# #[ignore]d (it runs as part of the base `cargo test --workspace` step, the
-# one that actually failed here) — no `--ignored` flag, or this filters the
-# test out entirely and every iteration "passes" by running nothing.
-for i in $(seq 1 20); do
-  cargo test -p autumn-web --test integration_tests -- \
-    same_seed_replays_a_byte_identical_outcome_100_times \
-    || echo "FAIL run $i"
-done
-```
+   ```
+   # Run on macOS hardware/a macos-latest-class runner. Mirrors the actual
+   # failing step; do not add a name filter or you're back to the isolated
+   # case Codex flagged.
+   for i in $(seq 1 10); do
+     cargo test --workspace 2>&1 | tee "run-$i.log"
+     grep -E "upgrades_in_place_under_load_without_dropping|cache_stampede::swr_serves_stale_and_refreshes_in_background|sim_fault_plan::same_seed_replays_a_byte_identical_outcome_100_times" "run-$i.log"
+   done
+   ```
 
-Whichever of the three reproduces at a measurable rate names the mechanism;
-whichever doesn't reproduce locally at all is the strongest evidence the
-cause is runner-class contention rather than the test/product code, and
-argues for a shuffled-order + load-experiment pass (Tier 1/3) pinned to
-`macos-latest` specifically before touching any of the three tests.
+2. **The isolated rerun (Tier 3, a narrower, cheaper, and strictly weaker
+   check)**: useful only for ruling out a bug that reproduces with no load
+   at all — a positive result there is still informative (bug confirmed
+   independent of contention), but a clean 0/N is not evidence against the
+   contention hypothesis and must not be read as one, unlike what an
+   earlier revision of this report claimed:
+
+   ```
+   for i in $(seq 1 20); do
+     cargo test -p hot-upgrade --test live_upgrade -- --test-threads=1 \
+       || echo "FAIL run $i"
+   done
+   for i in $(seq 1 20); do
+     cargo test -p autumn-web --test integration_tests -- \
+       cache_stampede::swr_serves_stale_and_refreshes_in_background \
+       || echo "FAIL run $i"
+   done
+   # Plain #[test], not #[ignore]d -- no --ignored flag, or this filters
+   # the test out entirely and every iteration "passes" by running nothing.
+   for i in $(seq 1 20); do
+     cargo test -p autumn-web --test integration_tests -- \
+       same_seed_replays_a_byte_identical_outcome_100_times \
+       || echo "FAIL run $i"
+   done
+   ```
+
+Run (1) first. If it reproduces at a measurable rate, that names the
+mechanism and (2) becomes a useful follow-up to separate "load-dependent"
+from "load-independent." If (1) comes back clean at N=10, that is real
+evidence against the contention hypothesis (unlike a clean (2)) and argues
+for a shuffled-order pass instead. Either way, (2) alone was never enough
+to conclude anything about runner-class contention, and this report was
+wrong to imply otherwise.
 
 This census opens no *fix* PR: it lands as a report, per this role's own
 rule that a report is a legitimate, non-default outcome when the gate isn't

--- a/docs/reports/2026-09-04-semaphore-ci-health-census.md
+++ b/docs/reports/2026-09-04-semaphore-ci-health-census.md
@@ -5,7 +5,9 @@
 Merging into `trunk-dev` waits on `.github/workflows/ci.yml`'s `pull_request`
 run: `meta` → `lint` (+ `migration-guides`, `plugin-contract`, `supply-chain`
 in parallel) → `test` (matrix: ubuntu/macos/windows-latest) → `coverage`
-(non-blocking, Codecov only) / `loom`, plus the standalone `msrv`,
+(non-blocking, Codecov only) / `loom`, plus `lint` → `windows-tier1`
+(`ci.yml:965-967`, the Windows Tier 1 journey job — this census's failure
+sample includes one hit against it) and the standalone `msrv`,
 `sqlite-runtime`, `sim-sweep`, and `edge-conformance` jobs. No ambient retry
 wrapper exists anywhere in the workflow — a red run stays red until a human
 clicks "Re-run failed jobs" or pushes a fix, so Law 1 (an untrustworthy green
@@ -27,10 +29,15 @@ post-merge trunk-dev run as a live health signal.
 **Harness**: GitHub Actions API (`actions_list`/`get_job_logs` via the
 `github` MCP server), no new CI spend incurred. Sampled the 100 most recent
 `pull_request`-triggered `ci.yml` runs (2026-09-03 16:13 UTC → 2026-09-04
-10:12 UTC, run numbers 8125-8212 across ~40 distinct PR branches — one
-sitting's worth of this repository's actual PR throughput, not a
-same-commit rerun campaign; see Reproduce below for why that campaign is the
-right next step, not something this census fabricated a rate for).
+10:12 UTC, run numbers 8124-8230 — a 107-wide span for 100 rows because
+`run_number` increments per-workflow across every trigger, `pull_request`
+included but not exclusive, so a handful of numbers in that span belong to
+this same workflow's `push` runs and aren't in this pull_request-only
+sample — across 17 distinct PR branches, i.e. ~6 runs per branch on
+average from iteration/rerun churn — one sitting's worth of this
+repository's actual PR throughput, not a same-commit rerun campaign; see
+Reproduce below for why that campaign is the right next step, not
+something this census fabricated a rate for).
 
 - 97 completed, 78 cancelled (superseded by a same-PR push, expected and
   excluded from the rate below). Of the 19 that reached a real verdict, the
@@ -85,10 +92,13 @@ right next step, not something this census fabricated a rate for).
   2. **`integration::cache_stampede::swr_serves_stale_and_refreshes_in_
      background`** — the background refresh never published within its
      1,000×25ms (~25s) poll budget (run 8190, macOS). This assertion was
-     already hardened once for a documented macOS/windows scheduler-
+     already hardened once for a documented `windows-latest` scheduler-
      starvation flake (`elapsed < 150ms` → a `Notify`-gated deterministic
      wait, issue #1809, see the comment block at
-     `cache_stampede.rs:354-364`); the failure seen here is a *different*
+     `cache_stampede.rs:354-364`) — a different platform than the one this
+     census caught it on, which is itself worth noting: the same test has
+     now shown timing sensitivity on both non-Linux runners, just via
+     different assertions; the failure seen here is a *different*
      assertion in the same test (line 501, the publish-visibility poll), so
      #1809's fix does not cover it. Cross-platform test, one macOS
      occurrence in the sample — suggestive, not yet a repeat signature on

--- a/docs/reports/2026-09-04-semaphore-ci-health-census.md
+++ b/docs/reports/2026-09-04-semaphore-ci-health-census.md
@@ -32,10 +32,14 @@ sitting's worth of this repository's actual PR throughput, not a
 same-commit rerun campaign; see Reproduce below for why that campaign is the
 right next step, not something this census fabricated a rate for).
 
-- 97 completed, 78 cancelled (superseded by a same-PR push, expected and not
-  counted below), 10 success, **9 failure** (~9.3% of completed, non-
-  cancelled runs; ~2 automatic reruns among the sample moved 2 of those 9 to
-  green on attempt 2, both `Test (macos-latest)`).
+- 97 completed, 78 cancelled (superseded by a same-PR push, expected and
+  excluded from the rate below), 10 success, **9 failure** — of the 19 runs
+  that actually reached a real verdict (10 + 9, i.e. completed minus
+  cancelled), **9 failed: ~47.4%**. That is the number that matters, not the
+  9.3%-of-all-97 a first pass over this data gives if cancelled runs are left
+  in the denominator after being called out as excluded (~2 automatic
+  reruns among the sample moved 2 of those 9 to green on attempt 2, both
+  `Test (macos-latest)`).
 - Failure-signature clustering, by job:
 
   | Job | Failures | Signature |
@@ -121,7 +125,8 @@ without that work is exactly the laundering this role exists to refuse.
 ## 📊 Measurement
 
 Before: as tabulated above (organic-traffic census, not a controlled rerun;
-n=9 failures, n=97 completed non-cancelled PR runs, one calendar day). No
+n=9 failures, n=19 completed non-cancelled PR runs (97 completed minus 78
+cancelled), one calendar day). No
 after-measurement — no change shipped this pass.
 
 ## 🔬 Reproduce
@@ -144,11 +149,13 @@ for i in $(seq 1 20); do
     || echo "FAIL run $i"
 done
 
-# sim_fault_plan's job-runtime-not-initialized panic
+# sim_fault_plan's job-runtime-not-initialized panic. Plain #[test], not
+# #[ignore]d (it runs as part of the base `cargo test --workspace` step, the
+# one that actually failed here) — no `--ignored` flag, or this filters the
+# test out entirely and every iteration "passes" by running nothing.
 for i in $(seq 1 20); do
-  cargo test -p autumn-web --features "test-support,offline-sync,ws,mail,redis,i18n" \
-    --test integration_tests -- --ignored --test-threads=1 \
-    integration::sim_fault_plan::same_seed_replays_a_byte_identical_outcome_100_times \
+  cargo test -p autumn-web --test integration_tests -- \
+    same_seed_replays_a_byte_identical_outcome_100_times \
     || echo "FAIL run $i"
 done
 ```

--- a/docs/reports/2026-09-04-semaphore-ci-health-census.md
+++ b/docs/reports/2026-09-04-semaphore-ci-health-census.md
@@ -33,51 +33,70 @@ same-commit rerun campaign; see Reproduce below for why that campaign is the
 right next step, not something this census fabricated a rate for).
 
 - 97 completed, 78 cancelled (superseded by a same-PR push, expected and
-  excluded from the rate below), 10 success, **9 failure** — of the 19 runs
-  that actually reached a real verdict (10 + 9, i.e. completed minus
-  cancelled), **9 failed: ~47.4%**. That is the number that matters, not the
-  9.3%-of-all-97 a first pass over this data gives if cancelled runs are left
-  in the denominator after being called out as excluded (~2 automatic
-  reruns among the sample moved 2 of those 9 to green on attempt 2, both
-  `Test (macos-latest)`).
+  excluded from the rate below). Of the 19 that reached a real verdict, the
+  *latest* conclusion is 10 success / 9 failure — **9/19 ≈ 47.4%**, the
+  number that matters (not the 9/97 ≈ 9.3% a denominator that still includes
+  cancelled runs gives). Four of those 19 runs needed more than one attempt:
+  2 first attempts failed and the rerun (attempt 2) came back green — those
+  2 are correctly counted in the "10 success," their first-attempt red
+  otherwise invisible in a conclusion-only count — and 2 more failed *again*
+  on rerun, which is why they stand in the "9 failure" rather than being
+  written off as one-off blips. Reading first-attempt-only instead of latest
+  conclusion gives 11/19 ≈ 57.9% red on the first try; either framing is
+  defensible, but they are not interchangeable, and this report uses the
+  latest-conclusion framing (9/19) throughout.
 - Failure-signature clustering, by job:
 
   | Job | Failures | Signature |
   |---|---|---|
   | `Lint` → `Clippy` | 2 | real clippy findings in WIP branches, both later fixed same-PR — not a suite defect |
-  | `Test (macos-latest)` → `Run tests` | **6** | 4 distinct assertions, see below |
+  | `Test (macos-latest)` → `Run tests` | **6** | 3 distinct assertions, see below |
   | `Test (ubuntu-latest)` → `Run tests` | 1 | `starters::tests::embedded_saas_matches_example_saas` (same WIP-branch drift as below, also hit ubuntu) |
   | `Test (ubuntu-latest)` → `Run Docker-dependent tests` | 1 | unrelated to this census's macOS finding; not triaged further here |
   | `Windows Tier 1 journey` → app-builds-on-Windows | 1 | same WIP-branch compile error as the ubuntu Clippy hit, same PR |
 
-  `Test (macos-latest)` failed in 6 of the 9 failing runs — every platform
-  in the matrix runs the identical `cargo test --workspace` command, so a
-  6/1/0 (macOS/ubuntu/windows) split on the same command is itself a
-  measurement: something about the macOS runner class, not the test code
-  path, is the shared variable. Of those 6, one (`embedded_saas_matches_
-  example_saas`, a byte-for-byte starter/example drift check) is a genuine
-  product-side catch in a still-in-progress branch — it also failed on
-  ubuntu in the same run, so it is not a macOS-specific finding and is
-  excluded from what follows. The other 5 cluster into 3 distinct
-  timing-shaped assertions, each in a different test:
+  `Test (macos-latest)` failed in 6 of the 9 failing runs. One of those six
+  (`embedded_saas_matches_example_saas`, a byte-for-byte starter/example
+  drift check) is a genuine product-side catch in a still-in-progress
+  branch — it also failed on ubuntu in the same run, so it says nothing
+  macOS-specific and is excluded below. The other 5 are all one of two
+  cross-platform integration tests (`autumn/tests/integration/`, no
+  platform `cfg`, compiled and run identically on every matrix leg) —
+  **except** the dominant signature, `live_upgrade`, whose whole file is
+  `#![cfg(unix)]` (`examples/hot-upgrade/tests/live_upgrade.rs:14`) and so
+  structurally never runs on `windows-latest` at all. That means the fair
+  comparison for `live_upgrade` is macOS-vs-ubuntu only, not the three-way
+  split the earlier draft of this report used to argue "runner class, not
+  code path" — a `cargo test --workspace` command being identical across
+  the matrix does not make the set of tests it actually executes identical,
+  and thanking Codex review for catching that distinction:
 
   1. **`live_upgrade::upgrades_in_place_under_load_without_dropping_a_
      connection_or_the_state`** — `assert_eq!(connect_errors, 0)` failed
-     `left: 1, right: 0` at `examples/hot-upgrade/tests/live_upgrade.rs:268`,
-     identically, twice, on two unrelated branches ~13 hours apart (runs
-     8147 and 8161). Same test, same line, same value, same runner class —
-     the strongest repeat signature in the sample.
+     identically, `left: 1, right: 0` at
+     `examples/hot-upgrade/tests/live_upgrade.rs:268`, on **three** unrelated
+     branches within under 2 hours of each other by the job logs' own
+     timestamps (20:51:17Z, 22:39:43Z, 22:44:42Z on 2026-09-03; runs 8132,
+     8147, 8161) — all three
+     on `macos-latest`, none on `ubuntu-latest`, the only other platform the
+     test ever runs on. Same test, same line, same value, 3-for-3 on one
+     platform and 0-for-N on the other: the strongest repeat signature in
+     the sample, and the one this report's diagnosis section focuses on.
   2. **`integration::cache_stampede::swr_serves_stale_and_refreshes_in_
      background`** — the background refresh never published within its
-     1,000×25ms (~25s) poll budget (run 8190). This assertion was already
-     hardened once for a documented macOS/windows scheduler-starvation flake
-     (`elapsed < 150ms` → a `Notify`-gated deterministic wait, issue #1809,
-     see the comment block at `cache_stampede.rs:354-364`); the failure seen
-     here is a *different* assertion in the same test (line 501, the
-     publish-visibility poll), so #1809's fix does not cover it.
+     1,000×25ms (~25s) poll budget (run 8190, macOS). This assertion was
+     already hardened once for a documented macOS/windows scheduler-
+     starvation flake (`elapsed < 150ms` → a `Notify`-gated deterministic
+     wait, issue #1809, see the comment block at
+     `cache_stampede.rs:354-364`); the failure seen here is a *different*
+     assertion in the same test (line 501, the publish-visibility poll), so
+     #1809's fix does not cover it. Cross-platform test, one macOS
+     occurrence in the sample — suggestive, not yet a repeat signature on
+     its own.
   3. **`integration::sim_fault_plan::same_seed_replays_a_byte_identical_
      outcome_100_times`** — panicked enqueueing a probe job: `"job runtime
-     is not initialized; register jobs with AppBuilder::jobs()"` (run 8159).
+     is not initialized; register jobs with AppBuilder::jobs()"` (run 8159,
+     macOS). Cross-platform test, likewise one occurrence here.
 
 - Quarantine ledger: no formal ledger exists in this repo (no
   intake-form/owner/date convention). One `--skip` in `ci.yml`'s Docker
@@ -97,21 +116,29 @@ right next step, not something this census fabricated a rate for).
 
 **Root-cause category**: runner-class / resource-contention timing
 dependence, provisionally — **not yet confirmed**, and this is the load-
-bearing caveat of this report. Three different tests, each already written
-with generous, load-tolerant budgets by the standards of this codebase (a
-25-second, 1000-attempt poll; a 5-second cutover-latency ceiling explicitly
-sized for "a busy CI runner"), still failed only on `macos-latest` in this
-sample. That pattern is consistent with GitHub's shared macOS runners being
-more heavily contended than the sample's ubuntu/windows lanes — but it is
-equally consistent with a genuine narrow product race that macOS's slower
-scheduling merely exposes more often. Law 3 applies directly here: I read
-`autumn/src/upgrade.rs`'s handoff design (the listening socket is `dup`'d
-and handed to the successor as its stdin — inetd-style — so the same
-underlying open file description stays live in *some* process throughout
-the cutover; there is no rebind/reopen window in that path as designed).
-That reading does not by itself explain the observed `connect_errors == 1`,
-which means the mechanism is not yet named to the standard this role
-requires, and the test-vs-product verdict is **not yet rendered**.
+bearing caveat of this report. The primary evidence is `live_upgrade`,
+which is written with a hard, zero-tolerance assertion
+(`connect_errors == 0`, no slack at all, unlike this same test's own
+300-read floor and 5-second latency ceiling, both explicitly sized "so a
+busy CI runner cannot fail the run") and failed identically 3-for-3 on
+`macos-latest` against 0-for-however-many-times-it-ran on `ubuntu-latest`
+— the only other platform the unix-gated test executes on. `cache_stampede`
+and `sim_fault_plan`, each already written with generous, load-tolerant
+budgets by this codebase's own standards (a 25-second/1,000-attempt poll),
+each failed once, also on macOS, also in tests with no platform gate — one
+occurrence apiece is corroborating, not yet a repeat signature in its own
+right. Together the pattern is consistent with GitHub's shared macOS
+runners being more heavily contended than this sample's ubuntu lane — but
+it is equally consistent with a genuine narrow product race that macOS's
+scheduling merely exposes more reliably. Law 3 applies directly here: I
+read `autumn/src/upgrade.rs`'s handoff design (the listening socket is
+`dup`'d and handed to the successor as its stdin — inetd-style — so the
+same underlying open file description stays live in *some* process
+throughout the cutover; there is no rebind/reopen window in that path as
+designed). That reading does not by itself explain the observed
+`connect_errors == 1`, which means the mechanism is not yet named to the
+standard this role requires, and the test-vs-product verdict is **not yet
+rendered**.
 
 ## 🔧 Treatment
 
@@ -136,7 +163,8 @@ on `examples/hot-upgrade` and the `cache_stampede`/`sim_fault_plan` suites,
 specifically on a macOS runner (or macOS-class local hardware), at N≥20:
 
 ```
-# live_upgrade, the strongest repeat signature (2/2 identical failures observed)
+# live_upgrade, the strongest repeat signature (3/3 identical failures observed
+# on macOS in the census; run this on macOS hardware/runner to match)
 for i in $(seq 1 20); do
   cargo test -p hot-upgrade --test live_upgrade -- --test-threads=1 \
     || echo "FAIL run $i"
@@ -166,6 +194,6 @@ cause is runner-class contention rather than the test/product code, and
 argues for a shuffled-order + load-experiment pass (Tier 1/3) pinned to
 `macos-latest` specifically before touching any of the three tests.
 
-This census opens no PR: it is a report, per this role's own rule that a
-report is a legitimate, non-default outcome when the gate isn't cleared —
-not a consolation prize for not finding a fix.
+This census opens no *fix* PR: it lands as a report, per this role's own
+rule that a report is a legitimate, non-default outcome when the gate isn't
+cleared — not a consolation prize for not finding a fix.

--- a/docs/reports/2026-09-04-semaphore-ci-health-census.md
+++ b/docs/reports/2026-09-04-semaphore-ci-health-census.md
@@ -84,11 +84,24 @@ something this census fabricated a rate for).
      `examples/hot-upgrade/tests/live_upgrade.rs:268`, on **three** unrelated
      branches within under 2 hours of each other by the job logs' own
      timestamps (20:51:17Z, 22:39:43Z, 22:44:42Z on 2026-09-03; runs 8132,
-     8147, 8161) — all three
-     on `macos-latest`, none on `ubuntu-latest`, the only other platform the
-     test ever runs on. Same test, same line, same value, 3-for-3 on one
-     platform and 0-for-N on the other: the strongest repeat signature in
-     the sample, and the one this report's diagnosis section focuses on.
+     8147, 8161) — all three on `macos-latest`, none on `ubuntu-latest`, the
+     only other platform the test ever runs on. The real denominator, not
+     just the failure count: of the 19 verdicted runs, 2 never reached the
+     `test` matrix at all (blocked by an earlier `lint` failure), leaving 17
+     that did. Of those, macOS's `Run tests` step failed 6 times (this test
+     3 times, `cache_stampede` and `sim_fault_plan` once each, plus the
+     unrelated `embedded_saas` drift) and succeeded 11 — and because a
+     single failing test fails the whole `cargo test --workspace` step,
+     every one of those 11 successes proves `live_upgrade` itself passed.
+     That puts it at **3 failures in at least 14 known macOS executions
+     (≥21%)**, against **0 failures in at least 16 known ubuntu executions**
+     (ubuntu's `Run tests` step failed only once, via the unrelated
+     `embedded_saas` drift; its one other failure, run 8190's Docker step,
+     is a later step in the same job, so that run's `Run tests` step — and
+     `live_upgrade` within it — passed). Thanking Codex review again here:
+     the earlier "3-for-3" phrasing counted only failures and implied a
+     100% macOS fail rate the data doesn't support — ≥21% against 0% is
+     still the strongest repeat signature in the sample, just not that one.
   2. **`integration::cache_stampede::swr_serves_stale_and_refreshes_in_
      background`** — the background refresh never published within its
      1,000×25ms (~25s) poll budget (run 8190, macOS). This assertion was
@@ -130,9 +143,11 @@ bearing caveat of this report. The primary evidence is `live_upgrade`,
 which is written with a hard, zero-tolerance assertion
 (`connect_errors == 0`, no slack at all, unlike this same test's own
 300-read floor and 5-second latency ceiling, both explicitly sized "so a
-busy CI runner cannot fail the run") and failed identically 3-for-3 on
-`macos-latest` against 0-for-however-many-times-it-ran on `ubuntu-latest`
-— the only other platform the unix-gated test executes on. `cache_stampede`
+busy CI runner cannot fail the run") and failed identically in at least 3
+of 14 known macOS executions (≥21%) against 0 of at least 16 known
+`ubuntu-latest` executions — the only other platform the unix-gated test
+runs on (see Symptom above for how those counts are derived from job-step
+pass/fail logic, not a fresh rerun). `cache_stampede`
 and `sim_fault_plan`, each already written with generous, load-tolerant
 budgets by this codebase's own standards (a 25-second/1,000-attempt poll),
 each failed once, also on macOS, also in tests with no platform gate — one

--- a/docs/reports/2026-09-04-semaphore-ci-health-census.md
+++ b/docs/reports/2026-09-04-semaphore-ci-health-census.md
@@ -99,12 +99,15 @@ something this census fabricated a rate for).
      single failing test fails the whole `cargo test --workspace` step,
      every one of those 11 successes proves `live_upgrade` itself passed.
      That puts the macOS rate for this specific test between **3/17 ≈ 17.6%**
-     (crediting the one run whose `live_upgrade` outcome isn't directly
-     provable — the `embedded_saas` failure — as a pass, since nothing shows
-     otherwise) and **3/14 ≈ 21.4%** (counting only the 14 executions whose
-     `live_upgrade` outcome step-conclusion logic actually proves either
-     way): **3 failures in 17 eligible macOS executions, 14 to 17 of them
-     confirmed**. Against that, **0 failures in 16 to 17 known ubuntu
+     (crediting the three runs whose `live_upgrade` outcome isn't directly
+     provable — the `cache_stampede`, `sim_fault_plan`, and `embedded_saas`
+     failures, none of which was checked for what `live_upgrade` itself did
+     in that same run — as passes, since nothing shows otherwise) and
+     **3/14 ≈ 21.4%** (counting only the 14 executions — 11 successes plus
+     the 3 confirmed `live_upgrade` failures — whose `live_upgrade` outcome
+     step-conclusion logic actually proves either way): **3 failures in 17
+     eligible macOS executions, 14 of them confirmed, 3 unresolved**.
+     Against that, **0 failures in 16 to 17 known ubuntu
      executions** (ubuntu's `Run tests` step failed only once in the 17,
      via the unrelated `embedded_saas` drift; its one other failure, run
      8190's Docker step, is a later step in the same job, so that run's
@@ -158,15 +161,22 @@ which is written with a hard, zero-tolerance assertion
 (`connect_errors == 0`, no slack at all, unlike this same test's own
 300-read floor and 5-second latency ceiling, both explicitly sized "so a
 busy CI runner cannot fail the run") and failed identically in 3 of 17
-eligible macOS executions (17.6%-21.4% depending on one unresolved run —
-see Symptom above for the derivation) against 0 of 16-17 known
+eligible macOS executions (17.6%-21.4% depending on three unresolved runs
+— see Symptom above for the derivation) against 0 of 16-17 known
 `ubuntu-latest` executions — the only other platform the unix-gated test
-runs on. `cache_stampede`
-and `sim_fault_plan`, each already written with generous, load-tolerant
-budgets by this codebase's own standards (a 25-second/1,000-attempt poll),
-each failed once, also on macOS, also in tests with no platform gate — one
-occurrence apiece is corroborating, not yet a repeat signature in its own
-right. Together the pattern is consistent with GitHub's shared macOS
+runs on. `cache_stampede` and `sim_fault_plan` each failed once more, also
+on macOS, also in tests with no platform gate, but they don't share one
+mechanism with each other or with `live_upgrade`: `cache_stampede`'s is a
+generous, load-tolerant real-time poll (25 seconds, 1,000 attempts) by this
+codebase's own standards; `sim_fault_plan` instead runs jobs under a
+process-global lock (`job::global_job_runtime_test_lock`) and a paused,
+single-threaded simulated clock — no wall-clock budget to compare — and
+its failure ("job runtime is not initialized") reads as a setup/shared-
+state defect, not an exhausted wait. One occurrence apiece is
+corroborating that macOS is where this sample's timing- and state-shaped
+failures land, not yet a repeat signature in its own right, and not
+evidence for a single shared mechanism across all three. Together the
+pattern is consistent with GitHub's shared macOS
 runners being more heavily contended than this sample's ubuntu lane — but
 it is equally consistent with a genuine narrow product race that macOS's
 scheduling merely exposes more reliably. Law 3 applies directly here: I
@@ -216,7 +226,7 @@ That leaves two tiers, and they are not substitutes for each other:
    needs)**: rerun the exact CI command, unfiltered, and grep each run's
    output for the target test's own result line. This is expensive — the
    `Run tests` step itself took 1,501-1,607s (25-27 minutes) in the census
-   sample — so N=20 here is a multi-hour campaign, not a quick check:
+   sample — so even N=10 here is a ~4-5 hour campaign, not a quick check:
 
    ```
    # Run on macOS hardware/a macos-latest-class runner. Mirrors the actual
@@ -254,13 +264,18 @@ That leaves two tiers, and they are not substitutes for each other:
    done
    ```
 
-Run (1) first. If it reproduces at a measurable rate, that names the
-mechanism and (2) becomes a useful follow-up to separate "load-dependent"
-from "load-independent." If (1) comes back clean at N=10, that is real
-evidence against the contention hypothesis (unlike a clean (2)) and argues
-for a shuffled-order pass instead. Either way, (2) alone was never enough
-to conclude anything about runner-class contention, and this report was
-wrong to imply otherwise.
+Run (1) first. If it reproduces at a measurable rate, that confirms the
+failure is real under realistic load and gives a rate to work from — it
+does *not* by itself name the mechanism, since a reproducing failure is
+equally consistent with runner contention and with a genuine product race
+that macOS's scheduling exposes more often (the two explanations Diagnosis
+leaves open). Separating them needs (2) run alongside it (does the same
+failure show up with no concurrent load at all?) and a shuffled-order pass
+on the full suite. If (1) instead comes back clean at N=10, that is real
+evidence against the contention hypothesis specifically (unlike a clean
+(2), which never was). Either way, (2) alone was never enough to conclude
+anything about runner-class contention, and this report was wrong to imply
+otherwise.
 
 This census opens no *fix* PR: it lands as a report, per this role's own
 rule that a report is a legitimate, non-default outcome when the gate isn't

--- a/docs/reports/2026-09-04-semaphore-ci-health-census.md
+++ b/docs/reports/2026-09-04-semaphore-ci-health-census.md
@@ -209,12 +209,15 @@ after-measurement — no change shipped this pass.
 
 An earlier revision of this section proposed reruns filtered to just the
 named test (`cargo test ... -- <test name>`). Codex review correctly
-rejected that: all three tests live in the consolidated `integration_tests`
-binary (or, for `live_upgrade`, its own binary), and every CI failure this
-census found happened while that binary ran as part of the full `Run
-tests` step (`cargo test --workspace`) — thousands of tests, much of it
-concurrent, on a runner that had already been building and testing for a
-while. A filtered single-test rerun strips out exactly the load the
+rejected that: every CI failure this census found happened while the
+target test ran as part of the full `Run tests` step (`cargo test
+--workspace`), on a runner that had already been compiling and testing for
+a while — `cache_stampede` and `sim_fault_plan` inside the consolidated
+`integration_tests` binary alongside thousands of others running
+concurrently across worker threads, `live_upgrade` alone in its own crate
+but still downstream of that same ~25-minute build-up. A filtered
+single-test rerun strips out exactly the load (or, for `live_upgrade`, the
+cumulative runner history — see tier 2 below for the distinction) the
 runner-contention hypothesis in Diagnosis depends on: a clean result from
 it would show the test has no bug *in isolation*, not that macOS isn't
 contended. It answers a real but different, narrower question than the one
@@ -226,12 +229,18 @@ That leaves two tiers, and they are not substitutes for each other:
    needs)**: rerun the exact CI command, unfiltered, and grep each run's
    output for the target test's own result line. This is expensive — the
    `Run tests` step itself took 1,501-1,607s (25-27 minutes) in the census
-   sample — so even N=10 here is a ~4-5 hour campaign, not a quick check:
+   sample — so even N=10 here is a ~4-5 hour campaign, not a quick check.
+   It must run on an actual GitHub-hosted `macos-latest` runner (a
+   `workflow_dispatch` job on `ci.yml`'s own matrix leg is the simplest way
+   to get one): the hypothesis under test is contention specific to that
+   *shared, GitHub-hosted* runner class, so a clean result on a personal
+   or otherwise-provisioned Mac tests a different, less contended
+   environment and cannot stand in as evidence against it either way.
 
    ```
-   # Run on macOS hardware/a macos-latest-class runner. Mirrors the actual
-   # failing step; do not add a name filter or you're back to the isolated
-   # case Codex flagged.
+   # Must run on macos-latest itself (see above) -- not just "any macOS
+   # box". Mirrors the actual failing step; do not add a name filter or
+   # you're back to the isolated case Codex flagged.
    for i in $(seq 1 10); do
      cargo test --workspace 2>&1 | tee "run-$i.log"
      grep -E "upgrades_in_place_under_load_without_dropping|cache_stampede::swr_serves_stale_and_refreshes_in_background|sim_fault_plan::same_seed_replays_a_byte_identical_outcome_100_times" "run-$i.log"
@@ -243,7 +252,19 @@ That leaves two tiers, and they are not substitutes for each other:
    at all — a positive result there is still informative (bug confirmed
    independent of contention), but a clean 0/N is not evidence against the
    contention hypothesis and must not be read as one, unlike what an
-   earlier revision of this report claimed:
+   earlier revision of this report claimed. And "isolation" means something
+   different per test here: `cache_stampede` and `sim_fault_plan` share the
+   heavily-parallel `integration_tests` binary with thousands of other
+   tests running across worker threads, so filtering to one name really
+   does remove concurrent *thread* contention within that process.
+   `live_upgrade` is the only test in its own crate (`hot-upgrade` has one
+   `[[test]]` target and cargo runs test binaries one at a time regardless
+   of filtering), so it was never running alongside other tests in the
+   first place — isolating it instead skips the ~25 minutes of prior
+   workspace compilation and testing that could leave the runner's
+   thermal, memory, or disk state different by the time it runs. That is
+   still a real difference from the CI scenario, just a cumulative-history
+   one rather than a concurrency one, and the two shouldn't be conflated:
 
    ```
    for i in $(seq 1 20); do

--- a/docs/reports/2026-09-04-semaphore-ci-health-census.md
+++ b/docs/reports/2026-09-04-semaphore-ci-health-census.md
@@ -1,0 +1,164 @@
+# 🚦 Semaphore: CI health census, 2026-09-04
+
+## 🎯 Verdict path
+
+Merging into `trunk-dev` waits on `.github/workflows/ci.yml`'s `pull_request`
+run: `meta` → `lint` (+ `migration-guides`, `plugin-contract`, `supply-chain`
+in parallel) → `test` (matrix: ubuntu/macos/windows-latest) → `coverage`
+(non-blocking, Codecov only) / `loom`, plus the standalone `msrv`,
+`sqlite-runtime`, `sim-sweep`, and `edge-conformance` jobs. No ambient retry
+wrapper exists anywhere in the workflow — a red run stays red until a human
+clicks "Re-run failed jobs" or pushes a fix, so Law 1 (an untrustworthy green
+is worse than a red) is not currently at risk from retry-laundering. That is
+the one clean bill of health this census hands back.
+
+Push events to `trunk-dev` share a `cancel-in-progress: true` concurrency
+group keyed on the branch, so a fast merge cadence cancels the in-flight
+post-merge verification run before it finishes — 44 of the last 50 push-
+triggered runs sampled ended `cancelled`, not `success` or `failure`. That
+run exists to prove the merged tip is green; when it can't outrun the next
+merge it proves nothing. It is advisory today (the real gate is the PR-time
+run, which does not share that concurrency group), so this is a symptom of
+throughput, not a correctness hole — flagged here in case anyone treats a
+post-merge trunk-dev run as a live health signal.
+
+## 🌡️ Symptom
+
+**Harness**: GitHub Actions API (`actions_list`/`get_job_logs` via the
+`github` MCP server), no new CI spend incurred. Sampled the 100 most recent
+`pull_request`-triggered `ci.yml` runs (2026-09-03 16:13 UTC → 2026-09-04
+10:12 UTC, run numbers 8125-8212 across ~40 distinct PR branches — one
+sitting's worth of this repository's actual PR throughput, not a
+same-commit rerun campaign; see Reproduce below for why that campaign is the
+right next step, not something this census fabricated a rate for).
+
+- 97 completed, 78 cancelled (superseded by a same-PR push, expected and not
+  counted below), 10 success, **9 failure** (~9.3% of completed, non-
+  cancelled runs; ~2 automatic reruns among the sample moved 2 of those 9 to
+  green on attempt 2, both `Test (macos-latest)`).
+- Failure-signature clustering, by job:
+
+  | Job | Failures | Signature |
+  |---|---|---|
+  | `Lint` → `Clippy` | 2 | real clippy findings in WIP branches, both later fixed same-PR — not a suite defect |
+  | `Test (macos-latest)` → `Run tests` | **6** | 4 distinct assertions, see below |
+  | `Test (ubuntu-latest)` → `Run tests` | 1 | `starters::tests::embedded_saas_matches_example_saas` (same WIP-branch drift as below, also hit ubuntu) |
+  | `Test (ubuntu-latest)` → `Run Docker-dependent tests` | 1 | unrelated to this census's macOS finding; not triaged further here |
+  | `Windows Tier 1 journey` → app-builds-on-Windows | 1 | same WIP-branch compile error as the ubuntu Clippy hit, same PR |
+
+  `Test (macos-latest)` failed in 6 of the 9 failing runs — every platform
+  in the matrix runs the identical `cargo test --workspace` command, so a
+  6/1/0 (macOS/ubuntu/windows) split on the same command is itself a
+  measurement: something about the macOS runner class, not the test code
+  path, is the shared variable. Of those 6, one (`embedded_saas_matches_
+  example_saas`, a byte-for-byte starter/example drift check) is a genuine
+  product-side catch in a still-in-progress branch — it also failed on
+  ubuntu in the same run, so it is not a macOS-specific finding and is
+  excluded from what follows. The other 5 cluster into 3 distinct
+  timing-shaped assertions, each in a different test:
+
+  1. **`live_upgrade::upgrades_in_place_under_load_without_dropping_a_
+     connection_or_the_state`** — `assert_eq!(connect_errors, 0)` failed
+     `left: 1, right: 0` at `examples/hot-upgrade/tests/live_upgrade.rs:268`,
+     identically, twice, on two unrelated branches ~13 hours apart (runs
+     8147 and 8161). Same test, same line, same value, same runner class —
+     the strongest repeat signature in the sample.
+  2. **`integration::cache_stampede::swr_serves_stale_and_refreshes_in_
+     background`** — the background refresh never published within its
+     1,000×25ms (~25s) poll budget (run 8190). This assertion was already
+     hardened once for a documented macOS/windows scheduler-starvation flake
+     (`elapsed < 150ms` → a `Notify`-gated deterministic wait, issue #1809,
+     see the comment block at `cache_stampede.rs:354-364`); the failure seen
+     here is a *different* assertion in the same test (line 501, the
+     publish-visibility poll), so #1809's fix does not cover it.
+  3. **`integration::sim_fault_plan::same_seed_replays_a_byte_identical_
+     outcome_100_times`** — panicked enqueueing a probe job: `"job runtime
+     is not initialized; register jobs with AppBuilder::jobs()"` (run 8159).
+
+- Quarantine ledger: no formal ledger exists in this repo (no
+  intake-form/owner/date convention). One `--skip` in `ci.yml`'s Docker
+  sweep is the closest analogue — `cancelled_release_does_not_leak_lock`,
+  commented `flaky wall-clock zero-duration-timeout race; needs
+  deterministic/paused time to de-flake (tracked as a follow-up)` — which is
+  a diagnosis-bearing skip but has no owner or diagnose-by date attached.
+  That is this repo's one open admissions gap, not a new finding.
+- Rerun-button / merge-queue telemetry: not available through the tools this
+  census had access to (no merge-queue product in use here; GitHub's basic
+  Actions API does not expose historical manual-rerun click counts beyond
+  the `run_attempt` field already folded into the failure count above).
+- Escape mining (reverts/hotfixes): not run this pass — flagged as a gap in
+  this census, not attempted and not claimed.
+
+## 🔍 Diagnosis
+
+**Root-cause category**: runner-class / resource-contention timing
+dependence, provisionally — **not yet confirmed**, and this is the load-
+bearing caveat of this report. Three different tests, each already written
+with generous, load-tolerant budgets by the standards of this codebase (a
+25-second, 1000-attempt poll; a 5-second cutover-latency ceiling explicitly
+sized for "a busy CI runner"), still failed only on `macos-latest` in this
+sample. That pattern is consistent with GitHub's shared macOS runners being
+more heavily contended than the sample's ubuntu/windows lanes — but it is
+equally consistent with a genuine narrow product race that macOS's slower
+scheduling merely exposes more often. Law 3 applies directly here: I read
+`autumn/src/upgrade.rs`'s handoff design (the listening socket is `dup`'d
+and handed to the successor as its stdin — inetd-style — so the same
+underlying open file description stays live in *some* process throughout
+the cutover; there is no rebind/reopen window in that path as designed).
+That reading does not by itself explain the observed `connect_errors == 1`,
+which means the mechanism is not yet named to the standard this role
+requires, and the test-vs-product verdict is **not yet rendered**.
+
+## 🔧 Treatment
+
+None applied. The hard gate for a fix PR — a rerun-rate baseline from a
+committed harness, a named mechanism, the test-vs-product verdict, and a
+post-fix 0/N revert-checked measurement — is not cleared by a single day's
+organic PR sample, however suggestive the clustering. Shipping a timeout
+bump, a sleep, or a widened tolerance against any of the three tests above
+without that work is exactly the laundering this role exists to refuse.
+
+## 📊 Measurement
+
+Before: as tabulated above (organic-traffic census, not a controlled rerun;
+n=9 failures, n=97 completed non-cancelled PR runs, one calendar day). No
+after-measurement — no change shipped this pass.
+
+## 🔬 Reproduce
+
+The next legitimate step is Tier 1, not Tier 3: same-commit rerun statistics
+on `examples/hot-upgrade` and the `cache_stampede`/`sim_fault_plan` suites,
+specifically on a macOS runner (or macOS-class local hardware), at N≥20:
+
+```
+# live_upgrade, the strongest repeat signature (2/2 identical failures observed)
+for i in $(seq 1 20); do
+  cargo test -p hot-upgrade --test live_upgrade -- --test-threads=1 \
+    || echo "FAIL run $i"
+done
+
+# cache_stampede's publish-visibility poll
+for i in $(seq 1 20); do
+  cargo test -p autumn-web --test integration_tests -- \
+    cache_stampede::swr_serves_stale_and_refreshes_in_background \
+    || echo "FAIL run $i"
+done
+
+# sim_fault_plan's job-runtime-not-initialized panic
+for i in $(seq 1 20); do
+  cargo test -p autumn-web --features "test-support,offline-sync,ws,mail,redis,i18n" \
+    --test integration_tests -- --ignored --test-threads=1 \
+    integration::sim_fault_plan::same_seed_replays_a_byte_identical_outcome_100_times \
+    || echo "FAIL run $i"
+done
+```
+
+Whichever of the three reproduces at a measurable rate names the mechanism;
+whichever doesn't reproduce locally at all is the strongest evidence the
+cause is runner-class contention rather than the test/product code, and
+argues for a shuffled-order + load-experiment pass (Tier 1/3) pinned to
+`macos-latest` specifically before touching any of the three tests.
+
+This census opens no PR: it is a report, per this role's own rule that a
+report is a legitimate, non-default outcome when the gate isn't cleared —
+not a consolation prize for not finding a fix.

--- a/docs/reports/2026-09-04-semaphore-ci-health-census.md
+++ b/docs/reports/2026-09-04-semaphore-ci-health-census.md
@@ -4,11 +4,16 @@
 
 Merging into `trunk-dev` waits on `.github/workflows/ci.yml`'s `pull_request`
 run: `meta` → `lint` (+ `migration-guides`, `plugin-contract`, `supply-chain`
-in parallel) → `test` (matrix: ubuntu/macos/windows-latest) → `coverage`
-(non-blocking, Codecov only) / `loom`, plus `lint` → `windows-tier1`
-(`ci.yml:965-967`, the Windows Tier 1 journey job — this census's failure
-sample includes one hit against it) and the standalone `msrv`,
-`sqlite-runtime`, `sim-sweep`, and `edge-conformance` jobs. No ambient retry
+in parallel) → `test` (matrix: ubuntu/macos/windows-latest) → `coverage` /
+`loom`, plus `lint` → `windows-tier1` (`ci.yml:965-967`, the Windows Tier 1
+journey job — this census's failure sample includes one hit against it)
+and the standalone `msrv`, `sqlite-runtime`, `sim-sweep`, and
+`edge-conformance` jobs. Correction to an earlier revision of this report:
+`coverage` is not "non-blocking, Codecov only" — only its final upload
+step tolerates failure (`fail_ci_if_error: false`, `ci.yml:767`); the many
+`cargo llvm-cov` invocations in its "Generate coverage" step
+(`ci.yml:676-761`) carry no such tolerance, so a real compile or test
+failure there fails the job like any other. No ambient retry
 wrapper exists anywhere in the workflow — a red run stays red until a human
 clicks "Re-run failed jobs" or pushes a fix, so Law 1 (an untrustworthy green
 is worse than a red) is not currently at risk from retry-laundering. That is
@@ -93,15 +98,24 @@ something this census fabricated a rate for).
      unrelated `embedded_saas` drift) and succeeded 11 — and because a
      single failing test fails the whole `cargo test --workspace` step,
      every one of those 11 successes proves `live_upgrade` itself passed.
-     That puts it at **3 failures in at least 14 known macOS executions
-     (≥21%)**, against **0 failures in at least 16 known ubuntu executions**
-     (ubuntu's `Run tests` step failed only once, via the unrelated
-     `embedded_saas` drift; its one other failure, run 8190's Docker step,
-     is a later step in the same job, so that run's `Run tests` step — and
-     `live_upgrade` within it — passed). Thanking Codex review again here:
-     the earlier "3-for-3" phrasing counted only failures and implied a
-     100% macOS fail rate the data doesn't support — ≥21% against 0% is
-     still the strongest repeat signature in the sample, just not that one.
+     That puts the macOS rate for this specific test between **3/17 ≈ 17.6%**
+     (crediting the one run whose `live_upgrade` outcome isn't directly
+     provable — the `embedded_saas` failure — as a pass, since nothing shows
+     otherwise) and **3/14 ≈ 21.4%** (counting only the 14 executions whose
+     `live_upgrade` outcome step-conclusion logic actually proves either
+     way): **3 failures in 17 eligible macOS executions, 14 to 17 of them
+     confirmed**. Against that, **0 failures in 16 to 17 known ubuntu
+     executions** (ubuntu's `Run tests` step failed only once in the 17,
+     via the unrelated `embedded_saas` drift; its one other failure, run
+     8190's Docker step, is a later step in the same job, so that run's
+     `Run tests` step — and `live_upgrade` within it — passed). Thanking
+     Codex review again here, twice over: the earlier "3-for-3" phrasing
+     counted only failures and implied a 100% macOS fail rate, and the
+     revision after that inverted the bound — more confirmed executions can
+     only pull a fixed failure count's rate *down*, not up, so "at least 14
+     known executions" supports *at most* 21.4%, not "≥21%". A rate in the
+     17.6%-21.4% range against 0% is still the strongest repeat signature
+     in the sample, just not the number either earlier revision gave.
   2. **`integration::cache_stampede::swr_serves_stale_and_refreshes_in_
      background`** — the background refresh never published within its
      1,000×25ms (~25s) poll budget (run 8190, macOS). This assertion was
@@ -143,11 +157,11 @@ bearing caveat of this report. The primary evidence is `live_upgrade`,
 which is written with a hard, zero-tolerance assertion
 (`connect_errors == 0`, no slack at all, unlike this same test's own
 300-read floor and 5-second latency ceiling, both explicitly sized "so a
-busy CI runner cannot fail the run") and failed identically in at least 3
-of 14 known macOS executions (≥21%) against 0 of at least 16 known
+busy CI runner cannot fail the run") and failed identically in 3 of 17
+eligible macOS executions (17.6%-21.4% depending on one unresolved run —
+see Symptom above for the derivation) against 0 of 16-17 known
 `ubuntu-latest` executions — the only other platform the unix-gated test
-runs on (see Symptom above for how those counts are derived from job-step
-pass/fail logic, not a fresh rerun). `cache_stampede`
+runs on. `cache_stampede`
 and `sim_fault_plan`, each already written with generous, load-tolerant
 budgets by this codebase's own standards (a 25-second/1,000-attempt poll),
 each failed once, also on macOS, also in tests with no platform gate — one

--- a/docs/reports/2026-09-04-semaphore-ci-health-census.md
+++ b/docs/reports/2026-09-04-semaphore-ci-health-census.md
@@ -268,9 +268,16 @@ That leaves two tiers, and they are not substitutes for each other:
        steps:
          - uses: actions/checkout@v7
          - uses: dtolnay/rust-toolchain@stable
-         # Deliberately NO cache action here: a warm Swatinem/rust-cache
-         # restore is exactly the shortcut around the cold build-up this
-         # campaign needs to reproduce.
+         # Restore the cache, matching ci.yml:345 exactly. An earlier
+         # revision of this section omitted it on the theory that a warm
+         # cache would shortcut the cold build-up under test -- wrong: the
+         # fresh-VM-per-sample structure above already guarantees a cold
+         # *runner*, and the sampled CI runs themselves all restored this
+         # same cache before "Run tests". Skipping it would make every
+         # sample recompile the entire dependency graph from scratch,
+         # which is slower AND less faithful to the thing being measured,
+         # not more.
+         - uses: Swatinem/rust-cache@v2.7.8
          - name: Run the exact CI command, but keep going past a failure
            # --no-fail-fast matters: plain `cargo test --workspace` stops
            # at the FIRST failing test binary and never runs the rest
@@ -282,10 +289,22 @@ That leaves two tiers, and they are not substitutes for each other:
            # `live_upgrade`'s outcome specifically.
            run: cargo test --workspace --no-fail-fast 2>&1 | tee run.log
          - name: Classify this sample's result for each target test
+           # Three independent checks, not one grep with a single
+           # pass/fail fallback: a single combined grep only reports
+           # "nothing matched at all", so if two of the three targets
+           # produced a result line and one didn't, that one's absence
+           # would silently pass as if the whole sample succeeded.
            if: always()
            run: |
-             grep -E "upgrades_in_place_under_load_without_dropping|cache_stampede::swr_serves_stale_and_refreshes_in_background|sim_fault_plan::same_seed_replays_a_byte_identical_outcome_100_times" run.log \
-               || echo "none of the three target tests produced a result line -- treat as missing, not passing, for this sample"
+             for pattern in \
+               "upgrades_in_place_under_load_without_dropping" \
+               "cache_stampede::swr_serves_stale_and_refreshes_in_background" \
+               "sim_fault_plan::same_seed_replays_a_byte_identical_outcome_100_times"
+             do
+               grep -q "$pattern" run.log \
+                 && grep "$pattern" run.log \
+                 || echo "MISSING result line for $pattern -- treat as missing, not passing, for this sample"
+             done
    ```
 
 2. **The isolated rerun (Tier 3, a narrower, cheaper, and strictly weaker

--- a/docs/reports/2026-09-04-semaphore-ci-health-census.md
+++ b/docs/reports/2026-09-04-semaphore-ci-health-census.md
@@ -277,7 +277,15 @@ That leaves two tiers, and they are not substitutes for each other:
      RUST_BACKTRACE: 1
      RUST_MIN_STACK: 8388608
    jobs:
-     sample:
+     # Named `test`, not `sample`: Swatinem/rust-cache keys its cache
+     # entry on the job id by default (ci.yml:270-273 notes this itself --
+     # "this job name gets its own `rust-cache` entry"), so a job called
+     # `sample` would never hit the cache the production `test` job has
+     # been warming on this branch and every sample would cold-build the
+     # entire dependency graph -- a different resource profile from the
+     # runs actually being reproduced. Reusing the job id `test` hits that
+     # same cache entry instead.
+     test:
        strategy:
          fail-fast: false
          matrix: { n: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10] }


### PR DESCRIPTION
## Summary

Docs-only report. Mines the 100 most recent `pull_request`-triggered `ci.yml` runs via the GitHub Actions API (no new CI spend) to establish the current verdict path's actual health, per the Semaphore CI-health-agent brief.

- 🎯 **Verdict path**: no ambient retry laundering anywhere in `ci.yml` — a red PR run stays red until a human reruns or fixes it. Clean bill of health there. `meta` and `lint` run in parallel (not serially) and both gate `test`; `coverage`'s test-generation steps are NOT fault-tolerant (only its final Codecov upload step is). Push-triggered `trunk-dev` runs share a `cancel-in-progress` concurrency group and get superseded before completing 88% of the time in a separate 50-run sample — advisory only, flagged for awareness.
- 🌡️ **Symptom**: of 97 completed PR runs (8124-8230, 17 branches), 78 were cancelled and never reached a verdict; of the 19 that did, latest conclusion is **9 failed ≈ 47.4%** (11/19 ≈ 57.9% first-attempt-only). `Test (macos-latest)` accounts for 6 of the 9. One is a genuine WIP-branch product bug also seen on ubuntu, excluded from what follows. The other 5 cluster into 3 distinct assertions — dominated by `live_upgrade`'s zero-connection-errors check, which failed in 3 of 17 eligible macOS executions (17.6%-21.4%) against 0 of 16-17 known ubuntu executions, within under 2 hours across three unrelated branches — plus one occurrence each of `cache_stampede`'s real-time publish-visibility poll and `sim_fault_plan`'s job-runtime-not-initialized panic (a different mechanism entirely).
- 🔍 **Diagnosis**: provisionally runner-class/contention timing dependence on `macos-latest`, but explicitly **not confirmed**.
- 🔧 **Treatment**: none — the hard gate isn't cleared by a one-day organic sample.
- 🔬 **Reproduce**: two non-substitutable tiers, both on actual hosted `macos-latest` runners with production cache/env restored (matched by job identity, so `rust-cache` actually hits the production job's cache entry) and pinned to the exact commit being measured (`workflow_dispatch` `sha` input passed to `checkout`'s `ref`, so a rerun can't silently float onto the branch's current tip) — a load-faithful `strategy.matrix` rerun (10 independent fresh jobs, `cargo test --workspace --no-fail-fast`) and a cheaper isolated single-test rerun.

**Update**: Codex review caught twenty-six real defects across twelve rounds, all confirmed against the source data (one with a throwaway empirical repro of cargo's cross-target fail-fast behavior) and fixed — the headline failure-rate denominator, reproduce commands that stripped the load the contention hypothesis depends on, an inverted probability bound, conflated test safeguards, a false job-dependency chain, a missing production env var in the repro campaign, an unpinned commit that let the campaign float onto the dispatch branch's tip instead of the measured revision, a missing `continue-on-error` on the restored cache step, a job-id mismatch that would have silently defeated that same cache restoration, and progressively tightening the repro campaign's fidelity to actual CI (fresh runners, production cache, matching env, independent per-target result checks). I also self-caught two: a guessed "18 hours" between failures (actually under 2) and a wrong platform attribution on a cited prior flake.

## Test plan

- [x] Report is a mined-evidence document only — no code changes, nothing to run
- [x] No workflow, test, or CI-spend changes included

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011CEXBXXCe7kGHL78rEcqVP