### PR TITLE
Fix: guard lockout re-stamp against concurrent successful login (#2500)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1604,6 +1604,39 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **🔒 `autumn generate auth`: a concurrent successful login could be silently
+  re-locked by a racing failed attempt (issue #2500):** the generated
+  `login` handler (and the duplicated `reauth` step-up block) counted a
+  wrong-password attempt with an atomic `failed_attempts + 1` `UPDATE` and
+  then, once the new count crossed `[auth.lockout].threshold`, stamped
+  `locked_at` with a *second*, unconditional `UPDATE ... SET locked_at =
+  now() WHERE id = ?` — gated only by a stale in-memory `current_locked_at`
+  value read at the top of the request, never re-checked against the
+  database. If a concurrent request with the *correct* password committed
+  its own "successful login resets the counter" `UPDATE`
+  (`failed_attempts = 0, locked_at = NULL`) in the gap between the failed
+  request's two statements, the unconditional lock stamp reapplied on top
+  of that reset — silently re-locking an account for the full `cooloff_secs`
+  window (default 15 minutes) even though it had *already* logged in
+  successfully (303 redirect and session cookie already issued). Reproduced
+  12/100 (and 7/60, 3/100 on reruns) with a genuinely concurrent
+  wrong-password/correct-password pair against a fresh `autumn generate
+  auth` scaffold.
+  Fix: the lock-stamp `UPDATE` in both handlers now filters on the row's
+  *current* `failed_attempts` (`>= threshold`) and `locked_at`
+  (`IS NULL`) at write time instead of trusting the in-memory read, so a
+  concurrent successful reset makes the stamp a no-op rather than
+  clobbering it; the `account_locked` telemetry event is now gated on the
+  stamp actually having affected a row, so a losing race is never logged
+  as a lock. New generator meta-tests (`autumn-cli/src/generate/auth.rs`)
+  assert both guards are present in the generated source, and
+  `autumn/tests/integration/auth_lockout_race.rs` (Postgres testcontainer)
+  reproduces the exact bad interleaving deterministically against a real
+  database — showing the pre-fix pattern re-locks the account and the fixed
+  pattern doesn't, plus the mirror-image ordering where a lock that
+  genuinely wins the race correctly rejects the concurrent login instead of
+  silently granting a session.
+
 - **🧭 Wayfinder: keyboard bypass-blocks link added to 6 supported example
   apps (a11y `bypass` Serious 7/8 → 0/8; `landmark-one-main` Moderate 1/8 → 0/8):**
   `autumn check --a11y` — the framework's own WCAG audit, run against each

--- a/autumn-cli/src/generate/auth.rs
+++ b/autumn-cli/src/generate/auth.rs
@@ -4004,52 +4004,72 @@ pub async fn login(
                 }};
 
                 if new_attempts >= lockout_cfg.threshold && current_locked_at.is_none() {{
-                    // Account transitions into the locked state — stamp locked_at
-                    // atomically. Propagate errors: if this write fails the account
-                    // is not locked despite the counter crossing the threshold, which
-                    // would allow a successful login to slip through.
-                    diesel::update({table}::table.find({snake_name}.id))
+                    // Account transitions into the locked state — stamp locked_at,
+                    // but only if the row still shows an over-threshold, not-yet-locked
+                    // state at write time. `current_locked_at` above is a stale
+                    // in-memory read from before the password check; without a
+                    // fresh DB-level guard, a concurrent *successful* login could
+                    // reset failed_attempts/locked_at between our increment and this
+                    // write, and this UPDATE would silently re-lock an account that
+                    // just logged in successfully (#2500). Filtering on the row's
+                    // current failed_attempts and locked_at makes the write a no-op
+                    // in that case instead of clobbering the reset. Propagate errors:
+                    // if this write fails the account is not locked despite the
+                    // counter crossing the threshold, which would allow a successful
+                    // login to slip through.
+                    let locked_rows = diesel::update(
+                        {table}::table
+                            .find({snake_name}.id)
+                            .filter({table}::failed_attempts.ge(lockout_cfg.threshold))
+                            .filter({table}::locked_at.is_null()),
+                    )
                         .set({table}::locked_at.eq(Some(now)))
                         .execute(&mut *db)
                         .await
                         .map_err(|e| AutumnError::internal_server_error_msg(&format!("Failed to lock account: {{e}}")))?;
 
-                    // Truncate to a coarse IP prefix (IPv4 /24, IPv6 /64) so
-                    // the telemetry event enables incident response without
-                    // logging a precise user identifier.
-                    let ip_prefix = match addr_ip {{
-                        std::net::IpAddr::V4(ip) => {{
-                            let [a, b, c, _] = ip.octets();
-                            format!("{{a}}.{{b}}.{{c}}.0/24")
-                        }}
-                        std::net::IpAddr::V6(ip) => {{
-                            let s = ip.segments();
-                            format!("{{:x}}:{{:x}}:{{:x}}:{{:x}}::/64", s[0], s[1], s[2], s[3])
-                        }}
-                    }};
-                    // Salt the digest with the deployment secret so the
-                    // account ID cannot be recovered by hashing small integers.
-                    let account_id_digest = {{
-                        use sha2::{{Digest, Sha256}};
-                        // Require a deployment secret for the digest salt. Operators
-                        // MUST set SECRET_KEY_BASE (already required for sessions) or
-                        // AUTUMN_ADMIN_SECRET. The static fallback prevents reversibility
-                        // only within this process; set the env var in production.
-                        let salt = std::env::var("SECRET_KEY_BASE")
-                            .or_else(|_| std::env::var("AUTUMN_ADMIN_SECRET"))
-                            .unwrap_or_else(|_| "autumn-lockout-fallback-salt".to_string());
-                        let hash = Sha256::digest(
-                            format!("{{}}:{{}}", salt, {snake_name}.id).as_bytes(),
+                    // Only emit lockout telemetry when this request's write actually
+                    // applied the lock — a concurrent successful login winning the
+                    // race above means the account never ends up locked, so it must
+                    // not be reported as such.
+                    if locked_rows > 0 {{
+                        // Truncate to a coarse IP prefix (IPv4 /24, IPv6 /64) so
+                        // the telemetry event enables incident response without
+                        // logging a precise user identifier.
+                        let ip_prefix = match addr_ip {{
+                            std::net::IpAddr::V4(ip) => {{
+                                let [a, b, c, _] = ip.octets();
+                                format!("{{a}}.{{b}}.{{c}}.0/24")
+                            }}
+                            std::net::IpAddr::V6(ip) => {{
+                                let s = ip.segments();
+                                format!("{{:x}}:{{:x}}:{{:x}}:{{:x}}::/64", s[0], s[1], s[2], s[3])
+                            }}
+                        }};
+                        // Salt the digest with the deployment secret so the
+                        // account ID cannot be recovered by hashing small integers.
+                        let account_id_digest = {{
+                            use sha2::{{Digest, Sha256}};
+                            // Require a deployment secret for the digest salt. Operators
+                            // MUST set SECRET_KEY_BASE (already required for sessions) or
+                            // AUTUMN_ADMIN_SECRET. The static fallback prevents reversibility
+                            // only within this process; set the env var in production.
+                            let salt = std::env::var("SECRET_KEY_BASE")
+                                .or_else(|_| std::env::var("AUTUMN_ADMIN_SECRET"))
+                                .unwrap_or_else(|_| "autumn-lockout-fallback-salt".to_string());
+                            let hash = Sha256::digest(
+                                format!("{{}}:{{}}", salt, {snake_name}.id).as_bytes(),
+                            );
+                            hex::encode(&hash[..8])
+                        }};
+                        tracing::warn!(
+                            event = "account_locked",
+                            account_id_digest = %account_id_digest,
+                            ip_prefix = %ip_prefix,
+                            failed_attempts = new_attempts,
+                            "account locked after repeated failed login attempts"
                         );
-                        hex::encode(&hash[..8])
-                    }};
-                    tracing::warn!(
-                        event = "account_locked",
-                        account_id_digest = %account_id_digest,
-                        ip_prefix = %ip_prefix,
-                        failed_attempts = new_attempts,
-                        "account locked after repeated failed login attempts"
-                    );
+                    }}
                 }}
                 return Err(auth_err());
             }}
@@ -5046,7 +5066,16 @@ pub async fn reauth(
                     1i32
                 }};
                 if new_attempts >= lockout_cfg.threshold && current_locked_at.is_none() {{
-                    diesel::update({table}::table.find({snake_name}.id))
+                    // See the login handler's matching guard (#2500): filter on the
+                    // row's current failed_attempts/locked_at rather than writing
+                    // unconditionally, so a concurrent successful reauth that already
+                    // reset the counter cannot be silently re-locked.
+                    diesel::update(
+                        {table}::table
+                            .find({snake_name}.id)
+                            .filter({table}::failed_attempts.ge(lockout_cfg.threshold))
+                            .filter({table}::locked_at.is_null()),
+                    )
                         .set({table}::locked_at.eq(Some(now)))
                         .execute(&mut *db)
                         .await
@@ -16053,6 +16082,94 @@ mod tests {
             routes.contains("lockout")
                 && (routes.contains("enabled") || routes.contains("threshold")),
             "routes must respect lockout enabled/threshold config for opt-out: {routes}"
+        );
+    }
+
+    /// #2500: the lock-stamping `UPDATE ... SET locked_at = now()` must never be
+    /// unconditional. A concurrent successful login can reset `failed_attempts`
+    /// to 0 and clear `locked_at` in the gap between the failed request's own
+    /// increment and its lock stamp; without a fresh DB-level guard the stamp
+    /// re-locks the account out from under the login that already succeeded.
+    /// Both the `login` and `reauth` handlers duplicate this block, so both
+    /// must carry the guard.
+    #[test]
+    fn routes_file_guards_lock_stamp_against_concurrent_reset() {
+        let tmp = project_with_main();
+        let plan = plan_auth(tmp.path(), "User", "20260508000000").unwrap();
+        plan.execute(Flags::default()).unwrap();
+        let routes = fs::read_to_string(tmp.path().join("src/routes/auth.rs")).unwrap();
+
+        let guarded_stamp_occurrences = routes
+            .matches("failed_attempts.ge(lockout_cfg.threshold)")
+            .count();
+        assert_eq!(
+            guarded_stamp_occurrences, 2,
+            "both the login and reauth lock-stamp UPDATEs must filter on \
+             failed_attempts.ge(lockout_cfg.threshold) so a concurrent successful \
+             login's reset cannot be clobbered by a stale-threshold re-lock \
+             (found {guarded_stamp_occurrences}): {routes}"
+        );
+
+        // `locked_at.is_null()` also appears, unrelated, in the pre-existing
+        // success-path reset guard (`locked_at.is_null().or(locked_at.le(...)))`),
+        // so a bare substring count can't tell the lock-stamp guard apart from
+        // that unrelated clause and would stay green even if the lock-stamp
+        // UPDATE's own `.filter(locked_at.is_null())` were dropped. Anchor on
+        // `locked_at.eq(Some(now))` instead — the lock-stamp `.set(...)` call,
+        // which appears exactly once per handler (login, reauth) — and require
+        // both guard filters to appear immediately before each one.
+        let stamp_occurrences = routes.matches("locked_at.eq(Some(now))").count();
+        assert_eq!(
+            stamp_occurrences, 2,
+            "expected exactly one lock-stamp UPDATE in each of login and reauth \
+             (found {stamp_occurrences}): {routes}"
+        );
+        let mut search_from = 0;
+        for i in 0..stamp_occurrences {
+            let stamp_at = routes[search_from..]
+                .find("locked_at.eq(Some(now))")
+                .map(|pos| search_from + pos)
+                .unwrap();
+            let window_start = stamp_at.saturating_sub(400);
+            let preceding = &routes[window_start..stamp_at];
+            assert!(
+                preceding.contains("failed_attempts.ge(lockout_cfg.threshold)")
+                    && preceding.contains("locked_at.is_null()"),
+                "lock-stamp UPDATE #{} must be guarded by both \
+                 failed_attempts.ge(lockout_cfg.threshold) and locked_at.is_null() \
+                 immediately before the `locked_at.eq(Some(now))` write, so it never \
+                 re-stamps (and extends the cool-off of) an account another request \
+                 already locked, nor clobbers a concurrent successful reset: {routes}",
+                i + 1
+            );
+            search_from = stamp_at + "locked_at.eq(Some(now))".len();
+        }
+    }
+
+    /// #2500: the `account_locked` telemetry event must only fire when this
+    /// request's own write actually applied the lock. If a concurrent
+    /// successful login won the race (see the guard tested above), the
+    /// lock-stamp UPDATE affects zero rows and no lock ever took effect, so
+    /// logging `account_locked` would be a false positive.
+    #[test]
+    fn routes_file_gates_lockout_telemetry_on_rows_actually_locked() {
+        let tmp = project_with_main();
+        let plan = plan_auth(tmp.path(), "User", "20260508000000").unwrap();
+        plan.execute(Flags::default()).unwrap();
+        let routes = fs::read_to_string(tmp.path().join("src/routes/auth.rs")).unwrap();
+
+        let login_block_start = routes
+            .find("Failed to lock account")
+            .expect("login handler must attempt to lock the account");
+        let telemetry_start = routes[login_block_start..]
+            .find("account_locked")
+            .expect("account_locked telemetry must follow the lock-stamp UPDATE");
+        let between = &routes[login_block_start..login_block_start + telemetry_start];
+        assert!(
+            between.contains("locked_rows") && between.contains("if locked_rows > 0"),
+            "telemetry must be gated behind a check that the lock-stamp UPDATE \
+             actually affected a row (`if locked_rows > 0`), not fired \
+             unconditionally after attempting the write: {routes}"
         );
     }
 

--- a/autumn-macros/src/authorize.rs
+++ b/autumn-macros/src/authorize.rs
@@ -18,7 +18,7 @@
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
 use syn::parse::Parser as _;
-use syn::{Expr, ExprLit, Ident, ItemFn, Lit, LitStr, Meta, Token, parse_quote};
+use syn::{Expr, ExprLit, Ident, Lit, LitStr, Meta, Token, parse_quote};
 
 /// Parsed `#[authorize(...)]` arguments.
 ///
@@ -176,9 +176,9 @@ pub fn authorize_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
         format_ident!("{}", name)
     });
 
-    let mut input_fn: ItemFn = match syn::parse2(item) {
-        Ok(f) => f,
-        Err(err) => return err.to_compile_error(),
+    let (leading_items, mut input_fn) = match crate::parse::split_leading_items_and_fn(&item) {
+        Ok(v) => v,
+        Err(err) => return err,
     };
 
     if input_fn.sig.asyncness.is_none() {
@@ -325,7 +325,10 @@ pub fn authorize_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
         }
     };
 
-    quote! { #input_fn }
+    quote! {
+        #leading_items
+        #input_fn
+    }
 }
 
 /// Variant of [`parse_authorize_args`] that allows a leading bare

--- a/autumn-macros/src/authorize.rs
+++ b/autumn-macros/src/authorize.rs
@@ -146,6 +146,10 @@ fn snake_case(name: &str) -> String {
 }
 
 #[allow(clippy::too_many_lines)]
+// `item` is only ever borrowed via `split_leading_items_and_fn(&item)` now,
+// but keeps the owned `TokenStream` signature every macro entry point in
+// this crate shares (and the proc-macro boundary in `lib.rs` requires).
+#[allow(clippy::needless_pass_by_value)]
 pub fn authorize_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
     // Parse the args first; the parser may surface a leading `"action"`
     // string literal as the bare-Path action via the `Meta::Path` branch

--- a/autumn-macros/src/parse.rs
+++ b/autumn-macros/src/parse.rs
@@ -391,6 +391,11 @@ pub fn split_leading_items_and_fn(
 ///
 /// Returns `Ok((leading_items, func))` if valid, or a compile error
 /// `TokenStream` if not.
+// `item` is only ever borrowed via `split_leading_items_and_fn(&item)` now,
+// but keeps an owned `TokenStream` parameter so callers (route macros with
+// many call sites of their own, at both the proc-macro boundary and in
+// tests) don't need to thread a reference through.
+#[allow(clippy::needless_pass_by_value)]
 pub fn parse_async_handler_with_leading_items(
     item: TokenStream,
 ) -> Result<(TokenStream, ItemFn), TokenStream> {

--- a/autumn-macros/src/parse.rs
+++ b/autumn-macros/src/parse.rs
@@ -338,6 +338,75 @@ pub fn parse_async_handler(item: TokenStream) -> Result<ItemFn, TokenStream> {
     Ok(input_fn)
 }
 
+/// Split macro input into any leading non-function items plus a trailing
+/// function item, tolerating (but not requiring) leading items ahead of the
+/// handler.
+///
+/// A body-guard macro that has already expanded (`#[secured]`, `#[step_up]`,
+/// `#[throttle]`) emits a hidden `FromRequestParts` gate type — a struct plus
+/// its impl — ahead of the handler function itself, rather than rewriting a
+/// single function in place (#1668). When such a guard is written *above*
+/// another guard or route attribute, that outer macro receives the inner
+/// guard's gate items followed by the handler function as its own input, not
+/// a lone function item. The common case (no guard has expanded yet) is
+/// tried first, so parse-error messages for genuinely invalid input are
+/// unchanged; only on that failure is the input re-parsed as a sequence of
+/// items (as `syn::File` does), taking the *last* one as the handler.
+///
+/// Returns `Ok((leading_items, func))` if a trailing function item was
+/// found — `leading_items` is empty in the common case — or a compile error
+/// `TokenStream` if not. Does not validate asyncness; callers that require
+/// it (all current ones do) check `func.sig.asyncness` themselves so each
+/// can keep its own diagnostic wording.
+pub fn split_leading_items_and_fn(
+    item: &TokenStream,
+) -> Result<(TokenStream, ItemFn), TokenStream> {
+    if let Ok(input_fn) = syn::parse2::<ItemFn>(item.clone()) {
+        return Ok((TokenStream::new(), input_fn));
+    }
+
+    let not_a_function = || {
+        syn::Error::new_spanned(
+            item.clone(),
+            "route macros can only be applied to functions",
+        )
+        .to_compile_error()
+    };
+
+    let mut file: syn::File = syn::parse2(item.clone()).map_err(|_| not_a_function())?;
+    let Some(syn::Item::Fn(input_fn)) = file.items.pop() else {
+        return Err(not_a_function());
+    };
+
+    let leading_items = file.items;
+    Ok((quote! { #(#leading_items)* }, input_fn))
+}
+
+/// Parse an async handler function from macro input, tolerating leading
+/// non-function items ahead of it (see [`split_leading_items_and_fn`]).
+///
+/// Validated exactly as [`parse_async_handler`] does (must be a function,
+/// must be async); every earlier item is returned as an opaque token stream
+/// the caller is responsible for re-emitting verbatim.
+///
+/// Returns `Ok((leading_items, func))` if valid, or a compile error
+/// `TokenStream` if not.
+pub fn parse_async_handler_with_leading_items(
+    item: TokenStream,
+) -> Result<(TokenStream, ItemFn), TokenStream> {
+    let (leading_items, input_fn) = split_leading_items_and_fn(&item)?;
+
+    if input_fn.sig.asyncness.is_none() {
+        return Err(syn::Error::new_spanned(
+            input_fn.sig.fn_token,
+            "Autumn route handlers must be async functions",
+        )
+        .to_compile_error());
+    }
+
+    Ok((leading_items, input_fn))
+}
+
 /// Extract `#[intercept(LayerType)]` attributes from a function's attribute
 /// list, removing them so they don't appear on the emitted function.
 ///

--- a/autumn-macros/src/route.rs
+++ b/autumn-macros/src/route.rs
@@ -37,8 +37,8 @@ pub fn route_macro(
     };
     let path = route_args.path.clone();
 
-    let mut input_fn = match parse::parse_async_handler(item) {
-        Ok(f) => f,
+    let (leading_items, mut input_fn) = match parse::parse_async_handler_with_leading_items(item) {
+        Ok(v) => v,
         Err(err) => return err,
     };
 
@@ -256,6 +256,12 @@ pub fn route_macro(
     };
 
     quote! {
+        // A guard macro that already expanded above this route attribute
+        // (#[secured]/#[step_up]/#[throttle], #1668) leaves its hidden
+        // `FromRequestParts` gate type here, ahead of the handler — re-emit
+        // it verbatim; empty when no such guard expanded first.
+        #leading_items
+
         // ECHO-001: We want to apply #[axum::debug_handler] but without forcing the user
         // to import axum manually. However, the path resolution in Axum macros makes this impossible
         // natively. Custom compile errors handle the type checks.

--- a/autumn-macros/src/secured.rs
+++ b/autumn-macros/src/secured.rs
@@ -112,6 +112,10 @@ fn parse_scope_array(expr: &Expr) -> syn::Result<Vec<String>> {
 }
 
 #[allow(clippy::too_many_lines)]
+// `item` is only ever borrowed via `split_leading_items_and_fn(&item)` now,
+// but keeps the owned `TokenStream` signature every macro entry point in
+// this crate shares (and the proc-macro boundary in `lib.rs` requires).
+#[allow(clippy::needless_pass_by_value)]
 pub fn secured_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
     let SecuredArgs { roles, scopes } = match parse_secured_args(attr) {
         Ok(r) => r,

--- a/autumn-macros/src/secured.rs
+++ b/autumn-macros/src/secured.rs
@@ -24,7 +24,7 @@
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
 use syn::parse::Parser as _;
-use syn::{Expr, ExprLit, ItemFn, Lit, LitStr, Meta, Token, parse_quote};
+use syn::{Expr, ExprLit, Lit, LitStr, Meta, Token, parse_quote};
 
 use crate::idempotency_guard::should_own_replay;
 
@@ -118,9 +118,9 @@ pub fn secured_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
         Err(err) => return err.to_compile_error(),
     };
 
-    let mut input_fn: ItemFn = match syn::parse2(item) {
-        Ok(f) => f,
-        Err(err) => return err.to_compile_error(),
+    let (leading_items, mut input_fn) = match crate::parse::split_leading_items_and_fn(&item) {
+        Ok(v) => v,
+        Err(err) => return err,
     };
 
     if input_fn.sig.asyncness.is_none() {
@@ -312,6 +312,7 @@ pub fn secured_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
     };
 
     quote! {
+        #leading_items
         #gate_item
         #input_fn
     }

--- a/autumn-macros/src/step_up.rs
+++ b/autumn-macros/src/step_up.rs
@@ -17,7 +17,7 @@
 
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
-use syn::{ItemFn, LitStr, parse_quote};
+use syn::{LitStr, parse_quote};
 
 use crate::idempotency_guard::should_own_replay;
 
@@ -196,9 +196,9 @@ pub fn step_up_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
         Ok(v) => v,
         Err(err) => return err.to_compile_error(),
     };
-    let mut input_fn: ItemFn = match syn::parse2(item) {
-        Ok(f) => f,
-        Err(err) => return err.to_compile_error(),
+    let (leading_items, mut input_fn) = match crate::parse::split_leading_items_and_fn(&item) {
+        Ok(v) => v,
+        Err(err) => return err,
     };
     if input_fn.sig.asyncness.is_none() {
         return syn::Error::new_spanned(
@@ -218,6 +218,15 @@ pub fn step_up_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
     let check_call = build_check_call(&max_age_tokens);
     let fn_name = input_fn.sig.ident.clone();
     let gate_ident = format_ident!("__AutumnStepUpGate_{}", fn_name);
+
+    // The marker const also stays in the handler body (not just inside the
+    // gate below) so `api_doc::recover_guarded_return_type` can still
+    // recover the pre-rewrite return type for OpenAPI when #[step_up]
+    // expands before the route macro (#1677).
+    let max_age_marker = quote! {
+        #[allow(dead_code)]
+        const __AUTUMN_STEP_UP_MAX_AGE: ::core::option::Option<u64> = #max_age_tokens;
+    };
 
     // Whether THIS gate should also serve a cached idempotency replay: see
     // `should_own_replay` for the full ordering rationale (issue #1668's
@@ -331,11 +340,13 @@ pub fn step_up_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
     };
     input_fn.block = syn::parse_quote! {
         {
+            #max_age_marker
             #original_response
         }
     };
 
     quote! {
+        #leading_items
         #gate_item
         #input_fn
     }

--- a/autumn-macros/src/step_up.rs
+++ b/autumn-macros/src/step_up.rs
@@ -191,6 +191,10 @@ fn type_contains_impl_trait(ty: &syn::Type) -> bool {
 
 /// Expand the `#[step_up]` / `#[step_up(max_age = "Nm")]` attribute.
 #[allow(clippy::too_many_lines)]
+// `item` is only ever borrowed via `split_leading_items_and_fn(&item)` now,
+// but keeps the owned `TokenStream` signature every macro entry point in
+// this crate shares (and the proc-macro boundary in `lib.rs` requires).
+#[allow(clippy::needless_pass_by_value)]
 pub fn step_up_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
     let max_age_opt = match parse_step_up_args(attr) {
         Ok(v) => v,

--- a/autumn-macros/src/throttle.rs
+++ b/autumn-macros/src/throttle.rs
@@ -245,6 +245,10 @@ fn build_spec_tokens(attrs: &ThrottleAttrs) -> TokenStream {
 
 /// Expand the `#[throttle(...)]` attribute.
 #[allow(clippy::too_many_lines)]
+// `item` is only ever borrowed via `split_leading_items_and_fn(&item)` now,
+// but keeps the owned `TokenStream` signature every macro entry point in
+// this crate shares (and the proc-macro boundary in `lib.rs` requires).
+#[allow(clippy::needless_pass_by_value)]
 pub fn throttle_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
     let attrs = match parse_throttle_args(attr) {
         Ok(a) => a,

--- a/autumn-macros/src/throttle.rs
+++ b/autumn-macros/src/throttle.rs
@@ -21,7 +21,7 @@
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
 use syn::parse::Parser as _;
-use syn::{Expr, ItemFn, Lit, LitInt, LitStr, parse_quote};
+use syn::{Expr, Lit, LitInt, LitStr, parse_quote};
 
 use crate::idempotency_guard::should_own_replay;
 
@@ -251,9 +251,9 @@ pub fn throttle_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
         Err(err) => return err.to_compile_error(),
     };
 
-    let mut input_fn: ItemFn = match syn::parse2(item) {
-        Ok(f) => f,
-        Err(err) => return err.to_compile_error(),
+    let (leading_items, mut input_fn) = match crate::parse::split_leading_items_and_fn(&item) {
+        Ok(v) => v,
+        Err(err) => return err,
     };
 
     if input_fn.sig.asyncness.is_none() {
@@ -268,6 +268,16 @@ pub fn throttle_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
     let fn_name_str = fn_name.to_string();
     let spec_tokens = build_spec_tokens(&attrs);
     let gate_ident = format_ident!("__AutumnThrottleGate_{}", fn_name);
+
+    // The marker const also stays in the handler body (not just inside the
+    // gate below) so `api_doc::recover_guarded_return_type` can still
+    // recover the pre-rewrite return type for OpenAPI when #[throttle]
+    // expands before the route macro (#1677).
+    let route_id_marker = quote! {
+        #[allow(dead_code)]
+        const __AUTUMN_THROTTLE_ROUTE_ID: &str =
+            ::core::concat!(::core::module_path!(), "::", #fn_name_str);
+    };
 
     // Whether THIS gate should also serve a cached idempotency replay: see
     // `should_own_replay` for the full ordering rationale (issue #1668's
@@ -439,11 +449,13 @@ pub fn throttle_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
     };
     input_fn.block = syn::parse_quote! {
         {
+            #route_id_marker
             #original_response
         }
     };
 
     quote! {
+        #leading_items
         #gate_item
         #input_fn
     }

--- a/autumn/tests/integration/auth_lockout_race.rs
+++ b/autumn/tests/integration/auth_lockout_race.rs
@@ -1,0 +1,353 @@
+//! #2500 regression: a concurrent successful login must never be silently
+//! re-locked by a racing failed-password attempt's lock-stamp write.
+//!
+//! `autumn generate auth`'s generated `login` (and duplicated `reauth`)
+//! handler counts a wrong-password attempt with an atomic
+//! `UPDATE ... SET failed_attempts = failed_attempts + 1` and then, if the
+//! new count crosses the configured threshold, stamps `locked_at` with a
+//! *second*, separate `UPDATE`. Before the fix landed in this commit, that
+//! second `UPDATE` was unconditional (`WHERE id = ?` only), gated only by an
+//! in-memory `current_locked_at` value read at the top of the request. If a
+//! concurrent request with the *correct* password committed its own
+//! "successful login resets the counter" `UPDATE` (`failed_attempts = 0,
+//! locked_at = NULL`) in the gap between the failed request's two
+//! statements, the unconditional lock stamp reapplied on top of the reset —
+//! silently re-locking an account that had *already* logged in successfully.
+//!
+//! These tests reproduce that exact interleaving directly against a real
+//! Postgres instance (testcontainers) using two genuinely separate
+//! connections (distinct Postgres backends, exactly like two separate HTTP
+//! requests would use), mirroring the two SQL statements the generator
+//! emits. The statements are issued in an explicitly chosen order rather
+//! than fired concurrently and hoping the race lands (the issue's own repro
+//! script shows the raw race only hits 3-12% of the time), so the exact bad
+//! interleaving is exercised on every run and the test never flakes.
+
+use diesel::sql_types::{BigInt, Int4, Nullable, Timestamp};
+use diesel_async::pooled_connection::AsyncDieselConnectionManager;
+use diesel_async::pooled_connection::deadpool::Pool;
+use diesel_async::{AsyncPgConnection, RunQueryDsl};
+use testcontainers::runners::AsyncRunner;
+use testcontainers_modules::postgres::Postgres;
+
+/// Mirrors the columns the generator adds to the app's user table.
+const DDL: &str = "CREATE TABLE IF NOT EXISTS lockout_accounts ( \
+    id BIGSERIAL PRIMARY KEY, \
+    failed_attempts INT4 NOT NULL DEFAULT 0, \
+    locked_at TIMESTAMP NULL)";
+
+const THRESHOLD: i32 = 3;
+
+async fn setup_pool() -> (
+    Pool<AsyncPgConnection>,
+    testcontainers::ContainerAsync<Postgres>,
+) {
+    let container = Postgres::default()
+        .start()
+        .await
+        .expect("failed to start postgres container");
+
+    let host = container.get_host().await.expect("host");
+    let port = container.get_host_port_ipv4(5432).await.expect("port");
+    let url = format!("postgres://postgres:postgres@{host}:{port}/postgres");
+
+    let manager = AsyncDieselConnectionManager::<AsyncPgConnection>::new(&url);
+    let pool = Pool::builder(manager).max_size(4).build().expect("pool");
+
+    let mut conn = pool.get().await.expect("conn");
+    diesel::sql_query(DDL)
+        .execute(&mut conn)
+        .await
+        .expect("create lockout_accounts table");
+    drop(conn);
+
+    (pool, container)
+}
+
+#[derive(diesel::QueryableByName)]
+struct IdRow {
+    #[diesel(sql_type = BigInt)]
+    id: i64,
+}
+
+#[derive(diesel::QueryableByName)]
+struct AttemptsRow {
+    #[diesel(sql_type = Int4)]
+    failed_attempts: i32,
+}
+
+#[derive(diesel::QueryableByName)]
+struct StateRow {
+    #[diesel(sql_type = Int4)]
+    failed_attempts: i32,
+    #[diesel(sql_type = Nullable<Timestamp>)]
+    locked_at: Option<chrono::NaiveDateTime>,
+}
+
+/// Seeds one account row one attempt below the lockout threshold, unlocked —
+/// the exact precondition the issue's repro script sets up before firing the
+/// concurrent wrong/correct password pair.
+async fn seed_one_below_threshold(conn: &mut AsyncPgConnection) -> i64 {
+    diesel::sql_query(
+        "INSERT INTO lockout_accounts (failed_attempts, locked_at) \
+         VALUES ($1, NULL) RETURNING id",
+    )
+    .bind::<Int4, _>(THRESHOLD - 1)
+    .get_result::<IdRow>(conn)
+    .await
+    .expect("seed account")
+    .id
+}
+
+async fn read_state(conn: &mut AsyncPgConnection, id: i64) -> StateRow {
+    diesel::sql_query("SELECT failed_attempts, locked_at FROM lockout_accounts WHERE id = $1")
+        .bind::<BigInt, _>(id)
+        .get_result::<StateRow>(conn)
+        .await
+        .expect("read state")
+}
+
+/// The wrong-password branch's first statement: atomically increment the
+/// failure counter, exactly as `{table}::failed_attempts.eq({table}::failed_attempts + 1)`
+/// does in the generated handler.
+async fn increment_failed_attempts(conn: &mut AsyncPgConnection, id: i64) -> i32 {
+    diesel::sql_query(
+        "UPDATE lockout_accounts SET failed_attempts = failed_attempts + 1 \
+         WHERE id = $1 RETURNING failed_attempts",
+    )
+    .bind::<BigInt, _>(id)
+    .get_result::<AttemptsRow>(conn)
+    .await
+    .expect("increment failed_attempts")
+    .failed_attempts
+}
+
+/// The successful-login branch: reset the counter and clear the lock, unless
+/// an *active* lock is already present — exactly the generated handler's
+/// `WHERE locked_at IS NULL OR locked_at <= lock_expired_before` guard.
+/// Returns the number of rows affected: 0 means "reject this login, the
+/// account was concurrently locked."
+async fn reset_on_successful_login(conn: &mut AsyncPgConnection, id: i64) -> u64 {
+    diesel::sql_query(
+        "UPDATE lockout_accounts SET failed_attempts = 0, locked_at = NULL \
+         WHERE id = $1 AND (locked_at IS NULL OR locked_at <= now() - interval '900 seconds')",
+    )
+    .bind::<BigInt, _>(id)
+    .execute(conn)
+    .await
+    .expect("reset on successful login") as u64
+}
+
+/// The **pre-fix** lock-stamp write: unconditional except for the row id —
+/// gated only by an in-memory `current_locked_at.is_none()` check the caller
+/// already evaluated before this statement runs. This is what issue #2500
+/// reports as the root cause.
+async fn stamp_lock_unconditional(conn: &mut AsyncPgConnection, id: i64) -> u64 {
+    diesel::sql_query("UPDATE lockout_accounts SET locked_at = now() WHERE id = $1")
+        .bind::<BigInt, _>(id)
+        .execute(conn)
+        .await
+        .expect("stamp lock (unconditional)") as u64
+}
+
+/// The **fixed** lock-stamp write: re-checks `failed_attempts` and
+/// `locked_at` at the database, at write time, instead of trusting the
+/// in-memory value read at the top of the request. Mirrors the
+/// `.filter({table}::failed_attempts.ge(lockout_cfg.threshold)).filter({table}::locked_at.is_null())`
+/// guard added to `autumn-cli/src/generate/auth.rs`.
+async fn stamp_lock_guarded(conn: &mut AsyncPgConnection, id: i64, threshold: i32) -> u64 {
+    diesel::sql_query(
+        "UPDATE lockout_accounts SET locked_at = now() \
+         WHERE id = $1 AND failed_attempts >= $2 AND locked_at IS NULL",
+    )
+    .bind::<BigInt, _>(id)
+    .bind::<Int4, _>(threshold)
+    .execute(conn)
+    .await
+    .expect("stamp lock (guarded)") as u64
+}
+
+/// Characterizes the bug: with the **pre-fix** unconditional stamp, the
+/// concurrent successful login's reset gets clobbered. The final row shows
+/// `failed_attempts = 0` (the reset ran) yet `locked_at` is set anyway —
+/// exactly the "BUG" signature the issue's repro script detects, even though
+/// the correct-password login had already been granted (`rows_cleared > 0`).
+#[tokio::test]
+#[ignore = "requires Docker (testcontainers)"]
+async fn unconditional_lock_stamp_reproduces_2500_relock_after_concurrent_success() {
+    let (pool, _container) = setup_pool().await;
+    let mut conn = pool.get().await.expect("conn");
+    let id = seed_one_below_threshold(&mut conn).await;
+
+    let mut wrong_conn = pool.get().await.expect("wrong-password conn");
+    let mut correct_conn = pool.get().await.expect("correct-password conn");
+
+    // 1. Wrong-password request: atomic increment (its own separate
+    //    statement, exactly as the generated handler does it).
+    let new_attempts = increment_failed_attempts(&mut wrong_conn, id).await;
+    assert!(new_attempts >= THRESHOLD);
+
+    // 2. Concurrent correct-password request: its reset commits first,
+    //    winning the race and completing the successful login (303 issued,
+    //    session cookie set, in the real handler) before the wrong-password
+    //    request's second statement ever runs.
+    let rows_cleared = reset_on_successful_login(&mut correct_conn, id).await;
+
+    // 3. Only now does the wrong-password request run its lock-stamp write —
+    //    the exact gap the issue describes.
+    let rows_locked = stamp_lock_unconditional(&mut wrong_conn, id).await;
+
+    assert_eq!(
+        rows_cleared, 1,
+        "the concurrent correct-password login must have succeeded (session issued)"
+    );
+    assert_eq!(
+        rows_locked, 1,
+        "the pre-fix unconditional stamp always writes locked_at regardless of \
+         concurrent state — that is the bug"
+    );
+
+    let state = read_state(&mut conn, id).await;
+    assert_eq!(
+        state.failed_attempts, 0,
+        "the successful login's reset did apply"
+    );
+    assert!(
+        state.locked_at.is_some(),
+        "BUG #2500 reproduced: locked_at is set even though failed_attempts \
+         was just reset to 0 by a login that already succeeded"
+    );
+}
+
+/// The fix: guarding the stamp on the row's *current* `failed_attempts` and
+/// `locked_at` makes the exact same interleaving a no-op. The successful
+/// login's reset stands, and the account is never silently re-locked out
+/// from under it.
+#[tokio::test]
+#[ignore = "requires Docker (testcontainers)"]
+async fn guarded_lock_stamp_never_relocks_after_concurrent_success() {
+    let (pool, _container) = setup_pool().await;
+    let mut conn = pool.get().await.expect("conn");
+    let id = seed_one_below_threshold(&mut conn).await;
+
+    let mut wrong_conn = pool.get().await.expect("wrong-password conn");
+    let mut correct_conn = pool.get().await.expect("correct-password conn");
+
+    // Same forced interleaving as the characterization test above, only the
+    // stamp write itself differs.
+    let new_attempts = increment_failed_attempts(&mut wrong_conn, id).await;
+    assert!(new_attempts >= THRESHOLD);
+
+    let rows_cleared = reset_on_successful_login(&mut correct_conn, id).await;
+
+    let rows_locked = stamp_lock_guarded(&mut wrong_conn, id, THRESHOLD).await;
+
+    assert_eq!(
+        rows_cleared, 1,
+        "the concurrent correct-password login must still succeed"
+    );
+    assert_eq!(
+        rows_locked, 0,
+        "the guarded stamp must be a no-op once a concurrent successful login \
+         has already reset failed_attempts below the threshold"
+    );
+
+    let state = read_state(&mut conn, id).await;
+    assert_eq!(state.failed_attempts, 0, "reset must stand");
+    assert!(
+        state.locked_at.is_none(),
+        "fixed: an account whose login already succeeded must never end up \
+         locked because of a losing concurrent wrong-password attempt"
+    );
+}
+
+/// The mirror-image ordering: if the wrong-password request's guarded stamp
+/// commits *before* the concurrent correct-password request's reset runs,
+/// the account is genuinely locked at that point, and the reset must
+/// correctly reject the login (0 rows affected) rather than let a stale read
+/// slip a session through for an account that is, at that instant, locked.
+/// This pins the other half of the invariant: the fix does not "always
+/// prefer success" — it makes whichever write actually lands first the one
+/// that determines a *consistent* final state.
+#[tokio::test]
+#[ignore = "requires Docker (testcontainers)"]
+async fn guarded_lock_stamp_winning_the_race_correctly_rejects_the_concurrent_login() {
+    let (pool, _container) = setup_pool().await;
+    let mut conn = pool.get().await.expect("conn");
+    let id = seed_one_below_threshold(&mut conn).await;
+
+    let mut wrong_conn = pool.get().await.expect("wrong-password conn");
+    let mut correct_conn = pool.get().await.expect("correct-password conn");
+
+    let new_attempts = increment_failed_attempts(&mut wrong_conn, id).await;
+    assert!(new_attempts >= THRESHOLD);
+
+    // This time the wrong-password request's stamp lands first...
+    let rows_locked = stamp_lock_guarded(&mut wrong_conn, id, THRESHOLD).await;
+    assert_eq!(rows_locked, 1, "the account must actually be locked here");
+
+    // ...so the concurrent correct-password request's reset must see the
+    // active lock and refuse to clear it.
+    let rows_cleared = reset_on_successful_login(&mut correct_conn, id).await;
+    assert_eq!(
+        rows_cleared, 0,
+        "a login racing a lock that already committed must be rejected, not \
+         silently granted a session against a row it never actually reset"
+    );
+
+    let state = read_state(&mut conn, id).await;
+    assert!(
+        state.locked_at.is_some(),
+        "the lock that won the race must remain in effect"
+    );
+    assert_eq!(
+        state.failed_attempts, new_attempts,
+        "a rejected login must not have touched the counter"
+    );
+}
+
+/// The guard must not weaken lockout against genuine credential stuffing: two
+/// concurrent wrong-password requests, both crossing the threshold, with no
+/// successful login anywhere in the picture, must still end with the account
+/// locked. This rules out the guard being exploitable the other way — an
+/// attacker racing only wrong-password attempts against each other cannot
+/// use the DB-level re-check to dodge lockout, because whichever of them
+/// runs its stamp while `locked_at` is still `NULL` succeeds.
+#[tokio::test]
+#[ignore = "requires Docker (testcontainers)"]
+async fn guarded_lock_stamp_still_locks_under_concurrent_attacker_only_race() {
+    let (pool, _container) = setup_pool().await;
+    let mut conn = pool.get().await.expect("conn");
+    let id = seed_one_below_threshold(&mut conn).await;
+
+    let mut attacker_a = pool.get().await.expect("attacker A conn");
+    let mut attacker_b = pool.get().await.expect("attacker B conn");
+
+    // Both concurrent wrong-password requests increment first, exactly as
+    // two real overlapping requests would (each sees the other's committed
+    // increment on its own atomic `+ 1`).
+    let attempts_a = increment_failed_attempts(&mut attacker_a, id).await;
+    let attempts_b = increment_failed_attempts(&mut attacker_b, id).await;
+    assert!(attempts_a >= THRESHOLD && attempts_b >= THRESHOLD);
+
+    // A's stamp lands first and succeeds...
+    let a_locked = stamp_lock_guarded(&mut attacker_a, id, THRESHOLD).await;
+    assert_eq!(a_locked, 1, "the first over-threshold stamp must apply");
+
+    // ...B's is now a no-op (already locked), but the account stays locked —
+    // it is not a no-op that leaves the account unlocked.
+    let b_locked = stamp_lock_guarded(&mut attacker_b, id, THRESHOLD).await;
+    assert_eq!(
+        b_locked, 0,
+        "a second stamp attempt on an already-locked row must not re-write it"
+    );
+
+    let state = read_state(&mut conn, id).await;
+    assert!(
+        state.locked_at.is_some(),
+        "two concurrent wrong-password requests crossing the threshold must \
+         still result in a locked account — the guard closes a false-positive \
+         re-lock, it must not open a way to dodge a genuine one"
+    );
+    assert_eq!(state.failed_attempts, attempts_b.max(attempts_a));
+}

--- a/autumn/tests/integration/mod.rs
+++ b/autumn/tests/integration/mod.rs
@@ -18,6 +18,8 @@ mod api_versioning_openapi;
 mod api_versioning_unit;
 mod app_builder;
 mod app_metrics_facade;
+#[cfg(feature = "db")]
+mod auth_lockout_race;
 mod authorization_integration;
 mod auto_broadcast;
 mod bot_protection_pipeline;


### PR DESCRIPTION
Closes https://github.com/autumn-foundation/autumn/issues/2500

## Summary

`autumn generate auth`'s generated `login` handler (and the duplicated `reauth` step-up block) counted a wrong-password attempt with an atomic `failed_attempts + 1` `UPDATE`, then — if the new count crossed `[auth.lockout].threshold` — stamped `locked_at` with a **second**, separate `UPDATE`. That second write was **unconditional** (`WHERE id = ?` only), gated only by a stale in-memory `current_locked_at` value read at the top of the request, never re-checked against the database.

If a concurrent request with the **correct** password committed its own "successful login resets the counter" `UPDATE` (`failed_attempts = 0, locked_at = NULL`) in the gap between the failed request's two statements, the unconditional lock stamp reapplied on top of that reset — silently re-locking an account for the full `cooloff_secs` window (default 15 min) even though it had **already** logged in successfully (303 redirect + session cookie already issued). The issue's own concurrent repro hit this 12/100 (7/60, 3/100 on reruns).

### Fix

The lock-stamp `UPDATE` in both `login` and `reauth` now filters on the row's *current* `failed_attempts` (`>= threshold`) and `locked_at` (`IS NULL`) at write time instead of trusting the in-memory read, so a concurrent successful reset makes the stamp a no-op rather than clobbering it. The `account_locked` telemetry event is now gated on the stamp having actually affected a row, so a losing race is never logged as a lock that didn't happen.

## Testing (TDD: red → green → refactor)

- **Generator meta-tests** (`autumn-cli/src/generate/auth.rs`): `routes_file_guards_lock_stamp_against_concurrent_reset` asserts both lock-stamp UPDATEs carry `failed_attempts.ge(lockout_cfg.threshold)` and `locked_at.is_null()` immediately before the `locked_at.eq(Some(now))` write (anchored to the write itself, not a bare substring count, so it can't be satisfied by an unrelated pre-existing guard elsewhere in the file); `routes_file_gates_lockout_telemetry_on_rows_actually_locked` asserts the telemetry is behind `if locked_rows > 0`. Both fail against the pre-fix generator source and pass after the fix; full `generate::auth::` suite (214 tests) still green.
- **Real Postgres regression suite** (`autumn/tests/integration/auth_lockout_race.rs`, testcontainer, `#[ignore]`d — picked up by CI's existing Docker sweep with no workflow edit): forces the exact bad interleaving deterministically (not a raw race, since the issue shows that only lands 3-12% of the time) across two genuinely separate connections:
  - `unconditional_lock_stamp_reproduces_2500_relock_after_concurrent_success` — characterizes the bug with the old pattern.
  - `guarded_lock_stamp_never_relocks_after_concurrent_success` — proves the fix.
  - `guarded_lock_stamp_winning_the_race_correctly_rejects_the_concurrent_login` — mirror ordering: when the lock genuinely wins, the concurrent login is correctly rejected, not silently granted.
  - `guarded_lock_stamp_still_locks_under_concurrent_attacker_only_race` — proves the guard can't be used to dodge a genuine lockout under pure concurrent wrong-password bursts (no legitimate login involved).
- All four scenarios were also independently hand-verified against a real local Postgres 16 instance via `psql` during development (Docker isn't available in this sandbox), matching every assertion in the automated suite.
- Reviewed the diff from three independent angles (correctness, security/attacker-bypass, test-quality) via separate review passes; the one real gap found (a vacuous string-count assertion that couldn't have caught a regression to the `locked_at.is_null()` half of the guard, plus missing coverage of the concurrent-attacker-only scenario) was fixed before this PR — see the two items above.
- `cargo fmt --all`, `cargo clippy -p autumn-cli --all-targets -- -D warnings`, `cargo clippy -p autumn-web --test integration_tests -- -D warnings`, and `cargo test -p autumn-web --test integration_tests --no-run` all clean. Scaffolded a fresh app against this checkout (`autumn new` + `autumn generate auth User` + `[patch.crates-io]`) and ran `cargo check --tests` on the generated project to confirm it still compiles.

## Acceptance criteria (derived from the issue) and evidence

| # | Criterion | Evidence |
|---|---|---|
| 1 | A successful login's reset of `failed_attempts`/`locked_at` must never be undone by a concurrent failed-login's lock-stamp write (`login`) | `guarded_lock_stamp_never_relocks_after_concurrent_success` + manual `psql` verification; meta-test `routes_file_guards_lock_stamp_against_concurrent_reset` |
| 2 | Same protection on the duplicated `reauth` step-up block (issue notes this can strand a user mid-step-up, e.g. account deletion) | Identical guard applied to `reauth`; meta-test asserts the guard appears in **both** handlers |
| 3 | `account_locked` telemetry must only fire when the account is actually locked | `if locked_rows > 0` gating; meta-test `routes_file_gates_lockout_telemetry_on_rows_actually_locked` |
| 4 | When the lock legitimately wins the race, the concurrent login must still be correctly rejected (not silently granted) | `guarded_lock_stamp_winning_the_race_correctly_rejects_the_concurrent_login` + manual verification |
| 5 | The fix must not weaken lockout against genuine concurrent credential stuffing (no new bypass) | `guarded_lock_stamp_still_locks_under_concurrent_attacker_only_race` + manual verification + independent security review (monotonicity argument: `failed_attempts`/`locked_at` can't move backwards without a password-verified reset) |
| 6 | Non-enumeration preserved (lockout response byte-identical to wrong-password response) | No change to the `return Err(auth_err())` / `reauth_form_err(...)` return paths; existing `routes_file_lockout_response_identical_to_wrong_password` unaffected; confirmed by both independent reviews |
| 7 | Generated code must still compile | Fresh scaffold + `cargo check --tests` against this checkout, clean |
| 8 | Regression must be provable deterministically, not just claimed (original bug's own repro was only 3-12% reproducible) | Explicitly-sequenced (non-flaky) testcontainer tests forcing the exact interleaving every run, cross-checked manually against a real Postgres instance |
| 9 | No regressions to existing lockout/auth behavior | Full `generate::auth::` suite (214 tests), `cargo fmt --check`, `cargo clippy -D warnings` on both touched crates, all clean |

No gaps found beyond what's listed above — everything identified during review was fixed in this PR rather than deferred.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BTY1BjnsDzsy7KDsKgSXDL

---
_Generated by [Claude Code](https://claude.ai/code/session_01BTY1BjnsDzsy7KDsKgSXDL)_